### PR TITLE
HDDS-7535. Eliminate duplicated config in LegacyReplicationManager

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/LegacyReplicationManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/LegacyReplicationManager.java
@@ -41,6 +41,7 @@ import org.apache.hadoop.hdds.scm.container.ContainerReplica;
 import org.apache.hadoop.hdds.scm.container.ReplicationManagerReport;
 import org.apache.hadoop.hdds.scm.container.ReplicationManagerReport.HealthState;
 import org.apache.hadoop.hdds.scm.container.common.helpers.MoveDataNodePair;
+import org.apache.hadoop.hdds.scm.container.replication.ReplicationManager.ReplicationManagerConfiguration;
 import org.apache.hadoop.hdds.scm.events.SCMEvents;
 import org.apache.hadoop.hdds.scm.ha.SCMContext;
 import org.apache.hadoop.hdds.scm.ha.SCMHAInvocationHandler;
@@ -70,7 +71,6 @@ import org.slf4j.LoggerFactory;
 import java.io.IOException;
 import java.lang.reflect.Proxy;
 import java.time.Clock;
-import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
@@ -358,10 +358,12 @@ public class LegacyReplicationManager {
     this.scmContext = scmContext;
     this.nodeManager = nodeManager;
     this.rmConf = conf.getObject(ReplicationManagerConfiguration.class);
+    LegacyReplicationManagerConfiguration legacyConf = conf
+        .getObject(LegacyReplicationManagerConfiguration.class);
     this.inflightReplication = new InflightMap(InflightType.REPLICATION,
-        rmConf.getContainerInflightReplicationLimit());
+        legacyConf.getContainerInflightReplicationLimit());
     this.inflightDeletion = new InflightMap(InflightType.DELETION,
-        rmConf.getContainerInflightDeletionLimit());
+        legacyConf.getContainerInflightDeletionLimit());
     this.inflightMoveFuture = new ConcurrentHashMap<>();
     this.minHealthyForMaintenance = rmConf.getMaintenanceReplicaMinimum();
     this.clock = clock;
@@ -1695,55 +1697,7 @@ public class LegacyReplicationManager {
    * Configuration used by the Replication Manager.
    */
   @ConfigGroup(prefix = "hdds.scm.replication")
-  public static class ReplicationManagerConfiguration {
-    /**
-     * The frequency in which ReplicationMonitor thread should run.
-     */
-    @Config(key = "thread.interval",
-        type = ConfigType.TIME,
-        defaultValue = "300s",
-        tags = {SCM, OZONE},
-        description = "There is a replication monitor thread running inside " +
-            "SCM which takes care of replicating the containers in the " +
-            "cluster. This property is used to configure the interval in " +
-            "which that thread runs."
-    )
-    private long interval = Duration.ofSeconds(300).toMillis();
-
-    /**
-     * Timeout for container replication & deletion command issued by
-     * ReplicationManager.
-     */
-    @Config(key = "event.timeout",
-        type = ConfigType.TIME,
-        defaultValue = "30m",
-        tags = {SCM, OZONE},
-        description = "Timeout for the container replication/deletion commands "
-            + "sent  to datanodes. After this timeout the command will be "
-            + "retried.")
-    private long eventTimeout = Duration.ofMinutes(30).toMillis();
-    public void setInterval(Duration interval) {
-      this.interval = interval.toMillis();
-    }
-
-    public void setEventTimeout(Duration timeout) {
-      this.eventTimeout = timeout.toMillis();
-    }
-
-    /**
-     * The number of container replica which must be available for a node to
-     * enter maintenance.
-     */
-    @Config(key = "maintenance.replica.minimum",
-        type = ConfigType.INT,
-        defaultValue = "2",
-        tags = {SCM, OZONE},
-        description = "The minimum number of container replicas which must " +
-            " be available for a node to enter maintenance. If putting a " +
-            " node into maintenance reduces the available replicas for any " +
-            " container below this level, the node will remain in the " +
-            " entering maintenance state until a new replica is created.")
-    private int maintenanceReplicaMinimum = 2;
+  public static class LegacyReplicationManagerConfiguration {
 
     @Config(key = "container.inflight.replication.limit",
         type = ConfigType.INT,
@@ -1771,10 +1725,6 @@ public class LegacyReplicationManager {
       this.containerInflightDeletionLimit = deletionLimit;
     }
 
-    public void setMaintenanceReplicaMinimum(int replicaCount) {
-      this.maintenanceReplicaMinimum = replicaCount;
-    }
-
     public int getContainerInflightReplicationLimit() {
       return containerInflightReplicationLimit;
     }
@@ -1783,17 +1733,6 @@ public class LegacyReplicationManager {
       return containerInflightDeletionLimit;
     }
 
-    public long getInterval() {
-      return interval;
-    }
-
-    public long getEventTimeout() {
-      return eventTimeout;
-    }
-
-    public int getMaintenanceReplicaMinimum() {
-      return maintenanceReplicaMinimum;
-    }
   }
 
   protected void notifyStatusChanged() {

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestLegacyReplicationManager.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestLegacyReplicationManager.java
@@ -42,8 +42,8 @@ import org.apache.hadoop.hdds.scm.container.ContainerStateManagerImpl;
 import org.apache.hadoop.hdds.scm.container.ReplicationManagerReport;
 import org.apache.hadoop.hdds.scm.container.SimpleMockNodeManager;
 import org.apache.hadoop.hdds.scm.container.TestContainerManagerImpl;
-import org.apache.hadoop.hdds.scm.container.replication.ReplicationManager
-    .ReplicationManagerConfiguration;
+import org.apache.hadoop.hdds.scm.container.replication.LegacyReplicationManager.LegacyReplicationManagerConfiguration;
+import org.apache.hadoop.hdds.scm.container.replication.ReplicationManager.ReplicationManagerConfiguration;
 import org.apache.hadoop.hdds.scm.PlacementPolicy;
 import org.apache.hadoop.hdds.scm.container.common.helpers.MoveDataNodePair;
 import org.apache.hadoop.hdds.scm.container.placement.algorithms.ContainerPlacementStatusDefault;
@@ -221,15 +221,15 @@ public class TestLegacyReplicationManager {
       throws Exception {
     replicationManager.stop();
     dbStore.close();
-    final LegacyReplicationManager.ReplicationManagerConfiguration conf
-        = new LegacyReplicationManager.ReplicationManagerConfiguration();
+    final LegacyReplicationManagerConfiguration conf
+        = new LegacyReplicationManagerConfiguration();
     conf.setContainerInflightReplicationLimit(replicationLimit);
     conf.setContainerInflightDeletionLimit(deletionLimit);
     createReplicationManager(conf);
   }
 
   void createReplicationManager(
-      LegacyReplicationManager.ReplicationManagerConfiguration conf)
+      LegacyReplicationManagerConfiguration conf)
       throws Exception {
     createReplicationManager(null, conf);
   }
@@ -240,7 +240,7 @@ public class TestLegacyReplicationManager {
   }
 
   void createReplicationManager(ReplicationManagerConfiguration rmConf,
-      LegacyReplicationManager.ReplicationManagerConfiguration lrmConf)
+      LegacyReplicationManagerConfiguration lrmConf)
       throws InterruptedException, IOException {
     OzoneConfiguration config = new OzoneConfiguration();
     testDir = GenericTestUtils


### PR DESCRIPTION
## What changes were proposed in this pull request?

`ReplicationManager` and `LegacyReplicationManager` both define some of the same configuration keys in their own `ReplicationManagerConfiguration` class.  This results in duplicate items in the generated config:

```
$ grep '<name>hdds.scm.replication' hadoop-hdds/server-scm/target/classes/ozone-default-generated.xml | sort | uniq -c
      1     <name>hdds.scm.replication.container.inflight.deletion.limit</name>
      1     <name>hdds.scm.replication.container.inflight.replication.limit</name>
      2     <name>hdds.scm.replication.event.timeout</name>
      1     <name>hdds.scm.replication.maintenance.remaining.redundancy</name>
      2     <name>hdds.scm.replication.maintenance.replica.minimum</name>
      1     <name>hdds.scm.replication.over.replicated.interval</name>
      2     <name>hdds.scm.replication.thread.interval</name>
      1     <name>hdds.scm.replication.under.replicated.interval</name>
```

In the long run, we are planning to get rid of `LegacyReplicationManager` completely.  In the meantime, we can eliminate the duplication by making `LegacyReplicationManager` get config values from `ReplicationManager`'s config where applicable.

https://issues.apache.org/jira/browse/HDDS-7535

## How was this patch tested?

Verified that all keys are still present in the generated config and they are unique:

```
$ grep '<name>hdds.scm.replication' hadoop-hdds/server-scm/target/classes/ozone-default-generated.xml | sort | uniq -c
      1     <name>hdds.scm.replication.container.inflight.deletion.limit</name>
      1     <name>hdds.scm.replication.container.inflight.replication.limit</name>
      1     <name>hdds.scm.replication.event.timeout</name>
      1     <name>hdds.scm.replication.maintenance.remaining.redundancy</name>
      1     <name>hdds.scm.replication.maintenance.replica.minimum</name>
      1     <name>hdds.scm.replication.over.replicated.interval</name>
      1     <name>hdds.scm.replication.thread.interval</name>
      1     <name>hdds.scm.replication.under.replicated.interval</name>
``` 

Regular CI:
https://github.com/adoroszlai/hadoop-ozone/actions/runs/3535067762