### PR TITLE
HDDS-6664. Implements getUri in TrashOzoneFileSystem

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/OzoneConsts.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/OzoneConsts.java
@@ -98,7 +98,6 @@ public final class OzoneConsts {
 
   public static final String OZONE_RPC_SCHEME = "o3";
   public static final String OZONE_O3TRASH_URI_SCHEME = "o3trash";
-  public static final String OZONE_O3TRASH_NO_HOST = "o3trash.nohost";
   public static final String OZONE_HTTP_SCHEME = "http";
   public static final String OZONE_URI_DELIMITER = "/";
   public static final String OZONE_ROOT = OZONE_URI_DELIMITER;

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/OzoneConsts.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/OzoneConsts.java
@@ -97,6 +97,8 @@ public final class OzoneConsts {
   public static final String OZONE_OFS_URI_SCHEME = "ofs";
 
   public static final String OZONE_RPC_SCHEME = "o3";
+  public static final String OZONE_O3TRASH_URI_SCHEME = "o3trash";
+  public static final String OZONE_O3TRASH_NO_HOST = "o3trash.nohost";
   public static final String OZONE_HTTP_SCHEME = "http";
   public static final String OZONE_URI_DELIMITER = "/";
   public static final String OZONE_ROOT = OZONE_URI_DELIMITER;

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/TrashOzoneFileSystem.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/TrashOzoneFileSystem.java
@@ -42,7 +42,6 @@ import org.apache.hadoop.ozone.om.request.OMClientRequest;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos;
 import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.hadoop.util.Progressable;
-import org.apache.http.client.utils.URIBuilder;
 import org.apache.ratis.protocol.ClientId;
 import org.apache.ratis.protocol.Message;
 import org.apache.ratis.protocol.RaftClientRequest;
@@ -53,7 +52,6 @@ import java.io.Closeable;
 import java.io.IOException;
 import java.net.InetAddress;
 import java.net.URI;
-import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
@@ -61,7 +59,6 @@ import java.util.Map;
 import java.util.Iterator;
 import java.util.concurrent.atomic.AtomicLong;
 
-import static org.apache.hadoop.ozone.OzoneConsts.OZONE_O3TRASH_NO_HOST;
 import static org.apache.hadoop.ozone.OzoneConsts.OZONE_O3TRASH_URI_SCHEME;
 import static org.apache.hadoop.ozone.OzoneConsts.OZONE_URI_DELIMITER;
 import static org.apache.hadoop.ozone.om.helpers.OzoneFSUtils.addTrailingSlashIfNeeded;
@@ -127,15 +124,7 @@ public class TrashOzoneFileSystem extends FileSystem {
 
   @Override
   public URI getUri() {
-    URI uri = null;
-    try {
-      uri = new URIBuilder().setScheme(OZONE_O3TRASH_URI_SCHEME)
-              .setHost(OZONE_O3TRASH_NO_HOST)
-              .build();
-    } catch (URISyntaxException e) {
-      LOG.error("Invalid syntax while building URI", e);
-    }
-    return uri;
+    return URI.create(OZONE_O3TRASH_URI_SCHEME + ":///");
   }
 
   @Override

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/TrashOzoneFileSystem.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/TrashOzoneFileSystem.java
@@ -42,6 +42,7 @@ import org.apache.hadoop.ozone.om.request.OMClientRequest;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos;
 import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.hadoop.util.Progressable;
+import org.apache.http.client.utils.URIBuilder;
 import org.apache.ratis.protocol.ClientId;
 import org.apache.ratis.protocol.Message;
 import org.apache.ratis.protocol.RaftClientRequest;
@@ -52,6 +53,7 @@ import java.io.Closeable;
 import java.io.IOException;
 import java.net.InetAddress;
 import java.net.URI;
+import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
@@ -60,6 +62,7 @@ import java.util.Iterator;
 import java.util.concurrent.atomic.AtomicLong;
 
 import static org.apache.hadoop.ozone.OzoneConsts.OZONE_URI_DELIMITER;
+import static org.apache.hadoop.ozone.OzoneConsts.OZONE_URI_SCHEME;
 import static org.apache.hadoop.ozone.om.helpers.OzoneFSUtils.addTrailingSlashIfNeeded;
 import static org.apache.hadoop.ozone.om.helpers.OzoneFSUtils.pathToKey;
 
@@ -123,8 +126,15 @@ public class TrashOzoneFileSystem extends FileSystem {
 
   @Override
   public URI getUri() {
-    throw new UnsupportedOperationException(
-        "fs.getUri() not implemented in TrashOzoneFileSystem");
+    URI uri = null;
+    try {
+      uri = new URIBuilder().setScheme(OZONE_URI_SCHEME)
+              .setHost("ofs.trash")
+              .build();
+    } catch (URISyntaxException e) {
+      LOG.error("Invalid syntax while building URI");
+    }
+    return uri;
   }
 
   @Override

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/TrashOzoneFileSystem.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/TrashOzoneFileSystem.java
@@ -61,8 +61,9 @@ import java.util.Map;
 import java.util.Iterator;
 import java.util.concurrent.atomic.AtomicLong;
 
+import static org.apache.hadoop.ozone.OzoneConsts.OZONE_O3TRASH_NO_HOST;
+import static org.apache.hadoop.ozone.OzoneConsts.OZONE_O3TRASH_URI_SCHEME;
 import static org.apache.hadoop.ozone.OzoneConsts.OZONE_URI_DELIMITER;
-import static org.apache.hadoop.ozone.OzoneConsts.OZONE_URI_SCHEME;
 import static org.apache.hadoop.ozone.om.helpers.OzoneFSUtils.addTrailingSlashIfNeeded;
 import static org.apache.hadoop.ozone.om.helpers.OzoneFSUtils.pathToKey;
 
@@ -128,11 +129,11 @@ public class TrashOzoneFileSystem extends FileSystem {
   public URI getUri() {
     URI uri = null;
     try {
-      uri = new URIBuilder().setScheme(OZONE_URI_SCHEME)
-              .setHost("ofs.trash")
+      uri = new URIBuilder().setScheme(OZONE_O3TRASH_URI_SCHEME)
+              .setHost(OZONE_O3TRASH_NO_HOST)
               .build();
     } catch (URISyntaxException e) {
-      LOG.error("Invalid syntax while building URI");
+      LOG.error("Invalid syntax while building URI", e);
     }
     return uri;
   }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fix the following exception being thrown during FileSystem.close()

Exception in thread "Trash Emptier" java.lang.UnsupportedOperationException: fs.getUri() not implemented in TrashOzoneFileSystem
        

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-6664

## How was this patch tested?

Ran relevant checks scripts locally and build-branch was successful with  this change. https://github.com/pratapchandu/ozone/actions/runs/3172304615
 