### PR TITLE
HDDS-6056. Recon /containers endpoint should return SCM container data instead of OM container data.

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/recon/TestReconWithOzoneManager.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/recon/TestReconWithOzoneManager.java
@@ -189,10 +189,6 @@ public class TestReconWithOzoneManager {
     OmKeyInfo keyInfo1 =
         metadataManager.getKeyTable(getBucketLayout()).get(ozoneKey);
 
-    TableIterator<String, ? extends Table.KeyValue<String, OmKeyInfo>>
-        omKeyValueTableIterator =
-        metadataManager.getKeyTable(getBucketLayout()).iterator();
-
     // verify if OM has /vol0/bucket0/key0
     Assert.assertEquals("vol0", keyInfo1.getVolumeName());
     Assert.assertEquals("bucket0", keyInfo1.getBucketName());

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/recon/TestReconWithOzoneManager.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/recon/TestReconWithOzoneManager.java
@@ -193,8 +193,6 @@ public class TestReconWithOzoneManager {
         omKeyValueTableIterator =
         metadataManager.getKeyTable(getBucketLayout()).iterator();
 
-    long omMetadataKeyCount = getTableKeyCount(omKeyValueTableIterator);
-
     // verify if OM has /vol0/bucket0/key0
     Assert.assertEquals("vol0", keyInfo1.getVolumeName());
     Assert.assertEquals("bucket0", keyInfo1.getBucketName());
@@ -203,21 +201,6 @@ public class TestReconWithOzoneManager {
         cluster.getReconServer().getOzoneManagerServiceProvider();
     impl.syncDataFromOM();
     OzoneManagerSyncMetrics metrics = impl.getMetrics();
-
-    // HTTP call to /api/containers
-    String containerResponse = makeHttpCall(containerKeyServiceURL);
-    long reconMetadataContainerCount =
-        getReconContainerCount(containerResponse);
-    // verify count of keys after full snapshot
-    Assert.assertEquals(omMetadataKeyCount, reconMetadataContainerCount);
-
-    // verify if Recon Metadata captures vol0/bucket0/key0 info in container0
-    LinkedTreeMap containerResponseMap = getContainerResponseMap(
-        containerResponse, 0);
-    Assert.assertEquals(0,
-        (long)(double) containerResponseMap.get("ContainerID"));
-    Assert.assertEquals(1,
-        (long)(double) containerResponseMap.get("NumberOfKeys"));
     
     // HTTP call to /api/task/status
     long omLatestSeqNumber = ((RDBStore) metadataManager.getStore())
@@ -235,27 +218,9 @@ public class TestReconWithOzoneManager {
 
     //add 4 keys to check for delta updates
     addKeys(1, 5);
-    omKeyValueTableIterator =
-        metadataManager.getKeyTable(getBucketLayout()).iterator();
-    omMetadataKeyCount = getTableKeyCount(omKeyValueTableIterator);
 
     // update the next snapshot from om to verify delta updates
     impl.syncDataFromOM();
-
-    // HTTP call to /api/containers
-    containerResponse = makeHttpCall(containerKeyServiceURL);
-    reconMetadataContainerCount = getReconContainerCount(containerResponse);
-
-    //verify count of keys
-    Assert.assertEquals(omMetadataKeyCount, reconMetadataContainerCount);
-
-    //verify if Recon Metadata captures vol3/bucket3/key3 info in container3
-    containerResponseMap = getContainerResponseMap(
-        containerResponse, 3);
-    Assert.assertEquals(3,
-        (long)(double) containerResponseMap.get("ContainerID"));
-    Assert.assertEquals(1,
-        (long)(double) containerResponseMap.get("NumberOfKeys"));
 
     // HTTP call to /api/task/status
     omLatestSeqNumber = ((RDBStore) metadataManager.getStore())
@@ -282,27 +247,9 @@ public class TestReconWithOzoneManager {
 
     //add 5 more keys to OM
     addKeys(5, 10);
-    omKeyValueTableIterator =
-        metadataManager.getKeyTable(getBucketLayout()).iterator();
-    omMetadataKeyCount = getTableKeyCount(omKeyValueTableIterator);
 
     // get the next snapshot from om
     impl.syncDataFromOM();
-
-    // HTTP call to /api/containers
-    containerResponse = makeHttpCall(containerKeyServiceURL);
-    reconMetadataContainerCount = getReconContainerCount(containerResponse);
-
-    // verify count of keys
-    Assert.assertEquals(omMetadataKeyCount, reconMetadataContainerCount);
-
-    // verify if Recon Metadata captures vol7/bucket7/key7 info in container7
-    containerResponseMap = getContainerResponseMap(
-        containerResponse, 7);
-    Assert.assertEquals(7,
-        (long)(double) containerResponseMap.get("ContainerID"));
-    Assert.assertEquals(1,
-        (long)(double) containerResponseMap.get("NumberOfKeys"));
 
     // HTTP call to /api/task/status
     omLatestSeqNumber = ((RDBStore) metadataManager.getStore())

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/api/ContainerEndpoint.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/api/ContainerEndpoint.java
@@ -122,7 +122,7 @@ public class ContainerEndpoint {
       return Response.ok().build();
     }
     long containersCount;
-    Collection<ContainerMetadata> containerMetadatas =
+    Collection<ContainerMetadata> containerMetaDataList =
         containerManager.getContainers(ContainerID.valueOf(prevKey), limit)
             .stream()
             .map(container -> {
@@ -133,9 +133,9 @@ public class ContainerEndpoint {
             })
             .collect(Collectors.toList());
 
-    containersCount = containerMetadatas.size();
+    containersCount = containerMetaDataList.size();
     ContainersResponse containersResponse =
-        new ContainersResponse(containersCount, containerMetadatas);
+        new ContainersResponse(containersCount, containerMetaDataList);
     return Response.ok(containersResponse).build();
   }
 

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/api/ContainerEndpoint.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/api/ContainerEndpoint.java
@@ -119,7 +119,7 @@ public class ContainerEndpoint {
       @QueryParam(RECON_QUERY_PREVKEY) long prevKey) {
     if (limit < 0 || prevKey < 0) {
       // Send back an empty response
-      return Response.ok().build();
+      return Response.status(Response.Status.NOT_ACCEPTABLE).build();
     }
     long containersCount;
     Collection<ContainerMetadata> containerMetaDataList =

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/api/TestContainerEndpoint.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/api/TestContainerEndpoint.java
@@ -96,7 +96,7 @@ import org.junit.rules.TemporaryFolder;
 /**
  * Test for container endpoint.
  */
-public class TestContainerEndpoint extends AbstractReconContainerManagerTest {
+public class TestContainerEndpoint {
 
   @Rule
   public TemporaryFolder temporaryFolder = new TemporaryFolder();
@@ -330,14 +330,9 @@ public class TestContainerEndpoint extends AbstractReconContainerManagerTest {
   }
 
   @Test
-  public void testGetContainers() {
-    try {
+  public void testGetContainers() throws IOException, TimeoutException {
       putContainerInfos(5);
-    } catch (IOException e) {
-      e.printStackTrace();
-    } catch (TimeoutException e) {
-      e.printStackTrace();
-    }
+
     Response response = containerEndpoint.getContainers(10, 0L);
 
     ContainersResponse responseObject =

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/api/TestContainerEndpoint.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/api/TestContainerEndpoint.java
@@ -75,7 +75,6 @@ import org.apache.hadoop.ozone.recon.api.types.UnhealthyContainersResponse;
 import org.apache.hadoop.ozone.recon.persistence.ContainerHistory;
 import org.apache.hadoop.ozone.recon.persistence.ContainerHealthSchemaManager;
 import org.apache.hadoop.ozone.recon.recovery.ReconOMMetadataManager;
-import org.apache.hadoop.ozone.recon.scm.AbstractReconContainerManagerTest;
 import org.apache.hadoop.ozone.recon.scm.ReconContainerManager;
 import org.apache.hadoop.ozone.recon.scm.ReconPipelineManager;
 import org.apache.hadoop.ozone.recon.scm.ReconStorageContainerManagerFacade;
@@ -331,7 +330,7 @@ public class TestContainerEndpoint {
 
   @Test
   public void testGetContainers() throws IOException, TimeoutException {
-      putContainerInfos(5);
+    putContainerInfos(5);
 
     Response response = containerEndpoint.getContainers(10, 0L);
 

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/api/TestContainerEndpoint.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/api/TestContainerEndpoint.java
@@ -23,6 +23,8 @@ import static org.apache.hadoop.ozone.recon.OMMetadataManagerTestUtils.getRandom
 import static org.apache.hadoop.ozone.recon.OMMetadataManagerTestUtils.getTestReconOmMetadataManager;
 import static org.apache.hadoop.ozone.recon.OMMetadataManagerTestUtils.initializeNewOmMetadataManager;
 import static org.apache.hadoop.ozone.recon.OMMetadataManagerTestUtils.writeDataToOm;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
@@ -432,7 +434,7 @@ public class TestContainerEndpoint {
     MissingContainerMetadata containerWithLimit =
             responseWithLimitObject.getContainers().stream().findFirst()
                     .orElse(null);
-    Assert.assertNotNull(containerWithLimit);
+    assertNotNull(containerWithLimit);
 
     Collection<MissingContainerMetadata> recordsWithLimit
             = responseWithLimitObject.getContainers();
@@ -448,7 +450,7 @@ public class TestContainerEndpoint {
     assertEquals(5, responseObject.getTotalCount());
     MissingContainerMetadata container =
         responseObject.getContainers().stream().findFirst().orElse(null);
-    Assert.assertNotNull(container);
+    assertNotNull(container);
 
     assertEquals(containerID.getId(), container.getContainerID());
     assertEquals(keyCount, container.getKeys());

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/scm/TestReconContainerManager.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/scm/TestReconContainerManager.java
@@ -47,9 +47,7 @@ import org.apache.hadoop.hdds.scm.container.ContainerReplica;
 import org.apache.hadoop.hdds.scm.container.common.helpers.ContainerWithPipeline;
 import org.apache.hadoop.hdds.scm.ha.SCMHAManager;
 import org.apache.hadoop.hdds.scm.pipeline.Pipeline;
-
 import org.junit.jupiter.api.Test;
-
 
 /**
  * Test Recon Container Manager.

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/scm/TestReconContainerManager.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/scm/TestReconContainerManager.java
@@ -47,7 +47,9 @@ import org.apache.hadoop.hdds.scm.container.ContainerReplica;
 import org.apache.hadoop.hdds.scm.container.common.helpers.ContainerWithPipeline;
 import org.apache.hadoop.hdds.scm.ha.SCMHAManager;
 import org.apache.hadoop.hdds.scm.pipeline.Pipeline;
+
 import org.junit.jupiter.api.Test;
+
 
 /**
  * Test Recon Container Manager.


### PR DESCRIPTION
## What changes were proposed in this pull request?

**Problem :** 
- The problem is that currently we are iterating through the OM-DB Snapshot using the ReconContainerMetadataManagerto provide data to these endpoints. Which is not very Reliable and UpToDate for container metadata. On the other hand we know for a fact that SCM DB snapshots are also fetched by recon which have a more reliable and upToDate information about the containters. Hence, recon should use its SCM metadata to give out information through the Container Endpoint. 

**Solution:**
- Its sugested that SCM Snapshots have a better upTodate information about the containers, To get the required data from these snapshots, we will fetch data from `ReconContainerManager` Class which interacts with the SCM snapshots and use its methods to populate the results of `ContainerEndpoint` .

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-6056

## How was this patch tested?

UT
