### PR TITLE
HDDS-7456. Recon: Refreshed at not working on Pipeline and DataNode page

### DIFF
--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/views/datanodes/datanodes.tsx
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/views/datanodes/datanodes.tsx
@@ -414,7 +414,7 @@ export class Datanodes extends React.Component<Record<string, object>, IDatanode
           </div>
           <AutoReloadPanel
             isLoading={loading}
-            lastUpdated={lastUpdated}
+            lastRefreshed={lastUpdated}
             togglePolling={this.autoReload.handleAutoReloadToggle}
             onReload={this._loadData}
           />

--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/views/pipelines/pipelines.tsx
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/views/pipelines/pipelines.tsx
@@ -226,7 +226,7 @@ export class Pipelines extends React.Component<Record<string, object>, IPipeline
       <div className='pipelines-container'>
         <div className='page-header'>
           Pipelines ({activeTotalCount})
-          <AutoReloadPanel isLoading={activeLoading} lastUpdated={lastUpdated} togglePolling={this.autoReload.handleAutoReloadToggle} onReload={this._loadData}/>
+          <AutoReloadPanel isLoading={activeLoading} lastRefreshed={lastUpdated} togglePolling={this.autoReload.handleAutoReloadToggle} onReload={this._loadData}/>
         </div>
         <div className='content-div'>
           <Tabs defaultActiveKey='1' onChange={this.onTabChange}>


### PR DESCRIPTION
What changes were proposed in this pull request?
To show last refreshed at Pipeline and Datanodes Page.

What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-7456

How was this patch tested?
Manually

![image](https://user-images.githubusercontent.com/112169209/199940125-a2a1ed85-b596-43a8-8977-3b7af8f0337a.png)

