### PR TITLE
HDDS-6962. [Snapshot] Background Service to delete irrelevant SST files in a snapshot.

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/OzoneConfigKeys.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/OzoneConfigKeys.java
@@ -190,6 +190,12 @@ public final class OzoneConfigKeys {
   public static final String OZONE_BLOCK_DELETING_SERVICE_TIMEOUT_DEFAULT
       = "300s"; // 300s for default
 
+  public static final String OZONE_SNAPSHOT_SST_FILTERING_SERVICE_TIMEOUT =
+      "ozone.sst.filtering.service.timeout";
+  public static final String
+      OZONE_SNAPSHOT_SST_FILTERING_SERVICE_TIMEOUT_DEFAULT = "300s";
+      // 300s for default
+
   public static final String OZONE_BLOCK_DELETING_SERVICE_WORKERS =
       "ozone.block.deleting.service.workers";
   public static final int OZONE_BLOCK_DELETING_SERVICE_WORKERS_DEFAULT

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/OzoneConsts.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/OzoneConsts.java
@@ -554,4 +554,6 @@ public final class OzoneConsts {
   public static final String OM_SNAPSHOT_DIR = "db.snapshots";
   public static final String OM_SNAPSHOT_INDICATOR = ".snapshot";
 
+  public static final String FILTERED_SNAPSHOTS = "filtered-snapshots";
+
 }

--- a/hadoop-hdds/common/src/main/resources/ozone-default.xml
+++ b/hadoop-hdds/common/src/main/resources/ozone-default.xml
@@ -3058,6 +3058,28 @@
       directory deleting service per time interval.
     </description>
   </property>
+  <property>
+    <name>ozone.snapshot.filtering.limit.per.task</name>
+    <value>2</value>
+    <tag>OZONE, PERFORMANCE, OM</tag>
+    <description>A maximum number of snapshots to be filtered by
+      sst filtering service per time interval.
+    </description>
+  </property>
+  <property>
+    <name>ozone.snapshot.filtering.service.interval</name>
+    <value>1m</value>
+    <tag>OZONE, PERFORMANCE, OM</tag>
+    <description>Time interval of the SST File filtering service from Snapshot.
+    </description>
+  </property>
+  <property>
+    <name>ozone.sst.filtering.service.timeout</name>
+    <value>300000ms</value>
+    <tag>OZONE, PERFORMANCE,OM</tag>
+    <description>A timeout value of sst filtering service.
+    </description>
+  </property>
 
   <property>
     <name>ozone.scm.event.ContainerReport.thread.pool.size</name>

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/BooleanTriFunction.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/BooleanTriFunction.java
@@ -1,0 +1,20 @@
+package org.apache.hadoop.hdds.utils;
+
+import java.util.Objects;
+import java.util.function.Function;
+
+/**
+ * Defines a functional interface having three inputs and returns boolean as
+ * output.
+ */
+@FunctionalInterface
+public interface BooleanTriFunction<T, U, V, R> {
+
+  R apply(T t, U u, V v);
+
+  default <K> BooleanTriFunction<T, U, V, K> andThen(
+      Function<? super R, ? extends K> after) {
+    Objects.requireNonNull(after);
+    return (T t, U u, V v) -> after.apply(apply(t, u, v));
+  }
+}

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/BooleanTriFunction.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/BooleanTriFunction.java
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.hadoop.hdds.utils;
 
 import java.util.Objects;

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/DBProfile.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/DBProfile.java
@@ -121,6 +121,31 @@ public enum DBProfile {
     public ManagedBlockBasedTableConfig getBlockBasedTableConfig() {
       return SSD.getBlockBasedTableConfig();
     }
+  },
+  TEST {
+    @Override
+    public String toString() {
+      return "TEST";
+    }
+
+    @Override
+    public ManagedDBOptions getDBOptions() {
+      ManagedDBOptions dbOptions = SSD.getDBOptions();
+      return dbOptions;
+    }
+
+    @Override
+    public ManagedColumnFamilyOptions getColumnFamilyOptions() {
+      ManagedColumnFamilyOptions cfOptions = SSD.getColumnFamilyOptions();
+      cfOptions.setCompactionStyle(CompactionStyle.LEVEL);
+      cfOptions.setDisableAutoCompactions(true);
+      return cfOptions;
+    }
+
+    @Override
+    public ManagedBlockBasedTableConfig getBlockBasedTableConfig() {
+      return SSD.getBlockBasedTableConfig();
+    }
   };
 
   public static long toLong(double value) {

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/RDBStore.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/RDBStore.java
@@ -42,6 +42,7 @@ import org.apache.ozone.rocksdiff.RocksDBCheckpointDiffer;
 import com.google.common.base.Preconditions;
 import org.apache.ratis.thirdparty.com.google.common.annotations.VisibleForTesting;
 import org.rocksdb.RocksDBException;
+
 import org.rocksdb.TransactionLogIterator.BatchResult;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/RocksDatabase.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/RocksDatabase.java
@@ -42,6 +42,7 @@ import org.slf4j.LoggerFactory;
 import java.io.Closeable;
 import java.io.File;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -431,7 +432,7 @@ public final class RocksDatabase {
       ColumnFamilyHandle handle) throws IOException {
     for (ColumnFamilyHandle cf : getColumnFamilyHandles()) {
       try {
-        if (cfName.equals(new String(cf.getName()))) {
+        if (cfName.equals(new String(cf.getName(), StandardCharsets.UTF_8))) {
           handle = cf;
           break;
         }
@@ -612,8 +613,8 @@ public final class RocksDatabase {
   public void deleteFilesNotMatchingPrefix(
       List<Pair<String, String>> prefixPairs) throws RocksDBException {
     for (LiveFileMetaData liveFileMetaData : getSstFileList()) {
-      String sstFileColumnFamily =
-          new String(liveFileMetaData.columnFamilyName());
+      String sstFileColumnFamily = new String(liveFileMetaData
+          .columnFamilyName(), StandardCharsets.UTF_8);
       int lastLevel = getLastLevel();
       for (Pair<String, String> prefixPair : prefixPairs) {
         String columnFamily = prefixPair.getKey();

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/RocksDatabase.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/RocksDatabase.java
@@ -627,8 +627,10 @@ public final class RocksDatabase {
           // Instead perform the level check here
           // itself to avoid failed delete attempts for lower level files.
           if (liveFileMetaData.level() == lastLevel && lastLevel != 0) {
-            String firstDbKey = new String(liveFileMetaData.smallestKey());
-            String lastDbKey = new String(liveFileMetaData.largestKey());
+            String firstDbKey = new String(liveFileMetaData.smallestKey(),
+                StandardCharsets.UTF_8);
+            String lastDbKey = new String(liveFileMetaData.largestKey(),
+                StandardCharsets.UTF_8);
             boolean isKeyWithPrefixPresent =
                 firstDbKey.compareTo(prefixForColumnFamily) <= 0
                     && prefixForColumnFamily.compareTo(lastDbKey) <= 0;

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/RocksDatabase.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/RocksDatabase.java
@@ -18,7 +18,7 @@
 package org.apache.hadoop.hdds.utils.db;
 
 import com.google.common.annotations.VisibleForTesting;
-import javafx.util.Pair;
+import org.apache.commons.lang3.tuple.Pair;
 import org.apache.hadoop.hdds.utils.HddsServerUtil;
 import org.apache.hadoop.hdds.utils.db.managed.ManagedCheckpoint;
 import org.apache.hadoop.hdds.utils.db.managed.ManagedDBOptions;

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/RocksDatabase.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/RocksDatabase.java
@@ -137,16 +137,17 @@ public final class RocksDatabase {
           .collect(Collectors.toList());
 
       // open RocksDB
-      columnFamilyHandles = new ArrayList<>();
+      final List<ColumnFamilyHandle> handles = new ArrayList<>();
       if (readOnly) {
         db = ManagedRocksDB.openReadOnly(dbOptions, dbFile.getAbsolutePath(),
-            descriptors, columnFamilyHandles);
+            descriptors, handles);
       } else {
         db = ManagedRocksDB.open(dbOptions, dbFile.getAbsolutePath(),
-            descriptors, columnFamilyHandles);
+            descriptors, handles);
       }
+      columnFamilyHandles = handles;
       // init a column family map.
-      for (ColumnFamilyHandle h : columnFamilyHandles) {
+      for (ColumnFamilyHandle h : handles) {
         final ColumnFamily f = new ColumnFamily(h);
         columnFamilies.put(f.getName(), f);
       }

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/RocksDatabase.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/RocksDatabase.java
@@ -640,7 +640,11 @@ public final class RocksDatabase {
         boolean isKeyWithPrefixPresent =
             filterFunction.apply(firstDbKey, lastDbKey, prefixForColumnFamily);
         if (!isKeyWithPrefixPresent) {
-          db.get().deleteFile(liveFileMetaData.fileName());
+          String sstFileName = liveFileMetaData.fileName();
+          LOG.info("Deleting sst file {} corresponding to column family"
+                  + " {} from db: {}", sstFileName,
+              liveFileMetaData.columnFamilyName(), db.get().getName());
+          db.get().deleteFile(sstFileName);
         }
       }
     }

--- a/hadoop-hdds/rocksdb-checkpoint-differ/pom.xml
+++ b/hadoop-hdds/rocksdb-checkpoint-differ/pom.xml
@@ -35,6 +35,11 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
       <artifactId>rocksdbjni</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.apache.ozone</groupId>
+      <artifactId>hdds-common</artifactId>
+      <version>1.3.0-SNAPSHOT</version>
+    </dependency>
+    <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
     </dependency>

--- a/hadoop-hdds/rocksdb-checkpoint-differ/pom.xml
+++ b/hadoop-hdds/rocksdb-checkpoint-differ/pom.xml
@@ -165,6 +165,8 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
                     <allowedImport>org.rocksdb.RocksDBException</allowedImport>
                     <allowedImport>org.rocksdb.SstFileReader</allowedImport>
                     <allowedImport>org.rocksdb.TableProperties</allowedImport>
+                    <allowedImport>org.rocksdb.SstFileReaderIterator</allowedImport>
+                    <allowedImport>org.rocksdb.ReadOptions</allowedImport>
                   </allowedImports>
                   <exclusion>org.apache.hadoop.hdds.utils.db.managed.*</exclusion>
                 </RestrictImports>

--- a/hadoop-hdds/rocksdb-checkpoint-differ/src/main/java/org/apache/ozone/rocksdiff/RocksDBCheckpointDiffer.java
+++ b/hadoop-hdds/rocksdb-checkpoint-differ/src/main/java/org/apache/ozone/rocksdiff/RocksDBCheckpointDiffer.java
@@ -48,7 +48,6 @@ import java.nio.file.Paths;
 import java.nio.file.StandardOpenOption;
 import java.util.ArrayList;
 import java.util.Comparator;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
@@ -733,7 +732,7 @@ public class RocksDBCheckpointDiffer {
       try (SstFileReader sstFileReader = new SstFileReader(new Options())) {
         sstFileReader.open(filepath);
         TableProperties properties = sstFileReader.getTableProperties();
-        String tableName = new String(properties.getColumnFamilyName());
+        String tableName = new String(properties.getColumnFamilyName(), UTF_8);
         if (tableToPrefixMap.containsKey(tableName)) {
           String prefix = tableToPrefixMap.get(tableName);
           SstFileReaderIterator iterator =

--- a/hadoop-hdds/rocksdb-checkpoint-differ/src/main/java/org/apache/ozone/rocksdiff/RocksDBCheckpointDiffer.java
+++ b/hadoop-hdds/rocksdb-checkpoint-differ/src/main/java/org/apache/ozone/rocksdiff/RocksDBCheckpointDiffer.java
@@ -738,11 +738,11 @@ public class RocksDBCheckpointDiffer {
           SstFileReaderIterator iterator =
               sstFileReader.newIterator(new ReadOptions());
           iterator.seekToFirst();
-          String firstKey =
-              RocksDiffUtils.constructBucketKey(new String(iterator.key()));
+          String firstKey = RocksDiffUtils
+              .constructBucketKey(new String(iterator.key(), UTF_8));
           iterator.seekToLast();
-          String lastKey =
-              RocksDiffUtils.constructBucketKey(new String(iterator.key()));
+          String lastKey = RocksDiffUtils
+              .constructBucketKey(new String(iterator.key(), UTF_8));
           if (!RocksDiffUtils
               .isKeyWithPrefixPresent(prefix, firstKey, lastKey)) {
             inputFiles.remove(filename);

--- a/hadoop-hdds/rocksdb-checkpoint-differ/src/main/java/org/apache/ozone/rocksdiff/RocksDBCheckpointDiffer.java
+++ b/hadoop-hdds/rocksdb-checkpoint-differ/src/main/java/org/apache/ozone/rocksdiff/RocksDBCheckpointDiffer.java
@@ -719,15 +719,15 @@ public class RocksDBCheckpointDiffer {
       LOG.debug("{}", logSB);
     }
 
-/*    if (src.getTablePrefixes() != null && !src.getTablePrefixes().isEmpty()) {
-    //  filterRelevantSstFiles(fwdDAGDifferentFiles, src.getTablePrefixes());
-    }*/
+    if (src.getTablePrefixes() != null && !src.getTablePrefixes().isEmpty()) {
+      filterRelevantSstFiles(fwdDAGDifferentFiles, src.getTablePrefixes());
+    }
 
     return new ArrayList<>(fwdDAGDifferentFiles);
   }
 
   public void filterRelevantSstFiles(Set<String> inputFiles,
-      HashMap<String, String> tableToPrefixMap) {
+      Map<String, String> tableToPrefixMap) {
     for (String filename : inputFiles) {
       String filepath = getAbsoluteSstFilePath(filename);
       try (SstFileReader sstFileReader = new SstFileReader(new Options())) {

--- a/hadoop-hdds/rocksdb-checkpoint-differ/src/main/java/org/apache/ozone/rocksdiff/RocksDiffUtils.java
+++ b/hadoop-hdds/rocksdb-checkpoint-differ/src/main/java/org/apache/ozone/rocksdiff/RocksDiffUtils.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.ozone.rocksdiff;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.hadoop.ozone.OzoneConsts;
+
+/**
+ * Helper methods for snap-diff operations.
+ */
+public final class RocksDiffUtils {
+
+  private RocksDiffUtils() {
+  }
+
+  public static boolean isKeyWithPrefixPresent(String prefixForColumnFamily,
+      String firstDbKey, String lastDbKey) {
+    return firstDbKey.compareTo(prefixForColumnFamily) <= 0
+        && prefixForColumnFamily.compareTo(lastDbKey) <= 0;
+  }
+
+  public static String constructBucketKey(String keyName) {
+    if (!keyName.startsWith(OzoneConsts.OM_KEY_PREFIX)) {
+      keyName = OzoneConsts.OM_KEY_PREFIX.concat(keyName);
+    }
+    String[] elements = keyName.split(OzoneConsts.OM_KEY_PREFIX);
+    String volume = elements[1];
+    String bucket = elements[2];
+    StringBuilder builder =
+        new StringBuilder().append(OzoneConsts.OM_KEY_PREFIX).append(volume);
+
+    if (StringUtils.isNotBlank(bucket)) {
+      builder.append(OzoneConsts.OM_KEY_PREFIX).append(bucket);
+    }
+    return builder.toString();
+  }
+
+
+}

--- a/hadoop-hdds/rocksdb-checkpoint-differ/src/test/java/org/apache/ozone/rocksdiff/TestRocksDBCheckpointDiffer.java
+++ b/hadoop-hdds/rocksdb-checkpoint-differ/src/test/java/org/apache/ozone/rocksdiff/TestRocksDBCheckpointDiffer.java
@@ -211,7 +211,7 @@ public class TestRocksDBCheckpointDiffer {
     createCheckPoint(TEST_DB_PATH, cpPath, rocksDB);
     final String snapshotId = "snap_id_" + snapshotGeneration;
     final DifferSnapshotInfo currentSnapshot =
-        new DifferSnapshotInfo(cpPath, snapshotId, snapshotGeneration);
+        new DifferSnapshotInfo(cpPath, snapshotId, snapshotGeneration, null);
     this.snapshots.add(currentSnapshot);
 
     // Same as what OmSnapshotManager#createOmSnapshotCheckpoint would do

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/OMConfigKeys.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/OMConfigKeys.java
@@ -320,6 +320,16 @@ public final class OMConfigKeys {
       "ozone.path.deleting.limit.per.task";
   public static final int OZONE_PATH_DELETING_LIMIT_PER_TASK_DEFAULT = 10000;
 
+  public static final String SNAPSHOT_SST_DELETING_LIMIT_PER_TASK =
+      "ozone.snapshot.filtering.limit.per.task";
+  public static final int SNAPSHOT_SST_DELETING_LIMIT_PER_TASK_DEFAULT = 2;
+
+  public static final String OZONE_SNAPSHOT_SST_FILTERING_SERVICE_INTERVAL =
+      "ozone.directory.deleting.service.interval";
+  public static final String
+      OZONE_SNAPSHOT_SST_FILTERING_SERVICE_INTERVAL_DEFAULT = "60s";
+
+
   public static final String OZONE_OM_GRPC_MAXIMUM_RESPONSE_LENGTH =
       "ozone.om.grpc.maximum.response.length";
   /** Default value for GRPC_MAXIMUM_RESPONSE_LENGTH. */

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/OMConfigKeys.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/OMConfigKeys.java
@@ -325,7 +325,7 @@ public final class OMConfigKeys {
   public static final int SNAPSHOT_SST_DELETING_LIMIT_PER_TASK_DEFAULT = 2;
 
   public static final String OZONE_SNAPSHOT_SST_FILTERING_SERVICE_INTERVAL =
-      "ozone.directory.deleting.service.interval";
+      "ozone.snapshot.filtering.service.interval";
   public static final String
       OZONE_SNAPSHOT_SST_FILTERING_SERVICE_INTERVAL_DEFAULT = "60s";
 

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/freon/TestOMSnapshotDAG.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/freon/TestOMSnapshotDAG.java
@@ -52,6 +52,7 @@ import java.time.Duration;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.TimeoutException;
 import java.util.stream.Collectors;
 
@@ -142,7 +143,7 @@ public class TestOMSnapshotDAG {
         getTablePrefixes(omMetadataManager, volumeName, bucketName));
   }
 
-  private HashMap<String, String> getTablePrefixes(
+  private Map<String, String> getTablePrefixes(
       OMMetadataManager omMetadataManager, String volumeName, String bucketName)
       throws IOException {
     HashMap<String, String> tablePrefixes = new HashMap<>();
@@ -150,11 +151,11 @@ public class TestOMSnapshotDAG {
     String bucketId =
         String.valueOf(omMetadataManager.getBucketId(volumeName, bucketName));
     tablePrefixes.put(OmMetadataManagerImpl.KEY_TABLE,
-        "/" + volumeName + "/" + bucketName);
-    tablePrefixes
-        .put(OmMetadataManagerImpl.FILE_TABLE, "/" + volumeId + "/" + bucketId);
+        OM_KEY_PREFIX + volumeName + OM_KEY_PREFIX + bucketName);
+    tablePrefixes.put(OmMetadataManagerImpl.FILE_TABLE,
+        OM_KEY_PREFIX + volumeId + OM_KEY_PREFIX + bucketId);
     tablePrefixes.put(OmMetadataManagerImpl.DIRECTORY_TABLE,
-        "/" + volumeId + "/" + bucketId);
+        OM_KEY_PREFIX + volumeId + OM_KEY_PREFIX + bucketId);
     return tablePrefixes;
   }
 

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/freon/TestOMSnapshotDAG.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/freon/TestOMSnapshotDAG.java
@@ -27,6 +27,7 @@ import org.apache.hadoop.ozone.client.OzoneBucket;
 import org.apache.hadoop.ozone.client.OzoneVolume;
 import org.apache.hadoop.ozone.om.OMMetadataManager;
 import org.apache.hadoop.ozone.om.OMStorage;
+import org.apache.hadoop.ozone.om.OmMetadataManagerImpl;
 import org.apache.hadoop.ozone.om.OzoneManager;
 import org.apache.hadoop.ozone.om.helpers.OmBucketInfo;
 import org.apache.hadoop.ozone.om.helpers.OmVolumeArgs;
@@ -49,6 +50,7 @@ import java.io.File;
 import java.io.IOException;
 import java.time.Duration;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.concurrent.TimeoutException;
 import java.util.stream.Collectors;
@@ -136,7 +138,24 @@ public class TestOMSnapshotDAG {
     // Use RocksDB transaction sequence number in SnapshotInfo, which is
     // persisted at the time of snapshot creation, as the snapshot generation
     return new DifferSnapshotInfo(checkpointPath, snapshotInfo.getSnapshotID(),
-        snapshotInfo.getDbTxSequenceNumber());
+        snapshotInfo.getDbTxSequenceNumber(),
+        getTablePrefixes(omMetadataManager, volumeName, bucketName));
+  }
+
+  private HashMap<String, String> getTablePrefixes(
+      OMMetadataManager omMetadataManager, String volumeName, String bucketName)
+      throws IOException {
+    HashMap<String, String> tablePrefixes = new HashMap<>();
+    String volumeId = String.valueOf(omMetadataManager.getVolumeId(volumeName));
+    String bucketId =
+        String.valueOf(omMetadataManager.getBucketId(volumeName, bucketName));
+    tablePrefixes.put(OmMetadataManagerImpl.KEY_TABLE,
+        "/" + volumeName + "/" + bucketName);
+    tablePrefixes
+        .put(OmMetadataManagerImpl.FILE_TABLE, "/" + volumeId + "/" + bucketId);
+    tablePrefixes.put(OmMetadataManagerImpl.DIRECTORY_TABLE,
+        "/" + volumeId + "/" + bucketId);
+    return tablePrefixes;
   }
 
   @Test

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/KeyManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/KeyManager.java
@@ -231,4 +231,10 @@ public interface KeyManager extends OzoneManagerFS, IOzoneAcl {
    * @return Background service.
    */
   BackgroundService getOpenKeyCleanupService();
+
+  /**
+   * Returns the instance of Snapshot SST Filtering service.
+   * @return Background service.
+   */
+  BackgroundService getSnapshotSstFilteringService();
 }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/KeyManagerImpl.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/KeyManagerImpl.java
@@ -110,6 +110,8 @@ import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_CLIENT_LIST_TRASH_KE
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_CLIENT_LIST_TRASH_KEYS_MAX_DEFAULT;
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_SCM_BLOCK_SIZE;
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_SCM_BLOCK_SIZE_DEFAULT;
+import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_SNAPSHOT_SST_FILTERING_SERVICE_TIMEOUT;
+import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_SNAPSHOT_SST_FILTERING_SERVICE_TIMEOUT_DEFAULT;
 import static org.apache.hadoop.ozone.OzoneConsts.OZONE_URI_DELIMITER;
 import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_DIR_DELETING_SERVICE_INTERVAL;
 import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_DIR_DELETING_SERVICE_INTERVAL_DEFAULT;
@@ -117,6 +119,8 @@ import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_OPEN_KEY_CLEANUP_
 import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_OPEN_KEY_CLEANUP_SERVICE_INTERVAL_DEFAULT;
 import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_OPEN_KEY_CLEANUP_SERVICE_TIMEOUT;
 import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_OPEN_KEY_CLEANUP_SERVICE_TIMEOUT_DEFAULT;
+import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_SNAPSHOT_SST_FILTERING_SERVICE_INTERVAL;
+import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_SNAPSHOT_SST_FILTERING_SERVICE_INTERVAL_DEFAULT;
 import static org.apache.hadoop.ozone.om.OzoneManagerUtils.getBucketLayout;
 import static org.apache.hadoop.ozone.om.exceptions.OMException.ResultCodes.BUCKET_NOT_FOUND;
 import static org.apache.hadoop.ozone.om.exceptions.OMException.ResultCodes.FILE_NOT_FOUND;
@@ -151,6 +155,8 @@ public class KeyManagerImpl implements KeyManager {
   private final boolean grpcBlockTokenEnabled;
 
   private BackgroundService keyDeletingService;
+
+  private BackgroundService snapshotSstFilteringService;
 
   private final KeyProviderCryptoExtension kmsProvider;
   private final boolean enableFileSystemPaths;
@@ -236,6 +242,21 @@ public class KeyManagerImpl implements KeyManager {
           TimeUnit.MILLISECONDS, serviceTimeout, ozoneManager, configuration);
       openKeyCleanupService.start();
     }
+
+    if (snapshotSstFilteringService == null) {
+      long serviceInterval = configuration.getTimeDuration(
+          OZONE_SNAPSHOT_SST_FILTERING_SERVICE_INTERVAL,
+          OZONE_SNAPSHOT_SST_FILTERING_SERVICE_INTERVAL_DEFAULT,
+          TimeUnit.MILLISECONDS);
+      long serviceTimeout = configuration.getTimeDuration(
+          OZONE_SNAPSHOT_SST_FILTERING_SERVICE_TIMEOUT,
+          OZONE_SNAPSHOT_SST_FILTERING_SERVICE_TIMEOUT_DEFAULT,
+          TimeUnit.MILLISECONDS);
+      snapshotSstFilteringService =
+          new SstFilteringService(serviceInterval, TimeUnit.MILLISECONDS,
+              serviceTimeout, ozoneManager, configuration);
+      snapshotSstFilteringService.start();
+    }
   }
 
   KeyProviderCryptoExtension getKMSProvider() {
@@ -255,6 +276,10 @@ public class KeyManagerImpl implements KeyManager {
     if (openKeyCleanupService != null) {
       openKeyCleanupService.shutdown();
       openKeyCleanupService = null;
+    }
+    if (snapshotSstFilteringService != null) {
+      snapshotSstFilteringService.shutdown();
+      snapshotSstFilteringService = null;
     }
   }
 
@@ -568,6 +593,10 @@ public class KeyManagerImpl implements KeyManager {
 
   public BackgroundService getOpenKeyCleanupService() {
     return openKeyCleanupService;
+  }
+
+  public BackgroundService getSnapshotSstFilteringService() {
+    return snapshotSstFilteringService;
   }
 
   @Override

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/KeyManagerImpl.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/KeyManagerImpl.java
@@ -142,6 +142,7 @@ import org.slf4j.LoggerFactory;
 public class KeyManagerImpl implements KeyManager {
   private static final Logger LOG =
       LoggerFactory.getLogger(KeyManagerImpl.class);
+  public static final int DISABLE_VALUE = -1;
 
   /**
    * A SCM block client, used to talk to SCM to allocate block during putKey.
@@ -252,10 +253,12 @@ public class KeyManagerImpl implements KeyManager {
           OZONE_SNAPSHOT_SST_FILTERING_SERVICE_TIMEOUT,
           OZONE_SNAPSHOT_SST_FILTERING_SERVICE_TIMEOUT_DEFAULT,
           TimeUnit.MILLISECONDS);
-      snapshotSstFilteringService =
-          new SstFilteringService(serviceInterval, TimeUnit.MILLISECONDS,
-              serviceTimeout, ozoneManager, configuration);
-      snapshotSstFilteringService.start();
+      if (serviceInterval != DISABLE_VALUE) {
+        snapshotSstFilteringService =
+            new SstFilteringService(serviceInterval, TimeUnit.MILLISECONDS,
+                serviceTimeout, ozoneManager, configuration);
+        snapshotSstFilteringService.start();
+      }
     }
   }
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
@@ -1417,6 +1417,15 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
   }
 
   /**
+   * Get snapshot manager.
+   *
+   * @return Om snapshot manager.
+   */
+  public OmSnapshotManager getOmSnapshotManager() {
+    return omSnapshotManager;
+  }
+
+  /**
    * Get metadata manager.
    *
    * @return metadata manager.

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/SstFilteringService.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/SstFilteringService.java
@@ -53,7 +53,7 @@ import static org.apache.hadoop.ozone.om.OMConfigKeys.SNAPSHOT_SST_DELETING_LIMI
 
 /**
  * When snapshots are taken, an entire snapshot of the
- * OM RocksDB is captured and it will SST files corresponding
+ * OM RocksDB is captured and it will contain SST files corresponding
  * to all volumes/buckets and keys and also have data from
  * all the tables (columnFamilies) defined in the rocksdb
  * This is a background service which will cleanup and filter out

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/SstFilteringService.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/SstFilteringService.java
@@ -18,7 +18,8 @@
  */
 package org.apache.hadoop.ozone.om;
 
-import javafx.util.Pair;
+
+import org.apache.commons.lang3.tuple.Pair;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.utils.BackgroundService;
 import org.apache.hadoop.hdds.utils.BackgroundTask;
@@ -180,11 +181,11 @@ public class SstFilteringService extends BackgroundService {
 
       List<Pair<String, String>> prefixPairs = new ArrayList<>();
       prefixPairs
-          .add(new Pair<>(OmMetadataManagerImpl.KEY_TABLE, filterPrefix));
+          .add(Pair.of(OmMetadataManagerImpl.KEY_TABLE, filterPrefix));
       prefixPairs.add(
-          new Pair<>(OmMetadataManagerImpl.DIRECTORY_TABLE, filterPrefixFSO));
+          Pair.of(OmMetadataManagerImpl.DIRECTORY_TABLE, filterPrefixFSO));
       prefixPairs
-          .add(new Pair<>(OmMetadataManagerImpl.FILE_TABLE, filterPrefixFSO));
+          .add(Pair.of(OmMetadataManagerImpl.FILE_TABLE, filterPrefixFSO));
       return prefixPairs;
     }
   }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/SstFilteringService.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/SstFilteringService.java
@@ -36,6 +36,7 @@ import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -143,8 +144,8 @@ public class SstFilteringService extends BackgroundService {
 
             // mark the snapshot as filtered by writing to the file
             String content = snapshotInfo.getSnapshotID() + "\n";
-            Files.write(filePath, content.getBytes(), StandardOpenOption.CREATE,
-                StandardOpenOption.APPEND);
+            Files.write(filePath, content.getBytes(StandardCharsets.UTF_8),
+                StandardOpenOption.CREATE, StandardOpenOption.APPEND);
             snapshotLimit--;
             snapshotFilteredCount.getAndIncrement();
           }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/SstFilteringService.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/SstFilteringService.java
@@ -175,7 +175,8 @@ public class SstFilteringService extends BackgroundService {
       String bucketName = snapshotInfo.getBucketName();
 
       long volumeId = ozoneManager.getMetadataManager().getVolumeId(volumeName);
-      // TODO : buckets can be deleted via ofs , handle deletion of bucket case.
+      // TODO : HDDS-6984  buckets can be deleted via ofs
+      //  handle deletion of bucket case.
       long bucketId =
           ozoneManager.getMetadataManager().getBucketId(volumeName, bucketName);
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/SstFilteringService.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/SstFilteringService.java
@@ -1,0 +1,203 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package org.apache.hadoop.ozone.om;
+
+import javafx.util.Pair;
+import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import org.apache.hadoop.hdds.utils.BackgroundService;
+import org.apache.hadoop.hdds.utils.BackgroundTask;
+import org.apache.hadoop.hdds.utils.BackgroundTaskQueue;
+import org.apache.hadoop.hdds.utils.BackgroundTaskResult;
+import org.apache.hadoop.hdds.utils.db.RDBStore;
+import org.apache.hadoop.hdds.utils.db.RocksDatabase;
+import org.apache.hadoop.hdds.utils.db.Table;
+import org.apache.hadoop.hdds.utils.db.TableIterator;
+import org.apache.hadoop.ozone.om.helpers.SnapshotInfo;
+import org.rocksdb.RocksDBException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.StandardOpenOption;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+
+import static org.apache.hadoop.ozone.OzoneConsts.FILTERED_SNAPSHOTS;
+import static org.apache.hadoop.ozone.OzoneConsts.OM_DB_NAME;
+import static org.apache.hadoop.ozone.OzoneConsts.OM_KEY_PREFIX;
+import static org.apache.hadoop.ozone.OzoneConsts.OM_SNAPSHOT_DIR;
+import static org.apache.hadoop.ozone.om.OMConfigKeys.SNAPSHOT_SST_DELETING_LIMIT_PER_TASK;
+import static org.apache.hadoop.ozone.om.OMConfigKeys.SNAPSHOT_SST_DELETING_LIMIT_PER_TASK_DEFAULT;
+
+/**
+ * When snapshots are taken, an entire snapshot of the
+ * OM RocksDB is captured and it will SST files corresponding
+ * to all volumes/buckets and keys and also have data from
+ * all the tables (columnFamilies) defined in the rocksdb
+ * This is a background service which will cleanup and filter out
+ * all the irrelevant and safe to delete sst files that don't correspond
+ * to the bucket on which the snapshot was taken.
+ */
+public class SstFilteringService extends BackgroundService {
+
+  private static final Logger LOG =
+      LoggerFactory.getLogger(SstFilteringService.class);
+
+  // Use only a single thread for SST deletion. Multiple threads would read
+  // or write to same snapshots and can send deletion requests for same sst
+  // multiple times.
+  private static final int SST_FILTERING_CORE_POOL_SIZE = 1;
+
+  private final OzoneManager ozoneManager;
+
+  // Number of files to be batched in an iteration.
+  private final long snapshotLimitPerTask;
+
+  private AtomicLong snapshotFilteredCount;
+
+  public SstFilteringService(long interval, TimeUnit unit, long serviceTimeout,
+      OzoneManager ozoneManager, OzoneConfiguration configuration) {
+    super("SstFilteringService", interval, unit, SST_FILTERING_CORE_POOL_SIZE,
+        serviceTimeout);
+    this.ozoneManager = ozoneManager;
+    this.snapshotLimitPerTask = configuration
+        .getLong(SNAPSHOT_SST_DELETING_LIMIT_PER_TASK,
+            SNAPSHOT_SST_DELETING_LIMIT_PER_TASK_DEFAULT);
+    snapshotFilteredCount = new AtomicLong(0);
+  }
+
+  private class SSTFilteringTask implements BackgroundTask {
+
+    @Override
+    public BackgroundTaskResult call() throws Exception {
+
+      Table<String, SnapshotInfo> snapshotInfoTable =
+          ozoneManager.getMetadataManager().getSnapshotInfoTable();
+      try (
+          TableIterator<String, ? extends Table.KeyValue
+              <String, SnapshotInfo>> iterator = snapshotInfoTable
+              .iterator()) {
+        iterator.seekToFirst();
+
+        long snapshotLimit = snapshotLimitPerTask;
+
+        while (iterator.hasNext() && snapshotLimit > 0) {
+          Table.KeyValue<String, SnapshotInfo> keyValue = iterator.next();
+          String snapShotTableKey = keyValue.getKey();
+          SnapshotInfo snapshotInfo = keyValue.getValue();
+
+          File omMetadataDir =
+              OMStorage.getOmDbDir(ozoneManager.getConfiguration());
+          String snapshotDir = omMetadataDir + OM_KEY_PREFIX + OM_SNAPSHOT_DIR;
+          Path filePath =
+              Paths.get(snapshotDir + OM_KEY_PREFIX + FILTERED_SNAPSHOTS);
+
+          boolean isSnapshotFiltered = false;
+
+          // If entry for the snapshotID is present in this file,
+          // it has already undergone filtering.
+          if (Files.exists(filePath)) {
+            List<String> processedSnapshotIds = Files.readAllLines(filePath);
+            if (processedSnapshotIds.contains(snapshotInfo.getSnapshotID())) {
+              isSnapshotFiltered = true;
+            }
+          }
+
+          if (!isSnapshotFiltered) {
+            LOG.debug("Processing snapshot {} to filter relevant SST Files",
+                snapShotTableKey);
+
+            List<Pair<String, String>> prefixPairs =
+                constructPrefixPairs(snapshotInfo);
+
+            String dbName = OM_DB_NAME + snapshotInfo.getCheckpointDirName();
+
+            RDBStore rdbStore = (RDBStore) OmMetadataManagerImpl
+                .loadDB(ozoneManager.getConfiguration(), new File(snapshotDir),
+                    dbName, true);
+            RocksDatabase db = rdbStore.getDb();
+            db.deleteFilesNotMatchingPrefix(prefixPairs);
+
+            // mark the snapshot as filtered by writing to the file
+            String content = snapshotInfo.getSnapshotID() + "\n";
+            Files.write(filePath, content.getBytes(), StandardOpenOption.CREATE,
+                StandardOpenOption.APPEND);
+            snapshotLimit--;
+            snapshotFilteredCount.getAndIncrement();
+          }
+        }
+      } catch (RocksDBException | IOException e) {
+        LOG.error("Error during Snapshot sst filtering ", e);
+      }
+
+      // nothing to return here
+      return BackgroundTaskResult.EmptyTaskResult.newResult();
+    }
+
+    /**
+     * @param snapshotInfo
+     * @return a list of pairs (tableName,keyPrefix).
+     * @throws IOException
+     */
+    private List<Pair<String, String>> constructPrefixPairs(
+        SnapshotInfo snapshotInfo) throws IOException {
+      String volumeName = snapshotInfo.getVolumeName();
+      String bucketName = snapshotInfo.getBucketName();
+
+      long volumeId = ozoneManager.getMetadataManager().getVolumeId(volumeName);
+      // TODO : buckets can be deleted via ofs , handle deletion of bucket case.
+      long bucketId =
+          ozoneManager.getMetadataManager().getBucketId(volumeName, bucketName);
+
+      String filterPrefix =
+          OM_KEY_PREFIX + volumeName + OM_KEY_PREFIX + bucketName
+              + OM_KEY_PREFIX;
+
+      String filterPrefixFSO =
+          OM_KEY_PREFIX + volumeId + OM_KEY_PREFIX + bucketId + OM_KEY_PREFIX;
+
+      List<Pair<String, String>> prefixPairs = new ArrayList<>();
+      prefixPairs
+          .add(new Pair<>(OmMetadataManagerImpl.KEY_TABLE, filterPrefix));
+      prefixPairs.add(
+          new Pair<>(OmMetadataManagerImpl.DIRECTORY_TABLE, filterPrefixFSO));
+      prefixPairs
+          .add(new Pair<>(OmMetadataManagerImpl.FILE_TABLE, filterPrefixFSO));
+      return prefixPairs;
+    }
+  }
+
+
+  @Override
+  public BackgroundTaskQueue getTasks() {
+    BackgroundTaskQueue queue = new BackgroundTaskQueue();
+    queue.add(new SSTFilteringTask());
+    return queue;
+  }
+
+  public AtomicLong getSnapshotFilteredCount() {
+    return snapshotFilteredCount;
+  }
+}

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestKeyDeletingService.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestKeyDeletingService.java
@@ -228,9 +228,11 @@ public class TestKeyDeletingService {
     // Create 2 versions of the same key
     String keyName = String.format("key%s",
         RandomStringUtils.randomAlphanumeric(5));
-    OmKeyArgs keyArgs = createAndCommitKey(keyManager, volumeName, bucketName,
-        keyName, 1);
-    createAndCommitKey(keyManager, volumeName, bucketName, keyName, 2);
+    OmKeyArgs keyArgs =
+        createAndCommitKey(writeClient, keyManager, volumeName, bucketName,
+            keyName, 1);
+    createAndCommitKey(writeClient, keyManager, volumeName, bucketName, keyName,
+        2);
 
     // Delete the key
     writeClient.deleteKey(keyArgs);
@@ -266,15 +268,16 @@ public class TestKeyDeletingService {
       createVolumeAndBucket(keyManager, volumeName, bucketName, false);
 
       // Create the key
-      OmKeyArgs keyArg = createAndCommitKey(keyManager, volumeName, bucketName,
-          keyName, numBlocks);
+      OmKeyArgs keyArg =
+          createAndCommitKey(writeClient, keyManager, volumeName, bucketName,
+              keyName, numBlocks);
 
       // Delete the key
       writeClient.deleteKey(keyArg);
     }
   }
 
-  private void createVolumeAndBucket(KeyManager keyManager, String volumeName,
+  static void createVolumeAndBucket(KeyManager keyManager, String volumeName,
       String bucketName, boolean isVersioningEnabled) throws IOException {
     // cheat here, just create a volume and bucket entry so that we can
     // create the keys, we put the same data for key and value since the
@@ -293,7 +296,8 @@ public class TestKeyDeletingService {
             .build());
   }
 
-  private OmKeyArgs createAndCommitKey(KeyManager keyManager, String volumeName,
+  static OmKeyArgs createAndCommitKey(OzoneManagerProtocol writeClient,
+      KeyManager keyManager, String volumeName,
       String bucketName, String keyName, int numBlocks) throws IOException {
     OmKeyArgs keyArg =
         new OmKeyArgs.Builder()

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestSstFilteringService.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestSstFilteringService.java
@@ -1,0 +1,230 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package org.apache.hadoop.ozone.om;
+
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import org.apache.commons.lang3.RandomStringUtils;
+import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import org.apache.hadoop.hdds.server.ServerUtils;
+import org.apache.hadoop.hdds.utils.db.DBConfigFromFile;
+import org.apache.hadoop.hdds.utils.db.DBProfile;
+import org.apache.hadoop.hdds.utils.db.RDBStore;
+import org.apache.hadoop.ozone.OzoneConsts;
+import org.apache.hadoop.ozone.om.helpers.SnapshotInfo;
+import org.apache.hadoop.ozone.om.protocol.OzoneManagerProtocol;
+import org.apache.hadoop.security.authentication.client.AuthenticationException;
+import org.apache.ozone.test.GenericTestUtils;
+import org.apache.ratis.util.ExitUtils;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.rocksdb.LiveFileMetaData;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_CONTAINER_REPORT_INTERVAL;
+import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_DB_PROFILE;
+import static org.apache.hadoop.ozone.OzoneConsts.OM_DB_NAME;
+import static org.apache.hadoop.ozone.OzoneConsts.OM_KEY_PREFIX;
+import static org.apache.hadoop.ozone.OzoneConsts.OM_SNAPSHOT_DIR;
+import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_SNAPSHOT_SST_FILTERING_SERVICE_INTERVAL;
+
+/**
+ * Test SST Filtering Service.
+ */
+public class TestSstFilteringService {
+  @Rule
+  public TemporaryFolder folder = new TemporaryFolder();
+  private OzoneManagerProtocol writeClient;
+  private OzoneManager om;
+  private static final Logger LOG =
+      LoggerFactory.getLogger(TestSstFilteringService.class);
+
+  @BeforeClass
+  public static void setup() {
+    ExitUtils.disableSystemExit();
+  }
+
+  private OzoneConfiguration createConfAndInitValues() throws IOException {
+    OzoneConfiguration conf = new OzoneConfiguration();
+    File newFolder = folder.newFolder();
+    if (!newFolder.exists()) {
+      Assert.assertTrue(newFolder.mkdirs());
+    }
+    System.setProperty(DBConfigFromFile.CONFIG_DIR, "/");
+    ServerUtils.setOzoneMetaDirPath(conf, newFolder.toString());
+    conf.setTimeDuration(HDDS_CONTAINER_REPORT_INTERVAL, 200,
+        TimeUnit.MILLISECONDS);
+    conf.setTimeDuration(OZONE_SNAPSHOT_SST_FILTERING_SERVICE_INTERVAL, 100,
+        TimeUnit.MILLISECONDS);
+    conf.setEnum(HDDS_DB_PROFILE, DBProfile.TEST);
+    conf.setQuietMode(false);
+
+    return conf;
+  }
+
+  @After
+  public void cleanup() throws Exception {
+    om.stop();
+  }
+
+  /**
+   * Test checks whether for existing snapshots
+   * the checkpoint should not have any sst files that do not correspond to
+   * the bucket on which create snapshot command was issued.
+   *
+   * The SSTFiltering service deletes only the last level of
+   * sst file (rocksdb behaviour).
+   *
+   * 1. Create Keys for vol1/buck1 (L0 ssts will be created for vol1/buck1)
+   * 2. compact the db (new level SSTS will be created for vol1/buck1)
+   * 3. Create keys for vol1/buck2 (L0 ssts will be created for vol1/buck2)
+   * 4. Take snapshot on vol1/buck2.
+   * 5. The snapshot will contain compacted sst files pertaining to vol1/buck1
+   *    Wait till the BG service deletes these.
+   *
+   * @throws IOException - on Failure.
+   */
+
+  @Test
+  public void testIrrelevantSstFileDeletion()
+      throws IOException, TimeoutException, InterruptedException,
+      AuthenticationException {
+    OzoneConfiguration conf = createConfAndInitValues();
+    OmTestManagers omTestManagers = new OmTestManagers(conf);
+    KeyManager keyManager = omTestManagers.getKeyManager();
+    writeClient = omTestManagers.getWriteClient();
+    om = omTestManagers.getOzoneManager();
+    RDBStore store = (RDBStore) om.getMetadataManager().getStore();
+
+    final int keyCount = 100;
+    createKeys(keyManager, "vol1", "buck1", keyCount / 2, 1);
+    SstFilteringService sstFilteringService =
+        (SstFilteringService) keyManager.getSnapshotSstFilteringService();
+
+    String rocksDbDir = om.getRocksDbDirectory();
+
+    store.getDb().flush(OmMetadataManagerImpl.KEY_TABLE);
+
+    createKeys(keyManager, "vol1", "buck1", keyCount / 2, 1);
+    store.getDb().flush(OmMetadataManagerImpl.KEY_TABLE);
+
+    int level0FilesCount = 0;
+    int totalFileCount = 0;
+
+    List<LiveFileMetaData> initialsstFileList = store.getDb().getSstFileList();
+    for (LiveFileMetaData fileMetaData : initialsstFileList) {
+      totalFileCount++;
+      if (fileMetaData.level() == 0) {
+        level0FilesCount++;
+      }
+    }
+    LOG.debug("Total files : {}", totalFileCount);
+    LOG.debug("Total L0 files: {}", level0FilesCount);
+
+    Assert.assertEquals(totalFileCount, level0FilesCount);
+
+    store.getDb().compactRange(OmMetadataManagerImpl.KEY_TABLE);
+
+    int level0FilesCountAfterCompact = 0;
+    int totalFileCountAfterCompact = 0;
+    int nonlevel0FilesCountAfterCompact = 0;
+    List<LiveFileMetaData> nonlevelOFiles = new ArrayList<>();
+
+    for (LiveFileMetaData fileMetaData : store.getDb().getSstFileList()) {
+      totalFileCountAfterCompact++;
+      if (fileMetaData.level() == 0) {
+        level0FilesCountAfterCompact++;
+      } else {
+        nonlevel0FilesCountAfterCompact++;
+        nonlevelOFiles.add(fileMetaData);
+      }
+    }
+
+    LOG.debug("Total files : {}", totalFileCountAfterCompact);
+    LOG.debug("Total L0 files: {}", level0FilesCountAfterCompact);
+    LOG.debug("Total non L0/compacted files: {}",
+        nonlevel0FilesCountAfterCompact);
+
+    Assert.assertTrue(nonlevel0FilesCountAfterCompact > 0);
+
+    createKeys(keyManager, "vol1", "buck2", keyCount, 1);
+
+    store.getDb().flush(OmMetadataManagerImpl.KEY_TABLE);
+
+    writeClient.createSnapshot("vol1", "buck2", "snapshot1");
+
+    GenericTestUtils.waitFor(
+        () -> sstFilteringService.getSnapshotFilteredCount().get() >= 1, 1000,
+        10000);
+
+    Assert
+        .assertEquals(1, sstFilteringService.getSnapshotFilteredCount().get());
+
+    SnapshotInfo snapshotInfo = om.getMetadataManager().getSnapshotInfoTable()
+        .get(SnapshotInfo.getTableKey("vol1", "buck2", "snapshot1"));
+
+    String dbSnapshots = rocksDbDir + OM_KEY_PREFIX + OM_SNAPSHOT_DIR;
+    String snapshotDirName =
+        dbSnapshots + OM_KEY_PREFIX + OM_DB_NAME + snapshotInfo
+            .getCheckpointDirName();
+
+    for (LiveFileMetaData file : nonlevelOFiles) {
+      File sstFile =
+          new File(snapshotDirName + OM_KEY_PREFIX + file.fileName());
+      Assert.assertFalse(sstFile.exists());
+    }
+
+    List<String> processedSnapshotIds = Files
+        .readAllLines(Paths.get(dbSnapshots, OzoneConsts.FILTERED_SNAPSHOTS));
+    Assert.assertTrue(
+        processedSnapshotIds.contains(snapshotInfo.getSnapshotID()));
+
+  }
+
+  @SuppressFBWarnings("RV_RETURN_VALUE_IGNORED_NO_SIDE_EFFECT")
+  private void createKeys(KeyManager keyManager, String volumeName,
+      String bucketName, int keyCount, int numBlocks) throws IOException {
+    for (int x = 0; x < keyCount; x++) {
+      String keyName =
+          String.format("key%s", RandomStringUtils.randomAlphanumeric(5));
+      // Create Volume and Bucket
+      TestKeyDeletingService
+          .createVolumeAndBucket(keyManager, volumeName, bucketName, false);
+
+      // Create the key
+      TestKeyDeletingService
+          .createAndCommitKey(writeClient, keyManager, volumeName, bucketName,
+              keyName, numBlocks);
+    }
+  }
+
+}

--- a/pom.xml
+++ b/pom.xml
@@ -1836,6 +1836,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
                       <allowedImport>org.rocksdb.StatsLevel</allowedImport>
                       <allowedImport>org.rocksdb.TransactionLogIterator.BatchResult</allowedImport>
                       <allowedImport>org.rocksdb.TickerType</allowedImport>
+                      <allowedImport>org.rocksdb.LiveFileMetaData</allowedImport>
 
                       <!-- Allow RocksObjects whose native pointer is managed by RocksDB. -->
                       <allowedImport>org.rocksdb.ColumnFamilyHandle</allowedImport>


### PR DESCRIPTION
## What changes were proposed in this pull request?
This PR introduces a background service `SSTFilteringService` to delete irrelevant SST files of a snapshot, It makes use of RocksDB#deleteFile
API to do so which only permits the deletion of [last level of SST files](https://github.com/facebook/rocksdb/blob/de34e7196fdfc7d361404f5a69c6302c03b5090d/db/db_impl/db_impl.cc#L4212) ie if there are n levels of SST's at a given point , the service will delete only nth level SST's. This is still beneficial as the last level SST's are the bulkiest and deletion of these can help save space. On successful deletion , it will update a marker file `filtered-snapshots` and write the snapshot ID of the processed Snapshot to it. Only the` keyTable`, `fileTable` & `directoryTable` keys are deleted as they can grow very large compared to other tables.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-6962

## How was this patch tested?
Unit tests

- [x] Background Service to cleanup SST Files
- [x] Filter out and add only relevant SST Files from Compaction DAG output