### PR TITLE
HDDS-7528. EC: ReplicationManager - refactor logic to send datanode commands into a central place

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/OverReplicatedProcessor.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/OverReplicatedProcessor.java
@@ -19,12 +19,6 @@ package org.apache.hadoop.hdds.scm.container.replication;
 
 import com.google.common.annotations.VisibleForTesting;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
-import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos;
-import org.apache.hadoop.hdds.scm.container.ContainerID;
-import org.apache.hadoop.hdds.scm.events.SCMEvents;
-import org.apache.hadoop.hdds.server.events.EventPublisher;
-import org.apache.hadoop.ozone.protocol.commands.CommandForDatanode;
-import org.apache.hadoop.ozone.protocol.commands.DeleteContainerCommand;
 import org.apache.hadoop.ozone.protocol.commands.SCMCommand;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ReplicationManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ReplicationManager.java
@@ -595,21 +595,16 @@ public class ReplicationManager implements SCMService {
       final DatanodeDetails datanode, final boolean force) {
 
     ContainerID containerID = container.containerID();
-    LOG.info("Sending close container command for container {}" +
-        " to datanode {}.", containerID, datanode);
     CloseContainerCommand closeContainerCommand =
         new CloseContainerCommand(container.getContainerID(),
             container.getPipelineID(), force);
+    closeContainerCommand.setEncodedToken(getContainerToken(containerID));
     try {
-      closeContainerCommand.setTerm(scmContext.getTermOfLeader());
+      sendDatanodeCommand(closeContainerCommand, container, datanode);
     } catch (NotLeaderException nle) {
       LOG.warn("Skip sending close container command,"
           + " since current SCM is not leader.", nle);
-      return;
     }
-    closeContainerCommand.setEncodedToken(getContainerToken(containerID));
-    eventPublisher.fireEvent(SCMEvents.DATANODE_COMMAND,
-        new CommandForDatanode<>(datanode.getUuid(), closeContainerCommand));
   }
 
   private String getContainerToken(ContainerID containerID) {

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ReplicationManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ReplicationManager.java
@@ -403,17 +403,17 @@ public class ReplicationManager implements SCMService {
    */
   public void sendDeleteCommand(final ContainerInfo container, int replicaIndex,
       final DatanodeDetails datanode) throws NotLeaderException {
-    LOG.info("Sending delete container command for container {}" +
-        " to datanode {}", container.containerID(), datanode);
-
     final DeleteContainerCommand deleteCommand =
         new DeleteContainerCommand(container.containerID(), false);
+    deleteCommand.setReplicaIndex(replicaIndex);
     sendDatanodeCommand(deleteCommand, container, datanode);
   }
 
   public void sendDatanodeCommand(SCMCommand<?> command,
       ContainerInfo containerInfo, DatanodeDetails target)
       throws NotLeaderException {
+    LOG.info("Sending command of type {} for container {} to {}",
+        command.getType(), containerInfo, target);
     command.setTerm(getScmTerm());
     final CommandForDatanode<?> datanodeCommand =
         new CommandForDatanode<>(target.getUuid(), command);

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ReplicationManagerMetrics.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ReplicationManagerMetrics.java
@@ -391,6 +391,14 @@ public final class ReplicationManagerMetrics implements MetricsSource {
     return ecDeletionCmdsSentTotal.value();
   }
 
+  public long getEcReconstructionCmdsSentTotal() {
+    return ecReconstructionCmdsSentTotal.value();
+  }
+
+  public long getEcReplicationCmdsSentTotal() {
+    return ecReplicationCmdsSentTotal.value();
+  }
+
   public void incrEcDeletionCmdsTimeoutTotal() {
     this.ecDeletionCmdsTimeoutTotal.incr();
   }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ReplicationManagerMetrics.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ReplicationManagerMetrics.java
@@ -387,6 +387,10 @@ public final class ReplicationManagerMetrics implements MetricsSource {
     this.ecReplicationCmdsTimeoutTotal.incr();
   }
 
+  public long getEcDeletionCmdsSentTotal() {
+    return ecDeletionCmdsSentTotal.value();
+  }
+
   public void incrEcDeletionCmdsTimeoutTotal() {
     this.ecDeletionCmdsTimeoutTotal.incr();
   }

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestOverReplicatedProcessor.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestOverReplicatedProcessor.java
@@ -25,12 +25,9 @@ import org.apache.hadoop.hdds.protocol.MockDatanodeDetails;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.hdds.scm.container.ContainerInfo;
 import org.apache.hadoop.hdds.scm.container.replication.ReplicationManager.ReplicationManagerConfiguration;
-import org.apache.hadoop.hdds.scm.events.SCMEvents;
-import org.apache.hadoop.hdds.server.events.EventPublisher;
 import org.apache.hadoop.ozone.protocol.commands.DeleteContainerCommand;
 import org.apache.hadoop.ozone.protocol.commands.SCMCommand;
 import org.apache.ozone.test.TestClock;
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
@@ -39,11 +36,9 @@ import java.io.IOException;
 import java.time.Instant;
 import java.time.ZoneId;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
 
 /**
  * Tests for the OverReplicatedProcessor class.

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestOverReplicatedProcessor.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestOverReplicatedProcessor.java
@@ -27,14 +27,11 @@ import org.apache.hadoop.hdds.scm.container.ContainerInfo;
 import org.apache.hadoop.hdds.scm.container.replication.ReplicationManager.ReplicationManagerConfiguration;
 import org.apache.hadoop.ozone.protocol.commands.DeleteContainerCommand;
 import org.apache.hadoop.ozone.protocol.commands.SCMCommand;
-import org.apache.ozone.test.TestClock;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
 
 import java.io.IOException;
-import java.time.Instant;
-import java.time.ZoneId;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -46,7 +43,6 @@ import static org.mockito.ArgumentMatchers.any;
 public class TestOverReplicatedProcessor {
 
   private ConfigurationSource conf;
-  private TestClock clock;
   private ReplicationManager replicationManager;
   private ECReplicationConfig repConfig;
   private OverReplicatedProcessor overReplicatedProcessor;
@@ -56,7 +52,6 @@ public class TestOverReplicatedProcessor {
     conf = new OzoneConfiguration();
     ReplicationManagerConfiguration rmConf =
         conf.getObject(ReplicationManagerConfiguration.class);
-    clock = new TestClock(Instant.now(), ZoneId.systemDefault());
     replicationManager = Mockito.mock(ReplicationManager.class);
     repConfig = new ECReplicationConfig(3, 2);
     overReplicatedProcessor = new OverReplicatedProcessor(

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestReplicationManager.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestReplicationManager.java
@@ -40,6 +40,8 @@ import org.apache.hadoop.hdds.scm.ha.SCMServiceManager;
 import org.apache.hadoop.hdds.scm.node.NodeManager;
 import org.apache.hadoop.hdds.server.events.EventPublisher;
 import org.apache.hadoop.ozone.protocol.commands.DeleteContainerCommand;
+import org.apache.hadoop.ozone.protocol.commands.ReconstructECContainersCommand;
+import org.apache.hadoop.ozone.protocol.commands.ReplicateContainerCommand;
 import org.apache.ozone.test.TestClock;
 import org.apache.ratis.protocol.exceptions.NotLeaderException;
 import org.junit.Assert;
@@ -61,6 +63,7 @@ import java.util.Set;
 import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_SCM_WAIT_TIME_AFTER_SAFE_MODE_EXIT;
 import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.NodeOperationalState.DECOMMISSIONING;
 import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationFactor.THREE;
+import static org.apache.hadoop.hdds.scm.container.replication.ContainerReplicaOp.PendingOpType.ADD;
 import static org.apache.hadoop.hdds.scm.container.replication.ReplicationTestUtil.createContainerInfo;
 import static org.apache.hadoop.hdds.scm.container.replication.ReplicationTestUtil.createReplicas;
 import static org.mockito.ArgumentMatchers.any;
@@ -358,7 +361,7 @@ public class TestReplicationManager {
     DatanodeDetails target = MockDatanodeDetails.randomDatanodeDetails();
 
     DeleteContainerCommand deleteContainerCommand = new DeleteContainerCommand(
-      containerInfo.getContainerID());
+        containerInfo.getContainerID());
     deleteContainerCommand.setReplicaIndex(1);
 
     replicationManager.sendDatanodeCommand(deleteContainerCommand,
@@ -402,6 +405,113 @@ public class TestReplicationManager {
         .getNumDeletionCmdsSent());
     Assertions.assertEquals(20, replicationManager.getMetrics()
         .getNumDeletionBytesTotal());
+  }
+
+  @Test
+  public void testSendDatanodeReconstructCommand() throws NotLeaderException {
+    ECReplicationConfig ecRepConfig = new ECReplicationConfig(3, 2);
+    ContainerInfo containerInfo =
+        ReplicationTestUtil.createContainerInfo(ecRepConfig, 1,
+            HddsProtos.LifeCycleState.CLOSED, 10, 20);
+
+    List<ReconstructECContainersCommand.DatanodeDetailsAndReplicaIndex>
+        sourceNodes = new ArrayList<>();
+    for (int i = 1; i <= 3; i++) {
+      sourceNodes.add(
+          new ReconstructECContainersCommand.DatanodeDetailsAndReplicaIndex(
+              MockDatanodeDetails.randomDatanodeDetails(), i));
+    }
+    List<DatanodeDetails> targetNodes = new ArrayList<>();
+    DatanodeDetails target4 = MockDatanodeDetails.randomDatanodeDetails();
+    DatanodeDetails target5 = MockDatanodeDetails.randomDatanodeDetails();
+    targetNodes.add(target4);
+    targetNodes.add(target5);
+    byte[] missingIndexes = {4, 5};
+
+    ReconstructECContainersCommand command = new ReconstructECContainersCommand(
+        containerInfo.getContainerID(), sourceNodes, targetNodes,
+        missingIndexes, ecRepConfig);
+
+    replicationManager.sendDatanodeCommand(command, containerInfo, target4);
+
+    List<ContainerReplicaOp> ops = containerReplicaPendingOps.getPendingOps(
+        containerInfo.containerID());
+    Mockito.verify(eventPublisher).fireEvent(any(), any());
+    Assertions.assertEquals(2, ops.size());
+    Set<DatanodeDetails> cmdTargets = new HashSet<>();
+    Set<Integer> cmdIndexes = new HashSet<>();
+    for (ContainerReplicaOp op : ops) {
+      Assertions.assertEquals(ADD, op.getOpType());
+      cmdTargets.add(op.getTarget());
+      cmdIndexes.add(op.getReplicaIndex());
+    }
+    Assertions.assertEquals(2, cmdTargets.size());
+    for (DatanodeDetails dn : targetNodes) {
+      Assertions.assertTrue(cmdTargets.contains(dn));
+    }
+
+    Assertions.assertEquals(2, cmdIndexes.size());
+    for (int i : missingIndexes) {
+      Assertions.assertTrue(cmdIndexes.contains(i));
+    }
+    Assertions.assertEquals(1, replicationManager.getMetrics()
+        .getEcReconstructionCmdsSentTotal());
+  }
+
+  @Test
+  public void testSendDatanodeRewplicateCommand() throws NotLeaderException {
+    ECReplicationConfig ecRepConfig = new ECReplicationConfig(3, 2);
+    ContainerInfo containerInfo =
+        ReplicationTestUtil.createContainerInfo(ecRepConfig, 1,
+            HddsProtos.LifeCycleState.CLOSED, 10, 20);
+    DatanodeDetails target = MockDatanodeDetails.randomDatanodeDetails();
+
+    List<DatanodeDetails> sources = new ArrayList<>();
+    sources.add(MockDatanodeDetails.randomDatanodeDetails());
+    sources.add(MockDatanodeDetails.randomDatanodeDetails());
+
+
+    ReplicateContainerCommand command = new ReplicateContainerCommand(
+        containerInfo.getContainerID(), sources);
+    command.setReplicaIndex(1);
+
+    replicationManager.sendDatanodeCommand(command, containerInfo, target);
+
+    List<ContainerReplicaOp> ops = containerReplicaPendingOps.getPendingOps(
+        containerInfo.containerID());
+    Mockito.verify(eventPublisher).fireEvent(any(), any());
+    Assertions.assertEquals(1, ops.size());
+    Assertions.assertEquals(ContainerReplicaOp.PendingOpType.ADD,
+        ops.get(0).getOpType());
+    Assertions.assertEquals(target, ops.get(0).getTarget());
+    Assertions.assertEquals(1, ops.get(0).getReplicaIndex());
+    Assertions.assertEquals(1, replicationManager.getMetrics()
+        .getEcReplicationCmdsSentTotal());
+    Assertions.assertEquals(0, replicationManager.getMetrics()
+        .getNumReplicationCmdsSent());
+
+    // Repeat with Ratis container, as different metrics should be incremented
+    Mockito.clearInvocations(eventPublisher);
+    RatisReplicationConfig ratisRepConfig =
+        RatisReplicationConfig.getInstance(THREE);
+    containerInfo = ReplicationTestUtil.createContainerInfo(ratisRepConfig, 2,
+        HddsProtos.LifeCycleState.CLOSED, 10, 20);
+
+    command = new ReplicateContainerCommand(
+        containerInfo.getContainerID(), sources);
+    replicationManager.sendDatanodeCommand(command, containerInfo, target);
+
+    ops = containerReplicaPendingOps.getPendingOps(containerInfo.containerID());
+    Mockito.verify(eventPublisher).fireEvent(any(), any());
+    Assertions.assertEquals(1, ops.size());
+    Assertions.assertEquals(ContainerReplicaOp.PendingOpType.ADD,
+        ops.get(0).getOpType());
+    Assertions.assertEquals(target, ops.get(0).getTarget());
+    Assertions.assertEquals(0, ops.get(0).getReplicaIndex());
+    Assertions.assertEquals(1, replicationManager.getMetrics()
+        .getEcReplicationCmdsSentTotal());
+    Assertions.assertEquals(1, replicationManager.getMetrics()
+        .getNumReplicationCmdsSent());
   }
 
   @SafeVarargs

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestReplicationManager.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestReplicationManager.java
@@ -459,7 +459,7 @@ public class TestReplicationManager {
   }
 
   @Test
-  public void testSendDatanodeRewplicateCommand() throws NotLeaderException {
+  public void testSendDatanodeReplicateCommand() throws NotLeaderException {
     ECReplicationConfig ecRepConfig = new ECReplicationConfig(3, 2);
     ContainerInfo containerInfo =
         ReplicationTestUtil.createContainerInfo(ecRepConfig, 1,

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestUnderReplicatedProcessor.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestUnderReplicatedProcessor.java
@@ -25,13 +25,10 @@ import org.apache.hadoop.hdds.protocol.MockDatanodeDetails;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.hdds.scm.container.ContainerInfo;
 import org.apache.hadoop.hdds.scm.container.replication.ReplicationManager.ReplicationManagerConfiguration;
-import org.apache.hadoop.hdds.scm.events.SCMEvents;
-import org.apache.hadoop.hdds.server.events.EventPublisher;
 import org.apache.hadoop.ozone.protocol.commands.ReconstructECContainersCommand;
 import org.apache.hadoop.ozone.protocol.commands.ReplicateContainerCommand;
 import org.apache.hadoop.ozone.protocol.commands.SCMCommand;
 import org.apache.ozone.test.TestClock;
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
@@ -44,7 +41,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.any;
 
 /**
  * Tests for the UnderReplicatedProcessor class.
@@ -53,9 +50,7 @@ public class TestUnderReplicatedProcessor {
 
   private ConfigurationSource conf;
   private TestClock clock;
-  private ContainerReplicaPendingOps pendingOps;
   private ReplicationManager replicationManager;
-  private EventPublisher eventPublisher;
   private ECReplicationConfig repConfig;
   private UnderReplicatedProcessor underReplicatedProcessor;
 
@@ -65,13 +60,10 @@ public class TestUnderReplicatedProcessor {
     ReplicationManagerConfiguration rmConf =
         conf.getObject(ReplicationManagerConfiguration.class);
     clock = new TestClock(Instant.now(), ZoneId.systemDefault());
-    pendingOps = new ContainerReplicaPendingOps(conf, clock);
     replicationManager = Mockito.mock(ReplicationManager.class);
-    eventPublisher = Mockito.mock(EventPublisher.class);
     repConfig = new ECReplicationConfig(3, 2);
     underReplicatedProcessor = new UnderReplicatedProcessor(
-        replicationManager, pendingOps, eventPublisher,
-        rmConf.getUnderReplicatedInterval());
+        replicationManager, rmConf.getUnderReplicatedInterval());
     Mockito.when(replicationManager.shouldRun()).thenReturn(true);
     Mockito.when(replicationManager.getMetrics())
         .thenReturn(ReplicationManagerMetrics.create(replicationManager));
@@ -103,24 +95,14 @@ public class TestUnderReplicatedProcessor {
             sourceNodes, targetNodes, missingIndexes, repConfig));
 
     Mockito.when(replicationManager
-            .processUnderReplicatedContainer(Mockito.any()))
+            .processUnderReplicatedContainer(any()))
         .thenReturn(commands);
     underReplicatedProcessor.processAll();
 
-    Mockito.verify(eventPublisher, Mockito.times(1))
-        .fireEvent(eq(SCMEvents.DATANODE_COMMAND), Mockito.any());
+    Mockito.verify(replicationManager, Mockito.times(1))
+        .sendDatanodeCommand(any(), any(), any());
     Mockito.verify(replicationManager, Mockito.times(0))
-        .requeueUnderReplicatedContainer(Mockito.any());
-
-    // Ensure pending ops is updated for the target DNs in the command and the
-    // correct indexes.
-    List<ContainerReplicaOp> ops = pendingOps
-        .getPendingOps(container.containerID());
-    Assert.assertEquals(2, ops.size());
-    for (ContainerReplicaOp op : ops) {
-      int ind = targetNodes.indexOf(op.getTarget());
-      Assert.assertEquals(missingIndexes[ind], op.getReplicaIndex());
-    }
+        .requeueUnderReplicatedContainer(any());
   }
 
   @Test
@@ -142,24 +124,14 @@ public class TestUnderReplicatedProcessor {
     commands.put(targetDn, rcc);
 
     Mockito.when(replicationManager
-            .processUnderReplicatedContainer(Mockito.any()))
+            .processUnderReplicatedContainer(any()))
         .thenReturn(commands);
     underReplicatedProcessor.processAll();
 
-    Mockito.verify(eventPublisher, Mockito.times(1))
-        .fireEvent(eq(SCMEvents.DATANODE_COMMAND), Mockito.any());
+    Mockito.verify(replicationManager, Mockito.times(1))
+        .sendDatanodeCommand(any(), any(), any());
     Mockito.verify(replicationManager, Mockito.times(0))
-        .requeueUnderReplicatedContainer(Mockito.any());
-
-    // Ensure pending ops is updated for the target DNs in the command and the
-    // correct indexes.
-    List<ContainerReplicaOp> ops = pendingOps
-        .getPendingOps(container.containerID());
-    //Check InFlight Replication
-    Assert.assertEquals(pendingOps
-        .getPendingOpCount(ContainerReplicaOp.PendingOpType.ADD), 1);
-    Assert.assertEquals(1, ops.size());
-    Assert.assertEquals(3, ops.get(0).getReplicaIndex());
+        .requeueUnderReplicatedContainer(any());
   }
 
   @Test
@@ -172,18 +144,13 @@ public class TestUnderReplicatedProcessor {
             (ContainerHealthResult.UnderReplicatedHealthResult) null);
 
     Mockito.when(replicationManager
-            .processUnderReplicatedContainer(Mockito.any()))
+            .processUnderReplicatedContainer(any()))
         .thenThrow(new IOException("Test Exception"));
     underReplicatedProcessor.processAll();
 
-    Mockito.verify(eventPublisher, Mockito.times(0))
-        .fireEvent(eq(SCMEvents.DATANODE_COMMAND), Mockito.any());
+    Mockito.verify(replicationManager, Mockito.times(0))
+        .sendDatanodeCommand(any(), any(), any());
     Mockito.verify(replicationManager, Mockito.times(1))
-        .requeueUnderReplicatedContainer(Mockito.any());
-
-    // Ensure pending ops has nothing for this container.
-    List<ContainerReplicaOp> ops = pendingOps
-        .getPendingOps(container.containerID());
-    Assert.assertEquals(0, ops.size());
+        .requeueUnderReplicatedContainer(any());
   }
 }

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestUnderReplicatedProcessor.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestUnderReplicatedProcessor.java
@@ -28,14 +28,11 @@ import org.apache.hadoop.hdds.scm.container.replication.ReplicationManager.Repli
 import org.apache.hadoop.ozone.protocol.commands.ReconstructECContainersCommand;
 import org.apache.hadoop.ozone.protocol.commands.ReplicateContainerCommand;
 import org.apache.hadoop.ozone.protocol.commands.SCMCommand;
-import org.apache.ozone.test.TestClock;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
 
 import java.io.IOException;
-import java.time.Instant;
-import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -49,7 +46,6 @@ import static org.mockito.ArgumentMatchers.any;
 public class TestUnderReplicatedProcessor {
 
   private ConfigurationSource conf;
-  private TestClock clock;
   private ReplicationManager replicationManager;
   private ECReplicationConfig repConfig;
   private UnderReplicatedProcessor underReplicatedProcessor;
@@ -59,7 +55,6 @@ public class TestUnderReplicatedProcessor {
     conf = new OzoneConfiguration();
     ReplicationManagerConfiguration rmConf =
         conf.getObject(ReplicationManagerConfiguration.class);
-    clock = new TestClock(Instant.now(), ZoneId.systemDefault());
     replicationManager = Mockito.mock(ReplicationManager.class);
     repConfig = new ECReplicationConfig(3, 2);
     underReplicatedProcessor = new UnderReplicatedProcessor(


### PR DESCRIPTION
## What changes were proposed in this pull request?

The logic to send datanode commands, such as replicate, reconstruct, delete and close container happens in a few different places in the RM classes. It would make sense to centralise this in some common code, as it will make it more re-usable. There is some logic in the balancer which could re-use these new central methods to send replicate and delete commands too.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-7528

## How was this patch tested?

Some tests modified and some new ones added to cover the new logic.
