### PR TITLE
HDDS-7524. [Snapshot] Prune backup SST files that can be expanded periodically

### DIFF
--- a/hadoop-hdds/rocksdb-checkpoint-differ/src/main/java/org/apache/ozone/rocksdiff/RocksDBCheckpointDiffer.java
+++ b/hadoop-hdds/rocksdb-checkpoint-differ/src/main/java/org/apache/ozone/rocksdiff/RocksDBCheckpointDiffer.java
@@ -204,7 +204,7 @@ public class RocksDBCheckpointDiffer implements AutoCloseable {
           TimeUnit.MILLISECONDS);
 
       this.executor.scheduleWithFixedDelay(
-          this::pruneSttFiles,
+          this::pruneSstFiles,
           pruneCompactionDagDaemonRunIntervalInMs,
           pruneCompactionDagDaemonRunIntervalInMs,
           TimeUnit.MILLISECONDS
@@ -1290,7 +1290,7 @@ public class RocksDBCheckpointDiffer implements AutoCloseable {
    * those are not needed to generate snapshot diff. These files are basically
    * non-leaf nodes of the DAG.
    */
-  public void pruneSttFiles() {
+  public void pruneSstFiles() {
     Set<String> nonLeafSstFiles;
 
     synchronized (compactionListenerWriteLock) {

--- a/hadoop-hdds/rocksdb-checkpoint-differ/src/main/java/org/apache/ozone/rocksdiff/RocksDBCheckpointDiffer.java
+++ b/hadoop-hdds/rocksdb-checkpoint-differ/src/main/java/org/apache/ozone/rocksdiff/RocksDBCheckpointDiffer.java
@@ -73,7 +73,7 @@ import static java.util.Arrays.asList;
 //      - This bootstrapping should also receive the compaction-DAG information
 //  9. Handle rebuilding the DAG for a lagging follower. There are two cases
 //      - receive RATIS transactions to replay. Nothing needs to be done in
-//      these case.
+//      these cases.
 //      - Getting the DB sync. This case needs to handle getting the
 //      compaction-DAG information as well.
 

--- a/hadoop-hdds/rocksdb-checkpoint-differ/src/main/java/org/apache/ozone/rocksdiff/RocksDBCheckpointDiffer.java
+++ b/hadoop-hdds/rocksdb-checkpoint-differ/src/main/java/org/apache/ozone/rocksdiff/RocksDBCheckpointDiffer.java
@@ -72,8 +72,8 @@ import static java.util.Arrays.asList;
 //      rocksDB checkpoints.
 //      - This bootstrapping should also receive the compaction-DAG information
 //  9. Handle rebuilding the DAG for a lagging follower. There are two cases
-//      - recieve RATIS transactions to replay. Nothing needs to be done in
-//      thise case.
+//      - receive RATIS transactions to replay. Nothing needs to be done in
+//      these case.
 //      - Getting the DB sync. This case needs to handle getting the
 //      compaction-DAG information as well.
 
@@ -145,7 +145,7 @@ public class RocksDBCheckpointDiffer implements AutoCloseable {
    * Used to trim the file extension when writing compaction entries to the log
    * to save space.
    */
-  private static final String SST_FILE_EXTENSION = ".sst";
+  static final String SST_FILE_EXTENSION = ".sst";
   private static final int SST_FILE_EXTENSION_LENGTH =
       SST_FILE_EXTENSION.length();
 
@@ -202,6 +202,13 @@ public class RocksDBCheckpointDiffer implements AutoCloseable {
           pruneCompactionDagDaemonRunIntervalInMs,
           pruneCompactionDagDaemonRunIntervalInMs,
           TimeUnit.MILLISECONDS);
+
+      this.executor.scheduleWithFixedDelay(
+          this::pruneSttFiles,
+          pruneCompactionDagDaemonRunIntervalInMs,
+          pruneCompactionDagDaemonRunIntervalInMs,
+          TimeUnit.MILLISECONDS
+      );
     }
   }
 
@@ -1005,7 +1012,8 @@ public class RocksDBCheckpointDiffer implements AutoCloseable {
    */
   private void removeSstFile(Set<String> sstFileNodes) {
     for (String sstFileNode: sstFileNodes) {
-      File file = new File(sstBackupDir + sstFileNode + SST_FILE_EXTENSION);
+      File file =
+          new File(sstBackupDir + "/" + sstFileNode + SST_FILE_EXTENSION);
       try {
         Files.deleteIfExists(file.toPath());
       } catch (IOException exception) {
@@ -1269,6 +1277,30 @@ public class RocksDBCheckpointDiffer implements AutoCloseable {
       this.snapshotId = snapshotId;
       this.snapshotCreatedAt = snapshotCreatedAt;
     }
+  }
+
+  /**
+   * Defines the task that removes SST files from backup directory which are
+   * not needed to generate snapshot diff using compaction DAG to clean
+   * the disk space.
+   * We can’t simply delete input files in the compaction completed listener
+   * because it is not known which of input files are from previous compaction
+   * and which were created after the compaction.
+   * We can remove SST files which were created from the compaction because
+   * those are not needed to generate snapshot diff. These files are basically
+   * non-leaf nodes of the DAG.
+   */
+  public void pruneSttFiles() {
+    Set<String> nonLeafSstFiles;
+
+    synchronized (compactionListenerWriteLock) {
+      nonLeafSstFiles = forwardCompactionDAG.nodes().stream()
+          .filter(node -> !forwardCompactionDAG.successors(node).isEmpty())
+          .map(node -> node.getFileName())
+          .collect(Collectors.toSet());
+    }
+
+    removeSstFile(nonLeafSstFiles);
   }
 
   @VisibleForTesting

--- a/hadoop-hdds/rocksdb-checkpoint-differ/src/test/java/org/apache/ozone/rocksdiff/TestRocksDBCheckpointDiffer.java
+++ b/hadoop-hdds/rocksdb-checkpoint-differ/src/test/java/org/apache/ozone/rocksdiff/TestRocksDBCheckpointDiffer.java
@@ -459,10 +459,10 @@ public class TestRocksDBCheckpointDiffer {
     return rocksDB;
   }
 
-  private boolean deleteDirectory(java.io.File directoryToBeDeleted) {
+  private boolean deleteDirectory(File directoryToBeDeleted) {
     File[] allContents = directoryToBeDeleted.listFiles();
     if (allContents != null) {
-      for (java.io.File file : allContents) {
+      for (File file : allContents) {
         if (!deleteDirectory(file)) {
           return false;
         }
@@ -473,8 +473,10 @@ public class TestRocksDBCheckpointDiffer {
 
   // Read from a given RocksDB instance and optionally write all the
   // keys to a given file.
-  private void readRocksDBInstance(String dbPathArg, RocksDB rocksDB, FileWriter file,
-      RocksDBCheckpointDiffer differ) {
+  private void readRocksDBInstance(String dbPathArg,
+                                   RocksDB rocksDB,
+                                   FileWriter file,
+                                   RocksDBCheckpointDiffer differ) {
 
     LOG.debug("Reading RocksDB: " + dbPathArg);
     boolean createdDB = false;
@@ -1212,8 +1214,8 @@ public class TestRocksDBCheckpointDiffer {
 
   private void createFileWithContext(String fileName, String context)
       throws IOException {
-    FileOutputStream fileOutputStream = new FileOutputStream(fileName);
-    fileOutputStream.write(context.getBytes(UTF_8));
-    fileOutputStream.close();
+    try (FileOutputStream fileOutputStream = new FileOutputStream(fileName)) {
+      fileOutputStream.write(context.getBytes(UTF_8));
+    }
   }
 }

--- a/hadoop-hdds/rocksdb-checkpoint-differ/src/test/java/org/apache/ozone/rocksdiff/TestRocksDBCheckpointDiffer.java
+++ b/hadoop-hdds/rocksdb-checkpoint-differ/src/test/java/org/apache/ozone/rocksdiff/TestRocksDBCheckpointDiffer.java
@@ -1192,7 +1192,7 @@ public class TestRocksDBCheckpointDiffer {
             MINUTES.toMillis(10));
 
     differ.loadAllCompactionLogs();
-    differ.pruneSttFiles();
+    differ.pruneSstFiles();
 
     Set<String> actualFileSetAfterPruning;
     try (Stream<Path> pathStream = Files.list(Paths.get(sstBackUpDirName))

--- a/hadoop-hdds/rocksdb-checkpoint-differ/src/test/java/org/apache/ozone/rocksdiff/TestRocksDBCheckpointDiffer.java
+++ b/hadoop-hdds/rocksdb-checkpoint-differ/src/test/java/org/apache/ozone/rocksdiff/TestRocksDBCheckpointDiffer.java
@@ -22,10 +22,12 @@ import static java.util.Arrays.asList;
 import static java.util.concurrent.TimeUnit.MINUTES;
 import com.google.common.graph.GraphBuilder;
 import java.io.File;
+import java.io.FileOutputStream;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -68,6 +70,7 @@ import org.slf4j.event.Level;
 import static org.apache.ozone.rocksdiff.RocksDBCheckpointDiffer.COMPACTION_LOG_FILE_NAME_SUFFIX;
 import static org.apache.ozone.rocksdiff.RocksDBCheckpointDiffer.DEBUG_DAG_LIVE_NODES;
 import static org.apache.ozone.rocksdiff.RocksDBCheckpointDiffer.DEBUG_READ_ALL_DB_KEYS;
+import static org.apache.ozone.rocksdiff.RocksDBCheckpointDiffer.SST_FILE_EXTENSION;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -456,7 +459,7 @@ public class TestRocksDBCheckpointDiffer {
     return rocksDB;
   }
 
-  static boolean deleteDirectory(java.io.File directoryToBeDeleted) {
+  private boolean deleteDirectory(java.io.File directoryToBeDeleted) {
     File[] allContents = directoryToBeDeleted.listFiles();
     if (allContents != null) {
       for (java.io.File file : allContents) {
@@ -470,7 +473,7 @@ public class TestRocksDBCheckpointDiffer {
 
   // Read from a given RocksDB instance and optionally write all the
   // keys to a given file.
-  void readRocksDBInstance(String dbPathArg, RocksDB rocksDB, FileWriter file,
+  private void readRocksDBInstance(String dbPathArg, RocksDB rocksDB, FileWriter file,
       RocksDBCheckpointDiffer differ) {
 
     LOG.debug("Reading RocksDB: " + dbPathArg);
@@ -1080,11 +1083,20 @@ public class TestRocksDBCheckpointDiffer {
 
     differ.pruneOlderSnapshotsWithCompactionHistory();
 
-    Set<String> actualNodes = differ.getForwardCompactionDAG().nodes().stream()
+    Set<String> actualNodesInForwardDAG = differ.getForwardCompactionDAG()
+        .nodes()
+        .stream()
         .map(CompactionNode::getFileName)
         .collect(Collectors.toSet());
 
-    assertEquals(expectedNodes, actualNodes);
+    Set<String> actualNodesBackwardDAG = differ.getBackwardCompactionDAG()
+        .nodes()
+        .stream()
+        .map(CompactionNode::getFileName)
+        .collect(Collectors.toSet());
+
+    assertEquals(expectedNodes, actualNodesInForwardDAG);
+    assertEquals(expectedNodes, actualNodesBackwardDAG);
 
     for (int i = 0; i < expectedNumberOfLogFilesDeleted; i++) {
       File compactionFile = filesCreated.get(i);
@@ -1099,5 +1111,109 @@ public class TestRocksDBCheckpointDiffer {
 
     deleteDirectory(compactionLogDir);
     deleteDirectory(sstBackUpDir);
+  }
+
+  private static Stream<Arguments> sstFilePruningScenarios() {
+    return Stream.of(
+        Arguments.of("Case 1: No compaction.",
+            "",
+            Arrays.asList("000015", "000013", "000011", "000009"),
+            Arrays.asList("000015", "000013", "000011", "000009")
+        ),
+        Arguments.of("Case 2: One level compaction.",
+            "C 000015,000013,000011,000009:000018,000016,000017\n",
+            Arrays.asList("000015", "000013", "000011", "000009", "000018",
+                "000016", "000017", "000026", "000024", "000022", "000020"),
+            Arrays.asList("000015", "000013", "000011", "000009", "000026",
+                "000024", "000022", "000020")
+        ),
+        Arguments.of("Case 3: Multi-level compaction.",
+            "C 000015,000013,000011,000009:000018,000016,000017\n" +
+                "C 000018,000016,000017,000026,000024,000022,000020:000027," +
+                "000030,000028,000031,000029\n" +
+                "C 000027,000030,000028,000031,000029,000039,000037,000035," +
+                "000033:000040,000044,000042,000043,000046,000041,000045\n" +
+                "C 000040,000044,000042,000043,000046,000041,000045,000054," +
+                "000052,000050,000048:000059,000055,000056,000060,000057," +
+                "000058\n",
+            Arrays.asList("000015", "000013", "000011", "000009", "000018",
+                "000016", "000017", "000026", "000024", "000022", "000020",
+                "000027", "000030", "000028", "000031", "000029", "000039",
+                "000037", "000035", "000033", "000040", "000044", "000042",
+                "000043", "000046", "000041", "000045", "000054", "000052",
+                "000050", "000048", "000059", "000055", "000056", "000060",
+                "000057", "000058"),
+            Arrays.asList("000013", "000024", "000035", "000011", "000022",
+                "000033", "000039", "000015", "000026", "000037", "000048",
+                "000009", "000050", "000054", "000020", "000052")
+        )
+    );
+  }
+
+  /**
+   * End-to-end test for SST file pruning.
+   */
+  @ParameterizedTest(name = "{0}")
+  @MethodSource("sstFilePruningScenarios")
+  public void testSstFilePruning(
+      String description,
+      String compactionLog,
+      List<String> initialFiles,
+      List<String> expectedFiles
+  ) throws IOException {
+
+    String sstBackUpDirName = "./test-compaction-sst-backup";
+    File sstBackUpDir = new File(sstBackUpDirName);
+    if (!sstBackUpDir.exists() && !sstBackUpDir.mkdirs()) {
+      fail("Error creating SST backup directory: " + sstBackUpDirName);
+    }
+
+    String compactionLogDirName = "./test-compaction-log";
+    File compactionLogDir = new File(compactionLogDirName);
+    if (!compactionLogDir.exists() && !compactionLogDir.mkdirs()) {
+      fail("Error creating compaction log directory: " + compactionLogDirName);
+    }
+
+    createFileWithContext(compactionLogDirName + "/compaction_log" +
+            COMPACTION_LOG_FILE_NAME_SUFFIX,
+        compactionLog);
+
+    for (String fileName : initialFiles) {
+      createFileWithContext(sstBackUpDir + "/" + fileName + SST_FILE_EXTENSION,
+          fileName);
+    }
+
+    RocksDBCheckpointDiffer differ =
+        new RocksDBCheckpointDiffer(sstBackUpDirName,
+            compactionLogDirName,
+            null,
+            MINUTES.toMillis(10));
+
+    differ.loadAllCompactionLogs();
+    differ.pruneSttFiles();
+
+    Set<String> actualFileSetAfterPruning;
+    try (Stream<Path> pathStream = Files.list(Paths.get(sstBackUpDirName))
+        .filter(e -> e.toString().toLowerCase()
+            .endsWith(SST_FILE_EXTENSION))
+        .sorted()) {
+      actualFileSetAfterPruning =
+          pathStream.map(path -> path.getFileName().toString())
+              .map(name -> name.substring(0,
+                  name.length() - SST_FILE_EXTENSION.length()))
+              .collect(Collectors.toSet());
+    }
+
+    Set<String> expectedFileSet = new HashSet<>(expectedFiles);
+    assertEquals(expectedFileSet, actualFileSetAfterPruning);
+    deleteDirectory(compactionLogDir);
+    deleteDirectory(sstBackUpDir);
+  }
+
+  private void createFileWithContext(String fileName, String context)
+      throws IOException {
+    FileOutputStream fileOutputStream = new FileOutputStream(fileName);
+    fileOutputStream.write(context.getBytes(UTF_8));
+    fileOutputStream.close();
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

This change is to proactively remove the unnecessary SST files from the backup directory which are not needed to generate diff using compaction DAG.
These files are the one which get compacted to new files at each level. For example in the below graph, "000015", "000013", "000011", "000009" get compacted to "000018",  "000016", "000017". 
We don't need "000018",  "000016", "000017" to generate diff because these are compaction of previous level .

![reverseGraph](https://user-images.githubusercontent.com/6820020/211372896-c4f6eada-3fb0-4838-bcc6-08c47606a43f.png)


## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-7524

## How was this patch tested?
* Unit tests
