### PR TITLE
HDDS-7270. Fix bug in checking healthy replica placement policy check in EC underReplication handler

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ECUnderReplicationHandler.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ECUnderReplicationHandler.java
@@ -174,7 +174,6 @@ public class ECUnderReplicationHandler implements UnhealthyReplicationHandler {
                       .filter(datanodeDetails ->
                               datanodeDetails.getPersistedOpState() ==
                               HddsProtos.NodeOperationalState.IN_SERVICE)
-                      .filter(DatanodeDetails::isDecomissioned)
                       .collect(Collectors.toList());
       // We got the missing indexes, this is excluded any decommissioning
       // indexes. Find the good source nodes.

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestECUnderReplicationHandler.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestECUnderReplicationHandler.java
@@ -45,8 +45,6 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
-import org.mockito.invocation.InvocationOnMock;
-import org.mockito.stubbing.Answer;
 
 import java.io.IOException;
 import java.util.Collections;


### PR DESCRIPTION
## What changes were proposed in this pull request?
Fixing bug on existing healthy node selection in ECUnderReplicationHandler.  

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-7270

## How was this patch tested?
Fixing Unit Test cases.
