### PR TITLE
HDDS-7578. Wrong directory config used for SCM HA Ratis Snapshot

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMHAUtils.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMHAUtils.java
@@ -146,7 +146,7 @@ public final class SCMHAUtils {
 
   public static String getSCMRatisSnapshotDirectory(ConfigurationSource conf) {
     String snapshotDir =
-            conf.get(ScmConfigKeys.OZONE_SCM_HA_RATIS_STORAGE_DIR);
+            conf.get(ScmConfigKeys.OZONE_SCM_HA_RATIS_SNAPSHOT_DIR);
 
     // If ratis snapshot directory is not set, fall back to ozone.metadata.dir.
     if (Strings.isNullOrEmpty(snapshotDir)) {

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/TestSCMInstallSnapshot.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/TestSCMInstallSnapshot.java
@@ -112,9 +112,12 @@ public class TestSCMInstallSnapshot {
     provider.setPeerNodesMap(peerMap);
     DBCheckpoint checkpoint =
         provider.getSCMDBSnapshot(scmNodeDetails.getNodeId());
+    String snapshotDir =
+        conf.get(ScmConfigKeys.OZONE_SCM_HA_RATIS_SNAPSHOT_DIR);
     final File[] files = FileUtil.listFiles(provider.getScmSnapshotDir());
     Assert.assertTrue(files[0].getName().startsWith(
         OzoneConsts.SCM_DB_NAME + "-" + scmNodeDetails.getNodeId()));
+    Assert.assertTrue(files[0].getAbsolutePath().startsWith(snapshotDir));
     return checkpoint;
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

The configuration of "OZONE_SCM_HA_RATIS_SNAPSHOT_DIR" is not correctly used as the directory of ratis snapshot.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-7578

## How was this patch tested?

unit test.
