### PR TITLE
HDDS-7025. Add table cache metrics in OM.

### DIFF
--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/TableCacheMetrics.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/TableCacheMetrics.java
@@ -1,0 +1,92 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hdds.utils;
+
+import org.apache.hadoop.hdds.utils.db.cache.CacheStats;
+import org.apache.hadoop.hdds.utils.db.cache.TableCache;
+import org.apache.hadoop.metrics2.MetricsCollector;
+import org.apache.hadoop.metrics2.MetricsInfo;
+import org.apache.hadoop.metrics2.MetricsRecordBuilder;
+import org.apache.hadoop.metrics2.MetricsSource;
+import org.apache.hadoop.metrics2.MetricsSystem;
+import org.apache.hadoop.metrics2.lib.DefaultMetricsSystem;
+
+/**
+ * This class emits table level cache metrics.
+ */
+public final class TableCacheMetrics implements MetricsSource {
+  private enum MetricsInfos implements MetricsInfo {
+    TableName("Table Name."),
+    Size("Size of the cache."),
+    HitCount("Number of time the lookup methods return a cached value."),
+    MissCount("Number of times the requested value is not in the cache."),
+    IterationCount("Number of times the table cache is iterated through.");
+
+    private final String desc;
+
+    MetricsInfos(String desc) {
+      this.desc = desc;
+    }
+
+    @Override
+    public String description() {
+      return desc;
+    }
+  }
+
+  public static final String SOURCE_NAME =
+      TableCacheMetrics.class.getSimpleName();
+
+  private final TableCache<?, ?> cache;
+  private final String tableName;
+
+  private TableCacheMetrics(TableCache<?, ?> cache, String name) {
+    this.cache = cache;
+    this.tableName = name;
+  }
+
+  public static TableCacheMetrics create(TableCache<?, ?> cache,
+                                         String tableName) {
+    MetricsSystem ms = DefaultMetricsSystem.instance();
+    TableCacheMetrics tableMetrics = new TableCacheMetrics(cache, tableName);
+    return ms.register(tableMetrics.getSourceName(), "Table cache metrics",
+        tableMetrics);
+  }
+
+  private String getSourceName() {
+    return tableName + "Cache";
+  }
+
+  @Override
+  public void getMetrics(MetricsCollector collector, boolean all) {
+    MetricsRecordBuilder recordBuilder = collector.addRecord(SOURCE_NAME)
+        .setContext("Table cache metrics")
+        .tag(MetricsInfos.TableName, tableName);
+    CacheStats stats = cache.getStats();
+    recordBuilder
+        .addGauge(MetricsInfos.Size, cache.size())
+        .addGauge(MetricsInfos.HitCount, stats.getCacheHits())
+        .addGauge(MetricsInfos.MissCount, stats.getCacheMisses())
+        .addGauge(MetricsInfos.IterationCount, stats.getIterationTimes());
+  }
+
+  public void unregister() {
+    MetricsSystem ms = DefaultMetricsSystem.instance();
+    ms.unregisterSource(getSourceName());
+  }
+}

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/Table.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/Table.java
@@ -28,6 +28,7 @@ import java.util.Map;
 import org.apache.commons.lang3.NotImplementedException;
 import org.apache.hadoop.hdds.annotation.InterfaceStability;
 import org.apache.hadoop.hdds.utils.MetadataKeyFilters;
+import org.apache.hadoop.hdds.utils.TableCacheMetrics;
 import org.apache.hadoop.hdds.utils.db.cache.CacheKey;
 import org.apache.hadoop.hdds.utils.db.cache.CacheValue;
 /**
@@ -213,6 +214,13 @@ public interface Table<KEY, VALUE> extends AutoCloseable {
   default Iterator<Map.Entry<CacheKey<KEY>, CacheValue<VALUE>>>
       cacheIterator() {
     throw new NotImplementedException("cacheIterator is not implemented");
+  }
+
+  /**
+   * Create the metrics datasource that emits table cache metrics.
+   */
+  default TableCacheMetrics createCacheMetrics() throws IOException {
+    throw new NotImplementedException("getCacheValue is not implemented");
   }
 
   /**

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/TypedTable.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/TypedTable.java
@@ -28,6 +28,7 @@ import java.util.Map;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Optional;
 import org.apache.hadoop.hdds.utils.MetadataKeyFilters;
+import org.apache.hadoop.hdds.utils.TableCacheMetrics;
 import org.apache.hadoop.hdds.utils.db.cache.CacheKey;
 import org.apache.hadoop.hdds.utils.db.cache.CacheResult;
 import org.apache.hadoop.hdds.utils.db.cache.CacheValue;
@@ -320,6 +321,11 @@ public class TypedTable<KEY, VALUE> implements Table<KEY, VALUE> {
   @Override
   public Iterator<Map.Entry<CacheKey<KEY>, CacheValue<VALUE>>> cacheIterator() {
     return cache.iterator();
+  }
+
+  @Override
+  public TableCacheMetrics createCacheMetrics() throws IOException {
+    return TableCacheMetrics.create(cache, getName());
   }
 
   @Override

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/cache/CacheStats.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/cache/CacheStats.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hdds.utils.db.cache;
+
+/**
+ * Include cache stat counters.
+ */
+public class CacheStats {
+  private final long cacheHits;
+  private final long cacheMisses;
+  private final long iterationTimes;
+
+  public CacheStats(long cacheHits, long cacheMisses, long iterationTimes) {
+    this.cacheHits = cacheHits;
+    this.cacheMisses = cacheMisses;
+    this.iterationTimes = iterationTimes;
+  }
+
+  public long getCacheHits() {
+    return cacheHits;
+  }
+
+  public long getCacheMisses() {
+    return cacheMisses;
+  }
+
+  public long getIterationTimes() {
+    return iterationTimes;
+  }
+}

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/cache/CacheStatsRecorder.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/cache/CacheStatsRecorder.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hdds.utils.db.cache;
+
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ * Records cache stats.
+ */
+class CacheStatsRecorder {
+  private final AtomicLong cacheHits = new AtomicLong(0);
+  private final AtomicLong cacheMisses = new AtomicLong(0);
+  private final AtomicLong iterationTimes = new AtomicLong(0);
+
+  public void recordHit() {
+    cacheHits.incrementAndGet();
+  }
+
+  public void recordMiss() {
+    cacheMisses.incrementAndGet();
+  }
+
+  public void recordValue(CacheValue<?> value) {
+    if (value == null) {
+      recordMiss();
+    } else {
+      recordHit();
+    }
+  }
+
+  public void recordIteration() {
+    iterationTimes.incrementAndGet();
+  }
+
+  public CacheStats snapshot() {
+    return new CacheStats(
+        cacheHits.get(),
+        cacheMisses.get(),
+        iterationTimes.get()
+    );
+  }
+
+}

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/cache/TableCache.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/cache/TableCache.java
@@ -112,6 +112,12 @@ public interface TableCache<CACHEKEY extends CacheKey,
   NavigableMap<Long, Set<CACHEKEY>> getEpochEntries();
 
   /**
+   * Return the stat counters.
+   * @return
+   */
+  CacheStats getStats();
+
+  /**
    * Cache completeness.
    */
   enum CacheType {


### PR DESCRIPTION
## What changes were proposed in this pull request?

Create table cache metrics. Initially, only the cache size is included.

https://issues.apache.org/jira/browse/HDDS-7025

## How was this patch tested?

Standard CI.
Also local test to ensure expected metrics are emitted to Prometheus. 