### PR TITLE
HDDS-7620. Check term for async commands before processing

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/DatanodeStateMachine.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/DatanodeStateMachine.java
@@ -192,7 +192,7 @@ public class DatanodeStateMachine implements Closeable {
     ecReconstructionMetrics = ECReconstructionMetrics.create();
 
     ECReconstructionCoordinator ecReconstructionCoordinator =
-        new ECReconstructionCoordinator(conf, certClient,
+        new ECReconstructionCoordinator(conf, certClient, context,
             ecReconstructionMetrics);
     ecReconstructionSupervisor =
         new ECReconstructionSupervisor(container.getContainerSet(), context,

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/StateContext.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/StateContext.java
@@ -742,12 +742,11 @@ public class StateContext {
   }
 
   @VisibleForTesting
-  void setTermOfLeaderSCM(long term) {
+  public void setTermOfLeaderSCM(long term) {
     termOfLeaderSCM = OptionalLong.of(term);
   }
 
-  @VisibleForTesting
-  OptionalLong getTermOfLeaderSCM() {
+  public OptionalLong getTermOfLeaderSCM() {
     return termOfLeaderSCM;
   }
 

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/DeleteContainerCommandHandler.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/DeleteContainerCommandHandler.java
@@ -33,6 +33,7 @@ import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.time.Clock;
+import java.util.OptionalLong;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ThreadPoolExecutor;
@@ -73,26 +74,44 @@ public class DeleteContainerCommandHandler implements CommandHandler {
     final DeleteContainerCommand deleteContainerCommand =
         (DeleteContainerCommand) command;
     final ContainerController controller = ozoneContainer.getController();
-    executor.execute(() -> {
-      final long startTime = Time.monotonicNow();
-      invocationCount.incrementAndGet();
-      try {
-        if (command.hasExpired(clock.millis())) {
-          LOG.info("Not processing the delete container command for " +
-              "container {} as the current time {}ms is after the command " +
-              "deadline {}ms", deleteContainerCommand.getContainerID(),
-              clock.millis(), command.getDeadline());
-          timeoutCount.incrementAndGet();
+    executor.execute(() ->
+        handleInternal(command, context, deleteContainerCommand, controller));
+  }
+
+  private void handleInternal(SCMCommand command, StateContext context,
+      DeleteContainerCommand deleteContainerCommand,
+      ContainerController controller) {
+    final long startTime = Time.monotonicNow();
+    invocationCount.incrementAndGet();
+    try {
+      if (command.hasExpired(clock.millis())) {
+        LOG.info("Not processing the delete container command for " +
+            "container {} as the current time {}ms is after the command " +
+            "deadline {}ms", deleteContainerCommand.getContainerID(),
+            clock.millis(), command.getDeadline());
+        timeoutCount.incrementAndGet();
+        return;
+      }
+
+      if (context != null) {
+        final OptionalLong currentTerm = context.getTermOfLeaderSCM();
+        final long cmdTerm = command.getTerm();
+        if (currentTerm.isPresent() && cmdTerm < currentTerm.getAsLong()) {
+          LOG.info("Ignoring delete container command for container {} since " +
+              "SCM leader has new term ({} < {})",
+              deleteContainerCommand.getContainerID(),
+              cmdTerm, currentTerm.getAsLong());
           return;
         }
-        controller.deleteContainer(deleteContainerCommand.getContainerID(),
-            deleteContainerCommand.isForce());
-      } catch (IOException e) {
-        LOG.error("Exception occurred while deleting the container.", e);
-      } finally {
-        totalTime.getAndAdd(Time.monotonicNow() - startTime);
       }
-    });
+
+      controller.deleteContainer(deleteContainerCommand.getContainerID(),
+          deleteContainerCommand.isForce());
+    } catch (IOException e) {
+      LOG.error("Exception occurred while deleting the container.", e);
+    } finally {
+      totalTime.getAndAdd(Time.monotonicNow() - startTime);
+    }
   }
 
   @Override

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/ec/reconstruction/ECReconstructionCommandInfo.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/ec/reconstruction/ECReconstructionCommandInfo.java
@@ -36,6 +36,7 @@ public class ECReconstructionCommandInfo {
       sources;
   private List<DatanodeDetails> targetDatanodes;
   private long deadlineMsSinceEpoch = 0;
+  private final long term;
 
   public ECReconstructionCommandInfo(ReconstructECContainersCommand cmd) {
     this.containerID = cmd.getContainerID();
@@ -46,6 +47,7 @@ public class ECReconstructionCommandInfo {
     this.sources = cmd.getSources();
     this.targetDatanodes = cmd.getTargetDatanodes();
     this.deadlineMsSinceEpoch = cmd.getDeadline();
+    this.term = cmd.getTerm();
   }
 
   public long getDeadline() {
@@ -82,5 +84,9 @@ public class ECReconstructionCommandInfo {
         .toString(missingContainerIndexes)
         + ", sources=" + sources
         + ", targetDatanodes=" + targetDatanodes + '}';
+  }
+
+  public long getTerm() {
+    return term;
   }
 }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/ec/reconstruction/ECReconstructionCoordinator.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/ec/reconstruction/ECReconstructionCoordinator.java
@@ -46,6 +46,7 @@ import org.apache.hadoop.ozone.client.io.BlockInputStreamFactoryImpl;
 import org.apache.hadoop.ozone.client.io.ECBlockInputStreamProxy;
 import org.apache.hadoop.ozone.client.io.ECBlockReconstructedStripeInputStream;
 import org.apache.hadoop.ozone.container.common.helpers.BlockData;
+import org.apache.hadoop.ozone.container.common.statemachine.StateContext;
 import org.apache.hadoop.security.token.Token;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -58,6 +59,8 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
+import java.util.OptionalLong;
 import java.util.SortedMap;
 import java.util.TreeMap;
 import java.util.concurrent.CompletableFuture;
@@ -105,10 +108,13 @@ public class ECReconstructionCoordinator implements Closeable {
   private final TokenHelper tokenHelper;
   private final ContainerClientMetrics clientMetrics;
   private final ECReconstructionMetrics metrics;
+  private final StateContext context;
 
   public ECReconstructionCoordinator(ConfigurationSource conf,
       CertificateClient certificateClient,
+      StateContext context,
       ECReconstructionMetrics metrics) throws IOException {
+    this.context = context;
     this.containerOperationClient = new ECContainerOperationClient(conf,
         certificateClient);
     this.byteBufferPool = new ElasticByteBufferPool();
@@ -473,5 +479,11 @@ public class ECReconstructionCoordinator implements Closeable {
 
   public ECReconstructionMetrics getECReconstructionMetrics() {
     return this.metrics;
+  }
+
+  OptionalLong getTermOfLeaderSCM() {
+    return Optional.ofNullable(context)
+        .map(StateContext::getTermOfLeaderSCM)
+        .orElse(OptionalLong.empty());
   }
 }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/replication/ReplicationTask.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/replication/ReplicationTask.java
@@ -37,7 +37,9 @@ public class ReplicationTask {
 
   private final Instant queued = Instant.now();
 
-  private long deadlineMsSinceEpoch = 0;
+  private final long deadlineMsSinceEpoch;
+
+  private final long term;
 
   /**
    * Counter for the transferred bytes.
@@ -48,6 +50,7 @@ public class ReplicationTask {
     this.containerId = cmd.getContainerID();
     this.sources = cmd.getSourceDatanodes();
     this.deadlineMsSinceEpoch = cmd.getDeadline();
+    this.term = cmd.getTerm();
   }
 
   /**
@@ -121,6 +124,10 @@ public class ReplicationTask {
 
   public void setTransferredBytes(long transferredBytes) {
     this.transferredBytes = transferredBytes;
+  }
+
+  long getTerm() {
+    return term;
   }
 
   /**

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/replication/TestReplicationSupervisor.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/replication/TestReplicationSupervisor.java
@@ -36,6 +36,8 @@ import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.metrics2.impl.MetricsCollectorImpl;
 import org.apache.hadoop.ozone.container.common.impl.ContainerLayoutVersion;
 import org.apache.hadoop.ozone.container.common.impl.ContainerSet;
+import org.apache.hadoop.ozone.container.common.statemachine.DatanodeStateMachine;
+import org.apache.hadoop.ozone.container.common.statemachine.StateContext;
 import org.apache.hadoop.ozone.container.keyvalue.ContainerLayoutTestInfo;
 import org.apache.hadoop.ozone.container.keyvalue.KeyValueContainer;
 import org.apache.hadoop.ozone.container.keyvalue.KeyValueContainerData;
@@ -62,6 +64,8 @@ import static java.util.Collections.emptyList;
 @RunWith(Parameterized.class)
 public class TestReplicationSupervisor {
 
+  private static final long CURRENT_TERM = 1;
+
   private final ContainerReplicator noopReplicator = task -> { };
   private final ContainerReplicator throwingReplicator = task -> {
     throw new RuntimeException("testing replication failure");
@@ -80,6 +84,8 @@ public class TestReplicationSupervisor {
   private ContainerSet set;
 
   private final ContainerLayoutVersion layout;
+
+  private StateContext context;
   private TestClock clock;
 
   public TestReplicationSupervisor(ContainerLayoutVersion layout) {
@@ -95,6 +101,11 @@ public class TestReplicationSupervisor {
   public void setUp() throws Exception {
     clock = new TestClock(Instant.now(), ZoneId.systemDefault());
     set = new ContainerSet(1000);
+    context = new StateContext(
+        new OzoneConfiguration(),
+        DatanodeStateMachine.DatanodeStates.getInitState(),
+        Mockito.mock(DatanodeStateMachine.class));
+    context.setTermOfLeaderSCM(CURRENT_TERM);
   }
 
   @After
@@ -112,9 +123,9 @@ public class TestReplicationSupervisor {
 
     try {
       //WHEN
-      supervisor.addTask(new ReplicationTask(1L, emptyList()));
-      supervisor.addTask(new ReplicationTask(2L, emptyList()));
-      supervisor.addTask(new ReplicationTask(5L, emptyList()));
+      supervisor.addTask(createTask(1L));
+      supervisor.addTask(createTask(2L));
+      supervisor.addTask(createTask(5L));
 
       Assert.assertEquals(3, supervisor.getReplicationRequestCount());
       Assert.assertEquals(3, supervisor.getReplicationSuccessCount());
@@ -140,10 +151,10 @@ public class TestReplicationSupervisor {
 
     try {
       //WHEN
-      supervisor.addTask(new ReplicationTask(6L, emptyList()));
-      supervisor.addTask(new ReplicationTask(6L, emptyList()));
-      supervisor.addTask(new ReplicationTask(6L, emptyList()));
-      supervisor.addTask(new ReplicationTask(6L, emptyList()));
+      supervisor.addTask(createTask(6L));
+      supervisor.addTask(createTask(6L));
+      supervisor.addTask(createTask(6L));
+      supervisor.addTask(createTask(6L));
 
       //THEN
       Assert.assertEquals(4, supervisor.getReplicationRequestCount());
@@ -165,7 +176,7 @@ public class TestReplicationSupervisor {
 
     try {
       //WHEN
-      ReplicationTask task = new ReplicationTask(1L, emptyList());
+      ReplicationTask task = createTask(1L);
       supervisor.addTask(task);
 
       //THEN
@@ -189,9 +200,9 @@ public class TestReplicationSupervisor {
 
     try {
       //WHEN
-      supervisor.addTask(new ReplicationTask(1L, emptyList()));
-      supervisor.addTask(new ReplicationTask(2L, emptyList()));
-      supervisor.addTask(new ReplicationTask(3L, emptyList()));
+      supervisor.addTask(createTask(1L));
+      supervisor.addTask(createTask(2L));
+      supervisor.addTask(createTask(3L));
 
       //THEN
       Assert.assertEquals(0, supervisor.getReplicationRequestCount());
@@ -214,9 +225,9 @@ public class TestReplicationSupervisor {
 
     try {
       //WHEN
-      supervisor.addTask(new ReplicationTask(1L, emptyList()));
-      supervisor.addTask(new ReplicationTask(2L, emptyList()));
-      supervisor.addTask(new ReplicationTask(3L, emptyList()));
+      supervisor.addTask(createTask(1L));
+      supervisor.addTask(createTask(2L));
+      supervisor.addTask(createTask(3L));
 
       //THEN
       Assert.assertEquals(3, supervisor.getInFlightReplications());
@@ -236,7 +247,7 @@ public class TestReplicationSupervisor {
   @Test
   public void testDownloadAndImportReplicatorFailure() {
     ReplicationSupervisor supervisor =
-        new ReplicationSupervisor(set, null, mutableReplicator,
+        new ReplicationSupervisor(set, context, mutableReplicator,
             newDirectExecutorService(), clock);
 
     // Mock to fetch an exception in the importContainer method.
@@ -255,7 +266,7 @@ public class TestReplicationSupervisor {
     GenericTestUtils.LogCapturer logCapturer = GenericTestUtils.LogCapturer
         .captureLogs(DownloadAndImportReplicator.LOG);
 
-    supervisor.addTask(new ReplicationTask(1L, emptyList()));
+    supervisor.addTask(createTask(1L));
     Assert.assertEquals(1, supervisor.getReplicationFailureCount());
     Assert.assertEquals(0, supervisor.getReplicationSuccessCount());
     Assert.assertTrue(logCapturer.getOutput()
@@ -267,14 +278,13 @@ public class TestReplicationSupervisor {
     ReplicationSupervisor supervisor =
         supervisorWithReplicator(FakeReplicator::new);
 
-    ReplicateContainerCommand cmd = new ReplicateContainerCommand(1L,
-        emptyList());
+    ReplicateContainerCommand cmd = createCommand(1);
     cmd.setDeadline(clock.millis() + 10000);
     ReplicationTask task1 = new ReplicationTask(cmd);
-    cmd = new ReplicateContainerCommand(2L, emptyList());
+    cmd = createCommand(2);
     cmd.setDeadline(clock.millis() + 20000);
     ReplicationTask task2 = new ReplicationTask(cmd);
-    cmd = new ReplicateContainerCommand(3L, emptyList());
+    cmd = createCommand(3);
     // No deadline set
     ReplicationTask task3 = new ReplicationTask(cmd);
     // no deadline set
@@ -295,6 +305,19 @@ public class TestReplicationSupervisor {
 
   }
 
+  @Test
+  public void taskWithObsoleteTermIsDropped() {
+    final long newTerm = 2;
+    ReplicationSupervisor supervisor =
+        supervisorWithReplicator(FakeReplicator::new);
+
+    context.setTermOfLeaderSCM(newTerm);
+    supervisor.addTask(createTask(1L));
+
+    Assert.assertEquals(1, supervisor.getReplicationRequestCount());
+    Assert.assertEquals(0, supervisor.getReplicationSuccessCount());
+  }
+
   private ReplicationSupervisor supervisorWithReplicator(
       Function<ReplicationSupervisor, ContainerReplicator> replicatorFactory) {
     return supervisorWith(replicatorFactory, newDirectExecutorService());
@@ -304,10 +327,22 @@ public class TestReplicationSupervisor {
       Function<ReplicationSupervisor, ContainerReplicator> replicatorFactory,
       ExecutorService executor) {
     ReplicationSupervisor supervisor =
-        new ReplicationSupervisor(set, null, mutableReplicator, executor,
+        new ReplicationSupervisor(set, context, mutableReplicator, executor,
             clock);
     replicatorRef.set(replicatorFactory.apply(supervisor));
     return supervisor;
+  }
+
+  private static ReplicationTask createTask(long containerId) {
+    ReplicateContainerCommand cmd = createCommand(containerId);
+    return new ReplicationTask(cmd);
+  }
+
+  private static ReplicateContainerCommand createCommand(long containerId) {
+    ReplicateContainerCommand cmd =
+        new ReplicateContainerCommand(containerId, emptyList());
+    cmd.setTerm(CURRENT_TERM);
+    return cmd;
   }
 
   /**

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/storage/TestContainerCommandsEC.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/storage/TestContainerCommandsEC.java
@@ -392,7 +392,7 @@ public class TestContainerCommandsEC {
     createKeyAndWriteData(keyString, bucket);
     ECReconstructionCoordinator coordinator =
         new ECReconstructionCoordinator(config, certClient,
-            ECReconstructionMetrics.create());
+            null, ECReconstructionMetrics.create());
 
     ECReconstructionMetrics metrics = coordinator.getECReconstructionMetrics();
     OzoneKeyDetails key = bucket.getKey(keyString);
@@ -569,7 +569,7 @@ public class TestContainerCommandsEC {
     Assert.assertThrows(IOException.class, () -> {
       ECReconstructionCoordinator coordinator =
           new ECReconstructionCoordinator(config, certClient,
-              ECReconstructionMetrics.create());
+              null, ECReconstructionMetrics.create());
       coordinator.reconstructECContainerGroup(conID,
           (ECReplicationConfig) containerPipeline.getReplicationConfig(),
           sourceNodeMap, targetNodeMap);


### PR DESCRIPTION
## What changes were proposed in this pull request?

Some of datanode's SCM commands are processed asynchronously.  SCM term is currently only checked when taking them out of the main queue.  This PR adds logic to discard three types of such commands if they get outdated by the time they get out of the sub-queue.

https://issues.apache.org/jira/browse/HDDS-7620

## How was this patch tested?

Added unit tests.

https://github.com/adoroszlai/hadoop-ozone/actions/runs/3704261127