### PR TITLE
HDDS-7920. User cannot list their own volumes without access to root volume

### DIFF
--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
@@ -2592,8 +2592,13 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
       metrics.incNumVolumeLists();
       if (isAclEnabled) {
         String remoteUserName = remoteUserUgi.getShortUserName();
+        // Convert userName to short username
+        final UserGroupInformation ugiUserParam =
+            UserGroupInformation.createRemoteUser(userName);
+        final String userParamShortName = ugiUserParam.getShortUserName();
         // if not admin nor list my own volumes, check ACL.
-        if (!remoteUserName.equals(userName) && !isAdmin(remoteUserUgi)) {
+        if (!remoteUserName.equals(userParamShortName)
+            && !isAdmin(remoteUserUgi)) {
           omMetadataReader.checkAcls(ResourceType.VOLUME,
               StoreType.OZONE, ACLType.LIST,
               OzoneConsts.OZONE_ROOT, null, null);

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
@@ -196,6 +196,7 @@ import org.apache.hadoop.ozone.upgrade.UpgradeFinalizer.StatusAndMessages;
 import org.apache.hadoop.hdds.ExitManager;
 import org.apache.hadoop.ozone.util.OzoneVersionInfo;
 import org.apache.hadoop.ozone.util.ShutdownHookManager;
+import org.apache.hadoop.security.HadoopKerberosName;
 import org.apache.hadoop.security.SecurityUtil;
 import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.hadoop.security.UserGroupInformation.AuthenticationMethod;
@@ -2593,9 +2594,8 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
       if (isAclEnabled) {
         String remoteUserName = remoteUserUgi.getShortUserName();
         // Convert userName to short username
-        final UserGroupInformation ugiUserParam =
-            UserGroupInformation.createRemoteUser(userName);
-        final String userParamShortName = ugiUserParam.getShortUserName();
+        String userParamShortName = new HadoopKerberosName(userName)
+            .getShortName();
         // if not admin nor list my own volumes, check ACL.
         if (!remoteUserName.equals(userParamShortName)
             && !isAdmin(remoteUserUgi)) {


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR is to fix the issue that users without Admin permission got PERMISSION_DENIED when listing their volume.
```
>> kinit -kt compose/_keytabs/testuser.keytab testuser/om@EXAMPLE.COM
>> ozone sh volume list 
PERMISSION_DENIED User testuser/om@EXAMPLE.COM doesn't have LIST permission to access volume Volume:/
```

Please see details and analysis in the related JIRA.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-7920

## How was this patch tested?

Tested manually in docker with `testuser/om@EXAMPLE.COM` (not an admin) in  `testuser.keytab`.
```
sh-4.2$ kinit -kt compose/_keytabs/testuser.keytab testuser/om@EXAMPLE.COM
sh-4.2$ ozone sh volume list
[ ]
sh-4.2$
```
I couldn't find any existing security test-suit to add this test to.