### PR TITLE
HDDS-7337. Replace set-output in Github Actions workflow

### DIFF
--- a/dev-support/ci/lib/_initialization.sh
+++ b/dev-support/ci/lib/_initialization.sh
@@ -129,7 +129,9 @@ function initialization::parameters_to_json() {
 
 # output parameter name and value - both to stdout and to be set by GitHub Actions
 function initialization::ga_output() {
-    echo "::set-output name=${1}::${2}"
+    if [[ -n "${GITHUB_OUTPUT=}" ]]; then
+        echo "${1}=${2}" >> "${GITHUB_OUTPUT}"
+    fi
     echo "${1}=${2}"
 }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

`set-output` has been deprecated by Github, to be replaced by redirection to `$GITHUB_OUTPUT` file.

https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

https://issues.apache.org/jira/browse/HDDS-7337

## How was this patch tested?

https://github.com/adoroszlai/hadoop-ozone/actions/runs/3254979226