### PR TITLE
HDDS-7295. Introduce delimiter-awareness into `KeyIteratorFSO`

### DIFF
--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/OzoneBucket.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/OzoneBucket.java
@@ -1013,17 +1013,15 @@ public class OzoneBucket extends WithMetadata {
      * If prevKey is null it iterates from the first key in the bucket.
      * The returned keys match key prefix.
      * @param keyPrefix
+     * @param delimiter
+     * @param prevKey
      */
-    KeyIterator(String keyPrefix, String prevKey) throws IOException {
-      setKeyPrefix(keyPrefix);
-      this.currentValue = null;
-      this.currentIterator = getNextListOfKeys(prevKey).iterator();
-    }
-
     KeyIterator(String keyPrefix, String delimiter, String prevKey)
         throws IOException {
-      this(keyPrefix, prevKey);
-      this.delimiter = delimiter;
+      setKeyPrefix(keyPrefix);
+      setDelimiter(delimiter);
+      this.currentValue = null;
+      this.currentIterator = getNextListOfKeys(prevKey).iterator();
     }
 
     @Override

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/OzoneBucket.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/OzoneBucket.java
@@ -1327,17 +1327,18 @@ public class OzoneBucket extends WithMetadata {
         keysResultList.add(ozoneKey);
 
         if (status.isDirectory()) {
+          // If a slash ('/') delimiter is defined, children can be considered
+          // as CommonPrefix. So we do not need to fetch recursively.
+          if (StringUtils.isNotBlank(getDelimiter()) &&
+              OZONE_URI_DELIMITER.equals(getDelimiter())) {
+            return false;
+          }
           // Adding in-progress keyPath back to the stack to make sure
           // all the siblings will be fetched.
           stack.push(new ImmutablePair<>(keyPrefix, keyInfo.getKeyName()));
-          // If a slash ('/') delimiter is defined, children can be considered
-          // as CommonPrefix. So we do not need fetch recursively.
-          if (StringUtils.isBlank(getDelimiter()) ||
-              !OZONE_URI_DELIMITER.equals(getDelimiter())) {
-            // Adding current directory to the stack, so that this dir will be
-            // the top element. Moving seek pointer to fetch sub-paths
-            stack.push(new ImmutablePair<>(keyInfo.getKeyName(), ""));
-          }
+          // Adding current directory to the stack, so that this dir will be
+          // the top element. Moving seek pointer to fetch sub-paths
+          stack.push(new ImmutablePair<>(keyInfo.getKeyName(), ""));
           // Return it so that the next iteration will be
           // started using the stacked items.
           return true;

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/OzoneBucket.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/OzoneBucket.java
@@ -1331,7 +1331,7 @@ public class OzoneBucket extends WithMetadata {
           // as CommonPrefix. So we do not need to fetch recursively.
           if (StringUtils.isNotBlank(getDelimiter()) &&
               OZONE_URI_DELIMITER.equals(getDelimiter())) {
-            return false;
+            continue;
           }
           // Adding in-progress keyPath back to the stack to make sure
           // all the siblings will be fetched.

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFSWithObjectStoreCreate.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFSWithObjectStoreCreate.java
@@ -386,18 +386,18 @@ public class TestOzoneFSWithObjectStoreCreate {
     // Iterator with key name as prefix.
 
     Iterator<? extends OzoneKey > ozoneKeyIterator =
-        ozoneBucket.listKeys("/dir1//");
+        ozoneBucket.listKeys("/dir1//", null);
 
     checkKeyList(ozoneKeyIterator, keys);
 
     // Iterator with with normalized key prefix.
     ozoneKeyIterator =
-        ozoneBucket.listKeys("dir1/");
+        ozoneBucket.listKeys("dir1/", null);
 
     checkKeyList(ozoneKeyIterator, keys);
 
     // Iterator with key name as previous key.
-    ozoneKeyIterator = ozoneBucket.listKeys(null,
+    ozoneKeyIterator = ozoneBucket.listKeys(null, null,
         "/dir1///dir2/file1/");
 
     // Remove keys before //dir1/dir2/file1
@@ -408,7 +408,7 @@ public class TestOzoneFSWithObjectStoreCreate {
     checkKeyList(ozoneKeyIterator, keys);
 
     // Iterator with  normalized key as previous key.
-    ozoneKeyIterator = ozoneBucket.listKeys(null,
+    ozoneKeyIterator = ozoneBucket.listKeys(null, null,
         OmUtils.normalizeKey(key1, false));
 
     checkKeyList(ozoneKeyIterator, keys);

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestOzoneRpcClientAbstract.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestOzoneRpcClientAbstract.java
@@ -2336,7 +2336,7 @@ public abstract class TestOzoneRpcClientAbstract {
       four.close();
     }
     Iterator<? extends OzoneKey> volABucketAIter =
-        volAbucketA.listKeys("key-");
+        volAbucketA.listKeys("key-", null);
     int volABucketAKeyCount = 0;
     while (volABucketAIter.hasNext()) {
       volABucketAIter.next();
@@ -2344,7 +2344,7 @@ public abstract class TestOzoneRpcClientAbstract {
     }
     Assert.assertEquals(20, volABucketAKeyCount);
     Iterator<? extends OzoneKey> volABucketBIter =
-        volAbucketB.listKeys("key-");
+        volAbucketB.listKeys("key-", null);
     int volABucketBKeyCount = 0;
     while (volABucketBIter.hasNext()) {
       volABucketBIter.next();
@@ -2352,7 +2352,7 @@ public abstract class TestOzoneRpcClientAbstract {
     }
     Assert.assertEquals(20, volABucketBKeyCount);
     Iterator<? extends OzoneKey> volBBucketAIter =
-        volBbucketA.listKeys("key-");
+        volBbucketA.listKeys("key-", null);
     int volBBucketAKeyCount = 0;
     while (volBBucketAIter.hasNext()) {
       volBBucketAIter.next();
@@ -2360,7 +2360,7 @@ public abstract class TestOzoneRpcClientAbstract {
     }
     Assert.assertEquals(20, volBBucketAKeyCount);
     Iterator<? extends OzoneKey> volBBucketBIter =
-        volBbucketB.listKeys("key-");
+        volBbucketB.listKeys("key-", null);
     int volBBucketBKeyCount = 0;
     while (volBBucketBIter.hasNext()) {
       volBBucketBIter.next();
@@ -2368,7 +2368,7 @@ public abstract class TestOzoneRpcClientAbstract {
     }
     Assert.assertEquals(20, volBBucketBKeyCount);
     Iterator<? extends OzoneKey> volABucketAKeyAIter =
-        volAbucketA.listKeys("key-a-");
+        volAbucketA.listKeys("key-a-", null);
     int volABucketAKeyACount = 0;
     while (volABucketAKeyAIter.hasNext()) {
       volABucketAKeyAIter.next();
@@ -2376,7 +2376,7 @@ public abstract class TestOzoneRpcClientAbstract {
     }
     Assert.assertEquals(10, volABucketAKeyACount);
     Iterator<? extends OzoneKey> volABucketAKeyBIter =
-        volAbucketA.listKeys("key-b-");
+        volAbucketA.listKeys("key-b-", null);
     for (int i = 0; i < 10; i++) {
       Assert.assertTrue(volABucketAKeyBIter.next().getName()
           .startsWith("key-b-" + i + "-"));
@@ -2393,7 +2393,7 @@ public abstract class TestOzoneRpcClientAbstract {
     OzoneVolume vol = store.getVolume(volume);
     vol.createBucket(bucket);
     OzoneBucket buc = vol.getBucket(bucket);
-    Iterator<? extends OzoneKey> keys = buc.listKeys("");
+    Iterator<? extends OzoneKey> keys = buc.listKeys("", null);
     while (keys.hasNext()) {
       fail();
     }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/freon/TestOmBucketReadWriteKeyOps.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/freon/TestOmBucketReadWriteKeyOps.java
@@ -183,7 +183,8 @@ public class TestOmBucketReadWriteKeyOps {
   private void verifyKeyCreation(int expectedCount, OzoneBucket bucket,
                                  String keyPrefix) throws IOException {
     int actual = 0;
-    Iterator<? extends OzoneKey> ozoneKeyIterator = bucket.listKeys(keyPrefix);
+    Iterator<? extends OzoneKey> ozoneKeyIterator =
+        bucket.listKeys(keyPrefix, null);
     while (ozoneKeyIterator.hasNext()) {
       ozoneKeyIterator.next();
       ++actual;

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestBucketOwner.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestBucketOwner.java
@@ -123,7 +123,7 @@ public class TestBucketOwner {
     //Bucket Delete
     volume.deleteBucket("bucket3");
     //List Keys
-    ozoneBucket.listKeys("key");
+    ozoneBucket.listKeys("key", null);
     //Get Acls
     ozoneBucket.getAcls();
     //Add Acls
@@ -172,7 +172,7 @@ public class TestBucketOwner {
       OzoneVolume volume = cluster.getClient().getObjectStore()
               .getVolume("volume1");
       ozoneBucket = volume.getBucket("bucket1");
-      ozoneBucket.listKeys("key");
+      ozoneBucket.listKeys("key", null);
       fail("List keys as non-volume and non-bucket owner should fail");
     } catch (Exception ex) {
       LOG.info(ex.getMessage());
@@ -213,7 +213,7 @@ public class TestBucketOwner {
     //Key Delete
     ozoneBucket.deleteKey("key2");
     //List Keys
-    ozoneBucket.listKeys("key");
+    ozoneBucket.listKeys("key", null);
     //Get Acls
     ozoneBucket.getAcls();
     //Add Acls

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestListKeysWithFSO.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestListKeysWithFSO.java
@@ -475,7 +475,7 @@ public class TestListKeysWithFSO {
   private static List<String> getExpectedKeyList(String keyPrefix,
       String startKey, OzoneBucket legacyBucket) throws Exception {
     Iterator<? extends OzoneKey> ozoneKeyIterator =
-        legacyBucket.listKeys(keyPrefix, startKey);
+        legacyBucket.listKeys(keyPrefix, null, startKey);
 
     List<String> keys = new LinkedList<>();
     while (ozoneKeyIterator.hasNext()) {
@@ -489,7 +489,7 @@ public class TestListKeysWithFSO {
       List<String> keys, OzoneBucket fsoBucket) throws Exception {
 
     Iterator<? extends OzoneKey> ozoneKeyIterator =
-        fsoBucket.listKeys(keyPrefix, startKey);
+        fsoBucket.listKeys(keyPrefix, null, startKey);
 
     List <String> keyLists = new ArrayList<>();
     while (ozoneKeyIterator.hasNext()) {

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestObjectStoreWithFSO.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestObjectStoreWithFSO.java
@@ -435,18 +435,18 @@ public class TestObjectStoreWithFSO {
 
     // Root level listing keys
     Iterator<? extends OzoneKey> ozoneKeyIterator =
-        ozoneBucket.listKeys(null, null);
+        ozoneBucket.listKeys(null, null, null);
     verifyFullTreeStructure(ozoneKeyIterator);
 
     ozoneKeyIterator =
-        ozoneBucket.listKeys("a/", null);
+        ozoneBucket.listKeys("a/", null, null);
     verifyFullTreeStructure(ozoneKeyIterator);
 
     LinkedList<String> expectedKeys;
 
     // Intermediate level keyPrefix - 2nd level
     ozoneKeyIterator =
-        ozoneBucket.listKeys("a///b2///", null);
+        ozoneBucket.listKeys("a///b2///", null, null);
     expectedKeys = new LinkedList<>();
     expectedKeys.add("a/b2/");
     expectedKeys.add("a/b2/d1/");
@@ -460,7 +460,7 @@ public class TestObjectStoreWithFSO {
 
     // Intermediate level keyPrefix - 3rd level
     ozoneKeyIterator =
-        ozoneBucket.listKeys("a/b2/d1", null);
+        ozoneBucket.listKeys("a/b2/d1", null, null);
     expectedKeys = new LinkedList<>();
     expectedKeys.add("a/b2/d1/");
     expectedKeys.add("a/b2/d1/d11.tx");
@@ -468,14 +468,14 @@ public class TestObjectStoreWithFSO {
 
     // Boundary of a level
     ozoneKeyIterator =
-        ozoneBucket.listKeys("a/b2/d2", "a/b2/d2/d21.tx");
+        ozoneBucket.listKeys("a/b2/d2", null, "a/b2/d2/d21.tx");
     expectedKeys = new LinkedList<>();
     expectedKeys.add("a/b2/d2/d22.tx");
     checkKeyList(ozoneKeyIterator, expectedKeys);
 
     // Boundary case - last node in the depth-first-traversal
     ozoneKeyIterator =
-        ozoneBucket.listKeys("a/b3/e3", "a/b3/e3/e31.tx");
+        ozoneBucket.listKeys("a/b3/e3", null, "a/b3/e3/e31.tx");
     expectedKeys = new LinkedList<>();
     checkKeyList(ozoneKeyIterator, expectedKeys);
   }
@@ -538,18 +538,18 @@ public class TestObjectStoreWithFSO {
     // Iterator with key name as prefix.
 
     Iterator<? extends OzoneKey> ozoneKeyIterator =
-            ozoneBucket.listKeys("/dir1//", null);
+            ozoneBucket.listKeys("/dir1//", null, null);
 
     checkKeyList(ozoneKeyIterator, keys);
 
     // Iterator with with normalized key prefix.
     ozoneKeyIterator =
-            ozoneBucket.listKeys("dir1/");
+            ozoneBucket.listKeys("dir1/", null, null);
 
     checkKeyList(ozoneKeyIterator, keys);
 
     // Iterator with key name as previous key.
-    ozoneKeyIterator = ozoneBucket.listKeys(null,
+    ozoneKeyIterator = ozoneBucket.listKeys(null, null,
             "/dir1///dir2/file1/");
 
     // Remove keys before //dir1/dir2/file1
@@ -560,7 +560,7 @@ public class TestObjectStoreWithFSO {
     checkKeyList(ozoneKeyIterator, keys);
 
     // Iterator with  normalized key as previous key.
-    ozoneKeyIterator = ozoneBucket.listKeys(null,
+    ozoneKeyIterator = ozoneBucket.listKeys(null, null,
             OmUtils.normalizeKey(key1, false));
 
     checkKeyList(ozoneKeyIterator, keys);

--- a/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicOzoneClientAdapterImpl.java
+++ b/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicOzoneClientAdapterImpl.java
@@ -377,7 +377,7 @@ public class BasicOzoneClientAdapterImpl implements OzoneClientAdapter {
   @Override
   public Iterator<BasicKeyInfo> listKeys(String pathKey) throws IOException {
     incrementCounter(Statistic.OBJECTS_LIST, 1);
-    return new IteratorAdapter(bucket.listKeys(pathKey));
+    return new IteratorAdapter(bucket.listKeys(pathKey, null));
   }
 
   @Override

--- a/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicRootedOzoneClientAdapterImpl.java
+++ b/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicRootedOzoneClientAdapterImpl.java
@@ -693,7 +693,7 @@ public class BasicRootedOzoneClientAdapterImpl
       // return an empty list on error
       return new IteratorAdapter(Collections.emptyIterator());
     }
-    return new IteratorAdapter(bucket.listKeys(key));
+    return new IteratorAdapter(bucket.listKeys(key, null));
   }
 
   /**

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/BucketEndpoint.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/BucketEndpoint.java
@@ -134,13 +134,15 @@ public class BucketEndpoint extends EndpointBase {
       if (startAfter != null && continueToken != null) {
         // If continuation token and start after both are provided, then we
         // ignore start After
-        ozoneKeyIterator = bucket.listKeys(prefix, decodedToken.getLastKey());
+        ozoneKeyIterator = bucket.listKeys(prefix, delimiter,
+            decodedToken.getLastKey());
       } else if (startAfter != null && continueToken == null) {
-        ozoneKeyIterator = bucket.listKeys(prefix, startAfter);
+        ozoneKeyIterator = bucket.listKeys(prefix, delimiter, startAfter);
       } else if (startAfter == null && continueToken != null) {
-        ozoneKeyIterator = bucket.listKeys(prefix, decodedToken.getLastKey());
+        ozoneKeyIterator = bucket.listKeys(prefix, delimiter,
+            decodedToken.getLastKey());
       } else {
-        ozoneKeyIterator = bucket.listKeys(prefix);
+        ozoneKeyIterator = bucket.listKeys(prefix, delimiter);
       }
     } catch (OMException ex) {
       AUDIT.logReadFailure(

--- a/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/client/OzoneBucketStub.java
+++ b/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/client/OzoneBucketStub.java
@@ -184,7 +184,8 @@ public class OzoneBucketStub extends OzoneBucket {
   }
 
   @Override
-  public Iterator<? extends OzoneKey> listKeys(String keyPrefix) {
+  public Iterator<? extends OzoneKey> listKeys(String keyPrefix,
+      String delimiter) {
     Map<String, OzoneKey> sortedKey = new TreeMap<String, OzoneKey>(keyDetails);
     return sortedKey.values()
         .stream()
@@ -195,7 +196,7 @@ public class OzoneBucketStub extends OzoneBucket {
 
   @Override
   public Iterator<? extends OzoneKey> listKeys(String keyPrefix,
-      String prevKey) {
+      String delimiter, String prevKey) {
     Map<String, OzoneKey> sortedKey = new TreeMap<String, OzoneKey>(keyDetails);
     return sortedKey.values()
         .stream()

--- a/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestObjectDelete.java
+++ b/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestObjectDelete.java
@@ -55,6 +55,6 @@ public class TestObjectDelete {
 
     //THEN
     Assert.assertFalse("Bucket Should not contain any key after delete",
-        bucket.listKeys("").hasNext());
+        bucket.listKeys("", null).hasNext());
   }
 }

--- a/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestObjectMultiDelete.java
+++ b/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestObjectMultiDelete.java
@@ -61,7 +61,8 @@ public class TestObjectMultiDelete {
     MultiDeleteResponse response = rest.multiDelete("b1", "", mdr);
 
     //THEN
-    Set<String> keysAtTheEnd = Sets.newHashSet(bucket.listKeys("")).stream()
+    Set<String> keysAtTheEnd = Sets.newHashSet(
+        bucket.listKeys("", null)).stream()
         .map(OzoneKey::getName)
         .collect(Collectors.toSet());
 
@@ -93,7 +94,8 @@ public class TestObjectMultiDelete {
     MultiDeleteResponse response = rest.multiDelete("b1", "", mdr);
 
     //THEN
-    Set<String> keysAtTheEnd = Sets.newHashSet(bucket.listKeys("")).stream()
+    Set<String> keysAtTheEnd = Sets.newHashSet(
+        bucket.listKeys("", null)).stream()
         .map(OzoneKey::getName)
         .collect(Collectors.toSet());
 

--- a/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestPermissionCheck.java
+++ b/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestPermissionCheck.java
@@ -168,7 +168,7 @@ public class TestPermissionCheck {
   public void testListKey() throws IOException {
     Mockito.when(objectStore.getVolume(anyString())).thenReturn(volume);
     Mockito.when(objectStore.getS3Bucket(anyString())).thenReturn(bucket);
-    doThrow(exception).when(bucket).listKeys(anyString());
+    doThrow(exception).when(bucket).listKeys(anyString(), null);
     BucketEndpoint bucketEndpoint = new BucketEndpoint();
     bucketEndpoint.setClient(client);
 

--- a/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestPermissionCheck.java
+++ b/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestPermissionCheck.java
@@ -45,6 +45,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.when;
 
@@ -168,7 +169,7 @@ public class TestPermissionCheck {
   public void testListKey() throws IOException {
     Mockito.when(objectStore.getVolume(anyString())).thenReturn(volume);
     Mockito.when(objectStore.getS3Bucket(anyString())).thenReturn(bucket);
-    doThrow(exception).when(bucket).listKeys(anyString(), null);
+    doThrow(exception).when(bucket).listKeys(anyString(), isNull());
     BucketEndpoint bucketEndpoint = new BucketEndpoint();
     bucketEndpoint.setClient(client);
 

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/RandomKeyGenerator.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/RandomKeyGenerator.java
@@ -878,7 +878,7 @@ public final class RandomKeyGenerator implements Callable<Void> {
         bucketName, volume.getName());
     ArrayList<String> keys = new ArrayList<>();
     try {
-      bucket.listKeys(null).forEachRemaining(x -> keys.add(x.getName()));
+      bucket.listKeys(null, null).forEachRemaining(x -> keys.add(x.getName()));
       bucket.deleteKeys(keys);
       volume.deleteBucket(bucketName);
       numberOfBucketsCleaned.getAndIncrement();

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/keys/ListKeyHandler.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/keys/ListKeyHandler.java
@@ -54,7 +54,7 @@ public class ListKeyHandler extends BucketHandler {
     OzoneVolume vol = client.getObjectStore().getVolume(volumeName);
     OzoneBucket bucket = vol.getBucket(bucketName);
     Iterator<? extends OzoneKey> keyIterator = bucket.listKeys(
-        listOptions.getPrefix(), listOptions.getStartItem());
+        listOptions.getPrefix(), null, listOptions.getStartItem());
 
     int maxKeyLimit = listOptions.getLimit();
     int counter = printAsJsonArray(keyIterator, maxKeyLimit);


### PR DESCRIPTION
## What changes were proposed in this pull request?

When FSO-enabled bucket, we can optimize KeyIterator by `delimiter` param. If we have large bucket, reduce much query execution by stopping recursive listStatus query. It can be useful when user just fetches bucket structure via S3 API.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-7295

## How was this patch tested?
- DONE: Manual tests on our cluster (`aws s3 ls s3://bucket/` is success)
- TODO: Write more unittests