### PR TITLE
HDDS-7316. Print stacktrace to identify the location of RocksObject leaks.

### DIFF
--- a/hadoop-hdds/framework/pom.xml
+++ b/hadoop-hdds/framework/pom.xml
@@ -147,6 +147,11 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-params</artifactId>
     </dependency>
+    <dependency>
+      <groupId>com.github.spotbugs</groupId>
+      <artifactId>spotbugs-annotations</artifactId>
+      <scope>compile</scope>
+    </dependency>
   </dependencies>
 
 

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/managed/ManagedObject.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/managed/ManagedObject.java
@@ -19,6 +19,8 @@
 package org.apache.hadoop.hdds.utils.db.managed;
 
 import org.rocksdb.RocksObject;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * General template for a managed RocksObject.
@@ -29,9 +31,15 @@ class ManagedObject<T extends RocksObject> implements AutoCloseable {
 
   private final StackTraceElement[] elements;
 
+  public static final Logger LOG = LoggerFactory.getLogger(ManagedObject.class);
+
   ManagedObject(T original) {
     this.original = original;
-    this.elements = Thread.currentThread().getStackTrace();
+    if (LOG.isDebugEnabled()) {
+      this.elements = Thread.currentThread().getStackTrace();
+    } else {
+      this.elements = null;
+    }
   }
 
   public T get() {

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/managed/ManagedObject.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/managed/ManagedObject.java
@@ -55,11 +55,8 @@ class ManagedObject<T extends RocksObject> implements AutoCloseable {
 
   public String getStackTrace() {
     if (elements != null && elements.length > 0) {
-      // 15 lines should be good enough to know the caller of
-      // the unclosed instance?
-      int maxStackTraceLines = 15;
       StringBuilder sb = new StringBuilder();
-      for (int line = 1; line <= maxStackTraceLines; line++) {
+      for (int line = 1; line < elements.length; line++) {
         sb.append(elements[line]);
         sb.append("\n");
       }

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/managed/ManagedObject.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/managed/ManagedObject.java
@@ -27,7 +27,7 @@ import org.rocksdb.RocksObject;
 class ManagedObject<T extends RocksObject> implements AutoCloseable {
   private final T original;
 
-  private final StackTraceElement [] elements;
+  private final StackTraceElement[] elements;
 
   ManagedObject(T original) {
     this.original = original;
@@ -49,13 +49,13 @@ class ManagedObject<T extends RocksObject> implements AutoCloseable {
     super.finalize();
   }
 
-  public String getStackTrace(){
+  public String getStackTrace() {
     if (elements != null && elements.length > 0) {
       // 15 lines should be good enough to know the caller of
       // the unclosed instance?
       int maxStackTraceLines = 15;
       StringBuilder sb = new StringBuilder();
-      for (int line =1; line<=maxStackTraceLines; line++){
+      for (int line = 1; line <= maxStackTraceLines; line++) {
         sb.append(elements[line]);
         sb.append("\n");
       }

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/managed/ManagedObject.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/managed/ManagedObject.java
@@ -27,8 +27,11 @@ import org.rocksdb.RocksObject;
 class ManagedObject<T extends RocksObject> implements AutoCloseable {
   private final T original;
 
+  private final StackTraceElement [] elements;
+
   ManagedObject(T original) {
     this.original = original;
+    this.elements = Thread.currentThread().getStackTrace();
   }
 
   public T get() {
@@ -42,7 +45,23 @@ class ManagedObject<T extends RocksObject> implements AutoCloseable {
 
   @Override
   protected void finalize() throws Throwable {
-    ManagedRocksObjectUtils.assertClosed(original);
+    ManagedRocksObjectUtils.assertClosed(this);
     super.finalize();
   }
+
+  public String getStackTrace(){
+    if (elements != null && elements.length > 0) {
+      // 15 lines should be good enough to know the caller of
+      // the unclosed instance?
+      int maxStackTraceLines = 15;
+      StringBuilder sb = new StringBuilder();
+      for (int line =1; line<=maxStackTraceLines; line++){
+        sb.append(elements[line]);
+        sb.append("\n");
+      }
+      return sb.toString();
+    }
+    return "";
+  }
+
 }

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/managed/ManagedObject.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/managed/ManagedObject.java
@@ -19,8 +19,6 @@
 package org.apache.hadoop.hdds.utils.db.managed;
 
 import org.rocksdb.RocksObject;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * General template for a managed RocksObject.
@@ -31,11 +29,9 @@ class ManagedObject<T extends RocksObject> implements AutoCloseable {
 
   private final StackTraceElement[] elements;
 
-  public static final Logger LOG = LoggerFactory.getLogger(ManagedObject.class);
-
   ManagedObject(T original) {
     this.original = original;
-    if (LOG.isDebugEnabled()) {
+    if (ManagedRocksObjectUtils.LOG.isDebugEnabled()) {
       this.elements = Thread.currentThread().getStackTrace();
     } else {
       this.elements = null;

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/managed/ManagedRocksObjectUtils.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/managed/ManagedRocksObjectUtils.java
@@ -33,34 +33,22 @@ public final class ManagedRocksObjectUtils {
       LoggerFactory.getLogger(ManagedRocksObjectUtils.class);
 
   static void assertClosed(RocksObject rocksObject) {
-    ManagedRocksObjectMetrics.INSTANCE.increaseManagedObject();
-    if (rocksObject.isOwningHandle()) {
-      ManagedRocksObjectMetrics.INSTANCE.increaseLeakObject();
-      LOG.warn("{} is not closed properly",
-          rocksObject.getClass().getSimpleName());
-    }
+    assertClosed(rocksObject, null);
   }
 
   static void assertClosed(ManagedObject<?> object) {
-    RocksObject rocksObject = object.get();
+    assertClosed(object.get(), object.getStackTrace());
+  }
+
+  static void assertClosed(RocksObject rocksObject, String stackTrace) {
     ManagedRocksObjectMetrics.INSTANCE.increaseManagedObject();
     if (rocksObject.isOwningHandle()) {
       ManagedRocksObjectMetrics.INSTANCE.increaseLeakObject();
       LOG.warn("{} is not closed properly",
           rocksObject.getClass().getSimpleName());
-      if (LOG.isDebugEnabled()) {
-        LOG.debug("StackTrace for unclosed instance: {}",
-            object.getStackTrace());
+      if (stackTrace != null && LOG.isDebugEnabled()) {
+        LOG.debug("StackTrace for unclosed instance: {}", stackTrace);
       }
-    }
-  }
-
-  static void assertClosed(RocksObject rocksObject, Throwable stack) {
-    ManagedRocksObjectMetrics.INSTANCE.increaseManagedObject();
-    if (rocksObject.isOwningHandle()) {
-      ManagedRocksObjectMetrics.INSTANCE.increaseLeakObject();
-      LOG.warn("{} is not closed properly",
-          rocksObject.getClass().getSimpleName(), stack);
     }
   }
 }

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/managed/ManagedRocksObjectUtils.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/managed/ManagedRocksObjectUtils.java
@@ -44,11 +44,14 @@ public final class ManagedRocksObjectUtils {
     ManagedRocksObjectMetrics.INSTANCE.increaseManagedObject();
     if (rocksObject.isOwningHandle()) {
       ManagedRocksObjectMetrics.INSTANCE.increaseLeakObject();
-      LOG.warn("{} is not closed properly",
+      String warning = String.format("%s is not closed properly",
           rocksObject.getClass().getSimpleName());
       if (stackTrace != null && LOG.isDebugEnabled()) {
-        LOG.debug("StackTrace for unclosed instance: {}", stackTrace);
+        String debugMessage = String
+            .format("%n StackTrace for unclosed instance: %s", stackTrace);
+        warning = warning.concat(debugMessage);
       }
+      LOG.warn(warning);
     }
   }
 }

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/managed/ManagedRocksObjectUtils.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/managed/ManagedRocksObjectUtils.java
@@ -41,6 +41,19 @@ public final class ManagedRocksObjectUtils {
     }
   }
 
+  static void assertClosed(ManagedObject<?>object) {
+    RocksObject rocksObject = object.get();
+    ManagedRocksObjectMetrics.INSTANCE.increaseManagedObject();
+    if (rocksObject.isOwningHandle()) {
+      ManagedRocksObjectMetrics.INSTANCE.increaseLeakObject();
+      LOG.warn("{} is not closed properly",
+          rocksObject.getClass().getSimpleName());
+      if (LOG.isDebugEnabled()) {
+        LOG.debug("StackTrace for unclosed instance: {}", object.getStackTrace());
+      }
+    }
+  }
+
   static void assertClosed(RocksObject rocksObject, Throwable stack) {
     ManagedRocksObjectMetrics.INSTANCE.increaseManagedObject();
     if (rocksObject.isOwningHandle()) {

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/managed/ManagedRocksObjectUtils.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/managed/ManagedRocksObjectUtils.java
@@ -36,7 +36,7 @@ public final class ManagedRocksObjectUtils {
     assertClosed(rocksObject, null);
   }
 
-  static void assertClosed(ManagedObject<?> object) {
+  public static void assertClosed(ManagedObject<?> object) {
     assertClosed(object.get(), object.getStackTrace());
   }
 

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/managed/ManagedRocksObjectUtils.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/managed/ManagedRocksObjectUtils.java
@@ -41,7 +41,7 @@ public final class ManagedRocksObjectUtils {
     }
   }
 
-  static void assertClosed(ManagedObject<?>object) {
+  static void assertClosed(ManagedObject<?> object) {
     RocksObject rocksObject = object.get();
     ManagedRocksObjectMetrics.INSTANCE.increaseManagedObject();
     if (rocksObject.isOwningHandle()) {
@@ -49,7 +49,8 @@ public final class ManagedRocksObjectUtils {
       LOG.warn("{} is not closed properly",
           rocksObject.getClass().getSimpleName());
       if (LOG.isDebugEnabled()) {
-        LOG.debug("StackTrace for unclosed instance: {}", object.getStackTrace());
+        LOG.debug("StackTrace for unclosed instance: {}",
+            object.getStackTrace());
       }
     }
   }

--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/utils/db/TestRDBStoreIterator.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/utils/db/TestRDBStoreIterator.java
@@ -18,6 +18,7 @@
  */
 package org.apache.hadoop.hdds.utils.db;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.apache.hadoop.hdds.utils.db.managed.ManagedRocksIterator;
 import org.apache.hadoop.hdds.utils.db.managed.ManagedRocksObjectUtils;
 import org.apache.log4j.Level;
@@ -300,6 +301,7 @@ public class TestRDBStoreIterator {
   }
 
   @Test
+  @SuppressFBWarnings("RV_RETURN_VALUE_IGNORED_NO_SIDE_EFFECT")
   public void testGetStackTrace() {
     ManagedRocksIterator iterator = mock(ManagedRocksIterator.class);
     RocksIterator mock = mock(RocksIterator.class);

--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/utils/db/TestRDBStoreIterator.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/utils/db/TestRDBStoreIterator.java
@@ -19,6 +19,10 @@
 package org.apache.hadoop.hdds.utils.db;
 
 import org.apache.hadoop.hdds.utils.db.managed.ManagedRocksIterator;
+import org.apache.hadoop.hdds.utils.db.managed.ManagedRocksObjectUtils;
+import org.apache.log4j.Level;
+import org.apache.log4j.Logger;
+import org.junit.Assert;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
@@ -61,6 +65,7 @@ public class TestRDBStoreIterator {
     rocksDBIteratorMock = mock(RocksIterator.class);
     managedRocksIterator = new ManagedRocksIterator(rocksDBIteratorMock);
     rocksTableMock = mock(RDBTable.class);
+    Logger.getLogger(ManagedRocksObjectUtils.class).setLevel(Level.DEBUG);
   }
 
   @Test
@@ -292,5 +297,29 @@ public class TestRDBStoreIterator {
     }
 
     iter.close();
+  }
+
+  @Test
+  public void testGetStackTrace() {
+    ManagedRocksIterator iterator = mock(ManagedRocksIterator.class);
+    RocksIterator mock = mock(RocksIterator.class);
+    when(iterator.get()).thenReturn(mock);
+    when(mock.isOwningHandle()).thenReturn(true);
+    ManagedRocksObjectUtils.assertClosed(iterator);
+    verify(iterator, times(1)).getStackTrace();
+
+    iterator = new ManagedRocksIterator(rocksDBIteratorMock);
+
+    // construct the expected trace.
+    StackTraceElement[] traceElements = Thread.currentThread().getStackTrace();
+    StringBuilder sb = new StringBuilder();
+    // first 2 lines will differ.
+    for (int i = 2; i < traceElements.length; i++) {
+      sb.append(traceElements[i]);
+      sb.append("\n");
+    }
+    String expectedTrace = sb.toString();
+    String fromObjectInit = iterator.getStackTrace();
+    Assert.assertTrue(fromObjectInit.contains(expectedTrace));
   }
 }

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/spi/impl/ReconContainerMetadataManagerImpl.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/spi/impl/ReconContainerMetadataManagerImpl.java
@@ -613,7 +613,8 @@ public class ReconContainerMetadataManagerImpl
 
   private void initializeKeyContainerTable() throws IOException {
     Instant start = Instant.now();
-    try(TableIterator<ContainerKeyPrefix, ? extends KeyValue<ContainerKeyPrefix,
+    try (TableIterator<ContainerKeyPrefix, ?
+        extends KeyValue<ContainerKeyPrefix,
         Integer>> iterator = containerKeyTable.iterator()) {
       KeyValue<ContainerKeyPrefix, Integer> keyValue;
       long count = 0;

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/spi/impl/ReconContainerMetadataManagerImpl.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/spi/impl/ReconContainerMetadataManagerImpl.java
@@ -613,21 +613,22 @@ public class ReconContainerMetadataManagerImpl
 
   private void initializeKeyContainerTable() throws IOException {
     Instant start = Instant.now();
-    TableIterator<ContainerKeyPrefix, ? extends KeyValue<ContainerKeyPrefix,
-        Integer>> iterator = containerKeyTable.iterator();
-    KeyValue<ContainerKeyPrefix, Integer> keyValue;
-    long count = 0;
-    while (iterator.hasNext()) {
-      keyValue = iterator.next();
-      ContainerKeyPrefix containerKeyPrefix = keyValue.getKey();
-      if (!StringUtils.isEmpty(containerKeyPrefix.getKeyPrefix()) &&
-          containerKeyPrefix.getContainerId() != -1) {
-        keyContainerTable.put(containerKeyPrefix.toKeyPrefixContainer(), 1);
+    try(TableIterator<ContainerKeyPrefix, ? extends KeyValue<ContainerKeyPrefix,
+        Integer>> iterator = containerKeyTable.iterator()) {
+      KeyValue<ContainerKeyPrefix, Integer> keyValue;
+      long count = 0;
+      while (iterator.hasNext()) {
+        keyValue = iterator.next();
+        ContainerKeyPrefix containerKeyPrefix = keyValue.getKey();
+        if (!StringUtils.isEmpty(containerKeyPrefix.getKeyPrefix())
+            && containerKeyPrefix.getContainerId() != -1) {
+          keyContainerTable.put(containerKeyPrefix.toKeyPrefixContainer(), 1);
+        }
+        count++;
       }
-      count++;
+      long duration = Duration.between(start, Instant.now()).toMillis();
+      LOG.info("It took {} seconds to initialized {} records"
+          + " to KEY_CONTAINER table", (double) duration / 1000, count);
     }
-    long duration = Duration.between(start, Instant.now()).toMillis();
-    LOG.info("It took {} seconds to initialized {} records" +
-        " to KEY_CONTAINER table", (double) duration / 1000, count);
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?
Add logging to identify location/trace of unclosed RocksObjects .

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-7316

## How was this patch tested?
Tested on docker with debug logs enabled , identified an instance and fixed in this PR

```
[34mrecon_1     |[0m 2022-10-12 13:56:51 WARN  ManagedRocksObjectUtils:49 - RocksIterator is not closed properly
[34mrecon_1     |[0m 2022-10-12 13:56:51 DEBUG ManagedRocksObjectUtils:52 - StackTrace for unclosed instance: org.apache.hadoop.hdds.utils.db.managed.ManagedObject.<init>(ManagedObject.java:34)
[34mrecon_1     |[0m org.apache.hadoop.hdds.utils.db.managed.ManagedRocksIterator.<init>(ManagedRocksIterator.java:28)
[34mrecon_1     |[0m org.apache.hadoop.hdds.utils.db.managed.ManagedRocksIterator.managed(ManagedRocksIterator.java:32)
[34mrecon_1     |[0m org.apache.hadoop.hdds.utils.db.RocksDatabase.newIterator(RocksDatabase.java:492)
[34mrecon_1     |[0m org.apache.hadoop.hdds.utils.db.RDBTable.iterator(RDBTable.java:161)
[34mrecon_1     |[0m org.apache.hadoop.hdds.utils.db.TypedTable.iterator(TypedTable.java:280)
[34mrecon_1     |[0m org.apache.hadoop.ozone.recon.spi.impl.ReconContainerMetadataManagerImpl.initializeKeyContainerTable(ReconContainerMetadataManagerImpl.java:617)
[34mrecon_1     |[0m org.apache.hadoop.ozone.recon.spi.impl.ReconContainerMetadataManagerImpl.initializeTables(ReconContainerMetadataManagerImpl.java:135)
[34mrecon_1     |[0m org.apache.hadoop.ozone.recon.spi.impl.ReconContainerMetadataManagerImpl.<init>(ReconContainerMetadataManagerImpl.java:88)
[34mrecon_1     |[0m org.apache.hadoop.ozone.recon.spi.impl.ReconContainerMetadataManagerImpl$$FastClassByGuice$$7c269485.newInstance(<generated>)
[34mrecon_1     |[0m com.google.inject.internal.cglib.reflect.$FastConstructor.newInstance(FastConstructor.java:40)
[34mrecon_1     |[0m com.google.inject.internal.DefaultConstructionProxyFactory$1.newInstance(DefaultConstructionProxyFactory.java:61)
[34mrecon_1     |[0m com.google.inject.internal.ConstructorInjector.provision(ConstructorInjector.java:105)
[34mrecon_1     |[0m com.google.inject.internal.ConstructorInjector.construct(ConstructorInjector.java:85)
[34mrecon_1     |[0m com.google.inject.internal.ConstructorBindingImpl$Factory.get(ConstructorBindingImpl.java:267)```
