### PR TITLE
HDDS-7008. Mark TestOzoneHARatisLogParser as flaky

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/parser/TestOzoneHARatisLogParser.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/parser/TestOzoneHARatisLogParser.java
@@ -30,18 +30,17 @@ import org.apache.hadoop.ozone.MiniOzoneCluster;
 import org.apache.hadoop.ozone.segmentparser.OMRatisLogParser;
 import org.apache.hadoop.ozone.segmentparser.SCMRatisLogParser;
 import org.apache.ozone.test.GenericTestUtils;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.apache.ozone.test.tag.Flaky;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.PrintStream;
 import java.util.UUID;
-
-import org.junit.Rule;
-import org.junit.rules.Timeout;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.apache.hadoop.hdds.HddsConfigKeys.OZONE_METADATA_DIRS;
@@ -49,20 +48,16 @@ import static org.apache.hadoop.hdds.HddsConfigKeys.OZONE_METADATA_DIRS;
 /**
  * Test Ozone OM and SCM HA Ratis log parser.
  */
-public class TestOzoneHARatisLogParser {
-
-  /**
-    * Set a timeout for each test.
-    */
-  @Rule
-  public Timeout timeout = Timeout.seconds(300);
+@Flaky("HDDS-7008")
+@Timeout(300)
+class TestOzoneHARatisLogParser {
 
   private MiniOzoneHAClusterImpl cluster = null;
   private final ByteArrayOutputStream out = new ByteArrayOutputStream();
   private final ByteArrayOutputStream err = new ByteArrayOutputStream();
 
-  @Before
-  public void setup() throws Exception {
+  @BeforeEach
+  void setup() throws Exception {
     String clusterId = UUID.randomUUID().toString();
     String scmId = UUID.randomUUID().toString();
     String omServiceId = "omServiceId1";
@@ -91,8 +86,8 @@ public class TestOzoneHARatisLogParser {
         UUID.randomUUID().toString());
   }
 
-  @After
-  public void destroy() throws Exception {
+  @AfterEach
+  void destroy() throws Exception {
     if (cluster != null) {
       cluster.shutdown();
     }
@@ -102,7 +97,7 @@ public class TestOzoneHARatisLogParser {
   }
 
   @Test
-  public void testRatisLogParsing() throws Exception {
+  void testRatisLogParsing() throws Exception {
     OzoneConfiguration ozoneConfiguration =
         cluster.getOMLeader().getConfiguration();
 
@@ -114,20 +109,20 @@ public class TestOzoneHARatisLogParser {
 
     File omMetaDir = new File(ozoneConfiguration.get(OZONE_METADATA_DIRS),
         "ratis");
-    Assert.assertTrue(omMetaDir.isDirectory());
+    Assertions.assertTrue(omMetaDir.isDirectory());
 
     String[] ratisDirs = omMetaDir.list();
-    Assert.assertNotNull(ratisDirs);
-    Assert.assertEquals(1, ratisDirs.length);
+    Assertions.assertNotNull(ratisDirs);
+    Assertions.assertEquals(1, ratisDirs.length);
 
     File groupDir = new File(omMetaDir, ratisDirs[0]);
 
-    Assert.assertNotNull(groupDir);
-    Assert.assertTrue(groupDir.isDirectory());
+    Assertions.assertNotNull(groupDir);
+    Assertions.assertTrue(groupDir.isDirectory());
     File currentDir = new File(groupDir, "current");
     File logFile = new File(currentDir, "log_inprogress_0");
     GenericTestUtils.waitFor(logFile::exists, 100, 15000);
-    Assert.assertTrue(logFile.isFile());
+    Assertions.assertTrue(logFile.isFile());
 
     OMRatisLogParser omRatisLogParser = new OMRatisLogParser();
     omRatisLogParser.setSegmentFile(logFile);
@@ -136,27 +131,27 @@ public class TestOzoneHARatisLogParser {
 
     // Not checking total entry count, because of not sure of exact count of
     // metadata entry changes.
-    Assert.assertTrue(out.toString(UTF_8.name())
+    Assertions.assertTrue(out.toString(UTF_8.name())
         .contains("Num Total Entries:"));
     out.reset();
 
     // Now check for SCM.
     File scmMetadataDir =
         new File(RatisUtil.getRatisStorageDir(leaderSCMConfig));
-    Assert.assertTrue(scmMetadataDir.isDirectory());
+    Assertions.assertTrue(scmMetadataDir.isDirectory());
 
     ratisDirs = scmMetadataDir.list();
-    Assert.assertNotNull(ratisDirs);
-    Assert.assertEquals(1, ratisDirs.length);
+    Assertions.assertNotNull(ratisDirs);
+    Assertions.assertEquals(1, ratisDirs.length);
 
     groupDir = new File(scmMetadataDir, ratisDirs[0]);
 
-    Assert.assertNotNull(groupDir);
-    Assert.assertTrue(groupDir.isDirectory());
+    Assertions.assertNotNull(groupDir);
+    Assertions.assertTrue(groupDir.isDirectory());
     currentDir = new File(groupDir, "current");
     logFile = new File(currentDir, "log_inprogress_1");
     GenericTestUtils.waitFor(logFile::exists, 100, 15000);
-    Assert.assertTrue(logFile.isFile());
+    Assertions.assertTrue(logFile.isFile());
 
     SCMRatisLogParser scmRatisLogParser = new SCMRatisLogParser();
     scmRatisLogParser.setSegmentFile(logFile);
@@ -164,7 +159,7 @@ public class TestOzoneHARatisLogParser {
 
     // Not checking total entry count, because of not sure of exact count of
     // metadata entry changes.
-    Assert.assertTrue(out.toString(UTF_8.name())
+    Assertions.assertTrue(out.toString(UTF_8.name())
         .contains("Num Total Entries:"));
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Convert `TestOzoneHARatisLogParser` to JUnit5 and mark it as `@Flaky`.

https://issues.apache.org/jira/browse/HDDS-7008

## How was this patch tested?

Verified that `TestOzoneHARatisLogParser` is run as part of _integration (flaky)_:
https://github.com/adoroszlai/hadoop-ozone/actions/runs/3688403684/jobs/6243167414#step:6:3148