### PR TITLE
HDDS-7101. EC: ReplicationManager - handle UNHEALTHY replicas

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ContainerCheckRequest.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ContainerCheckRequest.java
@@ -20,6 +20,7 @@ import org.apache.hadoop.hdds.scm.container.ContainerInfo;
 import org.apache.hadoop.hdds.scm.container.ContainerReplica;
 import org.apache.hadoop.hdds.scm.container.ReplicationManagerReport;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 
@@ -39,8 +40,9 @@ public final class ContainerCheckRequest {
 
   private ContainerCheckRequest(Builder builder) {
     this.containerInfo = builder.containerInfo;
-    this.containerReplicas = builder.containerReplicas;
-    this.pendingOps = builder.pendingOps;
+    this.containerReplicas =
+        Collections.unmodifiableSet(builder.containerReplicas);
+    this.pendingOps = Collections.unmodifiableList(builder.pendingOps);
     this.maintenanceRedundancy = builder.maintenanceRedundancy;
     this.report = builder.report;
     this.replicationQueue = builder.replicationQueue;

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ECContainerReplicaCount.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ECContainerReplicaCount.java
@@ -19,6 +19,7 @@ package org.apache.hadoop.hdds.scm.container.replication;
 
 import org.apache.hadoop.hdds.client.ECReplicationConfig;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
+import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.ContainerReplicaProto;
 import org.apache.hadoop.hdds.scm.container.ContainerInfo;
 import org.apache.hadoop.hdds.scm.container.ContainerReplica;
 
@@ -51,6 +52,8 @@ import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.NodeOperationalSt
  *     will eventually go away.
  *   * Any pending deletes are treated as if they have deleted
  *   * Pending adds are ignored as they may fail to create.
+ *   * Unhealthy replicas contribute to under replication - an index with
+ *   only unhealthy and no closed replicas is considered under replicated
  *
  * Similar for over replication:
  *
@@ -58,6 +61,7 @@ import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.NodeOperationalSt
  *   * Pending delete replicas will complete
  *   * Pending adds are ignored as they may not complete.
  *   * Maintenance copies are not considered until they are back to IN_SERVICE
+ *   * Having unhealthy replicas is not considered over replication
  */
 
 public class ECContainerReplicaCount implements ContainerReplicaCount {
@@ -93,6 +97,25 @@ public class ECContainerReplicaCount implements ContainerReplicaCount {
     }
 
     for (ContainerReplica replica : replicas) {
+      /*
+      Remove UNHEALTHY replicas because they are unavailable. They could be a
+      reason for under replication but should not be a reason for over
+      replication.
+
+      For example, consider the following set of replicas for an EC 3-2
+      container:
+      Replica Index 1: Closed
+      Replica Index 2: Closed
+      Replica Index 3: Closed, Unhealthy (2 replicas for this index)
+      Replica Index 4: Unhealthy
+      Replica Index 5: Closed
+
+      This is a case of under replication because index 4 is unavailable. Index
+      3 is not considered over replicated because its second copy is unhealthy.
+      */
+      if (replica.getState() == ContainerReplicaProto.State.UNHEALTHY) {
+        continue;
+      }
       HddsProtos.NodeOperationalState state =
           replica.getDatanodeDetails().getPersistedOpState();
       int index = replica.getReplicaIndex();

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ReplicationManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ReplicationManager.java
@@ -469,6 +469,11 @@ public class ReplicationManager implements SCMService {
         containerID);
     List<ContainerReplicaOp> pendingOps =
         containerReplicaPendingOps.getPendingOps(containerID);
+
+    // remove unhealthy replicas because they are unavailable and should
+    // be a reason for under replication
+    replicas.removeIf(containerReplica -> containerReplica.getState() ==
+        ContainerReplicaProto.State.UNHEALTHY);
     return ecUnderReplicationHandler.processAndCreateCommands(replicas,
         pendingOps, result, maintenanceRedundancy);
   }
@@ -480,6 +485,11 @@ public class ReplicationManager implements SCMService {
         containerID);
     List<ContainerReplicaOp> pendingOps =
         containerReplicaPendingOps.getPendingOps(containerID);
+
+    // remove unhealthy replicas because they are unavailable and should
+    // NOT be a reason for over replication
+    replicas.removeIf(containerReplica -> containerReplica.getState() ==
+        ContainerReplicaProto.State.UNHEALTHY);
     return ecOverReplicationHandler.processAndCreateCommands(replicas,
         pendingOps, result, maintenanceRedundancy);
   }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/health/ClosedWithUnhealthyReplicasHandler.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/health/ClosedWithUnhealthyReplicasHandler.java
@@ -1,0 +1,111 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.apache.hadoop.hdds.scm.container.replication.health;
+
+import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
+import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.ContainerReplicaProto;
+import org.apache.hadoop.hdds.scm.container.ContainerInfo;
+import org.apache.hadoop.hdds.scm.container.ContainerReplica;
+import org.apache.hadoop.hdds.scm.container.ReplicationManagerReport;
+import org.apache.hadoop.hdds.scm.container.replication.ContainerCheckRequest;
+import org.apache.hadoop.hdds.scm.container.replication.ReplicationManager;
+import org.apache.ratis.protocol.exceptions.NotLeaderException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Set;
+
+/**
+ * Handler to process containers EC which are closed but have some replicas that
+ * are unhealthy.
+ */
+public class ClosedWithUnhealthyReplicasHandler extends AbstractCheck {
+
+  public static final Logger LOG =
+      LoggerFactory.getLogger(ClosedWithUnhealthyReplicasHandler.class);
+  private final ReplicationManager replicationManager;
+
+  public ClosedWithUnhealthyReplicasHandler(
+      ReplicationManager replicationManager) {
+    this.replicationManager = replicationManager;
+  }
+
+  /**
+   * Handles a closed EC container with unhealthy replicas. Note that if we
+   * reach here, there is no over, under, or mis replication. This handler
+   * will just send commands to delete the unhealthy replicas.
+   *
+   * <p>
+   * Consider the following set of replicas for a closed EC 3-2 container:
+   * Replica Index 1: Closed
+   * Replica Index 2: Closed
+   * Replica Index 3: Closed replica, Unhealthy replica (2 replicas)
+   * Replica Index 4: Closed
+   * Replica Index 5: Closed
+   *
+   * In this case, the unhealthy replica of index 3 should be deleted. This
+   * is not over replication because that unhealthy replica is not available.
+   * </p>
+   * @param request ContainerCheckRequest object representing the container
+   * @return true if this is a closed EC container with unhealthy replicas,
+   * else false
+   */
+  @Override
+  public boolean handle(ContainerCheckRequest request) {
+    ContainerInfo containerInfo = request.getContainerInfo();
+    if (containerInfo.getReplicationType() != HddsProtos.ReplicationType.EC) {
+      return false;
+    }
+    if (containerInfo.getState() != HddsProtos.LifeCycleState.CLOSED) {
+      return false;
+    }
+
+    Set<ContainerReplica> replicas = request.getContainerReplicas();
+    boolean foundUnhealthy = false;
+    // send delete commands for unhealthy replicas
+    for (ContainerReplica replica : replicas) {
+      if (replica.getState() == ContainerReplicaProto.State.UNHEALTHY) {
+        foundUnhealthy = true;
+        LOG.debug("Trying to delete unhealthy replica with index {} for " +
+            "container {} on datanode {}", replica.getReplicaIndex(),
+            containerInfo.containerID(),
+            replica.getDatanodeDetails().getUuidString());
+        try {
+          replicationManager.sendDeleteCommand(containerInfo,
+              replica.getReplicaIndex(), replica.getDatanodeDetails());
+        } catch (NotLeaderException e) {
+          LOG.warn("Failed to delete unhealthy replica with index {} for " +
+                  "container {} on datanode {}",
+              replica.getReplicaIndex(),
+              containerInfo.containerID(),
+              replica.getDatanodeDetails().getUuidString(), e);
+        }
+      }
+    }
+
+    // some unhealthy replicas were found so mark UNHEALTHY (note that
+    // UNHEALTHY is currently not a LifeCycleState for a Container)
+    if (foundUnhealthy) {
+      request.getReport().incrementAndSample(
+          ReplicationManagerReport.HealthState.UNHEALTHY,
+          containerInfo.containerID());
+    }
+    return foundUnhealthy;
+  }
+}

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/health/ECReplicationCheckHandler.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/health/ECReplicationCheckHandler.java
@@ -17,7 +17,6 @@
 package org.apache.hadoop.hdds.scm.container.replication.health;
 
 import org.apache.hadoop.hdds.client.ECReplicationConfig;
-import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.ContainerReplicaProto;
 import org.apache.hadoop.hdds.scm.container.ContainerID;
 import org.apache.hadoop.hdds.scm.container.ContainerInfo;
 import org.apache.hadoop.hdds.scm.container.ContainerReplica;
@@ -96,24 +95,6 @@ public class ECReplicationCheckHandler extends AbstractCheck {
   public ContainerHealthResult checkHealth(ContainerCheckRequest request) {
     ContainerInfo container = request.getContainerInfo();
     Set<ContainerReplica> replicas = request.getContainerReplicas();
-
-    /*
-    Remove UNHEALTHY replicas because they are unavailable. They could be a
-    reason for under replication but should not be a reason for over
-    replication.
-
-    For example, consider the following set of replicas for an EC 3-2 container:
-    Replica Index 1: Closed
-    Replica Index 2: Closed
-    Replica Index 3: Closed, Unhealthy (2 replicas for this index)
-    Replica Index 4: Unhealthy
-    Replica Index 5: Closed
-
-    This is a case of under replication because index 4 is unavailable. Index
-    3 is not considered over replicated because its second copy is unhealthy.
-     */
-    replicas.removeIf(containerReplica -> containerReplica.getState() ==
-        ContainerReplicaProto.State.UNHEALTHY);
     List<ContainerReplicaOp> replicaPendingOps = request.getPendingOps();
     ECContainerReplicaCount replicaCount =
         new ECContainerReplicaCount(container, replicas, replicaPendingOps,

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/health/ECReplicationCheckHandler.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/health/ECReplicationCheckHandler.java
@@ -17,6 +17,7 @@
 package org.apache.hadoop.hdds.scm.container.replication.health;
 
 import org.apache.hadoop.hdds.client.ECReplicationConfig;
+import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.ContainerReplicaProto;
 import org.apache.hadoop.hdds.scm.container.ContainerID;
 import org.apache.hadoop.hdds.scm.container.ContainerInfo;
 import org.apache.hadoop.hdds.scm.container.ContainerReplica;
@@ -95,6 +96,24 @@ public class ECReplicationCheckHandler extends AbstractCheck {
   public ContainerHealthResult checkHealth(ContainerCheckRequest request) {
     ContainerInfo container = request.getContainerInfo();
     Set<ContainerReplica> replicas = request.getContainerReplicas();
+
+    /*
+    Remove UNHEALTHY replicas because they are unavailable. They could be a
+    reason for under replication but should not be a reason for over
+    replication.
+
+    For example, consider the following set of replicas for an EC 3-2 container:
+    Replica Index 1: Closed
+    Replica Index 2: Closed
+    Replica Index 3: Closed, Unhealthy (2 replicas for this index)
+    Replica Index 4: Unhealthy
+    Replica Index 5: Closed
+
+    This is a case of under replication because index 4 is unavailable. Index
+    3 is not considered over replicated because its second copy is unhealthy.
+     */
+    replicas.removeIf(containerReplica -> containerReplica.getState() ==
+        ContainerReplicaProto.State.UNHEALTHY);
     List<ContainerReplicaOp> replicaPendingOps = request.getPendingOps();
     ECContainerReplicaCount replicaCount =
         new ECContainerReplicaCount(container, replicas, replicaPendingOps,

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/health/TestClosedWithUnhealthyReplicasHandler.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/health/TestClosedWithUnhealthyReplicasHandler.java
@@ -169,4 +169,26 @@ public class TestClosedWithUnhealthyReplicasHandler {
 
     Assert.assertFalse(handler.handle(request));
   }
+
+  @Test
+  public void testUnderReplicatedContainerReturnsFalse() {
+    ContainerInfo container =
+        createContainerInfo(ecReplicationConfig, 1, CLOSED);
+
+    // make it under replicated by having only UNHEALTHY replica for index 2
+    Set<ContainerReplica> containerReplicas =
+        ReplicationTestUtil.createReplicas(container.containerID(),
+            ContainerReplicaProto.State.CLOSED, 1, 3, 4, 5);
+    ContainerReplica unhealthyIndex2 =
+        createContainerReplica(container.containerID(), 2,
+            IN_SERVICE, ContainerReplicaProto.State.UNHEALTHY);
+    containerReplicas.add(unhealthyIndex2);
+
+    ContainerCheckRequest request = requestBuilder
+        .setContainerReplicas(containerReplicas)
+        .setContainerInfo(container)
+        .build();
+
+    Assert.assertFalse(handler.handle(request));
+  }
 }

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/health/TestClosedWithUnhealthyReplicasHandler.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/health/TestClosedWithUnhealthyReplicasHandler.java
@@ -1,0 +1,172 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.apache.hadoop.hdds.scm.container.replication.health;
+
+import org.apache.hadoop.hdds.client.ECReplicationConfig;
+import org.apache.hadoop.hdds.client.RatisReplicationConfig;
+import org.apache.hadoop.hdds.protocol.DatanodeDetails;
+import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
+import org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationFactor;
+import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.ContainerReplicaProto;
+import org.apache.hadoop.hdds.scm.container.ContainerInfo;
+import org.apache.hadoop.hdds.scm.container.ContainerReplica;
+import org.apache.hadoop.hdds.scm.container.ReplicationManagerReport;
+import org.apache.hadoop.hdds.scm.container.replication.ContainerCheckRequest;
+import org.apache.hadoop.hdds.scm.container.replication.ReplicationManager;
+import org.apache.hadoop.hdds.scm.container.replication.ReplicationTestUtil;
+import org.apache.ratis.protocol.exceptions.NotLeaderException;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
+
+import java.util.Collections;
+import java.util.Set;
+
+import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.LifeCycleState.CLOSED;
+import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.LifeCycleState.CLOSING;
+import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.NodeOperationalState.IN_SERVICE;
+import static org.apache.hadoop.hdds.scm.container.replication.ReplicationTestUtil.createContainerInfo;
+import static org.apache.hadoop.hdds.scm.container.replication.ReplicationTestUtil.createContainerReplica;
+
+/**
+ * Tests for {@link ClosedWithUnhealthyReplicasHandler}.
+ */
+public class TestClosedWithUnhealthyReplicasHandler {
+  private ClosedWithUnhealthyReplicasHandler handler;
+  private ReplicationManager replicationManager;
+  private ECReplicationConfig ecReplicationConfig;
+  private ContainerCheckRequest.Builder requestBuilder;
+
+  @Before
+  public void setup() {
+    ecReplicationConfig = new ECReplicationConfig(3, 2);
+    replicationManager = Mockito.mock(ReplicationManager.class);
+    handler = new ClosedWithUnhealthyReplicasHandler(replicationManager);
+    requestBuilder = new ContainerCheckRequest.Builder()
+        .setPendingOps(Collections.emptyList())
+        .setReport(new ReplicationManagerReport());
+  }
+
+  @Test
+  public void testNonClosedContainerReturnsFalse() {
+    ContainerInfo containerInfo = ReplicationTestUtil.createContainerInfo(
+        ecReplicationConfig, 1, CLOSING);
+    Set<ContainerReplica> containerReplicas =
+        ReplicationTestUtil.createReplicas(containerInfo.containerID(),
+            ContainerReplicaProto.State.CLOSED, 1, 2, 3, 4, 5);
+    containerReplicas.add(
+        ReplicationTestUtil.createContainerReplica(containerInfo.containerID(),
+            5, HddsProtos.NodeOperationalState.IN_SERVICE,
+            ContainerReplicaProto.State.UNHEALTHY));
+
+    ContainerCheckRequest request = requestBuilder
+        .setContainerReplicas(containerReplicas)
+        .setContainerInfo(containerInfo)
+        .build();
+
+    Assert.assertFalse(handler.handle(request));
+  }
+
+  @Test
+  public void testRatisContainerReturnsFalse() {
+    ContainerInfo containerInfo = ReplicationTestUtil.createContainerInfo(
+        RatisReplicationConfig.getInstance(ReplicationFactor.THREE), 1,
+        CLOSED);
+    Set<ContainerReplica> containerReplicas =
+        ReplicationTestUtil.createReplicas(containerInfo.containerID(),
+            ContainerReplicaProto.State.CLOSED, 0, 0, 0);
+    containerReplicas.add(
+        ReplicationTestUtil.createContainerReplica(containerInfo.containerID(),
+            0, HddsProtos.NodeOperationalState.IN_SERVICE,
+            ContainerReplicaProto.State.UNHEALTHY));
+
+    ContainerCheckRequest request = requestBuilder
+        .setContainerReplicas(containerReplicas)
+        .setContainerInfo(containerInfo)
+        .build();
+
+    Assert.assertFalse(handler.handle(request));
+  }
+
+  /**
+   * A closed EC container that is not under, over, or mis replicated but
+   * has some unhealthy replicas should be handled.
+   */
+  @Test
+  public void
+      testClosedWithSufficientReplicationDespiteUnhealthyReplicasReturnsTrue()
+      throws NotLeaderException {
+    ContainerInfo container =
+        createContainerInfo(ecReplicationConfig, 1, CLOSED);
+
+    // create 5 closed replicas and 1 unhealthy replica each for indices 2 and 5
+    Set<ContainerReplica> containerReplicas =
+        ReplicationTestUtil.createReplicas(container.containerID(),
+            ContainerReplicaProto.State.CLOSED, 1, 2, 3, 4, 5);
+    ContainerReplica unhealthyIndex2 =
+        createContainerReplica(container.containerID(), 2,
+            IN_SERVICE, ContainerReplicaProto.State.UNHEALTHY);
+    ContainerReplica unhealthyIndex5 =
+        createContainerReplica(container.containerID(), 5,
+            IN_SERVICE, ContainerReplicaProto.State.UNHEALTHY);
+    containerReplicas.add(unhealthyIndex2);
+    containerReplicas.add(unhealthyIndex5);
+
+    ContainerCheckRequest request = requestBuilder
+        .setContainerReplicas(containerReplicas)
+        .setContainerInfo(container)
+        .build();
+
+    Assert.assertTrue(handler.handle(request));
+    Assert.assertEquals(1, request.getReport().getStat(
+        ReplicationManagerReport.HealthState.UNHEALTHY));
+
+    ArgumentCaptor<Integer> replicaIndexCaptor =
+        ArgumentCaptor.forClass(Integer.class);
+    Mockito.verify(replicationManager, Mockito.times(2))
+        .sendDeleteCommand(Mockito.eq(container), Mockito.anyInt(), Mockito.any(
+            DatanodeDetails.class));
+    // replica index that delete was sent for should either be 2 or 5
+    replicaIndexCaptor.getAllValues()
+        .forEach(index -> Assert.assertTrue(index == 2 || index == 5));
+  }
+
+  /**
+   * Closed EC container that does not have unhealthy replicas should not be
+   * handled.
+   */
+  @Test
+  public void testClosedWithNoUnhealthyReplicasShouldReturnFalse() {
+    ContainerInfo container =
+        createContainerInfo(ecReplicationConfig, 1, CLOSED);
+
+    Set<ContainerReplica> containerReplicas =
+        ReplicationTestUtil.createReplicas(container.containerID(),
+            ContainerReplicaProto.State.CLOSED, 1, 2, 3, 4, 5);
+
+    ContainerCheckRequest request = requestBuilder
+        .setContainerReplicas(containerReplicas)
+        .setContainerInfo(container)
+        .build();
+
+    Assert.assertFalse(handler.handle(request));
+  }
+}

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/health/TestECReplicationCheckHandler.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/health/TestECReplicationCheckHandler.java
@@ -19,6 +19,7 @@ package org.apache.hadoop.hdds.scm.container.replication.health;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.hadoop.hdds.client.ECReplicationConfig;
 import org.apache.hadoop.hdds.protocol.MockDatanodeDetails;
+import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.ContainerReplicaProto;
 import org.apache.hadoop.hdds.scm.container.ContainerInfo;
 import org.apache.hadoop.hdds.scm.container.ContainerReplica;
 import org.apache.hadoop.hdds.scm.container.ReplicationManagerReport;
@@ -30,6 +31,7 @@ import org.apache.hadoop.hdds.scm.container.replication.ContainerHealthResult.He
 
 import org.apache.hadoop.hdds.scm.container.replication.ContainerReplicaOp;
 import org.apache.hadoop.hdds.scm.container.replication.ReplicationQueue;
+import org.apache.hadoop.hdds.scm.container.replication.ReplicationTestUtil;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -39,6 +41,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 
+import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.LifeCycleState.CLOSED;
 import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.NodeOperationalState.DECOMMISSIONED;
 import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.NodeOperationalState.DECOMMISSIONING;
 import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.NodeOperationalState.IN_MAINTENANCE;
@@ -46,6 +49,7 @@ import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.NodeOperationalSt
 import static org.apache.hadoop.hdds.scm.container.replication.ContainerReplicaOp.PendingOpType.ADD;
 import static org.apache.hadoop.hdds.scm.container.replication.ContainerReplicaOp.PendingOpType.DELETE;
 import static org.apache.hadoop.hdds.scm.container.replication.ReplicationTestUtil.createContainerInfo;
+import static org.apache.hadoop.hdds.scm.container.replication.ReplicationTestUtil.createContainerReplica;
 import static org.apache.hadoop.hdds.scm.container.replication.ReplicationTestUtil.createReplicas;
 
 /**
@@ -258,6 +262,74 @@ public class TestECReplicationCheckHandler {
         ReplicationManagerReport.HealthState.UNDER_REPLICATED));
     Assert.assertEquals(1, report.getStat(
         ReplicationManagerReport.HealthState.MISSING));
+  }
+
+  /**
+   * Tests that a closed EC 3-2 container with 4 closed and 1 unhealthy
+   * replica is under replicated.
+   */
+  @Test
+  public void testUnderReplicatedDueToUnhealthyReplicas() {
+    ContainerInfo container = createContainerInfo(repConfig, 1, CLOSED);
+
+    // create 4 closed and 1 unhealthy replica
+    Set<ContainerReplica> containerReplicas =
+        ReplicationTestUtil.createReplicas(container.containerID(),
+            ContainerReplicaProto.State.CLOSED, 1, 2, 3, 4);
+    ContainerReplica unhealthyIndex5 =
+        createContainerReplica(container.containerID(), 5,
+            IN_SERVICE, ContainerReplicaProto.State.UNHEALTHY);
+    containerReplicas.add(unhealthyIndex5);
+
+    ContainerCheckRequest request = requestBuilder
+        .setContainerReplicas(containerReplicas)
+        .setContainerInfo(container)
+        .build();
+
+    UnderReplicatedHealthResult result = (UnderReplicatedHealthResult)
+        healthCheck.checkHealth(request);
+    Assert.assertEquals(HealthState.UNDER_REPLICATED, result.getHealthState());
+    Assert.assertEquals(1, result.getRemainingRedundancy());
+    Assert.assertFalse(result.isSufficientlyReplicatedAfterPending());
+    Assert.assertFalse(result.underReplicatedDueToDecommission());
+
+    Assert.assertTrue(healthCheck.handle(request));
+    Assert.assertEquals(1, repQueue.underReplicatedQueueSize());
+    Assert.assertEquals(0, repQueue.overReplicatedQueueSize());
+    Assert.assertEquals(1, report.getStat(
+        ReplicationManagerReport.HealthState.UNDER_REPLICATED));
+  }
+
+  /**
+   * Tests that a closed EC 3-2 container with 5 closed replicas and 1 more
+   * unhealthy replica for an index is sufficiently replicated. This is not over
+   * replication because the unhealthy replica is unavailable and should not be
+   * considered.
+   */
+  @Test
+  public void testSufficientlyReplicatedDespiteUnhealthyReplicas() {
+    ContainerInfo container = createContainerInfo(repConfig, 1, CLOSED);
+
+    // create 5 closed replicas and 1 unhealthy replica for index 5
+    Set<ContainerReplica> containerReplicas =
+        ReplicationTestUtil.createReplicas(container.containerID(),
+            ContainerReplicaProto.State.CLOSED, 1, 2, 3, 4, 5);
+    ContainerReplica unhealthyIndex5 =
+        createContainerReplica(container.containerID(), 5,
+            IN_SERVICE, ContainerReplicaProto.State.UNHEALTHY);
+    containerReplicas.add(unhealthyIndex5);
+
+    ContainerCheckRequest request = requestBuilder
+        .setContainerReplicas(containerReplicas)
+        .setContainerInfo(container)
+        .build();
+
+    ContainerHealthResult result = healthCheck.checkHealth(request);
+    Assert.assertEquals(HealthState.HEALTHY, result.getHealthState());
+
+    Assert.assertFalse(healthCheck.handle(request));
+    Assert.assertEquals(0, repQueue.underReplicatedQueueSize());
+    Assert.assertEquals(0, repQueue.overReplicatedQueueSize());
   }
 
   @Test


### PR DESCRIPTION
## What changes were proposed in this pull request?

If the DN scrubber marks a container as UNHEALTHY, the EC Replication Manager logic needs to be able to deal with it. It needs to remove the unhealthy one, and create a new copy using EC Reconstruction.

This PR proposes considering UNHEALTHY replicas when checking for under and over replication in `ECReplicationCheckHandler`. 

The newly introduced handler `ClosedWithUnhealthyReplicasHandler` will handle closed EC containers with unhealthy replicas but no under, over or mis replication.

For example, consider a closed EC 3-2 container with the following replicas:
Replica Index 1: Closed
Replica Index 2: Closed
Replica Index 3: Closed, Unhealthy (2 replicas for this index)
Replica Index 4: Unhealthy
Replica Index 5: Closed

This is a case of under replication because index 4 is unavailable. Index 3 is not considered over replicated because its second copy is unhealthy. In the current iteration of replication manager,
`ECReplicationCheckHandler` will find this container is under replicated and will add it to the under replication queue. When the container is no longer under (or over, mis) replicated, `ClosedWithUnhealthyReplicasHandler` will handle it by deleting the unhealthy replicas in a future iteration.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-7101

## How was this patch tested?
`TestClosedWithUnhealthyReplicasHandler` and `TestECReplicationCheckHandler`