### PR TITLE
HDDS-7429. Remove Tag from SCMMetadataStoreMetrics

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/metadata/SCMMetadataStoreMetrics.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/metadata/SCMMetadataStoreMetrics.java
@@ -17,7 +17,6 @@
 
 package org.apache.hadoop.hdds.scm.metadata;
 
-import com.google.gson.Gson;
 import org.apache.commons.text.WordUtils;
 import org.apache.hadoop.metrics2.MetricsCollector;
 import org.apache.hadoop.metrics2.MetricsInfo;
@@ -31,7 +30,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
-import java.util.HashMap;
 import java.util.Map;
 import java.util.stream.Collectors;
 
@@ -48,10 +46,6 @@ public final class SCMMetadataStoreMetrics implements MetricsSource {
 
   public static final String METRICS_SOURCE_NAME =
       SCMMetadataStoreMetrics.class.getSimpleName();
-
-  private static final MetricsInfo ESTIMATED_KEY_COUNT = info(
-      "EstimatedKeyCount",
-      "Tracked estimated key count of all column families");
 
   private MetricsRegistry registry;
   private static SCMMetadataStoreMetrics instance;
@@ -84,7 +78,6 @@ public final class SCMMetadataStoreMetrics implements MetricsSource {
   public void getMetrics(MetricsCollector collector, boolean all) {
     MetricsRecordBuilder builder = collector.addRecord(METRICS_SOURCE_NAME);
 
-    Map<String, Long> keyCountMap = new HashMap<>();
     for (Map.Entry<String, MetricsInfo> entry: columnFamilyMetrics.entrySet()) {
       long count = 0L;
       try {
@@ -95,11 +88,7 @@ public final class SCMMetadataStoreMetrics implements MetricsSource {
             entry.getKey(), e);
       }
       builder.addGauge(entry.getValue(), count);
-      keyCountMap.put(entry.getKey(), count);
     }
-
-    Gson gson = new Gson();
-    builder.tag(ESTIMATED_KEY_COUNT, gson.toJson(keyCountMap));
   }
 
   public static synchronized void unRegister() {

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/metadata/TestSCMMetadataStoreImpl.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/metadata/TestSCMMetadataStoreImpl.java
@@ -30,7 +30,6 @@ import java.nio.file.Path;
 
 import static org.apache.hadoop.test.MetricsAsserts.getLongGauge;
 import static org.apache.hadoop.test.MetricsAsserts.getMetrics;
-import static org.apache.hadoop.test.MetricsAsserts.getStringMetric;
 
 
 /**
@@ -50,8 +49,6 @@ public class TestSCMMetadataStoreImpl {
 
   @Test
   public void testEstimatedKeyCount() {
-    Assertions.assertTrue(getString("EstimatedKeyCount")
-        .contains("\"sequenceId\":0"));
     Assertions.assertEquals(0, getGauge("SequenceIdEstimatedKeyCount"));
 
     try {
@@ -60,18 +57,11 @@ public class TestSCMMetadataStoreImpl {
       // Ignore
     }
 
-    Assertions.assertTrue(getString("EstimatedKeyCount")
-        .contains("\"sequenceId\":1"));
     Assertions.assertEquals(1, getGauge("SequenceIdEstimatedKeyCount"));
   }
 
   private long getGauge(String metricName) {
     return getLongGauge(metricName,
-        getMetrics(SCMMetadataStoreMetrics.METRICS_SOURCE_NAME));
-  }
-
-  private String getString(String metricName) {
-    return getStringMetric(metricName,
         getMetrics(SCMMetadataStoreMetrics.METRICS_SOURCE_NAME));
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

In SCMMetadataStoreMetrics, we introduced a "Tag" which has all the estimated sizes as a String for a better summary.

But it's causing the Prometheus metrics page adding duplicated metrics, seems we can only have identical values in "Tag" of metrics under this constriant.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-7429

## How was this patch tested?

unit test. 