### PR TITLE
HDDS-7340. Bump jackson-databind to 2.13.4.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -137,7 +137,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
 
     <!-- jackson versions -->
     <jackson2.version>2.13.4</jackson2.version>
-    <jackson2.databind.version>2.13.4</jackson2.databind.version>
+    <jackson2.databind.version>2.13.4.2</jackson2.databind.version>
 
     <!-- jaegertracing veresion -->
     <jaeger.version>1.6.0</jaeger.version>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Bump `jackson2-databind` to 2.13.4.2 due to CVE-2022-42003.

https://issues.apache.org/jira/browse/HDDS-7340

## How was this patch tested?

https://github.com/adoroszlai/hadoop-ozone/actions/runs/3263801866