### PR TITLE
HDDS-7631. Log format error on quotas when exceeding the space quota

### DIFF
--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyRequest.java
@@ -528,7 +528,7 @@ public abstract class OMKeyRequest extends OMClientRequest {
       long quotaInBytes = omBucketInfo.getQuotaInBytes();
       if (quotaInBytes - usedBytes < allocateSize) {
         throw new OMException("The DiskSpace quota of bucket:"
-            + omBucketInfo.getBucketName() + "exceeded: quotaInBytes: "
+            + omBucketInfo.getBucketName() + " exceeded: quotaInBytes: "
             + quotaInBytes + " Bytes but diskspace consumed: " + (usedBytes
             + allocateSize) + " Bytes.",
             OMException.ResultCodes.QUOTA_EXCEEDED);

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyRequest.java
@@ -528,7 +528,7 @@ public abstract class OMKeyRequest extends OMClientRequest {
       long quotaInBytes = omBucketInfo.getQuotaInBytes();
       if (quotaInBytes - usedBytes < allocateSize) {
         throw new OMException("The DiskSpace quota of bucket:"
-            + omBucketInfo.getBucketName() + " exceeded: quotaInBytes: "
+            + omBucketInfo.getBucketName() + " exceeded quotaInBytes: "
             + quotaInBytes + " Bytes but diskspace consumed: " + (usedBytes
             + allocateSize) + " Bytes.",
             OMException.ResultCodes.QUOTA_EXCEEDED);


### PR DESCRIPTION
## What changes were proposed in this pull request?

Change error message when DiskSpace quota of bucket is exceeded.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-7631

## How was this patch tested?

Manual test.

## How to recreate behavior described in the ticket?

1. `mvn clean install -DskipTests -DskipShade`
2. `cd hadoop-ozone/dist/target/ozone-*/compose/ozone`
3. `docker-compose up -d --scale datanode=3`
4. `docker exec -it ozone_om_1 /bin/bash`
a. `ozone sh volume create /vol`
b. `ozone sh bucket create /vol/buc`
c. `ozone sh bucket setquota --space-quota 610929 /vol/buc`
d. `ozone fs -put README.md ofs://om/vol/buc/readme.md`
