### PR TITLE
HDDS-7428. Change AllocateBlock API for precise allocation and better abstraction

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/container/common/helpers/AllocatedBlock.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/container/common/helpers/AllocatedBlock.java
@@ -26,8 +26,9 @@ import org.apache.hadoop.hdds.scm.pipeline.Pipeline;
  * contains a Pipeline and the key.
  */
 public final class AllocatedBlock {
-  private Pipeline pipeline;
-  private ContainerBlockID containerBlockID;
+  private final Pipeline pipeline;
+  private final ContainerBlockID containerBlockID;
+  private final long size;
 
   /**
    * Builder for AllocatedBlock.
@@ -35,6 +36,7 @@ public final class AllocatedBlock {
   public static class Builder {
     private Pipeline pipeline;
     private ContainerBlockID containerBlockID;
+    private long size;
 
     public Builder setPipeline(Pipeline p) {
       this.pipeline = p;
@@ -46,14 +48,21 @@ public final class AllocatedBlock {
       return this;
     }
 
+    public Builder setSize(long s) {
+      this.size = s;
+      return this;
+    }
+
     public AllocatedBlock build() {
-      return new AllocatedBlock(pipeline, containerBlockID);
+      return new AllocatedBlock(pipeline, containerBlockID, size);
     }
   }
 
-  private AllocatedBlock(Pipeline pipeline, ContainerBlockID containerBlockID) {
+  private AllocatedBlock(Pipeline pipeline, ContainerBlockID containerBlockID,
+      long size) {
     this.pipeline = pipeline;
     this.containerBlockID = containerBlockID;
+    this.size = size;
   }
 
   public Pipeline getPipeline() {
@@ -62,5 +71,13 @@ public final class AllocatedBlock {
 
   public ContainerBlockID getBlockID() {
     return containerBlockID;
+  }
+
+  public boolean hasSize() {
+    return size > 0;
+  }
+
+  public long getSize() {
+    return size;
   }
 }

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/scm/protocol/ScmBlockLocationProtocol.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/scm/protocol/ScmBlockLocationProtocol.java
@@ -65,7 +65,7 @@ public interface ScmBlockLocationProtocol extends Closeable {
   default List<AllocatedBlock> allocateBlock(long size, int numBlocks,
       ReplicationType type, ReplicationFactor factor, String owner,
       ExcludeList excludeList) throws IOException, TimeoutException {
-    return allocateBlock(size, numBlocks, ReplicationConfig
+    return allocateBlock(size, numBlocks, 0, ReplicationConfig
         .fromProtoTypeAndFactor(type, factor), owner, excludeList);
   }
 
@@ -75,6 +75,7 @@ public interface ScmBlockLocationProtocol extends Closeable {
    *
    * @param size              - size of the block.
    * @param numBlocks         - number of blocks.
+   * @param requestedSize     - total size requested.
    * @param replicationConfig - replicationConfiguration
    * @param owner             - service owner of the new block
    * @param excludeList       List of datanodes/containers to exclude during
@@ -84,7 +85,7 @@ public interface ScmBlockLocationProtocol extends Closeable {
    * @throws IOException
    */
   List<AllocatedBlock> allocateBlock(long size, int numBlocks,
-      ReplicationConfig replicationConfig, String owner,
+      long requestedSize, ReplicationConfig replicationConfig, String owner,
       ExcludeList excludeList) throws IOException;
 
   /**

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/scm/protocol/ScmBlockLocationProtocol.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/scm/protocol/ScmBlockLocationProtocol.java
@@ -66,7 +66,7 @@ public interface ScmBlockLocationProtocol extends Closeable {
   default List<AllocatedBlock> allocateBlock(long size, int numBlocks,
       ReplicationType type, ReplicationFactor factor, String owner,
       ExcludeList excludeList) throws IOException, TimeoutException {
-    return allocateBlock(size, numBlocks, ReplicationConfig
+    return allocateBlock(size * numBlocks, size, ReplicationConfig
         .fromProtoTypeAndFactor(type, factor), owner, excludeList);
   }
 
@@ -74,31 +74,8 @@ public interface ScmBlockLocationProtocol extends Closeable {
    * Asks SCM where a block should be allocated. SCM responds with the
    * set of datanodes that should be used creating this block.
    *
-   * @param size              - size of the block.
-   * @param numBlocks         - number of blocks.
-   * @param replicationConfig - replicationConfiguration
-   * @param owner             - service owner of the new block
-   * @param excludeList       List of datanodes/containers to exclude during
-   *                          block
-   *                          allocation.
-   * @return allocated block accessing info (key, pipeline).
-   * @throws IOException
-   */
-  @Deprecated
-  default List<AllocatedBlock> allocateBlock(long size, int numBlocks,
-      ReplicationConfig replicationConfig, String owner,
-      ExcludeList excludeList) throws IOException {
-    final int numData = replicationConfig instanceof ECReplicationConfig ?
-        ((ECReplicationConfig) replicationConfig).getData() : 1;
-    return allocateBlock(size * numBlocks * numData, replicationConfig,
-        owner, excludeList);
-  }
-
-  /**
-   * Asks SCM where a block should be allocated. SCM responds with the
-   * set of datanodes that should be used creating this block.
-   *
    * @param requestedSize     - total size requested.
+   * @param blockSize         - client specified block size, 0 for default.
    * @param replicationConfig - replicationConfiguration
    * @param owner             - service owner of the new block
    * @param excludeList       List of datanodes/containers to exclude during
@@ -108,7 +85,7 @@ public interface ScmBlockLocationProtocol extends Closeable {
    * @throws IOException
    */
   List<AllocatedBlock> allocateBlock(long requestedSize,
-      ReplicationConfig replicationConfig, String owner,
+      long blockSize, ReplicationConfig replicationConfig, String owner,
       ExcludeList excludeList) throws IOException;
 
   /**

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/scm/protocol/ScmBlockLocationProtocol.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/scm/protocol/ScmBlockLocationProtocol.java
@@ -65,7 +65,7 @@ public interface ScmBlockLocationProtocol extends Closeable {
   default List<AllocatedBlock> allocateBlock(long size, int numBlocks,
       ReplicationType type, ReplicationFactor factor, String owner,
       ExcludeList excludeList) throws IOException, TimeoutException {
-    return allocateBlock(size, numBlocks, 0, ReplicationConfig
+    return allocateBlock(size, numBlocks, ReplicationConfig
         .fromProtoTypeAndFactor(type, factor), owner, excludeList);
   }
 
@@ -75,6 +75,26 @@ public interface ScmBlockLocationProtocol extends Closeable {
    *
    * @param size              - size of the block.
    * @param numBlocks         - number of blocks.
+   * @param replicationConfig - replicationConfiguration
+   * @param owner             - service owner of the new block
+   * @param excludeList       List of datanodes/containers to exclude during
+   *                          block
+   *                          allocation.
+   * @return allocated block accessing info (key, pipeline).
+   * @throws IOException
+   */
+  @Deprecated
+  default List<AllocatedBlock> allocateBlock(long size, int numBlocks,
+      ReplicationConfig replicationConfig, String owner,
+      ExcludeList excludeList) throws IOException {
+    return allocateBlock(size * numBlocks, replicationConfig,
+        owner, excludeList);
+  }
+
+  /**
+   * Asks SCM where a block should be allocated. SCM responds with the
+   * set of datanodes that should be used creating this block.
+   *
    * @param requestedSize     - total size requested.
    * @param replicationConfig - replicationConfiguration
    * @param owner             - service owner of the new block
@@ -84,8 +104,8 @@ public interface ScmBlockLocationProtocol extends Closeable {
    * @return allocated block accessing info (key, pipeline).
    * @throws IOException
    */
-  List<AllocatedBlock> allocateBlock(long size, int numBlocks,
-      long requestedSize, ReplicationConfig replicationConfig, String owner,
+  List<AllocatedBlock> allocateBlock(long requestedSize,
+      ReplicationConfig replicationConfig, String owner,
       ExcludeList excludeList) throws IOException;
 
   /**

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/scm/protocol/ScmBlockLocationProtocol.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/scm/protocol/ScmBlockLocationProtocol.java
@@ -17,6 +17,7 @@
  */
 package org.apache.hadoop.hdds.scm.protocol;
 
+import org.apache.hadoop.hdds.client.ECReplicationConfig;
 import org.apache.hadoop.hdds.client.ReplicationConfig;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
 import org.apache.hadoop.hdds.scm.AddSCMRequest;
@@ -87,7 +88,9 @@ public interface ScmBlockLocationProtocol extends Closeable {
   default List<AllocatedBlock> allocateBlock(long size, int numBlocks,
       ReplicationConfig replicationConfig, String owner,
       ExcludeList excludeList) throws IOException {
-    return allocateBlock(size * numBlocks, replicationConfig,
+    final int numData = replicationConfig instanceof ECReplicationConfig ?
+        ((ECReplicationConfig) replicationConfig).getData() : 1;
+    return allocateBlock(size * numBlocks * numData, replicationConfig,
         owner, excludeList);
   }
 

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/scm/protocol/ScmBlockLocationProtocol.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/scm/protocol/ScmBlockLocationProtocol.java
@@ -17,7 +17,6 @@
  */
 package org.apache.hadoop.hdds.scm.protocol;
 
-import org.apache.hadoop.hdds.client.ECReplicationConfig;
 import org.apache.hadoop.hdds.client.ReplicationConfig;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
 import org.apache.hadoop.hdds.scm.AddSCMRequest;

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/scm/protocolPB/ScmBlockLocationProtocolClientSideTranslatorPB.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/scm/protocolPB/ScmBlockLocationProtocolClientSideTranslatorPB.java
@@ -140,6 +140,7 @@ public final class ScmBlockLocationProtocolClientSideTranslatorPB
    *
    * @param size              - size of the block.
    * @param num               - number of blocks.
+   * @param requestedSize     - total size requested.
    * @param replicationConfig - replication configuration of the blocks.
    * @param excludeList       - exclude list while allocating blocks.
    * @return allocated block accessing info (key, pipeline).
@@ -147,7 +148,7 @@ public final class ScmBlockLocationProtocolClientSideTranslatorPB
    */
   @Override
   public List<AllocatedBlock> allocateBlock(
-      long size, int num,
+      long size, int num, long requestedSize,
       ReplicationConfig replicationConfig,
       String owner, ExcludeList excludeList
   ) throws IOException {
@@ -157,6 +158,7 @@ public final class ScmBlockLocationProtocolClientSideTranslatorPB
         AllocateScmBlockRequestProto.newBuilder()
             .setSize(size)
             .setNumBlocks(num)
+            .setRequestedSize(requestedSize)
             .setType(replicationConfig.getReplicationType())
             .setOwner(owner)
             .setExcludeList(excludeList.getProtoBuf());

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/scm/protocolPB/ScmBlockLocationProtocolClientSideTranslatorPB.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/scm/protocolPB/ScmBlockLocationProtocolClientSideTranslatorPB.java
@@ -203,7 +203,8 @@ public final class ScmBlockLocationProtocolClientSideTranslatorPB
       AllocatedBlock.Builder builder = new AllocatedBlock.Builder()
           .setContainerBlockID(
               ContainerBlockID.getFromProtobuf(resp.getContainerBlockID()))
-          .setPipeline(Pipeline.getFromProtobuf(resp.getPipeline()));
+          .setPipeline(Pipeline.getFromProtobuf(resp.getPipeline()))
+          .setSize(resp.getSize());
       blocks.add(builder.build());
     }
 

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/scm/protocolPB/ScmBlockLocationProtocolClientSideTranslatorPB.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/scm/protocolPB/ScmBlockLocationProtocolClientSideTranslatorPB.java
@@ -156,7 +156,7 @@ public final class ScmBlockLocationProtocolClientSideTranslatorPB
 
     final AllocateScmBlockRequestProto.Builder requestBuilder =
         AllocateScmBlockRequestProto.newBuilder()
-            .setSize(0) // deprecated required field
+            .setSize(blockSize)
             .setNumBlocks(0) // deprecated required field
             .setRequestedSize(requestedSize)
             .setType(replicationConfig.getReplicationType())

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/scm/protocolPB/ScmBlockLocationProtocolClientSideTranslatorPB.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/scm/protocolPB/ScmBlockLocationProtocolClientSideTranslatorPB.java
@@ -139,6 +139,7 @@ public final class ScmBlockLocationProtocolClientSideTranslatorPB
    * set of datanodes that should be used creating this block.
    *
    * @param requestedSize     - total size requested.
+   * @param blockSize         - client specified block size, 0 for default.
    * @param replicationConfig - replication configuration of the blocks.
    * @param excludeList       - exclude list while allocating blocks.
    * @return allocated block accessing info (key, pipeline).
@@ -146,7 +147,7 @@ public final class ScmBlockLocationProtocolClientSideTranslatorPB
    */
   @Override
   public List<AllocatedBlock> allocateBlock(
-      long requestedSize,
+      long requestedSize, long blockSize,
       ReplicationConfig replicationConfig,
       String owner, ExcludeList excludeList
   ) throws IOException {

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/scm/protocolPB/ScmBlockLocationProtocolClientSideTranslatorPB.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/scm/protocolPB/ScmBlockLocationProtocolClientSideTranslatorPB.java
@@ -138,8 +138,6 @@ public final class ScmBlockLocationProtocolClientSideTranslatorPB
    * Asks SCM where a block should be allocated. SCM responds with the
    * set of datanodes that should be used creating this block.
    *
-   * @param size              - size of the block.
-   * @param num               - number of blocks.
    * @param requestedSize     - total size requested.
    * @param replicationConfig - replication configuration of the blocks.
    * @param excludeList       - exclude list while allocating blocks.
@@ -148,16 +146,17 @@ public final class ScmBlockLocationProtocolClientSideTranslatorPB
    */
   @Override
   public List<AllocatedBlock> allocateBlock(
-      long size, int num, long requestedSize,
+      long requestedSize,
       ReplicationConfig replicationConfig,
       String owner, ExcludeList excludeList
   ) throws IOException {
-    Preconditions.checkArgument(size > 0, "block size must be greater than 0");
+    Preconditions.checkArgument(requestedSize > 0,
+        "Requested size must be greater than 0");
 
     final AllocateScmBlockRequestProto.Builder requestBuilder =
         AllocateScmBlockRequestProto.newBuilder()
-            .setSize(size)
-            .setNumBlocks(num)
+            .setSize(0) // deprecated required field
+            .setNumBlocks(0) // deprecated required field
             .setRequestedSize(requestedSize)
             .setType(replicationConfig.getReplicationType())
             .setOwner(owner)

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/scm/protocolPB/ScmBlockLocationProtocolClientSideTranslatorPB.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/scm/protocolPB/ScmBlockLocationProtocolClientSideTranslatorPB.java
@@ -139,18 +139,17 @@ public final class ScmBlockLocationProtocolClientSideTranslatorPB
    * set of datanodes that should be used creating this block.
    *
    * @param requestedSize     - total size requested.
-   * @param blockSize         - client specified block size, 0 for default.
    * @param replicationConfig - replication configuration of the blocks.
    * @param excludeList       - exclude list while allocating blocks.
+   * @param blockSize         - client specified block size, 0 for default.
    * @return allocated block accessing info (key, pipeline).
    * @throws IOException
    */
   @Override
   public List<AllocatedBlock> allocateBlock(
-      long requestedSize, long blockSize,
-      ReplicationConfig replicationConfig,
-      String owner, ExcludeList excludeList
-  ) throws IOException {
+      long requestedSize, ReplicationConfig replicationConfig,
+      String owner, ExcludeList excludeList, long blockSize)
+      throws IOException {
     Preconditions.checkArgument(requestedSize > 0,
         "Requested size must be greater than 0");
 

--- a/hadoop-hdds/interface-server/src/main/proto/ScmServerProtocol.proto
+++ b/hadoop-hdds/interface-server/src/main/proto/ScmServerProtocol.proto
@@ -143,9 +143,12 @@ message AllocateScmBlockRequestProto {
   required string owner = 5;
   optional ExcludeListProto excludeList = 7;
 
-  //used for EC replicaiton instead of the replication factor
+  //used for EC replication instead of the replication factor
   optional hadoop.hdds.ECReplicationConfig ecReplicationConfig = 8;
 
+  // If requestedSize is greater than 0, size and numBlocks can be ignored.
+  // It is up to SCM to decide how many blocks to allocate.
+  optional uint64 requestedSize = 9;
 }
 
 /**

--- a/hadoop-hdds/interface-server/src/main/proto/ScmServerProtocol.proto
+++ b/hadoop-hdds/interface-server/src/main/proto/ScmServerProtocol.proto
@@ -136,7 +136,7 @@ enum Status {
 * Request send to SCM asking allocate block of specified size.
 */
 message AllocateScmBlockRequestProto {
-  required uint64 size = 1 [deprecated = true];
+  required uint64 size = 1; // client specified block size, 0 means None
   required uint32 numBlocks = 2 [deprecated = true];
   required ReplicationType type = 3;
   optional hadoop.hdds.ReplicationFactor factor = 4;

--- a/hadoop-hdds/interface-server/src/main/proto/ScmServerProtocol.proto
+++ b/hadoop-hdds/interface-server/src/main/proto/ScmServerProtocol.proto
@@ -136,8 +136,8 @@ enum Status {
 * Request send to SCM asking allocate block of specified size.
 */
 message AllocateScmBlockRequestProto {
-  required uint64 size = 1;
-  required uint32 numBlocks = 2;
+  required uint64 size = 1 [deprecated = true];
+  required uint32 numBlocks = 2 [deprecated = true];
   required ReplicationType type = 3;
   optional hadoop.hdds.ReplicationFactor factor = 4;
   required string owner = 5;

--- a/hadoop-hdds/interface-server/src/main/proto/ScmServerProtocol.proto
+++ b/hadoop-hdds/interface-server/src/main/proto/ScmServerProtocol.proto
@@ -202,6 +202,7 @@ message DeleteScmBlockResult {
 message AllocateBlockResponse {
   optional ContainerBlockID containerBlockID = 1;
   optional hadoop.hdds.Pipeline pipeline = 2;
+  optional uint64 size = 3;
 }
 
 /**

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/block/BlockManagerImpl.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/block/BlockManagerImpl.java
@@ -178,7 +178,7 @@ public class BlockManagerImpl implements BlockManager, BlockmanagerMXBean {
         size, replicationConfig, owner, excludeList);
 
     if (containerInfo != null) {
-      return newBlock(containerInfo);
+      return newBlock(containerInfo, size);
     }
     // we have tried all strategies we know and but somehow we are not able
     // to get a container for this block. Log that info and return a null.
@@ -192,9 +192,10 @@ public class BlockManagerImpl implements BlockManager, BlockmanagerMXBean {
    * newBlock - returns a new block assigned to a container.
    *
    * @param containerInfo - Container Info.
+   * @param size - Block Size.
    * @return AllocatedBlock
    */
-  private AllocatedBlock newBlock(ContainerInfo containerInfo)
+  private AllocatedBlock newBlock(ContainerInfo containerInfo, long size)
       throws NotLeaderException, TimeoutException {
     try {
       final Pipeline pipeline = pipelineManager
@@ -203,10 +204,11 @@ public class BlockManagerImpl implements BlockManager, BlockmanagerMXBean {
       long containerID = containerInfo.getContainerID();
       AllocatedBlock.Builder abb =  new AllocatedBlock.Builder()
           .setContainerBlockID(new ContainerBlockID(containerID, localID))
-          .setPipeline(pipeline);
+          .setPipeline(pipeline)
+          .setSize(size);
       if (LOG.isTraceEnabled()) {
-        LOG.trace("New block allocated : {} Container ID: {}", localID,
-            containerID);
+        LOG.trace("New block allocated : {} Container ID: {} Block Size: {}",
+            localID, containerID, size);
       }
       pipelineManager.incNumBlocksAllocatedMetric(pipeline.getId());
       return abb.build();

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/protocol/ScmBlockLocationProtocolServerSideTranslatorPB.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/protocol/ScmBlockLocationProtocolServerSideTranslatorPB.java
@@ -191,6 +191,7 @@ public final class ScmBlockLocationProtocolServerSideTranslatorPB
     List<AllocatedBlock> allocatedBlocks =
         impl.allocateBlock(request.getSize(),
             request.getNumBlocks(),
+            request.getRequestedSize(),
             ReplicationConfig.fromProto(
                 request.getType(),
                 request.getFactor(),

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/protocol/ScmBlockLocationProtocolServerSideTranslatorPB.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/protocol/ScmBlockLocationProtocolServerSideTranslatorPB.java
@@ -199,6 +199,7 @@ public final class ScmBlockLocationProtocolServerSideTranslatorPB
     List<AllocatedBlock> allocatedBlocks =
         impl.allocateBlock(
             requestedSize,
+            request.getSize(),
             ReplicationConfig.fromProto(
                 request.getType(),
                 request.getFactor(),

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/protocol/ScmBlockLocationProtocolServerSideTranslatorPB.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/protocol/ScmBlockLocationProtocolServerSideTranslatorPB.java
@@ -199,13 +199,13 @@ public final class ScmBlockLocationProtocolServerSideTranslatorPB
     List<AllocatedBlock> allocatedBlocks =
         impl.allocateBlock(
             requestedSize,
-            request.getSize(),
             ReplicationConfig.fromProto(
                 request.getType(),
                 request.getFactor(),
                 request.getEcReplicationConfig()),
-            request.getOwner(),
-            ExcludeList.getFromProtoBuf(request.getExcludeList()));
+                request.getOwner(),
+                ExcludeList.getFromProtoBuf(request.getExcludeList()),
+                request.getSize());
 
     AllocateScmBlockResponseProto.Builder builder =
         AllocateScmBlockResponseProto.newBuilder();

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMBlockProtocolServer.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMBlockProtocolServer.java
@@ -28,6 +28,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeoutException;
 
+import com.google.common.annotations.VisibleForTesting;
 import org.apache.hadoop.fs.CommonConfigurationKeys;
 import org.apache.hadoop.hdds.client.BlockID;
 import org.apache.hadoop.hdds.client.ECReplicationConfig;
@@ -178,6 +179,11 @@ public class SCMBlockProtocolServer implements
   public void join() throws InterruptedException {
     LOG.trace("Join RPC server for Block Protocol");
     getBlockRpcServer().join();
+  }
+
+  @VisibleForTesting
+  public long getScmBlockSize() {
+    return scmBlockSize;
   }
 
   @Override

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMBlockProtocolServer.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMBlockProtocolServer.java
@@ -197,15 +197,9 @@ public class SCMBlockProtocolServer implements
     int num = (int) ((requestedSize - 1) / (scmBlockSize * numData) + 1);
 
     if (LOG.isDebugEnabled()) {
-      if (replicationConfig instanceof ECReplicationConfig) {
-        LOG.debug("Requested Size {} replicationConfig {}," +
-                "allocating {} block groups of size {}, with {}",
-            requestedSize, replicationConfig, num, numData * size, excludeList);
-      } else {
-        LOG.debug("Requested Size {} replicationConfig {}," +
-                "allocating {} blocks of size {}, with {}",
-            requestedSize, replicationConfig, num, size, excludeList);
-      }
+      LOG.debug("Requested Size {} replicationConfig {}," +
+              "allocating {} blocks (or block groups) of size {}, with {}",
+          requestedSize, replicationConfig, num, numData * size, excludeList);
     }
 
     List<AllocatedBlock> blocks = new ArrayList<>(num);

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMBlockProtocolServer.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMBlockProtocolServer.java
@@ -199,21 +199,16 @@ public class SCMBlockProtocolServer implements
           "requestedSize is {}, with {}",
           num, size, requestedSize, excludeList);
     }
-    long lastBlockSize = size; // for backward compatibility
     if (requestedSize > 0) {
       size = scmBlockSize;
       int numData = replicationConfig instanceof ECReplicationConfig ?
           ((ECReplicationConfig) replicationConfig).getData() : 1;
       num = (int) ((requestedSize - 1) / (scmBlockSize * numData) + 1);
-      // For EC, lastBlockSize = min(lastStripeSize, scmBlockSize)
-      lastBlockSize = Math.min(scmBlockSize,
-          requestedSize - (num - 1) * scmBlockSize * numData);
     }
     try {
       for (int i = 0; i < num; i++) {
         AllocatedBlock block = scm.getScmBlockManager()
-            .allocateBlock(i + 1 == num ? lastBlockSize : size,
-                replicationConfig, owner, excludeList);
+            .allocateBlock(size, replicationConfig, owner, excludeList);
         if (block != null) {
           blocks.add(block);
         }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMBlockProtocolServer.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMBlockProtocolServer.java
@@ -188,9 +188,8 @@ public class SCMBlockProtocolServer implements
 
   @Override
   public List<AllocatedBlock> allocateBlock(
-      long requestedSize, long blockSize,
-      ReplicationConfig replicationConfig,
-      String owner, ExcludeList excludeList
+      long requestedSize, ReplicationConfig replicationConfig,
+      String owner, ExcludeList excludeList, long blockSize
   ) throws IOException {
     Map<String, String> auditMap = Maps.newHashMap();
     auditMap.put("requestedSize", String.valueOf(requestedSize));

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/StorageContainerManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/StorageContainerManager.java
@@ -1761,6 +1761,11 @@ public final class StorageContainerManager extends ServiceRuntimeInfoImpl
   }
 
   @VisibleForTesting
+  public void setScmBlockManager(BlockManager blockManager) {
+    this.scmBlockManager = blockManager;
+  }
+
+  @VisibleForTesting
   public SCMSafeModeManager getScmSafeModeManager() {
     return scmSafeModeManager;
   }

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/server/TestSCMBlockProtocolServer.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/server/TestSCMBlockProtocolServer.java
@@ -18,14 +18,25 @@
 
 package org.apache.hadoop.hdds.scm.server;
 
+import org.apache.commons.lang3.RandomUtils;
 import org.apache.hadoop.hdds.HddsConfigKeys;
+import org.apache.hadoop.hdds.client.ContainerBlockID;
+import org.apache.hadoop.hdds.client.ECReplicationConfig;
+import org.apache.hadoop.hdds.client.ReplicationConfig;
+import org.apache.hadoop.hdds.client.ReplicationFactor;
+import org.apache.hadoop.hdds.client.ReplicationType;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
 import org.apache.hadoop.hdds.protocol.proto.ScmBlockLocationProtocolProtos;
 import org.apache.hadoop.hdds.scm.HddsTestUtils;
+import org.apache.hadoop.hdds.scm.block.BlockManager;
+import org.apache.hadoop.hdds.scm.container.common.helpers.AllocatedBlock;
+import org.apache.hadoop.hdds.scm.container.common.helpers.ExcludeList;
 import org.apache.hadoop.hdds.scm.ha.SCMHAManagerStub;
 import org.apache.hadoop.hdds.scm.ha.SCMContext;
 import org.apache.hadoop.hdds.scm.node.NodeManager;
+import org.apache.hadoop.hdds.scm.pipeline.Pipeline;
+import org.apache.hadoop.hdds.scm.pipeline.PipelineID;
 import org.apache.hadoop.hdds.utils.ProtocolMessageMetrics;
 import org.apache.hadoop.hdds.scm.protocol.ScmBlockLocationProtocolServerSideTranslatorPB;
 import org.apache.hadoop.ozone.ClientVersion;
@@ -35,12 +46,17 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.Mockito;
 
 import java.io.File;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
+import java.util.stream.Stream;
 
 import static org.apache.hadoop.hdds.protocol.MockDatanodeDetails.randomDatanodeDetails;
 
@@ -75,6 +91,24 @@ public class TestSCMBlockProtocolServer {
     server = scm.getBlockProtocolServer();
     service = new ScmBlockLocationProtocolServerSideTranslatorPB(server, scm,
         Mockito.mock(ProtocolMessageMetrics.class));
+    BlockManager mockedBlockManager = Mockito.mock(BlockManager.class);
+    Mockito.when(mockedBlockManager.allocateBlock(
+        Mockito.anyLong(), Mockito.any(ReplicationConfig.class),
+            Mockito.anyString(), Mockito.any(ExcludeList.class)))
+        .thenAnswer(invocation -> new AllocatedBlock.Builder()
+            .setSize((long) invocation.getArguments()[0])
+            .setContainerBlockID(new ContainerBlockID(
+                RandomUtils.nextInt(), RandomUtils.nextInt()))
+            .setPipeline(new Pipeline.Builder()
+                .setId(PipelineID.randomId())
+                .setCreateTimestamp(System.currentTimeMillis())
+                .setState(Pipeline.PipelineState.OPEN)
+                .setReplicationConfig(invocation.getArgument(1))
+                .setNodes(Collections.emptyList())
+                .build())
+            .build()
+        );
+    scm.setScmBlockManager(mockedBlockManager);
   }
 
   @AfterEach
@@ -82,6 +116,56 @@ public class TestSCMBlockProtocolServer {
     if (scm != null) {
       scm.stop();
       scm.join();
+    }
+  }
+
+  private static final ReplicationConfig RATIS_THREE =
+      ReplicationConfig.fromTypeAndFactor(ReplicationType.RATIS,
+          ReplicationFactor.THREE);
+
+  private static final ReplicationConfig EC_3_2 =
+      new ECReplicationConfig(3, 2);
+
+  private static final ReplicationConfig EC_6_3 =
+      new ECReplicationConfig(6, 3);
+
+  private static Stream<Arguments> allocateBlockParams() {
+    return Stream.of(
+        Arguments.of(10, 10, RATIS_THREE, 1),
+        Arguments.of(11, 10, RATIS_THREE, 2),
+        Arguments.of(11, 0, RATIS_THREE, 1), // scm decide block size
+        Arguments.of(30, 10, EC_3_2, 1), // 1 stripe is 3 x 10
+        Arguments.of(31, 10, EC_3_2, 2),
+        Arguments.of(60, 10, EC_6_3, 1), // 1 stripe is 6 x 10
+        Arguments.of(61, 10, EC_6_3, 2)
+    );
+  }
+
+  @ParameterizedTest
+  @MethodSource("allocateBlockParams")
+  public void testAllocateBlock(long requestedSize, long blockSize,
+      ReplicationConfig repConfig, int expectedBlocks)
+      throws Exception {
+    List<AllocatedBlock> blocks = server.allocateBlock(
+        requestedSize, blockSize, repConfig,
+        UUID.randomUUID().toString(), new ExcludeList());
+    Assertions.assertEquals(expectedBlocks, blocks.size());
+
+    final long totalBlockSize = blocks.stream()
+        .mapToLong(AllocatedBlock::getSize)
+        .sum();
+    final long writableSize = repConfig instanceof ECReplicationConfig
+        ? ((ECReplicationConfig) repConfig).getData() * totalBlockSize
+        : totalBlockSize;
+    Assertions.assertTrue(writableSize >= requestedSize);
+
+    // TODO: allow smaller block size for the last block
+    final long expectedBlockSize = blockSize > 0 ?
+        blockSize : server.getScmBlockSize();
+    for (AllocatedBlock block : blocks) {
+      Assertions.assertEquals(expectedBlockSize, block.getSize());
+      Assertions.assertEquals(repConfig, block.getPipeline()
+          .getReplicationConfig());
     }
   }
 

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/server/TestSCMBlockProtocolServer.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/server/TestSCMBlockProtocolServer.java
@@ -147,8 +147,8 @@ public class TestSCMBlockProtocolServer {
       ReplicationConfig repConfig, int expectedBlocks)
       throws Exception {
     List<AllocatedBlock> blocks = server.allocateBlock(
-        requestedSize, blockSize, repConfig,
-        UUID.randomUUID().toString(), new ExcludeList());
+        requestedSize, repConfig, UUID.randomUUID().toString(),
+        new ExcludeList(), blockSize);
     Assertions.assertEquals(expectedBlocks, blocks.size());
 
     final long totalBlockSize = blocks.stream()

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestKeyManagerImpl.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestKeyManagerImpl.java
@@ -215,7 +215,7 @@ public class TestKeyManagerImpl {
     mockContainerClient();
 
     Mockito.when(mockScmBlockLocationProtocol
-        .allocateBlock(Mockito.anyLong(), Mockito.anyInt(),
+        .allocateBlock(Mockito.anyLong(), Mockito.anyInt(), Mockito.anyLong(),
             any(ReplicationConfig.class),
             Mockito.anyString(),
             any(ExcludeList.class))).thenThrow(

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestKeyManagerImpl.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestKeyManagerImpl.java
@@ -215,7 +215,7 @@ public class TestKeyManagerImpl {
     mockContainerClient();
 
     Mockito.when(mockScmBlockLocationProtocol
-        .allocateBlock(Mockito.anyLong(), Mockito.anyInt(), Mockito.anyLong(),
+        .allocateBlock(Mockito.anyLong(), Mockito.anyInt(),
             any(ReplicationConfig.class),
             Mockito.anyString(),
             any(ExcludeList.class))).thenThrow(

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestKeyManagerImpl.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestKeyManagerImpl.java
@@ -215,7 +215,7 @@ public class TestKeyManagerImpl {
     mockContainerClient();
 
     Mockito.when(mockScmBlockLocationProtocol
-        .allocateBlock(Mockito.anyLong(), Mockito.anyInt(),
+        .allocateBlock(Mockito.anyLong(), Mockito.anyLong(),
             any(ReplicationConfig.class),
             Mockito.anyString(),
             any(ExcludeList.class))).thenThrow(

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestKeyManagerImpl.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestKeyManagerImpl.java
@@ -215,7 +215,7 @@ public class TestKeyManagerImpl {
     mockContainerClient();
 
     Mockito.when(mockScmBlockLocationProtocol
-        .allocateBlock(Mockito.anyLong(), Mockito.anyLong(),
+        .allocateBlock(Mockito.anyLong(), Mockito.anyInt(),
             any(ReplicationConfig.class),
             Mockito.anyString(),
             any(ExcludeList.class))).thenThrow(

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestKeyManagerImpl.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestKeyManagerImpl.java
@@ -215,11 +215,12 @@ public class TestKeyManagerImpl {
     mockContainerClient();
 
     Mockito.when(mockScmBlockLocationProtocol
-        .allocateBlock(Mockito.anyLong(), Mockito.anyInt(),
+        .allocateBlock(Mockito.anyLong(),
             any(ReplicationConfig.class),
             Mockito.anyString(),
-            any(ExcludeList.class))).thenThrow(
-                new SCMException("SafeModePrecheck failed for allocateBlock",
+            any(ExcludeList.class),
+            Mockito.anyLong()))
+        .thenThrow(new SCMException("SafeModePrecheck failed for allocateBlock",
             ResultCodes.SAFE_MODE_EXCEPTION));
     createVolume(VOLUME_NAME);
     createBucket(VOLUME_NAME, BUCKET_NAME, false);

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyRequest.java
@@ -155,8 +155,8 @@ public abstract class OMKeyRequest extends OMClientRequest {
     List<AllocatedBlock> allocatedBlocks;
     try {
       allocatedBlocks = scmClient.getBlockClient()
-          .allocateBlock(requestedSizeFinal, scmBlockSize,
-              replicationConfig, omID, excludeList);
+          .allocateBlock(requestedSizeFinal, replicationConfig,
+              omID, excludeList, scmBlockSize);
     } catch (SCMException ex) {
       if (ex.getResult()
           .equals(SCMException.ResultCodes.SAFE_MODE_EXCEPTION)) {

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyRequest.java
@@ -139,16 +139,10 @@ public abstract class OMKeyRequest extends OMClientRequest {
     Preconditions.checkArgument(requestedSize > 0,
         "Requested size must be greater than 0");
 
+    int numData = replicationConfig instanceof ECReplicationConfig ?
+        ((ECReplicationConfig) replicationConfig).getData() : 1;
     // Limit the number of blocks to preallocate to the configured maximum.
-    long requestedSizeMax;
-    if (replicationConfig instanceof ECReplicationConfig) {
-      int numData = ((ECReplicationConfig) replicationConfig).getData();
-      int numStripe = preallocateBlocksMax / numData;
-      numStripe = numStripe == 0 ? 1 : numStripe; // at least one stripe
-      requestedSizeMax = numData * numStripe * scmBlockSize;
-    } else {
-      requestedSizeMax = preallocateBlocksMax * scmBlockSize;
-    }
+    final long requestedSizeMax = preallocateBlocksMax * scmBlockSize * numData;
     final long requestedSizeFinal = Math.min(requestedSize, requestedSizeMax);
 
     String remoteUser = getRemoteUser().getShortUserName();

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyRequest.java
@@ -155,8 +155,8 @@ public abstract class OMKeyRequest extends OMClientRequest {
     List<AllocatedBlock> allocatedBlocks;
     try {
       allocatedBlocks = scmClient.getBlockClient()
-          .allocateBlock(requestedSizeFinal,
-              replicationConfig, omID, excludeList);
+          .allocateBlock(requestedSizeFinal, replicationConfig, omID,
+              excludeList);
     } catch (SCMException ex) {
       if (ex.getResult()
           .equals(SCMException.ResultCodes.SAFE_MODE_EXCEPTION)) {

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyRequest.java
@@ -155,8 +155,8 @@ public abstract class OMKeyRequest extends OMClientRequest {
     List<AllocatedBlock> allocatedBlocks;
     try {
       allocatedBlocks = scmClient.getBlockClient()
-          .allocateBlock(requestedSizeFinal, replicationConfig, omID,
-              excludeList);
+          .allocateBlock(requestedSizeFinal, scmBlockSize,
+              replicationConfig, omID, excludeList);
     } catch (SCMException ex) {
       if (ex.getResult()
           .equals(SCMException.ResultCodes.SAFE_MODE_EXCEPTION)) {

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/ScmBlockLocationTestingClient.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/ScmBlockLocationTestingClient.java
@@ -113,14 +113,17 @@ public class ScmBlockLocationTestingClient implements ScmBlockLocationProtocol {
   /**
    * Returns Fake blocks to the BlockManager so we get blocks in the Database.
    * @param size - size of the block.
+   * @param num - number of blocks to return.
+   * @param requestedSize - total size requested.
+   * @param config - ReplicationConfig.
    * @param owner - String owner.
    * @param excludeList list of dns/pipelines to exclude
-   * @return
+   * @return List of AllocatedBlocks.
    * @throws IOException
    */
   @Override
   public List<AllocatedBlock> allocateBlock(long size, int num,
-      ReplicationConfig config,
+      long requestedSize, ReplicationConfig config,
       String owner, ExcludeList excludeList) throws IOException {
     DatanodeDetails datanodeDetails = randomDatanodeDetails();
     Pipeline pipeline = createPipeline(datanodeDetails);

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/ScmBlockLocationTestingClient.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/ScmBlockLocationTestingClient.java
@@ -112,9 +112,6 @@ public class ScmBlockLocationTestingClient implements ScmBlockLocationProtocol {
 
   /**
    * Returns Fake blocks to the BlockManager so we get blocks in the Database.
-   * @param size - size of the block.
-   * @param num - number of blocks to return.
-   * @param requestedSize - total size requested.
    * @param config - ReplicationConfig.
    * @param owner - String owner.
    * @param excludeList list of dns/pipelines to exclude
@@ -122,8 +119,8 @@ public class ScmBlockLocationTestingClient implements ScmBlockLocationProtocol {
    * @throws IOException
    */
   @Override
-  public List<AllocatedBlock> allocateBlock(long size, int num,
-      long requestedSize, ReplicationConfig config,
+  public List<AllocatedBlock> allocateBlock(long requestedSize,
+      ReplicationConfig config,
       String owner, ExcludeList excludeList) throws IOException {
     DatanodeDetails datanodeDetails = randomDatanodeDetails();
     Pipeline pipeline = createPipeline(datanodeDetails);

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/ScmBlockLocationTestingClient.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/ScmBlockLocationTestingClient.java
@@ -112,6 +112,7 @@ public class ScmBlockLocationTestingClient implements ScmBlockLocationProtocol {
 
   /**
    * Returns Fake blocks to the BlockManager so we get blocks in the Database.
+   * @param requestedSize - Total size to allocate.
    * @param config - ReplicationConfig.
    * @param owner - String owner.
    * @param excludeList list of dns/pipelines to exclude

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/ScmBlockLocationTestingClient.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/ScmBlockLocationTestingClient.java
@@ -113,15 +113,16 @@ public class ScmBlockLocationTestingClient implements ScmBlockLocationProtocol {
   /**
    * Returns Fake blocks to the BlockManager so we get blocks in the Database.
    * @param requestedSize - Total size to allocate.
-   * @param config - ReplicationConfig.
-   * @param owner - String owner.
-   * @param excludeList list of dns/pipelines to exclude
+   * @param blockSize     - client specified block size, 0 for default.
+   * @param config        - ReplicationConfig.
+   * @param owner         - String owner.
+   * @param excludeList   list of dns/pipelines to exclude
    * @return List of AllocatedBlocks.
    * @throws IOException
    */
   @Override
   public List<AllocatedBlock> allocateBlock(long requestedSize,
-      ReplicationConfig config,
+      long blockSize, ReplicationConfig config,
       String owner, ExcludeList excludeList) throws IOException {
     DatanodeDetails datanodeDetails = randomDatanodeDetails();
     Pipeline pipeline = createPipeline(datanodeDetails);

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/ScmBlockLocationTestingClient.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/ScmBlockLocationTestingClient.java
@@ -112,18 +112,19 @@ public class ScmBlockLocationTestingClient implements ScmBlockLocationProtocol {
 
   /**
    * Returns Fake blocks to the BlockManager so we get blocks in the Database.
+   *
    * @param requestedSize - Total size to allocate.
-   * @param blockSize     - client specified block size, 0 for default.
    * @param config        - ReplicationConfig.
    * @param owner         - String owner.
    * @param excludeList   list of dns/pipelines to exclude
+   * @param blockSize     - client specified block size, 0 for default.
    * @return List of AllocatedBlocks.
    * @throws IOException
    */
   @Override
   public List<AllocatedBlock> allocateBlock(long requestedSize,
-      long blockSize, ReplicationConfig config,
-      String owner, ExcludeList excludeList) throws IOException {
+      ReplicationConfig config, String owner, ExcludeList excludeList,
+      long blockSize) throws IOException {
     DatanodeDetails datanodeDetails = randomDatanodeDetails();
     Pipeline pipeline = createPipeline(datanodeDetails);
     long containerID = Time.monotonicNow();

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMKeyRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMKeyRequest.java
@@ -174,7 +174,7 @@ public class TestOMKeyRequest {
         .setPipeline(pipeline);
 
     when(scmBlockLocationProtocol.allocateBlock(anyLong(), anyInt(),
-        any(ReplicationConfig.class),
+        anyLong(), any(ReplicationConfig.class),
         anyString(), any(ExcludeList.class))).thenAnswer(invocation -> {
           int num = invocation.getArgument(1);
           List<AllocatedBlock> allocatedBlocks = new ArrayList<>(num);

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMKeyRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMKeyRequest.java
@@ -70,7 +70,6 @@ import org.apache.hadoop.hdds.security.token.OzoneBlockTokenSecretManager;
 import org.apache.hadoop.util.Time;
 
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
@@ -178,24 +177,23 @@ public class TestOMKeyRequest {
         any(ReplicationConfig.class), anyString(),
         any(ExcludeList.class), anyLong())
     ).thenAnswer(invocation -> {
-          long requestedSize = invocation.getArgument(0);
-          long blockSize = invocation.getArgument(4);
-          ReplicationConfig repConfig = invocation.getArgument(1);
-          int numData = repConfig instanceof ECReplicationConfig ?
-              ((ECReplicationConfig) repConfig).getData() : 1;
-          if (blockSize == 0) {
-            blockSize = scmBlockSize;
-          }
-          int num = (int) ((requestedSize - 1) / (blockSize * numData)) + 1;
-          List<AllocatedBlock> allocatedBlocks = new ArrayList<>(num);
-          for (int i = 0; i < num; i++) {
-            blockBuilder.setContainerBlockID(
-                new ContainerBlockID(CONTAINER_ID + i, LOCAL_ID + i));
-            allocatedBlocks.add(blockBuilder.build());
-          }
-          return allocatedBlocks;
-        });
-
+      long requestedSize = invocation.getArgument(0);
+      long blockSize = invocation.getArgument(4);
+      ReplicationConfig repConfig = invocation.getArgument(1);
+      int numData = repConfig instanceof ECReplicationConfig ?
+          ((ECReplicationConfig) repConfig).getData() : 1;
+      if (blockSize == 0) {
+        blockSize = scmBlockSize;
+      }
+      int num = (int) ((requestedSize - 1) / (blockSize * numData)) + 1;
+      List<AllocatedBlock> allocatedBlocks = new ArrayList<>(num);
+      for (int i = 0; i < num; i++) {
+        blockBuilder.setContainerBlockID(
+            new ContainerBlockID(CONTAINER_ID + i, LOCAL_ID + i));
+        allocatedBlocks.add(blockBuilder.build());
+      }
+      return allocatedBlocks;
+    });
 
     volumeName = UUID.randomUUID().toString();
     bucketName = UUID.randomUUID().toString();

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMKeyRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMKeyRequest.java
@@ -174,7 +174,7 @@ public class TestOMKeyRequest {
         .setPipeline(pipeline);
 
     when(scmBlockLocationProtocol.allocateBlock(anyLong(), anyInt(),
-        anyLong(), any(ReplicationConfig.class),
+        any(ReplicationConfig.class),
         anyString(), any(ExcludeList.class))).thenAnswer(invocation -> {
           int num = invocation.getArgument(1);
           List<AllocatedBlock> allocatedBlocks = new ArrayList<>(num);

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/SCMThroughputBenchmark.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/SCMThroughputBenchmark.java
@@ -482,8 +482,8 @@ public final class SCMThroughputBenchmark implements Callable<Void> {
     private void doAllocateBlock(long size, int nBlocks,
         ReplicationConfig config) {
       try {
-        scmBlockClient.allocateBlock(size, nBlocks, config, "STB",
-            new ExcludeList());
+        scmBlockClient.allocateBlock(size, nBlocks, 0,
+            config, "STB", new ExcludeList());
         succBlockCounter.incrementAndGet();
       } catch (IOException e) {
         LOG.error("{}", e);

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/SCMThroughputBenchmark.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/SCMThroughputBenchmark.java
@@ -482,8 +482,8 @@ public final class SCMThroughputBenchmark implements Callable<Void> {
     private void doAllocateBlock(long size, int nBlocks,
         ReplicationConfig config) {
       try {
-        scmBlockClient.allocateBlock(size, nBlocks, 0,
-            config, "STB", new ExcludeList());
+        scmBlockClient.allocateBlock(size, nBlocks, config, "STB",
+            new ExcludeList());
         succBlockCounter.incrementAndGet();
       } catch (IOException e) {
         LOG.error("{}", e);


### PR DESCRIPTION
## What changes were proposed in this pull request?

Currently, AllocateBlock takes two major arguments: size and num. There are some problems in the current API:

1. For EC replication type, the allocated size for clients to write is `size` * `ec.numData` * `num`, which is not a good abstraction from the HDDS client's view.
2. It assumes all blocks are in same size. However, sometimes it's useful to let SCM allocate arbitrary size the client wants (e.g. when client know the key size in advance).

In this Jira, I wish to add a `requestedSize` field in the AllocateBlock RPC.
SCM will calculate how many blocks to allocate based on `requestedSize`,
and return size of each block allocated to client.

The old `size` field is used for the client specified block size, if set to 0, SCM will decide the block size.
The old `numBlock` field is not used anymore.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-7428

## How was this patch tested?

UT: TestSCMBlockProtocolServer#testAllocateBlock
CI: https://github.com/kaijchen/ozone/actions/runs/3345373585