### PR TITLE
HDDS-7494. [Snapshot] Fix SnapshotInfo#dbTxSequenceNumber (de)serialization

### DIFF
--- a/hadoop-hdds/rocksdb-checkpoint-differ/src/main/java/org/apache/ozone/rocksdiff/RocksDBCheckpointDiffer.java
+++ b/hadoop-hdds/rocksdb-checkpoint-differ/src/main/java/org/apache/ozone/rocksdiff/RocksDBCheckpointDiffer.java
@@ -223,8 +223,7 @@ public class RocksDBCheckpointDiffer {
       LOG.warn("Compaction log exists: {}. Will append", newCompactionLog);
     }
 
-    this.currentCompactionLogPath =
-        compactionLogDir + latestSequenceIdStr + COMPACTION_LOG_FILENAME_SUFFIX;
+    this.currentCompactionLogPath = newCompactionLog;
 
     // Create empty file if it doesn't exist
     appendToCurrentCompactionLog("");

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/SnapshotInfo.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/SnapshotInfo.java
@@ -138,7 +138,8 @@ public final class SnapshotInfo implements Auditable {
                        String pathPreviousSnapshotID,
                        String globalPreviousSnapshotID,
                        String snapshotPath,
-                       String checkpointDir) {
+                       String checkpointDir,
+                       long dbTxSequenceNumber) {
     this.snapshotID = snapshotID;
     this.name = name;
     this.volumeName = volumeName;
@@ -150,6 +151,7 @@ public final class SnapshotInfo implements Auditable {
     this.globalPreviousSnapshotID = globalPreviousSnapshotID;
     this.snapshotPath = snapshotPath;
     this.checkpointDir = checkpointDir;
+    this.dbTxSequenceNumber = dbTxSequenceNumber;
   }
 
   public void setName(String name) {
@@ -267,6 +269,7 @@ public final class SnapshotInfo implements Auditable {
     private String globalPreviousSnapshotID;
     private String snapshotPath;
     private String checkpointDir;
+    private long dbTxSequenceNumber;
 
     public Builder() {
       // default values
@@ -329,6 +332,11 @@ public final class SnapshotInfo implements Auditable {
       return this;
     }
 
+    public Builder setDbTxSequenceNumber(long dbTxSequenceNumber) {
+      this.dbTxSequenceNumber = dbTxSequenceNumber;
+      return this;
+    }
+
     public SnapshotInfo build() {
       Preconditions.checkNotNull(name);
       return new SnapshotInfo(
@@ -342,7 +350,8 @@ public final class SnapshotInfo implements Auditable {
           pathPreviousSnapshotID,
           globalPreviousSnapshotID,
           snapshotPath,
-          checkpointDir
+          checkpointDir,
+          dbTxSequenceNumber
       );
     }
   }
@@ -388,10 +397,12 @@ public final class SnapshotInfo implements Auditable {
         .setGlobalPreviousSnapshotID(snapshotInfoProto.
             getGlobalPreviousSnapshotID())
         .setSnapshotPath(snapshotInfoProto.getSnapshotPath())
-        .setCheckpointDir(snapshotInfoProto.getCheckpointDir());
+        .setCheckpointDir(snapshotInfoProto.getCheckpointDir())
+        .setDbTxSequenceNumber(snapshotInfoProto.getDbTxSequenceNumber());
 
     return osib.build();
   }
+
   @Override
   public Map<String, String> toAuditMap() {
     Map<String, String> auditMap = new LinkedHashMap<>();

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/SnapshotInfo.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/SnapshotInfo.java
@@ -372,7 +372,8 @@ public final class SnapshotInfo implements Auditable {
         .setPathPreviousSnapshotID(pathPreviousSnapshotID)
         .setGlobalPreviousSnapshotID(globalPreviousSnapshotID)
         .setSnapshotPath(snapshotPath)
-        .setCheckpointDir(checkpointDir);
+        .setCheckpointDir(checkpointDir)
+        .setDbTxSequenceNumber(dbTxSequenceNumber);
     return sib.build();
   }
 

--- a/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/om/helpers/TestOmSnapshotInfo.java
+++ b/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/om/helpers/TestOmSnapshotInfo.java
@@ -49,6 +49,7 @@ public class TestOmSnapshotInfo {
       PATH_PREVIOUS_SNAPSHOT_ID;
   private static final String SNAPSHOT_PATH = "test/path";
   private static final String CHECKPOINT_DIR = "checkpoint.testdir";
+  private static final long DB_TX_SEQUENCE_NUMBER = 12345L;
 
   private SnapshotInfo createSnapshotInfo() {
     return new SnapshotInfo.Builder()
@@ -63,6 +64,7 @@ public class TestOmSnapshotInfo {
         .setGlobalPreviousSnapshotID(GLOBAL_PREVIOUS_SNAPSHOT_ID)
         .setSnapshotPath(SNAPSHOT_PATH)
         .setCheckpointDir(CHECKPOINT_DIR)
+        .setDbTxSequenceNumber(DB_TX_SEQUENCE_NUMBER)
         .build();
   }
 
@@ -79,6 +81,7 @@ public class TestOmSnapshotInfo {
         .setGlobalPreviousSnapshotID(GLOBAL_PREVIOUS_SNAPSHOT_ID)
         .setSnapshotPath(SNAPSHOT_PATH)
         .setCheckpointDir(CHECKPOINT_DIR)
+        .setDbTxSequenceNumber(DB_TX_SEQUENCE_NUMBER)
         .build();
   }
 
@@ -108,6 +111,8 @@ public class TestOmSnapshotInfo {
         snapshotInfoEntryActual.getBucketName());
     Assert.assertEquals(snapshotInfoEntryExpected.getSnapshotStatus(),
         snapshotInfoEntryActual.getSnapshotStatus());
+    Assert.assertEquals(snapshotInfoEntryExpected.getDbTxSequenceNumber(),
+        snapshotInfoEntryActual.getDbTxSequenceNumber());
     Assert.assertEquals(snapshotInfoEntryExpected, snapshotInfoEntryActual);
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

> It turns out in HDDS-7281 I forgot to add the serialization and deserialization logic for dbTxSequenceNumber in SnapshotInfo. As a result, dbTxSequenceNumber is always zero when deserialized. This is a simple fix to address that issue.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-7494

## How was this patch tested?

- This is manually tested on a deployed cluster.