### PR TITLE
HDDS-7423. DB Scanner should allow iteration from specific key

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestLDBCli.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestLDBCli.java
@@ -113,7 +113,6 @@ public class TestLDBCli {
     }
     rdbParser.setDbPath(dbStore.getDbLocation().getAbsolutePath());
     dbScanner.setParent(rdbParser);
-    dbScanner.setStartKey("/sampleVol/sampleBuck/key3");
     Assert.assertEquals(5, getKeyNames(dbScanner).size());
     Assert.assertTrue(getKeyNames(dbScanner).contains("key1"));
     Assert.assertTrue(getKeyNames(dbScanner).contains("key5"));
@@ -121,6 +120,11 @@ public class TestLDBCli {
 
     DBScanner.setLimit(1);
     Assert.assertEquals(1, getKeyNames(dbScanner).size());
+
+    // Testing the startKey function
+    DBScanner.setLimit(-1);
+    DBScanner.setStartKey("key3");
+    Assert.assertEquals(3, getKeyNames(dbScanner).size());
 
     DBScanner.setLimit(0);
     try {
@@ -132,6 +136,7 @@ public class TestLDBCli {
 
     // If set with -1, check if it dumps entire table data.
     DBScanner.setLimit(-1);
+    DBScanner.setStartKey(null);
     Assert.assertEquals(5, getKeyNames(dbScanner).size());
 
     // Test dump to file.

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestLDBCli.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestLDBCli.java
@@ -113,6 +113,7 @@ public class TestLDBCli {
     }
     rdbParser.setDbPath(dbStore.getDbLocation().getAbsolutePath());
     dbScanner.setParent(rdbParser);
+    dbScanner.setStartKey("/sampleVol/sampleBuck/key3");
     Assert.assertEquals(5, getKeyNames(dbScanner).size());
     Assert.assertTrue(getKeyNames(dbScanner).contains("key1"));
     Assert.assertTrue(getKeyNames(dbScanner).contains("key5"));

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/DBScanner.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/DBScanner.java
@@ -23,6 +23,8 @@ import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import org.apache.hadoop.hdds.cli.SubcommandWithParent;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import org.apache.hadoop.hdds.scm.container.ContainerID;
+import org.apache.hadoop.hdds.scm.pipeline.PipelineID;
 import org.apache.hadoop.hdds.utils.db.DBColumnFamilyDefinition;
 import org.apache.hadoop.hdds.utils.db.DBDefinition;
 import org.apache.hadoop.hdds.utils.db.FixedLengthStringUtils;
@@ -48,6 +50,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
+import java.util.UUID;
 import java.util.concurrent.Callable;
 
 /**
@@ -80,6 +83,10 @@ public class DBScanner implements Callable<Void>, SubcommandWithParent {
       description = "File to dump table scan data")
   private static String fileName;
 
+  @CommandLine.Option(names = {"--startkey", "-sk"},
+      description = "Key from which to iterate the DB")
+  private static String startKey;
+
   @CommandLine.Option(names = {"--dnSchema", "-d"},
       description = "Datanode DB Schema Version : V1/V2/V3",
       defaultValue = "V2")
@@ -97,9 +104,31 @@ public class DBScanner implements Callable<Void>, SubcommandWithParent {
 
   private List<Object> scannedObjects;
 
+  public static byte[] getValueObject(
+      DBColumnFamilyDefinition dbColumnFamilyDefinition) throws IOException {
+    String str = dbColumnFamilyDefinition.getKeyType().getName();
+    if (str.equals("java.lang.String")) {
+      return startKey.getBytes();
+    } else if (str.equals("org.apache.hadoop.hdds.scm.container.ContainerID")) {
+      return new ContainerID(Long.parseLong(startKey)).getBytes();
+    } else if (str.equals("java.lang.Long")) {
+      return Longs.toByteArray(Long.parseLong(startKey));
+    } else if (str.equals("org.apache.hadoop.hdds.scm.pipeline.PipelineID")) {
+      return PipelineID.valueOf(UUID.fromString(startKey)).getProtobuf()
+          .toByteArray();
+    } else {
+      throw new IllegalArgumentException(
+          "StartKey is not supported for this table.");
+    }
+  }
+
   private static List<Object> displayTable(ManagedRocksIterator iterator,
       DBColumnFamilyDefinition dbColumnFamilyDefinition) throws IOException {
     List<Object> outputs = new ArrayList<>();
+
+    if (startKey != null) {
+      iterator.get().seek(getValueObject(dbColumnFamilyDefinition));
+    }
 
     Writer fileWriter = null;
     PrintWriter printWriter = null;
@@ -298,6 +327,10 @@ public class DBScanner implements Callable<Void>, SubcommandWithParent {
   @Override
   public Class<?> getParentType() {
     return RDBParser.class;
+  }
+
+  public void setStartKey(String startKey) {
+    DBScanner.startKey = startKey;
   }
 }
 

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/DBScanner.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/DBScanner.java
@@ -106,14 +106,14 @@ public class DBScanner implements Callable<Void>, SubcommandWithParent {
 
   public static byte[] getValueObject(
       DBColumnFamilyDefinition dbColumnFamilyDefinition) throws IOException {
-    String str = dbColumnFamilyDefinition.getKeyType().getName();
-    if (str.equals("java.lang.String")) {
-      return startKey.getBytes();
-    } else if (str.equals("org.apache.hadoop.hdds.scm.container.ContainerID")) {
+    Class<?> keyType = dbColumnFamilyDefinition.getKeyType();
+    if (keyType.equals(String.class)) {
+      return startKey.getBytes(StandardCharsets.UTF_8);
+    } else if (keyType.equals(ContainerID.class)) {
       return new ContainerID(Long.parseLong(startKey)).getBytes();
-    } else if (str.equals("java.lang.Long")) {
+    } else if (keyType.equals(Long.class)) {
       return Longs.toByteArray(Long.parseLong(startKey));
-    } else if (str.equals("org.apache.hadoop.hdds.scm.pipeline.PipelineID")) {
+    } else if (keyType.equals(PipelineID.class)) {
       return PipelineID.valueOf(UUID.fromString(startKey)).getProtobuf()
           .toByteArray();
     } else {
@@ -329,7 +329,7 @@ public class DBScanner implements Callable<Void>, SubcommandWithParent {
     return RDBParser.class;
   }
 
-  public void setStartKey(String startKey) {
+  public static void setStartKey(String startKey) {
     DBScanner.startKey = startKey;
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

The current RocksDB scanner command allows only a simple length parameter to limit the number of records to scan in a specific col family. In the case of a huge table like keyTable or containers, while we are looking for a specific entry, the search is needlessly large and explorative (since we do not know the 'index' of the key)

A startKey param would be useful.

 ozone debug ldb --db=<> scan --column_family=<> --length=<> --startKey=<>

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-7423

## How was this patch tested?

Tested Manually.
