### PR TITLE
HDDS-7396. Force close non-RATIS containers in ReplicationManager

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/health/ClosingContainerHandler.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/health/ClosingContainerHandler.java
@@ -51,10 +51,13 @@ public class ClosingContainerHandler extends AbstractCheck {
       return false;
     }
 
+    boolean forceClose = request.getContainerInfo().getReplicationConfig()
+        .getReplicationType() != HddsProtos.ReplicationType.RATIS;
+
     for (ContainerReplica replica : request.getContainerReplicas()) {
       if (replica.getState() != ContainerReplicaProto.State.UNHEALTHY) {
         replicationManager.sendCloseContainerReplicaCommand(
-            containerInfo, replica.getDatanodeDetails(), false);
+            containerInfo, replica.getDatanodeDetails(), forceClose);
       }
     }
     return true;

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/health/TestClosingContainerHandler.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/health/TestClosingContainerHandler.java
@@ -213,29 +213,6 @@ public class TestClosingContainerHandler {
         .forEach(f -> Assertions.assertEquals(force, f));
   }
 
-  @Test
-  public void testOpenOrClosingRatisReplicasAreClosed() {
-    ContainerInfo containerInfo = ReplicationTestUtil.createContainerInfo(
-        RATIS_REPLICATION_CONFIG, 1, CLOSING);
-    Set<ContainerReplica> containerReplicas = ReplicationTestUtil
-        .createReplicas(containerInfo.containerID(),
-            ContainerReplicaProto.State.CLOSING, 0, 0);
-    containerReplicas.add(ReplicationTestUtil.createContainerReplica(
-        containerInfo.containerID(), 0,
-        HddsProtos.NodeOperationalState.IN_SERVICE,
-        ContainerReplicaProto.State.OPEN));
-
-    ContainerCheckRequest request = new ContainerCheckRequest.Builder()
-        .setPendingOps(Collections.EMPTY_LIST)
-        .setReport(new ReplicationManagerReport())
-        .setContainerInfo(containerInfo)
-        .setContainerReplicas(containerReplicas)
-        .build();
-
-    assertAndVerify(request, true, 3);
-  }
-
-
   private void assertAndVerify(ContainerCheckRequest request,
       boolean assertion, int times) {
     Assertions.assertEquals(assertion, closingContainerHandler.handle(request));

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/health/TestClosingContainerHandler.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/health/TestClosingContainerHandler.java
@@ -53,9 +53,9 @@ import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationType.R
 public class TestClosingContainerHandler {
   private ReplicationManager replicationManager;
   private ClosingContainerHandler closingContainerHandler;
-  private static final ECReplicationConfig ecReplicationConfig =
+  private static final ECReplicationConfig EC_REPLICATION_CONFIG =
       new ECReplicationConfig(3, 2);
-  private static final RatisReplicationConfig ratisReplicationConfig =
+  private static final RatisReplicationConfig RATIS_REPLICATION_CONFIG =
       RatisReplicationConfig.getInstance(HddsProtos.ReplicationFactor.THREE);
 
   @BeforeEach
@@ -65,7 +65,7 @@ public class TestClosingContainerHandler {
   }
 
   private static Stream<ReplicationConfig> replicationConfigs() {
-    return Stream.of(ratisReplicationConfig, ecReplicationConfig);
+    return Stream.of(RATIS_REPLICATION_CONFIG, EC_REPLICATION_CONFIG);
   }
 
   /**
@@ -76,7 +76,7 @@ public class TestClosingContainerHandler {
   @Test
   public void testNonClosingContainerReturnsFalse() {
     ContainerInfo containerInfo = ReplicationTestUtil.createContainerInfo(
-        ecReplicationConfig, 1, CLOSED);
+        EC_REPLICATION_CONFIG, 1, CLOSED);
     Set<ContainerReplica> containerReplicas = ReplicationTestUtil
         .createReplicas(containerInfo.containerID(),
             ContainerReplicaProto.State.CLOSING, 1, 2, 3, 4, 5);
@@ -94,7 +94,7 @@ public class TestClosingContainerHandler {
   @Test
   public void testNonClosingRatisContainerReturnsFalse() {
     ContainerInfo containerInfo = ReplicationTestUtil.createContainerInfo(
-        ratisReplicationConfig, 1, CLOSED);
+        RATIS_REPLICATION_CONFIG, 1, CLOSED);
     Set<ContainerReplica> containerReplicas = ReplicationTestUtil
         .createReplicas(containerInfo.containerID(),
             ContainerReplicaProto.State.CLOSING, 0, 0, 0);
@@ -117,7 +117,7 @@ public class TestClosingContainerHandler {
   @Test
   public void testUnhealthyReplicaIsNotClosed() {
     ContainerInfo containerInfo = ReplicationTestUtil.createContainerInfo(
-        ecReplicationConfig, 1, CLOSING);
+        EC_REPLICATION_CONFIG, 1, CLOSING);
     Set<ContainerReplica> containerReplicas = ReplicationTestUtil
         .createReplicas(containerInfo.containerID(),
             ContainerReplicaProto.State.UNHEALTHY, 1, 2, 3, 4);
@@ -140,7 +140,7 @@ public class TestClosingContainerHandler {
   @Test
   public void testUnhealthyRatisReplicaIsNotClosed() {
     ContainerInfo containerInfo = ReplicationTestUtil.createContainerInfo(
-        ratisReplicationConfig, 1, CLOSING);
+        RATIS_REPLICATION_CONFIG, 1, CLOSING);
     Set<ContainerReplica> containerReplicas = ReplicationTestUtil
         .createReplicas(containerInfo.containerID(),
             ContainerReplicaProto.State.UNHEALTHY, 0, 0);
@@ -176,7 +176,7 @@ public class TestClosingContainerHandler {
     Set<ContainerReplica> containerReplicas = new HashSet<>();
 
     // Add CLOSING container replicas with index [1, closing]
-    for (int i = 1; i <= closing; i++ ) {
+    for (int i = 1; i <= closing; i++) {
       containerReplicas.add(ReplicationTestUtil.createContainerReplica(
           containerInfo.containerID(), i,
           HddsProtos.NodeOperationalState.IN_SERVICE,
@@ -184,7 +184,7 @@ public class TestClosingContainerHandler {
     }
 
     // Add OPEN container replicas with index [closing + 1, replicas]
-    for (int i = closing + 1; i <= replicas; i++ ) {
+    for (int i = closing + 1; i <= replicas; i++) {
       containerReplicas.add(ReplicationTestUtil.createContainerReplica(
           containerInfo.containerID(), i,
           HddsProtos.NodeOperationalState.IN_SERVICE,
@@ -211,7 +211,7 @@ public class TestClosingContainerHandler {
   @Test
   public void testOpenOrClosingRatisReplicasAreClosed() {
     ContainerInfo containerInfo = ReplicationTestUtil.createContainerInfo(
-        ratisReplicationConfig, 1, CLOSING);
+        RATIS_REPLICATION_CONFIG, 1, CLOSING);
     Set<ContainerReplica> containerReplicas = ReplicationTestUtil
         .createReplicas(containerInfo.containerID(),
             ContainerReplicaProto.State.CLOSING, 0, 0);

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/health/TestClosingContainerHandler.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/health/TestClosingContainerHandler.java
@@ -171,7 +171,7 @@ public class TestClosingContainerHandler {
         repConfig, 1, CLOSING);
 
     final int replicas = repConfig.getRequiredNodes();
-    final int closing = replicas / 2 + 1;
+    final int closing = replicas / 2;
     final boolean force = repConfig.getReplicationType() != RATIS;
 
     Set<ContainerReplica> containerReplicas = new HashSet<>();

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/health/TestClosingContainerHandler.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/health/TestClosingContainerHandler.java
@@ -45,6 +45,7 @@ import java.util.stream.Stream;
 
 import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.LifeCycleState.CLOSED;
 import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.LifeCycleState.CLOSING;
+import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationType.EC;
 import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationType.RATIS;
 
 /**
@@ -175,18 +176,22 @@ public class TestClosingContainerHandler {
 
     Set<ContainerReplica> containerReplicas = new HashSet<>();
 
-    // Add CLOSING container replicas with index [1, closing]
+    // Add CLOSING container replicas.
+    // For EC, replica index will be in [1, closing].
     for (int i = 1; i <= closing; i++) {
       containerReplicas.add(ReplicationTestUtil.createContainerReplica(
-          containerInfo.containerID(), i,
+          containerInfo.containerID(),
+          repConfig.getReplicationType() == EC ? i : 0,
           HddsProtos.NodeOperationalState.IN_SERVICE,
           ContainerReplicaProto.State.CLOSING));
     }
 
-    // Add OPEN container replicas with index [closing + 1, replicas]
+    // Add OPEN container replicas.
+    // For EC, replica index will be in [closing + 1, replicas].
     for (int i = closing + 1; i <= replicas; i++) {
       containerReplicas.add(ReplicationTestUtil.createContainerReplica(
-          containerInfo.containerID(), i,
+          containerInfo.containerID(),
+          repConfig.getReplicationType() == EC ? i : 0,
           HddsProtos.NodeOperationalState.IN_SERVICE,
           ContainerReplicaProto.State.OPEN));
     }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Force close non-RATIS containers in ReplicationManager.

https://github.com/apache/ozone/blob/965d31cde91ba7c9973beb9e082f7c0e492e18a8/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/CloseContainerCommandHandler.java#L106-L113

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-7396

## How was this patch tested?

TestClosingContainerHandler#testOpenOrClosingReplicasAreClosed