### PR TITLE
HDDS-7774. Update outdated trash documentation

### DIFF
--- a/hadoop-hdds/docs/content/design/trash.md
+++ b/hadoop-hdds/docs/content/design/trash.md
@@ -23,8 +23,3 @@ author: Matthew Sharp
 The design doc is uploaded to the JIRA: 
 
 https://issues.apache.org/jira/secure/attachment/12985273/Ozone_Trash_Feature.docx
-
-## Special note
-
-Trash is disabled for both o3fs and ofs even if `fs.trash.interval` is set
-on purpose. (HDDS-3982)


### PR DESCRIPTION
## What changes were proposed in this pull request?
Update outdated trash documentation.
[HDDS-3982. Disable moveToTrash in o3fs and ofs temporarily](https://github.com/apache/ozone/pull/1215) introduced the modified content, [HDDS-4307.Start Trash Emptier in Ozone Manager #1507](https://github.com/apache/ozone/pull/1507) supported this function, but did not update the document, it is easy to misunderstand new users.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-7774

## How was this patch tested?
no need test
