### PR TITLE
HDDS-7859. ICR processing does not remove container reference in NodeManager for a deleted replica

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/IncrementalContainerReportHandler.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/IncrementalContainerReportHandler.java
@@ -91,6 +91,8 @@ public class IncrementalContainerReportHandler extends
             if (!replicaProto.getState().equals(
                 ContainerReplicaProto.State.DELETED)) {
               nodeManager.addContainer(dd, id);
+            } else {
+              nodeManager.removeContainer(dd, id);
             }
           }
           if (ContainerReportValidator.validate(container, dd, replicaProto)) {


### PR DESCRIPTION
## What changes were proposed in this pull request?

If a container is deleted on a datanode, then the deleted state is reported via an Incremental Container Report. This ICR processing will remove the deleted replica from the ContainerManager replica map, but it does not remove it from the NodeManager which has a mapping of all containers on a datanode.

This can result in problems with decommissioning, where SCM thinks a node has a replica, but then ContainerManager reports no replicas.

Most likely the issue would resolve itself when the next FCR is issued, as it will handle updating NodeManager for any containers which are present there but not in the full report.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-7859

## How was this patch tested?

Modified a unit test to reproduce it and then fixed the issue.
