### PR TITLE
HDDS-7449. Avoid overwriting bucket encryption properties when quota/replication config are set on an existing bucket

### DIFF
--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/bucket/OMBucketSetPropertyRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/bucket/OMBucketSetPropertyRequest.java
@@ -153,6 +153,7 @@ public class OMBucketSetPropertyRequest extends OMClientRequest {
           .setBucketName(dbBucketInfo.getBucketName())
           .setObjectID(dbBucketInfo.getObjectID())
           .setBucketLayout(dbBucketInfo.getBucketLayout())
+          .setBucketEncryptionKey(dbBucketInfo.getEncryptionKeyInfo())
           .setUpdateID(transactionLogIndex);
       bucketInfoBuilder.addAllMetadata(KeyValueUtil
           .getFromProtobuf(bucketArgs.getMetadataList()));

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/bucket/TestOMBucketSetPropertyRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/bucket/TestOMBucketSetPropertyRequest.java
@@ -314,7 +314,7 @@ public class TestOMBucketSetPropertyRequest extends TestBucketRequest {
             .getProtobuf();
 
     OMRequest omRequest = OMRequest.newBuilder().setSetBucketPropertyRequest(
-                    SetBucketPropertyRequest.newBuilder().setBucketArgs(bucketArgs))
+            SetBucketPropertyRequest.newBuilder().setBucketArgs(bucketArgs))
             .setCmdType(OzoneManagerProtocolProtos.Type.SetBucketProperty)
             .setClientId(UUID.randomUUID().toString()).build();
 
@@ -331,7 +331,8 @@ public class TestOMBucketSetPropertyRequest extends TestBucketRequest {
     OmBucketInfo dbBucketInfo =
             omMetadataManager.getBucketTable().get(bucketKey);
 
-    Assert.assertEquals(TEST_KEY, dbBucketInfo.getEncryptionKeyInfo().getKeyName());
+    Assert.assertEquals(TEST_KEY,
+            dbBucketInfo.getEncryptionKeyInfo().getKeyName());
     Assert.assertEquals(EC,
             dbBucketInfo.getDefaultReplicationConfig().getType());
   }
@@ -368,7 +369,8 @@ public class TestOMBucketSetPropertyRequest extends TestBucketRequest {
     OmBucketInfo dbBucketInfo =
             omMetadataManager.getBucketTable().get(bucketKey);
 
-    Assert.assertEquals(TEST_KEY, dbBucketInfo.getEncryptionKeyInfo().getKeyName());
+    Assert.assertEquals(TEST_KEY,
+            dbBucketInfo.getEncryptionKeyInfo().getKeyName());
     Assert.assertEquals(20 * GB,
             dbBucketInfo.getQuotaInBytes());
     Assert.assertEquals(1000L,


### PR DESCRIPTION

## What changes were proposed in this pull request?

If EC or quotas are set on an existing encrypted bucket, the encryption bucket property gets overwritten. Any keys created on the updated bucket are not encrypted. 
```
sh-4.2$ ozone sh bucket create -k key1 o3://om/vol1/saketa-ec1bucket
sh-4.2$ ozone sh bucket info o3://om/vol1/saketa-ec1bucket
{
  "metadata" : { },
  "volumeName" : "vol1",
  "name" : "saketa-ec1bucket",
  "storageType" : "DISK",
  "versioning" : false,
  "usedBytes" : 0,
  "usedNamespace" : 0,
  "creationTime" : "2022-11-22T17:32:37.501Z",
  "modificationTime" : "2022-11-22T17:32:37.501Z",
  "encryptionKeyName" : "key1",
  "quotaInBytes" : -1,
  "quotaInNamespace" : -1,
  "bucketLayout" : "LEGACY",
  "owner" : "testuser",
  "link" : false
}
sh-4.2$ ozone sh bucket set-replication-config o3://om/vol1/saketa-ec1bucket --type EC --replication rs-3-2-1024k
sh-4.2$ ozone sh bucket info o3://om/vol1/saketa-ec1bucket
{
  "metadata" : { },
  "volumeName" : "vol1",
  "name" : "saketa-ec1bucket",
  "storageType" : "DISK",
  "versioning" : false,
  "usedBytes" : 0,
  "usedNamespace" : 0,
  "creationTime" : "2022-11-22T17:32:37.501Z",
  "modificationTime" : "2022-11-22T17:33:43.131Z",
  "quotaInBytes" : -1,
  "quotaInNamespace" : -1,
  "bucketLayout" : "LEGACY",
  "replicationConfig" : {
    "data" : 3,
    "parity" : 2,
    "ecChunkSize" : 1048576,
    "codec" : "RS",
    "replicationType" : "EC",
    "requiredNodes" : 5
  },
  "link" : false
}

sh-4.2$ ozone sh bucket create -k key1 o3://om/vol1/saketa-quota1bucket
sh-4.2$ ozone sh bucket info o3://om/vol1/saketa-quota1bucket
{
  "metadata" : { },
  "volumeName" : "vol1",
  "name" : "saketa-quota1bucket",
  "storageType" : "DISK",
  "versioning" : false,
  "usedBytes" : 0,
  "usedNamespace" : 0,
  "creationTime" : "2022-11-22T18:13:52.289Z",
  "modificationTime" : "2022-11-22T18:13:52.289Z",
  "encryptionKeyName" : "key1",
  "quotaInBytes" : -1,
  "quotaInNamespace" : -1,
  "bucketLayout" : "LEGACY",
  "owner" : "testuser",
  "link" : false
}
sh-4.2$ ozone sh bucket setquota --quota=1GB --namespace-quota=1000 o3://om/vol1/saketa-quota1bucket
sh-4.2$ ozone sh bucket info o3://om/vol1/saketa-quota1bucket
{
  "metadata" : { },
  "volumeName" : "vol1",
  "name" : "saketa-quota1bucket",
  "storageType" : "DISK",
  "versioning" : false,
  "usedBytes" : 0,
  "usedNamespace" : 0,
  "creationTime" : "2022-11-22T18:13:52.289Z",
  "modificationTime" : "2022-11-22T18:14:57.738Z",
  "quotaInBytes" : 1073741824,
  "quotaInNamespace" : 1000,
  "bucketLayout" : "LEGACY",
  "replicationConfig" : {
    "replicationFactor" : "ONE",
    "requiredNodes" : 1,
    "replicationType" : "RATIS"
  },
  "link" : false
}
```
Fix includes retaining encryption properties from existing bucket info when building the new omBucketInfo object. 

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-7449

## How was this patch tested?

Manual test.
```
sh-4.2$ ozone sh bucket create -k key1 o3://om/vol1/saketa-ec3bucket --layout FILE_SYSTEM_OPTIMIZED
sh-4.2$ ozone sh bucket info o3://om/vol1/saketa-ec3bucket
{
  "metadata" : { },
  "volumeName" : "vol1",
  "name" : "saketa-ec3bucket",
  "storageType" : "DISK",
  "versioning" : false,
  "usedBytes" : 0,
  "usedNamespace" : 0,
  "creationTime" : "2022-11-22T18:36:17.932Z",
  "modificationTime" : "2022-11-22T18:36:17.932Z",
  "encryptionKeyName" : "key1",
  "quotaInBytes" : -1,
  "quotaInNamespace" : -1,
  "bucketLayout" : "FILE_SYSTEM_OPTIMIZED",
  "owner" : "testuser",
  "link" : false
}
sh-4.2$ ozone sh bucket set-replication-config o3://om/vol1/saketa-ec3bucket --type EC --replication rs-3-2-1024k
sh-4.2$ ozone sh bucket info o3://om/vol1/saketa-ec3bucket
{
  "metadata" : { },
  "volumeName" : "vol1",
  "name" : "saketa-ec3bucket",
  "storageType" : "DISK",
  "versioning" : false,
  "usedBytes" : 0,
  "usedNamespace" : 0,
  "creationTime" : "2022-11-22T18:36:17.932Z",
  "modificationTime" : "2022-11-22T18:36:27.930Z",
  "encryptionKeyName" : "key1",
  "quotaInBytes" : -1,
  "quotaInNamespace" : -1,
  "bucketLayout" : "FILE_SYSTEM_OPTIMIZED",
  "replicationConfig" : {
    "data" : 3,
    "parity" : 2,
    "ecChunkSize" : 1048576,
    "codec" : "RS",
    "replicationType" : "EC",
    "requiredNodes" : 5
  },
  "link" : false
}

sh-4.2$ ozone sh bucket info o3://om/vol1/saketa-quota1bucket
ozone sh bucket setquota --quota=1GB --namespace-quota=1000 o3://om/vol1/saketa-quota1bucket{
  "metadata" : { },
  "volumeName" : "vol1",
  "name" : "saketa-quota1bucket",
  "storageType" : "DISK",
  "versioning" : false,
  "usedBytes" : 0,
  "usedNamespace" : 0,
  "creationTime" : "2022-11-22T18:37:17.889Z",
  "modificationTime" : "2022-11-22T18:37:17.889Z",
  "encryptionKeyName" : "key1",
  "quotaInBytes" : -1,
  "quotaInNamespace" : -1,
  "bucketLayout" : "LEGACY",
  "owner" : "testuser",
  "link" : false
}

sh-4.2$ ozone sh bucket setquota --quota=1GB --namespace-quota=1000 o3://om/vol1/saketa-quota1bucket
sh-4.2$ ozone sh bucket info o3://om/vol1/saketa-quota1bucket
{
  "metadata" : { },
  "volumeName" : "vol1",
  "name" : "saketa-quota1bucket",
  "storageType" : "DISK",
  "versioning" : false,
  "usedBytes" : 0,
  "usedNamespace" : 0,
  "creationTime" : "2022-11-22T18:37:17.889Z",
  "modificationTime" : "2022-11-22T18:37:26.994Z",
  "encryptionKeyName" : "key1",
  "quotaInBytes" : 1073741824,
  "quotaInNamespace" : 1000,
  "bucketLayout" : "LEGACY",
  "replicationConfig" : {
    "replicationFactor" : "ONE",
    "requiredNodes" : 1,
    "replicationType" : "RATIS"
  },
  "link" : false
}
```
