### PR TITLE
HDDS-7497. Fix mkdir does not update bucket's usedNamespace

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestOzoneRpcClientAbstract.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestOzoneRpcClientAbstract.java
@@ -1178,11 +1178,10 @@ public abstract class TestOzoneRpcClientAbstract {
   public void testBucketUsedNamespace(BucketLayout layout) throws IOException {
     String volumeName = UUID.randomUUID().toString();
     String bucketName = UUID.randomUUID().toString();
-    OzoneVolume volume = null;
     String value = "sample value";
     int valueLength = value.getBytes(UTF_8).length;
     store.createVolume(volumeName);
-    volume = store.getVolume(volumeName);
+    OzoneVolume volume = store.getVolume(volumeName);
     BucketArgs bucketArgs = BucketArgs.newBuilder()
         .setBucketLayout(layout)
         .build();

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestOzoneRpcClientAbstract.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestOzoneRpcClientAbstract.java
@@ -89,6 +89,7 @@ import org.apache.hadoop.ozone.container.common.interfaces.DBHandle;
 import org.apache.hadoop.ozone.container.keyvalue.KeyValueContainerData;
 import org.apache.hadoop.ozone.container.keyvalue.helpers.BlockUtils;
 import org.apache.hadoop.ozone.container.keyvalue.helpers.KeyValueContainerLocationUtil;
+import org.apache.hadoop.ozone.om.OMConfigKeys;
 import org.apache.hadoop.ozone.om.OMMetadataManager;
 import org.apache.hadoop.ozone.om.OmFailoverProxyUtil;
 import org.apache.hadoop.ozone.om.OzoneManager;
@@ -1083,6 +1084,7 @@ public abstract class TestOzoneRpcClientAbstract {
   static Stream<BucketLayout> bucketLayouts() {
     return Stream.of(
         BucketLayout.OBJECT_STORE,
+        BucketLayout.LEGACY,
         BucketLayout.FILE_SYSTEM_OPTIMIZED
     );
   }
@@ -1187,41 +1189,85 @@ public abstract class TestOzoneRpcClientAbstract {
         .build();
     volume.createBucket(bucketName, bucketArgs);
     OzoneBucket bucket = volume.getBucket(bucketName);
-    String keyName = UUID.randomUUID().toString();
-    store.getVolume(volumeName).getBucket(bucketName);
+    String keyName1 = UUID.randomUUID().toString();
+    String keyName2 = UUID.randomUUID().toString();
 
-    writeKey(bucket, keyName, ONE, value, valueLength);
-    Assert.assertEquals(1L,
-        store.getVolume(volumeName).getBucket(bucketName).getUsedNamespace());
+    writeKey(bucket, keyName1, ONE, value, valueLength);
+    Assert.assertEquals(1L, getBucketUsedNamespace(volumeName, bucketName));
     // Test create a file twice will not increase usedNamespace twice
-    writeKey(bucket, keyName, ONE, value, valueLength);
-    Assert.assertEquals(1L,
-        store.getVolume(volumeName).getBucket(bucketName).getUsedNamespace());
-
-    bucket.deleteKey(keyName);
-    Assert.assertEquals(0L,
-        store.getVolume(volumeName).getBucket(bucketName).getUsedNamespace());
+    writeKey(bucket, keyName1, ONE, value, valueLength);
+    Assert.assertEquals(1L, getBucketUsedNamespace(volumeName, bucketName));
+    writeKey(bucket, keyName2, ONE, value, valueLength);
+    Assert.assertEquals(2L, getBucketUsedNamespace(volumeName, bucketName));
+    bucket.deleteKey(keyName1);
+    Assert.assertEquals(1L, getBucketUsedNamespace(volumeName, bucketName));
+    bucket.deleteKey(keyName2);
+    Assert.assertEquals(0L, getBucketUsedNamespace(volumeName, bucketName));
 
     RpcClient client = new RpcClient(cluster.getConf(), null);
-    String directoryName = UUID.randomUUID().toString();
+    String directoryName1 = UUID.randomUUID().toString();
+    String directoryName2 = UUID.randomUUID().toString();
 
-    client.createDirectory(volumeName, bucketName, directoryName);
-    Assert.assertEquals(1L,
-        store.getVolume(volumeName).getBucket(bucketName).getUsedNamespace());
+    client.createDirectory(volumeName, bucketName, directoryName1);
+    Assert.assertEquals(1L, getBucketUsedNamespace(volumeName, bucketName));
     // Test create a directory twice will not increase usedNamespace twice
-    client.createDirectory(volumeName, bucketName, directoryName);
-    Assert.assertEquals(1L,
-        store.getVolume(volumeName).getBucket(bucketName).getUsedNamespace());
-
+    client.createDirectory(volumeName, bucketName, directoryName2);
+    Assert.assertEquals(2L, getBucketUsedNamespace(volumeName, bucketName));
     client.deleteKey(volumeName, bucketName,
-        OzoneFSUtils.addTrailingSlashIfNeeded(directoryName), false);
-    Assert.assertEquals(0L,
-        store.getVolume(volumeName).getBucket(bucketName).getUsedNamespace());
+        OzoneFSUtils.addTrailingSlashIfNeeded(directoryName1), false);
+    Assert.assertEquals(1L, getBucketUsedNamespace(volumeName, bucketName));
+    client.deleteKey(volumeName, bucketName,
+        OzoneFSUtils.addTrailingSlashIfNeeded(directoryName2), false);
+    Assert.assertEquals(0L, getBucketUsedNamespace(volumeName, bucketName));
 
-    String multiComponentsDir = "a/b/c/d";
+    String multiComponentsDir = "dir1/dir2/dir3/dir4";
     client.createDirectory(volumeName, bucketName, multiComponentsDir);
     Assert.assertEquals(OzoneFSUtils.getFileCount(multiComponentsDir),
-        store.getVolume(volumeName).getBucket(bucketName).getUsedNamespace());
+        getBucketUsedNamespace(volumeName, bucketName));
+  }
+
+  @ParameterizedTest
+  @MethodSource("bucketLayouts")
+  public void testMissingParentBucketUsedNamespace(BucketLayout layout)
+      throws IOException {
+    // when will put a key that contain not exist directory only FSO buckets
+    // and LEGACY buckets with ozone.om.enable.filesystem.paths set to true
+    // will create missing directories.
+    String volumeName = UUID.randomUUID().toString();
+    String bucketName = UUID.randomUUID().toString();
+    String value = "sample value";
+    int valueLength = value.getBytes(UTF_8).length;
+    store.createVolume(volumeName);
+    OzoneVolume volume = store.getVolume(volumeName);
+    BucketArgs bucketArgs = BucketArgs.newBuilder()
+        .setBucketLayout(layout)
+        .build();
+    volume.createBucket(bucketName, bucketArgs);
+    OzoneBucket bucket = volume.getBucket(bucketName);
+
+    if (layout.equals(BucketLayout.LEGACY)) {
+      OzoneConfiguration conf = cluster.getConf();
+      conf.setBoolean(OMConfigKeys.OZONE_OM_ENABLE_FILESYSTEM_PATHS, true);
+      cluster.setConf(conf);
+    }
+
+    // the directory "/dir1", ""/dir1/dir2/", "/dir1/dir2/dir3/"
+    // will be created automatically
+    String missingParentKeyName = "dir1/dir2/dir3/file1";
+    writeKey(bucket, missingParentKeyName, ONE, value, valueLength);
+    if (layout.equals(BucketLayout.OBJECT_STORE)) {
+      // for OBJECT_STORE bucket, missing parent will not be
+      // created automatically
+      Assert.assertEquals(1, getBucketUsedNamespace(volumeName, bucketName));
+    } else {
+      Assert.assertEquals(OzoneFSUtils.getFileCount(missingParentKeyName),
+          getBucketUsedNamespace(volumeName, bucketName));
+    }
+  }
+
+  private long getBucketUsedNamespace(String volume, String bucket)
+      throws IOException {
+    return store.getVolume(volume).getBucket(bucket).getUsedNamespace();
   }
 
   @Test

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestOzoneRpcClientAbstract.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestOzoneRpcClientAbstract.java
@@ -1194,7 +1194,7 @@ public abstract class TestOzoneRpcClientAbstract {
     writeKey(bucket, keyName, ONE, value, valueLength);
     Assert.assertEquals(1L,
         store.getVolume(volumeName).getBucket(bucketName).getUsedNamespace());
-
+    // Test create a file twice will not increase usedNamespace twice
     writeKey(bucket, keyName, ONE, value, valueLength);
     Assert.assertEquals(1L,
         store.getVolume(volumeName).getBucket(bucketName).getUsedNamespace());
@@ -1209,7 +1209,7 @@ public abstract class TestOzoneRpcClientAbstract {
     client.createDirectory(volumeName, bucketName, directoryName);
     Assert.assertEquals(1L,
         store.getVolume(volumeName).getBucket(bucketName).getUsedNamespace());
-
+    // Test create a directory twice will not increase usedNamespace twice
     client.createDirectory(volumeName, bucketName, directoryName);
     Assert.assertEquals(1L,
         store.getVolume(volumeName).getBucket(bucketName).getUsedNamespace());

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/file/OMDirectoryCreateRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/file/OMDirectoryCreateRequest.java
@@ -221,8 +221,8 @@ public class OMDirectoryCreateRequest extends OMKeyRequest {
         omBucketInfo.incrUsedNamespace(numMissingParents + 1L);
         result = Result.SUCCESS;
         omClientResponse = new OMDirectoryCreateResponse(omResponse.build(),
-            dirKeyInfo, missingParentInfos, omBucketInfo.copyObject(),
-            result, getBucketLayout());
+            dirKeyInfo, missingParentInfos, result, getBucketLayout(),
+            omBucketInfo.copyObject());
       } else {
         // omDirectoryResult == DIRECTORY_EXITS
         result = Result.DIRECTORY_ALREADY_EXISTS;

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/file/OMDirectoryCreateRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/file/OMDirectoryCreateRequest.java
@@ -36,6 +36,7 @@ import org.apache.hadoop.ozone.om.helpers.OmKeyLocationInfoGroup;
 import org.apache.hadoop.ozone.om.helpers.OzoneAclUtil;
 import org.apache.hadoop.ozone.om.helpers.OzoneFSUtils;
 import org.apache.hadoop.ozone.om.helpers.BucketLayout;
+import org.apache.hadoop.ozone.om.helpers.OmBucketInfo;
 import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
 import org.apache.hadoop.ozone.om.ratis.utils.OzoneManagerDoubleBufferHelper;
 import org.apache.hadoop.ozone.om.request.util.OmResponseUtil;
@@ -215,6 +216,9 @@ public class OMDirectoryCreateRequest extends OMKeyRequest {
         OMFileRequest.addKeyTableCacheEntries(omMetadataManager, volumeName,
             bucketName, Optional.of(dirKeyInfo),
             Optional.of(missingParentInfos), trxnLogIndex);
+        OmBucketInfo omBucketInfo =
+            getBucketInfo(omMetadataManager, volumeName, bucketName);
+        omBucketInfo.incrUsedNamespace(numMissingParents + 1L);
         result = Result.SUCCESS;
         omClientResponse = new OMDirectoryCreateResponse(omResponse.build(),
             dirKeyInfo, missingParentInfos, result, getBucketLayout());

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/file/OMDirectoryCreateRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/file/OMDirectoryCreateRequest.java
@@ -221,7 +221,8 @@ public class OMDirectoryCreateRequest extends OMKeyRequest {
         omBucketInfo.incrUsedNamespace(numMissingParents + 1L);
         result = Result.SUCCESS;
         omClientResponse = new OMDirectoryCreateResponse(omResponse.build(),
-            dirKeyInfo, missingParentInfos, result, getBucketLayout());
+            dirKeyInfo, missingParentInfos, omBucketInfo,
+            result, getBucketLayout());
       } else {
         // omDirectoryResult == DIRECTORY_EXITS
         result = Result.DIRECTORY_ALREADY_EXISTS;

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/file/OMDirectoryCreateRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/file/OMDirectoryCreateRequest.java
@@ -221,7 +221,7 @@ public class OMDirectoryCreateRequest extends OMKeyRequest {
         omBucketInfo.incrUsedNamespace(numMissingParents + 1L);
         result = Result.SUCCESS;
         omClientResponse = new OMDirectoryCreateResponse(omResponse.build(),
-            dirKeyInfo, missingParentInfos, omBucketInfo,
+            dirKeyInfo, missingParentInfos, omBucketInfo.copyObject(),
             result, getBucketLayout());
       } else {
         // omDirectoryResult == DIRECTORY_EXITS

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/file/OMDirectoryCreateRequestWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/file/OMDirectoryCreateRequestWithFSO.java
@@ -27,6 +27,7 @@ import org.apache.hadoop.ozone.om.OMMetrics;
 import org.apache.hadoop.ozone.om.OzoneManager;
 import org.apache.hadoop.ozone.om.exceptions.OMException;
 import org.apache.hadoop.ozone.om.helpers.BucketLayout;
+import org.apache.hadoop.ozone.om.helpers.OmBucketInfo;
 import org.apache.hadoop.ozone.om.helpers.OmDirectoryInfo;
 import org.apache.hadoop.ozone.om.helpers.OzoneAclUtil;
 import org.apache.hadoop.ozone.om.ratis.utils.OzoneManagerDoubleBufferHelper;
@@ -172,6 +173,9 @@ public class OMDirectoryCreateRequestWithFSO extends OMDirectoryCreateRequest {
 
         // total number of keys created.
         numKeysCreated = missingParentInfos.size() + 1;
+        OmBucketInfo omBucketInfo =
+            getBucketInfo(omMetadataManager, volumeName, bucketName);
+        omBucketInfo.incrUsedNamespace(numKeysCreated);
 
         result = OMDirectoryCreateRequest.Result.SUCCESS;
         omClientResponse =

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/file/OMDirectoryCreateRequestWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/file/OMDirectoryCreateRequestWithFSO.java
@@ -180,8 +180,8 @@ public class OMDirectoryCreateRequestWithFSO extends OMDirectoryCreateRequest {
         result = OMDirectoryCreateRequest.Result.SUCCESS;
         omClientResponse =
             new OMDirectoryCreateResponseWithFSO(omResponse.build(),
-                volumeId, bucketId, dirInfo, missingParentInfos, omBucketInfo,
-                result, getBucketLayout());
+                volumeId, bucketId, dirInfo, missingParentInfos,
+                omBucketInfo.copyObject(), result, getBucketLayout());
       } else {
         result = Result.DIRECTORY_ALREADY_EXISTS;
         omResponse.setStatus(Status.DIRECTORY_ALREADY_EXISTS);

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/file/OMDirectoryCreateRequestWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/file/OMDirectoryCreateRequestWithFSO.java
@@ -180,8 +180,8 @@ public class OMDirectoryCreateRequestWithFSO extends OMDirectoryCreateRequest {
         result = OMDirectoryCreateRequest.Result.SUCCESS;
         omClientResponse =
             new OMDirectoryCreateResponseWithFSO(omResponse.build(),
-                volumeId, bucketId, dirInfo, missingParentInfos, result,
-                getBucketLayout());
+                volumeId, bucketId, dirInfo, missingParentInfos, omBucketInfo,
+                result, getBucketLayout());
       } else {
         result = Result.DIRECTORY_ALREADY_EXISTS;
         omResponse.setStatus(Status.DIRECTORY_ALREADY_EXISTS);

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/file/OMDirectoryCreateRequestWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/file/OMDirectoryCreateRequestWithFSO.java
@@ -180,8 +180,8 @@ public class OMDirectoryCreateRequestWithFSO extends OMDirectoryCreateRequest {
         result = OMDirectoryCreateRequest.Result.SUCCESS;
         omClientResponse =
             new OMDirectoryCreateResponseWithFSO(omResponse.build(),
-                volumeId, bucketId, dirInfo, missingParentInfos,
-                omBucketInfo.copyObject(), result, getBucketLayout());
+                volumeId, bucketId, dirInfo, missingParentInfos, result,
+                getBucketLayout(), omBucketInfo.copyObject());
       } else {
         result = Result.DIRECTORY_ALREADY_EXISTS;
         omResponse.setStatus(Status.DIRECTORY_ALREADY_EXISTS);

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyCreateRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyCreateRequest.java
@@ -319,6 +319,7 @@ public class OMKeyCreateRequest extends OMKeyRequest {
           new CacheKey<>(dbOpenKeyName),
           new CacheValue<>(Optional.of(omKeyInfo), trxnLogIndex));
 
+      omBucketInfo.incrUsedNamespace(numMissingParents);
       // Prepare response
       omResponse.setCreateKeyResponse(CreateKeyResponse.newBuilder()
           .setKeyInfo(omKeyInfo.getNetworkProtobuf(getOmRequest().getVersion(),

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyCreateRequestWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyCreateRequestWithFSO.java
@@ -204,6 +204,7 @@ public class OMKeyCreateRequestWithFSO extends OMKeyCreateRequest {
       // Prepare response. Sets user given full key name in the 'keyName'
       // attribute in response object.
       int clientVersion = getOmRequest().getVersion();
+      omBucketInfo.incrUsedNamespace(numKeysCreated);
       omResponse.setCreateKeyResponse(CreateKeyResponse.newBuilder()
               .setKeyInfo(omFileInfo.getNetworkProtobuf(keyName, clientVersion,
                   keyArgs.getLatestVersionLocation()))

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/file/OMDirectoryCreateResponse.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/file/OMDirectoryCreateResponse.java
@@ -54,13 +54,13 @@ public class OMDirectoryCreateResponse extends OmKeyResponse {
 
   public OMDirectoryCreateResponse(@Nonnull OMResponse omResponse,
       @Nonnull OmKeyInfo dirKeyInfo,
-      @Nonnull List<OmKeyInfo> parentKeyInfos, @Nonnull OmBucketInfo bucketInfo,
-      @Nonnull Result result, @Nonnull BucketLayout bucketLayout) {
+      @Nonnull List<OmKeyInfo> parentKeyInfos, @Nonnull Result result,
+      @Nonnull BucketLayout bucketLayout, @Nonnull OmBucketInfo bucketInfo) {
     super(omResponse, bucketLayout);
     this.dirKeyInfo = dirKeyInfo;
     this.parentKeyInfos = parentKeyInfos;
-    this.bucketInfo = bucketInfo;
     this.result = result;
+    this.bucketInfo = bucketInfo;
   }
 
   /**

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/file/OMDirectoryCreateResponse.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/file/OMDirectoryCreateResponse.java
@@ -20,6 +20,7 @@ package org.apache.hadoop.ozone.om.response.file;
 
 import org.apache.hadoop.ozone.om.OMMetadataManager;
 import org.apache.hadoop.ozone.om.helpers.BucketLayout;
+import org.apache.hadoop.ozone.om.helpers.OmBucketInfo;
 import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
 import org.apache.hadoop.ozone.om.response.CleanupTableInfo;
 import org.apache.hadoop.ozone.om.request.file.OMDirectoryCreateRequest.Result;
@@ -49,14 +50,16 @@ public class OMDirectoryCreateResponse extends OmKeyResponse {
   private OmKeyInfo dirKeyInfo;
   private List<OmKeyInfo> parentKeyInfos;
   private Result result;
+  private OmBucketInfo bucketInfo;
 
   public OMDirectoryCreateResponse(@Nonnull OMResponse omResponse,
       @Nonnull OmKeyInfo dirKeyInfo,
-      @Nonnull List<OmKeyInfo> parentKeyInfos, @Nonnull Result result,
-      @Nonnull BucketLayout bucketLayout) {
+      @Nonnull List<OmKeyInfo> parentKeyInfos, @Nonnull OmBucketInfo bucketInfo,
+      @Nonnull Result result, @Nonnull BucketLayout bucketLayout) {
     super(omResponse, bucketLayout);
     this.dirKeyInfo = dirKeyInfo;
     this.parentKeyInfos = parentKeyInfos;
+    this.bucketInfo = bucketInfo;
     this.result = result;
   }
 
@@ -89,6 +92,10 @@ public class OMDirectoryCreateResponse extends OmKeyResponse {
           dirKeyInfo.getBucketName(), dirKeyInfo.getKeyName());
       omMetadataManager.getKeyTable(getBucketLayout())
           .putWithBatch(batchOperation, dirKey, dirKeyInfo);
+      String bucketKey = omMetadataManager.getBucketKey(
+          bucketInfo.getVolumeName(), bucketInfo.getBucketName());
+      omMetadataManager.getBucketTable().putWithBatch(batchOperation,
+          bucketKey, bucketInfo);
     } else if (Result.DIRECTORY_ALREADY_EXISTS == result) {
       // When directory already exists, we don't add it to cache. And it is
       // not an error, in this case dirKeyInfo will be null.

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/file/OMDirectoryCreateResponseWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/file/OMDirectoryCreateResponseWithFSO.java
@@ -56,16 +56,15 @@ public class OMDirectoryCreateResponseWithFSO extends OmKeyResponse {
   public OMDirectoryCreateResponseWithFSO(@Nonnull OMResponse omResponse,
       @Nonnull long volumeId, @Nonnull long bucketId,
       @Nonnull OmDirectoryInfo dirInfo,
-      @Nonnull List<OmDirectoryInfo> pDirInfos,
-      @Nonnull OmBucketInfo bucketInfo, @Nonnull Result result,
-      @Nonnull BucketLayout bucketLayout) {
+      @Nonnull List<OmDirectoryInfo> pDirInfos, @Nonnull Result result,
+      @Nonnull BucketLayout bucketLayout, @Nonnull OmBucketInfo bucketInfo) {
     super(omResponse, bucketLayout);
     this.dirInfo = dirInfo;
     this.parentDirInfos = pDirInfos;
-    this.bucketInfo = bucketInfo;
     this.result = result;
     this.volumeId = volumeId;
     this.bucketId = bucketId;
+    this.bucketInfo = bucketInfo;
   }
 
   /**

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/file/OMDirectoryCreateResponseWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/file/OMDirectoryCreateResponseWithFSO.java
@@ -21,6 +21,7 @@ package org.apache.hadoop.ozone.om.response.file;
 import org.apache.hadoop.hdds.utils.db.BatchOperation;
 import org.apache.hadoop.ozone.om.OMMetadataManager;
 import org.apache.hadoop.ozone.om.helpers.BucketLayout;
+import org.apache.hadoop.ozone.om.helpers.OmBucketInfo;
 import org.apache.hadoop.ozone.om.helpers.OmDirectoryInfo;
 import org.apache.hadoop.ozone.om.request.file.OMDirectoryCreateRequest.Result;
 import org.apache.hadoop.ozone.om.response.CleanupTableInfo;
@@ -49,15 +50,19 @@ public class OMDirectoryCreateResponseWithFSO extends OmKeyResponse {
   private Result result;
   private long volumeId;
   private long bucketId;
+  private OmBucketInfo bucketInfo;
 
+  @SuppressWarnings("checkstyle:ParameterNumber")
   public OMDirectoryCreateResponseWithFSO(@Nonnull OMResponse omResponse,
       @Nonnull long volumeId, @Nonnull long bucketId,
       @Nonnull OmDirectoryInfo dirInfo,
-      @Nonnull List<OmDirectoryInfo> pDirInfos, @Nonnull Result result,
+      @Nonnull List<OmDirectoryInfo> pDirInfos,
+      @Nonnull OmBucketInfo bucketInfo, @Nonnull Result result,
       @Nonnull BucketLayout bucketLayout) {
     super(omResponse, bucketLayout);
     this.dirInfo = dirInfo;
     this.parentDirInfos = pDirInfos;
+    this.bucketInfo = bucketInfo;
     this.result = result;
     this.volumeId = volumeId;
     this.bucketId = bucketId;
@@ -100,6 +105,10 @@ public class OMDirectoryCreateResponseWithFSO extends OmKeyResponse {
               dirInfo.getParentObjectID(), dirInfo.getName());
       omMetadataManager.getDirectoryTable().putWithBatch(batchOperation, dirKey,
               dirInfo);
+      String bucketKey = omMetadataManager.getBucketKey(
+          bucketInfo.getVolumeName(), bucketInfo.getBucketName());
+      omMetadataManager.getBucketTable().putWithBatch(batchOperation,
+          bucketKey, bucketInfo);
     } else {
       // When directory already exists, we don't add it to cache. And it is
       // not an error, in this case dirKeyInfo will be null.

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/file/TestOMDirectoryCreateRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/file/TestOMDirectoryCreateRequest.java
@@ -41,6 +41,7 @@ import org.mockito.Mockito;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.ozone.audit.AuditLogger;
 import org.apache.hadoop.ozone.audit.AuditMessage;
+import org.apache.hadoop.ozone.om.helpers.OmBucketInfo;
 import org.apache.hadoop.ozone.om.OMConfigKeys;
 import org.apache.hadoop.ozone.om.OMMetadataManager;
 import org.apache.hadoop.ozone.om.OMMetrics;
@@ -156,6 +157,10 @@ public class TestOMDirectoryCreateRequest {
         .get(omMetadataManager.getOzoneDirKey(volumeName, bucketName, keyName))
         != null);
 
+    OmBucketInfo bucketInfo = omMetadataManager.getBucketTable()
+        .get(omMetadataManager.getBucketKey(volumeName, bucketName));
+    Assert.assertEquals(OzoneFSUtils.getFileCount(keyName),
+        bucketInfo.getUsedNamespace());
   }
 
   @Test

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/file/TestOMDirectoryCreateRequestWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/file/TestOMDirectoryCreateRequestWithFSO.java
@@ -165,6 +165,11 @@ public class TestOMDirectoryCreateRequestWithFSO {
     Assert.assertTrue(omClientResponse.getOMResponse().getStatus()
             == OzoneManagerProtocolProtos.Status.OK);
     verifyDirectoriesInDB(dirs, volumeId, bucketId);
+
+    OmBucketInfo bucketInfo = omMetadataManager.getBucketTable()
+        .get(omMetadataManager.getBucketKey(volumeName, bucketName));
+    Assert.assertEquals(OzoneFSUtils.getFileCount(keyName),
+        bucketInfo.getUsedNamespace());
   }
 
   @Test

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/file/TestOMDirectoryCreateResponse.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/file/TestOMDirectoryCreateResponse.java
@@ -20,14 +20,17 @@ package org.apache.hadoop.ozone.om.response.file;
 
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
+import org.apache.hadoop.hdds.utils.db.Table;
 import org.apache.hadoop.ozone.om.OMConfigKeys;
 import org.apache.hadoop.ozone.om.OMMetadataManager;
 import org.apache.hadoop.ozone.om.OmMetadataManagerImpl;
 import org.apache.hadoop.ozone.om.helpers.BucketLayout;
+import org.apache.hadoop.ozone.om.helpers.OmBucketInfo;
 import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
 import org.apache.hadoop.ozone.om.helpers.OzoneFSUtils;
 import org.apache.hadoop.ozone.om.request.OMRequestTestUtils;
 import org.apache.hadoop.ozone.om.request.file.OMDirectoryCreateRequest.Result;
+import org.apache.hadoop.ozone.om.response.TestOMResponseUtils;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos
     .OMResponse;
@@ -40,6 +43,7 @@ import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
 import java.util.ArrayList;
+import java.util.Random;
 import java.util.UUID;
 
 /**
@@ -79,6 +83,13 @@ public class TestOMDirectoryCreateResponse {
         bucketName, OzoneFSUtils.addTrailingSlashIfNeeded(keyName),
         HddsProtos.ReplicationType.RATIS, HddsProtos.ReplicationFactor.ONE);
 
+    Random random = new Random();
+    long usedNamespace = Math.abs(random.nextLong());
+    OmBucketInfo omBucketInfo = TestOMResponseUtils.createBucket(
+        volumeName, bucketName);
+    omBucketInfo = omBucketInfo.toBuilder()
+        .setUsedNamespace(usedNamespace).build();
+
     OMResponse omResponse = OMResponse.newBuilder().setCreateDirectoryResponse(
         OzoneManagerProtocolProtos.CreateDirectoryResponse.getDefaultInstance())
             .setStatus(OzoneManagerProtocolProtos.Status.OK)
@@ -87,7 +98,7 @@ public class TestOMDirectoryCreateResponse {
 
     OMDirectoryCreateResponse omDirectoryCreateResponse =
         new OMDirectoryCreateResponse(omResponse, omKeyInfo,
-            new ArrayList<>(), Result.SUCCESS, getBucketLayout());
+            new ArrayList<>(), omBucketInfo, Result.SUCCESS, getBucketLayout());
 
     omDirectoryCreateResponse.addToDBBatch(omMetadataManager, batchOperation);
 
@@ -96,6 +107,12 @@ public class TestOMDirectoryCreateResponse {
 
     Assert.assertNotNull(omMetadataManager.getKeyTable(getBucketLayout()).get(
         omMetadataManager.getOzoneDirKey(volumeName, bucketName, keyName)));
+
+    Table.KeyValue<String, OmBucketInfo> keyValue =
+        omMetadataManager.getBucketTable().iterator().next();
+    Assert.assertEquals(omMetadataManager.getBucketKey(volumeName,
+        bucketName), keyValue.getKey());
+    Assert.assertEquals(usedNamespace, keyValue.getValue().getUsedNamespace());
   }
 
   public BucketLayout getBucketLayout() {

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/file/TestOMDirectoryCreateResponse.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/file/TestOMDirectoryCreateResponse.java
@@ -98,7 +98,7 @@ public class TestOMDirectoryCreateResponse {
 
     OMDirectoryCreateResponse omDirectoryCreateResponse =
         new OMDirectoryCreateResponse(omResponse, omKeyInfo,
-            new ArrayList<>(), omBucketInfo, Result.SUCCESS, getBucketLayout());
+            new ArrayList<>(), Result.SUCCESS, getBucketLayout(), omBucketInfo);
 
     omDirectoryCreateResponse.addToDBBatch(omMetadataManager, batchOperation);
 

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/file/TestOMDirectoryCreateResponse.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/file/TestOMDirectoryCreateResponse.java
@@ -43,8 +43,8 @@ import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
 import java.util.ArrayList;
-import java.util.Random;
 import java.util.UUID;
+import java.util.concurrent.ThreadLocalRandom;
 
 /**
  * Tests OMDirectoryCreateResponse.
@@ -83,8 +83,8 @@ public class TestOMDirectoryCreateResponse {
         bucketName, OzoneFSUtils.addTrailingSlashIfNeeded(keyName),
         HddsProtos.ReplicationType.RATIS, HddsProtos.ReplicationFactor.ONE);
 
-    Random random = new Random();
-    long usedNamespace = Math.abs(random.nextLong());
+    ThreadLocalRandom random = ThreadLocalRandom.current();
+    long usedNamespace = Math.abs(random.nextLong(Long.MAX_VALUE));
     OmBucketInfo omBucketInfo = TestOMResponseUtils.createBucket(
         volumeName, bucketName);
     omBucketInfo = omBucketInfo.toBuilder()

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/file/TestOMDirectoryCreateResponseWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/file/TestOMDirectoryCreateResponseWithFSO.java
@@ -45,8 +45,8 @@ import org.junit.rules.TemporaryFolder;
 
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Random;
 import java.util.UUID;
+import java.util.concurrent.ThreadLocalRandom;
 
 /**
  * Tests OMDirectoryCreateResponseWithFSO - prefix layout.
@@ -89,8 +89,8 @@ public class TestOMDirectoryCreateResponseWithFSO {
             .setStatus(OzoneManagerProtocolProtos.Status.OK)
             .setCmdType(OzoneManagerProtocolProtos.Type.CreateDirectory)
             .build();
-    Random random = new Random();
-    long usedNamespace = Math.abs(random.nextLong());
+    ThreadLocalRandom random = ThreadLocalRandom.current();
+    long usedNamespace = Math.abs(random.nextLong(Long.MAX_VALUE));
     OmBucketInfo omBucketInfo = TestOMResponseUtils.createBucket(
         volumeName, bucketName);
     omBucketInfo = omBucketInfo.toBuilder()

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/file/TestOMDirectoryCreateResponseWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/file/TestOMDirectoryCreateResponseWithFSO.java
@@ -24,6 +24,7 @@ import org.apache.hadoop.hdds.protocol.StorageType;
 import org.apache.hadoop.hdds.utils.db.BatchOperation;
 import org.apache.hadoop.hdds.utils.db.cache.CacheKey;
 import org.apache.hadoop.hdds.utils.db.cache.CacheValue;
+import org.apache.hadoop.hdds.utils.db.Table;
 import org.apache.hadoop.ozone.om.OMConfigKeys;
 import org.apache.hadoop.ozone.om.OMMetadataManager;
 import org.apache.hadoop.ozone.om.OmMetadataManagerImpl;
@@ -33,6 +34,7 @@ import org.apache.hadoop.ozone.om.helpers.OmDirectoryInfo;
 import org.apache.hadoop.ozone.om.helpers.OmVolumeArgs;
 import org.apache.hadoop.ozone.om.request.OMRequestTestUtils;
 import org.apache.hadoop.ozone.om.request.file.OMDirectoryCreateRequestWithFSO;
+import org.apache.hadoop.ozone.om.response.TestOMResponseUtils;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMResponse;
 import org.junit.Assert;
@@ -43,6 +45,7 @@ import org.junit.rules.TemporaryFolder;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Random;
 import java.util.UUID;
 
 /**
@@ -67,6 +70,8 @@ public class TestOMDirectoryCreateResponseWithFSO {
   @Test
   public void testAddToDBBatch() throws Exception {
 
+    String volumeName = UUID.randomUUID().toString();
+    String bucketName = UUID.randomUUID().toString();
     String keyName = UUID.randomUUID().toString();
 
     final String volume = "volume";
@@ -84,10 +89,16 @@ public class TestOMDirectoryCreateResponseWithFSO {
             .setStatus(OzoneManagerProtocolProtos.Status.OK)
             .setCmdType(OzoneManagerProtocolProtos.Type.CreateDirectory)
             .build();
+    Random random = new Random();
+    long usedNamespace = Math.abs(random.nextLong());
+    OmBucketInfo omBucketInfo = TestOMResponseUtils.createBucket(
+        volumeName, bucketName);
+    omBucketInfo = omBucketInfo.toBuilder()
+        .setUsedNamespace(usedNamespace).build();
 
     OMDirectoryCreateResponseWithFSO omDirectoryCreateResponseWithFSO =
         new OMDirectoryCreateResponseWithFSO(omResponse, volumeId, bucketId,
-                omDirInfo, new ArrayList<>(),
+                omDirInfo, new ArrayList<>(), omBucketInfo,
                 OMDirectoryCreateRequestWithFSO.Result.SUCCESS,
                 BucketLayout.FILE_SYSTEM_OPTIMIZED);
 
@@ -100,6 +111,12 @@ public class TestOMDirectoryCreateResponseWithFSO {
     Assert.assertNotNull(omMetadataManager.getDirectoryTable().get(
             omMetadataManager.getOzonePathKey(volumeId, bucketId,
                     parentID, keyName)));
+
+    Table.KeyValue<String, OmBucketInfo> keyValue =
+        omMetadataManager.getBucketTable().iterator().next();
+    Assert.assertEquals(omMetadataManager.getBucketKey(volumeName,
+        bucketName), keyValue.getKey());
+    Assert.assertEquals(usedNamespace, keyValue.getValue().getUsedNamespace());
   }
 
   private void addVolumeToDB(String volumeName) throws IOException {

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/file/TestOMDirectoryCreateResponseWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/file/TestOMDirectoryCreateResponseWithFSO.java
@@ -98,9 +98,9 @@ public class TestOMDirectoryCreateResponseWithFSO {
 
     OMDirectoryCreateResponseWithFSO omDirectoryCreateResponseWithFSO =
         new OMDirectoryCreateResponseWithFSO(omResponse, volumeId, bucketId,
-                omDirInfo, new ArrayList<>(), omBucketInfo,
+                omDirInfo, new ArrayList<>(),
                 OMDirectoryCreateRequestWithFSO.Result.SUCCESS,
-                BucketLayout.FILE_SYSTEM_OPTIMIZED);
+                BucketLayout.FILE_SYSTEM_OPTIMIZED, omBucketInfo);
 
     omDirectoryCreateResponseWithFSO
         .addToDBBatch(omMetadataManager, batchOperation);


### PR DESCRIPTION
## What changes were proposed in this pull request?
Fix `Ozone` fs `mkdir` does not update bucket's `usedNamespace`

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-7497

## How was this patch tested?
Before this PR: 
Bucket property `usedNamespace` will become negative after delete a directory, because the `mkdir` will not increase the `usedNamespace` of bucket but `rmdir` will decrease `usedNamespace`.
```java
"usedNamespace" can be updated when `mkdir`

[root@Linux /root/ozone]% ozone sh bucket create s3v/bucket1
[root@Linux /root/ozone]% ozone fs -mkdir ofs://localhost/s3v/bucket1/dir1
[root@Linux /root/ozone]% ozone sh bucket info s3v/bucket1
{
  "metadata" : { },
  "volumeName" : "s3v",
  "name" : "bucket1",
  "storageType" : "DISK",
  "versioning" : false,
  "usedBytes" : 0,
  "usedNamespace" : 0,
  "creationTime" : "2022-11-16T11:17:26.512Z",
  "modificationTime" : "2022-11-16T11:17:26.512Z",
  "quotaInBytes" : -1,
  "quotaInNamespace" : -1,
  "bucketLayout" : "OBJECT_STORE",
  "owner" : "root"
}

[root@Linux /root/ozone]% ozone fs -rmdir ofs://localhost/s3v/bucket1/dir1
[root@Linux /root/ozone]% ozone sh bucket info s3v/bucket1
{
  "metadata" : { },
  "volumeName" : "s3v",
  "name" : "bucket1",
  "storageType" : "DISK",
  "versioning" : false,
  "usedBytes" : 0,
  "usedNamespace" : -1,
  "creationTime" : "2022-11-16T11:17:26.512Z",
  "modificationTime" : "2022-11-16T11:17:26.512Z",
  "quotaInBytes" : -1,
  "quotaInNamespace" : -1,
  "bucketLayout" : "OBJECT_STORE",
  "owner" : "root"
}
[root@Linux /root/ozone]%
```
---

After this PR:
Bucket property `usedNamespace` will not be negative
```java
[root@Linux /root/ozone]% ozone sh bucket create s3v/bucket1
[root@Linux /root/ozone]% ozone fs -mkdir ofs://localhost/s3v/bucket1/dir1
[root@Linux /root/ozone]% ozone sh bucket info s3v/bucket1
{
  "metadata" : { },
  "volumeName" : "s3v",
  "name" : "bucket1",
  "storageType" : "DISK",
  "versioning" : false,
  "usedBytes" : 0,
  "usedNamespace" : 1,
  "creationTime" : "2022-11-16T11:17:26.512Z",
  "modificationTime" : "2022-11-16T11:17:26.512Z",
  "quotaInBytes" : -1,
  "quotaInNamespace" : -1,
  "bucketLayout" : "OBJECT_STORE",
  "owner" : "root"
}

[root@Linux /root/ozone]% ozone fs -rmdir ofs://localhost/s3v/bucket1/dir1
[root@Linux /root/ozone]% ozone sh bucket info s3v/bucket1
{
  "metadata" : { },
  "volumeName" : "s3v",
  "name" : "bucket1",
  "storageType" : "DISK",
  "versioning" : false,
  "usedBytes" : 0,
  "usedNamespace" : 0,
  "creationTime" : "2022-11-16T11:17:26.512Z",
  "modificationTime" : "2022-11-16T11:17:26.512Z",
  "quotaInBytes" : -1,
  "quotaInNamespace" : -1,
  "bucketLayout" : "OBJECT_STORE",
  "owner" : "root"
}
[root@Linux /root/ozone]%

`FSO` bucket will have the same result as above
```

