### PR TITLE
HDDS-7753. Simplify DatanodeDetails#toString to improve log messages

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/protocol/DatanodeDetails.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/protocol/DatanodeDetails.java
@@ -196,15 +196,6 @@ public class DatanodeDetails extends NodeImpl implements
   }
 
   /**
-   * Returns the Hostname and IP of the datanode separated by a slash.
-   *
-   * Eg: datanode001.corp/192.168.0.123
-   */
-  public String getHostNameAndIP() {
-    return getHostName() + "/" + getIpAddress();
-  }
-
-  /**
    * Sets a DataNode Port.
    *
    * @param port DataNode port

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/protocol/DatanodeDetails.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/protocol/DatanodeDetails.java
@@ -503,6 +503,10 @@ public class DatanodeDetails extends NodeImpl implements
 
   @Override
   public String toString() {
+    return uuidString + "(" + hostName + "/" + ipAddress + ")";
+  }
+
+  public String toDebugString() {
     return uuid.toString() + "{" +
         "ip: " +
         ipAddress +

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/ec/reconstruction/ECReconstructionCommandInfo.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/ec/reconstruction/ECReconstructionCommandInfo.java
@@ -28,7 +28,6 @@ import java.util.TreeMap;
 import java.util.stream.IntStream;
 
 import static java.util.Collections.unmodifiableSortedMap;
-import static java.util.stream.Collectors.joining;
 import static java.util.stream.Collectors.toMap;
 
 /**
@@ -91,14 +90,8 @@ public class ECReconstructionCommandInfo {
         + "containerID=" + containerID
         + ", replication=" + ecReplicationConfig.getReplication()
         + ", missingIndexes=" + Arrays.toString(missingContainerIndexes)
-        + ", sources={" + toString(sourceNodeMap) + "}"
-        + ", targets={" + toString(targetNodeMap) + "}}";
-  }
-
-  private String toString(SortedMap<Integer, DatanodeDetails> nodeMap) {
-    return nodeMap.entrySet().stream()
-        .map(e -> e.getKey() + ":" + e.getValue().getHostNameAndIP())
-        .collect(joining(","));
+        + ", sources=" + sourceNodeMap
+        + ", targets=" + targetNodeMap + "}";
   }
 
   public long getTerm() {

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/protocol/commands/ReconstructECContainersCommand.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/protocol/commands/ReconstructECContainersCommand.java
@@ -141,12 +141,10 @@ public class ReconstructECContainersCommand
         .append(": containerID: ").append(containerID)
         .append(", replicationConfig: ").append(ecReplicationConfig)
         .append(", sources: [").append(getSources().stream()
-            .map(a -> a.dnDetails.getHostNameAndIP()
+            .map(a -> a.dnDetails
                 + " replicaIndex: " + a.getReplicaIndex())
             .collect(Collectors.joining(", "))).append("]")
-        .append(", targets: [").append(getTargetDatanodes().stream()
-            .map(DatanodeDetails::getHostNameAndIP)
-        .collect(Collectors.joining(", "))).append("]")
+        .append(", targets: ").append(getTargetDatanodes())
         .append(", missingIndexes: ").append(
             Arrays.toString(missingContainerIndexes));
     return sb.toString();

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/protocol/commands/ReplicateContainerCommand.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/protocol/commands/ReplicateContainerCommand.java
@@ -116,10 +116,7 @@ public class ReplicateContainerCommand
     sb.append(getType());
     sb.append(": containerId: ").append(getContainerID());
     sb.append(", replicaIndex: ").append(getReplicaIndex());
-    sb.append(", sourceNodes: [");
-    sb.append(sourceDatanodes.stream()
-        .map(DatanodeDetails::getHostNameAndIP)
-        .collect(Collectors.joining(", "))).append("]");
+    sb.append(", sourceNodes: ").append(sourceDatanodes);
     return sb.toString();
   }
 }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/SCMNodeManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/SCMNodeManager.java
@@ -543,9 +543,11 @@ public class SCMNodeManager implements NodeManager {
     if (opStateDiffers(reportedDn, scmStatus)) {
       if (scmContext.isLeader()) {
         LOG.info("Scheduling a command to update the operationalState " +
-                "persisted on {} as the reported value does not " +
+                "persisted on {} as the reported value ({}, {}) does not " +
                 "match the value stored in SCM ({}, {})",
             reportedDn,
+            reportedDn.getPersistedOpState(),
+            reportedDn.getPersistedOpStateExpiryEpochSec(),
             scmStatus.getOperationalState(),
             scmStatus.getOpStateExpiryEpochSeconds());
 
@@ -563,9 +565,11 @@ public class SCMNodeManager implements NodeManager {
         }
       } else {
         LOG.info("Update the operationalState saved in follower SCM " +
-                "for {} as the reported value does not " +
+                "for {} as the reported value ({}, {}) does not " +
                 "match the value stored in SCM ({}, {})",
             reportedDn,
+            reportedDn.getPersistedOpState(),
+            reportedDn.getPersistedOpStateExpiryEpochSec(),
             scmStatus.getOperationalState(),
             scmStatus.getOpStateExpiryEpochSeconds());
 

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/SCMNodeManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/SCMNodeManager.java
@@ -394,16 +394,16 @@ public class SCMNodeManager implements NodeManager {
         addEntryToDnsToUuidMap(dnsName, datanodeDetails.getUuidString());
         // Updating Node Report, as registration is successful
         processNodeReport(datanodeDetails, nodeReport);
-        LOG.info("Registered Data node : {}", datanodeDetails);
+        LOG.info("Registered Data node : {}", datanodeDetails.toDebugString());
         scmNodeEventPublisher.fireEvent(SCMEvents.NEW_NODE, datanodeDetails);
       } catch (NodeAlreadyExistsException e) {
         if (LOG.isTraceEnabled()) {
           LOG.trace("Datanode is already registered. Datanode: {}",
-              datanodeDetails.toString());
+              datanodeDetails);
         }
       } catch (NodeNotFoundException e) {
         LOG.error("Cannot find datanode {} from nodeStateManager",
-            datanodeDetails.toString());
+            datanodeDetails);
       }
     } else {
       // Update datanode if it is registered but the ip or hostname changes


### PR DESCRIPTION
## What changes were proposed in this pull request?

`DatanodeDetails#toString` outputs too much detail for it to be usable in each and every log message related to datanodes.  Thus log statements currently have to build their own output (e.g. for list of hosts, etc.), leading to duplication.

This PR replaces `toString` with less verbose implementation, but keeps the current one for occasional usage as `toDebugString`.

https://issues.apache.org/jira/browse/HDDS-7753

## How was this patch tested?

Checked for log messages in `TestECContainerRecovery` output.

```
... [Under Replicated Processor] INFO  replication.ReplicationManager (ReplicationManager.java:sendDatanodeCommand(426)) - Sending command [reconstructECContainersCommand: containerID: 1, replicationConfig: EC/ECReplicationConfig{data=3, parity=2, ecChunkSize=1024, codec=rs}, sources: [38ebee1d-b2cd-4e58-9de6-20f391beb291(localhost/127.0.0.1) replicaIndex: 2, 66af460b-94b6-43e2-85e5-afa286f13712(localhost/127.0.0.1) replicaIndex: 3, 10ecf3b6-90a9-4cf6-8e18-633a6d41e838(localhost/127.0.0.1) replicaIndex: 4, a0edd823-1e08-4f0b-905c-87b466267435(localhost/127.0.0.1) replicaIndex: 5], targets: [edc89870-9c73-4040-b6c3-508456f7c48e(localhost/127.0.0.1)], missingIndexes: [1]] for container ContainerInfo{id=#1, state=CLOSED, pipelineID=PipelineID=60cb9ff8-f103-4e1d-8113-1704304fe882, stateEnterTime=2023-01-09T15:35:20.157Z, owner=om1} to edc89870-9c73-4040-b6c3-508456f7c48e(localhost/127.0.0.1)
... [ECContainerReconstructionThread-0] INFO  reconstruction.ECReconstructionCoordinatorTask (ECReconstructionCoordinatorTask.java:run(97)) - Completed ECReconstructionCommand{containerID=1, replication=rs-3-2-1024, missingIndexes=[1], sources={2=38ebee1d-b2cd-4e58-9de6-20f391beb291(localhost/127.0.0.1), 3=66af460b-94b6-43e2-85e5-afa286f13712(localhost/127.0.0.1), 4=10ecf3b6-90a9-4cf6-8e18-633a6d41e838(localhost/127.0.0.1), 5=a0edd823-1e08-4f0b-905c-87b466267435(localhost/127.0.0.1)}, targets={1=edc89870-9c73-4040-b6c3-508456f7c48e(localhost/127.0.0.1)` in 272 ms
... [Over Replicated Processor] INFO  replication.ReplicationManager (ReplicationManager.java:sendDatanodeCommand(426)) - Sending command [deleteContainerCommand: containerID: 1, replicaIndex: 1, force: true] for container ContainerInfo{id=#1, state=CLOSED, pipelineID=PipelineID=60cb9ff8-f103-4e1d-8113-1704304fe882, stateEnterTime=2023-01-09T15:35:20.157Z, owner=om1} to b4e72fba-ed18-4213-b609-5d05054eab1c(localhost/127.0.0.1)
... [Under Replicated Processor] INFO  replication.ReplicationManager (ReplicationManager.java:sendDatanodeCommand(426)) - Sending command [reconstructECContainersCommand: containerID: 2, replicationConfig: EC/ECReplicationConfig{data=3, parity=2, ecChunkSize=1024, codec=rs}, sources: [5f45cafe-8ef6-4bae-8d82-ead9d2bb2384(localhost/127.0.0.1) replicaIndex: 2, 66af460b-94b6-43e2-85e5-afa286f13712(localhost/127.0.0.1) replicaIndex: 3, b4e72fba-ed18-4213-b609-5d05054eab1c(localhost/127.0.0.1) replicaIndex: 4, 5d638143-0bbd-4dd8-931f-e16d2a604d5d(localhost/127.0.0.1) replicaIndex: 5], targets: [edc89870-9c73-4040-b6c3-508456f7c48e(localhost/127.0.0.1)], missingIndexes: [1]] for container ContainerInfo{id=#2, state=CLOSED, pipelineID=PipelineID=410d64cf-d917-4b03-b3a0-dc4fdeb535d7, stateEnterTime=2023-01-09T15:35:58.366Z, owner=om1} to edc89870-9c73-4040-b6c3-508456f7c48e(localhost/127.0.0.1)
... [ECContainerReconstructionThread-1] WARN  reconstruction.ECReconstructionCoordinatorTask (ECReconstructionCoordinatorTask.java:run(100)) - Failed ECReconstructionCommand{containerID=2, replication=rs-3-2-1024, missingIndexes=[1], sources={2=5f45cafe-8ef6-4bae-8d82-ead9d2bb2384(localhost/127.0.0.1), 3=66af460b-94b6-43e2-85e5-afa286f13712(localhost/127.0.0.1), 4=b4e72fba-ed18-4213-b609-5d05054eab1c(localhost/127.0.0.1), 5=5d638143-0bbd-4dd8-931f-e16d2a604d5d(localhost/127.0.0.1)}, targets={1=edc89870-9c73-4040-b6c3-508456f7c48e(localhost/127.0.0.1)` after 2333 ms
```

Regular CI:
https://github.com/adoroszlai/hadoop-ozone/actions/runs/3875394666