### PR TITLE
HDDS-5331. Recon: Trigger PipelineSyncTask when DN becomes stale and ContainerHealthTask when DN becomes dead.

### DIFF
--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/fsck/ContainerHealthTask.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/fsck/ContainerHealthTask.java
@@ -85,18 +85,20 @@ public class ContainerHealthTask extends ReconScmTask {
   @Override
   public void run() {
     try {
-      lock.writeLock().lock();
       while (canRun()) {
+        try {
+          lock.writeLock().lock();
+          triggerContainerHealthCheck();
+        } finally {
+          lock.writeLock().unlock();
+        }
         Thread.sleep(interval);
-        triggerContainerHealthCheck();
       }
     } catch (Throwable t) {
       LOG.error("Exception in Missing Container task Thread.", t);
       if (t instanceof InterruptedException) {
         Thread.currentThread().interrupt();
       }
-    } finally {
-      lock.writeLock().unlock();
     }
   }
 

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/fsck/ContainerHealthTask.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/fsck/ContainerHealthTask.java
@@ -86,12 +86,7 @@ public class ContainerHealthTask extends ReconScmTask {
   public void run() {
     try {
       while (canRun()) {
-        try {
-          lock.writeLock().lock();
-          triggerContainerHealthCheck();
-        } finally {
-          lock.writeLock().unlock();
-        }
+        triggerContainerHealthCheck();
         Thread.sleep(interval);
       }
     } catch (Throwable t) {

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/fsck/ContainerHealthTask.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/fsck/ContainerHealthTask.java
@@ -98,8 +98,8 @@ public class ContainerHealthTask extends ReconScmTask {
   }
 
   public void triggerContainerHealthCheck() {
+    lock.writeLock().lock();
     try {
-      lock.writeLock().lock();
       long start = Time.monotonicNow();
       long currentTime = System.currentTimeMillis();
       long existingCount = processExistingDBRecords(currentTime);

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/fsck/ContainerHealthTask.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/fsck/ContainerHealthTask.java
@@ -87,7 +87,7 @@ public class ContainerHealthTask extends ReconScmTask {
     try {
       lock.writeLock().lock();
       while (canRun()) {
-        wait(interval);
+        Thread.sleep(interval);
         triggerContainerHealthCheck();
       }
     } catch (Throwable t) {

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/fsck/ContainerHealthTask.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/fsck/ContainerHealthTask.java
@@ -24,6 +24,8 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.TimeoutException;
+import java.util.concurrent.locks.ReadWriteLock;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
 
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.hdds.scm.PlacementPolicy;
@@ -56,6 +58,8 @@ public class ContainerHealthTask extends ReconScmTask {
   private static final Logger LOG =
       LoggerFactory.getLogger(ContainerHealthTask.class);
 
+  private ReadWriteLock lock = new ReentrantReadWriteLock(true);
+
   private StorageContainerServiceProvider scmClient;
   private ContainerManager containerManager;
   private ContainerHealthSchemaManager containerHealthSchemaManager;
@@ -79,32 +83,44 @@ public class ContainerHealthTask extends ReconScmTask {
   }
 
   @Override
-  public synchronized void run() {
+  public void run() {
     try {
+      lock.writeLock().lock();
       while (canRun()) {
         wait(interval);
-        long start = Time.monotonicNow();
-        long currentTime = System.currentTimeMillis();
-        long existingCount = processExistingDBRecords(currentTime);
-        LOG.info("Container Health task thread took {} milliseconds to" +
-                " process {} existing database records.",
-            Time.monotonicNow() - start, existingCount);
-        start = Time.monotonicNow();
-        final List<ContainerInfo> containers = containerManager.getContainers();
-        containers.stream()
-            .filter(c -> !processedContainers.contains(c))
-            .forEach(c -> processContainer(c, currentTime));
-        recordSingleRunCompletion();
-        LOG.info("Container Health task thread took {} milliseconds for" +
-                " processing {} containers.", Time.monotonicNow() - start,
-            containers.size());
-        processedContainers.clear();
+        triggerContainerHealthCheck();
       }
     } catch (Throwable t) {
       LOG.error("Exception in Missing Container task Thread.", t);
       if (t instanceof InterruptedException) {
         Thread.currentThread().interrupt();
       }
+    } finally {
+      lock.writeLock().unlock();
+    }
+  }
+
+  public void triggerContainerHealthCheck() {
+    try {
+      lock.writeLock().lock();
+      long start = Time.monotonicNow();
+      long currentTime = System.currentTimeMillis();
+      long existingCount = processExistingDBRecords(currentTime);
+      LOG.info("Container Health task thread took {} milliseconds to" +
+              " process {} existing database records.",
+          Time.monotonicNow() - start, existingCount);
+      start = Time.monotonicNow();
+      final List<ContainerInfo> containers = containerManager.getContainers();
+      containers.stream()
+          .filter(c -> !processedContainers.contains(c))
+          .forEach(c -> processContainer(c, currentTime));
+      recordSingleRunCompletion();
+      LOG.info("Container Health task thread took {} milliseconds for" +
+              " processing {} containers.", Time.monotonicNow() - start,
+          containers.size());
+      processedContainers.clear();
+    } finally {
+      lock.writeLock().unlock();
     }
   }
 

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/scm/PipelineSyncTask.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/scm/PipelineSyncTask.java
@@ -69,7 +69,7 @@ public class PipelineSyncTask extends ReconScmTask {
   }
 
   @Override
-  protected synchronized void run() {
+  public void run() {
     try {
       while (canRun()) {
         try {

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/scm/PipelineSyncTask.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/scm/PipelineSyncTask.java
@@ -71,18 +71,20 @@ public class PipelineSyncTask extends ReconScmTask {
   @Override
   protected synchronized void run() {
     try {
-      lock.writeLock().lock();
       while (canRun()) {
-        triggerPipelineSyncTask();
-        wait(interval);
+        try {
+          lock.writeLock().lock();
+          triggerPipelineSyncTask();
+        } finally {
+          lock.writeLock().unlock();
+        }
+        Thread.sleep(interval);
       }
     } catch (Throwable t) {
       LOG.error("Exception in Pipeline sync Thread.", t);
       if (t instanceof InterruptedException) {
         Thread.currentThread().interrupt();
       }
-    } finally {
-      lock.writeLock().unlock();
     }
   }
 

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/scm/PipelineSyncTask.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/scm/PipelineSyncTask.java
@@ -85,8 +85,8 @@ public class PipelineSyncTask extends ReconScmTask {
 
   public void triggerPipelineSyncTask()
       throws IOException, TimeoutException, NodeNotFoundException {
+    lock.writeLock().lock();
     try {
-      lock.writeLock().lock();
       long start = Time.monotonicNow();
       List<Pipeline> pipelinesFromScm = scmClient.getPipelines();
       reconPipelineManager.initializePipelines(pipelinesFromScm);

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/scm/PipelineSyncTask.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/scm/PipelineSyncTask.java
@@ -72,12 +72,7 @@ public class PipelineSyncTask extends ReconScmTask {
   public void run() {
     try {
       while (canRun()) {
-        try {
-          lock.writeLock().lock();
-          triggerPipelineSyncTask();
-        } finally {
-          lock.writeLock().unlock();
-        }
+        triggerPipelineSyncTask();
         Thread.sleep(interval);
       }
     } catch (Throwable t) {

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/scm/ReconDeadNodeHandler.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/scm/ReconDeadNodeHandler.java
@@ -41,19 +41,20 @@ public class ReconDeadNodeHandler extends DeadNodeHandler {
   private static final Logger LOG =
       LoggerFactory.getLogger(ReconDeadNodeHandler.class);
 
-
   private StorageContainerServiceProvider scmClient;
-
   private ContainerHealthTask containerHealthTask;
+  private PipelineSyncTask pipelineSyncTask;
 
   public ReconDeadNodeHandler(NodeManager nodeManager,
                               PipelineManager pipelineManager,
                               ContainerManager containerManager,
                               StorageContainerServiceProvider scmClient,
-                              ContainerHealthTask containerHealthTask) {
+                              ContainerHealthTask containerHealthTask,
+                              PipelineSyncTask pipelineSyncTask) {
     super(nodeManager, pipelineManager, containerManager);
     this.scmClient = scmClient;
     this.containerHealthTask = containerHealthTask;
+    this.pipelineSyncTask = pipelineSyncTask;
   }
 
   @Override
@@ -77,6 +78,7 @@ public class ReconDeadNodeHandler extends DeadNodeHandler {
             "information about it.", datanodeDetails);
       }
       containerHealthTask.triggerContainerHealthCheck();
+      pipelineSyncTask.triggerPipelineSyncTask();
     } catch (Exception ioEx) {
       LOG.error("Error trying to verify Node operational state from SCM.",
           ioEx);

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/scm/ReconDeadNodeHandler.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/scm/ReconDeadNodeHandler.java
@@ -28,6 +28,7 @@ import org.apache.hadoop.hdds.scm.node.DeadNodeHandler;
 import org.apache.hadoop.hdds.scm.node.NodeManager;
 import org.apache.hadoop.hdds.scm.pipeline.PipelineManager;
 import org.apache.hadoop.hdds.server.events.EventPublisher;
+import org.apache.hadoop.ozone.recon.fsck.ContainerHealthTask;
 import org.apache.hadoop.ozone.recon.spi.StorageContainerServiceProvider;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -43,12 +44,16 @@ public class ReconDeadNodeHandler extends DeadNodeHandler {
 
   private StorageContainerServiceProvider scmClient;
 
+  private ContainerHealthTask containerHealthTask;
+
   public ReconDeadNodeHandler(NodeManager nodeManager,
                               PipelineManager pipelineManager,
                               ContainerManager containerManager,
-                              StorageContainerServiceProvider scmClient) {
+                              StorageContainerServiceProvider scmClient,
+                              ContainerHealthTask containerHealthTask) {
     super(nodeManager, pipelineManager, containerManager);
     this.scmClient = scmClient;
+    this.containerHealthTask = containerHealthTask;
   }
 
   @Override
@@ -71,6 +76,7 @@ public class ReconDeadNodeHandler extends DeadNodeHandler {
         LOG.warn("Node {} has reached DEAD state, but SCM does not have " +
             "information about it.", datanodeDetails);
       }
+      containerHealthTask.triggerContainerHealthCheck();
     } catch (Exception ioEx) {
       LOG.error("Error trying to verify Node operational state from SCM.",
           ioEx);

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/scm/ReconStaleNodeHandler.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/scm/ReconStaleNodeHandler.java
@@ -33,7 +33,7 @@ import org.slf4j.LoggerFactory;
 public class ReconStaleNodeHandler extends StaleNodeHandler {
 
   private static final Logger LOG =
-        LoggerFactory.getLogger(ReconDeadNodeHandler.class);
+        LoggerFactory.getLogger(ReconStaleNodeHandler.class);
   private PipelineSyncTask pipelineSyncTask;
 
   public ReconStaleNodeHandler(NodeManager nodeManager,

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/scm/ReconStaleNodeHandler.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/scm/ReconStaleNodeHandler.java
@@ -1,0 +1,40 @@
+package org.apache.hadoop.ozone.recon.scm;
+
+import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import org.apache.hadoop.hdds.protocol.DatanodeDetails;
+import org.apache.hadoop.hdds.scm.node.NodeManager;
+import org.apache.hadoop.hdds.scm.node.StaleNodeHandler;
+import org.apache.hadoop.hdds.scm.pipeline.PipelineManager;
+import org.apache.hadoop.hdds.server.events.EventPublisher;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Recon's handling of Stale node.
+ */
+public class ReconStaleNodeHandler extends StaleNodeHandler {
+
+  private static final Logger LOG =
+        LoggerFactory.getLogger(ReconDeadNodeHandler.class);
+  private PipelineSyncTask pipelineSyncTask;
+
+  public ReconStaleNodeHandler(NodeManager nodeManager,
+                                 PipelineManager pipelineManager,
+                                 OzoneConfiguration conf,
+                                 PipelineSyncTask pipelineSyncTask) {
+    super(nodeManager, pipelineManager, conf);
+    this.pipelineSyncTask = pipelineSyncTask;
+  }
+
+  @Override
+  public void onMessage(final DatanodeDetails datanodeDetails,
+                          final EventPublisher publisher) {
+    super.onMessage(datanodeDetails, publisher);
+    try {
+      pipelineSyncTask.triggerPipelineSyncTask();
+    } catch (Exception exp) {
+      LOG.error("Error trying to trigger pipeline sync task..",
+          exp);
+    }
+  }
+}

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/scm/ReconStaleNodeHandler.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/scm/ReconStaleNodeHandler.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.hadoop.ozone.recon.scm;
 
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/scm/ReconStorageContainerManagerFacade.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/scm/ReconStorageContainerManagerFacade.java
@@ -216,7 +216,7 @@ public class ReconStorageContainerManagerFacade
             conf, pipelineSyncTask);
     DeadNodeHandler deadNodeHandler = new ReconDeadNodeHandler(nodeManager,
         pipelineManager, containerManager,
-        scmServiceProvider, containerHealthTask);
+        scmServiceProvider, containerHealthTask, pipelineSyncTask);
 
     ContainerReportHandler containerReportHandler =
         new ReconContainerReportHandler(nodeManager, containerManager);

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/scm/ReconStorageContainerManagerFacade.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/scm/ReconStorageContainerManagerFacade.java
@@ -197,10 +197,26 @@ public class ReconStorageContainerManagerFacade
     PipelineActionHandler pipelineActionHandler =
         new PipelineActionHandler(pipelineManager, scmContext, conf);
 
+    ReconTaskConfig reconTaskConfig = conf.getObject(ReconTaskConfig.class);
+    PipelineSyncTask pipelineSyncTask = new PipelineSyncTask(
+        pipelineManager,
+        nodeManager,
+        scmServiceProvider,
+        reconTaskStatusDao,
+        reconTaskConfig);
+    ContainerHealthTask containerHealthTask = new ContainerHealthTask(
+        containerManager,
+        scmServiceProvider,
+        reconTaskStatusDao, containerHealthSchemaManager,
+        containerPlacementPolicy,
+        reconTaskConfig);
+
     StaleNodeHandler staleNodeHandler =
-        new StaleNodeHandler(nodeManager, pipelineManager, conf);
+        new ReconStaleNodeHandler(nodeManager, pipelineManager,
+            conf, pipelineSyncTask);
     DeadNodeHandler deadNodeHandler = new ReconDeadNodeHandler(nodeManager,
-        pipelineManager, containerManager, scmServiceProvider);
+        pipelineManager, containerManager,
+        scmServiceProvider, containerHealthTask);
 
     ContainerReportHandler containerReportHandler =
         new ReconContainerReportHandler(nodeManager, containerManager);
@@ -268,19 +284,8 @@ public class ReconStorageContainerManagerFacade
     eventQueue.addHandler(SCMEvents.CLOSE_CONTAINER, closeContainerHandler);
     eventQueue.addHandler(SCMEvents.NEW_NODE, newNodeHandler);
 
-    ReconTaskConfig reconTaskConfig = conf.getObject(ReconTaskConfig.class);
-    reconScmTasks.add(new PipelineSyncTask(
-        pipelineManager,
-        nodeManager,
-        scmServiceProvider,
-        reconTaskStatusDao,
-        reconTaskConfig));
-    reconScmTasks.add(new ContainerHealthTask(
-        containerManager,
-        scmServiceProvider,
-        reconTaskStatusDao, containerHealthSchemaManager,
-        containerPlacementPolicy,
-        reconTaskConfig));
+    reconScmTasks.add(pipelineSyncTask);
+    reconScmTasks.add(containerHealthTask);
   }
 
   /**


### PR DESCRIPTION
Currently, the ContainerHealthTask runs in periodic intervals to check if a container is under replicated or missing. A small improvement by triggering a run of this task when a DN goes STALE or DEAD can help identify under replicated containers quicker.
Since StaleNodeHandler don't update container state or remove container replica from Recon cache on which ContainerHelathTask is dependent on identifying missing or unhealthy containers, so we should trigger PipelineSyncTask on StaleNodeHandler and ContainerHealthTask on DeadNodeHandler.

https://issues.apache.org/jira/browse/HDDS-5331

Existing test cases will cover the above scenario. So tested manually.
