### PR TITLE
HDDS-5112. Recon Insights page does not list buckets when only one volume is present.

### DIFF
--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/api/db.json
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/api/db.json
@@ -856,43 +856,43 @@
     },
     {
       "volume": "vol1",
-      "bucket": "bucket1",
+      "bucket": "bucket2",
       "fileSize": 4096,
       "count": 25
     },
     {
       "volume": "vol1",
-      "bucket": "bucket1",
+      "bucket": "bucket3",
       "fileSize": 32768,
       "count": 312
     },
     {
       "volume": "vol1",
-      "bucket": "bucket1",
+      "bucket": "bucket4",
       "fileSize": 131072,
       "count": 78
     },
     {
       "volume": "vol1",
-      "bucket": "bucket2",
+      "bucket": "bucket5",
       "fileSize": 1024,
       "count": 123
     },
     {
       "volume": "vol1",
-      "bucket": "bucket2",
+      "bucket": "bucket6",
       "fileSize": 131072,
       "count": 187
     },
     {
       "volume": "vol2",
-      "bucket": "bucket1",
+      "bucket": "bucket7",
       "fileSize": 1024,
       "count": 54
     },
     {
-      "volume": "vol2",
-      "bucket": "bucket2",
+      "volume": "vol3",
+      "bucket": "bucket8",
       "fileSize": 131072,
       "count": 217
     }

--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/views/insights/insights.tsx
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/views/insights/insights.tsx
@@ -91,12 +91,11 @@ export class Insights extends React.Component<Record<string, object>, IInsightsS
     // Update bucket options only if one volume is selected
     if (selectedVolumes && selectedVolumes.length !== null && (selectedVolumes.length === 2 && selectedVolumes[0].value == '*') || (selectedVolumes.length === 1)){
       let selectedVolume;
-      if (selectedVolumes.length === 1)
-      {
-      selectedVolume = selectedVolumes[0].value;
+      if (selectedVolumes.length === 1) {
+        selectedVolume = selectedVolumes[0].value;
       }
       else {
-      selectedVolume = selectedVolumes[1].value;
+        selectedVolume = selectedVolumes[1].value;
       }
       if (volumeBucketMap.has(selectedVolume) && volumeBucketMap.get(selectedVolume)) {
         bucketOptions = Array.from(volumeBucketMap.get(selectedVolume)!).map(bucket => ({

--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/views/insights/insights.tsx
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/views/insights/insights.tsx
@@ -89,7 +89,7 @@ export class Insights extends React.Component<Record<string, object>, IInsightsS
     // selected buckets value should be reset to all buckets
     let selectedBuckets = [allBucketsOption];
     // Update bucket options only if one volume is selected
-    if (selectedVolumes && selectedVolumes.length !== null && (selectedVolumes.length === 2 && selectedVolumes[0].value == '*') || (selectedVolumes.length === 1)){
+    if (((selectedVolumes && selectedVolumes.length != null) && (selectedVolumes.length === 2 && selectedVolumes[0].value === '*')) || (selectedVolumes.length === 1)){
       let selectedVolume;
       if (selectedVolumes.length === 1) {
         selectedVolume = selectedVolumes[0].value;

--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/views/insights/insights.tsx
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/views/insights/insights.tsx
@@ -89,7 +89,7 @@ export class Insights extends React.Component<Record<string, object>, IInsightsS
     // selected buckets value should be reset to all buckets
     let selectedBuckets = [allBucketsOption];
     // Update bucket options only if one volume is selected
-    if (((selectedVolumes && selectedVolumes.length != null) && (selectedVolumes.length === 2 && selectedVolumes[0].value === '*')) || (selectedVolumes.length === 1)){
+    if (selectedVolumes && ((selectedVolumes.length === 2 && selectedVolumes[0].value === '*') || (selectedVolumes.length === 1))){
       let selectedVolume;
       if (selectedVolumes.length === 1) {
         selectedVolume = selectedVolumes[0].value;

--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/views/insights/insights.tsx
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/views/insights/insights.tsx
@@ -89,8 +89,15 @@ export class Insights extends React.Component<Record<string, object>, IInsightsS
     // selected buckets value should be reset to all buckets
     let selectedBuckets = [allBucketsOption];
     // Update bucket options only if one volume is selected
-    if (selectedVolumes && selectedVolumes.length === 1) {
-      const selectedVolume = selectedVolumes[0].value;
+    if (selectedVolumes && selectedVolumes.length !== null && (selectedVolumes.length === 2 && selectedVolumes[0].value == '*') || (selectedVolumes.length === 1)){
+      let selectedVolume;
+      if (selectedVolumes.length === 1)
+      {
+      selectedVolume = selectedVolumes[0].value;
+      }
+      else {
+      selectedVolume = selectedVolumes[1].value;
+      }
       if (volumeBucketMap.has(selectedVolume) && volumeBucketMap.get(selectedVolume)) {
         bucketOptions = Array.from(volumeBucketMap.get(selectedVolume)!).map(bucket => ({
           label: bucket,


### PR DESCRIPTION
What changes were proposed in this pull request?
When there is only one volume present in the cluster, the buckets dropdown does not list is getting displayed.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-5112

## How was this patch tested?
Manually

![image](https://user-images.githubusercontent.com/112169209/199924302-703e1963-398d-4edd-be5d-0a8e4a32a310.png)

