### PR TITLE
HDDS-7149. Update ratis version to 2.4.0 and thirdparty version to 1.0.2.

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMStateMachine.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMStateMachine.java
@@ -354,10 +354,10 @@ public class SCMStateMachine extends BaseStateMachine {
   @Override
   public void pause() {
     final LifeCycle lc = getLifeCycle();
-      if (lc.getCurrentState() != LifeCycle.State.NEW) {
-        lc.transition(LifeCycle.State.PAUSING);
-        lc.transition(LifeCycle.State.PAUSED);
-      }
+    if (lc.getCurrentState() != LifeCycle.State.NEW) {
+      lc.transition(LifeCycle.State.PAUSING);
+      lc.transition(LifeCycle.State.PAUSED);
+    }
   }
 
   @Override

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMStateMachine.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMStateMachine.java
@@ -353,8 +353,11 @@ public class SCMStateMachine extends BaseStateMachine {
 
   @Override
   public void pause() {
-    getLifeCycle().transition(LifeCycle.State.PAUSING);
-    getLifeCycle().transition(LifeCycle.State.PAUSED);
+    final LifeCycle lc = getLifeCycle();
+      if (lc.getCurrentState() != LifeCycle.State.NEW) {
+        lc.transition(LifeCycle.State.PAUSING);
+        lc.transition(LifeCycle.State.PAUSED);
+      }
   }
 
   @Override

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestValidateBCSIDOnRestart.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestValidateBCSIDOnRestart.java
@@ -233,7 +233,7 @@ public class TestValidateBCSIDOnRestart {
     // in the and what is there in RockSDB and hence the container would be
     // marked unhealthy
     index = cluster.getHddsDatanodeIndex(dn.getDatanodeDetails());
-    cluster.restartHddsDatanode(dn.getDatanodeDetails(), false);
+    cluster.restartHddsDatanode(dn.getDatanodeDetails(), true);
     // Make sure the container is marked unhealthy
     Assert.assertTrue(
             cluster.getHddsDatanodes().get(index)

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/scm/TestSCMInstallSnapshotWithHA.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/scm/TestSCMInstallSnapshotWithHA.java
@@ -51,6 +51,7 @@ import org.apache.ratis.server.protocol.TermIndex;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.assertFalse;
 
+import org.apache.ratis.util.LifeCycle;
 import org.junit.Assert;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -273,7 +274,9 @@ public class TestSCMInstallSnapshotWithHA {
 
     Assert.assertTrue(logCapture.getOutput()
         .contains("Failed to reload SCM state and instantiate services."));
-    Assert.assertTrue(followerSM.getLifeCycleState().isPausingOrPaused());
+    final LifeCycle.State s = followerSM.getLifeCycleState();
+    Assert.assertTrue("Unexpected lifeCycle state: " + s,
+        s == LifeCycle.State.NEW || s.isPausingOrPaused());
 
     // Verify correct reloading
     followerSM.setInstallingDBCheckpoint(

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/OzoneManagerStateMachine.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/OzoneManagerStateMachine.java
@@ -391,8 +391,12 @@ public class OzoneManagerStateMachine extends BaseStateMachine {
     if (getLifeCycleState() == LifeCycle.State.PAUSED) {
       return;
     }
-    getLifeCycle().transition(LifeCycle.State.PAUSING);
-    getLifeCycle().transition(LifeCycle.State.PAUSED);
+    final LifeCycle lc = getLifeCycle();
+    if (lc.getCurrentState() != LifeCycle.State.NEW) {
+      getLifeCycle().transition(LifeCycle.State.PAUSING);
+      getLifeCycle().transition(LifeCycle.State.PAUSED);
+    }
+
     ozoneManagerDoubleBuffer.stop();
   }
 

--- a/pom.xml
+++ b/pom.xml
@@ -78,10 +78,10 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
     <declared.ozone.version>${ozone.version}</declared.ozone.version>
 
     <!-- Apache Ratis version -->
-    <ratis.version>2.4.0-SNAPSHOT</ratis.version>
+    <ratis.version>2.4.0</ratis.version>
 
     <!-- Apache Ratis thirdparty version -->
-    <ratis.thirdparty.version>1.0.0</ratis.thirdparty.version>
+    <ratis.thirdparty.version>1.0.2</ratis.thirdparty.version>
 
     <!-- Apache Ranger plugin version -->
     <ranger.version>2.3.0</ranger.version>

--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
     <repository>
       <id>ratis-240-rc2</id>
       <name>Apache Ratis 2.4.0 RC2</name>
-      <url>https://repository.apache.org/content/repositories/orgapacheratis-1118/</url>
+      <url>https://repository.apache.org/content/repositories/orgapacheratis-1127/</url>
     </repository>
   </repositories>
 

--- a/pom.xml
+++ b/pom.xml
@@ -49,9 +49,9 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
       <url>${distMgmtSnapshotsUrl}</url>
     </repository>
     <repository>
-      <id>ratis-240-rc2</id>
-      <name>Apache Ratis 2.4.0 RC2</name>
-      <url>https://repository.apache.org/content/repositories/orgapacheratis-1127/</url>
+      <id>ratis-240-rc5</id>
+      <name>Apache Ratis 2.4.0 RC5</name>
+      <url>https://repository.apache.org/content/repositories/orgapacheratis-1129/</url>
     </repository>
   </repositories>
 

--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
     <repository>
       <id>ratis-240-rc2</id>
       <name>Apache Ratis 2.4.0 RC2</name>
-      <url>https://repository.apache.org/content/repositories/orgapacheratis-1109/</url>
+      <url>https://repository.apache.org/content/repositories/orgapacheratis-1118/</url>
     </repository>
   </repositories>
 
@@ -78,10 +78,10 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
     <declared.ozone.version>${ozone.version}</declared.ozone.version>
 
     <!-- Apache Ratis version -->
-    <ratis.version>2.4.0</ratis.version>
+    <ratis.version>2.4.0-SNAPSHOT</ratis.version>
 
     <!-- Apache Ratis thirdparty version -->
-    <ratis.thirdparty.version>1.0.2</ratis.thirdparty.version>
+    <ratis.thirdparty.version>1.0.0</ratis.thirdparty.version>
 
     <!-- Apache Ranger plugin version -->
     <ranger.version>2.3.0</ranger.version>

--- a/pom.xml
+++ b/pom.xml
@@ -48,11 +48,6 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
       <name>${distMgmtSnapshotsName}</name>
       <url>${distMgmtSnapshotsUrl}</url>
     </repository>
-    <repository>
-      <id>ratis-240-rc5</id>
-      <name>Apache Ratis 2.4.0 RC5</name>
-      <url>https://repository.apache.org/content/repositories/orgapacheratis-1129/</url>
-    </repository>
   </repositories>
 
   <licenses>

--- a/pom.xml
+++ b/pom.xml
@@ -48,6 +48,11 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
       <name>${distMgmtSnapshotsName}</name>
       <url>${distMgmtSnapshotsUrl}</url>
     </repository>
+    <repository>
+      <id>ratis-240-rc1</id>
+      <name>Apache Ratis 2.4.0 RC1</name>
+      <url>https://repository.apache.org/content/repositories/orgapacheratis-1108/</url>
+    </repository>
   </repositories>
 
   <licenses>
@@ -73,10 +78,10 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
     <declared.ozone.version>${ozone.version}</declared.ozone.version>
 
     <!-- Apache Ratis version -->
-    <ratis.version>2.3.0</ratis.version>
+    <ratis.version>2.4.0</ratis.version>
 
     <!-- Apache Ratis thirdparty version -->
-    <ratis.thirdparty.version>1.0.0</ratis.thirdparty.version>
+    <ratis.thirdparty.version>1.0.2</ratis.thirdparty.version>
 
     <!-- Apache Ranger plugin version -->
     <ranger.version>2.3.0</ranger.version>

--- a/pom.xml
+++ b/pom.xml
@@ -49,9 +49,9 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
       <url>${distMgmtSnapshotsUrl}</url>
     </repository>
     <repository>
-      <id>ratis-240-rc1</id>
-      <name>Apache Ratis 2.4.0 RC1</name>
-      <url>https://repository.apache.org/content/repositories/orgapacheratis-1108/</url>
+      <id>ratis-240-rc2</id>
+      <name>Apache Ratis 2.4.0 RC2</name>
+      <url>https://repository.apache.org/content/repositories/orgapacheratis-1109/</url>
     </repository>
   </repositories>
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

We should update  Ratis to 2.4.0  to fix [gRPC memleak](https://github.com/grpc/grpc-java/pull/9415). 
After we update ratis to 2.4.0, we will  start release ozone 1.3.0.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-7149

## How was this patch tested?

UT had been update.
