### PR TITLE
HDDS-4261. Recon should display Top N folders for each file size range.

### DIFF
--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/tasks/FileSizeCountTask.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/tasks/FileSizeCountTask.java
@@ -37,6 +37,7 @@ import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
@@ -44,6 +45,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 
+import static org.apache.hadoop.ozone.om.OmMetadataManagerImpl.FILE_TABLE;
 import static org.apache.hadoop.ozone.om.OmMetadataManagerImpl.KEY_TABLE;
 import static org.hadoop.ozone.recon.schema.tables.FileCountBySizeTable.FILE_COUNT_BY_SIZE;
 
@@ -105,7 +107,7 @@ public class FileSizeCountTask implements ReconOmTask {
   }
 
   public Collection<String> getTaskTables() {
-    return Collections.singletonList(KEY_TABLE);
+    return Arrays.asList(KEY_TABLE, FILE_TABLE);
   }
 
   /**

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/tasks/FileSizeCountTask.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/tasks/FileSizeCountTask.java
@@ -39,7 +39,6 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;


### PR DESCRIPTION
Current behaviour in Recon under Insights shows the file size ranges only for Legacy buckets. IMO, we have to support FSO buckets as well. In above issue mentioned number of keys in FSO path under a size range bucket like below, but we can show only at bucket level like legacy not at individual path level.

https://issues.apache.org/jira/browse/HDDS-4261

Patch was tested using existing "TestFileSizeCountTask" LLT.

<img width="955" alt="image" src="https://user-images.githubusercontent.com/20607992/212821795-e28f1a98-70cf-41ba-80f1-a6368ee7f75f.png">

