### PR TITLE
HDDS-7413. Fix logging while marking container state unhealthy

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/KeyValueContainer.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/KeyValueContainer.java
@@ -328,6 +328,7 @@ public class KeyValueContainer implements Container<KeyValueContainerData> {
   @Override
   public void markContainerUnhealthy() throws StorageContainerException {
     writeLock();
+    ContainerDataProto.State prevState = containerData.getState();
     try {
       updateContainerData(() ->
           containerData.setState(ContainerDataProto.State.UNHEALTHY));
@@ -336,7 +337,7 @@ public class KeyValueContainer implements Container<KeyValueContainerData> {
       writeUnlock();
     }
     LOG.warn("Moving container {} to state UNHEALTHY from state:{} Trace:{}",
-            containerData.getContainerPath(), containerData.getState(),
+            containerData.getContainerPath(), prevState,
             StringUtils.getStackTrace(Thread.currentThread()));
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?
Currently the logging shows the new state as the previous state after setting the state as UNHEALTHY. We need to fix the logging to show the previous state of the container.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-7413

## How was this patch tested?
Logging Changes, no testing required.