### PR TITLE
HDDS-7506. [Snapshot] Expose more snapshot metrics under OMMetrics

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOmMetrics.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOmMetrics.java
@@ -21,7 +21,6 @@ import static org.apache.hadoop.ozone.security.acl.OzoneObj.ResourceType.BUCKET;
 import static org.apache.hadoop.ozone.security.acl.OzoneObj.ResourceType.VOLUME;
 import static org.apache.hadoop.ozone.security.acl.OzoneObj.StoreType.OZONE;
 import static org.apache.hadoop.test.MetricsAsserts.assertCounter;
-import static org.apache.hadoop.test.MetricsAsserts.assertGauge;
 import static org.apache.hadoop.test.MetricsAsserts.getMetrics;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
@@ -417,9 +416,9 @@ public class TestOmMetrics {
     assertCounter("NumSnapshotListFails", 0L, omMetrics);
     assertCounter("NumSnapshotLists", 0L, omMetrics);
 
-    assertGauge("NumSnapshotActive", 1L, omMetrics);
-    assertGauge("NumSnapshotDeleted", 0L, omMetrics);
-    assertGauge("NumSnapshotReclaimed", 0L, omMetrics);
+    assertCounter("NumSnapshotActive", 1L, omMetrics);
+    assertCounter("NumSnapshotDeleted", 0L, omMetrics);
+    assertCounter("NumSnapshotReclaimed", 0L, omMetrics);
 
     // Create second key
     OmKeyArgs keyArgs2 = createKeyArgs(volumeName, bucketName,
@@ -434,7 +433,7 @@ public class TestOmMetrics {
     writeClient.listSnapshot(volumeName, bucketName);
 
     omMetrics = getMetrics("OMMetrics");
-    assertGauge("NumSnapshotActive", 2L, omMetrics);
+    assertCounter("NumSnapshotActive", 2L, omMetrics);
     assertCounter("NumSnapshotCreates", 2L, omMetrics);
     assertCounter("NumSnapshotLists", 1L, omMetrics);
 
@@ -443,7 +442,7 @@ public class TestOmMetrics {
 
     // Check number of active snapshots in the snapshot table
     // is the same after OM restart
-    assertGauge("NumSnapshotActive", 2L, omMetrics);
+    assertCounter("NumSnapshotActive", 2L, omMetrics);
   }
 
   private <T> void mockWritePathExceptions(Class<T>klass) throws Exception {

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOmMetrics.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOmMetrics.java
@@ -391,7 +391,7 @@ public class TestOmMetrics {
     clusterBuilder.setNumDatanodes(3);
     startCluster();
 
-    OmBucketInfo omBucketInfo = createBucketInfo();
+    OmBucketInfo omBucketInfo = createBucketInfo(false);
 
     String volumeName = omBucketInfo.getVolumeName();
     String bucketName = omBucketInfo.getBucketName();

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OMMetrics.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OMMetrics.java
@@ -456,11 +456,11 @@ public class OMMetrics implements OmMetadataReaderMetrics {
     numSnapshotActive.incr(num - currVal);
   }
 
-  public void incrNumSnapshotActive() {
+  public void incNumSnapshotActive() {
     numSnapshotActive.incr();
   }
 
-  public void decrNumSnapshotActive() {
+  public void decNumSnapshotActive() {
     numSnapshotActive.incr(-1);
   }
 
@@ -469,11 +469,11 @@ public class OMMetrics implements OmMetadataReaderMetrics {
     numSnapshotDeleted.incr(num - currVal);
   }
 
-  public void incrNumSnapshotDeleted() {
+  public void incNumSnapshotDeleted() {
     numSnapshotDeleted.incr();
   }
 
-  public void decrNumSnapshotDeleted() {
+  public void decNumSnapshotDeleted() {
     numSnapshotDeleted.incr(-1);
   }
 
@@ -482,11 +482,11 @@ public class OMMetrics implements OmMetadataReaderMetrics {
     numSnapshotReclaimed.incr(num - currVal);
   }
 
-  public void incrNumSnapshotReclaimed() {
+  public void incNumSnapshotReclaimed() {
     numSnapshotReclaimed.incr();
   }
 
-  public void decrNumSnapshotReclaimed() {
+  public void decNumSnapshotReclaimed() {
     numSnapshotReclaimed.incr(-1);
   }
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OMMetrics.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OMMetrics.java
@@ -26,6 +26,7 @@ import org.apache.hadoop.metrics2.annotation.Metric;
 import org.apache.hadoop.metrics2.annotation.Metrics;
 import org.apache.hadoop.metrics2.lib.DefaultMetricsSystem;
 import org.apache.hadoop.metrics2.lib.MutableCounterLong;
+import org.apache.hadoop.metrics2.lib.MutableGaugeLong;
 
 /**
  * This class is for maintaining Ozone Manager statistics.
@@ -120,6 +121,9 @@ public class OMMetrics implements OmMetadataReaderMetrics {
   private @Metric MutableCounterLong numOpenKeyDeleteRequestFails;
   private @Metric MutableCounterLong numSnapshotCreateFails;
   private @Metric MutableCounterLong numSnapshotListFails;
+  private @Metric MutableGaugeLong numSnapshotActive;
+  private @Metric MutableGaugeLong numSnapshotDeleted;
+  private @Metric MutableGaugeLong numSnapshotReclaimed;
 
   // Number of tenant operations attempted
   private @Metric MutableCounterLong numTenantOps;
@@ -446,6 +450,18 @@ public class OMMetrics implements OmMetadataReaderMetrics {
 
   public void incNumSnapshotListFails() {
     numSnapshotListFails.incr();
+  }
+
+  public void setNumSnapshotActive(long num) {
+    numSnapshotActive.set(num);
+  }
+
+  public void setNumSnapshotDeleted(long num) {
+    numSnapshotDeleted.set(num);
+  }
+
+  public void setNumSnapshotReclaimed(long num) {
+    numSnapshotReclaimed.set(num);
   }
 
   public void incNumCompleteMultipartUploadFails() {
@@ -1141,6 +1157,18 @@ public class OMMetrics implements OmMetadataReaderMetrics {
 
   public long getNumSnapshotListFails() {
     return numSnapshotListFails.value();
+  }
+
+  public long getNumSnapshotActive() {
+    return numSnapshotActive.value();
+  }
+
+  public long getNumSnapshotDeleted() {
+    return numSnapshotDeleted.value();
+  }
+
+  public long getNumSnapshotReclaimed() {
+    return numSnapshotReclaimed.value();
   }
 
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OMMetrics.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OMMetrics.java
@@ -26,7 +26,6 @@ import org.apache.hadoop.metrics2.annotation.Metric;
 import org.apache.hadoop.metrics2.annotation.Metrics;
 import org.apache.hadoop.metrics2.lib.DefaultMetricsSystem;
 import org.apache.hadoop.metrics2.lib.MutableCounterLong;
-import org.apache.hadoop.metrics2.lib.MutableGaugeLong;
 
 /**
  * This class is for maintaining Ozone Manager statistics.
@@ -121,9 +120,9 @@ public class OMMetrics implements OmMetadataReaderMetrics {
   private @Metric MutableCounterLong numOpenKeyDeleteRequestFails;
   private @Metric MutableCounterLong numSnapshotCreateFails;
   private @Metric MutableCounterLong numSnapshotListFails;
-  private @Metric MutableGaugeLong numSnapshotActive;
-  private @Metric MutableGaugeLong numSnapshotDeleted;
-  private @Metric MutableGaugeLong numSnapshotReclaimed;
+  private @Metric MutableCounterLong numSnapshotActive;
+  private @Metric MutableCounterLong numSnapshotDeleted;
+  private @Metric MutableCounterLong numSnapshotReclaimed;
 
   // Number of tenant operations attempted
   private @Metric MutableCounterLong numTenantOps;
@@ -453,15 +452,42 @@ public class OMMetrics implements OmMetadataReaderMetrics {
   }
 
   public void setNumSnapshotActive(long num) {
-    numSnapshotActive.set(num);
+    long currVal = numSnapshotActive.value();
+    numSnapshotActive.incr(num - currVal);
+  }
+
+  public void incrNumSnapshotActive() {
+    numSnapshotActive.incr();
+  }
+
+  public void decrNumSnapshotActive() {
+    numSnapshotActive.incr(-1);
   }
 
   public void setNumSnapshotDeleted(long num) {
-    numSnapshotDeleted.set(num);
+    long currVal = numSnapshotDeleted.value();
+    numSnapshotDeleted.incr(num - currVal);
+  }
+
+  public void incrNumSnapshotDeleted() {
+    numSnapshotDeleted.incr();
+  }
+
+  public void decrNumSnapshotDeleted() {
+    numSnapshotDeleted.incr(-1);
   }
 
   public void setNumSnapshotReclaimed(long num) {
-    numSnapshotReclaimed.set(num);
+    long currVal = numSnapshotReclaimed.value();
+    numSnapshotReclaimed.incr(num - currVal);
+  }
+
+  public void incrNumSnapshotReclaimed() {
+    numSnapshotReclaimed.incr();
+  }
+
+  public void decrNumSnapshotReclaimed() {
+    numSnapshotReclaimed.incr(-1);
   }
 
   public void incNumCompleteMultipartUploadFails() {

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/snapshot/OMSnapshotCreateRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/snapshot/OMSnapshotCreateRequest.java
@@ -109,7 +109,7 @@ public class OMSnapshotCreateRequest extends OMClientRequest {
 
     OMMetrics omMetrics = ozoneManager.getMetrics();
     omMetrics.incNumSnapshotCreates();
-    omMetrics.incrNumSnapshotActive();
+    omMetrics.incNumSnapshotActive();
 
     boolean acquiredBucketLock = false, acquiredSnapshotLock = false;
     IOException exception = null;

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/snapshot/OMSnapshotCreateRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/snapshot/OMSnapshotCreateRequest.java
@@ -109,10 +109,7 @@ public class OMSnapshotCreateRequest extends OMClientRequest {
 
     OMMetrics omMetrics = ozoneManager.getMetrics();
     omMetrics.incNumSnapshotCreates();
-    // get current number of active snapshot and increment by 1
-    long activeSnapshots = omMetrics.getNumSnapshotActive() + 1;
-    // update number of active snapshots
-    omMetrics.setNumSnapshotActive(activeSnapshots);
+    omMetrics.incrNumSnapshotActive();
 
     boolean acquiredBucketLock = false, acquiredSnapshotLock = false;
     IOException exception = null;

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/snapshot/OMSnapshotCreateRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/snapshot/OMSnapshotCreateRequest.java
@@ -109,6 +109,10 @@ public class OMSnapshotCreateRequest extends OMClientRequest {
 
     OMMetrics omMetrics = ozoneManager.getMetrics();
     omMetrics.incNumSnapshotCreates();
+    // get current number of active snapshot and increment by 1
+    long activeSnapshots = omMetrics.getNumSnapshotActive() + 1;
+    // update number of active snapshots
+    omMetrics.setNumSnapshotActive(activeSnapshots);
 
     boolean acquiredBucketLock = false, acquiredSnapshotLock = false;
     IOException exception = null;


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR is adding more snapshot metrics in `OMMetrics` to keep track of the count of each snapshot status. 
Right now there is no implementation for snapshot delete or reclaim and therefore these metrics are not getting a value anywhere in the code. 

We are going over the snapshot table on OM `start()`, `restart()` and `reloadOMState()` and get a count for every snapshot status. Also we are incrementing the number of active snapshots during every create request. In the future we might want to decrement the number of active when incrementing the number of delete and similarly decrement number of delete when incrementing number of reclaimed.

I've checked the snapshot metrics from HDFS and couldn't find something applicable here that's missing.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-7506

## How was this patch tested?

A new test was added in `TestOmMetrics` under `integration-test` package. Also we might want to expand this test method in the future as more snapshot features are made available.

This patch was also tested manually in a docker cluster like so

create a snapshot
```
❯ docker-compose up --scale datanode=3 -d
Creating network "ozone_default" with the default driver
Creating ozone_recon_1    ... done
Creating ozone_om_1       ... done
Creating ozone_s3g_1      ... done
Creating ozone_scm_1      ... done
Creating ozone_datanode_1 ... done
Creating ozone_datanode_2 ... done
Creating ozone_datanode_3 ... done

❯ docker exec -it ozone_om_1 bash
bash-4.2$ ozone sh volume create /vol1
bash-4.2$ ozone sh bucket create /vol1/bucket1 
bash-4.2$ ozone sh key put /vol1/bucket1/key1 README.md
bash-4.2$ ozone sh snapshot create /vol1/bucket1 snap1
```
on `0.0.0.0:9874/jmx`
```
    "NumSnapshotActive" : 1,
    "NumSnapshotCreateFails" : 0,
    "NumSnapshotCreates" : 1,
```

create another snapshot
```
bash-4.2$ ozone sh key put /vol1/bucket1/key2 /etc/hosts
bash-4.2$ ozone sh snapshot create /vol1/bucket1 snap2
bash-4.2$ exit
exit
```

check `0.0.0.0:9874/jmx` again
```
    "NumSnapshotActive" : 2,
    "NumSnapshotCreateFails" : 0,
    "NumSnapshotCreates" : 2,
```

restart the OM
```
❯ docker restart ozone_om_1 
ozone_om_1
```
check  `0.0.0.0:9874/jmx` right after restarting om
```
    "NumSnapshotActive" : 0,
    "NumSnapshotCreateFails" : 0,
    "NumSnapshotCreates" : 0,
```

after a minute, on `0.0.0.0:9874/jmx`
```
    "NumSnapshotActive" : 2,
    "NumSnapshotCreateFails" : 0,
    "NumSnapshotCreates" : 0,
```

