### PR TITLE
HDDS-7230. Implement GetKeyInfo API

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/util/CheckedRunnable.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/util/CheckedRunnable.java
@@ -15,39 +15,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.hadoop.ozone.om.helpers;
-
-import org.apache.hadoop.metrics2.lib.MutableRate;
-import org.apache.hadoop.util.Time;
+package org.apache.hadoop.util;
 
 import java.io.IOException;
 
 /**
- * Encloses helpers to deal with metrics.
+ * This presents a block of code with a possibility of throwing an IOException.
  */
-public final class MetricUtil {
-  private MetricUtil() {
-  }
-
-  public static <T, E extends IOException> T captureLatencyNs(
-      MutableRate metric,
-      CheckedSupplier<T, E> block) throws E {
-    long start = Time.monotonicNowNanos();
-    try {
-      return block.get();
-    } finally {
-      metric.add(Time.monotonicNowNanos() - start);
-    }
-  }
-
-  public static <E extends IOException> void captureLatencyNs(
-      MutableRate metric,
-      CheckedRunnable<E> block) throws IOException {
-    long start = Time.monotonicNowNanos();
-    try {
-      block.run();
-    } finally {
-      metric.add(Time.monotonicNowNanos() - start);
-    }
-  }
+@FunctionalInterface
+public interface CheckedRunnable<E extends IOException> {
+  void run() throws E;
 }

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/util/CheckedSupplier.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/util/CheckedSupplier.java
@@ -15,14 +15,15 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.hadoop.ozone.om.helpers;
+package org.apache.hadoop.util;
 
 import java.io.IOException;
 
 /**
- * This presents a block of code with a possibility of throwing an IOException.
+ * Similar to {@link java.util.function.Supplier}, this class presents a block
+ * of code generating a value with a possibility of throwing an IOException.
  */
 @FunctionalInterface
-public interface CheckedRunnable<E extends IOException> {
-  void run() throws E;
+public interface CheckedSupplier<T, E extends IOException> {
+  T get() throws E;
 }

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/checksum/BaseFileChecksumHelper.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/checksum/BaseFileChecksumHelper.java
@@ -162,7 +162,7 @@ public abstract class BaseFileChecksumHelper {
       OmKeyArgs keyArgs =
           new OmKeyArgs.Builder().setVolumeName(volume.getName())
               .setBucketName(bucket.getName()).setKeyName(keyName)
-              .setRefreshPipeline(true).setSortDatanodesInPipeline(true)
+              .setSortDatanodesInPipeline(true)
               .setLatestVersionLocation(true).build();
       keyInfo = ozoneManagerClient.lookupKey(keyArgs);
     }

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/rpc/RpcClient.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/rpc/RpcClient.java
@@ -1242,7 +1242,6 @@ public class RpcClient implements ClientProtocol {
         .setVolumeName(volumeName)
         .setBucketName(bucketName)
         .setKeyName(keyName)
-        .setRefreshPipeline(true)
         .setSortDatanodesInPipeline(topologyAwareReadEnabled)
         .setLatestVersionLocation(getLatestVersionLocation)
         .build();
@@ -1266,7 +1265,6 @@ public class RpcClient implements ClientProtocol {
         .setVolumeName(volumeName)
         .setBucketName(bucketName)
         .setKeyName(keyName)
-        .setRefreshPipeline(true)
         .setSortDatanodesInPipeline(topologyAwareReadEnabled)
         .build();
 
@@ -1412,7 +1410,6 @@ public class RpcClient implements ClientProtocol {
         .setVolumeName(volumeName)
         .setBucketName(bucketName)
         .setKeyName(keyName)
-        .setRefreshPipeline(true)
         .setSortDatanodesInPipeline(topologyAwareReadEnabled)
         .setLatestVersionLocation(getLatestVersionLocation)
         .build();
@@ -1644,7 +1641,6 @@ public class RpcClient implements ClientProtocol {
         .setVolumeName(volumeName)
         .setBucketName(bucketName)
         .setKeyName(keyName)
-        .setRefreshPipeline(true)
         .setSortDatanodesInPipeline(topologyAwareReadEnabled)
         .setLatestVersionLocation(getLatestVersionLocation)
         .build();
@@ -1702,7 +1698,6 @@ public class RpcClient implements ClientProtocol {
             .setVolumeName(omKeyInfo.getVolumeName())
             .setBucketName(omKeyInfo.getBucketName())
             .setKeyName(omKeyInfo.getKeyName())
-            .setRefreshPipeline(true)
             .setSortDatanodesInPipeline(topologyAwareReadEnabled)
             .setLatestVersionLocation(getLatestVersionLocation)
             .build();
@@ -1747,7 +1742,6 @@ public class RpcClient implements ClientProtocol {
         .setVolumeName(volumeName)
         .setBucketName(bucketName)
         .setKeyName(keyName)
-        .setRefreshPipeline(true)
         .setSortDatanodesInPipeline(topologyAwareReadEnabled)
         .setLatestVersionLocation(getLatestVersionLocation)
         .build();

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/OmUtils.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/OmUtils.java
@@ -273,11 +273,11 @@ public final class OmUtils {
     case TenantListUser:
     case EchoRPC:
     case RangerBGSync:
-    case GetKeyInfo:
       // RangerBGSync is a read operation in the sense that it doesn't directly
       // write to OM DB. And therefore it doesn't need a OMClientRequest.
       // Although indirectly the Ranger sync service task could invoke write
       // operation SetRangerServiceVersion.
+    case GetKeyInfo:
       return true;
     case CreateVolume:
     case SetVolumeProperty:

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/OmUtils.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/OmUtils.java
@@ -273,6 +273,7 @@ public final class OmUtils {
     case TenantListUser:
     case EchoRPC:
     case RangerBGSync:
+    case GetKeyInfo:
       // RangerBGSync is a read operation in the sense that it doesn't directly
       // write to OM DB. And therefore it doesn't need a OMClientRequest.
       // Although indirectly the Ranger sync service task could invoke write

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/CheckedRunnable.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/CheckedRunnable.java
@@ -1,0 +1,28 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.ozone.om.helpers;
+
+import java.io.IOException;
+
+/**
+ * This presents a block of code with a possibility of throwing an IOException.
+ */
+@FunctionalInterface
+public interface CheckedRunnable<E extends IOException> {
+  void run() throws E;
+}

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/CheckedSupplier.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/CheckedSupplier.java
@@ -1,0 +1,29 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.ozone.om.helpers;
+
+import java.io.IOException;
+
+/**
+ * Similar to {@link java.util.function.Supplier}, this class presents a block
+ * of code generating a value with a possibility of throwing an IOException.
+ */
+@FunctionalInterface
+public interface CheckedSupplier<T, E extends IOException> {
+  T get() throws E;
+}

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/KeyInfoWithVolumeContext.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/KeyInfoWithVolumeContext.java
@@ -1,0 +1,110 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.ozone.om.helpers;
+
+import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.GetKeyInfoResponse;
+
+import java.io.IOException;
+import java.util.Optional;
+
+/**
+ * Encloses a {@link OmKeyInfo} and optionally a volume context.
+ */
+public class KeyInfoWithVolumeContext {
+  /**
+   * Volume arguments.
+   */
+  private final Optional<OmVolumeArgs> volumeArgs;
+
+  /**
+   * To be used for client-side operations involving KMS like getDEK().
+   */
+  private final Optional<String> userPrincipal;
+
+  private final OmKeyInfo keyInfo;
+
+  public KeyInfoWithVolumeContext(OmVolumeArgs volumeArgs,
+                                  String userPrincipal,
+                                  OmKeyInfo keyInfo) {
+    this.volumeArgs = Optional.ofNullable(volumeArgs);
+    this.userPrincipal = Optional.ofNullable(userPrincipal);
+    this.keyInfo = keyInfo;
+  }
+
+  public static KeyInfoWithVolumeContext fromProtobuf(
+      GetKeyInfoResponse proto) throws IOException {
+    return newBuilder()
+        .setVolumeArgs(proto.hasVolumeInfo() ?
+            OmVolumeArgs.getFromProtobuf(proto.getVolumeInfo()) : null)
+        .setUserPrincipal(proto.getUserPrincipal())
+        .setKeyInfo(OmKeyInfo.getFromProtobuf(proto.getKeyInfo()))
+        .build();
+  }
+
+  public GetKeyInfoResponse toProtobuf(int clientVersion) {
+    GetKeyInfoResponse.Builder builder = GetKeyInfoResponse.newBuilder();
+    volumeArgs.ifPresent(v -> builder.setVolumeInfo(v.getProtobuf()));
+    userPrincipal.ifPresent(builder::setUserPrincipal);
+    builder.setKeyInfo(keyInfo.getProtobuf(clientVersion));
+    return builder.build();
+  }
+
+  public OmKeyInfo getKeyInfo() {
+    return keyInfo;
+  }
+
+  public Optional<OmVolumeArgs> getVolumeArgs() {
+    return volumeArgs;
+  }
+
+  public Optional<String> getUserPrincipal() {
+    return userPrincipal;
+  }
+
+  public static Builder newBuilder() {
+    return new Builder();
+  }
+
+  /**
+   * Builder for KeyInfoWithVolumeContext.
+   */
+  public static class Builder {
+    private OmVolumeArgs volumeArgs;
+    private String userPrincipal;
+    private OmKeyInfo keyInfo;
+
+    public Builder setVolumeArgs(OmVolumeArgs volumeArgs) {
+      this.volumeArgs = volumeArgs;
+      return this;
+    }
+
+    public Builder setUserPrincipal(String userPrincipal) {
+      this.userPrincipal = userPrincipal;
+      return this;
+    }
+
+    public Builder setKeyInfo(OmKeyInfo keyInfo) {
+      this.keyInfo = keyInfo;
+      return this;
+    }
+
+    public KeyInfoWithVolumeContext build() {
+      return new KeyInfoWithVolumeContext(volumeArgs, userPrincipal, keyInfo);
+    }
+  }
+}

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/MetricUtil.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/MetricUtil.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.ozone.om.helpers;
+
+import org.apache.hadoop.metrics2.lib.MutableRate;
+import org.apache.hadoop.util.Time;
+
+import java.io.IOException;
+
+/**
+ * Encloses helpers to deal with metrics.
+ */
+public final class MetricUtil {
+  private MetricUtil() {
+  }
+
+  public static <T, E extends IOException> T captureLatencyNs(
+      MutableRate metric,
+      CheckedSupplier<T, E> block) throws E {
+    long start = Time.monotonicNowNanos();
+    try {
+      return block.get();
+    } finally {
+      metric.add(Time.monotonicNowNanos() - start);
+    }
+  }
+
+  public static <E extends IOException> void captureLatencyNs(
+      MutableRate metric,
+      CheckedRunnable<E> block) throws IOException {
+    long start = Time.monotonicNowNanos();
+    try {
+      block.run();
+    } finally {
+      metric.add(Time.monotonicNowNanos() - start);
+    }
+  }
+}

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmKeyArgs.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmKeyArgs.java
@@ -49,6 +49,7 @@ public final class OmKeyArgs implements Auditable {
   private boolean latestVersionLocation;
   private boolean recursive;
   private boolean headOp;
+  private boolean forceUpdateContainerCacheFromSCM;
 
   @SuppressWarnings("parameternumber")
   private OmKeyArgs(String volumeName, String bucketName, String keyName,
@@ -57,7 +58,8 @@ public final class OmKeyArgs implements Auditable {
       String uploadID, int partNumber,
       Map<String, String> metadataMap, boolean refreshPipeline,
       List<OzoneAcl> acls, boolean sortDatanode,
-      boolean latestVersionLocation, boolean recursive, boolean headOp) {
+      boolean latestVersionLocation, boolean recursive, boolean headOp,
+      boolean forceUpdateContainerCacheFromSCM) {
     this.volumeName = volumeName;
     this.bucketName = bucketName;
     this.keyName = keyName;
@@ -68,12 +70,12 @@ public final class OmKeyArgs implements Auditable {
     this.multipartUploadID = uploadID;
     this.multipartUploadPartNumber = partNumber;
     this.metadata = metadataMap;
-    this.refreshPipeline = refreshPipeline;
     this.acls = acls;
     this.sortDatanodesInPipeline = sortDatanode;
     this.latestVersionLocation = latestVersionLocation;
     this.recursive = recursive;
     this.headOp = headOp;
+    this.forceUpdateContainerCacheFromSCM = forceUpdateContainerCacheFromSCM;
   }
 
   public boolean getIsMultipartKey() {
@@ -132,10 +134,6 @@ public final class OmKeyArgs implements Auditable {
     return locationInfoList;
   }
 
-  public boolean getRefreshPipeline() {
-    return refreshPipeline;
-  }
-
   public boolean getSortDatanodes() {
     return sortDatanodesInPipeline;
   }
@@ -150,6 +148,10 @@ public final class OmKeyArgs implements Auditable {
 
   public boolean isHeadOp() {
     return headOp;
+  }
+
+  public boolean isForceUpdateContainerCacheFromSCM() {
+    return forceUpdateContainerCacheFromSCM;
   }
 
   @Override
@@ -185,11 +187,11 @@ public final class OmKeyArgs implements Auditable {
         .setMultipartUploadID(multipartUploadID)
         .setMultipartUploadPartNumber(multipartUploadPartNumber)
         .addAllMetadata(metadata)
-        .setRefreshPipeline(refreshPipeline)
         .setSortDatanodesInPipeline(sortDatanodesInPipeline)
         .setHeadOp(headOp)
         .setLatestVersionLocation(latestVersionLocation)
-        .setAcls(acls);
+        .setAcls(acls)
+        .setForceUpdateContainerCacheFromSCM(forceUpdateContainerCacheFromSCM);
   }
 
   /**
@@ -212,6 +214,7 @@ public final class OmKeyArgs implements Auditable {
     private List<OzoneAcl> acls;
     private boolean recursive;
     private boolean headOp;
+    private boolean forceUpdateContainerCacheFromSCM;
 
     public Builder setVolumeName(String volume) {
       this.volumeName = volume;
@@ -298,12 +301,18 @@ public final class OmKeyArgs implements Auditable {
       return this;
     }
 
+    public Builder setForceUpdateContainerCacheFromSCM(boolean value) {
+      this.forceUpdateContainerCacheFromSCM = value;
+      return this;
+    }
+
     public OmKeyArgs build() {
       return new OmKeyArgs(volumeName, bucketName, keyName, dataSize,
           replicationConfig, locationInfoList, isMultipartKey,
           multipartUploadID,
           multipartUploadPartNumber, metadata, refreshPipeline, acls,
-          sortDatanodesInPipeline, latestVersionLocation, recursive, headOp);
+          sortDatanodesInPipeline, latestVersionLocation, recursive, headOp,
+          forceUpdateContainerCacheFromSCM);
     }
 
   }

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmKeyArgs.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmKeyArgs.java
@@ -21,6 +21,8 @@ import org.apache.hadoop.hdds.client.ReplicationConfig;
 import org.apache.hadoop.ozone.OzoneAcl;
 import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.hadoop.ozone.audit.Auditable;
+import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.KeyArgs;
+import org.jetbrains.annotations.NotNull;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -43,7 +45,6 @@ public final class OmKeyArgs implements Auditable {
   private final String multipartUploadID;
   private final int multipartUploadPartNumber;
   private Map<String, String> metadata;
-  private boolean refreshPipeline;
   private boolean sortDatanodesInPipeline;
   private List<OzoneAcl> acls;
   private boolean latestVersionLocation;
@@ -56,7 +57,7 @@ public final class OmKeyArgs implements Auditable {
       long dataSize, ReplicationConfig replicationConfig,
       List<OmKeyLocationInfo> locationInfoList, boolean isMultipart,
       String uploadID, int partNumber,
-      Map<String, String> metadataMap, boolean refreshPipeline,
+      Map<String, String> metadataMap,
       List<OzoneAcl> acls, boolean sortDatanode,
       boolean latestVersionLocation, boolean recursive, boolean headOp,
       boolean forceUpdateContainerCacheFromSCM) {
@@ -194,6 +195,21 @@ public final class OmKeyArgs implements Auditable {
         .setForceUpdateContainerCacheFromSCM(forceUpdateContainerCacheFromSCM);
   }
 
+  @NotNull
+  public KeyArgs toProtobuf() {
+    return KeyArgs.newBuilder()
+        .setVolumeName(getVolumeName())
+        .setBucketName(getBucketName())
+        .setKeyName(getKeyName())
+        .setDataSize(getDataSize())
+        .setSortDatanodes(getSortDatanodes())
+        .setLatestVersionLocation(getLatestVersionLocation())
+        .setHeadOp(isHeadOp())
+        .setForceUpdateContainerCacheFromSCM(
+            isForceUpdateContainerCacheFromSCM())
+        .build();
+  }
+
   /**
    * Builder class of OmKeyArgs.
    */
@@ -208,7 +224,6 @@ public final class OmKeyArgs implements Auditable {
     private String multipartUploadID;
     private int multipartUploadPartNumber;
     private Map<String, String> metadata = new HashMap<>();
-    private boolean refreshPipeline;
     private boolean sortDatanodesInPipeline;
     private boolean latestVersionLocation;
     private List<OzoneAcl> acls;
@@ -276,11 +291,6 @@ public final class OmKeyArgs implements Auditable {
       return this;
     }
 
-    public Builder setRefreshPipeline(boolean refresh) {
-      this.refreshPipeline = refresh;
-      return this;
-    }
-
     public Builder setSortDatanodesInPipeline(boolean sort) {
       this.sortDatanodesInPipeline = sort;
       return this;
@@ -310,7 +320,7 @@ public final class OmKeyArgs implements Auditable {
       return new OmKeyArgs(volumeName, bucketName, keyName, dataSize,
           replicationConfig, locationInfoList, isMultipartKey,
           multipartUploadID,
-          multipartUploadPartNumber, metadata, refreshPipeline, acls,
+          multipartUploadPartNumber, metadata, acls,
           sortDatanodesInPipeline, latestVersionLocation, recursive, headOp,
           forceUpdateContainerCacheFromSCM);
     }

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocol/OzoneManagerProtocol.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocol/OzoneManagerProtocol.java
@@ -28,6 +28,7 @@ import org.apache.hadoop.ozone.om.OMConfigKeys;
 import org.apache.hadoop.ozone.om.exceptions.OMException;
 import org.apache.hadoop.ozone.om.helpers.DBUpdates;
 import org.apache.hadoop.ozone.om.helpers.DeleteTenantState;
+import org.apache.hadoop.ozone.om.helpers.KeyInfoWithVolumeContext;
 import org.apache.hadoop.ozone.om.helpers.OmBucketArgs;
 import org.apache.hadoop.ozone.om.helpers.OmBucketInfo;
 import org.apache.hadoop.ozone.om.helpers.OmDeleteKeys;
@@ -271,6 +272,18 @@ public interface OzoneManagerProtocol
    * @throws IOException
    */
   OmKeyInfo lookupKey(OmKeyArgs args) throws IOException;
+
+  /**
+   * Lookup for the container of an existing key.
+   *
+   * @param args the args of the key.
+   * @param assumeS3Context if true OM will automatically lookup the S3
+   *                        volume context and includes in the response.
+   * @return KeyInfoWithVolumeContext includes info that client uses to talk
+   *         to containers and S3 volume context info if assumeS3Context is set.
+   */
+  KeyInfoWithVolumeContext getKeyInfo(OmKeyArgs args, boolean assumeS3Context)
+      throws IOException;
 
   /**
    * Rename an existing key within a bucket.

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocolPB/OzoneManagerProtocolClientSideTranslatorPB.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocolPB/OzoneManagerProtocolClientSideTranslatorPB.java
@@ -780,16 +780,7 @@ public final class OzoneManagerProtocolClientSideTranslatorPB
   @Override
   public OmKeyInfo lookupKey(OmKeyArgs args) throws IOException {
     LookupKeyRequest.Builder req = LookupKeyRequest.newBuilder();
-    KeyArgs keyArgs = KeyArgs.newBuilder()
-        .setVolumeName(args.getVolumeName())
-        .setBucketName(args.getBucketName())
-        .setKeyName(args.getKeyName())
-        .setDataSize(args.getDataSize())
-        .setSortDatanodes(args.getSortDatanodes())
-        .setLatestVersionLocation(args.getLatestVersionLocation())
-        .setHeadOp(args.isHeadOp())
-        .build();
-    req.setKeyArgs(keyArgs);
+    req.setKeyArgs(args.toProtobuf());
 
     OMRequest omRequest = createOMRequest(Type.LookupKey)
         .setLookupKeyRequest(req)
@@ -806,18 +797,7 @@ public final class OzoneManagerProtocolClientSideTranslatorPB
                                              boolean assumeS3Context)
       throws IOException {
     GetKeyInfoRequest.Builder req = GetKeyInfoRequest.newBuilder();
-    KeyArgs keyArgs = KeyArgs.newBuilder()
-        .setVolumeName(args.getVolumeName())
-        .setBucketName(args.getBucketName())
-        .setKeyName(args.getKeyName())
-        .setDataSize(args.getDataSize())
-        .setSortDatanodes(args.getSortDatanodes())
-        .setLatestVersionLocation(args.getLatestVersionLocation())
-        .setHeadOp(args.isHeadOp())
-        .setForceUpdateContainerCacheFromSCM(
-            args.isForceUpdateContainerCacheFromSCM())
-        .build();
-    req.setKeyArgs(keyArgs);
+    req.setKeyArgs(args.toProtobuf());
     req.setAssumeS3Context(assumeS3Context);
 
     OMRequest omRequest = createOMRequest(Type.GetKeyInfo)

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/TestStorageContainerManagerHelper.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/TestStorageContainerManagerHelper.java
@@ -89,7 +89,6 @@ public class TestStorageContainerManagerHelper {
           .setVolumeName(bucket.getVolumeName())
           .setBucketName(bucket.getName())
           .setKeyName(key)
-          .setRefreshPipeline(true)
           .build();
       OmKeyInfo location = cluster.getOzoneManager()
           .lookupKey(arg);

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestBCSID.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestBCSID.java
@@ -132,7 +132,6 @@ public class TestBCSID {
             RatisReplicationConfig
                 .getInstance(HddsProtos.ReplicationFactor.ONE))
         .setKeyName("ratis")
-        .setRefreshPipeline(true)
         .build();
     OmKeyInfo keyInfo = cluster.getOzoneManager().lookupKey(keyArgs);
     List<OmKeyLocationInfo> keyLocationInfos =

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestCloseContainerHandlingByClient.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestCloseContainerHandlingByClient.java
@@ -145,7 +145,6 @@ public class TestCloseContainerHandlingByClient {
         .setBucketName(bucketName)
         .setReplicationConfig(RatisReplicationConfig.getInstance(ONE))
         .setKeyName(keyName)
-        .setRefreshPipeline(true)
         .build();
 
     waitForContainerClose(key);
@@ -179,7 +178,6 @@ public class TestCloseContainerHandlingByClient {
         .setBucketName(bucketName)
         .setReplicationConfig(StandaloneReplicationConfig.getInstance(ONE))
         .setKeyName(keyName)
-        .setRefreshPipeline(true)
         .build();
 
     waitForContainerClose(key);
@@ -214,7 +212,6 @@ public class TestCloseContainerHandlingByClient {
         .setBucketName(bucketName)
         .setReplicationConfig(RatisReplicationConfig.getInstance(ONE))
         .setKeyName(keyName)
-        .setRefreshPipeline(true)
         .build();
 
     waitForContainerClose(key);
@@ -275,7 +272,6 @@ public class TestCloseContainerHandlingByClient {
         .setBucketName(bucketName)
         .setReplicationConfig(RatisReplicationConfig.getInstance(THREE))
         .setKeyName(keyName)
-        .setRefreshPipeline(true)
         .build();
 
     waitForContainerClose(key);
@@ -320,7 +316,6 @@ public class TestCloseContainerHandlingByClient {
         .setBucketName(bucketName)
         .setReplicationConfig(RatisReplicationConfig.getInstance(THREE))
         .setKeyName(keyName)
-        .setRefreshPipeline(true)
         .build();
 
     waitForContainerClose(key);
@@ -383,7 +378,6 @@ public class TestCloseContainerHandlingByClient {
         setBucketName(bucketName)
         .setReplicationConfig(RatisReplicationConfig.getInstance(THREE))
         .setKeyName(keyName)
-        .setRefreshPipeline(true)
         .build();
 
     Assert.assertTrue(key.getOutputStream() instanceof KeyOutputStream);
@@ -418,7 +412,6 @@ public class TestCloseContainerHandlingByClient {
         .setBucketName(bucketName)
         .setReplicationConfig(RatisReplicationConfig.getInstance(ONE))
         .setKeyName(keyName)
-        .setRefreshPipeline(true)
         .build();
 
     waitForContainerClose(key);

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestContainerStateMachineFailures.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestContainerStateMachineFailures.java
@@ -781,7 +781,6 @@ public class TestContainerStateMachineFailures {
         .setVolumeName(volumeName)
         .setBucketName(bucketName)
         .setKeyName(key)
-        .setRefreshPipeline(true)
         .build();
     OmKeyInfo keyInfo = null;
     try {

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestFailureHandlingByClient.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestFailureHandlingByClient.java
@@ -196,7 +196,6 @@ public class TestFailureHandlingByClient {
         .setBucketName(bucketName)
         .setReplicationConfig(RatisReplicationConfig.getInstance(THREE))
         .setKeyName(keyName)
-        .setRefreshPipeline(true)
         .build();
     OmKeyInfo keyInfo = cluster.getOzoneManager().lookupKey(keyArgs);
 
@@ -339,7 +338,6 @@ public class TestFailureHandlingByClient {
         .setBucketName(bucketName)
         .setReplicationConfig(RatisReplicationConfig.getInstance(THREE))
         .setKeyName(keyName)
-        .setRefreshPipeline(true)
         .build();
     OmKeyInfo keyInfo = cluster.getOzoneManager().lookupKey(keyArgs);
 
@@ -401,7 +399,6 @@ public class TestFailureHandlingByClient {
         .setBucketName(bucketName)
         .setReplicationConfig(RatisReplicationConfig.getInstance(THREE))
         .setKeyName(keyName)
-        .setRefreshPipeline(true)
         .build();
     OmKeyInfo keyInfo = cluster.getOzoneManager().lookupKey(keyArgs);
 
@@ -466,7 +463,6 @@ public class TestFailureHandlingByClient {
         .setBucketName(bucketName)
         .setReplicationConfig(RatisReplicationConfig.getInstance(THREE))
         .setKeyName(keyName)
-        .setRefreshPipeline(true)
         .build();
     OmKeyInfo keyInfo = cluster.getOzoneManager().lookupKey(keyArgs);
 
@@ -530,7 +526,6 @@ public class TestFailureHandlingByClient {
         .setBucketName(bucketName)
         .setReplicationConfig(RatisReplicationConfig.getInstance(THREE))
         .setKeyName(keyName)
-        .setRefreshPipeline(true)
         .build();
     OmKeyInfo keyInfo = cluster.getOzoneManager().lookupKey(keyArgs);
 

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestFailureHandlingByClientFlushDelay.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestFailureHandlingByClientFlushDelay.java
@@ -217,7 +217,6 @@ public class TestFailureHandlingByClientFlushDelay {
             RatisReplicationConfig
                 .getInstance(HddsProtos.ReplicationFactor.THREE))
         .setKeyName(keyName)
-        .setRefreshPipeline(true)
         .build();
     OmKeyInfo keyInfo = cluster.getOzoneManager().lookupKey(keyArgs);
 

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestMultiBlockWritesWithDnFailures.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestMultiBlockWritesWithDnFailures.java
@@ -181,7 +181,6 @@ public class TestMultiBlockWritesWithDnFailures {
             RatisReplicationConfig
                 .getInstance(HddsProtos.ReplicationFactor.THREE))
         .setKeyName(keyName)
-        .setRefreshPipeline(true)
         .build();
     OmKeyInfo keyInfo = cluster.getOzoneManager().lookupKey(keyArgs);
     Assert.assertEquals(2 * data.getBytes(UTF_8).length, keyInfo.getDataSize());
@@ -234,7 +233,6 @@ public class TestMultiBlockWritesWithDnFailures {
             RatisReplicationConfig
                 .getInstance(HddsProtos.ReplicationFactor.THREE))
         .setKeyName(keyName)
-        .setRefreshPipeline(true)
         .build();
     OmKeyInfo keyInfo = cluster.getOzoneManager().lookupKey(keyArgs);
     Assert.assertEquals(4 * data.getBytes(UTF_8).length, keyInfo.getDataSize());

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestOzoneAtRestEncryption.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestOzoneAtRestEncryption.java
@@ -382,7 +382,6 @@ public class TestOzoneAtRestEncryption {
         .setVolumeName(volumeName)
         .setBucketName(bucketName)
         .setKeyName(keyName)
-        .setRefreshPipeline(true)
         .build();
     HddsProtos.ReplicationType replicationType =
         HddsProtos.ReplicationType.valueOf(type.toString());

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestOzoneRpcClientAbstract.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestOzoneRpcClientAbstract.java
@@ -855,7 +855,6 @@ public abstract class TestOzoneRpcClientAbstract {
         .setVolumeName(volumeName)
         .setBucketName(bucketName)
         .setKeyName(keyName)
-        .setRefreshPipeline(true)
         .build();
     OmKeyInfo keyInfo = ozoneManager.lookupKey(keyArgs);
     for (OmKeyLocationInfo info:
@@ -1350,7 +1349,7 @@ public abstract class TestOzoneRpcClientAbstract {
     out.close();
     OmKeyArgs.Builder builder = new OmKeyArgs.Builder();
     builder.setVolumeName(volumeName).setBucketName(bucketName)
-        .setKeyName(keyName).setRefreshPipeline(true);
+        .setKeyName(keyName);
     OmKeyInfo keyInfo = ozoneManager.lookupKey(builder.build());
 
     List<OmKeyLocationInfo> locationInfoList =
@@ -1620,7 +1619,7 @@ public abstract class TestOzoneRpcClientAbstract {
     // First, confirm the key info from the client matches the info in OM.
     OmKeyArgs.Builder builder = new OmKeyArgs.Builder();
     builder.setVolumeName(volumeName).setBucketName(bucketName)
-        .setKeyName(keyName).setRefreshPipeline(true);
+        .setKeyName(keyName);
     OmKeyLocationInfo keyInfo = ozoneManager.lookupKey(builder.build()).
         getKeyLocationVersions().get(0).getBlocksLatestVersionOnly().get(0);
     long containerID = keyInfo.getContainerID();

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestOzoneRpcClientWithRatis.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestOzoneRpcClientWithRatis.java
@@ -110,7 +110,7 @@ public class TestOzoneRpcClientWithRatis extends TestOzoneRpcClientAbstract {
     // equal to getClosestNode.
     OmKeyArgs.Builder builder = new OmKeyArgs.Builder();
     builder.setVolumeName(volumeName).setBucketName(bucketName)
-        .setKeyName(keyName).setRefreshPipeline(true);
+        .setKeyName(keyName);
 
     // read key with topology aware read enabled
     try (OzoneInputStream is = bucket.readKey(keyName)) {

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestReadRetries.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestReadRetries.java
@@ -178,7 +178,7 @@ public class TestReadRetries {
     // First, confirm the key info from the client matches the info in OM.
     OmKeyArgs.Builder builder = new OmKeyArgs.Builder();
     builder.setVolumeName(volumeName).setBucketName(bucketName)
-        .setKeyName(keyName).setRefreshPipeline(true);
+        .setKeyName(keyName);
     OmKeyLocationInfo keyInfo = ozoneManager.lookupKey(builder.build()).
         getKeyLocationVersions().get(0).getBlocksLatestVersionOnly().get(0);
     long containerID = keyInfo.getContainerID();

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestSecureOzoneRpcClient.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestSecureOzoneRpcClient.java
@@ -315,7 +315,6 @@ public class TestSecureOzoneRpcClient extends TestOzoneRpcClient {
         .setVolumeName(volumeName)
         .setBucketName(bucketName)
         .setKeyName(keyName)
-        .setRefreshPipeline(true)
         .build();
     HddsProtos.ReplicationType replicationType =
         HddsProtos.ReplicationType.valueOf(type.toString());

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/TestBlockDeletion.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/TestBlockDeletion.java
@@ -201,7 +201,6 @@ public class TestBlockDeletion {
     OmKeyArgs keyArgs = new OmKeyArgs.Builder().setVolumeName(volumeName)
         .setBucketName(bucketName).setKeyName(keyName).setDataSize(0)
         .setReplicationConfig(repConfig)
-        .setRefreshPipeline(true)
         .build();
     List<OmKeyLocationInfoGroup> omKeyLocationInfoGroupList =
         om.lookupKey(keyArgs).getKeyLocationVersions();
@@ -312,7 +311,6 @@ public class TestBlockDeletion {
         .setReplicationConfig(
             RatisReplicationConfig
                 .getInstance(HddsProtos.ReplicationFactor.THREE))
-        .setRefreshPipeline(true)
         .build();
     List<OmKeyLocationInfoGroup> omKeyLocationInfoGroupList =
         om.lookupKey(keyArgs).getKeyLocationVersions();
@@ -508,7 +506,6 @@ public class TestBlockDeletion {
           .setReplicationConfig(
               RatisReplicationConfig
                   .getInstance(HddsProtos.ReplicationFactor.THREE))
-          .setRefreshPipeline(true)
           .build();
       writeClient.deleteKey(keyArgs);
     }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/TestCloseContainerByPipeline.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/TestCloseContainerByPipeline.java
@@ -120,7 +120,7 @@ public class TestCloseContainerByPipeline {
         new OmKeyArgs.Builder().setVolumeName("test").setBucketName("test")
             .setReplicationConfig(RatisReplicationConfig.getInstance(ONE))
             .setDataSize(1024)
-            .setKeyName(keyName).setRefreshPipeline(true).build();
+            .setKeyName(keyName).build();
     OmKeyLocationInfo omKeyLocationInfo =
         cluster.getOzoneManager().lookupKey(keyArgs).getKeyLocationVersions()
             .get(0).getBlocksLatestVersionOnly().get(0);
@@ -178,7 +178,6 @@ public class TestCloseContainerByPipeline {
             .setReplicationConfig(RatisReplicationConfig.getInstance(ONE))
             .setDataSize(1024)
             .setKeyName("standalone")
-            .setRefreshPipeline(true)
             .build();
 
     OmKeyLocationInfo omKeyLocationInfo =
@@ -236,7 +235,7 @@ public class TestCloseContainerByPipeline {
         setBucketName("test")
         .setReplicationConfig(RatisReplicationConfig.getInstance(THREE))
         .setDataSize(1024)
-        .setKeyName("ratis").setRefreshPipeline(true).build();
+        .setKeyName("ratis").build();
 
     OmKeyLocationInfo omKeyLocationInfo =
         cluster.getOzoneManager().lookupKey(keyArgs).getKeyLocationVersions()
@@ -302,7 +301,6 @@ public class TestCloseContainerByPipeline {
             .setReplicationConfig(RatisReplicationConfig.getInstance(ONE))
             .setDataSize(1024)
             .setKeyName(keyName)
-            .setRefreshPipeline(true)
             .build();
 
     OmKeyLocationInfo omKeyLocationInfo =

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/TestCloseContainerHandler.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/TestCloseContainerHandler.java
@@ -109,7 +109,6 @@ public class TestCloseContainerHandler {
             .setReplicationConfig(StandaloneReplicationConfig.getInstance(ONE))
             .setDataSize(1024)
             .setKeyName("test")
-            .setRefreshPipeline(true)
             .build();
 
     OmKeyLocationInfo omKeyLocationInfo =

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/TestDeleteContainerHandler.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/TestDeleteContainerHandler.java
@@ -280,7 +280,6 @@ public class TestDeleteContainerHandler {
             .setBucketName(bucketName)
             .setReplicationConfig(StandaloneReplicationConfig.getInstance(ONE))
             .setKeyName(keyName)
-            .setRefreshPipeline(true)
             .build();
 
     OmKeyLocationInfo omKeyLocationInfo =

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/dn/scanner/TestDataScanner.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/dn/scanner/TestDataScanner.java
@@ -210,7 +210,6 @@ public class TestDataScanner {
         .setVolumeName(volumeName)
         .setBucketName(bucketName)
         .setKeyName(keyName)
-        .setRefreshPipeline(true)
         .build();
     HddsProtos.ReplicationType replicationType =
         HddsProtos.ReplicationType.valueOf(type.toString());

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestContainerReportWithKeys.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestContainerReportWithKeys.java
@@ -123,7 +123,6 @@ public class TestContainerReportWithKeys {
             StandaloneReplicationConfig
                 .getInstance(HddsProtos.ReplicationFactor.ONE))
         .setDataSize(keySize)
-        .setRefreshPipeline(true)
         .build();
 
 

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOMEpochForNonRatis.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOMEpochForNonRatis.java
@@ -146,7 +146,7 @@ public class TestOMEpochForNonRatis {
         .setVolumeName(volumeName)
         .setBucketName(bucketName)
         .setKeyName(keyName)
-        .setRefreshPipeline(true).build());
+        .build());
     long keyTrxnIndex = OmUtils.getTxIdFromObjectId(
         omKeyInfo.getObjectID());
     Assert.assertEquals(3, keyTrxnIndex);

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOmBlockVersioning.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOmBlockVersioning.java
@@ -106,7 +106,6 @@ public class TestOmBlockVersioning {
         .setBucketName(bucketName)
         .setKeyName(keyName)
         .setDataSize(1000)
-        .setRefreshPipeline(true)
         .setAcls(new ArrayList<>())
         .setReplicationConfig(StandaloneReplicationConfig.getInstance(ONE))
         .build();
@@ -186,7 +185,6 @@ public class TestOmBlockVersioning {
         .setBucketName(bucketName)
         .setKeyName(keyName)
         .setDataSize(1000)
-        .setRefreshPipeline(true)
         .build();
 
     String dataString = RandomStringUtils.randomAlphabetic(100);

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/scm/TestStorageContainerManagerHA.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/scm/TestStorageContainerManagerHA.java
@@ -182,7 +182,7 @@ public class TestStorageContainerManagerHA {
         .setReplicationConfig(RatisReplicationConfig.getInstance(
             HddsProtos.ReplicationFactor.ONE))
         .setKeyName(keyName)
-        .setRefreshPipeline(true).build();
+        .build();
     final OmKeyInfo keyInfo = cluster.getOzoneManager().lookupKey(keyArgs);
     final List<OmKeyLocationInfo> keyLocationInfos =
         keyInfo.getKeyLocationVersions().get(0).getBlocksLatestVersionOnly();

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/scm/pipeline/TestSCMPipelineBytesWrittenMetrics.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/scm/pipeline/TestSCMPipelineBytesWrittenMetrics.java
@@ -100,7 +100,7 @@ public class TestSCMPipelineBytesWrittenMetrics {
 
     OmKeyArgs.Builder builder = new OmKeyArgs.Builder();
     builder.setVolumeName(volumeName).setBucketName(bucketName)
-        .setKeyName(keyName).setRefreshPipeline(true);
+        .setKeyName(keyName);
 
     OzoneKeyDetails keyDetails = bucket.getKey(keyName);
     Assertions.assertEquals(keyName, keyDetails.getName());

--- a/hadoop-ozone/interface-client/src/main/proto/OmClientProtocol.proto
+++ b/hadoop-ozone/interface-client/src/main/proto/OmClientProtocol.proto
@@ -123,6 +123,7 @@ enum Type {
   SetRangerServiceVersion = 107;
   RangerBGSync = 109;
   EchoRPC = 110;
+  GetKeyInfo = 111;
 }
 
 message OMRequest {
@@ -228,6 +229,7 @@ message OMRequest {
   optional SetRangerServiceVersionRequest   SetRangerServiceVersionRequest = 107;
   optional RangerBGSyncRequest              RangerBGSyncRequest            = 109;
   optional EchoRPCRequest                   EchoRPCRequest                 = 110;
+  optional GetKeyInfoRequest                GetKeyInfoRequest              = 111;
 }
 
 message OMResponse {
@@ -326,6 +328,7 @@ message OMResponse {
   optional SetRangerServiceVersionResponse   SetRangerServiceVersionResponse = 107;
   optional RangerBGSyncResponse              RangerBGSyncResponse          = 109;
   optional EchoRPCResponse                   EchoRPCResponse               = 110;
+  optional GetKeyInfoResponse                GetKeyInfoResponse            = 111;
 }
 
 enum Status {
@@ -867,6 +870,8 @@ message KeyArgs {
     // When it is a head operation which is to check whether key exist
     optional bool headOp = 18;
     optional hadoop.hdds.ECReplicationConfig ecReplicationConfig = 19;
+    // Force OM to update container cache location from SCL
+    optional bool forceUpdateContainerCacheFromSCM = 20;
 }
 
 message KeyLocation {
@@ -1051,6 +1056,17 @@ message LookupKeyResponse {
     optional uint64 ID = 3;
     // TODO : allow specifying a particular version to read.
     optional uint64 openVersion = 4;
+}
+
+message GetKeyInfoRequest {
+  required KeyArgs keyArgs = 1;
+  optional bool assumeS3Context = 2;
+}
+
+message GetKeyInfoResponse {
+  optional KeyInfo keyInfo = 1;
+  optional VolumeInfo volumeInfo = 2;
+  optional string UserPrincipal = 3;
 }
 
 message RenameKeysRequest {

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/KeyManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/KeyManager.java
@@ -64,6 +64,17 @@ public interface KeyManager extends OzoneManagerFS, IOzoneAcl {
    */
   OmKeyInfo lookupKey(OmKeyArgs args, String clientAddress) throws IOException;
 
+  /**
+   * Return info of an existing key to client side to access to data on
+   * datanodes.
+   * @param args the args of the key provided by client.
+   * @param clientAddress a hint to key manager, order the datanode in returned
+   *                      pipeline by distance between client and datanode.
+   * @return a OmKeyInfo instance client uses to talk to container.
+   * @throws IOException
+   */
+  OmKeyInfo getKeyInfo(OmKeyArgs args, String clientAddress) throws IOException;
+
 
   /**
    * Returns a list of keys represented by {@link OmKeyInfo}

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/KeyManagerImpl.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/KeyManagerImpl.java
@@ -129,7 +129,7 @@ import static org.apache.hadoop.ozone.om.exceptions.OMException.ResultCodes.INVA
 import static org.apache.hadoop.ozone.om.exceptions.OMException.ResultCodes.KEY_NOT_FOUND;
 import static org.apache.hadoop.ozone.om.exceptions.OMException.ResultCodes.SCM_GET_PIPELINE_EXCEPTION;
 import static org.apache.hadoop.ozone.om.exceptions.OMException.ResultCodes.VOLUME_NOT_FOUND;
-import static org.apache.hadoop.ozone.om.helpers.MetricUtil.captureLatencyNs;
+import static org.apache.hadoop.util.MetricUtil.captureLatencyNs;
 import static org.apache.hadoop.ozone.om.lock.OzoneManagerLock.Resource.BUCKET_LOCK;
 import static org.apache.hadoop.ozone.security.acl.OzoneObj.ResourceType.KEY;
 import static org.apache.hadoop.util.Time.monotonicNow;

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/KeyManagerImpl.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/KeyManagerImpl.java
@@ -51,6 +51,7 @@ import org.apache.hadoop.hdds.scm.container.common.helpers.ContainerWithPipeline
 import org.apache.hadoop.hdds.scm.pipeline.Pipeline;
 import org.apache.hadoop.hdds.scm.protocol.ScmBlockLocationProtocol;
 import org.apache.hadoop.hdds.scm.protocol.StorageContainerLocationProtocol;
+import org.apache.hadoop.hdds.scm.storage.BlockLocationInfo;
 import org.apache.hadoop.hdds.utils.BackgroundService;
 import org.apache.hadoop.hdds.utils.db.CodecRegistry;
 import org.apache.hadoop.hdds.utils.db.RDBStore;
@@ -128,6 +129,7 @@ import static org.apache.hadoop.ozone.om.exceptions.OMException.ResultCodes.INVA
 import static org.apache.hadoop.ozone.om.exceptions.OMException.ResultCodes.KEY_NOT_FOUND;
 import static org.apache.hadoop.ozone.om.exceptions.OMException.ResultCodes.SCM_GET_PIPELINE_EXCEPTION;
 import static org.apache.hadoop.ozone.om.exceptions.OMException.ResultCodes.VOLUME_NOT_FOUND;
+import static org.apache.hadoop.ozone.om.helpers.MetricUtil.captureLatencyNs;
 import static org.apache.hadoop.ozone.om.lock.OzoneManagerLock.Resource.BUCKET_LOCK;
 import static org.apache.hadoop.ozone.security.acl.OzoneObj.ResourceType.KEY;
 import static org.apache.hadoop.util.Time.monotonicNow;
@@ -321,10 +323,36 @@ public class KeyManagerImpl implements KeyManager {
   public OmKeyInfo lookupKey(OmKeyArgs args, String clientAddress)
       throws IOException {
     Preconditions.checkNotNull(args);
+
+    OmKeyInfo value = captureLatencyNs(metrics.getLookupReadKeyInfoLatencyNs(),
+        () -> readKeyInfo(args));
+
+    // If operation is head, do not perform any additional steps based on flags.
+    // As head operation does not need any of those details.
+    if (!args.isHeadOp()) {
+
+      // add block token for read.
+      captureLatencyNs(metrics.getLookupGenerateBlockTokenLatencyNs(),
+          () -> addBlockToken4Read(value));
+
+      // Refresh container pipeline info from SCM
+      // based on OmKeyArgs.refreshPipeline flag
+      // value won't be null as the check is done inside try/catch block.
+      captureLatencyNs(metrics.getLookupRefreshLocationLatencyNs(),
+          () -> refresh(value));
+
+      if (args.getSortDatanodes()) {
+        sortDatanodes(clientAddress, value);
+      }
+    }
+
+    return value;
+  }
+
+  private OmKeyInfo readKeyInfo(OmKeyArgs args) throws IOException {
     String volumeName = args.getVolumeName();
     String bucketName = args.getBucketName();
     String keyName = args.getKeyName();
-    long start = Time.monotonicNowNanos();
     metadataManager.getLock().acquireReadLock(BUCKET_LOCK, volumeName,
         bucketName);
 
@@ -355,44 +383,17 @@ public class KeyManagerImpl implements KeyManager {
       metadataManager.getLock().releaseReadLock(BUCKET_LOCK, volumeName,
           bucketName);
     }
-    metrics.addLookupReadKeyInfoLatency(Time.monotonicNowNanos() - start);
 
     if (value == null) {
       if (LOG.isDebugEnabled()) {
         LOG.debug("volume:{} bucket:{} Key:{} not found", volumeName,
-                bucketName, keyName);
+            bucketName, keyName);
       }
       throw new OMException("Key:" + keyName + " not found", KEY_NOT_FOUND);
     }
-
-
     if (args.getLatestVersionLocation()) {
       slimLocationVersion(value);
     }
-
-    // If operation is head, do not perform any additional steps based on flags.
-    // As head operation does not need any of those details.
-    if (!args.isHeadOp()) {
-
-      // add block token for read.
-      start = Time.monotonicNowNanos();
-      addBlockToken4Read(value);
-      metrics.addLookupGenerateBlockTokenLatency(
-          Time.monotonicNowNanos() - start);
-
-      // Refresh container pipeline info from SCM
-      // based on OmKeyArgs.refreshPipeline flag
-      // value won't be null as the check is done inside try/catch block.
-      start = Time.monotonicNowNanos();
-      refresh(value);
-      metrics.addLookupRefreshLocationLatency(Time.monotonicNowNanos() - start);
-
-      if (args.getSortDatanodes()) {
-        sortDatanodes(clientAddress, value);
-      }
-
-    }
-
     return value;
   }
 
@@ -1931,5 +1932,60 @@ public class KeyManagerImpl implements KeyManager {
       return buckInfo.getBucketLayout().isFileSystemOptimized();
     }
     return false;
+  }
+
+  @Override
+  public OmKeyInfo getKeyInfo(OmKeyArgs args, String clientAddress)
+      throws IOException {
+    Preconditions.checkNotNull(args);
+
+    OmKeyInfo value = captureLatencyNs(
+        metrics.getGetKeyInfoReadKeyInfoLatencyNs(),
+        () -> readKeyInfo(args));
+
+    // If operation is head, do not perform any additional steps based on flags.
+    // As head operation does not need any of those details.
+    if (!args.isHeadOp()) {
+
+      // add block token for read.
+      captureLatencyNs(metrics.getGetKeyInfoGenerateBlockTokenLatencyNs(),
+          () -> addBlockToken4Read(value));
+
+      // get container pipeline info from cache.
+      captureLatencyNs(metrics.getGetKeyInfoRefreshLocationLatencyNs(),
+          () -> refreshPipelineFromCache(value,
+              args.isForceUpdateContainerCacheFromSCM()));
+
+      if (args.getSortDatanodes()) {
+        sortDatanodes(clientAddress, value);
+      }
+    }
+    return value;
+  }
+
+  protected void refreshPipelineFromCache(OmKeyInfo keyInfo,
+                                          boolean forceRefresh)
+      throws IOException {
+    Set<Long> containerIds = keyInfo.getKeyLocationVersions().stream()
+        .flatMap(v -> v.getLocationList().stream())
+        .map(BlockLocationInfo::getContainerID)
+        .collect(Collectors.toSet());
+
+    Map<Long, Pipeline> containerLocations =
+        scmClient.getContainerLocations(containerIds, forceRefresh);
+
+    for (OmKeyLocationInfoGroup key : keyInfo.getKeyLocationVersions()) {
+      for (List<OmKeyLocationInfo> omKeyLocationInfoList :
+          key.getLocationLists()) {
+        for (OmKeyLocationInfo omKeyLocationInfo : omKeyLocationInfoList) {
+          Pipeline pipeline = containerLocations.get(
+              omKeyLocationInfo.getContainerID());
+          if (pipeline != null &&
+              !pipeline.equals(omKeyLocationInfo.getPipeline())) {
+            omKeyLocationInfo.setPipeline(pipeline);
+          }
+        }
+      }
+    }
   }
 }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OMMetrics.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OMMetrics.java
@@ -83,6 +83,7 @@ public class OMMetrics {
   private @Metric MutableCounterLong numSetAcl;
   private @Metric MutableCounterLong numGetAcl;
   private @Metric MutableCounterLong numRemoveAcl;
+  private @Metric MutableCounterLong numGetKeyInfo;
 
   // Failure Metrics
   private @Metric MutableCounterLong numVolumeCreateFails;
@@ -150,6 +151,7 @@ public class OMMetrics {
   private @Metric MutableCounterLong numCreateFileFails;
   private @Metric MutableCounterLong numLookupFileFails;
   private @Metric MutableCounterLong numListStatusFails;
+  private @Metric MutableCounterLong getNumGetKeyInfoFails;
 
   // Metrics for total amount of data written
   private @Metric MutableCounterLong totalDataCommitted;
@@ -719,6 +721,15 @@ public class OMMetrics {
 
   public void incNumRemoveAcl() {
     numRemoveAcl.incr();
+  }
+
+  public void incNumGetKeyInfo() {
+    numGetKeyInfo.incr();
+    numKeyOps.incr();
+  }
+
+  public void incNumGetKeyInfoFails() {
+    getNumGetKeyInfoFails.incr();
   }
 
   @VisibleForTesting

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OMPerformanceMetrics.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OMPerformanceMetrics.java
@@ -58,6 +58,25 @@ public class OMPerformanceMetrics {
   @Metric(about = "resolveBucketLink latency nanoseconds")
   private MutableRate lookupResolveBucketLatencyNs;
 
+
+  @Metric(about = "Overall getKeyInfo in nanoseconds")
+  private MutableRate getKeyInfoLatencyNs;
+
+  @Metric(about = "Read key info from db in getKeyInfo")
+  private MutableRate getKeyInfoReadKeyInfoLatencyNs;
+
+  @Metric(about = "Block token generation latency in getKeyInfo")
+  private MutableRate getKeyInfoGenerateBlockTokenLatencyNs;
+
+  @Metric(about = "Refresh location latency in getKeyInfo")
+  private MutableRate getKeyInfoRefreshLocationLatencyNs;
+
+  @Metric(about = "ACLs check in getKeyInfo")
+  private MutableRate getKeyInfoAclCheckLatencyNs;
+
+  @Metric(about = "resolveBucketLink latency in getKeyInfo")
+  private MutableRate getKeyInfoResolveBucketLatencyNs;
+
   @Metric(about = "s3VolumeInfo latency nanoseconds")
   private MutableRate s3VolumeContextLatencyNs;
 
@@ -66,27 +85,52 @@ public class OMPerformanceMetrics {
     lookupLatencyNs.add(latencyInNs);
   }
 
-  public void addLookupGenerateBlockTokenLatency(long latencyInNs) {
-    lookupGenerateBlockTokenLatencyNs.add(latencyInNs);
+  public MutableRate getLookupRefreshLocationLatencyNs() {
+    return lookupRefreshLocationLatencyNs;
   }
 
-  public void addLookupRefreshLocationLatency(long latencyInNs) {
-    lookupRefreshLocationLatencyNs.add(latencyInNs);
+
+  public MutableRate getLookupGenerateBlockTokenLatencyNs() {
+    return lookupGenerateBlockTokenLatencyNs;
   }
 
-  public void addLookupAclCheckLatency(long latencyInNs) {
-    lookupAclCheckLatencyNs.add(latencyInNs);
+  public MutableRate getLookupReadKeyInfoLatencyNs() {
+    return lookupReadKeyInfoLatencyNs;
   }
 
-  public void addLookupReadKeyInfoLatency(long latencyInNs) {
-    lookupReadKeyInfoLatencyNs.add(latencyInNs);
+  public MutableRate getLookupAclCheckLatencyNs() {
+    return lookupAclCheckLatencyNs;
   }
 
   public void addS3VolumeContextLatencyNs(long latencyInNs) {
     s3VolumeContextLatencyNs.add(latencyInNs);
   }
 
-  public void addLookupResolveBucketLatencyNs(long latencyInNs) {
-    lookupResolveBucketLatencyNs.add(latencyInNs);
+  public MutableRate getLookupResolveBucketLatencyNs() {
+    return lookupResolveBucketLatencyNs;
+  }
+
+  public void addGetKeyInfoLatencyNs(long value) {
+    getKeyInfoLatencyNs.add(value);
+  }
+
+  public MutableRate getGetKeyInfoAclCheckLatencyNs() {
+    return getKeyInfoAclCheckLatencyNs;
+  }
+
+  public MutableRate getGetKeyInfoGenerateBlockTokenLatencyNs() {
+    return getKeyInfoGenerateBlockTokenLatencyNs;
+  }
+
+  public MutableRate getGetKeyInfoReadKeyInfoLatencyNs() {
+    return getKeyInfoReadKeyInfoLatencyNs;
+  }
+
+  public MutableRate getGetKeyInfoRefreshLocationLatencyNs() {
+    return getKeyInfoRefreshLocationLatencyNs;
+  }
+
+  public MutableRate getGetKeyInfoResolveBucketLatencyNs() {
+    return getKeyInfoResolveBucketLatencyNs;
   }
 }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
@@ -74,6 +74,7 @@ import org.apache.hadoop.hdds.utils.db.Table;
 import org.apache.hadoop.hdds.utils.db.Table.KeyValue;
 import org.apache.hadoop.hdds.utils.db.TableIterator;
 import org.apache.hadoop.ozone.OzoneManagerVersion;
+import org.apache.hadoop.ozone.om.helpers.KeyInfoWithVolumeContext;
 import org.apache.hadoop.ozone.om.service.OMRangerBGSyncService;
 import org.apache.hadoop.ozone.util.OzoneNetUtils;
 import org.apache.hadoop.ozone.om.helpers.BucketLayout;
@@ -270,6 +271,7 @@ import static org.apache.hadoop.ozone.om.exceptions.OMException.ResultCodes.INVA
 import static org.apache.hadoop.ozone.om.exceptions.OMException.ResultCodes.INVALID_REQUEST;
 import static org.apache.hadoop.ozone.om.exceptions.OMException.ResultCodes.PERMISSION_DENIED;
 import static org.apache.hadoop.ozone.om.exceptions.OMException.ResultCodes.TOKEN_ERROR_OTHER;
+import static org.apache.hadoop.ozone.om.helpers.MetricUtil.captureLatencyNs;
 import static org.apache.hadoop.ozone.om.lock.OzoneManagerLock.Resource.BUCKET_LOCK;
 import static org.apache.hadoop.ozone.om.lock.OzoneManagerLock.Resource.VOLUME_LOCK;
 import static org.apache.hadoop.ozone.om.ratis.OzoneManagerRatisServer.RaftServerStatus.LEADER_AND_READY;
@@ -2815,25 +2817,25 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
   @Override
   public OmKeyInfo lookupKey(OmKeyArgs args) throws IOException {
     long start = Time.monotonicNowNanos();
-    ResolvedBucket bucket = resolveBucketLink(args);
-    perfMetrics.addLookupResolveBucketLatencyNs(
-        Time.monotonicNowNanos() - start);
+    ResolvedBucket bucket = captureLatencyNs(
+        perfMetrics.getLookupResolveBucketLatencyNs(),
+        () -> resolveBucketLink(args));
 
     if (isAclEnabled) {
-      long startAcl = Time.monotonicNowNanos();
-      checkAcls(ResourceType.KEY, StoreType.OZONE, ACLType.READ,
-          bucket.realVolume(), bucket.realBucket(), args.getKeyName());
-      perfMetrics.addLookupAclCheckLatency(Time.monotonicNowNanos() - startAcl);
+      captureLatencyNs(perfMetrics.getLookupAclCheckLatencyNs(),
+          () -> checkAcls(ResourceType.KEY, StoreType.OZONE, ACLType.READ,
+            bucket.realVolume(), bucket.realBucket(), args.getKeyName())
+      );
     }
 
     boolean auditSuccess = true;
     Map<String, String> auditMap = bucket.audit(args.toAuditMap());
 
-    args = bucket.update(args);
+    OmKeyArgs resolvedArgs = bucket.update(args);
 
     try {
       metrics.incNumKeyLookups();
-      return keyManager.lookupKey(args, getClientAddress());
+      return keyManager.lookupKey(resolvedArgs, getClientAddress());
     } catch (Exception ex) {
       metrics.incNumKeyLookupFails();
       auditSuccess = false;
@@ -2847,6 +2849,67 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
       }
 
       perfMetrics.addLookupLatency(Time.monotonicNowNanos() - start);
+    }
+  }
+
+  @Override
+  public KeyInfoWithVolumeContext getKeyInfo(final OmKeyArgs args,
+                                             boolean assumeS3Context)
+      throws IOException {
+    long start = Time.monotonicNowNanos();
+
+    java.util.Optional<S3VolumeContext> s3VolumeContext =
+        java.util.Optional.empty();
+
+    final OmKeyArgs resolvedVolumeArgs;
+    if (assumeS3Context) {
+      S3VolumeContext context = getS3VolumeContext();
+      s3VolumeContext = java.util.Optional.of(context);
+      resolvedVolumeArgs = args.toBuilder()
+          .setVolumeName(context.getOmVolumeArgs().getVolume())
+          .build();
+    } else {
+      resolvedVolumeArgs = args;
+    }
+
+    final ResolvedBucket bucket = captureLatencyNs(
+        perfMetrics.getGetKeyInfoResolveBucketLatencyNs(),
+        () -> resolveBucketLink(resolvedVolumeArgs));
+
+    if (isAclEnabled) {
+      captureLatencyNs(perfMetrics.getGetKeyInfoAclCheckLatencyNs(), () ->
+          checkAcls(ResourceType.KEY, StoreType.OZONE, ACLType.READ,
+              bucket.realVolume(), bucket.realBucket(), args.getKeyName())
+      );
+    }
+
+    boolean auditSuccess = true;
+    OmKeyArgs resolvedArgs = bucket.update(args);
+
+    try {
+      metrics.incNumGetKeyInfo();
+      OmKeyInfo keyInfo =
+          keyManager.getKeyInfo(resolvedArgs, getClientAddress());
+      KeyInfoWithVolumeContext.Builder builder = KeyInfoWithVolumeContext
+          .newBuilder()
+          .setKeyInfo(keyInfo);
+      s3VolumeContext.ifPresent(context -> {
+        builder.setVolumeArgs(context.getOmVolumeArgs());
+        builder.setUserPrincipal(context.getUserPrincipal());
+      });
+      return builder.build();
+    } catch (Exception ex) {
+      metrics.incNumGetKeyInfoFails();
+      auditSuccess = false;
+      AUDIT.logReadFailure(buildAuditMessageForFailure(OMAction.READ_KEY,
+          bucket.audit(resolvedVolumeArgs.toAuditMap()), ex));
+      throw ex;
+    } finally {
+      if (auditSuccess) {
+        AUDIT.logReadSuccess(buildAuditMessageForSuccess(OMAction.READ_KEY,
+            bucket.audit(resolvedVolumeArgs.toAuditMap())));
+      }
+      perfMetrics.addGetKeyInfoLatencyNs(Time.monotonicNowNanos() - start);
     }
   }
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
@@ -271,7 +271,7 @@ import static org.apache.hadoop.ozone.om.exceptions.OMException.ResultCodes.INVA
 import static org.apache.hadoop.ozone.om.exceptions.OMException.ResultCodes.INVALID_REQUEST;
 import static org.apache.hadoop.ozone.om.exceptions.OMException.ResultCodes.PERMISSION_DENIED;
 import static org.apache.hadoop.ozone.om.exceptions.OMException.ResultCodes.TOKEN_ERROR_OTHER;
-import static org.apache.hadoop.ozone.om.helpers.MetricUtil.captureLatencyNs;
+import static org.apache.hadoop.util.MetricUtil.captureLatencyNs;
 import static org.apache.hadoop.ozone.om.lock.OzoneManagerLock.Resource.BUCKET_LOCK;
 import static org.apache.hadoop.ozone.om.lock.OzoneManagerLock.Resource.VOLUME_LOCK;
 import static org.apache.hadoop.ozone.om.ratis.OzoneManagerRatisServer.RaftServerStatus.LEADER_AND_READY;

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzonePrefixPathImpl.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzonePrefixPathImpl.java
@@ -56,7 +56,6 @@ public class OzonePrefixPathImpl implements OzonePrefixPath {
         .setVolumeName(volumeName)
         .setBucketName(bucketName)
         .setKeyName(keyPrefix)
-        .setRefreshPipeline(false)
         .setHeadOp(true)
         .build();
     try {
@@ -158,7 +157,6 @@ public class OzonePrefixPathImpl implements OzonePrefixPath {
           .setVolumeName(volumeName)
           .setBucketName(bucketName)
           .setKeyName(keyPrefix)
-          .setRefreshPipeline(false)
           .setHeadOp(true)
           .build();
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/protocolPB/OzoneManagerRequestHandler.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/protocolPB/OzoneManagerRequestHandler.java
@@ -39,6 +39,7 @@ import org.apache.hadoop.ozone.om.OzoneManagerPrepareState;
 import org.apache.hadoop.ozone.om.exceptions.OMException;
 import org.apache.hadoop.ozone.om.helpers.BucketLayout;
 import org.apache.hadoop.ozone.om.helpers.DBUpdates;
+import org.apache.hadoop.ozone.om.helpers.KeyInfoWithVolumeContext;
 import org.apache.hadoop.ozone.om.helpers.OmBucketInfo;
 import org.apache.hadoop.ozone.om.helpers.OmKeyArgs;
 import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
@@ -70,6 +71,8 @@ import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.Finaliz
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.FinalizeUpgradeProgressResponse;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.GetFileStatusRequest;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.GetFileStatusResponse;
+import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.GetKeyInfoRequest;
+import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.GetKeyInfoResponse;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.InfoBucketRequest;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.InfoBucketResponse;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.InfoVolumeRequest;
@@ -276,6 +279,10 @@ public class OzoneManagerRequestHandler implements RequestHandler {
         TenantListUserResponse listUserResponse = tenantListUsers(
             request.getTenantListUserRequest());
         responseBuilder.setTenantListUserResponse(listUserResponse);
+        break;
+      case GetKeyInfo:
+        responseBuilder.setGetKeyInfoResponse(
+            getKeyInfo(request.getGetKeyInfoRequest(), request.getVersion()));
         break;
       default:
         responseBuilder.setSuccess(false);
@@ -497,6 +504,25 @@ public class OzoneManagerRequestHandler implements RequestHandler {
     resp.setKeyInfo(keyInfo.getProtobuf(keyArgs.getHeadOp(), clientVersion));
 
     return resp.build();
+  }
+
+  private GetKeyInfoResponse getKeyInfo(GetKeyInfoRequest request,
+                                        int clientVersion) throws IOException {
+    KeyArgs keyArgs = request.getKeyArgs();
+    OmKeyArgs omKeyArgs = new OmKeyArgs.Builder()
+        .setVolumeName(keyArgs.getVolumeName())
+        .setBucketName(keyArgs.getBucketName())
+        .setKeyName(keyArgs.getKeyName())
+        .setLatestVersionLocation(keyArgs.getLatestVersionLocation())
+        .setSortDatanodesInPipeline(keyArgs.getSortDatanodes())
+        .setHeadOp(keyArgs.getHeadOp())
+        .setForceUpdateContainerCacheFromSCM(
+            keyArgs.getForceUpdateContainerCacheFromSCM())
+        .build();
+    KeyInfoWithVolumeContext keyInfo = impl.getKeyInfo(omKeyArgs,
+        request.getAssumeS3Context());
+
+    return keyInfo.toProtobuf(clientVersion);
   }
 
   @RequestFeatureValidator(

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/protocolPB/OzoneManagerRequestHandler.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/protocolPB/OzoneManagerRequestHandler.java
@@ -901,7 +901,6 @@ public class OzoneManagerRequestHandler implements RequestHandler {
         .setVolumeName(keyArgs.getVolumeName())
         .setBucketName(keyArgs.getBucketName())
         .setKeyName(keyArgs.getKeyName())
-        .setRefreshPipeline(true)
         .build();
 
     GetFileStatusResponse.Builder rb = GetFileStatusResponse.newBuilder();
@@ -1013,7 +1012,6 @@ public class OzoneManagerRequestHandler implements RequestHandler {
         .setVolumeName(keyArgs.getVolumeName())
         .setBucketName(keyArgs.getBucketName())
         .setKeyName(keyArgs.getKeyName())
-        .setRefreshPipeline(true)
         .setSortDatanodesInPipeline(keyArgs.getSortDatanodes())
         .setLatestVersionLocation(keyArgs.getLatestVersionLocation())
         .build();
@@ -1088,7 +1086,6 @@ public class OzoneManagerRequestHandler implements RequestHandler {
         .setVolumeName(keyArgs.getVolumeName())
         .setBucketName(keyArgs.getBucketName())
         .setKeyName(keyArgs.getKeyName())
-        .setRefreshPipeline(true)
         .setLatestVersionLocation(keyArgs.getLatestVersionLocation())
         .setHeadOp(keyArgs.getHeadOp())
         .build();

--- a/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/OzoneClientUtils.java
+++ b/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/OzoneClientUtils.java
@@ -210,7 +210,7 @@ public final class OzoneClientUtils {
     }
     OmKeyArgs keyArgs = new OmKeyArgs.Builder().setVolumeName(volume.getName())
         .setBucketName(bucket.getName()).setKeyName(keyName)
-        .setRefreshPipeline(true).setSortDatanodesInPipeline(true)
+        .setSortDatanodesInPipeline(true)
         .setLatestVersionLocation(true).build();
     OmKeyInfo keyInfo = rpcClient.getOzoneManagerClient().lookupKey(keyArgs);
 

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/ChunkKeyHandler.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/ChunkKeyHandler.java
@@ -97,7 +97,6 @@ public class ChunkKeyHandler extends KeyHandler implements
             .setVolumeName(volumeName)
             .setBucketName(bucketName)
             .setKeyName(keyName)
-            .setRefreshPipeline(true)
             .build();
     OmKeyInfo keyInfo = ozoneManagerClient.lookupKey(keyArgs);
     // querying  the keyLocations.The OM is queried to get containerID and


### PR DESCRIPTION
## What changes were proposed in this pull request?

Server-side implementation of GetKeyInfo API, which implies 2 primary purposes:
1. It leverages the container location cache to avoid calling SCM to get block location information.
2. It allows S3G to call without a volume name, which the API can assume. S3G can call GetKeyInfo with assumeS3Context and OM will resolve the s3 volume context (volume name and s3 auth) and include it in the API response. This saves S3G another call to get S3VolumeContext before reading a key.

https://issues.apache.org/jira/browse/HDDS-7230

This PR only includes server-side implementation. Full client-side integration and tests will be done by HDDS-7231.
## How was this patch tested?
Unit tests and standard CI: https://github.com/duongkame/ozone/actions/runs/3131964309

