### PR TITLE
HDDS-7253. Fix exception when '/' in key name

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFileSystem.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFileSystem.java
@@ -153,7 +153,7 @@ public class TestOzoneFileSystem {
   private static OzoneManagerProtocol writeClient;
   private static FileSystem fs;
   private static OzoneFileSystem o3fs;
-  private static OzoneBucket bucket;
+  private static OzoneBucket ozoneBucket;
   private static String volumeName;
   private static String bucketName;
   private static Trash trash;
@@ -180,9 +180,9 @@ public class TestOzoneFileSystem {
     writeClient = cluster.getRpcClient().getObjectStore()
         .getClientProxy().getOzoneManagerClient();
     // create a volume and a bucket to be used by OzoneFileSystem
-    bucket = TestDataUtil.createVolumeAndBucket(cluster, bucketLayout);
-    volumeName = bucket.getVolumeName();
-    bucketName = bucket.getName();
+    ozoneBucket = TestDataUtil.createVolumeAndBucket(cluster, bucketLayout);
+    volumeName = ozoneBucket.getVolumeName();
+    bucketName = ozoneBucket.getName();
 
     String rootPath = String.format("%s://%s.%s/",
             OzoneConsts.OZONE_URI_SCHEME, bucketName, volumeName);
@@ -344,7 +344,7 @@ public class TestOzoneFileSystem {
 
     String fakeParentKey = "dir1/dir2";
     String fullKeyName = fakeParentKey + "/key1";
-    TestDataUtil.createKey(bucket, fullKeyName, "");
+    TestDataUtil.createKey(ozoneBucket, fullKeyName, "");
 
     // /dir1/dir2 should not exist
     assertFalse(fs.exists(new Path(fakeParentKey)));
@@ -758,7 +758,7 @@ public class TestOzoneFileSystem {
     * the "/dir1", "/dir1/dir2/" are fake directory
     * */
     String keyName = "dir1/dir2/key1";
-    TestDataUtil.createKey(bucket, keyName, "");
+    TestDataUtil.createKey(ozoneBucket, keyName, "");
     FileStatus[] fileStatuses;
 
     fileStatuses = fs.listStatus(new Path("/"));
@@ -1328,7 +1328,7 @@ public class TestOzoneFileSystem {
   public void testRenameContainDelimiterFile() throws Exception {
     String sourceKeyName = "dir1/dir2/key1";
     String targetKeyName = "dir1/dir2/key2";
-    TestDataUtil.createKey(bucket, sourceKeyName, "");
+    TestDataUtil.createKey(ozoneBucket, sourceKeyName, "");
 
     Path sourcePath = new Path(fs.getUri().toString() + "/" + sourceKeyName);
     Path targetPath = new Path(fs.getUri().toString() + "/" + targetKeyName);

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFileSystem.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFileSystem.java
@@ -342,7 +342,8 @@ public class TestOzoneFileSystem {
      *  "dir1/testDir" can be created normal
      */
 
-    String fakeParentKey = "dir1/dir2";
+    String fakeGrandpaKey = "dir1";
+    String fakeParentKey = fakeGrandpaKey + "/dir2";
     String fullKeyName = fakeParentKey + "/key1";
     TestDataUtil.createKey(ozoneBucket, fullKeyName, "");
 
@@ -352,6 +353,9 @@ public class TestOzoneFileSystem {
     // /dir1/dir2/key2 should be created because has a fake parent directory
     Path subdir = new Path(fakeParentKey, "key2");
     assertTrue(fs.mkdirs(subdir));
+    // the intermediate directories /dir1 and /dir1/dir2 will be created too
+    assertTrue(fs.exists(new Path(fakeGrandpaKey)));
+    assertTrue(fs.exists(new Path(fakeParentKey)));
   }
 
   @Test
@@ -1326,14 +1330,20 @@ public class TestOzoneFileSystem {
 
   @Test
   public void testRenameContainDelimiterFile() throws Exception {
-    String sourceKeyName = "dir1/dir2/key1";
-    String targetKeyName = "dir1/dir2/key2";
+    String fakeGrandpaKey = "dir1";
+    String fakeParentKey = fakeGrandpaKey + "/dir2";
+    String sourceKeyName = fakeParentKey + "/key1";
+    String targetKeyName = fakeParentKey +  "/key2";
     TestDataUtil.createKey(ozoneBucket, sourceKeyName, "");
 
     Path sourcePath = new Path(fs.getUri().toString() + "/" + sourceKeyName);
     Path targetPath = new Path(fs.getUri().toString() + "/" + targetKeyName);
     assertTrue(fs.rename(sourcePath, targetPath));
+    assertFalse(fs.exists(sourcePath));
     assertTrue(fs.exists(targetPath));
+    // intermediate directories will not be created
+    assertFalse(fs.exists(new Path(fakeGrandpaKey)));
+    assertFalse(fs.exists(new Path(fakeParentKey)));
   }
 
 

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestKeyManagerImpl.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestKeyManagerImpl.java
@@ -1296,19 +1296,22 @@ public class TestKeyManagerImpl {
     String key = "key1";
     String fullKeyName = parentDir + OZONE_URI_DELIMITER + key;
     OzoneFileStatus ozoneFileStatus;
+
+    // create a key "dir1/key1"
     OmKeyArgs keyArgs = createBuilder().setKeyName(fullKeyName).build();
     OpenKeySession keySession = writeClient.createFile(keyArgs, true, true);
     keyArgs.setLocationInfoList(
         keySession.getKeyInfo().getLatestVersionLocations().getLocationList());
     writeClient.commitKey(keyArgs, keySession.getId());
 
-    // create a key "dir1/key1"
+    // verify
+    String keyArg;
+    keyArg = metadataManager.getOzoneKey(VOLUME_NAME, BUCKET_NAME, parentDir);
     Assert.assertNull(
-        metadataManager.getKeyTable(getDefaultBucketLayout()).get(
-            metadataManager.getOzoneKey(VOLUME_NAME, BUCKET_NAME, parentDir)));
-    Assert.assertNotNull(
-        metadataManager.getKeyTable(getDefaultBucketLayout())
-            .get(metadataManager.getOzoneKey(VOLUME_NAME, BUCKET_NAME, fullKeyName)));
+        metadataManager.getKeyTable(getDefaultBucketLayout()).get(keyArg));
+    keyArg = metadataManager.getOzoneKey(VOLUME_NAME, BUCKET_NAME, parentDir);
+    Assert.assertNotNull(metadataManager.getKeyTable(getDefaultBucketLayout())
+        .get(keyArg));
 
     // get a non-existing "dir1", since the key is prefixed "dir1/key1",
     // a fake "/dir1" will be returned
@@ -1318,7 +1321,7 @@ public class TestKeyManagerImpl {
     Assert.assertTrue(ozoneFileStatus.isDirectory());
 
     // get a non-existing "dir", since the key is not prefixed "dir1/key1",
-    // a `OMException` will be throw
+    // a `OMException` will be thrown
     keyArgs = createBuilder().setKeyName("dir").build();
     OmKeyArgs finalKeyArgs = keyArgs;
     Assert.assertThrows(OMException.class, () -> keyManager.getFileStatus(

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestKeyManagerImpl.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestKeyManagerImpl.java
@@ -1299,7 +1299,7 @@ public class TestKeyManagerImpl {
 
     // create a key "dir1/key1"
     OmKeyArgs keyArgs = createBuilder().setKeyName(fullKeyName).build();
-    OpenKeySession keySession = writeClient.openKey(keyArgs, true, true);
+    OpenKeySession keySession = writeClient.openKey(keyArgs);
     keyArgs.setLocationInfoList(
         keySession.getKeyInfo().getLatestVersionLocations().getLocationList());
     writeClient.commitKey(keyArgs, keySession.getId());

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestKeyManagerImpl.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestKeyManagerImpl.java
@@ -1309,7 +1309,7 @@ public class TestKeyManagerImpl {
     keyArg = metadataManager.getOzoneKey(VOLUME_NAME, BUCKET_NAME, parentDir);
     Assert.assertNull(
         metadataManager.getKeyTable(getDefaultBucketLayout()).get(keyArg));
-    keyArg = metadataManager.getOzoneKey(VOLUME_NAME, BUCKET_NAME, parentDir);
+    keyArg = metadataManager.getOzoneKey(VOLUME_NAME, BUCKET_NAME, fullKeyName);
     Assert.assertNotNull(metadataManager.getKeyTable(getDefaultBucketLayout())
         .get(keyArg));
 

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestKeyManagerImpl.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestKeyManagerImpl.java
@@ -800,19 +800,20 @@ public class TestKeyManagerImpl {
     List<OmKeyLocationInfo> locationList =
         keySession.getKeyInfo().getLatestVersionLocations().getLocationList();
     Assert.assertEquals(1, locationList.size());
+    long containerID = locationList.get(0).getContainerID();
     locationInfoList.add(
         new OmKeyLocationInfo.Builder().setPipeline(pipeline)
-            .setBlockID(new BlockID(locationList.get(0).getContainerID(),
+            .setBlockID(new BlockID(containerID,
                 locationList.get(0).getLocalID())).build());
     keyArgs.setLocationInfoList(locationInfoList);
 
     writeClient.commitKey(keyArgs, keySession.getId());
-    ContainerInfo containerInfo = new ContainerInfo.Builder().setContainerID(1L)
-        .setPipelineID(pipeline.getId()).build();
+    ContainerInfo containerInfo = new ContainerInfo.Builder()
+        .setContainerID(containerID).setPipelineID(pipeline.getId()).build();
     List<ContainerWithPipeline> containerWithPipelines = Arrays.asList(
         new ContainerWithPipeline(containerInfo, pipeline));
     when(mockScmContainerClient.getContainerWithPipelineBatch(
-        Arrays.asList(1L))).thenReturn(containerWithPipelines);
+        Arrays.asList(containerID))).thenReturn(containerWithPipelines);
 
     OmKeyInfo key = keyManager.lookupKey(keyArgs, null);
     Assert.assertEquals(key.getKeyName(), keyName);

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestKeyManagerImpl.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestKeyManagerImpl.java
@@ -1299,7 +1299,7 @@ public class TestKeyManagerImpl {
 
     // create a key "dir1/key1"
     OmKeyArgs keyArgs = createBuilder().setKeyName(fullKeyName).build();
-    OpenKeySession keySession = writeClient.createFile(keyArgs, true, true);
+    OpenKeySession keySession = writeClient.openKey(keyArgs, true, true);
     keyArgs.setLocationInfoList(
         keySession.getKeyInfo().getLatestVersionLocations().getLocationList());
     writeClient.commitKey(keyArgs, keySession.getId());

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/KeyManagerImpl.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/KeyManagerImpl.java
@@ -1249,10 +1249,8 @@ public class KeyManagerImpl implements KeyManager {
             if (fullPath.startsWith(subPath)) {
               // create fake directory
               fakeDirKeyInfo = createDirectoryKey(
-                  omKeyInfo.getVolumeName(),
-                  omKeyInfo.getBucketName(),
-                  dirKey,
-                  omKeyInfo.getAcls());
+                  omKeyInfo,
+                  dirKey);
             }
           }
         }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/KeyManagerImpl.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/KeyManagerImpl.java
@@ -1263,7 +1263,8 @@ public class KeyManagerImpl implements KeyManager {
       metadataManager.getLock().releaseReadLock(BUCKET_LOCK, volumeName,
               bucketName);
       if (fileKeyInfo != null) {
-        // if the key is a file then do refresh pipeline info in OM by asking SCM
+        // if the key is a file
+        // then do refresh pipeline info in OM by asking SCM
         if (args.getLatestVersionLocation()) {
           slimLocationVersion(fileKeyInfo);
         }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/KeyManagerImpl.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/KeyManagerImpl.java
@@ -1223,7 +1223,8 @@ public class KeyManagerImpl implements KeyManager {
       // Check if the key is a file.
       String fileKeyBytes = metadataManager.getOzoneKey(
               volumeName, bucketName, keyName);
-      BucketLayout layout = getBucketLayout(metadataManager, volumeName, bucketName);
+      BucketLayout layout =
+          getBucketLayout(metadataManager, volumeName, bucketName);
       fileKeyInfo = metadataManager.getKeyTable(layout).get(fileKeyBytes);
       String dirKey = OzoneFSUtils.addTrailingSlashIfNeeded(keyName);
 
@@ -1261,24 +1262,24 @@ public class KeyManagerImpl implements KeyManager {
               bucketName);
     }
 
-      if (fileKeyInfo != null) {
-        // if the key is a file then do refresh pipeline info in OM by asking SCM
-        if (args.getLatestVersionLocation()) {
-          slimLocationVersion(fileKeyInfo);
-        }
-        // If operation is head, do not perform any additional steps
-        // As head operation does not need any of those details.
-        if (!args.isHeadOp()) {
-          // refreshPipeline flag check has been removed as part of
-          // https://issues.apache.org/jira/browse/HDDS-3658.
-          // Please refer this jira for more details.
-          refresh(fileKeyInfo);
-          if (args.getSortDatanodes()) {
-            sortDatanodes(clientAddress, fileKeyInfo);
-          }
-        }
-        return new OzoneFileStatus(fileKeyInfo, scmBlockSize, false);
+    if (fileKeyInfo != null) {
+      // if the key is a file then do refresh pipeline info in OM by asking SCM
+      if (args.getLatestVersionLocation()) {
+        slimLocationVersion(fileKeyInfo);
       }
+      // If operation is head, do not perform any additional steps
+      // As head operation does not need any of those details.
+      if (!args.isHeadOp()) {
+        // refreshPipeline flag check has been removed as part of
+        // https://issues.apache.org/jira/browse/HDDS-3658.
+        // Please refer this jira for more details.
+        refresh(fileKeyInfo);
+        if (args.getSortDatanodes()) {
+          sortDatanodes(clientAddress, fileKeyInfo);
+        }
+      }
+      return new OzoneFileStatus(fileKeyInfo, scmBlockSize, false);
+    }
 
     if (dirKeyInfo != null) {
       return new OzoneFileStatus(dirKeyInfo, scmBlockSize, true);

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/KeyManagerImpl.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/KeyManagerImpl.java
@@ -1255,8 +1255,6 @@ public class KeyManagerImpl implements KeyManager {
           }
         }
       }
-    } catch (Exception e) {
-      LOG.error("Failed to get info of key {}", keyName, e);
     } finally {
       metadataManager.getLock().releaseReadLock(BUCKET_LOCK, volumeName,
               bucketName);


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fix exception when '/' in key name

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-7253

## How was this patch tested?

How to reproduce the bug

- First put a key that containing '/'

```bash
[root@Linux /root/ozone]% bin/ozone sh key put s3v/testbucket/dir1/dir2/key1 ~/testfile
[root@Linux /root/ozone]% bin/ozone sh key ls s3v/testbucket/ | grep name
  "name" : "dir1/dir2/key1"
```
- Execute command

`ls` command for keys containing '/'
before this commit
```bash
[root@Linux /root/ozone]% bin/ozone fs -ls ofs://localhost/s3v/testbucket/
Found 1 items
drwxrwxrwx   - root root          0 2022-09-19 14:11 ofs://localhost/s3v/testbucket/dir1
[root@Linux /root/ozone]% bin/ozone fs -ls ofs://localhost/s3v/testbucket/dir1
ls: `ofs://localhost/s3v/testbucket/dir1': No such file or directory
```
after this commit
```bash
[root@Linux /root/ozone]% bin/ozone fs -ls ofs://localhost/s3v/testbucket/
Found 1 items
drwxrwxrwx   - root root          0 2022-09-19 14:37 ofs://localhost/s3v/testbucket/dir1
[root@Linux /root/ozone]% bin/ozone fs -ls ofs://localhost/s3v/testbucket/dir1
Found 1 items
drwxrwxrwx   - root root          0 2022-09-19 14:37 ofs://localhost/s3v/testbucket/dir1/dir2
```

for `mv`, `mkdir`, `count` command for keys containing '/' 



before this commit 
```bash
[root@Linux /root/ozone]% bin/ozone fs -count ofs://localhost/s3v/testbucket/
count: dir1: No such file or directory!
[root@Linux /root/ozone]% bin/ozone fs -mv ofs://localhost/s3v/testbucket/dir1 ofs://localhost/s3v/testbucket/dir2
mv: `ofs://localhost/s3v/testbucket/dir1': No such file or directory
[root@Linux /root/ozone]% bin/ozone fs -mkdir ofs://localhost/s3v/testbucket/dir1/dir2/key2
mkdir: `ofs://localhost/s3v/testbucket/dir1/dir2': No such file or directory
```
after this commit
```bash
[root@Linux /root/ozone]% bin/ozone fs -count ofs://localhost/s3v/testbucket/
           3            1            1048576 ofs://localhost/s3v/testbucket
[root@Linux /root/ozone]% bin/ozone fs -mv ofs://localhost/s3v/testbucket/dir1 ofs://localhost/s3v/testbucket/newdir1
[root@Linux /root/ozone]% bin/ozone fs -ls ofs://localhost/s3v/testbucket/
Found 1 items
drwxrwxrwx   - root root          0 2022-09-19 14:39 ofs://localhost/s3v/testbucket/newdir1
[root@Linux /root/ozone]% bin/ozone fs -mkdir ofs://localhost/s3v/testbucket/newdir1/dir2/dir3
[root@Linux /root/ozone]% bin/ozone fs -ls ofs://localhost/s3v/testbucket/newdir1/dir2/
Found 2 items
drwxrwxrwx   - root root          0 2022-09-19 14:43 ofs://localhost/s3v/testbucket/newdir1/dir2/dir3
-rw-rw-rw-   3 root root    1048576 2022-09-19 14:39 ofs://localhost/s3v/testbucket/newdir1/dir2/key1
```
