### PR TITLE
HDDS-7141. Recon: Improve Disk Usage Page

### DIFF
--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/index.less
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/index.less
@@ -19,14 +19,11 @@
 body {
   margin: 0;
   padding: 0;
-  font-family: -apple-system, BlinkMacSystemFont, 'Roboto', 'Segoe UI',
-    'Oxygen', 'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans',
-    'Helvetica Neue', sans-serif;
+  font-family: 'Roboto', sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
 }
 
 code {
-  font-family: source-code-pro, Menlo, Monaco, Consolas, 'Courier New',
-    monospace;
+  font-family: 'Roboto', sans-serif;
 }

--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/index.less
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/index.less
@@ -19,11 +19,14 @@
 body {
   margin: 0;
   padding: 0;
-  font-family: 'Roboto', sans-serif;
+  font-family: -apple-system, BlinkMacSystemFont, 'Roboto', 'Segoe UI',
+    'Oxygen', 'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans',
+    'Helvetica Neue', sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
 }
 
 code {
-  font-family: 'Roboto', sans-serif;
+  font-family: source-code-pro, Menlo, Monaco, Consolas, 'Courier New',
+    monospace;
 }

--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/views/diskUsage/diskUsage.less
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/views/diskUsage/diskUsage.less
@@ -63,7 +63,7 @@
   }
 }
 
- .input {
+.input {
     padding-left: 5px;
     margin-right: 10px;
     display: inline-block;

--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/views/diskUsage/diskUsage.less
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/views/diskUsage/diskUsage.less
@@ -63,7 +63,7 @@
   }
 }
 
-  .input {
+ .input {
     padding-left: 5px;
     margin-right: 10px;
     display: inline-block;

--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/views/diskUsage/diskUsage.less
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/views/diskUsage/diskUsage.less
@@ -68,16 +68,15 @@
     margin-right: 10px;
     display: inline-block;
     width: 300px;
-  }
-  
-  .metadatainformation {
-    font-size: 14px;
-    fill: rgba(0, 0, 0, 0.65) !important;
-    line-height: 1.5;
-    font-feature-settings: 'tnum', "tnum";
-  }
-  
- .ant-drawer-open .ant-drawer-mask
-  {
-    opacity: 0 !important;
-  }
+}
+
+.metadatainformation {
+  font-size: 14px;
+  fill: rgba(0, 0, 0, 0.65) !important;
+  line-height: 1.5;
+  font-feature-settings: 'tnum', "tnum";
+}
+
+.ant-drawer-open .ant-drawer-mask {
+  opacity: 0 !important;
+}

--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/views/diskUsage/diskUsage.less
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/views/diskUsage/diskUsage.less
@@ -38,15 +38,46 @@
     margin-right: 25px;
   }
 
-  h3 {
-    display: inline-block;
-    padding-right: 5px;
+  .legendtext {
+    fill: rgba(0, 0, 0, 0.65) !important;
+    line-height: 1.5;
+    font-size: 16px !important;
+    font-feature-settings: 'tnum', "tnum";
+    font-variant: tabular-nums;
+  }
+
+  .gtitle {
+    font-size: 22px;
+    font-weight: 500 !important;
+    fill: rgba(0, 0, 0, 0.60) !important;
+    font-feature-settings: 'tnum', "tnum";
+    font-variant: tabular-nums;
+  }
+
+  .slicetext {
+    fill: rgba(0, 0, 0, 0.60) !important;
+    font-size: 17px !important;
+    line-height: 1.5;
+    font-feature-settings: 'tnum', "tnum";
+    font-variant: tabular-nums;
   }
 }
 
-.input {
+  .input {
     padding-left: 5px;
     margin-right: 10px;
     display: inline-block;
     width: 300px;
-}
+  }
+  
+  .metadatainformation {
+    font-size: 14px;
+    fill: rgba(0, 0, 0, 0.65) !important;
+    line-height: 1.5;
+    font-feature-settings: 'tnum', "tnum";
+  }
+  
+ .ant-drawer-open .ant-drawer-mask
+  {
+    opacity: 0 !important;
+  }

--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/views/diskUsage/diskUsage.tsx
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/views/diskUsage/diskUsage.tsx
@@ -172,13 +172,13 @@ export class DiskUsage extends React.Component<Record<string, object>, IDUState>
           return (subpath.isKey || subpathName === OTHER_PATH_NAME) ? subpathName : subpathName + '/';
         });
 
-       values = subpaths.map(subpath => {
-        return subpath.size / dataSize;
-      });
+        values = subpaths.map(subpath => {
+          return subpath.size / dataSize;
+        });
 
-       percentage = values.map(value => {
-        return (value * 100).toFixed(2);
-      });
+        percentage = values.map(value => {
+          return (value * 100).toFixed(2);
+        });
 
         sizeStr = subpaths.map(subpath => {
           return this.byteToSize(subpath.size, 1);

--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/views/diskUsage/diskUsage.tsx
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/views/diskUsage/diskUsage.tsx
@@ -419,27 +419,27 @@ export class DiskUsage extends React.Component<Record<string, object>, IDUState>
                 </Col>
               </Row>
               <Row>
-                {(duResponse.size > 0)?
-                    <div style={{height: 800}}>
+                {(duResponse.size > 0) ?
+                  <div style={{height: 800}}>
                     <div className='metadatainformation'>
                       <br/> {' '}
                         You can also view its metadata details by clicking the top right button.
                     </div>
                     <Plot
-                    data={plotData}
-                    layout={
-                      {
-                        width: 800,
-                        height: 750,
-                        font: {
-                          family: 'Roboto, sans-serif',
-                          size: 15
-                        },
-                        showlegend: true,
-                        title: 'Disk Usage for ' + returnPath + ' (Total Size: ' + this.byteToSize(duResponse.size, 1) + ')'
+                      data={plotData}
+                      layout={
+                        {
+                          width: 800,
+                          height: 750,
+                          font: {
+                            family: 'Roboto, sans-serif',
+                            size: 15
+                          },
+                          showlegend: true,
+                          title: 'Disk Usage for ' + returnPath + ' (Total Size: ' + this.byteToSize(duResponse.size, 1) + ')'
+                        }
                       }
-                    }
-                    onClick={(duResponse.subPathCount === 0) ? undefined : e => this.clickPieSection(e, returnPath)}/>
+                      onClick={(duResponse.subPathCount === 0) ? undefined : e => this.clickPieSection(e, returnPath)}/>
                   </div>
                     :
                   <div style={{height: 800}} className='metadatainformation'><br/>

--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/views/diskUsage/diskUsage.tsx
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/views/diskUsage/diskUsage.tsx
@@ -182,7 +182,7 @@ export class DiskUsage extends React.Component<Record<string, object>, IDUState>
 
         sizeStr = subpaths.map(subpath => {
           return this.byteToSize(subpath.size, 1);
-        }); 
+        });
       }
     
       this.setState({
@@ -421,10 +421,6 @@ export class DiskUsage extends React.Component<Record<string, object>, IDUState>
               <Row>
                 {(duResponse.size > 0) ?
                   <div style={{height: 800}}>
-                    <div className='metadatainformation'>
-                      <br/> {' '}
-                        You can also view its metadata details by clicking the top right button.
-                    </div>
                     <Plot
                       data={plotData}
                       layout={

--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/views/diskUsage/diskUsage.tsx
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/views/diskUsage/diskUsage.tsx
@@ -172,12 +172,12 @@ export class DiskUsage extends React.Component<Record<string, object>, IDUState>
           return (subpath.isKey || subpathName === OTHER_PATH_NAME) ? subpathName : subpathName + '/';
         });
 
-        values = subpaths.map(subpath => {
-          return subpath.size / dataSize;
-        });
+       values = subpaths.map(subpath => {
+         return subpath.size / dataSize;
+       });
 
         percentage = values.map(value => {
-          return (value * 100).toFixed(2);
+         return (value * 100).toFixed(2);
         });
 
         sizeStr = subpaths.map(subpath => {

--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/views/diskUsage/diskUsage.tsx
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/views/diskUsage/diskUsage.tsx
@@ -157,7 +157,7 @@ export class DiskUsage extends React.Component<Record<string, object>, IDUState>
       if (duResponse.subPathCount === 0 || subpaths === 0) {
         pieces = duResponse && duResponse.path.split('/');
         subpathName = pieces[pieces.length - 1];
-        pathLabels = [((duResponse.path).isKey || subpathName === OTHER_PATH_NAME) ? subpathName : subpathName];
+        pathLabels = [subpathName];
         values = [0.1];
         percentage = [100.00];
         sizeStr = [this.byteToSize(duResponse.size, 1)];
@@ -172,13 +172,13 @@ export class DiskUsage extends React.Component<Record<string, object>, IDUState>
           return (subpath.isKey || subpathName === OTHER_PATH_NAME) ? subpathName : subpathName + '/';
         });
 
-        values = subpaths.map(subpath => {
-          return subpath.size / dataSize;
-        });
+      values = subpaths.map(subpath => {
+        return subpath.size / dataSize;
+      });
 
-        percentage = values.map(value => {
-          return (value * 100).toFixed(2);
-        });
+      percentage = values.map(value => {
+        return (value * 100).toFixed(2);
+      });
 
         sizeStr = subpaths.map(subpath => {
           return this.byteToSize(subpath.size, 1);
@@ -419,8 +419,7 @@ export class DiskUsage extends React.Component<Record<string, object>, IDUState>
                 </Col>
               </Row>
               <Row>
-                {(duResponse.size > 0) ?
-                  ((duResponse.size > 0 && duResponse.subPathCount === 0) ?
+                {(duResponse.size > 0)?
                     <div style={{height: 800}}>
                     <div  className='metadatainformation'>
                       <br/> {' '}
@@ -439,24 +438,10 @@ export class DiskUsage extends React.Component<Record<string, object>, IDUState>
                         showlegend: true,
                         title: 'Disk Usage for ' + returnPath + ' (Total Size: ' + this.byteToSize(duResponse.size, 1) + ')'
                       }
-                    }/>
+                    }
+                    onClick={(duResponse.subPathCount === 0) ? undefined : e => this.clickPieSection(e, returnPath)}/>
                   </div>
                     :
-                    <Plot
-                      data={plotData}
-                      layout={
-                        {
-                          width: 800,
-                          height: 750,
-                          font: {
-                            family: 'Roboto, sans-serif',
-                            size: 15
-                          },
-                          showlegend: true,
-                          title: 'Disk Usage for ' + returnPath + ' (Total Size: ' + this.byteToSize(duResponse.size, 1) + ')'
-                        }
-                      }
-                      onClick={e => this.clickPieSection(e, returnPath)}/>) :
                   <div style={{height: 800}} className='metadatainformation'><br/>
                     This object is empty. Add files to it to see a visualization on disk usage.{' '}<br/>
                       You can also view its metadata details by clicking the top right button.

--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/views/diskUsage/diskUsage.tsx
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/views/diskUsage/diskUsage.tsx
@@ -173,12 +173,12 @@ export class DiskUsage extends React.Component<Record<string, object>, IDUState>
         });
 
        values = subpaths.map(subpath => {
-         return subpath.size / dataSize;
+        return subpath.size / dataSize;
        });
 
-        percentage = values.map(value => {
-         return (value * 100).toFixed(2);
-        });
+       percentage = values.map(value => {
+        return (value * 100).toFixed(2);
+       });
 
         sizeStr = subpaths.map(subpath => {
           return this.byteToSize(subpath.size, 1);

--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/views/diskUsage/diskUsage.tsx
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/views/diskUsage/diskUsage.tsx
@@ -174,11 +174,11 @@ export class DiskUsage extends React.Component<Record<string, object>, IDUState>
 
        values = subpaths.map(subpath => {
         return subpath.size / dataSize;
-       });
+      });
 
        percentage = values.map(value => {
         return (value * 100).toFixed(2);
-       });
+      });
 
         sizeStr = subpaths.map(subpath => {
           return this.byteToSize(subpath.size, 1);

--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/views/diskUsage/diskUsage.tsx
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/views/diskUsage/diskUsage.tsx
@@ -155,7 +155,7 @@ export class DiskUsage extends React.Component<Record<string, object>, IDUState>
       let pathLabels, values, percentage, sizeStr, pieces, subpathName;
 
       if (duResponse.subPathCount === 0 || subpaths === 0) {
-        pieces = duResponse && duResponse.path.split('/');
+        pieces = duResponse && duResponse.path != null && duResponse.path.split('/');
         subpathName = pieces[pieces.length - 1];
         pathLabels = [subpathName];
         values = [0.1];

--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/views/diskUsage/diskUsage.tsx
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/views/diskUsage/diskUsage.tsx
@@ -152,26 +152,39 @@ export class DiskUsage extends React.Component<Record<string, object>, IDUState>
         subpaths.push(other);
       }
 
-      const pathLabels = subpaths.map(subpath => {
-        // The return subPath must be normalized in a format with
-        // a leading slash and without trailing slash
-        const pieces = subpath.path.split('/');
-        const subpathName = pieces[pieces.length - 1];
-        // Differentiate key without trailing slash
-        return (subpath.isKey || subpathName === OTHER_PATH_NAME) ? subpathName : subpathName + '/';
-      });
+      let pathLabels, values, percentage, sizeStr, pieces, subpathName;
 
-      const values = subpaths.map(subpath => {
-        return subpath.size / dataSize;
-      });
+      if (duResponse.subPathCount === 0 || subpaths === 0) {
+        pieces = duResponse && duResponse.path.split('/');
+        subpathName = pieces[pieces.length - 1];
+        pathLabels = [((duResponse.path).isKey || subpathName === OTHER_PATH_NAME) ? subpathName : subpathName];
+        values = [0.1];
+        percentage = [100.00];
+        sizeStr = [this.byteToSize(duResponse.size, 1)];
+      }
+      else {
+        pathLabels = subpaths.map(subpath => {
+          // The return subPath must be normalized in a format with
+          // a leading slash and without trailing slash
+          pieces = subpath.path.split('/');
+          subpathName = pieces[pieces.length - 1];
+          // Differentiate key without trailing slash
+          return (subpath.isKey || subpathName === OTHER_PATH_NAME) ? subpathName : subpathName + '/';
+        });
 
-      const percentage = values.map(value => {
-        return (value * 100).toFixed(2);
-      });
+        values = subpaths.map(subpath => {
+          return subpath.size / dataSize;
+        });
 
-      const sizeStr = subpaths.map(subpath => {
-        return this.byteToSize(subpath.size, 1);
-      });
+        percentage = values.map(value => {
+          return (value * 100).toFixed(2);
+        });
+
+        sizeStr = subpaths.map(subpath => {
+          return this.byteToSize(subpath.size, 1);
+        }); 
+      }
+    
       this.setState({
         // Normalized path
         isLoading: false,
@@ -207,7 +220,7 @@ export class DiskUsage extends React.Component<Record<string, object>, IDUState>
     this.updatePieChart('/', DEFAULT_DISPLAY_LIMIT);
   }
 
-  clickPieSection(e, curPath: string): void {
+  clickPieSection(e, curPath: string): void { 
     const subPath: string = e.points[0].label;
     if (subPath === OTHER_PATH_NAME) {
       return;
@@ -409,11 +422,26 @@ export class DiskUsage extends React.Component<Record<string, object>, IDUState>
                 {(duResponse.size > 0) ?
                   ((duResponse.size > 0 && duResponse.subPathCount === 0) ?
                     <div style={{height: 800}}>
+                    <div  className='metadatainformation'>
                       <br/> {' '}
-                      <h3>This object is a key with a file size of {this.byteToSize(duResponse.size, 1)}.<br/> {' '}
                         You can also view its metadata details by clicking the top right button.
-                      </h3>
-                    </div> :
+                    </div>
+                    <Plot
+                    data={plotData}
+                    layout={
+                      {
+                        width: 800,
+                        height: 750,
+                        font: {
+                          family: 'Roboto, sans-serif',
+                          size: 15
+                        },
+                        showlegend: true,
+                        title: 'Disk Usage for ' + returnPath + ' (Total Size: ' + this.byteToSize(duResponse.size, 1) + ')'
+                      }
+                    }/>
+                  </div>
+                    :
                     <Plot
                       data={plotData}
                       layout={
@@ -421,18 +449,17 @@ export class DiskUsage extends React.Component<Record<string, object>, IDUState>
                           width: 800,
                           height: 750,
                           font: {
-                            family: 'Arial',
-                            size: 14
+                            family: 'Roboto, sans-serif',
+                            size: 15
                           },
                           showlegend: true,
                           title: 'Disk Usage for ' + returnPath + ' (Total Size: ' + this.byteToSize(duResponse.size, 1) + ')'
                         }
                       }
                       onClick={e => this.clickPieSection(e, returnPath)}/>) :
-                  <div style={{height: 800}}><br/>
-                    <h3>This object is empty. Add files to it to see a visualization on disk usage.<br/> {' '}
+                  <div style={{height: 800}} className='metadatainformation'><br/>
+                    This object is empty. Add files to it to see a visualization on disk usage.{' '}<br/>
                       You can also view its metadata details by clicking the top right button.
-                    </h3>
                   </div>}
                 <DetailPanel path={returnPath} keys={panelKeys} values={panelValues} visible={showPanel}/>
               </Row>

--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/views/diskUsage/diskUsage.tsx
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/views/diskUsage/diskUsage.tsx
@@ -172,13 +172,13 @@ export class DiskUsage extends React.Component<Record<string, object>, IDUState>
           return (subpath.isKey || subpathName === OTHER_PATH_NAME) ? subpathName : subpathName + '/';
         });
 
-      values = subpaths.map(subpath => {
-        return subpath.size / dataSize;
-      });
+        values = subpaths.map(subpath => {
+          return subpath.size / dataSize;
+        });
 
-      percentage = values.map(value => {
-        return (value * 100).toFixed(2);
-      });
+        percentage = values.map(value => {
+          return (value * 100).toFixed(2);
+        });
 
         sizeStr = subpaths.map(subpath => {
           return this.byteToSize(subpath.size, 1);
@@ -421,7 +421,7 @@ export class DiskUsage extends React.Component<Record<string, object>, IDUState>
               <Row>
                 {(duResponse.size > 0)?
                     <div style={{height: 800}}>
-                    <div  className='metadatainformation'>
+                    <div className='metadatainformation'>
                       <br/> {' '}
                         You can also view its metadata details by clicking the top right button.
                     </div>

--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/views/diskUsage/diskUsage.tsx
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/views/diskUsage/diskUsage.tsx
@@ -220,7 +220,7 @@ export class DiskUsage extends React.Component<Record<string, object>, IDUState>
     this.updatePieChart('/', DEFAULT_DISPLAY_LIMIT);
   }
 
-  clickPieSection(e, curPath: string): void { 
+  clickPieSection(e, curPath: string): void {
     const subPath: string = e.points[0].label;
     if (subPath === OTHER_PATH_NAME) {
       return;


### PR DESCRIPTION
## What changes were proposed in this pull request?

1) Make the DU page's texts the same font and color as on the other pages in Recon.
2) The chart description (which color stands for which volume/bucket/key) could be a bit bigger
3) If we click into the chart parts we go into that bucket and change the pie chart accordingly. If we click on the last key there is no pie chart showing up, we could change this to show a pie chart with 100% of the key.
4) There is a button on the right side that says Show Metadata for Current Path. If we click on it there is a page popping up on the right side with information about the current path. We could fix this page on the right side as we have plenty of space to do that. We can remove the button in this case and we don't need to make the left side of the page (the chart) grey.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-7141

## How was this patch tested?
Manually