### PR TITLE
HDDS-7868. Intermittent failure in TestOmAcls

### DIFF
--- a/hadoop-hdds/common/src/test/java/org/apache/hadoop/ozone/audit/AuditLogTestUtils.java
+++ b/hadoop-hdds/common/src/test/java/org/apache/hadoop/ozone/audit/AuditLogTestUtils.java
@@ -17,14 +17,15 @@
  */
 package org.apache.hadoop.ozone.audit;
 
-import java.io.BufferedReader;
+import org.apache.commons.io.FileUtils;
+
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
+import java.util.concurrent.TimeoutException;
+
+import static org.apache.ozone.test.GenericTestUtils.waitFor;
 
 /**
  * Utility class to read audit logs.
@@ -47,33 +48,34 @@ public final class AuditLogTestUtils {
    * Searches for the given action in the audit log file.
    */
   public static void verifyAuditLog(AuditAction action,
-                                    AuditEventStatus eventStatus) {
-    Path file = Paths.get(AUDITLOG_FILENAME);
-    try (BufferedReader br = Files.newBufferedReader(file,
-            StandardCharsets.UTF_8)) {
-      String line;
-      while ((line = br.readLine()) != null) {
-        if (line.contains(action.getAction()) &&
-                line.contains(eventStatus.getStatus())) {
-          return;
-        }
-      }
-    } catch (Exception e) {
-      throw new AssertionError(e);
-    } finally {
-      truncateAuditLogFile();
-    }
-    throw new AssertionError("Audit log file doesn't contain " +
-            "the message with params  event=" + action.getAction() +
-            " result=" + eventStatus.getStatus());
+      AuditEventStatus eventStatus)
+      throws InterruptedException, TimeoutException {
+    waitFor(
+        () -> auditLogContains(action.getAction(), eventStatus.getStatus()),
+        1000, 10000);
   }
 
-  private static void truncateAuditLogFile() {
-    File auditLogFile = new File(AUDITLOG_FILENAME);
+  public static boolean auditLogContains(String... strings) {
+    File file = new File(AUDITLOG_FILENAME);
     try {
-      new FileOutputStream(auditLogFile).getChannel().truncate(0).close();
+      String contents = FileUtils.readFileToString(file, StandardCharsets.UTF_8);
+      for (String s : strings) {
+        if (!contents.contains(s)) {
+          return false;
+        }
+      }
+      return true;
     } catch (IOException e) {
-      System.out.println("Failed to truncate file: " + AUDITLOG_FILENAME);
+      return false;
     }
+  }
+
+  public static void truncateAuditLogFile() throws IOException {
+    File auditLogFile = new File(AUDITLOG_FILENAME);
+    new FileOutputStream(auditLogFile).getChannel().truncate(0).close();
+  }
+
+  public static void deleteAuditLogFile() {
+    FileUtils.deleteQuietly(new File(AUDITLOG_FILENAME));
   }
 }

--- a/hadoop-hdds/common/src/test/java/org/apache/hadoop/ozone/audit/AuditLogTestUtils.java
+++ b/hadoop-hdds/common/src/test/java/org/apache/hadoop/ozone/audit/AuditLogTestUtils.java
@@ -22,9 +22,9 @@ import org.apache.commons.io.FileUtils;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
 import java.util.concurrent.TimeoutException;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.apache.ozone.test.GenericTestUtils.waitFor;
 
 /**
@@ -58,7 +58,7 @@ public final class AuditLogTestUtils {
   public static boolean auditLogContains(String... strings) {
     File file = new File(AUDITLOG_FILENAME);
     try {
-      String contents = FileUtils.readFileToString(file, StandardCharsets.UTF_8);
+      String contents = FileUtils.readFileToString(file, UTF_8);
       for (String s : strings) {
         if (!contents.contains(s)) {
           return false;

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOmAcls.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOmAcls.java
@@ -38,6 +38,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.Timeout;
 
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.UUID;
 
@@ -102,11 +103,13 @@ public class TestOmAcls {
     if (cluster != null) {
       cluster.shutdown();
     }
+    AuditLogTestUtils.deleteAuditLogFile();
   }
 
   @Before
-  public void setup() {
+  public void setup() throws IOException {
     logCapturer.clearOutput();
+    AuditLogTestUtils.truncateAuditLogFile();
 
     TestOmAcls.volumeAclAllow = true;
     TestOmAcls.bucketAclAllow = true;
@@ -115,7 +118,7 @@ public class TestOmAcls {
   }
 
   @Test
-  public void testCreateVolumePermissionDenied() {
+  public void testCreateVolumePermissionDenied() throws Exception {
     TestOmAcls.volumeAclAllow = false;
 
     OMException exception = assertThrows(OMException.class,
@@ -142,7 +145,7 @@ public class TestOmAcls {
   }
 
   @Test
-  public void testCreateBucketPermissionDenied() {
+  public void testCreateBucketPermissionDenied() throws Exception {
     TestOmAcls.bucketAclAllow = false;
 
     OMException exception = assertThrows(OMException.class,


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fix intermittent failure in `TestOmAcls` where audit log did not have the expected content.

I think this is caused by audit log being written asynchronously (to reduce delay of Ozone operations).  Thus we have to wait for the content to be written.

Also added removal of the `audit.log` file, which was leftover after the test finished.

https://issues.apache.org/jira/browse/HDDS-7868

## How was this patch tested?

Repeated 100 times successfully:
https://github.com/adoroszlai/hadoop-ozone/actions/runs/4072040018/jobs/7014405350

Regular CI:
https://github.com/adoroszlai/hadoop-ozone/actions/runs/4073118127