### PR TITLE
HDDS-7597. Improve ambiguous messages

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/StorageContainerManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/StorageContainerManager.java
@@ -1769,7 +1769,7 @@ public final class StorageContainerManager extends ServiceRuntimeInfoImpl
     if (remoteUser != null && !scmAdmins.isAdmin(remoteUser)) {
       throw new AccessControlException(
           "Access denied for user " + remoteUser.getUserName() +
-              ". Superuser privilege is required.");
+              ". SCM superuser privilege is required.");
     }
   }
 

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/TestStorageContainerManager.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/TestStorageContainerManager.java
@@ -261,7 +261,7 @@ public class TestStorageContainerManager {
 
   private void verifyPermissionDeniedException(Exception e, String userName) {
     String expectedErrorMessage = "Access denied for user "
-        + userName + ". " + "Superuser privilege is required.";
+        + userName + ". " + "SCM superuser privilege is required.";
     Assert.assertTrue(e instanceof IOException);
     Assert.assertEquals(expectedErrorMessage, e.getMessage());
   }


### PR DESCRIPTION
## What changes were proposed in this pull request?
Change error message when user does not have SCM superuser priviledge.

## What is the link to the Apache JIRA
[HDDS-7597](https://issues.apache.org/jira/browse/HDDS-7597)

## How was this patch tested?
Manual test.

## How to recreate behavior described in ticket?
1. `mvn clean install -DskipTests -DskipShade`
2. `cd hadoop-ozone/dist/target/ozone-*/compose/ozonesecure`
3. `docker-compose up -d --scale datanode=3 `
4. `docker exec -it ozonesecure_om_1 /bin/bash`
 a. `kinit -k testuser/om@EXAMPLE.COM -t /etc/security/keytabs/testuser.keytab` 
 b. `ozone admin container report`