### PR TITLE
HDDS-7788. Ratis OverReplicationHandler should exclude stale replicas

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ReplicationManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ReplicationManager.java
@@ -229,7 +229,7 @@ public class ReplicationManager implements SCMService {
     ratisUnderReplicationHandler = new RatisUnderReplicationHandler(
         ratisContainerPlacement, conf, nodeManager);
     ratisOverReplicationHandler =
-        new RatisOverReplicationHandler(ratisContainerPlacement);
+        new RatisOverReplicationHandler(ratisContainerPlacement, nodeManager);
     underReplicatedProcessor =
         new UnderReplicatedProcessor(this,
             rmConf.getUnderReplicatedInterval());

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestRatisOverReplicationHandler.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestRatisOverReplicationHandler.java
@@ -28,6 +28,8 @@ import org.apache.hadoop.hdds.scm.PlacementPolicy;
 import org.apache.hadoop.hdds.scm.container.ContainerInfo;
 import org.apache.hadoop.hdds.scm.container.ContainerReplica;
 import org.apache.hadoop.hdds.scm.container.placement.algorithms.ContainerPlacementStatusDefault;
+import org.apache.hadoop.hdds.scm.node.NodeManager;
+import org.apache.hadoop.hdds.scm.node.NodeStatus;
 import org.apache.hadoop.hdds.scm.node.states.NodeNotFoundException;
 import org.apache.hadoop.ozone.protocol.commands.SCMCommand;
 import org.apache.ozone.test.GenericTestUtils;
@@ -56,6 +58,7 @@ public class TestRatisOverReplicationHandler {
   private static final RatisReplicationConfig RATIS_REPLICATION_CONFIG =
       RatisReplicationConfig.getInstance(HddsProtos.ReplicationFactor.THREE);
   private PlacementPolicy policy;
+  private NodeManager nodeManager;
 
   @Before
   public void setup() throws NodeNotFoundException {
@@ -66,6 +69,10 @@ public class TestRatisOverReplicationHandler {
     Mockito.when(policy.validateContainerPlacement(
         Mockito.anyList(), Mockito.anyInt()))
         .thenReturn(new ContainerPlacementStatusDefault(2, 2, 3));
+
+    nodeManager = Mockito.mock(NodeManager.class);
+    Mockito.when(nodeManager.getNodeStatus(Mockito.any()))
+        .thenReturn(NodeStatus.inServiceHealthy());
 
     GenericTestUtils.setLogLevel(RatisOverReplicationHandler.LOG, Level.DEBUG);
   }
@@ -86,6 +93,24 @@ public class TestRatisOverReplicationHandler {
     // created
     testProcessing(replicas, pendingOps, getOverReplicatedHealthResult(),
         1);
+  }
+
+  /**
+   * Handler should create one delete command when a closed ratis container
+   * has 5 replicas and 1 pending delete.
+   */
+  @Test
+  public void testOverReplicatedClosedContainerWithStale() throws IOException,
+      NodeNotFoundException {
+    Set<ContainerReplica> replicas = createReplicas(container.containerID(),
+        ContainerReplicaProto.State.CLOSED, 0, 0, 0, 0);
+
+    ContainerReplica stale = replicas.stream().findFirst().get();
+    Mockito.when(nodeManager.getNodeStatus(stale.getDatanodeDetails()))
+        .thenReturn(NodeStatus.inServiceStale());
+
+    testProcessing(replicas, Collections.emptyList(),
+        getOverReplicatedHealthResult(), 0);
   }
 
   /**
@@ -261,7 +286,7 @@ public class TestRatisOverReplicationHandler {
       ContainerHealthResult healthResult,
       int expectNumCommands) throws IOException {
     RatisOverReplicationHandler handler =
-        new RatisOverReplicationHandler(policy);
+        new RatisOverReplicationHandler(policy, nodeManager);
 
     Map<DatanodeDetails, SCMCommand<?>> commands =
         handler.processAndCreateCommands(replicas, pendingOps,

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestRatisOverReplicationHandler.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestRatisOverReplicationHandler.java
@@ -96,8 +96,7 @@ public class TestRatisOverReplicationHandler {
   }
 
   /**
-   * Handler should create one delete command when a closed ratis container
-   * has 5 replicas and 1 pending delete.
+   * Container has 4 replicas and 1 stale so none should be deleted.
    */
   @Test
   public void testOverReplicatedClosedContainerWithStale() throws IOException,


### PR DESCRIPTION
## What changes were proposed in this pull request?

As a stale DN is more than likely dead, in the RatisOverReplicationHandler we should exclude stale replicas before checking for over-replication. That way, we will not allow stale replicas to count toward over-replication. If we continue consider a stale replica as "present" for over-replication, we may remove another replica and then the stale one could go dead and get removed too, resulting in under replication.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-7788

## How was this patch tested?

New unit test added.
