### PR TITLE
HDDS-7453. Check certificate expiration at service startup, renew if necessary.

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/HddsConfigKeys.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/HddsConfigKeys.java
@@ -192,7 +192,7 @@ public final class HddsConfigKeys {
   public static final String HDDS_X509_RENEW_GRACE_DURATION =
       "hdds.x509.renew.grace.duration";
 
-  public static final String HDDS_X509_RENEW_GRACE_DURATION_DEFAULT = "28D";
+  public static final String HDDS_X509_RENEW_GRACE_DURATION_DEFAULT = "P28D";
 
   /**
    * Do not instantiate.

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/HddsConfigKeys.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/HddsConfigKeys.java
@@ -185,6 +185,16 @@ public final class HddsConfigKeys {
   public static final String HDDS_X509_DEFAULT_DURATION_DEFAULT = "P365D";
 
   /**
+   * Duration in days within which before the certificate expiration date the
+   * certificate is automatically renewed.
+   * Default is 28 days.
+   */
+  public static final String HDDS_X509_RENEW_GRACE_DURATION =
+      "hdds.x509.renew.grace.duration";
+
+  public static final String HDDS_X509_RENEW_GRACE_DURATION_DEFAULT = "28";
+
+  /**
    * Do not instantiate.
    */
   private HddsConfigKeys() {

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/HddsConfigKeys.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/HddsConfigKeys.java
@@ -185,14 +185,14 @@ public final class HddsConfigKeys {
   public static final String HDDS_X509_DEFAULT_DURATION_DEFAULT = "P365D";
 
   /**
-   * Duration in days within which before the certificate expiration date the
-   * certificate is automatically renewed.
+   * Duration of the grace period within which a certificate should be
+   * renewed before the current one expires.
    * Default is 28 days.
    */
   public static final String HDDS_X509_RENEW_GRACE_DURATION =
       "hdds.x509.renew.grace.duration";
 
-  public static final String HDDS_X509_RENEW_GRACE_DURATION_DEFAULT = "28";
+  public static final String HDDS_X509_RENEW_GRACE_DURATION_DEFAULT = "28D";
 
   /**
    * Do not instantiate.

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/security/x509/SecurityConfig.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/security/x509/SecurityConfig.java
@@ -102,7 +102,7 @@ public class SecurityConfig {
   private final String certificateFileName;
   private final boolean grpcTlsEnabled;
   private final Duration defaultCertDuration;
-  private final int renewalGraceDays;
+  private final Duration renewalGracePeriod;
   private final boolean isSecurityEnabled;
   private final String crlName;
   private boolean grpcTlsUseTestCert;
@@ -167,10 +167,10 @@ public class SecurityConfig {
         this.configuration.get(HDDS_X509_DEFAULT_DURATION,
             HDDS_X509_DEFAULT_DURATION_DEFAULT);
     defaultCertDuration = Duration.parse(certDurationString);
-    String renewalGraceDuration = this.configuration.get(
+    String renewalGraceDurationString = this.configuration.get(
         HDDS_X509_RENEW_GRACE_DURATION,
         HDDS_X509_RENEW_GRACE_DURATION_DEFAULT);
-    renewalGraceDays = Integer.parseInt(renewalGraceDuration);
+    renewalGracePeriod = Duration.parse(renewalGraceDurationString);
 
     if (maxCertDuration.compareTo(defaultCertDuration) < 0) {
       LOG.error("Certificate duration {} should not be greater than Maximum " +
@@ -229,8 +229,8 @@ public class SecurityConfig {
    *
    * @return the value of hdds.x509.renew.grace.duration property
    */
-  public int getRenewalGraceDays() {
-    return renewalGraceDays;
+  public Duration getRenewalGracePeriod() {
+    return renewalGracePeriod;
   }
 
   /**

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/security/x509/SecurityConfig.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/security/x509/SecurityConfig.java
@@ -224,8 +224,9 @@ public class SecurityConfig {
   }
 
   /**
-   * Returns the number of days within which before expiration a certificate
-   * should be renewed.
+   * Duration of the grace period within which a certificate should be
+   * renewed before the current one expires.
+   * Default is 28 days.
    *
    * @return the value of hdds.x509.renew.grace.duration property
    */

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/security/x509/SecurityConfig.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/security/x509/SecurityConfig.java
@@ -63,6 +63,8 @@ import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_X509_FILE_NAME;
 import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_X509_FILE_NAME_DEFAULT;
 import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_X509_MAX_DURATION;
 import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_X509_MAX_DURATION_DEFAULT;
+import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_X509_RENEW_GRACE_DURATION;
+import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_X509_RENEW_GRACE_DURATION_DEFAULT;
 import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_X509_SIGNATURE_ALGO;
 import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_X509_SIGNATURE_ALGO_DEFAULT;
 import static org.apache.hadoop.hdds.HddsConfigKeys.OZONE_METADATA_DIRS;
@@ -100,6 +102,7 @@ public class SecurityConfig {
   private final String certificateFileName;
   private final boolean grpcTlsEnabled;
   private final Duration defaultCertDuration;
+  private final int renewalGraceDays;
   private final boolean isSecurityEnabled;
   private final String crlName;
   private boolean grpcTlsUseTestCert;
@@ -164,6 +167,10 @@ public class SecurityConfig {
         this.configuration.get(HDDS_X509_DEFAULT_DURATION,
             HDDS_X509_DEFAULT_DURATION_DEFAULT);
     defaultCertDuration = Duration.parse(certDurationString);
+    String renewalGraceDuration = this.configuration.get(
+        HDDS_X509_RENEW_GRACE_DURATION,
+        HDDS_X509_RENEW_GRACE_DURATION_DEFAULT);
+    renewalGraceDays = Integer.parseInt(renewalGraceDuration);
 
     if (maxCertDuration.compareTo(defaultCertDuration) < 0) {
       LOG.error("Certificate duration {} should not be greater than Maximum " +
@@ -214,6 +221,16 @@ public class SecurityConfig {
    */
   public Duration getDefaultCertDuration() {
     return defaultCertDuration;
+  }
+
+  /**
+   * Returns the number of days within which before expiration a certificate
+   * should be renewed.
+   *
+   * @return the value of hdds.x509.renew.grace.duration property
+   */
+  public int getRenewalGraceDays() {
+    return renewalGraceDays;
   }
 
   /**

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/common/StorageInfo.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/common/StorageInfo.java
@@ -154,6 +154,10 @@ public class StorageInfo {
     properties.setProperty(key, value);
   }
 
+  public void unsetProperty(String key) {
+    properties.remove(key);
+  }
+
   public void setClusterId(String clusterId) {
     properties.setProperty(CLUSTER_ID, clusterId);
   }

--- a/hadoop-hdds/common/src/main/resources/ozone-default.xml
+++ b/hadoop-hdds/common/src/main/resources/ozone-default.xml
@@ -2081,8 +2081,8 @@
     <name>hdds.x509.renew.grace.duration</name>
     <value>28D</value>
     <tag>OZONE, HDDS, SECURITY</tag>
-    <description>Duration in days within which before the certificate expiration
-      date the certificate is automatically renewed. Default is 28 days.
+    <description>Duration of the grace period within which a certificate should be
+      * renewed before the current one expires. Default is 28 days.
     </description>
   </property>
   <property>

--- a/hadoop-hdds/common/src/main/resources/ozone-default.xml
+++ b/hadoop-hdds/common/src/main/resources/ozone-default.xml
@@ -2079,7 +2079,7 @@
   </property>
   <property>
     <name>hdds.x509.renew.grace.duration</name>
-    <value>28</value>
+    <value>28D</value>
     <tag>OZONE, HDDS, SECURITY</tag>
     <description>Duration in days within which before the certificate expiration
       date the certificate is automatically renewed. Default is 28 days.

--- a/hadoop-hdds/common/src/main/resources/ozone-default.xml
+++ b/hadoop-hdds/common/src/main/resources/ozone-default.xml
@@ -2079,7 +2079,7 @@
   </property>
   <property>
     <name>hdds.x509.renew.grace.duration</name>
-    <value>28D</value>
+    <value>P28D</value>
     <tag>OZONE, HDDS, SECURITY</tag>
     <description>Duration of the grace period within which a certificate should be
       * renewed before the current one expires. Default is 28 days.

--- a/hadoop-hdds/common/src/main/resources/ozone-default.xml
+++ b/hadoop-hdds/common/src/main/resources/ozone-default.xml
@@ -2078,6 +2078,14 @@
       PnDTnHnMn.nS</description>
   </property>
   <property>
+    <name>hdds.x509.renew.grace.duration</name>
+    <value>28</value>
+    <tag>OZONE, HDDS, SECURITY</tag>
+    <description>Duration in days within which before the certificate expiration
+      date the certificate is automatically renewed. Default is 28 days.
+    </description>
+  </property>
+  <property>
     <name>hdds.x509.dir.name</name>
     <value>certs</value>
     <tag>OZONE, HDDS, SECURITY</tag>

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/HddsDatanodeService.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/HddsDatanodeService.java
@@ -339,6 +339,11 @@ public class HddsDatanodeService extends GenericCli implements ServicePlugin {
     LOG.info("Initializing secure Datanode.");
 
     CertificateClient.InitResponse response = dnCertClient.init();
+    if (response.equals(CertificateClient.InitResponse.REINIT)) {
+      LOG.info("Re-initialize certificate client.");
+      dnCertClient = new DNCertificateClient(new SecurityConfig(conf));
+      response = dnCertClient.init();
+    }
     LOG.info("Init response: {}", response);
     switch (response) {
     case SUCCESS:

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/TestHddsSecureDatanodeInit.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/TestHddsSecureDatanodeInit.java
@@ -102,7 +102,7 @@ public class TestHddsSecureDatanodeInit {
     X509Certificate x509Certificate = null;
 
     x509Certificate = KeyStoreTestUtil.generateCertificate(
-        "CN=Test", new KeyPair(publicKey, privateKey), 10,
+        "CN=Test", new KeyPair(publicKey, privateKey), 365,
         securityConfig.getSignatureAlgo());
     certHolder = new X509CertificateHolder(x509Certificate.getEncoded());
 

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/security/x509/certificate/client/CertificateClient.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/security/x509/certificate/client/CertificateClient.java
@@ -203,7 +203,8 @@ public interface CertificateClient {
     SUCCESS,
     FAILURE,
     GETCERT,
-    RECOVER
+    RECOVER,
+    REINIT
   }
 
   /**

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/security/x509/certificate/client/CommonCertificateClient.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/security/x509/certificate/client/CommonCertificateClient.java
@@ -25,6 +25,7 @@ import org.slf4j.Logger;
 import static org.apache.hadoop.hdds.security.x509.certificate.client.CertificateClient.InitResponse.FAILURE;
 import static org.apache.hadoop.hdds.security.x509.certificate.client.CertificateClient.InitResponse.GETCERT;
 import static org.apache.hadoop.hdds.security.x509.certificate.client.CertificateClient.InitResponse.RECOVER;
+import static org.apache.hadoop.hdds.security.x509.certificate.client.CertificateClient.InitResponse.REINIT;
 import static org.apache.hadoop.hdds.security.x509.certificate.client.CertificateClient.InitResponse.SUCCESS;
 
 /**
@@ -102,6 +103,11 @@ public class CommonCertificateClient extends DefaultCertificateClient {
       } else {
         return FAILURE;
       }
+    case EXPIRES:
+      getLogger().info("Component certificate is about to expire. Initiating" +
+          "renewal.");
+      removeMaterial();
+      return REINIT;
     default:
       log.error("Unexpected case: {} (private/public/cert)",
           Integer.toBinaryString(init.ordinal()));

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/security/x509/certificate/client/CommonCertificateClient.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/security/x509/certificate/client/CommonCertificateClient.java
@@ -103,7 +103,7 @@ public class CommonCertificateClient extends DefaultCertificateClient {
       } else {
         return FAILURE;
       }
-    case EXPIRES:
+    case EXPIRED_CERT:
       getLogger().info("Component certificate is about to expire. Initiating" +
           "renewal.");
       removeMaterial();

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/security/x509/certificate/client/DefaultCertificateClient.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/security/x509/certificate/client/DefaultCertificateClient.java
@@ -639,7 +639,10 @@ public abstract class DefaultCertificateClient implements CertificateClient {
    * 6. PUBLICKEY_PRIVATEKEY  indicates private and public key were read
    *                          successfully from configured location but
    *                          Certificate.
-   * 7. All                   Keypair as well as certificate is present.
+   * 7. ALL                   Keypair as well as certificate is present.
+   * 8. EXPIRED_CERT          The certificate is present, but either it has
+   *                          already expired, or is about to be expired within
+   *                          the grace period provided in the configuration.
    *
    * */
   protected enum InitCase {
@@ -661,7 +664,7 @@ public abstract class DefaultCertificateClient implements CertificateClient {
    * 2. Generates and stores a keypair.
    * 3. Try to recover public key if private key and certificate is present
    *    but public key is missing.
-   * 4. Checks is the certificate is about to be expired or have already been
+   * 4. Checks if the certificate is about to be expired or have already been
    *    expired, and if yes removes the key material and the certificate and
    *    asks for re-initialization in the result.
    *

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/security/x509/certificate/client/SCMCertificateClient.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/security/x509/certificate/client/SCMCertificateClient.java
@@ -61,11 +61,6 @@ public class SCMCertificateClient extends DefaultCertificateClient {
   }
 
   @Override
-  protected boolean handleExpiration() {
-    return false;
-  }
-
-  @Override
   protected InitResponse handleCase(InitCase init)
       throws CertificateException {
     // This is similar to OM.
@@ -114,6 +109,9 @@ public class SCMCertificateClient extends DefaultCertificateClient {
       } else {
         return FAILURE;
       }
+    case EXPIRED_CERT:
+      LOG.error("SCM CA certificate is about to be expire!");
+      return SUCCESS;
     default:
       LOG.error("Unexpected case: {} (private/public/cert)",
           Integer.toBinaryString(init.ordinal()));

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/security/x509/certificate/client/SCMCertificateClient.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/security/x509/certificate/client/SCMCertificateClient.java
@@ -61,6 +61,11 @@ public class SCMCertificateClient extends DefaultCertificateClient {
   }
 
   @Override
+  protected boolean handleExpiration() {
+    return false;
+  }
+
+  @Override
   protected InitResponse handleCase(InitCase init)
       throws CertificateException {
     // This is similar to OM.

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/security/x509/certificate/client/SCMCertificateClient.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/security/x509/certificate/client/SCMCertificateClient.java
@@ -110,7 +110,7 @@ public class SCMCertificateClient extends DefaultCertificateClient {
         return FAILURE;
       }
     case EXPIRED_CERT:
-      LOG.error("SCM CA certificate is about to be expire!");
+      LOG.warn("SCM CA certificate is about to be expire!");
       return SUCCESS;
     default:
       LOG.error("Unexpected case: {} (private/public/cert)",

--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/security/x509/certificate/client/TestCertificateClientInit.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/security/x509/certificate/client/TestCertificateClientInit.java
@@ -212,6 +212,6 @@ public class TestCertificateClientInit {
 
   private X509Certificate getX509Certificate() throws Exception {
     return KeyStoreTestUtil.generateCertificate(
-        "CN=Test", keyPair, 10, securityConfig.getSignatureAlgo());
+        "CN=Test", keyPair, 365, securityConfig.getSignatureAlgo());
   }
 }

--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/security/x509/certificate/client/TestDefaultCertificateClient.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/security/x509/certificate/client/TestDefaultCertificateClient.java
@@ -18,6 +18,7 @@
  */
 package org.apache.hadoop.hdds.security.x509.certificate.client;
 
+import org.apache.hadoop.hdds.security.x509.certificate.client.CertificateClient.InitResponse;
 import org.apache.hadoop.hdds.security.x509.certificate.utils.CertificateCodec;
 import org.apache.hadoop.hdds.security.x509.exceptions.CertificateException;
 import org.apache.hadoop.hdds.security.x509.keys.KeyCodec;
@@ -35,6 +36,8 @@ import java.security.PrivateKey;
 import java.security.PublicKey;
 import java.security.Signature;
 import java.security.cert.X509Certificate;
+import java.util.Calendar;
+import java.util.Date;
 import java.util.UUID;
 
 import org.apache.commons.io.FileUtils;
@@ -48,18 +51,25 @@ import org.apache.hadoop.hdds.security.x509.keys.HDDSKeyGenerator;
 import org.apache.hadoop.security.ssl.KeyStoreTestUtil;
 import org.apache.ozone.test.GenericTestUtils;
 import org.apache.ozone.test.LambdaTestUtils;
+import org.slf4j.Logger;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.apache.hadoop.fs.CommonConfigurationKeysPublic.IPC_CLIENT_CONNECT_MAX_RETRIES_KEY;
 import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_METADATA_DIR_NAME;
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_NAMES;
 import static org.apache.hadoop.hdds.security.x509.certificate.client.CertificateClient.InitResponse.FAILURE;
+import static org.apache.hadoop.hdds.security.x509.certificate.client.CertificateClient.InitResponse.REINIT;
 import static org.apache.hadoop.hdds.security.x509.certificate.utils.CertificateCodec.getPEMEncodedString;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 /**
  * Test class for {@link DefaultCertificateClient}.
@@ -474,4 +484,46 @@ public class TestDefaultCertificateClient {
     omClientLog.clearOutput();
   }
 
+  @SuppressWarnings("checkstyle:LeftCurly")
+  @Test
+  public void testCertificateExpirationHandlingInInit() throws Exception {
+    String certId = "1L";
+    String compName = "TEST";
+
+    Logger mockLogger = mock(Logger.class);
+
+    SecurityConfig config = mock(SecurityConfig.class);
+    Path nonexistent = Paths.get("nonexistent");
+    when(config.getCertificateLocation(anyString())).thenReturn(nonexistent);
+    when(config.getKeyLocation(anyString())).thenReturn(nonexistent);
+    when(config.getRenewalGraceDays()).thenReturn(28);
+
+    Calendar cal = Calendar.getInstance();
+    cal.add(Calendar.DAY_OF_YEAR, 2);
+    Date expiration = cal.getTime();
+    X509Certificate mockCert = mock(X509Certificate.class);
+    when(mockCert.getNotAfter()).thenReturn(expiration);
+
+    DefaultCertificateClient client =
+        new DefaultCertificateClient(config, mockLogger, certId, compName) {
+          @Override
+          public PrivateKey getPrivateKey() {
+            return mock(PrivateKey.class);
+          }
+
+          @Override
+          public PublicKey getPublicKey() {
+            return mock(PublicKey.class);
+          }
+
+          @Override
+          public X509Certificate getCertificate() {
+            return mockCert;
+          }
+        };
+
+    InitResponse resp = client.init();
+    verify(mockLogger, atLeastOnce()).info(anyString());
+    assertEquals(resp, REINIT);
+  }
 }

--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/security/x509/certificate/client/TestDefaultCertificateClient.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/security/x509/certificate/client/TestDefaultCertificateClient.java
@@ -36,6 +36,7 @@ import java.security.PrivateKey;
 import java.security.PublicKey;
 import java.security.Signature;
 import java.security.cert.X509Certificate;
+import java.time.Duration;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.UUID;
@@ -484,7 +485,6 @@ public class TestDefaultCertificateClient {
     omClientLog.clearOutput();
   }
 
-  @SuppressWarnings("checkstyle:LeftCurly")
   @Test
   public void testCertificateExpirationHandlingInInit() throws Exception {
     String certId = "1L";
@@ -496,7 +496,7 @@ public class TestDefaultCertificateClient {
     Path nonexistent = Paths.get("nonexistent");
     when(config.getCertificateLocation(anyString())).thenReturn(nonexistent);
     when(config.getKeyLocation(anyString())).thenReturn(nonexistent);
-    when(config.getRenewalGraceDays()).thenReturn(28);
+    when(config.getRenewalGracePeriod()).thenReturn(Duration.ofDays(28));
 
     Calendar cal = Calendar.getInstance();
     cal.add(Calendar.DAY_OF_YEAR, 2);

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/HASecurityUtils.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/HASecurityUtils.java
@@ -93,11 +93,6 @@ public final class HASecurityUtils {
     CertificateClient certClient =
         new SCMCertificateClient(new SecurityConfig(conf));
     InitResponse response = certClient.init();
-    if (response.equals(CertificateClient.InitResponse.REINIT)) {
-      LOG.info("Re-initialize certificate client.");
-      certClient = new SCMCertificateClient(new SecurityConfig(conf));
-      response = certClient.init();
-    }
     LOG.info("Init response: {}", response);
     switch (response) {
     case SUCCESS:

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/HASecurityUtils.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/HASecurityUtils.java
@@ -93,6 +93,11 @@ public final class HASecurityUtils {
     CertificateClient certClient =
         new SCMCertificateClient(new SecurityConfig(conf));
     InitResponse response = certClient.init();
+    if (response.equals(CertificateClient.InitResponse.REINIT)) {
+      LOG.info("Re-initialize certificate client.");
+      certClient = new SCMCertificateClient(new SecurityConfig(conf));
+      response = certClient.init();
+    }
     LOG.info("Init response: {}", response);
     switch (response) {
     case SUCCESS:

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestSecureOzoneManager.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestSecureOzoneManager.java
@@ -164,7 +164,7 @@ public class TestSecureOzoneManager {
     CertificateCodec certCodec =
         new CertificateCodec(securityConfig, COMPONENT);
     X509Certificate x509Certificate = KeyStoreTestUtil.generateCertificate(
-        "CN=Test", new KeyPair(publicKey, privateKey), 10,
+        "CN=Test", new KeyPair(publicKey, privateKey), 365,
         securityConfig.getSignatureAlgo());
     certCodec.writeCertificate(new X509CertificateHolder(
         x509Certificate.getEncoded()));

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OMStorage.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OMStorage.java
@@ -55,6 +55,10 @@ public class OMStorage extends Storage {
     getStorageInfo().setProperty(OM_CERT_SERIAL_ID, certSerialId);
   }
 
+  public void unsetOmCertSerialId() throws IOException {
+    getStorageInfo().unsetProperty(OM_CERT_SERIAL_ID);
+  }
+
   public void setOmId(String omId) throws IOException {
     if (getState() == StorageState.INITIALIZED) {
       throw new IOException("OM is already initialized.");

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/scm/ReconStorageConfig.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/scm/ReconStorageConfig.java
@@ -90,5 +90,9 @@ public class ReconStorageConfig extends SCMStorageConfig {
     return getStorageInfo().getProperty(RECON_CERT_SERIAL_ID);
   }
 
+  public void unsetReconCertSerialId() {
+    getStorageInfo().unsetProperty(RECON_CERT_SERIAL_ID);
+  }
+
 
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?
In this PR I would like to add a check to the security initialization code, that check if a certificate is about to be expire soon, and if yes, then it will remove the certificate materials of the service, re-initializes the certificate client in a state where there are no keys and certificates anymore, and with that forces the new instance to get a new certificate as it does during the basic security initialization.
This would help to renew certificates with a restart instead of a tedious manual process that involves a restart and removing the files by hand.

For Ozone Manager the code would run when the OM is started with the --init option, as that code is responsible to initialize certificates also when security gets enabled.
For DataNode and for Recon it works during regular startup as it does when first enabling security.
And it will skip SCM as SCMs does not have a regular but a CA certificate and that is more complex to clean up when expires, but at least by default it expires after 5 years compared to the regular certificates with 1 year expiration date.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-7453

## How was this patch tested?

JUnit test added to the core functionality, also tested the changes on a regular cluster with certificates have an expiration date shorter than the renew grace period and it was renewing certificates fine at every service startup as expected.
