### PR TITLE
HDDS-7402. Adapt CommandQueue to track the count of each queued command type

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/NodeManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/NodeManager.java
@@ -318,6 +318,15 @@ public interface NodeManager extends StorageContainerNodeProtocol,
       SCMCommandProto.Type cmdType) throws NodeNotFoundException;
 
   /**
+   * Get the number of commands of the given type queued in the SCM CommandQueue
+   * for the given datanode.
+   * @param dnID The UUID of the datanode.
+   * @param cmdType The Type of command to query the current count for.
+   * @return The count of commands queued, or zero if none.
+   */
+  int getCommandQueueCount(UUID dnID, SCMCommandProto.Type cmdType);
+
+  /**
    * Get list of SCMCommands in the Command Queue for a particular Datanode.
    * @param dnID - Datanode uuid.
    * @return list of commands

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/SCMNodeManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/SCMNodeManager.java
@@ -729,10 +729,23 @@ public class SCMNodeManager implements NodeManager {
    * @param cmdType
    * @return The queued count or -1 if no data has been received from the DN.
    */
+  @Override
   public int getNodeQueuedCommandCount(DatanodeDetails datanodeDetails,
       SCMCommandProto.Type cmdType) throws NodeNotFoundException {
     DatanodeInfo datanodeInfo = nodeStateManager.getNode(datanodeDetails);
     return datanodeInfo.getCommandCount(cmdType);
+  }
+
+  /**
+   * Get the number of commands of the given type queued in the SCM CommandQueue
+   * for the given datanode.
+   * @param dnID The UUID of the datanode.
+   * @param cmdType The Type of command to query the current count for.
+   * @return The count of commands queued, or zero if none.
+   */
+  @Override
+  public int getCommandQueueCount(UUID dnID, SCMCommandProto.Type cmdType) {
+    return commandQueue.getDatanodeCommandCount(dnID, cmdType);
   }
 
   /**

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/MockNodeManager.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/MockNodeManager.java
@@ -616,6 +616,18 @@ public class MockNodeManager implements NodeManager {
   }
 
   /**
+   * Get the number of commands of the given type queued in the SCM CommandQueue
+   * for the given datanode.
+   * @param dnID The UUID of the datanode.
+   * @param cmdType The Type of command to query the current count for.
+   * @return The count of commands queued, or zero if none.
+   */
+  @Override
+  public int getCommandQueueCount(UUID dnID, SCMCommandProto.Type cmdType) {
+    return 0;
+  }
+
+  /**
    * Update set of containers available on a datanode.
    * @param uuid - DatanodeID
    * @param containerIds - Set of containerIDs

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/SimpleMockNodeManager.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/SimpleMockNodeManager.java
@@ -309,6 +309,18 @@ public class SimpleMockNodeManager implements NodeManager {
     return -1;
   }
 
+  /**
+   * Get the number of commands of the given type queued in the SCM CommandQueue
+   * for the given datanode.
+   * @param dnID The UUID of the datanode.
+   * @param cmdType The Type of command to query the current count for.
+   * @return The count of commands queued, or zero if none.
+   */
+  @Override
+  public int getCommandQueueCount(UUID dnID, SCMCommandProto.Type cmdType) {
+    return 0;
+  }
+
   @Override
   public List<SCMCommand> getCommandQueue(UUID dnID) {
     return null;

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/node/TestCommandQueue.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/node/TestCommandQueue.java
@@ -1,0 +1,108 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.apache.hadoop.hdds.scm.node;
+
+import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
+import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.SCMCommandProto;
+import org.apache.hadoop.hdds.scm.pipeline.PipelineID;
+import org.apache.hadoop.ozone.protocol.commands.CloseContainerCommand;
+import org.apache.hadoop.ozone.protocol.commands.CreatePipelineCommand;
+import org.apache.hadoop.ozone.protocol.commands.SCMCommand;
+import org.junit.Assert;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * Test for the CommandQueue class.
+ */
+
+public class TestCommandQueue {
+
+  private final long containerID = 1;
+  private CommandQueue commandQueue;
+
+  @BeforeEach
+  public void setup() {
+    commandQueue = new CommandQueue();
+  }
+
+  @Test
+  public void testSummaryUpdated() {
+    SCMCommand<?> closeContainerCommand =
+        new CloseContainerCommand(containerID, PipelineID.randomId());
+    SCMCommand<?> createPipelineCommand =
+        new CreatePipelineCommand(PipelineID.randomId(),
+            HddsProtos.ReplicationType.RATIS,
+            HddsProtos.ReplicationFactor.THREE, Collections.emptyList());
+
+    UUID datanode1UUID = UUID.randomUUID();
+    UUID datanode2UUID = UUID.randomUUID();
+
+    commandQueue.addCommand(datanode1UUID, closeContainerCommand);
+    commandQueue.addCommand(datanode1UUID, closeContainerCommand);
+    commandQueue.addCommand(datanode1UUID, createPipelineCommand);
+
+    commandQueue.addCommand(datanode2UUID, closeContainerCommand);
+    commandQueue.addCommand(datanode2UUID, createPipelineCommand);
+    commandQueue.addCommand(datanode2UUID, createPipelineCommand);
+
+    // Check zero returned for unknown DN
+    Assert.assertEquals(0, commandQueue.getDatanodeCommandCount(
+        UUID.randomUUID(), SCMCommandProto.Type.closeContainerCommand));
+
+    Assert.assertEquals(2, commandQueue.getDatanodeCommandCount(
+        datanode1UUID, SCMCommandProto.Type.closeContainerCommand));
+    Assert.assertEquals(1, commandQueue.getDatanodeCommandCount(
+        datanode1UUID, SCMCommandProto.Type.createPipelineCommand));
+    Assert.assertEquals(0, commandQueue.getDatanodeCommandCount(
+        datanode1UUID, SCMCommandProto.Type.closePipelineCommand));
+
+    Assert.assertEquals(1, commandQueue.getDatanodeCommandCount(
+        datanode2UUID, SCMCommandProto.Type.closeContainerCommand));
+    Assert.assertEquals(2, commandQueue.getDatanodeCommandCount(
+        datanode2UUID, SCMCommandProto.Type.createPipelineCommand));
+
+    // Ensure the counts are cleared when the commands are retrieved
+    List<SCMCommand> cmds = commandQueue.getCommand(datanode1UUID);
+    Assert.assertEquals(3, cmds.size());
+
+    Assert.assertEquals(0, commandQueue.getDatanodeCommandCount(
+        datanode1UUID, SCMCommandProto.Type.closeContainerCommand));
+    Assert.assertEquals(0, commandQueue.getDatanodeCommandCount(
+        datanode1UUID, SCMCommandProto.Type.createPipelineCommand));
+    Assert.assertEquals(0, commandQueue.getDatanodeCommandCount(
+        datanode1UUID, SCMCommandProto.Type.closePipelineCommand));
+
+    Assert.assertEquals(1, commandQueue.getDatanodeCommandCount(
+        datanode2UUID, SCMCommandProto.Type.closeContainerCommand));
+    Assert.assertEquals(2, commandQueue.getDatanodeCommandCount(
+        datanode2UUID, SCMCommandProto.Type.createPipelineCommand));
+
+    // Ensure the commands are zeroed when the queue is cleared
+    commandQueue.clear();
+    Assert.assertEquals(0, commandQueue.getDatanodeCommandCount(
+        datanode2UUID, SCMCommandProto.Type.closeContainerCommand));
+    Assert.assertEquals(0, commandQueue.getDatanodeCommandCount(
+        datanode2UUID, SCMCommandProto.Type.createPipelineCommand));
+  }
+
+}

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/ozone/container/testutils/ReplicationNodeManagerMock.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/ozone/container/testutils/ReplicationNodeManagerMock.java
@@ -451,6 +451,18 @@ public class ReplicationNodeManagerMock implements NodeManager {
     return -1;
   }
 
+  /**
+   * Get the number of commands of the given type queued in the SCM CommandQueue
+   * for the given datanode.
+   * @param dnID The UUID of the datanode.
+   * @param cmdType The Type of command to query the current count for.
+   * @return The count of commands queued, or zero if none.
+   */
+  @Override
+  public int getCommandQueueCount(UUID dnID, SCMCommandProto.Type cmdType) {
+    return commandQueue.getDatanodeCommandCount(dnID, cmdType);
+  }
+
   @Override
   public void onMessage(CommandForDatanode commandForDatanode,
                         EventPublisher publisher) {


### PR DESCRIPTION
## What changes were proposed in this pull request?

Currently, all commands queued for a datanode are stored in an ArrayList, which is sent to the DN on each heartbeat.

In order to limit the number of commands queued on a DN at any time, it would be useful to be able to query the current queued count of each command type, allowing Replication Manager, for example, to stop sending more work to the DN until it has free capacity.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-7402

## How was this patch tested?

New unit tests
