### PR TITLE
HDDS-7966. Replace Hadoop annotations with Ozone-specific ones

### DIFF
--- a/hadoop-ozone/httpfsgateway/src/main/java/org/apache/ozone/fs/http/HttpFSConstants.java
+++ b/hadoop-ozone/httpfsgateway/src/main/java/org/apache/ozone/fs/http/HttpFSConstants.java
@@ -17,9 +17,9 @@
  */
 package org.apache.ozone.fs.http;
 
-import org.apache.hadoop.classification.InterfaceAudience;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.permission.FsPermission;
+import org.apache.hadoop.hdds.annotation.InterfaceAudience;
 
 /**
  * Constants for the HttpFs server side implementations.

--- a/hadoop-ozone/httpfsgateway/src/main/java/org/apache/ozone/fs/http/server/CheckUploadContentTypeFilter.java
+++ b/hadoop-ozone/httpfsgateway/src/main/java/org/apache/ozone/fs/http/server/CheckUploadContentTypeFilter.java
@@ -19,7 +19,7 @@
 package org.apache.ozone.fs.http.server;
 
 
-import org.apache.hadoop.classification.InterfaceAudience;
+import org.apache.hadoop.hdds.annotation.InterfaceAudience;
 import org.apache.ozone.fs.http.HttpFSConstants;
 import org.apache.hadoop.util.StringUtils;
 

--- a/hadoop-ozone/httpfsgateway/src/main/java/org/apache/ozone/fs/http/server/FSOperations.java
+++ b/hadoop-ozone/httpfsgateway/src/main/java/org/apache/ozone/fs/http/server/FSOperations.java
@@ -17,7 +17,6 @@
  */
 package org.apache.ozone.fs.http.server;
 
-import org.apache.hadoop.classification.InterfaceAudience;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.BlockStoragePolicySpi;
 import org.apache.hadoop.fs.ContentSummary;
@@ -39,6 +38,7 @@ import org.apache.hadoop.fs.permission.AclEntry;
 import org.apache.hadoop.fs.permission.AclStatus;
 import org.apache.hadoop.fs.permission.FsAction;
 import org.apache.hadoop.fs.permission.FsPermission;
+import org.apache.hadoop.hdds.annotation.InterfaceAudience;
 import org.apache.hadoop.hdfs.DistributedFileSystem;
 import org.apache.hadoop.hdfs.protocol.BlockStoragePolicy;
 import org.apache.hadoop.hdfs.protocol.ErasureCodingPolicy;

--- a/hadoop-ozone/httpfsgateway/src/main/java/org/apache/ozone/fs/http/server/HttpFSAuthenticationFilter.java
+++ b/hadoop-ozone/httpfsgateway/src/main/java/org/apache/ozone/fs/http/server/HttpFSAuthenticationFilter.java
@@ -17,8 +17,8 @@
  */
 package org.apache.ozone.fs.http.server;
 
-import org.apache.hadoop.classification.InterfaceAudience;
 import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hdds.annotation.InterfaceAudience;
 import org.apache.ozone.hdfs.web.WebHdfsConstants;
 import org.apache.hadoop.security.authentication.server.AuthenticationFilter;
 import org.apache.hadoop.security.authentication.util.RandomSignerSecretProvider;

--- a/hadoop-ozone/httpfsgateway/src/main/java/org/apache/ozone/fs/http/server/HttpFSExceptionProvider.java
+++ b/hadoop-ozone/httpfsgateway/src/main/java/org/apache/ozone/fs/http/server/HttpFSExceptionProvider.java
@@ -19,7 +19,7 @@
 package org.apache.ozone.fs.http.server;
 
 import com.sun.jersey.api.container.ContainerException;
-import org.apache.hadoop.classification.InterfaceAudience;
+import org.apache.hadoop.hdds.annotation.InterfaceAudience;
 import org.apache.ozone.lib.service.FileSystemAccessException;
 import org.apache.ozone.lib.wsrs.ExceptionProvider;
 import org.slf4j.Logger;

--- a/hadoop-ozone/httpfsgateway/src/main/java/org/apache/ozone/fs/http/server/HttpFSParametersProvider.java
+++ b/hadoop-ozone/httpfsgateway/src/main/java/org/apache/ozone/fs/http/server/HttpFSParametersProvider.java
@@ -17,9 +17,9 @@
  */
 package org.apache.ozone.fs.http.server;
 
-import org.apache.hadoop.classification.InterfaceAudience;
 import org.apache.hadoop.fs.XAttrCodec;
 import org.apache.hadoop.fs.XAttrSetFlag;
+import org.apache.hadoop.hdds.annotation.InterfaceAudience;
 import org.apache.ozone.fs.http.HttpFSConstants;
 import org.apache.ozone.fs.http.HttpFSConstants.Operation;
 import org.apache.hadoop.hdfs.client.HdfsClientConfigKeys;

--- a/hadoop-ozone/httpfsgateway/src/main/java/org/apache/ozone/fs/http/server/HttpFSReleaseFilter.java
+++ b/hadoop-ozone/httpfsgateway/src/main/java/org/apache/ozone/fs/http/server/HttpFSReleaseFilter.java
@@ -18,7 +18,7 @@
 
 package org.apache.ozone.fs.http.server;
 
-import org.apache.hadoop.classification.InterfaceAudience;
+import org.apache.hadoop.hdds.annotation.InterfaceAudience;
 import org.apache.ozone.lib.service.FileSystemAccess;
 import org.apache.ozone.lib.servlet.FileSystemReleaseFilter;
 

--- a/hadoop-ozone/httpfsgateway/src/main/java/org/apache/ozone/fs/http/server/HttpFSServer.java
+++ b/hadoop-ozone/httpfsgateway/src/main/java/org/apache/ozone/fs/http/server/HttpFSServer.java
@@ -18,7 +18,6 @@
 
 package org.apache.ozone.fs.http.server;
 
-import org.apache.hadoop.classification.InterfaceAudience;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.XAttrCodec;
@@ -54,6 +53,7 @@ import org.apache.ozone.fs.http.server.HttpFSParametersProvider.XAttrNameParam;
 import org.apache.ozone.fs.http.server.HttpFSParametersProvider.XAttrSetFlagParam;
 import org.apache.ozone.fs.http.server.HttpFSParametersProvider.XAttrValueParam;
 import org.apache.hadoop.fs.permission.FsAction;
+import org.apache.hadoop.hdds.annotation.InterfaceAudience;
 import org.apache.hadoop.http.JettyUtils;
 import org.apache.ozone.lib.service.FileSystemAccess;
 import org.apache.ozone.lib.service.FileSystemAccessException;

--- a/hadoop-ozone/httpfsgateway/src/main/java/org/apache/ozone/fs/http/server/HttpFSServerWebApp.java
+++ b/hadoop-ozone/httpfsgateway/src/main/java/org/apache/ozone/fs/http/server/HttpFSServerWebApp.java
@@ -18,13 +18,13 @@
 
 package org.apache.ozone.fs.http.server;
 
-import org.apache.hadoop.classification.InterfaceAudience;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.CommonConfigurationKeysPublic;
 import org.apache.ozone.fs.http.server.metrics.HttpFSServerMetrics;
 import org.apache.ozone.lib.server.ServerException;
 import org.apache.ozone.lib.service.FileSystemAccess;
 import org.apache.ozone.lib.servlet.ServerWebApp;
+import org.apache.hadoop.hdds.annotation.InterfaceAudience;
 import org.apache.hadoop.metrics2.lib.DefaultMetricsSystem;
 import org.apache.hadoop.util.JvmPauseMonitor;
 

--- a/hadoop-ozone/httpfsgateway/src/main/java/org/apache/ozone/fs/http/server/HttpFSServerWebServer.java
+++ b/hadoop-ozone/httpfsgateway/src/main/java/org/apache/ozone/fs/http/server/HttpFSServerWebServer.java
@@ -27,8 +27,8 @@ import java.net.URL;
 import java.util.LinkedHashSet;
 import java.util.Set;
 
-import org.apache.hadoop.classification.InterfaceAudience;
 import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hdds.annotation.InterfaceAudience;
 import org.apache.hadoop.http.HttpServer2;
 import org.apache.hadoop.security.AuthenticationFilterInitializer;
 import org.apache.hadoop.security.authentication.server.ProxyUserAuthenticationFilterInitializer;

--- a/hadoop-ozone/httpfsgateway/src/main/java/org/apache/ozone/fs/http/server/metrics/HttpFSServerMetrics.java
+++ b/hadoop-ozone/httpfsgateway/src/main/java/org/apache/ozone/fs/http/server/metrics/HttpFSServerMetrics.java
@@ -19,8 +19,8 @@ package org.apache.ozone.fs.http.server.metrics;
 
 import static org.apache.hadoop.metrics2.impl.MsInfo.SessionId;
 
-import org.apache.hadoop.classification.InterfaceAudience;
 import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hdds.annotation.InterfaceAudience;
 import org.apache.hadoop.metrics2.MetricsSystem;
 import org.apache.hadoop.metrics2.annotation.Metric;
 import org.apache.hadoop.metrics2.annotation.Metrics;

--- a/hadoop-ozone/httpfsgateway/src/main/java/org/apache/ozone/fs/http/server/metrics/package-info.java
+++ b/hadoop-ozone/httpfsgateway/src/main/java/org/apache/ozone/fs/http/server/metrics/package-info.java
@@ -22,5 +22,5 @@
 @InterfaceStability.Evolving
 package org.apache.ozone.fs.http.server.metrics;
 
-import org.apache.hadoop.classification.InterfaceAudience;
-import org.apache.hadoop.classification.InterfaceStability;
+import org.apache.hadoop.hdds.annotation.InterfaceAudience;
+import org.apache.hadoop.hdds.annotation.InterfaceStability;

--- a/hadoop-ozone/httpfsgateway/src/main/java/org/apache/ozone/hdfs/web/WebHdfsConstants.java
+++ b/hadoop-ozone/httpfsgateway/src/main/java/org/apache/ozone/hdfs/web/WebHdfsConstants.java
@@ -17,7 +17,7 @@
  */
 package org.apache.ozone.hdfs.web;
 
-import org.apache.hadoop.classification.InterfaceAudience;
+import org.apache.hadoop.hdds.annotation.InterfaceAudience;
 import org.apache.hadoop.hdfs.protocol.HdfsFileStatus;
 import org.apache.hadoop.io.Text;
 

--- a/hadoop-ozone/httpfsgateway/src/main/java/org/apache/ozone/lib/lang/RunnableCallable.java
+++ b/hadoop-ozone/httpfsgateway/src/main/java/org/apache/ozone/lib/lang/RunnableCallable.java
@@ -18,7 +18,7 @@
 
 package org.apache.ozone.lib.lang;
 
-import org.apache.hadoop.classification.InterfaceAudience;
+import org.apache.hadoop.hdds.annotation.InterfaceAudience;
 import org.apache.ozone.lib.util.Check;
 
 import java.util.concurrent.Callable;

--- a/hadoop-ozone/httpfsgateway/src/main/java/org/apache/ozone/lib/lang/XException.java
+++ b/hadoop-ozone/httpfsgateway/src/main/java/org/apache/ozone/lib/lang/XException.java
@@ -18,7 +18,7 @@
 
 package org.apache.ozone.lib.lang;
 
-import org.apache.hadoop.classification.InterfaceAudience;
+import org.apache.hadoop.hdds.annotation.InterfaceAudience;
 import org.apache.ozone.lib.util.Check;
 
 import java.text.MessageFormat;

--- a/hadoop-ozone/httpfsgateway/src/main/java/org/apache/ozone/lib/server/BaseService.java
+++ b/hadoop-ozone/httpfsgateway/src/main/java/org/apache/ozone/lib/server/BaseService.java
@@ -18,8 +18,8 @@
 
 package org.apache.ozone.lib.server;
 
-import org.apache.hadoop.classification.InterfaceAudience;
 import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hdds.annotation.InterfaceAudience;
 import org.apache.ozone.lib.util.ConfigurationUtils;
 
 import java.util.Map;

--- a/hadoop-ozone/httpfsgateway/src/main/java/org/apache/ozone/lib/server/Server.java
+++ b/hadoop-ozone/httpfsgateway/src/main/java/org/apache/ozone/lib/server/Server.java
@@ -18,9 +18,9 @@
 
 package org.apache.ozone.lib.server;
 
-import org.apache.hadoop.classification.InterfaceAudience;
 import org.apache.hadoop.conf.ConfigRedactor;
 import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hdds.annotation.InterfaceAudience;
 import org.apache.ozone.lib.util.Check;
 import org.apache.ozone.lib.util.ConfigurationUtils;
 import org.apache.hadoop.util.StringUtils;

--- a/hadoop-ozone/httpfsgateway/src/main/java/org/apache/ozone/lib/server/ServerException.java
+++ b/hadoop-ozone/httpfsgateway/src/main/java/org/apache/ozone/lib/server/ServerException.java
@@ -18,7 +18,7 @@
 
 package org.apache.ozone.lib.server;
 
-import org.apache.hadoop.classification.InterfaceAudience;
+import org.apache.hadoop.hdds.annotation.InterfaceAudience;
 import org.apache.ozone.lib.lang.XException;
 
 /**

--- a/hadoop-ozone/httpfsgateway/src/main/java/org/apache/ozone/lib/server/Service.java
+++ b/hadoop-ozone/httpfsgateway/src/main/java/org/apache/ozone/lib/server/Service.java
@@ -18,7 +18,7 @@
 
 package org.apache.ozone.lib.server;
 
-import org.apache.hadoop.classification.InterfaceAudience;
+import org.apache.hadoop.hdds.annotation.InterfaceAudience;
 
 /**
  * Service interface for components to be managed by the {@link Server} class.

--- a/hadoop-ozone/httpfsgateway/src/main/java/org/apache/ozone/lib/server/ServiceException.java
+++ b/hadoop-ozone/httpfsgateway/src/main/java/org/apache/ozone/lib/server/ServiceException.java
@@ -18,7 +18,7 @@
 
 package org.apache.ozone.lib.server;
 
-import org.apache.hadoop.classification.InterfaceAudience;
+import org.apache.hadoop.hdds.annotation.InterfaceAudience;
 import org.apache.ozone.lib.lang.XException;
 
 /**

--- a/hadoop-ozone/httpfsgateway/src/main/java/org/apache/ozone/lib/service/FileSystemAccess.java
+++ b/hadoop-ozone/httpfsgateway/src/main/java/org/apache/ozone/lib/service/FileSystemAccess.java
@@ -18,9 +18,9 @@
 
 package org.apache.ozone.lib.service;
 
-import org.apache.hadoop.classification.InterfaceAudience;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.hdds.annotation.InterfaceAudience;
 
 import java.io.IOException;
 

--- a/hadoop-ozone/httpfsgateway/src/main/java/org/apache/ozone/lib/service/FileSystemAccessException.java
+++ b/hadoop-ozone/httpfsgateway/src/main/java/org/apache/ozone/lib/service/FileSystemAccessException.java
@@ -18,7 +18,7 @@
 
 package org.apache.ozone.lib.service;
 
-import org.apache.hadoop.classification.InterfaceAudience;
+import org.apache.hadoop.hdds.annotation.InterfaceAudience;
 import org.apache.ozone.lib.lang.XException;
 
 /**

--- a/hadoop-ozone/httpfsgateway/src/main/java/org/apache/ozone/lib/service/Groups.java
+++ b/hadoop-ozone/httpfsgateway/src/main/java/org/apache/ozone/lib/service/Groups.java
@@ -18,7 +18,7 @@
 
 package org.apache.ozone.lib.service;
 
-import org.apache.hadoop.classification.InterfaceAudience;
+import org.apache.hadoop.hdds.annotation.InterfaceAudience;
 
 import java.io.IOException;
 import java.util.List;

--- a/hadoop-ozone/httpfsgateway/src/main/java/org/apache/ozone/lib/service/Instrumentation.java
+++ b/hadoop-ozone/httpfsgateway/src/main/java/org/apache/ozone/lib/service/Instrumentation.java
@@ -18,7 +18,7 @@
 
 package org.apache.ozone.lib.service;
 
-import org.apache.hadoop.classification.InterfaceAudience;
+import org.apache.hadoop.hdds.annotation.InterfaceAudience;
 
 import java.util.Map;
 

--- a/hadoop-ozone/httpfsgateway/src/main/java/org/apache/ozone/lib/service/Scheduler.java
+++ b/hadoop-ozone/httpfsgateway/src/main/java/org/apache/ozone/lib/service/Scheduler.java
@@ -18,7 +18,7 @@
 
 package org.apache.ozone.lib.service;
 
-import org.apache.hadoop.classification.InterfaceAudience;
+import org.apache.hadoop.hdds.annotation.InterfaceAudience;
 
 import java.util.concurrent.Callable;
 import java.util.concurrent.TimeUnit;

--- a/hadoop-ozone/httpfsgateway/src/main/java/org/apache/ozone/lib/service/hadoop/FileSystemAccessService.java
+++ b/hadoop-ozone/httpfsgateway/src/main/java/org/apache/ozone/lib/service/hadoop/FileSystemAccessService.java
@@ -18,12 +18,12 @@
 
 package org.apache.ozone.lib.service.hadoop;
 
-import org.apache.hadoop.classification.InterfaceAudience;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.CommonConfigurationKeysPublic;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.permission.FsPermission;
+import org.apache.hadoop.hdds.annotation.InterfaceAudience;
 import org.apache.ozone.lib.server.BaseService;
 import org.apache.ozone.lib.server.ServiceException;
 import org.apache.ozone.lib.service.FileSystemAccess;

--- a/hadoop-ozone/httpfsgateway/src/main/java/org/apache/ozone/lib/service/instrumentation/InstrumentationService.java
+++ b/hadoop-ozone/httpfsgateway/src/main/java/org/apache/ozone/lib/service/instrumentation/InstrumentationService.java
@@ -18,7 +18,7 @@
 
 package org.apache.ozone.lib.service.instrumentation;
 
-import org.apache.hadoop.classification.InterfaceAudience;
+import org.apache.hadoop.hdds.annotation.InterfaceAudience;
 import org.apache.ozone.lib.server.BaseService;
 import org.apache.ozone.lib.server.ServiceException;
 import org.apache.ozone.lib.service.Instrumentation;

--- a/hadoop-ozone/httpfsgateway/src/main/java/org/apache/ozone/lib/service/scheduler/SchedulerService.java
+++ b/hadoop-ozone/httpfsgateway/src/main/java/org/apache/ozone/lib/service/scheduler/SchedulerService.java
@@ -18,7 +18,7 @@
 
 package org.apache.ozone.lib.service.scheduler;
 
-import org.apache.hadoop.classification.InterfaceAudience;
+import org.apache.hadoop.hdds.annotation.InterfaceAudience;
 import org.apache.ozone.lib.lang.RunnableCallable;
 import org.apache.ozone.lib.server.BaseService;
 import org.apache.ozone.lib.server.Server;

--- a/hadoop-ozone/httpfsgateway/src/main/java/org/apache/ozone/lib/service/security/GroupsService.java
+++ b/hadoop-ozone/httpfsgateway/src/main/java/org/apache/ozone/lib/service/security/GroupsService.java
@@ -18,8 +18,8 @@
 
 package org.apache.ozone.lib.service.security;
 
-import org.apache.hadoop.classification.InterfaceAudience;
 import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hdds.annotation.InterfaceAudience;
 import org.apache.ozone.lib.server.BaseService;
 import org.apache.ozone.lib.server.ServiceException;
 import org.apache.ozone.lib.service.Groups;

--- a/hadoop-ozone/httpfsgateway/src/main/java/org/apache/ozone/lib/servlet/FileSystemReleaseFilter.java
+++ b/hadoop-ozone/httpfsgateway/src/main/java/org/apache/ozone/lib/servlet/FileSystemReleaseFilter.java
@@ -18,8 +18,8 @@
 
 package org.apache.ozone.lib.servlet;
 
-import org.apache.hadoop.classification.InterfaceAudience;
 import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.hdds.annotation.InterfaceAudience;
 import org.apache.ozone.lib.service.FileSystemAccess;
 
 import javax.servlet.Filter;

--- a/hadoop-ozone/httpfsgateway/src/main/java/org/apache/ozone/lib/servlet/HostnameFilter.java
+++ b/hadoop-ozone/httpfsgateway/src/main/java/org/apache/ozone/lib/servlet/HostnameFilter.java
@@ -19,7 +19,7 @@
 package org.apache.ozone.lib.servlet;
 
 
-import org.apache.hadoop.classification.InterfaceAudience;
+import org.apache.hadoop.hdds.annotation.InterfaceAudience;
 
 import javax.servlet.Filter;
 import javax.servlet.FilterChain;

--- a/hadoop-ozone/httpfsgateway/src/main/java/org/apache/ozone/lib/servlet/MDCFilter.java
+++ b/hadoop-ozone/httpfsgateway/src/main/java/org/apache/ozone/lib/servlet/MDCFilter.java
@@ -18,7 +18,7 @@
 
 package org.apache.ozone.lib.servlet;
 
-import org.apache.hadoop.classification.InterfaceAudience;
+import org.apache.hadoop.hdds.annotation.InterfaceAudience;
 import org.slf4j.MDC;
 
 import javax.servlet.Filter;

--- a/hadoop-ozone/httpfsgateway/src/main/java/org/apache/ozone/lib/servlet/ServerWebApp.java
+++ b/hadoop-ozone/httpfsgateway/src/main/java/org/apache/ozone/lib/servlet/ServerWebApp.java
@@ -18,8 +18,8 @@
 
 package org.apache.ozone.lib.servlet;
 
-import org.apache.hadoop.classification.InterfaceAudience;
 import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hdds.annotation.InterfaceAudience;
 import org.apache.ratis.thirdparty.com.google.common.annotations.VisibleForTesting;
 import org.apache.ozone.lib.server.Server;
 import org.apache.ozone.lib.server.ServerException;

--- a/hadoop-ozone/httpfsgateway/src/main/java/org/apache/ozone/lib/util/Check.java
+++ b/hadoop-ozone/httpfsgateway/src/main/java/org/apache/ozone/lib/util/Check.java
@@ -18,7 +18,7 @@
 
 package org.apache.ozone.lib.util;
 
-import org.apache.hadoop.classification.InterfaceAudience;
+import org.apache.hadoop.hdds.annotation.InterfaceAudience;
 
 import java.text.MessageFormat;
 import java.util.List;

--- a/hadoop-ozone/httpfsgateway/src/main/java/org/apache/ozone/lib/util/ConfigurationUtils.java
+++ b/hadoop-ozone/httpfsgateway/src/main/java/org/apache/ozone/lib/util/ConfigurationUtils.java
@@ -18,8 +18,8 @@
 
 package org.apache.ozone.lib.util;
 
-import org.apache.hadoop.classification.InterfaceAudience;
 import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hdds.annotation.InterfaceAudience;
 
 import java.io.IOException;
 import java.io.InputStream;

--- a/hadoop-ozone/httpfsgateway/src/main/java/org/apache/ozone/lib/wsrs/BooleanParam.java
+++ b/hadoop-ozone/httpfsgateway/src/main/java/org/apache/ozone/lib/wsrs/BooleanParam.java
@@ -18,7 +18,7 @@
 
 package org.apache.ozone.lib.wsrs;
 
-import org.apache.hadoop.classification.InterfaceAudience;
+import org.apache.hadoop.hdds.annotation.InterfaceAudience;
 
 import java.text.MessageFormat;
 

--- a/hadoop-ozone/httpfsgateway/src/main/java/org/apache/ozone/lib/wsrs/ByteParam.java
+++ b/hadoop-ozone/httpfsgateway/src/main/java/org/apache/ozone/lib/wsrs/ByteParam.java
@@ -18,7 +18,7 @@
 
 package org.apache.ozone.lib.wsrs;
 
-import org.apache.hadoop.classification.InterfaceAudience;
+import org.apache.hadoop.hdds.annotation.InterfaceAudience;
 
 /**
  * Byte parameter.

--- a/hadoop-ozone/httpfsgateway/src/main/java/org/apache/ozone/lib/wsrs/EnumParam.java
+++ b/hadoop-ozone/httpfsgateway/src/main/java/org/apache/ozone/lib/wsrs/EnumParam.java
@@ -18,7 +18,7 @@
 
 package org.apache.ozone.lib.wsrs;
 
-import org.apache.hadoop.classification.InterfaceAudience;
+import org.apache.hadoop.hdds.annotation.InterfaceAudience;
 import org.apache.hadoop.util.StringUtils;
 
 import java.util.Arrays;

--- a/hadoop-ozone/httpfsgateway/src/main/java/org/apache/ozone/lib/wsrs/EnumSetParam.java
+++ b/hadoop-ozone/httpfsgateway/src/main/java/org/apache/ozone/lib/wsrs/EnumSetParam.java
@@ -21,7 +21,7 @@ import java.util.Arrays;
 import java.util.EnumSet;
 import java.util.Iterator;
 
-import org.apache.hadoop.classification.InterfaceAudience;
+import org.apache.hadoop.hdds.annotation.InterfaceAudience;
 import org.apache.hadoop.util.StringUtils;
 
 /**

--- a/hadoop-ozone/httpfsgateway/src/main/java/org/apache/ozone/lib/wsrs/ExceptionProvider.java
+++ b/hadoop-ozone/httpfsgateway/src/main/java/org/apache/ozone/lib/wsrs/ExceptionProvider.java
@@ -18,7 +18,7 @@
 
 package org.apache.ozone.lib.wsrs;
 
-import org.apache.hadoop.classification.InterfaceAudience;
+import org.apache.hadoop.hdds.annotation.InterfaceAudience;
 import org.apache.hadoop.util.HttpExceptionUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/hadoop-ozone/httpfsgateway/src/main/java/org/apache/ozone/lib/wsrs/InputStreamEntity.java
+++ b/hadoop-ozone/httpfsgateway/src/main/java/org/apache/ozone/lib/wsrs/InputStreamEntity.java
@@ -18,7 +18,7 @@
 
 package org.apache.ozone.lib.wsrs;
 
-import org.apache.hadoop.classification.InterfaceAudience;
+import org.apache.hadoop.hdds.annotation.InterfaceAudience;
 import org.apache.ozone.fs.http.server.FSOperations;
 import org.apache.ozone.fs.http.server.HttpFSServerWebApp;
 import org.apache.ozone.fs.http.server.metrics.HttpFSServerMetrics;

--- a/hadoop-ozone/httpfsgateway/src/main/java/org/apache/ozone/lib/wsrs/IntegerParam.java
+++ b/hadoop-ozone/httpfsgateway/src/main/java/org/apache/ozone/lib/wsrs/IntegerParam.java
@@ -18,7 +18,7 @@
 
 package org.apache.ozone.lib.wsrs;
 
-import org.apache.hadoop.classification.InterfaceAudience;
+import org.apache.hadoop.hdds.annotation.InterfaceAudience;
 
 /**
  * Integer parameter.

--- a/hadoop-ozone/httpfsgateway/src/main/java/org/apache/ozone/lib/wsrs/JSONMapProvider.java
+++ b/hadoop-ozone/httpfsgateway/src/main/java/org/apache/ozone/lib/wsrs/JSONMapProvider.java
@@ -18,7 +18,7 @@
 
 package org.apache.ozone.lib.wsrs;
 
-import org.apache.hadoop.classification.InterfaceAudience;
+import org.apache.hadoop.hdds.annotation.InterfaceAudience;
 import org.apache.hadoop.http.JettyUtils;
 import org.json.simple.JSONObject;
 

--- a/hadoop-ozone/httpfsgateway/src/main/java/org/apache/ozone/lib/wsrs/JSONProvider.java
+++ b/hadoop-ozone/httpfsgateway/src/main/java/org/apache/ozone/lib/wsrs/JSONProvider.java
@@ -18,7 +18,7 @@
 
 package org.apache.ozone.lib.wsrs;
 
-import org.apache.hadoop.classification.InterfaceAudience;
+import org.apache.hadoop.hdds.annotation.InterfaceAudience;
 import org.apache.hadoop.http.JettyUtils;
 import org.json.simple.JSONStreamAware;
 

--- a/hadoop-ozone/httpfsgateway/src/main/java/org/apache/ozone/lib/wsrs/LongParam.java
+++ b/hadoop-ozone/httpfsgateway/src/main/java/org/apache/ozone/lib/wsrs/LongParam.java
@@ -18,7 +18,7 @@
 
 package org.apache.ozone.lib.wsrs;
 
-import org.apache.hadoop.classification.InterfaceAudience;
+import org.apache.hadoop.hdds.annotation.InterfaceAudience;
 
 /**
  * Long parameter.

--- a/hadoop-ozone/httpfsgateway/src/main/java/org/apache/ozone/lib/wsrs/Param.java
+++ b/hadoop-ozone/httpfsgateway/src/main/java/org/apache/ozone/lib/wsrs/Param.java
@@ -18,7 +18,7 @@
 
 package org.apache.ozone.lib.wsrs;
 
-import org.apache.hadoop.classification.InterfaceAudience;
+import org.apache.hadoop.hdds.annotation.InterfaceAudience;
 
 import java.text.MessageFormat;
 

--- a/hadoop-ozone/httpfsgateway/src/main/java/org/apache/ozone/lib/wsrs/Parameters.java
+++ b/hadoop-ozone/httpfsgateway/src/main/java/org/apache/ozone/lib/wsrs/Parameters.java
@@ -17,7 +17,7 @@
  */
 package org.apache.ozone.lib.wsrs;
 
-import org.apache.hadoop.classification.InterfaceAudience;
+import org.apache.hadoop.hdds.annotation.InterfaceAudience;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/hadoop-ozone/httpfsgateway/src/main/java/org/apache/ozone/lib/wsrs/ParametersProvider.java
+++ b/hadoop-ozone/httpfsgateway/src/main/java/org/apache/ozone/lib/wsrs/ParametersProvider.java
@@ -24,7 +24,7 @@ import com.sun.jersey.core.spi.component.ComponentScope;
 import com.sun.jersey.server.impl.inject.AbstractHttpContextInjectable;
 import com.sun.jersey.spi.inject.Injectable;
 import com.sun.jersey.spi.inject.InjectableProvider;
-import org.apache.hadoop.classification.InterfaceAudience;
+import org.apache.hadoop.hdds.annotation.InterfaceAudience;
 import org.apache.hadoop.util.StringUtils;
 
 import javax.ws.rs.core.Context;

--- a/hadoop-ozone/httpfsgateway/src/main/java/org/apache/ozone/lib/wsrs/ShortParam.java
+++ b/hadoop-ozone/httpfsgateway/src/main/java/org/apache/ozone/lib/wsrs/ShortParam.java
@@ -18,7 +18,7 @@
 
 package org.apache.ozone.lib.wsrs;
 
-import org.apache.hadoop.classification.InterfaceAudience;
+import org.apache.hadoop.hdds.annotation.InterfaceAudience;
 
 /**
  * Short parameter.

--- a/hadoop-ozone/httpfsgateway/src/main/java/org/apache/ozone/lib/wsrs/StringParam.java
+++ b/hadoop-ozone/httpfsgateway/src/main/java/org/apache/ozone/lib/wsrs/StringParam.java
@@ -17,7 +17,7 @@
  */
 package org.apache.ozone.lib.wsrs;
 
-import org.apache.hadoop.classification.InterfaceAudience;
+import org.apache.hadoop.hdds.annotation.InterfaceAudience;
 
 import java.text.MessageFormat;
 import java.util.regex.Pattern;


### PR DESCRIPTION
## What changes were proposed in this pull request?

Replace new usage of Hadoop's `InterfaceAudience` and `InterfaceStability` annotations with Ozone-specific ones (introduced in HDDS-3028).

https://issues.apache.org/jira/browse/HDDS-7966

## How was this patch tested?

Build and checkstyle:
https://github.com/adoroszlai/hadoop-ozone/actions/runs/4194009972