### PR TITLE
HDDS-7917. EC: ECBlockInputStream should try spare replicas on error

### DIFF
--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/storage/ExtendedInputStream.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/storage/ExtendedInputStream.java
@@ -46,12 +46,7 @@ public abstract class ExtendedInputStream extends InputStream
 
   @Override
   public synchronized int read(byte[] b, int off, int len) throws IOException {
-    ByteReaderStrategy strategy = new ByteArrayReader(b, off, len);
-    int bufferLen = strategy.getTargetLength();
-    if (bufferLen == 0) {
-      return 0;
-    }
-    return readWithStrategy(strategy);
+    return read(ByteBuffer.wrap(b, off, len));
   }
 
   @Override

--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/storage/ExtendedInputStream.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/storage/ExtendedInputStream.java
@@ -46,7 +46,12 @@ public abstract class ExtendedInputStream extends InputStream
 
   @Override
   public synchronized int read(byte[] b, int off, int len) throws IOException {
-    return read(ByteBuffer.wrap(b, off, len));
+    ByteReaderStrategy strategy = new ByteArrayReader(b, off, len);
+    int bufferLen = strategy.getTargetLength();
+    if (bufferLen == 0) {
+      return 0;
+    }
+    return readWithStrategy(strategy);
   }
 
   @Override

--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/ozone/client/io/BadDataLocationException.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/ozone/client/io/BadDataLocationException.java
@@ -20,6 +20,8 @@ package org.apache.hadoop.ozone.client.io;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
 
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * Exception used to indicate a problem with a specific block location, allowing
@@ -27,30 +29,46 @@ import java.io.IOException;
  */
 public class BadDataLocationException extends IOException {
 
-  private DatanodeDetails failedLocation;
+  private List<DatanodeDetails> failedLocations = new ArrayList<>();
+  private int failedLocationIndex;
 
   public BadDataLocationException(DatanodeDetails dn) {
     super();
-    failedLocation = dn;
+    failedLocations.add(dn);
   }
 
   public BadDataLocationException(DatanodeDetails dn, String message) {
     super(message);
-    failedLocation = dn;
+    failedLocations.add(dn);
   }
 
   public BadDataLocationException(DatanodeDetails dn, String message,
       Throwable ex) {
     super(message, ex);
-    failedLocation = dn;
+    failedLocations.add(dn);
   }
 
   public BadDataLocationException(DatanodeDetails dn, Throwable ex) {
     super(ex);
-    failedLocation = dn;
+    failedLocations.add(dn);
   }
 
-  public DatanodeDetails getFailedLocation() {
-    return failedLocation;
+  public BadDataLocationException(DatanodeDetails dn, int failedIndex,
+      Throwable ex) {
+    super(ex);
+    failedLocations.add(dn);
+    failedLocationIndex = failedIndex;
+  }
+
+  public List<DatanodeDetails> getFailedLocations() {
+    return failedLocations;
+  }
+
+  public void addFailedLocations(List<DatanodeDetails> dns) {
+    failedLocations.addAll(dns);
+  }
+
+  public int getFailedLocationIndex() {
+    return failedLocationIndex;
   }
 }

--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/ozone/client/io/ECBlockInputStream.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/ozone/client/io/ECBlockInputStream.java
@@ -36,8 +36,14 @@ import org.slf4j.LoggerFactory;
 
 import java.io.EOFException;
 import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
 import java.util.function.Function;
 
 /**
@@ -58,6 +64,9 @@ public class ECBlockInputStream extends BlockExtendedInputStream {
   private final BlockLocationInfo blockInfo;
   private final DatanodeDetails[] dataLocations;
   private final BlockExtendedInputStream[] blockStreams;
+  private final Map<Integer, LinkedList<DatanodeDetails>> spareDataLocations
+      = new HashMap<>();
+  private final List<DatanodeDetails> failedLocations = new ArrayList<>();
   private final int maxLocations;
 
   private long position = 0;
@@ -263,7 +272,13 @@ public class ECBlockInputStream extends BlockExtendedInputStream {
       throw new IndexOutOfBoundsException("The index " + index + " is greater "
           + "than the EC Replication Config (" + repConfig + ")");
     }
-    dataLocations[index - 1] = location;
+    int arrayIndex = index - 1;
+    if (dataLocations[arrayIndex] == null) {
+      dataLocations[arrayIndex] = location;
+    } else {
+      spareDataLocations.computeIfAbsent(arrayIndex,
+          k -> new LinkedList<>()).add(location);
+    }
   }
 
   protected long blockLength() {
@@ -272,6 +287,40 @@ public class ECBlockInputStream extends BlockExtendedInputStream {
 
   protected long remaining() {
     return blockLength() - position;
+  }
+
+  @Override
+  public synchronized int read(ByteBuffer byteBuffer) throws IOException {
+    while (true) {
+      int currentBufferPosition = byteBuffer.position();
+      long currentPosition = getPos();
+      try {
+        return super.read(byteBuffer);
+      } catch (BadDataLocationException e) {
+        int failedIndex = e.getFailedLocationIndex();
+        if (shouldRetryFailedRead(failedIndex)) {
+          byteBuffer.position(currentBufferPosition);
+          seek(currentPosition);
+        } else {
+          e.addFailedLocations(failedLocations);
+          throw e;
+        }
+      }
+    }
+  }
+
+  private boolean shouldRetryFailedRead(int failedIndex) throws IOException {
+    LinkedList<DatanodeDetails> spare = spareDataLocations.get(failedIndex);
+    if (spare != null && spare.size() > 0) {
+      failedLocations.add(dataLocations[failedIndex]);
+      dataLocations[failedIndex] = spare.removeFirst();
+      if (blockStreams[failedIndex] != null) {
+        blockStreams[failedIndex].close();
+        blockStreams[failedIndex] = null;
+      }
+      return true;
+    }
+    return false;
   }
 
   /**
@@ -294,15 +343,15 @@ public class ECBlockInputStream extends BlockExtendedInputStream {
 
     int totalRead = 0;
     while (strategy.getTargetLength() > 0 && remaining() > 0) {
+      int currentIndex = currentStreamIndex();
       try {
-        int currentIndex = currentStreamIndex();
         BlockExtendedInputStream stream = getOrOpenStream(currentIndex);
         int read = readFromStream(stream, strategy);
         totalRead += read;
         position += read;
       } catch (IOException ioe) {
         throw new BadDataLocationException(
-            dataLocations[currentStreamIndex()], ioe);
+            dataLocations[currentIndex], currentIndex, ioe);
       }
     }
     return totalRead;

--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/ozone/client/io/ECBlockInputStream.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/ozone/client/io/ECBlockInputStream.java
@@ -290,6 +290,11 @@ public class ECBlockInputStream extends BlockExtendedInputStream {
   }
 
   @Override
+  public synchronized int read(byte[] b, int off, int len) throws IOException {
+    return read(ByteBuffer.wrap(b, off, len));
+  }
+
+  @Override
   public synchronized int read(ByteBuffer byteBuffer) throws IOException {
     while (true) {
       int currentBufferPosition = byteBuffer.position();

--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/ozone/client/io/ECBlockInputStreamProxy.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/ozone/client/io/ECBlockInputStreamProxy.java
@@ -182,7 +182,7 @@ public class ECBlockInputStreamProxy extends BlockExtendedInputStream {
         }
 
         failoverToReconstructionRead(
-            ((BadDataLocationException) e).getFailedLocation(), lastPosition);
+            ((BadDataLocationException) e).getFailedLocations(), lastPosition);
         buf.reset();
         totalRead += read(buf);
       } else {
@@ -193,10 +193,9 @@ public class ECBlockInputStreamProxy extends BlockExtendedInputStream {
   }
 
   private synchronized void failoverToReconstructionRead(
-      DatanodeDetails badLocation, long lastPosition) throws IOException {
-    if (badLocation != null) {
-      failedLocations.add(badLocation);
-    }
+      List<DatanodeDetails> badLocations, long lastPosition)
+      throws IOException {
+    failedLocations.addAll(badLocations);
     blockReader.close();
     reconstructionReader = true;
     createBlockReader();

--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/ozone/client/io/ECBlockInputStreamProxy.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/ozone/client/io/ECBlockInputStreamProxy.java
@@ -195,7 +195,9 @@ public class ECBlockInputStreamProxy extends BlockExtendedInputStream {
   private synchronized void failoverToReconstructionRead(
       List<DatanodeDetails> badLocations, long lastPosition)
       throws IOException {
-    failedLocations.addAll(badLocations);
+    if (badLocations != null) {
+      failedLocations.addAll(badLocations);
+    }
     blockReader.close();
     reconstructionReader = true;
     createBlockReader();

--- a/hadoop-hdds/client/src/test/java/org/apache/hadoop/ozone/client/io/TestECBlockInputStream.java
+++ b/hadoop-hdds/client/src/test/java/org/apache/hadoop/ozone/client/io/TestECBlockInputStream.java
@@ -425,8 +425,13 @@ public class TestECBlockInputStream {
       read = ecb.read(buf);
       Assertions.assertEquals(3 * ONEMB, read);
 
-      // Now make the spare one error on the next read and we should get an
-      // error with two failed locations
+      // Now make the spare one error on the next read, and we should get an
+      // error with two failed locations. As each stream is created, a new
+      // stream will be created in the stream factory. Our read will read from
+      // DNs with EC indexes 1 - 3 first, creating streams 0 to 2. Then when
+      // stream(0) is failed for index=1 a new steam is created for the
+      // alternative index=1 at stream(3). Hence, to make it error we set
+      // stream(3) to throw as below.
       streamFactory.getBlockStreams().get(3).setThrowException(true);
       buf.clear();
       BadDataLocationException e =

--- a/hadoop-hdds/client/src/test/java/org/apache/hadoop/ozone/client/io/TestECBlockInputStream.java
+++ b/hadoop-hdds/client/src/test/java/org/apache/hadoop/ozone/client/io/TestECBlockInputStream.java
@@ -40,6 +40,7 @@ import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
@@ -393,7 +394,51 @@ public class TestECBlockInputStream {
       BadDataLocationException e =
           assertThrows(BadDataLocationException.class, () -> ecb.read(buf));
       Assertions.assertEquals(2,
-          keyInfo.getPipeline().getReplicaIndex(e.getFailedLocation()));
+          keyInfo.getPipeline().getReplicaIndex(e.getFailedLocations().get(0)));
+    }
+  }
+
+  @Test
+  public void testNoErrorIfSpareLocationToRead() throws IOException {
+    repConfig = new ECReplicationConfig(3, 2, ECReplicationConfig.EcCodec.RS,
+        ONEMB);
+    Map<DatanodeDetails, Integer> datanodes = new LinkedHashMap<>();
+    for (int i = 1; i <= repConfig.getRequiredNodes(); i++) {
+      datanodes.put(MockDatanodeDetails.randomDatanodeDetails(), i);
+    }
+    // Add a second index = 1
+    datanodes.put(MockDatanodeDetails.randomDatanodeDetails(), 1);
+
+    BlockLocationInfo keyInfo =
+        ECStreamTestUtil.createKeyInfo(repConfig, 8 * ONEMB, datanodes);
+    try (ECBlockInputStream ecb = new ECBlockInputStream(repConfig,
+        keyInfo, true, null, null, streamFactory)) {
+      // Read a full stripe to ensure all streams are created in the stream
+      // factory
+      ByteBuffer buf = ByteBuffer.allocate(3 * ONEMB);
+      int read = ecb.read(buf);
+      Assertions.assertEquals(3 * ONEMB, read);
+      // Now make replication index 1 error on the next read but as there is a
+      // spare it should read from it with no errors
+      streamFactory.getBlockStreams().get(0).setThrowException(true);
+      buf.clear();
+      read = ecb.read(buf);
+      Assertions.assertEquals(3 * ONEMB, read);
+
+      // Now make the spare one error on the next read and we should get an
+      // error with two failed locations
+      streamFactory.getBlockStreams().get(3).setThrowException(true);
+      buf.clear();
+      BadDataLocationException e =
+          assertThrows(BadDataLocationException.class, () -> ecb.read(buf));
+      List<DatanodeDetails> failed = e.getFailedLocations();
+      // Expect 2 different DNs reported as failure
+      Assertions.assertEquals(2, failed.size());
+      Assertions.assertNotEquals(failed.get(0), failed.get(1));
+      // Both failures should map to index = 1.
+      for (DatanodeDetails dn : failed) {
+        Assertions.assertEquals(1, datanodes.get(dn));
+      }
     }
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?


In ECBlockInputStream, it is possible to have multiple locations for a single replicaIndex, if, say one replica is decommissioned but still online and there is also an IN_SERVICE replica.

Similar for Maintenance - there can be maintenance and in_service replicas, or just over replicated replicas.

As things stand, if a read to an index fails, it causes a failover to reconstruction read, but there are occassions where it would be possible to read from the spare replica and no need to fall back to reconstruction.

This PR allows spare replicas to be tried before giving up with an error.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-7917

## How was this patch tested?

Added a new unit test.
