### PR TITLE
HDDS-7627. EC: Bug fix for calculating Misreplication Count

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/placement/algorithms/ContainerPlacementStatusDefault.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/placement/algorithms/ContainerPlacementStatusDefault.java
@@ -81,7 +81,7 @@ public class ContainerPlacementStatusDefault
     }
     return Math.max(requiredRacks - currentRacks,
             rackReplicaCnts.stream().mapToInt(
-                    cnt -> Math.max(maxReplicasPerRack - cnt, 0)).sum());
+                    cnt -> Math.max(cnt - maxReplicasPerRack, 0)).sum());
   }
 
   @Override

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/placement/algorithms/ContainerPlacementStatusDefault.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/placement/algorithms/ContainerPlacementStatusDefault.java
@@ -45,9 +45,9 @@ public class ContainerPlacementStatusDefault
     this.rackReplicaCnts = rackReplicaCnts;
   }
 
-  public ContainerPlacementStatusDefault(int requiredRacks, int currentRacks,
+  public ContainerPlacementStatusDefault(int currentRacks, int requiredRacks,
       int totalRacks) {
-    this(requiredRacks, currentRacks, totalRacks, 1,
+    this(currentRacks, requiredRacks, totalRacks, 1,
          currentRacks == 0 ? Collections.emptyList()
                  : Collections.nCopies(currentRacks, 1));
   }
@@ -65,9 +65,9 @@ public class ContainerPlacementStatusDefault
     if (isPolicySatisfied()) {
       return null;
     }
-    if (currentRacks < Math.min(requiredRacks, totalRacks)) {
+    if (currentRacks < expectedPlacementCount()) {
       return "The container is mis-replicated as it is on " + currentRacks +
-              " racks but should be on " + requiredRacks + " racks.";
+              " racks but should be on " + expectedPlacementCount() + " racks.";
     }
     return "The container is mis-replicated as max number of replicas per rack "
             + "is " + maxReplicasPerRack + " but number of replicas per rack" +
@@ -79,7 +79,7 @@ public class ContainerPlacementStatusDefault
     if (isPolicySatisfied()) {
       return 0;
     }
-    return Math.max(requiredRacks - currentRacks,
+    return Math.max(expectedPlacementCount() - currentRacks,
             rackReplicaCnts.stream().mapToInt(
                     cnt -> Math.max(cnt - maxReplicasPerRack, 0)).sum());
   }

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/placement/algorithms/TestContainerPlacementStatusDefault.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/placement/algorithms/TestContainerPlacementStatusDefault.java
@@ -19,6 +19,9 @@
 package org.apache.hadoop.hdds.scm.container.placement.algorithms;
 
 import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -48,6 +51,10 @@ public class TestContainerPlacementStatusDefault {
     stat = new ContainerPlacementStatusDefault(3, 2, 3);
     assertTrue(stat.isPolicySatisfied());
     assertEquals(0, stat.misReplicationCount());
+
+    stat = new ContainerPlacementStatusDefault(3, 2, 3);
+    assertTrue(stat.isPolicySatisfied());
+    assertEquals(0, stat.misReplicationCount());
   }
 
   @Test
@@ -60,11 +67,24 @@ public class TestContainerPlacementStatusDefault {
     // Zero rack, but need 2 - shouldn't really happen in practice
     stat = new ContainerPlacementStatusDefault(0, 2, 1);
     assertFalse(stat.isPolicySatisfied());
-    assertEquals(2, stat.misReplicationCount());
+    assertEquals(1, stat.misReplicationCount());
 
     stat = new ContainerPlacementStatusDefault(2, 3, 3);
     assertFalse(stat.isPolicySatisfied());
     assertEquals(1, stat.misReplicationCount());
+
+    stat = new ContainerPlacementStatusDefault(2, 4, 3, 1, Arrays.asList(1, 3));
+    assertFalse(stat.isPolicySatisfied());
+    assertEquals(2, stat.misReplicationCount());
+
+    stat = new ContainerPlacementStatusDefault(1, 4, 3, 1, Arrays.asList(1, 2));
+    assertFalse(stat.isPolicySatisfied());
+    assertEquals(2, stat.misReplicationCount());
+
+    stat = new ContainerPlacementStatusDefault(2, 2, 3, 2, Arrays.asList(3, 1));
+    assertFalse(stat.isPolicySatisfied());
+    assertEquals(1, stat.misReplicationCount());
+
   }
 
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Currently the calculation of misreplication count for max replicas per rack is done wrong, the signs have been swapped thus reporting negative value as the misreplication count.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-7627


## How was this patch tested?
Unit Tests