### PR TITLE
HDDS-7268. EC: Fix tests for HealthCheck handlers of RM that use Replica Indexes for Ratis Containers

### DIFF
--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/health/TestClosedWithMismatchedReplicasHandler.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/health/TestClosedWithMismatchedReplicasHandler.java
@@ -162,7 +162,7 @@ public class TestClosedWithMismatchedReplicasHandler {
         ratisReplicationConfig, 1, CLOSED);
     Set<ContainerReplica> containerReplicas =
         ReplicationTestUtil.createReplicas(containerInfo.containerID(),
-            ContainerReplicaProto.State.CLOSED, 1, 2, 3);
+            ContainerReplicaProto.State.CLOSED, 0, 0, 0);
     ContainerCheckRequest request = new ContainerCheckRequest.Builder()
         .setPendingOps(Collections.EMPTY_LIST)
         .setReport(new ReplicationManagerReport())
@@ -181,15 +181,15 @@ public class TestClosedWithMismatchedReplicasHandler {
     ContainerInfo containerInfo = ReplicationTestUtil.createContainerInfo(
         ratisReplicationConfig, 1, CLOSED);
     ContainerReplica mismatch1 = ReplicationTestUtil.createContainerReplica(
-        containerInfo.containerID(), 1,
+        containerInfo.containerID(), 0,
         HddsProtos.NodeOperationalState.IN_SERVICE,
         ContainerReplicaProto.State.OPEN);
     ContainerReplica mismatch2 = ReplicationTestUtil.createContainerReplica(
-        containerInfo.containerID(), 2,
+        containerInfo.containerID(), 0,
         HddsProtos.NodeOperationalState.IN_SERVICE,
         ContainerReplicaProto.State.CLOSING);
     ContainerReplica mismatch3 = ReplicationTestUtil.createContainerReplica(
-        containerInfo.containerID(), 3,
+        containerInfo.containerID(), 0,
         HddsProtos.NodeOperationalState.IN_SERVICE,
         ContainerReplicaProto.State.UNHEALTHY);
     Set<ContainerReplica> containerReplicas = new HashSet<>();

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/health/TestClosingContainerHandler.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/health/TestClosingContainerHandler.java
@@ -87,7 +87,7 @@ public class TestClosingContainerHandler {
         ratisReplicationConfig, 1, CLOSED);
     Set<ContainerReplica> containerReplicas = ReplicationTestUtil
         .createReplicas(containerInfo.containerID(),
-            ContainerReplicaProto.State.CLOSING, 1, 2, 3);
+            ContainerReplicaProto.State.CLOSING, 0, 0, 0);
 
     ContainerCheckRequest request = new ContainerCheckRequest.Builder()
         .setPendingOps(Collections.EMPTY_LIST)
@@ -133,9 +133,9 @@ public class TestClosingContainerHandler {
         ratisReplicationConfig, 1, CLOSING);
     Set<ContainerReplica> containerReplicas = ReplicationTestUtil
         .createReplicas(containerInfo.containerID(),
-            ContainerReplicaProto.State.UNHEALTHY, 1, 2);
+            ContainerReplicaProto.State.UNHEALTHY, 0, 0);
     ContainerReplica openReplica = ReplicationTestUtil.createContainerReplica(
-        containerInfo.containerID(), 3,
+        containerInfo.containerID(), 0,
         HddsProtos.NodeOperationalState.IN_SERVICE,
         ContainerReplicaProto.State.OPEN);
     containerReplicas.add(openReplica);
@@ -181,9 +181,9 @@ public class TestClosingContainerHandler {
         ratisReplicationConfig, 1, CLOSING);
     Set<ContainerReplica> containerReplicas = ReplicationTestUtil
         .createReplicas(containerInfo.containerID(),
-            ContainerReplicaProto.State.CLOSING, 1, 2);
+            ContainerReplicaProto.State.CLOSING, 0, 0);
     containerReplicas.add(ReplicationTestUtil.createContainerReplica(
-        containerInfo.containerID(), 3,
+        containerInfo.containerID(), 0,
         HddsProtos.NodeOperationalState.IN_SERVICE,
         ContainerReplicaProto.State.OPEN));
 

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/health/TestOpenContainerHandler.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/health/TestOpenContainerHandler.java
@@ -118,7 +118,7 @@ public class TestOpenContainerHandler {
         ratisReplicationConfig, 1, CLOSED);
     Set<ContainerReplica> containerReplicas = ReplicationTestUtil
         .createReplicas(containerInfo.containerID(),
-            ContainerReplicaProto.State.CLOSED, 1, 2, 3);
+            ContainerReplicaProto.State.CLOSED, 0, 0, 0);
     ContainerCheckRequest request = new ContainerCheckRequest.Builder()
         .setPendingOps(Collections.EMPTY_LIST)
         .setReport(new ReplicationManagerReport())
@@ -136,7 +136,7 @@ public class TestOpenContainerHandler {
         ratisReplicationConfig, 1, OPEN);
     Set<ContainerReplica> containerReplicas = ReplicationTestUtil
         .createReplicas(containerInfo.containerID(),
-            ContainerReplicaProto.State.OPEN, 1, 2, 3);
+            ContainerReplicaProto.State.OPEN, 0, 0, 0);
     ContainerCheckRequest request = new ContainerCheckRequest.Builder()
         .setPendingOps(Collections.EMPTY_LIST)
         .setReport(new ReplicationManagerReport())
@@ -154,7 +154,7 @@ public class TestOpenContainerHandler {
         ratisReplicationConfig, 1, OPEN);
     Set<ContainerReplica> containerReplicas = ReplicationTestUtil
         .createReplicas(containerInfo.containerID(),
-            ContainerReplicaProto.State.CLOSED, 1, 2, 3);
+            ContainerReplicaProto.State.CLOSED, 0, 0, 0);
     ContainerCheckRequest request = new ContainerCheckRequest.Builder()
         .setPendingOps(Collections.EMPTY_LIST)
         .setReport(new ReplicationManagerReport())


### PR DESCRIPTION
## What changes were proposed in this pull request?

Some tests such as TestClosedWithMismatchedReplicasHandler#testClosedHealthyRatisContainerReturnsFalse specify the Replica Index field for Ratis container replicas. This field is only meaningful for EC and should be removed.

```
    Set<ContainerReplica> containerReplicas =
        ReplicationTestUtil.createReplicas(containerInfo.containerID(),
            ContainerReplicaProto.State.CLOSED, 1, 2, 3);
```

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-7268