### PR TITLE
HDDS-5934. Add OM NodeID to VERSION file.

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerConfiguration.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerConfiguration.java
@@ -83,6 +83,7 @@ public class TestOzoneManagerConfiguration {
         RATIS_RPC_TIMEOUT, TimeUnit.MILLISECONDS);
     OMStorage omStore = new OMStorage(conf);
     omStore.setClusterId("testClusterId");
+    omStore.setOmNodeId(OzoneConsts.OM_DEFAULT_NODE_ID, false);
     // writes the version file properties
     omStore.initialize();
   }
@@ -485,5 +486,28 @@ public class TestOzoneManagerConfiguration {
   private String getOMAddrKeyWithSuffix(String serviceId, String nodeId) {
     return ConfUtils.addKeySuffixes(OMConfigKeys.OZONE_OM_ADDRESS_KEY,
         serviceId, nodeId);
+  }
+
+  /**
+   * Re-initializing OMStorage with new nodeId should fail.
+   */
+  @Test
+  public void testChangeOMNodeId() throws Exception {
+    OMStorage omStore = new OMStorage(conf);
+    // As the OMStorage is already initialized in the setup, the nodeId
+    // must be set to the default OM NodeId - om1.
+    Assert.assertEquals(OzoneConsts.OM_DEFAULT_NODE_ID, omStore.getOmNodeId());
+
+    // Setting NodeId to a different value should throw an IOException
+    String newNodeId = "om1-hash";
+    try {
+      omStore.setOmNodeId(newNodeId, false);
+      Assert.fail("Setting new OM NodeId should fail.");
+    } catch (IOException e) {
+      String expectedErrorMsg = "OM NodeId: " + newNodeId + " does not match " +
+          "existing nodeId from VERSION file: " +
+          OzoneConsts.OM_DEFAULT_NODE_ID;
+      Assert.assertEquals(expectedErrorMsg, e.getLocalizedMessage());
+    }
   }
 }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerConfiguration.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerConfiguration.java
@@ -83,7 +83,6 @@ public class TestOzoneManagerConfiguration {
         RATIS_RPC_TIMEOUT, TimeUnit.MILLISECONDS);
     OMStorage omStore = new OMStorage(conf);
     omStore.setClusterId("testClusterId");
-    omStore.setOmNodeId(OzoneConsts.OM_DEFAULT_NODE_ID);
     // writes the version file properties
     omStore.initialize();
   }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerConfiguration.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerConfiguration.java
@@ -83,7 +83,7 @@ public class TestOzoneManagerConfiguration {
         RATIS_RPC_TIMEOUT, TimeUnit.MILLISECONDS);
     OMStorage omStore = new OMStorage(conf);
     omStore.setClusterId("testClusterId");
-    omStore.setOmNodeId(OzoneConsts.OM_DEFAULT_NODE_ID, false);
+    omStore.setOmNodeId(OzoneConsts.OM_DEFAULT_NODE_ID);
     // writes the version file properties
     omStore.initialize();
   }
@@ -486,28 +486,5 @@ public class TestOzoneManagerConfiguration {
   private String getOMAddrKeyWithSuffix(String serviceId, String nodeId) {
     return ConfUtils.addKeySuffixes(OMConfigKeys.OZONE_OM_ADDRESS_KEY,
         serviceId, nodeId);
-  }
-
-  /**
-   * Re-initializing OMStorage with new nodeId should fail.
-   */
-  @Test
-  public void testChangeOMNodeId() throws Exception {
-    OMStorage omStore = new OMStorage(conf);
-    // As the OMStorage is already initialized in the setup, the nodeId
-    // must be set to the default OM NodeId - om1.
-    Assert.assertEquals(OzoneConsts.OM_DEFAULT_NODE_ID, omStore.getOmNodeId());
-
-    // Setting NodeId to a different value should throw an IOException
-    String newNodeId = "om1-hash";
-    try {
-      omStore.setOmNodeId(newNodeId, false);
-      Assert.fail("Setting new OM NodeId should fail.");
-    } catch (IOException e) {
-      String expectedErrorMsg = "OM NodeId: " + newNodeId + " does not match " +
-          "existing nodeId from VERSION file: " +
-          OzoneConsts.OM_DEFAULT_NODE_ID;
-      Assert.assertEquals(expectedErrorMsg, e.getLocalizedMessage());
-    }
   }
 }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OMStorage.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OMStorage.java
@@ -40,6 +40,7 @@ public class OMStorage extends Storage {
   public static final String STORAGE_DIR = "om";
   public static final String OM_ID = "omUuid";
   public static final String OM_CERT_SERIAL_ID = "omCertSerialId";
+  public static final String OM_NODE_ID = "nodeId";
 
   /**
    * Construct OMStorage.
@@ -68,11 +69,51 @@ public class OMStorage extends Storage {
   }
 
   /**
+   * Set the OM NodeId property.
+   * @param nodeId OM NodeId
+   * @param persistToDisk if true, persist the nodeId to VERSION file if not
+   *                      already present
+   * @throws IOException if existing nodeId from VERSION file does not match
+   * the new nodeId.
+   */
+  public void setOmNodeId(String nodeId, boolean persistToDisk)
+      throws IOException {
+    String nodeIdFromDisk = getOmNodeId();
+    if (nodeIdFromDisk != null) {
+      // Verify the existing NodeId from VERSION file equals that from the
+      // configuration
+      if (!nodeIdFromDisk.equals(nodeId)) {
+        throw new IOException("OM NodeId: " + nodeId + " does not match " +
+            "existing nodeId from VERSION file: " + nodeIdFromDisk);
+      } else {
+        // NodeId is already set correctly.
+        return;
+      }
+    }
+
+    getStorageInfo().setProperty(OM_NODE_ID, nodeId);
+
+    if (persistToDisk) {
+      // Current VERSION file does not have the nodeId. Persist the nodeId to
+      // disk.
+      persistCurrentState();
+    }
+  }
+
+  /**
    * Retrieves the OM ID from the version file.
    * @return OM_ID
    */
   public String getOmId() {
     return getStorageInfo().getProperty(OM_ID);
+  }
+
+  /**
+   * Retrieves the OM NodeId from the version file.
+   * @return OM_NODE_ID
+   */
+  public String getOmNodeId() {
+    return getStorageInfo().getProperty(OM_NODE_ID);
   }
 
   /**
@@ -91,6 +132,10 @@ public class OMStorage extends Storage {
     }
     Properties omProperties = new Properties();
     omProperties.setProperty(OM_ID, omId);
+    String nodeId = getOmNodeId();
+    if (nodeId != null) {
+      omProperties.setProperty(OM_NODE_ID, nodeId);
+    }
 
     if (getOmCertSerialId() != null) {
       omProperties.setProperty(OM_CERT_SERIAL_ID, getOmCertSerialId());

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OMStorage.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OMStorage.java
@@ -150,15 +150,14 @@ public class OMStorage extends Storage {
   }
 
   /**
-   * Validates if the provided value is saved to the VERSION file.
-   * As this property was added to the VERSION file later on, this method
-   * provides a convenience to check if the configured value and the one that
-   * was stored in the VERSION file are matching, and to make it easy to ensure
-   * that the VERSION file contains this value when starting Ozone Manager for
-   * the first time after the code changes have been applied.
+   * Validates if the provided value is the one saved in the VERSION file.
+   * This method provides a convenience to check if the configured value and
+   * the one that was stored in the VERSION file are matching.
    *
-   * This method persist the value provided if it is not present in the
-   * VERSION file already, and in this case does not throw an exception.
+   * As a VERSION file that was created by an older version of OM might not
+   * contain the value, if the VERSION file does not have this property, the
+   * method persists the provided expectedNodeId into the VERSION file
+   * and skips the validation.
    *
    * @param expectedNodeId the nodeId read from configuration, that has to be
    *                       matched against what we have saved in the VERSION
@@ -169,6 +168,20 @@ public class OMStorage extends Storage {
    *                     - if the VERSION file contains a different value than
    *                        the expectedNodeId provided
    *                     - if reading/writing the VERSION file fails
+   */
+  /* Note that we have other options as well to handle this case, but at this
+   * time this seemed to be a good tradeoff.
+   * Other options:
+   *   1. Use the Upgrade framework and bump Layout version.
+   *     Excessive work, and the addition, with that the verification happens
+   *     too late, after a bunch of things has been initialized, and there
+   *     might be possible problems from the late validation.
+   *   2. Write the value during omInit only as with anything added earlier
+   *     Seems to be error-prone, as without re-initializing the OM, the value
+   *     will not get to the VERSION file, and validation will fail.
+   * This approach has the potential to scatter OzoneManager constructor call,
+   *   so if anything like this one is to be implemented, try to figure out
+   *   a better way, or switch to another approach if feasible.
    */
   public void validateOrPersistOmNodeId(String expectedNodeId)
       throws IOException {

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OMStorage.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OMStorage.java
@@ -32,19 +32,46 @@ import org.apache.hadoop.ozone.om.upgrade.OMLayoutVersionManager;
 import static org.apache.hadoop.ozone.om.OmUpgradeConfig.ConfigStrings.OZONE_OM_INIT_DEFAULT_LAYOUT_VERSION;
 
 /**
- * OMStorage is responsible for management of the StorageDirectories used by
- * the Ozone Manager.
+ * Ozone Manager VERSION file representation.
+ * On top of what is defined in the base Storage class, this class adds
+ * functionality to hold Ozone Manager related data in its VERSION file.
+ * The additional values stored:
+ * - Ozone Manager ID - a UUID that identifies this Ozone Manager.
+ *                      The value can not be changed once initialized.
+ * - Ozone Manager Node Id - the node id defined for this Ozone manager in the
+ *                           configuration. The value can not be changed after
+ *                           it was set.
+ * - Ozone Manager Certificate Serial Id - the serial id of the Ozone Manager's
+ *                                         SSL certificate if one exists.
  */
 public class OMStorage extends Storage {
 
-  public static final String STORAGE_DIR = "om";
-  public static final String OM_ID = "omUuid";
-  public static final String OM_CERT_SERIAL_ID = "omCertSerialId";
-  public static final String OM_NODE_ID = "nodeId";
+  static final String ERROR_OM_IS_ALREADY_INITIALIZED =
+      "OM is already initialized.";
+  static final String ERROR_UNEXPECTED_OM_NODE_ID_TEMPLATE =
+      "OM NodeId: {} does not match existing nodeId from VERSION file: {}";
+  static final String ERROR_STORAGE_NOT_INITIALIZED =
+      "OM Storage is not initialized yet.";
+
+  static final String STORAGE_DIR = "om";
+  static final String OM_ID = "omUuid";
+  static final String OM_CERT_SERIAL_ID = "omCertSerialId";
+  static final String OM_NODE_ID = "nodeId";
 
   /**
-   * Construct OMStorage.
+   * Construct the OMStorage instance based on the configuration.
+   * The parent directory used by the storage is defined by the
+   * {@link OMConfigKeys#OZONE_OM_DB_DIRS} property, if that is not set the
+   * {@link org.apache.hadoop.hdds.HddsConfigKeys#OZONE_METADATA_DIRS} property
+   * value is used as a fallback. If none of these are defined in the
+   * configuration an IllegalArgumentException is being thrown.
+   *
+   * @param conf an OzoneConfiguration instance containing the properties that
+   *             can define the path where Ozone Manager stores its metadata
+   *
    * @throws IOException if any directories are inaccessible.
+   * @throws IllegalArgumentException if the configuration does not specify the
+   *                               path where the metadata should be stored
    */
   public OMStorage(OzoneConfiguration conf) throws IOException {
     super(NodeType.OM, getOmDbDir(conf), STORAGE_DIR,
@@ -52,57 +79,113 @@ public class OMStorage extends Storage {
             OMLayoutVersionManager::maxLayoutVersion));
   }
 
+  /**
+   * Sets the certificate serial id to be stored in the VERSION file
+   * representation.
+   * Note that, to change the VERSION file itself,
+   * {@link #persistCurrentState()} has to be called after this method.
+   *
+   * @param certSerialId the new certificate serial id to set
+   *
+   * @throws IOException if the current VERSION file is not readable
+   */
   public void setOmCertSerialId(String certSerialId) throws IOException {
     getStorageInfo().setProperty(OM_CERT_SERIAL_ID, certSerialId);
   }
 
-  public void unsetOmCertSerialId() throws IOException {
+  /**
+   * Removes the certificate serial id from the VERSION file representation.
+   * Note that, to change the VERSION file itself,
+   * {@link #persistCurrentState()} has to be called after this method.
+   */
+  public void unsetOmCertSerialId() {
     getStorageInfo().unsetProperty(OM_CERT_SERIAL_ID);
   }
 
+  /**
+   * Set's the Ozone Manager ID to be stored in the VERSION file representation.
+   * Note that, to change the VERSION file itself,
+   * {@link #persistCurrentState()} has to be called after this method.
+   *
+   * @param omId the UUID that identifies this Ozone Manager as a String
+   *
+   * @throws IOException if the Storage representation is already initialized,
+   *                     as this property can not be changed once it has been
+   *                     set and stored
+   */
   public void setOmId(String omId) throws IOException {
     if (getState() == StorageState.INITIALIZED) {
-      throw new IOException("OM is already initialized.");
+      throw new IOException(ERROR_OM_IS_ALREADY_INITIALIZED);
     } else {
       getStorageInfo().setProperty(OM_ID, omId);
     }
   }
 
   /**
-   * Set the OM NodeId property.
-   * @param nodeId OM NodeId
-   * @param persistToDisk if true, persist the nodeId to VERSION file if not
-   *                      already present
-   * @throws IOException if existing nodeId from VERSION file does not match
-   * the new nodeId.
+   * Set's the Ozone Manager Node ID.
+   * This value should be set based on the configuration and should not be
+   * changed later on neither in the configuration nor in the VERSION file
+   * to ensure consistency within the Ozone Manager HA peers.
+   *
+   * Note that, to change the VERSION file itself,
+   * {@link #persistCurrentState()} has to be called after this method.
+   *
+   * @param nodeId the UUID that identifies this Ozone Manager as a String
+   *
+   * @throws IOException if the Storage representation is already initialized,
+   *                     as this property can not be changed once it has been
+   *                     set and stored.
    */
-  public void setOmNodeId(String nodeId, boolean persistToDisk)
+  public void setOmNodeId(String nodeId)
       throws IOException {
-    String nodeIdFromDisk = getOmNodeId();
-    if (nodeIdFromDisk != null) {
-      // Verify the existing NodeId from VERSION file equals that from the
-      // configuration
-      if (!nodeIdFromDisk.equals(nodeId)) {
-        throw new IOException("OM NodeId: " + nodeId + " does not match " +
-            "existing nodeId from VERSION file: " + nodeIdFromDisk);
-      } else {
-        // NodeId is already set correctly.
-        return;
-      }
+    if (getState() == StorageState.INITIALIZED) {
+      throw new IOException(ERROR_OM_IS_ALREADY_INITIALIZED);
+    } else {
+      getStorageInfo().setProperty(OM_NODE_ID, nodeId);
     }
+  }
 
-    getStorageInfo().setProperty(OM_NODE_ID, nodeId);
-
-    if (persistToDisk) {
-      // Current VERSION file does not have the nodeId. Persist the nodeId to
-      // disk.
+  /**
+   * Validates if the provided value is saved to the VERSION file.
+   * As this property was added to the VERSION file later on, this method
+   * provides a convenience to check if the configured value and the one that
+   * was stored in the VERSION file are matching, and to make it easy to ensure
+   * that the VERSION file contains this value when starting Ozone Manager for
+   * the first time after the code changes have been applied.
+   *
+   * This method persist the value provided if it is not present in the
+   * VERSION file already, and in this case does not throw an exception.
+   *
+   * @param expectedNodeId the nodeId read from configuration, that has to be
+   *                       matched against what we have saved in the VERSION
+   *                       file
+   *
+   * @throws IOException - if the VERSION file is not present at the time of the
+   *                        call
+   *                     - if the VERSION file contains a different value than
+   *                        the expectedNodeId provided
+   *                     - if reading/writing the VERSION file fails
+   */
+  public void validateOrPersistOmNodeId(String expectedNodeId)
+      throws IOException {
+    if (getState() != StorageState.INITIALIZED) {
+      throw new IOException(ERROR_STORAGE_NOT_INITIALIZED);
+    }
+    String ourValue = getOmNodeId();
+    if (ourValue != null && !ourValue.equals(expectedNodeId)) {
+      String msg = String.format(
+          ERROR_UNEXPECTED_OM_NODE_ID_TEMPLATE, expectedNodeId, ourValue);
+      throw new IOException(msg);
+    } else {
+      getStorageInfo().setProperty(OM_NODE_ID, expectedNodeId);
       persistCurrentState();
     }
   }
 
   /**
    * Retrieves the OM ID from the version file.
-   * @return OM_ID
+   *
+   * @return the stored OM ID
    */
   public String getOmId() {
     return getStorageInfo().getProperty(OM_ID);
@@ -110,7 +193,8 @@ public class OMStorage extends Storage {
 
   /**
    * Retrieves the OM NodeId from the version file.
-   * @return OM_NODE_ID
+   *
+   * @return the stored OM Node ID
    */
   public String getOmNodeId() {
     return getStorageInfo().getProperty(OM_NODE_ID);
@@ -118,7 +202,8 @@ public class OMStorage extends Storage {
 
   /**
    * Retrieves the serial id of certificate issued by SCM.
-   * @return OM_ID
+   *
+   * @return the stored Certificate Serial ID
    */
   public String getOmCertSerialId() {
     return getStorageInfo().getProperty(OM_CERT_SERIAL_ID);
@@ -144,11 +229,20 @@ public class OMStorage extends Storage {
   }
 
   /**
-   * Get the location where OM should store its metadata directories.
-   * Fall back to OZONE_METADATA_DIRS if not defined.
+   * From the provided configuration gets the directory that Ozone Manager
+   * should use to store its metadata.
+   * The value of {@link OMConfigKeys#OZONE_OM_DB_DIRS} property is returned
+   * as the primary value, if that is not set, the method falls back to the
+   * {@link org.apache.hadoop.hdds.HddsConfigKeys#OZONE_METADATA_DIRS} property.
+   * If none of these are defined, an IllegalArgumentException is being thrown.
    *
-   * @param conf - Config
-   * @return File path, after creating all the required Directories.
+   * @param conf - the configuration to get the properties from
+   *
+   * @return The metadata directory path, that should be used by OM, after
+   *         creating all the necessary directories
+   *
+   * @throws IllegalArgumentException if the metadata directory can not be
+   *                                  determined from the configuration
    */
   public static File getOmDbDir(ConfigurationSource conf) {
     return ServerUtils.getDBPath(conf, OMConfigKeys.OZONE_OM_DB_DIRS);

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OMStorage.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OMStorage.java
@@ -37,7 +37,11 @@ import static org.apache.hadoop.ozone.om.OmUpgradeConfig.ConfigStrings.OZONE_OM_
  * functionality to hold Ozone Manager related data in its VERSION file.
  * The additional values stored:
  * - Ozone Manager ID - a UUID that identifies this Ozone Manager.
- *                      The value can not be changed once initialized.
+ *                      The value can not be changed once initialized, and
+ *                      it is initialized automatically in this class.
+ *                      The value itself is not used anymore, it is part of the
+ *                      {@link org.apache.hadoop.hdds.protocol.proto.HddsProtos
+ *                      .OzoneManagerDetailsProto} hence not removed yet.
  * - Ozone Manager Node Id - the node id defined for this Ozone manager in the
  *                           configuration. The value can not be changed after
  *                           it was set.
@@ -49,7 +53,7 @@ public class OMStorage extends Storage {
   static final String ERROR_OM_IS_ALREADY_INITIALIZED =
       "OM is already initialized.";
   static final String ERROR_UNEXPECTED_OM_NODE_ID_TEMPLATE =
-      "OM NodeId: {} does not match existing nodeId from VERSION file: {}";
+      "OM NodeId: %s does not match existing nodeId from VERSION file: %s";
   static final String ERROR_STORAGE_NOT_INITIALIZED =
       "OM Storage is not initialized yet.";
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
@@ -454,7 +454,7 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
     this.omNodeDetails = omhaNodeDetails.getLocalNodeDetails();
 
     omStorage = new OMStorage(conf);
-    omStorage.setOmNodeId(omNodeDetails.getNodeId(), true);
+    omStorage.validateOrPersistOmNodeId(omNodeDetails.getNodeId());
     omId = omStorage.getOmId();
 
     versionManager = new OMLayoutVersionManager(omStorage.getLayoutVersion());
@@ -1248,7 +1248,7 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
       }
 
       if (state != StorageState.INITIALIZED) {
-        omStorage.setOmNodeId(nodeId, false);
+        omStorage.setOmNodeId(nodeId);
         omStorage.setClusterId(clusterId);
         omStorage.initialize();
         System.out.println(

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
@@ -454,6 +454,7 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
     this.omNodeDetails = omhaNodeDetails.getLocalNodeDetails();
 
     omStorage = new OMStorage(conf);
+    omStorage.setOmNodeId(omNodeDetails.getNodeId(), true);
     omId = omStorage.getOmId();
 
     versionManager = new OMLayoutVersionManager(omStorage.getLayoutVersion());
@@ -1229,7 +1230,8 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
   @VisibleForTesting
   public static boolean omInit(OzoneConfiguration conf) throws IOException,
       AuthenticationException {
-    OMHANodeDetails.loadOMHAConfig(conf);
+    OMHANodeDetails omhaNodeDetails = OMHANodeDetails.loadOMHAConfig(conf);
+    String nodeId = omhaNodeDetails.getLocalNodeDetails().getNodeId();
     loginOMUserIfSecurityEnabled(conf);
     OMStorage omStorage = new OMStorage(conf);
     StorageState state = omStorage.getState();
@@ -1246,6 +1248,7 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
       }
 
       if (state != StorageState.INITIALIZED) {
+        omStorage.setOmNodeId(nodeId, false);
         omStorage.setClusterId(clusterId);
         omStorage.initialize();
         System.out.println(

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
@@ -454,6 +454,10 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
     this.omNodeDetails = omhaNodeDetails.getLocalNodeDetails();
 
     omStorage = new OMStorage(conf);
+    // validate if the stored one is the same we get in the OMNodeDetails
+    // if not, fails the start. If the VERSION file does not contain the node
+    // id yet, it stores it to the VERSION file and skips validation for the
+    // that case.
     omStorage.validateOrPersistOmNodeId(omNodeDetails.getNodeId());
     omId = omStorage.getOmId();
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
@@ -454,10 +454,6 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
     this.omNodeDetails = omhaNodeDetails.getLocalNodeDetails();
 
     omStorage = new OMStorage(conf);
-    // validate if the stored one is the same we get in the OMNodeDetails
-    // if not, fails the start. If the VERSION file does not contain the node
-    // id yet, it stores it to the VERSION file and skips validation for the
-    // that case.
     omStorage.validateOrPersistOmNodeId(omNodeDetails.getNodeId());
     omId = omStorage.getOmId();
 

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestOMStorage.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestOMStorage.java
@@ -17,64 +17,85 @@
 package org.apache.hadoop.ozone.om;
 
 import java.io.File;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Properties;
+import java.util.UUID;
 
 import org.apache.hadoop.hdds.HddsConfigKeys;
-import org.apache.hadoop.hdds.conf.MutableConfigurationSource;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
-import org.apache.ozone.test.GenericTestUtils;
-
-import org.apache.commons.io.FileUtils;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import org.apache.hadoop.ozone.om.upgrade.OMLayoutVersionManager;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
+import org.junit.rules.TemporaryFolder;
+
+import static org.apache.hadoop.ozone.common.Storage.StorageState.INITIALIZED;
+import static org.apache.hadoop.ozone.om.OMStorage.ERROR_OM_IS_ALREADY_INITIALIZED;
+import static org.apache.hadoop.ozone.om.OMStorage.ERROR_UNEXPECTED_OM_NODE_ID_TEMPLATE;
+import static org.apache.hadoop.ozone.om.OMStorage.OM_CERT_SERIAL_ID;
+import static org.apache.hadoop.ozone.om.OMStorage.OM_ID;
+import static org.apache.hadoop.ozone.om.OMStorage.OM_NODE_ID;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.nullValue;
+import static org.junit.Assert.fail;
 
 /**
  * Testing OMStorage class.
+ * Assumptions tested:
+ *   1. certificate serial ID can be set and unset anytime.
+ *   2. OmId the UUID of the Ozone Manager can be set only when the OMStorage
+ *       is not initialized already. Once initialized, setting OmId throws
+ *       IOException
+ *   3. OmNodeId:
+ *     3.1. can be set when the storage is not initialized, once initialize,
+ *         setting OmNodeId throws IOException
+ *     3.2. verifying the OmNodeId is possible once the storage is initialized,
+ *         until it is not initialized, verification throws IOException
+ *     3.3. verifying the OmNodeId does not do anything if the provided value is
+ *         equal to the stored value, throws an IOException otherwise
+ *   4. Configuration parsing:
+ *     4.1. getOmDbDir returns the configured
+ *         {@link OMConfigKeys#OZONE_OM_DB_DIRS} value
+ *     4.2. getOmDbDir falls back to {@link HddsConfigKeys#OZONE_METADATA_DIRS}
+ *         when {@link OMConfigKeys#OZONE_OM_DB_DIRS} is not set
+ *     4.3. getOmDbDir throws exception if none of the above properties are set
+ *   5. the protected getNodeProperties method properly returns all the keys
+ *       that are set properly in the OMStorage object.
  */
 public class TestOMStorage {
 
   @Rule
   public ExpectedException thrown = ExpectedException.none();
 
-  /**
-   * Test {@link OMStorage#getOmDbDir}.
-   */
-  @Test
-  public void testGetOmDbDir() {
-    final File testDir = createTestDir();
-    final File dbDir = new File(testDir, "omDbDir");
-    final File metaDir = new File(testDir, "metaDir");   // should be ignored.
-    final MutableConfigurationSource conf = new OzoneConfiguration();
-    conf.set(OMConfigKeys.OZONE_OM_DB_DIRS, dbDir.getPath());
-    conf.set(HddsConfigKeys.OZONE_METADATA_DIRS, metaDir.getPath());
+  @Rule
+  public TemporaryFolder tmpFolder = new TemporaryFolder();
 
-    try {
-      assertEquals(dbDir, OMStorage.getOmDbDir(conf));
-      assertTrue(dbDir.exists());          // should have been created.
-    } finally {
-      FileUtils.deleteQuietly(dbDir);
-    }
+  private static final String OM_ID_STR = new UUID(1L, 1L).toString();
+
+  @Test
+  public void testGetOmDbDir() throws Exception {
+    final File testDir = tmpFolder.newFolder();
+    final File dbDir = new File(testDir, "omDbDir");
+    final File metaDir = new File(testDir, "metaDir");
+    OzoneConfiguration conf = confWithHDDSMetaAndOMDBDir(metaDir, dbDir);
+
+    assertThat(dbDir, equalTo(OMStorage.getOmDbDir(conf)));
+    assertThat(dbDir.exists(), is(true));
+    assertThat(metaDir.exists(), is(false));
   }
 
-  /**
-   * Test {@link OMStorage#getOmDbDir} with fallback to OZONE_METADATA_DIRS
-   * when OZONE_OM_DB_DIRS is undefined.
-   */
   @Test
-  public void testGetOmDbDirWithFallback() {
-    final File testDir = createTestDir();
-    final File metaDir = new File(testDir, "metaDir");
-    final MutableConfigurationSource conf = new OzoneConfiguration();
-    conf.set(HddsConfigKeys.OZONE_METADATA_DIRS, metaDir.getPath());
+  public void testGetOmDbDirWithFallback() throws Exception {
+    File metaDir = tmpFolder.newFolder();
+    OzoneConfiguration conf = confWithHDDSMetadataDir(metaDir);
 
-    try {
-      assertEquals(metaDir, OMStorage.getOmDbDir(conf));
-      assertTrue(metaDir.exists());        // should have been created.
-    } finally {
-      FileUtils.deleteQuietly(metaDir);
-    }
+    assertThat(metaDir, equalTo(OMStorage.getOmDbDir(conf)));
+    assertThat(metaDir.exists(), is(true));
   }
 
   @Test
@@ -83,10 +104,225 @@ public class TestOMStorage {
     OMStorage.getOmDbDir(new OzoneConfiguration());
   }
 
-  public File createTestDir() {
-    File dir = new File(GenericTestUtils.getRandomizedTestDir(),
-        TestOMStorage.class.getSimpleName());
-    dir.mkdirs();
-    return dir;
+  @Test
+  public void testSetOmIdOnNotInitializedStorage() throws Exception {
+    OMStorage storage = new OMStorage(configWithOMDBDir());
+    assertThat(storage.getState(), is(not(INITIALIZED)));
+
+    String omId = "omId";
+    try {
+      storage.setOmId(omId);
+    } catch (IOException e) {
+      fail("Can not set OmId on a Storage that is not initialized.");
+    }
+    assertThat(storage.getOmId(), is(omId));
+    assertGetNodeProperties(storage, omId);
   }
+
+  @Test
+  public void testSetOmIdOnInitializedStorage() throws Exception {
+    OzoneConfiguration conf = configWithOMDBDir();
+    setupAPersistedVersionFile(conf);
+    thrown.expect(IOException.class);
+    thrown.expectMessage(ERROR_OM_IS_ALREADY_INITIALIZED);
+
+    OMStorage storage = new OMStorage(conf);
+    storage.setOmId("omId");
+  }
+
+  @Test
+  public void testCertSerialIdOperations() throws Exception {
+    OzoneConfiguration conf = configWithOMDBDir();
+    OMStorage storage = new OMStorage(conf);
+
+    assertThat(storage.getState(), is(not(INITIALIZED)));
+    assertCertOps(storage);
+    storage.initialize();
+    storage.persistCurrentState();
+
+    storage = new OMStorage(conf);
+    assertThat(storage.getState(), is(INITIALIZED));
+    assertCertOps(storage);
+  }
+
+  @Test
+  public void testSetOmNodeIdOnNotInitializedStorage() throws Exception {
+    OMStorage storage = new OMStorage(configWithOMDBDir());
+    assertThat(storage.getState(), is(not(INITIALIZED)));
+
+    String nodeId = "nodeId";
+    try {
+      storage.setOmNodeId(nodeId);
+    } catch (IOException e) {
+      fail("Can not set OmNodeId on a Storage that is not initialized.");
+    }
+    assertThat(storage.getOmNodeId(), is(nodeId));
+    assertGetNodeProperties(storage, null, nodeId);
+  }
+
+  @Test
+  public void testSetOMNodeIdOnInitializedStorageWithoutNodeID()
+      throws Exception {
+    OzoneConfiguration conf = configWithOMDBDir();
+    setupAPersistedVersionFile(conf);
+    thrown.expect(IOException.class);
+    thrown.expectMessage(ERROR_OM_IS_ALREADY_INITIALIZED);
+
+    OMStorage storage = new OMStorage(conf);
+    storage.setOmNodeId("nodeId");
+  }
+
+  @Test
+  public void testSetOMNodeIdOnInitializedStorageWithNodeID() throws Exception {
+    OzoneConfiguration conf = configWithOMDBDir();
+    setupAPersistedVersionFileWithNodeId(conf, "nodeId");
+    thrown.expect(IOException.class);
+    thrown.expectMessage(ERROR_OM_IS_ALREADY_INITIALIZED);
+
+    OMStorage storage = new OMStorage(conf);
+    storage.setOmNodeId("nodeId");
+  }
+
+  @Test
+  public void testValidateOrPersistOmNodeIdPersistsNewlySetValue()
+      throws Exception {
+    String nodeId = "nodeId";
+    OzoneConfiguration conf = configWithOMDBDir();
+    setupAPersistedVersionFile(conf);
+
+    OMStorage storage = new OMStorage(conf);
+    assertThat(storage.getState(), is(INITIALIZED));
+    assertThat(storage.getOmNodeId(), is(nullValue()));
+
+    storage.validateOrPersistOmNodeId(nodeId);
+    assertThat(storage.getOmNodeId(), is(nodeId));
+    assertGetNodeProperties(storage, OM_ID_STR, nodeId);
+
+    storage = new OMStorage(conf);
+    assertThat(storage.getOmNodeId(), is(nodeId));
+    assertGetNodeProperties(storage, OM_ID_STR, nodeId);
+  }
+
+  @Test
+  public void testValidateOrPersistOmNodeIdDoesRunWithSameNodeIdAsInFile()
+      throws Exception {
+    String nodeId = "nodeId";
+    OzoneConfiguration conf = configWithOMDBDir();
+    setupAPersistedVersionFileWithNodeId(conf, nodeId);
+
+    OMStorage storage = new OMStorage(conf);
+    assertThat(storage.getState(), is(INITIALIZED));
+    assertThat(storage.getOmNodeId(), is(nodeId));
+    assertGetNodeProperties(storage, OM_ID_STR, nodeId);
+
+    storage.validateOrPersistOmNodeId(nodeId);
+
+    assertThat(storage.getOmNodeId(), is(nodeId));
+    assertGetNodeProperties(storage, OM_ID_STR, nodeId);
+  }
+
+  @Test
+  public void testValidateOrPersistOmNodeIdThrowsWithDifferentNodeIdAsInFile()
+      throws Exception {
+    String nodeId = "nodeId";
+    String newId = "newId";
+    OzoneConfiguration conf = configWithOMDBDir();
+    setupAPersistedVersionFileWithNodeId(conf, nodeId);
+
+    OMStorage storage = new OMStorage(conf);
+    assertThat(storage.getState(), is(INITIALIZED));
+    assertThat(storage.getOmNodeId(), is(nodeId));
+
+    thrown.expect(IOException.class);
+    String expectedMsg =
+        String.format(ERROR_UNEXPECTED_OM_NODE_ID_TEMPLATE, nodeId, newId);
+    thrown.expectMessage(expectedMsg);
+
+    storage.validateOrPersistOmNodeId(newId);
+  }
+
+  private void assertCertOps(OMStorage storage) throws IOException {
+    String certSerialId = "12345";
+    String certSerialId2 = "54321";
+    storage.setOmCertSerialId(certSerialId);
+    assertThat(storage.getOmCertSerialId(), is(certSerialId));
+    assertGetNodeProperties(storage, null, null, certSerialId);
+
+    storage.setOmCertSerialId(certSerialId2);
+    assertThat(storage.getOmCertSerialId(), is(certSerialId2));
+    assertGetNodeProperties(storage, null, null, certSerialId2);
+
+    storage.unsetOmCertSerialId();
+    assertThat(storage.getOmCertSerialId(), is(nullValue()));
+    assertGetNodeProperties(storage, null, null, null);
+  }
+
+  private void assertGetNodeProperties(OMStorage storage, String... values) {
+    Properties p = storage.getNodeProperties();
+    Map<String, String> e = toExpectedPropertyMapping(values);
+
+    if (e.get(OM_ID) != null) {
+      assertThat(p.getProperty(OM_ID), is(e.get(OM_ID)));
+    }
+    if (e.get(OM_NODE_ID) != null) {
+      assertThat(p.get(OM_NODE_ID), is(e.get(OM_NODE_ID)));
+    }
+    if (e.get(OM_CERT_SERIAL_ID) != null) {
+      assertThat(p.get(OM_CERT_SERIAL_ID), is(e.get(OM_CERT_SERIAL_ID)));
+    }
+  }
+
+  private Map<String, String> toExpectedPropertyMapping(String... values) {
+    Map<String, String> ret = new HashMap<>();
+    String[] propNames = new String[]{OM_ID, OM_NODE_ID, OM_CERT_SERIAL_ID};
+    for (int i = 0; i < values.length; i++) {
+      ret.put(propNames[i], values[i]);
+    }
+    return ret;
+  }
+
+  private OMStorage setupAPersistedVersionFile(OzoneConfiguration conf)
+      throws IOException {
+    return setupAPersistedVersionFileWithNodeId(conf, null);
+  }
+
+  private OMStorage setupAPersistedVersionFileWithNodeId(
+      OzoneConfiguration conf, String nodeId) throws IOException {
+    OMStorage storage = new OMStorage(conf);
+    storage.setClusterId("clusterId");
+    storage.setLayoutVersion(OMLayoutVersionManager.maxLayoutVersion());
+    storage.setOmId(OM_ID_STR);
+    if (nodeId != null) {
+      storage.setOmNodeId(nodeId);
+    }
+    storage.initialize();
+    storage.persistCurrentState();
+    return storage;
+  }
+
+  private OzoneConfiguration configWithOMDBDir() throws IOException {
+    File dir = tmpFolder.newFolder();
+    return configWithOMDBDir(dir);
+  }
+
+  private OzoneConfiguration confWithHDDSMetaAndOMDBDir(
+      File metaDir, File dbDir) {
+    OzoneConfiguration conf = new OzoneConfiguration();
+    conf.set(HddsConfigKeys.OZONE_METADATA_DIRS, metaDir.getAbsolutePath());
+    conf.set(OMConfigKeys.OZONE_OM_DB_DIRS, dbDir.getAbsolutePath());
+    return conf;
+  }
+
+  private OzoneConfiguration confWithHDDSMetadataDir(File dir) {
+    OzoneConfiguration conf = new OzoneConfiguration();
+    conf.set(HddsConfigKeys.OZONE_METADATA_DIRS, dir.getAbsolutePath());
+    return conf;
+  }
+
+  private OzoneConfiguration configWithOMDBDir(File dir) {
+    OzoneConfiguration conf = new OzoneConfiguration();
+    conf.set(OMConfigKeys.OZONE_OM_DB_DIRS, dir.getAbsolutePath());
+    return conf;
+  }
+
 }

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestOMStorage.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestOMStorage.java
@@ -235,7 +235,7 @@ public class TestOMStorage {
 
     thrown.expect(IOException.class);
     String expectedMsg =
-        String.format(ERROR_UNEXPECTED_OM_NODE_ID_TEMPLATE, nodeId, newId);
+        String.format(ERROR_UNEXPECTED_OM_NODE_ID_TEMPLATE, newId, nodeId);
     thrown.expectMessage(expectedMsg);
 
     storage.validateOrPersistOmNodeId(newId);
@@ -281,12 +281,12 @@ public class TestOMStorage {
     return ret;
   }
 
-  private OMStorage setupAPersistedVersionFile(OzoneConfiguration conf)
+  private void setupAPersistedVersionFile(OzoneConfiguration conf)
       throws IOException {
-    return setupAPersistedVersionFileWithNodeId(conf, null);
+    setupAPersistedVersionFileWithNodeId(conf, null);
   }
 
-  private OMStorage setupAPersistedVersionFileWithNodeId(
+  private void setupAPersistedVersionFileWithNodeId(
       OzoneConfiguration conf, String nodeId) throws IOException {
     OMStorage storage = new OMStorage(conf);
     storage.setClusterId("clusterId");
@@ -297,7 +297,6 @@ public class TestOMStorage {
     }
     storage.initialize();
     storage.persistCurrentState();
-    return storage;
   }
 
   private OzoneConfiguration configWithOMDBDir() throws IOException {


### PR DESCRIPTION
## What changes were proposed in this pull request?
OM uses its NodeID to generate the RaftPeerId. As such, the OM NodeId should be immutable. This Jira proposes to add the OM NodeId to its VERSION file. On restarts, the OM NodeID should be compared with the nodeId in the VERSION file to verify that it has not been updated.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-5934

## How was this patch tested?
Added unit test
