### PR TITLE
HDDS-4565. [FSO]Delete : quotaReleased on directory deletion should consider all sub paths

### DIFF
--- a/hadoop-ozone/interface-client/src/main/proto/OmClientProtocol.proto
+++ b/hadoop-ozone/interface-client/src/main/proto/OmClientProtocol.proto
@@ -1131,6 +1131,7 @@ message DeletedKeys {
     required string volumeName = 1;
     required string bucketName = 2;
     repeated string keys = 3;
+    optional uint64 totalKeySize = 4;
 }
 
 

--- a/hadoop-ozone/interface-storage/src/main/java/org/apache/hadoop/ozone/om/OMMetadataManager.java
+++ b/hadoop-ozone/interface-storage/src/main/java/org/apache/hadoop/ozone/om/OMMetadataManager.java
@@ -28,7 +28,6 @@ import org.apache.hadoop.hdds.utils.DBStoreHAManager;
 import org.apache.hadoop.hdds.utils.db.TableIterator;
 import org.apache.hadoop.hdds.utils.db.cache.CacheKey;
 import org.apache.hadoop.hdds.utils.db.cache.CacheValue;
-import org.apache.hadoop.ozone.common.BlockGroup;
 import org.apache.hadoop.ozone.om.helpers.OmBucketInfo;
 import org.apache.hadoop.ozone.om.helpers.OmDBAccessIdInfo;
 import org.apache.hadoop.ozone.om.helpers.OmDBUserPrincipalInfo;
@@ -250,15 +249,15 @@ public interface OMMetadataManager extends DBStoreHAManager {
 
   /**
    * Returns a list of pending deletion key info that ups to the given count.
-   * Each entry is a {@link BlockGroup}, which contains the info about the key
-   * name and all its associated block IDs. A pending deletion key is stored
+   * Each entry is a {@link OmKeyInfo}, which contains the info about the key
+   * and all its associated block IDs. A pending deletion key is stored
    * with #deleting# prefix in OM DB.
    *
    * @param count max number of keys to return.
-   * @return a list of {@link BlockGroup} represent keys and blocks.
+   * @return a list of {@link OmKeyInfo} represent keys and blocks.
    * @throws IOException
    */
-  List<BlockGroup> getPendingDeletionKeys(int count) throws IOException;
+  List<OmKeyInfo> getPendingDeletionKeys(int count) throws IOException;
 
   /**
    * Returns the names of up to {@code count} open keys whose age is

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/KeyManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/KeyManager.java
@@ -18,7 +18,6 @@ package org.apache.hadoop.ozone.om;
 
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.utils.db.Table;
-import org.apache.hadoop.ozone.common.BlockGroup;
 import org.apache.hadoop.ozone.om.exceptions.OMException;
 import org.apache.hadoop.ozone.om.helpers.BucketLayout;
 import org.apache.hadoop.ozone.om.helpers.OmKeyArgs;
@@ -121,15 +120,15 @@ public interface KeyManager extends OzoneManagerFS, IOzoneAcl {
 
   /**
    * Returns a list of pending deletion key info that ups to the given count.
-   * Each entry is a {@link BlockGroup}, which contains the info about the
-   * key name and all its associated block IDs. A pending deletion key is
+   * Each entry is a {@link OmKeyInfo}, which contains the info about the
+   * key and all its associated block IDs. A pending deletion key is
    * stored with #deleting# prefix in OM DB.
    *
    * @param count max number of keys to return.
-   * @return a list of {@link BlockGroup} representing keys and blocks.
+   * @return a list of {@link OmKeyInfo} representing keys and blocks.
    * @throws IOException
    */
-  List<BlockGroup> getPendingDeletionKeys(int count) throws IOException;
+  List<OmKeyInfo> getPendingDeletionKeys(int count) throws IOException;
 
   /**
    * Returns the names of up to {@code count} open keys whose age is

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/KeyManagerImpl.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/KeyManagerImpl.java
@@ -61,7 +61,6 @@ import org.apache.hadoop.hdds.utils.db.cache.CacheValue;
 import org.apache.hadoop.ipc.Server;
 import org.apache.hadoop.ozone.OmUtils;
 import org.apache.hadoop.ozone.OzoneAcl;
-import org.apache.hadoop.ozone.common.BlockGroup;
 import org.apache.hadoop.ozone.om.exceptions.OMException;
 import org.apache.hadoop.ozone.om.exceptions.OMException.ResultCodes;
 import org.apache.hadoop.ozone.om.helpers.BucketEncryptionKeyInfo;
@@ -581,7 +580,7 @@ public class KeyManagerImpl implements KeyManager {
   }
 
   @Override
-  public List<BlockGroup> getPendingDeletionKeys(final int count)
+  public List<OmKeyInfo> getPendingDeletionKeys(final int count)
       throws IOException {
     return  metadataManager.getPendingDeletionKeys(count);
   }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/key/OMKeyPurgeResponse.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/key/OMKeyPurgeResponse.java
@@ -18,7 +18,9 @@
 
 package org.apache.hadoop.ozone.om.response.key;
 
+import org.apache.commons.lang3.tuple.Pair;
 import org.apache.hadoop.ozone.om.OMMetadataManager;
+import org.apache.hadoop.ozone.om.helpers.OmBucketInfo;
 import org.apache.hadoop.ozone.om.response.CleanupTableInfo;
 import org.apache.hadoop.ozone.om.request.key.OMKeyPurgeRequest;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMResponse;
@@ -28,28 +30,36 @@ import java.io.IOException;
 import java.util.List;
 import javax.annotation.Nonnull;
 
+import static org.apache.hadoop.ozone.om.OmMetadataManagerImpl.BUCKET_TABLE;
 import static org.apache.hadoop.ozone.om.OmMetadataManagerImpl.DELETED_TABLE;
 
 /**
  * Response for {@link OMKeyPurgeRequest} request.
  */
-@CleanupTableInfo(cleanupTables = {DELETED_TABLE})
+@CleanupTableInfo(cleanupTables = {DELETED_TABLE, BUCKET_TABLE})
 public class OMKeyPurgeResponse extends OmKeyResponse {
-  private List<String> purgeKeyList;
+  private List<Pair<OmBucketInfo, List<String>>> purgeKeyList;
 
   public OMKeyPurgeResponse(@Nonnull OMResponse omResponse,
-      @Nonnull List<String> keyList) {
+      @Nonnull List<Pair<OmBucketInfo, List<String>>> bucketKeyList) {
     super(omResponse);
-    this.purgeKeyList = keyList;
+    this.purgeKeyList = bucketKeyList;
   }
 
   @Override
   public void addToDBBatch(OMMetadataManager omMetadataManager,
       BatchOperation batchOperation) throws IOException {
 
-    for (String key : purgeKeyList) {
-      omMetadataManager.getDeletedTable().deleteWithBatch(batchOperation,
-          key);
+    for (Pair<OmBucketInfo, List<String>> bucketKeyListInfo : purgeKeyList) {
+      for (String key : bucketKeyListInfo.getValue()) {
+        omMetadataManager.getDeletedTable().deleteWithBatch(batchOperation,
+            key);
+      }
+      // update bucket usedBytes.
+      OmBucketInfo omBucketInfo = bucketKeyListInfo.getKey();
+      omMetadataManager.getBucketTable().putWithBatch(batchOperation,
+          omMetadataManager.getBucketKey(omBucketInfo.getVolumeName(),
+              omBucketInfo.getBucketName()), omBucketInfo);
     }
   }
 

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/service/TestKeyDeletingService.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/service/TestKeyDeletingService.java
@@ -22,19 +22,16 @@ package org.apache.hadoop.ozone.om.service;
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
-import java.util.stream.Collectors;
 
 import org.apache.hadoop.ozone.om.KeyManager;
 import org.apache.hadoop.ozone.om.OmTestManagers;
 import org.apache.hadoop.ozone.om.OzoneManager;
 import org.apache.hadoop.ozone.om.ScmBlockLocationTestingClient;
-import org.apache.hadoop.ozone.common.BlockGroup;
 import org.apache.hadoop.ozone.om.helpers.OmKeyLocationInfo;
 import org.apache.hadoop.ozone.om.helpers.OmKeyLocationInfoGroup;
 import org.apache.hadoop.ozone.om.request.OMRequestTestUtils;
@@ -252,9 +249,9 @@ public class TestKeyDeletingService {
           try {
             return keyManager.getPendingDeletionKeys(Integer.MAX_VALUE)
                 .stream()
-                .map(BlockGroup::getBlockIDList)
-                .flatMap(Collection::stream)
-                .collect(Collectors.toList()).size() == 1;
+                .mapToInt(e -> e.getKeyLocationVersions().stream()
+                    .map(OmKeyLocationInfoGroup::getLocationList).
+                    mapToInt(List::size).sum()).sum() == 1;
           } catch (IOException e) {
             e.printStackTrace();
           }
@@ -274,9 +271,9 @@ public class TestKeyDeletingService {
           try {
             return keyManager.getPendingDeletionKeys(Integer.MAX_VALUE)
                 .stream()
-                .map(BlockGroup::getBlockIDList)
-                .flatMap(Collection::stream)
-                .collect(Collectors.toList()).size() == 3;
+                .mapToInt(e -> e.getKeyLocationVersions().stream()
+                    .map(OmKeyLocationInfoGroup::getLocationList).
+                    mapToInt(List::size).sum()).sum() == 3;
           } catch (IOException e) {
             e.printStackTrace();
           }


### PR DESCRIPTION
## What changes were proposed in this pull request?

While delete keys in background service for recursive cleanup, cleanup of key's space and its namespace is added in purge of keys.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-4565

## How was this patch tested?

Test is done considering below scenario:
1. single file remove with delete folder hierarchy
2. multiple files in different level with delete folder hierarchy
3. multiple files in same level with delete folder hierarchy
