### PR TITLE
HDDS-7684. Embed Matomo Web Analytics tracking code in docs.

### DIFF
--- a/hadoop-hdds/docs/themes/ozonedoc/layouts/partials/header.html
+++ b/hadoop-hdds/docs/themes/ozonedoc/layouts/partials/header.html
@@ -31,4 +31,26 @@
     <!-- Custom styles for this template -->
     <link href="{{ "css/ozonedoc.css" | relURL}}" rel="stylesheet">
 
+    <!-- Matomo -->
+    <script>
+      var _paq = window._paq = window._paq || [];
+      /* tracker methods like "setCustomDimension" should be called before
+"trackPageView" */
+      /* We explicitly disable cookie tracking to avoid privacy issues */
+      _paq.push(['disableCookies']);
+      /* Measure a visit to flink.apache.org and nightlies.apache.org/flink
+as the same visit */
+      _paq.push(['trackPageView']);
+      _paq.push(['enableLinkTracking']);
+      (function() {
+        var u="//analytics.apache.org/";
+        _paq.push(['setTrackerUrl', u+'matomo.php']);
+        _paq.push(['setSiteId', '34']);
+        var d=document, g=d.createElement('script'),
+s=d.getElementsByTagName('script')[0];
+        g.async=true; g.src=u+'matomo.js'; s.parentNode.insertBefore(g,s);
+      })();
+    </script>
+    <!-- End Matomo Code -->
+
   </head>


### PR DESCRIPTION
## What changes were proposed in this pull request?

To help understand our users, I propose to embed Mamoto tracking code into Ozone web page. More details can be found at https://privacy.apache.org/matomo/

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-7684

## How was this patch tested?

Manually verifies the rendered page issues request to the Matomo javascript resources. However, I am yet to see results on analytics.apache.org