### PR TITLE
HDDS-7618. Replication Commands should timeout if not processed on datanodes in time

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/DatanodeStateMachine.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/DatanodeStateMachine.java
@@ -18,6 +18,8 @@ package org.apache.hadoop.ozone.container.common.statemachine;
 
 import java.io.Closeable;
 import java.io.IOException;
+import java.time.Clock;
+import java.time.ZoneId;
 import java.util.Map;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -40,6 +42,7 @@ import org.apache.hadoop.hdds.security.x509.certificate.client.CertificateClient
 import org.apache.hadoop.hdds.upgrade.HDDSLayoutVersionManager;
 import org.apache.hadoop.hdds.utils.LegacyHadoopConfigurationSource;
 import org.apache.hadoop.ozone.HddsDatanodeStopService;
+import org.apache.hadoop.ozone.common.MonotonicClock;
 import org.apache.hadoop.ozone.container.common.DatanodeLayoutStorage;
 import org.apache.hadoop.ozone.container.common.report.ReportManager;
 import org.apache.hadoop.ozone.container.common.statemachine.commandhandler.CloseContainerCommandHandler;
@@ -139,6 +142,7 @@ public class DatanodeStateMachine implements Closeable {
     this.conf = conf;
     this.datanodeDetails = datanodeDetails;
 
+    Clock clock = new MonotonicClock(ZoneId.systemDefault());
     // Expected to be initialized already.
     layoutStorage = new DatanodeLayoutStorage(conf,
         datanodeDetails.getUuidString());
@@ -180,7 +184,7 @@ public class DatanodeStateMachine implements Closeable {
         conf.getObject(ReplicationConfig.class);
     supervisor =
         new ReplicationSupervisor(container.getContainerSet(), context,
-            replicatorMetrics, replicationConfig);
+            replicatorMetrics, replicationConfig, clock);
 
     replicationSupervisorMetrics =
         ReplicationSupervisorMetrics.create(supervisor);

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/DatanodeStateMachine.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/DatanodeStateMachine.java
@@ -211,7 +211,7 @@ public class DatanodeStateMachine implements Closeable {
         .addHandler(new ReconstructECContainersCommandHandler(conf,
             ecReconstructionSupervisor))
         .addHandler(new DeleteContainerCommandHandler(
-            dnConf.getContainerDeleteThreads()))
+            dnConf.getContainerDeleteThreads(), clock))
         .addHandler(new ClosePipelineCommandHandler())
         .addHandler(new CreatePipelineCommandHandler(conf))
         .addHandler(new SetNodeOperationalStateCommandHandler(conf))

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/DatanodeStateMachine.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/DatanodeStateMachine.java
@@ -197,7 +197,7 @@ public class DatanodeStateMachine implements Closeable {
     ecReconstructionSupervisor =
         new ECReconstructionSupervisor(container.getContainerSet(), context,
             replicationConfig.getReplicationMaxStreams(),
-            ecReconstructionCoordinator);
+            ecReconstructionCoordinator, clock);
 
 
     // When we add new handlers just adding a new handler here should do the

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/ReconstructECContainersCommandHandler.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/ReconstructECContainersCommandHandler.java
@@ -51,7 +51,8 @@ public class ReconstructECContainersCommandHandler implements CommandHandler {
             ecContainersCommand.getEcReplicationConfig(),
             ecContainersCommand.getMissingContainerIndexes(),
             ecContainersCommand.getSources(),
-            ecContainersCommand.getTargetDatanodes());
+            ecContainersCommand.getTargetDatanodes(),
+            ecContainersCommand.getDeadline());
     this.supervisor.addTask(reconstructionCommandInfo);
   }
 

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/ReconstructECContainersCommandHandler.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/ReconstructECContainersCommandHandler.java
@@ -47,12 +47,7 @@ public class ReconstructECContainersCommandHandler implements CommandHandler {
     ReconstructECContainersCommand ecContainersCommand =
         (ReconstructECContainersCommand) command;
     ECReconstructionCommandInfo reconstructionCommandInfo =
-        new ECReconstructionCommandInfo(ecContainersCommand.getContainerID(),
-            ecContainersCommand.getEcReplicationConfig(),
-            ecContainersCommand.getMissingContainerIndexes(),
-            ecContainersCommand.getSources(),
-            ecContainersCommand.getTargetDatanodes(),
-            ecContainersCommand.getDeadline());
+        new ECReconstructionCommandInfo(ecContainersCommand);
     this.supervisor.addTask(reconstructionCommandInfo);
   }
 

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/ReplicateContainerCommandHandler.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/ReplicateContainerCommandHandler.java
@@ -72,8 +72,7 @@ public class ReplicateContainerCommandHandler implements CommandHandler {
         "Replication command is received for container %s "
             + "without source datanodes.", containerID);
 
-    ReplicationTask task = new ReplicationTask(containerID, sourceDatanodes);
-    task.setDeadline(deadline);
+    ReplicationTask task = new ReplicationTask(replicateCommand);
     supervisor.addTask(task);
   }
 

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/ReplicateContainerCommandHandler.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/ReplicateContainerCommandHandler.java
@@ -66,12 +66,15 @@ public class ReplicateContainerCommandHandler implements CommandHandler {
     final List<DatanodeDetails> sourceDatanodes =
         replicateCommand.getSourceDatanodes();
     final long containerID = replicateCommand.getContainerID();
+    final long deadline = replicateCommand.getDeadline();
 
     Preconditions.checkArgument(sourceDatanodes.size() > 0,
         "Replication command is received for container %s "
             + "without source datanodes.", containerID);
 
-    supervisor.addTask(new ReplicationTask(containerID, sourceDatanodes));
+    ReplicationTask task = new ReplicationTask(containerID, sourceDatanodes);
+    task.setDeadline(deadline);
+    supervisor.addTask(task);
   }
 
   @Override

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/ReplicateContainerCommandHandler.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/ReplicateContainerCommandHandler.java
@@ -66,7 +66,6 @@ public class ReplicateContainerCommandHandler implements CommandHandler {
     final List<DatanodeDetails> sourceDatanodes =
         replicateCommand.getSourceDatanodes();
     final long containerID = replicateCommand.getContainerID();
-    final long deadline = replicateCommand.getDeadline();
 
     Preconditions.checkArgument(sourceDatanodes.size() > 0,
         "Replication command is received for container %s "

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/states/endpoint/HeartbeatEndpointTask.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/states/endpoint/HeartbeatEndpointTask.java
@@ -426,6 +426,7 @@ public class HeartbeatEndpointTask
    * Common processing for SCM commands.
    *  - set term
    *  - set encoded token
+   *  - any deadline which is relevant to the command
    *  - add to context's queue
    */
   private void processCommonCommand(
@@ -435,6 +436,9 @@ public class HeartbeatEndpointTask
     }
     if (response.hasEncodedToken()) {
       cmd.setEncodedToken(response.getEncodedToken());
+    }
+    if (response.hasDeadlineMsSinceEpoch()) {
+      cmd.setDeadline(response.getDeadlineMsSinceEpoch());
     }
     context.addCommand(cmd);
   }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/ec/reconstruction/ECReconstructionCommandInfo.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/ec/reconstruction/ECReconstructionCommandInfo.java
@@ -35,17 +35,23 @@ public class ECReconstructionCommandInfo {
   private List<ReconstructECContainersCommand.DatanodeDetailsAndReplicaIndex>
       sources;
   private List<DatanodeDetails> targetDatanodes;
+  private long deadlineMsSinceEpoch = 0;
 
   public ECReconstructionCommandInfo(long containerID,
       ECReplicationConfig ecReplicationConfig, byte[] missingContainerIndexes,
       List<DatanodeDetailsAndReplicaIndex> sources,
-      List<DatanodeDetails> targetDatanodes) {
+      List<DatanodeDetails> targetDatanodes, long deadlineMsSinceEpoch) {
     this.containerID = containerID;
     this.ecReplicationConfig = ecReplicationConfig;
     this.missingContainerIndexes =
         Arrays.copyOf(missingContainerIndexes, missingContainerIndexes.length);
     this.sources = sources;
     this.targetDatanodes = targetDatanodes;
+    this.deadlineMsSinceEpoch = deadlineMsSinceEpoch;
+  }
+
+  public long getDeadline() {
+    return deadlineMsSinceEpoch;
   }
 
   public long getContainerID() {

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/ec/reconstruction/ECReconstructionCommandInfo.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/ec/reconstruction/ECReconstructionCommandInfo.java
@@ -37,17 +37,15 @@ public class ECReconstructionCommandInfo {
   private List<DatanodeDetails> targetDatanodes;
   private long deadlineMsSinceEpoch = 0;
 
-  public ECReconstructionCommandInfo(long containerID,
-      ECReplicationConfig ecReplicationConfig, byte[] missingContainerIndexes,
-      List<DatanodeDetailsAndReplicaIndex> sources,
-      List<DatanodeDetails> targetDatanodes, long deadlineMsSinceEpoch) {
-    this.containerID = containerID;
-    this.ecReplicationConfig = ecReplicationConfig;
+  public ECReconstructionCommandInfo(ReconstructECContainersCommand cmd) {
+    this.containerID = cmd.getContainerID();
+    this.ecReplicationConfig = cmd.getEcReplicationConfig();
     this.missingContainerIndexes =
-        Arrays.copyOf(missingContainerIndexes, missingContainerIndexes.length);
-    this.sources = sources;
-    this.targetDatanodes = targetDatanodes;
-    this.deadlineMsSinceEpoch = deadlineMsSinceEpoch;
+        Arrays.copyOf(cmd.getMissingContainerIndexes(),
+            cmd.getMissingContainerIndexes().length);
+    this.sources = cmd.getSources();
+    this.targetDatanodes = cmd.getTargetDatanodes();
+    this.deadlineMsSinceEpoch = cmd.getDeadline();
   }
 
   public long getDeadline() {

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/replication/ReplicationSupervisorMetrics.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/replication/ReplicationSupervisorMetrics.java
@@ -68,7 +68,7 @@ public class ReplicationSupervisorMetrics implements MetricsSource {
             "Number of requested replications"),
             supervisor.getReplicationRequestCount())
         .addGauge(Interns.info("numTimeoutReplications",
-            "Number of timeout replications in queue"),
+            "Number of replication requests timed out before being processed"),
             supervisor.getReplicationTimeoutCount());
   }
 }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/replication/ReplicationSupervisorMetrics.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/replication/ReplicationSupervisorMetrics.java
@@ -66,6 +66,9 @@ public class ReplicationSupervisorMetrics implements MetricsSource {
             supervisor.getQueueSize())
         .addGauge(Interns.info("numRequestedReplications",
             "Number of requested replications"),
-            supervisor.getReplicationRequestCount());
+            supervisor.getReplicationRequestCount())
+        .addGauge(Interns.info("numTimeoutReplications",
+            "Number of timeout replications in queue"),
+            supervisor.getReplicationTimeoutCount());
   }
 }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/replication/ReplicationTask.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/replication/ReplicationTask.java
@@ -22,6 +22,7 @@ import java.util.List;
 import java.util.Objects;
 
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
+import org.apache.hadoop.ozone.protocol.commands.ReplicateContainerCommand;
 
 /**
  * The task to download a container from the sources.
@@ -32,7 +33,7 @@ public class ReplicationTask {
 
   private final long containerId;
 
-  private List<DatanodeDetails> sources;
+  private final List<DatanodeDetails> sources;
 
   private final Instant queued = Instant.now();
 
@@ -43,21 +44,20 @@ public class ReplicationTask {
    */
   private long transferredBytes;
 
-  public ReplicationTask(
-      long containerId,
-      List<DatanodeDetails> sources
-  ) {
-    this.containerId = containerId;
-    this.sources = sources;
+  public ReplicationTask(ReplicateContainerCommand cmd) {
+    this.containerId = cmd.getContainerID();
+    this.sources = cmd.getSourceDatanodes();
+    this.deadlineMsSinceEpoch = cmd.getDeadline();
   }
 
   /**
-   * Set the time, in milliseconds since the epoch when this task should have
-   * completed by, otherwise it should be dropped.
-   * @param msSinceEpoch The task deadline in milliseconds since the epoch.
+   * Intended to only be used in tests.
    */
-  public void setDeadline(long msSinceEpoch) {
-    this.deadlineMsSinceEpoch = msSinceEpoch;
+  protected ReplicationTask(
+      long containerId,
+      List<DatanodeDetails> sources
+  ) {
+    this(new ReplicateContainerCommand(containerId, sources));
   }
 
   /**

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/replication/ReplicationTask.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/replication/ReplicationTask.java
@@ -36,6 +36,8 @@ public class ReplicationTask {
 
   private final Instant queued = Instant.now();
 
+  private long deadlineMsSinceEpoch = 0;
+
   /**
    * Counter for the transferred bytes.
    */
@@ -47,6 +49,23 @@ public class ReplicationTask {
   ) {
     this.containerId = containerId;
     this.sources = sources;
+  }
+
+  /**
+   * Set the time, in milliseconds since the epoch when this task should have
+   * completed by, otherwise it should be dropped.
+   * @param msSinceEpoch The task deadline in milliseconds since the epoch.
+   */
+  public void setDeadline(long msSinceEpoch) {
+    this.deadlineMsSinceEpoch = msSinceEpoch;
+  }
+
+  /**
+   * Returns any deadline set on this task, in milliseconds since the epoch.
+   * A returned value of zero indicates no deadline.
+   */
+  public long getDeadline() {
+    return deadlineMsSinceEpoch;
   }
 
   @Override

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/protocol/commands/SCMCommand.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/protocol/commands/SCMCommand.java
@@ -120,10 +120,7 @@ public abstract class SCMCommand<T extends Message> implements
    *         set deadline has expired.
    */
   public boolean hasExpired(long currentEpochMs) {
-    if (deadlineMsSinceEpoch > 0 &&
-        currentEpochMs > deadlineMsSinceEpoch) {
-      return true;
-    }
-    return false;
+    return deadlineMsSinceEpoch > 0 &&
+        currentEpochMs > deadlineMsSinceEpoch;
   }
 }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/protocol/commands/SCMCommand.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/protocol/commands/SCMCommand.java
@@ -38,6 +38,8 @@ public abstract class SCMCommand<T extends Message> implements
 
   private String encodedToken = "";
 
+  private long deadlineMsSinceEpoch = 0;
+
   SCMCommand() {
     this.id = HddsIdFactory.getLongId();
   }
@@ -87,5 +89,41 @@ public abstract class SCMCommand<T extends Message> implements
 
   public void setEncodedToken(String encodedToken) {
     this.encodedToken = encodedToken;
+  }
+
+  /**
+   * Allows a deadline to be set on the command. The deadline is set as the
+   * milliseconds since the epoch when the command must have been completed by.
+   * It is up to the code processing the command to enforce the deadline by
+   * calling the hasExpired() method, and the code sending the command to set
+   * the deadline. The default deadline is zero, which means no deadline.
+   * @param deadlineMs The ms since epoch when the command must have completed
+   *                   by.
+   */
+  public void setDeadline(long deadlineMs) {
+    this.deadlineMsSinceEpoch = deadlineMs;
+  }
+
+  /**
+   * @return The deadline set for this command, or zero if no command has been
+   *         set.
+   */
+  public long getDeadline() {
+    return deadlineMsSinceEpoch;
+  }
+
+  /**
+   * If a deadline has been set to a non zero value, test if the current time
+   * passed is beyond the deadline or not.
+   * @param currentEpochMs current time in milliseconds since the epoch.
+   * @return false if there is no deadline, or it has not expired. True if the
+   *         set deadline has expired.
+   */
+  public boolean hasExpired(long currentEpochMs) {
+    if (deadlineMsSinceEpoch > 0 &&
+        currentEpochMs > deadlineMsSinceEpoch) {
+      return true;
+    }
+    return false;
   }
 }

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/TestDeleteContainerCommandHandler.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/TestDeleteContainerCommandHandler.java
@@ -1,0 +1,71 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.ozone.container.common.statemachine.commandhandler;
+
+import org.apache.hadoop.ozone.container.ozoneimpl.ContainerController;
+import org.apache.hadoop.ozone.container.ozoneimpl.OzoneContainer;
+import org.apache.hadoop.ozone.protocol.commands.DeleteContainerCommand;
+import org.apache.ozone.test.TestClock;
+import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.mockito.Mockito;
+
+import java.io.IOException;
+import java.time.Instant;
+import java.time.ZoneId;
+
+import static com.google.common.util.concurrent.MoreExecutors.newDirectExecutorService;
+import static org.mockito.Mockito.times;
+
+/**
+ * Test for the DeleteContainerCommandHandler.
+ */
+public class TestDeleteContainerCommandHandler {
+
+  @Test
+  public void testExpiredCommandsAreNotProcessed() throws IOException {
+    TestClock clock = new TestClock(Instant.now(), ZoneId.systemDefault());
+    DeleteContainerCommandHandler handler =
+        new DeleteContainerCommandHandler(clock, newDirectExecutorService());
+    OzoneContainer ozoneContainer = Mockito.mock(OzoneContainer.class);
+    ContainerController controller = Mockito.mock(ContainerController.class);
+    Mockito.when(ozoneContainer.getController()).thenReturn(controller);
+
+    DeleteContainerCommand command1 = new DeleteContainerCommand(1L);
+    command1.setDeadline(clock.millis() + 10000);
+    DeleteContainerCommand command2 = new DeleteContainerCommand(2L);
+    command2.setDeadline(clock.millis() + 20000);
+    DeleteContainerCommand command3 = new DeleteContainerCommand(3L);
+    // No deadline on the 3rd command
+
+    clock.fastForward(15000);
+    handler.handle(command1, ozoneContainer, null, null);
+    Assertions.assertEquals(1, handler.getTimeoutCount());
+    handler.handle(command2, ozoneContainer, null, null);
+    handler.handle(command3, ozoneContainer, null, null);
+    Assertions.assertEquals(1, handler.getTimeoutCount());
+    Assertions.assertEquals(3, handler.getInvocationCount());
+    Mockito.verify(controller, times(0))
+        .deleteContainer(1L, false);
+    Mockito.verify(controller, times(1))
+        .deleteContainer(2L, false);
+    Mockito.verify(controller, times(1))
+        .deleteContainer(3L, false);
+  }
+
+}

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/ec/reconstruction/TestECReconstructionSupervisor.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/ec/reconstruction/TestECReconstructionSupervisor.java
@@ -22,18 +22,36 @@ import org.apache.hadoop.hdds.client.ECReplicationConfig;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
 import org.apache.ozone.test.GenericTestUtils;
+import org.apache.ozone.test.TestClock;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 
 import java.io.IOException;
+import java.time.Instant;
+import java.time.ZoneId;
 import java.util.SortedMap;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeoutException;
+
+import static com.google.common.util.concurrent.MoreExecutors.newDirectExecutorService;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.times;
 
 /**
  * Tests the ECReconstructionSupervisor.
  */
 public class TestECReconstructionSupervisor {
+
+  private TestClock clock;
+
+  @BeforeEach
+  public void setup() {
+    clock = new TestClock(Instant.now(), ZoneId.systemDefault());
+  }
+
 
   @Test
   public void testAddTaskShouldExecuteTheGivenTask()
@@ -58,15 +76,50 @@ public class TestECReconstructionSupervisor {
                 super.reconstructECContainerGroup(containerID, repConfig,
                     sourceNodeMap, targetNodeMap);
               }
-            }) {
+            }, clock) {
         };
     supervisor.addTask(
         new ECReconstructionCommandInfo(1, new ECReplicationConfig(3, 2),
-            new byte[0], ImmutableList.of(), ImmutableList.of()));
+            new byte[0], ImmutableList.of(), ImmutableList.of(), 0));
     runnableInvoked.await();
     Assertions.assertEquals(1, supervisor.getInFlightReplications());
     holdProcessing.countDown();
     GenericTestUtils
         .waitFor(() -> supervisor.getInFlightReplications() == 0, 100, 15000);
   }
+
+  @Test
+  public void testTasksWithDeadlineExceededAreNotRun() throws IOException {
+    ECReconstructionCoordinator coordinator =
+        Mockito.mock(ECReconstructionCoordinator.class);
+    ECReconstructionSupervisor supervisor =
+        new ECReconstructionSupervisor(null, null,
+            newDirectExecutorService(), coordinator, clock);
+
+    ECReconstructionCommandInfo task1 = new ECReconstructionCommandInfo(1L,
+        new ECReplicationConfig(3, 2), new byte[0], ImmutableList.of(),
+        ImmutableList.of(), 0);
+    ECReconstructionCommandInfo task2 = new ECReconstructionCommandInfo(2L,
+        new ECReplicationConfig(3, 2), new byte[0], ImmutableList.of(),
+        ImmutableList.of(), clock.millis() + 10000);
+    ECReconstructionCommandInfo task3 = new ECReconstructionCommandInfo(3L,
+        new ECReplicationConfig(3, 2), new byte[0], ImmutableList.of(),
+        ImmutableList.of(), clock.millis() + 20000);
+
+    clock.fastForward(15000);
+    supervisor.addTask(task1);
+    supervisor.addTask(task2);
+    supervisor.addTask(task3);
+
+    // No deadline for container 1, it should run.
+    Mockito.verify(coordinator, times(1))
+        .reconstructECContainerGroup(eq(1L), any(), any(), any());
+    // Deadline passed for container 2, it should not run.
+    Mockito.verify(coordinator, times(0))
+        .reconstructECContainerGroup(eq(2L), any(), any(), any());
+    // Deadline not passed for container 3, it should run.
+    Mockito.verify(coordinator, times(1))
+        .reconstructECContainerGroup(eq(3L), any(), any(), any());
+  }
+
 }

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/replication/ReplicationSupervisorScheduling.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/replication/ReplicationSupervisorScheduling.java
@@ -17,6 +17,7 @@
  */
 package org.apache.hadoop.ozone.container.replication;
 
+import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -24,8 +25,10 @@ import java.util.Map;
 import java.util.Random;
 import java.util.UUID;
 
+import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
 import org.apache.hadoop.hdds.protocol.MockDatanodeDetails;
+import org.apache.hadoop.ozone.common.MonotonicClock;
 import org.apache.hadoop.ozone.container.common.impl.ContainerSet;
 
 import org.junit.jupiter.api.Assertions;
@@ -43,6 +46,9 @@ public class ReplicationSupervisorScheduling {
 
   @Test
   public void test() throws InterruptedException {
+    OzoneConfiguration conf = new OzoneConfiguration();
+    ReplicationServer.ReplicationConfig replicationConfig
+        = conf.getObject(ReplicationServer.ReplicationConfig.class);
     List<DatanodeDetails> datanodes = new ArrayList<>();
     datanodes.add(MockDatanodeDetails.randomDatanodeDetails());
     datanodes.add(MockDatanodeDetails.randomDatanodeDetails());
@@ -69,7 +75,7 @@ public class ReplicationSupervisorScheduling {
 
     ContainerSet cs = new ContainerSet(1000);
 
-    ReplicationSupervisor rs = new ReplicationSupervisor(cs,
+    ReplicationSupervisor rs = new ReplicationSupervisor(cs, null,
 
         //simplified executor emulating the current sequential download +
         //import.
@@ -107,7 +113,7 @@ public class ReplicationSupervisorScheduling {
             }
           }
 
-        }, 10);
+        }, replicationConfig, new MonotonicClock(ZoneId.systemDefault()));
 
     final long start = System.currentTimeMillis();
 

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/replication/TestReplicationSupervisor.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/replication/TestReplicationSupervisor.java
@@ -20,6 +20,9 @@ package org.apache.hadoop.ozone.container.replication;
 
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneId;
 import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.AbstractExecutorService;
@@ -39,6 +42,7 @@ import org.apache.hadoop.ozone.container.keyvalue.KeyValueContainer;
 import org.apache.hadoop.ozone.container.keyvalue.KeyValueContainerData;
 
 import org.apache.ozone.test.GenericTestUtils;
+import org.apache.ozone.test.TestClock;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -76,6 +80,7 @@ public class TestReplicationSupervisor {
   private ContainerSet set;
 
   private final ContainerLayoutVersion layout;
+  private Clock clock = new TestClock(Instant.now(), ZoneId.systemDefault());
 
   public TestReplicationSupervisor(ContainerLayoutVersion layout) {
     this.layout = layout;
@@ -231,7 +236,7 @@ public class TestReplicationSupervisor {
   public void testDownloadAndImportReplicatorFailure() {
     ReplicationSupervisor supervisor =
         new ReplicationSupervisor(set, null, mutableReplicator,
-            newDirectExecutorService());
+            newDirectExecutorService(), clock);
 
     // Mock to fetch an exception in the importContainer method.
     SimpleContainerDownloader moc =
@@ -265,7 +270,8 @@ public class TestReplicationSupervisor {
       Function<ReplicationSupervisor, ContainerReplicator> replicatorFactory,
       ExecutorService executor) {
     ReplicationSupervisor supervisor =
-        new ReplicationSupervisor(set, null, mutableReplicator, executor);
+        new ReplicationSupervisor(set, null, mutableReplicator, executor,
+            clock);
     replicatorRef.set(replicatorFactory.apply(supervisor));
     return supervisor;
   }

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/replication/TestReplicationSupervisor.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/replication/TestReplicationSupervisor.java
@@ -40,6 +40,7 @@ import org.apache.hadoop.ozone.container.keyvalue.ContainerLayoutTestInfo;
 import org.apache.hadoop.ozone.container.keyvalue.KeyValueContainer;
 import org.apache.hadoop.ozone.container.keyvalue.KeyValueContainerData;
 
+import org.apache.hadoop.ozone.protocol.commands.ReplicateContainerCommand;
 import org.apache.ozone.test.GenericTestUtils;
 import org.apache.ozone.test.TestClock;
 import org.junit.After;
@@ -266,11 +267,16 @@ public class TestReplicationSupervisor {
     ReplicationSupervisor supervisor =
         supervisorWithReplicator(FakeReplicator::new);
 
-    ReplicationTask task1 = new ReplicationTask(1L, emptyList());
-    task1.setDeadline(clock.millis() + 10000);
-    ReplicationTask task2 = new ReplicationTask(2L, emptyList());
-    task2.setDeadline(clock.millis() + 20000);
-    ReplicationTask task3 = new ReplicationTask(3L, emptyList());
+    ReplicateContainerCommand cmd = new ReplicateContainerCommand(1L,
+        emptyList());
+    cmd.setDeadline(clock.millis() + 10000);
+    ReplicationTask task1 = new ReplicationTask(cmd);
+    cmd = new ReplicateContainerCommand(2L, emptyList());
+    cmd.setDeadline(clock.millis() + 20000);
+    ReplicationTask task2 = new ReplicationTask(cmd);
+    cmd = new ReplicateContainerCommand(3L, emptyList());
+    // No deadline set
+    ReplicationTask task3 = new ReplicationTask(cmd);
     // no deadline set
 
     clock.fastForward(15000);

--- a/hadoop-hdds/interface-server/src/main/proto/ScmServerDatanodeHeartbeatProtocol.proto
+++ b/hadoop-hdds/interface-server/src/main/proto/ScmServerDatanodeHeartbeatProtocol.proto
@@ -343,6 +343,7 @@ message SCMCommandProto {
   // SCM is a leader. If running without Ratis, holds SCMContext.INVALID_TERM.
   optional int64 term = 15;
   optional string encodedToken = 16;
+  optional int64 deadlineMsSinceEpoch = 17;
 }
 
 /**

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ReplicationManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ReplicationManager.java
@@ -24,6 +24,7 @@ import org.apache.hadoop.hdds.conf.Config;
 import org.apache.hadoop.hdds.conf.ConfigGroup;
 import org.apache.hadoop.hdds.conf.ConfigType;
 import org.apache.hadoop.hdds.conf.ConfigurationSource;
+import org.apache.hadoop.hdds.conf.PostConstruct;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.ContainerReplicaProto;
@@ -788,10 +789,6 @@ public class ReplicationManager implements SCMService {
     }
 
     public void setCommandDeadlineFactor(double val) {
-      if (!(val > 0) || (val > 1)) {
-        throw new IllegalArgumentException(val
-            + " must be greater than 0 and less than equal to 1");
-      }
       commandDeadlineFactor = val;
     }
 
@@ -840,6 +837,15 @@ public class ReplicationManager implements SCMService {
             " is seamless to the client, but will affect read performance."
     )
     private int maintenanceRemainingRedundancy = 1;
+
+    @PostConstruct
+    public void validate() {
+      if (!(commandDeadlineFactor > 0) || (commandDeadlineFactor > 1)) {
+        throw new IllegalArgumentException("command.deadline.factor is set to "
+            + commandDeadlineFactor
+            + " and must be greater than 0 and less than equal to 1");
+      }
+    }
 
     public void setMaintenanceRemainingRedundancy(int redundancy) {
       this.maintenanceRemainingRedundancy = redundancy;

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMDatanodeProtocolServer.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMDatanodeProtocolServer.java
@@ -272,7 +272,7 @@ public class SCMDatanodeProtocolServer implements
       SCMHeartbeatRequestProto heartbeat) throws IOException, TimeoutException {
     List<SCMCommandProto> cmdResponses = new ArrayList<>();
     for (SCMCommand cmd : heartbeatDispatcher.dispatch(heartbeat)) {
-      cmdResponses.add(getCommandResponse(cmd));
+      cmdResponses.add(getCommandResponse(cmd, scm));
     }
     boolean auditSuccess = true;
     Map<String, String> auditMap = Maps.newHashMap();
@@ -305,8 +305,8 @@ public class SCMDatanodeProtocolServer implements
    * @throws IOException
    */
   @VisibleForTesting
-  public SCMCommandProto getCommandResponse(SCMCommand cmd)
-      throws IOException, TimeoutException {
+  public static SCMCommandProto getCommandResponse(SCMCommand cmd,
+      OzoneStorageContainerManager scm) throws IOException, TimeoutException {
     SCMCommandProto.Builder builder = SCMCommandProto.newBuilder()
         .setEncodedToken(cmd.getEncodedToken());
 

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMDatanodeProtocolServer.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMDatanodeProtocolServer.java
@@ -313,6 +313,9 @@ public class SCMDatanodeProtocolServer implements
     // In HA mode, it is the term of current leader SCM.
     // In non-HA mode, it is the default value 0.
     builder.setTerm(cmd.getTerm());
+    // The default deadline is 0, which means no deadline. Individual commands
+    // may have a deadline set.
+    builder.setDeadlineMsSinceEpoch(cmd.getDeadline());
 
     switch (cmd.getType()) {
     case reregisterCommand:

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestReplicationManager.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestReplicationManager.java
@@ -477,6 +477,15 @@ public class TestReplicationManager {
 
     replicationManager.sendDatanodeCommand(command, containerInfo, target);
 
+    // Ensure that the command deadline is set to current time
+    // + evenTime * factor
+    ReplicationManager.ReplicationManagerConfiguration rmConf = configuration
+        .getObject(ReplicationManager.ReplicationManagerConfiguration.class);
+    long expectedDeadline = clock.millis() +
+        Math.round(rmConf.getEventTimeout() *
+            rmConf.getCommandDeadlineFactor());
+    Assert.assertEquals(expectedDeadline, command.getDeadline());
+
     List<ContainerReplicaOp> ops = containerReplicaPendingOps.getPendingOps(
         containerInfo.containerID());
     Mockito.verify(eventPublisher).fireEvent(any(), any());

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/TestSCMDatanodeProtocolServer.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/TestSCMDatanodeProtocolServer.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with this
+ * work for additional information regarding copyright ownership.  The ASF
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.hadoop.hdds.scm;
+
+import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos;
+import org.apache.hadoop.hdds.scm.server.OzoneStorageContainerManager;
+import org.apache.hadoop.hdds.scm.server.SCMDatanodeProtocolServer;
+import org.apache.hadoop.ozone.protocol.commands.ReplicateContainerCommand;
+import org.junit.Assert;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.concurrent.TimeoutException;
+
+/**
+ * Test for StorageContainerDatanodeProtocolProtos.
+ */
+public class TestSCMDatanodeProtocolServer {
+
+  @Test
+  public void ensureTermAndDeadlineOnCommands()
+      throws IOException, TimeoutException {
+    OzoneStorageContainerManager scm =
+        Mockito.mock(OzoneStorageContainerManager.class);
+
+    ReplicateContainerCommand command = new ReplicateContainerCommand(1L,
+        Collections.emptyList());
+    command.setTerm(5L);
+    command.setDeadline(1234L);
+    StorageContainerDatanodeProtocolProtos.SCMCommandProto proto =
+        SCMDatanodeProtocolServer.getCommandResponse(command, scm);
+
+    Assert.assertEquals(StorageContainerDatanodeProtocolProtos.SCMCommandProto
+        .Type.replicateContainerCommand, proto.getCommandType());
+    Assert.assertEquals(5L, proto.getTerm());
+    Assert.assertEquals(1234L, proto.getDeadlineMsSinceEpoch());
+  }
+}

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/ClosedContainerReplicator.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/ClosedContainerReplicator.java
@@ -28,6 +28,7 @@ import org.apache.hadoop.hdds.scm.container.ContainerInfo;
 import org.apache.hadoop.hdds.scm.container.common.helpers.ContainerWithPipeline;
 import org.apache.hadoop.hdds.utils.HddsServerUtil;
 import org.apache.hadoop.hdfs.server.datanode.StorageLocation;
+import org.apache.hadoop.ozone.common.MonotonicClock;
 import org.apache.hadoop.ozone.container.common.helpers.ContainerMetrics;
 import org.apache.hadoop.ozone.container.common.impl.ContainerSet;
 import org.apache.hadoop.ozone.container.common.interfaces.Handler;
@@ -37,6 +38,7 @@ import org.apache.hadoop.ozone.container.keyvalue.TarContainerPacker;
 import org.apache.hadoop.ozone.container.ozoneimpl.ContainerController;
 import org.apache.hadoop.ozone.container.replication.ContainerReplicator;
 import org.apache.hadoop.ozone.container.replication.DownloadAndImportReplicator;
+import org.apache.hadoop.ozone.container.replication.ReplicationServer;
 import org.apache.hadoop.ozone.container.replication.ReplicationSupervisor;
 import org.apache.hadoop.ozone.container.replication.ReplicationTask;
 import org.apache.hadoop.ozone.container.replication.SimpleContainerDownloader;
@@ -48,6 +50,7 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
@@ -203,7 +206,11 @@ public class ClosedContainerReplicator extends BaseFreonGenerator implements
             new SimpleContainerDownloader(conf, null),
             new TarContainerPacker());
 
-    supervisor = new ReplicationSupervisor(containerSet, replicator, 10);
+    ReplicationServer.ReplicationConfig replicationConfig
+        = conf.getObject(ReplicationServer.ReplicationConfig.class);
+    supervisor = new ReplicationSupervisor(containerSet, null,
+        replicator, replicationConfig,
+        new MonotonicClock(ZoneId.systemDefault()));
   }
 
   private void replicateContainer(long counter) throws Exception {

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/ClosedContainerReplicator.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/ClosedContainerReplicator.java
@@ -42,6 +42,7 @@ import org.apache.hadoop.ozone.container.replication.ReplicationServer;
 import org.apache.hadoop.ozone.container.replication.ReplicationSupervisor;
 import org.apache.hadoop.ozone.container.replication.ReplicationTask;
 import org.apache.hadoop.ozone.container.replication.SimpleContainerDownloader;
+import org.apache.hadoop.ozone.protocol.commands.ReplicateContainerCommand;
 import org.jetbrains.annotations.NotNull;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Option;
@@ -126,8 +127,9 @@ public class ClosedContainerReplicator extends BaseFreonGenerator implements
         //if datanode is specified, replicate only container if it has a
         //replica.
         if (datanode.isEmpty() || datanodeUUIDs.contains(datanode)) {
-          replicationTasks.add(new ReplicationTask(container.getContainerID(),
-              datanodesWithContainer));
+          replicationTasks.add(new ReplicationTask(
+              new ReplicateContainerCommand(container.getContainerID(),
+                  datanodesWithContainer)));
         }
       }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

The new and old replication manager sends commands to the datanodes. If the command has not processed on the datanodes within the replicationManager event.timeout, RM assumes the command has failed for some reason, and may send another one to the same or a different host.

It makes sense to drop any command not processed on the datanode slightly before ReplicationManager gives up on it. Especially with delete container commands, we don't want to have two or more deletes pending in the system for the same container, when RM thinks there is only 1.

To facilitate dropping the commands, we can add a deadline to all commands. Only for commands we want to enforce a deadline on, we can set the deadline in SCM and check for it on the DN side. The deadline is the epoch time that the command should be processed by, otherwise the DN should ignore it. A deadline of zero is the default, and means no deadline set.

This change ensure that all commands sent to a datanode from RM will have a deadline set to 0.9 * event.timeout. On the datanode side, we only enforce the deadline on ReplicationContainer, DeleteContainer and ECReconstruction commands.

This has turned into quite a large change, but it is split into individual commits for each stage so they can be reviewed in isolation.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-7618

## How was this patch tested?

Various new unit tests added.
