### PR TITLE
HDDS-7715. Omit to serve pipelineInfo in listStatus API call

### DIFF
--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/KeyManagerImpl.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/KeyManagerImpl.java
@@ -1622,7 +1622,6 @@ public class KeyManagerImpl implements KeyManager {
     if (args.getLatestVersionLocation()) {
       slimLocationVersion(keyInfoList.toArray(new OmKeyInfo[0]));
     }
-    refreshPipeline(keyInfoList);
 
     if (args.getSortDatanodes()) {
       sortDatanodes(clientAddress, keyInfoList.toArray(new OmKeyInfo[0]));
@@ -1756,10 +1755,6 @@ public class KeyManagerImpl implements KeyManager {
     if (omKeyArgs.getLatestVersionLocation()) {
       slimLocationVersion(keyInfoList.toArray(new OmKeyInfo[0]));
     }
-    // refreshPipeline flag check has been removed as part of
-    // https://issues.apache.org/jira/browse/HDDS-3658.
-    // Please refer this jira for more details.
-    refreshPipeline(keyInfoList);
 
     if (omKeyArgs.getSortDatanodes()) {
       sortDatanodes(clientAddress, keyInfoList.toArray(new OmKeyInfo[0]));


### PR DESCRIPTION
## What changes were proposed in this pull request?
listStatus API in FSO buckets sometimes fails with a maximum IPC length exceeded error when a prefix has many or some large files. The problem is KeyLocation is potentially fat because it has unnecessary fields not needed to list keys such as pipeline info. This patch is omitting pipeline info in the KeyLocation entry to reduce the size of the KeyLocationList.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-7715

## How was this patch tested?
- triggered by CI
- manual tests via Ozone CLI; `ozone sh key list`
(Please explain how this patch was tested. Ex: unit tests, manual tests)
(If this patch involves UI changes, please attach a screen-shot; otherwise, remove this)
