### PR TITLE
HDDS-7326. Intermittent timeout in TestECContainerRecovery.testContainerRecoveryOverReplicationProcessing

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/TestECContainerRecovery.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/TestECContainerRecovery.java
@@ -50,6 +50,8 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
+import java.time.Duration;
+import java.time.temporal.ChronoUnit;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
@@ -94,7 +96,17 @@ public class TestECContainerRecovery {
     conf.setFromObject(clientConfig);
 
     conf.setTimeDuration(HDDS_SCM_WATCHER_TIMEOUT, 1000, TimeUnit.MILLISECONDS);
-    conf.set("hdds.scm.replication.thread.interval", "10s");
+    ReplicationManager.ReplicationManagerConfiguration rmConfig = conf
+            .getObject(
+                    ReplicationManager.ReplicationManagerConfiguration.class);
+    //Setting all the intervals to 10 seconds current tests have timeout
+    // of 100s.
+    rmConfig.setUnderReplicatedInterval(Duration.of(10,
+            ChronoUnit.SECONDS));
+    rmConfig.setOverReplicatedInterval(Duration.of(10,
+            ChronoUnit.SECONDS));
+    rmConfig.setInterval(Duration.of(10, ChronoUnit.SECONDS));
+    conf.setFromObject(rmConfig);
     conf.set(ScmConfigKeys.OZONE_SCM_DEADNODE_INTERVAL, "1s");
     conf.set(ScmConfigKeys.OZONE_SCM_STALENODE_INTERVAL, "1s");
     conf.set(HddsConfigKeys.HDDS_CONTAINER_REPORT_INTERVAL, "1s");

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/TestECContainerRecovery.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/TestECContainerRecovery.java
@@ -94,6 +94,7 @@ public class TestECContainerRecovery {
     conf.setFromObject(clientConfig);
 
     conf.setTimeDuration(HDDS_SCM_WATCHER_TIMEOUT, 1000, TimeUnit.MILLISECONDS);
+    conf.set("hdds.scm.replication.thread.interval", "10s");
     conf.set(ScmConfigKeys.OZONE_SCM_DEADNODE_INTERVAL, "1s");
     conf.set(ScmConfigKeys.OZONE_SCM_STALENODE_INTERVAL, "1s");
     conf.set(HddsConfigKeys.HDDS_CONTAINER_REPORT_INTERVAL, "1s");


### PR DESCRIPTION
## What changes were proposed in this pull request?

Changing **hdds.scm.replication.thread.interval** to run Replication Manager more frequently which defaults to 300s should fix intermittency of the tests under class.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-7326

## How was this patch tested?
UT changes
