### PR TITLE
HDDS-7988. Run S3 tests with HA Proxy

### DIFF
--- a/hadoop-ozone/dist/src/main/compose/ozones3-haproxy/test.sh
+++ b/hadoop-ozone/dist/src/main/compose/ozones3-haproxy/test.sh
@@ -18,12 +18,14 @@
 COMPOSE_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 export COMPOSE_DIR
 
+export SECURITY_ENABLED=false
+
 # shellcheck source=/dev/null
 source "$COMPOSE_DIR/../testlib.sh"
 
 start_docker_env
 
-execute_robot_test scm basic/basic.robot
+execute_robot_test scm s3
 
 stop_docker_env
 

--- a/hadoop-ozone/dist/src/main/smoketest/s3/webui.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/s3/webui.robot
@@ -32,7 +32,7 @@ ${BUCKET}             generated
 S3 Gateway Web UI
     Run Keyword if      '${SECURITY_ENABLED}' == 'true'     Kinit HTTP user
     ${result} =         Execute                             curl --negotiate -u : -v ${ENDPOINT_URL}
-                        Should contain      ${result}       Location
+                        Should contain      ${result}       Location:    ignore_case=True
                         Should contain      ${result}       /static/
     ${result} =         Execute                             curl --negotiate -u : -v ${ENDPOINT_URL}/static/index.html
                         Should contain      ${result}       Apache Ozone S3


### PR DESCRIPTION
## What changes were proposed in this pull request?

HDDS-1972 added a docker-compose example for HA Proxy in front of multiple S3 Gateways.  The example only runs basic, non-S3 tests.  This change replaces it with S3 tests, to verify S3 Gateway works with such setup.

https://issues.apache.org/jira/browse/HDDS-7988

## How was this patch tested?

https://github.com/adoroszlai/hadoop-ozone/actions/runs/4205557222/jobs/7298351301#step:5:849