### PR TITLE
HDDS-7370. Add pending commands in SCM to Datanode command count

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/CommandQueueReportHandler.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/CommandQueueReportHandler.java
@@ -44,6 +44,7 @@ public class CommandQueueReportHandler implements
     Preconditions.checkNotNull(dn, "QueueReport is "
         + "missing DatanodeDetails.");
     nodeManager.processNodeCommandQueueReport(dn,
-        queueReportFromDatanode.getReport());
+        queueReportFromDatanode.getReport(),
+        queueReportFromDatanode.getCommandsToBeSent());
   }
 }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/DatanodeInfo.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/DatanodeInfo.java
@@ -320,7 +320,7 @@ public class DatanodeInfo extends DatanodeDetails {
         // there is a command queued for. The DNs should return a count for all
         // command types even if they have a zero count, so this is really to
         // handle something being wrong on the DN where it sends a spare report.
-        // It really should never happe.
+        // It really should never happen.
         mutableCmds.remove(command);
         commandCounts.put(command, cmdCount);
       }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/DatanodeInfo.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/DatanodeInfo.java
@@ -286,11 +286,20 @@ public class DatanodeInfo extends DatanodeDetails {
    * Set the current command counts for this datanode, as reported in the last
    * heartbeat.
    * @param cmds Proto message containing a list of command count pairs.
+   * @param commandsToBeSent Summary of commands which will be sent to the DN
+   *                         as the heartbeat is processed and should be added
+   *                         to the command count.
    */
-  public void setCommandCounts(CommandQueueReportProto cmds) {
+  public void setCommandCounts(CommandQueueReportProto cmds,
+      Map<SCMCommandProto.Type, Integer> commandsToBeSent) {
     try {
       int count = cmds.getCommandCount();
+      Map<SCMCommandProto.Type, Integer> mutableCmds
+          = new HashMap<>(commandsToBeSent);
       lock.writeLock().lock();
+      // Purge the existing counts, as each report should completely replace
+      // the existing counts.
+      commandCounts.clear();
       for (int i = 0; i < count; i++) {
         SCMCommandProto.Type command = cmds.getCommand(i);
         if (command == SCMCommandProto.Type.unknownScmCommand) {
@@ -305,8 +314,19 @@ public class DatanodeInfo extends DatanodeDetails {
               "Setting it to zero", cmdCount, this);
           cmdCount = 0;
         }
+        cmdCount += mutableCmds.getOrDefault(command, 0);
+        // Each CommandType will be in the report once only. So we remove any
+        // we have seen, so we can add anything the DN has not reported but
+        // there is a command queued for. The DNs should return a count for all
+        // command types even if they have a zero count, so this is really to
+        // handle something being wrong on the DN where it sends a spare report.
+        // It really should never happe.
+        mutableCmds.remove(command);
         commandCounts.put(command, cmdCount);
       }
+      // Add any counts which the DN did not report. See comment above. This
+      // should not happen.
+      commandCounts.putAll(mutableCmds);
     } finally {
       lock.writeLock().unlock();
     }
@@ -322,12 +342,7 @@ public class DatanodeInfo extends DatanodeDetails {
   public int getCommandCount(SCMCommandProto.Type cmd) {
     try {
       lock.readLock().lock();
-      Integer count = commandCounts.get(cmd);
-      if (count == null) {
-        return -1;
-      } else {
-        return count.intValue();
-      }
+      return commandCounts.getOrDefault(cmd, -1);
     } finally {
       lock.readLock().unlock();
     }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/NodeManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/NodeManager.java
@@ -301,11 +301,15 @@ public interface NodeManager extends StorageContainerNodeProtocol,
   /**
    * Process the Command Queue Report sent from datanodes as part of the
    * heartbeat message.
-   * @param datanodeDetails
-   * @param commandReport
+   * @param datanodeDetails DatanodeDetails the report is from
+   * @param commandReport Command summary report from the DN when the heartbeat
+   *                      was created.
+   * @param commandsToBeSent Summary of command counts that will be sent to
+   *                         the Datanode as part of the current heartbeat
    */
   void processNodeCommandQueueReport(DatanodeDetails datanodeDetails,
-      CommandQueueReportProto commandReport);
+      CommandQueueReportProto commandReport,
+      Map<SCMCommandProto.Type, Integer> commandsToBeSent);
 
   /**
    * Get the number of commands of the given type queued on the datanode at the

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/SCMNodeManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/SCMNodeManager.java
@@ -698,10 +698,12 @@ public class SCMNodeManager implements NodeManager {
    *
    * @param datanodeDetails
    * @param commandQueueReportProto
+   * @param commandsToBeSent
    */
   @Override
   public void processNodeCommandQueueReport(DatanodeDetails datanodeDetails,
-      CommandQueueReportProto commandQueueReportProto) {
+      CommandQueueReportProto commandQueueReportProto,
+      Map<SCMCommandProto.Type, Integer> commandsToBeSent) {
     LOG.debug("Processing Command Queue Report from [datanode={}]",
         datanodeDetails.getHostName());
     if (LOG.isTraceEnabled()) {
@@ -712,7 +714,8 @@ public class SCMNodeManager implements NodeManager {
     try {
       DatanodeInfo datanodeInfo = nodeStateManager.getNode(datanodeDetails);
       if (commandQueueReportProto != null) {
-        datanodeInfo.setCommandCounts(commandQueueReportProto);
+        datanodeInfo.setCommandCounts(commandQueueReportProto,
+            commandsToBeSent);
         metrics.incNumNodeCommandQueueReportProcessed();
       }
     } catch (NodeNotFoundException e) {

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMDatanodeHeartbeatDispatcher.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMDatanodeHeartbeatDispatcher.java
@@ -25,6 +25,7 @@ import org.apache.hadoop.hdds.protocol.proto
 import org.apache.hadoop.hdds.protocol.proto
     .StorageContainerDatanodeProtocolProtos.IncrementalContainerReportProto;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.LayoutVersionProto;
+import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.SCMCommandProto;
 import org.apache.hadoop.hdds.protocol.proto
     .StorageContainerDatanodeProtocolProtos.PipelineReportsProto;
 import org.apache.hadoop.hdds.protocol.proto
@@ -48,7 +49,9 @@ import com.google.protobuf.Message;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 
 import static org.apache.hadoop.hdds.scm.events.SCMEvents.CONTAINER_ACTIONS;
@@ -136,9 +139,14 @@ public final class SCMDatanodeHeartbeatDispatcher {
 
       if (heartbeat.hasCommandQueueReport()) {
         LOG.debug("Dispatching Queued Command Report");
+        Map<SCMCommandProto.Type, Integer> cmdSummary = new HashMap<>();
+        for (SCMCommand<?> c : commands) {
+          cmdSummary.put(c.getType(),
+              cmdSummary.getOrDefault(c.getType(), 0) + 1);
+        }
         eventPublisher.fireEvent(COMMAND_QUEUE_REPORT,
             new CommandQueueReportFromDatanode(datanodeDetails,
-                heartbeat.getCommandQueueReport()));
+                heartbeat.getCommandQueueReport(), cmdSummary));
       }
 
       if (heartbeat.hasContainerReport()) {
@@ -247,9 +255,17 @@ public final class SCMDatanodeHeartbeatDispatcher {
    */
   public static class CommandQueueReportFromDatanode
       extends ReportFromDatanode<CommandQueueReportProto> {
+
+    private final Map<SCMCommandProto.Type, Integer> commandsToBeSent;
     public CommandQueueReportFromDatanode(DatanodeDetails datanodeDetails,
-                                          CommandQueueReportProto report) {
+        CommandQueueReportProto report,
+        Map<SCMCommandProto.Type, Integer> commandsToBeSent) {
       super(datanodeDetails, report);
+      this.commandsToBeSent = commandsToBeSent;
+    }
+
+    public Map<SCMCommandProto.Type, Integer> getCommandsToBeSent() {
+      return commandsToBeSent;
     }
   }
 

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/MockNodeManager.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/MockNodeManager.java
@@ -595,10 +595,12 @@ public class MockNodeManager implements NodeManager {
    * heartbeat message.
    * @param datanodeDetails
    * @param commandReport
+   * @param commandsToBeSent
    */
   @Override
   public void processNodeCommandQueueReport(DatanodeDetails datanodeDetails,
-      CommandQueueReportProto commandReport) {
+      CommandQueueReportProto commandReport,
+      Map<SCMCommandProto.Type, Integer> commandsToBeSent) {
     // do nothing.
   }
 

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/SimpleMockNodeManager.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/SimpleMockNodeManager.java
@@ -293,7 +293,8 @@ public class SimpleMockNodeManager implements NodeManager {
 
   @Override
   public void processNodeCommandQueueReport(DatanodeDetails datanodeDetails,
-      CommandQueueReportProto commandReport) {
+      CommandQueueReportProto commandReport,
+      Map<SCMCommandProto.Type, Integer> commandsToBeSent) {
   }
 
   /**

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/node/TestSCMNodeManager.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/node/TestSCMNodeManager.java
@@ -23,6 +23,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Set;
 import java.util.UUID;
@@ -962,16 +963,36 @@ public class TestSCMNodeManager {
         HddsTestUtils.createRandomDatanodeAndRegister(nodeManager);
     verify(eventPublisher,
         times(1)).fireEvent(NEW_NODE, node1);
+    Map<SCMCommandProto.Type, Integer> commandsToBeSent = new HashMap<>();
+    commandsToBeSent.put(SCMCommandProto.Type.replicateContainerCommand, 3);
+    commandsToBeSent.put(SCMCommandProto.Type.deleteBlocksCommand, 5);
+
     nodeManager.processNodeCommandQueueReport(node1,
         CommandQueueReportProto.newBuilder()
             .addCommand(SCMCommandProto.Type.replicateContainerCommand)
             .addCount(123)
             .addCommand(SCMCommandProto.Type.closeContainerCommand)
             .addCount(11)
-            .build());
+            .build(),
+        commandsToBeSent);
     assertEquals(-1, nodeManager.getNodeQueuedCommandCount(
         node1, SCMCommandProto.Type.closePipelineCommand));
-    assertEquals(123, nodeManager.getNodeQueuedCommandCount(
+    assertEquals(126, nodeManager.getNodeQueuedCommandCount(
+        node1, SCMCommandProto.Type.replicateContainerCommand));
+    assertEquals(11, nodeManager.getNodeQueuedCommandCount(
+        node1, SCMCommandProto.Type.closeContainerCommand));
+    assertEquals(5, nodeManager.getNodeQueuedCommandCount(
+        node1, SCMCommandProto.Type.deleteBlocksCommand));
+
+    // Send another report missing an earlier entry, and ensure it is not
+    // still reported as a stale value.
+    nodeManager.processNodeCommandQueueReport(node1,
+        CommandQueueReportProto.newBuilder()
+            .addCommand(SCMCommandProto.Type.closeContainerCommand)
+            .addCount(11)
+            .build(),
+        Collections.emptyMap());
+    assertEquals(-1, nodeManager.getNodeQueuedCommandCount(
         node1, SCMCommandProto.Type.replicateContainerCommand));
     assertEquals(11, nodeManager.getNodeQueuedCommandCount(
         node1, SCMCommandProto.Type.closeContainerCommand));

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/ozone/container/testutils/ReplicationNodeManagerMock.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/ozone/container/testutils/ReplicationNodeManagerMock.java
@@ -434,7 +434,8 @@ public class ReplicationNodeManagerMock implements NodeManager {
 
   @Override
   public void processNodeCommandQueueReport(DatanodeDetails datanodeDetails,
-      CommandQueueReportProto commandReport) {
+      CommandQueueReportProto commandReport,
+      Map<SCMCommandProto.Type, Integer> commandsToBeSent) {
     // Do nothing.
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

In [HDDS-6567](https://issues.apache.org/jira/browse/HDDS-6567), we stored the datanode queued command counts into DatanodeInfo on each heartbeat. However, we did not consider the commands that were queued to goto the Datanode on that heartbeat. The real count, is the count queued on the DNs, plus the commands queued in SCM we are about to send to the DN over the heartbeat being processed.

This Jira adds the "commands ready to send" count to the stored counts to give a better reflection on the current queued count on the DN.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-7370

## How was this patch tested?

Adapted existing tests
