### PR TITLE
HDDS-7833. EC: Refactor ReplicationSupervisor to allow Replication and ECReconstruction tasks

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/DatanodeStateMachine.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/DatanodeStateMachine.java
@@ -193,9 +193,7 @@ public class DatanodeStateMachine implements Closeable {
 
     ReplicationConfig replicationConfig =
         conf.getObject(ReplicationConfig.class);
-    supervisor =
-        new ReplicationSupervisor(container.getContainerSet(), context,
-            replicatorMetrics, pushReplicator, replicationConfig, clock);
+    supervisor = new ReplicationSupervisor(context, replicationConfig, clock);
 
     replicationSupervisorMetrics =
         ReplicationSupervisorMetrics.create(supervisor);

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/DatanodeStateMachine.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/DatanodeStateMachine.java
@@ -217,7 +217,8 @@ public class DatanodeStateMachine implements Closeable {
         .addHandler(new DeleteBlocksCommandHandler(getContainer(),
             conf, dnConf.getBlockDeleteThreads(),
             dnConf.getBlockDeleteQueueLimit()))
-        .addHandler(new ReplicateContainerCommandHandler(conf, supervisor))
+        .addHandler(new ReplicateContainerCommandHandler(conf, supervisor,
+            replicatorMetrics))
         .addHandler(new ReconstructECContainersCommandHandler(conf,
             ecReconstructionSupervisor))
         .addHandler(new DeleteContainerCommandHandler(

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/DatanodeStateMachine.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/DatanodeStateMachine.java
@@ -180,6 +180,7 @@ public class DatanodeStateMachine implements Closeable {
         container.getController(),
         new TarContainerPacker(), container.getVolumeSet());
     ContainerReplicator pullReplicator = new DownloadAndImportReplicator(
+        container.getContainerSet(),
         importer,
         new SimpleContainerDownloader(conf, dnCertClient));
     ContainerReplicator pushReplicator = new PushReplicator(

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/DatanodeStateMachine.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/DatanodeStateMachine.java
@@ -219,7 +219,7 @@ public class DatanodeStateMachine implements Closeable {
             conf, dnConf.getBlockDeleteThreads(),
             dnConf.getBlockDeleteQueueLimit()))
         .addHandler(new ReplicateContainerCommandHandler(conf, supervisor,
-            replicatorMetrics))
+            replicatorMetrics, pushReplicator))
         .addHandler(new ReconstructECContainersCommandHandler(conf,
             ecReconstructionSupervisor))
         .addHandler(new DeleteContainerCommandHandler(

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/ReplicateContainerCommandHandler.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/ReplicateContainerCommandHandler.java
@@ -51,15 +51,19 @@ public class ReplicateContainerCommandHandler implements CommandHandler {
 
   private ReplicationSupervisor supervisor;
 
-  private ContainerReplicator replicator;
+  private ContainerReplicator downloadReplicator;
+
+  private ContainerReplicator pushReplicator;
 
   public ReplicateContainerCommandHandler(
       ConfigurationSource conf,
       ReplicationSupervisor supervisor,
-      ContainerReplicator replicator) {
+      ContainerReplicator downloadReplicator,
+      ContainerReplicator pushReplicator) {
     this.conf = conf;
     this.supervisor = supervisor;
-    this.replicator = replicator;
+    this.downloadReplicator = downloadReplicator;
+    this.pushReplicator = pushReplicator;
   }
 
   @Override
@@ -76,6 +80,10 @@ public class ReplicateContainerCommandHandler implements CommandHandler {
     Preconditions.checkArgument(!sourceDatanodes.isEmpty() || target != null,
         "Replication command is received for container %s "
             + "without source or target datanodes.", containerID);
+
+    ContainerReplicator replicator =
+        replicateCommand.getTargetDatanode() == null ?
+            downloadReplicator : pushReplicator;
 
     ReplicationTask task = new ReplicationTask(replicateCommand, replicator);
     supervisor.addTask(task);

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/ReplicateContainerCommandHandler.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/ReplicateContainerCommandHandler.java
@@ -25,6 +25,7 @@ import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolPro
 import org.apache.hadoop.ozone.container.common.statemachine.SCMConnectionManager;
 import org.apache.hadoop.ozone.container.common.statemachine.StateContext;
 import org.apache.hadoop.ozone.container.ozoneimpl.OzoneContainer;
+import org.apache.hadoop.ozone.container.replication.ContainerReplicator;
 import org.apache.hadoop.ozone.container.replication.ReplicationSupervisor;
 import org.apache.hadoop.ozone.container.replication.ReplicationTask;
 import org.apache.hadoop.ozone.protocol.commands.ReplicateContainerCommand;
@@ -50,11 +51,15 @@ public class ReplicateContainerCommandHandler implements CommandHandler {
 
   private ReplicationSupervisor supervisor;
 
+  private ContainerReplicator replicator;
+
   public ReplicateContainerCommandHandler(
       ConfigurationSource conf,
-      ReplicationSupervisor supervisor) {
+      ReplicationSupervisor supervisor,
+      ContainerReplicator replicator) {
     this.conf = conf;
     this.supervisor = supervisor;
+    this.replicator = replicator;
   }
 
   @Override
@@ -72,7 +77,7 @@ public class ReplicateContainerCommandHandler implements CommandHandler {
         "Replication command is received for container %s "
             + "without source or target datanodes.", containerID);
 
-    ReplicationTask task = new ReplicationTask(replicateCommand);
+    ReplicationTask task = new ReplicationTask(replicateCommand, replicator);
     supervisor.addTask(task);
   }
 

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/ec/reconstruction/ECReconstructionCoordinatorTask.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/ec/reconstruction/ECReconstructionCoordinatorTask.java
@@ -17,6 +17,7 @@
  */
 package org.apache.hadoop.ozone.container.ec.reconstruction;
 
+import org.apache.hadoop.ozone.container.replication.AbstractReplicationTask;
 import org.apache.hadoop.util.Time;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -29,7 +30,8 @@ import java.util.concurrent.ConcurrentHashMap;
 /**
  * This is the actual EC reconstruction coordination task.
  */
-public class ECReconstructionCoordinatorTask implements Runnable {
+public class ECReconstructionCoordinatorTask
+    extends AbstractReplicationTask implements Runnable {
   private static final Logger LOG =
       LoggerFactory.getLogger(ECReconstructionCoordinatorTask.class);
   private final ConcurrentHashMap.KeySetView<Object, Boolean> inprogressCounter;
@@ -43,6 +45,9 @@ public class ECReconstructionCoordinatorTask implements Runnable {
       ConcurrentHashMap.KeySetView<Object, Boolean>
           inprogressReconstructionCoordinatorCounter,
       Clock clock) {
+    super(reconstructionCommandInfo.getContainerID(),
+        reconstructionCommandInfo.getDeadline(),
+        reconstructionCommandInfo.getTerm());
     this.reconstructionCoordinator = coordinator;
     this.reconstructionCommandInfo = reconstructionCommandInfo;
     this.inprogressCounter = inprogressReconstructionCoordinatorCounter;
@@ -50,7 +55,7 @@ public class ECReconstructionCoordinatorTask implements Runnable {
   }
 
   @Override
-  public void run() {
+  public void runTask() {
     // Implement the coordinator logic to handle a container group
     // reconstruction.
 
@@ -106,5 +111,10 @@ public class ECReconstructionCoordinatorTask implements Runnable {
   @Override
   public String toString() {
     return "ECReconstructionTask{info=" + reconstructionCommandInfo + '}';
+  }
+
+  @Override
+  public void run() {
+    runTask();
   }
 }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/replication/AbstractReplicationTask.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/replication/AbstractReplicationTask.java
@@ -85,6 +85,6 @@ public abstract class AbstractReplicationTask {
    * Abstract method which needs to be overridden by the sub classes to execute
    * the task.
    */
-  public abstract void run();
+  public abstract void runTask();
 
 }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/replication/AbstractReplicationTask.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/replication/AbstractReplicationTask.java
@@ -1,0 +1,90 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.apache.hadoop.ozone.container.replication;
+
+import java.time.Instant;
+
+/**
+ * Abstract class to capture common variables and methods for different types
+ * of replication tasks.
+ */
+public abstract class AbstractReplicationTask {
+
+  /**
+   * ENUM representing the different status values a replication task can
+   * have.
+   */
+  public enum Status {
+    QUEUED,
+    IN_PROGRESS,
+    DOWNLOADING, // TODO - remove
+    FAILED,
+    DONE
+  }
+
+  private volatile Status status = Status.QUEUED;
+
+  private final long containerId;
+
+  private final Instant queued = Instant.now();
+
+  private final long deadlineMsSinceEpoch;
+
+  private final long term;
+
+  protected AbstractReplicationTask(long containerID,
+      long deadlineMsSinceEpoch, long term) {
+    this.containerId = containerID;
+    this.deadlineMsSinceEpoch = deadlineMsSinceEpoch;
+    this.term = term;
+  }
+
+  public long getContainerId() {
+    return containerId;
+  }
+  public Status getStatus() {
+    return status;
+  }
+
+  protected void setStatus(Status newStatus) {
+    this.status = newStatus;
+  }
+
+  public Instant getQueued() {
+    return queued;
+  }
+
+  public long getTerm() {
+    return term;
+  }
+
+  /**
+   * Returns any deadline set on this task, in milliseconds since the epoch.
+   * A returned value of zero indicates no deadline.
+   */
+  public long getDeadline() {
+    return deadlineMsSinceEpoch;
+  }
+
+  /**
+   * Abstract method which needs to be overridden by the sub classes to execute
+   * the task.
+   */
+  public abstract void run();
+
+}

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/replication/AbstractReplicationTask.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/replication/AbstractReplicationTask.java
@@ -32,9 +32,9 @@ public abstract class AbstractReplicationTask {
   public enum Status {
     QUEUED,
     IN_PROGRESS,
-    DOWNLOADING, // TODO - remove
     FAILED,
-    DONE
+    DONE,
+    SKIPPED
   }
 
   private volatile Status status = Status.QUEUED;

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/replication/DownloadAndImportReplicator.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/replication/DownloadAndImportReplicator.java
@@ -23,6 +23,7 @@ import java.nio.file.Path;
 import java.util.List;
 
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
+import org.apache.hadoop.ozone.container.common.impl.ContainerSet;
 import org.apache.hadoop.ozone.container.common.volume.HddsVolume;
 import org.apache.hadoop.ozone.container.replication.AbstractReplicationTask.Status;
 
@@ -42,10 +43,13 @@ public class DownloadAndImportReplicator implements ContainerReplicator {
 
   private final ContainerDownloader downloader;
   private final ContainerImporter containerImporter;
+  private final ContainerSet containerSet;
 
   public DownloadAndImportReplicator(
+      ContainerSet containerSet,
       ContainerImporter containerImporter,
       ContainerDownloader downloader) {
+    this.containerSet = containerSet;
     this.downloader = downloader;
     this.containerImporter = containerImporter;
   }
@@ -53,6 +57,11 @@ public class DownloadAndImportReplicator implements ContainerReplicator {
   @Override
   public void replicate(ReplicationTask task) {
     long containerID = task.getContainerId();
+    if (containerSet.getContainer(containerID) != null) {
+      LOG.debug("Container {} has already been downloaded.", containerID);
+      task.setStatus(Status.SKIPPED);
+      return;
+    }
 
     List<DatanodeDetails> sourceDatanodes = task.getSources();
 

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/replication/DownloadAndImportReplicator.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/replication/DownloadAndImportReplicator.java
@@ -24,7 +24,7 @@ import java.util.List;
 
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
 import org.apache.hadoop.ozone.container.common.volume.HddsVolume;
-import org.apache.hadoop.ozone.container.replication.ReplicationTask.Status;
+import org.apache.hadoop.ozone.container.replication.AbstractReplicationTask.Status;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/replication/MeasuredReplicator.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/replication/MeasuredReplicator.java
@@ -25,7 +25,7 @@ import org.apache.hadoop.metrics2.annotation.Metrics;
 import org.apache.hadoop.metrics2.lib.DefaultMetricsSystem;
 import org.apache.hadoop.metrics2.lib.MutableCounterLong;
 import org.apache.hadoop.metrics2.lib.MutableGaugeLong;
-import org.apache.hadoop.ozone.container.replication.ReplicationTask.Status;
+import org.apache.hadoop.ozone.container.replication.AbstractReplicationTask.Status;
 
 import com.google.common.annotations.VisibleForTesting;
 import org.apache.hadoop.util.Time;

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/replication/PushReplicator.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/replication/PushReplicator.java
@@ -19,7 +19,7 @@ package org.apache.hadoop.ozone.container.replication;
 
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
 import org.apache.hadoop.hdds.utils.IOUtils;
-import org.apache.hadoop.ozone.container.replication.ReplicationTask.Status;
+import org.apache.hadoop.ozone.container.replication.AbstractReplicationTask.Status;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/replication/ReplicationSupervisor.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/replication/ReplicationSupervisor.java
@@ -32,7 +32,7 @@ import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.ozone.container.common.impl.ContainerSet;
 import org.apache.hadoop.ozone.container.common.statemachine.StateContext;
 import org.apache.hadoop.ozone.container.replication.ReplicationServer.ReplicationConfig;
-import org.apache.hadoop.ozone.container.replication.ReplicationTask.Status;
+import org.apache.hadoop.ozone.container.replication.AbstractReplicationTask.Status;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/replication/ReplicationSupervisor.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/replication/ReplicationSupervisor.java
@@ -65,7 +65,7 @@ public class ReplicationSupervisor {
    * or queued for download. Tracked so we don't schedule > 1
    * concurrent download for the same container.
    */
-  private final Set<ReplicationTask> inFlight;
+  private final Set<AbstractReplicationTask> inFlight;
 
   @VisibleForTesting
   ReplicationSupervisor(
@@ -100,7 +100,7 @@ public class ReplicationSupervisor {
   /**
    * Queue an asynchronous download of the given container.
    */
-  public void addTask(ReplicationTask task) {
+  public void addTask(AbstractReplicationTask task) {
     if (inFlight.add(task)) {
       executor.execute(new TaskRunner(task));
     }
@@ -175,12 +175,6 @@ public class ReplicationSupervisor {
           }
         }
 
-        // TODO - remove this commented blocks and put replicator choice into
-        //  the cmd
-        // task.setStatus(Status.IN_PROGRESS);
-        // ContainerReplicator replicator = pull ?
-        //     pullReplicator : pushReplicator;
-        // replicator.replicate(task);
         task.setStatus(Status.IN_PROGRESS);
         task.runTask();
         if (task.getStatus() == Status.FAILED) {

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/replication/ReplicationSupervisor.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/replication/ReplicationSupervisor.java
@@ -29,7 +29,6 @@ import java.util.concurrent.atomic.AtomicLong;
 
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
-import org.apache.hadoop.ozone.container.common.impl.ContainerSet;
 import org.apache.hadoop.ozone.container.common.statemachine.StateContext;
 import org.apache.hadoop.ozone.container.replication.ReplicationServer.ReplicationConfig;
 import org.apache.hadoop.ozone.container.replication.AbstractReplicationTask.Status;
@@ -47,9 +46,6 @@ public class ReplicationSupervisor {
   private static final Logger LOG =
       LoggerFactory.getLogger(ReplicationSupervisor.class);
 
-  private final ContainerSet containerSet;
-  private final ContainerReplicator pullReplicator;
-  private final ContainerReplicator pushReplicator;
   private final ExecutorService executor;
   private final StateContext context;
   private final Clock clock;
@@ -69,13 +65,7 @@ public class ReplicationSupervisor {
 
   @VisibleForTesting
   ReplicationSupervisor(
-      ContainerSet containerSet, StateContext context,
-      ContainerReplicator pullReplicator, ContainerReplicator pushReplicator,
-      ExecutorService executor,
-      Clock clock) {
-    this.containerSet = containerSet;
-    this.pullReplicator = pullReplicator;
-    this.pushReplicator = pushReplicator;
+      StateContext context, ExecutorService executor, Clock clock) {
     this.inFlight = ConcurrentHashMap.newKeySet();
     this.executor = executor;
     this.context = context;
@@ -83,10 +73,8 @@ public class ReplicationSupervisor {
   }
 
   public ReplicationSupervisor(
-      ContainerSet containerSet, StateContext context,
-      ContainerReplicator pullReplicator, ContainerReplicator pushReplicator,
-      ReplicationConfig replicationConfig, Clock clock) {
-    this(containerSet, context, pullReplicator, pushReplicator,
+      StateContext context, ReplicationConfig replicationConfig, Clock clock) {
+    this(context,
         new ThreadPoolExecutor(
             replicationConfig.getReplicationMaxStreams(),
             replicationConfig.getReplicationMaxStreams(), 60, TimeUnit.SECONDS,

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/replication/ReplicationSupervisorMetrics.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/replication/ReplicationSupervisorMetrics.java
@@ -69,6 +69,9 @@ public class ReplicationSupervisorMetrics implements MetricsSource {
             supervisor.getReplicationRequestCount())
         .addGauge(Interns.info("numTimeoutReplications",
             "Number of replication requests timed out before being processed"),
-            supervisor.getReplicationTimeoutCount());
+            supervisor.getReplicationTimeoutCount())
+        .addGauge(Interns.info("numSkippedReplications",
+            "Number of replication requests skipped as the container is "
+            + "already present"), supervisor.getReplicationSkippedCount());
   }
 }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/replication/ReplicationTask.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/replication/ReplicationTask.java
@@ -94,7 +94,7 @@ public class ReplicationTask extends AbstractReplicationTask {
   }
 
   @Override
-  public void run() {
+  public void runTask() {
     // Placeholder for now
   }
 }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/replication/ReplicationTask.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/replication/ReplicationTask.java
@@ -28,18 +28,31 @@ import org.apache.hadoop.ozone.protocol.commands.ReplicateContainerCommand;
  */
 public class ReplicationTask extends AbstractReplicationTask {
 
-  private volatile Status status = Status.QUEUED;
-
   private final ReplicateContainerCommand cmd;
+  private final ContainerReplicator replicator;
 
   /**
    * Counter for the transferred bytes.
    */
   private long transferredBytes;
 
-  public ReplicationTask(ReplicateContainerCommand cmd) {
+  public ReplicationTask(ReplicateContainerCommand cmd,
+                         ContainerReplicator replicator) {
     super(cmd.getContainerID(), cmd.getDeadline(), cmd.getTerm());
     this.cmd = cmd;
+    this.replicator = replicator;
+  }
+
+  /**
+   * Intended to only be used in tests.
+   */
+  protected ReplicationTask(
+      long containerId,
+      List<DatanodeDetails> sources,
+      ContainerReplicator replicator
+  ) {
+    this(ReplicateContainerCommand.fromSources(containerId, sources),
+        replicator);
   }
 
   @Override
@@ -95,6 +108,6 @@ public class ReplicationTask extends AbstractReplicationTask {
 
   @Override
   public void runTask() {
-    // Placeholder for now
+    replicator.replicate(this);
   }
 }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/replication/ReplicationTask.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/replication/ReplicationTask.java
@@ -17,7 +17,6 @@
  */
 package org.apache.hadoop.ozone.container.replication;
 
-import java.time.Instant;
 import java.util.List;
 import java.util.Objects;
 
@@ -27,11 +26,9 @@ import org.apache.hadoop.ozone.protocol.commands.ReplicateContainerCommand;
 /**
  * The task to download a container from the sources.
  */
-public class ReplicationTask {
+public class ReplicationTask extends AbstractReplicationTask {
 
   private volatile Status status = Status.QUEUED;
-
-  private final Instant queued = Instant.now();
 
   private final ReplicateContainerCommand cmd;
 
@@ -41,15 +38,8 @@ public class ReplicationTask {
   private long transferredBytes;
 
   public ReplicationTask(ReplicateContainerCommand cmd) {
+    super(cmd.getContainerID(), cmd.getDeadline(), cmd.getTerm());
     this.cmd = cmd;
-  }
-
-  /**
-   * Returns any deadline set on this task, in milliseconds since the epoch.
-   * A returned value of zero indicates no deadline.
-   */
-  public long getDeadline() {
-    return cmd.getDeadline();
   }
 
   @Override
@@ -78,25 +68,13 @@ public class ReplicationTask {
     return cmd.getSourceDatanodes();
   }
 
-  public Status getStatus() {
-    return status;
-  }
-
-  public void setStatus(Status status) {
-    this.status = status;
-  }
-
   @Override
   public String toString() {
     return "ReplicationTask{" +
-        "status=" + status +
+        "status=" + getStatus() +
         ", cmd={" + cmd + "}" +
-        ", queued=" + queued +
+        ", queued=" + getQueued() +
         '}';
-  }
-
-  public Instant getQueued() {
-    return queued;
   }
 
   public long getTransferredBytes() {
@@ -107,10 +85,6 @@ public class ReplicationTask {
     this.transferredBytes = transferredBytes;
   }
 
-  long getTerm() {
-    return cmd.getTerm();
-  }
-
   DatanodeDetails getTarget() {
     return cmd.getTargetDatanode();
   }
@@ -119,13 +93,8 @@ public class ReplicationTask {
     return cmd;
   }
 
-  /**
-   * Status of the replication.
-   */
-  public enum Status {
-    QUEUED,
-    IN_PROGRESS,
-    FAILED,
-    DONE
+  @Override
+  public void run() {
+    // Placeholder for now
   }
 }

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/replication/ReplicationSupervisorScheduling.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/replication/ReplicationSupervisorScheduling.java
@@ -29,7 +29,6 @@ import java.util.UUID;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
 import org.apache.hadoop.hdds.protocol.MockDatanodeDetails;
-import org.apache.hadoop.ozone.container.common.impl.ContainerSet;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/replication/ReplicationSupervisorScheduling.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/replication/ReplicationSupervisorScheduling.java
@@ -113,9 +113,8 @@ public class ReplicationSupervisorScheduling {
       }
     };
 
-    ReplicationSupervisor rs = new ReplicationSupervisor(cs, null,
-        replicator, null, replicationConfig,
-        Clock.system(ZoneId.systemDefault()));
+    ReplicationSupervisor rs = new ReplicationSupervisor(null,
+        replicationConfig, Clock.system(ZoneId.systemDefault()));
 
     final long start = System.currentTimeMillis();
 

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/replication/ReplicationSupervisorScheduling.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/replication/ReplicationSupervisorScheduling.java
@@ -75,8 +75,6 @@ public class ReplicationSupervisorScheduling {
       destinationLocks.put(i, new Object());
     }
 
-    ContainerSet cs = new ContainerSet(1000);
-
     //simplified executor emulating the current sequential download +
     //import.
     ContainerReplicator replicator = task -> {

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/replication/TestMeasuredReplicator.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/replication/TestMeasuredReplicator.java
@@ -20,7 +20,7 @@ package org.apache.hadoop.ozone.container.replication;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 
-import org.apache.hadoop.ozone.container.replication.ReplicationTask.Status;
+import org.apache.hadoop.ozone.container.replication.AbstractReplicationTask.Status;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/replication/TestMeasuredReplicator.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/replication/TestMeasuredReplicator.java
@@ -35,11 +35,11 @@ import static org.apache.hadoop.ozone.protocol.commands.ReplicateContainerComman
 public class TestMeasuredReplicator {
 
   private MeasuredReplicator measuredReplicator;
+  private ContainerReplicator replicator;
 
   @BeforeEach
   public void initReplicator() {
-    measuredReplicator = new MeasuredReplicator(task -> {
-
+    replicator = task -> {
       task.setTransferredBytes(task.getContainerId() * 1024);
 
       //fail if container id is even
@@ -53,7 +53,8 @@ public class TestMeasuredReplicator {
       } catch (InterruptedException e) {
         e.printStackTrace();
       }
-    });
+    };
+    measuredReplicator = new MeasuredReplicator(replicator);
   }
 
   @AfterEach
@@ -64,9 +65,9 @@ public class TestMeasuredReplicator {
   @Test
   public void measureFailureSuccessAndBytes() {
     //WHEN
-    measuredReplicator.replicate(new ReplicationTask(forTest(1)));
-    measuredReplicator.replicate(new ReplicationTask(forTest(2)));
-    measuredReplicator.replicate(new ReplicationTask(forTest(3)));
+    measuredReplicator.replicate(new ReplicationTask(forTest(1), replicator));
+    measuredReplicator.replicate(new ReplicationTask(forTest(2), replicator));
+    measuredReplicator.replicate(new ReplicationTask(forTest(3), replicator));
 
     //THEN
     //even containers should be failed
@@ -84,9 +85,9 @@ public class TestMeasuredReplicator {
   public void testReplicationTime() throws Exception {
     //WHEN
     //will wait at least the 300ms
-    measuredReplicator.replicate(new ReplicationTask(forTest(101)));
-    measuredReplicator.replicate(new ReplicationTask(forTest(201)));
-    measuredReplicator.replicate(new ReplicationTask(forTest(300)));
+    measuredReplicator.replicate(new ReplicationTask(forTest(101), replicator));
+    measuredReplicator.replicate(new ReplicationTask(forTest(201), replicator));
+    measuredReplicator.replicate(new ReplicationTask(forTest(300), replicator));
 
     //THEN
     //even containers should be failed
@@ -102,7 +103,8 @@ public class TestMeasuredReplicator {
   public void testFailureTimeSuccessExcluded() {
     //WHEN
     //will wait at least the 15ms
-    measuredReplicator.replicate(new ReplicationTask(forTest(15)));
+    measuredReplicator.replicate(new ReplicationTask(forTest(15), replicator));
+
 
     //THEN
     //even containers should be failed, supposed to be zero
@@ -113,7 +115,8 @@ public class TestMeasuredReplicator {
   public void testSuccessTimeFailureExcluded() {
     //WHEN
     //will wait at least the 10ms
-    measuredReplicator.replicate(new ReplicationTask(forTest(10)));
+    measuredReplicator.replicate(new ReplicationTask(forTest(10), replicator));
+
 
     //THEN
     //even containers should be failed, supposed to be zero
@@ -123,7 +126,7 @@ public class TestMeasuredReplicator {
   @Test
   public void testReplicationQueueTimeMetrics() {
     final Instant queued = Instant.now().minus(1, ChronoUnit.SECONDS);
-    ReplicationTask task = new ReplicationTask(forTest(100)) {
+    ReplicationTask task = new ReplicationTask(forTest(100), replicator) {
       @Override
       public Instant getQueued() {
         return queued;

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/replication/TestReplicationSupervisor.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/replication/TestReplicationSupervisor.java
@@ -256,8 +256,7 @@ public class TestReplicationSupervisor {
   @Test
   public void testDownloadAndImportReplicatorFailure() throws IOException {
     ReplicationSupervisor supervisor =
-        new ReplicationSupervisor(set, context, pullReplicator,
-            pushReplicator, newDirectExecutorService(), clock);
+        new ReplicationSupervisor(context, newDirectExecutorService(), clock);
 
     OzoneConfiguration conf = new OzoneConfiguration();
     // Mock to fetch an exception in the importContainer method.
@@ -347,8 +346,7 @@ public class TestReplicationSupervisor {
       Function<ReplicationSupervisor, ContainerReplicator> replicatorFactory,
       ExecutorService executor) {
     ReplicationSupervisor supervisor =
-        new ReplicationSupervisor(set, context, pullReplicator, pushReplicator,
-            executor, clock);
+        new ReplicationSupervisor(context, executor, clock);
     replicatorRef.set(replicatorFactory.apply(supervisor));
     return supervisor;
   }

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/replication/TestReplicationSupervisor.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/replication/TestReplicationSupervisor.java
@@ -299,13 +299,13 @@ public class TestReplicationSupervisor {
 
     ReplicateContainerCommand cmd = createCommand(1);
     cmd.setDeadline(clock.millis() + 10000);
-    ReplicationTask task1 = new ReplicationTask(cmd);
+    ReplicationTask task1 = new ReplicationTask(cmd, replicatorRef.get());
     cmd = createCommand(2);
     cmd.setDeadline(clock.millis() + 20000);
-    ReplicationTask task2 = new ReplicationTask(cmd);
+    ReplicationTask task2 = new ReplicationTask(cmd, replicatorRef.get());
     cmd = createCommand(3);
     // No deadline set
-    ReplicationTask task3 = new ReplicationTask(cmd);
+    ReplicationTask task3 = new ReplicationTask(cmd, replicatorRef.get());
     // no deadline set
 
     clock.fastForward(15000);
@@ -352,9 +352,9 @@ public class TestReplicationSupervisor {
     return supervisor;
   }
 
-  private static ReplicationTask createTask(long containerId) {
+  private ReplicationTask createTask(long containerId) {
     ReplicateContainerCommand cmd = createCommand(containerId);
-    return new ReplicationTask(cmd);
+    return new ReplicationTask(cmd, replicatorRef.get());
   }
 
   private static ReplicateContainerCommand createCommand(long containerId) {

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/ClosedContainerReplicator.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/ClosedContainerReplicator.java
@@ -207,7 +207,7 @@ public class ClosedContainerReplicator extends BaseFreonGenerator implements
 
     ContainerImporter importer = new ContainerImporter(conf, containerSet,
         controller, new TarContainerPacker(), null);
-    replicator = new DownloadAndImportReplicator(importer,
+    replicator = new DownloadAndImportReplicator(containerSet, importer,
         new SimpleContainerDownloader(conf, null));
 
     ReplicationServer.ReplicationConfig replicationConfig

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/ClosedContainerReplicator.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/ClosedContainerReplicator.java
@@ -212,8 +212,7 @@ public class ClosedContainerReplicator extends BaseFreonGenerator implements
 
     ReplicationServer.ReplicationConfig replicationConfig
         = conf.getObject(ReplicationServer.ReplicationConfig.class);
-    supervisor = new ReplicationSupervisor(containerSet, null,
-        replicator, null, replicationConfig,
+    supervisor = new ReplicationSupervisor(null, replicationConfig,
         Clock.system(ZoneId.systemDefault()));
   }
 

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/ClosedContainerReplicator.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/ClosedContainerReplicator.java
@@ -82,6 +82,8 @@ public class ClosedContainerReplicator extends BaseFreonGenerator implements
 
   private ReplicationSupervisor supervisor;
 
+  private ContainerReplicator replicator;
+
   private Timer timer;
 
   private List<ReplicationTask> replicationTasks;
@@ -130,7 +132,7 @@ public class ClosedContainerReplicator extends BaseFreonGenerator implements
         if (datanode.isEmpty() || datanodeUUIDs.contains(datanode)) {
           replicationTasks.add(new ReplicationTask(
               ReplicateContainerCommand.fromSources(container.getContainerID(),
-                  datanodesWithContainer)));
+                  datanodesWithContainer), replicator));
         }
       }
 
@@ -205,7 +207,7 @@ public class ClosedContainerReplicator extends BaseFreonGenerator implements
 
     ContainerImporter importer = new ContainerImporter(conf, containerSet,
         controller, new TarContainerPacker(), null);
-    ContainerReplicator replicator = new DownloadAndImportReplicator(importer,
+    replicator = new DownloadAndImportReplicator(importer,
         new SimpleContainerDownloader(conf, null));
 
     ReplicationServer.ReplicationConfig replicationConfig


### PR DESCRIPTION
## What changes were proposed in this pull request?

A refactor or the existing ReplicationSupervisor so we can have the same supervisor (and threadpool) manage both Replication and EC Reconstruction tasks.

This change does not include moving the EC tasks into the ReplicationSupervisor - that will be done in another PR as this one is already large enough with this change.

This change makes ReplicationSupervisor accept AbstractReplicationTask's rather than a ReplicationTask, so we can have a version for EC Reconstruction and Ratis.

This results in the ReplicationTask having a `runTask()` method so it contains the knowledge of how to run itself and the supervisor can simply check the state. The choice of Replicator (push or download) is decided in the ReplicateContainerCommandHandler and a reference to the correct replicator is stored in the task. Previously it was decided inside the ReplicationSupervisor.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-7833

## How was this patch tested?

Small change to one unit test and other existing tests should cover this.
