### PR TITLE
HDDS-7702. [snapshot] Add unit-testcases for Ozone fs createSnapshot

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFsSnapshot.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFsSnapshot.java
@@ -16,7 +16,10 @@
  */
 package org.apache.hadoop.fs.ozone;
 
+import java.util.Random;
 import java.util.UUID;
+
+import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.ozone.MiniOzoneCluster;
 import org.apache.hadoop.ozone.om.OzoneManager;
@@ -112,6 +115,189 @@ public class TestOzoneFsSnapshot {
       // We can't use list or valid if snapshot directory exists because DB
       // transaction might not be flushed by the time.
       Assert.assertNotNull(snapshotInfo);
+    } finally {
+      shell.close();
+    }
+  }
+
+  @Test
+  public void testCreateSnapshotDuplicateName() throws Exception {
+    String volume = "vol-" + RandomStringUtils.randomNumeric(5);
+    String bucket = "buc-" + RandomStringUtils.randomNumeric(5);
+    String key = "key-" + RandomStringUtils.randomNumeric(5);
+    String snapshotName = "snap-" + RandomStringUtils.randomNumeric(5);
+
+    String testVolBucket = OM_KEY_PREFIX + volume + OM_KEY_PREFIX + bucket;
+    String testKey = testVolBucket + OM_KEY_PREFIX + key;
+
+    OzoneFsShell shell = new OzoneFsShell(clientConf);
+    try {
+      // Create volume and bucket
+      int res = ToolRunner.run(shell,
+              new String[]{"-mkdir", "-p", testVolBucket});
+      assertEquals(0, res);
+      // Create key
+      ToolRunner.run(shell, new String[]{"-touch", testKey});
+      assertEquals(0, res);
+      // List the bucket to make sure that bucket exists.
+      ToolRunner.run(shell, new String[]{"-ls", testVolBucket});
+      assertEquals(0, res);
+
+      res = ToolRunner.run(shell,
+              new String[]{"-createSnapshot", testVolBucket, snapshotName});
+      // Asserts that create request succeeded
+      assertEquals(0, res);
+
+      res = ToolRunner.run(shell,
+              new String[]{"-createSnapshot", testVolBucket, snapshotName});
+      // Asserts that create request fails due to same snapshot name provided twice
+      assertEquals(1, res);
+    } finally {
+      shell.close();
+    }
+  }
+
+  @Test
+  public void testCreateSnapshotInvalidName() throws Exception {
+    String volume = "vol-" + RandomStringUtils.randomNumeric(5);
+    String bucket = "buc-" + RandomStringUtils.randomNumeric(5);
+    String key = "key-" + RandomStringUtils.randomNumeric(5);
+    String snapshotName = "snapa?b";
+
+    String testVolBucket = OM_KEY_PREFIX + volume + OM_KEY_PREFIX + bucket;
+    String testKey = testVolBucket + OM_KEY_PREFIX + key;
+
+    OzoneFsShell shell = new OzoneFsShell(clientConf);
+    try {
+      // Create volume and bucket
+      int res = ToolRunner.run(shell,
+              new String[]{"-mkdir", "-p", testVolBucket});
+      assertEquals(0, res);
+      // Create key
+      ToolRunner.run(shell, new String[]{"-touch", testKey});
+      assertEquals(0, res);
+      // List the bucket to make sure that bucket exists.
+      ToolRunner.run(shell, new String[]{"-ls", testVolBucket});
+      assertEquals(0, res);
+
+      res = ToolRunner.run(shell,
+              new String[]{"-createSnapshot", testVolBucket, snapshotName});
+      // Asserts that create request failed since invalid name passed
+      assertEquals(1, res);
+
+    } finally {
+      shell.close();
+    }
+  }
+
+  @Test
+  public void testCreateSnapshotOnlyNumericName() throws Exception {
+    String volume = "vol-" + RandomStringUtils.randomNumeric(5);
+    String bucket = "buc-" + RandomStringUtils.randomNumeric(5);
+    String key = "key-" + RandomStringUtils.randomNumeric(5);
+    String snapshotName = "1234";
+
+    String testVolBucket = OM_KEY_PREFIX + volume + OM_KEY_PREFIX + bucket;
+    String testKey = testVolBucket + OM_KEY_PREFIX + key;
+
+    OzoneFsShell shell = new OzoneFsShell(clientConf);
+    try {
+      // Create volume and bucket
+      int res = ToolRunner.run(shell,
+              new String[]{"-mkdir", "-p", testVolBucket});
+      assertEquals(0, res);
+      // Create key
+      ToolRunner.run(shell, new String[]{"-touch", testKey});
+      assertEquals(0, res);
+      // List the bucket to make sure that bucket exists.
+      ToolRunner.run(shell, new String[]{"-ls", testVolBucket});
+      assertEquals(0, res);
+
+      res = ToolRunner.run(shell,
+              new String[]{"-createSnapshot", testVolBucket, snapshotName});
+      // Asserts that create request failed since only numeric name passed
+      assertEquals(1, res);
+
+    } finally {
+      shell.close();
+    }
+  }
+
+  @Test
+  public void testCreateSnapshotInvalidURI() throws Exception {
+
+    OzoneFsShell shell = new OzoneFsShell(clientConf);
+    try {
+
+      int res = ToolRunner.run(shell,
+              new String[]{"-createSnapshot", "invalidURI"});
+      // Asserts that create request failed since invalid volume-bucket URI passed
+      assertEquals(1, res);
+
+    } finally {
+      shell.close();
+    }
+  }
+
+  @Test
+  public void testCreateSnapshotNameLength() throws Exception {
+    String volume = "vol-" + RandomStringUtils.randomNumeric(5);
+    String bucket = "buc-" + RandomStringUtils.randomNumeric(5);
+    String key = "key-" + RandomStringUtils.randomNumeric(5);
+    String name63 =
+            "snap75795657617173401188448010125899089001363595171500499231286";
+    String name64 =
+            "snap156808943643007724443266605711479126926050896107709081166294";
+
+    String testVolBucket = OM_KEY_PREFIX + volume + OM_KEY_PREFIX + bucket;
+    String testKey = testVolBucket + OM_KEY_PREFIX + key;
+
+    OzoneFsShell shell = new OzoneFsShell(clientConf);
+    try {
+      // Create volume and bucket
+      int res = ToolRunner.run(shell,
+              new String[]{"-mkdir", "-p", testVolBucket});
+      assertEquals(0, res);
+      // Create key
+      ToolRunner.run(shell, new String[]{"-touch", testKey});
+      assertEquals(0, res);
+      // List the bucket to make sure that bucket exists.
+      ToolRunner.run(shell, new String[]{"-ls", testVolBucket});
+      assertEquals(0, res);
+
+      res = ToolRunner.run(shell,
+              new String[]{"-createSnapshot", testVolBucket, name63});
+      // Asserts that create request succeeded since namelength less than 64 char
+      assertEquals(0, res);
+
+      res = ToolRunner.run(shell,
+              new String[]{"-createSnapshot", testVolBucket, name64});
+      // Asserts that create request fails since namelength more than 64 char
+      assertEquals(1, res);
+
+      SnapshotInfo snapshotInfo = ozoneManager
+              .getMetadataManager()
+              .getSnapshotInfoTable()
+              .get(SnapshotInfo.getTableKey(volume, bucket, name63));
+
+      Assert.assertNotNull(snapshotInfo);
+
+    } finally {
+      shell.close();
+    }
+  }
+
+  @Test
+  public void testCreateSnapshotParameterMissing() throws Exception {
+
+    OzoneFsShell shell = new OzoneFsShell(clientConf);
+    try {
+
+      int res = ToolRunner.run(shell,
+              new String[]{"-createSnapshot"});
+      // Asserts that create request failed since mandatory params not passed
+      assertEquals(-1, res);
+
     } finally {
       shell.close();
     }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFsSnapshot.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFsSnapshot.java
@@ -33,7 +33,6 @@ import org.junit.Test;
 import org.junit.rules.Timeout;
 
 import static org.apache.hadoop.fs.FileSystem.FS_DEFAULT_NAME_KEY;
-import static org.apache.hadoop.fs.FileSystem.create;
 import static org.apache.hadoop.ozone.OzoneConsts.OM_KEY_PREFIX;
 import static org.apache.hadoop.ozone.OzoneConsts.OZONE_OFS_URI_SCHEME;
 import static org.junit.Assert.assertEquals;
@@ -80,7 +79,8 @@ public class TestOzoneFsSnapshot {
     }
   }
 
-  private void createVolBuckKey(String testVolBucket, String testKey) throws Exception {
+  private void createVolBuckKey(String testVolBucket, String testKey)
+          throws Exception {
     OzoneFsShell shell = new OzoneFsShell(clientConf);
     try {
       // Create volume and bucket

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFsSnapshot.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFsSnapshot.java
@@ -16,7 +16,6 @@
  */
 package org.apache.hadoop.fs.ozone;
 
-import java.util.Random;
 import java.util.UUID;
 
 import org.apache.commons.lang3.RandomStringUtils;
@@ -150,7 +149,7 @@ public class TestOzoneFsSnapshot {
 
       res = ToolRunner.run(shell,
               new String[]{"-createSnapshot", testVolBucket, snapshotName});
-      // Asserts that create request fails due to same snapshot name provided twice
+      // Asserts that create request fails since snapshot name provided twice
       assertEquals(1, res);
     } finally {
       shell.close();
@@ -231,7 +230,8 @@ public class TestOzoneFsSnapshot {
 
       int res = ToolRunner.run(shell,
               new String[]{"-createSnapshot", "invalidURI"});
-      // Asserts that create request failed since invalid volume-bucket URI passed
+      // Asserts that create request failed since
+      // invalid volume-bucket URI passed
       assertEquals(1, res);
 
     } finally {
@@ -267,12 +267,14 @@ public class TestOzoneFsSnapshot {
 
       res = ToolRunner.run(shell,
               new String[]{"-createSnapshot", testVolBucket, name63});
-      // Asserts that create request succeeded since namelength less than 64 char
+      // Asserts that create request succeeded since namelength
+      // less than 64 char
       assertEquals(0, res);
 
       res = ToolRunner.run(shell,
               new String[]{"-createSnapshot", testVolBucket, name64});
-      // Asserts that create request fails since namelength more than 64 char
+      // Asserts that create request fails since namelength
+      // more than 64 char
       assertEquals(1, res);
 
       SnapshotInfo snapshotInfo = ozoneManager

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFsSnapshot.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFsSnapshot.java
@@ -33,6 +33,7 @@ import org.junit.Test;
 import org.junit.rules.Timeout;
 
 import static org.apache.hadoop.fs.FileSystem.FS_DEFAULT_NAME_KEY;
+import static org.apache.hadoop.fs.FileSystem.create;
 import static org.apache.hadoop.ozone.OzoneConsts.OM_KEY_PREFIX;
 import static org.apache.hadoop.ozone.OzoneConsts.OZONE_OFS_URI_SCHEME;
 import static org.junit.Assert.assertEquals;
@@ -79,6 +80,24 @@ public class TestOzoneFsSnapshot {
     }
   }
 
+  private void createVolBuckKey(String testVolBucket, String testKey) throws Exception {
+    OzoneFsShell shell = new OzoneFsShell(clientConf);
+    try {
+      // Create volume and bucket
+      int res = ToolRunner.run(shell,
+              new String[]{"-mkdir", "-p", testVolBucket});
+      assertEquals(0, res);
+      // Create key
+      res = ToolRunner.run(shell, new String[]{"-touch", testKey});
+      assertEquals(0, res);
+      // List the bucket to make sure that bucket exists.
+      res = ToolRunner.run(shell, new String[]{"-ls", testVolBucket});
+      assertEquals(0, res);
+    } finally {
+      shell.close();
+    }
+  }
+
   @Test
   public void testCreateSnapshot() throws Exception {
     String volume = "vol1";
@@ -87,20 +106,11 @@ public class TestOzoneFsSnapshot {
     String snapshotName = "snap1";
     String testKey = testVolBucket + "/key1";
 
+    createVolBuckKey(testVolBucket, testKey);
+
     OzoneFsShell shell = new OzoneFsShell(clientConf);
     try {
-      // Create volume and bucket
       int res = ToolRunner.run(shell,
-          new String[]{"-mkdir", "-p", testVolBucket});
-      assertEquals(0, res);
-      // Create key
-      ToolRunner.run(shell, new String[]{"-touch", testKey});
-      assertEquals(0, res);
-      // List the bucket to make sure that bucket exists.
-      ToolRunner.run(shell, new String[]{"-ls", testVolBucket});
-      assertEquals(0, res);
-
-      res = ToolRunner.run(shell,
           new String[]{"-createSnapshot", testVolBucket, snapshotName});
       // Asserts that create request succeeded
       assertEquals(0, res);
@@ -129,20 +139,11 @@ public class TestOzoneFsSnapshot {
     String testVolBucket = OM_KEY_PREFIX + volume + OM_KEY_PREFIX + bucket;
     String testKey = testVolBucket + OM_KEY_PREFIX + key;
 
+    createVolBuckKey(testVolBucket, testKey);
+
     OzoneFsShell shell = new OzoneFsShell(clientConf);
     try {
-      // Create volume and bucket
       int res = ToolRunner.run(shell,
-              new String[]{"-mkdir", "-p", testVolBucket});
-      assertEquals(0, res);
-      // Create key
-      ToolRunner.run(shell, new String[]{"-touch", testKey});
-      assertEquals(0, res);
-      // List the bucket to make sure that bucket exists.
-      ToolRunner.run(shell, new String[]{"-ls", testVolBucket});
-      assertEquals(0, res);
-
-      res = ToolRunner.run(shell,
               new String[]{"-createSnapshot", testVolBucket, snapshotName});
       // Asserts that create request succeeded
       assertEquals(0, res);
@@ -166,20 +167,11 @@ public class TestOzoneFsSnapshot {
     String testVolBucket = OM_KEY_PREFIX + volume + OM_KEY_PREFIX + bucket;
     String testKey = testVolBucket + OM_KEY_PREFIX + key;
 
+    createVolBuckKey(testVolBucket, testKey);
+
     OzoneFsShell shell = new OzoneFsShell(clientConf);
     try {
-      // Create volume and bucket
       int res = ToolRunner.run(shell,
-              new String[]{"-mkdir", "-p", testVolBucket});
-      assertEquals(0, res);
-      // Create key
-      ToolRunner.run(shell, new String[]{"-touch", testKey});
-      assertEquals(0, res);
-      // List the bucket to make sure that bucket exists.
-      ToolRunner.run(shell, new String[]{"-ls", testVolBucket});
-      assertEquals(0, res);
-
-      res = ToolRunner.run(shell,
               new String[]{"-createSnapshot", testVolBucket, snapshotName});
       // Asserts that create request failed since invalid name passed
       assertEquals(1, res);
@@ -199,20 +191,11 @@ public class TestOzoneFsSnapshot {
     String testVolBucket = OM_KEY_PREFIX + volume + OM_KEY_PREFIX + bucket;
     String testKey = testVolBucket + OM_KEY_PREFIX + key;
 
+    createVolBuckKey(testVolBucket, testKey);
+
     OzoneFsShell shell = new OzoneFsShell(clientConf);
     try {
-      // Create volume and bucket
       int res = ToolRunner.run(shell,
-              new String[]{"-mkdir", "-p", testVolBucket});
-      assertEquals(0, res);
-      // Create key
-      ToolRunner.run(shell, new String[]{"-touch", testKey});
-      assertEquals(0, res);
-      // List the bucket to make sure that bucket exists.
-      ToolRunner.run(shell, new String[]{"-ls", testVolBucket});
-      assertEquals(0, res);
-
-      res = ToolRunner.run(shell,
               new String[]{"-createSnapshot", testVolBucket, snapshotName});
       // Asserts that create request failed since only numeric name passed
       assertEquals(1, res);
@@ -252,20 +235,11 @@ public class TestOzoneFsSnapshot {
     String testVolBucket = OM_KEY_PREFIX + volume + OM_KEY_PREFIX + bucket;
     String testKey = testVolBucket + OM_KEY_PREFIX + key;
 
+    createVolBuckKey(testVolBucket, testKey);
+
     OzoneFsShell shell = new OzoneFsShell(clientConf);
     try {
-      // Create volume and bucket
       int res = ToolRunner.run(shell,
-              new String[]{"-mkdir", "-p", testVolBucket});
-      assertEquals(0, res);
-      // Create key
-      ToolRunner.run(shell, new String[]{"-touch", testKey});
-      assertEquals(0, res);
-      // List the bucket to make sure that bucket exists.
-      ToolRunner.run(shell, new String[]{"-ls", testVolBucket});
-      assertEquals(0, res);
-
-      res = ToolRunner.run(shell,
               new String[]{"-createSnapshot", testVolBucket, name63});
       // Asserts that create request succeeded since namelength
       // less than 64 char


### PR DESCRIPTION
## What changes were proposed in this pull request?

Add UTs for fs createSnapshot - `TestOzoneFsSnapshot`
Testcases :
```
- testCreateSnapshotDuplicateName
- testCreateSnapshotInvalidName
- testCreateSnapshotOnlyNumericName
- testCreateSnapshotInvalidURI
- testCreateSnapshotNameLength
- testCreateSnapshotParameterMissing
```

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-7702 

## How was this patch tested?

Testcase file - `hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFsSnapshot.java`
```
mvn -Dtest=TestOzoneFsSnapshot test
[INFO] -------------------------------------------------------
[INFO]  T E S T S
[INFO] -------------------------------------------------------
[INFO] Running org.apache.hadoop.fs.ozone.TestOzoneFsSnapshot
[INFO] Tests run: 7, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 42.015 s - in org.apache.hadoop.fs.ozone.TestOzoneFsSnapshot
[INFO]
[INFO] Results:
[INFO]
[INFO] Tests run: 7, Failures: 0, Errors: 0, Skipped: 0
```

