### PR TITLE
HDDS-7287. Send deleteBlocksRequest with correct retry count

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/block/DeletedBlockLogImpl.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/block/DeletedBlockLogImpl.java
@@ -195,6 +195,9 @@ public class DeletedBlockLogImpl
             .map(DeletedBlocksTransaction::getTxID)
             .collect(Collectors.toList());
       }
+      for (Long txID: txIDs) {
+        transactionToRetryCountMap.computeIfPresent(txID, (key, value) -> 0);
+      }
       return deletedBlockLogStateManager.resetRetryCountOfTransactionInDB(
           new ArrayList<>(new HashSet<>(txIDs)));
     } finally {
@@ -390,17 +393,22 @@ public class DeletedBlockLogImpl
   private void getTransaction(DeletedBlocksTransaction tx,
       DatanodeDeletedBlockTransactions transactions) {
     try {
+      DeletedBlocksTransaction updatedTxn = DeletedBlocksTransaction
+          .newBuilder(tx)
+          .setCount(transactionToRetryCountMap.getOrDefault(tx.getTxID(), 0))
+          .build();
       Set<ContainerReplica> replicas = containerManager
-          .getContainerReplicas(ContainerID.valueOf(tx.getContainerID()));
+          .getContainerReplicas(
+              ContainerID.valueOf(updatedTxn.getContainerID()));
       for (ContainerReplica replica : replicas) {
         UUID dnID = replica.getDatanodeDetails().getUuid();
         Set<UUID> dnsWithTransactionCommitted =
-            transactionToDNsCommitMap.get(tx.getTxID());
+            transactionToDNsCommitMap.get(updatedTxn.getTxID());
         if (dnsWithTransactionCommitted == null || !dnsWithTransactionCommitted
             .contains(dnID)) {
           // Transaction need not be sent to dns which have
           // already committed it
-          transactions.addTransactionToDN(dnID, tx);
+          transactions.addTransactionToDN(dnID, updatedTxn);
         }
       }
     } catch (IOException e) {

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/block/TestDeletedBlockLog.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/block/TestDeletedBlockLog.java
@@ -335,10 +335,19 @@ public class TestDeletedBlockLog {
     // This will return all TXs, total num 30.
     List<DeletedBlocksTransaction> blocks = getAllTransactions();
     List<Long> txIDs = blocks.stream().map(DeletedBlocksTransaction::getTxID)
-        .collect(Collectors.toList());
+        .distinct().collect(Collectors.toList());
+    Assertions.assertEquals(30, txIDs.size());
+
+    for (DeletedBlocksTransaction block : blocks) {
+      Assertions.assertEquals(0, block.getCount());
+    }
 
     for (int i = 0; i < maxRetry; i++) {
       incrementCount(txIDs);
+    }
+    blocks = getAllTransactions();
+    for (DeletedBlocksTransaction block : blocks) {
+      Assertions.assertEquals(maxRetry, block.getCount());
     }
 
     // Increment another time so it exceed the maxRetry.

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/block/TestDeletedBlockLog.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/block/TestDeletedBlockLog.java
@@ -397,6 +397,14 @@ public class TestDeletedBlockLog {
     for (DeletedBlocksTransaction block : blocks) {
       Assertions.assertEquals(0, block.getCount());
     }
+
+    // Increment for the reset transactions.
+    incrementCount(txIDs);
+    blocks = getAllTransactions();
+    for (DeletedBlocksTransaction block : blocks) {
+      Assertions.assertEquals(1, block.getCount());
+    }
+
     Assertions.assertEquals(30 * THREE, blocks.size());
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

This ticket is to fix two related errors on transactionToRetryCountMap.

* SCM sends a request to dn, the retry count of the message is currently read from DB, but the DB value won't be changed until exceeding the max retry times, so it will always be 0 before exceeding the max value.
* Reset retry count didn't reset the value of transactionToRetryCountMap.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-7287

## How was this patch tested?

unit test.