### PR TITLE
HDDS-7690. [Snapshot] Use SST file list output from compaction DAG as SnapshotDiff input

### DIFF
--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmSnapshotManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmSnapshotManager.java
@@ -62,7 +62,12 @@ public final class OmSnapshotManager {
   OmSnapshotManager(OzoneManager ozoneManager) {
     this.ozoneManager = ozoneManager;
 
-    this.snapshotDiffManager = new SnapshotDiffManager();
+    // Pass in the differ
+    final RocksDBCheckpointDiffer differ = ozoneManager
+            .getMetadataManager()
+            .getStore()
+            .getRocksDBCheckpointDiffer();
+    this.snapshotDiffManager = new SnapshotDiffManager(differ);
 
     // size of lru cache
     int cacheSize = ozoneManager.getConfiguration().getInt(
@@ -241,7 +246,8 @@ public final class OmSnapshotManager {
     try {
       final OmSnapshot fs = snapshotCache.get(fsKey);
       final OmSnapshot ts = snapshotCache.get(tsKey);
-      return snapshotDiffManager.getSnapshotDiffReport(volume, bucket, fs, ts);
+      return snapshotDiffManager.getSnapshotDiffReport(volume, bucket, fs, ts,
+              fsInfo, tsInfo);
     } catch (ExecutionException | RocksDBException e) {
       throw new IOException(e.getCause());
     }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/snapshot/SnapshotDiffManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/snapshot/SnapshotDiffManager.java
@@ -235,12 +235,12 @@ public class SnapshotDiffManager {
       List<String> sstDiffList =
               differ.getSSTDiffListWithFullPath(toDSI, fromDSI);
       LOG.debug("SST diff list: {}", sstDiffList);
-      deltaFiles.addAll(sstDiffList);  // TODO: Uncomment this.
+      deltaFiles.addAll(sstDiffList);
 
       // TODO: Remove the workaround below when the SnapDiff logic can read
       //  tombstones in SST files.
       // Workaround: Append "From DB" SST files to the deltaFiles list so that
-      //  the current SnapDiff logic can
+      //  the current SnapDiff logic correctly handles deleted keys.
       if (!deltaFiles.isEmpty()) {
         Set<String> fromSnapshotFiles =
                 RdbUtil.getSSTFilesForComparison(

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/snapshot/SnapshotDiffManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/snapshot/SnapshotDiffManager.java
@@ -138,7 +138,7 @@ public class SnapshotDiffManager {
     final Set<String> deltaFilesForKeyOrFileTable =
         getDeltaFiles(fromSnapshot, toSnapshot,
             Collections.singletonList(fsKeyTable.getName()),
-                fsInfo, tsInfo, differ, volume, bucket);
+                fsInfo, tsInfo, volume, bucket);
 
     addToObjectIdMap(fsKeyTable, tsKeyTable, deltaFilesForKeyOrFileTable,
         oldObjIdToKeyMap, newObjIdToKeyMap, objectIDsToCheck, false);
@@ -152,7 +152,7 @@ public class SnapshotDiffManager {
       final Set<String> deltaFilesForDirTable =
           getDeltaFiles(fromSnapshot, toSnapshot,
               Collections.singletonList(fsDirTable.getName()),
-                  fsInfo, tsInfo, differ, volume, bucket);
+                  fsInfo, tsInfo, volume, bucket);
       addToObjectIdMap(fsDirTable, tsDirTable, deltaFilesForDirTable,
           oldObjIdToKeyMap, newObjIdToKeyMap, objectIDsToCheck, true);
     }
@@ -210,10 +210,11 @@ public class SnapshotDiffManager {
   }
 
   @NotNull
+  @SuppressWarnings("parameternumber")
   private Set<String> getDeltaFiles(OmSnapshot fromSnapshot,
       OmSnapshot toSnapshot, List<String> tablesToLookUp,
       SnapshotInfo fsInfo, SnapshotInfo tsInfo,
-      RocksDBCheckpointDiffer differ, String volume, String bucket)
+      String volume, String bucket)
           throws RocksDBException, IOException {
     // TODO: Refactor the parameter list
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

This is a follow-up to [HDDS-7466](https://issues.apache.org/jira/browse/HDDS-7466).

Currently [HDDS-7466](https://issues.apache.org/jira/browse/HDDS-7466) is not being passed in the "filtered" SST list result from compaction DAG output.

The original jira HDDS-7466 does not have UTs. Some test are being added in [HDDS-7607](https://issues.apache.org/jira/browse/HDDS-7607). More tests to come in [HDDS-7467](https://issues.apache.org/jira/browse/HDDS-7467).

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-7690

## How was this patch tested?

- [x] Integration test from #4108 passed.
- [x] Manually tested.