### PR TITLE
HDDS-7738. SCM terminates when adding container to a closed pipeline

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/PipelineStateMap.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/PipelineStateMap.java
@@ -107,8 +107,8 @@ class PipelineStateMap {
     Pipeline pipeline = getPipeline(pipelineID);
     if (pipeline.isClosed()) {
       LOG.warn("Adding container {} to pipeline={} in CLOSED state." +
-          "  This happens only for some exceptional cases." +
-          "  Check for the previous exceptions.", containerID, pipelineID);
+          " This happens only for some exceptional cases." +
+          " Check for the previous exceptions.", containerID, pipelineID);
     }
     pipeline2container.get(pipelineID).add(containerID);
   }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/PipelineStateMap.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/PipelineStateMap.java
@@ -106,13 +106,9 @@ class PipelineStateMap {
 
     Pipeline pipeline = getPipeline(pipelineID);
     if (pipeline.isClosed()) {
-      /*
-       * It should be fine to add a container to a CLOSED pipeline as pipeline
-       * state can be changed while the container creating transaction is
-       * waiting to be processed by SCM.
-       */
-      LOG.info("Container {} in open state for pipeline={} in closed state",
-          containerID, pipelineID);
+      LOG.warn("Adding container {} to pipeline={} in CLOSED state." +
+          "  This happens only for some exceptional cases." +
+          "  Check for the previous exceptions.", containerID, pipelineID);
     }
     pipeline2container.get(pipelineID).add(containerID);
   }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/PipelineStateMap.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/PipelineStateMap.java
@@ -106,9 +106,13 @@ class PipelineStateMap {
 
     Pipeline pipeline = getPipeline(pipelineID);
     if (pipeline.isClosed()) {
-      throw new IOException(String
-          .format("Cannot add container to pipeline=%s in closed state",
-              pipelineID));
+      /*
+       * It should be fine to add a container to a CLOSED pipeline as pipeline
+       * state can be changed while the container creating transaction is
+       * waiting to be processed by SCM.
+       */
+      LOG.info("Container {} in open state for pipeline={} in closed state",
+          containerID, pipelineID);
     }
     pipeline2container.get(pipelineID).add(containerID);
   }

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestPipelineManagerImpl.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestPipelineManagerImpl.java
@@ -807,7 +807,7 @@ public class TestPipelineManagerImpl {
     pipelineManager.addContainerToPipeline(pipelineID,
         ContainerID.valueOf(2));
     assertTrue(logCapturer.getOutput().contains(
-        "Adding container #2 to pipeline=" + pipelineID +" in CLOSED state."));
+        "Adding container #2 to pipeline=" + pipelineID + " in CLOSED state."));
   }
 
   @Test

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestPipelineManagerImpl.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestPipelineManagerImpl.java
@@ -762,7 +762,7 @@ public class TestPipelineManagerImpl {
   }
 
   @Test
-  public void testAddContainerWithClosedPipeline() throws Exception {
+  public void testAddContainerWithClosedPipelineScmStart() throws Exception {
     GenericTestUtils.LogCapturer logCapturer = GenericTestUtils.LogCapturer.
             captureLogs(LoggerFactory.getLogger(PipelineStateMap.class));
     SCMHADBTransactionBuffer buffer = new SCMHADBTransactionBufferStub(dbStore);
@@ -784,6 +784,30 @@ public class TestPipelineManagerImpl {
     assertTrue(logCapturer.getOutput().contains("Container " +
             ContainerID.valueOf(2) + " in open state for pipeline=" +
             pipelineID + " in closed state"));
+  }
+
+  @Test
+  public void testAddContainerWithClosedPipeline() throws Exception {
+    GenericTestUtils.LogCapturer logCapturer = GenericTestUtils.LogCapturer.
+        captureLogs(LoggerFactory.getLogger(PipelineStateMap.class));
+    SCMHADBTransactionBuffer buffer = new SCMHADBTransactionBufferStub(dbStore);
+    PipelineManagerImpl pipelineManager =
+        createPipelineManager(true, buffer);
+    Table<PipelineID, Pipeline> pipelineStore =
+        SCMDBDefinition.PIPELINES.getTable(dbStore);
+    Pipeline pipeline = pipelineManager.createPipeline(
+        RatisReplicationConfig
+            .getInstance(HddsProtos.ReplicationFactor.THREE));
+    PipelineID pipelineID = pipeline.getId();
+    pipelineManager.addContainerToPipeline(pipelineID, ContainerID.valueOf(1));
+    pipelineManager.getStateManager().updatePipelineState(
+        pipelineID.getProtobuf(), HddsProtos.PipelineState.PIPELINE_CLOSED);
+    buffer.flush();
+    Assertions.assertTrue(pipelineStore.get(pipelineID).isClosed());
+    pipelineManager.addContainerToPipeline(pipelineID,
+        ContainerID.valueOf(2));
+    assertTrue(logCapturer.getOutput().contains(
+        "Adding container #2 to pipeline=" + pipelineID +" in CLOSED state."));
   }
 
   @Test


### PR DESCRIPTION
## What changes were proposed in this pull request?

SCM should allow adding a container to a CLOSED pipeline as a pipeline state can be changed while the container creating transaction is waiting to be processed by SCM.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-7738

## How was this patch tested?
Unit tests.
Standard CI: https://github.com/duongkame/ozone/actions/runs/3857497185/jobs/6574962174