### PR TITLE
HDDS-7512. [snapshot] List Snapshot returns an empty list for a non-existent bucket

### DIFF
--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmMetadataManagerImpl.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmMetadataManagerImpl.java
@@ -1178,6 +1178,12 @@ public class OmMetadataManagerImpl implements OMMetadataManager {
           ResultCodes.BUCKET_NOT_FOUND);
     }
 
+    String bucketNameBytes = getBucketKey(volumeName, bucketName);
+    if (getBucketTable().get(bucketNameBytes) == null) {
+      throw new OMException("Bucket " + bucketName + " not found.",
+          ResultCodes.BUCKET_NOT_FOUND);
+    }
+
     String prefix = getBucketKey(volumeName, bucketName + OM_KEY_PREFIX);
     TreeMap<String, SnapshotInfo> snapshotInfoMap = new TreeMap<>();
 
@@ -1207,6 +1213,7 @@ public class OmMetadataManagerImpl implements OMMetadataManager {
     try (TableIterator<String, ? extends KeyValue<String, SnapshotInfo>>
              snapshotIter = snapshotInfoTable.iterator()) {
       KeyValue< String, SnapshotInfo> snapshotinfo;
+      snapshotIter.seek(prefix);
       while (snapshotIter.hasNext()) {
         snapshotinfo = snapshotIter.next();
         if (snapshotinfo != null && snapshotinfo.getKey().startsWith(prefix)) {

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmMetadataManagerImpl.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmMetadataManagerImpl.java
@@ -1169,19 +1169,17 @@ public class OmMetadataManagerImpl implements OMMetadataManager {
   public List<SnapshotInfo> listSnapshot(String volumeName, String bucketName)
       throws IOException {
     if (Strings.isNullOrEmpty(volumeName)) {
-      throw new OMException("Volume name is required.",
-          ResultCodes.VOLUME_NOT_FOUND);
+      throw new OMException("Volume name is required.", VOLUME_NOT_FOUND);
     }
 
     if (Strings.isNullOrEmpty(bucketName)) {
-      throw new OMException("Bucket name is required.",
-          ResultCodes.BUCKET_NOT_FOUND);
+      throw new OMException("Bucket name is required.", BUCKET_NOT_FOUND);
     }
 
     String bucketNameBytes = getBucketKey(volumeName, bucketName);
     if (getBucketTable().get(bucketNameBytes) == null) {
       throw new OMException("Bucket " + bucketName + " not found.",
-          ResultCodes.BUCKET_NOT_FOUND);
+          BUCKET_NOT_FOUND);
     }
 
     String prefix = getBucketKey(volumeName, bucketName + OM_KEY_PREFIX);

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestOmMetadataManager.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestOmMetadataManager.java
@@ -34,7 +34,6 @@ import org.apache.hadoop.ozone.om.helpers.SnapshotInfo;
 import org.apache.hadoop.ozone.om.request.OMRequestTestUtils;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OpenKey;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OpenKeyBucket;
-import org.apache.ozone.test.LambdaTestUtils.VoidCallable;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.io.TempDir;
@@ -63,6 +62,7 @@ import static org.apache.hadoop.ozone.om.exceptions.OMException.ResultCodes.BUCK
 import static org.apache.hadoop.ozone.om.exceptions.OMException.ResultCodes.VOLUME_NOT_FOUND;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 import static org.junit.jupiter.params.provider.Arguments.arguments;
@@ -77,17 +77,6 @@ public class TestOmMetadataManager {
   @TempDir
   private File folder;
 
-  public static <E extends Throwable> void expectOmException(
-      ResultCodes code,
-      VoidCallable eval)
-      throws Exception {
-    try {
-      eval.call();
-      fail("OMException is expected");
-    } catch (OMException ex) {
-      assertEquals(code, ex.getResult());
-    }
-  }
 
   @BeforeEach
   public void setup() throws Exception {
@@ -732,9 +721,9 @@ public class TestOmMetadataManager {
     OMRequestTestUtils.addVolumeToDB(vol1, omMetadataManager);
     addBucketsToCache(vol1, bucket1);
 
-    expectOmException(expectedResultCode,
+    OMException oe = assertThrows(OMException.class,
         () -> omMetadataManager.listSnapshot(volume, bucket));
-
+    assertEquals(expectedResultCode, oe.getResult());
   }
 
   private static Stream<Arguments> listSnapshotWithInvalidPathCases() {

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestOmMetadataManager.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestOmMetadataManager.java
@@ -673,6 +673,7 @@ public class TestOmMetadataManager {
   public void testListSnapshot() throws Exception {
     String vol1 = "vol1";
     String bucket1 = "bucket1";
+    String nonexistentBucket = "nonexistentBucket";
 
     OMRequestTestUtils.addVolumeToDB(vol1, omMetadataManager);
     addBucketsToCache(vol1, bucket1);
@@ -689,12 +690,17 @@ public class TestOmMetadataManager {
     }
 
     //Test listing snapshots with no volume name.
-    Assert.assertThrows(OMException.class, () -> omMetadataManager.listSnapshot(
-        null, null));
+    Assert.assertThrows(OMException.class,
+        () -> omMetadataManager.listSnapshot(null, null));
 
     //Test listing snapshots with no bucket name.
-    Assert.assertThrows(OMException.class, () -> omMetadataManager.listSnapshot(
-        vol1, null));
+    Assert.assertThrows(OMException.class,
+        () -> omMetadataManager.listSnapshot(vol1, null));
+
+    //Test listing snapshots with non-existent bucket.
+
+    Assert.assertThrows(OMException.class,
+        () -> omMetadataManager.listSnapshot(vol1, nonexistentBucket));
 
     //Test listing all snapshots.
     List<SnapshotInfo> snapshotInfos = omMetadataManager.listSnapshot(vol1,

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestOmMetadataManager.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestOmMetadataManager.java
@@ -64,7 +64,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
 import static org.junit.jupiter.params.provider.Arguments.arguments;
 
 /**

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestOmMetadataManager.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestOmMetadataManager.java
@@ -34,7 +34,7 @@ import org.apache.hadoop.ozone.om.helpers.SnapshotInfo;
 import org.apache.hadoop.ozone.om.request.OMRequestTestUtils;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OpenKey;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OpenKeyBucket;
-import org.apache.ozone.test.LambdaTestUtils;
+import org.apache.ozone.test.LambdaTestUtils.VoidCallable;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.io.TempDir;
@@ -78,8 +78,8 @@ public class TestOmMetadataManager {
   private File folder;
 
   public static <E extends Throwable> void expectOmException(
-      OMException.ResultCodes code,
-      LambdaTestUtils.VoidCallable eval)
+      ResultCodes code,
+      VoidCallable eval)
       throws Exception {
     try {
       eval.call();

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestOmMetadataManager.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestOmMetadataManager.java
@@ -720,7 +720,8 @@ public class TestOmMetadataManager {
   @ParameterizedTest
   @NullSource
   @ValueSource(strings = { "nonexistentBucket"})
-  public void testListSnapshotWithInvalidPath(String invalidBucket) throws Exception {
+  public void testListSnapshotWithInvalidPath(String invalidBucket)
+      throws Exception {
     String vol1 = "vol1";
     String bucket1 = "bucket1";
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

1. Fix list snapshot API. Let it list the correct snapshot when there are more than one buckets.
2. Throw an exception when listing a non-existent bucket.
3. Add a assertion in `testListSnapshot` for listing a non-existent bucket.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-7512

## How was this patch tested?

The following is a manual test on docker for listing correct snapshot:
![螢幕快照 2022-11-23 10-26-37](https://user-images.githubusercontent.com/65023303/203458307-ba5ef215-7e7c-43ba-a109-7df98ca275d6.png)

The following is a manual test on docker for listing a non-existent bucket:
![螢幕快照 2022-11-23 10-29-18](https://user-images.githubusercontent.com/65023303/203458613-390d4f09-7145-4f5a-8c30-ad198c553d31.png)

The following is the unit test: 
![螢幕快照 2022-11-23 10-43-15](https://user-images.githubusercontent.com/65023303/203460012-494f6aef-c1be-4e9d-9115-2d0fd7e07ad0.png)

