### PR TITLE
HDDS-5526. ContainerBalancer#checkConditionsForBalancing pre-emptively checks iteration limits.

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/balancer/AbstractFindTargetGreedy.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/balancer/AbstractFindTargetGreedy.java
@@ -222,10 +222,7 @@ public abstract class AbstractFindTargetGreedy implements FindTargetStrategy {
     setConfiguration(conf);
     setUpperLimit(upLimit);
     sizeEnteringNode.clear();
-    potentialDataNodes.forEach(
-        p -> sizeEnteringNode.put(p.getDatanodeDetails(), 0L));
-    potentialTargets.clear();
-    potentialTargets.addAll(potentialDataNodes);
+    resetTargets(potentialDataNodes);
   }
 
   @VisibleForTesting
@@ -240,4 +237,22 @@ public abstract class AbstractFindTargetGreedy implements FindTargetStrategy {
    */
   @VisibleForTesting
   public abstract void sortTargetForSource(DatanodeDetails source);
+
+  /**
+   * Resets the collection of potential target datanodes that are considered
+   * to identify a target for a source.
+   * @param targets potential targets
+   */
+  void resetTargets(Collection<DatanodeUsageInfo> targets) {
+    potentialTargets.clear();
+    targets.forEach(datanodeUsageInfo -> {
+      sizeEnteringNode.putIfAbsent(datanodeUsageInfo.getDatanodeDetails(), 0L);
+      potentialTargets.add(datanodeUsageInfo);
+    });
+  }
+
+  NodeManager getNodeManager() {
+    return nodeManager;
+  }
+
 }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/balancer/ContainerBalancerTask.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/balancer/ContainerBalancerTask.java
@@ -462,7 +462,6 @@ public class ContainerBalancerTask implements Runnable {
     // loop
     //TODO(jacksonyao): take withinThresholdUtilizedNodes as candidate for both
     // source and target
-    findSourceStrategy.reInitialize(getPotentialSources(), config, lowerLimit);
     List<DatanodeUsageInfo> potentialTargets = getPotentialTargets();
     findTargetStrategy.reInitialize(potentialTargets, config, upperLimit);
     findSourceStrategy.reInitialize(getPotentialSources(), config, lowerLimit);

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/balancer/FindSourceStrategy.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/balancer/FindSourceStrategy.java
@@ -21,6 +21,8 @@ package org.apache.hadoop.hdds.scm.container.balancer;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
 import org.apache.hadoop.hdds.scm.node.DatanodeUsageInfo;
 
+import javax.annotation.Nonnull;
+import java.util.Collection;
 import java.util.List;
 
 /**
@@ -64,4 +66,13 @@ public interface FindSourceStrategy {
    */
   void reInitialize(List<DatanodeUsageInfo> potentialDataNodes,
                     ContainerBalancerConfiguration config, Double lowerLimit);
+
+  /**
+   * Resets the collection of source {@link DatanodeUsageInfo} that can be
+   * selected for balancing.
+   *
+   * @param sources collection of source
+   *                {@link DatanodeDetails} that containers can move from
+   */
+  void resetPotentialSources(@Nonnull Collection<DatanodeDetails> sources);
 }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/balancer/FindTargetGreedyByNetworkTopology.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/balancer/FindTargetGreedyByNetworkTopology.java
@@ -25,8 +25,11 @@ import org.apache.hadoop.hdds.scm.container.ContainerManager;
 import org.apache.hadoop.hdds.scm.net.NetworkTopology;
 import org.apache.hadoop.hdds.scm.node.DatanodeUsageInfo;
 import org.apache.hadoop.hdds.scm.node.NodeManager;
+import org.jetbrains.annotations.NotNull;
 import org.slf4j.LoggerFactory;
 
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
@@ -75,4 +78,22 @@ public class FindTargetGreedyByNetworkTopology
         return compareByUsage(da, db);
       });
   }
+
+  /**
+   * Resets the collection of target datanode usage info that will be
+   * considered for balancing. Gets the latest usage info from node manager.
+   * @param targets collection of target {@link DatanodeDetails} that
+   *                containers can move to
+   */
+  @Override
+  public void resetPotentialTargets(
+      @NotNull Collection<DatanodeDetails> targets) {
+    // create DatanodeUsageInfo from DatanodeDetails
+    List<DatanodeUsageInfo> usageInfos = new ArrayList<>(targets.size());
+    targets.forEach(datanodeDetails -> usageInfos.add(
+        getNodeManager().getUsageInfo(datanodeDetails)));
+
+    super.resetTargets(usageInfos);
+  }
+
 }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/balancer/FindTargetGreedyByUsageInfo.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/balancer/FindTargetGreedyByUsageInfo.java
@@ -22,9 +22,14 @@ import com.google.common.annotations.VisibleForTesting;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
 import org.apache.hadoop.hdds.scm.PlacementPolicyValidateProxy;
 import org.apache.hadoop.hdds.scm.container.ContainerManager;
+import org.apache.hadoop.hdds.scm.node.DatanodeUsageInfo;
 import org.apache.hadoop.hdds.scm.node.NodeManager;
+import org.jetbrains.annotations.NotNull;
 import org.slf4j.LoggerFactory;
 
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
 import java.util.TreeSet;
 
 /**
@@ -49,4 +54,22 @@ public class FindTargetGreedyByUsageInfo extends AbstractFindTargetGreedy {
     //noop, Treeset is naturally sorted.
     return;
   }
+
+  /**
+   * Resets the collection of target datanode usage info that will be
+   * considered for balancing. Gets the latest usage info from node manager.
+   * @param targets collection of target {@link DatanodeDetails} that
+   *                containers can move to
+   */
+  @Override
+  public void resetPotentialTargets(
+      @NotNull Collection<DatanodeDetails> targets) {
+    // create DatanodeUsageInfo from DatanodeDetails
+    List<DatanodeUsageInfo> usageInfos = new ArrayList<>(targets.size());
+    targets.forEach(datanodeDetails -> usageInfos.add(
+        getNodeManager().getUsageInfo(datanodeDetails)));
+
+    super.resetTargets(usageInfos);
+  }
+
 }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/balancer/FindTargetStrategy.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/balancer/FindTargetStrategy.java
@@ -22,6 +22,8 @@ import org.apache.hadoop.hdds.protocol.DatanodeDetails;
 import org.apache.hadoop.hdds.scm.container.ContainerID;
 import org.apache.hadoop.hdds.scm.node.DatanodeUsageInfo;
 
+import javax.annotation.Nonnull;
+import java.util.Collection;
 import java.util.List;
 import java.util.Set;
 
@@ -60,4 +62,11 @@ public interface FindTargetStrategy {
   void reInitialize(List<DatanodeUsageInfo> potentialDataNodes,
                     ContainerBalancerConfiguration config, Double upperLimit);
 
+  /**
+   * Resets the collection of target {@link DatanodeUsageInfo} that can be
+   * selected for balancing.
+   * @param targets collection of target {@link DatanodeDetails}
+   *               that containers can be moved to
+   */
+  void resetPotentialTargets(@Nonnull Collection<DatanodeDetails> targets);
 }

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/balancer/TestContainerBalancerTask.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/balancer/TestContainerBalancerTask.java
@@ -133,7 +133,7 @@ public class TestContainerBalancerTask {
     balancerConfiguration.setMaxSizeToMovePerIteration(50 * STORAGE_UNIT);
     balancerConfiguration.setMaxSizeEnteringTarget(50 * STORAGE_UNIT);
     conf.setFromObject(balancerConfiguration);
-    GenericTestUtils.setLogLevel(ContainerBalancer.LOG, Level.DEBUG);
+    GenericTestUtils.setLogLevel(ContainerBalancerTask.LOG, Level.DEBUG);
 
     averageUtilization = createCluster();
     mockNodeManager = new MockNodeManager(datanodeToContainersMap);

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/balancer/TestContainerBalancerTask.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/balancer/TestContainerBalancerTask.java
@@ -290,14 +290,13 @@ public class TestContainerBalancerTask {
   public void containerBalancerShouldObeyMaxDatanodesToInvolveLimit()
       throws IllegalContainerBalancerStateException, IOException,
       InvalidContainerBalancerConfigurationException, TimeoutException {
-    int percent = 20;
+    int percent = 40;
     balancerConfiguration.setMaxDatanodesPercentageToInvolvePerIteration(
         percent);
     balancerConfiguration.setMaxSizeToMovePerIteration(100 * STORAGE_UNIT);
     balancerConfiguration.setThreshold(1);
     balancerConfiguration.setIterations(1);
     startBalancer(balancerConfiguration);
-
 
     int number = percent * numberOfNodes / 100;
     ContainerBalancerMetrics metrics = containerBalancerTask.getMetrics();

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/balancer/TestFindTargetStrategy.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/balancer/TestFindTargetStrategy.java
@@ -20,6 +20,7 @@ package org.apache.hadoop.hdds.scm.container.balancer;
 
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
 import org.apache.hadoop.hdds.protocol.MockDatanodeDetails;
+import org.apache.hadoop.hdds.scm.container.MockNodeManager;
 import org.apache.hadoop.hdds.scm.container.placement.metrics.SCMNodeStat;
 import org.apache.hadoop.hdds.scm.net.NetworkTopology;
 import org.apache.hadoop.hdds.scm.net.NetworkTopologyImpl;
@@ -88,6 +89,39 @@ public class TestFindTargetStrategy {
     Assertions.assertEquals(((DatanodeUsageInfo)sortedPotentialTargetArray[2])
         .getDatanodeDetails(), dui1.getDatanodeDetails());
 
+  }
+
+  /**
+   * Tests {@link FindTargetStrategy#resetPotentialTargets(Collection)}.
+   */
+  @Test
+  public void testResetPotentialTargets() {
+    // create three datanodes with different usage infos
+    DatanodeUsageInfo dui1 = new DatanodeUsageInfo(MockDatanodeDetails
+        .randomDatanodeDetails(), new SCMNodeStat(100, 30, 70));
+    DatanodeUsageInfo dui2 = new DatanodeUsageInfo(MockDatanodeDetails
+        .randomDatanodeDetails(), new SCMNodeStat(100, 20, 80));
+    DatanodeUsageInfo dui3 = new DatanodeUsageInfo(MockDatanodeDetails
+        .randomDatanodeDetails(), new SCMNodeStat(100, 10, 90));
+
+    List<DatanodeUsageInfo> potentialTargets = new ArrayList<>();
+    potentialTargets.add(dui1);
+    potentialTargets.add(dui2);
+    potentialTargets.add(dui3);
+    MockNodeManager mockNodeManager = new MockNodeManager(potentialTargets);
+
+    FindTargetGreedyByUsageInfo findTargetGreedyByUsageInfo =
+        new FindTargetGreedyByUsageInfo(null, null, mockNodeManager);
+    findTargetGreedyByUsageInfo.reInitialize(potentialTargets, null, null);
+
+    // now, reset potential targets to only the first datanode
+    List<DatanodeDetails> newPotentialTargets = new ArrayList<>(1);
+    newPotentialTargets.add(dui1.getDatanodeDetails());
+    findTargetGreedyByUsageInfo.resetPotentialTargets(newPotentialTargets);
+    Assertions.assertEquals(1,
+        findTargetGreedyByUsageInfo.getPotentialTargets().size());
+    Assertions.assertEquals(dui1,
+        findTargetGreedyByUsageInfo.getPotentialTargets().iterator().next());
   }
 
   /**


### PR DESCRIPTION
## What changes were proposed in this pull request?

Currently, we stop an iteration of balancer if we are one datanode or 5GB away from the limits "datanodes.involved.max.percentage.per.iteration" and "size.moved.max.per.iteration" respectively. This is a pre-emptive check. 

This PR changes this by trying to dynamically adapt to these limits if possible instead of breaking out of the loop right away. If we're nearing the limits - that is, we're one DN away - then we restrict potential source datanodes to the ones that have already been selected. If we've reached the limits, then we restrict potential sources and targets both to datanodes that have already been selected. The iteration can continue because we aren't involving any new datanodes (Changes made in `ContainerBalancerTask`, `FindSourceStrategy` and `FindTargetStrategy`). We adapt to the max size to move limit by filtering out candidate containers according to size (changes made in `ContainerBalancerSelectionCriteria`).

For example, suppose we have 10 datanodes in the cluster and the max datanodes percentage is 90%. This means that a max of 9 DNs can be involved in balancing. When 8 datanodes have been selected for balancing, we restrict potential (datanode that can be a source for move) source DNs to already selected ones. This means we're allowed to select new target DNs, but source DNs must be ones that have already been selected. If a new target is selected, we'll reach 9 datanodes. If an already  selected target is selected, we'll stay at 8 DNs. Suppose a new target was selected. Now we have involved 9/10 datanodes, which is our limit. Balancer will now restrict potential sources and targets to already selected DNs and will never cross the limit.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-5526

## How was this patch tested?
Existing tests