### PR TITLE
HDDS-7394. OM RPC FairCallQueue decay decision metrics list caller username in the metric

### DIFF
--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/server/http/PrometheusMetricsSink.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/server/http/PrometheusMetricsSink.java
@@ -65,16 +65,15 @@ public class PrometheusMetricsSink implements MetricsSink {
 
         String metricName = DecayRpcSchedulerUtil
             .splitMetricNameIfNeeded(metricsRecord.name(), metrics.name());
+        // If there is no username this should be null
+        String username = DecayRpcSchedulerUtil
+            .checkMetricNameForUsername(metricsRecord.name(), metrics.name());
 
         String key = prometheusName(
             metricsRecord.name(), metricName);
 
         String prometheusMetricKeyAsString =
-            getPrometheusMetricKeyAsString(metricsRecord, key);
-
-        if (DecayRpcSchedulerUtil.USERNAME_LIST.size() > 0) {
-          DecayRpcSchedulerUtil.USERNAME_LIST.clear();
-        }
+            getPrometheusMetricKeyAsString(metricsRecord, key, username);
 
         String metricKey = "# TYPE "
             + key
@@ -89,14 +88,17 @@ public class PrometheusMetricsSink implements MetricsSink {
   }
 
   private String getPrometheusMetricKeyAsString(MetricsRecord metricsRecord,
-      String key) {
+      String key, String username) {
     StringBuilder prometheusMetricKey = new StringBuilder();
     prometheusMetricKey.append(key)
         .append("{");
     String sep = "";
 
+    // tagListWithUsernameIfNeeded() checks if username is null.
+    // If it's not then it returns a list with the existing
+    // metric tags and a username tag.
     List<MetricsTag> metricTagList = DecayRpcSchedulerUtil
-        .tagListWithUsernameIfNeeded(metricsRecord);
+        .tagListWithUsernameIfNeeded(metricsRecord, username);
 
     //add tags
     for (MetricsTag tag : metricTagList) {

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/DecayRpcSchedulerUtil.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/DecayRpcSchedulerUtil.java
@@ -52,9 +52,14 @@ public final class DecayRpcSchedulerUtil {
    * or
    * "Caller(<callers_username>).Priority"
    * Split it and return the metric.
+   *
+   * If the recordName doesn't belong to Decay_Rpc_Scheduler,
+   * then return the metricName as it is without making
+   * any changes to it.
+   *
    * @param recordName
    * @param metricName "Caller(xyz).Volume" or "Caller(xyz).Priority"
-   * @return "Volume" or "Priority"
+   * @return "Volume" or "Priority" or metricName(unchanged)
    */
   public static String splitMetricNameIfNeeded(String recordName,
                                                String metricName) {

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/DecayRpcSchedulerUtil.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/DecayRpcSchedulerUtil.java
@@ -1,0 +1,101 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with this
+ * work for additional information regarding copyright ownership.  The ASF
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package org.apache.hadoop.hdds.utils;
+
+import org.apache.hadoop.metrics2.MetricsInfo;
+import org.apache.hadoop.metrics2.MetricsRecord;
+import org.apache.hadoop.metrics2.MetricsTag;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Helper functions for DecayRpcScheduler
+ * metrics for Prometheus.
+ */
+public final class DecayRpcSchedulerUtil {
+
+  private DecayRpcSchedulerUtil() {
+  }
+
+  private static final MetricsInfo USERNAME_INFO = new MetricsInfo() {
+    @Override
+    public String name() {
+      return "username";
+    }
+
+    @Override
+    public String description() {
+      return "caller username";
+    }
+  };
+
+  public static final List<String> USERNAME_LIST = new ArrayList<>();
+
+  /**
+   * For Decay_Rpc_Scheduler, the metric name is in format
+   * "Caller(<callers_username>).Volume"
+   * or
+   * "Caller(<callers_username>).Priority"
+   * Split it, store the username in a list to register it as a tag
+   * and return only the metric.
+   * @param recordName
+   * @param metricName "Caller(xyz).Volume" or "Caller(xyz).Priority"
+   * @return "Volume" or "Priority"
+   */
+  public static String splitMetricNameIfNeeded(String recordName,
+                                               String metricName) {
+    if (recordName.toLowerCase().contains("decayrpcscheduler") &&
+        metricName.toLowerCase().contains("caller(")) {
+      // names will contain ["Caller(xyz)", "Volume" / "Priority"]
+      String[] names = metricName.split("[.]");
+
+      // Caller(xyz)
+      String caller = names[0];
+
+      // subStrings will contain ["Caller", "xyz"]
+      String[] subStrings = caller.split("[()]");
+
+      String username = subStrings[1];
+      USERNAME_LIST.add(username);
+
+      // "Volume" or "Priority"
+      return names[1];
+    }
+
+    return metricName;
+  }
+
+  /**
+   * MetricRecord.tags() is an unmodifiable collection of tags.
+   * Store it in a list, to modify it and add a username tag.
+   * @param metricsRecord
+   * @return the new list with the metric tags and the username tag
+   */
+  public static List<MetricsTag> tagListWithUsernameIfNeeded(
+      MetricsRecord metricsRecord) {
+    List<MetricsTag> list = new ArrayList<>(metricsRecord.tags());
+
+    if (USERNAME_LIST.size() > 0) {
+      String username = USERNAME_LIST.get(0);
+      MetricsTag tag = new MetricsTag(USERNAME_INFO, username);
+      list.add(tag);
+    }
+    return list;
+  }
+}

--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/utils/TestDecayRpcSchedulerUtil.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/utils/TestDecayRpcSchedulerUtil.java
@@ -1,0 +1,75 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.apache.hadoop.hdds.utils;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+/**
+ * Test class for DecayRpcSchedulerUtil.
+ */
+public class TestDecayRpcSchedulerUtil {
+
+  private static final String USERNAME = "testUser";
+  private static final String METRIC_NAME_VOLUME = "Volume";
+
+  private static final String RECORD_NAME =
+      "org.apache.hadoop.ipc.DecayRpcScheduler";
+  private static final String METRIC_NAME =
+      "Caller(" + USERNAME + ")." + METRIC_NAME_VOLUME;
+
+  private static final String RANDOM_RECORD_NAME = "JvmMetrics";
+  private static final String RANDOM_METRIC_NAME = "ThreadsNew";
+
+  @Test
+  public void testSplitMetricNameIfNeeded() {
+    // Split the metric name and return only the
+    // name of the metric type.
+    String splitName = DecayRpcSchedulerUtil
+        .splitMetricNameIfNeeded(RECORD_NAME, METRIC_NAME);
+
+    assertEquals(METRIC_NAME_VOLUME, splitName);
+
+    // This metric name should remain the same.
+    String unchangedName = DecayRpcSchedulerUtil
+        .splitMetricNameIfNeeded(RANDOM_RECORD_NAME, RANDOM_METRIC_NAME);
+
+    assertEquals(RANDOM_METRIC_NAME, unchangedName);
+  }
+
+  @Test
+  public void testCheckMetricNameForUsername() {
+    // Get the username from the metric name.
+    String decayRpcSchedulerUsername = DecayRpcSchedulerUtil
+        .checkMetricNameForUsername(RECORD_NAME, METRIC_NAME);
+
+    assertEquals(USERNAME, decayRpcSchedulerUsername);
+
+    // This metric doesn't contain a username in the metric name.
+    // DecayRpcSchedulerUtil.checkMetricNameForUsername()
+    // should return null.
+    String nullUsername = DecayRpcSchedulerUtil
+        .checkMetricNameForUsername(RANDOM_RECORD_NAME, RANDOM_METRIC_NAME);
+
+    assertNull(nullUsername);
+  }
+}


### PR DESCRIPTION
## What changes were proposed in this pull request?

On the Prometheus endpoint for the OM, in the DecayRpcScheduler summary for users, the username is exposed in the metric name. It makes almost impossible to monitor these values as every time a new user shows up we need to register a new metrics name. 

The metric name from `org_apache_hadoop_ipc_decay_rpc_scheduler_volume` becomes `org_apache_hadoop_ipc_decay_rpc_scheduler_caller_hadoop_volume` for a user with `hadoop` username.

The proposed solution is to filter the logs and remove the username from the metric and add it in a username tag. 

This metric comes from `hadoop-common-3.3.4.jar/DecayRpcScheduler` and more specifically

```
Metrics2Util.NameValuePair entry = (Metrics2Util.NameValuePair)topNCallers.poll();
String topCaller = "Caller(" + entry.getName() + ")";
String topCallerVolume = topCaller + ".Volume";
String topCallerPriority = topCaller + ".Priority";
rb.addCounter(Interns.info(topCallerVolume, topCallerVolume), entry.getValue());
``` 
The name is in the format `Caller(username).MetricType` eg. `Caller(hadoop).Volume`. The username might exist in the metric name for a purpose. We don't want to change the way the metric works but the way it's presented. The cleanest way to deal with this seems to filter the metric in `PrometheusMetricsSink`. We are not making any functional changes but we are only filtering what is presented to the user.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-7394

## How was this patch tested?

New unit tests were added for this patch. It was also tested manually, with a docker cluster and the OM `/prom` endpoint.

To test it in a docker environment:

in `compose/ozone` add in docker-config
```
CORE-SITE.XML_ipc.9862.callqueue.impl=org.apache.hadoop.ipc.FairCallQueue
CORE-SITE.XML_ipc.9862.scheduler.impl=org.apache.hadoop.ipc.DecayRpcScheduler
CORE-SITE.XML_ipc.9862.scheduler.priority.levels=2
CORE-SITE.XML_ipc.9862.backoff.enable=true
CORE-SITE.XML_ipc.9862.faircallqueue.multiplexer.weights=99,1
CORE-SITE.XML_ipc.9862.decay-scheduler.thresholds=90
OZONE-SITE.XML_ozone.om.address=0.0.0.0:9862
```
then

```
$ export COMPOSE_FILE=docker-compose.yaml:monitoring.yaml
$ docker-compose up --scale datanode=3 -d
$ docker exec -it ozone_s3g_1 bash
bash-4.2$ export AWS_ACCESS_KEY=test AWS_SECRET_KEY=pass
bash-4.2$ ozone freon s3bg -t 1 -n 10
```
on your browser go to `http://localhost:9874/prom` and you should see 

```
# TYPE org_apache_hadoop_ipc_decay_rpc_scheduler_priority counter
org_apache_hadoop_ipc_decay_rpc_scheduler_priority{context="ipc.9862",hostname="e32f2e3bddb9",username="hadoop"} 1
...
...
...
# TYPE org_apache_hadoop_ipc_decay_rpc_scheduler_volume counter
org_apache_hadoop_ipc_decay_rpc_scheduler_volume{context="ipc.9862",hostname="e32f2e3bddb9",username="hadoop"} 21
```