### PR TITLE
HDDS-7352. OM logs are flooded with info loggings from AWSV4AuthValidator

### DIFF
--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/security/AWSV4AuthValidator.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/security/AWSV4AuthValidator.java
@@ -84,7 +84,9 @@ final class AWSV4AuthValidator {
     byte[] kRegion = sign(kDate, regionName);
     byte[] kService = sign(kRegion, serviceName);
     byte[] kSigning = sign(kService, "aws4_request");
-    LOG.info(Hex.encode(kSigning));
+    if (LOG.isDebugEnabled()) {
+      LOG.debug(Hex.encode(kSigning));
+    }
     return kSigning;
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?
`AWSV4AuthValidator.getSigningKey()` authenticates the user and logs the info for every request it validates. If we are sending a lot of requests through S3 Gateway, OM logs are flooded with the same message which makes it hard to debug.
Proposed solution is to change the LOG message type from info to debug.

You can reproduce it and check the logs as follows

from master in `compose/ozonesecure`
```
$ docker-compose up -d --scale datanode=3
$ docker-compose exec scm bash

bash-4.2$ kinit -kt /etc/security/keytabs/testuser.keytab testuser/scm@EXAMPLE.COM
bash-4.2$ ozone s3 getsecret
awsAccessKey=testuser/scm@EXAMPLE.COM
awsSecret=<key>
```

Copy the awsSecret key

```
bash-4.2$ exit

$ docker exec -it ozonesecure_s3g_1 bash

bash-4.2$ export AWS_ACCESS_KEY=testuser/scm@EXAMPLE.COM AWS_SECRET_KEY=<key>
bash-4.2$ ozone freon s3bg -t 10 -n 5000
bash-4.2$ exit
```

Check om logs

```
$ docker logs ozonesecure_om_1


2022-10-18 18:57:24,154 [IPC Server handler 97 on default port 9862] INFO security.AWSV4AuthValidator: d708c4a18a6f12e47ddb5528dcac1fa28653d949f460c1b841ffad02e7c9bae6
2022-10-18 18:57:24,155 [IPC Server handler 68 on default port 9862] INFO security.AWSV4AuthValidator: d708c4a18a6f12e47ddb5528dcac1fa28653d949f460c1b841ffad02e7c9bae6
2022-10-18 18:57:24,155 [IPC Server handler 48 on default port 9862] INFO security.AWSV4AuthValidator: d708c4a18a6f12e47ddb5528dcac1fa28653d949f460c1b841ffad02e7c9bae6
2022-10-18 18:57:24,155 [IPC Server handler 59 on default port 9862] INFO security.AWSV4AuthValidator: d708c4a18a6f12e47ddb5528dcac1fa28653d949f460c1b841ffad02e7c9bae6
2022-10-18 18:57:24,155 [IPC Server handler 84 on default port 9862] INFO security.AWSV4AuthValidator: d708c4a18a6f12e47ddb5528dcac1fa28653d949f460c1b841ffad02e7c9bae6
2022-10-18 18:57:24,155 [IPC Server handler 92 on default port 9862] INFO security.AWSV4AuthValidator: d708c4a18a6f12e47ddb5528dcac1fa28653d949f460c1b841ffad02e7c9bae6
2022-10-18 18:57:24,155 [IPC Server handler 48 on default port 9862] INFO security.AWSV4AuthValidator: d708c4a18a6f12e47ddb5528dcac1fa28653d949f460c1b841ffad02e7c9bae6
2022-10-18 18:57:24,155 [IPC Server handler 82 on default port 9862] INFO security.AWSV4AuthValidator: d708c4a18a6f12e47ddb5528dcac1fa28653d949f460c1b841ffad02e7c9bae6
2022-10-18 18:57:24,155 [IPC Server handler 59 on default port 9862] INFO security.AWSV4AuthValidator: d708c4a18a6f12e47ddb5528dcac1fa28653d949f460c1b841ffad02e7c9bae6
2022-10-18 18:57:24,155 [IPC Server handler 64 on default port 9862] INFO security.AWSV4AuthValidator: d708c4a18a6f12e47ddb5528dcac1fa28653d949f460c1b841ffad02e7c9bae6
2022-10-18 18:57:24,155 [IPC Server handler 18 on default port 9862] INFO security.AWSV4AuthValidator: d708c4a18a6f12e47ddb5528dcac1fa28653d949f460c1b841ffad02e7c9bae6
2022-10-18 18:57:24,156 [IPC Server handler 41 on default port 9862] INFO security.AWSV4AuthValidator: d708c4a18a6f12e47ddb5528dcac1fa28653d949f460c1b841ffad02e7c9bae6
2022-10-18 18:57:24,156 [IPC Server handler 0 on default port 9862] INFO security.AWSV4AuthValidator: d708c4a18a6f12e47ddb5528dcac1fa28653d949f460c1b841ffad02e7c9bae6
```

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-7352

## How was this patch tested?

This patch was tested manually in a docker cluster.
