### PR TITLE
HDDS-7722. FSO buckets fail to invalidate open file table cache when committing a key

### DIFF
--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyCommitRequestWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyCommitRequestWithFSO.java
@@ -193,7 +193,7 @@ public class OMKeyCommitRequestWithFSO extends OMKeyCommitRequest {
       }
 
       // Add to cache of open key table and key table.
-      OMFileRequest.addOpenFileTableCacheEntry(omMetadataManager, dbFileKey,
+      OMFileRequest.addOpenFileTableCacheEntry(omMetadataManager, dbOpenFileKey,
               null, fileName, trxnLogIndex);
 
       OMFileRequest.addFileTableCacheEntry(omMetadataManager, dbFileKey,

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMKeyCommitRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMKeyCommitRequest.java
@@ -83,8 +83,8 @@ public class TestOMKeyCommitRequest extends TestOMKeyRequest {
     String ozoneKey = getOzonePathKey();
 
     OmKeyInfo omKeyInfo =
-            omMetadataManager.getOpenKeyTable(omKeyCommitRequest.getBucketLayout())
-            .get(openKey);
+            omMetadataManager.getOpenKeyTable(
+                    omKeyCommitRequest.getBucketLayout()).get(openKey);
     Assert.assertNotNull(omKeyInfo);
 
     // Key should not be there in key table, as validateAndUpdateCache is
@@ -147,11 +147,17 @@ public class TestOMKeyCommitRequest extends TestOMKeyRequest {
     OMRequestTestUtils.addVolumeAndBucketToDB(volumeName, bucketName,
         omMetadataManager, omKeyCommitRequest.getBucketLayout());
 
-    String ozoneKey = addKeyToOpenKeyTable(allocatedLocationList);
+    String openKey = addKeyToOpenKeyTable(allocatedLocationList);
+    String ozoneKey = getOzonePathKey();
+
+    OmKeyInfo omKeyInfo =
+            omMetadataManager.getOpenKeyTable(
+                    omKeyCommitRequest.getBucketLayout()).get(openKey);
+    Assert.assertNotNull(omKeyInfo);
 
     // Key should not be there in key table, as validateAndUpdateCache is
     // still not called.
-    OmKeyInfo omKeyInfo =
+    omKeyInfo =
         omMetadataManager.getKeyTable(omKeyCommitRequest.getBucketLayout())
             .get(ozoneKey);
 
@@ -167,7 +173,7 @@ public class TestOMKeyCommitRequest extends TestOMKeyRequest {
     // Entry should be deleted from openKey Table.
     omKeyInfo =
         omMetadataManager.getOpenKeyTable(omKeyCommitRequest.getBucketLayout())
-            .get(ozoneKey);
+            .get(openKey);
     Assert.assertNull(omKeyInfo);
 
     // Now entry should be created in key Table.
@@ -220,11 +226,17 @@ public class TestOMKeyCommitRequest extends TestOMKeyRequest {
     OMRequestTestUtils.addVolumeAndBucketToDB(volumeName, bucketName,
         omMetadataManager, omKeyCommitRequest.getBucketLayout());
 
-    String ozoneKey = addKeyToOpenKeyTable(allocatedBlockList);
+    String openKey = addKeyToOpenKeyTable(allocatedBlockList);
+    String ozoneKey = getOzonePathKey();
+
+    OmKeyInfo omKeyInfo =
+            omMetadataManager.getOpenKeyTable(
+                    omKeyCommitRequest.getBucketLayout()).get(openKey);
+    Assert.assertNotNull(omKeyInfo);
 
     // Key should not be there in key table, as validateAndUpdateCache is
     // still not called.
-    OmKeyInfo omKeyInfo =
+    omKeyInfo =
         omMetadataManager.getKeyTable(omKeyCommitRequest.getBucketLayout())
             .get(ozoneKey);
 
@@ -249,7 +261,7 @@ public class TestOMKeyCommitRequest extends TestOMKeyRequest {
     // Entry should be deleted from openKey Table.
     omKeyInfo =
         omMetadataManager.getOpenKeyTable(omKeyCommitRequest.getBucketLayout())
-            .get(ozoneKey);
+            .get(openKey);
     Assert.assertNull(omKeyInfo);
 
     // Now entry should be created in key Table.

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMKeyCommitRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMKeyCommitRequest.java
@@ -79,11 +79,17 @@ public class TestOMKeyCommitRequest extends TestOMKeyRequest {
     OMRequestTestUtils.addVolumeAndBucketToDB(volumeName, bucketName,
         omMetadataManager, omKeyCommitRequest.getBucketLayout());
 
-    String ozoneKey = addKeyToOpenKeyTable(allocatedLocationList);
+    String openKey = addKeyToOpenKeyTable(allocatedLocationList);
+    String ozoneKey = getOzonePathKey();
+
+    OmKeyInfo omKeyInfo =
+            omMetadataManager.getOpenKeyTable(omKeyCommitRequest.getBucketLayout())
+            .get(openKey);
+    Assert.assertNotNull(omKeyInfo);
 
     // Key should not be there in key table, as validateAndUpdateCache is
     // still not called.
-    OmKeyInfo omKeyInfo =
+    omKeyInfo =
         omMetadataManager.getKeyTable(omKeyCommitRequest.getBucketLayout())
             .get(ozoneKey);
 
@@ -99,7 +105,7 @@ public class TestOMKeyCommitRequest extends TestOMKeyRequest {
     // Entry should be deleted from openKey Table.
     omKeyInfo =
         omMetadataManager.getOpenKeyTable(omKeyCommitRequest.getBucketLayout())
-            .get(ozoneKey);
+            .get(openKey);
     Assert.assertNull(omKeyInfo);
 
     // Now entry should be created in key Table.
@@ -613,7 +619,8 @@ public class TestOMKeyCommitRequest extends TestOMKeyRequest {
         clientID, replicationType, replicationFactor, omMetadataManager,
         locationList, version);
 
-    return getOzonePathKey();
+    return omMetadataManager.getOpenKey(volumeName, bucketName,
+              keyName, clientID);
   }
 
   @NotNull

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMKeyCommitRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMKeyCommitRequest.java
@@ -180,7 +180,6 @@ public class TestOMKeyCommitRequest extends TestOMKeyRequest {
     omKeyInfo =
         omMetadataManager.getKeyTable(omKeyCommitRequest.getBucketLayout())
             .get(ozoneKey);
-
     Assert.assertNotNull(omKeyInfo);
     // DB keyInfo format
     verifyKeyName(omKeyInfo);

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMKeyCommitRequestWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMKeyCommitRequestWithFSO.java
@@ -57,11 +57,12 @@ public class TestOMKeyCommitRequestWithFSO extends TestOMKeyCommitRequest {
 
   @Override
   protected String getOzonePathKey() throws IOException {
-    final long volumeId = getVolumeID();
+    final long volumeID = getVolumeID();
     final long bucketID = getBucketID();
     String fileName = OzoneFSUtils.getFileName(keyName);
-    return omMetadataManager.getOzonePathKey(volumeId, bucketID,
-            bucketID, fileName);
+
+    return omMetadataManager.getOzonePathKey(volumeID, bucketID,
+            parentID, fileName);
   }
 
   @Override
@@ -84,11 +85,9 @@ public class TestOMKeyCommitRequestWithFSO extends TestOMKeyCommitRequest {
     omKeyInfoFSO.appendNewBlocks(locationList, false);
 
     String fileName = OzoneFSUtils.getFileName(keyName);
-    OMRequestTestUtils.addFileToKeyTable(true, false,
+    return OMRequestTestUtils.addFileToKeyTable(true, false,
             fileName, omKeyInfoFSO, clientID, txnLogId, omMetadataManager);
 
-    return omMetadataManager.getOzonePathKey(getVolumeID(), getBucketID(),
-            parentID, fileName);
   }
 
   @NotNull


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fix incorrect use of openKeyTable/openFileTable, where key/file name, instead of open key/file name is used.

## What is the link to the Apache JIRA

[HDDS-7722](https://issues.apache.org/jira/browse/HDDS-7722)

## How was this patch tested?

Existing unit tests