### PR TITLE
HDDS-7879. Intermittent BindException in HA integration tests

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/ratis/RatisHelper.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/ratis/RatisHelper.java
@@ -47,7 +47,6 @@ import org.apache.ratis.client.RaftClient;
 import org.apache.ratis.client.RaftClientConfigKeys;
 import org.apache.ratis.conf.Parameters;
 import org.apache.ratis.conf.RaftProperties;
-import org.apache.ratis.datastream.SupportedDataStreamType;
 import org.apache.ratis.grpc.GrpcConfigKeys;
 import org.apache.ratis.grpc.GrpcTlsConfig;
 import org.apache.ratis.netty.NettyConfigKeys;
@@ -305,8 +304,6 @@ public final class RatisHelper {
   public static RaftProperties setRpcType(RaftProperties properties,
       RpcType rpcType) {
     RaftConfigKeys.Rpc.setType(properties, rpcType);
-    RaftConfigKeys.DataStream.setType(properties,
-        SupportedDataStreamType.NETTY);
     return properties;
   }
 

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/ratis/RatisHelper.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/ratis/RatisHelper.java
@@ -47,6 +47,7 @@ import org.apache.ratis.client.RaftClient;
 import org.apache.ratis.client.RaftClientConfigKeys;
 import org.apache.ratis.conf.Parameters;
 import org.apache.ratis.conf.RaftProperties;
+import org.apache.ratis.datastream.SupportedDataStreamType;
 import org.apache.ratis.grpc.GrpcConfigKeys;
 import org.apache.ratis.grpc.GrpcTlsConfig;
 import org.apache.ratis.netty.NettyConfigKeys;
@@ -236,6 +237,7 @@ public final class RatisHelper {
           rpcType, leader, group);
     }
     final RaftProperties properties = newRaftProperties(rpcType);
+    enableNettyStreaming(properties);
 
     // Set the ratis client headers which are matching with regex.
     createRaftClientProperties(ozoneConfiguration, properties);
@@ -304,6 +306,12 @@ public final class RatisHelper {
   public static RaftProperties setRpcType(RaftProperties properties,
       RpcType rpcType) {
     RaftConfigKeys.Rpc.setType(properties, rpcType);
+    return properties;
+  }
+
+  public static RaftProperties enableNettyStreaming(RaftProperties properties) {
+    RaftConfigKeys.DataStream.setType(properties,
+        SupportedDataStreamType.NETTY);
     return properties;
   }
 

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/transport/server/ratis/XceiverServerRatis.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/transport/server/ratis/XceiverServerRatis.java
@@ -77,10 +77,8 @@ import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import io.opentracing.Scope;
 import io.opentracing.Span;
 import io.opentracing.util.GlobalTracer;
-import org.apache.ratis.RaftConfigKeys;
 import org.apache.ratis.conf.Parameters;
 import org.apache.ratis.conf.RaftProperties;
-import org.apache.ratis.datastream.SupportedDataStreamType;
 import org.apache.ratis.grpc.GrpcConfigKeys;
 import org.apache.ratis.grpc.GrpcTlsConfig;
 import org.apache.ratis.netty.NettyConfigKeys;
@@ -233,8 +231,7 @@ public final class XceiverServerRatis implements XceiverServerSpi {
           OzoneConfigKeys.DFS_CONTAINER_RATIS_DATASTREAM_PORT,
           OzoneConfigKeys.DFS_CONTAINER_RATIS_DATASTREAM_PORT_DEFAULT);
     }
-    RaftConfigKeys.DataStream.setType(properties,
-        SupportedDataStreamType.NETTY);
+    RatisHelper.enableNettyStreaming(properties);
     NettyConfigKeys.DataStream.setPort(properties, dataStreamPort);
     int dataStreamAsyncRequestThreadPoolSize =
         conf.getObject(DatanodeRatisServerConfig.class)

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/transport/server/ratis/XceiverServerRatis.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/transport/server/ratis/XceiverServerRatis.java
@@ -77,8 +77,10 @@ import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import io.opentracing.Scope;
 import io.opentracing.Span;
 import io.opentracing.util.GlobalTracer;
+import org.apache.ratis.RaftConfigKeys;
 import org.apache.ratis.conf.Parameters;
 import org.apache.ratis.conf.RaftProperties;
+import org.apache.ratis.datastream.SupportedDataStreamType;
 import org.apache.ratis.grpc.GrpcConfigKeys;
 import org.apache.ratis.grpc.GrpcTlsConfig;
 import org.apache.ratis.netty.NettyConfigKeys;
@@ -231,6 +233,8 @@ public final class XceiverServerRatis implements XceiverServerSpi {
           OzoneConfigKeys.DFS_CONTAINER_RATIS_DATASTREAM_PORT,
           OzoneConfigKeys.DFS_CONTAINER_RATIS_DATASTREAM_PORT_DEFAULT);
     }
+    RaftConfigKeys.DataStream.setType(properties,
+        SupportedDataStreamType.NETTY);
     NettyConfigKeys.DataStream.setPort(properties, dataStreamPort);
     int dataStreamAsyncRequestThreadPoolSize =
         conf.getObject(DatanodeRatisServerConfig.class)


### PR DESCRIPTION
## What changes were proposed in this pull request?

Avoid starting Netty datastream service for OM/SCM HA Ratis servers, to reduce the probability of port conflicts (due to random ports).

https://issues.apache.org/jira/browse/HDDS-7879

## How was this patch tested?

Successfully repeated (20x) HA integration tests that have been observed to fail due to port conflict by Netty:
https://github.com/adoroszlai/hadoop-ozone/actions/runs/4075097777
https://github.com/adoroszlai/hadoop-ozone/actions/runs/4075532254

Regular CI:
https://github.com/adoroszlai/hadoop-ozone/actions/runs/4075093534