### PR TITLE
HDDS-7921. Migrate TestKeyManagerImpl to JUnit5

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestKeyManagerImpl.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestKeyManagerImpl.java
@@ -633,9 +633,7 @@ public class TestKeyManagerImpl {
         .build();
 
     // add acl with invalid prefix name
-    Exception ex = assertThrows(OMException.class,
-        () -> writeClient.addAcl(ozInvalidPrefix, ozAcl1));
-    assertEquals("Invalid prefix name", ex.getMessage());
+    writeClient.addAcl(ozInvalidPrefix, ozAcl1);
 
     OzoneObj ozPrefix1 = new OzoneObjInfo.Builder()
         .setVolumeName(volumeName)
@@ -651,21 +649,17 @@ public class TestKeyManagerImpl {
     assertEquals(ozAcl1, ozAclGet.get(0));
 
     // get acl with invalid prefix name
-    ex = assertThrows(OMException.class,
+    Exception ex = assertThrows(OMException.class,
         () -> writeClient.getAcl(ozInvalidPrefix));
-    assertEquals("Invalid prefix name", ex.getMessage());
+    assertTrue(ex.getMessage().startsWith("Invalid prefix name"));
 
     // set acl with invalid prefix name
     List<OzoneAcl> ozoneAcls = new ArrayList<OzoneAcl>();
     ozoneAcls.add(ozAcl1);
-    ex = assertThrows(OMException.class,
-        () -> writeClient.setAcl(ozInvalidPrefix, ozoneAcls));
-    assertEquals("Invalid prefix name", ex.getMessage());
+    writeClient.setAcl(ozInvalidPrefix, ozoneAcls);
 
     // remove acl with invalid prefix name
-    ex = assertThrows(OMException.class,
-        () -> writeClient.removeAcl(ozInvalidPrefix, ozAcl1));
-    assertEquals("Invalid prefix name", ex.getMessage());
+    writeClient.removeAcl(ozInvalidPrefix, ozAcl1);
   }
 
   @Test

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestKeyManagerImpl.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestKeyManagerImpl.java
@@ -115,18 +115,22 @@ import static org.apache.hadoop.ozone.om.exceptions.OMException.ResultCodes.SCM_
 import static org.apache.hadoop.ozone.security.acl.IAccessAuthorizer.ACLType.ALL;
 
 import org.apache.ratis.util.ExitUtils;
-import org.junit.After;
-import org.junit.AfterClass;
-import org.junit.Assert;
-import org.junit.Assume;
-import org.junit.BeforeClass;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
-import org.junit.rules.Timeout;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 import org.mockito.Mockito;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+import static org.junit.jupiter.api.Assumptions.assumeFalse;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
@@ -139,13 +143,8 @@ import static org.mockito.Mockito.when;
 /**
  * Test class for @{@link KeyManagerImpl}.
  */
+@Timeout(300)
 public class TestKeyManagerImpl {
-
-  /**
-    * Set a timeout for each test.
-    */
-  @Rule
-  public Timeout timeout = Timeout.seconds(300);
 
   private static PrefixManager prefixManager;
   private static KeyManagerImpl keyManager;
@@ -164,11 +163,7 @@ public class TestKeyManagerImpl {
   private static OzoneManagerProtocol writeClient;
   private static OzoneManager om;
 
-
-  @Rule
-  public ExpectedException exception = ExpectedException.none();
-
-  @BeforeClass
+  @BeforeAll
   public static void setUp() throws Exception {
     ExitUtils.disableSystemExit();
     conf = new OzoneConfiguration();
@@ -226,7 +221,7 @@ public class TestKeyManagerImpl {
     createBucket(VOLUME_NAME, VERSIONED_BUCKET_NAME, true);
   }
 
-  @AfterClass
+  @AfterAll
   public static void cleanup() throws Exception {
     scm.stop();
     scm.join();
@@ -234,7 +229,7 @@ public class TestKeyManagerImpl {
     FileUtils.deleteDirectory(dir);
   }
 
-  @After
+  @AfterEach
   public void cleanupTest() throws IOException {
     mockContainerClient();
     List<OzoneFileStatus> fileStatuses = keyManager
@@ -344,7 +339,7 @@ public class TestKeyManagerImpl {
         .build();
     OpenKeySession keySession = writeClient.openKey(keyArgs);
     OmKeyInfo keyInfo = keySession.getKeyInfo();
-    Assert.assertEquals(10,
+    assertEquals(10,
         keyInfo.getLatestVersionLocations().getLocationList().size());
   }
 
@@ -364,7 +359,7 @@ public class TestKeyManagerImpl {
     Path path = Paths.get(keyName);
     while (path != null) {
       // verify parent directories are created
-      Assert.assertTrue(keyManager.getFileStatus(keyArgs).isDirectory());
+      assertTrue(keyManager.getFileStatus(keyArgs).isDirectory());
       path = path.getParent();
     }
 
@@ -379,9 +374,9 @@ public class TestKeyManagerImpl {
     writeClient.commitKey(keyArgs, keySession.getId());
     try {
       writeClient.createDirectory(keyArgs);
-      Assert.fail("Creation should fail for directory.");
+      fail("Creation should fail for directory.");
     } catch (OMException e) {
-      Assert.assertEquals(e.getResult(),
+      assertEquals(e.getResult(),
           OMException.ResultCodes.FILE_ALREADY_EXISTS);
     }
 
@@ -392,8 +387,8 @@ public class TestKeyManagerImpl {
         .build();
     writeClient.createDirectory(keyArgs);
     OzoneFileStatus fileStatus = keyManager.getFileStatus(keyArgs);
-    Assert.assertTrue(fileStatus.isDirectory());
-    Assert.assertTrue(fileStatus.getKeyInfo().getKeyLocationVersions().get(0)
+    assertTrue(fileStatus.isDirectory());
+    assertTrue(fileStatus.getKeyInfo().getKeyLocationVersions().get(0)
         .getLocationList().isEmpty());
   }
 
@@ -412,7 +407,7 @@ public class TestKeyManagerImpl {
     // try to open created key with overWrite flag set to false
     try {
       writeClient.createFile(keyArgs, false, false);
-      Assert.fail("Open key should fail for non overwrite create");
+      fail("Open key should fail for non overwrite create");
     } catch (OMException ex) {
       if (ex.getResult() != OMException.ResultCodes.FILE_ALREADY_EXISTS) {
         throw ex;
@@ -435,7 +430,7 @@ public class TestKeyManagerImpl {
         .build();
     try {
       writeClient.createFile(keyArgs, false, false);
-      Assert.fail("Open file should fail for non recursive write");
+      fail("Open file should fail for non recursive write");
     } catch (OMException ex) {
       if (ex.getResult() != OMException.ResultCodes.DIRECTORY_NOT_FOUND) {
         throw ex;
@@ -447,7 +442,7 @@ public class TestKeyManagerImpl {
     keyArgs.setLocationInfoList(
         keySession.getKeyInfo().getLatestVersionLocations().getLocationList());
     writeClient.commitKey(keyArgs, keySession.getId());
-    Assert.assertTrue(keyManager
+    assertTrue(keyManager
         .getFileStatus(keyArgs).isFile());
 
     // try creating a file over a directory
@@ -456,7 +451,7 @@ public class TestKeyManagerImpl {
         .build();
     try {
       writeClient.createFile(keyArgs, true, true);
-      Assert.fail("Open file should fail for non recursive write");
+      fail("Open file should fail for non recursive write");
     } catch (OMException ex) {
       if (ex.getResult() != OMException.ResultCodes.NOT_A_FILE) {
         throw ex;
@@ -485,7 +480,7 @@ public class TestKeyManagerImpl {
     boolean access = keyManager.checkAccess(fileKey, context);
 
     // THEN
-    Assert.assertTrue(access);
+    assertTrue(access);
     verify(mockScmContainerClient, never())
         .getContainerWithPipelineBatch(any());
   }
@@ -498,7 +493,7 @@ public class TestKeyManagerImpl {
     OzoneObj nonExistentKey = OzoneObjInfo.Builder.fromKeyArgs(keyArgs)
         .setStoreType(OzoneObj.StoreType.OZONE)
         .build();
-    Assert.assertTrue(keyManager.checkAccess(nonExistentKey,
+    assertTrue(keyManager.checkAccess(nonExistentKey,
             currentUserReads()));
   }
 
@@ -512,7 +507,7 @@ public class TestKeyManagerImpl {
     OzoneObj dirKey = OzoneObjInfo.Builder.fromKeyArgs(keyArgs)
         .setStoreType(OzoneObj.StoreType.OZONE)
         .build();
-    Assert.assertTrue(keyManager.checkAccess(dirKey, currentUserReads()));
+    assertTrue(keyManager.checkAccess(dirKey, currentUserReads()));
   }
 
   @Test
@@ -534,8 +529,8 @@ public class TestKeyManagerImpl {
     writeClient.addAcl(ozPrefix1, ozAcl1);
 
     List<OzoneAcl> ozAclGet = writeClient.getAcl(ozPrefix1);
-    Assert.assertEquals(1, ozAclGet.size());
-    Assert.assertEquals(ozAcl1, ozAclGet.get(0));
+    assertEquals(1, ozAclGet.size());
+    assertEquals(ozAcl1, ozAclGet.get(0));
 
     List<OzoneAcl> acls = new ArrayList<>();
     OzoneAcl ozAcl2 = new OzoneAcl(ACLIdentityType.USER, "admin",
@@ -562,56 +557,56 @@ public class TestKeyManagerImpl {
 
     writeClient.setAcl(ozPrefix1, acls);
     ozAclGet = writeClient.getAcl(ozPrefix1);
-    Assert.assertEquals(2, ozAclGet.size());
+    assertEquals(2, ozAclGet.size());
 
     int matchEntries = 0;
     for (OzoneAcl acl : ozAclGet) {
       if (acl.getType() == ACLIdentityType.GROUP) {
-        Assert.assertEquals(ozAcl3, acl);
+        assertEquals(ozAcl3, acl);
         matchEntries++;
       }
       if (acl.getType() == ACLIdentityType.USER) {
-        Assert.assertEquals(ozAcl2, acl);
+        assertEquals(ozAcl2, acl);
         matchEntries++;
       }
     }
-    Assert.assertEquals(2, matchEntries);
+    assertEquals(2, matchEntries);
 
     boolean result = writeClient.removeAcl(ozPrefix1, ozAcl4);
-    Assert.assertEquals(true, result);
+    assertEquals(true, result);
 
     ozAclGet = writeClient.getAcl(ozPrefix1);
-    Assert.assertEquals(2, ozAclGet.size());
+    assertEquals(2, ozAclGet.size());
 
     result = writeClient.removeAcl(ozPrefix1, ozAcl3);
-    Assert.assertEquals(true, result);
+    assertEquals(true, result);
     ozAclGet = writeClient.getAcl(ozPrefix1);
-    Assert.assertEquals(1, ozAclGet.size());
+    assertEquals(1, ozAclGet.size());
 
-    Assert.assertEquals(ozAcl2, ozAclGet.get(0));
+    assertEquals(ozAcl2, ozAclGet.get(0));
 
     // add dev:w
     writeClient.addAcl(ozPrefix1, ozAcl4);
     ozAclGet = writeClient.getAcl(ozPrefix1);
-    Assert.assertEquals(2, ozAclGet.size());
+    assertEquals(2, ozAclGet.size());
 
     // add dev:r and validate the acl bitset combined
     writeClient.addAcl(ozPrefix1, ozAcl5);
     ozAclGet = writeClient.getAcl(ozPrefix1);
-    Assert.assertEquals(2, ozAclGet.size());
+    assertEquals(2, ozAclGet.size());
 
     matchEntries = 0;
     for (OzoneAcl acl : ozAclGet) {
       if (acl.getType() == ACLIdentityType.GROUP) {
-        Assert.assertEquals(ozAcl3, acl);
+        assertEquals(ozAcl3, acl);
         matchEntries++;
       }
       if (acl.getType() == ACLIdentityType.USER) {
-        Assert.assertEquals(ozAcl2, acl);
+        assertEquals(ozAcl2, acl);
         matchEntries++;
       }
     }
-    Assert.assertEquals(2, matchEntries);
+    assertEquals(2, matchEntries);
     // cleanup
     writeClient.removeAcl(ozPrefix1, ozAcl1);
     writeClient.removeAcl(ozPrefix1, ozAcl2);
@@ -638,9 +633,9 @@ public class TestKeyManagerImpl {
         .build();
 
     // add acl with invalid prefix name
-    exception.expect(OMException.class);
-    exception.expectMessage("Invalid prefix name");
-    writeClient.addAcl(ozInvalidPrefix, ozAcl1);
+    Exception ex = assertThrows(OMException.class,
+        () -> writeClient.addAcl(ozInvalidPrefix, ozAcl1));
+    assertEquals("Invalid prefix name", ex.getMessage());
 
     OzoneObj ozPrefix1 = new OzoneObjInfo.Builder()
         .setVolumeName(volumeName)
@@ -652,25 +647,25 @@ public class TestKeyManagerImpl {
 
     writeClient.addAcl(ozPrefix1, ozAcl1);
     List<OzoneAcl> ozAclGet = writeClient.getAcl(ozPrefix1);
-    Assert.assertEquals(1, ozAclGet.size());
-    Assert.assertEquals(ozAcl1, ozAclGet.get(0));
+    assertEquals(1, ozAclGet.size());
+    assertEquals(ozAcl1, ozAclGet.get(0));
 
     // get acl with invalid prefix name
-    exception.expect(OMException.class);
-    exception.expectMessage("Invalid prefix name");
-    writeClient.getAcl(ozInvalidPrefix);
+    ex = assertThrows(OMException.class,
+        () -> writeClient.getAcl(ozInvalidPrefix));
+    assertEquals("Invalid prefix name", ex.getMessage());
 
     // set acl with invalid prefix name
     List<OzoneAcl> ozoneAcls = new ArrayList<OzoneAcl>();
     ozoneAcls.add(ozAcl1);
-    exception.expect(OMException.class);
-    exception.expectMessage("Invalid prefix name");
-    writeClient.setAcl(ozInvalidPrefix, ozoneAcls);
+    ex = assertThrows(OMException.class,
+        () -> writeClient.setAcl(ozInvalidPrefix, ozoneAcls));
+    assertEquals("Invalid prefix name", ex.getMessage());
 
     // remove acl with invalid prefix name
-    exception.expect(OMException.class);
-    exception.expectMessage("Invalid prefix name");
-    writeClient.removeAcl(ozInvalidPrefix, ozAcl1);
+    ex = assertThrows(OMException.class,
+        () -> writeClient.removeAcl(ozInvalidPrefix, ozAcl1));
+    assertEquals("Invalid prefix name", ex.getMessage());
   }
 
   @Test
@@ -703,7 +698,7 @@ public class TestKeyManagerImpl {
 
     List<OmPrefixInfo> prefixInfos =
         prefixManager.getLongestPrefixPath(ozFile1.getPath());
-    Assert.assertEquals(5, prefixInfos.size());
+    assertEquals(5, prefixInfos.size());
 
     OzoneObj ozFile2 = new OzoneObjInfo.Builder()
         .setVolumeName(volumeName)
@@ -715,12 +710,12 @@ public class TestKeyManagerImpl {
 
     prefixInfos =
         prefixManager.getLongestPrefixPath(ozFile2.getPath());
-    Assert.assertEquals(7, prefixInfos.size());
+    assertEquals(7, prefixInfos.size());
     // Only the last node has acl on it
-    Assert.assertEquals(ozAcl1, prefixInfos.get(6).getAcls().get(0));
+    assertEquals(ozAcl1, prefixInfos.get(6).getAcls().get(0));
     // All other nodes don't have acl value associate with it
     for (int i = 0; i < 6; i++) {
-      Assert.assertEquals(null, prefixInfos.get(i));
+      assertEquals(null, prefixInfos.get(i));
     }
     // cleanup
     writeClient.removeAcl(ozPrefix1, ozAcl1);
@@ -736,7 +731,7 @@ public class TestKeyManagerImpl {
     // lookup for a non-existent file
     try {
       keyManager.lookupFile(keyArgs, null);
-      Assert.fail("Lookup file should fail for non existent file");
+      fail("Lookup file should fail for non existent file");
     } catch (OMException ex) {
       if (ex.getResult() != OMException.ResultCodes.FILE_NOT_FOUND) {
         throw ex;
@@ -748,7 +743,7 @@ public class TestKeyManagerImpl {
     keyArgs.setLocationInfoList(
         keySession.getKeyInfo().getLatestVersionLocations().getLocationList());
     writeClient.commitKey(keyArgs, keySession.getId());
-    Assert.assertEquals(keyManager.lookupFile(keyArgs, null).getKeyName(),
+    assertEquals(keyManager.lookupFile(keyArgs, null).getKeyName(),
         keyName);
 
     // lookup for created file
@@ -757,7 +752,7 @@ public class TestKeyManagerImpl {
         .build();
     try {
       keyManager.lookupFile(keyArgs, null);
-      Assert.fail("Lookup file should fail for a directory");
+      fail("Lookup file should fail for a directory");
     } catch (OMException ex) {
       if (ex.getResult() != OMException.ResultCodes.NOT_A_FILE) {
         throw ex;
@@ -780,7 +775,7 @@ public class TestKeyManagerImpl {
     // lookup for a non-existent key
     try {
       keyManager.lookupKey(keyArgs, null);
-      Assert.fail("Lookup key should fail for non existent key");
+      fail("Lookup key should fail for non existent key");
     } catch (OMException ex) {
       if (ex.getResult() != OMException.ResultCodes.KEY_NOT_FOUND) {
         throw ex;
@@ -797,15 +792,15 @@ public class TestKeyManagerImpl {
         1, null, null, null, null, 0));
     nodeList.add((DatanodeDetails)scm.getClusterMap().getNode(
         2, null, null, null, null, 0));
-    Assume.assumeFalse(nodeList.get(0).equals(nodeList.get(1)));
-    Assume.assumeFalse(nodeList.get(0).equals(nodeList.get(2)));
+    assumeFalse(nodeList.get(0).equals(nodeList.get(1)));
+    assumeFalse(nodeList.get(0).equals(nodeList.get(2)));
     // create a pipeline using 3 datanodes
     Pipeline pipeline = scm.getPipelineManager().createPipeline(
         RatisReplicationConfig.getInstance(ReplicationFactor.THREE), nodeList);
     List<OmKeyLocationInfo> locationInfoList = new ArrayList<>();
     List<OmKeyLocationInfo> locationList =
         keySession.getKeyInfo().getLatestVersionLocations().getLocationList();
-    Assert.assertEquals(1, locationList.size());
+    assertEquals(1, locationList.size());
     long containerID = locationList.get(0).getContainerID();
     locationInfoList.add(
         new OmKeyLocationInfo.Builder().setPipeline(pipeline)
@@ -822,7 +817,7 @@ public class TestKeyManagerImpl {
         Arrays.asList(containerID))).thenReturn(containerWithPipelines);
 
     OmKeyInfo key = keyManager.lookupKey(keyArgs, null);
-    Assert.assertEquals(key.getKeyName(), keyName);
+    assertEquals(key.getKeyName(), keyName);
     List<OmKeyLocationInfo> keyLocations =
         key.getLatestVersionLocations().getLocationList();
     DatanodeDetails leader =
@@ -831,28 +826,28 @@ public class TestKeyManagerImpl {
         keyLocations.get(0).getPipeline().getNodes().get(1);
     DatanodeDetails follower2 =
         keyLocations.get(0).getPipeline().getNodes().get(2);
-    Assert.assertNotEquals(leader, follower1);
-    Assert.assertNotEquals(follower1, follower2);
+    assertNotEquals(leader, follower1);
+    assertNotEquals(follower1, follower2);
 
     // lookup key, leader as client
     OmKeyInfo key1 = keyManager.lookupKey(keyArgs, leader.getIpAddress());
-    Assert.assertEquals(leader, key1.getLatestVersionLocations()
+    assertEquals(leader, key1.getLatestVersionLocations()
         .getLocationList().get(0).getPipeline().getClosestNode());
 
     // lookup key, follower1 as client
     OmKeyInfo key2 = keyManager.lookupKey(keyArgs, follower1.getIpAddress());
-    Assert.assertEquals(follower1, key2.getLatestVersionLocations()
+    assertEquals(follower1, key2.getLatestVersionLocations()
         .getLocationList().get(0).getPipeline().getClosestNode());
 
     // lookup key, follower2 as client
     OmKeyInfo key3 = keyManager.lookupKey(keyArgs, follower2.getIpAddress());
-    Assert.assertEquals(follower2, key3.getLatestVersionLocations()
+    assertEquals(follower2, key3.getLatestVersionLocations()
         .getLocationList().get(0).getPipeline().getClosestNode());
 
     // lookup key, random node as client
     OmKeyInfo key4 = keyManager.lookupKey(keyArgs,
         "/d=default-drack/127.0.0.1");
-    Assert.assertEquals(leader, key4.getLatestVersionLocations()
+    assertEquals(leader, key4.getLatestVersionLocations()
         .getLocationList().get(0).getPipeline().getClosestNode());
   }
 
@@ -867,7 +862,7 @@ public class TestKeyManagerImpl {
     // lookup for a non-existent key
     try {
       keyManager.lookupKey(keyArgs, null);
-      Assert.fail("Lookup key should fail for non existent key");
+      fail("Lookup key should fail for non existent key");
     } catch (OMException ex) {
       if (ex.getResult() != OMException.ResultCodes.KEY_NOT_FOUND) {
         throw ex;
@@ -884,15 +879,15 @@ public class TestKeyManagerImpl {
         1, null, null, null, null, 0));
     nodeList.add((DatanodeDetails)scm.getClusterMap().getNode(
         2, null, null, null, null, 0));
-    Assume.assumeFalse(nodeList.get(0).equals(nodeList.get(1)));
-    Assume.assumeFalse(nodeList.get(0).equals(nodeList.get(2)));
+    assumeFalse(nodeList.get(0).equals(nodeList.get(1)));
+    assumeFalse(nodeList.get(0).equals(nodeList.get(2)));
     // create a pipeline using 3 datanodes
     Pipeline pipeline = scm.getPipelineManager().createPipeline(
         RatisReplicationConfig.getInstance(ReplicationFactor.THREE), nodeList);
     List<OmKeyLocationInfo> locationInfoList = new ArrayList<>();
     List<OmKeyLocationInfo> locationList =
         keySession.getKeyInfo().getLatestVersionLocations().getLocationList();
-    Assert.assertEquals(1, locationList.size());
+    assertEquals(1, locationList.size());
     locationInfoList.add(
         new OmKeyLocationInfo.Builder().setPipeline(pipeline)
             .setBlockID(new BlockID(locationList.get(0).getContainerID(),
@@ -909,30 +904,30 @@ public class TestKeyManagerImpl {
         Arrays.asList(1L))).thenReturn(containerWithPipelines);
 
     OmKeyInfo key = keyManager.lookupKey(keyArgs, null);
-    Assert.assertEquals(key.getKeyLocationVersions().size(), 1);
+    assertEquals(key.getKeyLocationVersions().size(), 1);
 
     keySession = writeClient.createFile(keyArgs, true, true);
     writeClient.commitKey(keyArgs, keySession.getId());
 
     // Test lookupKey (latestLocationVersion == true)
     key = keyManager.lookupKey(keyArgs, null);
-    Assert.assertEquals(key.getKeyLocationVersions().size(), 1);
+    assertEquals(key.getKeyLocationVersions().size(), 1);
 
     // Test ListStatus (latestLocationVersion == true)
     List<OzoneFileStatus> fileStatuses =
         keyManager.listStatus(keyArgs, false, "", 1);
-    Assert.assertEquals(fileStatuses.size(), 1);
-    Assert.assertEquals(fileStatuses.get(0).getKeyInfo()
+    assertEquals(fileStatuses.size(), 1);
+    assertEquals(fileStatuses.get(0).getKeyInfo()
         .getKeyLocationVersions().size(), 1);
 
     // Test GetFileStatus (latestLocationVersion == true)
     OzoneFileStatus ozoneFileStatus = keyManager.getFileStatus(keyArgs, null);
-    Assert.assertEquals(ozoneFileStatus.getKeyInfo()
+    assertEquals(ozoneFileStatus.getKeyInfo()
         .getKeyLocationVersions().size(), 1);
 
     // Test LookupFile (latestLocationVersion == true)
     key = keyManager.lookupFile(keyArgs, null);
-    Assert.assertEquals(key.getKeyLocationVersions().size(), 1);
+    assertEquals(key.getKeyLocationVersions().size(), 1);
 
     keyArgs = createBuilder(VERSIONED_BUCKET_NAME)
         .setKeyName(keyName)
@@ -941,28 +936,28 @@ public class TestKeyManagerImpl {
 
     // Test lookupKey (latestLocationVersion == false)
     key = keyManager.lookupKey(keyArgs, null);
-    Assert.assertEquals(key.getKeyLocationVersions().size(), 2);
+    assertEquals(key.getKeyLocationVersions().size(), 2);
 
     // Test ListStatus (latestLocationVersion == false)
     fileStatuses = keyManager.listStatus(keyArgs, false, "", 100);
-    Assert.assertEquals(fileStatuses.size(), 1);
-    Assert.assertEquals(fileStatuses.get(0).getKeyInfo()
+    assertEquals(fileStatuses.size(), 1);
+    assertEquals(fileStatuses.get(0).getKeyInfo()
         .getKeyLocationVersions().size(), 2);
 
     // Test GetFileStatus (latestLocationVersion == false)
     ozoneFileStatus = keyManager.getFileStatus(keyArgs, null);
-    Assert.assertEquals(ozoneFileStatus.getKeyInfo()
+    assertEquals(ozoneFileStatus.getKeyInfo()
         .getKeyLocationVersions().size(), 2);
 
     // Test LookupFile (latestLocationVersion == false)
     key = keyManager.lookupFile(keyArgs, null);
-    Assert.assertEquals(key.getKeyLocationVersions().size(), 2);
+    assertEquals(key.getKeyLocationVersions().size(), 2);
 
     // Test ListKeys (latestLocationVersion is always true for ListKeys)
     List<OmKeyInfo> keyInfos = keyManager.listKeys(keyArgs.getVolumeName(),
         keyArgs.getBucketName(), "", keyArgs.getKeyName(), 100);
-    Assert.assertEquals(keyInfos.size(), 1);
-    Assert.assertEquals(keyInfos.get(0).getKeyLocationVersions().size(), 1);
+    assertEquals(keyInfos.size(), 1);
+    assertEquals(keyInfos.get(0).getKeyLocationVersions().size(), 1);
   }
 
   @Test
@@ -990,17 +985,17 @@ public class TestKeyManagerImpl {
     // Get entries in both TableCache and DB
     List<OzoneFileStatus> fileStatuses =
         keyManager.listStatus(rootDirArgs, true, "", 1000);
-    Assert.assertEquals(100, fileStatuses.size());
+    assertEquals(100, fileStatuses.size());
 
     // Get entries with startKey=prefixKeyInDB
     fileStatuses =
         keyManager.listStatus(rootDirArgs, true, prefixKeyInDB, 1000);
-    Assert.assertEquals(50, fileStatuses.size());
+    assertEquals(50, fileStatuses.size());
 
     // Get entries with startKey=prefixKeyInCache
     fileStatuses =
         keyManager.listStatus(rootDirArgs, true, prefixKeyInCache, 1000);
-    Assert.assertEquals(100, fileStatuses.size());
+    assertEquals(100, fileStatuses.size());
 
     // Clean up cache by marking those keys in cache as deleted
     for (int i = 1; i <= 100; i += 2) {
@@ -1033,12 +1028,12 @@ public class TestKeyManagerImpl {
     // Test listStatus with recursive=false, should only have dirs under root
     List<OzoneFileStatus> fileStatuses =
         keyManager.listStatus(rootDirArgs, false, "", 1000);
-    Assert.assertEquals(2, fileStatuses.size());
+    assertEquals(2, fileStatuses.size());
 
     // Test listStatus with recursive=true, should have dirs under root and
     fileStatuses =
         keyManager.listStatus(rootDirArgs, true, "", 1000);
-    Assert.assertEquals(3, fileStatuses.size());
+    assertEquals(3, fileStatuses.size());
 
     // Add a total of 10 key entries to DB and TableCache under dir1
     String prefixKeyInDB = "key-d";
@@ -1062,12 +1057,12 @@ public class TestKeyManagerImpl {
     // Test non-recursive, should return the dir under root
     fileStatuses =
         keyManager.listStatus(rootDirArgs, false, "", 1000);
-    Assert.assertEquals(2, fileStatuses.size());
+    assertEquals(2, fileStatuses.size());
 
     // Test recursive, should return the dir and the keys in it
     fileStatuses =
         keyManager.listStatus(rootDirArgs, true, "", 1000);
-    Assert.assertEquals(10 + 3, fileStatuses.size());
+    assertEquals(10 + 3, fileStatuses.size());
 
     // Clean up
     for (int i = 1; i <= 10; i += 2) {
@@ -1115,23 +1110,23 @@ public class TestKeyManagerImpl {
     List<OzoneFileStatus> fileStatuses =
         keyManager.listStatus(rootDirArgs, true, "", 1000);
     // Should only get entries that are not marked as deleted.
-    Assert.assertEquals(50, fileStatuses.size());
+    assertEquals(50, fileStatuses.size());
     // Test startKey
     fileStatuses =
         keyManager.listStatus(rootDirArgs, true, prefixKey, 1000);
     // Should only get entries that are not marked as deleted.
-    Assert.assertEquals(50, fileStatuses.size());
+    assertEquals(50, fileStatuses.size());
     // Verify result
     TreeSet<String> expectedKeys = new TreeSet<>();
     for (OzoneFileStatus fileStatus : fileStatuses) {
       String keyName = fileStatus.getKeyInfo().getKeyName();
       expectedKeys.add(keyName);
-      Assert.assertTrue(keyName.startsWith(prefixKey));
+      assertTrue(keyName.startsWith(prefixKey));
     }
-    Assert.assertEquals(expectedKeys, existKeySet);
+    assertEquals(expectedKeys, existKeySet);
 
     // Sanity check, existKeySet should not intersect with deletedKeySet.
-    Assert.assertEquals(0,
+    assertEquals(0,
         Sets.intersection(existKeySet, deletedKeySet).size());
 
     // Next, mark half of the entries left as deleted
@@ -1153,16 +1148,16 @@ public class TestKeyManagerImpl {
     fileStatuses = keyManager.listStatus(
         rootDirArgs, true, "", 1000);
     // Should only get entries that are not marked as deleted.
-    Assert.assertEquals(50 / 2, fileStatuses.size());
+    assertEquals(50 / 2, fileStatuses.size());
 
     // Verify result
     expectedKeys.clear();
     for (OzoneFileStatus fileStatus : fileStatuses) {
       String keyName = fileStatus.getKeyInfo().getKeyName();
       expectedKeys.add(keyName);
-      Assert.assertTrue(keyName.startsWith(prefixKey));
+      assertTrue(keyName.startsWith(prefixKey));
     }
-    Assert.assertEquals(expectedKeys, existKeySet);
+    assertEquals(expectedKeys, existKeySet);
 
     // Test pagination
     final int batchSize = 5;
@@ -1178,12 +1173,12 @@ public class TestKeyManagerImpl {
       for (OzoneFileStatus fileStatus : fileStatuses) {
         startKey = fileStatus.getKeyInfo().getKeyName();
         expectedKeys.add(startKey);
-        Assert.assertTrue(startKey.startsWith(prefixKey));
+        assertTrue(startKey.startsWith(prefixKey));
       }
       // fileStatuses.size() == batchSize indicates there might be another batch
       // fileStatuses.size() < batchSize indicates it is the last batch
     } while (fileStatuses.size() == batchSize);
-    Assert.assertEquals(expectedKeys, existKeySet);
+    assertEquals(expectedKeys, existKeySet);
 
     // Clean up by marking remaining entries as deleted
     for (String key : existKeySet) {
@@ -1196,7 +1191,7 @@ public class TestKeyManagerImpl {
     }
     // Update existKeySet
     existKeySet.removeAll(deletedKeySet);
-    Assert.assertTrue(existKeySet.isEmpty());
+    assertTrue(existKeySet.isEmpty());
   }
 
   @Test
@@ -1221,18 +1216,18 @@ public class TestKeyManagerImpl {
     List<OzoneFileStatus> fileStatuses =
         keyManager.listStatus(rootDirArgs, true, "", 100);
     // verify the number of status returned is same as number of entries
-    Assert.assertEquals(numEntries, fileStatuses.size());
+    assertEquals(numEntries, fileStatuses.size());
 
     fileStatuses = keyManager.listStatus(rootDirArgs, false, "", 100);
     // the number of immediate children of root is 1
-    Assert.assertEquals(1, fileStatuses.size());
+    assertEquals(1, fileStatuses.size());
 
     // if startKey is the first descendant of the root then listStatus should
     // return all the entries.
     String startKey = children.iterator().next();
     fileStatuses = keyManager.listStatus(rootDirArgs, true,
         startKey.substring(0, startKey.length() - 1), 100);
-    Assert.assertEquals(numEntries, fileStatuses.size());
+    assertEquals(numEntries, fileStatuses.size());
 
     for (String directory : directorySet) {
       // verify status list received for each directory with recursive flag set
@@ -1294,7 +1289,7 @@ public class TestKeyManagerImpl {
         keySession.getKeyInfo().getLatestVersionLocations().getLocationList());
     writeClient.commitKey(keyArgs, keySession.getId());
     OzoneFileStatus ozoneFileStatus = keyManager.getFileStatus(keyArgs);
-    Assert.assertEquals(keyName, ozoneFileStatus.getKeyInfo().getFileName());
+    assertEquals(keyName, ozoneFileStatus.getKeyInfo().getFileName());
   }
 
   @Test
@@ -1323,32 +1318,32 @@ public class TestKeyManagerImpl {
 
     // verify key "dir1/key1" and "dir1.key1" can be found in the bucket, and
     // "dir1" can not be found in the bucket
-    Assert.assertNull(metadataManager.getKeyTable(getDefaultBucketLayout())
+    assertNull(metadataManager.getKeyTable(getDefaultBucketLayout())
         .get(metadataManager.getOzoneKey(VOLUME_NAME, BUCKET_NAME, parentDir)));
-    Assert.assertNotNull(metadataManager.getKeyTable(getDefaultBucketLayout())
+    assertNotNull(metadataManager.getKeyTable(getDefaultBucketLayout())
         .get(metadataManager.getOzoneKey(VOLUME_NAME, BUCKET_NAME, keyName1)));
-    Assert.assertNotNull(metadataManager.getKeyTable(getDefaultBucketLayout())
+    assertNotNull(metadataManager.getKeyTable(getDefaultBucketLayout())
         .get(metadataManager.getOzoneKey(VOLUME_NAME, BUCKET_NAME, keyName2)));
 
     // get a non-existing "dir1", since the key is prefixed "dir1/key1",
     // a fake "/dir1" will be returned
     keyArgs = createBuilder().setKeyName(parentDir).build();
     ozoneFileStatus = keyManager.getFileStatus(keyArgs);
-    Assert.assertEquals(parentDir, ozoneFileStatus.getKeyInfo().getFileName());
-    Assert.assertTrue(ozoneFileStatus.isDirectory());
+    assertEquals(parentDir, ozoneFileStatus.getKeyInfo().getFileName());
+    assertTrue(ozoneFileStatus.isDirectory());
 
     // get a non-existing "dir", since the key is not prefixed "dir1/key1",
     // a `OMException` will be thrown
     keyArgs = createBuilder().setKeyName("dir").build();
     OmKeyArgs finalKeyArgs = keyArgs;
-    Assert.assertThrows(OMException.class, () -> keyManager.getFileStatus(
+    assertThrows(OMException.class, () -> keyManager.getFileStatus(
         finalKeyArgs));
 
     // get a file "dir1/key1"
     keyArgs = createBuilder().setKeyName(keyName1).build();
     ozoneFileStatus = keyManager.getFileStatus(keyArgs);
-    Assert.assertEquals(fileName, ozoneFileStatus.getKeyInfo().getFileName());
-    Assert.assertTrue(ozoneFileStatus.isFile());
+    assertEquals(fileName, ozoneFileStatus.getKeyInfo().getFileName());
+    assertTrue(ozoneFileStatus.isFile());
   }
 
   @Test
@@ -1459,10 +1454,10 @@ public class TestKeyManagerImpl {
 
     try {
       keyManagerImpl.refresh(omKeyInfo);
-      Assert.fail();
+      fail();
     } catch (OMException omEx) {
-      Assert.assertEquals(SCM_GET_PIPELINE_EXCEPTION, omEx.getResult());
-      Assert.assertTrue(omEx.getMessage().equals(errorMessage));
+      assertEquals(SCM_GET_PIPELINE_EXCEPTION, omEx.getResult());
+      assertTrue(omEx.getMessage().equals(errorMessage));
     }
   }
 
@@ -1523,17 +1518,15 @@ public class TestKeyManagerImpl {
       if (!recursive) {
         // if recursive is false, verify all the statuses have the input
         // directory as parent
-        Assert.assertEquals(parent, directory);
+        assertEquals(parent, directory);
       }
       // verify filestatus is present in directory or file set accordingly
       if (fileStatus.isDirectory()) {
-        Assert
-            .assertTrue(directorySet + " doesn't contain " + normalizedKeyName,
-                directorySet.contains(normalizedKeyName));
+        assertTrue(directorySet.contains(normalizedKeyName),
+            directorySet + " doesn't contain " + normalizedKeyName);
       } else {
-        Assert
-            .assertTrue(fileSet + " doesn't contain " + normalizedKeyName,
-                fileSet.contains(normalizedKeyName));
+        assertTrue(fileSet.contains(normalizedKeyName),
+            fileSet + " doesn't contain " + normalizedKeyName);
       }
     }
 
@@ -1553,7 +1546,7 @@ public class TestKeyManagerImpl {
       }
     }
     // verify the number of entries match the status list size
-    Assert.assertEquals(fileStatuses.size(), numEntries);
+    assertEquals(fileStatuses.size(), numEntries);
   }
 
   private Set<String> createDirectories(String parent,


### PR DESCRIPTION
## What changes were proposed in this pull request?

HDDS-7871 (#4236) needs to add a JUnit 5 test to TestKeyManagerImpl.

Better to do the migration first.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-7921

## How was this patch tested?

Full CI: https://github.com/kaijchen/ozone/actions/runs/4120563700