### PR TITLE
HDDS-7808. Intermittent failure in TestReplicationManager#testUnderReplicationQueuePopulated

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ReplicationManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ReplicationManager.java
@@ -265,10 +265,6 @@ public class ReplicationManager implements SCMService {
       metrics = ReplicationManagerMetrics.create(this);
       legacyReplicationManager.setMetrics(metrics);
       containerReplicaPendingOps.setReplicationMetrics(metrics);
-      replicationMonitor = new Thread(this::run);
-      replicationMonitor.setName("ReplicationMonitor");
-      replicationMonitor.setDaemon(true);
-      replicationMonitor.start();
       startSubServices();
     } else {
       LOG.info("Replication Monitor Thread is already running.");
@@ -311,7 +307,13 @@ public class ReplicationManager implements SCMService {
    * Create Replication Manager sub services such as Over and Under Replication
    * processors.
    */
-  private void startSubServices() {
+  @VisibleForTesting
+  protected void startSubServices() {
+    replicationMonitor = new Thread(this::run);
+    replicationMonitor.setName("ReplicationMonitor");
+    replicationMonitor.setDaemon(true);
+    replicationMonitor.start();
+
     underReplicatedProcessorThread = new Thread(underReplicatedProcessor);
     underReplicatedProcessorThread.setName("Under Replicated Processor");
     underReplicatedProcessorThread.setDaemon(true);

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestReplicationManager.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestReplicationManager.java
@@ -133,7 +133,12 @@ public class TestReplicationManager {
         nodeManager,
         clock,
         legacyReplicationManager,
-        containerReplicaPendingOps);
+        containerReplicaPendingOps) {
+      @Override
+      protected void startSubServices() {
+        // do not start any threads for processing
+      }
+    };
     containerReplicaMap = new HashMap<>();
     containerInfoSet = new HashSet<>();
     repConfig = new ECReplicationConfig(3, 2);


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fix intermittent failure in `TestReplicationManager#testUnderReplicationQueuePopulated`.  Unexpected results were caused by concurrent processing of the replication queue in background threads.  The unit test assumes deterministic results after explicit `processAll` calls.  The patch disables those threads for the unit test.

https://issues.apache.org/jira/browse/HDDS-7808

## How was this patch tested?

Reproduced the problem without the fix in 5 out of 1000 repetitions:
https://github.com/adoroszlai/hadoop-ozone/actions/runs/4016532071/jobs/6899876966#step:5:750
https://github.com/adoroszlai/hadoop-ozone/actions/runs/4016532071/jobs/6899875959#step:5:750
https://github.com/adoroszlai/hadoop-ozone/actions/runs/4016532071/jobs/6899876132#step:5:750

With the fix, the failure has not happened in any of the 1000 repetitions:
https://github.com/adoroszlai/hadoop-ozone/actions/runs/4016703254

Regular CI:
https://github.com/adoroszlai/hadoop-ozone/actions/runs/4016369664