### PR TITLE
HDDS-7807. TarContainerPacker closes streams multiple times

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/TarContainerPacker.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/TarContainerPacker.java
@@ -166,9 +166,7 @@ public class TarContainerPacker
 
     KeyValueContainerData containerData = container.getContainerData();
 
-    try (OutputStream compressed = compress(output);
-         ArchiveOutputStream archiveOutput = tar(compressed)) {
-
+    try (ArchiveOutputStream archiveOutput = tar(compress(output))) {
       includePath(getDbPath(containerData), DB_DIR_NAME,
           archiveOutput);
 
@@ -187,8 +185,7 @@ public class TarContainerPacker
   @Override
   public byte[] unpackContainerDescriptor(InputStream input)
       throws IOException {
-    try (InputStream decompressed = decompress(input);
-        ArchiveInputStream archiveInput = untar(decompressed)) {
+    try (ArchiveInputStream archiveInput = untar(decompress(input))) {
 
       ArchiveEntry entry = archiveInput.getNextEntry();
       while (entry != null) {
@@ -313,8 +310,7 @@ public class TarContainerPacker
   private byte[] innerUnpack(InputStream input, Path dbRoot, Path chunksRoot)
       throws IOException {
     byte[] descriptorFileContent = null;
-    try (InputStream decompressed = decompress(input);
-         ArchiveInputStream archiveInput = untar(decompressed)) {
+    try (ArchiveInputStream archiveInput = untar(decompress(input))) {
       ArchiveEntry entry = archiveInput.getNextEntry();
       while (entry != null) {
         String name = entry.getName();

--- a/hadoop-hdds/test-utils/src/main/java/org/apache/ozone/test/SpyInputStream.java
+++ b/hadoop-hdds/test-utils/src/main/java/org/apache/ozone/test/SpyInputStream.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.ozone.test;
+
+import java.io.FilterInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Filter input stream that allows assertions on behavior.
+ */
+public class SpyInputStream extends FilterInputStream {
+
+  private final AtomicInteger closed = new AtomicInteger();
+
+  public SpyInputStream(InputStream in) {
+    super(in);
+  }
+
+  @Override
+  public void close() throws IOException {
+    closed.incrementAndGet();
+    super.close();
+  }
+
+  public void assertClosedExactlyOnce() {
+    assertEquals(1, closed.get());
+  }
+}

--- a/hadoop-hdds/test-utils/src/main/java/org/apache/ozone/test/SpyOutputStream.java
+++ b/hadoop-hdds/test-utils/src/main/java/org/apache/ozone/test/SpyOutputStream.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.ozone.test;
+
+import java.io.FilterOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Filter output stream that allows assertions on behavior.
+ */
+public class SpyOutputStream extends FilterOutputStream {
+
+  private final AtomicInteger closed = new AtomicInteger();
+
+  public SpyOutputStream(OutputStream out) {
+    super(out);
+  }
+
+  @Override
+  public void close() throws IOException {
+    closed.incrementAndGet();
+    super.close();
+  }
+
+  public void assertClosedExactlyOnce() {
+    assertEquals(1, closed.get());
+  }
+}


### PR DESCRIPTION
## What changes were proposed in this pull request?

`TarContainerPacker` closes the underlying `GrpcOutputStream` multiple times:

```
datanode_1  | java.lang.IllegalStateException: call already closed
datanode_1  | 	at org.apache.ratis.thirdparty.com.google.common.base.Preconditions.checkState(Preconditions.java:502)
datanode_1  | 	at org.apache.ratis.thirdparty.io.grpc.internal.ServerCallImpl.closeInternal(ServerCallImpl.java:218)
datanode_1  | 	at org.apache.ratis.thirdparty.io.grpc.internal.ServerCallImpl.close(ServerCallImpl.java:211)
datanode_1  | 	at org.apache.ratis.thirdparty.io.grpc.stub.ServerCalls$ServerCallStreamObserverImpl.onCompleted(ServerCalls.java:395)
datanode_1  | 	at org.apache.hadoop.ozone.container.replication.GrpcOutputStream.close(GrpcOutputStream.java:106)
datanode_1  | 	at org.apache.hadoop.ozone.container.keyvalue.TarContainerPacker.pack(TarContainerPacker.java:180)
datanode_1  | 	at org.apache.hadoop.ozone.container.keyvalue.KeyValueContainer.packContainerToDestination(KeyValueContainer.java:902)
datanode_1  | 	at org.apache.hadoop.ozone.container.keyvalue.KeyValueContainer.exportContainerData(KeyValueContainer.java:630)
datanode_1  | 	at org.apache.hadoop.ozone.container.keyvalue.KeyValueHandler.exportContainer(KeyValueHandler.java:1038)
datanode_1  | 	at org.apache.hadoop.ozone.container.ozoneimpl.ContainerController.exportContainer(ContainerController.java:167)
datanode_1  | 	at org.apache.hadoop.ozone.container.replication.OnDemandContainerReplicationSource.copyData(OnDemandContainerReplicationSource.java:75)
datanode_1  | 	at org.apache.hadoop.ozone.container.replication.GrpcReplicationService.download(GrpcReplicationService.java:60)
```

The exception seems harmless, but it may be confusing and pollutes the log.

This can be reproduced by adding assertion about number of `close()` calls in `TestTarContainerPacker`:

```
AssertionFailedError: expected: <1> but was: <2>
	at org.junit.jupiter.api.AssertionUtils.fail(AssertionUtils.java:55)
	at org.junit.jupiter.api.AssertionUtils.failNotEqual(AssertionUtils.java:62)
	at org.junit.jupiter.api.AssertEquals.assertEquals(AssertEquals.java:150)
	at org.junit.jupiter.api.AssertEquals.assertEquals(AssertEquals.java:145)
	at org.junit.jupiter.api.Assertions.assertEquals(Assertions.java:527)
	at org.apache.ozone.test.SpyOutputStream.assertClosedExactlyOnce(SpyOutputStream.java:45)
	at org.apache.hadoop.ozone.container.keyvalue.TestTarContainerPacker.pack(TestTarContainerPacker.java:216)
```

This happens because `TarArchiveInputStream` and `TarArchiveOutputStream` both close the underlying in/output streams, so we only need to close these, not the underlying ones.

https://issues.apache.org/jira/browse/HDDS-7807

## How was this patch tested?

Added assertions in unit test.

https://github.com/adoroszlai/hadoop-ozone/actions/runs/3960752311