### PR TITLE
HDDS-7832. Support FSO buckets for FileSizeCountTask.

### DIFF
--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/tasks/FileSizeCountTask.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/tasks/FileSizeCountTask.java
@@ -92,7 +92,7 @@ public class FileSizeCountTask implements ReconOmTask {
     boolean statusOBS =
         reprocessBucketLayout(BucketLayout.LEGACY, omMetadataManager,
             fileSizeCountMap);
-    if (statusFSO && statusOBS) {
+    if (!statusFSO && !statusOBS) {
       return new ImmutablePair<>(getTaskName(), false);
     }
     writeCountsToDB(true, fileSizeCountMap);

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/tasks/FileSizeCountTask.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/tasks/FileSizeCountTask.java
@@ -84,11 +84,15 @@ public class FileSizeCountTask implements ReconOmTask {
     LOG.info("Deleted {} records from {}", execute, FILE_COUNT_BY_SIZE);
 
     // Call reprocessBucket method for FILE_SYSTEM_OPTIMIZED bucket layout
-    boolean statusFSO = reprocessBucketLayout(BucketLayout.FILE_SYSTEM_OPTIMIZED, omMetadataManager,
-        fileSizeCountMap);
+    boolean statusFSO =
+        reprocessBucketLayout(BucketLayout.FILE_SYSTEM_OPTIMIZED,
+            omMetadataManager,
+            fileSizeCountMap);
     // Call reprocessBucket method for LEGACY bucket layout
-    boolean statusOBS = reprocessBucketLayout(BucketLayout.LEGACY, omMetadataManager, fileSizeCountMap);
-    if(statusFSO && statusOBS){
+    boolean statusOBS =
+        reprocessBucketLayout(BucketLayout.LEGACY, omMetadataManager,
+            fileSizeCountMap);
+    if (statusFSO && statusOBS) {
       return new ImmutablePair<>(getTaskName(), false);
     }
     writeCountsToDB(true, fileSizeCountMap);

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/tasks/FileSizeCountTask.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/tasks/FileSizeCountTask.java
@@ -72,7 +72,8 @@ public class FileSizeCountTask implements ReconOmTask {
     Map<FileSizeCountKey, Long> fileSizeCountMap = new HashMap<>();
 
     // Call reprocessBucket method for FILE_SYSTEM_OPTIMIZED bucket layout
-    reprocessBucket(BucketLayout.FILE_SYSTEM_OPTIMIZED, omMetadataManager, fileSizeCountMap);
+    reprocessBucket(BucketLayout.FILE_SYSTEM_OPTIMIZED, omMetadataManager,
+        fileSizeCountMap);
     // Call reprocessBucket method for LEGACY bucket layout
     reprocessBucket(BucketLayout.LEGACY, omMetadataManager, fileSizeCountMap);
 
@@ -85,8 +86,10 @@ public class FileSizeCountTask implements ReconOmTask {
   }
 
   private void reprocessBucket(BucketLayout bucketLayout,
-                             OMMetadataManager omMetadataManager, Map<FileSizeCountKey, Long> fileSizeCountMap) {
-    Table<String, OmKeyInfo> omKeyInfoTable = omMetadataManager.getKeyTable(bucketLayout);
+                               OMMetadataManager omMetadataManager,
+                               Map<FileSizeCountKey, Long> fileSizeCountMap) {
+    Table<String, OmKeyInfo> omKeyInfoTable =
+        omMetadataManager.getKeyTable(bucketLayout);
     try (TableIterator<String, ? extends Table.KeyValue<String, OmKeyInfo>>
              keyIter = omKeyInfoTable.iterator()) {
       while (keyIter.hasNext()) {
@@ -94,7 +97,8 @@ public class FileSizeCountTask implements ReconOmTask {
         handlePutKeyEvent(kv.getValue(), fileSizeCountMap);
       }
     } catch (IOException ioEx) {
-      LOG.error("Unable to populate File Size Count for " + bucketLayout + " in Recon DB. ", ioEx);
+      LOG.error("Unable to populate File Size Count for " + bucketLayout +
+          " in Recon DB. ", ioEx);
     }
   }
 

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/tasks/FileSizeCountTask.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/tasks/FileSizeCountTask.java
@@ -38,12 +38,12 @@ import org.slf4j.LoggerFactory;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 
+import static org.apache.hadoop.ozone.om.OmMetadataManagerImpl.FILE_TABLE;
 import static org.apache.hadoop.ozone.om.OmMetadataManagerImpl.KEY_TABLE;
 import static org.hadoop.ozone.recon.schema.tables.FileCountBySizeTable.FILE_COUNT_BY_SIZE;
 
@@ -105,7 +105,10 @@ public class FileSizeCountTask implements ReconOmTask {
   }
 
   public Collection<String> getTaskTables() {
-    return Collections.singletonList(KEY_TABLE);
+    List<String> taskTables = new ArrayList<>();
+    taskTables.add(KEY_TABLE);
+    taskTables.add(FILE_TABLE);
+    return taskTables;
   }
 
   /**

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/tasks/FileSizeCountTask.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/tasks/FileSizeCountTask.java
@@ -67,6 +67,14 @@ public class FileSizeCountTask implements ReconOmTask {
     this.dslContext = utilizationSchemaDefinition.getDSLContext();
   }
 
+  /**
+   * Read the Keys from OM snapshot DB and calculate the upper bound of
+   * File Size it belongs to.
+   *
+   * @param omMetadataManager OM Metadata instance.
+   * @return Pair
+   */
+  @Override
   public Pair<String, Boolean> reprocess(OMMetadataManager omMetadataManager) {
     // Map to store the count of files based on file size
     Map<FileSizeCountKey, Long> fileSizeCountMap = new HashMap<>();

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/api/TestEndpoints.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/api/TestEndpoints.java
@@ -635,44 +635,44 @@ public class TestEndpoints extends AbstractReconSqlDBTest {
     given(omKeyInfo3.getDataSize()).willReturn(1000L);
 
     OMMetadataManager omMetadataManager = mock(OmMetadataManagerImpl.class);
-    TypedTable<String, OmKeyInfo> keyTable1 = mock(TypedTable.class);
-    TypedTable<String, OmKeyInfo> keyTable2 = mock(TypedTable.class);
+    TypedTable<String, OmKeyInfo> keyTableLegacy = mock(TypedTable.class);
+    TypedTable<String, OmKeyInfo> keyTableFso = mock(TypedTable.class);
 
-    TypedTable.TypedTableIterator mockKeyIter1 = mock(TypedTable
+    TypedTable.TypedTableIterator mockKeyIterLegacy = mock(TypedTable
         .TypedTableIterator.class);
-    TypedTable.TypedTableIterator mockKeyIter2 = mock(TypedTable
+    TypedTable.TypedTableIterator mockKeyIterFso = mock(TypedTable
         .TypedTableIterator.class);
-    TypedTable.TypedKeyValue mockKeyValue1 = mock(
+    TypedTable.TypedKeyValue mockKeyValueLegacy = mock(
         TypedTable.TypedKeyValue.class);
-    TypedTable.TypedKeyValue mockKeyValue2 = mock(
+    TypedTable.TypedKeyValue mockKeyValueFso = mock(
         TypedTable.TypedKeyValue.class);
 
-    when(keyTable1.iterator()).thenReturn(mockKeyIter1);
-    when(keyTable2.iterator()).thenReturn(mockKeyIter2);
+    when(keyTableLegacy.iterator()).thenReturn(mockKeyIterLegacy);
+    when(keyTableFso.iterator()).thenReturn(mockKeyIterFso);
 
     when(omMetadataManager.getKeyTable(BucketLayout.LEGACY)).thenReturn(
-        keyTable1);
+        keyTableLegacy);
     when(omMetadataManager.getKeyTable(
-        BucketLayout.FILE_SYSTEM_OPTIMIZED)).thenReturn(keyTable2);
+        BucketLayout.FILE_SYSTEM_OPTIMIZED)).thenReturn(keyTableFso);
 
-    when(mockKeyIter1.hasNext())
+    when(mockKeyIterLegacy.hasNext())
         .thenReturn(true)
         .thenReturn(true)
         .thenReturn(true)
         .thenReturn(false);
-    when(mockKeyIter2.hasNext())
+    when(mockKeyIterFso.hasNext())
         .thenReturn(true)
         .thenReturn(true)
         .thenReturn(true)
         .thenReturn(false);
-    when(mockKeyIter1.next()).thenReturn(mockKeyValue1);
-    when(mockKeyIter2.next()).thenReturn(mockKeyValue2);
+    when(mockKeyIterLegacy.next()).thenReturn(mockKeyValueLegacy);
+    when(mockKeyIterFso.next()).thenReturn(mockKeyValueFso);
 
-    when(mockKeyValue1.getValue())
+    when(mockKeyValueLegacy.getValue())
         .thenReturn(omKeyInfo1)
         .thenReturn(omKeyInfo2)
         .thenReturn(omKeyInfo3);
-    when(mockKeyValue2.getValue())
+    when(mockKeyValueFso.getValue())
         .thenReturn(omKeyInfo1)
         .thenReturn(omKeyInfo2)
         .thenReturn(omKeyInfo3);

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/api/TestEndpoints.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/api/TestEndpoints.java
@@ -650,8 +650,10 @@ public class TestEndpoints extends AbstractReconSqlDBTest {
     when(keyTable1.iterator()).thenReturn(mockKeyIter1);
     when(keyTable2.iterator()).thenReturn(mockKeyIter2);
 
-    when(omMetadataManager.getKeyTable(BucketLayout.LEGACY)).thenReturn(keyTable1);
-    when(omMetadataManager.getKeyTable(BucketLayout.FILE_SYSTEM_OPTIMIZED)).thenReturn(keyTable2);
+    when(omMetadataManager.getKeyTable(BucketLayout.LEGACY)).thenReturn(
+        keyTable1);
+    when(omMetadataManager.getKeyTable(
+        BucketLayout.FILE_SYSTEM_OPTIMIZED)).thenReturn(keyTable2);
 
     when(mockKeyIter1.hasNext())
         .thenReturn(true)

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/api/TestEndpoints.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/api/TestEndpoints.java
@@ -635,22 +635,42 @@ public class TestEndpoints extends AbstractReconSqlDBTest {
     given(omKeyInfo3.getDataSize()).willReturn(1000L);
 
     OMMetadataManager omMetadataManager = mock(OmMetadataManagerImpl.class);
-    TypedTable<String, OmKeyInfo> keyTable = mock(TypedTable.class);
+    TypedTable<String, OmKeyInfo> keyTable1 = mock(TypedTable.class);
+    TypedTable<String, OmKeyInfo> keyTable2 = mock(TypedTable.class);
 
-    TypedTable.TypedTableIterator mockKeyIter = mock(TypedTable
+    TypedTable.TypedTableIterator mockKeyIter1 = mock(TypedTable
         .TypedTableIterator.class);
-    TypedTable.TypedKeyValue mockKeyValue = mock(
+    TypedTable.TypedTableIterator mockKeyIter2 = mock(TypedTable
+        .TypedTableIterator.class);
+    TypedTable.TypedKeyValue mockKeyValue1 = mock(
+        TypedTable.TypedKeyValue.class);
+    TypedTable.TypedKeyValue mockKeyValue2 = mock(
         TypedTable.TypedKeyValue.class);
 
-    when(keyTable.iterator()).thenReturn(mockKeyIter);
-    when(omMetadataManager.getKeyTable(getBucketLayout())).thenReturn(keyTable);
-    when(mockKeyIter.hasNext())
+    when(keyTable1.iterator()).thenReturn(mockKeyIter1);
+    when(keyTable2.iterator()).thenReturn(mockKeyIter2);
+
+    when(omMetadataManager.getKeyTable(BucketLayout.LEGACY)).thenReturn(keyTable1);
+    when(omMetadataManager.getKeyTable(BucketLayout.FILE_SYSTEM_OPTIMIZED)).thenReturn(keyTable2);
+
+    when(mockKeyIter1.hasNext())
         .thenReturn(true)
         .thenReturn(true)
         .thenReturn(true)
         .thenReturn(false);
-    when(mockKeyIter.next()).thenReturn(mockKeyValue);
-    when(mockKeyValue.getValue())
+    when(mockKeyIter2.hasNext())
+        .thenReturn(true)
+        .thenReturn(true)
+        .thenReturn(true)
+        .thenReturn(false);
+    when(mockKeyIter1.next()).thenReturn(mockKeyValue1);
+    when(mockKeyIter2.next()).thenReturn(mockKeyValue2);
+
+    when(mockKeyValue1.getValue())
+        .thenReturn(omKeyInfo1)
+        .thenReturn(omKeyInfo2)
+        .thenReturn(omKeyInfo3);
+    when(mockKeyValue2.getValue())
         .thenReturn(omKeyInfo1)
         .thenReturn(omKeyInfo2)
         .thenReturn(omKeyInfo3);
@@ -666,13 +686,13 @@ public class TestEndpoints extends AbstractReconSqlDBTest {
     assertEquals(3, resultSet.size());
     assertTrue(resultSet.stream().anyMatch(o -> o.getVolume().equals("vol1") &&
         o.getBucket().equals("bucket1") && o.getFileSize() == 1024L &&
-        o.getCount() == 1L));
+        o.getCount() == 2L));
     assertTrue(resultSet.stream().anyMatch(o -> o.getVolume().equals("vol1") &&
         o.getBucket().equals("bucket1") && o.getFileSize() == 131072 &&
-        o.getCount() == 1L));
+        o.getCount() == 2L));
     assertTrue(resultSet.stream().anyMatch(o -> o.getVolume().equals("vol2") &&
         o.getBucket().equals("bucket1") && o.getFileSize() == 1024L &&
-        o.getCount() == 1L));
+        o.getCount() == 2L));
 
     // Test for "volume" query param
     response = utilizationEndpoint.getFileCounts("vol1", null, 0);

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/tasks/TestFileSizeCountTask.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/tasks/TestFileSizeCountTask.java
@@ -47,10 +47,10 @@ import static org.hadoop.ozone.recon.schema.tables.FileCountBySizeTable.FILE_COU
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
-
 /**
  * Unit test for File Size Count Task.
  */
@@ -73,45 +73,60 @@ public class TestFileSizeCountTask extends AbstractReconSqlDBTest {
   }
 
   @Test
-  public void testReprocess() throws IOException {
-    OmKeyInfo omKeyInfo1 = mock(OmKeyInfo.class);
-    given(omKeyInfo1.getKeyName()).willReturn("key1");
-    given(omKeyInfo1.getVolumeName()).willReturn("vol1");
-    given(omKeyInfo1.getBucketName()).willReturn("bucket1");
-    given(omKeyInfo1.getDataSize()).willReturn(1000L);
+  public void testReprocessFSO1() throws IOException {
+    OmKeyInfo[] omKeyInfos = new OmKeyInfo[3];
+    String[] keyNames = {"key1", "key2", "key3"};
+    String[] volumeNames = {"vol1", "vol1", "vol1"};
+    String[] bucketNames = {"bucket1", "bucket1", "bucket1"};
+    Long[] dataSizes = {1000L, 100000L, 1125899906842624L * 4};
 
-    OmKeyInfo omKeyInfo2 = mock(OmKeyInfo.class);
-    given(omKeyInfo2.getKeyName()).willReturn("key2");
-    given(omKeyInfo2.getVolumeName()).willReturn("vol1");
-    given(omKeyInfo2.getBucketName()).willReturn("bucket1");
-    given(omKeyInfo2.getDataSize()).willReturn(100000L);
+    // Loop to initialize each instance of OmKeyInfo
+    for (int i = 0; i < 3; i++) {
+      omKeyInfos[i] = mock(OmKeyInfo.class);
+      given(omKeyInfos[i].getKeyName()).willReturn(keyNames[i]);
+      given(omKeyInfos[i].getVolumeName()).willReturn(volumeNames[i]);
+      given(omKeyInfos[i].getBucketName()).willReturn(bucketNames[i]);
+      given(omKeyInfos[i].getDataSize()).willReturn(dataSizes[i]);
+    }
 
-    OmKeyInfo omKeyInfo3 = mock(OmKeyInfo.class);
-    given(omKeyInfo3.getKeyName()).willReturn("key3");
-    given(omKeyInfo3.getVolumeName()).willReturn("vol1");
-    given(omKeyInfo3.getBucketName()).willReturn("bucket1");
-    given(omKeyInfo3.getDataSize()).willReturn(1125899906842624L * 4); // 4PB
-
+    // Create two mock instances of TypedTable, one for FILE_SYSTEM_OPTIMIZED
+    // layout and one for LEGACY layout
     OMMetadataManager omMetadataManager = mock(OmMetadataManagerImpl.class);
-    TypedTable<String, OmKeyInfo> keyTable = mock(TypedTable.class);
+    TypedTable<String, OmKeyInfo> keyTable1 = mock(TypedTable.class);
+    TypedTable<String, OmKeyInfo> keyTable2 = mock(TypedTable.class);
 
-    TypedTable.TypedTableIterator mockKeyIter = mock(TypedTable
-        .TypedTableIterator.class);
-    TypedTable.TypedKeyValue mockKeyValue = mock(
-        TypedTable.TypedKeyValue.class);
+    // Set return values for getKeyTable() for FILE_SYSTEM_OPTIMIZED
+    // and LEGACY layout
+    when(omMetadataManager.getKeyTable(eq(BucketLayout.FILE_SYSTEM_OPTIMIZED)))
+        .thenReturn(keyTable1);
+    when(omMetadataManager.getKeyTable(eq(BucketLayout.LEGACY)))
+        .thenReturn(keyTable2);
 
-    when(keyTable.iterator()).thenReturn(mockKeyIter);
-    when(omMetadataManager.getKeyTable(getBucketLayout())).thenReturn(keyTable);
-    when(mockKeyIter.hasNext())
-        .thenReturn(true)
-        .thenReturn(true)
-        .thenReturn(true)
-        .thenReturn(false);
-    when(mockKeyIter.next()).thenReturn(mockKeyValue);
-    when(mockKeyValue.getValue())
-        .thenReturn(omKeyInfo1)
-        .thenReturn(omKeyInfo2)
-        .thenReturn(omKeyInfo3);
+    // Create two mock instances of TypedTableIterator, one for each
+    // instance of TypedTable
+    TypedTable.TypedTableIterator mockKeyIter1 =
+        mock(TypedTable.TypedTableIterator.class);
+    when(keyTable1.iterator()).thenReturn(mockKeyIter1);
+    // Set return values for hasNext() and next() of the mock instance of
+    // TypedTableIterator for keyTable1
+    when(mockKeyIter1.hasNext()).thenReturn(true, true, true, false);
+    TypedTable.TypedKeyValue mockKeyValue1 =
+        mock(TypedTable.TypedKeyValue.class);
+    when(mockKeyIter1.next()).thenReturn(mockKeyValue1);
+    when(mockKeyValue1.getValue()).thenReturn(omKeyInfos[0], omKeyInfos[1],
+        omKeyInfos[2]);
+
+
+    // Same as above, but for keyTable2
+    TypedTable.TypedTableIterator mockKeyIter2 =
+        mock(TypedTable.TypedTableIterator.class);
+    when(keyTable2.iterator()).thenReturn(mockKeyIter2);
+    when(mockKeyIter2.hasNext()).thenReturn(true, true, true, false);
+    TypedTable.TypedKeyValue mockKeyValue2 =
+        mock(TypedTable.TypedKeyValue.class);
+    when(mockKeyIter2.next()).thenReturn(mockKeyValue2);
+    when(mockKeyValue2.getValue()).thenReturn(omKeyInfos[0], omKeyInfos[1],
+        omKeyInfos[2]);
 
     // Reprocess could be called from table having existing entries. Adding
     // an entry to simulate that.
@@ -120,25 +135,30 @@ public class TestFileSizeCountTask extends AbstractReconSqlDBTest {
 
     Pair<String, Boolean> result =
         fileSizeCountTask.reprocess(omMetadataManager);
+
+    // Verify that the result of reprocess is true
     assertTrue(result.getRight());
 
+    // Verify that the number of entries in fileCountBySizeDao is 3
     assertEquals(3, fileCountBySizeDao.count());
+
+    // Create a record to find the count of files in a specific volume, bucket and file size
     Record3<String, String, Long> recordToFind = dslContext
         .newRecord(FILE_COUNT_BY_SIZE.VOLUME,
-        FILE_COUNT_BY_SIZE.BUCKET,
-        FILE_COUNT_BY_SIZE.FILE_SIZE)
+            FILE_COUNT_BY_SIZE.BUCKET,
+            FILE_COUNT_BY_SIZE.FILE_SIZE)
         .value1("vol1")
         .value2("bucket1")
         .value3(1024L);
-    assertEquals(1L,
+    assertEquals(2L,
         fileCountBySizeDao.findById(recordToFind).getCount().longValue());
     // file size upper bound for 100000L is 131072L (next highest power of 2)
     recordToFind.value3(131072L);
-    assertEquals(1L,
+    assertEquals(2L,
         fileCountBySizeDao.findById(recordToFind).getCount().longValue());
     // file size upper bound for 4PB is Long.MAX_VALUE
     recordToFind.value3(Long.MAX_VALUE);
-    assertEquals(1L,
+    assertEquals(2L,
         fileCountBySizeDao.findById(recordToFind).getCount().longValue());
   }
 
@@ -166,7 +186,7 @@ public class TestFileSizeCountTask extends AbstractReconSqlDBTest {
         .setAction(PUT)
         .setKey("updatedKey")
         .setValue(toBeUpdatedKey)
-        .setTable(OmMetadataManagerImpl.KEY_TABLE)
+        .setTable(OmMetadataManagerImpl.FILE_TABLE)
         .build();
 
     OMUpdateEventBatch omUpdateEventBatch =
@@ -221,7 +241,7 @@ public class TestFileSizeCountTask extends AbstractReconSqlDBTest {
         .setAction(DELETE)
         .setKey("deletedKey")
         .setValue(toBeDeletedKey)
-        .setTable(OmMetadataManagerImpl.KEY_TABLE)
+        .setTable(OmMetadataManagerImpl.FILE_TABLE)
         .build();
 
     omUpdateEventBatch = new OMUpdateEventBatch(
@@ -267,19 +287,34 @@ public class TestFileSizeCountTask extends AbstractReconSqlDBTest {
     hasNextAnswer.add(false);
 
     OMMetadataManager omMetadataManager = mock(OmMetadataManagerImpl.class);
-    TypedTable<String, OmKeyInfo> keyTable = mock(TypedTable.class);
+    TypedTable<String, OmKeyInfo> keyTable1 = mock(TypedTable.class);
+    TypedTable<String, OmKeyInfo> keyTable2 = mock(TypedTable.class);
 
-    TypedTable.TypedTableIterator mockKeyIter = mock(TypedTable
+    TypedTable.TypedTableIterator mockKeyIter1 = mock(TypedTable
         .TypedTableIterator.class);
-    TypedTable.TypedKeyValue mockKeyValue = mock(
+    TypedTable.TypedTableIterator mockKeyIter2 = mock(TypedTable
+        .TypedTableIterator.class);
+    TypedTable.TypedKeyValue mockKeyValue1 = mock(
+        TypedTable.TypedKeyValue.class);
+    TypedTable.TypedKeyValue mockKeyValue2 = mock(
         TypedTable.TypedKeyValue.class);
 
-    when(keyTable.iterator()).thenReturn(mockKeyIter);
-    when(omMetadataManager.getKeyTable(getBucketLayout())).thenReturn(keyTable);
-    when(mockKeyIter.hasNext())
+    when(keyTable1.iterator()).thenReturn(mockKeyIter1);
+    when(keyTable2.iterator()).thenReturn(mockKeyIter2);
+
+    when(omMetadataManager.getKeyTable(BucketLayout.LEGACY)).thenReturn(keyTable1);
+    when(omMetadataManager.getKeyTable(BucketLayout.FILE_SYSTEM_OPTIMIZED)).thenReturn(keyTable2);
+
+    when(mockKeyIter1.hasNext())
         .thenAnswer(AdditionalAnswers.returnsElementsOf(hasNextAnswer));
-    when(mockKeyIter.next()).thenReturn(mockKeyValue);
-    when(mockKeyValue.getValue())
+    when(mockKeyIter2.hasNext())
+        .thenAnswer(AdditionalAnswers.returnsElementsOf(hasNextAnswer));
+    when(mockKeyIter1.next()).thenReturn(mockKeyValue1);
+    when(mockKeyIter2.next()).thenReturn(mockKeyValue2);
+
+    when(mockKeyValue1.getValue())
+        .thenAnswer(AdditionalAnswers.returnsElementsOf(omKeyInfoList));
+    when(mockKeyValue2.getValue())
         .thenAnswer(AdditionalAnswers.returnsElementsOf(omKeyInfoList));
 
     Pair<String, Boolean> result =
@@ -295,16 +330,16 @@ public class TestFileSizeCountTask extends AbstractReconSqlDBTest {
         .value1("vol1")
         .value2("bucket1")
         .value3(1024L);
-    assertEquals(1L,
+    assertEquals(2L,
         fileCountBySizeDao.findById(recordToFind).getCount().longValue());
     // file size upper bound for 100000L is 131072L (next highest power of 2)
     recordToFind.value1("vol1");
     recordToFind.value3(131072L);
-    assertEquals(1L,
+    assertEquals(2L,
         fileCountBySizeDao.findById(recordToFind).getCount().longValue());
     recordToFind.value2("bucket500");
     recordToFind.value3(Long.MAX_VALUE);
-    assertEquals(1L,
+    assertEquals(2L,
         fileCountBySizeDao.findById(recordToFind).getCount().longValue());
   }
 
@@ -324,12 +359,23 @@ public class TestFileSizeCountTask extends AbstractReconSqlDBTest {
           long fileSize = (long)Math.pow(2, keyIndex + 9) - 1L;
           given(omKeyInfo.getDataSize()).willReturn(fileSize);
           omKeyInfoList.add(omKeyInfo);
-          omDbEventList.add(new OMUpdateEventBuilder()
-              .setAction(PUT)
-              .setKey("key" + keyIndex)
-              .setValue(omKeyInfo)
-              .setTable(OmMetadataManagerImpl.KEY_TABLE)
-              .build());
+          // All the keys ending with even will be stored in KEY-TABLE
+          if(keyIndex % 2 ==0){
+            omDbEventList.add(new OMUpdateEventBuilder()
+                .setAction(PUT)
+                .setKey("key" + keyIndex)
+                .setValue(omKeyInfo)
+                .setTable(OmMetadataManagerImpl.KEY_TABLE)
+                .build());
+          }else{
+            // All the keys ending with odd will be stored in FILE-TABLE
+            omDbEventList.add(new OMUpdateEventBuilder()
+                .setAction(PUT)
+                .setKey("key" + keyIndex)
+                .setValue(omKeyInfo)
+                .setTable(OmMetadataManagerImpl.FILE_TABLE)
+                .build());
+          }
         }
       }
     }
@@ -368,24 +414,44 @@ public class TestFileSizeCountTask extends AbstractReconSqlDBTest {
           if (keyIndex <= 5) {
             long fileSize = (long)Math.pow(2, keyIndex + 9) - 1L;
             given(omKeyInfo.getDataSize()).willReturn(fileSize);
-            omDbEventList.add(new OMUpdateEventBuilder()
-                .setAction(DELETE)
-                .setKey("key" + keyIndex)
-                .setValue(omKeyInfo)
-                .setTable(OmMetadataManagerImpl.KEY_TABLE)
-                .build());
+            if(keyIndex % 2 ==0){
+              omDbEventList.add(new OMUpdateEventBuilder()
+                  .setAction(DELETE)
+                  .setKey("key" + keyIndex)
+                  .setValue(omKeyInfo)
+                  .setTable(OmMetadataManagerImpl.KEY_TABLE)
+                  .build());
+            } else {
+              omDbEventList.add(new OMUpdateEventBuilder()
+                  .setAction(DELETE)
+                  .setKey("key" + keyIndex)
+                  .setValue(omKeyInfo)
+                  .setTable(OmMetadataManagerImpl.FILE_TABLE)
+                  .build());
+            }
           } else {
             // update all the files with keyIndex > 5 to filesize 1023L
             // so that they get into first bin
             given(omKeyInfo.getDataSize()).willReturn(1023L);
-            omDbEventList.add(new OMUpdateEventBuilder()
-                .setAction(UPDATE)
-                .setKey("key" + keyIndex)
-                .setValue(omKeyInfo)
-                .setTable(OmMetadataManagerImpl.KEY_TABLE)
-                .setOldValue(
-                    omKeyInfoList.get((volIndex * bktIndex) + keyIndex))
-                .build());
+            if (keyIndex % 2 == 0) {
+              omDbEventList.add(new OMUpdateEventBuilder()
+                  .setAction(UPDATE)
+                  .setKey("key" + keyIndex)
+                  .setValue(omKeyInfo)
+                  .setTable(OmMetadataManagerImpl.KEY_TABLE)
+                  .setOldValue(
+                      omKeyInfoList.get((volIndex * bktIndex) + keyIndex))
+                  .build());
+            } else {
+              omDbEventList.add(new OMUpdateEventBuilder()
+                  .setAction(UPDATE)
+                  .setKey("key" + keyIndex)
+                  .setValue(omKeyInfo)
+                  .setTable(OmMetadataManagerImpl.FILE_TABLE)
+                  .setOldValue(
+                      omKeyInfoList.get((volIndex * bktIndex) + keyIndex))
+                  .build());
+            }
           }
         }
       }
@@ -417,7 +483,4 @@ public class TestFileSizeCountTask extends AbstractReconSqlDBTest {
         .getCount().longValue());
   }
 
-  private BucketLayout getBucketLayout() {
-    return BucketLayout.DEFAULT;
-  }
 }

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/tasks/TestFileSizeCountTask.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/tasks/TestFileSizeCountTask.java
@@ -73,7 +73,7 @@ public class TestFileSizeCountTask extends AbstractReconSqlDBTest {
   }
 
   @Test
-  public void testReprocessFSO1() throws IOException {
+  public void testReprocessFSO() throws IOException {
     OmKeyInfo[] omKeyInfos = new OmKeyInfo[3];
     String[] keyNames = {"key1", "key2", "key3"};
     String[] volumeNames = {"vol1", "vol1", "vol1"};
@@ -92,40 +92,40 @@ public class TestFileSizeCountTask extends AbstractReconSqlDBTest {
     // Create two mock instances of TypedTable, one for FILE_SYSTEM_OPTIMIZED
     // layout and one for LEGACY layout
     OMMetadataManager omMetadataManager = mock(OmMetadataManagerImpl.class);
-    TypedTable<String, OmKeyInfo> keyTable1 = mock(TypedTable.class);
-    TypedTable<String, OmKeyInfo> keyTable2 = mock(TypedTable.class);
+    TypedTable<String, OmKeyInfo> keyTableLegacy = mock(TypedTable.class);
+    TypedTable<String, OmKeyInfo> keyTableFso = mock(TypedTable.class);
 
     // Set return values for getKeyTable() for FILE_SYSTEM_OPTIMIZED
     // and LEGACY layout
-    when(omMetadataManager.getKeyTable(eq(BucketLayout.FILE_SYSTEM_OPTIMIZED)))
-        .thenReturn(keyTable1);
     when(omMetadataManager.getKeyTable(eq(BucketLayout.LEGACY)))
-        .thenReturn(keyTable2);
+        .thenReturn(keyTableLegacy);
+    when(omMetadataManager.getKeyTable(eq(BucketLayout.FILE_SYSTEM_OPTIMIZED)))
+        .thenReturn(keyTableFso);
 
     // Create two mock instances of TypedTableIterator, one for each
     // instance of TypedTable
-    TypedTable.TypedTableIterator mockKeyIter1 =
+    TypedTable.TypedTableIterator mockKeyIterLegacy =
         mock(TypedTable.TypedTableIterator.class);
-    when(keyTable1.iterator()).thenReturn(mockKeyIter1);
+    when(keyTableLegacy.iterator()).thenReturn(mockKeyIterLegacy);
     // Set return values for hasNext() and next() of the mock instance of
-    // TypedTableIterator for keyTable1
-    when(mockKeyIter1.hasNext()).thenReturn(true, true, true, false);
-    TypedTable.TypedKeyValue mockKeyValue1 =
+    // TypedTableIterator for keyTableLegacy
+    when(mockKeyIterLegacy.hasNext()).thenReturn(true, true, true, false);
+    TypedTable.TypedKeyValue mockKeyValueLegacy =
         mock(TypedTable.TypedKeyValue.class);
-    when(mockKeyIter1.next()).thenReturn(mockKeyValue1);
-    when(mockKeyValue1.getValue()).thenReturn(omKeyInfos[0], omKeyInfos[1],
+    when(mockKeyIterLegacy.next()).thenReturn(mockKeyValueLegacy);
+    when(mockKeyValueLegacy.getValue()).thenReturn(omKeyInfos[0], omKeyInfos[1],
         omKeyInfos[2]);
 
 
-    // Same as above, but for keyTable2
-    TypedTable.TypedTableIterator mockKeyIter2 =
+    // Same as above, but for keyTableFso
+    TypedTable.TypedTableIterator mockKeyIterFso =
         mock(TypedTable.TypedTableIterator.class);
-    when(keyTable2.iterator()).thenReturn(mockKeyIter2);
-    when(mockKeyIter2.hasNext()).thenReturn(true, true, true, false);
-    TypedTable.TypedKeyValue mockKeyValue2 =
+    when(keyTableFso.iterator()).thenReturn(mockKeyIterFso);
+    when(mockKeyIterFso.hasNext()).thenReturn(true, true, true, false);
+    TypedTable.TypedKeyValue mockKeyValueFso =
         mock(TypedTable.TypedKeyValue.class);
-    when(mockKeyIter2.next()).thenReturn(mockKeyValue2);
-    when(mockKeyValue2.getValue()).thenReturn(omKeyInfos[0], omKeyInfos[1],
+    when(mockKeyIterFso.next()).thenReturn(mockKeyValueFso);
+    when(mockKeyValueFso.getValue()).thenReturn(omKeyInfos[0], omKeyInfos[1],
         omKeyInfos[2]);
 
     // Reprocess could be called from table having existing entries. Adding
@@ -288,36 +288,36 @@ public class TestFileSizeCountTask extends AbstractReconSqlDBTest {
     hasNextAnswer.add(false);
 
     OMMetadataManager omMetadataManager = mock(OmMetadataManagerImpl.class);
-    TypedTable<String, OmKeyInfo> keyTable1 = mock(TypedTable.class);
-    TypedTable<String, OmKeyInfo> keyTable2 = mock(TypedTable.class);
+    TypedTable<String, OmKeyInfo> keyTableLegacy = mock(TypedTable.class);
+    TypedTable<String, OmKeyInfo> keyTableFso = mock(TypedTable.class);
 
-    TypedTable.TypedTableIterator mockKeyIter1 = mock(TypedTable
+    TypedTable.TypedTableIterator mockKeyIterLegacy = mock(TypedTable
         .TypedTableIterator.class);
-    TypedTable.TypedTableIterator mockKeyIter2 = mock(TypedTable
+    TypedTable.TypedTableIterator mockKeyIterFso = mock(TypedTable
         .TypedTableIterator.class);
-    TypedTable.TypedKeyValue mockKeyValue1 = mock(
+    TypedTable.TypedKeyValue mockKeyValueLegacy = mock(
         TypedTable.TypedKeyValue.class);
-    TypedTable.TypedKeyValue mockKeyValue2 = mock(
+    TypedTable.TypedKeyValue mockKeyValueFso = mock(
         TypedTable.TypedKeyValue.class);
 
-    when(keyTable1.iterator()).thenReturn(mockKeyIter1);
-    when(keyTable2.iterator()).thenReturn(mockKeyIter2);
+    when(keyTableLegacy.iterator()).thenReturn(mockKeyIterLegacy);
+    when(keyTableFso.iterator()).thenReturn(mockKeyIterFso);
 
     when(omMetadataManager.getKeyTable(BucketLayout.LEGACY))
-        .thenReturn(keyTable1);
+        .thenReturn(keyTableLegacy);
     when(omMetadataManager.getKeyTable(BucketLayout.FILE_SYSTEM_OPTIMIZED))
-        .thenReturn(keyTable2);
+        .thenReturn(keyTableFso);
 
-    when(mockKeyIter1.hasNext())
+    when(mockKeyIterLegacy.hasNext())
         .thenAnswer(AdditionalAnswers.returnsElementsOf(hasNextAnswer));
-    when(mockKeyIter2.hasNext())
+    when(mockKeyIterFso.hasNext())
         .thenAnswer(AdditionalAnswers.returnsElementsOf(hasNextAnswer));
-    when(mockKeyIter1.next()).thenReturn(mockKeyValue1);
-    when(mockKeyIter2.next()).thenReturn(mockKeyValue2);
+    when(mockKeyIterLegacy.next()).thenReturn(mockKeyValueLegacy);
+    when(mockKeyIterFso.next()).thenReturn(mockKeyValueFso);
 
-    when(mockKeyValue1.getValue())
+    when(mockKeyValueLegacy.getValue())
         .thenAnswer(AdditionalAnswers.returnsElementsOf(omKeyInfoList));
-    when(mockKeyValue2.getValue())
+    when(mockKeyValueFso.getValue())
         .thenAnswer(AdditionalAnswers.returnsElementsOf(omKeyInfoList));
 
     Pair<String, Boolean> result =

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/tasks/TestFileSizeCountTask.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/tasks/TestFileSizeCountTask.java
@@ -73,7 +73,7 @@ public class TestFileSizeCountTask extends AbstractReconSqlDBTest {
   }
 
   @Test
-  public void testReprocessFSO() throws IOException {
+  public void testReprocess() throws IOException {
     OmKeyInfo[] omKeyInfos = new OmKeyInfo[3];
     String[] keyNames = {"key1", "key2", "key3"};
     String[] volumeNames = {"vol1", "vol1", "vol1"};

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/tasks/TestFileSizeCountTask.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/tasks/TestFileSizeCountTask.java
@@ -142,7 +142,8 @@ public class TestFileSizeCountTask extends AbstractReconSqlDBTest {
     // Verify that the number of entries in fileCountBySizeDao is 3
     assertEquals(3, fileCountBySizeDao.count());
 
-    // Create a record to find the count of files in a specific volume, bucket and file size
+    // Create a record to find the count of files in a specific volume,
+    // bucket and file size
     Record3<String, String, Long> recordToFind = dslContext
         .newRecord(FILE_COUNT_BY_SIZE.VOLUME,
             FILE_COUNT_BY_SIZE.BUCKET,
@@ -302,8 +303,10 @@ public class TestFileSizeCountTask extends AbstractReconSqlDBTest {
     when(keyTable1.iterator()).thenReturn(mockKeyIter1);
     when(keyTable2.iterator()).thenReturn(mockKeyIter2);
 
-    when(omMetadataManager.getKeyTable(BucketLayout.LEGACY)).thenReturn(keyTable1);
-    when(omMetadataManager.getKeyTable(BucketLayout.FILE_SYSTEM_OPTIMIZED)).thenReturn(keyTable2);
+    when(omMetadataManager.getKeyTable(BucketLayout.LEGACY))
+        .thenReturn(keyTable1);
+    when(omMetadataManager.getKeyTable(BucketLayout.FILE_SYSTEM_OPTIMIZED))
+        .thenReturn(keyTable2);
 
     when(mockKeyIter1.hasNext())
         .thenAnswer(AdditionalAnswers.returnsElementsOf(hasNextAnswer));
@@ -360,14 +363,14 @@ public class TestFileSizeCountTask extends AbstractReconSqlDBTest {
           given(omKeyInfo.getDataSize()).willReturn(fileSize);
           omKeyInfoList.add(omKeyInfo);
           // All the keys ending with even will be stored in KEY-TABLE
-          if(keyIndex % 2 ==0){
+          if (keyIndex % 2 == 0) {
             omDbEventList.add(new OMUpdateEventBuilder()
                 .setAction(PUT)
                 .setKey("key" + keyIndex)
                 .setValue(omKeyInfo)
                 .setTable(OmMetadataManagerImpl.KEY_TABLE)
                 .build());
-          }else{
+          } else {
             // All the keys ending with odd will be stored in FILE-TABLE
             omDbEventList.add(new OMUpdateEventBuilder()
                 .setAction(PUT)
@@ -414,7 +417,7 @@ public class TestFileSizeCountTask extends AbstractReconSqlDBTest {
           if (keyIndex <= 5) {
             long fileSize = (long)Math.pow(2, keyIndex + 9) - 1L;
             given(omKeyInfo.getDataSize()).willReturn(fileSize);
-            if(keyIndex % 2 ==0){
+            if (keyIndex % 2 == 0) {
               omDbEventList.add(new OMUpdateEventBuilder()
                   .setAction(DELETE)
                   .setKey("key" + keyIndex)


### PR DESCRIPTION
## What changes were proposed in this pull request?

In order to display the sizes of files stored in FSO (File Storage Optimised) buckets on the user interface, you will need to update the code that retrieves and displays the file information to also include files stored in FSO buckets. 


## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-7832?filter=-1

## How was this patch tested?

- Modified the existing UT's to check support for FSO

- Checked the UI by manually creating a Legacy, FSO and OBS bucket - 
```
ozone sh bucket create --layout FILE_SYSTEM_OPTIMIZED /s3v/fso-bucket
ozone sh key put s3v/fso-bucket/key1-fso NOTICE.txt
ozone sh key put s3v/fso-bucket/key2-fso NOTICE.txt

ozone sh bucket create --layout OBJECT_STORE /s3v/obs-bucket
ozone sh key put s3v/obs-bucket/key1-obs NOTICE.txt
ozone sh key put s3v/obs-bucket/key2-obs NOTICE.txt
ozone sh key put s3v/obs-bucket/key3-obs  NOTICE.txt

ozone sh bucket create s3v/legacy-bucket
ozone sh key put s3v/legacy-bucket/key1-legacy NOTICE.txt
ozone sh key put s3v/legacy-bucket/key2-legacy NOTICE.txt
```
### Total keys 7 across all the buckets in S3V volume :- 
<img width="894" alt="image" src="https://user-images.githubusercontent.com/98023601/217560330-3a3f078c-36a6-4d9b-aa92-5a548b7cba54.png">

### Total 2 Keys in FSO bucket :- 
<img width="850" alt="image" src="https://user-images.githubusercontent.com/98023601/217560551-49f04f21-8722-43a9-b0b5-67634fb244e3.png">

### Total 3 Keys in OBS bucket :- 
<img width="822" alt="image" src="https://user-images.githubusercontent.com/98023601/217560651-67f22838-1eb9-4e53-b69c-a085b3e9ef80.png">

### Total 2 Keys in Legacy bucket :- 
<img width="792" alt="image" src="https://user-images.githubusercontent.com/98023601/217560724-c37ae288-67bf-4773-9a35-6b6fb5398e8d.png">



