### PR TITLE
HDDS-7314. Recon graceful shutdown while closing RocksDB handle.

### DIFF
--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/ReconServer.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/ReconServer.java
@@ -290,6 +290,7 @@ public class ReconServer extends GenericCli {
       if (reconTaskStatusMetrics != null) {
         reconTaskStatusMetrics.unregister();
       }
+      isStarted = false;
       if (reconDBProvider != null) {
         try {
           LOG.info("Closing Recon Container Key DB.");
@@ -298,7 +299,6 @@ public class ReconServer extends GenericCli {
           LOG.error("Recon Container Key DB close failed", ex);
         }
       }
-      isStarted = false;
     }
   }
 

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/ReconServer.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/ReconServer.java
@@ -287,11 +287,16 @@ public class ReconServer extends GenericCli {
       if (ozoneManagerServiceProvider != null) {
         ozoneManagerServiceProvider.stop();
       }
-      if (reconDBProvider != null) {
-        reconDBProvider.close();
-      }
       if (reconTaskStatusMetrics != null) {
         reconTaskStatusMetrics.unregister();
+      }
+      if (reconDBProvider != null) {
+        try {
+          LOG.info("Closing Recon Container Key DB.");
+          reconDBProvider.close();
+        } catch (Exception ex) {
+          LOG.error("Recon Container Key DB close failed", ex);
+        }
       }
       isStarted = false;
     }


### PR DESCRIPTION
## What changes were proposed in this pull request?

JVM crash is observed in ozone integration test. The cause for this,

Rocks DB is closed
Operation in other thread accessing rocks db for read and write
As solution, need to perform graceful shutdown in order, closing other threads and then rocksdb handle at last.

https://issues.apache.org/jira/browse/HDDS-7314

## How was this patch tested?

This patch was tested manually by running integration tests. All integration tests are passing now and no rocksDB crash exception observed in any of the integration tests which was otherwise observed as per log attached in JIRA.
