### PR TITLE
HDDS-7919. EC: ECPipelineProvider.createForRead should filter out dead replicas and sort replicas

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/ContainerReplica.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/ContainerReplica.java
@@ -163,6 +163,18 @@ public final class ContainerReplica implements Comparable<ContainerReplica> {
     return new ContainerReplicaBuilder();
   }
 
+  public ContainerReplicaBuilder toBuilder() {
+    return newBuilder()
+        .setBytesUsed(bytesUsed)
+        .setContainerID(containerID)
+        .setContainerState(state)
+        .setDatanodeDetails(datanodeDetails)
+        .setKeyCount(keyCount)
+        .setOriginNodeId(placeOfBirth)
+        .setReplicaIndex(replicaIndex)
+        .setSequenceId(sequenceId);
+  }
+
   @Override
   public String toString() {
     return "ContainerReplica{" +

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/NodeStatus.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/NodeStatus.java
@@ -28,7 +28,7 @@ import java.util.Objects;
  * in_service, decommissioned and maintenance mode) along with the expiry time
  * for the operational state (used with maintenance mode).
  */
-public class NodeStatus {
+public class NodeStatus implements Comparable<NodeStatus> {
 
   private HddsProtos.NodeOperationalState operationalState;
   private HddsProtos.NodeState health;
@@ -91,6 +91,10 @@ public class NodeStatus {
       return false;
     }
     return System.currentTimeMillis() / 1000 >= opStateExpiryEpochSeconds;
+  }
+
+  public boolean isInService() {
+    return operationalState == HddsProtos.NodeOperationalState.IN_SERVICE;
   }
 
   /**
@@ -212,6 +216,18 @@ public class NodeStatus {
   public String toString() {
     return "OperationalState: " + operationalState + " Health: " + health +
         " OperationStateExpiry: " + opStateExpiryEpochSeconds;
+  }
+
+  @Override
+  public int compareTo(NodeStatus o) {
+    int order = Boolean.compare(o.isHealthy(), isHealthy());
+    if (order == 0) {
+      order = Boolean.compare(isDead(), o.isDead());
+    }
+    if (order == 0) {
+      order = operationalState.compareTo(o.operationalState);
+    }
+    return order;
   }
 
 }

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/TestContainerReplica.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/TestContainerReplica.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hdds.scm.container;
+
+import org.apache.hadoop.hdds.protocol.MockDatanodeDetails;
+import org.junit.jupiter.api.Test;
+
+import java.util.UUID;
+import java.util.concurrent.ThreadLocalRandom;
+
+import static org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.ContainerReplicaProto.State.CLOSED;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Tests for {@link ContainerReplica}.
+ */
+class TestContainerReplica {
+
+  @Test
+  void toBuilder() {
+    ContainerReplica subject = ContainerReplica.newBuilder()
+        .setBytesUsed(ThreadLocalRandom.current().nextLong())
+        .setContainerID(ContainerID.valueOf(
+            ThreadLocalRandom.current().nextLong(Long.MAX_VALUE - 1) + 1))
+        .setContainerState(CLOSED)
+        .setKeyCount(ThreadLocalRandom.current().nextLong())
+        .setOriginNodeId(UUID.randomUUID())
+        .setSequenceId(ThreadLocalRandom.current().nextLong())
+        .setReplicaIndex(ThreadLocalRandom.current().nextInt())
+        .setDatanodeDetails(MockDatanodeDetails.randomDatanodeDetails())
+        .build();
+
+    ContainerReplica copy = subject.toBuilder().build();
+    assertEquals(subject, copy);
+    assertEquals(subject.toString(), copy.toString()); // equals is incomplete
+  }
+
+}

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/node/TestNodeStatus.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/node/TestNodeStatus.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hdds.scm.node;
+
+import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+
+import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.NodeOperationalState.DECOMMISSIONING;
+import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.NodeOperationalState.ENTERING_MAINTENANCE;
+import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.NodeState.HEALTHY;
+import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.NodeState.HEALTHY_READONLY;
+import static org.apache.hadoop.hdds.scm.node.NodeStatus.inServiceDead;
+import static org.apache.hadoop.hdds.scm.node.NodeStatus.inServiceHealthy;
+import static org.apache.hadoop.hdds.scm.node.NodeStatus.inServiceStale;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Tests for {@link NodeStatus}.
+ */
+class TestNodeStatus {
+
+  @ParameterizedTest
+  @EnumSource
+  void readOnly(HddsProtos.NodeOperationalState state) {
+    assertEquals(0, new NodeStatus(state, HEALTHY)
+        .compareTo(new NodeStatus(state, HEALTHY_READONLY)));
+  }
+
+  @Test
+  void healthyFirst() {
+    assertTrue(0 > inServiceHealthy().compareTo(inServiceStale()));
+    assertTrue(0 < inServiceDead().compareTo(inServiceHealthy()));
+    assertTrue(0 > new NodeStatus(ENTERING_MAINTENANCE, HEALTHY).compareTo(
+        inServiceStale()
+    ));
+    assertTrue(0 < inServiceStale().compareTo(
+        new NodeStatus(DECOMMISSIONING, HEALTHY)
+    ));
+  }
+
+  @Test
+  void inServiceFirst() {
+    assertTrue(0 > inServiceHealthy().compareTo(
+        new NodeStatus(ENTERING_MAINTENANCE, HEALTHY)));
+    assertTrue(0 < new NodeStatus(DECOMMISSIONING, HEALTHY).compareTo(
+        inServiceHealthy()
+    ));
+  }
+
+}


### PR DESCRIPTION
## What changes were proposed in this pull request?

Sort datanodes of EC read pipeline by health and state, omit dead datanodes.

https://issues.apache.org/jira/browse/HDDS-7919

## How was this patch tested?

Added unit test.

https://github.com/adoroszlai/hadoop-ozone/actions/runs/4177372996