### PR TITLE
HDDS-7617. Intermittent timeout in TestECContainerRecovery

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/TestECContainerRecovery.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/TestECContainerRecovery.java
@@ -227,6 +227,7 @@ public class TestECContainerRecovery {
         .ContainerReplicaProto.State.CLOSED, container.containerID());
     //Temporarily stop the RM process.
     scm.getReplicationManager().stop();
+    waitForReplicationManagerStopped(scm.getReplicationManager());
 
     // Wait for the lower replication.
     waitForContainerCount(4, container.containerID(), scm);
@@ -239,6 +240,7 @@ public class TestECContainerRecovery {
     // Let's verify for Over replications now.
     //Temporarily stop the RM process.
     scm.getReplicationManager().stop();
+    waitForReplicationManagerStopped(scm.getReplicationManager());
 
     // Restart the DN to make the over replication and expect replication to be
     // increased.
@@ -329,6 +331,7 @@ public class TestECContainerRecovery {
             .ContainerReplicaProto.State.CLOSED, container.containerID());
     //Temporarily stop the RM process.
     scm.getReplicationManager().stop();
+    waitForReplicationManagerStopped(scm.getReplicationManager());
 
     // Wait for the lower replication.
     waitForContainerCount(4, container.containerID(), scm);
@@ -403,6 +406,11 @@ public class TestECContainerRecovery {
           String.valueOf(i % 9).getBytes(UTF_8)[0]);
     }
     return inputData;
+  }
+
+  private void waitForReplicationManagerStopped(ReplicationManager rm)
+      throws TimeoutException, InterruptedException {
+    GenericTestUtils.waitFor(() -> !rm.isRunning(), 1000, 10000);
   }
 
 }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/TestECContainerRecovery.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/TestECContainerRecovery.java
@@ -410,7 +410,7 @@ public class TestECContainerRecovery {
 
   private void waitForReplicationManagerStopped(ReplicationManager rm)
       throws TimeoutException, InterruptedException {
-    GenericTestUtils.waitFor(() -> !rm.isRunning(), 1000, 10000);
+    GenericTestUtils.waitFor(() -> !rm.isRunning(), 100, 10000);
   }
 
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?
Fix intermittent timeout in TestECContainerRecovery.
Remove `running` and use `isrunning()` , because I think it is not `running` but `isrunning()` representing the Replication Monitor thread.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-7617

## How was this patch tested?

Run `TestECContainerRecovery` for many times.