### PR TITLE
HDDS-7716. Add ACL errors to OM audit logs for read requests

### DIFF
--- a/hadoop-hdds/common/src/test/java/org/apache/hadoop/ozone/audit/AuditLogTestUtils.java
+++ b/hadoop-hdds/common/src/test/java/org/apache/hadoop/ozone/audit/AuditLogTestUtils.java
@@ -15,10 +15,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.hadoop.ozone.utils;
-
-import org.apache.hadoop.ozone.audit.AuditAction;
-import org.apache.hadoop.ozone.audit.AuditEventStatus;
+package org.apache.hadoop.ozone.audit;
 
 import java.io.BufferedReader;
 import java.io.File;
@@ -32,10 +29,10 @@ import java.nio.file.Paths;
 /**
  * Utility class to read audit logs.
  */
-public final class AuditLogUtils {
+public final class AuditLogTestUtils {
   private static final String AUDITLOG_FILENAME = "audit.log";
 
-  private AuditLogUtils() {
+  private AuditLogTestUtils() {
   }
 
   /**

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOmAcls.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOmAcls.java
@@ -29,7 +29,7 @@ import org.apache.hadoop.ozone.security.acl.IAccessAuthorizer;
 import org.apache.hadoop.ozone.security.acl.IOzoneObj;
 import org.apache.hadoop.ozone.security.acl.OzoneObjInfo;
 import org.apache.hadoop.ozone.security.acl.RequestContext;
-import org.apache.hadoop.ozone.utils.AuditLogUtils;
+import org.apache.hadoop.ozone.audit.AuditLogTestUtils;
 import org.apache.ozone.test.GenericTestUtils;
 import org.junit.AfterClass;
 import org.junit.Before;
@@ -45,7 +45,7 @@ import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_ACL_AUTHORIZER_CLASS
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_ACL_ENABLED;
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_ADMINISTRATORS;
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_ADMINISTRATORS_WILDCARD;
-import static org.apache.hadoop.ozone.utils.AuditLogUtils.verifyAuditLog;
+import static org.apache.hadoop.ozone.audit.AuditLogTestUtils.verifyAuditLog;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -69,7 +69,7 @@ public class TestOmAcls {
   private static GenericTestUtils.LogCapturer logCapturer;
 
   static {
-    AuditLogUtils.enableAuditLog();
+    AuditLogTestUtils.enableAuditLog();
   }
 
   /**

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOmAcls.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOmAcls.java
@@ -16,38 +16,39 @@
  */
 package org.apache.hadoop.ozone.om;
 
-import java.util.ArrayList;
-import java.util.UUID;
-
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.ozone.MiniOzoneCluster;
-import org.apache.hadoop.ozone.OzoneTestUtils;
 import org.apache.hadoop.ozone.TestDataUtil;
-import org.apache.hadoop.ozone.client.BucketArgs;
+import org.apache.hadoop.ozone.audit.AuditEventStatus;
+import org.apache.hadoop.ozone.audit.OMAction;
+import org.apache.hadoop.ozone.client.ObjectStore;
 import org.apache.hadoop.ozone.client.OzoneBucket;
-import org.apache.hadoop.ozone.client.OzoneVolume;
-import org.apache.hadoop.ozone.client.VolumeArgs;
+import org.apache.hadoop.ozone.om.exceptions.OMException;
 import org.apache.hadoop.ozone.om.exceptions.OMException.ResultCodes;
 import org.apache.hadoop.ozone.security.acl.IAccessAuthorizer;
 import org.apache.hadoop.ozone.security.acl.IOzoneObj;
 import org.apache.hadoop.ozone.security.acl.OzoneObjInfo;
 import org.apache.hadoop.ozone.security.acl.RequestContext;
+import org.apache.hadoop.ozone.utils.AuditLogUtils;
 import org.apache.ozone.test.GenericTestUtils;
-
-import org.apache.commons.lang3.RandomStringUtils;
-import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_ACL_AUTHORIZER_CLASS;
-import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_ACL_ENABLED;
-import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_ADMINISTRATORS;
-import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_ADMINISTRATORS_WILDCARD;
 import org.junit.AfterClass;
-import static org.junit.Assert.assertTrue;
-
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 import org.junit.rules.Timeout;
+
+import java.util.ArrayList;
+import java.util.UUID;
+
+import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_ACL_AUTHORIZER_CLASS;
+import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_ACL_ENABLED;
+import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_ADMINISTRATORS;
+import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_ADMINISTRATORS_WILDCARD;
+import static org.apache.hadoop.ozone.utils.AuditLogUtils.verifyAuditLog;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
  * Test for Ozone Manager ACLs.
@@ -65,15 +66,11 @@ public class TestOmAcls {
   private static boolean keyAclAllow = true;
   private static boolean prefixAclAllow = true;
   private static MiniOzoneCluster cluster = null;
-  private static OMMetrics omMetrics;
-  private static OzoneConfiguration conf;
-  private static String clusterId;
-  private static String scmId;
-  private static String omId;
   private static GenericTestUtils.LogCapturer logCapturer;
 
-  @Rule
-  public ExpectedException exception = ExpectedException.none();
+  static {
+    AuditLogUtils.enableAuditLog();
+  }
 
   /**
    * Create a MiniDFSCluster for testing.
@@ -82,10 +79,10 @@ public class TestOmAcls {
    */
   @BeforeClass
   public static void init() throws Exception {
-    conf = new OzoneConfiguration();
-    clusterId = UUID.randomUUID().toString();
-    scmId = UUID.randomUUID().toString();
-    omId = UUID.randomUUID().toString();
+    OzoneConfiguration conf = new OzoneConfiguration();
+    String clusterId = UUID.randomUUID().toString();
+    String scmId = UUID.randomUUID().toString();
+    String omId = UUID.randomUUID().toString();
     conf.setBoolean(OZONE_ACL_ENABLED, true);
     conf.setClass(OZONE_ACL_AUTHORIZER_CLASS, OzoneAccessAuthorizerTest.class,
         IAccessAuthorizer.class);
@@ -96,14 +93,10 @@ public class TestOmAcls {
         .setOmId(omId)
         .build();
     cluster.waitForClusterToBeReady();
-    omMetrics = cluster.getOzoneManager().getMetrics();
     logCapturer =
         GenericTestUtils.LogCapturer.captureLogs(OzoneManager.getLogger());
   }
 
-  /**
-   * Shutdown MiniDFSCluster.
-   */
   @AfterClass
   public static void shutdown() {
     if (cluster != null) {
@@ -111,11 +104,10 @@ public class TestOmAcls {
     }
   }
 
-  /**
-   * Reset ACL.
-   */
   @Before
-  public void resetAcl() {
+  public void setup() {
+    logCapturer.clearOutput();
+
     TestOmAcls.volumeAclAllow = true;
     TestOmAcls.bucketAclAllow = true;
     TestOmAcls.keyAclAllow = true;
@@ -123,72 +115,101 @@ public class TestOmAcls {
   }
 
   @Test
-  public void testBucketCreationPermissionDenied() throws Exception {
+  public void testCreateVolumePermissionDenied() {
+    TestOmAcls.volumeAclAllow = false;
 
-    String volumeName = RandomStringUtils.randomAlphabetic(5).toLowerCase();
-    String bucketName = RandomStringUtils.randomAlphabetic(5).toLowerCase();
-
-    VolumeArgs createVolumeArgs = VolumeArgs.newBuilder()
-        .setOwner("user" + RandomStringUtils.randomNumeric(5))
-        .setAdmin("admin" + RandomStringUtils.randomNumeric(5))
-        .build();
-
-    cluster.getClient().getObjectStore().createVolume(volumeName,
-        createVolumeArgs);
-    OzoneVolume volume =
-        cluster.getClient().getObjectStore().getVolume(volumeName);
-
-    TestOmAcls.bucketAclAllow = false;
-    OzoneTestUtils.expectOmException(ResultCodes.PERMISSION_DENIED,
-        () -> volume.createBucket(bucketName));
+    OMException exception = assertThrows(OMException.class,
+            () -> TestDataUtil.createVolumeAndBucket(cluster));
+    assertEquals(ResultCodes.PERMISSION_DENIED, exception.getResult());
 
     assertTrue(logCapturer.getOutput()
-        .contains("doesn't have CREATE permission to access bucket"));
+            .contains("doesn't have CREATE permission to access volume"));
+    verifyAuditLog(OMAction.CREATE_VOLUME, AuditEventStatus.FAILURE);
   }
 
   @Test
-  public void testFailureInKeyOp() throws Exception {
-    final VolumeArgs createVolumeArgs;
-
+  public void testReadVolumePermissionDenied() throws Exception {
     OzoneBucket bucket = TestDataUtil.createVolumeAndBucket(cluster);
-    logCapturer.clearOutput();
+    TestOmAcls.volumeAclAllow = false;
+    ObjectStore objectStore = cluster.getClient().getObjectStore();
+    OMException exception = assertThrows(OMException.class, () ->
+            objectStore.getVolume(bucket.getVolumeName()));
+    assertEquals(ResultCodes.PERMISSION_DENIED, exception.getResult());
 
+    assertTrue(logCapturer.getOutput()
+            .contains("doesn't have READ permission to access volume"));
+    verifyAuditLog(OMAction.READ_VOLUME, AuditEventStatus.FAILURE);
+  }
+
+  @Test
+  public void testCreateBucketPermissionDenied() {
+    TestOmAcls.bucketAclAllow = false;
+
+    OMException exception = assertThrows(OMException.class,
+            () -> TestDataUtil.createVolumeAndBucket(cluster));
+    assertEquals(ResultCodes.PERMISSION_DENIED, exception.getResult());
+
+    assertTrue(logCapturer.getOutput()
+            .contains("doesn't have CREATE permission to access bucket"));
+    verifyAuditLog(OMAction.CREATE_BUCKET, AuditEventStatus.FAILURE);
+  }
+
+  @Test
+  public void testReadBucketPermissionDenied() throws Exception {
+    OzoneBucket bucket = TestDataUtil.createVolumeAndBucket(cluster);
+    TestOmAcls.bucketAclAllow = false;
+    ObjectStore objectStore = cluster.getClient().getObjectStore();
+    OMException exception = assertThrows(OMException.class,
+            () -> objectStore.getVolume(
+                    bucket.getVolumeName()).getBucket(bucket.getName())
+    );
+
+    assertEquals(ResultCodes.PERMISSION_DENIED, exception.getResult());
+    assertTrue(logCapturer.getOutput()
+            .contains("doesn't have READ permission to access bucket"));
+    verifyAuditLog(OMAction.READ_BUCKET, AuditEventStatus.FAILURE);
+  }
+
+  @Test
+  public void testCreateKeyPermissionDenied() throws Exception {
     TestOmAcls.keyAclAllow = false;
 
-    OzoneTestUtils.expectOmException(ResultCodes.PERMISSION_DENIED,
-        () -> TestDataUtil.createKey(bucket, "testKey", "testcontent"));
+    OzoneBucket bucket = TestDataUtil.createVolumeAndBucket(cluster);
+
+    OMException exception = assertThrows(OMException.class,
+            () -> TestDataUtil.createKey(bucket, "testKey", "testcontent"));
+    assertEquals(ResultCodes.PERMISSION_DENIED, exception.getResult());
     assertTrue(logCapturer.getOutput().contains("doesn't have CREATE " +
-        "permission to access key"));
+            "permission to access key"));
+  }
+
+  @Test
+  public void testReadKeyPermissionDenied() throws Exception {
+    OzoneBucket bucket = TestDataUtil.createVolumeAndBucket(cluster);
+    TestDataUtil.createKey(bucket, "testKey", "testcontent");
+
+    TestOmAcls.keyAclAllow = false;
+    OMException exception = assertThrows(OMException.class,
+            () -> TestDataUtil.getKey(bucket, "testKey"));
+
+    assertEquals(ResultCodes.PERMISSION_DENIED, exception.getResult());
+    assertTrue(logCapturer.getOutput().contains("doesn't have READ " +
+            "permission to access key"));
+    verifyAuditLog(OMAction.READ_KEY, AuditEventStatus.FAILURE);
   }
 
   @Test
   public void testSetACLPermissionDenied() throws Exception {
-
-    String volumeName = RandomStringUtils.randomAlphabetic(5).toLowerCase();
-    String bucketName = RandomStringUtils.randomAlphabetic(5).toLowerCase();
-
-    VolumeArgs createVolumeArgs = VolumeArgs.newBuilder()
-        .setOwner("user" + RandomStringUtils.randomNumeric(5))
-        .setAdmin("admin" + RandomStringUtils.randomNumeric(5))
-        .build();
-    BucketArgs createBucketArgs = BucketArgs.newBuilder()
-        .setOwner("user" + RandomStringUtils.randomNumeric(5))
-        .build();
-
-    cluster.getClient().getObjectStore().createVolume(volumeName,
-        createVolumeArgs);
-    OzoneVolume volume =
-        cluster.getClient().getObjectStore().getVolume(volumeName);
-    volume.createBucket(bucketName, createBucketArgs);
-
-    OzoneBucket bucket = volume.getBucket(bucketName);
+    OzoneBucket bucket = TestDataUtil.createVolumeAndBucket(cluster);
 
     TestOmAcls.bucketAclAllow = false;
-    OzoneTestUtils.expectOmException(ResultCodes.PERMISSION_DENIED,
-        () -> bucket.setAcl(new ArrayList<>()));
 
+    OMException exception = assertThrows(OMException.class,
+            () -> bucket.setAcl(new ArrayList<>()));
+    assertEquals(ResultCodes.PERMISSION_DENIED, exception.getResult());
     assertTrue(logCapturer.getOutput()
         .contains("doesn't have WRITE_ACL permission to access bucket"));
+    verifyAuditLog(OMAction.SET_ACL, AuditEventStatus.FAILURE);
   }
 
   /**

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/utils/AuditLogUtils.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/utils/AuditLogUtils.java
@@ -23,8 +23,11 @@ import org.apache.hadoop.ozone.audit.AuditEventStatus;
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileOutputStream;
-import java.io.FileReader;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 
 /**
  * Utility class to read audit logs.
@@ -48,8 +51,9 @@ public final class AuditLogUtils {
    */
   public static void verifyAuditLog(AuditAction action,
                                     AuditEventStatus eventStatus) {
-    File file = new File(AUDITLOG_FILENAME);
-    try (BufferedReader br = new BufferedReader(new FileReader(file))) {
+    Path file = Paths.get(AUDITLOG_FILENAME);
+    try (BufferedReader br = Files.newBufferedReader(file,
+            StandardCharsets.UTF_8)) {
       String line;
       while ((line = br.readLine()) != null) {
         if (line.contains(action.getAction()) &&

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/utils/AuditLogUtils.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/utils/AuditLogUtils.java
@@ -1,0 +1,78 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.ozone.utils;
+
+import org.apache.hadoop.ozone.audit.AuditAction;
+import org.apache.hadoop.ozone.audit.AuditEventStatus;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.FileReader;
+import java.io.IOException;
+
+/**
+ * Utility class to read audit logs.
+ */
+public final class AuditLogUtils {
+  private static final String AUDITLOG_FILENAME = "audit.log";
+
+  private AuditLogUtils() {
+  }
+
+  /**
+   * Enables audit logging for the mini ozone cluster. Must be called in static
+   * block of the test class before starting the cluster.
+   */
+  public static void enableAuditLog() {
+    System.setProperty("log4j.configurationFile", "auditlog.properties");
+  }
+
+  /**
+   * Searches for the given action in the audit log file.
+   */
+  public static void verifyAuditLog(AuditAction action,
+                                    AuditEventStatus eventStatus) {
+    File file = new File(AUDITLOG_FILENAME);
+    try (BufferedReader br = new BufferedReader(new FileReader(file))) {
+      String line;
+      while ((line = br.readLine()) != null) {
+        if (line.contains(action.getAction()) &&
+                line.contains(eventStatus.getStatus())) {
+          return;
+        }
+      }
+    } catch (Exception e) {
+      throw new AssertionError(e);
+    } finally {
+      truncateAuditLogFile();
+    }
+    throw new AssertionError("Audit log file doesn't contain " +
+            "the message with params  event=" + action.getAction() +
+            " result=" + eventStatus.getStatus());
+  }
+
+  private static void truncateAuditLogFile() {
+    File auditLogFile = new File(AUDITLOG_FILENAME);
+    try {
+      new FileOutputStream(auditLogFile).getChannel().truncate(0).close();
+    } catch (IOException e) {
+      System.out.println("Failed to truncate file: " + AUDITLOG_FILENAME);
+    }
+  }
+}

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
@@ -2826,20 +2826,19 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
     ResolvedBucket bucket = captureLatencyNs(
         perfMetrics.getLookupResolveBucketLatencyNs(),
         () -> resolveBucketLink(args));
-
-    if (isAclEnabled) {
-      captureLatencyNs(perfMetrics.getLookupAclCheckLatencyNs(),
-          () -> checkAcls(ResourceType.KEY, StoreType.OZONE, ACLType.READ,
-            bucket.realVolume(), bucket.realBucket(), args.getKeyName())
-      );
-    }
-
     boolean auditSuccess = true;
     Map<String, String> auditMap = bucket.audit(args.toAuditMap());
 
     OmKeyArgs resolvedArgs = bucket.update(args);
 
     try {
+      if (isAclEnabled) {
+        captureLatencyNs(perfMetrics.getLookupAclCheckLatencyNs(),
+                () -> checkAcls(ResourceType.KEY, StoreType.OZONE,
+                        ACLType.READ, bucket.realVolume(), bucket.realBucket(),
+                        args.getKeyName())
+        );
+      }
       metrics.incNumKeyLookups();
       return keyManager.lookupKey(resolvedArgs, getClientAddress());
     } catch (Exception ex) {

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
@@ -282,6 +282,7 @@ import static org.apache.hadoop.ozone.om.ratis.OzoneManagerRatisServer.getRaftGr
 import static org.apache.hadoop.ozone.protocol.proto.OzoneManagerInterServiceProtocolProtos.OzoneManagerInterService;
 import static org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OzoneManagerService;
 import static org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.PrepareStatusResponse.PrepareStatus;
+
 import org.apache.ratis.proto.RaftProtos.RaftPeerRole;
 import org.apache.ratis.protocol.RaftGroupId;
 import org.apache.ratis.protocol.RaftPeer;
@@ -2609,14 +2610,13 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
    */
   @Override
   public OmVolumeArgs getVolumeInfo(String volume) throws IOException {
-    if (isAclEnabled) {
-      checkAcls(ResourceType.VOLUME, StoreType.OZONE, ACLType.READ, volume,
-          null, null);
-    }
-
     boolean auditSuccess = true;
     Map<String, String> auditMap = buildAuditMap(volume);
     try {
+      if (isAclEnabled) {
+        checkAcls(ResourceType.VOLUME, StoreType.OZONE, ACLType.READ, volume,
+                null, null);
+      }
       metrics.incNumVolumeInfos();
       return volumeManager.getVolumeInfo(volume);
     } catch (Exception ex) {
@@ -2748,10 +2748,6 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
   public List<OmBucketInfo> listBuckets(String volumeName,
       String startKey, String prefix, int maxNumOfBuckets)
       throws IOException {
-    if (isAclEnabled) {
-      checkAcls(ResourceType.VOLUME, StoreType.OZONE, ACLType.LIST, volumeName,
-          null, null);
-    }
     boolean auditSuccess = true;
     Map<String, String> auditMap = buildAuditMap(volumeName);
     auditMap.put(OzoneConsts.START_KEY, startKey);
@@ -2759,6 +2755,10 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
     auditMap.put(OzoneConsts.MAX_NUM_OF_BUCKETS,
         String.valueOf(maxNumOfBuckets));
     try {
+      if (isAclEnabled) {
+        checkAcls(ResourceType.VOLUME, StoreType.OZONE, ACLType.LIST,
+                volumeName, null, null);
+      }
       metrics.incNumBucketLists();
       return bucketManager.listBuckets(volumeName,
           startKey, prefix, maxNumOfBuckets);
@@ -2787,14 +2787,14 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
   @Override
   public OmBucketInfo getBucketInfo(String volume, String bucket)
       throws IOException {
-    if (isAclEnabled) {
-      checkAcls(ResourceType.BUCKET, StoreType.OZONE, ACLType.READ, volume,
-          bucket, null);
-    }
     boolean auditSuccess = true;
     Map<String, String> auditMap = buildAuditMap(volume);
     auditMap.put(OzoneConsts.BUCKET, bucket);
     try {
+      if (isAclEnabled) {
+        checkAcls(ResourceType.BUCKET, StoreType.OZONE, ACLType.READ, volume,
+                bucket, null);
+      }
       metrics.incNumBucketInfos();
       final OmBucketInfo bucketInfo =
           bucketManager.getBucketInfo(volume, bucket);
@@ -2882,17 +2882,18 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
         perfMetrics.getGetKeyInfoResolveBucketLatencyNs(),
         () -> resolveBucketLink(resolvedVolumeArgs));
 
-    if (isAclEnabled) {
-      captureLatencyNs(perfMetrics.getGetKeyInfoAclCheckLatencyNs(), () ->
-          checkAcls(ResourceType.KEY, StoreType.OZONE, ACLType.READ,
-              bucket.realVolume(), bucket.realBucket(), args.getKeyName())
-      );
-    }
-
     boolean auditSuccess = true;
     OmKeyArgs resolvedArgs = bucket.update(args);
 
     try {
+      if (isAclEnabled) {
+        captureLatencyNs(perfMetrics.getGetKeyInfoAclCheckLatencyNs(), () ->
+                checkAcls(ResourceType.KEY, StoreType.OZONE,
+                        ACLType.READ, bucket.realVolume(),
+                        bucket.realBucket(), args.getKeyName())
+        );
+      }
+
       metrics.incNumGetKeyInfo();
       OmKeyInfo keyInfo =
           keyManager.getKeyInfo(resolvedArgs, getClientAddress());
@@ -2925,11 +2926,6 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
 
     ResolvedBucket bucket = resolveBucketLink(Pair.of(volumeName, bucketName));
 
-    if (isAclEnabled) {
-      checkAcls(ResourceType.BUCKET, StoreType.OZONE, ACLType.LIST,
-          bucket.realVolume(), bucket.realBucket(), keyPrefix);
-    }
-
     boolean auditSuccess = true;
     Map<String, String> auditMap = bucket.audit();
     auditMap.put(OzoneConsts.START_KEY, startKey);
@@ -2937,6 +2933,10 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
     auditMap.put(OzoneConsts.KEY_PREFIX, keyPrefix);
 
     try {
+      if (isAclEnabled) {
+        checkAcls(ResourceType.BUCKET, StoreType.OZONE, ACLType.LIST,
+                bucket.realVolume(), bucket.realBucket(), keyPrefix);
+      }
       metrics.incNumKeyLists();
       return keyManager.listKeys(bucket.realVolume(), bucket.realBucket(),
           startKey, keyPrefix, maxKeys);
@@ -2958,22 +2958,17 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
   public List<RepeatedOmKeyInfo> listTrash(String volumeName,
       String bucketName, String startKeyName, String keyPrefix, int maxKeys)
       throws IOException {
-
-    // bucket links not supported
-
-    if (isAclEnabled) {
-      checkAcls(ResourceType.BUCKET, StoreType.OZONE, ACLType.LIST,
-          volumeName, bucketName, keyPrefix);
-    }
-
     boolean auditSuccess = true;
     Map<String, String> auditMap = buildAuditMap(volumeName);
     auditMap.put(OzoneConsts.BUCKET, bucketName);
     auditMap.put(OzoneConsts.START_KEY, startKeyName);
     auditMap.put(OzoneConsts.KEY_PREFIX, keyPrefix);
     auditMap.put(OzoneConsts.MAX_KEYS, String.valueOf(maxKeys));
-
     try {
+      if (isAclEnabled) {
+        checkAcls(ResourceType.BUCKET, StoreType.OZONE, ACLType.LIST,
+                volumeName, bucketName, keyPrefix);
+      }
       metrics.incNumTrashKeyLists();
       return keyManager.listTrash(volumeName, bucketName,
           startKeyName, keyPrefix, maxKeys);
@@ -3599,17 +3594,16 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
   public OmKeyInfo lookupFile(OmKeyArgs args) throws IOException {
     ResolvedBucket bucket = resolveBucketLink(args);
 
-    if (isAclEnabled) {
-      checkAcls(ResourceType.KEY, StoreType.OZONE, ACLType.READ,
-          bucket.realVolume(), bucket.realBucket(), args.getKeyName());
-    }
-
     boolean auditSuccess = true;
     Map<String, String> auditMap = bucket.audit(args.toAuditMap());
 
     args = bucket.update(args);
 
     try {
+      if (isAclEnabled) {
+        checkAcls(ResourceType.KEY, StoreType.OZONE, ACLType.READ,
+                bucket.realVolume(), bucket.realBucket(), args.getKeyName());
+      }
       metrics.incNumLookupFile();
       return keyManager.lookupFile(args, getClientAddress());
     } catch (Exception ex) {
@@ -3645,17 +3639,16 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
 
     ResolvedBucket bucket = resolveBucketLink(args);
 
-    if (isAclEnabled) {
-      checkAcls(getResourceType(args), StoreType.OZONE, ACLType.READ,
-          bucket.realVolume(), bucket.realBucket(), args.getKeyName());
-    }
-
     boolean auditSuccess = true;
     Map<String, String> auditMap = bucket.audit(args.toAuditMap());
 
     args = bucket.update(args);
 
     try {
+      if (isAclEnabled) {
+        checkAcls(getResourceType(args), StoreType.OZONE, ACLType.READ,
+                bucket.realVolume(), bucket.realBucket(), args.getKeyName());
+      }
       metrics.incNumListStatus();
       return keyManager.listStatus(args, recursive, startKey,
           maxListingPageSize, getClientAddress(), allowPartialPrefixes);


### PR DESCRIPTION
## What changes were proposed in this pull request?

adding log entries to OM audit log in case a request is prohibited by ACL policies. Also, a way of testing audit logs is added along with integration tests (see AuditLogUtils.class).

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-7716

## How was this patch tested?

* local unit tests run, 
* integration tests were added,
* deployed modified jars to dev server to ensure that log entries have been added
