### PR TITLE
HDDS-7240. List all volume operation should go through ACL check as well in order to trigger audit logging

### DIFF
--- a/hadoop-hdds/common/src/main/resources/ozone-default.xml
+++ b/hadoop-hdds/common/src/main/resources/ozone-default.xml
@@ -608,7 +608,11 @@
     <description>
       Allows everyone to list all volumes when set to true. Defaults to true.
       When set to false, non-admin users can only list the volumes they have
-      access to. Admins can always list all volumes.
+      access to. Admins can always list all volumes. Note that this config
+      only applies to OzoneNativeAuthorizer. For other authorizers, admin
+      needs to set policies accordingly to allow all volume listing
+      e.g. for Ranger, a new policy with special volume "/" can be added to
+      allow group public LIST access.
     </description>
   </property>
   <property>

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
@@ -2709,12 +2709,9 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
     auditMap.put(OzoneConsts.USERNAME, null);
     try {
       metrics.incNumVolumeLists();
-      if (!allowListAllVolumes) {
-        // Only admin can list all volumes when disallowed in config
-        if (isAclEnabled) {
-          checkAcls(ResourceType.VOLUME, StoreType.OZONE, ACLType.LIST,
-              OzoneConsts.OZONE_ROOT, null, null);
-        }
+      if (isAclEnabled) {
+        checkAcls(ResourceType.VOLUME, StoreType.OZONE, ACLType.LIST,
+            OzoneConsts.OZONE_ROOT, null, null);
       }
       return volumeManager.listVolumes(null, prefix, prevKey, maxKeys);
     } catch (Exception ex) {


### PR DESCRIPTION
## What changes were proposed in this pull request?

Previously the list all volume operation only went through the ACL check if the list all volume was disabled. Because of this the audit logging wasn't triggered. I removed the if condition checking the `ozone.om.volume.listall.allowed`'s value, so the ACL check gets triggered in every case (if the ACL is enabled). I also updated the `ozone.om.volume.listall.allowed`'s description in `ozone-default.xml`.

OzoneNativeAuthorizer wouldn't be affected by this change, because of [this](https://github.com/apache/ozone/pull/1395) change, the allowListAllVolumes is set [here](https://github.com/apache/ozone/blob/master/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java#L762) on the authorizer side.  

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-7240

## How was this patch tested?

Run related tests. 