### PR TITLE
HDDS-1202. Detection and Removal of Orphan Chunks at the Container Level

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/helpers/ContainerUtils.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/helpers/ContainerUtils.java
@@ -23,6 +23,7 @@ import static org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.Res
 import static org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.Result.NO_SUCH_ALGORITHM;
 import static org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.Result.CLOSED_CONTAINER_IO;
 import static org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.Result.CONTAINER_NOT_OPEN;
+import static org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.Result.UNABLE_TO_FIND_DATA_DIR;
 import static org.apache.hadoop.hdds.scm.protocolPB.ContainerCommandResponseBuilders.getContainerCommandResponse;
 import static org.apache.hadoop.ozone.container.common.impl.ContainerData.CHARSET_ENCODING;
 
@@ -240,6 +241,27 @@ public final class ContainerUtils {
     String containerFilePath = OzoneConsts.CONTAINER_META_PATH + File.separator
         + getContainerID(containerBaseDir) + OzoneConsts.CONTAINER_EXTENSION;
     return new File(containerBaseDir, containerFilePath);
+  }
+
+  public static File getChunkDir(ContainerData containerData)
+      throws StorageContainerException {
+    Preconditions.checkNotNull(containerData, "Container data can't be null");
+
+    String chunksPath = containerData.getChunksPath();
+    if (chunksPath == null) {
+      LOG.error("Chunks path is null in the container data");
+      throw new StorageContainerException("Unable to get Chunks directory.",
+          UNABLE_TO_FIND_DATA_DIR);
+    }
+
+    File chunksDir = new File(chunksPath);
+    if (!chunksDir.exists()) {
+      LOG.error("Chunks dir {} does not exist", chunksDir.getAbsolutePath());
+      throw new StorageContainerException("Chunks directory " +
+          chunksDir.getAbsolutePath() + " does not exist.",
+          UNABLE_TO_FIND_DATA_DIR);
+    }
+    return chunksDir;
   }
 
   /**

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/impl/ContainerLayoutVersion.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/impl/ContainerLayoutVersion.java
@@ -27,9 +27,8 @@ import org.apache.hadoop.hdds.scm.ScmConfigKeys;
 import org.apache.hadoop.hdds.scm.container.common.helpers.StorageContainerException;
 import org.apache.hadoop.ozone.container.common.helpers.ChunkInfo;
 
-import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
-import static org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.Result.UNABLE_TO_FIND_DATA_DIR;
+import org.apache.hadoop.ozone.container.common.helpers.ContainerUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -123,34 +122,13 @@ public enum ContainerLayoutVersion {
 
   public File getChunkFile(ContainerData containerData, BlockID blockID,
       ChunkInfo info) throws StorageContainerException {
-    File chunkDir = getChunkDir(containerData);
+    File chunkDir = ContainerUtils.getChunkDir(containerData);
     return getChunkFile(chunkDir, blockID, info);
   }
 
   @Override
   public String toString() {
     return "ContainerLayout:v" + version;
-  }
-
-  private static File getChunkDir(ContainerData containerData)
-      throws StorageContainerException {
-    Preconditions.checkNotNull(containerData, "Container data can't be null");
-
-    String chunksPath = containerData.getChunksPath();
-    if (chunksPath == null) {
-      LOG.error("Chunks path is null in the container data");
-      throw new StorageContainerException("Unable to get Chunks directory.",
-          UNABLE_TO_FIND_DATA_DIR);
-    }
-
-    File chunksDir = new File(chunksPath);
-    if (!chunksDir.exists()) {
-      LOG.error("Chunks dir {} does not exist", chunksDir.getAbsolutePath());
-      throw new StorageContainerException("Chunks directory " +
-          chunksDir.getAbsolutePath() + " does not exist.",
-          UNABLE_TO_FIND_DATA_DIR);
-    }
-    return chunksDir;
   }
 
 }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/interfaces/Container.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/interfaces/Container.java
@@ -36,6 +36,7 @@ import org.apache.hadoop.hdfs.util.DataTransferThrottler;
 import org.apache.hadoop.hdfs.util.RwLock;
 import org.apache.hadoop.ozone.container.common.impl.ContainerData;
 import org.apache.hadoop.ozone.container.common.volume.VolumeSet;
+import org.apache.hadoop.ozone.container.ozoneimpl.ContainerController;
 
 /**
  * Interface for Container Operations.
@@ -178,8 +179,12 @@ public interface Container<CONTAINERDATA extends ContainerData> extends RwLock {
    *                  perform I/O bandwidth throttling
    * @param canceler  A reference of {@link Canceler} used to cancel the
    *                  I/O bandwidth throttling (e.g. for shutdown purpose).
+   * @param controller A reference of {@link ContainerController} used to
+   *                   handle orphan chunks
+   *
    * @return true if the checksum verification succeeds
    *         false otherwise
    */
-  boolean scanData(DataTransferThrottler throttler, Canceler canceler);
+  boolean scanData(DataTransferThrottler throttler, Canceler canceler,
+      ContainerController controller);
 }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/interfaces/Handler.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/interfaces/Handler.java
@@ -18,9 +18,11 @@
 
 package org.apache.hadoop.ozone.container.common.interfaces;
 
+import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.util.Set;
 
 import org.apache.hadoop.hdds.conf.ConfigurationSource;
 import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos;
@@ -189,6 +191,16 @@ public abstract class Handler {
    * @throws IOException
    */
   public abstract void deleteBlock(Container container, BlockData blockData)
+      throws IOException;
+
+  /**
+   * Deletes the given orphan files in the container.
+   *
+   * @param container container whose orphan chunk is to be deleted
+   * @param files     files to be deleted
+   * @throws IOException
+   */
+  public abstract void deleteOrphanChunks(Container container, Set<File> files)
       throws IOException;
 
   public void setClusterID(String clusterID) {

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/KeyValueContainer.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/KeyValueContainer.java
@@ -56,6 +56,7 @@ import org.apache.hadoop.ozone.container.common.volume.VolumeSet;
 import org.apache.hadoop.ozone.container.keyvalue.helpers.BlockUtils;
 import org.apache.hadoop.ozone.container.keyvalue.helpers.KeyValueContainerLocationUtil;
 import org.apache.hadoop.ozone.container.keyvalue.helpers.KeyValueContainerUtil;
+import org.apache.hadoop.ozone.container.ozoneimpl.ContainerController;
 import org.apache.hadoop.ozone.container.upgrade.VersionedDatanodeFeatures;
 import org.apache.hadoop.util.DiskChecker.DiskOutOfSpaceException;
 
@@ -825,10 +826,8 @@ public class KeyValueContainer implements Container<KeyValueContainerData> {
 
   @Override
   public boolean scanMetaData() {
-    long containerId = containerData.getContainerID();
     KeyValueContainerCheck checker =
-        new KeyValueContainerCheck(containerData.getMetadataPath(), config,
-            containerId, containerData.getVolume(), this);
+        new KeyValueContainerCheck(this, config, null);
     return checker.fastCheck();
   }
 
@@ -839,17 +838,16 @@ public class KeyValueContainer implements Container<KeyValueContainerData> {
   }
 
   @Override
-  public boolean scanData(DataTransferThrottler throttler, Canceler canceler) {
+  public boolean scanData(DataTransferThrottler throttler, Canceler canceler,
+      ContainerController controller) {
     if (!shouldScanData()) {
       throw new IllegalStateException("The checksum verification can not be" +
           " done for container in state "
           + containerData.getState());
     }
 
-    long containerId = containerData.getContainerID();
-    KeyValueContainerCheck checker =
-        new KeyValueContainerCheck(containerData.getMetadataPath(), config,
-            containerId, containerData.getVolume(), this);
+    KeyValueContainerCheck checker = new KeyValueContainerCheck(this, config,
+        controller);
 
     return checker.fullCheck(throttler, canceler);
   }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/ozoneimpl/AbstractContainerGarbageCollector.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/ozoneimpl/AbstractContainerGarbageCollector.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.apache.hadoop.ozone.container.ozoneimpl;
+
+import org.apache.hadoop.ozone.container.common.interfaces.Container;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Set;
+
+/**
+ * The collector of orphan files(garbage) in the container chunk directory.
+ * It should be executed after container full scan, then the garbage would be
+ * deleted here.
+ */
+public abstract class AbstractContainerGarbageCollector {
+
+  /**
+   * Collect the garbage files with the container info.
+   *
+   * @param container container where garbage is found
+   * @param files     garbage files to be deleted
+   * @throws IOException
+   */
+  public abstract void collectGarbage(Container container, Set<File> files)
+      throws IOException;
+
+  /**
+   * Check container state before delete.
+   *
+   * @param container container where garbage is found
+   * @return to delete or not
+   */
+  public abstract boolean isDeletionAllowed(Container container);
+
+}

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/ozoneimpl/ContainerController.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/ozoneimpl/ContainerController.java
@@ -33,6 +33,7 @@ import org.apache.hadoop.ozone.container.keyvalue.TarContainerPacker;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -180,6 +181,20 @@ public class ContainerController {
     final Container container = containerSet.getContainer(containerId);
     if (container != null) {
       getHandler(container).deleteContainer(container, force);
+    }
+  }
+
+  /**
+   * Deletes the given orphan chunks in the certain container.
+   * @param containerId Id of the container
+   * @param chunks      the set of orphan chunk files
+   * @throws IOException
+   */
+  public void deleteOrphanChunks(final long containerId, Set<File> chunks)
+      throws IOException {
+    final Container container = containerSet.getContainer(containerId);
+    if (container != null) {
+      getHandler(container).deleteOrphanChunks(container, chunks);
     }
   }
 

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/ozoneimpl/ContainerDataScanner.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/ozoneimpl/ContainerDataScanner.java
@@ -67,7 +67,7 @@ public class ContainerDataScanner extends AbstractContainerScanner {
     ContainerData containerData = c.getContainerData();
     long containerId = containerData.getContainerID();
     logScanStart(containerData);
-    if (!c.scanData(throttler, canceler)) {
+    if (!c.scanData(throttler, canceler, controller)) {
       metrics.incNumUnHealthyContainers();
       controller.markContainerUnhealthy(containerId);
     } else {

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/ozoneimpl/ContainerGarbageCollectorConfiguration.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/ozoneimpl/ContainerGarbageCollectorConfiguration.java
@@ -1,0 +1,90 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.apache.hadoop.ozone.container.ozoneimpl;
+
+import org.apache.hadoop.hdds.conf.Config;
+import org.apache.hadoop.hdds.conf.ConfigGroup;
+import org.apache.hadoop.hdds.conf.ConfigTag;
+import org.apache.hadoop.hdds.conf.ConfigType;
+import org.apache.hadoop.hdds.conf.PostConstruct;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.time.Duration;
+
+/**
+ * This class defines configuration parameters for the container garbage
+ *  collector.
+ **/
+@ConfigGroup(prefix = "hdds.container.garbage")
+public class ContainerGarbageCollectorConfiguration {
+
+  private static final Logger LOG =
+      LoggerFactory.getLogger(ContainerGarbageCollectorConfiguration.class);
+
+  // only for log
+  public static final String HDDS_CONTAINER_GARBAGE_REMOVE_ENABLED =
+      "hdds.container.garbage.remove.enabled";
+  public static final String HDDS_CONTAINER_GARBAGE_RETAIN_INTERVAL =
+      "hdds.container.garbage.retain.interval";
+
+  public static final long DATA_ORPHAN_RETAIN_INTERVAL_DEFAULT =
+      Duration.ofDays(1).toMillis();
+
+  @Config(key = "remove.enabled",
+      type = ConfigType.BOOLEAN,
+      defaultValue = "false",
+      tags = {ConfigTag.STORAGE},
+      description = "Config parameter to enable container scanner.")
+  private boolean enabled = false;
+
+  @Config(key = "retain.interval",
+      type = ConfigType.TIME,
+      defaultValue = "1d",
+      tags = {ConfigTag.STORAGE},
+      description = "Minimum time interval before the detected orphan block" +
+          " can be deleted since its last modified time. " +
+          " Unit could be defined with postfix (ns,ms,s,m,h,d).")
+  private long retainInterval = DATA_ORPHAN_RETAIN_INTERVAL_DEFAULT;
+
+  @PostConstruct
+  public void validate() {
+    if (retainInterval < 0) {
+      LOG.warn(DATA_ORPHAN_RETAIN_INTERVAL_DEFAULT +
+              " must be >= 0 and was set to {}. Defaulting to {}",
+          retainInterval, DATA_ORPHAN_RETAIN_INTERVAL_DEFAULT);
+      retainInterval = DATA_ORPHAN_RETAIN_INTERVAL_DEFAULT;
+    }
+  }
+
+  public void setEnabled(boolean enabled) {
+    this.enabled = enabled;
+  }
+
+  public boolean isRemoveEnabled() {
+    return enabled;
+  }
+
+  public void setRetainInterval(long retainInterval) {
+    this.retainInterval = retainInterval;
+  }
+
+  public long getRetainInterval() {
+    return retainInterval;
+  }
+}

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/ozoneimpl/SimpleContainerGarbageCollector.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/ozoneimpl/SimpleContainerGarbageCollector.java
@@ -1,0 +1,103 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.apache.hadoop.ozone.container.ozoneimpl;
+
+import com.google.common.annotations.VisibleForTesting;
+import org.apache.hadoop.fs.FileUtil;
+import org.apache.hadoop.hdds.conf.ConfigurationSource;
+import org.apache.hadoop.ozone.container.common.helpers.ContainerUtils;
+import org.apache.hadoop.ozone.container.common.interfaces.Container;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ * The simple Impl of garbage collector.
+ * Executed after full scan of container by each volume thread.
+ */
+public class SimpleContainerGarbageCollector extends
+    AbstractContainerGarbageCollector {
+
+  public static final Logger LOG =
+      LoggerFactory.getLogger(SimpleContainerGarbageCollector.class);
+
+  private final long retain;
+  private final AtomicLong totalDeleted;
+  
+  public SimpleContainerGarbageCollector(ConfigurationSource conf) {
+    ContainerGarbageCollectorConfiguration cgcConf = conf.
+        getObject(ContainerGarbageCollectorConfiguration.class);
+    this.retain = cgcConf.getRetainInterval();
+    this.totalDeleted = new AtomicLong(0);
+  }
+
+  @Override
+  public void collectGarbage(Container container, Set<File> files)
+      throws IOException {
+    removeGarbage(container, files);
+  }
+
+  private void removeGarbage(Container container, Set<File> files)
+      throws IOException {
+    if (!isDeletionAllowed(container)) {
+      return;
+    }
+    File chunkDir = ContainerUtils.getChunkDir(container.getContainerData());
+    long containerId = container.getContainerData().getContainerID();
+    for (File f: files) {
+      if (!f.exists()) {
+        LOG.warn("Garbage file {} is already deleted", f);
+        continue;
+      }
+      if (!f.getParentFile().equals(chunkDir)) {
+        LOG.warn("Garbage file {} is not in the expected container {}",
+            f, containerId);
+        continue;
+      }
+      // precautionary check to avoid deleting the file in the process
+      long elapsed = System.currentTimeMillis() - f.lastModified();
+      if (elapsed > retain) {
+        long minutes = millisecondToMinute(elapsed);
+        FileUtil.fullyDelete(f);
+        totalDeleted.incrementAndGet();
+        LOG.info("Garbage file {} in container {} is deleted, elapsed {} " +
+            "minutes since last modified.", f, containerId, minutes);
+      }
+    }
+  }
+
+  @Override
+  public boolean isDeletionAllowed(Container container) {
+    return container.getContainerData().isClosed();
+  }
+
+  private long millisecondToMinute(long millis) {
+    return TimeUnit.MILLISECONDS.toMinutes(millis);
+  }
+
+  @VisibleForTesting
+  public long getTotalDeleted() {
+    return totalDeleted.get();
+  }
+}

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/TestKeyValueContainerCheck.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/TestKeyValueContainerCheck.java
@@ -21,23 +21,39 @@ package org.apache.hadoop.ozone.container.keyvalue;
 import org.apache.hadoop.hdds.client.BlockID;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos;
+import org.apache.hadoop.hdds.utils.db.Table;
 import org.apache.hadoop.hdfs.util.DataTransferThrottler;
 import org.apache.hadoop.ozone.container.common.helpers.BlockData;
 import org.apache.hadoop.ozone.container.common.helpers.ChunkInfo;
+import org.apache.hadoop.ozone.container.common.helpers.ContainerUtils;
+import org.apache.hadoop.ozone.container.common.impl.ContainerLayoutVersion;
+import org.apache.hadoop.ozone.container.common.impl.ContainerSet;
 import org.apache.hadoop.ozone.container.common.interfaces.BlockIterator;
 import org.apache.hadoop.ozone.container.common.interfaces.DBHandle;
 import org.apache.hadoop.ozone.container.keyvalue.helpers.BlockUtils;
 import org.apache.hadoop.ozone.container.keyvalue.helpers.KeyValueContainerLocationUtil;
+import org.apache.hadoop.ozone.container.ozoneimpl.ContainerController;
 import org.apache.hadoop.ozone.container.ozoneimpl.ContainerScannerConfiguration;
+import org.apache.ratis.util.TimeDuration;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
 import java.io.File;
+import java.io.IOException;
 import java.io.RandomAccessFile;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
 
+import static java.util.Collections.singletonMap;
+import static org.apache.hadoop.ozone.container.ozoneimpl.ContainerGarbageCollectorConfiguration.HDDS_CONTAINER_GARBAGE_REMOVE_ENABLED;
+import static org.apache.hadoop.ozone.container.ozoneimpl.ContainerGarbageCollectorConfiguration.HDDS_CONTAINER_GARBAGE_RETAIN_INTERVAL;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 
@@ -67,11 +83,9 @@ public class TestKeyValueContainerCheck
     // test Closed Container
     KeyValueContainer container = createContainerWithBlocks(containerID,
         normalBlocks, deletedBlocks);
-    KeyValueContainerData containerData = container.getContainerData();
 
     KeyValueContainerCheck kvCheck =
-        new KeyValueContainerCheck(containerData.getMetadataPath(), conf,
-            containerID, containerData.getVolume(), container);
+        new KeyValueContainerCheck(container, conf, null);
 
     // first run checks on a Open Container
     boolean valid = kvCheck.fastCheck();
@@ -105,8 +119,7 @@ public class TestKeyValueContainerCheck
     container.close();
 
     KeyValueContainerCheck kvCheck =
-        new KeyValueContainerCheck(containerData.getMetadataPath(), conf,
-            containerID, containerData.getVolume(), container);
+        new KeyValueContainerCheck(container, conf, null);
 
     File dbFile = KeyValueContainerLocationUtil
         .getContainerDBFile(containerData);
@@ -138,5 +151,109 @@ public class TestKeyValueContainerCheck
     valid = kvCheck.fullCheck(new DataTransferThrottler(
             sc.getBandwidthPerVolume()), null);
     assertFalse(valid);
+  }
+
+  @Test
+  public void testKeyValueContainerCheckWithOrphanBlocks() throws Exception {
+    long containerID = 103;
+    int deletedBlocks = 1;
+    int normalBlocks = 5;
+    int numOrphanBlocks = 2;
+    OzoneConfiguration conf = getConf();
+    ContainerScannerConfiguration sc = conf.getObject(
+        ContainerScannerConfiguration.class);
+    conf.setBoolean(HDDS_CONTAINER_GARBAGE_REMOVE_ENABLED, true);
+    conf.setLong(HDDS_CONTAINER_GARBAGE_RETAIN_INTERVAL,
+        TimeDuration.ONE_DAY.toLong(TimeUnit.MILLISECONDS));
+
+    // test Closed Container
+    KeyValueContainer container = createContainerWithBlocks(containerID,
+        normalBlocks, deletedBlocks);
+    KeyValueContainerData containerData = container.getContainerData();
+
+    container.close();
+
+    ContainerSet containerSet = new ContainerSet(1000);
+    containerSet.addContainer(container);
+    ContainerController controller = new ContainerController(containerSet,
+        singletonMap(ContainerProtos.ContainerType.KeyValueContainer,
+            new KeyValueHandler(conf, UUID.randomUUID().toString(),
+                containerSet,  getVolumeSet(), null, null)));
+
+    KeyValueContainerCheck kvCheck =
+        new KeyValueContainerCheck(container, conf, controller);
+
+    File dbFile = KeyValueContainerLocationUtil
+        .getContainerDBFile(containerData);
+    containerData.setDbFile(dbFile);
+
+    ContainerLayoutVersion layoutVersion = containerData.getLayoutVersion();
+    // Remove DB record, so the chunks will be unreferenced/orphan
+    Set<File> orphanChunks = new HashSet<>();
+    try (DBHandle metadataStore = BlockUtils.getDB(containerData, conf)) {
+      for (int i = 0; i < numOrphanBlocks; i++) {
+        BlockID blockID = new BlockID(containerID, i);
+        String key = containerData.blockKey(blockID.getLocalID());
+        Table<String, BlockData> table = metadataStore.getStore().
+            getBlockDataTable();
+        orphanChunks.addAll(table.get(key).getChunks().stream()
+            .map(chunk -> {
+              try {
+                return ChunkInfo.getFromProtoBuf(chunk);
+              } catch (IOException ex) {
+                throw new RuntimeException(ex);
+              }
+            })
+            .map(chunkInfo -> {
+              try {
+                return layoutVersion.getChunkFile(containerData, blockID,
+                    chunkInfo);
+              } catch (IOException ex) {
+                throw new RuntimeException(ex);
+              }
+            })
+            .collect(Collectors.toList()));
+        table.delete(key);
+      }
+    }
+
+    // check if orphan chunk num matches
+    int numExpectedOrphanChunks = getChunkLayout().getVersion() == 1 ?
+        CHUNKS_PER_BLOCK * numOrphanBlocks : numOrphanBlocks;
+    assertEquals(numExpectedOrphanChunks, orphanChunks.size());
+
+    File[] totalFiles = ContainerUtils.getChunkDir(containerData).listFiles();
+    assertNotNull(totalFiles);
+    int numTotalChunksBefore = totalFiles.length;
+
+    // check file existence and adjust the last modified time
+    for (File orphan: orphanChunks) {
+      assertTrue(orphan.exists());
+      if (!orphan.setLastModified(System.currentTimeMillis() -
+          2 * TimeDuration.ONE_DAY.toLong(TimeUnit.MILLISECONDS))) {
+        throw new IOException("Set LastModified failed for " + orphan);
+      }
+    }
+
+    // metadata check should pass.
+    boolean valid = kvCheck.fastCheck();
+    assertTrue(valid);
+
+    // checksum validation should pass.
+    valid = kvCheck.fullCheck(new DataTransferThrottler(
+        sc.getBandwidthPerVolume()), null);
+    assertTrue(valid);
+
+    // the full check should remove the unreferenced blocks
+    for (File chunk: orphanChunks) {
+      assertFalse(chunk.exists());
+    }
+
+    // make sure the valid chunks not deleted
+    totalFiles = ContainerUtils.getChunkDir(containerData).listFiles();
+    assertNotNull(totalFiles);
+    int numTotalChunksAfter = totalFiles.length;
+    assertEquals(numTotalChunksBefore, numTotalChunksAfter +
+        orphanChunks.size());
   }
 }

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/TestKeyValueContainerIntegrityChecks.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/TestKeyValueContainerIntegrityChecks.java
@@ -116,6 +116,9 @@ public class TestKeyValueContainerIntegrityChecks {
     return conf;
   }
 
+  public MutableVolumeSet getVolumeSet() {
+    return volumeSet;
+  }
 
   /**
    * Creates a container with normal and deleted blocks.

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/ozoneimpl/TestContainerScannerMetrics.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/ozoneimpl/TestContainerScannerMetrics.java
@@ -156,8 +156,8 @@ public class TestContainerScannerMetrics {
     when(c.getContainerData()).thenReturn(data);
     when(c.shouldScanData()).thenReturn(shouldScanData);
     when(c.scanMetaData()).thenReturn(scanMetaDataSuccess);
-    when(c.scanData(any(DataTransferThrottler.class), any(Canceler.class)))
-        .thenReturn(scanDataSuccess);
+    when(c.scanData(any(DataTransferThrottler.class), any(Canceler.class),
+        any(ContainerController.class))).thenReturn(scanDataSuccess);
   }
 
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

1. add detection of unreferenced chunks in full data scan
2. add contanierGarbageCollector in **KeyValueHandler** to collect and remove the orphan files
3. move the function **getChunkDir** from **ContainerLayoutVersion** to **ContainerUtils**

This aims to solve the case B in 
https://docs.google.com/document/d/1Oi1zPKdmvA7DFwIcUWz6zw_p-pY3D1L76gyV37jQT94/edit#

Currently, there is no report of such orphan chunk info forward to Recon/SCM. We directly delete them serially after a full data scan with a few checks to avoid possible accidents. Maybe we could add a recon to imply this info and add a button to trigger the removal.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-1202

## How was this patch tested?
1. Created a POC test and tested deleting the orphan blocks created by EC write.
2. UT