### PR TITLE
HDDS-7092. EC: Offline Recovery with simultaneous Over Replication & Under Replication

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ECOverReplicationHandler.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ECOverReplicationHandler.java
@@ -77,42 +77,20 @@ public class ECOverReplicationHandler extends AbstractOverReplicationHandler {
       ContainerHealthResult result, int remainingMaintenanceRedundancy) {
     ContainerInfo container = result.getContainerInfo();
 
-    ContainerCheckRequest request = new ContainerCheckRequest.Builder()
-        .setContainerInfo(container)
-        .setContainerReplicas(replicas)
-        .setPendingOps(pendingOps)
-        .setMaintenanceRedundancy(remainingMaintenanceRedundancy)
-        .build();
-    ContainerHealthResult currentUnderRepRes = ecReplicationCheck
-        .checkHealth(request);
-    LOG.debug("Handling over-replicated EC container: {}", container);
-
-    //sanity check
-    if (currentUnderRepRes.getHealthState() !=
-        ContainerHealthResult.HealthState.OVER_REPLICATED) {
-      LOG.info("The container {} state changed and it's not in over"
-              + " replication any more. Current state is: {}",
-          container.getContainerID(), currentUnderRepRes);
-      return emptyMap();
-    }
-
-    ContainerHealthResult.OverReplicatedHealthResult containerHealthResult =
-        ((ContainerHealthResult.OverReplicatedHealthResult)
-            currentUnderRepRes);
-    if (containerHealthResult.isReplicatedOkAfterPending()) {
-      LOG.info("The container {} with replicas {} will be corrected " +
-              "by the pending delete", container.getContainerID(), replicas);
-      return emptyMap();
-    }
-
-    // we don`t support hybrid state(both under and over replicated) for
-    // EC container and we always handle under-replicated first now. it
-    // means when reaching here, we have all the replica indexes and some
-    // of them are more than 1.
-    // TODO: support hybrid state if needed.
     final ECContainerReplicaCount replicaCount =
         new ECContainerReplicaCount(container, replicas, pendingOps,
             remainingMaintenanceRedundancy);
+    if (!replicaCount.isOverReplicated()) {
+      LOG.info("The container {} state changed and it's not in over"
+              + " replication any more", container.getContainerID());
+      return emptyMap();
+    }
+
+    if (!replicaCount.isOverReplicated(true)) {
+      LOG.info("The container {} with replicas {} will be corrected " +
+          "by the pending delete", container.getContainerID(), replicas);
+      return emptyMap();
+    }
 
     List<Integer> overReplicatedIndexes =
         replicaCount.overReplicatedIndexes(true);

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ECUnderReplicationHandler.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ECUnderReplicationHandler.java
@@ -42,7 +42,6 @@ import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
@@ -68,7 +67,7 @@ public class ECUnderReplicationHandler implements UnhealthyReplicationHandler {
   private final ReplicationManager replicationManager;
 
   private static class CannotFindTargetsException extends IOException {
-    public CannotFindTargetsException(Throwable cause) {
+    CannotFindTargetsException(Throwable cause) {
       super(cause);
     }
   }
@@ -206,11 +205,11 @@ public class ECUnderReplicationHandler implements UnhealthyReplicationHandler {
         // If the container is also over replicated, then hand it off to the
         // over-rep handler, and after those over-rep indexes are cleared the
         // under replication can be re-tried in the next iteration of RM.
-        // However we should only hand off to the over rep handler if there are
+        // However, we should only hand off to the over rep handler if there are
         // no commands already created. If we have some commands, they may
         // attempt to use sources the over-rep handler would remove. So we
         // should let the commands we have created be processed, and then the
-        // container will be re-processed in a futher RM pass.
+        // container will be re-processed in a further RM pass.
         LOG.debug("Unable to located new target nodes for container {}",
             container, e);
         if (commands.size() > 0) {
@@ -368,8 +367,8 @@ public class ECUnderReplicationHandler implements UnhealthyReplicationHandler {
           if (decomIndexes.contains(replica.getReplicaIndex())) {
             if (!iterator.hasNext()) {
               LOG.warn("Couldn't find enough targets. Available source"
-                      + " nodes: {}, the target nodes: {}, excluded nodes: {} and"
-                      + "  the decommission indexes: {}",
+                      + " nodes: {}, the target nodes: {}, excluded nodes: {}"
+                      + "  and the decommission indexes: {}",
                   replicas, selectedDatanodes, excludedNodes, decomIndexes);
               break;
             }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ReplicationManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ReplicationManager.java
@@ -215,7 +215,8 @@ public class ReplicationManager implements SCMService {
     this.ratisMaintenanceMinReplicas = rmConf.getMaintenanceReplicaMinimum();
 
     ecUnderReplicationHandler = new ECUnderReplicationHandler(
-        ecReplicationCheckHandler, ecContainerPlacement, conf, nodeManager);
+        ecReplicationCheckHandler, ecContainerPlacement, conf, nodeManager,
+        this);
     ecOverReplicationHandler =
         new ECOverReplicationHandler(ecReplicationCheckHandler,
             ecContainerPlacement, nodeManager);

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestECUnderReplicationHandler.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestECUnderReplicationHandler.java
@@ -334,10 +334,7 @@ public class TestECUnderReplicationHandler {
     DatanodeDetails newNode = MockDatanodeDetails.randomDatanodeDetails();
     PlacementPolicy sameNodePolicy = ReplicationTestUtil
         .getSameNodeTestPlacementPolicy(nodeManager, conf, newNode);
-
-    ContainerReplica overRepReplica =
-        ReplicationTestUtil.createContainerReplica(container.containerID(),
-            4, IN_SERVICE, CLOSED);
+    
     ContainerReplica decomReplica =
         ReplicationTestUtil.createContainerReplica(container.containerID(),
             5, DECOMMISSIONING, CLOSED);

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestECUnderReplicationHandler.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestECUnderReplicationHandler.java
@@ -71,6 +71,7 @@ public class TestECUnderReplicationHandler {
   private ECReplicationConfig repConfig;
   private ContainerInfo container;
   private NodeManager nodeManager;
+  private ReplicationManager replicationManager;
   private OzoneConfiguration conf;
   private PlacementPolicy policy;
   private static final int DATA = 3;
@@ -87,6 +88,7 @@ public class TestECUnderReplicationHandler {
             dd.getPersistedOpState(), HddsProtos.NodeState.HEALTHY, 0);
       }
     };
+    replicationManager = Mockito.mock(ReplicationManager.class);
     conf = SCMTestUtils.getConf();
     repConfig = new ECReplicationConfig(DATA, PARITY);
     container = ReplicationTestUtil
@@ -304,7 +306,7 @@ public class TestECUnderReplicationHandler {
       PlacementPolicy placementPolicy) throws IOException {
     ECUnderReplicationHandler ecURH =
         new ECUnderReplicationHandler(replicationCheck,
-            placementPolicy, conf, nodeManager);
+            placementPolicy, conf, nodeManager, replicationManager);
     ContainerHealthResult.UnderReplicatedHealthResult result =
         Mockito.mock(ContainerHealthResult.UnderReplicatedHealthResult.class);
     Mockito.when(result.isUnrecoverable()).thenReturn(false);

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestECUnderReplicationHandler.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestECUnderReplicationHandler.java
@@ -373,10 +373,6 @@ public class TestECUnderReplicationHandler {
         availableReplicas.add(toAdd);
       }
 
-      Map<DatanodeDetails, SCMCommand<?>> expectedDelete = new HashMap<>();
-      expectedDelete.put(overRepReplica.getDatanodeDetails(),
-          createDeleteContainerCommand(container, overRepReplica));
-
       Map<DatanodeDetails, SCMCommand<?>> commands =
           ecURH.processAndCreateCommands(availableReplicas,
               Collections.emptyList(), underRep, 2);

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestECUnderReplicationHandler.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestECUnderReplicationHandler.java
@@ -24,6 +24,7 @@ import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
 import org.apache.hadoop.hdds.protocol.MockDatanodeDetails;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
+import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos;
 import org.apache.hadoop.hdds.scm.ContainerPlacementStatus;
 import org.apache.hadoop.hdds.scm.PlacementPolicy;
 import org.apache.hadoop.hdds.scm.container.ContainerInfo;
@@ -37,6 +38,7 @@ import org.apache.hadoop.hdds.scm.net.NodeSchemaManager;
 import org.apache.hadoop.hdds.scm.node.NodeManager;
 import org.apache.hadoop.hdds.scm.node.NodeStatus;
 import org.apache.hadoop.ozone.container.common.SCMTestUtils;
+import org.apache.hadoop.ozone.protocol.commands.DeleteContainerCommand;
 import org.apache.hadoop.ozone.protocol.commands.ReconstructECContainersCommand;
 import org.apache.hadoop.ozone.protocol.commands.ReplicateContainerCommand;
 import org.apache.hadoop.ozone.protocol.commands.SCMCommand;
@@ -48,21 +50,26 @@ import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
 import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.NodeOperationalState.DECOMMISSIONING;
+import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.NodeOperationalState.ENTERING_MAINTENANCE;
 import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.NodeOperationalState.IN_MAINTENANCE;
 import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.NodeOperationalState.IN_SERVICE;
+import static org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.ContainerReplicaProto.State.CLOSED;
 import static org.apache.hadoop.hdds.scm.net.NetConstants.LEAF_SCHEMA;
 import static org.apache.hadoop.hdds.scm.net.NetConstants.RACK_SCHEMA;
 import static org.apache.hadoop.hdds.scm.net.NetConstants.ROOT_SCHEMA;
 import static org.junit.Assert.assertThrows;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.Mockito.times;
 
 /**
  * Tests the ECUnderReplicationHandling functionality.
@@ -251,7 +258,188 @@ public class TestECUnderReplicationHandler {
   }
 
   @Test
-  public void testSameNodeIsNotReused() throws IOException {
+  public void testUnderRepSentToOverRepHandlerIfNoNewNodes()
+      throws IOException {
+    PlacementPolicy noNodesPolicy = ReplicationTestUtil
+        .getNoNodesTestPlacementPolicy(nodeManager, conf);
+
+    ContainerReplica overRepReplica =
+        ReplicationTestUtil.createContainerReplica(container.containerID(),
+            4, IN_SERVICE, CLOSED);
+    ContainerReplica decomReplica =
+        ReplicationTestUtil.createContainerReplica(container.containerID(),
+        5, DECOMMISSIONING, CLOSED);
+    ContainerReplica maintReplica =
+        ReplicationTestUtil.createContainerReplica(container.containerID(),
+            5, ENTERING_MAINTENANCE, CLOSED);
+
+    List<ContainerReplica> replicasToAdd = new ArrayList<>();
+    replicasToAdd.add(null);
+    replicasToAdd.add(decomReplica);
+    replicasToAdd.add(maintReplica);
+
+    ECUnderReplicationHandler ecURH =
+        new ECUnderReplicationHandler(replicationCheck,
+            noNodesPolicy, conf, nodeManager, replicationManager);
+    ContainerHealthResult.UnderReplicatedHealthResult underRep =
+        new ContainerHealthResult.UnderReplicatedHealthResult(container,
+            1, false, false, false);
+
+    // The underRepHandler processes in stages. First missing indexes, then
+    // decommission and then maintenance. If a stage cannot find new nodes and
+    // there are no commands created yet, then we should either throw, or pass
+    // control to the over rep handler if the container is also over replicated.
+    // In this loop we first have the container under replicated with a missing
+    // index, then with an under-rep index, and finally with a maintenance
+    // index. In all cases, initially have it not over replicated, so it should
+    // throw an exception, and then make it also over replicated, returning the
+    // commands to fix the over replication instead.
+    for (ContainerReplica toAdd : replicasToAdd) {
+      Mockito.clearInvocations(replicationManager);
+      Set<ContainerReplica> availableReplicas = ReplicationTestUtil
+          .createReplicas(Pair.of(IN_SERVICE, 1),
+              Pair.of(IN_SERVICE, 2), Pair.of(IN_SERVICE, 3),
+              Pair.of(IN_SERVICE, 4));
+      if (toAdd != null) {
+        availableReplicas.add(toAdd);
+      }
+
+      Assert.assertThrows(SCMException.class,
+          () -> ecURH.processAndCreateCommands(availableReplicas,
+              Collections.emptyList(), underRep, 2));
+
+      // Now adjust replicas so it is also over replicated. This time rather
+      // than throwing it should call the OverRepHandler and return whatever it
+      // returns, which in this case is a delete command for replica index 4.
+      availableReplicas.add(overRepReplica);
+
+      Map<DatanodeDetails, SCMCommand<?>> expectedDelete = new HashMap<>();
+      expectedDelete.put(overRepReplica.getDatanodeDetails(),
+          createDeleteContainerCommand(container, overRepReplica));
+
+      Mockito.when(replicationManager.processOverReplicatedContainer(
+          underRep)).thenReturn(expectedDelete);
+      Map<DatanodeDetails, SCMCommand<?>> commands =
+          ecURH.processAndCreateCommands(availableReplicas,
+              Collections.emptyList(), underRep, 2);
+      Mockito.verify(replicationManager, times(1))
+          .processOverReplicatedContainer(underRep);
+      Assertions.assertEquals(true, expectedDelete.equals(commands));
+    }
+  }
+
+  @Test
+  public void testUnderRepWithDecommissionAndNotEnoughNodes()
+      throws IOException {
+    DatanodeDetails newNode = MockDatanodeDetails.randomDatanodeDetails();
+    PlacementPolicy sameNodePolicy = ReplicationTestUtil
+        .getSameNodeTestPlacementPolicy(nodeManager, conf, newNode);
+
+    ContainerReplica overRepReplica =
+        ReplicationTestUtil.createContainerReplica(container.containerID(),
+            4, IN_SERVICE, CLOSED);
+    ContainerReplica decomReplica =
+        ReplicationTestUtil.createContainerReplica(container.containerID(),
+            5, DECOMMISSIONING, CLOSED);
+    ContainerReplica maintReplica =
+        ReplicationTestUtil.createContainerReplica(container.containerID(),
+            5, ENTERING_MAINTENANCE, CLOSED);
+
+    List<ContainerReplica> replicasToAdd = new ArrayList<>();
+    replicasToAdd.add(decomReplica);
+    replicasToAdd.add(maintReplica);
+
+    ECUnderReplicationHandler ecURH =
+        new ECUnderReplicationHandler(replicationCheck,
+            sameNodePolicy, conf, nodeManager, replicationManager);
+    ContainerHealthResult.UnderReplicatedHealthResult underRep =
+        new ContainerHealthResult.UnderReplicatedHealthResult(container,
+            1, false, false, false);
+
+    // The underRepHandler processes in stages. First missing indexes, then
+    // decommission and then maintenance. If a stage fails due to no new nodes
+    // available and there are some commands created by an earlier stage, we
+    // should just return those created commands even if the container is over
+    // replicated.
+    for (ContainerReplica toAdd : replicasToAdd) {
+      // The replicas are always over replicated with 2 index 4's.
+      // Index 1 is missing, then we add in either a decommissioning or
+      // entering_maintenance replica 5.
+      Set<ContainerReplica> availableReplicas = ReplicationTestUtil
+          .createReplicas(
+              Pair.of(IN_SERVICE, 2), Pair.of(IN_SERVICE, 3),
+              Pair.of(IN_SERVICE, 4), Pair.of(IN_SERVICE, 4));
+      if (toAdd != null) {
+        availableReplicas.add(toAdd);
+      }
+
+      Map<DatanodeDetails, SCMCommand<?>> expectedDelete = new HashMap<>();
+      expectedDelete.put(overRepReplica.getDatanodeDetails(),
+          createDeleteContainerCommand(container, overRepReplica));
+
+      Map<DatanodeDetails, SCMCommand<?>> commands =
+          ecURH.processAndCreateCommands(availableReplicas,
+              Collections.emptyList(), underRep, 2);
+
+      Mockito.verify(replicationManager, times(0))
+          .processOverReplicatedContainer(underRep);
+      Assertions.assertEquals(1, commands.size());
+      Assertions.assertEquals(StorageContainerDatanodeProtocolProtos
+              .SCMCommandProto.Type.reconstructECContainersCommand,
+          commands.get(newNode).getType());
+    }
+  }
+
+  @Test
+  public void testUnderRepDueToDecomAndOverRep()
+      throws IOException {
+    PlacementPolicy sameNodePolicy = ReplicationTestUtil
+        .getNoNodesTestPlacementPolicy(nodeManager, conf);
+    // First it is under-replicated, due to decom index 5, but no mode will be
+    // found. This will cause an exception to be thrown out, as the container is
+    // not also over replicated.
+    Set<ContainerReplica> availableReplicas = ReplicationTestUtil
+        .createReplicas(Pair.of(IN_SERVICE, 1),
+            Pair.of(IN_SERVICE, 2), Pair.of(IN_SERVICE, 3),
+            Pair.of(IN_SERVICE, 4), Pair.of(DECOMMISSIONING, 5));
+
+    ECUnderReplicationHandler ecURH =
+        new ECUnderReplicationHandler(replicationCheck,
+            sameNodePolicy, conf, nodeManager, replicationManager);
+
+    ContainerHealthResult.UnderReplicatedHealthResult underRep =
+        new ContainerHealthResult.UnderReplicatedHealthResult(container,
+            1, true, false, false);
+
+    Assert.assertThrows(SCMException.class,
+        () -> ecURH.processAndCreateCommands(availableReplicas,
+            Collections.emptyList(), underRep, 1));
+
+    // Now adjust replicas so it is also over replicated. This time rather than
+    // throwing it should call the OverRepHandler and return whatever it
+    // returns, which in this case is a delete command for replica index 4.
+    ContainerReplica overRepReplica =
+        ReplicationTestUtil.createContainerReplica(container.containerID(),
+            4, IN_SERVICE, CLOSED);
+    availableReplicas.add(overRepReplica);
+
+    Map<DatanodeDetails, SCMCommand<?>> expectedDelete = new HashMap<>();
+    expectedDelete.put(overRepReplica.getDatanodeDetails(),
+        createDeleteContainerCommand(container, overRepReplica));
+
+    Mockito.when(replicationManager.processOverReplicatedContainer(
+        underRep)).thenReturn(expectedDelete);
+    Map<DatanodeDetails, SCMCommand<?>> commands =
+        ecURH.processAndCreateCommands(availableReplicas,
+            Collections.emptyList(), underRep, 1);
+    Mockito.verify(replicationManager, times(1))
+        .processOverReplicatedContainer(underRep);
+    Assertions.assertEquals(true, expectedDelete.equals(commands));
+  }
+
+  @Test
+  public void testMissingAndDecomIndexWithOnlyOneNewNodeAvailable()
+      throws IOException {
     DatanodeDetails newDn = MockDatanodeDetails.randomDatanodeDetails();
     PlacementPolicy sameNodePolicy = ReplicationTestUtil
         .getSameNodeTestPlacementPolicy(nodeManager, conf, newDn);
@@ -266,12 +454,14 @@ public class TestECUnderReplicationHandler {
         availableReplicas, 0, 0, sameNodePolicy);
 
     // Now add a decommissioning index - we will not get a replicate command
-    // for it, as the placement policy will throw an exception we we catch
-    // and just return the reconstruction command.
+    // for it, as the placement policy will throw an exception as we catch
+    // and just return the first reconstruction command. This will not goto
+    // the over-rep handler as we have a command already created for the under
+    // replication, even if the container is over replicated too.
     Set<ContainerReplica> replicas = ReplicationTestUtil
         .createReplicas(Pair.of(DECOMMISSIONING, 1),
             Pair.of(IN_SERVICE, 2), Pair.of(IN_SERVICE, 3),
-            Pair.of(IN_SERVICE, 4));
+            Pair.of(IN_SERVICE, 4), Pair.of(IN_SERVICE, 4));
     testUnderReplicationWithMissingIndexes(ImmutableList.of(5),
         replicas, 0, 0, sameNodePolicy);
   }
@@ -346,5 +536,13 @@ public class TestECUnderReplicationHandler {
     Assertions.assertEquals(shouldReconstructCommandExist ? 1 : 0,
         reconstructCommand);
     return datanodeDetailsSCMCommandMap;
+  }
+
+  private DeleteContainerCommand createDeleteContainerCommand(
+      ContainerInfo containerInfo, ContainerReplica replica) {
+    DeleteContainerCommand deleteCommand =
+        new DeleteContainerCommand(containerInfo.getContainerID(), true);
+    deleteCommand.setReplicaIndex(replica.getReplicaIndex());
+    return deleteCommand;
   }
 }

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestECUnderReplicationHandler.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestECUnderReplicationHandler.java
@@ -265,17 +265,15 @@ public class TestECUnderReplicationHandler {
     testUnderReplicationWithMissingIndexes(ImmutableList.of(5),
         availableReplicas, 0, 0, sameNodePolicy);
 
-    // Now add a decommissioning index - we should get an exception as the
-    // placement policy should throw. It will have used up the node for
-    // reconstruction, and hence no nodes will be found to fix the decommission
-    // index.
+    // Now add a decommissioning index - we will not get a replicate command
+    // for it, as the placement policy will throw an exception we we catch
+    // and just return the reconstruction command.
     Set<ContainerReplica> replicas = ReplicationTestUtil
         .createReplicas(Pair.of(DECOMMISSIONING, 1),
             Pair.of(IN_SERVICE, 2), Pair.of(IN_SERVICE, 3),
             Pair.of(IN_SERVICE, 4));
-    assertThrows(SCMException.class, () ->
-        testUnderReplicationWithMissingIndexes(ImmutableList.of(5),
-            replicas, 1, 0, sameNodePolicy));
+    testUnderReplicationWithMissingIndexes(ImmutableList.of(5),
+        replicas, 0, 0, sameNodePolicy);
   }
 
   @Test


### PR DESCRIPTION
## What changes were proposed in this pull request?

On a small cluster, if an EC container is both over replicated and under replicated, there might be no free nodes to place a new replica on. In this case, we need to remove over-replicated replicas first, freeing up nodes to put the new replicas onto.

We always attempt to process under replication first and a container is only ever in one "bad" state (over, under or mis replicated), so the case of both under and over replication will fall into the under replication handler.

This PR solves this problem by catching "not enough nodes" exceptions in the under-replication handler - it then checks to see if the container is also over-replicated and if it is, passes control to the over-rep handler instead.

The under-replication repair will be reattempted on the next pass, hopefully after the excess replicas have been removed.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-7092

## How was this patch tested?

New unit tests added to validate the new logic.
