### PR TITLE
HDDS-7286. Clean up ContainerManager

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/ContainerManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/ContainerManager.java
@@ -32,14 +32,10 @@ import org.apache.hadoop.hdds.utils.db.Table;
 import org.apache.hadoop.ozone.common.statemachine.InvalidStateTransitionException;
 
 /**
- * TODO: Add extensive javadoc.
- *
- * ContainerManager class contains the mapping from a name to a pipeline
- * mapping. This is used by SCM when allocating new locations and when
- * looking up a key.
+ * ContainerManager is responsible for keeping track of all Containers and
+ * managing all containers operations like creating, deleting etc.
  */
 public interface ContainerManager extends Closeable {
-  // TODO: Rename this to ContainerManager
 
   /**
    * Reinitialize the containerManager with the updated container store.
@@ -190,12 +186,6 @@ public interface ContainerManager extends Closeable {
    */
   void deleteContainer(ContainerID containerID)
       throws IOException, TimeoutException;
-
-  /**
-   * Returns the list of containersIDs.
-   * @return list of containerIDs
-   */
-  Set<ContainerID> getContainerIDs();
 
   /**
    * Returns containerStateManger.

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/ContainerManagerImpl.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/ContainerManagerImpl.java
@@ -58,34 +58,20 @@ import org.slf4j.LoggerFactory;
 import static org.apache.hadoop.hdds.scm.ha.SequenceIdGenerator.CONTAINER_ID;
 
 /**
- * TODO: Add javadoc.
+ * {@link ContainerManager} implementation in SCM server.
  */
 public class ContainerManagerImpl implements ContainerManager {
 
-  /*
-   * TODO: Introduce container level locks.
-   */
-
-  /**
-   *
-   */
   private static final Logger LOG = LoggerFactory.getLogger(
       ContainerManagerImpl.class);
 
   /**
-   *
+   * Limit the number of on-going ratis operations.
    */
-  // Limit the number of on-going ratis operations.
   private final Lock lock;
 
-  /**
-   *
-   */
   private final PipelineManager pipelineManager;
 
-  /**
-   *
-   */
   private final ContainerStateManager containerStateManager;
 
   private final SCMHAManager haManager;
@@ -162,9 +148,6 @@ public class ContainerManagerImpl implements ContainerManager {
   public List<ContainerInfo> getContainers(final ContainerID startID,
                                            final int count) {
     scmContainerManagerMetrics.incNumListContainersOps();
-    // TODO: Remove the null check, startID should not be null. Fix the unit
-    //  test before removing the check.
-    final long start = startID == null ? 0 : startID.getId();
     final List<ContainerID> containersIds =
         new ArrayList<>(containerStateManager.getContainerIDs());
     Collections.sort(containersIds);
@@ -172,7 +155,7 @@ public class ContainerManagerImpl implements ContainerManager {
     lock.lock();
     try {
       containers = containersIds.stream()
-          .filter(id -> id.getId() >= start).limit(count)
+          .filter(id -> id.compareTo(startID) >= 0).limit(count)
           .map(containerStateManager::getContainer)
           .collect(Collectors.toList());
     } finally {
@@ -477,9 +460,5 @@ public class ContainerManagerImpl implements ContainerManager {
   @VisibleForTesting
   public SCMHAManager getSCMHAManager() {
     return haManager;
-  }
-
-  public Set<ContainerID> getContainerIDs() {
-    return containerStateManager.getContainerIDs();
   }
 }

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/TestContainerManagerImpl.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/TestContainerManagerImpl.java
@@ -101,7 +101,7 @@ public class TestContainerManagerImpl {
   }
 
   @Test
-  public void testAllocateContainer() throws Exception {
+  void testAllocateContainer() throws Exception {
     Assertions.assertTrue(
         containerManager.getContainers().isEmpty());
     final ContainerInfo container = containerManager.allocateContainer(
@@ -113,7 +113,7 @@ public class TestContainerManagerImpl {
   }
 
   @Test
-  public void testUpdateContainerState() throws Exception {
+  void testUpdateContainerState() throws Exception {
     final ContainerInfo container = containerManager.allocateContainer(
         RatisReplicationConfig.getInstance(
             ReplicationFactor.THREE), "admin");
@@ -135,7 +135,7 @@ public class TestContainerManagerImpl {
   }
 
   @Test
-  public void testGetContainers() throws Exception {
+  void testGetContainers() throws Exception {
     Assertions.assertTrue(
         containerManager.getContainers().isEmpty());
 
@@ -181,7 +181,7 @@ public class TestContainerManagerImpl {
   }
 
   @Test
-  public void testAllocateContainersWithECReplicationConfig() throws Exception {
+  void testAllocateContainersWithECReplicationConfig() throws Exception {
     final ContainerInfo admin = containerManager
         .allocateContainer(new ECReplicationConfig(3, 2), "admin");
     Assertions.assertEquals(1, containerManager.getContainers().size());
@@ -190,7 +190,7 @@ public class TestContainerManagerImpl {
   }
 
   @Test
-  public void testUpdateContainerReplicaInvokesPendingOp()
+  void testUpdateContainerReplicaInvokesPendingOp()
       throws IOException, TimeoutException {
     final ContainerInfo container = containerManager.allocateContainer(
         RatisReplicationConfig.getInstance(
@@ -211,7 +211,7 @@ public class TestContainerManagerImpl {
   }
 
   @Test
-  public void testRemoveContainerReplicaInvokesPendingOp()
+  void testRemoveContainerReplicaInvokesPendingOp()
       throws IOException, TimeoutException {
     final ContainerInfo container = containerManager.allocateContainer(
         RatisReplicationConfig.getInstance(

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/container/TestContainerStateManagerIntegration.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/container/TestContainerStateManagerIntegration.java
@@ -166,7 +166,7 @@ public class TestContainerStateManagerIntegration {
     cluster.restartStorageContainerManager(false);
 
     List<ContainerInfo> result = cluster.getStorageContainerManager()
-        .getContainerManager().getContainers(null, 100);
+        .getContainerManager().getContainers();
 
     long matchCount = result.stream()
         .filter(info ->

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/storage/TestContainerCommandsEC.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/storage/TestContainerCommandsEC.java
@@ -658,8 +658,13 @@ public class TestContainerCommandsEC {
         out.write(values[i]);
       }
     }
+//    List<ContainerID> containerIDs =
+//        new ArrayList<>(scm.getContainerManager().getContainerIDs());
     List<ContainerID> containerIDs =
-        new ArrayList<>(scm.getContainerManager().getContainerIDs());
+            scm.getContainerManager().getContainers()
+                    .stream()
+                    .map(ContainerInfo::containerID)
+                    .collect(Collectors.toList());
     Assertions.assertEquals(1, containerIDs.size());
     containerID = containerIDs.get(0).getId();
     List<Pipeline> pipelines = scm.getPipelineManager().getPipelines(repConfig);

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/recon/TestReconAsPassiveScm.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/recon/TestReconAsPassiveScm.java
@@ -138,8 +138,8 @@ public class TestReconAsPassiveScm {
     runTestOzoneContainerViaDataNode(containerID, client);
 
     // Verify Recon picked up the new container that was created.
-    assertEquals(scmContainerManager.getContainerIDs(),
-        reconContainerManager.getContainerIDs());
+    assertEquals(scmContainerManager.getContainers(),
+        reconContainerManager.getContainers());
 
     GenericTestUtils.LogCapturer logCapturer =
         GenericTestUtils.LogCapturer.captureLogs(ReconNodeManager.LOG);

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/recon/TestReconTasks.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/recon/TestReconTasks.java
@@ -115,8 +115,8 @@ public class TestReconTasks {
     runTestOzoneContainerViaDataNode(containerID, client);
 
     // Make sure Recon got the container report with new container.
-    Assert.assertEquals(scmContainerManager.getContainerIDs(),
-        reconContainerManager.getContainerIDs());
+    Assert.assertEquals(scmContainerManager.getContainers(),
+        reconContainerManager.getContainers());
 
     // Bring down the Datanode that had the container replica.
     cluster.shutdownHddsDatanode(pipeline.getFirstNode());


### PR DESCRIPTION
## What changes were proposed in this pull request?

Clean up of org.apache.hadoop.hdds.scm.container.ContainerManager and its descendants. Removed various code smells such as 

- using deprecated methods
- missing javadocs
- using methods annotated VisibleForTesting in production code

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-7286

Please replace this section with the link to the Apache JIRA)

## How was this patch tested?

Unit tests
