### PR TITLE
HDDS-7221. EC: ReplicationManager - Encapsulate the under and over rep queues into a queue object

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ContainerCheckRequest.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ContainerCheckRequest.java
@@ -21,7 +21,6 @@ import org.apache.hadoop.hdds.scm.container.ContainerReplica;
 import org.apache.hadoop.hdds.scm.container.ReplicationManagerReport;
 
 import java.util.List;
-import java.util.Queue;
 import java.util.Set;
 
 /**
@@ -35,10 +34,7 @@ public final class ContainerCheckRequest {
   private final List<ContainerReplicaOp> pendingOps;
   private final int maintenanceRedundancy;
   private final ReplicationManagerReport report;
-  private final Queue<ContainerHealthResult.UnderReplicatedHealthResult>
-      underRepQueue;
-  private final Queue<ContainerHealthResult.OverReplicatedHealthResult>
-      overRepQueue;
+  private final ReplicationQueue replicationQueue;
 
 
   private ContainerCheckRequest(Builder builder) {
@@ -47,8 +43,7 @@ public final class ContainerCheckRequest {
     this.pendingOps = builder.pendingOps;
     this.maintenanceRedundancy = builder.maintenanceRedundancy;
     this.report = builder.report;
-    this.overRepQueue = builder.overRepQueue;
-    this.underRepQueue = builder.underRepQueue;
+    this.replicationQueue = builder.replicationQueue;
   }
 
   public List<ContainerReplicaOp> getPendingOps() {
@@ -71,14 +66,8 @@ public final class ContainerCheckRequest {
     return report;
   }
 
-  public Queue<ContainerHealthResult.UnderReplicatedHealthResult>
-      getUnderRepQueue() {
-    return underRepQueue;
-  }
-
-  public Queue<ContainerHealthResult.OverReplicatedHealthResult>
-      getOverRepQueue() {
-    return overRepQueue;
+  public ReplicationQueue getReplicationQueue() {
+    return replicationQueue;
   }
 
   /**
@@ -91,10 +80,7 @@ public final class ContainerCheckRequest {
     private List<ContainerReplicaOp> pendingOps;
     private int maintenanceRedundancy;
     private ReplicationManagerReport report;
-    private Queue<ContainerHealthResult.UnderReplicatedHealthResult>
-        underRepQueue;
-    private Queue<ContainerHealthResult.OverReplicatedHealthResult>
-        overRepQueue;
+    private ReplicationQueue replicationQueue;
 
     public Builder setContainerInfo(ContainerInfo containerInfo) {
       this.containerInfo = containerInfo;
@@ -117,15 +103,8 @@ public final class ContainerCheckRequest {
       return this;
     }
 
-    public Builder setUnderRepQueue(
-        Queue<ContainerHealthResult.UnderReplicatedHealthResult> queue) {
-      this.underRepQueue = queue;
-      return this;
-    }
-
-    public Builder setOverRepQueue(
-        Queue<ContainerHealthResult.OverReplicatedHealthResult> queue) {
-      this.overRepQueue = queue;
+    public Builder setReplicationQueue(ReplicationQueue repQueue) {
+      this.replicationQueue = repQueue;
       return this;
     }
 

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ReplicationManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ReplicationManager.java
@@ -58,10 +58,8 @@ import org.slf4j.LoggerFactory;
 import java.io.IOException;
 import java.time.Clock;
 import java.time.Duration;
-import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
-import java.util.PriorityQueue;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
@@ -485,21 +483,6 @@ public class ReplicationManager implements SCMService {
       return scm.getContainerTokenGenerator().generateEncodedToken(containerID);
     }
     return ""; // unit test
-  }
-
-  /**
-   * Creates a priority queue of UnderReplicatedHealthResult, where the elements
-   * are ordered by the weighted redundancy of the container. This means that
-   * containers with the least remaining redundancy are at the front of the
-   * queue, and will be processed first.
-   * @return An empty instance of a PriorityQueue.
-   */
-  protected PriorityQueue<ContainerHealthResult.UnderReplicatedHealthResult>
-      createUnderReplicatedQueue() {
-    return new PriorityQueue<>(Comparator.comparing(ContainerHealthResult
-            .UnderReplicatedHealthResult::getWeightedRedundancy)
-        .thenComparing(ContainerHealthResult
-            .UnderReplicatedHealthResult::getRequeueCount));
   }
 
   public ReplicationManagerReport getContainerReport() {

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ReplicationManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ReplicationManager.java
@@ -59,11 +59,9 @@ import java.io.IOException;
 import java.time.Clock;
 import java.time.Duration;
 import java.util.Comparator;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.PriorityQueue;
-import java.util.Queue;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
@@ -146,10 +144,7 @@ public class ReplicationManager implements SCMService {
   private final ECReplicationCheckHandler ecReplicationCheckHandler;
   private final EventPublisher eventPublisher;
   private final ReentrantLock lock = new ReentrantLock();
-  private Queue<ContainerHealthResult.UnderReplicatedHealthResult>
-      underRepQueue;
-  private Queue<ContainerHealthResult.OverReplicatedHealthResult>
-      overRepQueue;
+  private ReplicationQueue replicationQueue;
   private final ECUnderReplicationHandler ecUnderReplicationHandler;
   private final ECOverReplicationHandler ecOverReplicationHandler;
   private final int maintenanceRedundancy;
@@ -194,8 +189,7 @@ public class ReplicationManager implements SCMService {
     this.legacyReplicationManager = legacyReplicationManager;
     this.ecReplicationCheckHandler = new ECReplicationCheckHandler();
     this.nodeManager = nodeManager;
-    this.underRepQueue = createUnderReplicatedQueue();
-    this.overRepQueue = new LinkedList<>();
+    this.replicationQueue = new ReplicationQueue();
     this.maintenanceRedundancy = rmConf.maintenanceRemainingRedundancy;
     ecUnderReplicationHandler = new ECUnderReplicationHandler(
         ecReplicationCheckHandler, containerPlacement, conf, nodeManager);
@@ -299,11 +293,7 @@ public class ReplicationManager implements SCMService {
     final List<ContainerInfo> containers =
         containerManager.getContainers();
     ReplicationManagerReport report = new ReplicationManagerReport();
-    Queue<ContainerHealthResult.UnderReplicatedHealthResult>
-        underReplicated = createUnderReplicatedQueue();
-    Queue<ContainerHealthResult.OverReplicatedHealthResult> overReplicated =
-        new LinkedList<>();
-
+    ReplicationQueue newRepQueue = new ReplicationQueue();
     for (ContainerInfo c : containers) {
       if (!shouldRun()) {
         break;
@@ -314,7 +304,7 @@ public class ReplicationManager implements SCMService {
         continue;
       }
       try {
-        processContainer(c, underReplicated, overReplicated, report);
+        processContainer(c, newRepQueue, report);
         // TODO - send any commands contained in the health result
       } catch (ContainerNotFoundException e) {
         LOG.error("Container {} not found", c.getContainerID(), e);
@@ -323,8 +313,7 @@ public class ReplicationManager implements SCMService {
     report.setComplete();
     lock.lock();
     try {
-      underRepQueue = underReplicated;
-      overRepQueue = overReplicated;
+      replicationQueue = newRepQueue;
     } finally {
       lock.unlock();
     }
@@ -344,7 +333,7 @@ public class ReplicationManager implements SCMService {
       dequeueUnderReplicatedContainer() {
     lock.lock();
     try {
-      return underRepQueue.poll();
+      return replicationQueue.dequeueUnderReplicatedContainer();
     } finally {
       lock.unlock();
     }
@@ -360,7 +349,7 @@ public class ReplicationManager implements SCMService {
       dequeueOverReplicatedContainer() {
     lock.lock();
     try {
-      return overRepQueue.poll();
+      return replicationQueue.dequeueOverReplicatedContainer();
     } finally {
       lock.unlock();
     }
@@ -389,7 +378,7 @@ public class ReplicationManager implements SCMService {
     underReplicatedHealthResult.incrementRequeueCount();
     lock.lock();
     try {
-      underRepQueue.add(underReplicatedHealthResult);
+      replicationQueue.enqueue(underReplicatedHealthResult);
     } finally {
       lock.unlock();
     }
@@ -399,7 +388,7 @@ public class ReplicationManager implements SCMService {
       .OverReplicatedHealthResult overReplicatedHealthResult) {
     lock.lock();
     try {
-      overRepQueue.add(overReplicatedHealthResult);
+      replicationQueue.enqueue(overReplicatedHealthResult);
     } finally {
       lock.unlock();
     }
@@ -432,9 +421,8 @@ public class ReplicationManager implements SCMService {
   }
 
   protected void processContainer(ContainerInfo containerInfo,
-      Queue<ContainerHealthResult.UnderReplicatedHealthResult> underRep,
-      Queue<ContainerHealthResult.OverReplicatedHealthResult> overRep,
-      ReplicationManagerReport report) throws ContainerNotFoundException {
+      ReplicationQueue repQueue, ReplicationManagerReport report)
+      throws ContainerNotFoundException {
 
     ContainerID containerID = containerInfo.containerID();
     Set<ContainerReplica> replicas = containerManager.getContainerReplicas(
@@ -448,8 +436,7 @@ public class ReplicationManager implements SCMService {
         .setMaintenanceRedundancy(maintenanceRedundancy)
         .setReport(report)
         .setPendingOps(pendingOps)
-        .setUnderRepQueue(underRep)
-        .setOverRepQueue(overRep)
+        .setReplicationQueue(repQueue)
         .build();
     // This will call the chain of container health handlers in turn which
     // will issue commands as needed, update the report and perhaps add

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ReplicationQueue.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ReplicationQueue.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hdds.scm.container.replication;
+
+import java.util.Comparator;
+import java.util.LinkedList;
+import java.util.PriorityQueue;
+import java.util.Queue;
+
+/**
+ * Object to encapsulate the under and over replication queues used by
+ * replicationManager.
+ */
+public class ReplicationQueue {
+
+  private final Queue<ContainerHealthResult.UnderReplicatedHealthResult>
+      underRepQueue;
+  private final Queue<ContainerHealthResult.OverReplicatedHealthResult>
+      overRepQueue;
+
+  public ReplicationQueue() {
+    underRepQueue = new PriorityQueue<>(
+        Comparator.comparing(ContainerHealthResult
+            .UnderReplicatedHealthResult::getWeightedRedundancy)
+        .thenComparing(ContainerHealthResult
+            .UnderReplicatedHealthResult::getRequeueCount));
+    overRepQueue = new LinkedList<>();
+  }
+
+  public void enqueue(ContainerHealthResult.UnderReplicatedHealthResult
+      underReplicatedHealthResult) {
+    underRepQueue.add(underReplicatedHealthResult);
+  }
+
+  public void enqueue(ContainerHealthResult.OverReplicatedHealthResult
+      overReplicatedHealthResult) {
+    overRepQueue.add(overReplicatedHealthResult);
+  }
+
+  public ContainerHealthResult.UnderReplicatedHealthResult
+      dequeueUnderReplicatedContainer() {
+    return underRepQueue.poll();
+  }
+
+  public ContainerHealthResult.OverReplicatedHealthResult
+      dequeueOverReplicatedContainer() {
+    return overRepQueue.poll();
+  }
+
+  public int underReplicatedQueueSize() {
+    return underRepQueue.size();
+  }
+
+  public int overReplicatedQueueSize() {
+    return overRepQueue.size();
+  }
+
+}

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/health/ECReplicationCheckHandler.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/health/ECReplicationCheckHandler.java
@@ -73,7 +73,7 @@ public class ECReplicationCheckHandler extends AbstractCheck {
       //        handlers can be tried?
       if (!underHealth.isSufficientlyReplicatedAfterPending() &&
           !underHealth.isUnrecoverable()) {
-        request.getUnderRepQueue().add(underHealth);
+        request.getReplicationQueue().enqueue(underHealth);
       }
       return true;
     } else if (health.getHealthState()
@@ -83,7 +83,7 @@ public class ECReplicationCheckHandler extends AbstractCheck {
       ContainerHealthResult.OverReplicatedHealthResult overHealth
           = ((ContainerHealthResult.OverReplicatedHealthResult) health);
       if (!overHealth.isSufficientlyReplicatedAfterPending()) {
-        request.getOverRepQueue().add(overHealth);
+        request.getReplicationQueue().enqueue(overHealth);
       }
       return true;
     }


### PR DESCRIPTION
## What changes were proposed in this pull request?

We should consider if we should encapsulate the under and over replicated queues into a single object. We may want to have queues with different priorities or more queues going forward, so bring these together into a single object would make things more flexible in the future.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-7221

## How was this patch tested?

Existing tests cover the changes.
