### PR TITLE
HDDS-7923. [EC] Reconstruction is failing with IndexOutOfBoundsException

### DIFF
--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/storage/ECBlockOutputStream.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/storage/ECBlockOutputStream.java
@@ -117,7 +117,8 @@ public class ECBlockOutputStream extends BlockOutputStream {
         continue;
       }
       List<ChunkInfo> chunks = bd.getChunks();
-      if (chunks != null && chunks.get(0).hasStripeChecksum()) {
+      if (chunks != null && chunks.size() > 0 && chunks.get(0)
+          .hasStripeChecksum()) {
         checksumBlockData = bd;
         break;
       }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/storage/TestContainerCommandsEC.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/storage/TestContainerCommandsEC.java
@@ -349,8 +349,15 @@ public class TestContainerCommandsEC {
   @MethodSource("recoverableMissingIndexes")
   void testECReconstructionCoordinatorWith(List<Integer> missingIndexes)
       throws Exception {
-    testECReconstructionCoordinator(missingIndexes);
+    testECReconstructionCoordinator(missingIndexes, 3);
   }
+
+  @Test
+  void testECReconstructionWithPartialStripe()
+          throws Exception {
+    testECReconstructionCoordinator(ImmutableList.of(4, 5), 1);
+  }
+
 
   static Stream<List<Integer>> recoverableMissingIndexes() {
     return Stream
@@ -367,7 +374,7 @@ public class TestContainerCommandsEC {
   public void testECReconstructionCoordinatorWithMissingIndexes135() {
     InsufficientLocationsException exception =
         Assert.assertThrows(InsufficientLocationsException.class, () -> {
-          testECReconstructionCoordinator(ImmutableList.of(1, 3, 5));
+          testECReconstructionCoordinator(ImmutableList.of(1, 3, 5), 3);
         });
 
     String expectedMessage =
@@ -377,8 +384,8 @@ public class TestContainerCommandsEC {
     Assert.assertEquals(expectedMessage, actualMessage);
   }
 
-  private void testECReconstructionCoordinator(List<Integer> missingIndexes)
-      throws Exception {
+  private void testECReconstructionCoordinator(List<Integer> missingIndexes,
+      int numInputChunks) throws Exception {
     ObjectStore objectStore = rpcClient.getObjectStore();
     String keyString = UUID.randomUUID().toString();
     String volumeName = UUID.randomUUID().toString();
@@ -389,7 +396,7 @@ public class TestContainerCommandsEC {
     OzoneBucket bucket = volume.getBucket(bucketName);
     XceiverClientManager xceiverClientManager =
         new XceiverClientManager(config);
-    createKeyAndWriteData(keyString, bucket);
+    createKeyAndWriteData(keyString, bucket, numInputChunks);
     ECReconstructionCoordinator coordinator =
         new ECReconstructionCoordinator(config, certClient,
             null, ECReconstructionMetrics.create());
@@ -499,9 +506,9 @@ public class TestContainerCommandsEC {
     Assertions.assertEquals(metrics.getReconstructionTotal(), 1L);
   }
 
-  private void createKeyAndWriteData(String keyString, OzoneBucket bucket)
+  private void createKeyAndWriteData(String keyString, OzoneBucket bucket, int numChunks)
       throws IOException {
-    for (int i = 0; i < EC_DATA; i++) {
+    for (int i = 0; i < numChunks; i++) {
       inputChunks[i] = getBytesWith(i + 1, EC_CHUNK_SIZE);
     }
     try (OzoneOutputStream out = bucket.createKey(keyString, 4096,
@@ -525,7 +532,7 @@ public class TestContainerCommandsEC {
     objectStore.getVolume(volumeName).createBucket(bucketName);
     OzoneVolume volume = objectStore.getVolume(volumeName);
     OzoneBucket bucket = volume.getBucket(bucketName);
-    createKeyAndWriteData(keyString, bucket);
+    createKeyAndWriteData(keyString, bucket, 3);
 
     OzoneKeyDetails key = bucket.getKey(keyString);
     long conID = key.getOzoneKeyLocations().get(0).getContainerID();

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/storage/TestContainerCommandsEC.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/storage/TestContainerCommandsEC.java
@@ -514,7 +514,7 @@ public class TestContainerCommandsEC {
     try (OzoneOutputStream out = bucket.createKey(keyString, 4096,
         new ECReplicationConfig(3, 2, EcCodec.RS, 1024), new HashMap<>())) {
       Assert.assertTrue(out.getOutputStream() instanceof KeyOutputStream);
-      for (int i = 0; i < inputChunks.length; i++) {
+      for (int i = 0; i < numChunks; i++) {
         out.write(inputChunks[i]);
       }
     }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/storage/TestContainerCommandsEC.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/storage/TestContainerCommandsEC.java
@@ -506,8 +506,8 @@ public class TestContainerCommandsEC {
     Assertions.assertEquals(metrics.getReconstructionTotal(), 1L);
   }
 
-  private void createKeyAndWriteData(String keyString, OzoneBucket bucket, int numChunks)
-      throws IOException {
+  private void createKeyAndWriteData(String keyString, OzoneBucket bucket,
+      int numChunks) throws IOException {
     for (int i = 0; i < numChunks; i++) {
       inputChunks[i] = getBytesWith(i + 1, EC_CHUNK_SIZE);
     }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Handled the case when chunk list null, but getChunks internal method returning empty list. In this case, we have made wrong assumption and access array elements. This fixed the issue and added the necessary checks.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-7923


## How was this patch tested?

Added the test.