### PR TITLE
HDDS-7455. ClassCastException: OzoneTokenIdentifier cannot be cast to String

### DIFF
--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/tasks/OMDBUpdatesHandler.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/tasks/OMDBUpdatesHandler.java
@@ -50,7 +50,7 @@ public class OMDBUpdatesHandler extends ManagedWriteBatch.Handler {
   private CodecRegistry codecRegistry;
   private OMMetadataManager omMetadataManager;
   private List<OMDBUpdateEvent> omdbUpdateEvents = new ArrayList<>();
-  private Map<String, OMDBUpdateEvent> omdbLatestUpdateEvents
+  private Map<Object, OMDBUpdateEvent> omdbLatestUpdateEvents
       = new HashMap<>();
   private OMDBDefinition omdbDefinition;
 
@@ -102,9 +102,6 @@ public class OMDBUpdatesHandler extends ManagedWriteBatch.Handler {
     // When this table data will be needed, all events for this table will be
     // saved using Object as key and new task will also retrieve using Object
     // as key.
-    if (OMDBDefinition.DTOKEN_TABLE.getName().equalsIgnoreCase(tableName)) {
-      return;
-    }
     Optional<Class> keyType = omdbDefinition.getKeyType(tableName);
     Optional<Class> valueType = omdbDefinition.getValueType(tableName);
     if (keyType.isPresent() && valueType.isPresent()) {
@@ -112,7 +109,7 @@ public class OMDBUpdatesHandler extends ManagedWriteBatch.Handler {
           new OMDBUpdateEvent.OMUpdateEventBuilder<>();
       builder.setTable(tableName);
       builder.setAction(action);
-      String key = (String) codecRegistry.asObject(keyBytes, keyType.get());
+      Object key = codecRegistry.asObject(keyBytes, keyType.get());
       builder.setKey(key);
 
       // Put new

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/tasks/TestOMDBUpdatesHandler.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/tasks/TestOMDBUpdatesHandler.java
@@ -38,6 +38,7 @@ import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.hdds.server.ServerUtils;
 import org.apache.hadoop.hdds.utils.db.RocksDatabase;
 import org.apache.hadoop.hdds.utils.db.managed.ManagedTransactionLogIterator;
+import org.apache.hadoop.io.Text;
 import org.apache.hadoop.ozone.om.OMMetadataManager;
 import org.apache.hadoop.ozone.om.OmMetadataManagerImpl;
 import org.apache.hadoop.ozone.om.codec.OMDBDefinition;
@@ -112,11 +113,20 @@ public class TestOMDBUpdatesHandler {
     reconOmMetadataManager.getKeyTable(getBucketLayout())
         .put("/sampleVol/bucketOne/key_two", secondKey);
 
+
+    Text tester = new Text("tester");
+    OzoneTokenIdentifier identifier =
+        new OzoneTokenIdentifier(tester, tester, tester);
+    identifier.setOmCertSerialId("certID");
+    identifier.setOmServiceId("");
+
+    omMetadataManager.getDelegationTokenTable().put(identifier, 12345L);
+
     List<byte[]> writeBatches = getBytesFromOmMetaManager(0);
     OMDBUpdatesHandler omdbUpdatesHandler = captureEvents(writeBatches);
 
     List<OMDBUpdateEvent> events = omdbUpdatesHandler.getEvents();
-    assertEquals(3, events.size());
+    assertEquals(4, events.size());
 
     OMDBUpdateEvent volEvent = events.get(0);
     assertEquals(PUT, volEvent.getAction());


### PR DESCRIPTION
This JIRA is a bug in code while updating OM DB snapshots in Recon where framework for applying DB updates assumes storing OM DB updates in a event map with table keyType as "String" and while doing codec deserializing and type casting for DTOKENTABLE, it throws ClassCastException because for DTOKENTABLE, table key type is of "OzoneTokenIdentifier" class instead of String. 

**_Patch Fix:_**
This patch is fixed by skipping any updates or syncing of table DTOKENTABLE in Recon because Recon don't use this table for any use case as of now. If in future , DTOKENTABLE table data is needed, all events for this table updates will be saved using Object as key and new task will also retrieve using Object as key.

https://issues.apache.org/jira/browse/HDDS-7455

This patch was tested manually by creating secure cluster and tested with creating entry for DelegationToken type in dTokenTable.
