### PR TITLE
HDDS-7801. Bucket not found when calling getKeyInfo with tenant context

### DIFF
--- a/hadoop-ozone/dist/src/main/smoketest/security/ozone-secure-tenant.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/security/ozone-secure-tenant.robot
@@ -66,7 +66,7 @@ Verify Bucket 1 Owner
     ${result} =         Execute          ozone sh bucket info /tenantone/bucket-test1 | jq -r '.owner'
                         Should Be Equal  ${result}       testuser
 
-Put, get and delete a key in the tennant bucket
+Put, get and delete a key in the tenant bucket
                         Execute                 echo "Randomtext" > /tmp/testfile
                         Execute and checkrc     aws s3api --endpoint-url ${S3G_ENDPOINT_URL} put-object --bucket bucket-test1 --key mykey --body /tmp/testfile  0
                         Execute and checkrc     aws s3api --endpoint-url ${S3G_ENDPOINT_URL} head-object --bucket bucket-test1 --key mykey  0

--- a/hadoop-ozone/dist/src/main/smoketest/security/ozone-secure-tenant.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/security/ozone-secure-tenant.robot
@@ -66,6 +66,13 @@ Verify Bucket 1 Owner
     ${result} =         Execute          ozone sh bucket info /tenantone/bucket-test1 | jq -r '.owner'
                         Should Be Equal  ${result}       testuser
 
+Put, get and delete a key in the tennant bucket
+                        Execute                 echo "Randomtext" > /tmp/testfile
+                        Execute and checkrc     aws s3api --endpoint-url ${S3G_ENDPOINT_URL} put-object --bucket bucket-test1 --key mykey --body /tmp/testfile  0
+                        Execute and checkrc     aws s3api --endpoint-url ${S3G_ENDPOINT_URL} head-object --bucket bucket-test1 --key mykey  0
+                        Execute and checkrc     aws s3api --endpoint-url ${S3G_ENDPOINT_URL} delete-object --bucket bucket-test1 --key mykey  0
+
+
 SetSecret Success with Cluster Admin
     ${output} =         Execute          ozone tenant user setsecret 'tenantone$testuser' --secret=somesecret1
                         Should contain   ${output}         export AWS_SECRET_ACCESS_KEY='somesecret1'

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
@@ -2776,7 +2776,7 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
         () -> resolveBucketLink(resolvedVolumeArgs));
 
     boolean auditSuccess = true;
-    OmKeyArgs resolvedArgs = bucket.update(args);
+    OmKeyArgs resolvedArgs = bucket.update(resolvedVolumeArgs);
 
     try {
       if (isAclEnabled) {


### PR DESCRIPTION
## What changes were proposed in this pull request?

This is a regression from the GetKeyInfo implementation ([HDDS-7230](https://issues.apache.org/jira/browse/HDDS-7230)). When called in the context of tenant volume, OM fails to resolve the correct tenant volume and instead uses the default `s3v` volume. This result in a "Bucket not found" error.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-7801

## How was this patch tested?

Robot test.