### PR TITLE
HDDS-7441. Rename function names of retrieving metadata keys

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/DeleteBlocksCommandHandler.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/DeleteBlocksCommandHandler.java
@@ -332,7 +332,7 @@ public class DeleteBlocksCommandHandler implements CommandHandler {
     DeletionMarker schemaV3Marker = (table, batch, tid, txn) -> {
       Table<String, DeletedBlocksTransaction> delTxTable =
           (Table<String, DeletedBlocksTransaction>) table;
-      delTxTable.putWithBatch(batch, containerData.getDeleteTxnMetaKey(tid),
+      delTxTable.putWithBatch(batch, containerData.getDeleteTxnKey(tid),
           txn);
     };
 
@@ -403,10 +403,10 @@ public class DeleteBlocksCommandHandler implements CommandHandler {
       try (BatchOperation batch = containerDB.getStore().getBatchHandler()
           .initBatchOperation()) {
         for (Long blkLong : delTX.getLocalIDList()) {
-          String blk = containerData.getBlockMetaKey(blkLong);
+          String blk = containerData.getBlockKey(blkLong);
           BlockData blkInfo = blockDataTable.get(blk);
           if (blkInfo != null) {
-            String deletingKey = containerData.getDeletingBlockMetaKey(blkLong);
+            String deletingKey = containerData.getDeletingBlockKey(blkLong);
             if (blockDataTable.get(deletingKey) != null
                 || deletedBlocksTable.get(blk) != null) {
               if (LOG.isDebugEnabled()) {
@@ -459,14 +459,14 @@ public class DeleteBlocksCommandHandler implements CommandHandler {
         // Update in DB pending delete key count and delete transaction ID.
         metadataTable
             .putWithBatch(batchOperation,
-                containerData.getLatestDeleteTxnMetaKey(), delTX.getTxID());
+                containerData.getLatestDeleteTxnKey(), delTX.getTxID());
       }
 
       long pendingDeleteBlocks =
           containerData.getNumPendingDeletionBlocks() + newDeletionBlocks;
       metadataTable
           .putWithBatch(batchOperation,
-              containerData.getPendingDeleteBlockCountMetaKey(),
+              containerData.getPendingDeleteBlockCountKey(),
               pendingDeleteBlocks);
 
       // update pending deletion blocks count and delete transaction ID in

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/KeyValueContainerCheck.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/KeyValueContainerCheck.java
@@ -277,7 +277,7 @@ public class KeyValueContainerCheck {
   private BlockData getBlockDataFromDB(DBHandle db, BlockData block)
       throws IOException {
     String blockKey =
-        onDiskContainerData.getBlockMetaKey(block.getBlockID().getLocalID());
+        onDiskContainerData.getBlockKey(block.getBlockID().getLocalID());
     return db.getStore().getBlockDataTable().get(blockKey);
   }
 

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/KeyValueContainerCheck.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/KeyValueContainerCheck.java
@@ -277,7 +277,7 @@ public class KeyValueContainerCheck {
   private BlockData getBlockDataFromDB(DBHandle db, BlockData block)
       throws IOException {
     String blockKey =
-        onDiskContainerData.blockKey(block.getBlockID().getLocalID());
+        onDiskContainerData.getBlockMetaKey(block.getBlockID().getLocalID());
     return db.getStore().getBlockDataTable().get(blockKey);
   }
 

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/KeyValueContainerData.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/KeyValueContainerData.java
@@ -306,12 +306,12 @@ public class KeyValueContainerData extends ContainerData {
     Table<String, Long> metadataTable = db.getStore().getMetadataTable();
 
     // Set Bytes used and block count key.
-    metadataTable.putWithBatch(batchOperation, getBytesUsedMetaKey(),
+    metadataTable.putWithBatch(batchOperation, getBytesUsedKey(),
             getBytesUsed() - releasedBytes);
-    metadataTable.putWithBatch(batchOperation, getBlockCountMetaKey(),
+    metadataTable.putWithBatch(batchOperation, getBlockCountKey(),
             getBlockCount() - deletedBlockCount);
     metadataTable.putWithBatch(batchOperation,
-        getPendingDeleteBlockCountMetaKey(),
+        getPendingDeleteBlockCountKey(),
         getNumPendingDeletionBlocks() - deletedBlockCount);
 
     db.getStore().getBatchHandler().commitBatchOperation(batchOperation);
@@ -329,35 +329,35 @@ public class KeyValueContainerData extends ContainerData {
   // to container schemas, we should use them instead of using
   // raw const variables defined.
 
-  public String getBlockMetaKey(long localID) {
+  public String getBlockKey(long localID) {
     return formatKey(Long.toString(localID));
   }
 
-  public String getDeletingBlockMetaKey(long localID) {
+  public String getDeletingBlockKey(long localID) {
     return formatKey(DELETING_KEY_PREFIX + localID);
   }
 
-  public String getDeleteTxnMetaKey(long txnID) {
+  public String getDeleteTxnKey(long txnID) {
     return formatKey(Long.toString(txnID));
   }
 
-  public String getLatestDeleteTxnMetaKey() {
+  public String getLatestDeleteTxnKey() {
     return formatKey(DELETE_TRANSACTION_KEY);
   }
 
-  public String getBcsIdMetaKey() {
+  public String getBcsIdKey() {
     return formatKey(BLOCK_COMMIT_SEQUENCE_ID);
   }
 
-  public String getBlockCountMetaKey() {
+  public String getBlockCountKey() {
     return formatKey(BLOCK_COUNT);
   }
 
-  public String getBytesUsedMetaKey() {
+  public String getBytesUsedKey() {
     return formatKey(CONTAINER_BYTES_USED);
   }
 
-  public String getPendingDeleteBlockCountMetaKey() {
+  public String getPendingDeleteBlockCountKey() {
     return formatKey(PENDING_DELETE_BLOCK_COUNT);
   }
 

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/KeyValueContainerData.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/KeyValueContainerData.java
@@ -306,11 +306,12 @@ public class KeyValueContainerData extends ContainerData {
     Table<String, Long> metadataTable = db.getStore().getMetadataTable();
 
     // Set Bytes used and block count key.
-    metadataTable.putWithBatch(batchOperation, bytesUsedKey(),
+    metadataTable.putWithBatch(batchOperation, getBytesUsedMetaKey(),
             getBytesUsed() - releasedBytes);
-    metadataTable.putWithBatch(batchOperation, blockCountKey(),
+    metadataTable.putWithBatch(batchOperation, getBlockCountMetaKey(),
             getBlockCount() - deletedBlockCount);
-    metadataTable.putWithBatch(batchOperation, pendingDeleteBlockCountKey(),
+    metadataTable.putWithBatch(batchOperation,
+        getPendingDeleteBlockCountMetaKey(),
         getNumPendingDeletionBlocks() - deletedBlockCount);
 
     db.getStore().getBatchHandler().commitBatchOperation(batchOperation);
@@ -328,39 +329,39 @@ public class KeyValueContainerData extends ContainerData {
   // to container schemas, we should use them instead of using
   // raw const variables defined.
 
-  public String blockKey(long localID) {
+  public String getBlockMetaKey(long localID) {
     return formatKey(Long.toString(localID));
   }
 
-  public String deletingBlockKey(long localID) {
+  public String getDeletingBlockMetaKey(long localID) {
     return formatKey(DELETING_KEY_PREFIX + localID);
   }
 
-  public String deleteTxnKey(long txnID) {
+  public String getDeleteTxnMetaKey(long txnID) {
     return formatKey(Long.toString(txnID));
   }
 
-  public String latestDeleteTxnKey() {
+  public String getLatestDeleteTxnMetaKey() {
     return formatKey(DELETE_TRANSACTION_KEY);
   }
 
-  public String bcsIdKey() {
+  public String getBcsIdMetaKey() {
     return formatKey(BLOCK_COMMIT_SEQUENCE_ID);
   }
 
-  public String blockCountKey() {
+  public String getBlockCountMetaKey() {
     return formatKey(BLOCK_COUNT);
   }
 
-  public String bytesUsedKey() {
+  public String getBytesUsedMetaKey() {
     return formatKey(CONTAINER_BYTES_USED);
   }
 
-  public String pendingDeleteBlockCountKey() {
+  public String getPendingDeleteBlockCountMetaKey() {
     return formatKey(PENDING_DELETE_BLOCK_COUNT);
   }
 
-  public String deletingBlockKeyPrefix() {
+  public String getDeletingBlockKeyPrefix() {
     return formatKey(DELETING_KEY_PREFIX);
   }
 
@@ -370,7 +371,7 @@ public class KeyValueContainerData extends ContainerData {
   }
 
   public KeyPrefixFilter getDeletingBlockKeyFilter() {
-    return new KeyPrefixFilter().addFilter(deletingBlockKeyPrefix());
+    return new KeyPrefixFilter().addFilter(getDeletingBlockKeyPrefix());
   }
 
   /**

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/KeyValueContainerMetadataInspector.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/KeyValueContainerMetadataInspector.java
@@ -229,15 +229,15 @@ public class KeyValueContainerMetadataInspector implements ContainerInspector {
     JsonObject dBMetadata = new JsonObject();
 
     dBMetadata.addProperty(OzoneConsts.BLOCK_COUNT,
-        metadataTable.get(containerData.getBlockCountMetaKey()));
+        metadataTable.get(containerData.getBlockCountKey()));
     dBMetadata.addProperty(OzoneConsts.CONTAINER_BYTES_USED,
-        metadataTable.get(containerData.getBytesUsedMetaKey()));
+        metadataTable.get(containerData.getBytesUsedKey()));
     dBMetadata.addProperty(OzoneConsts.PENDING_DELETE_BLOCK_COUNT,
-        metadataTable.get(containerData.getPendingDeleteBlockCountMetaKey()));
+        metadataTable.get(containerData.getPendingDeleteBlockCountKey()));
     dBMetadata.addProperty(OzoneConsts.DELETE_TRANSACTION_KEY,
-        metadataTable.get(containerData.getLatestDeleteTxnMetaKey()));
+        metadataTable.get(containerData.getLatestDeleteTxnKey()));
     dBMetadata.addProperty(OzoneConsts.BLOCK_COMMIT_SEQUENCE_ID,
-        metadataTable.get(containerData.getBcsIdMetaKey()));
+        metadataTable.get(containerData.getBcsIdKey()));
 
     return dBMetadata;
   }
@@ -341,7 +341,7 @@ public class KeyValueContainerMetadataInspector implements ContainerInspector {
       BooleanSupplier keyRepairAction = () -> {
         boolean repaired = false;
         try {
-          metadataTable.put(containerData.getBlockCountMetaKey(),
+          metadataTable.put(containerData.getBlockCountKey(),
               blockCountAggregate.getAsLong());
           repaired = true;
         } catch (IOException ex) {
@@ -376,7 +376,7 @@ public class KeyValueContainerMetadataInspector implements ContainerInspector {
       BooleanSupplier keyRepairAction = () -> {
         boolean repaired = false;
         try {
-          metadataTable.put(containerData.getBytesUsedMetaKey(),
+          metadataTable.put(containerData.getBytesUsedKey(),
               usedBytesAggregate.getAsLong());
           repaired = true;
         } catch (IOException ex) {

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/KeyValueContainerMetadataInspector.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/KeyValueContainerMetadataInspector.java
@@ -229,15 +229,15 @@ public class KeyValueContainerMetadataInspector implements ContainerInspector {
     JsonObject dBMetadata = new JsonObject();
 
     dBMetadata.addProperty(OzoneConsts.BLOCK_COUNT,
-        metadataTable.get(containerData.blockCountKey()));
+        metadataTable.get(containerData.getBlockCountMetaKey()));
     dBMetadata.addProperty(OzoneConsts.CONTAINER_BYTES_USED,
-        metadataTable.get(containerData.bytesUsedKey()));
+        metadataTable.get(containerData.getBytesUsedMetaKey()));
     dBMetadata.addProperty(OzoneConsts.PENDING_DELETE_BLOCK_COUNT,
-        metadataTable.get(containerData.pendingDeleteBlockCountKey()));
+        metadataTable.get(containerData.getPendingDeleteBlockCountMetaKey()));
     dBMetadata.addProperty(OzoneConsts.DELETE_TRANSACTION_KEY,
-        metadataTable.get(containerData.latestDeleteTxnKey()));
+        metadataTable.get(containerData.getLatestDeleteTxnMetaKey()));
     dBMetadata.addProperty(OzoneConsts.BLOCK_COMMIT_SEQUENCE_ID,
-        metadataTable.get(containerData.bcsIdKey()));
+        metadataTable.get(containerData.getBcsIdMetaKey()));
 
     return dBMetadata;
   }
@@ -341,7 +341,7 @@ public class KeyValueContainerMetadataInspector implements ContainerInspector {
       BooleanSupplier keyRepairAction = () -> {
         boolean repaired = false;
         try {
-          metadataTable.put(containerData.blockCountKey(),
+          metadataTable.put(containerData.getBlockCountMetaKey(),
               blockCountAggregate.getAsLong());
           repaired = true;
         } catch (IOException ex) {
@@ -376,7 +376,7 @@ public class KeyValueContainerMetadataInspector implements ContainerInspector {
       BooleanSupplier keyRepairAction = () -> {
         boolean repaired = false;
         try {
-          metadataTable.put(containerData.bytesUsedKey(),
+          metadataTable.put(containerData.getBytesUsedMetaKey(),
               usedBytesAggregate.getAsLong());
           repaired = true;
         } catch (IOException ex) {

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/helpers/KeyValueContainerUtil.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/helpers/KeyValueContainerUtil.java
@@ -246,7 +246,7 @@ public final class KeyValueContainerUtil {
     // Set pending deleted block count.
     Long pendingDeleteBlockCount =
         metadataTable.get(kvContainerData
-            .getPendingDeleteBlockCountMetaKey());
+            .getPendingDeleteBlockCountKey());
     if (pendingDeleteBlockCount != null) {
       kvContainerData.incrPendingDeletionBlocks(
           pendingDeleteBlockCount);
@@ -263,7 +263,7 @@ public final class KeyValueContainerUtil {
 
     // Set delete transaction id.
     Long delTxnId =
-        metadataTable.get(kvContainerData.getLatestDeleteTxnMetaKey());
+        metadataTable.get(kvContainerData.getLatestDeleteTxnKey());
     if (delTxnId != null) {
       kvContainerData
           .updateDeleteTransactionId(delTxnId);
@@ -271,7 +271,7 @@ public final class KeyValueContainerUtil {
 
     // Set BlockCommitSequenceId.
     Long bcsId = metadataTable.get(
-        kvContainerData.getBcsIdMetaKey());
+        kvContainerData.getBcsIdKey());
     if (bcsId != null) {
       kvContainerData
           .updateBlockCommitSequenceId(bcsId);
@@ -280,7 +280,7 @@ public final class KeyValueContainerUtil {
     // Set bytes used.
     // commitSpace for Open Containers relies on usedBytes
     Long bytesUsed =
-        metadataTable.get(kvContainerData.getBytesUsedMetaKey());
+        metadataTable.get(kvContainerData.getBytesUsedKey());
     if (bytesUsed != null) {
       isBlockMetadataSet = true;
       kvContainerData.setBytesUsed(bytesUsed);
@@ -288,7 +288,7 @@ public final class KeyValueContainerUtil {
 
     // Set block count.
     Long blockCount = metadataTable.get(
-        kvContainerData.getBlockCountMetaKey());
+        kvContainerData.getBlockCountKey());
     if (blockCount != null) {
       isBlockMetadataSet = true;
       kvContainerData.setBlockCount(blockCount);

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/helpers/KeyValueContainerUtil.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/helpers/KeyValueContainerUtil.java
@@ -246,7 +246,7 @@ public final class KeyValueContainerUtil {
     // Set pending deleted block count.
     Long pendingDeleteBlockCount =
         metadataTable.get(kvContainerData
-            .pendingDeleteBlockCountKey());
+            .getPendingDeleteBlockCountMetaKey());
     if (pendingDeleteBlockCount != null) {
       kvContainerData.incrPendingDeletionBlocks(
           pendingDeleteBlockCount);
@@ -263,7 +263,7 @@ public final class KeyValueContainerUtil {
 
     // Set delete transaction id.
     Long delTxnId =
-        metadataTable.get(kvContainerData.latestDeleteTxnKey());
+        metadataTable.get(kvContainerData.getLatestDeleteTxnMetaKey());
     if (delTxnId != null) {
       kvContainerData
           .updateDeleteTransactionId(delTxnId);
@@ -271,7 +271,7 @@ public final class KeyValueContainerUtil {
 
     // Set BlockCommitSequenceId.
     Long bcsId = metadataTable.get(
-        kvContainerData.bcsIdKey());
+        kvContainerData.getBcsIdMetaKey());
     if (bcsId != null) {
       kvContainerData
           .updateBlockCommitSequenceId(bcsId);
@@ -280,7 +280,7 @@ public final class KeyValueContainerUtil {
     // Set bytes used.
     // commitSpace for Open Containers relies on usedBytes
     Long bytesUsed =
-        metadataTable.get(kvContainerData.bytesUsedKey());
+        metadataTable.get(kvContainerData.getBytesUsedMetaKey());
     if (bytesUsed != null) {
       isBlockMetadataSet = true;
       kvContainerData.setBytesUsed(bytesUsed);
@@ -288,7 +288,7 @@ public final class KeyValueContainerUtil {
 
     // Set block count.
     Long blockCount = metadataTable.get(
-        kvContainerData.blockCountKey());
+        kvContainerData.getBlockCountMetaKey());
     if (blockCount != null) {
       isBlockMetadataSet = true;
       kvContainerData.setBlockCount(blockCount);

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/impl/BlockManagerImpl.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/impl/BlockManagerImpl.java
@@ -158,7 +158,7 @@ public class BlockManagerImpl implements BlockManager {
         // If block exists in cache, blockCount should not be incremented.
         if (!isBlockInCache) {
           if (db.getStore().getBlockDataTable().get(
-              containerData.getBlockMetaKey(localID)) == null) {
+              containerData.getBlockKey(localID)) == null) {
             // Block does not exist in DB => blockCount needs to be
             // incremented when the block is added into DB.
             incrBlockCount = true;
@@ -166,10 +166,10 @@ public class BlockManagerImpl implements BlockManager {
         }
 
         db.getStore().getBlockDataTable().putWithBatch(
-            batch, containerData.getBlockMetaKey(localID), data);
+            batch, containerData.getBlockKey(localID), data);
         if (bcsId != 0) {
           db.getStore().getMetadataTable().putWithBatch(
-              batch, containerData.getBcsIdMetaKey(), bcsId);
+              batch, containerData.getBcsIdKey(), bcsId);
         }
 
         // Set Bytes used, this bytes used will be updated for every write and
@@ -179,13 +179,13 @@ public class BlockManagerImpl implements BlockManager {
         // is only used to compute the bytes used. This is done to keep the
         // current behavior and avoid DB write during write chunk operation.
         db.getStore().getMetadataTable().putWithBatch(
-            batch, containerData.getBytesUsedMetaKey(),
+            batch, containerData.getBytesUsedKey(),
             containerData.getBytesUsed());
 
         // Set Block Count for a container.
         if (incrBlockCount) {
           db.getStore().getMetadataTable().putWithBatch(
-              batch, containerData.getBlockCountMetaKey(),
+              batch, containerData.getBlockCountKey(),
               containerData.getBlockCount() + 1);
         }
 
@@ -327,7 +327,7 @@ public class BlockManagerImpl implements BlockManager {
       try (DBHandle db = BlockUtils.getDB(cData, config)) {
         result = new ArrayList<>();
         String startKey = (startLocalID == -1) ? cData.startKeyEmpty()
-            : cData.getBlockMetaKey(startLocalID);
+            : cData.getBlockKey(startLocalID);
         List<? extends Table.KeyValue<String, BlockData>> range =
             db.getStore().getBlockDataTable()
                 .getSequentialRangeKVs(startKey, count,
@@ -352,7 +352,7 @@ public class BlockManagerImpl implements BlockManager {
 
   private BlockData getBlockByID(DBHandle db, BlockID blockID,
       KeyValueContainerData containerData) throws IOException {
-    String blockKey = containerData.getBlockMetaKey(blockID.getLocalID());
+    String blockKey = containerData.getBlockKey(blockID.getLocalID());
 
     BlockData blockData = db.getStore().getBlockDataTable().get(blockKey);
     if (blockData == null) {

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/impl/BlockManagerImpl.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/impl/BlockManagerImpl.java
@@ -158,7 +158,7 @@ public class BlockManagerImpl implements BlockManager {
         // If block exists in cache, blockCount should not be incremented.
         if (!isBlockInCache) {
           if (db.getStore().getBlockDataTable().get(
-              containerData.blockKey(localID)) == null) {
+              containerData.getBlockMetaKey(localID)) == null) {
             // Block does not exist in DB => blockCount needs to be
             // incremented when the block is added into DB.
             incrBlockCount = true;
@@ -166,10 +166,10 @@ public class BlockManagerImpl implements BlockManager {
         }
 
         db.getStore().getBlockDataTable().putWithBatch(
-            batch, containerData.blockKey(localID), data);
+            batch, containerData.getBlockMetaKey(localID), data);
         if (bcsId != 0) {
           db.getStore().getMetadataTable().putWithBatch(
-              batch, containerData.bcsIdKey(), bcsId);
+              batch, containerData.getBcsIdMetaKey(), bcsId);
         }
 
         // Set Bytes used, this bytes used will be updated for every write and
@@ -179,13 +179,13 @@ public class BlockManagerImpl implements BlockManager {
         // is only used to compute the bytes used. This is done to keep the
         // current behavior and avoid DB write during write chunk operation.
         db.getStore().getMetadataTable().putWithBatch(
-            batch, containerData.bytesUsedKey(),
+            batch, containerData.getBytesUsedMetaKey(),
             containerData.getBytesUsed());
 
         // Set Block Count for a container.
         if (incrBlockCount) {
           db.getStore().getMetadataTable().putWithBatch(
-              batch, containerData.blockCountKey(),
+              batch, containerData.getBlockCountMetaKey(),
               containerData.getBlockCount() + 1);
         }
 
@@ -327,7 +327,7 @@ public class BlockManagerImpl implements BlockManager {
       try (DBHandle db = BlockUtils.getDB(cData, config)) {
         result = new ArrayList<>();
         String startKey = (startLocalID == -1) ? cData.startKeyEmpty()
-            : cData.blockKey(startLocalID);
+            : cData.getBlockMetaKey(startLocalID);
         List<? extends Table.KeyValue<String, BlockData>> range =
             db.getStore().getBlockDataTable()
                 .getSequentialRangeKVs(startKey, count,
@@ -352,7 +352,7 @@ public class BlockManagerImpl implements BlockManager {
 
   private BlockData getBlockByID(DBHandle db, BlockID blockID,
       KeyValueContainerData containerData) throws IOException {
-    String blockKey = containerData.blockKey(blockID.getLocalID());
+    String blockKey = containerData.getBlockMetaKey(blockID.getLocalID());
 
     BlockData blockData = db.getStore().getBlockDataTable().get(blockKey);
     if (blockData == null) {

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/statemachine/background/BlockDeletingService.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/statemachine/background/BlockDeletingService.java
@@ -441,7 +441,7 @@ public class BlockDeletingService extends BackgroundService {
         Table<String, DeletedBlocksTransaction> delTxTable =
             (Table<String, DeletedBlocksTransaction>) table;
         delTxTable.deleteWithBatch(batch,
-            containerData.getDeleteTxnMetaKey(tid));
+            containerData.getDeleteTxnKey(tid));
       };
       Table<String, DeletedBlocksTransaction> deleteTxns =
           ((DeleteTransactionStore<String>) meta.getStore())
@@ -503,7 +503,7 @@ public class BlockDeletingService extends BackgroundService {
             deleter.apply(deleteTxns, batch, delTx.getTxID());
             for (Long blk : delTx.getLocalIDList()) {
               blockDataTable.deleteWithBatch(batch,
-                  containerData.getBlockMetaKey(blk));
+                  containerData.getBlockKey(blk));
             }
           }
 
@@ -551,7 +551,7 @@ public class BlockDeletingService extends BackgroundService {
       long bytesReleased = 0;
       for (DeletedBlocksTransaction entry : delBlocks) {
         for (Long blkLong : entry.getLocalIDList()) {
-          String blk = containerData.getBlockMetaKey(blkLong);
+          String blk = containerData.getBlockKey(blkLong);
           BlockData blkInfo = blockDataTable.get(blk);
           LOG.debug("Deleting block {}", blkLong);
           if (blkInfo == null) {

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/statemachine/background/BlockDeletingService.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/statemachine/background/BlockDeletingService.java
@@ -440,7 +440,8 @@ public class BlockDeletingService extends BackgroundService {
       Deleter schema3Deleter = (table, batch, tid) -> {
         Table<String, DeletedBlocksTransaction> delTxTable =
             (Table<String, DeletedBlocksTransaction>) table;
-        delTxTable.deleteWithBatch(batch, containerData.deleteTxnKey(tid));
+        delTxTable.deleteWithBatch(batch,
+            containerData.getDeleteTxnMetaKey(tid));
       };
       Table<String, DeletedBlocksTransaction> deleteTxns =
           ((DeleteTransactionStore<String>) meta.getStore())
@@ -502,7 +503,7 @@ public class BlockDeletingService extends BackgroundService {
             deleter.apply(deleteTxns, batch, delTx.getTxID());
             for (Long blk : delTx.getLocalIDList()) {
               blockDataTable.deleteWithBatch(batch,
-                  containerData.blockKey(blk));
+                  containerData.getBlockMetaKey(blk));
             }
           }
 
@@ -550,7 +551,7 @@ public class BlockDeletingService extends BackgroundService {
       long bytesReleased = 0;
       for (DeletedBlocksTransaction entry : delBlocks) {
         for (Long blkLong : entry.getLocalIDList()) {
-          String blk = containerData.blockKey(blkLong);
+          String blk = containerData.getBlockMetaKey(blkLong);
           BlockData blkInfo = blockDataTable.get(blk);
           LOG.debug("Deleting block {}", blkLong);
           if (blkInfo == null) {

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/TestBlockDeletingService.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/TestBlockDeletingService.java
@@ -218,7 +218,7 @@ public class TestBlockDeletingService {
     try (DBHandle metadata = BlockUtils.getDB(data, conf)) {
       for (int j = 0; j < numOfBlocksPerContainer; j++) {
         blockID = ContainerTestHelper.getTestBlockID(containerID);
-        String deleteStateName = data.getDeletingBlockMetaKey(
+        String deleteStateName = data.getDeletingBlockKey(
             blockID.getLocalID());
         BlockData kd = new BlockData(blockID);
         List<ContainerProtos.ChunkInfo> chunks = Lists.newArrayList();
@@ -251,7 +251,7 @@ public class TestBlockDeletingService {
           container, blockID);
       kd.setChunks(chunks);
       try (DBHandle metadata = BlockUtils.getDB(data, conf)) {
-        String blockKey = data.getBlockMetaKey(blockID.getLocalID());
+        String blockKey = data.getBlockKey(blockID.getLocalID());
         metadata.getStore().getBlockDataTable().put(blockKey, kd);
       } catch (IOException exception) {
         LOG.info("Exception = " + exception);
@@ -286,7 +286,7 @@ public class TestBlockDeletingService {
           DatanodeStoreSchemaThreeImpl dnStoreThreeImpl =
               (DatanodeStoreSchemaThreeImpl) ds;
           dnStoreThreeImpl.getDeleteTransactionTable()
-              .putWithBatch(batch, data.getDeleteTxnMetaKey(txnID), dtx);
+              .putWithBatch(batch, data.getDeleteTxnKey(txnID), dtx);
         } else {
           DatanodeStoreSchemaTwoImpl dnStoreTwoImpl =
               (DatanodeStoreSchemaTwoImpl) ds;
@@ -335,12 +335,12 @@ public class TestBlockDeletingService {
       container.getContainerData().setBlockCount(numOfBlocksPerContainer);
       // Set block count, bytes used and pending delete block count.
       metadata.getStore().getMetadataTable()
-          .put(data.getBlockCountMetaKey(), (long) numOfBlocksPerContainer);
+          .put(data.getBlockCountKey(), (long) numOfBlocksPerContainer);
       metadata.getStore().getMetadataTable()
-          .put(data.getBytesUsedMetaKey(),
+          .put(data.getBytesUsedKey(),
               chunkLength * numOfChunksPerBlock * numOfBlocksPerContainer);
       metadata.getStore().getMetadataTable()
-          .put(data.getPendingDeleteBlockCountMetaKey(),
+          .put(data.getPendingDeleteBlockCountKey(),
               (long) numOfBlocksPerContainer);
     } catch (IOException exception) {
       LOG.warn("Meta Data update was not successful for container: "
@@ -456,7 +456,7 @@ public class TestBlockDeletingService {
       // Ensure there are 3 blocks under deletion and 0 deleted blocks
       Assert.assertEquals(3, getUnderDeletionBlocksCount(meta, data));
       Assert.assertEquals(3, meta.getStore().getMetadataTable()
-          .get(data.getPendingDeleteBlockCountMetaKey()).longValue());
+          .get(data.getPendingDeleteBlockCountKey()).longValue());
 
       // Container contains 3 blocks. So, space used by the container
       // should be greater than zero.
@@ -486,9 +486,9 @@ public class TestBlockDeletingService {
       // Check finally DB counters.
       // Not checking bytes used, as handler is a mock call.
       Assert.assertEquals(0, meta.getStore().getMetadataTable()
-          .get(data.getPendingDeleteBlockCountMetaKey()).longValue());
+          .get(data.getPendingDeleteBlockCountKey()).longValue());
       Assert.assertEquals(0,
-          meta.getStore().getMetadataTable().get(data.getBlockCountMetaKey())
+          meta.getStore().getMetadataTable().get(data.getBlockCountKey())
               .longValue());
       Assert.assertEquals(3,
           deletingServiceMetrics.getSuccessCount()

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/TestBlockDeletingService.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/TestBlockDeletingService.java
@@ -218,7 +218,8 @@ public class TestBlockDeletingService {
     try (DBHandle metadata = BlockUtils.getDB(data, conf)) {
       for (int j = 0; j < numOfBlocksPerContainer; j++) {
         blockID = ContainerTestHelper.getTestBlockID(containerID);
-        String deleteStateName = data.deletingBlockKey(blockID.getLocalID());
+        String deleteStateName = data.getDeletingBlockMetaKey(
+            blockID.getLocalID());
         BlockData kd = new BlockData(blockID);
         List<ContainerProtos.ChunkInfo> chunks = Lists.newArrayList();
         putChunksInBlock(numOfChunksPerBlock, j, chunks, buffer, chunkManager,
@@ -250,7 +251,7 @@ public class TestBlockDeletingService {
           container, blockID);
       kd.setChunks(chunks);
       try (DBHandle metadata = BlockUtils.getDB(data, conf)) {
-        String blockKey = data.blockKey(blockID.getLocalID());
+        String blockKey = data.getBlockMetaKey(blockID.getLocalID());
         metadata.getStore().getBlockDataTable().put(blockKey, kd);
       } catch (IOException exception) {
         LOG.info("Exception = " + exception);
@@ -285,7 +286,7 @@ public class TestBlockDeletingService {
           DatanodeStoreSchemaThreeImpl dnStoreThreeImpl =
               (DatanodeStoreSchemaThreeImpl) ds;
           dnStoreThreeImpl.getDeleteTransactionTable()
-              .putWithBatch(batch, data.deleteTxnKey(txnID), dtx);
+              .putWithBatch(batch, data.getDeleteTxnMetaKey(txnID), dtx);
         } else {
           DatanodeStoreSchemaTwoImpl dnStoreTwoImpl =
               (DatanodeStoreSchemaTwoImpl) ds;
@@ -334,12 +335,12 @@ public class TestBlockDeletingService {
       container.getContainerData().setBlockCount(numOfBlocksPerContainer);
       // Set block count, bytes used and pending delete block count.
       metadata.getStore().getMetadataTable()
-          .put(data.blockCountKey(), (long) numOfBlocksPerContainer);
+          .put(data.getBlockCountMetaKey(), (long) numOfBlocksPerContainer);
       metadata.getStore().getMetadataTable()
-          .put(data.bytesUsedKey(),
+          .put(data.getBytesUsedMetaKey(),
               chunkLength * numOfChunksPerBlock * numOfBlocksPerContainer);
       metadata.getStore().getMetadataTable()
-          .put(data.pendingDeleteBlockCountKey(),
+          .put(data.getPendingDeleteBlockCountMetaKey(),
               (long) numOfBlocksPerContainer);
     } catch (IOException exception) {
       LOG.warn("Meta Data update was not successful for container: "
@@ -455,7 +456,7 @@ public class TestBlockDeletingService {
       // Ensure there are 3 blocks under deletion and 0 deleted blocks
       Assert.assertEquals(3, getUnderDeletionBlocksCount(meta, data));
       Assert.assertEquals(3, meta.getStore().getMetadataTable()
-          .get(data.pendingDeleteBlockCountKey()).longValue());
+          .get(data.getPendingDeleteBlockCountMetaKey()).longValue());
 
       // Container contains 3 blocks. So, space used by the container
       // should be greater than zero.
@@ -485,9 +486,9 @@ public class TestBlockDeletingService {
       // Check finally DB counters.
       // Not checking bytes used, as handler is a mock call.
       Assert.assertEquals(0, meta.getStore().getMetadataTable()
-          .get(data.pendingDeleteBlockCountKey()).longValue());
+          .get(data.getPendingDeleteBlockCountMetaKey()).longValue());
       Assert.assertEquals(0,
-          meta.getStore().getMetadataTable().get(data.blockCountKey())
+          meta.getStore().getMetadataTable().get(data.getBlockCountMetaKey())
               .longValue());
       Assert.assertEquals(3,
           deletingServiceMetrics.getSuccessCount()

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/TestSchemaOneBackwardsCompatibility.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/TestSchemaOneBackwardsCompatibility.java
@@ -239,14 +239,14 @@ public class TestSchemaOneBackwardsCompatibility {
     try (DBHandle db = BlockUtils.getDB(cData, conf)) {
       Table<String, Long> metadataTable = db.getStore().getMetadataTable();
 
-      metadataTable.delete(cData.getBlockCountMetaKey());
-      assertNull(metadataTable.get(cData.getBlockCountMetaKey()));
+      metadataTable.delete(cData.getBlockCountKey());
+      assertNull(metadataTable.get(cData.getBlockCountKey()));
 
-      metadataTable.delete(cData.getBytesUsedMetaKey());
-      assertNull(metadataTable.get(cData.getBytesUsedMetaKey()));
+      metadataTable.delete(cData.getBytesUsedKey());
+      assertNull(metadataTable.get(cData.getBytesUsedKey()));
 
-      metadataTable.delete(cData.getPendingDeleteBlockCountMetaKey());
-      assertNull(metadataTable.get(cData.getPendingDeleteBlockCountMetaKey()));
+      metadataTable.delete(cData.getPendingDeleteBlockCountKey());
+      assertNull(metadataTable.get(cData.getPendingDeleteBlockCountKey()));
     }
 
     // Create a new container data object, and fill in its metadata by
@@ -317,7 +317,7 @@ public class TestSchemaOneBackwardsCompatibility {
       Table<String, Long> metadataTable =
               refCountedDB.getStore().getMetadataTable();
       assertEquals(expectedRegularBlocks + expectedDeletingBlocks,
-              (long)metadataTable.get(cData.getBlockCountMetaKey()));
+              (long)metadataTable.get(cData.getBlockCountKey()));
     }
   }
 
@@ -401,7 +401,7 @@ public class TestSchemaOneBackwardsCompatibility {
 
       // Test encoding keys and decoding database values.
       for (String blockID: TestDB.BLOCK_IDS) {
-        String blockKey = cData.getBlockMetaKey(Long.parseLong(blockID));
+        String blockKey = cData.getBlockKey(Long.parseLong(blockID));
         BlockData blockData = blockDataTable.get(blockKey);
         Assert.assertEquals(Long.toString(blockData.getLocalID()), blockID);
       }
@@ -444,7 +444,7 @@ public class TestSchemaOneBackwardsCompatibility {
           refCountedDB.getStore().getBlockDataTable();
 
       for (String blockID: TestDB.DELETING_BLOCK_IDS) {
-        String blockKey = cData.getDeletingBlockMetaKey(
+        String blockKey = cData.getDeletingBlockKey(
             Long.parseLong(blockID));
         BlockData blockData = blockDataTable.get(blockKey);
         Assert.assertEquals(Long.toString(blockData.getLocalID()), blockID);
@@ -465,7 +465,7 @@ public class TestSchemaOneBackwardsCompatibility {
       // Apply the deleting prefix to the saved block IDs so we can compare
       // them to the retrieved keys.
       List<String> expectedKeys = TestDB.DELETING_BLOCK_IDS.stream()
-          .map(key -> cData.getDeletingBlockMetaKey(Long.parseLong(key)))
+          .map(key -> cData.getDeletingBlockKey(Long.parseLong(key)))
           .collect(Collectors.toList());
 
       Assert.assertEquals(expectedKeys, decodedKeys);
@@ -497,11 +497,11 @@ public class TestSchemaOneBackwardsCompatibility {
           refCountedDB.getStore().getMetadataTable();
 
       Assert.assertEquals(TestDB.KEY_COUNT,
-          metadataTable.get(cData.getBlockCountMetaKey()).longValue());
+          metadataTable.get(cData.getBlockCountKey()).longValue());
       Assert.assertEquals(TestDB.BYTES_USED,
-          metadataTable.get(cData.getBytesUsedMetaKey()).longValue());
+          metadataTable.get(cData.getBytesUsedKey()).longValue());
       Assert.assertEquals(TestDB.NUM_PENDING_DELETION_BLOCKS,
-          metadataTable.get(cData.getPendingDeleteBlockCountMetaKey())
+          metadataTable.get(cData.getPendingDeleteBlockCountKey())
               .longValue());
     }
   }

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/TestSchemaOneBackwardsCompatibility.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/TestSchemaOneBackwardsCompatibility.java
@@ -239,14 +239,14 @@ public class TestSchemaOneBackwardsCompatibility {
     try (DBHandle db = BlockUtils.getDB(cData, conf)) {
       Table<String, Long> metadataTable = db.getStore().getMetadataTable();
 
-      metadataTable.delete(cData.blockCountKey());
-      assertNull(metadataTable.get(cData.blockCountKey()));
+      metadataTable.delete(cData.getBlockCountMetaKey());
+      assertNull(metadataTable.get(cData.getBlockCountMetaKey()));
 
-      metadataTable.delete(cData.bytesUsedKey());
-      assertNull(metadataTable.get(cData.bytesUsedKey()));
+      metadataTable.delete(cData.getBytesUsedMetaKey());
+      assertNull(metadataTable.get(cData.getBytesUsedMetaKey()));
 
-      metadataTable.delete(cData.pendingDeleteBlockCountKey());
-      assertNull(metadataTable.get(cData.pendingDeleteBlockCountKey()));
+      metadataTable.delete(cData.getPendingDeleteBlockCountMetaKey());
+      assertNull(metadataTable.get(cData.getPendingDeleteBlockCountMetaKey()));
     }
 
     // Create a new container data object, and fill in its metadata by
@@ -317,7 +317,7 @@ public class TestSchemaOneBackwardsCompatibility {
       Table<String, Long> metadataTable =
               refCountedDB.getStore().getMetadataTable();
       assertEquals(expectedRegularBlocks + expectedDeletingBlocks,
-              (long)metadataTable.get(cData.blockCountKey()));
+              (long)metadataTable.get(cData.getBlockCountMetaKey()));
     }
   }
 
@@ -401,7 +401,7 @@ public class TestSchemaOneBackwardsCompatibility {
 
       // Test encoding keys and decoding database values.
       for (String blockID: TestDB.BLOCK_IDS) {
-        String blockKey = cData.blockKey(Long.parseLong(blockID));
+        String blockKey = cData.getBlockMetaKey(Long.parseLong(blockID));
         BlockData blockData = blockDataTable.get(blockKey);
         Assert.assertEquals(Long.toString(blockData.getLocalID()), blockID);
       }
@@ -444,7 +444,8 @@ public class TestSchemaOneBackwardsCompatibility {
           refCountedDB.getStore().getBlockDataTable();
 
       for (String blockID: TestDB.DELETING_BLOCK_IDS) {
-        String blockKey = cData.deletingBlockKey(Long.parseLong(blockID));
+        String blockKey = cData.getDeletingBlockMetaKey(
+            Long.parseLong(blockID));
         BlockData blockData = blockDataTable.get(blockKey);
         Assert.assertEquals(Long.toString(blockData.getLocalID()), blockID);
       }
@@ -464,7 +465,7 @@ public class TestSchemaOneBackwardsCompatibility {
       // Apply the deleting prefix to the saved block IDs so we can compare
       // them to the retrieved keys.
       List<String> expectedKeys = TestDB.DELETING_BLOCK_IDS.stream()
-          .map(key -> cData.deletingBlockKey(Long.parseLong(key)))
+          .map(key -> cData.getDeletingBlockMetaKey(Long.parseLong(key)))
           .collect(Collectors.toList());
 
       Assert.assertEquals(expectedKeys, decodedKeys);
@@ -496,11 +497,11 @@ public class TestSchemaOneBackwardsCompatibility {
           refCountedDB.getStore().getMetadataTable();
 
       Assert.assertEquals(TestDB.KEY_COUNT,
-          metadataTable.get(cData.blockCountKey()).longValue());
+          metadataTable.get(cData.getBlockCountMetaKey()).longValue());
       Assert.assertEquals(TestDB.BYTES_USED,
-          metadataTable.get(cData.bytesUsedKey()).longValue());
+          metadataTable.get(cData.getBytesUsedMetaKey()).longValue());
       Assert.assertEquals(TestDB.NUM_PENDING_DELETION_BLOCKS,
-          metadataTable.get(cData.pendingDeleteBlockCountKey())
+          metadataTable.get(cData.getPendingDeleteBlockCountMetaKey())
               .longValue());
     }
   }

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/TestSchemaTwoBackwardsCompatibility.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/TestSchemaTwoBackwardsCompatibility.java
@@ -317,9 +317,9 @@ public class TestSchemaTwoBackwardsCompatibility {
 
           // update delete related metadata
           db.getStore().getMetadataTable().putWithBatch(batch,
-              cData.getLatestDeleteTxnMetaKey(), txn.getTxID());
+              cData.getLatestDeleteTxnKey(), txn.getTxID());
           db.getStore().getMetadataTable().putWithBatch(batch,
-              cData.getPendingDeleteBlockCountMetaKey(),
+              cData.getPendingDeleteBlockCountKey(),
               cData.getNumPendingDeletionBlocks() + BLOCKS_PER_TXN);
           db.getStore().getBatchHandler().commitBatchOperation(batch);
 

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/TestSchemaTwoBackwardsCompatibility.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/TestSchemaTwoBackwardsCompatibility.java
@@ -317,9 +317,9 @@ public class TestSchemaTwoBackwardsCompatibility {
 
           // update delete related metadata
           db.getStore().getMetadataTable().putWithBatch(batch,
-              cData.latestDeleteTxnKey(), txn.getTxID());
+              cData.getLatestDeleteTxnMetaKey(), txn.getTxID());
           db.getStore().getMetadataTable().putWithBatch(batch,
-              cData.pendingDeleteBlockCountKey(),
+              cData.getPendingDeleteBlockCountMetaKey(),
               cData.getNumPendingDeletionBlocks() + BLOCKS_PER_TXN);
           db.getStore().getBatchHandler().commitBatchOperation(batch);
 

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/TestKeyValueContainer.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/TestKeyValueContainer.java
@@ -327,14 +327,14 @@ public class TestKeyValueContainer {
               metadataStore.getStore().getBlockDataTable();
 
       for (long i = 0; i < numberOfKeysToWrite; i++) {
-        blockDataTable.put(cData.getBlockMetaKey(i),
+        blockDataTable.put(cData.getBlockKey(i),
             new BlockData(new BlockID(i, i)));
       }
 
       // As now when we put blocks, we increment block count and update in DB.
       // As for test, we are doing manually so adding key count to DB.
       metadataStore.getStore().getMetadataTable()
-              .put(cData.getBlockCountMetaKey(), numberOfKeysToWrite);
+              .put(cData.getBlockCountKey(), numberOfKeysToWrite);
     }
 
     Map<String, String> metadata = new HashMap<>();

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/TestKeyValueContainer.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/TestKeyValueContainer.java
@@ -327,14 +327,14 @@ public class TestKeyValueContainer {
               metadataStore.getStore().getBlockDataTable();
 
       for (long i = 0; i < numberOfKeysToWrite; i++) {
-        blockDataTable.put(cData.blockKey(i),
+        blockDataTable.put(cData.getBlockMetaKey(i),
             new BlockData(new BlockID(i, i)));
       }
 
       // As now when we put blocks, we increment block count and update in DB.
       // As for test, we are doing manually so adding key count to DB.
       metadataStore.getStore().getMetadataTable()
-              .put(cData.blockCountKey(), numberOfKeysToWrite);
+              .put(cData.getBlockCountMetaKey(), numberOfKeysToWrite);
     }
 
     Map<String, String> metadata = new HashMap<>();

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/TestKeyValueContainerIntegrityChecks.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/TestKeyValueContainerIntegrityChecks.java
@@ -172,10 +172,10 @@ public class TestKeyValueContainerIntegrityChecks {
         blockData.setChunks(chunkList);
 
         // normal key
-        String key = containerData.getBlockMetaKey(blockID.getLocalID());
+        String key = containerData.getBlockKey(blockID.getLocalID());
         if (i >= normalBlocks) {
           // deleted key
-          key = containerData.getDeletingBlockMetaKey(blockID.getLocalID());
+          key = containerData.getDeletingBlockKey(blockID.getLocalID());
         }
         metadataStore.getStore().getBlockDataTable().put(key, blockData);
       }

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/TestKeyValueContainerIntegrityChecks.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/TestKeyValueContainerIntegrityChecks.java
@@ -172,10 +172,10 @@ public class TestKeyValueContainerIntegrityChecks {
         blockData.setChunks(chunkList);
 
         // normal key
-        String key = containerData.blockKey(blockID.getLocalID());
+        String key = containerData.getBlockMetaKey(blockID.getLocalID());
         if (i >= normalBlocks) {
           // deleted key
-          key = containerData.deletingBlockKey(blockID.getLocalID());
+          key = containerData.getDeletingBlockMetaKey(blockID.getLocalID());
         }
         metadataStore.getStore().getBlockDataTable().put(key, blockData);
       }

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/TestKeyValueContainerMetadataInspector.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/TestKeyValueContainerMetadataInspector.java
@@ -293,8 +293,8 @@ public class TestKeyValueContainerMetadataInspector
     try (DBHandle db = BlockUtils.getDB(containerData, getConf())) {
       Table<String, Long> metadataTable = db.getStore().getMetadataTable();
       // Don't care about in memory state. Just change the DB values.
-      metadataTable.put(containerData.getBlockCountMetaKey(), blockCount);
-      metadataTable.put(containerData.getBytesUsedMetaKey(), byteCount);
+      metadataTable.put(containerData.getBlockCountKey(), blockCount);
+      metadataTable.put(containerData.getBytesUsedKey(), byteCount);
     }
   }
 
@@ -303,10 +303,10 @@ public class TestKeyValueContainerMetadataInspector
     try (DBHandle db = BlockUtils.getDB(containerData, getConf())) {
       Table<String, Long> metadataTable = db.getStore().getMetadataTable();
 
-      long bytesUsed = metadataTable.get(containerData.getBytesUsedMetaKey());
+      long bytesUsed = metadataTable.get(containerData.getBytesUsedKey());
       Assert.assertEquals(expectedBytesUsed, bytesUsed);
 
-      long blockCount = metadataTable.get(containerData.getBlockCountMetaKey());
+      long blockCount = metadataTable.get(containerData.getBlockCountKey());
       Assert.assertEquals(expectedBlockCount, blockCount);
     }
   }

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/TestKeyValueContainerMetadataInspector.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/TestKeyValueContainerMetadataInspector.java
@@ -293,8 +293,8 @@ public class TestKeyValueContainerMetadataInspector
     try (DBHandle db = BlockUtils.getDB(containerData, getConf())) {
       Table<String, Long> metadataTable = db.getStore().getMetadataTable();
       // Don't care about in memory state. Just change the DB values.
-      metadataTable.put(containerData.blockCountKey(), blockCount);
-      metadataTable.put(containerData.bytesUsedKey(), byteCount);
+      metadataTable.put(containerData.getBlockCountMetaKey(), blockCount);
+      metadataTable.put(containerData.getBytesUsedMetaKey(), byteCount);
     }
   }
 
@@ -303,10 +303,10 @@ public class TestKeyValueContainerMetadataInspector
     try (DBHandle db = BlockUtils.getDB(containerData, getConf())) {
       Table<String, Long> metadataTable = db.getStore().getMetadataTable();
 
-      long bytesUsed = metadataTable.get(containerData.bytesUsedKey());
+      long bytesUsed = metadataTable.get(containerData.getBytesUsedMetaKey());
       Assert.assertEquals(expectedBytesUsed, bytesUsed);
 
-      long blockCount = metadataTable.get(containerData.blockCountKey());
+      long blockCount = metadataTable.get(containerData.getBlockCountMetaKey());
       Assert.assertEquals(expectedBlockCount, blockCount);
     }
   }

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/ozoneimpl/TestContainerReader.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/ozoneimpl/TestContainerReader.java
@@ -161,11 +161,11 @@ public class TestContainerReader {
                 metadataStore.getStore().getBlockDataTable();
 
         Long localID = blockNames.get(i);
-        String blk = cData.getBlockMetaKey(localID);
+        String blk = cData.getBlockKey(localID);
         BlockData blkInfo = blockDataTable.get(blk);
 
         blockDataTable.delete(blk);
-        blockDataTable.put(cData.getDeletingBlockMetaKey(localID), blkInfo);
+        blockDataTable.put(cData.getDeletingBlockKey(localID), blkInfo);
       }
 
       if (setMetaData) {
@@ -173,7 +173,7 @@ public class TestContainerReader {
         // and bytes used metadata values, so those do not change.
         Table<String, Long> metadataTable =
                 metadataStore.getStore().getMetadataTable();
-        metadataTable.put(cData.getPendingDeleteBlockCountMetaKey(),
+        metadataTable.put(cData.getPendingDeleteBlockCountKey(),
             (long)count);
       }
     }
@@ -202,14 +202,14 @@ public class TestContainerReader {
         blockData.setChunks(chunkList);
         blkNames.add(localBlockID);
         metadataStore.getStore().getBlockDataTable()
-                .put(cData.getBlockMetaKey(localBlockID), blockData);
+                .put(cData.getBlockKey(localBlockID), blockData);
       }
 
       if (setMetaData) {
         metadataStore.getStore().getMetadataTable()
-                .put(cData.getBlockCountMetaKey(), (long)blockCount);
+                .put(cData.getBlockCountKey(), (long)blockCount);
         metadataStore.getStore().getMetadataTable()
-                .put(cData.getBytesUsedMetaKey(), blockCount * blockLen);
+                .put(cData.getBytesUsedKey(), blockCount * blockLen);
       }
     }
 

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/ozoneimpl/TestContainerReader.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/ozoneimpl/TestContainerReader.java
@@ -161,11 +161,11 @@ public class TestContainerReader {
                 metadataStore.getStore().getBlockDataTable();
 
         Long localID = blockNames.get(i);
-        String blk = cData.blockKey(localID);
+        String blk = cData.getBlockMetaKey(localID);
         BlockData blkInfo = blockDataTable.get(blk);
 
         blockDataTable.delete(blk);
-        blockDataTable.put(cData.deletingBlockKey(localID), blkInfo);
+        blockDataTable.put(cData.getDeletingBlockMetaKey(localID), blkInfo);
       }
 
       if (setMetaData) {
@@ -173,7 +173,8 @@ public class TestContainerReader {
         // and bytes used metadata values, so those do not change.
         Table<String, Long> metadataTable =
                 metadataStore.getStore().getMetadataTable();
-        metadataTable.put(cData.pendingDeleteBlockCountKey(), (long)count);
+        metadataTable.put(cData.getPendingDeleteBlockCountMetaKey(),
+            (long)count);
       }
     }
 
@@ -201,14 +202,14 @@ public class TestContainerReader {
         blockData.setChunks(chunkList);
         blkNames.add(localBlockID);
         metadataStore.getStore().getBlockDataTable()
-                .put(cData.blockKey(localBlockID), blockData);
+                .put(cData.getBlockMetaKey(localBlockID), blockData);
       }
 
       if (setMetaData) {
         metadataStore.getStore().getMetadataTable()
-                .put(cData.blockCountKey(), (long)blockCount);
+                .put(cData.getBlockCountMetaKey(), (long)blockCount);
         metadataStore.getStore().getMetadataTable()
-                .put(cData.bytesUsedKey(), blockCount * blockLen);
+                .put(cData.getBytesUsedMetaKey(), blockCount * blockLen);
       }
     }
 

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/ozoneimpl/TestOzoneContainer.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/ozoneimpl/TestOzoneContainer.java
@@ -320,13 +320,13 @@ public class TestOzoneContainer {
           chunkList.add(info.getProtoBufMessage());
         }
         blockData.setChunks(chunkList);
-        blockDataTable.put(cData.getBlockMetaKey(blockID.getLocalID()),
+        blockDataTable.put(cData.getBlockKey(blockID.getLocalID()),
             blockData);
       }
 
       // Set Block count and used bytes.
-      metadataTable.put(cData.getBlockCountMetaKey(), (long) blocks);
-      metadataTable.put(cData.getBytesUsedMetaKey(), usedBytes);
+      metadataTable.put(cData.getBlockCountKey(), (long) blocks);
+      metadataTable.put(cData.getBytesUsedKey(), usedBytes);
     }
     // remaining available capacity of the container
     return (freeBytes - usedBytes);

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/ozoneimpl/TestOzoneContainer.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/ozoneimpl/TestOzoneContainer.java
@@ -320,12 +320,13 @@ public class TestOzoneContainer {
           chunkList.add(info.getProtoBufMessage());
         }
         blockData.setChunks(chunkList);
-        blockDataTable.put(cData.blockKey(blockID.getLocalID()), blockData);
+        blockDataTable.put(cData.getBlockMetaKey(blockID.getLocalID()),
+            blockData);
       }
 
       // Set Block count and used bytes.
-      metadataTable.put(cData.blockCountKey(), (long) blocks);
-      metadataTable.put(cData.bytesUsedKey(), usedBytes);
+      metadataTable.put(cData.getBlockCountMetaKey(), (long) blocks);
+      metadataTable.put(cData.getBytesUsedMetaKey(), usedBytes);
     }
     // remaining available capacity of the container
     return (freeBytes - usedBytes);

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/TestStorageContainerManagerHelper.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/TestStorageContainerManagerHelper.java
@@ -111,7 +111,7 @@ public class TestStorageContainerManagerHelper {
 
       for (Table.KeyValue<String, BlockData> entry : kvs) {
         pendingDeletionBlocks
-            .add(entry.getKey().replace(cData.deletingBlockKeyPrefix(), ""));
+            .add(entry.getKey().replace(cData.getDeletingBlockKeyPrefix(), ""));
       }
     }
     return pendingDeletionBlocks;

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestFailureHandlingByClient.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestFailureHandlingByClient.java
@@ -268,7 +268,7 @@ public class TestFailureHandlingByClient {
             .getContainer(containerId1)).getContainerData();
     try (DBHandle containerDb1 = BlockUtils.getDB(containerData1, conf)) {
       BlockData blockData1 = containerDb1.getStore().getBlockDataTable().get(
-          containerData1.getBlockMetaKey(locationList.get(0).getBlockID()
+          containerData1.getBlockKey(locationList.get(0).getBlockID()
               .getLocalID()));
       // The first Block could have 1 or 2 chunkSize of data
       int block1NumChunks = blockData1.getChunks().size();
@@ -287,7 +287,7 @@ public class TestFailureHandlingByClient {
             .getContainer(containerId2)).getContainerData();
     try (DBHandle containerDb2 = BlockUtils.getDB(containerData2, conf)) {
       BlockData blockData2 = containerDb2.getStore().getBlockDataTable().get(
-          containerData2.getBlockMetaKey(locationList.get(1).getBlockID()
+          containerData2.getBlockKey(locationList.get(1).getBlockID()
               .getLocalID()));
       // The second Block should have 0.5 chunkSize of data
       Assert.assertEquals(block2ExpectedChunkCount,

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestFailureHandlingByClient.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestFailureHandlingByClient.java
@@ -268,7 +268,7 @@ public class TestFailureHandlingByClient {
             .getContainer(containerId1)).getContainerData();
     try (DBHandle containerDb1 = BlockUtils.getDB(containerData1, conf)) {
       BlockData blockData1 = containerDb1.getStore().getBlockDataTable().get(
-          containerData1.blockKey(locationList.get(0).getBlockID()
+          containerData1.getBlockMetaKey(locationList.get(0).getBlockID()
               .getLocalID()));
       // The first Block could have 1 or 2 chunkSize of data
       int block1NumChunks = blockData1.getChunks().size();
@@ -287,7 +287,7 @@ public class TestFailureHandlingByClient {
             .getContainer(containerId2)).getContainerData();
     try (DBHandle containerDb2 = BlockUtils.getDB(containerData2, conf)) {
       BlockData blockData2 = containerDb2.getStore().getBlockDataTable().get(
-          containerData2.blockKey(locationList.get(1).getBlockID()
+          containerData2.getBlockMetaKey(locationList.get(1).getBlockID()
               .getLocalID()));
       // The second Block should have 0.5 chunkSize of data
       Assert.assertEquals(block2ExpectedChunkCount,

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestOzoneRpcClientAbstract.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestOzoneRpcClientAbstract.java
@@ -1790,7 +1790,7 @@ public abstract class TestOzoneRpcClientAbstract {
         KeyValueContainerData cData =
             (KeyValueContainerData) container.getContainerData();
         try (DBHandle db = BlockUtils.getDB(cData, cluster.getConf())) {
-          db.getStore().getMetadataTable().put(cData.getBcsIdMetaKey(),
+          db.getStore().getMetadataTable().put(cData.getBcsIdKey(),
               newBCSID);
         }
         container.updateBlockCommitSequenceId(newBCSID);

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestOzoneRpcClientAbstract.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestOzoneRpcClientAbstract.java
@@ -1790,7 +1790,8 @@ public abstract class TestOzoneRpcClientAbstract {
         KeyValueContainerData cData =
             (KeyValueContainerData) container.getContainerData();
         try (DBHandle db = BlockUtils.getDB(cData, cluster.getConf())) {
-          db.getStore().getMetadataTable().put(cData.bcsIdKey(), newBCSID);
+          db.getStore().getMetadataTable().put(cData.getBcsIdMetaKey(),
+              newBCSID);
         }
         container.updateBlockCommitSequenceId(newBCSID);
         index++;

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestValidateBCSIDOnRestart.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestValidateBCSIDOnRestart.java
@@ -227,7 +227,7 @@ public class TestValidateBCSIDOnRestart {
       // modify the bcsid for the container in the ROCKS DB thereby inducing
       // corruption
       db.getStore().getMetadataTable()
-          .put(keyValueContainerData.getBcsIdMetaKey(), 0L);
+          .put(keyValueContainerData.getBcsIdKey(), 0L);
     }
     // after the restart, there will be a mismatch in BCSID of what is recorded
     // in the and what is there in RockSDB and hence the container would be

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestValidateBCSIDOnRestart.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestValidateBCSIDOnRestart.java
@@ -227,7 +227,7 @@ public class TestValidateBCSIDOnRestart {
       // modify the bcsid for the container in the ROCKS DB thereby inducing
       // corruption
       db.getStore().getMetadataTable()
-          .put(keyValueContainerData.bcsIdKey(), 0L);
+          .put(keyValueContainerData.getBcsIdMetaKey(), 0L);
     }
     // after the restart, there will be a mismatch in BCSID of what is recorded
     // in the and what is there in RockSDB and hence the container would be

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/TestBlockDeletion.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/TestBlockDeletion.java
@@ -443,7 +443,7 @@ public class TestBlockDeletion {
             .getContainer(blockID.getContainerID()).getContainerData();
         try (DBHandle db = BlockUtils.getDB(cData, conf)) {
           Assertions.assertNotNull(db.getStore().getBlockDataTable()
-              .get(cData.getBlockMetaKey(blockID.getLocalID())));
+              .get(cData.getBlockKey(blockID.getLocalID())));
         }
       }, omKeyLocationInfoGroups);
     }
@@ -461,12 +461,12 @@ public class TestBlockDeletion {
           Table<String, BlockData> blockDataTable =
               db.getStore().getBlockDataTable();
 
-          String blockKey = cData.getBlockMetaKey(blockID.getLocalID());
+          String blockKey = cData.getBlockKey(blockID.getLocalID());
 
           BlockData blockData = blockDataTable.get(blockKey);
           Assertions.assertNull(blockData);
 
-          String deletingKey = cData.getDeletingBlockMetaKey(
+          String deletingKey = cData.getDeletingBlockKey(
               blockID.getLocalID());
           Assertions.assertNull(blockDataTable.get(deletingKey));
         }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/TestBlockDeletion.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/TestBlockDeletion.java
@@ -443,7 +443,7 @@ public class TestBlockDeletion {
             .getContainer(blockID.getContainerID()).getContainerData();
         try (DBHandle db = BlockUtils.getDB(cData, conf)) {
           Assertions.assertNotNull(db.getStore().getBlockDataTable()
-              .get(cData.blockKey(blockID.getLocalID())));
+              .get(cData.getBlockMetaKey(blockID.getLocalID())));
         }
       }, omKeyLocationInfoGroups);
     }
@@ -461,12 +461,13 @@ public class TestBlockDeletion {
           Table<String, BlockData> blockDataTable =
               db.getStore().getBlockDataTable();
 
-          String blockKey = cData.blockKey(blockID.getLocalID());
+          String blockKey = cData.getBlockMetaKey(blockID.getLocalID());
 
           BlockData blockData = blockDataTable.get(blockKey);
           Assertions.assertNull(blockData);
 
-          String deletingKey = cData.deletingBlockKey(blockID.getLocalID());
+          String deletingKey = cData.getDeletingBlockMetaKey(
+              blockID.getLocalID());
           Assertions.assertNull(blockDataTable.get(deletingKey));
         }
         containerIdsWithDeletedBlocks.add(blockID.getContainerID());


### PR DESCRIPTION
## What changes were proposed in this pull request?

The current function names to get metadata keys in KeyValueContainerData might be confusing to users, this ticket is to update the names for better readability.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-7441

## How was this patch tested?

Only update function names, no need to add tests.