### PR TITLE
HDDS-7257. Bump snakeyaml to 1.32

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -249,7 +249,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
     <proto-backwards-compatibility.version>1.0.7</proto-backwards-compatibility.version>
 
     <swagger-annotations-version>1.5.4</swagger-annotations-version>
-    <snakeyaml.version>1.26</snakeyaml.version>
+    <snakeyaml.version>1.32</snakeyaml.version>
     <sonar.java.binaries>${basedir}/target/classes</sonar.java.binaries>
 
     <aspectj.version>1.9.7</aspectj.version>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Bump snakeyaml to latest, 1.32.

https://issues.apache.org/jira/browse/HDDS-7257

## How was this patch tested?

Regular CI:
https://github.com/adoroszlai/hadoop-ozone/actions/runs/3108064849