### PR TITLE
HDDS-7399. Enable specifying external root ca

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/HddsConfigKeys.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/HddsConfigKeys.java
@@ -194,22 +194,22 @@ public final class HddsConfigKeys {
 
   public static final String HDDS_X509_RENEW_GRACE_DURATION_DEFAULT = "P28D";
 
-  public static final String HDDS_EXTERNAL_ROOT_CA_CERT_PATH =
+  public static final String HDDS_X509_ROOTCA_CERTIFICATE_FILE =
       "hdds.x509.rootca.certificate.file";
 
-  public static final String HDDS_EXTERNAL_ROOT_CA_CERT_PATH_DEFAULT =
+  public static final String HDDS_X509_ROOTCA_CERTIFICATE_FILE_DEFAULT =
       "";
 
-  public static final String HDDS_EXTERNAL_ROOT_CA_PUBLIC_KEY_PATH =
+  public static final String HDDS_X509_ROOTCA_PUBLIC_KEY_FILE =
       "hdds.x509.rootca.public.key.file";
 
-  public static final String HDDS_EXTERNAL_ROOT_CA_PUBLIC_KEY_PATH_DEFAULT =
+  public static final String HDDS_X509_ROOTCA_PUBLIC_KEY_FILE_DEFAULT =
       "";
 
-  public static final String HDDS_EXTERNAL_ROOT_CA_PRIVATE_KEY_PATH =
+  public static final String HDDS_X509_ROOTCA_PRIVATE_KEY_FILE =
       "hdds.x509.rootca.private.key.file";
 
-  public static final String HDDS_EXTERNAL_ROOT_CA_PRIVATE_KEY_PATH_DEFAULT =
+  public static final String HDDS_X509_ROOTCA_PRIVATE_KEY_FILE_DEFAULT =
       "";
 
   /**

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/HddsConfigKeys.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/HddsConfigKeys.java
@@ -195,19 +195,19 @@ public final class HddsConfigKeys {
   public static final String HDDS_X509_RENEW_GRACE_DURATION_DEFAULT = "P28D";
 
   public static final String HDDS_EXTERNAL_ROOT_CA_CERT_PATH =
-      "hdds.external.root.ca.cert";
+      "hdds.x509.rootca.certificate.file";
 
   public static final String HDDS_EXTERNAL_ROOT_CA_CERT_PATH_DEFAULT =
       "";
 
   public static final String HDDS_EXTERNAL_ROOT_CA_PUBLIC_KEY_PATH =
-      "hdds.external.root.ca.public.key";
+      "hdds.x509.rootca.public.key.file";
 
   public static final String HDDS_EXTERNAL_ROOT_CA_PUBLIC_KEY_PATH_DEFAULT =
       "";
 
   public static final String HDDS_EXTERNAL_ROOT_CA_PRIVATE_KEY_PATH =
-      "hdds.external.root.ca.private.key";
+      "hdds.x509.rootca.private.key.file";
 
   public static final String HDDS_EXTERNAL_ROOT_CA_PRIVATE_KEY_PATH_DEFAULT =
       "";

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/HddsConfigKeys.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/HddsConfigKeys.java
@@ -194,6 +194,24 @@ public final class HddsConfigKeys {
 
   public static final String HDDS_X509_RENEW_GRACE_DURATION_DEFAULT = "P28D";
 
+  public static final String HDDS_EXTERNAL_ROOT_CA_CERT_PATH =
+      "hdds.external.root.ca.cert";
+
+  public static final String HDDS_EXTERNAL_ROOT_CA_CERT_PATH_DEFAULT =
+      "";
+
+  public static final String HDDS_EXTERNAL_ROOT_CA_PUBLIC_KEY_PATH =
+      "hdds.external.root.ca.public.key";
+
+  public static final String HDDS_EXTERNAL_ROOT_CA_PUBLIC_KEY_PATH_DEFAULT =
+      "";
+
+  public static final String HDDS_EXTERNAL_ROOT_CA_PRIVATE_KEY_PATH =
+      "hdds.external.root.ca.private.key";
+
+  public static final String HDDS_EXTERNAL_ROOT_CA_PRIVATE_KEY_PATH_DEFAULT =
+      "";
+
   /**
    * Do not instantiate.
    */

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/security/x509/SecurityConfig.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/security/x509/SecurityConfig.java
@@ -190,9 +190,15 @@ public class SecurityConfig {
           "greater than maximum Certificate duration");
     }
 
-    this.externalRootCaCert = this.configuration.get(HDDS_EXTERNAL_ROOT_CA_CERT_PATH, HDDS_EXTERNAL_ROOT_CA_CERT_PATH_DEFAULT);
-    this.externalRootCaPublicKeyPath = this.configuration.get(HDDS_EXTERNAL_ROOT_CA_PUBLIC_KEY_PATH, HDDS_EXTERNAL_ROOT_CA_CERT_PATH_DEFAULT);
-    this.externalRootCaPrivateKeyPath = this.configuration.get(HDDS_EXTERNAL_ROOT_CA_PRIVATE_KEY_PATH, HDDS_EXTERNAL_ROOT_CA_PRIVATE_KEY_PATH_DEFAULT);
+    this.externalRootCaCert = this.configuration.get(
+        HDDS_EXTERNAL_ROOT_CA_CERT_PATH,
+        HDDS_EXTERNAL_ROOT_CA_CERT_PATH_DEFAULT);
+    this.externalRootCaPublicKeyPath = this.configuration.get(
+        HDDS_EXTERNAL_ROOT_CA_PUBLIC_KEY_PATH,
+        HDDS_EXTERNAL_ROOT_CA_CERT_PATH_DEFAULT);
+    this.externalRootCaPrivateKeyPath = this.configuration.get(
+        HDDS_EXTERNAL_ROOT_CA_PRIVATE_KEY_PATH,
+        HDDS_EXTERNAL_ROOT_CA_PRIVATE_KEY_PATH_DEFAULT);
 
     this.crlName = this.configuration.get(HDDS_X509_CRL_NAME,
         HDDS_X509_CRL_NAME_DEFAULT);

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/security/x509/SecurityConfig.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/security/x509/SecurityConfig.java
@@ -116,9 +116,9 @@ public class SecurityConfig {
   private boolean grpcTlsUseTestCert;
   private final long keystoreReloadInterval;
   private final long truststoreReloadInterval;
-  private String externalRootCaPublicKeyPath;
-  private String externalRootCaPrivateKeyPath;
-  private String externalRootCaCert;
+  private final String externalRootCaPublicKeyPath;
+  private final String externalRootCaPrivateKeyPath;
+  private final String externalRootCaCert;
 
   /**
    * Constructs a SecurityConfig.

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/security/x509/SecurityConfig.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/security/x509/SecurityConfig.java
@@ -43,6 +43,7 @@ import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_EXTERNAL_ROOT_CA_CERT_P
 import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_EXTERNAL_ROOT_CA_PRIVATE_KEY_PATH;
 import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_EXTERNAL_ROOT_CA_PRIVATE_KEY_PATH_DEFAULT;
 import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_EXTERNAL_ROOT_CA_PUBLIC_KEY_PATH;
+import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_EXTERNAL_ROOT_CA_PUBLIC_KEY_PATH_DEFAULT;
 import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_GRPC_TLS_ENABLED;
 import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_GRPC_TLS_ENABLED_DEFAULT;
 import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_GRPC_TLS_PROVIDER;
@@ -197,7 +198,7 @@ public class SecurityConfig {
         HDDS_EXTERNAL_ROOT_CA_CERT_PATH_DEFAULT);
     this.externalRootCaPublicKeyPath = this.configuration.get(
         HDDS_EXTERNAL_ROOT_CA_PUBLIC_KEY_PATH,
-        HDDS_EXTERNAL_ROOT_CA_CERT_PATH_DEFAULT);
+        HDDS_EXTERNAL_ROOT_CA_PUBLIC_KEY_PATH_DEFAULT);
     this.externalRootCaPrivateKeyPath = this.configuration.get(
         HDDS_EXTERNAL_ROOT_CA_PRIVATE_KEY_PATH,
         HDDS_EXTERNAL_ROOT_CA_PRIVATE_KEY_PATH_DEFAULT);

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/security/x509/SecurityConfig.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/security/x509/SecurityConfig.java
@@ -19,20 +19,17 @@
 
 package org.apache.hadoop.hdds.security.x509;
 
-import com.google.common.base.Preconditions;
-import org.apache.hadoop.hdds.conf.ConfigurationSource;
-import org.apache.hadoop.ozone.OzoneConfigKeys;
-import org.apache.ratis.thirdparty.io.netty.handler.ssl.SslProvider;
-import org.bouncycastle.jce.provider.BouncyCastleProvider;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.security.Provider;
 import java.security.Security;
 import java.time.Duration;
 import java.util.concurrent.TimeUnit;
+
+import org.apache.hadoop.hdds.conf.ConfigurationSource;
+import org.apache.hadoop.ozone.OzoneConfigKeys;
+
+import com.google.common.base.Preconditions;
 
 import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_BLOCK_TOKEN_ENABLED;
 import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_BLOCK_TOKEN_ENABLED_DEFAULT;
@@ -83,6 +80,11 @@ import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_SECURITY_SSL_TRUSTSTORE
 import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_SECURITY_SSL_TRUSTSTORE_RELOAD_INTERVAL_DEFAULT;
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_SECURITY_ENABLED_DEFAULT;
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_SECURITY_ENABLED_KEY;
+
+import org.apache.ratis.thirdparty.io.netty.handler.ssl.SslProvider;
+import org.bouncycastle.jce.provider.BouncyCastleProvider;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * A class that deals with all Security related configs in HDDS.

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/security/x509/SecurityConfig.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/security/x509/SecurityConfig.java
@@ -38,12 +38,12 @@ import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_CONTAINER_TOKEN_ENABLED
 import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_DEFAULT_KEY_ALGORITHM;
 import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_DEFAULT_KEY_LEN;
 import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_DEFAULT_SECURITY_PROVIDER;
-import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_EXTERNAL_ROOT_CA_CERT_PATH;
-import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_EXTERNAL_ROOT_CA_CERT_PATH_DEFAULT;
-import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_EXTERNAL_ROOT_CA_PRIVATE_KEY_PATH;
-import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_EXTERNAL_ROOT_CA_PRIVATE_KEY_PATH_DEFAULT;
-import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_EXTERNAL_ROOT_CA_PUBLIC_KEY_PATH;
-import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_EXTERNAL_ROOT_CA_PUBLIC_KEY_PATH_DEFAULT;
+import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_X509_ROOTCA_CERTIFICATE_FILE;
+import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_X509_ROOTCA_CERTIFICATE_FILE_DEFAULT;
+import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_X509_ROOTCA_PRIVATE_KEY_FILE;
+import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_X509_ROOTCA_PRIVATE_KEY_FILE_DEFAULT;
+import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_X509_ROOTCA_PUBLIC_KEY_FILE;
+import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_X509_ROOTCA_PUBLIC_KEY_FILE_DEFAULT;
 import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_GRPC_TLS_ENABLED;
 import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_GRPC_TLS_ENABLED_DEFAULT;
 import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_GRPC_TLS_PROVIDER;
@@ -194,14 +194,14 @@ public class SecurityConfig {
     }
 
     this.externalRootCaCert = this.configuration.get(
-        HDDS_EXTERNAL_ROOT_CA_CERT_PATH,
-        HDDS_EXTERNAL_ROOT_CA_CERT_PATH_DEFAULT);
+        HDDS_X509_ROOTCA_CERTIFICATE_FILE,
+        HDDS_X509_ROOTCA_CERTIFICATE_FILE_DEFAULT);
     this.externalRootCaPublicKeyPath = this.configuration.get(
-        HDDS_EXTERNAL_ROOT_CA_PUBLIC_KEY_PATH,
-        HDDS_EXTERNAL_ROOT_CA_PUBLIC_KEY_PATH_DEFAULT);
+        HDDS_X509_ROOTCA_PUBLIC_KEY_FILE,
+        HDDS_X509_ROOTCA_PUBLIC_KEY_FILE_DEFAULT);
     this.externalRootCaPrivateKeyPath = this.configuration.get(
-        HDDS_EXTERNAL_ROOT_CA_PRIVATE_KEY_PATH,
-        HDDS_EXTERNAL_ROOT_CA_PRIVATE_KEY_PATH_DEFAULT);
+        HDDS_X509_ROOTCA_PRIVATE_KEY_FILE,
+        HDDS_X509_ROOTCA_PRIVATE_KEY_FILE_DEFAULT);
 
     this.crlName = this.configuration.get(HDDS_X509_CRL_NAME,
         HDDS_X509_CRL_NAME_DEFAULT);

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/security/x509/SecurityConfig.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/security/x509/SecurityConfig.java
@@ -19,6 +19,14 @@
 
 package org.apache.hadoop.hdds.security.x509;
 
+import com.google.common.base.Preconditions;
+import org.apache.hadoop.hdds.conf.ConfigurationSource;
+import org.apache.hadoop.ozone.OzoneConfigKeys;
+import org.apache.ratis.thirdparty.io.netty.handler.ssl.SslProvider;
+import org.bouncycastle.jce.provider.BouncyCastleProvider;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.security.Provider;
@@ -26,10 +34,6 @@ import java.security.Security;
 import java.time.Duration;
 import java.util.concurrent.TimeUnit;
 
-import org.apache.hadoop.hdds.conf.ConfigurationSource;
-import org.apache.hadoop.ozone.OzoneConfigKeys;
-
-import com.google.common.base.Preconditions;
 import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_BLOCK_TOKEN_ENABLED;
 import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_BLOCK_TOKEN_ENABLED_DEFAULT;
 import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_CONTAINER_TOKEN_ENABLED;
@@ -37,6 +41,11 @@ import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_CONTAINER_TOKEN_ENABLED
 import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_DEFAULT_KEY_ALGORITHM;
 import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_DEFAULT_KEY_LEN;
 import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_DEFAULT_SECURITY_PROVIDER;
+import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_EXTERNAL_ROOT_CA_CERT_PATH;
+import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_EXTERNAL_ROOT_CA_CERT_PATH_DEFAULT;
+import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_EXTERNAL_ROOT_CA_PRIVATE_KEY_PATH;
+import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_EXTERNAL_ROOT_CA_PRIVATE_KEY_PATH_DEFAULT;
+import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_EXTERNAL_ROOT_CA_PUBLIC_KEY_PATH;
 import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_GRPC_TLS_ENABLED;
 import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_GRPC_TLS_ENABLED_DEFAULT;
 import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_GRPC_TLS_PROVIDER;
@@ -74,10 +83,6 @@ import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_SECURITY_SSL_TRUSTSTORE
 import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_SECURITY_SSL_TRUSTSTORE_RELOAD_INTERVAL_DEFAULT;
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_SECURITY_ENABLED_DEFAULT;
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_SECURITY_ENABLED_KEY;
-import org.apache.ratis.thirdparty.io.netty.handler.ssl.SslProvider;
-import org.bouncycastle.jce.provider.BouncyCastleProvider;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * A class that deals with all Security related configs in HDDS.
@@ -111,6 +116,9 @@ public class SecurityConfig {
   private boolean grpcTlsUseTestCert;
   private final long keystoreReloadInterval;
   private final long truststoreReloadInterval;
+  private String externalRootCaPublicKeyPath;
+  private String externalRootCaPrivateKeyPath;
+  private String externalRootCaCert;
 
   /**
    * Constructs a SecurityConfig.
@@ -182,8 +190,12 @@ public class SecurityConfig {
           "greater than maximum Certificate duration");
     }
 
+    this.externalRootCaCert = this.configuration.get(HDDS_EXTERNAL_ROOT_CA_CERT_PATH, HDDS_EXTERNAL_ROOT_CA_CERT_PATH_DEFAULT);
+    this.externalRootCaPublicKeyPath = this.configuration.get(HDDS_EXTERNAL_ROOT_CA_PUBLIC_KEY_PATH, HDDS_EXTERNAL_ROOT_CA_CERT_PATH_DEFAULT);
+    this.externalRootCaPrivateKeyPath = this.configuration.get(HDDS_EXTERNAL_ROOT_CA_PRIVATE_KEY_PATH, HDDS_EXTERNAL_ROOT_CA_PRIVATE_KEY_PATH_DEFAULT);
+
     this.crlName = this.configuration.get(HDDS_X509_CRL_NAME,
-                                          HDDS_X509_CRL_NAME_DEFAULT);
+        HDDS_X509_CRL_NAME_DEFAULT);
 
     // First Startup -- if the provider is null, check for the provider.
     if (SecurityConfig.provider == null) {
@@ -397,6 +409,18 @@ public class SecurityConfig {
   public SslProvider getGrpcSslProvider() {
     return SslProvider.valueOf(configuration.get(HDDS_GRPC_TLS_PROVIDER,
         HDDS_GRPC_TLS_PROVIDER_DEFAULT));
+  }
+
+  public String getExternalRootCaPrivateKeyPath() {
+    return externalRootCaPrivateKeyPath;
+  }
+
+  public String getExternalRootCaPublicKeyPath() {
+    return externalRootCaPublicKeyPath;
+  }
+
+  public String getExternalRootCaCert() {
+    return externalRootCaCert;
   }
 
   /**

--- a/hadoop-hdds/common/src/main/resources/ozone-default.xml
+++ b/hadoop-hdds/common/src/main/resources/ozone-default.xml
@@ -2087,13 +2087,40 @@
     <description>Max time for which certificate issued by SCM CA are valid.
       This duration is used for self-signed root cert and scm sub-ca certs
       issued by root ca. The formats accepted are based on the ISO-8601
-      duration format PnDTnHnMn.nS</description>
+      duration format PnDTnHnMn.nS
+    </description>
   </property>
   <property>
     <name>hdds.x509.signature.algorithm</name>
     <value>SHA256withRSA</value>
     <tag>OZONE, HDDS, SECURITY</tag>
     <description>X509 signature certificate.</description>
+  </property>
+  <property>
+    <name>hdds.external.root.ca.cert</name>
+    <value></value>
+    <description>Path to an external CA certificate. This certificate is
+      used when initializing SCM to create a root certificate authority.
+      By default, a self-signed certificate is generated instead.
+    </description>
+  </property>
+  <property>
+    <name>hdds.external.root.ca.private.key</name>
+    <value></value>
+    <description>Path to an external private key. This private key is later used
+      when initializing SCM to sign certificates as the root certificate
+      authority. When not specified a private and public key is generated
+      instead.
+    </description>
+  </property>
+  <property>
+    <name>hdds.external.root.ca.public.key</name>
+    <value></value>
+    <description>Path to an external public key. This public key is later used
+      when initializing SCM to sign certificates as the root certificate
+      authority. When only the private key is specified
+      the public key is read from the external certificate.
+    </description>
   </property>
   <property>
     <name>ozone.scm.security.handler.count.key</name>

--- a/hadoop-hdds/common/src/main/resources/ozone-default.xml
+++ b/hadoop-hdds/common/src/main/resources/ozone-default.xml
@@ -2122,13 +2122,13 @@
   <property>
     <name>hdds.x509.rootca.public.key.file</name>
     <value></value>
-    <description>Path to an external public key. This public key is later used
-      when initializing SCM to sign certificates as the root certificate
-      authority. When only the private key is specified
-      the public key is read from the external certificate.
-      Note that this is only used for Ozone's internal communication, and it
-      does not affect the HTTPS protocol at WebUIs as they can be configured
-      separately.
+    <description>Path to an external public key. The file format is expected
+      to be pem. This public key is later used when initializing SCM to sign
+      certificates as the root certificate authority.
+      When only the private key is specified the public key is read from the
+      external certificate. Note that this is only used for Ozone's internal
+      communication, and it does not affect the HTTPS protocol at WebUIs as
+      they can be configured separately.
     </description>
   </property>
   <property>

--- a/hadoop-hdds/common/src/main/resources/ozone-default.xml
+++ b/hadoop-hdds/common/src/main/resources/ozone-default.xml
@@ -2097,29 +2097,38 @@
     <description>X509 signature certificate.</description>
   </property>
   <property>
-    <name>hdds.external.root.ca.cert</name>
+    <name>hdds.x509.rootca.certificate.file</name>
     <value></value>
-    <description>Path to an external CA certificate. This certificate is
-      used when initializing SCM to create a root certificate authority.
-      By default, a self-signed certificate is generated instead.
+    <description>Path to an external CA certificate. The file format is expected
+      to be pem. This certificate is used when initializing SCM to create
+      a root certificate authority. By default, a self-signed certificate is
+      generated instead. Note that this certificate is only used for Ozone's
+      internal communication, and it does not affect the certificates used for
+      HTTPS protocol at WebUIs as they can be configured separately.
     </description>
   </property>
   <property>
-    <name>hdds.external.root.ca.private.key</name>
+    <name>hdds.x509.rootca.private.key.file</name>
     <value></value>
-    <description>Path to an external private key. This private key is later used
-      when initializing SCM to sign certificates as the root certificate
-      authority. When not specified a private and public key is generated
-      instead.
+    <description>Path to an external private key. The file format is expected
+      to be pem. This private key is later used when initializing SCM to sign
+      certificates as the root certificate authority. When not specified a
+      private and public key is generated instead.
+      These keys are only used for Ozone's internal communication, and it does
+      not affect the HTTPS protocol at WebUIs as they can be configured
+      separately.
     </description>
   </property>
   <property>
-    <name>hdds.external.root.ca.public.key</name>
+    <name>hdds.x509.rootca.public.key.file</name>
     <value></value>
     <description>Path to an external public key. This public key is later used
       when initializing SCM to sign certificates as the root certificate
       authority. When only the private key is specified
       the public key is read from the external certificate.
+      Note that this is only used for Ozone's internal communication, and it
+      does not affect the HTTPS protocol at WebUIs as they can be configured
+      separately.
     </description>
   </property>
   <property>

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/security/x509/certificate/authority/DefaultCAServer.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/security/x509/certificate/authority/DefaultCAServer.java
@@ -493,9 +493,9 @@ public class DefaultCAServer implements CertificateServer {
         };
       }
       break;
-      default:
-        /* Make CheckStyle happy */
-        break;
+    default:
+      /* Make CheckStyle happy */
+      break;
     }
     return consumer;
   }

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/security/x509/certificate/authority/DefaultCAServer.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/security/x509/certificate/authority/DefaultCAServer.java
@@ -596,11 +596,22 @@ public class DefaultCAServer implements CertificateServer {
     CertificateCodec certificateCodec =
         new CertificateCodec(config, componentName);
     try {
+      Path extCertParent = extCertPath.getParent();
+      Path extCertName = extCertPath.getFileName();
+      if (extCertParent == null || extCertName == null) {
+        throw new IOException("External cert path is not correct: " +
+            extCertPath);
+      }
       X509CertificateHolder certHolder = certificateCodec.readCertificate(
-          extCertPath.getParent(), extCertPath.getFileName().toString());
-      PrivateKey privateKey = keyCodec.readPrivateKey(
-          extPrivateKeyPath.getParent(),
-          extPrivateKeyPath.getFileName().toString());
+          extCertParent, extCertName.toString());
+      Path extPrivateKeyParent = extPrivateKeyPath.getParent();
+      Path extPrivateKeyFileName = extPrivateKeyPath.getFileName();
+      if (extPrivateKeyParent == null || extPrivateKeyFileName == null) {
+        throw new IOException("External private key path is not correct: " +
+            extPrivateKeyPath);
+      }
+      PrivateKey privateKey = keyCodec.readPrivateKey(extPrivateKeyParent,
+          extPrivateKeyFileName.toString());
       PublicKey publicKey;
       publicKey = readPublicKeyWithExternalData(
           externalPublicKeyLocation, keyCodec, certHolder);
@@ -623,8 +634,13 @@ public class DefaultCAServer implements CertificateServer {
           .getPublicKey();
     } else {
       Path publicKeyPath = Paths.get(externalPublicKeyLocation);
+      Path publicKeyPathFileName = publicKeyPath.getFileName();
+      Path publicKeyParent = publicKeyPath.getParent();
+      if (publicKeyPathFileName == null || publicKeyParent == null) {
+        throw new IOException("Public key path incorrect: " + publicKeyParent);
+      }
       publicKey = keyCodec.readPublicKey(
-          publicKeyPath.getParent(), publicKeyPath.getFileName().toString());
+          publicKeyParent, publicKeyPathFileName.toString());
     }
     return publicKey;
   }

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/security/x509/certificate/authority/DefaultCAServer.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/security/x509/certificate/authority/DefaultCAServer.java
@@ -67,8 +67,8 @@ import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.Consumer;
 
-import static org.apache.hadoop.hdds.security.exception.SCMSecurityException.ErrorCode.UNABLE_TO_ISSUE_CERTIFICATE;
 import static org.apache.hadoop.hdds.security.x509.certificates.utils.CertificateSignRequest.getCertificationRequest;
+import static org.apache.hadoop.hdds.security.exception.SCMSecurityException.ErrorCode.UNABLE_TO_ISSUE_CERTIFICATE;
 import static org.apache.hadoop.hdds.security.x509.exceptions.CertificateException.ErrorCode.CSR_ERROR;
 
 /**
@@ -455,11 +455,9 @@ public class DefaultCAServer implements CertificateServer {
       break;
     case MISSING_KEYS:
       consumer = (arg) -> {
-        LOG.error("We have found the Certificate for this " +
-            "CertificateServer, " +
+        LOG.error("We have found the Certificate for this CertificateServer, " +
             "but keys used by this CertificateServer is missing. This is a " +
-            "non-recoverable error. Please restart the system after " +
-            "locating " +
+            "non-recoverable error. Please restart the system after locating " +
             "the Keys used by the CertificateServer.");
         LOG.error("Exiting due to unrecoverable CertificateServer error.");
         throw new IllegalStateException("Missing Keys, cannot continue.");
@@ -468,13 +466,11 @@ public class DefaultCAServer implements CertificateServer {
     case MISSING_CERTIFICATE:
       consumer = (arg) -> {
         LOG.error("We found the keys, but the root certificate for this " +
-            "CertificateServer is missing. Please restart SCM after " +
-            "locating " +
+            "CertificateServer is missing. Please restart SCM after locating " +
             "the " +
             "Certificates.");
         LOG.error("Exiting due to unrecoverable CertificateServer error.");
-        throw new IllegalStateException("Missing Root Certs, cannot " +
-            "continue.");
+        throw new IllegalStateException("Missing Root Certs, cannot continue.");
       };
       break;
     case INITIALIZE:
@@ -485,8 +481,7 @@ public class DefaultCAServer implements CertificateServer {
         // both keys/certs are missing, init/bootstrap is missed to be
         // performed.
         consumer = (arg) -> {
-          LOG.error("Sub SCM CA Server is missing keys/certs. SCM is " +
-              "started " +
+          LOG.error("Sub SCM CA Server is missing keys/certs. SCM is started " +
               "with out init/bootstrap");
           throw new IllegalStateException("INTERMEDIARY_CA Should not be" +
               " in Initialize State during startup.");

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/security/x509/certificate/authority/DefaultCAServer.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/security/x509/certificate/authority/DefaultCAServer.java
@@ -493,9 +493,9 @@ public class DefaultCAServer implements CertificateServer {
         };
       }
       break;
-    default:
-      /* Make CheckStyle happy */
-      break;
+      default:
+        /* Make CheckStyle happy */
+        break;
     }
     return consumer;
   }

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/security/x509/keys/KeyCodec.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/security/x509/keys/KeyCodec.java
@@ -323,9 +323,9 @@ public class KeyCodec {
     checkPreconditions(basePath);
 
     File privateKeyFile =
-        Paths.get(location.toString(), privateKeyFileName).toFile();
+        Paths.get(basePath.toString(), privateKeyFileName).toFile();
     File publicKeyFile =
-        Paths.get(location.toString(), publicKeyFileName).toFile();
+        Paths.get(basePath.toString(), publicKeyFileName).toFile();
     checkKeyFile(privateKeyFile, force, publicKeyFile);
 
     try (PemWriter privateKeyWriter = new PemWriter(new

--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/security/x509/certificate/authority/TestDefaultCAServer.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/security/x509/certificate/authority/TestDefaultCAServer.java
@@ -391,11 +391,11 @@ public class TestDefaultCAServer {
     String publicKeyPath = Paths.get(tempDir.toString(),
         HddsConfigKeys.HDDS_PUBLIC_KEY_FILE_NAME_DEFAULT).toString();
 
-    conf.set(HddsConfigKeys.HDDS_EXTERNAL_ROOT_CA_CERT_PATH,
+    conf.set(HddsConfigKeys.HDDS_X509_ROOTCA_CERTIFICATE_FILE,
         externalCaCertPart);
-    conf.set(HddsConfigKeys.HDDS_EXTERNAL_ROOT_CA_PRIVATE_KEY_PATH,
+    conf.set(HddsConfigKeys.HDDS_X509_ROOTCA_PRIVATE_KEY_FILE,
         privateKeyPath);
-    conf.set(HddsConfigKeys.HDDS_EXTERNAL_ROOT_CA_PUBLIC_KEY_PATH,
+    conf.set(HddsConfigKeys.HDDS_X509_ROOTCA_PUBLIC_KEY_FILE,
         publicKeyPath);
   }
 

--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/security/x509/certificate/authority/TestDefaultCAServer.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/security/x509/certificate/authority/TestDefaultCAServer.java
@@ -36,6 +36,7 @@ import org.apache.hadoop.hdds.security.x509.keys.KeyCodec;
 import org.apache.hadoop.ozone.OzoneSecurityUtil;
 import org.apache.hadoop.security.ssl.KeyStoreTestUtil;
 import org.apache.ozone.test.LambdaTestUtils;
+
 import org.bouncycastle.asn1.x509.CRLReason;
 import org.bouncycastle.cert.X509CertificateHolder;
 import org.bouncycastle.cert.jcajce.JcaX509CertificateConverter;

--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/security/x509/certificate/authority/TestDefaultCAServer.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/security/x509/certificate/authority/TestDefaultCAServer.java
@@ -20,6 +20,7 @@
 package org.apache.hadoop.hdds.security.x509.certificate.authority;
 
 import org.apache.commons.lang3.RandomStringUtils;
+import org.apache.commons.validator.routines.DomainValidator;
 import org.apache.hadoop.hdds.HddsConfigKeys;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.security.exception.SCMSecurityException;
@@ -29,9 +30,11 @@ import org.apache.hadoop.hdds.security.x509.certificate.client.CertificateClient
 import org.apache.hadoop.hdds.security.x509.certificate.client.SCMCertificateClient;
 import org.apache.hadoop.hdds.security.x509.certificate.utils.CertificateCodec;
 import org.apache.hadoop.hdds.security.x509.certificates.utils.CertificateSignRequest;
+import org.apache.hadoop.hdds.security.x509.certificates.utils.SelfSignedCertificate;
 import org.apache.hadoop.hdds.security.x509.keys.HDDSKeyGenerator;
+import org.apache.hadoop.hdds.security.x509.keys.KeyCodec;
+import org.apache.hadoop.ozone.OzoneSecurityUtil;
 import org.apache.ozone.test.LambdaTestUtils;
-
 import org.bouncycastle.asn1.x509.CRLReason;
 import org.bouncycastle.cert.X509CertificateHolder;
 import org.bouncycastle.cert.jcajce.JcaX509CertificateConverter;
@@ -50,12 +53,14 @@ import java.security.NoSuchProviderException;
 import java.security.cert.CertificateException;
 import java.security.cert.X509Certificate;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Date;
 import java.util.List;
 import java.util.Optional;
+import java.util.UUID;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import java.util.function.Consumer;
@@ -65,6 +70,7 @@ import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.NodeType.OM;
 import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.NodeType.SCM;
 import static org.apache.hadoop.hdds.security.x509.certificate.authority.CertificateServer.CAType.INTERMEDIARY_CA;
 import static org.apache.hadoop.hdds.security.x509.certificate.authority.CertificateServer.CAType.SELF_SIGNED_CA;
+import static org.apache.hadoop.hdds.security.x509.exceptions.CertificateException.ErrorCode.CSR_ERROR;
 import static org.apache.hadoop.ozone.OzoneConsts.SCM_CA_CERT_STORAGE_DIR;
 import static org.apache.hadoop.ozone.OzoneConsts.SCM_CA_PATH;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -340,6 +346,27 @@ public class TestDefaultCAServer {
   }
 
   @Test
+  public void testExternalRootCA(@TempDir Path tempDir) throws Exception {
+    String externalCaCert = "CaCert.pem";
+    SecurityConfig securityConfig = new SecurityConfig(conf);
+    SCMCertificateClient scmCertificateClient =
+        new SCMCertificateClient(new SecurityConfig(conf));
+    KeyPair keyPair = new HDDSKeyGenerator(conf).generateKey();
+    KeyCodec keyPEMWriter = new KeyCodec(securityConfig,
+        scmCertificateClient.getComponentName());
+    keyPEMWriter.writeKey(tempDir, keyPair, true);
+    X509CertificateHolder certificateHolder = generateExternalCert(securityConfig);
+
+    CertificateCodec certificateCodec = new CertificateCodec(securityConfig,
+        scmCertificateClient.getComponentName());
+
+    certificateCodec.writeCertificate(tempDir, externalCaCert,
+        CertificateCodec.getPEMEncodedString(certificateHolder), true);
+    
+    conf.set(HddsConfigKeys.HDDS_EXTERNAL_ROOT_CA_CERT_PATH, tempDir.toString());
+  }
+
+  @Test
   public void testIntermediaryCA() throws Exception {
 
     conf.set(HddsConfigKeys.HDDS_X509_MAX_DURATION, "P3650D");
@@ -412,6 +439,47 @@ public class TestDefaultCAServer {
       fail("testIntermediaryCA failed during init");
     }
 
+  }
+
+  private X509CertificateHolder generateExternalCert(SecurityConfig securityConfig) throws Exception {
+    LocalDateTime notBefore = LocalDateTime.now();
+    LocalDateTime notAfter = notBefore.plusYears(1);
+    String clusterID = UUID.randomUUID().toString();
+    String scmID = UUID.randomUUID().toString();
+    String subject = "testRootCert";
+    HDDSKeyGenerator keyGen =
+        new HDDSKeyGenerator(securityConfig.getConfiguration());
+    KeyPair keyPair = keyGen.generateKey();
+
+    SelfSignedCertificate.Builder builder =
+        SelfSignedCertificate.newBuilder()
+            .setBeginDate(notBefore)
+            .setEndDate(notAfter)
+            .setClusterID(clusterID)
+            .setScmID(scmID)
+            .setSubject(subject)
+            .setKey(keyPair)
+            .setConfiguration(conf)
+            .makeCA();
+
+    try {
+      DomainValidator validator = DomainValidator.getInstance();
+      // Add all valid ips.
+      OzoneSecurityUtil.getValidInetsForCurrentHost().forEach(
+          ip -> {
+            builder.addIpAddress(ip.getHostAddress());
+            if (validator.isValid(ip.getCanonicalHostName())) {
+              builder.addDnsName(ip.getCanonicalHostName());
+            }
+          });
+    } catch (IOException e) {
+      throw new org.apache.hadoop.hdds.security.x509
+          .exceptions.CertificateException(
+          "Error while adding ip to CA self signed certificate", e,
+          CSR_ERROR);
+    }
+
+    return builder.build();
   }
 
 }

--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/security/x509/certificate/authority/TestDefaultCAServer.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/security/x509/certificate/authority/TestDefaultCAServer.java
@@ -85,11 +85,12 @@ import static org.junit.jupiter.api.Assertions.fail;
  * Tests the Default CA Server.
  */
 public class TestDefaultCAServer {
-  private static OzoneConfiguration conf = new OzoneConfiguration();
+  private OzoneConfiguration conf;
   private MockCAStore caStore;
 
   @BeforeEach
   public void init(@TempDir Path tempDir) throws IOException {
+    conf = new OzoneConfiguration();
     conf.set(OZONE_METADATA_DIRS, tempDir.toString());
     caStore = new MockCAStore();
   }


### PR DESCRIPTION
## What changes were proposed in this pull request?

During SCM startup an external root CA can now be specified to use instead of generating a self signed CA.

## What is the link to the Apache JIRA

[HDDS-7399](https://issues.apache.org/jira/browse/HDDS-7399)

## How was this patch tested?

Added unit test.