### PR TITLE
HDDS-7447. Leak of TableIterator in DirectoryDeletingService.

### DIFF
--- a/hadoop-ozone/dev-support/intellij/log4j.properties
+++ b/hadoop-ozone/dev-support/intellij/log4j.properties
@@ -16,3 +16,5 @@ log4j.appender.stdout=org.apache.log4j.ConsoleAppender
 log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
 log4j.appender.stdout.layout.ConversionPattern=%d{ISO8601} %-5p %c{2} (%F:%M(%L)) - %m%n
 log4j.logger.io.jagertraecing=DEBUG
+
+log4j.logger.org.apache.hadoop.hdds.utils.db.managed=DEBUG

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/service/DirectoryDeletingService.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/service/DirectoryDeletingService.java
@@ -144,10 +144,9 @@ public class DirectoryDeletingService extends BackgroundService {
         List<PurgePathRequest> purgePathRequestList = new ArrayList<>();
 
         Table.KeyValue<String, OmKeyInfo> pendingDeletedDirInfo;
-        try {
-          TableIterator<String, ? extends KeyValue<String, OmKeyInfo>>
-              deleteTableIterator = ozoneManager.getMetadataManager().
-              getDeletedDirTable().iterator();
+        try (TableIterator<String, ? extends KeyValue<String, OmKeyInfo>>
+                 deleteTableIterator = ozoneManager.getMetadataManager().
+            getDeletedDirTable().iterator()) {
 
           long startTime = Time.monotonicNow();
           while (remainNum > 0 && deleteTableIterator.hasNext()) {


### PR DESCRIPTION
## What changes were proposed in this pull request?

Found this Iterator leak when working on another problem. TableIterator is not closed, introduce from [this change](https://github.com/apache/ozone/pull/3844/files#diff-7ec30412dac9f4304cc72760eec9efe605e901ec3a7d379551da7c6ab67ea7eaR148).

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-7447


## How was this patch tested?
Standard CI.
Manual verify the no leaks is introduced from running DirectoryDeletingService.
