### PR TITLE
HDDS-7250. Add HttpServer metrics

### DIFF
--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/server/http/HttpServer2.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/server/http/HttpServer2.java
@@ -194,6 +194,7 @@ public final class HttpServer2 implements FilterContainer {
   static final String STATE_DESCRIPTION_NOT_LIVE = " - not live";
   private final SignerSecretProvider secretProvider;
   private XFrameOption xFrameOption;
+  private HttpServer2Metrics metrics;
   private boolean xFrameOptionIsEnabled;
   public static final String HTTP_HEADER_PREFIX = "ozone.http.header.";
   private static final String HTTP_HEADER_REGEX =
@@ -604,7 +605,7 @@ public final class HttpServer2 implements FilterContainer {
       threadPool.setMaxThreads(maxThreads);
     }
 
-    HttpServer2Metrics.create(threadPool, name);
+    metrics = HttpServer2Metrics.create(threadPool, name);
     SessionHandler handler = webAppContext.getSessionHandler();
     handler.setHttpOnly(true);
     handler.getSessionCookieConfig().setSecure(true);
@@ -1366,6 +1367,7 @@ public final class HttpServer2 implements FilterContainer {
       // clear & stop webAppContext attributes to avoid memory leaks.
       webAppContext.clearAttributes();
       webAppContext.stop();
+      metrics.unRegister();
     } catch (Exception e) {
       LOG.error("Error while stopping web app context for webapp "
           + webAppContext.getDisplayName(), e);

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/server/http/HttpServer2.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/server/http/HttpServer2.java
@@ -604,6 +604,7 @@ public final class HttpServer2 implements FilterContainer {
       threadPool.setMaxThreads(maxThreads);
     }
 
+    HttpServer2Metrics.create(threadPool, name);
     SessionHandler handler = webAppContext.getSessionHandler();
     handler.setHttpOnly(true);
     handler.getSessionCookieConfig().setSecure(true);

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/server/http/HttpServer2Metrics.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/server/http/HttpServer2Metrics.java
@@ -65,14 +65,13 @@ public final class HttpServer2Metrics implements MetricsSource {
     this.name = name;
   }
 
-  public static HttpServer2Metrics create(QueuedThreadPool threadPool,
-                                          String name) {
-    if (instance != null) {
-      return instance;
+  public static synchronized HttpServer2Metrics create(
+          QueuedThreadPool threadPool, String name) {
+    if (instance == null) {
+      MetricsSystem ms = DefaultMetricsSystem.instance();
+      instance = ms.register(NAME, "HttpServer2 Metrics",
+              new HttpServer2Metrics(threadPool, name));
     }
-    MetricsSystem ms = DefaultMetricsSystem.instance();
-    instance = ms.register(NAME, "HttpServer2 Metrics",
-        new HttpServer2Metrics(threadPool, name));
     return instance;
   }
 
@@ -90,5 +89,11 @@ public final class HttpServer2Metrics implements MetricsSource {
             threadPool.getMaxThreads())
         .addGauge(HttpServer2MetricsInfo.HttpServerThreadQueueWaitingTaskCount,
             threadPool.getQueueSize());
+  }
+
+  public void unRegister() {
+    MetricsSystem ms = DefaultMetricsSystem.instance();
+    ms.unregisterSource(NAME);
+    instance = null;
   }
 }

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/server/http/HttpServer2Metrics.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/server/http/HttpServer2Metrics.java
@@ -57,6 +57,7 @@ public final class HttpServer2Metrics implements MetricsSource {
   public static final String NAME = HttpServer2Metrics.class.getSimpleName();
 
   private final QueuedThreadPool threadPool;
+  private static HttpServer2Metrics instance;
   private final String name;
 
   private HttpServer2Metrics(QueuedThreadPool threadPool, String name) {
@@ -65,10 +66,14 @@ public final class HttpServer2Metrics implements MetricsSource {
   }
 
   public static HttpServer2Metrics create(QueuedThreadPool threadPool,
-      String name) {
+                                          String name) {
+    if (instance != null) {
+      return instance;
+    }
     MetricsSystem ms = DefaultMetricsSystem.instance();
-    return ms.register(NAME, "HttpServer2 Metrics",
+    instance = ms.register(NAME, "HttpServer2 Metrics",
         new HttpServer2Metrics(threadPool, name));
+    return instance;
   }
 
   @Override

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/server/http/HttpServer2Metrics.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/server/http/HttpServer2Metrics.java
@@ -1,0 +1,89 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hdds.server.http;
+
+import org.apache.hadoop.hdds.annotation.InterfaceAudience;
+import org.apache.hadoop.metrics2.MetricsCollector;
+import org.apache.hadoop.metrics2.MetricsInfo;
+import org.apache.hadoop.metrics2.MetricsRecordBuilder;
+import org.apache.hadoop.metrics2.MetricsSource;
+import org.apache.hadoop.metrics2.MetricsSystem;
+import org.apache.hadoop.metrics2.lib.DefaultMetricsSystem;
+import org.eclipse.jetty.util.thread.QueuedThreadPool;
+
+/**
+ * Metrics related to HttpServer threadPool.
+ */
+@InterfaceAudience.Private
+public final class HttpServer2Metrics implements MetricsSource {
+  enum HttpServer2MetricsInfo implements MetricsInfo {
+    SERVER_NAME("HttpServer2 Metrics."),
+    HttpServerThreadCount("Number of threads in the pool."),
+    HttpServerIdleThreadCount("Number of idle threads but not reserved."),
+    HttpServerMaxThreadCount("Maximum number of threads in the pool."),
+    HttpServerThreadQueueWaitingTaskCount(
+        "The number of jobs in the queue waiting for a thread");
+
+    private final String desc;
+
+    HttpServer2MetricsInfo(String desc) {
+      this.desc = desc;
+    }
+
+    @Override
+    public String description() {
+      return desc;
+    }
+  }
+
+  public static final String SOURCE_NAME =
+      HttpServer2Metrics.class.getSimpleName();
+
+  public static final String NAME = HttpServer2Metrics.class.getSimpleName();
+
+  private final QueuedThreadPool threadPool;
+  private final String name;
+
+  private HttpServer2Metrics(QueuedThreadPool threadPool, String name) {
+    this.threadPool = threadPool;
+    this.name = name;
+  }
+
+  public static HttpServer2Metrics create(QueuedThreadPool threadPool,
+      String name) {
+    MetricsSystem ms = DefaultMetricsSystem.instance();
+    return ms.register(NAME, "HttpServer2 Metrics",
+        new HttpServer2Metrics(threadPool, name));
+  }
+
+  @Override
+  public void getMetrics(MetricsCollector collector, boolean all) {
+    MetricsRecordBuilder recordBuilder = collector.addRecord(SOURCE_NAME)
+        .setContext("HttpServer2")
+        .tag(HttpServer2MetricsInfo.SERVER_NAME, name);
+
+    recordBuilder.addGauge(HttpServer2MetricsInfo.HttpServerThreadCount,
+            threadPool.getThreads())
+        .addGauge(HttpServer2MetricsInfo.HttpServerIdleThreadCount,
+            threadPool.getIdleThreads())
+        .addGauge(HttpServer2MetricsInfo.HttpServerMaxThreadCount,
+            threadPool.getMaxThreads())
+        .addGauge(HttpServer2MetricsInfo.HttpServerThreadQueueWaitingTaskCount,
+            threadPool.getQueueSize());
+  }
+}

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/server/http/HttpServer2Metrics.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/server/http/HttpServer2Metrics.java
@@ -57,7 +57,6 @@ public final class HttpServer2Metrics implements MetricsSource {
   public static final String NAME = HttpServer2Metrics.class.getSimpleName();
 
   private final QueuedThreadPool threadPool;
-  private static HttpServer2Metrics instance;
   private final String name;
 
   private HttpServer2Metrics(QueuedThreadPool threadPool, String name) {
@@ -65,14 +64,11 @@ public final class HttpServer2Metrics implements MetricsSource {
     this.name = name;
   }
 
-  public static synchronized HttpServer2Metrics create(
-          QueuedThreadPool threadPool, String name) {
-    if (instance == null) {
-      MetricsSystem ms = DefaultMetricsSystem.instance();
-      instance = ms.register(NAME, "HttpServer2 Metrics",
-              new HttpServer2Metrics(threadPool, name));
-    }
-    return instance;
+  public static HttpServer2Metrics create(
+      QueuedThreadPool threadPool, String name) {
+    MetricsSystem ms = DefaultMetricsSystem.instance();
+    return ms.register(NAME, "HttpServer2 Metrics",
+        new HttpServer2Metrics(threadPool, name));
   }
 
   @Override
@@ -91,9 +87,8 @@ public final class HttpServer2Metrics implements MetricsSource {
             threadPool.getQueueSize());
   }
 
-  public synchronized void unRegister() {
+  public void unRegister() {
     MetricsSystem ms = DefaultMetricsSystem.instance();
     ms.unregisterSource(NAME);
-    instance = null;
   }
 }

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/server/http/HttpServer2Metrics.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/server/http/HttpServer2Metrics.java
@@ -91,7 +91,7 @@ public final class HttpServer2Metrics implements MetricsSource {
             threadPool.getQueueSize());
   }
 
-  public void unRegister() {
+  public synchronized void unRegister() {
     MetricsSystem ms = DefaultMetricsSystem.instance();
     ms.unregisterSource(NAME);
     instance = null;

--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/server/http/TestHttpServer2MetricsTest.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/server/http/TestHttpServer2MetricsTest.java
@@ -65,11 +65,11 @@ public class TestHttpServer2MetricsTest {
     int threadQueueWaitingTaskCount = random.nextInt();
     String name = "s3g";
 
-    Mockito.doReturn(threadCount).when(threadPool).getThreads();
-    Mockito.doReturn(maxThreadCount).when(threadPool).getMaxThreads();
-    Mockito.doReturn(idleThreadCount).when(threadPool).getIdleThreads();
-    Mockito.doReturn(threadQueueWaitingTaskCount).when(threadPool)
-        .getQueueSize();
+    Mockito.when(threadPool.getThreads()).thenReturn(threadCount);
+    Mockito.when(threadPool.getMaxThreads()).thenReturn(maxThreadCount);
+    Mockito.when(threadPool.getIdleThreads()).thenReturn(idleThreadCount);
+    Mockito.when(threadPool.getQueueSize())
+            .thenReturn(threadQueueWaitingTaskCount);
     when(recorder.addGauge(any(MetricsInfo.class), anyInt()))
         .thenReturn(recorder);
     when(recorder.setContext(anyString())).thenReturn(recorder);

--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/server/http/TestHttpServer2MetricsTest.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/server/http/TestHttpServer2MetricsTest.java
@@ -58,10 +58,11 @@ public class TestHttpServer2MetricsTest {
   @Test
   public void testMetrics() {
     // crate mock metrics
-    int threadCount = new Random().nextInt();
-    int maxThreadCount = new Random().nextInt();
-    int idleThreadCount = new Random().nextInt();
-    int threadQueueWaitingTaskCount = new Random().nextInt();
+    Random random = new Random();
+    int threadCount = random.nextInt();
+    int maxThreadCount = random.nextInt();
+    int idleThreadCount = random.nextInt();
+    int threadQueueWaitingTaskCount = random.nextInt();
     String name = "s3g";
 
     Mockito.doReturn(threadCount).when(threadPool).getThreads();

--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/server/http/TestHttpServer2MetricsTest.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/server/http/TestHttpServer2MetricsTest.java
@@ -1,0 +1,93 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hdds.server.http;
+
+import static org.apache.hadoop.hdds.server.http.HttpServer2Metrics.HttpServer2MetricsInfo.HttpServerIdleThreadCount;
+import static org.apache.hadoop.hdds.server.http.HttpServer2Metrics.HttpServer2MetricsInfo.HttpServerMaxThreadCount;
+import static org.apache.hadoop.hdds.server.http.HttpServer2Metrics.HttpServer2MetricsInfo.HttpServerThreadCount;
+import static org.apache.hadoop.hdds.server.http.HttpServer2Metrics.HttpServer2MetricsInfo.HttpServerThreadQueueWaitingTaskCount;
+import static org.apache.hadoop.hdds.server.http.HttpServer2Metrics.HttpServer2MetricsInfo.SERVER_NAME;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import org.apache.hadoop.metrics2.MetricsCollector;
+import org.apache.hadoop.metrics2.MetricsInfo;
+import org.apache.hadoop.metrics2.MetricsRecordBuilder;
+import org.eclipse.jetty.util.thread.QueuedThreadPool;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import java.util.Random;
+
+/**
+ * Testing HttpServer2Metrics.
+ */
+public class TestHttpServer2MetricsTest {
+
+  private QueuedThreadPool threadPool;
+  private MetricsCollector metricsCollector;
+  private MetricsRecordBuilder recorder;
+
+  @Before
+  public void setup() {
+    threadPool = Mockito.mock(QueuedThreadPool.class);
+    metricsCollector = Mockito.mock(MetricsCollector.class);
+    recorder = mock(MetricsRecordBuilder.class);
+  }
+
+  @Test
+  public void testMetrics() {
+    // crate mock metrics
+    int threadCount = new Random().nextInt();
+    int maxThreadCount = new Random().nextInt();
+    int idleThreadCount = new Random().nextInt();
+    int threadQueueWaitingTaskCount = new Random().nextInt();
+    String name = "s3g";
+
+    Mockito.doReturn(threadCount).when(threadPool).getThreads();
+    Mockito.doReturn(maxThreadCount).when(threadPool).getMaxThreads();
+    Mockito.doReturn(idleThreadCount).when(threadPool).getIdleThreads();
+    Mockito.doReturn(threadQueueWaitingTaskCount).when(threadPool)
+        .getQueueSize();
+    when(recorder.addGauge(any(MetricsInfo.class), anyInt()))
+        .thenReturn(recorder);
+    when(recorder.setContext(anyString())).thenReturn(recorder);
+    when(recorder.tag(any(MetricsInfo.class), anyString()))
+        .thenReturn(recorder);
+    when(metricsCollector.addRecord(anyString())).thenReturn(recorder);
+
+    // get metrics
+    HttpServer2Metrics server2Metrics =
+        HttpServer2Metrics.create(threadPool, name);
+    server2Metrics.getMetrics(metricsCollector, true);
+
+    // verify
+    verify(recorder).tag(SERVER_NAME, name);
+    verify(metricsCollector).addRecord(HttpServer2Metrics.SOURCE_NAME);
+    verify(recorder).addGauge(HttpServerThreadCount, threadCount);
+    verify(recorder).addGauge(HttpServerMaxThreadCount, maxThreadCount);
+    verify(recorder).addGauge(HttpServerIdleThreadCount, idleThreadCount);
+    verify(recorder).addGauge(HttpServerThreadQueueWaitingTaskCount,
+        threadQueueWaitingTaskCount);
+  }
+}


### PR DESCRIPTION
## What changes were proposed in this pull request?
Add some metrics to monitor `HttpServer` threadpool.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-7250

Please replace this section with the link to the Apache JIRA)

## How was this patch tested?
for `SCM`
```bash
[root@Linux /root/ozone]% curl -s http://0.0.0.0:9876/prom | grep -i http
# TYPE http_server2_metrics_http_server_idle_thread_count gauge
http_server2_metrics_http_server_idle_thread_count{context="HttpServer2",server_name="scm",hostname="C02GKEF9MD6M"} 0
# TYPE http_server2_metrics_http_server_max_thread_count gauge
http_server2_metrics_http_server_max_thread_count{context="HttpServer2",server_name="scm",hostname="C02GKEF9MD6M"} 200
# TYPE http_server2_metrics_http_server_thread_count gauge
http_server2_metrics_http_server_thread_count{context="HttpServer2",server_name="scm",hostname="C02GKEF9MD6M"} 9
# TYPE http_server2_metrics_http_server_thread_queue_waiting_task_count gauge
http_server2_metrics_http_server_thread_queue_waiting_task_count{context="HttpServer2",server_name="scm",hostname="C02GKEF9MD6M"} 0
```
for `OM`
```bash
[root@Linux /root/ozone]% curl -s http://0.0.0.0:9874/prom | grep -i http
# TYPE http_server2_metrics_http_server_idle_thread_count gauge
http_server2_metrics_http_server_idle_thread_count{context="HttpServer2",server_name="ozoneManager",hostname="C02GKEF9MD6M"} 0
# TYPE http_server2_metrics_http_server_max_thread_count gauge
http_server2_metrics_http_server_max_thread_count{context="HttpServer2",server_name="ozoneManager",hostname="C02GKEF9MD6M"} 200
# TYPE http_server2_metrics_http_server_thread_count gauge
http_server2_metrics_http_server_thread_count{context="HttpServer2",server_name="ozoneManager",hostname="C02GKEF9MD6M"} 9
# TYPE http_server2_metrics_http_server_thread_queue_waiting_task_count gauge
http_server2_metrics_http_server_thread_queue_waiting_task_count{context="HttpServer2",server_name="ozoneManager",hostname="C02GKEF9MD6M"} 0
```
Similarly, other components can also get similar metrics

we can refer `InstrumentedQueuedThreadPool` to  calculate  `size`, `jobs`, `utilization-max`, `utilization` these four metrics
https://github.com/dropwizard/metrics/blob/88137c1c797e17445e4bdbcd9d2535118b24dc39/metrics-jetty9/src/main/java/com/codahale/metrics/jetty9/InstrumentedQueuedThreadPool.java

about metrics `size`, `jobs`, `utilization-max`, `utilization`
https://stackoverflow.com/a/64100087