### PR TITLE
HDDS-7476. SCM root CA stored under hdds.datanode.dir if ozone.metadata.dirs is not specified

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/security/x509/SecurityConfig.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/security/x509/SecurityConfig.java
@@ -68,7 +68,6 @@ import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_X509_RENEW_GRACE_DURATI
 import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_X509_SIGNATURE_ALGO;
 import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_X509_SIGNATURE_ALGO_DEFAULT;
 import static org.apache.hadoop.hdds.HddsConfigKeys.OZONE_METADATA_DIRS;
-import static org.apache.hadoop.hdds.scm.ScmConfigKeys.HDDS_DATANODE_DIR_KEY;
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_SECURITY_ENABLED_DEFAULT;
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_SECURITY_ENABLED_KEY;
 import org.apache.ratis.thirdparty.io.netty.handler.ssl.SslProvider;
@@ -90,7 +89,7 @@ public class SecurityConfig {
   private final int size;
   private final String keyAlgo;
   private final String providerString;
-  private final String metadatDir;
+  private final String metadataDir;
   private final String keyDir;
   private final String privateKeyFileName;
   private final String publicKeyFileName;
@@ -123,10 +122,8 @@ public class SecurityConfig {
 
     // Please Note: To make it easy for our customers we will attempt to read
     // HDDS metadata dir and if that is not set, we will use Ozone directory.
-    // TODO: We might want to fix this later.
-    this.metadatDir = this.configuration.get(HDDS_METADATA_DIR_NAME,
-        configuration.get(OZONE_METADATA_DIRS,
-            configuration.get(HDDS_DATANODE_DIR_KEY)));
+    this.metadataDir = this.configuration.get(HDDS_METADATA_DIR_NAME,
+        configuration.get(OZONE_METADATA_DIRS));
     this.keyDir = this.configuration.get(HDDS_KEY_DIR_NAME,
         HDDS_KEY_DIR_NAME_DEFAULT);
     this.privateKeyFileName = this.configuration.get(HDDS_PRIVATE_KEY_FILE_NAME,
@@ -271,9 +268,9 @@ public class SecurityConfig {
    * @return Path Key location.
    */
   public Path getKeyLocation(String component) {
-    Preconditions.checkNotNull(this.metadatDir, "Metadata directory can't be"
+    Preconditions.checkNotNull(this.metadataDir, "Metadata directory can't be"
         + " null. Please check configs.");
-    return Paths.get(metadatDir, component, keyDir);
+    return Paths.get(metadataDir, component, keyDir);
   }
 
   /**
@@ -284,9 +281,9 @@ public class SecurityConfig {
    * @return Path location.
    */
   public Path getCertificateLocation(String component) {
-    Preconditions.checkNotNull(this.metadatDir, "Metadata directory can't be"
+    Preconditions.checkNotNull(this.metadataDir, "Metadata directory can't be"
         + " null. Please check configs.");
-    return Paths.get(metadatDir, component, certificateDir);
+    return Paths.get(metadataDir, component, certificateDir);
   }
 
   /**

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/hdds/datanode/metadata/CRLDBDefinition.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/hdds/datanode/metadata/CRLDBDefinition.java
@@ -34,7 +34,6 @@ import java.io.File;
 
 import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_METADATA_DIR_NAME;
 import static org.apache.hadoop.hdds.HddsConfigKeys.OZONE_METADATA_DIRS;
-import static org.apache.hadoop.hdds.scm.ScmConfigKeys.HDDS_DATANODE_DIR_KEY;
 
 /**
  * Class defines the structure and types of the crl.db.
@@ -73,10 +72,8 @@ public class CRLDBDefinition implements DBDefinition {
   public File getDBLocation(ConfigurationSource conf) {
     // Please Note: To make it easy for our customers we will attempt to read
     // HDDS metadata dir and if that is not set, we will use Ozone directory.
-    // TODO: We might want to fix this later.
     String metadataDir = conf.get(HDDS_METADATA_DIR_NAME,
-        conf.get(OZONE_METADATA_DIRS,
-            conf.get(HDDS_DATANODE_DIR_KEY)));
+        conf.get(OZONE_METADATA_DIRS));
     Preconditions.checkNotNull(metadataDir, "Metadata directory can't be"
         + " null. Please check configs.");
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

In a secure cluster, if `ozone.metadata.dirs` are not specified then SCM will fallback to `hdds.datanode.dir` and will end up storing its certificates under the datanode path. It's preferable to let the system crash, rather than storing  scm data under the datanode disk. Also, the datanodes crash if `ozone.metadata.dirs` aren't specified, so it makes sense to not have a fallback.

from `master` under `compose/ozonesecure`, edit `docker-config`
```
# OZONE-SITE.XML_ozone.metadata.dirs=/data/metadata

OZONE-SITE.XML_ozone.om.ratis.storage.dir=/data/om/ratis
OZONE-SITE.XML_ozone.om.db.dirs=/data/om/db
OZONE-SITE.XML_ozone.om.ratis.snapshot.dir=/data/om/ratis-snap
OZONE-SITE.XML_ozone.scm.ha.ratis.storage.dir=/data/scm/ratis
OZONE-SITE.XML_ozone.scm.db.dirs=/data/scm/db
OZONE-SITE.XML_ozone.recon.db.dir=/data/recon/db
OZONE-SITE.XML_ozone.recon.om.db.dir=/data/recon/om-db
OZONE-SITE.XML_ozone.recon.scm.db.dirs=/data/recon/scm-db
OZONE-SITE.XML_dfs.container.ratis.datanode.storage.dir=/data/dn/ratis
...
...
OZONE-SITE.XML_hdds.datanode.dir=/data/hdds
```
connect to scm and check files under `/data/hdds`

```
> docker-compose up --scale datanode=3 -d
> docker exec -it ozonesecure_scm_1 bash
bash-4.2$ ls -lah /data/hdds/scm/sub-ca/certs
total 20K
drwxr-xr-x 2 hadoop hadoop 4.0K Nov 10 19:03 .
drwxr-xr-x 4 hadoop hadoop 4.0K Nov 10 19:03 ..
-rwx------ 1 hadoop hadoop 1.3K Nov 10 19:03 36633700951438.crt
-rwx------ 1 hadoop hadoop 1.3K Nov 10 19:03 CA-1.crt
-rwx------ 1 hadoop hadoop 1.3K Nov 10 19:03 certificate.crt
```

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-7476

## How was this patch tested?

This patch was tested manually in a docker cluster.