### PR TITLE
HDDS-7834. Remove unnecessary streams

### DIFF
--- a/hadoop-hdds/client/src/test/java/org/apache/hadoop/ozone/client/io/ECStreamTestUtil.java
+++ b/hadoop-hdds/client/src/test/java/org/apache/hadoop/ozone/client/io/ECStreamTestUtil.java
@@ -46,7 +46,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.SplittableRandom;
 import java.util.function.Function;
-import java.util.stream.Collectors;
 
 /**
  * Utility class providing methods useful in EC tests.
@@ -230,7 +229,7 @@ public final class ECStreamTestUtil {
 
     public synchronized
         List<ECStreamTestUtil.TestBlockInputStream> getBlockStreams() {
-      return blockStreams.values().stream().collect(Collectors.toList());
+      return new ArrayList<>(blockStreams.values());
     }
 
     public synchronized Set<Integer> getStreamIndexes() {

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ECContainerReplicaCount.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ECContainerReplicaCount.java
@@ -324,7 +324,7 @@ public class ECContainerReplicaCount implements ContainerReplicaCount {
     for (Integer i : decommissionIndexes.keySet()) {
       missing.remove(i);
     }
-    return missing.stream().collect(Collectors.toList());
+    return new ArrayList<>(missing);
   }
 
   /**

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/LegacyReplicationManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/LegacyReplicationManager.java
@@ -871,7 +871,7 @@ public class LegacyReplicationManager {
       // check whether {Existing replicas + Target_Dn - Source_Dn}
       // satisfies current placement policy
       if (!isPolicySatisfiedAfterMove(cif, srcDn, targetDn,
-          currentReplicas.stream().collect(Collectors.toList()))) {
+          new ArrayList<>(currentReplicas))) {
         ret.complete(MoveResult.PLACEMENT_POLICY_NOT_SATISFIED);
         return ret;
       }
@@ -905,8 +905,7 @@ public class LegacyReplicationManager {
   private boolean isPolicySatisfiedAfterMove(ContainerInfo cif,
                     DatanodeDetails srcDn, DatanodeDetails targetDn,
                     final List<ContainerReplica> replicas) {
-    Set<ContainerReplica> movedReplicas =
-        replicas.stream().collect(Collectors.toSet());
+    Set<ContainerReplica> movedReplicas = new HashSet<>(replicas);
     movedReplicas.removeIf(r -> r.getDatanodeDetails().equals(srcDn));
     movedReplicas.add(ContainerReplica.newBuilder()
         .setDatanodeDetails(targetDn)
@@ -1368,8 +1367,7 @@ public class LegacyReplicationManager {
         cif.getReplicationConfig().getRequiredNodes();
     ContainerPlacementStatus currentCPS =
         getPlacementStatus(replicaSet, replicationFactor);
-    Set<ContainerReplica> newReplicaSet = replicaSet.
-        stream().collect(Collectors.toSet());
+    Set<ContainerReplica> newReplicaSet = new HashSet<>(replicaSet);
     newReplicaSet.removeIf(r -> r.getDatanodeDetails().equals(srcDn));
     ContainerPlacementStatus newCPS =
         getPlacementStatus(newReplicaSet, replicationFactor);

--- a/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicRootedOzoneFileSystem.java
+++ b/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicRootedOzoneFileSystem.java
@@ -786,9 +786,7 @@ public class BasicRootedOzoneFileSystem extends FileSystem {
     do {
       tmpStatusList =
           adapter.listStatus(pathToKey(f), false, startPath,
-              numEntries, uri, workingDir, getUsername())
-              .stream()
-              .collect(Collectors.toList());
+              numEntries, uri, workingDir, getUsername());
 
       if (!tmpStatusList.isEmpty()) {
         if (startPath.isEmpty() || !statuses.getLast().getPath().toString()


### PR DESCRIPTION
## What changes were proposed in this pull request?

Streams are overkill for simple list/set conversion, when no filtering/transformation is applied.  These can be replaced with a simple constructor call.

https://issues.apache.org/jira/browse/HDDS-7834

## How was this patch tested?

No functional change, so existing tests cover it.

https://github.com/adoroszlai/hadoop-ozone/actions/runs/3999006508