### PR TITLE
HDDS-7488. EC: ReplicationManager: Move Mis-Replicated into a separate unhealthy state

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ContainerHealthResult.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ContainerHealthResult.java
@@ -184,7 +184,7 @@ public class ContainerHealthResult {
      * @return True if the under-replication is corrected by the pending
      *         replicas. False otherwise.
      */
-    public boolean isSufficientlyReplicatedAfterPending() {
+    public boolean isReplicatedOkAfterPending() {
       return sufficientlyReplicatedAfterPending;
     }
 
@@ -258,7 +258,7 @@ public class ContainerHealthResult {
      * @return True if the over-replication is corrected by the pending
      *         deletes. False otherwise.
      */
-    public boolean isSufficientlyReplicatedAfterPending() {
+    public boolean isReplicatedOkAfterPending() {
       return sufficientlyReplicatedAfterPending;
     }
   }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ContainerHealthResult.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ContainerHealthResult.java
@@ -34,7 +34,8 @@ public class ContainerHealthResult {
     HEALTHY,
     UNHEALTHY,
     UNDER_REPLICATED,
-    OVER_REPLICATED
+    OVER_REPLICATED,
+    MIS_REPLICATED
   }
 
   private final ContainerInfo containerInfo;
@@ -265,6 +266,28 @@ public class ContainerHealthResult {
      */
     public boolean isUnrecoverable() {
       return unrecoverable;
+    }
+  }
+
+  /**
+   * Class to represent a container healthy state which is mis-Replicated. This
+   * means the container is neither over nor under replicated, but its replicas
+   * don't meet the requirements of the container placement policy. Eg the
+   * containers are not spread across enough racks.
+   */
+  public static class MisReplicatedHealthResult
+      extends ContainerHealthResult {
+
+    private final boolean misReplicatedAfterPending;
+
+    public MisReplicatedHealthResult(ContainerInfo containerInfo,
+        boolean misReplicatedAfterPending) {
+      super(containerInfo, HealthState.MIS_REPLICATED);
+      this.misReplicatedAfterPending = misReplicatedAfterPending;
+    }
+
+    public boolean isMisReplicatedAfterPending() {
+      return misReplicatedAfterPending;
     }
   }
 

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ContainerHealthResult.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ContainerHealthResult.java
@@ -107,9 +107,6 @@ public class ContainerHealthResult {
     private final int remainingRedundancy;
     private final boolean dueToDecommission;
     private final boolean sufficientlyReplicatedAfterPending;
-    private boolean dueToMisReplication = false;
-    private boolean isMisReplicated = false;
-    private boolean isMisReplicatedAfterPending = false;
     private final boolean unrecoverable;
     private int requeueCount = 0;
 
@@ -121,44 +118,6 @@ public class ContainerHealthResult {
       this.dueToDecommission = dueToDecommission;
       this.sufficientlyReplicatedAfterPending = replicatedOkWithPending;
       this.unrecoverable = unrecoverable;
-    }
-
-    /**
-     * Pass true to indicate the container is mis-replicated - ie it does not
-     * meet the placement policy.
-     * @param isMisRep True if the container is mis-replicated, false if not.
-     * @return this object to allow calls to be chained
-     */
-    public UnderReplicatedHealthResult
-        setMisReplicated(boolean isMisRep) {
-      this.isMisReplicated = isMisRep;
-      return this;
-    }
-
-    /**
-     * Pass true to indicate the container is mis-replicated after considering
-     * pending replicas scheduled for create or delete.
-     * @param isMisRep True if the container is mis-replicated considering
-     *                 pending replicas, or false if not.
-     * @return this object to allow calls to be chained
-     */
-    public UnderReplicatedHealthResult
-        setMisReplicatedAfterPending(boolean isMisRep) {
-      this.isMisReplicatedAfterPending = isMisRep;
-      return this;
-    }
-
-    /**
-     * If the container is ONLY under replicated due to mis-replication, pass
-     * true, otherwise pass false.
-     * @param dueToMisRep Pass true if the container has enough replicas but
-     *                    does not meet the placement policy.
-     * @return
-     */
-    public UnderReplicatedHealthResult
-        setDueToMisReplication(boolean dueToMisRep) {
-      this.dueToMisReplication = dueToMisRep;
-      return this;
     }
 
     /**
@@ -230,34 +189,6 @@ public class ContainerHealthResult {
     }
 
     /**
-     * Returns true if the container is mis-replicated, ignoring any pending
-     * replicas scheduled to be created.
-     * @return True if mis-replicated, ignoring pending
-     */
-    public boolean isMisReplicated() {
-      return isMisReplicated;
-    }
-
-    /**
-     * Returns true if the container is mis-replicated after taking account of
-     * pending replicas, which are schedule to be created.
-     * @return true is mis-replicated after pending.
-     */
-    public boolean isMisReplicatedAfterPending() {
-      return isMisReplicatedAfterPending;
-    }
-
-    /**
-     * Returns true if the under replication is only due to mis-replication.
-     * In other words, the container has enough replicas, but they do not meet
-     * the placement policy.
-     * @return true if the under-replication is only due to mis-replication
-     */
-    public boolean isDueToMisReplication() {
-      return dueToMisReplication;
-    }
-
-    /**
      * Indicates whether a container has enough replicas to be read. For Ratis
      * at least one replia must be available. For EC, at least dataNum replicas
      * are needed.
@@ -278,16 +209,16 @@ public class ContainerHealthResult {
   public static class MisReplicatedHealthResult
       extends ContainerHealthResult {
 
-    private final boolean misReplicatedAfterPending;
+    private final boolean replicatedOkAfterPending;
 
     public MisReplicatedHealthResult(ContainerInfo containerInfo,
-        boolean misReplicatedAfterPending) {
+        boolean replicatedOkAfterPending) {
       super(containerInfo, HealthState.MIS_REPLICATED);
-      this.misReplicatedAfterPending = misReplicatedAfterPending;
+      this.replicatedOkAfterPending = replicatedOkAfterPending;
     }
 
-    public boolean isMisReplicatedAfterPending() {
-      return misReplicatedAfterPending;
+    public boolean isReplicatedOkAfterPending() {
+      return replicatedOkAfterPending;
     }
   }
 

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ECOverReplicationHandler.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ECOverReplicationHandler.java
@@ -99,7 +99,7 @@ public class ECOverReplicationHandler extends AbstractOverReplicationHandler {
     ContainerHealthResult.OverReplicatedHealthResult containerHealthResult =
         ((ContainerHealthResult.OverReplicatedHealthResult)
             currentUnderRepRes);
-    if (containerHealthResult.isSufficientlyReplicatedAfterPending()) {
+    if (containerHealthResult.isReplicatedOkAfterPending()) {
       LOG.info("The container {} with replicas {} will be corrected " +
               "by the pending delete", container.getContainerID(), replicas);
       return emptyMap();

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ECUnderReplicationHandler.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ECUnderReplicationHandler.java
@@ -145,7 +145,7 @@ public class ECUnderReplicationHandler implements UnhealthyReplicationHandler {
     ContainerHealthResult.UnderReplicatedHealthResult containerHealthResult =
         ((ContainerHealthResult.UnderReplicatedHealthResult)
             currentUnderRepRes);
-    if (containerHealthResult.isSufficientlyReplicatedAfterPending()) {
+    if (containerHealthResult.isReplicatedOkAfterPending()) {
       LOG.info("The container {} with replicas {} is sufficiently replicated",
           container.getContainerID(), replicaCount.getReplicas());
       return emptyMap();

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ReplicationQueue.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ReplicationQueue.java
@@ -32,6 +32,8 @@ public class ReplicationQueue {
       underRepQueue;
   private final Queue<ContainerHealthResult.OverReplicatedHealthResult>
       overRepQueue;
+  private final Queue<ContainerHealthResult.MisReplicatedHealthResult>
+      misRepQueue;
 
   public ReplicationQueue() {
     underRepQueue = new PriorityQueue<>(
@@ -40,6 +42,7 @@ public class ReplicationQueue {
         .thenComparing(ContainerHealthResult
             .UnderReplicatedHealthResult::getRequeueCount));
     overRepQueue = new LinkedList<>();
+    misRepQueue = new LinkedList<>();
   }
 
   public void enqueue(ContainerHealthResult.UnderReplicatedHealthResult
@@ -52,6 +55,11 @@ public class ReplicationQueue {
     overRepQueue.add(overReplicatedHealthResult);
   }
 
+  public void enqueue(ContainerHealthResult.MisReplicatedHealthResult
+      misReplicatedHealthResult) {
+    misRepQueue.add(misReplicatedHealthResult);
+  }
+
   public ContainerHealthResult.UnderReplicatedHealthResult
       dequeueUnderReplicatedContainer() {
     return underRepQueue.poll();
@@ -62,12 +70,21 @@ public class ReplicationQueue {
     return overRepQueue.poll();
   }
 
+  public ContainerHealthResult.MisReplicatedHealthResult
+      dequeueMisReplicatedContainer() {
+    return misRepQueue.poll();
+  }
+
   public int underReplicatedQueueSize() {
     return underRepQueue.size();
   }
 
   public int overReplicatedQueueSize() {
     return overRepQueue.size();
+  }
+
+  public int misReplicatedQueueSize() {
+    return misRepQueue.size();
   }
 
 }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/health/ECReplicationCheckHandler.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/health/ECReplicationCheckHandler.java
@@ -101,11 +101,10 @@ public class ECReplicationCheckHandler extends AbstractCheck {
           ReplicationManagerReport.HealthState.MIS_REPLICATED, containerID);
       ContainerHealthResult.MisReplicatedHealthResult misRepHealth
           = ((ContainerHealthResult.MisReplicatedHealthResult) health);
-      // TODO - enqueue the container
-      //if (!misRepHealth.isMisReplicatedAfterPending()) {
-      //  // add to the queue, but ATM the queue expects an over or under rep
-      //  // health state so we need to change that.
-      //}
+      if (!misRepHealth.isReplicatedOkAfterPending()) {
+        request.getReplicationQueue().enqueue(misRepHealth);
+      }
+      return true;
     }
     // Should not get here, but incase it does the container is not healthy,
     // but is also not under or over replicated.
@@ -156,7 +155,7 @@ public class ECReplicationCheckHandler extends AbstractCheck {
           replicas, container.getReplicationConfig().getRequiredNodes(),
           Collections.emptyList());
       return new ContainerHealthResult.MisReplicatedHealthResult(
-          container, !placementAfterPending.isPolicySatisfied());
+          container, placementAfterPending.isPolicySatisfied());
     }
     // No issues detected, so return healthy.
     return new ContainerHealthResult.HealthyResult(container);

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/health/ECReplicationCheckHandler.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/health/ECReplicationCheckHandler.java
@@ -17,6 +17,9 @@
 package org.apache.hadoop.hdds.scm.container.replication.health;
 
 import org.apache.hadoop.hdds.client.ECReplicationConfig;
+import org.apache.hadoop.hdds.protocol.DatanodeDetails;
+import org.apache.hadoop.hdds.scm.ContainerPlacementStatus;
+import org.apache.hadoop.hdds.scm.PlacementPolicy;
 import org.apache.hadoop.hdds.scm.container.ContainerID;
 import org.apache.hadoop.hdds.scm.container.ContainerInfo;
 import org.apache.hadoop.hdds.scm.container.ContainerReplica;
@@ -26,8 +29,11 @@ import org.apache.hadoop.hdds.scm.container.replication.ContainerHealthResult;
 import org.apache.hadoop.hdds.scm.container.replication.ContainerReplicaOp;
 import org.apache.hadoop.hdds.scm.container.replication.ECContainerReplicaCount;
 
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationType.EC;
 
@@ -38,7 +44,10 @@ import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationType.E
  */
 public class ECReplicationCheckHandler extends AbstractCheck {
 
-  public ECReplicationCheckHandler() {
+  private final PlacementPolicy placementPolicy;
+
+  public ECReplicationCheckHandler(PlacementPolicy placementPolicy) {
+    this.placementPolicy = placementPolicy;
   }
 
   @Override
@@ -86,6 +95,17 @@ public class ECReplicationCheckHandler extends AbstractCheck {
         request.getReplicationQueue().enqueue(overHealth);
       }
       return true;
+    } else if (health.getHealthState() ==
+        ContainerHealthResult.HealthState.MIS_REPLICATED) {
+      report.incrementAndSample(
+          ReplicationManagerReport.HealthState.MIS_REPLICATED, containerID);
+      ContainerHealthResult.MisReplicatedHealthResult misRepHealth
+          = ((ContainerHealthResult.MisReplicatedHealthResult) health);
+      // TODO - enqueue the container
+      //if (!misRepHealth.isMisReplicatedAfterPending()) {
+      //  // add to the queue, but ATM the queue expects an over or under rep
+      //  // health state so we need to change that.
+      //}
     }
     // Should not get here, but incase it does the container is not healthy,
     // but is also not under or over replicated.
@@ -128,7 +148,43 @@ public class ECReplicationCheckHandler extends AbstractCheck {
           .OverReplicatedHealthResult(container, overRepIndexes.size(),
           !replicaCount.isOverReplicated(true));
     }
+    ContainerPlacementStatus placement = getPlacementStatus(replicas,
+        container.getReplicationConfig().getRequiredNodes(),
+        Collections.emptyList());
+    if (!placement.isPolicySatisfied()) {
+      ContainerPlacementStatus placementAfterPending = getPlacementStatus(
+          replicas, container.getReplicationConfig().getRequiredNodes(),
+          Collections.emptyList());
+      return new ContainerHealthResult.MisReplicatedHealthResult(
+          container, !placementAfterPending.isPolicySatisfied());
+    }
     // No issues detected, so return healthy.
     return new ContainerHealthResult.HealthyResult(container);
+  }
+
+  /**
+   * Given a set of ContainerReplica, transform it to a list of DatanodeDetails
+   * and then check if the list meets the container placement policy.
+   * @param replicas List of containerReplica
+   * @param replicationFactor Expected Replication Factor of the containe
+   * @return ContainerPlacementStatus indicating if the policy is met or not
+   */
+  private ContainerPlacementStatus getPlacementStatus(
+      Set<ContainerReplica> replicas, int replicationFactor,
+      List<ContainerReplicaOp> pendingOps) {
+
+    Set<DatanodeDetails> replicaDns = replicas.stream()
+        .map(ContainerReplica::getDatanodeDetails)
+        .collect(Collectors.toSet());
+    for (ContainerReplicaOp op : pendingOps) {
+      if (op.getOpType() == ContainerReplicaOp.PendingOpType.ADD) {
+        replicaDns.add(op.getTarget());
+      }
+      if (op.getOpType() == ContainerReplicaOp.PendingOpType.DELETE) {
+        replicaDns.remove(op.getTarget());
+      }
+    }
+    return placementPolicy.validateContainerPlacement(
+        new ArrayList<>(replicaDns), replicationFactor);
   }
 }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/health/ECReplicationCheckHandler.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/health/ECReplicationCheckHandler.java
@@ -80,7 +80,7 @@ public class ECReplicationCheckHandler extends AbstractCheck {
       }
       // TODO - if it is unrecoverable, should we return false to other
       //        handlers can be tried?
-      if (!underHealth.isSufficientlyReplicatedAfterPending() &&
+      if (!underHealth.isReplicatedOkAfterPending() &&
           !underHealth.isUnrecoverable()) {
         request.getReplicationQueue().enqueue(underHealth);
       }
@@ -91,7 +91,7 @@ public class ECReplicationCheckHandler extends AbstractCheck {
           ReplicationManagerReport.HealthState.OVER_REPLICATED, containerID);
       ContainerHealthResult.OverReplicatedHealthResult overHealth
           = ((ContainerHealthResult.OverReplicatedHealthResult) health);
-      if (!overHealth.isSufficientlyReplicatedAfterPending()) {
+      if (!overHealth.isReplicatedOkAfterPending()) {
         request.getReplicationQueue().enqueue(overHealth);
       }
       return true;

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/health/ECReplicationCheckHandler.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/health/ECReplicationCheckHandler.java
@@ -78,8 +78,6 @@ public class ECReplicationCheckHandler extends AbstractCheck {
         report.incrementAndSample(
             ReplicationManagerReport.HealthState.MISSING, containerID);
       }
-      // TODO - if it is unrecoverable, should we return false to other
-      //        handlers can be tried?
       if (!underHealth.isReplicatedOkAfterPending() &&
           !underHealth.isUnrecoverable()) {
         request.getReplicationQueue().enqueue(underHealth);

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/health/ECReplicationCheckHandler.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/health/ECReplicationCheckHandler.java
@@ -153,7 +153,7 @@ public class ECReplicationCheckHandler extends AbstractCheck {
     if (!placement.isPolicySatisfied()) {
       ContainerPlacementStatus placementAfterPending = getPlacementStatus(
           replicas, container.getReplicationConfig().getRequiredNodes(),
-          Collections.emptyList());
+          request.getPendingOps());
       return new ContainerHealthResult.MisReplicatedHealthResult(
           container, placementAfterPending.isPolicySatisfied());
     }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/health/RatisReplicationCheckHandler.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/health/RatisReplicationCheckHandler.java
@@ -82,16 +82,10 @@ public class RatisReplicationCheckHandler extends AbstractCheck {
         report.incrementAndSample(ReplicationManagerReport.HealthState.MISSING,
             container.containerID());
       }
-      if (underHealth.isMisReplicated()) {
-        report.incrementAndSample(
-            ReplicationManagerReport.HealthState.MIS_REPLICATED,
-            container.containerID());
-      }
       // TODO - if it is unrecoverable, should we return false to other
       //        handlers can be tried?
       if (!underHealth.isUnrecoverable() &&
-          (underHealth.isMisReplicatedAfterPending() ||
-              !underHealth.isSufficientlyReplicatedAfterPending())) {
+          !underHealth.isSufficientlyReplicatedAfterPending()) {
         request.getReplicationQueue().enqueue(underHealth);
       }
       return true;
@@ -106,6 +100,18 @@ public class RatisReplicationCheckHandler extends AbstractCheck {
           = ((ContainerHealthResult.OverReplicatedHealthResult) health);
       if (!overHealth.isSufficientlyReplicatedAfterPending()) {
         request.getReplicationQueue().enqueue(overHealth);
+      }
+      return true;
+    }
+    if (health.getHealthState() ==
+        ContainerHealthResult.HealthState.MIS_REPLICATED) {
+      report.incrementAndSample(
+          ReplicationManagerReport.HealthState.MIS_REPLICATED,
+          container.containerID());
+      ContainerHealthResult.MisReplicatedHealthResult misRepHealth
+          = ((ContainerHealthResult.MisReplicatedHealthResult) health);
+      if (!misRepHealth.isReplicatedOkAfterPending()) {
+        request.getReplicationQueue().enqueue(misRepHealth);
       }
       return true;
     }
@@ -136,30 +142,15 @@ public class RatisReplicationCheckHandler extends AbstractCheck {
         new RatisContainerReplicaCount(container, replicas, pendingAdd,
             pendingDelete, requiredNodes, minReplicasForMaintenance);
 
-    ContainerPlacementStatus placementStatus =
-        getPlacementStatus(replicas, requiredNodes, Collections.emptyList());
-
-    ContainerPlacementStatus placementStatusWithPending = placementStatus;
-    if (replicaPendingOps.size() > 0) {
-      placementStatusWithPending =
-          getPlacementStatus(replicas, requiredNodes, replicaPendingOps);
-    }
     boolean sufficientlyReplicated
         = replicaCount.isSufficientlyReplicated(false);
-    boolean isPolicySatisfied = placementStatus.isPolicySatisfied();
-    if (!sufficientlyReplicated || !isPolicySatisfied) {
+    if (!sufficientlyReplicated) {
       ContainerHealthResult.UnderReplicatedHealthResult result =
           new ContainerHealthResult.UnderReplicatedHealthResult(
           container, replicaCount.getRemainingRedundancy(),
-          isPolicySatisfied
-              && replicas.size() - pendingDelete >= requiredNodes,
+          replicas.size() - pendingDelete >= requiredNodes,
           replicaCount.isSufficientlyReplicated(true),
           replicaCount.isUnrecoverable());
-      result.setMisReplicated(!isPolicySatisfied)
-          .setMisReplicatedAfterPending(
-              !placementStatusWithPending.isPolicySatisfied())
-          .setDueToMisReplication(
-              !isPolicySatisfied && replicaCount.isSufficientlyReplicated());
       return result;
     }
 
@@ -169,6 +160,19 @@ public class RatisReplicationCheckHandler extends AbstractCheck {
       return new ContainerHealthResult.OverReplicatedHealthResult(
           container, replicaCount.getExcessRedundancy(false), repOkWithPending);
     }
+
+    ContainerPlacementStatus placementStatus =
+        getPlacementStatus(replicas, requiredNodes, Collections.emptyList());
+    ContainerPlacementStatus placementStatusWithPending = placementStatus;
+    if (!placementStatus.isPolicySatisfied()) {
+      if (replicaPendingOps.size() > 0) {
+        placementStatusWithPending =
+            getPlacementStatus(replicas, requiredNodes, replicaPendingOps);
+      }
+      return new ContainerHealthResult.MisReplicatedHealthResult(
+          container, placementStatusWithPending.isPolicySatisfied());
+    }
+
     // No issues detected, just return healthy.
     return new ContainerHealthResult.HealthyResult(container);
   }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/health/RatisReplicationCheckHandler.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/health/RatisReplicationCheckHandler.java
@@ -85,7 +85,7 @@ public class RatisReplicationCheckHandler extends AbstractCheck {
       // TODO - if it is unrecoverable, should we return false to other
       //        handlers can be tried?
       if (!underHealth.isUnrecoverable() &&
-          !underHealth.isSufficientlyReplicatedAfterPending()) {
+          !underHealth.isReplicatedOkAfterPending()) {
         request.getReplicationQueue().enqueue(underHealth);
       }
       return true;
@@ -98,7 +98,7 @@ public class RatisReplicationCheckHandler extends AbstractCheck {
           container.containerID());
       ContainerHealthResult.OverReplicatedHealthResult overHealth
           = ((ContainerHealthResult.OverReplicatedHealthResult) health);
-      if (!overHealth.isSufficientlyReplicatedAfterPending()) {
+      if (!overHealth.isReplicatedOkAfterPending()) {
         request.getReplicationQueue().enqueue(overHealth);
       }
       return true;

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/StorageContainerManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/StorageContainerManager.java
@@ -761,6 +761,7 @@ public final class StorageContainerManager extends ServiceRuntimeInfoImpl
           conf,
           containerManager,
           containerPlacementPolicy,
+          ecContainerPlacementPolicy,
           eventQueue,
           scmContext,
           scmNodeManager,

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestECOverReplicationHandler.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestECOverReplicationHandler.java
@@ -28,6 +28,7 @@ import org.apache.hadoop.hdds.scm.PlacementPolicy;
 import org.apache.hadoop.hdds.scm.container.ContainerInfo;
 import org.apache.hadoop.hdds.scm.container.ContainerReplica;
 import org.apache.hadoop.hdds.scm.container.MockNodeManager;
+import org.apache.hadoop.hdds.scm.container.placement.algorithms.ContainerPlacementStatusDefault;
 import org.apache.hadoop.hdds.scm.container.replication.health.ECReplicationCheckHandler;
 import org.apache.hadoop.hdds.scm.net.NodeSchema;
 import org.apache.hadoop.hdds.scm.net.NodeSchemaManager;
@@ -52,6 +53,8 @@ import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.NodeOperationalSt
 import static org.apache.hadoop.hdds.scm.net.NetConstants.LEAF_SCHEMA;
 import static org.apache.hadoop.hdds.scm.net.NetConstants.RACK_SCHEMA;
 import static org.apache.hadoop.hdds.scm.net.NetConstants.ROOT_SCHEMA;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyList;
 
 /**
  * Tests the ECOverReplicationHandling functionality.
@@ -63,6 +66,7 @@ public class TestECOverReplicationHandler {
   private OzoneConfiguration conf;
   private PlacementPolicy policy;
   private ECReplicationCheckHandler replicationCheck;
+  private PlacementPolicy placementPolicy;
 
   @BeforeEach
   public void setup() {
@@ -82,7 +86,11 @@ public class TestECOverReplicationHandler {
     NodeSchema[] schemas =
         new NodeSchema[] {ROOT_SCHEMA, RACK_SCHEMA, LEAF_SCHEMA};
     NodeSchemaManager.getInstance().init(schemas, true);
-    replicationCheck = new ECReplicationCheckHandler();
+    placementPolicy = Mockito.mock(PlacementPolicy.class);
+    Mockito.when(placementPolicy.validateContainerPlacement(
+        anyList(), anyInt()))
+        .thenReturn(new ContainerPlacementStatusDefault(2, 2, 3));
+    replicationCheck = new ECReplicationCheckHandler(placementPolicy);
   }
 
   @Test

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestLegacyReplicationManager.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestLegacyReplicationManager.java
@@ -117,7 +117,8 @@ public class TestLegacyReplicationManager {
 
   private ReplicationManager replicationManager;
   private ContainerStateManager containerStateManager;
-  private PlacementPolicy containerPlacementPolicy;
+  private PlacementPolicy ratisContainerPlacementPolicy;
+  private PlacementPolicy ecContainerPlacementPolicy;
   private EventQueue eventQueue;
   private DatanodeCommandHandler datanodeCommandHandler;
   private SimpleMockNodeManager nodeManager;
@@ -193,9 +194,10 @@ public class TestLegacyReplicationManager {
             .getContainerReplicas(((ContainerID)invocation
                 .getArguments()[0])));
 
-    containerPlacementPolicy = Mockito.mock(PlacementPolicy.class);
+    ratisContainerPlacementPolicy = Mockito.mock(PlacementPolicy.class);
+    ecContainerPlacementPolicy = Mockito.mock(PlacementPolicy.class);
 
-    Mockito.when(containerPlacementPolicy.chooseDatanodes(
+    Mockito.when(ratisContainerPlacementPolicy.chooseDatanodes(
         Mockito.any(), Mockito.any(), Mockito.anyInt(),
             Mockito.anyLong(), Mockito.anyLong()))
         .thenAnswer(invocation -> {
@@ -205,7 +207,7 @@ public class TestLegacyReplicationManager {
               .collect(Collectors.toList());
         });
 
-    Mockito.when(containerPlacementPolicy.validateContainerPlacement(
+    Mockito.when(ratisContainerPlacementPolicy.validateContainerPlacement(
         Mockito.any(),
         Mockito.anyInt()
         )).thenAnswer(invocation ->
@@ -257,14 +259,15 @@ public class TestLegacyReplicationManager {
       config, new SCMDBDefinition());
 
     LegacyReplicationManager legacyRM = new LegacyReplicationManager(
-        config, containerManager, containerPlacementPolicy, eventQueue,
+        config, containerManager, ratisContainerPlacementPolicy, eventQueue,
         SCMContext.emptyContext(), nodeManager, scmHAManager, clock,
         SCMDBDefinition.MOVE.getTable(dbStore));
 
     replicationManager = new ReplicationManager(
         config,
         containerManager,
-        containerPlacementPolicy,
+        ratisContainerPlacementPolicy,
+        ecContainerPlacementPolicy,
         eventQueue,
         SCMContext.emptyContext(),
         nodeManager,
@@ -1102,7 +1105,7 @@ public class TestLegacyReplicationManager {
     // Ensure a mis-replicated status is returned for any containers in this
     // test where there are 3 replicas. When there are 2 or 4 replicas
     // the status returned will be healthy.
-    Mockito.when(containerPlacementPolicy.validateContainerPlacement(
+    Mockito.when(ratisContainerPlacementPolicy.validateContainerPlacement(
         Mockito.argThat(list -> list.size() == 3),
         Mockito.anyInt()
     )).thenAnswer(invocation ->  {
@@ -1138,7 +1141,7 @@ public class TestLegacyReplicationManager {
     // Now make it so that all containers seem mis-replicated no matter how
     // many replicas. This will test replicas are not scheduled if the new
     // replica does not fix the mis-replication.
-    Mockito.when(containerPlacementPolicy.validateContainerPlacement(
+    Mockito.when(ratisContainerPlacementPolicy.validateContainerPlacement(
         Mockito.anyList(),
         Mockito.anyInt()
     )).thenAnswer(invocation ->  {
@@ -1190,7 +1193,7 @@ public class TestLegacyReplicationManager {
 
     // Ensure a mis-replicated status is returned for any containers in this
     // test where there are exactly 3 replicas checked.
-    Mockito.when(containerPlacementPolicy.validateContainerPlacement(
+    Mockito.when(ratisContainerPlacementPolicy.validateContainerPlacement(
         Mockito.argThat(list -> list.size() == 3),
         Mockito.anyInt()
     )).thenAnswer(
@@ -1241,7 +1244,7 @@ public class TestLegacyReplicationManager {
         id, replicaThree);
     containerStateManager.updateContainerReplica(id, replicaFour);
 
-    Mockito.when(containerPlacementPolicy.validateContainerPlacement(
+    Mockito.when(ratisContainerPlacementPolicy.validateContainerPlacement(
         Mockito.argThat(list -> list.size() == 3),
         Mockito.anyInt()
     )).thenAnswer(
@@ -1289,7 +1292,7 @@ public class TestLegacyReplicationManager {
     containerStateManager.updateContainerReplica(id, replicaFour);
     containerStateManager.updateContainerReplica(id, replicaFive);
 
-    Mockito.when(containerPlacementPolicy.validateContainerPlacement(
+    Mockito.when(ratisContainerPlacementPolicy.validateContainerPlacement(
         Mockito.argThat(list -> list != null && list.size() <= 4),
         Mockito.anyInt()
     )).thenAnswer(

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/health/TestECReplicationCheckHandler.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/health/TestECReplicationCheckHandler.java
@@ -118,7 +118,7 @@ public class TestECReplicationCheckHandler {
         healthCheck.checkHealth(request);
     Assert.assertEquals(HealthState.UNDER_REPLICATED, result.getHealthState());
     Assert.assertEquals(1, result.getRemainingRedundancy());
-    Assert.assertFalse(result.isSufficientlyReplicatedAfterPending());
+    Assert.assertFalse(result.isReplicatedOkAfterPending());
     Assert.assertFalse(result.underReplicatedDueToDecommission());
 
     Assert.assertTrue(healthCheck.handle(request));
@@ -145,7 +145,7 @@ public class TestECReplicationCheckHandler {
         healthCheck.checkHealth(request);
     Assert.assertEquals(HealthState.UNDER_REPLICATED, result.getHealthState());
     Assert.assertEquals(1, result.getRemainingRedundancy());
-    Assert.assertTrue(result.isSufficientlyReplicatedAfterPending());
+    Assert.assertTrue(result.isReplicatedOkAfterPending());
     Assert.assertFalse(result.underReplicatedDueToDecommission());
 
     Assert.assertTrue(healthCheck.handle(request));
@@ -173,7 +173,7 @@ public class TestECReplicationCheckHandler {
         healthCheck.checkHealth(request);
     Assert.assertEquals(HealthState.UNDER_REPLICATED, result.getHealthState());
     Assert.assertEquals(2, result.getRemainingRedundancy());
-    Assert.assertFalse(result.isSufficientlyReplicatedAfterPending());
+    Assert.assertFalse(result.isReplicatedOkAfterPending());
     Assert.assertTrue(result.underReplicatedDueToDecommission());
 
     Assert.assertTrue(healthCheck.handle(request));
@@ -204,7 +204,7 @@ public class TestECReplicationCheckHandler {
         healthCheck.checkHealth(request);
     Assert.assertEquals(HealthState.UNDER_REPLICATED, result.getHealthState());
     Assert.assertEquals(2, result.getRemainingRedundancy());
-    Assert.assertTrue(result.isSufficientlyReplicatedAfterPending());
+    Assert.assertTrue(result.isReplicatedOkAfterPending());
     Assert.assertTrue(result.underReplicatedDueToDecommission());
 
     Assert.assertTrue(healthCheck.handle(request));
@@ -235,7 +235,7 @@ public class TestECReplicationCheckHandler {
         healthCheck.checkHealth(request);
     Assert.assertEquals(HealthState.UNDER_REPLICATED, result.getHealthState());
     Assert.assertEquals(1, result.getRemainingRedundancy());
-    Assert.assertFalse(result.isSufficientlyReplicatedAfterPending());
+    Assert.assertFalse(result.isReplicatedOkAfterPending());
     Assert.assertFalse(result.underReplicatedDueToDecommission());
 
     Assert.assertTrue(healthCheck.handle(request));
@@ -259,7 +259,7 @@ public class TestECReplicationCheckHandler {
         healthCheck.checkHealth(request);
     Assert.assertEquals(HealthState.UNDER_REPLICATED, result.getHealthState());
     Assert.assertEquals(-1, result.getRemainingRedundancy());
-    Assert.assertFalse(result.isSufficientlyReplicatedAfterPending());
+    Assert.assertFalse(result.isReplicatedOkAfterPending());
     Assert.assertFalse(result.underReplicatedDueToDecommission());
     Assert.assertTrue(result.isUnrecoverable());
 
@@ -363,7 +363,7 @@ public class TestECReplicationCheckHandler {
         healthCheck.checkHealth(request);
     Assert.assertEquals(HealthState.OVER_REPLICATED, result.getHealthState());
     Assert.assertEquals(2, result.getExcessRedundancy());
-    Assert.assertFalse(result.isSufficientlyReplicatedAfterPending());
+    Assert.assertFalse(result.isReplicatedOkAfterPending());
 
     Assert.assertTrue(healthCheck.handle(request));
     Assert.assertEquals(0, repQueue.underReplicatedQueueSize());
@@ -396,7 +396,7 @@ public class TestECReplicationCheckHandler {
         healthCheck.checkHealth(request);
     Assert.assertEquals(HealthState.OVER_REPLICATED, result.getHealthState());
     Assert.assertEquals(2, result.getExcessRedundancy());
-    Assert.assertTrue(result.isSufficientlyReplicatedAfterPending());
+    Assert.assertTrue(result.isReplicatedOkAfterPending());
 
     Assert.assertTrue(healthCheck.handle(request));
     Assert.assertEquals(0, repQueue.underReplicatedQueueSize());

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/health/TestECReplicationCheckHandler.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/health/TestECReplicationCheckHandler.java
@@ -480,8 +480,6 @@ public class TestECReplicationCheckHandler {
     ContainerHealthResult result = healthCheck.checkHealth(request);
     Assert.assertEquals(HealthState.MIS_REPLICATED, result.getHealthState());
 
-    // Under-replicated takes precedence and the over-replication is ignored
-    // for now.
     Assert.assertTrue(healthCheck.handle(request));
     Assert.assertEquals(0, repQueue.underReplicatedQueueSize());
     Assert.assertEquals(0, repQueue.overReplicatedQueueSize());
@@ -503,7 +501,7 @@ public class TestECReplicationCheckHandler {
         Mockito.anyInt()
     )).thenAnswer(invocation -> {
       List<DatanodeDetails> dns = invocation.getArgument(0);
-      // If the number of DNs is 3 or less make it be mis-replicated
+      // If the number of DNs is 5 or less make it be mis-replicated
       if (dns.size() <= 5) {
         return new ContainerPlacementStatusDefault(4, 5, 9);
       } else {

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/health/TestECReplicationCheckHandler.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/health/TestECReplicationCheckHandler.java
@@ -304,7 +304,7 @@ public class TestECReplicationCheckHandler {
         healthCheck.checkHealth(request);
     Assert.assertEquals(HealthState.UNDER_REPLICATED, result.getHealthState());
     Assert.assertEquals(0, result.getRemainingRedundancy());
-    Assert.assertFalse(result.isSufficientlyReplicatedAfterPending());
+    Assert.assertFalse(result.isReplicatedOkAfterPending());
     Assert.assertFalse(result.underReplicatedDueToDecommission());
 
     Assert.assertTrue(healthCheck.handle(request));

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/health/TestECReplicationCheckHandler.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/health/TestECReplicationCheckHandler.java
@@ -20,9 +20,11 @@ import org.apache.commons.lang3.tuple.Pair;
 import org.apache.hadoop.hdds.client.ECReplicationConfig;
 import org.apache.hadoop.hdds.protocol.MockDatanodeDetails;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.ContainerReplicaProto;
+import org.apache.hadoop.hdds.scm.PlacementPolicy;
 import org.apache.hadoop.hdds.scm.container.ContainerInfo;
 import org.apache.hadoop.hdds.scm.container.ContainerReplica;
 import org.apache.hadoop.hdds.scm.container.ReplicationManagerReport;
+import org.apache.hadoop.hdds.scm.container.placement.algorithms.ContainerPlacementStatusDefault;
 import org.apache.hadoop.hdds.scm.container.replication.ContainerCheckRequest;
 import org.apache.hadoop.hdds.scm.container.replication.ContainerHealthResult;
 import org.apache.hadoop.hdds.scm.container.replication.ContainerHealthResult.OverReplicatedHealthResult;
@@ -35,6 +37,7 @@ import org.apache.hadoop.hdds.scm.container.replication.ReplicationTestUtil;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.Mockito;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -51,6 +54,8 @@ import static org.apache.hadoop.hdds.scm.container.replication.ContainerReplicaO
 import static org.apache.hadoop.hdds.scm.container.replication.ReplicationTestUtil.createContainerInfo;
 import static org.apache.hadoop.hdds.scm.container.replication.ReplicationTestUtil.createContainerReplica;
 import static org.apache.hadoop.hdds.scm.container.replication.ReplicationTestUtil.createReplicas;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyList;
 
 /**
  * Tests for the ECContainerHealthCheck class.
@@ -63,11 +68,15 @@ public class TestECReplicationCheckHandler {
   private int maintenanceRedundancy = 2;
   private ContainerCheckRequest.Builder requestBuilder;
   private ReplicationManagerReport report;
-
+  private PlacementPolicy placementPolicy;
 
   @Before
   public void setup() {
-    healthCheck = new ECReplicationCheckHandler();
+    placementPolicy = Mockito.mock(PlacementPolicy.class);
+    Mockito.when(placementPolicy.validateContainerPlacement(
+        anyList(), anyInt()))
+        .thenReturn(new ContainerPlacementStatusDefault(2, 2, 3));
+    healthCheck = new ECReplicationCheckHandler(placementPolicy);
     repConfig = new ECReplicationConfig(3, 2);
     repQueue = new ReplicationQueue();
     report = new ReplicationManagerReport();

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/health/TestRatisReplicationCheckHandler.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/health/TestRatisReplicationCheckHandler.java
@@ -129,7 +129,7 @@ public class TestRatisReplicationCheckHandler {
         healthCheck.checkHealth(requestBuilder.build());
     Assert.assertEquals(HealthState.UNDER_REPLICATED, result.getHealthState());
     Assert.assertEquals(1, result.getRemainingRedundancy());
-    Assert.assertFalse(result.isSufficientlyReplicatedAfterPending());
+    Assert.assertFalse(result.isReplicatedOkAfterPending());
     Assert.assertFalse(result.underReplicatedDueToDecommission());
 
     Assert.assertTrue(healthCheck.handle(requestBuilder.build()));
@@ -154,7 +154,7 @@ public class TestRatisReplicationCheckHandler {
         healthCheck.checkHealth(requestBuilder.build());
     Assert.assertEquals(HealthState.UNDER_REPLICATED, result.getHealthState());
     Assert.assertEquals(1, result.getRemainingRedundancy());
-    Assert.assertFalse(result.isSufficientlyReplicatedAfterPending());
+    Assert.assertFalse(result.isReplicatedOkAfterPending());
     Assert.assertFalse(result.underReplicatedDueToDecommission());
 
     Assert.assertTrue(healthCheck.handle(requestBuilder.build()));
@@ -179,7 +179,7 @@ public class TestRatisReplicationCheckHandler {
         healthCheck.checkHealth(requestBuilder.build());
     Assert.assertEquals(HealthState.UNDER_REPLICATED, result.getHealthState());
     Assert.assertEquals(1, result.getRemainingRedundancy());
-    Assert.assertTrue(result.isSufficientlyReplicatedAfterPending());
+    Assert.assertTrue(result.isReplicatedOkAfterPending());
     Assert.assertFalse(result.underReplicatedDueToDecommission());
 
     Assert.assertTrue(healthCheck.handle(requestBuilder.build()));
@@ -204,7 +204,7 @@ public class TestRatisReplicationCheckHandler {
         healthCheck.checkHealth(requestBuilder.build());
     Assert.assertEquals(HealthState.UNDER_REPLICATED, result.getHealthState());
     Assert.assertEquals(2, result.getRemainingRedundancy());
-    Assert.assertFalse(result.isSufficientlyReplicatedAfterPending());
+    Assert.assertFalse(result.isReplicatedOkAfterPending());
     Assert.assertTrue(result.underReplicatedDueToDecommission());
 
     Assert.assertTrue(healthCheck.handle(requestBuilder.build()));
@@ -231,7 +231,7 @@ public class TestRatisReplicationCheckHandler {
         healthCheck.checkHealth(requestBuilder.build());
     Assert.assertEquals(HealthState.UNDER_REPLICATED, result.getHealthState());
     Assert.assertEquals(2, result.getRemainingRedundancy());
-    Assert.assertTrue(result.isSufficientlyReplicatedAfterPending());
+    Assert.assertTrue(result.isReplicatedOkAfterPending());
     Assert.assertTrue(result.underReplicatedDueToDecommission());
 
     Assert.assertTrue(healthCheck.handle(requestBuilder.build()));
@@ -259,7 +259,7 @@ public class TestRatisReplicationCheckHandler {
         healthCheck.checkHealth(requestBuilder.build());
     Assert.assertEquals(HealthState.UNDER_REPLICATED, result.getHealthState());
     Assert.assertEquals(1, result.getRemainingRedundancy());
-    Assert.assertFalse(result.isSufficientlyReplicatedAfterPending());
+    Assert.assertFalse(result.isReplicatedOkAfterPending());
     Assert.assertFalse(result.underReplicatedDueToDecommission());
 
     Assert.assertTrue(healthCheck.handle(requestBuilder.build()));
@@ -280,7 +280,7 @@ public class TestRatisReplicationCheckHandler {
         healthCheck.checkHealth(requestBuilder.build());
     Assert.assertEquals(HealthState.UNDER_REPLICATED, result.getHealthState());
     Assert.assertEquals(0, result.getRemainingRedundancy());
-    Assert.assertFalse(result.isSufficientlyReplicatedAfterPending());
+    Assert.assertFalse(result.isReplicatedOkAfterPending());
     Assert.assertFalse(result.underReplicatedDueToDecommission());
     Assert.assertTrue(result.isUnrecoverable());
 
@@ -316,7 +316,7 @@ public class TestRatisReplicationCheckHandler {
         healthCheck.checkHealth(requestBuilder.build());
     Assert.assertEquals(HealthState.OVER_REPLICATED, result.getHealthState());
     Assert.assertEquals(4, result.getExcessRedundancy());
-    Assert.assertFalse(result.isSufficientlyReplicatedAfterPending());
+    Assert.assertFalse(result.isReplicatedOkAfterPending());
 
     Assert.assertTrue(healthCheck.handle(requestBuilder.build()));
     Assert.assertEquals(0, repQueue.underReplicatedQueueSize());
@@ -343,7 +343,7 @@ public class TestRatisReplicationCheckHandler {
         healthCheck.checkHealth(requestBuilder.build());
     Assert.assertEquals(HealthState.OVER_REPLICATED, result.getHealthState());
     Assert.assertEquals(1, result.getExcessRedundancy());
-    Assert.assertTrue(result.isSufficientlyReplicatedAfterPending());
+    Assert.assertTrue(result.isReplicatedOkAfterPending());
 
     Assert.assertTrue(healthCheck.handle(requestBuilder.build()));
     Assert.assertEquals(0, repQueue.underReplicatedQueueSize());
@@ -368,7 +368,7 @@ public class TestRatisReplicationCheckHandler {
         healthCheck.checkHealth(requestBuilder.build());
     Assert.assertEquals(HealthState.OVER_REPLICATED, result.getHealthState());
     Assert.assertEquals(1, result.getExcessRedundancy());
-    Assert.assertFalse(result.isSufficientlyReplicatedAfterPending());
+    Assert.assertFalse(result.isReplicatedOkAfterPending());
 
     Assert.assertTrue(healthCheck.handle(requestBuilder.build()));
     Assert.assertEquals(0, repQueue.underReplicatedQueueSize());
@@ -417,7 +417,7 @@ public class TestRatisReplicationCheckHandler {
         healthCheck.checkHealth(requestBuilder.build());
     Assert.assertEquals(HealthState.UNDER_REPLICATED, result.getHealthState());
     Assert.assertEquals(1, result.getRemainingRedundancy());
-    Assert.assertFalse(result.isSufficientlyReplicatedAfterPending());
+    Assert.assertFalse(result.isReplicatedOkAfterPending());
     Assert.assertFalse(result.underReplicatedDueToDecommission());
 
     Assert.assertTrue(healthCheck.handle(requestBuilder.build()));
@@ -462,7 +462,7 @@ public class TestRatisReplicationCheckHandler {
         healthCheck.checkHealth(requestBuilder.build());
     Assert.assertEquals(HealthState.UNDER_REPLICATED, result.getHealthState());
     Assert.assertEquals(1, result.getRemainingRedundancy());
-    Assert.assertTrue(result.isSufficientlyReplicatedAfterPending());
+    Assert.assertTrue(result.isReplicatedOkAfterPending());
     Assert.assertFalse(result.underReplicatedDueToDecommission());
 
     Assert.assertTrue(healthCheck.handle(requestBuilder.build()));


### PR DESCRIPTION
## What changes were proposed in this pull request?



While looking into mis-replicated handling for EC, we found the code is much simplified if we handle mis-replicated containers only when they are not also over or under replicated.

With that in mind, we should have a separate unhealthy state for mis-replication, rather than making it part of under-replication.

This change adds that new state, adds mis-replication logic to the ECReplicationCheckHandler and amends the RatisReplicationCheckHandler to match it.

For now, a mis-replicated queue has been added, but this may change later, as we need to look into the queues and see if they need more work to separate out EC and Ratis or not.


## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-7488

## How was this patch tested?

New and modified unit tests
