### PR TITLE
HDDS-7710. Support AWS s3 ListObjects API's encodingType request parameter

### DIFF
--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/commontypes/EncodingTypeObject.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/commontypes/EncodingTypeObject.java
@@ -17,33 +17,37 @@
  */
 package org.apache.hadoop.ozone.s3.commontypes;
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
+import javax.annotation.Nullable;
 
 /**
- * Directory name ("key prefix") in case of listing.
+ * A converter to encode string if needed.
  */
-@XmlAccessorType(XmlAccessType.FIELD)
-public class CommonPrefix {
+public final class EncodingTypeObject {
+  private final String encodingType;
+  private final String name;
 
-  @XmlJavaTypeAdapter(ObjectKeyNameAdapter.class)
-  @XmlElement(name = "Prefix")
-  private EncodingTypeObject prefix;
-
-  public CommonPrefix(EncodingTypeObject prefix) {
-    this.prefix = prefix;
+  private EncodingTypeObject(String name, @Nullable String encodingType) {
+    this.encodingType = encodingType;
+    this.name = name;
   }
 
-  public CommonPrefix() {
+  @Nullable public String getEncodingType() {
+    return encodingType;
   }
 
-  public EncodingTypeObject getPrefix() {
-    return prefix;
+  public String getName() {
+    return name;
   }
 
-  public void setPrefix(EncodingTypeObject prefix) {
-    this.prefix = prefix;
+  /**
+   * Create a EncodingTypeObject Object, if the parameter name is null.
+   * @return If name is null return null else return a EncodingTypeObject object
+   */
+  @Nullable public static EncodingTypeObject createNullable(
+      @Nullable String name, @Nullable String encodingType) {
+    if (name == null) {
+      return null;
+    }
+    return new EncodingTypeObject(name, encodingType);
   }
 }

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/commontypes/KeyMetadata.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/commontypes/KeyMetadata.java
@@ -31,7 +31,7 @@ public class KeyMetadata {
 
   @XmlJavaTypeAdapter(ObjectKeyNameAdapter.class)
   @XmlElement(name = "Key")
-  private String key; // or the Object Name
+  private EncodingTypeObject key; // or the Object Name
 
   @XmlJavaTypeAdapter(IsoDateAdapter.class)
   @XmlElement(name = "LastModified")
@@ -46,11 +46,11 @@ public class KeyMetadata {
   @XmlElement(name = "StorageClass")
   private String storageClass;
 
-  public String getKey() {
+  public EncodingTypeObject getKey() {
     return key;
   }
 
-  public void setKey(String key) {
+  public void setKey(EncodingTypeObject key) {
     this.key = key;
   }
 

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/commontypes/ObjectKeyNameAdapter.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/commontypes/ObjectKeyNameAdapter.java
@@ -27,16 +27,20 @@ import java.io.UnsupportedEncodingException;
  * A converter to convert raw-String to S3 compliant object key name.
  * ref: https://docs.aws.amazon.com/AmazonS3/latest/userguide/object-keys.html
  */
-public class ObjectKeyNameAdapter extends XmlAdapter<String, String> {
+public class ObjectKeyNameAdapter extends
+    XmlAdapter<String, EncodingTypeObject> {
   @Override
-  public String unmarshal(String s) {
+  public EncodingTypeObject unmarshal(String s) {
     throw new UnsupportedOperationException();
   }
 
   @Override
-  public String marshal(String s)
+  public String marshal(EncodingTypeObject s)
       throws UnsupportedEncodingException {
-    return S3Utils.urlEncode(s)
-        .replaceAll("%2F", "/");
+    if (s.getEncodingType() != null && s.getEncodingType().equals("url")) {
+      return S3Utils.urlEncode(s.getName())
+          .replaceAll("%2F", "/");
+    }
+    return s.getName();
   }
 }

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/ListObjectResponse.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/ListObjectResponse.java
@@ -22,11 +22,14 @@ import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
+import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
 import java.util.ArrayList;
 import java.util.List;
 
 import org.apache.hadoop.ozone.s3.commontypes.CommonPrefix;
+import org.apache.hadoop.ozone.s3.commontypes.EncodingTypeObject;
 import org.apache.hadoop.ozone.s3.commontypes.KeyMetadata;
+import org.apache.hadoop.ozone.s3.commontypes.ObjectKeyNameAdapter;
 
 /**
  * Response from the ListObject RPC Call.
@@ -40,7 +43,8 @@ public class ListObjectResponse {
   private String name;
 
   @XmlElement(name = "Prefix")
-  private String prefix;
+  @XmlJavaTypeAdapter(ObjectKeyNameAdapter.class)
+  private EncodingTypeObject prefix;
 
   @XmlElement(name = "Marker")
   private String marker;
@@ -51,11 +55,12 @@ public class ListObjectResponse {
   @XmlElement(name = "KeyCount")
   private int keyCount;
 
+  @XmlJavaTypeAdapter(ObjectKeyNameAdapter.class)
   @XmlElement(name = "Delimiter")
-  private String delimiter = "/";
+  private EncodingTypeObject delimiter;
 
   @XmlElement(name = "EncodingType")
-  private String encodingType = "url";
+  private String encodingType;
 
   @XmlElement(name = "IsTruncated")
   private boolean isTruncated;
@@ -75,6 +80,10 @@ public class ListObjectResponse {
   @XmlElement(name = "CommonPrefixes")
   private List<CommonPrefix> commonPrefixes = new ArrayList<>();
 
+  @XmlJavaTypeAdapter(ObjectKeyNameAdapter.class)
+  @XmlElement(name = "StartAfter")
+  private EncodingTypeObject startAfter;
+
   public String getName() {
     return name;
   }
@@ -83,11 +92,11 @@ public class ListObjectResponse {
     this.name = name;
   }
 
-  public String getPrefix() {
+  public EncodingTypeObject getPrefix() {
     return prefix;
   }
 
-  public void setPrefix(String prefix) {
+  public void setPrefix(EncodingTypeObject prefix) {
     this.prefix = prefix;
   }
 
@@ -107,11 +116,11 @@ public class ListObjectResponse {
     this.maxKeys = maxKeys;
   }
 
-  public String getDelimiter() {
+  public EncodingTypeObject getDelimiter() {
     return delimiter;
   }
 
-  public void setDelimiter(String delimiter) {
+  public void setDelimiter(EncodingTypeObject delimiter) {
     this.delimiter = delimiter;
   }
 
@@ -153,7 +162,7 @@ public class ListObjectResponse {
     contents.add(keyMetadata);
   }
 
-  public void addPrefix(String relativeKeyName) {
+  public void addPrefix(EncodingTypeObject relativeKeyName) {
     commonPrefixes.add(new CommonPrefix(relativeKeyName));
   }
 
@@ -187,5 +196,13 @@ public class ListObjectResponse {
 
   public String getNextMarker() {
     return nextMarker;
+  }
+
+  public void setStartAfter(EncodingTypeObject startAfter) {
+    this.startAfter = startAfter;
+  }
+
+  public EncodingTypeObject getStartAfter() {
+    return startAfter;
   }
 }

--- a/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/commontypes/TestObjectKeyNameAdapter.java
+++ b/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/commontypes/TestObjectKeyNameAdapter.java
@@ -19,6 +19,8 @@
  */
 package org.apache.hadoop.ozone.s3.commontypes;
 
+import static org.apache.hadoop.ozone.s3.util.S3Consts.ENCODING_TYPE;
+
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -29,15 +31,22 @@ import javax.xml.bind.annotation.adapters.XmlAdapter;
 public class TestObjectKeyNameAdapter {
   @Test
   public void testEncodeResult() throws Exception {
-    Assert.assertEquals("abc/",
-        getAdapter().marshal("abc/"));
-    Assert.assertEquals("a+b+c/",
-        getAdapter().marshal("a b c/"));
-    Assert.assertEquals("a%2Bb%2Bc/",
-        getAdapter().marshal("a+b+c/"));
+    Assert.assertEquals("abc/", getAdapter()
+        .marshal(EncodingTypeObject.createNullable("abc/", ENCODING_TYPE)));
+    Assert.assertEquals("a+b+c/", getAdapter()
+        .marshal(EncodingTypeObject.createNullable("a b c/", ENCODING_TYPE)));
+    Assert.assertEquals("a%2Bb%2Bc/", getAdapter()
+        .marshal(EncodingTypeObject.createNullable("a+b+c/", ENCODING_TYPE)));
+
+    Assert.assertEquals("abc/", getAdapter()
+        .marshal(EncodingTypeObject.createNullable("abc/", null)));
+    Assert.assertEquals("a b c/", getAdapter()
+        .marshal(EncodingTypeObject.createNullable("a b c/", null)));
+    Assert.assertEquals("a+b+c/", getAdapter()
+        .marshal(EncodingTypeObject.createNullable("a+b+c/", null)));
   }
 
-  private XmlAdapter<String, String> getAdapter() {
+  private XmlAdapter<String, EncodingTypeObject> getAdapter() {
     return (new ObjectKeyNameAdapter());
   }
 }

--- a/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestBucketList.java
+++ b/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestBucketList.java
@@ -24,9 +24,13 @@ import java.io.IOException;
 import org.apache.hadoop.ozone.client.OzoneBucket;
 import org.apache.hadoop.ozone.client.OzoneClient;
 import org.apache.hadoop.ozone.client.OzoneClientStub;
+import org.apache.hadoop.ozone.s3.commontypes.EncodingTypeObject;
 import org.apache.hadoop.ozone.s3.exception.OS3Exception;
 
+import org.apache.hadoop.ozone.s3.exception.S3ErrorTable;
 import org.junit.Assert;
+
+import static org.apache.hadoop.ozone.s3.util.S3Consts.ENCODING_TYPE;
 import static org.junit.Assert.fail;
 import org.junit.Test;
 
@@ -51,11 +55,11 @@ public class TestBucketList {
 
     Assert.assertEquals(1, getBucketResponse.getCommonPrefixes().size());
     Assert.assertEquals("dir1/",
-        getBucketResponse.getCommonPrefixes().get(0).getPrefix());
+        getBucketResponse.getCommonPrefixes().get(0).getPrefix().getName());
 
     Assert.assertEquals(1, getBucketResponse.getContents().size());
     Assert.assertEquals("file1",
-        getBucketResponse.getContents().get(0).getKey());
+        getBucketResponse.getContents().get(0).getKey().getName());
 
   }
 
@@ -74,7 +78,7 @@ public class TestBucketList {
 
     Assert.assertEquals(1, getBucketResponse.getCommonPrefixes().size());
     Assert.assertEquals("dir1/",
-        getBucketResponse.getCommonPrefixes().get(0).getPrefix());
+        getBucketResponse.getCommonPrefixes().get(0).getPrefix().getName());
 
     Assert.assertEquals(0, getBucketResponse.getContents().size());
 
@@ -99,11 +103,11 @@ public class TestBucketList {
 
     Assert.assertEquals(1, getBucketResponse.getCommonPrefixes().size());
     Assert.assertEquals("dir1/dir2/",
-        getBucketResponse.getCommonPrefixes().get(0).getPrefix());
+        getBucketResponse.getCommonPrefixes().get(0).getPrefix().getName());
 
     Assert.assertEquals(1, getBucketResponse.getContents().size());
     Assert.assertEquals("dir1/file2",
-        getBucketResponse.getContents().get(0).getKey());
+        getBucketResponse.getContents().get(0).getKey().getName());
 
   }
 
@@ -144,7 +148,7 @@ public class TestBucketList {
 
     Assert.assertEquals(3, getBucketResponse.getCommonPrefixes().size());
     Assert.assertEquals("file2", getBucketResponse.getContents().get(0)
-        .getKey());
+        .getKey().getName());
 
   }
 
@@ -240,9 +244,9 @@ public class TestBucketList {
     Assert.assertEquals(0, getBucketResponse.getContents().size());
     Assert.assertEquals(2, getBucketResponse.getCommonPrefixes().size());
     Assert.assertEquals("test/dir1/",
-        getBucketResponse.getCommonPrefixes().get(0).getPrefix());
+        getBucketResponse.getCommonPrefixes().get(0).getPrefix().getName());
     Assert.assertEquals("test/dir2/",
-        getBucketResponse.getCommonPrefixes().get(1).getPrefix());
+        getBucketResponse.getCommonPrefixes().get(1).getPrefix().getName());
 
     getBucketResponse =
         (ListObjectResponse) getBucket.get("b1", "/", null, null, maxKeys,
@@ -251,9 +255,9 @@ public class TestBucketList {
     Assert.assertEquals(1, getBucketResponse.getContents().size());
     Assert.assertEquals(1, getBucketResponse.getCommonPrefixes().size());
     Assert.assertEquals("test/dir3/",
-        getBucketResponse.getCommonPrefixes().get(0).getPrefix());
+        getBucketResponse.getCommonPrefixes().get(0).getPrefix().getName());
     Assert.assertEquals("test/file8",
-        getBucketResponse.getContents().get(0).getKey());
+        getBucketResponse.getContents().get(0).getKey().getName());
 
   }
 
@@ -361,6 +365,102 @@ public class TestBucketList {
     Assert.assertEquals(0, getBucketResponse.getContents().size());
 
 
+  }
+
+  @Test
+  public void testEncodingType() throws IOException, OS3Exception {
+    /*
+    * OP1 -> Create key "data=1970" and "data==1970" in a bucket
+    * OP2 -> List Object, if encodingType == url the result will be like blow:
+
+        <?xml version="1.0" encoding="UTF-8"?>
+          <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
+              ...
+              <Prefix>data%3D</Prefix>
+              <StartAfter>data%3D</StartAfter>
+              <Delimiter>%3D</Delimiter>
+              <EncodingType>url</EncodingType>
+              ...
+              <Contents>
+                  <Key>data%3D1970</Key>
+                  ....
+              </Contents>
+              <CommonPrefixes>
+                  <Prefix>data%3D%3D</Prefix>
+              </CommonPrefixes>
+          </ListBucketResult>
+
+      if encodingType == null , the = will not be encoded to "%3D"
+    * */
+
+    BucketEndpoint getBucket = new BucketEndpoint();
+    OzoneClient ozoneClient =
+        createClientWithKeys("data=1970", "data==1970");
+    getBucket.setClient(ozoneClient);
+
+    String delimiter = "=";
+    String prefix = "data=";
+    String startAfter = "data=";
+    String encodingType = ENCODING_TYPE;
+
+    ListObjectResponse response = (ListObjectResponse) getBucket.get(
+        "b1", delimiter, encodingType, null, 1000, prefix,
+        null, null, startAfter, null, null).getEntity();
+
+    // Assert encodingType == url.
+    // The Object name will be encoded by ObjectKeyNameAdapter
+    // if encodingType == url
+    assertEncodingTypeObject(delimiter, encodingType, response.getDelimiter());
+    assertEncodingTypeObject(prefix, encodingType, response.getPrefix());
+    assertEncodingTypeObject(startAfter, encodingType,
+        response.getStartAfter());
+    Assert.assertNotNull(response.getCommonPrefixes());
+    Assert.assertNotNull(response.getContents());
+    assertEncodingTypeObject(prefix + delimiter, encodingType,
+        response.getCommonPrefixes().get(0).getPrefix());
+    Assert.assertEquals(encodingType,
+        response.getContents().get(0).getKey().getEncodingType());
+
+    response = (ListObjectResponse) getBucket.get(
+        "b1", delimiter, null, null, 1000, prefix,
+        null, null, startAfter, null, null).getEntity();
+
+    // Assert encodingType == null.
+    // The Object name will not be encoded by ObjectKeyNameAdapter
+    // if encodingType == null
+    assertEncodingTypeObject(delimiter, null, response.getDelimiter());
+    assertEncodingTypeObject(prefix, null, response.getPrefix());
+    assertEncodingTypeObject(startAfter, null, response.getStartAfter());
+    Assert.assertNotNull(response.getCommonPrefixes());
+    Assert.assertNotNull(response.getContents());
+    assertEncodingTypeObject(prefix + delimiter, null,
+        response.getCommonPrefixes().get(0).getPrefix());
+    Assert.assertNull(response.getContents().get(0).getKey().getEncodingType());
+
+  }
+  @Test
+  public void testEncodingTypeException() throws IOException, OS3Exception {
+    BucketEndpoint getBucket = new BucketEndpoint();
+    OzoneClient client = new OzoneClientStub();
+    client.getObjectStore().createS3Bucket("b1");
+    getBucket.setClient(client);
+    try {
+      ListObjectResponse response = (ListObjectResponse) getBucket.get(
+          "b1", null, "unSupportType", null, 1000, null,
+          null, null, null, null, null).getEntity();
+      Assert.fail();
+    } catch (Exception e) {
+      Assert.assertTrue(e instanceof OS3Exception);
+      Assert.assertEquals(S3ErrorTable.INVALID_ARGUMENT.getCode(),
+          ((OS3Exception) e).getCode());
+    }
+
+  }
+
+  private void assertEncodingTypeObject(
+      String exceptName, String exceptEncodingType, EncodingTypeObject object) {
+    Assert.assertEquals(exceptName, object.getName());
+    Assert.assertEquals(exceptEncodingType, object.getEncodingType());
   }
 
   private OzoneClient createClientWithKeys(String... keys) throws IOException {

--- a/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestBucketList.java
+++ b/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestBucketList.java
@@ -405,7 +405,7 @@ public class TestBucketList {
 
     ListObjectResponse response = (ListObjectResponse) getBucket.get(
         "b1", delimiter, encodingType, null, 1000, prefix,
-        null, null, startAfter, null, null).getEntity();
+        null, startAfter, null, null, null).getEntity();
 
     // Assert encodingType == url.
     // The Object name will be encoded by ObjectKeyNameAdapter
@@ -423,7 +423,7 @@ public class TestBucketList {
 
     response = (ListObjectResponse) getBucket.get(
         "b1", delimiter, null, null, 1000, prefix,
-        null, null, startAfter, null, null).getEntity();
+        null, startAfter, null, null, null).getEntity();
 
     // Assert encodingType == null.
     // The Object name will not be encoded by ObjectKeyNameAdapter
@@ -438,6 +438,7 @@ public class TestBucketList {
     Assert.assertNull(response.getContents().get(0).getKey().getEncodingType());
 
   }
+
   @Test
   public void testEncodingTypeException() throws IOException, OS3Exception {
     BucketEndpoint getBucket = new BucketEndpoint();


### PR DESCRIPTION
## What changes were proposed in this pull request?
Support AWS s3 ListObjects API's encodingType request parameter

refer:
https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListObjectsV2.html#AmazonS3-ListObjectsV2-response-EncodingType


current Ozone will encode `key` and `prefix` in the `ListObjects` response in the default, however, the AWS s3 has a request parameter of `encoding-type` that can control whether to encode fields such as key in the response 

### Why do we need to add this feature
The Ozone default encoding key can cause some bugs
For example, when using go-SDK `ListObjectsV2`, the encoded key is returned instead of the original character.

this is the example code:
you can put some keys that contain special characters in the key name (such as `=`), execute this code and check the return value(`=` will become `%3d`), you will find that special characters are encoded. (If using this code to access AWS's s3 a correct name will be returned)
```golang
package main

import (
	"fmt"
	"github.com/aws/aws-sdk-go/aws"
	"github.com/aws/aws-sdk-go/aws/credentials"
	"github.com/aws/aws-sdk-go/aws/session"
	"github.com/aws/aws-sdk-go/service/s3"
)

const (
	AccessKeyID     = "id"
	SecretAccessKey = "key"
	BucketRegion    = "none"
	BucketName      = "bucket1"
	Endpoint        = "http://localhost:9878"
)

func ListItems(client *s3.S3, bucketName string, prefix string) (*s3.ListObjectsV2Output, error) {
	res, err := client.ListObjectsV2(&s3.ListObjectsV2Input{
		Bucket: aws.String(bucketName),
		Prefix: aws.String(prefix),
	})
	if err != nil {
		return nil, err
	}
	return res, nil
}

func main() {
	// create session
	sess := session.Must(session.NewSession(aws.NewConfig().
		WithRegion(BucketRegion).
		WithCredentials(credentials.NewStaticCredentials(AccessKeyID, SecretAccessKey, "")).
		WithEndpoint(Endpoint).
		WithS3ForcePathStyle(true)))
	s3session := s3.New(sess)
	prefixName := ""

	bucketObjects, err := ListItems(s3session, BucketName, prefixName)
	if err != nil {
		fmt.Printf("Couldn't retrieve bucket items: %v", err)
		return
	}

	for _, item := range bucketObjects.Contents {
		fmt.Printf("Name: %s, Last Modified: %s\n", *item.Key, *item.LastModified)
	}
}
```

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-7710

## How was this patch tested?


- create a bucket and put some keys 
```shell
[root@Linux /root/ozone-1.3.0-SNAPSHOT]% bin/ozone sh bucket create s3v/bucket1
[root@Linux /root/ozone-1.3.0-SNAPSHOT]% bin/ozone sh key put /s3v/bucket1/file=124 ~/testfile
[root@Linux /root/ozone-1.3.0-SNAPSHOT]% bin/ozone sh key put /s3v/bucket1/file==124 ~/testfile
[root@Linux /root/ozone-1.3.0-SNAPSHOT]
```

- Prepare a postman APP
- configure the postman APP's S3 Authorization
<img width="1260" alt="image" src="https://user-images.githubusercontent.com/32928346/209475686-a2840e47-f494-4a41-8610-16d05bd00b46.png">


- Create a `ListObjects` request using postman as shown below

If you specify the encoding-type request parameter, S3 includes this element in the response, and returns encoded key name values in the following response elements:

Get URL: `http://s3.localhost:9878/bucket1/?encoding-type=url&prefix=file=&start-after=file=&delimiter==&list-type=2`
<img width="974" alt="image" src="https://user-images.githubusercontent.com/32928346/209475244-e89e151a-bcce-4dea-98ed-3f2d687e4fae.png">

- Send the `ListObjects` request again, but without the `encodingtype` parameter


If you do not specify the encoding-type request parameter, Amazon S3 does not include this element in the response, and returns unencoded key name values in the following response elements:

Get URL: `http://s3.localhost:9878/bucket1/?prefix=file=&start-after=file=&delimiter==&list-type=2`
<img width="988" alt="image" src="https://user-images.githubusercontent.com/32928346/209475288-f76e4e46-d7e2-489f-b929-3bd121ecacf1.png">

- if the encoding-type request parameter is invalid
<img width="913" alt="image" src="https://user-images.githubusercontent.com/32928346/209475831-020d681f-16a3-41af-a3bb-bd74117e4a47.png">





### refer AWS s3's response:

I verified the AWS response using the postman

the key in the bucket
```shell
[root@VM-8-3-centos ~]$ aws s3 ls s3://pony-bucket1/
2022-12-23 15:08:39       2884 file=124
2022-12-23 15:19:23        234 file==hosts
[root@VM-8-3-centos ~]$
```

If you specify the encoding-type request parameter, Amazon S3 includes this element in the response, and returns encoded key name values in the following response elements:

`Delimiter`, `Prefix`, `Key`, and `StartAfter`.

<img width="1201" alt="image" src="https://user-images.githubusercontent.com/32928346/209474637-16961931-deb6-4924-b1e2-ec177e1e3629.png">

If you do not specify the encoding-type request parameter, Amazon S3 does not include this element in the response, and returns unencoded key name values in the following response elements:

<img width="1003" alt="image" src="https://user-images.githubusercontent.com/32928346/209474508-01d9898a-2436-42b4-8277-b1d3055fb60d.png">

if the encoding-type request parameter is invalid
<img width="929" alt="image" src="https://user-images.githubusercontent.com/32928346/209475771-fe2c4641-523e-4181-a7e5-1d98419fb3bd.png">



