### PR TITLE
HDDS-7229. Introduce container location cache in ScmClient

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/protocol/StorageContainerLocationProtocol.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/protocol/StorageContainerLocationProtocol.java
@@ -116,7 +116,7 @@ public interface StorageContainerLocationProtocol extends Closeable {
    * @throws IOException
    */
   List<ContainerWithPipeline> getContainerWithPipelineBatch(
-      List<Long> containerIDs) throws IOException;
+      Iterable<? extends Long> containerIDs) throws IOException;
 
   /**
    * Ask SCM which containers of the given list exist.

--- a/hadoop-hdds/common/src/main/resources/ozone-default.xml
+++ b/hadoop-hdds/common/src/main/resources/ozone-default.xml
@@ -3334,4 +3334,25 @@
       will create intermediate directories.
     </description>
   </property>
+
+  <property>
+    <name>ozone.om.container.location.cache.size</name>
+    <value>100000</value>
+    <tag>OZONE, OM</tag>
+    <description>
+      The size of the container locations cache in Ozone Manager. This cache allows Ozone Manager to populate
+      block locations in key-read responses without calling SCM, thus increases Ozone Manager read performance.
+    </description>
+  </property>
+
+  <property>
+    <name>ozone.om.container.location.cache.ttl</name>
+    <value>360m</value>
+    <tag>OZONE, OM</tag>
+    <description>
+      The time to live for container location cache in Ozone.
+    </description>
+  </property>
+
+
 </configuration>

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/scm/protocolPB/StorageContainerLocationProtocolClientSideTranslatorPB.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/scm/protocolPB/StorageContainerLocationProtocolClientSideTranslatorPB.java
@@ -286,7 +286,7 @@ public final class StorageContainerLocationProtocolClientSideTranslatorPB
    */
   @Override
   public List<ContainerWithPipeline> getContainerWithPipelineBatch(
-      List<Long> containerIDs) throws IOException {
+      Iterable<? extends Long> containerIDs) throws IOException {
     for (Long containerID: containerIDs) {
       Preconditions.checkState(containerID >= 0,
           "Container ID cannot be negative");

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMClientProtocolServer.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMClientProtocolServer.java
@@ -320,7 +320,7 @@ public class SCMClientProtocolServer implements
 
   @Override
   public List<ContainerWithPipeline> getContainerWithPipelineBatch(
-      List<Long> containerIDs) throws IOException {
+      Iterable<? extends Long> containerIDs) throws IOException {
     getScm().checkAdminAccess(null);
 
     List<ContainerWithPipeline> cpList = new ArrayList<>();

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/OMConfigKeys.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/OMConfigKeys.java
@@ -17,9 +17,6 @@
 
 package org.apache.hadoop.ozone.om;
 
-import java.time.Duration;
-import java.time.temporal.ChronoUnit;
-import java.time.temporal.TemporalUnit;
 import java.util.concurrent.TimeUnit;
 
 import org.apache.hadoop.hdds.client.ReplicationFactor;

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/OMConfigKeys.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/OMConfigKeys.java
@@ -17,6 +17,9 @@
 
 package org.apache.hadoop.ozone.om;
 
+import java.time.Duration;
+import java.time.temporal.ChronoUnit;
+import java.time.temporal.TemporalUnit;
 import java.util.concurrent.TimeUnit;
 
 import org.apache.hadoop.hdds.client.ReplicationFactor;
@@ -394,4 +397,15 @@ public final class OMConfigKeys {
   public static final TimeDuration
       OZONE_OM_MULTITENANCY_RANGER_SYNC_TIMEOUT_DEFAULT
       = TimeDuration.valueOf(10, TimeUnit.SECONDS);
+
+  public static final String OZONE_OM_CONTAINER_LOCATION_CACHE_SIZE
+      = "ozone.om.container.location.cache.size";
+  public static final int OZONE_OM_CONTAINER_LOCATION_CACHE_SIZE_DEFAULT
+      = 100_000;
+
+  public static final String OZONE_OM_CONTAINER_LOCATION_CACHE_TTL
+      = "ozone.om.container.location.cache.ttl";
+
+  public static final TimeDuration OZONE_OM_CONTAINER_LOCATION_CACHE_TTL_DEFAULT
+      = TimeDuration.valueOf(360, TimeUnit.MINUTES);
 }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestKeyManagerImpl.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestKeyManagerImpl.java
@@ -260,7 +260,8 @@ public class TestKeyManagerImpl {
         "scmClient", scmClient);
   }
   private static void mockBlockClient() {
-    ScmClient scmClient = new ScmClient(mockScmBlockLocationProtocol, null, conf);
+    ScmClient scmClient = new ScmClient(mockScmBlockLocationProtocol, null,
+        conf);
     HddsWhiteboxTestUtils.setInternalState(keyManager,
         "scmClient", scmClient);
     HddsWhiteboxTestUtils.setInternalState(om,

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestKeyManagerImpl.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestKeyManagerImpl.java
@@ -253,14 +253,14 @@ public class TestKeyManagerImpl {
 
   private static void mockContainerClient() {
     ScmClient scmClient = new ScmClient(scm.getBlockProtocolServer(),
-        mockScmContainerClient);
+        mockScmContainerClient, conf);
     HddsWhiteboxTestUtils.setInternalState(keyManager,
         "scmClient", scmClient);
     HddsWhiteboxTestUtils.setInternalState(om,
         "scmClient", scmClient);
   }
   private static void mockBlockClient() {
-    ScmClient scmClient = new ScmClient(mockScmBlockLocationProtocol, null);
+    ScmClient scmClient = new ScmClient(mockScmBlockLocationProtocol, null, conf);
     HddsWhiteboxTestUtils.setInternalState(keyManager,
         "scmClient", scmClient);
     HddsWhiteboxTestUtils.setInternalState(om,

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/KeyManagerImpl.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/KeyManagerImpl.java
@@ -179,7 +179,7 @@ public class KeyManagerImpl implements KeyManager {
       OMMetadataManager metadataManager, OzoneConfiguration conf, String omId,
       OzoneBlockTokenSecretManager secretManager,
       OMPerformanceMetrics metrics) {
-    this(null, new ScmClient(scmBlockClient, null), metadataManager,
+    this(null, new ScmClient(scmBlockClient, null, conf), metadataManager,
         conf, omId, secretManager, null, null, metrics);
   }
 
@@ -189,7 +189,7 @@ public class KeyManagerImpl implements KeyManager {
       OMMetadataManager metadataManager, OzoneConfiguration conf, String omId,
       OzoneBlockTokenSecretManager secretManager,
       OMPerformanceMetrics metrics) {
-    this(null, new ScmClient(scmBlockClient, scmContainerClient),
+    this(null, new ScmClient(scmBlockClient, scmContainerClient, conf),
         metadataManager, conf, omId, secretManager, null, null,
         metrics);
   }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
@@ -529,7 +529,8 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
     scmContainerClient = getScmContainerClient(configuration);
     // verifies that the SCM info in the OM Version file is correct.
     scmBlockClient = getScmBlockClient(configuration);
-    this.scmClient = new ScmClient(scmBlockClient, scmContainerClient);
+    this.scmClient = new ScmClient(scmBlockClient, scmContainerClient,
+        configuration);
     this.ozoneLockProvider = new OzoneLockProvider(getKeyPathLockEnabled(),
         getEnableFileSystemPaths());
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ScmClient.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ScmClient.java
@@ -17,9 +17,27 @@
 
 package org.apache.hadoop.ozone.om;
 
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.CacheLoader;
+import com.google.common.cache.LoadingCache;
+import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import org.apache.hadoop.hdds.scm.container.common.helpers.ContainerWithPipeline;
+import org.apache.hadoop.hdds.scm.pipeline.Pipeline;
 import org.apache.hadoop.hdds.scm.protocol.ScmBlockLocationProtocol;
 import org.apache.hadoop.hdds.scm.protocol.StorageContainerLocationProtocol;
 import org.apache.hadoop.hdds.scm.update.client.SCMUpdateServiceGrpcClient;
+import org.jetbrains.annotations.NotNull;
+
+import java.io.IOException;
+import java.util.Map;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+
+import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_CONTAINER_LOCATION_CACHE_SIZE;
+import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_CONTAINER_LOCATION_CACHE_SIZE_DEFAULT;
+import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_CONTAINER_LOCATION_CACHE_TTL;
+import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_CONTAINER_LOCATION_CACHE_TTL_DEFAULT;
 
 /**
  * Wrapper class for Scm protocol clients.
@@ -28,12 +46,55 @@ public class ScmClient {
 
   private final ScmBlockLocationProtocol blockClient;
   private final StorageContainerLocationProtocol containerClient;
+  private final LoadingCache<Long, Pipeline> containerLocationCache;
   private SCMUpdateServiceGrpcClient updateServiceGrpcClient;
 
   ScmClient(ScmBlockLocationProtocol blockClient,
-            StorageContainerLocationProtocol containerClient) {
+            StorageContainerLocationProtocol containerClient,
+            LoadingCache<Long, Pipeline> containerLocationCache) {
     this.containerClient = containerClient;
     this.blockClient = blockClient;
+    this.containerLocationCache = containerLocationCache;
+  }
+
+  ScmClient(ScmBlockLocationProtocol blockClient,
+            StorageContainerLocationProtocol containerClient,
+            OzoneConfiguration configuration) {
+    this(blockClient, containerClient,
+        createContainerLocationCache(configuration, containerClient));
+  }
+
+  static LoadingCache<Long, Pipeline> createContainerLocationCache(
+      OzoneConfiguration configuration,
+      StorageContainerLocationProtocol containerClient) {
+    int maxSize = configuration.getInt(OZONE_OM_CONTAINER_LOCATION_CACHE_SIZE,
+        OZONE_OM_CONTAINER_LOCATION_CACHE_SIZE_DEFAULT);
+    TimeUnit unit =  OZONE_OM_CONTAINER_LOCATION_CACHE_TTL_DEFAULT.getUnit();
+    long ttl = configuration.getTimeDuration(
+        OZONE_OM_CONTAINER_LOCATION_CACHE_TTL,
+        OZONE_OM_CONTAINER_LOCATION_CACHE_TTL_DEFAULT.getDuration(), unit);
+    return CacheBuilder.newBuilder()
+        .maximumSize(maxSize)
+        .expireAfterWrite(ttl, unit)
+        .build(new CacheLoader<Long, Pipeline>() {
+          @NotNull
+          @Override
+          public Pipeline load(@NotNull Long key) throws Exception {
+            return containerClient.getContainerWithPipeline(key).getPipeline();
+          }
+
+          @NotNull
+          @Override
+          public Map<Long, Pipeline> loadAll(@NotNull Iterable<? extends Long> keys)
+              throws Exception {
+            return containerClient.getContainerWithPipelineBatch(keys)
+                .stream()
+                .collect(Collectors.toMap(
+                    x -> x.getContainerInfo().getContainerID(),
+                    ContainerWithPipeline::getPipeline
+                ));
+          }
+        });
   }
 
   public ScmBlockLocationProtocol getBlockClient() {
@@ -51,5 +112,39 @@ public class ScmClient {
 
   public SCMUpdateServiceGrpcClient getUpdateServiceGrpcClient() {
     return updateServiceGrpcClient;
+  }
+
+  public Pipeline getContainerLocation(long containerId, boolean forceRefresh)
+      throws IOException {
+    if (forceRefresh) {
+      containerLocationCache.invalidate(containerId);
+    }
+    try {
+      return containerLocationCache.get(containerId);
+    } catch (ExecutionException e) {
+      return handleCacheExecutionException(e);
+    }
+  }
+
+  public Map<Long, Pipeline> getContainerLocations(Iterable<Long> containerIds,
+                                                  boolean forceRefresh)
+      throws IOException {
+    if (forceRefresh) {
+      containerLocationCache.invalidateAll(containerIds);
+    }
+    try {
+      return containerLocationCache.getAll(containerIds);
+    } catch (ExecutionException e) {
+      return handleCacheExecutionException(e);
+    }
+  }
+
+  private <T> T handleCacheExecutionException(ExecutionException e)
+      throws IOException {
+    if (e.getCause() instanceof IOException) {
+      throw (IOException) e.getCause();
+    }
+    throw new IllegalStateException("Unexpected exception accessing " +
+        "container location", e.getCause());
   }
 }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ScmClient.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ScmClient.java
@@ -85,8 +85,8 @@ public class ScmClient {
 
           @NotNull
           @Override
-          public Map<Long, Pipeline> loadAll(@NotNull Iterable<? extends Long> keys)
-              throws Exception {
+          public Map<Long, Pipeline> loadAll(
+              @NotNull Iterable<? extends Long> keys) throws Exception {
             return containerClient.getContainerWithPipelineBatch(keys)
                 .stream()
                 .collect(Collectors.toMap(

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ScmClient.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ScmClient.java
@@ -108,18 +108,6 @@ public class ScmClient {
     return updateServiceGrpcClient;
   }
 
-  public Pipeline getContainerLocation(long containerId, boolean forceRefresh)
-      throws IOException {
-    if (forceRefresh) {
-      containerLocationCache.invalidate(containerId);
-    }
-    try {
-      return containerLocationCache.get(containerId);
-    } catch (ExecutionException e) {
-      return handleCacheExecutionException(e);
-    }
-  }
-
   public Map<Long, Pipeline> getContainerLocations(Iterable<Long> containerIds,
                                                   boolean forceRefresh)
       throws IOException {

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ScmClient.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ScmClient.java
@@ -51,17 +51,11 @@ public class ScmClient {
 
   ScmClient(ScmBlockLocationProtocol blockClient,
             StorageContainerLocationProtocol containerClient,
-            LoadingCache<Long, Pipeline> containerLocationCache) {
+            OzoneConfiguration configuration) {
     this.containerClient = containerClient;
     this.blockClient = blockClient;
-    this.containerLocationCache = containerLocationCache;
-  }
-
-  ScmClient(ScmBlockLocationProtocol blockClient,
-            StorageContainerLocationProtocol containerClient,
-            OzoneConfiguration configuration) {
-    this(blockClient, containerClient,
-        createContainerLocationCache(configuration, containerClient));
+    this.containerLocationCache =
+        createContainerLocationCache(configuration, containerClient);
   }
 
   static LoadingCache<Long, Pipeline> createContainerLocationCache(
@@ -147,4 +141,6 @@ public class ScmClient {
     throw new IllegalStateException("Unexpected exception accessing " +
         "container location", e.getCause());
   }
+
+
 }

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/OmTestManagers.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/OmTestManagers.java
@@ -101,7 +101,7 @@ public final class OmTestManagers {
 
     keyManager = (KeyManagerImpl) HddsWhiteboxTestUtils
         .getInternalState(om, "keyManager");
-    ScmClient scmClient = new ScmClient(scmBlockClient, containerClient);
+    ScmClient scmClient = new ScmClient(scmBlockClient, containerClient, conf);
     HddsWhiteboxTestUtils.setInternalState(om,
         "scmClient", scmClient);
     HddsWhiteboxTestUtils.setInternalState(keyManager,

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestScmClient.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestScmClient.java
@@ -1,0 +1,198 @@
+package org.apache.hadoop.ozone.om;
+
+import com.google.common.collect.Sets;
+import org.apache.hadoop.hdds.client.ReplicationFactor;
+import org.apache.hadoop.hdds.client.ReplicationType;
+import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import org.apache.hadoop.hdds.protocol.DatanodeDetails;
+import org.apache.hadoop.hdds.scm.container.ContainerInfo;
+import org.apache.hadoop.hdds.scm.container.common.helpers.ContainerWithPipeline;
+import org.apache.hadoop.hdds.scm.pipeline.Pipeline;
+import org.apache.hadoop.hdds.scm.pipeline.PipelineID;
+import org.apache.hadoop.hdds.scm.protocol.ScmBlockLocationProtocol;
+import org.apache.hadoop.hdds.scm.protocol.StorageContainerLocationProtocol;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+import java.util.stream.Stream;
+
+import static com.google.common.collect.Sets.newHashSet;
+import static java.util.Arrays.asList;
+import static org.apache.commons.lang.RandomStringUtils.randomAlphabetic;
+import static org.apache.hadoop.hdds.client.ReplicationConfig.fromTypeAndFactor;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class TestScmClient {
+  private ScmBlockLocationProtocol scmBlockLocationProtocol;
+  private StorageContainerLocationProtocol containerLocationProtocol;
+  private OzoneConfiguration conf;
+  private ScmClient scmClient;
+
+  @BeforeEach
+  public void setUp() {
+    scmBlockLocationProtocol = mock(ScmBlockLocationProtocol.class);
+    containerLocationProtocol = mock(StorageContainerLocationProtocol.class);
+    conf = new OzoneConfiguration();
+    scmClient = new ScmClient(scmBlockLocationProtocol,
+        containerLocationProtocol, conf);
+  }
+
+  private static Stream<Arguments> getContainerLocationTestCases() {
+    return Stream.of(
+        Arguments.of("New key",
+            newHashSet(1L , 2L), 3L, false, 1),
+
+        Arguments.of("Existing key",
+            newHashSet(1L , 2L), 1L, false, 1),
+
+        Arguments.of("New key with force refresh",
+            newHashSet(1L , 2L), 3L, true, 1),
+
+        Arguments.of("Existing key, force refresh",
+            newHashSet(1L , 2L), 1L, true, 2)
+    );
+  }
+
+  @ParameterizedTest
+  @MethodSource("getContainerLocationTestCases")
+  public void testGetContainerLocation(String testCases,
+                                       Set<Long> prepopulatedIds,
+                                       long testId,
+                                       boolean forceRefresh,
+                                       int expectedScmCalls)
+      throws IOException {
+
+    Map<Long, ContainerWithPipeline> actualLocations = new HashMap<>();
+    // pre population of the cache.
+    for (long containerId : prepopulatedIds) {
+      ContainerWithPipeline pipeline = createPipeline(containerId);
+      actualLocations.put(containerId, pipeline);
+      when(containerLocationProtocol.getContainerWithPipeline(eq(containerId)))
+          .thenReturn(pipeline);
+      Pipeline location = scmClient.getContainerLocation(containerId, false);
+      Assertions.assertEquals(pipeline.getPipeline(), location);
+      verify(containerLocationProtocol, times(1)).getContainerWithPipeline(containerId);
+    }
+
+    if (!prepopulatedIds.contains(testId)) {
+      ContainerWithPipeline pipeline = createPipeline(testId);
+      actualLocations.put(testId, pipeline);
+      when(containerLocationProtocol.getContainerWithPipeline(eq(testId)))
+          .thenReturn(pipeline);
+    }
+
+    // consecutive call.
+    Pipeline location = scmClient.getContainerLocation(testId, forceRefresh);
+    Assertions.assertEquals(actualLocations.get(testId).getPipeline(),
+        location);
+
+    verify(containerLocationProtocol, times(expectedScmCalls))
+        .getContainerWithPipeline(testId);
+  }
+
+  private static Stream<Arguments> getContainerLocationsTestCases() {
+    return Stream.of(
+        Arguments.of("Existing keys",
+            newHashSet(1L , 2L, 3L), newHashSet(2L, 3L), false, newHashSet()),
+
+        Arguments.of("New keys",
+            newHashSet(1L , 2L), newHashSet(3L, 4L), false, newHashSet(3L, 4L)),
+
+        Arguments.of("Partial new keys",
+            newHashSet(1L , 2L), newHashSet(1L, 3L, 4L), false, newHashSet(3L, 4L)),
+
+        Arguments.of("Existing keys with force refresh",
+            newHashSet(1L , 2L, 3L), newHashSet(2L, 3L), true, newHashSet(2L, 3L)),
+
+        Arguments.of("New keys with force refresh",
+            newHashSet(1L , 2L), newHashSet(3L, 4L), true, newHashSet(3L, 4L)),
+
+        Arguments.of("Partial new keys with force refresh",
+            newHashSet(1L , 2L), newHashSet(1L, 3L, 4L), true, newHashSet(1L, 3L, 4L))
+    );
+  }
+  @ParameterizedTest
+  @MethodSource("getContainerLocationsTestCases")
+  public void testGetContainerLocations(String testCases,
+                                       Set<Long> prepopulatedIds,
+                                       Set<Long> testIds,
+                                       boolean forceRefresh,
+                                        Set<Long> expectedScmCallIds)
+      throws IOException {
+
+    Map<Long, ContainerWithPipeline> actualLocations = new HashMap<>();
+
+    for (long containerId : prepopulatedIds) {
+      ContainerWithPipeline pipeline = createPipeline(containerId);
+      actualLocations.put(containerId, pipeline);
+    }
+
+    // pre population of the cache.
+    when(containerLocationProtocol.getContainerWithPipelineBatch(eq(prepopulatedIds)))
+        .thenReturn(new ArrayList<>(actualLocations.values()));
+    Map<Long, Pipeline> locations = scmClient.getContainerLocations(prepopulatedIds, false);
+    locations.forEach((id, pipeline) -> {
+      Assertions.assertEquals(actualLocations.get(id).getPipeline(), pipeline);
+    });
+    verify(containerLocationProtocol, times(1)).getContainerWithPipelineBatch(prepopulatedIds);
+
+    // consecutive call
+    if (!expectedScmCallIds.isEmpty()) {
+      List<ContainerWithPipeline> scmLocations = new ArrayList<>();
+      for (long containerId : expectedScmCallIds) {
+        ContainerWithPipeline pipeline = createPipeline(containerId);
+        scmLocations.add(pipeline);
+        actualLocations.put(containerId, pipeline);
+      }
+      when(containerLocationProtocol.getContainerWithPipelineBatch(eq(expectedScmCallIds)))
+          .thenReturn(scmLocations);
+    }
+
+    locations = scmClient.getContainerLocations(testIds, forceRefresh);
+    locations.forEach((id, pipeline) -> {
+      Assertions.assertEquals(actualLocations.get(id).getPipeline(), pipeline);
+    });
+
+    if (!expectedScmCallIds.isEmpty()) {
+      verify(containerLocationProtocol, times(1))
+          .getContainerWithPipelineBatch(expectedScmCallIds);
+    }
+  }
+
+  ContainerWithPipeline createPipeline(long containerId) {
+    ContainerInfo containerInfo = new ContainerInfo.Builder()
+        .setContainerID(containerId)
+        .build();
+    Pipeline pipeline = Pipeline.newBuilder()
+        .setId(PipelineID.randomId())
+        .setNodes(asList(randomDatanode(), randomDatanode()))
+        .setReplicationConfig(fromTypeAndFactor(
+            ReplicationType.RATIS, ReplicationFactor.THREE))
+        .setState(Pipeline.PipelineState.OPEN)
+        .build();
+    return new ContainerWithPipeline(containerInfo, pipeline);
+  }
+
+  private DatanodeDetails randomDatanode() {
+    return DatanodeDetails.newBuilder()
+        .setUuid(UUID.randomUUID())
+        .setHostName(randomAlphabetic(5))
+        .setIpAddress(randomAlphabetic(5))
+        .build();
+  }
+
+}

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestScmClient.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestScmClient.java
@@ -98,7 +98,7 @@ public class TestScmClient {
   }
   @ParameterizedTest
   @MethodSource("getContainerLocationsTestCases")
-  public void testGetContainerLocations(String testCases,
+  public void testGetContainerLocations(String testCaseName,
                                        Set<Long> prepopulatedIds,
                                        Set<Long> testContainerIds,
                                        boolean forceRefresh,

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestScmClient.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestScmClient.java
@@ -35,7 +35,6 @@ import org.junit.jupiter.params.provider.MethodSource;
 
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestScmClient.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestScmClient.java
@@ -90,7 +90,7 @@ public class TestScmClient {
   @MethodSource("getContainerLocationTestCases")
   public void testGetContainerLocation(String testCases,
                                        Set<Long> prepopulatedIds,
-                                       long testId,
+                                       long containerIdToTest,
                                        boolean forceRefresh,
                                        int expectedScmCalls)
       throws IOException {

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestScmClient.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestScmClient.java
@@ -1,6 +1,21 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with this
+ * work for additional information regarding copyright ownership.  The ASF
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
 package org.apache.hadoop.ozone.om;
 
-import com.google.common.collect.Sets;
 import org.apache.hadoop.hdds.client.ReplicationFactor;
 import org.apache.hadoop.hdds.client.ReplicationType;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
@@ -36,6 +51,9 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+/**
+ * ScmClient test-cases.
+ */
 public class TestScmClient {
   private ScmBlockLocationProtocol scmBlockLocationProtocol;
   private StorageContainerLocationProtocol containerLocationProtocol;
@@ -54,16 +72,16 @@ public class TestScmClient {
   private static Stream<Arguments> getContainerLocationTestCases() {
     return Stream.of(
         Arguments.of("New key",
-            newHashSet(1L , 2L), 3L, false, 1),
+            newHashSet(1L, 2L), 3L, false, 1),
 
         Arguments.of("Existing key",
-            newHashSet(1L , 2L), 1L, false, 1),
+            newHashSet(1L, 2L), 1L, false, 1),
 
         Arguments.of("New key with force refresh",
-            newHashSet(1L , 2L), 3L, true, 1),
+            newHashSet(1L, 2L), 3L, true, 1),
 
         Arguments.of("Existing key, force refresh",
-            newHashSet(1L , 2L), 1L, true, 2)
+            newHashSet(1L, 2L), 1L, true, 2)
     );
   }
 
@@ -85,7 +103,8 @@ public class TestScmClient {
           .thenReturn(pipeline);
       Pipeline location = scmClient.getContainerLocation(containerId, false);
       Assertions.assertEquals(pipeline.getPipeline(), location);
-      verify(containerLocationProtocol, times(1)).getContainerWithPipeline(containerId);
+      verify(containerLocationProtocol, times(1))
+          .getContainerWithPipeline(containerId);
     }
 
     if (!prepopulatedIds.contains(testId)) {
@@ -107,22 +126,27 @@ public class TestScmClient {
   private static Stream<Arguments> getContainerLocationsTestCases() {
     return Stream.of(
         Arguments.of("Existing keys",
-            newHashSet(1L , 2L, 3L), newHashSet(2L, 3L), false, newHashSet()),
+            newHashSet(1L, 2L, 3L), newHashSet(2L, 3L), false, newHashSet()),
 
         Arguments.of("New keys",
-            newHashSet(1L , 2L), newHashSet(3L, 4L), false, newHashSet(3L, 4L)),
+            newHashSet(1L, 2L), newHashSet(3L, 4L),
+            false, newHashSet(3L, 4L)),
 
         Arguments.of("Partial new keys",
-            newHashSet(1L , 2L), newHashSet(1L, 3L, 4L), false, newHashSet(3L, 4L)),
+            newHashSet(1L, 2L), newHashSet(1L, 3L, 4L),
+            false, newHashSet(3L, 4L)),
 
         Arguments.of("Existing keys with force refresh",
-            newHashSet(1L , 2L, 3L), newHashSet(2L, 3L), true, newHashSet(2L, 3L)),
+            newHashSet(1L, 2L, 3L), newHashSet(2L, 3L),
+            true, newHashSet(2L, 3L)),
 
         Arguments.of("New keys with force refresh",
-            newHashSet(1L , 2L), newHashSet(3L, 4L), true, newHashSet(3L, 4L)),
+            newHashSet(1L, 2L), newHashSet(3L, 4L),
+            true, newHashSet(3L, 4L)),
 
         Arguments.of("Partial new keys with force refresh",
-            newHashSet(1L , 2L), newHashSet(1L, 3L, 4L), true, newHashSet(1L, 3L, 4L))
+            newHashSet(1L, 2L), newHashSet(1L, 3L, 4L),
+            true, newHashSet(1L, 3L, 4L))
     );
   }
   @ParameterizedTest
@@ -142,13 +166,16 @@ public class TestScmClient {
     }
 
     // pre population of the cache.
-    when(containerLocationProtocol.getContainerWithPipelineBatch(eq(prepopulatedIds)))
+    when(containerLocationProtocol
+        .getContainerWithPipelineBatch(eq(prepopulatedIds)))
         .thenReturn(new ArrayList<>(actualLocations.values()));
-    Map<Long, Pipeline> locations = scmClient.getContainerLocations(prepopulatedIds, false);
+    Map<Long, Pipeline> locations =
+        scmClient.getContainerLocations(prepopulatedIds, false);
     locations.forEach((id, pipeline) -> {
       Assertions.assertEquals(actualLocations.get(id).getPipeline(), pipeline);
     });
-    verify(containerLocationProtocol, times(1)).getContainerWithPipelineBatch(prepopulatedIds);
+    verify(containerLocationProtocol, times(1))
+        .getContainerWithPipelineBatch(prepopulatedIds);
 
     // consecutive call
     if (!expectedScmCallIds.isEmpty()) {
@@ -158,8 +185,8 @@ public class TestScmClient {
         scmLocations.add(pipeline);
         actualLocations.put(containerId, pipeline);
       }
-      when(containerLocationProtocol.getContainerWithPipelineBatch(eq(expectedScmCallIds)))
-          .thenReturn(scmLocations);
+      when(containerLocationProtocol.getContainerWithPipelineBatch(
+          eq(expectedScmCallIds))).thenReturn(scmLocations);
     }
 
     locations = scmClient.getContainerLocations(testIds, forceRefresh);


### PR DESCRIPTION
## What changes were proposed in this pull request?

Introduce container location cache in ScmClient.

https://issues.apache.org/jira/browse/HDDS-7229

Also, this is done without DatanodeDetails normalization. Just did an experiment to confirm the cache size on top of the changes in this PR and the results are documented as per [HDDS-7249](https://issues.apache.org/jira/browse/HDDS-7249). In summary, 10K containers take 35mb heap and that number linearly grows with the number of containers.  

## How was this patch tested?

Standard CI with added unit test to cover new ScmClient interfaces: https://github.com/duongkame/ozone/actions/runs/3099408939