### PR TITLE
HDDS-5560. Updating clusterId to correct value

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/DatanodeLayoutStorage.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/DatanodeLayoutStorage.java
@@ -64,6 +64,11 @@ public class DatanodeLayoutStorage extends Storage {
     return new Properties();
   }
 
+  @Override
+  public void setClusterId(String clusterId) throws IOException {
+    super.getStorageInfo().setClusterId(clusterId);
+  }
+
   /**
    * Older versions of the code did not write a VERSION file to disk for the
    * datanode. Therefore, When a datanode starts up and does not find a metadata

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/states/endpoint/VersionEndpointTask.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/states/endpoint/VersionEndpointTask.java
@@ -22,6 +22,7 @@ import java.util.concurrent.Callable;
 import org.apache.hadoop.hdds.conf.ConfigurationSource;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.SCMVersionResponseProto;
 import org.apache.hadoop.ozone.OzoneConsts;
+import org.apache.hadoop.ozone.container.common.DatanodeLayoutStorage;
 import org.apache.hadoop.ozone.container.common.statemachine.EndpointStateMachine;
 import org.apache.hadoop.ozone.container.common.utils.StorageVolumeUtil;
 import org.apache.hadoop.ozone.container.common.volume.MutableVolumeSet;
@@ -75,6 +76,10 @@ public class VersionEndpointTask implements
           // If end point is passive, datanode does not need to check volumes.
           String scmId = response.getValue(OzoneConsts.SCM_ID);
           String clusterId = response.getValue(OzoneConsts.CLUSTER_ID);
+          DatanodeLayoutStorage layoutStorage = new DatanodeLayoutStorage(configuration, clusterId);
+          layoutStorage.setClusterId(clusterId);
+          LOG.warn("Nishit *** " + clusterId);
+          layoutStorage.forceInitialize();
 
           Preconditions.checkNotNull(scmId,
               "Reply from SCM: scmId cannot be null");

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/states/endpoint/VersionEndpointTask.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/states/endpoint/VersionEndpointTask.java
@@ -76,9 +76,9 @@ public class VersionEndpointTask implements
           // If end point is passive, datanode does not need to check volumes.
           String scmId = response.getValue(OzoneConsts.SCM_ID);
           String clusterId = response.getValue(OzoneConsts.CLUSTER_ID);
-          DatanodeLayoutStorage layoutStorage = new DatanodeLayoutStorage(configuration, clusterId);
+          DatanodeLayoutStorage layoutStorage
+                  = new DatanodeLayoutStorage(configuration, clusterId);
           layoutStorage.setClusterId(clusterId);
-          LOG.warn("Nishit *** " + clusterId);
           layoutStorage.forceInitialize();
 
           Preconditions.checkNotNull(scmId,


### PR DESCRIPTION
## What changes were proposed in this pull request?

ClusterId was being incorrectly set as datanodeId in the dnlayoutversion/version file.
While this field was not being used anywhere and poses no immediate problem, we wanted to fix it to reflect the correct value.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-5560

## How was this patch tested?

Built successfully.
Local test on docker to see the value is being updated correctly.
