### PR TITLE
HDDS-7208. Erasure coding and encryption are not flagged on FileStatus

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFileSystem.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFileSystem.java
@@ -632,6 +632,11 @@ public class TestOzoneFileSystem {
     FileStatus[] fileStatuses = fs.listStatus(parent);
     // the number of immediate children of root is 1
     Assert.assertEquals(1, fileStatuses.length);
+    Assert.assertEquals(fileStatuses[0].isErasureCoded(),
+            !bucketLayout.isFileSystemOptimized());
+    fileStatuses = fs.listStatus(new Path(
+            fileStatuses[0].getPath().toString()+"/object-name1"));
+    Assert.assertEquals(1, fileStatuses.length);
     Assert.assertTrue(fileStatuses[0].isErasureCoded());
     writeClient.deleteKey(keyArgs);
   }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFileSystem.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFileSystem.java
@@ -629,6 +629,18 @@ public class TestOzoneFileSystem {
     OpenKeySession session = writeClient.openKey(keyArgs);
     writeClient.commitKey(keyArgs, session.getId());
     Path parent = new Path("/");
+    // Wait until the filestatus is updated
+    if (!enabledFileSystemPaths) {
+      GenericTestUtils.waitFor(() -> {
+        try {
+          return fs.listStatus(parent).length != 0;
+        } catch (IOException e) {
+          LOG.error("listStatus() Failed", e);
+          Assert.fail("listStatus() Failed");
+          return false;
+        }
+      }, 1000, 120000);
+    }
     FileStatus[] fileStatuses = fs.listStatus(parent);
     // the number of immediate children of root is 1
     Assert.assertEquals(1, fileStatuses.length);

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFileSystem.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFileSystem.java
@@ -635,7 +635,7 @@ public class TestOzoneFileSystem {
     Assert.assertEquals(fileStatuses[0].isErasureCoded(),
             !bucketLayout.isFileSystemOptimized());
     fileStatuses = fs.listStatus(new Path(
-            fileStatuses[0].getPath().toString()+"/object-name1"));
+            fileStatuses[0].getPath().toString() + "/object-name1"));
     Assert.assertEquals(1, fileStatuses.length);
     Assert.assertTrue(fileStatuses[0].isErasureCoded());
     writeClient.deleteKey(keyArgs);

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFileSystem.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFileSystem.java
@@ -32,17 +32,7 @@ import java.util.Set;
 import java.util.TreeSet;
 
 import org.apache.hadoop.conf.Configuration;
-import org.apache.hadoop.fs.CommonConfigurationKeysPublic;
-import org.apache.hadoop.fs.FSDataInputStream;
-import org.apache.hadoop.fs.FSDataOutputStream;
-import org.apache.hadoop.fs.FileAlreadyExistsException;
-import org.apache.hadoop.fs.FileStatus;
-import org.apache.hadoop.fs.FileSystem;
-import org.apache.hadoop.fs.InvalidPathException;
-import org.apache.hadoop.fs.Path;
-import org.apache.hadoop.fs.PathIsNotEmptyDirectoryException;
-import org.apache.hadoop.fs.Trash;
-import org.apache.hadoop.fs.TrashPolicy;
+import org.apache.hadoop.fs.*;
 import org.apache.hadoop.fs.contract.ContractTestUtils;
 import org.apache.hadoop.fs.permission.FsPermission;
 import org.apache.hadoop.hdds.client.ECReplicationConfig;
@@ -111,11 +101,12 @@ public class TestOzoneFileSystem {
 
   @Parameterized.Parameters
   public static Collection<Object[]> data() {
-    return Arrays.asList(
-        new Object[]{true, true},
-        new Object[]{true, false},
-        new Object[]{false, true},
-        new Object[]{false, false});
+    return Collections.singletonList(new Object[]{true, true});
+//    return Arrays.asList(
+////        new Object[]{true, true},
+////        new Object[]{true, false},
+//        new Object[]{false, true},
+//        new Object[]{false, false});
   }
 
   public TestOzoneFileSystem(boolean setDefaultFs, boolean enableOMRatis) {
@@ -124,7 +115,7 @@ public class TestOzoneFileSystem {
     // TestOzoneFileSystem#init() function will be invoked only at the
     // beginning of every new set of Parameterized.Parameters.
     if (enabledFileSystemPaths != setDefaultFs ||
-            omRatisEnabled != enableOMRatis) {
+            omRatisEnabled != enableOMRatis || cluster == null) {
       enabledFileSystemPaths = setDefaultFs;
       omRatisEnabled = enableOMRatis;
       try {
@@ -209,6 +200,7 @@ public class TestOzoneFileSystem {
   @After
   public void cleanup() {
     try {
+      System.out.println("Cleaning Up");
       Path root = new Path("/");
       FileStatus[] fileStatuses = fs.listStatus(root);
       for (FileStatus fileStatus : fileStatuses) {
@@ -610,9 +602,65 @@ public class TestOzoneFileSystem {
     }
 
     FileStatus[] fileStatuses = fs.listStatus(parent);
-
     // the number of immediate children of root is 1
     Assert.assertEquals(1, fileStatuses.length);
+    writeClient.deleteKey(keyArgs);
+  }
+
+  @Test
+  public void testListStatusWithIntermediateDirWithECEnabled() throws Exception {
+    System.out.println("Executing");
+    String keyName = "object-dir/object-name1";
+    OmKeyArgs keyArgs = new OmKeyArgs.Builder()
+            .setVolumeName(volumeName)
+            .setBucketName(bucketName)
+            .setKeyName(keyName)
+            .setAcls(Collections.emptyList())
+            .setReplicationConfig(new ECReplicationConfig(3, 2))
+            .setLocationInfoList(new ArrayList<>())
+            .build();
+    OpenKeySession session = writeClient.openKey(keyArgs);
+
+    writeClient.commitKey(keyArgs, session.getId());
+
+
+
+
+
+
+
+    keyName = "object-dir/object-name2";
+    keyArgs = new OmKeyArgs.Builder()
+            .setVolumeName(volumeName)
+            .setBucketName(bucketName)
+            .setKeyName(keyName)
+            .setAcls(Collections.emptyList())
+            .setReplicationConfig(new ECReplicationConfig(3, 2))
+            .setLocationInfoList(new ArrayList<>())
+            .build();
+    session = writeClient.openKey(keyArgs);
+
+    writeClient.commitKey(keyArgs, session.getId());
+
+    Path parent = new Path("/");
+
+    // Wait until the filestatus is updated
+    if (!enabledFileSystemPaths) {
+      GenericTestUtils.waitFor(() -> {
+        try {
+          return fs.listStatus(parent).length != 0;
+        } catch (IOException e) {
+          LOG.error("listStatus() Failed", e);
+          Assert.fail("listStatus() Failed");
+          return false;
+        }
+      }, 1000, 120000);
+    }
+
+    FileStatus[] fileStatuses = fs.listStatus(parent);
+    // the number of immediate children of root is 1
+    Assert.assertEquals(2, fileStatuses.length);
+    Assert.assertTrue(fileStatuses[0].isErasureCoded());
     writeClient.deleteKey(keyArgs);
   }
 

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/TestDataUtil.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/TestDataUtil.java
@@ -23,9 +23,7 @@ import java.io.OutputStream;
 import java.util.HashMap;
 import java.util.Scanner;
 
-import org.apache.hadoop.hdds.client.ReplicationConfig;
-import org.apache.hadoop.hdds.client.ReplicationFactor;
-import org.apache.hadoop.hdds.client.ReplicationType;
+import org.apache.hadoop.hdds.client.*;
 import org.apache.hadoop.hdds.protocol.StorageType;
 import org.apache.hadoop.ozone.client.BucketArgs;
 import org.apache.hadoop.ozone.client.ObjectStore;
@@ -63,7 +61,8 @@ public final class TestDataUtil {
     if (bucketLayout != null) {
       builder.setBucketLayout(bucketLayout);
     }
-    omBucketArgs = builder.build();
+    omBucketArgs =
+            builder.setDefaultReplicationConfig(new DefaultReplicationConfig(new ECReplicationConfig(3,2))).build();
 
     return createVolumeAndBucket(cluster, volumeName, bucketName, bucketLayout,
         omBucketArgs);

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/TestDataUtil.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/TestDataUtil.java
@@ -23,7 +23,9 @@ import java.io.OutputStream;
 import java.util.HashMap;
 import java.util.Scanner;
 
-import org.apache.hadoop.hdds.client.*;
+import org.apache.hadoop.hdds.client.ReplicationConfig;
+import org.apache.hadoop.hdds.client.ReplicationFactor;
+import org.apache.hadoop.hdds.client.ReplicationType;
 import org.apache.hadoop.hdds.protocol.StorageType;
 import org.apache.hadoop.ozone.client.BucketArgs;
 import org.apache.hadoop.ozone.client.ObjectStore;
@@ -61,8 +63,7 @@ public final class TestDataUtil {
     if (bucketLayout != null) {
       builder.setBucketLayout(bucketLayout);
     }
-    omBucketArgs =
-            builder.setDefaultReplicationConfig(new DefaultReplicationConfig(new ECReplicationConfig(3,2))).build();
+    omBucketArgs = builder.build();
 
     return createVolumeAndBucket(cluster, volumeName, bucketName, bucketLayout,
         omBucketArgs);

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/KeyManagerImpl.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/KeyManagerImpl.java
@@ -1379,12 +1379,14 @@ public class KeyManagerImpl implements KeyManager {
   }
 
   private OmKeyInfo createDirectoryKey(String volumeName, String bucketName,
-      String keyName, List<OzoneAcl> acls) throws IOException {
+      String keyName, List<OzoneAcl> acls,
+      ReplicationConfig replicationConfig) throws IOException {
     // verify bucket exists
     OmBucketInfo bucketInfo = getBucketInfo(volumeName, bucketName);
 
     String dir = OzoneFSUtils.addTrailingSlashIfNeeded(keyName);
     FileEncryptionInfo encInfo = getFileEncryptionInfo(bucketInfo);
+
     return new OmKeyInfo.Builder()
         .setVolumeName(volumeName)
         .setBucketName(bucketName)
@@ -1394,8 +1396,7 @@ public class KeyManagerImpl implements KeyManager {
         .setCreationTime(Time.now())
         .setModificationTime(Time.now())
         .setDataSize(0)
-        .setReplicationConfig(RatisReplicationConfig
-            .getInstance(ReplicationFactor.ONE))
+        .setReplicationConfig(replicationConfig)
         .setFileEncryptionInfo(encInfo)
         .setAcls(acls)
         .build();
@@ -1690,7 +1691,8 @@ public class KeyManagerImpl implements KeyManager {
                 if (!entryKeyName.equals(immediateChild)) {
                   OmKeyInfo fakeDirEntry = createDirectoryKey(
                       omKeyInfo.getVolumeName(), omKeyInfo.getBucketName(),
-                      immediateChild, omKeyInfo.getAcls());
+                      immediateChild, omKeyInfo.getAcls(),
+                      omKeyInfo.getReplicationConfig());
                   cacheKeyMap.put(entryInDb,
                       new OzoneFileStatus(fakeDirEntry,
                           scmBlockSize, true));

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/KeyManagerImpl.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/KeyManagerImpl.java
@@ -45,11 +45,9 @@ import org.apache.hadoop.conf.StorageUnit;
 import org.apache.hadoop.crypto.key.KeyProviderCryptoExtension;
 import org.apache.hadoop.crypto.key.KeyProviderCryptoExtension.EncryptedKeyVersion;
 import org.apache.hadoop.fs.FileEncryptionInfo;
-import org.apache.hadoop.hdds.client.RatisReplicationConfig;
 import org.apache.hadoop.hdds.client.ReplicationConfig;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
-import org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationFactor;
 import org.apache.hadoop.hdds.scm.container.common.helpers.ContainerWithPipeline;
 import org.apache.hadoop.hdds.scm.pipeline.Pipeline;
 import org.apache.hadoop.hdds.scm.protocol.ScmBlockLocationProtocol;
@@ -1378,27 +1376,26 @@ public class KeyManagerImpl implements KeyManager {
             FILE_NOT_FOUND);
   }
 
-  private OmKeyInfo createDirectoryKey(String volumeName, String bucketName,
-      String keyName, List<OzoneAcl> acls,
-      ReplicationConfig replicationConfig) throws IOException {
+  private OmKeyInfo createDirectoryKey(OmKeyInfo keyInfo, String keyName)
+          throws IOException {
     // verify bucket exists
-    OmBucketInfo bucketInfo = getBucketInfo(volumeName, bucketName);
+    OmBucketInfo bucketInfo = getBucketInfo(keyInfo.getVolumeName(),
+            keyInfo.getBucketName());
 
     String dir = OzoneFSUtils.addTrailingSlashIfNeeded(keyName);
     FileEncryptionInfo encInfo = getFileEncryptionInfo(bucketInfo);
-
     return new OmKeyInfo.Builder()
-        .setVolumeName(volumeName)
-        .setBucketName(bucketName)
+        .setVolumeName(keyInfo.getVolumeName())
+        .setBucketName(keyInfo.getBucketName())
         .setKeyName(dir)
         .setOmKeyLocationInfos(Collections.singletonList(
             new OmKeyLocationInfoGroup(0, new ArrayList<>())))
         .setCreationTime(Time.now())
         .setModificationTime(Time.now())
         .setDataSize(0)
-        .setReplicationConfig(replicationConfig)
+        .setReplicationConfig(keyInfo.getReplicationConfig())
         .setFileEncryptionInfo(encInfo)
-        .setAcls(acls)
+        .setAcls(keyInfo.getAcls())
         .build();
   }
   /**
@@ -1690,9 +1687,7 @@ public class KeyManagerImpl implements KeyManager {
               if (!isKeyDeleted(entryInDb, keyTable)) {
                 if (!entryKeyName.equals(immediateChild)) {
                   OmKeyInfo fakeDirEntry = createDirectoryKey(
-                      omKeyInfo.getVolumeName(), omKeyInfo.getBucketName(),
-                      immediateChild, omKeyInfo.getAcls(),
-                      omKeyInfo.getReplicationConfig());
+                      omKeyInfo, immediateChild);
                   cacheKeyMap.put(entryInDb,
                       new OzoneFileStatus(fakeDirEntry,
                           scmBlockSize, true));

--- a/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicOzoneClientAdapterImpl.java
+++ b/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicOzoneClientAdapterImpl.java
@@ -27,7 +27,6 @@ import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
-import java.util.Objects;
 
 import com.google.common.annotations.VisibleForTesting;
 import org.apache.hadoop.conf.Configuration;
@@ -43,7 +42,6 @@ import org.apache.hadoop.hdds.client.ReplicationFactor;
 import org.apache.hadoop.hdds.conf.ConfigurationSource;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
-import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.hdds.scm.OzoneClientConfig;
 import org.apache.hadoop.hdds.security.x509.SecurityConfig;
 import org.apache.hadoop.io.Text;
@@ -537,9 +535,8 @@ public class BasicOzoneClientAdapterImpl implements OzoneClientAdapter {
         owner,
         null,
         getBlockLocations(status),
-        !Objects.isNull(keyInfo.getFileEncryptionInfo()),
-        keyInfo.getReplicationConfig().getReplicationType() ==
-        HddsProtos.ReplicationType.EC
+        OzoneClientUtils.isKeyEncrypted(keyInfo),
+        OzoneClientUtils.isKeyErasureCode(keyInfo)
     );
   }
 

--- a/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicOzoneClientAdapterImpl.java
+++ b/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicOzoneClientAdapterImpl.java
@@ -23,10 +23,7 @@ import java.io.InputStream;
 import java.net.URI;
 import java.time.Clock;
 import java.time.ZoneOffset;
-import java.util.ArrayList;
-import java.util.Iterator;
-import java.util.List;
-import java.util.HashSet;
+import java.util.*;
 
 import com.google.common.annotations.VisibleForTesting;
 import org.apache.hadoop.conf.Configuration;
@@ -42,6 +39,7 @@ import org.apache.hadoop.hdds.client.ReplicationFactor;
 import org.apache.hadoop.hdds.conf.ConfigurationSource;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
+import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.hdds.scm.OzoneClientConfig;
 import org.apache.hadoop.hdds.security.x509.SecurityConfig;
 import org.apache.hadoop.io.Text;
@@ -534,7 +532,10 @@ public class BasicOzoneClientAdapterImpl implements OzoneClientAdapter {
         owner,
         owner,
         null,
-        getBlockLocations(status)
+        getBlockLocations(status),
+        !Objects.isNull(keyInfo.getFileEncryptionInfo()),
+        keyInfo.getReplicationConfig().getReplicationType() ==
+        HddsProtos.ReplicationType.EC
     );
   }
 

--- a/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicOzoneClientAdapterImpl.java
+++ b/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicOzoneClientAdapterImpl.java
@@ -23,7 +23,11 @@ import java.io.InputStream;
 import java.net.URI;
 import java.time.Clock;
 import java.time.ZoneOffset;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Objects;
 
 import com.google.common.annotations.VisibleForTesting;
 import org.apache.hadoop.conf.Configuration;

--- a/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicOzoneFileSystem.java
+++ b/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicOzoneFileSystem.java
@@ -1026,32 +1026,27 @@ public class BasicOzoneFileSystem extends FileSystem {
     return true;
   }
 
+  protected FileStatus constructFileStatus(FileStatusAdapter fileStatusAdapter) {
+    return new FileStatus(fileStatusAdapter.getLength(),
+            fileStatusAdapter.isDir(),
+            fileStatusAdapter.getBlockReplication(),
+            fileStatusAdapter.getBlocksize(),
+            fileStatusAdapter.getModificationTime(),
+            fileStatusAdapter.getAccessTime(),
+            new FsPermission(fileStatusAdapter.getPermission()),
+            fileStatusAdapter.getOwner(),
+            fileStatusAdapter.getGroup(),
+            fileStatusAdapter.getSymlink(),
+            fileStatusAdapter.getPath(),
+            false,
+            fileStatusAdapter.isEncrypted(),
+            fileStatusAdapter.isErasureCoded()
+    );
+  }
+
   private FileStatus convertFileStatus(
       FileStatusAdapter fileStatusAdapter) {
-
-    Path symLink = null;
-    try {
-      fileStatusAdapter.getSymlink();
-    } catch (Exception ex) {
-      //NOOP: If not symlink symlink remains null.
-    }
-
-    FileStatus fileStatus =  new FileStatus(
-        fileStatusAdapter.getLength(),
-        fileStatusAdapter.isDir(),
-        fileStatusAdapter.getBlockReplication(),
-        fileStatusAdapter.getBlocksize(),
-        fileStatusAdapter.getModificationTime(),
-        fileStatusAdapter.getAccessTime(),
-        new FsPermission(fileStatusAdapter.getPermission()),
-        fileStatusAdapter.getOwner(),
-        fileStatusAdapter.getGroup(),
-        symLink,
-        fileStatusAdapter.getPath(),
-        false,
-        fileStatusAdapter.isEncrypted(),
-        fileStatusAdapter.isErasureCoded()
-    );
+    FileStatus fileStatus = constructFileStatus(fileStatusAdapter);
 
     BlockLocation[] blockLocations = fileStatusAdapter.getBlockLocations();
     if (blockLocations == null || blockLocations.length == 0) {

--- a/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicOzoneFileSystem.java
+++ b/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicOzoneFileSystem.java
@@ -1047,7 +1047,10 @@ public class BasicOzoneFileSystem extends FileSystem {
         fileStatusAdapter.getOwner(),
         fileStatusAdapter.getGroup(),
         symLink,
-        fileStatusAdapter.getPath()
+        fileStatusAdapter.getPath(),
+        false,
+        fileStatusAdapter.isEncrypted(),
+        fileStatusAdapter.isErasureCoded()
     );
 
     BlockLocation[] blockLocations = fileStatusAdapter.getBlockLocations();

--- a/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicOzoneFileSystem.java
+++ b/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicOzoneFileSystem.java
@@ -1026,7 +1026,8 @@ public class BasicOzoneFileSystem extends FileSystem {
     return true;
   }
 
-  protected FileStatus constructFileStatus(FileStatusAdapter fileStatusAdapter) {
+  protected FileStatus constructFileStatus(
+          FileStatusAdapter fileStatusAdapter) {
     return new FileStatus(fileStatusAdapter.getLength(),
             fileStatusAdapter.isDir(),
             fileStatusAdapter.getBlockReplication(),

--- a/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicRootedOzoneClientAdapterImpl.java
+++ b/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicRootedOzoneClientAdapterImpl.java
@@ -28,7 +28,6 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
-import java.util.Objects;
 import java.util.stream.Collectors;
 
 import com.google.common.base.Preconditions;
@@ -960,9 +959,8 @@ public class BasicRootedOzoneClientAdapterImpl
         owner,
         null,
         getBlockLocations(status),
-        !Objects.isNull(keyInfo.getFileEncryptionInfo()),
-        keyInfo.getReplicationConfig().getReplicationType() ==
-                HddsProtos.ReplicationType.EC
+        OzoneClientUtils.isKeyEncrypted(keyInfo),
+        OzoneClientUtils.isKeyErasureCode(keyInfo)
     );
   }
 

--- a/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicRootedOzoneClientAdapterImpl.java
+++ b/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicRootedOzoneClientAdapterImpl.java
@@ -22,7 +22,13 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Objects;
 import java.util.stream.Collectors;
 
 import com.google.common.base.Preconditions;

--- a/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicRootedOzoneClientAdapterImpl.java
+++ b/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicRootedOzoneClientAdapterImpl.java
@@ -22,12 +22,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.Iterator;
-import java.util.List;
-import java.util.HashSet;
+import java.util.*;
 import java.util.stream.Collectors;
 
 import com.google.common.base.Preconditions;
@@ -48,6 +43,7 @@ import org.apache.hadoop.hdds.client.ReplicationFactor;
 import org.apache.hadoop.hdds.conf.ConfigurationSource;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
+import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.hdds.scm.OzoneClientConfig;
 import org.apache.hadoop.hdds.security.x509.SecurityConfig;
 import org.apache.hadoop.io.Text;
@@ -957,7 +953,10 @@ public class BasicRootedOzoneClientAdapterImpl
         owner,
         owner,
         null,
-        getBlockLocations(status)
+        getBlockLocations(status),
+        !Objects.isNull(keyInfo.getFileEncryptionInfo()),
+        keyInfo.getReplicationConfig().getReplicationType() ==
+                HddsProtos.ReplicationType.EC
     );
   }
 
@@ -1051,8 +1050,7 @@ public class BasicRootedOzoneClientAdapterImpl
     return new FileStatusAdapter(0L, path, true, (short)0, 0L,
         ozoneVolume.getCreationTime().getEpochSecond() * 1000, 0L,
         FsPermission.getDirDefault().toShort(),
-        owner, group, path,
-        new BlockLocation[0]
+        owner, group, path, new BlockLocation[0], false, false
     );
   }
 
@@ -1075,10 +1073,14 @@ public class BasicRootedOzoneClientAdapterImpl
               ozoneBucket.getName(), pathStr);
     }
     Path path = new Path(pathStr);
+
     return new FileStatusAdapter(0L, path, true, (short)0, 0L,
         ozoneBucket.getCreationTime().getEpochSecond() * 1000, 0L,
         FsPermission.getDirDefault().toShort(),
-        owner, group, path, new BlockLocation[0]);
+        owner, group, path, new BlockLocation[0],
+        !StringUtils.isEmpty(ozoneBucket.getEncryptionKeyName()),
+        ozoneBucket.getReplicationConfig().getReplicationType() ==
+                    HddsProtos.ReplicationType.EC);
   }
 
   /**
@@ -1093,8 +1095,7 @@ public class BasicRootedOzoneClientAdapterImpl
     return new FileStatusAdapter(0L, path, true, (short)0, 0L,
         System.currentTimeMillis(), 0L,
         FsPermission.getDirDefault().toShort(),
-        null, null, null, new BlockLocation[0]
-    );
+        null, null, null, new BlockLocation[0], false, false);
   }
 
   @Override

--- a/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicRootedOzoneClientAdapterImpl.java
+++ b/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicRootedOzoneClientAdapterImpl.java
@@ -1083,7 +1083,8 @@ public class BasicRootedOzoneClientAdapterImpl
         FsPermission.getDirDefault().toShort(),
         owner, group, path, new BlockLocation[0],
         !StringUtils.isEmpty(ozoneBucket.getEncryptionKeyName()),
-        ozoneBucket.getReplicationConfig().getReplicationType() ==
+        ozoneBucket.getReplicationConfig() != null &&
+                    ozoneBucket.getReplicationConfig().getReplicationType() ==
                     HddsProtos.ReplicationType.EC);
   }
 

--- a/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/FileStatusAdapter.java
+++ b/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/FileStatusAdapter.java
@@ -47,11 +47,16 @@ public final class FileStatusAdapter {
   private final Path symlink;
   private final BlockLocation[] blockLocations;
 
+  private final boolean isEncrypted;
+
+  private final boolean isErasureCoded;
+
   @SuppressWarnings("checkstyle:ParameterNumber")
   public FileStatusAdapter(long length, Path path, boolean isdir,
       short blockReplication, long blocksize, long modificationTime,
       long accessTime, short permission, String owner,
-      String group, Path symlink, BlockLocation[] locations) {
+      String group, Path symlink, BlockLocation[] locations,
+      boolean isEncrypted, boolean isErasureCoded) {
     this.length = length;
     this.path = path;
     this.isdir = isdir;
@@ -64,6 +69,8 @@ public final class FileStatusAdapter {
     this.group = group;
     this.symlink = symlink;
     this.blockLocations = locations.clone();
+    this.isEncrypted = isEncrypted;
+    this.isErasureCoded = isErasureCoded;
   }
 
 
@@ -109,6 +116,14 @@ public final class FileStatusAdapter {
 
   public long getLength() {
     return length;
+  }
+
+  public boolean isEncrypted() {
+    return isEncrypted;
+  }
+
+  public boolean isErasureCoded() {
+    return isErasureCoded;
   }
 
   @SuppressFBWarnings("EI_EXPOSE_REP")

--- a/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/OzoneClientUtils.java
+++ b/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/OzoneClientUtils.java
@@ -37,6 +37,7 @@ import org.apache.hadoop.ozone.om.helpers.OmKeyArgs;
 import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
 
 import java.io.IOException;
+import java.util.Objects;
 import java.util.Set;
 
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_REPLICATION;
@@ -224,4 +225,14 @@ public final class OzoneClientUtils {
     helper.compute();
     return helper.getFileChecksum();
   }
+
+  public static boolean isKeyErasureCode(OmKeyInfo keyInfo) {
+    return keyInfo.getReplicationConfig().getReplicationType() ==
+            HddsProtos.ReplicationType.EC;
+  }
+
+  public static boolean isKeyEncrypted(OmKeyInfo keyInfo) {
+    return !Objects.isNull(keyInfo.getFileEncryptionInfo());
+  }
+
 }

--- a/hadoop-ozone/ozonefs-hadoop2/src/main/java/org/apache/hadoop/fs/ozone/OzoneFileSystem.java
+++ b/hadoop-ozone/ozonefs-hadoop2/src/main/java/org/apache/hadoop/fs/ozone/OzoneFileSystem.java
@@ -24,20 +24,20 @@ import org.apache.hadoop.fs.permission.FsPermission;
  * Minimal Ozone File System compatible with Hadoop 2.x.
  */
 public class OzoneFileSystem extends BasicOzoneFileSystem {
-    @Override
-    protected FileStatus constructFileStatus(
-            FileStatusAdapter fileStatusAdapter) {
-        return new FileStatus(fileStatusAdapter.getLength(),
-                fileStatusAdapter.isDir(),
-                fileStatusAdapter.getBlockReplication(),
-                fileStatusAdapter.getBlocksize(),
-                fileStatusAdapter.getModificationTime(),
-                fileStatusAdapter.getAccessTime(),
-                new FsPermission(fileStatusAdapter.getPermission()),
-                fileStatusAdapter.getOwner(),
-                fileStatusAdapter.getGroup(),
-                fileStatusAdapter.getSymlink(),
-                fileStatusAdapter.getPath()
+  @Override
+  protected FileStatus constructFileStatus(
+          FileStatusAdapter fileStatusAdapter) {
+    return new FileStatus(fileStatusAdapter.getLength(),
+            fileStatusAdapter.isDir(),
+            fileStatusAdapter.getBlockReplication(),
+            fileStatusAdapter.getBlocksize(),
+            fileStatusAdapter.getModificationTime(),
+            fileStatusAdapter.getAccessTime(),
+            new FsPermission(fileStatusAdapter.getPermission()),
+            fileStatusAdapter.getOwner(),
+            fileStatusAdapter.getGroup(),
+            fileStatusAdapter.getSymlink(),
+            fileStatusAdapter.getPath()
         );
-    }
+  }
 }

--- a/hadoop-ozone/ozonefs-hadoop2/src/main/java/org/apache/hadoop/fs/ozone/OzoneFileSystem.java
+++ b/hadoop-ozone/ozonefs-hadoop2/src/main/java/org/apache/hadoop/fs/ozone/OzoneFileSystem.java
@@ -17,9 +17,27 @@
  */
 package org.apache.hadoop.fs.ozone;
 
+import org.apache.hadoop.fs.FileStatus;
+import org.apache.hadoop.fs.permission.FsPermission;
+
 /**
  * Minimal Ozone File System compatible with Hadoop 2.x.
  */
 public class OzoneFileSystem extends BasicOzoneFileSystem {
-
+    @Override
+    protected FileStatus constructFileStatus(
+            FileStatusAdapter fileStatusAdapter) {
+        return new FileStatus(fileStatusAdapter.getLength(),
+                fileStatusAdapter.isDir(),
+                fileStatusAdapter.getBlockReplication(),
+                fileStatusAdapter.getBlocksize(),
+                fileStatusAdapter.getModificationTime(),
+                fileStatusAdapter.getAccessTime(),
+                new FsPermission(fileStatusAdapter.getPermission()),
+                fileStatusAdapter.getOwner(),
+                fileStatusAdapter.getGroup(),
+                fileStatusAdapter.getSymlink(),
+                fileStatusAdapter.getPath()
+        );
+    }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?
Hadoop FileStatus accepts flags for erasure coding and encryption on creation. Impala relies on FileStatus.isErasureCoded. Ozone doesn't use this signature, so isErasureCoded and isEncrypted always return false.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-7208



## How was this patch tested?
Changing Getter Setters