### PR TITLE
HDDS-7579. Use Netty 4.1.77 for consistency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -186,6 +186,8 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
     <grpc.protobuf-compile.version>3.19.6</grpc.protobuf-compile.version>
     <os-maven-plugin.version>1.5.0.Final</os-maven-plugin.version>
 
+    <!-- Use netty version known to work with grpc-netty. See table: -->
+    <!-- https://github.com/grpc/grpc-java/blob/master/SECURITY.md#netty -->
     <netty.version>4.1.77.Final</netty.version>
     <io.grpc.version>1.48.1</io.grpc.version>
 

--- a/pom.xml
+++ b/pom.xml
@@ -186,7 +186,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
     <grpc.protobuf-compile.version>3.19.6</grpc.protobuf-compile.version>
     <os-maven-plugin.version>1.5.0.Final</os-maven-plugin.version>
 
-    <netty.version>4.1.79.Final</netty.version>
+    <netty.version>4.1.77.Final</netty.version>
     <io.grpc.version>1.48.1</io.grpc.version>
 
     <!-- define the Java language version used by the compiler -->


### PR DESCRIPTION
## What changes were proposed in this pull request?

Ratis uses Netty 4.1.77.  The same version is recommended for gRPC 1.48.1 which Ozone uses.  This PR proposes to move from Netty 4.1.79 to Netty 4.1.77 for consistency.

https://issues.apache.org/jira/browse/HDDS-7579

## How was this patch tested?

Regular CI:
https://github.com/adoroszlai/hadoop-ozone/actions/runs/3600140354