### PR TITLE
HDDS-7654. EC: ReplicationManager - merge mis-rep queue into under replicated queue

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ContainerHealthResult.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ContainerHealthResult.java
@@ -113,7 +113,15 @@ public class ContainerHealthResult {
     public UnderReplicatedHealthResult(ContainerInfo containerInfo,
         int remainingRedundancy, boolean dueToDecommission,
         boolean replicatedOkWithPending, boolean unrecoverable) {
-      super(containerInfo, HealthState.UNDER_REPLICATED);
+      this(containerInfo, remainingRedundancy, dueToDecommission,
+          replicatedOkWithPending, unrecoverable, HealthState.UNDER_REPLICATED);
+    }
+
+    protected UnderReplicatedHealthResult(ContainerInfo containerInfo,
+        int remainingRedundancy, boolean dueToDecommission,
+        boolean replicatedOkWithPending, boolean unrecoverable,
+        HealthState healthState) {
+      super(containerInfo, healthState);
       this.remainingRedundancy = remainingRedundancy;
       this.dueToDecommission = dueToDecommission;
       this.sufficientlyReplicatedAfterPending = replicatedOkWithPending;
@@ -148,7 +156,7 @@ public class ContainerHealthResult {
       if (dueToDecommission) {
         result += DECOMMISSION_REDUNDANCY;
       } else {
-        result += remainingRedundancy;
+        result += getRemainingRedundancy();
       }
       return result;
     }
@@ -207,19 +215,28 @@ public class ContainerHealthResult {
    * containers are not spread across enough racks.
    */
   public static class MisReplicatedHealthResult
-      extends ContainerHealthResult {
+      extends UnderReplicatedHealthResult {
 
-    private final boolean replicatedOkAfterPending;
+    /**
+     * In UnderReplicatedHealthState, DECOMMISSION_REDUNDANCY is defined as
+     * 5 so that containers which are really under replicated get fixed as a
+     * priority over decommissioning hosts. We have defined that a container
+     * can only be mis replicated if it is not over or under replicated. Fixing
+     * mis replication is arguably less important than competing a decommission.
+     * So as a lot of mis replicated container do not block decommission, we
+     * set the redundancy of mis replicated containers to 6 so they sort after
+     * under / over replicated and decommissioning replicas in the under
+     * replication queue.
+     */
+    private static final int MIS_REP_REDUNDANCY = 6;
 
     public MisReplicatedHealthResult(ContainerInfo containerInfo,
         boolean replicatedOkAfterPending) {
-      super(containerInfo, HealthState.MIS_REPLICATED);
-      this.replicatedOkAfterPending = replicatedOkAfterPending;
+      super(containerInfo, MIS_REP_REDUNDANCY, false,
+          replicatedOkAfterPending, false,
+          HealthState.MIS_REPLICATED);
     }
 
-    public boolean isReplicatedOkAfterPending() {
-      return replicatedOkAfterPending;
-    }
   }
 
   /**

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ReplicationManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ReplicationManager.java
@@ -159,6 +159,7 @@ public class ReplicationManager implements SCMService {
   private ReplicationQueue replicationQueue;
   private final ECUnderReplicationHandler ecUnderReplicationHandler;
   private final ECOverReplicationHandler ecOverReplicationHandler;
+  private final ECMisReplicationHandler ecMisReplicationHandler;
   private final RatisUnderReplicationHandler ratisUnderReplicationHandler;
   private final RatisOverReplicationHandler ratisOverReplicationHandler;
   private final int maintenanceRedundancy;
@@ -223,6 +224,8 @@ public class ReplicationManager implements SCMService {
         ecContainerPlacement, conf, nodeManager, this);
     ecOverReplicationHandler =
         new ECOverReplicationHandler(ecContainerPlacement, nodeManager);
+    ecMisReplicationHandler = new ECMisReplicationHandler(ecContainerPlacement,
+        conf, nodeManager);
     ratisUnderReplicationHandler = new RatisUnderReplicationHandler(
         ratisContainerPlacement, conf, nodeManager);
     ratisOverReplicationHandler =
@@ -525,8 +528,18 @@ public class ReplicationManager implements SCMService {
     List<ContainerReplicaOp> pendingOps =
         containerReplicaPendingOps.getPendingOps(containerID);
     if (result.getContainerInfo().getReplicationType() == EC) {
-      return ecUnderReplicationHandler.processAndCreateCommands(replicas,
-          pendingOps, result, maintenanceRedundancy);
+      if (result.getHealthState()
+          == ContainerHealthResult.HealthState.UNDER_REPLICATED) {
+        return ecUnderReplicationHandler.processAndCreateCommands(replicas,
+            pendingOps, result, maintenanceRedundancy);
+      } else if (result.getHealthState()
+          == ContainerHealthResult.HealthState.MIS_REPLICATED) {
+        return ecMisReplicationHandler.processAndCreateCommands(replicas,
+            pendingOps, result, maintenanceRedundancy);
+      } else {
+        throw new IllegalArgumentException("Unexpected health state: "
+            + result.getHealthState());
+      }
     }
     return ratisUnderReplicationHandler.processAndCreateCommands(replicas,
         pendingOps, result, ratisMaintenanceMinReplicas);

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ReplicationQueue.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ReplicationQueue.java
@@ -32,8 +32,6 @@ public class ReplicationQueue {
       underRepQueue;
   private final Queue<ContainerHealthResult.OverReplicatedHealthResult>
       overRepQueue;
-  private final Queue<ContainerHealthResult.MisReplicatedHealthResult>
-      misRepQueue;
 
   public ReplicationQueue() {
     underRepQueue = new PriorityQueue<>(
@@ -42,7 +40,6 @@ public class ReplicationQueue {
         .thenComparing(ContainerHealthResult
             .UnderReplicatedHealthResult::getRequeueCount));
     overRepQueue = new LinkedList<>();
-    misRepQueue = new LinkedList<>();
   }
 
   public void enqueue(ContainerHealthResult.UnderReplicatedHealthResult
@@ -55,11 +52,6 @@ public class ReplicationQueue {
     overRepQueue.add(overReplicatedHealthResult);
   }
 
-  public void enqueue(ContainerHealthResult.MisReplicatedHealthResult
-      misReplicatedHealthResult) {
-    misRepQueue.add(misReplicatedHealthResult);
-  }
-
   public ContainerHealthResult.UnderReplicatedHealthResult
       dequeueUnderReplicatedContainer() {
     return underRepQueue.poll();
@@ -70,21 +62,12 @@ public class ReplicationQueue {
     return overRepQueue.poll();
   }
 
-  public ContainerHealthResult.MisReplicatedHealthResult
-      dequeueMisReplicatedContainer() {
-    return misRepQueue.poll();
-  }
-
   public int underReplicatedQueueSize() {
     return underRepQueue.size();
   }
 
   public int overReplicatedQueueSize() {
     return overRepQueue.size();
-  }
-
-  public int misReplicatedQueueSize() {
-    return misRepQueue.size();
   }
 
 }

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/health/TestECReplicationCheckHandler.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/health/TestECReplicationCheckHandler.java
@@ -481,9 +481,8 @@ public class TestECReplicationCheckHandler {
     Assert.assertEquals(HealthState.MIS_REPLICATED, result.getHealthState());
 
     Assert.assertTrue(healthCheck.handle(request));
-    Assert.assertEquals(0, repQueue.underReplicatedQueueSize());
+    Assert.assertEquals(1, repQueue.underReplicatedQueueSize());
     Assert.assertEquals(0, repQueue.overReplicatedQueueSize());
-    Assert.assertEquals(1, repQueue.misReplicatedQueueSize());
     Assert.assertEquals(0, report.getStat(
         ReplicationManagerReport.HealthState.UNDER_REPLICATED));
     Assert.assertEquals(0, report.getStat(
@@ -531,7 +530,6 @@ public class TestECReplicationCheckHandler {
     Assert.assertTrue(healthCheck.handle(request));
     Assert.assertEquals(0, repQueue.underReplicatedQueueSize());
     Assert.assertEquals(0, repQueue.overReplicatedQueueSize());
-    Assert.assertEquals(0, repQueue.misReplicatedQueueSize());
     Assert.assertEquals(0, report.getStat(
         ReplicationManagerReport.HealthState.UNDER_REPLICATED));
     Assert.assertEquals(0, report.getStat(
@@ -567,7 +565,6 @@ public class TestECReplicationCheckHandler {
     Assert.assertTrue(healthCheck.handle(request));
     Assert.assertEquals(1, repQueue.underReplicatedQueueSize());
     Assert.assertEquals(0, repQueue.overReplicatedQueueSize());
-    Assert.assertEquals(0, repQueue.misReplicatedQueueSize());
     Assert.assertEquals(1, report.getStat(
         ReplicationManagerReport.HealthState.UNDER_REPLICATED));
     Assert.assertEquals(0, report.getStat(
@@ -604,7 +601,6 @@ public class TestECReplicationCheckHandler {
     Assert.assertTrue(healthCheck.handle(request));
     Assert.assertEquals(0, repQueue.underReplicatedQueueSize());
     Assert.assertEquals(1, repQueue.overReplicatedQueueSize());
-    Assert.assertEquals(0, repQueue.misReplicatedQueueSize());
     Assert.assertEquals(0, report.getStat(
         ReplicationManagerReport.HealthState.UNDER_REPLICATED));
     Assert.assertEquals(1, report.getStat(

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/health/TestRatisReplicationCheckHandler.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/health/TestRatisReplicationCheckHandler.java
@@ -423,7 +423,6 @@ public class TestRatisReplicationCheckHandler {
     Assert.assertTrue(healthCheck.handle(requestBuilder.build()));
     Assert.assertEquals(1, repQueue.underReplicatedQueueSize());
     Assert.assertEquals(0, repQueue.overReplicatedQueueSize());
-    Assert.assertEquals(0, repQueue.misReplicatedQueueSize());
     Assert.assertEquals(1, report.getStat(
         ReplicationManagerReport.HealthState.UNDER_REPLICATED));
     Assert.assertEquals(0, report.getStat(
@@ -468,7 +467,6 @@ public class TestRatisReplicationCheckHandler {
     Assert.assertTrue(healthCheck.handle(requestBuilder.build()));
     Assert.assertEquals(0, repQueue.underReplicatedQueueSize());
     Assert.assertEquals(0, repQueue.overReplicatedQueueSize());
-    Assert.assertEquals(0, repQueue.misReplicatedQueueSize());
     Assert.assertEquals(1, report.getStat(
         ReplicationManagerReport.HealthState.UNDER_REPLICATED));
     Assert.assertEquals(0, report.getStat(
@@ -494,9 +492,8 @@ public class TestRatisReplicationCheckHandler {
     Assert.assertFalse(result.isReplicatedOkAfterPending());
 
     Assert.assertTrue(healthCheck.handle(requestBuilder.build()));
-    Assert.assertEquals(0, repQueue.underReplicatedQueueSize());
+    Assert.assertEquals(1, repQueue.underReplicatedQueueSize());
     Assert.assertEquals(0, repQueue.overReplicatedQueueSize());
-    Assert.assertEquals(1, repQueue.misReplicatedQueueSize());
     Assert.assertEquals(0, report.getStat(
         ReplicationManagerReport.HealthState.UNDER_REPLICATED));
     Assert.assertEquals(1, report.getStat(


### PR DESCRIPTION
## What changes were proposed in this pull request?

Mis Replication is another form of under replication, but with a lower priority. Therefore it would make sense that mis-replicated containers are queued in the same queue as under-replicated. Ideally, we would not spend resources fixing mis-replicated until all the under replicated containers are handled, so having them in separate queues doesn't add any value.

Mis-Replicated containers are queued with a priority lower than decommissioning containers in this PR, so they do not block decommission from completing if they are ahead of it in the queue.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-7654

## How was this patch tested?

Added a unit test to prove the mis-rep container queues with a lower priority than decommission. Small changes to existing tests cover most of the rest of the changes.

Ideally we should have a test in TestReplicationManager to cover the logic in `ReplicationManager.processUnderReplicatedContainer` but the way things are currently structured, that would need a bit of refactoring to be feasible, as ideally we should inject the under / over / mis-rep handler and then we can mock them to ensure the correct one is called. At the moment, they are created inside ReplicationManager so that is not possible.
