### PR TITLE
HDDS-7369. Fix wrong order of command arguments in Nonrolling-Upgrade.md

### DIFF
--- a/hadoop-hdds/docs/content/feature/Nonrolling-Upgrade.md
+++ b/hadoop-hdds/docs/content/feature/Nonrolling-Upgrade.md
@@ -62,15 +62,15 @@ Starting with your current version of Ozone, complete the following steps to upg
 4. Start the components
     1. Start the SCM and datanodes as usual:
         ```
-        ozone --daemon scm start
+        ozone --daemon start scm
         ```
         ```
-        ozone --daemon datanode start
+        ozone --daemon start datanode
         ```
 
     2. Start the Ozone Manager using the `--upgrade` flag to take it out of prepare mode.
         ```
-        ozone --daemon om start --upgrade
+        ozone --daemon start om --upgrade
         ```
         - There also exists a `--downgrade` flag which is an alias of `--upgrade`. The name used does not matter.
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Found the following typos in Nonrolling-Upgrade.md:

**ozone --daemon scm start
ozone --daemon datanode start
ozone --daemon om start --upgrade**

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-7369

