### PR TITLE
HDDS-7714. Docker cluster ozone-om-ha fails during docker-compose up

### DIFF
--- a/hadoop-ozone/dist/src/main/compose/ozone-om-ha/docker-compose.yaml
+++ b/hadoop-ozone/dist/src/main/compose/ozone-om-ha/docker-compose.yaml
@@ -20,6 +20,7 @@ services:
       build:
          context: .
          args:
+            - OZONE_RUNNER_IMAGE
             - OZONE_RUNNER_VERSION
       image: ozone-runner-om-ha:${OZONE_RUNNER_VERSION}
       privileged: true #required by the profiler
@@ -34,6 +35,7 @@ services:
       build:
          context: .
          args:
+            - OZONE_RUNNER_IMAGE
             - OZONE_RUNNER_VERSION
       image: ozone-runner-om-ha:${OZONE_RUNNER_VERSION}
       privileged: true #required by the profiler
@@ -51,6 +53,7 @@ services:
       build:
          context: .
          args:
+            - OZONE_RUNNER_IMAGE
             - OZONE_RUNNER_VERSION
       image: ozone-runner-om-ha:${OZONE_RUNNER_VERSION}
       privileged: true #required by the profiler
@@ -68,6 +71,7 @@ services:
       build:
          context: .
          args:
+            - OZONE_RUNNER_IMAGE
             - OZONE_RUNNER_VERSION
       image: ozone-runner-om-ha:${OZONE_RUNNER_VERSION}
       privileged: true #required by the profiler
@@ -85,6 +89,7 @@ services:
       build:
          context: .
          args:
+            - OZONE_RUNNER_IMAGE
             - OZONE_RUNNER_VERSION
       image: ozone-runner-om-ha:${OZONE_RUNNER_VERSION}
       privileged: true #required by the profiler


### PR DESCRIPTION
## What changes were proposed in this pull request?

`ozone-om-ha` uses a temporary Docker image based on top of the regular `ozone-runner` images.

HDDS-6293 added support for custom `ozone-runner` image, but the change had a bug: `OZONE_RUNNER_IMAGE` variable was not passed to the Docker build context in `ozone-om-ha`.  This was not noticed as this test is disabled due to flakiness.

Compare to `ozonescripts` environment, which also uses its own derived image.

https://issues.apache.org/jira/browse/HDDS-7714

## How was this patch tested?

```
$ cd hadoop-ozone/dist/target/ozone-1.3.0-SNAPSHOT/compose/ozone-om-ha
$ docker-compose up -d
Building datanode
Sending build context to Docker daemon  29.18kB
Step 1/23 : ARG OZONE_RUNNER_IMAGE
Step 2/23 : ARG OZONE_RUNNER_VERSION
Step 3/23 : FROM ${OZONE_RUNNER_IMAGE}:${OZONE_RUNNER_VERSION}
 ---> 2f81b649e1b7
Step 4/23 : RUN sudo yum install -y openssh-clients openssh-server
 ---> Running in 61a7cb57a64c
...
Successfully built 9667608351f9
Successfully tagged ozone-runner-om-ha:20220623-1
WARNING: Image for service datanode was built because it did not already exist. To rebuild this image you must use `docker-compose build` or `docker-compose up --build`.
Creating ozone-om-ha_om2_1      ... done
Creating ozone-om-ha_scm_1      ... done
Creating ozone-om-ha_om3_1      ... done
Creating ozone-om-ha_om1_1      ... done
Creating ozone-om-ha_datanode_1 ... done
```