### PR TITLE
HDDS-7500. Ozone recon server Memory Optimization.

### DIFF
--- a/hadoop-hdds/common/src/main/resources/ozone-default.xml
+++ b/hadoop-hdds/common/src/main/resources/ozone-default.xml
@@ -3397,4 +3397,15 @@
       optimum performance.
     </description>
   </property>
+
+  <property>
+    <name>ozone.recon.nssummary.flush.db.max.threshold</name>
+    <value>150000</value>
+    <tag>OZONE, RECON, PERFORMANCE</tag>
+    <description>
+      Maximum threshold number of entries to hold in memory for NSSummary task in hashmap before flushing to
+      recon rocks DB namespaceSummaryTable
+    </description>
+  </property>
+
 </configuration>

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/ReconServerConfigKeys.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/ReconServerConfigKeys.java
@@ -143,6 +143,12 @@ public final class  ReconServerConfigKeys {
       "ozone.recon.scm.connection.request.timeout";
   public static final String
       OZONE_RECON_SCM_CONNECTION_REQUEST_TIMEOUT_DEFAULT = "5s";
+
+  public static final String OZONE_RECON_NSSUMMARY_FLUSH_TO_DB_MAX_THRESHOLD =
+      "ozone.recon.nssummary.flush.db.max.threshold";
+
+  public static final long
+      OZONE_RECON_NSSUMMARY_FLUSH_TO_DB_MAX_THRESHOLD_DEFAULT = 150 * 1000L;
   /**
    * Private constructor for utility class.
    */

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/tasks/NSSummaryTask.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/tasks/NSSummaryTask.java
@@ -79,7 +79,8 @@ public class NSSummaryTask implements ReconOmTask {
     this.reconOMMetadataManager = reconOMMetadataManager;
     this.ozoneConfiguration = ozoneConfiguration;
     this.nsSummaryTaskWithFSO = new NSSummaryTaskWithFSO(
-        reconNamespaceSummaryManager, reconOMMetadataManager);
+        reconNamespaceSummaryManager,
+        reconOMMetadataManager, ozoneConfiguration);
     this.nsSummaryTaskWithLegacy = new NSSummaryTaskWithLegacy(
         reconNamespaceSummaryManager,
         reconOMMetadataManager, ozoneConfiguration);

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/tasks/NSSummaryTaskDbEventHandler.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/tasks/NSSummaryTaskDbEventHandler.java
@@ -208,6 +208,7 @@ public class NSSummaryTaskDbEventHandler {
   protected boolean flushAndCommitNSToDB(Map<Long, NSSummary> nsSummaryMap) {
     try {
       writeNSSummariesToDB(nsSummaryMap);
+      nsSummaryMap.clear();
     } catch (IOException e) {
       LOG.error("Unable to write Namespace Summary data in Recon DB.", e);
       return false;

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/tasks/NSSummaryTaskWithFSO.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/tasks/NSSummaryTaskWithFSO.java
@@ -17,6 +17,7 @@
  */
 
 package org.apache.hadoop.ozone.recon.tasks;
+import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.utils.db.Table;
 import org.apache.hadoop.hdds.utils.db.TableIterator;
 import org.apache.hadoop.ozone.om.OMMetadataManager;
@@ -50,8 +51,11 @@ public class NSSummaryTaskWithFSO extends NSSummaryTaskDbEventHandler {
   public NSSummaryTaskWithFSO(ReconNamespaceSummaryManager
                               reconNamespaceSummaryManager,
                               ReconOMMetadataManager
-                              reconOMMetadataManager) {
-    super(reconNamespaceSummaryManager, reconOMMetadataManager);
+                              reconOMMetadataManager,
+                              OzoneConfiguration
+                              ozoneConfiguration) {
+    super(reconNamespaceSummaryManager,
+        reconOMMetadataManager, ozoneConfiguration);
   }
 
   // We only listen to updates from FSO-enabled KeyTable(FileTable) and DirTable

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/tasks/NSSummaryTaskWithLegacy.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/tasks/NSSummaryTaskWithLegacy.java
@@ -185,12 +185,13 @@ public class NSSummaryTaskWithLegacy extends NSSummaryTaskDbEventHandler {
             ioEx);
         return false;
       }
+      if (!checkAndCallFlushToDB(nsSummaryMap)) {
+        return false;
+      }
     }
 
-    try {
-      writeNSSummariesToDB(nsSummaryMap);
-    } catch (IOException e) {
-      LOG.error("Unable to write Namespace Summary data in Recon DB.", e);
+    // flush and commit left out entries at end
+    if (!flushAndCommitNSToDB(nsSummaryMap)) {
       return false;
     }
 
@@ -241,6 +242,9 @@ public class NSSummaryTaskWithLegacy extends NSSummaryTaskDbEventHandler {
           } else {
             handlePutKeyEvent(keyInfo, nsSummaryMap);
           }
+          if (!checkAndCallFlushToDB(nsSummaryMap)) {
+            return false;
+          }
         }
       }
     } catch (IOException ioEx) {
@@ -249,10 +253,8 @@ public class NSSummaryTaskWithLegacy extends NSSummaryTaskDbEventHandler {
       return false;
     }
 
-    try {
-      writeNSSummariesToDB(nsSummaryMap);
-    } catch (IOException e) {
-      LOG.error("Unable to write Namespace Summary data in Recon DB.", e);
+    // flush and commit left out entries at end
+    if (!flushAndCommitNSToDB(nsSummaryMap)) {
       return false;
     }
     LOG.info("Completed a reprocess run of NSSummaryTaskWithLegacy");

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/tasks/NSSummaryTaskWithLegacy.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/tasks/NSSummaryTaskWithLegacy.java
@@ -60,7 +60,8 @@ public class NSSummaryTaskWithLegacy extends NSSummaryTaskDbEventHandler {
                                  reconOMMetadataManager,
                                  OzoneConfiguration
                                  ozoneConfiguration) {
-    super(reconNamespaceSummaryManager, reconOMMetadataManager);
+    super(reconNamespaceSummaryManager,
+        reconOMMetadataManager, ozoneConfiguration);
     // true if FileSystemPaths enabled
     enableFileSystemPaths = ozoneConfiguration
         .getBoolean(OMConfigKeys.OZONE_OM_ENABLE_FILESYSTEM_PATHS,

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/api/TestNSSummaryEndpointWithFSO.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/api/TestNSSummaryEndpointWithFSO.java
@@ -108,7 +108,7 @@ public class TestNSSummaryEndpointWithFSO {
 
   private ReconOMMetadataManager reconOMMetadataManager;
   private NSSummaryEndpoint nsSummaryEndpoint;
-  private static OzoneConfiguration ozoneConfiguration;
+  private OzoneConfiguration ozoneConfiguration;
 
   private static final String TEST_PATH_UTILITY =
           "/vol1/buck1/a/b/c/d/e/file1.txt";

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/api/TestNSSummaryEndpointWithFSO.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/api/TestNSSummaryEndpointWithFSO.java
@@ -75,6 +75,7 @@ import static org.apache.hadoop.ozone.recon.OMMetadataManagerTestUtils.writeDirT
 import static org.apache.hadoop.ozone.recon.OMMetadataManagerTestUtils.writeKeyToOm;
 import static org.apache.hadoop.ozone.recon.OMMetadataManagerTestUtils.getTestReconOmMetadataManager;
 import static org.apache.hadoop.ozone.recon.OMMetadataManagerTestUtils.getMockOzoneManagerServiceProviderWithFSO;
+import static org.apache.hadoop.ozone.recon.ReconServerConfigKeys.OZONE_RECON_NSSUMMARY_FLUSH_TO_DB_MAX_THRESHOLD;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -107,6 +108,7 @@ public class TestNSSummaryEndpointWithFSO {
 
   private ReconOMMetadataManager reconOMMetadataManager;
   private NSSummaryEndpoint nsSummaryEndpoint;
+  private static OzoneConfiguration ozoneConfiguration;
 
   private static final String TEST_PATH_UTILITY =
           "/vol1/buck1/a/b/c/d/e/file1.txt";
@@ -341,6 +343,9 @@ public class TestNSSummaryEndpointWithFSO {
 
   @Before
   public void setUp() throws Exception {
+    ozoneConfiguration = new OzoneConfiguration();
+    ozoneConfiguration.setLong(OZONE_RECON_NSSUMMARY_FLUSH_TO_DB_MAX_THRESHOLD,
+        150 * 1000L);
     OMMetadataManager omMetadataManager = initializeNewOmMetadataManager(
         temporaryFolder.newFolder());
     OzoneManagerServiceProviderImpl ozoneManagerServiceProvider =
@@ -368,7 +373,7 @@ public class TestNSSummaryEndpointWithFSO {
     populateOMDB();
     NSSummaryTaskWithFSO nSSummaryTaskWithFso =
         new NSSummaryTaskWithFSO(reconNamespaceSummaryManager,
-            reconOMMetadataManager);
+            reconOMMetadataManager, ozoneConfiguration);
     nSSummaryTaskWithFso.reprocessWithFSO(reconOMMetadataManager);
   }
 

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/api/TestNSSummaryEndpointWithFSO.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/api/TestNSSummaryEndpointWithFSO.java
@@ -345,7 +345,7 @@ public class TestNSSummaryEndpointWithFSO {
   public void setUp() throws Exception {
     ozoneConfiguration = new OzoneConfiguration();
     ozoneConfiguration.setLong(OZONE_RECON_NSSUMMARY_FLUSH_TO_DB_MAX_THRESHOLD,
-        15 * 1000L);
+        10);
     OMMetadataManager omMetadataManager = initializeNewOmMetadataManager(
         temporaryFolder.newFolder());
     OzoneManagerServiceProviderImpl ozoneManagerServiceProvider =

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/api/TestNSSummaryEndpointWithFSO.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/api/TestNSSummaryEndpointWithFSO.java
@@ -345,7 +345,7 @@ public class TestNSSummaryEndpointWithFSO {
   public void setUp() throws Exception {
     ozoneConfiguration = new OzoneConfiguration();
     ozoneConfiguration.setLong(OZONE_RECON_NSSUMMARY_FLUSH_TO_DB_MAX_THRESHOLD,
-        150 * 1000L);
+        15 * 1000L);
     OMMetadataManager omMetadataManager = initializeNewOmMetadataManager(
         temporaryFolder.newFolder());
     OzoneManagerServiceProviderImpl ozoneManagerServiceProvider =

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/tasks/TestNSSummaryTaskWithFSO.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/tasks/TestNSSummaryTaskWithFSO.java
@@ -123,7 +123,7 @@ public final class TestNSSummaryTaskWithFSO {
   public static void setUp() throws Exception {
     ozoneConfiguration = new OzoneConfiguration();
     ozoneConfiguration.setLong(OZONE_RECON_NSSUMMARY_FLUSH_TO_DB_MAX_THRESHOLD,
-        150 * 1000L);
+        15 * 1000L);
     omMetadataManager = initializeNewOmMetadataManager(
             TEMPORARY_FOLDER.newFolder());
     OzoneManagerServiceProvider ozoneManagerServiceProvider =

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/tasks/TestNSSummaryTaskWithFSO.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/tasks/TestNSSummaryTaskWithFSO.java
@@ -67,7 +67,7 @@ public final class TestNSSummaryTaskWithFSO {
   private static ReconOMMetadataManager reconOMMetadataManager;
   private static NSSummaryTaskWithFSO nSSummaryTaskWithFso;
 
-  private OzoneConfiguration ozoneConfiguration;
+  private static OzoneConfiguration ozoneConfiguration;
 
   // Object names in FSO-enabled format
   private static final String VOL = "vol";

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/tasks/TestNSSummaryTaskWithFSO.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/tasks/TestNSSummaryTaskWithFSO.java
@@ -67,7 +67,7 @@ public final class TestNSSummaryTaskWithFSO {
   private static ReconOMMetadataManager reconOMMetadataManager;
   private static NSSummaryTaskWithFSO nSSummaryTaskWithFso;
 
-  private static OzoneConfiguration ozoneConfiguration;
+  private OzoneConfiguration ozoneConfiguration;
 
   // Object names in FSO-enabled format
   private static final String VOL = "vol";
@@ -148,7 +148,8 @@ public final class TestNSSummaryTaskWithFSO {
     populateOMDB();
 
     nSSummaryTaskWithFso = new NSSummaryTaskWithFSO(
-        reconNamespaceSummaryManager, reconOMMetadataManager, ozoneConfiguration);
+        reconNamespaceSummaryManager, reconOMMetadataManager,
+        ozoneConfiguration);
   }
 
   /**

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/tasks/TestNSSummaryTaskWithFSO.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/tasks/TestNSSummaryTaskWithFSO.java
@@ -123,7 +123,7 @@ public final class TestNSSummaryTaskWithFSO {
   public static void setUp() throws Exception {
     ozoneConfiguration = new OzoneConfiguration();
     ozoneConfiguration.setLong(OZONE_RECON_NSSUMMARY_FLUSH_TO_DB_MAX_THRESHOLD,
-        15 * 1000L);
+        10);
     omMetadataManager = initializeNewOmMetadataManager(
             TEMPORARY_FOLDER.newFolder());
     OzoneManagerServiceProvider ozoneManagerServiceProvider =

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/tasks/TestNSSummaryTaskWithFSO.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/tasks/TestNSSummaryTaskWithFSO.java
@@ -19,6 +19,7 @@
 package org.apache.hadoop.ozone.recon.tasks;
 
 import org.apache.hadoop.hdds.client.StandaloneReplicationConfig;
+import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.hdds.utils.db.RDBBatchOperation;
 import org.apache.hadoop.ozone.om.OMMetadataManager;
@@ -50,6 +51,7 @@ import static org.apache.hadoop.ozone.recon.OMMetadataManagerTestUtils.getTestRe
 import static org.apache.hadoop.ozone.recon.OMMetadataManagerTestUtils.initializeNewOmMetadataManager;
 import static org.apache.hadoop.ozone.recon.OMMetadataManagerTestUtils.writeDirToOm;
 import static org.apache.hadoop.ozone.recon.OMMetadataManagerTestUtils.writeKeyToOm;
+import static org.apache.hadoop.ozone.recon.ReconServerConfigKeys.OZONE_RECON_NSSUMMARY_FLUSH_TO_DB_MAX_THRESHOLD;
 
 /**
  * Test for NSSummaryTaskWithFSO.
@@ -64,6 +66,8 @@ public final class TestNSSummaryTaskWithFSO {
   private static OMMetadataManager omMetadataManager;
   private static ReconOMMetadataManager reconOMMetadataManager;
   private static NSSummaryTaskWithFSO nSSummaryTaskWithFso;
+
+  private static OzoneConfiguration ozoneConfiguration;
 
   // Object names in FSO-enabled format
   private static final String VOL = "vol";
@@ -117,6 +121,9 @@ public final class TestNSSummaryTaskWithFSO {
 
   @BeforeClass
   public static void setUp() throws Exception {
+    ozoneConfiguration = new OzoneConfiguration();
+    ozoneConfiguration.setLong(OZONE_RECON_NSSUMMARY_FLUSH_TO_DB_MAX_THRESHOLD,
+        150 * 1000L);
     omMetadataManager = initializeNewOmMetadataManager(
             TEMPORARY_FOLDER.newFolder());
     OzoneManagerServiceProvider ozoneManagerServiceProvider =
@@ -141,7 +148,7 @@ public final class TestNSSummaryTaskWithFSO {
     populateOMDB();
 
     nSSummaryTaskWithFso = new NSSummaryTaskWithFSO(
-        reconNamespaceSummaryManager, reconOMMetadataManager);
+        reconNamespaceSummaryManager, reconOMMetadataManager, ozoneConfiguration);
   }
 
   /**


### PR DESCRIPTION
Issue:
we are keep on iterating that iterator using while loop and "handlePutDirEvent" method keep pushing the keys and value objects (NSSummary) in `nsSummaryMap` and that hashmap is retaining lot of objects worth of 16 GB and then eventually goes OOM. At the end of while loop down the code in this method, we push the data to NSSummaryTable in recon SQL DB.

<img width="695" alt="Screenshot 2022-11-17 at 11 21 28 AM" src="https://user-images.githubusercontent.com/20607992/202446439-89936e40-2fe3-432b-abfd-51ade5637619.png">
<img width="1689" alt="image" src="https://user-images.githubusercontent.com/20607992/202446512-1af61be4-8b81-4746-b655-dccd1d8d7292.png">


Solution:
As per heap dump provided, further analysed recon code which runs NSSummary task, the code which is adding these objects "NSSummary" in hashmap. "NSSummary" object is used for storing metadata summary of dir/keys using few data structures and all internal data structures are using primitive types for storing this metadata which are already optimized. As per heapdump analysis, it is being observed that this each metadata object is occupying ~7KB on an average if we take out the average of all ~25 million records., So now we can think of a simpler solution to keep tab on Recon memory stepping upto max of 1 GB during this NSSummary task operation, we can do below simple math:

1 GB = 1024 * 1024 KB
Number of elements to load in HashMap before flushing to DB = (1024 * 1024) / 7 = ~150K entries,

After 150K entries in HashMap, we can flush to DB and then clear out the hashmap to reuse and memory will be freed after GC.

https://issues.apache.org/jira/browse/HDDS-7500

and you need to set the title of the pull request which starts with
the corresponding JIRA issue number. (e.g. HDDS-XXXX. Fix a typo in YYY.)

Please replace this section with the link to the Apache JIRA)

## How was this patch tested?

Tested Manually with test cases by generating keys and directories using freon and made hit the code.
