### PR TITLE
HDDS-7324. S3G: Avoid calling getS3VolumeContext by using GetKeyInfo

### DIFF
--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/ObjectStore.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/ObjectStore.java
@@ -40,7 +40,6 @@ import org.apache.hadoop.ozone.om.helpers.S3VolumeContext;
 import org.apache.hadoop.ozone.om.helpers.TenantStateList;
 import org.apache.hadoop.ozone.om.helpers.TenantUserInfoValue;
 import org.apache.hadoop.ozone.om.helpers.TenantUserList;
-import org.apache.hadoop.ozone.om.protocol.S3Auth;
 import org.apache.hadoop.ozone.security.OzoneTokenIdentifier;
 import org.apache.hadoop.ozone.security.acl.OzoneObj;
 import org.apache.hadoop.security.UserGroupInformation;
@@ -165,18 +164,6 @@ public class ObjectStore {
 
   public OzoneVolume getS3Volume() throws IOException {
     final S3VolumeContext resp = proxy.getS3VolumeContext();
-
-    S3Auth s3Auth = proxy.getThreadLocalS3Auth();
-    // Update user principal if needed to be used for KMS client
-    if (s3Auth != null) {
-      // Update userPrincipal field with the value returned from OM. So that
-      //  in multi-tenancy, KMS client can use the correct identity
-      //  (instead of using accessId) to communicate with KMS.
-      LOG.debug("Updating S3Auth.userPrincipal to {}", resp.getUserPrincipal());
-      s3Auth.setUserPrincipal(resp.getUserPrincipal());
-      proxy.setThreadLocalS3Auth(s3Auth);
-    }
-
     OmVolumeArgs volume = resp.getOmVolumeArgs();
     return proxy.buildOzoneVolume(volume);
   }

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/OzoneKey.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/OzoneKey.java
@@ -22,6 +22,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import org.apache.hadoop.hdds.client.ReplicationConfig;
 import org.apache.hadoop.hdds.client.ReplicationFactor;
 import org.apache.hadoop.hdds.client.ReplicationType;
+import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
 
 import java.time.Instant;
 import java.util.Map;
@@ -185,6 +186,13 @@ public class OzoneKey {
 
   public ReplicationConfig getReplicationConfig() {
     return replicationConfig;
+  }
+
+  public static OzoneKey fromKeyInfo(OmKeyInfo keyInfo) {
+    return new OzoneKey(keyInfo.getVolumeName(), keyInfo.getBucketName(),
+        keyInfo.getKeyName(), keyInfo.getDataSize(), keyInfo.getCreationTime(),
+        keyInfo.getModificationTime(), keyInfo.getReplicationConfig(),
+        keyInfo.getMetadata());
   }
 
 }

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/protocol/ClientProtocol.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/protocol/ClientProtocol.java
@@ -134,6 +134,27 @@ public interface ClientProtocol {
    */
   S3VolumeContext getS3VolumeContext() throws IOException;
 
+  /**
+   * Returns OzoneKey that contains the application generated/visible
+   * metadata for an Ozone Object in S3 context.
+   *
+   * If Key exists, return returns OzoneKey.
+   * If Key does not exist, throws an exception with error code KEY_NOT_FOUND
+   *
+   * @return OzoneKey which gives basic information about the key.
+   */
+  OzoneKey headS3Object(String bucketName, String keyName) throws IOException;
+
+  /**
+   * Get OzoneKey in S3 context.
+   * @param bucketName Name of the Bucket
+   * @param keyName Key name
+   * @return {@link OzoneKey}
+   * @throws IOException
+   */
+  OzoneKeyDetails getS3KeyDetails(String bucketName, String keyName)
+      throws IOException;
+
   OzoneVolume buildOzoneVolume(OmVolumeArgs volume);
 
   /**

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/ObjectEndpoint.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/ObjectEndpoint.java
@@ -297,10 +297,8 @@ public class ObjectEndpoint extends EndpointBase {
             partMarker, maxParts);
       }
 
-      OzoneVolume volume = getVolume();
-
-      OzoneKeyDetails keyDetails = getClientProtocol().getKeyDetails(
-          volume.getName(), bucketName, keyPath);
+      OzoneKeyDetails keyDetails = getClientProtocol()
+          .getS3KeyDetails(bucketName, keyPath);
 
       long length = keyDetails.getDataSize();
 
@@ -445,9 +443,7 @@ public class ObjectEndpoint extends EndpointBase {
 
     OzoneKey key;
     try {
-      OzoneVolume volume = getVolume();
-      key = getClientProtocol().headObject(volume.getName(),
-          bucketName, keyPath);
+      key = getClientProtocol().headS3Object(bucketName, keyPath);
       // TODO: return the specified range bytes of this object.
     } catch (OMException ex) {
       AUDIT.logReadFailure(

--- a/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/client/ClientProtocolStub.java
+++ b/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/client/ClientProtocolStub.java
@@ -101,6 +101,19 @@ public class ClientProtocolStub implements ClientProtocol {
   }
 
   @Override
+  public OzoneKey headS3Object(String bucketName, String keyName)
+      throws IOException {
+    return objectStoreStub.getS3Volume().getBucket(bucketName)
+        .headObject(keyName);
+  }
+
+  @Override
+  public OzoneKeyDetails getS3KeyDetails(String bucketName, String keyName)
+      throws IOException {
+    return objectStoreStub.getS3Volume().getBucket(bucketName).getKey(keyName);
+  }
+
+  @Override
   public OzoneVolume buildOzoneVolume(OmVolumeArgs volume) {
     return null;
   }

--- a/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestPermissionCheck.java
+++ b/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestPermissionCheck.java
@@ -254,10 +254,9 @@ public class TestPermissionCheck {
    */
   @Test
   public void testGetKey() throws IOException {
-    Mockito.when(objectStore.getS3Volume()).thenReturn(volume);
     Mockito.when(client.getProxy()).thenReturn(clientProtocol);
     doThrow(exception).when(clientProtocol)
-        .getKeyDetails(anyString(), anyString(), anyString());
+        .getS3KeyDetails(anyString(), anyString());
     ObjectEndpoint objectEndpoint = new ObjectEndpoint();
     objectEndpoint.setClient(client);
     objectEndpoint.setHeaders(headers);


### PR DESCRIPTION
## What changes were proposed in this pull request?
HDDS-7230 implements the GetKeyInfo with the ability to assume S3 volume context by OM. That releases S3G from having to call `getS3VolumeContext` prior to calling `lookupKey`, as it does today.

Changes include:
 - S3G Get Key API to call GetKeyInfo via RpcClient with `assumeS3Context=true`, and without a proper `volumeName`. S3G doesn't need to call GetS3VolumeContext prior to GetKeyInfo. 
 - RpcClient once it sees an S3 context in the GetKeyInfo response, takes the user principal, and sets it to the [S3LocalAuthContext](https://github.com/apache/ozone/blob/master/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/protocol/ClientProtocol.java#L923-L923).

That code change reduces once roundtrip between S3G and OM for every S3 Object Get/Head request.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-7324

## How was this patch tested?

Standard CI.