### PR TITLE
HDDS-7407. EC: Block allocation should not be stripped across the EC group

### DIFF
--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestWritableECContainerProvider.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestWritableECContainerProvider.java
@@ -298,12 +298,11 @@ public class TestWritableECContainerProvider {
     // Update all the containers to make them nearly full, but with enough space
     // for an EC block to be striped across them.
     for (ContainerInfo c : allocatedContainers) {
-      c.setUsedBytes(getMaxContainerSize() - 30 * 1024 * 1024);
+      c.setUsedBytes(getMaxContainerSize() - 90 * 1024 * 1024);
     }
 
     // Get a new container of size 50 and ensure it is one of the original set.
-    // We ask for a space of 50, but as it is stripped across the EC group it
-    // will actually need 50 / dataNum space
+    // We ask for a space of 50 MB, and will actually need 50 MB space.
     ContainerInfo newContainer =
         provider.getContainer(50 * 1024 * 1024, repConfig, OWNER,
             new ExcludeList());


### PR DESCRIPTION
## What changes were proposed in this pull request?

In [HDDS-6452](https://issues.apache.org/jira/browse/HDDS-6452), we have discussed the unit of EC block allocation.

In each container replica, the minimum allocation unit should be scmBlockSize
instead of scmBlockSize / dataNum.
For each key, the minimum allocation unit should be scmBlockSize * dataNum,
instead of scmBlockSize.

So the allocation logic in TestWritableECContainerProvider should be updated.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-7407

## How was this patch tested?

TestWritableECContainerProvider#testNewContainerAllocatedAndPipelinesClosedIfNoSpaceInExisting is updated.