### PR TITLE
HDDS-7633. Compile error with Java 11: package com.sun.jmx.mbeanserver is not visible

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -147,7 +147,7 @@ jobs:
           distribution: 'temurin'
           java-version: ${{ matrix.java }}
       - name: Compile Ozone using Java ${{ matrix.java }}
-        run: hadoop-ozone/dev-support/checks/build.sh -Dskip.npx -Dskip.installnpx
+        run: hadoop-ozone/dev-support/checks/build.sh -Dskip.npx -Dskip.installnpx -Djavac.version=${{ matrix.java }}
       - name: Delete temporary build artifacts before caching
         run: |
           #Never cache local artifacts

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/HddsDatanodeService.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/HddsDatanodeService.java
@@ -71,7 +71,6 @@ import org.apache.hadoop.util.Time;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
-import com.sun.jmx.mbeanserver.Introspector;
 
 import static org.apache.hadoop.hdds.security.x509.certificate.utils.CertificateCodec.getX509Certificate;
 import static org.apache.hadoop.hdds.security.x509.certificates.utils.CertificateSignRequest.getEncodedString;
@@ -154,7 +153,6 @@ public class HddsDatanodeService extends GenericCli implements ServicePlugin {
     try {
       OzoneNetUtils.disableJvmNetworkAddressCacheIfRequired(
               new OzoneConfiguration());
-      Introspector.checkCompliance(DNMXBeanImpl.class);
       HddsDatanodeService hddsDatanodeService =
           createHddsDatanodeService(args, true);
       hddsDatanodeService.run(args);


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fix error when compiling Ozone for target Java version 11:

```
$ mvn -Djavac.version=11 -DskipTests clean package
...
[ERROR] hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/HddsDatanodeService.java:[74,19] package com.sun.jmx.mbeanserver is not visible
[ERROR]   (package com.sun.jmx.mbeanserver is declared in module java.management, which does not export it)
```

Change _compile_ CI check so that it, in addition to using JDK of the specified version, also targets the same Java version.  This way we can catch such errors in CI.

https://issues.apache.org/jira/browse/HDDS-7633

## How was this patch tested?

```
$ mvn -Djavac.version=11 -DskipTests clean package
...
[INFO] BUILD SUCCESS
```

https://github.com/adoroszlai/hadoop-ozone/actions/runs/3687864892/jobs/6242414957