### PR TITLE
HDDS-7813. Handle Mismatched Replicas (OPEN or CLOSING) of QUASI-CLOSED containers in RM

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ReplicationManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ReplicationManager.java
@@ -37,7 +37,7 @@ import org.apache.hadoop.hdds.scm.container.ContainerNotFoundException;
 import org.apache.hadoop.hdds.scm.container.ContainerReplica;
 
 import org.apache.hadoop.hdds.scm.container.ReplicationManagerReport;
-import org.apache.hadoop.hdds.scm.container.replication.health.ClosedWithMismatchedReplicasHandler;
+import org.apache.hadoop.hdds.scm.container.replication.health.MismatchedReplicasHandler;
 import org.apache.hadoop.hdds.scm.container.replication.health.ClosedWithUnhealthyReplicasHandler;
 import org.apache.hadoop.hdds.scm.container.replication.health.ClosingContainerHandler;
 import org.apache.hadoop.hdds.scm.container.replication.health.DeletingContainerHandler;
@@ -243,7 +243,7 @@ public class ReplicationManager implements SCMService {
     containerCheckChain
         .addNext(new ClosingContainerHandler(this))
         .addNext(new QuasiClosedContainerHandler(this))
-        .addNext(new ClosedWithMismatchedReplicasHandler(this))
+        .addNext(new MismatchedReplicasHandler(this))
         .addNext(new EmptyContainerHandler(this))
         .addNext(new DeletingContainerHandler(this))
         .addNext(ecReplicationCheckHandler)

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/health/MismatchedReplicasHandler.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/health/MismatchedReplicasHandler.java
@@ -29,38 +29,43 @@ import org.slf4j.LoggerFactory;
 import java.util.Set;
 
 /**
- * Handler to process containers which are closed, but some replicas are still
- * open or closing. This handler will send a command to the datanodes for each
- * mis-matched replica to close it.
+ * Handler to process containers which are closed or quasi-closed, but some
+ * replicas are still open or closing. This handler will send a command to
+ * the datanodes for each mis-matched replica to close it.
  */
-public class ClosedWithMismatchedReplicasHandler extends AbstractCheck {
+public class MismatchedReplicasHandler extends AbstractCheck {
 
   public static final Logger LOG =
-      LoggerFactory.getLogger(ClosedWithMismatchedReplicasHandler.class);
+      LoggerFactory.getLogger(MismatchedReplicasHandler.class);
 
   private ReplicationManager replicationManager;
 
-  public ClosedWithMismatchedReplicasHandler(
+  public MismatchedReplicasHandler(
       ReplicationManager replicationManager) {
     this.replicationManager = replicationManager;
   }
 
   /**
-   * Handles CLOSED EC or RATIS container. If some replicas are CLOSING or
-   * OPEN, this sends a force-close command for them.
+   * Handles CLOSED EC or CLOSED/QUASI-CLOSED RATIS containers. If some
+   * replicas are CLOSING or OPEN, this tries to close them. Force close
+   * command is sent for CLOSED and close command is sent for QUASI-CLOSED
+   * containers (replicas of quasi-closed containers should move to
+   * quasi-closed state).
+   *
    * @param request ContainerCheckRequest object representing the container
-   * @return always returns true so that other handlers in the chain can fix
+   * @return always returns false so that other handlers in the chain can fix
    * issues such as under replication
    */
   @Override
   public boolean handle(ContainerCheckRequest request) {
     ContainerInfo containerInfo = request.getContainerInfo();
     Set<ContainerReplica> replicas = request.getContainerReplicas();
-    if (containerInfo.getState() != HddsProtos.LifeCycleState.CLOSED) {
-      // Handler is only relevant for CLOSED containers.
+    if (containerInfo.getState() != HddsProtos.LifeCycleState.CLOSED &&
+        containerInfo.getState() != HddsProtos.LifeCycleState.QUASI_CLOSED) {
+      // Handler is only relevant for CLOSED or QUASI-CLOSED containers.
       return false;
     }
-    LOG.debug("Checking container {} in ClosedWithMismatchedReplicasHandler",
+    LOG.debug("Checking container {} in MismatchedReplicasHandler",
         containerInfo);
 
     // close replica if its state is OPEN or CLOSING
@@ -68,8 +73,15 @@ public class ClosedWithMismatchedReplicasHandler extends AbstractCheck {
       if (isMismatched(replica)) {
         LOG.debug("Sending close command for mismatched replica {} of " +
             "container {}.", replica, containerInfo);
-        replicationManager.sendCloseContainerReplicaCommand(
-            containerInfo, replica.getDatanodeDetails(), true);
+
+        if (containerInfo.getState() == HddsProtos.LifeCycleState.CLOSED) {
+          replicationManager.sendCloseContainerReplicaCommand(
+              containerInfo, replica.getDatanodeDetails(), true);
+        } else if (containerInfo.getState() ==
+            HddsProtos.LifeCycleState.QUASI_CLOSED) {
+          replicationManager.sendCloseContainerReplicaCommand(
+              containerInfo, replica.getDatanodeDetails(), false);
+        }
       }
     }
 
@@ -81,8 +93,8 @@ public class ClosedWithMismatchedReplicasHandler extends AbstractCheck {
   }
 
   /**
-   * If a CLOSED container has an OPEN or CLOSING replica, there is a state
-   * mismatch.
+   * If a CLOSED or QUASI-CLOSED container has an OPEN or CLOSING replica,
+   * there is a state mismatch.
    * @param replica replica to check for mismatch
    * @return true if the replica is in CLOSING or OPEN state, else false
    */


### PR DESCRIPTION
## What changes were proposed in this pull request?

Mismatched replicas are replicas which don't match the container state. Such as CLOSING or OPEN replicas for CLOSED or QUASI_CLOSED containers. UNHEALTHY replicas also don't match the container's state, but the distinction is that we cannot close these replicas today. Hence these are uniquely considered as unhealthy replicas.

ClosedWithMismatchedReplicasHandler already handles CLOSED containers. This jira proposes handling QUASI_CLOSED along with CLOSED in that handler.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-7813

## How was this patch tested?

Added a new UT