### PR TITLE
HDDS-7443. CLI admin namespace -quota should return whole file system disk capacity consumed by all replicas

### DIFF
--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/api/handlers/BucketEntityHandler.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/api/handlers/BucketEntityHandler.java
@@ -126,15 +126,16 @@ public class BucketEntityHandler extends EntityHandler {
   public QuotaUsageResponse getQuotaResponse()
           throws IOException {
     QuotaUsageResponse quotaUsageResponse = new QuotaUsageResponse();
-    String[] names = getNames();
-    String bucketKey = getOmMetadataManager().getBucketKey(names[0], names[1]);
-    OmBucketInfo bucketInfo = getOmMetadataManager()
-            .getBucketTable().getSkipCache(bucketKey);
-    long bucketObjectId = bucketInfo.getObjectID();
-    long quotaInBytes = bucketInfo.getQuotaInBytes();
-    long quotaUsedInBytes = getTotalSize(bucketObjectId);
-    quotaUsageResponse.setQuota(quotaInBytes);
-    quotaUsageResponse.setQuotaUsed(quotaUsedInBytes);
+    RootEntityHandler rootEntityHandler = new RootEntityHandler(
+      getReconNamespaceSummaryManager(),
+      getOmMetadataManager(),
+      getReconSCM(),
+      "/"
+    );
+    QuotaUsageResponse rootQuotaUsageResponse= rootEntityHandler.getQuotaResponse();
+
+    quotaUsageResponse.setQuota(rootQuotaUsageResponse.getQuota());
+    quotaUsageResponse.setQuotaUsed(rootQuotaUsageResponse.getQuotaUsed());
     return quotaUsageResponse;
   }
 

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/api/handlers/BucketEntityHandler.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/api/handlers/BucketEntityHandler.java
@@ -18,7 +18,6 @@
 package org.apache.hadoop.ozone.recon.api.handlers;
 
 import org.apache.hadoop.hdds.scm.server.OzoneStorageContainerManager;
-import org.apache.hadoop.ozone.om.helpers.OmBucketInfo;
 import org.apache.hadoop.ozone.recon.api.types.NamespaceSummaryResponse;
 import org.apache.hadoop.ozone.recon.api.types.EntityType;
 import org.apache.hadoop.ozone.recon.api.types.DUResponse;
@@ -127,12 +126,13 @@ public class BucketEntityHandler extends EntityHandler {
           throws IOException {
     QuotaUsageResponse quotaUsageResponse = new QuotaUsageResponse();
     RootEntityHandler rootEntityHandler = new RootEntityHandler(
-      getReconNamespaceSummaryManager(),
-      getOmMetadataManager(),
-      getReconSCM(),
-      "/"
+        getReconNamespaceSummaryManager(),
+        getOmMetadataManager(),
+        getReconSCM(),
+        "/"
     );
-    QuotaUsageResponse rootQuotaUsageResponse= rootEntityHandler.getQuotaResponse();
+    QuotaUsageResponse rootQuotaUsageResponse = 
+        rootEntityHandler.getQuotaResponse();
 
     quotaUsageResponse.setQuota(rootQuotaUsageResponse.getQuota());
     quotaUsageResponse.setQuotaUsed(rootQuotaUsageResponse.getQuotaUsed());

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/api/handlers/RootEntityHandler.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/api/handlers/RootEntityHandler.java
@@ -28,6 +28,8 @@ import org.apache.hadoop.ozone.recon.api.types.QuotaUsageResponse;
 import org.apache.hadoop.ozone.recon.api.types.FileSizeDistributionResponse;
 import org.apache.hadoop.ozone.recon.recovery.ReconOMMetadataManager;
 import org.apache.hadoop.ozone.recon.spi.ReconNamespaceSummaryManager;
+import org.apache.hadoop.hdds.scm.container.placement.metrics.SCMNodeStat;
+
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -132,7 +134,7 @@ public class RootEntityHandler extends EntityHandler {
 
     SCMNodeStat stats = getReconSCM().getScmNodeManager().getStats();
     long quotaInBytes = stats.getCapacity().get();
-    long quotaUsedInBytes = stats.getScmUsed().get();
+    long quotaUsedInBytes = getDuResponse(true, true).getSizeWithReplica();
 
     quotaUsageResponse.setQuota(quotaInBytes);
     quotaUsageResponse.setQuotaUsed(quotaUsedInBytes);

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/api/handlers/RootEntityHandler.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/api/handlers/RootEntityHandler.java
@@ -129,23 +129,10 @@ public class RootEntityHandler extends EntityHandler {
     QuotaUsageResponse quotaUsageResponse = new QuotaUsageResponse();
     List<OmVolumeArgs> volumes = listVolumes();
     List<OmBucketInfo> buckets = listBucketsUnderVolume(null);
-    long quotaInBytes = 0L;
-    long quotaUsedInBytes = 0L;
 
-    for (OmVolumeArgs volume: volumes) {
-      final long quota = volume.getQuotaInBytes();
-      assert (quota >= -1L);
-      if (quota == -1L) {
-        // If one volume has unlimited quota, the "root" quota is unlimited.
-        quotaInBytes = -1L;
-        break;
-      }
-      quotaInBytes += quota;
-    }
-    for (OmBucketInfo bucket: buckets) {
-      long bucketObjectId = bucket.getObjectID();
-      quotaUsedInBytes += getTotalSize(bucketObjectId);
-    }
+    SCMNodeStat stats = getReconSCM().getScmNodeManager().getStats();
+    long quotaInBytes = stats.getCapacity().get();
+    long quotaUsedInBytes = stats.getScmUsed().get();
 
     quotaUsageResponse.setQuota(quotaInBytes);
     quotaUsageResponse.setQuotaUsed(quotaUsedInBytes);

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/api/handlers/RootEntityHandler.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/api/handlers/RootEntityHandler.java
@@ -30,7 +30,6 @@ import org.apache.hadoop.ozone.recon.recovery.ReconOMMetadataManager;
 import org.apache.hadoop.ozone.recon.spi.ReconNamespaceSummaryManager;
 import org.apache.hadoop.hdds.scm.container.placement.metrics.SCMNodeStat;
 
-
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/api/handlers/VolumeEntityHandler.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/api/handlers/VolumeEntityHandler.java
@@ -117,21 +117,16 @@ public class VolumeEntityHandler extends EntityHandler {
   public QuotaUsageResponse getQuotaResponse()
           throws IOException {
     QuotaUsageResponse quotaUsageResponse = new QuotaUsageResponse();
-    String[] names = getNames();
-    List<OmBucketInfo> buckets = listBucketsUnderVolume(names[0]);
-    String volKey = getOmMetadataManager().getVolumeKey(names[0]);
-    OmVolumeArgs volumeArgs =
-            getOmMetadataManager().getVolumeTable().getSkipCache(volKey);
-    long quotaInBytes = volumeArgs.getQuotaInBytes();
-    long quotaUsedInBytes = 0L;
+    RootEntityHandler rootEntityHandler = new RootEntityHandler(
+      getReconNamespaceSummaryManager(),
+      getOmMetadataManager(),
+      getReconSCM(),
+      "/"
+    );
+    QuotaUsageResponse rootQuotaUsageResponse = rootEntityHandler.getQuotaResponse();
 
-    // Get the total data size used by all buckets
-    for (OmBucketInfo bucketInfo: buckets) {
-      long bucketObjectId = bucketInfo.getObjectID();
-      quotaUsedInBytes += getTotalSize(bucketObjectId);
-    }
-    quotaUsageResponse.setQuota(quotaInBytes);
-    quotaUsageResponse.setQuotaUsed(quotaUsedInBytes);
+    quotaUsageResponse.setQuota(rootQuotaUsageResponse.getQuota());
+    quotaUsageResponse.setQuotaUsed(rootQuotaUsageResponse.getQuotaUsed());
     return quotaUsageResponse;
   }
 

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/api/handlers/VolumeEntityHandler.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/api/handlers/VolumeEntityHandler.java
@@ -19,7 +19,6 @@ package org.apache.hadoop.ozone.recon.api.handlers;
 
 import org.apache.hadoop.hdds.scm.server.OzoneStorageContainerManager;
 import org.apache.hadoop.ozone.om.helpers.OmBucketInfo;
-import org.apache.hadoop.ozone.om.helpers.OmVolumeArgs;
 import org.apache.hadoop.ozone.recon.ReconConstants;
 import org.apache.hadoop.ozone.recon.api.types.NamespaceSummaryResponse;
 import org.apache.hadoop.ozone.recon.api.types.EntityType;
@@ -118,12 +117,13 @@ public class VolumeEntityHandler extends EntityHandler {
           throws IOException {
     QuotaUsageResponse quotaUsageResponse = new QuotaUsageResponse();
     RootEntityHandler rootEntityHandler = new RootEntityHandler(
-      getReconNamespaceSummaryManager(),
-      getOmMetadataManager(),
-      getReconSCM(),
-      "/"
+        getReconNamespaceSummaryManager(),
+        getOmMetadataManager(),
+        getReconSCM(),
+        "/"
     );
-    QuotaUsageResponse rootQuotaUsageResponse = rootEntityHandler.getQuotaResponse();
+    QuotaUsageResponse rootQuotaUsageResponse = 
+        rootEntityHandler.getQuotaResponse();
 
     quotaUsageResponse.setQuota(rootQuotaUsageResponse.getQuota());
     quotaUsageResponse.setQuotaUsed(rootQuotaUsageResponse.getQuotaUsed());

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/api/TestNSSummaryEndpointWithFSO.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/api/TestNSSummaryEndpointWithFSO.java
@@ -27,6 +27,7 @@ import org.apache.hadoop.hdds.scm.container.ContainerManager;
 import org.apache.hadoop.hdds.scm.container.ContainerNotFoundException;
 import org.apache.hadoop.hdds.scm.container.ContainerReplica;
 import org.apache.hadoop.hdds.scm.server.OzoneStorageContainerManager;
+import org.apache.hadoop.hdds.scm.container.placement.metrics.SCMNodeStat;
 import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.hadoop.ozone.om.OMMetadataManager;
 import org.apache.hadoop.ozone.om.OmMetadataManagerImpl;
@@ -52,6 +53,7 @@ import org.apache.hadoop.ozone.recon.spi.StorageContainerServiceProvider;
 import org.apache.hadoop.ozone.recon.spi.impl.OzoneManagerServiceProviderImpl;
 import org.apache.hadoop.ozone.recon.spi.impl.StorageContainerServiceProviderImpl;
 import org.apache.hadoop.ozone.recon.tasks.NSSummaryTaskWithFSO;
+import org.apache.hadoop.ozone.recon.scm.ReconNodeManager;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
@@ -1240,10 +1242,17 @@ public class TestNSSummaryEndpointWithFSO {
         .thenReturn(containerReplicas6);
 
     when(reconSCM.getContainerManager()).thenReturn(containerManager);
+    ReconNodeManager mockReconNodeManager = mock(ReconNodeManager.class);
+    when(mockReconNodeManager.getStats()).thenReturn(getMockSCMRootStat());
+    when(reconSCM.getScmNodeManager()).thenReturn(mockReconNodeManager);
     return reconSCM;
   }
 
   private static BucketLayout getBucketLayout() {
     return BucketLayout.FILE_SYSTEM_OPTIMIZED;
+  }
+
+  private static SCMNodeStat getMockSCMRootStat() {
+    return new SCMNodeStat(ROOT_QUOTA,ROOT_DATA_SIZE,ROOT_QUOTA - ROOT_DATA_SIZE);
   }
 }

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/api/TestNSSummaryEndpointWithFSO.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/api/TestNSSummaryEndpointWithFSO.java
@@ -1253,6 +1253,7 @@ public class TestNSSummaryEndpointWithFSO {
   }
 
   private static SCMNodeStat getMockSCMRootStat() {
-    return new SCMNodeStat(ROOT_QUOTA,ROOT_DATA_SIZE,ROOT_QUOTA - ROOT_DATA_SIZE);
+    return new SCMNodeStat(ROOT_QUOTA, ROOT_DATA_SIZE, 
+        ROOT_QUOTA - ROOT_DATA_SIZE);
   }
 }

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/api/TestNSSummaryEndpointWithLegacy.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/api/TestNSSummaryEndpointWithLegacy.java
@@ -1283,10 +1283,17 @@ public class TestNSSummaryEndpointWithLegacy {
         .thenReturn(containerReplicas6);
 
     when(reconSCM.getContainerManager()).thenReturn(containerManager);
+    ReconNodeManager mockReconNodeManager = mock(ReconNodeManager.class);
+    when(mockReconNodeManager.getStats()).thenReturn(getMockSCMRootStat());
+    when(reconSCM.getScmNodeManager()).thenReturn(mockReconNodeManager);
     return reconSCM;
   }
 
   private static BucketLayout getBucketLayout() {
     return BucketLayout.LEGACY;
+  }
+
+  private static SCMNodeStat getMockSCMRootStat() {
+    return new SCMNodeStat(ROOT_QUOTA,ROOT_DATA_SIZE,ROOT_QUOTA - ROOT_DATA_SIZE);
   }
 }

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/api/TestNSSummaryEndpointWithLegacy.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/api/TestNSSummaryEndpointWithLegacy.java
@@ -27,6 +27,8 @@ import org.apache.hadoop.hdds.scm.container.ContainerManager;
 import org.apache.hadoop.hdds.scm.container.ContainerNotFoundException;
 import org.apache.hadoop.hdds.scm.container.ContainerReplica;
 import org.apache.hadoop.hdds.scm.server.OzoneStorageContainerManager;
+import org.apache.hadoop.hdds.scm.container.placement.metrics.SCMNodeStat;
+
 import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.hadoop.ozone.om.OMConfigKeys;
 import org.apache.hadoop.ozone.om.OMMetadataManager;
@@ -53,6 +55,7 @@ import org.apache.hadoop.ozone.recon.spi.StorageContainerServiceProvider;
 import org.apache.hadoop.ozone.recon.spi.impl.OzoneManagerServiceProviderImpl;
 import org.apache.hadoop.ozone.recon.spi.impl.StorageContainerServiceProviderImpl;
 import org.apache.hadoop.ozone.recon.tasks.NSSummaryTaskWithLegacy;
+import org.apache.hadoop.ozone.recon.scm.ReconNodeManager;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/api/TestNSSummaryEndpointWithLegacy.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/api/TestNSSummaryEndpointWithLegacy.java
@@ -1294,6 +1294,7 @@ public class TestNSSummaryEndpointWithLegacy {
   }
 
   private static SCMNodeStat getMockSCMRootStat() {
-    return new SCMNodeStat(ROOT_QUOTA,ROOT_DATA_SIZE,ROOT_QUOTA - ROOT_DATA_SIZE);
+    return new SCMNodeStat(ROOT_QUOTA, ROOT_DATA_SIZE, 
+        ROOT_QUOTA - ROOT_DATA_SIZE);
   }
 }

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/admin/nssummary/QuotaUsageSubCommand.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/admin/nssummary/QuotaUsageSubCommand.java
@@ -85,7 +85,7 @@ public class QuotaUsageSubCommand implements Callable {
         printBucketReminder();
       }
 
-      printWithUnderline("Quota", true);
+      printWithUnderline("Quota (Whole file system)", true);
       long quotaAllowed = (long)(double)quotaResponse.get("allowed");
       long quotaUsed = (long)(double)quotaResponse.get("used");
       printSpaces(2);


### PR DESCRIPTION
## What changes were proposed in this pull request?
HDDS-7443. CLI admin namespace -quota should return whole file system disk capacity consumed by all replicas

Command `ozone admin namespace quota ` should return whole file system's disk capacity for root/volume/bucket.
(HDFS -df command returns whole file system's disk capacity for directory)

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-7443

## How was this patch tested?
- Manual test.