### PR TITLE
HDDS-7596. Fix OM crash due to a corner case for FSO-enabled bucket

### DIFF
--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3MultipartUploadCompleteRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3MultipartUploadCompleteRequest.java
@@ -263,10 +263,11 @@ public class S3MultipartUploadCompleteRequest extends OMKeyRequest {
                 .setHash(DigestUtils.sha256Hex(keyName)));
 
         long volumeId = omMetadataManager.getVolumeId(volumeName);
+        long bucketId = omMetadataManager.getBucketId(volumeName, bucketName);
         omClientResponse =
             getOmClientResponse(multipartKey, omResponse, dbMultipartOpenKey,
                 omKeyInfo, unUsedParts, omBucketInfo, oldKeyVersionsToDelete,
-                volumeId);
+                volumeId, bucketId);
 
         result = Result.SUCCESS;
       } else {
@@ -306,7 +307,7 @@ public class S3MultipartUploadCompleteRequest extends OMKeyRequest {
       OMResponse.Builder omResponse, String dbMultipartOpenKey,
       OmKeyInfo omKeyInfo,  List<OmKeyInfo> unUsedParts,
       OmBucketInfo omBucketInfo, RepeatedOmKeyInfo oldKeyVersionsToDelete,
-      long volumeId) {
+      long volumeId, long bucketId) {
 
     return new S3MultipartUploadCompleteResponse(omResponse.build(),
         multipartKey, dbMultipartOpenKey, omKeyInfo, unUsedParts,

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3MultipartUploadCompleteRequestWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3MultipartUploadCompleteRequestWithFSO.java
@@ -163,11 +163,11 @@ public class S3MultipartUploadCompleteRequestWithFSO
       OzoneManagerProtocolProtos.OMResponse.Builder omResponse,
       String dbMultipartOpenKey, OmKeyInfo omKeyInfo,
       List<OmKeyInfo> unUsedParts, OmBucketInfo omBucketInfo,
-      RepeatedOmKeyInfo oldKeyVersionsToDelete, long volumeId) {
+      RepeatedOmKeyInfo oldKeyVersionsToDelete, long volumeId, long bucketId) {
 
     return new S3MultipartUploadCompleteResponseWithFSO(omResponse.build(),
         multipartKey, dbMultipartOpenKey, omKeyInfo, unUsedParts,
-        getBucketLayout(), omBucketInfo, oldKeyVersionsToDelete, volumeId);
+        getBucketLayout(), omBucketInfo, oldKeyVersionsToDelete, volumeId, bucketId);
   }
 
   @Override

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3MultipartUploadCompleteRequestWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3MultipartUploadCompleteRequestWithFSO.java
@@ -167,7 +167,8 @@ public class S3MultipartUploadCompleteRequestWithFSO
 
     return new S3MultipartUploadCompleteResponseWithFSO(omResponse.build(),
         multipartKey, dbMultipartOpenKey, omKeyInfo, unUsedParts,
-        getBucketLayout(), omBucketInfo, oldKeyVersionsToDelete, volumeId, bucketId);
+        getBucketLayout(), omBucketInfo, oldKeyVersionsToDelete,
+        volumeId, bucketId);
   }
 
   @Override

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/s3/multipart/S3MultipartUploadCompleteResponse.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/s3/multipart/S3MultipartUploadCompleteResponse.java
@@ -136,20 +136,7 @@ public class S3MultipartUploadCompleteResponse extends OmKeyResponse {
     return ozoneKey;
   }
 
-  protected String getMultipartKey() {
-    return multipartKey;
-  }
-
   protected OmKeyInfo getOmKeyInfo() {
     return omKeyInfo;
-  }
-
-  protected List<OmKeyInfo> getPartsUnusedList() {
-    return partsUnusedList;
-  }
-
-  @CheckForNull
-  public OmBucketInfo getOmBucketInfo() {
-    return omBucketInfo;
   }
 }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/s3/multipart/S3MultipartUploadCompleteResponse.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/s3/multipart/S3MultipartUploadCompleteResponse.java
@@ -136,20 +136,7 @@ public class S3MultipartUploadCompleteResponse extends OmKeyResponse {
     return ozoneKey;
   }
 
-  protected String getMultipartKey() {
-    return multipartKey;
-  }
-
-  protected OmKeyInfo getOmKeyInfo() {
-    return omKeyInfo;
-  }
-
   protected List<OmKeyInfo> getPartsUnusedList() {
     return partsUnusedList;
-  }
-
-  @CheckForNull
-  public OmBucketInfo getOmBucketInfo() {
-    return omBucketInfo;
   }
 }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/s3/multipart/S3MultipartUploadCompleteResponse.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/s3/multipart/S3MultipartUploadCompleteResponse.java
@@ -136,7 +136,20 @@ public class S3MultipartUploadCompleteResponse extends OmKeyResponse {
     return ozoneKey;
   }
 
+  protected String getMultipartKey() {
+    return multipartKey;
+  }
+
+  protected OmKeyInfo getOmKeyInfo() {
+    return omKeyInfo;
+  }
+
   protected List<OmKeyInfo> getPartsUnusedList() {
     return partsUnusedList;
+  }
+
+  @CheckForNull
+  public OmBucketInfo getOmBucketInfo() {
+    return omBucketInfo;
   }
 }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/s3/multipart/S3MultipartUploadCompleteResponse.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/s3/multipart/S3MultipartUploadCompleteResponse.java
@@ -32,6 +32,7 @@ import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos
     .OMResponse;
 import org.apache.hadoop.hdds.utils.db.BatchOperation;
 
+import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
 
 import static org.apache.hadoop.ozone.om.OmMetadataManagerImpl.BUCKET_TABLE;
@@ -66,7 +67,7 @@ public class S3MultipartUploadCompleteResponse extends OmKeyResponse {
       @Nonnull OmKeyInfo omKeyInfo,
       @Nonnull List<OmKeyInfo> unUsedParts,
       @Nonnull BucketLayout bucketLayout,
-      @Nonnull OmBucketInfo omBucketInfo,
+      @CheckForNull OmBucketInfo omBucketInfo,
       RepeatedOmKeyInfo keyVersionsToDelete) {
     super(omResponse, bucketLayout);
     this.partsUnusedList = unUsedParts;
@@ -147,6 +148,7 @@ public class S3MultipartUploadCompleteResponse extends OmKeyResponse {
     return partsUnusedList;
   }
 
+  @CheckForNull
   public OmBucketInfo getOmBucketInfo() {
     return omBucketInfo;
   }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/s3/multipart/S3MultipartUploadCompleteResponseWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/s3/multipart/S3MultipartUploadCompleteResponseWithFSO.java
@@ -28,6 +28,7 @@ import org.apache.hadoop.ozone.om.request.file.OMFileRequest;
 import org.apache.hadoop.ozone.om.response.CleanupTableInfo;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMResponse;
 
+import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
 import java.io.IOException;
 import java.util.List;
@@ -51,6 +52,7 @@ public class S3MultipartUploadCompleteResponseWithFSO
         extends S3MultipartUploadCompleteResponse {
 
   private long volumeId;
+  private long bucketId;
 
   @SuppressWarnings("checkstyle:ParameterNumber")
   public S3MultipartUploadCompleteResponseWithFSO(
@@ -60,11 +62,13 @@ public class S3MultipartUploadCompleteResponseWithFSO
       @Nonnull OmKeyInfo omKeyInfo,
       @Nonnull List<OmKeyInfo> unUsedParts,
       @Nonnull BucketLayout bucketLayout,
-      @Nonnull OmBucketInfo omBucketInfo,
-      RepeatedOmKeyInfo keysToDelete, @Nonnull long volumeId) {
+      @CheckForNull OmBucketInfo omBucketInfo,
+      RepeatedOmKeyInfo keysToDelete,
+      @Nonnull long volumeId, @Nonnull long bucketId) {
     super(omResponse, multipartKey, multipartOpenKey, omKeyInfo, unUsedParts,
         bucketLayout, omBucketInfo, keysToDelete);
     this.volumeId = volumeId;
+    this.bucketId = bucketId;
   }
 
   /**
@@ -87,7 +91,7 @@ public class S3MultipartUploadCompleteResponseWithFSO
 
     OMFileRequest
         .addToFileTable(omMetadataManager, batchOperation, getOmKeyInfo(),
-            volumeId, getOmBucketInfo().getObjectID());
+            volumeId, bucketId);
 
     return ozoneKey;
 

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/s3/multipart/TestS3MultipartResponse.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/s3/multipart/TestS3MultipartResponse.java
@@ -321,7 +321,7 @@ public class TestS3MultipartResponse {
 
     return new S3MultipartUploadCompleteResponseWithFSO(omResponse,
         multipartKey, multipartOpenKey, omKeyInfo, unUsedParts,
-        getBucketLayout(), omBucketInfo, keysToDelete, volumeId);
+        getBucketLayout(), omBucketInfo, keysToDelete, volumeId, bucketId);
   }
 
   protected S3InitiateMultipartUploadResponse getS3InitiateMultipartUploadResp(


### PR DESCRIPTION
## What changes were proposed in this pull request?
When `keyToDelete.getDataSize()` returns zero and a request for FSO-enable bucket, a `CompleteMultipartUpload` request will crash with NullPointerException by attempting to read a bucketInfo that is assigned as null at this line [^1]. This patch proposes to prevent crash that changes not to read bucketInfo in the request handler.

```
2022-12-02 20:48:24,809 [OMDoubleBufferFlushThread] ERROR org.apache.hadoop.ozone.om.ratis.OzoneManagerDoubleBuffer: Terminating with exit status 2: OMDoubleBuffer flush thread OMDoubleBufferFlushThread encountered Throwable error
java.lang.NullPointerException: Cannot invoke "org.apache.hadoop.ozone.om.helpers.OmBucketInfo.getObjectID()" because the return value of "org.apache.hadoop.ozone.om.response.s3.multipart.S3MultipartUploadCompleteResponseWithFSO.getOmBucketInfo()" is null
        at org.apache.hadoop.ozone.om.response.s3.multipart.S3MultipartUploadCompleteResponseWithFSO.addToKeyTable(S3MultipartUploadCompleteResponseWithFSO.java:90)
        at org.apache.hadoop.ozone.om.response.s3.multipart.S3MultipartUploadCompleteResponse.addToDBBatch(S3MultipartUploadCompleteResponse.java:101)
        at org.apache.hadoop.ozone.om.response.OMClientResponse.checkAndUpdateDB(OMClientResponse.java:73)
        at org.apache.hadoop.ozone.om.ratis.OzoneManagerDoubleBuffer.lambda$2(OzoneManagerDoubleBuffer.java:283)
        at org.apache.hadoop.ozone.om.ratis.OzoneManagerDoubleBuffer.addToBatchWithTrace(OzoneManagerDoubleBuffer.java:228)
        at org.apache.hadoop.ozone.om.ratis.OzoneManagerDoubleBuffer.lambda$1(OzoneManagerDoubleBuffer.java:281)
        at java.base/java.util.Iterator.forEachRemaining(Iterator.java:133)
        at org.apache.hadoop.ozone.om.ratis.OzoneManagerDoubleBuffer.flushTransactions(OzoneManagerDoubleBuffer.java:277)
        at java.base/java.lang.Thread.run(Thread.java:833)
```

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-7596

## How was this patch tested?
- checked manually in our environment
- fix annotations to CheckForNull

[^1]: https://github.com/apache/ozone/blob/037492f839903c67709d44bd5a4ea9ca9ea093a9/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3MultipartUploadCompleteRequest.java#L247