### PR TITLE
HDDS-7464. Container Report at SCM is not coming separately for ICR and FCR in prometheus endpoint

### DIFF
--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/metrics/MetricsUtil.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/metrics/MetricsUtil.java
@@ -1,0 +1,100 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hdds.metrics;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.util.Map;
+import org.apache.hadoop.metrics2.annotation.Metrics;
+import org.apache.hadoop.metrics2.lib.DefaultMetricsSystem;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Metrics util for metrics.
+ */
+public final class MetricsUtil {
+  private static final String ANNOTATIONS = "annotations";
+  private static final String ANNOTATION_DATA = "annotationData";
+  private static final Class<? extends Annotation> ANNOTATION_TO_ALTER
+      = Metrics.class;
+
+  private static final Logger LOG =
+      LoggerFactory.getLogger(MetricsUtil.class);
+  
+  private MetricsUtil() {
+  }
+
+  /**
+   * register metric with changing class annotation for metrics.
+   * 
+   * @param source source to register
+   * @param name name of metric
+   * @param desc description of metric
+   * @param context context of metric
+   * @param <T> source type
+   */
+  public static <T> void registerDynamic(
+      T source, String name, String desc, String context) {
+    updateAnnotation(source.getClass(), name, desc, context);
+    DefaultMetricsSystem.instance().register(name, desc, source);
+  }
+  
+  private static void updateAnnotation(
+      Class clz, String name, String desc, String context) {
+    try {
+      Annotation annotationValue = new Metrics() {
+
+        @Override
+        public Class<? extends Annotation> annotationType() {
+          return ANNOTATION_TO_ALTER;
+        }
+
+        @Override
+        public String name() {
+          return name;
+        }
+
+        @Override
+        public String about() {
+          return desc;
+        }
+
+        @Override
+        public String context() {
+          return context;
+        }
+      };
+      
+      Method method = clz.getClass().getDeclaredMethod(
+          ANNOTATION_DATA, null);
+      method.setAccessible(true);
+      Object annotationData = method.invoke(clz);
+      Field annotations = annotationData.getClass()
+          .getDeclaredField(ANNOTATIONS);
+      annotations.setAccessible(true);
+      Map<Class<? extends Annotation>, Annotation> map =
+          (Map<Class<? extends Annotation>, Annotation>) annotations
+              .get(annotationData);
+      map.put(ANNOTATION_TO_ALTER, annotationValue);
+    } catch (Exception e) {
+      LOG.error("Update Metrics annotation failed. ", e);
+    }
+  }
+}

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/metrics/package-info.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/metrics/package-info.java
@@ -1,0 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * metrics registeration util.
+ */
+package org.apache.hadoop.hdds.metrics;

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/server/events/FixedThreadPoolWithAffinityExecutor.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/server/events/FixedThreadPoolWithAffinityExecutor.java
@@ -18,6 +18,7 @@
 package org.apache.hadoop.hdds.server.events;
 
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
+import org.apache.hadoop.hdds.metrics.MetricsUtil;
 import org.apache.hadoop.metrics2.annotation.Metric;
 import org.apache.hadoop.metrics2.annotation.Metrics;
 import org.apache.hadoop.metrics2.lib.DefaultMetricsSystem;
@@ -126,10 +127,8 @@ public class FixedThreadPoolWithAffinityExecutor<P, Q>
       ++i;
     }
 
-    DefaultMetricsSystem.instance()
-        .register(EVENT_QUEUE + name,
-            "Event Executor metrics ",
-            this);
+    MetricsUtil.registerDynamic(this, EVENT_QUEUE + name,
+        "Event Executor metrics ", "EventQueue");
   }
   
   public void setQueueWaitThreshold(long queueWaitThreshold) {

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/server/events/SingleThreadExecutor.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/server/events/SingleThreadExecutor.java
@@ -26,7 +26,6 @@ import java.util.concurrent.Executors;
 
 import org.apache.hadoop.metrics2.annotation.Metric;
 import org.apache.hadoop.metrics2.annotation.Metrics;
-import org.apache.hadoop.metrics2.lib.DefaultMetricsSystem;
 import org.apache.hadoop.metrics2.lib.MutableCounterLong;
 
 /**

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/server/events/SingleThreadExecutor.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/server/events/SingleThreadExecutor.java
@@ -17,6 +17,7 @@
  */
 package org.apache.hadoop.hdds.server.events;
 
+import org.apache.hadoop.hdds.metrics.MetricsUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -64,8 +65,8 @@ public class SingleThreadExecutor<P> implements EventExecutor<P> {
    */
   public SingleThreadExecutor(String name) {
     this.name = name;
-    DefaultMetricsSystem.instance()
-        .register(EVENT_QUEUE + name, "Event Executor metrics ", this);
+    MetricsUtil.registerDynamic(this, EVENT_QUEUE + name,
+        "Event Executor metrics ", "EventQueue");
 
     executor = Executors.newSingleThreadExecutor(
         runnable -> {


### PR DESCRIPTION
## What changes were proposed in this pull request?

Event Queue metrics is not reported properly to prometheus, as classname is same for all reports. As HDDS metrics, annotation is used to identify metric name for prometheus, but if not present make use of classname.
As change, 
1) Updating annotation dynamically while registeration with name provided for EventQueue and then registering to metrics system 

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-7464

## How was this patch tested?

1. Metrics are verified using prometheus endpoint

Event queue metrics reported:
FCR:
<img width="1035" alt="image" src="https://user-images.githubusercontent.com/23372859/205322842-0d7d5b29-e44f-4be9-b84c-a8ae945d3e4d.png">

ICR:
<img width="1174" alt="image" src="https://user-images.githubusercontent.com/23372859/205323007-fc253632-0e5f-4a9a-bcb8-45cc961cdf2b.png">


Earlier, event_queue_** reports were not coming as prefix. Its coming directly with class name.