### PR TITLE
HDDS-7592. Recursive delete of directory multiple time impacts some directory not removed

### DIFF
--- a/hadoop-ozone/interface-storage/src/main/java/org/apache/hadoop/ozone/om/OMMetadataManager.java
+++ b/hadoop-ozone/interface-storage/src/main/java/org/apache/hadoop/ozone/om/OMMetadataManager.java
@@ -449,6 +449,16 @@ public interface OMMetadataManager extends DBStoreHAManager {
                          long parentObjectId, String pathComponentName);
 
   /**
+   * Given ozone path key, component id, return the corresponding 
+   * DB path key for delete table.
+   *
+   * @param objectId - object Id
+   * @param pathKey   - path key of component
+   * @return DB Delete directory key as String.
+   */
+  String getOzoneDeletePathKey(long objectId, String pathKey);
+
+  /**
    * Returns DB key name of an open file in OM metadata store. Should be
    * #open# prefix followed by actual leaf node name.
    *

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmMetadataManagerImpl.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmMetadataManagerImpl.java
@@ -1453,6 +1453,11 @@ public class OmMetadataManagerImpl implements OMMetadataManager {
   }
 
   @Override
+  public String getOzoneDeletePathKey(long objectId, String pathKey) {
+    return pathKey + OM_KEY_PREFIX + objectId;
+  }
+
+  @Override
   public String getOpenFileName(long volumeId, long bucketId,
                                 long parentID, String fileName,
                                 long id) {

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/key/OMDirectoriesPurgeResponseWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/key/OMDirectoriesPurgeResponseWithFSO.java
@@ -85,8 +85,10 @@ public class OMDirectoriesPurgeResponseWithFSO extends OmKeyResponse {
         OmKeyInfo keyInfo = OmKeyInfo.getFromProtobuf(key);
         String ozoneDbKey = omMetadataManager.getOzonePathKey(volumeId,
                 bucketId, keyInfo.getParentObjectID(), keyInfo.getFileName());
+        String ozoneDeleteKey = omMetadataManager.getOzoneDeletePathKey(
+            key.getObjectID(), ozoneDbKey);
         omMetadataManager.getDeletedDirTable().putWithBatch(batchOperation,
-                ozoneDbKey, keyInfo);
+            ozoneDeleteKey, keyInfo);
 
         omMetadataManager.getDirectoryTable().deleteWithBatch(batchOperation,
                 ozoneDbKey);

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/key/OMKeyDeleteResponseWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/key/OMKeyDeleteResponseWithFSO.java
@@ -84,8 +84,10 @@ public class OMKeyDeleteResponseWithFSO extends OMKeyDeleteResponse {
       // Sets full absolute key name to OmKeyInfo, which is
       // required for moving the sub-files to KeyDeletionService.
       omKeyInfo.setKeyName(keyName);
+      String ozoneDeleteKey = omMetadataManager.getOzoneDeletePathKey(
+          omKeyInfo.getObjectID(), ozoneDbKey);
       omMetadataManager.getDeletedDirTable().putWithBatch(
-          batchOperation, ozoneDbKey, omKeyInfo);
+          batchOperation, ozoneDeleteKey, omKeyInfo);
     } else {
       Table<String, OmKeyInfo> keyTable =
           omMetadataManager.getKeyTable(getBucketLayout());

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/key/OMKeysDeleteResponseWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/key/OMKeysDeleteResponseWithFSO.java
@@ -70,8 +70,10 @@ public class OMKeysDeleteResponseWithFSO extends OMKeysDeleteResponse {
           omKeyInfo.getParentObjectID(), omKeyInfo.getFileName());
       omMetadataManager.getDirectoryTable().deleteWithBatch(batchOperation,
           ozoneDbKey);
+      String ozoneDeleteKey = omMetadataManager.getOzoneDeletePathKey(
+          omKeyInfo.getObjectID(), ozoneDbKey);
       omMetadataManager.getDeletedDirTable().putWithBatch(
-          batchOperation, ozoneDbKey, omKeyInfo);
+          batchOperation, ozoneDeleteKey, omKeyInfo);
     }
 
     // remove keys from FileTable and add to DeletedTable

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/service/DirectoryDeletingService.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/service/DirectoryDeletingService.java
@@ -252,7 +252,9 @@ public class DirectoryDeletingService extends BackgroundService {
     for (OmKeyInfo dirInfo : subDirs) {
       String ozoneDbKey = omMetadataManager.getOzonePathKey(volumeId,
           bucketId, dirInfo.getParentObjectID(), dirInfo.getFileName());
-      subDirList.add(Pair.of(ozoneDbKey, dirInfo));
+      String ozoneDeleteKey = omMetadataManager.getOzoneDeletePathKey(
+          dirInfo.getObjectID(), ozoneDbKey);
+      subDirList.add(Pair.of(ozoneDeleteKey, dirInfo));
       LOG.debug("Moved sub dir name: {}", dirInfo.getKeyName());
     }
 

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/key/TestOMKeysDeleteResponseWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/key/TestOMKeysDeleteResponseWithFSO.java
@@ -53,6 +53,7 @@ public class TestOMKeysDeleteResponseWithFSO
 
   private List<OmKeyInfo> dirDeleteList = new ArrayList<>();
   private List<String> dirDBKeys = new ArrayList<>();
+  private List<String> dirDelDBKeys = new ArrayList<>();
   private long volId;
 
   @Override
@@ -82,6 +83,8 @@ public class TestOMKeysDeleteResponseWithFSO
         bucketName, dirInfo, dir);
     dirDeleteList.add(dirKeyInfo);
     dirDBKeys.add(dirOzoneDBKey);
+    dirDelDBKeys.add(omMetadataManager.getOzoneDeletePathKey(
+        dirKeyInfo.getObjectID(), dirOzoneDBKey));
 
     // create set of keys directly under the bucket
     String ozoneDBKey = "";
@@ -150,10 +153,12 @@ public class TestOMKeysDeleteResponseWithFSO
       RepeatedOmKeyInfo repeatedOmKeyInfo =
           omMetadataManager.getDeletedTable().get(dirDBKey);
       Assert.assertNull(repeatedOmKeyInfo);
+    }
 
+    for (String dirDelDBKey : dirDelDBKeys) {
       // dir added to the deleted dir table, for deep cleanups
       OmKeyInfo omDirInfo =
-          omMetadataManager.getDeletedDirTable().get(dirDBKey);
+          omMetadataManager.getDeletedDirTable().get(dirDelDBKey);
       Assert.assertNotNull(omDirInfo);
     }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Adding additional suffix "objectId" in deletedTable key to make it unique in case of frequent add and delete directory.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-7592

## How was this patch tested?

Impacted UTs are verified and CI will cover other impact cases for cleanup.

From E2E perspective, its verified that cleanup of all directory and related keys are deleted. table entry also have unique value,

```
sumitagrawal@sumitagrawal-MBP16 bin % ./ozone debug ldb --db /tmp/metadata/om.db scan --with-keys --column_family=deletedDirectoryTable | grep d1
"/-9223372036853886720/-9223372036853885696/-9223372036853885696/d1/-9223372036853877503" -> {
  "keyName": "d1",
  "fileName": "d1",
"/-9223372036853886720/-9223372036853885696/-9223372036853885696/d1/-9223372036853878527" -> {
  "keyName": "d1",
  "fileName": "d1",
```
