### PR TITLE
HDDS-7554. Recon UI should show DORMANT in pipeline status filter

### DIFF
--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/views/pipelines/pipelines.tsx
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/views/pipelines/pipelines.tsx
@@ -31,7 +31,7 @@ import {IAxiosResponse} from 'types/axios.types';
 import {ColumnSearch} from 'utils/columnSearch';
 
 const {TabPane} = Tabs;
-const PipelineStatusList = ['OPEN', 'CLOSING', 'QUASI_CLOSED', 'CLOSED', 'UNHEALTHY', 'INVALID', 'DELETED'] as const;
+const PipelineStatusList = ['OPEN', 'CLOSING', 'QUASI_CLOSED', 'CLOSED', 'UNHEALTHY', 'INVALID', 'DELETED', 'DORMANT'] as const;
 type PipelineStatusTuple = typeof PipelineStatusList;
 export type PipelineStatus = PipelineStatusTuple[number]; // 'OPEN' | 'CLOSING' | 'QUASI_CLOSED' | 'CLOSED' | 'UNHEALTHY' | 'INVALID' | 'DELETED';
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Recon UI should show `DORMANT` in pipeline status filter.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-7554

## How was this patch tested?

- Manually

![image](https://user-images.githubusercontent.com/112169209/204512379-32c2895a-38c2-490c-ac8a-e06ed0a267b6.png)


