### PR TITLE
HDDS-7338. Reduced number of OzoneVolume constructors

### DIFF
--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/rpc/RpcClient.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/rpc/RpcClient.java
@@ -522,12 +522,12 @@ public class RpcClient implements ClientProtocol {
         volume.getOwnerName(),
         volume.getQuotaInBytes(),
         volume.getQuotaInNamespace(),
-        volume.getUsedNamespace(),
         volume.getCreationTime(),
         volume.getModificationTime(),
         volume.getAcls(),
         volume.getMetadata(),
-        volume.getRefCount());
+        volume.getRefCount(),
+        volume.getUsedNamespace());
   }
 
   @Override
@@ -557,10 +557,12 @@ public class RpcClient implements ClientProtocol {
         volume.getOwnerName(),
         volume.getQuotaInBytes(),
         volume.getQuotaInNamespace(),
-        volume.getUsedNamespace(),
         volume.getCreationTime(),
         volume.getModificationTime(),
-        volume.getAcls()))
+        volume.getAcls(),
+        volume.getMetadata(),
+        volume.getRefCount(),
+        volume.getUsedNamespace()))
         .collect(Collectors.toList());
   }
 
@@ -579,11 +581,12 @@ public class RpcClient implements ClientProtocol {
         volume.getOwnerName(),
         volume.getQuotaInBytes(),
         volume.getQuotaInNamespace(),
-        volume.getUsedNamespace(),
         volume.getCreationTime(),
         volume.getModificationTime(),
         volume.getAcls(),
-        volume.getMetadata()))
+        volume.getMetadata(),
+        volume.getRefCount(),
+        volume.getUsedNamespace()))
         .collect(Collectors.toList());
   }
 

--- a/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/client/ObjectStoreStub.java
+++ b/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/client/ObjectStoreStub.java
@@ -68,7 +68,11 @@ public class ObjectStoreStub extends ObjectStore {
             volumeArgs.getQuotaInBytes(),
             volumeArgs.getQuotaInNamespace(),
             Time.now(),
-            volumeArgs.getAcls());
+            Time.now(),
+            volumeArgs.getAcls(),
+            volumeArgs.getMetadata(),
+            0,
+            0);
     volumes.put(volumeName, volume);
   }
 

--- a/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/client/OzoneVolumeStub.java
+++ b/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/client/OzoneVolumeStub.java
@@ -27,6 +27,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
+import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.protocol.StorageType;
 import org.apache.hadoop.ozone.OzoneAcl;
 import org.apache.hadoop.ozone.om.exceptions.OMException;
@@ -41,11 +42,14 @@ public class OzoneVolumeStub extends OzoneVolume {
 
   private ArrayList<OzoneAcl> aclList = new ArrayList<>();
 
+  @SuppressWarnings("parameternumber")
   public OzoneVolumeStub(String name, String admin, String owner,
       long quotaInBytes, long quotaInNamespace, long creationTime,
-      List<OzoneAcl> acls) {
-    super(name, admin, owner, quotaInBytes, quotaInNamespace, creationTime,
-        acls);
+      long modificationTime, List<OzoneAcl> acls,
+      Map<String, String> metadata, long refCount, long usedNamespace) {
+    super(new OzoneConfiguration(), null, name, admin, owner, quotaInBytes,
+            quotaInNamespace, creationTime, modificationTime, acls, metadata,
+            refCount, usedNamespace);
   }
 
   @Override

--- a/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/client/OzoneVolumeStub.java
+++ b/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/client/OzoneVolumeStub.java
@@ -30,8 +30,11 @@ import java.util.stream.Collectors;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.protocol.StorageType;
 import org.apache.hadoop.ozone.OzoneAcl;
+import org.apache.hadoop.ozone.client.protocol.ClientProtocol;
 import org.apache.hadoop.ozone.om.exceptions.OMException;
 import org.apache.hadoop.util.Time;
+
+import static org.mockito.Mockito.mock;
 
 /**
  * Ozone volume with in-memory state for testing.
@@ -47,9 +50,9 @@ public class OzoneVolumeStub extends OzoneVolume {
       long quotaInBytes, long quotaInNamespace, long creationTime,
       long modificationTime, List<OzoneAcl> acls,
       Map<String, String> metadata, long refCount, long usedNamespace) {
-    super(new OzoneConfiguration(), null, name, admin, owner, quotaInBytes,
-            quotaInNamespace, creationTime, modificationTime, acls, metadata,
-            refCount, usedNamespace);
+    super(new OzoneConfiguration(), mock(ClientProtocol.class), name, admin,
+            owner, quotaInBytes, quotaInNamespace, creationTime,
+            modificationTime, acls, metadata, refCount, usedNamespace);
   }
 
   @Override


### PR DESCRIPTION
## What changes were proposed in this pull request?

I reduced number of constructors in org.apache.hadoop.ozone.client.OzoneVolume to 1 (from 7) and refactored javadoc comments.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-7338

## How was this patch tested?

unit tests
