### PR TITLE
HDDS-7847. Handle Replication of Unhealthy Replicas in RM

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ContainerHealthResult.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ContainerHealthResult.java
@@ -278,6 +278,7 @@ public class ContainerHealthResult {
     private final int excessRedundancy;
     private final boolean sufficientlyReplicatedAfterPending;
     private boolean hasMismatchedReplicas;
+    private boolean isSafelyOverReplicated;
 
     public OverReplicatedHealthResult(ContainerInfo containerInfo,
         int excessRedundancy, boolean replicatedOkWithPending) {
@@ -316,6 +317,14 @@ public class ContainerHealthResult {
 
     public void setHasMismatchedReplicas(boolean hasMismatchedReplicas) {
       this.hasMismatchedReplicas = hasMismatchedReplicas;
+    }
+
+    public boolean isSafelyOverReplicated() {
+      return isSafelyOverReplicated;
+    }
+
+    public void setIsSafelyOverReplicated(boolean isSafelyOverReplicated) {
+      this.isSafelyOverReplicated = isSafelyOverReplicated;
     }
   }
 }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/LegacyRatisContainerReplicaCount.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/LegacyRatisContainerReplicaCount.java
@@ -48,4 +48,15 @@ public class LegacyRatisContainerReplicaCount extends
   protected int healthyReplicaCountAdapter() {
     return -getMisMatchedReplicaCount();
   }
+
+  /**
+   * For LegacyReplicationManager, unhealthy replicas are all replicas that
+   * don't match the container's state. For a CLOSED container with replicas
+   * {CLOSED, CLOSING, UNHEALTHY, OPEN}, unhealthy replica count is 3. 2
+   * mismatches (CLOSING, OPEN) + 1 UNHEALTHY = 3.
+   */
+  @Override
+  public int getUnhealthyReplicaCountAdapter() {
+    return getMisMatchedReplicaCount();
+  }
 }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/RatisContainerReplicaCount.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/RatisContainerReplicaCount.java
@@ -86,24 +86,20 @@ public class RatisContainerReplicaCount implements ContainerReplicaCount {
     for (ContainerReplica cr : this.replicas) {
       HddsProtos.NodeOperationalState state =
           cr.getDatanodeDetails().getPersistedOpState();
-      if (cr.getState() == ContainerReplicaProto.State.UNHEALTHY) {
-        unhealthyReplicaCount++;
-        if (!considerUnhealthy) {
-          continue;
-        }
-      }
       if (state == DECOMMISSIONED || state == DECOMMISSIONING) {
         decommissionCount++;
       } else if (state == IN_MAINTENANCE || state == ENTERING_MAINTENANCE) {
         maintenanceCount++;
       } else {
         if (!ReplicationManager.compareState(container.getState(),
-            cr.getState()) &&
-            cr.getState() != ContainerReplicaProto.State.UNHEALTHY) {
-          healthyReplicaCount++;
-          misMatchedReplicaCount++;
-        } else if (ReplicationManager.compareState(container.getState(),
             cr.getState())) {
+          if (cr.getState() == ContainerReplicaProto.State.UNHEALTHY) {
+            unhealthyReplicaCount++;
+          } else {
+            healthyReplicaCount++;
+            misMatchedReplicaCount++;
+          }
+        } else {
           healthyReplicaCount++;
           matchingReplicaCount++;
         }
@@ -168,24 +164,20 @@ public class RatisContainerReplicaCount implements ContainerReplicaCount {
     for (ContainerReplica cr : this.replicas) {
       HddsProtos.NodeOperationalState state =
           cr.getDatanodeDetails().getPersistedOpState();
-      if (cr.getState() == ContainerReplicaProto.State.UNHEALTHY) {
-        unhealthyReplicaCount++;
-        if (!considerUnhealthy) {
-          continue;
-        }
-      }
       if (state == DECOMMISSIONED || state == DECOMMISSIONING) {
         decommissionCount++;
       } else if (state == IN_MAINTENANCE || state == ENTERING_MAINTENANCE) {
         maintenanceCount++;
       } else {
         if (!ReplicationManager.compareState(container.getState(),
-            cr.getState()) &&
-            cr.getState() != ContainerReplicaProto.State.UNHEALTHY) {
-          healthyReplicaCount++;
-          misMatchedReplicaCount++;
-        } else if (ReplicationManager.compareState(container.getState(),
             cr.getState())) {
+          if (cr.getState() == ContainerReplicaProto.State.UNHEALTHY) {
+            unhealthyReplicaCount++;
+          } else {
+            healthyReplicaCount++;
+            misMatchedReplicaCount++;
+          }
+        } else {
           healthyReplicaCount++;
           matchingReplicaCount++;
         }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/RatisOverReplicationHandler.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/RatisOverReplicationHandler.java
@@ -44,7 +44,6 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
-
 /**
  * This class handles Ratis containers that are over replicated. It should
  * be used to obtain SCMCommands that can be sent to datanodes to solve

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ReplicationManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ReplicationManager.java
@@ -48,6 +48,7 @@ import org.apache.hadoop.hdds.scm.container.replication.health.HealthCheck;
 import org.apache.hadoop.hdds.scm.container.replication.health.OpenContainerHandler;
 import org.apache.hadoop.hdds.scm.container.replication.health.QuasiClosedContainerHandler;
 import org.apache.hadoop.hdds.scm.container.replication.health.RatisReplicationCheckHandler;
+import org.apache.hadoop.hdds.scm.container.replication.health.RatisUnhealthyReplicationCheckHandler;
 import org.apache.hadoop.hdds.scm.events.SCMEvents;
 import org.apache.hadoop.hdds.scm.ha.SCMContext;
 import org.apache.hadoop.hdds.scm.ha.SCMService;
@@ -250,7 +251,8 @@ public class ReplicationManager implements SCMService {
         .addNext(new DeletingContainerHandler(this))
         .addNext(ecReplicationCheckHandler)
         .addNext(ratisReplicationCheckHandler)
-        .addNext(new ClosedWithUnhealthyReplicasHandler(this));
+        .addNext(new ClosedWithUnhealthyReplicasHandler(this))
+        .addNext(new RatisUnhealthyReplicationCheckHandler());
     start();
   }
 

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/health/RatisReplicationCheckHandler.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/health/RatisReplicationCheckHandler.java
@@ -26,13 +26,11 @@ import org.apache.hadoop.hdds.scm.container.replication.ContainerCheckRequest;
 import org.apache.hadoop.hdds.scm.container.replication.ContainerHealthResult;
 import org.apache.hadoop.hdds.scm.container.replication.ContainerReplicaOp;
 import org.apache.hadoop.hdds.scm.container.replication.RatisContainerReplicaCount;
-import org.apache.hadoop.hdds.scm.container.replication.ReplicationManager;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -205,24 +203,6 @@ public class RatisReplicationCheckHandler extends AbstractCheck {
     }
     // No issues detected, just return healthy.
     return new ContainerHealthResult.HealthyResult(container);
-  }
-
-  private boolean hasSufficientMatchingReplicas(ContainerCheckRequest request) {
-    ContainerInfo container = request.getContainerInfo();
-    Set<ContainerReplica> replicas =
-        new HashSet<>(request.getContainerReplicas());
-
-    // keep only matching replicas
-    replicas.removeIf(
-        replica -> !ReplicationManager.compareState(container.getState(),
-            replica.getState()));
-
-    RatisContainerReplicaCount replicaCount =
-        new RatisContainerReplicaCount(container, replicas,
-            request.getPendingOps(),
-            request.getMaintenanceRedundancy(), false);
-
-    return replicaCount.isSufficientlyReplicated();
   }
 
   /**

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/health/RatisUnhealthyReplicationCheckHandler.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/health/RatisUnhealthyReplicationCheckHandler.java
@@ -1,0 +1,193 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.hdds.scm.container.replication.health;
+
+import com.google.common.annotations.VisibleForTesting;
+import org.apache.hadoop.hdds.scm.container.ContainerInfo;
+import org.apache.hadoop.hdds.scm.container.ReplicationManagerReport;
+import org.apache.hadoop.hdds.scm.container.replication.ContainerCheckRequest;
+import org.apache.hadoop.hdds.scm.container.replication.ContainerHealthResult;
+import org.apache.hadoop.hdds.scm.container.replication.RatisContainerReplicaCount;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationType.RATIS;
+
+/**
+ * This class handles UNHEALTHY RATIS replicas. Its responsibilities include:
+ * <ul>
+ *   <li>If only unhealthy replicas exist, check if there are replication
+ *   factor number of replicas and queue them for under/over replication if
+ *   needed.
+ *   </li>
+ *   <li>If there is perfect replication of healthy replicas, remove any
+ *   excess unhealthy replicas.
+ *   </li>
+ * </ul>
+ */
+public class RatisUnhealthyReplicationCheckHandler extends AbstractCheck {
+  public static final Logger LOG = LoggerFactory.getLogger(
+      RatisUnhealthyReplicationCheckHandler.class);
+
+  @Override
+  public boolean handle(ContainerCheckRequest request) {
+    if (request.getContainerInfo().getReplicationType() != RATIS) {
+      // This handler is only for Ratis containers.
+      return false;
+    }
+    ReplicationManagerReport report = request.getReport();
+    ContainerInfo container = request.getContainerInfo();
+
+    /*
+    First, verify there's perfect replication without considering UNHEALTHY
+    replicas.
+     */
+    if (!verifyPerfectReplication(request)) {
+      return false;
+    }
+
+    // Now, consider UNHEALTHY replicas when calculating replication status
+    RatisContainerReplicaCount replicaCount =
+        new RatisContainerReplicaCount(container,
+            request.getContainerReplicas(), request.getPendingOps(),
+            request.getMaintenanceRedundancy(), true);
+    if (replicaCount.getUnhealthyReplicaCount() == 0) {
+      LOG.info("No UNHEALTHY replicas are present for container {} with " +
+          "replicas [{}].", container, request.getContainerReplicas());
+      return false;
+    } else {
+      LOG.debug("Container {} has UNHEALTHY replicas. Checking its " +
+          "replication status.", container);
+      report.incrementAndSample(ReplicationManagerReport.HealthState.UNHEALTHY,
+          container.containerID());
+    }
+
+    ContainerHealthResult health = checkReplication(request);
+    if (health.getHealthState()
+        == ContainerHealthResult.HealthState.UNDER_REPLICATED) {
+      ContainerHealthResult.UnderReplicatedHealthResult underHealth
+          = ((ContainerHealthResult.UnderReplicatedHealthResult) health);
+      report.incrementAndSample(
+          ReplicationManagerReport.HealthState.UNDER_REPLICATED,
+          container.containerID());
+      LOG.debug("Container {} is Under Replicated. isReplicatedOkAfterPending" +
+              " is [{}]. isUnrecoverable is [{}]. hasHealthyReplicas is [{}].",
+          container,
+          underHealth.isReplicatedOkAfterPending(),
+          underHealth.isUnrecoverable(), underHealth.hasHealthyReplicas());
+
+      if (!underHealth.isReplicatedOkAfterPending()) {
+        request.getReplicationQueue().enqueue(underHealth);
+      }
+      return true;
+    }
+
+    if (health.getHealthState()
+        == ContainerHealthResult.HealthState.OVER_REPLICATED) {
+      report.incrementAndSample(
+          ReplicationManagerReport.HealthState.OVER_REPLICATED,
+          container.containerID());
+      ContainerHealthResult.OverReplicatedHealthResult overHealth
+          = ((ContainerHealthResult.OverReplicatedHealthResult) health);
+      LOG.debug("Container {} is Over Replicated. isReplicatedOkAfterPending" +
+              " is [{}]. hasMismatchedReplicas is [{}]", container,
+          overHealth.isReplicatedOkAfterPending(),
+          overHealth.hasMismatchedReplicas());
+
+      if (!overHealth.isReplicatedOkAfterPending()) {
+        request.getReplicationQueue().enqueue(overHealth);
+      }
+      return true;
+    }
+
+    return false;
+  }
+
+  /**
+   * Verify there's no under or over replication if only healthy replicas are
+   * considered, or that there are no healthy replicas.
+   * @return true if there's no under/over replication considering healthy
+   * replicas
+   */
+  private boolean verifyPerfectReplication(ContainerCheckRequest request) {
+    RatisContainerReplicaCount replicaCountWithoutUnhealthy =
+        new RatisContainerReplicaCount(request.getContainerInfo(),
+            request.getContainerReplicas(), request.getPendingOps(),
+            request.getMaintenanceRedundancy(), false);
+
+    if (replicaCountWithoutUnhealthy.getHealthyReplicaCount() == 0) {
+      return true;
+    }
+    if (!replicaCountWithoutUnhealthy.isSufficientlyReplicated() ||
+        replicaCountWithoutUnhealthy.isOverReplicated()) {
+      LOG.info("Checking replication for container {} without considering " +
+              "UNHEALTHY replicas. isSufficientlyReplicated is [{}]. " +
+              "isOverReplicated is [{}]. Returning false because there should" +
+              " be perfect replication for this handler to work.",
+          request.getContainerInfo(),
+          replicaCountWithoutUnhealthy.isSufficientlyReplicated(),
+          replicaCountWithoutUnhealthy.isOverReplicated());
+      return false;
+    }
+    return true;
+  }
+
+  /**
+   * Checks if the container is over or under replicated.
+   */
+  @VisibleForTesting
+  protected ContainerHealthResult checkReplication(
+      ContainerCheckRequest request) {
+    RatisContainerReplicaCount replicaCount =
+        new RatisContainerReplicaCount(request.getContainerInfo(),
+            request.getContainerReplicas(), request.getPendingOps(),
+            request.getMaintenanceRedundancy(), true);
+
+    boolean sufficientlyReplicated
+        = replicaCount.isSufficientlyReplicated(false);
+    if (!sufficientlyReplicated) {
+      ContainerHealthResult.UnderReplicatedHealthResult result =
+          new ContainerHealthResult.UnderReplicatedHealthResult(
+              replicaCount.getContainer(),
+              replicaCount.getRemainingRedundancy(),
+              replicaCount.inSufficientDueToDecommission(false),
+              replicaCount.isSufficientlyReplicated(true),
+              replicaCount.isUnrecoverable());
+      result.setHasHealthyReplicas(replicaCount.getHealthyReplicaCount() > 0);
+      return result;
+    }
+
+    boolean isOverReplicated = replicaCount.isOverReplicated(false);
+    if (isOverReplicated) {
+      boolean repOkWithPending = !replicaCount.isOverReplicated(true);
+      ContainerHealthResult.OverReplicatedHealthResult result =
+          new ContainerHealthResult.OverReplicatedHealthResult(
+              replicaCount.getContainer(),
+              replicaCount.getExcessRedundancy(false),
+              repOkWithPending);
+      result.setHasMismatchedReplicas(
+          replicaCount.getMisMatchedReplicaCount() > 0);
+      return result;
+    }
+
+    return new ContainerHealthResult.UnHealthyResult(
+        replicaCount.getContainer());
+  }
+}

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/ReplicationTestUtil.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/ReplicationTestUtil.java
@@ -121,6 +121,16 @@ public final class ReplicationTestUtil {
         datanodeDetails, datanodeDetails.getUuid());
   }
 
+  public static ContainerReplica createContainerReplica(ContainerID containerID,
+      int replicaIndex, HddsProtos.NodeOperationalState opState,
+      ContainerReplicaProto.State replicaState, long seqId) {
+    DatanodeDetails datanodeDetails
+        = MockDatanodeDetails.randomDatanodeDetails();
+    return createContainerReplica(containerID, replicaIndex, opState,
+        replicaState, 123L, 1234L,
+        datanodeDetails, datanodeDetails.getUuid(), seqId);
+  }
+
   @SuppressWarnings("checkstyle:ParameterNumber")
   public static ContainerReplica createContainerReplica(ContainerID containerID,
       int replicaIndex, HddsProtos.NodeOperationalState opState,
@@ -140,6 +150,24 @@ public final class ReplicationTestUtil {
     return builder.build();
   }
 
+  @SuppressWarnings("checkstyle:ParameterNumber")
+  public static ContainerReplica createContainerReplica(ContainerID containerID,
+      int replicaIndex, HddsProtos.NodeOperationalState opState,
+      ContainerReplicaProto.State replicaState, long keyCount, long bytesUsed,
+      DatanodeDetails datanodeDetails, UUID originNodeId, long seqId) {
+    ContainerReplica.ContainerReplicaBuilder builder
+        = ContainerReplica.newBuilder();
+    datanodeDetails.setPersistedOpState(opState);
+    builder.setContainerID(containerID);
+    builder.setReplicaIndex(replicaIndex);
+    builder.setKeyCount(keyCount);
+    builder.setBytesUsed(bytesUsed);
+    builder.setContainerState(replicaState);
+    builder.setDatanodeDetails(datanodeDetails);
+    builder.setSequenceId(seqId);
+    builder.setOriginNodeId(originNodeId);
+    return builder.build();
+  }
 
   public static ContainerInfo createContainerInfo(ReplicationConfig repConfig) {
     return createContainerInfo(repConfig, 1, HddsProtos.LifeCycleState.CLOSED);

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestRatisContainerReplicaCount.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestRatisContainerReplicaCount.java
@@ -347,6 +347,7 @@ class TestRatisContainerReplicaCount {
     RatisContainerReplicaCount rcnt =
         new RatisContainerReplicaCount(container, replica, 0, 0, 3, 2);
     validate(rcnt, true, -1, true);
+    assertTrue(rcnt.isSafelyOverReplicated());
   }
 
   @Test
@@ -435,7 +436,7 @@ class TestRatisContainerReplicaCount {
     RatisContainerReplicaCount rcnt =
         new RatisContainerReplicaCount(container, replicas,
             Collections.emptyList(), 2, false);
-    assertTrue(rcnt.isSufficientlyReplicated());
+    validate(rcnt, true, 0, false);
   }
 
   @Test
@@ -537,6 +538,16 @@ class TestRatisContainerReplicaCount {
     assertEquals(1, rcnt.getDecommissionCount());
   }
 
+  /**
+   * There is a CLOSED container with 3 CLOSED replicas and 1 UNHEALTHY
+   * replica. There is a pending delete on the UNHEALTHY replica.
+   * Expectation: If considerUnhealthy in RatisContainerReplicaCount is
+   * false, the pending delete on the UNHEALTHY replica should be ignored.
+   * The container should be sufficiently replicated.
+   * If considerUnhealthy is true, the pending delete should be considered,
+   * but the container is still sufficiently replicated because we have
+   * enough CLOSED replicas.
+   */
   @Test
   void testSufficientReplicationWithPendingDeleteOnUnhealthyReplica() {
     ContainerInfo container =
@@ -544,7 +555,7 @@ class TestRatisContainerReplicaCount {
             HddsProtos.ReplicationFactor.THREE), 1L,
             HddsProtos.LifeCycleState.CLOSED);
     Set<ContainerReplica> replicas =
-        createReplicas(ContainerID.valueOf(1L), CLOSED, 0, 0, 0);
+        createReplicas(container.containerID(), CLOSED, 0, 0, 0);
     ContainerReplica unhealthyReplica = createContainerReplica(
         ContainerID.valueOf(1L), 0, IN_SERVICE, UNHEALTHY);
     replicas.add(unhealthyReplica);
@@ -552,9 +563,13 @@ class TestRatisContainerReplicaCount {
     List<ContainerReplicaOp> ops = new ArrayList<>();
     ops.add(ContainerReplicaOp.create(ContainerReplicaOp.PendingOpType.DELETE,
         unhealthyReplica.getDatanodeDetails(), 0));
-    RatisContainerReplicaCount replicaCount =
+    RatisContainerReplicaCount withoutUnhealthy =
         new RatisContainerReplicaCount(container, replicas, ops, 2, false);
-    assertTrue(replicaCount.isSufficientlyReplicated());
+    validate(withoutUnhealthy, true, 0, false);
+
+    RatisContainerReplicaCount withUnhealthy =
+        new RatisContainerReplicaCount(container, replicas, ops, 2, true);
+    validate(withUnhealthy, true, 0, false);
   }
 
   @Test
@@ -589,6 +604,81 @@ class TestRatisContainerReplicaCount {
     assertFalse(rcnt.isOverReplicated(true));
     assertEquals(2, rcnt.getExcessRedundancy(false));
     assertEquals(0, rcnt.getExcessRedundancy(true));
+  }
+
+  /**
+   * A container is safely over replicated if:
+   * 1. It is over replicated.
+   * 2. Has at least replication factor number of matching replicas.
+   * 3. # matching replicas - replication factor >= pending deletes.
+   */
+  @Test
+  void testSafelyOverReplicated() {
+    /*
+    First case: 3 CLOSED, 2 UNHEALTHY, 1 pending delete.
+    Expectation: Not safely over replicated because rule 3 is violated.
+     */
+    ContainerInfo container =
+        createContainerInfo(RatisReplicationConfig.getInstance(
+                HddsProtos.ReplicationFactor.THREE), 1L,
+            HddsProtos.LifeCycleState.CLOSED);
+    Set<ContainerReplica> replicas =
+        createReplicas(container.containerID(), CLOSED, 0, 0, 0);
+    Set<ContainerReplica> unhealthyReplicas =
+        createReplicas(container.containerID(), UNHEALTHY, 0, 0);
+    replicas.addAll(unhealthyReplicas);
+    List<ContainerReplicaOp> ops = new ArrayList<>();
+    ops.add(ContainerReplicaOp.create(ContainerReplicaOp.PendingOpType.DELETE,
+        unhealthyReplicas.iterator().next().getDatanodeDetails(), 0));
+
+    RatisContainerReplicaCount withoutUnhealthy =
+        new RatisContainerReplicaCount(container, replicas, ops, 2, false);
+    validate(withoutUnhealthy, true, 0, false);
+    assertFalse(withoutUnhealthy.isSafelyOverReplicated());
+
+    RatisContainerReplicaCount withUnhealthy =
+        new RatisContainerReplicaCount(container, replicas, ops, 2, true);
+    validate(withUnhealthy, true, -1, true);
+    assertFalse(withUnhealthy.isSafelyOverReplicated());
+
+    /*
+    Second case: 2 CLOSED, 1 CLOSING, 1 UNHEALTHY
+     */
+    container = createContainerInfo(RatisReplicationConfig.getInstance(
+                HddsProtos.ReplicationFactor.THREE), 1L,
+            HddsProtos.LifeCycleState.CLOSED);
+    replicas = createReplicas(container.containerID(), CLOSED, 0, 0);
+    ContainerReplica unhealthyReplica =
+        createContainerReplica(container.containerID(), 0, IN_SERVICE,
+            UNHEALTHY);
+    ContainerReplica misMatchedReplica =
+        createContainerReplica(container.containerID(), 0, IN_SERVICE, CLOSING);
+    replicas.add(unhealthyReplica);
+    replicas.add(misMatchedReplica);
+
+    withoutUnhealthy =
+        new RatisContainerReplicaCount(container, replicas,
+            Collections.emptyList(), 2,
+            false);
+    validate(withoutUnhealthy, true, 0, false);
+    assertFalse(withoutUnhealthy.isSafelyOverReplicated());
+
+    withUnhealthy =
+        new RatisContainerReplicaCount(container, replicas,
+            Collections.emptyList(), 2,
+            true);
+    validate(withUnhealthy, true, -1, true);
+    // Violates rule 2
+    assertFalse(withUnhealthy.isSafelyOverReplicated());
+    // now check by adding a CLOSED replica
+    replicas.add(createContainerReplica(container.containerID(), 0,
+        IN_SERVICE, CLOSED));
+    withUnhealthy =
+        new RatisContainerReplicaCount(container, replicas,
+            Collections.emptyList(), 2,
+            true);
+    validate(withUnhealthy, true, -2, true);
+    assertTrue(withUnhealthy.isSafelyOverReplicated());
   }
 
   @Test

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestRatisOverReplicationHandler.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestRatisOverReplicationHandler.java
@@ -145,6 +145,15 @@ public class TestRatisOverReplicationHandler {
         RATIS_REPLICATION_CONFIG);
     Set<ContainerReplica> replicas = createReplicas(container.containerID(),
         ContainerReplicaProto.State.QUASI_CLOSED, 0, 0, 0, 0, 0);
+    /*
+     Even an unhealthy replica shouldn't be deleted if it has a unique
+     origin. It might be possible to close this replica in the future.
+     */
+    ContainerReplica unhealthyReplica =
+        createContainerReplica(container.containerID(), 0,
+            HddsProtos.NodeOperationalState.IN_SERVICE,
+            ContainerReplicaProto.State.UNHEALTHY);
+    replicas.add(unhealthyReplica);
 
     testProcessing(replicas, Collections.emptyList(),
         getOverReplicatedHealthResult(), 0);
@@ -258,7 +267,7 @@ public class TestRatisOverReplicationHandler {
    *                          handler
    * @param expectNumCommands number of commands expected to be created by
    *                          the handler
-   * @return map of commands
+   * @return set of commands
    */
   private Set<Pair<DatanodeDetails, SCMCommand<?>>> testProcessing(
       Set<ContainerReplica> replicas, List<ContainerReplicaOp> pendingOps,

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestReplicationManager.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestReplicationManager.java
@@ -26,6 +26,7 @@ import org.apache.hadoop.hdds.protocol.DatanodeDetails;
 import org.apache.hadoop.hdds.protocol.MockDatanodeDetails;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.ContainerReplicaProto;
+import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.SCMCommandProto;
 import org.apache.hadoop.hdds.scm.PlacementPolicy;
 import org.apache.hadoop.hdds.scm.container.ContainerID;
 import org.apache.hadoop.hdds.scm.container.ContainerInfo;
@@ -38,10 +39,13 @@ import org.apache.hadoop.hdds.scm.events.SCMEvents;
 import org.apache.hadoop.hdds.scm.ha.SCMContext;
 import org.apache.hadoop.hdds.scm.ha.SCMServiceManager;
 import org.apache.hadoop.hdds.scm.node.NodeManager;
+import org.apache.hadoop.hdds.scm.node.NodeStatus;
+import org.apache.hadoop.hdds.scm.node.states.NodeNotFoundException;
 import org.apache.hadoop.hdds.server.events.EventPublisher;
 import org.apache.hadoop.ozone.protocol.commands.DeleteContainerCommand;
 import org.apache.hadoop.ozone.protocol.commands.ReconstructECContainersCommand;
 import org.apache.hadoop.ozone.protocol.commands.ReplicateContainerCommand;
+import org.apache.hadoop.ozone.protocol.commands.SCMCommand;
 import org.apache.ozone.test.TestClock;
 import org.apache.ratis.protocol.exceptions.NotLeaderException;
 import org.junit.Assert;
@@ -54,11 +58,13 @@ import java.io.IOException;
 import java.time.Instant;
 import java.time.ZoneId;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.UUID;
 
 import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_SCM_WAIT_TIME_AFTER_SAFE_MODE_EXIT;
 import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.NodeOperationalState.DECOMMISSIONING;
@@ -68,6 +74,7 @@ import static org.apache.hadoop.hdds.scm.container.replication.ContainerReplicaO
 import static org.apache.hadoop.hdds.scm.container.replication.ReplicationTestUtil.createContainerInfo;
 import static org.apache.hadoop.hdds.scm.container.replication.ReplicationTestUtil.createContainerReplica;
 import static org.apache.hadoop.hdds.scm.container.replication.ReplicationTestUtil.createReplicas;
+import static org.apache.hadoop.hdds.scm.container.replication.ReplicationTestUtil.createReplicasWithSameOrigin;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyList;
@@ -101,6 +108,8 @@ public class TestReplicationManager {
     configuration.set(HDDS_SCM_WAIT_TIME_AFTER_SAFE_MODE_EXIT, "0s");
     containerManager = Mockito.mock(ContainerManager.class);
     ratisPlacementPolicy = Mockito.mock(PlacementPolicy.class);
+    Mockito.when(ratisPlacementPolicy.validateContainerPlacement(anyList(),
+        anyInt())).thenReturn(new ContainerPlacementStatusDefault(2, 2, 3));
     ecPlacementPolicy = Mockito.mock(PlacementPolicy.class);
     Mockito.when(ecPlacementPolicy.validateContainerPlacement(
         anyList(), anyInt()))
@@ -265,6 +274,95 @@ public class TestReplicationManager {
         ReplicationManagerReport.HealthState.UNHEALTHY));
     Assert.assertEquals(1, repQueue.underReplicatedQueueSize());
     Assert.assertEquals(0, repQueue.overReplicatedQueueSize());
+  }
+
+  /**
+   * Situation: QUASI_CLOSED container with 3 QUASI_CLOSED and 1 UNHEALTHY
+   * replica. They all have the same origin node id. It's expected that the
+   * UNHEALTHY replica (and not a QUASI_CLOSED one) is deleted.
+   */
+  @Test
+  public void testQuasiClosedContainerWithExcessUnhealthyReplica()
+      throws IOException, NodeNotFoundException {
+    RatisReplicationConfig ratisRepConfig =
+        RatisReplicationConfig.getInstance(THREE);
+    ContainerInfo container = createContainerInfo(ratisRepConfig, 1,
+        HddsProtos.LifeCycleState.QUASI_CLOSED);
+    Set<ContainerReplica> replicas =
+        createReplicasWithSameOrigin(container.containerID(),
+            ContainerReplicaProto.State.QUASI_CLOSED, 0, 0, 0);
+    UUID origin = replicas.iterator().next().getOriginDatanodeId();
+    ContainerReplica unhealthy =
+        createContainerReplica(container.containerID(), 0, IN_SERVICE,
+            ContainerReplicaProto.State.UNHEALTHY, 1, 123,
+            MockDatanodeDetails.randomDatanodeDetails(), origin);
+    replicas.add(unhealthy);
+    storeContainerAndReplicas(container, replicas);
+
+    replicationManager.processContainer(container, repQueue, repReport);
+    Assert.assertEquals(0, repReport.getStat(
+        ReplicationManagerReport.HealthState.UNDER_REPLICATED));
+    Assert.assertEquals(1, repReport.getStat(
+        ReplicationManagerReport.HealthState.OVER_REPLICATED));
+    Assert.assertEquals(1, repReport.getStat(
+        ReplicationManagerReport.HealthState.UNHEALTHY));
+    Assert.assertEquals(0, repQueue.underReplicatedQueueSize());
+    Assert.assertEquals(1, repQueue.overReplicatedQueueSize());
+
+    RatisOverReplicationHandler handler =
+        new RatisOverReplicationHandler(ratisPlacementPolicy, nodeManager);
+
+    Mockito.when(nodeManager.getNodeStatus(any(DatanodeDetails.class)))
+        .thenReturn(NodeStatus.inServiceHealthy());
+    Set<Pair<DatanodeDetails, SCMCommand<?>>> commands =
+        handler.processAndCreateCommands(replicas, Collections.emptyList(),
+            repQueue.dequeueOverReplicatedContainer(), 2);
+    Assert.assertTrue(commands.iterator().hasNext());
+    Assert.assertEquals(unhealthy.getDatanodeDetails(),
+        commands.iterator().next().getKey());
+    Assert.assertEquals(SCMCommandProto.Type.deleteContainerCommand,
+        commands.iterator().next().getValue().getType());
+  }
+
+  @Test
+  public void testQuasiClosedContainerWithUnhealthyReplicaOnUniqueOrigin()
+      throws IOException, NodeNotFoundException {
+    RatisReplicationConfig ratisRepConfig =
+        RatisReplicationConfig.getInstance(THREE);
+    ContainerInfo container = createContainerInfo(ratisRepConfig, 1,
+        HddsProtos.LifeCycleState.QUASI_CLOSED);
+    Set<ContainerReplica> replicas =
+        createReplicasWithSameOrigin(container.containerID(),
+            ContainerReplicaProto.State.QUASI_CLOSED, 0, 0, 0);
+    ContainerReplica unhealthy =
+        createContainerReplica(container.containerID(), 0, IN_SERVICE,
+            ContainerReplicaProto.State.UNHEALTHY);
+    replicas.add(unhealthy);
+    storeContainerAndReplicas(container, replicas);
+
+    replicationManager.processContainer(container, repQueue, repReport);
+    Assert.assertEquals(0, repReport.getStat(
+        ReplicationManagerReport.HealthState.UNDER_REPLICATED));
+    Assert.assertEquals(1, repReport.getStat(
+        ReplicationManagerReport.HealthState.OVER_REPLICATED));
+    Assert.assertEquals(1, repReport.getStat(
+        ReplicationManagerReport.HealthState.UNHEALTHY));
+    Assert.assertEquals(0, repQueue.underReplicatedQueueSize());
+    Assert.assertEquals(1, repQueue.overReplicatedQueueSize());
+
+    RatisOverReplicationHandler handler =
+        new RatisOverReplicationHandler(ratisPlacementPolicy, nodeManager);
+
+    Mockito.when(nodeManager.getNodeStatus(any(DatanodeDetails.class)))
+        .thenReturn(NodeStatus.inServiceHealthy());
+    Set<Pair<DatanodeDetails, SCMCommand<?>>> commands =
+        handler.processAndCreateCommands(replicas, Collections.emptyList(),
+            repQueue.dequeueOverReplicatedContainer(), 2);
+    Assert.assertTrue(commands.iterator().hasNext());
+    Assert.assertNotEquals(unhealthy.getDatanodeDetails(),
+        commands.iterator().next().getKey());
+    Assert.assertEquals(SCMCommandProto.Type.deleteContainerCommand,
+        commands.iterator().next().getValue().getType());
   }
 
   @Test

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/health/TestRatisUnhealthyReplicationCheckHandler.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/health/TestRatisUnhealthyReplicationCheckHandler.java
@@ -1,0 +1,295 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with this
+ * work for additional information regarding copyright ownership.  The ASF
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p/>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p/>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package org.apache.hadoop.hdds.scm.container.replication.health;
+
+import com.google.common.collect.ImmutableList;
+import org.apache.hadoop.hdds.client.ECReplicationConfig;
+import org.apache.hadoop.hdds.client.RatisReplicationConfig;
+import org.apache.hadoop.hdds.client.ReplicationConfig;
+import org.apache.hadoop.hdds.protocol.MockDatanodeDetails;
+import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
+import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.ContainerReplicaProto;
+import org.apache.hadoop.hdds.scm.container.ContainerInfo;
+import org.apache.hadoop.hdds.scm.container.ContainerReplica;
+import org.apache.hadoop.hdds.scm.container.ReplicationManagerReport;
+import org.apache.hadoop.hdds.scm.container.replication.ContainerCheckRequest;
+import org.apache.hadoop.hdds.scm.container.replication.ContainerHealthResult;
+import org.apache.hadoop.hdds.scm.container.replication.ContainerReplicaOp;
+import org.apache.hadoop.hdds.scm.container.replication.ReplicationQueue;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+
+import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.NodeOperationalState.IN_SERVICE;
+import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationFactor.THREE;
+import static org.apache.hadoop.hdds.scm.container.replication.ReplicationTestUtil.createContainerInfo;
+import static org.apache.hadoop.hdds.scm.container.replication.ReplicationTestUtil.createContainerReplica;
+import static org.apache.hadoop.hdds.scm.container.replication.ReplicationTestUtil.createReplicas;
+
+/**
+ * Tests for {@link RatisUnhealthyReplicationCheckHandler}.
+ */
+public class TestRatisUnhealthyReplicationCheckHandler {
+  private RatisUnhealthyReplicationCheckHandler handler;
+  private ReplicationConfig repConfig;
+  private ReplicationQueue repQueue;
+  private ContainerCheckRequest.Builder requestBuilder;
+  private ReplicationManagerReport report;
+  private int maintenanceRedundancy = 2;
+
+  @Before
+  public void setup() throws IOException {
+    handler = new RatisUnhealthyReplicationCheckHandler();
+    repConfig = RatisReplicationConfig.getInstance(THREE);
+    repQueue = new ReplicationQueue();
+    report = new ReplicationManagerReport();
+    requestBuilder = new ContainerCheckRequest.Builder()
+        .setReplicationQueue(repQueue)
+        .setMaintenanceRedundancy(maintenanceRedundancy)
+        .setPendingOps(Collections.emptyList())
+        .setReport(report);
+  }
+
+  @Test
+  public void testReturnFalseForNonRatis() {
+    ContainerInfo container =
+        createContainerInfo(new ECReplicationConfig(3, 2));
+    Set<ContainerReplica> replicas =
+        createReplicas(container.containerID(), 1, 2, 3, 4);
+
+    requestBuilder.setContainerReplicas(replicas)
+        .setContainerInfo(container);
+    Assert.assertFalse(handler.handle(requestBuilder.build()));
+    Assert.assertEquals(0, repQueue.underReplicatedQueueSize());
+    Assert.assertEquals(0, repQueue.overReplicatedQueueSize());
+  }
+
+  @Test
+  public void shouldReturnFalseForPerfectReplicationConsideringHealthy() {
+    ContainerInfo container =
+        createContainerInfo(repConfig, 1L, HddsProtos.LifeCycleState.CLOSED);
+    Set<ContainerReplica> replicas
+        = createReplicas(container.containerID(),
+        ContainerReplicaProto.State.CLOSED, 0, 0, 0);
+    requestBuilder.setContainerReplicas(replicas)
+        .setContainerInfo(container);
+
+    Assert.assertFalse(handler.handle(requestBuilder.build()));
+  }
+
+  @Test
+  public void shouldReturnFalseForUnderReplicatedHealthyReplicas() {
+    ContainerInfo container =
+        createContainerInfo(repConfig, 1L, HddsProtos.LifeCycleState.CLOSED);
+    Set<ContainerReplica> replicas
+        = createReplicas(container.containerID(),
+        ContainerReplicaProto.State.CLOSED, 0, 0);
+    requestBuilder.setContainerReplicas(replicas)
+        .setContainerInfo(container);
+
+    Assert.assertFalse(handler.handle(requestBuilder.build()));
+  }
+
+  @Test
+  public void shouldReturnFalseForOverReplicatedHealthyReplicas() {
+    ContainerInfo container =
+        createContainerInfo(repConfig, 1L, HddsProtos.LifeCycleState.CLOSED);
+    Set<ContainerReplica> replicas
+        = createReplicas(container.containerID(),
+        ContainerReplicaProto.State.CLOSED, 0, 0, 0, 0);
+    ContainerReplica unhealthyReplica =
+        createContainerReplica(container.containerID(), 0, IN_SERVICE,
+            ContainerReplicaProto.State.UNHEALTHY);
+    replicas.add(unhealthyReplica);
+
+    requestBuilder.setContainerReplicas(replicas)
+        .setContainerInfo(container);
+
+    Assert.assertFalse(handler.handle(requestBuilder.build()));
+  }
+
+  @Test
+  public void shouldReturnTrueForExcessUnhealthyReplicas() {
+    ContainerInfo container =
+        createContainerInfo(repConfig, 1L, HddsProtos.LifeCycleState.CLOSED);
+    Set<ContainerReplica> replicas
+        = createReplicas(container.containerID(),
+        ContainerReplicaProto.State.CLOSED, 0, 0, 0);
+    ContainerReplica unhealthyReplica =
+        createContainerReplica(container.containerID(), 0, IN_SERVICE,
+            ContainerReplicaProto.State.UNHEALTHY);
+    replicas.add(unhealthyReplica);
+    requestBuilder.setContainerReplicas(replicas)
+        .setContainerInfo(container);
+
+    ContainerHealthResult.OverReplicatedHealthResult result =
+        (ContainerHealthResult.OverReplicatedHealthResult)
+            handler.checkReplication(requestBuilder.build());
+    Assert.assertEquals(ContainerHealthResult.HealthState.OVER_REPLICATED,
+        result.getHealthState());
+    Assert.assertEquals(1, result.getExcessRedundancy());
+    Assert.assertFalse(result.isReplicatedOkAfterPending());
+
+    Assert.assertTrue(handler.handle(requestBuilder.build()));
+    Assert.assertEquals(0, repQueue.underReplicatedQueueSize());
+    Assert.assertEquals(1, repQueue.overReplicatedQueueSize());
+    Assert.assertEquals(1, report.getStat(
+        ReplicationManagerReport.HealthState.OVER_REPLICATED));
+    Assert.assertEquals(1,
+        report.getStat(ReplicationManagerReport.HealthState.UNHEALTHY));
+  }
+
+  @Test
+  public void shouldReturnTrueForUnderReplicatedUnhealthyReplicas() {
+    ContainerInfo container =
+        createContainerInfo(repConfig, 1L, HddsProtos.LifeCycleState.CLOSED);
+    Set<ContainerReplica> replicas
+        = createReplicas(container.containerID(),
+        ContainerReplicaProto.State.UNHEALTHY, 0);
+    List<ContainerReplicaOp> pendingOps =
+        ImmutableList.of(ContainerReplicaOp.create(
+            ContainerReplicaOp.PendingOpType.ADD,
+            MockDatanodeDetails.randomDatanodeDetails(), 0));
+    requestBuilder.setContainerReplicas(replicas)
+        .setContainerInfo(container)
+        .setPendingOps(pendingOps);
+
+    ContainerHealthResult.UnderReplicatedHealthResult
+        result = (ContainerHealthResult.UnderReplicatedHealthResult)
+        handler.checkReplication(requestBuilder.build());
+
+    Assert.assertEquals(ContainerHealthResult.HealthState.UNDER_REPLICATED,
+        result.getHealthState());
+    Assert.assertEquals(0, result.getRemainingRedundancy());
+    Assert.assertFalse(result.isReplicatedOkAfterPending());
+    Assert.assertFalse(result.underReplicatedDueToDecommission());
+
+    Assert.assertTrue(handler.handle(requestBuilder.build()));
+    Assert.assertEquals(1, repQueue.underReplicatedQueueSize());
+    Assert.assertEquals(0, repQueue.overReplicatedQueueSize());
+    Assert.assertEquals(1, report.getStat(
+        ReplicationManagerReport.HealthState.UNDER_REPLICATED));
+    Assert.assertEquals(1,
+        report.getStat(ReplicationManagerReport.HealthState.UNHEALTHY));
+  }
+
+  @Test
+  public void testUnderReplicatedFixedByPendingAdd() {
+    ContainerInfo container =
+        createContainerInfo(repConfig, 1L, HddsProtos.LifeCycleState.CLOSED);
+    Set<ContainerReplica> replicas
+        = createReplicas(container.containerID(),
+        ContainerReplicaProto.State.UNHEALTHY, 0, 0);
+    List<ContainerReplicaOp> pendingOps =
+        ImmutableList.of(ContainerReplicaOp.create(
+            ContainerReplicaOp.PendingOpType.ADD,
+            MockDatanodeDetails.randomDatanodeDetails(), 0));
+    requestBuilder.setContainerReplicas(replicas)
+        .setContainerInfo(container)
+        .setPendingOps(pendingOps);
+
+    ContainerHealthResult.UnderReplicatedHealthResult
+        result = (ContainerHealthResult.UnderReplicatedHealthResult)
+        handler.checkReplication(requestBuilder.build());
+
+    Assert.assertEquals(ContainerHealthResult.HealthState.UNDER_REPLICATED,
+        result.getHealthState());
+    Assert.assertEquals(1, result.getRemainingRedundancy());
+    Assert.assertTrue(result.isReplicatedOkAfterPending());
+    Assert.assertFalse(result.underReplicatedDueToDecommission());
+
+    Assert.assertTrue(handler.handle(requestBuilder.build()));
+    Assert.assertEquals(0, repQueue.underReplicatedQueueSize());
+    Assert.assertEquals(0, repQueue.overReplicatedQueueSize());
+    Assert.assertEquals(1, report.getStat(
+        ReplicationManagerReport.HealthState.UNDER_REPLICATED));
+    Assert.assertEquals(1,
+        report.getStat(ReplicationManagerReport.HealthState.UNHEALTHY));
+  }
+
+  @Test
+  public void testUnderReplicatedDueToPendingDelete() {
+    ContainerInfo container =
+        createContainerInfo(repConfig, 1L, HddsProtos.LifeCycleState.CLOSED);
+    Set<ContainerReplica> replicas
+        = createReplicas(container.containerID(),
+        ContainerReplicaProto.State.UNHEALTHY, 0, 0, 0);
+    List<ContainerReplicaOp> pendingOps =
+        ImmutableList.of(ContainerReplicaOp.create(
+            ContainerReplicaOp.PendingOpType.DELETE,
+            replicas.stream().findFirst().get().getDatanodeDetails(), 0));
+    requestBuilder.setContainerReplicas(replicas)
+        .setContainerInfo(container)
+        .setPendingOps(pendingOps);
+
+    ContainerHealthResult.UnderReplicatedHealthResult
+        result = (ContainerHealthResult.UnderReplicatedHealthResult)
+        handler.checkReplication(requestBuilder.build());
+
+    Assert.assertEquals(ContainerHealthResult.HealthState.UNDER_REPLICATED,
+        result.getHealthState());
+    Assert.assertEquals(1, result.getRemainingRedundancy());
+    Assert.assertFalse(result.isReplicatedOkAfterPending());
+
+    Assert.assertTrue(handler.handle(requestBuilder.build()));
+    Assert.assertEquals(1, repQueue.underReplicatedQueueSize());
+    Assert.assertEquals(0, repQueue.overReplicatedQueueSize());
+    Assert.assertEquals(1, report.getStat(
+        ReplicationManagerReport.HealthState.UNDER_REPLICATED));
+    Assert.assertEquals(1,
+        report.getStat(ReplicationManagerReport.HealthState.UNHEALTHY));
+  }
+
+  @Test
+  public void testOverReplicationFixedByPendingDelete() {
+    ContainerInfo container =
+        createContainerInfo(repConfig, 1L, HddsProtos.LifeCycleState.CLOSED);
+    Set<ContainerReplica> replicas
+        = createReplicas(container.containerID(),
+        ContainerReplicaProto.State.UNHEALTHY, 0, 0, 0, 0);
+    List<ContainerReplicaOp> pendingOps =
+        ImmutableList.of(ContainerReplicaOp.create(
+            ContainerReplicaOp.PendingOpType.DELETE,
+            replicas.stream().findFirst().get().getDatanodeDetails(), 0));
+    requestBuilder.setContainerReplicas(replicas)
+        .setContainerInfo(container)
+        .setPendingOps(pendingOps);
+
+    ContainerHealthResult.OverReplicatedHealthResult
+        result = (ContainerHealthResult.OverReplicatedHealthResult)
+        handler.checkReplication(requestBuilder.build());
+
+    Assert.assertEquals(ContainerHealthResult.HealthState.OVER_REPLICATED,
+        result.getHealthState());
+    Assert.assertEquals(1, result.getExcessRedundancy());
+    Assert.assertTrue(result.isReplicatedOkAfterPending());
+
+    Assert.assertTrue(handler.handle(requestBuilder.build()));
+    Assert.assertEquals(0, repQueue.underReplicatedQueueSize());
+    Assert.assertEquals(0, repQueue.overReplicatedQueueSize());
+    Assert.assertEquals(1, report.getStat(
+        ReplicationManagerReport.HealthState.OVER_REPLICATED));
+    Assert.assertEquals(1,
+        report.getStat(ReplicationManagerReport.HealthState.UNHEALTHY));
+  }
+}


### PR DESCRIPTION
## What changes were proposed in this pull request?

Check the jira for a description of the task: https://issues.apache.org/jira/browse/HDDS-7847
Legacy RM calls mismatched and UNHEALTHY replicas unhealthy. New RM calls only UNHEALTHY replicas unhealthy.

Some notes about the changes proposed here:
1. Legacy RM tries to close all replicas, even UNHEALTHY ones. We don’t do this in RM - No need?
2. Legacy RM currently does not handle mis replication when ALL replicas are unhealthy. New RM will not either.
3. Legacy tries to close a quasi closed replica of a closed container, while new RM doesn't. We need to add this to MismatchedReplicasHandler but this is not done in this pr.
4. Legacy tries to close a quasi closed replica of a quasi closed container in some cases. This is probably a bug and is not done in new RM.
5. If a container is over rep with mismatched replicas, it will not be queued to over rep queue in the new RM. We need an improvement jira that tries to enqueue such a container if there is sufficient replication when considering only matching replicas. For example, for a CLOSED container with replicas {CLOSED, CLOSED, CLOSED, OPEN, UNHEALTHY}. `RatisReplicationCheckHandler` will not queue this. Check `testOverReplicatedContainerWithMismatchedReplicas`. Legacy will try to close the open replica and delete the UNHEALTHY one in `handleOverReplicatedExcessUnhealthy`. Whereas RM will only try to close the OPEN replica.

## How was this patch tested?
Added UTs. Still need to add some in `TestReplicationManager`.