### PR TITLE
HDDS-7470. [Quota] bucket is created crossing quota makes OM crash and unable to start

### DIFF
--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/bucket/OMBucketCreateRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/bucket/OMBucketCreateRequest.java
@@ -405,10 +405,10 @@ public class OMBucketCreateRequest extends OMClientRequest {
     }
     if (volumeQuotaInBytes < totalBucketQuota
         && volumeQuotaInBytes != OzoneConsts.QUOTA_RESET) {
-      throw new IllegalArgumentException("Total buckets quota in this volume " +
+      throw new OMException("Total buckets quota in this volume " +
           "should not be greater than volume quota : the total space quota is" +
           " set to:" + totalBucketQuota + ". But the volume space quota is:" +
-          volumeQuotaInBytes);
+          volumeQuotaInBytes, OMException.ResultCodes.QUOTA_EXCEEDED);
     }
     return true;
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/tenant/OMTenantAssignUserAccessIdRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/tenant/OMTenantAssignUserAccessIdRequest.java
@@ -261,7 +261,8 @@ public class OMTenantAssignUserAccessIdRequest extends OMClientRequest {
           if (accessIdInfo == null) {
             LOG.error("Metadata error: accessIdInfo is null for accessId '{}'. "
                 + "Ignoring.", existingAccId);
-            throw new NullPointerException("accessIdInfo is null");
+            throw new OMException("accessIdInfo is null",
+                ResultCodes.INVALID_ACCESS_ID);
           }
           if (tenantId.equals(accessIdInfo.getTenantId())) {
             throw new OMException("The same user is not allowed to be assigned "

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/bucket/TestOMBucketCreateRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/bucket/TestOMBucketCreateRequest.java
@@ -140,6 +140,52 @@ public class TestOMBucketCreateRequest extends TestBucketRequest {
         omMetadataManager.getBucketTable().get(bucketKey).getBucketLayout());
   }
 
+  @Test
+  public void testValidateAndUpdateCacheCrossSpaceQuota() throws Exception {
+    String volumeName = UUID.randomUUID().toString();
+    String bucketName = UUID.randomUUID().toString();
+
+    // create a volume with less quota
+    OmVolumeArgs omVolumeArgs =
+        OmVolumeArgs.newBuilder().setCreationTime(Time.now())
+            .setQuotaInBytes(100)
+            .setVolume(volumeName).setAdminName(UUID.randomUUID().toString())
+            .setOwnerName(UUID.randomUUID().toString()).build();
+    OMRequestTestUtils.addVolumeToOM(omMetadataManager, omVolumeArgs);
+    
+    // create a bucket require higher bucket quota
+    OzoneManagerProtocolProtos.BucketInfo bucketInfo =
+        OzoneManagerProtocolProtos.BucketInfo.newBuilder()
+            .setBucketName(bucketName)
+            .setVolumeName(volumeName)
+            .setIsVersionEnabled(false)
+            .setQuotaInBytes(99999L)
+            .setStorageType(StorageTypeProto.SSD)
+            .addAllMetadata(OMRequestTestUtils.getMetadataList()).build();
+    OzoneManagerProtocolProtos.CreateBucketRequest.Builder req =
+        OzoneManagerProtocolProtos.CreateBucketRequest.newBuilder();
+    req.setBucketInfo(bucketInfo);
+    OMRequest originalRequest = OzoneManagerProtocolProtos.OMRequest
+        .newBuilder()
+        .setCreateBucketRequest(req)
+        .setCmdType(OzoneManagerProtocolProtos.Type.CreateBucket)
+        .setClientId(UUID.randomUUID().toString()).build();
+
+    OMBucketCreateRequest omBucketCreateRequest =
+        new OMBucketCreateRequest(originalRequest);
+
+    OMRequest modifiedRequest = omBucketCreateRequest.preExecute(ozoneManager);
+    verifyRequest(modifiedRequest, originalRequest);
+
+    OMBucketCreateRequest testRequest =
+        new OMBucketCreateRequest(modifiedRequest);
+    OMClientResponse resp = testRequest.validateAndUpdateCache(
+        ozoneManager, 1, ozoneManagerDoubleBufferHelper);
+
+    Assert.assertEquals(resp.getOMResponse().getStatus().toString(),
+        OMException.ResultCodes.QUOTA_EXCEEDED.toString());
+  }
+
   private OMBucketCreateRequest doPreExecute(String volumeName,
       String bucketName) throws Exception {
     addCreateVolumeToTable(volumeName, omMetadataManager);


### PR DESCRIPTION
## What changes were proposed in this pull request?

Avoid IllegalArgumentException in validateAndUpdateCache() which is called during applyTransaction
1. return OMException with QUOTA_EXCEEDED
2. OMTenantAssignUserAccessIdRequest also return IllegalArgumentException in similar case, returned OMException

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-7470

## How was this patch tested?

Test scenario for create bucket crossing the size quota
