### PR TITLE
HDDS-7341. EC: Close pipelines with unregistered nodes

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/PipelineManagerImpl.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/PipelineManagerImpl.java
@@ -522,7 +522,35 @@ public class PipelineManagerImpl implements PipelineManager {
         closeContainersForPipeline(p.getId());
         removePipeline(p);
       }
+      // If a datanode is stopped and then SCM is restarted, a pipline can get
+      // stuck in an open state. For Ratis, provided some other DNs that were
+      // part of the open pipeline register to SCM after the restart, the Ratis
+      // pipeline close will get triggered by the DNs. For EC that will never
+      // happen, as the DNs are not aware of the pipeline. Therefore we should
+      // close any pipelines in the scrubber if they have nodes which are not
+      // registered
+      if (isOpenWithUnregisteredNodes(p)) {
+        closeContainersForPipeline(p.getId());
+        closePipeline(p, true);
+      }
     }
+  }
+
+  /**
+   * @param pipeline The pipeline to check
+   * @return True if the pipeline is open and contains unregistered nodes. False
+   *         otherwise.
+   */
+  private boolean isOpenWithUnregisteredNodes(Pipeline pipeline) {
+    if (!pipeline.isOpen()) {
+      return false;
+    }
+    for (DatanodeDetails dn : pipeline.getNodes()) {
+      if (nodeManager.getNodeByUuid(dn.getUuidString()) == null) {
+        return true;
+      }
+    }
+    return false;
   }
 
   /**

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/PipelineManagerImpl.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/PipelineManagerImpl.java
@@ -509,20 +509,20 @@ public class PipelineManagerImpl implements PipelineManager {
       if (p.getPipelineState() == Pipeline.PipelineState.ALLOCATED &&
           (currentTime.toEpochMilli() - p.getCreationTimestamp()
               .toEpochMilli() >= pipelineScrubTimeoutInMills)) {
-        LOG.info("Scrubbing pipeline: id: " + p.getId().toString() +
-            " since it stays at ALLOCATED stage for " +
+        LOG.info("Scrubbing pipeline: id: {} since it stays at ALLOCATED " +
+            "stage for {} mins.", p.getId(),
             Duration.between(currentTime, p.getCreationTimestamp())
-                .toMinutes() + " mins.");
+                .toMinutes());
         closePipeline(p, false);
       }
       // scrub pipelines who stay CLOSED for too long.
       if (p.getPipelineState() == Pipeline.PipelineState.CLOSED) {
-        LOG.info("Scrubbing pipeline: id: " + p.getId().toString() +
-            " since it stays at CLOSED stage.");
+        LOG.info("Scrubbing pipeline: id: {} since it stays at CLOSED stage.",
+            p.getId());
         closeContainersForPipeline(p.getId());
         removePipeline(p);
       }
-      // If a datanode is stopped and then SCM is restarted, a pipline can get
+      // If a datanode is stopped and then SCM is restarted, a pipeline can get
       // stuck in an open state. For Ratis, provided some other DNs that were
       // part of the open pipeline register to SCM after the restart, the Ratis
       // pipeline close will get triggered by the DNs. For EC that will never
@@ -530,6 +530,8 @@ public class PipelineManagerImpl implements PipelineManager {
       // close any pipelines in the scrubber if they have nodes which are not
       // registered
       if (isOpenWithUnregisteredNodes(p)) {
+        LOG.info("Scrubbing pipeline: id: {} as it has unregistered nodes",
+            p.getId());
         closeContainersForPipeline(p.getId());
         closePipeline(p, true);
       }

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestPipelineManagerImpl.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestPipelineManagerImpl.java
@@ -348,7 +348,6 @@ public class TestPipelineManagerImpl {
   @Test
   public void testRemovePipeline() throws Exception {
     PipelineManagerImpl pipelineManager = createPipelineManager(true);
-    pipelineManager.setScmContext(scmContext);
     // Create a pipeline
     Pipeline pipeline = pipelineManager.createPipeline(
         RatisReplicationConfig.getInstance(ReplicationFactor.THREE));
@@ -398,7 +397,6 @@ public class TestPipelineManagerImpl {
   @Test
   public void testClosePipelineShouldFailOnFollower() throws Exception {
     PipelineManagerImpl pipelineManager = createPipelineManager(true);
-    pipelineManager.setScmContext(scmContext);
     Pipeline pipeline = pipelineManager.createPipeline(
         RatisReplicationConfig.getInstance(ReplicationFactor.THREE));
     Assertions.assertEquals(1, pipelineManager.getPipelines().size());
@@ -420,7 +418,6 @@ public class TestPipelineManagerImpl {
   @Test
   public void testPipelineReport() throws Exception {
     PipelineManagerImpl pipelineManager = createPipelineManager(true);
-    pipelineManager.setScmContext(scmContext);
     SCMSafeModeManager scmSafeModeManager =
         new SCMSafeModeManager(conf, new ArrayList<>(), null, pipelineManager,
             new EventQueue(), serviceManager, scmContext);
@@ -578,7 +575,6 @@ public class TestPipelineManagerImpl {
         OZONE_SCM_PIPELINE_ALLOCATED_TIMEOUT, 50, TimeUnit.SECONDS);
 
     PipelineManagerImpl pipelineManager = createPipelineManager(true);
-    pipelineManager.setScmContext(scmContext);
     Pipeline allocatedPipeline = pipelineManager
         .createPipeline(RatisReplicationConfig
             .getInstance(ReplicationFactor.THREE));
@@ -638,7 +634,6 @@ public class TestPipelineManagerImpl {
   @Test
   public void testScrubOpenWithUnregisteredNodes() throws Exception {
     PipelineManagerImpl pipelineManager = createPipelineManager(true);
-    pipelineManager.setScmContext(scmContext);
     Pipeline pipeline = pipelineManager
         .createPipeline(new ECReplicationConfig(3, 2));
     pipelineManager.openPipeline(pipeline.getId());
@@ -666,7 +661,6 @@ public class TestPipelineManagerImpl {
         OZONE_SCM_PIPELINE_ALLOCATED_TIMEOUT, 10, TimeUnit.SECONDS);
 
     PipelineManagerImpl pipelineManager = createPipelineManager(true);
-    pipelineManager.setScmContext(scmContext);
     Pipeline pipeline = pipelineManager
         .createPipeline(RatisReplicationConfig
             .getInstance(ReplicationFactor.THREE));
@@ -797,7 +791,6 @@ public class TestPipelineManagerImpl {
     GenericTestUtils.LogCapturer logCapturer = GenericTestUtils.LogCapturer
             .captureLogs(LoggerFactory.getLogger(PipelineManagerImpl.class));
     PipelineManagerImpl pipelineManager = createPipelineManager(true);
-    pipelineManager.setScmContext(scmContext);
     Pipeline pipeline = pipelineManager.createPipeline(
             RatisReplicationConfig
                 .getInstance(HddsProtos.ReplicationFactor.THREE));


### PR DESCRIPTION
## What changes were proposed in this pull request?

A datanode is stopped and before the stale node handler is triggered, SCM is restarted. When SCM restarts its loads all the only pipelines and nodes from RocksDB, and then all the nodes will register again.

In the case of EC pipelines, there is nothing to trigger the close of a pipeline (and the containers on it) except:

1. The Container getting full and the DN triggering the close
2. The stale / dead node handlers noticing a node on it has gone dead.

In the case above, the EC pipeline will sit forever in an Open state, but any attempt to write to it will likely result in errors on the client due to one of the nodes not being available. These errors still will not trigger it to close.

A solution to this problem, is to add logic to the pipeline scrubber to close any pipelines that have unregistered nodes. Stale / Dead nodes should be handled by the existing stale / dead node handlers.


## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-7341

## How was this patch tested?

New unit test and validated on a docker compose cluster.