### PR TITLE
HDDS-7416. Unify license headers for hdds-annotation-processing

### DIFF
--- a/hadoop-hdds/annotations/src/main/java/org/apache/ozone/annotations/ReplicateAnnotationProcessor.java
+++ b/hadoop-hdds/annotations/src/main/java/org/apache/ozone/annotations/ReplicateAnnotationProcessor.java
@@ -1,14 +1,14 @@
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
- * contributor license agreements. See the NOTICE file distributed with this
- * work for additional information regarding copyright ownership. The ASF
+ * contributor license agreements.  See the NOTICE file distributed with this
+ * work for additional information regarding copyright ownership.  The ASF
  * licenses this file to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * <p>
- * <p>http://www.apache.org/licenses/LICENSE-2.0
- * <p>
- * <p>Unless required by applicable law or agreed to in writing, software
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
  * License for the specific language governing permissions and limitations under

--- a/hadoop-hdds/annotations/src/main/java/org/apache/ozone/annotations/RequestFeatureValidatorProcessor.java
+++ b/hadoop-hdds/annotations/src/main/java/org/apache/ozone/annotations/RequestFeatureValidatorProcessor.java
@@ -5,9 +5,9 @@
  * licenses this file to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * <p>
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * <p>
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the

--- a/hadoop-hdds/dev-support/checkstyle/java.header
+++ b/hadoop-hdds/dev-support/checkstyle/java.header
@@ -14,9 +14,3 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
-/**
- * Annotation processors used at compile time by the Ozone project to validate
- * internal annotations and related code as needed, if needed.
- */
-package org.apache.ozone.annotations;


### PR DESCRIPTION
## What changes were proposed in this pull request?

Added license header template and changed license headers in hdds-annotation-processing according to this template.
This is the very first step for ultimately adding checkstyle rule for license header validation (see https://issues.apache.org/jira/browse/HDDS-7414)

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-7416

Please replace this section with the link to the Apache JIRA)

## How was this patch tested?

checkstyle, unit tests