### PR TITLE
HDDS-7420. Bump Spring framework from 5.2.20 to 5.3.23

### DIFF
--- a/hadoop-ozone/dist/src/main/license/jar-report.txt
+++ b/hadoop-ozone/dist/src/main/license/jar-report.txt
@@ -252,11 +252,11 @@ share/ozone/lib/slf4j-api.jar
 share/ozone/lib/slf4j-reload4j.jar
 share/ozone/lib/snakeyaml.jar
 share/ozone/lib/snappy-java.jar
-share/ozone/lib/spring-beans.RELEASE.jar
-share/ozone/lib/spring-core.RELEASE.jar
-share/ozone/lib/spring-jcl.RELEASE.jar
-share/ozone/lib/spring-jdbc.RELEASE.jar
-share/ozone/lib/spring-tx.RELEASE.jar
+share/ozone/lib/spring-beans.jar
+share/ozone/lib/spring-core.jar
+share/ozone/lib/spring-jcl.jar
+share/ozone/lib/spring-jdbc.jar
+share/ozone/lib/spring-tx.jar
 share/ozone/lib/sqlite-jdbc.jar
 share/ozone/lib/stax2-api.jar
 share/ozone/lib/stax-ex.jar

--- a/hadoop-ozone/pom.xml
+++ b/hadoop-ozone/pom.xml
@@ -26,7 +26,7 @@
 
   <properties>
     <docker.image>apache/ozone:${project.version}</docker.image>
-    <spring.version>5.3.21</spring.version>
+    <spring.version>5.3.23</spring.version>
     <jooq.version>3.11.10</jooq.version>
   </properties>
   <modules>

--- a/hadoop-ozone/pom.xml
+++ b/hadoop-ozone/pom.xml
@@ -26,7 +26,7 @@
 
   <properties>
     <docker.image>apache/ozone:${project.version}</docker.image>
-    <spring.version>5.2.20.RELEASE</spring.version>
+    <spring.version>5.3.21</spring.version>
     <jooq.version>3.11.10</jooq.version>
   </properties>
   <modules>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Bump Spring framework from 5.2.20 to 5.3.23.

https://issues.apache.org/jira/browse/HDDS-7420

## How was this patch tested?

Regular CI:
https://github.com/adoroszlai/hadoop-ozone/actions/runs/3335701458