### PR TITLE
HDDS-4402. Recon dashboard page does not load until missing containers API returns data.

### DIFF
--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/api/db.json
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/api/db.json
@@ -1,15 +1,15 @@
 {
   "clusterState": {
+    "pipelines": 32,
     "totalDatanodes": 24,
     "healthyDatanodes": 24,
-    "pipelines": 32,
     "storageReport": {
-      "capacity": 32985348833280,
-      "used": 15942918602752,
-      "remaining": 12094627905536
+    "capacity": 202114732032,
+    "used": 16384,
+    "remaining": 182447632384
     },
     "containers": 3230,
-    "openContainers": 3210,
+    "missingContainers": 8,
     "volumes": 5,
     "buckets": 156,
     "keys": 253000

--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/api/db.json
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/api/db.json
@@ -4,9 +4,9 @@
     "totalDatanodes": 24,
     "healthyDatanodes": 24,
     "storageReport": {
-    "capacity": 202114732032,
-    "used": 16384,
-    "remaining": 182447632384
+     "capacity": 202114732032,
+     "used": 16384,
+     "remaining": 182447632384
     },
     "containers": 3230,
     "missingContainers": 8,

--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/api/db.json
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/api/db.json
@@ -9,7 +9,7 @@
      "remaining": 182447632384
     },
     "containers": 3230,
-    "missingContainers": 8,
+    "missingContainers": 1002,
     "volumes": 5,
     "buckets": 156,
     "keys": 253000

--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/api/db.json
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/api/db.json
@@ -4,9 +4,9 @@
     "totalDatanodes": 24,
     "healthyDatanodes": 24,
     "storageReport": {
-     "capacity": 202114732032,
-     "used": 16384,
-     "remaining": 182447632384
+      "capacity": 202114732032,
+      "used": 16384,
+      "remaining": 182447632384
     },
     "containers": 3230,
     "missingContainers": 1002,

--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/api/routes.json
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/api/routes.json
@@ -23,6 +23,5 @@
   "/namespace/summary?path=*": "/metadata",
   "/namespace/quota?path=*": "/quota",
   "/task/status": "/taskStatus",
-  "/containers/missing": "/missingContainers",
   "/containers/unhealthy": "/unhealthyContainers"
 }

--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/views/overview/overview.tsx
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/views/overview/overview.tsx
@@ -144,7 +144,7 @@ export class Overview extends React.Component<Record<string, object>, IOverviewS
     const duLink = '/DiskUsage';
     const containersElement = missingContainersCount > 0 ? (
       <span>
-        <Tooltip placement='bottom' title={ missingContainersCount > 1000 ? `1000+ Containers are missing,  for more information go to Containers page.` : `${missingContainersCount} ${containersTooltip}`}>
+        <Tooltip placement='bottom' title={missingContainersCount > 1000 ? `1000+ Containers are missing, For more information, go to the Containers page.` : `${missingContainersCount} ${containersTooltip}`}>
           <Icon type='exclamation-circle' theme='filled' className='icon-failure icon-small'/>
         </Tooltip>
         <span className='padded-text'>{containers - missingContainersCount}/{containers}</span>

--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/views/overview/overview.tsx
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/views/overview/overview.tsx
@@ -144,7 +144,7 @@ export class Overview extends React.Component<Record<string, object>, IOverviewS
     const duLink = '/DiskUsage';
     const containersElement = missingContainersCount > 0 ? (
       <span>
-        <Tooltip placement='bottom' title={missingContainersCount > 1000 ? `1000+ Containers are missing, For more information, go to the Containers page.` : `${missingContainersCount} ${containersTooltip}`}>
+        <Tooltip placement='bottom' title={missingContainersCount > 1000 ? `1000+ Containers are missing. For more information, go to the Containers page.` : `${missingContainersCount} ${containersTooltip}`}>
           <Icon type='exclamation-circle' theme='filled' className='icon-failure icon-small'/>
         </Tooltip>
         <span className='padded-text'>{containers - missingContainersCount}/{containers}</span>

--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/views/overview/overview.tsx
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/views/overview/overview.tsx
@@ -144,7 +144,7 @@ export class Overview extends React.Component<Record<string, object>, IOverviewS
     const duLink = '/DiskUsage';
     const containersElement = missingContainersCount > 0 ? (
       <span>
-        <Tooltip placement='bottom' title={`${missingContainersCount} ${containersTooltip}`}>
+        <Tooltip placement='bottom' title={ missingContainersCount > 1000 ? `1000+ Containers are missing, for more information go to Containers page.` : `${missingContainersCount} ${containersTooltip}`}>
           <Icon type='exclamation-circle' theme='filled' className='icon-failure icon-small'/>
         </Tooltip>
         <span className='padded-text'>{containers - missingContainersCount}/{containers}</span>

--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/views/overview/overview.tsx
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/views/overview/overview.tsx
@@ -21,7 +21,6 @@ import {Row, Col, Icon, Tooltip} from 'antd';
 import OverviewCard from 'components/overviewCard/overviewCard';
 import axios from 'axios';
 import {IStorageReport} from 'types/datanode.types';
-import {IMissingContainersResponse} from '../missingContainers/missingContainers';
 import moment from 'moment';
 import AutoReloadPanel from 'components/autoReloadPanel/autoReloadPanel';
 import {showDataFetchError} from 'utils/common';
@@ -32,6 +31,7 @@ import './overview.less';
 const size = filesize.partial({round: 1});
 
 interface IClusterStateResponse {
+  missingContainers: number;
   totalDatanodes: number;
   healthyDatanodes: number;
   pipelines: number;
@@ -90,14 +90,12 @@ export class Overview extends React.Component<Record<string, object>, IOverviewS
     });
     axios.all([
       axios.get('/api/v1/clusterState'),
-      axios.get('/api/v1/containers/missing'),
       axios.get('/api/v1/task/status')
-    ]).then(axios.spread((clusterStateResponse, missingContainersResponse,taskstatusResponse) => {
+    ]).then(axios.spread((clusterStateResponse, taskstatusResponse) => {
       
       const clusterState: IClusterStateResponse = clusterStateResponse.data;
-      const missingContainers: IMissingContainersResponse = missingContainersResponse.data;     
       const taskStatus = taskstatusResponse.data;
-      const missingContainersCount = missingContainers.totalCount;
+      const missingContainersCount = clusterState.missingContainers;
       const omDBDeltaObject = taskStatus && taskStatus.find((item:any) => item.taskName === 'OmDeltaRequest');
       const omDBFullObject = taskStatus && taskStatus.find((item:any) => item.taskName === 'OmSnapshotRequest');
     

--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/views/overview/overview.tsx
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/views/overview/overview.tsx
@@ -144,7 +144,7 @@ export class Overview extends React.Component<Record<string, object>, IOverviewS
     const duLink = '/DiskUsage';
     const containersElement = missingContainersCount > 0 ? (
       <span>
-        <Tooltip placement='bottom' title={ missingContainersCount > 1000 ? `1000+ Containers are missing, for more information go to Containers page.` : `${missingContainersCount} ${containersTooltip}`}>
+        <Tooltip placement='bottom' title={ missingContainersCount > 1000 ? `1000+ Containers are missing,  for more information go to Containers page.` : `${missingContainersCount} ${containersTooltip}`}>
           <Icon type='exclamation-circle' theme='filled' className='icon-failure icon-small'/>
         </Tooltip>
         <span className='padded-text'>{containers - missingContainersCount}/{containers}</span>


### PR DESCRIPTION
 What changes were proposed in this pull request?
Remove missingContainer Endpoint and use missingCounter from ClusterState End Point.
On a cluster with million containers, it was observed that the Recon dashboard page does not load even when most of the information has been returned by the backend through the /clusterState API, but the /missing containers API is still blocked.

What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-4402

How was this patch tested?
Manually Tested

![image](https://user-images.githubusercontent.com/112169209/202403326-174b4715-121c-4167-a590-88fc78aa2e88.png)

