### PR TITLE
HDDS-7844. EC: Add normal and low priority to replication supervisor and commands

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/replication/AbstractReplicationTask.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/replication/AbstractReplicationTask.java
@@ -17,7 +17,13 @@
  */
 package org.apache.hadoop.ozone.container.replication;
 
+import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.ReplicationCommandPriority;
+
+import java.time.Clock;
 import java.time.Instant;
+import java.time.ZoneId;
+
+import static org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.ReplicationCommandPriority.NORMAL;
 
 /**
  * Abstract class to capture common variables and methods for different types
@@ -41,17 +47,26 @@ public abstract class AbstractReplicationTask {
 
   private final long containerId;
 
-  private final Instant queued = Instant.now();
+  private final Instant queued;
 
   private final long deadlineMsSinceEpoch;
 
   private final long term;
 
+  private int priority = NORMAL.getNumber();
+
   protected AbstractReplicationTask(long containerID,
       long deadlineMsSinceEpoch, long term) {
+    this(containerID, deadlineMsSinceEpoch, term,
+        Clock.system(ZoneId.systemDefault()));
+  }
+
+  protected AbstractReplicationTask(long containerID,
+      long deadlineMsSinceEpoch, long term, Clock clock) {
     this.containerId = containerID;
     this.deadlineMsSinceEpoch = deadlineMsSinceEpoch;
     this.term = term;
+    queued = Instant.now(clock);
   }
 
   public long getContainerId() {
@@ -86,5 +101,24 @@ public abstract class AbstractReplicationTask {
    * the task.
    */
   public abstract void runTask();
+
+  /**
+   * Set the relative priority of a task. Internally Tasks use the integer value
+   * associated with the ENUM parameter. An ENUM with a lower integer value
+   * will be sorted earlier in the queue than a larger value.
+   * @param priority ENUM representing an integer indicating the priority of
+   *                 this task.
+   */
+  public void setPriority(ReplicationCommandPriority priority) {
+    this.priority = priority.getNumber();
+  }
+
+  /**
+   * Returns the priority of the task. A lower number indicates a higher
+   * priority.
+   */
+  public int getPriority() {
+    return priority;
+  }
 
 }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/replication/AbstractReplicationTask.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/replication/AbstractReplicationTask.java
@@ -53,7 +53,7 @@ public abstract class AbstractReplicationTask {
 
   private final long term;
 
-  private int priority = NORMAL.getNumber();
+  private ReplicationCommandPriority priority = NORMAL;
 
   protected AbstractReplicationTask(long containerID,
       long deadlineMsSinceEpoch, long term) {
@@ -110,15 +110,14 @@ public abstract class AbstractReplicationTask {
    *                 this task.
    */
   public void setPriority(ReplicationCommandPriority priority) {
-    this.priority = priority.getNumber();
+    this.priority = priority;
   }
 
   /**
    * Returns the priority of the task. A lower number indicates a higher
    * priority.
    */
-  public int getPriority() {
+  public ReplicationCommandPriority getPriority() {
     return priority;
   }
-
 }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/replication/ReplicationSupervisor.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/replication/ReplicationSupervisor.java
@@ -20,6 +20,7 @@ package org.apache.hadoop.ozone.container.replication;
 import java.time.Clock;
 import java.util.Comparator;
 import java.util.Map;
+import java.util.Objects;
 import java.util.OptionalLong;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
@@ -50,9 +51,9 @@ public class ReplicationSupervisor {
   private static final Logger LOG =
       LoggerFactory.getLogger(ReplicationSupervisor.class);
 
-  private static final Comparator TASK_RUNNER_COMPARATOR = Comparator
-      .comparing(TaskRunner::getTaskPriority)
-      .thenComparing(TaskRunner::getTaskQueueTime);
+  private static final Comparator<TaskRunner> TASK_RUNNER_COMPARATOR =
+      Comparator.comparing(TaskRunner::getTaskPriority)
+          .thenComparing(TaskRunner::getTaskQueueTime);
 
   private final ExecutorService executor;
   private final StateContext context;
@@ -244,7 +245,24 @@ public class ReplicationSupervisor {
 
     @Override
     public int compareTo(Object o) {
-      return TASK_RUNNER_COMPARATOR.compare(this, o);
+      return TASK_RUNNER_COMPARATOR.compare(this, (TaskRunner) o);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(task);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (o == null || getClass() != o.getClass()) {
+        return false;
+      }
+      TaskRunner that = (TaskRunner) o;
+      return task.equals(that.task);
     }
   }
 

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/replication/ReplicationTask.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/replication/ReplicationTask.java
@@ -39,6 +39,7 @@ public class ReplicationTask extends AbstractReplicationTask {
   public ReplicationTask(ReplicateContainerCommand cmd,
                          ContainerReplicator replicator) {
     super(cmd.getContainerID(), cmd.getDeadline(), cmd.getTerm());
+    setPriority(cmd.getPriority());
     this.cmd = cmd;
     this.replicator = replicator;
   }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/protocol/commands/ReplicateContainerCommand.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/protocol/commands/ReplicateContainerCommand.java
@@ -22,8 +22,8 @@ import java.util.stream.Collectors;
 
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos.DatanodeDetailsProto;
-import org.apache.hadoop.hdds.protocol.proto
-    .StorageContainerDatanodeProtocolProtos.ReplicateContainerCommandProto;
+import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.ReplicationCommandPriority;
+import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.ReplicateContainerCommandProto;
 import org.apache.hadoop.hdds.protocol.proto
     .StorageContainerDatanodeProtocolProtos.ReplicateContainerCommandProto
     .Builder;
@@ -46,6 +46,8 @@ public final class ReplicateContainerCommand
   private final List<DatanodeDetails> sourceDatanodes;
   private final DatanodeDetails targetDatanode;
   private int replicaIndex = 0;
+  private ReplicationCommandPriority priority =
+      ReplicationCommandPriority.NORMAL;
 
   public static ReplicateContainerCommand fromSources(long containerID,
       List<DatanodeDetails> sourceDatanodes) {
@@ -82,6 +84,10 @@ public final class ReplicateContainerCommand
     replicaIndex = index;
   }
 
+  public void setPriority(ReplicationCommandPriority priority) {
+    this.priority = priority;
+  }
+
   @Override
   public Type getType() {
     return SCMCommandProto.Type.replicateContainerCommand;
@@ -99,6 +105,7 @@ public final class ReplicateContainerCommand
     if (targetDatanode != null) {
       builder.setTarget(targetDatanode.getProtoBufMessage());
     }
+    builder.setPriority(priority);
     return builder.build();
   }
 
@@ -122,6 +129,9 @@ public final class ReplicateContainerCommand
     if (protoMessage.hasReplicaIndex()) {
       cmd.setReplicaIndex(protoMessage.getReplicaIndex());
     }
+    if (protoMessage.hasPriority()) {
+      cmd.setPriority(protoMessage.getPriority());
+    }
     return cmd;
   }
 
@@ -141,6 +151,10 @@ public final class ReplicateContainerCommand
     return replicaIndex;
   }
 
+  public ReplicationCommandPriority getPriority() {
+    return priority;
+  }
+
   @Override
   public String toString() {
     StringBuilder sb = new StringBuilder();
@@ -152,6 +166,7 @@ public final class ReplicateContainerCommand
     } else {
       sb.append(", sourceNodes: ").append(sourceDatanodes);
     }
+    sb.append(", priority: ").append(priority);
     return sb.toString();
   }
 }

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/replication/TestReplicationSupervisor.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/replication/TestReplicationSupervisor.java
@@ -403,11 +403,23 @@ public class TestReplicationSupervisor {
     expectedOrder.add("LOW_5");
     expectedOrder.add("LOW_10");
 
+    // Before unblocking the queue, check the queue count for the OrderedTask.
+    // We loaded 3 High / normal priority and 2 low. The counter should not
+    // include the low counts.
+    Assert.assertEquals(3,
+        supervisor.getInFlightReplications(OrderedTask.class));
+    Assert.assertEquals(1,
+        supervisor.getInFlightReplications(BlockingTask.class));
+
     // Unblock the queue
     completeRunning.countDown();
     // Wait for all tasks to complete
     tasksCompleteLatch.await();
     Assert.assertEquals(expectedOrder, completionOrder);
+    Assert.assertEquals(0,
+        supervisor.getInFlightReplications(OrderedTask.class));
+    Assert.assertEquals(0,
+        supervisor.getInFlightReplications(BlockingTask.class));
   }
 
   private static class BlockingTask extends AbstractReplicationTask {

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/replication/TestReplicationSupervisor.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/replication/TestReplicationSupervisor.java
@@ -71,6 +71,7 @@ import javax.annotation.Nonnull;
 
 import static com.google.common.util.concurrent.MoreExecutors.newDirectExecutorService;
 import static java.util.Collections.emptyList;
+import static org.apache.hadoop.ozone.container.replication.AbstractReplicationTask.Status.DONE;
 import static org.junit.jupiter.api.Assertions.fail;
 import static org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.ReplicationCommandPriority.LOW;
 import static org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.ReplicationCommandPriority.NORMAL;
@@ -442,6 +443,7 @@ public class TestReplicationSupervisor {
       } catch (InterruptedException e) {
         fail("Interrupted waiting for the completion latch to be released");
       }
+      setStatus(DONE);
     }
   }
 
@@ -465,6 +467,7 @@ public class TestReplicationSupervisor {
     @Override
     public void runTask() {
       completeList.add(name);
+      setStatus(DONE);
       completeLatch.countDown();
     }
   }
@@ -560,7 +563,7 @@ public class TestReplicationSupervisor {
 
       try {
         set.addContainer(kvc);
-        task.setStatus(ReplicationTask.Status.DONE);
+        task.setStatus(DONE);
       } catch (Exception e) {
         Assert.fail("Unexpected error: " + e.getMessage());
       }

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/replication/TestReplicationSupervisor.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/replication/TestReplicationSupervisor.java
@@ -21,6 +21,7 @@ package org.apache.hadoop.ozone.container.replication;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.time.Clock;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.time.Instant;
@@ -28,6 +29,7 @@ import java.time.ZoneId;
 import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.AbstractExecutorService;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.ThreadPoolExecutor;
@@ -39,6 +41,7 @@ import org.apache.hadoop.hdds.client.ECReplicationConfig;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
 import org.apache.hadoop.hdds.protocol.MockDatanodeDetails;
+import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.ReplicationCommandPriority;
 import org.apache.hadoop.metrics2.impl.MetricsCollectorImpl;
 import org.apache.hadoop.ozone.container.common.impl.ContainerLayoutVersion;
 import org.apache.hadoop.ozone.container.common.impl.ContainerSet;
@@ -68,6 +71,9 @@ import javax.annotation.Nonnull;
 
 import static com.google.common.util.concurrent.MoreExecutors.newDirectExecutorService;
 import static java.util.Collections.emptyList;
+import static org.junit.jupiter.api.Assertions.fail;
+import static org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.ReplicationCommandPriority.LOW;
+import static org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.ReplicationCommandPriority.NORMAL;
 
 /**
  * Test the replication supervisor.
@@ -348,6 +354,107 @@ public class TestReplicationSupervisor {
 
     Assert.assertEquals(1, supervisor.getReplicationRequestCount());
     Assert.assertEquals(0, supervisor.getReplicationSuccessCount());
+  }
+
+  @Test
+  public void testPriorityOrdering() throws InterruptedException {
+    long deadline = clock.millis() + 1000;
+    long containerId = 1;
+    long term = 1;
+    OzoneConfiguration conf = new OzoneConfiguration();
+    ReplicationServer.ReplicationConfig repConf =
+        conf.getObject(ReplicationServer.ReplicationConfig.class);
+    repConf.setReplicationMaxStreams(1);
+    ReplicationSupervisor supervisor =
+        new ReplicationSupervisor(null, repConf, clock);
+
+    final CountDownLatch indicateRunning = new CountDownLatch(1);
+    final CountDownLatch completeRunning = new CountDownLatch(1);
+    // Going to create 5 tasks below, so this counter needs to be set to 5.
+    final CountDownLatch tasksCompleteLatch = new CountDownLatch(5);
+
+    supervisor.addTask(new BlockingTask(containerId, deadline, term,
+        indicateRunning, completeRunning));
+    // Wait for the first task to block the single threaded executor
+    indicateRunning.await();
+
+    List<String> completionOrder = new ArrayList<>();
+    // Now load some tasks out of order.
+    clock.fastForward(10);
+    supervisor.addTask(new OrderedTask(containerId, deadline, term, clock,
+        LOW, "LOW_10", completionOrder, tasksCompleteLatch));
+    clock.rewind(5);
+    supervisor.addTask(new OrderedTask(containerId, deadline, term, clock,
+        LOW, "LOW_5", completionOrder, tasksCompleteLatch));
+
+    supervisor.addTask(new OrderedTask(containerId, deadline, term, clock,
+        NORMAL, "HIGH_5", completionOrder, tasksCompleteLatch));
+    clock.rewind(4);
+    supervisor.addTask(new OrderedTask(containerId, deadline, term, clock,
+        NORMAL, "HIGH_1", completionOrder, tasksCompleteLatch));
+    clock.fastForward(10);
+    supervisor.addTask(new OrderedTask(containerId, deadline, term, clock,
+        NORMAL, "HIGH_11", completionOrder, tasksCompleteLatch));
+
+    List<String> expectedOrder = new ArrayList<>();
+    expectedOrder.add("HIGH_1");
+    expectedOrder.add("HIGH_5");
+    expectedOrder.add("HIGH_11");
+    expectedOrder.add("LOW_5");
+    expectedOrder.add("LOW_10");
+
+    // Unblock the queue
+    completeRunning.countDown();
+    // Wait for all tasks to complete
+    tasksCompleteLatch.await();
+    Assert.assertEquals(expectedOrder, completionOrder);
+  }
+
+  private static class BlockingTask extends AbstractReplicationTask {
+
+    private CountDownLatch runningLatch;
+    private CountDownLatch waitForCompleteLatch;
+
+    BlockingTask(long containerId, long deadlineEpochMs, long term,
+        CountDownLatch running, CountDownLatch waitForCompletion) {
+      super(containerId, deadlineEpochMs, term);
+      this.runningLatch = running;
+      this.waitForCompleteLatch = waitForCompletion;
+    }
+
+    @Override
+    public void runTask() {
+      runningLatch.countDown();
+      try {
+        waitForCompleteLatch.await();
+      } catch (InterruptedException e) {
+        fail("Interrupted waiting for the completion latch to be released");
+      }
+    }
+  }
+
+  private static class OrderedTask extends  AbstractReplicationTask {
+
+    private final String name;
+    private final List<String> completeList;
+    private final CountDownLatch completeLatch;
+
+    @SuppressWarnings("checkstyle:parameterNumber")
+    OrderedTask(long containerId, long deadlineEpochMs, long term,
+        Clock clock, ReplicationCommandPriority priority,
+        String name, List<String> completeList, CountDownLatch completeLatch) {
+      super(containerId, deadlineEpochMs, term, clock);
+      this.completeList = completeList;
+      this.name = name;
+      this.completeLatch = completeLatch;
+      setPriority(priority);
+    }
+
+    @Override
+    public void runTask() {
+      completeList.add(name);
+      completeLatch.countDown();
+    }
   }
 
   private ReplicationSupervisor supervisorWithReplicator(

--- a/hadoop-hdds/interface-server/src/main/proto/ScmServerDatanodeHeartbeatProtocol.proto
+++ b/hadoop-hdds/interface-server/src/main/proto/ScmServerDatanodeHeartbeatProtocol.proto
@@ -407,6 +407,11 @@ message DeleteContainerCommandProto {
   optional int32 replicaIndex = 4;
 }
 
+enum ReplicationCommandPriority {
+  NORMAL = 1;
+  LOW = 2;
+}
+
 /**
 This command asks the datanode to replicate a container from specific sources.
 */
@@ -416,6 +421,7 @@ message ReplicateContainerCommandProto {
   required int64 cmdId = 3;
   optional int32 replicaIndex = 4;
   optional DatanodeDetailsProto target = 5;
+  optional ReplicationCommandPriority priority = 6 [default = NORMAL];
 }
 
 /**


### PR DESCRIPTION
## What changes were proposed in this pull request?

In order to allow replication commands intended to fix under and mis-replication to run with higher priority that replication commands related to the balancer, we will change the replication supervisor to be a priority queue, ordered by priority, enqueue time.

Commands sent from the balancer will have a low priority, other commands will a normal priority. The default will be NORMAL. This means that balancer commands will not run while there are other replication commands present in the queue.

This means it is not important if the balancer adds a lot of replication commands to the queue and then some nodes go down in the cluster. The replication commands related to the down nodes will automatically get to the front of the queue.

Note that LOW priority tasks are not counted in the command queue sizes returned to SCM. This is because SCM will not consider LOW priority tasks when making decisions about where to schedule replication commands.

Note that this change does not modify the balancer to sent low priority commands, and all commands sent from SCM will be NORMAL priority for now. Another Jira will make changes to the balancer to send its replicate commands with low priority.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-7844

## How was this patch tested?

Add tests to the supervisor to validate the priority ordering works as expected.
