### PR TITLE
HDDS-6893. EC: ReplicationManager - move the empty container handling into RM from Legacy

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/protocol/commands/DeleteContainerCommand.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/protocol/commands/DeleteContainerCommand.java
@@ -23,6 +23,7 @@ import org.apache.hadoop.hdds.protocol.proto
     .StorageContainerDatanodeProtocolProtos.SCMCommandProto;
 import org.apache.hadoop.hdds.protocol.proto
     .StorageContainerDatanodeProtocolProtos.DeleteContainerCommandProto;
+import org.apache.hadoop.hdds.scm.container.ContainerID;
 
 /**
  * SCM command which tells the datanode to delete a container.
@@ -53,6 +54,11 @@ public class DeleteContainerCommand extends
 
   public DeleteContainerCommand(long containerId, boolean forceFlag) {
     this.containerId = containerId;
+    this.force = forceFlag;
+  }
+
+  public DeleteContainerCommand(ContainerID containerID, boolean forceFlag) {
+    this.containerId = containerID.getId();
     this.force = forceFlag;
   }
 

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ReplicationManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ReplicationManager.java
@@ -388,8 +388,10 @@ public class ReplicationManager implements SCMService {
     containerReplicaPendingOps.scheduleDeleteReplica(container.containerID(),
         datanode, replicaIndex);
 
-    metrics.incrNumDeletionCmdsSent();
-    metrics.incrNumDeletionBytesTotal(container.getUsedBytes());
+    synchronized (this) {
+      metrics.incrNumDeletionCmdsSent();
+      metrics.incrNumDeletionBytesTotal(container.getUsedBytes());
+    }
   }
 
 

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ReplicationManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ReplicationManager.java
@@ -27,6 +27,7 @@ import org.apache.hadoop.hdds.conf.ConfigurationSource;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.ContainerReplicaProto;
+import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.DeleteContainerCommandProto;
 import org.apache.hadoop.hdds.scm.PlacementPolicy;
 import org.apache.hadoop.hdds.scm.container.ContainerID;
 import org.apache.hadoop.hdds.scm.container.ContainerInfo;
@@ -51,6 +52,7 @@ import org.apache.hadoop.hdds.scm.server.StorageContainerManager;
 import org.apache.hadoop.hdds.server.events.EventPublisher;
 import org.apache.hadoop.ozone.protocol.commands.CloseContainerCommand;
 import org.apache.hadoop.ozone.protocol.commands.CommandForDatanode;
+import org.apache.hadoop.ozone.protocol.commands.DeleteContainerCommand;
 import org.apache.hadoop.ozone.protocol.commands.SCMCommand;
 import org.apache.hadoop.util.ExitUtil;
 import org.apache.ratis.protocol.exceptions.NotLeaderException;
@@ -361,6 +363,35 @@ public class ReplicationManager implements SCMService {
   public void sendCloseContainerEvent(ContainerID containerID) {
     eventPublisher.fireEvent(SCMEvents.CLOSE_CONTAINER, containerID);
   }
+
+  /**
+   * Sends delete container command for the given container to the given
+   * datanode.
+   *
+   * @param container Container to be deleted
+   * @param replicaIndex Index of the container replica to be deleted
+   * @param datanode  The datanode on which the replica should be deleted
+   * @throws NotLeaderException when this SCM is not the leader
+   */
+  public void sendDeleteCommand(final ContainerInfo container, int replicaIndex,
+      final DatanodeDetails datanode) throws NotLeaderException {
+    LOG.info("Sending delete container command for container {}" +
+        " to datanode {}", container.containerID(), datanode);
+
+    final DeleteContainerCommand deleteCommand =
+        new DeleteContainerCommand(container.containerID(), false);
+    deleteCommand.setTerm(getScmTerm());
+
+    final CommandForDatanode<DeleteContainerCommandProto> datanodeCommand =
+        new CommandForDatanode<>(datanode.getUuid(), deleteCommand);
+    eventPublisher.fireEvent(SCMEvents.DATANODE_COMMAND, datanodeCommand);
+    containerReplicaPendingOps.scheduleDeleteReplica(container.containerID(),
+        datanode, replicaIndex);
+
+    metrics.incrNumDeletionCmdsSent();
+    metrics.incrNumDeletionBytesTotal(container.getUsedBytes());
+  }
+
 
   /**
    * Add an under replicated container back to the queue if it was unable to

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ReplicationManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ReplicationManager.java
@@ -788,7 +788,7 @@ public class ReplicationManager implements SCMService {
     return ReplicationManager.class.getSimpleName();
   }
 
-  public ReplicationManagerMetrics getMetrics() {
+  public synchronized ReplicationManagerMetrics getMetrics() {
     return metrics;
   }
 

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/health/EmptyContainerHandler.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/health/EmptyContainerHandler.java
@@ -63,7 +63,7 @@ public class EmptyContainerHandler extends AbstractCheck {
     ContainerInfo containerInfo = request.getContainerInfo();
     Set<ContainerReplica> replicas = request.getContainerReplicas();
 
-    if (isContainerEmpty(containerInfo, replicas)) {
+    if (isContainerEmptyAndClosed(containerInfo, replicas)) {
       request.getReport()
           .incrementAndSample(ReplicationManagerReport.HealthState.EMPTY,
               containerInfo.containerID());
@@ -97,7 +97,7 @@ public class EmptyContainerHandler extends AbstractCheck {
    * @param replicas Set of ContainerReplica
    * @return true if the container is considered empty, false otherwise
    */
-  private boolean isContainerEmpty(final ContainerInfo container,
+  private boolean isContainerEmptyAndClosed(final ContainerInfo container,
       final Set<ContainerReplica> replicas) {
     return container.getState() == HddsProtos.LifeCycleState.CLOSED &&
         container.getNumberOfKeys() == 0 && replicas.stream()

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/health/EmptyContainerHandler.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/health/EmptyContainerHandler.java
@@ -1,0 +1,145 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.apache.hadoop.hdds.scm.container.replication.health;
+
+import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
+import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.ContainerReplicaProto;
+import org.apache.hadoop.hdds.scm.container.ContainerInfo;
+import org.apache.hadoop.hdds.scm.container.ContainerManager;
+import org.apache.hadoop.hdds.scm.container.ContainerReplica;
+import org.apache.hadoop.hdds.scm.container.ReplicationManagerReport;
+import org.apache.hadoop.hdds.scm.container.replication.ContainerCheckRequest;
+import org.apache.hadoop.hdds.scm.container.replication.ReplicationManager;
+import org.apache.hadoop.ozone.common.statemachine.InvalidStateTransitionException;
+import org.apache.ratis.protocol.exceptions.NotLeaderException;
+import org.apache.ratis.util.Preconditions;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.Set;
+import java.util.concurrent.TimeoutException;
+
+/**
+ * This handler deletes a container if it's closed and empty (0 key count)
+ * and all its replicas are empty.
+ */
+public class EmptyContainerHandler extends AbstractCheck {
+  public static final Logger LOG =
+      LoggerFactory.getLogger(EmptyContainerHandler.class);
+
+  private final ReplicationManager replicationManager;
+  private final ContainerManager containerManager;
+
+  public EmptyContainerHandler(ReplicationManager replicationManager,
+      ContainerManager containerManager) {
+    this.replicationManager = replicationManager;
+    this.containerManager = containerManager;
+  }
+
+  /**
+   * Deletes a container if it's closed and empty (0 key count) and all its
+   * replicas are closed and empty.
+   * @param request ContainerCheckRequest object representing the container
+   * @return true if the specified container is empty, otherwise false
+   */
+  @Override
+  public boolean handle(ContainerCheckRequest request) {
+    ContainerInfo containerInfo = request.getContainerInfo();
+    Set<ContainerReplica> replicas = request.getContainerReplicas();
+
+    if (isContainerEmpty(containerInfo, replicas)) {
+      request.getReport()
+          .incrementAndSample(ReplicationManagerReport.HealthState.EMPTY,
+              containerInfo.containerID());
+
+      // delete replicas if they are closed and empty
+      deleteContainerReplicas(containerInfo, replicas);
+
+      // Update the container's state
+      try {
+        containerManager.updateContainerState(containerInfo.containerID(),
+            HddsProtos.LifeCycleEvent.DELETE);
+      } catch (IOException | InvalidStateTransitionException |
+          TimeoutException e) {
+        LOG.error("Failed to delete empty container {}",
+            request.getContainerInfo(), e);
+      }
+      return true;
+    }
+
+    return false;
+  }
+
+  /**
+   * Returns true if the container is empty and CLOSED.
+   * A container is empty if its key count is 0. The usedBytes counter is not
+   * checked here because usedBytes is not an accurate representation of the
+   * committed blocks. There could be orphaned chunks in the container which
+   * contribute to usedBytes.
+   *
+   * @param container Container to check
+   * @param replicas Set of ContainerReplica
+   * @return true if the container is considered empty, false otherwise
+   */
+  private boolean isContainerEmpty(final ContainerInfo container,
+      final Set<ContainerReplica> replicas) {
+    return container.getState() == HddsProtos.LifeCycleState.CLOSED &&
+        container.getNumberOfKeys() == 0 && replicas.stream()
+        .allMatch(r -> r.getState() == ContainerReplicaProto.State.CLOSED &&
+            r.getKeyCount() == 0);
+  }
+
+  /**
+   * Deletes the specified container's replicas if they are closed and empty.
+   *
+   * @param containerInfo ContainerInfo to delete
+   * @param replicas Set of ContainerReplica
+   */
+  private void deleteContainerReplicas(final ContainerInfo containerInfo,
+      final Set<ContainerReplica> replicas) {
+    Preconditions.assertTrue(containerInfo.getState() ==
+        HddsProtos.LifeCycleState.CLOSED);
+    Preconditions.assertTrue(containerInfo.getNumberOfKeys() == 0);
+
+    for (ContainerReplica rp : replicas) {
+      Preconditions.assertTrue(
+          rp.getState() == ContainerReplicaProto.State.CLOSED);
+      Preconditions.assertTrue(rp.getKeyCount() == 0);
+
+      if (LOG.isDebugEnabled()) {
+        LOG.debug(
+            "Trying to delete empty replica with index {} for container " +
+                "{} on datanode {}", rp.getReplicaIndex(),
+            containerInfo.containerID(),
+            rp.getDatanodeDetails().getUuidString());
+      }
+      try {
+        replicationManager.sendDeleteCommand(containerInfo,
+            rp.getReplicaIndex(), rp.getDatanodeDetails());
+      } catch (NotLeaderException e) {
+        LOG.warn("Failed to delete empty replica with index {} for container" +
+                " {} on datanode {}",
+            rp.getReplicaIndex(),
+            containerInfo.containerID(),
+            rp.getDatanodeDetails().getUuidString(), e);
+      }
+    }
+  }
+
+}

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/health/EmptyContainerHandler.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/health/EmptyContainerHandler.java
@@ -122,13 +122,9 @@ public class EmptyContainerHandler extends AbstractCheck {
           rp.getState() == ContainerReplicaProto.State.CLOSED);
       Preconditions.assertTrue(rp.getKeyCount() == 0);
 
-      if (LOG.isDebugEnabled()) {
-        LOG.debug(
-            "Trying to delete empty replica with index {} for container " +
-                "{} on datanode {}", rp.getReplicaIndex(),
-            containerInfo.containerID(),
-            rp.getDatanodeDetails().getUuidString());
-      }
+      LOG.debug("Trying to delete empty replica with index {} for container " +
+              "{} on datanode {}", rp.getReplicaIndex(),
+          containerInfo.containerID(), rp.getDatanodeDetails().getUuidString());
       try {
         replicationManager.sendDeleteCommand(containerInfo,
             rp.getReplicaIndex(), rp.getDatanodeDetails());

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/ReplicationTestUtil.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/ReplicationTestUtil.java
@@ -84,6 +84,19 @@ public final class ReplicationTestUtil {
     return replicas;
   }
 
+  public static Set<ContainerReplica> createReplicas(ContainerID containerID,
+      ContainerReplicaProto.State replicaState, long keyCount, long bytesUsed,
+      int... indexes) {
+    Set<ContainerReplica> replicas = new HashSet<>();
+    for (int i : indexes) {
+      DatanodeDetails dn = MockDatanodeDetails.randomDatanodeDetails();
+      replicas.add(createContainerReplica(containerID, i, IN_SERVICE,
+          replicaState, keyCount, bytesUsed,
+          dn, dn.getUuid()));
+    }
+    return replicas;
+  }
+
   public static Set<ContainerReplica> createReplicasWithSameOrigin(
       ContainerID containerID, ContainerReplicaProto.State replicaState,
       int... indexes) {
@@ -91,7 +104,7 @@ public final class ReplicationTestUtil {
     UUID originNodeId = MockDatanodeDetails.randomDatanodeDetails().getUuid();
     for (int i : indexes) {
       replicas.add(createContainerReplica(
-          containerID, i, IN_SERVICE, replicaState,
+          containerID, i, IN_SERVICE, replicaState, 123L, 1234L,
           MockDatanodeDetails.randomDatanodeDetails(), originNodeId));
     }
     return replicas;
@@ -103,20 +116,22 @@ public final class ReplicationTestUtil {
     DatanodeDetails datanodeDetails
         = MockDatanodeDetails.randomDatanodeDetails();
     return createContainerReplica(containerID, replicaIndex, opState,
-        replicaState, datanodeDetails, datanodeDetails.getUuid());
+        replicaState, 123L, 1234L,
+        datanodeDetails, datanodeDetails.getUuid());
   }
 
+  @SuppressWarnings("checkstyle:ParameterNumber")
   public static ContainerReplica createContainerReplica(ContainerID containerID,
       int replicaIndex, HddsProtos.NodeOperationalState opState,
-      ContainerReplicaProto.State replicaState,
+      ContainerReplicaProto.State replicaState, long keyCount, long bytesUsed,
       DatanodeDetails datanodeDetails, UUID originNodeId) {
     ContainerReplica.ContainerReplicaBuilder builder
         = ContainerReplica.newBuilder();
     datanodeDetails.setPersistedOpState(opState);
     builder.setContainerID(containerID);
     builder.setReplicaIndex(replicaIndex);
-    builder.setKeyCount(123);
-    builder.setBytesUsed(1234);
+    builder.setKeyCount(keyCount);
+    builder.setBytesUsed(bytesUsed);
     builder.setContainerState(replicaState);
     builder.setDatanodeDetails(datanodeDetails);
     builder.setSequenceId(0);
@@ -138,6 +153,20 @@ public final class ReplicationTestUtil {
     builder.setPipelineID(PipelineID.randomId());
     builder.setReplicationConfig(replicationConfig);
     builder.setState(containerState);
+    return builder.build();
+  }
+
+  public static ContainerInfo createContainerInfo(
+      ReplicationConfig replicationConfig, long containerID,
+      HddsProtos.LifeCycleState containerState, long keyCount, long bytesUsed) {
+    ContainerInfo.Builder builder = new ContainerInfo.Builder();
+    builder.setContainerID(containerID);
+    builder.setOwner("Ozone");
+    builder.setPipelineID(PipelineID.randomId());
+    builder.setReplicationConfig(replicationConfig);
+    builder.setState(containerState);
+    builder.setNumberOfKeys(keyCount);
+    builder.setUsedBytes(bytesUsed);
     return builder.build();
   }
 

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/health/TestEmptyContainerHandler.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/health/TestEmptyContainerHandler.java
@@ -1,0 +1,194 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.apache.hadoop.hdds.scm.container.replication.health;
+
+import org.apache.hadoop.hdds.client.ECReplicationConfig;
+import org.apache.hadoop.hdds.client.RatisReplicationConfig;
+import org.apache.hadoop.hdds.protocol.DatanodeDetails;
+import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
+import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.ContainerReplicaProto;
+import org.apache.hadoop.hdds.scm.container.ContainerID;
+import org.apache.hadoop.hdds.scm.container.ContainerInfo;
+import org.apache.hadoop.hdds.scm.container.ContainerManager;
+import org.apache.hadoop.hdds.scm.container.ContainerReplica;
+import org.apache.hadoop.hdds.scm.container.ReplicationManagerReport;
+import org.apache.hadoop.hdds.scm.container.replication.ContainerCheckRequest;
+import org.apache.hadoop.hdds.scm.container.replication.ReplicationManager;
+import org.apache.hadoop.hdds.scm.container.replication.ReplicationTestUtil;
+import org.apache.hadoop.ozone.common.statemachine.InvalidStateTransitionException;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.Set;
+import java.util.concurrent.TimeoutException;
+
+import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.LifeCycleState.CLOSED;
+import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.LifeCycleState.CLOSING;
+
+/**
+ * Tests for {@link EmptyContainerHandler}.
+ */
+public class TestEmptyContainerHandler {
+  private ReplicationManager replicationManager;
+  private ContainerManager containerManager;
+  private EmptyContainerHandler emptyContainerHandler;
+  private ECReplicationConfig ecReplicationConfig;
+  private RatisReplicationConfig ratisReplicationConfig;
+
+  @BeforeEach
+  public void setup()
+      throws IOException, InvalidStateTransitionException, TimeoutException {
+    ecReplicationConfig = new ECReplicationConfig(3, 2);
+    ratisReplicationConfig = RatisReplicationConfig.getInstance(
+        HddsProtos.ReplicationFactor.THREE);
+    replicationManager = Mockito.mock(ReplicationManager.class);
+    containerManager = Mockito.mock(ContainerManager.class);
+
+    emptyContainerHandler =
+        new EmptyContainerHandler(replicationManager, containerManager);
+  }
+
+  /**
+   * A container is considered empty if it has 0 key count. Handler should
+   * return true for empty and CLOSED EC containers.
+   */
+  @Test
+  public void testEmptyAndClosedECContainerReturnsTrue() {
+    ContainerInfo containerInfo = ReplicationTestUtil.createContainerInfo(
+        ecReplicationConfig, 1, CLOSED, 0L, 123L);
+    Set<ContainerReplica> containerReplicas = ReplicationTestUtil
+        .createReplicas(containerInfo.containerID(),
+            ContainerReplicaProto.State.CLOSED, 0L, 123L, 1, 2, 3, 4, 5);
+
+    ContainerCheckRequest request = new ContainerCheckRequest.Builder()
+        .setPendingOps(Collections.emptyList())
+        .setReport(new ReplicationManagerReport())
+        .setContainerInfo(containerInfo)
+        .setContainerReplicas(containerReplicas)
+        .build();
+
+    assertAndVerify(request, true, 5);
+  }
+
+  @Test
+  public void testEmptyAndClosedRatisContainerReturnsTrue() {
+    ContainerInfo containerInfo = ReplicationTestUtil.createContainerInfo(
+        ratisReplicationConfig, 1, CLOSED, 0L, 123L);
+    Set<ContainerReplica> containerReplicas = ReplicationTestUtil
+        .createReplicas(containerInfo.containerID(),
+            ContainerReplicaProto.State.CLOSED, 0L, 123L, 0, 0, 0);
+
+    ContainerCheckRequest request = new ContainerCheckRequest.Builder()
+        .setPendingOps(Collections.emptyList())
+        .setReport(new ReplicationManagerReport())
+        .setContainerInfo(containerInfo)
+        .setContainerReplicas(containerReplicas)
+        .build();
+
+    assertAndVerify(request, true, 3);
+  }
+
+  /**
+   * Handler should return false when key count is 0 but the container is not
+   * in CLOSED state.
+   */
+  @Test
+  public void testEmptyAndNonClosedECContainerReturnsFalse() {
+    ContainerInfo containerInfo = ReplicationTestUtil.createContainerInfo(
+        ecReplicationConfig, 1, CLOSING, 0L, 123L);
+
+    // though key count is 0, the container and its replicas are not CLOSED
+    Set<ContainerReplica> containerReplicas = ReplicationTestUtil
+        .createReplicas(containerInfo.containerID(),
+            ContainerReplicaProto.State.OPEN, 0L, 123L, 1, 2, 3, 4, 5);
+
+    ContainerCheckRequest request = new ContainerCheckRequest.Builder()
+        .setPendingOps(Collections.emptyList())
+        .setReport(new ReplicationManagerReport())
+        .setContainerInfo(containerInfo)
+        .setContainerReplicas(containerReplicas)
+        .build();
+
+    assertAndVerify(request, false, 0);
+  }
+
+  /**
+   * This test exists to verify that the definition of an empty container is
+   * 0 key count. Number of used bytes are not considered.
+   */
+  @Test
+  public void testNonEmptyRatisContainerReturnsFalse() {
+    ContainerInfo containerInfo = ReplicationTestUtil.createContainerInfo(
+        ratisReplicationConfig, 1, CLOSED, 5L, 123L);
+
+    // though container and its replicas are CLOSED, key count is not 0
+    Set<ContainerReplica> containerReplicas = ReplicationTestUtil
+        .createReplicas(containerInfo.containerID(),
+            ContainerReplicaProto.State.CLOSED, 5L, 123L, 0, 0, 0);
+
+    ContainerCheckRequest request = new ContainerCheckRequest.Builder()
+        .setPendingOps(Collections.emptyList())
+        .setReport(new ReplicationManagerReport())
+        .setContainerInfo(containerInfo)
+        .setContainerReplicas(containerReplicas)
+        .build();
+
+    assertAndVerify(request, false, 0);
+  }
+
+  @Test
+  public void testEmptyContainerWithNonZeroBytesUsedReturnsTrue() {
+    ContainerInfo containerInfo = ReplicationTestUtil.createContainerInfo(
+        ratisReplicationConfig, 1, CLOSED, 0L, 123L);
+    Set<ContainerReplica> containerReplicas = ReplicationTestUtil
+        .createReplicas(containerInfo.containerID(),
+            ContainerReplicaProto.State.CLOSED, 0L, 123L, 0, 0, 0);
+
+    ContainerCheckRequest request = new ContainerCheckRequest.Builder()
+        .setPendingOps(Collections.emptyList())
+        .setReport(new ReplicationManagerReport())
+        .setContainerInfo(containerInfo)
+        .setContainerReplicas(containerReplicas)
+        .build();
+
+    assertAndVerify(request, true, 3);
+  }
+
+  private void assertAndVerify(ContainerCheckRequest request,
+      boolean assertion, int times) {
+    Assertions.assertEquals(assertion, emptyContainerHandler.handle(request));
+    try {
+      Mockito.verify(replicationManager, Mockito.times(times))
+          .sendDeleteCommand(Mockito.any(ContainerInfo.class), Mockito.anyInt(),
+              Mockito.any(DatanodeDetails.class));
+
+      if (times > 0) {
+        Mockito.verify(containerManager, Mockito.times(1))
+            .updateContainerState(Mockito.any(ContainerID.class),
+                Mockito.any(HddsProtos.LifeCycleEvent.class));
+      }
+    } catch (Exception e) {
+      // meaningless; do nothing
+    }
+  }
+
+}


### PR DESCRIPTION
## What changes were proposed in this pull request?

Created a handler for empty containers. This mostly contains the same logic as the legacy RM for checking if a container is closed and empty, deleting its replicas, and moving it to DELETING state. Also introduced a new method in RM for sending a delete command to a DN and adding it to `ContainerReplicaPendingOps`. 

We should not add this handler to the chain of handlers in RM until the DELETING container handler has been added. This is because the DELETING container handler will take care of resending delete commands to replicas of a DELETING container.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-6893

## How was this patch tested?

`TestEmptyContainerHandler`