### PR TITLE
HDDS-7452. [snapshot] Add unit-testcases for snapshot create validation.

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOmSnapshot.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOmSnapshot.java
@@ -37,6 +37,7 @@ import org.apache.hadoop.ozone.om.helpers.OzoneFileStatus;
 import org.apache.hadoop.ozone.om.helpers.SnapshotInfo;
 import org.apache.hadoop.ozone.om.protocol.OzoneManagerProtocol;
 import org.apache.ozone.test.GenericTestUtils;
+import org.apache.ozone.test.LambdaTestUtils;
 import org.junit.Assert;
 import org.junit.AfterClass;
 import org.junit.Rule;
@@ -410,6 +411,20 @@ public class TestOmSnapshot {
 
     deleteKeys(volbucket);
 
+  }
+
+  @Test
+  public void testDummyBucket()
+          throws Exception {
+    String volume = "vol-" + RandomStringUtils.randomNumeric(5);
+    String bucket = "buc-" + RandomStringUtils.randomNumeric(5);
+    //create volume but not bucket
+    store.createVolume(volume);
+    OzoneVolume vol = store.getVolume(volume);
+
+    LambdaTestUtils.intercept(OMException.class,
+            "Bucket not found",
+            () -> createSnapshot(volume, bucket));
   }
 
   private String createSnapshot()

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOmSnapshot.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOmSnapshot.java
@@ -420,7 +420,6 @@ public class TestOmSnapshot {
     String bucket = "buc-" + RandomStringUtils.randomNumeric(5);
     //create volume but not bucket
     store.createVolume(volume);
-    OzoneVolume vol = store.getVolume(volume);
 
     LambdaTestUtils.intercept(OMException.class,
             "Bucket not found",

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOmSnapshot.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOmSnapshot.java
@@ -414,7 +414,7 @@ public class TestOmSnapshot {
   }
 
   @Test
-  public void testDummyBucket()
+  public void testNonExistentBucket()
           throws Exception {
     String volume = "vol-" + RandomStringUtils.randomNumeric(5);
     String bucket = "buc-" + RandomStringUtils.randomNumeric(5);


### PR DESCRIPTION
## What changes were proposed in this pull request?

Added unit testcase for create snapshot validation -  `TestOmSnapshot / testNonExistentBucket`

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-7452

## How was this patch tested?

Added testcases in file - hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOmSnapshot.java
`mvn -Dtest=TestOmSnapshot test`
[INFO] -------------------------------------------------------
[INFO]  T E S T S
[INFO] -------------------------------------------------------
[INFO] Running org.apache.hadoop.ozone.om.TestOmSnapshot
[INFO] Tests run: 18, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 156.251 s - in org.apache.hadoop.ozone.om.TestOmSnapshot
[ERROR] Exception in thread "Thread-1021" Exception in thread "Thread-2642" Exception in thread "Thread-2926" Exception in thread "Thread-4261" Exception in thread "Thread-4642"
[INFO]
[INFO] Results:
[INFO]
[INFO] Tests run: 18, Failures: 0, Errors: 0, Skipped: 0