### PR TITLE
HDDS-7769. Implement client initiated lease recovery

### DIFF
--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/OmUtils.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/OmUtils.java
@@ -311,6 +311,7 @@ public final class OmUtils {
     case DeleteSnapshot:
     case SnapshotMoveDeletedKeys:
     case SnapshotPurge:
+    case RecoverLease:
       return false;
     default:
       LOG.error("CmdType {} is not categorized as readOnly or not.", cmdType);

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/audit/OMAction.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/audit/OMAction.java
@@ -26,7 +26,10 @@ public enum OMAction implements AuditAction {
   ALLOCATE_BLOCK,
   ALLOCATE_KEY,
   COMMIT_KEY,
+
   HSYNC,
+  RECOVER_LEASE,
+
   CREATE_VOLUME,
   CREATE_BUCKET,
   DELETE_VOLUME,

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/exceptions/OMException.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/exceptions/OMException.java
@@ -262,6 +262,5 @@ public class OMException extends IOException {
     INVALID_SNAPSHOT_ERROR,
     CONTAINS_SNAPSHOT,
     SSL_CONNECTION_FAILURE,
-    KEY_ALREADY_CLOSED,
   }
 }

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/exceptions/OMException.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/exceptions/OMException.java
@@ -261,6 +261,7 @@ public class OMException extends IOException {
 
     INVALID_SNAPSHOT_ERROR,
     CONTAINS_SNAPSHOT,
-    SSL_CONNECTION_FAILURE
+    SSL_CONNECTION_FAILURE,
+    KEY_ALREADY_CLOSED,
   }
 }

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocol/OzoneManagerProtocol.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocol/OzoneManagerProtocol.java
@@ -983,4 +983,16 @@ public interface OzoneManagerProtocol
                              int payloadSizeResp)
           throws IOException;
 
+
+  /**
+   * Start the lease recovery of a file.
+   *
+   * @param volumeName - The volume name.
+   * @param bucketName - The bucket name.
+   * @param keyName - The key user want to recover.
+   * @return true if the file is already closed
+   * @throws IOException if an error occurs
+   */
+  boolean recoverLease(String volumeName, String bucketName,
+                              String keyName) throws IOException;
 }

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocolPB/OzoneManagerProtocolClientSideTranslatorPB.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocolPB/OzoneManagerProtocolClientSideTranslatorPB.java
@@ -151,6 +151,8 @@ import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OzoneAc
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OzoneFileStatusProto;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.RangerBGSyncRequest;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.RangerBGSyncResponse;
+import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.RecoverLeaseRequest;
+import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.RecoverLeaseResponse;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.RecoverTrashRequest;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.RecoverTrashResponse;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.RemoveAclRequest;
@@ -2193,6 +2195,24 @@ public final class OzoneManagerProtocolClientSideTranslatorPB
     EchoRPCResponse echoRPCResponse =
             handleError(submitRequest(omRequest)).getEchoRPCResponse();
     return echoRPCResponse;
+  }
+
+  @Override
+  public boolean recoverLease(String volumeName, String bucketName,
+                              String keyName) throws IOException {
+    RecoverLeaseRequest recoverLeaseRequest =
+            RecoverLeaseRequest.newBuilder()
+                    .setVolumeName(volumeName)
+                    .setBucketName(bucketName)
+                    .setKeyName(keyName)
+                    .build();
+
+    OMRequest omRequest = createOMRequest(Type.RecoverLease)
+            .setRecoverLeaseRequest(recoverLeaseRequest).build();
+
+    RecoverLeaseResponse recoverLeaseResponse =
+            handleError(submitRequest(omRequest)).getRecoverLeaseResponse();
+    return recoverLeaseResponse.getResponse();
   }
 
   @VisibleForTesting

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestLeaseRecovery.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestLeaseRecovery.java
@@ -48,6 +48,7 @@ import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_ADDRESS_KEY;
 import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_RATIS_ENABLE_KEY;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 
 /**
@@ -133,5 +134,22 @@ public class TestLeaseRecovery {
       assertEquals(readBytes, 1 << 20);
       assertArrayEquals(readData, data);
     }
+  }
+
+  @Test
+  public void testOBSRecoveryShouldFail() throws Exception {
+    // Set the fs.defaultFS
+    bucket = TestDataUtil.createVolumeAndBucket(client,
+        "vol2", "obs", BucketLayout.OBJECT_STORE);
+    final String rootPath = String.format("%s://%s/", OZONE_OFS_URI_SCHEME,
+        conf.get(OZONE_OM_ADDRESS_KEY));
+    conf.set(CommonConfigurationKeysPublic.FS_DEFAULT_NAME_KEY, rootPath);
+
+    final String dir = OZONE_ROOT + bucket.getVolumeName() +
+        OZONE_URI_DELIMITER + bucket.getName();
+    final Path file = new Path(dir, "file");
+
+    RootedOzoneFileSystem fs = (RootedOzoneFileSystem) FileSystem.get(conf);
+    assertThrows(IllegalArgumentException.class, () -> fs.recoverLease(file));
   }
 }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestLeaseRecovery.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestLeaseRecovery.java
@@ -1,0 +1,131 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.fs.ozone;
+
+import org.apache.hadoop.conf.StorageUnit;
+import org.apache.hadoop.fs.CommonConfigurationKeysPublic;
+import org.apache.hadoop.fs.FSDataInputStream;
+import org.apache.hadoop.fs.FSDataOutputStream;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import org.apache.hadoop.ozone.MiniOzoneCluster;
+import org.apache.hadoop.ozone.TestDataUtil;
+import org.apache.hadoop.ozone.client.OzoneBucket;
+import org.apache.hadoop.ozone.om.helpers.BucketLayout;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.Timeout;
+
+import java.io.IOException;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.TimeoutException;
+
+import static org.apache.hadoop.ozone.OzoneConsts.OZONE_OFS_URI_SCHEME;
+import static org.apache.hadoop.ozone.OzoneConsts.OZONE_ROOT;
+import static org.apache.hadoop.ozone.OzoneConsts.OZONE_URI_DELIMITER;
+import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_DEFAULT_BUCKET_LAYOUT;
+import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_ADDRESS_KEY;
+import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_RATIS_ENABLE_KEY;
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Test cases for recoverLease() API.
+ */
+public class TestLeaseRecovery {
+  @Rule
+  public Timeout timeout = Timeout.seconds(300);
+
+  private static MiniOzoneCluster cluster;
+  private static OzoneBucket bucket;
+  private final OzoneConfiguration conf = new OzoneConfiguration();
+
+  @Before
+  public void init() throws IOException, InterruptedException,
+      TimeoutException {
+    final int chunkSize = 16 << 10;
+    final int flushSize = 2 * chunkSize;
+    final int maxFlushSize = 2 * flushSize;
+    final int blockSize = 2 * maxFlushSize;
+    final BucketLayout layout = BucketLayout.FILE_SYSTEM_OPTIMIZED;
+
+    conf.setBoolean(OZONE_OM_RATIS_ENABLE_KEY, false);
+    conf.set(OZONE_DEFAULT_BUCKET_LAYOUT, layout.name());
+    cluster = MiniOzoneCluster.newBuilder(conf)
+      .setNumDatanodes(5)
+      .setTotalPipelineNumLimit(10)
+      .setBlockSize(blockSize)
+      .setChunkSize(chunkSize)
+      .setStreamBufferFlushSize(flushSize)
+      .setStreamBufferMaxSize(maxFlushSize)
+      .setDataStreamBufferFlushize(maxFlushSize)
+      .setStreamBufferSizeUnit(StorageUnit.BYTES)
+      .setDataStreamMinPacketSize(chunkSize)
+      .setDataStreamStreamWindowSize(5 * chunkSize)
+      .build();
+    cluster.waitForClusterToBeReady();
+
+    // create a volume and a bucket to be used by OzoneFileSystem
+    bucket = TestDataUtil.createVolumeAndBucket(cluster, layout);
+  }
+
+  @After
+  public void tearDown() {
+    if (cluster != null) {
+      cluster.shutdown();
+    }
+  }
+
+  @Test
+  public void testRecovery() throws Exception {
+    // Set the fs.defaultFS
+    final String rootPath = String.format("%s://%s/",
+        OZONE_OFS_URI_SCHEME, conf.get(OZONE_OM_ADDRESS_KEY));
+    conf.set(CommonConfigurationKeysPublic.FS_DEFAULT_NAME_KEY, rootPath);
+
+    final String dir = OZONE_ROOT + bucket.getVolumeName()
+        + OZONE_URI_DELIMITER + bucket.getName();
+    final Path file = new Path(dir, "file");
+
+    RootedOzoneFileSystem fs = (RootedOzoneFileSystem)FileSystem.get(conf);
+    final FSDataOutputStream stream = fs.create(file, true);
+
+    final byte[] data = new byte[1 << 20];
+    ThreadLocalRandom.current().nextBytes(data);
+    stream.write(data);
+    stream.hsync();
+
+    int count = 0;
+    while (count++ < 15 && !fs.recoverLease(file)) {
+      Thread.sleep(1000);
+    }
+    // The lease should have been recovered.
+    assertTrue("File should be closed", fs.recoverLease(file));
+    // open it again, make sure the data is correct
+    byte[] readData = new byte[1 << 20];
+    try (FSDataInputStream fdis = fs.open(file)) {
+      int readBytes = fdis.read(readData);
+      assertEquals(readBytes, 1 << 20);
+      assertArrayEquals(readData, data);
+    }
+  }
+}

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestLeaseRecovery.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestLeaseRecovery.java
@@ -57,10 +57,10 @@ public class TestLeaseRecovery {
   @Rule
   public Timeout timeout = Timeout.seconds(300);
 
-  private static MiniOzoneCluster cluster;
-  private static OzoneBucket bucket;
+  private MiniOzoneCluster cluster;
+  private OzoneBucket bucket;
 
-  private static OzoneClient client;
+  private OzoneClient client;
   private final OzoneConfiguration conf = new OzoneConfiguration();
 
   @Before

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestLeaseRecovery.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestLeaseRecovery.java
@@ -24,9 +24,11 @@ import org.apache.hadoop.fs.FSDataOutputStream;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import org.apache.hadoop.hdds.utils.IOUtils;
 import org.apache.hadoop.ozone.MiniOzoneCluster;
 import org.apache.hadoop.ozone.TestDataUtil;
 import org.apache.hadoop.ozone.client.OzoneBucket;
+import org.apache.hadoop.ozone.client.OzoneClient;
 import org.apache.hadoop.ozone.om.helpers.BucketLayout;
 import org.junit.After;
 import org.junit.Before;
@@ -57,6 +59,8 @@ public class TestLeaseRecovery {
 
   private static MiniOzoneCluster cluster;
   private static OzoneBucket bucket;
+
+  private static OzoneClient client;
   private final OzoneConfiguration conf = new OzoneConfiguration();
 
   @Before
@@ -83,13 +87,15 @@ public class TestLeaseRecovery {
       .setDataStreamStreamWindowSize(5 * chunkSize)
       .build();
     cluster.waitForClusterToBeReady();
+    client = cluster.newClient();
 
     // create a volume and a bucket to be used by OzoneFileSystem
-    bucket = TestDataUtil.createVolumeAndBucket(cluster, layout);
+    bucket = TestDataUtil.createVolumeAndBucket(client, layout);
   }
 
   @After
   public void tearDown() {
+    IOUtils.closeQuietly(client);
     if (cluster != null) {
       cluster.shutdown();
     }

--- a/hadoop-ozone/interface-client/src/main/proto/OmClientProtocol.proto
+++ b/hadoop-ozone/interface-client/src/main/proto/OmClientProtocol.proto
@@ -131,9 +131,9 @@ enum Type {
   SnapshotDiff = 114;
   DeleteSnapshot = 115;
   SnapshotMoveDeletedKeys = 116;
-
   TransferLeadership = 117;
   SnapshotPurge = 118;
+  RecoverLease = 119;
 }
 
 message OMRequest {
@@ -251,6 +251,7 @@ message OMRequest {
   optional hdds.TransferLeadershipRequestProto      TransferOmLeadershipRequest    = 117;
   optional SnapshotPurgeRequest             SnapshotPurgeRequest           = 118;
 
+  optional RecoverLeaseRequest              RecoverLeaseRequest            = 119;
 }
 
 message OMResponse {
@@ -360,6 +361,7 @@ message OMResponse {
 
   optional hdds.TransferLeadershipResponseProto   TransferOmLeadershipResponse  = 117;
   optional SnapshotPurgeResponse              SnapshotPurgeResponse         = 118;
+  optional RecoverLeaseResponse              RecoverLeaseResponse          = 119;
 }
 
 enum Status {
@@ -1861,6 +1863,16 @@ message S3Authentication {
     optional string stringToSign = 1;
     optional string signature = 2;
     optional string accessId = 3;
+}
+
+message RecoverLeaseRequest {
+  optional string volumeName = 1;
+  optional string bucketName = 2;
+  optional string keyName = 3;
+}
+
+message RecoverLeaseResponse {
+  optional bool response = 1;
 }
 
 /**

--- a/hadoop-ozone/interface-storage/src/main/java/org/apache/hadoop/ozone/om/OMMetadataManager.java
+++ b/hadoop-ozone/interface-storage/src/main/java/org/apache/hadoop/ozone/om/OMMetadataManager.java
@@ -506,6 +506,19 @@ public interface OMMetadataManager extends DBStoreHAManager {
   String getRenameKey(String volume, String bucket, long objectID);
 
   /**
+   * Returns DB key name of an open file in OM metadata store. Should be
+   * #open# prefix followed by actual leaf node name.
+   *
+   * @param volumeId       - ID of the volume
+   * @param bucketId       - ID of the bucket
+   * @param parentObjectId - parent object Id
+   * @param fileName       - file name
+   * @return DB directory key as String.
+   */
+  String getOpenFileNamePrefix(long volumeId, long bucketId,
+      long parentObjectId, String fileName);
+
+  /**
    * Returns the DB key name of a multipart upload key in OM metadata store.
    *
    * @param volumeId       - ID of the volume

--- a/hadoop-ozone/interface-storage/src/main/java/org/apache/hadoop/ozone/om/OMMetadataManager.java
+++ b/hadoop-ozone/interface-storage/src/main/java/org/apache/hadoop/ozone/om/OMMetadataManager.java
@@ -506,19 +506,6 @@ public interface OMMetadataManager extends DBStoreHAManager {
   String getRenameKey(String volume, String bucket, long objectID);
 
   /**
-   * Returns DB key name of an open file in OM metadata store. Should be
-   * #open# prefix followed by actual leaf node name.
-   *
-   * @param volumeId       - ID of the volume
-   * @param bucketId       - ID of the bucket
-   * @param parentObjectId - parent object Id
-   * @param fileName       - file name
-   * @return DB directory key as String.
-   */
-  String getOpenFileNamePrefix(long volumeId, long bucketId,
-      long parentObjectId, String fileName);
-
-  /**
    * Returns the DB key name of a multipart upload key in OM metadata store.
    *
    * @param volumeId       - ID of the volume

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OMMetrics.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OMMetrics.java
@@ -155,12 +155,16 @@ public class OMMetrics implements OmMetadataReaderMetrics {
   // Metric for list users in tenant operation
   private @Metric MutableCounterLong numTenantTenantUserLists;
 
+  private @Metric MutableCounterLong numRecoverLease;
+
   private @Metric MutableCounterLong numGetFileStatusFails;
   private @Metric MutableCounterLong numCreateDirectoryFails;
   private @Metric MutableCounterLong numCreateFileFails;
   private @Metric MutableCounterLong numLookupFileFails;
   private @Metric MutableCounterLong numListStatusFails;
   private @Metric MutableCounterLong getNumGetKeyInfoFails;
+
+  private @Metric MutableCounterLong numRecoverLeaseFails;
 
   // Metrics for total amount of data written
   private @Metric MutableCounterLong totalDataCommitted;
@@ -1306,6 +1310,16 @@ public class OMMetrics implements OmMetadataReaderMetrics {
 
   public void incEcBucketCreateFailsTotal() {
     ecBucketCreateFailsTotal.incr();
+  }
+
+  public void incNumRecoverLease() {
+    numKeyOps.incr();
+    numFSOps.incr();
+    numRecoverLease.incr();
+  }
+
+  public void incNumRecoverLeaseFails() {
+    numRecoverLeaseFails.incr();
   }
 
   public void unRegister() {

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmMetadataManagerImpl.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmMetadataManagerImpl.java
@@ -1749,19 +1749,6 @@ public class OmMetadataManagerImpl implements OMMetadataManager,
     renameKey.append(OM_KEY_PREFIX).append(objectID);
     return renameKey.toString();
   }
-
-  @Override
-  public String getOpenFileNamePrefix(long volumeId, long bucketId,
-      long parentID, String fileName) {
-    StringBuilder openKey = new StringBuilder();
-    openKey.append(OM_KEY_PREFIX).append(volumeId);
-    openKey.append(OM_KEY_PREFIX).append(bucketId);
-    openKey.append(OM_KEY_PREFIX).append(parentID);
-    openKey.append(OM_KEY_PREFIX).append(fileName);
-    openKey.append(OM_KEY_PREFIX);
-    return openKey.toString();
-  }
-
   @Override
   public String getMultipartKey(long volumeId, long bucketId,
                                 long parentID, String fileName,

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmMetadataManagerImpl.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmMetadataManagerImpl.java
@@ -1751,6 +1751,18 @@ public class OmMetadataManagerImpl implements OMMetadataManager,
   }
 
   @Override
+  public String getOpenFileNamePrefix(long volumeId, long bucketId,
+      long parentID, String fileName) {
+    StringBuilder openKey = new StringBuilder();
+    openKey.append(OM_KEY_PREFIX).append(volumeId);
+    openKey.append(OM_KEY_PREFIX).append(bucketId);
+    openKey.append(OM_KEY_PREFIX).append(parentID);
+    openKey.append(OM_KEY_PREFIX).append(fileName);
+    openKey.append(OM_KEY_PREFIX);
+    return openKey.toString();
+  }
+
+  @Override
   public String getMultipartKey(long volumeId, long bucketId,
                                 long parentID, String fileName,
                                 String uploadId) {

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
@@ -4384,6 +4384,12 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
     return null;
   }
 
+  @Override
+  public boolean recoverLease(String volumeName, String bucketName,
+                              String keyName) throws IOException {
+    return false;
+  }
+
   /**
    * Write down Layout version of a finalized feature to DB on finalization.
    * @param lvm OMLayoutVersionManager

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/utils/OzoneManagerRatisUtils.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/utils/OzoneManagerRatisUtils.java
@@ -44,6 +44,7 @@ import org.apache.hadoop.ozone.om.request.OMClientRequest;
 import org.apache.hadoop.ozone.om.request.bucket.acl.OMBucketAddAclRequest;
 import org.apache.hadoop.ozone.om.request.bucket.acl.OMBucketRemoveAclRequest;
 import org.apache.hadoop.ozone.om.request.bucket.acl.OMBucketSetAclRequest;
+import org.apache.hadoop.ozone.om.request.file.OMRecoverLeaseRequest;
 import org.apache.hadoop.ozone.om.request.key.OMKeyPurgeRequest;
 import org.apache.hadoop.ozone.om.request.key.OMDirectoriesPurgeRequestWithFSO;
 import org.apache.hadoop.ozone.om.request.key.OMOpenKeysDeleteRequest;
@@ -100,6 +101,7 @@ import org.slf4j.LoggerFactory;
 import static org.apache.hadoop.hdds.HddsConfigKeys.OZONE_METADATA_DIRS;
 import static org.apache.hadoop.ozone.OzoneConsts.OM_RATIS_SNAPSHOT_DIR;
 import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_RATIS_SNAPSHOT_DIR;
+import static org.apache.hadoop.ozone.om.OzoneManagerUtils.getBucketLayout;
 
 /**
  * Utility class used by OzoneManager HA.
@@ -228,6 +230,17 @@ public final class OzoneManagerRatisUtils {
             omRequest.getDeleteOpenKeysRequest().getBucketLayout());
       }
       return new OMOpenKeysDeleteRequest(omRequest, bktLayout);
+    case RecoverLease:
+      volumeName = omRequest.getRecoverLeaseRequest().getVolumeName();
+      bucketName = omRequest.getRecoverLeaseRequest().getBucketName();
+      bucketLayout =
+        getBucketLayout(ozoneManager.getMetadataManager(), volumeName,
+          bucketName);
+      if (bucketLayout != BucketLayout.FILE_SYSTEM_OPTIMIZED) {
+        throw new IOException("Bucket " + bucketName + " is not FSO layout. " +
+                "It does not support lease recovery");
+      }
+      return new OMRecoverLeaseRequest(omRequest);
     /*
      * Key requests that can have multiple variants based on the bucket layout
      * should be created using {@link BucketLayoutAwareOMKeyRequestFactory}.

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/file/OMRecoverLeaseRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/file/OMRecoverLeaseRequest.java
@@ -62,7 +62,6 @@ import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
-import static org.apache.hadoop.ozone.om.exceptions.OMException.ResultCodes.KEY_ALREADY_EXISTS;
 import static org.apache.hadoop.ozone.om.exceptions.OMException.ResultCodes.KEY_NOT_FOUND;
 import static org.apache.hadoop.ozone.om.lock.OzoneManagerLock.Resource.BUCKET_LOCK;
 import static org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos
@@ -208,8 +207,7 @@ public class OMRecoverLeaseRequest extends OMKeyRequest {
     final String clientId = keyInfo.getMetadata().get(
         OzoneConsts.HSYNC_CLIENT_ID);
     if (clientId == null) {
-      throw new OMException("Key:" + keyName + " is closed",
-          KEY_ALREADY_EXISTS);
+      LOG.warn("Key:" + keyName + " is closed");
     }
     String openKeyEntryName = getOpenFileEntryName(volumeId, bucketId,
         parentID, fileName);

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/file/OMRecoverLeaseRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/file/OMRecoverLeaseRequest.java
@@ -1,0 +1,278 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.ozone.om.request.file;
+
+import com.google.common.base.Optional;
+import com.google.common.base.Preconditions;
+
+import org.apache.hadoop.hdds.utils.db.Table;
+import org.apache.hadoop.hdds.utils.db.TableIterator;
+import org.apache.hadoop.hdds.utils.db.cache.CacheKey;
+import org.apache.hadoop.hdds.utils.db.cache.CacheValue;
+import org.apache.hadoop.ozone.OzoneConsts;
+import org.apache.hadoop.ozone.audit.OMAction;
+import org.apache.hadoop.ozone.om.OMMetadataManager;
+import org.apache.hadoop.ozone.om.OMMetrics;
+import org.apache.hadoop.ozone.om.OzoneManager;
+import org.apache.hadoop.ozone.om.exceptions.OMException;
+import org.apache.hadoop.ozone.om.helpers.BucketLayout;
+import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
+import org.apache.hadoop.ozone.om.helpers.OzoneFSUtils;
+import org.apache.hadoop.ozone.om.ratis.utils.OzoneManagerDoubleBufferHelper;
+import org.apache.hadoop.ozone.om.request.key.OMKeyRequest;
+import org.apache.hadoop.ozone.om.request.util.OmResponseUtil;
+import org.apache.hadoop.ozone.om.response.OMClientResponse;
+import org.apache.hadoop.ozone.om.response.file.OMRecoverLeaseResponse;
+import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos
+        .OMResponse;
+import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos
+        .OMRequest;
+import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos
+        .RecoverLeaseRequest;
+import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos
+        .RecoverLeaseResponse;
+
+import org.apache.hadoop.ozone.security.acl.IAccessAuthorizer;
+import org.apache.hadoop.ozone.security.acl.OzoneObj;
+import org.apache.hadoop.util.Time;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Iterator;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import static org.apache.hadoop.ozone.om.exceptions.OMException.ResultCodes.KEY_NOT_FOUND;
+import static org.apache.hadoop.ozone.om.lock.OzoneManagerLock.Resource.BUCKET_LOCK;
+import static org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos
+        .Type.RecoverLease;
+
+/**
+ * Perform actions for RecoverLease requests.
+ */
+public class OMRecoverLeaseRequest extends OMKeyRequest {
+  private static final Logger LOG =
+      LoggerFactory.getLogger(OMRecoverLeaseRequest.class);
+
+  private String volumeName;
+  private String bucketName;
+  private String keyName;
+
+  private String normalizedKeyPath;
+
+  private OMMetadataManager omMetadataManager;
+
+  public OMRecoverLeaseRequest(OMRequest omRequest) {
+    super(omRequest, BucketLayout.FILE_SYSTEM_OPTIMIZED);
+    RecoverLeaseRequest recoverLeaseRequest = getOmRequest()
+        .getRecoverLeaseRequest();
+
+    Preconditions.checkNotNull(recoverLeaseRequest);
+    volumeName = recoverLeaseRequest.getVolumeName();
+    bucketName = recoverLeaseRequest.getBucketName();
+    keyName = recoverLeaseRequest.getKeyName();
+  }
+
+  @Override
+  public OMRequest preExecute(OzoneManager ozoneManager) throws IOException {
+    RecoverLeaseRequest recoverLeaseRequest = getOmRequest()
+        .getRecoverLeaseRequest();
+
+    String keyPath = recoverLeaseRequest.getKeyName();
+    normalizedKeyPath =
+        validateAndNormalizeKey(ozoneManager.getEnableFileSystemPaths(),
+        keyPath, getBucketLayout());
+
+    return getOmRequest().toBuilder()
+        .setRecoverLeaseRequest(
+            recoverLeaseRequest.toBuilder()
+                .setKeyName(normalizedKeyPath))
+        .build();
+  }
+
+  @Override
+  public OMClientResponse validateAndUpdateCache(OzoneManager ozoneManager,
+      long transactionLogIndex,
+      OzoneManagerDoubleBufferHelper ozoneManagerDoubleBufferHelper) {
+    RecoverLeaseRequest recoverLeaseRequest = getOmRequest()
+        .getRecoverLeaseRequest();
+    Preconditions.checkNotNull(recoverLeaseRequest);
+
+    Map<String, String> auditMap = new LinkedHashMap<>();
+    auditMap.put(OzoneConsts.VOLUME, volumeName);
+    auditMap.put(OzoneConsts.BUCKET, bucketName);
+    auditMap.put(OzoneConsts.KEY, keyName);
+
+    OMResponse.Builder omResponse = OmResponseUtil.getOMResponseBuilder(
+        getOmRequest());
+
+    omMetadataManager = ozoneManager.getMetadataManager();
+    OMClientResponse omClientResponse = null;
+    IOException exception = null;
+    // increment metric
+    OMMetrics omMetrics = ozoneManager.getMetrics();
+
+    boolean acquiredLock = false;
+    try {
+      // check ACL
+      checkKeyAcls(ozoneManager, volumeName, bucketName, keyName,
+          IAccessAuthorizer.ACLType.WRITE, OzoneObj.ResourceType.KEY);
+
+      // acquire lock
+      acquiredLock = omMetadataManager.getLock().acquireWriteLock(BUCKET_LOCK,
+          volumeName, bucketName);
+
+      validateBucketAndVolume(omMetadataManager, volumeName, bucketName);
+
+      String openKeyEntryName = doWork(ozoneManager, recoverLeaseRequest,
+          transactionLogIndex);
+
+      // Prepare response
+      boolean responseCode = true;
+      omResponse.setRecoverLeaseResponse(RecoverLeaseResponse.newBuilder()
+              .setResponse(responseCode).build())
+          .setCmdType(RecoverLease);
+      omClientResponse =
+          new OMRecoverLeaseResponse(omResponse.build(), getBucketLayout(),
+              openKeyEntryName);
+      omMetrics.incNumRecoverLease();
+      LOG.debug("Key recovered. Volume:{}, Bucket:{}, Key:{}", volumeName,
+          bucketName, keyName);
+    } catch (IOException ex) {
+      LOG.error("Fail for recovering lease. Volume:{}, Bucket:{}, Key:{}",
+          volumeName, bucketName, keyName, ex);
+      exception = ex;
+      omMetrics.incNumRecoverLeaseFails();
+      omResponse.setCmdType(RecoverLease);
+      omClientResponse = new OMRecoverLeaseResponse(
+          createErrorOMResponse(omResponse, ex), getBucketLayout());
+    } finally {
+      if (omClientResponse != null) {
+        omClientResponse.setFlushFuture(
+            ozoneManagerDoubleBufferHelper.add(omClientResponse,
+                transactionLogIndex));
+      }
+      if (acquiredLock) {
+        omMetadataManager.getLock().releaseWriteLock(BUCKET_LOCK, volumeName,
+            bucketName);
+      }
+    }
+
+    // Audit Log outside the lock
+    auditLog(ozoneManager.getAuditLogger(), buildAuditMessage(
+        OMAction.RECOVER_LEASE, auditMap, exception,
+        getOmRequest().getUserInfo()));
+
+    return omClientResponse;
+  }
+
+  private String doWork(OzoneManager ozoneManager,
+      RecoverLeaseRequest recoverLeaseRequest, long transactionLogIndex)
+      throws IOException {
+
+    final long volumeId = omMetadataManager.getVolumeId(volumeName);
+    final long bucketId = omMetadataManager.getBucketId(
+        volumeName, bucketName);
+    Iterator<Path> pathComponents = Paths.get(keyName).iterator();
+    long parentID = OMFileRequest.getParentID(volumeId, bucketId,
+        pathComponents, keyName, omMetadataManager,
+        "Cannot recover file : " + keyName
+            + " as parent directory doesn't exist");
+    String fileName = OzoneFSUtils.getFileName(keyName);
+    String dbFileKey = omMetadataManager.getOzonePathKey(volumeId, bucketId,
+        parentID, fileName);
+
+    OmKeyInfo keyInfo = getKey(dbFileKey);
+    if (keyInfo == null) {
+      throw new OMException("Key:" + keyName + " not found", KEY_NOT_FOUND);
+    }
+    String openKeyEntryName = getOpenFileEntryName(volumeId, bucketId,
+        parentID, fileName);
+    if (openKeyEntryName != null) {
+      checkFileState(keyInfo, openKeyEntryName);
+      commitKey(dbFileKey, keyInfo, ozoneManager, transactionLogIndex);
+      removeOpenKey(openKeyEntryName, transactionLogIndex);
+    }
+
+    return openKeyEntryName;
+  }
+
+  private OmKeyInfo getKey(String dbOzoneKey) throws IOException {
+    return omMetadataManager.getKeyTable(getBucketLayout()).get(dbOzoneKey);
+  }
+
+  private String getOpenFileEntryName(long volumeId, long bucketId,
+      long parentObjectId, String fileName) throws IOException {
+    String openFileEntryName = null;
+    String dbOpenKeyPrefix =
+        omMetadataManager.getOpenFileNamePrefix(volumeId, bucketId,
+            parentObjectId, fileName);
+    try (TableIterator<String, ? extends Table.KeyValue<String, OmKeyInfo>>
+        iter = omMetadataManager.getOpenKeyTable(getBucketLayout())
+        .iterator(dbOpenKeyPrefix)) {
+
+      while (iter.hasNext()) {
+        if (openFileEntryName != null) {
+          throw new IOException("Found more than two keys in the" +
+            " open key table for file" + fileName);
+        }
+        openFileEntryName = iter.next().getKey();
+      }
+    }
+    /*if (openFileEntryName == null) {
+      throw new IOException("Unable to find the corresponding key in " +
+        "the open key table for file " + fileName);
+    }*/
+    return openFileEntryName;
+  }
+
+  private void checkFileState(OmKeyInfo keyInfo, String openKeyEntryName)
+      throws IOException {
+
+    // if file is closed, do nothing and return right away.
+    if (openKeyEntryName.isEmpty()) {
+      return; // ("File is closed");
+    }
+    // if file is open, no sync, fail right away.
+    if (keyInfo == null) {
+      throw new IOException("file is open but not yet sync'ed");
+    }
+  }
+
+  private void commitKey(String dbOzoneKey, OmKeyInfo omKeyInfo,
+      OzoneManager ozoneManager, long transactionLogIndex) throws IOException {
+    omKeyInfo.setModificationTime(Time.now());
+    omKeyInfo.setUpdateID(transactionLogIndex, ozoneManager.isRatisEnabled());
+
+    omMetadataManager.getKeyTable(getBucketLayout()).addCacheEntry(
+      new CacheKey<>(dbOzoneKey),
+      new CacheValue<>(Optional.of(omKeyInfo), transactionLogIndex));
+  }
+
+  private void removeOpenKey(String openKeyName, long transactionLogIndex)
+      throws IOException {
+    omMetadataManager.getOpenKeyTable(getBucketLayout()).addCacheEntry(
+      new CacheKey<>(openKeyName),
+      new CacheValue<>(Optional.absent(), transactionLogIndex));
+  }
+}

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/file/OMRecoverLeaseRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/file/OMRecoverLeaseRequest.java
@@ -18,13 +18,8 @@
 
 package org.apache.hadoop.ozone.om.request.file;
 
-import com.google.common.base.Optional;
 import com.google.common.base.Preconditions;
 
-import org.apache.hadoop.hdds.utils.db.Table;
-import org.apache.hadoop.hdds.utils.db.TableIterator;
-import org.apache.hadoop.hdds.utils.db.cache.CacheKey;
-import org.apache.hadoop.hdds.utils.db.cache.CacheValue;
 import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.hadoop.ozone.audit.OMAction;
 import org.apache.hadoop.ozone.om.OMMetadataManager;

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyCommitRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyCommitRequest.java
@@ -422,7 +422,7 @@ public class OMKeyCommitRequest extends OMKeyRequest {
       processingPhase = RequestProcessingPhase.PRE_PROCESS,
       requestType = Type.CommitKey
   )
-  public static OMRequest disallowCreateBucketWithECReplicationConfig(
+  public static OMRequest disallowHsync(
       OMRequest req, ValidationContext ctx) throws OMException {
     if (!ctx.versionManager()
         .isAllowed(OMLayoutFeature.HSYNC)) {

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyCommitRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyCommitRequest.java
@@ -416,4 +416,27 @@ public class OMKeyCommitRequest extends OMKeyRequest {
     }
     return req;
   }
+
+  @RequestFeatureValidator(
+      conditions = ValidationCondition.CLUSTER_NEEDS_FINALIZATION,
+      processingPhase = RequestProcessingPhase.PRE_PROCESS,
+      requestType = Type.CommitKey
+  )
+  public static OMRequest disallowCreateBucketWithECReplicationConfig(
+      OMRequest req, ValidationContext ctx) throws OMException {
+    if (!ctx.versionManager()
+        .isAllowed(OMLayoutFeature.HSYNC)) {
+      CommitKeyRequest commitKeyRequest = req.getCommitKeyRequest();
+      boolean isHSync = commitKeyRequest.hasHsync() &&
+          commitKeyRequest.getHsync();
+      if (isHSync) {
+        throw new OMException("Cluster does not have the hsync support "
+            + "feature finalized yet, but the request contains"
+            + " an hsync field. Rejecting the request,"
+            + " please finalize the cluster upgrade and then try again.",
+            OMException.ResultCodes.NOT_SUPPORTED_OPERATION_PRIOR_FINALIZATION);
+      }
+    }
+    return req;
+  }
 }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/file/OMRecoverLeaseResponse.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/file/OMRecoverLeaseResponse.java
@@ -1,0 +1,54 @@
+package org.apache.hadoop.ozone.om.response.file;
+
+import org.apache.hadoop.hdds.utils.db.BatchOperation;
+import org.apache.hadoop.ozone.om.OMMetadataManager;
+import org.apache.hadoop.ozone.om.helpers.BucketLayout;
+import org.apache.hadoop.ozone.om.response.CleanupTableInfo;
+import org.apache.hadoop.ozone.om.response.key.OmKeyResponse;
+import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos
+        .OMResponse;
+
+import javax.annotation.Nonnull;
+import java.io.IOException;
+
+import static org.apache.hadoop.ozone.om.OmMetadataManagerImpl.FILE_TABLE;
+import static org.apache.hadoop.ozone.om.OmMetadataManagerImpl.OPEN_FILE_TABLE;
+
+/**
+ * Performs tasks for RecoverLease request responses.
+ */
+@CleanupTableInfo(cleanupTables = {FILE_TABLE, OPEN_FILE_TABLE})
+public class OMRecoverLeaseResponse extends OmKeyResponse {
+
+  private String openKeyName;
+  public OMRecoverLeaseResponse(@Nonnull OMResponse omResponse,
+      BucketLayout bucketLayout, String openKeyName) {
+    super(omResponse, bucketLayout);
+    this.openKeyName = openKeyName;
+  }
+
+  /**
+   * For when the request is not successful.
+   * For a successful request, the other constructor should be used.
+   */
+  public OMRecoverLeaseResponse(@Nonnull OMResponse omResponse,
+      @Nonnull BucketLayout bucketLayout) {
+    super(omResponse, bucketLayout);
+    checkStatusNotOK();
+  }
+
+  @Override
+  protected void addToDBBatch(OMMetadataManager omMetadataManager,
+      BatchOperation batchOperation) throws IOException {
+    // Delete from OpenKey table
+    if (openKeyName != null) {
+      omMetadataManager.getOpenKeyTable(getBucketLayout()).deleteWithBatch(
+          batchOperation, openKeyName);
+    }
+  }
+
+  @Override
+  public BucketLayout getBucketLayout() {
+    return BucketLayout.FILE_SYSTEM_OPTIMIZED;
+  }
+}

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/file/OMRecoverLeaseResponse.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/file/OMRecoverLeaseResponse.java
@@ -1,10 +1,27 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.hadoop.ozone.om.response.file;
 
 import org.apache.hadoop.hdds.utils.db.BatchOperation;
 import org.apache.hadoop.ozone.om.OMMetadataManager;
 import org.apache.hadoop.ozone.om.helpers.BucketLayout;
 import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
-import org.apache.hadoop.ozone.om.request.file.OMFileRequest;
 import org.apache.hadoop.ozone.om.response.CleanupTableInfo;
 import org.apache.hadoop.ozone.om.response.key.OmKeyResponse;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/file/OMRecoverLeaseResponse.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/file/OMRecoverLeaseResponse.java
@@ -3,6 +3,8 @@ package org.apache.hadoop.ozone.om.response.file;
 import org.apache.hadoop.hdds.utils.db.BatchOperation;
 import org.apache.hadoop.ozone.om.OMMetadataManager;
 import org.apache.hadoop.ozone.om.helpers.BucketLayout;
+import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
+import org.apache.hadoop.ozone.om.request.file.OMFileRequest;
 import org.apache.hadoop.ozone.om.response.CleanupTableInfo;
 import org.apache.hadoop.ozone.om.response.key.OmKeyResponse;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos
@@ -20,10 +22,15 @@ import static org.apache.hadoop.ozone.om.OmMetadataManagerImpl.OPEN_FILE_TABLE;
 @CleanupTableInfo(cleanupTables = {FILE_TABLE, OPEN_FILE_TABLE})
 public class OMRecoverLeaseResponse extends OmKeyResponse {
 
+  private OmKeyInfo keyInfo;
+  private String dbFileKey;
   private String openKeyName;
   public OMRecoverLeaseResponse(@Nonnull OMResponse omResponse,
-      BucketLayout bucketLayout, String openKeyName) {
+      BucketLayout bucketLayout, OmKeyInfo keyInfo, String dbFileKey,
+      String openKeyName) {
     super(omResponse, bucketLayout);
+    this.keyInfo = keyInfo;
+    this.dbFileKey = dbFileKey;
     this.openKeyName = openKeyName;
   }
 
@@ -45,6 +52,8 @@ public class OMRecoverLeaseResponse extends OmKeyResponse {
       omMetadataManager.getOpenKeyTable(getBucketLayout()).deleteWithBatch(
           batchOperation, openKeyName);
     }
+    omMetadataManager.getKeyTable(BucketLayout.FILE_SYSTEM_OPTIMIZED)
+        .putWithBatch(batchOperation, dbFileKey, keyInfo);
   }
 
   @Override

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/file/OMRecoverLeaseResponse.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/file/OMRecoverLeaseResponse.java
@@ -68,9 +68,9 @@ public class OMRecoverLeaseResponse extends OmKeyResponse {
     if (openKeyName != null) {
       omMetadataManager.getOpenKeyTable(getBucketLayout()).deleteWithBatch(
           batchOperation, openKeyName);
+      omMetadataManager.getKeyTable(getBucketLayout())
+          .putWithBatch(batchOperation, dbFileKey, keyInfo);
     }
-    omMetadataManager.getKeyTable(BucketLayout.FILE_SYSTEM_OPTIMIZED)
-        .putWithBatch(batchOperation, dbFileKey, keyInfo);
   }
 
   @Override

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/upgrade/OMLayoutFeature.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/upgrade/OMLayoutFeature.java
@@ -38,7 +38,9 @@ public enum OMLayoutFeature implements LayoutFeature {
       "layouts and introducing the FILE_SYSTEM_OPTIMIZED and OBJECT_STORE " +
       "bucket layout types."),
 
-  MULTITENANCY_SCHEMA(3, "Multi-Tenancy Schema");
+  MULTITENANCY_SCHEMA(3, "Multi-Tenancy Schema"),
+
+  HSYNC(4, "Support hsync");
 
   ///////////////////////////////  /////////////////////////////
   //    Example OM Layout Feature with Actions

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/file/TestOMRecoverLeaseRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/file/TestOMRecoverLeaseRequest.java
@@ -19,6 +19,7 @@
 package org.apache.hadoop.ozone.om.request.file;
 
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
+import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.hadoop.ozone.om.helpers.BucketLayout;
 import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
 import org.apache.hadoop.ozone.om.helpers.OmKeyLocationInfo;
@@ -257,6 +258,8 @@ public class TestOMRecoverLeaseRequest extends TestOMKeyRequest {
         bucketName, keyName, replicationType, replicationFactor, 0, parentId,
         0, Time.now(), version);
     omKeyInfo.appendNewBlocks(locationList, false);
+    omKeyInfo.getMetadata().put(OzoneConsts.HSYNC_CLIENT_ID,
+        String.valueOf(clientID));
 
     OMRequestTestUtils.addFileToKeyTable(
         true, false, omKeyInfo.getFileName(),

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/file/TestOMRecoverLeaseRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/file/TestOMRecoverLeaseRequest.java
@@ -1,0 +1,294 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.ozone.om.request.file;
+
+import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
+import org.apache.hadoop.ozone.om.helpers.BucketLayout;
+import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
+import org.apache.hadoop.ozone.om.helpers.OmKeyLocationInfo;
+import org.apache.hadoop.ozone.om.helpers.OzoneFSUtils;
+import org.apache.hadoop.ozone.om.request.OMRequestTestUtils;
+import org.apache.hadoop.ozone.om.request.key.TestOMKeyRequest;
+import org.apache.hadoop.ozone.om.response.OMClientResponse;
+import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos;
+import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos
+    .KeyLocation;
+import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMRequest;
+import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos
+    .RecoverLeaseRequest;
+import org.apache.hadoop.util.Time;
+import org.jetbrains.annotations.NotNull;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+/**
+ * Tests OMRecoverLeaseRequest.
+ */
+public class TestOMRecoverLeaseRequest extends TestOMKeyRequest {
+
+  private long parentId;
+
+  @Override
+  public BucketLayout getBucketLayout() {
+    return BucketLayout.FILE_SYSTEM_OPTIMIZED;
+  }
+
+  /**
+   * Verify that RecoverLease request closes properly for an open file where
+   * hsync was called .
+   * @throws Exception
+   */
+  @Test
+  public void testRecoverHsyncFile() throws Exception {
+    populateNamespace(true, true);
+
+    OMClientResponse omClientResponse = validateAndUpdateCache();
+
+    Assert.assertEquals(OzoneManagerProtocolProtos.Status.OK,
+        omClientResponse.getOMResponse().getStatus());
+
+    verifyTables(true, false);
+  }
+
+  /**
+   * verify that recover a closed file should be allowed (essentially no-op).
+    */
+  @Test
+  public void testRecoverClosedFile() throws Exception {
+    populateNamespace(true, false);
+
+    OMClientResponse omClientResponse = validateAndUpdateCache();
+
+    Assert.assertEquals(OzoneManagerProtocolProtos.Status.OK,
+        omClientResponse.getOMResponse().getStatus());
+
+    verifyTables(true, false);
+  }
+
+  /**
+   * verify that recover an open (not yet hsync'ed) file doesn't work.
+    */
+  @Test
+  public void testRecoverOpenFile() throws Exception {
+    populateNamespace(false, true);
+
+    OMClientResponse omClientResponse = validateAndUpdateCache();
+
+    Assert.assertEquals(OzoneManagerProtocolProtos.Status.KEY_NOT_FOUND,
+        omClientResponse.getOMResponse().getStatus());
+
+    verifyTables(false, true);
+  }
+
+  /**
+   * Verify that recovering a file that doesn't exist throws an exception.
+   * @throws Exception
+   */
+  @Test
+  public void testRecoverAbsentFile() throws Exception {
+    populateNamespace(false, false);
+
+    OMClientResponse omClientResponse = validateAndUpdateCache();
+
+    Assert.assertEquals(OzoneManagerProtocolProtos.Status.KEY_NOT_FOUND,
+        omClientResponse.getOMResponse().getStatus());
+
+    verifyTables(false, false);
+  }
+
+  private void populateNamespace(boolean addKeyTable, boolean addOpenKeyTable)
+      throws Exception {
+    String parentDir = "c/d/e";
+    String fileName = "f";
+    keyName = parentDir + "/" + fileName;
+    OMRequestTestUtils.addVolumeAndBucketToDB(volumeName, bucketName,
+        omMetadataManager, getBucketLayout());
+    // Create parent dirs for the path
+    parentId = OMRequestTestUtils.addParentsToDirTable(volumeName,
+        bucketName, parentDir, omMetadataManager);
+
+    // add to both key table and open key table
+    List<OmKeyLocationInfo> allocatedLocationList = getKeyLocation(3);
+
+    OmKeyInfo omKeyInfo;
+    if (addKeyTable) {
+      String ozoneKey = addToFileTable(allocatedLocationList);
+      omKeyInfo = omMetadataManager.getKeyTable(getBucketLayout())
+          .get(ozoneKey);
+      Assert.assertNotNull(omKeyInfo);
+    }
+
+    if (addOpenKeyTable) {
+      String openKey = addToOpenFileTable(allocatedLocationList);
+
+      omKeyInfo = omMetadataManager.getOpenKeyTable(getBucketLayout())
+          .get(openKey);
+      Assert.assertNotNull(omKeyInfo);
+    }
+  }
+
+  @NotNull
+  protected OMRequest createRecoverLeaseRequest(
+      String volumeName, String bucketName, String keyName) {
+
+    RecoverLeaseRequest recoverLeaseRequest = RecoverLeaseRequest.newBuilder()
+        .setVolumeName(volumeName)
+        .setBucketName(bucketName)
+        .setKeyName(keyName).build();
+
+    return OMRequest.newBuilder()
+        .setCmdType(OzoneManagerProtocolProtos.Type.RecoverLease)
+        .setClientId(UUID.randomUUID().toString())
+        .setRecoverLeaseRequest(recoverLeaseRequest).build();
+  }
+
+
+  private OMClientResponse validateAndUpdateCache() throws Exception {
+    OMRequest modifiedOmRequest = doPreExecute(createRecoverLeaseRequest(
+        volumeName, bucketName, keyName));
+
+    OMRecoverLeaseRequest omRecoverLeaseRequest = getOmRecoverLeaseRequest(
+        modifiedOmRequest);
+
+    OMClientResponse omClientResponse =
+        omRecoverLeaseRequest.validateAndUpdateCache(ozoneManager,
+            100L, ozoneManagerDoubleBufferHelper);
+    return omClientResponse;
+  }
+
+  private void verifyTables(boolean hasKey, boolean hasOpenKey)
+      throws IOException {
+    // Now entry should be created in key Table.
+    String ozoneKey = getFileName();
+    OmKeyInfo omKeyInfo = omMetadataManager.getKeyTable(getBucketLayout())
+        .get(ozoneKey);
+    if (hasKey) {
+      Assert.assertNotNull(omKeyInfo);
+    } else {
+      Assert.assertNull(omKeyInfo);
+    }
+    // Entry should be deleted from openKey Table.
+    String openKey = getOpenFileName();
+    omKeyInfo = omMetadataManager.getOpenKeyTable(getBucketLayout())
+        .get(openKey);
+    if (hasOpenKey) {
+      Assert.assertNotNull(omKeyInfo);
+    } else {
+      Assert.assertNull(omKeyInfo);
+    }
+  }
+
+  String getOpenFileName() throws IOException {
+    final long volumeId = omMetadataManager.getVolumeId(
+        volumeName);
+    final long bucketId = omMetadataManager.getBucketId(
+        volumeName, bucketName);
+    final String fileName = OzoneFSUtils.getFileName(keyName);
+    return omMetadataManager.getOpenFileName(volumeId, bucketId,
+        parentId, fileName, clientID);
+  }
+
+  String getFileName() throws IOException {
+    final long volumeId = omMetadataManager.getVolumeId(
+        volumeName);
+    final long bucketId = omMetadataManager.getBucketId(
+        volumeName, bucketName);
+    final String fileName = OzoneFSUtils.getFileName(keyName);
+    return omMetadataManager.getOzonePathKey(volumeId, bucketId, parentId,
+        fileName);
+  }
+
+  protected OMRecoverLeaseRequest getOmRecoverLeaseRequest(
+      OMRequest omRequest) {
+    return new OMRecoverLeaseRequest(omRequest);
+  }
+
+  private List<OmKeyLocationInfo> getKeyLocation(int count) {
+    List<KeyLocation> keyLocations = new ArrayList<>();
+
+    for (int i = 0; i < count; i++) {
+      KeyLocation keyLocation =
+          KeyLocation.newBuilder()
+              .setBlockID(HddsProtos.BlockID.newBuilder()
+                  .setContainerBlockID(HddsProtos.ContainerBlockID.newBuilder()
+                      .setContainerID(i + 1000).setLocalID(i + 100).build()))
+              .setOffset(0).setLength(200).setCreateVersion(version).build();
+      keyLocations.add(keyLocation);
+    }
+    return keyLocations.stream().map(OmKeyLocationInfo::getFromProtobuf)
+        .collect(Collectors.toList());
+  }
+
+  private OMRequest doPreExecute(OMRequest originalOMRequest) throws Exception {
+    OMRecoverLeaseRequest omRecoverLeaseRequest =
+        getOmRecoverLeaseRequest(originalOMRequest);
+
+    OMRequest modifiedOmRequest = omRecoverLeaseRequest.preExecute(
+        ozoneManager);
+
+    return modifiedOmRequest;
+  }
+
+  String addToOpenFileTable(List<OmKeyLocationInfo> locationList)
+      throws Exception {
+    OmKeyInfo omKeyInfo = OMRequestTestUtils.createOmKeyInfo(volumeName,
+        bucketName, keyName, replicationType, replicationFactor, 0, parentId,
+        0, Time.now(), version);
+    omKeyInfo.appendNewBlocks(locationList, false);
+
+    OMRequestTestUtils.addFileToKeyTable(
+        true, false, omKeyInfo.getFileName(),
+        omKeyInfo, clientID, omKeyInfo.getUpdateID(), omMetadataManager);
+
+    final long volumeId = omMetadataManager.getVolumeId(
+        omKeyInfo.getVolumeName());
+    final long bucketId = omMetadataManager.getBucketId(
+        omKeyInfo.getVolumeName(), omKeyInfo.getBucketName());
+
+    return omMetadataManager.getOpenFileName(volumeId, bucketId,
+        omKeyInfo.getParentObjectID(), omKeyInfo.getFileName(), clientID);
+  }
+
+  String addToFileTable(List<OmKeyLocationInfo> locationList)
+      throws Exception {
+    OmKeyInfo omKeyInfo = OMRequestTestUtils.createOmKeyInfo(volumeName,
+        bucketName, keyName, replicationType, replicationFactor, 0, parentId,
+        0, Time.now(), version);
+    omKeyInfo.appendNewBlocks(locationList, false);
+
+    OMRequestTestUtils.addFileToKeyTable(
+        false, false, omKeyInfo.getFileName(),
+        omKeyInfo, clientID, omKeyInfo.getUpdateID(), omMetadataManager);
+
+    final long volumeId = omMetadataManager.getVolumeId(
+        omKeyInfo.getVolumeName());
+    final long bucketId = omMetadataManager.getBucketId(
+        omKeyInfo.getVolumeName(), omKeyInfo.getBucketName());
+
+    return omMetadataManager.getOzonePathKey(volumeId, bucketId, parentId,
+        omKeyInfo.getFileName());
+  }
+
+}

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/file/TestOMRecoverLeaseRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/file/TestOMRecoverLeaseRequest.java
@@ -70,7 +70,7 @@ public class TestOMRecoverLeaseRequest extends TestOMKeyRequest {
     Assert.assertEquals(OzoneManagerProtocolProtos.Status.OK,
         omClientResponse.getOMResponse().getStatus());
 
-    verifyTables(true, false);
+    verifyTables(true, true);
   }
 
   /**

--- a/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicRootedOzoneClientAdapterImpl.java
+++ b/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicRootedOzoneClientAdapterImpl.java
@@ -1282,4 +1282,13 @@ public class BasicRootedOzoneClientAdapterImpl
             ofsPath.getBucketName(),
             snapshotName);
   }
+
+  public boolean recoverLease(final Path f) throws IOException {
+    OFSPath ofsPath = new OFSPath(f, config);
+
+    OzoneVolume volume = objectStore.getVolume(ofsPath.getVolumeName());
+    OzoneBucket bucket = getBucket(ofsPath, false);
+    return ozoneClient.getProxy().getOzoneManagerClient().recoverLease(
+            volume.getName(), bucket.getName(), ofsPath.getKeyName());
+  }
 }

--- a/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicRootedOzoneFileSystem.java
+++ b/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicRootedOzoneFileSystem.java
@@ -1417,4 +1417,15 @@ public class BasicRootedOzoneFileSystem extends FileSystem {
         spaceConsumed(summary[1]).build();
   }
 
+  /**
+   * Start the lease recovery of a file.
+   *
+   * @param f a file
+   * @return true if the file is already closed
+   * @throws IOException if an error occurs
+   */
+  public boolean recoverLease(final Path f) throws IOException {
+    return adapterImpl.recoverLease(f);
+  }
+
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Implement recoverLease() API that is similar to HDFS's one, which allows a client to forcefully close an open file. 

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-7769

## How was this patch tested?

Unit tests