### PR TITLE
HDDS-7777. Implement container replication in push model

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/ReplicateContainerCommandHandler.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/ReplicateContainerCommandHandler.java
@@ -66,10 +66,11 @@ public class ReplicateContainerCommandHandler implements CommandHandler {
     final List<DatanodeDetails> sourceDatanodes =
         replicateCommand.getSourceDatanodes();
     final long containerID = replicateCommand.getContainerID();
+    final DatanodeDetails target = replicateCommand.getTargetDatanode();
 
-    Preconditions.checkArgument(sourceDatanodes.size() > 0,
+    Preconditions.checkArgument(!sourceDatanodes.isEmpty() || target != null,
         "Replication command is received for container %s "
-            + "without source datanodes.", containerID);
+            + "without source or target datanodes.", containerID);
 
     ReplicationTask task = new ReplicationTask(replicateCommand);
     supervisor.addTask(task);

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/KeyValueContainer.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/KeyValueContainer.java
@@ -58,7 +58,7 @@ import org.apache.hadoop.ozone.container.common.volume.VolumeSet;
 import org.apache.hadoop.ozone.container.keyvalue.helpers.BlockUtils;
 import org.apache.hadoop.ozone.container.keyvalue.helpers.KeyValueContainerLocationUtil;
 import org.apache.hadoop.ozone.container.keyvalue.helpers.KeyValueContainerUtil;
-import org.apache.hadoop.ozone.container.replication.DownloadAndImportReplicator;
+import org.apache.hadoop.ozone.container.replication.ContainerImporter;
 import org.apache.hadoop.ozone.container.upgrade.VersionedDatanodeFeatures;
 import org.apache.hadoop.util.DiskChecker.DiskOutOfSpaceException;
 
@@ -519,7 +519,7 @@ public class KeyValueContainer implements Container<KeyValueContainerData> {
     Path destContainerDir =
         Paths.get(KeyValueContainerLocationUtil.getBaseContainerLocation(
             hddsVolume.getHddsRootDir().toString(), idDir, containerId));
-    Path tmpDir = DownloadAndImportReplicator.getUntarDirectory(hddsVolume);
+    Path tmpDir = ContainerImporter.getUntarDirectory(hddsVolume);
     writeLock();
     try {
       //copy the values from the input stream to the final destination

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/ozoneimpl/OzoneContainer.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/ozoneimpl/OzoneContainer.java
@@ -53,8 +53,10 @@ import org.apache.hadoop.ozone.container.common.volume.MutableVolumeSet;
 import org.apache.hadoop.ozone.container.common.volume.StorageVolume;
 import org.apache.hadoop.ozone.container.common.volume.StorageVolume.VolumeType;
 import org.apache.hadoop.ozone.container.common.volume.StorageVolumeChecker;
+import org.apache.hadoop.ozone.container.keyvalue.TarContainerPacker;
 import org.apache.hadoop.ozone.container.keyvalue.statemachine.background.BlockDeletingService;
 import org.apache.hadoop.ozone.container.keyvalue.statemachine.background.StaleRecoveringContainerScrubbingService;
+import org.apache.hadoop.ozone.container.replication.ContainerImporter;
 import org.apache.hadoop.ozone.container.replication.ReplicationServer;
 import org.apache.hadoop.ozone.container.replication.ReplicationServer.ReplicationConfig;
 import org.apache.hadoop.ozone.container.upgrade.VersionedDatanodeFeatures.SchemaV3;
@@ -204,7 +206,9 @@ public class OzoneContainer {
         controller,
         conf.getObject(ReplicationConfig.class),
         secConf,
-        certClient);
+        certClient,
+        new ContainerImporter(conf, containerSet, controller,
+            new TarContainerPacker(), volumeSet));
 
     readChannel = new XceiverServerGrpc(
         datanodeDetails, config, hddsDispatcher, certClient);

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/replication/ContainerImporter.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/replication/ContainerImporter.java
@@ -1,0 +1,109 @@
+package org.apache.hadoop.ozone.container.replication;
+
+import org.apache.hadoop.hdds.conf.ConfigurationSource;
+import org.apache.hadoop.hdds.conf.StorageUnit;
+import org.apache.hadoop.hdds.scm.ScmConfigKeys;
+import org.apache.hadoop.ozone.container.common.impl.ContainerDataYaml;
+import org.apache.hadoop.ozone.container.common.impl.ContainerSet;
+import org.apache.hadoop.ozone.container.common.interfaces.Container;
+import org.apache.hadoop.ozone.container.common.interfaces.VolumeChoosingPolicy;
+import org.apache.hadoop.ozone.container.common.utils.StorageVolumeUtil;
+import org.apache.hadoop.ozone.container.common.volume.HddsVolume;
+import org.apache.hadoop.ozone.container.common.volume.MutableVolumeSet;
+import org.apache.hadoop.ozone.container.common.volume.RoundRobinVolumeChoosingPolicy;
+import org.apache.hadoop.ozone.container.keyvalue.KeyValueContainerData;
+import org.apache.hadoop.ozone.container.keyvalue.TarContainerPacker;
+import org.apache.hadoop.ozone.container.ozoneimpl.ContainerController;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_DATANODE_VOLUME_CHOOSING_POLICY;
+
+/**
+ * Imports container from tarball.
+ */
+public class ContainerImporter {
+
+  private static final Logger LOG =
+      LoggerFactory.getLogger(ContainerImporter.class);
+
+  public static final String CONTAINER_COPY_DIR = "container-copy";
+  private static final String CONTAINER_COPY_TMP_DIR = "tmp";
+  private final ContainerSet containerSet;
+  private final ContainerController controller;
+  private final TarContainerPacker packer;
+  private final MutableVolumeSet volumeSet;
+  private final VolumeChoosingPolicy volumeChoosingPolicy;
+  private final long containerSize;
+
+  public ContainerImporter(ConfigurationSource conf, ContainerSet containerSet,
+      ContainerController controller, TarContainerPacker tarContainerPacker,
+      MutableVolumeSet volumeSet) {
+    this.containerSet = containerSet;
+    this.controller = controller;
+    this.packer = tarContainerPacker;
+    this.volumeSet = volumeSet;
+    try {
+      volumeChoosingPolicy = conf.getClass(
+          HDDS_DATANODE_VOLUME_CHOOSING_POLICY, RoundRobinVolumeChoosingPolicy
+              .class, VolumeChoosingPolicy.class).newInstance();
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+    containerSize = (long) conf.getStorageSize(
+        ScmConfigKeys.OZONE_SCM_CONTAINER_SIZE,
+        ScmConfigKeys.OZONE_SCM_CONTAINER_SIZE_DEFAULT, StorageUnit.BYTES);
+  }
+
+  public void importContainer(long containerID, Path tarFilePath,
+      HddsVolume hddsVolume) throws IOException {
+
+    HddsVolume targetVolume = hddsVolume;
+    if (targetVolume == null) {
+      targetVolume = chooseNextVolume();
+    }
+    try {
+      KeyValueContainerData containerData;
+
+      try (FileInputStream input = new FileInputStream(tarFilePath.toFile())) {
+        byte[] containerDescriptorYaml =
+            packer.unpackContainerDescriptor(input);
+        containerData = (KeyValueContainerData) ContainerDataYaml
+            .readContainer(containerDescriptorYaml);
+      }
+      containerData.setVolume(targetVolume);
+
+      try (FileInputStream input = new FileInputStream(tarFilePath.toFile())) {
+        Container container = controller.importContainer(
+            containerData, input, packer);
+        containerSet.addContainer(container);
+      }
+    } finally {
+      try {
+        Files.delete(tarFilePath);
+      } catch (Exception ex) {
+        LOG.error("Got exception while deleting temporary container file: "
+            + tarFilePath.toAbsolutePath(), ex);
+      }
+    }
+  }
+
+  HddsVolume chooseNextVolume() throws IOException {
+    // Choose volume that can hold both container in tmp and dest directory
+    return volumeChoosingPolicy.chooseVolume(
+        StorageVolumeUtil.getHddsVolumesList(volumeSet.getVolumesList()),
+        containerSize * 2);
+  }
+
+  public static Path getUntarDirectory(HddsVolume hddsVolume)
+      throws IOException {
+    return Paths.get(hddsVolume.getVolumeRootDir())
+        .resolve(CONTAINER_COPY_TMP_DIR).resolve(CONTAINER_COPY_DIR);
+  }
+}

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/replication/ContainerImporter.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/replication/ContainerImporter.java
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
 package org.apache.hadoop.ozone.container.replication;
 
 import org.apache.hadoop.hdds.conf.ConfigurationSource;

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/replication/ContainerUploader.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/replication/ContainerUploader.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.ozone.container.replication;
+
+import org.apache.hadoop.hdds.protocol.DatanodeDetails;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * Client-side interface for sending a container to a target datanode.
+ */
+public interface ContainerUploader {
+  OutputStream startUpload(long containerId, DatanodeDetails target,
+      CompletableFuture<Void> callback) throws IOException;
+}

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/replication/CopyContainerResponseStream.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/replication/CopyContainerResponseStream.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.ozone.container.replication;
+
+import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.CopyContainerResponseProto;
+import org.apache.ratis.thirdparty.com.google.protobuf.ByteString;
+import org.apache.ratis.thirdparty.io.grpc.stub.StreamObserver;
+
+/**
+ * Output stream adapter for CopyContainerResponse.
+ */
+class CopyContainerResponseStream
+    extends GrpcOutputStream<CopyContainerResponseProto> {
+
+  CopyContainerResponseStream(
+      StreamObserver<CopyContainerResponseProto> streamObserver,
+      long containerId, int bufferSize) {
+    super(streamObserver, containerId, bufferSize);
+  }
+
+  protected void sendPart(boolean eof, int length, ByteString data) {
+    CopyContainerResponseProto response =
+        CopyContainerResponseProto.newBuilder()
+            .setContainerID(getContainerId())
+            .setData(data)
+            .setEof(eof)
+            .setReadOffset(getWrittenBytes())
+            .setLen(length)
+            .build();
+    getStreamObserver().onNext(response);
+  }
+}

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/replication/DownloadAndImportReplicator.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/replication/DownloadAndImportReplicator.java
@@ -17,34 +17,17 @@
  */
 package org.apache.hadoop.ozone.container.replication;
 
-import java.io.FileInputStream;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.List;
 
-import org.apache.hadoop.hdds.conf.ConfigurationSource;
-import org.apache.hadoop.hdds.conf.StorageUnit;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
-import org.apache.hadoop.hdds.scm.ScmConfigKeys;
-import org.apache.hadoop.ozone.container.common.impl.ContainerDataYaml;
-import org.apache.hadoop.ozone.container.common.impl.ContainerSet;
-import org.apache.hadoop.ozone.container.common.interfaces.Container;
-import org.apache.hadoop.ozone.container.common.interfaces.VolumeChoosingPolicy;
-import org.apache.hadoop.ozone.container.common.utils.StorageVolumeUtil;
 import org.apache.hadoop.ozone.container.common.volume.HddsVolume;
-import org.apache.hadoop.ozone.container.common.volume.MutableVolumeSet;
-import org.apache.hadoop.ozone.container.common.volume.RoundRobinVolumeChoosingPolicy;
-import org.apache.hadoop.ozone.container.keyvalue.KeyValueContainerData;
-import org.apache.hadoop.ozone.container.keyvalue.TarContainerPacker;
-import org.apache.hadoop.ozone.container.ozoneimpl.ContainerController;
 import org.apache.hadoop.ozone.container.replication.ReplicationTask.Status;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_DATANODE_VOLUME_CHOOSING_POLICY;
 
 /**
  * Default replication implementation.
@@ -57,77 +40,14 @@ public class DownloadAndImportReplicator implements ContainerReplicator {
   public static final Logger LOG =
       LoggerFactory.getLogger(DownloadAndImportReplicator.class);
 
-  public static final String CONTAINER_COPY_DIR = "container-copy";
-  public static final String CONTAINER_COPY_TMP_DIR = "tmp";
-
-  private final ContainerSet containerSet;
-  private final ContainerController controller;
   private final ContainerDownloader downloader;
-  private final TarContainerPacker packer;
-  private final MutableVolumeSet volumeSet;
-  private final VolumeChoosingPolicy volumeChoosingPolicy;
-  private final long containerSize;
+  private final ContainerImporter containerImporter;
 
   public DownloadAndImportReplicator(
-      ConfigurationSource conf,
-      ContainerSet containerSet,
-      ContainerController controller,
-      ContainerDownloader downloader,
-      TarContainerPacker packer,
-      MutableVolumeSet volumeSet) {
-    this.containerSet = containerSet;
-    this.controller = controller;
+      ContainerImporter containerImporter,
+      ContainerDownloader downloader) {
     this.downloader = downloader;
-    this.packer = packer;
-    this.volumeSet = volumeSet;
-    try {
-      this.volumeChoosingPolicy = conf.getClass(
-          HDDS_DATANODE_VOLUME_CHOOSING_POLICY, RoundRobinVolumeChoosingPolicy
-              .class, VolumeChoosingPolicy.class).newInstance();
-    } catch (Exception e) {
-      throw new RuntimeException(e);
-    }
-    this.containerSize = (long) conf.getStorageSize(
-        ScmConfigKeys.OZONE_SCM_CONTAINER_SIZE,
-        ScmConfigKeys.OZONE_SCM_CONTAINER_SIZE_DEFAULT, StorageUnit.BYTES);
-
-  }
-
-  public void importContainer(long containerID, Path tarFilePath,
-      HddsVolume hddsVolume) throws IOException {
-
-    HddsVolume targetVolume = hddsVolume;
-    if (targetVolume == null) {
-      targetVolume = chooseNextVolume();
-    }
-    KeyValueContainerData originalContainerData;
-    try {
-      try (FileInputStream tmpContainerTarStream = new FileInputStream(
-          tarFilePath.toFile())) {
-        byte[] containerDescriptorYaml =
-            packer.unpackContainerDescriptor(tmpContainerTarStream);
-        originalContainerData = (KeyValueContainerData) ContainerDataYaml
-            .readContainer(containerDescriptorYaml);
-      }
-      originalContainerData.setVolume(targetVolume);
-
-      try (FileInputStream tempContainerTarStream = new FileInputStream(
-          tarFilePath.toFile())) {
-
-        Container container = controller.importContainer(
-            originalContainerData, tempContainerTarStream, packer);
-
-        containerSet.addContainer(container);
-      }
-
-    } finally {
-      try {
-        Files.delete(tarFilePath);
-      } catch (Exception ex) {
-        LOG.error("Got exception while deleting downloaded container file: "
-            + tarFilePath.toAbsolutePath().toString(), ex);
-      }
-    }
+    this.containerImporter = containerImporter;
   }
 
   @Override
@@ -140,12 +60,12 @@ public class DownloadAndImportReplicator implements ContainerReplicator {
         sourceDatanodes);
 
     try {
-      HddsVolume targetVolume = chooseNextVolume();
+      HddsVolume targetVolume = containerImporter.chooseNextVolume();
       // Wait for the download. This thread pool is limiting the parallel
       // downloads, so it's ok to block here and wait for the full download.
       Path tarFilePath =
           downloader.getContainerDataFromReplicas(containerID, sourceDatanodes,
-              getUntarDirectory(targetVolume));
+              ContainerImporter.getUntarDirectory(targetVolume));
       if (tarFilePath == null) {
         task.setStatus(Status.FAILED);
         return;
@@ -155,7 +75,7 @@ public class DownloadAndImportReplicator implements ContainerReplicator {
               containerID, bytes);
       task.setTransferredBytes(bytes);
 
-      importContainer(containerID, tarFilePath, targetVolume);
+      containerImporter.importContainer(containerID, tarFilePath, targetVolume);
 
       LOG.info("Container {} is replicated successfully", containerID);
       task.setStatus(Status.DONE);
@@ -165,20 +85,4 @@ public class DownloadAndImportReplicator implements ContainerReplicator {
     }
   }
 
-  private HddsVolume chooseNextVolume() throws IOException {
-    // Choose volume that can hold both container in tmp and dest directory
-    return volumeChoosingPolicy.chooseVolume(
-        StorageVolumeUtil.getHddsVolumesList(volumeSet.getVolumesList()),
-        containerSize * 2);
-  }
-
-  public static Path getUntarDirectory(HddsVolume hddsVolume)
-      throws IOException {
-    return Paths.get(hddsVolume.getVolumeRootDir())
-        .resolve(CONTAINER_COPY_TMP_DIR).resolve(CONTAINER_COPY_DIR);
-  }
-
-  private List<HddsVolume> getHddsVolumesList() {
-    return StorageVolumeUtil.getHddsVolumesList(volumeSet.getVolumesList());
-  }
 }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/replication/GrpcContainerUploader.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/replication/GrpcContainerUploader.java
@@ -1,0 +1,100 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.ozone.container.replication;
+
+import org.apache.hadoop.hdds.conf.ConfigurationSource;
+import org.apache.hadoop.hdds.protocol.DatanodeDetails;
+import org.apache.hadoop.hdds.protocol.DatanodeDetails.Port;
+import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.SendContainerRequest;
+import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.SendContainerResponse;
+import org.apache.hadoop.hdds.security.x509.SecurityConfig;
+import org.apache.hadoop.hdds.security.x509.certificate.client.CertificateClient;
+import org.apache.ratis.thirdparty.io.grpc.stub.StreamObserver;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * Uploads container to target datanode via gRPC.
+ */
+public class GrpcContainerUploader implements ContainerUploader {
+
+  private static final Logger LOG =
+      LoggerFactory.getLogger(GrpcContainerUploader.class);
+
+  private final SecurityConfig securityConfig;
+  private final CertificateClient certClient;
+  private final CopyContainerCompression compression;
+
+  public GrpcContainerUploader(
+      ConfigurationSource conf, CertificateClient certClient) {
+    this.certClient = certClient;
+    securityConfig = new SecurityConfig(conf);
+    compression = CopyContainerCompression.getConf(conf);
+  }
+
+  @Override
+  public OutputStream startUpload(long containerId, DatanodeDetails target,
+      CompletableFuture<Void> callback) throws IOException {
+    GrpcReplicationClient client =
+        new GrpcReplicationClient(target.getIpAddress(),
+            target.getPort(Port.Name.REPLICATION).getValue(),
+            securityConfig, certClient, compression.toString());
+    StreamObserver<SendContainerRequest> requestStream = client.upload(
+        new SendContainerResponseStreamObserver(containerId, target, callback));
+    return new SendContainerOutputStream(requestStream, containerId,
+        GrpcReplicationService.BUFFER_SIZE);
+  }
+
+  /**
+   *
+   */
+  private static class SendContainerResponseStreamObserver
+      implements StreamObserver<SendContainerResponse> {
+    private final long containerId;
+    private final DatanodeDetails target;
+    private final CompletableFuture<Void> callback;
+
+    SendContainerResponseStreamObserver(long containerId,
+        DatanodeDetails target, CompletableFuture<Void> callback) {
+      this.containerId = containerId;
+      this.target = target;
+      this.callback = callback;
+    }
+
+    @Override
+    public void onNext(SendContainerResponse sendContainerResponse) {
+      LOG.info("Response for upload container {} to {}", containerId, target);
+    }
+
+    @Override
+    public void onError(Throwable t) {
+      LOG.warn("Failed to upload container {} to {}", containerId, target, t);
+      callback.completeExceptionally(t);
+    }
+
+    @Override
+    public void onCompleted() {
+      LOG.info("Finished uploading container {} to {}", containerId, target);
+      callback.complete(null);
+    }
+  }
+}

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/replication/GrpcReplicationClient.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/replication/GrpcReplicationClient.java
@@ -30,6 +30,8 @@ import java.util.concurrent.TimeUnit;
 import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos;
 import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.CopyContainerRequestProto;
 import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.CopyContainerResponseProto;
+import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.SendContainerRequest;
+import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.SendContainerResponse;
 import org.apache.hadoop.hdds.protocol.datanode.proto.IntraDatanodeProtocolServiceGrpc;
 import org.apache.hadoop.hdds.protocol.datanode.proto.IntraDatanodeProtocolServiceGrpc.IntraDatanodeProtocolServiceStub;
 import org.apache.hadoop.hdds.security.ssl.KeyStoresFactory;
@@ -60,12 +62,10 @@ public class GrpcReplicationClient implements AutoCloseable {
 
   private final IntraDatanodeProtocolServiceStub client;
 
-  private final Path workingDirectory;
-
   private final ContainerProtos.CopyContainerCompressProto compression;
 
   public GrpcReplicationClient(
-      String host, int port, Path workingDir,
+      String host, int port,
       SecurityConfig secConfig, CertificateClient certClient,
       String compression)
       throws IOException {
@@ -92,12 +92,11 @@ public class GrpcReplicationClient implements AutoCloseable {
     }
     channel = channelBuilder.build();
     client = IntraDatanodeProtocolServiceGrpc.newStub(channel);
-    workingDirectory = workingDir;
     this.compression =
         ContainerProtos.CopyContainerCompressProto.valueOf(compression);
   }
 
-  public CompletableFuture<Path> download(long containerId) {
+  public CompletableFuture<Path> download(long containerId, Path dir) {
     CopyContainerRequestProto request =
         CopyContainerRequestProto.newBuilder()
             .setContainerID(containerId)
@@ -108,7 +107,7 @@ public class GrpcReplicationClient implements AutoCloseable {
 
     CompletableFuture<Path> response = new CompletableFuture<>();
 
-    Path destinationPath = getWorkingDirectory()
+    Path destinationPath = dir
         .resolve(ContainerUtils.getContainerTarGzName(containerId));
 
     client.download(request,
@@ -117,8 +116,9 @@ public class GrpcReplicationClient implements AutoCloseable {
     return response;
   }
 
-  private Path getWorkingDirectory() {
-    return workingDirectory;
+  public StreamObserver<SendContainerRequest> upload(
+      StreamObserver<SendContainerResponse> responseObserver) {
+    return client.upload(responseObserver);
   }
 
   public void shutdown() {

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/replication/GrpcReplicationService.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/replication/GrpcReplicationService.java
@@ -19,9 +19,12 @@
 package org.apache.hadoop.ozone.container.replication;
 
 import java.io.IOException;
+import java.io.OutputStream;
 
 import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.CopyContainerRequestProto;
 import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.CopyContainerResponseProto;
+import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.SendContainerRequest;
+import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.SendContainerResponse;
 import org.apache.hadoop.hdds.protocol.datanode.proto.IntraDatanodeProtocolServiceGrpc;
 
 import org.apache.ratis.thirdparty.io.grpc.stub.StreamObserver;
@@ -37,12 +40,15 @@ public class GrpcReplicationService extends
   private static final Logger LOG =
       LoggerFactory.getLogger(GrpcReplicationService.class);
 
-  private static final int BUFFER_SIZE = 1024 * 1024;
+  static final int BUFFER_SIZE = 1024 * 1024;
 
   private final ContainerReplicationSource source;
+  private final ContainerImporter importer;
 
-  public GrpcReplicationService(ContainerReplicationSource source) {
+  public GrpcReplicationService(ContainerReplicationSource source,
+      ContainerImporter importer) {
     this.source = source;
+    this.importer = importer;
   }
 
   @Override
@@ -55,8 +61,8 @@ public class GrpcReplicationService extends
     LOG.info("Streaming container data ({}) to other datanode " +
         "with compression {}", containerID, compression);
     try {
-      GrpcOutputStream outputStream =
-          new GrpcOutputStream(responseObserver, containerID, BUFFER_SIZE);
+      OutputStream outputStream = new CopyContainerResponseStream(
+          responseObserver, containerID, BUFFER_SIZE);
       source.copyData(containerID, outputStream, compression);
     } catch (IOException e) {
       LOG.error("Error streaming container {}", containerID, e);
@@ -64,4 +70,10 @@ public class GrpcReplicationService extends
     }
   }
 
+  @Override
+  public StreamObserver<SendContainerRequest> upload(
+      StreamObserver<SendContainerResponse> responseObserver) {
+
+    return new SendContainerRequestHandler(importer, responseObserver);
+  }
 }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/replication/PushReplicator.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/replication/PushReplicator.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.ozone.container.replication;
+
+import org.apache.hadoop.hdds.protocol.DatanodeDetails;
+import org.apache.hadoop.ozone.container.replication.ReplicationTask.Status;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.OutputStream;
+import java.util.concurrent.CompletableFuture;
+
+import static org.apache.hadoop.ozone.container.replication.CopyContainerCompression.NO_COMPRESSION;
+
+/**
+ * Pushes the container to the target datanode.
+ */
+public class PushReplicator implements ContainerReplicator {
+
+  private static final Logger LOG =
+      LoggerFactory.getLogger(PushReplicator.class);
+
+  private final ContainerReplicationSource source;
+  private final ContainerUploader uploader;
+
+  public PushReplicator(ContainerReplicationSource source,
+      ContainerUploader uploader) {
+    this.source = source;
+    this.uploader = uploader;
+  }
+
+  @Override
+  public void replicate(ReplicationTask task) {
+    long containerID = task.getContainerId();
+    DatanodeDetails target = task.getTarget();
+    CompletableFuture<Void> fut = new CompletableFuture<>();
+
+    source.prepare(containerID);
+
+    try (OutputStream output = uploader.startUpload(containerID, target, fut)) {
+      source.copyData(containerID, output, NO_COMPRESSION.name());
+      fut.get();
+      task.setStatus(Status.DONE);
+    } catch (Exception e) {
+      LOG.warn("Container {} replication was unsuccessful.", containerID, e);
+      task.setStatus(Status.FAILED);
+    }
+  }
+}

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/replication/ReplicationServer.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/replication/ReplicationServer.java
@@ -59,13 +59,15 @@ public class ReplicationServer {
   private ContainerController controller;
 
   private int port;
+  private final ContainerImporter importer;
 
   public ReplicationServer(ContainerController controller,
       ReplicationConfig replicationConfig, SecurityConfig secConf,
-      CertificateClient caClient) {
+      CertificateClient caClient, ContainerImporter importer) {
     this.secConf = secConf;
     this.caClient = caClient;
     this.controller = controller;
+    this.importer = importer;
     this.port = replicationConfig.getPort();
     init();
   }
@@ -74,7 +76,8 @@ public class ReplicationServer {
     NettyServerBuilder nettyServerBuilder = NettyServerBuilder.forPort(port)
         .maxInboundMessageSize(OzoneConsts.OZONE_SCM_CHUNK_MAX_SIZE)
         .addService(ServerInterceptors.intercept(new GrpcReplicationService(
-            new OnDemandContainerReplicationSource(controller)
+            new OnDemandContainerReplicationSource(controller),
+            importer
         ), new GrpcServerInterceptor()));
 
     if (secConf.isSecurityEnabled() && secConf.isGrpcTlsEnabled()) {

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/replication/ReplicationTask.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/replication/ReplicationTask.java
@@ -31,15 +31,9 @@ public class ReplicationTask {
 
   private volatile Status status = Status.QUEUED;
 
-  private final long containerId;
-
-  private final List<DatanodeDetails> sources;
-
   private final Instant queued = Instant.now();
 
-  private final long deadlineMsSinceEpoch;
-
-  private final long term;
+  private final ReplicateContainerCommand cmd;
 
   /**
    * Counter for the transferred bytes.
@@ -47,10 +41,7 @@ public class ReplicationTask {
   private long transferredBytes;
 
   public ReplicationTask(ReplicateContainerCommand cmd) {
-    this.containerId = cmd.getContainerID();
-    this.sources = cmd.getSourceDatanodes();
-    this.deadlineMsSinceEpoch = cmd.getDeadline();
-    this.term = cmd.getTerm();
+    this.cmd = cmd;
   }
 
   /**
@@ -68,7 +59,7 @@ public class ReplicationTask {
    * A returned value of zero indicates no deadline.
    */
   public long getDeadline() {
-    return deadlineMsSinceEpoch;
+    return cmd.getDeadline();
   }
 
   @Override
@@ -80,20 +71,21 @@ public class ReplicationTask {
       return false;
     }
     ReplicationTask that = (ReplicationTask) o;
-    return containerId == that.containerId;
+    return getContainerId() == that.getContainerId() &&
+        Objects.equals(getTarget(), that.getTarget());
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(containerId);
+    return Objects.hash(getContainerId(), getTarget());
   }
 
   public long getContainerId() {
-    return containerId;
+    return cmd.getContainerID();
   }
 
   public List<DatanodeDetails> getSources() {
-    return sources;
+    return cmd.getSourceDatanodes();
   }
 
   public Status getStatus() {
@@ -108,8 +100,7 @@ public class ReplicationTask {
   public String toString() {
     return "ReplicationTask{" +
         "status=" + status +
-        ", containerId=" + containerId +
-        ", sources=" + sources +
+        ", cmd={" + cmd + "}" +
         ", queued=" + queued +
         '}';
   }
@@ -127,7 +118,15 @@ public class ReplicationTask {
   }
 
   long getTerm() {
-    return term;
+    return cmd.getTerm();
+  }
+
+  DatanodeDetails getTarget() {
+    return cmd.getTargetDatanode();
+  }
+
+  ReplicateContainerCommand getCommand() {
+    return cmd;
   }
 
   /**
@@ -135,7 +134,7 @@ public class ReplicationTask {
    */
   public enum Status {
     QUEUED,
-    DOWNLOADING,
+    IN_PROGRESS,
     FAILED,
     DONE
   }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/replication/ReplicationTask.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/replication/ReplicationTask.java
@@ -45,16 +45,6 @@ public class ReplicationTask {
   }
 
   /**
-   * Intended to only be used in tests.
-   */
-  protected ReplicationTask(
-      long containerId,
-      List<DatanodeDetails> sources
-  ) {
-    this(new ReplicateContainerCommand(containerId, sources));
-  }
-
-  /**
    * Returns any deadline set on this task, in milliseconds since the epoch.
    * A returned value of zero indicates no deadline.
    */

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/replication/SendContainerOutputStream.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/replication/SendContainerOutputStream.java
@@ -37,8 +37,6 @@ class SendContainerOutputStream extends GrpcOutputStream<SendContainerRequest> {
         .setContainerID(getContainerId())
         .setData(data)
         .setOffset(getWrittenBytes())
-        .setLen(length)
-        .setEof(eof)
         .build();
     getStreamObserver().onNext(request);
   }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/replication/SendContainerOutputStream.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/replication/SendContainerOutputStream.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.ozone.container.replication;
+
+import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.SendContainerRequest;
+import org.apache.ratis.thirdparty.com.google.protobuf.ByteString;
+import org.apache.ratis.thirdparty.io.grpc.stub.StreamObserver;
+
+/**
+ * Output stream adapter for SendContainerResponse.
+ */
+class SendContainerOutputStream extends GrpcOutputStream<SendContainerRequest> {
+  SendContainerOutputStream(
+      StreamObserver<SendContainerRequest> streamObserver,
+      long containerId, int bufferSize) {
+    super(streamObserver, containerId, bufferSize);
+  }
+
+  @Override
+  protected void sendPart(boolean eof, int length, ByteString data) {
+    SendContainerRequest request = SendContainerRequest.newBuilder()
+        .setContainerID(getContainerId())
+        .setOffset(getWrittenBytes())
+        .setLen(length)
+        .setEof(eof)
+        .build();
+    getStreamObserver().onNext(request);
+  }
+}

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/replication/SendContainerOutputStream.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/replication/SendContainerOutputStream.java
@@ -35,6 +35,7 @@ class SendContainerOutputStream extends GrpcOutputStream<SendContainerRequest> {
   protected void sendPart(boolean eof, int length, ByteString data) {
     SendContainerRequest request = SendContainerRequest.newBuilder()
         .setContainerID(getContainerId())
+        .setData(data)
         .setOffset(getWrittenBytes())
         .setLen(length)
         .setEof(eof)

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/replication/SendContainerRequestHandler.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/replication/SendContainerRequestHandler.java
@@ -108,6 +108,7 @@ class SendContainerRequestHandler
     try {
       importer.importContainer(containerId, path, volume);
       LOG.info("Imported container {}", containerId);
+      responseObserver.onNext(SendContainerResponse.newBuilder().build());
       responseObserver.onCompleted();
     } catch (Throwable t) {
       LOG.info("Failed to import container {}", containerId, t);

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/replication/SendContainerRequestHandler.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/replication/SendContainerRequestHandler.java
@@ -70,8 +70,10 @@ class SendContainerRequestHandler
       if (containerId == -1) {
         containerId = req.getContainerID();
         volume = importer.chooseNextVolume();
-        path = ContainerImporter.getUntarDirectory(volume)
-            .resolve(ContainerUtils.getContainerTarGzName(containerId));
+        Path dir = ContainerImporter.getUntarDirectory(volume);
+        Files.createDirectories(dir);
+        // FIXME cleanup on completion
+        path = dir.resolve(ContainerUtils.getContainerTarGzName(containerId));
         output = Files.newOutputStream(path);
       }
 
@@ -81,6 +83,7 @@ class SendContainerRequestHandler
 
       nextOffset += req.getLen();
     } catch (Throwable t) {
+      LOG.error("Error", t);
       IOUtils.cleanupWithLogger(LOG, output);
       output = null;
       responseObserver.onError(t);

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/replication/SendContainerRequestHandler.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/replication/SendContainerRequestHandler.java
@@ -61,12 +61,11 @@ class SendContainerRequestHandler
   @Override
   public void onNext(SendContainerRequest req) {
     try {
-      LOG.info("Received part for container id:{} offset:{} len:{} eof:{}",
-          req.getContainerID(), req.getOffset(), req.getLen(), req.getEof());
+      final long length = req.getData().size();
+      LOG.info("Received part for container id:{} offset:{} len:{}",
+          req.getContainerID(), req.getOffset(), length);
 
       assertSame(nextOffset, req.getOffset(), "offset");
-      // TODO get rid of 'eof'?
-      // TODO get rid of 'len'?
 
       if (containerId == -1) {
         containerId = req.getContainerID();
@@ -81,7 +80,7 @@ class SendContainerRequestHandler
 
       req.getData().writeTo(output);
 
-      nextOffset += req.getLen();
+      nextOffset += length;
     } catch (Throwable t) {
       onError(t);
     }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/replication/SendContainerRequestHandler.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/replication/SendContainerRequestHandler.java
@@ -1,0 +1,117 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.ozone.container.replication;
+
+import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.SendContainerRequest;
+import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.SendContainerResponse;
+import org.apache.hadoop.hdds.utils.IOUtils;
+import org.apache.hadoop.ozone.container.common.helpers.ContainerUtils;
+import org.apache.hadoop.ozone.container.common.volume.HddsVolume;
+import org.apache.ratis.thirdparty.io.grpc.stub.StreamObserver;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.OutputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.apache.ratis.util.Preconditions.assertSame;
+
+/**
+ * Handles incoming container pushed by other datanode.
+ */
+class SendContainerRequestHandler
+    implements StreamObserver<SendContainerRequest> {
+
+  private static final Logger LOG =
+      LoggerFactory.getLogger(SendContainerRequestHandler.class);
+
+  private final ContainerImporter importer;
+  private final StreamObserver<SendContainerResponse> responseObserver;
+
+  private long containerId = -1;
+  private long nextOffset;
+  private OutputStream output;
+  private HddsVolume volume;
+  private Path path;
+
+  SendContainerRequestHandler(
+      ContainerImporter importer,
+      StreamObserver<SendContainerResponse> responseObserver) {
+    this.importer = importer;
+    this.responseObserver = responseObserver;
+  }
+
+  @Override
+  public void onNext(SendContainerRequest req) {
+    try {
+      LOG.info("Received part for container id:{} offset:{} len:{} eof:{}",
+          req.getContainerID(), req.getOffset(), req.getLen(), req.getEof());
+
+      assertSame(nextOffset, req.getOffset(), "offset");
+      // TODO get rid of 'eof'?
+      // TODO get rid of 'len'?
+
+      if (containerId == -1) {
+        containerId = req.getContainerID();
+        volume = importer.chooseNextVolume();
+        path = ContainerImporter.getUntarDirectory(volume)
+            .resolve(ContainerUtils.getContainerTarGzName(containerId));
+        output = Files.newOutputStream(path);
+      }
+
+      assertSame(containerId, req.getContainerID(), "containerID");
+
+      req.getData().writeTo(output);
+
+      nextOffset += req.getLen();
+    } catch (Throwable t) {
+      IOUtils.cleanupWithLogger(LOG, output);
+      output = null;
+      responseObserver.onError(t);
+    }
+  }
+
+  @Override
+  public void onError(Throwable t) {
+    LOG.error("Error", t);
+    IOUtils.cleanupWithLogger(LOG, output);
+    responseObserver.onError(t);
+  }
+
+  @Override
+  public void onCompleted() {
+    if (output == null) {
+      LOG.warn("Received container without any parts");
+      return;
+    }
+
+    LOG.info("Received all parts for container {}", containerId);
+    IOUtils.cleanupWithLogger(LOG, output);
+
+    try {
+      importer.importContainer(containerId, path, volume);
+    } catch (Throwable t) {
+      LOG.info("Failed to import container {}", containerId, t);
+      responseObserver.onError(t);
+    }
+
+    LOG.info("Imported container {}", containerId);
+    responseObserver.onCompleted();
+  }
+}

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/replication/SimpleContainerDownloader.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/replication/SimpleContainerDownloader.java
@@ -37,9 +37,6 @@ import com.google.common.annotations.VisibleForTesting;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import static org.apache.hadoop.ozone.container.replication.DownloadAndImportReplicator.CONTAINER_COPY_DIR;
-
-
 /**
  * Simple ContainerDownloaderImplementation to download the missing container
  * from the first available datanode.
@@ -70,7 +67,7 @@ public class SimpleContainerDownloader implements ContainerDownloader {
 
     if (downloadDir == null) {
       downloadDir = Paths.get(System.getProperty("java.io.tmpdir"))
-              .resolve(CONTAINER_COPY_DIR);
+              .resolve(ContainerImporter.CONTAINER_COPY_DIR);
     }
 
     final List<DatanodeDetails> shuffledDatanodes =
@@ -118,9 +115,9 @@ public class SimpleContainerDownloader implements ContainerDownloader {
     GrpcReplicationClient grpcReplicationClient =
         new GrpcReplicationClient(datanode.getIpAddress(),
             datanode.getPort(Name.REPLICATION).getValue(),
-            downloadDir, securityConfig, certClient, compression);
+            securityConfig, certClient, compression);
 
-    result = grpcReplicationClient.download(containerId)
+    result = grpcReplicationClient.download(containerId, downloadDir)
         .whenComplete((r, ex) -> {
           try {
             grpcReplicationClient.close();

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/protocol/commands/ReplicateContainerCommand.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/protocol/commands/ReplicateContainerCommand.java
@@ -39,7 +39,7 @@ import static java.util.Collections.emptyList;
 /**
  * SCM command to request replication of a container.
  */
-public class ReplicateContainerCommand
+public final class ReplicateContainerCommand
     extends SCMCommand<ReplicateContainerCommandProto> {
 
   private final long containerID;
@@ -57,17 +57,15 @@ public class ReplicateContainerCommand
     return new ReplicateContainerCommand(containerID, emptyList(), target);
   }
 
+  public static ReplicateContainerCommand forTest(long containerID) {
+    return new ReplicateContainerCommand(containerID, emptyList(), null);
+  }
+
   private ReplicateContainerCommand(long containerID,
       List<DatanodeDetails> sourceDatanodes, DatanodeDetails target) {
     this.containerID = containerID;
     this.sourceDatanodes = sourceDatanodes;
     this.targetDatanode = target;
-  }
-
-
-  public ReplicateContainerCommand(long containerID,
-      List<DatanodeDetails> sourceDatanodes) {
-    this(containerID, sourceDatanodes, null);
   }
 
   // Should be called only for protobuf conversion

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/protocol/commands/ReplicateContainerCommand.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/protocol/commands/ReplicateContainerCommand.java
@@ -21,6 +21,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
+import org.apache.hadoop.hdds.protocol.proto.HddsProtos.DatanodeDetailsProto;
 import org.apache.hadoop.hdds.protocol.proto
     .StorageContainerDatanodeProtocolProtos.ReplicateContainerCommandProto;
 import org.apache.hadoop.hdds.protocol.proto
@@ -33,6 +34,8 @@ import org.apache.hadoop.hdds.protocol.proto
 
 import com.google.common.base.Preconditions;
 
+import static java.util.Collections.emptyList;
+
 /**
  * SCM command to request replication of a container.
  */
@@ -41,21 +44,40 @@ public class ReplicateContainerCommand
 
   private final long containerID;
   private final List<DatanodeDetails> sourceDatanodes;
+  private final DatanodeDetails targetDatanode;
   private int replicaIndex = 0;
+
+  public static ReplicateContainerCommand fromSources(long containerID,
+      List<DatanodeDetails> sourceDatanodes) {
+    return new ReplicateContainerCommand(containerID, sourceDatanodes, null);
+  }
+
+  public static ReplicateContainerCommand toTarget(long containerID,
+      DatanodeDetails target) {
+    return new ReplicateContainerCommand(containerID, emptyList(), target);
+  }
+
+  private ReplicateContainerCommand(long containerID,
+      List<DatanodeDetails> sourceDatanodes, DatanodeDetails target) {
+    this.containerID = containerID;
+    this.sourceDatanodes = sourceDatanodes;
+    this.targetDatanode = target;
+  }
+
 
   public ReplicateContainerCommand(long containerID,
       List<DatanodeDetails> sourceDatanodes) {
-    super();
-    this.containerID = containerID;
-    this.sourceDatanodes = sourceDatanodes;
+    this(containerID, sourceDatanodes, null);
   }
 
   // Should be called only for protobuf conversion
-  public ReplicateContainerCommand(long containerID,
-      List<DatanodeDetails> sourceDatanodes, long id) {
+  private ReplicateContainerCommand(long containerID,
+      List<DatanodeDetails> sourceDatanodes, long id,
+      DatanodeDetails targetDatanode) {
     super(id);
     this.containerID = containerID;
     this.sourceDatanodes = sourceDatanodes;
+    this.targetDatanode = targetDatanode;
   }
 
   public void setReplicaIndex(int index) {
@@ -76,6 +98,9 @@ public class ReplicateContainerCommand
       builder.addSources(dd.getProtoBufMessage());
     }
     builder.setReplicaIndex(replicaIndex);
+    if (targetDatanode != null) {
+      builder.setTarget(targetDatanode.getProtoBufMessage());
+    }
     return builder.build();
   }
 
@@ -83,15 +108,19 @@ public class ReplicateContainerCommand
       ReplicateContainerCommandProto protoMessage) {
     Preconditions.checkNotNull(protoMessage);
 
-    List<DatanodeDetails> datanodeDetails =
-        protoMessage.getSourcesList()
-            .stream()
+    List<DatanodeDetailsProto> sources = protoMessage.getSourcesList();
+    List<DatanodeDetails> sourceNodes = !sources.isEmpty()
+        ? sources.stream()
             .map(DatanodeDetails::getFromProtoBuf)
-            .collect(Collectors.toList());
+            .collect(Collectors.toList())
+        : emptyList();
+    DatanodeDetails targetNode = protoMessage.hasTarget()
+        ? DatanodeDetails.getFromProtoBuf(protoMessage.getTarget())
+        : null;
 
     ReplicateContainerCommand cmd =
         new ReplicateContainerCommand(protoMessage.getContainerID(),
-            datanodeDetails, protoMessage.getCmdId());
+            sourceNodes, protoMessage.getCmdId(), targetNode);
     if (protoMessage.hasReplicaIndex()) {
       cmd.setReplicaIndex(protoMessage.getReplicaIndex());
     }
@@ -106,6 +135,10 @@ public class ReplicateContainerCommand
     return sourceDatanodes;
   }
 
+  public DatanodeDetails getTargetDatanode() {
+    return targetDatanode;
+  }
+
   public int getReplicaIndex() {
     return replicaIndex;
   }
@@ -116,7 +149,11 @@ public class ReplicateContainerCommand
     sb.append(getType());
     sb.append(": containerId: ").append(getContainerID());
     sb.append(", replicaIndex: ").append(getReplicaIndex());
-    sb.append(", sourceNodes: ").append(sourceDatanodes);
+    if (targetDatanode != null) {
+      sb.append(", targetNode: ").append(targetDatanode);
+    } else {
+      sb.append(", sourceNodes: ").append(sourceDatanodes);
+    }
     return sb.toString();
   }
 }

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/statemachine/TestStateContext.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/statemachine/TestStateContext.java
@@ -19,7 +19,6 @@
 package org.apache.hadoop.ozone.container.common.statemachine;
 
 import static com.google.common.util.concurrent.MoreExecutors.newDirectExecutorService;
-import static java.util.Collections.emptyList;
 import static org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.ClosePipelineInfo;
 import static org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.ContainerAction.Action.CLOSE;
 import static org.apache.ozone.test.GenericTestUtils.waitFor;
@@ -615,10 +614,10 @@ public class TestStateContext {
   @Test
   public void testCommandQueueSummary() throws IOException {
     StateContext ctx = createSubject();
-    ctx.addCommand(new ReplicateContainerCommand(1, null));
+    ctx.addCommand(ReplicateContainerCommand.forTest(1));
     ctx.addCommand(new ClosePipelineCommand(PipelineID.randomId()));
-    ctx.addCommand(new ReplicateContainerCommand(2, null));
-    ctx.addCommand(new ReplicateContainerCommand(3, null));
+    ctx.addCommand(ReplicateContainerCommand.forTest(2));
+    ctx.addCommand(ReplicateContainerCommand.forTest(3));
     ctx.addCommand(new ClosePipelineCommand(PipelineID.randomId()));
     ctx.addCommand(new CloseContainerCommand(1, PipelineID.randomId()));
 
@@ -682,7 +681,7 @@ public class TestStateContext {
   }
 
   private static SCMCommand<?> someCommand() {
-    return new ReplicateContainerCommand(1, emptyList());
+    return ReplicateContainerCommand.forTest(1);
   }
 
 }

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/replication/ReplicationSupervisorScheduling.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/replication/ReplicationSupervisorScheduling.java
@@ -34,6 +34,8 @@ import org.apache.hadoop.ozone.container.common.impl.ContainerSet;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
+import static org.apache.hadoop.ozone.protocol.commands.ReplicateContainerCommand.fromSources;
+
 /**
  * Helper to check scheduling efficiency.
  * <p>
@@ -121,7 +123,7 @@ public class ReplicationSupervisorScheduling {
     for (int i = 0; i < 100; i++) {
       List<DatanodeDetails> sources = new ArrayList<>();
       sources.add(datanodes.get(random.nextInt(datanodes.size())));
-      rs.addTask(new ReplicationTask(i, sources));
+      rs.addTask(new ReplicationTask(fromSources(i, sources)));
     }
     rs.shutdownAfterFinish();
     final long executionTime = System.currentTimeMillis() - start;

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/replication/ReplicationSupervisorScheduling.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/replication/ReplicationSupervisorScheduling.java
@@ -113,7 +113,7 @@ public class ReplicationSupervisorScheduling {
             }
           }
 
-        }, replicationConfig, Clock.system(ZoneId.systemDefault()));
+        }, null, replicationConfig, Clock.system(ZoneId.systemDefault()));
 
     final long start = System.currentTimeMillis();
 

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/replication/TestCopyContainerResponseStream.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/replication/TestCopyContainerResponseStream.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.ozone.container.replication;
+
+import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.CopyContainerResponseProto;
+import org.apache.ratis.thirdparty.com.google.protobuf.ByteString;
+
+import java.io.OutputStream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Test for {@link CopyContainerResponseStream}.
+ */
+class TestCopyContainerResponseStream
+    extends GrpcOutputStreamTest<CopyContainerResponseProto> {
+
+  TestCopyContainerResponseStream() {
+    super(CopyContainerResponseProto.class);
+  }
+
+  @Override
+  protected OutputStream createSubject() {
+    return new CopyContainerResponseStream(getObserver(),
+        getContainerId(), getBufferSize());
+  }
+
+  protected ByteString verifyPart(CopyContainerResponseProto response,
+      int expectedOffset, int size) {
+    assertEquals(getContainerId(), response.getContainerID());
+    assertEquals(expectedOffset, response.getReadOffset());
+    assertEquals(size, response.getLen());
+    return response.getData();
+  }
+}

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/replication/TestMeasuredReplicator.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/replication/TestMeasuredReplicator.java
@@ -19,7 +19,6 @@ package org.apache.hadoop.ozone.container.replication;
 
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
-import java.util.ArrayList;
 
 import org.apache.hadoop.ozone.container.replication.ReplicationTask.Status;
 
@@ -27,6 +26,8 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+
+import static org.apache.hadoop.ozone.protocol.commands.ReplicateContainerCommand.forTest;
 
 /**
  * Test replicator metric measurement.
@@ -63,9 +64,9 @@ public class TestMeasuredReplicator {
   @Test
   public void measureFailureSuccessAndBytes() {
     //WHEN
-    measuredReplicator.replicate(new ReplicationTask(1L, new ArrayList<>()));
-    measuredReplicator.replicate(new ReplicationTask(2L, new ArrayList<>()));
-    measuredReplicator.replicate(new ReplicationTask(3L, new ArrayList<>()));
+    measuredReplicator.replicate(new ReplicationTask(forTest(1)));
+    measuredReplicator.replicate(new ReplicationTask(forTest(2)));
+    measuredReplicator.replicate(new ReplicationTask(forTest(3)));
 
     //THEN
     //even containers should be failed
@@ -83,9 +84,9 @@ public class TestMeasuredReplicator {
   public void testReplicationTime() throws Exception {
     //WHEN
     //will wait at least the 300ms
-    measuredReplicator.replicate(new ReplicationTask(101L, new ArrayList<>()));
-    measuredReplicator.replicate(new ReplicationTask(201L, new ArrayList<>()));
-    measuredReplicator.replicate(new ReplicationTask(300L, new ArrayList<>()));
+    measuredReplicator.replicate(new ReplicationTask(forTest(101)));
+    measuredReplicator.replicate(new ReplicationTask(forTest(201)));
+    measuredReplicator.replicate(new ReplicationTask(forTest(300)));
 
     //THEN
     //even containers should be failed
@@ -101,7 +102,7 @@ public class TestMeasuredReplicator {
   public void testFailureTimeSuccessExcluded() {
     //WHEN
     //will wait at least the 15ms
-    measuredReplicator.replicate(new ReplicationTask(15L, new ArrayList<>()));
+    measuredReplicator.replicate(new ReplicationTask(forTest(15)));
 
     //THEN
     //even containers should be failed, supposed to be zero
@@ -112,7 +113,7 @@ public class TestMeasuredReplicator {
   public void testSuccessTimeFailureExcluded() {
     //WHEN
     //will wait at least the 10ms
-    measuredReplicator.replicate(new ReplicationTask(10L, new ArrayList<>()));
+    measuredReplicator.replicate(new ReplicationTask(forTest(10)));
 
     //THEN
     //even containers should be failed, supposed to be zero
@@ -122,7 +123,7 @@ public class TestMeasuredReplicator {
   @Test
   public void testReplicationQueueTimeMetrics() {
     final Instant queued = Instant.now().minus(1, ChronoUnit.SECONDS);
-    ReplicationTask task = new ReplicationTask(100L, new ArrayList<>()) {
+    ReplicationTask task = new ReplicationTask(forTest(100)) {
       @Override
       public Instant getQueued() {
         return queued;

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/replication/TestReplicationSupervisor.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/replication/TestReplicationSupervisor.java
@@ -82,8 +82,12 @@ public class TestReplicationSupervisor {
   };
   private final AtomicReference<ContainerReplicator> replicatorRef =
       new AtomicReference<>();
-  private final ContainerReplicator mutableReplicator =
+  private final AtomicReference<ContainerReplicator> pushReplicatorRef =
+      new AtomicReference<>();
+  private final ContainerReplicator pullReplicator =
       task -> replicatorRef.get().replicate(task);
+  private final ContainerReplicator pushReplicator =
+      task -> pushReplicatorRef.get().replicate(task);
 
   private ContainerSet set;
 
@@ -251,8 +255,8 @@ public class TestReplicationSupervisor {
   @Test
   public void testDownloadAndImportReplicatorFailure() throws IOException {
     ReplicationSupervisor supervisor =
-        new ReplicationSupervisor(set, context, mutableReplicator,
-            newDirectExecutorService(), clock);
+        new ReplicationSupervisor(set, context, pullReplicator,
+            pushReplicator, newDirectExecutorService(), clock);
 
     OzoneConfiguration conf = new OzoneConfiguration();
     // Mock to fetch an exception in the importContainer method.
@@ -271,10 +275,12 @@ public class TestReplicationSupervisor {
     Mockito.when(volumeSet.getVolumesList())
         .thenReturn(Collections.singletonList(
             new HddsVolume.Builder(testDir).conf(conf).build()));
-    ContainerReplicator replicatorFactory =
-        new DownloadAndImportReplicator(conf, set, null, moc, null, volumeSet);
+    ContainerImporter importer =
+        new ContainerImporter(conf, set, null, null, volumeSet);
+    ContainerReplicator replicator =
+        new DownloadAndImportReplicator(importer, moc);
 
-    replicatorRef.set(replicatorFactory);
+    replicatorRef.set(replicator);
 
     GenericTestUtils.LogCapturer logCapturer = GenericTestUtils.LogCapturer
         .captureLogs(DownloadAndImportReplicator.LOG);
@@ -340,8 +346,8 @@ public class TestReplicationSupervisor {
       Function<ReplicationSupervisor, ContainerReplicator> replicatorFactory,
       ExecutorService executor) {
     ReplicationSupervisor supervisor =
-        new ReplicationSupervisor(set, context, mutableReplicator, executor,
-            clock);
+        new ReplicationSupervisor(set, context, pullReplicator, pushReplicator,
+            executor, clock);
     replicatorRef.set(replicatorFactory.apply(supervisor));
     return supervisor;
   }

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/replication/TestReplicationSupervisor.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/replication/TestReplicationSupervisor.java
@@ -359,7 +359,7 @@ public class TestReplicationSupervisor {
 
   private static ReplicateContainerCommand createCommand(long containerId) {
     ReplicateContainerCommand cmd =
-        new ReplicateContainerCommand(containerId, emptyList());
+        ReplicateContainerCommand.forTest(containerId);
     cmd.setTerm(CURRENT_TERM);
     return cmd;
   }

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/upgrade/TestDatanodeUpgradeToScmHA.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/upgrade/TestDatanodeUpgradeToScmHA.java
@@ -40,10 +40,9 @@ import org.apache.hadoop.ozone.container.common.states.endpoint.VersionEndpointT
 import org.apache.hadoop.ozone.container.common.utils.HddsVolumeUtil;
 import org.apache.hadoop.ozone.container.keyvalue.KeyValueContainerData;
 import org.apache.hadoop.ozone.container.keyvalue.TarContainerPacker;
+import org.apache.hadoop.ozone.container.replication.ContainerImporter;
 import org.apache.hadoop.ozone.container.replication.ContainerReplicationSource;
-import org.apache.hadoop.ozone.container.replication.DownloadAndImportReplicator;
 import org.apache.hadoop.ozone.container.replication.OnDemandContainerReplicationSource;
-import org.apache.hadoop.ozone.container.replication.SimpleContainerDownloader;
 import org.apache.ozone.test.LambdaTestUtils;
 import org.junit.After;
 import org.junit.Assert;
@@ -666,11 +665,10 @@ public class TestDatanodeUpgradeToScmHA {
    * {@code containerID}.
    */
   public void importContainer(long containerID, File source) throws Exception {
-    DownloadAndImportReplicator replicator =
-        new DownloadAndImportReplicator(dsm.getConf(),
+    ContainerImporter replicator =
+        new ContainerImporter(dsm.getConf(),
             dsm.getContainer().getContainerSet(),
             dsm.getContainer().getController(),
-            new SimpleContainerDownloader(conf, null),
             new TarContainerPacker(), dsm.getContainer().getVolumeSet());
 
     File tempFile = tempFolder.newFile(

--- a/hadoop-hdds/interface-client/src/main/proto/DatanodeClientProtocol.proto
+++ b/hadoop-hdds/interface-client/src/main/proto/DatanodeClientProtocol.proto
@@ -505,10 +505,8 @@ message CopyContainerResponseProto {
 message SendContainerRequest {
   required int64 containerID = 1;
   required uint64 offset = 2;
-  required uint64 len = 3;
-  required bool eof = 4;
-  required bytes data = 5;
-  optional int64 checksum = 6;
+  required bytes data = 3;
+  optional int64 checksum = 4;
 }
 
 message SendContainerResponse {

--- a/hadoop-hdds/interface-client/src/main/proto/DatanodeClientProtocol.proto
+++ b/hadoop-hdds/interface-client/src/main/proto/DatanodeClientProtocol.proto
@@ -502,6 +502,18 @@ message CopyContainerResponseProto {
   optional int64 checksum = 6;
 }
 
+message SendContainerRequest {
+  required int64 containerID = 1;
+  required uint64 offset = 2;
+  required uint64 len = 3;
+  required bool eof = 4;
+  required bytes data = 5;
+  optional int64 checksum = 6;
+}
+
+message SendContainerResponse {
+}
+
 service XceiverClientProtocolService {
   // A client-to-datanode RPC to send container commands
   rpc send(stream ContainerCommandRequestProto) returns
@@ -512,4 +524,5 @@ service XceiverClientProtocolService {
 service IntraDatanodeProtocolService {
   // An intradatanode service to copy the raw container data between nodes
   rpc download (CopyContainerRequestProto) returns (stream CopyContainerResponseProto);
+  rpc upload (stream SendContainerRequest) returns (SendContainerResponse);
 }

--- a/hadoop-hdds/interface-server/src/main/proto/ScmServerDatanodeHeartbeatProtocol.proto
+++ b/hadoop-hdds/interface-server/src/main/proto/ScmServerDatanodeHeartbeatProtocol.proto
@@ -415,6 +415,7 @@ message ReplicateContainerCommandProto {
   repeated DatanodeDetailsProto sources = 2;
   required int64 cmdId = 3;
   optional int32 replicaIndex = 4;
+  optional DatanodeDetailsProto target = 5;
 }
 
 /**

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ECMisReplicationHandler.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ECMisReplicationHandler.java
@@ -26,7 +26,6 @@ import org.apache.hadoop.hdds.scm.node.NodeManager;
 import org.apache.hadoop.ozone.protocol.commands.ReplicateContainerCommand;
 
 import java.io.IOException;
-import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 
@@ -37,8 +36,8 @@ import java.util.Set;
 public class ECMisReplicationHandler extends MisReplicationHandler {
   public ECMisReplicationHandler(
           PlacementPolicy<ContainerReplica> containerPlacement,
-          ConfigurationSource conf, NodeManager nodeManager) {
-    super(containerPlacement, conf, nodeManager);
+          ConfigurationSource conf, NodeManager nodeManager, boolean push) {
+    super(containerPlacement, conf, nodeManager, push);
   }
 
   @Override
@@ -56,15 +55,12 @@ public class ECMisReplicationHandler extends MisReplicationHandler {
   }
 
   @Override
-  protected ReplicateContainerCommand getReplicateCommand(
-          ContainerInfo containerInfo, ContainerReplica replica) {
-    final ReplicateContainerCommand replicateCommand =
-            new ReplicateContainerCommand(containerInfo.getContainerID(),
-            Collections.singletonList(replica.getDatanodeDetails()));
+  protected ReplicateContainerCommand updateReplicateCommand(
+          ReplicateContainerCommand command, ContainerReplica replica) {
     // For EC containers, we need to track the replica index which is
     // to be replicated, so add it to the command.
-    replicateCommand.setReplicaIndex(replica.getReplicaIndex());
-    return replicateCommand;
+    command.setReplicaIndex(replica.getReplicaIndex());
+    return command;
   }
 
 

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ECUnderReplicationHandler.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ECUnderReplicationHandler.java
@@ -356,18 +356,7 @@ public class ECUnderReplicationHandler implements UnhealthyReplicationHandler {
                   replicas, selectedDatanodes, excludedNodes, decomIndexes);
               break;
             }
-            final boolean push = replicationManager.getConfig().isPush();
-            DatanodeDetails source = replica.getDatanodeDetails();
-            DatanodeDetails target = iterator.next();
-            final long containerID = container.getContainerID();
-            final ReplicateContainerCommand replicateCommand = push
-                ? ReplicateContainerCommand.toTarget(containerID, target)
-                : ReplicateContainerCommand.fromSources(containerID,
-                    ImmutableList.of(source));
-            // For EC containers, we need to track the replica index which is
-            // to be replicated, so add it to the command.
-            replicateCommand.setReplicaIndex(replica.getReplicaIndex());
-            commands.put(push ? source : target, replicateCommand);
+            createReplicateCommand(commands, container, iterator, replica);
           }
         }
       }
@@ -416,19 +405,28 @@ public class ECUnderReplicationHandler implements UnhealthyReplicationHandler {
               replicas, targets, excludedNodes, maintIndexes);
           break;
         }
-        DatanodeDetails maintenanceSourceNode = replica.getDatanodeDetails();
-        final ReplicateContainerCommand replicateCommand =
-            new ReplicateContainerCommand(
-                container.containerID().getProtobuf().getId(),
-                ImmutableList.of(maintenanceSourceNode));
-        // For EC containers we need to track the replica index which is
-        // to be replicated, so add it to the command.
-        replicateCommand.setReplicaIndex(replica.getReplicaIndex());
-        DatanodeDetails target = iterator.next();
-        commands.put(target, replicateCommand);
+        createReplicateCommand(commands, container, iterator, replica);
         additionalMaintenanceCopiesNeeded -= 1;
       }
     }
+  }
+
+  private void createReplicateCommand(
+      Map<DatanodeDetails, SCMCommand<?>> commands,
+      ContainerInfo container, Iterator<DatanodeDetails> iterator,
+      ContainerReplica replica) {
+    final boolean push = replicationManager.getConfig().isPush();
+    DatanodeDetails source = replica.getDatanodeDetails();
+    DatanodeDetails target = iterator.next();
+    final long containerID = container.getContainerID();
+    final ReplicateContainerCommand replicateCommand = push
+        ? ReplicateContainerCommand.toTarget(containerID, target)
+        : ReplicateContainerCommand.fromSources(containerID,
+            ImmutableList.of(source));
+    // For EC containers, we need to track the replica index which is
+    // to be replicated, so add it to the command.
+    replicateCommand.setReplicaIndex(replica.getReplicaIndex());
+    commands.put(push ? source : target, replicateCommand);
   }
 
   private static byte[] int2byte(List<Integer> src) {

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ECUnderReplicationHandler.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ECUnderReplicationHandler.java
@@ -356,16 +356,18 @@ public class ECUnderReplicationHandler implements UnhealthyReplicationHandler {
                   replicas, selectedDatanodes, excludedNodes, decomIndexes);
               break;
             }
-            DatanodeDetails decommissioningSrcNode
-                = replica.getDatanodeDetails();
-            final ReplicateContainerCommand replicateCommand =
-                new ReplicateContainerCommand(container.getContainerID(),
-                    ImmutableList.of(decommissioningSrcNode));
+            final boolean push = replicationManager.getConfig().isPush();
+            DatanodeDetails source = replica.getDatanodeDetails();
+            DatanodeDetails target = iterator.next();
+            final long containerID = container.getContainerID();
+            final ReplicateContainerCommand replicateCommand = push
+                ? ReplicateContainerCommand.toTarget(containerID, target)
+                : ReplicateContainerCommand.fromSources(containerID,
+                    ImmutableList.of(source));
             // For EC containers, we need to track the replica index which is
             // to be replicated, so add it to the command.
             replicateCommand.setReplicaIndex(replica.getReplicaIndex());
-            DatanodeDetails target = iterator.next();
-            commands.put(target, replicateCommand);
+            commands.put(push ? source : target, replicateCommand);
           }
         }
       }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/RatisMisReplicationHandler.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/RatisMisReplicationHandler.java
@@ -27,7 +27,6 @@ import org.apache.hadoop.hdds.scm.node.NodeManager;
 import org.apache.hadoop.ozone.protocol.commands.ReplicateContainerCommand;
 
 import java.io.IOException;
-import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 
@@ -39,8 +38,8 @@ public class RatisMisReplicationHandler extends MisReplicationHandler {
 
   public RatisMisReplicationHandler(
           PlacementPolicy<ContainerReplica> containerPlacement,
-          ConfigurationSource conf, NodeManager nodeManager) {
-    super(containerPlacement, conf, nodeManager);
+          ConfigurationSource conf, NodeManager nodeManager, boolean push) {
+    super(containerPlacement, conf, nodeManager, push);
   }
 
   @Override
@@ -70,9 +69,8 @@ public class RatisMisReplicationHandler extends MisReplicationHandler {
   }
 
   @Override
-  protected ReplicateContainerCommand getReplicateCommand(
-          ContainerInfo containerInfo, ContainerReplica replica) {
-    return new ReplicateContainerCommand(containerInfo.getContainerID(),
-            Collections.singletonList(replica.getDatanodeDetails()));
+  protected ReplicateContainerCommand updateReplicateCommand(
+          ReplicateContainerCommand command, ContainerReplica replica) {
+    return command;
   }
 }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ReplicationManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ReplicationManager.java
@@ -226,9 +226,9 @@ public class ReplicationManager implements SCMService {
     ecOverReplicationHandler =
         new ECOverReplicationHandler(ecContainerPlacement, nodeManager);
     ecMisReplicationHandler = new ECMisReplicationHandler(ecContainerPlacement,
-        conf, nodeManager);
+        conf, nodeManager, rmConf.isPush());
     ratisUnderReplicationHandler = new RatisUnderReplicationHandler(
-        ratisContainerPlacement, conf, nodeManager);
+        ratisContainerPlacement, conf, nodeManager, this);
     ratisOverReplicationHandler =
         new RatisOverReplicationHandler(ratisContainerPlacement);
     underReplicatedProcessor =

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ReplicationManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ReplicationManager.java
@@ -79,6 +79,7 @@ import java.util.concurrent.TimeoutException;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 
+import static org.apache.hadoop.hdds.conf.ConfigTag.DATANODE;
 import static org.apache.hadoop.hdds.conf.ConfigTag.OZONE;
 import static org.apache.hadoop.hdds.conf.ConfigTag.SCM;
 import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationType.EC;
@@ -861,6 +862,16 @@ public class ReplicationManager implements SCMService {
     )
     private int maintenanceRemainingRedundancy = 1;
 
+    @Config(key = "push",
+        type = ConfigType.BOOLEAN,
+        defaultValue = "false",
+        tags = { SCM, DATANODE },
+        description = "If false, replication happens by asking the target to " +
+            "pull from source nodes.  If true, the source node is asked to " +
+            "push to the target node."
+    )
+    private boolean push;
+
     @PostConstruct
     public void validate() {
       if (!(commandDeadlineFactor > 0) || (commandDeadlineFactor > 1)) {
@@ -904,6 +915,10 @@ public class ReplicationManager implements SCMService {
 
     public int getMaintenanceReplicaMinimum() {
       return maintenanceReplicaMinimum;
+    }
+
+    public boolean isPush() {
+      return push;
     }
   }
 
@@ -950,6 +965,10 @@ public class ReplicationManager implements SCMService {
 
   public synchronized ReplicationManagerMetrics getMetrics() {
     return metrics;
+  }
+
+  public ReplicationManagerConfiguration getConfig() {
+    return rmConf;
   }
 
 

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestECMisReplicationHandler.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestECMisReplicationHandler.java
@@ -169,6 +169,7 @@ public class TestECMisReplicationHandler extends TestMisReplicationHandler {
   protected MisReplicationHandler getMisreplicationHandler(
           PlacementPolicy placementPolicy, OzoneConfiguration conf,
           NodeManager nodeManager) {
-    return new ECMisReplicationHandler(placementPolicy, conf, nodeManager);
+    return new ECMisReplicationHandler(placementPolicy, conf, nodeManager,
+        false);
   }
 }

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestECUnderReplicationHandler.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestECUnderReplicationHandler.java
@@ -97,6 +97,10 @@ public class TestECUnderReplicationHandler {
       }
     };
     replicationManager = Mockito.mock(ReplicationManager.class);
+    ReplicationManager.ReplicationManagerConfiguration rmConf =
+        new ReplicationManager.ReplicationManagerConfiguration();
+    Mockito.when(replicationManager.getConfig())
+        .thenReturn(rmConf);
     conf = SCMTestUtils.getConf();
     repConfig = new ECReplicationConfig(DATA, PARITY);
     container = ReplicationTestUtil

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestRatisMisReplicationHandler.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestRatisMisReplicationHandler.java
@@ -173,6 +173,7 @@ public class TestRatisMisReplicationHandler extends TestMisReplicationHandler {
   protected MisReplicationHandler getMisreplicationHandler(
           PlacementPolicy placementPolicy, OzoneConfiguration conf,
           NodeManager nodeManager) {
-    return new RatisMisReplicationHandler(placementPolicy, conf, nodeManager);
+    return new RatisMisReplicationHandler(placementPolicy, conf, nodeManager,
+        false);
   }
 }

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestRatisUnderReplicationHandler.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestRatisUnderReplicationHandler.java
@@ -30,6 +30,7 @@ import org.apache.hadoop.hdds.scm.PlacementPolicy;
 import org.apache.hadoop.hdds.scm.container.ContainerInfo;
 import org.apache.hadoop.hdds.scm.container.ContainerReplica;
 import org.apache.hadoop.hdds.scm.container.replication.ContainerHealthResult.UnderReplicatedHealthResult;
+import org.apache.hadoop.hdds.scm.container.replication.ReplicationManager.ReplicationManagerConfiguration;
 import org.apache.hadoop.hdds.scm.node.NodeManager;
 import org.apache.hadoop.hdds.scm.node.NodeStatus;
 import org.apache.hadoop.hdds.scm.node.states.NodeNotFoundException;
@@ -61,6 +62,7 @@ public class TestRatisUnderReplicationHandler {
   private static final RatisReplicationConfig RATIS_REPLICATION_CONFIG =
       RatisReplicationConfig.getInstance(HddsProtos.ReplicationFactor.THREE);
   private PlacementPolicy policy;
+  private ReplicationManager replicationManager;
 
   @Before
   public void setup() throws NodeNotFoundException {
@@ -71,6 +73,9 @@ public class TestRatisUnderReplicationHandler {
     conf = SCMTestUtils.getConf();
     policy = ReplicationTestUtil
         .getSimpleTestPlacementPolicy(nodeManager, conf);
+    replicationManager = Mockito.mock(ReplicationManager.class);
+    Mockito.when(replicationManager.getConfig())
+        .thenReturn(new ReplicationManagerConfiguration());
 
     /*
      Return NodeStatus with NodeOperationalState as specified in
@@ -183,7 +188,8 @@ public class TestRatisUnderReplicationHandler {
     policy = ReplicationTestUtil.getNoNodesTestPlacementPolicy(nodeManager,
         conf);
     RatisUnderReplicationHandler handler =
-        new RatisUnderReplicationHandler(policy, conf, nodeManager);
+        new RatisUnderReplicationHandler(policy, conf, nodeManager,
+            replicationManager);
 
     Set<ContainerReplica> replicas
         = createReplicas(container.containerID(), State.CLOSED, 0, 0);
@@ -211,7 +217,8 @@ public class TestRatisUnderReplicationHandler {
       ContainerHealthResult healthResult,
       int minHealthyForMaintenance, int expectNumCommands) throws IOException {
     RatisUnderReplicationHandler handler =
-        new RatisUnderReplicationHandler(policy, conf, nodeManager);
+        new RatisUnderReplicationHandler(policy, conf, nodeManager,
+            replicationManager);
 
     Map<DatanodeDetails, SCMCommand<?>> commands =
         handler.processAndCreateCommands(replicas, pendingOps,

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestReplicationManager.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestReplicationManager.java
@@ -576,7 +576,7 @@ public class TestReplicationManager {
     sources.add(MockDatanodeDetails.randomDatanodeDetails());
 
 
-    ReplicateContainerCommand command = new ReplicateContainerCommand(
+    ReplicateContainerCommand command = ReplicateContainerCommand.fromSources(
         containerInfo.getContainerID(), sources);
     command.setReplicaIndex(1);
 
@@ -611,7 +611,7 @@ public class TestReplicationManager {
     containerInfo = ReplicationTestUtil.createContainerInfo(ratisRepConfig, 2,
         HddsProtos.LifeCycleState.CLOSED, 10, 20);
 
-    command = new ReplicateContainerCommand(
+    command = ReplicateContainerCommand.fromSources(
         containerInfo.getContainerID(), sources);
     replicationManager.sendDatanodeCommand(command, containerInfo, target);
 

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestUnderReplicatedProcessor.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestUnderReplicatedProcessor.java
@@ -111,7 +111,7 @@ public class TestUnderReplicatedProcessor {
     List<DatanodeDetails> sourceDns = new ArrayList<>();
     sourceDns.add(MockDatanodeDetails.randomDatanodeDetails());
     DatanodeDetails targetDn = MockDatanodeDetails.randomDatanodeDetails();
-    ReplicateContainerCommand rcc = new ReplicateContainerCommand(
+    ReplicateContainerCommand rcc = ReplicateContainerCommand.fromSources(
         container.getContainerID(), sourceDns);
     rcc.setReplicaIndex(3);
 

--- a/hadoop-ozone/dist/src/main/compose/ozonesecure/docker-config
+++ b/hadoop-ozone/dist/src/main/compose/ozonesecure/docker-config
@@ -68,6 +68,7 @@ OZONE-SITE.XML_ozone.s3g.kerberos.principal=s3g/s3g@EXAMPLE.COM
 
 OZONE-SITE.XML_hdds.scm.replication.thread.interval=5s
 OZONE-SITE.XML_hdds.scm.replication.event.timeout=10s
+OZONE-SITE.XML_hdds.scm.replication.push=true
 OZONE-SITE.XML_ozone.scm.stale.node.interval=30s
 OZONE-SITE.XML_ozone.scm.dead.node.interval=45s
 OZONE-SITE.XML_hdds.container.report.interval=60s

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/TestSCMDatanodeProtocolServer.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/TestSCMDatanodeProtocolServer.java
@@ -25,7 +25,6 @@ import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 import java.io.IOException;
-import java.util.Collections;
 import java.util.concurrent.TimeoutException;
 
 /**
@@ -39,8 +38,7 @@ public class TestSCMDatanodeProtocolServer {
     OzoneStorageContainerManager scm =
         Mockito.mock(OzoneStorageContainerManager.class);
 
-    ReplicateContainerCommand command = new ReplicateContainerCommand(1L,
-        Collections.emptyList());
+    ReplicateContainerCommand command = ReplicateContainerCommand.forTest(1);
     command.setTerm(5L);
     command.setDeadline(1234L);
     StorageContainerDatanodeProtocolProtos.SCMCommandProto proto =

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/ClosedContainerReplicator.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/ClosedContainerReplicator.java
@@ -129,7 +129,7 @@ public class ClosedContainerReplicator extends BaseFreonGenerator implements
         //replica.
         if (datanode.isEmpty() || datanodeUUIDs.contains(datanode)) {
           replicationTasks.add(new ReplicationTask(
-              new ReplicateContainerCommand(container.getContainerID(),
+              ReplicateContainerCommand.fromSources(container.getContainerID(),
                   datanodesWithContainer)));
         }
       }

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/ClosedContainerReplicator.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/ClosedContainerReplicator.java
@@ -35,6 +35,7 @@ import org.apache.hadoop.ozone.container.common.volume.MutableVolumeSet;
 import org.apache.hadoop.ozone.container.common.volume.StorageVolume;
 import org.apache.hadoop.ozone.container.keyvalue.TarContainerPacker;
 import org.apache.hadoop.ozone.container.ozoneimpl.ContainerController;
+import org.apache.hadoop.ozone.container.replication.ContainerImporter;
 import org.apache.hadoop.ozone.container.replication.ContainerReplicator;
 import org.apache.hadoop.ozone.container.replication.DownloadAndImportReplicator;
 import org.apache.hadoop.ozone.container.replication.ReplicationServer;
@@ -202,16 +203,16 @@ public class ClosedContainerReplicator extends BaseFreonGenerator implements
     ContainerController controller =
         new ContainerController(containerSet, handlers);
 
-    ContainerReplicator replicator =
-        new DownloadAndImportReplicator(conf, containerSet,
-            controller,
-            new SimpleContainerDownloader(conf, null),
-            new TarContainerPacker(), null);
+    ContainerImporter importer = new ContainerImporter(conf, containerSet,
+        controller, new TarContainerPacker(), null);
+    ContainerReplicator replicator = new DownloadAndImportReplicator(importer,
+        new SimpleContainerDownloader(conf, null));
 
     ReplicationServer.ReplicationConfig replicationConfig
         = conf.getObject(ReplicationServer.ReplicationConfig.class);
     supervisor = new ReplicationSupervisor(containerSet, null,
-        replicator, replicationConfig, Clock.system(ZoneId.systemDefault()));
+        replicator, null, replicationConfig,
+        Clock.system(ZoneId.systemDefault()));
   }
 
   private void replicateContainer(long counter) throws Exception {


### PR DESCRIPTION
## What changes were proposed in this pull request?

Container replication works in a pull model: SCM asks the target datanode to download the container, listing available source datanodes.

The goal of this change is to add an alternative implementation, where the source datanode pushes the container to some target datanode.

The new push model is disabled by default, can be enabled by setting `hdds.scm.replication.push=true`.

~This is a draft, because I still need to add unit tests.~ (created HDDS-7806 for adding the unit tests) 

https://issues.apache.org/jira/browse/HDDS-7777

## How was this patch tested?

The patch enabled push replication in `ozonesecure` environment, which includes a simple Ratis re-replication test.

https://github.com/adoroszlai/hadoop-ozone/actions/runs/3970334317

Also tested with push replication enabled by default on a "test" branch:

https://github.com/adoroszlai/hadoop-ozone/actions/runs/3970335804