### PR TITLE
HDDS-7575. Correct showing of RATIS-THREE icon in Recon UI

### DIFF
--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/utils/themeIcons.tsx
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/utils/themeIcons.tsx
@@ -49,7 +49,7 @@ export class RatisIcon extends React.PureComponent<IRatisIconProps> {
   render() {
     const {replicationFactor, isLeader} = this.props;
     const threeFactorClass = isLeader ? 'icon-text-three-dots-leader' : 'icon-text-three-dots';
-    const textClass = replicationFactor == "THREE" ? threeFactorClass : 'icon-text-one-dot';
+    const textClass = replicationFactor === "THREE" ? threeFactorClass : 'icon-text-one-dot';
     return (
       <div className='ratis-icon'>
         <div className={textClass}>R</div>

--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/utils/themeIcons.tsx
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/utils/themeIcons.tsx
@@ -34,12 +34,12 @@ export class FilledIcon extends React.Component {
 }
 
 interface IRatisIconProps {
-  replicationFactor: number;
+  replicationFactor: string;
   isLeader: boolean;
 }
 
 interface IReplicationIconProps {
-  replicationFactor: number;
+  replicationFactor: string;
   replicationType: string;
   leaderNode: string;
   isLeader: boolean;
@@ -49,7 +49,7 @@ export class RatisIcon extends React.PureComponent<IRatisIconProps> {
   render() {
     const {replicationFactor, isLeader} = this.props;
     const threeFactorClass = isLeader ? 'icon-text-three-dots-leader' : 'icon-text-three-dots';
-    const textClass = replicationFactor >= 3 ? threeFactorClass : 'icon-text-one-dot';
+    const textClass = replicationFactor == "THREE" ? threeFactorClass : 'icon-text-one-dot';
     return (
       <div className='ratis-icon'>
         <div className={textClass}>R</div>


### PR DESCRIPTION
## What changes were proposed in this pull request?

This bug in introduced in [HDDS-6308](https://issues.apache.org/jira/browse/HDDS-6308), which updates the type of "replicationFactor" from "number" to "string".

This ticket is to fix this issue.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-7575

## How was this patch tested?

<img width="739" alt="image" src="https://user-images.githubusercontent.com/14933944/205085892-8c266a52-03ec-4068-a16e-17f70d6e33de.png">

