### PR TITLE
HDDS-7299. Migrate simple tests in hdds-container-service to JUnit5

### DIFF
--- a/hadoop-hdds/container-service/pom.xml
+++ b/hadoop-hdds/container-service/pom.xml
@@ -127,6 +127,11 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
       <groupId>io.netty</groupId>
       <artifactId>netty-handler</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-junit-jupiter</artifactId>
+      <scope>test</scope>
+    </dependency>
 
   </dependencies>
 

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/hdds/datanode/metadata/TestDatanodeCRLStoreImpl.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/hdds/datanode/metadata/TestDatanodeCRLStoreImpl.java
@@ -31,17 +31,17 @@ import org.apache.ozone.test.GenericTestUtils;
 import org.bouncycastle.asn1.x509.CRLReason;
 import org.bouncycastle.cert.X509CertificateHolder;
 import org.bouncycastle.cert.X509v2CRLBuilder;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.io.File;
 import java.security.KeyPair;
 import java.security.cert.X509Certificate;
 import java.util.Date;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 /**
  * Test class for {@link DatanodeCRLStoreImpl}.
@@ -54,7 +54,7 @@ public class TestDatanodeCRLStoreImpl {
   private CRLApprover crlApprover;
   private SecurityConfig securityConfig;
 
-  @Before
+  @BeforeEach
   public void setUp() throws Exception {
     testDir = GenericTestUtils.getRandomizedTestDir();
     conf = new OzoneConfiguration();
@@ -62,24 +62,16 @@ public class TestDatanodeCRLStoreImpl {
     dnCRLStore = new DatanodeCRLStoreImpl(conf);
     keyPair = KeyStoreTestUtil.generateKeyPair("RSA");
     securityConfig = new SecurityConfig(conf);
-  }
-
-  @Before
-  public void initCRLApprover() {
     crlApprover = new DefaultCRLApprover(securityConfig,
         keyPair.getPrivate());
   }
 
-  @After
-  public void tearDown() {
-    FileUtil.fullyDelete(testDir);
-  }
-
-  @After
+  @AfterEach
   public void destroyDbStore() throws Exception {
     if (dnCRLStore.getStore() != null) {
       dnCRLStore.getStore().close();
     }
+    FileUtil.fullyDelete(testDir);
   }
   @Test
   public void testCRLStore() throws Exception {

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/TestHddsDatanodeService.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/TestHddsDatanodeService.java
@@ -27,16 +27,16 @@ import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.ozone.test.GenericTestUtils;
 import org.apache.hadoop.util.ServicePlugin;
 
-import org.junit.After;
+import org.junit.jupiter.api.AfterEach;
 
 import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_BLOCK_TOKEN_ENABLED;
 import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_CONTAINER_TOKEN_ENABLED;
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_SECURITY_ENABLED_KEY;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import org.junit.Before;
-import org.junit.Test;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * Test class for {@link HddsDatanodeService}.
@@ -47,7 +47,7 @@ public class TestHddsDatanodeService {
   private HddsDatanodeService service;
   private String[] args = new String[] {};
 
-  @Before
+  @BeforeEach
   public void setUp() {
     testDir = GenericTestUtils.getRandomizedTestDir();
     conf = new OzoneConfiguration();
@@ -66,7 +66,7 @@ public class TestHddsDatanodeService {
     conf.set(DFSConfigKeysLegacy.DFS_DATANODE_DATA_DIR_KEY, volumeDir);
   }
 
-  @After
+  @AfterEach
   public void tearDown() {
     FileUtil.fullyDelete(testDir);
   }

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/TestHddsSecureDatanodeInit.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/TestHddsSecureDatanodeInit.java
@@ -43,11 +43,11 @@ import static org.apache.hadoop.ozone.HddsDatanodeService.getLogger;
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_SECURITY_ENABLED_KEY;
 import org.bouncycastle.cert.X509CertificateHolder;
 import org.bouncycastle.pkcs.PKCS10CertificationRequest;
-import org.junit.AfterClass;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 /**
  * Test class for {@link HddsDatanodeService}.
@@ -69,7 +69,7 @@ public class TestHddsSecureDatanodeInit {
 
   private CertificateClient client;
 
-  @BeforeClass
+  @BeforeAll
   public static void setUp() throws Exception {
     testDir = GenericTestUtils.getRandomizedTestDir();
     conf = new OzoneConfiguration();
@@ -108,12 +108,12 @@ public class TestHddsSecureDatanodeInit {
 
   }
 
-  @AfterClass
+  @AfterAll
   public static void tearDown() {
     FileUtil.fullyDelete(testDir);
   }
 
-  @Before
+  @BeforeEach
   public void setUpDNCertClient() {
 
     FileUtils.deleteQuietly(Paths.get(
@@ -139,10 +139,11 @@ public class TestHddsSecureDatanodeInit {
     LambdaTestUtils.intercept(Exception.class, "",
         () -> service.initializeCertificateClient(conf));
 
-    Assert.assertNotNull(client.getPrivateKey());
-    Assert.assertNotNull(client.getPublicKey());
-    Assert.assertNull(client.getCertificate());
-    Assert.assertTrue(dnLogs.getOutput().contains("Init response: GETCERT"));
+    Assertions.assertNotNull(client.getPrivateKey());
+    Assertions.assertNotNull(client.getPublicKey());
+    Assertions.assertNull(client.getCertificate());
+    Assertions.assertTrue(dnLogs.getOutput()
+        .contains("Init response: GETCERT"));
   }
 
   @Test
@@ -153,10 +154,11 @@ public class TestHddsSecureDatanodeInit {
     LambdaTestUtils.intercept(RuntimeException.class, "DN security" +
             " initialization failed",
         () -> service.initializeCertificateClient(conf));
-    Assert.assertNull(client.getPrivateKey());
-    Assert.assertNull(client.getPublicKey());
-    Assert.assertNotNull(client.getCertificate());
-    Assert.assertTrue(dnLogs.getOutput().contains("Init response: FAILURE"));
+    Assertions.assertNull(client.getPrivateKey());
+    Assertions.assertNull(client.getPublicKey());
+    Assertions.assertNotNull(client.getCertificate());
+    Assertions.assertTrue(dnLogs.getOutput()
+        .contains("Init response: FAILURE"));
   }
 
   @Test
@@ -166,10 +168,11 @@ public class TestHddsSecureDatanodeInit {
     LambdaTestUtils.intercept(RuntimeException.class, "DN security" +
             " initialization failed",
         () -> service.initializeCertificateClient(conf));
-    Assert.assertNull(client.getPrivateKey());
-    Assert.assertNotNull(client.getPublicKey());
-    Assert.assertNull(client.getCertificate());
-    Assert.assertTrue(dnLogs.getOutput().contains("Init response: FAILURE"));
+    Assertions.assertNull(client.getPrivateKey());
+    Assertions.assertNotNull(client.getPublicKey());
+    Assertions.assertNull(client.getCertificate());
+    Assertions.assertTrue(dnLogs.getOutput()
+        .contains("Init response: FAILURE"));
   }
 
   @Test
@@ -180,10 +183,11 @@ public class TestHddsSecureDatanodeInit {
     LambdaTestUtils.intercept(RuntimeException.class, "DN security" +
             " initialization failed",
         () -> service.initializeCertificateClient(conf));
-    Assert.assertNull(client.getPrivateKey());
-    Assert.assertNotNull(client.getPublicKey());
-    Assert.assertNotNull(client.getCertificate());
-    Assert.assertTrue(dnLogs.getOutput().contains("Init response: FAILURE"));
+    Assertions.assertNull(client.getPrivateKey());
+    Assertions.assertNotNull(client.getPublicKey());
+    Assertions.assertNotNull(client.getCertificate());
+    Assertions.assertTrue(dnLogs.getOutput()
+        .contains("Init response: FAILURE"));
   }
 
   @Test
@@ -193,10 +197,11 @@ public class TestHddsSecureDatanodeInit {
     LambdaTestUtils.intercept(RuntimeException.class, " DN security" +
             " initialization failed",
         () -> service.initializeCertificateClient(conf));
-    Assert.assertNotNull(client.getPrivateKey());
-    Assert.assertNull(client.getPublicKey());
-    Assert.assertNull(client.getCertificate());
-    Assert.assertTrue(dnLogs.getOutput().contains("Init response: FAILURE"));
+    Assertions.assertNotNull(client.getPrivateKey());
+    Assertions.assertNull(client.getPublicKey());
+    Assertions.assertNull(client.getCertificate());
+    Assertions.assertTrue(dnLogs.getOutput()
+        .contains("Init response: FAILURE"));
     dnLogs.clearOutput();
   }
 
@@ -206,10 +211,11 @@ public class TestHddsSecureDatanodeInit {
     certCodec.writeCertificate(certHolder);
     keyCodec.writePrivateKey(privateKey);
     service.initializeCertificateClient(conf);
-    Assert.assertNotNull(client.getPrivateKey());
-    Assert.assertNotNull(client.getPublicKey());
-    Assert.assertNotNull(client.getCertificate());
-    Assert.assertTrue(dnLogs.getOutput().contains("Init response: SUCCESS"));
+    Assertions.assertNotNull(client.getPrivateKey());
+    Assertions.assertNotNull(client.getPublicKey());
+    Assertions.assertNotNull(client.getCertificate());
+    Assertions.assertTrue(dnLogs.getOutput()
+        .contains("Init response: SUCCESS"));
   }
 
   @Test
@@ -219,10 +225,11 @@ public class TestHddsSecureDatanodeInit {
     keyCodec.writePrivateKey(privateKey);
     LambdaTestUtils.intercept(Exception.class, "",
         () -> service.initializeCertificateClient(conf));
-    Assert.assertNotNull(client.getPrivateKey());
-    Assert.assertNotNull(client.getPublicKey());
-    Assert.assertNull(client.getCertificate());
-    Assert.assertTrue(dnLogs.getOutput().contains("Init response: GETCERT"));
+    Assertions.assertNotNull(client.getPrivateKey());
+    Assertions.assertNotNull(client.getPublicKey());
+    Assertions.assertNull(client.getCertificate());
+    Assertions.assertTrue(dnLogs.getOutput()
+        .contains("Init response: GETCERT"));
   }
 
   @Test
@@ -233,10 +240,11 @@ public class TestHddsSecureDatanodeInit {
     certCodec.writeCertificate(certHolder);
 
     service.initializeCertificateClient(conf);
-    Assert.assertNotNull(client.getPrivateKey());
-    Assert.assertNotNull(client.getPublicKey());
-    Assert.assertNotNull(client.getCertificate());
-    Assert.assertTrue(dnLogs.getOutput().contains("Init response: SUCCESS"));
+    Assertions.assertNotNull(client.getPrivateKey());
+    Assertions.assertNotNull(client.getPublicKey());
+    Assertions.assertNotNull(client.getCertificate());
+    Assertions.assertTrue(dnLogs.getOutput()
+        .contains("Init response: SUCCESS"));
   }
 
   /**
@@ -259,16 +267,16 @@ public class TestHddsSecureDatanodeInit {
     service.setCertificateClient(client);
     PKCS10CertificationRequest csr =
         service.getCSR(conf);
-    Assert.assertNotNull(csr);
+    Assertions.assertNotNull(csr);
 
     csr = service.getCSR(conf);
-    Assert.assertNotNull(csr);
+    Assertions.assertNotNull(csr);
 
     csr = service.getCSR(conf);
-    Assert.assertNotNull(csr);
+    Assertions.assertNotNull(csr);
 
     csr = service.getCSR(conf);
-    Assert.assertNotNull(csr);
+    Assertions.assertNotNull(csr);
   }
 
 }

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/TestContainerLayoutVersion.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/TestContainerLayoutVersion.java
@@ -19,11 +19,11 @@
 package org.apache.hadoop.ozone.container.common;
 
 import org.apache.hadoop.ozone.container.common.impl.ContainerLayoutVersion;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.apache.hadoop.ozone.container.common.impl.ContainerLayoutVersion.FILE_PER_BLOCK;
 import static org.apache.hadoop.ozone.container.common.impl.ContainerLayoutVersion.FILE_PER_CHUNK;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * This class tests ContainerLayoutVersion.

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/TestDatanodeLayOutVersion.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/TestDatanodeLayOutVersion.java
@@ -17,8 +17,8 @@
 
 package org.apache.hadoop.ozone.container.common;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 /**
  * This class tests DatanodeLayOutVersion.
@@ -28,11 +28,11 @@ public class TestDatanodeLayOutVersion {
   @Test
   public void testDatanodeLayOutVersion() {
     // Check Latest Version and description
-    Assert.assertEquals(1, HDDSVolumeLayoutVersion.getLatestVersion()
+    Assertions.assertEquals(1, HDDSVolumeLayoutVersion.getLatestVersion()
         .getVersion());
-    Assert.assertEquals("HDDS Datanode LayOut Version 1",
+    Assertions.assertEquals("HDDS Datanode LayOut Version 1",
         HDDSVolumeLayoutVersion.getLatestVersion().getDescription());
-    Assert.assertEquals(HDDSVolumeLayoutVersion.getAllVersions().length,
+    Assertions.assertEquals(HDDSVolumeLayoutVersion.getAllVersions().length,
         HDDSVolumeLayoutVersion.getAllVersions().length);
   }
 }

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/TestDatanodeStateMachine.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/TestDatanodeStateMachine.java
@@ -50,11 +50,11 @@ import com.google.common.collect.Maps;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.HDDS_DATANODE_DIR_KEY;
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_HEARTBEAT_RPC_TIMEOUT;
-import org.junit.After;
-import org.junit.Assert;
-import static org.junit.Assert.assertTrue;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -74,7 +74,7 @@ public class TestDatanodeStateMachine {
   private OzoneConfiguration conf;
   private File testRoot;
 
-  @Before
+  @BeforeEach
   public void setUp() throws Exception {
     conf = SCMTestUtils.getConf();
     conf.setTimeDuration(OZONE_SCM_HEARTBEAT_RPC_TIMEOUT, 500,
@@ -118,7 +118,7 @@ public class TestDatanodeStateMachine {
             .setNameFormat("Test Data Node State Machine Thread - %d").build());
   }
 
-  @After
+  @AfterEach
   public void tearDown() throws Exception {
     try {
       if (executorService != null) {
@@ -221,12 +221,12 @@ public class TestDatanodeStateMachine {
                  null)) {
       DatanodeStateMachine.DatanodeStates currentState =
           stateMachine.getContext().getState();
-      Assert.assertEquals(DatanodeStateMachine.DatanodeStates.INIT,
+      Assertions.assertEquals(DatanodeStateMachine.DatanodeStates.INIT,
           currentState);
 
       DatanodeState<DatanodeStateMachine.DatanodeStates> task =
           stateMachine.getContext().getTask();
-      Assert.assertEquals(InitDatanodeState.class, task.getClass());
+      Assertions.assertEquals(InitDatanodeState.class, task.getClass());
 
       task.execute(executorService);
       DatanodeStateMachine.DatanodeStates newState =
@@ -235,20 +235,20 @@ public class TestDatanodeStateMachine {
       for (EndpointStateMachine endpoint :
           stateMachine.getConnectionManager().getValues()) {
         // We assert that each of the is in State GETVERSION.
-        Assert.assertEquals(EndpointStateMachine.EndPointStates.GETVERSION,
+        Assertions.assertEquals(EndpointStateMachine.EndPointStates.GETVERSION,
             endpoint.getState());
       }
 
       // The Datanode has moved into Running State, since endpoints are created.
       // We move to running state when we are ready to issue RPC calls to SCMs.
-      Assert.assertEquals(DatanodeStateMachine.DatanodeStates.RUNNING,
+      Assertions.assertEquals(DatanodeStateMachine.DatanodeStates.RUNNING,
           newState);
 
       // If we had called context.execute instead of calling into each state
       // this would have happened automatically.
       stateMachine.getContext().setState(newState);
       task = stateMachine.getContext().getTask();
-      Assert.assertEquals(RunningDatanodeState.class, task.getClass());
+      Assertions.assertEquals(RunningDatanodeState.class, task.getClass());
 
       // This execute will invoke getVersion calls against all SCM endpoints
       // that we know of.
@@ -271,7 +271,7 @@ public class TestDatanodeStateMachine {
       }, 1000, 50000);
 
       // If we are in running state, we should be in running.
-      Assert.assertEquals(DatanodeStateMachine.DatanodeStates.RUNNING,
+      Assertions.assertEquals(DatanodeStateMachine.DatanodeStates.RUNNING,
           newState);
 
       for (EndpointStateMachine endpoint :
@@ -279,18 +279,18 @@ public class TestDatanodeStateMachine {
 
         // Since the earlier task.execute called into GetVersion, the
         // endPointState Machine should move to REGISTER state.
-        Assert.assertEquals(EndpointStateMachine.EndPointStates.REGISTER,
+        Assertions.assertEquals(EndpointStateMachine.EndPointStates.REGISTER,
             endpoint.getState());
 
         // We assert that each of the end points have gotten a version from the
         // SCM Server.
-        Assert.assertNotNull(endpoint.getVersion());
+        Assertions.assertNotNull(endpoint.getVersion());
       }
 
       // We can also assert that all mock servers have received only one RPC
       // call at this point of time.
       for (ScmTestMock mock : mockServers) {
-        Assert.assertEquals(1, mock.getRpcCount());
+        Assertions.assertEquals(1, mock.getRpcCount());
       }
 
       // This task is the Running task, but running task executes tasks based
@@ -301,11 +301,11 @@ public class TestDatanodeStateMachine {
       newState = task.await(2, TimeUnit.SECONDS);
 
       // If we are in running state, we should be in running.
-      Assert.assertEquals(DatanodeStateMachine.DatanodeStates.RUNNING,
+      Assertions.assertEquals(DatanodeStateMachine.DatanodeStates.RUNNING,
           newState);
 
       for (ScmTestMock mock : mockServers) {
-        Assert.assertEquals(2, mock.getRpcCount());
+        Assertions.assertEquals(2, mock.getRpcCount());
       }
 
       // This task is the Running task, but running task executes tasks based
@@ -316,12 +316,12 @@ public class TestDatanodeStateMachine {
       newState = task.await(2, TimeUnit.SECONDS);
 
       // If we are in running state, we should be in running.
-      Assert.assertEquals(DatanodeStateMachine.DatanodeStates.RUNNING,
+      Assertions.assertEquals(DatanodeStateMachine.DatanodeStates.RUNNING,
           newState);
 
 
       for (ScmTestMock mock : mockServers) {
-        Assert.assertEquals(1, mock.getHeartbeatCount());
+        Assertions.assertEquals(1, mock.getHeartbeatCount());
       }
     }
   }
@@ -344,12 +344,12 @@ public class TestDatanodeStateMachine {
                  null)) {
       DatanodeStateMachine.DatanodeStates currentState =
           stateMachine.getContext().getState();
-      Assert.assertEquals(DatanodeStateMachine.DatanodeStates.INIT,
+      Assertions.assertEquals(DatanodeStateMachine.DatanodeStates.INIT,
           currentState);
 
       DatanodeState<DatanodeStateMachine.DatanodeStates> task =
           stateMachine.getContext().getTask();
-      Assert.assertEquals(InitDatanodeState.class, task.getClass());
+      Assertions.assertEquals(InitDatanodeState.class, task.getClass());
 
       //Set the idPath to read only, state machine will fail to write
       // datanodeId file and set the state to shutdown.
@@ -362,7 +362,7 @@ public class TestDatanodeStateMachine {
 
       //As, we have changed the permission of idPath to readable, writing
       // will fail and it will set the state to shutdown.
-      Assert.assertEquals(DatanodeStateMachine.DatanodeStates.SHUTDOWN,
+      Assertions.assertEquals(DatanodeStateMachine.DatanodeStates.SHUTDOWN,
           newState);
 
       //Setting back to writable.
@@ -402,17 +402,17 @@ public class TestDatanodeStateMachine {
           getNewDatanodeDetails(), perTestConf, null, null, null)) {
         DatanodeStateMachine.DatanodeStates currentState =
             stateMachine.getContext().getState();
-        Assert.assertEquals(DatanodeStateMachine.DatanodeStates.INIT,
+        Assertions.assertEquals(DatanodeStateMachine.DatanodeStates.INIT,
             currentState);
         DatanodeState<DatanodeStateMachine.DatanodeStates> task =
             stateMachine.getContext().getTask();
         task.execute(executorService);
         DatanodeStateMachine.DatanodeStates newState =
             task.await(2, TimeUnit.SECONDS);
-        Assert.assertEquals(DatanodeStateMachine.DatanodeStates.SHUTDOWN,
+        Assertions.assertEquals(DatanodeStateMachine.DatanodeStates.SHUTDOWN,
             newState);
       } catch (Exception e) {
-        Assert.fail("Unexpected exception found");
+        Assertions.fail("Unexpected exception found");
       }
     });
   }

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/helpers/TestContainerUtils.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/helpers/TestContainerUtils.java
@@ -22,7 +22,7 @@ import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.ContainerC
 import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.ContainerCommandResponseProto;
 import org.apache.hadoop.hdds.scm.ByteStringConversion;
 import org.apache.hadoop.ozone.common.ChunkBuffer;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.nio.ByteBuffer;
 
@@ -31,7 +31,7 @@ import static org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.Typ
 import static org.apache.hadoop.hdds.scm.protocolPB.ContainerCommandResponseBuilders.getReadChunkResponse;
 import static org.apache.hadoop.hdds.HddsUtils.processForDebug;
 import static org.apache.hadoop.ozone.container.ContainerTestHelper.getDummyCommandRequestProto;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * Test for {@link ContainerUtils}.

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/report/TestReportManager.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/report/TestReportManager.java
@@ -22,7 +22,7 @@ import java.util.concurrent.ScheduledExecutorService;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.ozone.container.common.statemachine.StateContext;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import org.mockito.Mockito;

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/report/TestReportPublisher.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/report/TestReportPublisher.java
@@ -41,9 +41,9 @@ import org.apache.hadoop.ozone.container.common.statemachine.DatanodeStateMachin
 import org.apache.hadoop.ozone.container.common.statemachine.StateContext;
 import org.apache.hadoop.ozone.protocol.commands.CommandStatus;
 import org.apache.hadoop.util.concurrent.HadoopExecutors;
-import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 import java.util.Random;
@@ -62,7 +62,7 @@ public class TestReportPublisher {
 
   private static ConfigurationSource config;
 
-  @BeforeClass
+  @BeforeAll
   public static void setup() {
     config = new OzoneConfiguration();
   }
@@ -112,13 +112,16 @@ public class TestReportPublisher {
                 .setNameFormat("Unit test ReportManager Thread - %d").build());
     publisher.init(dummyContext, executorService);
     Thread.sleep(150);
-    Assert.assertEquals(1, ((DummyReportPublisher) publisher).getReportCount);
+    Assertions.assertEquals(1,
+        ((DummyReportPublisher) publisher).getReportCount);
     Thread.sleep(100);
-    Assert.assertEquals(2, ((DummyReportPublisher) publisher).getReportCount);
+    Assertions.assertEquals(2,
+        ((DummyReportPublisher) publisher).getReportCount);
     executorService.shutdown();
     // After executor shutdown, no new reports should be published
     Thread.sleep(100);
-    Assert.assertEquals(2, ((DummyReportPublisher) publisher).getReportCount);
+    Assertions.assertEquals(2,
+        ((DummyReportPublisher) publisher).getReportCount);
   }
 
   @Test
@@ -132,11 +135,13 @@ public class TestReportPublisher {
     publisher.init(dummyContext, executorService);
     Thread.sleep(150);
     executorService.shutdown();
-    Assert.assertEquals(1, ((DummyReportPublisher) publisher).getReportCount);
+    Assertions.assertEquals(1,
+        ((DummyReportPublisher) publisher).getReportCount);
     verify(dummyContext, times(1)).refreshFullReport(null);
     // After executor shutdown, no new reports should be published
     Thread.sleep(100);
-    Assert.assertEquals(1, ((DummyReportPublisher) publisher).getReportCount);
+    Assertions.assertEquals(1,
+        ((DummyReportPublisher) publisher).getReportCount);
   }
 
   @Test
@@ -152,7 +157,8 @@ public class TestReportPublisher {
             new ThreadFactoryBuilder().setDaemon(true)
                 .setNameFormat("Unit test ReportManager Thread - %d").build());
     publisher.init(dummyContext, executorService);
-    Assert.assertNull(((CommandStatusReportPublisher) publisher).getReport());
+    Assertions.assertNull(
+        ((CommandStatusReportPublisher) publisher).getReport());
 
     // Insert to status object to state context map and then get the report.
     CommandStatus obj1 = CommandStatus.CommandStatusBuilder.newBuilder()
@@ -168,9 +174,10 @@ public class TestReportPublisher {
     cmdStatusMap.put(obj1.getCmdId(), obj1);
     cmdStatusMap.put(obj2.getCmdId(), obj2);
     // We are not sending the commands whose status is PENDING.
-    Assert.assertEquals("Should publish report with 2 status objects", 1,
+    Assertions.assertEquals(1,
         ((CommandStatusReportPublisher) publisher).getReport()
-            .getCmdStatusCount());
+            .getCmdStatusCount(),
+        "Should publish report with 2 status objects");
     executorService.shutdown();
   }
 
@@ -197,12 +204,12 @@ public class TestReportPublisher {
     publisher.init(dummyContext, executorService);
     Message report =
         ((CRLStatusReportPublisher) publisher).getReport();
-    Assert.assertNotNull(report);
+    Assertions.assertNotNull(report);
     for (Descriptors.FieldDescriptor descriptor :
         report.getDescriptorForType().getFields()) {
       if (descriptor.getNumber() ==
           CRLStatusReport.RECEIVEDCRLID_FIELD_NUMBER) {
-        Assert.assertEquals(3L, report.getField(descriptor));
+        Assertions.assertEquals(3L, report.getField(descriptor));
       }
     }
     executorService.shutdown();

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/statemachine/TestDatanodeConfiguration.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/statemachine/TestDatanodeConfiguration.java
@@ -18,7 +18,7 @@
 package org.apache.hadoop.ozone.container.common.statemachine;
 
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.concurrent.TimeUnit;
 
@@ -35,7 +35,7 @@ import static org.apache.hadoop.ozone.container.common.statemachine.DatanodeConf
 import static org.apache.hadoop.ozone.container.common.statemachine.DatanodeConfiguration.FAILED_METADATA_VOLUMES_TOLERATED_KEY;
 import static org.apache.hadoop.ozone.container.common.statemachine.DatanodeConfiguration.FAILED_VOLUMES_TOLERATED_DEFAULT;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * Test for {@link DatanodeConfiguration}.

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/statemachine/TestStateContext.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/statemachine/TestStateContext.java
@@ -22,11 +22,11 @@ import static com.google.common.util.concurrent.MoreExecutors.newDirectExecutorS
 import static org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.ClosePipelineInfo;
 import static org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.ContainerAction.Action.CLOSE;
 import static org.apache.ozone.test.GenericTestUtils.waitFor;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -63,8 +63,8 @@ import org.apache.hadoop.ozone.protocol.commands.CloseContainerCommand;
 import org.apache.hadoop.ozone.protocol.commands.ClosePipelineCommand;
 import org.apache.hadoop.ozone.protocol.commands.ReplicateContainerCommand;
 import org.apache.ozone.test.LambdaTestUtils;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import com.google.protobuf.Message;
 
@@ -502,7 +502,7 @@ public class TestStateContext {
     }
     executorService.submit((Callable<String>) futureTwo::get);
 
-    Assert.assertFalse(stateContext.isThreadPoolAvailable(executorService));
+    Assertions.assertFalse(stateContext.isThreadPoolAvailable(executorService));
 
     futureOne.complete("futureOne");
     LambdaTestUtils.await(1000, 100, () ->
@@ -644,11 +644,11 @@ public class TestStateContext {
     ctx.addCommand(new CloseContainerCommand(1, PipelineID.randomId()));
 
     Map<SCMCommandProto.Type, Integer> summary = ctx.getCommandQueueSummary();
-    Assert.assertEquals(3,
+    Assertions.assertEquals(3,
         summary.get(SCMCommandProto.Type.replicateContainerCommand).intValue());
-    Assert.assertEquals(2,
+    Assertions.assertEquals(2,
         summary.get(SCMCommandProto.Type.closePipelineCommand).intValue());
-    Assert.assertEquals(1,
+    Assertions.assertEquals(1,
         summary.get(SCMCommandProto.Type.closeContainerCommand).intValue());
   }
 

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/states/datanode/TestRunningDatanodeState.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/states/datanode/TestRunningDatanodeState.java
@@ -19,8 +19,8 @@ package org.apache.hadoop.ozone.container.common.states.datanode;
 import org.apache.hadoop.ozone.container.common.statemachine.EndpointStateMachine;
 import org.apache.hadoop.ozone.container.common.statemachine.SCMConnectionManager;
 import org.apache.hadoop.util.Time;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 import java.util.ArrayList;
@@ -69,7 +69,7 @@ public class TestRunningDatanodeState {
     long startTime = Time.monotonicNow();
     state.await(500, TimeUnit.MILLISECONDS);
     long endTime = Time.monotonicNow();
-    Assert.assertTrue((endTime - startTime) >= 500);
+    Assertions.assertTrue((endTime - startTime) >= 500);
 
     futureOne.complete(SHUTDOWN);
 
@@ -83,7 +83,7 @@ public class TestRunningDatanodeState {
     startTime = Time.monotonicNow();
     state.await(500, TimeUnit.MILLISECONDS);
     endTime = Time.monotonicNow();
-    Assert.assertTrue((endTime - startTime) < 500);
+    Assertions.assertTrue((endTime - startTime) < 500);
 
     executorService.shutdown();
   }

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/states/endpoint/TestHeartbeatEndpointTask.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/states/endpoint/TestHeartbeatEndpointTask.java
@@ -52,8 +52,8 @@ import org.apache.hadoop.ozone.container.common.statemachine.StateContext;
 import org.apache.hadoop.ozone.protocol.commands.ReconstructECContainersCommand;
 import org.apache.hadoop.ozone.protocolPB.StorageContainerDatanodeProtocolClientSideTranslatorPB;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 
@@ -101,7 +101,7 @@ public class TestHeartbeatEndpointTask {
     task.call();
 
     // THEN
-    Assert.assertEquals(1, context.getCommandQueueSummary()
+    Assertions.assertEquals(1, context.getCommandQueueSummary()
         .get(reconstructECContainersCommand).intValue());
   }
 
@@ -123,11 +123,11 @@ public class TestHeartbeatEndpointTask {
     HeartbeatEndpointTask endpointTask = getHeartbeatEndpointTask(scm);
     endpointTask.call();
     SCMHeartbeatRequestProto heartbeat = argument.getValue();
-    Assert.assertTrue(heartbeat.hasDatanodeDetails());
-    Assert.assertFalse(heartbeat.hasNodeReport());
-    Assert.assertFalse(heartbeat.hasContainerReport());
-    Assert.assertTrue(heartbeat.getCommandStatusReportsCount() == 0);
-    Assert.assertFalse(heartbeat.hasContainerActions());
+    Assertions.assertTrue(heartbeat.hasDatanodeDetails());
+    Assertions.assertFalse(heartbeat.hasNodeReport());
+    Assertions.assertFalse(heartbeat.hasContainerReport());
+    Assertions.assertTrue(heartbeat.getCommandStatusReportsCount() == 0);
+    Assertions.assertFalse(heartbeat.hasContainerActions());
   }
 
   @Test
@@ -155,11 +155,11 @@ public class TestHeartbeatEndpointTask {
     context.refreshFullReport(NodeReportProto.getDefaultInstance());
     endpointTask.call();
     SCMHeartbeatRequestProto heartbeat = argument.getValue();
-    Assert.assertTrue(heartbeat.hasDatanodeDetails());
-    Assert.assertTrue(heartbeat.hasNodeReport());
-    Assert.assertFalse(heartbeat.hasContainerReport());
-    Assert.assertTrue(heartbeat.getCommandStatusReportsCount() == 0);
-    Assert.assertFalse(heartbeat.hasContainerActions());
+    Assertions.assertTrue(heartbeat.hasDatanodeDetails());
+    Assertions.assertTrue(heartbeat.hasNodeReport());
+    Assertions.assertFalse(heartbeat.hasContainerReport());
+    Assertions.assertTrue(heartbeat.getCommandStatusReportsCount() == 0);
+    Assertions.assertFalse(heartbeat.hasContainerActions());
   }
 
   @Test
@@ -187,11 +187,11 @@ public class TestHeartbeatEndpointTask {
     context.refreshFullReport(ContainerReportsProto.getDefaultInstance());
     endpointTask.call();
     SCMHeartbeatRequestProto heartbeat = argument.getValue();
-    Assert.assertTrue(heartbeat.hasDatanodeDetails());
-    Assert.assertFalse(heartbeat.hasNodeReport());
-    Assert.assertTrue(heartbeat.hasContainerReport());
-    Assert.assertTrue(heartbeat.getCommandStatusReportsCount() == 0);
-    Assert.assertFalse(heartbeat.hasContainerActions());
+    Assertions.assertTrue(heartbeat.hasDatanodeDetails());
+    Assertions.assertFalse(heartbeat.hasNodeReport());
+    Assertions.assertTrue(heartbeat.hasContainerReport());
+    Assertions.assertTrue(heartbeat.getCommandStatusReportsCount() == 0);
+    Assertions.assertFalse(heartbeat.hasContainerActions());
   }
 
   @Test
@@ -220,11 +220,11 @@ public class TestHeartbeatEndpointTask {
         CommandStatusReportsProto.getDefaultInstance());
     endpointTask.call();
     SCMHeartbeatRequestProto heartbeat = argument.getValue();
-    Assert.assertTrue(heartbeat.hasDatanodeDetails());
-    Assert.assertFalse(heartbeat.hasNodeReport());
-    Assert.assertFalse(heartbeat.hasContainerReport());
-    Assert.assertTrue(heartbeat.getCommandStatusReportsCount() != 0);
-    Assert.assertFalse(heartbeat.hasContainerActions());
+    Assertions.assertTrue(heartbeat.hasDatanodeDetails());
+    Assertions.assertFalse(heartbeat.hasNodeReport());
+    Assertions.assertFalse(heartbeat.hasContainerReport());
+    Assertions.assertTrue(heartbeat.getCommandStatusReportsCount() != 0);
+    Assertions.assertFalse(heartbeat.hasContainerActions());
   }
 
   @Test
@@ -252,11 +252,11 @@ public class TestHeartbeatEndpointTask {
     context.addContainerAction(getContainerAction());
     endpointTask.call();
     SCMHeartbeatRequestProto heartbeat = argument.getValue();
-    Assert.assertTrue(heartbeat.hasDatanodeDetails());
-    Assert.assertFalse(heartbeat.hasNodeReport());
-    Assert.assertFalse(heartbeat.hasContainerReport());
-    Assert.assertTrue(heartbeat.getCommandStatusReportsCount() == 0);
-    Assert.assertTrue(heartbeat.hasContainerActions());
+    Assertions.assertTrue(heartbeat.hasDatanodeDetails());
+    Assertions.assertFalse(heartbeat.hasNodeReport());
+    Assertions.assertFalse(heartbeat.hasContainerReport());
+    Assertions.assertTrue(heartbeat.getCommandStatusReportsCount() == 0);
+    Assertions.assertTrue(heartbeat.hasContainerActions());
   }
 
   @Test
@@ -299,17 +299,17 @@ public class TestHeartbeatEndpointTask {
     context.addContainerAction(getContainerAction());
     endpointTask.call();
     SCMHeartbeatRequestProto heartbeat = argument.getValue();
-    Assert.assertTrue(heartbeat.hasDatanodeDetails());
-    Assert.assertTrue(heartbeat.hasNodeReport());
-    Assert.assertTrue(heartbeat.hasContainerReport());
-    Assert.assertTrue(heartbeat.getCommandStatusReportsCount() != 0);
-    Assert.assertTrue(heartbeat.hasContainerActions());
-    Assert.assertTrue(heartbeat.hasCommandQueueReport());
+    Assertions.assertTrue(heartbeat.hasDatanodeDetails());
+    Assertions.assertTrue(heartbeat.hasNodeReport());
+    Assertions.assertTrue(heartbeat.hasContainerReport());
+    Assertions.assertTrue(heartbeat.getCommandStatusReportsCount() != 0);
+    Assertions.assertTrue(heartbeat.hasContainerActions());
+    Assertions.assertTrue(heartbeat.hasCommandQueueReport());
     CommandQueueReportProto queueCount = heartbeat.getCommandQueueReport();
-    Assert.assertEquals(queueCount.getCommandCount(), commands.size());
-    Assert.assertEquals(queueCount.getCountCount(), commands.size());
+    Assertions.assertEquals(queueCount.getCommandCount(), commands.size());
+    Assertions.assertEquals(queueCount.getCountCount(), commands.size());
     for (int i = 0; i < commands.size(); i++) {
-      Assert.assertEquals(commands.get(queueCount.getCommand(i)).intValue(),
+      Assertions.assertEquals(commands.get(queueCount.getCommand(i)).intValue(),
           queueCount.getCount(i));
     }
   }

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/volume/TestCapacityVolumeChoosingPolicy.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/volume/TestCapacityVolumeChoosingPolicy.java
@@ -25,10 +25,10 @@ import org.apache.hadoop.hdds.fs.SpaceUsageCheckFactory;
 import org.apache.hadoop.hdds.fs.SpaceUsagePersistence;
 import org.apache.hadoop.hdds.fs.SpaceUsageSource;
 import org.apache.hadoop.util.DiskChecker.DiskOutOfSpaceException;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.time.Duration;
 import java.util.ArrayList;
@@ -37,7 +37,7 @@ import java.util.List;
 import java.util.Map;
 
 import static org.apache.ozone.test.GenericTestUtils.getTestDir;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Tests {@link CapacityVolumeChoosingPolicy}.
@@ -55,7 +55,7 @@ public class TestCapacityVolumeChoosingPolicy {
   private static final String VOLUME_2 = BASE_DIR + "disk2";
   private static final String VOLUME_3 = BASE_DIR + "disk3";
 
-  @Before
+  @BeforeEach
   public void setup() throws Exception {
     policy = new CapacityVolumeChoosingPolicy();
 
@@ -87,7 +87,7 @@ public class TestCapacityVolumeChoosingPolicy {
     volumes.add(vol3);
   }
 
-  @After
+  @AfterEach
   public void cleanUp() {
     volumes.forEach(HddsVolume::shutdown);
   }
@@ -98,9 +98,9 @@ public class TestCapacityVolumeChoosingPolicy {
     HddsVolume hddsVolume2 = volumes.get(1);
     HddsVolume hddsVolume3 = volumes.get(2);
 
-    Assert.assertEquals(100L, hddsVolume1.getAvailable());
-    Assert.assertEquals(200L, hddsVolume2.getAvailable());
-    Assert.assertEquals(300L, hddsVolume3.getAvailable());
+    Assertions.assertEquals(100L, hddsVolume1.getAvailable());
+    Assertions.assertEquals(200L, hddsVolume2.getAvailable());
+    Assertions.assertEquals(300L, hddsVolume3.getAvailable());
 
     Map<HddsVolume, Integer> chooseCount = new HashMap<>();
     chooseCount.put(hddsVolume1, 0);
@@ -113,21 +113,22 @@ public class TestCapacityVolumeChoosingPolicy {
       chooseCount.put(volume, chooseCount.get(volume) + 1);
     }
 
-    Assert.assertTrue(chooseCount.get(hddsVolume3) >
+    Assertions.assertTrue(chooseCount.get(hddsVolume3) >
         chooseCount.get(hddsVolume1));
-    Assert.assertTrue(chooseCount.get(hddsVolume3) >
+    Assertions.assertTrue(chooseCount.get(hddsVolume3) >
         chooseCount.get(hddsVolume2));
   }
 
   @Test
   public void throwsDiskOutOfSpaceIfRequestMoreThanAvailable() {
-    Exception e = Assert.assertThrows(DiskOutOfSpaceException.class,
+    Exception e = Assertions.assertThrows(DiskOutOfSpaceException.class,
         () -> policy.chooseVolume(volumes, 500));
 
     String msg = e.getMessage();
-    assertTrue(msg,
+    assertTrue(
         msg.contains("No volumes have enough space for a new container.  " +
-            "Most available space: 250 bytes"));
+            "Most available space: 250 bytes"),
+        msg);
   }
 
 }

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/volume/TestRoundRobinVolumeChoosingPolicy.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/volume/TestRoundRobinVolumeChoosingPolicy.java
@@ -31,12 +31,12 @@ import org.apache.hadoop.hdds.fs.SpaceUsageSource;
 import org.apache.hadoop.util.DiskChecker.DiskOutOfSpaceException;
 
 import static org.apache.ozone.test.GenericTestUtils.getTestDir;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * Tests {@link RoundRobinVolumeChoosingPolicy}.
@@ -53,7 +53,7 @@ public class TestRoundRobinVolumeChoosingPolicy {
   private static final String VOLUME_1 = BASE_DIR + "disk1";
   private static final String VOLUME_2 = BASE_DIR + "disk2";
 
-  @Before
+  @BeforeEach
   public void setup() throws Exception {
     policy = new RoundRobinVolumeChoosingPolicy();
 
@@ -77,7 +77,7 @@ public class TestRoundRobinVolumeChoosingPolicy {
     volumes.add(vol2);
   }
 
-  @After
+  @AfterEach
   public void cleanUp() {
     volumes.forEach(HddsVolume::shutdown);
   }
@@ -87,30 +87,31 @@ public class TestRoundRobinVolumeChoosingPolicy {
     HddsVolume hddsVolume1 = volumes.get(0);
     HddsVolume hddsVolume2 = volumes.get(1);
 
-    Assert.assertEquals(100L, hddsVolume1.getAvailable());
-    Assert.assertEquals(200L, hddsVolume2.getAvailable());
+    Assertions.assertEquals(100L, hddsVolume1.getAvailable());
+    Assertions.assertEquals(200L, hddsVolume2.getAvailable());
 
     // Test two rounds of round-robin choosing
-    Assert.assertEquals(hddsVolume1, policy.chooseVolume(volumes, 0));
-    Assert.assertEquals(hddsVolume2, policy.chooseVolume(volumes, 0));
-    Assert.assertEquals(hddsVolume1, policy.chooseVolume(volumes, 0));
-    Assert.assertEquals(hddsVolume2, policy.chooseVolume(volumes, 0));
+    Assertions.assertEquals(hddsVolume1, policy.chooseVolume(volumes, 0));
+    Assertions.assertEquals(hddsVolume2, policy.chooseVolume(volumes, 0));
+    Assertions.assertEquals(hddsVolume1, policy.chooseVolume(volumes, 0));
+    Assertions.assertEquals(hddsVolume2, policy.chooseVolume(volumes, 0));
 
     // The first volume has only 100L space, so the policy should
     // choose the second one in case we ask for more.
-    Assert.assertEquals(hddsVolume2,
+    Assertions.assertEquals(hddsVolume2,
         policy.chooseVolume(volumes, 120));
   }
 
   @Test
   public void throwsDiskOutOfSpaceIfRequestMoreThanAvailable() {
-    Exception e = Assert.assertThrows(DiskOutOfSpaceException.class,
+    Exception e = Assertions.assertThrows(DiskOutOfSpaceException.class,
         () -> policy.chooseVolume(volumes, 300));
 
     String msg = e.getMessage();
-    assertTrue(msg,
+    assertTrue(
         msg.contains("No volumes have enough space for a new container.  " +
-            "Most available space: 150 bytes"));
+            "Most available space: 150 bytes"),
+        msg);
   }
 
 }

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/ec/reconstruction/TestECReconstructionSupervisor.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/ec/reconstruction/TestECReconstructionSupervisor.java
@@ -22,8 +22,8 @@ import org.apache.hadoop.hdds.client.ECReplicationConfig;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
 import org.apache.ozone.test.GenericTestUtils;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.util.SortedMap;
@@ -63,7 +63,7 @@ public class TestECReconstructionSupervisor {
         new ECReconstructionCommandInfo(1, new ECReplicationConfig(3, 2),
             new byte[0], ImmutableList.of(), ImmutableList.of()));
     runnableInvoked.await();
-    Assert.assertEquals(1, supervisor.getInFlightReplications());
+    Assertions.assertEquals(1, supervisor.getInFlightReplications());
     holdProcessing.countDown();
     GenericTestUtils
         .waitFor(() -> supervisor.getInFlightReplications() == 0, 100, 15000);

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/TestKeyValueHandlerWithUnhealthyContainer.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/TestKeyValueHandlerWithUnhealthyContainer.java
@@ -27,7 +27,7 @@ import org.apache.hadoop.ozone.container.common.impl.TestHddsDispatcher;
 import org.apache.hadoop.ozone.container.common.statemachine.DatanodeStateMachine;
 
 import org.apache.hadoop.ozone.container.common.volume.MutableVolumeSet;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -38,8 +38,7 @@ import static org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.Res
 import static org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.Result.UNKNOWN_BCSID;
 import static org.apache.hadoop.ozone.container.ContainerTestHelper.DATANODE_UUID;
 import static org.apache.hadoop.ozone.container.ContainerTestHelper.getDummyCommandRequestProto;
-import static org.hamcrest.core.Is.is;
-import static org.junit.Assert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -60,7 +59,7 @@ public class TestKeyValueHandlerWithUnhealthyContainer {
         handler.handleReadContainer(
             getDummyCommandRequestProto(ContainerProtos.Type.ReadContainer),
             container);
-    assertThat(response.getResult(), is(SUCCESS));
+    assertEquals(SUCCESS, response.getResult());
   }
 
   @Test
@@ -72,7 +71,7 @@ public class TestKeyValueHandlerWithUnhealthyContainer {
         handler.handleGetBlock(
             getDummyCommandRequestProto(ContainerProtos.Type.GetBlock),
             container);
-    assertThat(response.getResult(), is(UNKNOWN_BCSID));
+    assertEquals(UNKNOWN_BCSID, response.getResult());
   }
 
   @Test
@@ -85,7 +84,7 @@ public class TestKeyValueHandlerWithUnhealthyContainer {
             getDummyCommandRequestProto(
                 ContainerProtos.Type.GetCommittedBlockLength),
             container);
-    assertThat(response.getResult(), is(UNKNOWN_BCSID));
+    assertEquals(UNKNOWN_BCSID, response.getResult());
   }
 
   @Test
@@ -98,7 +97,7 @@ public class TestKeyValueHandlerWithUnhealthyContainer {
             getDummyCommandRequestProto(
                 ContainerProtos.Type.ReadChunk),
             container, null);
-    assertThat(response.getResult(), is(UNKNOWN_BCSID));
+    assertEquals(UNKNOWN_BCSID, response.getResult());
   }
 
   @Test
@@ -111,7 +110,7 @@ public class TestKeyValueHandlerWithUnhealthyContainer {
             getDummyCommandRequestProto(
                 ContainerProtos.Type.GetSmallFile),
             container);
-    assertThat(response.getResult(), is(UNKNOWN_BCSID));
+    assertEquals(UNKNOWN_BCSID, response.getResult());
   }
 
   // -- Helper methods below.

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/helpers/TestChunkUtils.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/helpers/TestChunkUtils.java
@@ -44,11 +44,11 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.Result.UNABLE_TO_FIND_CHUNK;
 
 import org.apache.ozone.test.LambdaTestUtils;
-import org.junit.Assert;
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -86,7 +86,7 @@ public class TestChunkUtils {
             ChunkUtils.readData(file, readBuffers, offset, len, null);
 
             // There should be only one element in readBuffers
-            Assert.assertEquals(1, readBuffers.length);
+            Assertions.assertEquals(1, readBuffers.length);
             ByteBuffer readBuffer = readBuffers[0];
 
             LOG.info("Read data ({}): {}", threadNumber,
@@ -173,7 +173,7 @@ public class TestChunkUtils {
       ChunkUtils.readData(file, readBuffers, offset, len, null);
 
       // There should be only one element in readBuffers
-      Assert.assertEquals(1, readBuffers.length);
+      Assertions.assertEquals(1, readBuffers.length);
       ByteBuffer readBuffer = readBuffers[0];
 
       assertArrayEquals(array, readBuffer.array());
@@ -191,11 +191,11 @@ public class TestChunkUtils {
     Path tempFile = Files.createTempFile(PREFIX, "overwrite");
     FileUtils.write(tempFile.toFile(), "test", UTF_8);
 
-    Assert.assertTrue(
+    Assertions.assertTrue(
         ChunkUtils.validateChunkForOverwrite(tempFile.toFile(),
             new ChunkInfo("chunk", 3, 5)));
 
-    Assert.assertFalse(
+    Assertions.assertFalse(
         ChunkUtils.validateChunkForOverwrite(tempFile.toFile(),
             new ChunkInfo("chunk", 5, 5)));
   }
@@ -214,7 +214,7 @@ public class TestChunkUtils {
         () -> ChunkUtils.readData(nonExistentFile, bufs, offset, len, null));
 
     // then
-    Assert.assertEquals(UNABLE_TO_FIND_CHUNK, e.getResult());
+    Assertions.assertEquals(UNABLE_TO_FIND_CHUNK, e.getResult());
   }
 
 }

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/impl/AbstractTestChunkManager.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/impl/AbstractTestChunkManager.java
@@ -33,9 +33,8 @@ import org.apache.hadoop.ozone.container.keyvalue.KeyValueContainer;
 import org.apache.hadoop.ozone.container.keyvalue.KeyValueContainerData;
 import org.apache.hadoop.ozone.container.keyvalue.interfaces.BlockManager;
 import org.apache.hadoop.ozone.container.keyvalue.interfaces.ChunkManager;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.io.TempDir;
 import org.mockito.Mockito;
 
 import java.io.File;
@@ -44,9 +43,9 @@ import java.nio.ByteBuffer;
 import java.util.UUID;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.mock;
@@ -65,9 +64,6 @@ public abstract class AbstractTestChunkManager {
   private byte[] header;
   private BlockManager blockManager;
 
-  @Rule
-  public TemporaryFolder folder = new TemporaryFolder();
-
   protected abstract ContainerLayoutTestInfo getStrategy();
 
   protected ChunkManager createTestSubject() {
@@ -75,12 +71,12 @@ public abstract class AbstractTestChunkManager {
     return getStrategy().createChunkManager(true, blockManager);
   }
 
-  @Before
-  public final void setUp() throws Exception {
+  @BeforeEach
+  public final void setUp(@TempDir File confDir) throws Exception {
     OzoneConfiguration config = new OzoneConfiguration();
     getStrategy().updateConfig(config);
     UUID datanodeId = UUID.randomUUID();
-    hddsVolume = new HddsVolume.Builder(folder.getRoot()
+    hddsVolume = new HddsVolume.Builder(confDir
         .getAbsolutePath()).conf(config).datanodeUuid(datanodeId
         .toString()).build();
 

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/impl/CommonChunkManagerTestCases.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/impl/CommonChunkManagerTestCases.java
@@ -28,7 +28,7 @@ import org.apache.hadoop.ozone.container.common.transport.server.ratis.Dispatche
 import org.apache.hadoop.ozone.container.keyvalue.KeyValueContainer;
 import org.apache.hadoop.ozone.container.keyvalue.interfaces.ChunkManager;
 import org.apache.ozone.test.GenericTestUtils;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.io.File;
 import java.io.IOException;
@@ -36,10 +36,10 @@ import java.nio.ByteBuffer;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.apache.hadoop.ozone.OzoneConsts.OZONE_SCM_CHUNK_MAX_SIZE;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  * Common test cases for ChunkManager implementation tests.

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/impl/TestChunkManagerDummyImpl.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/impl/TestChunkManagerDummyImpl.java
@@ -22,9 +22,9 @@ import org.apache.hadoop.ozone.common.ChunkBuffer;
 import org.apache.hadoop.ozone.container.common.transport.server.ratis.DispatcherContext;
 import org.apache.hadoop.ozone.container.keyvalue.ContainerLayoutTestInfo;
 import org.apache.hadoop.ozone.container.keyvalue.interfaces.ChunkManager;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 /**
  * Tests for ChunkManagerDummyImpl.

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/impl/TestFilePerBlockStrategy.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/impl/TestFilePerBlockStrategy.java
@@ -29,15 +29,15 @@ import org.apache.hadoop.ozone.container.common.transport.server.ratis.Dispatche
 import org.apache.hadoop.ozone.container.keyvalue.ContainerLayoutTestInfo;
 import org.apache.hadoop.ozone.container.keyvalue.KeyValueContainer;
 import org.apache.hadoop.ozone.container.keyvalue.interfaces.ChunkManager;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.nio.ByteBuffer;
 import java.security.MessageDigest;
 
 import static org.apache.hadoop.ozone.container.ContainerTestHelper.getChunk;
 import static org.apache.hadoop.ozone.container.ContainerTestHelper.setDataChecksum;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  * Test for FilePerBlockStrategy.

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/impl/TestFilePerChunkStrategy.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/impl/TestFilePerChunkStrategy.java
@@ -28,13 +28,13 @@ import org.apache.hadoop.ozone.container.keyvalue.ContainerLayoutTestInfo;
 import org.apache.hadoop.ozone.container.keyvalue.KeyValueContainer;
 import org.apache.hadoop.ozone.container.keyvalue.helpers.ChunkUtils;
 import org.apache.hadoop.ozone.container.keyvalue.interfaces.ChunkManager;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.io.File;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Test for FilePerChunkStrategy.

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/ozoneimpl/TestContainerScannerConfiguration.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/ozoneimpl/TestContainerScannerConfiguration.java
@@ -19,8 +19,8 @@ package org.apache.hadoop.ozone.container.ozoneimpl;
 
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.conf.StorageUnit;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.time.Duration;
 
@@ -30,7 +30,7 @@ import static org.apache.hadoop.ozone.container.ozoneimpl.ContainerScannerConfig
 import static org.apache.hadoop.ozone.container.ozoneimpl.ContainerScannerConfiguration.METADATA_SCAN_INTERVAL_DEFAULT;
 import static org.apache.hadoop.ozone.container.ozoneimpl.ContainerScannerConfiguration.METADATA_SCAN_INTERVAL_KEY;
 import static org.apache.hadoop.ozone.container.ozoneimpl.ContainerScannerConfiguration.VOLUME_BYTES_PER_SECOND_KEY;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * Test for {@link ContainerScannerConfiguration}.
@@ -39,7 +39,7 @@ public class TestContainerScannerConfiguration {
 
   private OzoneConfiguration conf;
 
-  @Before
+  @BeforeEach
   public void setup() {
     this.conf = new OzoneConfiguration();
   }

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/ozoneimpl/TestContainerScannerMetrics.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/ozoneimpl/TestContainerScannerMetrics.java
@@ -23,11 +23,13 @@ import org.apache.hadoop.metrics2.lib.DefaultMetricsSystem;
 import org.apache.hadoop.ozone.container.common.impl.ContainerData;
 import org.apache.hadoop.ozone.container.common.interfaces.Container;
 import org.apache.hadoop.ozone.container.common.volume.HddsVolume;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
 
 import java.io.IOException;
 import java.util.Arrays;
@@ -35,9 +37,9 @@ import java.util.Collection;
 import java.util.concurrent.atomic.AtomicLong;
 
 import static org.apache.hadoop.hdds.conf.OzoneConfiguration.newInstanceOf;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -45,7 +47,8 @@ import static org.mockito.Mockito.when;
 /**
  * This test verifies the container scanner metrics functionality.
  */
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
 public class TestContainerScannerMetrics {
 
   private final AtomicLong containerIdSeq = new AtomicLong(100);
@@ -65,7 +68,7 @@ public class TestContainerScannerMetrics {
   private ContainerScannerConfiguration conf;
   private ContainerController controller;
 
-  @Before
+  @BeforeEach
   public void setup() {
     conf = newInstanceOf(ContainerScannerConfiguration.class);
     conf.setMetadataScanInterval(0);

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/replication/ReplicationSupervisorScheduling.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/replication/ReplicationSupervisorScheduling.java
@@ -28,8 +28,8 @@ import org.apache.hadoop.hdds.protocol.DatanodeDetails;
 import org.apache.hadoop.hdds.protocol.MockDatanodeDetails;
 import org.apache.hadoop.ozone.container.common.impl.ContainerSet;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 /**
  * Helper to check scheduling efficiency.
@@ -120,8 +120,8 @@ public class ReplicationSupervisorScheduling {
     rs.shutdownAfterFinish();
     final long executionTime = System.currentTimeMillis() - start;
     System.out.println(executionTime);
-    Assert.assertTrue("Execution was too slow : " + executionTime + " ms",
-        executionTime < 100_000);
+    Assertions.assertTrue(executionTime < 100_000,
+        "Execution was too slow : " + executionTime + " ms");
   }
 
 }

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/replication/TestGrpcOutputStream.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/replication/TestGrpcOutputStream.java
@@ -20,12 +20,12 @@ package org.apache.hadoop.ozone.container.replication;
 import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.CopyContainerResponseProto;
 import org.apache.ratis.thirdparty.com.google.protobuf.ByteString;
 import org.apache.ratis.thirdparty.io.grpc.stub.StreamObserver;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.io.IOException;
 import java.io.OutputStream;
@@ -34,8 +34,8 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Random;
 
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -43,7 +43,7 @@ import static org.mockito.Mockito.verify;
 /**
  * Tests for {@code GrpcOutputStream}.
  */
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class TestGrpcOutputStream {
 
   private static final Random RND = new Random();
@@ -56,7 +56,7 @@ public class TestGrpcOutputStream {
 
   private OutputStream subject;
 
-  @Before
+  @BeforeEach
   public void setUp() throws Exception {
     subject = new GrpcOutputStream(observer, containerId, bufferSize);
   }

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/replication/TestMeasuredReplicator.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/replication/TestMeasuredReplicator.java
@@ -23,10 +23,10 @@ import java.util.ArrayList;
 
 import org.apache.hadoop.ozone.container.replication.ReplicationTask.Status;
 
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * Test replicator metric measurement.
@@ -35,7 +35,7 @@ public class TestMeasuredReplicator {
 
   private MeasuredReplicator measuredReplicator;
 
-  @Before
+  @BeforeEach
   public void initReplicator() {
     measuredReplicator = new MeasuredReplicator(task -> {
 
@@ -55,7 +55,7 @@ public class TestMeasuredReplicator {
     });
   }
 
-  @After
+  @AfterEach
   public void closeReplicator() throws Exception {
     measuredReplicator.close();
   }
@@ -69,13 +69,13 @@ public class TestMeasuredReplicator {
 
     //THEN
     //even containers should be failed
-    Assert.assertEquals(2, measuredReplicator.getSuccess().value());
-    Assert.assertEquals(1, measuredReplicator.getFailure().value());
+    Assertions.assertEquals(2, measuredReplicator.getSuccess().value());
+    Assertions.assertEquals(1, measuredReplicator.getFailure().value());
 
     //sum of container ids (success) in kb
-    Assert.assertEquals((1 + 3) * 1024,
+    Assertions.assertEquals((1 + 3) * 1024,
         measuredReplicator.getTransferredBytes().value());
-    Assert.assertEquals(2 * 1024,
+    Assertions.assertEquals(2 * 1024,
         measuredReplicator.getFailureBytes().value());
   }
 
@@ -91,12 +91,10 @@ public class TestMeasuredReplicator {
     //even containers should be failed
     long successTime = measuredReplicator.getSuccessTime().value();
     long failureTime = measuredReplicator.getFailureTime().value();
-    Assert.assertTrue(
-        "Measured time should be at least 300 ms but was " + successTime,
-        successTime >= 300L);
-    Assert.assertTrue(
-        "Measured time should be at least 300 ms but was " + failureTime,
-        failureTime >= 300L);
+    Assertions.assertTrue(successTime >= 300L,
+        "Measured time should be at least 300 ms but was " + successTime);
+    Assertions.assertTrue(failureTime >= 300L,
+        "Measured time should be at least 300 ms but was " + failureTime);
   }
 
   @Test
@@ -107,7 +105,7 @@ public class TestMeasuredReplicator {
 
     //THEN
     //even containers should be failed, supposed to be zero
-    Assert.assertEquals(0, measuredReplicator.getFailureTime().value());
+    Assertions.assertEquals(0, measuredReplicator.getFailureTime().value());
   }
 
   @Test
@@ -118,7 +116,7 @@ public class TestMeasuredReplicator {
 
     //THEN
     //even containers should be failed, supposed to be zero
-    Assert.assertEquals(0, measuredReplicator.getSuccessTime().value());
+    Assertions.assertEquals(0, measuredReplicator.getSuccessTime().value());
   }
 
   @Test
@@ -132,6 +130,6 @@ public class TestMeasuredReplicator {
     };
     measuredReplicator.replicate(task);
     // There might be some deviation, so we use >= 1000 here.
-    Assert.assertTrue(measuredReplicator.getQueueTime().value() >= 1000);
+    Assertions.assertTrue(measuredReplicator.getQueueTime().value() >= 1000);
   }
 }

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/replication/TestReplicationConfig.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/replication/TestReplicationConfig.java
@@ -19,11 +19,11 @@ package org.apache.hadoop.ozone.container.replication;
 
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.ozone.container.replication.ReplicationServer.ReplicationConfig;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.apache.hadoop.ozone.container.replication.ReplicationServer.ReplicationConfig.REPLICATION_MAX_STREAMS_DEFAULT;
 import static org.apache.hadoop.ozone.container.replication.ReplicationServer.ReplicationConfig.REPLICATION_STREAMS_LIMIT_KEY;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * Tests for {@link ReplicationConfig}.

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/replication/TestSimpleContainerDownloader.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/replication/TestSimpleContainerDownloader.java
@@ -31,8 +31,9 @@ import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
 import org.apache.hadoop.hdds.protocol.MockDatanodeDetails;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 /**
  * Test SimpleContainerDownloader.
@@ -55,7 +56,8 @@ public class TestSimpleContainerDownloader {
         downloader.getContainerDataFromReplicas(1L, datanodes);
 
     //THEN
-    Assert.assertEquals(datanodes.get(0).getUuidString(), result.toString());
+    Assertions.assertEquals(datanodes.get(0).getUuidString(),
+        result.toString());
   }
 
   @Test
@@ -74,7 +76,8 @@ public class TestSimpleContainerDownloader {
 
     //THEN
     //first datanode is failed, second worked
-    Assert.assertEquals(datanodes.get(1).getUuidString(), result.toString());
+    Assertions.assertEquals(datanodes.get(1).getUuidString(),
+        result.toString());
   }
 
   @Test
@@ -92,13 +95,15 @@ public class TestSimpleContainerDownloader {
 
     //THEN
     //first datanode is failed, second worked
-    Assert.assertEquals(datanodes.get(1).getUuidString(), result.toString());
+    Assertions.assertEquals(datanodes.get(1).getUuidString(),
+        result.toString());
   }
 
   /**
    * Test if different datanode is used for each download attempt.
    */
-  @Test(timeout = 10_000L)
+  @Test
+  @Timeout(10)
   public void testRandomSelection()
       throws ExecutionException, InterruptedException {
 
@@ -128,7 +133,7 @@ public class TestSimpleContainerDownloader {
     }
 
     //there is 1/3^10_000 chance for false positive, which is practically 0.
-    Assert.fail(
+    Assertions.fail(
         "Datanodes are selected 10000 times but second datanode was never "
             + "used.");
   }

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/stream/TestDirstreamClientHandler.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/stream/TestDirstreamClientHandler.java
@@ -22,10 +22,10 @@ import io.netty.buffer.Unpooled;
 import org.apache.commons.io.FileUtils;
 import org.apache.ozone.test.GenericTestUtils;
 import org.jetbrains.annotations.NotNull;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
@@ -39,12 +39,12 @@ public class TestDirstreamClientHandler {
 
   private Path tmpDir;
 
-  @Before
+  @BeforeEach
   public void init() {
     tmpDir = GenericTestUtils.getRandomizedTestDir().toPath();
   }
 
-  @After
+  @AfterEach
   public void destroy() throws IOException {
     FileUtils.deleteDirectory(tmpDir.toFile());
   }
@@ -58,8 +58,8 @@ public class TestDirstreamClientHandler {
 
     handler.doRead(null, wrap("4 asd.txt\nxxxx0 END"));
 
-    Assert.assertEquals("xxxx", getContent("asd.txt"));
-    Assert.assertTrue(handler.isAtTheEnd());
+    Assertions.assertEquals("xxxx", getContent("asd.txt"));
+    Assertions.assertTrue(handler.isAtTheEnd());
 
   }
 
@@ -77,8 +77,8 @@ public class TestDirstreamClientHandler {
     handler.doRead(null, wrap("1230 "));
     handler.doRead(null, wrap("END"));
 
-    Assert.assertEquals("1234", getContent("asd.txt"));
-    Assert.assertTrue(handler.isAtTheEnd());
+    Assertions.assertEquals("1234", getContent("asd.txt"));
+    Assertions.assertTrue(handler.isAtTheEnd());
   }
 
   @Test
@@ -91,8 +91,8 @@ public class TestDirstreamClientHandler {
     handler.doRead(null, wrap("4 asd."));
     handler.doRead(null, wrap("txt\nxxxx0 END"));
 
-    Assert.assertEquals("xxxx", getContent("asd.txt"));
-    Assert.assertTrue(handler.isAtTheEnd());
+    Assertions.assertEquals("xxxx", getContent("asd.txt"));
+    Assertions.assertTrue(handler.isAtTheEnd());
 
   }
 
@@ -107,9 +107,9 @@ public class TestDirstreamClientHandler {
     handler.doRead(null, wrap("4 asd.txt\nxxxx3"));
     handler.doRead(null, wrap(" bsd.txt\nyyy0 END"));
 
-    Assert.assertEquals("xxxx", getContent("asd.txt"));
-    Assert.assertEquals("yyy", getContent("bsd.txt"));
-    Assert.assertTrue(handler.isAtTheEnd());
+    Assertions.assertEquals("xxxx", getContent("asd.txt"));
+    Assertions.assertEquals("yyy", getContent("bsd.txt"));
+    Assertions.assertTrue(handler.isAtTheEnd());
   }
 
 
@@ -123,8 +123,8 @@ public class TestDirstreamClientHandler {
     handler.doRead(null, wrap("4 asd.txt\nxx"));
     handler.doRead(null, wrap("xx3 bsd.txt\nyyy\nEND"));
 
-    Assert.assertEquals("xxxx", getContent("asd.txt"));
-    Assert.assertEquals("yyy", getContent("bsd.txt"));
+    Assertions.assertEquals("xxxx", getContent("asd.txt"));
+    Assertions.assertEquals("yyy", getContent("bsd.txt"));
   }
 
   @NotNull

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/stream/TestStreamingServer.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/stream/TestStreamingServer.java
@@ -22,8 +22,8 @@ import io.netty.handler.ssl.SslContextBuilder;
 import io.netty.handler.ssl.util.InsecureTrustManagerFactory;
 import io.netty.handler.ssl.util.SelfSignedCertificate;
 import org.apache.ozone.test.GenericTestUtils;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
@@ -58,7 +58,7 @@ public class TestStreamingServer {
     //THEN: compare the files
     final byte[] targetContent = Files
         .readAllBytes(destDir.resolve(SUBDIR).resolve("file1"));
-    Assert.assertArrayEquals(CONTENT, targetContent);
+    Assertions.assertArrayEquals(CONTENT, targetContent);
 
   }
 
@@ -104,10 +104,10 @@ public class TestStreamingServer {
     //THEN: compare the files
     final byte[] targetContent = Files
         .readAllBytes(destDir.resolve(SUBDIR).resolve("file1"));
-    Assert.assertArrayEquals(CONTENT, targetContent);
+    Assertions.assertArrayEquals(CONTENT, targetContent);
 
   }
-  @Test(expected = RuntimeException.class)
+  @Test
   public void failedStream() throws Exception {
     Path sourceDir = GenericTestUtils.getRandomizedTestDir().toPath();
     Path destDir = GenericTestUtils.getRandomizedTestDir().toPath();
@@ -118,14 +118,15 @@ public class TestStreamingServer {
     Files.write(sourceDir.resolve(SUBDIR).resolve("file1"), CONTENT);
 
     //WHEN: stream subdir
-    streamDir(sourceDir, destDir, "NO_SUCH_ID");
+    Assertions.assertThrows(RuntimeException.class, () ->
+        streamDir(sourceDir, destDir, "NO_SUCH_ID"));
 
     //THEN: compare the files
     //exception is expected
 
   }
 
-  @Test(expected = RuntimeException.class)
+  @Test
   public void timeout() throws Exception {
     Path sourceDir = GenericTestUtils.getRandomizedTestDir().toPath();
     Path destDir = GenericTestUtils.getRandomizedTestDir().toPath();
@@ -150,7 +151,8 @@ public class TestStreamingServer {
                new StreamingClient("localhost", server.getPort(),
                    new DirectoryServerDestination(
                        destDir))) {
-        client.stream(SUBDIR, 1L, TimeUnit.SECONDS);
+        Assertions.assertThrows(RuntimeException.class, () ->
+            client.stream(SUBDIR, 1L, TimeUnit.SECONDS));
       }
     }
 

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/protocol/commands/TestReconstructionECContainersCommands.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/protocol/commands/TestReconstructionECContainersCommands.java
@@ -21,8 +21,8 @@ import org.apache.hadoop.hdds.client.ECReplicationConfig;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
 import org.apache.hadoop.hdds.protocol.MockDatanodeDetails;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -42,7 +42,7 @@ public class TestReconstructionECContainersCommands {
     List<DatanodeDetails> targetDns = new ArrayList<>();
     targetDns.add(MockDatanodeDetails.randomDatanodeDetails());
 
-    Assert.assertThrows(IllegalArgumentException.class,
+    Assertions.assertThrows(IllegalArgumentException.class,
         () -> new ReconstructECContainersCommand(1L, Collections.emptyList(),
         targetDns, missingContainerIndexes, ecReplicationConfig));
   }
@@ -76,27 +76,28 @@ public class TestReconstructionECContainersCommands {
     List<DatanodeDetails> targetDnsFromProto = proto.getTargetsList().stream()
         .map(a -> DatanodeDetails.getFromProtoBuf(a))
         .collect(Collectors.toList());
-    Assert.assertEquals(1L, proto.getContainerID());
-    Assert.assertEquals(sources, srcDnsFromProto);
-    Assert.assertEquals(targets, targetDnsFromProto);
-    Assert.assertArrayEquals(missingContainerIndexes,
+    Assertions.assertEquals(1L, proto.getContainerID());
+    Assertions.assertEquals(sources, srcDnsFromProto);
+    Assertions.assertEquals(targets, targetDnsFromProto);
+    Assertions.assertArrayEquals(missingContainerIndexes,
         proto.getMissingContainerIndexes().toByteArray());
-    Assert.assertEquals(ecReplicationConfig,
+    Assertions.assertEquals(ecReplicationConfig,
         new ECReplicationConfig(proto.getEcReplicationConfig()));
 
     ReconstructECContainersCommand fromProtobuf =
         ReconstructECContainersCommand.getFromProtobuf(proto);
 
-    Assert.assertEquals(reconstructECContainersCommand.getContainerID(),
+    Assertions.assertEquals(reconstructECContainersCommand.getContainerID(),
         fromProtobuf.getContainerID());
-    Assert.assertEquals(reconstructECContainersCommand.getSources(),
+    Assertions.assertEquals(reconstructECContainersCommand.getSources(),
         fromProtobuf.getSources());
-    Assert.assertEquals(reconstructECContainersCommand.getTargetDatanodes(),
+    Assertions.assertEquals(reconstructECContainersCommand.getTargetDatanodes(),
         fromProtobuf.getTargetDatanodes());
-    Assert.assertArrayEquals(
+    Assertions.assertArrayEquals(
         reconstructECContainersCommand.getMissingContainerIndexes(),
         fromProtobuf.getMissingContainerIndexes());
-    Assert.assertEquals(reconstructECContainersCommand.getEcReplicationConfig(),
+    Assertions.assertEquals(
+        reconstructECContainersCommand.getEcReplicationConfig(),
         fromProtobuf.getEcReplicationConfig());
   }
 

--- a/pom.xml
+++ b/pom.xml
@@ -186,6 +186,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
     <okhttp.version>2.7.5</okhttp.version>
     <mockito1-powermock.version>1.10.19</mockito1-powermock.version>
     <mockito2.version>2.28.2</mockito2.version>
+    <mockito-junit-jupiter.version>2.28.2</mockito-junit-jupiter.version>
     <hamcrest.version>1.3</hamcrest.version>
     <powermock1.version>1.6.5</powermock1.version>
     <powermock2.version>2.0.4</powermock2.version>
@@ -1285,6 +1286,12 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
         <groupId>org.mockito</groupId>
         <artifactId>mockito-core</artifactId>
         <version>${mockito2.version}</version>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.mockito</groupId>
+        <artifactId>mockito-junit-jupiter</artifactId>
+        <version>${mockito-junit-jupiter.version}</version>
         <scope>test</scope>
       </dependency>
       <dependency>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Migrate simple tests in hdds-container-service to JUnit5

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-7299

## How was this patch tested?

https://github.com/kaijchen/ozone/actions/runs/3210292407
