### PR TITLE
HDDS-7259. Fix uncounted blocksDeleted in BlockDeletingService

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/statemachine/background/BlockDeletingService.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/statemachine/background/BlockDeletingService.java
@@ -556,16 +556,25 @@ public class BlockDeletingService extends BackgroundService {
             LOG.warn("Missing delete block(Container = " +
                 container.getContainerData().getContainerID() + ", Block = " +
                 blkLong);
+            blocksDeleted++;
             continue;
           }
+
           try {
             handler.deleteBlock(container, blkInfo);
             blocksDeleted++;
-            bytesReleased += KeyValueContainerUtil.getBlockLength(blkInfo);
-          } catch (InvalidProtocolBufferException e) {
-            LOG.error("Failed to parse block info for block {}", blkLong, e);
           } catch (IOException e) {
+            // TODO: if deletion of certain block retries exceed the certain
+            //  number of times, service should skip deleting it,
+            //  otherwise invalid numPendingDeletionBlocks could accumulate
+            //  beyond the limit and the following deletion will stop.
             LOG.error("Failed to delete files for block {}", blkLong, e);
+          }
+
+          try {
+            bytesReleased += KeyValueContainerUtil.getBlockLength(blkInfo);
+          } catch (IOException e) {
+            LOG.error("Failed to get block length for block {}", blkLong, e);
           }
         }
       }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/statemachine/background/BlockDeletingService.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/statemachine/background/BlockDeletingService.java
@@ -577,7 +577,8 @@ public class BlockDeletingService extends BackgroundService {
             try {
               bytesReleased += KeyValueContainerUtil.getBlockLength(blkInfo);
             } catch (IOException e) {
-              // TODO: handle the bytesReleased correctly even when exception
+              // TODO: handle the bytesReleased correctly for the unexpected
+              //  exception.
               LOG.error("Failed to get block length for block {}", blkLong, e);
             }
           }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/statemachine/background/BlockDeletingService.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/statemachine/background/BlockDeletingService.java
@@ -560,9 +560,11 @@ public class BlockDeletingService extends BackgroundService {
             continue;
           }
 
+          boolean deleted = false;
           try {
             handler.deleteBlock(container, blkInfo);
             blocksDeleted++;
+            deleted = true;
           } catch (IOException e) {
             // TODO: if deletion of certain block retries exceed the certain
             //  number of times, service should skip deleting it,
@@ -571,10 +573,13 @@ public class BlockDeletingService extends BackgroundService {
             LOG.error("Failed to delete files for block {}", blkLong, e);
           }
 
-          try {
-            bytesReleased += KeyValueContainerUtil.getBlockLength(blkInfo);
-          } catch (IOException e) {
-            LOG.error("Failed to get block length for block {}", blkLong, e);
+          if (deleted) {
+            try {
+              bytesReleased += KeyValueContainerUtil.getBlockLength(blkInfo);
+            } catch (IOException e) {
+              // TODO: handle the bytesReleased correctly even when exception
+              LOG.error("Failed to get block length for block {}", blkLong, e);
+            }
           }
         }
       }


### PR DESCRIPTION
## What changes were proposed in this pull request?

If the block info is null, then blocksDeleted is not increased and the numPendingDeletionBlocks then will not be decreased.

During ```chooseContainerForBlockDeletion```, all containers with such inexistent blocks will still be chosen but no actual deletion happens, and normal block deletion will be blocked.

 
TODO:

Besides this, if deletion of certain block retries exceeds a certain number of times, the service should skip deleting it, otherwise invalid numPendingDeletionBlocks could accumulate beyond the limit and the following deletion will also stop. We should add this as a protection mechianism.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-7259

## How was this patch tested?
Manual test
