### PR TITLE
HDDS-7237. Update datanode's configuration variable names FAILED_DATA_VOLUMES_TOLERATED, FAILED_METADATA_VOLUMES_TOLERATED with their string values

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/DatanodeConfiguration.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/DatanodeConfiguration.java
@@ -42,9 +42,9 @@ public class DatanodeConfiguration {
       "hdds.datanode.container.delete.threads.max";
   static final String PERIODIC_DISK_CHECK_INTERVAL_MINUTES_KEY =
       "hdds.datanode.periodic.disk.check.interval.minutes";
-  public static final String FAILED_DATA_VOLUMES_TOLERATED_KEY =
+  public static final String HDDS_DATANODE_FAILED_DATA_VOLUMES_TOLERATED_KEY =
       "hdds.datanode.failed.data.volumes.tolerated";
-  public static final String FAILED_METADATA_VOLUMES_TOLERATED_KEY =
+  public static final String HDDS_DATANODE_FAILED_METADATA_VOLUMES_TOLERATED_KEY =
       "hdds.datanode.failed.metadata.volumes.tolerated";
   public static final String FAILED_DB_VOLUMES_TOLERATED_KEY =
       "hdds.datanode.failed.db.volumes.tolerated";
@@ -367,14 +367,14 @@ public class DatanodeConfiguration {
     }
 
     if (failedDataVolumesTolerated < -1) {
-      LOG.warn(FAILED_DATA_VOLUMES_TOLERATED_KEY +
+      LOG.warn(HDDS_DATANODE_FAILED_DATA_VOLUMES_TOLERATED_KEY +
           "must be greater than -1 and was set to {}. Defaulting to {}",
           failedDataVolumesTolerated, FAILED_VOLUMES_TOLERATED_DEFAULT);
       failedDataVolumesTolerated = FAILED_VOLUMES_TOLERATED_DEFAULT;
     }
 
     if (failedMetadataVolumesTolerated < -1) {
-      LOG.warn(FAILED_METADATA_VOLUMES_TOLERATED_KEY +
+      LOG.warn(HDDS_DATANODE_FAILED_METADATA_VOLUMES_TOLERATED_KEY +
               "must be greater than -1 and was set to {}. Defaulting to {}",
           failedMetadataVolumesTolerated, FAILED_VOLUMES_TOLERATED_DEFAULT);
       failedMetadataVolumesTolerated = FAILED_VOLUMES_TOLERATED_DEFAULT;

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/DatanodeStateMachine.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/DatanodeStateMachine.java
@@ -330,8 +330,8 @@ public class DatanodeStateMachine implements Closeable {
 
   public void handleFatalVolumeFailures() {
     LOG.error("DatanodeStateMachine Shutdown due to too many bad volumes, "
-        + "check " + DatanodeConfiguration.FAILED_DATA_VOLUMES_TOLERATED_KEY
-        + " and " + DatanodeConfiguration.FAILED_METADATA_VOLUMES_TOLERATED_KEY
+        + "check " + DatanodeConfiguration.HDDS_DATANODE_FAILED_DATA_VOLUMES_TOLERATED_KEY
+        + " and " + DatanodeConfiguration.HDDS_DATANODE_FAILED_METADATA_VOLUMES_TOLERATED_KEY
         + " and " + DatanodeConfiguration.FAILED_DB_VOLUMES_TOLERATED_KEY);
     hddsDatanodeStopService.stopService();
   }

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/statemachine/TestDatanodeConfiguration.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/statemachine/TestDatanodeConfiguration.java
@@ -31,8 +31,8 @@ import static org.apache.hadoop.ozone.container.common.statemachine.DatanodeConf
 import static org.apache.hadoop.ozone.container.common.statemachine.DatanodeConfiguration.FAILED_DB_VOLUMES_TOLERATED_KEY;
 import static org.apache.hadoop.ozone.container.common.statemachine.DatanodeConfiguration.PERIODIC_DISK_CHECK_INTERVAL_MINUTES_KEY;
 import static org.apache.hadoop.ozone.container.common.statemachine.DatanodeConfiguration.PERIODIC_DISK_CHECK_INTERVAL_MINUTES_DEFAULT;
-import static org.apache.hadoop.ozone.container.common.statemachine.DatanodeConfiguration.FAILED_DATA_VOLUMES_TOLERATED_KEY;
-import static org.apache.hadoop.ozone.container.common.statemachine.DatanodeConfiguration.FAILED_METADATA_VOLUMES_TOLERATED_KEY;
+import static org.apache.hadoop.ozone.container.common.statemachine.DatanodeConfiguration.HDDS_DATANODE_FAILED_DATA_VOLUMES_TOLERATED_KEY;
+import static org.apache.hadoop.ozone.container.common.statemachine.DatanodeConfiguration.HDDS_DATANODE_FAILED_METADATA_VOLUMES_TOLERATED_KEY;
 import static org.apache.hadoop.ozone.container.common.statemachine.DatanodeConfiguration.FAILED_VOLUMES_TOLERATED_DEFAULT;
 
 import static org.junit.Assert.assertEquals;
@@ -54,9 +54,9 @@ public class TestDatanodeConfiguration {
     conf.setInt(CONTAINER_DELETE_THREADS_MAX_KEY, validDeleteThreads);
     conf.setLong(PERIODIC_DISK_CHECK_INTERVAL_MINUTES_KEY,
         validDiskCheckIntervalMinutes);
-    conf.setInt(FAILED_DATA_VOLUMES_TOLERATED_KEY,
+    conf.setInt(HDDS_DATANODE_FAILED_DATA_VOLUMES_TOLERATED_KEY,
         validFailedVolumesTolerated);
-    conf.setInt(FAILED_METADATA_VOLUMES_TOLERATED_KEY,
+    conf.setInt(HDDS_DATANODE_FAILED_METADATA_VOLUMES_TOLERATED_KEY,
         validFailedVolumesTolerated);
     conf.setInt(FAILED_DB_VOLUMES_TOLERATED_KEY,
         validFailedVolumesTolerated);
@@ -96,9 +96,9 @@ public class TestDatanodeConfiguration {
     conf.setInt(CONTAINER_DELETE_THREADS_MAX_KEY, invalidDeleteThreads);
     conf.setLong(PERIODIC_DISK_CHECK_INTERVAL_MINUTES_KEY,
         invalidDiskCheckIntervalMinutes);
-    conf.setInt(FAILED_DATA_VOLUMES_TOLERATED_KEY,
+    conf.setInt(HDDS_DATANODE_FAILED_DATA_VOLUMES_TOLERATED_KEY,
         invalidFailedVolumesTolerated);
-    conf.setInt(FAILED_METADATA_VOLUMES_TOLERATED_KEY,
+    conf.setInt(HDDS_DATANODE_FAILED_METADATA_VOLUMES_TOLERATED_KEY,
         invalidFailedVolumesTolerated);
     conf.setInt(FAILED_DB_VOLUMES_TOLERATED_KEY,
         invalidFailedVolumesTolerated);


### PR DESCRIPTION

## What changes were proposed in this pull request?
Update datanode's configuration variable names FAILED_DATA_VOLUMES_TOLERATED, FAILED_METADATA_VOLUMES_TOLERATED with their string values to make the meaning of variables clearer.


## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-7237

