### PR TITLE
HDDS-5704. Ozone URI syntax description in help content needs to mention about ozone service id

### DIFF
--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/Shell.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/Shell.java
@@ -38,7 +38,7 @@ public abstract class Shell extends GenericCli {
       "Service id provides a logical name for multiple hosts and it is  " +
       "defined in the property ozone.om.service.ids." +
       "Example of a full URI with host name and port number for a key:" +
-      "\no3://omhostname/vol1/bucket1/key1\n" +
+      "\no3://omhostname:9862/vol1/bucket1/key1\n" +
       "With a service id for a volume:" +
       "\no3://omserviceid/vol1/\n" +
       "Short URI should start from the volume.\n" +

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/Shell.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/Shell.java
@@ -31,19 +31,19 @@ public abstract class Shell extends GenericCli {
 
   public static final String OZONE_URI_DESCRIPTION = "Ozone URI could either " +
       "be a full URI or short URI.\n" +
-      "Full URI should start with o3:// followed by the OM host name or the " +
-      "service id and can optionally also contain the port number. " +
-      "Service id provides a logical name for multiple hosts. " +
-      "It is defined in ozone.om.service.ids and later resolved as an " +
-      "exact host through the property: " +
-      "ozone.om.address.<serviceID>.<nodeID>=host. " +
-      "Example of a full URI with host name for a key:" +
+      "Full URI should start with o3://, " +
+      "in case of non-HA clusters it should be followed by the host name " +
+      "and optionally the port number. " +
+      "In case of HA clusters the service id should be used. " +
+      "Service id provides a logical name for multiple hosts and it is  " +
+      "defined in the property ozone.om.service.ids." +
+      "Example of a full URI with host name and port number for a key:" +
       "\no3://omhostname/vol1/bucket1/key1\n" +
-      "With a service id and port number for a volume:" +
-      "\no3://omserviceid:9862/vol1/\n" +
+      "With a service id for a volume:" +
+      "\no3://omserviceid/vol1/\n" +
       "Short URI should start from the volume.\n" +
       "Example of a short URI for a bucket:\nvol1/bucket1\n" +
-      "Unspecified information will be identified from the config files.";
+      "Any unspecified information will be identified from the config files.";
 
   public Shell() {
   }

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/Shell.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/Shell.java
@@ -29,21 +29,22 @@ import org.apache.hadoop.ozone.om.exceptions.OMException;
  */
 public abstract class Shell extends GenericCli {
 
-  public static final String OZONE_URI_DESCRIPTION = "Ozone URI could either " +
-      "be a full URI or short URI.\n" +
-      "Full URI should start with o3://, " +
-      "in case of non-HA clusters it should be followed by the host name " +
-      "and optionally the port number. " +
-      "In case of HA clusters the service id should be used. " +
-      "Service id provides a logical name for multiple hosts and it is  " +
-      "defined in the property ozone.om.service.ids." +
-      "Example of a full URI with host name and port number for a key:" +
-      "\no3://omhostname:9862/vol1/bucket1/key1\n" +
-      "With a service id for a volume:" +
-      "\no3://omserviceid/vol1/\n" +
-      "Short URI should start from the volume.\n" +
-      "Example of a short URI for a bucket:\nvol1/bucket1\n" +
-      "Any unspecified information will be identified from the config files.";
+  public static final String OZONE_URI_DESCRIPTION =
+      "Ozone URI could either be a full URI or short URI.\n" +
+          "Full URI should start with o3://, in case of non-HA\nclusters it " +
+          "should be followed by the host name and\noptionally the port " +
+          "number. In case of HA clusters\nthe service id should be used. " +
+          "Service id provides a\nlogical name for multiple hosts and it is " +
+          "defined\nin the property ozone.om.service.ids.\n" +
+          "Example of a full URI with host name and port number\nfor a key:" +
+          "\no3://omhostname:9862/vol1/bucket1/key1\n" +
+          "With a service id for a volume:" +
+          "\no3://omserviceid/vol1/\n" +
+          "Short URI should start from the volume." +
+          "\nExample of a short URI for a bucket:" +
+          "\nvol1/bucket1\n" +
+          "Any unspecified information will be identified from\n" +
+          "the config files.\n";
 
   public Shell() {
   }

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/Shell.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/Shell.java
@@ -31,14 +31,19 @@ public abstract class Shell extends GenericCli {
 
   public static final String OZONE_URI_DESCRIPTION = "Ozone URI could either " +
       "be a full URI or short URI.\n" +
-      "Full URI should start with o3://serviceId/ " +
-      "and can optionally also contain " +
-      "the port number: o3://serviceId:9999/\n" +
-      "Example of a full URI for a key:\no3://om/vol1/bucket1/key1\n" +
-      "With port number for a volume:\no3://om:9862/vol1/\n" +
-      "Not specified information will be identified from the config files.\n" +
+      "Full URI should start with o3:// followed by the OM host name or the " +
+      "service id and can optionally also contain the port number. " +
+      "Service id provides a logical name for multiple hosts. " +
+      "It is defined in ozone.om.service.ids and later resolved as an " +
+      "exact host through the property: " +
+      "ozone.om.address.<serviceID>.<nodeID>=host. " +
+      "Example of a full URI with host name for a key:" +
+      "\no3://omhostname/vol1/bucket1/key1\n" +
+      "With a service id and port number for a volume:" +
+      "\no3://omserviceid:9862/vol1/\n" +
       "Short URI should start from the volume.\n" +
-      "Example of a short URI for a bucket:\nvol1/bucket1";
+      "Example of a short URI for a bucket:\nvol1/bucket1\n" +
+      "Unspecified information will be identified from the config files.";
 
   public Shell() {
   }

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/Shell.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/Shell.java
@@ -29,11 +29,16 @@ import org.apache.hadoop.ozone.om.exceptions.OMException;
  */
 public abstract class Shell extends GenericCli {
 
-  public static final String OZONE_URI_DESCRIPTION = "Ozone URI could start "
-      + "with o3:// or without prefix. URI may contain the host/serviceId "
-      + "and port of the OM server. Both are optional. "
-      + "If they are not specified it will be identified from "
-      + "the config files.";
+  public static final String OZONE_URI_DESCRIPTION = "Ozone URI could either " +
+      "be a full URI or short URI.\n" +
+      "Full URI should start with o3://serviceId/ " +
+      "and can optionally also contain " +
+      "the port number: o3://serviceId:9999/\n" +
+      "Example of a full URI for a key:\no3://om/vol1/bucket1/key1\n" +
+      "With port number for a volume:\no3://om:9862/vol1/\n" +
+      "Not specified information will be identified from the config files.\n" +
+      "Short URI should start from the volume.\n" +
+      "Example of a short URI for a bucket:\nvol1/bucket1";
 
   public Shell() {
   }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Updated the URI syntax description so that it contains examples of serviceId and port usage.

## What is the link to the Apache JIRA

[Improve the description of Ozone URI in Ozone Shell help message](https://issues.apache.org/jira/browse/HDDS-5704)

## How was this patch tested?

Running on a local docker cluster I've reproduced the message and also experimented on separate ways how the URIs can be used.
