### PR TITLE
HDDS-7285. Fix concurrent issue in DeleteBlocksCommandHandler

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/DeleteBlocksCommandHandler.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/DeleteBlocksCommandHandler.java
@@ -58,6 +58,7 @@ import org.slf4j.LoggerFactory;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
@@ -193,18 +194,16 @@ public class DeleteBlocksCommandHandler implements CommandHandler {
   /**
    * Process one delete transaction.
    */
-  public final class ProcessTransactionTask implements Runnable {
+  public final class ProcessTransactionTask implements
+      Callable<DeleteBlockTransactionResult> {
     private DeletedBlocksTransaction tx;
-    private ContainerBlocksDeletionACKProto.Builder result;
 
-    public ProcessTransactionTask(DeletedBlocksTransaction transaction,
-        ContainerBlocksDeletionACKProto.Builder resultBuilder) {
-      this.result = resultBuilder;
+    public ProcessTransactionTask(DeletedBlocksTransaction transaction) {
       this.tx = transaction;
     }
 
     @Override
-    public void run() {
+    public DeleteBlockTransactionResult call() {
       DeleteBlockTransactionResult.Builder txResultBuilder =
           DeleteBlockTransactionResult.newBuilder();
       txResultBuilder.setTxID(tx.getTxID());
@@ -253,7 +252,7 @@ public class DeleteBlocksCommandHandler implements CommandHandler {
         txResultBuilder.setContainerID(containerId)
             .setSuccess(false);
       }
-      result.addResults(txResultBuilder.build());
+      return txResultBuilder.build();
     }
   }
 
@@ -279,18 +278,18 @@ public class DeleteBlocksCommandHandler implements CommandHandler {
 
       ContainerBlocksDeletionACKProto.Builder resultBuilder =
           ContainerBlocksDeletionACKProto.newBuilder();
-      List<Future> futures = new ArrayList<>();
+      List<Future<DeleteBlockTransactionResult>> futures = new ArrayList<>();
       for (int i = 0; i < containerBlocks.size(); i++) {
         DeletedBlocksTransaction tx = containerBlocks.get(i);
-        Future future = executor.submit(
-            new ProcessTransactionTask(tx, resultBuilder));
+        Future<DeleteBlockTransactionResult> future =
+            executor.submit(new ProcessTransactionTask(tx));
         futures.add(future);
       }
 
       // Wait for tasks to finish
       futures.forEach(f -> {
         try {
-          f.get();
+          resultBuilder.addResults(f.get());
         } catch (InterruptedException | ExecutionException e) {
           LOG.error("task failed.", e);
           Thread.currentThread().interrupt();


### PR DESCRIPTION
## What changes were proposed in this pull request?

After [HDDS-7283](https://issues.apache.org/jira/browse/HDDS-7283), the mark for the delete process will be handled concurrently.

The current implementation has a concurrent issue which will lead to the following exception.
```
java.util.concurrent.ExecutionException: java.lang.ArrayIndexOutOfBoundsException: 4
        at java.util.concurrent.FutureTask.report(FutureTask.java:122)
        at java.util.concurrent.FutureTask.get(FutureTask.java:192)
        at org.apache.hadoop.ozone.container.common.statemachine.commandhandler.DeleteBlocksCommandHandler.lambda$processCmd$0(DeleteBlocksCommandHandler.java:301)
        at java.util.ArrayList.forEach(ArrayList.java:1257)
        at org.apache.hadoop.ozone.container.common.statemachine.commandhandler.DeleteBlocksCommandHandler.processCmd(DeleteBlocksCommandHandler.java:299)
        at org.apache.hadoop.ozone.container.common.statemachine.commandhandler.DeleteBlocksCommandHandler.access$100(DeleteBlocksCommandHandler.java:79)
        at org.apache.hadoop.ozone.container.common.statemachine.commandhandler.DeleteBlocksCommandHandler$DeleteCmdWorker.run(DeleteBlocksCommandHandler.java:183)
        at java.lang.Thread.run(Thread.java:748)
Caused by: java.lang.ArrayIndexOutOfBoundsException: 4
        at java.util.ArrayList.add(ArrayList.java:463)
        at org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos$ContainerBlocksDeletionACKProto$Builder.addResults(StorageContainerDatanodeProtocolProtos.java:33469)
        at org.apache.hadoop.ozone.container.common.statemachine.commandhandler.DeleteBlocksCommandHandler$ProcessTransactionTask.run(DeleteBlocksCommandHandler.java:263)
        at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
        at java.util.concurrent.FutureTask.run(FutureTask.java:266)
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
        ... 1 more 
```
This ticket is to fix this issue.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-7285

## How was this patch tested?

Test on prod cluster with no more above exception.
