### PR TITLE
HDDS-7649. S3 multipart upload EC release space quota wrong for old version

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestOzoneClientMultipartUploadWithFSO.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestOzoneClientMultipartUploadWithFSO.java
@@ -321,10 +321,11 @@ public class TestOzoneClientMultipartUploadWithFSO {
     String volumeName = UUID.randomUUID().toString();
     String bucketName = UUID.randomUUID().toString();
     String keyName = UUID.randomUUID().toString();
-    String sampleData = "sample Value";
+    StringBuilder sb = new StringBuilder("sample Value");
     for (int i = 0; i < 4096; ++i) {
-      sampleData += "01234567890123456789";
+      sb.append("01234567890123456789");
     }
+    String sampleData = sb.toString();
 
     store.createVolume(volumeName);
     OzoneVolume volume = store.getVolume(volumeName);
@@ -381,10 +382,11 @@ public class TestOzoneClientMultipartUploadWithFSO {
     String volumeName = UUID.randomUUID().toString();
     String bucketName = UUID.randomUUID().toString();
     String keyName = UUID.randomUUID().toString();
-    String sampleData = "sample Value";
+    StringBuilder sb = new StringBuilder("sample Value");
     for (int i = 0; i < 4096; ++i) {
-      sampleData += "01234567890123456789";
+      sb.append("01234567890123456789");
     }
+    String sampleData = sb.toString();
 
     store.createVolume(volumeName);
     OzoneVolume volume = store.getVolume(volumeName);
@@ -402,8 +404,7 @@ public class TestOzoneClientMultipartUploadWithFSO {
     ozoneOutputStream.write(string2Bytes(sampleData), 0, sampleData.length());
     ozoneOutputStream.close();
 
-    OmMultipartCommitUploadPartInfo commitUploadPartInfo = ozoneOutputStream
-        .getCommitUploadPartInfo();
+    ozoneOutputStream.getCommitUploadPartInfo();
 
     Assert.assertEquals(volume.getBucket(bucketName).getUsedBytes(), 137228);
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3MultipartUploadCompleteRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3MultipartUploadCompleteRequest.java
@@ -229,8 +229,6 @@ public class S3MultipartUploadCompleteRequest extends OMKeyRequest {
           oldKeyVersionsToDelete = getOldVersionsToCleanUp(dbOzoneKey,
               keyToDelete, omMetadataManager,
               trxnLogIndex, ozoneManager.isRatisEnabled());
-          //long numCopy = keyToDelete.getReplicationConfig().getRequiredNodes();
-          //usedBytesDiff -= keyToDelete.getDataSize() * numCopy;
           usedBytesDiff -= keyToDelete.getReplicatedSize();
         } else {
           checkBucketQuotaInNamespace(omBucketInfo, 1L);

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3MultipartUploadCompleteRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3MultipartUploadCompleteRequest.java
@@ -229,8 +229,9 @@ public class S3MultipartUploadCompleteRequest extends OMKeyRequest {
           oldKeyVersionsToDelete = getOldVersionsToCleanUp(dbOzoneKey,
               keyToDelete, omMetadataManager,
               trxnLogIndex, ozoneManager.isRatisEnabled());
-          long numCopy = keyToDelete.getReplicationConfig().getRequiredNodes();
-          usedBytesDiff -= keyToDelete.getDataSize() * numCopy;
+          //long numCopy = keyToDelete.getReplicationConfig().getRequiredNodes();
+          //usedBytesDiff -= keyToDelete.getDataSize() * numCopy;
+          usedBytesDiff -= keyToDelete.getReplicatedSize();
         } else {
           checkBucketQuotaInNamespace(omBucketInfo, 1L);
           omBucketInfo.incrUsedNamespace(1L);


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fix for size calculation for EC case in complete flow when old version file is for removal

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-7649


## How was this patch tested?

Tested using UT cases and added for EC
