### PR TITLE
HDDS-7464. Container Report at SCM is not coming separately for ICR and FCR in prometheus endpoint

### DIFF
--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/server/events/EventExecutorMetrics.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/server/events/EventExecutorMetrics.java
@@ -1,0 +1,106 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hdds.server.events;
+
+/**
+ * Metrics for Event Executors.
+ */
+public interface EventExecutorMetrics {
+  /**
+   * get name
+   */
+  String getName();
+  
+  /**
+   * stop metrics.
+   */
+  void stop();
+  
+  /**
+   * Increment the number of the failed events.
+   */
+  void incrFailedEvents(long delta);
+
+
+  /**
+   * Increment the number of the processed events.
+   */
+  void incrSuccessfulEvents(long delta);
+
+  /**
+   * Increment the number of the not-yet processed events.
+   */
+  void incrQueuedEvents(long delta);
+
+  /**
+   * Increment the number of events scheduled to be processed.
+   */
+  void incrScheduledEvents(long delta);
+
+  /**
+   * Increment the number of dropped events to be processed.
+   */
+  void incrDroppedEvents(long delta);
+
+  /**
+   * Increment the number of events having long wait in queue 
+   * crossing threshold.
+   */
+  void incrLongWaitInQueueEvents(long delta);
+
+  /**
+   * Increment the number of events having long execution crossing threshold.
+   */
+  void incrLongTimeExecutionEvents(long delta);
+
+  /**
+   * Return the number of the failed events.
+   */
+  long failedEvents();
+
+
+  /**
+   * Return the number of the processed events.
+   */
+  long successfulEvents();
+
+  /**
+   * Return the number of the not-yet processed events.
+   */
+  long queuedEvents();
+
+  /**
+   * Return the number of events scheduled to be processed.
+   */
+  long scheduledEvents();
+
+  /**
+   * Return the number of dropped events to be processed.
+   */
+  long droppedEvents();
+
+  /**
+   * Return the number of events having long wait in queue crossing threshold.
+   */
+  long longWaitInQueueEvents();
+
+  /**
+   * Return the number of events having long execution crossing threshold.
+   */
+  long longTimeExecutionEvents();
+}

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/server/events/EventExecutorMetrics.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/server/events/EventExecutorMetrics.java
@@ -22,7 +22,7 @@ package org.apache.hadoop.hdds.server.events;
  */
 public interface EventExecutorMetrics {
   /**
-   * get name
+   * get name.
    */
   String getName();
   

--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/server/events/TestEventQueue.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/server/events/TestEventQueue.java
@@ -19,7 +19,6 @@ package org.apache.hadoop.hdds.server.events;
 
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
-import org.apache.hadoop.metrics2.lib.MutableCounterLong;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/metrics/ContainerReportMetrics.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/metrics/ContainerReportMetrics.java
@@ -1,0 +1,140 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hdds.scm.container.metrics;
+
+import org.apache.hadoop.hdds.server.events.EventExecutorMetrics;
+import org.apache.hadoop.metrics2.annotation.Metric;
+import org.apache.hadoop.metrics2.annotation.Metrics;
+import org.apache.hadoop.metrics2.lib.DefaultMetricsSystem;
+import org.apache.hadoop.metrics2.lib.MutableCounterLong;
+
+/**
+ * Metrics for Container Report Event Executors.
+ */
+@Metrics(context = "EventQueue")
+public class ContainerReportMetrics implements EventExecutorMetrics {
+  private static final String EVENT_QUEUE = "EventQueue";
+  private String name;
+  
+  @Metric
+  private MutableCounterLong queued;
+
+  @Metric
+  private MutableCounterLong done;
+
+  @Metric
+  private MutableCounterLong failed;
+
+  @Metric
+  private MutableCounterLong scheduled;
+
+  @Metric
+  private MutableCounterLong dropped;
+
+  @Metric
+  private MutableCounterLong longWaitInQueue;
+
+  @Metric
+  private MutableCounterLong longTimeExecution;
+
+  public ContainerReportMetrics(String name) {
+    this.name = name;
+    DefaultMetricsSystem.instance().register(EVENT_QUEUE + this.name,
+        "Event Executor metrics ", this);
+  }
+
+  @Override
+  public void stop() {
+    DefaultMetricsSystem.instance().unregisterSource(EVENT_QUEUE + name);
+  }
+  
+  @Override
+  public String getName() {
+    return name;
+  }
+
+  @Override
+  public void incrFailedEvents(long delta) {
+    failed.incr(delta);
+  }
+
+  @Override
+  public void incrSuccessfulEvents(long delta) {
+    done.incr(delta);
+  }
+
+  @Override
+  public void incrQueuedEvents(long delta) {
+    queued.incr(delta);
+  }
+
+  @Override
+  public void incrScheduledEvents(long delta) {
+    scheduled.incr(delta);
+  }
+
+  @Override
+  public void incrDroppedEvents(long delta) {
+    dropped.incr(delta);
+  }
+
+  @Override
+  public void incrLongWaitInQueueEvents(long delta) {
+    longWaitInQueue.incr(delta);
+  }
+
+  @Override
+  public void incrLongTimeExecutionEvents(long delta) {
+    longTimeExecution.incr(delta);
+  }
+  
+  @Override
+  public long failedEvents() {
+    return failed.value();
+  }
+
+  @Override
+  public long successfulEvents() {
+    return done.value();
+  }
+
+  @Override
+  public long queuedEvents() {
+    return queued.value();
+  }
+
+  @Override
+  public long scheduledEvents() {
+    return scheduled.value();
+  }
+
+  @Override
+  public long droppedEvents() {
+    return dropped.value();
+  }
+
+  @Override
+  public long longWaitInQueueEvents() {
+    return longWaitInQueue.value();
+  }
+
+  @Override
+  public long longTimeExecutionEvents() {
+    return longTimeExecution.value();
+  }
+}

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/metrics/IncrementalContainerReportMetrics.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/metrics/IncrementalContainerReportMetrics.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hdds.scm.container.metrics;
+
+import org.apache.hadoop.metrics2.annotation.Metrics;
+
+/**
+ * Metrics for Container Report Event Executors.
+ */
+@Metrics(context = "EventQueue")
+public class IncrementalContainerReportMetrics extends ContainerReportMetrics {
+  public IncrementalContainerReportMetrics(String name) {
+    super(name);
+  }
+}

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/scm/ReconStorageContainerManagerFacade.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/scm/ReconStorageContainerManagerFacade.java
@@ -43,6 +43,8 @@ import org.apache.hadoop.hdds.scm.container.ContainerActionsHandler;
 import org.apache.hadoop.hdds.scm.container.ContainerManager;
 import org.apache.hadoop.hdds.scm.container.ContainerReportHandler;
 import org.apache.hadoop.hdds.scm.container.IncrementalContainerReportHandler;
+import org.apache.hadoop.hdds.scm.container.metrics.ContainerReportMetrics;
+import org.apache.hadoop.hdds.scm.container.metrics.IncrementalContainerReportMetrics;
 import org.apache.hadoop.hdds.scm.container.replication.ContainerReplicaPendingOps;
 import org.apache.hadoop.hdds.scm.container.replication.ReplicationManager;
 import org.apache.hadoop.hdds.scm.container.balancer.ContainerBalancer;
@@ -67,6 +69,7 @@ import org.apache.hadoop.hdds.scm.pipeline.PipelineManager;
 import org.apache.hadoop.hdds.scm.safemode.SafeModeManager;
 import org.apache.hadoop.hdds.scm.server.OzoneStorageContainerManager;
 import org.apache.hadoop.hdds.scm.server.SCMStorageConfig;
+import org.apache.hadoop.hdds.server.events.EventExecutorMetrics;
 import org.apache.hadoop.hdds.server.events.EventQueue;
 import org.apache.hadoop.hdds.server.events.FixedThreadPoolWithAffinityExecutor;
 import org.apache.hadoop.hdds.upgrade.HDDSLayoutVersionManager;
@@ -233,25 +236,26 @@ public class ReconStorageContainerManagerFacade
         = FixedThreadPoolWithAffinityExecutor.initializeExecutorPool(queues);
     Map<String, FixedThreadPoolWithAffinityExecutor> reportExecutorMap
         = new ConcurrentHashMap<>();
+    EventExecutorMetrics containerReportMetrics = new ContainerReportMetrics(
+        EventQueue.getExecutorName(SCMEvents.CONTAINER_REPORT,
+            containerReportHandler));
     FixedThreadPoolWithAffinityExecutor<ContainerReportFromDatanode,
         ContainerReport> containerReportExecutors =
         new FixedThreadPoolWithAffinityExecutor<>(
-            EventQueue.getExecutorName(SCMEvents.CONTAINER_REPORT,
-                containerReportHandler),
             containerReportHandler, queues, eventQueue,
             ContainerReportFromDatanode.class, executors,
-            reportExecutorMap);
+            reportExecutorMap, containerReportMetrics);
     containerReportExecutors.setQueueWaitThreshold(waitQueueThreshold);
     containerReportExecutors.setExecWaitThreshold(execWaitThreshold);
+    EventExecutorMetrics icrMetrics = new IncrementalContainerReportMetrics(
+        EventQueue.getExecutorName(SCMEvents.INCREMENTAL_CONTAINER_REPORT,
+            icrHandler));
     FixedThreadPoolWithAffinityExecutor<IncrementalContainerReportFromDatanode,
         ContainerReport> incrementalReportExecutors =
         new FixedThreadPoolWithAffinityExecutor<>(
-            EventQueue.getExecutorName(
-                SCMEvents.INCREMENTAL_CONTAINER_REPORT,
-                icrHandler),
             icrHandler, queues, eventQueue,
             IncrementalContainerReportFromDatanode.class, executors,
-            reportExecutorMap);
+            reportExecutorMap, icrMetrics);
     incrementalReportExecutors.setQueueWaitThreshold(waitQueueThreshold);
     incrementalReportExecutors.setExecWaitThreshold(execWaitThreshold);
     eventQueue.addHandler(SCMEvents.CONTAINER_REPORT, containerReportExecutors,


### PR DESCRIPTION
## What changes were proposed in this pull request?

Metrics classes seperated for ICR and FCR to report seperately for prometheus

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-7464

## How was this patch tested?

1. Unit case to check report normal functionality
2. Over prometheus, its checked for both ICR and FCR reporting

<img width="1243" alt="image" src="https://user-images.githubusercontent.com/23372859/202694119-8d3e52a7-3f0a-4cfe-bdf1-676977e5b1fe.png">


<img width="1091" alt="image" src="https://user-images.githubusercontent.com/23372859/202692790-83ff8b06-5011-4ac5-b16c-ec636b5457e1.png">

