### PR TITLE
HDDS-7845. [Snapshot] Wait for RocksDB checkpoint directory creation

### DIFF
--- a/hadoop-hdds/framework/pom.xml
+++ b/hadoop-hdds/framework/pom.xml
@@ -166,7 +166,11 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
       <artifactId>rocksdb-checkpoint-differ</artifactId>
       <version>${hdds.version}</version>
     </dependency>
-
+    <dependency>
+      <groupId>org.awaitility</groupId>
+      <artifactId>awaitility</artifactId>
+      <version>4.2.0</version>
+    </dependency>
   </dependencies>
 
 

--- a/hadoop-hdds/framework/pom.xml
+++ b/hadoop-hdds/framework/pom.xml
@@ -169,7 +169,6 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <dependency>
       <groupId>org.awaitility</groupId>
       <artifactId>awaitility</artifactId>
-      <version>4.2.0</version>
     </dependency>
   </dependencies>
 

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/RDBCheckpointManager.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/RDBCheckpointManager.java
@@ -111,7 +111,8 @@ public class RDBCheckpointManager implements Closeable {
     try {
       await().until(file::exists);
     } catch (ConditionTimeoutException exception) {
-      LOG.info("Checkpoint directory didn't get created in 10 secs.");
+      LOG.info("Checkpoint directory: {} didn't get created in 10 secs.",
+          file.getAbsolutePath());
     }
   }
 

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/RDBCheckpointManager.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/RDBCheckpointManager.java
@@ -26,14 +26,13 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.time.Duration;
 import java.time.Instant;
-
-import static org.awaitility.Awaitility.await;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.hadoop.hdds.utils.db.RocksDatabase.RocksCheckpoint;
-
 import org.awaitility.core.ConditionTimeoutException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import static org.awaitility.Awaitility.await;
 
 /**
  * RocksDB Checkpoint Manager, used to create and cleanup checkpoints.

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/RDBCheckpointManager.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/RDBCheckpointManager.java
@@ -44,9 +44,9 @@ public class RDBCheckpointManager implements Closeable {
   private static final Logger LOG =
       LoggerFactory.getLogger(RDBCheckpointManager.class);
   private final String checkpointNamePrefix;
-  private static final Duration pollDelayDuration = Duration.ZERO;
-  private static final Duration pollIntervalDuration = Duration.ofMillis(100);
-  private static final Duration pollMaxDuration = Duration.ofSeconds(5);
+  private static final Duration POLL_DELAY_DURATION = Duration.ZERO;
+  private static final Duration POLL_INTERVAL_DURATION = Duration.ofMillis(100);
+  private static final Duration POLL_MAX_DURATION = Duration.ofSeconds(5);
 
   /**
    * Create a checkpoint manager with a prefix to be added to the
@@ -114,9 +114,9 @@ public class RDBCheckpointManager implements Closeable {
   private void waitForCheckpointDirectoryExist(File file) throws IOException {
     Instant start = Instant.now();
     try {
-      with().atMost(pollMaxDuration)
-          .pollDelay(pollDelayDuration)
-          .pollInterval(pollIntervalDuration)
+      with().atMost(POLL_MAX_DURATION)
+          .pollDelay(POLL_DELAY_DURATION)
+          .pollInterval(POLL_INTERVAL_DURATION)
           .await()
           .until(file::exists);
       LOG.info("Waited for {} milliseconds for checkpoint directory {}" +

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmKeyInfo.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmKeyInfo.java
@@ -761,7 +761,8 @@ public final class OmKeyInfo extends WithParentObjectId {
         .setObjectID(objectID)
         .setUpdateID(updateID)
         .setParentObjectID(parentObjectID)
-        .setFileName(fileName);
+        .setFileName(fileName)
+        .setFile(isFile);
 
     keyLocationVersions.forEach(keyLocationVersion ->
         builder.addOmKeyLocationInfoGroup(

--- a/hadoop-ozone/dist/src/main/license/bin/LICENSE.txt
+++ b/hadoop-ozone/dist/src/main/license/bin/LICENSE.txt
@@ -445,7 +445,7 @@ Apache License 2.0
    org.xerial:sqlite-jdbc
    org.yaml:snakeyaml
    software.amazon.ion:ion-java
-
+   org.awaitility:awaitility
 
 MIT
 =====================

--- a/hadoop-ozone/dist/src/main/license/jar-report.txt
+++ b/hadoop-ozone/dist/src/main/license/jar-report.txt
@@ -8,6 +8,7 @@ share/ozone/lib/aopalliance-repackaged.jar
 share/ozone/lib/asm.jar
 share/ozone/lib/aspectjrt.jar
 share/ozone/lib/aspectjweaver.jar
+share/ozone/lib/awaitility.jar
 share/ozone/lib/aws-java-sdk-core.jar
 share/ozone/lib/aws-java-sdk-kms.jar
 share/ozone/lib/aws-java-sdk-s3.jar
@@ -60,6 +61,7 @@ share/ozone/lib/hadoop-hdfs-client.jar
 share/ozone/lib/hadoop-hdfs.jar
 share/ozone/lib/hadoop-shaded-guava.jar
 share/ozone/lib/hadoop-shaded-protobuf_3_7.jar
+share/ozone/lib/hamcrest.jar
 share/ozone/lib/hdds-annotation-processing.jar
 share/ozone/lib/hdds-client.jar
 share/ozone/lib/hdds-common.jar

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/snapshot/TestOzoneSnapshotRestore.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/snapshot/TestOzoneSnapshotRestore.java
@@ -25,7 +25,6 @@ import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.scm.HddsWhiteboxTestUtils;
 import org.apache.hadoop.ozone.MiniOzoneCluster;
 import org.apache.hadoop.ozone.MiniOzoneHAClusterImpl;
-import org.apache.hadoop.ozone.TestDataUtil;
 import org.apache.hadoop.ozone.client.ObjectStore;
 import org.apache.hadoop.ozone.client.OzoneBucket;
 import org.apache.hadoop.ozone.client.OzoneClient;
@@ -39,7 +38,6 @@ import org.apache.hadoop.ozone.om.OmSnapshotManager;
 import org.apache.hadoop.ozone.om.OzoneManager;
 import org.apache.hadoop.ozone.om.helpers.BucketLayout;
 import org.apache.hadoop.ozone.om.helpers.SnapshotInfo;
-import org.apache.hadoop.ozone.om.protocol.OzoneManagerProtocol;
 import org.apache.hadoop.util.ToolRunner;
 import org.apache.ozone.test.GenericTestUtils;
 import org.junit.jupiter.api.AfterEach;
@@ -71,15 +69,10 @@ import static org.junit.jupiter.params.provider.Arguments.arguments;
 @Timeout(value = 300)
 public class TestOzoneSnapshotRestore {
   private static final String OM_SERVICE_ID = "om-service-test-1";
-  private static BucketLayout bucketLayout = BucketLayout.LEGACY;
-  private static MiniOzoneCluster cluster = null;
-  private static String volumeName;
-  private static String bucketName;
-  private static OzoneManagerProtocol writeClient;
-  private static ObjectStore store;
-  private static File metaDir;
-  private static OzoneManager leaderOzoneManager;
-  private static OzoneBucket ozoneBucket;
+  private MiniOzoneCluster cluster;
+  private ObjectStore store;
+  private File metaDir;
+  private OzoneManager leaderOzoneManager;
   private OzoneConfiguration clientConf;
 
   private static Stream<Arguments> bucketTypes() {
@@ -111,12 +104,6 @@ public class TestOzoneSnapshotRestore {
             .build();
     cluster.waitForClusterToBeReady();
 
-    // create a volume and a bucket to be used by OzoneFileSystem
-    ozoneBucket = TestDataUtil
-            .createVolumeAndBucket(cluster, bucketLayout);
-    volumeName = ozoneBucket.getVolumeName();
-    bucketName = ozoneBucket.getName();
-
     leaderOzoneManager = ((MiniOzoneHAClusterImpl) cluster).getOMLeader();
     OzoneConfiguration leaderConfig = leaderOzoneManager.getConfiguration();
     cluster.setConf(leaderConfig);
@@ -127,7 +114,6 @@ public class TestOzoneSnapshotRestore {
 
     OzoneClient client = cluster.getClient();
     store = client.getObjectStore();
-    writeClient = store.getClientProxy().getOzoneManagerClient();
 
     KeyManagerImpl keyManager = (KeyManagerImpl) HddsWhiteboxTestUtils
             .getInternalState(leaderOzoneManager, "keyManager");

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/snapshot/TestOzoneSnapshotRestore.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/snapshot/TestOzoneSnapshotRestore.java
@@ -42,11 +42,10 @@ import org.apache.hadoop.ozone.om.helpers.SnapshotInfo;
 import org.apache.hadoop.ozone.om.protocol.OzoneManagerProtocol;
 import org.apache.hadoop.util.ToolRunner;
 import org.apache.ozone.test.GenericTestUtils;
-import org.junit.Assert;
-import org.junit.Rule;
-import org.junit.rules.Timeout;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -55,7 +54,6 @@ import java.io.File;
 import java.io.IOException;
 import java.util.Iterator;
 import java.util.UUID;
-import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.stream.Stream;
 
@@ -71,9 +69,9 @@ import static org.junit.jupiter.params.provider.Arguments.arguments;
 /**
  * Tests Snapshot Restore function.
  */
-
+@Timeout(value = 300)
 public class TestOzoneSnapshotRestore {
-  private static final String OM_SERVICE_ID = "om-service-test1";
+  private static final String OM_SERVICE_ID = "om-service-test-1";
   private static BucketLayout bucketLayout = BucketLayout.LEGACY;
   private static MiniOzoneCluster cluster = null;
   private static String volumeName;
@@ -83,8 +81,6 @@ public class TestOzoneSnapshotRestore {
   private static File metaDir;
   private static OzoneManager leaderOzoneManager;
   private static OzoneBucket ozoneBucket;
-  @Rule
-  public Timeout timeout = new Timeout(500, TimeUnit.SECONDS);
   private OzoneConfiguration clientConf;
 
   private static Stream<Arguments> bucketTypes() {
@@ -232,11 +228,11 @@ public class TestOzoneSnapshotRestore {
     String snapshotKeyPrefix = createSnapshot(volume, bucket);
 
     int volBucketKeyCount = keyCount(buck, snapshotKeyPrefix + keyPrefix);
-    Assert.assertEquals(5, volBucketKeyCount);
+    Assertions.assertEquals(5, volBucketKeyCount);
 
     deleteKeys(buck);
     int delKeyCount = keyCount(buck, keyPrefix);
-    Assert.assertEquals(0, delKeyCount);
+    Assertions.assertEquals(0, delKeyCount);
 
     String sourcePath = OM_KEY_PREFIX + volume + OM_KEY_PREFIX + bucket
             + OM_KEY_PREFIX + snapshotKeyPrefix;
@@ -247,8 +243,7 @@ public class TestOzoneSnapshotRestore {
     }
 
     int finalKeyCount = keyCount(buck, keyPrefix);
-    Assert.assertEquals(5, finalKeyCount);
-
+    Assertions.assertEquals(5, finalKeyCount);
   }
 
   @ParameterizedTest
@@ -276,7 +271,7 @@ public class TestOzoneSnapshotRestore {
     String snapshotKeyPrefix = createSnapshot(volume, bucket);
 
     int volBucketKeyCount = keyCount(buck, snapshotKeyPrefix + keyPrefix);
-    Assert.assertEquals(5, volBucketKeyCount);
+    Assertions.assertEquals(5, volBucketKeyCount);
 
     String sourcePath = OM_KEY_PREFIX + volume + OM_KEY_PREFIX + bucket
             + OM_KEY_PREFIX + snapshotKeyPrefix;
@@ -287,8 +282,7 @@ public class TestOzoneSnapshotRestore {
     }
 
     int finalKeyCount = keyCount(buck2, keyPrefix);
-    Assert.assertEquals(5, finalKeyCount);
-
+    Assertions.assertEquals(5, finalKeyCount);
   }
 
   @ParameterizedTest
@@ -320,7 +314,7 @@ public class TestOzoneSnapshotRestore {
     String snapshotKeyPrefix = createSnapshot(volume, bucket);
 
     int volBucketKeyCount = keyCount(buck, snapshotKeyPrefix + keyPrefix);
-    Assert.assertEquals(5, volBucketKeyCount);
+    Assertions.assertEquals(5, volBucketKeyCount);
 
     String sourcePath = OM_KEY_PREFIX + volume + OM_KEY_PREFIX + bucket
             + OM_KEY_PREFIX + snapshotKeyPrefix;
@@ -331,8 +325,6 @@ public class TestOzoneSnapshotRestore {
     }
 
     int finalKeyCount = keyCount(buck2, keyPrefix);
-    Assert.assertEquals(5, finalKeyCount);
-
+    Assertions.assertEquals(5, finalKeyCount);
   }
-
 }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/snapshot/TestOzoneSnapshotRestore.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/snapshot/TestOzoneSnapshotRestore.java
@@ -63,7 +63,6 @@ import static org.apache.hadoop.ozone.OzoneConsts.OM_DB_NAME;
 import static org.apache.hadoop.ozone.OzoneConsts.OM_KEY_PREFIX;
 import static org.apache.hadoop.ozone.OzoneConsts.OM_SNAPSHOT_DIR;
 import static org.apache.hadoop.ozone.OzoneConsts.OZONE_OFS_URI_SCHEME;
-import static org.junit.Assert.assertEquals;
 import static org.junit.jupiter.params.provider.Arguments.arguments;
 
 /**
@@ -98,7 +97,7 @@ public class TestOzoneSnapshotRestore {
   }
 
   @BeforeEach
-  private void init() throws Exception {
+  public void init() throws Exception {
     OzoneConfiguration conf = new OzoneConfiguration();
     String clusterId = UUID.randomUUID().toString();
     String scmId = UUID.randomUUID().toString();
@@ -200,7 +199,7 @@ public class TestOzoneSnapshotRestore {
       // Copy key from source to destination path
       int res = ToolRunner.run(shell,
               new String[]{"-cp", sourcePath, destPath});
-      assertEquals(0, res);
+      Assertions.assertEquals(0, res);
     } finally {
       shell.close();
     }

--- a/pom.xml
+++ b/pom.xml
@@ -284,6 +284,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
     <aspectj.version>1.9.7</aspectj.version>
     <aspectj-plugin.version>1.14.0</aspectj-plugin.version>
     <restrict-imports.enforcer.version>2.0.0</restrict-imports.enforcer.version>
+    <awaitility.version>4.2.0</awaitility.version>
   </properties>
 
 
@@ -1442,6 +1443,11 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
         <groupId>org.xerial</groupId>
         <artifactId>sqlite-jdbc</artifactId>
         <version>${sqlite.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.awaitility</groupId>
+        <artifactId>awaitility</artifactId>
+        <version>${awaitility.version}</version>
       </dependency>
     </dependencies>
   </dependencyManagement>


### PR DESCRIPTION
## What changes were proposed in this pull request?
This change is to add the wait of 10 secs for checkpoint directory creation with 100 millis interval poll. We can't not use [wait()](https://docs.oracle.com/javase/7/docs/api/java/lang/Object.html#wait()) and [notify()](https://docs.oracle.com/javase/7/docs/api/java/lang/Object.html#notify()) because checkpointing directory creation happens inside RocksDB and RocksDB doesn't provide any [listen](https://javadoc.io/static/org.rocksdb/rocksdbjni/7.4.5/org/rocksdb/EventListener.html) which can be overloaded to notify.
Hence we are using `awaitility` polling mechanism to check if checkpoint directory gets created in 10 secs.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-7845

## How was this patch tested?
Existing tests.