### PR TITLE
HDDS-7822. Allow multiple commands per datanode in UnhealthyReplicationHandler

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/AbstractOverReplicationHandler.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/AbstractOverReplicationHandler.java
@@ -22,11 +22,8 @@ import org.apache.hadoop.hdds.protocol.DatanodeDetails;
 import org.apache.hadoop.hdds.scm.ContainerPlacementStatus;
 import org.apache.hadoop.hdds.scm.PlacementPolicy;
 import org.apache.hadoop.hdds.scm.container.ContainerReplica;
-import org.apache.hadoop.ozone.protocol.commands.SCMCommand;
 
-import java.io.IOException;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -41,23 +38,6 @@ public abstract class AbstractOverReplicationHandler
   protected AbstractOverReplicationHandler(PlacementPolicy placementPolicy) {
     this.placementPolicy = placementPolicy;
   }
-
-  /**
-   * Identify a new set of datanode(s) to delete the container
-   * and form the SCM commands to send it to DN.
-   *
-   * @param replicas - Set of available container replicas.
-   * @param pendingOps - Inflight replications and deletion ops.
-   * @param result - Health check result.
-   * @param remainingMaintenanceRedundancy - represents that how many nodes go
-   *                                      into maintenance.
-   * @return Returns the key value pair of destination dn where the command gets
-   * executed and the command itself.
-   */
-  public abstract Map<DatanodeDetails, SCMCommand<?>> processAndCreateCommands(
-      Set<ContainerReplica> replicas, List<ContainerReplicaOp> pendingOps,
-      ContainerHealthResult result, int remainingMaintenanceRedundancy) throws
-      IOException;
 
   /**
    * Identify whether the placement status is actually equal for a

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/OverReplicatedProcessor.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/OverReplicatedProcessor.java
@@ -17,11 +17,12 @@
  */
 package org.apache.hadoop.hdds.scm.container.replication;
 
+import org.apache.commons.lang3.tuple.Pair;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
 import org.apache.hadoop.ozone.protocol.commands.SCMCommand;
 
 import java.io.IOException;
-import java.util.Map;
+import java.util.Set;
 
 /**
  * Class used to pick messages from the ReplicationManager over replicated
@@ -50,7 +51,7 @@ public class OverReplicatedProcessor extends UnhealthyReplicationProcessor
     replicationManager.requeueOverReplicatedContainer(healthResult);
   }
   @Override
-  protected Map<DatanodeDetails, SCMCommand<?>> getDatanodeCommands(
+  protected Set<Pair<DatanodeDetails, SCMCommand<?>>> getDatanodeCommands(
       ReplicationManager replicationManager,
       ContainerHealthResult.OverReplicatedHealthResult healthResult)
       throws IOException {

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ReplicationManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ReplicationManager.java
@@ -19,6 +19,7 @@
 package org.apache.hadoop.hdds.scm.container.replication;
 
 import com.google.common.annotations.VisibleForTesting;
+import org.apache.commons.lang3.tuple.Pair;
 import org.apache.hadoop.hdds.HddsConfigKeys;
 import org.apache.hadoop.hdds.conf.Config;
 import org.apache.hadoop.hdds.conf.ConfigGroup;
@@ -522,7 +523,7 @@ public class ReplicationManager implements SCMService {
     }
   }
 
-  public Map<DatanodeDetails, SCMCommand<?>> processUnderReplicatedContainer(
+  Set<Pair<DatanodeDetails, SCMCommand<?>>> processUnderReplicatedContainer(
       final ContainerHealthResult result) throws IOException {
     ContainerID containerID = result.getContainerInfo().containerID();
     Set<ContainerReplica> replicas = containerManager.getContainerReplicas(
@@ -547,7 +548,7 @@ public class ReplicationManager implements SCMService {
         pendingOps, result, ratisMaintenanceMinReplicas);
   }
 
-  public Map<DatanodeDetails, SCMCommand<?>> processOverReplicatedContainer(
+  Set<Pair<DatanodeDetails, SCMCommand<?>>> processOverReplicatedContainer(
       final ContainerHealthResult result) throws IOException {
     ContainerID containerID = result.getContainerInfo().containerID();
     Set<ContainerReplica> replicas = containerManager.getContainerReplicas(

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/UnderReplicatedProcessor.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/UnderReplicatedProcessor.java
@@ -17,11 +17,12 @@
  */
 package org.apache.hadoop.hdds.scm.container.replication;
 
+import org.apache.commons.lang3.tuple.Pair;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
 import org.apache.hadoop.ozone.protocol.commands.SCMCommand;
 
 import java.io.IOException;
-import java.util.Map;
+import java.util.Set;
 
 /**
  * Class used to pick messages from the ReplicationManager under replicated
@@ -50,7 +51,7 @@ public class UnderReplicatedProcessor extends UnhealthyReplicationProcessor
   }
 
   @Override
-  protected Map<DatanodeDetails, SCMCommand<?>> getDatanodeCommands(
+  protected Set<Pair<DatanodeDetails, SCMCommand<?>>> getDatanodeCommands(
           ReplicationManager replicationManager,
           ContainerHealthResult.UnderReplicatedHealthResult healthResult)
           throws IOException {

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/UnhealthyReplicationHandler.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/UnhealthyReplicationHandler.java
@@ -17,13 +17,13 @@
  */
 package org.apache.hadoop.hdds.scm.container.replication;
 
+import org.apache.commons.lang3.tuple.Pair;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
 import org.apache.hadoop.hdds.scm.container.ContainerReplica;
 import org.apache.hadoop.ozone.protocol.commands.SCMCommand;
 
 import java.io.IOException;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 
 /**
@@ -47,8 +47,9 @@ public interface UnhealthyReplicationHandler {
    * queue. Any exception indicates that the container is still unhealthy and
    * should be retried later.
    */
-  Map<DatanodeDetails, SCMCommand<?>> processAndCreateCommands(
+  Set<Pair<DatanodeDetails, SCMCommand<?>>> processAndCreateCommands(
       Set<ContainerReplica> replicas, List<ContainerReplicaOp> pendingOps,
       ContainerHealthResult result, int remainingMaintenanceRedundancy)
       throws IOException;
+
 }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/UnhealthyReplicationProcessor.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/UnhealthyReplicationProcessor.java
@@ -20,6 +20,7 @@ package org.apache.hadoop.hdds.scm.container.replication;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.Maps;
+import org.apache.commons.lang3.tuple.Pair;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
 import org.apache.hadoop.ozone.protocol.commands.SCMCommand;
 import org.slf4j.Logger;
@@ -27,6 +28,7 @@ import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.util.Map;
+import java.util.Set;
 
 /**
  * Class used to pick messages from the respective ReplicationManager
@@ -107,17 +109,16 @@ public abstract class UnhealthyReplicationProcessor<HealthResult extends
   /**
    * Gets the commands to be run datanode to process the
    * container health result.
-   * @param rm
-   * @param healthResult
    * @return Commands to be run on Datanodes
    */
-  protected abstract Map<DatanodeDetails, SCMCommand<?>> getDatanodeCommands(
-          ReplicationManager rm, HealthResult healthResult)
+  protected abstract Set<Pair<DatanodeDetails, SCMCommand<?>>>
+      getDatanodeCommands(ReplicationManager rm, HealthResult healthResult)
           throws IOException;
+
   private void processContainer(HealthResult healthResult) throws IOException {
-    Map<DatanodeDetails, SCMCommand<?>> cmds = getDatanodeCommands(
+    Set<Pair<DatanodeDetails, SCMCommand<?>>> cmds = getDatanodeCommands(
             replicationManager, healthResult);
-    for (Map.Entry<DatanodeDetails, SCMCommand<?>> cmd : cmds.entrySet()) {
+    for (Map.Entry<DatanodeDetails, SCMCommand<?>> cmd : cmds) {
       replicationManager.sendDatanodeCommand(cmd.getValue(),
               healthResult.getContainerInfo(), cmd.getKey());
     }

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestECUnderReplicationHandler.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestECUnderReplicationHandler.java
@@ -51,7 +51,6 @@ import org.mockito.Mockito;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -155,13 +154,13 @@ public class TestECUnderReplicationHandler {
         .createReplicas(Pair.of(DECOMMISSIONING, 1), Pair.of(IN_SERVICE, 2),
             Pair.of(IN_SERVICE, 3), Pair.of(IN_SERVICE, 4),
             Pair.of(IN_SERVICE, 5));
-    Map<DatanodeDetails, SCMCommand<?>> cmds =
+    Set<Pair<DatanodeDetails, SCMCommand<?>>> cmds =
         testUnderReplicationWithMissingIndexes(
             Lists.emptyList(), availableReplicas, 1, 0, policy);
     Assertions.assertEquals(1, cmds.size());
     // Check the replicate command has index 1 set
-    ReplicateContainerCommand cmd = (ReplicateContainerCommand) cmds.values()
-        .iterator().next();
+    ReplicateContainerCommand cmd = (ReplicateContainerCommand) cmds
+        .iterator().next().getValue();
     Assertions.assertEquals(1, cmd.getReplicaIndex());
 
   }
@@ -317,13 +316,14 @@ public class TestECUnderReplicationHandler {
       // returns, which in this case is a delete command for replica index 4.
       availableReplicas.add(overRepReplica);
 
-      Map<DatanodeDetails, SCMCommand<?>> expectedDelete = new HashMap<>();
-      expectedDelete.put(overRepReplica.getDatanodeDetails(),
-          createDeleteContainerCommand(container, overRepReplica));
+      Set<Pair<DatanodeDetails, SCMCommand<?>>> expectedDelete =
+          new HashSet<>();
+      expectedDelete.add(Pair.of(overRepReplica.getDatanodeDetails(),
+          createDeleteContainerCommand(container, overRepReplica)));
 
       Mockito.when(replicationManager.processOverReplicatedContainer(
           underRep)).thenReturn(expectedDelete);
-      Map<DatanodeDetails, SCMCommand<?>> commands =
+      Set<Pair<DatanodeDetails, SCMCommand<?>>> commands =
           ecURH.processAndCreateCommands(availableReplicas,
               Collections.emptyList(), underRep, 2);
       Mockito.verify(replicationManager, times(1))
@@ -374,16 +374,18 @@ public class TestECUnderReplicationHandler {
         availableReplicas.add(toAdd);
       }
 
-      Map<DatanodeDetails, SCMCommand<?>> commands =
+      Set<Pair<DatanodeDetails, SCMCommand<?>>> commands =
           ecURH.processAndCreateCommands(availableReplicas,
               Collections.emptyList(), underRep, 2);
 
       Mockito.verify(replicationManager, times(0))
           .processOverReplicatedContainer(underRep);
       Assertions.assertEquals(1, commands.size());
+      Pair<DatanodeDetails, SCMCommand<?>> pair = commands.iterator().next();
+      Assertions.assertEquals(newNode, pair.getKey());
       Assertions.assertEquals(StorageContainerDatanodeProtocolProtos
               .SCMCommandProto.Type.reconstructECContainersCommand,
-          commands.get(newNode).getType());
+          pair.getValue().getType());
     }
   }
 
@@ -420,13 +422,13 @@ public class TestECUnderReplicationHandler {
             4, IN_SERVICE, CLOSED);
     availableReplicas.add(overRepReplica);
 
-    Map<DatanodeDetails, SCMCommand<?>> expectedDelete = new HashMap<>();
-    expectedDelete.put(overRepReplica.getDatanodeDetails(),
-        createDeleteContainerCommand(container, overRepReplica));
+    Set<Pair<DatanodeDetails, SCMCommand<?>>> expectedDelete = new HashSet<>();
+    expectedDelete.add(Pair.of(overRepReplica.getDatanodeDetails(),
+        createDeleteContainerCommand(container, overRepReplica)));
 
     Mockito.when(replicationManager.processOverReplicatedContainer(
         underRep)).thenReturn(expectedDelete);
-    Map<DatanodeDetails, SCMCommand<?>> commands =
+    Set<Pair<DatanodeDetails, SCMCommand<?>>> commands =
         ecURH.processAndCreateCommands(availableReplicas,
             Collections.emptyList(), underRep, 1);
     Mockito.verify(replicationManager, times(1))
@@ -469,12 +471,12 @@ public class TestECUnderReplicationHandler {
         .createReplicas(Pair.of(DECOMMISSIONING, 1), Pair.of(IN_SERVICE, 1),
             Pair.of(IN_MAINTENANCE, 1), Pair.of(IN_MAINTENANCE, 1),
             Pair.of(IN_SERVICE, 4), Pair.of(IN_SERVICE, 5));
-    Map<DatanodeDetails, SCMCommand<?>> cmds =
+    Set<Pair<DatanodeDetails, SCMCommand<?>>> cmds =
         testUnderReplicationWithMissingIndexes(ImmutableList.of(2, 3),
             availableReplicas, 0, 0, policy);
     Assertions.assertEquals(1, cmds.size());
     ReconstructECContainersCommand cmd =
-        (ReconstructECContainersCommand) cmds.values().iterator().next();
+        (ReconstructECContainersCommand) cmds.iterator().next().getValue();
     // Ensure that all source nodes are IN_SERVICE, we should not have picked
     // the non in-service nodes for index 1.
     for (ReconstructECContainersCommand.DatanodeDetailsAndReplicaIndex s
@@ -513,7 +515,7 @@ public class TestECUnderReplicationHandler {
     ECUnderReplicationHandler handler = new ECUnderReplicationHandler(
         ecPlacementPolicy, conf, nodeManager, replicationManager);
 
-    Map<DatanodeDetails, SCMCommand<?>> commands =
+    Set<Pair<DatanodeDetails, SCMCommand<?>>> commands =
         handler.processAndCreateCommands(availableReplicas,
             Collections.emptyList(), result, 1);
     Assertions.assertEquals(1, commands.size());
@@ -562,11 +564,11 @@ public class TestECUnderReplicationHandler {
     ECUnderReplicationHandler handler = new ECUnderReplicationHandler(
         ecPlacementPolicy, conf, nodeManager, replicationManager);
 
-    Map<DatanodeDetails, SCMCommand<?>> commands =
+    Set<Pair<DatanodeDetails, SCMCommand<?>>> commands =
         handler.processAndCreateCommands(availableReplicas, pendingOps, result,
             1);
     Assertions.assertEquals(1, commands.size());
-    Assertions.assertFalse(commands.containsKey(dn));
+    Assertions.assertNotEquals(dn, commands.iterator().next().getKey());
   }
 
   @Test
@@ -577,12 +579,12 @@ public class TestECUnderReplicationHandler {
     ContainerReplica decomReplica = ReplicationTestUtil.createContainerReplica(
         container.containerID(), 2, DECOMMISSIONING, CLOSED);
     availableReplicas.add(decomReplica);
-    Map<DatanodeDetails, SCMCommand<?>> cmds =
+    Set<Pair<DatanodeDetails, SCMCommand<?>>> cmds =
         testUnderReplicationWithMissingIndexes(Collections.emptyList(),
             availableReplicas, 1, 0, policy);
     Assertions.assertEquals(1, cmds.size());
     ReplicateContainerCommand cmd =
-        (ReplicateContainerCommand) cmds.values().iterator().next();
+        (ReplicateContainerCommand) cmds.iterator().next().getValue();
 
     List<DatanodeDetails> sources = cmd.getSourceDatanodes();
     Assertions.assertEquals(1, sources.size());
@@ -599,7 +601,7 @@ public class TestECUnderReplicationHandler {
         container.containerID(), 2, ENTERING_MAINTENANCE, CLOSED);
     availableReplicas.add(maintReplica);
 
-    Map<DatanodeDetails, SCMCommand<?>> cmds =
+    Set<Pair<DatanodeDetails, SCMCommand<?>>> cmds =
         testUnderReplicationWithMissingIndexes(Collections.emptyList(),
             availableReplicas, 0, 1, policy);
     Assertions.assertEquals(0, cmds.size());
@@ -611,7 +613,7 @@ public class TestECUnderReplicationHandler {
 
     Assertions.assertEquals(1, cmds.size());
     ReplicateContainerCommand cmd =
-        (ReplicateContainerCommand) cmds.values().iterator().next();
+        (ReplicateContainerCommand) cmds.iterator().next().getValue();
 
     List<DatanodeDetails> sources = cmd.getSourceDatanodes();
     Assertions.assertEquals(1, sources.size());
@@ -619,7 +621,7 @@ public class TestECUnderReplicationHandler {
         cmd.getSourceDatanodes().get(0));
   }
 
-  public Map<DatanodeDetails, SCMCommand<?>>
+  public Set<Pair<DatanodeDetails, SCMCommand<?>>>
       testUnderReplicationWithMissingIndexes(
       List<Integer> missingIndexes, Set<ContainerReplica> availableReplicas,
       int decomIndexes, int maintenanceIndexes,
@@ -632,11 +634,9 @@ public class TestECUnderReplicationHandler {
     Mockito.when(result.isUnrecoverable()).thenReturn(false);
     Mockito.when(result.getContainerInfo()).thenReturn(container);
 
-    Map<DatanodeDetails, SCMCommand<?>> datanodeDetailsSCMCommandMap = ecURH
+    Set<Pair<DatanodeDetails, SCMCommand<?>>> commands = ecURH
         .processAndCreateCommands(availableReplicas, ImmutableList.of(),
             result, remainingMaintenanceRedundancy);
-    Set<Map.Entry<DatanodeDetails, SCMCommand<?>>> entries =
-        datanodeDetailsSCMCommandMap.entrySet();
     int replicateCommand = 0;
     int reconstructCommand = 0;
     byte[] missingIndexesByteArr = new byte[missingIndexes.size()];
@@ -646,7 +646,7 @@ public class TestECUnderReplicationHandler {
     boolean shouldReconstructCommandExist =
         missingIndexes.size() > 0 && missingIndexes.size() <= repConfig
             .getParity();
-    for (Map.Entry<DatanodeDetails, SCMCommand<?>> dnCommand : entries) {
+    for (Map.Entry<DatanodeDetails, SCMCommand<?>> dnCommand : commands) {
       if (dnCommand.getValue() instanceof ReplicateContainerCommand) {
         replicateCommand++;
       } else if (dnCommand
@@ -666,7 +666,7 @@ public class TestECUnderReplicationHandler {
         replicateCommand);
     Assertions.assertEquals(shouldReconstructCommandExist ? 1 : 0,
         reconstructCommand);
-    return datanodeDetailsSCMCommandMap;
+    return commands;
   }
 
   private DeleteContainerCommand createDeleteContainerCommand(

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestOverReplicatedProcessor.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestOverReplicatedProcessor.java
@@ -17,6 +17,7 @@
  */
 package org.apache.hadoop.hdds.scm.container.replication;
 
+import org.apache.commons.lang3.tuple.Pair;
 import org.apache.hadoop.hdds.client.ECReplicationConfig;
 import org.apache.hadoop.hdds.conf.ConfigurationSource;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
@@ -32,8 +33,8 @@ import org.junit.Test;
 import org.mockito.Mockito;
 
 import java.io.IOException;
-import java.util.HashMap;
-import java.util.Map;
+import java.util.HashSet;
+import java.util.Set;
 
 import static org.mockito.ArgumentMatchers.any;
 
@@ -67,11 +68,11 @@ public class TestOverReplicatedProcessor {
         .thenReturn(
             new ContainerHealthResult.OverReplicatedHealthResult(container, 3,
                 false), null);
-    Map<DatanodeDetails, SCMCommand<?>> commands = new HashMap<>();
+    Set<Pair<DatanodeDetails, SCMCommand<?>>> commands = new HashSet<>();
     DeleteContainerCommand cmd =
         new DeleteContainerCommand(container.getContainerID());
     cmd.setReplicaIndex(5);
-    commands.put(MockDatanodeDetails.randomDatanodeDetails(), cmd);
+    commands.add(Pair.of(MockDatanodeDetails.randomDatanodeDetails(), cmd));
 
     Mockito
         .when(replicationManager.processOverReplicatedContainer(any()))

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestRatisUnderReplicationHandler.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestRatisUnderReplicationHandler.java
@@ -44,7 +44,6 @@ import org.mockito.Mockito;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 
 import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.NodeOperationalState.DECOMMISSIONING;
@@ -220,7 +219,7 @@ public class TestRatisUnderReplicationHandler {
         new RatisUnderReplicationHandler(policy, conf, nodeManager,
             replicationManager);
 
-    Map<DatanodeDetails, SCMCommand<?>> commands =
+    Set<Pair<DatanodeDetails, SCMCommand<?>>> commands =
         handler.processAndCreateCommands(replicas, pendingOps,
             healthResult, minHealthyForMaintenance);
     Assert.assertEquals(expectNumCommands, commands.size());

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestUnderReplicatedProcessor.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestUnderReplicatedProcessor.java
@@ -17,6 +17,7 @@
  */
 package org.apache.hadoop.hdds.scm.container.replication;
 
+import org.apache.commons.lang3.tuple.Pair;
 import org.apache.hadoop.hdds.client.ECReplicationConfig;
 import org.apache.hadoop.hdds.conf.ConfigurationSource;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
@@ -34,9 +35,9 @@ import org.mockito.Mockito;
 
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
-import java.util.Map;
+import java.util.Set;
 
 import static org.mockito.ArgumentMatchers.any;
 
@@ -84,10 +85,10 @@ public class TestUnderReplicatedProcessor {
     targetNodes.add(MockDatanodeDetails.randomDatanodeDetails());
     byte[] missingIndexes = {4, 5};
 
-    Map<DatanodeDetails, SCMCommand<?>> commands = new HashMap<>();
-    commands.put(MockDatanodeDetails.randomDatanodeDetails(),
+    Set<Pair<DatanodeDetails, SCMCommand<?>>> commands = new HashSet<>();
+    commands.add(Pair.of(MockDatanodeDetails.randomDatanodeDetails(),
         new ReconstructECContainersCommand(container.getContainerID(),
-            sourceNodes, targetNodes, missingIndexes, repConfig));
+            sourceNodes, targetNodes, missingIndexes, repConfig)));
 
     Mockito.when(replicationManager
             .processUnderReplicatedContainer(any()))
@@ -115,8 +116,8 @@ public class TestUnderReplicatedProcessor {
         container.getContainerID(), sourceDns);
     rcc.setReplicaIndex(3);
 
-    Map<DatanodeDetails, SCMCommand<?>> commands = new HashMap<>();
-    commands.put(targetDn, rcc);
+    Set<Pair<DatanodeDetails, SCMCommand<?>>> commands = new HashSet<>();
+    commands.add(Pair.of(targetDn, rcc));
 
     Mockito.when(replicationManager
             .processUnderReplicatedContainer(any()))


### PR DESCRIPTION
## What changes were proposed in this pull request?

`RatisUnderReplicationHandler` needs to create more than one command per datanode for push replication if there are fewer sources than targets (e.g. if only one out of three replicas is available).
This PR changes the `UnhealthyReplicationHandler` interface to allow this.

https://issues.apache.org/jira/browse/HDDS-7822

## How was this patch tested?

Regular CI:
https://github.com/adoroszlai/hadoop-ozone/actions/runs/3996840932