### PR TITLE
HDDS-7695. EC metrics related to replication commands don't add up

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ContainerReplicaPendingOps.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ContainerReplicaPendingOps.java
@@ -121,7 +121,7 @@ public class ContainerReplicaPendingOps {
     boolean completed = completeOp(ADD, containerID, target, replicaIndex);
     if (isMetricsNotNull() && completed) {
       if (replicaIndex > 0) {
-        replicationMetrics.incrEcReplicationCmdsCompletedTotal();
+        replicationMetrics.incrEcReplicasCreatedTotal();
       } else if (replicaIndex == 0) {
         replicationMetrics.incrNumReplicationCmdsCompleted();
       }
@@ -143,7 +143,7 @@ public class ContainerReplicaPendingOps {
     boolean completed = completeOp(DELETE, containerID, target, replicaIndex);
     if (isMetricsNotNull() && completed) {
       if (replicaIndex > 0) {
-        replicationMetrics.incrEcDeletionCmdsCompletedTotal();
+        replicationMetrics.incrEcReplicasDeletedTotal();
       } else if (replicaIndex == 0) {
         replicationMetrics.incrNumDeletionCmdsCompleted();
       }
@@ -214,13 +214,13 @@ public class ContainerReplicaPendingOps {
   private void updateTimeoutMetrics(ContainerReplicaOp op) {
     if (op.getOpType() == ADD && isMetricsNotNull()) {
       if (op.getReplicaIndex() > 0) {
-        replicationMetrics.incrEcReplicationCmdsTimeoutTotal();
+        replicationMetrics.incrEcReplicaCreateTimeoutTotal();
       } else if (op.getReplicaIndex() == 0) {
         replicationMetrics.incrNumReplicationCmdsTimeout();
       }
     } else if (op.getOpType() == DELETE && isMetricsNotNull()) {
       if (op.getReplicaIndex() > 0) {
-        replicationMetrics.incrEcDeletionCmdsTimeoutTotal();
+        replicationMetrics.incrEcReplicaDeleteTimeoutTotal();
       } else if (op.getReplicaIndex() == 0) {
         replicationMetrics.incrNumDeletionCmdsTimeout();
       }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ReplicationManagerMetrics.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ReplicationManagerMetrics.java
@@ -153,24 +153,23 @@ public final class ReplicationManagerMetrics implements MetricsSource {
   @Metric("Number of EC Replication commands sent.")
   private MutableCounterLong ecReplicationCmdsSentTotal;
 
-  @Metric("Number of EC Deletion commands timeout.")
+  @Metric("Number of EC Replica Deletion commands sent.")
   private MutableCounterLong ecDeletionCmdsSentTotal;
 
-  @Metric("Number of EC Replication commands completed.")
-  private MutableCounterLong ecReplicationCmdsCompletedTotal;
-
-  @Metric("Number of EC Deletion commands completed.")
-  private MutableCounterLong ecDeletionCmdsCompletedTotal;
-
-  @Metric("Number of EC Deletion commands completed.")
+  @Metric("Number of EC Reconstruction commands sent.")
   private MutableCounterLong ecReconstructionCmdsSentTotal;
 
-  @Metric("Number of EC Replication commands timeout.")
-  private MutableCounterLong ecReplicationCmdsTimeoutTotal;
+  @Metric("Number of EC replicas successfully created by Replication Manager.")
+  private MutableCounterLong ecReplicasCreatedTotal;
 
-  @Metric("Number of EC Deletion commands timeout.")
-  private MutableCounterLong ecDeletionCmdsTimeoutTotal;
+  @Metric("Number of EC replicas successfully deleted by Replication Manager.")
+  private MutableCounterLong ecReplicasDeletedTotal;
 
+  @Metric("Number of EC replicas scheduled to be created which timed out.")
+  private MutableCounterLong ecReplicaCreateTimeoutTotal;
+
+  @Metric("Number of EC replicas scheduled for delete which timed out.")
+  private MutableCounterLong ecReplicaDeleteTimeoutTotal;
 
   public ReplicationManagerMetrics(ReplicationManager manager) {
     this.registry = new MetricsRegistry(METRICS_SOURCE_NAME);
@@ -219,11 +218,11 @@ public final class ReplicationManagerMetrics implements MetricsSource {
     deletionTime.snapshot(builder, all);
     ecReplicationCmdsSentTotal.snapshot(builder, all);
     ecDeletionCmdsSentTotal.snapshot(builder, all);
-    ecReplicationCmdsCompletedTotal.snapshot(builder, all);
-    ecDeletionCmdsCompletedTotal.snapshot(builder, all);
+    ecReplicasCreatedTotal.snapshot(builder, all);
+    ecReplicasDeletedTotal.snapshot(builder, all);
     ecReconstructionCmdsSentTotal.snapshot(builder, all);
-    ecReplicationCmdsTimeoutTotal.snapshot(builder, all);
-    ecDeletionCmdsTimeoutTotal.snapshot(builder, all);
+    ecReplicaCreateTimeoutTotal.snapshot(builder, all);
+    ecReplicasDeletedTotal.snapshot(builder, all);
   }
 
   public void unRegister() {
@@ -361,12 +360,12 @@ public final class ReplicationManagerMetrics implements MetricsSource {
     this.ecDeletionCmdsSentTotal.incr();
   }
 
-  public void incrEcReplicationCmdsCompletedTotal() {
-    this.ecReplicationCmdsCompletedTotal.incr();
+  public void incrEcReplicasCreatedTotal() {
+    this.ecReplicasCreatedTotal.incr();
   }
 
-  public void incrEcDeletionCmdsCompletedTotal() {
-    this.ecDeletionCmdsCompletedTotal.incr();
+  public void incrEcReplicasDeletedTotal() {
+    this.ecReplicasDeletedTotal.incr();
   }
 
   public void incrEcReconstructionCmdsSentTotal() {
@@ -383,8 +382,8 @@ public final class ReplicationManagerMetrics implements MetricsSource {
         .getPendingOpCount(ContainerReplicaOp.PendingOpType.DELETE);
   }
 
-  public void incrEcReplicationCmdsTimeoutTotal() {
-    this.ecReplicationCmdsTimeoutTotal.incr();
+  public void incrEcReplicaCreateTimeoutTotal() {
+    this.ecReplicaCreateTimeoutTotal.incr();
   }
 
   public long getEcDeletionCmdsSentTotal() {
@@ -399,23 +398,23 @@ public final class ReplicationManagerMetrics implements MetricsSource {
     return ecReplicationCmdsSentTotal.value();
   }
 
-  public void incrEcDeletionCmdsTimeoutTotal() {
-    this.ecDeletionCmdsTimeoutTotal.incr();
+  public void incrEcReplicaDeleteTimeoutTotal() {
+    this.ecReplicaDeleteTimeoutTotal.incr();
   }
 
-  public long getEcReplicationCmdsTimeoutTotal() {
-    return ecReplicationCmdsTimeoutTotal.value();
+  public long getEcReplicaCreateTimeoutTotal() {
+    return ecReplicaCreateTimeoutTotal.value();
   }
 
-  public long getEcDeletionCmdsTimeoutTotal() {
-    return ecDeletionCmdsTimeoutTotal.value();
+  public long getEcReplicaDeleteTimeoutTotal() {
+    return ecReplicaDeleteTimeoutTotal.value();
   }
 
-  public long getEcReplicationCmdsCompletedTotal() {
-    return ecReplicationCmdsCompletedTotal.value();
+  public long getEcReplicasCreatedTotal() {
+    return ecReplicasCreatedTotal.value();
   }
 
-  public long getEcDeletionCmdsCompletedTotal() {
-    return ecDeletionCmdsCompletedTotal.value();
+  public long getEcReplicasDeletedTotal() {
+    return ecReplicasDeletedTotal.value();
   }
 }

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestContainerReplicaPendingOps.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestContainerReplicaPendingOps.java
@@ -244,8 +244,8 @@ public class TestContainerReplicaPendingOps {
     pendingOps.removeExpiredEntries(1000);
 
     // Two Delete and Replication command should be timeout
-    Assertions.assertEquals(metrics.getEcReplicationCmdsTimeoutTotal(), 2);
-    Assertions.assertEquals(metrics.getEcDeletionCmdsTimeoutTotal(), 2);
+    Assertions.assertEquals(metrics.getEcReplicaCreateTimeoutTotal(), 2);
+    Assertions.assertEquals(metrics.getEcReplicaDeleteTimeoutTotal(), 2);
 
     pendingOps.scheduleDeleteReplica(new ContainerID(3), dn1, 2);
     pendingOps.scheduleAddReplica(new ContainerID(3), dn1, 3);
@@ -262,8 +262,8 @@ public class TestContainerReplicaPendingOps {
     pendingOps.completeDeleteReplica(new ContainerID(4), dn2, 2);
     pendingOps.completeAddReplica(new ContainerID(4), dn3, 4);
 
-    Assertions.assertEquals(metrics.getEcReplicationCmdsCompletedTotal(), 2);
-    Assertions.assertEquals(metrics.getEcDeletionCmdsCompletedTotal(), 2);
+    Assertions.assertEquals(metrics.getEcReplicasCreatedTotal(), 2);
+    Assertions.assertEquals(metrics.getEcReplicasDeletedTotal(), 2);
 
     pendingOps.completeDeleteReplica(new ContainerID(3), dn1, 2);
     pendingOps.completeAddReplica(new ContainerID(2), dn1, 3);


### PR DESCRIPTION
## What changes were proposed in this pull request?

```
    "EcReplicationCmdsSentTotal" : 0,
    "EcDeletionCmdsSentTotal" : 259,
    "EcReplicationCmdsCompletedTotal" : 51,
    "EcDeletionCmdsCompletedTotal" : 51,
    "EcReconstructionCmdsSentTotal" : 571,
    "EcReplicationCmdsTimeoutTotal" : 765,
    "EcDeletionCmdsTimeoutTotal" : 204
```

Total replication commands sent are 0, while timed out are 765.

I think the code is working as intended, but it is confusing.

We have a metric for "EcReplicationCmdsSentTotal" and EcReconstructionCmdsSentTotal. However on completion or timeout we only have a metric EcReplicationCmdsCompletedTotal and EcReplicationCmdsTimeoutTotal - we don't have a reconstruction completed / timeout. This is because we track completion in ContainerReplicaPendingOps, and all it sees is a replica that has been scheduled to be created. It doesn't know if its an simple copy or a reconstruction that is going to create it.

That can explain why "EcReplicationCmdsSentTotal=0" and "EcReplicationCmdsTimeoutTotal=765" - likely all these scheduled commands were actually reconstructions, as we have 571 of those sent.

Why then do we have more ECReplication completed and timed out than scheduled? An EC reconstruction can create multiple new replicas in a single command, and they are tracked as a single command when sent, but then when the commands are completed in pending ops, it counts one per replica. So we can schedule a reconstruction to create 2 new replicas, and we will end up with 1 command sent and 2 in EcReplicationCmdsCompletedTotal.

To make this less confusing I have renamed the "complete" metrics in this PR to be Replicas created / deleted / timed out, rather than commands.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-7695

## How was this patch tested?

Existing tests should cover this as its just a rename of variables / methods.