### PR TITLE
HDDS-7236. Enable Recon SCM DB bootstrap by default.

### DIFF
--- a/hadoop-hdds/common/src/main/resources/ozone-default.xml
+++ b/hadoop-hdds/common/src/main/resources/ozone-default.xml
@@ -2788,7 +2788,7 @@
   </property>
   <property>
     <name>ozone.recon.scm.snapshot.enabled</name>
-    <value>false</value>
+    <value>true</value>
     <tag>OZONE, RECON, SCM</tag>
     <description>
       If enabled, SCM DB Snapshot is taken by Recon.

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/ReconServerConfigKeys.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/ReconServerConfigKeys.java
@@ -133,7 +133,7 @@ public final class  ReconServerConfigKeys {
 
   public static final String OZONE_RECON_SCM_SNAPSHOT_ENABLED =
       "ozone.recon.scm.snapshot.enabled";
-  public static final boolean OZONE_RECON_SCM_SNAPSHOT_ENABLED_DEFAULT = false;
+  public static final boolean OZONE_RECON_SCM_SNAPSHOT_ENABLED_DEFAULT = true;
 
   public static final String OZONE_RECON_SCM_CONNECTION_TIMEOUT =
       "ozone.recon.scm.connection.timeout";


### PR DESCRIPTION
## What changes were proposed in this pull request?

Enable Recon SCM DB bootstrap by default. `ozone.recon.scm.snapshot.enabled` was set to`false`, until other [tasks](https://issues.apache.org/jira/browse/HDDS-2852) were completed. 

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-7236

## How was this patch tested?

Using existing Unit and Integration tests for Recon which was added as part of the previous changes.
