### PR TITLE
HDDS-7580. Add option to show key count in DBScanner.

### DIFF
--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/RocksDatabase.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/RocksDatabase.java
@@ -68,7 +68,7 @@ import static org.rocksdb.RocksDB.listColumnFamilies;
 public final class RocksDatabase {
   static final Logger LOG = LoggerFactory.getLogger(RocksDatabase.class);
 
-  static final String ESTIMATE_NUM_KEYS = "rocksdb.estimate-num-keys";
+  public static final String ESTIMATE_NUM_KEYS = "rocksdb.estimate-num-keys";
 
 
   static IOException toIOException(Object name, String op, RocksDBException e) {

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestLDBCli.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestLDBCli.java
@@ -45,9 +45,11 @@ import org.junit.Assert;
 import org.junit.rules.TemporaryFolder;
 
 import java.io.BufferedReader;
+import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.InputStreamReader;
+import java.io.PrintStream;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.ArrayList;
@@ -82,6 +84,7 @@ public class TestLDBCli {
     if (dbStore != null) {
       dbStore.close();
     }
+    System.setOut(System.out);
     // Restore the static fields in DBScanner
     DBScanner.setContainerId(-1);
     DBScanner.setDnDBSchemaVersion("V2");
@@ -117,6 +120,16 @@ public class TestLDBCli {
     Assert.assertTrue(getKeyNames(dbScanner).contains("key1"));
     Assert.assertTrue(getKeyNames(dbScanner).contains("key5"));
     Assert.assertFalse(getKeyNames(dbScanner).contains("key6"));
+
+    final ByteArrayOutputStream outputStreamCaptor =
+        new ByteArrayOutputStream();
+    System.setOut(new PrintStream(outputStreamCaptor));
+    DBScanner.setShowCount(true);
+    dbScanner.call();
+    Assert.assertEquals("5", outputStreamCaptor.toString().trim());
+    System.setOut(System.out);
+    DBScanner.setShowCount(false);
+
 
     DBScanner.setLimit(1);
     Assert.assertEquals(1, getKeyNames(dbScanner).size());

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestLDBCli.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestLDBCli.java
@@ -67,6 +67,7 @@ public class TestLDBCli {
   private DBScanner dbScanner;
   private DBStore dbStore = null;
   private List<String> keyNames;
+  private static final String DEFAULT_ENCODING = UTF_8.name();
 
   @Rule
   public TemporaryFolder folder = new TemporaryFolder();
@@ -123,10 +124,11 @@ public class TestLDBCli {
 
     final ByteArrayOutputStream outputStreamCaptor =
         new ByteArrayOutputStream();
-    System.setOut(new PrintStream(outputStreamCaptor));
+    System.setOut(new PrintStream(outputStreamCaptor, false, DEFAULT_ENCODING));
     DBScanner.setShowCount(true);
     dbScanner.call();
-    Assert.assertEquals("5", outputStreamCaptor.toString().trim());
+    Assert.assertEquals("5",
+        outputStreamCaptor.toString(DEFAULT_ENCODING).trim());
     System.setOut(System.out);
     DBScanner.setShowCount(false);
 

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/DBScanner.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/DBScanner.java
@@ -28,6 +28,7 @@ import org.apache.hadoop.hdds.scm.pipeline.PipelineID;
 import org.apache.hadoop.hdds.utils.db.DBColumnFamilyDefinition;
 import org.apache.hadoop.hdds.utils.db.DBDefinition;
 import org.apache.hadoop.hdds.utils.db.FixedLengthStringUtils;
+import org.apache.hadoop.hdds.utils.db.RocksDatabase;
 import org.apache.hadoop.hdds.utils.db.managed.ManagedReadOptions;
 import org.apache.hadoop.hdds.utils.db.managed.ManagedRocksDB;
 import org.apache.hadoop.hdds.utils.db.managed.ManagedRocksIterator;
@@ -37,6 +38,9 @@ import org.apache.hadoop.ozone.container.metadata.DatanodeSchemaThreeDBDefinitio
 import org.kohsuke.MetaInfServices;
 import org.rocksdb.ColumnFamilyDescriptor;
 import org.rocksdb.ColumnFamilyHandle;
+import org.rocksdb.RocksDBException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import picocli.CommandLine;
 
 import java.io.FileOutputStream;
@@ -62,6 +66,9 @@ import java.util.concurrent.Callable;
 )
 @MetaInfServices(SubcommandWithParent.class)
 public class DBScanner implements Callable<Void>, SubcommandWithParent {
+
+  public static final Logger LOG =
+      LoggerFactory.getLogger(DBScanner.class);
 
   @CommandLine.Option(names = {"--column_family"},
       required = true,
@@ -96,6 +103,14 @@ public class DBScanner implements Callable<Void>, SubcommandWithParent {
       description = "Container ID when datanode DB Schema is V3",
       defaultValue = "-1")
   private static long containerId;
+
+  @CommandLine.Option(names = { "--show-count",
+      "-count" }, description = "Get estimated key count for a"
+      + " given column family in the db",
+      defaultValue = "false",
+      showDefaultValue = CommandLine.Help.Visibility.ALWAYS)
+  private static boolean showCount;
+
 
   @CommandLine.ParentCommand
   private RDBParser parent;
@@ -222,6 +237,10 @@ public class DBScanner implements Callable<Void>, SubcommandWithParent {
     DBScanner.withKey = withKey;
   }
 
+  public static void setShowCount(boolean showCount) {
+    DBScanner.showCount = showCount;
+  }
+
   private static ColumnFamilyHandle getColumnFamilyHandle(
             byte[] name, List<ColumnFamilyHandle> columnFamilyHandles) {
     return columnFamilyHandles
@@ -247,8 +266,7 @@ public class DBScanner implements Callable<Void>, SubcommandWithParent {
     DBColumnFamilyDefinition[] columnFamilyDefinitions = dbDefinition
             .getColumnFamilies();
     for (DBColumnFamilyDefinition definition:columnFamilyDefinitions) {
-      System.out.println("Added definition for table:" +
-          definition.getTableName());
+      LOG.info("Added definition for table: {}", definition.getTableName());
       this.columnFamilyMap.put(definition.getTableName(), definition);
     }
   }
@@ -269,7 +287,8 @@ public class DBScanner implements Callable<Void>, SubcommandWithParent {
 
   private void printAppropriateTable(
           List<ColumnFamilyHandle> columnFamilyHandleList,
-          ManagedRocksDB rocksDB, String dbPath) throws IOException {
+          ManagedRocksDB rocksDB, String dbPath)
+      throws IOException, RocksDBException {
     if (limit < 1 && limit != -1) {
       throw new IllegalArgumentException(
               "List length should be a positive number. Only allowed negative" +
@@ -291,6 +310,12 @@ public class DBScanner implements Callable<Void>, SubcommandWithParent {
                 columnFamilyHandleList);
         if (columnFamilyHandle == null) {
           throw new IllegalArgumentException("columnFamilyHandle is null");
+        }
+        if (showCount) {
+          long keyCount = rocksDB.get().getLongProperty(columnFamilyHandle,
+              RocksDatabase.ESTIMATE_NUM_KEYS);
+          System.out.println(keyCount);
+          return;
         }
         ManagedRocksIterator iterator;
         if (containerId > 0 && dnDBSchemaVersion != null &&


### PR DESCRIPTION
## What changes were proposed in this pull request?
Add option to show key count in DBScanner.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-7580

## How was this patch tested?
`bash-4.2$ ozone debug ldb --db=/data/metadata/om.db scan --column_family=keyTable -count`
Tested on docker , added unit tests.
