### PR TITLE
HDDS-7719. [HTTPFSGW] Fix secure integration tests for the HttpFS module

### DIFF
--- a/hadoop-ozone/dist/pom.xml
+++ b/hadoop-ozone/dist/pom.xml
@@ -28,7 +28,7 @@
   <properties>
     <file.encoding>UTF-8</file.encoding>
     <downloadSources>true</downloadSources>
-    <docker.ozone-runner.version>20220623-1</docker.ozone-runner.version>
+    <docker.ozone-runner.version>20230104-1</docker.ozone-runner.version>
     <docker.ozone-testkr5b.image>apache/ozone-testkrb5:20211102-1</docker.ozone-testkr5b.image>
   </properties>
 

--- a/hadoop-ozone/dist/src/main/compose/ozone-ha/docker-compose.yaml
+++ b/hadoop-ozone/dist/src/main/compose/ozone-ha/docker-compose.yaml
@@ -103,7 +103,7 @@ services:
   httpfs:
     <<: *common-config
     environment:
-      OZONE_CLASSPATH: "/opt/hadoop/share/ozone/lib/ozone-filesystem-${ozone.version}.jar:/opt/hadoop/share/ozone/lib/ozone-filesystem-common-${ozone.version}.jar:/opt/hadoop/share/ozone/lib/ozone-filesystem-hadoop3-${ozone.version}.jar"
+      OZONE_CLASSPATH: "/opt/hadoop/share/ozone/lib/ozone-filesystem-hadoop3-${ozone.version}.jar"
       OZONE-SITE.XML_hdds.scm.safemode.min.datanode: ${OZONE_SAFEMODE_MIN_DATANODES:-1}
       <<: *replication
     ports:

--- a/hadoop-ozone/dist/src/main/compose/ozone-ha/docker-compose.yaml
+++ b/hadoop-ozone/dist/src/main/compose/ozone-ha/docker-compose.yaml
@@ -103,7 +103,7 @@ services:
   httpfs:
     <<: *common-config
     environment:
-      OZONE_CLASSPATH: "/opt/hadoop/share/ozone/lib/ozone-filesystem-1.3.0-SNAPSHOT.jar:/opt/hadoop/share/ozone/lib/ozone-filesystem-common-1.3.0-SNAPSHOT.jar:/opt/hadoop/share/ozone/lib/ozone-filesystem-hadoop3-1.3.0-SNAPSHOT.jar"
+      OZONE_CLASSPATH: "/opt/hadoop/share/ozone/lib/ozone-filesystem-${ozone.version}.jar:/opt/hadoop/share/ozone/lib/ozone-filesystem-common-${ozone.version}.jar:/opt/hadoop/share/ozone/lib/ozone-filesystem-hadoop3-${ozone.version}.jar"
       OZONE-SITE.XML_hdds.scm.safemode.min.datanode: ${OZONE_SAFEMODE_MIN_DATANODES:-1}
       <<: *replication
     ports:

--- a/hadoop-ozone/dist/src/main/compose/ozone-ha/test.sh
+++ b/hadoop-ozone/dist/src/main/compose/ozone-ha/test.sh
@@ -34,7 +34,7 @@ execute_robot_test ${SCM} basic/ozone-shell-single.robot
 execute_robot_test ${SCM} basic/links.robot
 execute_robot_test ${SCM} s3
 execute_robot_test ${SCM} freon
-execute_robot_test ${SCM} -v SECURITY_ENABLED:${SECURITY_ENABLED} -v USERNAME:httpfs httpfs
+execute_robot_test ${SCM} -v USERNAME:httpfs httpfs
 
 stop_docker_env
 

--- a/hadoop-ozone/dist/src/main/compose/ozone/docker-compose.yaml
+++ b/hadoop-ozone/dist/src/main/compose/ozone/docker-compose.yaml
@@ -63,7 +63,7 @@ services:
   httpfs:
     <<: *common-config
     environment:
-      OZONE_CLASSPATH: "/opt/hadoop/share/ozone/lib/ozone-filesystem-1.3.0-SNAPSHOT.jar:/opt/hadoop/share/ozone/lib/ozone-filesystem-common-1.3.0-SNAPSHOT.jar:/opt/hadoop/share/ozone/lib/ozone-filesystem-hadoop3-1.3.0-SNAPSHOT.jar"
+      OZONE_CLASSPATH: "/opt/hadoop/share/ozone/lib/ozone-filesystem-${ozone.version}.jar:/opt/hadoop/share/ozone/lib/ozone-filesystem-common-${ozone.version}.jar:/opt/hadoop/share/ozone/lib/ozone-filesystem-hadoop3-${ozone.version}.jar"
       OZONE-SITE.XML_hdds.scm.safemode.min.datanode: ${OZONE_SAFEMODE_MIN_DATANODES:-1}
       <<: *replication
     ports:

--- a/hadoop-ozone/dist/src/main/compose/ozone/docker-compose.yaml
+++ b/hadoop-ozone/dist/src/main/compose/ozone/docker-compose.yaml
@@ -63,7 +63,7 @@ services:
   httpfs:
     <<: *common-config
     environment:
-      OZONE_CLASSPATH: "/opt/hadoop/share/ozone/lib/ozone-filesystem-${ozone.version}.jar:/opt/hadoop/share/ozone/lib/ozone-filesystem-common-${ozone.version}.jar:/opt/hadoop/share/ozone/lib/ozone-filesystem-hadoop3-${ozone.version}.jar"
+      OZONE_CLASSPATH: "/opt/hadoop/share/ozone/lib/ozone-filesystem-hadoop3-${ozone.version}.jar"
       OZONE-SITE.XML_hdds.scm.safemode.min.datanode: ${OZONE_SAFEMODE_MIN_DATANODES:-1}
       <<: *replication
     ports:

--- a/hadoop-ozone/dist/src/main/compose/ozone/test.sh
+++ b/hadoop-ozone/dist/src/main/compose/ozone/test.sh
@@ -55,7 +55,7 @@ execute_robot_test scm freon
 execute_robot_test scm cli
 execute_robot_test scm admincli
 
-execute_robot_test scm -v SECURITY_ENABLED:${SECURITY_ENABLED} -v USERNAME:httpfs httpfs
+execute_robot_test scm -v USERNAME:httpfs httpfs
 execute_debug_tests
 
 execute_robot_test scm -v SCHEME:ofs -v BUCKET_TYPE:link -N ozonefs-ofs-link ozonefs/ozonefs.robot

--- a/hadoop-ozone/dist/src/main/compose/ozonesecure-ha/docker-compose.yaml
+++ b/hadoop-ozone/dist/src/main/compose/ozonesecure-ha/docker-compose.yaml
@@ -196,7 +196,7 @@ services:
       - ./docker-config
     command: [ "/opt/hadoop/bin/ozone","httpfs" ]
     environment:
-      OZONE_CLASSPATH: "/opt/hadoop/share/ozone/lib/ozone-filesystem-1.3.0-SNAPSHOT.jar:/opt/hadoop/share/ozone/lib/ozone-filesystem-common-1.3.0-SNAPSHOT.jar:/opt/hadoop/share/ozone/lib/ozone-filesystem-hadoop3-1.3.0-SNAPSHOT.jar"
+      OZONE_CLASSPATH: "/opt/hadoop/share/ozone/lib/ozone-filesystem-${ozone.version}.jar:/opt/hadoop/share/ozone/lib/ozone-filesystem-common-${ozone.version}.jar:/opt/hadoop/share/ozone/lib/ozone-filesystem-hadoop3-${ozone.version}.jar"
       OZONE-SITE.XML_hdds.scm.safemode.min.datanode: ${OZONE_SAFEMODE_MIN_DATANODES:-1}
       OZONE_OPTS:
     networks:

--- a/hadoop-ozone/dist/src/main/compose/ozonesecure-ha/docker-compose.yaml
+++ b/hadoop-ozone/dist/src/main/compose/ozonesecure-ha/docker-compose.yaml
@@ -196,7 +196,7 @@ services:
       - ./docker-config
     command: [ "/opt/hadoop/bin/ozone","httpfs" ]
     environment:
-      OZONE_CLASSPATH: "/opt/hadoop/share/ozone/lib/ozone-filesystem-${ozone.version}.jar:/opt/hadoop/share/ozone/lib/ozone-filesystem-common-${ozone.version}.jar:/opt/hadoop/share/ozone/lib/ozone-filesystem-hadoop3-${ozone.version}.jar"
+      OZONE_CLASSPATH: "/opt/hadoop/share/ozone/lib/ozone-filesystem-hadoop3-${ozone.version}.jar"
       OZONE-SITE.XML_hdds.scm.safemode.min.datanode: ${OZONE_SAFEMODE_MIN_DATANODES:-1}
       OZONE_OPTS:
     networks:

--- a/hadoop-ozone/dist/src/main/compose/ozonesecure-ha/docker-config
+++ b/hadoop-ozone/dist/src/main/compose/ozonesecure-ha/docker-config
@@ -14,9 +14,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# For HttpFS it is required to enable impersonating users as root, because the httpfs is mapped to root as a result of the auth_to_local rules.
-CORE-SITE.XML_hadoop.proxyuser.root.hosts=*
-CORE-SITE.XML_hadoop.proxyuser.root.groups=*
+# For HttpFS service it is required to enable proxying users.
+CORE-SITE.XML_hadoop.proxyuser.httpfs.hosts=*
+CORE-SITE.XML_hadoop.proxyuser.httpfs.groups=*
 
 CORE-SITE.XML_fs.defaultFS=ofs://id1
 

--- a/hadoop-ozone/dist/src/main/compose/ozonesecure-ha/test.sh
+++ b/hadoop-ozone/dist/src/main/compose/ozonesecure-ha/test.sh
@@ -39,8 +39,7 @@ execute_robot_test ${SCM} s3
 
 execute_robot_test ${SCM} admincli
 
-# commented out until httpfs user and group is added to ozone-docker-runner
-# execute_robot_test ${SCM} -v SECURITY_ENABLED:${SECURITY_ENABLED} httpfs
+execute_robot_test ${SCM} -v SECURITY_ENABLED:${SECURITY_ENABLED} httpfs
 
 export SCM=scm2.org
 execute_robot_test ${SCM} admincli

--- a/hadoop-ozone/dist/src/main/compose/ozonesecure-ha/test.sh
+++ b/hadoop-ozone/dist/src/main/compose/ozonesecure-ha/test.sh
@@ -39,7 +39,7 @@ execute_robot_test ${SCM} s3
 
 execute_robot_test ${SCM} admincli
 
-execute_robot_test ${SCM} -v SECURITY_ENABLED:${SECURITY_ENABLED} httpfs
+execute_robot_test ${SCM} httpfs
 
 export SCM=scm2.org
 execute_robot_test ${SCM} admincli

--- a/hadoop-ozone/dist/src/main/compose/ozonesecure/docker-compose.yaml
+++ b/hadoop-ozone/dist/src/main/compose/ozonesecure/docker-compose.yaml
@@ -76,7 +76,7 @@ services:
       - ./docker-config
     command: [ "/opt/hadoop/bin/ozone","httpfs" ]
     environment:
-      OZONE_CLASSPATH: "/opt/hadoop/share/ozone/lib/ozone-filesystem-${ozone.version}.jar:/opt/hadoop/share/ozone/lib/ozone-filesystem-common-${ozone.version}.jar:/opt/hadoop/share/ozone/lib/ozone-filesystem-hadoop3-${ozone.version}.jar"
+      OZONE_CLASSPATH: "/opt/hadoop/share/ozone/lib/ozone-filesystem-hadoop3-${ozone.version}.jar"
       OZONE-SITE.XML_hdds.scm.safemode.min.datanode: ${OZONE_SAFEMODE_MIN_DATANODES:-1}
       OZONE_OPTS:
   s3g:

--- a/hadoop-ozone/dist/src/main/compose/ozonesecure/docker-compose.yaml
+++ b/hadoop-ozone/dist/src/main/compose/ozonesecure/docker-compose.yaml
@@ -76,7 +76,7 @@ services:
       - ./docker-config
     command: [ "/opt/hadoop/bin/ozone","httpfs" ]
     environment:
-      OZONE_CLASSPATH: "/opt/hadoop/share/ozone/lib/ozone-filesystem-1.3.0-SNAPSHOT.jar:/opt/hadoop/share/ozone/lib/ozone-filesystem-common-1.3.0-SNAPSHOT.jar:/opt/hadoop/share/ozone/lib/ozone-filesystem-hadoop3-1.3.0-SNAPSHOT.jar"
+      OZONE_CLASSPATH: "/opt/hadoop/share/ozone/lib/ozone-filesystem-${ozone.version}.jar:/opt/hadoop/share/ozone/lib/ozone-filesystem-common-${ozone.version}.jar:/opt/hadoop/share/ozone/lib/ozone-filesystem-hadoop3-${ozone.version}.jar"
       OZONE-SITE.XML_hdds.scm.safemode.min.datanode: ${OZONE_SAFEMODE_MIN_DATANODES:-1}
       OZONE_OPTS:
   s3g:

--- a/hadoop-ozone/dist/src/main/compose/ozonesecure/docker-config
+++ b/hadoop-ozone/dist/src/main/compose/ozonesecure/docker-config
@@ -16,9 +16,9 @@
 
 CORE-SITE.XML_fs.defaultFS=ofs://om
 CORE-SITE.XML_fs.trash.interval=1
-# For HttpFS it is required to enable impersonating users as root, because the httpfs is mapped to root as a result of the auth_to_local rules.
-CORE-SITE.XML_hadoop.proxyuser.root.hosts=*
-CORE-SITE.XML_hadoop.proxyuser.root.groups=*
+# For HttpFS service it is required to enable proxying users.
+CORE-SITE.XML_hadoop.proxyuser.httpfs.hosts=*
+CORE-SITE.XML_hadoop.proxyuser.httpfs.groups=*
 
 OZONE-SITE.XML_ozone.om.address=om
 OZONE-SITE.XML_ozone.om.http-address=om:9874

--- a/hadoop-ozone/dist/src/main/compose/ozonesecure/test.sh
+++ b/hadoop-ozone/dist/src/main/compose/ozonesecure/test.sh
@@ -54,7 +54,7 @@ execute_robot_test scm recon
 execute_robot_test scm admincli
 execute_robot_test scm spnego
 
-execute_robot_test scm -v SECURITY_ENABLED:${SECURITY_ENABLED} httpfs
+execute_robot_test scm httpfs
 
 # test replication
 docker-compose up -d --scale datanode=2

--- a/hadoop-ozone/dist/src/main/compose/ozonesecure/test.sh
+++ b/hadoop-ozone/dist/src/main/compose/ozonesecure/test.sh
@@ -54,8 +54,7 @@ execute_robot_test scm recon
 execute_robot_test scm admincli
 execute_robot_test scm spnego
 
-# commented out until httpfs user and group is added to ozone-docker-runner
-# execute_robot_test scm -v SECURITY_ENABLED:${SECURITY_ENABLED} httpfs
+execute_robot_test scm -v SECURITY_ENABLED:${SECURITY_ENABLED} httpfs
 
 # test replication
 docker-compose up -d --scale datanode=2

--- a/hadoop-ozone/dist/src/main/smoketest/httpfs/operations_tests.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/httpfs/operations_tests.robot
@@ -32,7 +32,7 @@ Generate volume
    Set Suite Variable  ${volume}  ${random}
 
 Kinit admin
-    Wait Until Keyword Succeeds      2min       10sec      Execute      kinit -k httpfs/httpfs@EXAMPLE.COM -t /etc/security/keytabs/httpfs.keytab
+    Wait Until Keyword Succeeds      2min       10sec      Execute      kinit -k om/om@EXAMPLE.COM -t /etc/security/keytabs/om.keytab
 
 *** Test Cases ***
 Kinit admin user


### PR DESCRIPTION
## What changes were proposed in this pull request?

In this change I fixed the Kerberos setup for the HttpFS tests in secure environment and also added them back to the `test.sh`, as after the master merge there were some changes that broke them. I added the new ozone-runner image to the `ozone-dist/pom.xml`, which has `httpfs` as a user and group. 

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-7719

## How was this patch tested?

Run the tests locally
Also waited the CI on my fork: https://github.com/dombizita/ozone/actions/runs/3854740738/jobs/6569223329 (only the flaky integration tests failed, not relevant with my change)
