### PR TITLE
HDDS-7686. Cherry-pick proto.lock files change from ozone-1.3 release branch to master

### DIFF
--- a/hadoop-hdds/interface-admin/src/main/resources/proto.lock
+++ b/hadoop-hdds/interface-admin/src/main/resources/proto.lock
@@ -155,6 +155,22 @@
               {
                 "name": "QueryUpgradeFinalizationProgress",
                 "integer": 32
+              },
+              {
+                "name": "GetContainerCount",
+                "integer": 33
+              },
+              {
+                "name": "GetContainerReplicas",
+                "integer": 34
+              },
+              {
+                "name": "GetReplicationManagerReport",
+                "integer": 35
+              },
+              {
+                "name": "ResetDeletedBlockRetryCount",
+                "integer": 36
               }
             ]
           },
@@ -200,177 +216,236 @@
               {
                 "id": 1,
                 "name": "cmdType",
-                "type": "Type"
+                "type": "Type",
+                "required": true
               },
               {
                 "id": 2,
                 "name": "traceID",
-                "type": "string"
+                "type": "string",
+                "optional": true
               },
               {
                 "id": 3,
                 "name": "version",
-                "type": "uint32"
+                "type": "uint32",
+                "optional": true
               },
               {
                 "id": 6,
                 "name": "containerRequest",
-                "type": "ContainerRequestProto"
+                "type": "ContainerRequestProto",
+                "optional": true
               },
               {
                 "id": 7,
                 "name": "getContainerRequest",
-                "type": "GetContainerRequestProto"
+                "type": "GetContainerRequestProto",
+                "optional": true
               },
               {
                 "id": 8,
                 "name": "getContainerWithPipelineRequest",
-                "type": "GetContainerWithPipelineRequestProto"
+                "type": "GetContainerWithPipelineRequestProto",
+                "optional": true
               },
               {
                 "id": 9,
                 "name": "scmListContainerRequest",
-                "type": "SCMListContainerRequestProto"
+                "type": "SCMListContainerRequestProto",
+                "optional": true
               },
               {
                 "id": 10,
                 "name": "scmDeleteContainerRequest",
-                "type": "SCMDeleteContainerRequestProto"
+                "type": "SCMDeleteContainerRequestProto",
+                "optional": true
               },
               {
                 "id": 11,
                 "name": "nodeQueryRequest",
-                "type": "NodeQueryRequestProto"
+                "type": "NodeQueryRequestProto",
+                "optional": true
               },
               {
                 "id": 12,
                 "name": "scmCloseContainerRequest",
-                "type": "SCMCloseContainerRequestProto"
+                "type": "SCMCloseContainerRequestProto",
+                "optional": true
               },
               {
                 "id": 13,
                 "name": "pipelineRequest",
-                "type": "PipelineRequestProto"
+                "type": "PipelineRequestProto",
+                "optional": true
               },
               {
                 "id": 14,
                 "name": "listPipelineRequest",
-                "type": "ListPipelineRequestProto"
+                "type": "ListPipelineRequestProto",
+                "optional": true
               },
               {
                 "id": 15,
                 "name": "activatePipelineRequest",
-                "type": "ActivatePipelineRequestProto"
+                "type": "ActivatePipelineRequestProto",
+                "optional": true
               },
               {
                 "id": 16,
                 "name": "deactivatePipelineRequest",
-                "type": "DeactivatePipelineRequestProto"
+                "type": "DeactivatePipelineRequestProto",
+                "optional": true
               },
               {
                 "id": 17,
                 "name": "closePipelineRequest",
-                "type": "ClosePipelineRequestProto"
+                "type": "ClosePipelineRequestProto",
+                "optional": true
               },
               {
                 "id": 18,
                 "name": "getScmInfoRequest",
-                "type": "GetScmInfoRequestProto"
+                "type": "GetScmInfoRequestProto",
+                "optional": true
               },
               {
                 "id": 19,
                 "name": "inSafeModeRequest",
-                "type": "InSafeModeRequestProto"
+                "type": "InSafeModeRequestProto",
+                "optional": true
               },
               {
                 "id": 20,
                 "name": "forceExitSafeModeRequest",
-                "type": "ForceExitSafeModeRequestProto"
+                "type": "ForceExitSafeModeRequestProto",
+                "optional": true
               },
               {
                 "id": 21,
                 "name": "startReplicationManagerRequest",
-                "type": "StartReplicationManagerRequestProto"
+                "type": "StartReplicationManagerRequestProto",
+                "optional": true
               },
               {
                 "id": 22,
                 "name": "stopReplicationManagerRequest",
-                "type": "StopReplicationManagerRequestProto"
+                "type": "StopReplicationManagerRequestProto",
+                "optional": true
               },
               {
                 "id": 23,
                 "name": "seplicationManagerStatusRequest",
-                "type": "ReplicationManagerStatusRequestProto"
+                "type": "ReplicationManagerStatusRequestProto",
+                "optional": true
               },
               {
                 "id": 24,
                 "name": "getPipelineRequest",
-                "type": "GetPipelineRequestProto"
+                "type": "GetPipelineRequestProto",
+                "optional": true
               },
               {
                 "id": 25,
                 "name": "getContainerWithPipelineBatchRequest",
-                "type": "GetContainerWithPipelineBatchRequestProto"
+                "type": "GetContainerWithPipelineBatchRequestProto",
+                "optional": true
               },
               {
                 "id": 26,
                 "name": "getSafeModeRuleStatusesRequest",
-                "type": "GetSafeModeRuleStatusesRequestProto"
+                "type": "GetSafeModeRuleStatusesRequestProto",
+                "optional": true
               },
               {
                 "id": 27,
                 "name": "decommissionNodesRequest",
-                "type": "DecommissionNodesRequestProto"
+                "type": "DecommissionNodesRequestProto",
+                "optional": true
               },
               {
                 "id": 28,
                 "name": "recommissionNodesRequest",
-                "type": "RecommissionNodesRequestProto"
+                "type": "RecommissionNodesRequestProto",
+                "optional": true
               },
               {
                 "id": 29,
                 "name": "startMaintenanceNodesRequest",
-                "type": "StartMaintenanceNodesRequestProto"
+                "type": "StartMaintenanceNodesRequestProto",
+                "optional": true
               },
               {
                 "id": 30,
                 "name": "DatanodeUsageInfoRequest",
-                "type": "DatanodeUsageInfoRequestProto"
+                "type": "DatanodeUsageInfoRequestProto",
+                "optional": true
               },
               {
                 "id": 31,
                 "name": "getExistContainerWithPipelinesInBatchRequest",
-                "type": "GetExistContainerWithPipelinesInBatchRequestProto"
+                "type": "GetExistContainerWithPipelinesInBatchRequestProto",
+                "optional": true
               },
               {
                 "id": 32,
                 "name": "containerTokenRequest",
-                "type": "GetContainerTokenRequestProto"
+                "type": "GetContainerTokenRequestProto",
+                "optional": true
               },
               {
                 "id": 33,
                 "name": "startContainerBalancerRequest",
-                "type": "StartContainerBalancerRequestProto"
+                "type": "StartContainerBalancerRequestProto",
+                "optional": true
               },
               {
                 "id": 34,
                 "name": "stopContainerBalancerRequest",
-                "type": "StopContainerBalancerRequestProto"
+                "type": "StopContainerBalancerRequestProto",
+                "optional": true
               },
               {
                 "id": 35,
                 "name": "containerBalancerStatusRequest",
-                "type": "ContainerBalancerStatusRequestProto"
+                "type": "ContainerBalancerStatusRequestProto",
+                "optional": true
               },
               {
                 "id": 36,
                 "name": "finalizeScmUpgradeRequest",
-                "type": "FinalizeScmUpgradeRequestProto"
+                "type": "FinalizeScmUpgradeRequestProto",
+                "optional": true
               },
               {
                 "id": 37,
                 "name": "queryUpgradeFinalizationProgressRequest",
-                "type": "QueryUpgradeFinalizationProgressRequestProto"
+                "type": "QueryUpgradeFinalizationProgressRequestProto",
+                "optional": true
+              },
+              {
+                "id": 38,
+                "name": "getContainerCountRequest",
+                "type": "GetContainerCountRequestProto",
+                "optional": true
+              },
+              {
+                "id": 39,
+                "name": "getContainerReplicasRequest",
+                "type": "GetContainerReplicasRequestProto",
+                "optional": true
+              },
+              {
+                "id": 40,
+                "name": "replicationManagerReportRequest",
+                "type": "ReplicationManagerReportRequestProto",
+                "optional": true
+              },
+              {
+                "id": 41,
+                "name": "resetDeletedBlockRetryCountRequest",
+                "type": "ResetDeletedBlockRetryCountRequestProto",
+                "optional": true
               }
             ]
           },
@@ -380,17 +455,20 @@
               {
                 "id": 1,
                 "name": "cmdType",
-                "type": "Type"
+                "type": "Type",
+                "required": true
               },
               {
                 "id": 2,
                 "name": "traceID",
-                "type": "string"
+                "type": "string",
+                "optional": true
               },
               {
                 "id": 3,
                 "name": "success",
                 "type": "bool",
+                "optional": true,
                 "options": [
                   {
                     "name": "default",
@@ -401,172 +479,230 @@
               {
                 "id": 4,
                 "name": "message",
-                "type": "string"
+                "type": "string",
+                "optional": true
               },
               {
                 "id": 5,
                 "name": "status",
-                "type": "Status"
+                "type": "Status",
+                "required": true
               },
               {
                 "id": 6,
                 "name": "containerResponse",
-                "type": "ContainerResponseProto"
+                "type": "ContainerResponseProto",
+                "optional": true
               },
               {
                 "id": 7,
                 "name": "getContainerResponse",
-                "type": "GetContainerResponseProto"
+                "type": "GetContainerResponseProto",
+                "optional": true
               },
               {
                 "id": 8,
                 "name": "getContainerWithPipelineResponse",
-                "type": "GetContainerWithPipelineResponseProto"
+                "type": "GetContainerWithPipelineResponseProto",
+                "optional": true
               },
               {
                 "id": 9,
                 "name": "scmListContainerResponse",
-                "type": "SCMListContainerResponseProto"
+                "type": "SCMListContainerResponseProto",
+                "optional": true
               },
               {
                 "id": 10,
                 "name": "scmDeleteContainerResponse",
-                "type": "SCMDeleteContainerResponseProto"
+                "type": "SCMDeleteContainerResponseProto",
+                "optional": true
               },
               {
                 "id": 11,
                 "name": "nodeQueryResponse",
-                "type": "NodeQueryResponseProto"
+                "type": "NodeQueryResponseProto",
+                "optional": true
               },
               {
                 "id": 12,
                 "name": "scmCloseContainerResponse",
-                "type": "SCMCloseContainerResponseProto"
+                "type": "SCMCloseContainerResponseProto",
+                "optional": true
               },
               {
                 "id": 13,
                 "name": "pipelineResponse",
-                "type": "PipelineResponseProto"
+                "type": "PipelineResponseProto",
+                "optional": true
               },
               {
                 "id": 14,
                 "name": "listPipelineResponse",
-                "type": "ListPipelineResponseProto"
+                "type": "ListPipelineResponseProto",
+                "optional": true
               },
               {
                 "id": 15,
                 "name": "activatePipelineResponse",
-                "type": "ActivatePipelineResponseProto"
+                "type": "ActivatePipelineResponseProto",
+                "optional": true
               },
               {
                 "id": 16,
                 "name": "deactivatePipelineResponse",
-                "type": "DeactivatePipelineResponseProto"
+                "type": "DeactivatePipelineResponseProto",
+                "optional": true
               },
               {
                 "id": 17,
                 "name": "closePipelineResponse",
-                "type": "ClosePipelineResponseProto"
+                "type": "ClosePipelineResponseProto",
+                "optional": true
               },
               {
                 "id": 18,
                 "name": "getScmInfoResponse",
-                "type": "GetScmInfoResponseProto"
+                "type": "GetScmInfoResponseProto",
+                "optional": true
               },
               {
                 "id": 19,
                 "name": "inSafeModeResponse",
-                "type": "InSafeModeResponseProto"
+                "type": "InSafeModeResponseProto",
+                "optional": true
               },
               {
                 "id": 20,
                 "name": "forceExitSafeModeResponse",
-                "type": "ForceExitSafeModeResponseProto"
+                "type": "ForceExitSafeModeResponseProto",
+                "optional": true
               },
               {
                 "id": 21,
                 "name": "startReplicationManagerResponse",
-                "type": "StartReplicationManagerResponseProto"
+                "type": "StartReplicationManagerResponseProto",
+                "optional": true
               },
               {
                 "id": 22,
                 "name": "stopReplicationManagerResponse",
-                "type": "StopReplicationManagerResponseProto"
+                "type": "StopReplicationManagerResponseProto",
+                "optional": true
               },
               {
                 "id": 23,
                 "name": "replicationManagerStatusResponse",
-                "type": "ReplicationManagerStatusResponseProto"
+                "type": "ReplicationManagerStatusResponseProto",
+                "optional": true
               },
               {
                 "id": 24,
                 "name": "getPipelineResponse",
-                "type": "GetPipelineResponseProto"
+                "type": "GetPipelineResponseProto",
+                "optional": true
               },
               {
                 "id": 25,
                 "name": "getContainerWithPipelineBatchResponse",
-                "type": "GetContainerWithPipelineBatchResponseProto"
+                "type": "GetContainerWithPipelineBatchResponseProto",
+                "optional": true
               },
               {
                 "id": 26,
                 "name": "getSafeModeRuleStatusesResponse",
-                "type": "GetSafeModeRuleStatusesResponseProto"
+                "type": "GetSafeModeRuleStatusesResponseProto",
+                "optional": true
               },
               {
                 "id": 27,
                 "name": "decommissionNodesResponse",
-                "type": "DecommissionNodesResponseProto"
+                "type": "DecommissionNodesResponseProto",
+                "optional": true
               },
               {
                 "id": 28,
                 "name": "recommissionNodesResponse",
-                "type": "RecommissionNodesResponseProto"
+                "type": "RecommissionNodesResponseProto",
+                "optional": true
               },
               {
                 "id": 29,
                 "name": "startMaintenanceNodesResponse",
-                "type": "StartMaintenanceNodesResponseProto"
+                "type": "StartMaintenanceNodesResponseProto",
+                "optional": true
               },
               {
                 "id": 30,
                 "name": "DatanodeUsageInfoResponse",
-                "type": "DatanodeUsageInfoResponseProto"
+                "type": "DatanodeUsageInfoResponseProto",
+                "optional": true
               },
               {
                 "id": 31,
                 "name": "getExistContainerWithPipelinesInBatchResponse",
-                "type": "GetExistContainerWithPipelinesInBatchResponseProto"
+                "type": "GetExistContainerWithPipelinesInBatchResponseProto",
+                "optional": true
               },
               {
                 "id": 32,
                 "name": "containerTokenResponse",
-                "type": "GetContainerTokenResponseProto"
+                "type": "GetContainerTokenResponseProto",
+                "optional": true
               },
               {
                 "id": 33,
                 "name": "startContainerBalancerResponse",
-                "type": "StartContainerBalancerResponseProto"
+                "type": "StartContainerBalancerResponseProto",
+                "optional": true
               },
               {
                 "id": 34,
                 "name": "stopContainerBalancerResponse",
-                "type": "StopContainerBalancerResponseProto"
+                "type": "StopContainerBalancerResponseProto",
+                "optional": true
               },
               {
                 "id": 35,
                 "name": "containerBalancerStatusResponse",
-                "type": "ContainerBalancerStatusResponseProto"
+                "type": "ContainerBalancerStatusResponseProto",
+                "optional": true
               },
               {
                 "id": 36,
                 "name": "finalizeScmUpgradeResponse",
-                "type": "FinalizeScmUpgradeResponseProto"
+                "type": "FinalizeScmUpgradeResponseProto",
+                "optional": true
               },
               {
                 "id": 37,
                 "name": "queryUpgradeFinalizationProgressResponse",
-                "type": "QueryUpgradeFinalizationProgressResponseProto"
+                "type": "QueryUpgradeFinalizationProgressResponseProto",
+                "optional": true
+              },
+              {
+                "id": 38,
+                "name": "getContainerCountResponse",
+                "type": "GetContainerCountResponseProto",
+                "optional": true
+              },
+              {
+                "id": 39,
+                "name": "getContainerReplicasResponse",
+                "type": "GetContainerReplicasResponseProto",
+                "optional": true
+              },
+              {
+                "id": 40,
+                "name": "getReplicationManagerReportResponse",
+                "type": "ReplicationManagerReportResponseProto",
+                "optional": true
+              },
+              {
+                "id": 41,
+                "name": "resetDeletedBlockRetryCountResponse",
+                "type": "ResetDeletedBlockRetryCountResponseProto",
+                "optional": true
               }
             ]
           },
@@ -576,22 +712,26 @@
               {
                 "id": 2,
                 "name": "replicationFactor",
-                "type": "ReplicationFactor"
+                "type": "ReplicationFactor",
+                "required": true
               },
               {
                 "id": 3,
                 "name": "replicationType",
-                "type": "ReplicationType"
+                "type": "ReplicationType",
+                "required": true
               },
               {
                 "id": 4,
                 "name": "owner",
-                "type": "string"
+                "type": "string",
+                "required": true
               },
               {
                 "id": 5,
                 "name": "traceID",
-                "type": "string"
+                "type": "string",
+                "optional": true
               }
             ]
           },
@@ -601,17 +741,20 @@
               {
                 "id": 1,
                 "name": "errorCode",
-                "type": "Error"
+                "type": "Error",
+                "required": true
               },
               {
                 "id": 2,
                 "name": "containerWithPipeline",
-                "type": "ContainerWithPipeline"
+                "type": "ContainerWithPipeline",
+                "required": true
               },
               {
                 "id": 3,
                 "name": "errorMessage",
-                "type": "string"
+                "type": "string",
+                "optional": true
               }
             ]
           },
@@ -621,12 +764,14 @@
               {
                 "id": 1,
                 "name": "containerID",
-                "type": "int64"
+                "type": "int64",
+                "required": true
               },
               {
                 "id": 2,
                 "name": "traceID",
-                "type": "string"
+                "type": "string",
+                "optional": true
               }
             ]
           },
@@ -636,7 +781,8 @@
               {
                 "id": 1,
                 "name": "containerInfo",
-                "type": "ContainerInfoProto"
+                "type": "ContainerInfoProto",
+                "required": true
               }
             ]
           },
@@ -646,12 +792,14 @@
               {
                 "id": 1,
                 "name": "containerID",
-                "type": "int64"
+                "type": "int64",
+                "required": true
               },
               {
                 "id": 2,
                 "name": "traceID",
-                "type": "string"
+                "type": "string",
+                "optional": true
               }
             ]
           },
@@ -661,7 +809,36 @@
               {
                 "id": 1,
                 "name": "containerWithPipeline",
-                "type": "ContainerWithPipeline"
+                "type": "ContainerWithPipeline",
+                "required": true
+              }
+            ]
+          },
+          {
+            "name": "GetContainerReplicasRequestProto",
+            "fields": [
+              {
+                "id": 1,
+                "name": "containerID",
+                "type": "int64",
+                "required": true
+              },
+              {
+                "id": 2,
+                "name": "traceID",
+                "type": "string",
+                "optional": true
+              }
+            ]
+          },
+          {
+            "name": "GetContainerReplicasResponseProto",
+            "fields": [
+              {
+                "id": 1,
+                "name": "containerReplica",
+                "type": "SCMContainerReplicaProto",
+                "is_repeated": true
               }
             ]
           },
@@ -677,7 +854,8 @@
               {
                 "id": 2,
                 "name": "traceID",
-                "type": "string"
+                "type": "string",
+                "optional": true
               }
             ]
           },
@@ -693,7 +871,8 @@
               {
                 "id": 2,
                 "name": "traceID",
-                "type": "string"
+                "type": "string",
+                "optional": true
               }
             ]
           },
@@ -706,17 +885,20 @@
               {
                 "id": 1,
                 "name": "ruleName",
-                "type": "string"
+                "type": "string",
+                "required": true
               },
               {
                 "id": 2,
                 "name": "validate",
-                "type": "bool"
+                "type": "bool",
+                "required": true
               },
               {
                 "id": 3,
                 "name": "statusText",
-                "type": "string"
+                "type": "string",
+                "required": true
               }
             ]
           },
@@ -759,22 +941,44 @@
               {
                 "id": 1,
                 "name": "count",
-                "type": "uint32"
+                "type": "uint32",
+                "required": true
               },
               {
                 "id": 2,
                 "name": "startContainerID",
-                "type": "uint64"
+                "type": "uint64",
+                "optional": true
               },
               {
                 "id": 3,
                 "name": "traceID",
-                "type": "string"
+                "type": "string",
+                "optional": true
               },
               {
                 "id": 4,
                 "name": "state",
-                "type": "LifeCycleState"
+                "type": "LifeCycleState",
+                "optional": true
+              },
+              {
+                "id": 5,
+                "name": "factor",
+                "type": "ReplicationFactor",
+                "optional": true
+              },
+              {
+                "id": 6,
+                "name": "type",
+                "type": "ReplicationType",
+                "optional": true
+              },
+              {
+                "id": 7,
+                "name": "ecReplicationConfig",
+                "type": "ECReplicationConfig",
+                "optional": true
               }
             ]
           },
@@ -795,12 +999,14 @@
               {
                 "id": 1,
                 "name": "containerID",
-                "type": "int64"
+                "type": "int64",
+                "required": true
               },
               {
                 "id": 2,
                 "name": "traceID",
-                "type": "string"
+                "type": "string",
+                "optional": true
               }
             ]
           },
@@ -813,12 +1019,14 @@
               {
                 "id": 1,
                 "name": "containerID",
-                "type": "int64"
+                "type": "int64",
+                "required": true
               },
               {
                 "id": 2,
                 "name": "traceID",
-                "type": "string"
+                "type": "string",
+                "optional": true
               }
             ]
           },
@@ -831,27 +1039,32 @@
               {
                 "id": 1,
                 "name": "state",
-                "type": "NodeState"
+                "type": "NodeState",
+                "optional": true
               },
               {
                 "id": 2,
                 "name": "scope",
-                "type": "QueryScope"
+                "type": "QueryScope",
+                "required": true
               },
               {
                 "id": 3,
                 "name": "poolName",
-                "type": "string"
+                "type": "string",
+                "optional": true
               },
               {
                 "id": 4,
                 "name": "traceID",
-                "type": "string"
+                "type": "string",
+                "optional": true
               },
               {
                 "id": 5,
                 "name": "opState",
-                "type": "NodeOperationalState"
+                "type": "NodeOperationalState",
+                "optional": true
               }
             ]
           },
@@ -872,22 +1085,26 @@
               {
                 "id": 1,
                 "name": "ipaddress",
-                "type": "string"
+                "type": "string",
+                "optional": true
               },
               {
                 "id": 2,
                 "name": "uuid",
-                "type": "string"
+                "type": "string",
+                "optional": true
               },
               {
                 "id": 3,
                 "name": "mostUsed",
-                "type": "bool"
+                "type": "bool",
+                "optional": true
               },
               {
                 "id": 4,
                 "name": "count",
-                "type": "uint32"
+                "type": "uint32",
+                "optional": true
               }
             ]
           },
@@ -919,12 +1136,14 @@
               {
                 "id": 1,
                 "name": "host",
-                "type": "string"
+                "type": "string",
+                "required": true
               },
               {
                 "id": 2,
                 "name": "error",
-                "type": "string"
+                "type": "string",
+                "required": true
               }
             ]
           },
@@ -973,7 +1192,8 @@
               {
                 "id": 2,
                 "name": "endInHours",
-                "type": "int64"
+                "type": "int64",
+                "optional": true
               }
             ]
           },
@@ -994,27 +1214,32 @@
               {
                 "id": 1,
                 "name": "replicationType",
-                "type": "ReplicationType"
+                "type": "ReplicationType",
+                "required": true
               },
               {
                 "id": 2,
                 "name": "replicationFactor",
-                "type": "ReplicationFactor"
+                "type": "ReplicationFactor",
+                "required": true
               },
               {
                 "id": 3,
                 "name": "nodePool",
-                "type": "NodePool"
+                "type": "NodePool",
+                "optional": true
               },
               {
                 "id": 4,
                 "name": "pipelineID",
-                "type": "string"
+                "type": "string",
+                "optional": true
               },
               {
                 "id": 5,
                 "name": "traceID",
-                "type": "string"
+                "type": "string",
+                "optional": true
               }
             ]
           },
@@ -1024,17 +1249,20 @@
               {
                 "id": 1,
                 "name": "errorCode",
-                "type": "Error"
+                "type": "Error",
+                "required": true
               },
               {
                 "id": 2,
                 "name": "pipeline",
-                "type": "Pipeline"
+                "type": "Pipeline",
+                "optional": true
               },
               {
                 "id": 3,
                 "name": "errorMessage",
-                "type": "string"
+                "type": "string",
+                "optional": true
               }
             ]
           },
@@ -1044,7 +1272,8 @@
               {
                 "id": 1,
                 "name": "traceID",
-                "type": "string"
+                "type": "string",
+                "optional": true
               }
             ]
           },
@@ -1065,12 +1294,14 @@
               {
                 "id": 1,
                 "name": "pipelineID",
-                "type": "PipelineID"
+                "type": "PipelineID",
+                "required": true
               },
               {
                 "id": 2,
                 "name": "traceID",
-                "type": "string"
+                "type": "string",
+                "optional": true
               }
             ]
           },
@@ -1080,7 +1311,22 @@
               {
                 "id": 1,
                 "name": "pipeline",
-                "type": "Pipeline"
+                "type": "Pipeline",
+                "required": true
+              }
+            ]
+          },
+          {
+            "name": "GetContainerCountRequestProto"
+          },
+          {
+            "name": "GetContainerCountResponseProto",
+            "fields": [
+              {
+                "id": 1,
+                "name": "containerCount",
+                "type": "int64",
+                "required": true
               }
             ]
           },
@@ -1090,12 +1336,14 @@
               {
                 "id": 1,
                 "name": "pipelineID",
-                "type": "PipelineID"
+                "type": "PipelineID",
+                "required": true
               },
               {
                 "id": 2,
                 "name": "traceID",
-                "type": "string"
+                "type": "string",
+                "optional": true
               }
             ]
           },
@@ -1108,12 +1356,14 @@
               {
                 "id": 1,
                 "name": "pipelineID",
-                "type": "PipelineID"
+                "type": "PipelineID",
+                "required": true
               },
               {
                 "id": 2,
                 "name": "traceID",
-                "type": "string"
+                "type": "string",
+                "optional": true
               }
             ]
           },
@@ -1126,12 +1376,14 @@
               {
                 "id": 1,
                 "name": "pipelineID",
-                "type": "PipelineID"
+                "type": "PipelineID",
+                "required": true
               },
               {
                 "id": 2,
                 "name": "traceID",
-                "type": "string"
+                "type": "string",
+                "optional": true
               }
             ]
           },
@@ -1144,7 +1396,8 @@
               {
                 "id": 1,
                 "name": "traceID",
-                "type": "string"
+                "type": "string",
+                "optional": true
               }
             ]
           },
@@ -1154,7 +1407,8 @@
               {
                 "id": 1,
                 "name": "inSafeMode",
-                "type": "bool"
+                "type": "bool",
+                "required": true
               }
             ]
           },
@@ -1164,7 +1418,8 @@
               {
                 "id": 1,
                 "name": "traceID",
-                "type": "string"
+                "type": "string",
+                "optional": true
               }
             ]
           },
@@ -1174,7 +1429,8 @@
               {
                 "id": 1,
                 "name": "exitedSafeMode",
-                "type": "bool"
+                "type": "bool",
+                "required": true
               }
             ]
           },
@@ -1184,7 +1440,8 @@
               {
                 "id": 1,
                 "name": "traceID",
-                "type": "string"
+                "type": "string",
+                "optional": true
               }
             ]
           },
@@ -1197,7 +1454,8 @@
               {
                 "id": 1,
                 "name": "traceID",
-                "type": "string"
+                "type": "string",
+                "optional": true
               }
             ]
           },
@@ -1210,7 +1468,8 @@
               {
                 "id": 1,
                 "name": "traceID",
-                "type": "string"
+                "type": "string",
+                "optional": true
               }
             ]
           },
@@ -1220,7 +1479,58 @@
               {
                 "id": 1,
                 "name": "isRunning",
-                "type": "bool"
+                "type": "bool",
+                "required": true
+              }
+            ]
+          },
+          {
+            "name": "ReplicationManagerReportRequestProto",
+            "fields": [
+              {
+                "id": 1,
+                "name": "traceID",
+                "type": "string",
+                "optional": true
+              }
+            ]
+          },
+          {
+            "name": "ReplicationManagerReportResponseProto",
+            "fields": [
+              {
+                "id": 1,
+                "name": "report",
+                "type": "ReplicationManagerReportProto",
+                "required": true
+              }
+            ]
+          },
+          {
+            "name": "ResetDeletedBlockRetryCountRequestProto",
+            "fields": [
+              {
+                "id": 1,
+                "name": "traceID",
+                "type": "string",
+                "optional": true
+              },
+              {
+                "id": 2,
+                "name": "transactionId",
+                "type": "int64",
+                "is_repeated": true
+              }
+            ]
+          },
+          {
+            "name": "ResetDeletedBlockRetryCountResponseProto",
+            "fields": [
+              {
+                "id": 1,
+                "name": "resetCount",
+                "type": "int32",
+                "required": true
               }
             ]
           },
@@ -1230,7 +1540,8 @@
               {
                 "id": 1,
                 "name": "upgradeClientId",
-                "type": "string"
+                "type": "string",
+                "required": true
               }
             ]
           },
@@ -1240,7 +1551,8 @@
               {
                 "id": 1,
                 "name": "status",
-                "type": "hadoop.hdds.UpgradeFinalizationStatus"
+                "type": "hadoop.hdds.UpgradeFinalizationStatus",
+                "required": true
               }
             ]
           },
@@ -1250,17 +1562,20 @@
               {
                 "id": 1,
                 "name": "upgradeClientId",
-                "type": "string"
+                "type": "string",
+                "required": true
               },
               {
                 "id": 2,
                 "name": "takeover",
-                "type": "bool"
+                "type": "bool",
+                "optional": true
               },
               {
                 "id": 3,
                 "name": "readonly",
-                "type": "bool"
+                "type": "bool",
+                "optional": true
               }
             ]
           },
@@ -1270,7 +1585,8 @@
               {
                 "id": 1,
                 "name": "status",
-                "type": "hadoop.hdds.UpgradeFinalizationStatus"
+                "type": "hadoop.hdds.UpgradeFinalizationStatus",
+                "required": true
               }
             ]
           },
@@ -1280,22 +1596,26 @@
               {
                 "id": 1,
                 "name": "ownerId",
-                "type": "string"
+                "type": "string",
+                "required": true
               },
               {
                 "id": 2,
                 "name": "containerId",
-                "type": "ContainerID"
+                "type": "ContainerID",
+                "required": true
               },
               {
                 "id": 3,
                 "name": "expiryDate",
-                "type": "uint64"
+                "type": "uint64",
+                "required": true
               },
               {
                 "id": 4,
                 "name": "certSerialId",
-                "type": "string"
+                "type": "string",
+                "required": true
               }
             ]
           },
@@ -1305,7 +1625,8 @@
               {
                 "id": 1,
                 "name": "containerID",
-                "type": "ContainerID"
+                "type": "ContainerID",
+                "required": true
               }
             ]
           },
@@ -1315,7 +1636,8 @@
               {
                 "id": 1,
                 "name": "token",
-                "type": "TokenProto"
+                "type": "TokenProto",
+                "required": true
               }
             ]
           },
@@ -1325,37 +1647,68 @@
               {
                 "id": 1,
                 "name": "traceID",
-                "type": "string"
+                "type": "string",
+                "optional": true
               },
               {
                 "id": 2,
                 "name": "threshold",
-                "type": "double"
+                "type": "double",
+                "optional": true
               },
               {
                 "id": 3,
                 "name": "idleiterations",
-                "type": "int32"
+                "type": "int32",
+                "optional": true,
+                "options": [
+                  {
+                    "name": "deprecated",
+                    "value": "true"
+                  }
+                ]
               },
               {
                 "id": 4,
                 "name": "maxDatanodesRatioToInvolvePerIteration",
-                "type": "double"
+                "type": "double",
+                "optional": true,
+                "options": [
+                  {
+                    "name": "deprecated",
+                    "value": "true"
+                  }
+                ]
               },
               {
                 "id": 5,
                 "name": "maxSizeToMovePerIterationInGB",
-                "type": "int64"
+                "type": "int64",
+                "optional": true
               },
               {
                 "id": 6,
                 "name": "maxSizeEnteringTargetInGB",
-                "type": "int64"
+                "type": "int64",
+                "optional": true
               },
               {
                 "id": 7,
                 "name": "maxSizeLeavingSourceInGB",
-                "type": "int64"
+                "type": "int64",
+                "optional": true
+              },
+              {
+                "id": 8,
+                "name": "maxDatanodesPercentageToInvolvePerIteration",
+                "type": "int32",
+                "optional": true
+              },
+              {
+                "id": 9,
+                "name": "iterations",
+                "type": "int32",
+                "optional": true
               }
             ]
           },
@@ -1365,7 +1718,14 @@
               {
                 "id": 1,
                 "name": "start",
-                "type": "bool"
+                "type": "bool",
+                "required": true
+              },
+              {
+                "id": 2,
+                "name": "message",
+                "type": "string",
+                "optional": true
               }
             ]
           },
@@ -1375,7 +1735,8 @@
               {
                 "id": 1,
                 "name": "traceID",
-                "type": "string"
+                "type": "string",
+                "optional": true
               }
             ]
           },
@@ -1388,7 +1749,8 @@
               {
                 "id": 1,
                 "name": "traceID",
-                "type": "string"
+                "type": "string",
+                "optional": true
               }
             ]
           },
@@ -1398,7 +1760,8 @@
               {
                 "id": 1,
                 "name": "isRunning",
-                "type": "bool"
+                "type": "bool",
+                "required": true
               }
             ]
           }

--- a/hadoop-hdds/interface-client/src/main/resources/proto.lock
+++ b/hadoop-hdds/interface-client/src/main/resources/proto.lock
@@ -251,6 +251,18 @@
               {
                 "name": "CHUNK_FILE_INCONSISTENCY",
                 "integer": 43
+              },
+              {
+                "name": "DELETE_ON_NON_EMPTY_CONTAINER",
+                "integer": 44
+              },
+              {
+                "name": "EXPORT_CONTAINER_METADATA_FAILED",
+                "integer": 45
+              },
+              {
+                "name": "IMPORT_CONTAINER_METADATA_FAILED",
+                "integer": 46
               }
             ]
           },
@@ -284,6 +296,10 @@
               {
                 "name": "DELETED",
                 "integer": 7
+              },
+              {
+                "name": "RECOVERING",
+                "integer": 8
               }
             ]
           },
@@ -341,23 +357,32 @@
               {
                 "id": 1,
                 "name": "containerID",
-                "type": "int64"
+                "type": "int64",
+                "required": true
               },
               {
                 "id": 2,
                 "name": "localID",
-                "type": "int64"
+                "type": "int64",
+                "required": true
               },
               {
                 "id": 3,
                 "name": "blockCommitSequenceId",
                 "type": "uint64",
+                "optional": true,
                 "options": [
                   {
                     "name": "default",
                     "value": "0"
                   }
                 ]
+              },
+              {
+                "id": 4,
+                "name": "replicaIndex",
+                "type": "int32",
+                "optional": true
               }
             ]
           },
@@ -367,12 +392,14 @@
               {
                 "id": 1,
                 "name": "key",
-                "type": "string"
+                "type": "string",
+                "required": true
               },
               {
                 "id": 2,
                 "name": "value",
-                "type": "string"
+                "type": "string",
+                "optional": true
               }
             ]
           },
@@ -382,122 +409,158 @@
               {
                 "id": 1,
                 "name": "cmdType",
-                "type": "Type"
+                "type": "Type",
+                "required": true
               },
               {
                 "id": 2,
                 "name": "traceID",
-                "type": "string"
+                "type": "string",
+                "optional": true
               },
               {
                 "id": 3,
                 "name": "containerID",
-                "type": "int64"
+                "type": "int64",
+                "required": true
               },
               {
                 "id": 4,
                 "name": "datanodeUuid",
-                "type": "string"
+                "type": "string",
+                "required": true
               },
               {
                 "id": 5,
                 "name": "pipelineID",
-                "type": "string"
+                "type": "string",
+                "optional": true
               },
               {
                 "id": 6,
                 "name": "createContainer",
-                "type": "CreateContainerRequestProto"
+                "type": "CreateContainerRequestProto",
+                "optional": true
               },
               {
                 "id": 7,
                 "name": "readContainer",
-                "type": "ReadContainerRequestProto"
+                "type": "ReadContainerRequestProto",
+                "optional": true
               },
               {
                 "id": 8,
                 "name": "updateContainer",
-                "type": "UpdateContainerRequestProto"
+                "type": "UpdateContainerRequestProto",
+                "optional": true
               },
               {
                 "id": 9,
                 "name": "deleteContainer",
-                "type": "DeleteContainerRequestProto"
+                "type": "DeleteContainerRequestProto",
+                "optional": true
               },
               {
                 "id": 10,
                 "name": "listContainer",
-                "type": "ListContainerRequestProto"
+                "type": "ListContainerRequestProto",
+                "optional": true
               },
               {
                 "id": 11,
                 "name": "closeContainer",
-                "type": "CloseContainerRequestProto"
+                "type": "CloseContainerRequestProto",
+                "optional": true
               },
               {
                 "id": 12,
                 "name": "putBlock",
-                "type": "PutBlockRequestProto"
+                "type": "PutBlockRequestProto",
+                "optional": true
               },
               {
                 "id": 13,
                 "name": "getBlock",
-                "type": "GetBlockRequestProto"
+                "type": "GetBlockRequestProto",
+                "optional": true
               },
               {
                 "id": 14,
                 "name": "deleteBlock",
-                "type": "DeleteBlockRequestProto"
+                "type": "DeleteBlockRequestProto",
+                "optional": true,
+                "options": [
+                  {
+                    "name": "deprecated",
+                    "value": "true"
+                  }
+                ]
               },
               {
                 "id": 15,
                 "name": "listBlock",
-                "type": "ListBlockRequestProto"
+                "type": "ListBlockRequestProto",
+                "optional": true
               },
               {
                 "id": 16,
                 "name": "readChunk",
-                "type": "ReadChunkRequestProto"
+                "type": "ReadChunkRequestProto",
+                "optional": true
               },
               {
                 "id": 17,
                 "name": "writeChunk",
-                "type": "WriteChunkRequestProto"
+                "type": "WriteChunkRequestProto",
+                "optional": true
               },
               {
                 "id": 18,
                 "name": "deleteChunk",
-                "type": "DeleteChunkRequestProto"
+                "type": "DeleteChunkRequestProto",
+                "optional": true,
+                "options": [
+                  {
+                    "name": "deprecated",
+                    "value": "true"
+                  }
+                ]
               },
               {
                 "id": 19,
                 "name": "listChunk",
-                "type": "ListChunkRequestProto"
+                "type": "ListChunkRequestProto",
+                "optional": true
               },
               {
                 "id": 20,
                 "name": "putSmallFile",
-                "type": "PutSmallFileRequestProto"
+                "type": "PutSmallFileRequestProto",
+                "optional": true
               },
               {
                 "id": 21,
                 "name": "getSmallFile",
-                "type": "GetSmallFileRequestProto"
+                "type": "GetSmallFileRequestProto",
+                "optional": true
               },
               {
                 "id": 22,
                 "name": "getCommittedBlockLength",
-                "type": "GetCommittedBlockLengthRequestProto"
+                "type": "GetCommittedBlockLengthRequestProto",
+                "optional": true
               },
               {
                 "id": 23,
                 "name": "encodedToken",
-                "type": "string"
+                "type": "string",
+                "optional": true
               },
               {
                 "id": 24,
                 "name": "version",
-                "type": "uint32"
+                "type": "uint32",
+                "optional": true
               }
             ]
           },
@@ -507,107 +570,128 @@
               {
                 "id": 1,
                 "name": "cmdType",
-                "type": "Type"
+                "type": "Type",
+                "required": true
               },
               {
                 "id": 2,
                 "name": "traceID",
-                "type": "string"
+                "type": "string",
+                "optional": true
               },
               {
                 "id": 3,
                 "name": "result",
-                "type": "Result"
+                "type": "Result",
+                "required": true
               },
               {
                 "id": 4,
                 "name": "message",
-                "type": "string"
+                "type": "string",
+                "optional": true
               },
               {
                 "id": 5,
                 "name": "createContainer",
-                "type": "CreateContainerResponseProto"
+                "type": "CreateContainerResponseProto",
+                "optional": true
               },
               {
                 "id": 6,
                 "name": "readContainer",
-                "type": "ReadContainerResponseProto"
+                "type": "ReadContainerResponseProto",
+                "optional": true
               },
               {
                 "id": 7,
                 "name": "updateContainer",
-                "type": "UpdateContainerResponseProto"
+                "type": "UpdateContainerResponseProto",
+                "optional": true
               },
               {
                 "id": 8,
                 "name": "deleteContainer",
-                "type": "DeleteContainerResponseProto"
+                "type": "DeleteContainerResponseProto",
+                "optional": true
               },
               {
                 "id": 9,
                 "name": "listContainer",
-                "type": "ListContainerResponseProto"
+                "type": "ListContainerResponseProto",
+                "optional": true
               },
               {
                 "id": 10,
                 "name": "closeContainer",
-                "type": "CloseContainerResponseProto"
+                "type": "CloseContainerResponseProto",
+                "optional": true
               },
               {
                 "id": 11,
                 "name": "putBlock",
-                "type": "PutBlockResponseProto"
+                "type": "PutBlockResponseProto",
+                "optional": true
               },
               {
                 "id": 12,
                 "name": "getBlock",
-                "type": "GetBlockResponseProto"
+                "type": "GetBlockResponseProto",
+                "optional": true
               },
               {
                 "id": 13,
                 "name": "deleteBlock",
-                "type": "DeleteBlockResponseProto"
+                "type": "DeleteBlockResponseProto",
+                "optional": true
               },
               {
                 "id": 14,
                 "name": "listBlock",
-                "type": "ListBlockResponseProto"
+                "type": "ListBlockResponseProto",
+                "optional": true
               },
               {
                 "id": 15,
                 "name": "writeChunk",
-                "type": "WriteChunkResponseProto"
+                "type": "WriteChunkResponseProto",
+                "optional": true
               },
               {
                 "id": 16,
                 "name": "readChunk",
-                "type": "ReadChunkResponseProto"
+                "type": "ReadChunkResponseProto",
+                "optional": true
               },
               {
                 "id": 17,
                 "name": "deleteChunk",
-                "type": "DeleteChunkResponseProto"
+                "type": "DeleteChunkResponseProto",
+                "optional": true
               },
               {
                 "id": 18,
                 "name": "listChunk",
-                "type": "ListChunkResponseProto"
+                "type": "ListChunkResponseProto",
+                "optional": true
               },
               {
                 "id": 19,
                 "name": "putSmallFile",
-                "type": "PutSmallFileResponseProto"
+                "type": "PutSmallFileResponseProto",
+                "optional": true
               },
               {
                 "id": 20,
                 "name": "getSmallFile",
-                "type": "GetSmallFileResponseProto"
+                "type": "GetSmallFileResponseProto",
+                "optional": true
               },
               {
                 "id": 21,
                 "name": "getCommittedBlockLength",
-                "type": "GetCommittedBlockLengthResponseProto"
+                "type": "GetCommittedBlockLengthResponseProto",
+                "optional": true
               }
             ]
           },
@@ -617,7 +701,8 @@
               {
                 "id": 1,
                 "name": "containerID",
-                "type": "int64"
+                "type": "int64",
+                "required": true
               },
               {
                 "id": 2,
@@ -628,27 +713,32 @@
               {
                 "id": 4,
                 "name": "containerPath",
-                "type": "string"
+                "type": "string",
+                "optional": true
               },
               {
                 "id": 6,
                 "name": "bytesUsed",
-                "type": "int64"
+                "type": "int64",
+                "optional": true
               },
               {
                 "id": 7,
                 "name": "size",
-                "type": "int64"
+                "type": "int64",
+                "optional": true
               },
               {
                 "id": 8,
                 "name": "blockCount",
-                "type": "int64"
+                "type": "int64",
+                "optional": true
               },
               {
                 "id": 9,
                 "name": "state",
                 "type": "State",
+                "optional": true,
                 "options": [
                   {
                     "name": "default",
@@ -660,6 +750,7 @@
                 "id": 10,
                 "name": "containerType",
                 "type": "ContainerType",
+                "optional": true,
                 "options": [
                   {
                     "name": "default",
@@ -695,12 +786,25 @@
                 "id": 3,
                 "name": "containerType",
                 "type": "ContainerType",
+                "optional": true,
                 "options": [
                   {
                     "name": "default",
                     "value": "KeyValueContainer"
                   }
                 ]
+              },
+              {
+                "id": 4,
+                "name": "replicaIndex",
+                "type": "int32",
+                "optional": true
+              },
+              {
+                "id": 5,
+                "name": "state",
+                "type": "ContainerDataProto.State",
+                "optional": true
               }
             ]
           },
@@ -716,7 +820,8 @@
               {
                 "id": 1,
                 "name": "containerData",
-                "type": "ContainerDataProto"
+                "type": "ContainerDataProto",
+                "optional": true
               }
             ]
           },
@@ -733,6 +838,7 @@
                 "id": 3,
                 "name": "forceUpdate",
                 "type": "bool",
+                "optional": true,
                 "options": [
                   {
                     "name": "default",
@@ -752,6 +858,7 @@
                 "id": 2,
                 "name": "forceDelete",
                 "type": "bool",
+                "optional": true,
                 "options": [
                   {
                     "name": "default",
@@ -770,7 +877,8 @@
               {
                 "id": 2,
                 "name": "count",
-                "type": "uint32"
+                "type": "uint32",
+                "optional": true
               }
             ]
           },
@@ -794,12 +902,14 @@
               {
                 "id": 1,
                 "name": "hash",
-                "type": "string"
+                "type": "string",
+                "optional": true
               },
               {
                 "id": 2,
                 "name": "containerID",
-                "type": "int64"
+                "type": "int64",
+                "optional": true
               }
             ]
           },
@@ -809,12 +919,14 @@
               {
                 "id": 1,
                 "name": "blockID",
-                "type": "DatanodeBlockID"
+                "type": "DatanodeBlockID",
+                "required": true
               },
               {
                 "id": 2,
                 "name": "flags",
-                "type": "int64"
+                "type": "int64",
+                "optional": true
               },
               {
                 "id": 3,
@@ -831,7 +943,8 @@
               {
                 "id": 5,
                 "name": "size",
-                "type": "int64"
+                "type": "int64",
+                "optional": true
               }
             ]
           },
@@ -841,12 +954,14 @@
               {
                 "id": 1,
                 "name": "blockData",
-                "type": "BlockData"
+                "type": "BlockData",
+                "required": true
               },
               {
                 "id": 2,
                 "name": "eof",
-                "type": "bool"
+                "type": "bool",
+                "optional": true
               }
             ]
           },
@@ -856,7 +971,8 @@
               {
                 "id": 1,
                 "name": "committedBlockLength",
-                "type": "GetCommittedBlockLengthResponseProto"
+                "type": "GetCommittedBlockLengthResponseProto",
+                "required": true
               }
             ]
           },
@@ -866,7 +982,8 @@
               {
                 "id": 1,
                 "name": "blockID",
-                "type": "DatanodeBlockID"
+                "type": "DatanodeBlockID",
+                "required": true
               }
             ]
           },
@@ -876,7 +993,8 @@
               {
                 "id": 1,
                 "name": "blockData",
-                "type": "BlockData"
+                "type": "BlockData",
+                "required": true
               }
             ]
           },
@@ -886,7 +1004,8 @@
               {
                 "id": 1,
                 "name": "blockID",
-                "type": "DatanodeBlockID"
+                "type": "DatanodeBlockID",
+                "required": true
               }
             ]
           },
@@ -896,7 +1015,8 @@
               {
                 "id": 1,
                 "name": "blockID",
-                "type": "DatanodeBlockID"
+                "type": "DatanodeBlockID",
+                "required": true
               }
             ]
           },
@@ -906,12 +1026,14 @@
               {
                 "id": 1,
                 "name": "blockID",
-                "type": "DatanodeBlockID"
+                "type": "DatanodeBlockID",
+                "required": true
               },
               {
                 "id": 2,
                 "name": "blockLength",
-                "type": "int64"
+                "type": "int64",
+                "required": true
               }
             ]
           },
@@ -924,12 +1046,14 @@
               {
                 "id": 2,
                 "name": "startLocalID",
-                "type": "int64"
+                "type": "int64",
+                "optional": true
               },
               {
                 "id": 3,
                 "name": "count",
-                "type": "uint32"
+                "type": "uint32",
+                "required": true
               }
             ]
           },
@@ -950,17 +1074,20 @@
               {
                 "id": 1,
                 "name": "chunkName",
-                "type": "string"
+                "type": "string",
+                "required": true
               },
               {
                 "id": 2,
                 "name": "offset",
-                "type": "uint64"
+                "type": "uint64",
+                "required": true
               },
               {
                 "id": 3,
                 "name": "len",
-                "type": "uint64"
+                "type": "uint64",
+                "required": true
               },
               {
                 "id": 4,
@@ -971,7 +1098,8 @@
               {
                 "id": 5,
                 "name": "checksumData",
-                "type": "ChecksumData"
+                "type": "ChecksumData",
+                "required": true
               }
             ]
           },
@@ -992,12 +1120,14 @@
               {
                 "id": 1,
                 "name": "type",
-                "type": "ChecksumType"
+                "type": "ChecksumType",
+                "required": true
               },
               {
                 "id": 2,
                 "name": "bytesPerChecksum",
-                "type": "uint32"
+                "type": "uint32",
+                "required": true
               },
               {
                 "id": 3,
@@ -1013,17 +1143,20 @@
               {
                 "id": 1,
                 "name": "blockID",
-                "type": "DatanodeBlockID"
+                "type": "DatanodeBlockID",
+                "required": true
               },
               {
                 "id": 2,
                 "name": "chunkData",
-                "type": "ChunkInfo"
+                "type": "ChunkInfo",
+                "required": true
               },
               {
                 "id": 3,
                 "name": "data",
-                "type": "bytes"
+                "type": "bytes",
+                "optional": true
               }
             ]
           },
@@ -1036,17 +1169,20 @@
               {
                 "id": 1,
                 "name": "blockID",
-                "type": "DatanodeBlockID"
+                "type": "DatanodeBlockID",
+                "required": true
               },
               {
                 "id": 2,
                 "name": "chunkData",
-                "type": "ChunkInfo"
+                "type": "ChunkInfo",
+                "required": true
               },
               {
                 "id": 3,
                 "name": "readChunkVersion",
-                "type": "ReadChunkVersion"
+                "type": "ReadChunkVersion",
+                "optional": true
               }
             ]
           },
@@ -1056,12 +1192,14 @@
               {
                 "id": 1,
                 "name": "blockID",
-                "type": "DatanodeBlockID"
+                "type": "DatanodeBlockID",
+                "required": true
               },
               {
                 "id": 2,
                 "name": "chunkData",
-                "type": "ChunkInfo"
+                "type": "ChunkInfo",
+                "required": true
               },
               {
                 "id": 3,
@@ -1092,12 +1230,14 @@
               {
                 "id": 1,
                 "name": "blockID",
-                "type": "DatanodeBlockID"
+                "type": "DatanodeBlockID",
+                "required": true
               },
               {
                 "id": 2,
                 "name": "chunkData",
-                "type": "ChunkInfo"
+                "type": "ChunkInfo",
+                "required": true
               }
             ]
           },
@@ -1110,17 +1250,20 @@
               {
                 "id": 1,
                 "name": "blockID",
-                "type": "DatanodeBlockID"
+                "type": "DatanodeBlockID",
+                "required": true
               },
               {
                 "id": 2,
                 "name": "prevChunkName",
-                "type": "string"
+                "type": "string",
+                "required": true
               },
               {
                 "id": 3,
                 "name": "count",
-                "type": "uint32"
+                "type": "uint32",
+                "required": true
               }
             ]
           },
@@ -1141,17 +1284,20 @@
               {
                 "id": 1,
                 "name": "block",
-                "type": "PutBlockRequestProto"
+                "type": "PutBlockRequestProto",
+                "required": true
               },
               {
                 "id": 2,
                 "name": "chunkInfo",
-                "type": "ChunkInfo"
+                "type": "ChunkInfo",
+                "required": true
               },
               {
                 "id": 3,
                 "name": "data",
-                "type": "bytes"
+                "type": "bytes",
+                "required": true
               }
             ]
           },
@@ -1161,7 +1307,8 @@
               {
                 "id": 1,
                 "name": "committedBlockLength",
-                "type": "GetCommittedBlockLengthResponseProto"
+                "type": "GetCommittedBlockLengthResponseProto",
+                "required": true
               }
             ]
           },
@@ -1171,12 +1318,14 @@
               {
                 "id": 1,
                 "name": "block",
-                "type": "GetBlockRequestProto"
+                "type": "GetBlockRequestProto",
+                "required": true
               },
               {
                 "id": 2,
                 "name": "readChunkVersion",
-                "type": "ReadChunkVersion"
+                "type": "ReadChunkVersion",
+                "optional": true
               }
             ]
           },
@@ -1186,7 +1335,8 @@
               {
                 "id": 1,
                 "name": "data",
-                "type": "ReadChunkResponseProto"
+                "type": "ReadChunkResponseProto",
+                "required": true
               }
             ]
           },
@@ -1196,22 +1346,26 @@
               {
                 "id": 1,
                 "name": "containerID",
-                "type": "int64"
+                "type": "int64",
+                "required": true
               },
               {
                 "id": 2,
                 "name": "readOffset",
-                "type": "uint64"
+                "type": "uint64",
+                "required": true
               },
               {
                 "id": 3,
                 "name": "len",
-                "type": "uint64"
+                "type": "uint64",
+                "optional": true
               },
               {
                 "id": 4,
                 "name": "version",
-                "type": "uint32"
+                "type": "uint32",
+                "optional": true
               }
             ]
           },
@@ -1221,32 +1375,38 @@
               {
                 "id": 1,
                 "name": "containerID",
-                "type": "int64"
+                "type": "int64",
+                "required": true
               },
               {
                 "id": 2,
                 "name": "readOffset",
-                "type": "uint64"
+                "type": "uint64",
+                "required": true
               },
               {
                 "id": 3,
                 "name": "len",
-                "type": "uint64"
+                "type": "uint64",
+                "required": true
               },
               {
                 "id": 4,
                 "name": "eof",
-                "type": "bool"
+                "type": "bool",
+                "required": true
               },
               {
                 "id": 5,
                 "name": "data",
-                "type": "bytes"
+                "type": "bytes",
+                "required": true
               },
               {
                 "id": 6,
                 "name": "checksum",
-                "type": "int64"
+                "type": "int64",
+                "optional": true
               }
             ]
           }
@@ -1426,6 +1586,10 @@
               {
                 "name": "DELETED",
                 "integer": 6
+              },
+              {
+                "name": "RECOVERING",
+                "integer": 7
               }
             ]
           },
@@ -1472,6 +1636,14 @@
               {
                 "name": "CHAINED",
                 "integer": 3
+              },
+              {
+                "name": "EC",
+                "integer": 4
+              },
+              {
+                "name": "NONE",
+                "integer": -1
               }
             ]
           },
@@ -1485,6 +1657,9 @@
               {
                 "name": "THREE",
                 "integer": 3
+              },
+              {
+                "name": "ZERO"
               }
             ]
           },
@@ -1591,12 +1766,14 @@
               {
                 "id": 1,
                 "name": "mostSigBits",
-                "type": "int64"
+                "type": "int64",
+                "required": true
               },
               {
                 "id": 2,
                 "name": "leastSigBits",
-                "type": "int64"
+                "type": "int64",
+                "required": true
               }
             ]
           },
@@ -1606,17 +1783,20 @@
               {
                 "id": 1,
                 "name": "uuid",
-                "type": "string"
+                "type": "string",
+                "optional": true
               },
               {
                 "id": 2,
                 "name": "ipAddress",
-                "type": "string"
+                "type": "string",
+                "required": true
               },
               {
                 "id": 3,
                 "name": "hostName",
-                "type": "string"
+                "type": "string",
+                "required": true
               },
               {
                 "id": 4,
@@ -1627,32 +1807,38 @@
               {
                 "id": 5,
                 "name": "certSerialId",
-                "type": "string"
+                "type": "string",
+                "optional": true
               },
               {
                 "id": 6,
                 "name": "networkName",
-                "type": "string"
+                "type": "string",
+                "optional": true
               },
               {
                 "id": 7,
                 "name": "networkLocation",
-                "type": "string"
+                "type": "string",
+                "optional": true
               },
               {
                 "id": 8,
                 "name": "persistedOpState",
-                "type": "NodeOperationalState"
+                "type": "NodeOperationalState",
+                "optional": true
               },
               {
                 "id": 9,
                 "name": "persistedOpStateExpiry",
-                "type": "int64"
+                "type": "int64",
+                "optional": true
               },
               {
                 "id": 100,
                 "name": "uuid128",
-                "type": "UUID"
+                "type": "UUID",
+                "optional": true
               }
             ]
           },
@@ -1662,27 +1848,32 @@
               {
                 "id": 1,
                 "name": "datanodeDetails",
-                "type": "DatanodeDetailsProto"
+                "type": "DatanodeDetailsProto",
+                "required": true
               },
               {
                 "id": 2,
                 "name": "version",
-                "type": "string"
+                "type": "string",
+                "optional": true
               },
               {
                 "id": 3,
                 "name": "setupTime",
-                "type": "int64"
+                "type": "int64",
+                "optional": true
               },
               {
                 "id": 4,
                 "name": "revision",
-                "type": "string"
+                "type": "string",
+                "optional": true
               },
               {
                 "id": 5,
                 "name": "buildDate",
-                "type": "string"
+                "type": "string",
+                "optional": true
               }
             ]
           },
@@ -1692,12 +1883,14 @@
               {
                 "id": 1,
                 "name": "src",
-                "type": "DatanodeDetailsProto"
+                "type": "DatanodeDetailsProto",
+                "required": true
               },
               {
                 "id": 2,
                 "name": "tgt",
-                "type": "DatanodeDetailsProto"
+                "type": "DatanodeDetailsProto",
+                "required": true
               }
             ]
           },
@@ -1707,17 +1900,20 @@
               {
                 "id": 1,
                 "name": "uuid",
-                "type": "string"
+                "type": "string",
+                "required": true
               },
               {
                 "id": 2,
                 "name": "ipAddress",
-                "type": "string"
+                "type": "string",
+                "required": true
               },
               {
                 "id": 3,
                 "name": "hostName",
-                "type": "string"
+                "type": "string",
+                "required": true
               },
               {
                 "id": 4,
@@ -1733,17 +1929,49 @@
               {
                 "id": 1,
                 "name": "scmNodeId",
-                "type": "string"
+                "type": "string",
+                "required": true
               },
               {
                 "id": 2,
                 "name": "clusterId",
-                "type": "string"
+                "type": "string",
+                "required": true
               },
               {
                 "id": 3,
                 "name": "hostName",
-                "type": "string"
+                "type": "string",
+                "required": true
+              }
+            ]
+          },
+          {
+            "name": "NodeDetailsProto",
+            "fields": [
+              {
+                "id": 1,
+                "name": "uuid",
+                "type": "string",
+                "required": true
+              },
+              {
+                "id": 2,
+                "name": "clusterId",
+                "type": "string",
+                "required": true
+              },
+              {
+                "id": 3,
+                "name": "hostName",
+                "type": "string",
+                "required": true
+              },
+              {
+                "id": 4,
+                "name": "nodeType",
+                "type": "NodeType",
+                "required": true
               }
             ]
           },
@@ -1753,12 +1981,14 @@
               {
                 "id": 1,
                 "name": "name",
-                "type": "string"
+                "type": "string",
+                "required": true
               },
               {
                 "id": 2,
                 "name": "value",
-                "type": "uint32"
+                "type": "uint32",
+                "required": true
               }
             ]
           },
@@ -1768,12 +1998,14 @@
               {
                 "id": 1,
                 "name": "id",
-                "type": "string"
+                "type": "string",
+                "optional": true
               },
               {
                 "id": 100,
                 "name": "uuid128",
-                "type": "UUID"
+                "type": "UUID",
+                "optional": true
               }
             ]
           },
@@ -1783,7 +2015,8 @@
               {
                 "id": 1,
                 "name": "id",
-                "type": "uint64"
+                "type": "uint64",
+                "required": true
               }
             ]
           },
@@ -1800,6 +2033,7 @@
                 "id": 2,
                 "name": "state",
                 "type": "PipelineState",
+                "optional": true,
                 "options": [
                   {
                     "name": "default",
@@ -1811,6 +2045,7 @@
                 "id": 3,
                 "name": "type",
                 "type": "ReplicationType",
+                "optional": true,
                 "options": [
                   {
                     "name": "default",
@@ -1822,6 +2057,7 @@
                 "id": 4,
                 "name": "factor",
                 "type": "ReplicationFactor",
+                "optional": true,
                 "options": [
                   {
                     "name": "default",
@@ -1832,12 +2068,14 @@
               {
                 "id": 5,
                 "name": "id",
-                "type": "PipelineID"
+                "type": "PipelineID",
+                "required": true
               },
               {
                 "id": 6,
                 "name": "leaderID",
-                "type": "string"
+                "type": "string",
+                "optional": true
               },
               {
                 "id": 7,
@@ -1848,17 +2086,32 @@
               {
                 "id": 8,
                 "name": "creationTimeStamp",
-                "type": "uint64"
+                "type": "uint64",
+                "optional": true
               },
               {
                 "id": 9,
                 "name": "suggestedLeaderID",
-                "type": "UUID"
+                "type": "UUID",
+                "optional": true
+              },
+              {
+                "id": 10,
+                "name": "memberReplicaIndexes",
+                "type": "uint32",
+                "is_repeated": true
+              },
+              {
+                "id": 11,
+                "name": "ecReplicationConfig",
+                "type": "ECReplicationConfig",
+                "optional": true
               },
               {
                 "id": 100,
                 "name": "leaderID128",
-                "type": "UUID"
+                "type": "UUID",
+                "optional": true
               }
             ]
           },
@@ -1868,12 +2121,14 @@
               {
                 "id": 1,
                 "name": "key",
-                "type": "string"
+                "type": "string",
+                "required": true
               },
               {
                 "id": 2,
                 "name": "value",
-                "type": "string"
+                "type": "string",
+                "optional": true
               }
             ]
           },
@@ -1883,7 +2138,8 @@
               {
                 "id": 1,
                 "name": "nodeID",
-                "type": "DatanodeDetailsProto"
+                "type": "DatanodeDetailsProto",
+                "required": true
               },
               {
                 "id": 2,
@@ -1916,22 +2172,26 @@
               {
                 "id": 1,
                 "name": "capacity",
-                "type": "int64"
+                "type": "int64",
+                "optional": true
               },
               {
                 "id": 2,
                 "name": "used",
-                "type": "int64"
+                "type": "int64",
+                "optional": true
               },
               {
                 "id": 3,
                 "name": "remaining",
-                "type": "int64"
+                "type": "int64",
+                "optional": true
               },
               {
                 "id": 4,
                 "name": "node",
-                "type": "DatanodeDetailsProto"
+                "type": "DatanodeDetailsProto",
+                "optional": true
               }
             ]
           },
@@ -1941,57 +2201,74 @@
               {
                 "id": 1,
                 "name": "containerID",
-                "type": "int64"
+                "type": "int64",
+                "required": true
               },
               {
                 "id": 2,
                 "name": "state",
-                "type": "LifeCycleState"
+                "type": "LifeCycleState",
+                "required": true
               },
               {
                 "id": 3,
                 "name": "pipelineID",
-                "type": "PipelineID"
+                "type": "PipelineID",
+                "optional": true
               },
               {
                 "id": 4,
                 "name": "usedBytes",
-                "type": "uint64"
+                "type": "uint64",
+                "required": true
               },
               {
                 "id": 5,
                 "name": "numberOfKeys",
-                "type": "uint64"
+                "type": "uint64",
+                "required": true
               },
               {
                 "id": 6,
                 "name": "stateEnterTime",
-                "type": "int64"
+                "type": "int64",
+                "optional": true
               },
               {
                 "id": 7,
                 "name": "owner",
-                "type": "string"
+                "type": "string",
+                "required": true
               },
               {
                 "id": 8,
                 "name": "deleteTransactionId",
-                "type": "int64"
+                "type": "int64",
+                "optional": true
               },
               {
                 "id": 9,
                 "name": "sequenceId",
-                "type": "int64"
+                "type": "int64",
+                "optional": true
               },
               {
                 "id": 10,
                 "name": "replicationFactor",
-                "type": "ReplicationFactor"
+                "type": "ReplicationFactor",
+                "optional": true
               },
               {
                 "id": 11,
                 "name": "replicationType",
-                "type": "ReplicationType"
+                "type": "ReplicationType",
+                "required": true
+              },
+              {
+                "id": 12,
+                "name": "ecReplicationConfig",
+                "type": "ECReplicationConfig",
+                "optional": true
               }
             ]
           },
@@ -2001,12 +2278,14 @@
               {
                 "id": 1,
                 "name": "containerInfo",
-                "type": "ContainerInfoProto"
+                "type": "ContainerInfoProto",
+                "required": true
               },
               {
                 "id": 2,
                 "name": "pipeline",
-                "type": "Pipeline"
+                "type": "Pipeline",
+                "required": true
               }
             ]
           },
@@ -2016,7 +2295,8 @@
               {
                 "id": 1,
                 "name": "traceID",
-                "type": "string"
+                "type": "string",
+                "optional": true
               }
             ]
           },
@@ -2026,12 +2306,14 @@
               {
                 "id": 1,
                 "name": "clusterId",
-                "type": "string"
+                "type": "string",
+                "required": true
               },
               {
                 "id": 2,
                 "name": "scmId",
-                "type": "string"
+                "type": "string",
+                "required": true
               },
               {
                 "id": 3,
@@ -2047,17 +2329,20 @@
               {
                 "id": 1,
                 "name": "clusterId",
-                "type": "string"
+                "type": "string",
+                "required": true
               },
               {
                 "id": 2,
                 "name": "scmId",
-                "type": "string"
+                "type": "string",
+                "required": true
               },
               {
                 "id": 3,
                 "name": "ratisAddr",
-                "type": "string"
+                "type": "string",
+                "required": true
               }
             ]
           },
@@ -2067,12 +2352,66 @@
               {
                 "id": 1,
                 "name": "success",
-                "type": "bool"
+                "type": "bool",
+                "required": true
               },
               {
                 "id": 2,
                 "name": "scmId",
-                "type": "string"
+                "type": "string",
+                "optional": true
+              }
+            ]
+          },
+          {
+            "name": "ECReplicationConfig",
+            "fields": [
+              {
+                "id": 1,
+                "name": "data",
+                "type": "int32",
+                "required": true
+              },
+              {
+                "id": 2,
+                "name": "parity",
+                "type": "int32",
+                "required": true
+              },
+              {
+                "id": 3,
+                "name": "codec",
+                "type": "string",
+                "required": true
+              },
+              {
+                "id": 4,
+                "name": "ecChunkSize",
+                "type": "int32",
+                "required": true
+              }
+            ]
+          },
+          {
+            "name": "DefaultReplicationConfig",
+            "fields": [
+              {
+                "id": 1,
+                "name": "type",
+                "type": "ReplicationType",
+                "required": true
+              },
+              {
+                "id": 2,
+                "name": "factor",
+                "type": "ReplicationFactor",
+                "optional": true
+              },
+              {
+                "id": 3,
+                "name": "ecReplicationConfig",
+                "type": "ECReplicationConfig",
+                "optional": true
               }
             ]
           },
@@ -2105,12 +2444,14 @@
               {
                 "id": 1,
                 "name": "containerID",
-                "type": "int64"
+                "type": "int64",
+                "required": true
               },
               {
                 "id": 2,
                 "name": "localID",
-                "type": "int64"
+                "type": "int64",
+                "required": true
               }
             ]
           },
@@ -2120,22 +2461,26 @@
               {
                 "id": 1,
                 "name": "keyId",
-                "type": "uint32"
+                "type": "uint32",
+                "required": true
               },
               {
                 "id": 2,
                 "name": "expiryDate",
-                "type": "uint64"
+                "type": "uint64",
+                "required": true
               },
               {
                 "id": 3,
                 "name": "privateKeyBytes",
-                "type": "bytes"
+                "type": "bytes",
+                "required": true
               },
               {
                 "id": 4,
                 "name": "publicKeyBytes",
-                "type": "bytes"
+                "type": "bytes",
+                "required": true
               }
             ]
           },
@@ -2145,22 +2490,26 @@
               {
                 "id": 1,
                 "name": "identifier",
-                "type": "bytes"
+                "type": "bytes",
+                "required": true
               },
               {
                 "id": 2,
                 "name": "password",
-                "type": "bytes"
+                "type": "bytes",
+                "required": true
               },
               {
                 "id": 3,
                 "name": "kind",
-                "type": "string"
+                "type": "string",
+                "required": true
               },
               {
                 "id": 4,
                 "name": "service",
-                "type": "string"
+                "type": "string",
+                "required": true
               }
             ]
           },
@@ -2170,22 +2519,26 @@
               {
                 "id": 1,
                 "name": "ownerId",
-                "type": "string"
+                "type": "string",
+                "required": true
               },
               {
                 "id": 2,
                 "name": "blockId",
-                "type": "string"
+                "type": "string",
+                "required": true
               },
               {
                 "id": 3,
                 "name": "expiryDate",
-                "type": "uint64"
+                "type": "uint64",
+                "required": true
               },
               {
                 "id": 4,
                 "name": "omCertSerialId",
-                "type": "string"
+                "type": "string",
+                "required": true
               },
               {
                 "id": 5,
@@ -2196,7 +2549,8 @@
               {
                 "id": 6,
                 "name": "maxLength",
-                "type": "uint64"
+                "type": "uint64",
+                "required": true
               }
             ]
           },
@@ -2206,12 +2560,14 @@
               {
                 "id": 1,
                 "name": "containerBlockID",
-                "type": "ContainerBlockID"
+                "type": "ContainerBlockID",
+                "required": true
               },
               {
                 "id": 2,
                 "name": "blockCommitSequenceId",
                 "type": "uint64",
+                "optional": true,
                 "options": [
                   {
                     "name": "default",
@@ -2227,7 +2583,8 @@
               {
                 "id": 1,
                 "name": "status",
-                "type": "Status"
+                "type": "Status",
+                "required": true
               },
               {
                 "id": 2,
@@ -2243,17 +2600,20 @@
               {
                 "id": 1,
                 "name": "x509CRL",
-                "type": "string"
+                "type": "string",
+                "required": true
               },
               {
                 "id": 2,
                 "name": "creationTimestamp",
-                "type": "uint64"
+                "type": "uint64",
+                "required": true
               },
               {
                 "id": 3,
                 "name": "crlSequenceID",
-                "type": "int64"
+                "type": "int64",
+                "required": true
               }
             ]
           },
@@ -2263,12 +2623,259 @@
               {
                 "id": 1,
                 "name": "x509Certificate",
-                "type": "string"
+                "type": "string",
+                "required": true
               },
               {
                 "id": 2,
                 "name": "timestamp",
-                "type": "uint64"
+                "type": "uint64",
+                "required": true
+              }
+            ]
+          },
+          {
+            "name": "ContainerReplicaHistoryListProto",
+            "fields": [
+              {
+                "id": 1,
+                "name": "replicaHistory",
+                "type": "ContainerReplicaHistoryProto",
+                "is_repeated": true
+              }
+            ]
+          },
+          {
+            "name": "ContainerReplicaHistoryProto",
+            "fields": [
+              {
+                "id": 1,
+                "name": "uuid",
+                "type": "string",
+                "required": true
+              },
+              {
+                "id": 2,
+                "name": "firstSeenTime",
+                "type": "int64",
+                "required": true
+              },
+              {
+                "id": 3,
+                "name": "lastSeenTime",
+                "type": "int64",
+                "required": true
+              },
+              {
+                "id": 4,
+                "name": "bcsId",
+                "type": "int64",
+                "required": true
+              }
+            ]
+          },
+          {
+            "name": "SCMContainerReplicaProto",
+            "fields": [
+              {
+                "id": 1,
+                "name": "containerID",
+                "type": "int64",
+                "required": true
+              },
+              {
+                "id": 2,
+                "name": "state",
+                "type": "string",
+                "required": true
+              },
+              {
+                "id": 3,
+                "name": "datanodeDetails",
+                "type": "DatanodeDetailsProto",
+                "required": true
+              },
+              {
+                "id": 4,
+                "name": "placeOfBirth",
+                "type": "string",
+                "required": true
+              },
+              {
+                "id": 5,
+                "name": "sequenceID",
+                "type": "int64",
+                "required": true
+              },
+              {
+                "id": 6,
+                "name": "keyCount",
+                "type": "int64",
+                "required": true
+              },
+              {
+                "id": 7,
+                "name": "bytesUsed",
+                "type": "int64",
+                "required": true
+              },
+              {
+                "id": 8,
+                "name": "replicaIndex",
+                "type": "int64",
+                "optional": true
+              }
+            ]
+          },
+          {
+            "name": "KeyContainerIDList",
+            "fields": [
+              {
+                "id": 1,
+                "name": "key",
+                "type": "string",
+                "required": true
+              },
+              {
+                "id": 2,
+                "name": "container",
+                "type": "ContainerID",
+                "is_repeated": true
+              }
+            ]
+          },
+          {
+            "name": "KeyIntValue",
+            "fields": [
+              {
+                "id": 1,
+                "name": "key",
+                "type": "string",
+                "required": true
+              },
+              {
+                "id": 2,
+                "name": "value",
+                "type": "int64",
+                "optional": true
+              }
+            ]
+          },
+          {
+            "name": "ReplicationManagerReportProto",
+            "fields": [
+              {
+                "id": 1,
+                "name": "timestamp",
+                "type": "int64",
+                "required": true
+              },
+              {
+                "id": 2,
+                "name": "stat",
+                "type": "KeyIntValue",
+                "is_repeated": true
+              },
+              {
+                "id": 3,
+                "name": "statSample",
+                "type": "KeyContainerIDList",
+                "is_repeated": true
+              }
+            ]
+          },
+          {
+            "name": "ContainerBalancerConfigurationProto",
+            "fields": [
+              {
+                "id": 5,
+                "name": "utilizationThreshold",
+                "type": "string",
+                "optional": true
+              },
+              {
+                "id": 6,
+                "name": "datanodesInvolvedMaxPercentagePerIteration",
+                "type": "int32",
+                "optional": true
+              },
+              {
+                "id": 7,
+                "name": "sizeMovedMaxPerIteration",
+                "type": "int64",
+                "optional": true
+              },
+              {
+                "id": 8,
+                "name": "sizeEnteringTargetMax",
+                "type": "int64",
+                "optional": true
+              },
+              {
+                "id": 9,
+                "name": "sizeLeavingSourceMax",
+                "type": "int64",
+                "optional": true
+              },
+              {
+                "id": 10,
+                "name": "iterations",
+                "type": "int32",
+                "optional": true
+              },
+              {
+                "id": 11,
+                "name": "excludeContainers",
+                "type": "string",
+                "optional": true
+              },
+              {
+                "id": 12,
+                "name": "moveTimeout",
+                "type": "int64",
+                "optional": true
+              },
+              {
+                "id": 13,
+                "name": "balancingIterationInterval",
+                "type": "int64",
+                "optional": true
+              },
+              {
+                "id": 14,
+                "name": "includeDatanodes",
+                "type": "string",
+                "optional": true
+              },
+              {
+                "id": 15,
+                "name": "excludeDatanodes",
+                "type": "string",
+                "optional": true
+              },
+              {
+                "id": 16,
+                "name": "moveNetworkTopologyEnable",
+                "type": "bool",
+                "optional": true
+              },
+              {
+                "id": 17,
+                "name": "triggerDuBeforeMoveEnable",
+                "type": "bool",
+                "optional": true
+              },
+              {
+                "id": 18,
+                "name": "shouldRun",
+                "type": "bool",
+                "required": true
+              },
+              {
+                "id": 19,
+                "name": "nextIterationIndex",
+                "type": "int32",
+                "optional": true
               }
             ]
           }

--- a/hadoop-hdds/interface-server/src/main/resources/proto.lock
+++ b/hadoop-hdds/interface-server/src/main/resources/proto.lock
@@ -10,7 +10,8 @@
               {
                 "id": 1,
                 "name": "flush",
-                "type": "bool"
+                "type": "bool",
+                "required": true
               }
             ]
           },
@@ -20,32 +21,38 @@
               {
                 "id": 1,
                 "name": "clusterId",
-                "type": "string"
+                "type": "string",
+                "required": true
               },
               {
                 "id": 2,
                 "name": "len",
-                "type": "uint64"
+                "type": "uint64",
+                "required": true
               },
               {
                 "id": 3,
                 "name": "eof",
-                "type": "bool"
+                "type": "bool",
+                "required": true
               },
               {
                 "id": 4,
                 "name": "data",
-                "type": "bytes"
+                "type": "bytes",
+                "required": true
               },
               {
                 "id": 6,
                 "name": "readOffset",
-                "type": "uint64"
+                "type": "uint64",
+                "required": true
               },
               {
                 "id": 7,
                 "name": "checksum",
-                "type": "int64"
+                "type": "int64",
+                "optional": true
               }
             ]
           }
@@ -112,6 +119,14 @@
               {
                 "name": "MOVE",
                 "integer": 6
+              },
+              {
+                "name": "STATEFUL_SERVICE_CONFIG",
+                "integer": 7
+              },
+              {
+                "name": "FINALIZE",
+                "integer": 8
               }
             ]
           }
@@ -123,7 +138,8 @@
               {
                 "id": 1,
                 "name": "name",
-                "type": "string"
+                "type": "string",
+                "required": true
               },
               {
                 "id": 2,
@@ -139,12 +155,14 @@
               {
                 "id": 1,
                 "name": "type",
-                "type": "string"
+                "type": "string",
+                "required": true
               },
               {
                 "id": 2,
                 "name": "value",
-                "type": "bytes"
+                "type": "bytes",
+                "required": true
               }
             ]
           },
@@ -154,7 +172,8 @@
               {
                 "id": 1,
                 "name": "type",
-                "type": "string"
+                "type": "string",
+                "required": true
               },
               {
                 "id": 2,
@@ -170,12 +189,14 @@
               {
                 "id": 1,
                 "name": "type",
-                "type": "RequestType"
+                "type": "RequestType",
+                "required": true
               },
               {
                 "id": 2,
                 "name": "method",
-                "type": "Method"
+                "type": "Method",
+                "required": true
               }
             ]
           },
@@ -185,12 +206,14 @@
               {
                 "id": 2,
                 "name": "type",
-                "type": "string"
+                "type": "string",
+                "required": true
               },
               {
                 "id": 3,
                 "name": "value",
-                "type": "bytes"
+                "type": "bytes",
+                "required": true
               }
             ]
           }
@@ -239,17 +262,20 @@
               {
                 "id": 1,
                 "name": "x509CRL",
-                "type": "string"
+                "type": "string",
+                "required": true
               },
               {
                 "id": 2,
                 "name": "creationTimestamp",
-                "type": "uint64"
+                "type": "uint64",
+                "required": true
               },
               {
                 "id": 3,
                 "name": "crlSequenceID",
-                "type": "int64"
+                "type": "int64",
+                "required": true
               }
             ]
           },
@@ -259,12 +285,14 @@
               {
                 "id": 1,
                 "name": "msb",
-                "type": "int64"
+                "type": "int64",
+                "required": true
               },
               {
                 "id": 2,
                 "name": "lsb",
-                "type": "int64"
+                "type": "int64",
+                "required": true
               }
             ]
           },
@@ -274,7 +302,8 @@
               {
                 "id": 1,
                 "name": "hostname",
-                "type": "string"
+                "type": "string",
+                "optional": true
               }
             ]
           },
@@ -284,7 +313,8 @@
               {
                 "id": 1,
                 "name": "clientId",
-                "type": "ClientId"
+                "type": "ClientId",
+                "required": true
               }
             ]
           },
@@ -294,22 +324,26 @@
               {
                 "id": 1,
                 "name": "updateType",
-                "type": "Type"
+                "type": "Type",
+                "required": true
               },
               {
                 "id": 2,
                 "name": "traceID",
-                "type": "string"
+                "type": "string",
+                "optional": true
               },
               {
                 "id": 3,
                 "name": "clientId",
-                "type": "ClientId"
+                "type": "ClientId",
+                "required": true
               },
               {
                 "id": 4,
                 "name": "crlUpdateRequest",
-                "type": "CRLUpdateRequest"
+                "type": "CRLUpdateRequest",
+                "optional": true
               }
             ]
           },
@@ -319,17 +353,20 @@
               {
                 "id": 1,
                 "name": "updateType",
-                "type": "Type"
+                "type": "Type",
+                "required": true
               },
               {
                 "id": 2,
                 "name": "traceID",
-                "type": "string"
+                "type": "string",
+                "optional": true
               },
               {
                 "id": 3,
                 "name": "crlUpdateResponse",
-                "type": "CRLUpdateResponse"
+                "type": "CRLUpdateResponse",
+                "optional": true
               }
             ]
           },
@@ -339,7 +376,8 @@
               {
                 "id": 1,
                 "name": "receivedCrlId",
-                "type": "int64"
+                "type": "int64",
+                "required": true
               },
               {
                 "id": 2,
@@ -355,7 +393,8 @@
               {
                 "id": 1,
                 "name": "crlInfo",
-                "type": "CRLInfoProto"
+                "type": "CRLInfoProto",
+                "optional": true
               }
             ]
           },
@@ -365,7 +404,8 @@
               {
                 "id": 1,
                 "name": "clientId",
-                "type": "ClientId"
+                "type": "ClientId",
+                "required": true
               }
             ]
           },
@@ -594,6 +634,9 @@
             "name": "SCMCommandProto.Type",
             "enum_fields": [
               {
+                "name": "unknownScmCommand"
+              },
+              {
                 "name": "reregisterCommand",
                 "integer": 1
               },
@@ -628,6 +671,14 @@
               {
                 "name": "finalizeNewLayoutVersionCommand",
                 "integer": 9
+              },
+              {
+                "name": "refreshVolumeUsageInfo",
+                "integer": 10
+              },
+              {
+                "name": "reconstructECContainersCommand",
+                "integer": 11
               }
             ]
           }
@@ -639,27 +690,32 @@
               {
                 "id": 1,
                 "name": "cmdType",
-                "type": "Type"
+                "type": "Type",
+                "required": true
               },
               {
                 "id": 2,
                 "name": "traceID",
-                "type": "string"
+                "type": "string",
+                "optional": true
               },
               {
                 "id": 3,
                 "name": "getVersionRequest",
-                "type": "SCMVersionRequestProto"
+                "type": "SCMVersionRequestProto",
+                "optional": true
               },
               {
                 "id": 4,
                 "name": "registerRequest",
-                "type": "SCMRegisterRequestProto"
+                "type": "SCMRegisterRequestProto",
+                "optional": true
               },
               {
                 "id": 5,
                 "name": "sendHeartbeatRequest",
-                "type": "SCMHeartbeatRequestProto"
+                "type": "SCMHeartbeatRequestProto",
+                "optional": true
               }
             ]
           },
@@ -669,17 +725,20 @@
               {
                 "id": 1,
                 "name": "cmdType",
-                "type": "Type"
+                "type": "Type",
+                "required": true
               },
               {
                 "id": 2,
                 "name": "traceID",
-                "type": "string"
+                "type": "string",
+                "optional": true
               },
               {
                 "id": 3,
                 "name": "success",
                 "type": "bool",
+                "optional": true,
                 "options": [
                   {
                     "name": "default",
@@ -690,27 +749,32 @@
               {
                 "id": 4,
                 "name": "message",
-                "type": "string"
+                "type": "string",
+                "optional": true
               },
               {
                 "id": 5,
                 "name": "status",
-                "type": "Status"
+                "type": "Status",
+                "required": true
               },
               {
                 "id": 6,
                 "name": "getVersionResponse",
-                "type": "SCMVersionResponseProto"
+                "type": "SCMVersionResponseProto",
+                "optional": true
               },
               {
                 "id": 7,
                 "name": "registerResponse",
-                "type": "SCMRegisteredResponseProto"
+                "type": "SCMRegisteredResponseProto",
+                "optional": true
               },
               {
                 "id": 8,
                 "name": "sendHeartbeatResponse",
-                "type": "SCMHeartbeatResponseProto"
+                "type": "SCMHeartbeatResponseProto",
+                "optional": true
               }
             ]
           },
@@ -720,12 +784,14 @@
               {
                 "id": 1,
                 "name": "metadataLayoutVersion",
-                "type": "uint32"
+                "type": "uint32",
+                "required": true
               },
               {
                 "id": 2,
                 "name": "softwareLayoutVersion",
-                "type": "uint32"
+                "type": "uint32",
+                "required": true
               }
             ]
           },
@@ -738,7 +804,8 @@
               {
                 "id": 1,
                 "name": "softwareVersion",
-                "type": "uint32"
+                "type": "uint32",
+                "required": true
               },
               {
                 "id": 2,
@@ -754,27 +821,32 @@
               {
                 "id": 1,
                 "name": "extendedDatanodeDetails",
-                "type": "ExtendedDatanodeDetailsProto"
+                "type": "ExtendedDatanodeDetailsProto",
+                "required": true
               },
               {
                 "id": 2,
                 "name": "nodeReport",
-                "type": "NodeReportProto"
+                "type": "NodeReportProto",
+                "required": true
               },
               {
                 "id": 3,
                 "name": "containerReport",
-                "type": "ContainerReportsProto"
+                "type": "ContainerReportsProto",
+                "required": true
               },
               {
                 "id": 4,
                 "name": "pipelineReports",
-                "type": "PipelineReportsProto"
+                "type": "PipelineReportsProto",
+                "required": true
               },
               {
                 "id": 5,
                 "name": "dataNodeLayoutVersion",
-                "type": "LayoutVersionProto"
+                "type": "LayoutVersionProto",
+                "optional": true
               }
             ]
           },
@@ -784,42 +856,50 @@
               {
                 "id": 1,
                 "name": "errorCode",
-                "type": "ErrorCode"
+                "type": "ErrorCode",
+                "required": true
               },
               {
                 "id": 2,
                 "name": "datanodeUUID",
-                "type": "string"
+                "type": "string",
+                "required": true
               },
               {
                 "id": 3,
                 "name": "clusterID",
-                "type": "string"
+                "type": "string",
+                "required": true
               },
               {
                 "id": 4,
                 "name": "addressList",
-                "type": "SCMNodeAddressList"
+                "type": "SCMNodeAddressList",
+                "optional": true
               },
               {
                 "id": 5,
                 "name": "hostname",
-                "type": "string"
+                "type": "string",
+                "optional": true
               },
               {
                 "id": 6,
                 "name": "ipAddress",
-                "type": "string"
+                "type": "string",
+                "optional": true
               },
               {
                 "id": 7,
                 "name": "networkName",
-                "type": "string"
+                "type": "string",
+                "optional": true
               },
               {
                 "id": 8,
                 "name": "networkLocation",
-                "type": "string"
+                "type": "string",
+                "optional": true
               }
             ]
           },
@@ -829,17 +909,20 @@
               {
                 "id": 1,
                 "name": "datanodeDetails",
-                "type": "DatanodeDetailsProto"
+                "type": "DatanodeDetailsProto",
+                "required": true
               },
               {
                 "id": 2,
                 "name": "nodeReport",
-                "type": "NodeReportProto"
+                "type": "NodeReportProto",
+                "optional": true
               },
               {
                 "id": 3,
                 "name": "containerReport",
-                "type": "ContainerReportsProto"
+                "type": "ContainerReportsProto",
+                "optional": true
               },
               {
                 "id": 4,
@@ -856,22 +939,49 @@
               {
                 "id": 6,
                 "name": "containerActions",
-                "type": "ContainerActionsProto"
+                "type": "ContainerActionsProto",
+                "optional": true
               },
               {
                 "id": 7,
                 "name": "pipelineActions",
-                "type": "PipelineActionsProto"
+                "type": "PipelineActionsProto",
+                "optional": true
               },
               {
                 "id": 8,
                 "name": "pipelineReports",
-                "type": "PipelineReportsProto"
+                "type": "PipelineReportsProto",
+                "optional": true
               },
               {
                 "id": 9,
                 "name": "dataNodeLayoutVersion",
-                "type": "LayoutVersionProto"
+                "type": "LayoutVersionProto",
+                "optional": true
+              },
+              {
+                "id": 10,
+                "name": "commandQueueReport",
+                "type": "CommandQueueReportProto",
+                "optional": true
+              }
+            ]
+          },
+          {
+            "name": "CommandQueueReportProto",
+            "fields": [
+              {
+                "id": 1,
+                "name": "command",
+                "type": "SCMCommandProto.Type",
+                "is_repeated": true
+              },
+              {
+                "id": 2,
+                "name": "count",
+                "type": "uint32",
+                "is_repeated": true
               }
             ]
           },
@@ -881,7 +991,8 @@
               {
                 "id": 1,
                 "name": "datanodeUUID",
-                "type": "string"
+                "type": "string",
+                "required": true
               },
               {
                 "id": 2,
@@ -916,6 +1027,12 @@
                 "name": "metadataStorageReport",
                 "type": "MetadataStorageReportProto",
                 "is_repeated": true
+              },
+              {
+                "id": 3,
+                "name": "dbStorageReport",
+                "type": "StorageReportProto",
+                "is_repeated": true
               }
             ]
           },
@@ -925,17 +1042,20 @@
               {
                 "id": 1,
                 "name": "storageUuid",
-                "type": "string"
+                "type": "string",
+                "required": true
               },
               {
                 "id": 2,
                 "name": "storageLocation",
-                "type": "string"
+                "type": "string",
+                "required": true
               },
               {
                 "id": 3,
                 "name": "capacity",
                 "type": "uint64",
+                "optional": true,
                 "options": [
                   {
                     "name": "default",
@@ -947,6 +1067,7 @@
                 "id": 4,
                 "name": "scmUsed",
                 "type": "uint64",
+                "optional": true,
                 "options": [
                   {
                     "name": "default",
@@ -958,6 +1079,7 @@
                 "id": 5,
                 "name": "remaining",
                 "type": "uint64",
+                "optional": true,
                 "options": [
                   {
                     "name": "default",
@@ -969,6 +1091,7 @@
                 "id": 6,
                 "name": "storageType",
                 "type": "StorageTypeProto",
+                "optional": true,
                 "options": [
                   {
                     "name": "default",
@@ -980,6 +1103,7 @@
                 "id": 7,
                 "name": "failed",
                 "type": "bool",
+                "optional": true,
                 "options": [
                   {
                     "name": "default",
@@ -995,12 +1119,14 @@
               {
                 "id": 1,
                 "name": "storageLocation",
-                "type": "string"
+                "type": "string",
+                "required": true
               },
               {
                 "id": 2,
                 "name": "storageType",
                 "type": "StorageTypeProto",
+                "optional": true,
                 "options": [
                   {
                     "name": "default",
@@ -1012,6 +1138,7 @@
                 "id": 3,
                 "name": "capacity",
                 "type": "uint64",
+                "optional": true,
                 "options": [
                   {
                     "name": "default",
@@ -1023,6 +1150,7 @@
                 "id": 4,
                 "name": "scmUsed",
                 "type": "uint64",
+                "optional": true,
                 "options": [
                   {
                     "name": "default",
@@ -1034,6 +1162,7 @@
                 "id": 5,
                 "name": "remaining",
                 "type": "uint64",
+                "optional": true,
                 "options": [
                   {
                     "name": "default",
@@ -1045,6 +1174,7 @@
                 "id": 6,
                 "name": "failed",
                 "type": "bool",
+                "optional": true,
                 "options": [
                   {
                     "name": "default",
@@ -1082,67 +1212,86 @@
               {
                 "id": 1,
                 "name": "containerID",
-                "type": "int64"
+                "type": "int64",
+                "required": true
               },
               {
                 "id": 2,
                 "name": "state",
-                "type": "State"
+                "type": "State",
+                "required": true
               },
               {
                 "id": 3,
                 "name": "size",
-                "type": "int64"
+                "type": "int64",
+                "optional": true
               },
               {
                 "id": 4,
                 "name": "used",
-                "type": "int64"
+                "type": "int64",
+                "optional": true
               },
               {
                 "id": 5,
                 "name": "keyCount",
-                "type": "int64"
+                "type": "int64",
+                "optional": true
               },
               {
                 "id": 6,
                 "name": "readCount",
-                "type": "int64"
+                "type": "int64",
+                "optional": true
               },
               {
                 "id": 7,
                 "name": "writeCount",
-                "type": "int64"
+                "type": "int64",
+                "optional": true
               },
               {
                 "id": 8,
                 "name": "readBytes",
-                "type": "int64"
+                "type": "int64",
+                "optional": true
               },
               {
                 "id": 9,
                 "name": "writeBytes",
-                "type": "int64"
+                "type": "int64",
+                "optional": true
               },
               {
                 "id": 10,
                 "name": "finalhash",
-                "type": "string"
+                "type": "string",
+                "optional": true
               },
               {
                 "id": 11,
                 "name": "deleteTransactionId",
-                "type": "int64"
+                "type": "int64",
+                "optional": true
               },
               {
                 "id": 12,
                 "name": "blockCommitSequenceId",
-                "type": "uint64"
+                "type": "uint64",
+                "optional": true
               },
               {
                 "id": 13,
                 "name": "originNodeId",
-                "type": "string"
+                "type": "string",
+                "optional": true
+              },
+              {
+                "id": 14,
+                "name": "replicaIndex",
+                "type": "int32",
+                "optional": true
               }
             ]
           },
@@ -1163,12 +1312,14 @@
               {
                 "id": 1,
                 "name": "cmdId",
-                "type": "int64"
+                "type": "int64",
+                "required": true
               },
               {
                 "id": 2,
                 "name": "status",
                 "type": "Status",
+                "required": true,
                 "options": [
                   {
                     "name": "default",
@@ -1179,17 +1330,20 @@
               {
                 "id": 3,
                 "name": "type",
-                "type": "SCMCommandProto.Type"
+                "type": "SCMCommandProto.Type",
+                "required": true
               },
               {
                 "id": 4,
                 "name": "msg",
-                "type": "string"
+                "type": "string",
+                "optional": true
               },
               {
                 "id": 5,
                 "name": "blockDeletionAck",
-                "type": "ContainerBlocksDeletionACKProto"
+                "type": "ContainerBlocksDeletionACKProto",
+                "optional": true
               }
             ]
           },
@@ -1210,17 +1364,20 @@
               {
                 "id": 1,
                 "name": "containerID",
-                "type": "int64"
+                "type": "int64",
+                "required": true
               },
               {
                 "id": 2,
                 "name": "action",
-                "type": "Action"
+                "type": "Action",
+                "required": true
               },
               {
                 "id": 3,
                 "name": "reason",
-                "type": "Reason"
+                "type": "Reason",
+                "optional": true
               }
             ]
           },
@@ -1230,17 +1387,20 @@
               {
                 "id": 1,
                 "name": "pipelineID",
-                "type": "PipelineID"
+                "type": "PipelineID",
+                "required": true
               },
               {
                 "id": 2,
                 "name": "isLeader",
-                "type": "bool"
+                "type": "bool",
+                "required": true
               },
               {
                 "id": 3,
                 "name": "bytesWritten",
-                "type": "uint64"
+                "type": "uint64",
+                "optional": true
               }
             ]
           },
@@ -1272,17 +1432,20 @@
               {
                 "id": 1,
                 "name": "pipelineID",
-                "type": "PipelineID"
+                "type": "PipelineID",
+                "required": true
               },
               {
                 "id": 3,
                 "name": "reason",
-                "type": "Reason"
+                "type": "Reason",
+                "optional": true
               },
               {
                 "id": 4,
                 "name": "detailedReason",
-                "type": "string"
+                "type": "string",
+                "optional": true
               }
             ]
           },
@@ -1292,12 +1455,14 @@
               {
                 "id": 1,
                 "name": "action",
-                "type": "Action"
+                "type": "Action",
+                "required": true
               },
               {
                 "id": 2,
                 "name": "closePipeline",
-                "type": "ClosePipelineInfo"
+                "type": "ClosePipelineInfo",
+                "optional": true
               }
             ]
           },
@@ -1307,62 +1472,86 @@
               {
                 "id": 1,
                 "name": "commandType",
-                "type": "Type"
+                "type": "Type",
+                "required": true
               },
               {
                 "id": 2,
                 "name": "reregisterCommandProto",
-                "type": "ReregisterCommandProto"
+                "type": "ReregisterCommandProto",
+                "optional": true
               },
               {
                 "id": 3,
                 "name": "deleteBlocksCommandProto",
-                "type": "DeleteBlocksCommandProto"
+                "type": "DeleteBlocksCommandProto",
+                "optional": true
               },
               {
                 "id": 4,
                 "name": "closeContainerCommandProto",
-                "type": "CloseContainerCommandProto"
+                "type": "CloseContainerCommandProto",
+                "optional": true
               },
               {
                 "id": 5,
                 "name": "deleteContainerCommandProto",
-                "type": "DeleteContainerCommandProto"
+                "type": "DeleteContainerCommandProto",
+                "optional": true
               },
               {
                 "id": 6,
                 "name": "replicateContainerCommandProto",
-                "type": "ReplicateContainerCommandProto"
+                "type": "ReplicateContainerCommandProto",
+                "optional": true
               },
               {
                 "id": 7,
                 "name": "createPipelineCommandProto",
-                "type": "CreatePipelineCommandProto"
+                "type": "CreatePipelineCommandProto",
+                "optional": true
               },
               {
                 "id": 8,
                 "name": "closePipelineCommandProto",
-                "type": "ClosePipelineCommandProto"
+                "type": "ClosePipelineCommandProto",
+                "optional": true
               },
               {
                 "id": 9,
                 "name": "setNodeOperationalStateCommandProto",
-                "type": "SetNodeOperationalStateCommandProto"
+                "type": "SetNodeOperationalStateCommandProto",
+                "optional": true
               },
               {
                 "id": 10,
                 "name": "finalizeNewLayoutVersionCommandProto",
-                "type": "FinalizeNewLayoutVersionCommandProto"
+                "type": "FinalizeNewLayoutVersionCommandProto",
+                "optional": true
+              },
+              {
+                "id": 11,
+                "name": "refreshVolumeUsageCommandProto",
+                "type": "RefreshVolumeUsageCommandProto",
+                "optional": true
+              },
+              {
+                "id": 12,
+                "name": "reconstructECContainersCommandProto",
+                "type": "ReconstructECContainersCommandProto",
+                "optional": true
               },
               {
                 "id": 15,
                 "name": "term",
-                "type": "int64"
+                "type": "int64",
+                "optional": true
               },
               {
                 "id": 16,
                 "name": "encodedToken",
-                "type": "string"
+                "type": "string",
+                "optional": true
               }
             ]
           },
@@ -1381,7 +1570,8 @@
               {
                 "id": 3,
                 "name": "cmdId",
-                "type": "int64"
+                "type": "int64",
+                "required": true
               }
             ]
           },
@@ -1391,12 +1581,14 @@
               {
                 "id": 1,
                 "name": "txID",
-                "type": "int64"
+                "type": "int64",
+                "required": true
               },
               {
                 "id": 2,
                 "name": "containerID",
-                "type": "int64"
+                "type": "int64",
+                "required": true
               },
               {
                 "id": 3,
@@ -1407,7 +1599,8 @@
               {
                 "id": 4,
                 "name": "count",
-                "type": "int32"
+                "type": "int32",
+                "required": true
               }
             ]
           },
@@ -1423,7 +1616,8 @@
               {
                 "id": 2,
                 "name": "dnId",
-                "type": "string"
+                "type": "string",
+                "required": true
               }
             ],
             "messages": [
@@ -1433,17 +1627,20 @@
                   {
                     "id": 1,
                     "name": "txID",
-                    "type": "int64"
+                    "type": "int64",
+                    "required": true
                   },
                   {
                     "id": 2,
                     "name": "containerID",
-                    "type": "int64"
+                    "type": "int64",
+                    "required": true
                   },
                   {
                     "id": 3,
                     "name": "success",
-                    "type": "bool"
+                    "type": "bool",
+                    "required": true
                   }
                 ]
               }
@@ -1455,22 +1652,26 @@
               {
                 "id": 1,
                 "name": "containerID",
-                "type": "int64"
+                "type": "int64",
+                "required": true
               },
               {
                 "id": 2,
                 "name": "pipelineID",
-                "type": "PipelineID"
+                "type": "PipelineID",
+                "required": true
               },
               {
                 "id": 3,
                 "name": "cmdId",
-                "type": "int64"
+                "type": "int64",
+                "required": true
               },
               {
                 "id": 4,
                 "name": "force",
                 "type": "bool",
+                "optional": true,
                 "options": [
                   {
                     "name": "default",
@@ -1486,23 +1687,32 @@
               {
                 "id": 1,
                 "name": "containerID",
-                "type": "int64"
+                "type": "int64",
+                "required": true
               },
               {
                 "id": 2,
                 "name": "cmdId",
-                "type": "int64"
+                "type": "int64",
+                "required": true
               },
               {
                 "id": 3,
                 "name": "force",
                 "type": "bool",
+                "required": true,
                 "options": [
                   {
                     "name": "default",
                     "value": "false"
                   }
                 ]
+              },
+              {
+                "id": 4,
+                "name": "replicaIndex",
+                "type": "int32",
+                "optional": true
               }
             ]
           },
@@ -1512,7 +1722,8 @@
               {
                 "id": 1,
                 "name": "containerID",
-                "type": "int64"
+                "type": "int64",
+                "required": true
               },
               {
                 "id": 2,
@@ -1523,7 +1734,72 @@
               {
                 "id": 3,
                 "name": "cmdId",
-                "type": "int64"
+                "type": "int64",
+                "required": true
+              },
+              {
+                "id": 4,
+                "name": "replicaIndex",
+                "type": "int32",
+                "optional": true
+              }
+            ]
+          },
+          {
+            "name": "ReconstructECContainersCommandProto",
+            "fields": [
+              {
+                "id": 1,
+                "name": "containerID",
+                "type": "int64",
+                "required": true
+              },
+              {
+                "id": 2,
+                "name": "sources",
+                "type": "DatanodeDetailsAndReplicaIndexProto",
+                "is_repeated": true
+              },
+              {
+                "id": 3,
+                "name": "targets",
+                "type": "DatanodeDetailsProto",
+                "is_repeated": true
+              },
+              {
+                "id": 4,
+                "name": "missingContainerIndexes",
+                "type": "bytes",
+                "required": true
+              },
+              {
+                "id": 5,
+                "name": "ecReplicationConfig",
+                "type": "ECReplicationConfig",
+                "required": true
+              },
+              {
+                "id": 6,
+                "name": "cmdId",
+                "type": "int64",
+                "required": true
+              }
+            ]
+          },
+          {
+            "name": "DatanodeDetailsAndReplicaIndexProto",
+            "fields": [
+              {
+                "id": 1,
+                "name": "datanodeDetails",
+                "type": "DatanodeDetailsProto",
+                "required": true
+              },
+              {
+                "id": 2,
+                "name": "replicaIndex",
+                "type": "int32",
+                "required": true
               }
             ]
           },
@@ -1533,17 +1809,20 @@
               {
                 "id": 1,
                 "name": "pipelineID",
-                "type": "PipelineID"
+                "type": "PipelineID",
+                "required": true
               },
               {
                 "id": 2,
                 "name": "type",
-                "type": "ReplicationType"
+                "type": "ReplicationType",
+                "required": true
               },
               {
                 "id": 3,
                 "name": "factor",
-                "type": "ReplicationFactor"
+                "type": "ReplicationFactor",
+                "required": true
               },
               {
                 "id": 4,
@@ -1554,7 +1833,8 @@
               {
                 "id": 5,
                 "name": "cmdId",
-                "type": "int64"
+                "type": "int64",
+                "required": true
               },
               {
                 "id": 6,
@@ -1570,12 +1850,25 @@
               {
                 "id": 1,
                 "name": "pipelineID",
-                "type": "PipelineID"
+                "type": "PipelineID",
+                "required": true
               },
               {
                 "id": 2,
                 "name": "cmdId",
-                "type": "int64"
+                "type": "int64",
+                "required": true
+              }
+            ]
+          },
+          {
+            "name": "RefreshVolumeUsageCommandProto",
+            "fields": [
+              {
+                "id": 1,
+                "name": "cmdId",
+                "type": "int64",
+                "required": true
               }
             ]
           },
@@ -1585,17 +1878,20 @@
               {
                 "id": 1,
                 "name": "cmdId",
-                "type": "int64"
+                "type": "int64",
+                "required": true
               },
               {
                 "id": 2,
                 "name": "nodeOperationalState",
-                "type": "NodeOperationalState"
+                "type": "NodeOperationalState",
+                "required": true
               },
               {
                 "id": 3,
                 "name": "stateExpiryEpochSeconds",
-                "type": "int64"
+                "type": "int64",
+                "required": true
               }
             ]
           },
@@ -1605,7 +1901,8 @@
               {
                 "id": 1,
                 "name": "receivedCrlId",
-                "type": "int64"
+                "type": "int64",
+                "required": true
               },
               {
                 "id": 2,
@@ -1621,7 +1918,8 @@
               {
                 "id": 1,
                 "name": "crlInfo",
-                "type": "CRLInfoProto"
+                "type": "CRLInfoProto",
+                "required": true
               }
             ]
           },
@@ -1632,6 +1930,7 @@
                 "id": 1,
                 "name": "finalizeNewLayoutVersion",
                 "type": "bool",
+                "required": true,
                 "options": [
                   {
                     "name": "default",
@@ -1642,12 +1941,14 @@
               {
                 "id": 2,
                 "name": "dataNodeLayoutVersion",
-                "type": "LayoutVersionProto"
+                "type": "LayoutVersionProto",
+                "required": true
               },
               {
                 "id": 3,
                 "name": "cmdId",
-                "type": "int64"
+                "type": "int64",
+                "required": true
               }
             ]
           }
@@ -1907,47 +2208,56 @@
               {
                 "id": 1,
                 "name": "cmdType",
-                "type": "Type"
+                "type": "Type",
+                "required": true
               },
               {
                 "id": 2,
                 "name": "traceID",
-                "type": "string"
+                "type": "string",
+                "optional": true
               },
               {
                 "id": 3,
                 "name": "userInfo",
-                "type": "UserInfo"
+                "type": "UserInfo",
+                "optional": true
               },
               {
                 "id": 4,
                 "name": "version",
-                "type": "uint32"
+                "type": "uint32",
+                "optional": true
               },
               {
                 "id": 11,
                 "name": "allocateScmBlockRequest",
-                "type": "AllocateScmBlockRequestProto"
+                "type": "AllocateScmBlockRequestProto",
+                "optional": true
               },
               {
                 "id": 12,
                 "name": "deleteScmKeyBlocksRequest",
-                "type": "DeleteScmKeyBlocksRequestProto"
+                "type": "DeleteScmKeyBlocksRequestProto",
+                "optional": true
               },
               {
                 "id": 13,
                 "name": "getScmInfoRequest",
-                "type": "hadoop.hdds.GetScmInfoRequestProto"
+                "type": "hadoop.hdds.GetScmInfoRequestProto",
+                "optional": true
               },
               {
                 "id": 14,
                 "name": "sortDatanodesRequest",
-                "type": "SortDatanodesRequestProto"
+                "type": "SortDatanodesRequestProto",
+                "optional": true
               },
               {
                 "id": 15,
                 "name": "addScmRequestProto",
-                "type": "hadoop.hdds.AddScmRequestProto"
+                "type": "hadoop.hdds.AddScmRequestProto",
+                "optional": true
               }
             ]
           },
@@ -1957,17 +2267,20 @@
               {
                 "id": 1,
                 "name": "cmdType",
-                "type": "Type"
+                "type": "Type",
+                "required": true
               },
               {
                 "id": 2,
                 "name": "traceID",
-                "type": "string"
+                "type": "string",
+                "optional": true
               },
               {
                 "id": 3,
                 "name": "success",
                 "type": "bool",
+                "optional": true,
                 "options": [
                   {
                     "name": "default",
@@ -1978,47 +2291,56 @@
               {
                 "id": 4,
                 "name": "message",
-                "type": "string"
+                "type": "string",
+                "optional": true
               },
               {
                 "id": 5,
                 "name": "status",
-                "type": "Status"
+                "type": "Status",
+                "required": true
               },
               {
                 "id": 6,
                 "name": "leaderOMNodeId",
-                "type": "string"
+                "type": "string",
+                "optional": true
               },
               {
                 "id": 7,
                 "name": "leaderSCMNodeId",
-                "type": "string"
+                "type": "string",
+                "optional": true
               },
               {
                 "id": 11,
                 "name": "allocateScmBlockResponse",
-                "type": "AllocateScmBlockResponseProto"
+                "type": "AllocateScmBlockResponseProto",
+                "optional": true
               },
               {
                 "id": 12,
                 "name": "deleteScmKeyBlocksResponse",
-                "type": "DeleteScmKeyBlocksResponseProto"
+                "type": "DeleteScmKeyBlocksResponseProto",
+                "optional": true
               },
               {
                 "id": 13,
                 "name": "getScmInfoResponse",
-                "type": "hadoop.hdds.GetScmInfoResponseProto"
+                "type": "hadoop.hdds.GetScmInfoResponseProto",
+                "optional": true
               },
               {
                 "id": 14,
                 "name": "sortDatanodesResponse",
-                "type": "SortDatanodesResponseProto"
+                "type": "SortDatanodesResponseProto",
+                "optional": true
               },
               {
                 "id": 15,
                 "name": "addScmResponse",
-                "type": "hadoop.hdds.AddScmResponseProto"
+                "type": "hadoop.hdds.AddScmResponseProto",
+                "optional": true
               }
             ]
           },
@@ -2028,12 +2350,14 @@
               {
                 "id": 1,
                 "name": "userName",
-                "type": "string"
+                "type": "string",
+                "optional": true
               },
               {
                 "id": 3,
                 "name": "remoteAddress",
-                "type": "string"
+                "type": "string",
+                "optional": true
               }
             ]
           },
@@ -2043,32 +2367,44 @@
               {
                 "id": 1,
                 "name": "size",
-                "type": "uint64"
+                "type": "uint64",
+                "required": true
               },
               {
                 "id": 2,
                 "name": "numBlocks",
-                "type": "uint32"
+                "type": "uint32",
+                "required": true
               },
               {
                 "id": 3,
                 "name": "type",
-                "type": "ReplicationType"
+                "type": "ReplicationType",
+                "required": true
               },
               {
                 "id": 4,
                 "name": "factor",
-                "type": "hadoop.hdds.ReplicationFactor"
+                "type": "hadoop.hdds.ReplicationFactor",
+                "optional": true
               },
               {
                 "id": 5,
                 "name": "owner",
-                "type": "string"
+                "type": "string",
+                "required": true
               },
               {
                 "id": 7,
                 "name": "excludeList",
-                "type": "ExcludeListProto"
+                "type": "ExcludeListProto",
+                "optional": true
+              },
+              {
+                "id": 8,
+                "name": "ecReplicationConfig",
+                "type": "hadoop.hdds.ECReplicationConfig",
+                "optional": true
               }
             ]
           },
@@ -2089,7 +2425,8 @@
               {
                 "id": 1,
                 "name": "key",
-                "type": "string"
+                "type": "string",
+                "required": true
               },
               {
                 "id": 2,
@@ -2116,7 +2453,8 @@
               {
                 "id": 1,
                 "name": "objectKey",
-                "type": "string"
+                "type": "string",
+                "required": true
               },
               {
                 "id": 2,
@@ -2132,12 +2470,14 @@
               {
                 "id": 1,
                 "name": "result",
-                "type": "Result"
+                "type": "Result",
+                "required": true
               },
               {
                 "id": 2,
                 "name": "blockID",
-                "type": "BlockID"
+                "type": "BlockID",
+                "required": true
               }
             ]
           },
@@ -2147,12 +2487,14 @@
               {
                 "id": 1,
                 "name": "containerBlockID",
-                "type": "ContainerBlockID"
+                "type": "ContainerBlockID",
+                "optional": true
               },
               {
                 "id": 2,
                 "name": "pipeline",
-                "type": "hadoop.hdds.Pipeline"
+                "type": "hadoop.hdds.Pipeline",
+                "optional": true
               }
             ]
           },
@@ -2173,7 +2515,8 @@
               {
                 "id": 1,
                 "name": "client",
-                "type": "string"
+                "type": "string",
+                "required": true
               },
               {
                 "id": 2,
@@ -2285,6 +2628,10 @@
               {
                 "name": "RevokeCertificates",
                 "integer": 11
+              },
+              {
+                "name": "GetCert",
+                "integer": 12
               }
             ]
           },
@@ -2443,62 +2790,80 @@
               {
                 "id": 1,
                 "name": "cmdType",
-                "type": "Type"
+                "type": "Type",
+                "required": true
               },
               {
                 "id": 2,
                 "name": "traceID",
-                "type": "string"
+                "type": "string",
+                "optional": true
               },
               {
                 "id": 3,
                 "name": "getDataNodeCertRequest",
-                "type": "SCMGetDataNodeCertRequestProto"
+                "type": "SCMGetDataNodeCertRequestProto",
+                "optional": true
               },
               {
                 "id": 4,
                 "name": "getOMCertRequest",
-                "type": "SCMGetOMCertRequestProto"
+                "type": "SCMGetOMCertRequestProto",
+                "optional": true
               },
               {
                 "id": 5,
                 "name": "getCertificateRequest",
-                "type": "SCMGetCertificateRequestProto"
+                "type": "SCMGetCertificateRequestProto",
+                "optional": true
               },
               {
                 "id": 6,
                 "name": "getCACertificateRequest",
-                "type": "SCMGetCACertificateRequestProto"
+                "type": "SCMGetCACertificateRequestProto",
+                "optional": true
               },
               {
                 "id": 7,
                 "name": "listCertificateRequest",
-                "type": "SCMListCertificateRequestProto"
+                "type": "SCMListCertificateRequestProto",
+                "optional": true
               },
               {
                 "id": 8,
                 "name": "getSCMCertificateRequest",
-                "type": "SCMGetSCMCertRequestProto"
+                "type": "SCMGetSCMCertRequestProto",
+                "optional": true
               },
               {
                 "id": 9,
                 "name": "listCACertificateRequestProto",
-                "type": "SCMListCACertificateRequestProto"
+                "type": "SCMListCACertificateRequestProto",
+                "optional": true
               },
               {
                 "id": 10,
                 "name": "getCrlsRequest",
-                "type": "SCMGetCrlsRequestProto"
+                "type": "SCMGetCrlsRequestProto",
+                "optional": true
               },
               {
                 "id": 11,
                 "name": "getLatestCrlIdRequest",
-                "type": "SCMGetLatestCrlIdRequestProto"
+                "type": "SCMGetLatestCrlIdRequestProto",
+                "optional": true
               },
               {
                 "id": 12,
                 "name": "revokeCertificatesRequest",
-                "type": "SCMRevokeCertificatesRequestProto"
+                "type": "SCMRevokeCertificatesRequestProto",
+                "optional": true
+              },
+              {
+                "id": 13,
+                "name": "getCertRequest",
+                "type": "SCMGetCertRequestProto",
+                "optional": true
               }
             ]
           },
@@ -2508,17 +2873,20 @@
               {
                 "id": 1,
                 "name": "cmdType",
-                "type": "Type"
+                "type": "Type",
+                "required": true
               },
               {
                 "id": 2,
                 "name": "traceID",
-                "type": "string"
+                "type": "string",
+                "optional": true
               },
               {
                 "id": 3,
                 "name": "success",
                 "type": "bool",
+                "optional": true,
                 "options": [
                   {
                     "name": "default",
@@ -2529,37 +2897,44 @@
               {
                 "id": 4,
                 "name": "message",
-                "type": "string"
+                "type": "string",
+                "optional": true
               },
               {
                 "id": 5,
                 "name": "status",
-                "type": "Status"
+                "type": "Status",
+                "required": true
               },
               {
                 "id": 6,
                 "name": "getCertResponseProto",
-                "type": "SCMGetCertResponseProto"
+                "type": "SCMGetCertResponseProto",
+                "optional": true
               },
               {
                 "id": 7,
                 "name": "listCertificateResponseProto",
-                "type": "SCMListCertificateResponseProto"
+                "type": "SCMListCertificateResponseProto",
+                "optional": true
               },
               {
                 "id": 8,
                 "name": "getCrlsResponseProto",
-                "type": "SCMGetCrlsResponseProto"
+                "type": "SCMGetCrlsResponseProto",
+                "optional": true
               },
               {
                 "id": 9,
                 "name": "getLatestCrlIdResponseProto",
-                "type": "SCMGetLatestCrlIdResponseProto"
+                "type": "SCMGetLatestCrlIdResponseProto",
+                "optional": true
               },
               {
                 "id": 10,
                 "name": "revokeCertificatesResponseProto",
-                "type": "SCMRevokeCertificatesResponseProto"
+                "type": "SCMRevokeCertificatesResponseProto",
+                "optional": true
               }
             ]
           },
@@ -2569,12 +2944,14 @@
               {
                 "id": 1,
                 "name": "datanodeDetails",
-                "type": "DatanodeDetailsProto"
+                "type": "DatanodeDetailsProto",
+                "required": true
               },
               {
                 "id": 2,
                 "name": "CSR",
-                "type": "string"
+                "type": "string",
+                "required": true
               }
             ]
           },
@@ -2584,12 +2961,31 @@
               {
                 "id": 1,
                 "name": "omDetails",
-                "type": "OzoneManagerDetailsProto"
+                "type": "OzoneManagerDetailsProto",
+                "required": true
               },
               {
                 "id": 2,
                 "name": "CSR",
-                "type": "string"
+                "type": "string",
+                "required": true
+              }
+            ]
+          },
+          {
+            "name": "SCMGetCertRequestProto",
+            "fields": [
+              {
+                "id": 1,
+                "name": "nodeDetails",
+                "type": "NodeDetailsProto",
+                "required": true
+              },
+              {
+                "id": 2,
+                "name": "CSR",
+                "type": "string",
+                "required": true
               }
             ]
           },
@@ -2599,12 +2995,14 @@
               {
                 "id": 1,
                 "name": "scmDetails",
-                "type": "ScmNodeDetailsProto"
+                "type": "ScmNodeDetailsProto",
+                "required": true
               },
               {
                 "id": 2,
                 "name": "CSR",
-                "type": "string"
+                "type": "string",
+                "required": true
               }
             ]
           },
@@ -2614,7 +3012,8 @@
               {
                 "id": 1,
                 "name": "certSerialId",
-                "type": "string"
+                "type": "string",
+                "required": true
               }
             ]
           },
@@ -2627,22 +3026,26 @@
               {
                 "id": 1,
                 "name": "role",
-                "type": "NodeType"
+                "type": "NodeType",
+                "optional": true
               },
               {
                 "id": 2,
                 "name": "startCertId",
-                "type": "int64"
+                "type": "int64",
+                "optional": true
               },
               {
                 "id": 3,
                 "name": "count",
-                "type": "uint32"
+                "type": "uint32",
+                "required": true
               },
               {
                 "id": 4,
                 "name": "isRevoked",
-                "type": "bool"
+                "type": "bool",
+                "optional": true
               }
             ]
           },
@@ -2652,22 +3055,26 @@
               {
                 "id": 1,
                 "name": "responseCode",
-                "type": "ResponseCode"
+                "type": "ResponseCode",
+                "required": true
               },
               {
                 "id": 2,
                 "name": "x509Certificate",
-                "type": "string"
+                "type": "string",
+                "required": true
               },
               {
                 "id": 3,
                 "name": "x509CACertificate",
-                "type": "string"
+                "type": "string",
+                "optional": true
               },
               {
                 "id": 4,
                 "name": "x509RootCACertificate",
-                "type": "string"
+                "type": "string",
+                "optional": true
               }
             ]
           },
@@ -2677,7 +3084,8 @@
               {
                 "id": 1,
                 "name": "responseCode",
-                "type": "ResponseCode"
+                "type": "ResponseCode",
+                "required": true
               },
               {
                 "id": 2,
@@ -2724,7 +3132,8 @@
               {
                 "id": 1,
                 "name": "crlId",
-                "type": "int64"
+                "type": "int64",
+                "optional": true
               }
             ]
           },
@@ -2741,6 +3150,7 @@
                 "id": 2,
                 "name": "reason",
                 "type": "Reason",
+                "optional": true,
                 "options": [
                   {
                     "name": "default",
@@ -2751,7 +3161,8 @@
               {
                 "id": 3,
                 "name": "revokeTime",
-                "type": "uint64"
+                "type": "uint64",
+                "optional": true
               }
             ]
           },
@@ -2761,7 +3172,8 @@
               {
                 "id": 1,
                 "name": "crlId",
-                "type": "int64"
+                "type": "int64",
+                "optional": true
               }
             ]
           }

--- a/hadoop-ozone/interface-client/src/main/resources/proto.lock
+++ b/hadoop-ozone/interface-client/src/main/resources/proto.lock
@@ -1,6 +1,173 @@
 {
   "definitions": [
     {
+      "protopath": "OMAdminProtocol.proto",
+      "def": {
+        "enums": [
+          {
+            "name": "NodeState",
+            "enum_fields": [
+              {
+                "name": "ACTIVE",
+                "integer": 1
+              },
+              {
+                "name": "DECOMMISSIONED",
+                "integer": 2
+              }
+            ]
+          }
+        ],
+        "messages": [
+          {
+            "name": "OMConfigurationRequest"
+          },
+          {
+            "name": "OMConfigurationResponse",
+            "fields": [
+              {
+                "id": 1,
+                "name": "success",
+                "type": "bool",
+                "required": true
+              },
+              {
+                "id": 2,
+                "name": "errorMsg",
+                "type": "string",
+                "optional": true
+              },
+              {
+                "id": 3,
+                "name": "nodesInMemory",
+                "type": "OMNodeInfo",
+                "is_repeated": true
+              },
+              {
+                "id": 4,
+                "name": "nodesInNewConf",
+                "type": "OMNodeInfo",
+                "is_repeated": true
+              }
+            ]
+          },
+          {
+            "name": "OMNodeInfo",
+            "fields": [
+              {
+                "id": 1,
+                "name": "nodeID",
+                "type": "string",
+                "required": true
+              },
+              {
+                "id": 2,
+                "name": "hostAddress",
+                "type": "string",
+                "required": true
+              },
+              {
+                "id": 3,
+                "name": "rpcPort",
+                "type": "uint32",
+                "required": true
+              },
+              {
+                "id": 4,
+                "name": "ratisPort",
+                "type": "uint32",
+                "required": true
+              },
+              {
+                "id": 5,
+                "name": "nodeState",
+                "type": "NodeState",
+                "optional": true,
+                "options": [
+                  {
+                    "name": "default",
+                    "value": "ACTIVE"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "name": "DecommissionOMRequest",
+            "fields": [
+              {
+                "id": 1,
+                "name": "nodeId",
+                "type": "string",
+                "required": true
+              },
+              {
+                "id": 2,
+                "name": "nodeAddress",
+                "type": "string",
+                "required": true
+              }
+            ]
+          },
+          {
+            "name": "DecommissionOMResponse",
+            "fields": [
+              {
+                "id": 1,
+                "name": "success",
+                "type": "bool",
+                "required": true
+              },
+              {
+                "id": 3,
+                "name": "errorMsg",
+                "type": "string",
+                "optional": true
+              }
+            ]
+          }
+        ],
+        "services": [
+          {
+            "name": "OzoneManagerAdminService",
+            "rpcs": [
+              {
+                "name": "getOMConfiguration",
+                "in_type": "OMConfigurationRequest",
+                "out_type": "OMConfigurationResponse"
+              },
+              {
+                "name": "decommission",
+                "in_type": "DecommissionOMRequest",
+                "out_type": "DecommissionOMResponse"
+              }
+            ]
+          }
+        ],
+        "package": {
+          "name": "hadoop.ozone"
+        },
+        "options": [
+          {
+            "name": "java_package",
+            "value": "org.apache.hadoop.ozone.protocol.proto"
+          },
+          {
+            "name": "java_outer_classname",
+            "value": "OzoneManagerAdminProtocolProtos"
+          },
+          {
+            "name": "java_generic_services",
+            "value": "true"
+          },
+          {
+            "name": "java_generate_equals_and_hash",
+            "value": "true"
+          }
+        ]
+      }
+    },
+    {
       "protopath": "OmClientProtocol.proto",
       "def": {
         "enums": [
@@ -214,6 +381,70 @@
               {
                 "name": "PurgePaths",
                 "integer": 94
+              },
+              {
+                "name": "PurgeDirectories",
+                "integer": 95
+              },
+              {
+                "name": "CreateTenant",
+                "integer": 96
+              },
+              {
+                "name": "DeleteTenant",
+                "integer": 97
+              },
+              {
+                "name": "ListTenant",
+                "integer": 98
+              },
+              {
+                "name": "TenantGetUserInfo",
+                "integer": 99
+              },
+              {
+                "name": "TenantAssignUserAccessId",
+                "integer": 100
+              },
+              {
+                "name": "TenantRevokeUserAccessId",
+                "integer": 101
+              },
+              {
+                "name": "TenantAssignAdmin",
+                "integer": 102
+              },
+              {
+                "name": "TenantRevokeAdmin",
+                "integer": 103
+              },
+              {
+                "name": "GetS3VolumeContext",
+                "integer": 104
+              },
+              {
+                "name": "TenantListUser",
+                "integer": 105
+              },
+              {
+                "name": "SetS3Secret",
+                "integer": 106
+              },
+              {
+                "name": "SetRangerServiceVersion",
+                "integer": 107
+              },
+              {
+                "name": "RangerBGSync",
+                "integer": 109
+              },
+              {
+                "name": "EchoRPC",
+                "integer": 110
+              },
+              {
+                "name": "GetKeyInfo",
+                "integer": 111
               }
             ]
           },
@@ -503,6 +734,54 @@
               {
                 "name": "NOT_SUPPORTED_OPERATION_WHEN_PREPARED",
                 "integer": 74
+              },
+              {
+                "name": "NOT_SUPPORTED_OPERATION_PRIOR_FINALIZATION",
+                "integer": 75
+              },
+              {
+                "name": "TENANT_NOT_FOUND",
+                "integer": 76
+              },
+              {
+                "name": "TENANT_ALREADY_EXISTS",
+                "integer": 77
+              },
+              {
+                "name": "INVALID_TENANT_ID",
+                "integer": 78
+              },
+              {
+                "name": "ACCESS_ID_NOT_FOUND",
+                "integer": 79
+              },
+              {
+                "name": "TENANT_USER_ACCESS_ID_ALREADY_EXISTS",
+                "integer": 80
+              },
+              {
+                "name": "INVALID_TENANT_USERNAME",
+                "integer": 81
+              },
+              {
+                "name": "INVALID_ACCESS_ID",
+                "integer": 82
+              },
+              {
+                "name": "TENANT_AUTHORIZER_ERROR",
+                "integer": 83
+              },
+              {
+                "name": "VOLUME_IS_REFERENCED",
+                "integer": 84
+              },
+              {
+                "name": "TENANT_NOT_EMPTY",
+                "integer": 85
+              },
+              {
+                "name": "FEATURE_NOT_ENABLED",
+                "integer": 86
               }
             ]
           },
@@ -659,6 +938,35 @@
             ]
           },
           {
+            "name": "ChecksumTypeProto",
+            "enum_fields": [
+              {
+                "name": "CHECKSUM_NULL"
+              },
+              {
+                "name": "CHECKSUM_CRC32",
+                "integer": 1
+              },
+              {
+                "name": "CHECKSUM_CRC32C",
+                "integer": 2
+              }
+            ]
+          },
+          {
+            "name": "FileChecksumTypeProto",
+            "enum_fields": [
+              {
+                "name": "MD5CRC",
+                "integer": 1
+              },
+              {
+                "name": "COMPOSITE_CRC",
+                "integer": 2
+              }
+            ]
+          },
+          {
             "name": "OMTokenProto.Type",
             "enum_fields": [
               {
@@ -717,307 +1025,476 @@
               {
                 "id": 1,
                 "name": "cmdType",
-                "type": "Type"
+                "type": "Type",
+                "required": true
               },
               {
                 "id": 2,
                 "name": "traceID",
-                "type": "string"
+                "type": "string",
+                "optional": true
               },
               {
                 "id": 3,
                 "name": "clientId",
-                "type": "string"
+                "type": "string",
+                "required": true
               },
               {
                 "id": 4,
                 "name": "userInfo",
-                "type": "UserInfo"
+                "type": "UserInfo",
+                "optional": true
               },
               {
                 "id": 5,
                 "name": "version",
-                "type": "uint32"
+                "type": "uint32",
+                "optional": true
               },
               {
                 "id": 6,
                 "name": "layoutVersion",
-                "type": "LayoutVersion"
+                "type": "LayoutVersion",
+                "optional": true
               },
               {
                 "id": 11,
                 "name": "createVolumeRequest",
-                "type": "CreateVolumeRequest"
+                "type": "CreateVolumeRequest",
+                "optional": true
               },
               {
                 "id": 12,
                 "name": "setVolumePropertyRequest",
-                "type": "SetVolumePropertyRequest"
+                "type": "SetVolumePropertyRequest",
+                "optional": true
               },
               {
                 "id": 13,
                 "name": "checkVolumeAccessRequest",
-                "type": "CheckVolumeAccessRequest"
+                "type": "CheckVolumeAccessRequest",
+                "optional": true
               },
               {
                 "id": 14,
                 "name": "infoVolumeRequest",
-                "type": "InfoVolumeRequest"
+                "type": "InfoVolumeRequest",
+                "optional": true
               },
               {
                 "id": 15,
                 "name": "deleteVolumeRequest",
-                "type": "DeleteVolumeRequest"
+                "type": "DeleteVolumeRequest",
+                "optional": true
               },
               {
                 "id": 16,
                 "name": "listVolumeRequest",
-                "type": "ListVolumeRequest"
+                "type": "ListVolumeRequest",
+                "optional": true
               },
               {
                 "id": 21,
                 "name": "createBucketRequest",
-                "type": "CreateBucketRequest"
+                "type": "CreateBucketRequest",
+                "optional": true
               },
               {
                 "id": 22,
                 "name": "infoBucketRequest",
-                "type": "InfoBucketRequest"
+                "type": "InfoBucketRequest",
+                "optional": true
               },
               {
                 "id": 23,
                 "name": "setBucketPropertyRequest",
-                "type": "SetBucketPropertyRequest"
+                "type": "SetBucketPropertyRequest",
+                "optional": true
               },
               {
                 "id": 24,
                 "name": "deleteBucketRequest",
-                "type": "DeleteBucketRequest"
+                "type": "DeleteBucketRequest",
+                "optional": true
               },
               {
                 "id": 25,
                 "name": "listBucketsRequest",
-                "type": "ListBucketsRequest"
+                "type": "ListBucketsRequest",
+                "optional": true
               },
               {
                 "id": 31,
                 "name": "createKeyRequest",
-                "type": "CreateKeyRequest"
+                "type": "CreateKeyRequest",
+                "optional": true
               },
               {
                 "id": 32,
                 "name": "lookupKeyRequest",
-                "type": "LookupKeyRequest"
+                "type": "LookupKeyRequest",
+                "optional": true
               },
               {
                 "id": 33,
                 "name": "renameKeyRequest",
-                "type": "RenameKeyRequest"
+                "type": "RenameKeyRequest",
+                "optional": true
               },
               {
                 "id": 34,
                 "name": "deleteKeyRequest",
-                "type": "DeleteKeyRequest"
+                "type": "DeleteKeyRequest",
+                "optional": true
               },
               {
                 "id": 35,
                 "name": "listKeysRequest",
-                "type": "ListKeysRequest"
+                "type": "ListKeysRequest",
+                "optional": true
               },
               {
                 "id": 36,
                 "name": "commitKeyRequest",
-                "type": "CommitKeyRequest"
+                "type": "CommitKeyRequest",
+                "optional": true
               },
               {
                 "id": 37,
                 "name": "allocateBlockRequest",
-                "type": "AllocateBlockRequest"
+                "type": "AllocateBlockRequest",
+                "optional": true
               },
               {
                 "id": 38,
                 "name": "deleteKeysRequest",
-                "type": "DeleteKeysRequest"
+                "type": "DeleteKeysRequest",
+                "optional": true
               },
               {
                 "id": 39,
                 "name": "renameKeysRequest",
-                "type": "RenameKeysRequest"
+                "type": "RenameKeysRequest",
+                "optional": true
               },
               {
                 "id": 40,
                 "name": "deleteOpenKeysRequest",
-                "type": "DeleteOpenKeysRequest"
+                "type": "DeleteOpenKeysRequest",
+                "optional": true
               },
               {
                 "id": 45,
                 "name": "initiateMultiPartUploadRequest",
-                "type": "MultipartInfoInitiateRequest"
+                "type": "MultipartInfoInitiateRequest",
+                "optional": true
               },
               {
                 "id": 46,
                 "name": "commitMultiPartUploadRequest",
-                "type": "MultipartCommitUploadPartRequest"
+                "type": "MultipartCommitUploadPartRequest",
+                "optional": true
               },
               {
                 "id": 47,
                 "name": "completeMultiPartUploadRequest",
-                "type": "MultipartUploadCompleteRequest"
+                "type": "MultipartUploadCompleteRequest",
+                "optional": true
               },
               {
                 "id": 48,
                 "name": "abortMultiPartUploadRequest",
-                "type": "MultipartUploadAbortRequest"
+                "type": "MultipartUploadAbortRequest",
+                "optional": true
               },
               {
                 "id": 49,
                 "name": "getS3SecretRequest",
-                "type": "GetS3SecretRequest"
+                "type": "GetS3SecretRequest",
+                "optional": true
               },
               {
                 "id": 50,
                 "name": "listMultipartUploadPartsRequest",
-                "type": "MultipartUploadListPartsRequest"
+                "type": "MultipartUploadListPartsRequest",
+                "optional": true
               },
               {
                 "id": 51,
                 "name": "serviceListRequest",
-                "type": "ServiceListRequest"
+                "type": "ServiceListRequest",
+                "optional": true
               },
               {
                 "id": 53,
                 "name": "dbUpdatesRequest",
-                "type": "DBUpdatesRequest"
+                "type": "DBUpdatesRequest",
+                "optional": true
               },
               {
                 "id": 54,
                 "name": "finalizeUpgradeRequest",
-                "type": "FinalizeUpgradeRequest"
+                "type": "FinalizeUpgradeRequest",
+                "optional": true
               },
               {
                 "id": 55,
                 "name": "finalizeUpgradeProgressRequest",
-                "type": "FinalizeUpgradeProgressRequest"
+                "type": "FinalizeUpgradeProgressRequest",
+                "optional": true
               },
               {
                 "id": 56,
                 "name": "prepareRequest",
-                "type": "PrepareRequest"
+                "type": "PrepareRequest",
+                "optional": true
               },
               {
                 "id": 57,
                 "name": "prepareStatusRequest",
-                "type": "PrepareStatusRequest"
+                "type": "PrepareStatusRequest",
+                "optional": true
               },
               {
                 "id": 58,
                 "name": "cancelPrepareRequest",
-                "type": "CancelPrepareRequest"
+                "type": "CancelPrepareRequest",
+                "optional": true
               },
               {
                 "id": 61,
                 "name": "getDelegationTokenRequest",
-                "type": "hadoop.common.GetDelegationTokenRequestProto"
+                "type": "hadoop.common.GetDelegationTokenRequestProto",
+                "optional": true
               },
               {
                 "id": 62,
                 "name": "renewDelegationTokenRequest",
-                "type": "hadoop.common.RenewDelegationTokenRequestProto"
+                "type": "hadoop.common.RenewDelegationTokenRequestProto",
+                "optional": true
               },
               {
                 "id": 63,
                 "name": "cancelDelegationTokenRequest",
-                "type": "hadoop.common.CancelDelegationTokenRequestProto"
+                "type": "hadoop.common.CancelDelegationTokenRequestProto",
+                "optional": true
               },
               {
                 "id": 64,
                 "name": "updateGetDelegationTokenRequest",
-                "type": "UpdateGetDelegationTokenRequest"
+                "type": "UpdateGetDelegationTokenRequest",
+                "optional": true
               },
               {
                 "id": 65,
                 "name": "updatedRenewDelegationTokenRequest",
-                "type": "UpdateRenewDelegationTokenRequest"
+                "type": "UpdateRenewDelegationTokenRequest",
+                "optional": true
               },
               {
                 "id": 70,
                 "name": "getFileStatusRequest",
-                "type": "GetFileStatusRequest"
+                "type": "GetFileStatusRequest",
+                "optional": true
               },
               {
                 "id": 71,
                 "name": "createDirectoryRequest",
-                "type": "CreateDirectoryRequest"
+                "type": "CreateDirectoryRequest",
+                "optional": true
               },
               {
                 "id": 72,
                 "name": "createFileRequest",
-                "type": "CreateFileRequest"
+                "type": "CreateFileRequest",
+                "optional": true
               },
               {
                 "id": 73,
                 "name": "lookupFileRequest",
-                "type": "LookupFileRequest"
+                "type": "LookupFileRequest",
+                "optional": true
               },
               {
                 "id": 74,
                 "name": "listStatusRequest",
-                "type": "ListStatusRequest"
+                "type": "ListStatusRequest",
+                "optional": true
               },
               {
                 "id": 75,
                 "name": "addAclRequest",
-                "type": "AddAclRequest"
+                "type": "AddAclRequest",
+                "optional": true
               },
               {
                 "id": 76,
                 "name": "removeAclRequest",
-                "type": "RemoveAclRequest"
+                "type": "RemoveAclRequest",
+                "optional": true
               },
               {
                 "id": 77,
                 "name": "setAclRequest",
-                "type": "SetAclRequest"
+                "type": "SetAclRequest",
+                "optional": true
               },
               {
                 "id": 78,
                 "name": "getAclRequest",
-                "type": "GetAclRequest"
+                "type": "GetAclRequest",
+                "optional": true
               },
               {
                 "id": 81,
                 "name": "purgeKeysRequest",
-                "type": "PurgeKeysRequest"
+                "type": "PurgeKeysRequest",
+                "optional": true
               },
               {
                 "id": 82,
                 "name": "updateGetS3SecretRequest",
-                "type": "UpdateGetS3SecretRequest"
+                "type": "UpdateGetS3SecretRequest",
+                "optional": true
               },
               {
                 "id": 83,
                 "name": "listMultipartUploadsRequest",
-                "type": "ListMultipartUploadsRequest"
+                "type": "ListMultipartUploadsRequest",
+                "optional": true
               },
               {
                 "id": 91,
                 "name": "listTrashRequest",
-                "type": "ListTrashRequest"
+                "type": "ListTrashRequest",
+                "optional": true
               },
               {
                 "id": 92,
                 "name": "RecoverTrashRequest",
-                "type": "RecoverTrashRequest"
+                "type": "RecoverTrashRequest",
+                "optional": true
               },
               {
                 "id": 93,
                 "name": "RevokeS3SecretRequest",
-                "type": "RevokeS3SecretRequest"
+                "type": "RevokeS3SecretRequest",
+                "optional": true
               },
               {
                 "id": 94,
                 "name": "purgePathsRequest",
-                "type": "PurgePathsRequest"
+                "type": "PurgePathsRequest",
+                "optional": true,
+                "options": [
+                  {
+                    "name": "deprecated",
+                    "value": "true"
+                  }
+                ]
+              },
+              {
+                "id": 108,
+                "name": "purgeDirectoriesRequest",
+                "type": "PurgeDirectoriesRequest",
+                "optional": true
+              },
+              {
+                "id": 95,
+                "name": "s3Authentication",
+                "type": "S3Authentication",
+                "optional": true
+              },
+              {
+                "id": 96,
+                "name": "CreateTenantRequest",
+                "type": "CreateTenantRequest",
+                "optional": true
+              },
+              {
+                "id": 97,
+                "name": "DeleteTenantRequest",
+                "type": "DeleteTenantRequest",
+                "optional": true
+              },
+              {
+                "id": 98,
+                "name": "ListTenantRequest",
+                "type": "ListTenantRequest",
+                "optional": true
+              },
+              {
+                "id": 99,
+                "name": "TenantGetUserInfoRequest",
+                "type": "TenantGetUserInfoRequest",
+                "optional": true
+              },
+              {
+                "id": 100,
+                "name": "TenantAssignUserAccessIdRequest",
+                "type": "TenantAssignUserAccessIdRequest",
+                "optional": true
+              },
+              {
+                "id": 101,
+                "name": "TenantRevokeUserAccessIdRequest",
+                "type": "TenantRevokeUserAccessIdRequest",
+                "optional": true
+              },
+              {
+                "id": 102,
+                "name": "TenantAssignAdminRequest",
+                "type": "TenantAssignAdminRequest",
+                "optional": true
+              },
+              {
+                "id": 103,
+                "name": "TenantRevokeAdminRequest",
+                "type": "TenantRevokeAdminRequest",
+                "optional": true
+              },
+              {
+                "id": 104,
+                "name": "getS3VolumeContextRequest",
+                "type": "GetS3VolumeContextRequest",
+                "optional": true
+              },
+              {
+                "id": 105,
+                "name": "tenantListUserRequest",
+                "type": "TenantListUserRequest",
+                "optional": true
+              },
+              {
+                "id": 106,
+                "name": "SetS3SecretRequest",
+                "type": "SetS3SecretRequest",
+                "optional": true
+              },
+              {
+                "id": 107,
+                "name": "SetRangerServiceVersionRequest",
+                "type": "SetRangerServiceVersionRequest",
+                "optional": true
+              },
+              {
+                "id": 109,
+                "name": "RangerBGSyncRequest",
+                "type": "RangerBGSyncRequest",
+                "optional": true
+              },
+              {
+                "id": 110,
+                "name": "EchoRPCRequest",
+                "type": "EchoRPCRequest",
+                "optional": true
+              },
+              {
+                "id": 111,
+                "name": "GetKeyInfoRequest",
+                "type": "GetKeyInfoRequest",
+                "optional": true
               }
             ]
           },
@@ -1027,17 +1504,20 @@
               {
                 "id": 1,
                 "name": "cmdType",
-                "type": "Type"
+                "type": "Type",
+                "required": true
               },
               {
                 "id": 2,
                 "name": "traceID",
-                "type": "string"
+                "type": "string",
+                "optional": true
               },
               {
                 "id": 3,
                 "name": "success",
                 "type": "bool",
+                "optional": true,
                 "options": [
                   {
                     "name": "default",
@@ -1048,267 +1528,422 @@
               {
                 "id": 4,
                 "name": "message",
-                "type": "string"
+                "type": "string",
+                "optional": true
               },
               {
                 "id": 5,
                 "name": "status",
-                "type": "Status"
+                "type": "Status",
+                "required": true
               },
               {
                 "id": 6,
                 "name": "leaderOMNodeId",
-                "type": "string"
+                "type": "string",
+                "optional": true
               },
               {
                 "id": 11,
                 "name": "createVolumeResponse",
-                "type": "CreateVolumeResponse"
+                "type": "CreateVolumeResponse",
+                "optional": true
               },
               {
                 "id": 12,
                 "name": "setVolumePropertyResponse",
-                "type": "SetVolumePropertyResponse"
+                "type": "SetVolumePropertyResponse",
+                "optional": true
               },
               {
                 "id": 13,
                 "name": "checkVolumeAccessResponse",
-                "type": "CheckVolumeAccessResponse"
+                "type": "CheckVolumeAccessResponse",
+                "optional": true
               },
               {
                 "id": 14,
                 "name": "infoVolumeResponse",
-                "type": "InfoVolumeResponse"
+                "type": "InfoVolumeResponse",
+                "optional": true
               },
               {
                 "id": 15,
                 "name": "deleteVolumeResponse",
-                "type": "DeleteVolumeResponse"
+                "type": "DeleteVolumeResponse",
+                "optional": true
               },
               {
                 "id": 16,
                 "name": "listVolumeResponse",
-                "type": "ListVolumeResponse"
+                "type": "ListVolumeResponse",
+                "optional": true
               },
               {
                 "id": 21,
                 "name": "createBucketResponse",
-                "type": "CreateBucketResponse"
+                "type": "CreateBucketResponse",
+                "optional": true
               },
               {
                 "id": 22,
                 "name": "infoBucketResponse",
-                "type": "InfoBucketResponse"
+                "type": "InfoBucketResponse",
+                "optional": true
               },
               {
                 "id": 23,
                 "name": "setBucketPropertyResponse",
-                "type": "SetBucketPropertyResponse"
+                "type": "SetBucketPropertyResponse",
+                "optional": true
               },
               {
                 "id": 24,
                 "name": "deleteBucketResponse",
-                "type": "DeleteBucketResponse"
+                "type": "DeleteBucketResponse",
+                "optional": true
               },
               {
                 "id": 25,
                 "name": "listBucketsResponse",
-                "type": "ListBucketsResponse"
+                "type": "ListBucketsResponse",
+                "optional": true
               },
               {
                 "id": 31,
                 "name": "createKeyResponse",
-                "type": "CreateKeyResponse"
+                "type": "CreateKeyResponse",
+                "optional": true
               },
               {
                 "id": 32,
                 "name": "lookupKeyResponse",
-                "type": "LookupKeyResponse"
+                "type": "LookupKeyResponse",
+                "optional": true
               },
               {
                 "id": 33,
                 "name": "renameKeyResponse",
-                "type": "RenameKeyResponse"
+                "type": "RenameKeyResponse",
+                "optional": true
               },
               {
                 "id": 34,
                 "name": "deleteKeyResponse",
-                "type": "DeleteKeyResponse"
+                "type": "DeleteKeyResponse",
+                "optional": true
               },
               {
                 "id": 35,
                 "name": "listKeysResponse",
-                "type": "ListKeysResponse"
+                "type": "ListKeysResponse",
+                "optional": true
               },
               {
                 "id": 36,
                 "name": "commitKeyResponse",
-                "type": "CommitKeyResponse"
+                "type": "CommitKeyResponse",
+                "optional": true
               },
               {
                 "id": 37,
                 "name": "allocateBlockResponse",
-                "type": "AllocateBlockResponse"
+                "type": "AllocateBlockResponse",
+                "optional": true
               },
               {
                 "id": 38,
                 "name": "deleteKeysResponse",
-                "type": "DeleteKeysResponse"
+                "type": "DeleteKeysResponse",
+                "optional": true
               },
               {
                 "id": 39,
                 "name": "renameKeysResponse",
-                "type": "RenameKeysResponse"
+                "type": "RenameKeysResponse",
+                "optional": true
               },
               {
                 "id": 45,
                 "name": "initiateMultiPartUploadResponse",
-                "type": "MultipartInfoInitiateResponse"
+                "type": "MultipartInfoInitiateResponse",
+                "optional": true
               },
               {
                 "id": 46,
                 "name": "commitMultiPartUploadResponse",
-                "type": "MultipartCommitUploadPartResponse"
+                "type": "MultipartCommitUploadPartResponse",
+                "optional": true
               },
               {
                 "id": 47,
                 "name": "completeMultiPartUploadResponse",
-                "type": "MultipartUploadCompleteResponse"
+                "type": "MultipartUploadCompleteResponse",
+                "optional": true
               },
               {
                 "id": 48,
                 "name": "abortMultiPartUploadResponse",
-                "type": "MultipartUploadAbortResponse"
+                "type": "MultipartUploadAbortResponse",
+                "optional": true
               },
               {
                 "id": 49,
                 "name": "getS3SecretResponse",
-                "type": "GetS3SecretResponse"
+                "type": "GetS3SecretResponse",
+                "optional": true
               },
               {
                 "id": 50,
                 "name": "listMultipartUploadPartsResponse",
-                "type": "MultipartUploadListPartsResponse"
+                "type": "MultipartUploadListPartsResponse",
+                "optional": true
               },
               {
                 "id": 51,
                 "name": "ServiceListResponse",
-                "type": "ServiceListResponse"
+                "type": "ServiceListResponse",
+                "optional": true
               },
               {
                 "id": 52,
                 "name": "dbUpdatesResponse",
-                "type": "DBUpdatesResponse"
+                "type": "DBUpdatesResponse",
+                "optional": true
               },
               {
                 "id": 54,
                 "name": "finalizeUpgradeResponse",
-                "type": "FinalizeUpgradeResponse"
+                "type": "FinalizeUpgradeResponse",
+                "optional": true
               },
               {
                 "id": 55,
                 "name": "finalizeUpgradeProgressResponse",
-                "type": "FinalizeUpgradeProgressResponse"
+                "type": "FinalizeUpgradeProgressResponse",
+                "optional": true
               },
               {
                 "id": 56,
                 "name": "prepareResponse",
-                "type": "PrepareResponse"
+                "type": "PrepareResponse",
+                "optional": true
               },
               {
                 "id": 57,
                 "name": "prepareStatusResponse",
-                "type": "PrepareStatusResponse"
+                "type": "PrepareStatusResponse",
+                "optional": true
               },
               {
                 "id": 58,
                 "name": "cancelPrepareResponse",
-                "type": "CancelPrepareResponse"
+                "type": "CancelPrepareResponse",
+                "optional": true
               },
               {
                 "id": 61,
                 "name": "getDelegationTokenResponse",
-                "type": "GetDelegationTokenResponseProto"
+                "type": "GetDelegationTokenResponseProto",
+                "optional": true
               },
               {
                 "id": 62,
                 "name": "renewDelegationTokenResponse",
-                "type": "RenewDelegationTokenResponseProto"
+                "type": "RenewDelegationTokenResponseProto",
+                "optional": true
               },
               {
                 "id": 63,
                 "name": "cancelDelegationTokenResponse",
-                "type": "CancelDelegationTokenResponseProto"
+                "type": "CancelDelegationTokenResponseProto",
+                "optional": true
               },
               {
                 "id": 70,
                 "name": "getFileStatusResponse",
-                "type": "GetFileStatusResponse"
+                "type": "GetFileStatusResponse",
+                "optional": true
               },
               {
                 "id": 71,
                 "name": "createDirectoryResponse",
-                "type": "CreateDirectoryResponse"
+                "type": "CreateDirectoryResponse",
+                "optional": true
               },
               {
                 "id": 72,
                 "name": "createFileResponse",
-                "type": "CreateFileResponse"
+                "type": "CreateFileResponse",
+                "optional": true
               },
               {
                 "id": 73,
                 "name": "lookupFileResponse",
-                "type": "LookupFileResponse"
+                "type": "LookupFileResponse",
+                "optional": true
               },
               {
                 "id": 74,
                 "name": "listStatusResponse",
-                "type": "ListStatusResponse"
+                "type": "ListStatusResponse",
+                "optional": true
               },
               {
                 "id": 75,
                 "name": "addAclResponse",
-                "type": "AddAclResponse"
+                "type": "AddAclResponse",
+                "optional": true
               },
               {
                 "id": 76,
                 "name": "removeAclResponse",
-                "type": "RemoveAclResponse"
+                "type": "RemoveAclResponse",
+                "optional": true
               },
               {
                 "id": 77,
                 "name": "setAclResponse",
-                "type": "SetAclResponse"
+                "type": "SetAclResponse",
+                "optional": true
               },
               {
                 "id": 78,
                 "name": "getAclResponse",
-                "type": "GetAclResponse"
+                "type": "GetAclResponse",
+                "optional": true
               },
               {
                 "id": 81,
                 "name": "purgeKeysResponse",
-                "type": "PurgeKeysResponse"
+                "type": "PurgeKeysResponse",
+                "optional": true
               },
               {
                 "id": 82,
                 "name": "listMultipartUploadsResponse",
-                "type": "ListMultipartUploadsResponse"
+                "type": "ListMultipartUploadsResponse",
+                "optional": true
               },
               {
                 "id": 91,
                 "name": "listTrashResponse",
-                "type": "ListTrashResponse"
+                "type": "ListTrashResponse",
+                "optional": true
               },
               {
                 "id": 92,
                 "name": "RecoverTrashResponse",
-                "type": "RecoverTrashResponse"
+                "type": "RecoverTrashResponse",
+                "optional": true
               },
               {
                 "id": 93,
                 "name": "purgePathsResponse",
-                "type": "PurgePathsResponse"
+                "type": "PurgePathsResponse",
+                "optional": true,
+                "options": [
+                  {
+                    "name": "deprecated",
+                    "value": "true"
+                  }
+                ]
+              },
+              {
+                "id": 108,
+                "name": "purgeDirectoriesResponse",
+                "type": "PurgeDirectoriesResponse",
+                "optional": true
+              },
+              {
+                "id": 96,
+                "name": "CreateTenantResponse",
+                "type": "CreateTenantResponse",
+                "optional": true
+              },
+              {
+                "id": 97,
+                "name": "DeleteTenantResponse",
+                "type": "DeleteTenantResponse",
+                "optional": true
+              },
+              {
+                "id": 98,
+                "name": "ListTenantResponse",
+                "type": "ListTenantResponse",
+                "optional": true
+              },
+              {
+                "id": 99,
+                "name": "TenantGetUserInfoResponse",
+                "type": "TenantGetUserInfoResponse",
+                "optional": true
+              },
+              {
+                "id": 100,
+                "name": "TenantAssignUserAccessIdResponse",
+                "type": "TenantAssignUserAccessIdResponse",
+                "optional": true
+              },
+              {
+                "id": 101,
+                "name": "TenantRevokeUserAccessIdResponse",
+                "type": "TenantRevokeUserAccessIdResponse",
+                "optional": true
+              },
+              {
+                "id": 102,
+                "name": "TenantAssignAdminResponse",
+                "type": "TenantAssignAdminResponse",
+                "optional": true
+              },
+              {
+                "id": 103,
+                "name": "TenantRevokeAdminResponse",
+                "type": "TenantRevokeAdminResponse",
+                "optional": true
+              },
+              {
+                "id": 104,
+                "name": "getS3VolumeContextResponse",
+                "type": "GetS3VolumeContextResponse",
+                "optional": true
+              },
+              {
+                "id": 105,
+                "name": "tenantListUserResponse",
+                "type": "TenantListUserResponse",
+                "optional": true
+              },
+              {
+                "id": 106,
+                "name": "SetS3SecretResponse",
+                "type": "SetS3SecretResponse",
+                "optional": true
+              },
+              {
+                "id": 107,
+                "name": "SetRangerServiceVersionResponse",
+                "type": "SetRangerServiceVersionResponse",
+                "optional": true
+              },
+              {
+                "id": 109,
+                "name": "RangerBGSyncResponse",
+                "type": "RangerBGSyncResponse",
+                "optional": true
+              },
+              {
+                "id": 110,
+                "name": "EchoRPCResponse",
+                "type": "EchoRPCResponse",
+                "optional": true
+              },
+              {
+                "id": 111,
+                "name": "GetKeyInfoResponse",
+                "type": "GetKeyInfoResponse",
+                "optional": true
               }
             ]
           },
@@ -1318,27 +1953,32 @@
               {
                 "id": 1,
                 "name": "volumeName",
-                "type": "string"
+                "type": "string",
+                "required": true
               },
               {
                 "id": 2,
                 "name": "bucketName",
-                "type": "string"
+                "type": "string",
+                "required": true
               },
               {
                 "id": 3,
                 "name": "startKeyName",
-                "type": "string"
+                "type": "string",
+                "optional": true
               },
               {
                 "id": 4,
                 "name": "keyPrefix",
-                "type": "string"
+                "type": "string",
+                "optional": true
               },
               {
                 "id": 5,
                 "name": "maxKeys",
-                "type": "int32"
+                "type": "int32",
+                "optional": true
               }
             ]
           },
@@ -1359,22 +1999,26 @@
               {
                 "id": 1,
                 "name": "volumeName",
-                "type": "string"
+                "type": "string",
+                "required": true
               },
               {
                 "id": 2,
                 "name": "bucketName",
-                "type": "string"
+                "type": "string",
+                "required": true
               },
               {
                 "id": 3,
                 "name": "keyName",
-                "type": "string"
+                "type": "string",
+                "required": true
               },
               {
                 "id": 4,
                 "name": "destinationBucket",
-                "type": "string"
+                "type": "string",
+                "required": true
               }
             ]
           },
@@ -1384,7 +2028,8 @@
               {
                 "id": 1,
                 "name": "response",
-                "type": "bool"
+                "type": "bool",
+                "required": true
               }
             ]
           },
@@ -1394,22 +2039,26 @@
               {
                 "id": 1,
                 "name": "adminName",
-                "type": "string"
+                "type": "string",
+                "required": true
               },
               {
                 "id": 2,
                 "name": "ownerName",
-                "type": "string"
+                "type": "string",
+                "required": true
               },
               {
                 "id": 3,
                 "name": "volume",
-                "type": "string"
+                "type": "string",
+                "required": true
               },
               {
                 "id": 4,
                 "name": "quotaInBytes",
-                "type": "uint64"
+                "type": "uint64",
+                "optional": true
               },
               {
                 "id": 5,
@@ -1426,27 +2075,32 @@
               {
                 "id": 7,
                 "name": "creationTime",
-                "type": "uint64"
+                "type": "uint64",
+                "optional": true
               },
               {
                 "id": 8,
                 "name": "objectID",
-                "type": "uint64"
+                "type": "uint64",
+                "optional": true
               },
               {
                 "id": 9,
                 "name": "updateID",
-                "type": "uint64"
+                "type": "uint64",
+                "optional": true
               },
               {
                 "id": 10,
                 "name": "modificationTime",
-                "type": "uint64"
+                "type": "uint64",
+                "optional": true
               },
               {
                 "id": 11,
                 "name": "quotaInNamespace",
                 "type": "int64",
+                "optional": true,
                 "options": [
                   {
                     "name": "default",
@@ -1457,7 +2111,14 @@
               {
                 "id": 12,
                 "name": "usedNamespace",
-                "type": "uint64"
+                "type": "uint64",
+                "optional": true
+              },
+              {
+                "id": 13,
+                "name": "refCount",
+                "type": "int64",
+                "optional": true
               }
             ]
           },
@@ -1467,17 +2128,20 @@
               {
                 "id": 1,
                 "name": "userName",
-                "type": "string"
+                "type": "string",
+                "optional": true
               },
               {
                 "id": 3,
                 "name": "remoteAddress",
-                "type": "string"
+                "type": "string",
+                "optional": true
               },
               {
                 "id": 4,
                 "name": "hostName",
-                "type": "string"
+                "type": "string",
+                "optional": true
               }
             ]
           },
@@ -1487,12 +2151,14 @@
               {
                 "id": 1,
                 "name": "getDelegationTokenResponse",
-                "type": "GetDelegationTokenResponseProto"
+                "type": "GetDelegationTokenResponseProto",
+                "required": true
               },
               {
                 "id": 2,
                 "name": "tokenRenewInterval",
-                "type": "uint64"
+                "type": "uint64",
+                "optional": true
               }
             ]
           },
@@ -1502,12 +2168,14 @@
               {
                 "id": 1,
                 "name": "renewDelegationTokenRequest",
-                "type": "hadoop.common.RenewDelegationTokenRequestProto"
+                "type": "hadoop.common.RenewDelegationTokenRequestProto",
+                "required": true
               },
               {
                 "id": 2,
                 "name": "renewDelegationTokenResponse",
-                "type": "RenewDelegationTokenResponseProto"
+                "type": "RenewDelegationTokenResponseProto",
+                "required": true
               }
             ]
           },
@@ -1517,7 +2185,8 @@
               {
                 "id": 1,
                 "name": "volumeInfo",
-                "type": "VolumeInfo"
+                "type": "VolumeInfo",
+                "required": true
               }
             ]
           },
@@ -1536,12 +2205,14 @@
               {
                 "id": 2,
                 "name": "objectID",
-                "type": "uint64"
+                "type": "uint64",
+                "optional": true
               },
               {
                 "id": 3,
                 "name": "updateID",
-                "type": "uint64"
+                "type": "uint64",
+                "optional": true
               }
             ]
           },
@@ -1551,27 +2222,32 @@
               {
                 "id": 1,
                 "name": "volumeName",
-                "type": "string"
+                "type": "string",
+                "required": true
               },
               {
                 "id": 2,
                 "name": "ownerName",
-                "type": "string"
+                "type": "string",
+                "optional": true
               },
               {
                 "id": 3,
                 "name": "quotaInBytes",
-                "type": "uint64"
+                "type": "uint64",
+                "optional": true
               },
               {
                 "id": 4,
                 "name": "modificationTime",
-                "type": "uint64"
+                "type": "uint64",
+                "optional": true
               },
               {
                 "id": 5,
                 "name": "quotaInNamespace",
-                "type": "uint64"
+                "type": "uint64",
+                "optional": true
               }
             ]
           },
@@ -1581,7 +2257,8 @@
               {
                 "id": 1,
                 "name": "response",
-                "type": "bool"
+                "type": "bool",
+                "optional": true
               }
             ]
           },
@@ -1591,12 +2268,14 @@
               {
                 "id": 1,
                 "name": "volumeName",
-                "type": "string"
+                "type": "string",
+                "required": true
               },
               {
                 "id": 2,
                 "name": "userAcl",
-                "type": "OzoneAclInfo"
+                "type": "OzoneAclInfo",
+                "required": true
               }
             ]
           },
@@ -1609,7 +2288,8 @@
               {
                 "id": 1,
                 "name": "volumeName",
-                "type": "string"
+                "type": "string",
+                "required": true
               }
             ]
           },
@@ -1619,7 +2299,8 @@
               {
                 "id": 2,
                 "name": "volumeInfo",
-                "type": "VolumeInfo"
+                "type": "VolumeInfo",
+                "optional": true
               }
             ]
           },
@@ -1629,7 +2310,8 @@
               {
                 "id": 1,
                 "name": "volumeName",
-                "type": "string"
+                "type": "string",
+                "required": true
               }
             ]
           },
@@ -1642,27 +2324,32 @@
               {
                 "id": 1,
                 "name": "scope",
-                "type": "Scope"
+                "type": "Scope",
+                "required": true
               },
               {
                 "id": 2,
                 "name": "userName",
-                "type": "string"
+                "type": "string",
+                "optional": true
               },
               {
                 "id": 3,
                 "name": "prefix",
-                "type": "string"
+                "type": "string",
+                "optional": true
               },
               {
                 "id": 4,
                 "name": "prevKey",
-                "type": "string"
+                "type": "string",
+                "optional": true
               },
               {
                 "id": 5,
                 "name": "maxKeys",
-                "type": "uint32"
+                "type": "uint32",
+                "optional": true
               }
             ]
           },
@@ -1683,12 +2370,14 @@
               {
                 "id": 1,
                 "name": "volumeName",
-                "type": "string"
+                "type": "string",
+                "required": true
               },
               {
                 "id": 2,
                 "name": "bucketName",
-                "type": "string"
+                "type": "string",
+                "required": true
               },
               {
                 "id": 3,
@@ -1700,6 +2389,7 @@
                 "id": 4,
                 "name": "isVersionEnabled",
                 "type": "bool",
+                "required": true,
                 "options": [
                   {
                     "name": "default",
@@ -1711,6 +2401,7 @@
                 "id": 5,
                 "name": "storageType",
                 "type": "StorageTypeProto",
+                "required": true,
                 "options": [
                   {
                     "name": "default",
@@ -1721,7 +2412,8 @@
               {
                 "id": 6,
                 "name": "creationTime",
-                "type": "uint64"
+                "type": "uint64",
+                "optional": true
               },
               {
                 "id": 7,
@@ -1732,42 +2424,50 @@
               {
                 "id": 8,
                 "name": "beinfo",
-                "type": "BucketEncryptionInfoProto"
+                "type": "BucketEncryptionInfoProto",
+                "optional": true
               },
               {
                 "id": 9,
                 "name": "objectID",
-                "type": "uint64"
+                "type": "uint64",
+                "optional": true
               },
               {
                 "id": 10,
                 "name": "updateID",
-                "type": "uint64"
+                "type": "uint64",
+                "optional": true
               },
               {
                 "id": 11,
                 "name": "modificationTime",
-                "type": "uint64"
+                "type": "uint64",
+                "optional": true
               },
               {
                 "id": 12,
                 "name": "sourceVolume",
-                "type": "string"
+                "type": "string",
+                "optional": true
               },
               {
                 "id": 13,
                 "name": "sourceBucket",
-                "type": "string"
+                "type": "string",
+                "optional": true
               },
               {
                 "id": 14,
                 "name": "usedBytes",
-                "type": "uint64"
+                "type": "uint64",
+                "optional": true
               },
               {
                 "id": 15,
                 "name": "quotaInBytes",
                 "type": "int64",
+                "optional": true,
                 "options": [
                   {
                     "name": "default",
@@ -1779,6 +2479,7 @@
                 "id": 16,
                 "name": "quotaInNamespace",
                 "type": "int64",
+                "optional": true,
                 "options": [
                   {
                     "name": "default",
@@ -1789,12 +2490,26 @@
               {
                 "id": 17,
                 "name": "usedNamespace",
-                "type": "uint64"
+                "type": "uint64",
+                "optional": true
               },
               {
                 "id": 18,
                 "name": "bucketLayout",
-                "type": "BucketLayoutProto"
+                "type": "BucketLayoutProto",
+                "optional": true
+              },
+              {
+                "id": 19,
+                "name": "owner",
+                "type": "string",
+                "optional": true
+              },
+              {
+                "id": 20,
+                "name": "defaultReplicationConfig",
+                "type": "hadoop.hdds.DefaultReplicationConfig",
+                "optional": true
               }
             ]
           },
@@ -1804,17 +2519,20 @@
               {
                 "id": 1,
                 "name": "keyName",
-                "type": "string"
+                "type": "string",
+                "required": true
               },
               {
                 "id": 2,
                 "name": "suite",
-                "type": "CipherSuiteProto"
+                "type": "CipherSuiteProto",
+                "optional": true
               },
               {
                 "id": 3,
                 "name": "cryptoProtocolVersion",
-                "type": "CryptoProtocolVersionProto"
+                "type": "CryptoProtocolVersionProto",
+                "optional": true
               }
             ]
           },
@@ -1824,32 +2542,38 @@
               {
                 "id": 1,
                 "name": "suite",
-                "type": "CipherSuiteProto"
+                "type": "CipherSuiteProto",
+                "required": true
               },
               {
                 "id": 2,
                 "name": "cryptoProtocolVersion",
-                "type": "CryptoProtocolVersionProto"
+                "type": "CryptoProtocolVersionProto",
+                "required": true
               },
               {
                 "id": 3,
                 "name": "key",
-                "type": "bytes"
+                "type": "bytes",
+                "required": true
               },
               {
                 "id": 4,
                 "name": "iv",
-                "type": "bytes"
+                "type": "bytes",
+                "required": true
               },
               {
                 "id": 5,
                 "name": "keyName",
-                "type": "string"
+                "type": "string",
+                "required": true
               },
               {
                 "id": 6,
                 "name": "ezKeyVersionName",
-                "type": "string"
+                "type": "string",
+                "required": true
               }
             ]
           },
@@ -1859,17 +2583,20 @@
               {
                 "id": 1,
                 "name": "key",
-                "type": "bytes"
+                "type": "bytes",
+                "required": true
               },
               {
                 "id": 2,
                 "name": "iv",
-                "type": "bytes"
+                "type": "bytes",
+                "required": true
               },
               {
                 "id": 3,
                 "name": "ezKeyVersionName",
-                "type": "string"
+                "type": "string",
+                "required": true
               }
             ]
           },
@@ -1879,27 +2606,32 @@
               {
                 "id": 1,
                 "name": "keyId",
-                "type": "uint32"
+                "type": "uint32",
+                "required": true
               },
               {
                 "id": 3,
                 "name": "nonce",
-                "type": "bytes"
+                "type": "bytes",
+                "required": true
               },
               {
                 "id": 4,
                 "name": "encryptionKey",
-                "type": "bytes"
+                "type": "bytes",
+                "required": true
               },
               {
                 "id": 5,
                 "name": "expiryDate",
-                "type": "uint64"
+                "type": "uint64",
+                "required": true
               },
               {
                 "id": 6,
                 "name": "encryptionAlgorithm",
-                "type": "string"
+                "type": "string",
+                "optional": true
               }
             ]
           },
@@ -1909,22 +2641,26 @@
               {
                 "id": 1,
                 "name": "volumeName",
-                "type": "string"
+                "type": "string",
+                "required": true
               },
               {
                 "id": 2,
                 "name": "bucketName",
-                "type": "string"
+                "type": "string",
+                "required": true
               },
               {
                 "id": 5,
                 "name": "isVersionEnabled",
-                "type": "bool"
+                "type": "bool",
+                "optional": true
               },
               {
                 "id": 6,
                 "name": "storageType",
-                "type": "StorageTypeProto"
+                "type": "StorageTypeProto",
+                "optional": true
               },
               {
                 "id": 7,
@@ -1935,12 +2671,26 @@
               {
                 "id": 8,
                 "name": "quotaInBytes",
-                "type": "uint64"
+                "type": "uint64",
+                "optional": true
               },
               {
                 "id": 9,
                 "name": "quotaInNamespace",
-                "type": "uint64"
+                "type": "uint64",
+                "optional": true
+              },
+              {
+                "id": 10,
+                "name": "ownerName",
+                "type": "string",
+                "optional": true
+              },
+              {
+                "id": 11,
+                "name": "defaultReplicationConfig",
+                "type": "hadoop.hdds.DefaultReplicationConfig",
+                "optional": true
               }
             ]
           },
@@ -1950,7 +2700,8 @@
               {
                 "id": 1,
                 "name": "name",
-                "type": "string"
+                "type": "string",
+                "required": true
               },
               {
                 "id": 2,
@@ -1967,12 +2718,14 @@
               {
                 "id": 4,
                 "name": "objectID",
-                "type": "uint64"
+                "type": "uint64",
+                "optional": true
               },
               {
                 "id": 5,
                 "name": "updateID",
-                "type": "uint64"
+                "type": "uint64",
+                "optional": true
               }
             ]
           },
@@ -1982,12 +2735,14 @@
               {
                 "id": 1,
                 "name": "resType",
-                "type": "ObjectType"
+                "type": "ObjectType",
+                "required": true
               },
               {
                 "id": 2,
                 "name": "storeType",
                 "type": "StoreType",
+                "required": true,
                 "options": [
                   {
                     "name": "default",
@@ -1998,7 +2753,8 @@
               {
                 "id": 3,
                 "name": "path",
-                "type": "string"
+                "type": "string",
+                "required": true
               }
             ]
           },
@@ -2008,22 +2764,26 @@
               {
                 "id": 1,
                 "name": "type",
-                "type": "OzoneAclType"
+                "type": "OzoneAclType",
+                "required": true
               },
               {
                 "id": 2,
                 "name": "name",
-                "type": "string"
+                "type": "string",
+                "required": true
               },
               {
                 "id": 3,
                 "name": "rights",
-                "type": "bytes"
+                "type": "bytes",
+                "required": true
               },
               {
                 "id": 4,
                 "name": "aclScope",
                 "type": "OzoneAclScope",
+                "required": true,
                 "options": [
                   {
                     "name": "default",
@@ -2039,7 +2799,8 @@
               {
                 "id": 1,
                 "name": "obj",
-                "type": "OzoneObj"
+                "type": "OzoneObj",
+                "required": true
               }
             ]
           },
@@ -2060,17 +2821,20 @@
               {
                 "id": 1,
                 "name": "obj",
-                "type": "OzoneObj"
+                "type": "OzoneObj",
+                "required": true
               },
               {
                 "id": 2,
                 "name": "acl",
-                "type": "OzoneAclInfo"
+                "type": "OzoneAclInfo",
+                "required": true
               },
               {
                 "id": 3,
                 "name": "modificationTime",
-                "type": "uint64"
+                "type": "uint64",
+                "optional": true
               }
             ]
           },
@@ -2080,7 +2844,8 @@
               {
                 "id": 1,
                 "name": "response",
-                "type": "bool"
+                "type": "bool",
+                "required": true
               }
             ]
           },
@@ -2090,17 +2855,20 @@
               {
                 "id": 1,
                 "name": "obj",
-                "type": "OzoneObj"
+                "type": "OzoneObj",
+                "required": true
               },
               {
                 "id": 2,
                 "name": "acl",
-                "type": "OzoneAclInfo"
+                "type": "OzoneAclInfo",
+                "required": true
               },
               {
                 "id": 3,
                 "name": "modificationTime",
-                "type": "uint64"
+                "type": "uint64",
+                "optional": true
               }
             ]
           },
@@ -2110,7 +2878,8 @@
               {
                 "id": 1,
                 "name": "response",
-                "type": "bool"
+                "type": "bool",
+                "required": true
               }
             ]
           },
@@ -2120,7 +2889,8 @@
               {
                 "id": 1,
                 "name": "obj",
-                "type": "OzoneObj"
+                "type": "OzoneObj",
+                "required": true
               },
               {
                 "id": 2,
@@ -2131,7 +2901,8 @@
               {
                 "id": 3,
                 "name": "modificationTime",
-                "type": "uint64"
+                "type": "uint64",
+                "optional": true
               }
             ]
           },
@@ -2141,7 +2912,8 @@
               {
                 "id": 1,
                 "name": "response",
-                "type": "bool"
+                "type": "bool",
+                "required": true
               }
             ]
           },
@@ -2151,7 +2923,8 @@
               {
                 "id": 1,
                 "name": "bucketInfo",
-                "type": "BucketInfo"
+                "type": "BucketInfo",
+                "required": true
               }
             ]
           },
@@ -2164,12 +2937,14 @@
               {
                 "id": 1,
                 "name": "volumeName",
-                "type": "string"
+                "type": "string",
+                "required": true
               },
               {
                 "id": 2,
                 "name": "bucketName",
-                "type": "string"
+                "type": "string",
+                "required": true
               }
             ]
           },
@@ -2179,7 +2954,8 @@
               {
                 "id": 2,
                 "name": "bucketInfo",
-                "type": "BucketInfo"
+                "type": "BucketInfo",
+                "optional": true
               }
             ]
           },
@@ -2189,17 +2965,27 @@
               {
                 "id": 1,
                 "name": "bucketArgs",
-                "type": "BucketArgs"
+                "type": "BucketArgs",
+                "optional": true
               },
               {
                 "id": 2,
                 "name": "modificationTime",
-                "type": "uint64"
+                "type": "uint64",
+                "optional": true
               }
             ]
           },
           {
-            "name": "SetBucketPropertyResponse"
+            "name": "SetBucketPropertyResponse",
+            "fields": [
+              {
+                "id": 1,
+                "name": "response",
+                "type": "bool",
+                "optional": true
+              }
+            ]
           },
           {
             "name": "DeleteBucketRequest",
@@ -2207,12 +2993,14 @@
               {
                 "id": 1,
                 "name": "volumeName",
-                "type": "string"
+                "type": "string",
+                "required": true
               },
               {
                 "id": 2,
                 "name": "bucketName",
-                "type": "string"
+                "type": "string",
+                "required": true
               }
             ]
           },
@@ -2225,22 +3013,26 @@
               {
                 "id": 1,
                 "name": "volumeName",
-                "type": "string"
+                "type": "string",
+                "required": true
               },
               {
                 "id": 2,
                 "name": "startKey",
-                "type": "string"
+                "type": "string",
+                "optional": true
               },
               {
                 "id": 3,
                 "name": "prefix",
-                "type": "string"
+                "type": "string",
+                "optional": true
               },
               {
                 "id": 4,
                 "name": "count",
-                "type": "int32"
+                "type": "int32",
+                "optional": true
               }
             ]
           },
@@ -2261,32 +3053,50 @@
               {
                 "id": 1,
                 "name": "volumeName",
-                "type": "string"
+                "type": "string",
+                "required": true
               },
               {
                 "id": 2,
                 "name": "bucketName",
-                "type": "string"
+                "type": "string",
+                "required": true
               },
               {
                 "id": 3,
                 "name": "keyName",
-                "type": "string"
+                "type": "string",
+                "required": true
               },
               {
                 "id": 4,
                 "name": "dataSize",
-                "type": "uint64"
+                "type": "uint64",
+                "optional": true
               },
               {
                 "id": 5,
                 "name": "type",
-                "type": "hadoop.hdds.ReplicationType"
+                "type": "hadoop.hdds.ReplicationType",
+                "optional": true,
+                "options": [
+                  {
+                    "name": "default",
+                    "value": "NONE"
+                  }
+                ]
               },
               {
                 "id": 6,
                 "name": "factor",
-                "type": "hadoop.hdds.ReplicationFactor"
+                "type": "hadoop.hdds.ReplicationFactor",
+                "optional": true,
+                "options": [
+                  {
+                    "name": "default",
+                    "value": "ZERO"
+                  }
+                ]
               },
               {
                 "id": 7,
@@ -2297,17 +3107,20 @@
               {
                 "id": 8,
                 "name": "isMultipartKey",
-                "type": "bool"
+                "type": "bool",
+                "optional": true
               },
               {
                 "id": 9,
                 "name": "multipartUploadID",
-                "type": "string"
+                "type": "string",
+                "optional": true
               },
               {
                 "id": 10,
                 "name": "multipartNumber",
-                "type": "uint32"
+                "type": "uint32",
+                "optional": true
               },
               {
                 "id": 11,
@@ -2324,32 +3137,50 @@
               {
                 "id": 13,
                 "name": "modificationTime",
-                "type": "uint64"
+                "type": "uint64",
+                "optional": true
               },
               {
                 "id": 14,
                 "name": "sortDatanodes",
-                "type": "bool"
+                "type": "bool",
+                "optional": true
               },
               {
                 "id": 15,
                 "name": "fileEncryptionInfo",
-                "type": "FileEncryptionInfoProto"
+                "type": "FileEncryptionInfoProto",
+                "optional": true
               },
               {
                 "id": 16,
                 "name": "latestVersionLocation",
-                "type": "bool"
+                "type": "bool",
+                "optional": true
               },
               {
                 "id": 17,
                 "name": "recursive",
-                "type": "bool"
+                "type": "bool",
+                "optional": true
               },
               {
                 "id": 18,
                 "name": "headOp",
-                "type": "bool"
+                "type": "bool",
+                "optional": true
+              },
+              {
+                "id": 19,
+                "name": "ecReplicationConfig",
+                "type": "hadoop.hdds.ECReplicationConfig",
+                "optional": true
+              },
+              {
+                "id": 20,
+                "name": "forceUpdateContainerCacheFromSCM",
+                "type": "bool",
+                "optional": true
               }
             ]
           },
@@ -2359,37 +3190,44 @@
               {
                 "id": 1,
                 "name": "blockID",
-                "type": "hadoop.hdds.BlockID"
+                "type": "hadoop.hdds.BlockID",
+                "required": true
               },
               {
                 "id": 3,
                 "name": "offset",
-                "type": "uint64"
+                "type": "uint64",
+                "required": true
               },
               {
                 "id": 4,
                 "name": "length",
-                "type": "uint64"
+                "type": "uint64",
+                "required": true
               },
               {
                 "id": 5,
                 "name": "createVersion",
-                "type": "uint64"
+                "type": "uint64",
+                "optional": true
               },
               {
                 "id": 6,
                 "name": "token",
-                "type": "hadoop.common.TokenProto"
+                "type": "hadoop.common.TokenProto",
+                "optional": true
               },
               {
                 "id": 7,
                 "name": "pipeline",
-                "type": "hadoop.hdds.Pipeline"
+                "type": "hadoop.hdds.Pipeline",
+                "optional": true
               },
               {
                 "id": 9,
                 "name": "partNumber",
                 "type": "int32",
+                "optional": true,
                 "options": [
                   {
                     "name": "default",
@@ -2405,7 +3243,8 @@
               {
                 "id": 1,
                 "name": "version",
-                "type": "uint64"
+                "type": "uint64",
+                "optional": true
               },
               {
                 "id": 2,
@@ -2416,12 +3255,14 @@
               {
                 "id": 3,
                 "name": "fileEncryptionInfo",
-                "type": "FileEncryptionInfoProto"
+                "type": "FileEncryptionInfoProto",
+                "optional": true
               },
               {
                 "id": 4,
                 "name": "isMultipartKey",
                 "type": "bool",
+                "optional": true,
                 "options": [
                   {
                     "name": "default",
@@ -2432,37 +3273,124 @@
             ]
           },
           {
+            "name": "CompositeCrcFileChecksumProto",
+            "fields": [
+              {
+                "id": 1,
+                "name": "checksumType",
+                "type": "ChecksumTypeProto",
+                "required": true
+              },
+              {
+                "id": 2,
+                "name": "bytesPerCrc",
+                "type": "uint32",
+                "required": true
+              },
+              {
+                "id": 3,
+                "name": "crc",
+                "type": "uint32",
+                "required": true
+              }
+            ]
+          },
+          {
+            "name": "MD5MD5Crc32FileChecksumProto",
+            "fields": [
+              {
+                "id": 1,
+                "name": "checksumType",
+                "type": "ChecksumTypeProto",
+                "required": true
+              },
+              {
+                "id": 2,
+                "name": "bytesPerCRC",
+                "type": "uint32",
+                "required": true
+              },
+              {
+                "id": 3,
+                "name": "crcPerBlock",
+                "type": "uint64",
+                "required": true
+              },
+              {
+                "id": 4,
+                "name": "md5",
+                "type": "bytes",
+                "required": true
+              }
+            ]
+          },
+          {
+            "name": "FileChecksumProto",
+            "fields": [
+              {
+                "id": 1,
+                "name": "checksumType",
+                "type": "FileChecksumTypeProto",
+                "required": true,
+                "options": [
+                  {
+                    "name": "default",
+                    "value": "COMPOSITE_CRC"
+                  }
+                ]
+              },
+              {
+                "id": 2,
+                "name": "compositeCrc",
+                "type": "CompositeCrcFileChecksumProto",
+                "optional": true
+              },
+              {
+                "id": 3,
+                "name": "md5Crc",
+                "type": "MD5MD5Crc32FileChecksumProto",
+                "optional": true
+              }
+            ]
+          },
+          {
             "name": "KeyInfo",
             "fields": [
               {
                 "id": 1,
                 "name": "volumeName",
-                "type": "string"
+                "type": "string",
+                "required": true
               },
               {
                 "id": 2,
                 "name": "bucketName",
-                "type": "string"
+                "type": "string",
+                "required": true
               },
               {
                 "id": 3,
                 "name": "keyName",
-                "type": "string"
+                "type": "string",
+                "required": true
               },
               {
                 "id": 4,
                 "name": "dataSize",
-                "type": "uint64"
+                "type": "uint64",
+                "required": true
               },
               {
                 "id": 5,
                 "name": "type",
-                "type": "hadoop.hdds.ReplicationType"
+                "type": "hadoop.hdds.ReplicationType",
+                "required": true
               },
               {
                 "id": 6,
                 "name": "factor",
-                "type": "hadoop.hdds.ReplicationFactor"
+                "type": "hadoop.hdds.ReplicationFactor",
+                "optional": true
               },
               {
                 "id": 7,
@@ -2473,17 +3401,20 @@
               {
                 "id": 8,
                 "name": "creationTime",
-                "type": "uint64"
+                "type": "uint64",
+                "required": true
               },
               {
                 "id": 9,
                 "name": "modificationTime",
-                "type": "uint64"
+                "type": "uint64",
+                "required": true
               },
               {
                 "id": 10,
                 "name": "latestVersion",
-                "type": "uint64"
+                "type": "uint64",
+                "optional": true
               },
               {
                 "id": 11,
@@ -2494,7 +3425,8 @@
               {
                 "id": 12,
                 "name": "fileEncryptionInfo",
-                "type": "FileEncryptionInfoProto"
+                "type": "FileEncryptionInfoProto",
+                "optional": true
               },
               {
                 "id": 13,
@@ -2505,17 +3437,32 @@
               {
                 "id": 14,
                 "name": "objectID",
-                "type": "uint64"
+                "type": "uint64",
+                "optional": true
               },
               {
                 "id": 15,
                 "name": "updateID",
-                "type": "uint64"
+                "type": "uint64",
+                "optional": true
               },
               {
                 "id": 16,
                 "name": "parentID",
-                "type": "uint64"
+                "type": "uint64",
+                "optional": true
+              },
+              {
+                "id": 17,
+                "name": "ecReplicationConfig",
+                "type": "hadoop.hdds.ECReplicationConfig",
+                "optional": true
+              },
+              {
+                "id": 18,
+                "name": "fileChecksum",
+                "type": "FileChecksumProto",
+                "optional": true
               }
             ]
           },
@@ -2525,17 +3472,20 @@
               {
                 "id": 1,
                 "name": "name",
-                "type": "string"
+                "type": "string",
+                "required": true
               },
               {
                 "id": 2,
                 "name": "creationTime",
-                "type": "uint64"
+                "type": "uint64",
+                "required": true
               },
               {
                 "id": 3,
                 "name": "modificationTime",
-                "type": "uint64"
+                "type": "uint64",
+                "required": true
               },
               {
                 "id": 4,
@@ -2552,17 +3502,20 @@
               {
                 "id": 6,
                 "name": "objectID",
-                "type": "uint64"
+                "type": "uint64",
+                "required": true
               },
               {
                 "id": 7,
                 "name": "updateID",
-                "type": "uint64"
+                "type": "uint64",
+                "required": true
               },
               {
                 "id": 8,
                 "name": "parentID",
-                "type": "uint64"
+                "type": "uint64",
+                "required": true
               }
             ]
           },
@@ -2583,17 +3536,20 @@
               {
                 "id": 2,
                 "name": "keyInfo",
-                "type": "KeyInfo"
+                "type": "KeyInfo",
+                "optional": true
               },
               {
                 "id": 3,
                 "name": "blockSize",
-                "type": "uint64"
+                "type": "uint64",
+                "optional": true
               },
               {
                 "id": 4,
                 "name": "isDirectory",
-                "type": "bool"
+                "type": "bool",
+                "optional": true
               }
             ]
           },
@@ -2603,7 +3559,8 @@
               {
                 "id": 1,
                 "name": "keyArgs",
-                "type": "KeyArgs"
+                "type": "KeyArgs",
+                "required": true
               }
             ]
           },
@@ -2613,7 +3570,8 @@
               {
                 "id": 1,
                 "name": "status",
-                "type": "OzoneFileStatusProto"
+                "type": "OzoneFileStatusProto",
+                "required": true
               }
             ]
           },
@@ -2623,7 +3581,8 @@
               {
                 "id": 1,
                 "name": "keyArgs",
-                "type": "KeyArgs"
+                "type": "KeyArgs",
+                "required": true
               }
             ]
           },
@@ -2636,22 +3595,26 @@
               {
                 "id": 1,
                 "name": "keyArgs",
-                "type": "KeyArgs"
+                "type": "KeyArgs",
+                "required": true
               },
               {
                 "id": 2,
                 "name": "isRecursive",
-                "type": "bool"
+                "type": "bool",
+                "required": true
               },
               {
                 "id": 3,
                 "name": "isOverwrite",
-                "type": "bool"
+                "type": "bool",
+                "required": true
               },
               {
                 "id": 4,
                 "name": "clientID",
-                "type": "uint64"
+                "type": "uint64",
+                "optional": true
               }
             ]
           },
@@ -2661,17 +3624,20 @@
               {
                 "id": 1,
                 "name": "keyInfo",
-                "type": "KeyInfo"
+                "type": "KeyInfo",
+                "optional": true
               },
               {
                 "id": 2,
                 "name": "ID",
-                "type": "uint64"
+                "type": "uint64",
+                "optional": true
               },
               {
                 "id": 3,
                 "name": "openVersion",
-                "type": "uint64"
+                "type": "uint64",
+                "optional": true
               }
             ]
           },
@@ -2681,7 +3647,8 @@
               {
                 "id": 1,
                 "name": "keyArgs",
-                "type": "KeyArgs"
+                "type": "KeyArgs",
+                "required": true
               }
             ]
           },
@@ -2691,7 +3658,8 @@
               {
                 "id": 1,
                 "name": "keyInfo",
-                "type": "KeyInfo"
+                "type": "KeyInfo",
+                "optional": true
               }
             ]
           },
@@ -2701,22 +3669,32 @@
               {
                 "id": 1,
                 "name": "keyArgs",
-                "type": "KeyArgs"
+                "type": "KeyArgs",
+                "required": true
               },
               {
                 "id": 2,
                 "name": "recursive",
-                "type": "bool"
+                "type": "bool",
+                "required": true
               },
               {
                 "id": 3,
                 "name": "startKey",
-                "type": "string"
+                "type": "string",
+                "required": true
               },
               {
                 "id": 4,
                 "name": "numEntries",
-                "type": "uint64"
+                "type": "uint64",
+                "required": true
+              },
+              {
+                "id": 5,
+                "name": "allowPartialPrefix",
+                "type": "bool",
+                "optional": true
               }
             ]
           },
@@ -2737,12 +3715,14 @@
               {
                 "id": 1,
                 "name": "keyArgs",
-                "type": "KeyArgs"
+                "type": "KeyArgs",
+                "required": true
               },
               {
                 "id": 2,
                 "name": "clientID",
-                "type": "uint64"
+                "type": "uint64",
+                "optional": true
               }
             ]
           },
@@ -2752,17 +3732,20 @@
               {
                 "id": 2,
                 "name": "keyInfo",
-                "type": "KeyInfo"
+                "type": "KeyInfo",
+                "optional": true
               },
               {
                 "id": 3,
                 "name": "ID",
-                "type": "uint64"
+                "type": "uint64",
+                "optional": true
               },
               {
                 "id": 4,
                 "name": "openVersion",
-                "type": "uint64"
+                "type": "uint64",
+                "optional": true
               }
             ]
           },
@@ -2772,7 +3755,8 @@
               {
                 "id": 1,
                 "name": "keyArgs",
-                "type": "KeyArgs"
+                "type": "KeyArgs",
+                "required": true
               }
             ]
           },
@@ -2782,17 +3766,60 @@
               {
                 "id": 2,
                 "name": "keyInfo",
-                "type": "KeyInfo"
+                "type": "KeyInfo",
+                "optional": true
               },
               {
                 "id": 3,
                 "name": "ID",
-                "type": "uint64"
+                "type": "uint64",
+                "optional": true
               },
               {
                 "id": 4,
                 "name": "openVersion",
-                "type": "uint64"
+                "type": "uint64",
+                "optional": true
+              }
+            ]
+          },
+          {
+            "name": "GetKeyInfoRequest",
+            "fields": [
+              {
+                "id": 1,
+                "name": "keyArgs",
+                "type": "KeyArgs",
+                "required": true
+              },
+              {
+                "id": 2,
+                "name": "assumeS3Context",
+                "type": "bool",
+                "optional": true
+              }
+            ]
+          },
+          {
+            "name": "GetKeyInfoResponse",
+            "fields": [
+              {
+                "id": 1,
+                "name": "keyInfo",
+                "type": "KeyInfo",
+                "optional": true
+              },
+              {
+                "id": 2,
+                "name": "volumeInfo",
+                "type": "VolumeInfo",
+                "optional": true
+              },
+              {
+                "id": 3,
+                "name": "UserPrincipal",
+                "type": "string",
+                "optional": true
               }
             ]
           },
@@ -2802,7 +3829,8 @@
               {
                 "id": 1,
                 "name": "renameKeysArgs",
-                "type": "RenameKeysArgs"
+                "type": "RenameKeysArgs",
+                "required": true
               }
             ]
           },
@@ -2812,12 +3840,14 @@
               {
                 "id": 1,
                 "name": "volumeName",
-                "type": "string"
+                "type": "string",
+                "required": true
               },
               {
                 "id": 2,
                 "name": "bucketName",
-                "type": "string"
+                "type": "string",
+                "required": true
               },
               {
                 "id": 3,
@@ -2833,12 +3863,14 @@
               {
                 "id": 1,
                 "name": "fromKeyName",
-                "type": "string"
+                "type": "string",
+                "required": true
               },
               {
                 "id": 2,
                 "name": "toKeyName",
-                "type": "string"
+                "type": "string",
+                "required": true
               }
             ]
           },
@@ -2854,7 +3886,8 @@
               {
                 "id": 2,
                 "name": "status",
-                "type": "bool"
+                "type": "bool",
+                "optional": true
               }
             ]
           },
@@ -2864,12 +3897,14 @@
               {
                 "id": 1,
                 "name": "keyArgs",
-                "type": "KeyArgs"
+                "type": "KeyArgs",
+                "required": true
               },
               {
                 "id": 2,
                 "name": "toKeyName",
-                "type": "string"
+                "type": "string",
+                "required": true
               }
             ]
           },
@@ -2882,7 +3917,8 @@
               {
                 "id": 1,
                 "name": "keyArgs",
-                "type": "KeyArgs"
+                "type": "KeyArgs",
+                "required": true
               }
             ]
           },
@@ -2892,7 +3928,8 @@
               {
                 "id": 1,
                 "name": "deleteKeys",
-                "type": "DeleteKeyArgs"
+                "type": "DeleteKeyArgs",
+                "optional": true
               }
             ]
           },
@@ -2902,12 +3939,14 @@
               {
                 "id": 1,
                 "name": "volumeName",
-                "type": "string"
+                "type": "string",
+                "required": true
               },
               {
                 "id": 2,
                 "name": "bucketName",
-                "type": "string"
+                "type": "string",
+                "required": true
               },
               {
                 "id": 3,
@@ -2923,12 +3962,14 @@
               {
                 "id": 1,
                 "name": "unDeletedKeys",
-                "type": "DeleteKeyArgs"
+                "type": "DeleteKeyArgs",
+                "optional": true
               },
               {
                 "id": 2,
                 "name": "status",
-                "type": "bool"
+                "type": "bool",
+                "optional": true
               }
             ]
           },
@@ -2938,17 +3979,20 @@
               {
                 "id": 2,
                 "name": "keyInfo",
-                "type": "KeyInfo"
+                "type": "KeyInfo",
+                "optional": true
               },
               {
                 "id": 3,
                 "name": "ID",
-                "type": "uint64"
+                "type": "uint64",
+                "optional": true
               },
               {
                 "id": 4,
                 "name": "openVersion",
-                "type": "uint64"
+                "type": "uint64",
+                "optional": true
               }
             ]
           },
@@ -2958,12 +4002,14 @@
               {
                 "id": 1,
                 "name": "volumeName",
-                "type": "string"
+                "type": "string",
+                "required": true
               },
               {
                 "id": 2,
                 "name": "bucketName",
-                "type": "string"
+                "type": "string",
+                "required": true
               },
               {
                 "id": 3,
@@ -3014,6 +4060,55 @@
             "name": "PurgePathsResponse"
           },
           {
+            "name": "PurgeDirectoriesRequest",
+            "fields": [
+              {
+                "id": 1,
+                "name": "deletedPath",
+                "type": "PurgePathRequest",
+                "is_repeated": true
+              }
+            ]
+          },
+          {
+            "name": "PurgeDirectoriesResponse"
+          },
+          {
+            "name": "PurgePathRequest",
+            "fields": [
+              {
+                "id": 1,
+                "name": "volumeId",
+                "type": "uint64",
+                "required": true
+              },
+              {
+                "id": 2,
+                "name": "bucketId",
+                "type": "uint64",
+                "required": true
+              },
+              {
+                "id": 3,
+                "name": "deletedDir",
+                "type": "string",
+                "optional": true
+              },
+              {
+                "id": 4,
+                "name": "deletedSubFiles",
+                "type": "KeyInfo",
+                "is_repeated": true
+              },
+              {
+                "id": 5,
+                "name": "markDeletedSubDirs",
+                "type": "KeyInfo",
+                "is_repeated": true
+              }
+            ]
+          },
+          {
             "name": "DeleteOpenKeysRequest",
             "fields": [
               {
@@ -3021,6 +4116,12 @@
                 "name": "openKeysPerBucket",
                 "type": "OpenKeyBucket",
                 "is_repeated": true
+              },
+              {
+                "id": 2,
+                "name": "bucketLayout",
+                "type": "BucketLayoutProto",
+                "optional": true
               }
             ]
           },
@@ -3030,12 +4131,14 @@
               {
                 "id": 1,
                 "name": "volumeName",
-                "type": "string"
+                "type": "string",
+                "required": true
               },
               {
                 "id": 2,
                 "name": "bucketName",
-                "type": "string"
+                "type": "string",
+                "required": true
               },
               {
                 "id": 3,
@@ -3051,12 +4154,20 @@
               {
                 "id": 1,
                 "name": "name",
-                "type": "string"
+                "type": "string",
+                "required": true
               },
               {
                 "id": 2,
                 "name": "clientID",
-                "type": "uint64"
+                "type": "uint64",
+                "optional": true,
+                "options": [
+                  {
+                    "name": "deprecated",
+                    "value": "true"
+                  }
+                ]
               }
             ]
           },
@@ -3066,77 +4177,92 @@
               {
                 "id": 1,
                 "name": "type",
-                "type": "Type"
+                "type": "Type",
+                "required": true
               },
               {
                 "id": 2,
                 "name": "version",
-                "type": "uint32"
+                "type": "uint32",
+                "optional": true
               },
               {
                 "id": 3,
                 "name": "owner",
-                "type": "string"
+                "type": "string",
+                "optional": true
               },
               {
                 "id": 4,
                 "name": "renewer",
-                "type": "string"
+                "type": "string",
+                "optional": true
               },
               {
                 "id": 5,
                 "name": "realUser",
-                "type": "string"
+                "type": "string",
+                "optional": true
               },
               {
                 "id": 6,
                 "name": "issueDate",
-                "type": "uint64"
+                "type": "uint64",
+                "optional": true
               },
               {
                 "id": 7,
                 "name": "maxDate",
-                "type": "uint64"
+                "type": "uint64",
+                "optional": true
               },
               {
                 "id": 8,
                 "name": "sequenceNumber",
-                "type": "uint32"
+                "type": "uint32",
+                "optional": true
               },
               {
                 "id": 9,
                 "name": "masterKeyId",
-                "type": "uint32"
+                "type": "uint32",
+                "optional": true
               },
               {
                 "id": 10,
                 "name": "expiryDate",
-                "type": "uint64"
+                "type": "uint64",
+                "optional": true
               },
               {
                 "id": 11,
                 "name": "omCertSerialId",
-                "type": "string"
+                "type": "string",
+                "optional": true
               },
               {
                 "id": 12,
                 "name": "accessKeyId",
-                "type": "string"
+                "type": "string",
+                "optional": true
               },
               {
                 "id": 13,
                 "name": "signature",
-                "type": "string"
+                "type": "string",
+                "optional": true
               },
               {
                 "id": 14,
                 "name": "strToSign",
-                "type": "string"
+                "type": "string",
+                "optional": true
               },
               {
                 "id": 15,
                 "name": "omServiceId",
-                "type": "string"
+                "type": "string",
+                "optional": true
               }
             ]
           },
@@ -3146,22 +4272,26 @@
               {
                 "id": 1,
                 "name": "keyId",
-                "type": "uint32"
+                "type": "uint32",
+                "required": true
               },
               {
                 "id": 2,
                 "name": "expiryDate",
-                "type": "uint64"
+                "type": "uint64",
+                "required": true
               },
               {
                 "id": 3,
                 "name": "privateKeyBytes",
-                "type": "bytes"
+                "type": "bytes",
+                "required": true
               },
               {
                 "id": 4,
                 "name": "publicKeyBytes",
-                "type": "bytes"
+                "type": "bytes",
+                "required": true
               }
             ]
           },
@@ -3171,27 +4301,32 @@
               {
                 "id": 1,
                 "name": "volumeName",
-                "type": "string"
+                "type": "string",
+                "required": true
               },
               {
                 "id": 2,
                 "name": "bucketName",
-                "type": "string"
+                "type": "string",
+                "required": true
               },
               {
                 "id": 3,
                 "name": "startKey",
-                "type": "string"
+                "type": "string",
+                "optional": true
               },
               {
                 "id": 4,
                 "name": "prefix",
-                "type": "string"
+                "type": "string",
+                "optional": true
               },
               {
                 "id": 5,
                 "name": "count",
-                "type": "int32"
+                "type": "int32",
+                "optional": true
               }
             ]
           },
@@ -3212,12 +4347,14 @@
               {
                 "id": 1,
                 "name": "keyArgs",
-                "type": "KeyArgs"
+                "type": "KeyArgs",
+                "required": true
               },
               {
                 "id": 2,
                 "name": "clientID",
-                "type": "uint64"
+                "type": "uint64",
+                "required": true
               }
             ]
           },
@@ -3230,22 +4367,26 @@
               {
                 "id": 1,
                 "name": "keyArgs",
-                "type": "KeyArgs"
+                "type": "KeyArgs",
+                "required": true
               },
               {
                 "id": 2,
                 "name": "clientID",
-                "type": "uint64"
+                "type": "uint64",
+                "required": true
               },
               {
                 "id": 3,
                 "name": "excludeList",
-                "type": "hadoop.hdds.ExcludeListProto"
+                "type": "hadoop.hdds.ExcludeListProto",
+                "optional": true
               },
               {
                 "id": 4,
                 "name": "keyLocation",
-                "type": "KeyLocation"
+                "type": "KeyLocation",
+                "optional": true
               }
             ]
           },
@@ -3255,7 +4396,8 @@
               {
                 "id": 2,
                 "name": "keyLocation",
-                "type": "KeyLocation"
+                "type": "KeyLocation",
+                "optional": true
               }
             ]
           },
@@ -3268,7 +4410,14 @@
               {
                 "id": 1,
                 "name": "sequenceNumber",
-                "type": "uint64"
+                "type": "uint64",
+                "required": true
+              },
+              {
+                "id": 2,
+                "name": "limitCount",
+                "type": "uint64",
+                "optional": true
               }
             ]
           },
@@ -3284,7 +4433,8 @@
               {
                 "id": 3,
                 "name": "caCertificate",
-                "type": "string"
+                "type": "string",
+                "optional": true
               },
               {
                 "id": 4,
@@ -3300,13 +4450,42 @@
               {
                 "id": 1,
                 "name": "sequenceNumber",
-                "type": "uint64"
+                "type": "uint64",
+                "required": true
               },
               {
                 "id": 2,
                 "name": "data",
                 "type": "bytes",
                 "is_repeated": true
+              },
+              {
+                "id": 3,
+                "name": "latestSequenceNumber",
+                "type": "uint64",
+                "optional": true
+              }
+            ]
+          },
+          {
+            "name": "RangerBGSyncRequest",
+            "fields": [
+              {
+                "id": 1,
+                "name": "noWait",
+                "type": "bool",
+                "optional": true
+              }
+            ]
+          },
+          {
+            "name": "RangerBGSyncResponse",
+            "fields": [
+              {
+                "id": 1,
+                "name": "runSuccess",
+                "type": "bool",
+                "optional": true
               }
             ]
           },
@@ -3316,7 +4495,8 @@
               {
                 "id": 1,
                 "name": "upgradeClientId",
-                "type": "string"
+                "type": "string",
+                "required": true
               }
             ]
           },
@@ -3326,7 +4506,8 @@
               {
                 "id": 1,
                 "name": "status",
-                "type": "hadoop.hdds.UpgradeFinalizationStatus"
+                "type": "hadoop.hdds.UpgradeFinalizationStatus",
+                "required": true
               }
             ]
           },
@@ -3336,17 +4517,20 @@
               {
                 "id": 1,
                 "name": "upgradeClientId",
-                "type": "string"
+                "type": "string",
+                "required": true
               },
               {
                 "id": 2,
                 "name": "takeover",
-                "type": "bool"
+                "type": "bool",
+                "optional": true
               },
               {
                 "id": 3,
                 "name": "readonly",
-                "type": "bool"
+                "type": "bool",
+                "optional": true
               }
             ]
           },
@@ -3356,7 +4540,8 @@
               {
                 "id": 1,
                 "name": "status",
-                "type": "hadoop.hdds.UpgradeFinalizationStatus"
+                "type": "hadoop.hdds.UpgradeFinalizationStatus",
+                "required": true
               }
             ]
           },
@@ -3366,7 +4551,8 @@
               {
                 "id": 1,
                 "name": "args",
-                "type": "PrepareRequestArgs"
+                "type": "PrepareRequestArgs",
+                "required": true
               }
             ]
           },
@@ -3377,6 +4563,7 @@
                 "id": 1,
                 "name": "txnApplyWaitTimeoutSeconds",
                 "type": "uint64",
+                "optional": true,
                 "options": [
                   {
                     "name": "default",
@@ -3388,6 +4575,7 @@
                 "id": 2,
                 "name": "txnApplyCheckIntervalSeconds",
                 "type": "uint64",
+                "optional": true,
                 "options": [
                   {
                     "name": "default",
@@ -3403,7 +4591,8 @@
               {
                 "id": 1,
                 "name": "txnID",
-                "type": "uint64"
+                "type": "uint64",
+                "required": true
               }
             ]
           },
@@ -3413,7 +4602,8 @@
               {
                 "id": 1,
                 "name": "txnID",
-                "type": "uint64"
+                "type": "uint64",
+                "required": true
               }
             ]
           },
@@ -3423,12 +4613,14 @@
               {
                 "id": 1,
                 "name": "status",
-                "type": "PrepareStatus"
+                "type": "PrepareStatus",
+                "required": true
               },
               {
                 "id": 2,
                 "name": "currentTxnIndex",
-                "type": "uint64"
+                "type": "uint64",
+                "optional": true
               }
             ]
           },
@@ -3444,12 +4636,14 @@
               {
                 "id": 1,
                 "name": "type",
-                "type": "Type"
+                "type": "Type",
+                "required": true
               },
               {
                 "id": 2,
                 "name": "value",
-                "type": "uint32"
+                "type": "uint32",
+                "required": true
               }
             ]
           },
@@ -3459,12 +4653,14 @@
               {
                 "id": 1,
                 "name": "nodeId",
-                "type": "string"
+                "type": "string",
+                "required": true
               },
               {
                 "id": 2,
                 "name": "serverRole",
-                "type": "string"
+                "type": "string",
+                "required": true
               }
             ]
           },
@@ -3474,12 +4670,14 @@
               {
                 "id": 1,
                 "name": "nodeType",
-                "type": "hadoop.hdds.NodeType"
+                "type": "hadoop.hdds.NodeType",
+                "required": true
               },
               {
                 "id": 2,
                 "name": "hostname",
-                "type": "string"
+                "type": "string",
+                "required": true
               },
               {
                 "id": 3,
@@ -3490,7 +4688,20 @@
               {
                 "id": 4,
                 "name": "omRole",
-                "type": "OMRoleInfo"
+                "type": "OMRoleInfo",
+                "optional": true
+              },
+              {
+                "id": 5,
+                "name": "OMVersion",
+                "type": "int32",
+                "optional": true,
+                "options": [
+                  {
+                    "name": "default",
+                    "value": "0"
+                  }
+                ]
               }
             ]
           },
@@ -3500,7 +4711,8 @@
               {
                 "id": 1,
                 "name": "keyArgs",
-                "type": "KeyArgs"
+                "type": "KeyArgs",
+                "required": true
               }
             ]
           },
@@ -3510,22 +4722,26 @@
               {
                 "id": 1,
                 "name": "volumeName",
-                "type": "string"
+                "type": "string",
+                "required": true
               },
               {
                 "id": 2,
                 "name": "bucketName",
-                "type": "string"
+                "type": "string",
+                "required": true
               },
               {
                 "id": 3,
                 "name": "keyName",
-                "type": "string"
+                "type": "string",
+                "required": true
               },
               {
                 "id": 4,
                 "name": "multipartUploadID",
-                "type": "string"
+                "type": "string",
+                "required": true
               }
             ]
           },
@@ -3535,22 +4751,26 @@
               {
                 "id": 1,
                 "name": "uploadID",
-                "type": "string"
+                "type": "string",
+                "required": true
               },
               {
                 "id": 2,
                 "name": "creationTime",
-                "type": "uint64"
+                "type": "uint64",
+                "required": true
               },
               {
                 "id": 3,
                 "name": "type",
-                "type": "hadoop.hdds.ReplicationType"
+                "type": "hadoop.hdds.ReplicationType",
+                "required": true
               },
               {
                 "id": 4,
                 "name": "factor",
-                "type": "hadoop.hdds.ReplicationFactor"
+                "type": "hadoop.hdds.ReplicationFactor",
+                "optional": true
               },
               {
                 "id": 5,
@@ -3561,17 +4781,26 @@
               {
                 "id": 6,
                 "name": "objectID",
-                "type": "uint64"
+                "type": "uint64",
+                "optional": true
               },
               {
                 "id": 7,
                 "name": "updateID",
-                "type": "uint64"
+                "type": "uint64",
+                "optional": true
               },
               {
                 "id": 8,
                 "name": "parentID",
-                "type": "uint64"
+                "type": "uint64",
+                "optional": true
+              },
+              {
+                "id": 9,
+                "name": "ecReplicationConfig",
+                "type": "hadoop.hdds.ECReplicationConfig",
+                "optional": true
               }
             ]
           },
@@ -3581,17 +4810,20 @@
               {
                 "id": 1,
                 "name": "partName",
-                "type": "string"
+                "type": "string",
+                "required": true
               },
               {
                 "id": 2,
                 "name": "partNumber",
-                "type": "uint32"
+                "type": "uint32",
+                "required": true
               },
               {
                 "id": 3,
                 "name": "partKeyInfo",
-                "type": "KeyInfo"
+                "type": "KeyInfo",
+                "required": true
               }
             ]
           },
@@ -3601,12 +4833,14 @@
               {
                 "id": 1,
                 "name": "keyArgs",
-                "type": "KeyArgs"
+                "type": "KeyArgs",
+                "required": true
               },
               {
                 "id": 2,
                 "name": "clientID",
-                "type": "uint64"
+                "type": "uint64",
+                "required": true
               }
             ]
           },
@@ -3616,7 +4850,8 @@
               {
                 "id": 1,
                 "name": "partName",
-                "type": "string"
+                "type": "string",
+                "optional": true
               }
             ]
           },
@@ -3626,7 +4861,8 @@
               {
                 "id": 1,
                 "name": "keyArgs",
-                "type": "KeyArgs"
+                "type": "KeyArgs",
+                "required": true
               },
               {
                 "id": 2,
@@ -3642,22 +4878,26 @@
               {
                 "id": 1,
                 "name": "volume",
-                "type": "string"
+                "type": "string",
+                "optional": true
               },
               {
                 "id": 2,
                 "name": "bucket",
-                "type": "string"
+                "type": "string",
+                "optional": true
               },
               {
                 "id": 3,
                 "name": "key",
-                "type": "string"
+                "type": "string",
+                "optional": true
               },
               {
                 "id": 4,
                 "name": "hash",
-                "type": "string"
+                "type": "string",
+                "optional": true
               }
             ]
           },
@@ -3667,12 +4907,14 @@
               {
                 "id": 1,
                 "name": "partNumber",
-                "type": "uint32"
+                "type": "uint32",
+                "required": true
               },
               {
                 "id": 2,
                 "name": "partName",
-                "type": "string"
+                "type": "string",
+                "required": true
               }
             ]
           },
@@ -3682,7 +4924,8 @@
               {
                 "id": 1,
                 "name": "keyArgs",
-                "type": "KeyArgs"
+                "type": "KeyArgs",
+                "required": true
               }
             ]
           },
@@ -3695,32 +4938,38 @@
               {
                 "id": 1,
                 "name": "volume",
-                "type": "string"
+                "type": "string",
+                "required": true
               },
               {
                 "id": 2,
                 "name": "bucket",
-                "type": "string"
+                "type": "string",
+                "required": true
               },
               {
                 "id": 3,
                 "name": "key",
-                "type": "string"
+                "type": "string",
+                "required": true
               },
               {
                 "id": 4,
                 "name": "uploadID",
-                "type": "string"
+                "type": "string",
+                "required": true
               },
               {
                 "id": 5,
                 "name": "partNumbermarker",
-                "type": "uint32"
+                "type": "uint32",
+                "optional": true
               },
               {
                 "id": 6,
                 "name": "maxParts",
-                "type": "uint32"
+                "type": "uint32",
+                "optional": true
               }
             ]
           },
@@ -3730,28 +4979,38 @@
               {
                 "id": 2,
                 "name": "type",
-                "type": "hadoop.hdds.ReplicationType"
+                "type": "hadoop.hdds.ReplicationType",
+                "optional": true
               },
               {
                 "id": 3,
                 "name": "factor",
-                "type": "hadoop.hdds.ReplicationFactor"
+                "type": "hadoop.hdds.ReplicationFactor",
+                "optional": true
               },
               {
                 "id": 4,
                 "name": "nextPartNumberMarker",
-                "type": "uint32"
+                "type": "uint32",
+                "optional": true
               },
               {
                 "id": 5,
                 "name": "isTruncated",
-                "type": "bool"
+                "type": "bool",
+                "optional": true
               },
               {
                 "id": 6,
                 "name": "partsList",
                 "type": "PartInfo",
                 "is_repeated": true
+              },
+              {
+                "id": 7,
+                "name": "ecReplicationConfig",
+                "type": "hadoop.hdds.ECReplicationConfig",
+                "optional": true
               }
             ]
           },
@@ -3761,17 +5020,20 @@
               {
                 "id": 1,
                 "name": "volume",
-                "type": "string"
+                "type": "string",
+                "required": true
               },
               {
                 "id": 2,
                 "name": "bucket",
-                "type": "string"
+                "type": "string",
+                "required": true
               },
               {
                 "id": 3,
                 "name": "prefix",
-                "type": "string"
+                "type": "string",
+                "required": true
               }
             ]
           },
@@ -3781,7 +5043,8 @@
               {
                 "id": 1,
                 "name": "isTruncated",
-                "type": "bool"
+                "type": "bool",
+                "optional": true
               },
               {
                 "id": 2,
@@ -3797,37 +5060,50 @@
               {
                 "id": 1,
                 "name": "volumeName",
-                "type": "string"
+                "type": "string",
+                "required": true
               },
               {
                 "id": 2,
                 "name": "bucketName",
-                "type": "string"
+                "type": "string",
+                "required": true
               },
               {
                 "id": 3,
                 "name": "keyName",
-                "type": "string"
+                "type": "string",
+                "required": true
               },
               {
                 "id": 4,
                 "name": "uploadId",
-                "type": "string"
+                "type": "string",
+                "required": true
               },
               {
                 "id": 5,
                 "name": "creationTime",
-                "type": "uint64"
+                "type": "uint64",
+                "required": true
               },
               {
                 "id": 6,
                 "name": "type",
-                "type": "hadoop.hdds.ReplicationType"
+                "type": "hadoop.hdds.ReplicationType",
+                "required": true
               },
               {
                 "id": 7,
                 "name": "factor",
-                "type": "hadoop.hdds.ReplicationFactor"
+                "type": "hadoop.hdds.ReplicationFactor",
+                "optional": true
+              },
+              {
+                "id": 8,
+                "name": "ecReplicationConfig",
+                "type": "hadoop.hdds.ECReplicationConfig",
+                "optional": true
               }
             ]
           },
@@ -3837,22 +5113,54 @@
               {
                 "id": 1,
                 "name": "partNumber",
-                "type": "uint32"
+                "type": "uint32",
+                "required": true
               },
               {
                 "id": 2,
                 "name": "partName",
-                "type": "string"
+                "type": "string",
+                "required": true
               },
               {
                 "id": 3,
                 "name": "modificationTime",
-                "type": "uint64"
+                "type": "uint64",
+                "required": true
               },
               {
                 "id": 4,
                 "name": "size",
-                "type": "uint64"
+                "type": "uint64",
+                "required": true
+              }
+            ]
+          },
+          {
+            "name": "EchoRPCRequest",
+            "fields": [
+              {
+                "id": 1,
+                "name": "payloadReq",
+                "type": "bytes",
+                "optional": true
+              },
+              {
+                "id": 2,
+                "name": "payloadSizeResp",
+                "type": "int32",
+                "optional": true
+              }
+            ]
+          },
+          {
+            "name": "EchoRPCResponse",
+            "fields": [
+              {
+                "id": 1,
+                "name": "payload",
+                "type": "bytes",
+                "optional": true
               }
             ]
           },
@@ -3862,7 +5170,8 @@
               {
                 "id": 2,
                 "name": "response",
-                "type": "hadoop.common.GetDelegationTokenResponseProto"
+                "type": "hadoop.common.GetDelegationTokenResponseProto",
+                "optional": true
               }
             ]
           },
@@ -3872,7 +5181,8 @@
               {
                 "id": 2,
                 "name": "response",
-                "type": "hadoop.common.RenewDelegationTokenResponseProto"
+                "type": "hadoop.common.RenewDelegationTokenResponseProto",
+                "optional": true
               }
             ]
           },
@@ -3882,7 +5192,8 @@
               {
                 "id": 2,
                 "name": "response",
-                "type": "hadoop.common.CancelDelegationTokenResponseProto"
+                "type": "hadoop.common.CancelDelegationTokenResponseProto",
+                "optional": true
               }
             ]
           },
@@ -3892,12 +5203,14 @@
               {
                 "id": 1,
                 "name": "kerberosID",
-                "type": "string"
+                "type": "string",
+                "required": true
               },
               {
                 "id": 2,
                 "name": "awsSecret",
-                "type": "string"
+                "type": "string",
+                "required": true
               }
             ]
           },
@@ -3907,7 +5220,14 @@
               {
                 "id": 1,
                 "name": "kerberosID",
-                "type": "string"
+                "type": "string",
+                "required": true
+              },
+              {
+                "id": 2,
+                "name": "createIfNotExist",
+                "type": "bool",
+                "optional": true
               }
             ]
           },
@@ -3917,7 +5237,210 @@
               {
                 "id": 2,
                 "name": "s3Secret",
-                "type": "S3Secret"
+                "type": "S3Secret",
+                "required": true
+              }
+            ]
+          },
+          {
+            "name": "SetS3SecretRequest",
+            "fields": [
+              {
+                "id": 1,
+                "name": "accessId",
+                "type": "string",
+                "optional": true
+              },
+              {
+                "id": 2,
+                "name": "secretKey",
+                "type": "string",
+                "optional": true
+              }
+            ]
+          },
+          {
+            "name": "SetS3SecretResponse",
+            "fields": [
+              {
+                "id": 1,
+                "name": "accessId",
+                "type": "string",
+                "optional": true
+              },
+              {
+                "id": 2,
+                "name": "secretKey",
+                "type": "string",
+                "optional": true
+              }
+            ]
+          },
+          {
+            "name": "TenantState",
+            "fields": [
+              {
+                "id": 1,
+                "name": "tenantId",
+                "type": "string",
+                "optional": true
+              },
+              {
+                "id": 2,
+                "name": "bucketNamespaceName",
+                "type": "string",
+                "optional": true
+              },
+              {
+                "id": 3,
+                "name": "userRoleName",
+                "type": "string",
+                "optional": true
+              },
+              {
+                "id": 4,
+                "name": "adminRoleName",
+                "type": "string",
+                "optional": true
+              },
+              {
+                "id": 5,
+                "name": "bucketNamespacePolicyName",
+                "type": "string",
+                "optional": true
+              },
+              {
+                "id": 6,
+                "name": "bucketPolicyName",
+                "type": "string",
+                "optional": true
+              }
+            ]
+          },
+          {
+            "name": "TenantUserPrincipalInfo",
+            "fields": [
+              {
+                "id": 1,
+                "name": "accessIds",
+                "type": "string",
+                "is_repeated": true
+              }
+            ]
+          },
+          {
+            "name": "UserAccessIdInfo",
+            "fields": [
+              {
+                "id": 1,
+                "name": "userPrincipal",
+                "type": "string",
+                "optional": true
+              },
+              {
+                "id": 2,
+                "name": "accessId",
+                "type": "string",
+                "optional": true
+              }
+            ]
+          },
+          {
+            "name": "ExtendedUserAccessIdInfo",
+            "fields": [
+              {
+                "id": 1,
+                "name": "userPrincipal",
+                "type": "string",
+                "optional": true
+              },
+              {
+                "id": 2,
+                "name": "accessId",
+                "type": "string",
+                "optional": true
+              },
+              {
+                "id": 3,
+                "name": "tenantId",
+                "type": "string",
+                "optional": true
+              },
+              {
+                "id": 4,
+                "name": "isAdmin",
+                "type": "bool",
+                "optional": true
+              },
+              {
+                "id": 5,
+                "name": "isDelegatedAdmin",
+                "type": "bool",
+                "optional": true
+              }
+            ]
+          },
+          {
+            "name": "ListTenantRequest"
+          },
+          {
+            "name": "ListTenantResponse",
+            "fields": [
+              {
+                "id": 1,
+                "name": "tenantState",
+                "type": "TenantState",
+                "is_repeated": true
+              }
+            ]
+          },
+          {
+            "name": "TenantListUserRequest",
+            "fields": [
+              {
+                "id": 1,
+                "name": "tenantId",
+                "type": "string",
+                "optional": true
+              },
+              {
+                "id": 2,
+                "name": "prefix",
+                "type": "string",
+                "optional": true
+              }
+            ]
+          },
+          {
+            "name": "TenantListUserResponse",
+            "fields": [
+              {
+                "id": 1,
+                "name": "userAccessIdInfo",
+                "type": "UserAccessIdInfo",
+                "is_repeated": true
+              }
+            ]
+          },
+          {
+            "name": "TenantGetUserInfoRequest",
+            "fields": [
+              {
+                "id": 1,
+                "name": "userPrincipal",
+                "type": "string",
+                "optional": true
+              }
+            ]
+          },
+          {
+            "name": "TenantGetUserInfoResponse",
+            "fields": [
+              {
+                "id": 1,
+                "name": "accessIdInfo",
+                "type": "ExtendedUserAccessIdInfo",
+                "is_repeated": true
               }
             ]
           },
@@ -3927,7 +5450,8 @@
               {
                 "id": 1,
                 "name": "version",
-                "type": "uint64"
+                "type": "uint64",
+                "required": true
               }
             ]
           },
@@ -3937,7 +5461,202 @@
               {
                 "id": 1,
                 "name": "kerberosID",
-                "type": "string"
+                "type": "string",
+                "required": true
+              }
+            ]
+          },
+          {
+            "name": "CreateTenantRequest",
+            "fields": [
+              {
+                "id": 1,
+                "name": "tenantId",
+                "type": "string",
+                "optional": true
+              },
+              {
+                "id": 2,
+                "name": "volumeName",
+                "type": "string",
+                "optional": true
+              },
+              {
+                "id": 3,
+                "name": "userRoleName",
+                "type": "string",
+                "optional": true
+              },
+              {
+                "id": 4,
+                "name": "adminRoleName",
+                "type": "string",
+                "optional": true
+              }
+            ]
+          },
+          {
+            "name": "SetRangerServiceVersionRequest",
+            "fields": [
+              {
+                "id": 1,
+                "name": "rangerServiceVersion",
+                "type": "uint64",
+                "required": true
+              }
+            ]
+          },
+          {
+            "name": "DeleteTenantRequest",
+            "fields": [
+              {
+                "id": 1,
+                "name": "tenantId",
+                "type": "string",
+                "optional": true
+              }
+            ]
+          },
+          {
+            "name": "TenantAssignUserAccessIdRequest",
+            "fields": [
+              {
+                "id": 1,
+                "name": "userPrincipal",
+                "type": "string",
+                "optional": true
+              },
+              {
+                "id": 2,
+                "name": "tenantId",
+                "type": "string",
+                "optional": true
+              },
+              {
+                "id": 3,
+                "name": "accessId",
+                "type": "string",
+                "optional": true
+              }
+            ]
+          },
+          {
+            "name": "TenantRevokeUserAccessIdRequest",
+            "fields": [
+              {
+                "id": 1,
+                "name": "accessId",
+                "type": "string",
+                "optional": true
+              },
+              {
+                "id": 2,
+                "name": "tenantId",
+                "type": "string",
+                "optional": true
+              }
+            ]
+          },
+          {
+            "name": "TenantAssignAdminRequest",
+            "fields": [
+              {
+                "id": 1,
+                "name": "accessId",
+                "type": "string",
+                "optional": true
+              },
+              {
+                "id": 2,
+                "name": "tenantId",
+                "type": "string",
+                "optional": true
+              },
+              {
+                "id": 3,
+                "name": "delegated",
+                "type": "bool",
+                "optional": true
+              }
+            ]
+          },
+          {
+            "name": "TenantRevokeAdminRequest",
+            "fields": [
+              {
+                "id": 1,
+                "name": "accessId",
+                "type": "string",
+                "optional": true
+              },
+              {
+                "id": 2,
+                "name": "tenantId",
+                "type": "string",
+                "optional": true
+              }
+            ]
+          },
+          {
+            "name": "GetS3VolumeContextRequest"
+          },
+          {
+            "name": "CreateTenantResponse"
+          },
+          {
+            "name": "SetRangerServiceVersionResponse"
+          },
+          {
+            "name": "DeleteTenantResponse",
+            "fields": [
+              {
+                "id": 1,
+                "name": "volumeName",
+                "type": "string",
+                "optional": true
+              },
+              {
+                "id": 2,
+                "name": "volRefCount",
+                "type": "int64",
+                "optional": true
+              }
+            ]
+          },
+          {
+            "name": "TenantAssignUserAccessIdResponse",
+            "fields": [
+              {
+                "id": 1,
+                "name": "s3Secret",
+                "type": "S3Secret",
+                "optional": true
+              }
+            ]
+          },
+          {
+            "name": "TenantRevokeUserAccessIdResponse"
+          },
+          {
+            "name": "TenantAssignAdminResponse"
+          },
+          {
+            "name": "TenantRevokeAdminResponse"
+          },
+          {
+            "name": "GetS3VolumeContextResponse",
+            "fields": [
+              {
+                "id": 1,
+                "name": "volumeInfo",
+                "type": "VolumeInfo",
+                "optional": true
+              },
+              {
+                "id": 2,
+                "name": "userPrincipal",
+                "type": "string",
+                "optional": true
               }
             ]
           },
@@ -3947,12 +5666,37 @@
               {
                 "id": 1,
                 "name": "kerberosID",
-                "type": "string"
+                "type": "string",
+                "required": true
               },
               {
                 "id": 2,
                 "name": "awsSecret",
-                "type": "string"
+                "type": "string",
+                "required": true
+              }
+            ]
+          },
+          {
+            "name": "S3Authentication",
+            "fields": [
+              {
+                "id": 1,
+                "name": "stringToSign",
+                "type": "string",
+                "optional": true
+              },
+              {
+                "id": 2,
+                "name": "signature",
+                "type": "string",
+                "optional": true
+              },
+              {
+                "id": 3,
+                "name": "accessId",
+                "type": "string",
+                "optional": true
               }
             ]
           }
@@ -4037,17 +5781,20 @@
               {
                 "id": 1,
                 "name": "nodeId",
-                "type": "string"
+                "type": "string",
+                "required": true
               },
               {
                 "id": 2,
                 "name": "hostAddress",
-                "type": "string"
+                "type": "string",
+                "required": true
               },
               {
                 "id": 3,
                 "name": "ratisPort",
-                "type": "uint32"
+                "type": "uint32",
+                "required": true
               }
             ]
           },
@@ -4057,17 +5804,20 @@
               {
                 "id": 1,
                 "name": "success",
-                "type": "bool"
+                "type": "bool",
+                "required": true
               },
               {
                 "id": 2,
                 "name": "errorCode",
-                "type": "ErrorCode"
+                "type": "ErrorCode",
+                "optional": true
               },
               {
                 "id": 3,
                 "name": "errorMsg",
-                "type": "string"
+                "type": "string",
+                "optional": true
               }
             ]
           }
@@ -4117,22 +5867,26 @@
               {
                 "id": 1,
                 "name": "identifier",
-                "type": "bytes"
+                "type": "bytes",
+                "required": true
               },
               {
                 "id": 2,
                 "name": "password",
-                "type": "bytes"
+                "type": "bytes",
+                "required": true
               },
               {
                 "id": 3,
                 "name": "kind",
-                "type": "string"
+                "type": "string",
+                "required": true
               },
               {
                 "id": 4,
                 "name": "service",
-                "type": "string"
+                "type": "string",
+                "required": true
               }
             ]
           },
@@ -4142,17 +5896,20 @@
               {
                 "id": 1,
                 "name": "alias",
-                "type": "string"
+                "type": "string",
+                "required": true
               },
               {
                 "id": 2,
                 "name": "token",
-                "type": "hadoop.common.TokenProto"
+                "type": "hadoop.common.TokenProto",
+                "optional": true
               },
               {
                 "id": 3,
                 "name": "secret",
-                "type": "bytes"
+                "type": "bytes",
+                "optional": true
               }
             ]
           },
@@ -4179,7 +5936,8 @@
               {
                 "id": 1,
                 "name": "renewer",
-                "type": "string"
+                "type": "string",
+                "required": true
               }
             ]
           },
@@ -4189,7 +5947,8 @@
               {
                 "id": 1,
                 "name": "token",
-                "type": "hadoop.common.TokenProto"
+                "type": "hadoop.common.TokenProto",
+                "optional": true
               }
             ]
           },
@@ -4199,7 +5958,8 @@
               {
                 "id": 1,
                 "name": "token",
-                "type": "hadoop.common.TokenProto"
+                "type": "hadoop.common.TokenProto",
+                "required": true
               }
             ]
           },
@@ -4209,7 +5969,8 @@
               {
                 "id": 1,
                 "name": "newExpiryTime",
-                "type": "uint64"
+                "type": "uint64",
+                "required": true
               }
             ]
           },
@@ -4219,7 +5980,8 @@
               {
                 "id": 1,
                 "name": "token",
-                "type": "hadoop.common.TokenProto"
+                "type": "hadoop.common.TokenProto",
+                "required": true
               }
             ]
           },


### PR DESCRIPTION
## What changes were proposed in this pull request?

Ozone 1.3.0 had Announced Release.
[Just as what we did after 1.2 release](https://github.com/apache/ozone/pull/2865). We also need cherry-pick proto.lock form ozone-1.3 branch to master.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-7686

## How was this patch tested?

Normal build process which runs the proto-backwards-compatability check.
