### PR TITLE
HDDS-7765. [Snapshot] Handle OzoneManager#getKeyInfo with OmMetadataReader.

### DIFF
--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/IOmMetadataReader.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/IOmMetadataReader.java
@@ -40,7 +40,7 @@ public interface IOmMetadataReader {
    */
   OmKeyInfo lookupKey(OmKeyArgs args) throws IOException;
 
-  KeyInfoWithVolumeContext getKeyInfo(final OmKeyArgs args,
+  KeyInfoWithVolumeContext getKeyInfo(OmKeyArgs args,
                                       boolean assumeS3Context)
       throws IOException;
 
@@ -82,7 +82,7 @@ public interface IOmMetadataReader {
    * OzoneFS api to lookup for a file.
    *
    * @param args Key args
-   * @throws OMException if given key is not found or it is not a file
+   * @throws OMException if given key is not found, or it is not a file
    *                     if bucket does not exist
    * @throws IOException if there is error in the db
    *                     invalid arguments

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/IOmMetadataReader.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/IOmMetadataReader.java
@@ -19,6 +19,7 @@ package org.apache.hadoop.ozone.om;
 
 import org.apache.hadoop.ozone.OzoneAcl;
 import org.apache.hadoop.ozone.om.exceptions.OMException;
+import org.apache.hadoop.ozone.om.helpers.KeyInfoWithVolumeContext;
 import org.apache.hadoop.ozone.om.helpers.OmKeyArgs;
 import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
 import org.apache.hadoop.ozone.om.helpers.OzoneFileStatus;
@@ -38,6 +39,10 @@ public interface IOmMetadataReader {
    * @return OmKeyInfo instance that client uses to talk to container.
    */
   OmKeyInfo lookupKey(OmKeyArgs args) throws IOException;
+
+  KeyInfoWithVolumeContext getKeyInfo(final OmKeyArgs args,
+                                      boolean assumeS3Context)
+      throws IOException;
 
   /**
    * List the status for a file or a directory and its contents.

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OMMetrics.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OMMetrics.java
@@ -760,11 +760,13 @@ public class OMMetrics implements OmMetadataReaderMetrics {
     numRemoveAcl.incr();
   }
 
+  @Override
   public void incNumGetKeyInfo() {
     numGetKeyInfo.incr();
     numKeyOps.incr();
   }
 
+  @Override
   public void incNumGetKeyInfoFails() {
     getNumGetKeyInfoFails.incr();
   }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmMetadataManagerImpl.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmMetadataManagerImpl.java
@@ -310,7 +310,7 @@ public class OmMetadataManagerImpl implements OMMetadataManager {
         OM_KEY_PREFIX + OM_SNAPSHOT_DIR;
     setStore(loadDB(conf, new File(snapshotDir),
         OM_DB_NAME + snapshotDirName, true));
-    initializeOmTables();
+    initializeOmTables(false);
   }
 
   /**
@@ -392,9 +392,9 @@ public class OmMetadataManagerImpl implements OMMetadataManager {
   @Override
   public Table<String, OmMultipartKeyInfo> getMultipartInfoTable() {
     return multipartInfoTable;
-  }
+  } 
 
-  private void checkTableStatus(Table table, String name) throws IOException {
+  private void checkTableStatus(Table table, String name, boolean addCacheMetrics) throws IOException {
     String logMessage = "Unable to get a reference to %s table. Cannot " +
         "continue.";
     String errMsg = "Inconsistent DB state, Table - %s. Please check the logs" +
@@ -404,7 +404,9 @@ public class OmMetadataManagerImpl implements OMMetadataManager {
       throw new IOException(String.format(errMsg, name));
     }
     this.tableMap.put(name, table);
-    tableCacheMetrics.add(table.createCacheMetrics());
+    if (addCacheMetrics) {
+      tableCacheMetrics.add(table.createCacheMetrics());
+    }
   }
 
   /**
@@ -450,7 +452,7 @@ public class OmMetadataManagerImpl implements OMMetadataManager {
 
       this.store = loadDB(configuration, metaDir);
 
-      initializeOmTables();
+      initializeOmTables(true);
     }
   }
 
@@ -523,96 +525,96 @@ public class OmMetadataManagerImpl implements OMMetadataManager {
    *
    * @throws IOException
    */
-  protected void initializeOmTables() throws IOException {
+  protected void initializeOmTables(boolean addCacheMetrics) throws IOException {
     userTable =
         this.store.getTable(USER_TABLE, String.class,
             PersistedUserVolumeInfo.class);
-    checkTableStatus(userTable, USER_TABLE);
+    checkTableStatus(userTable, USER_TABLE, addCacheMetrics);
 
     CacheType cacheType = CacheType.FULL_CACHE;
 
     volumeTable =
         this.store.getTable(VOLUME_TABLE, String.class, OmVolumeArgs.class,
             cacheType);
-    checkTableStatus(volumeTable, VOLUME_TABLE);
+    checkTableStatus(volumeTable, VOLUME_TABLE, addCacheMetrics);
 
     bucketTable =
         this.store.getTable(BUCKET_TABLE, String.class, OmBucketInfo.class,
             cacheType);
 
-    checkTableStatus(bucketTable, BUCKET_TABLE);
+    checkTableStatus(bucketTable, BUCKET_TABLE, addCacheMetrics);
 
     keyTable = this.store.getTable(KEY_TABLE, String.class, OmKeyInfo.class);
-    checkTableStatus(keyTable, KEY_TABLE);
+    checkTableStatus(keyTable, KEY_TABLE, addCacheMetrics);
 
     deletedTable = this.store.getTable(DELETED_TABLE, String.class,
         RepeatedOmKeyInfo.class);
-    checkTableStatus(deletedTable, DELETED_TABLE);
+    checkTableStatus(deletedTable, DELETED_TABLE, addCacheMetrics);
 
     openKeyTable =
         this.store.getTable(OPEN_KEY_TABLE, String.class,
             OmKeyInfo.class);
-    checkTableStatus(openKeyTable, OPEN_KEY_TABLE);
+    checkTableStatus(openKeyTable, OPEN_KEY_TABLE, addCacheMetrics);
 
     multipartInfoTable = this.store.getTable(MULTIPARTINFO_TABLE,
         String.class, OmMultipartKeyInfo.class);
-    checkTableStatus(multipartInfoTable, MULTIPARTINFO_TABLE);
+    checkTableStatus(multipartInfoTable, MULTIPARTINFO_TABLE, addCacheMetrics);
 
     dTokenTable = this.store.getTable(DELEGATION_TOKEN_TABLE,
         OzoneTokenIdentifier.class, Long.class);
-    checkTableStatus(dTokenTable, DELEGATION_TOKEN_TABLE);
+    checkTableStatus(dTokenTable, DELEGATION_TOKEN_TABLE, addCacheMetrics);
 
     s3SecretTable = this.store.getTable(S3_SECRET_TABLE, String.class,
         S3SecretValue.class);
-    checkTableStatus(s3SecretTable, S3_SECRET_TABLE);
+    checkTableStatus(s3SecretTable, S3_SECRET_TABLE, addCacheMetrics);
 
     prefixTable = this.store.getTable(PREFIX_TABLE, String.class,
         OmPrefixInfo.class);
-    checkTableStatus(prefixTable, PREFIX_TABLE);
+    checkTableStatus(prefixTable, PREFIX_TABLE, addCacheMetrics);
 
     dirTable = this.store.getTable(DIRECTORY_TABLE, String.class,
             OmDirectoryInfo.class);
-    checkTableStatus(dirTable, DIRECTORY_TABLE);
+    checkTableStatus(dirTable, DIRECTORY_TABLE, addCacheMetrics);
 
     fileTable = this.store.getTable(FILE_TABLE, String.class,
             OmKeyInfo.class);
-    checkTableStatus(fileTable, FILE_TABLE);
+    checkTableStatus(fileTable, FILE_TABLE, addCacheMetrics);
 
     openFileTable = this.store.getTable(OPEN_FILE_TABLE, String.class,
             OmKeyInfo.class);
-    checkTableStatus(openFileTable, OPEN_FILE_TABLE);
+    checkTableStatus(openFileTable, OPEN_FILE_TABLE, addCacheMetrics);
 
     deletedDirTable = this.store.getTable(DELETED_DIR_TABLE, String.class,
         OmKeyInfo.class);
-    checkTableStatus(deletedDirTable, DELETED_DIR_TABLE);
+    checkTableStatus(deletedDirTable, DELETED_DIR_TABLE, addCacheMetrics);
 
     transactionInfoTable = this.store.getTable(TRANSACTION_INFO_TABLE,
         String.class, TransactionInfo.class);
-    checkTableStatus(transactionInfoTable, TRANSACTION_INFO_TABLE);
+    checkTableStatus(transactionInfoTable, TRANSACTION_INFO_TABLE, addCacheMetrics);
 
     metaTable = this.store.getTable(META_TABLE, String.class, String.class);
-    checkTableStatus(metaTable, META_TABLE);
+    checkTableStatus(metaTable, META_TABLE, addCacheMetrics);
 
     // accessId -> OmDBAccessIdInfo (tenantId, secret, Kerberos principal)
     tenantAccessIdTable = this.store.getTable(TENANT_ACCESS_ID_TABLE,
         String.class, OmDBAccessIdInfo.class);
-    checkTableStatus(tenantAccessIdTable, TENANT_ACCESS_ID_TABLE);
+    checkTableStatus(tenantAccessIdTable, TENANT_ACCESS_ID_TABLE, addCacheMetrics);
 
     // User principal -> OmDBUserPrincipalInfo (a list of accessIds)
     principalToAccessIdsTable = this.store.getTable(
         PRINCIPAL_TO_ACCESS_IDS_TABLE,
         String.class, OmDBUserPrincipalInfo.class);
-    checkTableStatus(principalToAccessIdsTable, PRINCIPAL_TO_ACCESS_IDS_TABLE);
+    checkTableStatus(principalToAccessIdsTable, PRINCIPAL_TO_ACCESS_IDS_TABLE, addCacheMetrics);
 
     // tenant name -> tenant (tenant states)
     tenantStateTable = this.store.getTable(TENANT_STATE_TABLE,
         String.class, OmDBTenantState.class);
-    checkTableStatus(tenantStateTable, TENANT_STATE_TABLE);
+    checkTableStatus(tenantStateTable, TENANT_STATE_TABLE, addCacheMetrics);
 
     // path -> snapshotInfo (snapshot info for snapshot)
     snapshotInfoTable = this.store.getTable(SNAPSHOT_INFO_TABLE,
         String.class, SnapshotInfo.class);
-    checkTableStatus(snapshotInfoTable, SNAPSHOT_INFO_TABLE);
+    checkTableStatus(snapshotInfoTable, SNAPSHOT_INFO_TABLE, addCacheMetrics);
 
   }
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmMetadataManagerImpl.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmMetadataManagerImpl.java
@@ -392,9 +392,10 @@ public class OmMetadataManagerImpl implements OMMetadataManager {
   @Override
   public Table<String, OmMultipartKeyInfo> getMultipartInfoTable() {
     return multipartInfoTable;
-  } 
+  }
 
-  private void checkTableStatus(Table table, String name, boolean addCacheMetrics) throws IOException {
+  private void checkTableStatus(Table table, String name,
+      boolean addCacheMetrics) throws IOException {
     String logMessage = "Unable to get a reference to %s table. Cannot " +
         "continue.";
     String errMsg = "Inconsistent DB state, Table - %s. Please check the logs" +
@@ -525,7 +526,8 @@ public class OmMetadataManagerImpl implements OMMetadataManager {
    *
    * @throws IOException
    */
-  protected void initializeOmTables(boolean addCacheMetrics) throws IOException {
+  protected void initializeOmTables(boolean addCacheMetrics)
+      throws IOException {
     userTable =
         this.store.getTable(USER_TABLE, String.class,
             PersistedUserVolumeInfo.class);
@@ -590,7 +592,8 @@ public class OmMetadataManagerImpl implements OMMetadataManager {
 
     transactionInfoTable = this.store.getTable(TRANSACTION_INFO_TABLE,
         String.class, TransactionInfo.class);
-    checkTableStatus(transactionInfoTable, TRANSACTION_INFO_TABLE, addCacheMetrics);
+    checkTableStatus(transactionInfoTable, TRANSACTION_INFO_TABLE,
+        addCacheMetrics);
 
     metaTable = this.store.getTable(META_TABLE, String.class, String.class);
     checkTableStatus(metaTable, META_TABLE, addCacheMetrics);
@@ -598,13 +601,15 @@ public class OmMetadataManagerImpl implements OMMetadataManager {
     // accessId -> OmDBAccessIdInfo (tenantId, secret, Kerberos principal)
     tenantAccessIdTable = this.store.getTable(TENANT_ACCESS_ID_TABLE,
         String.class, OmDBAccessIdInfo.class);
-    checkTableStatus(tenantAccessIdTable, TENANT_ACCESS_ID_TABLE, addCacheMetrics);
+    checkTableStatus(tenantAccessIdTable, TENANT_ACCESS_ID_TABLE,
+        addCacheMetrics);
 
     // User principal -> OmDBUserPrincipalInfo (a list of accessIds)
     principalToAccessIdsTable = this.store.getTable(
         PRINCIPAL_TO_ACCESS_IDS_TABLE,
         String.class, OmDBUserPrincipalInfo.class);
-    checkTableStatus(principalToAccessIdsTable, PRINCIPAL_TO_ACCESS_IDS_TABLE, addCacheMetrics);
+    checkTableStatus(principalToAccessIdsTable, PRINCIPAL_TO_ACCESS_IDS_TABLE,
+        addCacheMetrics);
 
     // tenant name -> tenant (tenant states)
     tenantStateTable = this.store.getTable(TENANT_STATE_TABLE,

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmMetadataReaderMetrics.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmMetadataReaderMetrics.java
@@ -25,6 +25,10 @@ public interface OmMetadataReaderMetrics {
 
   void incNumKeyLookupFails();
 
+  void incNumGetKeyInfo();
+
+  void incNumGetKeyInfoFails();
+
   void incNumListStatus();
 
   void incNumListStatusFails();

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmSnapshot.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmSnapshot.java
@@ -23,6 +23,7 @@ import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.ozone.OzoneAcl;
 import org.apache.hadoop.ozone.audit.AuditLogger;
 import org.apache.hadoop.ozone.audit.AuditLoggerType;
+import org.apache.hadoop.ozone.om.helpers.KeyInfoWithVolumeContext;
 import org.apache.hadoop.ozone.om.helpers.OmKeyArgs;
 import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
 import org.apache.hadoop.ozone.om.helpers.OmKeyLocationInfoGroup;
@@ -88,6 +89,14 @@ public class OmSnapshot implements IOmMetadataReader, Closeable {
   public OmKeyInfo lookupKey(OmKeyArgs args) throws IOException {
     return denormalizeOmKeyInfo(omMetadataReader.lookupKey(
         normalizeOmKeyArgs(args)));
+  }
+
+  @Override
+  public KeyInfoWithVolumeContext getKeyInfo(final OmKeyArgs args,
+                                             boolean assumeS3Context)
+    throws IOException {
+    return denormalizeKeyInfoWithVolumeContext(
+        omMetadataReader.getKeyInfo(normalizeOmKeyArgs(args), assumeS3Context));
   }
 
   @Override
@@ -215,6 +224,11 @@ public class OmSnapshot implements IOmMetadataReader, Closeable {
         omKeyInfo, fileStatus.getBlockSize(), fileStatus.isDirectory());
   }
 
+  private KeyInfoWithVolumeContext denormalizeKeyInfoWithVolumeContext(KeyInfoWithVolumeContext k) {
+    return new KeyInfoWithVolumeContext(k.getVolumeArgs().orElse(null),
+        k.getUserPrincipal().orElse(null),
+        denormalizeOmKeyInfo(k.getKeyInfo()));
+  }
   private OmKeyInfo createDenormalizedBucketKeyInfo() {
     return new OmKeyInfo.Builder()
       .setVolumeName(volumeName)

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmSnapshot.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmSnapshot.java
@@ -231,6 +231,7 @@ public class OmSnapshot implements IOmMetadataReader, Closeable {
         k.getUserPrincipal().orElse(null),
         denormalizeOmKeyInfo(k.getKeyInfo()));
   }
+
   private OmKeyInfo createDenormalizedBucketKeyInfo() {
     return new OmKeyInfo.Builder()
       .setVolumeName(volumeName)

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmSnapshot.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmSnapshot.java
@@ -227,9 +227,11 @@ public class OmSnapshot implements IOmMetadataReader, Closeable {
 
   private KeyInfoWithVolumeContext denormalizeKeyInfoWithVolumeContext(
       KeyInfoWithVolumeContext k) {
-    return new KeyInfoWithVolumeContext(k.getVolumeArgs().orElse(null),
-        k.getUserPrincipal().orElse(null),
-        denormalizeOmKeyInfo(k.getKeyInfo()));
+    return new KeyInfoWithVolumeContext.Builder()
+        .setKeyInfo(denormalizeOmKeyInfo(k.getKeyInfo()))
+        .setVolumeArgs(k.getVolumeArgs().orElse(null))
+        .setUserPrincipal(k.getUserPrincipal().orElse(null))
+        .build();
   }
 
   private OmKeyInfo createDenormalizedBucketKeyInfo() {

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmSnapshot.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmSnapshot.java
@@ -96,7 +96,8 @@ public class OmSnapshot implements IOmMetadataReader, Closeable {
                                              boolean assumeS3Context)
     throws IOException {
     return denormalizeKeyInfoWithVolumeContext(
-        omMetadataReader.getKeyInfo(normalizeOmKeyArgs(args), assumeS3Context));
+        omMetadataReader.getKeyInfo(normalizeOmKeyArgs(args),
+        assumeS3Context));
   }
 
   @Override
@@ -224,7 +225,8 @@ public class OmSnapshot implements IOmMetadataReader, Closeable {
         omKeyInfo, fileStatus.getBlockSize(), fileStatus.isDirectory());
   }
 
-  private KeyInfoWithVolumeContext denormalizeKeyInfoWithVolumeContext(KeyInfoWithVolumeContext k) {
+  private KeyInfoWithVolumeContext denormalizeKeyInfoWithVolumeContext(
+      KeyInfoWithVolumeContext k) {
     return new KeyInfoWithVolumeContext(k.getVolumeArgs().orElse(null),
         k.getUserPrincipal().orElse(null),
         denormalizeOmKeyInfo(k.getKeyInfo()));

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmSnapshot.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmSnapshot.java
@@ -94,7 +94,7 @@ public class OmSnapshot implements IOmMetadataReader, Closeable {
   @Override
   public KeyInfoWithVolumeContext getKeyInfo(final OmKeyArgs args,
                                              boolean assumeS3Context)
-    throws IOException {
+      throws IOException {
     return denormalizeKeyInfoWithVolumeContext(
         omMetadataReader.getKeyInfo(normalizeOmKeyArgs(args),
         assumeS3Context));

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmSnapshotMetrics.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmSnapshotMetrics.java
@@ -65,6 +65,22 @@ public final class OmSnapshotMetrics implements OmMetadataReaderMetrics {
   }
 
   private @Metric
+      MutableCounterLong numGetKeyInfo;
+  private @Metric
+      MutableCounterLong numGetKeyInfoFails;
+
+  @Override
+  public void incNumGetKeyInfo() {
+    numKeyOps.incr();
+    numGetKeyInfo.incr();
+  }
+
+  @Override
+  public void incNumGetKeyInfoFails() {
+    numGetKeyInfoFails.incr();
+  }
+
+  private @Metric
       MutableCounterLong numListStatus;
   private @Metric
       MutableCounterLong numListStatusFails;

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
@@ -2657,63 +2657,7 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
   public KeyInfoWithVolumeContext getKeyInfo(final OmKeyArgs args,
                                              boolean assumeS3Context)
       throws IOException {
-    long start = Time.monotonicNowNanos();
-
-    java.util.Optional<S3VolumeContext> s3VolumeContext =
-        java.util.Optional.empty();
-
-    final OmKeyArgs resolvedVolumeArgs;
-    if (assumeS3Context) {
-      S3VolumeContext context = getS3VolumeContext();
-      s3VolumeContext = java.util.Optional.of(context);
-      resolvedVolumeArgs = args.toBuilder()
-          .setVolumeName(context.getOmVolumeArgs().getVolume())
-          .build();
-    } else {
-      resolvedVolumeArgs = args;
-    }
-
-    final ResolvedBucket bucket = captureLatencyNs(
-        perfMetrics.getGetKeyInfoResolveBucketLatencyNs(),
-        () -> resolveBucketLink(resolvedVolumeArgs));
-
-    boolean auditSuccess = true;
-    OmKeyArgs resolvedArgs = bucket.update(args);
-
-    try {
-      if (isAclEnabled) {
-        captureLatencyNs(perfMetrics.getGetKeyInfoAclCheckLatencyNs(), () ->
-            omMetadataReader.checkAcls(ResourceType.KEY,
-                StoreType.OZONE, ACLType.READ,
-                bucket.realVolume(), bucket.realBucket(), args.getKeyName())
-        );
-      }
-
-      metrics.incNumGetKeyInfo();
-      OmKeyInfo keyInfo =
-          keyManager.getKeyInfo(resolvedArgs,
-              OmMetadataReader.getClientAddress());
-      KeyInfoWithVolumeContext.Builder builder = KeyInfoWithVolumeContext
-          .newBuilder()
-          .setKeyInfo(keyInfo);
-      s3VolumeContext.ifPresent(context -> {
-        builder.setVolumeArgs(context.getOmVolumeArgs());
-        builder.setUserPrincipal(context.getUserPrincipal());
-      });
-      return builder.build();
-    } catch (Exception ex) {
-      metrics.incNumGetKeyInfoFails();
-      auditSuccess = false;
-      AUDIT.logReadFailure(buildAuditMessageForFailure(OMAction.READ_KEY,
-          bucket.audit(resolvedVolumeArgs.toAuditMap()), ex));
-      throw ex;
-    } finally {
-      if (auditSuccess) {
-        AUDIT.logReadSuccess(buildAuditMessageForSuccess(OMAction.READ_KEY,
-            bucket.audit(resolvedVolumeArgs.toAuditMap())));
-      }
-      perfMetrics.addGetKeyInfoLatencyNs(Time.monotonicNowNanos() - start);
-    }
+    return getReader(args).getKeyInfo(args, assumeS3Context);
   }
 
   @Override

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
@@ -263,7 +263,6 @@ import static org.apache.hadoop.ozone.om.exceptions.OMException.ResultCodes.INVA
 import static org.apache.hadoop.ozone.om.exceptions.OMException.ResultCodes.PERMISSION_DENIED;
 import static org.apache.hadoop.ozone.om.exceptions.OMException.ResultCodes.TOKEN_ERROR_OTHER;
 import static org.apache.hadoop.util.ExitUtil.terminate;
-import static org.apache.hadoop.util.MetricUtil.captureLatencyNs;
 import static org.apache.hadoop.ozone.om.lock.OzoneManagerLock.Resource.BUCKET_LOCK;
 import static org.apache.hadoop.ozone.om.lock.OzoneManagerLock.Resource.VOLUME_LOCK;
 import static org.apache.hadoop.ozone.om.ratis.OzoneManagerRatisServer.RaftServerStatus.LEADER_AND_READY;

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/recovery/ReconOmMetadataManagerImpl.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/recovery/ReconOmMetadataManagerImpl.java
@@ -94,7 +94,7 @@ public class ReconOmMetadataManagerImpl extends OmMetadataManagerImpl
       LOG.error("Unable to initialize Recon OM DB snapshot store.", ioEx);
     }
     if (getStore() != null) {
-      initializeOmTables();
+      initializeOmTables(true);
       omTablesInitialized = true;
     }
   }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Merge from master was incomplete in that it did not move the new getKeyInfo() method from OzoneManager to the OmMetadataReader,( and OmMetadataReaderMetrics).

This PR rectifies that.

It also modifies the OmMetadataManagerImpl to not use the unneeded tableCacheMetrics on snapshots.  (These metrics were added by the merge and are not used by snapshots.)


## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-7765

## How was this patch tested?

Tested against the acceptance test for this PR: https://github.com/apache/ozone/pull/4134

