### PR TITLE
HDDS-7871. Fix false positive in KeyManagerImpl#createFakeDirIfShould()

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestKeyManagerImpl.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestKeyManagerImpl.java
@@ -1388,8 +1388,9 @@ public class TestKeyManagerImpl {
     // 2nd dbKey "volume1/bucket2/foo2/bar2", which is not belong to bucket1.
     keyArgs = createBuilder(BUCKET_NAME).setKeyName(dirName).build();
     OmKeyArgs finalKeyArgs = keyArgs;
-    Assert.assertThrows(OMException.class, () -> keyManager.getFileStatus(
-        finalKeyArgs));
+    OMException ex = Assert.assertThrows(OMException.class,
+        () -> keyManager.getFileStatus(finalKeyArgs));
+    Assert.assertEquals(OMException.ResultCodes.FILE_NOT_FOUND, ex.getResult());
 
     // get a non-existing "foo2" from bucket2 should return a fake key.
     keyArgs = createBuilder(BUCKET2_NAME).setKeyName(dirName).build();

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestKeyManagerImpl.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestKeyManagerImpl.java
@@ -135,6 +135,10 @@ import org.junit.rules.Timeout;
 
 import org.mockito.Mockito;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
@@ -1680,10 +1684,10 @@ public class TestKeyManagerImpl {
     try {
       OmKeyInfo keyInfo = metadataManager.getKeyTable(getDefaultBucketLayout())
           .get(metadataManager.getOzoneKey(VOLUME_NAME, bucketName, keyName));
-      Assert.assertNotNull(keyInfo);
-      Assert.assertEquals(VOLUME_NAME, keyInfo.getVolumeName());
-      Assert.assertEquals(bucketName, keyInfo.getBucketName());
-      Assert.assertEquals(keyName, keyInfo.getKeyName());
+      assertNotNull(keyInfo);
+      assertEquals(VOLUME_NAME, keyInfo.getVolumeName());
+      assertEquals(bucketName, keyInfo.getBucketName());
+      assertEquals(keyName, keyInfo.getKeyName());
     } catch (IOException e) {
       throw new RuntimeException(e);
     }
@@ -1692,9 +1696,9 @@ public class TestKeyManagerImpl {
   private void assertFileNotFound(String bucketName, String keyName) {
     try {
       OmKeyArgs keyArgs = createBuilder(bucketName).setKeyName(keyName).build();
-      OMException ex = Assert.assertThrows(OMException.class,
+      OMException ex = assertThrows(OMException.class,
           () -> keyManager.getFileStatus(keyArgs));
-      Assert.assertEquals(OMException.ResultCodes.FILE_NOT_FOUND, ex.getResult());
+      assertEquals(OMException.ResultCodes.FILE_NOT_FOUND, ex.getResult());
     } catch (IOException e) {
       throw new RuntimeException(e);
     }
@@ -1705,10 +1709,10 @@ public class TestKeyManagerImpl {
       OmKeyArgs keyArgs = createBuilder(bucketName).setKeyName(keyName).build();
       OzoneFileStatus ozoneFileStatus = keyManager.getFileStatus(keyArgs);
       OmKeyInfo keyInfo = ozoneFileStatus.getKeyInfo();
-      Assert.assertEquals(VOLUME_NAME, keyInfo.getVolumeName());
-      Assert.assertEquals(bucketName, keyInfo.getBucketName());
-      Assert.assertEquals(keyName, keyInfo.getFileName());
-      Assert.assertTrue(ozoneFileStatus.isDirectory());
+      assertEquals(VOLUME_NAME, keyInfo.getVolumeName());
+      assertEquals(bucketName, keyInfo.getBucketName());
+      assertEquals(keyName, keyInfo.getFileName());
+      assertTrue(ozoneFileStatus.isDirectory());
     } catch (IOException e) {
       throw new RuntimeException(e);
     }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestKeyManagerImpl.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestKeyManagerImpl.java
@@ -1354,7 +1354,7 @@ public class TestKeyManagerImpl {
   }
 
   @Test
-  public void testGetFileStatusWithFakeDirForHDDS7871() throws IOException {
+  public void testGetFileStatusWithFakeDirFalsePositive() throws IOException {
     String dirName = "foo2";
     String fileName = "bar2";
     String keyName1 = "foo1";

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestKeyManagerImpl.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestKeyManagerImpl.java
@@ -1370,10 +1370,8 @@ public class TestKeyManagerImpl {
     // Verify the following dbKeys in key table:
     // 1. "volume1/bucket1/dir1/file1"
     // 2. "volume1/bucket2/dir2/file2"
-    Assert.assertNotNull(metadataManager.getKeyTable(getDefaultBucketLayout())
-        .get(metadataManager.getOzoneKey(VOLUME_NAME, BUCKET_NAME, keyName1)));
-    Assert.assertNotNull(metadataManager.getKeyTable(getDefaultBucketLayout())
-        .get(metadataManager.getOzoneKey(VOLUME_NAME, BUCKET2_NAME, keyName2)));
+    assertKeyExist(BUCKET_NAME, keyName1);
+    assertKeyExist(BUCKET2_NAME, keyName2);
 
     assertFileNotFound(BUCKET_NAME, dir0);
     // true positive: fake dir "volume1/bucket1/dir1" should be returned.
@@ -1410,16 +1408,11 @@ public class TestKeyManagerImpl {
     // 3. "volume1/bucket1/dir1/file3"
     // 4. "volume1/bucket2/dir1/file1"
     // 5. "volume1/bucket2/dir1/file2"
-    Assert.assertNotNull(metadataManager.getKeyTable(getDefaultBucketLayout())
-        .get(metadataManager.getOzoneKey(VOLUME_NAME, BUCKET_NAME, keyName1)));
-    Assert.assertNotNull(metadataManager.getKeyTable(getDefaultBucketLayout())
-        .get(metadataManager.getOzoneKey(VOLUME_NAME, BUCKET_NAME, keyName2)));
-    Assert.assertNotNull(metadataManager.getKeyTable(getDefaultBucketLayout())
-        .get(metadataManager.getOzoneKey(VOLUME_NAME, BUCKET_NAME, keyName3)));
-    Assert.assertNotNull(metadataManager.getKeyTable(getDefaultBucketLayout())
-        .get(metadataManager.getOzoneKey(VOLUME_NAME, BUCKET2_NAME, keyName1)));
-    Assert.assertNotNull(metadataManager.getKeyTable(getDefaultBucketLayout())
-        .get(metadataManager.getOzoneKey(VOLUME_NAME, BUCKET2_NAME, keyName2)));
+    assertKeyExist(BUCKET_NAME, keyName1);
+    assertKeyExist(BUCKET_NAME, keyName2);
+    assertKeyExist(BUCKET_NAME, keyName3);
+    assertKeyExist(BUCKET2_NAME, keyName1);
+    assertKeyExist(BUCKET2_NAME, keyName2);
 
     // get "volume1/bucket1/dir1" should return a fake dir.
     assertIsDirectory(BUCKET_NAME, dir1);
@@ -1672,6 +1665,16 @@ public class TestKeyManagerImpl {
     writeClient.commitKey(keyArgs, keySession.getId());
   }
 
+  private void assertKeyExist(String bucketName, String keyName)
+      throws IOException {
+    OmKeyInfo keyInfo = metadataManager.getKeyTable(getDefaultBucketLayout())
+        .get(metadataManager.getOzoneKey(VOLUME_NAME, bucketName, keyName));
+    Assert.assertNotNull(keyInfo);
+    Assert.assertEquals(VOLUME_NAME, keyInfo.getVolumeName());
+    Assert.assertEquals(bucketName, keyInfo.getBucketName());
+    Assert.assertEquals(keyName, keyInfo.getKeyName());
+  }
+
   private void assertFileNotFound(String bucketName, String keyName)
       throws IOException {
     OmKeyArgs keyArgs = createBuilder(bucketName).setKeyName(keyName).build();
@@ -1684,7 +1687,10 @@ public class TestKeyManagerImpl {
       throws IOException {
     OmKeyArgs keyArgs = createBuilder(bucketName).setKeyName(keyName).build();
     OzoneFileStatus ozoneFileStatus = keyManager.getFileStatus(keyArgs);
-    Assert.assertEquals(keyName, ozoneFileStatus.getKeyInfo().getFileName());
+    OmKeyInfo keyInfo = ozoneFileStatus.getKeyInfo();
+    Assert.assertEquals(VOLUME_NAME, keyInfo.getVolumeName());
+    Assert.assertEquals(bucketName, keyInfo.getBucketName());
+    Assert.assertEquals(keyName, keyInfo.getFileName());
     Assert.assertTrue(ozoneFileStatus.isDirectory());
   }
 

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestKeyManagerImpl.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestKeyManagerImpl.java
@@ -1424,10 +1424,7 @@ public class TestKeyManagerImpl {
       Stream<Pair<String, String>> keys,
       Stream<Pair<String, String>> positives,
       Stream<Pair<String, String>> negatives) {
-    keys.forEach(f -> {
-      createFile(f.getLeft(), f.getRight());
-      assertKeyExist(f.getLeft(), f.getRight());
-    });
+    keys.forEach(f -> createFile(f.getLeft(), f.getRight()));
     positives.forEach(f -> assertIsDirectory(f.getLeft(), f.getRight()));
     negatives.forEach(f -> assertFileNotFound(f.getLeft(), f.getRight()));
   }
@@ -1675,13 +1672,8 @@ public class TestKeyManagerImpl {
       keyArgs.setLocationInfoList(keySession.getKeyInfo()
           .getLatestVersionLocations().getLocationList());
       writeClient.commitKey(keyArgs, keySession.getId());
-    } catch (IOException e) {
-      throw new RuntimeException(e);
-    }
-  }
 
-  private void assertKeyExist(String bucketName, String keyName) {
-    try {
+      // verify key exist in table
       OmKeyInfo keyInfo = metadataManager.getKeyTable(getDefaultBucketLayout())
           .get(metadataManager.getOzoneKey(VOLUME_NAME, bucketName, keyName));
       assertNotNull(keyInfo);

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestKeyManagerImpl.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestKeyManagerImpl.java
@@ -1376,16 +1376,10 @@ public class TestKeyManagerImpl {
     // get a non-existing "dir2" from bucket1 should throw FILE_NOT_FOUND.
     // RocksIterator#seek("volume1/bucket1/dir2/") will position at the
     // 2nd dbKey "volume1/bucket2/dir2/file2", which is not belong to bucket1.
-    OmKeyArgs fpKey = createBuilder(BUCKET_NAME).setKeyName(dir2).build();
-    OMException ex = Assert.assertThrows(OMException.class,
-        () -> keyManager.getFileStatus(fpKey));
-    Assert.assertEquals(OMException.ResultCodes.FILE_NOT_FOUND, ex.getResult());
+    assertFileNotFound(BUCKET_NAME, dir2);
 
     // get a non-existing "dir2" from bucket2 should return a fake key.
-    OmKeyArgs fakeKey = createBuilder(BUCKET2_NAME).setKeyName(dir2).build();
-    OzoneFileStatus ozoneFileStatus = keyManager.getFileStatus(fakeKey);
-    Assert.assertEquals(dir2, ozoneFileStatus.getKeyInfo().getFileName());
-    Assert.assertTrue(ozoneFileStatus.isDirectory());
+    assertIsDirectory(BUCKET2_NAME, dir2);
   }
 
   @Test
@@ -1613,6 +1607,22 @@ public class TestKeyManagerImpl {
     keyArgs.setLocationInfoList(
         keySession.getKeyInfo().getLatestVersionLocations().getLocationList());
     writeClient.commitKey(keyArgs, keySession.getId());
+  }
+
+  private void assertFileNotFound(String bucketName, String keyName)
+      throws IOException {
+    OmKeyArgs keyArgs = createBuilder(bucketName).setKeyName(keyName).build();
+    OMException ex = Assert.assertThrows(OMException.class,
+        () -> keyManager.getFileStatus(keyArgs));
+    Assert.assertEquals(OMException.ResultCodes.FILE_NOT_FOUND, ex.getResult());
+  }
+
+  private void assertIsDirectory(String bucketName, String keyName)
+      throws IOException {
+    OmKeyArgs keyArgs = createBuilder(bucketName).setKeyName(keyName).build();
+    OzoneFileStatus ozoneFileStatus = keyManager.getFileStatus(keyArgs);
+    Assert.assertEquals(keyName, ozoneFileStatus.getKeyInfo().getFileName());
+    Assert.assertTrue(ozoneFileStatus.isDirectory());
   }
 
   private List<String> createFiles(String parent,

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestKeyManagerImpl.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestKeyManagerImpl.java
@@ -1355,37 +1355,36 @@ public class TestKeyManagerImpl {
 
   @Test
   public void testGetFileStatusWithFakeDirFalsePositive() throws IOException {
-    String dirName = "foo2";
-    String fileName = "bar2";
-    String keyName1 = "foo1";
-    // keyName2 = "foo2/bar2"
-    String keyName2 = dirName + OZONE_URI_DELIMITER + fileName;
+    String dir1 = "dir1";
+    String dir2 = "dir2";
+    String keyName1 = dir1 + OZONE_URI_DELIMITER + "file1";
+    String keyName2 = dir2 + OZONE_URI_DELIMITER + "file2";
 
-    // create a key "foo1" in bucket1
+    // create a key "dir1/file1" in bucket1
     createFile(BUCKET_NAME, keyName1);
-    // create a key "foo2/bar2" in bucket2
+    // create a key "dir2/file2" in bucket2
     createFile(BUCKET2_NAME, keyName2);
 
     // Verify the following dbKeys in key table:
-    // 1. "volume1/bucket1/foo1"
-    // 2. "volume1/bucket2/foo2/bar2"
+    // 1. "volume1/bucket1/dir1/file1"
+    // 2. "volume1/bucket2/dir2/file2"
     Assert.assertNotNull(metadataManager.getKeyTable(getDefaultBucketLayout())
         .get(metadataManager.getOzoneKey(VOLUME_NAME, BUCKET_NAME, keyName1)));
     Assert.assertNotNull(metadataManager.getKeyTable(getDefaultBucketLayout())
         .get(metadataManager.getOzoneKey(VOLUME_NAME, BUCKET2_NAME, keyName2)));
 
-    // get a non-existing "foo2" from bucket1 should throw FILE_NOT_FOUND.
-    // RocksIterator#seek("volume1/bucket1/foo2/") will position at the
-    // 2nd dbKey "volume1/bucket2/foo2/bar2", which is not belong to bucket1.
-    OmKeyArgs fpKey = createBuilder(BUCKET_NAME).setKeyName(dirName).build();
+    // get a non-existing "dir2" from bucket1 should throw FILE_NOT_FOUND.
+    // RocksIterator#seek("volume1/bucket1/dir2/") will position at the
+    // 2nd dbKey "volume1/bucket2/dir2/file2", which is not belong to bucket1.
+    OmKeyArgs fpKey = createBuilder(BUCKET_NAME).setKeyName(dir2).build();
     OMException ex = Assert.assertThrows(OMException.class,
         () -> keyManager.getFileStatus(fpKey));
     Assert.assertEquals(OMException.ResultCodes.FILE_NOT_FOUND, ex.getResult());
 
-    // get a non-existing "foo2" from bucket2 should return a fake key.
-    OmKeyArgs fakeKey = createBuilder(BUCKET2_NAME).setKeyName(dirName).build();
+    // get a non-existing "dir2" from bucket2 should return a fake key.
+    OmKeyArgs fakeKey = createBuilder(BUCKET2_NAME).setKeyName(dir2).build();
     OzoneFileStatus ozoneFileStatus = keyManager.getFileStatus(fakeKey);
-    Assert.assertEquals(dirName, ozoneFileStatus.getKeyInfo().getFileName());
+    Assert.assertEquals(dir2, ozoneFileStatus.getKeyInfo().getFileName());
     Assert.assertTrue(ozoneFileStatus.isDirectory());
   }
 

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestKeyManagerImpl.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestKeyManagerImpl.java
@@ -1384,7 +1384,8 @@ public class TestKeyManagerImpl {
     Assert.assertNotNull(metadataManager.getKeyTable(getDefaultBucketLayout())
         .get(metadataManager.getOzoneKey(VOLUME_NAME, BUCKET2_NAME, keyName2)));
 
-    // get a non-existing "foo2" from bucket1, RocksIter#seek() will find the
+    // get a non-existing "foo2" from bucket1 should throw FILE_NOT_FOUND.
+    // RocksIterator#seek("volume1/bucket1/foo2/") will position at the
     // 2nd dbKey "volume1/bucket2/foo2/bar2", which is not belong to bucket1.
     keyArgs = createBuilder(BUCKET_NAME).setKeyName(dirName).build();
     OmKeyArgs finalKeyArgs = keyArgs;

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestKeyManagerImpl.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestKeyManagerImpl.java
@@ -1355,8 +1355,10 @@ public class TestKeyManagerImpl {
 
   @Test
   public void testGetFileStatusWithFakeDirFalsePositive() throws IOException {
+    String dir0 = "dir0";
     String dir1 = "dir1";
     String dir2 = "dir2";
+    String dir3 = "dir3";
     String keyName1 = dir1 + OZONE_URI_DELIMITER + "file1";
     String keyName2 = dir2 + OZONE_URI_DELIMITER + "file2";
 
@@ -1373,13 +1375,20 @@ public class TestKeyManagerImpl {
     Assert.assertNotNull(metadataManager.getKeyTable(getDefaultBucketLayout())
         .get(metadataManager.getOzoneKey(VOLUME_NAME, BUCKET2_NAME, keyName2)));
 
-    // get a non-existing "dir2" from bucket1 should throw FILE_NOT_FOUND.
+    assertFileNotFound(BUCKET_NAME, dir0);
+    // true positive: fake dir "volume1/bucket1/dir1" should be returned.
+    assertIsDirectory(BUCKET_NAME, dir1);
     // RocksIterator#seek("volume1/bucket1/dir2/") will position at the
     // 2nd dbKey "volume1/bucket2/dir2/file2", which is not belong to bucket1.
+    // This might be a false positive, see HDDS-7871.
     assertFileNotFound(BUCKET_NAME, dir2);
+    assertFileNotFound(BUCKET_NAME, dir3);
 
-    // get a non-existing "dir2" from bucket2 should return a fake key.
+    assertFileNotFound(BUCKET2_NAME, dir0);
+    assertFileNotFound(BUCKET2_NAME, dir1);
+    // true positive: fake dir "volume1/bucket1/dir1" should be returned.
     assertIsDirectory(BUCKET2_NAME, dir2);
+    assertFileNotFound(BUCKET2_NAME, dir3);
   }
 
   @Test

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestKeyManagerImpl.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestKeyManagerImpl.java
@@ -1646,7 +1646,8 @@ public class TestKeyManagerImpl {
     return keyNames;
   }
 
-  private void createFile(String bucketName, String keyName) throws IOException {
+  private void createFile(String bucketName, String keyName)
+      throws IOException {
     OmKeyArgs keyArgs = createBuilder(bucketName).setKeyName(keyName).build();
     OpenKeySession keySession = writeClient.openKey(keyArgs);
     keyArgs.setLocationInfoList(

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestKeyManagerImpl.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestKeyManagerImpl.java
@@ -1392,6 +1392,42 @@ public class TestKeyManagerImpl {
   }
 
   @Test
+  public void testGetFileStatusWithFakeDirFalseNegative() throws IOException {
+    String dir1 = "dir1";
+    String keyName1 = dir1 + OZONE_URI_DELIMITER + "file1";
+    String keyName2 = dir1 + OZONE_URI_DELIMITER + "file2";
+    String keyName3 = dir1 + OZONE_URI_DELIMITER + "file3";
+
+    createFile(BUCKET_NAME, keyName1);
+    createFile(BUCKET_NAME, keyName2);
+    createFile(BUCKET_NAME, keyName3);
+    createFile(BUCKET2_NAME, keyName1);
+    createFile(BUCKET2_NAME, keyName2);
+
+    // Verify the following dbKeys in key table:
+    // 1. "volume1/bucket1/dir1/file1"
+    // 2. "volume1/bucket1/dir1/file2"
+    // 3. "volume1/bucket1/dir1/file3"
+    // 4. "volume1/bucket2/dir1/file1"
+    // 5. "volume1/bucket2/dir1/file2"
+    Assert.assertNotNull(metadataManager.getKeyTable(getDefaultBucketLayout())
+        .get(metadataManager.getOzoneKey(VOLUME_NAME, BUCKET_NAME, keyName1)));
+    Assert.assertNotNull(metadataManager.getKeyTable(getDefaultBucketLayout())
+        .get(metadataManager.getOzoneKey(VOLUME_NAME, BUCKET_NAME, keyName2)));
+    Assert.assertNotNull(metadataManager.getKeyTable(getDefaultBucketLayout())
+        .get(metadataManager.getOzoneKey(VOLUME_NAME, BUCKET_NAME, keyName3)));
+    Assert.assertNotNull(metadataManager.getKeyTable(getDefaultBucketLayout())
+        .get(metadataManager.getOzoneKey(VOLUME_NAME, BUCKET2_NAME, keyName1)));
+    Assert.assertNotNull(metadataManager.getKeyTable(getDefaultBucketLayout())
+        .get(metadataManager.getOzoneKey(VOLUME_NAME, BUCKET2_NAME, keyName2)));
+
+    // get "volume1/bucket1/dir1" should return a fake dir.
+    assertIsDirectory(BUCKET_NAME, dir1);
+    // get "volume1/bucket2/dir1" should return a fake dir.
+    assertIsDirectory(BUCKET2_NAME, dir1);
+  }
+
+  @Test
   public void testRefreshPipeline() throws Exception {
 
     OzoneManager ozoneManager = om;

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestKeyManagerImpl.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestKeyManagerImpl.java
@@ -1420,9 +1420,8 @@ public class TestKeyManagerImpl {
       Stream<Pair<String, String>> keys,
       Stream<Pair<String, String>> positives,
       Stream<Pair<String, String>> negatives) {
-    final OzoneManagerProtocol client = writeClient;
     keys.forEach(f -> {
-      createFile(client, f.getLeft(), f.getRight());
+      createFile(f.getLeft(), f.getRight());
       assertKeyExist(f.getLeft(), f.getRight());
     });
     positives.forEach(f -> assertIsDirectory(f.getLeft(), f.getRight()));
@@ -1666,11 +1665,6 @@ public class TestKeyManagerImpl {
   }
 
   private void createFile(String bucketName, String keyName) {
-    createFile(writeClient, bucketName, keyName);
-  }
-
-  private void createFile(OzoneManagerProtocol writeClient,
-      String bucketName, String keyName) {
     try {
       OmKeyArgs keyArgs = createBuilder(bucketName).setKeyName(keyName).build();
       OpenKeySession keySession = writeClient.openKey(keyArgs);

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestKeyManagerImpl.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestKeyManagerImpl.java
@@ -1646,6 +1646,23 @@ public class TestKeyManagerImpl {
     return keyNames;
   }
 
+  private List<String> createFiles(String parent,
+      Map<String, List<String>> fileMap, int numFiles) throws IOException {
+    List<String> keyNames = new ArrayList<>();
+    for (int i = 0; i < numFiles; i++) {
+      String keyName = parent + "/" + RandomStringUtils.randomAlphabetic(5);
+      OmKeyArgs keyArgs = createBuilder().setKeyName(keyName).build();
+      OpenKeySession keySession = writeClient.createFile(keyArgs, false, false);
+      keyArgs.setLocationInfoList(
+          keySession.getKeyInfo().getLatestVersionLocations()
+              .getLocationList());
+      writeClient.commitKey(keyArgs, keySession.getId());
+      keyNames.add(keyName);
+    }
+    fileMap.put(parent, keyNames);
+    return keyNames;
+  }
+
   private void createFile(String bucketName, String keyName)
       throws IOException {
     OmKeyArgs keyArgs = createBuilder(bucketName).setKeyName(keyName).build();
@@ -1669,23 +1686,6 @@ public class TestKeyManagerImpl {
     OzoneFileStatus ozoneFileStatus = keyManager.getFileStatus(keyArgs);
     Assert.assertEquals(keyName, ozoneFileStatus.getKeyInfo().getFileName());
     Assert.assertTrue(ozoneFileStatus.isDirectory());
-  }
-
-  private List<String> createFiles(String parent,
-      Map<String, List<String>> fileMap, int numFiles) throws IOException {
-    List<String> keyNames = new ArrayList<>();
-    for (int i = 0; i < numFiles; i++) {
-      String keyName = parent + "/" + RandomStringUtils.randomAlphabetic(5);
-      OmKeyArgs keyArgs = createBuilder().setKeyName(keyName).build();
-      OpenKeySession keySession = writeClient.createFile(keyArgs, false, false);
-      keyArgs.setLocationInfoList(
-          keySession.getKeyInfo().getLatestVersionLocations()
-              .getLocationList());
-      writeClient.commitKey(keyArgs, keySession.getId());
-      keyNames.add(keyName);
-    }
-    fileMap.put(parent, keyNames);
-    return keyNames;
   }
 
   private OmKeyArgs.Builder createBuilder() throws IOException {

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/KeyManagerImpl.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/KeyManagerImpl.java
@@ -1186,10 +1186,9 @@ public class KeyManagerImpl implements KeyManager {
 
       // HDDS-7871: RocksIterator#seek() may position at the key
       // past the target, we should check the full dbKeyName.
-      // For example, seeking "/vol1/bucket1/dir1/"
-      // may return "/vol1/bucket2/dir1/key1"
+      // For example, seeking "/vol1/bucket1/dir2/" may return a key
+      // in different volume/bucket, such as "/vol1/bucket2/dir2/key2".
       if (keyValue != null && keyValue.getKey().startsWith(targetKey)) {
-        // create fake directory
         fakeDirKeyInfo = createDirectoryKey(keyValue.getValue(), dirKey);
       }
     }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/KeyManagerImpl.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/KeyManagerImpl.java
@@ -1186,12 +1186,15 @@ public class KeyManagerImpl implements KeyManager {
               .seek(OzoneFSUtils.addTrailingSlashIfNeeded(fileKeyBytes));
 
       if (keyValue != null) {
-        Path fullPath = Paths.get(keyValue.getValue().getKeyName());
-        Path subPath = Paths.get(dirKey);
         OmKeyInfo omKeyInfo = keyValue.getValue();
-        if (fullPath.startsWith(subPath)) {
-          // create fake directory
-          fakeDirKeyInfo = createDirectoryKey(omKeyInfo, dirKey);
+        if (omKeyInfo.getVolumeName().equals(volume)
+            && omKeyInfo.getBucketName().equals(bucket)) {
+          Path fullPath = Paths.get(omKeyInfo.getKeyName());
+          Path subPath = Paths.get(dirKey);
+          if (fullPath.startsWith(subPath)) {
+            // create fake directory
+            fakeDirKeyInfo = createDirectoryKey(omKeyInfo, dirKey);
+          }
         }
       }
     }


### PR DESCRIPTION
## What changes were proposed in this pull request?

`RocksIterator#seek()` may position at the first key in the source that at or **past target**,
which results false positive in KeyManagerImpl#createFakeDirIfShould().

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-7871

## How was this patch tested?

TestKeyManagerImpl#testGetFileStatusWithFakeDirs()
