### PR TITLE
HDDS-7284. JVM crash for rocksdb for read/write after close

### DIFF
--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/TestSchemaOneBackwardsCompatibility.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/TestSchemaOneBackwardsCompatibility.java
@@ -160,7 +160,7 @@ public class TestSchemaOneBackwardsCompatibility {
       table.iterator();
       Assert.fail("Table iterator should have thrown " +
               "UnsupportedOperationException.");
-    } catch (UnsupportedOperationException ex) {
+    } catch (IOException | UnsupportedOperationException ex) {
       // Exception thrown as expected.
     }
   }

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/scm/metadata/SCMMetadataStore.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/scm/metadata/SCMMetadataStore.java
@@ -127,8 +127,10 @@ public interface SCMMetadataStore extends DBStoreHAManager {
    *
    * @param certType - CertType.
    * @return Iterator<X509Certificate>
+   * @throws IOException on failure.
    */
-  TableIterator getAllCerts(CertificateStore.CertType certType);
+  TableIterator getAllCerts(CertificateStore.CertType certType)
+      throws IOException;
 
   /**
    * A Table that maintains all the pipeline information.

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/RDBTable.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/RDBTable.java
@@ -157,12 +157,14 @@ class RDBTable implements Table<byte[], byte[]> {
   }
 
   @Override
-  public TableIterator<byte[], ByteArrayKeyValue> iterator() {
+  public TableIterator<byte[], ByteArrayKeyValue> iterator()
+      throws IOException {
     return new RDBStoreIterator(db.newIterator(family, false), this);
   }
 
   @Override
-  public TableIterator<byte[], ByteArrayKeyValue> iterator(byte[] prefix) {
+  public TableIterator<byte[], ByteArrayKeyValue> iterator(byte[] prefix)
+      throws IOException {
     return new RDBStoreIterator(db.newIterator(family, false), this,
         prefix);
   }

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/RocksDatabase.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/RocksDatabase.java
@@ -48,6 +48,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -137,12 +138,13 @@ public final class RocksDatabase {
             descriptors, handles);
       }
       // init a column family map.
+      AtomicLong counter = new AtomicLong(0);
       for (ColumnFamilyHandle h : handles) {
-        final ColumnFamily f = new ColumnFamily(h);
+        final ColumnFamily f = new ColumnFamily(h, counter);
         columnFamilies.put(f.getName(), f);
       }
       return new RocksDatabase(dbFile, db, dbOptions, writeOptions,
-          descriptors, Collections.unmodifiableMap(columnFamilies));
+          descriptors, Collections.unmodifiableMap(columnFamilies), counter);
     } catch (RocksDBException e) {
       close(columnFamilies, db, descriptors, writeOptions, dbOptions);
       throw toIOException(RocksDatabase.class, "open " + dbFile, e);
@@ -208,11 +210,15 @@ public final class RocksDatabase {
     }
 
     public void createCheckpoint(Path path) throws IOException {
+      assertClose();
       try {
+        counter.incrementAndGet();
         checkpoint.get().createCheckpoint(path.toString());
       } catch (RocksDBException e) {
-        closeOnError(e);
+        closeOnError(e, true);
         throw toIOException(this, "createCheckpoint " + path, e);
+      } finally {
+        counter.decrementAndGet();
       }
     }
 
@@ -233,11 +239,15 @@ public final class RocksDatabase {
    */
   public static final class ColumnFamily {
     private final byte[] nameBytes;
+    private AtomicLong counter;
     private final String name;
     private final ColumnFamilyHandle handle;
+    private AtomicBoolean isClosed = new AtomicBoolean(false);
 
-    public ColumnFamily(ColumnFamilyHandle handle) throws RocksDBException {
+    public ColumnFamily(ColumnFamilyHandle handle, AtomicLong counter)
+        throws RocksDBException {
       this.nameBytes = handle.getName();
+      this.counter = counter;
       this.name = bytes2String(nameBytes);
       this.handle = handle;
       LOG.debug("new ColumnFamily for {}", name);
@@ -261,19 +271,37 @@ public final class RocksDatabase {
 
     public void batchDelete(ManagedWriteBatch writeBatch, byte[] key)
         throws IOException {
+      assertClosed();
       try {
+        counter.incrementAndGet();
         writeBatch.delete(getHandle(), key);
       } catch (RocksDBException e) {
         throw toIOException(this, "batchDelete key " + bytes2String(key), e);
+      } finally {
+        counter.decrementAndGet();
       }
     }
 
     public void batchPut(ManagedWriteBatch writeBatch, byte[] key, byte[] value)
         throws IOException {
+      assertClosed();
       try {
+        counter.incrementAndGet();
         writeBatch.put(getHandle(), key, value);
       } catch (RocksDBException e) {
         throw toIOException(this, "batchPut key " + bytes2String(key), e);
+      } finally {
+        counter.decrementAndGet();
+      }
+    }
+    
+    public void markClosed() {
+      isClosed.set(true);
+    }
+
+    private void assertClosed() throws IOException {
+      if (isClosed.get()) {
+        throw new IOException("Rocks Database is closed");
       }
     }
 
@@ -291,28 +319,57 @@ public final class RocksDatabase {
   private final Map<String, ColumnFamily> columnFamilies;
 
   private final AtomicBoolean isClosed = new AtomicBoolean();
+  
+  private final AtomicLong counter;
 
   private RocksDatabase(File dbFile, ManagedRocksDB db,
       ManagedDBOptions dbOptions, ManagedWriteOptions writeOptions,
       List<ColumnFamilyDescriptor> descriptors,
-      Map<String, ColumnFamily> columnFamilies) {
+      Map<String, ColumnFamily> columnFamilies, AtomicLong counter) {
     this.name = getClass().getSimpleName() + "[" + dbFile + "]";
     this.db = db;
     this.dbOptions = dbOptions;
     this.writeOptions = writeOptions;
     this.descriptors = descriptors;
     this.columnFamilies = columnFamilies;
+    this.counter = counter;
   }
 
   public void close() {
     if (isClosed.compareAndSet(false, true)) {
-      close(columnFamilies, db, descriptors, writeOptions, dbOptions);
+      if (columnFamilies != null) {
+        columnFamilies.values().stream().forEach(f -> f.markClosed());
+      }
+      // each loop 1 milli sec, 5000 loop mak 5 sec wait
+      final int maxLoop = 5000;
+      for (int i = 0; i < maxLoop; ++i) {
+        if (counter.get() == 0) {
+          close(columnFamilies, db, descriptors, writeOptions, dbOptions);
+          break;
+        }
+        try {
+          Thread.currentThread().sleep(1);
+        } catch (InterruptedException e) {
+          close(columnFamilies, db, descriptors, writeOptions, dbOptions);
+          Thread.currentThread().interrupt();
+          break;
+        }
+      }
     }
   }
 
-  private void closeOnError(RocksDBException e) {
+  private void closeOnError(RocksDBException e, boolean isCounted) {
     if (shouldClose(e)) {
-      close();
+      try {
+        if (isCounted) {
+          counter.decrementAndGet();
+        }
+        close();
+      } finally {
+        if (isCounted) {
+          counter.incrementAndGet();
+        }
+      }
     }
   }
 
@@ -325,55 +382,81 @@ public final class RocksDatabase {
       return false;
     }
   }
+  
+  private void assertClose() throws IOException {
+    if (isClosed()) {
+      throw new IOException("Rocks Database is closed");
+    }
+  }
 
   public void ingestExternalFile(ColumnFamily family, List<String> files,
       ManagedIngestExternalFileOptions ingestOptions) throws IOException {
+    assertClose();
     try {
+      counter.incrementAndGet();
       db.get().ingestExternalFile(family.getHandle(), files, ingestOptions);
     } catch (RocksDBException e) {
-      closeOnError(e);
+      closeOnError(e, true);
       String msg = "Failed to ingest external files " +
           files.stream().collect(Collectors.joining(", ")) + " of " +
           family.getName();
       throw toIOException(this, msg, e);
+    } finally {
+      counter.decrementAndGet();
     }
   }
 
   public void put(ColumnFamily family, byte[] key, byte[] value)
       throws IOException {
+    assertClose();
     try {
+      counter.incrementAndGet();
       db.get().put(family.getHandle(), writeOptions, key, value);
     } catch (RocksDBException e) {
-      closeOnError(e);
+      closeOnError(e, true);
       throw toIOException(this, "put " + bytes2String(key), e);
+    } finally {
+      counter.decrementAndGet();
     }
   }
 
   public void flush() throws IOException {
+    assertClose();
     try (ManagedFlushOptions options = new ManagedFlushOptions()) {
+      counter.incrementAndGet();
       options.setWaitForFlush(true);
       db.get().flush(options);
     } catch (RocksDBException e) {
-      closeOnError(e);
+      closeOnError(e, true);
       throw toIOException(this, "flush", e);
+    } finally {
+      counter.decrementAndGet();
     }
   }
 
   public void flushWal(boolean sync) throws IOException {
+    assertClose();
     try {
+      counter.incrementAndGet();
       db.get().flushWal(sync);
     } catch (RocksDBException e) {
-      closeOnError(e);
+      closeOnError(e, true);
       throw toIOException(this, "flushWal with sync=" + sync, e);
+    } finally {
+      counter.decrementAndGet();
     }
   }
 
   public void compactRange() throws IOException {
+    assertClose();
     try {
+      counter.incrementAndGet();
       db.get().compactRange();
     } catch (RocksDBException e) {
-      closeOnError(e);
+      closeOnError(e, true);
       throw toIOException(this, "compactRange", e);
+    } finally {
+      counter.decrementAndGet();
     }
   }
 
@@ -386,8 +469,15 @@ public final class RocksDatabase {
    *         otherwise, return true.
    * @see org.rocksdb.RocksDB#keyMayExist(ColumnFamilyHandle, byte[], Holder)
    */
-  public boolean keyMayExist(ColumnFamily family, byte[] key) {
-    return db.get().keyMayExist(family.getHandle(), key, null);
+  public boolean keyMayExist(ColumnFamily family, byte[] key)
+      throws IOException {
+    assertClose();
+    try {
+      counter.incrementAndGet();
+      return db.get().keyMayExist(family.getHandle(), key, null);
+    } finally {
+      counter.decrementAndGet();
+    }
   }
 
   /**
@@ -396,10 +486,16 @@ public final class RocksDatabase {
    * @see org.rocksdb.RocksDB#keyMayExist(ColumnFamilyHandle, byte[], Holder)
    */
   public Supplier<byte[]> keyMayExistHolder(ColumnFamily family,
-      byte[] key) {
-    final Holder<byte[]> out = new Holder<>();
-    return db.get().keyMayExist(family.getHandle(), key, out) ?
-        out::getValue : null;
+      byte[] key) throws IOException {
+    assertClose();
+    try {
+      counter.incrementAndGet();
+      final Holder<byte[]> out = new Holder<>();
+      return db.get().keyMayExist(family.getHandle(), key, out) ?
+          out::getValue : null;
+    } finally {
+      counter.decrementAndGet();
+    }
   }
 
   public ColumnFamily getColumnFamily(String key) {
@@ -411,12 +507,16 @@ public final class RocksDatabase {
   }
 
   public byte[] get(ColumnFamily family, byte[] key) throws IOException {
+    assertClose();
     try {
+      counter.incrementAndGet();
       return db.get().get(family.getHandle(), key);
     } catch (RocksDBException e) {
-      closeOnError(e);
+      closeOnError(e, true);
       final String message = "get " + bytes2String(key) + " from " + family;
       throw toIOException(this, message, e);
+    } finally {
+      counter.decrementAndGet();
     }
   }
 
@@ -429,78 +529,118 @@ public final class RocksDatabase {
   }
 
   private long getLongProperty(String key) throws IOException {
+    assertClose();
     try {
+      counter.incrementAndGet();
       return db.get().getLongProperty(key);
     } catch (RocksDBException e) {
-      closeOnError(e);
+      closeOnError(e, true);
       throw toIOException(this, "getLongProperty " + key, e);
+    } finally {
+      counter.decrementAndGet();
     }
   }
 
   private long getLongProperty(ColumnFamily family, String key)
       throws IOException {
+    assertClose();
     try {
+      counter.incrementAndGet();
       return db.get().getLongProperty(family.getHandle(), key);
     } catch (RocksDBException e) {
-      closeOnError(e);
+      closeOnError(e, true);
       final String message = "getLongProperty " + key + " from " + family;
       throw toIOException(this, message, e);
+    } finally {
+      counter.decrementAndGet();
     }
   }
 
   public String getProperty(String key) throws IOException {
+    assertClose();
     try {
+      counter.incrementAndGet();
       return db.get().getProperty(key);
     } catch (RocksDBException e) {
-      closeOnError(e);
+      closeOnError(e, true);
       throw toIOException(this, "getProperty " + key, e);
+    } finally {
+      counter.decrementAndGet();
     }
   }
 
   public String getProperty(ColumnFamily family, String key)
       throws IOException {
+    assertClose();
     try {
+      counter.incrementAndGet();
       return db.get().getProperty(family.getHandle(), key);
     } catch (RocksDBException e) {
-      closeOnError(e);
+      closeOnError(e, true);
       throw toIOException(this, "getProperty " + key + " from " + family, e);
+    } finally {
+      counter.decrementAndGet();
     }
   }
 
   public ManagedTransactionLogIterator getUpdatesSince(long sequenceNumber)
       throws IOException {
+    assertClose();
     try {
+      counter.incrementAndGet();
       return managed(db.get().getUpdatesSince(sequenceNumber));
     } catch (RocksDBException e) {
-      closeOnError(e);
+      closeOnError(e, true);
       throw toIOException(this, "getUpdatesSince " + sequenceNumber, e);
+    } finally {
+      counter.decrementAndGet();
     }
   }
 
   public long getLatestSequenceNumber() {
-    return db.get().getLatestSequenceNumber();
+    try {
+      counter.incrementAndGet();
+      return db.get().getLatestSequenceNumber();
+    } finally {
+      counter.decrementAndGet();
+    }
   }
 
-  public ManagedRocksIterator newIterator(ColumnFamily family) {
-    return managed(db.get().newIterator(family.getHandle()));
+  public ManagedRocksIterator newIterator(ColumnFamily family)
+      throws IOException {
+    assertClose();
+    try {
+      counter.incrementAndGet();
+      return managed(db.get().newIterator(family.getHandle()));
+    } finally {
+      counter.decrementAndGet();
+    }
   }
 
   public ManagedRocksIterator newIterator(ColumnFamily family,
-                                          boolean fillCache) {
+      boolean fillCache) throws IOException {
+    assertClose();
     try (ManagedReadOptions readOptions = new ManagedReadOptions()) {
+      counter.incrementAndGet();
       readOptions.setFillCache(fillCache);
       return managed(db.get().newIterator(family.getHandle(), readOptions));
+    } finally {
+      counter.decrementAndGet();
     }
   }
 
   public void batchWrite(ManagedWriteBatch writeBatch,
                          ManagedWriteOptions options)
       throws IOException {
+    assertClose();
     try {
+      counter.incrementAndGet();
       db.get().write(options, writeBatch);
     } catch (RocksDBException e) {
-      closeOnError(e);
+      closeOnError(e, true);
       throw toIOException(this, "batchWrite", e);
+    } finally {
+      counter.decrementAndGet();
     }
   }
 
@@ -509,12 +649,16 @@ public final class RocksDatabase {
   }
 
   public void delete(ColumnFamily family, byte[] key) throws IOException {
+    assertClose();
     try {
+      counter.incrementAndGet();
       db.get().delete(family.getHandle(), key);
     } catch (RocksDBException e) {
-      closeOnError(e);
+      closeOnError(e, true);
       final String message = "delete " + bytes2String(key) + " from " + family;
       throw toIOException(this, message, e);
+    } finally {
+      counter.decrementAndGet();
     }
   }
 

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/RocksDatabase.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/RocksDatabase.java
@@ -340,9 +340,8 @@ public final class RocksDatabase {
       if (columnFamilies != null) {
         columnFamilies.values().stream().forEach(f -> f.markClosed());
       }
-      // each loop 1 milli sec, 5000 loop mak 5 sec wait
-      final int maxLoop = 5000;
-      for (int i = 0; i < maxLoop; ++i) {
+      // wait till all access to rocks db is process to avoid crash while close
+      while (true) {
         if (counter.get() == 0) {
           break;
         }
@@ -355,7 +354,7 @@ public final class RocksDatabase {
         }
       }
       
-      // After counter is 0 or max re-try, do force close
+      // close when counter is 0, no more operation
       close(columnFamilies, db, descriptors, writeOptions, dbOptions);
     }
   }

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/RocksDatabase.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/RocksDatabase.java
@@ -344,7 +344,6 @@ public final class RocksDatabase {
       final int maxLoop = 5000;
       for (int i = 0; i < maxLoop; ++i) {
         if (counter.get() == 0) {
-          close(columnFamilies, db, descriptors, writeOptions, dbOptions);
           break;
         }
         try {
@@ -352,9 +351,12 @@ public final class RocksDatabase {
         } catch (InterruptedException e) {
           close(columnFamilies, db, descriptors, writeOptions, dbOptions);
           Thread.currentThread().interrupt();
-          break;
+          return;
         }
       }
+      
+      // After counter is 0 or max re-try, do force close
+      close(columnFamilies, db, descriptors, writeOptions, dbOptions);
     }
   }
 

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/Table.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/Table.java
@@ -151,8 +151,10 @@ public interface Table<KEY, VALUE> extends AutoCloseable {
    * Returns the iterator for this metadata store.
    *
    * @return MetaStoreIterator
+   * @throws IOException on failure.
    */
-  TableIterator<KEY, ? extends KeyValue<KEY, VALUE>> iterator();
+  TableIterator<KEY, ? extends KeyValue<KEY, VALUE>> iterator()
+      throws IOException;
 
   /**
    * Returns a prefixed iterator for this metadata store.

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/TypedTable.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/TypedTable.java
@@ -275,7 +275,7 @@ public class TypedTable<KEY, VALUE> implements Table<KEY, VALUE> {
   }
 
   @Override
-  public TableIterator<KEY, TypedKeyValue> iterator() {
+  public TableIterator<KEY, TypedKeyValue> iterator() throws IOException {
     TableIterator<byte[], ? extends KeyValue<byte[], byte[]>> iterator =
         rawTable.iterator();
     return new TypedTableIterator(iterator, keyType, valueType);

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/block/DeletedBlockLogStateManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/block/DeletedBlockLogStateManager.java
@@ -49,7 +49,8 @@ public interface DeletedBlockLogStateManager {
       throws IOException, TimeoutException;
 
   TableIterator<Long,
-      KeyValue<Long, DeletedBlocksTransaction>> getReadOnlyIterator();
+      KeyValue<Long, DeletedBlocksTransaction>> getReadOnlyIterator()
+      throws IOException;
 
   void onFlush();
 

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/block/DeletedBlockLogStateManagerImpl.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/block/DeletedBlockLogStateManagerImpl.java
@@ -72,7 +72,7 @@ public class DeletedBlockLogStateManagerImpl
   }
 
   public TableIterator<Long, TypedTable.KeyValue<Long,
-      DeletedBlocksTransaction>> getReadOnlyIterator() {
+      DeletedBlocksTransaction>> getReadOnlyIterator() throws IOException {
     return new TableIterator<Long, TypedTable.KeyValue<Long,
         DeletedBlocksTransaction>>() {
 

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/metadata/SCMMetadataStoreImpl.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/metadata/SCMMetadataStoreImpl.java
@@ -17,47 +17,49 @@
  */
 package org.apache.hadoop.hdds.scm.metadata;
 
-import com.google.protobuf.ByteString;
 import java.io.File;
 import java.io.IOException;
 import java.math.BigInteger;
 import java.security.cert.X509Certificate;
+
+import com.google.protobuf.ByteString;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.DeletedBlocksTransaction;
 import org.apache.hadoop.hdds.scm.container.ContainerID;
 import org.apache.hadoop.hdds.scm.container.ContainerInfo;
 import org.apache.hadoop.hdds.scm.container.common.helpers.MoveDataNodePair;
-import org.apache.hadoop.hdds.scm.pipeline.Pipeline;
-import org.apache.hadoop.hdds.scm.pipeline.PipelineID;
 import org.apache.hadoop.hdds.security.x509.certificate.CertInfo;
-import org.apache.hadoop.hdds.security.x509.certificate.authority.CertificateStore;
-import org.apache.hadoop.hdds.security.x509.crl.CRLInfo;
 import org.apache.hadoop.hdds.utils.HAUtils;
 import org.apache.hadoop.hdds.utils.TransactionInfo;
+import org.apache.hadoop.hdds.scm.pipeline.Pipeline;
+import org.apache.hadoop.hdds.scm.pipeline.PipelineID;
+import org.apache.hadoop.hdds.security.x509.certificate.authority.CertificateStore;
+import org.apache.hadoop.hdds.security.x509.crl.CRLInfo;
 import org.apache.hadoop.hdds.utils.db.BatchOperationHandler;
 import org.apache.hadoop.hdds.utils.db.DBStore;
 import org.apache.hadoop.hdds.utils.db.DBStoreBuilder;
 import org.apache.hadoop.hdds.utils.db.Table;
 import org.apache.hadoop.hdds.utils.db.TableIterator;
-import org.apache.ratis.util.ExitUtils;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import static org.apache.hadoop.hdds.scm.metadata.SCMDBDefinition.CONTAINERS;
 import static org.apache.hadoop.hdds.scm.metadata.SCMDBDefinition.CRLS;
 import static org.apache.hadoop.hdds.scm.metadata.SCMDBDefinition.CRL_SEQUENCE_ID;
 import static org.apache.hadoop.hdds.scm.metadata.SCMDBDefinition.DELETED_BLOCKS;
-import static org.apache.hadoop.hdds.scm.metadata.SCMDBDefinition.META;
 import static org.apache.hadoop.hdds.scm.metadata.SCMDBDefinition.MOVE;
 import static org.apache.hadoop.hdds.scm.metadata.SCMDBDefinition.PIPELINES;
 import static org.apache.hadoop.hdds.scm.metadata.SCMDBDefinition.REVOKED_CERTS;
 import static org.apache.hadoop.hdds.scm.metadata.SCMDBDefinition.REVOKED_CERTS_V2;
-import static org.apache.hadoop.hdds.scm.metadata.SCMDBDefinition.SEQUENCE_ID;
 import static org.apache.hadoop.hdds.scm.metadata.SCMDBDefinition.STATEFUL_SERVICE_CONFIG;
 import static org.apache.hadoop.hdds.scm.metadata.SCMDBDefinition.TRANSACTIONINFO;
 import static org.apache.hadoop.hdds.scm.metadata.SCMDBDefinition.VALID_CERTS;
 import static org.apache.hadoop.hdds.scm.metadata.SCMDBDefinition.VALID_SCM_CERTS;
+import static org.apache.hadoop.hdds.scm.metadata.SCMDBDefinition.SEQUENCE_ID;
+import static org.apache.hadoop.hdds.scm.metadata.SCMDBDefinition.META;
 import static org.apache.hadoop.ozone.OzoneConsts.DB_TRANSIENT_MARKER;
+
+import org.apache.ratis.util.ExitUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * A RocksDB based implementation of SCM Metadata Store.

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/metadata/SCMMetadataStoreImpl.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/metadata/SCMMetadataStoreImpl.java
@@ -17,49 +17,47 @@
  */
 package org.apache.hadoop.hdds.scm.metadata;
 
+import com.google.protobuf.ByteString;
 import java.io.File;
 import java.io.IOException;
 import java.math.BigInteger;
 import java.security.cert.X509Certificate;
-
-import com.google.protobuf.ByteString;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.DeletedBlocksTransaction;
 import org.apache.hadoop.hdds.scm.container.ContainerID;
 import org.apache.hadoop.hdds.scm.container.ContainerInfo;
 import org.apache.hadoop.hdds.scm.container.common.helpers.MoveDataNodePair;
-import org.apache.hadoop.hdds.security.x509.certificate.CertInfo;
-import org.apache.hadoop.hdds.utils.HAUtils;
-import org.apache.hadoop.hdds.utils.TransactionInfo;
 import org.apache.hadoop.hdds.scm.pipeline.Pipeline;
 import org.apache.hadoop.hdds.scm.pipeline.PipelineID;
+import org.apache.hadoop.hdds.security.x509.certificate.CertInfo;
 import org.apache.hadoop.hdds.security.x509.certificate.authority.CertificateStore;
 import org.apache.hadoop.hdds.security.x509.crl.CRLInfo;
+import org.apache.hadoop.hdds.utils.HAUtils;
+import org.apache.hadoop.hdds.utils.TransactionInfo;
 import org.apache.hadoop.hdds.utils.db.BatchOperationHandler;
 import org.apache.hadoop.hdds.utils.db.DBStore;
 import org.apache.hadoop.hdds.utils.db.DBStoreBuilder;
 import org.apache.hadoop.hdds.utils.db.Table;
 import org.apache.hadoop.hdds.utils.db.TableIterator;
+import org.apache.ratis.util.ExitUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import static org.apache.hadoop.hdds.scm.metadata.SCMDBDefinition.CONTAINERS;
 import static org.apache.hadoop.hdds.scm.metadata.SCMDBDefinition.CRLS;
 import static org.apache.hadoop.hdds.scm.metadata.SCMDBDefinition.CRL_SEQUENCE_ID;
 import static org.apache.hadoop.hdds.scm.metadata.SCMDBDefinition.DELETED_BLOCKS;
+import static org.apache.hadoop.hdds.scm.metadata.SCMDBDefinition.META;
 import static org.apache.hadoop.hdds.scm.metadata.SCMDBDefinition.MOVE;
 import static org.apache.hadoop.hdds.scm.metadata.SCMDBDefinition.PIPELINES;
 import static org.apache.hadoop.hdds.scm.metadata.SCMDBDefinition.REVOKED_CERTS;
 import static org.apache.hadoop.hdds.scm.metadata.SCMDBDefinition.REVOKED_CERTS_V2;
+import static org.apache.hadoop.hdds.scm.metadata.SCMDBDefinition.SEQUENCE_ID;
 import static org.apache.hadoop.hdds.scm.metadata.SCMDBDefinition.STATEFUL_SERVICE_CONFIG;
 import static org.apache.hadoop.hdds.scm.metadata.SCMDBDefinition.TRANSACTIONINFO;
 import static org.apache.hadoop.hdds.scm.metadata.SCMDBDefinition.VALID_CERTS;
 import static org.apache.hadoop.hdds.scm.metadata.SCMDBDefinition.VALID_SCM_CERTS;
-import static org.apache.hadoop.hdds.scm.metadata.SCMDBDefinition.SEQUENCE_ID;
-import static org.apache.hadoop.hdds.scm.metadata.SCMDBDefinition.META;
 import static org.apache.hadoop.ozone.OzoneConsts.DB_TRANSIENT_MARKER;
-
-import org.apache.ratis.util.ExitUtils;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * A RocksDB based implementation of SCM Metadata Store.
@@ -253,7 +251,8 @@ public class SCMMetadataStoreImpl implements SCMMetadataStore {
   }
 
   @Override
-  public TableIterator getAllCerts(CertificateStore.CertType certType) {
+  public TableIterator getAllCerts(CertificateStore.CertType certType)
+      throws IOException {
     if (certType == CertificateStore.CertType.VALID_CERTS) {
       return validCertsTable.iterator();
     }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestObjectStoreWithLegacyFS.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestObjectStoreWithLegacyFS.java
@@ -145,10 +145,10 @@ public class TestObjectStoreWithLegacyFS {
   private boolean assertKeyCount(
       Table<String, OmKeyInfo> keyTable,
       String dbKey, int expectedCnt, String keyName) {
-    TableIterator<String, ? extends Table.KeyValue<String, OmKeyInfo>>
-        itr = keyTable.iterator();
     int countKeys = 0;
     try {
+      TableIterator<String, ? extends Table.KeyValue<String, OmKeyInfo>>
+          itr = keyTable.iterator();
       itr.seek(dbKey);
       while (itr.hasNext()) {
 

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerHAKeyDeletion.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerHAKeyDeletion.java
@@ -69,8 +69,14 @@ public class TestOzoneManagerHAKeyDeletion extends TestOzoneManagerHA {
     // Check delete table is empty or not on all OMs.
     getCluster().getOzoneManagersList().forEach((om) -> {
       try {
-        GenericTestUtils.waitFor(() ->
-                !om.getMetadataManager().getDeletedTable().iterator().hasNext(),
+        GenericTestUtils.waitFor(() -> {
+          try {
+            return !om.getMetadataManager().getDeletedTable().iterator()
+                .hasNext();
+          } catch (Exception ex) {
+            return false;
+          }
+        },
             10000, 120000);
       } catch (Exception ex) {
         fail("TestOzoneManagerHAKeyDeletion failed");

--- a/hadoop-ozone/interface-storage/src/main/java/org/apache/hadoop/ozone/om/OMMetadataManager.java
+++ b/hadoop-ozone/interface-storage/src/main/java/org/apache/hadoop/ozone/om/OMMetadataManager.java
@@ -433,7 +433,7 @@ public interface OMMetadataManager extends DBStoreHAManager {
       getBucketIterator();
 
   TableIterator<String, ? extends Table.KeyValue<String, OmKeyInfo>>
-      getKeyIterator();
+      getKeyIterator() throws IOException;
 
   /**
    * Given parent object id and path component name, return the corresponding

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/KeyManagerImpl.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/KeyManagerImpl.java
@@ -16,9 +16,6 @@
  */
 package org.apache.hadoop.ozone.om;
 
-import com.google.common.annotations.VisibleForTesting;
-import com.google.common.base.Preconditions;
-import com.google.common.base.Strings;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -43,7 +40,6 @@ import java.util.TreeMap;
 import java.util.TreeSet;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
-import org.apache.commons.lang3.StringUtils;
 import org.apache.hadoop.conf.StorageUnit;
 import org.apache.hadoop.crypto.key.KeyProviderCryptoExtension;
 import org.apache.hadoop.crypto.key.KeyProviderCryptoExtension.EncryptedKeyVersion;
@@ -57,7 +53,6 @@ import org.apache.hadoop.hdds.scm.container.common.helpers.ContainerWithPipeline
 import org.apache.hadoop.hdds.scm.pipeline.Pipeline;
 import org.apache.hadoop.hdds.scm.protocol.ScmBlockLocationProtocol;
 import org.apache.hadoop.hdds.scm.protocol.StorageContainerLocationProtocol;
-import org.apache.hadoop.hdds.security.token.OzoneBlockTokenSecretManager;
 import org.apache.hadoop.hdds.utils.BackgroundService;
 import org.apache.hadoop.hdds.utils.db.CodecRegistry;
 import org.apache.hadoop.hdds.utils.db.RDBStore;
@@ -72,7 +67,6 @@ import org.apache.hadoop.ozone.common.BlockGroup;
 import org.apache.hadoop.ozone.om.exceptions.OMException;
 import org.apache.hadoop.ozone.om.exceptions.OMException.ResultCodes;
 import org.apache.hadoop.ozone.om.helpers.BucketEncryptionKeyInfo;
-import org.apache.hadoop.ozone.om.helpers.BucketLayout;
 import org.apache.hadoop.ozone.om.helpers.OmBucketInfo;
 import org.apache.hadoop.ozone.om.helpers.OmDirectoryInfo;
 import org.apache.hadoop.ozone.om.helpers.OmKeyArgs;
@@ -88,18 +82,23 @@ import org.apache.hadoop.ozone.om.helpers.OzoneAclUtil;
 import org.apache.hadoop.ozone.om.helpers.OzoneFSUtils;
 import org.apache.hadoop.ozone.om.helpers.OzoneFileStatus;
 import org.apache.hadoop.ozone.om.helpers.RepeatedOmKeyInfo;
+import org.apache.hadoop.ozone.om.helpers.BucketLayout;
 import org.apache.hadoop.ozone.om.request.OMClientRequest;
 import org.apache.hadoop.ozone.om.request.file.OMFileRequest;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OpenKeyBucket;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.PartKeyInfo;
+import org.apache.hadoop.hdds.security.token.OzoneBlockTokenSecretManager;
 import org.apache.hadoop.ozone.security.acl.IAccessAuthorizer;
 import org.apache.hadoop.ozone.security.acl.OzoneObj;
 import org.apache.hadoop.ozone.security.acl.RequestContext;
 import org.apache.hadoop.security.SecurityUtil;
 import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.hadoop.util.Time;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Preconditions;
+import com.google.common.base.Strings;
+import org.apache.commons.lang3.StringUtils;
 
 import static org.apache.hadoop.fs.CommonConfigurationKeysPublic.HADOOP_SECURITY_KEY_PROVIDER_PATH;
 import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_BLOCK_TOKEN_ENABLED;
@@ -137,6 +136,9 @@ import static org.apache.hadoop.ozone.om.exceptions.OMException.ResultCodes.VOLU
 import static org.apache.hadoop.ozone.om.lock.OzoneManagerLock.Resource.BUCKET_LOCK;
 import static org.apache.hadoop.ozone.security.acl.OzoneObj.ResourceType.KEY;
 import static org.apache.hadoop.util.Time.monotonicNow;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Implementation of keyManager.

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmMetadataManagerImpl.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmMetadataManagerImpl.java
@@ -16,6 +16,9 @@
  */
 package org.apache.hadoop.ozone.om;
 
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Strings;
+import com.google.common.collect.Lists;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Paths;
@@ -30,9 +33,11 @@ import java.util.Set;
 import java.util.TreeMap;
 import java.util.TreeSet;
 import java.util.stream.Collectors;
-
+import org.apache.commons.lang3.StringUtils;
 import org.apache.hadoop.hdds.client.BlockID;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import org.apache.hadoop.hdds.utils.TransactionInfo;
+import org.apache.hadoop.hdds.utils.TransactionInfoCodec;
 import org.apache.hadoop.hdds.utils.db.DBStore;
 import org.apache.hadoop.hdds.utils.db.DBStoreBuilder;
 import org.apache.hadoop.hdds.utils.db.RocksDBConfiguration;
@@ -46,15 +51,14 @@ import org.apache.hadoop.hdds.utils.db.cache.TableCache.CacheType;
 import org.apache.hadoop.ozone.OmUtils;
 import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.hadoop.ozone.common.BlockGroup;
-import org.apache.hadoop.hdds.utils.TransactionInfoCodec;
 import org.apache.hadoop.ozone.om.codec.OmBucketInfoCodec;
 import org.apache.hadoop.ozone.om.codec.OmDBAccessIdInfoCodec;
+import org.apache.hadoop.ozone.om.codec.OmDBTenantStateCodec;
 import org.apache.hadoop.ozone.om.codec.OmDBUserPrincipalInfoCodec;
 import org.apache.hadoop.ozone.om.codec.OmDirectoryInfoCodec;
 import org.apache.hadoop.ozone.om.codec.OmKeyInfoCodec;
 import org.apache.hadoop.ozone.om.codec.OmMultipartKeyInfoCodec;
 import org.apache.hadoop.ozone.om.codec.OmPrefixInfoCodec;
-import org.apache.hadoop.ozone.om.codec.OmDBTenantStateCodec;
 import org.apache.hadoop.ozone.om.codec.OmVolumeArgsCodec;
 import org.apache.hadoop.ozone.om.codec.RepeatedOmKeyInfoCodec;
 import org.apache.hadoop.ozone.om.codec.S3SecretValueCodec;
@@ -62,8 +66,10 @@ import org.apache.hadoop.ozone.om.codec.TokenIdentifierCodec;
 import org.apache.hadoop.ozone.om.codec.UserVolumeInfoCodec;
 import org.apache.hadoop.ozone.om.exceptions.OMException;
 import org.apache.hadoop.ozone.om.exceptions.OMException.ResultCodes;
+import org.apache.hadoop.ozone.om.helpers.BucketLayout;
 import org.apache.hadoop.ozone.om.helpers.OmBucketInfo;
 import org.apache.hadoop.ozone.om.helpers.OmDBAccessIdInfo;
+import org.apache.hadoop.ozone.om.helpers.OmDBTenantState;
 import org.apache.hadoop.ozone.om.helpers.OmDBUserPrincipalInfo;
 import org.apache.hadoop.ozone.om.helpers.OmDirectoryInfo;
 import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
@@ -71,34 +77,25 @@ import org.apache.hadoop.ozone.om.helpers.OmKeyLocationInfoGroup;
 import org.apache.hadoop.ozone.om.helpers.OmMultipartKeyInfo;
 import org.apache.hadoop.ozone.om.helpers.OmMultipartUpload;
 import org.apache.hadoop.ozone.om.helpers.OmPrefixInfo;
-import org.apache.hadoop.ozone.om.helpers.OmDBTenantState;
 import org.apache.hadoop.ozone.om.helpers.OmVolumeArgs;
 import org.apache.hadoop.ozone.om.helpers.OzoneFSUtils;
 import org.apache.hadoop.ozone.om.helpers.RepeatedOmKeyInfo;
 import org.apache.hadoop.ozone.om.helpers.S3SecretValue;
-import org.apache.hadoop.ozone.om.helpers.BucketLayout;
 import org.apache.hadoop.ozone.om.lock.OzoneManagerLock;
-import org.apache.hadoop.hdds.utils.TransactionInfo;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OpenKey;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OpenKeyBucket;
-import org.apache.hadoop.ozone.storage.proto
-    .OzoneManagerStorageProtos.PersistedUserVolumeInfo;
 import org.apache.hadoop.ozone.security.OzoneTokenIdentifier;
+import org.apache.hadoop.ozone.storage.proto.OzoneManagerStorageProtos.PersistedUserVolumeInfo;
+import org.apache.ratis.util.ExitUtils;
+import org.eclipse.jetty.util.StringUtil;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
-import com.google.common.annotations.VisibleForTesting;
-import com.google.common.base.Strings;
-import com.google.common.collect.Lists;
-import org.apache.commons.lang3.StringUtils;
 import static org.apache.hadoop.ozone.OzoneConsts.DB_TRANSIENT_MARKER;
 import static org.apache.hadoop.ozone.OzoneConsts.OM_DB_NAME;
 import static org.apache.hadoop.ozone.OzoneConsts.OM_KEY_PREFIX;
 import static org.apache.hadoop.ozone.om.exceptions.OMException.ResultCodes.BUCKET_NOT_FOUND;
 import static org.apache.hadoop.ozone.om.exceptions.OMException.ResultCodes.VOLUME_NOT_FOUND;
-
-import org.apache.ratis.util.ExitUtils;
-import org.eclipse.jetty.util.StringUtil;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * Ozone metadata manager interface.
@@ -969,7 +966,7 @@ public class OmMetadataManagerImpl implements OMMetadataManager {
 
   @Override
   public TableIterator<String, ? extends KeyValue<String, OmKeyInfo>>
-      getKeyIterator() {
+      getKeyIterator() throws IOException {
     return keyTable.iterator();
   }
 

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/spi/impl/ReconContainerMetadataManagerImpl.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/spi/impl/ReconContainerMetadataManagerImpl.java
@@ -18,13 +18,6 @@
 
 package org.apache.hadoop.ozone.recon.spi.impl;
 
-import static org.apache.hadoop.ozone.recon.ReconConstants.CONTAINER_COUNT_KEY;
-import static org.apache.hadoop.ozone.recon.spi.impl.ReconDBDefinition.KEY_CONTAINER;
-import static org.apache.hadoop.ozone.recon.spi.impl.ReconDBDefinition.REPLICA_HISTORY_V2;
-import static org.apache.hadoop.ozone.recon.spi.impl.ReconDBProvider.truncateTable;
-import static org.apache.hadoop.ozone.recon.spi.impl.ReconDBDefinition.CONTAINER_KEY;
-import static org.apache.hadoop.ozone.recon.spi.impl.ReconDBDefinition.CONTAINER_KEY_COUNT;
-
 import java.io.IOException;
 import java.time.Duration;
 import java.time.Instant;
@@ -34,13 +27,15 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
-
 import javax.inject.Inject;
 import javax.inject.Singleton;
-
 import org.apache.commons.lang3.StringUtils;
 import org.apache.hadoop.hdds.utils.db.BatchOperation;
+import org.apache.hadoop.hdds.utils.db.DBStore;
 import org.apache.hadoop.hdds.utils.db.RDBBatchOperation;
+import org.apache.hadoop.hdds.utils.db.Table;
+import org.apache.hadoop.hdds.utils.db.Table.KeyValue;
+import org.apache.hadoop.hdds.utils.db.TableIterator;
 import org.apache.hadoop.ozone.recon.ReconUtils;
 import org.apache.hadoop.ozone.recon.api.types.ContainerKeyPrefix;
 import org.apache.hadoop.ozone.recon.api.types.ContainerMetadata;
@@ -48,15 +43,18 @@ import org.apache.hadoop.ozone.recon.api.types.KeyPrefixContainer;
 import org.apache.hadoop.ozone.recon.scm.ContainerReplicaHistory;
 import org.apache.hadoop.ozone.recon.scm.ContainerReplicaHistoryList;
 import org.apache.hadoop.ozone.recon.spi.ReconContainerMetadataManager;
-import org.apache.hadoop.hdds.utils.db.DBStore;
-import org.apache.hadoop.hdds.utils.db.Table;
-import org.apache.hadoop.hdds.utils.db.Table.KeyValue;
-import org.apache.hadoop.hdds.utils.db.TableIterator;
 import org.hadoop.ozone.recon.schema.tables.daos.GlobalStatsDao;
 import org.hadoop.ozone.recon.schema.tables.pojos.GlobalStats;
 import org.jooq.Configuration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import static org.apache.hadoop.ozone.recon.ReconConstants.CONTAINER_COUNT_KEY;
+import static org.apache.hadoop.ozone.recon.spi.impl.ReconDBDefinition.CONTAINER_KEY;
+import static org.apache.hadoop.ozone.recon.spi.impl.ReconDBDefinition.CONTAINER_KEY_COUNT;
+import static org.apache.hadoop.ozone.recon.spi.impl.ReconDBDefinition.KEY_CONTAINER;
+import static org.apache.hadoop.ozone.recon.spi.impl.ReconDBDefinition.REPLICA_HISTORY_V2;
+import static org.apache.hadoop.ozone.recon.spi.impl.ReconDBProvider.truncateTable;
 
 /**
  * Implementation of the Recon Container DB Service.
@@ -506,12 +504,12 @@ public class ReconContainerMetadataManagerImpl
   }
 
   @Override
-  public TableIterator getContainerTableIterator() {
+  public TableIterator getContainerTableIterator() throws IOException {
     return containerKeyTable.iterator();
   }
 
   @Override
-  public TableIterator getKeyContainerTableIterator() {
+  public TableIterator getKeyContainerTableIterator() throws IOException {
     return keyContainerTable.iterator();
   }
 

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/spi/impl/ReconContainerMetadataManagerImpl.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/spi/impl/ReconContainerMetadataManagerImpl.java
@@ -18,6 +18,13 @@
 
 package org.apache.hadoop.ozone.recon.spi.impl;
 
+import static org.apache.hadoop.ozone.recon.ReconConstants.CONTAINER_COUNT_KEY;
+import static org.apache.hadoop.ozone.recon.spi.impl.ReconDBDefinition.KEY_CONTAINER;
+import static org.apache.hadoop.ozone.recon.spi.impl.ReconDBDefinition.REPLICA_HISTORY_V2;
+import static org.apache.hadoop.ozone.recon.spi.impl.ReconDBProvider.truncateTable;
+import static org.apache.hadoop.ozone.recon.spi.impl.ReconDBDefinition.CONTAINER_KEY;
+import static org.apache.hadoop.ozone.recon.spi.impl.ReconDBDefinition.CONTAINER_KEY_COUNT;
+
 import java.io.IOException;
 import java.time.Duration;
 import java.time.Instant;
@@ -27,15 +34,13 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
+
 import javax.inject.Inject;
 import javax.inject.Singleton;
+
 import org.apache.commons.lang3.StringUtils;
 import org.apache.hadoop.hdds.utils.db.BatchOperation;
-import org.apache.hadoop.hdds.utils.db.DBStore;
 import org.apache.hadoop.hdds.utils.db.RDBBatchOperation;
-import org.apache.hadoop.hdds.utils.db.Table;
-import org.apache.hadoop.hdds.utils.db.Table.KeyValue;
-import org.apache.hadoop.hdds.utils.db.TableIterator;
 import org.apache.hadoop.ozone.recon.ReconUtils;
 import org.apache.hadoop.ozone.recon.api.types.ContainerKeyPrefix;
 import org.apache.hadoop.ozone.recon.api.types.ContainerMetadata;
@@ -43,18 +48,15 @@ import org.apache.hadoop.ozone.recon.api.types.KeyPrefixContainer;
 import org.apache.hadoop.ozone.recon.scm.ContainerReplicaHistory;
 import org.apache.hadoop.ozone.recon.scm.ContainerReplicaHistoryList;
 import org.apache.hadoop.ozone.recon.spi.ReconContainerMetadataManager;
+import org.apache.hadoop.hdds.utils.db.DBStore;
+import org.apache.hadoop.hdds.utils.db.Table;
+import org.apache.hadoop.hdds.utils.db.Table.KeyValue;
+import org.apache.hadoop.hdds.utils.db.TableIterator;
 import org.hadoop.ozone.recon.schema.tables.daos.GlobalStatsDao;
 import org.hadoop.ozone.recon.schema.tables.pojos.GlobalStats;
 import org.jooq.Configuration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import static org.apache.hadoop.ozone.recon.ReconConstants.CONTAINER_COUNT_KEY;
-import static org.apache.hadoop.ozone.recon.spi.impl.ReconDBDefinition.CONTAINER_KEY;
-import static org.apache.hadoop.ozone.recon.spi.impl.ReconDBDefinition.CONTAINER_KEY_COUNT;
-import static org.apache.hadoop.ozone.recon.spi.impl.ReconDBDefinition.KEY_CONTAINER;
-import static org.apache.hadoop.ozone.recon.spi.impl.ReconDBDefinition.REPLICA_HISTORY_V2;
-import static org.apache.hadoop.ozone.recon.spi.impl.ReconDBProvider.truncateTable;
 
 /**
  * Implementation of the Recon Container DB Service.

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/tasks/TestTableCountTask.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/tasks/TestTableCountTask.java
@@ -18,6 +18,8 @@
 
 package org.apache.hadoop.ozone.recon.tasks;
 
+import java.io.IOException;
+import java.util.ArrayList;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.hadoop.hdds.utils.db.TypedTable;
 import org.apache.hadoop.ozone.om.OMMetadataManager;
@@ -26,20 +28,16 @@ import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
 import org.apache.hadoop.ozone.recon.persistence.AbstractReconSqlDBTest;
 import org.apache.hadoop.ozone.recon.recovery.ReconOMMetadataManager;
 import org.apache.hadoop.ozone.recon.tasks.OMDBUpdateEvent.OMUpdateEventBuilder;
+import org.hadoop.ozone.recon.schema.tables.daos.GlobalStatsDao;
+import org.jooq.DSLContext;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import static org.apache.hadoop.ozone.om.OmMetadataManagerImpl.BUCKET_TABLE;
 import static org.apache.hadoop.ozone.om.OmMetadataManagerImpl.DELETED_TABLE;
 import static org.apache.hadoop.ozone.om.OmMetadataManagerImpl.KEY_TABLE;
 import static org.apache.hadoop.ozone.om.OmMetadataManagerImpl.OPEN_KEY_TABLE;
 import static org.apache.hadoop.ozone.om.OmMetadataManagerImpl.VOLUME_TABLE;
-import org.hadoop.ozone.recon.schema.tables.daos.GlobalStatsDao;
-import org.jooq.DSLContext;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-
-import java.io.IOException;
-import java.util.ArrayList;
-
 import static org.apache.hadoop.ozone.recon.OMMetadataManagerTestUtils.getTestReconOmMetadataManager;
 import static org.apache.hadoop.ozone.recon.OMMetadataManagerTestUtils.initializeNewOmMetadataManager;
 import static org.apache.hadoop.ozone.recon.tasks.OMDBUpdateEvent.OMDBUpdateAction.DELETE;
@@ -83,7 +81,7 @@ public class TestTableCountTask extends AbstractReconSqlDBTest {
   }
 
   @Test
-  public void testReprocess() {
+  public void testReprocess() throws Exception {
     OMMetadataManager omMetadataManager = mock(OmMetadataManagerImpl.class);
     // Mock 5 rows in each table and test the count
     for (String tableName: tableCountTask.getTaskTables()) {

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/tasks/TestTableCountTask.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/tasks/TestTableCountTask.java
@@ -18,8 +18,6 @@
 
 package org.apache.hadoop.ozone.recon.tasks;
 
-import java.io.IOException;
-import java.util.ArrayList;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.hadoop.hdds.utils.db.TypedTable;
 import org.apache.hadoop.ozone.om.OMMetadataManager;
@@ -28,16 +26,20 @@ import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
 import org.apache.hadoop.ozone.recon.persistence.AbstractReconSqlDBTest;
 import org.apache.hadoop.ozone.recon.recovery.ReconOMMetadataManager;
 import org.apache.hadoop.ozone.recon.tasks.OMDBUpdateEvent.OMUpdateEventBuilder;
-import org.hadoop.ozone.recon.schema.tables.daos.GlobalStatsDao;
-import org.jooq.DSLContext;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
 
 import static org.apache.hadoop.ozone.om.OmMetadataManagerImpl.BUCKET_TABLE;
 import static org.apache.hadoop.ozone.om.OmMetadataManagerImpl.DELETED_TABLE;
 import static org.apache.hadoop.ozone.om.OmMetadataManagerImpl.KEY_TABLE;
 import static org.apache.hadoop.ozone.om.OmMetadataManagerImpl.OPEN_KEY_TABLE;
 import static org.apache.hadoop.ozone.om.OmMetadataManagerImpl.VOLUME_TABLE;
+import org.hadoop.ozone.recon.schema.tables.daos.GlobalStatsDao;
+import org.jooq.DSLContext;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.util.ArrayList;
+
 import static org.apache.hadoop.ozone.recon.OMMetadataManagerTestUtils.getTestReconOmMetadataManager;
 import static org.apache.hadoop.ozone.recon.OMMetadataManagerTestUtils.initializeNewOmMetadataManager;
 import static org.apache.hadoop.ozone.recon.tasks.OMDBUpdateEvent.OMDBUpdateAction.DELETE;


### PR DESCRIPTION
## What changes were proposed in this pull request?

Added check for close of DB before db access, And a counter if any operation in progress
This counter is used for close to make sure operation is closed, and max wait for 5 sec for force close as strategy.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-7284


## How was this patch tested?

A test is performed to check if IO Exception after close is comming, as earlier it was causing Java crash,
