### PR TITLE
HDDS-7360. Investigate "TestRootedOzoneFileSystem" test cases.

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/OzoneConfigKeys.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/OzoneConfigKeys.java
@@ -531,6 +531,16 @@ public final class OzoneConfigKeys {
   public static final int
       OZONE_CLIENT_FS_MAX_LISTING_PAGE_SIZE = 5000;
 
+  public static final String
+      OZONE_SERVER_FS_LISTING_PAGE_SIZE =
+      "ozone.server.fs.listing.page.size";
+
+  public static final int
+      OZONE_SERVER_FS_LISTING_PAGE_SIZE_DEFAULT = 1024;
+
+  public static final int
+      OZONE_SERVER_FS_MAX_LISTING_PAGE_SIZE = 5000;
+
   /**
    * There is no need to instantiate this class.
    */

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/OzoneConfigKeys.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/OzoneConfigKeys.java
@@ -522,24 +522,16 @@ public final class OzoneConfigKeys {
 
   // Items listing page size for fs client sub-commands output
   public static final String
-      OZONE_CLIENT_FS_LISTING_PAGE_SIZE =
-      "ozone.client.fs.listing.page.size";
+      OZONE_FS_LISTING_PAGE_SIZE = "ozone.fs.listing.page.size";
 
   public static final int
-      OZONE_CLIENT_FS_LISTING_PAGE_SIZE_DEFAULT = 1024;
+      OZONE_FS_LISTING_PAGE_SIZE_DEFAULT = 1024;
 
   public static final int
-      OZONE_CLIENT_FS_MAX_LISTING_PAGE_SIZE = 5000;
+      OZONE_FS_MAX_LISTING_PAGE_SIZE = 5000;
 
   public static final String
-      OZONE_SERVER_FS_LISTING_PAGE_SIZE =
-      "ozone.server.fs.listing.page.size";
-
-  public static final int
-      OZONE_SERVER_FS_LISTING_PAGE_SIZE_DEFAULT = 1024;
-
-  public static final int
-      OZONE_SERVER_FS_MAX_LISTING_PAGE_SIZE = 5000;
+      OZONE_FS_LISTING_PAGE_SIZE_MAX = "ozone.fs.listing.page.size.max";
 
   /**
    * There is no need to instantiate this class.

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/OzoneConfigKeys.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/OzoneConfigKeys.java
@@ -519,6 +519,18 @@ public final class OzoneConfigKeys {
 
   public static final String OZONE_AUDIT_LOG_DEBUG_CMD_LIST_OMAUDIT =
       "ozone.audit.log.debug.cmd.list.omaudit";
+
+  // Items listing page size for fs client sub-commands output
+  public static final String
+      OZONE_CLIENT_FS_LISTING_PAGE_SIZE =
+      "ozone.client.fs.listing.page.size";
+
+  public static final int
+      OZONE_CLIENT_FS_LISTING_PAGE_SIZE_DEFAULT = 1024;
+
+  public static final int
+      OZONE_CLIENT_FS_MAX_LISTING_PAGE_SIZE = 5000;
+
   /**
    * There is no need to instantiate this class.
    */

--- a/hadoop-hdds/common/src/main/resources/ozone-default.xml
+++ b/hadoop-hdds/common/src/main/resources/ozone-default.xml
@@ -3368,4 +3368,15 @@
       optimum performance.
     </description>
   </property>
+
+  <property>
+    <name>ozone.server.fs.listing.page.size</name>
+    <value>1024</value>
+    <tag>OZONE, OM</tag>
+    <description>
+      Default listing page size value used for listing items on fs related sub-commands output. Kindly set
+      this config value responsibly to avoid high resource usage. Maximum value restricted is 5000 for
+      optimum performance.
+    </description>
+  </property>
 </configuration>

--- a/hadoop-hdds/common/src/main/resources/ozone-default.xml
+++ b/hadoop-hdds/common/src/main/resources/ozone-default.xml
@@ -3359,22 +3359,22 @@
   </property>
 
   <property>
-    <name>ozone.client.fs.listing.page.size</name>
+    <name>ozone.fs.listing.page.size</name>
     <value>1024</value>
     <tag>OZONE, CLIENT</tag>
     <description>
-      Default listing page size value used for listing items on fs related sub-commands output. Kindly set
-      this config value responsibly to avoid high resource usage. Maximum value restricted is 5000 for
+      Listing page size value used by client for listing number of items on fs related sub-commands output.
+      Kindly set this config value responsibly to avoid high resource usage. Maximum value restricted is 5000 for
       optimum performance.
     </description>
   </property>
 
   <property>
-    <name>ozone.server.fs.listing.page.size</name>
-    <value>1024</value>
+    <name>ozone.fs.listing.page.size.max</name>
+    <value>5000</value>
     <tag>OZONE, OM</tag>
     <description>
-      Default listing page size value used for listing items on fs related sub-commands output. Kindly set
+      Maximum listing page size value enforced by server for listing items on fs related sub-commands output. Kindly set
       this config value responsibly to avoid high resource usage. Maximum value restricted is 5000 for
       optimum performance.
     </description>

--- a/hadoop-hdds/common/src/main/resources/ozone-default.xml
+++ b/hadoop-hdds/common/src/main/resources/ozone-default.xml
@@ -3358,5 +3358,14 @@
     </description>
   </property>
 
-
+  <property>
+    <name>ozone.client.fs.listing.page.size</name>
+    <value>1024</value>
+    <tag>OZONE, CLIENT</tag>
+    <description>
+      Default listing page size value used for listing items on fs related sub-commands output. Kindly set
+      this config value responsibly to avoid high resource usage. Maximum value restricted is 5000 for
+      optimum performance.
+    </description>
+  </property>
 </configuration>

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneConfigUtil.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneConfigUtil.java
@@ -149,6 +149,14 @@ public final class OzoneConfigUtil {
           clientConfName, serverConfName, serverConfValue, serverConfValue);
       limitVal = serverConfValue;
     }
+    // Below logic of limiting min page size as 2 is due to behavior of
+    // startKey for getting file status where startKey once reached at
+    // leaf/key level, then startKey itself being returned when page size is
+    // set as 1 and non-recursive listStatus API at client side will go into
+    // infinite loop.
+    if (limitVal <= 1) {
+      limitVal = 2;
+    }
     return limitVal;
   }
 }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneConfigUtil.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneConfigUtil.java
@@ -24,6 +24,8 @@ import org.apache.hadoop.hdds.client.ReplicationType;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.security.UserGroupInformation;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.util.Collection;
@@ -37,6 +39,8 @@ import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_S3_ADMINISTRATORS_GR
  * Utility class for ozone configurations.
  */
 public final class OzoneConfigUtil {
+  static final Logger LOG =
+      LoggerFactory.getLogger(OzoneConfigUtil.class);
   private OzoneConfigUtil() {
   }
 
@@ -123,5 +127,28 @@ public final class OzoneConfigUtil {
       }
     }
     return replicationConfig;
+  }
+
+  /**
+   * Limits or cap the client config value to server supported config value,
+   * if client config value crosses the server supported config value.
+   * @param clientConfValue - the client config value to be capped
+   * @param clientConfName - the client config name
+   * @param serverConfName - the server config name
+   * @param serverConfValue - the server config value
+   * @return the capped config value
+   */
+  public static long limitValue(long clientConfValue, String clientConfName,
+                                String serverConfName, long serverConfValue) {
+    long limitVal = clientConfValue;
+    if (clientConfValue > serverConfValue) {
+      LOG.warn("{} config value is greater than server config {} " +
+          "value currently set at : {}, " +
+              "so limiting the config value to be used at server side " +
+              "to max value supported at server - {}",
+          clientConfName, serverConfName, serverConfValue, serverConfValue);
+      limitVal = serverConfValue;
+    }
+    return limitVal;
   }
 }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
@@ -226,15 +226,15 @@ import static org.apache.hadoop.ozone.OzoneConfigKeys.DFS_CONTAINER_RATIS_ENABLE
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_ACL_AUTHORIZER_CLASS;
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_ACL_ENABLED;
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_ACL_ENABLED_DEFAULT;
-import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_CLIENT_FS_LISTING_PAGE_SIZE;
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_FLEXIBLE_FQDN_RESOLUTION_ENABLED;
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_FLEXIBLE_FQDN_RESOLUTION_ENABLED_DEFAULT;
+import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_FS_LISTING_PAGE_SIZE;
+import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_FS_LISTING_PAGE_SIZE_DEFAULT;
+import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_FS_LISTING_PAGE_SIZE_MAX;
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_KEY_PREALLOCATION_BLOCKS_MAX;
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_KEY_PREALLOCATION_BLOCKS_MAX_DEFAULT;
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_SCM_BLOCK_SIZE;
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_SCM_BLOCK_SIZE_DEFAULT;
-import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_SERVER_FS_LISTING_PAGE_SIZE;
-import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_SERVER_FS_LISTING_PAGE_SIZE_DEFAULT;
 import static org.apache.hadoop.ozone.OzoneConsts.DB_TRANSIENT_MARKER;
 import static org.apache.hadoop.ozone.OzoneConsts.DEFAULT_OM_UPDATE_ID;
 import static org.apache.hadoop.ozone.OzoneConsts.LAYOUT_VERSION_KEY;
@@ -3631,12 +3631,12 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
   public List<OzoneFileStatus> listStatus(OmKeyArgs args, boolean recursive,
       String startKey, long numEntries, boolean allowPartialPrefixes)
       throws IOException {
-    long listingPageSize = configuration.getInt(
-        OZONE_SERVER_FS_LISTING_PAGE_SIZE,
-        OZONE_SERVER_FS_LISTING_PAGE_SIZE_DEFAULT);
-    listingPageSize = OzoneConfigUtil.limitValue(numEntries,
-        OZONE_CLIENT_FS_LISTING_PAGE_SIZE, OZONE_SERVER_FS_LISTING_PAGE_SIZE,
-        listingPageSize);
+    long maxListingPageSize = configuration.getInt(
+        OZONE_FS_LISTING_PAGE_SIZE_MAX,
+        OZONE_FS_LISTING_PAGE_SIZE_DEFAULT);
+    maxListingPageSize = OzoneConfigUtil.limitValue(numEntries,
+        OZONE_FS_LISTING_PAGE_SIZE, OZONE_FS_LISTING_PAGE_SIZE_MAX,
+        maxListingPageSize);
 
     ResolvedBucket bucket = resolveBucketLink(args);
 
@@ -3652,8 +3652,8 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
 
     try {
       metrics.incNumListStatus();
-      return keyManager.listStatus(args, recursive, startKey, listingPageSize,
-              getClientAddress(), allowPartialPrefixes);
+      return keyManager.listStatus(args, recursive, startKey,
+          maxListingPageSize, getClientAddress(), allowPartialPrefixes);
     } catch (Exception ex) {
       metrics.incNumListStatusFails();
       auditSuccess = false;

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
@@ -226,12 +226,15 @@ import static org.apache.hadoop.ozone.OzoneConfigKeys.DFS_CONTAINER_RATIS_ENABLE
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_ACL_AUTHORIZER_CLASS;
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_ACL_ENABLED;
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_ACL_ENABLED_DEFAULT;
+import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_CLIENT_FS_LISTING_PAGE_SIZE;
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_FLEXIBLE_FQDN_RESOLUTION_ENABLED;
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_FLEXIBLE_FQDN_RESOLUTION_ENABLED_DEFAULT;
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_KEY_PREALLOCATION_BLOCKS_MAX;
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_KEY_PREALLOCATION_BLOCKS_MAX_DEFAULT;
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_SCM_BLOCK_SIZE;
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_SCM_BLOCK_SIZE_DEFAULT;
+import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_SERVER_FS_LISTING_PAGE_SIZE;
+import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_SERVER_FS_LISTING_PAGE_SIZE_DEFAULT;
 import static org.apache.hadoop.ozone.OzoneConsts.DB_TRANSIENT_MARKER;
 import static org.apache.hadoop.ozone.OzoneConsts.DEFAULT_OM_UPDATE_ID;
 import static org.apache.hadoop.ozone.OzoneConsts.LAYOUT_VERSION_KEY;
@@ -3628,6 +3631,12 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
   public List<OzoneFileStatus> listStatus(OmKeyArgs args, boolean recursive,
       String startKey, long numEntries, boolean allowPartialPrefixes)
       throws IOException {
+    long listingPageSize = configuration.getInt(
+        OZONE_SERVER_FS_LISTING_PAGE_SIZE,
+        OZONE_SERVER_FS_LISTING_PAGE_SIZE_DEFAULT);
+    listingPageSize = OzoneConfigUtil.limitValue(numEntries,
+        OZONE_CLIENT_FS_LISTING_PAGE_SIZE, OZONE_SERVER_FS_LISTING_PAGE_SIZE,
+        listingPageSize);
 
     ResolvedBucket bucket = resolveBucketLink(args);
 
@@ -3643,7 +3652,7 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
 
     try {
       metrics.incNumListStatus();
-      return keyManager.listStatus(args, recursive, startKey, numEntries,
+      return keyManager.listStatus(args, recursive, startKey, listingPageSize,
               getClientAddress(), allowPartialPrefixes);
     } catch (Exception ex) {
       metrics.incNumListStatusFails();

--- a/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicOzoneFileSystem.java
+++ b/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicOzoneFileSystem.java
@@ -69,11 +69,11 @@ import java.util.stream.Collectors;
 
 import static org.apache.hadoop.fs.ozone.Constants.OZONE_DEFAULT_USER;
 import static org.apache.hadoop.fs.ozone.Constants.OZONE_USER_DIR;
-import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_CLIENT_FS_LISTING_PAGE_SIZE;
-import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_CLIENT_FS_LISTING_PAGE_SIZE_DEFAULT;
-import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_CLIENT_FS_MAX_LISTING_PAGE_SIZE;
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_FS_ITERATE_BATCH_SIZE;
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_FS_ITERATE_BATCH_SIZE_DEFAULT;
+import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_FS_LISTING_PAGE_SIZE;
+import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_FS_LISTING_PAGE_SIZE_DEFAULT;
+import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_FS_MAX_LISTING_PAGE_SIZE;
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_SCM_BLOCK_SIZE;
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_SCM_BLOCK_SIZE_DEFAULT;
 import static org.apache.hadoop.ozone.OzoneConsts.OZONE_URI_DELIMITER;
@@ -104,7 +104,7 @@ public class BasicOzoneFileSystem extends FileSystem {
   private OzoneClientAdapter adapter;
 
   private int listingPageSize =
-      OZONE_CLIENT_FS_LISTING_PAGE_SIZE_DEFAULT;
+      OZONE_FS_LISTING_PAGE_SIZE_DEFAULT;
 
   private static final Pattern URL_SCHEMA_PATTERN =
       Pattern.compile("([^\\.]+)\\.([^\\.]+)\\.{0,1}(.*)");
@@ -120,11 +120,11 @@ public class BasicOzoneFileSystem extends FileSystem {
   public void initialize(URI name, Configuration conf) throws IOException {
     super.initialize(name, conf);
     listingPageSize = conf.getInt(
-        OZONE_CLIENT_FS_LISTING_PAGE_SIZE,
-        OZONE_CLIENT_FS_LISTING_PAGE_SIZE_DEFAULT);
+        OZONE_FS_LISTING_PAGE_SIZE,
+        OZONE_FS_LISTING_PAGE_SIZE_DEFAULT);
     listingPageSize = OzoneClientUtils.limitValue(listingPageSize,
-        OZONE_CLIENT_FS_LISTING_PAGE_SIZE,
-        OZONE_CLIENT_FS_MAX_LISTING_PAGE_SIZE);
+        OZONE_FS_LISTING_PAGE_SIZE,
+        OZONE_FS_MAX_LISTING_PAGE_SIZE);
     setConf(conf);
     Preconditions.checkNotNull(name.getScheme(),
         "No scheme provided in %s", name);

--- a/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicOzoneFileSystem.java
+++ b/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicOzoneFileSystem.java
@@ -67,9 +67,11 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
-import static org.apache.hadoop.fs.ozone.Constants.LISTING_PAGE_SIZE;
 import static org.apache.hadoop.fs.ozone.Constants.OZONE_DEFAULT_USER;
 import static org.apache.hadoop.fs.ozone.Constants.OZONE_USER_DIR;
+import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_CLIENT_FS_LISTING_PAGE_SIZE;
+import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_CLIENT_FS_LISTING_PAGE_SIZE_DEFAULT;
+import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_CLIENT_FS_MAX_LISTING_PAGE_SIZE;
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_FS_ITERATE_BATCH_SIZE;
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_FS_ITERATE_BATCH_SIZE_DEFAULT;
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_SCM_BLOCK_SIZE;
@@ -101,6 +103,9 @@ public class BasicOzoneFileSystem extends FileSystem {
 
   private OzoneClientAdapter adapter;
 
+  private int listingPageSize =
+      OZONE_CLIENT_FS_LISTING_PAGE_SIZE_DEFAULT;
+
   private static final Pattern URL_SCHEMA_PATTERN =
       Pattern.compile("([^\\.]+)\\.([^\\.]+)\\.{0,1}(.*)");
 
@@ -114,6 +119,12 @@ public class BasicOzoneFileSystem extends FileSystem {
   @Override
   public void initialize(URI name, Configuration conf) throws IOException {
     super.initialize(name, conf);
+    listingPageSize = conf.getInt(
+        OZONE_CLIENT_FS_LISTING_PAGE_SIZE,
+        OZONE_CLIENT_FS_LISTING_PAGE_SIZE_DEFAULT);
+    listingPageSize = OzoneClientUtils.limitValue(listingPageSize,
+        OZONE_CLIENT_FS_LISTING_PAGE_SIZE,
+        OZONE_CLIENT_FS_MAX_LISTING_PAGE_SIZE);
     setConf(conf);
     Preconditions.checkNotNull(name.getScheme(),
         "No scheme provided in %s", name);
@@ -605,7 +616,7 @@ public class BasicOzoneFileSystem extends FileSystem {
     incrementCounter(Statistic.INVOCATION_LIST_STATUS, 1);
     statistics.incrementReadOps(1);
     LOG.trace("listStatus() path:{}", f);
-    int numEntries = LISTING_PAGE_SIZE;
+    int numEntries = listingPageSize;
     LinkedList<FileStatus> statuses = new LinkedList<>();
     List<FileStatus> tmpStatusList;
     String startKey = "";
@@ -930,8 +941,8 @@ public class BasicOzoneFileSystem extends FileSystem {
         return false;
       }
       if (i >= thisListing.size()) {
-        if (startPath != null && (thisListing.size() == LISTING_PAGE_SIZE ||
-            thisListing.size() == LISTING_PAGE_SIZE - 1)) {
+        if (startPath != null && (thisListing.size() == listingPageSize ||
+            thisListing.size() == listingPageSize - 1)) {
           // current listing is exhausted & fetch a new listing
           thisListing = listFileStatus(p, startPath);
           if (thisListing != null && !thisListing.isEmpty()) {
@@ -979,7 +990,7 @@ public class BasicOzoneFileSystem extends FileSystem {
     List<FileStatus> statusList;
     statusList =
         adapter.listStatus(pathToKey(f), false, startPath,
-            LISTING_PAGE_SIZE, uri, workingDir, getUsername())
+                listingPageSize, uri, workingDir, getUsername())
             .stream()
             .map(this::convertFileStatus)
             .collect(Collectors.toList());

--- a/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicRootedOzoneFileSystem.java
+++ b/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicRootedOzoneFileSystem.java
@@ -66,9 +66,11 @@ import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
 
-import static org.apache.hadoop.fs.ozone.Constants.LISTING_PAGE_SIZE;
 import static org.apache.hadoop.fs.ozone.Constants.OZONE_DEFAULT_USER;
 import static org.apache.hadoop.fs.ozone.Constants.OZONE_USER_DIR;
+import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_CLIENT_FS_LISTING_PAGE_SIZE;
+import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_CLIENT_FS_LISTING_PAGE_SIZE_DEFAULT;
+import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_CLIENT_FS_MAX_LISTING_PAGE_SIZE;
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_FS_ITERATE_BATCH_SIZE;
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_FS_ITERATE_BATCH_SIZE_DEFAULT;
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_SCM_BLOCK_SIZE;
@@ -102,6 +104,9 @@ public class BasicRootedOzoneFileSystem extends FileSystem {
   private OzoneClientAdapter adapter;
   private BasicRootedOzoneClientAdapterImpl adapterImpl;
 
+  private int listingPageSize =
+      OZONE_CLIENT_FS_LISTING_PAGE_SIZE_DEFAULT;
+
   private static final String URI_EXCEPTION_TEXT =
       "URL should be one of the following formats: " +
       "ofs://om-service-id/path/to/key  OR " +
@@ -111,6 +116,12 @@ public class BasicRootedOzoneFileSystem extends FileSystem {
   @Override
   public void initialize(URI name, Configuration conf) throws IOException {
     super.initialize(name, conf);
+    listingPageSize = conf.getInt(
+        OZONE_CLIENT_FS_LISTING_PAGE_SIZE,
+        OZONE_CLIENT_FS_LISTING_PAGE_SIZE_DEFAULT);
+    listingPageSize = OzoneClientUtils.limitValue(listingPageSize,
+        OZONE_CLIENT_FS_LISTING_PAGE_SIZE,
+        OZONE_CLIENT_FS_MAX_LISTING_PAGE_SIZE);
     setConf(conf);
     Preconditions.checkNotNull(name.getScheme(),
         "No scheme provided in %s", name);
@@ -735,7 +746,7 @@ public class BasicRootedOzoneFileSystem extends FileSystem {
     incrementCounter(Statistic.INVOCATION_LIST_STATUS, 1);
     statistics.incrementReadOps(1);
     LOG.trace("listStatus() path:{}", f);
-    int numEntries = LISTING_PAGE_SIZE;
+    int numEntries = listingPageSize;
     LinkedList<FileStatus> statuses = new LinkedList<>();
     List<FileStatus> tmpStatusList;
     String startPath = "";
@@ -1032,8 +1043,8 @@ public class BasicRootedOzoneFileSystem extends FileSystem {
         return false;
       }
       if (i >= thisListing.size()) {
-        if (startPath != null && (thisListing.size() == LISTING_PAGE_SIZE ||
-            thisListing.size() == LISTING_PAGE_SIZE - 1)) {
+        if (startPath != null && (thisListing.size() == listingPageSize ||
+            thisListing.size() == listingPageSize - 1)) {
           // current listing is exhausted & fetch a new listing
           thisListing = listFileStatus(p, startPath);
           if (thisListing != null && !thisListing.isEmpty()) {
@@ -1081,7 +1092,7 @@ public class BasicRootedOzoneFileSystem extends FileSystem {
     List<FileStatus> statusList;
     statusList =
         adapter.listStatus(pathToKey(f), false, startPath,
-            LISTING_PAGE_SIZE, uri, workingDir, getUsername())
+                listingPageSize, uri, workingDir, getUsername())
             .stream()
             .map(this::convertFileStatus)
             .collect(Collectors.toList());

--- a/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicRootedOzoneFileSystem.java
+++ b/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicRootedOzoneFileSystem.java
@@ -68,11 +68,11 @@ import java.util.stream.Collectors;
 
 import static org.apache.hadoop.fs.ozone.Constants.OZONE_DEFAULT_USER;
 import static org.apache.hadoop.fs.ozone.Constants.OZONE_USER_DIR;
-import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_CLIENT_FS_LISTING_PAGE_SIZE;
-import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_CLIENT_FS_LISTING_PAGE_SIZE_DEFAULT;
-import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_CLIENT_FS_MAX_LISTING_PAGE_SIZE;
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_FS_ITERATE_BATCH_SIZE;
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_FS_ITERATE_BATCH_SIZE_DEFAULT;
+import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_FS_LISTING_PAGE_SIZE;
+import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_FS_LISTING_PAGE_SIZE_DEFAULT;
+import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_FS_MAX_LISTING_PAGE_SIZE;
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_SCM_BLOCK_SIZE;
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_SCM_BLOCK_SIZE_DEFAULT;
 import static org.apache.hadoop.ozone.OzoneConsts.OZONE_URI_DELIMITER;
@@ -105,7 +105,7 @@ public class BasicRootedOzoneFileSystem extends FileSystem {
   private BasicRootedOzoneClientAdapterImpl adapterImpl;
 
   private int listingPageSize =
-      OZONE_CLIENT_FS_LISTING_PAGE_SIZE_DEFAULT;
+      OZONE_FS_LISTING_PAGE_SIZE_DEFAULT;
 
   private static final String URI_EXCEPTION_TEXT =
       "URL should be one of the following formats: " +
@@ -117,11 +117,11 @@ public class BasicRootedOzoneFileSystem extends FileSystem {
   public void initialize(URI name, Configuration conf) throws IOException {
     super.initialize(name, conf);
     listingPageSize = conf.getInt(
-        OZONE_CLIENT_FS_LISTING_PAGE_SIZE,
-        OZONE_CLIENT_FS_LISTING_PAGE_SIZE_DEFAULT);
+        OZONE_FS_LISTING_PAGE_SIZE,
+        OZONE_FS_LISTING_PAGE_SIZE_DEFAULT);
     listingPageSize = OzoneClientUtils.limitValue(listingPageSize,
-        OZONE_CLIENT_FS_LISTING_PAGE_SIZE,
-        OZONE_CLIENT_FS_MAX_LISTING_PAGE_SIZE);
+        OZONE_FS_LISTING_PAGE_SIZE,
+        OZONE_FS_MAX_LISTING_PAGE_SIZE);
     setConf(conf);
     Preconditions.checkNotNull(name.getScheme(),
         "No scheme provided in %s", name);

--- a/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/OzoneClientUtils.java
+++ b/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/OzoneClientUtils.java
@@ -35,6 +35,8 @@ import org.apache.hadoop.ozone.om.exceptions.OMException;
 import org.apache.hadoop.ozone.om.helpers.BucketLayout;
 import org.apache.hadoop.ozone.om.helpers.OmKeyArgs;
 import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.util.Objects;
@@ -49,6 +51,8 @@ import static org.apache.hadoop.ozone.om.exceptions.OMException.ResultCodes.DETE
  * Shared Utilities for Ozone FS and related classes.
  */
 public final class OzoneClientUtils {
+  static final Logger LOG =
+      LoggerFactory.getLogger(OzoneClientUtils.class);
   private OzoneClientUtils() {
     // Not used.
   }
@@ -233,6 +237,16 @@ public final class OzoneClientUtils {
 
   public static boolean isKeyEncrypted(OmKeyInfo keyInfo) {
     return !Objects.isNull(keyInfo.getFileEncryptionInfo());
+  }
+
+  public static int limitValue(int confValue, String confName, int maxLimit) {
+    int limitVal = confValue;
+    if (confValue > maxLimit) {
+      LOG.warn("{} config value is greater than max value : {}, " +
+          "limiting the config value to max value..", confName, maxLimit);
+      limitVal = maxLimit;
+    }
+    return limitVal;
   }
 
 }

--- a/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/OzoneClientUtils.java
+++ b/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/OzoneClientUtils.java
@@ -246,6 +246,14 @@ public final class OzoneClientUtils {
           "limiting the config value to max value..", confName, maxLimit);
       limitVal = maxLimit;
     }
+    // Below logic of limiting min page size as 2 is due to behavior of
+    // startKey for getting file status where startKey once reached at
+    // leaf/key level, then startKey itself being returned when page size is
+    // set as 1 and non-recursive listStatus API at client side will go into
+    // infinite loop.
+    if (limitVal <= 1) {
+      limitVal = 2;
+    }
     return limitVal;
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Investigate "TestRootedOzoneFileSystem" test cases in below scenarios for setting value of property "ozone.fs.listing.page.size" as per below scenarios and verify all test cases running fine and pass.

1. If give value at client less than equal to 1, it hung.
2. If give value more than 1 upto 3, then it doesn't hung any of the test case of TestRootedOzone file, but "listStatusCheckHelper" method makes assertion fail for 2-3 test cases.
3. If give value more than 3, all test cases passed.

https://issues.apache.org/jira/browse/HDDS-7360

Investigate "TestRootedOzoneFileSystem" test cases

## How was this patch tested?

Ran manually "TestRootedOzoneFileSystem" test cases with below 3 scenarios mentioned in JIRA. First scenario explanation is given below:

Scenario1:
listingPageSize is not for the listing of overall complete list shown on CLI, this parameter is used for retrieving the listingPageSize number of  items from keyTable for a given startKey, so this is the behavior from beginning. I have fixed the issue of hung when pageSize is set as 1, after discussing with @ChenSammi and other members... that startKey behavior is something which we cannot change as of now , so better we should limit this limitPageSize always be greater than 1, so when client configures as 1, normalise to 2 , rest all as per actual configuration.. because once startKey reaches leaf level, then it returns itself which is expected behavior.

Scenario2:
Assertion is happening on below 2 values:

 - One with recursive call of listStatus function and passing "/" as startPath which is beginning  of volumes and then buckets, keys...
 - Another value assertion on non-recursive call of listStatus but trying to implement recursive behavior in test code 

Asserting these expected and actual values seems  will fail as non-recursive listStatus implementation on client side works as expected based on startPath and dependent on number of volumes which test code is creating, So here test code is creating 3 volumes , so that is the reason with listing page size up to 3 value, assertion fails. Test code should not assert on these 2 values if listing page size goes less than number of volumes user is having.
