### PR TITLE
HDDS-7254. Document that moving SCM from non-HA to HA is currently unsupported.

### DIFF
--- a/hadoop-hdds/docs/content/feature/SCM-HA.md
+++ b/hadoop-hdds/docs/content/feature/SCM-HA.md
@@ -33,6 +33,13 @@ This document explains the HA setup of Storage Container Manager (SCM), please c
 
 ## Configuration
 
+> &#x26a0;&#xfe0f; **IMPORTANT** &#x26a0;&#xfe0f;
+>
+> SCM HA is currently supported only for fresh installations.
+> SCM HA must be enabled when starting the Ozone service in the beginning.
+> Once an SCM has been started in non-HA mode,
+> it is unsupported to change it to HA mode.
+
 HA mode of Storage Container Manager can be enabled with the following settings in `ozone-site.xml`:
 
 ```XML

--- a/hadoop-hdds/docs/content/feature/SCM-HA.md
+++ b/hadoop-hdds/docs/content/feature/SCM-HA.md
@@ -38,7 +38,7 @@ This document explains the HA setup of Storage Container Manager (SCM), please c
 > SCM HA is currently supported only for fresh installations.
 > SCM HA must be enabled when starting the Ozone service in the beginning.
 > Once an SCM has been started in non-HA mode,
-> it is unsupported to change it to HA mode.
+> changing it to HA mode is unsupported.
 
 HA mode of Storage Container Manager can be enabled with the following settings in `ozone-site.xml`:
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Currently SCM HA is supported only for fresh installations. SCM HA must be enabled when starting the Ozone service in the beginning.  After a SCM is started in non-HA mode, it cannot be easily changed to HA mode. We should document this clearly.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-7254

## How was this patch tested?

NA