### PR TITLE
HDDS-7820. Store container descriptor at start of tar archive

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/TarContainerPacker.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/TarContainerPacker.java
@@ -167,13 +167,13 @@ public class TarContainerPacker
     KeyValueContainerData containerData = container.getContainerData();
 
     try (ArchiveOutputStream archiveOutput = tar(compress(output))) {
+      includeFile(container.getContainerFile(), CONTAINER_FILE_NAME,
+          archiveOutput);
+
       includePath(getDbPath(containerData), DB_DIR_NAME,
           archiveOutput);
 
       includePath(Paths.get(containerData.getChunksPath()), CHUNKS_DIR_NAME,
-          archiveOutput);
-
-      includeFile(container.getContainerFile(), CONTAINER_FILE_NAME,
           archiveOutput);
     } catch (CompressorException e) {
       throw new IOException(

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/TarContainerPacker.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/TarContainerPacker.java
@@ -67,7 +67,7 @@ public class TarContainerPacker
 
   static final String DB_DIR_NAME = "db";
 
-  private static final String CONTAINER_FILE_NAME = "container.yaml";
+  static final String CONTAINER_FILE_NAME = "container.yaml";
 
   private final String compression;
 

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/TarContainerPacker.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/TarContainerPacker.java
@@ -263,6 +263,7 @@ public class TarContainerPacker
     // empty.
     ArchiveEntry entry = archiveOutput.createArchiveEntry(dir.toFile(), subdir);
     archiveOutput.putArchiveEntry(entry);
+    archiveOutput.closeArchiveEntry();
 
     // Add files in the directory.
     try (Stream<Path> dirEntries = Files.list(dir)) {

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/TestTarContainerPacker.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/TestTarContainerPacker.java
@@ -59,6 +59,7 @@ import org.junit.runners.Parameterized;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.nio.file.Files.newInputStream;
 import static java.nio.file.Files.newOutputStream;
+import static org.apache.hadoop.ozone.container.keyvalue.TarContainerPacker.CONTAINER_FILE_NAME;
 
 /**
  * Test the tar/untar for a given container.
@@ -199,15 +200,18 @@ public class TestTarContainerPacker {
       InputStream uncompressed = packer.decompress(input);
       tarStream = new TarArchiveInputStream(uncompressed);
 
+      boolean first = true;
       TarArchiveEntry entry;
       Map<String, TarArchiveEntry> entries = new HashMap<>();
       while ((entry = tarStream.getNextTarEntry()) != null) {
+        if (first) {
+          Assert.assertEquals(CONTAINER_FILE_NAME, entry.getName());
+          first = false;
+        }
         entries.put(entry.getName(), entry);
       }
 
-      Assert.assertTrue(
-          entries.containsKey("container.yaml"));
-
+      Assert.assertTrue(entries.containsKey(CONTAINER_FILE_NAME));
     } finally {
       if (tarStream != null) {
         tarStream.close();


### PR DESCRIPTION
## What changes were proposed in this pull request?

`DownloadAndImportReplicator` extracts container descriptor (`container.yaml`) as a first step when importing the container.

> A tar file isn't really indexed, and it doesn't have a "directory listing" section to list the files in it, it skips from one file header to the next seeking down the file. So if this file is always at the end, it must check all other file headers in the archive first.

Currently the descriptor is stored at the end of the tarball, so the import process needs to read the entire tarball twice.

This change moves the descriptor to the start of the archive.

https://issues.apache.org/jira/browse/HDDS-7820

## How was this patch tested?

Added an assertion about position of the descriptor.

Regular CI:
https://github.com/adoroszlai/hadoop-ozone/actions/runs/3988198928