### PR TITLE
HDDS-7064. S3 get-object response emits tracing spans outside ObjectEndpoint#get

### DIFF
--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/TracingFilter.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/TracingFilter.java
@@ -61,8 +61,8 @@ public class TracingFilter implements ContainerRequestFilter,
   @Override
   public void filter(ContainerRequestContext requestContext,
       ContainerResponseContext responseContext) {
-    // HDDS-7064: Span of GET request with StreamingOutput response should
-    // only be closed once the StreamingOutput callback has completely
+    // HDDS-7064: Operation performed while writing StreamingOutput response
+    // should only be closed once the StreamingOutput callback has completely
     // written the data to the destination
     if (!responseContext.hasEntity() ||
         !(responseContext.getEntity() instanceof StreamingOutput)) {

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/ObjectEndpoint.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/ObjectEndpoint.java
@@ -75,6 +75,7 @@ import org.apache.hadoop.ozone.om.helpers.OmMultipartInfo;
 import org.apache.hadoop.ozone.om.helpers.OmMultipartUploadCompleteInfo;
 import org.apache.hadoop.ozone.s3.HeaderPreprocessor;
 import org.apache.hadoop.ozone.s3.SignedChunksInputStream;
+import org.apache.hadoop.ozone.s3.TracingFilter;
 import org.apache.hadoop.ozone.s3.exception.OS3Exception;
 import org.apache.hadoop.ozone.s3.exception.S3ErrorTable;
 import org.apache.hadoop.ozone.s3.util.RFC1123Util;
@@ -341,6 +342,8 @@ public class ObjectEndpoint extends EndpointBase {
         StreamingOutput output = dest -> {
           try (OzoneInputStream key = keyDetails.getContent()) {
             IOUtils.copy(key, dest);
+          } finally {
+            TracingFilter.finishAndCloseActiveSpan();
           }
         };
         responseBuilder = Response
@@ -359,6 +362,8 @@ public class ObjectEndpoint extends EndpointBase {
             ozoneInputStream.seek(startOffset);
             IOUtils.copyLarge(ozoneInputStream, dest, 0,
                 copyLength, new byte[bufferSize]);
+          } finally {
+            TracingFilter.finishAndCloseActiveSpan();
           }
         };
         responseBuilder = Response

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/ObjectEndpoint.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/ObjectEndpoint.java
@@ -75,7 +75,6 @@ import org.apache.hadoop.ozone.om.helpers.OmMultipartInfo;
 import org.apache.hadoop.ozone.om.helpers.OmMultipartUploadCompleteInfo;
 import org.apache.hadoop.ozone.s3.HeaderPreprocessor;
 import org.apache.hadoop.ozone.s3.SignedChunksInputStream;
-import org.apache.hadoop.ozone.s3.TracingFilter;
 import org.apache.hadoop.ozone.s3.exception.OS3Exception;
 import org.apache.hadoop.ozone.s3.exception.S3ErrorTable;
 import org.apache.hadoop.ozone.s3.util.RFC1123Util;
@@ -342,8 +341,6 @@ public class ObjectEndpoint extends EndpointBase {
         StreamingOutput output = dest -> {
           try (OzoneInputStream key = keyDetails.getContent()) {
             IOUtils.copy(key, dest);
-          } finally {
-            TracingFilter.finishAndCloseActiveSpan();
           }
         };
         responseBuilder = Response
@@ -362,8 +359,6 @@ public class ObjectEndpoint extends EndpointBase {
             ozoneInputStream.seek(startOffset);
             IOUtils.copyLarge(ozoneInputStream, dest, 0,
                 copyLength, new byte[bufferSize]);
-          } finally {
-            TracingFilter.finishAndCloseActiveSpan();
           }
         };
         responseBuilder = Response


### PR DESCRIPTION
## What changes were proposed in this pull request?

This fix excludes closing `StreamingOutput` related operations' spans in `TracingFilter` and only closing them after `StreamingOutput` callback (i.e. `GetBlock` and `ReadChunk`) has finished and the data has been written to the destination

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-7064

## How was this patch tested?

Manual test in the docker-compose environment (with tracing enabled) and submitting AWS get-object request to S3G endpoint.

![Screenshot 2023-02-20 at 2 23 34 PM](https://user-images.githubusercontent.com/36403683/220031963-2ae5bf35-7859-4fed-84ff-305972f0d0c7.png)

