### PR TITLE
HDDS-7349. Flaky integration test have memory leak for RatisDropwizardExports

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/HddsDatanodeService.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/HddsDatanodeService.java
@@ -213,7 +213,7 @@ public class HddsDatanodeService extends GenericCli implements ServicePlugin {
     serviceRuntimeInfo.setStartTime();
 
     RatisDropwizardExports.
-        registerRatisMetricReporters(ratisMetricsMap, isStopped);
+        registerRatisMetricReporters(ratisMetricsMap, () -> isStopped.get());
 
     OzoneConfiguration.activate();
     HddsServerUtil.initializeMetrics(conf, "HddsDatanode");

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/HddsDatanodeService.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/HddsDatanodeService.java
@@ -213,7 +213,7 @@ public class HddsDatanodeService extends GenericCli implements ServicePlugin {
     serviceRuntimeInfo.setStartTime();
 
     RatisDropwizardExports.
-        registerRatisMetricReporters(ratisMetricsMap);
+        registerRatisMetricReporters(ratisMetricsMap, isStopped);
 
     OzoneConfiguration.activate();
     HddsServerUtil.initializeMetrics(conf, "HddsDatanode");

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/server/http/RatisDropwizardExports.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/server/http/RatisDropwizardExports.java
@@ -22,7 +22,7 @@ import io.prometheus.client.Collector;
 import io.prometheus.client.CollectorRegistry;
 import io.prometheus.client.dropwizard.DropwizardExports;
 import io.prometheus.client.dropwizard.samplebuilder.DefaultSampleBuilder;
-import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.BooleanSupplier;
 import org.apache.ratis.metrics.MetricRegistries;
 import org.apache.ratis.metrics.MetricsReporting;
 import org.apache.ratis.metrics.RatisMetricRegistry;
@@ -45,14 +45,14 @@ public class RatisDropwizardExports extends DropwizardExports {
 
   public static void registerRatisMetricReporters(
       Map<String, RatisDropwizardExports> ratisMetricsMap,
-      AtomicBoolean isStopped) {
+      BooleanSupplier checkStopped) {
     //All the Ratis metrics (registered from now) will be published via JMX and
     //via the prometheus exporter (used by the /prom servlet
     MetricRegistries.global()
         .addReporterRegistration(MetricsReporting.jmxReporter(),
             MetricsReporting.stopJmxReporter());
     MetricRegistries.global().addReporterRegistration(
-        r1 -> registerDropwizard(r1, ratisMetricsMap, isStopped),
+        r1 -> registerDropwizard(r1, ratisMetricsMap, checkStopped),
         r2 -> deregisterDropwizard(r2, ratisMetricsMap));
   }
 
@@ -72,14 +72,14 @@ public class RatisDropwizardExports extends DropwizardExports {
 
   private static void registerDropwizard(RatisMetricRegistry registry,
       Map<String, RatisDropwizardExports> ratisMetricsMap,
-      AtomicBoolean isStopped) {
-    if (isStopped.get()) {
+      BooleanSupplier checkStopped) {
+    if (checkStopped.getAsBoolean()) {
       return;
     }
     
-    String name = registry.getMetricRegistryInfo().getName();
     RatisDropwizardExports rde = new RatisDropwizardExports(
         registry.getDropWizardMetricRegistry());
+    String name = registry.getMetricRegistryInfo().getName();
     if (null == ratisMetricsMap.putIfAbsent(name, rde)) {
       // new rde is added for the name, so need register
       CollectorRegistry.defaultRegistry.register(rde);

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/server/http/RatisDropwizardExports.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/server/http/RatisDropwizardExports.java
@@ -22,6 +22,7 @@ import io.prometheus.client.Collector;
 import io.prometheus.client.CollectorRegistry;
 import io.prometheus.client.dropwizard.DropwizardExports;
 import io.prometheus.client.dropwizard.samplebuilder.DefaultSampleBuilder;
+import java.util.concurrent.atomic.AtomicBoolean;
 import org.apache.ratis.metrics.MetricRegistries;
 import org.apache.ratis.metrics.MetricsReporting;
 import org.apache.ratis.metrics.RatisMetricRegistry;
@@ -43,14 +44,15 @@ public class RatisDropwizardExports extends DropwizardExports {
   }
 
   public static void registerRatisMetricReporters(
-      Map<String, RatisDropwizardExports> ratisMetricsMap) {
+      Map<String, RatisDropwizardExports> ratisMetricsMap,
+      AtomicBoolean isStopped) {
     //All the Ratis metrics (registered from now) will be published via JMX and
     //via the prometheus exporter (used by the /prom servlet
     MetricRegistries.global()
         .addReporterRegistration(MetricsReporting.jmxReporter(),
             MetricsReporting.stopJmxReporter());
     MetricRegistries.global().addReporterRegistration(
-        r1 -> registerDropwizard(r1, ratisMetricsMap),
+        r1 -> registerDropwizard(r1, ratisMetricsMap, isStopped),
         r2 -> deregisterDropwizard(r2, ratisMetricsMap));
   }
 
@@ -69,12 +71,19 @@ public class RatisDropwizardExports extends DropwizardExports {
   }
 
   private static void registerDropwizard(RatisMetricRegistry registry,
-      Map<String, RatisDropwizardExports> ratisMetricsMap) {
+      Map<String, RatisDropwizardExports> ratisMetricsMap,
+      AtomicBoolean isStopped) {
+    if (isStopped.get()) {
+      return;
+    }
+    
+    String name = registry.getMetricRegistryInfo().getName();
     RatisDropwizardExports rde = new RatisDropwizardExports(
         registry.getDropWizardMetricRegistry());
-    CollectorRegistry.defaultRegistry.register(rde);
-    String name = registry.getMetricRegistryInfo().getName();
-    ratisMetricsMap.putIfAbsent(name, rde);
+    if (null == ratisMetricsMap.putIfAbsent(name, rde)) {
+      // new rde is added for the name, so need register
+      CollectorRegistry.defaultRegistry.register(rde);
+    }
   }
 
   private static void deregisterDropwizard(RatisMetricRegistry registry,

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/StorageContainerManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/StorageContainerManager.java
@@ -587,7 +587,7 @@ public final class StorageContainerManager extends ServiceRuntimeInfoImpl
     }
     // This needs to be done before initializing Ratis.
     RatisDropwizardExports.registerRatisMetricReporters(ratisMetricsMap,
-        isStopped);
+        () -> isStopped.get());
     if (configurator.getSCMHAManager() != null) {
       scmHAManager = configurator.getSCMHAManager();
     } else {

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/StorageContainerManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/StorageContainerManager.java
@@ -28,6 +28,7 @@ import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.RemovalListener;
 import com.google.protobuf.BlockingService;
 
+import java.util.concurrent.atomic.AtomicBoolean;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hdds.HddsConfigKeys;
@@ -290,7 +291,8 @@ public final class StorageContainerManager extends ServiceRuntimeInfoImpl
   // Used to keep track of pending replication and pending deletes for
   // container replicas.
   private ContainerReplicaPendingOps containerReplicaPendingOps;
-
+  private final AtomicBoolean isStopped = new AtomicBoolean(false);
+  
   /**
    * Creates a new StorageContainerManager. Configuration will be
    * updated with information on the actual listening addresses used
@@ -584,7 +586,8 @@ public final class StorageContainerManager extends ServiceRuntimeInfoImpl
       clusterMap = new NetworkTopologyImpl(conf);
     }
     // This needs to be done before initializing Ratis.
-    RatisDropwizardExports.registerRatisMetricReporters(ratisMetricsMap);
+    RatisDropwizardExports.registerRatisMetricReporters(ratisMetricsMap,
+        isStopped);
     if (configurator.getSCMHAManager() != null) {
       scmHAManager = configurator.getSCMHAManager();
     } else {
@@ -1519,6 +1522,10 @@ public final class StorageContainerManager extends ServiceRuntimeInfoImpl
    */
   @Override
   public void stop() {
+    if (isStopped.getAndSet(true)) {
+      LOG.info("Storage Container Manager is not running.");
+      return;
+    }
     try {
       if (containerBalancer.isBalancerRunning()) {
         LOG.info("Stopping Container Balancer service.");

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
@@ -17,6 +17,7 @@
 
 package org.apache.hadoop.ozone.om;
 
+import java.util.concurrent.atomic.AtomicBoolean;
 import javax.management.ObjectName;
 import java.io.BufferedWriter;
 import java.io.File;
@@ -438,6 +439,7 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
   private static final int MSECS_PER_MINUTE = 60 * 1000;
 
   private final boolean isSecurityEnabled;
+  private final AtomicBoolean isStopped = new AtomicBoolean(false);
 
   @SuppressWarnings("methodlength")
   private OzoneManager(OzoneConfiguration conf, StartupOption startupOption)
@@ -1967,7 +1969,7 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
       if (omRatisServer == null) {
         // This needs to be done before initializing Ratis.
         RatisDropwizardExports.
-            registerRatisMetricReporters(ratisMetricsMap);
+            registerRatisMetricReporters(ratisMetricsMap, isStopped);
         omRatisServer = OzoneManagerRatisServer.newOMRatisServer(
             configuration, this, omNodeDetails, peerNodesMap,
             secConfig, certClient, shouldBootstrap);
@@ -2037,6 +2039,7 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
     }
     try {
       omState = State.STOPPED;
+      isStopped.set(true);
       // Cancel the metrics timer and set to null.
       if (metricsTimer != null) {
         metricsTimer.cancel();

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
@@ -17,7 +17,6 @@
 
 package org.apache.hadoop.ozone.om;
 
-import java.util.concurrent.atomic.AtomicBoolean;
 import javax.management.ObjectName;
 import java.io.BufferedWriter;
 import java.io.File;
@@ -439,7 +438,6 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
   private static final int MSECS_PER_MINUTE = 60 * 1000;
 
   private final boolean isSecurityEnabled;
-  private final AtomicBoolean isStopped = new AtomicBoolean(false);
 
   @SuppressWarnings("methodlength")
   private OzoneManager(OzoneConfiguration conf, StartupOption startupOption)
@@ -1969,7 +1967,7 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
       if (omRatisServer == null) {
         // This needs to be done before initializing Ratis.
         RatisDropwizardExports.
-            registerRatisMetricReporters(ratisMetricsMap, isStopped);
+            registerRatisMetricReporters(ratisMetricsMap, () -> isStopped());
         omRatisServer = OzoneManagerRatisServer.newOMRatisServer(
             configuration, this, omNodeDetails, peerNodesMap,
             secConfig, certClient, shouldBootstrap);
@@ -2039,7 +2037,6 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
     }
     try {
       omState = State.STOPPED;
-      isStopped.set(true);
       // Cancel the metrics timer and set to null.
       if (metricsTimer != null) {
         metricsTimer.cancel();


### PR DESCRIPTION
## What changes were proposed in this pull request?

1. Additional RatisDropwizardExports old by DNs after its closed
2. register of RatisDropwizardExports even its already present with name in ratisMetricsMap

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-7349

## How was this patch tested?

Tested with flaky and taking heapdump for objects of RatisDropwizardExports referred by DNs ratisMetricsMap. 
