### PR TITLE
HDDS-7916. [Snapshot] Support for Distcp with Ozone Snapshots.

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/util/PersistentList.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/util/PersistentList.java
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-package org.apache.hadoop.ozone.om.snapshot;
+package org.apache.hadoop.ozone.util;
 
 import java.util.Iterator;
 

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/KeyValueContainer.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/KeyValueContainer.java
@@ -671,6 +671,18 @@ public class KeyValueContainer implements Container<KeyValueContainerData> {
     this.lock.writeLock().lock();
   }
 
+  @Override
+  public void readUnlock(String opName) {
+    // not used anywhere, implemented as part of interface.
+    this.lock.writeLock().lock();
+  }
+
+  @Override
+  public void writeUnlock(String opName) {
+    // not used anywhere, implemented as part of interface.
+    this.lock.writeLock().unlock();
+  }
+
   /**
    * Release write lock.
    */

--- a/hadoop-ozone/common/pom.xml
+++ b/hadoop-ozone/common/pom.xml
@@ -107,6 +107,10 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-params</artifactId>
     </dependency>
+      <dependency>
+          <groupId>org.apache.hadoop</groupId>
+          <artifactId>hadoop-hdfs-client</artifactId>
+      </dependency>
   </dependencies>
 
   <build>

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestDistcpWithSnapshots.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestDistcpWithSnapshots.java
@@ -1,0 +1,328 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with this
+ * work for additional information regarding copyright ownership.  The ASF
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.hadoop.fs.ozone;
+
+import org.apache.commons.io.IOUtils;
+import org.apache.commons.lang3.RandomStringUtils;
+import org.apache.hadoop.fs.FileStatus;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.fs.CommonConfigurationKeysPublic;
+import org.apache.hadoop.fs.contract.ContractTestUtils;
+import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import org.apache.hadoop.mapreduce.Job;
+import org.apache.hadoop.ozone.MiniOzoneCluster;
+import org.apache.hadoop.ozone.OzoneConsts;
+import org.apache.hadoop.ozone.TestDataUtil;
+import org.apache.hadoop.ozone.OFSPath;
+import org.apache.hadoop.ozone.client.OzoneBucket;
+import org.apache.hadoop.ozone.om.OMConfigKeys;
+import org.apache.hadoop.ozone.om.OMStorage;
+import org.apache.hadoop.ozone.om.helpers.BucketLayout;
+import org.apache.hadoop.ozone.om.helpers.SnapshotInfo;
+import org.apache.hadoop.tools.DistCp;
+import org.apache.hadoop.tools.DistCpOptions;
+import org.apache.hadoop.tools.DistCpSync;
+import org.apache.hadoop.tools.mapred.CopyMapper;
+import org.apache.ozone.test.GenericTestUtils;
+import org.jetbrains.annotations.NotNull;
+import org.junit.Rule;
+import org.junit.AfterClass;
+import org.junit.Test;
+import org.junit.Assert;
+import org.junit.rules.Timeout;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.concurrent.TimeoutException;
+
+import static org.apache.hadoop.ozone.OzoneConsts.OM_SNAPSHOT_DIR;
+import static org.apache.hadoop.ozone.OzoneConsts.OZONE_URI_DELIMITER;
+import static org.apache.hadoop.ozone.OzoneConsts.OM_DB_NAME;
+import static org.apache.hadoop.ozone.OzoneConsts.OM_KEY_PREFIX;
+import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_ADDRESS_KEY;
+
+/**
+ * Testing Distcp with -diff option that uses snapdiff.
+ */
+@RunWith(Parameterized.class)
+public class TestDistcpWithSnapshots {
+
+  private static final Logger LOG =
+      LoggerFactory.getLogger(TestDistcpWithSnapshots.class);
+
+  @Rule
+  public Timeout globalTimeout = Timeout.seconds(300);
+  private static OzoneConfiguration conf;
+  private static MiniOzoneCluster cluster = null;
+  private static FileSystem fs;
+  private static BucketLayout bucketLayout;
+  private static String rootPath;
+  private static boolean enableRatis;
+
+  private static File metaDir;
+
+  @Parameterized.Parameters
+  public static Collection<Object[]> data() {
+    return Arrays.asList(
+        new Object[] {true, BucketLayout.FILE_SYSTEM_OPTIMIZED},
+        new Object[] {false, BucketLayout.LEGACY});
+  }
+
+  public TestDistcpWithSnapshots(boolean enableRatis,
+      BucketLayout bucketLayout) {
+    // do nothing
+  }
+
+  @Parameterized.BeforeParam
+  public static void initParam(boolean ratisEnable, BucketLayout layout)
+      throws IOException, InterruptedException, TimeoutException {
+    // Initialize the cluster before EACH set of parameters
+    enableRatis = ratisEnable;
+    bucketLayout = layout;
+    initClusterAndEnv();
+  }
+
+  @Parameterized.AfterParam
+  public static void teardownParam() {
+    // Tear down the cluster after EACH set of parameters
+    if (cluster != null) {
+      cluster.shutdown();
+    }
+    IOUtils.closeQuietly(fs);
+  }
+
+  public static void initClusterAndEnv()
+      throws IOException, InterruptedException, TimeoutException {
+    conf = new OzoneConfiguration();
+    conf.setBoolean(OMConfigKeys.OZONE_OM_RATIS_ENABLE_KEY, enableRatis);
+    bucketLayout = BucketLayout.FILE_SYSTEM_OPTIMIZED;
+    conf.set(OMConfigKeys.OZONE_DEFAULT_BUCKET_LAYOUT, bucketLayout.name());
+    cluster = MiniOzoneCluster.newBuilder(conf).setNumDatanodes(5).build();
+    cluster.waitForClusterToBeReady();
+
+    rootPath = String.format("%s://%s/", OzoneConsts.OZONE_OFS_URI_SCHEME,
+        conf.get(OZONE_OM_ADDRESS_KEY));
+
+    // Set the fs.defaultFS and start the filesystem
+    conf.set(CommonConfigurationKeysPublic.FS_DEFAULT_NAME_KEY, rootPath);
+    conf.setClass("distcp.sync.class", OzoneDistcpSync.class,
+        DistCpSync.class);
+    fs = FileSystem.get(conf);
+    metaDir = OMStorage.getOmDbDir(conf);
+  }
+
+  @AfterClass
+  public static void shutdown() {
+    if (cluster != null) {
+      cluster.shutdown();
+    }
+  }
+
+  @Test
+  public void testDistcpWithSnapDiff() throws Exception {
+    Path srcBucketPath = createAndGetBucketPath();
+    Path insideSrcBucket = new Path(srcBucketPath, "*");
+    Path dstBucketPath = createAndGetBucketPath();
+    // create 2 files on source
+    createFiles(srcBucketPath, 2);
+    // Create target directory/bucket
+    fs.mkdirs(dstBucketPath);
+
+    // perform normal distcp
+    final DistCpOptions options =
+        new DistCpOptions.Builder(Collections.singletonList(insideSrcBucket),
+            dstBucketPath).build();
+    options.appendToConf(conf);
+    Job distcpJob = new DistCp(conf, options).execute();
+    verifyCopy(dstBucketPath, distcpJob, 2, 2);
+
+    // take Snapshot snap1 on both source and target
+    createSnapshot(srcBucketPath, "snap1");
+    createSnapshot(dstBucketPath, "snap1");
+
+
+
+    // create another file on src and take snapshot snap2 on source
+    createFiles(srcBucketPath, 1);
+    Assert.assertEquals(3, fs.listStatus(srcBucketPath).length);
+    createSnapshot(srcBucketPath, "snap2");
+
+    // perform distcp providing snapshot snap1.snap2 as arguments to
+    // copy only diff b/w them.
+    final DistCpOptions options2 =
+        new DistCpOptions.Builder(Collections.singletonList(srcBucketPath),
+            dstBucketPath).withUseDiff("snap1", "snap2").withSyncFolder(true)
+            .build();
+
+    distcpJob = new DistCp(conf, options2).execute();
+    verifyCopy(dstBucketPath, distcpJob, 1, 3);
+  }
+
+  @NotNull
+  private static Path createAndGetBucketPath() throws IOException {
+    OzoneBucket bucket =
+        TestDataUtil.createVolumeAndBucket(cluster, bucketLayout);
+    Path volumePath =
+        new Path(OZONE_URI_DELIMITER, bucket.getVolumeName());
+    Path bucketPath = new Path(volumePath, bucket.getName());
+    return bucketPath;
+  }
+
+  @Test
+  public void testDistcpWithSnapDiff2() throws Exception {
+    Path srcBucketPath = createAndGetBucketPath();
+    Path insideSrcBucket = new Path(srcBucketPath, "*");
+    Path dstBucketPath = createAndGetBucketPath();
+    // create 2 files on source
+    createFiles(srcBucketPath, 2);
+    // Create target directory/bucket
+    fs.mkdirs(dstBucketPath);
+
+    // perform normal distcp
+    final DistCpOptions options =
+        new DistCpOptions.Builder(Collections.singletonList(insideSrcBucket),
+            dstBucketPath).build();
+    options.appendToConf(conf);
+    Job distcpJob = new DistCp(conf, options).execute();
+    verifyCopy(dstBucketPath, distcpJob, 2, 2);
+
+    // take Snapshot snap1 on both source and target
+    createSnapshot(srcBucketPath, "snap1");
+    createSnapshot(dstBucketPath, "snap1");
+
+    // delete 1 file on source
+    deleteFiles(srcBucketPath, 1);
+    Assert.assertEquals(1, fs.listStatus(srcBucketPath).length);
+    createSnapshot(srcBucketPath, "snap2");
+
+    // perform distcp providing snapshot snap1.snap2 as arguments to
+    // copy only diff b/w them.
+    final DistCpOptions options2 =
+        new DistCpOptions.Builder(Collections.singletonList(srcBucketPath),
+            dstBucketPath).withUseDiff("snap1", "snap2").withSyncFolder(true)
+            .build();
+
+    distcpJob = new DistCp(conf, options2).execute();
+    verifyCopy(dstBucketPath, distcpJob, 0, 1);
+  }
+
+  @Test
+  public void testDistcpWithSnapDiff3() throws Exception {
+    Path srcBucketPath = createAndGetBucketPath();
+    Path insideSrcBucket = new Path(srcBucketPath, "*");
+    Path dstBucketPath = createAndGetBucketPath();
+    // create 2 files on source
+    createFiles(srcBucketPath, 2);
+    // Create target directory/bucket
+    fs.mkdirs(dstBucketPath);
+
+    // perform normal distcp
+    final DistCpOptions options =
+        new DistCpOptions.Builder(Collections.singletonList(insideSrcBucket),
+            dstBucketPath).build();
+    options.appendToConf(conf);
+    Job distcpJob = new DistCp(conf, options).execute();
+    verifyCopy(dstBucketPath, distcpJob, 2, 2);
+
+    // take Snapshot snap1 on both source and target
+    createSnapshot(srcBucketPath, "snap1");
+    createSnapshot(dstBucketPath, "snap1");
+
+    // delete 1 file on source
+    renameFiles(srcBucketPath, 1);
+    Assert.assertEquals(2, fs.listStatus(srcBucketPath).length);
+    createSnapshot(srcBucketPath, "snap2");
+
+    // perform distcp providing snapshot snap1.snap2 as arguments to
+    // copy only diff b/w them.
+    final DistCpOptions options2 =
+        new DistCpOptions.Builder(Collections.singletonList(srcBucketPath),
+            dstBucketPath).withUseDiff("snap1", "snap2").withSyncFolder(true)
+            .build();
+
+    distcpJob = new DistCp(conf, options2).execute();
+    verifyCopy(dstBucketPath, distcpJob, 0, 2);
+  }
+
+  private void deleteFiles(Path path, int fileCount) throws IOException {
+    FileStatus[] filesInPath = fs.listStatus(path);
+    Assert.assertTrue("Cannot delete more files than what is existing",
+        fileCount <= filesInPath.length);
+    for (int i = 0; i < fileCount; i++) {
+      Path toDelete = filesInPath[i].getPath();
+      fs.delete(toDelete, false);
+    }
+  }
+
+  private void renameFiles(Path path, int fileCount) throws IOException {
+    FileStatus[] filesInPath = fs.listStatus(path);
+    Assert.assertTrue("Cannot delete more files than what is existing",
+        fileCount <= filesInPath.length);
+    for (int i = 0; i < fileCount; i++) {
+      Path from = filesInPath[i].getPath();
+      Path to = new Path(from + "_renamed");
+      fs.rename(from, to);
+    }
+  }
+
+  private static void verifyCopy(Path dstBucketPath, Job distcpJob,
+      long expectedFilesToBeCopied, long expectedTotalFilesInDest)
+      throws IOException {
+    long filesCopied =
+        distcpJob.getCounters().findCounter(CopyMapper.Counter.COPY).getValue();
+    FileStatus[] destinationFileStatus = fs.listStatus(dstBucketPath);
+    Assert.assertEquals(expectedTotalFilesInDest, destinationFileStatus.length);
+    Assert.assertEquals(expectedFilesToBeCopied, filesCopied);
+  }
+
+  private static void createFiles(Path srcBucketPath, int fileCount)
+      throws IOException {
+    for (int i = 1; i <= fileCount; i++) {
+      String keyName = "key" + RandomStringUtils.randomNumeric(5);
+      Path file =
+          new Path(srcBucketPath, keyName);
+      ContractTestUtils.touch(fs, file);
+    }
+  }
+
+  private Path createSnapshot(Path path, String snapshotName)
+      throws IOException, InterruptedException, TimeoutException {
+    OFSPath ofsPath = new OFSPath(path, conf);
+    String volume = ofsPath.getVolumeName();
+    String bucket = ofsPath.getBucketName();
+    Path snapPath = fs.createSnapshot(path, snapshotName);
+    SnapshotInfo snapshotInfo =
+        cluster.getOzoneManager().getMetadataManager().getSnapshotInfoTable()
+            .get(SnapshotInfo.getTableKey(volume, bucket, snapshotName));
+    String snapshotDirName =
+        metaDir + OM_KEY_PREFIX + OM_SNAPSHOT_DIR + OM_KEY_PREFIX
+            + OM_DB_NAME + snapshotInfo.getCheckpointDirName() + OM_KEY_PREFIX
+            + "CURRENT";
+    GenericTestUtils.waitFor(() -> new File(snapshotDirName).exists(), 1000,
+        120000);
+    return snapPath;
+  }
+
+}

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOmSnapshot.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOmSnapshot.java
@@ -465,12 +465,16 @@ public class TestOmSnapshot {
     // Diff should have 2 entries
     SnapshotDiffReport diff2 = store.snapshotDiff(volume, bucket, snap2, snap3);
     Assert.assertEquals(2, diff2.getDiffList().size());
-    Assert.assertTrue(diff2.getDiffList().contains(
-        SnapshotDiffReport.DiffReportEntry
-            .of(SnapshotDiffReport.DiffType.CREATE, key2)));
-    Assert.assertTrue(diff2.getDiffList().contains(
-        SnapshotDiffReport.DiffReportEntry
-            .of(SnapshotDiffReport.DiffType.DELETE, key1)));
+    org.apache.hadoop.hdfs.protocol.SnapshotDiffReport.DiffReportEntry del =
+        new org.apache.hadoop.hdfs.protocol.SnapshotDiffReport.DiffReportEntry(
+            SnapshotDiffReport.DiffType.DELETE, key1.getBytes());
+    org.apache.hadoop.hdfs.protocol.SnapshotDiffReport.DiffReportEntry creat =
+        new org.apache.hadoop.hdfs.protocol.SnapshotDiffReport.DiffReportEntry(
+            SnapshotDiffReport.DiffType.CREATE, key2.getBytes());
+
+    Assert.assertTrue(diff2.getDiffList().contains(creat));
+
+    Assert.assertTrue(diff2.getDiffList().contains(del));
 
     // Rename Key2
     String key2Renamed = key2 + "_renamed";
@@ -480,8 +484,9 @@ public class TestOmSnapshot {
     SnapshotDiffReport diff3 = store.snapshotDiff(volume, bucket, snap3, snap4);
     Assert.assertEquals(1, diff3.getDiffList().size());
     Assert.assertTrue(diff3.getDiffList().contains(
-        SnapshotDiffReport.DiffReportEntry
-            .of(SnapshotDiffReport.DiffType.RENAME, key2, key2Renamed)));
+        new org.apache.hadoop.hdfs.protocol.SnapshotDiffReport.DiffReportEntry(
+            SnapshotDiffReport.DiffType.RENAME, key2.getBytes(),
+            key2Renamed.getBytes())));
 
 
     // Create a directory
@@ -497,8 +502,8 @@ public class TestOmSnapshot {
       dir1 = dir1 + OM_KEY_PREFIX;
     }
     Assert.assertTrue(diff4.getDiffList().contains(
-        SnapshotDiffReport.DiffReportEntry
-            .of(SnapshotDiffReport.DiffType.CREATE, dir1)));
+        new org.apache.hadoop.hdfs.protocol.SnapshotDiffReport.DiffReportEntry(
+            SnapshotDiffReport.DiffType.CREATE, dir1.getBytes())));
 
   }
 

--- a/hadoop-ozone/interface-storage/src/main/java/org/apache/hadoop/ozone/om/codec/OmDBDiffReportEntryCodec.java
+++ b/hadoop-ozone/interface-storage/src/main/java/org/apache/hadoop/ozone/om/codec/OmDBDiffReportEntryCodec.java
@@ -19,34 +19,39 @@ package org.apache.hadoop.ozone.om.codec;
 
 import java.io.IOException;
 import org.apache.hadoop.hdds.utils.db.Codec;
+import org.apache.hadoop.ozone.snapshot.SnapshotDiffReport;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos;
-import org.apache.hadoop.ozone.snapshot.SnapshotDiffReport.DiffReportEntry;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
 /**
  * Codec to encode DiffReportEntry as byte array.
  */
-public class OmDBDiffReportEntryCodec implements Codec<DiffReportEntry> {
+public class OmDBDiffReportEntryCodec implements Codec<org.apache.hadoop.hdfs.protocol.SnapshotDiffReport
+    .DiffReportEntry> {
 
   @Override
-  public byte[] toPersistedFormat(DiffReportEntry object)
+  public byte[] toPersistedFormat(org.apache.hadoop.hdfs.protocol.SnapshotDiffReport
+      .DiffReportEntry object)
       throws IOException {
     checkNotNull(object, "Null object can't be converted to byte array.");
-    return object.toProtobuf().toByteArray();
+    return SnapshotDiffReport.toProtobufDiffReportEntry(object).toByteArray();
   }
 
   @Override
-  public DiffReportEntry fromPersistedFormat(byte[] rawData)
+  public org.apache.hadoop.hdfs.protocol.SnapshotDiffReport
+      .DiffReportEntry fromPersistedFormat(byte[] rawData)
       throws IOException {
     checkNotNull(rawData, "Null byte array can't be converted to " +
         "real object.");
-    return DiffReportEntry.fromProtobuf(
+    return SnapshotDiffReport.fromProtobufDiffReportEntry(
         OzoneManagerProtocolProtos.DiffReportEntryProto.parseFrom(rawData));
   }
 
   @Override
-  public DiffReportEntry copyObject(DiffReportEntry object) {
+  public org.apache.hadoop.hdfs.protocol.SnapshotDiffReport
+      .DiffReportEntry copyObject(org.apache.hadoop.hdfs.protocol.SnapshotDiffReport
+      .DiffReportEntry object) {
     // Note: Not really a "copy". from OmDBDiffReportEntryCodec
     return object;
   }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/snapshot/RocksDbPersistentList.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/snapshot/RocksDbPersistentList.java
@@ -23,6 +23,7 @@ import java.util.Iterator;
 import org.apache.hadoop.hdds.utils.db.CodecRegistry;
 import org.apache.hadoop.hdds.utils.db.managed.ManagedRocksDB;
 import org.apache.hadoop.hdds.utils.db.managed.ManagedRocksIterator;
+import org.apache.hadoop.ozone.util.PersistentList;
 import org.rocksdb.ColumnFamilyHandle;
 import org.rocksdb.RocksDBException;
 

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/snapshot/TestRocksDbPersistentList.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/snapshot/TestRocksDbPersistentList.java
@@ -27,6 +27,7 @@ import org.apache.hadoop.hdds.utils.db.IntegerCodec;
 import org.apache.hadoop.hdds.utils.db.managed.ManagedColumnFamilyOptions;
 import org.apache.hadoop.hdds.utils.db.managed.ManagedOptions;
 import org.apache.hadoop.hdds.utils.db.managed.ManagedRocksDB;
+import org.apache.hadoop.ozone.util.PersistentList;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.params.ParameterizedTest;

--- a/hadoop-ozone/ozonefs-common/pom.xml
+++ b/hadoop-ozone/ozonefs-common/pom.xml
@@ -110,5 +110,10 @@
       <artifactId>powermock-api-mockito</artifactId>
       <scope>test</scope>
     </dependency>
+      <dependency>
+          <groupId>org.apache.hadoop</groupId>
+          <artifactId>hadoop-distcp</artifactId>
+        <scope>provided</scope>
+      </dependency>
   </dependencies>
 </project>

--- a/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicOzoneClientAdapterImpl.java
+++ b/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicOzoneClientAdapterImpl.java
@@ -63,6 +63,7 @@ import org.apache.hadoop.ozone.om.helpers.OmKeyLocationInfoGroup;
 import org.apache.hadoop.ozone.om.helpers.BucketLayout;
 import org.apache.hadoop.ozone.om.helpers.OzoneFileStatus;
 import org.apache.hadoop.ozone.security.OzoneTokenIdentifier;
+import org.apache.hadoop.ozone.snapshot.SnapshotDiffReport;
 import org.apache.hadoop.security.token.Token;
 import org.apache.hadoop.security.token.TokenRenewer;
 import org.apache.hadoop.ozone.om.helpers.OzoneFSUtils;
@@ -645,5 +646,13 @@ public class BasicOzoneClientAdapterImpl implements OzoneClientAdapter {
     return objectStore.createSnapshot(ofsPath.getVolumeName(),
         ofsPath.getBucketName(),
         snapshotName);
+  }
+
+  @Override
+  public SnapshotDiffReport getSnapshotDiffReport(Path snapshotDir,
+      String fromSnapshot, String toSnapshot) throws IOException {
+    OFSPath ofsPath = new OFSPath(snapshotDir, config);
+    return objectStore.snapshotDiff(ofsPath.getVolumeName(),
+        ofsPath.getBucketName(), fromSnapshot, toSnapshot);
   }
 }

--- a/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicRootedOzoneClientAdapterImpl.java
+++ b/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicRootedOzoneClientAdapterImpl.java
@@ -74,6 +74,7 @@ import org.apache.hadoop.ozone.om.helpers.OmKeyLocationInfoGroup;
 import org.apache.hadoop.ozone.om.helpers.OzoneFileStatus;
 import org.apache.hadoop.ozone.om.helpers.OzoneFSUtils;
 import org.apache.hadoop.ozone.security.OzoneTokenIdentifier;
+import org.apache.hadoop.ozone.snapshot.SnapshotDiffReport;
 import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.hadoop.security.token.Token;
 import org.apache.hadoop.security.token.TokenRenewer;
@@ -1281,5 +1282,13 @@ public class BasicRootedOzoneClientAdapterImpl
     return proxy.createSnapshot(ofsPath.getVolumeName(),
             ofsPath.getBucketName(),
             snapshotName);
+  }
+
+  @Override
+  public SnapshotDiffReport getSnapshotDiffReport(Path snapshotDir,
+      String fromSnapshot, String toSnapshot) throws IOException {
+    OFSPath ofsPath = new OFSPath(snapshotDir, config);
+    return proxy.snapshotDiff(ofsPath.getVolumeName(), ofsPath.getBucketName(),
+        fromSnapshot, toSnapshot);
   }
 }

--- a/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicRootedOzoneFileSystem.java
+++ b/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicRootedOzoneFileSystem.java
@@ -41,6 +41,7 @@ import org.apache.hadoop.hdds.conf.ConfigurationSource;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.conf.StorageUnit;
 import org.apache.hadoop.hdds.utils.LegacyHadoopConfigurationSource;
+import org.apache.hadoop.hdfs.protocol.SnapshotDiffReport;
 import org.apache.hadoop.ozone.OFSPath;
 import org.apache.hadoop.ozone.OzoneConfigKeys;
 import org.apache.hadoop.ozone.client.OzoneBucket;
@@ -1415,6 +1416,15 @@ public class BasicRootedOzoneFileSystem extends FileSystem {
     return new ContentSummary.Builder().length(summary[0]).
         fileCount(summary[2]).directoryCount(summary[3]).
         spaceConsumed(summary[1]).build();
+  }
+
+  public SnapshotDiffReport getSnapshotDiffReport(final Path snapshotDir,
+      final String fromSnapshot, final String toSnapshot) throws IOException {
+    OFSPath ofsPath =
+        new OFSPath(snapshotDir, OzoneConfiguration.of(getConf()));
+    Preconditions.checkArgument(ofsPath.isBucket(),
+        "Unsupported : Path is not a bucket");
+    return adapter.getSnapshotDiffReport(snapshotDir, fromSnapshot, toSnapshot);
   }
 
 }

--- a/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/OzoneClientAdapter.java
+++ b/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/OzoneClientAdapter.java
@@ -27,6 +27,7 @@ import org.apache.hadoop.crypto.key.KeyProvider;
 import org.apache.hadoop.fs.FileChecksum;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.ozone.security.OzoneTokenIdentifier;
+import org.apache.hadoop.ozone.snapshot.SnapshotDiffReport;
 import org.apache.hadoop.security.token.Token;
 
 /**
@@ -86,4 +87,7 @@ public interface OzoneClientAdapter {
   FileChecksum getFileChecksum(String keyName, long length) throws IOException;
 
   String createSnapshot(String pathStr, String snapshotName) throws IOException;
+
+  SnapshotDiffReport getSnapshotDiffReport(Path snapshotDir,
+      String fromSnapshot, String toSnapshot) throws IOException;
 }

--- a/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/OzoneDistcpSync.java
+++ b/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/OzoneDistcpSync.java
@@ -1,0 +1,78 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with this
+ * work for additional information regarding copyright ownership.  The ASF
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.hadoop.fs.ozone;
+
+
+
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.hdfs.protocol.SnapshotDiffReport;
+import org.apache.hadoop.tools.DistCpSync;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+import java.io.IOException;
+
+/**
+ * Ozone's DistcpSync implementation.
+ */
+public class OzoneDistcpSync extends DistCpSync {
+
+  private static final Logger LOG =
+      LoggerFactory.getLogger(OzoneDistcpSync.class);
+
+  @Override
+  public void checkFilesystemSupport(FileSystem srcFs, FileSystem tgtFs) {
+    if (!(srcFs instanceof BasicRootedOzoneFileSystem)) {
+      throw new IllegalArgumentException(
+          "Unsupported source file system: " + srcFs.getScheme() + "://. "
+              + "Supported file systems: ofs. If scheme is either " +
+              "hdfs/webhdfs use respective distcp.sync.class.name " +
+              "in the configuration ");
+    }
+    if (!(tgtFs instanceof BasicRootedOzoneFileSystem)) {
+      throw new IllegalArgumentException(
+          "Unsupported source file system: " + srcFs.getScheme() + "://. "
+              + "Supported file systems: ofs. If scheme is either " +
+              "hdfs/webhdfs use respective distcp.sync.class.name " +
+              "in the configuration ");
+    }
+
+  }
+
+  @Override
+  protected SnapshotDiffReport getSnapshotDiffReport(Path ssDir, FileSystem fs,
+      String from, String to) throws IOException {
+    if (fs instanceof BasicRootedOzoneFileSystem) {
+      BasicRootedOzoneFileSystem ofs = (BasicRootedOzoneFileSystem) fs;
+      return ofs.getSnapshotDiffReport(ssDir, from, to);
+    } else {
+      throw new IllegalArgumentException(
+          "Unsupported source file system: " + fs.getScheme() + "://. "
+              + "Supported file systems: ofs. If scheme is either " +
+              "hdfs/webhdfs use respective distcp.sync.class.name " +
+              "in the configuration ");
+    }
+  }
+
+  @Override
+  protected boolean checkNoChange(FileSystem fs, Path path) {
+    // TODO fix HDDS-7905.
+    return true;
+  }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -63,7 +63,8 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
 
   <properties>
     <hadoop2.version>2.7.3</hadoop2.version>
-    <hadoop.version>3.3.4</hadoop.version>
+    <!--<version>3.4.0-SNAPSHOT</version>-->
+    <hadoop.version>3.4.0-SNAPSHOT</hadoop.version>
 
     <!-- version for hdds/ozone components -->
     <hdds.version>${ozone.version}</hdds.version>
@@ -177,6 +178,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
     <disruptor.version>3.4.2</disruptor.version>
     <reload4j.version>1.2.22</reload4j.version>
 
+    <kerby.version>2.0.2</kerby.version>
     <kotlin.version>1.6.21</kotlin.version>
     <metainf-services.version>1.8</metainf-services.version>
     <picocli.version>4.6.1</picocli.version>


### PR DESCRIPTION
## What changes were proposed in this pull request?
Main changes
1. Make `org.apache.hadoop.ozone.snapshot.SnapshotDiffReport` extend `org.apache.hadoop.hdfs.protocol.SnapshotDiffReport`
2. Add Ozone's DistcpSync implementation that provides flexibility to use Ozone specific checks/ functions.

Changes to pom.xml
1. added `hadoop-distcp` dependency to `ozonefs-common`
2. added `hadoop-hdfs-client` to `ozone-common` (required to access `org.apache.hadoop.hdfs.protocol.SnapshotDiffReport`)
3. update `hadoop` version to` 3.4.0-Snapshot` that contains changes for distcp to work with ozone with snapshots.
4. Had to update  `kerby.version` as it was throwing Dependency convergence error for org.apache.kerby:kerb-core:jar:1.0.1  since latest version of hadoop uses this version.

this change requires latest version of hadoop that contains [HDFS-16911.](https://issues.apache.org/jira/browse/HDFS-16911)

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-7916

## How was this patch tested?
Unit tests