### PR TITLE
HDDS-6650. S3MultipartUpload support update bucket usedNamespace.

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestOzoneClientMultipartUploadWithFSO.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestOzoneClientMultipartUploadWithFSO.java
@@ -309,6 +309,12 @@ public class TestOzoneClientMultipartUploadWithFSO {
     // comparing part names and large file uploads work using aws cp.
     Assert.assertEquals("Part names should be same", partName,
         commitUploadPartInfo.getPartName());
+
+    // old part bytes written needs discard and have only
+    // new part bytes in quota for this bucket
+    long byteWritten = "name".length() * 3; // data written with replication
+    Assert.assertEquals(volume.getBucket(bucketName).getUsedBytes(),
+        byteWritten);
   }
 
   @Test

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3MultipartUploadCommitPartRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3MultipartUploadCommitPartRequest.java
@@ -229,8 +229,12 @@ public class S3MultipartUploadCommitPartRequest extends OMKeyRequest {
       omBucketInfo = getBucketInfo(omMetadataManager, volumeName, bucketName);
 
       long correctedSpace = omKeyInfo.getReplicatedSize();
-      // TODO: S3MultipartUpload did not check quota and did not add nameSpace,
-      //  we need to fix these issues in HDDS-6650.
+      if (null != oldPartKeyInfo) {
+        OmKeyInfo partKeyToBeDeleted =
+            OmKeyInfo.getFromProtobuf(oldPartKeyInfo.getPartKeyInfo());
+        correctedSpace -= partKeyToBeDeleted.getReplicatedSize();
+      }
+      checkBucketQuotaInBytes(omBucketInfo, correctedSpace);
       omBucketInfo.incrUsedBytes(correctedSpace);
 
       omResponse.setCommitMultiPartUploadResponse(


### PR DESCRIPTION
## What changes were proposed in this pull request?

1. for old part getting overwritten, quota cleanup for space
2. space-quota validation

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-6650

## How was this patch tested?

Patch is tested using integration-test and validation added for quota
