### PR TITLE
HDDS-7283. Set coreSize equal to maxSize for threadPoolExecutor

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/DeleteBlocksCommandHandler.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/DeleteBlocksCommandHandler.java
@@ -93,7 +93,7 @@ public class DeleteBlocksCommandHandler implements CommandHandler {
     this.containerSet = cset;
     this.conf = conf;
     this.executor = new ThreadPoolExecutor(
-        0, threadPoolSize, 60, TimeUnit.SECONDS,
+        threadPoolSize, threadPoolSize, 60, TimeUnit.SECONDS,
         new LinkedBlockingQueue<>(),
         new ThreadFactoryBuilder().setDaemon(true)
             .setNameFormat("DeleteBlocksCommandHandlerThread-%d")

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/DeleteBlocksCommandHandler.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/DeleteBlocksCommandHandler.java
@@ -60,9 +60,9 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.LinkedBlockingQueue;
-import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 
@@ -92,12 +92,9 @@ public class DeleteBlocksCommandHandler implements CommandHandler {
       ConfigurationSource conf, int threadPoolSize, int queueLimit) {
     this.containerSet = cset;
     this.conf = conf;
-    this.executor = new ThreadPoolExecutor(
-        threadPoolSize, threadPoolSize, 60, TimeUnit.SECONDS,
-        new LinkedBlockingQueue<>(),
-        new ThreadFactoryBuilder().setDaemon(true)
-            .setNameFormat("DeleteBlocksCommandHandlerThread-%d")
-            .build());
+    this.executor = Executors.newFixedThreadPool(
+        threadPoolSize, new ThreadFactoryBuilder()
+            .setNameFormat("DeleteBlocksCommandHandlerThread-%d").build());
     this.deleteCommandQueues = new LinkedBlockingQueue<>(queueLimit);
     handlerThread = new Daemon(new DeleteCmdWorker());
     handlerThread.start();

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/DeleteContainerCommandHandler.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/DeleteContainerCommandHandler.java
@@ -33,7 +33,7 @@ import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.util.concurrent.ExecutorService;
-import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.Executors;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -52,12 +52,9 @@ public class DeleteContainerCommandHandler implements CommandHandler {
   private final ExecutorService executor;
 
   public DeleteContainerCommandHandler(int threadPoolSize) {
-    this.executor = new ThreadPoolExecutor(
-        threadPoolSize, threadPoolSize, 60, TimeUnit.SECONDS,
-        new LinkedBlockingQueue<>(),
-        new ThreadFactoryBuilder().setDaemon(true)
-            .setNameFormat("DeleteContainerThread-%d")
-            .build());
+    this.executor = Executors.newFixedThreadPool(
+        threadPoolSize, new ThreadFactoryBuilder()
+            .setNameFormat("DeleteContainerThread-%d").build());
   }
 
   @Override

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/DeleteContainerCommandHandler.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/DeleteContainerCommandHandler.java
@@ -53,7 +53,7 @@ public class DeleteContainerCommandHandler implements CommandHandler {
 
   public DeleteContainerCommandHandler(int threadPoolSize) {
     this.executor = new ThreadPoolExecutor(
-        0, threadPoolSize, 60, TimeUnit.SECONDS,
+        threadPoolSize, threadPoolSize, 60, TimeUnit.SECONDS,
         new LinkedBlockingQueue<>(),
         new ThreadFactoryBuilder().setDaemon(true)
             .setNameFormat("DeleteContainerThread-%d")


### PR DESCRIPTION
## What changes were proposed in this pull request?

The thread count won't be growing for ThreadPoolExecutor in two cases of our current codebase.

The reason can be tracked here: https://stackoverflow.com/a/15485841/5365979

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-7283

## How was this patch tested?

By checking the thread count in the thread dump.
