### PR TITLE
HDDS-3419. Throw exception with correct code when available data nodes are not sufficient

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/PipelinePlacementPolicy.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/PipelinePlacementPolicy.java
@@ -124,13 +124,12 @@ public final class PipelinePlacementPolicy extends SCMCommonPlacementPolicy {
     // get nodes in HEALTHY state
     List<DatanodeDetails> healthyNodes =
         nodeManager.getNodes(NodeStatus.inServiceHealthy());
-    if (healthyNodes.size() < nodesRequired) {
-      String msg = String.format("Pipeline creation failed due to "
-                      + "no sufficient healthy nodes.Required %d. Found %d.",
-              nodesRequired, healthyNodes.size());
+    String msg;
+    if (healthyNodes.size() == 0) {
+      msg = "No healthy node found to allocate container.";
       LOG.error(msg);
-      throw new SCMException(msg,
-              SCMException.ResultCodes.FAILED_TO_FIND_SUITABLE_NODE);
+      throw new SCMException(msg, SCMException.ResultCodes
+              .FAILED_TO_FIND_HEALTHY_NODES);
     }
 
     healthyNodes = filterNodesWithSpace(healthyNodes, nodesRequired,
@@ -140,7 +139,6 @@ public final class PipelinePlacementPolicy extends SCMCommonPlacementPolicy {
       healthyNodes.removeAll(excludedNodes);
     }
     int initialHealthyNodesCount = healthyNodes.size();
-    String msg;
 
     if (initialHealthyNodesCount < nodesRequired) {
       msg = String.format("Pipeline creation failed due to no sufficient" +

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/PipelinePlacementPolicy.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/PipelinePlacementPolicy.java
@@ -124,6 +124,15 @@ public final class PipelinePlacementPolicy extends SCMCommonPlacementPolicy {
     // get nodes in HEALTHY state
     List<DatanodeDetails> healthyNodes =
         nodeManager.getNodes(NodeStatus.inServiceHealthy());
+    if (healthyNodes.size() < nodesRequired) {
+      String msg = String.format("Pipeline creation failed due to "
+                      + "no sufficient healthy nodes.Required %d. Found %d.",
+              nodesRequired, healthyNodes.size());
+      LOG.error(msg);
+      throw new SCMException(msg,
+              SCMException.ResultCodes.FAILED_TO_FIND_SUITABLE_NODE);
+    }
+
     healthyNodes = filterNodesWithSpace(healthyNodes, nodesRequired,
         metadataSizeRequired, dataSizeRequired);
     boolean multipleRacks = multipleRacksAvailable(healthyNodes);

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestRatisPipelineCreateAndDestroy.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestRatisPipelineCreateAndDestroy.java
@@ -134,6 +134,11 @@ public class TestRatisPipelineCreateAndDestroy {
       cluster.shutdownHddsDatanode(dn.getDatanodeDetails());
     }
 
+    GenericTestUtils.waitFor(() ->
+                    cluster.getStorageContainerManager().getScmNodeManager()
+                            .getNodeCount(NodeStatus.inServiceHealthy()) == 0,
+                    100, 10 * 1000);
+
     // try creating another pipeline now
     try {
       pipelineManager.createPipeline(RatisReplicationConfig.getInstance(
@@ -143,7 +148,7 @@ public class TestRatisPipelineCreateAndDestroy {
       // As now all datanodes are shutdown, they move to stale state, there
       // will be no sufficient datanodes to create the pipeline.
       Assert.assertTrue(ioe instanceof SCMException);
-      Assert.assertEquals(SCMException.ResultCodes.FAILED_TO_FIND_SUITABLE_NODE,
+      Assert.assertEquals(SCMException.ResultCodes.FAILED_TO_FIND_HEALTHY_NODES,
           ((SCMException) ioe).getResult());
     }
 

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestRatisPipelineCreateAndDestroy.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestRatisPipelineCreateAndDestroy.java
@@ -31,7 +31,6 @@ import org.apache.hadoop.ozone.MiniOzoneCluster;
 import org.apache.ozone.test.GenericTestUtils;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.Assert;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 
@@ -48,7 +47,6 @@ import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_STALENODE_INTER
 /**
  * Tests for RatisPipelineUtils.
  */
-@Disabled("HDDS-3419")
 public class TestRatisPipelineCreateAndDestroy {
 
   private MiniOzoneCluster cluster;


### PR DESCRIPTION
## What changes were proposed in this pull request?

  Fix and enable test cases in TestRatisPipelineCreateAndDestroy. Throw exception when available healthy nodes are not sufficient 

## What is the link to the Apache JIRA

  https://issues.apache.org/jira/browse/HDDS-3419

## How was this patch tested?
   All tests in TestRatisPipelineCreateAndDestroy were running successfully with the fix on developers machine. 
    build-branch was successful with the changes https://github.com/pratapchandu/ozone/actions/runs/3264534699
https://github.com/pratapchandu/ozone/actions/runs/3384457500
