### PR TITLE
HDDS-7326. Intermittent timeout in TestECContainerRecovery.testContainerRecoveryOverReplicationProcessing

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/TestECContainerRecovery.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/TestECContainerRecovery.java
@@ -270,7 +270,7 @@ public class TestECContainerRecovery {
       } catch (ContainerNotFoundException e) {
         return false;
       }
-    }, 100, 100000);
+    }, 1000, 100000);
   }
 
   private byte[] getInputBytes(int numChunks) {


### PR DESCRIPTION
## What changes were proposed in this pull request?

Sometimes TestECContainerRecovery.testContainerRecoveryOverReplicationProcessing [will timeout, resulting in CI failure.](https://github.com/apache/ozone/actions/runs/3391636515/jobs/5636987310#step:5:9461) We need to increase the inspection time to avoid this problem.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-7326

## How was this patch tested?

fix ut.
