### PR TITLE
HDDS-7368. [Multi-Tenant] Add Volume Existence check in preExecute for OMTenantCreateRequest.

### DIFF
--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/tenant/OMTenantCreateRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/tenant/OMTenantCreateRequest.java
@@ -152,6 +152,17 @@ public class OMTenantCreateRequest extends OMVolumeRequest {
     final String volumeName = request.getVolumeName();
     // Validate volume name
     OmUtils.validateVolumeName(volumeName);
+
+    final String dbVolumeKey = ozoneManager.getMetadataManager()
+        .getVolumeKey(volumeName);
+
+    // Check volume existence
+    if (ozoneManager.getMetadataManager().getVolumeTable()
+        .isExist(dbVolumeKey)) {
+      LOG.debug("volume: '{}' already exists", volumeName);
+      throw new OMException("Volume already exists", VOLUME_ALREADY_EXISTS);
+    }
+
     // TODO: Refactor this and OMVolumeCreateRequest to improve maintainability.
     final VolumeInfo volumeInfo = VolumeInfo.newBuilder()
         .setVolume(volumeName)


### PR DESCRIPTION
## What changes were proposed in this pull request?

For tenant create request, if the volume already exists it creates empty default Ranger policies as the check happens in validateAndUpdateCache. Even though Ranger Background sync thread deletes these policies later, it would be better to avoid creating these policies.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-7368

## How was this patch tested?

Existing Unit Tests.
