### PR TITLE
HDDS-7583. Support efficient Snapdiff only until configured Snapshot History

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/OzoneConfigKeys.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/OzoneConfigKeys.java
@@ -523,6 +523,11 @@ public final class OzoneConfigKeys {
   public static final String OZONE_OM_SNAPSHOT_CACHE_MAX_SIZE =
       "ozone.om.snapshot.cache.max.size";
   public static final int OZONE_OM_SNAPSHOT_CACHE_MAX_SIZE_DEFAULT = 10;
+
+  public static final String OZONE_SNAPSHOT_MAX_HISTORY =
+      "ozone.om.snapshot.history.max.count";
+
+  public static final int OZONE_SNAPSHOT_MAX_HISTORY_DEFAULT = 10;
   /**
    * There is no need to instantiate this class.
    */


### PR DESCRIPTION


## What changes were proposed in this pull request?

Adding config to only support Snapshot based on the max number of Snapshot history count

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-7583
## How was this patch tested?
Only Config changes. No unit test cases required