### PR TITLE
HDDS-7460. Bump snakeyaml from 1.32 to 1.33

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -248,7 +248,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
     <proto-backwards-compatibility.version>1.0.7</proto-backwards-compatibility.version>
 
     <swagger-annotations-version>1.5.4</swagger-annotations-version>
-    <snakeyaml.version>1.32</snakeyaml.version>
+    <snakeyaml.version>1.33</snakeyaml.version>
     <sonar.java.binaries>${basedir}/target/classes</sonar.java.binaries>
 
     <aspectj.version>1.9.7</aspectj.version>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Upgrade snakeyaml to 1.33, which fixes an [issue](https://bitbucket.org/snakeyaml/snakeyaml/issues/553/loaderoptionssetcodepointlimit-not-honored) with `loadAll()`.

No call to `loadAll()` in Ozone currently (hence not needed for 1.3), but let's upgrade to avoid issues with potential future uses.

https://issues.apache.org/jira/browse/HDDS-7460

## How was this patch tested?

Regular CI:
https://github.com/adoroszlai/hadoop-ozone/actions/runs/3392744185