### PR TITLE
HDDS-7644. S3 multipart upload does not update quota namespace for missing parents

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestOzoneClientMultipartUploadWithFSO.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestOzoneClientMultipartUploadWithFSO.java
@@ -432,6 +432,8 @@ public class TestOzoneClientMultipartUploadWithFSO {
 
     Assert.assertNotNull(omMultipartInfo.getUploadID());
 
+    Assert.assertEquals(volume.getBucket(bucketName).getUsedNamespace(), 4);
+
     String uploadID = omMultipartInfo.getUploadID();
 
     // upload part 1.

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3InitiateMultipartUploadRequestWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3InitiateMultipartUploadRequestWithFSO.java
@@ -193,6 +193,10 @@ public class S3InitiateMultipartUploadRequestWithFSO
               OMPBHelper.convert(keyArgs.getFileEncryptionInfo()) : null)
           .setParentObjectID(pathInfoFSO.getLastKnownParentId())
           .build();
+      
+      // validate and update namespace for missing parent directory
+      checkBucketQuotaInNamespace(bucketInfo, missingParentInfos.size());
+      bucketInfo.incrUsedNamespace(missingParentInfos.size());
 
       // Add cache entries for the prefix directories.
       // Skip adding for the file key itself, until Key Commit.
@@ -218,7 +222,8 @@ public class S3InitiateMultipartUploadRequestWithFSO
                       .setKeyName(keyName)
                       .setMultipartUploadID(keyArgs.getMultipartUploadID()))
                   .build(), multipartKeyInfo, omKeyInfo, multipartKey,
-              missingParentInfos, getBucketLayout(), volumeId, bucketId);
+              missingParentInfos, getBucketLayout(), volumeId, bucketId,
+              bucketInfo);
 
       result = Result.SUCCESS;
     } catch (IOException ex) {

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3InitiateMultipartUploadRequestWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3InitiateMultipartUploadRequestWithFSO.java
@@ -159,8 +159,8 @@ public class S3InitiateMultipartUploadRequestWithFSO
       // care of in the final complete multipart upload. AWS S3 behavior is
       // also like this, even when key exists in a bucket, user can still
       // initiate MPU.
-      final OmBucketInfo bucketInfo = omMetadataManager.getBucketTable()
-          .get(omMetadataManager.getBucketKey(volumeName, bucketName));
+      final OmBucketInfo bucketInfo = getBucketInfo(omMetadataManager,
+          volumeName, bucketName);
       final ReplicationConfig replicationConfig = OzoneConfigUtil
           .resolveReplicationConfigPreference(keyArgs.getType(),
               keyArgs.getFactor(), keyArgs.getEcReplicationConfig(),
@@ -195,8 +195,10 @@ public class S3InitiateMultipartUploadRequestWithFSO
           .build();
       
       // validate and update namespace for missing parent directory
-      checkBucketQuotaInNamespace(bucketInfo, missingParentInfos.size());
-      bucketInfo.incrUsedNamespace(missingParentInfos.size());
+      if (null != missingParentInfos) {
+        checkBucketQuotaInNamespace(bucketInfo, missingParentInfos.size());
+        bucketInfo.incrUsedNamespace(missingParentInfos.size());
+      }
 
       // Add cache entries for the prefix directories.
       // Skip adding for the file key itself, until Key Commit.
@@ -223,7 +225,7 @@ public class S3InitiateMultipartUploadRequestWithFSO
                       .setMultipartUploadID(keyArgs.getMultipartUploadID()))
                   .build(), multipartKeyInfo, omKeyInfo, multipartKey,
               missingParentInfos, getBucketLayout(), volumeId, bucketId,
-              bucketInfo);
+              bucketInfo.copyObject());
 
       result = Result.SUCCESS;
     } catch (IOException ex) {

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/s3/multipart/S3InitiateMultipartUploadResponseWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/s3/multipart/S3InitiateMultipartUploadResponseWithFSO.java
@@ -22,6 +22,7 @@ package org.apache.hadoop.ozone.om.response.s3.multipart;
 import org.apache.hadoop.hdds.utils.db.BatchOperation;
 import org.apache.hadoop.ozone.om.OMMetadataManager;
 import org.apache.hadoop.ozone.om.helpers.BucketLayout;
+import org.apache.hadoop.ozone.om.helpers.OmBucketInfo;
 import org.apache.hadoop.ozone.om.helpers.OmDirectoryInfo;
 import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
 import org.apache.hadoop.ozone.om.helpers.OmMultipartKeyInfo;
@@ -48,6 +49,7 @@ public class S3InitiateMultipartUploadResponseWithFSO extends
   private String mpuDBKey;
   private long volumeId;
   private long bucketId;
+  private OmBucketInfo omBucketInfo;
 
   @SuppressWarnings("parameternumber")
   public S3InitiateMultipartUploadResponseWithFSO(
@@ -56,12 +58,13 @@ public class S3InitiateMultipartUploadResponseWithFSO extends
       @Nonnull OmKeyInfo omKeyInfo, @Nonnull String mpuDBKey,
       @Nonnull List<OmDirectoryInfo> parentDirInfos,
       @Nonnull BucketLayout bucketLayout, @Nonnull long volumeId,
-      @Nonnull long bucketId) {
+      @Nonnull long bucketId, @Nonnull OmBucketInfo omBucketInfo) {
     super(omResponse, omMultipartKeyInfo, omKeyInfo, bucketLayout);
     this.parentDirInfos = parentDirInfos;
     this.mpuDBKey = mpuDBKey;
     this.volumeId = volumeId;
     this.bucketId = bucketId;
+    this.omBucketInfo = omBucketInfo;
   }
 
   /**
@@ -89,6 +92,13 @@ public class S3InitiateMultipartUploadResponseWithFSO extends
         omMetadataManager.getDirectoryTable().putWithBatch(batchOperation,
                 parentKey, parentDirInfo);
       }
+
+      // namespace quota changes for parent directory
+      String bucketKey = omMetadataManager.getBucketKey(
+          omBucketInfo.getVolumeName(),
+          omBucketInfo.getBucketName());
+      omMetadataManager.getBucketTable().putWithBatch(batchOperation,
+          bucketKey, omBucketInfo);
     }
 
     OMFileRequest.addToOpenFileTable(omMetadataManager, batchOperation,

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/s3/multipart/TestS3MultipartUploadCompleteRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/s3/multipart/TestS3MultipartUploadCompleteRequest.java
@@ -155,7 +155,7 @@ public class TestS3MultipartUploadCompleteRequest
         .getCacheValue(new CacheKey<>(
             omMetadataManager.getBucketKey(volumeName, bucketName)))
         .getCacheValue();
-    Assert.assertEquals(1L, omBucketInfo.getUsedNamespace());
+    Assert.assertEquals(getNamespaceCount(), omBucketInfo.getUsedNamespace());
   }
 
   protected void addVolumeAndBucket(String volumeName, String bucketName)
@@ -330,6 +330,10 @@ public class TestS3MultipartUploadCompleteRequest
 
   protected String getKeyName() {
     return UUID.randomUUID().toString();
+  }
+
+  protected long getNamespaceCount() {
+    return 1L;
   }
 }
 

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/s3/multipart/TestS3MultipartUploadCompleteRequestWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/s3/multipart/TestS3MultipartUploadCompleteRequestWithFSO.java
@@ -51,6 +51,12 @@ public class TestS3MultipartUploadCompleteRequestWithFSO
   }
 
   @Override
+  protected long getNamespaceCount() {
+    // parent directory count which is also created
+    return 5L;
+  }
+
+  @Override
   protected void addVolumeAndBucket(String volumeName, String bucketName)
       throws Exception {
     OMRequestTestUtils.addVolumeAndBucketToDB(volumeName, bucketName,

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/s3/multipart/TestS3MultipartResponse.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/s3/multipart/TestS3MultipartResponse.java
@@ -94,7 +94,7 @@ public class TestS3MultipartResponse {
 
   public S3InitiateMultipartUploadResponse createS3InitiateMPUResponse(
       String volumeName, String bucketName, String keyName,
-      String multipartUploadID) {
+      String multipartUploadID) throws IOException {
     OmMultipartKeyInfo multipartKeyInfo = new OmMultipartKeyInfo.Builder()
         .setUploadID(multipartUploadID)
         .setCreationTime(Time.now())
@@ -193,7 +193,7 @@ public class TestS3MultipartResponse {
   public S3InitiateMultipartUploadResponse createS3InitiateMPUResponseFSO(
       String volumeName, String bucketName, long parentID, String keyName,
       String multipartUploadID, List<OmDirectoryInfo> parentDirInfos,
-      long volumeId, long bucketId) {
+      long volumeId, long bucketId) throws IOException {
     OmMultipartKeyInfo multipartKeyInfo = new OmMultipartKeyInfo.Builder()
             .setUploadID(multipartUploadID)
             .setCreationTime(Time.now())
@@ -232,9 +232,13 @@ public class TestS3MultipartResponse {
         omKeyInfo.getVolumeName(), omKeyInfo.getBucketName(),
         keyName, multipartUploadID);
 
+    String buckDBKey = omMetadataManager.getBucketKey(volumeName, bucketName);
+    OmBucketInfo omBucketInfo =
+        omMetadataManager.getBucketTable().get(buckDBKey);
+
     return new S3InitiateMultipartUploadResponseWithFSO(omResponse,
         multipartKeyInfo, omKeyInfo, mpuKey, parentDirInfos, getBucketLayout(),
-        volumeId, bucketId);
+        volumeId, bucketId, omBucketInfo);
   }
 
   @SuppressWarnings("checkstyle:ParameterNumber")
@@ -326,7 +330,7 @@ public class TestS3MultipartResponse {
 
   protected S3InitiateMultipartUploadResponse getS3InitiateMultipartUploadResp(
       OmMultipartKeyInfo multipartKeyInfo, OmKeyInfo omKeyInfo,
-      OMResponse omResponse, long volumeId, long bucketId) {
+      OMResponse omResponse, long volumeId, long bucketId) throws IOException {
     return new S3InitiateMultipartUploadResponse(omResponse, multipartKeyInfo,
         omKeyInfo, getBucketLayout());
   }

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/s3/multipart/TestS3MultipartUploadAbortResponse.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/s3/multipart/TestS3MultipartUploadAbortResponse.java
@@ -100,7 +100,8 @@ public class TestS3MultipartUploadAbortResponse
   protected S3InitiateMultipartUploadResponse
         getS3InitiateMultipartUploadResponse(
       String volumeName, String bucketName, String keyName,
-      String multipartUploadID, long volumeId, long bucketId) {
+      String multipartUploadID, long volumeId, long bucketId)
+      throws IOException {
     return createS3InitiateMPUResponse(volumeName, bucketName, keyName,
         multipartUploadID);
   }

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/s3/multipart/TestS3MultipartUploadAbortResponseWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/s3/multipart/TestS3MultipartUploadAbortResponseWithFSO.java
@@ -65,23 +65,29 @@ public class TestS3MultipartUploadAbortResponseWithFSO
   protected S3InitiateMultipartUploadResponse getS3InitiateMultipartUploadResp(
       OmMultipartKeyInfo multipartKeyInfo, OmKeyInfo omKeyInfo,
       OzoneManagerProtocolProtos.OMResponse omResponse, long volumeId,
-      long bucketId) {
+      long bucketId) throws IOException {
 
     String mpuDBKey =
         omMetadataManager.getMultipartKey(omKeyInfo.getVolumeName(),
         omKeyInfo.getBucketName(), omKeyInfo.getKeyName(),
         multipartKeyInfo.getUploadID());
 
+    String buckDBKey = omMetadataManager.getBucketKey(omKeyInfo.getVolumeName(),
+        omKeyInfo.getBucketName());
+    OmBucketInfo omBucketInfo =
+        omMetadataManager.getBucketTable().get(buckDBKey);
+
     return new S3InitiateMultipartUploadResponseWithFSO(omResponse,
         multipartKeyInfo, omKeyInfo, mpuDBKey, new ArrayList<>(),
-        getBucketLayout(), volumeId, bucketId);
+        getBucketLayout(), volumeId, bucketId, omBucketInfo);
   }
 
   @Override
   protected S3InitiateMultipartUploadResponse
       getS3InitiateMultipartUploadResponse(
       String volumeName, String bucketName, String keyName,
-      String multipartUploadID, long volumeId, long bucketId) {
+      String multipartUploadID, long volumeId, long bucketId)
+      throws IOException {
     return createS3InitiateMPUResponseFSO(volumeName, bucketName, parentID,
         keyName,
         multipartUploadID, new ArrayList<>(), volumeId, bucketId);


### PR DESCRIPTION
## What changes were proposed in this pull request?
S3 multipart upload for FSO type creates a directory if missing for a parent. But the corresponding namespace addition is not recorded.
Validation and namespace quota updated for missing parent directory that got created.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-7644

## How was this patch tested?

Tested using unit test for namespace quota
