### PR TITLE
HDDS-7816. Add DataNode list to the SCM WebUI

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/audit/S3GAction.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/audit/S3GAction.java
@@ -44,7 +44,8 @@ public enum S3GAction implements AuditAction {
   INIT_MULTIPART_UPLOAD,
   COMPLETE_MULTIPART_UPLOAD,
   ABORT_MULTIPART_UPLOAD,
-  DELETE_KEY;
+  DELETE_KEY,
+  CREATE_DIRECTORY;
 
   @Override
   public String getAction() {

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/utils/db/DatanodeDBProfile.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/utils/db/DatanodeDBProfile.java
@@ -57,6 +57,7 @@ public abstract class DatanodeDBProfile {
     case SSD:
       return new SSD();
     case DISK:
+    case TEST:
       return new Disk();
     default:
       throw new IllegalArgumentException(

--- a/hadoop-hdds/rocksdb-checkpoint-differ/src/main/java/org/apache/ozone/rocksdiff/RocksDBCheckpointDiffer.java
+++ b/hadoop-hdds/rocksdb-checkpoint-differ/src/main/java/org/apache/ozone/rocksdiff/RocksDBCheckpointDiffer.java
@@ -56,6 +56,7 @@ import java.nio.file.StandardOpenOption;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.HashSet;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -823,7 +824,9 @@ public class RocksDBCheckpointDiffer implements AutoCloseable {
 
   public void filterRelevantSstFiles(Set<String> inputFiles,
       Map<String, String> tableToPrefixMap) {
-    for (String filename : inputFiles) {
+    for (Iterator<String> fileIterator =
+         inputFiles.iterator(); fileIterator.hasNext();) {
+      String filename = fileIterator.next();
       String filepath = getAbsoluteSstFilePath(filename);
       try (SstFileReader sstFileReader = new SstFileReader(new Options())) {
         sstFileReader.open(filepath);
@@ -841,11 +844,11 @@ public class RocksDBCheckpointDiffer implements AutoCloseable {
               .constructBucketKey(new String(iterator.key(), UTF_8));
           if (!RocksDiffUtils
               .isKeyWithPrefixPresent(prefix, firstKey, lastKey)) {
-            inputFiles.remove(filename);
+            fileIterator.remove();
           }
         } else {
           // entry from other tables
-          inputFiles.remove(filename);
+          fileIterator.remove();
         }
       } catch (RocksDBException e) {
         e.printStackTrace();

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ContainerHealthResult.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ContainerHealthResult.java
@@ -278,6 +278,7 @@ public class ContainerHealthResult {
     private final int excessRedundancy;
     private final boolean sufficientlyReplicatedAfterPending;
     private boolean hasMismatchedReplicas;
+    private boolean isSafelyOverReplicated;
 
     public OverReplicatedHealthResult(ContainerInfo containerInfo,
         int excessRedundancy, boolean replicatedOkWithPending) {
@@ -316,6 +317,14 @@ public class ContainerHealthResult {
 
     public void setHasMismatchedReplicas(boolean hasMismatchedReplicas) {
       this.hasMismatchedReplicas = hasMismatchedReplicas;
+    }
+
+    public boolean isSafelyOverReplicated() {
+      return isSafelyOverReplicated;
+    }
+
+    public void setIsSafelyOverReplicated(boolean isSafelyOverReplicated) {
+      this.isSafelyOverReplicated = isSafelyOverReplicated;
     }
   }
 }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/LegacyRatisContainerReplicaCount.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/LegacyRatisContainerReplicaCount.java
@@ -48,4 +48,15 @@ public class LegacyRatisContainerReplicaCount extends
   protected int healthyReplicaCountAdapter() {
     return -getMisMatchedReplicaCount();
   }
+
+  /**
+   * For LegacyReplicationManager, unhealthy replicas are all replicas that
+   * don't match the container's state. For a CLOSED container with replicas
+   * {CLOSED, CLOSING, UNHEALTHY, OPEN}, unhealthy replica count is 3. 2
+   * mismatches (CLOSING, OPEN) + 1 UNHEALTHY = 3.
+   */
+  @Override
+  public int getUnhealthyReplicaCountAdapter() {
+    return getMisMatchedReplicaCount();
+  }
 }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ReplicationManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ReplicationManager.java
@@ -48,6 +48,7 @@ import org.apache.hadoop.hdds.scm.container.replication.health.HealthCheck;
 import org.apache.hadoop.hdds.scm.container.replication.health.OpenContainerHandler;
 import org.apache.hadoop.hdds.scm.container.replication.health.QuasiClosedContainerHandler;
 import org.apache.hadoop.hdds.scm.container.replication.health.RatisReplicationCheckHandler;
+import org.apache.hadoop.hdds.scm.container.replication.health.RatisUnhealthyReplicationCheckHandler;
 import org.apache.hadoop.hdds.scm.events.SCMEvents;
 import org.apache.hadoop.hdds.scm.ha.SCMContext;
 import org.apache.hadoop.hdds.scm.ha.SCMService;
@@ -250,7 +251,8 @@ public class ReplicationManager implements SCMService {
         .addNext(new DeletingContainerHandler(this))
         .addNext(ecReplicationCheckHandler)
         .addNext(ratisReplicationCheckHandler)
-        .addNext(new ClosedWithUnhealthyReplicasHandler(this));
+        .addNext(new ClosedWithUnhealthyReplicasHandler(this))
+        .addNext(new RatisUnhealthyReplicationCheckHandler());
     start();
   }
 

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ReplicationManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ReplicationManager.java
@@ -265,7 +265,9 @@ public class ReplicationManager implements SCMService {
       LOG.info("Starting Replication Monitor Thread.");
       running = true;
       metrics = ReplicationManagerMetrics.create(this);
-      legacyReplicationManager.setMetrics(metrics);
+      if (rmConf.isLegacyEnabled()) {
+        legacyReplicationManager.setMetrics(metrics);
+      }
       containerReplicaPendingOps.setReplicationMetrics(metrics);
       startSubServices();
     } else {
@@ -297,7 +299,9 @@ public class ReplicationManager implements SCMService {
       underReplicatedProcessorThread.interrupt();
       overReplicatedProcessorThread.interrupt();
       running = false;
-      legacyReplicationManager.clearInflightActions();
+      if (rmConf.isLegacyEnabled()) {
+        legacyReplicationManager.clearInflightActions();
+      }
       metrics.unRegister();
       replicationMonitor.interrupt();
     } else {
@@ -347,7 +351,7 @@ public class ReplicationManager implements SCMService {
         break;
       }
       report.increment(c.getState());
-      if (c.getReplicationType() != EC) {
+      if (c.getReplicationType() != EC && rmConf.isLegacyEnabled()) {
         legacyReplicationManager.processContainer(c, report);
         continue;
       }
@@ -757,7 +761,12 @@ public class ReplicationManager implements SCMService {
     if (container.getReplicationType() == EC) {
       return getECContainerReplicaCount(container);
     }
-    return legacyReplicationManager.getContainerReplicaCount(container);
+
+    if (rmConf.isLegacyEnabled()) {
+      return legacyReplicationManager.getContainerReplicaCount(container);
+    } else {
+      return getRatisContainerReplicaCount(container);
+    }
   }
 
   /**
@@ -803,6 +812,30 @@ public class ReplicationManager implements SCMService {
    */
   @ConfigGroup(prefix = "hdds.scm.replication")
   public static class ReplicationManagerConfiguration {
+    /**
+     * True if LegacyReplicationManager should be used for RATIS containers.
+     */
+    @Config(key = "enable.legacy",
+        type = ConfigType.BOOLEAN,
+        defaultValue = "true",
+        tags = {SCM, OZONE},
+        description = "This configuration decides if " +
+            "LegacyReplicationManager should be used to handle RATIS " +
+            "containers. Default is true, which means " +
+            "LegacyReplicationManager will handle RATIS containers while " +
+            "ReplicationManager will handle EC containers. If false, " +
+            "ReplicationManager will handle both RATIS and EC."
+    )
+    private boolean enableLegacy = true;
+
+    public boolean isLegacyEnabled() {
+      return enableLegacy;
+    }
+
+    public void setEnableLegacy(boolean enableLegacy) {
+      this.enableLegacy = enableLegacy;
+    }
+
     /**
      * The frequency in which ReplicationMonitor thread should run.
      */
@@ -1004,9 +1037,11 @@ public class ReplicationManager implements SCMService {
           lastTimeToBeReadyInMillis = clock.millis();
           serviceStatus = ServiceStatus.RUNNING;
         }
-        //now, as the current scm is leader and it`s state is up-to-date,
-        //we need to take some action about replicated inflight move options.
-        legacyReplicationManager.notifyStatusChanged();
+        if (rmConf.isLegacyEnabled()) {
+          //now, as the current scm is leader and it`s state is up-to-date,
+          //we need to take some action about replicated inflight move options.
+          legacyReplicationManager.notifyStatusChanged();
+        }
       } else {
         serviceStatus = ServiceStatus.PAUSING;
       }
@@ -1086,6 +1121,16 @@ public class ReplicationManager implements SCMService {
         containerReplicaPendingOps.getPendingOps(containerInfo.containerID());
     return new ECContainerReplicaCount(
         containerInfo, replicas, pendingOps, maintenanceRedundancy);
+  }
+
+  private RatisContainerReplicaCount getRatisContainerReplicaCount(
+      ContainerInfo containerInfo) throws ContainerNotFoundException {
+    Set<ContainerReplica> replicas =
+        containerManager.getContainerReplicas(containerInfo.containerID());
+    List<ContainerReplicaOp> pendingOps =
+        containerReplicaPendingOps.getPendingOps(containerInfo.containerID());
+    return new RatisContainerReplicaCount(containerInfo, replicas, pendingOps,
+        ratisMaintenanceMinReplicas, false);
   }
   
   public ContainerReplicaPendingOps getContainerReplicaPendingOps() {

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/health/RatisReplicationCheckHandler.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/health/RatisReplicationCheckHandler.java
@@ -158,7 +158,7 @@ public class RatisReplicationCheckHandler extends AbstractCheck {
     int minReplicasForMaintenance = request.getMaintenanceRedundancy();
     RatisContainerReplicaCount replicaCount =
         new RatisContainerReplicaCount(container, replicas, replicaPendingOps,
-            minReplicasForMaintenance);
+            minReplicasForMaintenance, false);
 
     boolean sufficientlyReplicated
         = replicaCount.isSufficientlyReplicated(false);

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/health/RatisUnhealthyReplicationCheckHandler.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/health/RatisUnhealthyReplicationCheckHandler.java
@@ -1,0 +1,196 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.hdds.scm.container.replication.health;
+
+import com.google.common.annotations.VisibleForTesting;
+import org.apache.hadoop.hdds.scm.container.ContainerInfo;
+import org.apache.hadoop.hdds.scm.container.ReplicationManagerReport;
+import org.apache.hadoop.hdds.scm.container.replication.ContainerCheckRequest;
+import org.apache.hadoop.hdds.scm.container.replication.ContainerHealthResult;
+import org.apache.hadoop.hdds.scm.container.replication.RatisContainerReplicaCount;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationType.RATIS;
+
+/**
+ * This class handles UNHEALTHY RATIS replicas. Its responsibilities include:
+ * <ul>
+ *   <li>If only unhealthy replicas exist, check if there are replication
+ *   factor number of replicas and queue them for under/over replication if
+ *   needed.
+ *   </li>
+ *   <li>If there is perfect replication of healthy replicas, remove any
+ *   excess unhealthy replicas.
+ *   </li>
+ * </ul>
+ */
+public class RatisUnhealthyReplicationCheckHandler extends AbstractCheck {
+  public static final Logger LOG = LoggerFactory.getLogger(
+      RatisUnhealthyReplicationCheckHandler.class);
+
+  @Override
+  public boolean handle(ContainerCheckRequest request) {
+    if (request.getContainerInfo().getReplicationType() != RATIS) {
+      // This handler is only for Ratis containers.
+      return false;
+    }
+    ReplicationManagerReport report = request.getReport();
+    ContainerInfo container = request.getContainerInfo();
+
+    /*
+    First, verify there's perfect replication without considering UNHEALTHY
+    replicas. If not, we return false. Replication issues without UNHEALTHY
+    replicas should be solved first.
+     */
+    if (!verifyPerfectReplication(request)) {
+      return false;
+    }
+
+    // Now, consider UNHEALTHY replicas when calculating replication status
+    RatisContainerReplicaCount replicaCount =
+        new RatisContainerReplicaCount(container,
+            request.getContainerReplicas(), request.getPendingOps(),
+            request.getMaintenanceRedundancy(), true);
+    if (replicaCount.getUnhealthyReplicaCount() == 0) {
+      LOG.debug("No UNHEALTHY replicas are present for container {} with " +
+          "replicas [{}].", container, request.getContainerReplicas());
+      return false;
+    } else {
+      LOG.debug("Container {} has UNHEALTHY replicas. Checking its " +
+          "replication status.", container);
+      report.incrementAndSample(ReplicationManagerReport.HealthState.UNHEALTHY,
+          container.containerID());
+    }
+
+    ContainerHealthResult health = checkReplication(request);
+    if (health.getHealthState()
+        == ContainerHealthResult.HealthState.UNDER_REPLICATED) {
+      ContainerHealthResult.UnderReplicatedHealthResult underHealth
+          = ((ContainerHealthResult.UnderReplicatedHealthResult) health);
+      report.incrementAndSample(
+          ReplicationManagerReport.HealthState.UNDER_REPLICATED,
+          container.containerID());
+      LOG.debug("Container {} is Under Replicated. isReplicatedOkAfterPending" +
+              " is [{}]. isUnrecoverable is [{}]. hasHealthyReplicas is [{}].",
+          container,
+          underHealth.isReplicatedOkAfterPending(),
+          underHealth.isUnrecoverable(), underHealth.hasHealthyReplicas());
+
+      if (!underHealth.isReplicatedOkAfterPending()) {
+        request.getReplicationQueue().enqueue(underHealth);
+      }
+      return true;
+    }
+
+    if (health.getHealthState()
+        == ContainerHealthResult.HealthState.OVER_REPLICATED) {
+      report.incrementAndSample(
+          ReplicationManagerReport.HealthState.OVER_REPLICATED,
+          container.containerID());
+      ContainerHealthResult.OverReplicatedHealthResult overHealth
+          = ((ContainerHealthResult.OverReplicatedHealthResult) health);
+      LOG.debug("Container {} is Over Replicated. isReplicatedOkAfterPending" +
+              " is [{}]. hasMismatchedReplicas is [{}]", container,
+          overHealth.isReplicatedOkAfterPending(),
+          overHealth.hasMismatchedReplicas());
+
+      if (!overHealth.isReplicatedOkAfterPending() &&
+          overHealth.isSafelyOverReplicated()) {
+        request.getReplicationQueue().enqueue(overHealth);
+      }
+      return true;
+    }
+
+    return false;
+  }
+
+  /**
+   * Verify there's no under or over replication if only healthy replicas are
+   * considered, or that there are no healthy replicas.
+   * @return true if there's no under/over replication considering healthy
+   * replicas
+   */
+  private boolean verifyPerfectReplication(ContainerCheckRequest request) {
+    RatisContainerReplicaCount replicaCountWithoutUnhealthy =
+        new RatisContainerReplicaCount(request.getContainerInfo(),
+            request.getContainerReplicas(), request.getPendingOps(),
+            request.getMaintenanceRedundancy(), false);
+
+    if (replicaCountWithoutUnhealthy.getHealthyReplicaCount() == 0) {
+      return true;
+    }
+    if (replicaCountWithoutUnhealthy.isUnderReplicated() ||
+        replicaCountWithoutUnhealthy.isOverReplicated()) {
+      LOG.debug("Checking replication for container {} without considering " +
+              "UNHEALTHY replicas. isUnderReplicated is [{}]. " +
+              "isOverReplicated is [{}]. Returning false because there should" +
+              " be perfect replication for this handler to work.",
+          request.getContainerInfo(),
+          replicaCountWithoutUnhealthy.isUnderReplicated(),
+          replicaCountWithoutUnhealthy.isOverReplicated());
+      return false;
+    }
+    return true;
+  }
+
+  /**
+   * Checks if the container is over or under replicated.
+   */
+  @VisibleForTesting
+  protected ContainerHealthResult checkReplication(
+      ContainerCheckRequest request) {
+    RatisContainerReplicaCount replicaCount =
+        new RatisContainerReplicaCount(request.getContainerInfo(),
+            request.getContainerReplicas(), request.getPendingOps(),
+            request.getMaintenanceRedundancy(), true);
+
+    boolean sufficientlyReplicated
+        = replicaCount.isSufficientlyReplicated(false);
+    if (!sufficientlyReplicated) {
+      ContainerHealthResult.UnderReplicatedHealthResult result =
+          new ContainerHealthResult.UnderReplicatedHealthResult(
+              replicaCount.getContainer(),
+              replicaCount.getRemainingRedundancy(),
+              replicaCount.inSufficientDueToDecommission(false),
+              replicaCount.isSufficientlyReplicated(true),
+              replicaCount.isUnrecoverable());
+      result.setHasHealthyReplicas(replicaCount.getHealthyReplicaCount() > 0);
+      return result;
+    }
+
+    boolean isOverReplicated = replicaCount.isOverReplicated(false);
+    if (isOverReplicated) {
+      boolean repOkWithPending = !replicaCount.isOverReplicated(true);
+      ContainerHealthResult.OverReplicatedHealthResult result =
+          new ContainerHealthResult.OverReplicatedHealthResult(
+              replicaCount.getContainer(),
+              replicaCount.getExcessRedundancy(false),
+              repOkWithPending);
+      result.setHasMismatchedReplicas(
+          replicaCount.getMisMatchedReplicaCount() > 0);
+      result.setIsSafelyOverReplicated(replicaCount.isSafelyOverReplicated());
+      return result;
+    }
+
+    return new ContainerHealthResult.UnHealthyResult(
+        replicaCount.getContainer());
+  }
+}

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/NodeManagerMXBean.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/NodeManagerMXBean.java
@@ -20,6 +20,7 @@ package org.apache.hadoop.hdds.scm.node;
 
 import org.apache.hadoop.hdds.annotation.InterfaceAudience;
 
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -41,5 +42,6 @@ public interface NodeManagerMXBean {
    * storage type.
    */
   Map<String, Long> getNodeInfo();
+  Map<String, List<String>> getNodeStatusInfo();
 
 }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/SCMNodeManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/SCMNodeManager.java
@@ -964,6 +964,22 @@ public class SCMNodeManager implements NodeManager {
     return nodeInfo;
   }
 
+  @Override
+  public Map<String, List<String>> getNodeStatusInfo() {
+    Map<String, List<String>> nodes = new HashMap<>();
+    for (DatanodeInfo dni : nodeStateManager.getAllNodes()) {
+      String hostName = dni.getHostName();
+      NodeStatus Nodestatus = dni.getNodeStatus();
+      NodeState health = Nodestatus.getHealth();
+      NodeOperationalState operationalState = Nodestatus.getOperationalState();
+      List<String> ls = new ArrayList<>();
+      ls.add(health.name());
+      ls.add(operationalState.name());
+      nodes.put(hostName, ls);
+    }
+    return nodes;
+  }
+
   private enum UsageMetrics {
     DiskCapacity,
     DiskUsed,

--- a/hadoop-hdds/server-scm/src/main/resources/webapps/scm/scm-overview.html
+++ b/hadoop-hdds/server-scm/src/main/resources/webapps/scm/scm-overview.html
@@ -36,6 +36,7 @@
             <option value="10" ng-selected="{true}">10</option>
             <option value="20">20</option>
             <option value="50">50</option>
+            <option value="All">All</option>
         </select>
     </div>
     <div class="col-md-6 text-right">
@@ -44,18 +45,18 @@
 </div>
 <table class="table table-bordered table-striped col-md-6">
     <thead>
-    <tr>
-        <th ng-click="columnSort('hostname')">HostName</th>
-        <th ng-click="columnSort('opstate')">Operational State</th>
-        <th ng-click="columnSort('comstate')">Commisioned State</th>
-    </tr>
+        <tr>
+            <th ng-click = "columnSort('hostname')" ng-class="{'sortorder' : reverse, 'sortorder reverse' : !reverse}">HostName</th>
+            <th ng-click = "columnSort('opstate')" ng-class="{'sortorder' : reverse, 'sortorder reverse' : !reverse}">Operational State</th>
+            <th ng-click = "columnSort('comstate')" ng-class="{'sortorder' : reverse, 'sortorder reverse' : !reverse}">Commisioned State</th>
+        </tr>
     </thead>
     <tbody>
-    <tr ng-repeat="typestat in nodeStatus|filter:search|orderBy:columnName:reverse">
-        <td>{{typestat.hostname}}</td>
-        <td>{{typestat.opstate}}</td>
-        <td>{{typestat.comstate}}</td>
-    </tr>
+        <tr ng-repeat="typestat in nodeStatus|filter:search|orderBy:columnName:reverse">
+            <td>{{typestat.hostname}}</td>
+            <td>{{typestat.opstate}}</td>
+            <td>{{typestat.comstate}}</td>
+        </tr>
     </tbody>
 </table>
 <div>

--- a/hadoop-hdds/server-scm/src/main/resources/webapps/scm/scm-overview.html
+++ b/hadoop-hdds/server-scm/src/main/resources/webapps/scm/scm-overview.html
@@ -28,25 +28,53 @@
     </tbody>
 </table>
 
-<h2>Node counts</h2>
-
-<table class="table table-bordered table-striped" class="col-md-6">
+<h2>Node Status</h2>
+<div class="row">
+    <div class="col-md-6 text-left">
+        <label>Show: </label>
+        <select class="form-select" ng-model="RecordsToDisplay" ng-change="UpdateRecordsToShow()">
+            <option value="10" ng-selected="{true}">10</option>
+            <option value="20">20</option>
+            <option value="50">50</option>
+        </select>
+    </div>
+    <div class="col-md-6 text-right">
+        <label>Search: </label> <input type="text" ng-model="search">
+    </div>
+</div>
+<table class="table table-bordered table-stripedcol-md-6">
     <thead>
     <tr>
-        <th class="col-md-3"></th>
-        <th>HEALTHY</th>
-        <th>STALE</th>
-        <th>DEAD</th>
-        <th>HEALTHY_READONLY</th>
+        <th ng-click="columnSort('hostname')">HostName</th>
+        <th ng-click="columnSort('opstate')">Operational State</th>
+        <th ng-click="columnSort('comstate')">Commisioned State</th>
     </tr>
     </thead>
     <tbody>
-    <tr ng-repeat="nodeOpState in $ctrl.nodemanagermetrics.NodeCount | orderBy:'key':false:$ctrl.nodeOpStateOrder">
-        <td>{{nodeOpState.key}}</td>
-        <td ng-repeat="nodeState in nodeOpState.value | orderBy:'key':false:$ctrl.nodeStateOrder">{{nodeState.value}}</td>
+    <tr ng-repeat="typestat in nodeStatus|filter:search|orderBy:columnName:reverse">
+        <td>{{typestat.hostname}}</td>
+        <td>{{typestat.opstate}}</td>
+        <td>{{typestat.comstate}}</td>
     </tr>
     </tbody>
 </table>
+<div>
+    <nav aria-label="...">
+        <ul class="pagination">
+            <li class="page-item" ng-class="{disabled:currentPage==1}"
+                ng-click="handlePagination(currentPage-1,(currentPage==1))">
+                <span class="page-link" tabindex="-1">Previous</span>
+            </li>
+            <li class="page-item active">
+                <span class="page-link">{{currentPage}} </span>
+            </li>
+            <li class="page-item" ng-class="{disabled:lastIndex==currentPage}"
+                ng-click="handlePagination(currentPage+1, (lastIndex==currentPage))">
+                <span class="page-link" tabindex="-1">Next</span>
+            </li>
+        </ul>
+    </nav>
+</div>
 
 <h2>Status</h2>
 <table class="table table-bordered table-striped" class="col-md-6">

--- a/hadoop-hdds/server-scm/src/main/resources/webapps/scm/scm-overview.html
+++ b/hadoop-hdds/server-scm/src/main/resources/webapps/scm/scm-overview.html
@@ -42,7 +42,7 @@
         <label>Search: </label> <input type="text" ng-model="search">
     </div>
 </div>
-<table class="table table-bordered table-stripedcol-md-6">
+<table class="table table-bordered table-striped col-md-6">
     <thead>
     <tr>
         <th ng-click="columnSort('hostname')">HostName</th>

--- a/hadoop-hdds/server-scm/src/main/resources/webapps/scm/scm.js
+++ b/hadoop-hdds/server-scm/src/main/resources/webapps/scm/scm.js
@@ -26,11 +26,11 @@
         },
         controller: function ($http,$scope) {
             var ctrl = this;
-            $scope.reverse=true;
-            $scope.columnName="";
-            let nodeStatusCopy=[];
-            $scope.RecordsToDisplay ="10";
-            $scope.currentPage=1;
+            $scope.reverse = true;
+            $scope.columnName = "";
+            let nodeStatusCopy = [];
+            $scope.RecordsToDisplay = "10";
+            $scope.currentPage = 1;
             $scope.lastIndex = 0;
 
             $http.get("jmx?qry=Hadoop:service=SCMNodeManager,name=SCMNodeManagerInfo")
@@ -42,27 +42,36 @@
                                 opstate: value[0],
                                 comstate: value[1]
                             }});
-                  nodeStatusCopy = [...$scope.nodeStatus];
-                  $scope.lastIndex= Math.ceil(nodeStatusCopy.length/$scope.RecordsToDisplay);
-                  $scope.nodeStatus =nodeStatusCopy.slice(0,$scope.RecordsToDisplay);
+                nodeStatusCopy = [...$scope.nodeStatus];
+                $scope.lastIndex = Math.ceil(nodeStatusCopy.length/$scope.RecordsToDisplay);
+                $scope.nodeStatus = nodeStatusCopy.slice(0, $scope.RecordsToDisplay);
                   });
-                    $scope.UpdateRecordsToShow= ()=>{
-                       $scope.lastIndex= Math.ceil(nodeStatusCopy.length/$scope.RecordsToDisplay);
-                       $scope.nodeStatus =nodeStatusCopy.slice(0,$scope.RecordsToDisplay);
-                       $scope.currentPage=1;
+                /*if option is 'All' display all records else display specified record on page*/
+                $scope.UpdateRecordsToShow = () => {
+                     if($scope.RecordsToDisplay == 'All') {
+                         $scope.lastIndex = 1;
+                         $scope.nodeStatus = nodeStatusCopy;
+                     }
+                     else {
+                         $scope.lastIndex = Math.ceil(nodeStatusCopy.length/$scope.RecordsToDisplay);
+                         $scope.nodeStatus = nodeStatusCopy.slice(0, $scope.RecordsToDisplay);
+                     }
+                     $scope.currentPage=1;
+                }
+                /* Page Slicing  logic */
+                 $scope.handlePagination = (pageIndex, isDisabled) => {
+                    if(!isDisabled) {
+                        let startIndex = 0, endIndex = 0;
+                        $scope.currentPage = pageIndex;
+                        startIndex = (pageIndex * $scope.RecordsToDisplay) - $scope.RecordsToDisplay;
+                        endIndex = startIndex + parseInt($scope.RecordsToDisplay);
+                        $scope.nodeStatus = nodeStatusCopy.slice(startIndex, endIndex);
                     }
-                 $scope.handlePagination= (pageIndex,isDisabled )=>{
-                                    if(!isDisabled){
-                                        let startIndex=0, endIndex=0;
-                                        $scope.currentPage =pageIndex;
-                                        startIndex= (pageIndex* $scope.RecordsToDisplay) - $scope.RecordsToDisplay;
-                                        endIndex= startIndex + parseInt($scope.RecordsToDisplay);
-                                        $scope.nodeStatus= nodeStatusCopy.slice(startIndex, endIndex);
-                                    }
-                                  }
-                $scope.columnSort = (colName)=> {
-                    $scope.columnName=colName;
-                    $scope.reverse= !$scope.reverse;
+                 }
+                 /*column sort logic*/
+                $scope.columnSort = (colName) => {
+                    $scope.columnName = colName;
+                    $scope.reverse = !$scope.reverse;
                 }
 
             const nodeOpStateSortOrder = {

--- a/hadoop-hdds/server-scm/src/main/resources/webapps/scm/scm.js
+++ b/hadoop-hdds/server-scm/src/main/resources/webapps/scm/scm.js
@@ -24,12 +24,46 @@
         require: {
             overview: "^overview"
         },
-        controller: function ($http) {
+        controller: function ($http,$scope) {
             var ctrl = this;
+            $scope.reverse=true;
+            $scope.columnName="";
+            let nodeStatusCopy=[];
+            $scope.RecordsToDisplay ="10";
+            $scope.currentPage=1;
+            $scope.lastIndex = 0;
+
             $http.get("jmx?qry=Hadoop:service=SCMNodeManager,name=SCMNodeManagerInfo")
                 .then(function (result) {
                     ctrl.nodemanagermetrics = result.data.beans[0];
-                });
+                $scope.nodeStatus = ctrl.nodemanagermetrics && ctrl.nodemanagermetrics.NodeStatus && ctrl.nodemanagermetrics.NodeStatus.map(({ key, value}) =>{
+                            return {
+                                hostname: key,
+                                opstate: value[0],
+                                comstate: value[1]
+                            }});
+                  nodeStatusCopy = [...$scope.nodeStatus];
+                  $scope.lastIndex= Math.ceil(nodeStatusCopy.length/$scope.RecordsToDisplay);
+                  $scope.nodeStatus =nodeStatusCopy.slice(0,$scope.RecordsToDisplay);
+                  });
+                    $scope.UpdateRecordsToShow= ()=>{
+                       $scope.lastIndex= Math.ceil(nodeStatusCopy.length/$scope.RecordsToDisplay);
+                       $scope.nodeStatus =nodeStatusCopy.slice(0,$scope.RecordsToDisplay);
+                       $scope.currentPage=1;
+                    }
+                 $scope.handlePagination= (pageIndex,isDisabled )=>{
+                                    if(!isDisabled){
+                                        let startIndex=0, endIndex=0;
+                                        $scope.currentPage =pageIndex;
+                                        startIndex= (pageIndex* $scope.RecordsToDisplay) - $scope.RecordsToDisplay;
+                                        endIndex= startIndex + parseInt($scope.RecordsToDisplay);
+                                        $scope.nodeStatus= nodeStatusCopy.slice(startIndex, endIndex);
+                                    }
+                                  }
+                $scope.columnSort = (colName)=> {
+                    $scope.columnName=colName;
+                    $scope.reverse= !$scope.reverse;
+                }
 
             const nodeOpStateSortOrder = {
                 "IN_SERVICE": "a",

--- a/hadoop-hdds/server-scm/src/main/resources/webapps/scm/scm.js
+++ b/hadoop-hdds/server-scm/src/main/resources/webapps/scm/scm.js
@@ -36,7 +36,7 @@
             $http.get("jmx?qry=Hadoop:service=SCMNodeManager,name=SCMNodeManagerInfo")
                 .then(function (result) {
                     ctrl.nodemanagermetrics = result.data.beans[0];
-                $scope.nodeStatus = ctrl.nodemanagermetrics && ctrl.nodemanagermetrics.NodeStatus && ctrl.nodemanagermetrics.NodeStatus.map(({ key, value}) =>{
+                $scope.nodeStatus = ctrl.nodemanagermetrics && ctrl.nodemanagermetrics.NodeStatusInfo && ctrl.nodemanagermetrics.NodeStatusInfo.map(({ key, value}) =>{
                             return {
                                 hostname: key,
                                 opstate: value[0],

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/MockNodeManager.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/MockNodeManager.java
@@ -802,6 +802,11 @@ public class MockNodeManager implements NodeManager {
     return nodeInfo;
   }
 
+  @Override
+  public Map<String, List<String>> getNodeStatusInfo() {
+    return null;
+  }
+
   /**
    * Makes it easy to add a container.
    *

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/SimpleMockNodeManager.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/SimpleMockNodeManager.java
@@ -373,6 +373,11 @@ public class SimpleMockNodeManager implements NodeManager {
   }
 
   @Override
+  public Map<String, List<String>> getNodeStatusInfo() {
+    return null;
+  }
+
+  @Override
   public void onMessage(CommandForDatanode commandForDatanode,
                         EventPublisher publisher) {
   }

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/ReplicationTestUtil.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/ReplicationTestUtil.java
@@ -121,6 +121,16 @@ public final class ReplicationTestUtil {
         datanodeDetails, datanodeDetails.getUuid());
   }
 
+  public static ContainerReplica createContainerReplica(ContainerID containerID,
+      int replicaIndex, HddsProtos.NodeOperationalState opState,
+      ContainerReplicaProto.State replicaState, long seqId) {
+    DatanodeDetails datanodeDetails
+        = MockDatanodeDetails.randomDatanodeDetails();
+    return createContainerReplica(containerID, replicaIndex, opState,
+        replicaState, 123L, 1234L,
+        datanodeDetails, datanodeDetails.getUuid(), seqId);
+  }
+
   @SuppressWarnings("checkstyle:ParameterNumber")
   public static ContainerReplica createContainerReplica(ContainerID containerID,
       int replicaIndex, HddsProtos.NodeOperationalState opState,
@@ -140,6 +150,24 @@ public final class ReplicationTestUtil {
     return builder.build();
   }
 
+  @SuppressWarnings("checkstyle:ParameterNumber")
+  public static ContainerReplica createContainerReplica(ContainerID containerID,
+      int replicaIndex, HddsProtos.NodeOperationalState opState,
+      ContainerReplicaProto.State replicaState, long keyCount, long bytesUsed,
+      DatanodeDetails datanodeDetails, UUID originNodeId, long seqId) {
+    ContainerReplica.ContainerReplicaBuilder builder
+        = ContainerReplica.newBuilder();
+    datanodeDetails.setPersistedOpState(opState);
+    builder.setContainerID(containerID);
+    builder.setReplicaIndex(replicaIndex);
+    builder.setKeyCount(keyCount);
+    builder.setBytesUsed(bytesUsed);
+    builder.setContainerState(replicaState);
+    builder.setDatanodeDetails(datanodeDetails);
+    builder.setSequenceId(seqId);
+    builder.setOriginNodeId(originNodeId);
+    return builder.build();
+  }
 
   public static ContainerInfo createContainerInfo(ReplicationConfig repConfig) {
     return createContainerInfo(repConfig, 1, HddsProtos.LifeCycleState.CLOSED);

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestRatisOverReplicationHandler.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestRatisOverReplicationHandler.java
@@ -145,6 +145,15 @@ public class TestRatisOverReplicationHandler {
         RATIS_REPLICATION_CONFIG);
     Set<ContainerReplica> replicas = createReplicas(container.containerID(),
         ContainerReplicaProto.State.QUASI_CLOSED, 0, 0, 0, 0, 0);
+    /*
+     Even an unhealthy replica shouldn't be deleted if it has a unique
+     origin. It might be possible to close this replica in the future.
+     */
+    ContainerReplica unhealthyReplica =
+        createContainerReplica(container.containerID(), 0,
+            HddsProtos.NodeOperationalState.IN_SERVICE,
+            ContainerReplicaProto.State.UNHEALTHY);
+    replicas.add(unhealthyReplica);
 
     testProcessing(replicas, Collections.emptyList(),
         getOverReplicatedHealthResult(), 0);
@@ -258,7 +267,7 @@ public class TestRatisOverReplicationHandler {
    *                          handler
    * @param expectNumCommands number of commands expected to be created by
    *                          the handler
-   * @return map of commands
+   * @return set of commands
    */
   private Set<Pair<DatanodeDetails, SCMCommand<?>>> testProcessing(
       Set<ContainerReplica> replicas, List<ContainerReplicaOp> pendingOps,

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestReplicationManager.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestReplicationManager.java
@@ -26,6 +26,7 @@ import org.apache.hadoop.hdds.protocol.DatanodeDetails;
 import org.apache.hadoop.hdds.protocol.MockDatanodeDetails;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.ContainerReplicaProto;
+import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.SCMCommandProto;
 import org.apache.hadoop.hdds.scm.PlacementPolicy;
 import org.apache.hadoop.hdds.scm.container.ContainerID;
 import org.apache.hadoop.hdds.scm.container.ContainerInfo;
@@ -38,10 +39,13 @@ import org.apache.hadoop.hdds.scm.events.SCMEvents;
 import org.apache.hadoop.hdds.scm.ha.SCMContext;
 import org.apache.hadoop.hdds.scm.ha.SCMServiceManager;
 import org.apache.hadoop.hdds.scm.node.NodeManager;
+import org.apache.hadoop.hdds.scm.node.NodeStatus;
+import org.apache.hadoop.hdds.scm.node.states.NodeNotFoundException;
 import org.apache.hadoop.hdds.server.events.EventPublisher;
 import org.apache.hadoop.ozone.protocol.commands.DeleteContainerCommand;
 import org.apache.hadoop.ozone.protocol.commands.ReconstructECContainersCommand;
 import org.apache.hadoop.ozone.protocol.commands.ReplicateContainerCommand;
+import org.apache.hadoop.ozone.protocol.commands.SCMCommand;
 import org.apache.ozone.test.TestClock;
 import org.apache.ratis.protocol.exceptions.NotLeaderException;
 import org.junit.Assert;
@@ -54,11 +58,13 @@ import java.io.IOException;
 import java.time.Instant;
 import java.time.ZoneId;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.UUID;
 
 import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_SCM_WAIT_TIME_AFTER_SAFE_MODE_EXIT;
 import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.NodeOperationalState.DECOMMISSIONING;
@@ -68,6 +74,7 @@ import static org.apache.hadoop.hdds.scm.container.replication.ContainerReplicaO
 import static org.apache.hadoop.hdds.scm.container.replication.ReplicationTestUtil.createContainerInfo;
 import static org.apache.hadoop.hdds.scm.container.replication.ReplicationTestUtil.createContainerReplica;
 import static org.apache.hadoop.hdds.scm.container.replication.ReplicationTestUtil.createReplicas;
+import static org.apache.hadoop.hdds.scm.container.replication.ReplicationTestUtil.createReplicasWithSameOrigin;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyList;
@@ -101,6 +108,8 @@ public class TestReplicationManager {
     configuration.set(HDDS_SCM_WAIT_TIME_AFTER_SAFE_MODE_EXIT, "0s");
     containerManager = Mockito.mock(ContainerManager.class);
     ratisPlacementPolicy = Mockito.mock(PlacementPolicy.class);
+    Mockito.when(ratisPlacementPolicy.validateContainerPlacement(anyList(),
+        anyInt())).thenReturn(new ContainerPlacementStatusDefault(2, 2, 3));
     ecPlacementPolicy = Mockito.mock(PlacementPolicy.class);
     Mockito.when(ecPlacementPolicy.validateContainerPlacement(
         anyList(), anyInt()))
@@ -241,6 +250,119 @@ public class TestReplicationManager {
         ReplicationManagerReport.HealthState.UNDER_REPLICATED));
     Assert.assertEquals(1, repQueue.underReplicatedQueueSize());
     Assert.assertEquals(0, repQueue.overReplicatedQueueSize());
+  }
+
+  @Test
+  public void testUnderReplicatedClosedContainerWithOnlyUnhealthyReplicas()
+      throws ContainerNotFoundException {
+    RatisReplicationConfig ratisRepConfig =
+        RatisReplicationConfig.getInstance(THREE);
+    ContainerInfo container = createContainerInfo(ratisRepConfig, 1,
+        HddsProtos.LifeCycleState.CLOSED);
+    // Container is closed but replicas are UNHEALTHY
+    Set<ContainerReplica> replicas =
+        addReplicas(container, ContainerReplicaProto.State.UNHEALTHY, 0, 0);
+    ContainerReplica unhealthyOnDecommissioning = createContainerReplica(
+        container.containerID(), 0, DECOMMISSIONING,
+        ContainerReplicaProto.State.UNHEALTHY);
+    replicas.add(unhealthyOnDecommissioning);
+
+    replicationManager.processContainer(container, repQueue, repReport);
+    Assert.assertEquals(1, repReport.getStat(
+        ReplicationManagerReport.HealthState.UNDER_REPLICATED));
+    Assert.assertEquals(1, repReport.getStat(
+        ReplicationManagerReport.HealthState.UNHEALTHY));
+    Assert.assertEquals(1, repQueue.underReplicatedQueueSize());
+    Assert.assertEquals(0, repQueue.overReplicatedQueueSize());
+  }
+
+  /**
+   * Situation: QUASI_CLOSED container with 3 QUASI_CLOSED and 1 UNHEALTHY
+   * replica. They all have the same origin node id. It's expected that the
+   * UNHEALTHY replica (and not a QUASI_CLOSED one) is deleted.
+   */
+  @Test
+  public void testQuasiClosedContainerWithExcessUnhealthyReplica()
+      throws IOException, NodeNotFoundException {
+    RatisReplicationConfig ratisRepConfig =
+        RatisReplicationConfig.getInstance(THREE);
+    ContainerInfo container = createContainerInfo(ratisRepConfig, 1,
+        HddsProtos.LifeCycleState.QUASI_CLOSED);
+    Set<ContainerReplica> replicas =
+        createReplicasWithSameOrigin(container.containerID(),
+            ContainerReplicaProto.State.QUASI_CLOSED, 0, 0, 0);
+    UUID origin = replicas.iterator().next().getOriginDatanodeId();
+    ContainerReplica unhealthy =
+        createContainerReplica(container.containerID(), 0, IN_SERVICE,
+            ContainerReplicaProto.State.UNHEALTHY, 1, 123,
+            MockDatanodeDetails.randomDatanodeDetails(), origin);
+    replicas.add(unhealthy);
+    storeContainerAndReplicas(container, replicas);
+
+    replicationManager.processContainer(container, repQueue, repReport);
+    Assert.assertEquals(0, repReport.getStat(
+        ReplicationManagerReport.HealthState.UNDER_REPLICATED));
+    Assert.assertEquals(1, repReport.getStat(
+        ReplicationManagerReport.HealthState.OVER_REPLICATED));
+    Assert.assertEquals(1, repReport.getStat(
+        ReplicationManagerReport.HealthState.UNHEALTHY));
+    Assert.assertEquals(0, repQueue.underReplicatedQueueSize());
+    Assert.assertEquals(1, repQueue.overReplicatedQueueSize());
+
+    RatisOverReplicationHandler handler =
+        new RatisOverReplicationHandler(ratisPlacementPolicy, nodeManager);
+
+    Mockito.when(nodeManager.getNodeStatus(any(DatanodeDetails.class)))
+        .thenReturn(NodeStatus.inServiceHealthy());
+    Set<Pair<DatanodeDetails, SCMCommand<?>>> commands =
+        handler.processAndCreateCommands(replicas, Collections.emptyList(),
+            repQueue.dequeueOverReplicatedContainer(), 2);
+    Assert.assertTrue(commands.iterator().hasNext());
+    Assert.assertEquals(unhealthy.getDatanodeDetails(),
+        commands.iterator().next().getKey());
+    Assert.assertEquals(SCMCommandProto.Type.deleteContainerCommand,
+        commands.iterator().next().getValue().getType());
+  }
+
+  @Test
+  public void testQuasiClosedContainerWithUnhealthyReplicaOnUniqueOrigin()
+      throws IOException, NodeNotFoundException {
+    RatisReplicationConfig ratisRepConfig =
+        RatisReplicationConfig.getInstance(THREE);
+    ContainerInfo container = createContainerInfo(ratisRepConfig, 1,
+        HddsProtos.LifeCycleState.QUASI_CLOSED);
+    Set<ContainerReplica> replicas =
+        createReplicasWithSameOrigin(container.containerID(),
+            ContainerReplicaProto.State.QUASI_CLOSED, 0, 0, 0);
+    ContainerReplica unhealthy =
+        createContainerReplica(container.containerID(), 0, IN_SERVICE,
+            ContainerReplicaProto.State.UNHEALTHY);
+    replicas.add(unhealthy);
+    storeContainerAndReplicas(container, replicas);
+
+    replicationManager.processContainer(container, repQueue, repReport);
+    Assert.assertEquals(0, repReport.getStat(
+        ReplicationManagerReport.HealthState.UNDER_REPLICATED));
+    Assert.assertEquals(1, repReport.getStat(
+        ReplicationManagerReport.HealthState.OVER_REPLICATED));
+    Assert.assertEquals(1, repReport.getStat(
+        ReplicationManagerReport.HealthState.UNHEALTHY));
+    Assert.assertEquals(0, repQueue.underReplicatedQueueSize());
+    Assert.assertEquals(1, repQueue.overReplicatedQueueSize());
+
+    RatisOverReplicationHandler handler =
+        new RatisOverReplicationHandler(ratisPlacementPolicy, nodeManager);
+
+    Mockito.when(nodeManager.getNodeStatus(any(DatanodeDetails.class)))
+        .thenReturn(NodeStatus.inServiceHealthy());
+    Set<Pair<DatanodeDetails, SCMCommand<?>>> commands =
+        handler.processAndCreateCommands(replicas, Collections.emptyList(),
+            repQueue.dequeueOverReplicatedContainer(), 2);
+    Assert.assertTrue(commands.iterator().hasNext());
+    Assert.assertNotEquals(unhealthy.getDatanodeDetails(),
+        commands.iterator().next().getKey());
+    Assert.assertEquals(SCMCommandProto.Type.deleteContainerCommand,
+        commands.iterator().next().getValue().getType());
   }
 
   @Test

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/health/TestRatisUnhealthyReplicationCheckHandler.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/health/TestRatisUnhealthyReplicationCheckHandler.java
@@ -1,0 +1,334 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with this
+ * work for additional information regarding copyright ownership.  The ASF
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p/>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p/>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package org.apache.hadoop.hdds.scm.container.replication.health;
+
+import com.google.common.collect.ImmutableList;
+import org.apache.hadoop.hdds.client.ECReplicationConfig;
+import org.apache.hadoop.hdds.client.RatisReplicationConfig;
+import org.apache.hadoop.hdds.client.ReplicationConfig;
+import org.apache.hadoop.hdds.protocol.MockDatanodeDetails;
+import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
+import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.ContainerReplicaProto;
+import org.apache.hadoop.hdds.scm.container.ContainerInfo;
+import org.apache.hadoop.hdds.scm.container.ContainerReplica;
+import org.apache.hadoop.hdds.scm.container.ReplicationManagerReport;
+import org.apache.hadoop.hdds.scm.container.replication.ContainerCheckRequest;
+import org.apache.hadoop.hdds.scm.container.replication.ContainerHealthResult;
+import org.apache.hadoop.hdds.scm.container.replication.ContainerReplicaOp;
+import org.apache.hadoop.hdds.scm.container.replication.ReplicationQueue;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+
+import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.NodeOperationalState.IN_SERVICE;
+import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationFactor.THREE;
+import static org.apache.hadoop.hdds.scm.container.replication.ReplicationTestUtil.createContainerInfo;
+import static org.apache.hadoop.hdds.scm.container.replication.ReplicationTestUtil.createContainerReplica;
+import static org.apache.hadoop.hdds.scm.container.replication.ReplicationTestUtil.createReplicas;
+
+/**
+ * Tests for {@link RatisUnhealthyReplicationCheckHandler}.
+ */
+public class TestRatisUnhealthyReplicationCheckHandler {
+  private RatisUnhealthyReplicationCheckHandler handler;
+  private ReplicationConfig repConfig;
+  private ReplicationQueue repQueue;
+  private ContainerCheckRequest.Builder requestBuilder;
+  private ReplicationManagerReport report;
+  private int maintenanceRedundancy = 2;
+
+  @Before
+  public void setup() throws IOException {
+    handler = new RatisUnhealthyReplicationCheckHandler();
+    repConfig = RatisReplicationConfig.getInstance(THREE);
+    repQueue = new ReplicationQueue();
+    report = new ReplicationManagerReport();
+    requestBuilder = new ContainerCheckRequest.Builder()
+        .setReplicationQueue(repQueue)
+        .setMaintenanceRedundancy(maintenanceRedundancy)
+        .setPendingOps(Collections.emptyList())
+        .setReport(report);
+  }
+
+  @Test
+  public void testReturnFalseForNonRatis() {
+    ContainerInfo container =
+        createContainerInfo(new ECReplicationConfig(3, 2));
+    Set<ContainerReplica> replicas =
+        createReplicas(container.containerID(), 1, 2, 3, 4);
+
+    requestBuilder.setContainerReplicas(replicas)
+        .setContainerInfo(container);
+    Assert.assertFalse(handler.handle(requestBuilder.build()));
+    Assert.assertEquals(0, repQueue.underReplicatedQueueSize());
+    Assert.assertEquals(0, repQueue.overReplicatedQueueSize());
+  }
+
+  @Test
+  public void shouldReturnFalseForPerfectReplicationConsideringHealthy() {
+    ContainerInfo container =
+        createContainerInfo(repConfig, 1L, HddsProtos.LifeCycleState.CLOSED);
+    Set<ContainerReplica> replicas
+        = createReplicas(container.containerID(),
+        ContainerReplicaProto.State.CLOSED, 0, 0, 0);
+    requestBuilder.setContainerReplicas(replicas)
+        .setContainerInfo(container);
+
+    Assert.assertFalse(handler.handle(requestBuilder.build()));
+  }
+
+  @Test
+  public void shouldReturnFalseForUnderReplicatedHealthyReplicas() {
+    ContainerInfo container =
+        createContainerInfo(repConfig, 1L, HddsProtos.LifeCycleState.CLOSED);
+    Set<ContainerReplica> replicas
+        = createReplicas(container.containerID(),
+        ContainerReplicaProto.State.CLOSED, 0, 0);
+    requestBuilder.setContainerReplicas(replicas)
+        .setContainerInfo(container);
+
+    Assert.assertFalse(handler.handle(requestBuilder.build()));
+  }
+
+  @Test
+  public void shouldReturnFalseForOverReplicatedHealthyReplicas() {
+    ContainerInfo container =
+        createContainerInfo(repConfig, 1L, HddsProtos.LifeCycleState.CLOSED);
+    Set<ContainerReplica> replicas
+        = createReplicas(container.containerID(),
+        ContainerReplicaProto.State.CLOSED, 0, 0, 0, 0);
+    ContainerReplica unhealthyReplica =
+        createContainerReplica(container.containerID(), 0, IN_SERVICE,
+            ContainerReplicaProto.State.UNHEALTHY);
+    replicas.add(unhealthyReplica);
+
+    requestBuilder.setContainerReplicas(replicas)
+        .setContainerInfo(container);
+
+    Assert.assertFalse(handler.handle(requestBuilder.build()));
+  }
+
+  @Test
+  public void shouldReturnTrueForExcessUnhealthyReplicas() {
+    ContainerInfo container =
+        createContainerInfo(repConfig, 1L, HddsProtos.LifeCycleState.CLOSED);
+    Set<ContainerReplica> replicas
+        = createReplicas(container.containerID(),
+        ContainerReplicaProto.State.CLOSED, 0, 0, 0);
+    ContainerReplica unhealthyReplica =
+        createContainerReplica(container.containerID(), 0, IN_SERVICE,
+            ContainerReplicaProto.State.UNHEALTHY);
+    replicas.add(unhealthyReplica);
+    requestBuilder.setContainerReplicas(replicas)
+        .setContainerInfo(container);
+
+    ContainerHealthResult.OverReplicatedHealthResult result =
+        (ContainerHealthResult.OverReplicatedHealthResult)
+            handler.checkReplication(requestBuilder.build());
+    Assert.assertEquals(ContainerHealthResult.HealthState.OVER_REPLICATED,
+        result.getHealthState());
+    Assert.assertEquals(1, result.getExcessRedundancy());
+    Assert.assertFalse(result.isReplicatedOkAfterPending());
+
+    Assert.assertTrue(handler.handle(requestBuilder.build()));
+    Assert.assertEquals(0, repQueue.underReplicatedQueueSize());
+    Assert.assertEquals(1, repQueue.overReplicatedQueueSize());
+    Assert.assertEquals(1, report.getStat(
+        ReplicationManagerReport.HealthState.OVER_REPLICATED));
+    Assert.assertEquals(1,
+        report.getStat(ReplicationManagerReport.HealthState.UNHEALTHY));
+  }
+
+  @Test
+  public void shouldReturnTrueForUnderReplicatedUnhealthyReplicas() {
+    ContainerInfo container =
+        createContainerInfo(repConfig, 1L, HddsProtos.LifeCycleState.CLOSED);
+    Set<ContainerReplica> replicas
+        = createReplicas(container.containerID(),
+        ContainerReplicaProto.State.UNHEALTHY, 0);
+    List<ContainerReplicaOp> pendingOps =
+        ImmutableList.of(ContainerReplicaOp.create(
+            ContainerReplicaOp.PendingOpType.ADD,
+            MockDatanodeDetails.randomDatanodeDetails(), 0));
+    requestBuilder.setContainerReplicas(replicas)
+        .setContainerInfo(container)
+        .setPendingOps(pendingOps);
+
+    ContainerHealthResult.UnderReplicatedHealthResult
+        result = (ContainerHealthResult.UnderReplicatedHealthResult)
+        handler.checkReplication(requestBuilder.build());
+
+    Assert.assertEquals(ContainerHealthResult.HealthState.UNDER_REPLICATED,
+        result.getHealthState());
+    Assert.assertEquals(0, result.getRemainingRedundancy());
+    Assert.assertFalse(result.isReplicatedOkAfterPending());
+    Assert.assertFalse(result.underReplicatedDueToDecommission());
+
+    Assert.assertTrue(handler.handle(requestBuilder.build()));
+    Assert.assertEquals(1, repQueue.underReplicatedQueueSize());
+    Assert.assertEquals(0, repQueue.overReplicatedQueueSize());
+    Assert.assertEquals(1, report.getStat(
+        ReplicationManagerReport.HealthState.UNDER_REPLICATED));
+    Assert.assertEquals(1,
+        report.getStat(ReplicationManagerReport.HealthState.UNHEALTHY));
+  }
+
+  @Test
+  public void testUnderReplicatedFixedByPendingAdd() {
+    ContainerInfo container =
+        createContainerInfo(repConfig, 1L, HddsProtos.LifeCycleState.CLOSED);
+    Set<ContainerReplica> replicas
+        = createReplicas(container.containerID(),
+        ContainerReplicaProto.State.UNHEALTHY, 0, 0);
+    List<ContainerReplicaOp> pendingOps =
+        ImmutableList.of(ContainerReplicaOp.create(
+            ContainerReplicaOp.PendingOpType.ADD,
+            MockDatanodeDetails.randomDatanodeDetails(), 0));
+    requestBuilder.setContainerReplicas(replicas)
+        .setContainerInfo(container)
+        .setPendingOps(pendingOps);
+
+    ContainerHealthResult.UnderReplicatedHealthResult
+        result = (ContainerHealthResult.UnderReplicatedHealthResult)
+        handler.checkReplication(requestBuilder.build());
+
+    Assert.assertEquals(ContainerHealthResult.HealthState.UNDER_REPLICATED,
+        result.getHealthState());
+    Assert.assertEquals(1, result.getRemainingRedundancy());
+    Assert.assertTrue(result.isReplicatedOkAfterPending());
+    Assert.assertFalse(result.underReplicatedDueToDecommission());
+
+    Assert.assertTrue(handler.handle(requestBuilder.build()));
+    Assert.assertEquals(0, repQueue.underReplicatedQueueSize());
+    Assert.assertEquals(0, repQueue.overReplicatedQueueSize());
+    Assert.assertEquals(1, report.getStat(
+        ReplicationManagerReport.HealthState.UNDER_REPLICATED));
+    Assert.assertEquals(1,
+        report.getStat(ReplicationManagerReport.HealthState.UNHEALTHY));
+  }
+
+  @Test
+  public void testUnderReplicatedDueToPendingDelete() {
+    ContainerInfo container =
+        createContainerInfo(repConfig, 1L, HddsProtos.LifeCycleState.CLOSED);
+    Set<ContainerReplica> replicas
+        = createReplicas(container.containerID(),
+        ContainerReplicaProto.State.UNHEALTHY, 0, 0, 0);
+    List<ContainerReplicaOp> pendingOps =
+        ImmutableList.of(ContainerReplicaOp.create(
+            ContainerReplicaOp.PendingOpType.DELETE,
+            replicas.stream().findFirst().get().getDatanodeDetails(), 0));
+    requestBuilder.setContainerReplicas(replicas)
+        .setContainerInfo(container)
+        .setPendingOps(pendingOps);
+
+    ContainerHealthResult.UnderReplicatedHealthResult
+        result = (ContainerHealthResult.UnderReplicatedHealthResult)
+        handler.checkReplication(requestBuilder.build());
+
+    Assert.assertEquals(ContainerHealthResult.HealthState.UNDER_REPLICATED,
+        result.getHealthState());
+    Assert.assertEquals(1, result.getRemainingRedundancy());
+    Assert.assertFalse(result.isReplicatedOkAfterPending());
+
+    Assert.assertTrue(handler.handle(requestBuilder.build()));
+    Assert.assertEquals(1, repQueue.underReplicatedQueueSize());
+    Assert.assertEquals(0, repQueue.overReplicatedQueueSize());
+    Assert.assertEquals(1, report.getStat(
+        ReplicationManagerReport.HealthState.UNDER_REPLICATED));
+    Assert.assertEquals(1,
+        report.getStat(ReplicationManagerReport.HealthState.UNHEALTHY));
+  }
+
+  @Test
+  public void testOverReplicationFixedByPendingDelete() {
+    ContainerInfo container =
+        createContainerInfo(repConfig, 1L, HddsProtos.LifeCycleState.CLOSED);
+    Set<ContainerReplica> replicas
+        = createReplicas(container.containerID(),
+        ContainerReplicaProto.State.UNHEALTHY, 0, 0, 0, 0);
+    List<ContainerReplicaOp> pendingOps =
+        ImmutableList.of(ContainerReplicaOp.create(
+            ContainerReplicaOp.PendingOpType.DELETE,
+            replicas.stream().findFirst().get().getDatanodeDetails(), 0));
+    requestBuilder.setContainerReplicas(replicas)
+        .setContainerInfo(container)
+        .setPendingOps(pendingOps);
+
+    ContainerHealthResult.OverReplicatedHealthResult
+        result = (ContainerHealthResult.OverReplicatedHealthResult)
+        handler.checkReplication(requestBuilder.build());
+
+    Assert.assertEquals(ContainerHealthResult.HealthState.OVER_REPLICATED,
+        result.getHealthState());
+    Assert.assertEquals(1, result.getExcessRedundancy());
+    Assert.assertTrue(result.isReplicatedOkAfterPending());
+
+    Assert.assertTrue(handler.handle(requestBuilder.build()));
+    Assert.assertEquals(0, repQueue.underReplicatedQueueSize());
+    Assert.assertEquals(0, repQueue.overReplicatedQueueSize());
+    Assert.assertEquals(1, report.getStat(
+        ReplicationManagerReport.HealthState.OVER_REPLICATED));
+    Assert.assertEquals(1,
+        report.getStat(ReplicationManagerReport.HealthState.UNHEALTHY));
+  }
+
+  @Test
+  public void shouldQueueForOverReplicationOnlyWhenSafe() {
+    ContainerInfo container =
+        createContainerInfo(repConfig, 1L, HddsProtos.LifeCycleState.CLOSED);
+    Set<ContainerReplica> replicas = createReplicas(container.containerID(),
+        ContainerReplicaProto.State.CLOSED, 0, 0);
+    ContainerReplica unhealthyReplica =
+        createContainerReplica(container.containerID(), 0, IN_SERVICE,
+            ContainerReplicaProto.State.UNHEALTHY);
+    ContainerReplica mismatchedReplica =
+        createContainerReplica(container.containerID(), 0, IN_SERVICE,
+            ContainerReplicaProto.State.QUASI_CLOSED);
+    replicas.add(mismatchedReplica);
+    replicas.add(unhealthyReplica);
+
+    requestBuilder.setContainerReplicas(replicas)
+        .setContainerInfo(container);
+
+    ContainerHealthResult.OverReplicatedHealthResult
+        result = (ContainerHealthResult.OverReplicatedHealthResult)
+        handler.checkReplication(requestBuilder.build());
+
+    Assert.assertEquals(ContainerHealthResult.HealthState.OVER_REPLICATED,
+        result.getHealthState());
+    Assert.assertEquals(1, result.getExcessRedundancy());
+    Assert.assertFalse(result.isReplicatedOkAfterPending());
+
+    // not safe for over replication because we don't have 3 matching replicas
+    Assert.assertFalse(result.isSafelyOverReplicated());
+
+    Assert.assertTrue(handler.handle(requestBuilder.build()));
+    Assert.assertEquals(0, repQueue.underReplicatedQueueSize());
+    Assert.assertEquals(0, repQueue.overReplicatedQueueSize());
+    Assert.assertEquals(1, report.getStat(
+        ReplicationManagerReport.HealthState.OVER_REPLICATED));
+    Assert.assertEquals(1,
+        report.getStat(ReplicationManagerReport.HealthState.UNHEALTHY));
+  }
+}

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/ozone/container/testutils/ReplicationNodeManagerMock.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/ozone/container/testutils/ReplicationNodeManagerMock.java
@@ -86,6 +86,11 @@ public class ReplicationNodeManagerMock implements NodeManager {
     return null;
   }
 
+  @Override
+  public Map<String, List<String>> getNodeStatusInfo() {
+    return null;
+  }
+
   /**
    * Gets all Live Datanodes that is currently communicating with SCM.
    *

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/TestOzoneConfigurationFields.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/TestOzoneConfigurationFields.java
@@ -134,7 +134,8 @@ public class TestOzoneConfigurationFields extends TestConfigurationFieldsBase {
         OMConfigKeys.OZONE_RANGER_HTTPS_ADDRESS_KEY,
         OMConfigKeys.OZONE_OM_RANGER_HTTPS_ADMIN_API_USER,
         OMConfigKeys.OZONE_OM_RANGER_HTTPS_ADMIN_API_PASSWD,
-        ScmConfigKeys.OZONE_SCM_PIPELINE_PLACEMENT_IMPL_KEY
+        ScmConfigKeys.OZONE_SCM_PIPELINE_PLACEMENT_IMPL_KEY,
+        S3GatewayConfigKeys.OZONE_S3G_FSO_DIRECTORY_CREATION_ENABLED
     ));
   }
 }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/TestContainerReplication.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/TestContainerReplication.java
@@ -101,14 +101,6 @@ public class TestContainerReplication {
         Level.DEBUG);
     GenericTestUtils.setLogLevel(SCMContainerPlacementRackAware.LOG,
         Level.DEBUG);
-    OzoneConfiguration conf = createConfiguration();
-    conf.set(OZONE_SCM_CONTAINER_PLACEMENT_IMPL_KEY, placementPolicyClass);
-
-    cluster = MiniOzoneCluster.newBuilder(conf).setNumDatanodes(5).build();
-    cluster.waitForClusterToBeReady();
-
-    client = OzoneClientFactory.getRpcClient(conf);
-    createTestData();
   }
 
   @After
@@ -120,6 +112,13 @@ public class TestContainerReplication {
 
   @Test
   public void testContainerReplication() throws Exception {
+    OzoneConfiguration conf = createConfiguration();
+    conf.set(OZONE_SCM_CONTAINER_PLACEMENT_IMPL_KEY, placementPolicyClass);
+    cluster = MiniOzoneCluster.newBuilder(conf).setNumDatanodes(5).build();
+    cluster.waitForClusterToBeReady();
+    client = OzoneClientFactory.getRpcClient(conf);
+    createTestData();
+
     List<OmKeyLocationInfo> keyLocations = lookupKey(cluster);
     assertFalse(keyLocations.isEmpty());
 
@@ -128,6 +127,41 @@ public class TestContainerReplication {
     waitForContainerClose(cluster, containerID);
 
     cluster.shutdownHddsDatanode(keyLocation.getPipeline().getFirstNode());
+    waitForReplicaCount(containerID, 2, cluster);
+
+    waitForReplicaCount(containerID, 3, cluster);
+  }
+
+  @Test
+  public void testContainerReplicationWithLegacyReplicationManagerDisabled()
+      throws Exception {
+    OzoneConfiguration conf = createConfiguration();
+
+    /*
+    Disable LegacyReplicationManager so that ReplicationManager handles Ratis
+     containers.
+     */
+    ReplicationManagerConfiguration repConf =
+        conf.getObject(ReplicationManagerConfiguration.class);
+    repConf.setEnableLegacy(false);
+    repConf.setUnderReplicatedInterval(Duration.ofSeconds(1));
+    conf.setFromObject(repConf);
+
+    conf.set(OZONE_SCM_CONTAINER_PLACEMENT_IMPL_KEY, placementPolicyClass);
+    cluster = MiniOzoneCluster.newBuilder(conf).setNumDatanodes(5).build();
+    cluster.waitForClusterToBeReady();
+    client = OzoneClientFactory.getRpcClient(conf);
+    createTestData();
+
+    List<OmKeyLocationInfo> keyLocations = lookupKey(cluster);
+    assertFalse(keyLocations.isEmpty());
+
+    OmKeyLocationInfo keyLocation = keyLocations.get(0);
+    long containerID = keyLocation.getContainerID();
+    waitForContainerClose(cluster, containerID);
+
+    cluster.shutdownHddsDatanode(keyLocation.getPipeline().getFirstNode());
+    waitForReplicaCount(containerID, 2, cluster);
 
     waitForReplicaCount(containerID, 3, cluster);
   }

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/S3GatewayConfigKeys.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/S3GatewayConfigKeys.java
@@ -63,7 +63,14 @@ public final class S3GatewayConfigKeys {
       "ozone.s3g.kerberos.keytab.file";
   public static final String OZONE_S3G_KERBEROS_PRINCIPAL_KEY =
       "ozone.s3g.kerberos.principal";
-
+  /**
+   * Configuration key that enables creation of directory instead of 0 byte
+   * file if bucket layout is FSO.
+   */
+  public static final String OZONE_S3G_FSO_DIRECTORY_CREATION_ENABLED =
+      "ozone.s3g.fso.directory.creation";
+  public static final boolean OZONE_S3G_FSO_DIRECTORY_CREATION_ENABLED_DEFAULT =
+      true;
 
   /**
    * Never constructed.

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/ObjectEndpoint.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/ObjectEndpoint.java
@@ -69,6 +69,7 @@ import org.apache.hadoop.ozone.client.io.OzoneInputStream;
 import org.apache.hadoop.ozone.client.io.OzoneOutputStream;
 import org.apache.hadoop.ozone.om.exceptions.OMException;
 import org.apache.hadoop.ozone.om.exceptions.OMException.ResultCodes;
+import org.apache.hadoop.ozone.om.helpers.BucketLayout;
 import org.apache.hadoop.ozone.om.helpers.OmMultipartCommitUploadPartInfo;
 import org.apache.hadoop.ozone.om.helpers.OmMultipartInfo;
 import org.apache.hadoop.ozone.om.helpers.OmMultipartUploadCompleteInfo;
@@ -98,6 +99,8 @@ import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_REPLICATION_TYPE_DEF
 import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_ENABLE_FILESYSTEM_PATHS;
 import static org.apache.hadoop.ozone.s3.S3GatewayConfigKeys.OZONE_S3G_CLIENT_BUFFER_SIZE_DEFAULT;
 import static org.apache.hadoop.ozone.s3.S3GatewayConfigKeys.OZONE_S3G_CLIENT_BUFFER_SIZE_KEY;
+import static org.apache.hadoop.ozone.s3.S3GatewayConfigKeys.OZONE_S3G_FSO_DIRECTORY_CREATION_ENABLED;
+import static org.apache.hadoop.ozone.s3.S3GatewayConfigKeys.OZONE_S3G_FSO_DIRECTORY_CREATION_ENABLED_DEFAULT;
 import static org.apache.hadoop.ozone.s3.exception.S3ErrorTable.ENTITY_TOO_SMALL;
 import static org.apache.hadoop.ozone.s3.exception.S3ErrorTable.INVALID_ARGUMENT;
 import static org.apache.hadoop.ozone.s3.exception.S3ErrorTable.INVALID_REQUEST;
@@ -176,6 +179,7 @@ public class ObjectEndpoint extends EndpointBase {
       InputStream body) throws IOException, OS3Exception {
 
     S3GAction s3GAction = S3GAction.CREATE_KEY;
+
     boolean auditSuccess = true;
 
     OzoneOutputStream output = null;
@@ -207,6 +211,18 @@ public class ObjectEndpoint extends EndpointBase {
             storageTypeDefault);
         return Response.status(Status.OK).entity(copyObjectResponse).header(
             "Connection", "close").build();
+      }
+
+      if (length == 0 &&
+          ozoneConfiguration
+              .getBoolean(OZONE_S3G_FSO_DIRECTORY_CREATION_ENABLED,
+                  OZONE_S3G_FSO_DIRECTORY_CREATION_ENABLED_DEFAULT) &&
+          bucket.getBucketLayout() == BucketLayout.FILE_SYSTEM_OPTIMIZED) {
+        s3GAction = S3GAction.CREATE_DIRECTORY;
+        // create directory
+        getClientProtocol()
+            .createDirectory(volume.getName(), bucketName, keyPath);
+        return Response.ok().status(HttpStatus.SC_OK).build();
       }
 
       // Normal put object
@@ -245,6 +261,8 @@ public class ObjectEndpoint extends EndpointBase {
         throw newError(S3ErrorTable.ACCESS_DENIED, keyPath, ex);
       } else if (ex.getResult() == ResultCodes.BUCKET_NOT_FOUND) {
         throw newError(S3ErrorTable.NO_SUCH_BUCKET, bucketName, ex);
+      } else if (ex.getResult() == ResultCodes.FILE_ALREADY_EXISTS) {
+        throw newError(S3ErrorTable.NO_OVERWRITE, keyPath, ex);
       }
       throw ex;
     } catch (Exception ex) {

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/exception/S3ErrorTable.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/exception/S3ErrorTable.java
@@ -122,6 +122,9 @@ public final class S3ErrorTable {
       "NotImplemented", "This part of feature is not implemented yet.",
       HTTP_NOT_IMPLEMENTED);
 
+  public static final OS3Exception NO_OVERWRITE = new OS3Exception(
+      "Conflict", "Cannot overwrite file with directory", HTTP_CONFLICT);
+
   public static OS3Exception newError(OS3Exception e, String resource) {
     return newError(e, resource, null);
   }

--- a/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestObjectPut.java
+++ b/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestObjectPut.java
@@ -20,25 +20,32 @@
 
 package org.apache.hadoop.ozone.s3.endpoint;
 
-import javax.ws.rs.core.HttpHeaders;
-import javax.ws.rs.core.Response;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
-
+import java.io.InputStream;
+import javax.ws.rs.core.HttpHeaders;
+import javax.ws.rs.core.Response;
+import org.apache.commons.io.IOUtils;
 import org.apache.hadoop.hdds.client.ECReplicationConfig;
 import org.apache.hadoop.hdds.client.ReplicationType;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import org.apache.hadoop.ozone.client.ObjectStore;
+import org.apache.hadoop.ozone.client.OzoneBucket;
 import org.apache.hadoop.ozone.client.OzoneClient;
 import org.apache.hadoop.ozone.client.OzoneClientStub;
 import org.apache.hadoop.ozone.client.OzoneKeyDetails;
+import org.apache.hadoop.ozone.client.OzoneVolume;
 import org.apache.hadoop.ozone.client.io.OzoneInputStream;
+import org.apache.hadoop.ozone.client.protocol.ClientProtocol;
+import org.apache.hadoop.ozone.om.exceptions.OMException;
+import org.apache.hadoop.ozone.om.helpers.BucketLayout;
 import org.apache.hadoop.ozone.s3.exception.OS3Exception;
-
-import org.apache.commons.io.IOUtils;
 import org.apache.hadoop.ozone.s3.exception.S3ErrorTable;
+import org.apache.http.HttpStatus;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
 import org.mockito.Mockito;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
@@ -47,6 +54,10 @@ import static org.apache.hadoop.ozone.s3.util.S3Consts.STORAGE_CLASS_HEADER;
 import static org.apache.hadoop.ozone.s3.util.S3Utils.urlEncode;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.when;
 
 /**
@@ -287,5 +298,80 @@ public class TestObjectPut {
 
     //default type is set
     Assert.assertEquals(ReplicationType.RATIS, key.getReplicationType());
+  }
+
+  @Test
+  public void testDirectoryCreation() throws IOException,
+      OS3Exception {
+    // GIVEN
+    final String path = "dir";
+    final long length = 0L;
+    final int partNumber = 0;
+    final String uploadId = "";
+    final InputStream body = null;
+    final HttpHeaders headers = Mockito.mock(HttpHeaders.class);
+    final ObjectEndpoint objEndpoint = new ObjectEndpoint();
+    objEndpoint.setOzoneConfiguration(new OzoneConfiguration());
+    objEndpoint.setHeaders(headers);
+    final OzoneClient client = Mockito.mock(OzoneClient.class);
+    objEndpoint.setClient(client);
+    final ObjectStore objectStore = Mockito.mock(ObjectStore.class);
+    final OzoneVolume volume = Mockito.mock(OzoneVolume.class);
+    final OzoneBucket bucket = Mockito.mock(OzoneBucket.class);
+    final ClientProtocol protocol = Mockito.mock(ClientProtocol.class);
+
+    // WHEN
+    when(client.getObjectStore()).thenReturn(objectStore);
+    when(client.getObjectStore().getS3Volume()).thenReturn(volume);
+    when(volume.getBucket(bucketName)).thenReturn(bucket);
+    when(bucket.getBucketLayout())
+        .thenReturn(BucketLayout.FILE_SYSTEM_OPTIMIZED);
+    when(client.getProxy()).thenReturn(protocol);
+    final Response response = objEndpoint.put(bucketName, path, length,
+        partNumber, uploadId, body);
+
+    // THEN
+    Assertions.assertEquals(HttpStatus.SC_OK, response.getStatus());
+    Mockito.verify(protocol).createDirectory(any(), eq(bucketName), eq(path));
+  }
+
+  @Test
+  public void testDirectoryCreationOverFile() throws IOException {
+    // GIVEN
+    final String path = "key";
+    final long length = 0L;
+    final int partNumber = 0;
+    final String uploadId = "";
+    final ByteArrayInputStream body =
+        new ByteArrayInputStream("content".getBytes(UTF_8));
+    final HttpHeaders headers = Mockito.mock(HttpHeaders.class);
+    final ObjectEndpoint objEndpoint = new ObjectEndpoint();
+    objEndpoint.setOzoneConfiguration(new OzoneConfiguration());
+    objEndpoint.setHeaders(headers);
+    final OzoneClient client = Mockito.mock(OzoneClient.class);
+    objEndpoint.setClient(client);
+    final ObjectStore objectStore = Mockito.mock(ObjectStore.class);
+    final OzoneVolume volume = Mockito.mock(OzoneVolume.class);
+    final OzoneBucket bucket = Mockito.mock(OzoneBucket.class);
+    final ClientProtocol protocol = Mockito.mock(ClientProtocol.class);
+
+    // WHEN
+    when(client.getObjectStore()).thenReturn(objectStore);
+    when(client.getObjectStore().getS3Volume()).thenReturn(volume);
+    when(volume.getBucket(bucketName)).thenReturn(bucket);
+    when(bucket.getBucketLayout())
+        .thenReturn(BucketLayout.FILE_SYSTEM_OPTIMIZED);
+    when(client.getProxy()).thenReturn(protocol);
+    doThrow(new OMException(OMException.ResultCodes.FILE_ALREADY_EXISTS))
+        .when(protocol)
+        .createDirectory(any(), any(), any());
+
+    // THEN
+    final OS3Exception exception = Assertions.assertThrows(OS3Exception.class,
+        () -> objEndpoint
+            .put(bucketName, path, length, partNumber, uploadId, body));
+    Assertions.assertEquals("Conflict", exception.getCode());
+    Assertions.assertEquals(409, exception.getHttpCode());
+    Mockito.verify(protocol, times(1)).createDirectory(any(), any(), any());
   }
 }


### PR DESCRIPTION
**What changes were proposed in this pull request?**
commit id : 579d1eabdd565269fb3830e0065646d1b77f4cf9 (holding all backend & UI changes)
This Includes Sorting, Searching & Pagination on SCM UI where page deafult size is 10. we can also set this to 20 or 50 records per page as well. 
Page slicing & Record Slicing  both have been implemented along wth sort & search.

**Backend Changes** ::    
JMX API developed  & the response from API is 

"NodeStatusInfo" : [ {
      "key" : "ozone_datanode_1.ozone_default",
      "value" : [ "HEALTHY", "IN_SERVICE" ]
    }, {
      "key" : "ozone_datanode_3.ozone_default",
      "value" : [ "HEALTHY", "IN_SERVICE" ]
    }, {
      "key" : "ozone_datanode_2.ozone_default",
      "value" : [ "HEALTHY", "IN_SERVICE" ]
    } ]
	

**Note**: HDDS 7816 JIRA includes both UI & Backend changes .

**What is the link to the Apache JIRA**
https://issues.apache.org/jira/browse/HDDS-7816

**How was this patch tested?**

   Manually 
Attached screenshot for reference

![image](https://user-images.githubusercontent.com/112392916/217737898-03f790f3-da3c-4051-80ac-7e0726d767cc.png)

**Search**: 
![image](https://user-images.githubusercontent.com/112392916/217738165-8a5a22d6-fea9-4322-8b64-805f8ac794eb.png)

**Sort**: 
![image](https://user-images.githubusercontent.com/112392916/217738356-803d1f4c-d40b-4084-abaa-a8f0e4df6ec8.png)




