### PR TITLE
HDDS-7475. Remove outdated Hadoop dependencies stax2-api, nimbus-jose-jwt, json-smart

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1217,11 +1217,6 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
         <version>3.1.1</version>
       </dependency>
       <dependency>
-        <groupId>org.codehaus.woodstox</groupId>
-        <artifactId>stax2-api</artifactId>
-        <version>3.1.4</version>
-      </dependency>
-      <dependency>
         <groupId>com.fasterxml.woodstox</groupId>
         <artifactId>woodstox-core</artifactId>
         <version>5.4.0</version>
@@ -1463,33 +1458,11 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
       </dependency>
 
       <dependency>
-        <groupId>com.nimbusds</groupId>
-        <artifactId>nimbus-jose-jwt</artifactId>
-        <version>7.9</version>
-        <scope>compile</scope>
-        <exclusions>
-          <exclusion>
-            <groupId>org.bouncycastle</groupId>
-            <artifactId>bcprov-jdk15on</artifactId>
-          </exclusion>
-        </exclusions>
-      </dependency>
-
-      <dependency>
         <groupId>dnsjava</groupId>
         <artifactId>dnsjava</artifactId>
         <version>${dnsjava.version}</version>
       </dependency>
 
-      <dependency>
-        <!-- HACK.  Transitive dependency for nimbus-jose-jwt.  Needed for
-             packaging.  Please re-check this version when updating
-             nimbus-jose-jwt.  Please read HADOOP-14903 for more details.
-          -->
-        <groupId>net.minidev</groupId>
-        <artifactId>json-smart</artifactId>
-        <version>2.4.7</version>
-      </dependency>
       <dependency>
         <groupId>org.skyscreamer</groupId>
         <artifactId>jsonassert</artifactId>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Some transitive dependencies via Hadoop are declared explicitly, dating back to the time when Ozone was split from Hadoop project.  Since then Hadoop has moved on with these dependencies, and we have updated Hadoop version in Ozone, but retained the old versions of these transitive dependencies.

https://issues.apache.org/jira/browse/HDDS-7475

## How was this patch tested?

Regular CI:
https://github.com/adoroszlai/hadoop-ozone/actions/runs/3439905879

Dependency tree diff:

```
@@ -107,7 +107,7 @@
 |  |  \- org.apache.kerby:kerby-pkix:jar:1.0.1:compile
 |  |     +- org.apache.kerby:kerby-asn1:jar:1.0.1:compile
 |  |     \- org.apache.kerby:kerby-util:jar:1.0.1:compile
-|  +- org.codehaus.woodstox:stax2-api:jar:3.1.4:compile
+|  +- org.codehaus.woodstox:stax2-api:jar:4.2.1:compile
 |  +- com.fasterxml.woodstox:woodstox-core:jar:5.4.0:compile
 |  \- org.xerial.snappy:snappy-java:jar:1.1.8.2:compile
 +- org.apache.hadoop:hadoop-hdfs:jar:3.3.4:compile
@@ -170,7 +170,7 @@
 |  +- com.google.protobuf:protobuf-java:jar:2.5.0:compile
 |  +- com.google.code.gson:gson:jar:2.9.0:compile
 |  +- org.apache.hadoop:hadoop-auth:jar:3.3.4:compile
-|  |  +- com.nimbusds:nimbus-jose-jwt:jar:7.9:compile
+|  |  +- com.nimbusds:nimbus-jose-jwt:jar:9.8.1:compile
 |  |  |  \- com.github.stephenc.jcip:jcip-annotations:jar:1.0-1:compile
 |  |  +- net.minidev:json-smart:jar:2.4.7:compile
 |  |  |  \- net.minidev:accessors-smart:jar:2.4.7:compile
```