### PR TITLE
HDDS-7819. [snapshot] Add unit-testcases for fs delete of bucket havng snapshots

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFsSnapshot.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFsSnapshot.java
@@ -305,6 +305,17 @@ public class TestOzoneFsSnapshot {
       res = ToolRunner.run(shell,
               new String[]{"-rm", "-r", "-skipTrash", testVolBucket});
       assertEquals(1, res);
+
+      res = ToolRunner.run(shell,
+              new String[]{"-ls", testVolBucket});
+      assertEquals(0, res);
+
+      String snapshotPath = testVolBucket + OM_KEY_PREFIX + ".snapshot"
+              + OM_KEY_PREFIX + snapshotName + OM_KEY_PREFIX;
+      res = ToolRunner.run(shell,
+              new String[]{"-ls", snapshotPath});
+      assertEquals(0, res);
+
     } finally {
       shell.close();
     }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFsSnapshot.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFsSnapshot.java
@@ -278,4 +278,35 @@ public class TestOzoneFsSnapshot {
       shell.close();
     }
   }
+
+  @Test
+  public void testDeleteBucketWithSnapshot() throws Exception {
+    String volume = "vol-" + RandomStringUtils.randomNumeric(5);
+    String bucket = "buc-" + RandomStringUtils.randomNumeric(5);
+    String key = "key-" + RandomStringUtils.randomNumeric(5);
+    String snapshotName = "snap-" + RandomStringUtils.randomNumeric(5);
+
+    String testVolBucket = OM_KEY_PREFIX + volume + OM_KEY_PREFIX + bucket;
+    String testKey = testVolBucket + OM_KEY_PREFIX + key;
+
+    createVolBuckKey(testVolBucket, testKey);
+
+    OzoneFsShell shell = new OzoneFsShell(clientConf);
+    try {
+      int res = ToolRunner.run(shell,
+              new String[]{"-createSnapshot", testVolBucket, snapshotName});
+      // Asserts that create request succeeded
+      assertEquals(0, res);
+
+      res = ToolRunner.run(shell,
+              new String[]{"-rm", "-r", "-skipTrash", testKey});
+      assertEquals(0, res);
+
+      res = ToolRunner.run(shell,
+              new String[]{"-rm", "-r", "-skipTrash", testVolBucket});
+      assertEquals(1, res);
+    } finally {
+      shell.close();
+    }
+  }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Add unit-testcases for fs delete of bucket havng snapshots - `TestOzoneFsSnapshot#testDeleteBucketWithSnapshot`

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-7819

## How was this patch tested?

Testcase file - `hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFsSnapshot.java`
```
mvn -Dtest=TestOzoneFsSnapshot#testDeleteBucketWithSnapshot test
[INFO] -------------------------------------------------------
[INFO]  T E S T S
[INFO] -------------------------------------------------------
[INFO] Running org.apache.hadoop.fs.ozone.TestOzoneFsSnapshot
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 54.886 s - in org.apache.hadoop.fs.ozone.TestOzoneFsSnapshot
[INFO]
[INFO] Results:
[INFO]
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0
[INFO]
```
