### PR TITLE
HDDS-7323. Recon: Auto refresh toggle is switched back when visiting new site

### DIFF
--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/components/autoReloadPanel/autoReloadPanel.tsx
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/components/autoReloadPanel/autoReloadPanel.tsx
@@ -31,16 +31,20 @@ interface IAutoReloadPanelProps extends RouteComponentProps<object> {
   lastUpdatedOMDBFull: number;
   isLoading: boolean;
   togglePolling: (isEnabled: boolean) => void;
+  toggleChecking: (isEnabled: boolean) => void;
+  toggleCheck: boolean;
 }
 
 class AutoReloadPanel extends React.Component<IAutoReloadPanelProps> {
   autoReloadToggleHandler = (checked: boolean, _event: Event) => {
-    const {togglePolling} = this.props;
+    const {togglePolling, toggleChecking} = this.props;
     togglePolling(checked);
+    toggleChecking(checked);
   };
 
   render() {
     const {onReload, lastRefreshed, lastUpdatedOMDBDelta, lastUpdatedOMDBFull, isLoading} = this.props;
+    const toggleCheck = sessionStorage.getItem('toggleCheck') === 'false' ? false : true;
     
      const lastRefreshedText = lastRefreshed === 0 || lastRefreshed === undefined ? 'NA' :
       (
@@ -79,7 +83,7 @@ class AutoReloadPanel extends React.Component<IAutoReloadPanelProps> {
     return (
       <div className='auto-reload-panel'>
         Auto Refresh
-        &nbsp;<Switch defaultChecked size='small' className='toggle-switch' onChange={this.autoReloadToggleHandler}/>
+        &nbsp;<Switch defaultChecked={toggleCheck} size='small' className='toggle-switch' onChange={this.autoReloadToggleHandler}/>
         &nbsp; | Refreshed at {lastRefreshedText}
         &nbsp;<Button shape='circle' icon='reload' size='small' loading={isLoading} onClick={onReload}/>
         {lastUpdatedDeltaFullText}

--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/utils/autoReloadHelper.tsx
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/utils/autoReloadHelper.tsx
@@ -49,6 +49,10 @@ class AutoReloadHelper {
       this.stopPolling();
     }
   };
+
+  toggleChecking = (checked: boolean) => {
+    sessionStorage.setItem('toggleCheck', JSON.stringify(checked));
+  };
 }
 
 export {AutoReloadHelper};

--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/views/datanodes/datanodes.tsx
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/views/datanodes/datanodes.tsx
@@ -416,6 +416,7 @@ export class Datanodes extends React.Component<Record<string, object>, IDatanode
             isLoading={loading}
             lastUpdated={lastUpdated}
             togglePolling={this.autoReload.handleAutoReloadToggle}
+            toggleChecking={this.autoReload.toggleChecking}
             onReload={this._loadData}
           />
         </div>

--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/views/overview/overview.tsx
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/views/overview/overview.tsx
@@ -159,8 +159,9 @@ export class Overview extends React.Component<Record<string, object>, IOverviewS
         <div className='page-header'>
           Overview
           <AutoReloadPanel isLoading={loading} lastRefreshed={lastRefreshed}
-          lastUpdatedOMDBDelta={lastUpdatedOMDBDelta} lastUpdatedOMDBFull={lastUpdatedOMDBFull}
-          togglePolling={this.autoReload.handleAutoReloadToggle} onReload={this._loadData}/>
+            lastUpdatedOMDBDelta={lastUpdatedOMDBDelta} lastUpdatedOMDBFull={lastUpdatedOMDBFull}
+            togglePolling={this.autoReload.handleAutoReloadToggle} toggleChecking={this.autoReload.toggleChecking}
+            onReload={this._loadData}/>
         </div>
         <Row gutter={[25, 25]}>
           <Col xs={24} sm={18} md={12} lg={12} xl={6}>

--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/views/pipelines/pipelines.tsx
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/views/pipelines/pipelines.tsx
@@ -226,7 +226,7 @@ export class Pipelines extends React.Component<Record<string, object>, IPipeline
       <div className='pipelines-container'>
         <div className='page-header'>
           Pipelines ({activeTotalCount})
-          <AutoReloadPanel isLoading={activeLoading} lastUpdated={lastUpdated} togglePolling={this.autoReload.handleAutoReloadToggle} onReload={this._loadData}/>
+          <AutoReloadPanel isLoading={activeLoading} lastUpdated={lastUpdated} toggleChecking={this.autoReload.toggleChecking} togglePolling={this.autoReload.handleAutoReloadToggle} onReload={this._loadData}/>
         </div>
         <div className='content-div'>
           <Tabs defaultActiveKey='1' onChange={this.onTabChange}>


### PR DESCRIPTION
What changes were proposed in this pull request?
Auto Reload toggle on and off should be in sync with Datanode, Pipeline and Overview Page.

What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-7323

## How was this patch tested?
Manually