### PR TITLE
HDDS-7630. Show detailed OMResponse when OzoneManagerDoubleBuffer terminates

### DIFF
--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/OzoneManagerDoubleBuffer.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/OzoneManagerDoubleBuffer.java
@@ -391,12 +391,7 @@ public final class OzoneManagerDoubleBuffer {
       } catch (IOException ex) {
         terminate(ex, omResponse.get());
       } catch (Throwable t) {
-        StringBuilder s = new StringBuilder("OMDoubleBuffer flush thread " +
-            Thread.currentThread().getName() + " encountered Throwable error");
-        if (omResponse.get() != null) {
-          s.append(" when handling OMRequest: ").append(omResponse.get());
-        }
-        ExitUtils.terminate(2, s.toString(), t, LOG);
+        terminate(t, omResponse.get(), 2);
       }
     }
   }
@@ -486,14 +481,17 @@ public final class OzoneManagerDoubleBuffer {
 
   }
 
-  private void terminate(IOException ex, OMResponse omResponse) {
+  private void terminate(Throwable t, OMResponse omResponse) {
+    terminate(t, omResponse, 1);
+  }
+  private void terminate(Throwable t, OMResponse omResponse, int status) {
     StringBuilder message = new StringBuilder(
         "During flush to DB encountered error in " +
         "OMDoubleBuffer flush thread " + Thread.currentThread().getName());
     if (omResponse != null) {
       message.append(" when handling OMRequest: ").append(omResponse);
     }
-    ExitUtils.terminate(1, message.toString(), ex, LOG);
+    ExitUtils.terminate(status, message.toString(), t, LOG);
   }
 
   /**

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/OzoneManagerDoubleBuffer.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/OzoneManagerDoubleBuffer.java
@@ -291,9 +291,9 @@ public final class OzoneManagerDoubleBuffer {
               } catch (IOException ex) {
                 // During Adding to RocksDB batch entry got an exception.
                 // We should terminate the OM.
-                terminate(ex, omResponse.get());
+                terminate(ex, 1, omResponse.get());
               } catch (Throwable t) {
-                terminate(t, omResponse.get(), 2);
+                terminate(t, 2, omResponse.get());
               }
             });
             // Finished omResponse processing, set omResponse to null;
@@ -484,13 +484,10 @@ public final class OzoneManagerDoubleBuffer {
   }
 
   private void terminate(Throwable t, int status) {
-    terminate(t, null, status);
+    terminate(t, status, null);
   }
 
-  private void terminate(Throwable t, OMResponse omResponse) {
-    terminate(t, omResponse, 1);
-  }
-  private void terminate(Throwable t, OMResponse omResponse, int status) {
+  private void terminate(Throwable t, int status, OMResponse omResponse) {
     StringBuilder message = new StringBuilder(
         "During flush to DB encountered error in " +
         "OMDoubleBuffer flush thread " + Thread.currentThread().getName());


### PR DESCRIPTION
## What changes were proposed in this pull request?

When OzoneManagerDoubleBuffer fails due to exception, it's better to have detailed information of the OMResponse for debugging.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-7630

## How was this patch tested?

no test.

Some example outputs:

* Create bucket
```
cmdType: CreateBucket
traceID: ""
success: true
status: OK
createBucketResponse {
}
```
* Create key
```
cmdType: CreateKey
traceID: ""
success: true
status: OK
createKeyResponse {
  keyInfo {
    volumeName: "vol1"
    bucketName: "bucket1"
    keyName: "key1"
    dataSize: 3879
    type: RATIS
    factor: THREE
    keyLocationList {
      version: 0
      keyLocations {
        blockID {
          containerBlockID {
            containerID: 1
            localID: 109611004723200001
          }
          blockCommitSequenceId: 0
        }
        offset: 0
        length: 268435456
        createVersion: 0
        pipeline {
          members {
            uuid: "c6d47952-d622-4723-b28b-a6ff48fc1fe0"
            ipAddress: "172.21.0.8"
            hostName: "ozone-ha_datanode_2.ozone-ha_default"
            ports {
              name: "REPLICATION"
              value: 9886
            }
            ports {
              name: "RATIS"
              value: 9858
            }
            ports {
              name: "RATIS_ADMIN"
              value: 9857
            }
            ports {
              name: "RATIS_SERVER"
              value: 9856
            }
            ports {
              name: "STANDALONE"
              value: 9859
            }
            networkName: "c6d47952-d622-4723-b28b-a6ff48fc1fe0"
            networkLocation: "/default-rack"
            persistedOpState: IN_SERVICE
            persistedOpStateExpiry: 0
            uuid128 {
              mostSigBits: -4119534362450311389
              leastSigBits: -5581183697824243744
            }
          }
          members {
            uuid: "5a352379-c80a-4baa-aac7-fba7ea627a93"
            ipAddress: "172.21.0.4"
            hostName: "ozone-ha_datanode_4.ozone-ha_default"
            ports {
              name: "REPLICATION"
              value: 9886
            }
            ports {
              name: "RATIS"
              value: 9858
            }
            ports {
              name: "RATIS_ADMIN"
              value: 9857
            }
            ports {
              name: "RATIS_SERVER"
              value: 9856
            }
            ports {
              name: "STANDALONE"
              value: 9859
            }
            networkName: "5a352379-c80a-4baa-aac7-fba7ea627a93"
            networkLocation: "/default-rack"
            persistedOpState: IN_SERVICE
            persistedOpStateExpiry: 0
            uuid128 {
              mostSigBits: 6500140643133311914
              leastSigBits: -6140662868285949293
            }
          }
          members {
            uuid: "bc5e9247-5425-4f3a-a46f-22f449a0c94e"
            ipAddress: "172.21.0.3"
            hostName: "ozone-ha_datanode_3.ozone-ha_default"
            ports {
              name: "REPLICATION"
              value: 9886
            }
            ports {
              name: "RATIS"
              value: 9858
            }
            ports {
              name: "RATIS_ADMIN"
              value: 9857
            }
            ports {
              name: "RATIS_SERVER"
              value: 9856
            }
            ports {
              name: "STANDALONE"
              value: 9859
            }
            networkName: "bc5e9247-5425-4f3a-a46f-22f449a0c94e"
            networkLocation: "/default-rack"
            persistedOpState: IN_SERVICE
            persistedOpStateExpiry: 0
            uuid128 {
              mostSigBits: -4873296911716233414
              leastSigBits: -6598016496471848626
            }
          }
          state: PIPELINE_OPEN
          type: RATIS
          factor: THREE
          id {
            id: "38cafb50-39f9-407c-948b-fb8c8dfa1c0a"
            uuid128 {
              mostSigBits: 4092359533408108668
              leastSigBits: -7742818553237464054
            }
          }
          leaderID: "bc5e9247-5425-4f3a-a46f-22f449a0c94e"
          creationTimeStamp: 1671504330972
          suggestedLeaderID {
            mostSigBits: -4873296911716233414
            leastSigBits: -6598016496471848626
          }
          memberReplicaIndexes: 0
          memberReplicaIndexes: 0
          memberReplicaIndexes: 0
          leaderID128 {
            mostSigBits: -4873296911716233414
            leastSigBits: -6598016496471848626
          }
        }
        partNumber: 0
      }
      isMultipartKey: false
    }
    creationTime: 1671504595449
    modificationTime: 1671504595449
    latestVersion: 0
    acls {
      type: USER
      name: "hadoop"
      rights: "\200"
      aclScope: ACCESS
    }
    acls {
      type: GROUP
      name: "hadoop"
      rights: "\200"
      aclScope: ACCESS
    }
    objectID: 9223372036854778112
    updateID: 9
    parentID: 0
    isFile: false
  }
  ID: 109543725169115136
  openVersion: 0
}

```
