### PR TITLE
HDDS-7379. Use certificate bundles instead of the sole certificate

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/security/x509/certificate/utils/CertificateCodec.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/security/x509/certificate/utils/CertificateCodec.java
@@ -253,7 +253,6 @@ public class CertificateCodec {
    * @throws CertificateException - on Error.
    * @throws IOException          - on Error.
    */
-  //BUG HERE
   public X509CertificateHolder readCertificate() throws
       CertificateException, IOException {
     return readCertificate(this.location.toAbsolutePath(),

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/security/x509/certificate/utils/CertificateCodec.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/security/x509/certificate/utils/CertificateCodec.java
@@ -19,9 +19,7 @@
 
 package org.apache.hadoop.hdds.security.x509.certificate.utils;
 
-import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
-import org.apache.commons.io.LineIterator;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.hadoop.hdds.security.exception.SCMSecurityException;
 import org.apache.hadoop.hdds.security.x509.SecurityConfig;
@@ -29,17 +27,13 @@ import org.bouncycastle.cert.X509CertificateHolder;
 import org.bouncycastle.cert.jcajce.JcaX509CertificateConverter;
 import org.bouncycastle.jcajce.provider.asymmetric.x509.CertificateFactory;
 import org.bouncycastle.openssl.jcajce.JcaPEMWriter;
-import org.jetbrains.annotations.Contract;
-import org.jetbrains.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.BufferedWriter;
 import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
-import java.io.FileWriter;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.StringWriter;

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/security/x509/certificate/utils/CertificateCodec.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/security/x509/certificate/utils/CertificateCodec.java
@@ -169,7 +169,7 @@ public class CertificateCodec {
    */
   public static X509Certificate getX509Certificate(String pemEncodedString)
       throws CertificateException, IOException {
-    CertificateFactory fact = new CertificateFactory();
+    CertificateFactory fact = getCertFactory();
     try (InputStream input = IOUtils.toInputStream(pemEncodedString, UTF_8)) {
       return (X509Certificate) fact.engineGenerateCertificate(input);
     }
@@ -177,6 +177,10 @@ public class CertificateCodec {
 
   public static X509Certificate firstCertificateFrom(CertPath certificatePath) {
     return (X509Certificate) certificatePath.getCertificates().get(0);
+  }
+
+  public static CertificateFactory getCertFactory() {
+    return new CertificateFactory();
   }
 
   /**
@@ -314,7 +318,7 @@ public class CertificateCodec {
     for (Certificate cert : certificates) {
       updatedList.add((X509Certificate) cert);
     }
-    CertificateFactory factory = new CertificateFactory();
+    CertificateFactory factory = getCertFactory();
     return factory.engineGenerateCertPath(updatedList);
   }
 
@@ -341,7 +345,7 @@ public class CertificateCodec {
 
   private static CertPath generateCertPathFromInputStream(
       InputStream inputStream) throws CertificateException {
-    CertificateFactory fact = new CertificateFactory();
+    CertificateFactory fact = getCertFactory();
     return fact.engineGenerateCertPath(inputStream, "PEM");
   }
 

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/security/x509/certificate/utils/CertificateCodec.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/security/x509/certificate/utils/CertificateCodec.java
@@ -105,6 +105,9 @@ public class CertificateCodec {
     return CERTIFICATE_CONVERTER.getCertificate(holder);
   }
 
+  /**
+   * Get a valid pem encoded string for the certification path.
+   */
   public static String getPEMEncodedString(CertPath certPath)
       throws SCMSecurityException {
     List<? extends Certificate> certsInPath = certPath.getCertificates();
@@ -155,7 +158,9 @@ public class CertificateCodec {
   }
 
   /**
-   * Gets the X.509 Certificate from PEM encoded String.
+   * Get the leading X.509 Certificate from PEM encoded String possibly
+   * containing multiple certificates. To get all certificates, use
+   * {@link #getCertPathFromPemEncodedString(String)}.
    *
    * @param pemEncodedString - PEM encoded String.
    * @return X509Certificate  - Certificate.
@@ -197,17 +202,19 @@ public class CertificateCodec {
    * Write the Certificate to the specific file.
    *
    * @param xCertificate - Certificate to write.
-   * @param fileName - file name to write to.
+   * @param fileName     - file name to write to.
    * @throws SCMSecurityException - On Error.
    * @throws IOException          - On Error.
    */
   public void writeCertificate(X509CertificateHolder xCertificate,
-      String fileName)
-      throws SCMSecurityException, IOException {
+      String fileName) throws IOException {
     String pem = getPEMEncodedString(xCertificate);
     writeCertificate(location.toAbsolutePath(), fileName, pem);
   }
 
+  /**
+   * Write the pem encoded string to the specified file.
+   */
   public void writeCertificate(String fileName, String pemEncodedCert)
       throws IOException {
     writeCertificate(location.toAbsolutePath(), fileName, pemEncodedCert);
@@ -236,6 +243,9 @@ public class CertificateCodec {
     Files.setPosixFilePermissions(certificateFile.toPath(), permissionSet);
   }
 
+  /**
+   * Gets a certificate path from the specified pem encoded String.
+   */
   public static CertPath getCertPathFromPemEncodedString(
       String pemString) throws CertificateException, IOException {
     try (InputStream is =
@@ -258,11 +268,17 @@ public class CertificateCodec {
     }
   }
 
+  /**
+   * Get the certificate path stored under the specified filename.
+   */
   public CertPath getCertPath(String fileName)
       throws IOException, CertificateException {
     return getCertPath(location, fileName);
   }
 
+  /**
+   * Get the default certificate path for this cert codec.
+   */
   public CertPath getCertPath() throws CertificateException, IOException {
     return getCertPath(this.securityConfig.getCertificateFileName());
   }
@@ -281,6 +297,11 @@ public class CertificateCodec {
     return new X509CertificateHolder(x509cert.getEncoded());
   }
 
+  /**
+   * Helper method that takes in a certificate path and a certificate and
+   * generates a new certificate path starting with the new certificate
+   * followed by all certificates in the specified path.
+   */
   public CertPath prependCertToCertPath(X509CertificateHolder certHolder,
       CertPath path) throws CertificateException {
     List<? extends Certificate> certificates = path.getCertificates();
@@ -293,6 +314,10 @@ public class CertificateCodec {
     return factory.engineGenerateCertPath(updatedList);
   }
 
+  /**
+   * Helper method that gets one certificate from the specified location.
+   * The remaining certificates are ignored.
+   */
   public X509CertificateHolder getTargetCertHolder(Path path,
       String fileName) throws CertificateException, IOException {
     CertPath certPath = getCertPath(path, fileName);
@@ -301,6 +326,10 @@ public class CertificateCodec {
     return getCertificateHolder(certificate);
   }
 
+  /**
+   * Helper method that gets one certificate from the default location.
+   * The remaining certificates are ignored.
+   */
   public X509CertificateHolder getTargetCertHolder()
       throws CertificateException, IOException {
     return getTargetCertHolder(

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/security/x509/certificate/utils/CertificateCodec.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/security/x509/certificate/utils/CertificateCodec.java
@@ -175,6 +175,10 @@ public class CertificateCodec {
     }
   }
 
+  public static X509Certificate firstCertificateFrom(CertPath certificatePath) {
+    return (X509Certificate) certificatePath.getCertificates().get(0);
+  }
+
   /**
    * Get Certificate location.
    *
@@ -321,8 +325,7 @@ public class CertificateCodec {
   public X509CertificateHolder getTargetCertHolder(Path path,
       String fileName) throws CertificateException, IOException {
     CertPath certPath = getCertPath(path, fileName);
-    X509Certificate certificate =
-        (X509Certificate) certPath.getCertificates().get(0);
+    X509Certificate certificate = firstCertificateFrom(certPath);
     return getCertificateHolder(certificate);
   }
 

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/security/x509/certificate/authority/CAType.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/security/x509/certificate/authority/CAType.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.apache.hadoop.hdds.security.x509.certificate.authority;
+
+/**
+ * Certificate authority type. Root certificate is typically a self-signed
+ * certificate by the SCM. It can also be specified from an external
+ * source.
+ */
+public enum CAType {
+  NONE(""),
+  SUBORDINATE("CA-"),
+  ROOT("ROOTCA-");
+
+  private final String fileNamePrefix;
+
+  public final String getFileNamePrefix() {
+    return fileNamePrefix;
+  }
+
+  CAType(String fileNamePrefix) {
+    this.fileNamePrefix = fileNamePrefix;
+  }
+}

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/security/x509/certificate/authority/CertificateServer.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/security/x509/certificate/authority/CertificateServer.java
@@ -31,6 +31,7 @@ import org.bouncycastle.pkcs.PKCS10CertificationRequest;
 
 import java.io.IOException;
 import java.math.BigInteger;
+import java.security.cert.CertPath;
 import java.security.cert.CertificateException;
 import java.security.cert.X509Certificate;
 import java.util.Date;
@@ -75,7 +76,7 @@ public interface CertificateServer {
    * @throws CertificateException
    * @throws IOException
    */
-  List<X509CertificateHolder> getCaCertBundle() throws CertificateException,
+  CertPath getCaCertPath() throws CertificateException,
       IOException;
 
   /**
@@ -100,7 +101,7 @@ public interface CertificateServer {
    * approved.
    * @throws SCMSecurityException - on Error.
    */
-  Future<List<X509CertificateHolder>> requestCertificate(
+  Future<CertPath> requestCertificate(
       PKCS10CertificationRequest csr,
       CertificateApprover.ApprovalType type, NodeType role)
       throws SCMSecurityException;
@@ -117,7 +118,7 @@ public interface CertificateServer {
    * approved.
    * @throws SCMSecurityException - on Error.
    */
-  Future<List<X509CertificateHolder>> requestCertificate(String csr,
+  Future<CertPath> requestCertificate(String csr,
       ApprovalType type, NodeType nodeType) throws IOException;
 
   /**

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/security/x509/certificate/authority/CertificateServer.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/security/x509/certificate/authority/CertificateServer.java
@@ -165,12 +165,4 @@ public interface CertificateServer {
    * @return latest CRL id.
    */
   long getLatestCrlId();
-
-  /**
-   * Make it explicit what type of CertificateServer we are creating here.
-   */
-  enum CAType {
-    SELF_SIGNED_CA,
-    INTERMEDIARY_CA
-  }
 }

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/security/x509/certificate/authority/CertificateServer.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/security/x509/certificate/authority/CertificateServer.java
@@ -87,7 +87,7 @@ public interface CertificateServer {
    * approved.
    * @throws SCMSecurityException - on Error.
    */
-  Future<X509CertificateHolder> requestCertificate(
+  Future<List<X509CertificateHolder>> requestCertificate(
       PKCS10CertificationRequest csr,
       CertificateApprover.ApprovalType type, NodeType role)
       throws SCMSecurityException;
@@ -96,14 +96,15 @@ public interface CertificateServer {
   /**
    * Request a Certificate based on Certificate Signing Request.
    *
-   * @param csr - Certificate Signing Request as a PEM encoded String.
-   * @param type - An Enum which says what kind of approval process to follow.
+   * @param csr       - Certificate Signing Request as a PEM encoded String.
+   * @param type      - An Enum which says what kind of approval process to
+   *                  follow.
    * @param nodeType: OM/SCM/DN
    * @return A future that will have this certificate when this request is
    * approved.
    * @throws SCMSecurityException - on Error.
    */
-  Future<X509CertificateHolder> requestCertificate(String csr,
+  Future<List<X509CertificateHolder>> requestCertificate(String csr,
       ApprovalType type, NodeType nodeType) throws IOException;
 
   /**

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/security/x509/certificate/authority/CertificateServer.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/security/x509/certificate/authority/CertificateServer.java
@@ -66,6 +66,19 @@ public interface CertificateServer {
       throws CertificateException, IOException;
 
   /**
+   * Gets the certificate bundle for the CA certificate of this server.
+   * The first element of the list is the CA certificate. The issuer of an
+   * element of this list is always the next element of the list. The root CA
+   * certificate is the final element.
+   *
+   * @return the certificate bundle starting with the CA certificate.
+   * @throws CertificateException
+   * @throws IOException
+   */
+  List<X509CertificateHolder> getCaCertBundle() throws CertificateException,
+      IOException;
+
+  /**
    * Returns the Certificate corresponding to given certificate serial id if
    * exist. Return null if it doesn't exist.
    *

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/security/x509/certificate/authority/DefaultCAServer.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/security/x509/certificate/authority/DefaultCAServer.java
@@ -51,7 +51,6 @@ import java.security.NoSuchAlgorithmException;
 import java.security.NoSuchProviderException;
 import java.security.PrivateKey;
 import java.security.PublicKey;
-import java.security.cert.CertPath;
 import java.security.cert.CertificateException;
 import java.security.cert.X509Certificate;
 import java.security.spec.InvalidKeySpecException;
@@ -188,7 +187,8 @@ public class DefaultCAServer implements CertificateServer {
   }
 
   @Override
-  public List<X509CertificateHolder> getCaCertBundle() throws CertificateException, IOException {
+  public List<X509CertificateHolder> getCaCertBundle()
+      throws CertificateException, IOException {
     CertificateCodec codec = new CertificateCodec(config, componentName);
     return codec.getCertList();
   }

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/security/x509/certificate/authority/DefaultCAServer.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/security/x509/certificate/authority/DefaultCAServer.java
@@ -52,7 +52,6 @@ import java.security.NoSuchProviderException;
 import java.security.PrivateKey;
 import java.security.PublicKey;
 import java.security.cert.CertPath;
-import java.security.cert.Certificate;
 import java.security.cert.CertificateException;
 import java.security.cert.X509Certificate;
 import java.security.spec.InvalidKeySpecException;
@@ -250,7 +249,6 @@ public class DefaultCAServer implements CertificateServer {
       xCertHolders.completeExceptionally(new SCMSecurityException("Failed to " +
           "verify the CSR."));
     }
-    List<Certificate> allCerts;
     try {
       switch (approverType) {
       case MANUAL:

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/security/x509/certificate/authority/DefaultCAServer.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/security/x509/certificate/authority/DefaultCAServer.java
@@ -489,9 +489,9 @@ public class DefaultCAServer implements CertificateServer {
       };
       break;
     case INITIALIZE:
-      if (type == CAType.SELF_SIGNED_CA) {
+      if (type == CAType.ROOT) {
         consumer = this::initRootCa;
-      } else if (type == CAType.INTERMEDIARY_CA) {
+      } else if (type == CAType.SUBORDINATE) {
         // For sub CA certificates are generated during bootstrap/init. If
         // both keys/certs are missing, init/bootstrap is missed to be
         // performed.

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/security/x509/certificate/authority/DefaultCAServer.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/security/x509/certificate/authority/DefaultCAServer.java
@@ -51,6 +51,7 @@ import java.security.NoSuchAlgorithmException;
 import java.security.NoSuchProviderException;
 import java.security.PrivateKey;
 import java.security.PublicKey;
+import java.security.cert.CertPath;
 import java.security.cert.CertificateException;
 import java.security.cert.X509Certificate;
 import java.security.spec.InvalidKeySpecException;
@@ -184,6 +185,12 @@ public class DefaultCAServer implements CertificateServer {
     } catch (CertificateException e) {
       throw new IOException(e);
     }
+  }
+
+  @Override
+  public List<X509CertificateHolder> getCaCertBundle() throws CertificateException, IOException {
+    CertificateCodec codec = new CertificateCodec(config, componentName);
+    return codec.getCertList();
   }
 
   /**

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/security/x509/certificate/client/CertificateClient.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/security/x509/certificate/client/CertificateClient.java
@@ -33,6 +33,7 @@ import java.nio.file.Path;
 import java.security.KeyPair;
 import java.security.PrivateKey;
 import java.security.PublicKey;
+import java.security.cert.CertPath;
 import java.security.cert.CertStore;
 import java.security.cert.X509Certificate;
 import java.util.List;
@@ -78,10 +79,15 @@ public interface CertificateClient extends Closeable {
    *
    * @return certificate or Null if there is no data.
    */
+  CertPath getCertPath();
+
   X509Certificate getCertificate();
+
+  CertPath getCACertPath();
 
   /**
    * Return the latest CA certificate known to the client.
+   *
    * @return latest ca certificate known to the client.
    */
   X509Certificate getCACertificate();
@@ -184,25 +190,21 @@ public interface CertificateClient extends Closeable {
    * Stores the Certificate  for this client. Don't use this api to add
    * trusted certificates of others.
    *
-   * @param pemEncodedCert        - pem encoded X509 Certificate
-   * @param force                 - override any existing file
+   * @param pemEncodedCert - pem encoded X509 Certificate
    * @throws CertificateException - on Error.
-   *
    */
-  void storeCertificate(String pemEncodedCert, boolean force)
+  void storeCertificate(String pemEncodedCert)
       throws CertificateException;
 
   /**
    * Stores the Certificate  for this client. Don't use this api to add
    * trusted certificates of others.
    *
-   * @param pemEncodedCert        - pem encoded X509 Certificate
-   * @param force                 - override any existing file
-   * @param caCert                - Is CA certificate.
+   * @param pemEncodedCert - pem encoded X509 Certificate
+   * @param caCert         - Is CA certificate.
    * @throws CertificateException - on Error.
-   *
    */
-  void storeCertificate(String pemEncodedCert, boolean force, boolean caCert)
+  void storeCertificate(String pemEncodedCert, boolean caCert)
       throws CertificateException;
 
   /**
@@ -272,11 +274,11 @@ public interface CertificateClient extends Closeable {
 
   /**
    * Store RootCA certificate.
+   *
    * @param pemEncodedCert
-   * @param force
    * @throws CertificateException
    */
-  void storeRootCACertificate(String pemEncodedCert, boolean force)
+  void storeRootCACertificate(String pemEncodedCert)
       throws CertificateException;
 
   /**
@@ -365,7 +367,14 @@ public interface CertificateClient extends Closeable {
 
   /**
    * Register a receiver that will be called after the certificate renewed.
+   *
    * @param receiver
    */
   void registerNotificationReceiver(CertificateNotification receiver);
+
+  enum CertType {
+    INTERMEDIATE,
+    CA,
+    ROOT_CA
+  }
 }

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/security/x509/certificate/client/CertificateClient.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/security/x509/certificate/client/CertificateClient.java
@@ -74,15 +74,27 @@ public interface CertificateClient extends Closeable {
       throws CertificateException;
 
   /**
-   * Returns the certificate  of the specified component if it exists on the
-   * local system.
+   * Returns the full certificate path of the specified component if it
+   * exists on the local system.
    *
    * @return certificate or Null if there is no data.
    */
   CertPath getCertPath();
 
+  /**
+   * Returns the certificate used by the specified component if it exists
+   * on the local system.
+   *
+   * @return the target certificate or null if there is no data.
+   */
   X509Certificate getCertificate();
 
+  /**
+   * Returns the full certificate path for the CA certificate known to the
+   * client.
+   *
+   * @return latest ca certificate path known to the client
+   */
   CertPath getCACertPath();
 
   /**
@@ -372,6 +384,9 @@ public interface CertificateClient extends Closeable {
    */
   void registerNotificationReceiver(CertificateNotification receiver);
 
+  /**
+   * Type for specifying the type of the certificate to be stored.
+   */
   enum CertType {
     INTERMEDIATE,
     CA,

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/security/x509/certificate/client/CertificateClient.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/security/x509/certificate/client/CertificateClient.java
@@ -387,9 +387,19 @@ public interface CertificateClient extends Closeable {
   /**
    * Type for specifying the type of the certificate to be stored.
    */
-  enum CertType {
-    INTERMEDIATE,
-    CA,
-    ROOT_CA
+  enum CAType {
+    NONE(""),
+    SUBORDINATE("CA-"),
+    ROOT("ROOTCA-");
+
+    private final String fileNamePrefix;
+
+    public final String getFileNamePrefix() {
+      return fileNamePrefix;
+    }
+
+    CAType(String fileNamePrefix) {
+      this.fileNamePrefix = fileNamePrefix;
+    }
   }
 }

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/security/x509/certificate/client/CertificateClient.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/security/x509/certificate/client/CertificateClient.java
@@ -213,10 +213,10 @@ public interface CertificateClient extends Closeable {
    * trusted certificates of others.
    *
    * @param pemEncodedCert - pem encoded X509 Certificate
-   * @param caCert         - Is CA certificate.
+   * @param caType         - Is CA certificate.
    * @throws CertificateException - on Error.
    */
-  void storeCertificate(String pemEncodedCert, boolean caCert)
+  void storeCertificate(String pemEncodedCert, CAType caType)
       throws CertificateException;
 
   /**

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/security/x509/certificate/client/CertificateClient.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/security/x509/certificate/client/CertificateClient.java
@@ -21,6 +21,7 @@ package org.apache.hadoop.hdds.security.x509.certificate.client;
 
 import org.apache.hadoop.hdds.security.OzoneSecurityException;
 import org.apache.hadoop.hdds.security.ssl.KeyStoresFactory;
+import org.apache.hadoop.hdds.security.x509.certificate.authority.CAType;
 import org.apache.hadoop.hdds.security.x509.certificate.utils.CertificateSignRequest;
 import org.apache.hadoop.hdds.security.x509.crl.CRLInfo;
 import org.apache.hadoop.hdds.security.x509.exception.CertificateException;
@@ -383,23 +384,4 @@ public interface CertificateClient extends Closeable {
    * @param receiver
    */
   void registerNotificationReceiver(CertificateNotification receiver);
-
-  /**
-   * Type for specifying the type of the certificate to be stored.
-   */
-  enum CAType {
-    NONE(""),
-    SUBORDINATE("CA-"),
-    ROOT("ROOTCA-");
-
-    private final String fileNamePrefix;
-
-    public final String getFileNamePrefix() {
-      return fileNamePrefix;
-    }
-
-    CAType(String fileNamePrefix) {
-      this.fileNamePrefix = fileNamePrefix;
-    }
-  }
 }

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/security/x509/certificate/client/DNCertificateClient.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/security/x509/certificate/client/DNCertificateClient.java
@@ -106,7 +106,7 @@ public class DNCertificateClient extends DefaultCertificateClient {
 
   @Override
   public String signAndStoreCertificate(PKCS10CertificationRequest csr,
-      Path certPath) throws CertificateException {
+      Path certificatePath) throws CertificateException {
     try {
       // TODO: For SCM CA we should fetch certificate from multiple SCMs.
       SCMSecurityProtocolProtos.SCMGetCertResponseProto response =
@@ -117,7 +117,7 @@ public class DNCertificateClient extends DefaultCertificateClient {
       if (response.hasX509CACertificate()) {
         String pemEncodedCert = response.getX509Certificate();
         CertificateCodec certCodec = new CertificateCodec(
-            getSecurityConfig(), certPath);
+            getSecurityConfig(), certificatePath);
         // Certs will be added to cert map after reloadAllCertificate called
         storeCertificate(pemEncodedCert, CertType.INTERMEDIATE, certCodec,
             false);

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/security/x509/certificate/client/DNCertificateClient.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/security/x509/certificate/client/DNCertificateClient.java
@@ -119,15 +119,17 @@ public class DNCertificateClient extends DefaultCertificateClient {
         CertificateCodec certCodec = new CertificateCodec(
             getSecurityConfig(), certificatePath);
         // Certs will be added to cert map after reloadAllCertificate called
-        storeCertificate(pemEncodedCert, CertType.INTERMEDIATE, certCodec,
+        storeCertificate(pemEncodedCert, CAType.NONE,
+            certCodec,
             false);
-        storeCertificate(response.getX509CACertificate(), CertType.CA,
+        storeCertificate(response.getX509CACertificate(),
+            CAType.SUBORDINATE,
             certCodec, false);
 
         // Store Root CA certificate.
         if (response.hasX509RootCACertificate()) {
           storeCertificate(response.getX509RootCACertificate(),
-              CertType.ROOT_CA, certCodec, false);
+              CAType.ROOT, certCodec, false);
         }
         // Return the default certificate ID
         String dnCertSerialId = getX509Certificate(pemEncodedCert).

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/security/x509/certificate/client/DNCertificateClient.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/security/x509/certificate/client/DNCertificateClient.java
@@ -119,14 +119,15 @@ public class DNCertificateClient extends DefaultCertificateClient {
         CertificateCodec certCodec = new CertificateCodec(
             getSecurityConfig(), certPath);
         // Certs will be added to cert map after reloadAllCertificate called
-        storeCertificate(pemEncodedCert, true, false, false, certCodec, false);
-        storeCertificate(response.getX509CACertificate(), true, true,
-            false, certCodec, false);
+        storeCertificate(pemEncodedCert, CertType.INTERMEDIATE, certCodec,
+            false);
+        storeCertificate(response.getX509CACertificate(), CertType.CA,
+            certCodec, false);
 
         // Store Root CA certificate.
         if (response.hasX509RootCACertificate()) {
-          storeCertificate(response.getX509RootCACertificate(), true, false,
-              true, certCodec, false);
+          storeCertificate(response.getX509RootCACertificate(),
+              CertType.ROOT_CA, certCodec, false);
         }
         // Return the default certificate ID
         String dnCertSerialId = getX509Certificate(pemEncodedCert).

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/security/x509/certificate/client/DNCertificateClient.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/security/x509/certificate/client/DNCertificateClient.java
@@ -22,6 +22,7 @@ package org.apache.hadoop.hdds.security.x509.certificate.client;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
 import org.apache.hadoop.hdds.protocol.proto.SCMSecurityProtocolProtos;
 import org.apache.hadoop.hdds.security.x509.SecurityConfig;
+import org.apache.hadoop.hdds.security.x509.certificate.authority.CAType;
 import org.apache.hadoop.hdds.security.x509.certificate.utils.CertificateCodec;
 import org.apache.hadoop.hdds.security.x509.certificate.utils.CertificateSignRequest;
 import org.apache.hadoop.hdds.security.x509.exception.CertificateException;

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/security/x509/certificate/client/DefaultCertificateClient.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/security/x509/certificate/client/DefaultCertificateClient.java
@@ -291,7 +291,7 @@ public abstract class DefaultCertificateClient implements CertificateClient {
       try {
         publicKey = keyCodec.readPublicKey();
       } catch (InvalidKeySpecException | NoSuchAlgorithmException
-               | IOException e) {
+          | IOException e) {
         getLogger().error("Error while getting public key.", e);
       }
     }

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/security/x509/certificate/client/DefaultCertificateClient.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/security/x509/certificate/client/DefaultCertificateClient.java
@@ -37,6 +37,7 @@ import java.security.PublicKey;
 import java.security.SecureRandom;
 import java.security.Signature;
 import java.security.SignatureException;
+import java.security.cert.CertPath;
 import java.security.cert.CertStore;
 import java.security.cert.X509Certificate;
 import java.security.spec.InvalidKeySpecException;
@@ -97,7 +98,6 @@ import static org.apache.hadoop.hdds.security.x509.exception.CertificateExceptio
 import static org.apache.hadoop.hdds.security.x509.exception.CertificateException.ErrorCode.ROLLBACK_ERROR;
 import static org.apache.hadoop.hdds.utils.HddsServerUtil.getScmSecurityClientWithMaxRetry;
 
-import org.bouncycastle.cert.X509CertificateHolder;
 import org.bouncycastle.pkcs.PKCS10CertificationRequest;
 import org.slf4j.Logger;
 
@@ -120,8 +120,8 @@ public abstract class DefaultCertificateClient implements CertificateClient {
   private final KeyCodec keyCodec;
   private PrivateKey privateKey;
   private PublicKey publicKey;
-  private X509Certificate x509Certificate;
-  private Map<String, X509Certificate> certificateMap;
+  private CertPath certPath;
+  private Map<String, CertPath> certificateMap;
   private String certSerialId;
   private String caCertId;
   private String rootCaCertId;
@@ -176,11 +176,11 @@ public abstract class DefaultCertificateClient implements CertificateClient {
    * */
   private synchronized void loadAllCertificates() {
     // See if certs directory exists in file system.
-    Path certPath = securityConfig.getCertificateLocation(component);
-    if (Files.exists(certPath) && Files.isDirectory(certPath)) {
+    Path certificatePath = securityConfig.getCertificateLocation(component);
+    if (Files.exists(certificatePath) && Files.isDirectory(certificatePath)) {
       getLogger().info("Loading certificate from location:{}.",
-          certPath);
-      File[] certFiles = certPath.toFile().listFiles();
+          certificatePath);
+      File[] certFiles = certificatePath.toFile().listFiles();
 
       if (certFiles != null) {
         CertificateCodec certificateCodec =
@@ -190,16 +190,15 @@ public abstract class DefaultCertificateClient implements CertificateClient {
         for (File file : certFiles) {
           if (file.isFile()) {
             try {
-              X509CertificateHolder x509CertificateHolder = certificateCodec
-                  .readCertificate(certPath, file.getName());
-              X509Certificate cert =
-                  CertificateCodec.getX509Certificate(x509CertificateHolder);
+              CertPath allCertificates =
+                  certificateCodec.getCertPath(file.getName());
+              X509Certificate cert = getTargetCertificate(allCertificates);
               if (cert != null && cert.getSerialNumber() != null) {
                 if (cert.getSerialNumber().toString().equals(certSerialId)) {
-                  x509Certificate = cert;
+                  this.certPath = allCertificates;
                 }
                 certificateMap.putIfAbsent(cert.getSerialNumber().toString(),
-                    cert);
+                    allCertificates);
                 if (file.getName().startsWith(CA_CERT_PREFIX)) {
                   String certFileName = FilenameUtils.getBaseName(
                       file.getName());
@@ -238,7 +237,7 @@ public abstract class DefaultCertificateClient implements CertificateClient {
           rootCaCertId = Long.toString(latestRootCaCertSerialId);
         }
 
-        if (x509Certificate != null) {
+        if (certPath != null) {
           if (executorService == null) {
             startCertificateMonitor();
           }
@@ -292,11 +291,20 @@ public abstract class DefaultCertificateClient implements CertificateClient {
       try {
         publicKey = keyCodec.readPublicKey();
       } catch (InvalidKeySpecException | NoSuchAlgorithmException
-          | IOException e) {
+               | IOException e) {
         getLogger().error("Error while getting public key.", e);
       }
     }
     return publicKey;
+  }
+
+  @Override
+  public X509Certificate getCertificate() {
+    CertPath currentCertPath = getCertPath();
+    if (currentCertPath == null || currentCertPath.getCertificates() == null) {
+      return null;
+    }
+    return (X509Certificate) currentCertPath.getCertificates().get(0);
   }
 
   /**
@@ -305,9 +313,9 @@ public abstract class DefaultCertificateClient implements CertificateClient {
    * @return certificate or Null if there is no data.
    */
   @Override
-  public synchronized X509Certificate getCertificate() {
-    if (x509Certificate != null) {
-      return x509Certificate;
+  public synchronized CertPath getCertPath() {
+    if (certPath != null) {
+      return certPath;
     }
 
     if (certSerialId == null) {
@@ -318,17 +326,27 @@ public abstract class DefaultCertificateClient implements CertificateClient {
     // Refresh the cache from file system.
     loadAllCertificates();
     if (certificateMap.containsKey(certSerialId)) {
-      x509Certificate = certificateMap.get(certSerialId);
+      certPath = certificateMap.get(certSerialId);
     }
-    return x509Certificate;
+    return certPath;
   }
 
   /**
    * Return the latest CA certificate known to the client.
+   *
    * @return latest ca certificate known to the client.
    */
   @Override
   public synchronized X509Certificate getCACertificate() {
+    CertPath caCertPath = getCACertPath();
+    if (caCertPath == null || caCertPath.getCertificates() == null) {
+      return null;
+    }
+    return (X509Certificate) caCertPath.getCertificates().get(0);
+  }
+
+  @Override
+  public synchronized CertPath getCACertPath() {
     if (caCertId != null) {
       return certificateMap.get(caCertId);
     }
@@ -338,16 +356,18 @@ public abstract class DefaultCertificateClient implements CertificateClient {
   /**
    * Returns the certificate  with the specified certificate serial id if it
    * exists else try to get it from SCM.
-   * @param  certId
    *
+   * @param certId
    * @return certificate or Null if there is no data.
    */
   @Override
   public synchronized X509Certificate getCertificate(String certId)
       throws CertificateException {
     // Check if it is in cache.
-    if (certificateMap.containsKey(certId)) {
-      return certificateMap.get(certId);
+    if (certificateMap.containsKey(certId) &&
+        certificateMap.get(certId).getCertificates() != null) {
+      return (X509Certificate) certificateMap.get(certId)
+          .getCertificates().get(0);
     }
     // Try to get it from SCM.
     return this.getCertificateFromScm(certId);
@@ -388,7 +408,7 @@ public abstract class DefaultCertificateClient implements CertificateClient {
         certId);
     try {
       String pemEncodedCert = getScmSecureClient().getCertificate(certId);
-      this.storeCertificate(pemEncodedCert, true);
+      this.storeCertificate(pemEncodedCert);
       return CertificateCodec.getX509Certificate(pemEncodedCert);
     } catch (Exception e) {
       getLogger().error("Error while getting Certificate with " +
@@ -601,38 +621,40 @@ public abstract class DefaultCertificateClient implements CertificateClient {
    * Stores the Certificate  for this client. Don't use this api to add trusted
    * certificates of others.
    *
-   * @param pemEncodedCert        - pem encoded X509 Certificate
-   * @param force                 - override any existing file
+   * @param pemEncodedCert - pem encoded X509 Certificate
    * @throws CertificateException - on Error.
-   *
    */
   @Override
-  public void storeCertificate(String pemEncodedCert, boolean force)
+  public void storeCertificate(String pemEncodedCert)
       throws CertificateException {
-    this.storeCertificate(pemEncodedCert, force, false);
+    this.storeCertificate(pemEncodedCert, false);
   }
 
   /**
    * Stores the Certificate  for this client. Don't use this api to add trusted
    * certificates of others.
    *
-   * @param pemEncodedCert        - pem encoded X509 Certificate
-   * @param force                 - override any existing file
-   * @param caCert                - Is CA certificate.
+   * @param pemEncodedCert - pem encoded X509 Certificate
+   * @param caCert         - Is CA certificate.
    * @throws CertificateException - on Error.
-   *
    */
   @Override
-  public void storeCertificate(String pemEncodedCert, boolean force,
+  public void storeCertificate(String pemEncodedCert,
       boolean caCert) throws CertificateException {
     CertificateCodec certificateCodec = new CertificateCodec(securityConfig,
         component);
-    storeCertificate(pemEncodedCert, force, caCert, false,
-        certificateCodec, true);
+    if (caCert) {
+      storeCertificate(pemEncodedCert, CertType.CA,
+          certificateCodec, true);
+    } else {
+      storeCertificate(pemEncodedCert, CertType.INTERMEDIATE,
+          certificateCodec, true);
+    }
+
   }
 
   public synchronized void storeCertificate(String pemEncodedCert,
-      boolean force, boolean isCaCert, boolean isRootCaCert,
+      CertType certType,
       CertificateCodec codec, boolean addToCertMap)
       throws CertificateException {
     try {
@@ -641,18 +663,19 @@ public abstract class DefaultCertificateClient implements CertificateClient {
       String certName = String.format(CERT_FILE_NAME_FORMAT,
           cert.getSerialNumber().toString());
 
-      if (isCaCert) {
+      if (certType == CertType.CA) {
         certName = CA_CERT_PREFIX + certName;
         caCertId = cert.getSerialNumber().toString();
-      } else if (isRootCaCert) {
+      } else if (certType == CertType.ROOT_CA) {
         certName = ROOT_CA_CERT_PREFIX + certName;
         rootCaCertId = cert.getSerialNumber().toString();
       }
 
       codec.writeCertificate(codec.getLocation(), certName,
-          pemEncodedCert, force);
+          pemEncodedCert);
+      CertPath certPath = codec.getCertPathFromPemEncodedString(pemEncodedCert);
       if (addToCertMap) {
-        certificateMap.putIfAbsent(cert.getSerialNumber().toString(), cert);
+        certificateMap.putIfAbsent(cert.getSerialNumber().toString(), certPath);
       }
     } catch (IOException | java.security.cert.CertificateException e) {
       throw new CertificateException("Error while storing certificate.", e,
@@ -800,9 +823,13 @@ public abstract class DefaultCertificateClient implements CertificateClient {
     return handleCase(init);
   }
 
+  private X509Certificate getTargetCertificate(CertPath certPath) {
+    return (X509Certificate) certPath.getCertificates().get(0);
+  }
+
   /**
    * Default handling of each {@link InitCase}.
-   * */
+   */
   protected InitResponse handleCase(InitCase init)
       throws CertificateException {
     switch (init) {
@@ -986,17 +1013,18 @@ public abstract class DefaultCertificateClient implements CertificateClient {
   @Override
   public synchronized X509Certificate getRootCACertificate() {
     if (rootCaCertId != null) {
-      return certificateMap.get(rootCaCertId);
+      return (X509Certificate) certificateMap.get(rootCaCertId)
+          .getCertificates().get(0);
     }
     return null;
   }
 
   @Override
-  public void storeRootCACertificate(String pemEncodedCert, boolean force)
+  public void storeRootCACertificate(String pemEncodedCert)
       throws CertificateException {
     CertificateCodec certificateCodec = new CertificateCodec(securityConfig,
         component);
-    storeCertificate(pemEncodedCert, force, false, true,
+    storeCertificate(pemEncodedCert, CertType.ROOT_CA,
         certificateCodec, true);
   }
 
@@ -1159,7 +1187,8 @@ public abstract class DefaultCertificateClient implements CertificateClient {
     if (!force) {
       synchronized (this) {
         Preconditions.checkArgument(
-            timeBeforeExpiryGracePeriod(x509Certificate).isZero());
+            timeBeforeExpiryGracePeriod(getTargetCertificate(certPath))
+                .isZero());
       }
     }
 
@@ -1339,7 +1368,7 @@ public abstract class DefaultCertificateClient implements CertificateClient {
     // reset current value
     privateKey = null;
     publicKey = null;
-    x509Certificate = null;
+    certPath = null;
     certSerialId = null;
     caCertId = null;
     rootCaCertId = null;
@@ -1393,7 +1422,7 @@ public abstract class DefaultCertificateClient implements CertificateClient {
     // Schedule task to refresh certificate before it expires
     Duration gracePeriod = securityConfig.getRenewalGracePeriod();
     long timeBeforeGracePeriod =
-        timeBeforeExpiryGracePeriod(x509Certificate).toMillis();
+        timeBeforeExpiryGracePeriod(getTargetCertificate(certPath)).toMillis();
     // At least three chances to renew the certificate before it expires
     long interval =
         Math.min(gracePeriod.toMillis() / 3, TimeUnit.DAYS.toMillis(1));

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/security/x509/certificate/client/DefaultCertificateClient.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/security/x509/certificate/client/DefaultCertificateClient.java
@@ -627,7 +627,7 @@ public abstract class DefaultCertificateClient implements CertificateClient {
   @Override
   public void storeCertificate(String pemEncodedCert)
       throws CertificateException {
-    this.storeCertificate(pemEncodedCert, false);
+    this.storeCertificate(pemEncodedCert, CAType.NONE);
   }
 
   /**
@@ -635,21 +635,16 @@ public abstract class DefaultCertificateClient implements CertificateClient {
    * certificates of others.
    *
    * @param pemEncodedCert - pem encoded X509 Certificate
-   * @param caCert         - Is CA certificate.
+   * @param caType         - Is CA certificate.
    * @throws CertificateException - on Error.
    */
   @Override
   public void storeCertificate(String pemEncodedCert,
-      boolean caCert) throws CertificateException {
+      CAType caType) throws CertificateException {
     CertificateCodec certificateCodec = new CertificateCodec(securityConfig,
         component);
-    if (caCert) {
-      storeCertificate(pemEncodedCert, CAType.SUBORDINATE,
-          certificateCodec, true);
-    } else {
-      storeCertificate(pemEncodedCert, CAType.NONE, certificateCodec, true);
-    }
-
+    storeCertificate(pemEncodedCert, caType,
+        certificateCodec, true);
   }
 
   public synchronized void storeCertificate(String pemEncodedCert,

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/security/x509/certificate/client/DefaultCertificateClient.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/security/x509/certificate/client/DefaultCertificateClient.java
@@ -673,9 +673,11 @@ public abstract class DefaultCertificateClient implements CertificateClient {
 
       codec.writeCertificate(codec.getLocation(), certName,
           pemEncodedCert);
-      CertPath certPath = codec.getCertPathFromPemEncodedString(pemEncodedCert);
+      CertPath certificatePath =
+          codec.getCertPathFromPemEncodedString(pemEncodedCert);
       if (addToCertMap) {
-        certificateMap.putIfAbsent(cert.getSerialNumber().toString(), certPath);
+        certificateMap.putIfAbsent(
+            cert.getSerialNumber().toString(), certificatePath);
       }
     } catch (IOException | java.security.cert.CertificateException e) {
       throw new CertificateException("Error while storing certificate.", e,
@@ -823,8 +825,8 @@ public abstract class DefaultCertificateClient implements CertificateClient {
     return handleCase(init);
   }
 
-  private X509Certificate getTargetCertificate(CertPath certPath) {
-    return (X509Certificate) certPath.getCertificates().get(0);
+  private X509Certificate getTargetCertificate(CertPath certificatePath) {
+    return (X509Certificate) certificatePath.getCertificates().get(0);
   }
 
   /**
@@ -1387,7 +1389,7 @@ public abstract class DefaultCertificateClient implements CertificateClient {
 
   @Override
   public abstract String signAndStoreCertificate(
-      PKCS10CertificationRequest request, Path certPath)
+      PKCS10CertificationRequest request, Path certificatePath)
       throws CertificateException;
 
   public String signAndStoreCertificate(PKCS10CertificationRequest request)

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/security/x509/certificate/client/DefaultCertificateClient.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/security/x509/certificate/client/DefaultCertificateClient.java
@@ -67,6 +67,7 @@ import org.apache.commons.io.FileUtils;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.protocolPB.SCMSecurityProtocolClientSideTranslatorPB;
 import org.apache.hadoop.hdds.security.ssl.KeyStoresFactory;
+import org.apache.hadoop.hdds.security.x509.certificate.authority.CAType;
 import org.apache.hadoop.hdds.security.x509.crl.CRLInfo;
 import org.apache.hadoop.hdds.security.x509.SecurityConfig;
 import org.apache.hadoop.hdds.security.x509.certificate.utils.CertificateCodec;

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/security/x509/certificate/client/DefaultCertificateClient.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/security/x509/certificate/client/DefaultCertificateClient.java
@@ -658,8 +658,11 @@ public abstract class DefaultCertificateClient implements CertificateClient {
       CertificateCodec codec, boolean addToCertMap)
       throws CertificateException {
     try {
+      CertPath certificatePath =
+          CertificateCodec.getCertPathFromPemEncodedString(pemEncodedCert);
       X509Certificate cert =
-          CertificateCodec.getX509Certificate(pemEncodedCert);
+          (X509Certificate) certificatePath.getCertificates().get(0);
+
       String certName = String.format(CERT_FILE_NAME_FORMAT,
           cert.getSerialNumber().toString());
 
@@ -671,10 +674,8 @@ public abstract class DefaultCertificateClient implements CertificateClient {
         rootCaCertId = cert.getSerialNumber().toString();
       }
 
-      codec.writeCertificate(codec.getLocation(), certName,
+      codec.writeCertificate(certName,
           pemEncodedCert);
-      CertPath certificatePath =
-          codec.getCertPathFromPemEncodedString(pemEncodedCert);
       if (addToCertMap) {
         certificateMap.putIfAbsent(
             cert.getSerialNumber().toString(), certificatePath);

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/security/x509/certificate/client/ReconCertificateClient.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/security/x509/certificate/client/ReconCertificateClient.java
@@ -20,6 +20,7 @@ package org.apache.hadoop.hdds.security.x509.certificate.client;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.hdds.protocol.proto.SCMSecurityProtocolProtos;
 import org.apache.hadoop.hdds.security.x509.SecurityConfig;
+import org.apache.hadoop.hdds.security.x509.certificate.authority.CAType;
 import org.apache.hadoop.hdds.security.x509.certificate.utils.CertificateCodec;
 import org.apache.hadoop.hdds.security.x509.certificate.utils.CertificateSignRequest;
 import org.apache.hadoop.hdds.security.x509.exception.CertificateException;

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/security/x509/certificate/client/ReconCertificateClient.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/security/x509/certificate/client/ReconCertificateClient.java
@@ -114,14 +114,15 @@ public class ReconCertificateClient  extends CommonCertificateClient {
         String pemEncodedCert = response.getX509Certificate();
         CertificateCodec certCodec = new CertificateCodec(
             getSecurityConfig(), certPath);
-        storeCertificate(pemEncodedCert, true, false, false, certCodec, false);
-        storeCertificate(response.getX509CACertificate(), true, true,
-            false, certCodec, false);
+        storeCertificate(pemEncodedCert, CertType.INTERMEDIATE, certCodec,
+            false);
+        storeCertificate(response.getX509CACertificate(), CertType.CA,
+            certCodec, false);
 
         // Store Root CA certificate.
         if (response.hasX509RootCACertificate()) {
           storeCertificate(response.getX509RootCACertificate(),
-              true, false, true, certCodec, false);
+              CertType.ROOT_CA, certCodec, false);
         }
         return getX509Certificate(pemEncodedCert).getSerialNumber().toString();
       } else {

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/security/x509/certificate/client/ReconCertificateClient.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/security/x509/certificate/client/ReconCertificateClient.java
@@ -114,15 +114,17 @@ public class ReconCertificateClient  extends CommonCertificateClient {
         String pemEncodedCert = response.getX509Certificate();
         CertificateCodec certCodec = new CertificateCodec(
             getSecurityConfig(), certificatePath);
-        storeCertificate(pemEncodedCert, CertType.INTERMEDIATE, certCodec,
+        storeCertificate(pemEncodedCert, CAType.NONE,
+            certCodec,
             false);
-        storeCertificate(response.getX509CACertificate(), CertType.CA,
+        storeCertificate(response.getX509CACertificate(),
+            CAType.SUBORDINATE,
             certCodec, false);
 
         // Store Root CA certificate.
         if (response.hasX509RootCACertificate()) {
           storeCertificate(response.getX509RootCACertificate(),
-              CertType.ROOT_CA, certCodec, false);
+              CAType.ROOT, certCodec, false);
         }
         return getX509Certificate(pemEncodedCert).getSerialNumber().toString();
       } else {

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/security/x509/certificate/client/ReconCertificateClient.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/security/x509/certificate/client/ReconCertificateClient.java
@@ -96,7 +96,7 @@ public class ReconCertificateClient  extends CommonCertificateClient {
 
   @Override
   public String signAndStoreCertificate(PKCS10CertificationRequest csr,
-      Path certPath) throws CertificateException {
+      Path certificatePath) throws CertificateException {
     try {
       SCMSecurityProtocolProtos.SCMGetCertResponseProto response;
       HddsProtos.NodeDetailsProto.Builder reconDetailsProtoBuilder =
@@ -113,7 +113,7 @@ public class ReconCertificateClient  extends CommonCertificateClient {
       if (response.hasX509CACertificate()) {
         String pemEncodedCert = response.getX509Certificate();
         CertificateCodec certCodec = new CertificateCodec(
-            getSecurityConfig(), certPath);
+            getSecurityConfig(), certificatePath);
         storeCertificate(pemEncodedCert, CertType.INTERMEDIATE, certCodec,
             false);
         storeCertificate(response.getX509CACertificate(), CertType.CA,

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/security/x509/certificate/client/SCMCertificateClient.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/security/x509/certificate/client/SCMCertificateClient.java
@@ -146,7 +146,7 @@ public class SCMCertificateClient extends DefaultCertificateClient {
 
   @Override
   public String signAndStoreCertificate(PKCS10CertificationRequest request,
-      Path certPath) throws CertificateException {
+      Path certificatePath) throws CertificateException {
     return null;
   }
 

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/security/x509/crl/CRLCodec.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/security/x509/crl/CRLCodec.java
@@ -21,8 +21,10 @@ package org.apache.hadoop.hdds.security.x509.crl;
 import org.apache.commons.io.IOUtils;
 import org.apache.hadoop.hdds.security.exception.SCMSecurityException;
 import org.apache.hadoop.hdds.security.x509.SecurityConfig;
+import org.apache.hadoop.hdds.security.x509.certificate.utils.CertificateCodec;
 import org.bouncycastle.cert.X509CRLHolder;
 import org.bouncycastle.cert.jcajce.JcaX509CRLConverter;
+import org.bouncycastle.jcajce.provider.asymmetric.x509.CertificateFactory;
 import org.bouncycastle.openssl.jcajce.JcaPEMWriter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -38,7 +40,6 @@ import java.nio.file.Paths;
 import java.nio.file.attribute.PosixFilePermission;
 import java.security.cert.CRLException;
 import java.security.cert.CertificateException;
-import java.security.cert.CertificateFactory;
 import java.security.cert.X509CRL;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -123,14 +124,13 @@ public class CRLCodec {
    * @param pemEncodedString - PEM encoded String.
    * @return X509CRL  - Crl.
    * @throws CRLException - Thrown on Failure.
-   * @throws CertificateException - Thrown on Failure.
-   * @throws IOException          - Thrown on Failure.
+   * @throws IOException  - Thrown on Failure.
    */
   public static X509CRL getX509CRL(String pemEncodedString)
-      throws CRLException, CertificateException, IOException {
-    CertificateFactory fact = CertificateFactory.getInstance("X.509");
+      throws CRLException, IOException {
+    CertificateFactory fact = CertificateCodec.getCertFactory();
     try (InputStream input = IOUtils.toInputStream(pemEncodedString, UTF_8)) {
-      return (X509CRL) fact.generateCRL(input);
+      return (X509CRL) fact.engineGenerateCRL(input);
     }
   }
 

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/security/x509/crl/CRLCodec.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/security/x509/crl/CRLCodec.java
@@ -39,7 +39,6 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.attribute.PosixFilePermission;
 import java.security.cert.CRLException;
-import java.security.cert.CertificateException;
 import java.security.cert.X509CRL;
 import java.util.Set;
 import java.util.stream.Collectors;

--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/security/x509/CertificateClientTest.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/security/x509/CertificateClientTest.java
@@ -34,6 +34,7 @@ import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.security.ssl.KeyStoresFactory;
 import org.apache.hadoop.hdds.security.x509.certificate.client.CertificateClient;
 import org.apache.hadoop.hdds.security.x509.certificate.client.CertificateNotification;
+import org.apache.hadoop.hdds.security.x509.certificate.utils.CertificateCodec;
 import org.apache.hadoop.hdds.security.x509.certificate.utils.CertificateSignRequest;
 import org.apache.hadoop.hdds.security.x509.crl.CRLInfo;
 import org.apache.hadoop.hdds.security.x509.exception.CertificateException;
@@ -80,7 +81,7 @@ public class CertificateClientTest implements CertificateClient {
   @Override
   public X509Certificate getCertificate(String certSerialId)
       throws CertificateException {
-    return (X509Certificate) certPath.getCertificates().get(0);
+    return CertificateCodec.firstCertificateFrom(certPath);
   }
 
   @Override
@@ -90,12 +91,12 @@ public class CertificateClientTest implements CertificateClient {
 
   @Override
   public X509Certificate getCertificate() {
-    return (X509Certificate) certPath.getCertificates().get(0);
+    return CertificateCodec.firstCertificateFrom(certPath);
   }
 
   @Override
   public X509Certificate getCACertificate() {
-    return (X509Certificate) certPath.getCertificates().get(0);
+    return CertificateCodec.firstCertificateFrom(certPath);
   }
 
   @Override
@@ -211,7 +212,7 @@ public class CertificateClientTest implements CertificateClient {
 
   @Override
   public X509Certificate getRootCACertificate() {
-    return (X509Certificate) certPath.getCertificates().get(0);
+    return CertificateCodec.firstCertificateFrom(certPath);
   }
 
   @Override

--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/security/x509/CertificateClientTest.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/security/x509/CertificateClientTest.java
@@ -169,7 +169,7 @@ public class CertificateClientTest implements CertificateClient {
   }
 
   @Override
-  public void storeCertificate(String cert, boolean caCert)
+  public void storeCertificate(String cert, CAType caType)
       throws CertificateException {
   }
 

--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/security/x509/CertificateClientTest.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/security/x509/CertificateClientTest.java
@@ -22,11 +22,14 @@ import java.nio.file.Path;
 import java.security.KeyPair;
 import java.security.PrivateKey;
 import java.security.PublicKey;
+import java.security.cert.CertPath;
 import java.security.cert.CertStore;
+import java.security.cert.CertificateFactory;
 import java.security.cert.X509Certificate;
 import java.util.Collections;
 import java.util.List;
 
+import com.google.common.collect.ImmutableList;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.security.ssl.KeyStoresFactory;
 import org.apache.hadoop.hdds.security.x509.certificate.client.CertificateClient;
@@ -45,15 +48,17 @@ import org.bouncycastle.pkcs.PKCS10CertificationRequest;
 
 public class CertificateClientTest implements CertificateClient {
   private KeyPair keyPair;
-  private X509Certificate x509Certificate;
+  private CertPath certPath;
   private SecurityConfig secConfig;
 
   public CertificateClientTest(OzoneConfiguration conf)
       throws Exception {
     secConfig = new SecurityConfig(conf);
     keyPair = KeyStoreTestUtil.generateKeyPair("RSA");
-    x509Certificate = KeyStoreTestUtil.generateCertificate("CN=OzoneMaster",
-        keyPair, 30, "SHA256withRSA");
+    CertificateFactory fact = CertificateFactory.getInstance("X.509");
+    X509Certificate singleCert = KeyStoreTestUtil
+        .generateCertificate("CN=OzoneMaster", keyPair, 30, "SHA256withRSA");
+    certPath = fact.generateCertPath(ImmutableList.of(singleCert));
   }
 
   @Override
@@ -75,17 +80,27 @@ public class CertificateClientTest implements CertificateClient {
   @Override
   public X509Certificate getCertificate(String certSerialId)
       throws CertificateException {
-    return x509Certificate;
+    return (X509Certificate) certPath.getCertificates().get(0);
+  }
+
+  @Override
+  public CertPath getCertPath() {
+    return certPath;
   }
 
   @Override
   public X509Certificate getCertificate() {
-    return x509Certificate;
+    return (X509Certificate) certPath.getCertificates().get(0);
   }
 
   @Override
   public X509Certificate getCACertificate() {
-    return x509Certificate;
+    return (X509Certificate) certPath.getCertificates().get(0);
+  }
+
+  @Override
+  public CertPath getCACertPath() {
+    return certPath;
   }
 
   @Override
@@ -149,12 +164,12 @@ public class CertificateClientTest implements CertificateClient {
   }
 
   @Override
-  public void storeCertificate(String cert, boolean force)
+  public void storeCertificate(String cert)
       throws CertificateException {
   }
 
   @Override
-  public void storeCertificate(String cert, boolean force, boolean caCert)
+  public void storeCertificate(String cert, boolean caCert)
       throws CertificateException {
   }
 
@@ -196,11 +211,11 @@ public class CertificateClientTest implements CertificateClient {
 
   @Override
   public X509Certificate getRootCACertificate() {
-    return x509Certificate;
+    return (X509Certificate) certPath.getCertificates().get(0);
   }
 
   @Override
-  public void storeRootCACertificate(String pemEncodedCert, boolean force) {
+  public void storeRootCACertificate(String pemEncodedCert) {
 
   }
 
@@ -264,7 +279,8 @@ public class CertificateClientTest implements CertificateClient {
         "CN=OzoneMaster", keyPair, 30, "SHA256withRSA");
 
     keyPair = newKeyPair;
-    x509Certificate = newCert;
+    CertificateFactory fact = CertificateFactory.getInstance("X.509");
+    certPath = fact.generateCertPath(ImmutableList.of(newCert));
   }
 
   @Override

--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/security/x509/CertificateClientTest.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/security/x509/CertificateClientTest.java
@@ -24,7 +24,6 @@ import java.security.PrivateKey;
 import java.security.PublicKey;
 import java.security.cert.CertPath;
 import java.security.cert.CertStore;
-import java.security.cert.CertificateFactory;
 import java.security.cert.X509Certificate;
 import java.util.Collections;
 import java.util.List;
@@ -40,6 +39,7 @@ import org.apache.hadoop.hdds.security.x509.crl.CRLInfo;
 import org.apache.hadoop.hdds.security.x509.exception.CertificateException;
 
 import org.apache.hadoop.security.ssl.KeyStoreTestUtil;
+import org.bouncycastle.jcajce.provider.asymmetric.x509.CertificateFactory;
 import org.bouncycastle.pkcs.PKCS10CertificationRequest;
 
 /**
@@ -56,10 +56,11 @@ public class CertificateClientTest implements CertificateClient {
       throws Exception {
     secConfig = new SecurityConfig(conf);
     keyPair = KeyStoreTestUtil.generateKeyPair("RSA");
-    CertificateFactory fact = CertificateFactory.getInstance("X.509");
+    org.bouncycastle.jcajce.provider.asymmetric.x509.CertificateFactory fact
+        = CertificateCodec.getCertFactory();
     X509Certificate singleCert = KeyStoreTestUtil
         .generateCertificate("CN=OzoneMaster", keyPair, 30, "SHA256withRSA");
-    certPath = fact.generateCertPath(ImmutableList.of(singleCert));
+    certPath = fact.engineGenerateCertPath(ImmutableList.of(singleCert));
   }
 
   @Override
@@ -280,8 +281,8 @@ public class CertificateClientTest implements CertificateClient {
         "CN=OzoneMaster", keyPair, 30, "SHA256withRSA");
 
     keyPair = newKeyPair;
-    CertificateFactory fact = CertificateFactory.getInstance("X.509");
-    certPath = fact.generateCertPath(ImmutableList.of(newCert));
+    CertificateFactory fact = CertificateCodec.getCertFactory();
+    certPath = fact.engineGenerateCertPath(ImmutableList.of(newCert));
   }
 
   @Override

--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/security/x509/CertificateClientTest.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/security/x509/CertificateClientTest.java
@@ -31,6 +31,7 @@ import java.util.List;
 import com.google.common.collect.ImmutableList;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.security.ssl.KeyStoresFactory;
+import org.apache.hadoop.hdds.security.x509.certificate.authority.CAType;
 import org.apache.hadoop.hdds.security.x509.certificate.client.CertificateClient;
 import org.apache.hadoop.hdds.security.x509.certificate.client.CertificateNotification;
 import org.apache.hadoop.hdds.security.x509.certificate.utils.CertificateCodec;

--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/security/x509/CertificateClientTest.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/security/x509/CertificateClientTest.java
@@ -148,7 +148,7 @@ public class CertificateClientTest implements CertificateClient {
 
   @Override
   public String signAndStoreCertificate(PKCS10CertificationRequest request,
-      Path certPath) throws CertificateException {
+      Path certificatePath) throws CertificateException {
     return null;
   }
 

--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/security/x509/CertificateClientTest.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/security/x509/CertificateClientTest.java
@@ -57,8 +57,7 @@ public class CertificateClientTest implements CertificateClient {
       throws Exception {
     secConfig = new SecurityConfig(conf);
     keyPair = KeyStoreTestUtil.generateKeyPair("RSA");
-    org.bouncycastle.jcajce.provider.asymmetric.x509.CertificateFactory fact
-        = CertificateCodec.getCertFactory();
+    CertificateFactory fact = CertificateCodec.getCertFactory();
     X509Certificate singleCert = KeyStoreTestUtil
         .generateCertificate("CN=OzoneMaster", keyPair, 30, "SHA256withRSA");
     certPath = fact.engineGenerateCertPath(ImmutableList.of(singleCert));

--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/security/x509/certificate/authority/TestDefaultCAServer.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/security/x509/certificate/authority/TestDefaultCAServer.java
@@ -251,7 +251,7 @@ public class TestDefaultCAServer {
         csrString, CertificateApprover.ApprovalType.TESTING_AUTOMATIC, OM);
     // Right now our calls are synchronous. Eventually this will have to wait.
     assertTrue(holder.isDone());
-    assertNotNull(holder.get().getCertificates().get(0));
+    assertNotNull(CertificateCodec.firstCertificateFrom(holder.get()));
   }
 
   @Test
@@ -285,7 +285,7 @@ public class TestDefaultCAServer {
         csrString, CertificateApprover.ApprovalType.TESTING_AUTOMATIC, OM);
 
     X509Certificate certificate =
-        (X509Certificate) holder.get().getCertificates().get(0);
+        CertificateCodec.firstCertificateFrom(holder.get());
     List<BigInteger> serialIDs = new ArrayList<>();
     serialIDs.add(certificate.getSerialNumber());
     Future<Optional<Long>> revoked = testCA.revokeCertificates(serialIDs,
@@ -497,8 +497,8 @@ public class TestDefaultCAServer {
     Future<CertPath> holder = rootCA.requestCertificate(csr,
         CertificateApprover.ApprovalType.TESTING_AUTOMATIC, SCM);
     assertTrue(holder.isDone());
-    X509Certificate certificate = (X509Certificate) holder.get()
-        .getCertificates().get(0);
+    X509Certificate certificate =
+        CertificateCodec.firstCertificateFrom(holder.get());
     X509CertificateHolder certificateHolder =
         CertificateCodec.getCertificateHolder(certificate);
 

--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/security/x509/certificate/authority/TestDefaultCAServer.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/security/x509/certificate/authority/TestDefaultCAServer.java
@@ -28,7 +28,6 @@ import org.apache.hadoop.hdds.security.exception.SCMSecurityException;
 import org.apache.hadoop.hdds.security.x509.SecurityConfig;
 import org.apache.hadoop.hdds.security.x509.certificate.authority.profile.DefaultCAProfile;
 import org.apache.hadoop.hdds.security.x509.certificate.authority.profile.DefaultProfile;
-import org.apache.hadoop.hdds.security.x509.certificate.client.CertificateClient;
 import org.apache.hadoop.hdds.security.x509.certificate.client.SCMCertificateClient;
 import org.apache.hadoop.hdds.security.x509.certificate.utils.CertificateCodec;
 import org.apache.hadoop.hdds.security.x509.certificate.utils.CertificateSignRequest;
@@ -75,6 +74,7 @@ import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.NodeType.OM;
 import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.NodeType.SCM;
 import static org.apache.hadoop.hdds.security.x509.certificate.authority.CertificateServer.CAType.INTERMEDIARY_CA;
 import static org.apache.hadoop.hdds.security.x509.certificate.authority.CertificateServer.CAType.SELF_SIGNED_CA;
+import static org.apache.hadoop.hdds.security.x509.certificate.client.CertificateClient.*;
 import static org.apache.hadoop.hdds.security.x509.exception.CertificateException.ErrorCode.CSR_ERROR;
 import static org.apache.hadoop.ozone.OzoneConsts.SCM_CA_CERT_STORAGE_DIR;
 import static org.apache.hadoop.ozone.OzoneConsts.SCM_CA_PATH;
@@ -479,8 +479,8 @@ public class TestDefaultCAServer {
     SCMCertificateClient scmCertificateClient =
         new SCMCertificateClient(new SecurityConfig(conf));
 
-    CertificateClient.InitResponse response = scmCertificateClient.init();
-    assertEquals(CertificateClient.InitResponse.GETCERT, response);
+    InitResponse response = scmCertificateClient.init();
+    assertEquals(InitResponse.GETCERT, response);
 
     // Generate cert
     KeyPair keyPair =
@@ -512,7 +512,8 @@ public class TestDefaultCAServer {
     X509CertificateHolder rootCertHolder = rootCA.getCACertificate();
 
     scmCertificateClient.storeCertificate(
-        CertificateCodec.getPEMEncodedString(rootCertHolder), true);
+        CertificateCodec.getPEMEncodedString(rootCertHolder),
+        CAType.SUBORDINATE);
 
     // Write to the location where Default CA Server reads from.
     scmCertificateClient.storeCertificate(

--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/security/x509/certificate/client/TestDefaultCertificateClient.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/security/x509/certificate/client/TestDefaultCertificateClient.java
@@ -175,7 +175,7 @@ public class TestDefaultCertificateClient {
     X509Certificate cert = dnCertClient.getCertificate();
     assertNull(cert);
     dnCertClient.storeCertificate(getPEMEncodedString(x509Certificate),
-        true);
+        CertificateClient.CAType.SUBORDINATE);
 
     cert = dnCertClient.getCertificate(
         x509Certificate.getSerialNumber().toString());
@@ -473,16 +473,18 @@ public class TestDefaultCertificateClient {
     Duration gracePeriod = dnSecurityConfig.getRenewalGracePeriod();
 
     X509Certificate cert = KeyStoreTestUtil.generateCertificate("CN=Test",
-        keyPair, (int)(gracePeriod.toDays()),
+        keyPair, (int) (gracePeriod.toDays()),
         dnSecurityConfig.getSignatureAlgo());
-    dnCertClient.storeCertificate(getPEMEncodedString(cert), true);
+    dnCertClient.storeCertificate(
+        getPEMEncodedString(cert), CertificateClient.CAType.SUBORDINATE);
     Duration duration = dnCertClient.timeBeforeExpiryGracePeriod(cert);
     Assert.assertTrue(duration.isZero());
 
     cert = KeyStoreTestUtil.generateCertificate("CN=Test",
-        keyPair, (int)(gracePeriod.toDays() + 1),
+        keyPair, (int) (gracePeriod.toDays() + 1),
         dnSecurityConfig.getSignatureAlgo());
-    dnCertClient.storeCertificate(getPEMEncodedString(cert), true);
+    dnCertClient.storeCertificate(
+        getPEMEncodedString(cert), CertificateClient.CAType.SUBORDINATE);
     duration = dnCertClient.timeBeforeExpiryGracePeriod(cert);
     Assert.assertTrue(duration.toMillis() < Duration.ofDays(1).toMillis() &&
         duration.toMillis() > Duration.ofHours(23).plusMinutes(59).toMillis());

--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/security/x509/certificate/client/TestDefaultCertificateClient.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/security/x509/certificate/client/TestDefaultCertificateClient.java
@@ -553,7 +553,7 @@ public class TestDefaultCertificateClient {
     certCodec = new CertificateCodec(dnSecurityConfig,
         newCertDir.toPath());
     dnCertClient.storeCertificate(getPEMEncodedString(cert),
-        CertificateClient.CertType.INTERMEDIATE,
+        CertificateClient.CAType.NONE,
         certCodec, false);
     // a success renew after auto cleanup new key and cert dir
     dnCertClient.renewAndStoreKeyAndCertificate(true);

--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/security/x509/certificate/client/TestDefaultCertificateClient.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/security/x509/certificate/client/TestDefaultCertificateClient.java
@@ -307,11 +307,11 @@ public class TestDefaultCertificateClient {
         () -> dnCertClient.getCertificate(cert3.getSerialNumber()
             .toString()));
     codec.writeCertificate(certPath, "1.crt",
-        getPEMEncodedString(cert1), true);
+        getPEMEncodedString(cert1));
     codec.writeCertificate(certPath, "2.crt",
-        getPEMEncodedString(cert2), true);
+        getPEMEncodedString(cert2));
     codec.writeCertificate(certPath, "3.crt",
-        getPEMEncodedString(cert3), true);
+        getPEMEncodedString(cert3));
 
     // Re instantiate DN client which will load certificates from filesystem.
     dnCertClient = new DNCertificateClient(dnSecurityConfig, null,
@@ -333,9 +333,9 @@ public class TestDefaultCertificateClient {
     X509Certificate cert2 = generateX509Cert(keyPair);
     X509Certificate cert3 = generateX509Cert(keyPair);
 
-    dnCertClient.storeCertificate(getPEMEncodedString(cert1), true);
-    dnCertClient.storeCertificate(getPEMEncodedString(cert2), true);
-    dnCertClient.storeCertificate(getPEMEncodedString(cert3), true);
+    dnCertClient.storeCertificate(getPEMEncodedString(cert1));
+    dnCertClient.storeCertificate(getPEMEncodedString(cert2));
+    dnCertClient.storeCertificate(getPEMEncodedString(cert3));
 
     assertNotNull(dnCertClient.getCertificate(cert1.getSerialNumber()
         .toString()));
@@ -506,6 +506,7 @@ public class TestDefaultCertificateClient {
             .newBuilder().setResponseCode(SCMSecurityProtocolProtos
                 .SCMGetCertResponseProto.ResponseCode.success)
             .setX509Certificate(pemCert)
+            .setX509Certificate(pemCert)
             .setX509CACertificate(pemCert)
             .build();
     when(scmClient.getDataNodeCertificateChain(anyObject(), anyString()))
@@ -551,7 +552,8 @@ public class TestDefaultCertificateClient {
         "CN=OzoneMaster", keyPair, 30, "SHA256withRSA");
     certCodec = new CertificateCodec(dnSecurityConfig,
         newCertDir.toPath());
-    dnCertClient.storeCertificate(getPEMEncodedString(cert), true, false, false,
+    dnCertClient.storeCertificate(getPEMEncodedString(cert),
+        CertificateClient.CertType.INTERMEDIATE,
         certCodec, false);
     // a success renew after auto cleanup new key and cert dir
     dnCertClient.renewAndStoreKeyAndCertificate(true);

--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/security/x509/certificate/client/TestDefaultCertificateClient.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/security/x509/certificate/client/TestDefaultCertificateClient.java
@@ -450,7 +450,7 @@ public class TestDefaultCertificateClient {
 
           @Override
           public String signAndStoreCertificate(
-              PKCS10CertificationRequest request, Path certPath)
+              PKCS10CertificationRequest request, Path certificatePath)
               throws CertificateException {
             return null;
           }

--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/security/x509/certificate/client/TestDefaultCertificateClient.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/security/x509/certificate/client/TestDefaultCertificateClient.java
@@ -22,6 +22,7 @@ import org.apache.hadoop.hdds.HddsConfigKeys;
 import org.apache.hadoop.hdds.protocol.MockDatanodeDetails;
 import org.apache.hadoop.hdds.protocol.proto.SCMSecurityProtocolProtos;
 import org.apache.hadoop.hdds.protocolPB.SCMSecurityProtocolClientSideTranslatorPB;
+import org.apache.hadoop.hdds.security.x509.certificate.authority.CAType;
 import org.apache.hadoop.hdds.security.x509.certificate.client.CertificateClient.InitResponse;
 import org.apache.hadoop.hdds.security.x509.certificate.utils.CertificateCodec;
 import org.apache.hadoop.hdds.security.x509.certificate.utils.CertificateSignRequest;
@@ -66,7 +67,6 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.apache.hadoop.fs.CommonConfigurationKeysPublic.IPC_CLIENT_CONNECT_MAX_RETRIES_KEY;
 import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_METADATA_DIR_NAME;
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_NAMES;
-import static org.apache.hadoop.hdds.security.x509.certificate.client.CertificateClient.CAType;
 import static org.apache.hadoop.hdds.security.x509.certificate.client.CertificateClient.InitResponse.FAILURE;
 import static org.apache.hadoop.hdds.security.x509.certificate.client.CertificateClient.InitResponse.REINIT;
 import static org.apache.hadoop.hdds.security.x509.certificate.utils.CertificateCodec.getPEMEncodedString;
@@ -508,7 +508,6 @@ public class TestDefaultCertificateClient {
         SCMSecurityProtocolProtos.SCMGetCertResponseProto
             .newBuilder().setResponseCode(SCMSecurityProtocolProtos
                 .SCMGetCertResponseProto.ResponseCode.success)
-            .setX509Certificate(pemCert)
             .setX509Certificate(pemCert)
             .setX509CACertificate(pemCert)
             .build();

--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/security/x509/certificate/client/TestDefaultCertificateClient.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/security/x509/certificate/client/TestDefaultCertificateClient.java
@@ -66,6 +66,7 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.apache.hadoop.fs.CommonConfigurationKeysPublic.IPC_CLIENT_CONNECT_MAX_RETRIES_KEY;
 import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_METADATA_DIR_NAME;
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_NAMES;
+import static org.apache.hadoop.hdds.security.x509.certificate.client.CertificateClient.CAType;
 import static org.apache.hadoop.hdds.security.x509.certificate.client.CertificateClient.InitResponse.FAILURE;
 import static org.apache.hadoop.hdds.security.x509.certificate.client.CertificateClient.InitResponse.REINIT;
 import static org.apache.hadoop.hdds.security.x509.certificate.utils.CertificateCodec.getPEMEncodedString;
@@ -175,7 +176,7 @@ public class TestDefaultCertificateClient {
     X509Certificate cert = dnCertClient.getCertificate();
     assertNull(cert);
     dnCertClient.storeCertificate(getPEMEncodedString(x509Certificate),
-        CertificateClient.CAType.SUBORDINATE);
+        CAType.SUBORDINATE);
 
     cert = dnCertClient.getCertificate(
         x509Certificate.getSerialNumber().toString());
@@ -476,7 +477,7 @@ public class TestDefaultCertificateClient {
         keyPair, (int) (gracePeriod.toDays()),
         dnSecurityConfig.getSignatureAlgo());
     dnCertClient.storeCertificate(
-        getPEMEncodedString(cert), CertificateClient.CAType.SUBORDINATE);
+        getPEMEncodedString(cert), CAType.SUBORDINATE);
     Duration duration = dnCertClient.timeBeforeExpiryGracePeriod(cert);
     Assert.assertTrue(duration.isZero());
 
@@ -484,7 +485,7 @@ public class TestDefaultCertificateClient {
         keyPair, (int) (gracePeriod.toDays() + 1),
         dnSecurityConfig.getSignatureAlgo());
     dnCertClient.storeCertificate(
-        getPEMEncodedString(cert), CertificateClient.CAType.SUBORDINATE);
+        getPEMEncodedString(cert), CAType.SUBORDINATE);
     duration = dnCertClient.timeBeforeExpiryGracePeriod(cert);
     Assert.assertTrue(duration.toMillis() < Duration.ofDays(1).toMillis() &&
         duration.toMillis() > Duration.ofHours(23).plusMinutes(59).toMillis());
@@ -555,7 +556,7 @@ public class TestDefaultCertificateClient {
     certCodec = new CertificateCodec(dnSecurityConfig,
         newCertDir.toPath());
     dnCertClient.storeCertificate(getPEMEncodedString(cert),
-        CertificateClient.CAType.NONE,
+        CAType.NONE,
         certCodec, false);
     // a success renew after auto cleanup new key and cert dir
     dnCertClient.renewAndStoreKeyAndCertificate(true);

--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/security/x509/certificate/utils/TestCRLCodec.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/security/x509/certificate/utils/TestCRLCodec.java
@@ -271,7 +271,7 @@ public class TestCRLCodec {
       assertTrue(basePath.mkdirs());
     }
     codec.writeCertificate(basePath.toPath(), TMP_CERT_FILE_NAME,
-                           pemString, false);
+        pemString);
   }
 
   private X509CertificateHolder readTempCert()

--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/security/x509/certificate/utils/TestCRLCodec.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/security/x509/certificate/utils/TestCRLCodec.java
@@ -41,7 +41,6 @@ import java.security.NoSuchProviderException;
 import java.security.PrivateKey;
 import java.security.cert.CRLException;
 import java.security.cert.CertificateException;
-import java.security.cert.CertificateFactory;
 import java.security.cert.X509CRL;
 import java.time.LocalDateTime;
 import java.util.Date;
@@ -57,6 +56,7 @@ import org.bouncycastle.cert.X509CRLEntryHolder;
 import org.bouncycastle.cert.X509CRLHolder;
 import org.bouncycastle.cert.X509CertificateHolder;
 import org.bouncycastle.cert.X509v2CRLBuilder;
+import org.bouncycastle.jcajce.provider.asymmetric.x509.CertificateFactory;
 import org.bouncycastle.operator.OperatorCreationException;
 import org.bouncycastle.operator.jcajce.JcaContentSignerBuilder;
 import org.junit.jupiter.api.BeforeEach;
@@ -159,8 +159,8 @@ public class TestCRLCodec {
 
     byte[] crlBytes = TMP_CRL_ENTRY.getBytes(UTF_8);
     try (InputStream inStream = new ByteArrayInputStream(crlBytes)) {
-      CertificateFactory cf = CertificateFactory.getInstance("X.509");
-      X509CRL crl = (X509CRL)cf.generateCRL(inStream);
+      CertificateFactory cf = CertificateCodec.getCertFactory();
+      X509CRL crl = (X509CRL) cf.engineGenerateCRL(inStream);
 
       CRLCodec crlCodec = new CRLCodec(securityConfig);
       crlCodec.writeCRL(crl);
@@ -168,7 +168,7 @@ public class TestCRLCodec {
       // verify file generated or not
       File crlFile =
           Paths.get(crlCodec.getLocation().toString(),
-                    this.securityConfig.getCrlName()).toFile();
+              this.securityConfig.getCrlName()).toFile();
 
       assertTrue(crlFile.exists());
     }

--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/security/x509/certificate/utils/TestCRLCodec.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/security/x509/certificate/utils/TestCRLCodec.java
@@ -281,7 +281,7 @@ public class TestCRLCodec {
         new CertificateCodec(securityConfig, COMPONENT);
 
     X509CertificateHolder x509CertHolder =
-        codec.readCertificate(basePath.toPath(), TMP_CERT_FILE_NAME);
+        codec.getTargetCertHolder(basePath.toPath(), TMP_CERT_FILE_NAME);
 
     assertNotNull(x509CertHolder);
 

--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/security/x509/certificate/utils/TestCertificateCodec.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/security/x509/certificate/utils/TestCertificateCodec.java
@@ -51,14 +51,15 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * Tests the Certificate codecs.
  */
 public class TestCertificateCodec {
-  private static final OzoneConfiguration CONF = new OzoneConfiguration();
+  private OzoneConfiguration conf;
   private static final String COMPONENT = "test";
   private SecurityConfig securityConfig;
 
   @BeforeEach
   public void init(@TempDir Path tempDir) {
-    CONF.set(OZONE_METADATA_DIRS, tempDir.toString());
-    securityConfig = new SecurityConfig(CONF);
+    conf = new OzoneConfiguration();
+    conf.set(OZONE_METADATA_DIRS, tempDir.toString());
+    securityConfig = new SecurityConfig(conf);
   }
 
   /**
@@ -259,7 +260,7 @@ public class TestCertificateCodec {
   private X509CertificateHolder generateTestCert()
       throws IOException, NoSuchProviderException, NoSuchAlgorithmException {
     HDDSKeyGenerator keyGenerator =
-        new HDDSKeyGenerator(CONF);
+        new HDDSKeyGenerator(conf);
     LocalDateTime startDate = LocalDateTime.now();
     LocalDateTime endDate = startDate.plusDays(1);
     return SelfSignedCertificate.newBuilder()

--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/security/x509/certificate/utils/TestCertificateCodec.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/security/x509/certificate/utils/TestCertificateCodec.java
@@ -51,14 +51,14 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * Tests the Certificate codecs.
  */
 public class TestCertificateCodec {
-  private static final OzoneConfiguration conf = new OzoneConfiguration();
+  private static final OzoneConfiguration CONF = new OzoneConfiguration();
   private static final String COMPONENT = "test";
   private SecurityConfig securityConfig;
 
   @BeforeEach
   public void init(@TempDir Path tempDir) {
-    conf.set(OZONE_METADATA_DIRS, tempDir.toString());
-    securityConfig = new SecurityConfig(conf);
+    CONF.set(OZONE_METADATA_DIRS, tempDir.toString());
+    securityConfig = new SecurityConfig(CONF);
   }
 
   /**
@@ -259,7 +259,7 @@ public class TestCertificateCodec {
   private X509CertificateHolder generateTestCert()
       throws IOException, NoSuchProviderException, NoSuchAlgorithmException {
     HDDSKeyGenerator keyGenerator =
-        new HDDSKeyGenerator(conf);
+        new HDDSKeyGenerator(CONF);
     LocalDateTime startDate = LocalDateTime.now();
     LocalDateTime endDate = startDate.plusDays(1);
     return SelfSignedCertificate.newBuilder()

--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/security/x509/certificate/utils/TestCertificateCodec.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/security/x509/certificate/utils/TestCertificateCodec.java
@@ -218,10 +218,10 @@ public class TestCertificateCodec {
         certificates.getCertificates().iterator();
     Certificate rereadPrependedCert = iterator.next();
     Certificate rereadFirstCert = iterator.next();
-    assertEquals(CertificateCodec.getCertificateHolder((X509Certificate) rereadPrependedCert),
-        firstCert);
-    assertEquals(CertificateCodec.getCertificateHolder((X509Certificate) rereadFirstCert),
-        secondCert);
+    assertEquals(CertificateCodec.getCertificateHolder(
+        (X509Certificate) rereadPrependedCert), firstCert);
+    assertEquals(CertificateCodec.getCertificateHolder(
+        (X509Certificate) rereadFirstCert), secondCert);
   }
 
   private X509CertificateHolder generateTestCert(HDDSKeyGenerator keyGenerator,

--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/security/x509/certificate/utils/TestRootCertificate.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/security/x509/certificate/utils/TestRootCertificate.java
@@ -188,7 +188,7 @@ public class TestRootCertificate {
     String pemString = codec.getPEMEncodedString(certificateHolder);
 
     codec.writeCertificate(basePath, "pemcertificate.crt",
-        pemString, false);
+        pemString);
 
     X509CertificateHolder loadedCert =
         codec.readCertificate(basePath, "pemcertificate.crt");

--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/security/x509/certificate/utils/TestRootCertificate.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/security/x509/certificate/utils/TestRootCertificate.java
@@ -185,13 +185,13 @@ public class TestRootCertificate {
         certificateHolder.getSerialNumber());
 
     CertificateCodec codec = new CertificateCodec(securityConfig, "scm");
-    String pemString = codec.getPEMEncodedString(certificateHolder);
+    String pemString = CertificateCodec.getPEMEncodedString(certificateHolder);
 
     codec.writeCertificate(basePath, "pemcertificate.crt",
         pemString);
 
     X509CertificateHolder loadedCert =
-        codec.readCertificate(basePath, "pemcertificate.crt");
+        codec.getTargetCertHolder(basePath, "pemcertificate.crt");
     Assertions.assertNotNull(loadedCert);
     Assertions.assertEquals(certificateHolder.getSerialNumber(),
         loadedCert.getSerialNumber());

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/HASecurityUtils.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/HASecurityUtils.java
@@ -23,6 +23,7 @@ import org.apache.hadoop.hdds.protocolPB.SCMSecurityProtocolClientSideTranslator
 import org.apache.hadoop.hdds.ratis.RatisHelper;
 import org.apache.hadoop.hdds.scm.server.SCMStorageConfig;
 import org.apache.hadoop.hdds.security.x509.SecurityConfig;
+import org.apache.hadoop.hdds.security.x509.certificate.authority.CAType;
 import org.apache.hadoop.hdds.security.x509.certificate.authority.CertificateServer;
 import org.apache.hadoop.hdds.security.x509.certificate.authority.CertificateStore;
 import org.apache.hadoop.hdds.security.x509.certificate.authority.DefaultCAServer;
@@ -61,7 +62,6 @@ import java.util.concurrent.TimeUnit;
 
 import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.NodeType.SCM;
 import static org.apache.hadoop.hdds.security.x509.certificate.authority.CertificateApprover.ApprovalType.KERBEROS_TRUSTED;
-import static org.apache.hadoop.hdds.security.x509.certificate.client.CertificateClient.*;
 import static org.apache.hadoop.hdds.security.x509.certificate.utils.CertificateSignRequest.getEncodedString;
 import static org.apache.hadoop.ozone.OzoneConsts.SCM_ROOT_CA_COMPONENT_NAME;
 import static org.apache.hadoop.ozone.OzoneConsts.SCM_ROOT_CA_PREFIX;
@@ -212,7 +212,7 @@ public final class HASecurityUtils {
       //note: this does exactly the same as store certificate
       persistSubCACertificate(config, client, pemEncodedCert);
       X509Certificate cert =
-          CertificateCodec.firstCertificateFrom(subSCMCertHolderList);
+          (X509Certificate) subSCMCertHolderList.getCertificates().get(0);
       X509CertificateHolder subSCMCertHolder =
           CertificateCodec.getCertificateHolder(cert);
 
@@ -249,8 +249,7 @@ public final class HASecurityUtils {
         scmStorageConfig.getScmId(), scmCertStore, pkiProfile,
         SCM_ROOT_CA_COMPONENT_NAME);
 
-    rootCAServer.init(new SecurityConfig(config),
-        CertificateServer.CAType.SELF_SIGNED_CA);
+    rootCAServer.init(new SecurityConfig(config), CAType.ROOT);
 
     return rootCAServer;
   }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/HASecurityUtils.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/HASecurityUtils.java
@@ -212,7 +212,7 @@ public final class HASecurityUtils {
       //note: this does exactly the same as store certificate
       persistSubCACertificate(config, client, pemEncodedCert);
       X509Certificate cert =
-          (X509Certificate) subSCMCertHolderList.getCertificates().get(0);
+          CertificateCodec.firstCertificateFrom(subSCMCertHolderList);
       X509CertificateHolder subSCMCertHolder =
           CertificateCodec.getCertificateHolder(cert);
 

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/HASecurityUtils.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/HASecurityUtils.java
@@ -61,6 +61,7 @@ import java.util.concurrent.TimeUnit;
 
 import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.NodeType.SCM;
 import static org.apache.hadoop.hdds.security.x509.certificate.authority.CertificateApprover.ApprovalType.KERBEROS_TRUSTED;
+import static org.apache.hadoop.hdds.security.x509.certificate.client.CertificateClient.*;
 import static org.apache.hadoop.hdds.security.x509.certificate.utils.CertificateSignRequest.getEncodedString;
 import static org.apache.hadoop.ozone.OzoneConsts.SCM_ROOT_CA_COMPONENT_NAME;
 import static org.apache.hadoop.ozone.OzoneConsts.SCM_ROOT_CA_PREFIX;
@@ -154,7 +155,8 @@ public final class HASecurityUtils {
       // Store SCM sub CA and root CA certificate.
       if (response.hasX509CACertificate()) {
         String pemEncodedRootCert = response.getX509CACertificate();
-        client.storeCertificate(pemEncodedRootCert, true);
+        client.storeCertificate(
+            pemEncodedRootCert, CAType.SUBORDINATE);
         client.storeCertificate(pemEncodedCert);
         //note: this does exactly the same as store certificate
         persistSubCACertificate(config, client,
@@ -200,11 +202,12 @@ public final class HASecurityUtils {
 
       String pemEncodedCert =
           CertificateCodec.getPEMEncodedString(subSCMCertHolderList);
-      
+
       String pemEncodedRootCert =
           CertificateCodec.getPEMEncodedString(rootCACertificatePath);
 
-      client.storeCertificate(pemEncodedRootCert, true);
+      client.storeCertificate(
+          pemEncodedRootCert, CAType.SUBORDINATE);
       client.storeCertificate(pemEncodedCert);
       //note: this does exactly the same as store certificate
       persistSubCACertificate(config, client, pemEncodedCert);

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/HASecurityUtils.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/HASecurityUtils.java
@@ -195,8 +195,8 @@ public final class HASecurityUtils {
       List<X509CertificateHolder> subSCMCertHolderList = rootCAServer.
           requestCertificate(csr, KERBEROS_TRUSTED, SCM).get();
 
-      X509CertificateHolder rootCACertificateHolder =
-          rootCAServer.getCACertificate();
+      List<X509CertificateHolder> rootCACertificateHolder =
+          rootCAServer.getCaCertBundle();
 
       String pemEncodedCert =
           CertificateCodec.getPEMEncodedString(subSCMCertHolderList);

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMSecurityProtocolServer.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMSecurityProtocolServer.java
@@ -22,6 +22,7 @@ import com.google.protobuf.BlockingService;
 import java.io.IOException;
 import java.math.BigInteger;
 import java.net.InetSocketAddress;
+import java.security.cert.CertPath;
 import java.security.cert.CertificateException;
 import java.security.cert.X509Certificate;
 import java.util.ArrayList;
@@ -64,7 +65,6 @@ import org.apache.hadoop.security.KerberosInfo;
 
 import org.apache.hadoop.security.UserGroupInformation;
 import org.bouncycastle.asn1.x509.CRLReason;
-import org.bouncycastle.cert.X509CertificateHolder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -224,7 +224,7 @@ public class SCMSecurityProtocolServer implements SCMSecurityProtocol {
    */
   private String getEncodedCertToString(String certSignReq, NodeType nodeType)
       throws IOException {
-    Future<List<X509CertificateHolder>> future;
+    Future<CertPath> future;
     if (nodeType == NodeType.SCM) {
       future = rootCertificateServer.requestCertificate(certSignReq,
               KERBEROS_TRUSTED, nodeType);
@@ -301,7 +301,7 @@ public class SCMSecurityProtocolServer implements SCMSecurityProtocol {
     LOGGER.debug("Getting CA certificate.");
     try {
       return CertificateCodec.getPEMEncodedString(
-          scmCertificateServer.getCaCertBundle());
+          scmCertificateServer.getCaCertPath());
     } catch (CertificateException e) {
       throw new SCMSecurityException("getRootCertificate operation failed. ",
           e, GET_CA_CERT_FAILED);

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMSecurityProtocolServer.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMSecurityProtocolServer.java
@@ -224,8 +224,7 @@ public class SCMSecurityProtocolServer implements SCMSecurityProtocol {
    */
   private String getEncodedCertToString(String certSignReq, NodeType nodeType)
       throws IOException {
-
-    Future<X509CertificateHolder> future;
+    Future<List<X509CertificateHolder>> future;
     if (nodeType == NodeType.SCM) {
       future = rootCertificateServer.requestCertificate(certSignReq,
               KERBEROS_TRUSTED, nodeType);

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMSecurityProtocolServer.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMSecurityProtocolServer.java
@@ -301,7 +301,7 @@ public class SCMSecurityProtocolServer implements SCMSecurityProtocol {
     LOGGER.debug("Getting CA certificate.");
     try {
       return CertificateCodec.getPEMEncodedString(
-          scmCertificateServer.getCACertificate());
+          scmCertificateServer.getCaCertBundle());
     } catch (CertificateException e) {
       throw new SCMSecurityException("getRootCertificate operation failed. ",
           e, GET_CA_CERT_FAILED);

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/StorageContainerManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/StorageContainerManager.java
@@ -72,6 +72,7 @@ import org.apache.hadoop.hdds.scm.server.upgrade.ScmHAUnfinalizedStateValidation
 import org.apache.hadoop.hdds.scm.pipeline.WritableContainerFactory;
 import org.apache.hadoop.hdds.security.token.ContainerTokenGenerator;
 import org.apache.hadoop.hdds.security.token.ContainerTokenSecretManager;
+import org.apache.hadoop.hdds.security.x509.certificate.authority.CAType;
 import org.apache.hadoop.hdds.security.x509.certificate.authority.CertificateStore;
 import org.apache.hadoop.hdds.security.x509.certificate.authority.profile.DefaultCAProfile;
 import org.apache.hadoop.hdds.security.x509.certificate.authority.profile.DefaultProfile;
@@ -817,7 +818,7 @@ public final class StorageContainerManager extends ServiceRuntimeInfoImpl
           scmCertificateClient.getComponentName());
       // INTERMEDIARY_CA which issues certs to DN and OM.
       scmCertificateServer.init(new SecurityConfig(configuration),
-          CertificateServer.CAType.INTERMEDIARY_CA);
+          CAType.SUBORDINATE);
     }
 
     // If primary SCM node Id is set it means this is a cluster which has

--- a/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/cert/InfoSubcommand.java
+++ b/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/cert/InfoSubcommand.java
@@ -63,7 +63,7 @@ class InfoSubcommand extends ScmCertSubcommand {
     // Print container report info.
     LOG.info("Certificate id: {}", serialId);
     try {
-      X509Certificate cert = CertificateCodec.getX509Cert(certPemStr);
+      X509Certificate cert = CertificateCodec.getX509Certificate(certPemStr);
       LOG.info(cert.toString());
     } catch (CertificateException ex) {
       LOG.error("Failed to get certificate id " + serialId);

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/TestSecureOzoneCluster.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/TestSecureOzoneCluster.java
@@ -1263,9 +1263,7 @@ public final class TestSecureOzoneCluster {
     assertTrue(cert.getIssuerDN().toString().contains(clusterId));
 
     // Verify that certificate matches the public key.
-    String encodedKey1 = cert.getPublicKey().toString();
-    String encodedKey2 = om.getCertificateClient().getPublicKey().toString();
-    assertEquals(encodedKey1, encodedKey2);
+    assertEquals(cert.getPublicKey(), om.getCertificateClient().getPublicKey());
   }
 
   private void initializeOmStorage(OMStorage omStorage) throws IOException {

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/TestSecureOzoneCluster.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/TestSecureOzoneCluster.java
@@ -848,7 +848,8 @@ public final class TestSecureOzoneCluster {
       validateCertificate(certificate);
       String pemEncodedCACert =
           scm.getSecurityProtocolServer().getCACertificate();
-      X509Certificate caCert = CertificateCodec.getX509Cert(pemEncodedCACert);
+      X509Certificate caCert =
+          CertificateCodec.getX509Certificate(pemEncodedCACert);
       X509Certificate caCertStored = om.getCertificateClient()
           .getCertificate(caCert.getSerialNumber().toString());
       assertEquals(caCert, caCertStored);

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/CertificateClientTestImpl.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/CertificateClientTestImpl.java
@@ -27,6 +27,7 @@ import java.security.PrivateKey;
 import java.security.PublicKey;
 import java.security.Signature;
 import java.security.SignatureException;
+import java.security.cert.CertPath;
 import java.security.cert.CertStore;
 import java.security.cert.X509Certificate;
 import java.time.Duration;
@@ -196,8 +197,18 @@ public class CertificateClientTestImpl implements CertificateClient {
   }
 
   @Override
+  public CertPath getCertPath() {
+    return null;
+  }
+
+  @Override
   public X509Certificate getCertificate() {
     return x509Certificate;
+  }
+
+  @Override
+  public CertPath getCACertPath() {
+    return null;
   }
 
   @Override
@@ -277,12 +288,12 @@ public class CertificateClientTestImpl implements CertificateClient {
   }
 
   @Override
-  public void storeCertificate(String cert, boolean force)
+  public void storeCertificate(String cert)
       throws CertificateException {
   }
 
   @Override
-  public void storeCertificate(String cert, boolean force, boolean caCert)
+  public void storeCertificate(String cert, boolean caCert)
       throws CertificateException {
   }
 
@@ -329,7 +340,7 @@ public class CertificateClientTestImpl implements CertificateClient {
   }
 
   @Override
-  public void storeRootCACertificate(String pemEncodedCert, boolean force) {
+  public void storeRootCACertificate(String pemEncodedCert) {
 
   }
 

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/CertificateClientTestImpl.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/CertificateClientTestImpl.java
@@ -48,6 +48,7 @@ import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.security.ssl.KeyStoresFactory;
 import org.apache.hadoop.hdds.security.x509.SecurityConfig;
+import org.apache.hadoop.hdds.security.x509.certificate.authority.CAType;
 import org.apache.hadoop.hdds.security.x509.certificate.authority.DefaultApprover;
 import org.apache.hadoop.hdds.security.x509.certificate.authority.profile.DefaultProfile;
 import org.apache.hadoop.hdds.security.x509.certificate.client.CertificateClient;

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/CertificateClientTestImpl.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/CertificateClientTestImpl.java
@@ -293,7 +293,7 @@ public class CertificateClientTestImpl implements CertificateClient {
   }
 
   @Override
-  public void storeCertificate(String cert, boolean caCert)
+  public void storeCertificate(String cert, CAType caType)
       throws CertificateException {
   }
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/security/OMCertificateClient.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/security/OMCertificateClient.java
@@ -42,8 +42,6 @@ import java.security.KeyPair;
 import java.util.function.Consumer;
 
 import static org.apache.hadoop.hdds.security.x509.certificate.utils.CertificateSignRequest.getEncodedString;
-import static org.apache.hadoop.hdds.security.x509.certificate.client.CertificateClient.CertType.CA;
-import static org.apache.hadoop.hdds.security.x509.certificate.client.CertificateClient.CertType.INTERMEDIATE;
 
 /**
  * Certificate client for OzoneManager.
@@ -177,13 +175,14 @@ public class OMCertificateClient extends CommonCertificateClient {
       if (response.hasX509CACertificate()) {
         String pemEncodedRootCert = response.getX509CACertificate();
         storeCertificate(pemEncodedRootCert,
-            CA, certCodec, false);
-        storeCertificate(pemEncodedCert, INTERMEDIATE, certCodec, false);
+            CAType.SUBORDINATE, certCodec, false);
+        storeCertificate(pemEncodedCert, CAType.NONE, certCodec,
+            false);
 
         // Store Root CA certificate if available.
         if (response.hasX509RootCACertificate()) {
           storeCertificate(response.getX509RootCACertificate(),
-              CertType.ROOT_CA, certCodec, false);
+              CAType.ROOT, certCodec, false);
         }
         return CertificateCodec.getX509Certificate(pemEncodedCert)
             .getSerialNumber().toString();

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/security/OMCertificateClient.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/security/OMCertificateClient.java
@@ -164,14 +164,14 @@ public class OMCertificateClient extends CommonCertificateClient {
 
   @Override
   public String signAndStoreCertificate(PKCS10CertificationRequest request,
-      Path certPath) throws CertificateException {
+      Path certificatePath) throws CertificateException {
     try {
       SCMGetCertResponseProto response = getScmSecureClient()
           .getOMCertChain(omInfo, getEncodedString(request));
 
       String pemEncodedCert = response.getX509Certificate();
       CertificateCodec certCodec = new CertificateCodec(
-          getSecurityConfig(), certPath);
+          getSecurityConfig(), certificatePath);
 
       // Store SCM CA certificate.
       if (response.hasX509CACertificate()) {

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/security/OMCertificateClient.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/security/OMCertificateClient.java
@@ -24,6 +24,7 @@ import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.hdds.protocol.proto.SCMSecurityProtocolProtos.SCMGetCertResponseProto;
 import org.apache.hadoop.hdds.security.x509.SecurityConfig;
+import org.apache.hadoop.hdds.security.x509.certificate.authority.CAType;
 import org.apache.hadoop.hdds.security.x509.certificate.client.CommonCertificateClient;
 import org.apache.hadoop.hdds.security.x509.certificate.utils.CertificateCodec;
 import org.apache.hadoop.hdds.security.x509.certificate.utils.CertificateSignRequest;

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/security/OMCertificateClient.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/security/OMCertificateClient.java
@@ -42,6 +42,8 @@ import java.security.KeyPair;
 import java.util.function.Consumer;
 
 import static org.apache.hadoop.hdds.security.x509.certificate.utils.CertificateSignRequest.getEncodedString;
+import static org.apache.hadoop.hdds.security.x509.certificate.client.CertificateClient.CertType.CA;
+import static org.apache.hadoop.hdds.security.x509.certificate.client.CertificateClient.CertType.INTERMEDIATE;
 
 /**
  * Certificate client for OzoneManager.
@@ -175,13 +177,13 @@ public class OMCertificateClient extends CommonCertificateClient {
       if (response.hasX509CACertificate()) {
         String pemEncodedRootCert = response.getX509CACertificate();
         storeCertificate(pemEncodedRootCert,
-            true, true, false, certCodec, false);
-        storeCertificate(pemEncodedCert, true, false, false, certCodec, false);
+            CA, certCodec, false);
+        storeCertificate(pemEncodedCert, INTERMEDIATE, certCodec, false);
 
         // Store Root CA certificate if available.
         if (response.hasX509RootCACertificate()) {
           storeCertificate(response.getX509RootCACertificate(),
-              true, false, true, certCodec, false);
+              CertType.ROOT_CA, certCodec, false);
         }
         return CertificateCodec.getX509Certificate(pemEncodedCert)
             .getSerialNumber().toString();

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/security/TestOzoneDelegationTokenSecretManager.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/security/TestOzoneDelegationTokenSecretManager.java
@@ -25,7 +25,6 @@ import java.security.PrivateKey;
 import java.security.PublicKey;
 import java.security.Signature;
 import java.security.cert.CertPath;
-import java.security.cert.CertificateFactory;
 import java.security.cert.X509Certificate;
 import java.util.HashMap;
 import java.util.Map;
@@ -55,6 +54,8 @@ import org.apache.hadoop.util.Time;
 
 import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_RATIS_ENABLE_KEY;
 import static org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMTokenProto.Type.S3AUTHINFO;
+
+import org.bouncycastle.jcajce.provider.asymmetric.x509.CertificateFactory;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -139,10 +140,11 @@ public class TestOzoneDelegationTokenSecretManager {
    * */
   private CertificateClient setupCertificateClient() throws Exception {
     KeyPair keyPair = KeyStoreTestUtil.generateKeyPair("RSA");
-    CertificateFactory fact = CertificateFactory.getInstance("X.509");
+    CertificateFactory fact = CertificateCodec.getCertFactory();
     X509Certificate singleCert = KeyStoreTestUtil
         .generateCertificate("CN=OzoneMaster", keyPair, 30, "SHA256withRSA");
-    CertPath certPath = fact.generateCertPath(ImmutableList.of(singleCert));
+    CertPath certPath = fact.engineGenerateCertPath(
+        ImmutableList.of(singleCert));
 
     return new OMCertificateClient(securityConfig) {
       @Override

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/security/TestOzoneDelegationTokenSecretManager.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/security/TestOzoneDelegationTokenSecretManager.java
@@ -34,6 +34,7 @@ import com.google.common.collect.ImmutableList;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.security.x509.SecurityConfig;
 import org.apache.hadoop.hdds.security.x509.certificate.client.CertificateClient;
+import org.apache.hadoop.hdds.security.x509.certificate.utils.CertificateCodec;
 import org.apache.hadoop.hdds.server.ServerUtils;
 import org.apache.hadoop.io.Text;
 import org.apache.hadoop.ozone.OzoneConsts;
@@ -161,7 +162,7 @@ public class TestOzoneDelegationTokenSecretManager {
 
       @Override
       public X509Certificate getCertificate(String serialId) {
-        return (X509Certificate) certPath.getCertificates().get(0);
+        return CertificateCodec.firstCertificateFrom(certPath);
       }
     };
   }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Instead of using the sole certificate the whole cert bundle is used now.

In this new version, certificates are stored along with their entire certificate path up to the root CA. When getting these certificates, the whole chain is read back instead. In protocol messages the chain is converted into a String, so in reality `SCMGetCertResponseProto.x509Certificate` is now a pem encoded full certification chain.

Some minor refactors in CertificateCodec and removing some dead code is also included.

## What is the link to the Apache JIRA

[HDDS-7379](https://issues.apache.org/jira/browse/HDDS-7379)

## How was this patch tested?

Some local tests were added as well as a sanity check of running a local cluster with security enabled and inserting a key.
