### PR TITLE
HDDS-7419. Integrate the GetKeyInfo API to OFS

### DIFF
--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/rpc/RpcClient.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/rpc/RpcClient.java
@@ -1698,7 +1698,17 @@ public class RpcClient implements ClientProtocol {
         .setSortDatanodesInPipeline(topologyAwareReadEnabled)
         .setLatestVersionLocation(getLatestVersionLocation)
         .build();
-    OmKeyInfo keyInfo = ozoneManagerClient.lookupFile(keyArgs);
+    final OmKeyInfo keyInfo;
+    if (omVersion.compareTo(OzoneManagerVersion.OPTIMIZED_GET_KEY_INFO) >= 0) {
+      keyInfo = ozoneManagerClient.getKeyInfo(keyArgs, false)
+          .getKeyInfo();
+      if (!keyInfo.isFile()) {
+        throw new OMException(keyName + " is not a file.",
+            OMException.ResultCodes.NOT_A_FILE);
+      }
+    } else {
+      keyInfo = ozoneManagerClient.lookupFile(keyArgs);
+    }
     return getInputStreamWithRetryFunction(keyInfo);
   }
 

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmKeyInfo.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmKeyInfo.java
@@ -62,7 +62,7 @@ public final class OmKeyInfo extends WithParentObjectId {
   private FileEncryptionInfo encInfo;
   private FileChecksum fileChecksum;
   /**
-   * Support OSF use-case to identify if the key is a file or a directory.
+   * Support OFS use-case to identify if the key is a file or a directory.
    */
   private boolean isFile;
 

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmKeyInfo.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmKeyInfo.java
@@ -61,6 +61,10 @@ public final class OmKeyInfo extends WithParentObjectId {
   private ReplicationConfig replicationConfig;
   private FileEncryptionInfo encInfo;
   private FileChecksum fileChecksum;
+  /**
+   * Support OSF use-case to identify if the key is a file or a directory.
+   */
+  private boolean isFile;
 
   /**
    * Represents leaf node name. This also will be used when the keyName is
@@ -106,12 +110,13 @@ public final class OmKeyInfo extends WithParentObjectId {
             Map<String, String> metadata,
             FileEncryptionInfo encInfo, List<OzoneAcl> acls,
             long parentObjectID, long objectID, long updateID,
-            FileChecksum fileChecksum) {
+            FileChecksum fileChecksum, boolean isFile) {
     this(volumeName, bucketName, keyName, versions, dataSize,
             creationTime, modificationTime, replicationConfig, metadata,
             encInfo, acls, objectID, updateID, fileChecksum);
     this.fileName = fileName;
     this.parentObjectID = parentObjectID;
+    this.isFile = isFile;
   }
 
   public String getVolumeName() {
@@ -175,6 +180,14 @@ public final class OmKeyInfo extends WithParentObjectId {
 
   public void updateModifcationTime() {
     this.modificationTime = Time.monotonicNow();
+  }
+
+  public void setFile(boolean file) {
+    isFile = file;
+  }
+
+  public boolean isFile() {
+    return isFile;
   }
 
   /**
@@ -409,6 +422,8 @@ public final class OmKeyInfo extends WithParentObjectId {
     private long parentObjectID;
     private FileChecksum fileChecksum;
 
+    private boolean isFile;
+
     public Builder() {
       this.metadata = new HashMap<>();
       omKeyLocationInfoGroups = new ArrayList<>();
@@ -520,12 +535,17 @@ public final class OmKeyInfo extends WithParentObjectId {
       return this;
     }
 
+    public Builder setFile(boolean isAFile) {
+      this.isFile = isAFile;
+      return this;
+    }
+
     public OmKeyInfo build() {
       return new OmKeyInfo(
               volumeName, bucketName, keyName, fileName,
               omKeyLocationInfoGroups, dataSize, creationTime,
               modificationTime, replicationConfig, metadata, encInfo, acls,
-              parentObjectID, objectID, updateID, fileChecksum);
+              parentObjectID, objectID, updateID, fileChecksum, isFile);
     }
   }
 
@@ -627,6 +647,7 @@ public final class OmKeyInfo extends WithParentObjectId {
     if (encInfo != null) {
       kb.setFileEncryptionInfo(OMPBHelper.convert(encInfo));
     }
+    kb.setIsFile(isFile);
     return kb.build();
   }
 
@@ -669,6 +690,11 @@ public final class OmKeyInfo extends WithParentObjectId {
       FileChecksum fileChecksum = OMPBHelper.convert(keyInfo.getFileChecksum());
       builder.setFileChecksum(fileChecksum);
     }
+
+    if (keyInfo.hasIsFile()) {
+      builder.setFile(keyInfo.getIsFile());
+    }
+
     // not persisted to DB. FileName will be filtered out from keyName
     builder.setFileName(OzoneFSUtils.getFileName(keyInfo.getKeyName()));
     return builder.build();

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocol/OzoneManagerProtocol.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocol/OzoneManagerProtocol.java
@@ -759,7 +759,9 @@ public interface OzoneManagerProtocol
    *                     if bucket does not exist
    * @throws IOException if there is error in the db
    *                     invalid arguments
+   * @deprecated use {@link OzoneManagerProtocol#getKeyInfo} instead.
    */
+  @Deprecated
   OmKeyInfo lookupFile(OmKeyArgs keyArgs) throws IOException;
 
   /**

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFileSystem.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFileSystem.java
@@ -1005,10 +1005,10 @@ public class TestOzoneFileSystem {
     Path fileNotExists = new Path("/file_notexist");
     try {
       fs.open(fileNotExists);
-      Assert.fail("Should throw FILE_NOT_FOUND error as file doesn't exist!");
+      Assert.fail("Should throw FileNotFoundException as file doesn't exist!");
     } catch (FileNotFoundException fnfe) {
-      Assert.assertTrue("Expected FILE_NOT_FOUND error",
-              fnfe.getMessage().contains("FILE_NOT_FOUND"));
+      Assert.assertTrue("Expected KEY_NOT_FOUND error",
+              fnfe.getMessage().contains("KEY_NOT_FOUND"));
     }
   }
 

--- a/hadoop-ozone/interface-client/src/main/proto/OmClientProtocol.proto
+++ b/hadoop-ozone/interface-client/src/main/proto/OmClientProtocol.proto
@@ -953,6 +953,7 @@ message KeyInfo {
     optional uint64 parentID = 16;
     optional hadoop.hdds.ECReplicationConfig ecReplicationConfig = 17;
     optional FileChecksumProto fileChecksum = 18;
+    optional bool isFile = 19;
 }
 
 message DirectoryInfo {

--- a/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicOzoneClientAdapterImpl.java
+++ b/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicOzoneClientAdapterImpl.java
@@ -219,6 +219,7 @@ public class BasicOzoneClientAdapterImpl implements OzoneClientAdapter {
       return bucket.readFile(key).getInputStream();
     } catch (OMException ex) {
       if (ex.getResult() == OMException.ResultCodes.FILE_NOT_FOUND
+          || ex.getResult() == OMException.ResultCodes.KEY_NOT_FOUND
           || ex.getResult() == OMException.ResultCodes.NOT_A_FILE) {
         throw new FileNotFoundException(
             ex.getResult().name() + ": " + ex.getMessage());

--- a/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicRootedOzoneClientAdapterImpl.java
+++ b/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicRootedOzoneClientAdapterImpl.java
@@ -351,6 +351,7 @@ public class BasicRootedOzoneClientAdapterImpl
       return bucket.readFile(key).getInputStream();
     } catch (OMException ex) {
       if (ex.getResult() == OMException.ResultCodes.FILE_NOT_FOUND
+          || ex.getResult() == OMException.ResultCodes.KEY_NOT_FOUND
           || ex.getResult() == OMException.ResultCodes.NOT_A_FILE) {
         throw new FileNotFoundException(
             ex.getResult().name() + ": " + ex.getMessage());


### PR DESCRIPTION
## What changes were proposed in this pull request?

### Problem
The target of this task is to deprecate the `LookupFile` interface and use `GetKeyInfo` for the OFS use case.

The gap between OFS and object storage use cases (like S3) is that due to a file system nature, OFS has to answer the file read requests from its client. A file read input is a file path and OFS needs to be able to decide if the given path is a valid file. To be specific, if the given path is not a file (but a directory), OFS should return an error. Reading empty files is a valid use case.

```
// throws IOException if the given path is not a file.
FileSystem.open(path)
```

The `lookupKey` API returns the same content for an empty file and directory. 

Today, this is solved in Ozone by the separated `lookupFile` API, detecting if the given key is a directory and throwing an error on server-side.
```
throw new OMException(ResultCodes.NOT_A_FILE);
```

`GetKeyInfo` replaces `lookupKey` and inherits the same limit. 

### Solution
To make `GetKeyInfo` available for OFS, we can simply add to its response a field indicating if the key represents a directory or a file so that OFS client code can make the assertion.



https://issues.apaceorg/jira/browse/HDDS-7419

## How was this patch tested?

OFS integration test.