### PR TITLE
HDDS-7097. Container scanner log output lacks useful information

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/KeyValueContainer.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/KeyValueContainer.java
@@ -335,7 +335,7 @@ public class KeyValueContainer implements Container<KeyValueContainerData> {
     } finally {
       writeUnlock();
     }
-    LOG.warn("Moving container {} to state {} from state:{} Trace:{}",
+    LOG.warn("Moving container {} to state {} from state:{}",
             containerData.getContainerPath(), containerData.getState(),
             prevState);
   }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/KeyValueContainer.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/KeyValueContainer.java
@@ -338,7 +338,7 @@ public class KeyValueContainer implements Container<KeyValueContainerData> {
     }
     LOG.warn("Moving container {} to state {} from state:{} Trace:{}",
             containerData.getContainerPath(), containerData.getState(),
-            prevState, StringUtils.getStackTrace(Thread.currentThread()));
+            prevState);
   }
 
   @Override

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/KeyValueContainer.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/KeyValueContainer.java
@@ -72,7 +72,6 @@ import static org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.Res
 import static org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.Result.UNSUPPORTED_REQUEST;
 import static org.apache.hadoop.ozone.container.common.utils.StorageVolumeUtil.onFailure;
 
-import org.apache.hadoop.util.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/KeyValueContainerCheck.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/KeyValueContainerCheck.java
@@ -401,6 +401,6 @@ public class KeyValueContainerCheck {
     String errStr =
         "Corruption detected in container: [" + containerID + "] ";
     String logMessage = errStr + "Exception: [" + e.getMessage() + "]";
-    LOG.error(logMessage);
+    LOG.error(logMessage, e);
   }
 }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/KeyValueContainerCheck.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/KeyValueContainerCheck.java
@@ -396,7 +396,7 @@ public class KeyValueContainerCheck {
   }
 
   private void handleCorruption(IOException e) {
-    LOG.error("Marking Container [{}] UNHEALTHY as it failed metadata check." +
-                    " Exception: {}", containerID, e);
+    LOG.error("Corruption detected in container [{}]. Marking it UNHEALTHY.",
+            containerID, e);
   }
 }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/KeyValueContainerCheck.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/KeyValueContainerCheck.java
@@ -97,8 +97,6 @@ public class KeyValueContainerCheck {
       valid = true;
 
     } catch (IOException e) {
-      LOG.info("Marking Container {} UNHEALTHY as it failed metadata check",
-              containerID);
       handleCorruption(e);
     }
 
@@ -398,9 +396,6 @@ public class KeyValueContainerCheck {
   }
 
   private void handleCorruption(IOException e) {
-    String errStr =
-        "Corruption detected in container: [" + containerID + "] ";
-    String logMessage = errStr + "Exception: [" + e.getMessage() + "]";
-    LOG.error(logMessage, e);
+    LOG.error("Marking Container [{}] UNHEALTHY as it failed metadata check. Exception: {}", containerID, e);
   }
 }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/KeyValueContainerCheck.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/KeyValueContainerCheck.java
@@ -396,6 +396,7 @@ public class KeyValueContainerCheck {
   }
 
   private void handleCorruption(IOException e) {
-    LOG.error("Marking Container [{}] UNHEALTHY as it failed metadata check. Exception: {}", containerID, e);
+    LOG.error("Marking Container [{}] UNHEALTHY as it failed metadata check." +
+                    " Exception: {}", containerID, e);
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?
1. Add log for the exception object when container corruption happens to better identify the failure.
2. Remove the stack trace of the call to KeyValueContainer#markContainerUnhealthy (not very useful).

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-7097

## How was this patch tested?
Manually test in local cluster to verify the log message.

Example message format:
`ERROR keyvalue.KeyValueContainerCheck: Marking Container [{containerID}] UNHEALTHY as it failed metadata check. Exception: {exception stack trace}`