### PR TITLE
HDDS-7343. Do not log exception on file not found in getFileStatus()

### DIFF
--- a/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicOzoneFileSystem.java
+++ b/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicOzoneFileSystem.java
@@ -762,7 +762,6 @@ public class BasicOzoneFileSystem extends FileSystem {
           throw new FileNotFoundException("File not found. path:" + f);
         }
       }
-      LOG.warn("GetFileStatus failed for path {}", f, ex);
       throw ex;
     }
     return fileStatus;

--- a/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicRootedOzoneFileSystem.java
+++ b/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicRootedOzoneFileSystem.java
@@ -876,7 +876,6 @@ public class BasicRootedOzoneFileSystem extends FileSystem {
           throw new FileNotFoundException("File not found. path:" + f);
         }
       }
-      LOG.warn("GetFileStatus failed for path {}", f, e);
       throw e;
     }
     return fileStatus;


### PR DESCRIPTION
## What changes were proposed in this pull request?

I removed logging exceptions in ozone client getFileStatus() methods. This issue was introduced in https://github.com/apache/ozone/pull/3687

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-7343

## How was this patch tested?

manual test: I built Ozone from a branch, deployed Hadoop cluster, deployed Ozone in this Hadoop cluster, and checked those exceptions were gone.
