### PR TITLE
HDDS-7328. Improve Deletion of FSO Paths

### DIFF
--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/service/DirectoryDeletingService.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/service/DirectoryDeletingService.java
@@ -213,18 +213,17 @@ public class DirectoryDeletingService extends BackgroundService {
             submitPurgePaths(purgePathRequestList);
           }
 
-          deletedDirsCount.addAndGet(dirNum);
-          movedDirsCount.addAndGet(subDirNum);
-          movedFilesCount.addAndGet(subFileNum);
-          if (LOG.isDebugEnabled()) {
-            LOG.debug("Number of dirs deleted: {}, Number of sub-files moved:" +
+          if (dirNum != 0 || subDirNum != 0 || subFileNum != 0) {
+            deletedDirsCount.addAndGet(dirNum);
+            movedDirsCount.addAndGet(subDirNum);
+            movedFilesCount.addAndGet(subFileNum);
+            LOG.info("Number of dirs deleted: {}, Number of sub-files moved:" +
                     " {} to DeletedTable, Number of sub-dirs moved {} to " +
                     "DeletedDirectoryTable, iteration elapsed: {}ms," +
                     " totalRunCount: {}",
                 dirNum, subFileNum, subDirNum,
                 Time.monotonicNow() - startTime, getRunCount());
           }
-
 
         } catch (IOException e) {
           LOG.error("Error while running delete directories and files " +

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/service/DirectoryDeletingService.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/service/DirectoryDeletingService.java
@@ -24,15 +24,20 @@ import org.apache.hadoop.hdds.utils.BackgroundTask;
 import org.apache.hadoop.hdds.utils.BackgroundTaskQueue;
 import org.apache.hadoop.hdds.utils.BackgroundTaskResult;
 import org.apache.hadoop.hdds.utils.db.Table;
+import org.apache.hadoop.hdds.utils.db.Table.KeyValue;
+import org.apache.hadoop.hdds.utils.db.TableIterator;
 import org.apache.hadoop.ozone.ClientVersion;
 import org.apache.hadoop.ozone.om.OzoneManager;
 import org.apache.hadoop.ozone.om.helpers.OMRatisHelper;
 import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos;
+import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.PurgePathRequest;
 import org.apache.hadoop.util.Time;
 import org.apache.ratis.protocol.ClientId;
 import org.apache.ratis.protocol.Message;
 import org.apache.ratis.protocol.RaftClientRequest;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -63,10 +68,13 @@ import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_PATH_DELETING_LIMIT_
  * components of an orphan directory is visited.
  */
 public class DirectoryDeletingService extends BackgroundService {
+  public static final Logger LOG =
+      LoggerFactory.getLogger(DirectoryDeletingService.class);
 
   private final OzoneManager ozoneManager;
-  private AtomicLong deletedDirsCount;
-  private AtomicLong deletedFilesCount;
+  private final AtomicLong deletedDirsCount;
+  private final AtomicLong movedDirsCount;
+  private final AtomicLong movedFilesCount;
   private final AtomicLong runCount;
 
   private static ClientId clientId = ClientId.randomId();
@@ -86,7 +94,8 @@ public class DirectoryDeletingService extends BackgroundService {
         DIR_DELETING_CORE_POOL_SIZE, serviceTimeout);
     this.ozoneManager = ozoneManager;
     this.deletedDirsCount = new AtomicLong(0);
-    this.deletedFilesCount = new AtomicLong(0);
+    this.movedDirsCount = new AtomicLong(0);
+    this.movedFilesCount = new AtomicLong(0);
     this.runCount = new AtomicLong(0);
     this.pathLimitPerTask = configuration
         .getInt(OZONE_PATH_DELETING_LIMIT_PER_TASK,
@@ -125,73 +134,95 @@ public class DirectoryDeletingService extends BackgroundService {
     @Override
     public BackgroundTaskResult call() throws Exception {
       if (shouldRun()) {
+        if (LOG.isDebugEnabled()) {
+          LOG.debug("Running DirectoryDeletingService");
+        }
         runCount.incrementAndGet();
-        long count = pathLimitPerTask;
+        int dirNum = 0;
+        int subDirNum = 0;
+        int subFileNum = 0;
+        long remainNum = pathLimitPerTask;
+        List<PurgePathRequest> purgePathRequestList = new ArrayList<>();
+
+        Table.KeyValue<String, OmKeyInfo> pendingDeletedDirInfo;
         try {
+          TableIterator<String, ? extends KeyValue<String, OmKeyInfo>>
+              deleteTableIterator = ozoneManager.getMetadataManager().
+              getDeletedDirTable().iterator();
+
           long startTime = Time.monotonicNow();
-          // step-1) Get one pending deleted directory
-          Table.KeyValue<String, OmKeyInfo> pendingDeletedDirInfo =
-              ozoneManager.getKeyManager().getPendingDeletionDir();
-          if (pendingDeletedDirInfo != null) {
+          while (remainNum > 0 && deleteTableIterator.hasNext()) {
+            pendingDeletedDirInfo = deleteTableIterator.next();
+            // step-0: Get one pending deleted directory
             if (LOG.isDebugEnabled()) {
               LOG.debug("Pending deleted dir name: {}",
                   pendingDeletedDirInfo.getValue().getKeyName());
             }
             final String[] keys = pendingDeletedDirInfo.getKey()
-                    .split(OM_KEY_PREFIX);
+                .split(OM_KEY_PREFIX);
             final long volumeId = Long.parseLong(keys[1]);
             final long bucketId = Long.parseLong(keys[2]);
 
             // step-1: get all sub directories under the deletedDir
-            List<OmKeyInfo> dirs = ozoneManager.getKeyManager()
+            List<OmKeyInfo> subDirs = ozoneManager.getKeyManager()
                 .getPendingDeletionSubDirs(volumeId, bucketId,
-                        pendingDeletedDirInfo.getValue(), count);
-            count = count - dirs.size();
-            List<OmKeyInfo> deletedSubDirList = new ArrayList<>();
-            for (OmKeyInfo dirInfo : dirs) {
-              deletedSubDirList.add(dirInfo);
-              if (LOG.isDebugEnabled()) {
-                LOG.debug("deleted sub dir name: {}",
-                    dirInfo.getKeyName());
+                    pendingDeletedDirInfo.getValue(), remainNum);
+            remainNum = remainNum - subDirs.size();
+
+            if (LOG.isDebugEnabled()) {
+              for (OmKeyInfo dirInfo : subDirs) {
+                LOG.debug("Moved sub dir name: {}", dirInfo.getKeyName());
               }
             }
 
             // step-2: get all sub files under the deletedDir
-            List<OmKeyInfo> purgeDeletedFiles = ozoneManager.getKeyManager()
+            List<OmKeyInfo> subFiles = ozoneManager.getKeyManager()
                 .getPendingDeletionSubFiles(volumeId, bucketId,
-                        pendingDeletedDirInfo.getValue(), count);
-            count = count - purgeDeletedFiles.size();
+                    pendingDeletedDirInfo.getValue(), remainNum);
+            remainNum = remainNum - subFiles.size();
 
             if (LOG.isDebugEnabled()) {
-              for (OmKeyInfo fileInfo : purgeDeletedFiles) {
-                LOG.debug("deleted sub file name: {}", fileInfo.getKeyName());
+              for (OmKeyInfo fileInfo : subFiles) {
+                LOG.debug("Moved sub file name: {}", fileInfo.getKeyName());
               }
             }
 
-            // step-3: Since there is a boundary condition of 'numEntries' in
-            // each batch, check whether the sub paths count reached batch size
-            // limit. If count reached limit then there can be some more child
-            // paths to be visited and will keep the parent deleted directory
-            // for one more pass.
-            final Optional<String> purgeDeletedDir = count > 0 ?
-                    Optional.of(pendingDeletedDirInfo.getKey()) :
-                    Optional.empty();
+          // step-3: Since there is a boundary condition of 'numEntries' in
+          // each batch, check whether the sub paths count reached batch size
+          // limit. If count reached limit then there can be some more child
+          // paths to be visited and will keep the parent deleted directory
+          // for one more pass.
+            final Optional<String> purgeDeletedDir = remainNum > 0 ?
+                Optional.of(pendingDeletedDirInfo.getKey()) :
+                Optional.empty();
 
-            if (isRatisEnabled()) {
-              submitPurgePaths(volumeId, bucketId, purgeDeletedDir,
-                      purgeDeletedFiles, deletedSubDirList);
-            }
-            // TODO: need to handle delete with non-ratis
+            PurgePathRequest request = wrapPurgeRequest(volumeId, bucketId,
+                purgeDeletedDir, subFiles, subDirs);
+            purgePathRequestList.add(request);
 
-            deletedDirsCount.incrementAndGet();
-            deletedFilesCount.addAndGet(purgeDeletedFiles.size());
-            if (LOG.isDebugEnabled()) {
-              LOG.debug("Number of dirs deleted: {}, Number of files moved:" +
-                      " {} to DeletedTable, elapsed time: {}ms",
-                  deletedDirsCount, deletedFilesCount,
-                  Time.monotonicNow() - startTime);
+            // Count up the purgeDeletedDir, subDirs and subFiles
+            if (purgeDeletedDir.isPresent()) {
+              dirNum++;
             }
+            subDirNum += subDirs.size();
+            subFileNum += subFiles.size();
           }
+
+          // TODO: need to handle delete with non-ratis
+          if (isRatisEnabled()) {
+            submitPurgePaths(purgePathRequestList);
+          }
+
+          deletedDirsCount.addAndGet(dirNum);
+          movedDirsCount.addAndGet(subDirNum);
+          movedFilesCount.addAndGet(subFileNum);
+          LOG.info("Number of dirs deleted: {}, Number of sub-files moved:" +
+                  " {} to DeletedTable, Number of sub-dirs moved {} to " +
+                  "DeletedDirectoryTable, iteration elapsed: {}ms," +
+                  " totalRunCount: {}",
+              dirNum, subFileNum, subDirNum,
+              Time.monotonicNow() - startTime, getRunCount());
+
         } catch (IOException e) {
           LOG.error("Error while running delete directories and files " +
               "background task. Will retry at next run.", e);
@@ -214,6 +245,16 @@ public class DirectoryDeletingService extends BackgroundService {
   }
 
   /**
+   * Returns the number of sub-dirs deleted by the background service.
+   *
+   * @return Long count.
+   */
+  @VisibleForTesting
+  public long getMovedDirsCount() {
+    return movedDirsCount.get();
+  }
+
+  /**
    * Returns the number of files moved to DeletedTable by the background
    * service.
    *
@@ -221,7 +262,7 @@ public class DirectoryDeletingService extends BackgroundService {
    */
   @VisibleForTesting
   public long getMovedFilesCount() {
-    return deletedFilesCount.get();
+    return movedFilesCount.get();
   }
 
   /**
@@ -234,33 +275,10 @@ public class DirectoryDeletingService extends BackgroundService {
     return runCount.get();
   }
 
-  private int submitPurgePaths(final long volumeId, final long bucketId,
-      final Optional<String> purgeDeletedDir,
-      final List<OmKeyInfo> purgeDeletedFiles,
-      final List<OmKeyInfo> markDirsAsDeleted) {
-    // Put all keys to be purged in a list
-    int deletedCount = 0;
-    OzoneManagerProtocolProtos.PurgePathRequest.Builder purgePathsRequest =
-        OzoneManagerProtocolProtos.PurgePathRequest.newBuilder();
-    purgePathsRequest.setVolumeId(volumeId);
-    purgePathsRequest.setBucketId(bucketId);
-    purgeDeletedDir.ifPresent(purgePathsRequest::setDeletedDir);
-    for (OmKeyInfo purgeFile : purgeDeletedFiles) {
-      purgePathsRequest.addDeletedSubFiles(
-          purgeFile.getProtobuf(true, ClientVersion.CURRENT_VERSION));
-    }
-
-    // Add these directories to deletedDirTable, so that its sub-paths will be
-    // traversed in next iteration to ensure cleanup all sub-children.
-    for (OmKeyInfo dir : markDirsAsDeleted) {
-      purgePathsRequest.addMarkDeletedSubDirs(
-          dir.getProtobuf(ClientVersion.CURRENT_VERSION));
-    }
-
+  private void submitPurgePaths(List<PurgePathRequest> requests) {
     OzoneManagerProtocolProtos.PurgeDirectoriesRequest.Builder purgeDirRequest =
-            OzoneManagerProtocolProtos.PurgeDirectoriesRequest.newBuilder();
-    purgeDirRequest.addDeletedPath(purgePathsRequest.build());
-
+        OzoneManagerProtocolProtos.PurgeDirectoriesRequest.newBuilder();
+    purgeDirRequest.addAllDeletedPath(requests);
 
     OzoneManagerProtocolProtos.OMRequest omRequest =
         OzoneManagerProtocolProtos.OMRequest.newBuilder()
@@ -277,9 +295,32 @@ public class DirectoryDeletingService extends BackgroundService {
           raftClientRequest);
     } catch (ServiceException e) {
       LOG.error("PurgePaths request failed. Will retry at next run.");
-      return 0;
     }
-    return deletedCount;
+  }
+
+  private PurgePathRequest wrapPurgeRequest(final long volumeId,
+      final long bucketId,
+      final Optional<String> purgeDeletedDir,
+      final List<OmKeyInfo> purgeDeletedFiles,
+      final List<OmKeyInfo> markDirsAsDeleted) {
+    // Put all keys to be purged in a list
+    PurgePathRequest.Builder purgePathsRequest = PurgePathRequest.newBuilder();
+    purgePathsRequest.setVolumeId(volumeId);
+    purgePathsRequest.setBucketId(bucketId);
+    purgeDeletedDir.ifPresent(purgePathsRequest::setDeletedDir);
+    for (OmKeyInfo purgeFile : purgeDeletedFiles) {
+      purgePathsRequest.addDeletedSubFiles(
+          purgeFile.getProtobuf(true, ClientVersion.CURRENT_VERSION));
+    }
+
+    // Add these directories to deletedDirTable, so that its sub-paths will be
+    // traversed in next iteration to ensure cleanup all sub-children.
+    for (OmKeyInfo dir : markDirsAsDeleted) {
+      purgePathsRequest.addMarkDeletedSubDirs(
+          dir.getProtobuf(ClientVersion.CURRENT_VERSION));
+    }
+
+    return purgePathsRequest.build();
   }
 
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/service/DirectoryDeletingService.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/service/DirectoryDeletingService.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with this
  * work for additional information regarding copyright ownership.  The ASF
@@ -42,7 +42,6 @@ import org.slf4j.LoggerFactory;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 
@@ -192,16 +191,15 @@ public class DirectoryDeletingService extends BackgroundService {
           // limit. If count reached limit then there can be some more child
           // paths to be visited and will keep the parent deleted directory
           // for one more pass.
-            final Optional<String> purgeDeletedDir = remainNum > 0 ?
-                Optional.of(pendingDeletedDirInfo.getKey()) :
-                Optional.empty();
+            String purgeDeletedDir = remainNum > 0 ?
+                pendingDeletedDirInfo.getKey() : null;
 
             PurgePathRequest request = wrapPurgeRequest(volumeId, bucketId,
                 purgeDeletedDir, subFiles, subDirs);
             purgePathRequestList.add(request);
 
             // Count up the purgeDeletedDir, subDirs and subFiles
-            if (purgeDeletedDir.isPresent()) {
+            if (purgeDeletedDir != null) {
               dirNum++;
             }
             subDirNum += subDirs.size();
@@ -302,14 +300,18 @@ public class DirectoryDeletingService extends BackgroundService {
 
   private PurgePathRequest wrapPurgeRequest(final long volumeId,
       final long bucketId,
-      final Optional<String> purgeDeletedDir,
+      final String purgeDeletedDir,
       final List<OmKeyInfo> purgeDeletedFiles,
       final List<OmKeyInfo> markDirsAsDeleted) {
     // Put all keys to be purged in a list
     PurgePathRequest.Builder purgePathsRequest = PurgePathRequest.newBuilder();
     purgePathsRequest.setVolumeId(volumeId);
     purgePathsRequest.setBucketId(bucketId);
-    purgeDeletedDir.ifPresent(purgePathsRequest::setDeletedDir);
+
+    if (purgeDeletedDir != null) {
+      purgePathsRequest.setDeletedDir(purgeDeletedDir);
+    }
+
     for (OmKeyInfo purgeFile : purgeDeletedFiles) {
       purgePathsRequest.addDeletedSubFiles(
           purgeFile.getProtobuf(true, ClientVersion.CURRENT_VERSION));

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/service/DirectoryDeletingService.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/service/DirectoryDeletingService.java
@@ -216,12 +216,15 @@ public class DirectoryDeletingService extends BackgroundService {
           deletedDirsCount.addAndGet(dirNum);
           movedDirsCount.addAndGet(subDirNum);
           movedFilesCount.addAndGet(subFileNum);
-          LOG.info("Number of dirs deleted: {}, Number of sub-files moved:" +
-                  " {} to DeletedTable, Number of sub-dirs moved {} to " +
-                  "DeletedDirectoryTable, iteration elapsed: {}ms," +
-                  " totalRunCount: {}",
-              dirNum, subFileNum, subDirNum,
-              Time.monotonicNow() - startTime, getRunCount());
+          if (LOG.isDebugEnabled()) {
+            LOG.debug("Number of dirs deleted: {}, Number of sub-files moved:" +
+                    " {} to DeletedTable, Number of sub-dirs moved {} to " +
+                    "DeletedDirectoryTable, iteration elapsed: {}ms," +
+                    " totalRunCount: {}",
+                dirNum, subFileNum, subDirNum,
+                Time.monotonicNow() - startTime, getRunCount());
+          }
+
 
         } catch (IOException e) {
           LOG.error("Error while running delete directories and files " +


### PR DESCRIPTION
## What changes were proposed in this pull request?

Currently, the deleting speed of paths in the FSO bucket is too slow.

Every time the DirectoryDeletingService executes(every 1m by default),  it chooses only one path from DeletedDirectroyTable and tries adding its sub-files and sub-dirs into the PurgeDirectories Request. The real deletion happens in OMKeyDeleteResponseWithFSO, which moved all sub-dirs into DeletedDirectroyTable.  Then these sub-dirs will be chosen by the future execution of DirectoryDeletingService. 

In the real production environment, such deletion speed is not applicable. There could be lots of dirs deleted without sub-dirs or sub-files. The dir deletion speed would lag behind the dir creation speed.

In this PR,  I propose to optimize the logic of the DirectoryDeletingService, we could consume all the quota (ozone.path.deleting.limit.per.task) to delete paths as much as possible. The good news is the PB is already designed to do so, we could add more PurgePathRequest in one PurgeDirectoriesRequest. 

Originally: 1 min.  At most 1 path from deletedDirectoryTable.
Now:          1min.   At most 10000 paths from deletedDirectoryTable.

```
message PurgeDirectoriesRequest {
  repeated PurgePathRequest deletedPath = 1;
}
```


## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-7328

## How was this patch tested?

UT and real env