### PR TITLE
HDDS-7705. Fix OM Bootstrap request

### DIFF
--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocolPB/OMAdminProtocolPB.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocolPB/OMAdminProtocolPB.java
@@ -27,7 +27,7 @@ import org.apache.hadoop.security.KerberosInfo;
  * Protocol used for communication between OMs.
  */
 @ProtocolInfo(protocolName =
-    "org.apache.hadoop.ozone.om.protocol.OzoneManagerMetadataProtocol",
+    "org.apache.hadoop.ozone.om.protocol.OMAdminProtocol",
     protocolVersion = 1)
 @KerberosInfo(
     serverPrincipal = OMConfigKeys.OZONE_OM_KERBEROS_PRINCIPAL_KEY)


### PR DESCRIPTION
## What changes were proposed in this pull request?

Replaced OMAdminProtocolPB protocolName with a proper class name. The existing one does not exist and leads to "Unknown protocol" error, which does not allow to add a new OM to the existing cluster.


## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-7705

## How was this patch tested?

Manually tested, with the fix a new OM is able to join the existing cluster.
