### PR TITLE
HDDS-7581. Fix update-jar-report for snapshot versions

### DIFF
--- a/hadoop-ozone/dist/src/main/license/update-jar-report.sh
+++ b/hadoop-ozone/dist/src/main/license/update-jar-report.sh
@@ -30,4 +30,4 @@ cd "$OZONE_DIST_DIR"
 
 #sed expression removes the version. Usually license is not changed with version bumps
 #jacoco and test dependencies are excluded
-find . -type f -name "*.jar" | cut -c3- | perl -wpl -e 's/-[0-9]+(.[0-9]+)*(-([0-9a-z]+-)?SNAPSHOT)?+//g; s/\.v\d+\.jar/.jar/g;' | grep -v -e jacoco -e hdds-test-utils | sort > "$SCRIPTDIR"/$REPORT_NAME
+find . -type f -name "*.jar" | cut -c3- | perl -wpl -e 's/-[0-9]+(\.[0-9]+)*(-([0-9a-z]+-)?SNAPSHOT)?+//g; s/\.v\d+\.jar/.jar/g;' | grep -v -e jacoco -e hdds-test-utils | sort > "$SCRIPTDIR"/$REPORT_NAME


### PR DESCRIPTION
## What changes were proposed in this pull request?

Pattern matching for jar version numbers in `update-jar-report.sh` does not correctly work for `ratis-*-2.4.2-8b8bdda-SNAPSHOT`.

Expected:

```
share/ozone/lib/ratis-client.jar
share/ozone/lib/ratis-common.jar
share/ozone/lib/ratis-grpc.jar
share/ozone/lib/ratis-metrics.jar
share/ozone/lib/ratis-netty.jar
share/ozone/lib/ratis-proto.jar
share/ozone/lib/ratis-server-api.jar
share/ozone/lib/ratis-server.jar
```

Actual:

```
share/ozone/lib/ratis-clientbdda-SNAPSHOT.jar
share/ozone/lib/ratis-commonbdda-SNAPSHOT.jar
share/ozone/lib/ratis-grpcbdda-SNAPSHOT.jar
share/ozone/lib/ratis-metricsbdda-SNAPSHOT.jar
share/ozone/lib/ratis-nettybdda-SNAPSHOT.jar
share/ozone/lib/ratis-protobdda-SNAPSHOT.jar
share/ozone/lib/ratis-server-apibdda-SNAPSHOT.jar
share/ozone/lib/ratis-serverbdda-SNAPSHOT.jar
```

The problem is that `-[0-9]+(.[0-9]+)*` matches `-2.4.2-8b8` instead of `-2.4.2`, since `.` is "any char".  We should only accept a literal `.`.

https://issues.apache.org/jira/browse/HDDS-7581

## How was this patch tested?

```
$ echo 'ratis-server-2.4.2-8b8bdda-SNAPSHOT.jar' \
    | perl -wpl -e 's/-[0-9]+(\.[0-9]+)*(-([0-9a-z]+-)?SNAPSHOT)?+//g; s/\.v\d+\.jar/.jar/g;'
ratis-server.jar
```

Also executed build and dependency check both for current `ratis-2.4.1` and for `ratis-2.4.2-8b8bdda-SNAPSHOT` (from HDDS-7555).

https://github.com/adoroszlai/hadoop-ozone/actions/runs/3601990535/jobs/6068627412