### PR TITLE
HDDS-7869. Log configuration on component startup.

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/HddsUtils.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/HddsUtils.java
@@ -34,7 +34,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.OptionalInt;
-import java.util.Properties;
 import java.util.TreeMap;
 
 import org.apache.hadoop.conf.ConfigRedactor;
@@ -789,13 +788,13 @@ public final class HddsUtils {
    * @return Sorted Map of properties
    */
   public static Map<String, String> processForLogging(OzoneConfiguration conf) {
-    Properties props = conf.getAllProperties();
+    Map<String, String> ozoneProps = conf.getOzoneProperties();
     ConfigRedactor redactor = new ConfigRedactor(conf);
-    Map<String, String> configMap = new TreeMap<>();
-    for (String name : props.stringPropertyNames()) {
-      String value = redactor.redact(name, props.getProperty(name));
-      configMap.put(name, value);
+    Map<String, String> sortedOzoneProps = new TreeMap<>();
+    for (String name : ozoneProps.keySet()) {
+      String value = redactor.redact(name, ozoneProps.get(name));
+      sortedOzoneProps.put(name, value);
     }
-    return configMap;
+    return sortedOzoneProps;
   }
 }

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/HddsUtils.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/HddsUtils.java
@@ -782,8 +782,8 @@ public final class HddsUtils {
   }
 
   /**
-   * Redacts sensitive configuration and
-   * sorts all config properties by key name
+   * Redacts sensitive configuration.
+   * Sorts all properties by key name
    *
    * @param conf OzoneConfiguration object to be printed.
    * @return Sorted Map of properties

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/HddsUtils.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/HddsUtils.java
@@ -791,9 +791,9 @@ public final class HddsUtils {
     Map<String, String> ozoneProps = conf.getOzoneProperties();
     ConfigRedactor redactor = new ConfigRedactor(conf);
     Map<String, String> sortedOzoneProps = new TreeMap<>();
-    for (String name : ozoneProps.keySet()) {
-      String value = redactor.redact(name, ozoneProps.get(name));
-      sortedOzoneProps.put(name, value);
+    for (Map.Entry<String, String> entry : ozoneProps.entrySet()) {
+      String value = redactor.redact(entry.getKey(), entry.getValue());
+      sortedOzoneProps.put(entry.getKey(), value);
     }
     return sortedOzoneProps;
   }

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/HddsUtils.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/HddsUtils.java
@@ -34,13 +34,17 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.OptionalInt;
+import java.util.Properties;
+import java.util.TreeMap;
 
+import org.apache.hadoop.conf.ConfigRedactor;
 import org.apache.hadoop.fs.CommonConfigurationKeysPublic;
 import org.apache.hadoop.hdds.annotation.InterfaceAudience;
 import org.apache.hadoop.hdds.annotation.InterfaceStability;
 import org.apache.hadoop.hdds.client.BlockID;
 import org.apache.hadoop.hdds.conf.ConfigurationException;
 import org.apache.hadoop.hdds.conf.ConfigurationSource;
+import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos;
 import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.ContainerCommandRequestProtoOrBuilder;
 import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.ContainerDataProto.State;
@@ -775,5 +779,23 @@ public final class HddsUtils {
     }
 
     return msg;
+  }
+
+  /**
+   * Redacts sensitive configuration and
+   * sorts all config properties by key name
+   *
+   * @param conf OzoneConfiguration object to be printed.
+   * @return Sorted Map of properties
+   */
+  public static Map<String, String> processForLogging(OzoneConfiguration conf) {
+    Properties props = conf.getAllProperties();
+    ConfigRedactor redactor = new ConfigRedactor(conf);
+    Map<String, String> configMap = new TreeMap<>();
+    for (String name : props.stringPropertyNames()) {
+      String value = redactor.redact(name, props.getProperty(name));
+      configMap.put(name, value);
+    }
+    return configMap;
   }
 }

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/HddsUtils.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/HddsUtils.java
@@ -793,6 +793,9 @@ public final class HddsUtils {
     Map<String, String> sortedOzoneProps = new TreeMap<>();
     for (Map.Entry<String, String> entry : ozoneProps.entrySet()) {
       String value = redactor.redact(entry.getKey(), entry.getValue());
+      if (value != null) {
+        value = value.trim();
+      }
       sortedOzoneProps.put(entry.getKey(), value);
     }
     return sortedOzoneProps;

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/StringUtils.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/StringUtils.java
@@ -105,12 +105,12 @@ public final class StringUtils {
   }
 
   public static void startupShutdownMessage(VersionInfo versionInfo,
-      Class<?> clazz, String[] args, Logger log) {
+      Class<?> clazz, String[] args, Logger log, String conf) {
     final String hostname = NetUtils.getHostname();
     final String className = clazz.getSimpleName();
     if (log.isInfoEnabled()) {
       log.info(createStartupShutdownMessage(versionInfo, className, hostname,
-          args));
+          args, conf));
     }
 
     if (SystemUtils.IS_OS_UNIX) {
@@ -135,7 +135,7 @@ public final class StringUtils {
    * @return a string to log.
    */
   public static String createStartupShutdownMessage(VersionInfo versionInfo,
-      String className, String hostname, String[] args) {
+      String className, String hostname, String[] args, String conf) {
     return toStartupShutdownString("STARTUP_MSG: ",
         "Starting " + className,
         "  host = " + hostname,
@@ -146,7 +146,8 @@ public final class StringUtils {
             + versionInfo.getRevision()
             + " ; compiled by '" + versionInfo.getUser()
             + "' on " + versionInfo.getDate(),
-        "  java = " + System.getProperty("java.version"));
+        "  java = " + System.getProperty("java.version"),
+        "  conf = " + conf);
   }
 
   public static String appendIfNotPresent(String str, char c) {

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/StringUtils.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/StringUtils.java
@@ -26,7 +26,6 @@ import java.util.Map;
 import com.google.common.base.Preconditions;
 import org.apache.commons.lang3.SystemUtils;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
-import org.apache.hadoop.hdds.HddsUtils;
 import org.apache.hadoop.hdds.utils.SignalLogger;
 import org.apache.hadoop.hdds.utils.VersionInfo;
 import org.apache.hadoop.net.NetUtils;

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/StringUtils.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/StringUtils.java
@@ -21,9 +21,12 @@ import java.io.UnsupportedEncodingException;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Map;
 
 import com.google.common.base.Preconditions;
 import org.apache.commons.lang3.SystemUtils;
+import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import org.apache.hadoop.hdds.HddsUtils;
 import org.apache.hadoop.hdds.utils.SignalLogger;
 import org.apache.hadoop.hdds.utils.VersionInfo;
 import org.apache.hadoop.net.NetUtils;
@@ -105,12 +108,13 @@ public final class StringUtils {
   }
 
   public static void startupShutdownMessage(VersionInfo versionInfo,
-      Class<?> clazz, String[] args, Logger log, String conf) {
+      Class<?> clazz, String[] args, Logger log, OzoneConfiguration conf) {
     final String hostname = NetUtils.getHostname();
     final String className = clazz.getSimpleName();
+
     if (log.isInfoEnabled()) {
       log.info(createStartupShutdownMessage(versionInfo, className, hostname,
-          args, conf));
+          args, HddsUtils.processForLogging(conf)));
     }
 
     if (SystemUtils.IS_OS_UNIX) {
@@ -135,7 +139,8 @@ public final class StringUtils {
    * @return a string to log.
    */
   public static String createStartupShutdownMessage(VersionInfo versionInfo,
-      String className, String hostname, String[] args, String conf) {
+      String className, String hostname, String[] args,
+      Map<String, String> conf) {
     return toStartupShutdownString("STARTUP_MSG: ",
         "Starting " + className,
         "  host = " + hostname,

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/conf/OzoneConfiguration.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/conf/OzoneConfiguration.java
@@ -275,19 +275,8 @@ public class OzoneConfiguration extends Configuration
     return props;
   }
 
-  public Properties getAllPropertiesByPrefix(
-          String keyPrefix) {
-    Properties updatedProps = getProps();
-    Properties props = new Properties();
-    for (String name : updatedProps.stringPropertyNames()) {
-      if (name.startsWith(keyPrefix)) {
-        String value = get(name);
-        if (value != null) {
-          props.put(name, value);
-        }
-      }
-    }
-    return props;
+  public Properties getAllProperties() {
+    return getProps();
   }
 
   @Override

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/conf/OzoneConfiguration.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/conf/OzoneConfiguration.java
@@ -275,8 +275,9 @@ public class OzoneConfiguration extends Configuration
     return props;
   }
 
-  public Properties getAllProperties() {
-    return getProps();
+  public Map<String, String> getOzoneProperties() {
+    String ozoneRegex = ".*(ozone|hdds|ratis|container|scm|recon)\\..*";
+    return getValByRegex(ozoneRegex);
   }
 
   @Override

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/conf/OzoneConfiguration.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/conf/OzoneConfiguration.java
@@ -275,6 +275,21 @@ public class OzoneConfiguration extends Configuration
     return props;
   }
 
+  public Properties getAllPropertiesByPrefix(
+          String keyPrefix) {
+    Properties updatedProps = getProps();
+    Properties props = new Properties();
+    for (String name : updatedProps.stringPropertyNames()) {
+      if (name.startsWith(keyPrefix)) {
+        String value = get(name);
+        if (value != null) {
+          props.put(name, value);
+        }
+      }
+    }
+    return props;
+  }
+
   @Override
   public Collection<String> getConfigKeys() {
     return getProps().keySet()

--- a/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/TestHddsUtils.java
+++ b/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/TestHddsUtils.java
@@ -263,16 +263,16 @@ public class TestHddsUtils {
             "password$",
             "key$"));
     /* Sensitive properties */
-    conf.set("test.password", ORIGINAL_VALUE);
-    conf.set("fs.s3a.secret.key", ORIGINAL_VALUE);
+    conf.set("ozone.test.password", ORIGINAL_VALUE);
+    conf.set("hdds.test.secret.key", ORIGINAL_VALUE);
     /* Non-Sensitive properties */
-    conf.set("normal.config", ORIGINAL_VALUE);
+    conf.set("ozone.normal.config", ORIGINAL_VALUE);
     Map<String, String> processedConf = processForLogging(conf);
 
     /* Verify that sensitive properties are redacted */
-    assertEquals(processedConf.get("test.password"), REDACTED_TEXT);
-    assertEquals(processedConf.get("fs.s3a.secret.key"), REDACTED_TEXT);
+    assertEquals(processedConf.get("ozone.test.password"), REDACTED_TEXT);
+    assertEquals(processedConf.get("hdds.test.secret.key"), REDACTED_TEXT);
     /* Verify that non-sensitive properties retain their value */
-    assertEquals(processedConf.get("normal.config"), ORIGINAL_VALUE);
+    assertEquals(processedConf.get("ozone.normal.config"), ORIGINAL_VALUE);
   }
 }

--- a/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/TestHddsUtils.java
+++ b/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/TestHddsUtils.java
@@ -267,12 +267,12 @@ public class TestHddsUtils {
     conf.set("fs.s3a.secret.key", ORIGINAL_VALUE);
     /* Non-Sensitive properties */
     conf.set("normal.config", ORIGINAL_VALUE);
-    Map<String, String> processed_conf = processForLogging(conf);
+    Map<String, String> processedConf = processForLogging(conf);
 
     /* Verify that sensitive properties are redacted */
-    assertEquals(processed_conf.get("test.password"),REDACTED_TEXT);
-    assertEquals(processed_conf.get("fs.s3a.secret.key"),REDACTED_TEXT);
+    assertEquals(processedConf.get("test.password"), REDACTED_TEXT);
+    assertEquals(processedConf.get("fs.s3a.secret.key"), REDACTED_TEXT);
     /* Verify that non-sensitive properties retain their value */
-    assertEquals(processed_conf.get("normal.config"),ORIGINAL_VALUE);
+    assertEquals(processedConf.get("normal.config"), ORIGINAL_VALUE);
   }
 }

--- a/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/TestHddsUtils.java
+++ b/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/TestHddsUtils.java
@@ -31,8 +31,10 @@ import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.scm.ScmConfigKeys;
 import org.apache.hadoop.ozone.ha.ConfUtils;
 import org.apache.ozone.test.LambdaTestUtils;
+import org.apache.hadoop.fs.CommonConfigurationKeysPublic;
 
 import static org.apache.hadoop.hdds.HddsUtils.getSCMAddressForDatanodes;
+import static org.apache.hadoop.hdds.HddsUtils.processForLogging;
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_ADDRESS_KEY;
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_DATANODE_PORT_DEFAULT;
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_DATANODE_PORT_KEY;
@@ -49,6 +51,11 @@ import static org.junit.jupiter.api.Assertions.fail;
  * Testing HddsUtils.
  */
 public class TestHddsUtils {
+
+  private static final String REDACTED_TEXT = "<redacted>";
+  private static final String ORIGINAL_VALUE = "Hello, World!";
+  private static final String SENSITIVE_CONFIG_KEYS =
+          CommonConfigurationKeysPublic.HADOOP_SECURITY_SENSITIVE_CONFIG_KEYS;
 
   @Test
   public void testGetHostName() {
@@ -247,5 +254,25 @@ public class TestHddsUtils {
             ConfUtils.addKeySuffixes(OZONE_SCM_DATANODE_PORT_KEY,
                 serviceId, nodeId),
             OZONE_SCM_PIPELINE_OWNER_CONTAINER_COUNT).orElse(0));
+  }
+
+  @Test
+  public void testRedactSensitivePropsForLogging() {
+    OzoneConfiguration conf = new OzoneConfiguration();
+    conf.set(SENSITIVE_CONFIG_KEYS, String.join("\n",
+            "password$",
+            "key$"));
+    /* Sensitive properties */
+    conf.set("test.password", ORIGINAL_VALUE);
+    conf.set("fs.s3a.secret.key", ORIGINAL_VALUE);
+    /* Non-Sensitive properties */
+    conf.set("normal.config", ORIGINAL_VALUE);
+    Map<String, String> processed_conf = processForLogging(conf);
+
+    /* Verify that sensitive properties are redacted */
+    assertEquals(processed_conf.get("test.password"),REDACTED_TEXT);
+    assertEquals(processed_conf.get("fs.s3a.secret.key"),REDACTED_TEXT);
+    /* Verify that non-sensitive properties retain their value */
+    assertEquals(processed_conf.get("normal.config"),ORIGINAL_VALUE);
   }
 }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/HddsDatanodeService.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/HddsDatanodeService.java
@@ -166,9 +166,7 @@ public class HddsDatanodeService extends GenericCli implements ServicePlugin {
     OzoneConfiguration configuration = createOzoneConfiguration();
     if (printBanner) {
       StringUtils.startupShutdownMessage(HddsVersionInfo.HDDS_VERSION_INFO,
-          HddsDatanodeService.class, args, LOG,
-              configuration.getAllPropertiesByTag(
-                      ConfigTag.DATANODE.name()).toString());
+          HddsDatanodeService.class, args, LOG, configuration);
     }
     start(configuration);
     ShutdownHookManager.get().addShutdownHook(() -> {

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/HddsDatanodeService.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/HddsDatanodeService.java
@@ -36,7 +36,6 @@ import org.apache.hadoop.hdds.HddsUtils;
 import org.apache.hadoop.hdds.StringUtils;
 import org.apache.hadoop.hdds.cli.GenericCli;
 import org.apache.hadoop.hdds.cli.HddsVersionProvider;
-import org.apache.hadoop.hdds.conf.ConfigTag;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.datanode.metadata.DatanodeCRLStore;
 import org.apache.hadoop.hdds.datanode.metadata.DatanodeCRLStoreImpl;

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/HddsDatanodeService.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/HddsDatanodeService.java
@@ -36,6 +36,7 @@ import org.apache.hadoop.hdds.HddsUtils;
 import org.apache.hadoop.hdds.StringUtils;
 import org.apache.hadoop.hdds.cli.GenericCli;
 import org.apache.hadoop.hdds.cli.HddsVersionProvider;
+import org.apache.hadoop.hdds.conf.ConfigTag;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.datanode.metadata.DatanodeCRLStore;
 import org.apache.hadoop.hdds.datanode.metadata.DatanodeCRLStoreImpl;
@@ -162,11 +163,14 @@ public class HddsDatanodeService extends GenericCli implements ServicePlugin {
 
   @Override
   public Void call() throws Exception {
+    OzoneConfiguration configuration = createOzoneConfiguration();
     if (printBanner) {
       StringUtils.startupShutdownMessage(HddsVersionInfo.HDDS_VERSION_INFO,
-          HddsDatanodeService.class, args, LOG);
+          HddsDatanodeService.class, args, LOG,
+              configuration.getAllPropertiesByTag(
+                      ConfigTag.DATANODE.name()).toString());
     }
-    start(createOzoneConfiguration());
+    start(configuration);
     ShutdownHookManager.get().addShutdownHook(() -> {
       try {
         stop();

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/StorageContainerManagerStarter.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/StorageContainerManagerStarter.java
@@ -157,8 +157,7 @@ public class StorageContainerManagerStarter extends GenericCli {
     String[] originalArgs = getCmd().getParseResult().originalArgs()
         .toArray(new String[0]);
     StringUtils.startupShutdownMessage(HddsVersionInfo.HDDS_VERSION_INFO,
-        StorageContainerManager.class, originalArgs, LOG,
-            conf.getAllPropertiesByTag(ConfigTag.SCM.name()).toString());
+        StorageContainerManager.class, originalArgs, LOG, conf);
   }
 
   /**

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/StorageContainerManagerStarter.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/StorageContainerManagerStarter.java
@@ -24,6 +24,7 @@ package org.apache.hadoop.hdds.scm.server;
 import org.apache.hadoop.hdds.StringUtils;
 import org.apache.hadoop.hdds.cli.GenericCli;
 import org.apache.hadoop.hdds.cli.HddsVersionProvider;
+import org.apache.hadoop.hdds.conf.ConfigTag;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.tracing.TracingUtil;
 import org.apache.hadoop.hdds.utils.HddsVersionInfo;
@@ -156,7 +157,8 @@ public class StorageContainerManagerStarter extends GenericCli {
     String[] originalArgs = getCmd().getParseResult().originalArgs()
         .toArray(new String[0]);
     StringUtils.startupShutdownMessage(HddsVersionInfo.HDDS_VERSION_INFO,
-        StorageContainerManager.class, originalArgs, LOG);
+        StorageContainerManager.class, originalArgs, LOG,
+            conf.getAllPropertiesByTag(ConfigTag.SCM.name()).toString());
   }
 
   /**

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/StorageContainerManagerStarter.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/StorageContainerManagerStarter.java
@@ -24,7 +24,6 @@ package org.apache.hadoop.hdds.scm.server;
 import org.apache.hadoop.hdds.StringUtils;
 import org.apache.hadoop.hdds.cli.GenericCli;
 import org.apache.hadoop.hdds.cli.HddsVersionProvider;
-import org.apache.hadoop.hdds.conf.ConfigTag;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.tracing.TracingUtil;
 import org.apache.hadoop.hdds.utils.HddsVersionInfo;

--- a/hadoop-ozone/csi/src/main/java/org/apache/hadoop/ozone/csi/CsiServer.java
+++ b/hadoop-ozone/csi/src/main/java/org/apache/hadoop/ozone/csi/CsiServer.java
@@ -56,9 +56,7 @@ public class CsiServer extends GenericCli implements Callable<Void> {
             .toArray(new String[0]);
     OzoneConfiguration ozoneConfiguration = createOzoneConfiguration();
     StringUtils.startupShutdownMessage(OzoneVersionInfo.OZONE_VERSION_INFO,
-            CsiServer.class, originalArgs, LOG,
-            ozoneConfiguration.getAllPropertiesByPrefix(
-                    "ozone.csi").toString());
+            CsiServer.class, originalArgs, LOG, ozoneConfiguration);
     CsiConfig csiConfig = ozoneConfiguration.getObject(CsiConfig.class);
 
     OzoneClient rpcClient = OzoneClientFactory.getRpcClient(ozoneConfiguration);

--- a/hadoop-ozone/csi/src/main/java/org/apache/hadoop/ozone/csi/CsiServer.java
+++ b/hadoop-ozone/csi/src/main/java/org/apache/hadoop/ozone/csi/CsiServer.java
@@ -52,7 +52,13 @@ public class CsiServer extends GenericCli implements Callable<Void> {
 
   @Override
   public Void call() throws Exception {
+    String[] originalArgs = getCmd().getParseResult().originalArgs()
+            .toArray(new String[0]);
     OzoneConfiguration ozoneConfiguration = createOzoneConfiguration();
+    StringUtils.startupShutdownMessage(OzoneVersionInfo.OZONE_VERSION_INFO,
+            CsiServer.class, originalArgs, LOG,
+            ozoneConfiguration.getAllPropertiesByPrefix(
+                    "ozone.csi").toString());
     CsiConfig csiConfig = ozoneConfiguration.getObject(CsiConfig.class);
 
     OzoneClient rpcClient = OzoneClientFactory.getRpcClient(ozoneConfiguration);
@@ -85,8 +91,6 @@ public class CsiServer extends GenericCli implements Callable<Void> {
   }
 
   public static void main(String[] args) {
-    StringUtils.startupShutdownMessage(OzoneVersionInfo.OZONE_VERSION_INFO,
-        CsiServer.class, args, LOG);
     new CsiServer().run(args);
   }
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManagerStarter.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManagerStarter.java
@@ -20,6 +20,7 @@ package org.apache.hadoop.ozone.om;
 import org.apache.hadoop.hdds.StringUtils;
 import org.apache.hadoop.hdds.cli.GenericCli;
 import org.apache.hadoop.hdds.cli.HddsVersionProvider;
+import org.apache.hadoop.hdds.conf.ConfigTag;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.tracing.TracingUtil;
 import org.apache.hadoop.ozone.util.OzoneNetUtils;
@@ -173,7 +174,8 @@ public class OzoneManagerStarter extends GenericCli {
     String[] originalArgs = getCmd().getParseResult().originalArgs()
         .toArray(new String[0]);
     StringUtils.startupShutdownMessage(OzoneVersionInfo.OZONE_VERSION_INFO,
-        OzoneManager.class, originalArgs, LOG);
+        OzoneManager.class, originalArgs, LOG,
+            conf.getAllPropertiesByTag(ConfigTag.OM.name()).toString());
   }
 
   /**

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManagerStarter.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManagerStarter.java
@@ -174,8 +174,7 @@ public class OzoneManagerStarter extends GenericCli {
     String[] originalArgs = getCmd().getParseResult().originalArgs()
         .toArray(new String[0]);
     StringUtils.startupShutdownMessage(OzoneVersionInfo.OZONE_VERSION_INFO,
-        OzoneManager.class, originalArgs, LOG,
-            conf.getAllPropertiesByTag(ConfigTag.OM.name()).toString());
+        OzoneManager.class, originalArgs, LOG, conf);
   }
 
   /**

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManagerStarter.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManagerStarter.java
@@ -20,7 +20,6 @@ package org.apache.hadoop.ozone.om;
 import org.apache.hadoop.hdds.StringUtils;
 import org.apache.hadoop.hdds.cli.GenericCli;
 import org.apache.hadoop.hdds.cli.HddsVersionProvider;
-import org.apache.hadoop.hdds.conf.ConfigTag;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.tracing.TracingUtil;
 import org.apache.hadoop.ozone.util.OzoneNetUtils;

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/ReconServer.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/ReconServer.java
@@ -24,6 +24,7 @@ import com.google.inject.Injector;
 import org.apache.hadoop.hdds.HddsUtils;
 import org.apache.hadoop.hdds.StringUtils;
 import org.apache.hadoop.hdds.cli.GenericCli;
+import org.apache.hadoop.hdds.conf.ConfigTag;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.recon.ReconConfig;
 import org.apache.hadoop.hdds.scm.server.OzoneStorageContainerManager;
@@ -91,10 +92,12 @@ public class ReconServer extends GenericCli {
   public Void call() throws Exception {
     String[] originalArgs = getCmd().getParseResult().originalArgs()
         .toArray(new String[0]);
-    StringUtils.startupShutdownMessage(OzoneVersionInfo.OZONE_VERSION_INFO,
-        ReconServer.class, originalArgs, LOG);
 
     configuration = createOzoneConfiguration();
+    StringUtils.startupShutdownMessage(OzoneVersionInfo.OZONE_VERSION_INFO,
+            ReconServer.class, originalArgs, LOG,
+            configuration.getAllPropertiesByTag(
+                    ConfigTag.RECON.name()).toString());
     ConfigurationProvider.setConfiguration(configuration);
 
     injector = Guice.createInjector(new ReconControllerModule(),

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/ReconServer.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/ReconServer.java
@@ -95,9 +95,7 @@ public class ReconServer extends GenericCli {
 
     configuration = createOzoneConfiguration();
     StringUtils.startupShutdownMessage(OzoneVersionInfo.OZONE_VERSION_INFO,
-            ReconServer.class, originalArgs, LOG,
-            configuration.getAllPropertiesByTag(
-                    ConfigTag.RECON.name()).toString());
+            ReconServer.class, originalArgs, LOG, configuration);
     ConfigurationProvider.setConfiguration(configuration);
 
     injector = Guice.createInjector(new ReconControllerModule(),

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/ReconServer.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/ReconServer.java
@@ -24,7 +24,6 @@ import com.google.inject.Injector;
 import org.apache.hadoop.hdds.HddsUtils;
 import org.apache.hadoop.hdds.StringUtils;
 import org.apache.hadoop.hdds.cli.GenericCli;
-import org.apache.hadoop.hdds.conf.ConfigTag;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.recon.ReconConfig;
 import org.apache.hadoop.hdds.scm.server.OzoneStorageContainerManager;

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/Gateway.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/Gateway.java
@@ -89,9 +89,7 @@ public class Gateway extends GenericCli {
     String[] originalArgs = getCmd().getParseResult().originalArgs()
         .toArray(new String[0]);
     StringUtils.startupShutdownMessage(OzoneVersionInfo.OZONE_VERSION_INFO,
-        Gateway.class, originalArgs, LOG,
-            ozoneConfiguration.getAllPropertiesByTag(
-                    ConfigTag.S3GATEWAY.name()).toString());
+        Gateway.class, originalArgs, LOG, ozoneConfiguration);
 
     LOG.info("Starting Ozone S3 gateway");
     HddsServerUtil.initializeMetrics(ozoneConfiguration, "S3Gateway");

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/Gateway.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/Gateway.java
@@ -22,7 +22,6 @@ import java.io.IOException;
 import org.apache.hadoop.hdds.StringUtils;
 import org.apache.hadoop.hdds.cli.GenericCli;
 import org.apache.hadoop.hdds.cli.HddsVersionProvider;
-import org.apache.hadoop.hdds.conf.ConfigTag;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.tracing.TracingUtil;
 import org.apache.hadoop.hdds.utils.HddsServerUtil;

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/Gateway.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/Gateway.java
@@ -22,6 +22,7 @@ import java.io.IOException;
 import org.apache.hadoop.hdds.StringUtils;
 import org.apache.hadoop.hdds.cli.GenericCli;
 import org.apache.hadoop.hdds.cli.HddsVersionProvider;
+import org.apache.hadoop.hdds.conf.ConfigTag;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.tracing.TracingUtil;
 import org.apache.hadoop.hdds.utils.HddsServerUtil;
@@ -88,7 +89,9 @@ public class Gateway extends GenericCli {
     String[] originalArgs = getCmd().getParseResult().originalArgs()
         .toArray(new String[0]);
     StringUtils.startupShutdownMessage(OzoneVersionInfo.OZONE_VERSION_INFO,
-        Gateway.class, originalArgs, LOG);
+        Gateway.class, originalArgs, LOG,
+            ozoneConfiguration.getAllPropertiesByTag(
+                    ConfigTag.S3GATEWAY.name()).toString());
 
     LOG.info("Starting Ozone S3 gateway");
     HddsServerUtil.initializeMetrics(ozoneConfiguration, "S3Gateway");


### PR DESCRIPTION
## What changes were proposed in this pull request?

Added a `conf` field in `STARTUP_MSG` for all Ozone roles with configs relevant to the role. 

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-7869

## How was this patch tested?

Manual test
```
OM : 
/************************************************************
2023-02-12 20:11:34 STARTUP_MSG: Starting OzoneManager
...
2023-02-12 20:11:34 STARTUP_MSG:   java = 11.0.17
2023-02-12 20:11:34 STARTUP_MSG:   conf = {hadoop.hdds.db.rocksdb.logging.level=INFO, ozone.om.enable.ofs.shared.tmp.dir=false, ozone.om.ratis.log.appender.queue.num-elements=1024, hadoop.hdds.db.rocksdb.logging.enabled=false, ozone.om.snapshot.provider.socket.timeout=5000s, ozone.scm.info.wait.duration=10m, ozone.om.http.auth.type=kerberos, ozone.om.multitenancy.enabled=true, ozone.om.https-bind-host=0.0.0.0, ozone.om.ratis.server.request.timeout=3s, ozone.network.flexible.fqdn.resolution.enabled=false, ozone.om.snapshot.compaction.dag.max.time.allowed=30d, ozone.path.deleting.limit.per.task=10000, ozone.om.enable.filesystem.paths=false, ozone.recon.om.snapshot.task.flush.param=false, ozone.om.admin.protocol.max.retries=20, ozone.om.leader.election.minimum.timeout.duration=5s, ozone.om.ratis.log.appender.queue.byte-limit=32MB, ozone.network.jvm.address.cache.enabled=true, ozone.om.volume.listall.allowed=true, ozone.recon.om.socket.timeout=5s, ozone.om.keyname.character.check.enabled=false, ozone.om.open.key.cleanup.service.timeout=300s, ozone.om.ratis.server.retry.cache.timeout=600000ms, ozone.om.snapshot.provider.request.timeout=5000ms, ozone.directory.deleting.service.interval=1m, ozone.om.save.metrics.interval=5m, ozone.om.grpc.maximum.response.length=134217728, ozone.recon.om.snapshot.task.initial.delay=20s, ozone.om.https-address=0.0.0.0:9875, ozone.om.ratis.port=9872, ozone.key.deleting.limit.per.task=20000, ozone.om.ha.raft.server.retrycache.expirytime=300s, ozone.snapshot.filtering.service.interval=1m, ozone.scm.ca.list.retry.interval=10s, ozone.om.container.location.cache.size=100000, ozone.om.handler.count.key=100, ozone.om.client.trash.core.pool.size=5, hdds.db.profile=DISK, ozone.metastore.rocksdb.cf.write.buffer.size=128MB, ozone.fs.listing.page.size.max=5000, ozone.key.preallocation.max.blocks=64, ozone.om.http-bind-host=0.0.0.0, hdds.scm.http.auth.type=kerberos, ozone.om.fs.snapshot.max.limit=1000, ozone.om.snapshot.provider.connection.timeout=5000s, ozone.metadata.dirs=/data/metadata, ozone.recon.om.connection.timeout=5s, ozone.om.key.path.lock.enabled=false, ozone.metastore.rocksdb.statistics=OFF, ozone.om.ratis.log.purge.gap=1000000, ozone.om.group.rights=ALL, ozone.om.ratis.segment.size=4MB, ozone.om.multitenancy.ranger.sync.timeout=10s, ozone.om.open.key.expire.threshold=7d, ozone.om.snapshot.cache.max.size=10, ozone.om.user.max.volume=1024, ozone.om.client.rpc.timeout=15m, ozone.snapshot.filtering.limit.per.task=2, ozone.sst.filtering.service.timeout=300000ms, ozone.om.ratis.segment.preallocated.size=4MB, ozone.om.ratis.server.failure.timeout.duration=120s, ozone.om.unflushed.transaction.max.count=10000, ozone.om.user.rights=ALL, ozone.recon.om.snapshot.task.interval.delay=1m, ozone.om.container.location.cache.ttl=360m, ozone.om.upgrade.finalization.ratis.based.timeout=30s, ozone.om.http-address=om:9874, ozone.om.admin.protocol.wait.between.retries=1000, ozone.om.address=om, ozone.om.ratis.minimum.timeout=5s, ozone.om.snapshot.compaction.dag.prune.daemon.run.interval=3600s, ozone.om.open.key.cleanup.limit.per.task=1000, ozone.om.ratis.enable=true, ozone.service.shutdown.timeout=60s, hadoop.hdds.db.rocksdb.writeoption.sync=false, ozone.recon.om.connection.request.timeout=5000, ozone.om.multitenancy.ranger.sync.interval=30s, ozone.om.ratis.rpc.type=GRPC, ozone.om.ratis.server.leaderelection.pre-vote=false, ozone.om.http.enabled=true, ozone.om.open.key.cleanup.service.interval=24h, ozone.om.init.default.layout.version=-1}
```


```
SCM : 
2023-02-12 20:11:34 /************************************************************
2023-02-12 20:11:34 STARTUP_MSG: Starting StorageContainerManager
...
2023-02-12 20:11:34 STARTUP_MSG:   java = 11.0.17
2023-02-12 20:11:34 STARTUP_MSG:   conf = {ozone.scm.sequence.id.batch.size=1000, hdds.scm.replication.event.timeout=10s, ozone.scm.ha.ratis.snapshot.threshold=1000, hdds.scm.safemode.atleast.one.node.reported.pipeline.pct=0.90, ozone.scm.ha.ratis.server.leaderelection.pre-vote=false, hdds.scm.safemode.enabled=true, ozone.scm.client.port=9860, hdds.key.len=2048, ozone.network.jvm.address.cache.enabled=true, ozone.scm.pipeline.creation.interval=30s, hdds.datanode.storage.utilization.critical.threshold=0.95, hdds.scm.safemode.min.datanode=3, ozone.scm.client.bind.host=0.0.0.0, hdds.scm.block.deletion.per-interval.max=100000, hdds.scm.kerberos.keytab.file=/etc/security/keytabs/scm.keytab, ozone.scm.block.client.port=9863, ozone.scm.ha.ratis.segment.preallocated.size=4MB, hdds.scm.http.auth.kerberos.principal=HTTP/scm@EXAMPLE.COM, ozone.scm.block.deletion.max.retry=4096, ozone.scm.ratis.pipeline.limit=0, ozone.block.deleting.container.limit.per.interval=10, hdds.scm.http.auth.kerberos.keytab=/etc/security/keytabs/scm.keytab, ozone.block.deleting.service.interval=1m, ozone.scm.ca.list.retry.interval=10s, ozone.scm.ha.ratis.leader.election.timeout=5s, hdds.scm.safemode.pipeline.creation=true, ozone.metastore.rocksdb.cf.write.buffer.size=128MB, ozone.chunk.read.buffer.default.size=64KB, ozone.scm.ha.ratis.log.appender.queue.byte-limit=32MB, hdds.scm.kerberos.principal=scm/scm@EXAMPLE.COM, hdds.scmclient.failover.retry.interval=2s, hdds.scm.replication.maintenance.remaining.redundancy=1, ozone.scm.container.layout=FILE_PER_BLOCK, ozone.block.deleting.limit.per.task=1000, hdds.scm.replication.container.inflight.replication.limit=0, hdds.scmclient.max.retry.timeout=30s, hdds.datanode.block.deleting.service.interval=60s, ozone.scm.expired.container.replica.op.scrub.interval=5m, ozone.scm.block.client.bind.host=0.0.0.0, hdds.datanode.recovering.container.scrubbing.service.interval=1m, ozone.scm.block.client.address=scm, ozone.scm.ha.grpc.deadline.interval=30m, hdds.scm.init.default.layout.version=-1, hdds.scm.replication.command.deadline.factor=0.9, ozone.scm.pipeline.destroy.timeout=66s, ozone.recon.scm.snapshot.enabled=true, ozone.scm.pipeline.per.metadata.disk=2, hdds.datanode.storage.utilization.warning.threshold=0.75, hdds.key.dir.name=keys, ozone.scm.pipeline.owner.container.count=1, ozone.scm.ha.ratis.server.retry.cache.timeout=60s, ozone.scm.block.size=256MB, ozone.scm.pipeline.allocated.timeout=5m, hdds.scm.replication.thread.interval=5s, ozone.scm.ha.ratis.log.purge.enabled=false, ozone.scm.datanode.admin.monitor.interval=30s, ozone.scm.info.wait.duration=10m, hdds.scm.replication.maintenance.replica.minimum=2, hdds.scm.unknown-container.action=WARN, hdds.scm.replication.over.replicated.interval=30s, hdds.scmclient.failover.max.retry=15, ozone.network.flexible.fqdn.resolution.enabled=false, ozone.scm.ha.ratis.request.timeout=30s, hdds.scm.safemode.threshold.pct=0.99, ozone.scm.ratis.port=9894, hdds.scm.safemode.healthy.pipeline.pct=0.10, ozone.scm.ha.ratis.leader.ready.wait.timeout=60s, hdds.scm.wait.time.after.safemode.exit=5m, ozone.recon.scm.container.threshold=100, ozone.scm.pipeline.scrub.interval=5m, ozone.recon.scm.connection.request.timeout=5s, ozone.block.deleting.service.timeout=300000ms, ozone.block.deleting.service.workers=10, hdds.scm.block.deleting.service.interval=60s, ozone.scm.skip.bootstrap.validation=false, ozone.scm.ha.ratis.leader.ready.check.interval=2s, ozone.scm.datanode.disallow.same.peers=false, ozone.scm.update.client.crl.check.interval=600s, ozone.scm.pipeline.creation.auto.factor.one=true, hdds.scm.safemode.pipeline-availability.check=true, ozone.scm.event.ContainerReport.thread.pool.size=10, hdds.scm.replication.container.inflight.deletion.limit=0, ozone.metadata.dirs=/data/metadata, ozone.scm.ha.ratis.log.appender.queue.num-elements=1024, ozone.scm.ha.ratis.segment.size=4MB, ozone.scm.ha.ratis.rpc.type=GRPC, ozone.metastore.rocksdb.statistics=OFF, hdds.scm.replication.push=true, ozone.scm.datanode.pipeline.limit=1, ozone.scm.grpc.port=9895, hdds.scm.replication.under.replicated.interval=30s, ozone.recon.scm.connection.timeout=5s, hdds.scm.pipeline.choose.policy.impl=org.apache.hadoop.hdds.scm.pipeline.choose.algorithms.RandomPipelineChoosePolicy, ozone.scm.ha.ratis.server.failure.timeout.duration=120s, hdds.datanode.block.deleting.limit.per.interval=5000, ozone.service.shutdown.timeout=60s, ozone.scm.client.address=scm, ozone.scm.chunk.size=4MB, ozone.scm.ha.ratis.log.purge.gap=1000000, ozone.scm.pipeline.leader-choose.policy=
2023-02-12 20:11:34       org.apache.hadoop.hdds.scm.pipeline.leader.choose.algorithms.MinLeaderCountChoosePolicy
2023-02-12 20:11:34     , hdds.scmclient.rpc.timeout=15m}
2023-02-12 20:11:34 ************************************************************/
```

```
Recon: 
/************************************************************
2023-02-12 20:11:34 STARTUP_MSG: Starting ReconServer
...
2023-02-12 20:11:34 STARTUP_MSG:   java = 11.0.17
2023-02-12 20:11:34 STARTUP_MSG:   conf = {ozone.recon.http.auth.kerberos.principal=HTTP/recon@EXAMPLE.COM, ozone.recon.task.missingcontainer.interval=300s, ozone.recon.sql.db.conn.idle.max.age=3600s, ozone.recon.http.enabled=true, ozone.recon.task.pipelinesync.interval=300s, ozone.recon.http-address=0.0.0.0:9888, ozone.recon.nssummary.flush.db.max.threshold=150000, ozone.recon.om.connection.timeout=5s, recon.om.delta.update.loop.limit=10, ozone.recon.administrators=testuser2/scm@EXAMPLE.COM, recon.om.delta.update.limit=2000, ozone.recon.om.snapshot.task.flush.param=false, ozone.recon.sql.db.driver=org.apache.derby.jdbc.EmbeddedDriver, ozone.recon.security.client.datanode.container.protocol.acl=*, ozone.recon.scm.connection.timeout=5s, hdds.recon.heartbeat.interval=60s, ozone.recon.scm.container.threshold=100, ozone.recon.db.dir=/data/metadata/recon, ozone.recon.om.socket.timeout=5s, ozone.recon.sql.db.conn.timeout=30000ms, ozone.recon.https-bind-host=0.0.0.0, ozone.recon.om.snapshot.task.interval.delay=1m, ozone.recon.task.thread.count=1, ozone.recon.http.auth.type=kerberos, ozone.recon.sql.db.conn.idle.test.period=60s, ozone.recon.kerberos.principal=recon/recon@EXAMPLE.COM, ozone.recon.sql.db.conn.idle.test=SELECT 1, ozone.recon.sql.db.auto.commit=true, ozone.recon.scm.snapshot.enabled=true, ozone.recon.http-bind-host=0.0.0.0, ozone.recon.sql.db.jdbc.url=jdbc:derby:${ozone.recon.db.dir}/ozone_recon_derby.db, ozone.recon.scm.connection.request.timeout=5s, ozone.recon.om.snapshot.task.initial.delay=20s, ozone.service.shutdown.timeout=60s, ozone.recon.sql.db.conn.max.active=5, ozone.recon.scm.snapshot.task.initial.delay=1m, ozone.recon.scm.snapshot.task.interval.delay=24h, ozone.recon.om.connection.request.timeout=5000, ozone.recon.http.auth.kerberos.keytab=/etc/security/keytabs/recon.keytab, ozone.recon.task.safemode.wait.threshold=300s, ozone.recon.sql.db.jooq.dialect=DERBY, ozone.recon.sql.db.conn.max.age=1800s, ozone.recon.kerberos.keytab.file=/etc/security/keytabs/recon.keytab, ozone.recon.https-address=0.0.0.0:9889}

```

```
DN: 
/************************************************************
2023-02-12 20:11:34 STARTUP_MSG: Starting HddsDatanodeService
...
2023-02-12 20:11:34 STARTUP_MSG:   java = 11.0.17
2023-02-12 20:11:34 STARTUP_MSG:   conf = {hdds.datanode.metadata.rocksdb.cache.size=64MB, ozone.scm.datanode.ratis.volume.free-space.min=1GB, hdds.datanode.rocksdb.auto-compaction-small-sst-file-num-threshold=512, hdds.ratis.raft.server.delete.ratis.log.directory=true, ozone.network.jvm.address.cache.enabled=true, hdds.datanode.chunk.data.validation.check=false, hdds.datanode.rocksdb.log.level=INFO, hdds.datanode.container.delete.threads.max=2, hdds.ratis.raft.server.watch.timeout=180s, hdds.datanode.container.schema.v3.enabled=true, hdds.datanode.block.delete.threads.max=5, hdds.ratis.raft.server.notification.no-leader.timeout=300s, hdds.ratis.raft.server.datastream.client.pool.size=10, hdds.ratis.raft.server.datastream.request.threads=20, ozone.fs.datastream.enabled=false, hdds.datanode.wait.on.all.followers=false, hdds.ratis.raft.server.rpc.slowness.timeout=300s, ozone.scm.ca.list.retry.interval=10s, hdds.datanode.replication.streams.limit=10, hdds.datanode.rocksdb.auto-compaction-small-sst-file=true, hdds.datanode.failed.data.volumes.tolerated=-1, hdds.datanode.ratis.server.request.timeout=2m, hdds.datanode.rocksdb.max-open-files=1024, hdds.datanode.rocksdb.auto-compaction-small-sst-file-size-threshold=1MB, hdds.datanode.read.chunk.threads.per.volume=10, hdds.datanode.rocksdb.delete-obsolete-files-period=1h, hdds.datanode.container.schema.v3.key.separator=|, hdds.command.status.report.interval=30s, hdds.ratis.raft.server.leaderelection.pre-vote=false, hdds.datanode.block.delete.queue.limit=1440, hdds.ratis.raft.server.rpc.request.timeout=60s, hdds.container.replication.compression=NO_COMPRESSION, hdds.container.action.max.limit=20, hdds.datanode.periodic.disk.check.interval.minutes=60, hdds.datanode.rocksdb.log.max-file-num=64, hdds.datanode.df.refresh.period=5m, hdds.pipeline.action.max.limit=20, hdds.datanode.failed.db.volumes.tolerated=-1, hdds.datanode.rocksdb.log.max-file-size=32MB, hdds.datanode.disk.check.timeout=10m, hdds.container.close.threshold=0.9f, hdds.datanode.disk.check.min.gap=15m, ozone.service.shutdown.timeout=60s, hdds.ratis.raft.server.write.element-limit=1024, hdds.datanode.replication.port=9886, hdds.container.checksum.verification.enabled=true, hdds.datanode.failed.metadata.volumes.tolerated=-1, hdds.datanode.du.refresh.period=1h, hdds.datanode.http.auth.type=kerberos}
```

```
S3G: 
/************************************************************
2023-02-12 17:03:21 STARTUP_MSG: Starting Gateway
...
2023-02-12 17:03:21 STARTUP_MSG:   java = 11.0.17
2023-02-12 17:03:21 STARTUP_MSG:   conf = {hadoop.http.idle_timeout.ms=60000, ozone.s3g.volume.name=s3v, ozone.s3g.http-address=0.0.0.0:9878, ozone.om.grpc.maximum.response.length=134217728, ozone.s3g.http.enabled=true, ozone.service.shutdown.timeout=60s, ozone.s3g.client.buffer.size=4KB, ozone.s3g.http.auth.kerberos.principal=HTTP/s3g@EXAMPLE.COM, ozone.s3g.kerberos.principal=s3g/s3g@EXAMPLE.COM, ozone.s3g.kerberos.keytab.file=/etc/security/keytabs/s3g.keytab, ozone.s3g.http.auth.kerberos.keytab=/etc/security/keytabs/s3g.keytab, ozone.s3g.http-bind-host=0.0.0.0}
```

```
Ozone CSI:
sh-4.2$ ozone csi -conf=/etc/hadoop/x --verbose
...
2023-02-13 01:05:19,080 [main] INFO csi.CsiServer: STARTUP_MSG: 
/************************************************************
STARTUP_MSG: Starting CsiServer
STARTUP_MSG:   host = b453337cacf2/172.18.0.8
STARTUP_MSG:   args = [-conf=/etc/hadoop/x, --verbose]
STARTUP_MSG:   version = 1.4.0-SNAPSHOT
STARTUP_MSG:   classpath = /etc/hadoop...
STARTUP_MSG:   build = git@github.com:SaketaChalamchala/ozone.git/e2a52323ad6a6c0675717e89dd3e9f472e52c228 ; compiled by 'schalamchala' on 2023-02-13T02:12Z
STARTUP_MSG:   java = 11.0.17
STARTUP_MSG:   conf = {ozone.csi.s3g.address=http://localhost:9878, ozone.csi.mount.command=goofys --endpoint %s %s %s, ozone.csi.socket=/var/lib/csi.sock, ozone.csi.default-volume-size=1000000000}
```




