### PR TITLE
HDDS-7766. Extract Acl checks-related methods into a separate class

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOmAcls.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOmAcls.java
@@ -94,7 +94,7 @@ public class TestOmAcls {
         .build();
     cluster.waitForClusterToBeReady();
     logCapturer =
-        GenericTestUtils.LogCapturer.captureLogs(OzoneManager.getLogger());
+        GenericTestUtils.LogCapturer.captureLogs(AclManager.getLogger());
   }
 
   @AfterClass

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/AclManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/AclManager.java
@@ -1,0 +1,402 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with this
+ * work for additional information regarding copyright ownership.  The ASF
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.hadoop.ozone.om;
+
+import com.google.common.annotations.VisibleForTesting;
+import org.apache.hadoop.ipc.ProtobufRpcEngine;
+import org.apache.hadoop.ipc.Server;
+import org.apache.hadoop.ozone.OzoneConsts;
+import org.apache.hadoop.ozone.om.exceptions.OMException;
+import org.apache.hadoop.ozone.om.helpers.OmBucketInfo;
+import org.apache.hadoop.ozone.om.helpers.OmVolumeArgs;
+import org.apache.hadoop.ozone.security.acl.IAccessAuthorizer;
+import org.apache.hadoop.ozone.security.acl.OzoneObj;
+import org.apache.hadoop.ozone.security.acl.OzoneObjInfo;
+import org.apache.hadoop.ozone.security.acl.RequestContext;
+import org.apache.hadoop.security.UserGroupInformation;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+
+import static org.apache.hadoop.ozone.om.OzoneManager.getS3Auth;
+import static org.apache.hadoop.ozone.om.exceptions.OMException.ResultCodes.INVALID_REQUEST;
+import static org.apache.hadoop.ozone.om.lock.OzoneManagerLock.Resource.BUCKET_LOCK;
+import static org.apache.hadoop.ozone.om.lock.OzoneManagerLock.Resource.VOLUME_LOCK;
+
+/**
+ * AclManager is used to manage the ACLs for Ozone resources.
+ */
+public class AclManager {
+  public static final Logger LOG =
+      LoggerFactory.getLogger(AclManager.class);
+
+  private final OMMetadataManager metadataManager;
+  private final InetSocketAddress omRpcAddress;
+  private final IAccessAuthorizer accessAuthorizer;
+  private final boolean isNativeAuthorizerEnabled;
+
+  public AclManager(OMMetadataManager metadataManager,
+                    InetSocketAddress omRpcAddress,
+                    IAccessAuthorizer accessAuthorizer,
+                    boolean isNativeAuthorizerEnabled) {
+    this.metadataManager = metadataManager;
+    this.omRpcAddress = omRpcAddress;
+    this.accessAuthorizer = accessAuthorizer;
+    this.isNativeAuthorizerEnabled = isNativeAuthorizerEnabled;
+  }
+
+  public void checkAcls(OzoneObj.ResourceType resType,
+                        OzoneObj.StoreType store,
+                        IAccessAuthorizer.ACLType acl,
+                        String vol,
+                        String bucket,
+                        String key)
+      throws IOException {
+    UserGroupInformation user;
+    if (getS3Auth() != null) {
+      String principal =
+          OzoneAclUtils.accessIdToUserPrincipal(getS3Auth().getAccessId());
+      user = UserGroupInformation.createRemoteUser(principal);
+    } else {
+      user = ProtobufRpcEngine.Server.getRemoteUser();
+    }
+
+    InetAddress remoteIp = ProtobufRpcEngine.Server.getRemoteIp();
+
+    checkAllAcls(resType, store, acl,
+        vol, bucket, key,
+        user != null ? user : getRemoteUser(),
+        remoteIp != null ? remoteIp : omRpcAddress.getAddress(),
+        remoteIp != null ? remoteIp.getHostName()
+            : omRpcAddress.getHostName());
+  }
+
+  @SuppressWarnings("parameternumber")
+  private boolean checkAcls(OzoneObj.ResourceType resType,
+                            OzoneObj.StoreType storeType,
+                            IAccessAuthorizer.ACLType aclType,
+                            String vol, String bucket, String key,
+                            UserGroupInformation ugi,
+                            InetAddress remoteAddress, String hostName,
+                            boolean throwIfPermissionDenied, String volumeOwner)
+      throws OMException {
+    OzoneObj obj = OzoneObjInfo.Builder.newBuilder()
+        .setResType(resType)
+        .setStoreType(storeType)
+        .setVolumeName(vol)
+        .setBucketName(bucket)
+        .setKeyName(key).build();
+    RequestContext context = RequestContext.newBuilder()
+        .setClientUgi(ugi)
+        .setIp(remoteAddress)
+        .setHost(hostName)
+        .setAclType(IAccessAuthorizer.ACLIdentityType.USER)
+        .setAclRights(aclType)
+        .setOwnerName(volumeOwner)
+        .build();
+
+    return checkAcls(obj, context, throwIfPermissionDenied);
+  }
+
+  private boolean checkAcls(OzoneObj obj, RequestContext context,
+                            boolean throwIfPermissionDenied)
+      throws OMException {
+
+    if (!accessAuthorizer.checkAccess(obj, context)) {
+      if (throwIfPermissionDenied) {
+        String volumeName = obj.getVolumeName() != null ?
+            "Volume:" + obj.getVolumeName() + " " : "";
+        String bucketName = obj.getBucketName() != null ?
+            "Bucket:" + obj.getBucketName() + " " : "";
+        String keyName = obj.getKeyName() != null ?
+            "Key:" + obj.getKeyName() : "";
+        LOG.warn("User {} doesn't have {} permission to access {} {}{}{}",
+            context.getClientUgi().getUserName(), context.getAclRights(),
+            obj.getResourceType(), volumeName, bucketName, keyName);
+        throw new OMException("User " + context.getClientUgi().getUserName() +
+            " doesn't have " + context.getAclRights() +
+            " permission to access " + obj.getResourceType() + " " +
+            volumeName + bucketName + keyName,
+            OMException.ResultCodes.PERMISSION_DENIED);
+      }
+      return false;
+    } else {
+      return true;
+    }
+  }
+
+  @SuppressWarnings("parameternumber")
+  public void checkAllAcls(
+      OzoneObj.ResourceType resType,
+      OzoneObj.StoreType storeType, IAccessAuthorizer.ACLType aclType,
+      String vol, String bucket, String key,
+      UserGroupInformation user, InetAddress remoteAddress,
+      String hostName) throws IOException {
+
+    String volOwner = getVolumeOwner(vol, aclType, resType);
+    String bucketOwner = getBucketOwner(vol, bucket, aclType, resType);
+    boolean isVolOwner = isOwner(user, volOwner);
+
+    IAccessAuthorizer.ACLType parentAclRight = aclType;
+
+    //OzoneNativeAuthorizer differs from Ranger Authorizer as Ranger requires
+    // only READ access on parent level access. OzoneNativeAuthorizer has
+    // different parent level access based on the child level access type
+    if (isNativeAuthorizerEnabled) {
+      if (aclType == IAccessAuthorizer.ACLType.CREATE ||
+          aclType == IAccessAuthorizer.ACLType.DELETE ||
+          aclType == IAccessAuthorizer.ACLType.WRITE_ACL) {
+        parentAclRight = IAccessAuthorizer.ACLType.WRITE;
+      } else if (aclType == IAccessAuthorizer.ACLType.READ_ACL ||
+          aclType == IAccessAuthorizer.ACLType.LIST) {
+        parentAclRight = IAccessAuthorizer.ACLType.READ;
+      }
+    } else {
+      parentAclRight = IAccessAuthorizer.ACLType.READ;
+    }
+
+    switch (resType) {
+      //For Volume level access we only need to check {OWNER} equal
+      // to Volume Owner.
+    case VOLUME:
+      checkAcls(resType, storeType, aclType, vol, bucket, key,
+          user, remoteAddress, hostName, true,
+          volOwner);
+      break;
+    case BUCKET:
+    case KEY:
+      //For Bucket/Key/Prefix level access, first we need to check {OWNER}
+      //equal to volume owner on parent volume. Then we need to check
+      //{OWNER} equals volume owner if current ugi user is volume owner else
+      //we need check {OWNER} equals bucket owner for bucket/key/prefix.
+    case PREFIX:
+      checkAcls(OzoneObj.ResourceType.VOLUME, storeType,
+          parentAclRight, vol, bucket, key, user,
+          remoteAddress, hostName, true,
+          volOwner);
+      if (isVolOwner) {
+        checkAcls(resType, storeType, aclType, vol, bucket, key,
+            user, remoteAddress, hostName, true,
+            volOwner);
+      } else {
+        checkAcls(resType, storeType, aclType, vol, bucket, key,
+            user, remoteAddress, hostName, true,
+            bucketOwner);
+      }
+      break;
+    default:
+      throw new OMException("Unexpected object type:" +
+          resType, INVALID_REQUEST);
+    }
+  }
+
+  @VisibleForTesting
+  public static Logger getLogger() {
+    return LOG;
+  }
+
+  private String getVolumeOwner(String volume,
+                                IAccessAuthorizer.ACLType type,
+                                OzoneObj.ResourceType resType)
+      throws OMException {
+    if (volume.equals(OzoneConsts.OZONE_ROOT) ||
+        type == IAccessAuthorizer.ACLType.CREATE &&
+            resType == OzoneObj.ResourceType.VOLUME) {
+      return null;
+    }
+    Boolean lockAcquired = metadataManager.getLock().acquireReadLock(
+        VOLUME_LOCK, volume);
+    String dbVolumeKey = metadataManager.getVolumeKey(volume);
+    OmVolumeArgs volumeArgs = null;
+    try {
+      volumeArgs = metadataManager.getVolumeTable().get(dbVolumeKey);
+    } catch (IOException ioe) {
+      if (ioe instanceof OMException) {
+        throw (OMException) ioe;
+      } else {
+        throw new OMException("getVolumeOwner for Volume " + volume + " failed",
+            OMException.ResultCodes.INTERNAL_ERROR);
+      }
+    } finally {
+      if (lockAcquired) {
+        metadataManager.getLock().releaseReadLock(VOLUME_LOCK, volume);
+      }
+    }
+    if (volumeArgs != null) {
+      return volumeArgs.getOwnerName();
+    } else {
+      throw new OMException("Volume " + volume + " is not found",
+          OMException.ResultCodes.VOLUME_NOT_FOUND);
+    }
+  }
+
+  private String getBucketOwner(String volume, String bucket,
+                                IAccessAuthorizer.ACLType type,
+                                OzoneObj.ResourceType resType)
+      throws OMException {
+    if ((resType == OzoneObj.ResourceType.VOLUME) ||
+        type == IAccessAuthorizer.ACLType.CREATE &&
+            resType == OzoneObj.ResourceType.BUCKET) {
+      return null;
+    }
+    Boolean lockAcquired = metadataManager.getLock().acquireReadLock(
+        BUCKET_LOCK, volume, bucket);
+    String dbBucketKey = metadataManager.getBucketKey(volume, bucket);
+    OmBucketInfo bucketInfo = null;
+    try {
+      bucketInfo = metadataManager.getBucketTable().get(dbBucketKey);
+    } catch (IOException ioe) {
+      if (ioe instanceof OMException) {
+        throw (OMException) ioe;
+      } else {
+        throw new OMException("getBucketOwner for Bucket " + volume + "/" +
+            bucket + " failed: " + ioe.getMessage(),
+            OMException.ResultCodes.INTERNAL_ERROR);
+      }
+    } finally {
+      if (lockAcquired) {
+        metadataManager.getLock().releaseReadLock(BUCKET_LOCK, volume, bucket);
+      }
+    }
+    if (bucketInfo != null) {
+      return bucketInfo.getOwner();
+    } else {
+      throw new OMException("Bucket not found",
+          OMException.ResultCodes.BUCKET_NOT_FOUND);
+    }
+  }
+
+  private static UserGroupInformation getRemoteUser() throws IOException {
+    UserGroupInformation ugi = Server.getRemoteUser();
+    return (ugi != null) ? ugi : UserGroupInformation.getCurrentUser();
+  }
+
+  private static boolean isOwner(UserGroupInformation callerUgi,
+                                 String ownerName) {
+    if (ownerName == null) {
+      return false;
+    }
+    if (callerUgi.getUserName().equals(ownerName) ||
+        callerUgi.getShortUserName().equals(ownerName)) {
+      return true;
+    }
+    return false;
+  }
+
+  /**
+   * A variant of checkAcls that doesn't throw exception if permission denied.
+   *
+   * @return true if permission granted, false if permission denied.
+   */
+  public boolean hasAcls(String userName, OzoneObj.ResourceType resType,
+                         OzoneObj.StoreType store,
+                         IAccessAuthorizer.ACLType acl,
+                         String vol, String bucket, String key) {
+    try {
+      return checkAcls(resType, store, acl, vol, bucket, key,
+          UserGroupInformation.createRemoteUser(userName),
+          ProtobufRpcEngine.Server.getRemoteIp(),
+          ProtobufRpcEngine.Server.getRemoteIp().getHostName(),
+          false, getVolumeOwner(vol, acl, resType));
+    } catch (OMException ex) {
+      // Should not trigger exception here at all
+      return false;
+    }
+  }
+
+  @SuppressWarnings("parameternumber")
+  public void checkACLsWithFSO(
+      OzoneManager ozoneManager,
+      String volumeName,
+      String bucketName, String keyName,
+      IAccessAuthorizer.ACLType aclType,
+      InetAddress remoteAddress, String hostName,
+      UserGroupInformation ugi) throws IOException {
+
+    // TODO: Presently not populating sub-paths under a single bucket
+    //  lock. Need to revisit this to handle any concurrent operations
+    //  along with this.
+    OzonePrefixPathImpl pathViewer = new OzonePrefixPathImpl(volumeName,
+        bucketName, keyName, ozoneManager.getKeyManager());
+
+    OzoneObj obj = OzoneObjInfo.Builder.newBuilder()
+        .setResType(OzoneObj.ResourceType.KEY)
+        .setStoreType(OzoneObj.StoreType.OZONE)
+        .setVolumeName(volumeName)
+        .setBucketName(bucketName)
+        .setKeyName(keyName)
+        .setOzonePrefixPath(pathViewer).build();
+
+    RequestContext.Builder contextBuilder = RequestContext.newBuilder()
+        .setAclRights(aclType)
+        // recursive checks for a dir with sub-directories or sub-files
+        .setRecursiveAccessCheck(pathViewer.isCheckRecursiveAccess());
+
+    // check Acl
+
+    String volumeOwner = getVolumeOwner(obj.getVolumeName(),
+        contextBuilder.getAclRights(), obj.getResourceType());
+    String bucketOwner = getBucketOwner(obj.getVolumeName(),
+        obj.getBucketName(), contextBuilder.getAclRights(),
+        obj.getResourceType());
+    UserGroupInformation currentUser = ugi;
+    contextBuilder.setClientUgi(currentUser);
+    contextBuilder.setIp(remoteAddress);
+    contextBuilder.setHost(hostName);
+    contextBuilder.setAclType(IAccessAuthorizer.ACLIdentityType.USER);
+
+    boolean isVolOwner = isOwner(currentUser, volumeOwner);
+    IAccessAuthorizer.ACLType parentAclRight = aclType;
+    if (isVolOwner) {
+      contextBuilder.setOwnerName(volumeOwner);
+    } else {
+      contextBuilder.setOwnerName(bucketOwner);
+    }
+    if (isNativeAuthorizerEnabled) {
+      if (aclType == IAccessAuthorizer.ACLType.CREATE ||
+          aclType == IAccessAuthorizer.ACLType.DELETE ||
+          aclType == IAccessAuthorizer.ACLType.WRITE_ACL) {
+        parentAclRight = IAccessAuthorizer.ACLType.WRITE;
+      } else if (aclType == IAccessAuthorizer.ACLType.READ_ACL ||
+          aclType == IAccessAuthorizer.ACLType.LIST) {
+        parentAclRight = IAccessAuthorizer.ACLType.READ;
+      }
+    } else {
+      parentAclRight = IAccessAuthorizer.ACLType.READ;
+
+    }
+    OzoneObj volumeObj = OzoneObjInfo.Builder.newBuilder()
+        .setResType(OzoneObj.ResourceType.VOLUME)
+        .setStoreType(OzoneObj.StoreType.OZONE)
+        .setVolumeName(volumeName)
+        .setBucketName(bucketName)
+        .setKeyName(keyName).build();
+    RequestContext volumeContext = RequestContext.newBuilder()
+        .setClientUgi(currentUser)
+        .setIp(remoteAddress)
+        .setHost(hostName)
+        .setAclType(IAccessAuthorizer.ACLIdentityType.USER)
+        .setAclRights(parentAclRight)
+        .setOwnerName(volumeOwner)
+        .build();
+    checkAcls(volumeObj, volumeContext, true);
+    checkAcls(obj, contextBuilder.build(), true);
+  }
+}

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneAclUtils.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneAclUtils.java
@@ -17,16 +17,6 @@
 
 package org.apache.hadoop.ozone.om;
 
-import org.apache.hadoop.ozone.om.exceptions.OMException;
-import org.apache.hadoop.ozone.security.acl.IAccessAuthorizer;
-import org.apache.hadoop.ozone.security.acl.OzoneObj;
-import org.apache.hadoop.security.UserGroupInformation;
-
-import java.io.IOException;
-import java.net.InetAddress;
-
-import static org.apache.hadoop.ozone.om.exceptions.OMException.ResultCodes.INVALID_REQUEST;
-
 /**
  * Ozone Acl Wrapper class.
  */
@@ -58,93 +48,5 @@ public final class OzoneAclUtils {
     }
 
     return principal;
-  }
-
-  /**
-   * Check Acls of ozone object with volume owner and bucket owner.
-   * @param ozoneManager
-   * @param resType
-   * @param storeType
-   * @param aclType
-   * @param vol
-   * @param bucket
-   * @param key
-   * @param volOwner
-   * @param bucketOwner
-   * @throws IOException
-   */
-  @SuppressWarnings("parameternumber")
-  public static void checkAllAcls(OzoneManager ozoneManager,
-      OzoneObj.ResourceType resType,
-      OzoneObj.StoreType storeType, IAccessAuthorizer.ACLType aclType,
-      String vol, String bucket, String key, String volOwner,
-      String bucketOwner, UserGroupInformation user, InetAddress remoteAddress,
-      String hostName) throws IOException {
-
-    boolean isVolOwner = isOwner(user, volOwner);
-
-    IAccessAuthorizer.ACLType parentAclRight = aclType;
-
-    //OzoneNativeAuthorizer differs from Ranger Authorizer as Ranger requires
-    // only READ access on parent level access. OzoneNativeAuthorizer has
-    // different parent level access based on the child level access type
-    if (ozoneManager.isNativeAuthorizerEnabled()) {
-      if (aclType == IAccessAuthorizer.ACLType.CREATE ||
-          aclType == IAccessAuthorizer.ACLType.DELETE ||
-          aclType == IAccessAuthorizer.ACLType.WRITE_ACL) {
-        parentAclRight = IAccessAuthorizer.ACLType.WRITE;
-      } else if (aclType == IAccessAuthorizer.ACLType.READ_ACL ||
-          aclType == IAccessAuthorizer.ACLType.LIST) {
-        parentAclRight = IAccessAuthorizer.ACLType.READ;
-      }
-    } else {
-      parentAclRight =  IAccessAuthorizer.ACLType.READ;
-    }
-
-    switch (resType) {
-    //For Volume level access we only need to check {OWNER} equal
-    // to Volume Owner.
-    case VOLUME:
-      ozoneManager.checkAcls(resType, storeType, aclType, vol, bucket, key,
-          user, remoteAddress, hostName, true,
-          volOwner);
-      break;
-    case BUCKET:
-    case KEY:
-    //For Bucket/Key/Prefix level access, first we need to check {OWNER} equal
-    // to volume owner on parent volume. Then we need to check {OWNER} equals
-    // volume owner if current ugi user is volume owner else we need check
-    //{OWNER} equals bucket owner for bucket/key/prefix.
-    case PREFIX:
-      ozoneManager.checkAcls(OzoneObj.ResourceType.VOLUME, storeType,
-          parentAclRight, vol, bucket, key, user,
-          remoteAddress, hostName, true,
-          volOwner);
-      if (isVolOwner) {
-        ozoneManager.checkAcls(resType, storeType, aclType, vol, bucket, key,
-            user, remoteAddress, hostName, true,
-            volOwner);
-      } else {
-        ozoneManager.checkAcls(resType, storeType, aclType, vol, bucket, key,
-            user, remoteAddress, hostName, true,
-            bucketOwner);
-      }
-      break;
-    default:
-      throw new OMException("Unexpected object type:" +
-              resType, INVALID_REQUEST);
-    }
-  }
-
-  private static boolean isOwner(UserGroupInformation callerUgi,
-      String ownerName) {
-    if (ownerName == null) {
-      return false;
-    }
-    if (callerUgi.getUserName().equals(ownerName) ||
-        callerUgi.getShortUserName().equals(ownerName)) {
-      return true;
-    }
-    return false;
   }
 }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
@@ -228,7 +228,15 @@ import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_KEY_PREALLOCATION_BL
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_KEY_PREALLOCATION_BLOCKS_MAX_DEFAULT;
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_SCM_BLOCK_SIZE;
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_SCM_BLOCK_SIZE_DEFAULT;
-import static org.apache.hadoop.ozone.OzoneConsts.*;
+import static org.apache.hadoop.ozone.OzoneConsts.DB_TRANSIENT_MARKER;
+import static org.apache.hadoop.ozone.OzoneConsts.DEFAULT_OM_UPDATE_ID;
+import static org.apache.hadoop.ozone.OzoneConsts.LAYOUT_VERSION_KEY;
+import static org.apache.hadoop.ozone.OzoneConsts.OM_METRICS_FILE;
+import static org.apache.hadoop.ozone.OzoneConsts.OM_METRICS_TEMP_FILE;
+import static org.apache.hadoop.ozone.OzoneConsts.OM_RATIS_SNAPSHOT_DIR;
+import static org.apache.hadoop.ozone.OzoneConsts.PREPARE_MARKER_KEY;
+import static org.apache.hadoop.ozone.OzoneConsts.RPC_PORT;
+import static org.apache.hadoop.ozone.OzoneConsts.TRANSACTION_INFO_KEY;
 import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_ADDRESS_KEY;
 import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_ENABLE_FILESYSTEM_PATHS;
 import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_ENABLE_FILESYSTEM_PATHS_DEFAULT;
@@ -1575,6 +1583,9 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
     instantiateServices(false);
 
     startSecretManagerIfNecessary();
+
+    this.aclManager = new AclManager(metadataManager, omRpcAddress,
+        accessAuthorizer, isNativeAuthorizerEnabled);
 
     // Set metrics and start metrics back ground thread
     metrics.setNumVolumes(metadataManager.countRowsInTable(metadataManager
@@ -3668,6 +3679,9 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
       throws IOException {
 
     instantiateServices(true);
+
+    this.aclManager = new AclManager(metadataManager, omRpcAddress,
+        accessAuthorizer, isNativeAuthorizerEnabled);
 
     // Restart required services
     metadataManager.start(configuration);

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/OMClientRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/OMClientRequest.java
@@ -30,7 +30,6 @@ import org.apache.hadoop.ozone.audit.AuditLogger;
 import org.apache.hadoop.ozone.audit.AuditMessage;
 import org.apache.hadoop.ozone.om.OzoneAclUtils;
 import org.apache.hadoop.ozone.om.OzoneManager;
-import org.apache.hadoop.ozone.om.OzonePrefixPathImpl;
 import org.apache.hadoop.ozone.om.exceptions.OMException;
 import org.apache.hadoop.ozone.om.helpers.BucketLayout;
 import org.apache.hadoop.ozone.om.ratis.utils.OzoneManagerDoubleBufferHelper;
@@ -42,8 +41,6 @@ import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMReque
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMResponse;
 import org.apache.hadoop.ozone.security.acl.IAccessAuthorizer;
 import org.apache.hadoop.ozone.security.acl.OzoneObj;
-import org.apache.hadoop.ozone.security.acl.OzoneObjInfo;
-import org.apache.hadoop.ozone.security.acl.RequestContext;
 import org.apache.hadoop.security.UserGroupInformation;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -196,169 +193,12 @@ public abstract class OMClientRequest implements RequestAuditor {
     return getUserInfo();
   }
 
-  /**
-   * Check Acls of ozone object.
-   * @param ozoneManager
-   * @param resType
-   * @param storeType
-   * @param aclType
-   * @param vol
-   * @param bucket
-   * @param key
-   * @throws IOException
-   */
-  @SuppressWarnings("parameternumber")
-  public void checkAcls(OzoneManager ozoneManager,
+  protected void checkAcls(OzoneManager ozoneManager,
       OzoneObj.ResourceType resType,
       OzoneObj.StoreType storeType, IAccessAuthorizer.ACLType aclType,
       String vol, String bucket, String key) throws IOException {
-    checkAcls(ozoneManager, resType, storeType, aclType, vol, bucket, key,
-        ozoneManager.getVolumeOwner(vol, aclType, resType),
-        ozoneManager.getBucketOwner(vol, bucket, aclType, resType));
-  }
-
-  /**
-   * Check Acls for the ozone key.
-   * @param ozoneManager
-   * @param volumeName
-   * @param bucketName
-   * @param keyName
-   * @throws IOException
-   */
-  protected void checkACLsWithFSO(OzoneManager ozoneManager, String volumeName,
-                                  String bucketName, String keyName,
-                                  IAccessAuthorizer.ACLType aclType)
-      throws IOException {
-
-    // TODO: Presently not populating sub-paths under a single bucket
-    //  lock. Need to revisit this to handle any concurrent operations
-    //  along with this.
-    OzonePrefixPathImpl pathViewer = new OzonePrefixPathImpl(volumeName,
-        bucketName, keyName, ozoneManager.getKeyManager());
-
-    OzoneObj obj = OzoneObjInfo.Builder.newBuilder()
-        .setResType(OzoneObj.ResourceType.KEY)
-        .setStoreType(OzoneObj.StoreType.OZONE)
-        .setVolumeName(volumeName)
-        .setBucketName(bucketName)
-        .setKeyName(keyName)
-        .setOzonePrefixPath(pathViewer).build();
-
-    RequestContext.Builder contextBuilder = RequestContext.newBuilder()
-        .setAclRights(aclType)
-        // recursive checks for a dir with sub-directories or sub-files
-        .setRecursiveAccessCheck(pathViewer.isCheckRecursiveAccess());
-
-    // check Acl
-    if (ozoneManager.getAclsEnabled()) {
-      String volumeOwner = ozoneManager.getVolumeOwner(obj.getVolumeName(),
-          contextBuilder.getAclRights(), obj.getResourceType());
-      String bucketOwner = ozoneManager.getBucketOwner(obj.getVolumeName(),
-          obj.getBucketName(), contextBuilder.getAclRights(),
-          obj.getResourceType());
-      UserGroupInformation currentUser = createUGI();
-      contextBuilder.setClientUgi(currentUser);
-      contextBuilder.setIp(getRemoteAddress());
-      contextBuilder.setHost(getHostName());
-      contextBuilder.setAclType(IAccessAuthorizer.ACLIdentityType.USER);
-
-      boolean isVolOwner = isOwner(currentUser, volumeOwner);
-      IAccessAuthorizer.ACLType parentAclRight = aclType;
-      if (isVolOwner) {
-        contextBuilder.setOwnerName(volumeOwner);
-      } else {
-        contextBuilder.setOwnerName(bucketOwner);
-      }
-      if (ozoneManager.isNativeAuthorizerEnabled()) {
-        if (aclType == IAccessAuthorizer.ACLType.CREATE ||
-                aclType == IAccessAuthorizer.ACLType.DELETE ||
-                aclType == IAccessAuthorizer.ACLType.WRITE_ACL) {
-          parentAclRight = IAccessAuthorizer.ACLType.WRITE;
-        } else if (aclType == IAccessAuthorizer.ACLType.READ_ACL ||
-                aclType == IAccessAuthorizer.ACLType.LIST) {
-          parentAclRight = IAccessAuthorizer.ACLType.READ;
-        }
-      } else {
-        parentAclRight = IAccessAuthorizer.ACLType.READ;
-
-      }
-      OzoneObj volumeObj = OzoneObjInfo.Builder.newBuilder()
-              .setResType(OzoneObj.ResourceType.VOLUME)
-              .setStoreType(OzoneObj.StoreType.OZONE)
-              .setVolumeName(volumeName)
-              .setBucketName(bucketName)
-              .setKeyName(keyName).build();
-      RequestContext volumeContext = RequestContext.newBuilder()
-              .setClientUgi(currentUser)
-              .setIp(getRemoteAddress())
-              .setHost(getHostName())
-              .setAclType(IAccessAuthorizer.ACLIdentityType.USER)
-              .setAclRights(parentAclRight)
-              .setOwnerName(volumeOwner)
-              .build();
-      ozoneManager.checkAcls(volumeObj, volumeContext, true);
-      ozoneManager.checkAcls(obj, contextBuilder.build(), true);
-    }
-  }
-
-  private boolean isOwner(UserGroupInformation callerUgi,
-                                 String ownerName) {
-    if (ownerName == null) {
-      return false;
-    }
-    if (callerUgi.getUserName().equals(ownerName) ||
-        callerUgi.getShortUserName().equals(ownerName)) {
-      return true;
-    }
-    return false;
-  }
-
-  /**
-   * Check Acls of ozone object with volOwner given.
-   * @param ozoneManager
-   * @param resType
-   * @param storeType
-   * @param aclType
-   * @param vol
-   * @param bucket
-   * @param key
-   * @param volOwner
-   * @throws IOException
-   */
-  @SuppressWarnings("parameternumber")
-  public void checkAcls(OzoneManager ozoneManager,
-      OzoneObj.ResourceType resType,
-      OzoneObj.StoreType storeType, IAccessAuthorizer.ACLType aclType,
-      String vol, String bucket, String key, String volOwner)
-      throws IOException {
-    ozoneManager.checkAcls(resType, storeType, aclType, vol, bucket, key,
-        createUGI(), getRemoteAddress(), getHostName(), true,
-        volOwner);
-  }
-
-  /**
-   * Check Acls of ozone object with volOwner given.
-   * @param ozoneManager
-   * @param resType
-   * @param storeType
-   * @param aclType
-   * @param vol
-   * @param bucket
-   * @param key
-   * @param volOwner
-   * @param bucketOwner
-   * @throws IOException
-   */
-  @SuppressWarnings("parameternumber")
-  public void checkAcls(OzoneManager ozoneManager,
-      OzoneObj.ResourceType resType,
-      OzoneObj.StoreType storeType, IAccessAuthorizer.ACLType aclType,
-      String vol, String bucket, String key, String volOwner,
-      String bucketOwner)
-      throws IOException {
-
-    OzoneAclUtils.checkAllAcls(ozoneManager, resType, storeType, aclType,
-            vol, bucket, key, volOwner, bucketOwner, createUGI(),
+    ozoneManager.getAclManager().checkAllAcls(resType, storeType, aclType,
+            vol, bucket, key, createUGI(),
             getRemoteAddress(), getHostName());
   }
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyDeleteRequestWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyDeleteRequestWithFSO.java
@@ -100,8 +100,11 @@ public class OMKeyDeleteRequestWithFSO extends OMKeyDeleteRequest {
       volumeName = keyArgs.getVolumeName();
       bucketName = keyArgs.getBucketName();
 
-      checkACLsWithFSO(ozoneManager, volumeName, bucketName, keyName,
-          IAccessAuthorizer.ACLType.DELETE);
+      if (ozoneManager.getAclsEnabled()) {
+        ozoneManager.getAclManager().checkACLsWithFSO(ozoneManager, volumeName,
+            bucketName, keyName, IAccessAuthorizer.ACLType.DELETE,
+            getRemoteAddress(), getHostName(), createUGI());
+      }
 
       acquiredLock = omMetadataManager.getLock().acquireWriteLock(BUCKET_LOCK,
           volumeName, bucketName);

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyRenameRequestWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyRenameRequestWithFSO.java
@@ -113,8 +113,11 @@ public class OMKeyRenameRequestWithFSO extends OMKeyRenameRequest {
       // old key and create operation on new key
 
       // check Acl fromKeyName
-      checkACLsWithFSO(ozoneManager, volumeName, bucketName, fromKeyName,
-          IAccessAuthorizer.ACLType.DELETE);
+      if (ozoneManager.getAclsEnabled()) {
+        ozoneManager.getAclManager().checkACLsWithFSO(ozoneManager, volumeName,
+            bucketName, fromKeyName, IAccessAuthorizer.ACLType.DELETE,
+            getRemoteAddress(), getHostName(), createUGI());
+      }
 
       // check Acl toKeyName
       checkKeyAcls(ozoneManager, volumeName, bucketName, toKeyName,

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyRequest.java
@@ -215,19 +215,6 @@ public abstract class OMKeyRequest extends OMClientRequest {
         getBucketLayout());
   }
 
-  // For keys batch delete and rename only
-  protected String getVolumeOwner(OMMetadataManager omMetadataManager,
-      String volumeName) throws IOException {
-    String dbVolumeKey = omMetadataManager.getVolumeKey(volumeName);
-    OmVolumeArgs volumeArgs =
-        omMetadataManager.getVolumeTable().get(dbVolumeKey);
-    if (volumeArgs == null) {
-      throw new OMException("Volume not found " + volumeName,
-          VOLUME_NOT_FOUND);
-    }
-    return volumeArgs.getOwnerName();
-  }
-
   protected static Optional<FileEncryptionInfo> getFileEncryptionInfo(
       OzoneManager ozoneManager, OmBucketInfo bucketInfo) throws IOException {
     Optional<FileEncryptionInfo> encInfo = Optional.absent();
@@ -341,28 +328,6 @@ public abstract class OMKeyRequest extends OMClientRequest {
     if (ozoneManager.getAclsEnabled()) {
       checkAcls(ozoneManager, resourceType, OzoneObj.StoreType.OZONE, aclType,
           volume, bucket, key);
-    }
-  }
-
-  /**
-   * Check Acls for the ozone key with volumeOwner.
-   * @param ozoneManager
-   * @param volume
-   * @param bucket
-   * @param key
-   * @param aclType
-   * @param resourceType
-   * @throws IOException
-   */
-  @SuppressWarnings("parameternumber")
-  protected void checkKeyAcls(OzoneManager ozoneManager, String volume,
-      String bucket, String key, IAccessAuthorizer.ACLType aclType,
-      OzoneObj.ResourceType resourceType, String volumeOwner)
-      throws IOException {
-    if (ozoneManager.getAclsEnabled()) {
-      checkAcls(ozoneManager, resourceType, OzoneObj.StoreType.OZONE,
-          aclType, volume, bucket, key, volumeOwner,
-          ozoneManager.getBucketOwner(volume, bucket, aclType, resourceType));
     }
   }
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeysDeleteRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeysDeleteRequest.java
@@ -132,7 +132,6 @@ public class OMKeysDeleteRequest extends OMKeyRequest {
           .acquireWriteLock(BUCKET_LOCK, volumeName, bucketName);
       // Validate bucket and volume exists or not.
       validateBucketAndVolume(omMetadataManager, volumeName, bucketName);
-      String volumeOwner = getVolumeOwner(omMetadataManager, volumeName);
 
       for (indexFailed = 0; indexFailed < length; indexFailed++) {
         String keyName = deleteKeyArgs.getKeys(indexFailed);
@@ -153,8 +152,7 @@ public class OMKeysDeleteRequest extends OMKeyRequest {
         try {
           // check Acl
           checkKeyAcls(ozoneManager, volumeName, bucketName, keyName,
-              IAccessAuthorizer.ACLType.DELETE, OzoneObj.ResourceType.KEY,
-              volumeOwner);
+              IAccessAuthorizer.ACLType.DELETE, OzoneObj.ResourceType.KEY);
           addKeyToAppropriateList(omKeyInfoList, omKeyInfo, dirList,
               getOzoneKeyStatus(omMetadataManager, volumeName, bucketName,
                   keyName));

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeysRenameRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeysRenameRequest.java
@@ -126,7 +126,6 @@ public class OMKeysRenameRequest extends OMKeyRequest {
 
       // Validate bucket and volume exists or not.
       validateBucketAndVolume(omMetadataManager, volumeName, bucketName);
-      String volumeOwner = getVolumeOwner(omMetadataManager, volumeName);
       for (RenameKeysMap renameKey : renameKeysArgs.getRenameKeysMapList()) {
 
         fromKeyName = renameKey.getFromKeyName();
@@ -147,11 +146,9 @@ public class OMKeysRenameRequest extends OMKeyRequest {
           // check Acls to see if user has access to perform delete operation
           // on old key and create operation on new key
           checkKeyAcls(ozoneManager, volumeName, bucketName, fromKeyName,
-              IAccessAuthorizer.ACLType.DELETE, OzoneObj.ResourceType.KEY,
-              volumeOwner);
+              IAccessAuthorizer.ACLType.DELETE, OzoneObj.ResourceType.KEY);
           checkKeyAcls(ozoneManager, volumeName, bucketName, toKeyName,
-              IAccessAuthorizer.ACLType.CREATE, OzoneObj.ResourceType.KEY,
-              volumeOwner);
+              IAccessAuthorizer.ACLType.CREATE, OzoneObj.ResourceType.KEY);
         } catch (Exception ex) {
           renameStatus = false;
           unRenamedKeys.add(


### PR DESCRIPTION
## What changes were proposed in this pull request?

I moved all ACL check-related methods to AclManager to:
- make OzoneManager more readable
- make AclManager responsible for ACL-related actions
- decrease code duplication

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-7766

## How was this patch tested?

unit tests