### PR TITLE
HDDS-7427. [Snapshot] Add unit-testcases for Ozone snapshot feature.

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOmSnapshot.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOmSnapshot.java
@@ -394,15 +394,10 @@ public class TestOmSnapshot {
     OzoneBucket volbucket = vol.getBucket(bucket);
 
     String key = "key-";
-    byte[] value = RandomStringUtils.randomAscii(10240).getBytes(UTF_8);
-    OzoneOutputStream oneKey = volbucket.createKey(
-            key + RandomStringUtils.randomNumeric(5),
-            value.length, RATIS, ONE,
-            new HashMap<>());
-    oneKey.write(value);
-    oneKey.close();
-
+    createKeys(volbucket, key);
     String snapshotKeyPrefix = createSnapshot(volume, bucket);
+    deleteKeys(volbucket);
+
     Iterator<? extends OzoneKey> volBucketIter =
             volbucket.listKeys(snapshotKeyPrefix + "key-");
     int volBucketKeyCount = 0;
@@ -411,8 +406,6 @@ public class TestOmSnapshot {
       volBucketKeyCount++;
     }
     Assert.assertEquals(1, volBucketKeyCount);
-
-    deleteKeys(volbucket);
 
     snapshotKeyPrefix = createSnapshot(volume, bucket);
     Iterator<? extends OzoneKey> volBucketIter2 =
@@ -432,24 +425,12 @@ public class TestOmSnapshot {
     vol.createBucket(bucket);
     OzoneBucket volbucket = vol.getBucket(bucket);
 
-    String key = "key-";
-    byte[] value = RandomStringUtils.randomAscii(10240).getBytes(UTF_8);
-    OzoneOutputStream oneKey = volbucket.createKey(
-            key + "1-" + RandomStringUtils.randomNumeric(5),
-            value.length, RATIS, ONE,
-            new HashMap<>());
-    oneKey.write(value);
-    oneKey.close();
-
+    String key1 = "key-1-";
+    createKeys(volbucket, key1);
     String snapshotKeyPrefix1 = createSnapshot(volume, bucket);
 
-    OzoneOutputStream twoKey = volbucket.createKey(
-            key + "2-" + RandomStringUtils.randomNumeric(5),
-            value.length, RATIS, ONE,
-            new HashMap<>());
-    twoKey.write(value);
-    twoKey.close();
-
+    String key2 = "key-2-";
+    createKeys(volbucket, key2);
     String snapshotKeyPrefix2 = createSnapshot(volume, bucket);
 
     Iterator<? extends OzoneKey> volBucketIter =
@@ -460,7 +441,6 @@ public class TestOmSnapshot {
       volBucketKeyCount++;
     }
     Assert.assertEquals(1, volBucketKeyCount);
-
 
     Iterator<? extends OzoneKey> volBucketIter2 =
             volbucket.listKeys(snapshotKeyPrefix2 + "key-");
@@ -508,5 +488,16 @@ public class TestOmSnapshot {
       bucket.deleteKey(key.getName());
     }
   }
+
+  private void createKeys(OzoneBucket bucket, String keyprefix) throws IOException {
+    byte[] value = RandomStringUtils.randomAscii(10240).getBytes(UTF_8);
+    OzoneOutputStream fileKey = bucket.createKey(
+            keyprefix + RandomStringUtils.randomNumeric(5),
+            value.length, RATIS, ONE,
+            new HashMap<>());
+    fileKey.write(value);
+    fileKey.close();
+  }
+
 }
 

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOmSnapshot.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOmSnapshot.java
@@ -190,31 +190,10 @@ public class TestOmSnapshot {
      */
     String keyBaseA = "key-a-";
     for (int i = 0; i < 10; i++) {
-      byte[] value = RandomStringUtils.randomAscii(10240).getBytes(UTF_8);
-      OzoneOutputStream one = volAbucketA.createKey(
-          keyBaseA + i + "-" + RandomStringUtils.randomNumeric(5),
-          value.length, RATIS, ONE,
-          new HashMap<>());
-      one.write(value);
-      one.close();
-      OzoneOutputStream two = volAbucketB.createKey(
-          keyBaseA + i + "-" + RandomStringUtils.randomNumeric(5),
-          value.length, RATIS, ONE,
-          new HashMap<>());
-      two.write(value);
-      two.close();
-      OzoneOutputStream three = volBbucketA.createKey(
-          keyBaseA + i + "-" + RandomStringUtils.randomNumeric(5),
-          value.length, RATIS, ONE,
-          new HashMap<>());
-      three.write(value);
-      three.close();
-      OzoneOutputStream four = volBbucketB.createKey(
-          keyBaseA + i + "-" + RandomStringUtils.randomNumeric(5),
-          value.length, RATIS, ONE,
-          new HashMap<>());
-      four.write(value);
-      four.close();
+      createFileKey(volAbucketA, keyBaseA + i + "-");
+      createFileKey(volAbucketB, keyBaseA + i + "-");
+      createFileKey(volBbucketA, keyBaseA + i + "-");
+      createFileKey(volBbucketB, keyBaseA + i + "-");
     }
     /*
     Create 10 keys in  vol-a-<random>/buc-a-<random>,
@@ -223,33 +202,11 @@ public class TestOmSnapshot {
      */
     String keyBaseB = "key-b-";
     for (int i = 0; i < 10; i++) {
-      byte[] value = RandomStringUtils.randomAscii(10240).getBytes(UTF_8);
-      OzoneOutputStream one = volAbucketA.createKey(
-          keyBaseB + i + "-" + RandomStringUtils.randomNumeric(5),
-          value.length, RATIS, ONE,
-          new HashMap<>());
-      one.write(value);
-      one.close();
-      OzoneOutputStream two = volAbucketB.createKey(
-          keyBaseB + i + "-" + RandomStringUtils.randomNumeric(5),
-          value.length, RATIS, ONE,
-          new HashMap<>());
-      two.write(value);
-      two.close();
-      OzoneOutputStream three = volBbucketA.createKey(
-          keyBaseB + i + "-" + RandomStringUtils.randomNumeric(5),
-          value.length, RATIS, ONE,
-          new HashMap<>());
-      three.write(value);
-      three.close();
-      OzoneOutputStream four = volBbucketB.createKey(
-          keyBaseB + i + "-" + RandomStringUtils.randomNumeric(5),
-          value.length, RATIS, ONE,
-          new HashMap<>());
-      four.write(value);
-      four.close();
+      createFileKey(volAbucketA, keyBaseB + i + "-");
+      createFileKey(volAbucketB, keyBaseB + i + "-");
+      createFileKey(volBbucketA, keyBaseB + i + "-");
+      createFileKey(volBbucketB, keyBaseB + i + "-");
     }
-
 
     String snapshotKeyPrefix = createSnapshot(volumeA, bucketA);
     Iterator<? extends OzoneKey> volABucketAIter =
@@ -394,7 +351,7 @@ public class TestOmSnapshot {
     OzoneBucket volbucket = vol.getBucket(bucket);
 
     String key = "key-";
-    createKeys(volbucket, key);
+    createFileKey(volbucket, key);
     String snapshotKeyPrefix = createSnapshot(volume, bucket);
     deleteKeys(volbucket);
 
@@ -426,11 +383,11 @@ public class TestOmSnapshot {
     OzoneBucket volbucket = vol.getBucket(bucket);
 
     String key1 = "key-1-";
-    createKeys(volbucket, key1);
+    createFileKey(volbucket, key1);
     String snapshotKeyPrefix1 = createSnapshot(volume, bucket);
 
     String key2 = "key-2-";
-    createKeys(volbucket, key2);
+    createFileKey(volbucket, key2);
     String snapshotKeyPrefix2 = createSnapshot(volume, bucket);
 
     Iterator<? extends OzoneKey> volBucketIter =
@@ -489,7 +446,8 @@ public class TestOmSnapshot {
     }
   }
 
-  private void createKeys(OzoneBucket bucket, String keyprefix) throws IOException {
+  private void createFileKey(OzoneBucket bucket, String keyprefix)
+          throws IOException {
     byte[] value = RandomStringUtils.randomAscii(10240).getBytes(UTF_8);
     OzoneOutputStream fileKey = bucket.createKey(
             keyprefix + RandomStringUtils.randomNumeric(5),

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOmSnapshot.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOmSnapshot.java
@@ -368,7 +368,7 @@ public class TestOmSnapshot {
     Iterator<? extends OzoneKey> volBucketIter2 =
             volbucket.listKeys(snapshotKeyPrefix);
     while (volBucketIter2.hasNext()) {
-      fail();
+      fail("The last snapshot should not have any keys in it!");
     }
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Added unit-testcases for Ozone snapshot feature HDDS-6517

## What is the link to the Apache JIRA

[HDDS-7427](https://issues.apache.org/jira/browse/HDDS-7427)

## How was this patch tested?

Added testcases in file - hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOmSnapshot.java
`mvn -Dtest=TestOmSnapshot test`
[INFO] -------------------------------------------------------
[INFO]  T E S T S
[INFO] -------------------------------------------------------
[INFO] Running org.apache.hadoop.ozone.om.TestOmSnapshot
[INFO] Tests run: 15, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 159.773 s - in org.apache.hadoop.ozone.om.TestOmSnapshot
[INFO] 
[INFO] Results:
[INFO] 
[INFO] Tests run: 15, Failures: 0, Errors: 0, Skipped: 0
[INFO] 
