### PR TITLE
HDDS-7881. Intermittent timeout in basic acceptance test

### DIFF
--- a/hadoop-ozone/dist/src/main/smoketest/basic/ozone-shell-single.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/basic/ozone-shell-single.robot
@@ -18,7 +18,7 @@ Documentation       Test ozone shell CLI usage
 Library             OperatingSystem
 Resource            ../commonlib.robot
 Resource            ozone-shell-lib.robot
-Test Timeout        5 minute
+Test Timeout        10 minutes
 Suite Setup         Generate prefix
 
 *** Test Cases ***

--- a/hadoop-ozone/dist/src/main/smoketest/basic/ozone-shell.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/basic/ozone-shell.robot
@@ -19,7 +19,7 @@ Library             OperatingSystem
 Resource            ../commonlib.robot
 Resource            ozone-shell-lib.robot
 Test Setup          Run Keyword if    '${SECURITY_ENABLED}' == 'true'    Kinit test user     testuser     testuser.keytab
-Test Timeout        5 minute
+Test Timeout        10 minutes
 Suite Setup         Generate prefix
 
 *** Test Cases ***


### PR DESCRIPTION
## What changes were proposed in this pull request?

In some test runs each operation takes a bit longer, leading to intermittent timeouts in `ozone-shell` and `ozone-shell-single` tests.  The change increases timeout from 5 to 10 minutes.

https://issues.apache.org/jira/browse/HDDS-7881

## How was this patch tested?

Regular CI:
https://github.com/adoroszlai/hadoop-ozone/actions/runs/4076435810/jobs/7026141074

Two of the tests with increased timeout would have failed with the original limit (`Test ozone shell` and `RpcClient with port`) as they took just a few seconds more than 5 minutes:

```
2023-02-02T18:13:44.1486984Z Basic.Ozone-Shell-Single :: Test ozone shell CLI usage                        
2023-02-02T18:13:44.1487687Z ==============================================================================
2023-02-02T18:18:49.6730281Z Test ozone shell                                                      | PASS |
2023-02-02T18:18:49.6732536Z ------------------------------------------------------------------------------
2023-02-02T18:18:49.6748036Z Basic.Ozone-Shell-Single :: Test ozone shell CLI usage                | PASS |
2023-02-02T18:18:49.6751394Z 1 test, 1 passed, 0 failed
2023-02-02T18:18:49.6753040Z ==============================================================================
2023-02-02T18:18:49.6840848Z Basic.Ozone-Shell :: Test ozone shell CLI usage                               
2023-02-02T18:18:49.6841470Z ==============================================================================
2023-02-02T18:23:56.5605561Z RpcClient with port                                                   | PASS |
2023-02-02T18:23:56.5606845Z ------------------------------------------------------------------------------
2023-02-02T18:24:42.5919042Z RpcClient with execution errors                                       | PASS |
2023-02-02T18:24:42.5919834Z ------------------------------------------------------------------------------
2023-02-02T18:25:28.8795744Z RpcClient volume acls                                                 | PASS |
2023-02-02T18:25:28.8796534Z ------------------------------------------------------------------------------
2023-02-02T18:26:15.0852852Z RpcClient bucket acls                                                 | PASS |
2023-02-02T18:26:15.0853591Z ------------------------------------------------------------------------------
2023-02-02T18:27:04.4464087Z RpcClient key acls                                                    | PASS |
2023-02-02T18:27:04.4464859Z ------------------------------------------------------------------------------
2023-02-02T18:27:53.1262889Z RpcClient prefix acls                                                 | PASS |
2023-02-02T18:27:53.1264019Z ------------------------------------------------------------------------------
2023-02-02T18:32:47.5391480Z RpcClient without host                                                | PASS |
2023-02-02T18:32:47.5392409Z ------------------------------------------------------------------------------
2023-02-02T18:32:47.5416437Z Basic.Ozone-Shell :: Test ozone shell CLI usage                       | PASS |
2023-02-02T18:32:47.5426373Z 7 tests, 7 passed, 0 failed
```
https://github.com/adoroszlai/hadoop-ozone/actions/runs/4076435810/jobs/7026141074#step:5:169