### PR TITLE
HDDS-6857. [Snapshot] Implement Snapshot Delete CLI and API

### DIFF
--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/ObjectStore.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/ObjectStore.java
@@ -538,6 +538,18 @@ public class ObjectStore {
   }
 
   /**
+   * Delete snapshot.
+   * @param volumeName vol to be used
+   * @param bucketName bucket to be used
+   * @param snapshotName name of the snapshot to be deleted
+   * @throws IOException
+   */
+  public void deleteSnapshot(String volumeName,
+      String bucketName, String snapshotName) throws IOException {
+    proxy.deleteSnapshot(volumeName, bucketName, snapshotName);
+  }
+
+  /**
    * List snapshots in a volume/bucket.
    * @param volumeName volume name
    * @param bucketName bucket name
@@ -548,6 +560,7 @@ public class ObjectStore {
       throws IOException {
     return proxy.listSnapshot(volumeName, bucketName);
   }
+
   public SnapshotDiffReport snapshotDiff(String volumeName, String bucketName,
                                          String fromSnapshot, String toSnapshot)
       throws IOException {

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/protocol/ClientProtocol.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/protocol/ClientProtocol.java
@@ -1031,6 +1031,16 @@ public interface ClientProtocol {
       String bucketName, String snapshotName) throws IOException;
 
   /**
+   * Delete snapshot.
+   * @param volumeName vol to be used
+   * @param bucketName bucket to be used
+   * @param snapshotName name of the snapshot to be deleted
+   * @throws IOException
+   */
+  void deleteSnapshot(String volumeName,
+      String bucketName, String snapshotName) throws IOException;
+
+  /**
    * List snapshots in a volume/bucket.
    * @param volumeName volume name
    * @param bucketName bucket name

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/rpc/RpcClient.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/rpc/RpcClient.java
@@ -952,6 +952,25 @@ public class RpcClient implements ClientProtocol {
         bucketName, snapshotName);
   }
 
+  /**
+   * Delete Snapshot.
+   * @param volumeName vol to be used
+   * @param bucketName bucket to be used
+   * @param snapshotName name of the snapshot to be deleted
+   * @throws IOException
+   */
+  @Override
+  public void deleteSnapshot(String volumeName,
+      String bucketName, String snapshotName) throws IOException {
+    Preconditions.checkArgument(Strings.isNotBlank(volumeName),
+        "volume can't be null or empty.");
+    Preconditions.checkArgument(Strings.isNotBlank(bucketName),
+        "bucket can't be null or empty.");
+    Preconditions.checkArgument(Strings.isNotBlank(snapshotName),
+        "snapshot name can't be null or empty.");
+    ozoneManagerClient.deleteSnapshot(volumeName, bucketName, snapshotName);
+  }
+
   @Override
   public SnapshotDiffReport snapshotDiff(String volumeName, String bucketName,
                                          String fromSnapshot, String toSnapshot)

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/OmUtils.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/OmUtils.java
@@ -325,6 +325,7 @@ public final class OmUtils {
     case TenantRevokeAdmin:
     case SetRangerServiceVersion:
     case CreateSnapshot:
+    case DeleteSnapshot:
       return false;
     default:
       LOG.error("CmdType {} is not categorized as readOnly or not.", cmdType);

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/audit/OMAction.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/audit/OMAction.java
@@ -89,7 +89,9 @@ public enum OMAction implements AuditAction {
   TENANT_ASSIGN_ADMIN,
   TENANT_REVOKE_ADMIN,
   TENANT_LIST_USER,
+
   CREATE_SNAPSHOT,
+  DELETE_SNAPSHOT,
   LIST_SNAPSHOT;
 
   @Override

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocol/OzoneManagerProtocol.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocol/OzoneManagerProtocol.java
@@ -650,6 +650,19 @@ public interface OzoneManagerProtocol
   }
 
   /**
+   * Delete snapshot.
+   * @param volumeName vol to be used
+   * @param bucketName bucket to be used
+   * @param snapshotName name of the snapshot to be deleted
+   * @throws IOException
+   */
+  default void deleteSnapshot(String volumeName,
+      String bucketName, String snapshotName) throws IOException {
+    throw new UnsupportedOperationException("OzoneManager does not require " +
+        "this to be implemented");
+  }
+
+  /**
    * List snapshots in a volume/bucket.
    * @param volumeName volume name
    * @param bucketName bucket name

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocolPB/OzoneManagerProtocolClientSideTranslatorPB.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocolPB/OzoneManagerProtocolClientSideTranslatorPB.java
@@ -84,6 +84,7 @@ import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.CreateF
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.CreateFileResponse;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.CreateKeyRequest;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.CreateKeyResponse;
+import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.CreateSnapshotRequest;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.CreateTenantRequest;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.CreateVolumeRequest;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.DBUpdatesRequest;
@@ -92,6 +93,7 @@ import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.DeleteB
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.DeleteKeyArgs;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.DeleteKeyRequest;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.DeleteKeysRequest;
+import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.DeleteSnapshotRequest;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.DeleteTenantRequest;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.DeleteTenantResponse;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.DeleteVolumeRequest;
@@ -1108,9 +1110,8 @@ public final class OzoneManagerProtocolClientSideTranslatorPB
       String bucketName, String snapshotName)
       throws IOException {
 
-    final OzoneManagerProtocolProtos.CreateSnapshotRequest.Builder
-        requestBuilder =
-        OzoneManagerProtocolProtos.CreateSnapshotRequest.newBuilder()
+    final CreateSnapshotRequest.Builder requestBuilder =
+        CreateSnapshotRequest.newBuilder()
             .setVolumeName(volumeName)
             .setBucketName(bucketName);
     if (!StringUtils.isBlank(snapshotName)) {
@@ -1127,6 +1128,30 @@ public final class OzoneManagerProtocolClientSideTranslatorPB
     return snapshotInfo.getName();
   }
 
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public void deleteSnapshot(String volumeName,
+      String bucketName, String snapshotName)
+      throws IOException {
+
+    final DeleteSnapshotRequest.Builder requestBuilder =
+        DeleteSnapshotRequest.newBuilder()
+            .setVolumeName(volumeName)
+            .setBucketName(bucketName)
+            .setSnapshotName(snapshotName);
+
+    final OMRequest omRequest = createOMRequest(Type.DeleteSnapshot)
+        .setDeleteSnapshotRequest(requestBuilder)
+        .build();
+    final OMResponse omResponse = submitRequest(omRequest);
+    handleError(omResponse);
+  }
+
+  /**
+   * {@inheritDoc}
+   */
   @Override
   public List<SnapshotInfo> listSnapshot(String volumeName, String bucketName)
       throws IOException {

--- a/hadoop-ozone/interface-client/src/main/proto/OmClientProtocol.proto
+++ b/hadoop-ozone/interface-client/src/main/proto/OmClientProtocol.proto
@@ -129,6 +129,7 @@ enum Type {
   CreateSnapshot = 112;
   ListSnapshot = 113;
   SnapshotDiff = 114;
+  DeleteSnapshot = 115;
 }
 
 message OMRequest {
@@ -240,6 +241,7 @@ message OMRequest {
   optional CreateSnapshotRequest            CreateSnapshotRequest          = 112;
   optional ListSnapshotRequest              ListSnapshotRequest            = 113;
   optional SnapshotDiffRequest              snapshotDiffRequest            = 114;
+  optional DeleteSnapshotRequest            DeleteSnapshotRequest          = 115;
 
 }
 
@@ -345,6 +347,7 @@ message OMResponse {
   optional CreateSnapshotResponse            CreateSnapshotResponse        = 112;
   optional ListSnapshotResponse              ListSnapshotResponse          = 113;
   optional SnapshotDiffResponse              snapshotDiffResponse          = 114;
+  optional DeleteSnapshotResponse            DeleteSnapshotResponse        = 115;
 }
 
 enum Status {
@@ -1678,6 +1681,13 @@ message SnapshotDiffRequest {
   required string toSnapshot = 4;
 }
 
+message DeleteSnapshotRequest {
+  optional string volumeName = 1;
+  optional string bucketName = 2;
+  optional string snapshotName = 3;
+  optional uint64 deletionTime = 4;
+}
+
 message DeleteTenantRequest {
     optional string tenantId = 1;
 }
@@ -1723,9 +1733,12 @@ message ListSnapshotResponse {
   repeated SnapshotInfo snapshotInfo = 1;
 }
 
-
 message SnapshotDiffResponse {
   required SnapshotDiffReportProto snapshotDiffReport = 1;
+}
+
+message DeleteSnapshotResponse {
+
 }
 
 message SnapshotDiffReportProto {

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OMMetrics.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OMMetrics.java
@@ -69,6 +69,7 @@ public class OMMetrics implements OmMetadataReaderMetrics {
   private @Metric MutableCounterLong numInitiateMultipartUploads;
   private @Metric MutableCounterLong numCompleteMultipartUploads;
   private @Metric MutableCounterLong numSnapshotCreates;
+  private @Metric MutableCounterLong numSnapshotDeletes;
   private @Metric MutableCounterLong numSnapshotLists;
 
   private @Metric MutableCounterLong numGetFileStatus;
@@ -119,6 +120,7 @@ public class OMMetrics implements OmMetadataReaderMetrics {
   private @Metric MutableCounterLong numListMultipartUploadPartFails;
   private @Metric MutableCounterLong numOpenKeyDeleteRequestFails;
   private @Metric MutableCounterLong numSnapshotCreateFails;
+  private @Metric MutableCounterLong numSnapshotDeleteFails;
   private @Metric MutableCounterLong numSnapshotListFails;
 
   // Number of tenant operations attempted
@@ -438,6 +440,14 @@ public class OMMetrics implements OmMetadataReaderMetrics {
 
   public void incNumSnapshotCreateFails() {
     numSnapshotCreateFails.incr();
+  }
+
+  public void incNumSnapshotDeletes() {
+    numSnapshotDeletes.incr();
+  }
+
+  public void incNumSnapshotDeleteFails() {
+    numSnapshotDeleteFails.incr();
   }
 
   public void incNumSnapshotLists() {

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/utils/OzoneManagerRatisUtils.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/utils/OzoneManagerRatisUtils.java
@@ -71,6 +71,7 @@ import org.apache.hadoop.ozone.om.request.security.OMCancelDelegationTokenReques
 import org.apache.hadoop.ozone.om.request.security.OMGetDelegationTokenRequest;
 import org.apache.hadoop.ozone.om.request.security.OMRenewDelegationTokenRequest;
 import org.apache.hadoop.ozone.om.request.snapshot.OMSnapshotCreateRequest;
+import org.apache.hadoop.ozone.om.request.snapshot.OMSnapshotDeleteRequest;
 import org.apache.hadoop.ozone.om.request.upgrade.OMCancelPrepareRequest;
 import org.apache.hadoop.ozone.om.request.upgrade.OMFinalizeUpgradeRequest;
 import org.apache.hadoop.ozone.om.request.upgrade.OMPrepareRequest;
@@ -212,6 +213,8 @@ public final class OzoneManagerRatisUtils {
       return new OMSetRangerServiceVersionRequest(omRequest);
     case CreateSnapshot:
       return new OMSnapshotCreateRequest(omRequest);
+    case DeleteSnapshot:
+      return new OMSnapshotDeleteRequest(omRequest);
     case DeleteOpenKeys:
       BucketLayout bktLayout = BucketLayout.DEFAULT;
       if (omRequest.getDeleteOpenKeysRequest().hasBucketLayout()) {

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/snapshot/OMSnapshotCreateRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/snapshot/OMSnapshotCreateRequest.java
@@ -96,7 +96,7 @@ public class OMSnapshotCreateRequest extends OMClientRequest {
     if (!ozoneManager.isAdmin(ugi) &&
         !ozoneManager.isOwner(ugi, bucketOwner)) {
       throw new OMException(
-          "Only bucket owners/admins can create snapshots",
+          "Only bucket owners and Ozone admins can create snapshots",
           OMException.ResultCodes.PERMISSION_DENIED);
     }
     return omRequest;
@@ -134,7 +134,7 @@ public class OMSnapshotCreateRequest extends OMClientRequest {
 
       //Check if snapshot already exists
       if (omMetadataManager.getSnapshotInfoTable().isExist(key)) {
-        LOG.debug("snapshot: {} already exists ", key);
+        LOG.debug("Snapshot '{}' already exists under '{}'", key, snapshotPath);
         throw new OMException("Snapshot already exists", FILE_ALREADY_EXISTS);
       }
 
@@ -176,11 +176,11 @@ public class OMSnapshotCreateRequest extends OMClientRequest {
         snapshotInfo.toAuditMap(), exception, userInfo));
     
     if (exception == null) {
-      LOG.info("created snapshot: name {} in snapshotPath: {}", snapshotName,
-          snapshotPath);
+      LOG.info("Created snapshot '{}' under path '{}'",
+          snapshotName, snapshotPath);
     } else {
       omMetrics.incNumSnapshotCreateFails();
-      LOG.error("Snapshot creation failed for name:{} in snapshotPath:{}",
+      LOG.error("Failed to create snapshot '{}' under path '{}'",
           snapshotName, snapshotPath);
     }
     return omClientResponse;

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/snapshot/OMSnapshotDeleteRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/snapshot/OMSnapshotDeleteRequest.java
@@ -156,8 +156,18 @@ public class OMSnapshotDeleteRequest extends OMClientRequest {
       if (!snapshotInfo.getSnapshotStatus().equals(
           SnapshotInfo.SnapshotStatus.SNAPSHOT_ACTIVE)) {
         // If the snapshot is not in active state, throw exception as well
-        throw new OMException("Snapshot exists but no longer active",
-            FILE_NOT_FOUND);
+        switch (snapshotInfo.getSnapshotStatus()) {
+        case SNAPSHOT_DELETED:
+          throw new OMException("Snapshot is already deleted. "
+              + "Pending reclamation.", FILE_NOT_FOUND);
+        case SNAPSHOT_RECLAIMED:
+          throw new OMException("Snapshot is already deleted and reclaimed.",
+              FILE_NOT_FOUND);
+        default:
+          // Unknown snapshot non-active state
+          throw new OMException("Snapshot exists but no longer in active state",
+              FILE_NOT_FOUND);
+        }
       }
 
       // Mark snapshot as deleted

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/snapshot/OMSnapshotDeleteRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/snapshot/OMSnapshotDeleteRequest.java
@@ -1,0 +1,189 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.ozone.om.request.snapshot;
+
+import com.google.common.base.Optional;
+import org.apache.hadoop.hdds.utils.db.RDBStore;
+import org.apache.hadoop.hdds.utils.db.cache.CacheKey;
+import org.apache.hadoop.hdds.utils.db.cache.CacheValue;
+import org.apache.hadoop.ozone.OmUtils;
+import org.apache.hadoop.ozone.audit.AuditLogger;
+import org.apache.hadoop.ozone.audit.OMAction;
+import org.apache.hadoop.ozone.om.OMMetadataManager;
+import org.apache.hadoop.ozone.om.OMMetrics;
+import org.apache.hadoop.ozone.om.OzoneManager;
+import org.apache.hadoop.ozone.om.exceptions.OMException;
+import org.apache.hadoop.ozone.om.helpers.SnapshotInfo;
+import org.apache.hadoop.ozone.om.ratis.utils.OzoneManagerDoubleBufferHelper;
+import org.apache.hadoop.ozone.om.request.OMClientRequest;
+import org.apache.hadoop.ozone.om.request.util.OmResponseUtil;
+import org.apache.hadoop.ozone.om.response.OMClientResponse;
+import org.apache.hadoop.ozone.om.response.snapshot.OMSnapshotCreateResponse;
+import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos;
+import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.CreateSnapshotRequest;
+import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.CreateSnapshotResponse;
+import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMRequest;
+import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMResponse;
+import org.apache.hadoop.ozone.security.acl.IAccessAuthorizer;
+import org.apache.hadoop.ozone.security.acl.OzoneObj;
+import org.apache.hadoop.security.UserGroupInformation;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+
+import static org.apache.hadoop.ozone.om.exceptions.OMException.ResultCodes.FILE_ALREADY_EXISTS;
+import static org.apache.hadoop.ozone.om.lock.OzoneManagerLock.Resource.BUCKET_LOCK;
+import static org.apache.hadoop.ozone.om.lock.OzoneManagerLock.Resource.SNAPSHOT_LOCK;
+
+
+/**
+ * Handles CreateSnapshot Request.
+ */
+public class OMSnapshotCreateRequest extends OMClientRequest {
+  private static final Logger LOG =
+      LoggerFactory.getLogger(OMSnapshotCreateRequest.class);
+
+  private final String snapshotPath;
+  private final String volumeName;
+  private final String bucketName;
+  private final String snapshotName;
+  private final String snapshotId;
+  private final SnapshotInfo snapshotInfo;
+
+  public OMSnapshotCreateRequest(OMRequest omRequest) {
+    super(omRequest);
+    CreateSnapshotRequest createSnapshotRequest = omRequest
+        .getCreateSnapshotRequest();
+    volumeName = createSnapshotRequest.getVolumeName();
+    bucketName = createSnapshotRequest.getBucketName();
+    snapshotId = createSnapshotRequest.getSnapshotId();
+
+    String possibleName = createSnapshotRequest.getSnapshotName();
+    snapshotInfo = SnapshotInfo.newInstance(volumeName,
+        bucketName,
+        possibleName,
+        snapshotId);
+    snapshotName = snapshotInfo.getName();
+    snapshotPath = snapshotInfo.getSnapshotPath();
+  }
+
+  @Override
+  public OMRequest preExecute(OzoneManager ozoneManager) throws IOException {
+    final OMRequest omRequest = super.preExecute(ozoneManager);
+    // Verify name
+    OmUtils.validateSnapshotName(snapshotName);
+
+    UserGroupInformation ugi = createUGI();
+    String bucketOwner = ozoneManager.getBucketOwner(volumeName, bucketName,
+        IAccessAuthorizer.ACLType.READ, OzoneObj.ResourceType.BUCKET);
+    if (!ozoneManager.isAdmin(ugi) &&
+        !ozoneManager.isOwner(ugi, bucketOwner)) {
+      throw new OMException(
+          "Only bucket owners/admins can create snapshots",
+          OMException.ResultCodes.PERMISSION_DENIED);
+    }
+    return omRequest;
+  }
+  
+  @Override
+  public OMClientResponse validateAndUpdateCache(OzoneManager ozoneManager,
+      long transactionLogIndex,
+      OzoneManagerDoubleBufferHelper ozoneManagerDoubleBufferHelper) {
+
+    OMMetrics omMetrics = ozoneManager.getMetrics();
+    omMetrics.incNumSnapshotCreates();
+
+    boolean acquiredBucketLock = false, acquiredSnapshotLock = false;
+    IOException exception = null;
+    OMMetadataManager omMetadataManager = ozoneManager.getMetadataManager();
+    
+    OMResponse.Builder omResponse = OmResponseUtil.getOMResponseBuilder(
+        getOmRequest());
+    OMClientResponse omClientResponse = null;
+    AuditLogger auditLogger = ozoneManager.getAuditLogger();
+
+    OzoneManagerProtocolProtos.UserInfo userInfo = getOmRequest().getUserInfo();
+    String key = snapshotInfo.getTableKey();
+    try {
+      // Lock bucket so it doesn't
+      //  get deleted while creating snapshot
+      acquiredBucketLock =
+          omMetadataManager.getLock().acquireReadLock(BUCKET_LOCK,
+              volumeName, bucketName);
+
+      acquiredSnapshotLock =
+          omMetadataManager.getLock().acquireWriteLock(SNAPSHOT_LOCK,
+              volumeName, bucketName, snapshotName);
+
+      //Check if snapshot already exists
+      if (omMetadataManager.getSnapshotInfoTable().isExist(key)) {
+        LOG.debug("snapshot: {} already exists ", key);
+        throw new OMException("Snapshot already exists", FILE_ALREADY_EXISTS);
+      }
+
+      // Note down RDB latest transaction sequence number, which is used
+      // as snapshot generation in the differ.
+      final long dbLatestSequenceNumber =
+          ((RDBStore) omMetadataManager.getStore()).getDb()
+              .getLatestSequenceNumber();
+      snapshotInfo.setDbTxSequenceNumber(dbLatestSequenceNumber);
+
+      omMetadataManager.getSnapshotInfoTable()
+          .addCacheEntry(new CacheKey<>(key),
+            new CacheValue<>(Optional.of(snapshotInfo), transactionLogIndex));
+
+      omResponse.setCreateSnapshotResponse(
+          CreateSnapshotResponse.newBuilder()
+          .setSnapshotInfo(snapshotInfo.getProtobuf()));
+      omClientResponse = new OMSnapshotCreateResponse(
+          omResponse.build(), volumeName, bucketName, snapshotName);
+    } catch (IOException ex) {
+      exception = ex;
+      omClientResponse = new OMSnapshotCreateResponse(
+          createErrorOMResponse(omResponse, exception));
+    } finally {
+      addResponseToDoubleBuffer(transactionLogIndex, omClientResponse,
+          ozoneManagerDoubleBufferHelper);
+      if (acquiredSnapshotLock) {
+        omMetadataManager.getLock().releaseWriteLock(SNAPSHOT_LOCK, volumeName,
+            bucketName, snapshotName);
+      }
+      if (acquiredBucketLock) {
+        omMetadataManager.getLock().releaseReadLock(BUCKET_LOCK, volumeName,
+            bucketName);
+      }
+    }
+
+    // Performing audit logging outside the lock.
+    auditLog(auditLogger, buildAuditMessage(OMAction.CREATE_SNAPSHOT,
+        snapshotInfo.toAuditMap(), exception, userInfo));
+    
+    if (exception == null) {
+      LOG.info("created snapshot: name {} in snapshotPath: {}", snapshotName,
+          snapshotPath);
+    } else {
+      omMetrics.incNumSnapshotCreateFails();
+      LOG.error("Snapshot creation failed for name:{} in snapshotPath:{}",
+          snapshotName, snapshotPath);
+    }
+    return omClientResponse;
+  }
+  
+}

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/snapshot/OMSnapshotDeleteRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/snapshot/OMSnapshotDeleteRequest.java
@@ -197,7 +197,7 @@ public class OMSnapshotDeleteRequest extends OMClientRequest {
             bucketName, snapshotName);
       }
       if (acquiredBucketLock) {
-        omMetadataManager.getLock().releaseReadLock(BUCKET_LOCK, volumeName,
+        omMetadataManager.getLock().releaseWriteLock(BUCKET_LOCK, volumeName,
             bucketName);
       }
     }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/snapshot/OMSnapshotCreateResponse.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/snapshot/OMSnapshotCreateResponse.java
@@ -31,12 +31,11 @@ import java.io.IOException;
 import static org.apache.hadoop.ozone.om.OmMetadataManagerImpl.SNAPSHOT_INFO_TABLE;
 
 /**
- * Response for OMSnapshotCreateResponse.
+ * Response for OMSnapshotCreateRequest.
  */
 @CleanupTableInfo(cleanupTables = {SNAPSHOT_INFO_TABLE})
 public class OMSnapshotCreateResponse extends OMClientResponse {
 
-  @SuppressWarnings("checkstyle:parameternumber")
   public OMSnapshotCreateResponse(@Nonnull OMResponse omResponse,
       @Nonnull String volumeName, @Nonnull String bucketName,
                                   @Nonnull String snapshotName) {

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/snapshot/OMSnapshotDeleteResponse.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/snapshot/OMSnapshotDeleteResponse.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package org.apache.hadoop.ozone.om.response.snapshot;
+
+import org.apache.hadoop.hdds.utils.db.BatchOperation;
+import org.apache.hadoop.ozone.om.OMMetadataManager;
+import org.apache.hadoop.ozone.om.OmSnapshotManager;
+import org.apache.hadoop.ozone.om.helpers.SnapshotInfo;
+import org.apache.hadoop.ozone.om.response.CleanupTableInfo;
+import org.apache.hadoop.ozone.om.response.OMClientResponse;
+import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMResponse;
+
+import javax.annotation.Nonnull;
+import java.io.IOException;
+import static org.apache.hadoop.ozone.om.OmMetadataManagerImpl.SNAPSHOT_INFO_TABLE;
+
+/**
+ * Response for OMSnapshotCreateResponse.
+ */
+@CleanupTableInfo(cleanupTables = {SNAPSHOT_INFO_TABLE})
+public class OMSnapshotCreateResponse extends OMClientResponse {
+
+  @SuppressWarnings("checkstyle:parameternumber")
+  public OMSnapshotCreateResponse(@Nonnull OMResponse omResponse,
+      @Nonnull String volumeName, @Nonnull String bucketName,
+                                  @Nonnull String snapshotName) {
+    super(omResponse);
+  }
+
+  /**
+   * For when the request is not successful.
+   * For a successful request, the other constructor should be used.
+   */
+  public OMSnapshotCreateResponse(@Nonnull OMResponse omResponse) {
+    super(omResponse);
+    checkStatusNotOK();
+  }
+
+  @Override
+  public void addToDBBatch(OMMetadataManager omMetadataManager,
+      BatchOperation batchOperation) throws IOException {
+
+    SnapshotInfo snapshotInfo =
+        SnapshotInfo.getFromProtobuf(
+        getOMResponse().getCreateSnapshotResponse().getSnapshotInfo());
+
+    // Create the snapshot checkpoint
+    OmSnapshotManager.createOmSnapshotCheckpoint(omMetadataManager,
+        snapshotInfo);
+
+    String key = snapshotInfo.getTableKey();
+
+    // Add to db
+    omMetadataManager.getSnapshotInfoTable().putWithBatch(batchOperation,
+        key, snapshotInfo);
+  }
+}

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/snapshot/OMSnapshotDeleteResponse.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/snapshot/OMSnapshotDeleteResponse.java
@@ -20,7 +20,6 @@ package org.apache.hadoop.ozone.om.response.snapshot;
 
 import org.apache.hadoop.hdds.utils.db.BatchOperation;
 import org.apache.hadoop.ozone.om.OMMetadataManager;
-import org.apache.hadoop.ozone.om.OmSnapshotManager;
 import org.apache.hadoop.ozone.om.helpers.SnapshotInfo;
 import org.apache.hadoop.ozone.om.response.CleanupTableInfo;
 import org.apache.hadoop.ozone.om.response.OMClientResponse;
@@ -28,26 +27,31 @@ import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMRespo
 
 import javax.annotation.Nonnull;
 import java.io.IOException;
+
 import static org.apache.hadoop.ozone.om.OmMetadataManagerImpl.SNAPSHOT_INFO_TABLE;
 
 /**
- * Response for OMSnapshotCreateResponse.
+ * Response for OMSnapshotDeleteRequest.
  */
 @CleanupTableInfo(cleanupTables = {SNAPSHOT_INFO_TABLE})
-public class OMSnapshotCreateResponse extends OMClientResponse {
+public class OMSnapshotDeleteResponse extends OMClientResponse {
 
-  @SuppressWarnings("checkstyle:parameternumber")
-  public OMSnapshotCreateResponse(@Nonnull OMResponse omResponse,
-      @Nonnull String volumeName, @Nonnull String bucketName,
-                                  @Nonnull String snapshotName) {
+  private String tableKey;
+  private SnapshotInfo snapshotInfo;
+
+  public OMSnapshotDeleteResponse(@Nonnull OMResponse omResponse,
+      @Nonnull String tableKey,
+      @Nonnull SnapshotInfo snapshotInfo) {
     super(omResponse);
+    this.tableKey = tableKey;
+    this.snapshotInfo = snapshotInfo;
   }
 
   /**
    * For when the request is not successful.
    * For a successful request, the other constructor should be used.
    */
-  public OMSnapshotCreateResponse(@Nonnull OMResponse omResponse) {
+  public OMSnapshotDeleteResponse(@Nonnull OMResponse omResponse) {
     super(omResponse);
     checkStatusNotOK();
   }
@@ -56,18 +60,8 @@ public class OMSnapshotCreateResponse extends OMClientResponse {
   public void addToDBBatch(OMMetadataManager omMetadataManager,
       BatchOperation batchOperation) throws IOException {
 
-    SnapshotInfo snapshotInfo =
-        SnapshotInfo.getFromProtobuf(
-        getOMResponse().getCreateSnapshotResponse().getSnapshotInfo());
-
-    // Create the snapshot checkpoint
-    OmSnapshotManager.createOmSnapshotCheckpoint(omMetadataManager,
-        snapshotInfo);
-
-    String key = snapshotInfo.getTableKey();
-
     // Add to db
     omMetadataManager.getSnapshotInfoTable().putWithBatch(batchOperation,
-        key, snapshotInfo);
+        tableKey, snapshotInfo);
   }
 }

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/OMRequestTestUtils.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/OMRequestTestUtils.java
@@ -1134,7 +1134,30 @@ public final class OMRequestTestUtils {
 
     return OMRequest.newBuilder()
         .setCreateSnapshotRequest(createSnapshotRequest)
-        .setCmdType(OzoneManagerProtocolProtos.Type.CreateSnapshot)
+        .setCmdType(Type.CreateSnapshot)
+        .setClientId(UUID.randomUUID().toString())
+        .build();
+  }
+
+  /**
+   * Create OMRequest for Delete Snapshot.
+   * @param volumeName vol to be used
+   * @param bucketName bucket to be used
+   * @param snapshotName name of the snapshot to be deleted
+   */
+  public static OMRequest deleteSnapshotRequest(String volumeName,
+      String bucketName, String snapshotName) {
+    OzoneManagerProtocolProtos.DeleteSnapshotRequest deleteSnapshotRequest =
+        OzoneManagerProtocolProtos.DeleteSnapshotRequest.newBuilder()
+            .setVolumeName(volumeName)
+            .setBucketName(bucketName)
+            .setSnapshotName(snapshotName)
+            .setDeletionTime(Time.now())
+            .build();
+
+    return OMRequest.newBuilder()
+        .setDeleteSnapshotRequest(deleteSnapshotRequest)
+        .setCmdType(Type.DeleteSnapshot)
         .setClientId(UUID.randomUUID().toString())
         .build();
   }

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/snapshot/TestOMSnapshotCreateRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/snapshot/TestOMSnapshotCreateRequest.java
@@ -132,7 +132,7 @@ public class TestOMSnapshotCreateRequest {
         volumeName, bucketName, snapshotName);
     // Check bad owner
     LambdaTestUtils.intercept(OMException.class,
-        "Only bucket owners/admins can create snapshots",
+        "Only bucket owners and Ozone admins can create snapshots",
         () -> doPreExecute(omRequest));
   }
 
@@ -258,6 +258,14 @@ public class TestOMSnapshotCreateRequest {
 
   private OMSnapshotCreateRequest doPreExecute(
       OMRequest originalRequest) throws Exception {
+    return doPreExecute(originalRequest, ozoneManager);
+  }
+
+  /**
+   * Static helper method so this could be used in TestOMSnapshotDeleteRequest.
+   */
+  static OMSnapshotCreateRequest doPreExecute(
+      OMRequest originalRequest, OzoneManager ozoneManager) throws Exception {
     OMSnapshotCreateRequest omSnapshotCreateRequest =
         new OMSnapshotCreateRequest(originalRequest);
 

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/snapshot/TestOMSnapshotDeleteRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/snapshot/TestOMSnapshotDeleteRequest.java
@@ -1,0 +1,269 @@
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.apache.hadoop.ozone.om.request.snapshot;
+
+import java.util.UUID;
+
+import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import org.apache.hadoop.ozone.audit.AuditLogger;
+import org.apache.hadoop.ozone.audit.AuditMessage;
+
+import org.apache.hadoop.ozone.om.OMConfigKeys;
+import org.apache.hadoop.ozone.om.OMMetadataManager;
+import org.apache.hadoop.ozone.om.OMMetrics;
+import org.apache.hadoop.ozone.om.OmMetadataManagerImpl;
+import org.apache.hadoop.ozone.om.OzoneManager;
+import org.apache.hadoop.ozone.om.exceptions.OMException;
+import org.apache.hadoop.ozone.om.helpers.SnapshotInfo;
+import org.apache.hadoop.ozone.om.ratis.utils.OzoneManagerDoubleBufferHelper;
+import org.apache.hadoop.ozone.om.upgrade.OMLayoutVersionManager;
+import org.apache.ozone.test.LambdaTestUtils;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+
+import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos
+    .OMRequest;
+import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos
+    .OMResponse;
+import org.apache.hadoop.ozone.om.request.OMRequestTestUtils;
+import org.apache.hadoop.ozone.om.response.OMClientResponse;
+import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos;
+import org.junit.rules.TemporaryFolder;
+import org.mockito.Mockito;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Tests OMSnapshotCreateRequest class, which handles CreateSnapshot request.
+ */
+public class TestOMSnapshotCreateRequest {
+  @Rule
+  public TemporaryFolder folder = new TemporaryFolder();
+
+  private OzoneManager ozoneManager;
+  private OMMetrics omMetrics;
+  private OMMetadataManager omMetadataManager;
+
+  private String volumeName;
+  private String bucketName;
+  private String snapshotName;
+
+  // Just setting ozoneManagerDoubleBuffer which does nothing.
+  private final OzoneManagerDoubleBufferHelper ozoneManagerDoubleBufferHelper =
+      ((response, transactionIndex) -> null);
+
+  @Before
+  public void setup() throws Exception {
+
+    ozoneManager = mock(OzoneManager.class);
+    omMetrics = OMMetrics.create();
+    OzoneConfiguration ozoneConfiguration = new OzoneConfiguration();
+    ozoneConfiguration.set(OMConfigKeys.OZONE_OM_DB_DIRS,
+        folder.newFolder().getAbsolutePath());
+    omMetadataManager = new OmMetadataManagerImpl(ozoneConfiguration);
+    when(ozoneManager.getMetrics()).thenReturn(omMetrics);
+    when(ozoneManager.getMetadataManager()).thenReturn(omMetadataManager);
+    when(ozoneManager.isRatisEnabled()).thenReturn(true);
+    when(ozoneManager.isAdmin(any())).thenReturn(false);
+    when(ozoneManager.isOwner(any(), any())).thenReturn(false);
+    when(ozoneManager.getBucketOwner(any(), any(),
+        any(), any())).thenReturn("dummyBucketOwner");
+    OMLayoutVersionManager lvm = mock(OMLayoutVersionManager.class);
+    when(lvm.getMetadataLayoutVersion()).thenReturn(0);
+    when(ozoneManager.getVersionManager()).thenReturn(lvm);
+    AuditLogger auditLogger = mock(AuditLogger.class);
+    when(ozoneManager.getAuditLogger()).thenReturn(auditLogger);
+    Mockito.doNothing().when(auditLogger).logWrite(any(AuditMessage.class));
+
+    volumeName = UUID.randomUUID().toString();
+    bucketName = UUID.randomUUID().toString();
+    snapshotName = UUID.randomUUID().toString();
+    OMRequestTestUtils.addVolumeAndBucketToDB(
+        volumeName, bucketName, omMetadataManager);
+
+  }
+
+  @After
+  public void stop() {
+    omMetrics.unRegister();
+    Mockito.framework().clearInlineMocks();
+  }
+
+  @Test
+  public void testPreExecute() throws Exception {
+    // set the owner
+    when(ozoneManager.isOwner(any(), any())).thenReturn(true);
+    OMRequest omRequest =
+        OMRequestTestUtils.createSnapshotRequest(
+        volumeName, bucketName, snapshotName);
+    // should not throw
+    doPreExecute(omRequest);
+  }
+
+  @Test
+  public void testPreExecuteBadOwner() throws Exception {
+    // owner not set
+    OMRequest omRequest =
+        OMRequestTestUtils.createSnapshotRequest(
+        volumeName, bucketName, snapshotName);
+    // Check bad owner
+    LambdaTestUtils.intercept(OMException.class,
+        "Only bucket owners/admins can create snapshots",
+        () -> doPreExecute(omRequest));
+  }
+
+  @Test
+  public void testPreExecuteBadName() throws Exception {
+    // check invalid snapshot name
+    String badName = "a?b";
+    OMRequest omRequest =
+        OMRequestTestUtils.createSnapshotRequest(
+        volumeName, bucketName, badName);
+    LambdaTestUtils.intercept(OMException.class,
+        "Invalid snapshot name: " + badName,
+        () -> doPreExecute(omRequest));
+  }
+
+  @Test
+  public void testPreExecuteNameOnlyNumbers() throws Exception {
+    // check invalid snapshot name containing only numbers
+    String badNameON = "1234";
+    OMRequest omRequest =
+            OMRequestTestUtils.createSnapshotRequest(
+                    volumeName, bucketName, badNameON);
+    LambdaTestUtils.intercept(OMException.class,
+            "Invalid snapshot name: " + badNameON,
+            () -> doPreExecute(omRequest));
+  }
+
+  @Test
+  public void testPreExecuteNameLength() throws Exception {
+    // check snapshot name length
+    String name63 =
+            "snap75795657617173401188448010125899089001363595171500499231286";
+    String name64 =
+            "snap156808943643007724443266605711479126926050896107709081166294";
+
+    // name length = 63
+    when(ozoneManager.isOwner(any(), any())).thenReturn(true);
+    OMRequest omRequest = OMRequestTestUtils.createSnapshotRequest(
+                    volumeName, bucketName, name63);
+    // should not throw any error
+    doPreExecute(omRequest);
+
+    // name length = 64
+    OMRequest omRequest2 = OMRequestTestUtils.createSnapshotRequest(
+                    volumeName, bucketName, name64);
+    LambdaTestUtils.intercept(OMException.class,
+            "Invalid snapshot name: " + name64,
+            () -> doPreExecute(omRequest2));
+  }
+
+  @Test
+  public void testValidateAndUpdateCache() throws Exception {
+    when(ozoneManager.isAdmin(any())).thenReturn(true);
+    OMRequest omRequest =
+        OMRequestTestUtils.createSnapshotRequest(
+        volumeName, bucketName, snapshotName);
+    OMSnapshotCreateRequest omSnapshotCreateRequest =
+        doPreExecute(omRequest);
+    String key = SnapshotInfo.getTableKey(volumeName,
+        bucketName, snapshotName);
+
+    // As we have not still called validateAndUpdateCache, get() should
+    // return null.
+    Assert.assertNull(omMetadataManager.getSnapshotInfoTable().get(key));
+
+    // add key to cache
+    OMClientResponse omClientResponse =
+        omSnapshotCreateRequest.validateAndUpdateCache(ozoneManager, 1,
+            ozoneManagerDoubleBufferHelper);
+    
+    // check cache
+    SnapshotInfo snapshotInfo =
+        omMetadataManager.getSnapshotInfoTable().get(key);
+    Assert.assertNotNull(snapshotInfo);
+
+    // verify table data with response data.
+    SnapshotInfo snapshotInfoFromProto = SnapshotInfo.getFromProtobuf(
+        omClientResponse.getOMResponse()
+        .getCreateSnapshotResponse().getSnapshotInfo());
+    Assert.assertEquals(snapshotInfoFromProto, snapshotInfo);
+
+    OMResponse omResponse = omClientResponse.getOMResponse();
+    Assert.assertNotNull(omResponse.getCreateSnapshotResponse());
+    Assert.assertEquals(OzoneManagerProtocolProtos.Type.CreateSnapshot,
+        omResponse.getCmdType());
+    Assert.assertEquals(OzoneManagerProtocolProtos.Status.OK,
+        omResponse.getStatus());
+  }
+
+  @Test
+  public void testEntryExists() throws Exception {
+    when(ozoneManager.isAdmin(any())).thenReturn(true);
+    OMRequest omRequest =
+        OMRequestTestUtils.createSnapshotRequest(
+        volumeName, bucketName, snapshotName);
+    OMSnapshotCreateRequest omSnapshotCreateRequest = doPreExecute(omRequest);
+    String key = SnapshotInfo.getTableKey(volumeName,
+        bucketName, snapshotName);
+
+    Assert.assertNull(omMetadataManager.getSnapshotInfoTable().get(key));
+
+    //create entry
+    omSnapshotCreateRequest.validateAndUpdateCache(ozoneManager, 1,
+        ozoneManagerDoubleBufferHelper);
+    SnapshotInfo snapshotInfo =
+        omMetadataManager.getSnapshotInfoTable().get(key);
+    Assert.assertNotNull(snapshotInfo);
+
+    // Now try to create again to verify error
+    omRequest =
+        OMRequestTestUtils.createSnapshotRequest(
+        volumeName, bucketName, snapshotName);
+    omSnapshotCreateRequest = doPreExecute(omRequest);
+    OMClientResponse omClientResponse =
+        omSnapshotCreateRequest.validateAndUpdateCache(ozoneManager, 2,
+            ozoneManagerDoubleBufferHelper);
+    
+    OMResponse omResponse = omClientResponse.getOMResponse();
+    Assert.assertNotNull(omResponse.getCreateSnapshotResponse());
+    Assert.assertEquals(OzoneManagerProtocolProtos.Status.FILE_ALREADY_EXISTS,
+        omResponse.getStatus());
+  }
+
+  private OMSnapshotCreateRequest doPreExecute(
+      OMRequest originalRequest) throws Exception {
+    OMSnapshotCreateRequest omSnapshotCreateRequest =
+        new OMSnapshotCreateRequest(originalRequest);
+
+    OMRequest modifiedRequest =
+        omSnapshotCreateRequest.preExecute(ozoneManager);
+    return new OMSnapshotCreateRequest(modifiedRequest);
+  }
+
+}

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/snapshot/TestOMSnapshotDeleteRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/snapshot/TestOMSnapshotDeleteRequest.java
@@ -20,12 +20,12 @@
 
 package org.apache.hadoop.ozone.om.request.snapshot;
 
-import java.util.UUID;
-
+import com.google.common.base.Optional;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import org.apache.hadoop.hdds.utils.db.cache.CacheKey;
+import org.apache.hadoop.hdds.utils.db.cache.CacheValue;
 import org.apache.hadoop.ozone.audit.AuditLogger;
 import org.apache.hadoop.ozone.audit.AuditMessage;
-
 import org.apache.hadoop.ozone.om.OMConfigKeys;
 import org.apache.hadoop.ozone.om.OMMetadataManager;
 import org.apache.hadoop.ozone.om.OMMetrics;
@@ -34,33 +34,34 @@ import org.apache.hadoop.ozone.om.OzoneManager;
 import org.apache.hadoop.ozone.om.exceptions.OMException;
 import org.apache.hadoop.ozone.om.helpers.SnapshotInfo;
 import org.apache.hadoop.ozone.om.ratis.utils.OzoneManagerDoubleBufferHelper;
+import org.apache.hadoop.ozone.om.request.OMRequestTestUtils;
+import org.apache.hadoop.ozone.om.response.OMClientResponse;
 import org.apache.hadoop.ozone.om.upgrade.OMLayoutVersionManager;
+import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMRequest;
+import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMResponse;
+import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.Status;
+import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.Type;
 import org.apache.ozone.test.LambdaTestUtils;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
-
-
-import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos
-    .OMRequest;
-import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos
-    .OMResponse;
-import org.apache.hadoop.ozone.om.request.OMRequestTestUtils;
-import org.apache.hadoop.ozone.om.response.OMClientResponse;
-import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos;
 import org.junit.rules.TemporaryFolder;
 import org.mockito.Mockito;
+
+import java.util.UUID;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 /**
- * Tests OMSnapshotCreateRequest class, which handles CreateSnapshot request.
+ * Tests OMSnapshotDeleteRequest class, which handles DeleteSnapshot request.
+ * Mostly mirrors TestOMSnapshotCreateRequest.
+ * testEntryNotExist() and testEntryExists() are unique.
  */
-public class TestOMSnapshotCreateRequest {
+public class TestOMSnapshotDeleteRequest {
   @Rule
   public TemporaryFolder folder = new TemporaryFolder();
 
@@ -118,7 +119,7 @@ public class TestOMSnapshotCreateRequest {
     // set the owner
     when(ozoneManager.isOwner(any(), any())).thenReturn(true);
     OMRequest omRequest =
-        OMRequestTestUtils.createSnapshotRequest(
+        OMRequestTestUtils.deleteSnapshotRequest(
         volumeName, bucketName, snapshotName);
     // should not throw
     doPreExecute(omRequest);
@@ -128,11 +129,11 @@ public class TestOMSnapshotCreateRequest {
   public void testPreExecuteBadOwner() throws Exception {
     // owner not set
     OMRequest omRequest =
-        OMRequestTestUtils.createSnapshotRequest(
+        OMRequestTestUtils.deleteSnapshotRequest(
         volumeName, bucketName, snapshotName);
     // Check bad owner
     LambdaTestUtils.intercept(OMException.class,
-        "Only bucket owners/admins can create snapshots",
+        "Only bucket owners and Ozone admins can delete snapshots",
         () -> doPreExecute(omRequest));
   }
 
@@ -141,7 +142,7 @@ public class TestOMSnapshotCreateRequest {
     // check invalid snapshot name
     String badName = "a?b";
     OMRequest omRequest =
-        OMRequestTestUtils.createSnapshotRequest(
+        OMRequestTestUtils.deleteSnapshotRequest(
         volumeName, bucketName, badName);
     LambdaTestUtils.intercept(OMException.class,
         "Invalid snapshot name: " + badName,
@@ -152,12 +153,11 @@ public class TestOMSnapshotCreateRequest {
   public void testPreExecuteNameOnlyNumbers() throws Exception {
     // check invalid snapshot name containing only numbers
     String badNameON = "1234";
-    OMRequest omRequest =
-            OMRequestTestUtils.createSnapshotRequest(
-                    volumeName, bucketName, badNameON);
+    OMRequest omRequest = OMRequestTestUtils.deleteSnapshotRequest(
+        volumeName, bucketName, badNameON);
     LambdaTestUtils.intercept(OMException.class,
-            "Invalid snapshot name: " + badNameON,
-            () -> doPreExecute(omRequest));
+        "Invalid snapshot name: " + badNameON,
+        () -> doPreExecute(omRequest));
   }
 
   @Test
@@ -170,26 +170,26 @@ public class TestOMSnapshotCreateRequest {
 
     // name length = 63
     when(ozoneManager.isOwner(any(), any())).thenReturn(true);
-    OMRequest omRequest = OMRequestTestUtils.createSnapshotRequest(
-                    volumeName, bucketName, name63);
+    OMRequest omRequest = OMRequestTestUtils.deleteSnapshotRequest(
+        volumeName, bucketName, name63);
     // should not throw any error
     doPreExecute(omRequest);
 
     // name length = 64
-    OMRequest omRequest2 = OMRequestTestUtils.createSnapshotRequest(
-                    volumeName, bucketName, name64);
+    OMRequest omRequest2 = OMRequestTestUtils.deleteSnapshotRequest(
+        volumeName, bucketName, name64);
     LambdaTestUtils.intercept(OMException.class,
-            "Invalid snapshot name: " + name64,
-            () -> doPreExecute(omRequest2));
+        "Invalid snapshot name: " + name64,
+        () -> doPreExecute(omRequest2));
   }
 
   @Test
   public void testValidateAndUpdateCache() throws Exception {
     when(ozoneManager.isAdmin(any())).thenReturn(true);
     OMRequest omRequest =
-        OMRequestTestUtils.createSnapshotRequest(
+        OMRequestTestUtils.deleteSnapshotRequest(
         volumeName, bucketName, snapshotName);
-    OMSnapshotCreateRequest omSnapshotCreateRequest =
+    OMSnapshotDeleteRequest omSnapshotDeleteRequest =
         doPreExecute(omRequest);
     String key = SnapshotInfo.getTableKey(volumeName,
         bucketName, snapshotName);
@@ -199,71 +199,133 @@ public class TestOMSnapshotCreateRequest {
     Assert.assertNull(omMetadataManager.getSnapshotInfoTable().get(key));
 
     // add key to cache
-    OMClientResponse omClientResponse =
-        omSnapshotCreateRequest.validateAndUpdateCache(ozoneManager, 1,
-            ozoneManagerDoubleBufferHelper);
-    
-    // check cache
-    SnapshotInfo snapshotInfo =
-        omMetadataManager.getSnapshotInfoTable().get(key);
-    Assert.assertNotNull(snapshotInfo);
+    SnapshotInfo snapshotInfo = SnapshotInfo.newInstance(
+        volumeName, bucketName, snapshotName, null);
+    Assert.assertEquals(SnapshotInfo.SnapshotStatus.SNAPSHOT_ACTIVE,
+        snapshotInfo.getSnapshotStatus());
+    omMetadataManager.getSnapshotInfoTable().addCacheEntry(
+        new CacheKey<>(key),
+        new CacheValue<>(Optional.of(snapshotInfo), 1L));
 
-    // verify table data with response data.
-    SnapshotInfo snapshotInfoFromProto = SnapshotInfo.getFromProtobuf(
-        omClientResponse.getOMResponse()
-        .getCreateSnapshotResponse().getSnapshotInfo());
-    Assert.assertEquals(snapshotInfoFromProto, snapshotInfo);
+    // Trigger validateAndUpdateCache
+    OMClientResponse omClientResponse =
+        omSnapshotDeleteRequest.validateAndUpdateCache(ozoneManager, 2L,
+            ozoneManagerDoubleBufferHelper);
+
+    // check cache
+    snapshotInfo = omMetadataManager.getSnapshotInfoTable().get(key);
+    Assert.assertNotNull(snapshotInfo);
+    Assert.assertEquals(SnapshotInfo.SnapshotStatus.SNAPSHOT_DELETED,
+        snapshotInfo.getSnapshotStatus());
 
     OMResponse omResponse = omClientResponse.getOMResponse();
-    Assert.assertNotNull(omResponse.getCreateSnapshotResponse());
-    Assert.assertEquals(OzoneManagerProtocolProtos.Type.CreateSnapshot,
-        omResponse.getCmdType());
-    Assert.assertEquals(OzoneManagerProtocolProtos.Status.OK,
-        omResponse.getStatus());
+
+    // check response success flag
+    Assert.assertTrue(omResponse.getSuccess());
+
+    Assert.assertNotNull(omResponse.getDeleteSnapshotResponse());
+    Assert.assertEquals(Type.DeleteSnapshot, omResponse.getCmdType());
+    Assert.assertEquals(Status.OK, omResponse.getStatus());
   }
 
+  /**
+   * Expect snapshot deletion failure when snapshot entry does not exist.
+   */
+  @Test
+  public void testEntryNotExist() throws Exception {
+    when(ozoneManager.isAdmin(any())).thenReturn(true);
+    OMRequest omRequest = OMRequestTestUtils.deleteSnapshotRequest(
+        volumeName, bucketName, snapshotName);
+    OMSnapshotDeleteRequest omSnapshotDeleteRequest = doPreExecute(omRequest);
+    String key = SnapshotInfo.getTableKey(volumeName, bucketName, snapshotName);
+
+    // Entry does not exist
+    Assert.assertNull(omMetadataManager.getSnapshotInfoTable().get(key));
+
+    // Trigger delete snapshot validateAndUpdateCache
+    OMClientResponse omClientResponse =
+        omSnapshotDeleteRequest.validateAndUpdateCache(ozoneManager, 1L,
+            ozoneManagerDoubleBufferHelper);
+
+    OMResponse omResponse = omClientResponse.getOMResponse();
+    Assert.assertNotNull(omResponse.getDeleteSnapshotResponse());
+    Assert.assertEquals(Status.FILE_NOT_FOUND, omResponse.getStatus());
+  }
+
+  /**
+   * Expect successful snapshot deletion when snapshot entry exists.
+   * But a second deletion would result in an error.
+   */
   @Test
   public void testEntryExists() throws Exception {
     when(ozoneManager.isAdmin(any())).thenReturn(true);
-    OMRequest omRequest =
-        OMRequestTestUtils.createSnapshotRequest(
+    String key = SnapshotInfo.getTableKey(volumeName, bucketName, snapshotName);
+
+    OMRequest omRequest1 = OMRequestTestUtils.createSnapshotRequest(
         volumeName, bucketName, snapshotName);
-    OMSnapshotCreateRequest omSnapshotCreateRequest = doPreExecute(omRequest);
-    String key = SnapshotInfo.getTableKey(volumeName,
-        bucketName, snapshotName);
+    OMSnapshotCreateRequest omSnapshotCreateRequest =
+        TestOMSnapshotCreateRequest.doPreExecute(omRequest1, ozoneManager);
 
     Assert.assertNull(omMetadataManager.getSnapshotInfoTable().get(key));
 
-    //create entry
-    omSnapshotCreateRequest.validateAndUpdateCache(ozoneManager, 1,
+    // Create snapshot entry
+    omSnapshotCreateRequest.validateAndUpdateCache(ozoneManager, 1L,
         ozoneManagerDoubleBufferHelper);
     SnapshotInfo snapshotInfo =
         omMetadataManager.getSnapshotInfoTable().get(key);
     Assert.assertNotNull(snapshotInfo);
+    Assert.assertEquals(SnapshotInfo.SnapshotStatus.SNAPSHOT_ACTIVE,
+        snapshotInfo.getSnapshotStatus());
 
-    // Now try to create again to verify error
-    omRequest =
-        OMRequestTestUtils.createSnapshotRequest(
+    OMRequest omRequest2 = OMRequestTestUtils.deleteSnapshotRequest(
         volumeName, bucketName, snapshotName);
-    omSnapshotCreateRequest = doPreExecute(omRequest);
+    OMSnapshotDeleteRequest omSnapshotDeleteRequest = doPreExecute(omRequest2);
+
+    // Delete snapshot entry
     OMClientResponse omClientResponse =
-        omSnapshotCreateRequest.validateAndUpdateCache(ozoneManager, 2,
+        omSnapshotDeleteRequest.validateAndUpdateCache(ozoneManager, 2L,
             ozoneManagerDoubleBufferHelper);
-    
+
+    snapshotInfo = omMetadataManager.getSnapshotInfoTable().get(key);
+    // The snapshot entry should still exist in the table,
+    // but marked as DELETED.
+    Assert.assertNotNull(snapshotInfo);
+    Assert.assertEquals(SnapshotInfo.SnapshotStatus.SNAPSHOT_DELETED,
+        snapshotInfo.getSnapshotStatus());
+    Assert.assertTrue(snapshotInfo.getDeletionTime() > 0L);
+
+    // Response should be successful
     OMResponse omResponse = omClientResponse.getOMResponse();
-    Assert.assertNotNull(omResponse.getCreateSnapshotResponse());
-    Assert.assertEquals(OzoneManagerProtocolProtos.Status.FILE_ALREADY_EXISTS,
-        omResponse.getStatus());
+    Assert.assertNotNull(omResponse.getDeleteSnapshotResponse());
+    Assert.assertEquals(Status.OK, omResponse.getStatus());
+
+    // Now delete snapshot entry again, expect error
+    omRequest2 = OMRequestTestUtils.deleteSnapshotRequest(
+        volumeName, bucketName, snapshotName);
+    omSnapshotDeleteRequest = doPreExecute(omRequest2);
+    omClientResponse =
+        omSnapshotDeleteRequest.validateAndUpdateCache(ozoneManager, 3L,
+            ozoneManagerDoubleBufferHelper);
+
+    // Snapshot entry should still be there.
+    snapshotInfo = omMetadataManager.getSnapshotInfoTable().get(key);
+    Assert.assertNotNull(snapshotInfo);
+    Assert.assertEquals(SnapshotInfo.SnapshotStatus.SNAPSHOT_DELETED,
+        snapshotInfo.getSnapshotStatus());
+
+    omResponse = omClientResponse.getOMResponse();
+    Assert.assertNotNull(omResponse.getDeleteSnapshotResponse());
+    Assert.assertEquals(Status.FILE_NOT_FOUND, omResponse.getStatus());
   }
 
-  private OMSnapshotCreateRequest doPreExecute(
+  private OMSnapshotDeleteRequest doPreExecute(
       OMRequest originalRequest) throws Exception {
-    OMSnapshotCreateRequest omSnapshotCreateRequest =
-        new OMSnapshotCreateRequest(originalRequest);
+    OMSnapshotDeleteRequest omSnapshotDeleteRequest =
+        new OMSnapshotDeleteRequest(originalRequest);
 
     OMRequest modifiedRequest =
-        omSnapshotCreateRequest.preExecute(ozoneManager);
-    return new OMSnapshotCreateRequest(modifiedRequest);
+        omSnapshotDeleteRequest.preExecute(ozoneManager);
+    return new OMSnapshotDeleteRequest(modifiedRequest);
   }
 
 }

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/snapshot/TestOMSnapshotDeleteResponse.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/snapshot/TestOMSnapshotDeleteResponse.java
@@ -1,0 +1,122 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.apache.hadoop.ozone.om.response.snapshot;
+
+import java.io.File;
+import java.util.UUID;
+
+import org.apache.hadoop.hdds.utils.db.Table;
+import org.apache.hadoop.ozone.om.helpers.SnapshotInfo;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import org.apache.hadoop.ozone.om.OMConfigKeys;
+import org.apache.hadoop.ozone.om.OMMetadataManager;
+import org.apache.hadoop.ozone.om.OmMetadataManagerImpl;
+import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos;
+import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos
+    .CreateSnapshotResponse;
+import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos
+    .OMResponse;
+import org.apache.hadoop.hdds.utils.db.BatchOperation;
+import static org.apache.hadoop.ozone.OzoneConsts.OM_DB_NAME;
+import static org.apache.hadoop.ozone.OzoneConsts.OM_KEY_PREFIX;
+import static org.apache.hadoop.ozone.OzoneConsts.OM_SNAPSHOT_DIR;
+
+
+/**
+ * This class tests OMSnapshotCreateResponse.
+ */
+public class TestOMSnapshotCreateResponse {
+
+  @Rule
+  public TemporaryFolder folder = new TemporaryFolder();
+  
+  private OMMetadataManager omMetadataManager;
+  private BatchOperation batchOperation;
+  private String fsPath;
+  @Before
+  public void setup() throws Exception {
+    OzoneConfiguration ozoneConfiguration = new OzoneConfiguration();
+    fsPath = folder.newFolder().getAbsolutePath();
+    ozoneConfiguration.set(OMConfigKeys.OZONE_OM_DB_DIRS,
+        fsPath);
+    omMetadataManager = new OmMetadataManagerImpl(ozoneConfiguration);
+    batchOperation = omMetadataManager.getStore().initBatchOperation();
+  }
+
+  @After
+  public void tearDown() {
+    if (batchOperation != null) {
+      batchOperation.close();
+    }
+  }
+
+  @Test
+  public void testAddToDBBatch() throws Exception {
+    String volumeName = UUID.randomUUID().toString();
+    String bucketName = UUID.randomUUID().toString();
+    String snapshotName = UUID.randomUUID().toString();
+    String snapshotId = UUID.randomUUID().toString();
+    SnapshotInfo snapshotInfo = SnapshotInfo.newInstance(volumeName,
+        bucketName,
+        snapshotName,
+        snapshotId);
+
+    // confirm table is empty
+    Assert.assertEquals(0,
+        omMetadataManager
+        .countRowsInTable(omMetadataManager.getSnapshotInfoTable()));
+
+    // commit to table
+    OMSnapshotCreateResponse omSnapshotCreateResponse =
+        new OMSnapshotCreateResponse(OMResponse.newBuilder()
+            .setCmdType(OzoneManagerProtocolProtos.Type.CreateSnapshot)
+            .setStatus(OzoneManagerProtocolProtos.Status.OK)
+            .setCreateSnapshotResponse(
+                CreateSnapshotResponse.newBuilder()
+                .setSnapshotInfo(snapshotInfo.getProtobuf())
+                .build()).build(), volumeName, bucketName, snapshotName);
+    omSnapshotCreateResponse.addToDBBatch(omMetadataManager, batchOperation);
+    omMetadataManager.getStore().commitBatchOperation(batchOperation);
+
+    // Confirm snapshot directory was created
+    String snapshotDir = fsPath + OM_KEY_PREFIX +
+        OM_SNAPSHOT_DIR + OM_KEY_PREFIX + OM_DB_NAME +
+        snapshotInfo.getCheckpointDirName();
+    Assert.assertTrue((new File(snapshotDir)).exists());
+
+    // Confirm table has 1 entry
+    Assert.assertEquals(1, omMetadataManager
+        .countRowsInTable(omMetadataManager.getSnapshotInfoTable()));
+
+    // Check contents of entry
+    Table.KeyValue<String, SnapshotInfo> keyValue =
+        omMetadataManager.getSnapshotInfoTable().iterator().next();
+    SnapshotInfo storedInfo = keyValue.getValue();
+    Assert.assertEquals(snapshotInfo.getTableKey(), keyValue.getKey());
+    Assert.assertEquals(snapshotInfo, storedInfo);
+  }
+}

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/snapshot/TestOMSnapshotDeleteResponse.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/snapshot/TestOMSnapshotDeleteResponse.java
@@ -19,11 +19,16 @@
 
 package org.apache.hadoop.ozone.om.response.snapshot;
 
-import java.io.File;
-import java.util.UUID;
-
+import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import org.apache.hadoop.hdds.utils.db.BatchOperation;
 import org.apache.hadoop.hdds.utils.db.Table;
+import org.apache.hadoop.ozone.om.OMConfigKeys;
+import org.apache.hadoop.ozone.om.OMMetadataManager;
+import org.apache.hadoop.ozone.om.OmMetadataManagerImpl;
 import org.apache.hadoop.ozone.om.helpers.SnapshotInfo;
+import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos;
+import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.CreateSnapshotResponse;
+import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMResponse;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -31,25 +36,18 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
-import org.apache.hadoop.hdds.conf.OzoneConfiguration;
-import org.apache.hadoop.ozone.om.OMConfigKeys;
-import org.apache.hadoop.ozone.om.OMMetadataManager;
-import org.apache.hadoop.ozone.om.OmMetadataManagerImpl;
-import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos;
-import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos
-    .CreateSnapshotResponse;
-import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos
-    .OMResponse;
-import org.apache.hadoop.hdds.utils.db.BatchOperation;
+import java.io.File;
+import java.util.UUID;
+
 import static org.apache.hadoop.ozone.OzoneConsts.OM_DB_NAME;
 import static org.apache.hadoop.ozone.OzoneConsts.OM_KEY_PREFIX;
 import static org.apache.hadoop.ozone.OzoneConsts.OM_SNAPSHOT_DIR;
 
-
 /**
- * This class tests OMSnapshotCreateResponse.
+ * This class tests OMSnapshotDeleteResponse.
+ * TODO: WIP
  */
-public class TestOMSnapshotCreateResponse {
+public class TestOMSnapshotDeleteResponse {
 
   @Rule
   public TemporaryFolder folder = new TemporaryFolder();
@@ -57,6 +55,7 @@ public class TestOMSnapshotCreateResponse {
   private OMMetadataManager omMetadataManager;
   private BatchOperation batchOperation;
   private String fsPath;
+
   @Before
   public void setup() throws Exception {
     OzoneConfiguration ozoneConfiguration = new OzoneConfiguration();
@@ -90,7 +89,7 @@ public class TestOMSnapshotCreateResponse {
         omMetadataManager
         .countRowsInTable(omMetadataManager.getSnapshotInfoTable()));
 
-    // commit to table
+    // Prepare the table, write an entry with SnapshotCreate
     OMSnapshotCreateResponse omSnapshotCreateResponse =
         new OMSnapshotCreateResponse(OMResponse.newBuilder()
             .setCmdType(OzoneManagerProtocolProtos.Type.CreateSnapshot)
@@ -118,5 +117,9 @@ public class TestOMSnapshotCreateResponse {
     SnapshotInfo storedInfo = keyValue.getValue();
     Assert.assertEquals(snapshotInfo.getTableKey(), keyValue.getKey());
     Assert.assertEquals(snapshotInfo, storedInfo);
+
+    // TODO: OMSnapshotDeleteResponse
+    // Confirm that the snapshot directory is gone
+    // Confirm that the table still has 1 entry, and its content
   }
 }

--- a/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/client/ClientProtocolStub.java
+++ b/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/client/ClientProtocolStub.java
@@ -617,6 +617,13 @@ public class ClientProtocolStub implements ClientProtocol {
   }
 
   @Override
+  public void deleteSnapshot(String volumeName,
+      String bucketName, String snapshotName)
+      throws IOException {
+
+  }
+
+  @Override
   public List<OzoneSnapshot> listSnapshot(String volumeName, String bucketName)
       throws IOException {
     return null;

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/snapshot/CreateSnapshotHandler.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/snapshot/CreateSnapshotHandler.java
@@ -27,17 +27,16 @@ import picocli.CommandLine;
 import java.io.IOException;
 
 /**
- * ozone snapshot create.
+ * ozone sh snapshot create.
  */
 @CommandLine.Command(name = "create",
-    description = "create snapshot")
+    description = "Create a snapshot")
 public class CreateSnapshotHandler extends Handler {
 
   @CommandLine.Mixin
   private BucketUri snapshotPath;
 
-
-  @CommandLine.Parameters(description = "optional snapshot name",
+  @CommandLine.Parameters(description = "Snapshot name (Optional)",
       index = "1", arity = "0..1")
   private String snapshotName;
 
@@ -56,8 +55,8 @@ public class CreateSnapshotHandler extends Handler {
     String newName = client.getObjectStore()
         .createSnapshot(volumeName, bucketName, snapshotName);
     if (isVerbose()) {
-      out().format("created snapshot '%s/%s %s'.%n", volumeName, bucketName,
-          newName);
+      out().format("Created snapshot '%s' under '%s/%s'.%n",
+          newName, volumeName, bucketName);
     }
   }
 }

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/snapshot/DeleteSnapshotHandler.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/snapshot/DeleteSnapshotHandler.java
@@ -27,18 +27,17 @@ import picocli.CommandLine;
 import java.io.IOException;
 
 /**
- * ozone snapshot create.
+ * ozone snapshot delete.
  */
-@CommandLine.Command(name = "create",
-    description = "create snapshot")
-public class CreateSnapshotHandler extends Handler {
+@CommandLine.Command(name = "delete",
+    description = "Delete a snapshot")
+public class DeleteSnapshotHandler extends Handler {
 
   @CommandLine.Mixin
   private BucketUri snapshotPath;
 
-
-  @CommandLine.Parameters(description = "optional snapshot name",
-      index = "1", arity = "0..1")
+  @CommandLine.Parameters(description = "Snapshot name",
+      index = "1", arity = "1")
   private String snapshotName;
 
   @Override
@@ -52,12 +51,13 @@ public class CreateSnapshotHandler extends Handler {
 
     String volumeName = snapshotPath.getValue().getVolumeName();
     String bucketName = snapshotPath.getValue().getBucketName();
-    OmUtils.validateSnapshotName(snapshotName);
-    String newName = client.getObjectStore()
-        .createSnapshot(volumeName, bucketName, snapshotName);
+    OmUtils.validateSnapshotName(snapshotName);  // TODO: Not required in this case, can remove
+
+    client.getObjectStore()
+        .deleteSnapshot(volumeName, bucketName, snapshotName);
     if (isVerbose()) {
-      out().format("created snapshot '%s/%s %s'.%n", volumeName, bucketName,
-          newName);
+      out().format("Deleted snapshot '%s' under '%s/%s'.%n",
+          snapshotName, volumeName, bucketName);
     }
   }
 }

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/snapshot/DeleteSnapshotHandler.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/snapshot/DeleteSnapshotHandler.java
@@ -17,7 +17,6 @@
  */
 package org.apache.hadoop.ozone.shell.snapshot;
 
-import org.apache.hadoop.ozone.OmUtils;
 import org.apache.hadoop.ozone.client.OzoneClient;
 import org.apache.hadoop.ozone.shell.Handler;
 import org.apache.hadoop.ozone.shell.OzoneAddress;
@@ -51,7 +50,6 @@ public class DeleteSnapshotHandler extends Handler {
 
     String volumeName = snapshotPath.getValue().getVolumeName();
     String bucketName = snapshotPath.getValue().getBucketName();
-    OmUtils.validateSnapshotName(snapshotName);  // TODO: Not required in this case, can remove
 
     client.getObjectStore()
         .deleteSnapshot(volumeName, bucketName, snapshotName);

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/snapshot/DeleteSnapshotHandler.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/snapshot/DeleteSnapshotHandler.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.apache.hadoop.ozone.shell.snapshot;
+
+import org.apache.hadoop.ozone.OmUtils;
+import org.apache.hadoop.ozone.client.OzoneClient;
+import org.apache.hadoop.ozone.shell.Handler;
+import org.apache.hadoop.ozone.shell.OzoneAddress;
+import org.apache.hadoop.ozone.shell.bucket.BucketUri;
+import picocli.CommandLine;
+
+import java.io.IOException;
+
+/**
+ * ozone snapshot create.
+ */
+@CommandLine.Command(name = "create",
+    description = "create snapshot")
+public class CreateSnapshotHandler extends Handler {
+
+  @CommandLine.Mixin
+  private BucketUri snapshotPath;
+
+
+  @CommandLine.Parameters(description = "optional snapshot name",
+      index = "1", arity = "0..1")
+  private String snapshotName;
+
+  @Override
+  protected OzoneAddress getAddress() {
+    return snapshotPath.getValue();
+  }
+
+  @Override
+  protected void execute(OzoneClient client, OzoneAddress address)
+      throws IOException {
+
+    String volumeName = snapshotPath.getValue().getVolumeName();
+    String bucketName = snapshotPath.getValue().getBucketName();
+    OmUtils.validateSnapshotName(snapshotName);
+    String newName = client.getObjectStore()
+        .createSnapshot(volumeName, bucketName, snapshotName);
+    if (isVerbose()) {
+      out().format("created snapshot '%s/%s %s'.%n", volumeName, bucketName,
+          newName);
+    }
+  }
+}

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/snapshot/ListSnapshotHandler.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/snapshot/ListSnapshotHandler.java
@@ -28,11 +28,12 @@ import java.io.IOException;
 import java.util.List;
 
 /**
+ * ozone sh snapshot list.
  * a handler for Ozone shell CLI command 'list snapshot'.
  */
 @CommandLine.Command(name = "list",
     aliases = "ls",
-    description = "list snapshot for the buckets.")
+    description = "List snapshots for the buckets.")
 public class ListSnapshotHandler extends Handler {
 
   @CommandLine.Mixin

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/snapshot/SnapshotCommands.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/snapshot/SnapshotCommands.java
@@ -39,8 +39,9 @@ import picocli.CommandLine.ParentCommand;
     description = "Snapshot specific operations",
     subcommands = {
         CreateSnapshotHandler.class,
+        DeleteSnapshotHandler.class,
         ListSnapshotHandler.class,
-        SnapshotDiffHandler.class,
+        SnapshotDiffHandler.class
     },
     mixinStandardHelpOptions = true,
     versionProvider = HddsVersionProvider.class)


### PR DESCRIPTION
## What changes were proposed in this pull request?

- Implement CLI `ozone sh snapshot delete`.
- Implement Ratis Tx `OMSnapshotDeleteRequest`.
- Improve CLI output for UX.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-6857

## How was this patch tested?

- [x] Add UT `TestOMSnapshotDeleteRequest`.
- [ ] Finish UT `TestOMSnapshotDeleteResponse`. (Done in HDDS-7862 instead)
- [x] Tested manually in Docker locally:

```bash
$ ozone fs -mkdir -p ofs://om/vol1/buck1/dir1/
$ ozone fs -put README.md ofs://om/vol1/buck1/dir1/
$ ozone sh snapshot create /vol1/buck1 snap1
$ ozone sh snapshot delete /vol1/buck1 snap1
$ ozone sh snapshot delete /vol1/buck1 snap1
FILE_NOT_FOUND Snapshot exists but no longer active
$ ozone sh snapshot list /vol1/buck1
[ {
  "volumeName" : "vol1",
  "bucketName" : "buck1",
  "name" : "snap1",
  "creationTime" : 1673583279047,
  "snapshotStatus" : "SNAPSHOT_DELETED",
  "snapshotID" : "08f640e3-95db-4596-9d5f-a47cb7272329",
  "snapshotPath" : "vol1/buck1",
  "checkpointDir" : "-08f640e3-95db-4596-9d5f-a47cb7272329"
} ]
```