### PR TITLE
HDDS-7754. Download of container is failing with SSL/TLS error during re-replication

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/replication/GrpcReplicationClient.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/replication/GrpcReplicationClient.java
@@ -74,7 +74,7 @@ public class GrpcReplicationClient implements AutoCloseable {
             .usePlaintext()
             .maxInboundMessageSize(OzoneConsts.OZONE_SCM_CHUNK_MAX_SIZE);
 
-    if (secConfig.isSecurityEnabled()) {
+    if (secConfig.isSecurityEnabled() && secConfig.isGrpcTlsEnabled()) {
       channelBuilder.useTransportSecurity();
 
       SslContextBuilder sslContextBuilder = GrpcSslContexts.forClient();


### PR DESCRIPTION
## What changes were proposed in this pull request?

HDDS-7572 changed `ReplicationServer` (among others) to respect `hdds.grpc.tls.enabled`, but `GrpcReplicationClient` was left unchanged.  Thus protocol mismatch prevents replication when the following config is set:

 * `ozone.security.enabled=true`
 * `hdds.grpc.tls.enabled=false`

```
ERROR org.apache.hadoop.ozone.container.replication.GrpcReplicationClient: Download of container 1 was unsuccessful
org.apache.ratis.thirdparty.io.grpc.StatusRuntimeException: UNAVAILABLE: io exception
Channel Pipeline: [SslHandler#0, ProtocolNegotiators$ClientTlsHandler#0, WriteBufferingAndExceptionHandler#0, DefaultChannelPipeline$TailContext#0]
  at org.apache.ratis.thirdparty.io.grpc.Status.asRuntimeException(Status.java:535)
  ...
  at java.base/java.lang.Thread.run(Thread.java:834)
Caused by: org.apache.ratis.thirdparty.io.netty.handler.ssl.NotSslRecordException: not an SSL/TLS record: 00001204000000000000037fffffff000400100000000600002000000004080000000000000f0001
  at org.apache.ratis.thirdparty.io.netty.handler.ssl.SslHandler.decodeJdkCompatible(SslHandler.java:1214)
  at org.apache.ratis.thirdparty.io.netty.handler.ssl.SslHandler.decode(SslHandler.java:1284)
```

This can be reproduced in `ozonesecure` environment with `hdds.grpc.tls.enabled=false`.

The patch makes `GrpcReplicationClient` also respect the `hdds.grpc.tls.enabled` setting so the client and server are in sync.

https://issues.apache.org/jira/browse/HDDS-7754

## How was this patch tested?

Tested locally in `ozonesecure` environment with `hdds.grpc.tls.enabled=false`.

Executed same in CI:
https://github.com/adoroszlai/hadoop-ozone/actions/runs/3903794924

Regular CI:
https://github.com/adoroszlai/hadoop-ozone/actions/runs/3903769563