### PR TITLE
HDDS-7666. EC: Unrecoverable EC containers with some remaining replicas may block decommissioning

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ContainerHealthResult.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ContainerHealthResult.java
@@ -108,6 +108,7 @@ public class ContainerHealthResult {
     private final boolean dueToDecommission;
     private final boolean sufficientlyReplicatedAfterPending;
     private final boolean unrecoverable;
+    private boolean hasUnReplicatedOfflineIndexes = false;
     private int requeueCount = 0;
 
     public UnderReplicatedHealthResult(ContainerInfo containerInfo,
@@ -205,6 +206,27 @@ public class ContainerHealthResult {
      */
     public boolean isUnrecoverable() {
       return unrecoverable;
+    }
+
+    /**
+     * Pass true if a container has some indexes which are only on nodes
+     * which are DECOMMISSIONING or ENTERING_MAINTENANCE. These containers may
+     * need to be processed even if they are unrecoverable.
+     * @param val pass true if the container has indexes on nodes going offline
+     *            or false otherwise.
+     */
+    public void setHasUnReplicatedOfflineIndexes(boolean val) {
+      hasUnReplicatedOfflineIndexes = val;
+    }
+    /**
+     * Indicates whether a container has some indexes which are only on nodes
+     * which are DECOMMISSIONING or ENTERING_MAINTENANCE. These containers may
+     * need to be processed even if they are unrecoverable.
+     * @return True if the container has some decommission or maintenance only
+     *         indexes.
+     */
+    public boolean hasUnreplicatedOfflineIndexes() {
+      return hasUnReplicatedOfflineIndexes;
     }
   }
 

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ContainerReplicaCount.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ContainerReplicaCount.java
@@ -17,6 +17,7 @@
  */
 package org.apache.hadoop.hdds.scm.container.replication;
 
+import org.apache.hadoop.hdds.protocol.DatanodeDetails;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.hdds.scm.container.ContainerInfo;
 import org.apache.hadoop.hdds.scm.container.ContainerReplica;
@@ -35,6 +36,8 @@ public interface ContainerReplicaCount {
   Set<ContainerReplica> getReplicas();
 
   boolean isSufficientlyReplicated();
+
+  boolean isSufficientlyReplicatedForOffline(DatanodeDetails datanode);
 
   boolean isOverReplicated();
 

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ECContainerReplicaCount.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ECContainerReplicaCount.java
@@ -37,6 +37,7 @@ import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.NodeOperationalSt
 import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.NodeOperationalState.DECOMMISSIONING;
 import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.NodeOperationalState.ENTERING_MAINTENANCE;
 import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.NodeOperationalState.IN_MAINTENANCE;
+import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.NodeOperationalState.IN_SERVICE;
 
 /**
  * This class provides a set of methods to test for over / under replication of
@@ -443,6 +444,12 @@ public class ECContainerReplicaCount implements ContainerReplicaCount {
     // on another ONLINE node, ie in the healthy set. This means we avoid
     // blocking decommission or maintenance caused by un-recoverable EC
     // containers.
+    if (datanode.getPersistedOpState() == IN_SERVICE) {
+      // The node passed into this method must be a node going offline, so it
+      // cannot be IN_SERVICE. If an IN_SERVICE mode is passed, just return
+      // false.
+      return false;
+    }
     ContainerReplica thisReplica = null;
     for (ContainerReplica r : replicas) {
       if (r.getDatanodeDetails().equals(datanode)) {

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ECContainerReplicaCount.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ECContainerReplicaCount.java
@@ -18,6 +18,7 @@
 package org.apache.hadoop.hdds.scm.container.replication;
 
 import org.apache.hadoop.hdds.client.ECReplicationConfig;
+import org.apache.hadoop.hdds.protocol.DatanodeDetails;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.ContainerReplicaProto;
 import org.apache.hadoop.hdds.scm.container.ContainerInfo;
@@ -419,6 +420,43 @@ public class ECContainerReplicaCount implements ContainerReplicaCount {
     maintenanceIndexes.forEach((k, v) -> healthy.merge(k, v, Integer::sum));
     return hasFullSetOfIndexes(healthy) && onlineIndexes.size()
         >= repConfig.getData() + remainingMaintenanceRedundancy;
+  }
+
+  /**
+   * If we are checking a container for sufficient replication for "offline",
+   * ie decommission or maintenance, then it is not really a requirement that
+   * all replicas for the container are present. Instead, we can ensure the
+   * replica on the node going offline has a copy elsewhere on another
+   * IN_SERVICE node, and if so that replica is sufficiently replicated.
+   * @param datanode The datanode being checked to go offline.
+   * @return True if the container is sufficiently replicated or if this replica
+   *         on the passed node is present elsewhere on an IN_SERVICE node.
+   */
+  @Override
+  public boolean isSufficientlyReplicatedForOffline(DatanodeDetails datanode) {
+    boolean sufficientlyReplicated = isSufficientlyReplicated(false);
+    if (sufficientlyReplicated) {
+      return true;
+    }
+    // If it is not sufficiently replicated (ie the container has all replicas)
+    // then we need to check if the replica that is on this node is available
+    // on another ONLINE node, ie in the healthy set. This means we avoid
+    // blocking decommission or maintenance caused by un-recoverable EC
+    // containers.
+    ContainerReplica thisReplica = null;
+    for (ContainerReplica r : replicas) {
+      if (r.getDatanodeDetails().equals(datanode)) {
+        thisReplica = r;
+        break;
+      }
+    }
+    if (thisReplica == null) {
+      // From the set of replicas, none are on the passed datanode.
+      // This should not happen in practice but if it does we cannot indicate
+      // the container is sufficiently replicated.
+      return false;
+    }
+    return healthyIndexes.containsKey(thisReplica.getReplicaIndex());
   }
 
   @Override

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ECUnderReplicationHandler.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ECUnderReplicationHandler.java
@@ -136,11 +136,6 @@ public class ECUnderReplicationHandler implements UnhealthyReplicationHandler {
           container.getContainerID(), replicaCount.getReplicas());
       return emptyMap();
     }
-    if (replicaCount.isUnrecoverable()) {
-      LOG.warn("The container {} is unrecoverable. The available replicas" +
-          " are: {}.", container.containerID(), replicaCount.getReplicas());
-      return emptyMap();
-    }
 
     // don't place reconstructed replicas on exclude nodes, since they already
     // have replicas

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/RatisContainerReplicaCount.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/RatisContainerReplicaCount.java
@@ -17,6 +17,7 @@
  */
 package org.apache.hadoop.hdds.scm.container.replication;
 
+import org.apache.hadoop.hdds.protocol.DatanodeDetails;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.hdds.scm.container.ContainerInfo;
 import org.apache.hadoop.hdds.scm.container.ContainerReplica;
@@ -245,6 +246,17 @@ public class RatisContainerReplicaCount implements ContainerReplicaCount {
   @Override
   public boolean isSufficientlyReplicated() {
     return isSufficientlyReplicated(false);
+  }
+
+  /**
+   * For Ratis, this method is the same as isSufficientlyReplicated.
+   * @param datanode Not used in this implementation
+   * @return True if the container is sufficiently replicated and False
+   *         otherwise.
+   */
+  @Override
+  public boolean isSufficientlyReplicatedForOffline(DatanodeDetails datanode) {
+    return isSufficientlyReplicated();
   }
 
   /**

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/DatanodeAdminMonitorImpl.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/DatanodeAdminMonitorImpl.java
@@ -345,7 +345,7 @@ public class DatanodeAdminMonitorImpl implements DatanodeAdminMonitor {
       try {
         ContainerReplicaCount replicaSet =
             replicationManager.getContainerReplicaCount(cid);
-        if (replicaSet.isSufficientlyReplicated()) {
+        if (replicaSet.isSufficientlyReplicatedForOffline(dn)) {
           sufficientlyReplicated++;
         } else {
           if (LOG.isDebugEnabled()) {

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestECContainerReplicaCount.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestECContainerReplicaCount.java
@@ -24,11 +24,9 @@ import org.apache.hadoop.hdds.client.ECReplicationConfig;
 import org.apache.hadoop.hdds.protocol.MockDatanodeDetails;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.ContainerReplicaProto;
-import org.apache.hadoop.hdds.scm.container.ContainerID;
 import org.apache.hadoop.hdds.scm.container.ContainerInfo;
 import org.apache.hadoop.hdds.scm.container.ContainerReplica;
 import org.jetbrains.annotations.NotNull;
-import org.junit.Assert;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -583,7 +581,7 @@ public class TestECContainerReplicaCount {
 
     ContainerReplica offlineReplica =
         ReplicationTestUtil.createContainerReplica(container.containerID(),
-    1, DECOMMISSIONING, CLOSED);
+            1, DECOMMISSIONING, CLOSED);
     replica.add(offlineReplica);
 
     ContainerReplica offlineNotReplicated =

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestECContainerReplicaCount.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestECContainerReplicaCount.java
@@ -577,7 +577,12 @@ public class TestECContainerReplicaCount {
   @Test
   public void testSufficientlyReplicatedForOffline() {
     Set<ContainerReplica> replica = ReplicationTestUtil
-        .createReplicas(Pair.of(IN_SERVICE, 1), Pair.of(IN_SERVICE, 2));
+        .createReplicas(Pair.of(IN_SERVICE, 2));
+
+    ContainerReplica inServiceReplica =
+        ReplicationTestUtil.createContainerReplica(container.containerID(),
+            1, IN_SERVICE, CLOSED);
+    replica.add(inServiceReplica);
 
     ContainerReplica offlineReplica =
         ReplicationTestUtil.createContainerReplica(container.containerID(),
@@ -601,5 +606,10 @@ public class TestECContainerReplicaCount {
     // A random DN not hosting a replica for this container should return false.
     Assertions.assertFalse(rcnt.isSufficientlyReplicatedForOffline(
         MockDatanodeDetails.randomDatanodeDetails()));
+
+    // Passing the IN_SERVICE node should return false even though the
+    // replica is on a healthy node
+    Assertions.assertFalse(rcnt.isSufficientlyReplicatedForOffline(
+        inServiceReplica.getDatanodeDetails()));
   }
 }

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/node/DatanodeAdminMonitorTestUtil.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/node/DatanodeAdminMonitorTestUtil.java
@@ -17,7 +17,6 @@
  */
 package org.apache.hadoop.hdds.scm.node;
 
-import org.apache.commons.lang3.tuple.Pair;
 import org.apache.commons.lang3.tuple.Triple;
 import org.apache.hadoop.hdds.client.ECReplicationConfig;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
@@ -32,7 +31,6 @@ import org.apache.hadoop.hdds.scm.container.replication.ContainerReplicaCount;
 import org.apache.hadoop.hdds.scm.container.replication.ECContainerReplicaCount;
 import org.apache.hadoop.hdds.scm.container.replication.RatisContainerReplicaCount;
 import org.apache.hadoop.hdds.scm.container.replication.ReplicationManager;
-import org.apache.hadoop.hdds.scm.container.replication.ReplicationTestUtil;
 import org.apache.hadoop.hdds.server.events.EventHandler;
 import org.apache.hadoop.hdds.server.events.EventPublisher;
 import org.mockito.Mockito;
@@ -121,8 +119,8 @@ public final class DatanodeAdminMonitorTestUtil {
   public static ContainerReplicaCount generateECReplicaCount(
       ContainerID containerID, ECReplicationConfig repConfig,
       HddsProtos.LifeCycleState containerState,
-      Triple<HddsProtos.NodeOperationalState, DatanodeDetails, Integer>
-          ...states) {
+      Triple<HddsProtos.NodeOperationalState, DatanodeDetails,
+          Integer>...states) {
 
     Set<ContainerReplica> replicas = new HashSet<>();
     for (Triple<HddsProtos.NodeOperationalState, DatanodeDetails, Integer> t
@@ -179,8 +177,8 @@ public final class DatanodeAdminMonitorTestUtil {
       ReplicationManager repManager,
       HddsProtos.LifeCycleState containerState,
       ECReplicationConfig repConfig,
-      Triple<HddsProtos.NodeOperationalState, DatanodeDetails, Integer>
-          ...replicaStates)
+      Triple<HddsProtos.NodeOperationalState, DatanodeDetails,
+          Integer>...replicaStates)
       throws ContainerNotFoundException {
     reset(repManager);
     Mockito.when(repManager.getContainerReplicaCount(

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/node/DatanodeAdminMonitorTestUtil.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/node/DatanodeAdminMonitorTestUtil.java
@@ -17,6 +17,9 @@
  */
 package org.apache.hadoop.hdds.scm.node;
 
+import org.apache.commons.lang3.tuple.Pair;
+import org.apache.commons.lang3.tuple.Triple;
+import org.apache.hadoop.hdds.client.ECReplicationConfig;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.hdds.protocol.MockDatanodeDetails;
@@ -26,12 +29,15 @@ import org.apache.hadoop.hdds.scm.container.ContainerInfo;
 import org.apache.hadoop.hdds.scm.container.ContainerNotFoundException;
 import org.apache.hadoop.hdds.scm.container.ContainerReplica;
 import org.apache.hadoop.hdds.scm.container.replication.ContainerReplicaCount;
+import org.apache.hadoop.hdds.scm.container.replication.ECContainerReplicaCount;
 import org.apache.hadoop.hdds.scm.container.replication.RatisContainerReplicaCount;
 import org.apache.hadoop.hdds.scm.container.replication.ReplicationManager;
+import org.apache.hadoop.hdds.scm.container.replication.ReplicationTestUtil;
 import org.apache.hadoop.hdds.server.events.EventHandler;
 import org.apache.hadoop.hdds.server.events.EventPublisher;
 import org.mockito.Mockito;
 
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -53,20 +59,24 @@ public final class DatanodeAdminMonitorTestUtil {
    * @param containerID The ID the replica is associated with
    * @param nodeState The persistedOpState stored in datanodeDetails.
    * @param replicaState The state of the generated replica.
+   * @param replicaIndex The replica Index for the replica.
+   * @param datanodeDetails The datanode the replica is hosted on.
    * @return A containerReplica with the given ID and state
    */
   public static ContainerReplica generateReplica(
       ContainerID containerID,
       HddsProtos.NodeOperationalState nodeState,
       StorageContainerDatanodeProtocolProtos.ContainerReplicaProto
-          .State replicaState) {
-    DatanodeDetails dn = MockDatanodeDetails.randomDatanodeDetails();
-    dn.setPersistedOpState(nodeState);
+          .State replicaState,
+      int replicaIndex,
+      DatanodeDetails datanodeDetails) {
+    datanodeDetails.setPersistedOpState(nodeState);
     return ContainerReplica.newBuilder()
         .setContainerState(replicaState)
         .setContainerID(containerID)
         .setSequenceId(1)
-        .setDatanodeDetails(dn)
+        .setDatanodeDetails(datanodeDetails)
+        .setReplicaIndex(replicaIndex)
         .build();
   }
 
@@ -86,7 +96,8 @@ public final class DatanodeAdminMonitorTestUtil {
       HddsProtos.NodeOperationalState...states) {
     Set<ContainerReplica> replicas = new HashSet<>();
     for (HddsProtos.NodeOperationalState s : states) {
-      replicas.add(generateReplica(containerID, s, CLOSED));
+      replicas.add(generateReplica(containerID, s, CLOSED, 0,
+          MockDatanodeDetails.randomDatanodeDetails()));
     }
     ContainerInfo container = new ContainerInfo.Builder()
         .setContainerID(containerID.getId())
@@ -94,6 +105,39 @@ public final class DatanodeAdminMonitorTestUtil {
         .build();
 
     return new RatisContainerReplicaCount(container, replicas, 0, 0, 3, 2);
+  }
+
+  /**
+   * Create a ContainerReplicaCount object for an EC container, including a
+   * container with the requested ContainerID and state, along with a set of
+   * replicas of the given states.
+   * @param containerID The ID of the container to create an included
+   * @param repConfig The Replication Config for the container
+   * @param containerState The state of the container
+   * @param states Create a replica for each of the given states.
+   * @return A ContainerReplicaCount containing the generated container and
+   *         replica set
+   */
+  public static ContainerReplicaCount generateECReplicaCount(
+      ContainerID containerID, ECReplicationConfig repConfig,
+      HddsProtos.LifeCycleState containerState,
+      Triple<HddsProtos.NodeOperationalState, DatanodeDetails, Integer>
+          ...states) {
+
+    Set<ContainerReplica> replicas = new HashSet<>();
+    for (Triple<HddsProtos.NodeOperationalState, DatanodeDetails, Integer> t
+        : states) {
+      replicas.add(generateReplica(containerID, t.getLeft(), CLOSED,
+          t.getRight(), t.getMiddle()));
+    }
+    ContainerInfo container = new ContainerInfo.Builder()
+        .setContainerID(containerID.getId())
+        .setState(containerState)
+        .setReplicationConfig(repConfig)
+        .build();
+
+    return new ECContainerReplicaCount(container, replicas,
+        Collections.emptyList(), 1);
   }
 
   /**
@@ -118,6 +162,32 @@ public final class DatanodeAdminMonitorTestUtil {
         .thenAnswer(invocation ->
             generateReplicaCount((ContainerID)invocation.getArguments()[0],
                 containerState, replicaStates));
+  }
+
+  /**
+   * The only interaction the DatanodeAdminMonitor has with the
+   * ReplicationManager, is to request a ContainerReplicaCount object for each
+   * container on nodes being deocmmissioned or moved to maintenance. This
+   * method mocks that interface to return a ContainerReplicaCount with a
+   * container in the given containerState and a set of replias in the given
+   * replicaStates.
+   * @param containerState
+   * @param replicaStates
+   * @throws ContainerNotFoundException
+   */
+  public static void mockGetContainerReplicaCountForEC(
+      ReplicationManager repManager,
+      HddsProtos.LifeCycleState containerState,
+      ECReplicationConfig repConfig,
+      Triple<HddsProtos.NodeOperationalState, DatanodeDetails, Integer>
+          ...replicaStates)
+      throws ContainerNotFoundException {
+    reset(repManager);
+    Mockito.when(repManager.getContainerReplicaCount(
+            Mockito.any(ContainerID.class)))
+        .thenAnswer(invocation ->
+            generateECReplicaCount((ContainerID)invocation.getArguments()[0],
+                repConfig, containerState, replicaStates));
   }
 
   /**

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/node/TestDatanodeAdminMonitor.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/node/TestDatanodeAdminMonitor.java
@@ -17,6 +17,9 @@
  */
 package org.apache.hadoop.hdds.scm.node;
 
+import org.apache.commons.lang3.tuple.Pair;
+import org.apache.commons.lang3.tuple.Triple;
+import org.apache.hadoop.hdds.client.ECReplicationConfig;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
 import org.apache.hadoop.hdds.protocol.MockDatanodeDetails;
@@ -36,6 +39,7 @@ import java.io.IOException;
 import java.util.HashSet;
 import java.util.Set;
 
+import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.NodeOperationalState.DECOMMISSIONING;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.NodeOperationalState.DECOMMISSIONED;
@@ -198,6 +202,63 @@ public class TestDatanodeAdminMonitor {
                     IN_SERVICE,
                     IN_SERVICE,
                     IN_SERVICE);
+
+    monitor.run();
+
+    assertEquals(0, monitor.getTrackedNodeCount());
+    assertEquals(HddsProtos.NodeOperationalState.DECOMMISSIONED,
+        nodeManager.getNodeStatus(dn1).getOperationalState());
+  }
+
+  @Test
+  public void testDecommissionNodeWithUnrecoverableECContainer()
+      throws NodeNotFoundException, ContainerNotFoundException {
+    DatanodeDetails dn1 = MockDatanodeDetails.randomDatanodeDetails();
+    nodeManager.register(dn1,
+        new NodeStatus(HddsProtos.NodeOperationalState.DECOMMISSIONING,
+            HddsProtos.NodeState.HEALTHY));
+
+    nodeManager.setContainers(dn1, generateContainers(1));
+    // Mock Replication Manager to return ContainerReplicaCount's which
+    // always have a DECOMMISSIONED replica.
+    DatanodeAdminMonitorTestUtil
+        .mockGetContainerReplicaCountForEC(
+            repManager,
+            HddsProtos.LifeCycleState.CLOSED,
+            new ECReplicationConfig(3, 2),
+            Triple.of(DECOMMISSIONING, dn1, 1),
+            Triple.of(IN_SERVICE,
+                MockDatanodeDetails.randomDatanodeDetails(), 2));
+
+    // Run the monitor for the first time and the node will transition to
+    // REPLICATE_CONTAINERS as there are no pipelines to close.
+    monitor.startMonitoring(dn1);
+    monitor.run();
+    DatanodeDetails node = getFirstTrackedNode();
+    assertEquals(1, monitor.getTrackedNodeCount());
+    assertEquals(HddsProtos.NodeOperationalState.DECOMMISSIONING,
+        nodeManager.getNodeStatus(dn1).getOperationalState());
+
+    // Running the monitor again causes it to remain DECOMMISSIONING
+    // as nothing has changed.
+    monitor.run();
+    assertEquals(HddsProtos.NodeOperationalState.DECOMMISSIONING,
+        nodeManager.getNodeStatus(dn1).getOperationalState());
+
+    // Now change the replicationManager mock another copy of the
+    // decommissioning replica on an IN_SERVICE node and the node should
+    // complete the REPLICATE_CONTAINERS step, moving to complete which will end
+    // the decommission workflow
+    DatanodeAdminMonitorTestUtil
+        .mockGetContainerReplicaCountForEC(
+            repManager,
+            HddsProtos.LifeCycleState.CLOSED,
+            new ECReplicationConfig(3, 2),
+            Triple.of(DECOMMISSIONING, dn1, 1),
+            Triple.of(IN_SERVICE,
+                MockDatanodeDetails.randomDatanodeDetails(), 2),
+            Triple.of(IN_SERVICE,
+                MockDatanodeDetails.randomDatanodeDetails(), 1));
 
     monitor.run();
 

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/node/TestDatanodeAdminMonitor.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/node/TestDatanodeAdminMonitor.java
@@ -17,7 +17,6 @@
  */
 package org.apache.hadoop.hdds.scm.node;
 
-import org.apache.commons.lang3.tuple.Pair;
 import org.apache.commons.lang3.tuple.Triple;
 import org.apache.hadoop.hdds.client.ECReplicationConfig;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;


### PR DESCRIPTION
## What changes were proposed in this pull request?

In EC, a container is considered missing and under replicated if it has lost enough replicas that offline reconstruction is not possible. If any of the remaining replicas for this container are on a datanode that is being decommissioned, the decommissioning will not proceed. All the containers on that node must be restored to proper replication for it to finish decommissioning, but the code will not copy the replica of the missing container to a different node.

There are 3 parts to fixing this problem:

In DatanodeAdminMonitorImpl, inside the method checkContainersReplicatedOnNode, we use a call to ECContainerReplicaCount.isSufficientlyReplicated() to decide if the container is replicated ok or not. Even if we address 1 and 2 above, this is still a problem, as the container is un-recoverable. For EC container in the decommission monitor, perhaps we need a different check. Ie, that for the replica on the host being checked, it is also available on another IN_SERVICE host. From a decommission point of view, we don't care if the entire EC container is sufficiently replicated or not - we just care that the replica on the current host has a copy elsewhere.

In ECReplicationCheckHandler, we deliberately skip adding "unrecoverable" containers to the under replicated queue as we previously believed there was no point in adding them. They cannot be recovered anyway. However this decommission issue is specific to EC, so we should allow the container to make it onto the under-replicated queue if it has decommissioning or maintenance indexes.

In ECUnderReplicationHandle we need to check that the decommissioning indexes are copied ok, even if the container is otherwise unrecoverable.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-7666

## How was this patch tested?

New unit tests added.