### PR TITLE
HDDS-6923. KEY_NOT_FOUND on deleting a key via Ozone Cli.

### DIFF
--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/OMClientRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/OMClientRequest.java
@@ -66,7 +66,7 @@ public abstract class OMClientRequest implements RequestAuditor {
       LoggerFactory.getLogger(OMClientRequest.class);
 
   private OMRequest omRequest;
-
+  private static BucketLayout layout;
   private UserGroupInformation userGroupInformation;
   private InetAddress inetAddress;
 
@@ -505,6 +505,7 @@ public abstract class OMClientRequest implements RequestAuditor {
 
   public static String validateAndNormalizeKey(boolean enableFileSystemPaths,
       String keyPath, BucketLayout bucketLayout) throws OMException {
+    layout = bucketLayout;
     LOG.debug("Bucket Layout: {}", bucketLayout);
     if (bucketLayout.shouldNormalizePaths(enableFileSystemPaths)) {
       keyPath = validateAndNormalizeKey(true, keyPath);
@@ -520,7 +521,12 @@ public abstract class OMClientRequest implements RequestAuditor {
 
   public static String validateAndNormalizeKey(String keyName)
       throws OMException {
-    String normalizedKeyName = OmUtils.normalizeKey(keyName, false);
+    String normalizedKeyName;
+    if (layout.equals(BucketLayout.LEGACY)) {
+      normalizedKeyName = OmUtils.normalizeKey(keyName, true);
+    } else {
+      normalizedKeyName = OmUtils.normalizeKey(keyName, false);
+    }
     return isValidKeyPath(normalizedKeyName);
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Added a check to prevent removal of trailing slash through normalization so as to prevent KEY_NOT_FOUND exception, this will allow Ozone Shell commands to delete directories present in Legacy Buckets. 
## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-6923

## How was this patch tested?
Tested it on my local Docker Cluster 
