### PR TITLE
HDDS-7279. Snapshot Create requires Double Buffer Flush thread to split the commit batch.

### DIFF
--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/OzoneManagerDoubleBuffer.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/OzoneManagerDoubleBuffer.java
@@ -622,4 +622,8 @@ public final class OzoneManagerDoubleBuffer {
     return ozoneManagerDoubleBufferMetrics;
   }
 
+  @VisibleForTesting
+  public AtomicBoolean isRunning() {
+    return isRunning;
+  }
 }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/OzoneManagerDoubleBuffer.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/OzoneManagerDoubleBuffer.java
@@ -431,7 +431,7 @@ public final class OzoneManagerDoubleBuffer {
    * [snapshotRequest2], [request4]]
    */
   private List<Queue<DoubleBufferEntry<OMClientResponse>>>
-  splitReadyBufferAtCreateSnapshot() {
+      splitReadyBufferAtCreateSnapshot() {
     List<Queue<DoubleBufferEntry<OMClientResponse>>> response =
         new ArrayList<>();
 
@@ -439,7 +439,7 @@ public final class OzoneManagerDoubleBuffer {
         readyBuffer.iterator();
 
     OMResponse previousOmResponse = null;
-    while(iterator.hasNext()) {
+    while (iterator.hasNext()) {
       DoubleBufferEntry<OMClientResponse> entry = iterator.next();
       OMResponse omResponse = entry.getResponse().getOMResponse();
       // New queue gets created in three conditions:
@@ -449,7 +449,7 @@ public final class OzoneManagerDoubleBuffer {
       if (response.isEmpty() ||
           omResponse.getCreateSnapshotResponse() != null ||
           (previousOmResponse != null &&
-          previousOmResponse.getCreateSnapshotResponse() != null)) {
+              previousOmResponse.getCreateSnapshotResponse() != null)) {
         response.add(new LinkedList<>());
       }
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/OzoneManagerDoubleBuffer.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/OzoneManagerDoubleBuffer.java
@@ -286,14 +286,7 @@ public final class OzoneManagerDoubleBuffer {
           flushBatch(buffer);
         }
 
-        if (!isRatisEnabled) {
-          // Once all entries are flushed, we can complete their future.
-          readyFutureQueue.iterator()
-              .forEachRemaining((entry) -> entry.complete(null));
-          readyFutureQueue.clear();
-        }
-
-        readyBuffer.clear();
+        clearReadyBuffer();
       } catch (InterruptedException ex) {
         Thread.currentThread().interrupt();
         if (isRunning.get()) {
@@ -488,7 +481,15 @@ public final class OzoneManagerDoubleBuffer {
     }
   }
 
-
+  private synchronized void clearReadyBuffer() {
+    if (!isRatisEnabled) {
+      // Once all entries are flushed, we can complete their future.
+      readyFutureQueue.iterator()
+          .forEachRemaining((entry) -> entry.complete(null));
+      readyFutureQueue.clear();
+    }
+    readyBuffer.clear();
+  }
 
   private void cleanupCache(Map<String, List<Long>> cleanupEpochs) {
     cleanupEpochs.forEach((tableName, epochs) -> {

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/ratis/TestOzoneManagerDoubleBuffer.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/ratis/TestOzoneManagerDoubleBuffer.java
@@ -170,10 +170,15 @@ class TestOzoneManagerDoubleBuffer {
       float expectedAvgFlushTransactionsInMetric
   ) throws InterruptedException {
 
+    // Disable the daemon till we add all the responses to the buffer.
+    doubleBuffer.isRunning().compareAndSet(true, false);
+
     for (int i = 0; i < omClientResponses.size(); i++) {
       doubleBuffer.add(omClientResponses.get(i), i);
     }
 
+    // Enable the daemon after adding all the responses to the buffer.
+    doubleBuffer.isRunning().compareAndSet(false, true);
     // To make sure that daemon thread is executed.
     Thread.sleep(1000L);
 

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/ratis/TestOzoneManagerDoubleBuffer.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/ratis/TestOzoneManagerDoubleBuffer.java
@@ -1,3 +1,19 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with this
+ * work for additional information regarding copyright ownership.  The ASF
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
 package org.apache.hadoop.ozone.om.ratis;
 
 import java.io.File;
@@ -33,6 +49,9 @@ import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+/**
+ * This class tests snapshot aware OzoneManagerDoubleBuffer flushing logic.
+ */
 class TestOzoneManagerDoubleBuffer {
 
   private OzoneManager ozoneManager;

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/ratis/TestOzoneManagerDoubleBuffer.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/ratis/TestOzoneManagerDoubleBuffer.java
@@ -54,17 +54,11 @@ import static org.mockito.Mockito.when;
  */
 class TestOzoneManagerDoubleBuffer {
 
-  private OzoneManager ozoneManager;
-  private OMMetrics omMetrics;
-  private AuditLogger auditLogger;
-  private OMMetadataManager omMetadataManager;
   private OzoneManagerDoubleBuffer doubleBuffer;
-  private OzoneManagerRatisSnapshot ozoneManagerRatisSnapshot;
-  private volatile long lastAppliedIndex;
-  private long term = 1L;
-  private final CreateSnapshotResponse snapshotResponse1 =
+  private final long term = 1L;
+  private CreateSnapshotResponse snapshotResponse1 =
       mock(CreateSnapshotResponse.class);
-  private final CreateSnapshotResponse snapshotResponse2 =
+  private CreateSnapshotResponse snapshotResponse2 =
       mock(CreateSnapshotResponse.class);
   private OMResponse omKeyResponse = mock(OMResponse.class);
   private OMResponse omBucketResponse = mock(OMResponse.class);
@@ -83,20 +77,20 @@ class TestOzoneManagerDoubleBuffer {
 
   @BeforeEach
   public void setup() throws IOException {
-    omMetrics = OMMetrics.create();
+    OMMetrics omMetrics = OMMetrics.create();
     OzoneConfiguration ozoneConfiguration = new OzoneConfiguration();
     ozoneConfiguration.set(OMConfigKeys.OZONE_OM_DB_DIRS,
         tempDir.getAbsolutePath());
-    omMetadataManager = new OmMetadataManagerImpl(ozoneConfiguration);
-    ozoneManager = mock(OzoneManager.class);
+    OMMetadataManager omMetadataManager =
+        new OmMetadataManagerImpl(ozoneConfiguration);
+    OzoneManager ozoneManager = mock(OzoneManager.class);
     when(ozoneManager.getMetrics()).thenReturn(omMetrics);
     when(ozoneManager.getMetadataManager()).thenReturn(omMetadataManager);
     when(ozoneManager.getMaxUserVolumeCount()).thenReturn(10L);
-    auditLogger = mock(AuditLogger.class);
+    AuditLogger auditLogger = mock(AuditLogger.class);
     when(ozoneManager.getAuditLogger()).thenReturn(auditLogger);
     Mockito.doNothing().when(auditLogger).logWrite(any(AuditMessage.class));
-    ozoneManagerRatisSnapshot = index -> {
-      lastAppliedIndex = index.get(index.size() - 1);
+    OzoneManagerRatisSnapshot ozoneManagerRatisSnapshot = index -> {
     };
 
     doubleBuffer = new OzoneManagerDoubleBuffer.Builder()

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/ratis/TestOzoneManagerDoubleBuffer.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/ratis/TestOzoneManagerDoubleBuffer.java
@@ -1,0 +1,184 @@
+package org.apache.hadoop.ozone.om.ratis;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Stream;
+import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import org.apache.hadoop.ozone.audit.AuditLogger;
+import org.apache.hadoop.ozone.audit.AuditMessage;
+import org.apache.hadoop.ozone.om.OMConfigKeys;
+import org.apache.hadoop.ozone.om.OMMetadataManager;
+import org.apache.hadoop.ozone.om.OMMetrics;
+import org.apache.hadoop.ozone.om.OmMetadataManagerImpl;
+import org.apache.hadoop.ozone.om.OzoneManager;
+import org.apache.hadoop.ozone.om.ratis.metrics.OzoneManagerDoubleBufferMetrics;
+import org.apache.hadoop.ozone.om.response.OMClientResponse;
+import org.apache.hadoop.ozone.om.response.bucket.OMBucketCreateResponse;
+import org.apache.hadoop.ozone.om.response.key.OMKeyCreateResponse;
+import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.CreateSnapshotResponse;
+import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMResponse;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.Mockito;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class TestOzoneManagerDoubleBuffer {
+
+  private OzoneManager ozoneManager;
+  private OMMetrics omMetrics;
+  private AuditLogger auditLogger;
+  private OMMetadataManager omMetadataManager;
+  private OzoneManagerDoubleBuffer doubleBuffer;
+  private OzoneManagerRatisSnapshot ozoneManagerRatisSnapshot;
+  private volatile long lastAppliedIndex;
+  private long term = 1L;
+  private final CreateSnapshotResponse snapshotResponse1 =
+      mock(CreateSnapshotResponse.class);
+  private final CreateSnapshotResponse snapshotResponse2 =
+      mock(CreateSnapshotResponse.class);
+  private OMResponse omKeyResponse = mock(OMResponse.class);
+  private OMResponse omBucketResponse = mock(OMResponse.class);
+  private OMResponse omSnapshotResponse1 = mock(OMResponse.class);
+  private OMResponse omSnapshotResponse2 = mock(OMResponse.class);
+  private static OMClientResponse omKeyCreateResponse =
+      mock(OMKeyCreateResponse.class);
+  private static OMClientResponse omBucketCreateResponse =
+      mock(OMBucketCreateResponse.class);
+  private static OMClientResponse omSnapshotCreateResponse1 =
+      mock(OMBucketCreateResponse.class);
+  private static OMClientResponse omSnapshotCreateResponse2 =
+      mock(OMBucketCreateResponse.class);
+  @TempDir
+  private File tempDir;
+
+  @BeforeEach
+  public void setup() throws IOException {
+    omMetrics = OMMetrics.create();
+    OzoneConfiguration ozoneConfiguration = new OzoneConfiguration();
+    ozoneConfiguration.set(OMConfigKeys.OZONE_OM_DB_DIRS,
+        tempDir.getAbsolutePath());
+    omMetadataManager = new OmMetadataManagerImpl(ozoneConfiguration);
+    ozoneManager = mock(OzoneManager.class);
+    when(ozoneManager.getMetrics()).thenReturn(omMetrics);
+    when(ozoneManager.getMetadataManager()).thenReturn(omMetadataManager);
+    when(ozoneManager.getMaxUserVolumeCount()).thenReturn(10L);
+    auditLogger = mock(AuditLogger.class);
+    when(ozoneManager.getAuditLogger()).thenReturn(auditLogger);
+    Mockito.doNothing().when(auditLogger).logWrite(any(AuditMessage.class));
+    ozoneManagerRatisSnapshot = index -> {
+      lastAppliedIndex = index.get(index.size() - 1);
+    };
+
+    doubleBuffer = new OzoneManagerDoubleBuffer.Builder()
+        .setOmMetadataManager(omMetadataManager)
+        .setOzoneManagerRatisSnapShot(ozoneManagerRatisSnapshot)
+        .setmaxUnFlushedTransactionCount(1000)
+        .enableRatis(true)
+        .setIndexToTerm((i) -> term)
+        .build();
+
+    doNothing().when(omKeyCreateResponse).checkAndUpdateDB(any(), any());
+    doNothing().when(omBucketCreateResponse).checkAndUpdateDB(any(), any());
+    doNothing().when(omSnapshotCreateResponse1).checkAndUpdateDB(any(), any());
+    doNothing().when(omSnapshotCreateResponse2).checkAndUpdateDB(any(), any());
+
+    when(omKeyResponse.getTraceID()).thenReturn("keyTraceId");
+    when(omBucketResponse.getTraceID()).thenReturn("bucketTraceId");
+    when(omSnapshotResponse1.getTraceID()).thenReturn("snapshotTraceId-1");
+    when(omSnapshotResponse2.getTraceID()).thenReturn("snapshotTraceId-2");
+
+    when(omKeyResponse.getCreateSnapshotResponse()).thenReturn(null);
+    when(omBucketResponse.getCreateSnapshotResponse()).thenReturn(null);
+    when(omSnapshotResponse1.getCreateSnapshotResponse())
+        .thenReturn(snapshotResponse1);
+    when(omSnapshotResponse2.getCreateSnapshotResponse())
+        .thenReturn(snapshotResponse2);
+
+    when(omKeyCreateResponse.getOMResponse()).thenReturn(omKeyResponse);
+    when(omBucketCreateResponse.getOMResponse()).thenReturn(omBucketResponse);
+    when(omSnapshotCreateResponse1.getOMResponse())
+        .thenReturn(omSnapshotResponse1);
+    when(omSnapshotCreateResponse2.getOMResponse())
+        .thenReturn(omSnapshotResponse2);
+  }
+
+  @AfterEach
+  public void stop() {
+    if (doubleBuffer != null) {
+      doubleBuffer.stop();
+    }
+  }
+
+  private static Stream<Arguments> doubleBufferFlushCases() {
+    return Stream.of(
+        Arguments.of(Arrays.asList(omKeyCreateResponse,
+                omBucketCreateResponse),
+            1L, 2L, 1L, 2L, 2L, 2.0F),
+        Arguments.of(Arrays.asList(omSnapshotCreateResponse1,
+                omSnapshotCreateResponse1),
+            2L, 2L, 3L, 4L, 1L, 1.333F),
+        Arguments.of(Arrays.asList(omKeyCreateResponse,
+                omBucketCreateResponse,
+                omSnapshotCreateResponse1,
+                omSnapshotCreateResponse2),
+            3L, 4L, 6L, 8L, 2L, 1.333F),
+        Arguments.of(Arrays.asList(omKeyCreateResponse,
+                omSnapshotCreateResponse1,
+                omBucketCreateResponse,
+                omSnapshotCreateResponse2),
+            3L, 4L, 9L, 12L, 2L, 1.333F),
+        Arguments.of(Arrays.asList(omKeyCreateResponse,
+                omSnapshotCreateResponse1,
+                omSnapshotCreateResponse2,
+                omBucketCreateResponse),
+            3L, 4L, 12L, 16L, 2L, 1.333F)
+    );
+  }
+
+  @ParameterizedTest
+  @MethodSource("doubleBufferFlushCases")
+  public void testOzoneManagerDoubleBuffer(
+      List<OMClientResponse> omClientResponses,
+      long expectedFlushCounts,
+      long expectedFlushedTransactionCount,
+      long expectedFlushCountsInMetric,
+      long expectedFlushedTransactionCountInMetric,
+      long expectedMaxNumberOfTransactionsFlushedInMetric,
+      float expectedAvgFlushTransactionsInMetric
+  ) throws InterruptedException {
+
+    for (int i = 0; i < omClientResponses.size(); i++) {
+      doubleBuffer.add(omClientResponses.get(i), i);
+    }
+
+    // To make sure that daemon thread is executed.
+    Thread.sleep(1000L);
+
+    assertEquals(expectedFlushCounts, doubleBuffer.getFlushIterations());
+    assertEquals(expectedFlushedTransactionCount,
+        doubleBuffer.getFlushedTransactionCount());
+
+    OzoneManagerDoubleBufferMetrics bufferMetrics =
+        doubleBuffer.getOzoneManagerDoubleBufferMetrics();
+
+    assertEquals(expectedFlushCountsInMetric,
+        bufferMetrics.getTotalNumOfFlushOperations());
+    assertEquals(expectedFlushedTransactionCountInMetric,
+        bufferMetrics.getTotalNumOfFlushedTransactions());
+    assertEquals(expectedMaxNumberOfTransactionsFlushedInMetric,
+        bufferMetrics.getMaxNumberOfTransactionsFlushedInOneIteration());
+    assertEquals(expectedAvgFlushTransactionsInMetric,
+        bufferMetrics.getAvgFlushTransactionsInOneIteration(), 0.001);
+  }
+}

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/ratis/TestOzoneManagerDoubleBuffer.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/ratis/TestOzoneManagerDoubleBuffer.java
@@ -138,7 +138,7 @@ class TestOzoneManagerDoubleBuffer {
                 omBucketCreateResponse),
             1L, 2L, 1L, 2L, 2L, 2.0F),
         Arguments.of(Arrays.asList(omSnapshotCreateResponse1,
-                omSnapshotCreateResponse1),
+                omSnapshotCreateResponse2),
             2L, 2L, 3L, 4L, 1L, 1.333F),
         Arguments.of(Arrays.asList(omKeyCreateResponse,
                 omBucketCreateResponse,
@@ -158,6 +158,22 @@ class TestOzoneManagerDoubleBuffer {
     );
   }
 
+  /**
+   * Tests OzoneManagerDoubleBuffer's snapshot aware splitting and flushing
+   * logic.
+   *
+   * @param expectedFlushCounts,
+   * @param expectedFlushedTransactionCount
+   * @param expectedFlushCountsInMetric, Overall flush count, and it is not
+   *                                     same as expectedFlushCounts because
+   *                                     metric static and shared object.
+   * @param expectedFlushedTransactionCountInMetric, Overall transaction count.
+   * @param expectedMaxNumberOfTransactionsFlushedInMetric, Overall max
+   *                                                        transaction count
+   *                                                        per flush.
+   * @param expectedAvgFlushTransactionsInMetric, Overall avg transaction count
+   *                                              per flush.
+   */
   @ParameterizedTest
   @MethodSource("doubleBufferFlushCases")
   public void testOzoneManagerDoubleBuffer(

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/ratis/TestOzoneManagerDoubleBuffer.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/ratis/TestOzoneManagerDoubleBuffer.java
@@ -137,12 +137,12 @@ class TestOzoneManagerDoubleBuffer {
                 omSnapshotCreateResponse1,
                 omBucketCreateResponse,
                 omSnapshotCreateResponse2),
-            3L, 4L, 9L, 12L, 2L, 1.333F),
+            4L, 4L, 10L, 12L, 1L, 1.200F),
         Arguments.of(Arrays.asList(omKeyCreateResponse,
                 omSnapshotCreateResponse1,
                 omSnapshotCreateResponse2,
                 omBucketCreateResponse),
-            3L, 4L, 12L, 16L, 2L, 1.333F)
+            4L, 4L, 14L, 16L, 1L, 1.142F)
     );
   }
 

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/ratis/TestOzoneManagerDoubleBuffer.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/ratis/TestOzoneManagerDoubleBuffer.java
@@ -55,7 +55,6 @@ import static org.mockito.Mockito.when;
 class TestOzoneManagerDoubleBuffer {
 
   private OzoneManagerDoubleBuffer doubleBuffer;
-  private final long term = 1L;
   private CreateSnapshotResponse snapshotResponse1 =
       mock(CreateSnapshotResponse.class);
   private CreateSnapshotResponse snapshotResponse2 =
@@ -98,7 +97,7 @@ class TestOzoneManagerDoubleBuffer {
         .setOzoneManagerRatisSnapShot(ozoneManagerRatisSnapshot)
         .setmaxUnFlushedTransactionCount(1000)
         .enableRatis(true)
-        .setIndexToTerm((i) -> term)
+        .setIndexToTerm((i) -> 1L)
         .build();
 
     doNothing().when(omKeyCreateResponse).checkAndUpdateDB(any(), any());


### PR DESCRIPTION
## What changes were proposed in this pull request?
The OmRequest double buffer flush thread flushes the entire buffer as a batch.  Since follower OM's will flush batches with different contents, snapshots can't stay consistent between the leader and the followers.
This change is to flush double buffer snapshot aware and flush all the transactions before snapshot create request.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-7279

## How was this patch tested?
- Added unit test.
- Tested it by preventing the flush thread from waking up when a key commit request occurs as described by George in [jira](https://issues.apache.org/jira/browse/HDDS-7279)
