### PR TITLE
HDDS-7727. EC: SCM unregistered event handler for DatanodeCommandCountUpdated

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/StorageContainerManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/StorageContainerManager.java
@@ -43,6 +43,7 @@ import org.apache.hadoop.hdds.scm.container.ContainerManagerImpl;
 import org.apache.hadoop.hdds.scm.PlacementPolicyValidateProxy;
 import org.apache.hadoop.hdds.scm.container.ContainerReplica;
 import org.apache.hadoop.hdds.scm.container.replication.ContainerReplicaPendingOps;
+import org.apache.hadoop.hdds.scm.container.replication.DatanodeCommandCountUpdatedHandler;
 import org.apache.hadoop.hdds.scm.container.replication.LegacyReplicationManager;
 import org.apache.hadoop.hdds.scm.crl.CRLStatusReportHandler;
 import org.apache.hadoop.hdds.scm.ha.BackgroundSCMService;
@@ -455,6 +456,8 @@ public final class StorageContainerManager extends ServiceRuntimeInfoImpl
     eventQueue.addHandler(SCMEvents.NODE_REPORT, nodeReportHandler);
     eventQueue.addHandler(SCMEvents.COMMAND_QUEUE_REPORT,
         commandQueueReportHandler);
+    eventQueue.addHandler(SCMEvents.DATANODE_COMMAND_COUNT_UPDATED,
+        new DatanodeCommandCountUpdatedHandler(replicationManager));
 
     // Use the same executor for both ICR and FCR.
     // The Executor maps the event to a thread for DN.


### PR DESCRIPTION
## What changes were proposed in this pull request?

Register `DatanodeCommandCountUpdatedHandler` for `DATANODE_COMMAND_COUNT_UPDATED` events.

https://issues.apache.org/jira/browse/HDDS-7727

## How was this patch tested?

`No event handler registered for event ... 'Datanode_Command_Queue_Updated'` no longer appears in logs.

Regular CI:
https://github.com/adoroszlai/hadoop-ozone/actions/runs/3848900393