### PR TITLE
HDDS-7293. Bump jackson2 to 2.13.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -136,8 +136,8 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
     <jersey2.version>2.34</jersey2.version>
 
     <!-- jackson versions -->
-    <jackson2.version>2.13.2</jackson2.version>
-    <jackson2.databind.version>2.13.2.2</jackson2.databind.version>
+    <jackson2.version>2.13.4</jackson2.version>
+    <jackson2.databind.version>2.13.4</jackson2.databind.version>
 
     <!-- jaegertracing veresion -->
     <jaeger.version>1.6.0</jaeger.version>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Bump Jackson2 to 2.13.4 for https://github.com/FasterXML/jackson-databind/commit/063183589218fec19a9293ed2f17ec53ea80ba88.

https://issues.apache.org/jira/browse/HDDS-7293

## How was this patch tested?

https://github.com/adoroszlai/hadoop-ozone/actions/runs/3200004358