### PR TITLE
HDDS-7683. EC: ReplicationManager - UnderRep maintenance handler should not request nodes if none needed

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ECUnderReplicationHandler.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ECUnderReplicationHandler.java
@@ -400,6 +400,9 @@ public class ECUnderReplicationHandler implements UnhealthyReplicationHandler {
     // this many maintenance replicas need another copy
     int additionalMaintenanceCopiesNeeded =
         replicaCount.additionalMaintenanceCopiesNeeded(true);
+    if (additionalMaintenanceCopiesNeeded == 0) {
+      return;
+    }
     List<DatanodeDetails> targets = getTargetDatanodes(excludedNodes, container,
         additionalMaintenanceCopiesNeeded);
     excludedNodes.addAll(targets);


### PR DESCRIPTION
## What changes were proposed in this pull request?

If an EC container is under-replicated somehow, and also has some maintenance indexes that do not need replicated, the logic calls the placement policy requesting zero nodes. The policy then throws an exception as it expects to have greater than zero nodes requested.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-7683

## How was this patch tested?

Unit test used to reproduce the issue and then a code change to fix the test.