### PR TITLE
HDDS-7856. Fix timeout in TestPushReplicator

### DIFF
--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/replication/TestPushReplicator.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/replication/TestPushReplicator.java
@@ -21,7 +21,6 @@ import org.apache.hadoop.hdds.protocol.DatanodeDetails;
 import org.apache.hadoop.hdds.protocol.MockDatanodeDetails;
 import org.apache.hadoop.ozone.container.replication.AbstractReplicationTask.Status;
 import org.apache.ozone.test.SpyOutputStream;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 
@@ -35,6 +34,7 @@ import static org.apache.commons.io.output.NullOutputStream.NULL_OUTPUT_STREAM;
 import static org.apache.hadoop.ozone.container.replication.CopyContainerCompression.NO_COMPRESSION;
 import static org.apache.hadoop.ozone.protocol.commands.ReplicateContainerCommand.toTarget;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
@@ -43,7 +43,6 @@ import static org.mockito.Mockito.when;
 /**
  * Test for {@link PushReplicator}.
  */
-@Disabled("HDDS-7856")
 class TestPushReplicator {
 
   @Test
@@ -131,7 +130,7 @@ class TestPushReplicator {
       return null;
     })
         .when(source)
-        .copyData(containerID, outputStream, NO_COMPRESSION.name());
+        .copyData(eq(containerID), any(), eq(NO_COMPRESSION.name()));
 
     return new PushReplicator(source, uploader);
   }

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/replication/TestPushReplicator.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/replication/TestPushReplicator.java
@@ -22,6 +22,7 @@ import org.apache.hadoop.hdds.protocol.MockDatanodeDetails;
 import org.apache.hadoop.ozone.container.replication.AbstractReplicationTask.Status;
 import org.apache.ozone.test.SpyOutputStream;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.mockito.ArgumentCaptor;
 
 import java.io.IOException;
@@ -43,6 +44,7 @@ import static org.mockito.Mockito.when;
 /**
  * Test for {@link PushReplicator}.
  */
+@Timeout(30)
 class TestPushReplicator {
 
   @Test


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fix timeout in `TestPushReplicator`:

```
"main" 
   java.lang.Thread.State: WAITING
        at sun.misc.Unsafe.park(Native Method)
        at java.util.concurrent.locks.LockSupport.park(LockSupport.java:175)
        at java.util.concurrent.CompletableFuture$Signaller.block(CompletableFuture.java:1707)
        at java.util.concurrent.ForkJoinPool.managedBlock(ForkJoinPool.java:3323)
        at java.util.concurrent.CompletableFuture.waitingGet(CompletableFuture.java:1742)
        at java.util.concurrent.CompletableFuture.get(CompletableFuture.java:1908)
        at org.apache.hadoop.ozone.container.replication.PushReplicator.replicate(PushReplicator.java:62)
        at org.apache.hadoop.ozone.container.replication.TestPushReplicator.uploadCompletesNormally(TestPushReplicator.java:61)
```

The problem is that `PushReplicator` now (after HDDS-7778) wraps the output stream for counting bytes, but the test expects the original output stream to be passed to `ContainerReplicationSource#copyData`.  The `CompletableFuture` is completed by the mock's answer for the call with right arguments.  Since this call is not made, `CompletableFuture#get()` blocks.

https://issues.apache.org/jira/browse/HDDS-7856

## How was this patch tested?

```
[INFO] Running org.apache.hadoop.ozone.container.replication.TestPushReplicator
[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.348 s - in org.apache.hadoop.ozone.container.replication.TestPushReplicator
```