### PR TITLE
HDDS-7258. Cleanup the allocated but uncommitted blocks

### DIFF
--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmKeyInfo.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmKeyInfo.java
@@ -24,6 +24,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 import org.apache.commons.lang3.StringUtils;
@@ -229,9 +230,9 @@ public final class OmKeyInfo extends WithParentObjectId {
     // Only check ContainerBlockID here to avoid the mismatch of the pipeline
     // field and BcsId in the OmKeyLocationInfo, as the OmKeyInfoCodec ignores
     // the pipeline field by default and bcsId would be updated in Ratis mode.
-    List<ContainerBlockID> updatedBlockIDs = updatedBlockLocations.stream().
+    Set<ContainerBlockID> updatedBlockIDs = updatedBlockLocations.stream().
         map(BlockLocationInfo::getBlockID).map(BlockID::getContainerBlockID).
-        collect(Collectors.toList());
+        collect(Collectors.toSet());
     uncommittedBlocks.removeIf(block -> updatedBlockIDs.
         contains(block.getBlockID().getContainerBlockID()));
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyCommitRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyCommitRequest.java
@@ -245,7 +245,7 @@ public class OMKeyCommitRequest extends OMKeyRequest {
 
       // let the uncommitted blocks pretend as key's old version blocks
       // which will be deleted as RepeatedOmKeyInfo
-      if (uncommitted.size() > 0) {
+      if (!uncommitted.isEmpty()) {
         LOG.info("Detect allocated but uncommitted blocks {} in key {}.",
             uncommitted, keyName);
         OmKeyInfo pseudoKeyInfo = omKeyInfo.copyObject();

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyCommitRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyCommitRequest.java
@@ -244,7 +244,7 @@ public class OMKeyCommitRequest extends OMKeyRequest {
 
       // let the uncommitted blocks pretend as key's old version blocks
       // which will be deleted as RepeatedOmKeyInfo
-      OmKeyInfo pseudoKeyInfo = warpUncommittedBlocksAsPseudoKey(uncommitted,
+      OmKeyInfo pseudoKeyInfo = wrapUncommittedBlocksAsPseudoKey(uncommitted,
           omKeyInfo);
       if (pseudoKeyInfo != null) {
         if (oldKeyVersionsToDelete != null) {

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyCommitRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyCommitRequest.java
@@ -246,10 +246,12 @@ public class OMKeyCommitRequest extends OMKeyRequest {
       // which will be deleted as RepeatedOmKeyInfo
       OmKeyInfo pseudoKeyInfo = warpUncommittedBlocksAsPseudoKey(uncommitted,
           omKeyInfo);
-      if (oldKeyVersionsToDelete != null) {
-        oldKeyVersionsToDelete.addOmKeyInfo(pseudoKeyInfo);
-      } else {
-        oldKeyVersionsToDelete = new RepeatedOmKeyInfo(pseudoKeyInfo);
+      if (pseudoKeyInfo != null) {
+        if (oldKeyVersionsToDelete != null) {
+          oldKeyVersionsToDelete.addOmKeyInfo(pseudoKeyInfo);
+        } else {
+          oldKeyVersionsToDelete = new RepeatedOmKeyInfo(pseudoKeyInfo);
+        }
       }
 
       // Add to cache of open key table and key table.

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyCommitRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyCommitRequest.java
@@ -31,7 +31,6 @@ import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.hadoop.ozone.om.OMConfigKeys;
 import org.apache.hadoop.ozone.om.helpers.OmBucketInfo;
 import org.apache.hadoop.ozone.om.helpers.BucketLayout;
-import org.apache.hadoop.ozone.om.helpers.OmKeyLocationInfoGroup;
 import org.apache.hadoop.ozone.om.helpers.OzoneFSUtils;
 import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
 import org.apache.hadoop.ozone.om.helpers.OmKeyLocationInfo;
@@ -245,22 +244,12 @@ public class OMKeyCommitRequest extends OMKeyRequest {
 
       // let the uncommitted blocks pretend as key's old version blocks
       // which will be deleted as RepeatedOmKeyInfo
-      if (!uncommitted.isEmpty()) {
-        LOG.info("Detect allocated but uncommitted blocks {} in key {}.",
-            uncommitted, keyName);
-        OmKeyInfo pseudoKeyInfo = omKeyInfo.copyObject();
-        // set dataSize -1 here to distinguish from normal keyInfo
-        pseudoKeyInfo.setDataSize(-1);
-        List<OmKeyLocationInfoGroup> uncommittedGroups = new ArrayList<>();
-        // version not matters in the current logic of keyDeletingService,
-        // all versions of blocks will be deleted.
-        uncommittedGroups.add(new OmKeyLocationInfoGroup(0, uncommitted));
-        pseudoKeyInfo.setKeyLocationVersions(uncommittedGroups);
-        if (oldKeyVersionsToDelete == null) {
-          oldKeyVersionsToDelete = new RepeatedOmKeyInfo(pseudoKeyInfo);
-        } else {
-          oldKeyVersionsToDelete.addOmKeyInfo(pseudoKeyInfo);
-        }
+      OmKeyInfo pseudoKeyInfo = warpUncommittedBlocksAsPseudoKey(uncommitted,
+          omKeyInfo);
+      if (oldKeyVersionsToDelete != null) {
+        oldKeyVersionsToDelete.addOmKeyInfo(pseudoKeyInfo);
+      } else {
+        oldKeyVersionsToDelete = new RepeatedOmKeyInfo(pseudoKeyInfo);
       }
 
       // Add to cache of open key table and key table.

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyCommitRequestWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyCommitRequestWithFSO.java
@@ -184,10 +184,12 @@ public class OMKeyCommitRequestWithFSO extends OMKeyCommitRequest {
       // which will be deleted as RepeatedOmKeyInfo
       OmKeyInfo pseudoKeyInfo = warpUncommittedBlocksAsPseudoKey(uncommitted,
           omKeyInfo);
-      if (oldKeyVersionsToDelete != null) {
-        oldKeyVersionsToDelete.addOmKeyInfo(pseudoKeyInfo);
-      } else {
-        oldKeyVersionsToDelete = new RepeatedOmKeyInfo(pseudoKeyInfo);
+      if (pseudoKeyInfo != null) {
+        if (oldKeyVersionsToDelete != null) {
+          oldKeyVersionsToDelete.addOmKeyInfo(pseudoKeyInfo);
+        } else {
+          oldKeyVersionsToDelete = new RepeatedOmKeyInfo(pseudoKeyInfo);
+        }
       }
 
       // Add to cache of open key table and key table.

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyCommitRequestWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyCommitRequestWithFSO.java
@@ -150,8 +150,6 @@ public class OMKeyCommitRequestWithFSO extends OMKeyCommitRequest {
 
       omKeyInfo.setModificationTime(commitKeyArgs.getModificationTime());
 
-      // Update the block length for each block, return the allocated but
-      // uncommitted blocks
       List<OmKeyLocationInfo> uncommitted = omKeyInfo.updateLocationInfoList(
           locationInfoList, false);
 
@@ -185,7 +183,7 @@ public class OMKeyCommitRequestWithFSO extends OMKeyCommitRequest {
 
       // let the uncommitted blocks pretend as key's old version blocks
       // which will be deleted as RepeatedOmKeyInfo
-      if (uncommitted.size() > 0) {
+      if (!uncommitted.isEmpty()) {
         LOG.info("Detect allocated but uncommitted blocks {} in key {}.",
             uncommitted, keyName);
         OmKeyInfo pseudoKeyInfo = omKeyInfo.copyObject();

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyCommitRequestWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyCommitRequestWithFSO.java
@@ -182,7 +182,7 @@ public class OMKeyCommitRequestWithFSO extends OMKeyCommitRequest {
 
       // let the uncommitted blocks pretend as key's old version blocks
       // which will be deleted as RepeatedOmKeyInfo
-      OmKeyInfo pseudoKeyInfo = warpUncommittedBlocksAsPseudoKey(uncommitted,
+      OmKeyInfo pseudoKeyInfo = wrapUncommittedBlocksAsPseudoKey(uncommitted,
           omKeyInfo);
       if (pseudoKeyInfo != null) {
         if (oldKeyVersionsToDelete != null) {

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyRequest.java
@@ -818,13 +818,13 @@ public abstract class OMKeyRequest extends OMClientRequest {
   }
 
   /**
-   * Warp the uncommitted blocks as pseudoKeyInfo.
+   * Wrap the uncommitted blocks as pseudoKeyInfo.
    *
    * @param uncommitted Uncommitted OmKeyLocationInfo
    * @param omKeyInfo   Args for key block
    * @return pseudoKeyInfo
    */
-  protected OmKeyInfo warpUncommittedBlocksAsPseudoKey(
+  protected OmKeyInfo wrapUncommittedBlocksAsPseudoKey(
       List<OmKeyLocationInfo> uncommitted, OmKeyInfo omKeyInfo) {
     if (uncommitted.isEmpty()) {
       return null;

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyRequest.java
@@ -832,8 +832,7 @@ public abstract class OMKeyRequest extends OMClientRequest {
     LOG.info("Detect allocated but uncommitted blocks {} in key {}.",
         uncommitted, omKeyInfo.getKeyName());
     OmKeyInfo pseudoKeyInfo = omKeyInfo.copyObject();
-    // set dataSize -1 here to distinguish from normal keyInfo
-    pseudoKeyInfo.setDataSize(-1);
+    // TODO dataSize of pseudoKey is not real here
     List<OmKeyLocationInfoGroup> uncommittedGroups = new ArrayList<>();
     // version not matters in the current logic of keyDeletingService,
     // all versions of blocks will be deleted.

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyRequest.java
@@ -816,4 +816,29 @@ public abstract class OMKeyRequest extends OMClientRequest {
     return ozoneManager.getOzoneLockProvider()
         .createLockStrategy(getBucketLayout());
   }
+
+  /**
+   * Warp the uncommitted blocks as pseudoKeyInfo.
+   *
+   * @param uncommitted Uncommitted OmKeyLocationInfo
+   * @param omKeyInfo   Args for key block
+   * @return pseudoKeyInfo
+   */
+  protected OmKeyInfo warpUncommittedBlocksAsPseudoKey(
+      List<OmKeyLocationInfo> uncommitted, OmKeyInfo omKeyInfo) {
+    if (uncommitted.isEmpty()) {
+      return null;
+    }
+    LOG.info("Detect allocated but uncommitted blocks {} in key {}.",
+        uncommitted, omKeyInfo.getKeyName());
+    OmKeyInfo pseudoKeyInfo = omKeyInfo.copyObject();
+    // set dataSize -1 here to distinguish from normal keyInfo
+    pseudoKeyInfo.setDataSize(-1);
+    List<OmKeyLocationInfoGroup> uncommittedGroups = new ArrayList<>();
+    // version not matters in the current logic of keyDeletingService,
+    // all versions of blocks will be deleted.
+    uncommittedGroups.add(new OmKeyLocationInfoGroup(0, uncommitted));
+    pseudoKeyInfo.setKeyLocationVersions(uncommittedGroups);
+    return pseudoKeyInfo;
+  }
 }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/key/OMKeyCommitResponse.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/key/OMKeyCommitResponse.java
@@ -18,6 +18,7 @@
 
 package org.apache.hadoop.ozone.om.response.key;
 
+import com.google.common.annotations.VisibleForTesting;
 import org.apache.hadoop.ozone.om.OMMetadataManager;
 import org.apache.hadoop.ozone.om.helpers.BucketLayout;
 import org.apache.hadoop.ozone.om.helpers.OmBucketInfo;
@@ -102,6 +103,11 @@ public class OMKeyCommitResponse extends OmKeyResponse {
 
   protected String getOzoneKeyName() {
     return ozoneKeyName;
+  }
+
+  @VisibleForTesting
+  public RepeatedOmKeyInfo getKeysToDelete() {
+    return keysToDelete;
   }
 
   protected void updateDeletedTable(OMMetadataManager omMetadataManager,

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMKeyCommitRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMKeyCommitRequest.java
@@ -72,7 +72,7 @@ public class TestOMKeyCommitRequest extends TestOMKeyRequest {
         getOmKeyCommitRequest(modifiedOmRequest);
 
     // Append 3 blocks locations.
-    List<OmKeyLocationInfo> allocatedLocationList = getKeyLocation(3, 0)
+    List<OmKeyLocationInfo> allocatedLocationList = getKeyLocation(3)
         .stream().map(OmKeyLocationInfo::getFromProtobuf)
         .collect(Collectors.toList());
 
@@ -196,14 +196,14 @@ public class TestOMKeyCommitRequest extends TestOMKeyRequest {
       throws Exception {
 
     // allocated block list
-    List<KeyLocation> allocatedKeyLocationList = getKeyLocation(5, 0);
+    List<KeyLocation> allocatedKeyLocationList = getKeyLocation(5);
 
     List<OmKeyLocationInfo> allocatedBlockList = allocatedKeyLocationList
         .stream().map(OmKeyLocationInfo::getFromProtobuf)
         .collect(Collectors.toList());
 
     // committed block list, with three blocks different with the allocated
-    List<KeyLocation> committedKeyLocationList = getKeyLocation(5, 3);
+    List<KeyLocation> committedKeyLocationList = getKeyLocation(3);
 
     OMRequest modifiedOmRequest = doPreExecute(createCommitKeyRequest(
         committedKeyLocationList));
@@ -237,7 +237,7 @@ public class TestOMKeyCommitRequest extends TestOMKeyRequest {
     // This is the first time to commit key, only the allocated but uncommitted
     // blocks should be deleted.
     Assert.assertEquals(1, toDeleteKeyList.size());
-    Assert.assertEquals(3, toDeleteKeyList.get(0).
+    Assert.assertEquals(2, toDeleteKeyList.get(0).
         getKeyLocationVersions().get(0).getLocationList().size());
 
     // Entry should be deleted from openKey Table.
@@ -274,7 +274,7 @@ public class TestOMKeyCommitRequest extends TestOMKeyRequest {
     // Key table should have only two blocks.
     Assert.assertEquals(intersection,
         omKeyInfo.getLatestVersionLocations().getLocationList());
-    Assert.assertEquals(2, intersection.size());
+    Assert.assertEquals(3, intersection.size());
 
   }
 
@@ -555,7 +555,7 @@ public class TestOMKeyCommitRequest extends TestOMKeyRequest {
   }
 
   private OMRequest createCommitKeyRequest() {
-    return createCommitKeyRequest(getKeyLocation(5, 0));
+    return createCommitKeyRequest(getKeyLocation(5));
   }
 
   /**
@@ -581,10 +581,10 @@ public class TestOMKeyCommitRequest extends TestOMKeyRequest {
   /**
    * Create KeyLocation list.
    */
-  private List<KeyLocation> getKeyLocation(int count, int start) {
+  private List<KeyLocation> getKeyLocation(int count) {
     List<KeyLocation> keyLocations = new ArrayList<>();
 
-    for (int i = start; i < start + count; i++) {
+    for (int i = 0; i < count; i++) {
       KeyLocation keyLocation =
           KeyLocation.newBuilder()
               .setBlockID(HddsProtos.BlockID.newBuilder()

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMKeyCommitRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMKeyCommitRequest.java
@@ -271,7 +271,7 @@ public class TestOMKeyCommitRequest extends TestOMKeyRequest {
     List<OmKeyLocationInfo> intersection = new ArrayList<>(allocatedBlockList);
     intersection.retainAll(locationInfoListFromCommitKeyRequest);
 
-    // Key table should have only two blocks.
+    // Key table should have three blocks.
     Assert.assertEquals(intersection,
         omKeyInfo.getLatestVersionLocations().getLocationList());
     Assert.assertEquals(3, intersection.size());

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMKeyCommitRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMKeyCommitRequest.java
@@ -30,6 +30,7 @@ import org.apache.hadoop.ozone.om.helpers.BucketLayout;
 import org.apache.hadoop.ozone.om.helpers.OmBucketInfo;
 import org.apache.hadoop.ozone.om.helpers.OzoneFSUtils;
 import org.apache.hadoop.ozone.om.request.OMRequestTestUtils;
+import org.apache.hadoop.ozone.om.response.key.OMKeyCommitResponse;
 import org.apache.hadoop.util.Time;
 import org.jetbrains.annotations.NotNull;
 import org.junit.Assert;
@@ -71,7 +72,7 @@ public class TestOMKeyCommitRequest extends TestOMKeyRequest {
         getOmKeyCommitRequest(modifiedOmRequest);
 
     // Append 3 blocks locations.
-    List<OmKeyLocationInfo> allocatedLocationList = getKeyLocation(3)
+    List<OmKeyLocationInfo> allocatedLocationList = getKeyLocation(3, 0)
         .stream().map(OmKeyLocationInfo::getFromProtobuf)
         .collect(Collectors.toList());
 
@@ -188,6 +189,93 @@ public class TestOMKeyCommitRequest extends TestOMKeyRequest {
         omKeyInfo.getLatestVersionLocations().getLocationList());
     Assert.assertEquals(allocatedLocationList,
         omKeyInfo.getLatestVersionLocations().getLocationList());
+  }
+
+  @Test
+  public void testValidateAndUpdateCacheWithUncommittedBlocks()
+      throws Exception {
+
+    // allocated block list
+    List<KeyLocation> allocatedKeyLocationList = getKeyLocation(5, 0);
+
+    List<OmKeyLocationInfo> allocatedBlockList = allocatedKeyLocationList
+        .stream().map(OmKeyLocationInfo::getFromProtobuf)
+        .collect(Collectors.toList());
+
+    // committed block list, with three blocks different with the allocated
+    List<KeyLocation> committedKeyLocationList = getKeyLocation(5, 3);
+
+    OMRequest modifiedOmRequest = doPreExecute(createCommitKeyRequest(
+        committedKeyLocationList));
+
+    OMKeyCommitRequest omKeyCommitRequest =
+        getOmKeyCommitRequest(modifiedOmRequest);
+
+    OMRequestTestUtils.addVolumeAndBucketToDB(volumeName, bucketName,
+        omMetadataManager, omKeyCommitRequest.getBucketLayout());
+
+    String ozoneKey = addKeyToOpenKeyTable(allocatedBlockList);
+
+    // Key should not be there in key table, as validateAndUpdateCache is
+    // still not called.
+    OmKeyInfo omKeyInfo =
+        omMetadataManager.getKeyTable(omKeyCommitRequest.getBucketLayout())
+            .get(ozoneKey);
+
+    Assert.assertNull(omKeyInfo);
+
+    OMClientResponse omClientResponse =
+        omKeyCommitRequest.validateAndUpdateCache(ozoneManager,
+            100L, ozoneManagerDoubleBufferHelper);
+
+    Assert.assertEquals(OzoneManagerProtocolProtos.Status.OK,
+        omClientResponse.getOMResponse().getStatus());
+
+    List<OmKeyInfo> toDeleteKeyList = ((OMKeyCommitResponse) omClientResponse).
+        getKeysToDelete().cloneOmKeyInfoList();
+
+    // This is the first time to commit key, only the allocated but uncommitted
+    // blocks should be deleted.
+    Assert.assertEquals(1, toDeleteKeyList.size());
+    Assert.assertEquals(3, toDeleteKeyList.get(0).
+        getKeyLocationVersions().get(0).getLocationList().size());
+
+    // Entry should be deleted from openKey Table.
+    omKeyInfo =
+        omMetadataManager.getOpenKeyTable(omKeyCommitRequest.getBucketLayout())
+            .get(ozoneKey);
+    Assert.assertNull(omKeyInfo);
+
+    // Now entry should be created in key Table.
+    omKeyInfo =
+        omMetadataManager.getKeyTable(omKeyCommitRequest.getBucketLayout())
+            .get(ozoneKey);
+
+    Assert.assertNotNull(omKeyInfo);
+
+    // DB keyInfo format
+    verifyKeyName(omKeyInfo);
+
+    // Check modification time
+    CommitKeyRequest commitKeyRequest = modifiedOmRequest.getCommitKeyRequest();
+    Assert.assertEquals(commitKeyRequest.getKeyArgs().getModificationTime(),
+        omKeyInfo.getModificationTime());
+
+    // Check block location.
+    List<OmKeyLocationInfo> locationInfoListFromCommitKeyRequest =
+        commitKeyRequest.getKeyArgs()
+            .getKeyLocationsList().stream()
+            .map(OmKeyLocationInfo::getFromProtobuf)
+            .collect(Collectors.toList());
+
+    List<OmKeyLocationInfo> intersection = new ArrayList<>(allocatedBlockList);
+    intersection.retainAll(locationInfoListFromCommitKeyRequest);
+
+    // Key table should have only two blocks.
+    Assert.assertEquals(intersection,
+        omKeyInfo.getLatestVersionLocations().getLocationList());
+    Assert.assertEquals(2, intersection.size());
+
   }
 
   @Test
@@ -466,15 +554,19 @@ public class TestOMKeyCommitRequest extends TestOMKeyRequest {
         modifiedKeyArgs.getFactor());
   }
 
+  private OMRequest createCommitKeyRequest() {
+    return createCommitKeyRequest(getKeyLocation(5, 0));
+  }
+
   /**
    * Create OMRequest which encapsulates CommitKeyRequest.
    */
-  private OMRequest createCommitKeyRequest() {
+  private OMRequest createCommitKeyRequest(List<KeyLocation> keyLocations) {
     KeyArgs keyArgs =
         KeyArgs.newBuilder().setDataSize(dataSize).setVolumeName(volumeName)
             .setKeyName(keyName).setBucketName(bucketName)
             .setType(replicationType).setFactor(replicationFactor)
-            .addAllKeyLocations(getKeyLocation(5)).build();
+            .addAllKeyLocations(keyLocations).build();
 
     CommitKeyRequest commitKeyRequest =
         CommitKeyRequest.newBuilder().setKeyArgs(keyArgs)
@@ -489,10 +581,10 @@ public class TestOMKeyCommitRequest extends TestOMKeyRequest {
   /**
    * Create KeyLocation list.
    */
-  private List<KeyLocation> getKeyLocation(int count) {
+  private List<KeyLocation> getKeyLocation(int count, int start) {
     List<KeyLocation> keyLocations = new ArrayList<>();
 
-    for (int i = 0; i < count; i++) {
+    for (int i = start; i < start + count; i++) {
       KeyLocation keyLocation =
           KeyLocation.newBuilder()
               .setBlockID(HddsProtos.BlockID.newBuilder()


### PR DESCRIPTION
## What changes were proposed in this pull request?

We found that the blocks the client committed may not be equal to the allocated(when EC stripe fails), and the uncommitted blocks would remain forever as orphan blocks as no key maps to them anymore. 

Here I use a tricky solution that considers these blocks as repeated/ overwritten key blocks, and thus they would be deleted in the existing deletion path.


------ 
https://docs.google.com/document/d/1Oi1zPKdmvA7DFwIcUWz6zw_p-pY3D1L76gyV37jQT94/edit#

The prototype of the design.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-7258

## How was this patch tested?
UT and Manual test in the test environment.
