### PR TITLE
HDDS-7303. EC: ECBlockReconstructedStripeInputStream should set initialized false on re-init

### DIFF
--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/ozone/client/io/ECBlockReconstructedStripeInputStream.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/ozone/client/io/ECBlockReconstructedStripeInputStream.java
@@ -212,12 +212,14 @@ public class ECBlockReconstructedStripeInputStream extends ECBlockInputStream {
   }
 
   private void init() throws InsufficientLocationsException {
+    initialized = false;
     if (decoder == null) {
       decoder = CodecUtil.createRawDecoderWithFallback(getRepConfig());
     }
     if (!hasSufficientLocations()) {
-      throw new InsufficientLocationsException("There are insufficient " +
-          "datanodes to read the EC block");
+      String msg = "There are insufficient datanodes to read the EC block";
+      LOG.debug(msg);
+      throw new InsufficientLocationsException(msg);
     }
     allocateInternalBuffers();
     if (!isOfflineRecovery()) {
@@ -365,9 +367,6 @@ public class ECBlockReconstructedStripeInputStream extends ECBlockInputStream {
         loadDataBuffersFromStream();
         break;
       } catch (IOException e) {
-        // Re-init now the bad block has been excluded. If we have ran out of
-        // locations, init will throw an InsufficientLocations exception.
-        init();
         // seek to the current position so it rewinds any blocks we read
         // already.
         seek(getPos());
@@ -375,6 +374,9 @@ public class ECBlockReconstructedStripeInputStream extends ECBlockInputStream {
         for (ByteBuffer b : bufs) {
           b.position(0);
         }
+        // Re-init now the bad block has been excluded. If we have run out of
+        // locations, init will throw an InsufficientLocations exception.
+        init();
       } catch (InterruptedException ie) {
         Thread.currentThread().interrupt();
         throw new IOException("Interrupted waiting for reads to complete", ie);


### PR DESCRIPTION
## What changes were proposed in this pull request?

In ECBlockReconstructedStripeInputStream, when an exception occurs reading a block, the code calls the `init()` method to setup the missing indexes and buffers.

If an InsufficientLocations exception is thrown part way through that method, the class ends up partly re-initialized. If something then ignores / handles the InsufficientLocations and tries to call read again, it can cause strange results. In one case, we get an illegalArgumentException, which I think is related to the above:

```
Caused by: java.lang.ArrayIndexOutOfBoundsException: 1
	at org.apache.hadoop.ozone.client.io.ECBlockReconstructedStripeInputStream.assignBuffers(ECBlockReconstructedStripeInputStream.java:289)
	at org.apache.hadoop.ozone.client.io.ECBlockReconstructedStripeInputStream.read(ECBlockReconstructedStripeInputStream.java:360)
	at org.apache.hadoop.ozone.client.io.ECBlockReconstructedStripeInputStream.readStripe(ECBlockReconstructedStripeInputStream.java:345)
	at org.apache.hadoop.ozone.client.io.ECBlockReconstructedInputStream.readStripe(ECBlockReconstructedInputStream.java:214)
	at org.apache.hadoop.ozone.client.io.ECBlockReconstructedInputStream.readAndSeekStripe(ECBlockReconstructedInputStream.java:198)
	at org.apache.hadoop.ozone.client.io.ECBlockReconstructedInputStream.seek(ECBlockReconstructedInputStream.java:192)
	at org.apache.hadoop.ozone.client.io.ECBlockInputStreamProxy.seek(ECBlockInputStreamProxy.java:224)
	at org.apache.hadoop.ozone.client.io.KeyInputStream.seek(KeyInputStream.java:340)
	at org.apache.hadoop.fs.ozone.OzoneFSInputStream.seek(OzoneFSInputStream.java:78)
	at org.apache.hadoop.fs.FSInputStream.read(FSInputStream.java:85)
	at org.apache.hadoop.fs.FSInputStream.readFully(FSInputStream.java:124)
	at org.apache.hadoop.fs.FSDataInputStream.readFully(FSDataInputStream.java:116)
	at org.apache.orc.impl.RecordReaderUtils$DefaultDataReader.readStripeFooter(RecordReaderUtils.java:273)
	at org.apache.orc.impl.RecordReaderImpl.readStripeFooter(RecordReaderImpl.java:308)
	at org.apache.orc.impl.RecordReaderImpl.beginReadStripe(RecordReaderImpl.java:1131)
	at org.apache.orc.impl.RecordReaderImpl.readStripe(RecordReaderImpl.java:1093)
	at org.apache.orc.impl.RecordReaderImpl.advanceStripe(RecordReaderImpl.java:1261)
	at org.apache.orc.impl.RecordReaderImpl.advanceToNextRow(RecordReaderImpl.java:1296)
	at org.apache.orc.impl.RecordReaderImpl.nextBatch(RecordReaderImpl.java:1332)
	at org.apache.hadoop.hive.ql.io.orc.RecordReaderImpl.nextBatch(RecordReaderImpl.java:157)
	at org.apache.hadoop.hive.ql.io.orc.VectorizedOrcAcidRowBatchReader$1.next(VectorizedOrcAcidRowBatchReader.java:175)
	at org.apache.hadoop.hive.ql.io.orc.VectorizedOrcAcidRowBatchReader$1.next(VectorizedOrcAcidRowBatchReader.java:171)
	at org.apache.hadoop.hive.ql.io.orc.VectorizedOrcAcidRowBatchReader.next(VectorizedOrcAcidRowBatchReader.java:871)
	... 26 more
```

We should simply set initialized to false at the beginning of init and set it to try at the end when the full init method has completed.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-7303

## How was this patch tested?

Existing test cover this.
