### PR TITLE
HDDS-7302. Fix inaccurate container block count caused by missing block

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/statemachine/background/BlockDeletingService.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/statemachine/background/BlockDeletingService.java
@@ -29,7 +29,6 @@ import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
-import org.apache.commons.lang3.tuple.Pair;
 import org.apache.hadoop.hdds.conf.ConfigurationSource;
 import org.apache.hadoop.hdds.scm.ScmConfigKeys;
 import org.apache.hadoop.hdds.scm.container.common.helpers.StorageContainerException;
@@ -489,10 +488,11 @@ public class BlockDeletingService extends BackgroundService {
         Handler handler = Objects.requireNonNull(ozoneContainer.getDispatcher()
             .getHandler(container.getContainerType()));
 
-        Pair<Integer, Long> deleteBlocksResult =
+        DeleteTransactionStats deleteBlocksResult =
             deleteTransactions(delBlocks, handler, blockDataTable, container);
-        int deletedBlocksCount = deleteBlocksResult.getLeft();
-        long releasedBytes = deleteBlocksResult.getRight();
+        int deletedBlocksProceeded = deleteBlocksResult.getBlocksProcessed();
+        int deletedBlocksCount = deleteBlocksResult.getBlocksDeleted();
+        long releasedBytes = deleteBlocksResult.getBytesReleased();
 
         // Once blocks are deleted... remove the blockID from blockDataTable
         // and also remove the transactions from txnTable.
@@ -516,7 +516,7 @@ public class BlockDeletingService extends BackgroundService {
 
           // update count of pending deletion blocks, block count and used
           // bytes in in-memory container status and used space in volume.
-          containerData.decrPendingDeletionBlocks(deletedBlocksCount);
+          containerData.decrPendingDeletionBlocks(deletedBlocksProceeded);
           containerData.decrBlockCount(deletedBlocksCount);
           containerData.decrBytesUsed(releasedBytes);
           containerData.getVolume().decrementUsedSpace(releasedBytes);
@@ -541,10 +541,11 @@ public class BlockDeletingService extends BackgroundService {
      * Delete the chunks for the given blocks.
      * Return the deletedBlocks count and number of bytes released.
      */
-    private Pair<Integer, Long> deleteTransactions(
+    private DeleteTransactionStats deleteTransactions(
         List<DeletedBlocksTransaction> delBlocks, Handler handler,
         Table<String, BlockData> blockDataTable, Container container)
         throws IOException {
+      int blocksMissed = 0;
       int blocksDeleted = 0;
       long bytesReleased = 0;
       for (DeletedBlocksTransaction entry : delBlocks) {
@@ -556,7 +557,7 @@ public class BlockDeletingService extends BackgroundService {
             LOG.warn("Missing delete block(Container = " +
                 container.getContainerData().getContainerID() + ", Block = " +
                 blkLong);
-            blocksDeleted++;
+            blocksMissed++;
             continue;
           }
 
@@ -584,7 +585,8 @@ public class BlockDeletingService extends BackgroundService {
           }
         }
       }
-      return Pair.of(blocksDeleted, bytesReleased);
+      return new DeleteTransactionStats(blocksMissed + blocksDeleted,
+          blocksDeleted, bytesReleased);
     }
 
     @Override
@@ -600,5 +602,33 @@ public class BlockDeletingService extends BackgroundService {
 
   public BlockDeletingServiceMetrics getMetrics() {
     return metrics;
+  }
+
+  /**
+   * The wrapper class of the result of deleting transactions.
+   */
+  private class DeleteTransactionStats {
+
+    private final int blocksProcessed;
+    private final int blocksDeleted;
+    private final long bytesReleased;
+
+    DeleteTransactionStats(int proceeded, int deleted, long released) {
+      blocksProcessed =  proceeded;
+      blocksDeleted = deleted;
+      bytesReleased = released;
+    }
+
+    public int getBlocksProcessed() {
+      return blocksProcessed;
+    }
+
+    public int getBlocksDeleted() {
+      return blocksDeleted;
+    }
+
+    public long getBytesReleased() {
+      return bytesReleased;
+    }
   }
 }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/statemachine/background/BlockDeletingService.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/statemachine/background/BlockDeletingService.java
@@ -545,7 +545,7 @@ public class BlockDeletingService extends BackgroundService {
         List<DeletedBlocksTransaction> delBlocks, Handler handler,
         Table<String, BlockData> blockDataTable, Container container)
         throws IOException {
-      int blocksMissed = 0;
+      int blocksProcessed = 0;
       int blocksDeleted = 0;
       long bytesReleased = 0;
       for (DeletedBlocksTransaction entry : delBlocks) {
@@ -557,7 +557,7 @@ public class BlockDeletingService extends BackgroundService {
             LOG.warn("Missing delete block(Container = " +
                 container.getContainerData().getContainerID() + ", Block = " +
                 blkLong);
-            blocksMissed++;
+            blocksProcessed++;
             continue;
           }
 
@@ -565,6 +565,7 @@ public class BlockDeletingService extends BackgroundService {
           try {
             handler.deleteBlock(container, blkInfo);
             blocksDeleted++;
+            blocksProcessed++;
             deleted = true;
           } catch (IOException e) {
             // TODO: if deletion of certain block retries exceed the certain
@@ -585,7 +586,7 @@ public class BlockDeletingService extends BackgroundService {
           }
         }
       }
-      return new DeleteTransactionStats(blocksMissed + blocksDeleted,
+      return new DeleteTransactionStats(blocksProcessed,
           blocksDeleted, bytesReleased);
     }
 

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/statemachine/background/BlockDeletingService.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/statemachine/background/BlockDeletingService.java
@@ -490,7 +490,7 @@ public class BlockDeletingService extends BackgroundService {
 
         DeleteTransactionStats deleteBlocksResult =
             deleteTransactions(delBlocks, handler, blockDataTable, container);
-        int deletedBlocksProceeded = deleteBlocksResult.getBlocksProcessed();
+        int deletedBlocksProcessed = deleteBlocksResult.getBlocksProcessed();
         int deletedBlocksCount = deleteBlocksResult.getBlocksDeleted();
         long releasedBytes = deleteBlocksResult.getBytesReleased();
 
@@ -516,7 +516,7 @@ public class BlockDeletingService extends BackgroundService {
 
           // update count of pending deletion blocks, block count and used
           // bytes in in-memory container status and used space in volume.
-          containerData.decrPendingDeletionBlocks(deletedBlocksProceeded);
+          containerData.decrPendingDeletionBlocks(deletedBlocksProcessed);
           containerData.decrBlockCount(deletedBlocksCount);
           containerData.decrBytesUsed(releasedBytes);
           containerData.getVolume().decrementUsedSpace(releasedBytes);

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/statemachine/background/BlockDeletingService.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/statemachine/background/BlockDeletingService.java
@@ -607,7 +607,7 @@ public class BlockDeletingService extends BackgroundService {
   /**
    * The wrapper class of the result of deleting transactions.
    */
-  private class DeleteTransactionStats {
+  private static class DeleteTransactionStats {
 
     private final int blocksProcessed;
     private final int blocksDeleted;

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/TestBlockDeletingService.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/TestBlockDeletingService.java
@@ -558,6 +558,12 @@ public class TestBlockDeletingService {
     GenericTestUtils.waitFor(() -> ctr2.getNumPendingDeletionBlocks() == 0,
         200, 2000);
 
+    // To make sure the container stat calculation is right
+    Assert.assertEquals(0, ctr1.getBlockCount());
+    Assert.assertEquals(0, ctr1.getBytesUsed());
+    Assert.assertEquals(0, ctr2.getBlockCount());
+    Assert.assertEquals(0, ctr2.getBytesUsed());
+
     svc.shutdown();
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

After the patch of [HDDS-7259](https://issues.apache.org/jira/browse/HDDS-7259),  the number of empty containers is accumulating and they are not deleted.  The reason is due to the incorrect block count. 

The block count is increased each time of puttingBlock, so it should not decrease the missing block number.

While the pending deletion block number is increased by counting the blocks in the TXN(missing blocks included), so missing block number should be reduced.
![企业微信截图_c3ed4b94-30bc-477a-bffa-b6a3210e08a7](https://user-images.githubusercontent.com/10106574/194755867-c8cdf454-2dc9-40b8-a5a8-b95a56d792d2.png)


## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-7302

## How was this patch tested?

UT . See supplement of UT
