### PR TITLE
HDDS-7187. EC: Retry failed writes before rewrite to a new block group

### DIFF
--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/ECXceiverClientGrpc.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/ECXceiverClientGrpc.java
@@ -19,11 +19,29 @@
 package org.apache.hadoop.hdds.scm;
 
 import org.apache.hadoop.hdds.conf.ConfigurationSource;
+import org.apache.hadoop.hdds.protocol.DatanodeDetails;
 import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos;
 import org.apache.hadoop.hdds.scm.pipeline.Pipeline;
+import org.apache.hadoop.hdds.tracing.GrpcClientInterceptor;
+import org.apache.hadoop.ozone.OzoneConsts;
+import org.apache.ratis.thirdparty.io.grpc.ManagedChannel;
+import org.apache.ratis.thirdparty.io.grpc.Status;
+import org.apache.ratis.thirdparty.io.grpc.netty.GrpcSslContexts;
+import org.apache.ratis.thirdparty.io.grpc.netty.NettyChannelBuilder;
+import org.apache.ratis.thirdparty.io.netty.handler.ssl.SslContextBuilder;
 
+import java.io.IOException;
 import java.security.cert.X509Certificate;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+
+import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_CLIENT_EC_ENABLE_RETRIES;
+import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_CLIENT_EC_ENABLE_RETRIES_DEFAULT;
+import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_CLIENT_EC_GRPC_MAX_RETRIES;
+import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_CLIENT_EC_GRPC_MAX_RETRIES_DEFAULT;
 
 /**
  * {@link XceiverClientSpi} implementation to work specifically with EC
@@ -31,15 +49,19 @@ import java.util.List;
  * {@link XceiverClientGrpc} is that this implementation does async calls when
  * a write request is posted via the sendCommandAsync method.
  *
- * @see https://issues.apache.org/jira/browse/HDDS-5954
+ * @see <a href="https://issues.apache.org/jira/browse/HDDS-5954">HDDS-5954</a>
  */
 public class ECXceiverClientGrpc extends XceiverClientGrpc {
+
+  private final boolean enableRetries;
 
   public ECXceiverClientGrpc(
       Pipeline pipeline,
       ConfigurationSource config,
       List<X509Certificate> caCerts) {
     super(pipeline, config, caCerts);
+    this.enableRetries = config.getBoolean(OZONE_CLIENT_EC_ENABLE_RETRIES,
+        OZONE_CLIENT_EC_ENABLE_RETRIES_DEFAULT);
   }
 
   /**
@@ -56,5 +78,60 @@ public class ECXceiverClientGrpc extends XceiverClientGrpc {
   protected boolean shouldBlockAndWaitAsyncReply(
       ContainerProtos.ContainerCommandRequestProto request) {
     return false;
+  }
+
+  @Override
+  protected ManagedChannel createChannel(DatanodeDetails dn, int port)
+      throws IOException {
+    NettyChannelBuilder channelBuilder =
+        NettyChannelBuilder.forAddress(dn.getIpAddress(), port).usePlaintext()
+            .maxInboundMessageSize(OzoneConsts.OZONE_SCM_CHUNK_MAX_SIZE)
+            .intercept(new GrpcClientInterceptor());
+    if (getSecConfig().isGrpcTlsEnabled()) {
+      SslContextBuilder sslContextBuilder = GrpcSslContexts.forClient();
+      if (getCaCerts() != null) {
+        sslContextBuilder.trustManager(getCaCerts());
+      }
+      if (getSecConfig().useTestCert()) {
+        channelBuilder.overrideAuthority("localhost");
+      }
+      channelBuilder.useTransportSecurity().
+          sslContext(sslContextBuilder.build());
+    } else {
+      channelBuilder.usePlaintext();
+    }
+    if (enableRetries) {
+      double maxAttempts = getConfig().getInt(OZONE_CLIENT_EC_GRPC_MAX_RETRIES,
+          OZONE_CLIENT_EC_GRPC_MAX_RETRIES_DEFAULT);
+
+      channelBuilder.defaultServiceConfig(createRetryServiceConfig(maxAttempts))
+          .maxRetryAttempts((int) maxAttempts).enableRetry();
+    }
+    return channelBuilder.build();
+  }
+
+  private Map<String, Object> createRetryServiceConfig(double maxAttempts) {
+    Map<String, Object> retryPolicy = new HashMap<>();
+    // Maximum number of RPC attempts which including the original RPC.
+    retryPolicy.put("maxAttempts", maxAttempts);
+    // The initial retry attempt will occur at random(0, initialBackoff)
+    retryPolicy.put("initialBackoff", "0.5s");
+    retryPolicy.put("maxBackoff", "3s");
+    retryPolicy.put("backoffMultiplier", 1.5D);
+    //Status codes for with RPC retry are attempted.
+    retryPolicy.put("retryableStatusCodes", Arrays.asList(
+        Status.Code.UNAVAILABLE.name(),
+        Status.Code.DEADLINE_EXCEEDED.name()));
+    Map<String, Object> methodConfig = new HashMap<>();
+    methodConfig.put("retryPolicy", retryPolicy);
+
+    Map<String, Object> name = new HashMap<>();
+    name.put("service", "hadoop.hdds.datanode.XceiverClientProtocolService");
+    methodConfig.put("name", Collections.singletonList(name));
+
+    Map<String, Object> serviceConfig = new HashMap<>();
+    serviceConfig.put("methodConfig",
+        Collections.singletonList(methodConfig));
+    return serviceConfig;
   }
 }

--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/ECXceiverClientGrpc.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/ECXceiverClientGrpc.java
@@ -27,7 +27,6 @@ import org.apache.ratis.thirdparty.io.grpc.netty.NettyChannelBuilder;
 
 import java.io.IOException;
 import java.security.cert.X509Certificate;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -98,8 +97,7 @@ public class ECXceiverClientGrpc extends XceiverClientGrpc {
     retryPolicy.put("maxBackoff", "3s");
     retryPolicy.put("backoffMultiplier", 1.5D);
     //Status codes for with RPC retry are attempted.
-    retryPolicy.put("retryableStatusCodes", Arrays.asList(
-        Status.Code.UNAVAILABLE.name(),
+    retryPolicy.put("retryableStatusCodes", Collections.singletonList(
         Status.Code.DEADLINE_EXCEEDED.name()));
     Map<String, Object> methodConfig = new HashMap<>();
     methodConfig.put("retryPolicy", retryPolicy);

--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/XceiverClientGrpc.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/XceiverClientGrpc.java
@@ -185,14 +185,14 @@ public class XceiverClientGrpc extends XceiverClientSpi {
       LOG.debug("Nodes in pipeline : {}", pipeline.getNodes());
       LOG.debug("Connecting to server : {}", dn.getIpAddress());
     }
-    ManagedChannel channel = createChannel(dn, port);
+    ManagedChannel channel = createChannel(dn, port).build();
     XceiverClientProtocolServiceStub asyncStub =
         XceiverClientProtocolServiceGrpc.newStub(channel);
     asyncStubs.put(dn.getUuid(), asyncStub);
     channels.put(dn.getUuid(), channel);
   }
 
-  protected ManagedChannel createChannel(DatanodeDetails dn, int port)
+  protected NettyChannelBuilder createChannel(DatanodeDetails dn, int port)
       throws IOException {
     NettyChannelBuilder channelBuilder =
         NettyChannelBuilder.forAddress(dn.getIpAddress(), port).usePlaintext()
@@ -211,7 +211,7 @@ public class XceiverClientGrpc extends XceiverClientSpi {
     } else {
       channelBuilder.usePlaintext();
     }
-    return channelBuilder.build();
+    return channelBuilder;
   }
 
   /**
@@ -608,14 +608,6 @@ public class XceiverClientGrpc extends XceiverClientSpi {
   @Override
   public HddsProtos.ReplicationType getPipelineType() {
     return HddsProtos.ReplicationType.STAND_ALONE;
-  }
-
-  public SecurityConfig getSecConfig() {
-    return secConfig;
-  }
-
-  public List<X509Certificate> getCaCerts() {
-    return caCerts;
   }
 
   public ConfigurationSource getConfig() {

--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/XceiverClientGrpc.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/XceiverClientGrpc.java
@@ -185,6 +185,15 @@ public class XceiverClientGrpc extends XceiverClientSpi {
       LOG.debug("Nodes in pipeline : {}", pipeline.getNodes());
       LOG.debug("Connecting to server : {}", dn.getIpAddress());
     }
+    ManagedChannel channel = createChannel(dn, port);
+    XceiverClientProtocolServiceStub asyncStub =
+        XceiverClientProtocolServiceGrpc.newStub(channel);
+    asyncStubs.put(dn.getUuid(), asyncStub);
+    channels.put(dn.getUuid(), channel);
+  }
+
+  protected ManagedChannel createChannel(DatanodeDetails dn, int port)
+      throws IOException {
     NettyChannelBuilder channelBuilder =
         NettyChannelBuilder.forAddress(dn.getIpAddress(), port).usePlaintext()
             .maxInboundMessageSize(OzoneConsts.OZONE_SCM_CHUNK_MAX_SIZE)
@@ -202,11 +211,7 @@ public class XceiverClientGrpc extends XceiverClientSpi {
     } else {
       channelBuilder.usePlaintext();
     }
-    ManagedChannel channel = channelBuilder.build();
-    XceiverClientProtocolServiceStub asyncStub =
-        XceiverClientProtocolServiceGrpc.newStub(channel);
-    asyncStubs.put(dn.getUuid(), asyncStub);
-    channels.put(dn.getUuid(), channel);
+    return channelBuilder.build();
   }
 
   /**
@@ -603,6 +608,18 @@ public class XceiverClientGrpc extends XceiverClientSpi {
   @Override
   public HddsProtos.ReplicationType getPipelineType() {
     return HddsProtos.ReplicationType.STAND_ALONE;
+  }
+
+  public SecurityConfig getSecConfig() {
+    return secConfig;
+  }
+
+  public List<X509Certificate> getCaCerts() {
+    return caCerts;
+  }
+
+  public ConfigurationSource getConfig() {
+    return config;
   }
 
   @VisibleForTesting

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/OzoneConfigKeys.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/OzoneConfigKeys.java
@@ -119,12 +119,13 @@ public final class OzoneConfigKeys {
       "ozone.client.max.ec.stripe.write.retries";
   public static final String OZONE_CLIENT_MAX_EC_STRIPE_WRITE_RETRIES_DEFAULT =
       "10";
-  public static final String OZONE_CLIENT_EC_ENABLE_RETRIES =
-      "ozone.client.ec.enable.retries";
-  public static final boolean OZONE_CLIENT_EC_ENABLE_RETRIES_DEFAULT = true;
-  public static final String OZONE_CLIENT_EC_GRPC_MAX_RETRIES =
-      "ozone.client.ec.grpc.max.retries";
-  public static final int OZONE_CLIENT_EC_GRPC_MAX_RETRIES_DEFAULT = 5;
+  public static final String OZONE_CLIENT_EC_GRPC_RETRIES_ENABLED =
+      "ozone.client.ec.grpc.retries.enabled";
+  public static final boolean OZONE_CLIENT_EC_GRPC_RETRIES_ENABLED_DEFAULT
+      = true;
+  public static final String OZONE_CLIENT_EC_GRPC_RETRIES_MAX =
+      "ozone.client.ec.grpc.retries.max";
+  public static final int OZONE_CLIENT_EC_GRPC_RETRIES_MAX_DEFAULT = 5;
 
   /**
    * Ozone administrator users delimited by comma.

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/OzoneConfigKeys.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/OzoneConfigKeys.java
@@ -119,6 +119,12 @@ public final class OzoneConfigKeys {
       "ozone.client.max.ec.stripe.write.retries";
   public static final String OZONE_CLIENT_MAX_EC_STRIPE_WRITE_RETRIES_DEFAULT =
       "10";
+  public static final String OZONE_CLIENT_EC_ENABLE_RETRIES =
+      "ozone.client.ec.enable.retries";
+  public static final boolean OZONE_CLIENT_EC_ENABLE_RETRIES_DEFAULT = true;
+  public static final String OZONE_CLIENT_EC_GRPC_MAX_RETRIES =
+      "ozone.client.ec.grpc.max.retries";
+  public static final int OZONE_CLIENT_EC_GRPC_MAX_RETRIES_DEFAULT = 5;
 
   /**
    * Ozone administrator users delimited by comma.

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/OzoneConfigKeys.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/OzoneConfigKeys.java
@@ -125,7 +125,7 @@ public final class OzoneConfigKeys {
       = true;
   public static final String OZONE_CLIENT_EC_GRPC_RETRIES_MAX =
       "ozone.client.ec.grpc.retries.max";
-  public static final int OZONE_CLIENT_EC_GRPC_RETRIES_MAX_DEFAULT = 5;
+  public static final int OZONE_CLIENT_EC_GRPC_RETRIES_MAX_DEFAULT = 3;
 
   /**
    * Ozone administrator users delimited by comma.

--- a/hadoop-hdds/common/src/main/resources/ozone-default.xml
+++ b/hadoop-hdds/common/src/main/resources/ozone-default.xml
@@ -3276,6 +3276,24 @@
   </property>
 
   <property>
+    <name>ozone.client.ec.enable.retries</name>
+    <value>true</value>
+    <tag>CLIENT</tag>
+    <description>
+      To enable Grpc client retries for EC.
+    </description>
+  </property>
+
+  <property>
+    <name>ozone.client.ec.grpc.max.retries</name>
+    <value>5</value>
+    <tag>CLIENT</tag>
+    <description>
+      The maximum attempts GRPC client makes before failover.
+    </description>
+  </property>
+
+  <property>
     <name>ozone.audit.log.debug.cmd.list.omaudit</name>
     <value></value>
     <tag>OM</tag>

--- a/hadoop-hdds/common/src/main/resources/ozone-default.xml
+++ b/hadoop-hdds/common/src/main/resources/ozone-default.xml
@@ -3286,7 +3286,7 @@
 
   <property>
     <name>ozone.client.ec.grpc.retries.max</name>
-    <value>5</value>
+    <value>3</value>
     <tag>CLIENT</tag>
     <description>
       The maximum attempts GRPC client makes before failover.

--- a/hadoop-hdds/common/src/main/resources/ozone-default.xml
+++ b/hadoop-hdds/common/src/main/resources/ozone-default.xml
@@ -3276,7 +3276,7 @@
   </property>
 
   <property>
-    <name>ozone.client.ec.enable.retries</name>
+    <name>ozone.client.ec.grpc.retries.enabled</name>
     <value>true</value>
     <tag>CLIENT</tag>
     <description>
@@ -3285,7 +3285,7 @@
   </property>
 
   <property>
-    <name>ozone.client.ec.grpc.max.retries</name>
+    <name>ozone.client.ec.grpc.retries.max</name>
     <value>5</value>
     <tag>CLIENT</tag>
     <description>

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/impl/TestHddsDispatcher.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/impl/TestHddsDispatcher.java
@@ -292,6 +292,66 @@ public class TestHddsDispatcher {
     }
   }
 
+  @Test
+  public void testDuplicateWriteChunkAndPutBlockRequest() throws  IOException {
+    String testDir = GenericTestUtils.getTempPath(
+        TestHddsDispatcher.class.getSimpleName());
+    try {
+      UUID scmId = UUID.randomUUID();
+      OzoneConfiguration conf = new OzoneConfiguration();
+      conf.set(HDDS_DATANODE_DIR_KEY, testDir);
+      conf.set(OzoneConfigKeys.OZONE_METADATA_DIRS, testDir);
+      DatanodeDetails dd = randomDatanodeDetails();
+      HddsDispatcher hddsDispatcher = createDispatcher(dd, scmId, conf);
+      ContainerCommandRequestProto writeChunkRequest = getWriteChunkRequest(
+          dd.getUuidString(), 1L, 1L);
+      //Send same WriteChunkRequest
+      ContainerCommandResponseProto response;
+      hddsDispatcher.dispatch(writeChunkRequest, null);
+      hddsDispatcher.dispatch(writeChunkRequest, null);
+      response = hddsDispatcher.dispatch(writeChunkRequest, null);
+
+      Assert.assertEquals(ContainerProtos.Result.SUCCESS, response.getResult());
+      // Send Read Chunk request for written chunk.
+      response =
+          hddsDispatcher.dispatch(getReadChunkRequest(writeChunkRequest), null);
+      Assert.assertEquals(ContainerProtos.Result.SUCCESS, response.getResult());
+
+      ByteString responseData = BufferUtils.concatByteStrings(
+          response.getReadChunk().getDataBuffers().getBuffersList());
+      Assert.assertEquals(writeChunkRequest.getWriteChunk().getData(),
+          responseData);
+
+      // Put Block
+      ContainerCommandRequestProto putBlockRequest =
+          ContainerTestHelper.getPutBlockRequest(writeChunkRequest);
+
+      //Send same PutBlockRequest
+      hddsDispatcher.dispatch(putBlockRequest, null);
+      hddsDispatcher.dispatch(putBlockRequest, null);
+      response =  hddsDispatcher.dispatch(putBlockRequest, null);
+      Assert.assertEquals(ContainerProtos.Result.SUCCESS, response.getResult());
+
+      // Check PutBlock Data
+      ContainerCommandRequestProto listBlockRequest =
+          ContainerTestHelper.getListBlockRequest(writeChunkRequest);
+      response =  hddsDispatcher.dispatch(listBlockRequest, null);
+      Assert.assertEquals(ContainerProtos.Result.SUCCESS, response.getResult());
+      Assert.assertEquals(1, response.getListBlock().getBlockDataList().size());
+      for (ContainerProtos.BlockData blockData :
+          response.getListBlock().getBlockDataList()) {
+        Assert.assertEquals(writeChunkRequest.getWriteChunk().getBlockID(),
+            blockData.getBlockID());
+        Assert.assertEquals(writeChunkRequest.getWriteChunk().getChunkData()
+            .getLen(), blockData.getSize());
+        Assert.assertEquals(1, blockData.getChunksCount());
+      }
+    } finally {
+      ContainerMetrics.remove();
+      FileUtils.deleteDirectory(new File(testDir));
+    }
+  }
+
   /**
    * Creates HddsDispatcher instance with given infos.
    * @param dd datanode detail info.


### PR DESCRIPTION
## What changes were proposed in this pull request?

When WriteChunk or PutBlock fails when writing a stripe, the client should retry the operation before rewriting this stripe to a new block. So that the block files on the disk will be as large as possible. 

This patch addresses a way to configure `ECXceiverClientGrpc` to retry failed requests based on GRPC Status Code `DEADLINE_EXCEEDED` 

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-7187

## How was this patch tested?

Manual testing and Unit tests.
