### PR TITLE
HDDS-7934. NPE in RandomKeyGenerator's shutdown hook

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/freon/TestRandomKeyGenerator.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/freon/TestRandomKeyGenerator.java
@@ -87,6 +87,7 @@ public class TestRandomKeyGenerator {
     Assert.assertEquals(2, randomKeyGenerator.getNumberOfVolumesCreated());
     Assert.assertEquals(10, randomKeyGenerator.getNumberOfBucketsCreated());
     Assert.assertEquals(100, randomKeyGenerator.getNumberOfKeysAdded());
+    randomKeyGenerator.printStats(System.out);
   }
 
   @Test

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/RandomKeyGenerator.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/RandomKeyGenerator.java
@@ -75,6 +75,8 @@ import picocli.CommandLine.Mixin;
 import picocli.CommandLine.Option;
 import picocli.CommandLine.ParentCommand;
 
+import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_REPLICATION_DEFAULT;
+import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_REPLICATION_TYPE_DEFAULT;
 import static org.apache.hadoop.ozone.conf.OzoneServiceConfig.DEFAULT_SHUTDOWN_HOOK_PRIORITY;
 
 /**
@@ -484,8 +486,11 @@ public final class RandomKeyGenerator implements Callable<Void> {
     out.println("Number of Volumes created: " + numberOfVolumesCreated);
     out.println("Number of Buckets created: " + numberOfBucketsCreated);
     out.println("Number of Keys added: " + numberOfKeysAdded);
-    out.println("Replication: " + replicationConfig.getReplication());
-    out.println("Replication type: " + replicationConfig.getReplicationType());
+    out.println("Replication: " + (replicationConfig != null ?
+        replicationConfig.getReplication() : OZONE_REPLICATION_DEFAULT));
+    out.println("Replication type: " + (replicationConfig != null ?
+        replicationConfig.getReplicationType() :
+        OZONE_REPLICATION_TYPE_DEFAULT));
     out.println(
         "Average Time spent in volume creation: " + prettyAverageVolumeTime);
     out.println(

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/RandomKeyGenerator.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/RandomKeyGenerator.java
@@ -450,7 +450,7 @@ public final class RandomKeyGenerator implements Callable<Void> {
    *
    * @param out PrintStream
    */
-  private void printStats(PrintStream out) {
+  void printStats(PrintStream out) {
     long endTime = System.nanoTime() - startTime;
     String execTime = DurationFormatUtils
         .formatDuration(TimeUnit.NANOSECONDS.toMillis(endTime),

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/RandomKeyGenerator.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/RandomKeyGenerator.java
@@ -75,8 +75,6 @@ import picocli.CommandLine.Mixin;
 import picocli.CommandLine.Option;
 import picocli.CommandLine.ParentCommand;
 
-import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_REPLICATION_DEFAULT;
-import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_REPLICATION_TYPE_DEFAULT;
 import static org.apache.hadoop.ozone.conf.OzoneServiceConfig.DEFAULT_SHUTDOWN_HOOK_PRIORITY;
 
 /**

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/RandomKeyGenerator.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/RandomKeyGenerator.java
@@ -486,11 +486,9 @@ public final class RandomKeyGenerator implements Callable<Void> {
     out.println("Number of Volumes created: " + numberOfVolumesCreated);
     out.println("Number of Buckets created: " + numberOfBucketsCreated);
     out.println("Number of Keys added: " + numberOfKeysAdded);
-    out.println("Replication: " + (replicationConfig != null ?
-        replicationConfig.getReplication() : OZONE_REPLICATION_DEFAULT));
-    out.println("Replication type: " + (replicationConfig != null ?
-        replicationConfig.getReplicationType() :
-        OZONE_REPLICATION_TYPE_DEFAULT));
+    if (replicationConfig != null) {
+      out.println("Replication: " + replicationConfig);
+    }
     out.println(
         "Average Time spent in volume creation: " + prettyAverageVolumeTime);
     out.println(


### PR DESCRIPTION
## What changes were proposed in this pull request?

Resolve NullPointerException caused by `RandomKeyGenerator`

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-7934

## How was this patch tested?
This patch was tested by executing `ozone freon randomkeys --numOfVolumes=3 --numOfBuckets 10 --numOfKeys 30`, and the following is result.

***************************************************
Status: Success
Git Base Revision: a585a73c3e02ac62350c136643a5e7f6095a3dbb
Number of Volumes created: 3
Number of Buckets created: 30
Number of Keys added: 900
Replication: THREE
Replication type: RATIS
Average Time spent in volume creation: 00:00:00,010
Average Time spent in bucket creation: 00:00:00,058
Average Time spent in key creation: 00:00:07,202
Average Time spent in key write: 00:00:00,331
Total bytes written: 9216000
Total Execution time: 00:00:38,263
***************************************************

