### PR TITLE
HDDS-7778. Add metrics for push replication

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/utils/IOUtils.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/utils/IOUtils.java
@@ -51,4 +51,21 @@ public final class IOUtils {
     }
   }
 
+  /**
+   * Close each argument, catching exceptions and logging them as error.
+   */
+  public static void close(Logger logger, AutoCloseable... closeables) {
+    for (AutoCloseable c : closeables) {
+      if (c != null) {
+        try {
+          c.close();
+        } catch (Exception e) {
+          if (logger != null) {
+            logger.error("Exception in closing {}", c, e);
+          }
+        }
+      }
+    }
+  }
+
 }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/DatanodeStateMachine.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/DatanodeStateMachine.java
@@ -187,7 +187,6 @@ public class DatanodeStateMachine implements Closeable {
         importer,
         new SimpleContainerDownloader(conf, dnCertClient));
     ContainerReplicator pushReplicator = new PushReplicator(
-        // TODO compression, metrics
         new OnDemandContainerReplicationSource(container.getController()),
         new GrpcContainerUploader(conf, dnCertClient)
     );

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/DatanodeStateMachine.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/DatanodeStateMachine.java
@@ -40,6 +40,7 @@ import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolPro
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.PipelineReportsProto;
 import org.apache.hadoop.hdds.security.x509.certificate.client.CertificateClient;
 import org.apache.hadoop.hdds.upgrade.HDDSLayoutVersionManager;
+import org.apache.hadoop.hdds.utils.IOUtils;
 import org.apache.hadoop.hdds.utils.LegacyHadoopConfigurationSource;
 import org.apache.hadoop.ozone.HddsDatanodeStopService;
 import org.apache.hadoop.ozone.container.common.DatanodeLayoutStorage;
@@ -119,7 +120,8 @@ public class DatanodeStateMachine implements Closeable {
    * constructor in a non-thread-safe way - see HDDS-3116.
    */
   private final ReadWriteLock constructionLock = new ReentrantReadWriteLock();
-  private final MeasuredReplicator replicatorMetrics;
+  private final MeasuredReplicator pullReplicatorWithMetrics;
+  private final MeasuredReplicator pushReplicatorWithMetrics;
   private final ReplicationSupervisorMetrics replicationSupervisorMetrics;
   private final ECReconstructionMetrics ecReconstructionMetrics;
   // This is an instance variable as mockito needs to access it in a test
@@ -190,7 +192,8 @@ public class DatanodeStateMachine implements Closeable {
         new GrpcContainerUploader(conf, dnCertClient)
     );
 
-    replicatorMetrics = new MeasuredReplicator(pullReplicator);
+    pullReplicatorWithMetrics = new MeasuredReplicator(pullReplicator, "pull");
+    pushReplicatorWithMetrics = new MeasuredReplicator(pushReplicator, "push");
 
     ReplicationConfig replicationConfig =
         conf.getObject(ReplicationConfig.class);
@@ -218,7 +221,7 @@ public class DatanodeStateMachine implements Closeable {
             conf, dnConf.getBlockDeleteThreads(),
             dnConf.getBlockDeleteQueueLimit()))
         .addHandler(new ReplicateContainerCommandHandler(conf, supervisor,
-            replicatorMetrics, pushReplicator))
+            pullReplicatorWithMetrics, pushReplicatorWithMetrics))
         .addHandler(reconstructECContainersCommandHandler)
         .addHandler(new DeleteContainerCommandHandler(
             dnConf.getContainerDeleteThreads(), clock))
@@ -590,11 +593,7 @@ public class DatanodeStateMachine implements Closeable {
    */
   public synchronized void stopDaemon() {
     try {
-      try {
-        replicatorMetrics.close();
-      } catch (Exception e) {
-        LOG.error("Couldn't stop replicator metrics", e);
-      }
+      IOUtils.close(LOG, pushReplicatorWithMetrics, pullReplicatorWithMetrics);
       supervisor.stop();
       context.setShutdownGracefully();
       context.setState(DatanodeStates.SHUTDOWN);

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/replication/MeasuredReplicator.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/replication/MeasuredReplicator.java
@@ -36,9 +36,10 @@ import org.apache.hadoop.util.Time;
 @Metrics(about = "Closed container replication metrics", context = "dfs")
 public class MeasuredReplicator implements ContainerReplicator, AutoCloseable {
 
-  private static final String NAME = ContainerReplicator.class.toString();
+  private static final String NAME = ContainerReplicator.class.getSimpleName();
 
   private final ContainerReplicator delegate;
+  private final String name;
 
   @Metric(about = "Number of successful replication tasks")
   private MutableCounterLong success;
@@ -61,10 +62,15 @@ public class MeasuredReplicator implements ContainerReplicator, AutoCloseable {
   @Metric(about = "Bytes transferred for successful replication tasks")
   private MutableGaugeLong transferredBytes;
 
-  public MeasuredReplicator(ContainerReplicator delegate) {
+  public MeasuredReplicator(ContainerReplicator delegate, String name) {
     this.delegate = delegate;
-    DefaultMetricsSystem.instance()
-        .register(NAME, "Closed container replication", this);
+    this.name = name;
+    DefaultMetricsSystem.instance().register(metricsName(),
+        "Closed container " + name + " replication metrics", this);
+  }
+
+  private String metricsName() {
+    return NAME + "/" + name;
   }
 
   @Override
@@ -89,7 +95,7 @@ public class MeasuredReplicator implements ContainerReplicator, AutoCloseable {
 
   @Override
   public void close() throws Exception {
-    DefaultMetricsSystem.instance().unregisterSource(NAME);
+    DefaultMetricsSystem.instance().unregisterSource(metricsName());
   }
 
   @VisibleForTesting
@@ -127,4 +133,9 @@ public class MeasuredReplicator implements ContainerReplicator, AutoCloseable {
     return failureBytes;
   }
 
+  @Override
+  public String toString() {
+    return getClass().getSimpleName() + "{" + name + "}@"
+        + Integer.toHexString(hashCode());
+  }
 }

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/replication/TestMeasuredReplicator.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/replication/TestMeasuredReplicator.java
@@ -54,7 +54,7 @@ public class TestMeasuredReplicator {
         e.printStackTrace();
       }
     };
-    measuredReplicator = new MeasuredReplicator(replicator);
+    measuredReplicator = new MeasuredReplicator(replicator, "test");
   }
 
   @AfterEach


### PR DESCRIPTION
## What changes were proposed in this pull request?

Reuse existing `MeasuredReplicator` wrapper to register metrics for push replication, too.

https://issues.apache.org/jira/browse/HDDS-7778

## How was this patch tested?

Ran replication test (copied from `ozonesecure`) in `ozone` compose environment:

```
start_docker_env 3

execute_robot_test scm basic/basic.robot

execute_robot_test scm admincli/container.robot

# test replication
docker-compose up -d --scale datanode=2
execute_robot_test scm -v container:1 -v count:2 replication/wait.robot
docker-compose up -d --scale datanode=3
execute_robot_test scm -v container:1 -v count:3 replication/wait.robot
```

Datanode log:

```
[ContainerReplicationThread-0] INFO replication.GrpcOutputStream: Sent 30208 bytes for container 1
```

Verified metrics via JMX:

```
{
  "name" : "Hadoop:service=HddsDatanode,name=ContainerReplicator/push",
  "modelerType" : "ContainerReplicator/push",
  "tag.Context" : "dfs",
  "tag.Hostname" : "afeb2cccdbb9",
  "Failure" : 0,
  "FailureBytes" : 0,
  "FailureTime" : 0,
  "QueueTime" : 3,
  "Success" : 1,
  "SuccessTime" : 245,
  "TransferredBytes" : 30208
}
```

Regular CI:
https://github.com/adoroszlai/hadoop-ozone/actions/runs/4026673527