### PR TITLE
HDDS-7718. Bump Netty to 4.1.86 and gRPC to 1.51.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -220,8 +220,8 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
 
     <!-- Use netty version known to work with grpc-netty. See table: -->
     <!-- https://github.com/grpc/grpc-java/blob/master/SECURITY.md#netty -->
-    <netty.version>4.1.77.Final</netty.version>
-    <io.grpc.version>1.48.1</io.grpc.version>
+    <netty.version>4.1.86.Final</netty.version>
+    <io.grpc.version>1.51.1</io.grpc.version>
 
     <rocksdb.version>7.7.3</rocksdb.version>
     <sqlite.version>3.25.2</sqlite.version>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Upgrade Netty to 4.1.86 and gRPC to 1.51.1 (same as in RATIS-1760).

https://issues.apache.org/jira/browse/HDDS-7718

## How was this patch tested?

Regular CI:
https://github.com/adoroszlai/hadoop-ozone/actions/runs/3828414627