### PR TITLE
HDDS-7989. UnhealthyReplicationProcessor retries failure without delay

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/UnhealthyReplicationProcessor.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/UnhealthyReplicationProcessor.java
@@ -27,6 +27,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
+import java.util.LinkedList;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -80,6 +82,7 @@ public abstract class UnhealthyReplicationProcessor<HealthResult extends
     int failed = 0;
     Map<ContainerHealthResult.HealthState, Integer> healthStateCntMap =
             Maps.newHashMap();
+    List<HealthResult> failedOnes = new LinkedList<>();
     while (true) {
       if (!replicationManager.shouldRun()) {
         break;
@@ -99,9 +102,13 @@ public abstract class UnhealthyReplicationProcessor<HealthResult extends
                    "container {}", healthResult.getClass(),
                 healthResult.getContainerInfo(), e);
         failed++;
-        requeueHealthResultFromQueue(replicationManager, healthResult);
+        failedOnes.add(healthResult);
       }
     }
+
+    failedOnes.forEach(result ->
+        requeueHealthResultFromQueue(replicationManager, result));
+
     LOG.info("Processed {} containers with health state counts {}," +
              "failed processing {}", processed, healthStateCntMap, failed);
   }


### PR DESCRIPTION
## What changes were proposed in this pull request?

`UnhealthyReplicationProcessor#processAll` requeues any failed task.  Such tasks are attempted in the same `processAll` call, before exiting the loop.  This can flood SCM logs until the cause of the error is resolved.

This causes Github's environment to [run out of disk space](https://github.com/adoroszlai/hadoop-ozone/actions/runs/4205417969/jobs/7297733162#step:5:1527) in just a few minutes after testing EC reconstruction read (test being added in HDDS-7982).

This PR proposes to collect failed container health results and requeue them only after exiting the loop.

https://issues.apache.org/jira/browse/HDDS-7989

## How was this patch tested?

Added unit test.

Also verified together with HDDS-7982 (which uncovered the problem without this fix):
https://github.com/adoroszlai/hadoop-ozone/actions/runs/4207471575/jobs/7302558782

Regular CI:
https://github.com/adoroszlai/hadoop-ozone/actions/runs/4207414175