### PR TITLE
HDDS-7371. Create properties for all dependency versions

### DIFF
--- a/hadoop-hdds/common/pom.xml
+++ b/hadoop-hdds/common/pom.xml
@@ -212,7 +212,6 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <dependency>
       <groupId>org.reflections</groupId>
       <artifactId>reflections</artifactId>
-      <version>0.9.11</version>
     </dependency>
     <dependency>
       <groupId>org.mockito</groupId>
@@ -235,7 +234,6 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <dependency>
       <groupId>com.codahale.metrics</groupId>
       <artifactId>metrics-core</artifactId>
-      <version>3.0.2</version>
       <scope>test</scope>
       <!-- Needed for mocking RaftServerImpl -->
     </dependency>

--- a/hadoop-hdds/test-utils/pom.xml
+++ b/hadoop-hdds/test-utils/pom.xml
@@ -74,7 +74,6 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <dependency>
       <groupId>org.jacoco</groupId>
       <artifactId>org.jacoco.core</artifactId>
-      <version>0.8.5</version>
       <scope>provided</scope>
     </dependency>
     <dependency>

--- a/hadoop-ozone/dev-support/checks/coverage.sh
+++ b/hadoop-ozone/dev-support/checks/coverage.sh
@@ -26,13 +26,15 @@ REPORT_DIR="$DIR/../../../target/coverage"
 
 mkdir -p "$REPORT_DIR"
 
+JACOCO_VERSION=$(mvn help:evaluate -Dexpression=jacoco.version -q -DforceStdout)
+
 #Install jacoco cli
 mvn --non-recursive --no-transfer-progress \
   org.apache.maven.plugins:maven-dependency-plugin:3.1.2:copy \
-  -Dartifact=org.jacoco:org.jacoco.cli:0.8.5:jar:nodeps
+  -Dartifact=org.jacoco:org.jacoco.cli:${JACOCO_VERSION}:jar:nodeps
 
 jacoco() {
-  java -jar target/dependency/org.jacoco.cli-0.8.5-nodeps.jar "$@"
+  java -jar target/dependency/org.jacoco.cli-${JACOCO_VERSION}-nodeps.jar "$@"
 }
 
 #Merge all the jacoco.exec files

--- a/hadoop-ozone/dist/pom.xml
+++ b/hadoop-ozone/dist/pom.xml
@@ -271,7 +271,6 @@
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-dependency-plugin</artifactId>
-            <version>3.1.1</version>
             <executions>
               <execution>
                 <id>copy-jacoco-files</id>
@@ -287,21 +286,21 @@
                     <artifactItem>
                       <groupId>org.jacoco</groupId>
                       <artifactId>org.jacoco.agent</artifactId>
-                      <version>0.8.5</version>
+                      <version>${jacoco.version}</version>
                       <classifier>runtime</classifier>
                       <destFileName>jacoco-agent.jar</destFileName>
                     </artifactItem>
                     <artifactItem>
                       <groupId>org.jacoco</groupId>
                       <artifactId>org.jacoco.cli</artifactId>
-                      <version>0.8.5</version>
+                      <version>${jacoco.version}</version>
                       <classifier>nodeps</classifier>
                       <destFileName>jacoco-cli.jar</destFileName>
                     </artifactItem>
                     <artifactItem>
                       <groupId>org.jacoco</groupId>
                       <artifactId>org.jacoco.core</artifactId>
-                      <version>0.8.5</version>
+                      <version>${jacoco.version}</version>
                       <destFileName>jacoco-core.jar</destFileName>
                     </artifactItem>
                     <artifactItem>

--- a/hadoop-ozone/ozone-manager/pom.xml
+++ b/hadoop-ozone/ozone-manager/pom.xml
@@ -146,7 +146,6 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <dependency>
       <groupId>org.reflections</groupId>
       <artifactId>reflections</artifactId>
-      <version>0.9.11</version>
     </dependency>
 
     <dependency>

--- a/hadoop-ozone/ozonefs-common/pom.xml
+++ b/hadoop-ozone/ozonefs-common/pom.xml
@@ -92,7 +92,6 @@
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-all</artifactId>
-      <version>1.10.19</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -103,13 +102,12 @@
     <dependency>
       <groupId>org.powermock</groupId>
       <artifactId>powermock-module-junit4</artifactId>
-      <version>1.6.5</version>
+      <version>${powermock1.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.powermock</groupId>
       <artifactId>powermock-api-mockito</artifactId>
-      <version>1.6.5</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/hadoop-ozone/ozonefs-hadoop2/pom.xml
+++ b/hadoop-ozone/ozonefs-hadoop2/pom.xml
@@ -53,19 +53,19 @@
       <groupId>org.apache.hadoop</groupId>
       <artifactId>hadoop-common</artifactId>
       <scope>provided</scope>
-      <version>2.7.3</version>
+      <version>${hadoop2.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.hadoop</groupId>
       <artifactId>hadoop-annotations</artifactId>
       <scope>provided</scope>
-      <version>2.7.3</version>
+      <version>${hadoop2.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.hadoop</groupId>
       <artifactId>hadoop-auth</artifactId>
       <scope>provided</scope>
-      <version>2.7.3</version>
+      <version>${hadoop2.version}</version>
     </dependency>
     <dependency>
       <groupId>ch.qos.reload4j</groupId>

--- a/hadoop-ozone/recon-codegen/pom.xml
+++ b/hadoop-ozone/recon-codegen/pom.xml
@@ -35,7 +35,6 @@
     <dependency>
       <groupId>org.apache.derby</groupId>
       <artifactId>derby</artifactId>
-      <version>10.14.2.0</version>
     </dependency>
     <dependency>
       <groupId>com.google.inject.extensions</groupId>

--- a/hadoop-ozone/recon/pom.xml
+++ b/hadoop-ozone/recon/pom.xml
@@ -330,7 +330,6 @@
     <dependency>
       <groupId>org.apache.derby</groupId>
       <artifactId>derby</artifactId>
-      <version>10.14.2.0</version>
     </dependency>
     <dependency>
       <groupId>org.xerial</groupId>
@@ -353,7 +352,6 @@
     <dependency>
       <groupId>org.javassist</groupId>
       <artifactId>javassist</artifactId>
-      <version>3.21.0-GA</version>
     </dependency>
   </dependencies>
 </project>

--- a/hadoop-ozone/s3gateway/pom.xml
+++ b/hadoop-ozone/s3gateway/pom.xml
@@ -39,7 +39,6 @@
     <dependency>
       <groupId>org.javassist</groupId>
       <artifactId>javassist</artifactId>
-      <version>3.21.0-GA</version>
     </dependency>
     <dependency>
       <groupId>org.apache.ozone</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -62,6 +62,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
   </organization>
 
   <properties>
+    <hadoop2.version>2.7.3</hadoop2.version>
     <hadoop.version>3.3.4</hadoop.version>
 
     <!-- version for hdds/ozone components -->
@@ -128,7 +129,26 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
 
     <java.security.egd>file:///dev/urandom</java.security.egd>
 
+    <annotation-api.version>1.2</annotation-api.version>
+    <assertj.version>3.12.2</assertj.version>
+    <asm.version>5.0.4</asm.version>
+    <bonecp.version>0.8.0.RELEASE</bonecp.version>
     <bouncycastle.version>1.67</bouncycastle.version>
+    <cglib.version>3.2.0</cglib.version>
+    <derby.version>10.14.2.0</derby.version>
+    <codahale-metrics.version>3.0.2</codahale-metrics.version>
+    <dropwizard-metrics.version>3.2.4</dropwizard-metrics.version>
+    <jacoco.version>0.8.5</jacoco.version>
+    <javassist.version>3.21.0-GA</javassist.version>
+    <javax-activation.version>1.1.1</javax-activation.version>
+    <jaxb-api.version>2.3.0</jaxb-api.version>
+    <jaxb-runtime.version>2.3.0.1</jaxb-runtime.version>
+    <jsch.version>0.1.54</jsch.version>
+    <cdi-api.version>1.2</cdi-api.version>
+    <servlet-api.version>3.1.0</servlet-api.version>
+    <glassfish-servlet.version>3.1</glassfish-servlet.version>
+    <jsp-api.version>2.1</jsp-api.version>
+    <jsr311-api.version>1.1.1</jsr311-api.version>
 
     <!-- jersey version -->
     <jersey.version>1.19</jersey.version>
@@ -136,6 +156,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
 
     <!-- jackson versions -->
     <jackson2-bom.version>2.13.4.20221013</jackson2-bom.version>
+    <woodstox.version>5.4.0</woodstox.version>
 
     <!-- jaegertracing veresion -->
     <jaeger.version>1.6.0</jaeger.version>
@@ -153,7 +174,12 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
     <disruptor.version>3.4.2</disruptor.version>
     <reload4j.version>1.2.22</reload4j.version>
 
+    <kerby.version>1.0.1</kerby.version>
+    <kotlin.version>1.6.21</kotlin.version>
+    <metainf-services.version>1.8</metainf-services.version>
+    <picocli.version>4.6.1</picocli.version>
     <prometheus.version>0.7.0</prometheus.version>
+    <reflections.version>0.9.11</reflections.version>
 
     <!-- com.google.re2j version -->
     <re2j.version>1.1</re2j.version>
@@ -168,16 +194,21 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
     <spotbugs.version>3.1.12</spotbugs.version>
     <dnsjava.version>2.1.7</dnsjava.version>
 
+    <compile-testing.version>0.19</compile-testing.version>
+    <errorprone-annotations.version>2.2.0</errorprone-annotations.version>
     <guava.version>31.1-jre</guava.version>
     <guice.version>4.0</guice.version>
     <gson.version>2.9.0</gson.version>
 
+    <objenesis.version>1.0</objenesis.version>
     <okhttp.version>2.7.5</okhttp.version>
     <mockito1-powermock.version>1.10.19</mockito1-powermock.version>
     <mockito2.version>2.28.2</mockito2.version>
     <hamcrest.version>1.3</hamcrest.version>
     <powermock1.version>1.6.5</powermock1.version>
     <powermock2.version>2.0.4</powermock2.version>
+    <jmockit.version>1.24</jmockit.version>
+    <junit4.version>4.13.1</junit4.version>
     <junit.jupiter.version>5.8.2</junit.jupiter.version>
     <junit.platform.version>1.8.2</junit.platform.version>
 
@@ -190,6 +221,10 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
     <!-- https://github.com/grpc/grpc-java/blob/master/SECURITY.md#netty -->
     <netty.version>4.1.77.Final</netty.version>
     <io.grpc.version>1.48.1</io.grpc.version>
+
+    <rocksdb.version>7.7.3</rocksdb.version>
+    <sqlite.version>3.25.2</sqlite.version>
+    <weld-servlet.version>2.4.7.Final</weld-servlet.version>
 
     <!-- define the Java language version used by the compiler -->
     <javac.version>1.8</javac.version>
@@ -224,8 +259,10 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
     <apache-rat-plugin.version>0.12</apache-rat-plugin.version>
     <maven-deploy-plugin.version>2.8.1</maven-deploy-plugin.version>
     <build-helper-maven-plugin.version>1.9</build-helper-maven-plugin.version>
-    <maven-dependency-plugin.version>3.0.2</maven-dependency-plugin.version>
+    <maven-dependency-plugin.version>3.1.1</maven-dependency-plugin.version>
+    <docker-maven-plugin.version>0.29.0</docker-maven-plugin.version>
     <exec-maven-plugin.version>1.3.1</exec-maven-plugin.version>
+    <license-maven-plugin.version>1.10</license-maven-plugin.version>
     <make-maven-plugin.version>1.0-beta-1</make-maven-plugin.version>
     <native-maven-plugin.version>1.0-alpha-8</native-maven-plugin.version>
     <maven-checkstyle-plugin.version>3.1.2</maven-checkstyle-plugin.version>
@@ -259,7 +296,12 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
       <dependency>
         <groupId>info.picocli</groupId>
         <artifactId>picocli</artifactId>
-        <version>4.6.1</version>
+        <version>${picocli.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.derby</groupId>
+        <artifactId>derby</artifactId>
+        <version>${derby.version}</version>
       </dependency>
       <dependency>
         <groupId>org.apache.hadoop</groupId>
@@ -723,27 +765,27 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
       <dependency>
         <groupId>javax.activation</groupId>
         <artifactId>activation</artifactId>
-        <version>1.1.1</version>
+        <version>${javax-activation.version}</version>
       </dependency>
       <dependency>
         <groupId>javax.annotation</groupId>
         <artifactId>javax.annotation-api</artifactId>
-        <version>1.2</version>
+        <version>${annotation-api.version}</version>
       </dependency>
       <dependency>
         <groupId>javax.enterprise</groupId>
         <artifactId>cdi-api</artifactId>
-        <version>1.2</version>
+        <version>${cdi-api.version}</version>
       </dependency>
       <dependency>
         <groupId>javax.servlet</groupId>
         <artifactId>javax.servlet-api</artifactId>
-        <version>3.1.0</version>
+        <version>${servlet-api.version}</version>
       </dependency>
       <dependency>
         <groupId>javax.ws.rs</groupId>
         <artifactId>jsr311-api</artifactId>
-        <version>1.1.1</version>
+        <version>${jsr311-api.version}</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
@@ -779,12 +821,12 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
       <dependency>
         <groupId>javax.servlet.jsp</groupId>
         <artifactId>jsp-api</artifactId>
-        <version>2.1</version>
+        <version>${jsp-api.version}</version>
       </dependency>
       <dependency>
         <groupId>org.glassfish</groupId>
         <artifactId>javax.servlet</artifactId>
-        <version>3.1</version>
+        <version>${glassfish-servlet.version}</version>
       </dependency>
       <dependency>
         <groupId>org.glassfish.hk2</groupId>
@@ -856,7 +898,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
       <dependency>
         <groupId>org.ow2.asm</groupId>
         <artifactId>asm</artifactId>
-        <version>5.0.4</version>
+        <version>${asm.version}</version>
       </dependency>
       <dependency>
         <groupId>com.sun.jersey</groupId>
@@ -888,7 +930,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
       <dependency>
         <groupId>com.google.errorprone</groupId>
         <artifactId>error_prone_annotations</artifactId>
-        <version>2.2.0</version>
+        <version>${errorprone-annotations.version}</version>
         <optional>true</optional>
       </dependency>
 
@@ -915,13 +957,13 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
       <dependency>
         <groupId>com.jolbox</groupId>
         <artifactId>bonecp</artifactId>
-        <version>0.8.0.RELEASE</version>
+        <version>${bonecp.version}</version>
       </dependency>
 
       <dependency>
         <groupId>cglib</groupId>
         <artifactId>cglib</artifactId>
-        <version>3.2.0</version>
+        <version>${cglib.version}</version>
       </dependency>
 
       <dependency>
@@ -1042,6 +1084,12 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
         <version>${log4j2.version}</version>
       </dependency>
       <dependency>
+        <groupId>com.codahale.metrics</groupId>
+        <artifactId>metrics-core</artifactId>
+        <version>${codahale-metrics.version}</version>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
         <groupId>com.lmax</groupId>
         <artifactId>disruptor</artifactId>
         <version>${disruptor.version}</version>
@@ -1059,7 +1107,18 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
       <dependency>
         <groupId>junit</groupId>
         <artifactId>junit</artifactId>
-        <version>4.13.1</version>
+        <version>${junit4.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.jacoco</groupId>
+        <artifactId>org.jacoco.core</artifactId>
+        <scope>provided</scope>
+        <version>${jacoco.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.javassist</groupId>
+        <artifactId>javassist</artifactId>
+        <version>${javassist.version}</version>
       </dependency>
       <dependency>
         <groupId>org.junit.jupiter</groupId>
@@ -1146,7 +1205,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
       <dependency>
         <groupId>com.fasterxml.woodstox</groupId>
         <artifactId>woodstox-core</artifactId>
-        <version>5.4.0</version>
+        <version>${woodstox.version}</version>
       </dependency>
       <dependency>
         <groupId>com.fasterxml.jackson</groupId>
@@ -1170,7 +1229,13 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
       <dependency>
         <groupId>org.jmockit</groupId>
         <artifactId>jmockit</artifactId>
-        <version>1.24</version>
+        <version>${jmockit.version}</version>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.mockito</groupId>
+        <artifactId>mockito-all</artifactId>
+        <version>${mockito1-powermock.version}</version>
         <scope>test</scope>
       </dependency>
       <dependency>
@@ -1188,13 +1253,13 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
       <dependency>
         <groupId>com.google.testing.compile</groupId>
         <artifactId>compile-testing</artifactId>
-        <version>0.19</version>
+        <version>${compile-testing.version}</version>
         <scope>test</scope>
       </dependency>
       <dependency>
         <groupId>org.objenesis</groupId>
         <artifactId>objenesis</artifactId>
-        <version>1.0</version>
+        <version>${objenesis.version}</version>
       </dependency>
       <dependency>
         <groupId>com.google.re2j</groupId>
@@ -1219,19 +1284,19 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
       <dependency>
         <groupId>com.jcraft</groupId>
         <artifactId>jsch</artifactId>
-        <version>0.1.54</version>
+        <version>${jsch.version}</version>
       </dependency>
 
       <dependency>
         <groupId>org.kohsuke.metainf-services</groupId>
         <artifactId>metainf-services</artifactId>
-        <version>1.8</version>
+        <version>${metainf-services.version}</version>
         <optional>true</optional>
       </dependency>
       <dependency>
         <groupId>io.dropwizard.metrics</groupId>
         <artifactId>metrics-core</artifactId>
-        <version>3.2.4</version>
+        <version>${dropwizard-metrics.version}</version>
       </dependency>
       <dependency>
         <groupId>io.jaegertracing</groupId>
@@ -1251,7 +1316,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
       <dependency>
         <groupId>org.jetbrains.kotlin</groupId>
         <artifactId>kotlin-stdlib</artifactId>
-        <version>1.6.21</version>
+        <version>${kotlin.version}</version>
       </dependency>
       <dependency>
         <groupId>io.opentracing</groupId>
@@ -1292,12 +1357,12 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
       <dependency>
         <groupId>javax.xml.bind</groupId>
         <artifactId>jaxb-api</artifactId>
-        <version>2.3.0</version>
+        <version>${jaxb-api.version}</version>
       </dependency>
       <dependency>
         <groupId>org.glassfish.jaxb</groupId>
         <artifactId>jaxb-runtime</artifactId>
-        <version>2.3.0.1</version>
+        <version>${jaxb-runtime.version}</version>
       </dependency>
       <dependency>
         <groupId>com.sun.jersey</groupId>
@@ -1321,7 +1386,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
       <dependency>
         <groupId>org.apache.kerby</groupId>
         <artifactId>kerb-simplekdc</artifactId>
-        <version>1.0.1</version>
+        <version>${kerby.version}</version>
       </dependency>
       <dependency>
         <groupId>org.yaml</groupId>
@@ -1331,13 +1396,13 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
       <dependency>
         <groupId>org.assertj</groupId>
         <artifactId>assertj-core</artifactId>
-        <version>3.12.2</version>
+        <version>${assertj.version}</version>
         <scope>test</scope>
       </dependency>
       <dependency>
         <groupId>org.jboss.weld.servlet</groupId>
         <artifactId>weld-servlet</artifactId>
-        <version>2.4.7.Final</version>
+        <version>${weld-servlet.version}</version>
       </dependency>
       <dependency>
         <groupId>org.powermock</groupId>
@@ -1358,14 +1423,19 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
         <scope>test</scope>
       </dependency>
       <dependency>
+        <groupId>org.reflections</groupId>
+        <artifactId>reflections</artifactId>
+        <version>${reflections.version}</version>
+      </dependency>
+      <dependency>
         <groupId>org.rocksdb</groupId>
         <artifactId>rocksdbjni</artifactId>
-        <version>7.7.3</version>
+        <version>${rocksdb.version}</version>
       </dependency>
       <dependency>
         <groupId>org.xerial</groupId>
         <artifactId>sqlite-jdbc</artifactId>
-        <version>3.25.2</version>
+        <version>${sqlite.version}</version>
       </dependency>
     </dependencies>
   </dependencyManagement>
@@ -1413,7 +1483,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
         <plugin>
           <groupId>org.codehaus.mojo</groupId>
           <artifactId>license-maven-plugin</artifactId>
-          <version>1.10</version>
+          <version>${license-maven-plugin.version}</version>
           <configuration>
             <canUpdateCopyright>false</canUpdateCopyright>
             <roots><root>${project.basedir}</root></roots>
@@ -1618,12 +1688,12 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
         <plugin>
           <groupId>org.jacoco</groupId>
           <artifactId>jacoco-maven-plugin</artifactId>
-          <version>0.8.5</version>
+          <version>${jacoco.version}</version>
         </plugin>
         <plugin>
           <groupId>io.fabric8</groupId>
           <artifactId>docker-maven-plugin</artifactId>
-          <version>0.29.0</version>
+          <version>${docker-maven-plugin.version}</version>
         </plugin>
       </plugins>
     </pluginManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -259,7 +259,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
     <apache-rat-plugin.version>0.12</apache-rat-plugin.version>
     <maven-deploy-plugin.version>2.8.1</maven-deploy-plugin.version>
     <build-helper-maven-plugin.version>1.9</build-helper-maven-plugin.version>
-    <maven-dependency-plugin.version>3.1.1</maven-dependency-plugin.version>
+    <maven-dependency-plugin.version>3.0.2</maven-dependency-plugin.version>
     <docker-maven-plugin.version>0.29.0</docker-maven-plugin.version>
     <exec-maven-plugin.version>1.3.1</exec-maven-plugin.version>
     <license-maven-plugin.version>1.10</license-maven-plugin.version>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Move all dependency version definition to properties in root POM.  This allows overriding the dependency's version for each build.

https://issues.apache.org/jira/browse/HDDS-7371

## How was this patch tested?

Verified that all dependency versions are defined via properties, only enforcer rules have non-property-based `<version>` tags:

```
$ rg '<version>' | grep -Fv -e '1.3.0-SNAPSHOT' -e '<version>${'
pom.xml:                <version>[3.0.2,)</version>
pom.xml:                <version>[1.8,)</version>
```

Verified that dependency tree is same as for `master`:

```
$ git checkout master
$ mvn -Dorg.slf4j.simpleLogger.showDateTime=false -B --no-transfer-progress dependency:tree > dep.master
$ git checkout HDDS-7371
$ mvn -Dorg.slf4j.simpleLogger.showDateTime=false -B --no-transfer-progress dependency:tree > dep.HDDS-7371
$ diff -uw dep.master dep.HDDS-7371
--- dep.master	2022-12-08 10:08:39.198215059 +0100
+++ dep.HDDS-7371	2022-12-08 10:08:41.990179382 +0100
@@ -5080,52 +5080,52 @@
 [INFO] ------------------------------------------------------------------------
 [INFO] Reactor Summary for Apache Ozone Main 1.3.0-SNAPSHOT:
 [INFO] 
-[INFO] Apache Ozone Main .................................. SUCCESS [  0.234 s]
-[INFO] Apache Ozone HDDS .................................. SUCCESS [  0.293 s]
+[INFO] Apache Ozone Main .................................. SUCCESS [  0.211 s]
+[INFO] Apache Ozone HDDS .................................. SUCCESS [  0.316 s]
...
```