### PR TITLE
HDDS-7145. Recon: Show last OM DB sync time on Overview page

### DIFF
--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/api/db.json
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/api/db.json
@@ -1242,12 +1242,12 @@
     },
     {
       "taskName": "OmDeltaRequest",
-      "lastUpdatedTimestamp": 1663421088035,
+      "lastUpdatedTimestamp": 1663842113,
       "lastUpdatedSeqNumber": 0
     },
     {
       "taskName": "OmSnapshotRequest",
-      "lastUpdatedTimestamp": 1663421088049,
+      "lastUpdatedTimestamp": 1663421088035,
       "lastUpdatedSeqNumber": 0
     },
     {

--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/api/db.json
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/api/db.json
@@ -1242,7 +1242,7 @@
     },
     {
       "taskName": "OmDeltaRequest",
-      "lastUpdatedTimestamp": 1663842113,
+      "lastUpdatedTimestamp": 1663421088035,
       "lastUpdatedSeqNumber": 0
     },
     {

--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/api/db.json
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/api/db.json
@@ -1218,5 +1218,47 @@
       }
     ],
     "sizeDirectKey": 0
-  }
+  },
+  "taskStatus": [
+    {
+      "taskName": "ContainerKeyMapperTask",
+      "lastUpdatedTimestamp": 0,
+      "lastUpdatedSeqNumber": 0
+    },
+    {
+      "taskName": "FileSizeCountTask",
+      "lastUpdatedTimestamp": 0,
+      "lastUpdatedSeqNumber": 0
+    },
+    {
+      "taskName": "TableCountTask",
+      "lastUpdatedTimestamp": 0,
+      "lastUpdatedSeqNumber": 0
+    },
+    {
+      "taskName": "NSSummaryTaskWithFSO",
+      "lastUpdatedTimestamp": 0,
+      "lastUpdatedSeqNumber": 0
+    },
+    {
+      "taskName": "OmDeltaRequest",
+      "lastUpdatedTimestamp": 1663421088035,
+      "lastUpdatedSeqNumber": 0
+    },
+    {
+      "taskName": "OmSnapshotRequest",
+      "lastUpdatedTimestamp": 1663421088049,
+      "lastUpdatedSeqNumber": 0
+    },
+    {
+      "taskName": "ContainerHealthTask",
+      "lastUpdatedTimestamp": 0,
+      "lastUpdatedSeqNumber": 0
+    },
+    {
+      "taskName": "PipelineSyncTask",
+      "lastUpdatedTimestamp": 1663421094507,
+      "lastUpdatedSeqNumber": 0
+    }
+  ]
 }

--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/api/routes.json
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/api/routes.json
@@ -22,5 +22,6 @@
   "/namespace/du?path=/vol1/bucket1/empty&files=true": "/empty",
   "/namespace/du?path=/clunky&files=true": "/clunky",
   "/namespace/summary?path=*": "/metadata",
-  "/namespace/quota?path=*": "/quota"
+  "/namespace/quota?path=*": "/quota",
+  "/task/status": "/taskStatus"
 }

--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/components/autoReloadPanel/autoReloadPanel.tsx
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/components/autoReloadPanel/autoReloadPanel.tsx
@@ -27,6 +27,10 @@ import moment from 'moment';
 interface IAutoReloadPanelProps extends RouteComponentProps<object> {
   onReload: () => void;
   lastUpdated: number;
+  lastUpdatedOM:number;
+  lastUpdateOMSync:number;
+  lastUpdatedOMText:string;
+  lastUpdateOMSyncText:string;
   isLoading: boolean;
   togglePolling: (isEnabled: boolean) => void;
 }
@@ -38,8 +42,10 @@ class AutoReloadPanel extends React.Component<IAutoReloadPanelProps> {
   };
 
   render() {
-    const {onReload, lastUpdated, isLoading} = this.props;
-    const lastUpdatedText = lastUpdated === 0 ? 'NA' :
+    const {onReload, lastUpdated, lastUpdatedOM,lastUpdateOMSync,isLoading,lastUpdatedOMText,lastUpdateOMSyncText} = this.props;
+    const textOMSync= <span>{lastUpdatedOMText} : {moment(lastUpdatedOM).format('ll LTS') }<br/>
+                 {lastUpdateOMSyncText} : {moment(lastUpdateOMSync).format('ll LTS')}</span>
+    const lastUpdatedText = lastUpdated === 0 || lastUpdated === undefined? 'NA' :
       (
         <Tooltip
           placement='bottom' title={moment(lastUpdated).format('ll LTS')}
@@ -47,12 +53,28 @@ class AutoReloadPanel extends React.Component<IAutoReloadPanelProps> {
           {moment(lastUpdated).format('LTS')}
         </Tooltip>
       );
+      const lastUpdatedOMInfo = lastUpdatedOM === 0 || lastUpdatedOM === undefined || lastUpdateOMSync===0 || lastUpdateOMSync=== undefined ? 'NA' :
+      (
+        <Tooltip
+          placement='bottom' title={textOMSync}
+        >
+          {moment(lastUpdatedOM).format('LTS')}
+        </Tooltip>
+      );
+     const lastUpdatedOMDisplay= lastUpdatedOM === 0 || lastUpdatedOM === undefined || lastUpdateOMSync===0 || lastUpdateOMSync=== undefined ? '' :
+     (
+      <>
+      &nbsp; | OM DB Last updated at {lastUpdatedOMInfo}
+      &nbsp;<Button shape='circle' icon='reload' size='small' loading={isLoading} />
+      </>
+     );
     return (
       <div className='auto-reload-panel'>
         Auto Reload
         &nbsp;<Switch defaultChecked size='small' className='toggle-switch' onChange={this.autoReloadToggleHandler}/>
         &nbsp; | Last updated at {lastUpdatedText}
         &nbsp;<Button shape='circle' icon='reload' size='small' loading={isLoading} onClick={onReload}/>
+        {lastUpdatedOMDisplay}
       </div>
     );
   }

--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/components/autoReloadPanel/autoReloadPanel.tsx
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/components/autoReloadPanel/autoReloadPanel.tsx
@@ -27,9 +27,9 @@ import moment from 'moment';
 interface IAutoReloadPanelProps extends RouteComponentProps<object> {
   onReload: () => void;
   lastRefreshed: number;
-  lastUpdatedOMDBDelta:number;
-  lastUpdatedOMDBFull:number;
-  lastUpdatedOMLatest:number;
+  lastUpdatedOMDBDelta: number;
+  lastUpdatedOMDBFull: number;
+  lastUpdatedOMLatest: number;
   isLoading: boolean;
   togglePolling: (isEnabled: boolean) => void;
 }
@@ -48,19 +48,22 @@ class AutoReloadPanel extends React.Component<IAutoReloadPanelProps> {
         <Tooltip
           placement='bottom' title={moment(lastRefreshed).format('ll LTS')}
         >
-          {moment(lastRefreshed).format('LTS')}
+          {moment(lastRefreshed).format('LT')}
         </Tooltip>
       );
 
-      const omDBDeltaFullToolTip = <span>{'Last Delta Update'} : {moment(lastUpdatedOMDBDelta).format('ll LTS') }<br/>
-      {'Last Full Update'} : {moment(lastUpdatedOMDBFull).format('ll LTS')}</span>
+      const omDBDeltaFullToolTip = <span>
+          {'Delta Update'}: {moment(lastUpdatedOMDBDelta).fromNow()}, {moment(lastUpdatedOMDBDelta).format('ll LTS')}
+          <br/>
+          {'Full Update'}: {moment(lastUpdatedOMDBFull).fromNow()}, {moment(lastUpdatedOMDBFull).format('ll LTS')}
+       </span>
 
       const lastUpdatedDeltaFullToolTip = lastUpdatedOMDBDelta === 0 || lastUpdatedOMDBDelta === undefined || lastUpdatedOMDBFull === 0 || lastUpdatedOMDBFull === undefined ? 'NA' :
       (
         <Tooltip
           placement='bottom' title={omDBDeltaFullToolTip}
         >
-          {moment(lastUpdatedOMLatest).format('LTS')}
+          {moment(lastUpdatedOMLatest).format('LT')}
         </Tooltip>
       );
 
@@ -74,9 +77,9 @@ class AutoReloadPanel extends React.Component<IAutoReloadPanelProps> {
 
     return (
       <div className='auto-reload-panel'>
-        Auto Reload
+        Auto Refresh
         &nbsp;<Switch defaultChecked size='small' className='toggle-switch' onChange={this.autoReloadToggleHandler}/>
-        &nbsp; | Refreshed {lastRefreshedRext}
+        &nbsp; | Refreshed at {lastRefreshedRext}
         &nbsp;<Button shape='circle' icon='reload' size='small' loading={isLoading} onClick={onReload}/>
         {lastUpdatedDeltaFullText}
       </div>

--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/components/autoReloadPanel/autoReloadPanel.tsx
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/components/autoReloadPanel/autoReloadPanel.tsx
@@ -29,7 +29,6 @@ interface IAutoReloadPanelProps extends RouteComponentProps<object> {
   lastRefreshed: number;
   lastUpdatedOMDBDelta: number;
   lastUpdatedOMDBFull: number;
-  lastUpdatedOMLatest: number;
   isLoading: boolean;
   togglePolling: (isEnabled: boolean) => void;
 }
@@ -41,9 +40,9 @@ class AutoReloadPanel extends React.Component<IAutoReloadPanelProps> {
   };
 
   render() {
-    const {onReload, lastRefreshed, lastUpdatedOMDBDelta,lastUpdatedOMDBFull,isLoading,lastUpdatedOMLatest} = this.props;
+    const {onReload, lastRefreshed, lastUpdatedOMDBDelta, lastUpdatedOMDBFull, isLoading} = this.props;
     
-     const lastRefreshedRext = lastRefreshed === 0 || lastRefreshed === undefined ? 'NA' :
+     const lastRefreshedText = lastRefreshed === 0 || lastRefreshed === undefined ? 'NA' :
       (
         <Tooltip
           placement='bottom' title={moment(lastRefreshed).format('ll LTS')}
@@ -53,12 +52,14 @@ class AutoReloadPanel extends React.Component<IAutoReloadPanelProps> {
       );
 
       const omDBDeltaFullToolTip = <span>
-          {'Delta Update'}: {moment(lastUpdatedOMDBDelta).fromNow()}, {moment(lastUpdatedOMDBDelta).format('ll LTS')}
+          {'Delta Update'}: {moment(lastUpdatedOMDBDelta).fromNow()}, {moment(lastUpdatedOMDBDelta).format('LT')}
           <br/>
-          {'Full Update'}: {moment(lastUpdatedOMDBFull).fromNow()}, {moment(lastUpdatedOMDBFull).format('ll LTS')}
+          {'Full Update'}: {moment(lastUpdatedOMDBFull).fromNow()}, {moment(lastUpdatedOMDBFull).format('LT')}
        </span>
 
-      const lastUpdatedDeltaFullToolTip = lastUpdatedOMDBDelta === 0 || lastUpdatedOMDBDelta === undefined || lastUpdatedOMDBFull === 0 || lastUpdatedOMDBFull === undefined ? 'NA' :
+      const lastUpdatedOMLatest = lastUpdatedOMDBDelta > lastUpdatedOMDBFull ? lastUpdatedOMDBDelta : lastUpdatedOMDBFull;
+
+      const lastUpdatedDeltaFullToolTip = lastUpdatedOMDBDelta === 0 || lastUpdatedOMDBDelta === undefined || lastUpdatedOMDBFull === 0 || lastUpdatedOMDBFull === undefined ? 'N/A' :
       (
         <Tooltip
           placement='bottom' title={omDBDeltaFullToolTip}
@@ -67,10 +68,10 @@ class AutoReloadPanel extends React.Component<IAutoReloadPanelProps> {
         </Tooltip>
       );
 
-     const lastUpdatedDeltaFullText = lastUpdatedOMDBDelta === 0 || lastUpdatedOMDBDelta === undefined || lastUpdatedOMDBFull===0 || lastUpdatedOMDBFull === undefined ? '' :
+     const lastUpdatedDeltaFullText = lastUpdatedOMDBDelta === 0 || lastUpdatedOMDBDelta === undefined || lastUpdatedOMDBFull === 0 || lastUpdatedOMDBFull === undefined ? '' :
      (
       <>
-      &nbsp; | OM DB Last updated at {lastUpdatedDeltaFullToolTip}
+      &nbsp; | OM DB updated at {lastUpdatedDeltaFullToolTip}
       &nbsp;<Button shape='circle' icon='reload' size='small' loading={isLoading} />
       </>
      );
@@ -79,7 +80,7 @@ class AutoReloadPanel extends React.Component<IAutoReloadPanelProps> {
       <div className='auto-reload-panel'>
         Auto Refresh
         &nbsp;<Switch defaultChecked size='small' className='toggle-switch' onChange={this.autoReloadToggleHandler}/>
-        &nbsp; | Refreshed at {lastRefreshedRext}
+        &nbsp; | Refreshed at {lastRefreshedText}
         &nbsp;<Button shape='circle' icon='reload' size='small' loading={isLoading} onClick={onReload}/>
         {lastUpdatedDeltaFullText}
       </div>

--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/components/autoReloadPanel/autoReloadPanel.tsx
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/components/autoReloadPanel/autoReloadPanel.tsx
@@ -27,10 +27,10 @@ import moment from 'moment';
 interface IAutoReloadPanelProps extends RouteComponentProps<object> {
   onReload: () => void;
   lastUpdated: number;
-  lastUpdatedOM:number;
-  lastUpdateOMSync:number;
-  lastUpdatedOMText:string;
-  lastUpdateOMSyncText:string;
+  lastUpdatedOMDBDelta:number;
+  lastUpdatedOMDBFull:number;
+  lastUpdatedOMDBDeltaText:string;
+  lastUpdatedOMDBFullText:string;
   isLoading: boolean;
   togglePolling: (isEnabled: boolean) => void;
 }
@@ -42,10 +42,9 @@ class AutoReloadPanel extends React.Component<IAutoReloadPanelProps> {
   };
 
   render() {
-    const {onReload, lastUpdated, lastUpdatedOM,lastUpdateOMSync,isLoading,lastUpdatedOMText,lastUpdateOMSyncText} = this.props;
-    const textOMSync= <span>{lastUpdatedOMText} : {moment(lastUpdatedOM).format('ll LTS') }<br/>
-                 {lastUpdateOMSyncText} : {moment(lastUpdateOMSync).format('ll LTS')}</span>
-    const lastUpdatedText = lastUpdated === 0 || lastUpdated === undefined? 'NA' :
+    const {onReload, lastUpdated, lastUpdatedOMDBDelta,lastUpdatedOMDBFull,isLoading,lastUpdatedOMDBDeltaText,lastUpdatedOMDBFullText} = this.props;
+    
+     const lastUpdatedText = lastUpdated === 0 || lastUpdated === undefined ? 'NA' :
       (
         <Tooltip
           placement='bottom' title={moment(lastUpdated).format('ll LTS')}
@@ -53,28 +52,34 @@ class AutoReloadPanel extends React.Component<IAutoReloadPanelProps> {
           {moment(lastUpdated).format('LTS')}
         </Tooltip>
       );
-      const lastUpdatedOMInfo = lastUpdatedOM === 0 || lastUpdatedOM === undefined || lastUpdateOMSync===0 || lastUpdateOMSync=== undefined ? 'NA' :
+
+      const omDBDeltaFullToolTip = <span>{lastUpdatedOMDBDeltaText} : {moment(lastUpdatedOMDBDelta).format('ll LTS') }<br/>
+      {lastUpdatedOMDBFullText} : {moment(lastUpdatedOMDBFull).format('ll LTS')}</span>
+
+      const lastUpdatedDeltaToolTip = lastUpdatedOMDBDelta === 0 || lastUpdatedOMDBDelta === undefined || lastUpdatedOMDBFull === 0 || lastUpdatedOMDBFull === undefined ? 'NA' :
       (
         <Tooltip
-          placement='bottom' title={textOMSync}
+          placement='bottom' title={omDBDeltaFullToolTip}
         >
-          {moment(lastUpdatedOM).format('LTS')}
+          {moment(lastUpdatedOMDBDelta).format('LTS')}
         </Tooltip>
       );
-     const lastUpdatedOMDisplay= lastUpdatedOM === 0 || lastUpdatedOM === undefined || lastUpdateOMSync===0 || lastUpdateOMSync=== undefined ? '' :
+
+     const lastUpdatedDeltaText = lastUpdatedOMDBDelta === 0 || lastUpdatedOMDBDelta === undefined || lastUpdatedOMDBFull===0 || lastUpdatedOMDBFull === undefined ? '' :
      (
       <>
-      &nbsp; | OM DB Last updated at {lastUpdatedOMInfo}
+      &nbsp; | OM DB Last updated at {lastUpdatedDeltaToolTip}
       &nbsp;<Button shape='circle' icon='reload' size='small' loading={isLoading} />
       </>
      );
+
     return (
       <div className='auto-reload-panel'>
         Auto Reload
         &nbsp;<Switch defaultChecked size='small' className='toggle-switch' onChange={this.autoReloadToggleHandler}/>
         &nbsp; | Last updated at {lastUpdatedText}
         &nbsp;<Button shape='circle' icon='reload' size='small' loading={isLoading} onClick={onReload}/>
-        {lastUpdatedOMDisplay}
+        {lastUpdatedDeltaText}
       </div>
     );
   }

--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/components/autoReloadPanel/autoReloadPanel.tsx
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/components/autoReloadPanel/autoReloadPanel.tsx
@@ -29,8 +29,7 @@ interface IAutoReloadPanelProps extends RouteComponentProps<object> {
   lastRefreshed: number;
   lastUpdatedOMDBDelta:number;
   lastUpdatedOMDBFull:number;
-  lastUpdatedOMDBDeltaText:string;
-  lastUpdatedOMDBFullText:string;
+  lastUpdatedOMLatest:number;
   isLoading: boolean;
   togglePolling: (isEnabled: boolean) => void;
 }
@@ -42,7 +41,7 @@ class AutoReloadPanel extends React.Component<IAutoReloadPanelProps> {
   };
 
   render() {
-    const {onReload, lastRefreshed, lastUpdatedOMDBDelta,lastUpdatedOMDBFull,isLoading,lastUpdatedOMDBDeltaText,lastUpdatedOMDBFullText} = this.props;
+    const {onReload, lastRefreshed, lastUpdatedOMDBDelta,lastUpdatedOMDBFull,isLoading,lastUpdatedOMLatest} = this.props;
     
      const lastRefreshedRext = lastRefreshed === 0 || lastRefreshed === undefined ? 'NA' :
       (
@@ -53,15 +52,15 @@ class AutoReloadPanel extends React.Component<IAutoReloadPanelProps> {
         </Tooltip>
       );
 
-      const omDBDeltaFullToolTip = <span>{lastUpdatedOMDBDeltaText} : {moment(lastUpdatedOMDBDelta).format('ll LTS') }<br/>
-      {lastUpdatedOMDBFullText} : {moment(lastUpdatedOMDBFull).format('ll LTS')}</span>
+      const omDBDeltaFullToolTip = <span>{'Last Delta Update'} : {moment(lastUpdatedOMDBDelta).format('ll LTS') }<br/>
+      {'Last Full Update'} : {moment(lastUpdatedOMDBFull).format('ll LTS')}</span>
 
       const lastUpdatedDeltaFullToolTip = lastUpdatedOMDBDelta === 0 || lastUpdatedOMDBDelta === undefined || lastUpdatedOMDBFull === 0 || lastUpdatedOMDBFull === undefined ? 'NA' :
       (
         <Tooltip
           placement='bottom' title={omDBDeltaFullToolTip}
         >
-          {moment(lastUpdatedOMDBDelta).format('LTS')}
+          {moment(lastUpdatedOMLatest).format('LTS')}
         </Tooltip>
       );
 

--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/components/autoReloadPanel/autoReloadPanel.tsx
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/components/autoReloadPanel/autoReloadPanel.tsx
@@ -26,7 +26,7 @@ import moment from 'moment';
 
 interface IAutoReloadPanelProps extends RouteComponentProps<object> {
   onReload: () => void;
-  lastUpdated: number;
+  lastRefreshed: number;
   lastUpdatedOMDBDelta:number;
   lastUpdatedOMDBFull:number;
   lastUpdatedOMDBDeltaText:string;
@@ -42,21 +42,21 @@ class AutoReloadPanel extends React.Component<IAutoReloadPanelProps> {
   };
 
   render() {
-    const {onReload, lastUpdated, lastUpdatedOMDBDelta,lastUpdatedOMDBFull,isLoading,lastUpdatedOMDBDeltaText,lastUpdatedOMDBFullText} = this.props;
+    const {onReload, lastRefreshed, lastUpdatedOMDBDelta,lastUpdatedOMDBFull,isLoading,lastUpdatedOMDBDeltaText,lastUpdatedOMDBFullText} = this.props;
     
-     const lastUpdatedText = lastUpdated === 0 || lastUpdated === undefined ? 'NA' :
+     const lastRefreshedRext = lastRefreshed === 0 || lastRefreshed === undefined ? 'NA' :
       (
         <Tooltip
-          placement='bottom' title={moment(lastUpdated).format('ll LTS')}
+          placement='bottom' title={moment(lastRefreshed).format('ll LTS')}
         >
-          {moment(lastUpdated).format('LTS')}
+          {moment(lastRefreshed).format('LTS')}
         </Tooltip>
       );
 
       const omDBDeltaFullToolTip = <span>{lastUpdatedOMDBDeltaText} : {moment(lastUpdatedOMDBDelta).format('ll LTS') }<br/>
       {lastUpdatedOMDBFullText} : {moment(lastUpdatedOMDBFull).format('ll LTS')}</span>
 
-      const lastUpdatedDeltaToolTip = lastUpdatedOMDBDelta === 0 || lastUpdatedOMDBDelta === undefined || lastUpdatedOMDBFull === 0 || lastUpdatedOMDBFull === undefined ? 'NA' :
+      const lastUpdatedDeltaFullToolTip = lastUpdatedOMDBDelta === 0 || lastUpdatedOMDBDelta === undefined || lastUpdatedOMDBFull === 0 || lastUpdatedOMDBFull === undefined ? 'NA' :
       (
         <Tooltip
           placement='bottom' title={omDBDeltaFullToolTip}
@@ -65,10 +65,10 @@ class AutoReloadPanel extends React.Component<IAutoReloadPanelProps> {
         </Tooltip>
       );
 
-     const lastUpdatedDeltaText = lastUpdatedOMDBDelta === 0 || lastUpdatedOMDBDelta === undefined || lastUpdatedOMDBFull===0 || lastUpdatedOMDBFull === undefined ? '' :
+     const lastUpdatedDeltaFullText = lastUpdatedOMDBDelta === 0 || lastUpdatedOMDBDelta === undefined || lastUpdatedOMDBFull===0 || lastUpdatedOMDBFull === undefined ? '' :
      (
       <>
-      &nbsp; | OM DB Last updated at {lastUpdatedDeltaToolTip}
+      &nbsp; | OM DB Last updated at {lastUpdatedDeltaFullToolTip}
       &nbsp;<Button shape='circle' icon='reload' size='small' loading={isLoading} />
       </>
      );
@@ -77,9 +77,9 @@ class AutoReloadPanel extends React.Component<IAutoReloadPanelProps> {
       <div className='auto-reload-panel'>
         Auto Reload
         &nbsp;<Switch defaultChecked size='small' className='toggle-switch' onChange={this.autoReloadToggleHandler}/>
-        &nbsp; | Last updated at {lastUpdatedText}
+        &nbsp; | Refreshed {lastRefreshedRext}
         &nbsp;<Button shape='circle' icon='reload' size='small' loading={isLoading} onClick={onReload}/>
-        {lastUpdatedDeltaText}
+        {lastUpdatedDeltaFullText}
       </div>
     );
   }

--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/components/autoReloadPanel/autoReloadPanel.tsx
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/components/autoReloadPanel/autoReloadPanel.tsx
@@ -59,7 +59,7 @@ class AutoReloadPanel extends React.Component<IAutoReloadPanelProps> {
 
       const lastUpdatedOMLatest = lastUpdatedOMDBDelta > lastUpdatedOMDBFull ? lastUpdatedOMDBDelta : lastUpdatedOMDBFull;
 
-      const lastUpdatedDeltaFullToolTip = lastUpdatedOMDBDelta === 0 || lastUpdatedOMDBDelta === undefined || lastUpdatedOMDBFull === 0 || lastUpdatedOMDBFull === undefined ? 'N/A' :
+      const lastUpdatedDeltaFullToolTip = lastUpdatedOMDBDelta === 0 || lastUpdatedOMDBDelta === undefined || lastUpdatedOMDBFull === 0 || lastUpdatedOMDBFull === undefined ? 'NA' :
       (
         <Tooltip
           placement='bottom' title={omDBDeltaFullToolTip}

--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/views/overview/overview.tsx
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/views/overview/overview.tsx
@@ -52,7 +52,7 @@ interface IOverviewState {
   buckets: number;
   keys: number;
   missingContainersCount: number;
-  lastUpdated: number;
+  lastRefreshed: number;
   lastUpdatedOMDBDelta:number,
   lastUpdatedOMDBFull:number,
   lastUpdatedOMDBDeltaText:string,
@@ -79,7 +79,7 @@ export class Overview extends React.Component<Record<string, object>, IOverviewS
       buckets: 0,
       keys: 0,
       missingContainersCount: 0,
-      lastUpdated: 0,
+      lastRefreshed: 0,
       lastUpdatedOMDBDelta:0,
       lastUpdatedOMDBFull:0,
       lastUpdatedOMDBDeltaText:'',
@@ -116,7 +116,7 @@ export class Overview extends React.Component<Record<string, object>, IOverviewS
         buckets: clusterState.buckets,
         keys: clusterState.keys,
         missingContainersCount,
-        lastUpdated: Number(moment()),
+        lastRefreshed: Number(moment()),
         lastUpdatedOMDBDelta: omDBDeltaObject ? omDBDeltaObject.lastUpdatedTimestamp : 0,
         lastUpdatedOMDBFull:  omDBFullObject ? omDBFullObject.lastUpdatedTimestamp : 0,
         lastUpdatedOMDBDeltaText:omDBDeltaObject? omDBDeltaObject.taskName === 'OmDeltaRequest' ? 'Last Delta Update': 'Last Full Update': '',
@@ -142,7 +142,7 @@ export class Overview extends React.Component<Record<string, object>, IOverviewS
 
   render() {
     const {loading, datanodes, pipelines, storageReport, containers, volumes, buckets,
-      keys, missingContainersCount,lastUpdated,lastUpdatedOMDBDelta,lastUpdatedOMDBFull,lastUpdatedOMDBDeltaText,lastUpdatedOMDBFullText} = this.state;
+      keys, missingContainersCount,lastRefreshed,lastUpdatedOMDBDelta,lastUpdatedOMDBFull,lastUpdatedOMDBDeltaText,lastUpdatedOMDBFullText} = this.state;
     const datanodesElement = (
       <span>
         <Icon type='check-circle' theme='filled' className='icon-success icon-small'/> {datanodes} <span className='ant-card-meta-description meta'>HEALTHY</span>
@@ -165,7 +165,7 @@ export class Overview extends React.Component<Record<string, object>, IOverviewS
       <div className='overview-content'>
         <div className='page-header'>
           Overview
-          <AutoReloadPanel isLoading={loading} lastUpdated={lastUpdated} 
+          <AutoReloadPanel isLoading={loading} lastRefreshed={lastRefreshed} 
           lastUpdatedOMDBDelta={lastUpdatedOMDBDelta}  lastUpdatedOMDBFull={lastUpdatedOMDBFull}
           lastUpdatedOMDBDeltaText={lastUpdatedOMDBDeltaText}  lastUpdatedOMDBFullText={lastUpdatedOMDBFullText}
           togglePolling={this.autoReload.handleAutoReloadToggle} onReload={this._loadData}/>

--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/views/overview/overview.tsx
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/views/overview/overview.tsx
@@ -53,10 +53,10 @@ interface IOverviewState {
   keys: number;
   missingContainersCount: number;
   lastUpdated: number;
-  lastUpdatedOM:number,
-  lastUpdateOMSync:number,
-  lastUpdatedOMText:string,
-  lastUpdateOMSyncText:string
+  lastUpdatedOMDBDelta:number,
+  lastUpdatedOMDBFull:number,
+  lastUpdatedOMDBDeltaText:string,
+  lastUpdatedOMDBFullText:string
 }
 
 export class Overview extends React.Component<Record<string, object>, IOverviewState> {
@@ -80,10 +80,10 @@ export class Overview extends React.Component<Record<string, object>, IOverviewS
       keys: 0,
       missingContainersCount: 0,
       lastUpdated: 0,
-      lastUpdatedOM:0,
-      lastUpdateOMSync:0,
-      lastUpdatedOMText:'',
-      lastUpdateOMSyncText:''
+      lastUpdatedOMDBDelta:0,
+      lastUpdatedOMDBFull:0,
+      lastUpdatedOMDBDeltaText:'',
+      lastUpdatedOMDBFullText:''
 
     };
     this.autoReload = new AutoReloadHelper(this._loadData);
@@ -103,7 +103,9 @@ export class Overview extends React.Component<Record<string, object>, IOverviewS
       const missingContainers: IMissingContainersResponse = missingContainersResponse.data;     
       const taskStatus = taskstatusResponse.data && taskstatusResponse.data.filter((item:any) => item.taskName === 'OmDeltaRequest' || item.taskName === 'OmSnapshotRequest').sort((c1:any, c2:any) => c2.lastUpdatedTimestamp - c1.lastUpdatedTimestamp);
       const missingContainersCount = missingContainers.totalCount;
-      console.log("radha2",taskStatus);
+      const omDBDeltaObject=taskStatus[0];
+      const omDBFullObject= taskStatus[1];
+    
       this.setState({
         loading: false,
         datanodes: `${clusterState.healthyDatanodes}/${clusterState.totalDatanodes}`,
@@ -115,10 +117,10 @@ export class Overview extends React.Component<Record<string, object>, IOverviewS
         keys: clusterState.keys,
         missingContainersCount,
         lastUpdated: Number(moment()),
-        lastUpdatedOM: taskStatus[0] ? taskStatus[0] && taskStatus[0].lastUpdatedTimestamp : 0,
-        lastUpdateOMSync:taskStatus[1] ? taskStatus[1] && taskStatus[1].lastUpdatedTimestamp : 0,
-        lastUpdatedOMText:taskStatus[0] ? taskStatus[0] && taskStatus[0].taskName.toLowerCase() === 'OmDeltaRequest'.toLowerCase() ? 'Last Delta Update': 'Last Full Update': '',
-        lastUpdateOMSyncText: taskStatus[1] ? taskStatus[1] && taskStatus[1].taskName.toLowerCase() === 'OmDeltaRequest'.toLowerCase() ? 'Last Delta Update': 'Last Full Update' : ''
+        lastUpdatedOMDBDelta: omDBDeltaObject ? omDBDeltaObject.lastUpdatedTimestamp : 0,
+        lastUpdatedOMDBFull:  omDBFullObject ? omDBFullObject.lastUpdatedTimestamp : 0,
+        lastUpdatedOMDBDeltaText:omDBDeltaObject? omDBDeltaObject.taskName === 'OmDeltaRequest' ? 'Last Delta Update': 'Last Full Update': '',
+        lastUpdatedOMDBFullText: omDBFullObject ? omDBFullObject.taskName === 'OmDeltaRequest' ? 'Last Delta Update': 'Last Full Update' : ''
 
       });
     })).catch(error => {
@@ -140,7 +142,7 @@ export class Overview extends React.Component<Record<string, object>, IOverviewS
 
   render() {
     const {loading, datanodes, pipelines, storageReport, containers, volumes, buckets,
-      keys, missingContainersCount,lastUpdated,lastUpdatedOM,lastUpdateOMSync,lastUpdatedOMText,lastUpdateOMSyncText} = this.state;
+      keys, missingContainersCount,lastUpdated,lastUpdatedOMDBDelta,lastUpdatedOMDBFull,lastUpdatedOMDBDeltaText,lastUpdatedOMDBFullText} = this.state;
     const datanodesElement = (
       <span>
         <Icon type='check-circle' theme='filled' className='icon-success icon-small'/> {datanodes} <span className='ant-card-meta-description meta'>HEALTHY</span>
@@ -164,8 +166,8 @@ export class Overview extends React.Component<Record<string, object>, IOverviewS
         <div className='page-header'>
           Overview
           <AutoReloadPanel isLoading={loading} lastUpdated={lastUpdated} 
-          lastUpdatedOM={lastUpdatedOM}  lastUpdateOMSync={lastUpdateOMSync}
-          lastUpdatedOMText={lastUpdatedOMText}  lastUpdateOMSyncText={lastUpdateOMSyncText}
+          lastUpdatedOMDBDelta={lastUpdatedOMDBDelta}  lastUpdatedOMDBFull={lastUpdatedOMDBFull}
+          lastUpdatedOMDBDeltaText={lastUpdatedOMDBDeltaText}  lastUpdatedOMDBFullText={lastUpdatedOMDBFullText}
           togglePolling={this.autoReload.handleAutoReloadToggle} onReload={this._loadData}/>
         </div>
         <Row gutter={[25, 25]}>

--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/views/overview/overview.tsx
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/views/overview/overview.tsx
@@ -54,8 +54,7 @@ interface IOverviewState {
   missingContainersCount: number;
   lastRefreshed: number;
   lastUpdatedOMDBDelta: number,
-  lastUpdatedOMDBFull: number,
-  lastUpdatedOMLatest: number
+  lastUpdatedOMDBFull: number
 }
 
 export class Overview extends React.Component<Record<string, object>, IOverviewState> {
@@ -79,9 +78,8 @@ export class Overview extends React.Component<Record<string, object>, IOverviewS
       keys: 0,
       missingContainersCount: 0,
       lastRefreshed: 0,
-      lastUpdatedOMDBDelta:0,
-      lastUpdatedOMDBFull:0,
-      lastUpdatedOMLatest:0
+      lastUpdatedOMDBDelta: 0,
+      lastUpdatedOMDBFull: 0
     };
     this.autoReload = new AutoReloadHelper(this._loadData);
   }
@@ -98,10 +96,10 @@ export class Overview extends React.Component<Record<string, object>, IOverviewS
       
       const clusterState: IClusterStateResponse = clusterStateResponse.data;
       const missingContainers: IMissingContainersResponse = missingContainersResponse.data;     
-      const taskStatus = taskstatusResponse.data && taskstatusResponse.data.filter((item:any) => item.taskName === 'OmDeltaRequest' || item.taskName === 'OmSnapshotRequest').sort((c1:any, c2:any) => c2.lastUpdatedTimestamp - c1.lastUpdatedTimestamp);
+      const taskStatus = taskstatusResponse.data;
       const missingContainersCount = missingContainers.totalCount;
-      const omDBDeltaObject=taskStatus && taskStatus.find((item:any)=> item.taskName === 'OmDeltaRequest');
-      const omDBFullObject= taskStatus && taskStatus.find((item:any)=> item.taskName === 'OmSnapshotRequest');
+      const omDBDeltaObject = taskStatus && taskStatus.find((item:any) => item.taskName === 'OmDeltaRequest');
+      const omDBFullObject = taskStatus && taskStatus.find((item:any) => item.taskName === 'OmSnapshotRequest');
     
       this.setState({
         loading: false,
@@ -115,8 +113,7 @@ export class Overview extends React.Component<Record<string, object>, IOverviewS
         missingContainersCount,
         lastRefreshed: Number(moment()),
         lastUpdatedOMDBDelta:omDBDeltaObject && omDBDeltaObject.lastUpdatedTimestamp,
-        lastUpdatedOMDBFull:omDBFullObject && omDBFullObject.lastUpdatedTimestamp,
-        lastUpdatedOMLatest: taskStatus && taskStatus[0] &&taskStatus[0].lastUpdatedTimestamp
+        lastUpdatedOMDBFull:omDBFullObject && omDBFullObject.lastUpdatedTimestamp
       });
     })).catch(error => {
       this.setState({
@@ -137,7 +134,7 @@ export class Overview extends React.Component<Record<string, object>, IOverviewS
 
   render() {
     const {loading, datanodes, pipelines, storageReport, containers, volumes, buckets,
-      keys, missingContainersCount,lastRefreshed,lastUpdatedOMDBDelta,lastUpdatedOMDBFull,lastUpdatedOMLatest} = this.state;
+      keys, missingContainersCount, lastRefreshed, lastUpdatedOMDBDelta, lastUpdatedOMDBFull} = this.state;
       
     const datanodesElement = (
       <span>
@@ -161,8 +158,8 @@ export class Overview extends React.Component<Record<string, object>, IOverviewS
       <div className='overview-content'>
         <div className='page-header'>
           Overview
-          <AutoReloadPanel isLoading={loading} lastRefreshed={lastRefreshed} lastUpdatedOMLatest={lastUpdatedOMLatest}
-          lastUpdatedOMDBDelta={lastUpdatedOMDBDelta}  lastUpdatedOMDBFull={lastUpdatedOMDBFull}
+          <AutoReloadPanel isLoading={loading} lastRefreshed={lastRefreshed}
+          lastUpdatedOMDBDelta={lastUpdatedOMDBDelta} lastUpdatedOMDBFull={lastUpdatedOMDBFull}
           togglePolling={this.autoReload.handleAutoReloadToggle} onReload={this._loadData}/>
         </div>
         <Row gutter={[25, 25]}>

--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/views/overview/overview.tsx
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/views/overview/overview.tsx
@@ -112,8 +112,8 @@ export class Overview extends React.Component<Record<string, object>, IOverviewS
         keys: clusterState.keys,
         missingContainersCount,
         lastRefreshed: Number(moment()),
-        lastUpdatedOMDBDelta:omDBDeltaObject && omDBDeltaObject.lastUpdatedTimestamp,
-        lastUpdatedOMDBFull:omDBFullObject && omDBFullObject.lastUpdatedTimestamp
+        lastUpdatedOMDBDelta: omDBDeltaObject && omDBDeltaObject.lastUpdatedTimestamp,
+        lastUpdatedOMDBFull: omDBFullObject && omDBFullObject.lastUpdatedTimestamp
       });
     })).catch(error => {
       this.setState({

--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/views/overview/overview.tsx
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/views/overview/overview.tsx
@@ -53,8 +53,8 @@ interface IOverviewState {
   keys: number;
   missingContainersCount: number;
   lastRefreshed: number;
-  lastUpdatedOMDBDelta: number,
-  lastUpdatedOMDBFull: number
+  lastUpdatedOMDBDelta: number;
+  lastUpdatedOMDBFull: number;
 }
 
 export class Overview extends React.Component<Record<string, object>, IOverviewState> {

--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/views/overview/overview.tsx
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/views/overview/overview.tsx
@@ -53,9 +53,9 @@ interface IOverviewState {
   keys: number;
   missingContainersCount: number;
   lastRefreshed: number;
-  lastUpdatedOMDBDelta:number,
-  lastUpdatedOMDBFull:number,
-  lastUpdatedOMLatest:number
+  lastUpdatedOMDBDelta: number,
+  lastUpdatedOMDBFull: number,
+  lastUpdatedOMLatest: number
 }
 
 export class Overview extends React.Component<Record<string, object>, IOverviewState> {


### PR DESCRIPTION
## What changes were proposed in this pull request?
Display ToolTip to show OM last updated Delta and Full timestamp.


## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-7145

## How was this patch tested?
Manually Tested and reviewed by siyog and corrected review changes suggested by siyog.

