### PR TITLE
HDDS-7363. Changes to Ozone CLI to validate if the jars in classpath files are present on an install

### DIFF
--- a/hadoop-ozone/dist/src/shell/ozone/ozone
+++ b/hadoop-ozone/dist/src/shell/ozone/ozone
@@ -95,7 +95,6 @@ function ozonecmd_case
     classpath)
       if [[ "$#" -gt 0 ]]; then
         OZONE_RUN_ARTIFACT_NAME="$1"
-        OZONE_VALIDATE_CLASSPATH="true"
         OZONE_CLASSNAME="org.apache.hadoop.util.Classpath"
         #remove the artifact name and replace it with glob
         # (We need at least one argument to execute the Classpath helper class)
@@ -117,7 +116,6 @@ function ozonecmd_case
       OZONE_DATANODE_OPTS="-Dlog4j2.contextSelector=org.apache.logging.log4j.core.async.AsyncLoggerContextSelector ${OZONE_DATANODE_OPTS}"
       OZONE_CLASSNAME=org.apache.hadoop.ozone.HddsDatanodeService
       OZONE_RUN_ARTIFACT_NAME="ozone-datanode"
-      OZONE_VALIDATE_CLASSPATH="true"
     ;;
     envvars)
       echo "JAVA_HOME='${JAVA_HOME}'"
@@ -148,7 +146,6 @@ function ozonecmd_case
       OZONE_OM_OPTS="${OZONE_OM_OPTS} -Dlog4j.configurationFile=${OZONE_CONF_DIR}/om-audit-log4j2.properties"
       OZONE_OM_OPTS="-Dlog4j2.contextSelector=org.apache.logging.log4j.core.async.AsyncLoggerContextSelector ${OZONE_OM_OPTS}"
       OZONE_RUN_ARTIFACT_NAME="ozone-manager"
-      OZONE_VALIDATE_CLASSPATH="true"
     ;;
     sh | shell)
       OZONE_CLASSNAME=org.apache.hadoop.ozone.shell.OzoneShell
@@ -168,14 +165,12 @@ function ozonecmd_case
       OZONE_SCM_OPTS="${OZONE_SCM_OPTS} -Dlog4j.configurationFile=${OZONE_CONF_DIR}/scm-audit-log4j2.properties"
       OZONE_SCM_OPTS="-Dlog4j2.contextSelector=org.apache.logging.log4j.core.async.AsyncLoggerContextSelector ${OZONE_SCM_OPTS}"
       OZONE_RUN_ARTIFACT_NAME="hdds-server-scm"
-      OZONE_VALIDATE_CLASSPATH="true"
     ;;
     s3g)
       OZONE_SUBCMD_SUPPORTDAEMONIZATION="true"
       OZONE_CLASSNAME='org.apache.hadoop.ozone.s3.Gateway'
       OZONE_S3G_OPTS="${OZONE_S3G_OPTS} -Dlog4j.configurationFile=${OZONE_CONF_DIR}/s3g-audit-log4j2.properties"
       OZONE_RUN_ARTIFACT_NAME="ozone-s3gateway"
-      OZONE_VALIDATE_CLASSPATH="true"
     ;;
     tenant)
       OZONE_CLASSNAME=org.apache.hadoop.ozone.shell.tenant.TenantShell
@@ -185,13 +180,11 @@ function ozonecmd_case
       OZONE_SUBCMD_SUPPORTDAEMONIZATION="true"
       OZONE_CLASSNAME='org.apache.hadoop.ozone.csi.CsiServer'
       OZONE_RUN_ARTIFACT_NAME="ozone-csi"
-      OZONE_VALIDATE_CLASSPATH="true"
     ;;
     recon)
       OZONE_SUBCMD_SUPPORTDAEMONIZATION="true"
       OZONE_CLASSNAME='org.apache.hadoop.ozone.recon.ReconServer'
       OZONE_RUN_ARTIFACT_NAME="ozone-recon"
-      OZONE_VALIDATE_CLASSPATH="true"
     ;;
     fs)
       OZONE_CLASSNAME=org.apache.hadoop.fs.ozone.OzoneFsShell

--- a/hadoop-ozone/dist/src/shell/ozone/ozone
+++ b/hadoop-ozone/dist/src/shell/ozone/ozone
@@ -94,6 +94,7 @@ function ozonecmd_case
     classpath)
       if [[ "$#" -gt 0 ]]; then
         OZONE_RUN_ARTIFACT_NAME="$1"
+        OZONE_VALIDATE_CLASSPATH="true"
         OZONE_CLASSNAME="org.apache.hadoop.util.Classpath"
         #remove the artifact name and replace it with glob
         # (We need at least one argument to execute the Classpath helper class)
@@ -115,6 +116,7 @@ function ozonecmd_case
       OZONE_DATANODE_OPTS="-Dlog4j2.contextSelector=org.apache.logging.log4j.core.async.AsyncLoggerContextSelector ${OZONE_DATANODE_OPTS}"
       OZONE_CLASSNAME=org.apache.hadoop.ozone.HddsDatanodeService
       OZONE_RUN_ARTIFACT_NAME="ozone-datanode"
+      OZONE_VALIDATE_CLASSPATH="true"
     ;;
     envvars)
       echo "JAVA_HOME='${JAVA_HOME}'"
@@ -145,6 +147,7 @@ function ozonecmd_case
       OZONE_OM_OPTS="${OZONE_OM_OPTS} -Dlog4j.configurationFile=${OZONE_CONF_DIR}/om-audit-log4j2.properties"
       OZONE_OM_OPTS="-Dlog4j2.contextSelector=org.apache.logging.log4j.core.async.AsyncLoggerContextSelector ${OZONE_OM_OPTS}"
       OZONE_RUN_ARTIFACT_NAME="ozone-manager"
+      OZONE_VALIDATE_CLASSPATH="true"
     ;;
     sh | shell)
       OZONE_CLASSNAME=org.apache.hadoop.ozone.shell.OzoneShell
@@ -164,12 +167,14 @@ function ozonecmd_case
       OZONE_SCM_OPTS="${OZONE_SCM_OPTS} -Dlog4j.configurationFile=${OZONE_CONF_DIR}/scm-audit-log4j2.properties"
       OZONE_SCM_OPTS="-Dlog4j2.contextSelector=org.apache.logging.log4j.core.async.AsyncLoggerContextSelector ${OZONE_SCM_OPTS}"
       OZONE_RUN_ARTIFACT_NAME="hdds-server-scm"
+      OZONE_VALIDATE_CLASSPATH="true"
     ;;
     s3g)
       OZONE_SUBCMD_SUPPORTDAEMONIZATION="true"
       OZONE_CLASSNAME='org.apache.hadoop.ozone.s3.Gateway'
       OZONE_S3G_OPTS="${OZONE_S3G_OPTS} -Dlog4j.configurationFile=${OZONE_CONF_DIR}/s3g-audit-log4j2.properties"
       OZONE_RUN_ARTIFACT_NAME="ozone-s3gateway"
+      OZONE_VALIDATE_CLASSPATH="true"
     ;;
     tenant)
       OZONE_CLASSNAME=org.apache.hadoop.ozone.shell.tenant.TenantShell
@@ -179,11 +184,13 @@ function ozonecmd_case
       OZONE_SUBCMD_SUPPORTDAEMONIZATION="true"
       OZONE_CLASSNAME='org.apache.hadoop.ozone.csi.CsiServer'
       OZONE_RUN_ARTIFACT_NAME="ozone-csi"
+      OZONE_VALIDATE_CLASSPATH="true"
     ;;
     recon)
       OZONE_SUBCMD_SUPPORTDAEMONIZATION="true"
       OZONE_CLASSNAME='org.apache.hadoop.ozone.recon.ReconServer'
       OZONE_RUN_ARTIFACT_NAME="ozone-recon"
+      OZONE_VALIDATE_CLASSPATH="true"
     ;;
     fs)
       OZONE_CLASSNAME=org.apache.hadoop.fs.ozone.OzoneFsShell
@@ -273,6 +280,14 @@ if declare -f ozone_subcommand_"${OZONE_SUBCMD}" >/dev/null 2>&1; then
   "ozone_subcommand_${OZONE_SUBCMD}" "${OZONE_SUBCMD_ARGS[@]}"
 else
   ozonecmd_case "${OZONE_SUBCMD}" "${OZONE_SUBCMD_ARGS[@]}"
+fi
+
+if [[ "${OZONE_VALIDATE_CLASSPATH}" == true ]]; then
+  if [[ "${OZONE_SUBCMD_SUPPORTDAEMONIZATION}" == true ]] && [[ "${OZONE_DAEMON_MODE}" =~ ^st(art|op|atus)$ ]]; then
+    validate_classpath "$1" "$2"
+  elif [[ "${OZONE_SUBCMD}" == classpath ]]; then
+    validate_classpath "$2" "$3"
+  fi
 fi
 
 ozone_assemble_classpath

--- a/hadoop-ozone/dist/src/shell/ozone/ozone
+++ b/hadoop-ozone/dist/src/shell/ozone/ozone
@@ -34,6 +34,7 @@ function ozone_usage
   ozone_add_option "--loglevel level" "set the log4j level for this command"
   ozone_add_option "--workers" "turn on worker mode"
   ozone_add_option "--jvmargs arguments" "append JVM options to any existing options defined in the OZONE_OPTS environment variable. Any defined in OZONE_CLIENT_OPTS will be append after these jvmargs"
+  ozone_add_option "--validate (continue)" "validates if all jars as indicated in the corresponding OZONE_RUN_ARTIFACT_NAME classpath file are present"
 
   ozone_add_subcommand "auditparser" client "runs audit parser tool"
   ozone_add_subcommand "classpath" client "prints the class path needed for running ozone commands"
@@ -282,12 +283,8 @@ else
   ozonecmd_case "${OZONE_SUBCMD}" "${OZONE_SUBCMD_ARGS[@]}"
 fi
 
-if [[ "${OZONE_VALIDATE_CLASSPATH}" == true ]]; then
-  if [[ "${OZONE_SUBCMD_SUPPORTDAEMONIZATION}" == true ]] && [[ "${OZONE_DAEMON_MODE}" =~ ^st(art|op|atus)$ ]]; then
-    validate_classpath "$1" "$2"
-  elif [[ "${OZONE_SUBCMD}" == classpath ]]; then
-    validate_classpath "$2" "$3"
-  fi
+if [[ "${OZONE_SUBCMD_SUPPORTDAEMONIZATION}" == true && "${OZONE_DAEMON_MODE}" =~ ^st(art|op|atus)$ ]] || [[ "${OZONE_SUBCMD}" == classpath ]]; then
+  ozone_validate_classpath
 fi
 
 ozone_assemble_classpath

--- a/hadoop-ozone/dist/src/shell/ozone/ozone
+++ b/hadoop-ozone/dist/src/shell/ozone/ozone
@@ -276,9 +276,7 @@ else
   ozonecmd_case "${OZONE_SUBCMD}" "${OZONE_SUBCMD_ARGS[@]}"
 fi
 
-if [[ "${OZONE_SUBCMD_SUPPORTDAEMONIZATION}" == true && "${OZONE_DAEMON_MODE}" =~ ^st(art|op|atus)$ ]] || [[ "${OZONE_SUBCMD}" == classpath ]]; then
-  ozone_validate_classpath
-fi
+ozone_validate_classpath
 
 ozone_assemble_classpath
 

--- a/hadoop-ozone/dist/src/shell/ozone/ozone
+++ b/hadoop-ozone/dist/src/shell/ozone/ozone
@@ -34,7 +34,7 @@ function ozone_usage
   ozone_add_option "--loglevel level" "set the log4j level for this command"
   ozone_add_option "--workers" "turn on worker mode"
   ozone_add_option "--jvmargs arguments" "append JVM options to any existing options defined in the OZONE_OPTS environment variable. Any defined in OZONE_CLIENT_OPTS will be append after these jvmargs"
-  ozone_add_option "--validate (continue)" "validates if all jars as indicated in the corresponding OZONE_RUN_ARTIFACT_NAME classpath file are present"
+  ozone_add_option "--validate (continue)" "validates if all jars as indicated in the corresponding OZONE_RUN_ARTIFACT_NAME classpath file are present, command execution shall continue post validation failure if 'continue' is passed"
 
   ozone_add_subcommand "auditparser" client "runs audit parser tool"
   ozone_add_subcommand "classpath" client "prints the class path needed for running ozone commands"

--- a/hadoop-ozone/dist/src/shell/ozone/ozone-functions.sh
+++ b/hadoop-ozone/dist/src/shell/ozone/ozone-functions.sh
@@ -2701,8 +2701,8 @@ function validate_classpath
 ## @replaceable yes
 function validate_classpath_util
 {
-  local FLAG_FAIL
-  FLAG_FAIL=1
+  local fail_on_missing
+  fail_on_missing=true
 
   if [ -n "$1" ]; then
     if [ "${OZONE_SUBCMD_SUPPORTDAEMONIZATION}" == false ]; then
@@ -2725,7 +2725,7 @@ function validate_classpath_util
         ;;
       --continue)
         echo "The command execution shall continue even if the validation fails."
-        FLAG_FAIL=0
+        fail_on_missing=false
         ;;
       *)
         echo "Invalid option '$1'. Use --help to see the valid options."
@@ -2746,20 +2746,20 @@ function validate_classpath_util
   OIFS=$IFS
   IFS=':'
 
-  local flag
-  flag=1
+  local found_missing_jars
+  found_missing_jars=false
   for jar in $classpath; do
     if [[ ! -e "$jar" ]]; then
-      flag=0
+      found_missing_jars=true
       echo "ERROR: Jar file $(realpath "$jar") is missing"
     fi
   done
 
   IFS=$OIFS
 
-  if [[ "$flag" == 0 ]] && [[ "$FLAG_FAIL" == 0 ]]; then
+  if [[ "$found_missing_jars" == true ]] && [[ "$fail_on_missing" == false ]]; then
     echo "Validation FAILED due to missing jar files! Continuing command execution..."
-  elif [[ "$flag" == 0 ]] && [[ "$FLAG_FAIL" == 1 ]]; then
+  elif [[ "$found_missing_jars" == true ]] && [[ "$fail_on_missing" == true ]]; then
     echo "Validation FAILED due to missing jar files!"
     exit 1
   else

--- a/hadoop-ozone/dist/src/shell/ozone/ozone-functions.sh
+++ b/hadoop-ozone/dist/src/shell/ozone/ozone-functions.sh
@@ -65,12 +65,14 @@ function ozone_validate_classpath
   [[ "${OZONE_SUBCMD_SUPPORTDAEMONIZATION}" == true && "${OZONE_DAEMON_MODE}" =~ ^st(art|op|atus)$ ]] &&
   OZONE_OPTION_DAEMON=true || OZONE_OPTION_DAEMON=false
 
-  if [[ "${OZONE_VALIDATE_CLASSPATH}" == true && ( ( "${OZONE_VALIDATE_FAIL_ON_MISSING_JARS}" == true &&
-        ( "${OZONE_OPTION_DAEMON}" == true || "${OZONE_SUBCMD}" == classpath ) ) ||
-        ( "${OZONE_VALIDATE_FAIL_ON_MISSING_JARS}" == false && "${OZONE_OPTION_DAEMON}" == true ) ) ]]; then
-    ozone_validate_classpath_util
-  else
-    ozone_validate_classpath_usage
+  if [[ "${OZONE_VALIDATE_CLASSPATH}" == true ]]; then
+    if [[ ( "${OZONE_VALIDATE_FAIL_ON_MISSING_JARS}" == true && ( "${OZONE_OPTION_DAEMON}" == true ||
+          "${OZONE_SUBCMD}" == classpath ) ) || ( "${OZONE_VALIDATE_FAIL_ON_MISSING_JARS}" == false &&
+          "${OZONE_OPTION_DAEMON}" == true ) ]]; then
+      ozone_validate_classpath_util
+    else
+      ozone_validate_classpath_usage
+    fi
   fi
 }
 

--- a/hadoop-ozone/dist/src/shell/ozone/ozone-functions.sh
+++ b/hadoop-ozone/dist/src/shell/ozone/ozone-functions.sh
@@ -2763,7 +2763,7 @@ function validate_classpath_util
     echo "Validation FAILED due to missing jar files!"
     exit 1
   else
-    echo "Validation SUCCESSFUL, all the required jars are present!"
+    echo "Validation SUCCESSFUL, all required jars are present!"
   fi
 }
 

--- a/hadoop-ozone/dist/src/shell/ozone/ozone-functions.sh
+++ b/hadoop-ozone/dist/src/shell/ozone/ozone-functions.sh
@@ -48,7 +48,8 @@ function ozone_debug
 ## @replaceable yes
 function ozone_validate_classpath
 {
-  if [[ "${OZONE_VALIDATE_CLASSPATH}" == true ]]; then
+  if [[ ( "${OZONE_VALIDATE_CLASSPATH}" == true && ( "${OZONE_SUBCMD_SUPPORTDAEMONIZATION}" == true &&
+        "${OZONE_DAEMON_MODE}" =~ ^st(art|op|atus)$ ) || ( "${OZONE_SUBCMD}" == classpath ) ) ]]; then
     ozone_validate_classpath_util
   fi
 }

--- a/hadoop-ozone/dist/src/shell/ozone/ozone-functions.sh
+++ b/hadoop-ozone/dist/src/shell/ozone/ozone-functions.sh
@@ -2535,9 +2535,10 @@ function ozone_parse_args
           shift
           ((OZONE_PARSE_COUNTER=OZONE_PARSE_COUNTER+2))
         else
+          help_text=$'The --validate flag validates if all jars as indicated in the corresponding OZONE_RUN_ARTIFACT_NAME classpath file are present\n\n'
           usage_text=$'Usage I: ozone --validate classpath <ARTIFACTNAME>\nUsage II: ozone --validate [OPTIONS] --daemon start|status|stop csi|datanode|om|recon|s3g|scm\n\n'
           option_description=$'  OPTIONS is none or any of:\n\ncontinue\tcommand execution shall continue even if validation fails'
-          ozone_error "${usage_text}${option_description}"
+          ozone_error "${help_text}${usage_text}${option_description}"
           exit 1
         fi
       ;;


### PR DESCRIPTION
## What changes were proposed in this pull request?

To make changes to the Ozone CLI for validating if each of the jars as listed in the Ozone classpath files are present in the indicated location or not. 

To introduce a `--validate` flag in the Ozone CLI:

```
The --validate flag validates if all jars as indicated in the corresponding OZONE_RUN_ARTIFACT_NAME classpath file are present

Usage I: ozone --validate classpath <ARTIFACTNAME>
Usage II: ozone --validate [OPTIONS] --daemon start|status|stop csi|datanode|om|recon|s3g|scm

  OPTIONS is none or any of:

continue        command execution shall continue even if validation fails
```

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-7363

## How was this patch tested?

Follow-up Task (to introduce Robot acceptance tests): https://issues.apache.org/jira/browse/HDDS-7373
