### PR TITLE
HDDS-7160. Recon: Make Container and Bucket stats clickable in Overviews page

### DIFF
--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/routes.tsx
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/routes.tsx
@@ -51,6 +51,14 @@ export const routes: IRoute[] = [
     component: DiskUsage
   },
   {
+    path: '/Buckets',
+    component: DiskUsage,
+  },
+  {
+    path: '/Containers',
+    component: MissingContainers,
+  },
+  {
     path: '/:NotFound',
     component: NotFound
   }

--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/views/overview/overview.tsx
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/views/overview/overview.tsx
@@ -129,7 +129,7 @@ export class Overview extends React.Component<Record<string, object>, IOverviewS
       </span>
     );
     const containersTooltip = missingContainersCount === 1 ? 'container is missing' : 'containers are missing';
-    const containersLink = missingContainersCount > 0 ? '/MissingContainers' : '';
+    const containersLink = missingContainersCount > 0 ? '/MissingContainers' : '/Containers';
     const duLink = '/DiskUsage';
     const containersElement = missingContainersCount > 0 ? (
       <span>
@@ -178,7 +178,7 @@ export class Overview extends React.Component<Record<string, object>, IOverviewS
             <OverviewCard loading={loading} title='Volumes' data={volumes.toString()} icon='inbox' linkToUrl={duLink}/>
           </Col>
           <Col xs={24} sm={18} md={12} lg={12} xl={6}>
-            <OverviewCard loading={loading} title='Buckets' data={buckets.toString()} icon='folder-open'/>
+            <OverviewCard loading={loading} title='Buckets' data={buckets.toString()} icon='folder-open' linkToUrl='/Buckets'/>
           </Col>
           <Col xs={24} sm={18} md={12} lg={12} xl={6}>
             <OverviewCard loading={loading} title='Keys' data={keys.toString()} icon='file-text'/>


### PR DESCRIPTION
## What changes were proposed in this pull request?
Make Container and Bucket stats clickable in Overviews page


## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-7160

## How was this patch tested?
Manually

