### PR TITLE
HDDS-7347. [Multi-Tenant] Add proper error message to TenantAssignAdmin and TenantRevokeAdmin

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/shell/TestOzoneTenantShell.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/shell/TestOzoneTenantShell.java
@@ -399,6 +399,14 @@ public class TestOzoneTenantShell {
           + "  \"isDelegatedAdmin\": true\n" + "}\n", true, true);
       checkOutput(err, "", true);
 
+      //Re-assign same admin
+      executeHA(tenantShell, new String[] {"--verbose", "user", "assign-admin",
+          tenantName + "$" + userName, "--tenant=" + tenantName,
+          "--delegated=true"});
+      checkOutput(out, "", true);
+      checkOutput(err, "accessId 'devaa$alice' is " +
+          "already the tenant 'devaa' admin.\n", true);
+
       // Clean up
       executeHA(tenantShell, new String[] {"--verbose", "user", "revoke-admin",
           tenantName + "$" + userName, "--tenant=" + tenantName});

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/shell/TestOzoneTenantShell.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/shell/TestOzoneTenantShell.java
@@ -415,6 +415,12 @@ public class TestOzoneTenantShell {
           + "  \"isDelegatedAdmin\": false\n" + "}\n", true, true);
       checkOutput(err, "", true);
 
+      executeHA(tenantShell, new String[] {"--verbose", "user", "revoke-admin",
+          tenantName + "$" + userName, "--tenant=" + tenantName});
+      checkOutput(out, "", true);
+      checkOutput(err, "accessId 'devaa$alice' is already not " +
+          "the tenant 'devaa' admin.\n", true);
+
       executeHA(tenantShell, new String[] {
           "user", "revoke", tenantName + "$" + userName});
       checkOutput(out, "", true);

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/tenant/OMTenantAssignAdminRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/tenant/OMTenantAssignAdminRequest.java
@@ -120,7 +120,7 @@ public class OMTenantAssignAdminRequest extends OMClientRequest {
     if (accessIdInfo.getIsAdmin()) {
       throw new OMException("accessId '" + accessId +
           "' is already the tenant '" + tenantId + "' admin.",
-          OMException.ResultCodes.TENANT_USER_ACCESS_ID_ALREADY_EXISTS);
+          OMException.ResultCodes.INVALID_REQUEST);
     }
 
     final boolean delegated;

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/tenant/OMTenantAssignAdminRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/tenant/OMTenantAssignAdminRequest.java
@@ -116,6 +116,13 @@ public class OMTenantAssignAdminRequest extends OMClientRequest {
           OMException.ResultCodes.INVALID_TENANT_ID);
     }
 
+    // Prevent assigning the same user as admin.
+    if (accessIdInfo.getIsAdmin()) {
+      throw new OMException("accessId '" + accessId +
+          "' is already the tenant '" + tenantId + "' admin.",
+          OMException.ResultCodes.TENANT_USER_ACCESS_ID_ALREADY_EXISTS);
+    }
+
     final boolean delegated;
     if (request.hasDelegated()) {
       delegated = request.getDelegated();

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/tenant/OMTenantRevokeAdminRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/tenant/OMTenantRevokeAdminRequest.java
@@ -116,6 +116,13 @@ public class OMTenantRevokeAdminRequest extends OMClientRequest {
           OMException.ResultCodes.INVALID_TENANT_ID);
     }
 
+    // Check if the accessId is already the tenant admin
+    if (!accessIdInfo.getIsAdmin()) {
+      throw new OMException("accessId '" + accessId +
+          "' is already not the tenant '" + tenantId + "' admin.",
+          OMException.ResultCodes.INVALID_REQUEST);
+    }
+
     // Acquire write lock to authorizer (Ranger)
     multiTenantManager.getAuthorizerLock().tryWriteLockInOMRequest();
     try {


### PR DESCRIPTION
## What changes were proposed in this pull request?

- Add error message when the same user is assigned as tenant admin.
- Add error message when the non-admin user is revoked as tenant admin.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-7347

## How was this patch tested?

The patch was tested using unit tests. 
