### PR TITLE
HDDS-7532. EC: ReplicationManager - remove calls to ECHealthCheck from under and over replication processing

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ECOverReplicationHandler.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ECOverReplicationHandler.java
@@ -22,7 +22,6 @@ import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolPro
 import org.apache.hadoop.hdds.scm.PlacementPolicy;
 import org.apache.hadoop.hdds.scm.container.ContainerInfo;
 import org.apache.hadoop.hdds.scm.container.ContainerReplica;
-import org.apache.hadoop.hdds.scm.container.replication.health.ECReplicationCheckHandler;
 import org.apache.hadoop.hdds.scm.node.NodeManager;
 import org.apache.hadoop.ozone.protocol.commands.DeleteContainerCommand;
 import org.apache.hadoop.ozone.protocol.commands.SCMCommand;
@@ -48,13 +47,11 @@ public class ECOverReplicationHandler extends AbstractOverReplicationHandler {
   public static final Logger LOG =
       LoggerFactory.getLogger(ECOverReplicationHandler.class);
 
-  private final ECReplicationCheckHandler ecReplicationCheck;
   private final NodeManager nodeManager;
 
-  public ECOverReplicationHandler(ECReplicationCheckHandler ecReplicationCheck,
-      PlacementPolicy placementPolicy, NodeManager nodeManager) {
+  public ECOverReplicationHandler(PlacementPolicy placementPolicy,
+      NodeManager nodeManager) {
     super(placementPolicy);
-    this.ecReplicationCheck = ecReplicationCheck;
     this.nodeManager = nodeManager;
 
   }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ReplicationManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ReplicationManager.java
@@ -215,11 +215,9 @@ public class ReplicationManager implements SCMService {
     this.ratisMaintenanceMinReplicas = rmConf.getMaintenanceReplicaMinimum();
 
     ecUnderReplicationHandler = new ECUnderReplicationHandler(
-        ecReplicationCheckHandler, ecContainerPlacement, conf, nodeManager,
-        this);
+        ecContainerPlacement, conf, nodeManager, this);
     ecOverReplicationHandler =
-        new ECOverReplicationHandler(ecReplicationCheckHandler,
-            ecContainerPlacement, nodeManager);
+        new ECOverReplicationHandler(ecContainerPlacement, nodeManager);
     underReplicatedProcessor =
         new UnderReplicatedProcessor(this, containerReplicaPendingOps,
             eventPublisher, rmConf.getUnderReplicatedInterval());

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestECOverReplicationHandler.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestECOverReplicationHandler.java
@@ -29,7 +29,6 @@ import org.apache.hadoop.hdds.scm.container.ContainerInfo;
 import org.apache.hadoop.hdds.scm.container.ContainerReplica;
 import org.apache.hadoop.hdds.scm.container.MockNodeManager;
 import org.apache.hadoop.hdds.scm.container.placement.algorithms.ContainerPlacementStatusDefault;
-import org.apache.hadoop.hdds.scm.container.replication.health.ECReplicationCheckHandler;
 import org.apache.hadoop.hdds.scm.net.NodeSchema;
 import org.apache.hadoop.hdds.scm.net.NodeSchemaManager;
 import org.apache.hadoop.hdds.scm.node.NodeManager;
@@ -65,7 +64,6 @@ public class TestECOverReplicationHandler {
   private NodeManager nodeManager;
   private OzoneConfiguration conf;
   private PlacementPolicy policy;
-  private ECReplicationCheckHandler replicationCheck;
   private PlacementPolicy placementPolicy;
 
   @BeforeEach
@@ -90,7 +88,6 @@ public class TestECOverReplicationHandler {
     Mockito.when(placementPolicy.validateContainerPlacement(
         anyList(), anyInt()))
         .thenReturn(new ContainerPlacementStatusDefault(2, 2, 3));
-    replicationCheck = new ECReplicationCheckHandler(placementPolicy);
   }
 
   @Test
@@ -152,7 +149,7 @@ public class TestECOverReplicationHandler {
             container, 1, false, false, false);
 
     ECOverReplicationHandler ecORH =
-        new ECOverReplicationHandler(replicationCheck, policy, nodeManager);
+        new ECOverReplicationHandler(policy, nodeManager);
 
     Map<DatanodeDetails, SCMCommand<?>> commands = ecORH
         .processAndCreateCommands(availableReplicas, ImmutableList.of(),
@@ -168,7 +165,7 @@ public class TestECOverReplicationHandler {
       Set<ContainerReplica> availableReplicas,
       Map<Integer, Integer> index2excessNum) {
     ECOverReplicationHandler ecORH =
-        new ECOverReplicationHandler(replicationCheck, policy, nodeManager);
+        new ECOverReplicationHandler(policy, nodeManager);
     ContainerHealthResult.OverReplicatedHealthResult result =
         Mockito.mock(ContainerHealthResult.OverReplicatedHealthResult.class);
     Mockito.when(result.getContainerInfo()).thenReturn(container);

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestECUnderReplicationHandler.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestECUnderReplicationHandler.java
@@ -31,7 +31,6 @@ import org.apache.hadoop.hdds.scm.container.ContainerInfo;
 import org.apache.hadoop.hdds.scm.container.ContainerReplica;
 import org.apache.hadoop.hdds.scm.container.MockNodeManager;
 import org.apache.hadoop.hdds.scm.container.placement.algorithms.ContainerPlacementStatusDefault;
-import org.apache.hadoop.hdds.scm.container.replication.health.ECReplicationCheckHandler;
 import org.apache.hadoop.hdds.scm.exceptions.SCMException;
 import org.apache.hadoop.hdds.scm.net.NodeSchema;
 import org.apache.hadoop.hdds.scm.net.NodeSchemaManager;
@@ -83,7 +82,6 @@ public class TestECUnderReplicationHandler {
   private PlacementPolicy policy;
   private static final int DATA = 3;
   private static final int PARITY = 2;
-  private ECReplicationCheckHandler replicationCheck;
   private PlacementPolicy ecPlacementPolicy;
 
   @BeforeEach
@@ -109,7 +107,6 @@ public class TestECUnderReplicationHandler {
     Mockito.when(ecPlacementPolicy.validateContainerPlacement(
         anyList(), anyInt()))
         .thenReturn(new ContainerPlacementStatusDefault(2, 2, 3));
-    replicationCheck = new ECReplicationCheckHandler(ecPlacementPolicy);
   }
 
   @Test
@@ -279,7 +276,7 @@ public class TestECUnderReplicationHandler {
     replicasToAdd.add(maintReplica);
 
     ECUnderReplicationHandler ecURH =
-        new ECUnderReplicationHandler(replicationCheck,
+        new ECUnderReplicationHandler(
             noNodesPolicy, conf, nodeManager, replicationManager);
     ContainerHealthResult.UnderReplicatedHealthResult underRep =
         new ContainerHealthResult.UnderReplicatedHealthResult(container,
@@ -347,7 +344,7 @@ public class TestECUnderReplicationHandler {
     replicasToAdd.add(maintReplica);
 
     ECUnderReplicationHandler ecURH =
-        new ECUnderReplicationHandler(replicationCheck,
+        new ECUnderReplicationHandler(
             sameNodePolicy, conf, nodeManager, replicationManager);
     ContainerHealthResult.UnderReplicatedHealthResult underRep =
         new ContainerHealthResult.UnderReplicatedHealthResult(container,
@@ -397,7 +394,7 @@ public class TestECUnderReplicationHandler {
             Pair.of(IN_SERVICE, 4), Pair.of(DECOMMISSIONING, 5));
 
     ECUnderReplicationHandler ecURH =
-        new ECUnderReplicationHandler(replicationCheck,
+        new ECUnderReplicationHandler(
             sameNodePolicy, conf, nodeManager, replicationManager);
 
     ContainerHealthResult.UnderReplicatedHealthResult underRep =
@@ -486,7 +483,7 @@ public class TestECUnderReplicationHandler {
       int decomIndexes, int maintenanceIndexes,
       PlacementPolicy placementPolicy) throws IOException {
     ECUnderReplicationHandler ecURH =
-        new ECUnderReplicationHandler(replicationCheck,
+        new ECUnderReplicationHandler(
             placementPolicy, conf, nodeManager, replicationManager);
     ContainerHealthResult.UnderReplicatedHealthResult result =
         Mockito.mock(ContainerHealthResult.UnderReplicatedHealthResult.class);


### PR DESCRIPTION
## What changes were proposed in this pull request?

The under replication processing makes some calls which we no longer need into the ECContainerHealth check class. If the container ends up in the under replicated handler, it means it was under-replicated and we can just check that is still the case by checking the ECContainerReplicaCount object instead of going back to the ECContainerHealthCheck class.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-7532

## How was this patch tested?

Existing test cover this - its a small refactor rather than new logic.
