### PR TITLE
HDDS-7574. Not generate dependency-reduced-pom.xml by default

### DIFF
--- a/hadoop-ozone/ozonefs-hadoop3-client/pom.xml
+++ b/hadoop-ozone/ozonefs-hadoop3-client/pom.xml
@@ -74,6 +74,7 @@
               <goal>shade</goal>
             </goals>
             <configuration>
+              <createDependencyReducedPom>false</createDependencyReducedPom>
               <transformers>
                 <transformer
                         implementation="org.apache.maven.plugins.shade.resource.DontIncludeResourceTransformer">

--- a/hadoop-ozone/ozonefs-shaded/pom.xml
+++ b/hadoop-ozone/ozonefs-shaded/pom.xml
@@ -91,6 +91,7 @@
               <goal>shade</goal>
             </goals>
             <configuration>
+              <createDependencyReducedPom>false</createDependencyReducedPom>
               <transformers>
                 <transformer
                         implementation="org.apache.maven.plugins.shade.resource.DontIncludeResourceTransformer">


### PR DESCRIPTION
## What changes were proposed in this pull request?

During the release of 1.3.0, we found two extra files in two directories under ozone-1.3.0-src.tar.gz:
ozone-1.3.0-src/hadoop-ozone/ozonefs-hadoop3-client: dependency-reduced-pom.xml
ozone-1.3.0-src/hadoop-ozone/ozonefs-shaded: dependency-reduced-pom.xml

And the reason is that：
maven-shade-plugin generates dependency-reduced-pom.xml by default. If it is not needed we need to turn it off.

In addition, we also found that there were two more directories in ozone-1.3.0-src.tar.gz. We have not determined the cause of this problem, but this new two directories should have little impact on us.
ozone-1.3.0-src/hadoop-hdds/docs: resources
ozone-1.3.0-src: licenses

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-7574

## How was this patch tested?
Can use the following command to generate ozone-1.3.0-src.tar.gz and check if the two directories above if contain dependency-reduced-pom.xml.
mvn clean install -Dmaven.javadoc.skip=true -DskipTests -Psign,dist,src -Dtar