### PR TITLE
HDDS-7520. Only fail to register datanode if datanode's SLV is larger than SCM' SLV

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/states/endpoint/RegisterEndpointTask.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/states/endpoint/RegisterEndpointTask.java
@@ -159,11 +159,14 @@ public final class RegisterEndpointTask implements
             nodeReport, containerReport, pipelineReportsProto, layoutInfo);
         Preconditions.checkState(UUID.fromString(response.getDatanodeUUID())
                 .equals(datanodeDetails.getUuid()),
-            "Unexpected datanode ID in the response.");
+            "Unexpected datanode ID in the response from "
+                + rpcEndPoint.getAddressString());
         Preconditions.checkState(!StringUtils.isBlank(response.getClusterID()),
-            "Invalid cluster ID in the response.");
+            "Invalid cluster ID in the response from "
+                + rpcEndPoint.getAddressString());
         Preconditions.checkState(response.getErrorCode() == success,
-            "DataNode has higher Software Layout Version than SCM.");
+            "DataNode has higher Software Layout Version than Endpoint "
+                + rpcEndPoint.getAddressString());
         if (response.hasHostname() && response.hasIpAddress()) {
           datanodeDetails.setHostName(response.getHostname());
           datanodeDetails.setIpAddress(response.getIpAddress());

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/SCMNodeManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/SCMNodeManager.java
@@ -353,7 +353,7 @@ public class SCMNodeManager implements NodeManager {
       DatanodeDetails datanodeDetails, NodeReportProto nodeReport,
       PipelineReportsProto pipelineReportsProto,
       LayoutVersionProto layoutInfo) {
-    if (layoutInfo.getSoftwareLayoutVersion() !=
+    if (layoutInfo.getSoftwareLayoutVersion() >
         scmLayoutVersionManager.getSoftwareLayoutVersion()) {
       return RegisteredCommand.newBuilder()
           .setErrorCode(ErrorCode.errorNodeNotPermitted)

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/node/TestSCMNodeManager.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/node/TestSCMNodeManager.java
@@ -374,8 +374,6 @@ public class TestSCMNodeManager {
       registerWithCapacity(nodeManager,
           LARGER_SLV_LAYOUT_PROTO, errorNodeNotPermitted);
       registerWithCapacity(nodeManager,
-          SMALLER_MLV_SLV_LAYOUT_PROTO, errorNodeNotPermitted);
-      registerWithCapacity(nodeManager,
           LARGER_MLV_SLV_LAYOUT_PROTO, errorNodeNotPermitted);
       // Nodes with mismatched MLV can join, but should not be allowed in
       // pipelines.


### PR DESCRIPTION
## What changes were proposed in this pull request?

When SCM is upgraded with new LayoutVersion, old datanode won't be able to register to the new SCM, thus the new SCM change to safemode and the cluster becomes unavailable.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-7520

## How was this patch tested?

Removed the restrictive unit test.
