### PR TITLE
HDDS-7304. EC: EC Decode can fail when byteBuffer from elastic pool is larger than chunksize

### DIFF
--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/ozone/client/io/ECBlockReconstructedStripeInputStream.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/ozone/client/io/ECBlockReconstructedStripeInputStream.java
@@ -547,6 +547,7 @@ public class ECBlockReconstructedStripeInputStream extends ECBlockInputStream {
     for (int i : internalBuffers) {
       if (decoderInputBuffers[i] != null) {
         decoderInputBuffers[i].clear();
+        decoderInputBuffers[i].limit(getRepConfig().getEcChunkSize());
       }
     }
   }


### PR DESCRIPTION
## What changes were proposed in this pull request?

he EC client establishes an ElasticByteBufferPool, so that byte buffers can be assigned / freed and reused without allocating and freeing memory over and over. The buffer returned by the elastic buffer can be larger than the size requested, and if that is the case we can get an error on EC decode, such as:

```
java.lang.IllegalArgumentException: Invalid buffer [3], not of length 1048576

	at org.apache.ozone.erasurecode.rawcoder.ByteBufferDecodingState.checkInputBuffers(ByteBufferDecodingState.java:106)
	at org.apache.ozone.erasurecode.rawcoder.ByteBufferDecodingState.<init>(ByteBufferDecodingState.java:44)
	at org.apache.ozone.erasurecode.rawcoder.RawErasureDecoder.decode(RawErasureDecoder.java:84)
	at org.apache.hadoop.ozone.client.io.ECBlockReconstructedStripeInputStream.decodeStripe(ECBlockReconstructedStripeInputStream.java:649)
	at org.apache.hadoop.ozone.client.io.ECBlockReconstructedStripeInputStream.read(ECBlockReconstructedStripeInputStream.java:388)
	at org.apache.hadoop.ozone.client.io.TestECBlockReconstructedStripeInputStream.testErrorReadingBlockContinuesReading(TestECBlockReconstructedStripeInputStream.java:622)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.junit.platform.commons.util.ReflectionUtils.invokeMethod(ReflectionUtils.java:725)
	at org.junit.jupiter.engine.execution.MethodInvocation.proceed(MethodInvocation.java:60)
	at org.junit.jupiter.engine.execution.InvocationInterceptorChain$ValidatingInvocation.proceed(InvocationInterceptorChain.java:131)
...
```
The solution is to set the limit on the buffer to the appropriate size before attempting to use it.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-7304

## How was this patch tested?

Modification to the unit test caused many test failures and then the code change fix them.