### PR TITLE
HDDS-7915. Force close QUASI_CLOSED replicas only when the container is CLOSED in Legacy RM

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/LegacyReplicationManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/LegacyReplicationManager.java
@@ -1951,7 +1951,8 @@ public class LegacyReplicationManager {
         sendCloseCommand(container, replica.getDatanodeDetails(), false);
         numCloseCmdsSent++;
         iterator.remove();
-      } else if (state == State.QUASI_CLOSED) {
+      } else if (state == State.QUASI_CLOSED &&
+          container.getState() == LifeCycleState.CLOSED) {
         // Send force close command if the BCSID matches
         if (container.getSequenceId() == replica.getSequenceId()) {
           sendCloseCommand(container, replica.getDatanodeDetails(), true);


### PR DESCRIPTION
## What changes were proposed in this pull request?

LegacyReplicationManager#closeReplicasIfPossible tries to close replicas. 

```
  private int closeReplicasIfPossible(ContainerInfo container,
                                      List<ContainerReplica> replicas) {
    // This method should not be used on open containers.
    if (container.getState() == LifeCycleState.OPEN) {
      return 0;
    }

    int numCloseCmdsSent = 0;
    Iterator<ContainerReplica> iterator = replicas.iterator();
    while (iterator.hasNext()) {
      final ContainerReplica replica = iterator.next();
      final State state = replica.getState();
      if (state == State.OPEN || state == State.CLOSING) {
        sendCloseCommand(container, replica.getDatanodeDetails(), false);
        numCloseCmdsSent++;
        iterator.remove();
      } else if (state == State.QUASI_CLOSED) {
        // Send force close command if the BCSID matches
        if (container.getSequenceId() == replica.getSequenceId()) {
          sendCloseCommand(container, replica.getDatanodeDetails(), true);
          numCloseCmdsSent++;
          iterator.remove();
        }
      }
    }

    return numCloseCmdsSent;
  }
```

In one case, this method is called from LegacyReplicationManager#handleUnderReplicatedUnhealthy, where the replica's state matches the container state. If the state is QUASI_CLOSED, we will end up closing the replica and eventually the container, even though the replica doesn't have all the data. This should not happen and is what this jira is meant to fix. Force closing a QUASI_CLOSED replica of a QUASI_CLOSED container is handled separately earlier in the processContainer method.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-7915

## How was this patch tested?

Added UT