### PR TITLE
HDDS-7739. EC: Increase the information in the RM sending command log message

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/protocol/DatanodeDetails.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/protocol/DatanodeDetails.java
@@ -196,6 +196,15 @@ public class DatanodeDetails extends NodeImpl implements
   }
 
   /**
+   * Returns the Hostname and IP of the datanode separated by a slash.
+   *
+   * Eg: datanode001.corp/192.168.0.123
+   */
+  public String getHostNameAndIP() {
+    return getHostName() + "/" + getIpAddress();
+  }
+
+  /**
    * Sets a DataNode Port.
    *
    * @param port DataNode port

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/protocol/commands/CloseContainerCommand.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/protocol/commands/CloseContainerCommand.java
@@ -79,4 +79,14 @@ public class CloseContainerCommand
   public PipelineID getPipelineID() {
     return pipelineID;
   }
+
+  @Override
+  public String toString() {
+    StringBuilder sb = new StringBuilder();
+    sb.append(getType())
+        .append(": containerID: ").append(getContainerID())
+        .append(", pipelineID: ").append(getPipelineID())
+        .append(", force: ").append(force);
+    return sb.toString();
+  }
 }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/protocol/commands/DeleteContainerCommand.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/protocol/commands/DeleteContainerCommand.java
@@ -105,4 +105,14 @@ public class DeleteContainerCommand extends
   public int getReplicaIndex() {
     return replicaIndex;
   }
+
+  @Override
+  public String toString() {
+    StringBuilder sb = new StringBuilder();
+    sb.append(getType())
+        .append(": containerID: ").append(getContainerID())
+        .append(", replicaIndex: ").append(getReplicaIndex())
+        .append(", force: ").append(force);
+    return sb.toString();
+  }
 }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/protocol/commands/ReconstructECContainersCommand.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/protocol/commands/ReconstructECContainersCommand.java
@@ -134,6 +134,23 @@ public class ReconstructECContainersCommand
     return ecReplicationConfig;
   }
 
+  @Override
+  public String toString() {
+    StringBuilder sb = new StringBuilder();
+    sb.append(getType())
+        .append(": containerID: ").append(containerID)
+        .append(", replicationConfig: ").append(ecReplicationConfig)
+        .append(", sources: [").append(getSources().stream()
+            .map(a -> a.dnDetails.getHostNameAndIP()
+                + " replicaIndex: " + a.getReplicaIndex())
+            .collect(Collectors.joining(", "))).append("]")
+        .append(", targets: [").append(getTargetDatanodes().stream()
+            .map(DatanodeDetails::getHostNameAndIP)
+        .collect(Collectors.joining(", "))).append("]")
+        .append(", missingIndexes: ").append(
+            Arrays.toString(missingContainerIndexes));
+    return sb.toString();
+  }
   /**
    * To store the datanode details with replica index.
    */

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/protocol/commands/ReplicateContainerCommand.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/protocol/commands/ReplicateContainerCommand.java
@@ -109,4 +109,17 @@ public class ReplicateContainerCommand
   public int getReplicaIndex() {
     return replicaIndex;
   }
+
+  @Override
+  public String toString() {
+    StringBuilder sb = new StringBuilder();
+    sb.append(getType());
+    sb.append(": containerId: ").append(getContainerID());
+    sb.append(", replicaIndex: ").append(getReplicaIndex());
+    sb.append(", sourceNodes: [");
+    sb.append(sourceDatanodes.stream()
+        .map(DatanodeDetails::getHostNameAndIP)
+        .collect(Collectors.joining(", "))).append("]");
+    return sb.toString();
+  }
 }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ReplicationManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ReplicationManager.java
@@ -423,8 +423,8 @@ public class ReplicationManager implements SCMService {
   public void sendDatanodeCommand(SCMCommand<?> command,
       ContainerInfo containerInfo, DatanodeDetails target)
       throws NotLeaderException {
-    LOG.info("Sending command of type {} for container {} to {}",
-        command.getType(), containerInfo, target);
+    LOG.info("Sending command [{}] for container {} to {}",
+        command, containerInfo, target);
     command.setTerm(getScmTerm());
     command.setDeadline(clock.millis() +
         Math.round(rmConf.eventTimeout * rmConf.commandDeadlineFactor));


### PR DESCRIPTION
## What changes were proposed in this pull request?

Replication Manager writes an info log each time it sends a command to a datanode, but aside from the command name, it doesn't contain any further information about the command. This change is to log more details about the command being sent which may aid debugging issues in the future.

Example new messages after this change:

```
2023-01-06 17:23:06,080 [main] INFO  replication.ReplicationManager (ReplicationManager.java:sendDatanodeCommand(426)) - Sending command [replicateContainerCommand: containerId: 1, replicaIndex: 1, sourceNodes: [localhost-143.110.182.62/143.110.182.62, localhost-243.150.55.19/243.150.55.19]] for container ContainerInfo{id=#1, state=CLOSED, pipelineID=PipelineID=bdd96da4-f447-45d4-9331-62480e7bf224, stateEnterTime=1970-01-01T00:00:00Z, owner=Ozone} to f8bca9d9-cf71-4e8a-aaed-f48ddc148a73{ip: 37.218.105.163, host: localhost-37.218.105.163, ports: [STANDALONE=0, RATIS=0, REST=0, REPLICATION=0, RATIS_ADMIN=0, RATIS_SERVER=0, RATIS_DATASTREAM=0], networkLocation: /default-rack, certSerialId: null, persistedOpState: IN_SERVICE, persistedOpStateExpiryEpochSec: 0}

2023-01-06 17:23:05,893 [main] INFO  replication.ReplicationManager (ReplicationManager.java:sendDatanodeCommand(426)) - Sending command [closeContainerCommand: containerID: 1, pipelineID: PipelineID=6dad5a63-dfa1-4621-b8c4-7de81e024cdc, force: true] for container ContainerInfo{id=#1, state=CLOSED, pipelineID=PipelineID=6dad5a63-dfa1-4621-b8c4-7de81e024cdc, stateEnterTime=1970-01-01T00:00:00Z, owner=Ozone} to bb47be9c-0886-4852-8ca7-46799ac36883{ip: 140.122.156.42, host: localhost-140.122.156.42, ports: [STANDALONE=0, RATIS=0, REST=0, REPLICATION=0, RATIS_ADMIN=0, RATIS_SERVER=0, RATIS_DATASTREAM=0], networkLocation: /default-rack, certSerialId: null, persistedOpState: IN_SERVICE, persistedOpStateExpiryEpochSec: 0}


2023-01-06 17:23:05,938 [main] INFO  replication.ReplicationManager (ReplicationManager.java:sendDatanodeCommand(426)) - Sending command [reconstructECContainersCommand: containerID: 1, replicationConfig: EC/ECReplicationConfig{data=3, parity=2, ecChunkSize=1048576, codec=rs}, sources: [localhost-208.151.31.91/208.151.31.91 replicaIndex: 1, localhost-27.100.52.223/27.100.52.223 replicaIndex: 2, localhost-247.11.160.69/247.11.160.69 replicaIndex: 3], targets: [localhost-220.147.5.156/220.147.5.156, localhost-193.210.182.11/193.210.182.11], missingIndexes: [4, 5]] for container ContainerInfo{id=#1, state=CLOSED, pipelineID=PipelineID=874dd4ae-c222-4f91-b587-81551ef78a20, stateEnterTime=1970-01-01T00:00:00Z, owner=Ozone} to ecd0da3f-68b0-4bf8-85da-b7d3a41100a2{ip: 220.147.5.156, host: localhost-220.147.5.156, ports: [STANDALONE=0, RATIS=0, REST=0, REPLICATION=0, RATIS_ADMIN=0, RATIS_SERVER=0, RATIS_DATASTREAM=0], networkLocation: /default-rack, certSerialId: null, persistedOpState: IN_SERVICE, persistedOpStateExpiryEpochSec: 0}

2023-01-06 17:23:05,987 [main] INFO  replication.ReplicationManager (ReplicationManager.java:sendDatanodeCommand(426)) - Sending command [deleteContainerCommand: containerID: 1, replicaIndex: 1, force: false] for container ContainerInfo{id=#1, state=CLOSED, pipelineID=PipelineID=4c4b1a01-ebbf-466a-a1f3-45b306533709, stateEnterTime=1970-01-01T00:00:00Z, owner=Ozone} to 7c838ac2-d7bd-4719-ac38-f1ff5adb7869{ip: 122.2.174.81, host: localhost-122.2.174.81, ports: [STANDALONE=0, RATIS=0, REST=0, REPLICATION=0, RATIS_ADMIN=0, RATIS_SERVER=0, RATIS_DATASTREAM=0], networkLocation: /default-rack, certSerialId: null, persistedOpState: IN_SERVICE, persistedOpStateExpiryEpochSec: 0}
```

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-7739

## How was this patch tested?

Logging only change. I ran some tests which caused the logs to be emitted and checked their format (posted above).