### PR TITLE
HDDS-7485. Bump commons-codec to 1.15

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -108,7 +108,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
 
     <commons-beanutils.version>1.9.4</commons-beanutils.version>
     <commons-cli.version>1.2</commons-cli.version>
-    <commons-codec.version>1.11</commons-codec.version>
+    <commons-codec.version>1.15</commons-codec.version>
     <commons-collections.version>3.2.2</commons-collections.version>
     <commons-compress.version>1.21</commons-compress.version>
     <commons-configuration2.version>2.1.1</commons-configuration2.version>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Bump commons-codec to latest 1.15 due to [CODEC-134](https://issues.apache.org/jira/browse/CODEC-134).

https://issues.apache.org/jira/browse/HDDS-7485

## How was this patch tested?

Regular CI:
https://github.com/adoroszlai/hadoop-ozone/actions/runs/3456719263