### PR TITLE
HDDS-7571. [snapshot] Add unit-testcases for Ozone Snapshot create API name validation.

### DIFF
--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/snapshot/TestOMSnapshotCreateRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/snapshot/TestOMSnapshotCreateRequest.java
@@ -163,8 +163,10 @@ public class TestOMSnapshotCreateRequest {
   @Test
   public void testPreExecuteNameLength() throws Exception {
     // check snapshot name length
-    String name63 = "snap75795657617173401188448010125899089001363595171500499231286";
-    String name64 = "snap156808943643007724443266605711479126926050896107709081166294";
+    String name63 =
+            "snap75795657617173401188448010125899089001363595171500499231286";
+    String name64 =
+            "snap156808943643007724443266605711479126926050896107709081166294";
 
     // name length = 63
     when(ozoneManager.isOwner(any(), any())).thenReturn(true);

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/snapshot/TestOMSnapshotCreateRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/snapshot/TestOMSnapshotCreateRequest.java
@@ -147,7 +147,40 @@ public class TestOMSnapshotCreateRequest {
         "Invalid snapshot name: " + badName,
         () -> doPreExecute(omRequest));
   }
-  
+
+  @Test
+  public void testPreExecuteNameOnlyNumbers() throws Exception {
+    // check invalid snapshot name containing only numbers
+    String badNameON = "1234";
+    OMRequest omRequest =
+            OMRequestTestUtils.createSnapshotRequest(
+                    volumeName, bucketName, badNameON);
+    LambdaTestUtils.intercept(OMException.class,
+            "Invalid snapshot name: " + badNameON,
+            () -> doPreExecute(omRequest));
+  }
+
+  @Test
+  public void testPreExecuteNameLength() throws Exception {
+    // check snapshot name length
+    String name63 = "snap75795657617173401188448010125899089001363595171500499231286";
+    String name64 = "snap156808943643007724443266605711479126926050896107709081166294";
+
+    // name length = 63
+    when(ozoneManager.isOwner(any(), any())).thenReturn(true);
+    OMRequest omRequest = OMRequestTestUtils.createSnapshotRequest(
+                    volumeName, bucketName, name63);
+    // should not throw any error
+    doPreExecute(omRequest);
+
+    // name length = 64
+    OMRequest omRequest2 = OMRequestTestUtils.createSnapshotRequest(
+                    volumeName, bucketName, name64);
+    LambdaTestUtils.intercept(OMException.class,
+            "Invalid snapshot name: " + name64,
+            () -> doPreExecute(omRequest2));
+  }
+
   @Test
   public void testValidateAndUpdateCache() throws Exception {
     when(ozoneManager.isAdmin(any())).thenReturn(true);


### PR DESCRIPTION
## What changes were proposed in this pull request?

Added unit-testcases for Ozone Snapshot create API name validation - `TestOMSnapshotCreateRequest / testPreExecuteNameOnlyNumbers` and `TestOMSnapshotCreateRequest / testPreExecuteNameLength`

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-7571

## How was this patch tested?

Added testcases in file - `hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/snapshot/TestOMSnapshotCreateRequest.java`

```
$ mvn -Dtest=TestOMSnapshotCreateRequest test
[INFO] -------------------------------------------------------
[INFO]  T E S T S
[INFO] -------------------------------------------------------
[INFO] Running org.apache.hadoop.ozone.om.request.snapshot.TestOMSnapshotCreateRequest
[INFO] Tests run: 7, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 16.623 s - in org.apache.hadoop.ozone.om.request.snapshot.TestOMSnapshotCreateRequest
[INFO]
[INFO] Results:
[INFO]
[INFO] Tests run: 7, Failures: 0, Errors: 0, Skipped: 0
```