### PR TITLE
HDDS-6966. EC: Handle the placement policy satisfaction in HealthChecks handling

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/JavaUtils.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/JavaUtils.java
@@ -17,6 +17,12 @@
  */
 package org.apache.hadoop.hdds;
 
+import com.sun.tools.javac.util.Pair;
+
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
 /**
  * Various reusable utility methods related to Java.
  */
@@ -40,5 +46,13 @@ public final class JavaUtils {
    * Private constructor.
    */
   private JavaUtils() {
+  }
+
+  public static <K, V> Map<V, Set<K>> getReverseMapSet(
+          Map<K, Set<V>>  map) {
+    return map.entrySet().stream().flatMap(e -> e.getValue().stream()
+            .map(v -> Pair.of(v, e.getKey())))
+            .collect(Collectors.groupingBy(p -> p.fst,
+                    Collectors.mapping(r -> r.snd, Collectors.toSet())));
   }
 }

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/PlacementPolicy.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/PlacementPolicy.java
@@ -27,7 +27,7 @@ import java.util.List;
  * A PlacementPolicy support choosing datanodes to build
  * pipelines or containers with specified constraints.
  */
-public interface PlacementPolicy {
+public interface PlacementPolicy<G> {
 
   default List<DatanodeDetails> chooseDatanodes(
           List<DatanodeDetails> excludedNodes,
@@ -65,4 +65,6 @@ public interface PlacementPolicy {
    */
   ContainerPlacementStatus validateContainerPlacement(
       List<DatanodeDetails> dns, int replicas);
+
+  G getPlacementGroup(DatanodeDetails dn);
 }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/SCMCommonPlacementPolicy.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/SCMCommonPlacementPolicy.java
@@ -33,6 +33,7 @@ import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolPro
 import org.apache.hadoop.hdds.scm.container.placement.algorithms.ContainerPlacementStatusDefault;
 import org.apache.hadoop.hdds.scm.exceptions.SCMException;
 import org.apache.hadoop.hdds.scm.net.NetworkTopology;
+import org.apache.hadoop.hdds.scm.net.Node;
 import org.apache.hadoop.hdds.scm.node.DatanodeInfo;
 import org.apache.hadoop.hdds.scm.node.NodeManager;
 import org.apache.hadoop.hdds.scm.node.NodeStatus;
@@ -46,7 +47,8 @@ import org.slf4j.LoggerFactory;
  * for all basic placement policies, acts as the repository of helper
  * functions which are common to placement policies.
  */
-public abstract class SCMCommonPlacementPolicy implements PlacementPolicy {
+public abstract class SCMCommonPlacementPolicy
+        implements PlacementPolicy<Node> {
   @VisibleForTesting
   static final Logger LOG =
       LoggerFactory.getLogger(SCMCommonPlacementPolicy.class);
@@ -425,5 +427,10 @@ public abstract class SCMCommonPlacementPolicy implements PlacementPolicy {
       }
     }
     return false;
+  }
+
+  @Override
+  public Node getPlacementGroup(DatanodeDetails dn) {
+    return nodeManager.getClusterNetworkTopologyMap().getAncestor(dn, 1);
   }
 }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/placement/algorithms/SCMContainerPlacementRandom.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/placement/algorithms/SCMContainerPlacementRandom.java
@@ -23,6 +23,7 @@ import org.apache.hadoop.hdds.scm.PlacementPolicy;
 import org.apache.hadoop.hdds.scm.SCMCommonPlacementPolicy;
 import org.apache.hadoop.hdds.scm.exceptions.SCMException;
 import org.apache.hadoop.hdds.scm.net.NetworkTopology;
+import org.apache.hadoop.hdds.scm.net.Node;
 import org.apache.hadoop.hdds.scm.node.NodeManager;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
 import org.slf4j.Logger;
@@ -40,7 +41,7 @@ import java.util.List;
  * can be practically used.
  */
 public final class SCMContainerPlacementRandom extends SCMCommonPlacementPolicy
-    implements PlacementPolicy {
+    implements PlacementPolicy<Node> {
   @VisibleForTesting
   public static final Logger LOG =
       LoggerFactory.getLogger(SCMContainerPlacementRandom.class);

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ContainerHealthResult.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ContainerHealthResult.java
@@ -35,8 +35,7 @@ public class ContainerHealthResult {
     HEALTHY,
     UNHEALTHY,
     UNDER_REPLICATED,
-    OVER_REPLICATED,
-    UNHEALTHY_PLACEMENT
+    OVER_REPLICATED
   }
 
   private final ContainerInfo containerInfo;

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ContainerHealthResult.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ContainerHealthResult.java
@@ -16,6 +16,7 @@
  */
 package org.apache.hadoop.hdds.scm.container.replication;
 
+import org.apache.hadoop.hdds.scm.ContainerPlacementStatus;
 import org.apache.hadoop.hdds.scm.container.ContainerInfo;
 import org.apache.hadoop.ozone.protocol.commands.SCMCommand;
 
@@ -34,7 +35,8 @@ public class ContainerHealthResult {
     HEALTHY,
     UNHEALTHY,
     UNDER_REPLICATED,
-    OVER_REPLICATED
+    OVER_REPLICATED,
+    UNHEALTHY_PLACEMENT
   }
 
   private final ContainerInfo containerInfo;
@@ -112,14 +114,18 @@ public class ContainerHealthResult {
     private final boolean unrecoverable;
     private int requeueCount = 0;
 
+    private final ContainerPlacementStatus placementStatus;
+
     public UnderReplicatedHealthResult(ContainerInfo containerInfo,
         int remainingRedundancy, boolean dueToDecommission,
-        boolean replicatedOkWithPending, boolean unrecoverable) {
+        boolean replicatedOkWithPending, boolean unrecoverable,
+        ContainerPlacementStatus placementStatus) {
       super(containerInfo, HealthState.UNDER_REPLICATED);
       this.remainingRedundancy = remainingRedundancy;
       this.dueToDecommission = dueToDecommission;
       this.sufficientlyReplicatedAfterPending = replicatedOkWithPending;
       this.unrecoverable = unrecoverable;
+      this.placementStatus = placementStatus;
     }
 
     /**
@@ -266,6 +272,9 @@ public class ContainerHealthResult {
     public boolean isUnrecoverable() {
       return unrecoverable;
     }
+    public ContainerPlacementStatus getPlacementStatus() {
+      return placementStatus;
+    }
   }
 
   /**
@@ -307,5 +316,7 @@ public class ContainerHealthResult {
     public boolean isSufficientlyReplicatedAfterPending() {
       return sufficientlyReplicatedAfterPending;
     }
+
+
   }
 }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ContainerHealthResult.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ContainerHealthResult.java
@@ -130,7 +130,7 @@ public class ContainerHealthResult {
      * Pass true to indicate the container is mis-replicated - ie it does not
      * meet the placement policy.
      * @param isMisRep True if the container is mis-replicated, false if not.
-     * @param misreplicationCount
+     * @param misrepCount
      * @return this object to allow calls to be chained
      */
     public UnderReplicatedHealthResult setMisreplication(
@@ -145,7 +145,7 @@ public class ContainerHealthResult {
      * pending replicas scheduled for create or delete.
      * @param isMisRep True if the container is mis-replicated considering
      *                 pending replicas, or false if not.
-     * @param misreplicationCount Misreplication Count after pending replicas
+     * @param misrepCount Misreplication Count after pending replicas
      * @return this object to allow calls to be chained
      */
     public UnderReplicatedHealthResult setMisReplicationAfterPending(

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ContainerHealthResult.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ContainerHealthResult.java
@@ -16,7 +16,6 @@
  */
 package org.apache.hadoop.hdds.scm.container.replication;
 
-import org.apache.hadoop.hdds.scm.ContainerPlacementStatus;
 import org.apache.hadoop.hdds.scm.container.ContainerInfo;
 import org.apache.hadoop.ozone.protocol.commands.SCMCommand;
 
@@ -109,33 +108,35 @@ public class ContainerHealthResult {
     private final boolean sufficientlyReplicatedAfterPending;
     private boolean dueToMisReplication = false;
     private boolean isMisReplicated = false;
+
+    private int misreplicationCount = 0;
     private boolean isMisReplicatedAfterPending = false;
+
+    private int misreplicationCountAfterPending = 0;
     private final boolean unrecoverable;
     private int requeueCount = 0;
 
-    private final ContainerPlacementStatus placementStatus;
-
     public UnderReplicatedHealthResult(ContainerInfo containerInfo,
         int remainingRedundancy, boolean dueToDecommission,
-        boolean replicatedOkWithPending, boolean unrecoverable,
-        ContainerPlacementStatus placementStatus) {
+        boolean replicatedOkWithPending, boolean unrecoverable) {
       super(containerInfo, HealthState.UNDER_REPLICATED);
       this.remainingRedundancy = remainingRedundancy;
       this.dueToDecommission = dueToDecommission;
       this.sufficientlyReplicatedAfterPending = replicatedOkWithPending;
       this.unrecoverable = unrecoverable;
-      this.placementStatus = placementStatus;
     }
 
     /**
      * Pass true to indicate the container is mis-replicated - ie it does not
      * meet the placement policy.
      * @param isMisRep True if the container is mis-replicated, false if not.
+     * @param misreplicationCount
      * @return this object to allow calls to be chained
      */
-    public UnderReplicatedHealthResult
-        setMisReplicated(boolean isMisRep) {
+    public UnderReplicatedHealthResult setMisreplication(
+            boolean isMisRep, int misrepCount) {
       this.isMisReplicated = isMisRep;
+      this.misreplicationCount = misrepCount;
       return this;
     }
 
@@ -144,11 +145,13 @@ public class ContainerHealthResult {
      * pending replicas scheduled for create or delete.
      * @param isMisRep True if the container is mis-replicated considering
      *                 pending replicas, or false if not.
+     * @param misreplicationCount Misreplication Count after pending replicas
      * @return this object to allow calls to be chained
      */
-    public UnderReplicatedHealthResult
-        setMisReplicatedAfterPending(boolean isMisRep) {
+    public UnderReplicatedHealthResult setMisReplicationAfterPending(
+            boolean isMisRep, int misrepCount) {
       this.isMisReplicatedAfterPending = isMisRep;
+      this.misreplicationCountAfterPending = misrepCount;
       return this;
     }
 
@@ -271,8 +274,12 @@ public class ContainerHealthResult {
     public boolean isUnrecoverable() {
       return unrecoverable;
     }
-    public ContainerPlacementStatus getPlacementStatus() {
-      return placementStatus;
+    public int getMisreplicationCount() {
+      return misreplicationCount;
+    }
+
+    public int getMisreplicationCountAfterPending() {
+      return misreplicationCountAfterPending;
     }
   }
 

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ECPlacementManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ECPlacementManager.java
@@ -69,7 +69,7 @@ public class ECPlacementManager<G> {
     for (ContainerReplica replica : replicaSources) {
       G placementGroup = placementPolicy.getPlacementGroup(
               replica.getDatanodeDetails());
-      if (placementGroupReplicaIndexMap.containsKey(placementGroup)) {
+      if (!placementGroupReplicaIndexMap.containsKey(placementGroup)) {
         placementGroupReplicaIndexMap.put(placementGroup, new HashSet<>());
       }
       placementGroupReplicaIndexMap.get(placementGroup)

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ECPlacementManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ECPlacementManager.java
@@ -88,9 +88,9 @@ public class ECPlacementManager<G> {
   public List<Integer> getMisreplicatedIndexes(
           Map<G, Set<Integer>> placementGroupReplicaIndexMap,
           Set<Integer> excludedIndexes) {
-    for (G placementGroup : placementGroupReplicaIndexMap.keySet()) {
-      placementGroupReplicaIndexMap.get(placementGroup)
-              .removeAll(excludedIndexes);
+    for (Set<Integer> placementGroupIndexes :
+            placementGroupReplicaIndexMap.values()) {
+      placementGroupIndexes.removeAll(excludedIndexes);
     }
     Map<Integer, Set<G>> replicaIndexPlacementGroupMap =
             getReverseMapSet(placementGroupReplicaIndexMap);

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ECPlacementManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ECPlacementManager.java
@@ -1,0 +1,139 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.hdds.scm.container.replication;
+
+import org.apache.hadoop.hdds.scm.PlacementPolicy;
+import org.apache.hadoop.hdds.scm.container.ContainerReplica;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.ConcurrentSkipListSet;
+
+import static org.apache.hadoop.hdds.JavaUtils.getReverseMapSet;
+
+/**
+ * Class to handle placement of Replicas.
+ * @param <G> Placement Group
+ */
+public class ECPlacementManager<G> {
+
+  private PlacementPolicy<G> placementPolicy;
+  public ECPlacementManager(PlacementPolicy<G> placementPolicy) {
+    this.placementPolicy = placementPolicy;
+  }
+
+  private void removeReplicaIndex(int replicaIndex,
+          Map<G, Set<Integer>> placementGroupReplicaIndexMap,
+          Map<Integer, Set<G>> replicaIndexPlacementGroupMap,
+          ConcurrentSkipListSet<G> placementGroupSet) {
+    for (G placementGroup : replicaIndexPlacementGroupMap.get(replicaIndex)) {
+      placementGroupSet.remove(placementGroup);
+      placementGroupReplicaIndexMap.get(placementGroup).remove(replicaIndex);
+      placementGroupSet.add(placementGroup);
+    }
+  }
+
+  /**
+   * HDDS-6966: Getting the placement group for each of the replica
+   * (Rack for SCMCommonPlacementPolicy).
+   *
+   * @param replicaSources
+   * @return Placement group mapping to the set of replica indexes it holds
+   */
+  public Map<G, Set<Integer>> getPlacementGroupReplicaIndexMap(
+          List<ContainerReplica> replicaSources) {
+    Map<G, Set<Integer>> placementGroupReplicaIndexMap = new HashMap<>();
+    for (ContainerReplica replica : replicaSources) {
+      G placementGroup = placementPolicy.getPlacementGroup(
+              replica.getDatanodeDetails());
+      if (placementGroupReplicaIndexMap.containsKey(placementGroup)) {
+        placementGroupReplicaIndexMap.put(placementGroup, new HashSet<>());
+      }
+      placementGroupReplicaIndexMap.get(placementGroup)
+              .add(replica.getReplicaIndex());
+    }
+    return placementGroupReplicaIndexMap;
+  }
+
+  /**
+   * Get Misreplicated Replica Indexes in sorted order based on the replica
+   * index's spread across different placement group.
+   * @param placementGroupReplicaIndexMap
+   * @param excludedIndexes
+   * @return List of Misreplicated Indexes
+   */
+  public List<Integer> getMisreplicatedIndexes(
+          Map<G, Set<Integer>> placementGroupReplicaIndexMap,
+          Set<Integer> excludedIndexes) {
+    for (G placementGroup : placementGroupReplicaIndexMap.keySet()) {
+      placementGroupReplicaIndexMap.get(placementGroup)
+              .removeAll(excludedIndexes);
+    }
+    Map<Integer, Set<G>> replicaIndexPlacementGroupMap =
+            getReverseMapSet(placementGroupReplicaIndexMap);
+
+    ConcurrentSkipListSet<G> placementGroupSet = new ConcurrentSkipListSet<>(
+            Comparator.comparingInt(g -> placementGroupReplicaIndexMap.get(g)
+                    .size()).thenComparing(Object::toString));
+    placementGroupSet.addAll(placementGroupReplicaIndexMap.keySet());
+    ConcurrentSkipListSet<Integer> replicaSet = new ConcurrentSkipListSet<>(
+            Comparator.comparingInt(idx ->
+                            replicaIndexPlacementGroupMap
+                            .getOrDefault(idx, Collections.emptySet())
+                            .size()).thenComparingInt(idx -> (int) idx));
+    replicaSet.addAll(replicaIndexPlacementGroupMap.keySet());
+    List<Integer> misreplicatedIndexes = new ArrayList<>();
+
+    while (replicaSet.size() > 0) {
+      Optional<Integer> replicaIndex;
+      if (placementGroupReplicaIndexMap.get(placementGroupSet.first())
+              .size() <= 1) {
+        G placementGroup = placementGroupSet.pollFirst();
+        replicaIndex = placementGroupReplicaIndexMap
+                .get(placementGroup).stream().findFirst();
+        replicaIndex.ifPresent(replicaSet::remove);
+      } else {
+        replicaIndex = Optional.ofNullable(replicaSet.pollFirst());
+        misreplicatedIndexes.add(replicaIndex.get());
+      }
+
+      if (replicaIndex.isPresent()) {
+        int replicaIdx = replicaIndex.get();
+        this.removeReplicaIndex(replicaIdx, placementGroupReplicaIndexMap,
+                replicaIndexPlacementGroupMap, placementGroupSet);
+      }
+    }
+    return misreplicatedIndexes;
+  }
+
+  public List<Integer> getMisreplicatedIndexes(
+          List<ContainerReplica> replicaSources,
+          Set<Integer> excludedIndexes) {
+    return this.getMisreplicatedIndexes(
+            this.getPlacementGroupReplicaIndexMap(replicaSources),
+            excludedIndexes);
+  }
+}

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ECUnderReplicationHandler.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ECUnderReplicationHandler.java
@@ -411,8 +411,7 @@ public class ECUnderReplicationHandler<G>
           ContainerHealthResult.UnderReplicatedHealthResult
                   containerHealthResult)
           throws IOException {
-    if (containerHealthResult.isSufficientlyReplicatedAfterPending() &&
-            containerHealthResult.getMisreplicationCountAfterPending()
+    if (containerHealthResult.getMisreplicationCountAfterPending()
                     <= excludedIndexes.size()) {
       return Collections.emptyMap();
     }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ReplicationManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ReplicationManager.java
@@ -196,9 +196,10 @@ public class ReplicationManager implements SCMService {
         TimeUnit.MILLISECONDS);
     this.containerReplicaPendingOps = replicaPendingOps;
     this.legacyReplicationManager = legacyReplicationManager;
-    this.ecReplicationCheckHandler = new ECReplicationCheckHandler();
+    this.ecReplicationCheckHandler = new ECReplicationCheckHandler(
+        containerPlacement);
     this.ratisReplicationCheckHandler =
-        new RatisReplicationCheckHandler(containerPlacement);
+            new RatisReplicationCheckHandler(containerPlacement);
     this.nodeManager = nodeManager;
     this.replicationQueue = new ReplicationQueue();
     this.maintenanceRedundancy = rmConf.maintenanceRemainingRedundancy;

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/health/ECReplicationCheckHandler.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/health/ECReplicationCheckHandler.java
@@ -138,8 +138,6 @@ public class ECReplicationCheckHandler extends AbstractCheck {
   public ContainerHealthResult checkHealth(ContainerCheckRequest request) {
     ContainerInfo container = request.getContainerInfo();
     Set<ContainerReplica> replicas = request.getContainerReplicas();
-    List<DatanodeDetails> dns = replicas.stream()
-        .map(ContainerReplica::getDatanodeDetails).collect(Collectors.toList());
     int totalNumberOfNodesRequired = container.getReplicationConfig()
             .getRequiredNodes();
     List<ContainerReplicaOp> replicaPendingOps = request.getPendingOps();

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/health/RatisReplicationCheckHandler.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/health/RatisReplicationCheckHandler.java
@@ -155,10 +155,12 @@ public class RatisReplicationCheckHandler extends AbstractCheck {
               && replicas.size() - pendingDelete >= requiredNodes,
           replicaCount.isSufficientlyReplicated(true),
           replicaCount.isUnrecoverable());
-      result.setMisReplicated(!isPolicySatisfied)
-          .setMisReplicatedAfterPending(
-              !placementStatusWithPending.isPolicySatisfied())
-          .setDueToMisReplication(
+      result.setMisreplication(!isPolicySatisfied,
+              placementStatus.misReplicationCount())
+            .setMisReplicationAfterPending(
+                    !placementStatusWithPending.isPolicySatisfied(),
+                    placementStatusWithPending.misReplicationCount())
+            .setDueToMisReplication(
               !isPolicySatisfied && replicaCount.isSufficientlyReplicated());
       return result;
     }

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/MockNodeManager.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/MockNodeManager.java
@@ -127,6 +127,11 @@ public class MockNodeManager implements NodeManager {
     this.clusterMap = new NetworkTopologyImpl(new OzoneConfiguration());
   }
 
+  public void addNode(DatanodeDetails dd, int idx) {
+    register(dd, null, null);
+    populateNodeMetric(dd, idx);
+  }
+
   public MockNodeManager(NetworkTopologyImpl clusterMap,
                          List<DatanodeDetails> nodes,
                          boolean initializeFakeNodes, int nodeCount) {
@@ -134,15 +139,13 @@ public class MockNodeManager implements NodeManager {
     if (!nodes.isEmpty()) {
       for (int x = 0; x < nodes.size(); x++) {
         DatanodeDetails node = nodes.get(x);
-        register(node, null, null);
-        populateNodeMetric(node, x);
+        addNode(node, x);
       }
     }
     if (initializeFakeNodes) {
       for (int x = 0; x < nodeCount; x++) {
         DatanodeDetails dd = MockDatanodeDetails.randomDatanodeDetails();
-        register(dd, null, null);
-        populateNodeMetric(dd, x);
+        addNode(dd, x);
       }
     }
     safemode = false;

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/placement/algorithms/TestContainerPlacementFactory.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/placement/algorithms/TestContainerPlacementFactory.java
@@ -34,6 +34,7 @@ import org.apache.hadoop.hdds.scm.HddsTestUtils;
 import org.apache.hadoop.hdds.scm.exceptions.SCMException;
 import org.apache.hadoop.hdds.scm.net.NetworkTopology;
 import org.apache.hadoop.hdds.scm.net.NetworkTopologyImpl;
+import org.apache.hadoop.hdds.scm.net.Node;
 import org.apache.hadoop.hdds.scm.net.NodeSchema;
 import org.apache.hadoop.hdds.scm.net.NodeSchemaManager;
 import org.apache.hadoop.hdds.scm.node.DatanodeInfo;
@@ -176,7 +177,7 @@ public class TestContainerPlacementFactory {
   /**
    * A dummy container placement implementation for test.
    */
-  public static class DummyImpl implements PlacementPolicy {
+  public static class DummyImpl implements PlacementPolicy<Node> {
     @Override
     public List<DatanodeDetails> chooseDatanodes(
         List<DatanodeDetails> usedNodes,
@@ -190,6 +191,11 @@ public class TestContainerPlacementFactory {
     public ContainerPlacementStatus
         validateContainerPlacement(List<DatanodeDetails> dns, int replicas) {
       return new ContainerPlacementStatusDefault(1, 1, 1);
+    }
+
+    @Override
+    public Node getPlacementGroup(DatanodeDetails dn) {
+      return dn;
     }
   }
 

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestECOverReplicationHandler.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestECOverReplicationHandler.java
@@ -82,7 +82,7 @@ public class TestECOverReplicationHandler {
     NodeSchema[] schemas =
         new NodeSchema[] {ROOT_SCHEMA, RACK_SCHEMA, LEAF_SCHEMA};
     NodeSchemaManager.getInstance().init(schemas, true);
-    replicationCheck = new ECReplicationCheckHandler();
+    replicationCheck = new ECReplicationCheckHandler(policy);
   }
 
   @Test

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestECPlacementManager.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestECPlacementManager.java
@@ -1,0 +1,69 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.hdds.scm.container.replication;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Sets;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Test for ECPlacementManager Class.
+ */
+public class TestECPlacementManager {
+  @Test
+  public void testGetMisreplicationIndex() {
+    Map<String, Set<Integer>> map = new HashMap<String, Set<Integer>>() {{
+        put("r1", Sets.newHashSet(1, 2, 3));
+        put("r2", Sets.newHashSet(3, 4));
+        put("r3", Sets.newHashSet(4, 5));
+        put("r4", Sets.newHashSet(5));
+      }};
+    testMisreplication(map, ImmutableList.of(1));
+    map = new HashMap<String, Set<Integer>>() {{
+        put("r1", Sets.newHashSet(1, 2));
+        put("r2", Sets.newHashSet(3, 5));
+        put("r3", Sets.newHashSet(4, 3));
+        put("r4", Sets.newHashSet(4, 5));
+        put("r5", Sets.newHashSet(4, 1));
+      }};
+    testMisreplication(map, ImmutableList.of(2));
+    map = new HashMap<String, Set<Integer>>() {{
+        put("r1", Sets.newHashSet(1, 2));
+        put("r2", Sets.newHashSet(3, 5));
+        put("r3", Sets.newHashSet(4, 1));
+      }};
+    testMisreplication(map, ImmutableList.of(2, 3));
+  }
+
+  private static void testMisreplication(Map<String, Set<Integer>> map,
+                                         List<Integer> expectedMisreplication) {
+    ECPlacementManager<String> ecPlacementManager =
+            new ECPlacementManager<>(null);
+    List<Integer> misreplicatedIndexes = ecPlacementManager
+            .getMisreplicatedIndexes(map, Collections.emptySet());
+    Assertions.assertEquals(misreplicatedIndexes, expectedMisreplication);
+  }
+}

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestECUnderReplicationHandler.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestECUnderReplicationHandler.java
@@ -99,8 +99,8 @@ public class TestECUnderReplicationHandler {
 
   @Test
   public void testUnderReplicationWithMissingParityIndex5() throws IOException {
-    Set<ContainerReplica> availableReplicas = ReplicationTestUtil
-        .createReplicas(Pair.of(IN_SERVICE, 1), Pair.of(IN_SERVICE, 2),
+    Set<ContainerReplica> availableReplicas = createReplicas(
+            Pair.of(IN_SERVICE, 1), Pair.of(IN_SERVICE, 2),
             Pair.of(IN_SERVICE, 3), Pair.of(IN_SERVICE, 4));
     testUnderReplicationWithMissingIndexes(ImmutableList.of(5),
         availableReplicas, 0, 0, policy);
@@ -108,8 +108,8 @@ public class TestECUnderReplicationHandler {
 
   @Test
   public void testUnderReplicationWithMissingIndex34() throws IOException {
-    Set<ContainerReplica> availableReplicas = ReplicationTestUtil
-        .createReplicas(Pair.of(IN_SERVICE, 1), Pair.of(IN_SERVICE, 2),
+    Set<ContainerReplica> availableReplicas = createReplicas(
+            Pair.of(IN_SERVICE, 1), Pair.of(IN_SERVICE, 2),
             Pair.of(IN_SERVICE, 5));
     testUnderReplicationWithMissingIndexes(ImmutableList.of(3, 4),
         availableReplicas, 0, 0, policy);
@@ -117,8 +117,8 @@ public class TestECUnderReplicationHandler {
 
   @Test
   public void testUnderReplicationWithMissingIndex2345() throws IOException {
-    Set<ContainerReplica> availableReplicas =
-        ReplicationTestUtil.createReplicas(Pair.of(IN_SERVICE, 1));
+    Set<ContainerReplica> availableReplicas = createReplicas(
+            Pair.of(IN_SERVICE, 1));
     testUnderReplicationWithMissingIndexes(ImmutableList.of(2, 3, 4, 5),
         availableReplicas, 0, 0, policy);
   }
@@ -132,8 +132,8 @@ public class TestECUnderReplicationHandler {
 
   @Test
   public void testUnderReplicationWithDecomIndex1() throws IOException {
-    Set<ContainerReplica> availableReplicas = ReplicationTestUtil
-        .createReplicas(Pair.of(DECOMMISSIONING, 1), Pair.of(IN_SERVICE, 2),
+    Set<ContainerReplica> availableReplicas = createReplicas(
+            Pair.of(DECOMMISSIONING, 1), Pair.of(IN_SERVICE, 2),
             Pair.of(IN_SERVICE, 3), Pair.of(IN_SERVICE, 4),
             Pair.of(IN_SERVICE, 5));
     Map<DatanodeDetails, SCMCommand<?>> cmds =
@@ -149,10 +149,10 @@ public class TestECUnderReplicationHandler {
 
   @Test
   public void testUnderReplicationWithDecomIndex12() throws IOException {
-    Set<ContainerReplica> availableReplicas = ReplicationTestUtil
-        .createReplicas(Pair.of(DECOMMISSIONING, 1),
-            Pair.of(DECOMMISSIONING, 2), Pair.of(IN_SERVICE, 3),
-            Pair.of(IN_SERVICE, 4), Pair.of(IN_SERVICE, 5));
+    Set<ContainerReplica> availableReplicas = createReplicas(
+            Pair.of(DECOMMISSIONING, 1), Pair.of(DECOMMISSIONING, 2),
+            Pair.of(IN_SERVICE, 3), Pair.of(IN_SERVICE, 4),
+            Pair.of(IN_SERVICE, 5));
     testUnderReplicationWithMissingIndexes(Lists.emptyList(), availableReplicas,
         2, 0, policy);
   }
@@ -160,20 +160,19 @@ public class TestECUnderReplicationHandler {
   @Test
   public void testUnderReplicationWithMixedDecomAndMissingIndexes()
       throws IOException {
-    Set<ContainerReplica> availableReplicas = ReplicationTestUtil
-        .createReplicas(Pair.of(DECOMMISSIONING, 1),
-            Pair.of(DECOMMISSIONING, 2), Pair.of(IN_SERVICE, 3),
-            Pair.of(IN_SERVICE, 4));
+    Set<ContainerReplica> availableReplicas = createReplicas(
+            Pair.of(DECOMMISSIONING, 1), Pair.of(DECOMMISSIONING, 2),
+            Pair.of(IN_SERVICE, 3), Pair.of(IN_SERVICE, 4));
     testUnderReplicationWithMissingIndexes(ImmutableList.of(5),
         availableReplicas, 2, 0, policy);
   }
 
   @Test
   public void testUnderReplicationWithMaintenanceIndex12() throws IOException {
-    Set<ContainerReplica> availableReplicas = ReplicationTestUtil
-        .createReplicas(Pair.of(IN_MAINTENANCE, 1),
-            Pair.of(IN_MAINTENANCE, 2), Pair.of(IN_SERVICE, 3),
-            Pair.of(IN_SERVICE, 4), Pair.of(IN_SERVICE, 5));
+    Set<ContainerReplica> availableReplicas = createReplicas(
+            Pair.of(IN_MAINTENANCE, 1), Pair.of(IN_MAINTENANCE, 2),
+            Pair.of(IN_SERVICE, 3), Pair.of(IN_SERVICE, 4),
+            Pair.of(IN_SERVICE, 5));
     testUnderReplicationWithMissingIndexes(Lists.emptyList(), availableReplicas,
         0, 2, policy);
   }
@@ -181,10 +180,9 @@ public class TestECUnderReplicationHandler {
   @Test
   public void testUnderReplicationWithMaintenanceAndMissingIndexes()
       throws IOException {
-    Set<ContainerReplica> availableReplicas = ReplicationTestUtil
-        .createReplicas(Pair.of(IN_MAINTENANCE, 1),
-            Pair.of(IN_MAINTENANCE, 2), Pair.of(IN_SERVICE, 3),
-            Pair.of(IN_SERVICE, 4));
+    Set<ContainerReplica> availableReplicas = createReplicas(
+            Pair.of(IN_MAINTENANCE, 1), Pair.of(IN_MAINTENANCE, 2),
+            Pair.of(IN_SERVICE, 3), Pair.of(IN_SERVICE, 4));
     testUnderReplicationWithMissingIndexes(ImmutableList.of(5),
         availableReplicas, 0, 2, policy);
   }
@@ -192,10 +190,9 @@ public class TestECUnderReplicationHandler {
   @Test
   public void testUnderReplicationWithMissingDecomAndMaintenanceIndexes()
       throws IOException {
-    Set<ContainerReplica> availableReplicas = ReplicationTestUtil
-        .createReplicas(Pair.of(IN_MAINTENANCE, 1),
-            Pair.of(IN_MAINTENANCE, 2), Pair.of(DECOMMISSIONING, 3),
-            Pair.of(IN_SERVICE, 4));
+    Set<ContainerReplica> availableReplicas = createReplicas(
+            Pair.of(IN_MAINTENANCE, 1), Pair.of(IN_MAINTENANCE, 2),
+            Pair.of(DECOMMISSIONING, 3), Pair.of(IN_SERVICE, 4));
     testUnderReplicationWithMissingIndexes(ImmutableList.of(5),
         availableReplicas, 1, 2, policy);
   }
@@ -203,10 +200,9 @@ public class TestECUnderReplicationHandler {
   @Test
   public void testUnderReplicationWithInvalidPlacement()
           throws IOException {
-    Set<ContainerReplica> availableReplicas = ReplicationTestUtil
-            .createReplicas(Pair.of(DECOMMISSIONING, 1),
-                    Pair.of(DECOMMISSIONING, 2), Pair.of(IN_SERVICE, 3),
-                    Pair.of(IN_SERVICE, 4));
+    Set<ContainerReplica> availableReplicas = createReplicas(
+            Pair.of(DECOMMISSIONING, 1), Pair.of(DECOMMISSIONING, 2),
+            Pair.of(IN_SERVICE, 3), Pair.of(IN_SERVICE, 4));
     PlacementPolicy mockedPolicy = Mockito.spy(policy);
     ContainerPlacementStatus mockedContainerPlacementStatus =
             Mockito.mock(ContainerPlacementStatus.class);
@@ -233,10 +229,9 @@ public class TestECUnderReplicationHandler {
   @ValueSource(ints = {0, 1, 2, 3, 4, 5, 6})
   public void testUnderReplicationUnhealthyPlacementCheck(int misreplicationCnt)
           throws IOException {
-    Set<ContainerReplica> availableReplicas = ReplicationTestUtil
-            .createReplicas(Pair.of(IN_SERVICE, 1),
-                    Pair.of(IN_SERVICE, 2), Pair.of(IN_SERVICE, 3),
-                    Pair.of(IN_SERVICE, 4));
+    Set<ContainerReplica> availableReplicas = createReplicas(
+            Pair.of(IN_SERVICE, 1), Pair.of(IN_SERVICE, 2),
+            Pair.of(IN_SERVICE, 3), Pair.of(IN_SERVICE, 4));
     PlacementPolicy mockedPolicy = Mockito.spy(policy);
     ContainerPlacementStatus mockedContainerPlacementStatus =
             Mockito.mock(ContainerPlacementStatus.class);
@@ -265,17 +260,16 @@ public class TestECUnderReplicationHandler {
                     mockedPolicy, conf, nodeManager);
     testUnderReplicationWithMissingIndexes(Collections.emptyList(),
             availableReplicas, 0, 0,
-            Math.min(4, misreplicationCnt), ecURH);
+            Math.min(3, misreplicationCnt), ecURH);
   }
 
   @Test
   public void testExceptionIfNoNodesFound() {
     PlacementPolicy noNodesPolicy = ReplicationTestUtil
         .getNoNodesTestPlacementPolicy(nodeManager, conf);
-    Set<ContainerReplica> availableReplicas = ReplicationTestUtil
-        .createReplicas(Pair.of(DECOMMISSIONING, 1),
-            Pair.of(DECOMMISSIONING, 2), Pair.of(IN_SERVICE, 3),
-            Pair.of(IN_SERVICE, 4));
+    Set<ContainerReplica> availableReplicas = createReplicas(
+            Pair.of(DECOMMISSIONING, 1), Pair.of(DECOMMISSIONING, 2),
+            Pair.of(IN_SERVICE, 3), Pair.of(IN_SERVICE, 4));
     assertThrows(SCMException.class, () ->
         testUnderReplicationWithMissingIndexes(ImmutableList.of(5),
             availableReplicas, 2, 0, noNodesPolicy));
@@ -287,10 +281,9 @@ public class TestECUnderReplicationHandler {
     PlacementPolicy sameNodePolicy = ReplicationTestUtil
         .getSameNodeTestPlacementPolicy(nodeManager, conf, newDn);
     // Just have a missing index, this should return OK.
-    Set<ContainerReplica> availableReplicas = ReplicationTestUtil
-        .createReplicas(Pair.of(IN_SERVICE, 1),
-            Pair.of(IN_SERVICE, 2), Pair.of(IN_SERVICE, 3),
-            Pair.of(IN_SERVICE, 4));
+    Set<ContainerReplica> availableReplicas = createReplicas(
+            Pair.of(IN_SERVICE, 1), Pair.of(IN_SERVICE, 2),
+            Pair.of(IN_SERVICE, 3), Pair.of(IN_SERVICE, 4));
     // Passing zero for decommIndexes, as we don't expect the decom command to
     // get created due to the placement policy returning an already used node
     testUnderReplicationWithMissingIndexes(ImmutableList.of(5),
@@ -300,10 +293,9 @@ public class TestECUnderReplicationHandler {
     // placement policy should throw. It will have used up the node for
     // reconstruction, and hence no nodes will be found to fix the decommission
     // index.
-    Set<ContainerReplica> replicas = ReplicationTestUtil
-        .createReplicas(Pair.of(DECOMMISSIONING, 1),
-            Pair.of(IN_SERVICE, 2), Pair.of(IN_SERVICE, 3),
-            Pair.of(IN_SERVICE, 4));
+    Set<ContainerReplica> replicas = createReplicas(
+            Pair.of(DECOMMISSIONING, 1), Pair.of(IN_SERVICE, 2),
+            Pair.of(IN_SERVICE, 3), Pair.of(IN_SERVICE, 4));
     assertThrows(SCMException.class, () ->
         testUnderReplicationWithMissingIndexes(ImmutableList.of(5),
             replicas, 1, 0, sameNodePolicy));
@@ -311,8 +303,8 @@ public class TestECUnderReplicationHandler {
 
   @Test
   public void testUnderAndOverReplication() throws IOException {
-    Set<ContainerReplica> availableReplicas = ReplicationTestUtil
-        .createReplicas(Pair.of(DECOMMISSIONING, 1), Pair.of(IN_SERVICE, 1),
+    Set<ContainerReplica> availableReplicas = createReplicas(
+            Pair.of(DECOMMISSIONING, 1), Pair.of(IN_SERVICE, 1),
             Pair.of(IN_MAINTENANCE, 1), Pair.of(IN_MAINTENANCE, 1),
             Pair.of(IN_SERVICE, 4), Pair.of(IN_SERVICE, 5));
     Map<DatanodeDetails, SCMCommand<?>> cmds =
@@ -387,5 +379,13 @@ public class TestECUnderReplicationHandler {
     Assertions.assertEquals(shouldReconstructCommandExist ? 1 : 0,
         reconstructCommand);
     return datanodeDetailsSCMCommandMap;
+  }
+
+  private Set<ContainerReplica> createReplicas(
+          Pair<HddsProtos.NodeOperationalState, Integer>... states) {
+    Set<ContainerReplica> replicas = ReplicationTestUtil.createReplicas(states);
+    replicas.stream().map(ContainerReplica::getDatanodeDetails)
+            .forEach(dn -> ((MockNodeManager)nodeManager).addNode(dn, 0));
+    return replicas;
   }
 }

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestECUnderReplicationHandler.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestECUnderReplicationHandler.java
@@ -248,15 +248,15 @@ public class TestECUnderReplicationHandler {
             Mockito.anyInt())).thenReturn(mockedContainerPlacementStatus);
     Mockito.when(mockedPolicy.validateContainerPlacement(Mockito.anyList(),
             Mockito.anyInt())).thenAnswer(invocationOnMock -> {
-      Set<DatanodeDetails> dns =
-              new HashSet<>(invocationOnMock.getArgument(0));
-      Assert.assertTrue(
-              availableReplicas.stream()
+              Set<DatanodeDetails> dns =
+                  new HashSet<>(invocationOnMock.getArgument(0));
+              Assert.assertTrue(
+                      availableReplicas.stream()
                       .map(ContainerReplica::getDatanodeDetails)
                       .filter(dn -> dn.getPersistedOpState() == IN_SERVICE)
                       .allMatch(dns::contains));
-      return mockedContainerPlacementStatus;
-    });
+              return mockedContainerPlacementStatus;
+            });
     ECReplicationCheckHandler checkHandler =
             new ECReplicationCheckHandler(mockedPolicy);
 

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestReplicationManager.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestReplicationManager.java
@@ -24,6 +24,7 @@ import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.protocol.MockDatanodeDetails;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.ContainerReplicaProto;
+import org.apache.hadoop.hdds.scm.ContainerPlacementStatus;
 import org.apache.hadoop.hdds.scm.PlacementPolicy;
 import org.apache.hadoop.hdds.scm.container.ContainerID;
 import org.apache.hadoop.hdds.scm.container.ContainerInfo;
@@ -101,7 +102,12 @@ public class TestReplicationManager {
 
     Mockito.when(containerManager.getContainers()).thenAnswer(
         invocation -> new ArrayList<>(containerInfoSet));
-
+    ContainerPlacementStatus containerPlacementStatus =
+            Mockito.mock(ContainerPlacementStatus.class);
+    Mockito.when(containerPlacementStatus.isPolicySatisfied())
+            .thenReturn(true);
+    Mockito.when(placementPolicy.validateContainerPlacement(Mockito.anyList(),
+            Mockito.anyInt())).thenReturn(containerPlacementStatus);
     replicationManager = new ReplicationManager(
         configuration,
         containerManager,

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestUnderReplicatedProcessor.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestUnderReplicatedProcessor.java
@@ -23,7 +23,9 @@ import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
 import org.apache.hadoop.hdds.protocol.MockDatanodeDetails;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
+import org.apache.hadoop.hdds.scm.ContainerPlacementStatus;
 import org.apache.hadoop.hdds.scm.container.ContainerInfo;
+import org.apache.hadoop.hdds.scm.container.placement.algorithms.ContainerPlacementStatusDefault;
 import org.apache.hadoop.hdds.scm.container.replication.ReplicationManager.ReplicationManagerConfiguration;
 import org.apache.hadoop.hdds.scm.events.SCMEvents;
 import org.apache.hadoop.hdds.server.events.EventPublisher;
@@ -79,9 +81,14 @@ public class TestUnderReplicatedProcessor {
   public void testEcReconstructionCommand() throws IOException {
     ContainerInfo container = ReplicationTestUtil
         .createContainer(HddsProtos.LifeCycleState.CLOSED, repConfig);
+    ContainerPlacementStatus placementStatus =
+            Mockito.mock(ContainerPlacementStatus.class);
+    Mockito.when(placementStatus.isPolicySatisfied()).thenReturn(true);
+
     Mockito.when(replicationManager.dequeueUnderReplicatedContainer())
         .thenReturn(new ContainerHealthResult
-                .UnderReplicatedHealthResult(container, 3, false, false, false),
+                .UnderReplicatedHealthResult(container, 3, false, false, false,
+                        placementStatus),
             (ContainerHealthResult.UnderReplicatedHealthResult) null);
     List<ReconstructECContainersCommand.DatanodeDetailsAndReplicaIndex>
         sourceNodes = new ArrayList<>();
@@ -125,9 +132,13 @@ public class TestUnderReplicatedProcessor {
   public void testEcReplicationCommand() throws IOException {
     ContainerInfo container = ReplicationTestUtil
         .createContainer(HddsProtos.LifeCycleState.CLOSED, repConfig);
+    ContainerPlacementStatus placementStatus =
+            Mockito.mock(ContainerPlacementStatus.class);
+    Mockito.when(placementStatus.isPolicySatisfied()).thenReturn(true);
     Mockito.when(replicationManager.dequeueUnderReplicatedContainer())
         .thenReturn(new ContainerHealthResult
-                .UnderReplicatedHealthResult(container, 3, true, false, false),
+                .UnderReplicatedHealthResult(container, 3, true, false, false,
+                        placementStatus),
             (ContainerHealthResult.UnderReplicatedHealthResult) null);
     List<DatanodeDetails> sourceDns = new ArrayList<>();
     sourceDns.add(MockDatanodeDetails.randomDatanodeDetails());
@@ -161,9 +172,13 @@ public class TestUnderReplicatedProcessor {
   public void testMessageRequeuedOnException() throws IOException {
     ContainerInfo container = ReplicationTestUtil
         .createContainer(HddsProtos.LifeCycleState.CLOSED, repConfig);
+    ContainerPlacementStatus placementStatus =
+            Mockito.mock(ContainerPlacementStatus.class);
+    Mockito.when(placementStatus.isPolicySatisfied()).thenReturn(true);
     Mockito.when(replicationManager.dequeueUnderReplicatedContainer())
         .thenReturn(new ContainerHealthResult
-                .UnderReplicatedHealthResult(container, 3, false, false, false),
+                .UnderReplicatedHealthResult(container, 3, false, false, false,
+                        placementStatus),
             (ContainerHealthResult.UnderReplicatedHealthResult) null);
 
     Mockito.when(replicationManager

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestUnderReplicatedProcessor.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestUnderReplicatedProcessor.java
@@ -25,7 +25,6 @@ import org.apache.hadoop.hdds.protocol.MockDatanodeDetails;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.hdds.scm.ContainerPlacementStatus;
 import org.apache.hadoop.hdds.scm.container.ContainerInfo;
-import org.apache.hadoop.hdds.scm.container.placement.algorithms.ContainerPlacementStatusDefault;
 import org.apache.hadoop.hdds.scm.container.replication.ReplicationManager.ReplicationManagerConfiguration;
 import org.apache.hadoop.hdds.scm.events.SCMEvents;
 import org.apache.hadoop.hdds.server.events.EventPublisher;

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestUnderReplicatedProcessor.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestUnderReplicatedProcessor.java
@@ -80,14 +80,9 @@ public class TestUnderReplicatedProcessor {
   public void testEcReconstructionCommand() throws IOException {
     ContainerInfo container = ReplicationTestUtil
         .createContainer(HddsProtos.LifeCycleState.CLOSED, repConfig);
-    ContainerPlacementStatus placementStatus =
-            Mockito.mock(ContainerPlacementStatus.class);
-    Mockito.when(placementStatus.isPolicySatisfied()).thenReturn(true);
-
     Mockito.when(replicationManager.dequeueUnderReplicatedContainer())
         .thenReturn(new ContainerHealthResult
-                .UnderReplicatedHealthResult(container, 3, false, false, false,
-                        placementStatus),
+                .UnderReplicatedHealthResult(container, 3, false, false, false),
             (ContainerHealthResult.UnderReplicatedHealthResult) null);
     List<ReconstructECContainersCommand.DatanodeDetailsAndReplicaIndex>
         sourceNodes = new ArrayList<>();
@@ -136,8 +131,7 @@ public class TestUnderReplicatedProcessor {
     Mockito.when(placementStatus.isPolicySatisfied()).thenReturn(true);
     Mockito.when(replicationManager.dequeueUnderReplicatedContainer())
         .thenReturn(new ContainerHealthResult
-                .UnderReplicatedHealthResult(container, 3, true, false, false,
-                        placementStatus),
+                .UnderReplicatedHealthResult(container, 3, true, false, false),
             (ContainerHealthResult.UnderReplicatedHealthResult) null);
     List<DatanodeDetails> sourceDns = new ArrayList<>();
     sourceDns.add(MockDatanodeDetails.randomDatanodeDetails());
@@ -176,8 +170,7 @@ public class TestUnderReplicatedProcessor {
     Mockito.when(placementStatus.isPolicySatisfied()).thenReturn(true);
     Mockito.when(replicationManager.dequeueUnderReplicatedContainer())
         .thenReturn(new ContainerHealthResult
-                .UnderReplicatedHealthResult(container, 3, false, false, false,
-                        placementStatus),
+                .UnderReplicatedHealthResult(container, 3, false, false, false),
             (ContainerHealthResult.UnderReplicatedHealthResult) null);
 
     Mockito.when(replicationManager

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/health/TestECReplicationCheckHandler.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/health/TestECReplicationCheckHandler.java
@@ -25,17 +25,19 @@ import org.apache.hadoop.hdds.scm.container.ContainerInfo;
 import org.apache.hadoop.hdds.scm.container.ContainerReplica;
 import org.apache.hadoop.hdds.scm.container.ReplicationManagerReport;
 import org.apache.hadoop.hdds.scm.container.placement.algorithms.ContainerPlacementStatusDefault;
-import org.apache.hadoop.hdds.scm.container.replication.*;
+import org.apache.hadoop.hdds.scm.container.replication.ContainerCheckRequest;
+import org.apache.hadoop.hdds.scm.container.replication.ContainerHealthResult;
 import org.apache.hadoop.hdds.scm.container.replication.ContainerHealthResult.OverReplicatedHealthResult;
 import org.apache.hadoop.hdds.scm.container.replication.ContainerHealthResult.UnderReplicatedHealthResult;
 import org.apache.hadoop.hdds.scm.container.replication.ContainerHealthResult.HealthState;
 
+import org.apache.hadoop.hdds.scm.container.replication.ContainerReplicaOp;
+import org.apache.hadoop.hdds.scm.container.replication.ReplicationQueue;
 import org.junit.Assert;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
-import org.mockito.Mock;
 import org.mockito.Mockito;
 
 import java.util.ArrayList;

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/fsck/TestContainerHealthTask.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/fsck/TestContainerHealthTask.java
@@ -343,7 +343,7 @@ public class TestContainerHealthTask extends AbstractReconSqlDBTest {
    * of a datanode via setMisRepWhenDnPresent. If a DN with that UUID is passed
    * to validateContainerPlacement, then it will return an invalid placement.
    */
-  private static class MockPlacementPolicy implements PlacementPolicy {
+  private static class MockPlacementPolicy implements PlacementPolicy<Integer> {
 
     private UUID misRepWhenDnPresent = null;
 
@@ -368,6 +368,11 @@ public class TestContainerHealthTask extends AbstractReconSqlDBTest {
       } else {
         return new ContainerPlacementStatusDefault(1, 1, 1);
       }
+    }
+
+    @Override
+    public Integer getPlacementGroup(DatanodeDetails dn) {
+      return 1;
     }
 
     private boolean isDnPresent(List<DatanodeDetails> dns) {


### PR DESCRIPTION
## What changes were proposed in this pull request?
Currently as part of basic reconstruction implementation, we relaxed the placement policy satisfaction checks in different places like HealthChecks, UnderReplication andOverReplication handling. This is the Jira to track and enable placement policy satisfaction checks.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-6966

## How was this patch tested?
Unit Tests