### PR TITLE
HDDS-7926. [hsync] Recon throws ClassCastException.

### DIFF
--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/tasks/FileSizeCountTask.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/tasks/FileSizeCountTask.java
@@ -165,7 +165,7 @@ public class FileSizeCountTask implements ReconOmTask {
           return new ImmutablePair<>(getTaskName(), false);
         }
       } else {
-        LOG.debug("Unexpected value type {} for key {}. Skipping processing.",
+        LOG.warn("Unexpected value type {} for key {}. Skipping processing.",
             value.getClass().getName(), updatedKey);
       }
     }

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/tasks/FileSizeCountTask.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/tasks/FileSizeCountTask.java
@@ -131,7 +131,7 @@ public class FileSizeCountTask implements ReconOmTask {
       Object value = omdbUpdateEvent.getValue();
       Object oldValue = omdbUpdateEvent.getOldValue();
 
-      if (value instanceof OmKeyInfo || oldValue instanceof OmKeyInfo) {
+      if (value instanceof OmKeyInfo) {
         OmKeyInfo omKeyInfo = (OmKeyInfo) value;
         OmKeyInfo omKeyInfoOld = (OmKeyInfo) oldValue;
 
@@ -146,8 +146,13 @@ public class FileSizeCountTask implements ReconOmTask {
             break;
 
           case UPDATE:
-            handleDeleteKeyEvent(updatedKey, omKeyInfoOld, fileSizeCountMap);
-            handlePutKeyEvent(omKeyInfo, fileSizeCountMap);
+            if (omKeyInfoOld != null) {
+              handleDeleteKeyEvent(updatedKey, omKeyInfoOld, fileSizeCountMap);
+              handlePutKeyEvent(omKeyInfo, fileSizeCountMap);
+            } else {
+              LOG.warn("Update event does not have the old keyInfo for {}.",
+                  updatedKey);
+            }
             break;
 
           default:

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/tasks/NSSummaryTaskWithLegacy.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/tasks/NSSummaryTaskWithLegacy.java
@@ -91,7 +91,8 @@ public class NSSummaryTaskWithLegacy extends NSSummaryTaskDbEventHandler {
         Object value = keyTableUpdateEvent.getValue();
         Object oldValue = keyTableUpdateEvent.getOldValue();
         if (!(value instanceof OmKeyInfo)) {
-          LOG.debug("Unexpected value type for key. Skipping processing.");
+          LOG.debug("Unexpected value type for key. Skipping processing.",
+              value.getClass().getName(), updatedKey);
           continue;
         }
         OmKeyInfo updatedKeyInfo = (OmKeyInfo) value;

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/tasks/NSSummaryTaskWithLegacy.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/tasks/NSSummaryTaskWithLegacy.java
@@ -91,7 +91,7 @@ public class NSSummaryTaskWithLegacy extends NSSummaryTaskDbEventHandler {
         Object value = keyTableUpdateEvent.getValue();
         Object oldValue = keyTableUpdateEvent.getOldValue();
         if (!(value instanceof OmKeyInfo)) {
-          LOG.debug("Unexpected value type {} for key {}. Skipping processing.",
+          LOG.warn("Unexpected value type {} for key {}. Skipping processing.",
               value.getClass().getName(), updatedKey);
           continue;
         }

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/tasks/NSSummaryTaskWithLegacy.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/tasks/NSSummaryTaskWithLegacy.java
@@ -87,10 +87,15 @@ public class NSSummaryTaskWithLegacy extends NSSummaryTaskDbEventHandler {
       String updatedKey = omdbUpdateEvent.getKey();
 
       try {
-        OMDBUpdateEvent<String, OmKeyInfo> keyTableUpdateEvent =
-            (OMDBUpdateEvent<String, OmKeyInfo>) omdbUpdateEvent;
-        OmKeyInfo updatedKeyInfo = keyTableUpdateEvent.getValue();
-        OmKeyInfo oldKeyInfo = keyTableUpdateEvent.getOldValue();
+        OMDBUpdateEvent<String, ?> keyTableUpdateEvent = omdbUpdateEvent;
+        Object value = keyTableUpdateEvent.getValue();
+        Object oldValue = keyTableUpdateEvent.getOldValue();
+        if (!(value instanceof OmKeyInfo) || !(value instanceof OmKeyInfo)) {
+          LOG.debug("Unexpected value type for key. Skipping processing.");
+          continue;
+        }
+        OmKeyInfo updatedKeyInfo = (OmKeyInfo) value;
+        OmKeyInfo oldKeyInfo = (OmKeyInfo) oldValue;
 
         // KeyTable entries belong to both Legacy and OBS buckets.
         // Check bucket layout and if it's OBS

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/tasks/NSSummaryTaskWithLegacy.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/tasks/NSSummaryTaskWithLegacy.java
@@ -91,7 +91,7 @@ public class NSSummaryTaskWithLegacy extends NSSummaryTaskDbEventHandler {
         Object value = keyTableUpdateEvent.getValue();
         Object oldValue = keyTableUpdateEvent.getOldValue();
         if (!(value instanceof OmKeyInfo)) {
-          LOG.debug("Unexpected value type for key. Skipping processing.",
+          LOG.debug("Unexpected value type {} for key {}. Skipping processing.",
               value.getClass().getName(), updatedKey);
           continue;
         }

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/tasks/NSSummaryTaskWithLegacy.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/tasks/NSSummaryTaskWithLegacy.java
@@ -90,7 +90,7 @@ public class NSSummaryTaskWithLegacy extends NSSummaryTaskDbEventHandler {
         OMDBUpdateEvent<String, ?> keyTableUpdateEvent = omdbUpdateEvent;
         Object value = keyTableUpdateEvent.getValue();
         Object oldValue = keyTableUpdateEvent.getOldValue();
-        if (!(value instanceof OmKeyInfo) || !(value instanceof OmKeyInfo)) {
+        if (!(value instanceof OmKeyInfo) || !(oldValue instanceof OmKeyInfo)) {
           LOG.debug("Unexpected value type for key. Skipping processing.");
           continue;
         }

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/tasks/NSSummaryTaskWithLegacy.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/tasks/NSSummaryTaskWithLegacy.java
@@ -90,7 +90,7 @@ public class NSSummaryTaskWithLegacy extends NSSummaryTaskDbEventHandler {
         OMDBUpdateEvent<String, ?> keyTableUpdateEvent = omdbUpdateEvent;
         Object value = keyTableUpdateEvent.getValue();
         Object oldValue = keyTableUpdateEvent.getOldValue();
-        if (!(value instanceof OmKeyInfo) || !(oldValue instanceof OmKeyInfo)) {
+        if (!(value instanceof OmKeyInfo)) {
           LOG.debug("Unexpected value type for key. Skipping processing.");
           continue;
         }


### PR DESCRIPTION
## What changes were proposed in this pull request?

The Recon server is encountering an issue while processing a key in the file system, leading to an unexpected exception. The error message cites a "ClassCastException," indicating that the Recon server is attempting to cast an object of type `org.apache.hadoop.ozone.om.helpers.RepeatedOmKeyInfo` as an object of type `org.apache.hadoop.ozone.om.helpers.OmKeyInfo`. As a result, the server is unable to properly process the key and accurately display the number of files/keys.





So I have made changes to the fileSizeCountTask which will handle both RepeatedOmKeyInfo and OmKeyInfo objects.
## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-7926

## How was this patch tested?
UT's ran successfully 