### PR TITLE
HDDS-7584. Addition of new OM node expels itself from the Ratis ring after restart

### DIFF
--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
@@ -1775,9 +1775,10 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
     for (String omNodeId : decommissionedOMs) {
       if (isCurrentNode(omNodeId)) {
         // Decommissioning Node should not receive the configuration change
-        // request. Shut it down.
-        String errorMsg = "Shutting down as OM has been decommissioned.";
-        LOG.warn("Fatal Error: {}", errorMsg);
+        // request. It may receive the request if the newly added node id or
+        // the decommissioned node id is same.
+        LOG.warn("New OM node Id: {} is same as decommissioned earlier",
+            omNodeId);
       } else {
         // Remove decommissioned node from peer list (which internally
         // removed from Ratis peer list too)

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
@@ -1559,6 +1559,7 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
 
     if (omState == State.BOOTSTRAPPING) {
       bootstrap(omNodeDetails);
+      exitManager.exitSystem(0, "Bootstrapped Successfully", LOG);
     }
 
     omState = State.RUNNING;
@@ -1776,8 +1777,7 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
         // Decommissioning Node should not receive the configuration change
         // request. Shut it down.
         String errorMsg = "Shutting down as OM has been decommissioned.";
-        LOG.error("Fatal Error: {}", errorMsg);
-        exitManager.forceExit(1, errorMsg, LOG);
+        LOG.warn("Fatal Error: {}", errorMsg);
       } else {
         // Remove decommissioned node from peer list (which internally
         // removed from Ratis peer list too)

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
@@ -1559,7 +1559,6 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
 
     if (omState == State.BOOTSTRAPPING) {
       bootstrap(omNodeDetails);
-      exitManager.exitSystem(0, "Bootstrapped Successfully", LOG);
     }
 
     omState = State.RUNNING;


### PR DESCRIPTION
## What changes were proposed in this pull request?

When we add a new OM node right after decommissioning, the OM process on the new node gets terminated immediately on the restart. The new OM node is unable to join the ratis ring. 

This is because OM applies all the previous transactions which also includes the transaction to decommission(removal of a node from peer list) which causes termination of the newly added OM process node.
The assumption here is that the OM node id of the newly added node is the same as that of the decommissioned node.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-7584

## How was this patch tested?

Tested Manually
