### PR TITLE
HDDS-7526. Avoid overwriting replication config on existing bucket when quota is set

### DIFF
--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmBucketArgs.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmBucketArgs.java
@@ -55,7 +55,6 @@ public final class OmBucketArgs extends WithMetadata implements Auditable {
   private boolean quotaInBytesSet = false;
   private boolean quotaInNamespaceSet = false;
   private DefaultReplicationConfig defaultReplicationConfig = null;
-  private boolean defaultReplicationConfigSet = false;
   /**
    * Bucket Owner Name.
    */
@@ -152,19 +151,10 @@ public final class OmBucketArgs extends WithMetadata implements Auditable {
   }
 
   /**
-   * Returns true if defaultReplicationConfig has been set
-   * to a non default value.
-   */
-  public boolean hasDefaultReplicationConfig() {
-    return defaultReplicationConfigSet;
-  }
-
-  /**
    * Sets the Bucket default replication config.
    */
   private void setDefaultReplicationConfig(
       DefaultReplicationConfig defaultReplicationConfig) {
-    this.defaultReplicationConfigSet = true;
     this.defaultReplicationConfig = defaultReplicationConfig;
   }
 
@@ -227,7 +217,6 @@ public final class OmBucketArgs extends WithMetadata implements Auditable {
     private boolean quotaInNamespaceSet = false;
     private long quotaInNamespace;
     private DefaultReplicationConfig defaultReplicationConfig;
-    private boolean defaultReplicationConfigSet = false;
     private String ownerName;
     /**
      * Constructs a builder.
@@ -276,7 +265,6 @@ public final class OmBucketArgs extends WithMetadata implements Auditable {
 
     public Builder setDefaultReplicationConfig(
         DefaultReplicationConfig defaultRepConfig) {
-      this.defaultReplicationConfigSet = true;
       this.defaultReplicationConfig = defaultRepConfig;
       return this;
     }
@@ -296,9 +284,7 @@ public final class OmBucketArgs extends WithMetadata implements Auditable {
       OmBucketArgs omBucketArgs =
           new OmBucketArgs(volumeName, bucketName, isVersionEnabled,
               storageType, metadata, ownerName);
-      if (defaultReplicationConfigSet) {
-        omBucketArgs.setDefaultReplicationConfig(defaultReplicationConfig);
-      }
+      omBucketArgs.setDefaultReplicationConfig(defaultReplicationConfig);
       if (quotaInBytesSet) {
         omBucketArgs.setQuotaInBytes(quotaInBytes);
       }
@@ -330,7 +316,7 @@ public final class OmBucketArgs extends WithMetadata implements Auditable {
         quotaInNamespace > 0 || quotaInNamespace == OzoneConsts.QUOTA_RESET)) {
       builder.setQuotaInNamespace(quotaInNamespace);
     }
-    if (defaultReplicationConfigSet && defaultReplicationConfig != null) {
+    if (defaultReplicationConfig != null) {
       builder.setDefaultReplicationConfig(defaultReplicationConfig.toProto());
     }
     if (ownerName != null) {

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmBucketArgs.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmBucketArgs.java
@@ -55,6 +55,7 @@ public final class OmBucketArgs extends WithMetadata implements Auditable {
   private boolean quotaInBytesSet = false;
   private boolean quotaInNamespaceSet = false;
   private DefaultReplicationConfig defaultReplicationConfig = null;
+  private boolean defaultReplicationConfigSet = false;
   /**
    * Bucket Owner Name.
    */
@@ -151,10 +152,18 @@ public final class OmBucketArgs extends WithMetadata implements Auditable {
   }
 
   /**
+   * Returns true if defaultReplicationConfig has been set to a non default value.
+   */
+  public boolean hasDefaultReplicationConfig() {
+    return defaultReplicationConfigSet;
+  }
+
+  /**
    * Sets the Bucket default replication config.
    */
   private void setDefaultReplicationConfig(
       DefaultReplicationConfig defaultReplicationConfig) {
+    this.defaultReplicationConfigSet = true;
     this.defaultReplicationConfig = defaultReplicationConfig;
   }
 
@@ -217,6 +226,7 @@ public final class OmBucketArgs extends WithMetadata implements Auditable {
     private boolean quotaInNamespaceSet = false;
     private long quotaInNamespace;
     private DefaultReplicationConfig defaultReplicationConfig;
+    private boolean defaultReplicationConfigSet = false;
     private String ownerName;
     /**
      * Constructs a builder.
@@ -265,6 +275,7 @@ public final class OmBucketArgs extends WithMetadata implements Auditable {
 
     public Builder setDefaultReplicationConfig(
         DefaultReplicationConfig defaultRepConfig) {
+      this.defaultReplicationConfigSet = true;
       this.defaultReplicationConfig = defaultRepConfig;
       return this;
     }
@@ -284,7 +295,9 @@ public final class OmBucketArgs extends WithMetadata implements Auditable {
       OmBucketArgs omBucketArgs =
           new OmBucketArgs(volumeName, bucketName, isVersionEnabled,
               storageType, metadata, ownerName);
-      omBucketArgs.setDefaultReplicationConfig(defaultReplicationConfig);
+      if(defaultReplicationConfigSet) {
+        omBucketArgs.setDefaultReplicationConfig(defaultReplicationConfig);
+      }
       if (quotaInBytesSet) {
         omBucketArgs.setQuotaInBytes(quotaInBytes);
       }
@@ -316,7 +329,7 @@ public final class OmBucketArgs extends WithMetadata implements Auditable {
         quotaInNamespace > 0 || quotaInNamespace == OzoneConsts.QUOTA_RESET)) {
       builder.setQuotaInNamespace(quotaInNamespace);
     }
-    if (defaultReplicationConfig != null) {
+    if (defaultReplicationConfigSet && defaultReplicationConfig != null) {
       builder.setDefaultReplicationConfig(defaultReplicationConfig.toProto());
     }
     if (ownerName != null) {
@@ -343,9 +356,10 @@ public final class OmBucketArgs extends WithMetadata implements Auditable {
                 bucketArgs.getOwnerName() : null);
     // OmBucketArgs ctor already has more arguments, so setting the default
     // replication config separately.
-    omBucketArgs.setDefaultReplicationConfig(
-        new DefaultReplicationConfig(bucketArgs.getDefaultReplicationConfig()));
-
+    if (bucketArgs.hasDefaultReplicationConfig()) {
+      omBucketArgs.setDefaultReplicationConfig(
+              new DefaultReplicationConfig(bucketArgs.getDefaultReplicationConfig()));
+    }
     if (bucketArgs.hasQuotaInBytes()) {
       omBucketArgs.setQuotaInBytes(bucketArgs.getQuotaInBytes());
     }

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmBucketArgs.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmBucketArgs.java
@@ -152,7 +152,8 @@ public final class OmBucketArgs extends WithMetadata implements Auditable {
   }
 
   /**
-   * Returns true if defaultReplicationConfig has been set to a non default value.
+   * Returns true if defaultReplicationConfig has been set
+   * to a non default value.
    */
   public boolean hasDefaultReplicationConfig() {
     return defaultReplicationConfigSet;
@@ -295,7 +296,7 @@ public final class OmBucketArgs extends WithMetadata implements Auditable {
       OmBucketArgs omBucketArgs =
           new OmBucketArgs(volumeName, bucketName, isVersionEnabled,
               storageType, metadata, ownerName);
-      if(defaultReplicationConfigSet) {
+      if (defaultReplicationConfigSet) {
         omBucketArgs.setDefaultReplicationConfig(defaultReplicationConfig);
       }
       if (quotaInBytesSet) {
@@ -357,8 +358,8 @@ public final class OmBucketArgs extends WithMetadata implements Auditable {
     // OmBucketArgs ctor already has more arguments, so setting the default
     // replication config separately.
     if (bucketArgs.hasDefaultReplicationConfig()) {
-      omBucketArgs.setDefaultReplicationConfig(
-              new DefaultReplicationConfig(bucketArgs.getDefaultReplicationConfig()));
+      omBucketArgs.setDefaultReplicationConfig(new DefaultReplicationConfig(
+              bucketArgs.getDefaultReplicationConfig()));
     }
     if (bucketArgs.hasQuotaInBytes()) {
       omBucketArgs.setQuotaInBytes(bucketArgs.getQuotaInBytes());

--- a/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/om/helpers/TestOmBucketArgs.java
+++ b/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/om/helpers/TestOmBucketArgs.java
@@ -70,12 +70,9 @@ public class TestOmBucketArgs {
             .setVolumeName("volume")
             .build();
 
-    Assert.assertEquals(false, bucketArgs.hasDefaultReplicationConfig());
-
     OmBucketArgs argsFromProto = OmBucketArgs.getFromProtobuf(
             bucketArgs.getProtobuf());
 
-    Assert.assertEquals(false, argsFromProto.hasDefaultReplicationConfig());
     Assert.assertEquals(null, argsFromProto.getDefaultReplicationConfig());
 
     bucketArgs = OmBucketArgs.newBuilder()
@@ -85,12 +82,9 @@ public class TestOmBucketArgs {
                     EC, new ECReplicationConfig(3, 2)))
             .build();
 
-    Assert.assertEquals(true, bucketArgs.hasDefaultReplicationConfig());
-
     argsFromProto = OmBucketArgs.getFromProtobuf(
             bucketArgs.getProtobuf());
 
-    Assert.assertEquals(true, argsFromProto.hasDefaultReplicationConfig());
     Assert.assertEquals(EC,
             argsFromProto.getDefaultReplicationConfig().getType());
   }

--- a/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/om/helpers/TestOmBucketArgs.java
+++ b/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/om/helpers/TestOmBucketArgs.java
@@ -18,8 +18,12 @@
 
 package org.apache.hadoop.ozone.om.helpers;
 
+import org.apache.hadoop.hdds.client.DefaultReplicationConfig;
+import org.apache.hadoop.hdds.client.ECReplicationConfig;
 import org.junit.Assert;
 import org.junit.Test;
+
+import static org.apache.hadoop.hdds.client.ReplicationType.EC;
 
 /**
  * Tests for the OmBucketArgs class.
@@ -57,5 +61,36 @@ public class TestOmBucketArgs {
 
     Assert.assertEquals(true, argsFromProto.hasQuotaInBytes());
     Assert.assertEquals(true, argsFromProto.hasQuotaInNamespace());
+  }
+
+  @Test
+  public void testDefaultReplicationConfigIsSetCorrectly() {
+    OmBucketArgs bucketArgs = OmBucketArgs.newBuilder()
+            .setBucketName("bucket")
+            .setVolumeName("volume")
+            .build();
+
+    Assert.assertEquals(false, bucketArgs.hasDefaultReplicationConfig());
+
+    OmBucketArgs argsFromProto = OmBucketArgs.getFromProtobuf(
+            bucketArgs.getProtobuf());
+
+    Assert.assertEquals(false, argsFromProto.hasDefaultReplicationConfig());
+    Assert.assertEquals(null, argsFromProto.getDefaultReplicationConfig());
+
+    bucketArgs = OmBucketArgs.newBuilder()
+            .setBucketName("bucket")
+            .setVolumeName("volume")
+            .setDefaultReplicationConfig(new DefaultReplicationConfig(
+                    EC, new ECReplicationConfig(3, 2)))
+            .build();
+
+    Assert.assertEquals(true, bucketArgs.hasDefaultReplicationConfig());
+
+    argsFromProto = OmBucketArgs.getFromProtobuf(
+            bucketArgs.getProtobuf());
+
+    Assert.assertEquals(true, argsFromProto.hasDefaultReplicationConfig());
+    Assert.assertEquals(EC, argsFromProto.getDefaultReplicationConfig().getType());
   }
 }

--- a/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/om/helpers/TestOmBucketArgs.java
+++ b/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/om/helpers/TestOmBucketArgs.java
@@ -91,6 +91,7 @@ public class TestOmBucketArgs {
             bucketArgs.getProtobuf());
 
     Assert.assertEquals(true, argsFromProto.hasDefaultReplicationConfig());
-    Assert.assertEquals(EC, argsFromProto.getDefaultReplicationConfig().getType());
+    Assert.assertEquals(EC,
+            argsFromProto.getDefaultReplicationConfig().getType());
   }
 }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/bucket/OMBucketSetPropertyRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/bucket/OMBucketSetPropertyRequest.java
@@ -202,12 +202,10 @@ public class OMBucketSetPropertyRequest extends OMClientRequest {
       if (defaultReplicationConfig != null) {
         // Resetting the default replication config.
         bucketInfoBuilder.setDefaultReplicationConfig(defaultReplicationConfig);
-      } else {
+      } else if (dbBucketInfo.getDefaultReplicationConfig() != null) {
         // Retaining existing default replication config
-        if (dbBucketInfo.getDefaultReplicationConfig() != null) {
-          bucketInfoBuilder.setDefaultReplicationConfig(
+        bucketInfoBuilder.setDefaultReplicationConfig(
                   dbBucketInfo.getDefaultReplicationConfig());
-        }
       }
 
       bucketInfoBuilder.setCreationTime(dbBucketInfo.getCreationTime());

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/bucket/OMBucketSetPropertyRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/bucket/OMBucketSetPropertyRequest.java
@@ -202,6 +202,12 @@ public class OMBucketSetPropertyRequest extends OMClientRequest {
       if (defaultReplicationConfig != null) {
         // Resetting the default replication config.
         bucketInfoBuilder.setDefaultReplicationConfig(defaultReplicationConfig);
+      } else {
+        // Retaining existing default replication config
+        if (dbBucketInfo.getDefaultReplicationConfig() != null ) {
+          bucketInfoBuilder.setDefaultReplicationConfig(
+                  dbBucketInfo.getDefaultReplicationConfig());
+        }
       }
 
       bucketInfoBuilder.setCreationTime(dbBucketInfo.getCreationTime());

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/bucket/OMBucketSetPropertyRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/bucket/OMBucketSetPropertyRequest.java
@@ -204,7 +204,7 @@ public class OMBucketSetPropertyRequest extends OMClientRequest {
         bucketInfoBuilder.setDefaultReplicationConfig(defaultReplicationConfig);
       } else {
         // Retaining existing default replication config
-        if (dbBucketInfo.getDefaultReplicationConfig() != null ) {
+        if (dbBucketInfo.getDefaultReplicationConfig() != null) {
           bucketInfoBuilder.setDefaultReplicationConfig(
                   dbBucketInfo.getDefaultReplicationConfig());
         }

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/bucket/TestOMBucketSetPropertyRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/bucket/TestOMBucketSetPropertyRequest.java
@@ -23,9 +23,12 @@ import java.util.UUID;
 
 import org.apache.hadoop.hdds.client.DefaultReplicationConfig;
 import org.apache.hadoop.hdds.client.ECReplicationConfig;
-import org.apache.hadoop.ozone.om.helpers.*;
+import org.apache.hadoop.ozone.om.helpers.BucketEncryptionKeyInfo;
 import org.apache.hadoop.hdds.utils.db.cache.CacheKey;
 import org.apache.hadoop.hdds.utils.db.cache.CacheValue;
+import org.apache.hadoop.ozone.om.helpers.OmBucketArgs;
+import org.apache.hadoop.ozone.om.helpers.BucketLayout;
+import org.apache.hadoop.ozone.om.helpers.OmBucketInfo;
 import org.apache.hadoop.ozone.om.request.OMRequestTestUtils;
 import org.apache.ozone.test.GenericTestUtils;
 

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/bucket/TestOMBucketSetPropertyRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/bucket/TestOMBucketSetPropertyRequest.java
@@ -23,12 +23,9 @@ import java.util.UUID;
 
 import org.apache.hadoop.hdds.client.DefaultReplicationConfig;
 import org.apache.hadoop.hdds.client.ECReplicationConfig;
-import org.apache.hadoop.ozone.om.helpers.BucketEncryptionKeyInfo;
+import org.apache.hadoop.ozone.om.helpers.*;
 import org.apache.hadoop.hdds.utils.db.cache.CacheKey;
 import org.apache.hadoop.hdds.utils.db.cache.CacheValue;
-import org.apache.hadoop.ozone.om.helpers.OmBucketArgs;
-import org.apache.hadoop.ozone.om.helpers.BucketLayout;
-import org.apache.hadoop.ozone.om.helpers.OmBucketInfo;
 import org.apache.hadoop.ozone.om.request.OMRequestTestUtils;
 import org.apache.ozone.test.GenericTestUtils;
 
@@ -443,5 +440,92 @@ public class TestOMBucketSetPropertyRequest extends TestBucketRequest {
     Assert.assertTrue(omClientResponse.getOMResponse().getMessage().
         contains("Cannot update bucket quota. NamespaceQuota requested " +
             "is less than used namespaceQuota"));
+  }
+
+  @Test
+  public void testSettingQuotaRetainsReplication() throws Exception {
+    String volumeName1 = UUID.randomUUID().toString();
+    String bucketName1 = UUID.randomUUID().toString();
+    String volumeName2 = UUID.randomUUID().toString();
+    String bucketName2 = UUID.randomUUID().toString();
+
+    /* Bucket with default replication */
+    OMRequestTestUtils.addVolumeAndBucketToDB(
+            volumeName1,bucketName1,omMetadataManager);
+
+    String bucketKey = omMetadataManager
+            .getBucketKey(volumeName1, bucketName1);
+
+    OmBucketInfo dbBucketInfoBefore =
+            omMetadataManager.getBucketTable().get(bucketKey);
+
+    /* Setting quota on a bucket with default replication */
+    OMRequest omRequest = createSetBucketPropertyRequest(volumeName1,
+            bucketName1, true, 20 * GB);
+
+    OMBucketSetPropertyRequest omBucketSetPropertyRequest =
+            new OMBucketSetPropertyRequest(omRequest);
+
+    OMClientResponse omClientResponse = omBucketSetPropertyRequest
+            .validateAndUpdateCache(ozoneManager, 1,
+                    ozoneManagerDoubleBufferHelper);
+
+    Assert.assertEquals(true, omClientResponse.getOMResponse().getSuccess());
+
+    OmBucketInfo dbBucketInfoAfter =
+            omMetadataManager.getBucketTable().get(bucketKey);
+
+    Assert.assertEquals(null,dbBucketInfoAfter.getDefaultReplicationConfig());
+    Assert.assertEquals(
+            dbBucketInfoBefore.getDefaultReplicationConfig(),
+            dbBucketInfoAfter.getDefaultReplicationConfig());
+    Assert.assertEquals(20 * GB,
+            dbBucketInfoAfter.getQuotaInBytes());
+    Assert.assertEquals(1000L,
+            dbBucketInfoAfter.getQuotaInNamespace());
+
+    /* Bucket with EC replication */
+    OmBucketInfo.Builder bucketInfo = new OmBucketInfo.Builder()
+            .setVolumeName(volumeName2)
+            .setBucketName(bucketName2)
+            .setDefaultReplicationConfig(new DefaultReplicationConfig(
+                    EC, new ECReplicationConfig(3, 2)));
+
+    OMRequestTestUtils.addVolumeToDB(volumeName2,omMetadataManager);
+    OMRequestTestUtils.addBucketToDB(omMetadataManager, bucketInfo);
+
+    bucketKey = omMetadataManager
+            .getBucketKey(volumeName2, bucketName2);
+    dbBucketInfoBefore =
+            omMetadataManager.getBucketTable().get(bucketKey);
+
+    /* Setting quota on a bucket with non-default EC replication */
+    omRequest = createSetBucketPropertyRequest(volumeName2,
+            bucketName2, true, 20 * GB);
+
+    omBucketSetPropertyRequest =
+            new OMBucketSetPropertyRequest(omRequest);
+
+    omClientResponse = omBucketSetPropertyRequest
+            .validateAndUpdateCache(ozoneManager, 1,
+                    ozoneManagerDoubleBufferHelper);
+
+    Assert.assertEquals(true, omClientResponse.getOMResponse().getSuccess());
+
+    dbBucketInfoAfter =
+            omMetadataManager.getBucketTable().get(bucketKey);
+
+    Assert.assertEquals(EC,
+            dbBucketInfoAfter.getDefaultReplicationConfig().getType());
+    Assert.assertEquals(
+            dbBucketInfoBefore.getDefaultReplicationConfig().getType(),
+            dbBucketInfoAfter.getDefaultReplicationConfig().getType());
+    Assert.assertEquals(
+            dbBucketInfoBefore.getDefaultReplicationConfig().getFactor(),
+            dbBucketInfoAfter.getDefaultReplicationConfig().getFactor());
+    Assert.assertEquals(20 * GB,
+            dbBucketInfoAfter.getQuotaInBytes());
+    Assert.assertEquals(1000L,
+            dbBucketInfoAfter.getQuotaInNamespace());
   }
 }

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/bucket/TestOMBucketSetPropertyRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/bucket/TestOMBucketSetPropertyRequest.java
@@ -454,7 +454,7 @@ public class TestOMBucketSetPropertyRequest extends TestBucketRequest {
 
     /* Bucket with default replication */
     OMRequestTestUtils.addVolumeAndBucketToDB(
-            volumeName1,bucketName1,omMetadataManager);
+            volumeName1, bucketName1, omMetadataManager);
 
     String bucketKey = omMetadataManager
             .getBucketKey(volumeName1, bucketName1);
@@ -478,7 +478,8 @@ public class TestOMBucketSetPropertyRequest extends TestBucketRequest {
     OmBucketInfo dbBucketInfoAfter =
             omMetadataManager.getBucketTable().get(bucketKey);
 
-    Assert.assertEquals(null,dbBucketInfoAfter.getDefaultReplicationConfig());
+    Assert.assertEquals(null,
+            dbBucketInfoAfter.getDefaultReplicationConfig());
     Assert.assertEquals(
             dbBucketInfoBefore.getDefaultReplicationConfig(),
             dbBucketInfoAfter.getDefaultReplicationConfig());
@@ -494,7 +495,7 @@ public class TestOMBucketSetPropertyRequest extends TestBucketRequest {
             .setDefaultReplicationConfig(new DefaultReplicationConfig(
                     EC, new ECReplicationConfig(3, 2)));
 
-    OMRequestTestUtils.addVolumeToDB(volumeName2,omMetadataManager);
+    OMRequestTestUtils.addVolumeToDB(volumeName2, omMetadataManager);
     OMRequestTestUtils.addBucketToDB(omMetadataManager, bucketInfo);
 
     bucketKey = omMetadataManager


### PR DESCRIPTION
## What changes were proposed in this pull request?

Setting Quotas on an existing bucket overwrites the replication config to RATIS ONE. These are the first options for ReplicationType & ReplicationFactor enums in [hdds.proto](https://github.com/apache/ozone/blob/master/hadoop-hdds/interface-client/src/main/proto/hdds.proto#L267-L279) which are picked up by default. 

Proposed change is similar to [#3975 ](https://github.com/apache/ozone/pull/3975). Add `hasDefaultReplicationConfig` in OmBucketArgs.java to indicate if Replication Config is passed by the client. If not, avoid setting replication config in protobuf fields.
if replication config is not explicitly passed, retain replication config of existing bucket when setting bucket properties in OMBucketSetPropertyRequest.java 

```
# ozone sh volume create /ecvol
22/11/29 22:52:06 INFO rpc.RpcClient: Creating Volume: ecvol, with cdpuser1 as owner and space quota set to -1 bytes, counts quota set to -1
# ozone sh bucket create /ecvol/ec1bucket
22/11/29 22:52:15 INFO rpc.RpcClient: Creating Bucket: ecvol/ec1bucket, with the Bucket Layout null, cdpuser1 as owner, Versioning false, Storage Type set to DISK and Encryption set to false
# ozone sh bucket info /ecvol/ec1bucket
# ozone sh bucket set-replication-config -t EC -r rs-3-2-1024k /ecvol/ec1bucket
# ozone sh bucket info /ecvol/ec1bucket
{
  "metadata" : { },
  "volumeName" : "ecvol",
  "name" : "ec1bucket",
  "storageType" : "DISK",
  "versioning" : false,
  "usedBytes" : 0,
  "usedNamespace" : 0,
  "creationTime" : "2022-11-29T22:52:15.599Z",
  "modificationTime" : "2022-11-29T22:52:40.943Z",
  "quotaInBytes" : -1,
  "quotaInNamespace" : -1,
  "bucketLayout" : "LEGACY",
  "link" : false,
  "replicationConfig" : {
    "data" : 3,
    "parity" : 2,
    "ecChunkSize" : 1048576,
    "codec" : "RS",
    "replicationType" : "EC",
    "requiredNodes" : 5
  }
}
[root@schal-11-1 ~]# ozone sh bucket setquota --quota=1GB --namespace-quota=1000 /ecvol/ec1bucket
[root@schal-11-1 ~]# ozone sh bucket info /ecvol/ec1bucket
{
  "metadata" : { },
  "volumeName" : "ecvol",
  "name" : "ec1bucket",
  "storageType" : "DISK",
  "versioning" : false,
  "usedBytes" : 0,
  "usedNamespace" : 0,
  "creationTime" : "2022-11-29T22:52:15.599Z",
  "modificationTime" : "2022-11-29T22:54:09.507Z",
  "quotaInBytes" : 1073741824,
  "quotaInNamespace" : 1000,
  "bucketLayout" : "LEGACY",
  "link" : false,
  "replicationConfig" : {
    "replicationFactor" : "ONE",
    "requiredNodes" : 1,
    "replicationType" : "RATIS"
  }
}
[root@schal-11-1 ~]# ozone sh bucket create ecvol/def1bucket
22/11/29 22:54:35 INFO rpc.RpcClient: Creating Bucket: ecvol/def1bucket, with the Bucket Layout null, cdpuser1 as owner, Versioning false, Storage Type set to DISK and Encryption set to false 
[root@schal-11-1 ~]# ozone sh bucket info /ecvol/def1bucket
{
  "metadata" : { },
  "volumeName" : "ecvol",
  "name" : "def1bucket",
  "storageType" : "DISK",
  "versioning" : false,
  "usedBytes" : 0,
  "usedNamespace" : 0,
  "creationTime" : "2022-11-29T22:54:35.020Z",
  "modificationTime" : "2022-11-29T22:54:35.020Z",
  "quotaInBytes" : -1,
  "quotaInNamespace" : -1,
  "bucketLayout" : "LEGACY",
  "owner" : "cdpuser1",
  "link" : false
}
[root@schal-11-1 ~]# ozone sh bucket setquota --quota=1GB --namespace-quota=1000 /ecvol/def1bucket
[root@schal-11-1 ~]# ozone sh bucket info /ecvol/def1bucket
{
  "metadata" : { },
  "volumeName" : "ecvol",
  "name" : "def1bucket",
  "storageType" : "DISK",
  "versioning" : false,
  "usedBytes" : 0,
  "usedNamespace" : 0,
  "creationTime" : "2022-11-29T22:54:35.020Z",
  "modificationTime" : "2022-11-29T22:55:25.420Z",
  "quotaInBytes" : 1073741824,
  "quotaInNamespace" : 1000,
  "bucketLayout" : "LEGACY",
  "link" : false,
  "replicationConfig" : {
    "replicationFactor" : "ONE",
    "requiredNodes" : 1,
    "replicationType" : "RATIS"
  }
}
```

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-7526

## How was this patch tested?

Added Unit Tests to verify that Replication Config is set correctly in OmBucketArgs and that existing default/non-default replication config is retained when replication config is not set explicitly by the client