### PR TITLE
HDDS-7861. [Snapshot] Delete keys from the source bucket to fix the flakiness of snapshot restore tests

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/snapshot/TestOzoneSnapshotRestore.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/snapshot/TestOzoneSnapshotRestore.java
@@ -220,8 +220,9 @@ public class TestOzoneSnapshotRestore {
     Assertions.assertEquals(0, delKeyCount);
 
     String sourcePath = OM_KEY_PREFIX + volume + OM_KEY_PREFIX + bucket
-            + OM_KEY_PREFIX + snapshotKeyPrefix;
-    String destPath = OM_KEY_PREFIX + volume + OM_KEY_PREFIX + bucket;
+        + OM_KEY_PREFIX + snapshotKeyPrefix;
+    String destPath = OM_KEY_PREFIX + volume + OM_KEY_PREFIX + bucket
+        + OM_KEY_PREFIX;
 
     for (int i = 0; i < 5; i++) {
       keyCopy(sourcePath + keyPrefix + i, destPath);
@@ -259,8 +260,9 @@ public class TestOzoneSnapshotRestore {
     Assertions.assertEquals(5, volBucketKeyCount);
 
     String sourcePath = OM_KEY_PREFIX + volume + OM_KEY_PREFIX + bucket
-            + OM_KEY_PREFIX + snapshotKeyPrefix;
-    String destPath = OM_KEY_PREFIX + volume + OM_KEY_PREFIX + bucket2;
+        + OM_KEY_PREFIX + snapshotKeyPrefix;
+    String destPath = OM_KEY_PREFIX + volume + OM_KEY_PREFIX + bucket2
+        + OM_KEY_PREFIX;
 
     for (int i = 0; i < 5; i++) {
       keyCopy(sourcePath + keyPrefix + i, destPath);
@@ -302,8 +304,9 @@ public class TestOzoneSnapshotRestore {
     Assertions.assertEquals(5, volBucketKeyCount);
 
     String sourcePath = OM_KEY_PREFIX + volume + OM_KEY_PREFIX + bucket
-            + OM_KEY_PREFIX + snapshotKeyPrefix;
-    String destPath = OM_KEY_PREFIX + volume + OM_KEY_PREFIX + bucket2;
+        + OM_KEY_PREFIX + snapshotKeyPrefix;
+    String destPath = OM_KEY_PREFIX + volume + OM_KEY_PREFIX + bucket2
+        + OM_KEY_PREFIX;
 
     for (int i = 0; i < 5; i++) {
       keyCopy(sourcePath + keyPrefix + i, destPath);

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/snapshot/TestOzoneSnapshotRestore.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/snapshot/TestOzoneSnapshotRestore.java
@@ -264,13 +264,14 @@ public class TestOzoneSnapshotRestore {
     // If we don't delete keys from the source bucket, copy command
     // will fail. In copy command, there is a check to make sure that key
     // doesn't exist in the destination bucket.
-    // Bucket creation is async operation on server side, and it is possible
-    // that destination bucket doesn't get created by the time copy command
-    // starts.
-    // In that case, "key doesn't exist in destination bucket check" will fail
-    // because in scenario when key doesn't exist in requested bucket,
-    // we check in other buckets for the key and create a fake dir if similar
-    // key exists in some other bucket.
+    // Problem is that RocksDB's seek operation doesn't 100% guarantee that
+    // item key is available. Tho we believe that it is in
+    // `createFakeDirIfShould` function. When we seek if there is a directory
+    // for the key name, sometime it returns non-null response but in reality
+    // item doesn't exist.
+    // In the case when seek returns non-null response, "key doesn't exist in
+    // the destination bucket" check fails because getFileStatus returns
+    // dir with key name exists.
     deleteKeys(buck);
 
     String sourcePath = OM_KEY_PREFIX + volume + OM_KEY_PREFIX + bucket

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/snapshot/TestOzoneSnapshotRestore.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/snapshot/TestOzoneSnapshotRestore.java
@@ -259,6 +259,20 @@ public class TestOzoneSnapshotRestore {
     int volBucketKeyCount = keyCount(buck, snapshotKeyPrefix + keyPrefix);
     Assertions.assertEquals(5, volBucketKeyCount);
 
+    // Delete keys from the source bucket.
+    // This is temporary fix to make sure that test passes all the time.
+    // If we don't delete keys from the source bucket, copy command
+    // will fail. In copy command, there is a check to make sure that key
+    // doesn't exist in the destination bucket.
+    // Bucket creation is async operation on server side, and it is possible
+    // that destination bucket doesn't get created by the time copy command
+    // starts.
+    // In that case, key doesn't exist in destination bucket check will fail
+    // because in scenarios when key doesn't exist. We check in other buckets
+    // for the key and create a fake dir if similar key exists in some
+    // another bucket.
+    deleteKeys(buck);
+
     String sourcePath = OM_KEY_PREFIX + volume + OM_KEY_PREFIX + bucket
         + OM_KEY_PREFIX + snapshotKeyPrefix;
     String destPath = OM_KEY_PREFIX + volume + OM_KEY_PREFIX + bucket2

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/snapshot/TestOzoneSnapshotRestore.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/snapshot/TestOzoneSnapshotRestore.java
@@ -267,10 +267,10 @@ public class TestOzoneSnapshotRestore {
     // Bucket creation is async operation on server side, and it is possible
     // that destination bucket doesn't get created by the time copy command
     // starts.
-    // In that case, key doesn't exist in destination bucket check will fail
-    // because in scenarios when key doesn't exist. We check in other buckets
-    // for the key and create a fake dir if similar key exists in some
-    // another bucket.
+    // In that case, "key doesn't exist in destination bucket check" will fail
+    // because in scenario when key doesn't exist in requested bucket,
+    // we check in other buckets for the key and create a fake dir if similar
+    // key exists in some other bucket.
     deleteKeys(buck);
 
     String sourcePath = OM_KEY_PREFIX + volume + OM_KEY_PREFIX + bucket


### PR DESCRIPTION
## What changes were proposed in this pull request?
Snapshot [restore integration test](https://github.com/apache/ozone/blob/HDDS-6517-Snapshot/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/snapshot/TestOzoneSnapshotRestore.java#L236) fails when restoring form bucket1's snapshot to bucket2 for legacy bucket type.

This change is to delete keys from the source bucket. This is temporary fix to make sure that test passes all the time.
 If we don't delete keys from the source bucket, copy command will fail. In copy command, there is a check to make sure that key doesn't exist in the destination bucket.
Problem is that RocksDB's seek operation doesn't 100% guarantee that item key is available. Tho we believe that it is. When we seek if there is a directory for the key name, sometime it returns non-null response but in reality item doesn't exist.
[Here](https://github.com/apache/ozone/blob/d8765436c2bf76547973cc568f1648f1b1fe9fcb/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/KeyManagerImpl.java#L1184), sometimes seek returns null and sometimes it return source bucket (which is wrong). When is returns source bucket, we create fake dir and return the non-null response.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-7861

## How was this patch tested?
Existing integration tests.
