### PR TITLE
HDDS-7562. Suppress warning about long filenames in tar

### DIFF
--- a/hadoop-ozone/dist/pom.xml
+++ b/hadoop-ozone/dist/pom.xml
@@ -340,6 +340,7 @@
                   <appendAssemblyId>false</appendAssemblyId>
                   <attach>false</attach>
                   <finalName>ozone-${project.version}-src</finalName>
+                  <tarLongFileMode>gnu</tarLongFileMode>
                   <outputDirectory>target</outputDirectory>
                   <basedir>${project.basedir}/../..</basedir>
                   <!-- Not using descriptorRef and hadoop-assembly dependency -->

--- a/hadoop-ozone/dist/pom.xml
+++ b/hadoop-ozone/dist/pom.xml
@@ -340,7 +340,7 @@
                   <appendAssemblyId>false</appendAssemblyId>
                   <attach>false</attach>
                   <finalName>ozone-${project.version}-src</finalName>
-                  <tarLongFileMode>gnu</tarLongFileMode>
+                  <tarLongFileMode>posix</tarLongFileMode>
                   <outputDirectory>target</outputDirectory>
                   <basedir>${project.basedir}/../..</basedir>
                   <!-- Not using descriptorRef and hadoop-assembly dependency -->

--- a/pom.xml
+++ b/pom.xml
@@ -218,7 +218,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
     <maven-remote-resources-plugin.version>1.5</maven-remote-resources-plugin.version>
     <maven-enforcer-plugin.version>3.0.0-M1</maven-enforcer-plugin.version>
     <maven-javadoc-plugin.version>3.0.1</maven-javadoc-plugin.version>
-    <maven-assembly-plugin.version>2.4</maven-assembly-plugin.version>
+    <maven-assembly-plugin.version>3.4.2</maven-assembly-plugin.version>
     <apache-rat-plugin.version>0.12</apache-rat-plugin.version>
     <maven-deploy-plugin.version>2.8.1</maven-deploy-plugin.version>
     <build-helper-maven-plugin.version>1.9</build-helper-maven-plugin.version>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Suppress warning about long filenames output by `maven-assembly-plugin` when creating source tarball:

```
[INFO] --- maven-assembly-plugin:2.4:single (src-dist) @ ozone-dist ---
[INFO] Reading assembly descriptor: /home/adoroszlai/src/apache/ozone/hadoop-ozone/dist/src/main/assemblies/ozone-src.xml
[INFO] Building tar: /home/adoroszlai/src/apache/ozone/hadoop-ozone/dist/target/ozone-1.3.0-SNAPSHOT-src.tar.gz
[WARNING] Entry: ozone-1.3.0-SNAPSHOT-src/dev-support/annotations/target/maven-status/maven-compiler-plugin/compile/default-compile/ longer than 100 characters.
[WARNING] Resulting tar file can only be processed successfully by GNU compatible tar commands
[WARNING] Entry: ozone-1.3.0-SNAPSHOT-src/dev-support/annotations/target/classes/META-INF/services/javax.annotation.processing.Processor longer than 100 characters.
[WARNING] Entry: ozone-1.3.0-SNAPSHOT-src/dev-support/annotations/target/classes/org/apache/ozone/annotations/RequestFeatureValidatorProcessor$ProcessingPhaseVisitor.class longer than 100 characters.
[WARNING] Entry: ozone-1.3.0-SNAPSHOT-src/dev-support/annotations/target/classes/org/apache/ozone/annotations/ReplicateAnnotationProcessor.class longer than 100 characters.
[WARNING] Entry: ozone-1.3.0-SNAPSHOT-src/dev-support/annotations/target/classes/org/apache/ozone/annotations/RequestFeatureValidatorProcessor$ConditionValidator.class longer than 100 characters.
...
```

https://issues.apache.org/jira/browse/HDDS-7562

## How was this patch tested?

Verified that warnings are gone, tarball is unchanged.

```
$ git checkout master
$ mvn -B -Psrc -DskipTests clean verify > tee master.log
$ mv hadoop-ozone/dist/target/ozone-1.3.0-SNAPSHOT-src.tar.gz master.tar.gz

$ git checkout HDDS-7562
$ mvn -B -Psrc -DskipTests clean verify > tee patch.log
$ mv hadoop-ozone/dist/target/ozone-1.3.0-SNAPSHOT-src.tar.gz patch.tar.gz

$ wc -l master.log patch.log 
   6625 master.log
   2880 patch.log
   9505 total

$ diff -uw \
    <(tar tzvf master.tar.gz | awk '{ print $NF }' | sort) \
    <(tar tzvf patch.tar.gz | awk '{ print $NF }' | sort) \
    | wc -l
0
```

Regular CI:
https://github.com/adoroszlai/hadoop-ozone/actions/runs/3582866264