### PR TITLE
HDDS-7542. Refactor DefaultReplicationConfig

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/client/DefaultReplicationConfig.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/client/DefaultReplicationConfig.java
@@ -71,7 +71,7 @@ public class DefaultReplicationConfig {
   public HddsProtos.DefaultReplicationConfig toProto() {
     final HddsProtos.DefaultReplicationConfig.Builder builder =
         HddsProtos.DefaultReplicationConfig.newBuilder()
-            .setType(ReplicationType.toProto(this.type));
+            .setType(replicationConfig.getReplicationType());
     if (this.factor != null) {
       builder.setFactor(ReplicationFactor.toProto(this.factor));
     }

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/client/DefaultReplicationConfig.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/client/DefaultReplicationConfig.java
@@ -26,18 +26,21 @@ import java.util.Objects;
  */
 public class DefaultReplicationConfig {
 
-  private ReplicationType type;
+  private final ReplicationType type;
   private ReplicationFactor factor;
   private ECReplicationConfig ecReplicationConfig;
+  private final ReplicationConfig replicationConfig;
 
   public DefaultReplicationConfig(ReplicationType type,
       ReplicationFactor factor) {
+    this.replicationConfig = ReplicationConfig.fromTypeAndFactor(type, factor);
     this.type = type;
     this.factor = factor;
     this.ecReplicationConfig = null;
   }
 
   public DefaultReplicationConfig(ReplicationConfig replicationConfig) {
+    this.replicationConfig = replicationConfig;
     this.type =
         ReplicationType.fromProto(replicationConfig.getReplicationType());
     if (replicationConfig instanceof ECReplicationConfig) {
@@ -50,6 +53,7 @@ public class DefaultReplicationConfig {
 
   public DefaultReplicationConfig(ReplicationType type,
       ECReplicationConfig ecReplicationConfig) {
+    this.replicationConfig = ecReplicationConfig;
     this.type = type;
     this.factor = null;
     this.ecReplicationConfig = ecReplicationConfig;
@@ -57,6 +61,7 @@ public class DefaultReplicationConfig {
 
   public DefaultReplicationConfig(ReplicationType type,
       ReplicationFactor factor, ECReplicationConfig ecReplicationConfig) {
+    this.replicationConfig = ecReplicationConfig;
     this.type = type;
     this.factor = factor;
     this.ecReplicationConfig = ecReplicationConfig;
@@ -67,11 +72,12 @@ public class DefaultReplicationConfig {
           defaultReplicationConfig) {
     this.type = ReplicationType.fromProto(defaultReplicationConfig.getType());
     if (defaultReplicationConfig.hasEcReplicationConfig()) {
-      this.ecReplicationConfig = new ECReplicationConfig(
+      this.replicationConfig = this.ecReplicationConfig = new ECReplicationConfig(
           defaultReplicationConfig.getEcReplicationConfig());
     } else {
       this.factor =
           ReplicationFactor.fromProto(defaultReplicationConfig.getFactor());
+      this.replicationConfig = ReplicationConfig.fromTypeAndFactor(type, factor);
     }
   }
 
@@ -90,6 +96,10 @@ public class DefaultReplicationConfig {
 
   public ECReplicationConfig getEcReplicationConfig() {
     return this.ecReplicationConfig;
+  }
+
+  public ReplicationConfig getReplicationConfig() {
+    return replicationConfig;
   }
 
   public int getRequiredNodes() {

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/client/DefaultReplicationConfig.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/client/DefaultReplicationConfig.java
@@ -31,14 +31,6 @@ public class DefaultReplicationConfig {
   private ECReplicationConfig ecReplicationConfig;
   private final ReplicationConfig replicationConfig;
 
-  public DefaultReplicationConfig(ReplicationType type,
-      ReplicationFactor factor) {
-    this.replicationConfig = ReplicationConfig.fromTypeAndFactor(type, factor);
-    this.type = type;
-    this.factor = factor;
-    this.ecReplicationConfig = null;
-  }
-
   public DefaultReplicationConfig(ReplicationConfig replicationConfig) {
     this.replicationConfig = replicationConfig;
     this.type =
@@ -51,33 +43,18 @@ public class DefaultReplicationConfig {
     }
   }
 
-  public DefaultReplicationConfig(ReplicationType type,
-      ECReplicationConfig ecReplicationConfig) {
-    this.replicationConfig = ecReplicationConfig;
-    this.type = type;
-    this.factor = null;
-    this.ecReplicationConfig = ecReplicationConfig;
-  }
-
-  public DefaultReplicationConfig(ReplicationType type,
-      ReplicationFactor factor, ECReplicationConfig ecReplicationConfig) {
-    this.replicationConfig = ecReplicationConfig;
-    this.type = type;
-    this.factor = factor;
-    this.ecReplicationConfig = ecReplicationConfig;
-  }
-
   public DefaultReplicationConfig(
       org.apache.hadoop.hdds.protocol.proto.HddsProtos.DefaultReplicationConfig
           defaultReplicationConfig) {
-    this.type = ReplicationType.fromProto(defaultReplicationConfig.getType());
+    type = ReplicationType.fromProto(defaultReplicationConfig.getType());
     if (defaultReplicationConfig.hasEcReplicationConfig()) {
-      this.replicationConfig = this.ecReplicationConfig = new ECReplicationConfig(
+      ecReplicationConfig = new ECReplicationConfig(
           defaultReplicationConfig.getEcReplicationConfig());
+      replicationConfig = ecReplicationConfig;
     } else {
-      this.factor =
+      factor =
           ReplicationFactor.fromProto(defaultReplicationConfig.getFactor());
-      this.replicationConfig = ReplicationConfig.fromTypeAndFactor(type, factor);
+      replicationConfig = ReplicationConfig.fromTypeAndFactor(type, factor);
     }
   }
 
@@ -90,8 +67,7 @@ public class DefaultReplicationConfig {
   }
 
   public DefaultReplicationConfig copy() {
-    return new DefaultReplicationConfig(this.type, this.factor,
-        this.ecReplicationConfig);
+    return new DefaultReplicationConfig(replicationConfig);
   }
 
   public ECReplicationConfig getEcReplicationConfig() {

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/client/DefaultReplicationConfig.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/client/DefaultReplicationConfig.java
@@ -102,13 +102,6 @@ public class DefaultReplicationConfig {
     return replicationConfig;
   }
 
-  public int getRequiredNodes() {
-    if (this.type == ReplicationType.EC) {
-      return ecReplicationConfig.getRequiredNodes();
-    }
-    return this.factor.getValue();
-  }
-
   public HddsProtos.DefaultReplicationConfig toProto() {
     final HddsProtos.DefaultReplicationConfig.Builder builder =
         HddsProtos.DefaultReplicationConfig.newBuilder()

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/client/DefaultReplicationConfig.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/client/DefaultReplicationConfig.java
@@ -62,16 +62,8 @@ public class DefaultReplicationConfig {
     return this.type;
   }
 
-  public ReplicationFactor getFactor() {
-    return this.factor;
-  }
-
   public DefaultReplicationConfig copy() {
     return new DefaultReplicationConfig(replicationConfig);
-  }
-
-  public ECReplicationConfig getEcReplicationConfig() {
-    return this.ecReplicationConfig;
   }
 
   public ReplicationConfig getReplicationConfig() {
@@ -100,14 +92,17 @@ public class DefaultReplicationConfig {
       return false;
     }
     DefaultReplicationConfig that = (DefaultReplicationConfig) o;
-    return Objects.equals(type, that.type) && Objects
-        .equals(factor, that.factor) && Objects
-        .equals(ecReplicationConfig, that.ecReplicationConfig);
+    return Objects.equals(replicationConfig, that.replicationConfig);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(type, factor, ecReplicationConfig);
+    return Objects.hash(replicationConfig);
+  }
+
+  @Override
+  public String toString() {
+    return replicationConfig.toString();
   }
 }
 

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/client/DefaultReplicationConfig.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/client/DefaultReplicationConfig.java
@@ -27,19 +27,19 @@ import java.util.Objects;
 public class DefaultReplicationConfig {
 
   private final ReplicationType type;
-  private ReplicationFactor factor;
-  private ECReplicationConfig ecReplicationConfig;
+  private final ReplicationFactor factor;
+  private final ECReplicationConfig ecReplicationConfig;
   private final ReplicationConfig replicationConfig;
 
   public DefaultReplicationConfig(ReplicationConfig replicationConfig) {
     this.replicationConfig = replicationConfig;
-    this.type =
-        ReplicationType.fromProto(replicationConfig.getReplicationType());
+    type = ReplicationType.fromProto(replicationConfig.getReplicationType());
     if (replicationConfig instanceof ECReplicationConfig) {
-      this.ecReplicationConfig = (ECReplicationConfig) replicationConfig;
+      ecReplicationConfig = (ECReplicationConfig) replicationConfig;
+      factor = null;
     } else {
-      this.factor =
-          ReplicationFactor.valueOf(replicationConfig.getRequiredNodes());
+      factor = ReplicationFactor.valueOf(replicationConfig.getRequiredNodes());
+      ecReplicationConfig = null;
     }
   }
 
@@ -51,10 +51,12 @@ public class DefaultReplicationConfig {
       ecReplicationConfig = new ECReplicationConfig(
           defaultReplicationConfig.getEcReplicationConfig());
       replicationConfig = ecReplicationConfig;
+      factor = null;
     } else {
       factor =
           ReplicationFactor.fromProto(defaultReplicationConfig.getFactor());
       replicationConfig = ReplicationConfig.fromTypeAndFactor(type, factor);
+      ecReplicationConfig = null;
     }
   }
 

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/client/DefaultReplicationConfig.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/client/DefaultReplicationConfig.java
@@ -43,21 +43,17 @@ public class DefaultReplicationConfig {
     }
   }
 
-  public DefaultReplicationConfig(
-      org.apache.hadoop.hdds.protocol.proto.HddsProtos.DefaultReplicationConfig
-          defaultReplicationConfig) {
-    type = ReplicationType.fromProto(defaultReplicationConfig.getType());
-    if (defaultReplicationConfig.hasEcReplicationConfig()) {
-      ecReplicationConfig = new ECReplicationConfig(
-          defaultReplicationConfig.getEcReplicationConfig());
-      replicationConfig = ecReplicationConfig;
-      factor = null;
-    } else {
-      factor =
-          ReplicationFactor.fromProto(defaultReplicationConfig.getFactor());
-      replicationConfig = ReplicationConfig.fromTypeAndFactor(type, factor);
-      ecReplicationConfig = null;
+  public static DefaultReplicationConfig fromProto(
+      HddsProtos.DefaultReplicationConfig proto) {
+    if (proto == null) {
+      throw new IllegalArgumentException(
+          "Invalid argument: default replication config is null");
     }
+    ReplicationConfig config = proto.hasEcReplicationConfig()
+        ? new ECReplicationConfig(proto.getEcReplicationConfig())
+        : ReplicationConfig.fromProtoTypeAndFactor(
+            proto.getType(), proto.getFactor());
+    return new DefaultReplicationConfig(config);
   }
 
   public ReplicationType getType() {

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/client/DefaultReplicationConfig.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/client/DefaultReplicationConfig.java
@@ -26,19 +26,14 @@ import java.util.Objects;
  */
 public class DefaultReplicationConfig {
 
-  private final ReplicationType type;
-  private final ReplicationFactor factor;
   private final ECReplicationConfig ecReplicationConfig;
   private final ReplicationConfig replicationConfig;
 
   public DefaultReplicationConfig(ReplicationConfig replicationConfig) {
     this.replicationConfig = replicationConfig;
-    type = ReplicationType.fromProto(replicationConfig.getReplicationType());
     if (replicationConfig instanceof ECReplicationConfig) {
       ecReplicationConfig = (ECReplicationConfig) replicationConfig;
-      factor = null;
     } else {
-      factor = ReplicationFactor.valueOf(replicationConfig.getRequiredNodes());
       ecReplicationConfig = null;
     }
   }
@@ -57,7 +52,7 @@ public class DefaultReplicationConfig {
   }
 
   public ReplicationType getType() {
-    return this.type;
+    return ReplicationType.fromProto(replicationConfig.getReplicationType());
   }
 
   public DefaultReplicationConfig copy() {
@@ -72,11 +67,12 @@ public class DefaultReplicationConfig {
     final HddsProtos.DefaultReplicationConfig.Builder builder =
         HddsProtos.DefaultReplicationConfig.newBuilder()
             .setType(replicationConfig.getReplicationType());
-    if (this.factor != null) {
-      builder.setFactor(ReplicationFactor.toProto(this.factor));
-    }
     if (this.ecReplicationConfig != null) {
       builder.setEcReplicationConfig(this.ecReplicationConfig.toProto());
+    } else {
+      ReplicationFactor factor =
+          ReplicationFactor.valueOf(replicationConfig.getRequiredNodes());
+      builder.setFactor(factor.toProto());
     }
     return builder.build();
   }

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/OzoneBucket.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/OzoneBucket.java
@@ -245,12 +245,7 @@ public class OzoneBucket extends WithMetadata {
         quotaInNamespace, bucketLayout, owner);
     this.bucketLayout = bucketLayout;
     if (defaultReplicationConfig != null) {
-      this.defaultReplication =
-          defaultReplicationConfig.getType() == ReplicationType.EC ?
-              defaultReplicationConfig.getEcReplicationConfig() :
-              ReplicationConfig
-                  .fromTypeAndFactor(defaultReplicationConfig.getType(),
-                      defaultReplicationConfig.getFactor());
+      defaultReplication = defaultReplicationConfig.getReplicationConfig();
     } else {
       // Bucket level replication is not configured by default.
       this.defaultReplication = null;

--- a/hadoop-ozone/client/src/test/java/org/apache/hadoop/ozone/client/MockOmTransport.java
+++ b/hadoop-ozone/client/src/test/java/org/apache/hadoop/ozone/client/MockOmTransport.java
@@ -18,10 +18,7 @@
 package org.apache.hadoop.ozone.client;
 
 import org.apache.hadoop.hdds.client.DefaultReplicationConfig;
-import org.apache.hadoop.hdds.client.ECReplicationConfig;
 import org.apache.hadoop.hdds.client.ReplicationConfig;
-import org.apache.hadoop.hdds.client.ReplicationFactor;
-import org.apache.hadoop.hdds.client.ReplicationType;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.hdds.scm.container.common.helpers.ExcludeList;
@@ -285,20 +282,11 @@ public class MockOmTransport implements OmTransport {
     BucketInfo bucketInfo = buckets.get(infoBucketRequest.getVolumeName())
         .get(infoBucketRequest.getBucketName());
     if (!bucketInfo.hasDefaultReplicationConfig()) {
-      final ReplicationConfig replicationConfig = ReplicationConfig
-          .getDefault(new OzoneConfiguration());
-
-      bucketInfo = bucketInfo.toBuilder().setDefaultReplicationConfig(
-          new DefaultReplicationConfig(
-              ReplicationType.fromProto(replicationConfig.getReplicationType()),
-              replicationConfig
-                  .getReplicationType() != HddsProtos.ReplicationType.EC ?
-                  ReplicationFactor
-                      .valueOf(replicationConfig.getRequiredNodes()) :
-                  null, replicationConfig
-              .getReplicationType() == HddsProtos.ReplicationType.EC ?
-              (ECReplicationConfig) replicationConfig :
-              null).toProto()).build();
+      bucketInfo = bucketInfo.toBuilder()
+          .setDefaultReplicationConfig(new DefaultReplicationConfig(
+              ReplicationConfig.getDefault(new OzoneConfiguration())).toProto()
+          )
+          .build();
     }
     return InfoBucketResponse.newBuilder()
         .setBucketInfo(bucketInfo)

--- a/hadoop-ozone/client/src/test/java/org/apache/hadoop/ozone/client/TestOzoneECClient.java
+++ b/hadoop-ozone/client/src/test/java/org/apache/hadoop/ozone/client/TestOzoneECClient.java
@@ -22,7 +22,6 @@ import org.apache.hadoop.conf.StorageUnit;
 import org.apache.hadoop.hdds.client.BlockID;
 import org.apache.hadoop.hdds.client.DefaultReplicationConfig;
 import org.apache.hadoop.hdds.client.ECReplicationConfig;
-import org.apache.hadoop.hdds.client.ReplicationType;
 import org.apache.hadoop.hdds.conf.ConfigurationSource;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
@@ -216,7 +215,7 @@ public class TestOzoneECClient {
   public void testCreateBucketWithDefaultReplicationConfig()
       throws IOException {
     final OzoneBucket bucket = writeIntoECKey(inputChunks, keyName,
-        new DefaultReplicationConfig(ReplicationType.EC,
+        new DefaultReplicationConfig(
             new ECReplicationConfig(dataBlocks, parityBlocks,
                 ECReplicationConfig.EcCodec.RS, chunkSize)));
 
@@ -285,7 +284,7 @@ public class TestOzoneECClient {
           String.valueOf(i % 9).getBytes(UTF_8)[0]);
     }
     final OzoneBucket bucket = writeIntoECKey(offset, numChunks * chunkSize,
-            inputData, keyName, new DefaultReplicationConfig(ReplicationType.EC,
+            inputData, keyName, new DefaultReplicationConfig(
                     new ECReplicationConfig(dataBlocks, parityBlocks,
                             ECReplicationConfig.EcCodec.RS, chunkSize)));
     OzoneKey key = bucket.getKey(keyName);
@@ -319,7 +318,7 @@ public class TestOzoneECClient {
         Byte.parseByte("1"));
 
     writeIntoECKey(firstSmallChunk, keyName,
-        new DefaultReplicationConfig(ReplicationType.EC,
+        new DefaultReplicationConfig(
             new ECReplicationConfig(dataBlocks, parityBlocks,
                 ECReplicationConfig.EcCodec.RS, chunkSize)));
     OzoneManagerProtocolProtos.KeyLocationList blockList =
@@ -446,7 +445,7 @@ public class TestOzoneECClient {
     Arrays.fill(inputData, (numFullChunks * chunkSize),
         ((numFullChunks * chunkSize)) + partialChunkLen - 1, (byte) 1);
     final OzoneBucket bucket = writeIntoECKey(inputData, keyName,
-        new DefaultReplicationConfig(ReplicationType.EC,
+        new DefaultReplicationConfig(
             new ECReplicationConfig(dataBlocks, parityBlocks,
                 ECReplicationConfig.EcCodec.RS, chunkSize)));
     OzoneKey key = bucket.getKey(keyName);
@@ -457,7 +456,7 @@ public class TestOzoneECClient {
   public void testCommitKeyInfo()
       throws IOException {
     final OzoneBucket bucket = writeIntoECKey(inputChunks, keyName,
-        new DefaultReplicationConfig(ReplicationType.EC,
+        new DefaultReplicationConfig(
             new ECReplicationConfig(dataBlocks, parityBlocks,
                 ECReplicationConfig.EcCodec.RS, chunkSize)));
 

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmBucketArgs.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmBucketArgs.java
@@ -343,8 +343,11 @@ public final class OmBucketArgs extends WithMetadata implements Auditable {
                 bucketArgs.getOwnerName() : null);
     // OmBucketArgs ctor already has more arguments, so setting the default
     // replication config separately.
-    omBucketArgs.setDefaultReplicationConfig(
-        new DefaultReplicationConfig(bucketArgs.getDefaultReplicationConfig()));
+    if (bucketArgs.hasDefaultReplicationConfig()) {
+      omBucketArgs.setDefaultReplicationConfig(
+          DefaultReplicationConfig.fromProto(
+              bucketArgs.getDefaultReplicationConfig()));
+    }
 
     if (bucketArgs.hasQuotaInBytes()) {
       omBucketArgs.setQuotaInBytes(bucketArgs.getQuotaInBytes());

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmBucketInfo.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmBucketInfo.java
@@ -28,12 +28,8 @@ import java.util.Objects;
 import java.util.stream.Collectors;
 
 import org.apache.hadoop.hdds.client.DefaultReplicationConfig;
-import org.apache.hadoop.hdds.client.ECReplicationConfig;
 import org.apache.hadoop.hdds.client.ReplicationConfig;
-import org.apache.hadoop.hdds.client.ReplicationFactor;
-import org.apache.hadoop.hdds.client.ReplicationType;
 import org.apache.hadoop.hdds.protocol.StorageType;
-import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.ozone.OzoneAcl;
 import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.hadoop.ozone.audit.Auditable;
@@ -415,16 +411,7 @@ public final class OmBucketInfo extends WithObjectID implements Auditable {
   }
 
   public void setDefaultReplicationConfig(ReplicationConfig replicationConfig) {
-    this.defaultReplicationConfig = new DefaultReplicationConfig(
-        ReplicationType.fromProto(replicationConfig.getReplicationType()),
-        replicationConfig
-            .getReplicationType() == HddsProtos.ReplicationType.EC ?
-            null :
-            ReplicationFactor.valueOf(replicationConfig.getRequiredNodes()),
-        replicationConfig
-            .getReplicationType() == HddsProtos.ReplicationType.EC ?
-            ((ECReplicationConfig) replicationConfig) :
-            null);
+    defaultReplicationConfig = new DefaultReplicationConfig(replicationConfig);
   }
 
   /**

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmBucketInfo.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmBucketInfo.java
@@ -668,7 +668,8 @@ public final class OmBucketInfo extends WithObjectID implements Auditable {
     }
     if (bucketInfo.hasDefaultReplicationConfig()) {
       obib.setDefaultReplicationConfig(
-          OMPBHelper.convert(bucketInfo.getDefaultReplicationConfig()));
+          DefaultReplicationConfig.fromProto(
+              bucketInfo.getDefaultReplicationConfig()));
     }
     if (bucketInfo.hasObjectID()) {
       obib.setObjectID(bucketInfo.getObjectID());

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/protocolPB/OMPBHelper.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/protocolPB/OMPBHelper.java
@@ -28,9 +28,6 @@ import org.apache.hadoop.fs.MD5MD5CRC32FileChecksum;
 import org.apache.hadoop.fs.MD5MD5CRC32GzipFileChecksum;
 import org.apache.hadoop.fs.Options;
 import org.apache.hadoop.hdds.client.DefaultReplicationConfig;
-import org.apache.hadoop.hdds.client.ECReplicationConfig;
-import org.apache.hadoop.hdds.client.ReplicationFactor;
-import org.apache.hadoop.hdds.client.ReplicationType;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.io.DataInputBuffer;
 import org.apache.hadoop.io.DataOutputBuffer;
@@ -173,24 +170,10 @@ public final class OMPBHelper {
       HddsProtos.DefaultReplicationConfig defaultReplicationConfig) {
     if (defaultReplicationConfig == null) {
       throw new IllegalArgumentException(
-          "Invalid argument: default replication config" + " is null");
+          "Invalid argument: default replication config is null");
     }
 
-    final ReplicationType type =
-        ReplicationType.fromProto(defaultReplicationConfig.getType());
-    DefaultReplicationConfig defaultReplicationConfigObj = null;
-    switch (type) {
-    case EC:
-      defaultReplicationConfigObj = new DefaultReplicationConfig(type,
-          new ECReplicationConfig(
-              defaultReplicationConfig.getEcReplicationConfig()));
-      break;
-    default:
-      final ReplicationFactor factor =
-          ReplicationFactor.fromProto(defaultReplicationConfig.getFactor());
-      defaultReplicationConfigObj = new DefaultReplicationConfig(type, factor);
-    }
-    return defaultReplicationConfigObj;
+    return new DefaultReplicationConfig(defaultReplicationConfig);
   }
 
   public static FileChecksum convert(FileChecksumProto proto)

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/protocolPB/OMPBHelper.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/protocolPB/OMPBHelper.java
@@ -193,31 +193,6 @@ public final class OMPBHelper {
     return defaultReplicationConfigObj;
   }
 
-  public static HddsProtos.DefaultReplicationConfig convert(
-      DefaultReplicationConfig defaultReplicationConfig) {
-    if (defaultReplicationConfig == null) {
-      throw new IllegalArgumentException(
-          "Invalid argument: default replication config" + " is null");
-    }
-
-    final HddsProtos.DefaultReplicationConfig.Builder builder =
-        HddsProtos.DefaultReplicationConfig.newBuilder();
-    builder.setType(ReplicationType.toProto(
-        defaultReplicationConfig.getType()));
-
-    if (defaultReplicationConfig.getFactor() != null) {
-      builder.setFactor(ReplicationFactor.toProto(
-          defaultReplicationConfig.getFactor()));
-    }
-
-    if (defaultReplicationConfig.getEcReplicationConfig() != null) {
-      builder.setEcReplicationConfig(
-          defaultReplicationConfig.getEcReplicationConfig().toProto());
-    }
-
-    return builder.build();
-  }
-
   public static FileChecksum convert(FileChecksumProto proto)
       throws IOException {
     if (proto == null) {

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/protocolPB/OMPBHelper.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/protocolPB/OMPBHelper.java
@@ -27,8 +27,6 @@ import org.apache.hadoop.fs.MD5MD5CRC32CastagnoliFileChecksum;
 import org.apache.hadoop.fs.MD5MD5CRC32FileChecksum;
 import org.apache.hadoop.fs.MD5MD5CRC32GzipFileChecksum;
 import org.apache.hadoop.fs.Options;
-import org.apache.hadoop.hdds.client.DefaultReplicationConfig;
-import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.io.DataInputBuffer;
 import org.apache.hadoop.io.DataOutputBuffer;
 import org.apache.hadoop.io.MD5Hash;
@@ -164,16 +162,6 @@ public final class OMPBHelper {
     String keyName = proto.getKeyName();
     return new FileEncryptionInfo(suite, version, key, iv, keyName,
         ezKeyVersionName);
-  }
-
-  public static DefaultReplicationConfig convert(
-      HddsProtos.DefaultReplicationConfig defaultReplicationConfig) {
-    if (defaultReplicationConfig == null) {
-      throw new IllegalArgumentException(
-          "Invalid argument: default replication config is null");
-    }
-
-    return new DefaultReplicationConfig(defaultReplicationConfig);
   }
 
   public static FileChecksum convert(FileChecksumProto proto)

--- a/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/om/helpers/TestOmBucketInfo.java
+++ b/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/om/helpers/TestOmBucketInfo.java
@@ -145,7 +145,7 @@ public class TestOmBucketInfo {
             "defaultUser", IAccessAuthorizer.ACLType.WRITE_ACL,
             OzoneAcl.AclScope.ACCESS)))
         .setDefaultReplicationConfig(
-            new DefaultReplicationConfig(ReplicationType.EC,
+            new DefaultReplicationConfig(
                 new ECReplicationConfig(3, 2))).build();
     protobuf = omBucketInfo.getProtobuf();
 

--- a/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/om/helpers/TestOmBucketInfo.java
+++ b/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/om/helpers/TestOmBucketInfo.java
@@ -19,6 +19,7 @@ package org.apache.hadoop.ozone.om.helpers;
 
 import org.apache.hadoop.hdds.client.DefaultReplicationConfig;
 import org.apache.hadoop.hdds.client.ECReplicationConfig;
+import org.apache.hadoop.hdds.client.ReplicationConfig;
 import org.apache.hadoop.hdds.client.ReplicationType;
 import org.apache.hadoop.hdds.protocol.StorageType;
 
@@ -161,10 +162,8 @@ public class TestOmBucketInfo {
     recovered = OmBucketInfo.getFromProtobuf(protobuf);
     Assert.assertEquals(ReplicationType.EC,
         recovered.getDefaultReplicationConfig().getType());
-    ECReplicationConfig config =
-        recovered.getDefaultReplicationConfig().getEcReplicationConfig();
-    Assert.assertNotNull(config);
-    Assert.assertEquals(3, config.getData());
-    Assert.assertEquals(2, config.getParity());
+    ReplicationConfig config =
+        recovered.getDefaultReplicationConfig().getReplicationConfig();
+    Assert.assertEquals(new ECReplicationConfig(3, 2), config);
   }
 }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFSInputStream.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFSInputStream.java
@@ -34,7 +34,6 @@ import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hdds.client.DefaultReplicationConfig;
 import org.apache.hadoop.hdds.client.ECReplicationConfig;
-import org.apache.hadoop.hdds.client.ReplicationType;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.protocol.StorageType;
 import org.apache.hadoop.io.IOUtils;
@@ -115,7 +114,7 @@ public class TestOzoneFSInputStream {
     builder.setStorageType(StorageType.DISK);
     builder.setBucketLayout(BucketLayout.FILE_SYSTEM_OPTIMIZED);
     builder.setDefaultReplicationConfig(
-        new DefaultReplicationConfig(ReplicationType.EC,
+        new DefaultReplicationConfig(
             new ECReplicationConfig(3, 2, ECReplicationConfig.EcCodec.RS,
                 1024)));
     BucketArgs omBucketArgs = builder.build();

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFileChecksum.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFileChecksum.java
@@ -132,7 +132,7 @@ public class TestOzoneFileChecksum {
         .setStorageType(StorageType.DISK)
         .setBucketLayout(BucketLayout.LEGACY)
         .setDefaultReplicationConfig(
-            new DefaultReplicationConfig(ReplicationType.EC,
+            new DefaultReplicationConfig(
                 new ECReplicationConfig("RS-3-2-1024k")))
         .build();
 

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestRootedOzoneFileSystem.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestRootedOzoneFileSystem.java
@@ -39,8 +39,8 @@ import org.apache.hadoop.fs.ContentSummary;
 import org.apache.hadoop.hdds.client.DefaultReplicationConfig;
 import org.apache.hadoop.hdds.client.ECReplicationConfig;
 import org.apache.hadoop.hdds.client.RatisReplicationConfig;
-import org.apache.hadoop.hdds.client.ReplicationFactor;
 import org.apache.hadoop.hdds.client.ReplicationType;
+import org.apache.hadoop.hdds.client.StandaloneReplicationConfig;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.protocol.StorageType;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
@@ -1862,8 +1862,8 @@ public class TestRootedOzoneFileSystem {
     builder.setStorageType(StorageType.DISK);
     builder.setBucketLayout(BucketLayout.LEGACY);
     builder.setDefaultReplicationConfig(
-        new DefaultReplicationConfig(ReplicationType.STAND_ALONE,
-            ReplicationFactor.ONE));
+        new DefaultReplicationConfig(StandaloneReplicationConfig.getInstance(
+            HddsProtos.ReplicationFactor.ONE)));
     BucketArgs omBucketArgs = builder.build();
     String vol = UUID.randomUUID().toString();
     String buck = UUID.randomUUID().toString();
@@ -1893,7 +1893,7 @@ public class TestRootedOzoneFileSystem {
     builder.setStorageType(StorageType.DISK);
     builder.setBucketLayout(BucketLayout.LEGACY);
     builder.setDefaultReplicationConfig(
-        new DefaultReplicationConfig(ReplicationType.EC,
+        new DefaultReplicationConfig(
             new ECReplicationConfig("RS-3-2-1024")));
     BucketArgs omBucketArgs = builder.build();
     String vol = UUID.randomUUID().toString();

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestECKeyOutputStream.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestECKeyOutputStream.java
@@ -22,7 +22,6 @@ import org.apache.hadoop.hdds.client.DefaultReplicationConfig;
 import org.apache.hadoop.hdds.client.ECReplicationConfig;
 import org.apache.hadoop.hdds.client.RatisReplicationConfig;
 import org.apache.hadoop.hdds.client.ReplicationConfig;
-import org.apache.hadoop.hdds.client.ReplicationType;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
 import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos;
@@ -169,7 +168,7 @@ public class TestECKeyOutputStream {
     OzoneVolume volume = objectStore.getVolume(volumeName);
     final BucketArgs.Builder bucketArgs = BucketArgs.newBuilder();
     bucketArgs.setDefaultReplicationConfig(
-        new DefaultReplicationConfig(ReplicationType.EC,
+        new DefaultReplicationConfig(
             new ECReplicationConfig(3, 2, ECReplicationConfig.EcCodec.RS,
                 chunkSize)));
 
@@ -366,7 +365,7 @@ public class TestECKeyOutputStream {
     OzoneVolume volume = objectStore.getVolume(volumeName);
     final BucketArgs.Builder bucketArgs = BucketArgs.newBuilder();
     bucketArgs.setDefaultReplicationConfig(
-        new DefaultReplicationConfig(ReplicationType.EC,
+        new DefaultReplicationConfig(
             new ECReplicationConfig(3, 2, ECReplicationConfig.EcCodec.RS,
                 chunkSize)));
 

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/TestECContainerRecovery.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/TestECContainerRecovery.java
@@ -20,7 +20,6 @@ import org.apache.hadoop.conf.StorageUnit;
 import org.apache.hadoop.hdds.HddsConfigKeys;
 import org.apache.hadoop.hdds.client.DefaultReplicationConfig;
 import org.apache.hadoop.hdds.client.ECReplicationConfig;
-import org.apache.hadoop.hdds.client.ReplicationType;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
@@ -168,7 +167,7 @@ public class TestECContainerRecovery {
     OzoneVolume volume = objectStore.getVolume(volumeName);
     final BucketArgs.Builder bucketArgs = BucketArgs.newBuilder();
     bucketArgs.setDefaultReplicationConfig(
-        new DefaultReplicationConfig(ReplicationType.EC,
+        new DefaultReplicationConfig(
             new ECReplicationConfig(3, 2, ECReplicationConfig.EcCodec.RS,
                 chunkSize)));
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneConfigUtil.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneConfigUtil.java
@@ -19,8 +19,6 @@ package org.apache.hadoop.ozone.om;
 
 import org.apache.hadoop.hdds.client.DefaultReplicationConfig;
 import org.apache.hadoop.hdds.client.ReplicationConfig;
-import org.apache.hadoop.hdds.client.ReplicationFactor;
-import org.apache.hadoop.hdds.client.ReplicationType;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.security.UserGroupInformation;
@@ -106,25 +104,12 @@ public final class OzoneConfigUtil {
       // Client passed the replication config, so let's use it.
       replicationConfig = ReplicationConfig
           .fromProto(clientType, clientFactor, clientECReplicationConfig);
-    } else {
+    } else if (bucketDefaultReplicationConfig != null) {
       // type is NONE, so, let's look for the bucket defaults.
-      if (bucketDefaultReplicationConfig != null) {
-        boolean hasECReplicationConfig = bucketDefaultReplicationConfig
-            .getType() == ReplicationType.EC && bucketDefaultReplicationConfig
-            .getEcReplicationConfig() != null;
-        // Since Bucket defaults are available, let's inherit
-        replicationConfig = ReplicationConfig.fromProto(
-            ReplicationType.toProto(bucketDefaultReplicationConfig.getType()),
-            ReplicationFactor
-                .toProto(bucketDefaultReplicationConfig.getFactor()),
-            hasECReplicationConfig ?
-                bucketDefaultReplicationConfig.getEcReplicationConfig()
-                    .toProto() :
-                null);
-      } else {
-        // if bucket defaults also not available, then use server defaults.
-        replicationConfig = omDefaultReplicationConfig;
-      }
+      replicationConfig = bucketDefaultReplicationConfig.getReplicationConfig();
+    } else {
+      // if bucket defaults also not available, then use server defaults.
+      replicationConfig = omDefaultReplicationConfig;
     }
     return replicationConfig;
   }

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestOzoneConfigUtil.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestOzoneConfigUtil.java
@@ -20,7 +20,6 @@ import org.apache.hadoop.hdds.client.DefaultReplicationConfig;
 import org.apache.hadoop.hdds.client.ECReplicationConfig;
 import org.apache.hadoop.hdds.client.RatisReplicationConfig;
 import org.apache.hadoop.hdds.client.ReplicationConfig;
-import org.apache.hadoop.hdds.client.ReplicationFactor;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.ozone.OzoneConfigKeys;
@@ -54,7 +53,7 @@ public class TestOzoneConfigUtil {
         .resolveReplicationConfigPreference(noneType, zeroFactor,
             clientECReplicationConfig, bucketECConfig, ratis3ReplicationConfig);
     // Client has no preference, so we should bucket defaults as we passed.
-    Assert.assertEquals(bucketECConfig.getEcReplicationConfig(),
+    Assert.assertEquals(bucketECConfig.getReplicationConfig(),
         replicationConfig);
   }
 
@@ -91,19 +90,17 @@ public class TestOzoneConfigUtil {
    */
   @Test
   public void testResolveClientSideRepConfigWhenBucketHasEC3() {
+    ReplicationConfig ratisReplicationConfig =
+        RatisReplicationConfig.getInstance(HddsProtos.ReplicationFactor.THREE);
     DefaultReplicationConfig ratisBucketDefaults =
-        new DefaultReplicationConfig(RatisReplicationConfig.getInstance(
-            HddsProtos.ReplicationFactor.THREE));
+        new DefaultReplicationConfig(ratisReplicationConfig);
     ReplicationConfig replicationConfig = OzoneConfigUtil
         .resolveReplicationConfigPreference(noneType, zeroFactor,
             clientECReplicationConfig, ratisBucketDefaults,
             ratis3ReplicationConfig);
     // Client has no preference of type and bucket has ratis defaults, so it
     // should return ratis.
-    Assert.assertEquals(ratisBucketDefaults.getType().name(),
-        replicationConfig.getReplicationType().name());
-    Assert.assertEquals(ratisBucketDefaults.getFactor(),
-        ReplicationFactor.valueOf(replicationConfig.getRequiredNodes()));
+    Assert.assertEquals(ratisReplicationConfig, replicationConfig);
   }
 
   @Test

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestOzoneConfigUtil.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestOzoneConfigUtil.java
@@ -21,7 +21,6 @@ import org.apache.hadoop.hdds.client.ECReplicationConfig;
 import org.apache.hadoop.hdds.client.RatisReplicationConfig;
 import org.apache.hadoop.hdds.client.ReplicationConfig;
 import org.apache.hadoop.hdds.client.ReplicationFactor;
-import org.apache.hadoop.hdds.client.ReplicationType;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.ozone.OzoneConfigKeys;
@@ -93,8 +92,8 @@ public class TestOzoneConfigUtil {
   @Test
   public void testResolveClientSideRepConfigWhenBucketHasEC3() {
     DefaultReplicationConfig ratisBucketDefaults =
-        new DefaultReplicationConfig(ReplicationType.RATIS,
-            ReplicationFactor.THREE);
+        new DefaultReplicationConfig(RatisReplicationConfig.getInstance(
+            HddsProtos.ReplicationFactor.THREE));
     ReplicationConfig replicationConfig = OzoneConfigUtil
         .resolveReplicationConfigPreference(noneType, zeroFactor,
             clientECReplicationConfig, ratisBucketDefaults,

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/bucket/TestOMBucketSetPropertyRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/bucket/TestOMBucketSetPropertyRequest.java
@@ -257,7 +257,7 @@ public class TestOMBucketSetPropertyRequest extends TestBucketRequest {
 
     BucketArgs bucketArgs = OmBucketArgs.newBuilder()
         .setDefaultReplicationConfig(new DefaultReplicationConfig(
-            EC, new ECReplicationConfig(3, 2)))
+            new ECReplicationConfig(3, 2)))
         .setBucketName(bucketName)
         .setVolumeName(volumeName)
         .setIsVersionEnabled(true)


### PR DESCRIPTION
## What changes were proposed in this pull request?

Refactor the `DefaultReplicationConfig` class to eliminate duplication and make it easier to use.

 * reduce number of constructors
 * move factory method for proto conversion from `OMPBHelper`
 * expose underlying `ReplicationConfig`

https://issues.apache.org/jira/browse/HDDS-7542

## How was this patch tested?

Refactoring (no functional changes), existing tests cover it.  CI:
https://github.com/adoroszlai/hadoop-ozone/actions/runs/3557989788