### PR TITLE
HDDS-7928. EC: Change ContainerReplicaPendingOps to store deadline rather than scheduled time

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/ScmConfigKeys.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/ScmConfigKeys.java
@@ -370,10 +370,6 @@ public final class ScmConfigKeys {
   public static final String
       OZONE_SCM_EXPIRED_CONTAINER_REPLICA_OP_SCRUB_INTERVAL_DEFAULT =
       "5m";
-  public static final String OZONE_SCM_CONTAINER_REPLICA_OP_TIME_OUT =
-      "ozone.scm.expired.container.replica.op.time.out";
-  public static final String
-      OZONE_SCM_CONTAINER_REPLICA_OP_TIME_OUT_DEFAULT = "30m";
 
   // Upper limit for how many pipelines can be created
   // across the cluster nodes managed by SCM.

--- a/hadoop-hdds/common/src/main/resources/ozone-default.xml
+++ b/hadoop-hdds/common/src/main/resources/ozone-default.xml
@@ -1476,15 +1476,6 @@
     </description>
   </property>
   <property>
-    <name>ozone.scm.expired.container.replica.op.time.out</name>
-    <value>30m</value>
-    <tag>OZONE, SCM, CONTAINER</tag>
-    <description>
-      Timeout for the container replica operations(ADD/DELETE).After this
-      timeout the command will be retied
-    </description>
-  </property>
-  <property>
     <name>ozone.scm.pipeline.creation.auto.factor.one</name>
     <value>true</value>
     <tag>OZONE, SCM, PIPELINE</tag>

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ContainerReplicaOp.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ContainerReplicaOp.java
@@ -34,7 +34,7 @@ public class ContainerReplicaOp {
   private PendingOpType opType;
   private DatanodeDetails target;
   private int replicaIndex;
-  private long scheduledEpochMillis;
+  private long deadlineEpochMillis;
 
   public static ContainerReplicaOp create(PendingOpType opType,
       DatanodeDetails target, int replicaIndex) {
@@ -47,7 +47,7 @@ public class ContainerReplicaOp {
     this.opType = opType;
     this.target = target;
     this.replicaIndex = replicaIndex;
-    this.scheduledEpochMillis = scheduledTime;
+    this.deadlineEpochMillis = scheduledTime;
   }
 
   public PendingOpType getOpType() {
@@ -62,8 +62,8 @@ public class ContainerReplicaOp {
     return replicaIndex;
   }
 
-  public long getScheduledEpochMillis() {
-    return scheduledEpochMillis;
+  public long getDeadlineEpochMillis() {
+    return deadlineEpochMillis;
   }
 
 }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ContainerReplicaPendingOps.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ContainerReplicaPendingOps.java
@@ -91,10 +91,13 @@ public class ContainerReplicaPendingOps {
    * @param containerID ContainerID for which to add a replica
    * @param target The target datanode
    * @param replicaIndex The replica index (zero for Ratis, > 0 for EC)
+   * @param deadlineEpochMillis The time by which the replica should have been
+   *                            added and reported by the datanode, or it will
+   *                            be discarded.
    */
   public void scheduleAddReplica(ContainerID containerID,
-      DatanodeDetails target, int replicaIndex) {
-    addReplica(ADD, containerID, target, replicaIndex);
+      DatanodeDetails target, int replicaIndex, long deadlineEpochMillis) {
+    addReplica(ADD, containerID, target, replicaIndex, deadlineEpochMillis);
   }
 
   /**
@@ -102,10 +105,13 @@ public class ContainerReplicaPendingOps {
    * @param containerID ContainerID for which to delete a replica
    * @param target The target datanode
    * @param replicaIndex The replica index (zero for Ratis, > 0 for EC)
+   * @param deadlineEpochMillis The time by which the replica should have been
+   *                            deleted and reported by the datanode, or it will
+   *                            be discarded.
    */
   public void scheduleDeleteReplica(ContainerID containerID,
-      DatanodeDetails target, int replicaIndex) {
-    addReplica(DELETE, containerID, target, replicaIndex);
+      DatanodeDetails target, int replicaIndex, long deadlineEpochMillis) {
+    addReplica(DELETE, containerID, target, replicaIndex, deadlineEpochMillis);
   }
 
   /**
@@ -166,9 +172,8 @@ public class ContainerReplicaPendingOps {
   /**
    * Iterate over all pending entries and remove any which have expired, meaning
    * they have not completed the operation inside the given time.
-   * @param expiryMilliSeconds
    */
-  public void removeExpiredEntries(long expiryMilliSeconds) {
+  public void removeExpiredEntries() {
     for (ContainerID containerID : pendingOps.keySet()) {
       // List of expired ops that subscribers will be notified about
       List<ContainerReplicaOp> expiredOps = new ArrayList<>();
@@ -189,8 +194,7 @@ public class ContainerReplicaPendingOps {
         Iterator<ContainerReplicaOp> iterator = ops.listIterator();
         while (iterator.hasNext()) {
           ContainerReplicaOp op = iterator.next();
-          if (op.getScheduledEpochMillis() + expiryMilliSeconds
-              < clock.millis()) {
+          if (clock.millis() > op.getDeadlineEpochMillis()) {
             iterator.remove();
             expiredOps.add(op);
             pendingOpCount.get(op.getOpType()).decrementAndGet();
@@ -228,14 +232,15 @@ public class ContainerReplicaPendingOps {
   }
 
   private void addReplica(ContainerReplicaOp.PendingOpType opType,
-      ContainerID containerID, DatanodeDetails target, int replicaIndex) {
+      ContainerID containerID, DatanodeDetails target, int replicaIndex,
+      long deadlineEpochMillis) {
     Lock lock = writeLock(containerID);
     lock.lock();
     try {
       List<ContainerReplicaOp> ops = pendingOps.computeIfAbsent(
           containerID, s -> new ArrayList<>());
       ops.add(new ContainerReplicaOp(opType,
-          target, replicaIndex, clock.millis()));
+          target, replicaIndex, deadlineEpochMillis));
       pendingOpCount.get(opType).incrementAndGet();
     } finally {
       lock.unlock();

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ReplicationManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ReplicationManager.java
@@ -425,26 +425,89 @@ public class ReplicationManager implements SCMService {
     sendDatanodeCommand(deleteCommand, container, datanode);
   }
 
+  /**
+   * Send a push replication command to the given source datanode, instructing
+   * it to copy the given container to the target.
+   * @param container Container to replicate.
+   * @param replicaIndex Replica Index of the container to replicate. Zero for
+   *                     Ratis and greater than zero for EC.
+   * @param source The source hosting the container, which is where the command
+   *               will be sent.
+   * @param target The target to push container replica to
+   * @param scmDeadlineEpochMs The epoch time in ms, after which the command
+   *                           will be discarded from the SCMPendingOps table.
+   * @param datanodeDeadlineEpochMs The epoch time in ms, after which the
+   *                                command will be discarded on the data if
+   *                                it has not been processed. In general should
+   *                                be less than scmDeadlineEpochMs.
+   * @throws NotLeaderException
+   */
+  public void sendReplicateContainerCommand(final ContainerInfo container,
+      int replicaIndex, DatanodeDetails source, DatanodeDetails target,
+      long scmDeadlineEpochMs, long datanodeDeadlineEpochMs)
+      throws NotLeaderException {
+    final ReplicateContainerCommand command = ReplicateContainerCommand
+        .toTarget(container.getContainerID(), target);
+    command.setReplicaIndex(replicaIndex);
+    sendDatanodeCommand(command, container, source, scmDeadlineEpochMs,
+        datanodeDeadlineEpochMs);
+  }
+  /**
+   * Sends a command to a datanode with the command deadline set to the default
+   * in ReplicationManager config.
+   * @param command The command to send.
+   * @param containerInfo The container the command is for.
+   * @param target The datanode which will receive the command.
+   * @throws NotLeaderException
+   */
   public void sendDatanodeCommand(SCMCommand<?> command,
       ContainerInfo containerInfo, DatanodeDetails target)
       throws NotLeaderException {
-    LOG.info("Sending command [{}] for container {} to {}",
-        command, containerInfo, target);
+    long scmDeadline = clock.millis() + rmConf.eventTimeout;
+    long datanodeDeadline =
+        Math.round(scmDeadline * rmConf.commandDeadlineFactor);
+    sendDatanodeCommand(command, containerInfo, target, scmDeadline,
+        datanodeDeadline);
+  }
+
+  /**
+   * Sends a command to a datanode with a user defined deadline for the
+   * commands.
+   * @param command The command to send
+   * @param containerInfo The container the command is for.
+   * @param target The datanode which will receive the command.
+   * @param scmDeadlineEpochMs The epoch time in ms, after which the command
+   *                           will be discarded from the SCMPendingOps table.
+   * @param datanodeDeadlineEpochMs The epoch time in ms, after which the
+   *                                command will be discarded on the datanode if
+   *                                it has not been processed.
+   * @throws NotLeaderException
+   */
+  public void sendDatanodeCommand(SCMCommand<?> command,
+      ContainerInfo containerInfo, DatanodeDetails target,
+      long scmDeadlineEpochMs, long datanodeDeadlineEpochMs)
+      throws NotLeaderException {
+    LOG.info("Sending command [{}] for container {} to {} with datanode "
+        + "deadline {} and scm deadline {}",
+        command, containerInfo, target, datanodeDeadlineEpochMs,
+        scmDeadlineEpochMs);
     command.setTerm(getScmTerm());
-    command.setDeadline(clock.millis() +
-        Math.round(rmConf.eventTimeout * rmConf.commandDeadlineFactor));
+    command.setDeadline(datanodeDeadlineEpochMs);
     final CommandForDatanode<?> datanodeCommand =
         new CommandForDatanode<>(target.getUuid(), command);
     eventPublisher.fireEvent(SCMEvents.DATANODE_COMMAND, datanodeCommand);
-    adjustPendingOpsAndMetrics(containerInfo, command, target);
+    adjustPendingOpsAndMetrics(containerInfo, command, target,
+        scmDeadlineEpochMs);
   }
 
   private void adjustPendingOpsAndMetrics(ContainerInfo containerInfo,
-      SCMCommand<?> cmd, DatanodeDetails targetDatanode) {
+      SCMCommand<?> cmd, DatanodeDetails targetDatanode,
+      long scmDeadlineEpochMs) {
     if (cmd.getType() == Type.deleteContainerCommand) {
       DeleteContainerCommand rcc = (DeleteContainerCommand) cmd;
       containerReplicaPendingOps.scheduleDeleteReplica(
-          containerInfo.containerID(), targetDatanode, rcc.getReplicaIndex());
+          containerInfo.containerID(), targetDatanode, rcc.getReplicaIndex(),
+          scmDeadlineEpochMs);
       if (rcc.getReplicaIndex() > 0) {
         getMetrics().incrEcDeletionCmdsSentTotal();
       } else if (rcc.getReplicaIndex() == 0) {
@@ -457,13 +520,14 @@ public class ReplicationManager implements SCMService {
       byte[] targetIndexes = rcc.getMissingContainerIndexes();
       for (int i = 0; i < targetIndexes.length; i++) {
         containerReplicaPendingOps.scheduleAddReplica(
-            containerInfo.containerID(), targets.get(i), targetIndexes[i]);
+            containerInfo.containerID(), targets.get(i), targetIndexes[i],
+            scmDeadlineEpochMs);
       }
       getMetrics().incrEcReconstructionCmdsSentTotal();
     } else if (cmd.getType() == Type.replicateContainerCommand) {
       ReplicateContainerCommand rcc = (ReplicateContainerCommand) cmd;
-      containerReplicaPendingOps.scheduleAddReplica(
-          containerInfo.containerID(), targetDatanode, rcc.getReplicaIndex());
+      containerReplicaPendingOps.scheduleAddReplica(containerInfo.containerID(),
+          targetDatanode, rcc.getReplicaIndex(), scmDeadlineEpochMs);
       if (rcc.getReplicaIndex() > 0) {
         getMetrics().incrEcReplicationCmdsSentTotal();
       } else if (rcc.getReplicaIndex() == 0) {

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ReplicationManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ReplicationManager.java
@@ -464,8 +464,8 @@ public class ReplicationManager implements SCMService {
       ContainerInfo containerInfo, DatanodeDetails target)
       throws NotLeaderException {
     long scmDeadline = clock.millis() + rmConf.eventTimeout;
-    long datanodeDeadline =
-        Math.round(scmDeadline * rmConf.commandDeadlineFactor);
+    long datanodeDeadline = clock.millis() +
+        Math.round(rmConf.eventTimeout * rmConf.commandDeadlineFactor);
     sendDatanodeCommand(command, containerInfo, target, scmDeadline,
         datanodeDeadline);
   }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/StorageContainerManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/StorageContainerManager.java
@@ -694,11 +694,6 @@ public final class StorageContainerManager extends ServiceRuntimeInfoImpl
             .OZONE_SCM_EXPIRED_CONTAINER_REPLICA_OP_SCRUB_INTERVAL_DEFAULT,
         TimeUnit.MILLISECONDS);
 
-    long containerReplicaOpExpiryMs = conf.getTimeDuration(
-        ScmConfigKeys.OZONE_SCM_CONTAINER_REPLICA_OP_TIME_OUT,
-        ScmConfigKeys.OZONE_SCM_CONTAINER_REPLICA_OP_TIME_OUT_DEFAULT,
-        TimeUnit.MILLISECONDS);
-
     long backgroundServiceSafemodeWaitMs = conf.getTimeDuration(
         HddsConfigKeys.HDDS_SCM_WAIT_TIME_AFTER_SAFE_MODE_EXIT,
         HddsConfigKeys.HDDS_SCM_WAIT_TIME_AFTER_SAFE_MODE_EXIT_DEFAULT,
@@ -712,7 +707,7 @@ public final class StorageContainerManager extends ServiceRuntimeInfoImpl
             .setIntervalInMillis(containerReplicaOpScrubberIntervalMs)
             .setWaitTimeInMillis(backgroundServiceSafemodeWaitMs)
             .setPeriodicalTask(() -> containerReplicaPendingOps
-                .removeExpiredEntries(containerReplicaOpExpiryMs)).build();
+                .removeExpiredEntries()).build();
 
     serviceManager.register(expiredContainerReplicaOpScrubber);
 

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestReplicationManager.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestReplicationManager.java
@@ -276,7 +276,8 @@ public class TestReplicationManager {
         HddsProtos.LifeCycleState.CLOSED);
     addReplicas(container, ContainerReplicaProto.State.CLOSED, 1, 2, 3, 4);
     containerReplicaPendingOps.scheduleAddReplica(container.containerID(),
-        MockDatanodeDetails.randomDatanodeDetails(), 5);
+        MockDatanodeDetails.randomDatanodeDetails(), 5,
+        clock.millis() + 10000);
 
     replicationManager.processContainer(
         container, repQueue, repReport);
@@ -440,7 +441,8 @@ public class TestReplicationManager {
     addReplicas(container, ContainerReplicaProto.State.CLOSED,
         1, 2, 3, 4, 5, 5);
     containerReplicaPendingOps.scheduleDeleteReplica(container.containerID(),
-        MockDatanodeDetails.randomDatanodeDetails(), 5);
+        MockDatanodeDetails.randomDatanodeDetails(), 5,
+        clock.millis() + 10000);
     replicationManager.processContainer(
         container, repQueue, repReport);
     Assert.assertEquals(0, repQueue.underReplicatedQueueSize());

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/scm/node/TestDecommissionAndMaintenance.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/scm/node/TestDecommissionAndMaintenance.java
@@ -126,8 +126,6 @@ public class TestDecommissionAndMaintenance {
     conf.setTimeDuration(OZONE_SCM_DEADNODE_INTERVAL, 6, SECONDS);
     conf.setTimeDuration(OZONE_SCM_DATANODE_ADMIN_MONITOR_INTERVAL,
         1, SECONDS);
-    conf.setTimeDuration(ScmConfigKeys.OZONE_SCM_CONTAINER_REPLICA_OP_TIME_OUT,
-        10, SECONDS);
     conf.setTimeDuration(
         ScmConfigKeys.OZONE_SCM_EXPIRED_CONTAINER_REPLICA_OP_SCRUB_INTERVAL,
         1, SECONDS);


### PR DESCRIPTION
## What changes were proposed in this pull request?

In order to facilitate a "Move Manager" for the balancer, we need to schedule pending ops on the datanodes with different deadlines.

For example, as replica scheduled due to replication would have a timeout of 10 minutes.

However the balancer schedules large batches of work each hour, so replicas scheduled by the balancer probably need a timeout of 60 minutes.

To facilitate this, we need to change containerReplicaPending ops to store the deadline rather than the scheduled time. This also fixes another issue, in that the ContainerReplicaPendingOps "expiry thread" had its own setting for the timeout for all pending ops, and it is not related to the replication manager settings.

As part of this change, some APIs into RM has been changed a little to allow the move manager to schedule replication commands via RM, so that logic is consolidated in a single place. A later PR that adds the MoveManager will use these APIs.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-7928

## How was this patch tested?

Adjusted the tests for ContainerReplicaPendingOps.
