### PR TITLE
HDDS-6615. EC: Improve write performance by pipelining encode and flush

### DIFF
--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/OzoneClientConfig.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/OzoneClientConfig.java
@@ -143,6 +143,13 @@ public class OzoneClientConfig {
       tags = ConfigTag.CLIENT)
   private int maxECStripeWriteRetries = 10;
 
+  @Config(key = "ec.stripe.queue.size",
+      defaultValue = "2",
+      description = "The max number of EC stripes can be buffered in client " +
+          " before flushing into datanodes.",
+      tags = ConfigTag.CLIENT)
+  private int ecStripeQueueSize = 2;
+
   @Config(key = "exclude.nodes.expiry.time",
       defaultValue = "600000",
       description = "Time after which an excluded node is reconsidered for" +
@@ -286,6 +293,10 @@ public class OzoneClientConfig {
 
   public int getMaxECStripeWriteRetries() {
     return this.maxECStripeWriteRetries;
+  }
+
+  public int getEcStripeQueueSize() {
+    return this.ecStripeQueueSize;
   }
 
   public long getExcludeNodesExpiryTime() {

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/io/ECKeyOutputStream.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/io/ECKeyOutputStream.java
@@ -167,7 +167,7 @@ public final class ECKeyOutputStream extends KeyOutputStream {
       }
     } catch (Exception e) {
       markStreamClosed();
-      throw new IOException(e.getMessage());
+      throw e;
     }
     writeOffset += len;
   }

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/io/ECKeyOutputStream.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/io/ECKeyOutputStream.java
@@ -522,7 +522,7 @@ public final class ECKeyOutputStream extends KeyOutputStream {
 
   private void addStripeToQueue(ECChunkBuffers stripe) throws IOException {
     try {
-      while (!ecStripeQueue.offer(stripe, 1, TimeUnit.SECONDS)) {
+      do {
         // If flushFuture is done, it means that the flush thread has
         // encountered an exception. Call get() to throw that exception here.
         if (flushFuture.isDone()) {
@@ -530,7 +530,7 @@ public final class ECKeyOutputStream extends KeyOutputStream {
           // We should never reach here.
           throw new IOException("Flush thread has ended before stream close");
         }
-      }
+      } while (!ecStripeQueue.offer(stripe, 1, TimeUnit.SECONDS));
     } catch (InterruptedException e) {
       Thread.currentThread().interrupt();
       throw new IOException("Interrupted while adding stripe to queue", e);

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/io/ECKeyOutputStream.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/io/ECKeyOutputStream.java
@@ -190,15 +190,7 @@ public final class ECKeyOutputStream extends KeyOutputStream {
     // group.
     // TODO: we can improve to write partial stripe failures. In that case,
     //  we just need to write only available buffers.
-    blockOutputStreamEntryPool.allocateBlockIfNeeded();
-    final ECBlockOutputStreamEntry currentStreamEntry =
-        blockOutputStreamEntryPool.getCurrentStreamEntry();
-    for (int i = 0; i < numDataBlks; i++) {
-      if (dataBuffers[i].limit() > 0) {
-        handleOutputStreamWrite(i, dataBuffers[i].limit(), false);
-      }
-      currentStreamEntry.useNextBlockStream();
-    }
+    writeDataCells();
     return handleParityWrites();
   }
 
@@ -337,6 +329,17 @@ public final class ECKeyOutputStream extends KeyOutputStream {
     }
     for (int i = firstNonFullIndex + 1; i < dataBuffers.length; i++) {
       dataBuffers[i].limit(0);
+    }
+  }
+
+  private void writeDataCells() throws IOException {
+    blockOutputStreamEntryPool.allocateBlockIfNeeded();
+    ByteBuffer[] dataCells = ecChunkBufferCache.getDataBuffers();
+    for (int i = 0; i < numDataBlks; i++) {
+      if (dataCells[i].limit() > 0) {
+        handleOutputStreamWrite(i, dataCells[i].limit(), false);
+      }
+      blockOutputStreamEntryPool.getCurrentStreamEntry().useNextBlockStream();
     }
   }
 

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/io/ECKeyOutputStream.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/io/ECKeyOutputStream.java
@@ -191,12 +191,14 @@ public final class ECKeyOutputStream extends KeyOutputStream {
     // TODO: we can improve to write partial stripe failures. In that case,
     //  we just need to write only available buffers.
     writeDataCells();
-    return handleParityWrites();
+    writeParityCells();
+    return commitStripeWrite();
   }
 
   private void encodeAndWriteParityCells() throws IOException {
     generateParityCells();
-    if (handleParityWrites() == StripeWriteStatus.FAILED) {
+    writeParityCells();
+    if (commitStripeWrite() == StripeWriteStatus.FAILED) {
       retryStripeWrite(config.getMaxECStripeWriteRetries());
     }
   }
@@ -220,8 +222,7 @@ public final class ECKeyOutputStream extends KeyOutputStream {
     }
   }
 
-  private StripeWriteStatus handleParityWrites() throws IOException {
-    writeParityCells();
+  private StripeWriteStatus commitStripeWrite() throws IOException {
 
     ECBlockOutputStreamEntry streamEntry =
         blockOutputStreamEntryPool.getCurrentStreamEntry();

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/io/ECKeyOutputStream.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/io/ECKeyOutputStream.java
@@ -195,14 +195,6 @@ public final class ECKeyOutputStream extends KeyOutputStream {
     return commitStripeWrite();
   }
 
-  private void encodeAndWriteParityCells() throws IOException {
-    generateParityCells();
-    writeParityCells();
-    if (commitStripeWrite() == StripeWriteStatus.FAILED) {
-      retryStripeWrite(config.getMaxECStripeWriteRetries());
-    }
-  }
-
   private void logStreamError(List<ECBlockOutputStream> failedStreams,
                               String operation) {
     Set<Integer> failedStreamIndexSet =
@@ -373,7 +365,11 @@ public final class ECKeyOutputStream extends KeyOutputStream {
       // if this is last data cell in the stripe,
       // compute and write the parity cells
       if (currIdx == numDataBlks - 1) {
-        encodeAndWriteParityCells();
+        generateParityCells();
+        writeParityCells();
+        if (commitStripeWrite() == StripeWriteStatus.FAILED) {
+          retryStripeWrite(config.getMaxECStripeWriteRetries());
+        }
       }
     }
     return writeLen;
@@ -494,7 +490,11 @@ public final class ECKeyOutputStream extends KeyOutputStream {
           handleOutputStreamWrite(index, lastCell.position(), false);
         }
 
-        encodeAndWriteParityCells();
+        generateParityCells();
+        writeParityCells();
+        if (commitStripeWrite() == StripeWriteStatus.FAILED) {
+          retryStripeWrite(config.getMaxECStripeWriteRetries());
+        }
       }
 
       closeCurrentStreamEntry();

--- a/hadoop-ozone/client/src/test/java/org/apache/hadoop/ozone/client/TestOzoneECClient.java
+++ b/hadoop-ozone/client/src/test/java/org/apache/hadoop/ozone/client/TestOzoneECClient.java
@@ -45,6 +45,7 @@ import org.apache.hadoop.ozone.om.protocolPB.OmTransport;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos;
 import org.apache.ozone.erasurecode.rawcoder.RSRawErasureCoderFactory;
 import org.apache.ozone.erasurecode.rawcoder.RawErasureEncoder;
+import org.apache.ozone.test.GenericTestUtils;
 import org.apache.ratis.thirdparty.com.google.protobuf.ByteString;
 import org.junit.After;
 import org.junit.Assert;
@@ -610,29 +611,29 @@ public class TestOzoneECClient {
 
   @Test
   public void testWriteShouldFailIfMoreThanParityNodesFail()
-      throws IOException {
+      throws Exception {
     testNodeFailuresWhileWriting(new int[] {0, 1, 2}, 3, 2);
   }
 
   @Test
   public void testWriteShouldSuccessIfLessThanParityNodesFail()
-      throws IOException {
+      throws Exception {
     testNodeFailuresWhileWriting(new int[] {0}, 2, 2);
   }
 
   @Test
-  public void testWriteShouldSuccessIf4NodesFailed() throws IOException {
+  public void testWriteShouldSuccessIf4NodesFailed() throws Exception {
     testNodeFailuresWhileWriting(new int[] {0, 1, 2, 3}, 1, 2);
   }
 
   @Test
   public void testWriteShouldSuccessWithAdditional1BlockGroupAfterFailure()
-      throws IOException {
+      throws Exception {
     testNodeFailuresWhileWriting(new int[] {0, 1, 2, 3}, 10, 3);
   }
 
   @Test
-  public void testStripeWriteRetriesOn2Failures() throws IOException {
+  public void testStripeWriteRetriesOn2Failures() throws Exception {
     OzoneConfiguration con = new OzoneConfiguration();
     con.setStorageSize(OzoneConfigKeys.OZONE_SCM_BLOCK_SIZE, 2, StorageUnit.KB);
     // Cluster has 15 nodes. So, first we will create 3 block groups with
@@ -655,7 +656,7 @@ public class TestOzoneECClient {
   }
 
   @Test
-  public void testStripeWriteRetriesOn3Failures() throws IOException {
+  public void testStripeWriteRetriesOn3Failures() throws Exception {
     OzoneConfiguration con = new OzoneConfiguration();
     con.setStorageSize(OzoneConfigKeys.OZONE_SCM_BLOCK_SIZE, 2, StorageUnit.KB);
 
@@ -679,7 +680,7 @@ public class TestOzoneECClient {
   // The mocked impl throws IllegalStateException when there are not enough
   // nodes in allocateBlock request.
   @Test(expected = IllegalStateException.class)
-  public void testStripeWriteRetriesOnAllNodeFailures() throws IOException {
+  public void testStripeWriteRetriesOnAllNodeFailures() throws Exception {
     OzoneConfiguration con = new OzoneConfiguration();
     con.setStorageSize(OzoneConfigKeys.OZONE_SCM_BLOCK_SIZE, 2, StorageUnit.KB);
 
@@ -697,7 +698,7 @@ public class TestOzoneECClient {
 
   @Test
   public void testStripeWriteRetriesOn4FailuresWith3RetriesAllowed()
-      throws IOException {
+      throws Exception {
     OzoneConfiguration con = new OzoneConfiguration();
     con.setStorageSize(OzoneConfigKeys.OZONE_SCM_BLOCK_SIZE, 2, StorageUnit.KB);
     con.setInt(OzoneConfigKeys.OZONE_CLIENT_MAX_EC_STRIPE_WRITE_RETRIES, 3);
@@ -726,7 +727,7 @@ public class TestOzoneECClient {
   }
 
   public void testStripeWriteRetriesOnFailures(OzoneConfiguration con,
-      int clusterSize, int[] nodesIndexesToMarkFailure) throws IOException {
+      int clusterSize, int[] nodesIndexesToMarkFailure) throws Exception {
     close();
     MultiNodePipelineBlockAllocator blkAllocator =
         new MultiNodePipelineBlockAllocator(con, dataBlocks + parityBlocks,
@@ -744,6 +745,7 @@ public class TestOzoneECClient {
       for (int i = 0; i < dataBlocks; i++) {
         out.write(inputChunks[i]);
       }
+      waitForFlushingThreadToFinish((ECKeyOutputStream) out.getOutputStream());
       Assert.assertTrue(
           ((MockXceiverClientFactory) factoryStub).getStorages().size() == 5);
       List<DatanodeDetails> failedDNs = new ArrayList<>();
@@ -787,7 +789,7 @@ public class TestOzoneECClient {
 
   public void testNodeFailuresWhileWriting(int[] nodesIndexesToMarkFailure,
       int numChunksToWriteAfterFailure, int numExpectedBlockGrps)
-      throws IOException {
+      throws Exception {
     store.createVolume(volumeName);
     OzoneVolume volume = store.getVolume(volumeName);
     volume.createBucket(bucketName);
@@ -800,6 +802,7 @@ public class TestOzoneECClient {
       for (int i = 0; i < dataBlocks; i++) {
         out.write(inputChunks[i]);
       }
+      waitForFlushingThreadToFinish((ECKeyOutputStream) out.getOutputStream());
 
       List<DatanodeDetails> failedDNs = new ArrayList<>();
       List<HddsProtos.DatanodeDetailsProto> dns = allocator.getClusterDns();
@@ -841,22 +844,22 @@ public class TestOzoneECClient {
   }
 
   @Test
-  public void testExcludeOnDNFailure() throws IOException {
+  public void testExcludeOnDNFailure() throws Exception {
     testExcludeFailedDN(IntStream.range(0, 5), IntStream.empty());
   }
 
   @Test
-  public void testExcludeOnDNClosed() throws IOException {
+  public void testExcludeOnDNClosed() throws Exception {
     testExcludeFailedDN(IntStream.empty(), IntStream.range(0, 5));
   }
 
   @Test
-  public void testExcludeOnDNMixed() throws IOException {
+  public void testExcludeOnDNMixed() throws Exception {
     testExcludeFailedDN(IntStream.range(0, 3), IntStream.range(3, 5));
   }
 
   private void testExcludeFailedDN(IntStream failedDNIndex,
-      IntStream closedDNIndex) throws IOException {
+      IntStream closedDNIndex) throws Exception {
     close();
     OzoneConfiguration con = new OzoneConfiguration();
     MultiNodePipelineBlockAllocator blkAllocator =
@@ -882,6 +885,7 @@ public class TestOzoneECClient {
       for (int i = 0; i < dataBlocks; i++) {
         out.write(inputChunks[i % dataBlocks]);
       }
+      waitForFlushingThreadToFinish((ECKeyOutputStream) out.getOutputStream());
 
       // Then let's mark datanodes with closed container
       List<DatanodeDetails> closedDNs = closedDNIndex
@@ -899,6 +903,7 @@ public class TestOzoneECClient {
       for (int i = 0; i < dataBlocks; i++) {
         out.write(inputChunks[i % dataBlocks]);
       }
+      waitForFlushingThreadToFinish((ECKeyOutputStream) out.getOutputStream());
 
       // Assert excludeList only includes failedDNs
       Assert.assertArrayEquals(failedDNs.toArray(new DatanodeDetails[0]),
@@ -909,7 +914,7 @@ public class TestOzoneECClient {
 
   @Test
   public void testLargeWriteOfMultipleStripesWithStripeFailure()
-      throws IOException {
+      throws Exception {
     close();
     OzoneConfiguration con = new OzoneConfiguration();
     // block size of 3KB could hold 3 full stripes
@@ -943,6 +948,7 @@ public class TestOzoneECClient {
           out.write(inputChunks[i]);
         }
       }
+      waitForFlushingThreadToFinish((ECKeyOutputStream) out.getOutputStream());
 
       List<DatanodeDetails> failedDNs = new ArrayList<>();
       List<HddsProtos.DatanodeDetailsProto> dns = allocator.getClusterDns();
@@ -1055,7 +1061,7 @@ public class TestOzoneECClient {
 
   @Test
   public void testDiscardPreAllocatedBlocksPreventRetryExceeds()
-      throws IOException {
+      throws Exception {
     close();
     OzoneConfiguration con = new OzoneConfiguration();
     int maxRetries = 3;
@@ -1114,6 +1120,7 @@ public class TestOzoneECClient {
           out.write(inputChunks[i]);
         }
       }
+      waitForFlushingThreadToFinish((ECKeyOutputStream) out.getOutputStream());
 
       // Make the writes fail to trigger retry
       List<DatanodeDetails> failedDNs = new ArrayList<>();
@@ -1220,5 +1227,13 @@ public class TestOzoneECClient {
       locationInfoList.add(info);
     }
     return locationInfoList;
+  }
+
+  private static void waitForFlushingThreadToFinish(
+      ECKeyOutputStream ecOut) throws Exception {
+    final long checkpoint = System.currentTimeMillis();
+    ecOut.insertFlushCheckpoint(checkpoint);
+    GenericTestUtils.waitFor(() -> ecOut.getFlushCheckpoint() == checkpoint,
+        100, 10000);
   }
 }

--- a/hadoop-ozone/client/src/test/java/org/apache/hadoop/ozone/client/TestOzoneECClient.java
+++ b/hadoop-ozone/client/src/test/java/org/apache/hadoop/ozone/client/TestOzoneECClient.java
@@ -677,8 +677,8 @@ public class TestOzoneECClient {
   }
 
   // The mocked impl throws IllegalStateException when there are not enough
-  // nodes in allocateBlock request. But write() converts it to IOException.
-  @Test(expected = IOException.class)
+  // nodes in allocateBlock request.
+  @Test(expected = IllegalStateException.class)
   public void testStripeWriteRetriesOnAllNodeFailures() throws IOException {
     OzoneConfiguration con = new OzoneConfiguration();
     con.setStorageSize(OzoneConfigKeys.OZONE_SCM_BLOCK_SIZE, 2, StorageUnit.KB);

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestECKeyOutputStream.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestECKeyOutputStream.java
@@ -401,19 +401,25 @@ public class TestECKeyOutputStream {
       try (OzoneOutputStream out = bucket.createKey(keyName, 1024,
           new ECReplicationConfig(3, 2, ECReplicationConfig.EcCodec.RS,
               chunkSize), new HashMap<>())) {
+        ECKeyOutputStream ecOut = (ECKeyOutputStream) out.getOutputStream();
         out.write(inputData);
         // Kill a node from first pipeline
-        nodeToKill =
-            ((ECKeyOutputStream) out.getOutputStream()).getStreamEntries()
-                .get(0).getPipeline().getFirstNode();
+        nodeToKill = ecOut.getStreamEntries()
+            .get(0).getPipeline().getFirstNode();
         cluster.shutdownHddsDatanode(nodeToKill);
 
         out.write(inputData);
-        // Check the second blockGroup pipeline to make sure that the failed not
-        // is not selected.
-        Assert.assertFalse(
-            ((ECKeyOutputStream) out.getOutputStream()).getStreamEntries()
-                .get(1).getPipeline().getNodes().contains(nodeToKill));
+
+        // Wait for flushing thread to finish its work.
+        final long checkpoint = System.currentTimeMillis();
+        ecOut.insertFlushCheckpoint(checkpoint);
+        GenericTestUtils.waitFor(() -> ecOut.getFlushCheckpoint() == checkpoint,
+            100, 10000);
+
+        // Check the second blockGroup pipeline to make sure that the failed
+        // node is not selected.
+        Assert.assertFalse(ecOut.getStreamEntries()
+            .get(1).getPipeline().getNodes().contains(nodeToKill));
       }
 
       try (OzoneInputStream is = bucket.readKey(keyName)) {


### PR DESCRIPTION
## What changes were proposed in this pull request?

Introduced a new flush thread in ECKeyOutputStream, pipelining the encode stage and flush stage.
The producer thread does the buffering and encoding, and the consumer thread does the flushing.
They are connected by a `ArrayBlockingQueue`, whose size is `"ec.stripe.queue.size"`, which defaults to 2.
Necessary refactors has been done to seperate the two stages.

`EOFDummyStripe` is used to denote the end of the key, `CheckpointDummyStripe` is used for syncing in tests.
Synchronization was added in tests.

~~NOTE: Currently the exception handling needs another look. If exception were thrown in the flush thread,
the main thread will not get it until calling `Future.get()` in `close()`.~~ This has been fixed in d710aff.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-6615

## How was this patch tested?

It's covered by existing test. Synchronization was added before checking state.
Mannual test of writing 1 key by freon shows ~20% performance improvement.
* Before (63s): https://paste.ubuntu.com/p/pZJ9BB5ttF/
* After (50s): https://paste.ubuntu.com/p/tRRYW3tmqG/