### PR TITLE
HDDS-7647. [snapshot] Add unit-testcases for Ozone Snapshot List API

### DIFF
--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestOmMetadataManager.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestOmMetadataManager.java
@@ -732,4 +732,42 @@ public class TestOmMetadataManager {
         arguments("vol1", "nonexistentBucket", BUCKET_NOT_FOUND)
     );
   }
+
+  @Test
+  public void testListSnapshotDoesNotListOtherBucketSnapshots() throws Exception {
+    String vol1 = "vol1";
+    String bucket1 = "bucket1";
+    String bucket2 = "bucket2";
+
+    OMRequestTestUtils.addVolumeToDB(vol1, omMetadataManager);
+    addBucketsToCache(vol1, bucket1);
+    addBucketsToCache(vol1, bucket2);
+    String snapshotName1 = "snapshot1-";
+    String snapshotName2 = "snapshot2-";
+
+    for (int i = 1; i <= 2; i++) {
+      OMRequestTestUtils.addSnapshotToTable(vol1, bucket1,
+              snapshotName1 + i, omMetadataManager);
+    }
+
+    for (int i = 1; i <= 5; i++) {
+      OMRequestTestUtils.addSnapshotToTable(vol1, bucket2,
+              snapshotName2 + i, omMetadataManager);
+    }
+
+    //Test listing snapshots only lists snapshots of specified bucket
+    List<SnapshotInfo> snapshotInfos1 = omMetadataManager.listSnapshot(vol1,
+            bucket1);
+    assertEquals(2, snapshotInfos1.size());
+    for (SnapshotInfo snapshotInfo : snapshotInfos1) {
+      assertTrue(snapshotInfo.getName().startsWith(snapshotName1));
+    }
+
+    List<SnapshotInfo> snapshotInfos2 = omMetadataManager.listSnapshot(vol1,
+            bucket2);
+    assertEquals(5, snapshotInfos2.size());
+    for (SnapshotInfo snapshotInfo : snapshotInfos2) {
+      assertTrue(snapshotInfo.getName().startsWith(snapshotName2));
+    }
+  }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Added unit-testcases for Snapshot List API - `TestOmMetadataManager / testListSnapshotDoesNotListOtherBucketSnapshots`

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-7647

## How was this patch tested?

Added testcases in file - `hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestOmMetadataManager.java`
mvn -Dtest=TestOmMetadataManager test
```[INFO] -------------------------------------------------------
[INFO]  T E S T S
[INFO] -------------------------------------------------------
[INFO] Running org.apache.hadoop.ozone.om.TestOmMetadataManager
[INFO] Tests run: 14, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 25.162 s - in org.apache.hadoop.ozone.om.TestOmMetadataManager
[INFO]
[INFO] Results:
[INFO]
[INFO] Tests run: 14, Failures: 0, Errors: 0, Skipped: 0```
