### PR TITLE
HDDS-7540. Let reusable workflow inherit secrets

### DIFF
--- a/.github/workflows/post-commit.yml
+++ b/.github/workflows/post-commit.yml
@@ -23,3 +23,4 @@ concurrency:
 jobs:
   CI:
     uses: ./.github/workflows/ci.yml
+    secrets: inherit

--- a/.github/workflows/scheduled_ci.yml
+++ b/.github/workflows/scheduled_ci.yml
@@ -19,3 +19,4 @@ on:
 jobs:
   CI:
     uses: ./.github/workflows/ci.yml
+    secrets: inherit


### PR DESCRIPTION
## What changes were proposed in this pull request?

Minor addendum for #4004: the reusable workflow does not get the caller's secrets by default, so the _coverage_ check is running into error.

```
SONAR_TOKEN environment variable should be set
```

https://github.com/apache/ozone/actions/runs/3574181477/jobs/6010427884#step:8:19

The _coverage_ check is run only in Apache repo for `push` events, so it was not flagged in my fork, nor the PR.

Reference:
https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idsecretsinherit

https://issues.apache.org/jira/browse/HDDS-7540

## How was this patch tested?

It will be tested when the PR is merged.