### PR TITLE
HDDS-6926. Add support for shaded protobufs used by hadoop-client/spark.

### DIFF
--- a/hadoop-ozone/dist/pom.xml
+++ b/hadoop-ozone/dist/pom.xml
@@ -243,7 +243,7 @@
         </dependency>
         <dependency>
           <groupId>org.apache.ozone</groupId>
-          <artifactId>ozone-filesystem-hadoop-client</artifactId>
+          <artifactId>ozone-filesystem-hadoop3-client</artifactId>
         </dependency>
       </dependencies>
     </profile>

--- a/hadoop-ozone/dist/pom.xml
+++ b/hadoop-ozone/dist/pom.xml
@@ -241,6 +241,10 @@
           <groupId>org.apache.ozone</groupId>
           <artifactId>ozone-filesystem-hadoop3</artifactId>
         </dependency>
+        <dependency>
+          <groupId>org.apache.ozone</groupId>
+          <artifactId>ozone-filesystem-hadoop-client</artifactId>
+        </dependency>
       </dependencies>
     </profile>
     <profile>

--- a/hadoop-ozone/dist/src/main/license/jar-report.txt
+++ b/hadoop-ozone/dist/src/main/license/jar-report.txt
@@ -212,7 +212,7 @@ share/ozone/lib/ozone-filesystem-common.jar
 share/ozone/lib/ozone-filesystem-hadoop2.jar
 share/ozone/lib/ozone-filesystem-hadoop3.jar
 share/ozone/lib/ozone-filesystem.jar
-share/ozone/lib/ozone-filesystem-hadoop-client.jar
+share/ozone/lib/ozone-filesystem-hadoop3-client.jar
 share/ozone/lib/ozone-insight.jar
 share/ozone/lib/ozone-interface-client.jar
 share/ozone/lib/ozone-interface-storage.jar

--- a/hadoop-ozone/dist/src/main/license/jar-report.txt
+++ b/hadoop-ozone/dist/src/main/license/jar-report.txt
@@ -212,6 +212,7 @@ share/ozone/lib/ozone-filesystem-common.jar
 share/ozone/lib/ozone-filesystem-hadoop2.jar
 share/ozone/lib/ozone-filesystem-hadoop3.jar
 share/ozone/lib/ozone-filesystem.jar
+share/ozone/lib/ozone-filesystem-hadoop-client.jar
 share/ozone/lib/ozone-insight.jar
 share/ozone/lib/ozone-interface-client.jar
 share/ozone/lib/ozone-interface-storage.jar

--- a/hadoop-ozone/ozonefs-hadoop-client/pom.xml
+++ b/hadoop-ozone/ozonefs-hadoop-client/pom.xml
@@ -1,0 +1,112 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License. See accompanying LICENSE file.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.apache.ozone</groupId>
+    <artifactId>ozone</artifactId>
+    <version>1.3.0-SNAPSHOT</version>
+  </parent>
+  <artifactId>ozone-filesystem-hadoop-client</artifactId>
+  <name>Apache Ozone FS Hadoop shaded 3.x compatibility</name>
+  <packaging>jar</packaging>
+  <version>1.3.0-SNAPSHOT</version>
+  <dependencies>
+    <dependency>
+      <groupId>org.apache.ozone</groupId>
+      <artifactId>ozone-filesystem-hadoop3</artifactId>
+      <optional>true</optional>
+    </dependency>
+  </dependencies>
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-dependency-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>include-dependencies</id>
+            <phase>prepare-package</phase>
+            <goals>
+              <goal>unpack</goal>
+            </goals>
+            <configuration>
+              <excludes>META-INF/versions/**/*.*</excludes>
+              <artifactItems>
+                <artifactItem>
+                  <groupId>org.apache.ozone</groupId>
+                  <artifactId>ozone-filesystem-shaded</artifactId>
+                  <version>${project.version}</version>
+                </artifactItem>
+              </artifactItems>
+              <outputDirectory>target/classes</outputDirectory>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-shade-plugin</artifactId>
+        <executions>
+          <execution>
+            <phase>package</phase>
+            <goals>
+              <goal>shade</goal>
+            </goals>
+            <configuration>
+              <transformers>
+                <transformer
+                        implementation="org.apache.maven.plugins.shade.resource.DontIncludeResourceTransformer">
+                  <resources>
+                    <resource>META-INF/BC1024KE.DSA</resource>
+                    <resource>META-INF/BC2048KE.DSA</resource>
+                    <resource>META-INF/BC1024KE.SF</resource>
+                    <resource>META-INF/BC2048KE.SF</resource>
+                  </resources>
+                </transformer>
+                <transformer
+                        implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
+                <transformer
+                        implementation="org.apache.maven.plugins.shade.resource.XmlAppendingTransformer">
+                  <resource>ozone-default-generated.xml</resource>
+                </transformer>
+              </transformers>
+              <relocations>
+                <relocation>
+                  <pattern>com.google.protobuf</pattern>
+                  <shadedPattern>
+                    org.apache.hadoop.shaded.com.google.protobuf
+                  </shadedPattern>
+                  <includes>
+                    <include>com.google.protobuf.*</include>
+                  </includes>
+                </relocation>
+              </relocations>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>com.github.spotbugs</groupId>
+        <artifactId>spotbugs-maven-plugin</artifactId>
+        <configuration>
+          <onlyAnalyze>org.apache.hadoop.fs.ozone.*</onlyAnalyze>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/hadoop-ozone/ozonefs-hadoop3-client/pom.xml
+++ b/hadoop-ozone/ozonefs-hadoop3-client/pom.xml
@@ -21,7 +21,7 @@
     <artifactId>ozone</artifactId>
     <version>1.3.0-SNAPSHOT</version>
   </parent>
-  <artifactId>ozone-filesystem-hadoop-client</artifactId>
+  <artifactId>ozone-filesystem-hadoop3-client</artifactId>
   <name>Apache Ozone FS Hadoop shaded 3.x compatibility</name>
   <packaging>jar</packaging>
   <version>1.3.0-SNAPSHOT</version>

--- a/hadoop-ozone/ozonefs-hadoop3-client/pom.xml
+++ b/hadoop-ozone/ozonefs-hadoop3-client/pom.xml
@@ -21,6 +21,12 @@
     <artifactId>ozone</artifactId>
     <version>1.3.0-SNAPSHOT</version>
   </parent>
+<!--
+  This is called "ozone-filesystem-hadoop3-client" to correspond with
+  the shaded hadoop jar that it works with:
+  "hadoop-client-api.jar", (as opposed to the unshaded hadoop jar:
+  "hadoop-common.jar")
+-->
   <artifactId>ozone-filesystem-hadoop3-client</artifactId>
   <name>Apache Ozone FS Hadoop shaded 3.x compatibility</name>
   <packaging>jar</packaging>

--- a/hadoop-ozone/pom.xml
+++ b/hadoop-ozone/pom.xml
@@ -124,7 +124,7 @@
       </dependency>
       <dependency>
         <groupId>org.apache.ozone</groupId>
-        <artifactId>ozone-filesystem-hadoop-client</artifactId>
+        <artifactId>ozone-filesystem-hadoop3-client</artifactId>
         <version>${ozone.version}</version>
       </dependency>
       <dependency>
@@ -378,7 +378,7 @@
         <module>ozonefs-shaded</module>
         <module>ozonefs-hadoop2</module>
         <module>ozonefs-hadoop3</module>
-        <module>ozonefs-hadoop-client</module>
+        <module>ozonefs-hadoop3-client</module>
       </modules>
     </profile>
     <profile>

--- a/hadoop-ozone/pom.xml
+++ b/hadoop-ozone/pom.xml
@@ -124,6 +124,11 @@
       </dependency>
       <dependency>
         <groupId>org.apache.ozone</groupId>
+        <artifactId>ozone-filesystem-hadoop-client</artifactId>
+        <version>${ozone.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.ozone</groupId>
         <artifactId>ozone-filesystem-hadoop2</artifactId>
         <version>${ozone.version}</version>
       </dependency>
@@ -373,6 +378,7 @@
         <module>ozonefs-shaded</module>
         <module>ozonefs-hadoop2</module>
         <module>ozonefs-hadoop3</module>
+        <module>ozonefs-hadoop-client</module>
       </modules>
     </profile>
     <profile>


### PR DESCRIPTION
 ## What changes were proposed in this pull request?

Hadoop distributes two versions of their hdfs client:

hadoop-client-api-3.3.1.jar and hadoop-common-3.3.4.jar

The first uses shaded protobufs, eg: org.apache.hadoop.shaded.com.google.protobuf.Message

The second unshaded protobufs, eg: com.google.protobuf.Message


Currently, Ozone only supports unshaded protobufs, (with ozone-filesystem-hadoop3-1.3.0-SNAPSHOT.jar)

But projects like spark use shaded protobufs, (through hadoop-client-api-3.3.1.jar).

This PR adds the ozone-filesystem-hadoop3-client-1.3.0-SNAPSHOT.jar which is identical to the ozone-filesystem-hadoop3-1.3.0-SNAPSHOT.jar, except that it uses the shaded protobufs, (so as to work with spark and other systems distributed with the hadoop-client jars.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-6926

## How was this patch tested?


I installed spark and confirmed reading ozone keys with the new jar, (using the instructions below).  Note that the same instructions with the unshaded jar file, ozone-filesystem-hadoop3-1.3.0-SNAPSHOT.jar, will cause the cast exception reported in the jira ticket.

```
# install spark
<Download https://archive.apache.org/dist/spark/spark-3.2.1/spark-3.2.1-bin-hadoop3.2.tgz>
cd $OZONE_ROOT/hadoop-ozone/dist/target/ozone-1.3.0-SNAPSHOT
mkdir spark
cd spark
tar -xzf ~/Downloads/spark-3.2.1-bin-hadoop3.2.tgz

# copy over the shaded jar file
cp   $OZONE_ROOT/hadoop-ozone/ozonefs-hadoop3-client/target/ozone-filesystem-hadoop3-client-1.3.0-SNAPSHOT.jar $OZONE_ROOT/hadoop-ozone/dist/target/ozone-1.3.0-SNAPSHOT/spark/spark-3.2.1-bin-hadoop3.2/jars


# start up docker cluster
cd $OZONE_ROOT/hadoop-ozone/dist/target/ozone-1.3.0-SNAPSHOT/compose/ozone
docker-compose up --no-recreate --scale datanode=3 -d

# init docker cluster
docker exec -it ozone_om_1 bash
cd /opt/hadoop/spark/spark-3.2.1-bin-hadoop3.2/conf
cp /etc/hadoop/ozone-site.xml .
cd /opt/hadoop/spark/spark-3.2.1-bin-hadoop3.2/bin


# init vol/bucket/key
ozone sh volume create testgbj2
ozone sh bucket create testgbj2/bucket1
echo k1 > k1.orig
ozone sh key put testgbj2/bucket1/k1 k1.orig

# read ozone from spark
./spark-shell
sc.setLogLevel("DEBUG")
spark.read.text("ofs://om/testgbj2/bucket1/k1").show()

```

