### PR TITLE
HDDS-7696. MisReplicationHandler does not consider QUASI_CLOSED replicas as sources

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/MisReplicationHandler.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/MisReplicationHandler.java
@@ -95,15 +95,17 @@ public abstract class MisReplicationHandler implements
   }
 
   private Set<ContainerReplica> filterSources(Set<ContainerReplica> replicas) {
-    return replicas.stream().filter(r -> r
-                    .getState() == StorageContainerDatanodeProtocolProtos
-                    .ContainerReplicaProto.State.CLOSED)
-            .filter(r -> ReplicationManager
-                    .getNodeStatus(r.getDatanodeDetails(), nodeManager)
-                    .isHealthy())
-            .filter(r -> r.getDatanodeDetails().getPersistedOpState()
-                    == HddsProtos.NodeOperationalState.IN_SERVICE)
-            .collect(Collectors.toSet());
+    return replicas.stream()
+        .filter(r -> r.getState() == StorageContainerDatanodeProtocolProtos
+            .ContainerReplicaProto.State.CLOSED || r.getState() ==
+                StorageContainerDatanodeProtocolProtos
+                    .ContainerReplicaProto.State.QUASI_CLOSED
+        )
+        .filter(r -> ReplicationManager.getNodeStatus(
+            r.getDatanodeDetails(), nodeManager).isHealthy())
+        .filter(r -> r.getDatanodeDetails().getPersistedOpState()
+            == HddsProtos.NodeOperationalState.IN_SERVICE)
+        .collect(Collectors.toSet());
   }
 
   protected abstract ReplicateContainerCommand getReplicateCommand(

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestRatisMisReplicationHandler.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestRatisMisReplicationHandler.java
@@ -22,6 +22,7 @@ import org.apache.hadoop.hdds.client.RatisReplicationConfig;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.protocol.MockDatanodeDetails;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationFactor;
+import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.ContainerReplicaProto.State;
 import org.apache.hadoop.hdds.scm.ContainerPlacementStatus;
 import org.apache.hadoop.hdds.scm.PlacementPolicy;
 import org.apache.hadoop.hdds.scm.container.ContainerReplica;
@@ -65,6 +66,17 @@ public class TestRatisMisReplicationHandler extends TestMisReplicationHandler {
             Pair.of(IN_SERVICE, 0));
     testMisReplication(availableReplicas, Collections.emptyList(),
             0, misreplicationCount, Math.min(misreplicationCount, 3));
+  }
+
+  @ParameterizedTest
+  @ValueSource(ints = {1, 2, 3, 4, 5, 6, 7})
+  public void testMisReplicationWithAllNodesAvailableQuasiClosed(
+      int misreplicationCount) throws IOException {
+    Set<ContainerReplica> availableReplicas = ReplicationTestUtil
+        .createReplicas(State.QUASI_CLOSED, Pair.of(IN_SERVICE, 0),
+            Pair.of(IN_SERVICE, 0), Pair.of(IN_SERVICE, 0));
+    testMisReplication(availableReplicas, Collections.emptyList(),
+        0, misreplicationCount, Math.min(misreplicationCount, 3));
   }
 
   @Test


### PR DESCRIPTION
## What changes were proposed in this pull request?

MisReplicationHandler#filterSources gets a Set of replicas that can be used to fix mis replication. It selects CLOSED replicas:

```
  private Set<ContainerReplica> filterSources(Set<ContainerReplica> replicas) {
    return replicas.stream().filter(r -> r
                    .getState() == StorageContainerDatanodeProtocolProtos
                    .ContainerReplicaProto.State.CLOSED)
            .filter(r -> ReplicationManager
                    .getNodeStatus(r.getDatanodeDetails(), nodeManager)
                    .isHealthy())
            .filter(r -> r.getDatanodeDetails().getPersistedOpState()
                    == HddsProtos.NodeOperationalState.IN_SERVICE)
            .collect(Collectors.toSet());
  }
```

When thinking about Ratis Containers, QUASI_CLOSED replicas can also be mis replicated. They're also allowed to be replicated to datanodes so we should allow them as sources too.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-7696

## How was this patch tested?

New unit test added
