### PR TITLE
HDDS-7821. Let push replication use compression from configuration

### DIFF
--- a/hadoop-hdds/config/src/main/java/org/apache/hadoop/hdds/conf/ConfigurationTarget.java
+++ b/hadoop-hdds/config/src/main/java/org/apache/hadoop/hdds/conf/ConfigurationTarget.java
@@ -44,6 +44,10 @@ public interface ConfigurationTarget {
     set(name, Boolean.toString(value));
   }
 
+  default <T extends Enum<T>>void setEnum(String name, T value) {
+    set(name, value.name());
+  }
+
   default void setTimeDuration(String name, long value, TimeUnit unit) {
     set(name, value + ParsedTimeDuration.unitFor(unit).suffix());
   }

--- a/hadoop-hdds/config/src/main/java/org/apache/hadoop/hdds/conf/ConfigurationTarget.java
+++ b/hadoop-hdds/config/src/main/java/org/apache/hadoop/hdds/conf/ConfigurationTarget.java
@@ -44,7 +44,7 @@ public interface ConfigurationTarget {
     set(name, Boolean.toString(value));
   }
 
-  default <T extends Enum<T>>void setEnum(String name, T value) {
+  default <T extends Enum<T>> void setEnum(String name, T value) {
     set(name, value.name());
   }
 

--- a/hadoop-hdds/container-service/pom.xml
+++ b/hadoop-hdds/container-service/pom.xml
@@ -140,6 +140,10 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
       <artifactId>mockito-junit-jupiter</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-params</artifactId>
+    </dependency>
 
   </dependencies>
 

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/DatanodeStateMachine.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/DatanodeStateMachine.java
@@ -57,7 +57,6 @@ import org.apache.hadoop.ozone.container.common.statemachine.commandhandler.Repl
 import org.apache.hadoop.ozone.container.common.statemachine.commandhandler.SetNodeOperationalStateCommandHandler;
 import org.apache.hadoop.ozone.container.ec.reconstruction.ECReconstructionCoordinator;
 import org.apache.hadoop.ozone.container.ec.reconstruction.ECReconstructionMetrics;
-import org.apache.hadoop.ozone.container.keyvalue.TarContainerPacker;
 import org.apache.hadoop.ozone.container.ozoneimpl.OzoneContainer;
 import org.apache.hadoop.ozone.container.replication.ContainerImporter;
 import org.apache.hadoop.ozone.container.replication.ContainerReplicator;
@@ -179,12 +178,12 @@ public class DatanodeStateMachine implements Closeable {
     ContainerImporter importer = new ContainerImporter(conf,
         container.getContainerSet(),
         container.getController(),
-        new TarContainerPacker(), container.getVolumeSet());
+        container.getVolumeSet());
     ContainerReplicator pullReplicator = new DownloadAndImportReplicator(
-        container.getContainerSet(),
+        conf, container.getContainerSet(),
         importer,
         new SimpleContainerDownloader(conf, dnCertClient));
-    ContainerReplicator pushReplicator = new PushReplicator(
+    ContainerReplicator pushReplicator = new PushReplicator(conf,
         // TODO compression, metrics
         new OnDemandContainerReplicationSource(container.getController()),
         new GrpcContainerUploader(conf, dnCertClient)

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/TarContainerPacker.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/TarContainerPacker.java
@@ -30,7 +30,6 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
 import java.util.stream.Stream;
-import java.util.Objects;
 
 import com.google.common.annotations.VisibleForTesting;
 
@@ -40,18 +39,16 @@ import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.hadoop.ozone.container.common.interfaces.Container;
 import org.apache.hadoop.ozone.container.common.interfaces.ContainerPacker;
 
-
 import org.apache.commons.compress.archivers.ArchiveEntry;
 import org.apache.commons.compress.archivers.ArchiveInputStream;
 import org.apache.commons.compress.archivers.ArchiveOutputStream;
 import org.apache.commons.compress.archivers.tar.TarArchiveInputStream;
 import org.apache.commons.compress.archivers.tar.TarArchiveOutputStream;
-import org.apache.commons.compress.compressors.CompressorException;
-import org.apache.commons.compress.compressors.CompressorStreamFactory;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
 import org.apache.hadoop.ozone.container.keyvalue.helpers.KeyValueContainerLocationUtil;
 import org.apache.hadoop.ozone.container.metadata.DatanodeStoreSchemaThreeImpl;
+import org.apache.hadoop.ozone.container.replication.CopyContainerCompression;
 
 import static java.util.stream.Collectors.toList;
 import static org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.Result.CONTAINER_ALREADY_EXISTS;
@@ -69,15 +66,9 @@ public class TarContainerPacker
 
   static final String CONTAINER_FILE_NAME = "container.yaml";
 
-  private final String compression;
+  private final CopyContainerCompression compression;
 
-  private static final String NO_COMPRESSION = "no_compression";
-
-  public TarContainerPacker() {
-    this.compression = NO_COMPRESSION;
-  }
-
-  public TarContainerPacker(String compression) {
+  public TarContainerPacker(CopyContainerCompression compression) {
     this.compression = compression;
   }
 
@@ -175,10 +166,6 @@ public class TarContainerPacker
 
       includePath(Paths.get(containerData.getChunksPath()), CHUNKS_DIR_NAME,
           archiveOutput);
-    } catch (CompressorException e) {
-      throw new IOException(
-          "Can't compress the container: " + containerData.getContainerID(),
-          e);
     }
   }
 
@@ -195,10 +182,6 @@ public class TarContainerPacker
         }
         entry = archiveInput.getNextEntry();
       }
-    } catch (CompressorException e) {
-      throw new IOException(
-          "Can't read the container descriptor from the container archive",
-          e);
     }
 
     throw new IOException(
@@ -293,19 +276,13 @@ public class TarContainerPacker
   }
 
   @VisibleForTesting
-  InputStream decompress(InputStream input)
-      throws CompressorException {
-    return Objects.equals(compression, NO_COMPRESSION) ?
-        input : new CompressorStreamFactory()
-        .createCompressorInputStream(compression, input);
+  InputStream decompress(InputStream input) throws IOException {
+    return compression.wrap(input);
   }
 
   @VisibleForTesting
-  OutputStream compress(OutputStream output)
-      throws CompressorException {
-    return Objects.equals(compression, NO_COMPRESSION) ?
-        output : new CompressorStreamFactory()
-        .createCompressorOutputStream(compression, output);
+  OutputStream compress(OutputStream output) throws IOException {
+    return compression.wrap(output);
   }
 
   private byte[] innerUnpack(InputStream input, Path dbRoot, Path chunksRoot)
@@ -337,10 +314,6 @@ public class TarContainerPacker
         entry = archiveInput.getNextEntry();
       }
       return descriptorFileContent;
-
-    } catch (CompressorException e) {
-      throw new IOException("Can't uncompress to dbRoot: " + dbRoot +
-              ", chunksRoot: " + chunksRoot, e);
     }
   }
 }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/ozoneimpl/OzoneContainer.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/ozoneimpl/OzoneContainer.java
@@ -53,7 +53,6 @@ import org.apache.hadoop.ozone.container.common.volume.MutableVolumeSet;
 import org.apache.hadoop.ozone.container.common.volume.StorageVolume;
 import org.apache.hadoop.ozone.container.common.volume.StorageVolume.VolumeType;
 import org.apache.hadoop.ozone.container.common.volume.StorageVolumeChecker;
-import org.apache.hadoop.ozone.container.keyvalue.TarContainerPacker;
 import org.apache.hadoop.ozone.container.keyvalue.statemachine.background.BlockDeletingService;
 import org.apache.hadoop.ozone.container.keyvalue.statemachine.background.StaleRecoveringContainerScrubbingService;
 import org.apache.hadoop.ozone.container.replication.ContainerImporter;
@@ -208,7 +207,7 @@ public class OzoneContainer {
         secConf,
         certClient,
         new ContainerImporter(conf, containerSet, controller,
-            new TarContainerPacker(), volumeSet));
+            volumeSet));
 
     readChannel = new XceiverServerGrpc(
         datanodeDetails, config, hddsDispatcher, certClient);

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/replication/ContainerDownloader.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/replication/ContainerDownloader.java
@@ -34,6 +34,7 @@ import org.apache.hadoop.hdds.protocol.DatanodeDetails;
 public interface ContainerDownloader extends Closeable {
 
   Path getContainerDataFromReplicas(long containerId,
-      List<DatanodeDetails> sources, Path downloadDir);
+      List<DatanodeDetails> sources, Path downloadDir,
+      CopyContainerCompression compression);
 
 }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/replication/ContainerImporter.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/replication/ContainerImporter.java
@@ -54,17 +54,15 @@ public class ContainerImporter {
   private static final String CONTAINER_COPY_TMP_DIR = "tmp";
   private final ContainerSet containerSet;
   private final ContainerController controller;
-  private final TarContainerPacker packer;
   private final MutableVolumeSet volumeSet;
   private final VolumeChoosingPolicy volumeChoosingPolicy;
   private final long containerSize;
 
   public ContainerImporter(ConfigurationSource conf, ContainerSet containerSet,
-      ContainerController controller, TarContainerPacker tarContainerPacker,
+      ContainerController controller,
       MutableVolumeSet volumeSet) {
     this.containerSet = containerSet;
     this.controller = controller;
-    this.packer = tarContainerPacker;
     this.volumeSet = volumeSet;
     try {
       volumeChoosingPolicy = conf.getClass(
@@ -79,7 +77,8 @@ public class ContainerImporter {
   }
 
   public void importContainer(long containerID, Path tarFilePath,
-      HddsVolume hddsVolume) throws IOException {
+      HddsVolume hddsVolume, CopyContainerCompression compression)
+      throws IOException {
 
     HddsVolume targetVolume = hddsVolume;
     if (targetVolume == null) {
@@ -87,6 +86,8 @@ public class ContainerImporter {
     }
     try {
       KeyValueContainerData containerData;
+
+      TarContainerPacker packer = new TarContainerPacker(compression);
 
       try (FileInputStream input = new FileInputStream(tarFilePath.toFile())) {
         byte[] containerDescriptorYaml =

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/replication/ContainerReplicationSource.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/replication/ContainerReplicationSource.java
@@ -44,7 +44,8 @@ public interface ContainerReplicationSource {
    * @param compression Compression algorithm.
    * @throws IOException
    */
-  void copyData(long containerId, OutputStream destination, String compression)
+  void copyData(long containerId, OutputStream destination,
+      CopyContainerCompression compression)
       throws IOException;
 
 }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/replication/ContainerUploader.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/replication/ContainerUploader.java
@@ -28,5 +28,6 @@ import java.util.concurrent.CompletableFuture;
  */
 public interface ContainerUploader {
   OutputStream startUpload(long containerId, DatanodeDetails target,
-      CompletableFuture<Void> callback) throws IOException;
+      CompletableFuture<Void> callback, CopyContainerCompression compression)
+      throws IOException;
 }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/replication/GrpcContainerUploader.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/replication/GrpcContainerUploader.java
@@ -42,26 +42,25 @@ public class GrpcContainerUploader implements ContainerUploader {
 
   private final SecurityConfig securityConfig;
   private final CertificateClient certClient;
-  private final CopyContainerCompression compression;
 
   public GrpcContainerUploader(
       ConfigurationSource conf, CertificateClient certClient) {
     this.certClient = certClient;
     securityConfig = new SecurityConfig(conf);
-    compression = CopyContainerCompression.getConf(conf);
   }
 
   @Override
   public OutputStream startUpload(long containerId, DatanodeDetails target,
-      CompletableFuture<Void> callback) throws IOException {
+      CompletableFuture<Void> callback, CopyContainerCompression compression)
+      throws IOException {
     GrpcReplicationClient client =
         new GrpcReplicationClient(target.getIpAddress(),
             target.getPort(Port.Name.REPLICATION).getValue(),
-            securityConfig, certClient, compression.toString());
+            securityConfig, certClient, compression);
     StreamObserver<SendContainerRequest> requestStream = client.upload(
         new SendContainerResponseStreamObserver(containerId, target, callback));
     return new SendContainerOutputStream(requestStream, containerId,
-        GrpcReplicationService.BUFFER_SIZE);
+        GrpcReplicationService.BUFFER_SIZE, compression);
   }
 
   /**

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/replication/GrpcReplicationClient.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/replication/GrpcReplicationClient.java
@@ -27,7 +27,6 @@ import java.nio.file.Path;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 
-import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos;
 import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.CopyContainerRequestProto;
 import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.CopyContainerResponseProto;
 import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.SendContainerRequest;
@@ -62,12 +61,12 @@ public class GrpcReplicationClient implements AutoCloseable {
 
   private final IntraDatanodeProtocolServiceStub client;
 
-  private final ContainerProtos.CopyContainerCompressProto compression;
+  private final CopyContainerCompression compression;
 
   public GrpcReplicationClient(
       String host, int port,
       SecurityConfig secConfig, CertificateClient certClient,
-      String compression)
+      CopyContainerCompression compression)
       throws IOException {
     NettyChannelBuilder channelBuilder =
         NettyChannelBuilder.forAddress(host, port)
@@ -92,8 +91,7 @@ public class GrpcReplicationClient implements AutoCloseable {
     }
     channel = channelBuilder.build();
     client = IntraDatanodeProtocolServiceGrpc.newStub(channel);
-    this.compression =
-        ContainerProtos.CopyContainerCompressProto.valueOf(compression);
+    this.compression = compression;
   }
 
   public CompletableFuture<Path> download(long containerId, Path dir) {
@@ -102,7 +100,7 @@ public class GrpcReplicationClient implements AutoCloseable {
             .setContainerID(containerId)
             .setLen(-1)
             .setReadOffset(0)
-            .setCompression(compression)
+            .setCompression(compression.toProto())
             .build();
 
     CompletableFuture<Path> response = new CompletableFuture<>();

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/replication/GrpcReplicationService.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/replication/GrpcReplicationService.java
@@ -31,6 +31,8 @@ import org.apache.ratis.thirdparty.io.grpc.stub.StreamObserver;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import static org.apache.hadoop.ozone.container.replication.CopyContainerCompression.fromProto;
+
 /**
  * Service to make containers available for replication.
  */
@@ -55,9 +57,7 @@ public class GrpcReplicationService extends
   public void download(CopyContainerRequestProto request,
       StreamObserver<CopyContainerResponseProto> responseObserver) {
     long containerID = request.getContainerID();
-    String compression = request.hasCompression() ?
-        request.getCompression().toString() : CopyContainerCompression
-        .getDefaultCompression().toString();
+    CopyContainerCompression compression = fromProto(request.getCompression());
     LOG.info("Streaming container data ({}) to other datanode " +
         "with compression {}", containerID, compression);
     try {

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/replication/OnDemandContainerReplicationSource.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/replication/OnDemandContainerReplicationSource.java
@@ -19,13 +19,11 @@ package org.apache.hadoop.ozone.container.replication;
 
 import java.io.IOException;
 import java.io.OutputStream;
-import java.util.HashMap;
-import java.util.Map;
 
 import org.apache.hadoop.hdds.scm.container.common.helpers.StorageContainerException;
 import org.apache.hadoop.ozone.container.common.interfaces.Container;
-import org.apache.hadoop.ozone.container.keyvalue.TarContainerPacker;
 
+import org.apache.hadoop.ozone.container.keyvalue.TarContainerPacker;
 import org.apache.hadoop.ozone.container.ozoneimpl.ContainerController;
 
 import static org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.Result.CONTAINER_NOT_FOUND;
@@ -39,16 +37,9 @@ public class OnDemandContainerReplicationSource
 
   private final ContainerController controller;
 
-  private Map<String, TarContainerPacker> packer = new HashMap<>();
-
   public OnDemandContainerReplicationSource(
       ContainerController controller) {
     this.controller = controller;
-    for (Map.Entry<CopyContainerCompression, String> entry :
-        CopyContainerCompression.getCompressionMapping().entrySet()) {
-      packer.put(
-          entry.getKey().toString(), new TarContainerPacker(entry.getValue()));
-    }
   }
 
   @Override
@@ -58,7 +49,7 @@ public class OnDemandContainerReplicationSource
 
   @Override
   public void copyData(long containerId, OutputStream destination,
-                       String compression)
+                       CopyContainerCompression compression)
       throws IOException {
 
     Container container = controller.getContainer(containerId);
@@ -68,13 +59,8 @@ public class OnDemandContainerReplicationSource
           " is not found.", CONTAINER_NOT_FOUND);
     }
 
-    if (!packer.containsKey(compression)) {
-      throw new IOException("Can't compress the container. Compression " +
-          compression + " is not found.");
-    }
     controller.exportContainer(
         container.getContainerType(), containerId, destination,
-        packer.get(compression));
-
+        new TarContainerPacker(compression));
   }
 }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/replication/SendContainerOutputStream.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/replication/SendContainerOutputStream.java
@@ -25,10 +25,14 @@ import org.apache.ratis.thirdparty.io.grpc.stub.StreamObserver;
  * Output stream adapter for SendContainerResponse.
  */
 class SendContainerOutputStream extends GrpcOutputStream<SendContainerRequest> {
+
+  private final CopyContainerCompression compression;
+
   SendContainerOutputStream(
       StreamObserver<SendContainerRequest> streamObserver,
-      long containerId, int bufferSize) {
+      long containerId, int bufferSize, CopyContainerCompression compression) {
     super(streamObserver, containerId, bufferSize);
+    this.compression = compression;
   }
 
   @Override
@@ -37,6 +41,7 @@ class SendContainerOutputStream extends GrpcOutputStream<SendContainerRequest> {
         .setContainerID(getContainerId())
         .setData(data)
         .setOffset(getWrittenBytes())
+        .setCompression(compression.toProto())
         .build();
     getStreamObserver().onNext(request);
   }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/replication/SendContainerRequestHandler.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/replication/SendContainerRequestHandler.java
@@ -50,6 +50,7 @@ class SendContainerRequestHandler
   private OutputStream output;
   private HddsVolume volume;
   private Path path;
+  private CopyContainerCompression compression;
 
   SendContainerRequestHandler(
       ContainerImporter importer,
@@ -74,6 +75,7 @@ class SendContainerRequestHandler
         Files.createDirectories(dir);
         path = dir.resolve(ContainerUtils.getContainerTarName(containerId));
         output = Files.newOutputStream(path);
+        compression = CopyContainerCompression.fromProto(req.getCompression());
       }
 
       assertSame(containerId, req.getContainerID(), "containerID");
@@ -105,7 +107,7 @@ class SendContainerRequestHandler
     closeOutput();
 
     try {
-      importer.importContainer(containerId, path, volume);
+      importer.importContainer(containerId, path, volume, compression);
       LOG.info("Imported container {}", containerId);
       responseObserver.onNext(SendContainerResponse.newBuilder().build());
       responseObserver.onCompleted();

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/replication/SimpleContainerDownloader.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/replication/SimpleContainerDownloader.java
@@ -51,19 +51,17 @@ public class SimpleContainerDownloader implements ContainerDownloader {
 
   private final SecurityConfig securityConfig;
   private final CertificateClient certClient;
-  private final String compression;
 
   public SimpleContainerDownloader(
       ConfigurationSource conf, CertificateClient certClient) {
     securityConfig = new SecurityConfig(conf);
     this.certClient = certClient;
-    this.compression = CopyContainerCompression.getConf(conf).toString();
   }
 
   @Override
   public Path getContainerDataFromReplicas(
       long containerId, List<DatanodeDetails> sourceDatanodes,
-      Path downloadDir) {
+      Path downloadDir, CopyContainerCompression compression) {
 
     if (downloadDir == null) {
       downloadDir = Paths.get(System.getProperty("java.io.tmpdir"))
@@ -76,7 +74,7 @@ public class SimpleContainerDownloader implements ContainerDownloader {
     for (DatanodeDetails datanode : shuffledDatanodes) {
       try {
         CompletableFuture<Path> result =
-            downloadContainer(containerId, datanode, downloadDir);
+            downloadContainer(containerId, datanode, downloadDir, compression);
         return result.get();
       } catch (ExecutionException | IOException e) {
         LOG.error("Error on replicating container: {} from {}/{}", containerId,
@@ -108,9 +106,9 @@ public class SimpleContainerDownloader implements ContainerDownloader {
   }
 
   @VisibleForTesting
-  protected CompletableFuture<Path> downloadContainer(
-      long containerId, DatanodeDetails datanode, Path downloadDir)
-      throws IOException {
+  protected CompletableFuture<Path> downloadContainer(long containerId,
+      DatanodeDetails datanode, Path downloadDir,
+      CopyContainerCompression compression) throws IOException {
     CompletableFuture<Path> result;
     GrpcReplicationClient grpcReplicationClient =
         new GrpcReplicationClient(datanode.getIpAddress(),

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/TestKeyValueContainer.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/TestKeyValueContainer.java
@@ -80,6 +80,7 @@ import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
 import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_DB_PROFILE;
+import static org.apache.hadoop.ozone.container.replication.CopyContainerCompression.NO_COMPRESSION;
 import static org.apache.ratis.util.Preconditions.assertTrue;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -194,7 +195,7 @@ public class TestKeyValueContainer {
 
     //destination path
     File exportTar = folder.newFile("exported.tar");
-    TarContainerPacker packer = new TarContainerPacker();
+    TarContainerPacker packer = new TarContainerPacker(NO_COMPRESSION);
     //export the container
     try (FileOutputStream fos = new FileOutputStream(exportTar)) {
       keyValueContainer.exportContainerData(fos, packer);
@@ -221,9 +222,8 @@ public class TestKeyValueContainer {
 
     //destination path
     File folderToExport = folder.newFile("exported.tar");
-    for (Map.Entry<CopyContainerCompression, String> entry :
-        CopyContainerCompression.getCompressionMapping().entrySet()) {
-      TarContainerPacker packer = new TarContainerPacker(entry.getValue());
+    for (CopyContainerCompression compr : CopyContainerCompression.values()) {
+      TarContainerPacker packer = new TarContainerPacker(compr);
 
       //export the container
       try (FileOutputStream fos = new FileOutputStream(folderToExport)) {
@@ -364,7 +364,7 @@ public class TestKeyValueContainer {
 
     AtomicReference<String> failed = new AtomicReference<>();
 
-    TarContainerPacker packer = new TarContainerPacker();
+    TarContainerPacker packer = new TarContainerPacker(NO_COMPRESSION);
     List<Thread> threads = IntStream.range(0, 20)
         .mapToObj(i -> new Thread(() -> {
           try {

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/TestTarContainerPacker.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/TestTarContainerPacker.java
@@ -42,7 +42,6 @@ import org.apache.hadoop.ozone.container.common.impl.ContainerLayoutVersion;
 
 import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
 import org.apache.commons.compress.archivers.tar.TarArchiveInputStream;
-import org.apache.commons.compress.compressors.CompressorException;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
 import org.apache.hadoop.ozone.container.replication.CopyContainerCompression;
@@ -94,8 +93,8 @@ public class TestTarContainerPacker {
   private final String schemaVersion;
   private OzoneConfiguration conf;
 
-  public TestTarContainerPacker(
-      ContainerTestVersionInfo versionInfo, String compression) {
+  public TestTarContainerPacker(ContainerTestVersionInfo versionInfo,
+      CopyContainerCompression compression) {
     this.layout = versionInfo.getLayout();
     this.schemaVersion = versionInfo.getSchemaVersion();
     this.conf = new OzoneConfiguration();
@@ -110,10 +109,8 @@ public class TestTarContainerPacker {
         ContainerTestVersionInfo.getLayoutList();
     List<Object[]> parameterList = new ArrayList<>();
     for (ContainerTestVersionInfo containerTestVersionInfo : layoutList) {
-      for (Map.Entry<CopyContainerCompression, String> entry :
-          CopyContainerCompression.getCompressionMapping().entrySet()) {
-        parameterList.add(
-            new Object[]{containerTestVersionInfo, entry.getValue()});
+      for (CopyContainerCompression compr : CopyContainerCompression.values()) {
+        parameterList.add(new Object[]{containerTestVersionInfo, compr});
       }
     }
     return parameterList;
@@ -170,7 +167,7 @@ public class TestTarContainerPacker {
   }
 
   @Test
-  public void pack() throws IOException, CompressorException {
+  public void pack() throws IOException {
     //GIVEN
     KeyValueContainerData sourceContainerData =
         createContainer(SOURCE_CONTAINER_ROOT);

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/replication/GrpcOutputStreamTest.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/replication/GrpcOutputStreamTest.java
@@ -207,7 +207,7 @@ abstract class GrpcOutputStreamTest<T> {
     return bytes;
   }
 
-  private static byte[] getRandomBytes(int size) {
+  static byte[] getRandomBytes(int size) {
     byte[] bytes = new byte[size];
     RND.nextBytes(bytes);
     return bytes;

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/replication/TestCopyContainerCompression.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/replication/TestCopyContainerCompression.java
@@ -1,0 +1,95 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.ozone.container.replication;
+
+import org.apache.hadoop.hdds.conf.MutableConfigurationSource;
+import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.InputStream;
+import java.io.OutputStream;
+
+import static org.apache.commons.io.IOUtils.readFully;
+import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_CONTAINER_REPLICATION_COMPRESSION;
+import static org.apache.hadoop.ozone.container.replication.CopyContainerCompression.fromProto;
+import static org.apache.hadoop.ozone.container.replication.CopyContainerCompression.getDefaultCompression;
+import static org.apache.hadoop.ozone.container.replication.GrpcOutputStreamTest.getRandomBytes;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
+/**
+ * Test for {@link CopyContainerCompression}.
+ */
+class TestCopyContainerCompression {
+
+  @ParameterizedTest
+  @EnumSource
+  void protoConversion(CopyContainerCompression compression) {
+    assertEquals(compression, fromProto(compression.toProto()));
+  }
+
+  @ParameterizedTest
+  @EnumSource
+  void getConfReturnsValidSetting(CopyContainerCompression compression) {
+    MutableConfigurationSource conf = new OzoneConfiguration();
+    compression.setOn(conf);
+
+    assertEquals(compression, CopyContainerCompression.getConf(conf));
+  }
+
+  @Test
+  void getConfReturnsDefaultForUnknown() {
+    MutableConfigurationSource conf = new OzoneConfiguration();
+    conf.set(HDDS_CONTAINER_REPLICATION_COMPRESSION, "garbage");
+
+    assertEquals(getDefaultCompression(),
+        CopyContainerCompression.getConf(conf));
+  }
+
+  @ParameterizedTest
+  @EnumSource
+  void testInputOutput(CopyContainerCompression compression) throws Exception {
+    byte[] original = getRandomBytes(16);
+    ByteArrayOutputStream out = new ByteArrayOutputStream();
+
+    try (OutputStream compressed = compression.wrap(out)) {
+      compressed.write(original);
+    }
+
+    byte[] written = out.toByteArray();
+    if (compression == CopyContainerCompression.NO_COMPRESSION) {
+      assertArrayEquals(original, written);
+    } else {
+      assertNotEquals(original, written);
+    }
+
+    ByteArrayInputStream input = new ByteArrayInputStream(written);
+    try (InputStream uncompressed = compression.wrap(input)) {
+      byte[] read = new byte[original.length];
+      readFully(uncompressed, read);
+      assertArrayEquals(original, read);
+      assertEquals(0, uncompressed.available());
+    }
+  }
+
+}

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/replication/TestPushReplicator.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/replication/TestPushReplicator.java
@@ -17,11 +17,15 @@
  */
 package org.apache.hadoop.ozone.container.replication;
 
+import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
 import org.apache.hadoop.hdds.protocol.MockDatanodeDetails;
 import org.apache.hadoop.ozone.container.replication.AbstractReplicationTask.Status;
 import org.apache.ozone.test.SpyOutputStream;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
 import org.mockito.ArgumentCaptor;
 
 import java.io.IOException;
@@ -44,16 +48,26 @@ import static org.mockito.Mockito.when;
  */
 class TestPushReplicator {
 
-  @Test
-  void uploadCompletesNormally() throws IOException {
+  private OzoneConfiguration conf;
+
+  @BeforeEach
+  void setup() {
+    conf = new OzoneConfiguration();
+  }
+
+  @ParameterizedTest
+  @EnumSource
+  void uploadCompletesNormally(CopyContainerCompression compression)
+      throws IOException {
     // GIVEN
+    compression.setOn(conf);
     long containerID = randomContainerID();
     DatanodeDetails target = MockDatanodeDetails.randomDatanodeDetails();
     Consumer<CompletableFuture<Void>> completion =
         fut -> fut.complete(null);
     SpyOutputStream output = new SpyOutputStream(NULL_OUTPUT_STREAM);
     ContainerReplicator subject = createSubject(containerID, target,
-        output, completion);
+        output, completion, compression);
     ReplicationTask task = new ReplicationTask(toTarget(containerID, target),
         subject);
 
@@ -75,7 +89,7 @@ class TestPushReplicator {
     Consumer<CompletableFuture<Void>> completion =
         fut -> fut.completeExceptionally(new Exception("testing"));
     ContainerReplicator subject = createSubject(containerID, target,
-        output, completion);
+        output, completion, NO_COMPRESSION);
     ReplicationTask task = new ReplicationTask(toTarget(containerID, target),
         subject);
 
@@ -97,7 +111,7 @@ class TestPushReplicator {
       throw new RuntimeException();
     };
     ContainerReplicator subject = createSubject(containerID, target,
-        output, completion);
+        output, completion, NO_COMPRESSION);
     ReplicationTask task = new ReplicationTask(toTarget(containerID, target),
         subject);
 
@@ -113,25 +127,36 @@ class TestPushReplicator {
     return ThreadLocalRandom.current().nextLong();
   }
 
-  private static ContainerReplicator createSubject(
+  private ContainerReplicator createSubject(
       long containerID, DatanodeDetails target, OutputStream outputStream,
-      Consumer<CompletableFuture<Void>> completion) throws IOException {
+      Consumer<CompletableFuture<Void>> completion,
+      CopyContainerCompression compression
+  ) throws IOException {
     ContainerReplicationSource source = mock(ContainerReplicationSource.class);
     ContainerUploader uploader = mock(ContainerUploader.class);
-    ArgumentCaptor<CompletableFuture<Void>> captor =
+    ArgumentCaptor<CompletableFuture<Void>> futureArgument =
         ArgumentCaptor.forClass(CompletableFuture.class);
+    ArgumentCaptor<CopyContainerCompression> compressionArgument =
+        ArgumentCaptor.forClass(CopyContainerCompression.class);
 
-    when(uploader.startUpload(eq(containerID), eq(target), captor.capture()))
+    when(
+        uploader.startUpload(eq(containerID), eq(target),
+            futureArgument.capture(), compressionArgument.capture()
+        ))
         .thenReturn(outputStream);
 
     doAnswer(invocation -> {
-      completion.accept(captor.getValue());
+      compressionArgument.getAllValues().forEach(
+          c -> assertEquals(compression, c)
+      );
+      completion.accept(futureArgument.getValue());
       return null;
     })
         .when(source)
-        .copyData(containerID, outputStream, NO_COMPRESSION.name());
+        .copyData(eq(containerID), eq(outputStream),
+            compressionArgument.capture());
 
-    return new PushReplicator(source, uploader);
+    return new PushReplicator(conf, source, uploader);
   }
 
 }

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/replication/TestReplicationSupervisor.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/replication/TestReplicationSupervisor.java
@@ -278,7 +278,7 @@ public class TestReplicationSupervisor {
     Path res = Paths.get("file:/tmp/no-such-file");
     Mockito.when(
         moc.getContainerDataFromReplicas(Mockito.anyLong(), Mockito.anyList(),
-            Mockito.any(Path.class)))
+            Mockito.any(Path.class), Mockito.any()))
         .thenReturn(res);
 
     final String testDir = GenericTestUtils.getTempPath(
@@ -289,9 +289,9 @@ public class TestReplicationSupervisor {
         .thenReturn(Collections.singletonList(
             new HddsVolume.Builder(testDir).conf(conf).build()));
     ContainerImporter importer =
-        new ContainerImporter(conf, set, null, null, volumeSet);
+        new ContainerImporter(conf, set, null, volumeSet);
     ContainerReplicator replicator =
-        new DownloadAndImportReplicator(set, importer, moc);
+        new DownloadAndImportReplicator(conf, set, importer, moc);
 
     replicatorRef.set(replicator);
 

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/replication/TestSimpleContainerDownloader.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/replication/TestSimpleContainerDownloader.java
@@ -44,6 +44,8 @@ import org.junit.rules.TemporaryFolder;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Timeout;
 
+import static org.apache.hadoop.ozone.container.replication.CopyContainerCompression.NO_COMPRESSION;
+
 /**
  * Test SimpleContainerDownloader.
  */
@@ -66,7 +68,7 @@ public class TestSimpleContainerDownloader {
     //WHEN
     final Path result =
         downloader.getContainerDataFromReplicas(1L, datanodes,
-            tempDir.newFolder().toPath());
+            tempDir.newFolder().toPath(), NO_COMPRESSION);
 
     //THEN
     Assertions.assertEquals(datanodes.get(0).getUuidString(),
@@ -86,7 +88,7 @@ public class TestSimpleContainerDownloader {
     //WHEN
     final Path result =
         downloader.getContainerDataFromReplicas(1L, datanodes,
-            tempDir.newFolder().toPath());
+            tempDir.newFolder().toPath(), NO_COMPRESSION);
 
     //THEN
     //first datanode is failed, second worked
@@ -106,7 +108,7 @@ public class TestSimpleContainerDownloader {
     //WHEN
     final Path result =
         downloader.getContainerDataFromReplicas(1L, datanodes,
-            tempDir.newFolder().toPath());
+            tempDir.newFolder().toPath(), NO_COMPRESSION);
 
     //THEN
     //first datanode is failed, second worked
@@ -130,8 +132,8 @@ public class TestSimpleContainerDownloader {
 
           @Override
           protected CompletableFuture<Path> downloadContainer(
-              long containerId, DatanodeDetails datanode, Path downloadPath
-          ) {
+              long containerId, DatanodeDetails datanode, Path downloadPath,
+              CopyContainerCompression compression) {
             //download is always successful.
             return CompletableFuture
                 .completedFuture(Paths.get(datanode.getUuidString()));
@@ -142,7 +144,7 @@ public class TestSimpleContainerDownloader {
     //returned.
     for (int i = 0; i < 10000; i++) {
       Path path = downloader.getContainerDataFromReplicas(1L, datanodes,
-          tempDir.newFolder().toPath());
+          tempDir.newFolder().toPath(), NO_COMPRESSION);
       if (path.toString().equals(datanodes.get(1).getUuidString())) {
         return;
       }
@@ -183,8 +185,8 @@ public class TestSimpleContainerDownloader {
 
       @Override
       protected CompletableFuture<Path> downloadContainer(
-          long containerId, DatanodeDetails datanode, Path downloadPath
-      ) {
+          long containerId, DatanodeDetails datanode, Path downloadPath,
+          CopyContainerCompression compression) {
 
         if (datanodes.contains(datanode)) {
           if (directException) {

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/upgrade/TestDatanodeUpgradeToScmHA.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/upgrade/TestDatanodeUpgradeToScmHA.java
@@ -39,7 +39,6 @@ import org.apache.hadoop.ozone.container.common.statemachine.EndpointStateMachin
 import org.apache.hadoop.ozone.container.common.states.endpoint.VersionEndpointTask;
 import org.apache.hadoop.ozone.container.common.utils.HddsVolumeUtil;
 import org.apache.hadoop.ozone.container.keyvalue.KeyValueContainerData;
-import org.apache.hadoop.ozone.container.keyvalue.TarContainerPacker;
 import org.apache.hadoop.ozone.container.replication.ContainerImporter;
 import org.apache.hadoop.ozone.container.replication.ContainerReplicationSource;
 import org.apache.hadoop.ozone.container.replication.OnDemandContainerReplicationSource;
@@ -69,6 +68,8 @@ import java.util.UUID;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
+
+import static org.apache.hadoop.ozone.container.replication.CopyContainerCompression.NO_COMPRESSION;
 
 /**
  * Tests upgrading a single datanode from pre-SCM HA volume format that used
@@ -655,7 +656,7 @@ public class TestDatanodeUpgradeToScmHA {
 
     File destination = tempFolder.newFile();
     try (FileOutputStream fos = new FileOutputStream(destination)) {
-      replicationSource.copyData(containerId, fos, "NO_COMPRESSION");
+      replicationSource.copyData(containerId, fos, NO_COMPRESSION);
     }
     return destination;
   }
@@ -669,13 +670,14 @@ public class TestDatanodeUpgradeToScmHA {
         new ContainerImporter(dsm.getConf(),
             dsm.getContainer().getContainerSet(),
             dsm.getContainer().getController(),
-            new TarContainerPacker(), dsm.getContainer().getVolumeSet());
+            dsm.getContainer().getVolumeSet());
 
     File tempFile = tempFolder.newFile(
         ContainerUtils.getContainerTarName(containerID));
     Files.copy(source.toPath(), tempFile.toPath(),
         StandardCopyOption.REPLACE_EXISTING);
-    replicator.importContainer(containerID, tempFile.toPath(), null);
+    replicator.importContainer(containerID, tempFile.toPath(), null,
+        NO_COMPRESSION);
   }
 
   public void dispatchRequest(

--- a/hadoop-hdds/interface-client/src/main/proto/DatanodeClientProtocol.proto
+++ b/hadoop-hdds/interface-client/src/main/proto/DatanodeClientProtocol.proto
@@ -507,6 +507,7 @@ message SendContainerRequest {
   required uint64 offset = 2;
   required bytes data = 3;
   optional int64 checksum = 4;
+  optional CopyContainerCompressProto compression = 5;
 }
 
 message SendContainerResponse {

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/ozoneimpl/TestOzoneContainerWithTLS.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/ozoneimpl/TestOzoneContainerWithTLS.java
@@ -80,6 +80,7 @@ import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_X509_RENEW_GRACE_DURATI
 import static org.apache.hadoop.hdds.HddsConfigKeys.OZONE_METADATA_DIRS;
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.HDDS_DATANODE_DIR_KEY;
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_SECURITY_ENABLED_KEY;
+import static org.apache.hadoop.ozone.container.replication.CopyContainerCompression.NO_COMPRESSION;
 
 /**
  * Tests ozone containers via secure grpc/netty.
@@ -271,7 +272,7 @@ public class TestOzoneContainerWithTLS {
       SimpleContainerDownloader downloader =
           new SimpleContainerDownloader(conf, caClient);
       Path file = downloader.getContainerDataFromReplicas(
-          containerId, sourceDatanodes, null);
+          containerId, sourceDatanodes, null, NO_COMPRESSION);
       downloader.close();
       Assert.assertNull(file);
       Assert.assertTrue(logCapture.getOutput().contains(
@@ -309,7 +310,7 @@ public class TestOzoneContainerWithTLS {
         downloader = new SimpleContainerDownloader(conf, caClient);
         try {
           file = downloader.getContainerDataFromReplicas(cId, sourceDatanodes,
-                  null);
+                  null, NO_COMPRESSION);
           downloader.close();
           Assert.assertNotNull(file);
         } finally {

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/container/ExportSubcommand.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/container/ExportSubcommand.java
@@ -31,8 +31,8 @@ import java.io.File;
 import java.io.FileOutputStream;
 import java.util.concurrent.Callable;
 
-import static org.apache.commons.compress.compressors.CompressorStreamFactory.GZIP;
 import static org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.Result.CONTAINER_NOT_FOUND;
+import static org.apache.hadoop.ozone.container.replication.CopyContainerCompression.NO_COMPRESSION;
 
 /**
  * Handles {@code ozone debug container export} command.
@@ -76,7 +76,7 @@ public class ExportSubcommand implements Callable<Void> {
           new File(destination, "container-" + containerId + ".tar");
       try (FileOutputStream fos = new FileOutputStream(destinationFile)) {
         try {
-          replicationSource.copyData(containerId, fos, GZIP);
+          replicationSource.copyData(containerId, fos, NO_COMPRESSION);
         } catch (StorageContainerException e) {
           if (e.getResult() == CONTAINER_NOT_FOUND) {
             continue;

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/ClosedContainerReplicator.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/ClosedContainerReplicator.java
@@ -33,7 +33,6 @@ import org.apache.hadoop.ozone.container.common.impl.ContainerSet;
 import org.apache.hadoop.ozone.container.common.interfaces.Handler;
 import org.apache.hadoop.ozone.container.common.volume.MutableVolumeSet;
 import org.apache.hadoop.ozone.container.common.volume.StorageVolume;
-import org.apache.hadoop.ozone.container.keyvalue.TarContainerPacker;
 import org.apache.hadoop.ozone.container.ozoneimpl.ContainerController;
 import org.apache.hadoop.ozone.container.replication.ContainerImporter;
 import org.apache.hadoop.ozone.container.replication.ContainerReplicator;
@@ -206,8 +205,8 @@ public class ClosedContainerReplicator extends BaseFreonGenerator implements
         new ContainerController(containerSet, handlers);
 
     ContainerImporter importer = new ContainerImporter(conf, containerSet,
-        controller, new TarContainerPacker(), null);
-    replicator = new DownloadAndImportReplicator(containerSet, importer,
+        controller, null);
+    replicator = new DownloadAndImportReplicator(conf, containerSet, importer,
         new SimpleContainerDownloader(conf, null));
 
     ReplicationServer.ReplicationConfig replicationConfig


### PR DESCRIPTION
## What changes were proposed in this pull request?

Initial implementation of push replication had hard-coded "no compression", ignoring the configuration, which is currently only used by the pull direction.  The goal of this change is to use the compression defined in the config for push, too.

`PushReplicator` and `DownloadAndImportReplicator` take the compression from config.  Other components (`ContainerDownloader`, `ContainerImporter`, `ContainerReplicationSource`) apply the compression passed to them by their callers.  This is required because the actual compression is decided by the datanode that initiates the replication (source or target, depending on direction).  The other party applies the compression specified in the request.

Refactored `CopyContainerCompression` to use enum features instead of a string-based mapping, and moved all compressor-related logic into it.

https://issues.apache.org/jira/browse/HDDS-7821

## How was this patch tested?

Added unit tests.

Regular CI:
https://github.com/adoroszlai/hadoop-ozone/actions/runs/4056964585