### PR TITLE
HDDS-7816. Add DataNode list to the SCM WebUI

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/NodeManagerMXBean.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/NodeManagerMXBean.java
@@ -20,6 +20,7 @@ package org.apache.hadoop.hdds.scm.node;
 
 import org.apache.hadoop.hdds.annotation.InterfaceAudience;
 
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -41,5 +42,6 @@ public interface NodeManagerMXBean {
    * storage type.
    */
   Map<String, Long> getNodeInfo();
+  Map<String, List<String>> getNodeStatusInfo();
 
 }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/NodeManagerMXBean.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/NodeManagerMXBean.java
@@ -42,6 +42,11 @@ public interface NodeManagerMXBean {
    * storage type.
    */
   Map<String, Long> getNodeInfo();
+
+  /**
+   * @return Get the NodeStatus table information  like hostname,
+   * Commissioned State & Operational State column for dataNode
+   */
   Map<String, List<String>> getNodeStatusInfo();
 
 }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/SCMNodeManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/SCMNodeManager.java
@@ -964,6 +964,22 @@ public class SCMNodeManager implements NodeManager {
     return nodeInfo;
   }
 
+  @Override
+  public Map<String, List<String>> getNodeStatusInfo() {
+    Map<String, List<String>> nodes = new HashMap<>();
+    for (DatanodeInfo dni : nodeStateManager.getAllNodes()) {
+      String hostName = dni.getHostName();
+      NodeStatus nodestatus = dni.getNodeStatus();
+      NodeState health = nodestatus.getHealth();
+      NodeOperationalState operationalState = nodestatus.getOperationalState();
+      List<String> ls = new ArrayList<>();
+      ls.add(health.name());
+      ls.add(operationalState.name());
+      nodes.put(hostName, ls);
+    }
+    return nodes;
+  }
+
   private enum UsageMetrics {
     DiskCapacity,
     DiskUsed,

--- a/hadoop-hdds/server-scm/src/main/resources/webapps/scm/scm-overview.html
+++ b/hadoop-hdds/server-scm/src/main/resources/webapps/scm/scm-overview.html
@@ -28,25 +28,54 @@
     </tbody>
 </table>
 
-<h2>Node counts</h2>
-
-<table class="table table-bordered table-striped" class="col-md-6">
+<h2>Node Status</h2>
+<div class="row">
+    <div class="col-md-6 text-left">
+        <label>Show: </label>
+        <select class="form-select" ng-model="RecordsToDisplay" ng-change="UpdateRecordsToShow()">
+            <option value="2" ng-selected="{true}">2</option>
+            <option value="4">4</option>
+            <option value="6">6</option>
+            <option value="All">All</option>
+        </select>
+    </div>
+    <div class="col-md-6 text-right">
+        <label>Search: </label> <input type="text" ng-model="search">
+    </div>
+</div>
+<table class="table table-bordered table-striped col-md-6">
     <thead>
-    <tr>
-        <th class="col-md-3"></th>
-        <th>HEALTHY</th>
-        <th>STALE</th>
-        <th>DEAD</th>
-        <th>HEALTHY_READONLY</th>
-    </tr>
+        <tr>
+            <th ng-click = "columnSort('hostname')" ng-class="{'sortorder' : reverse, 'sortorder reverse' : !reverse}">HostName</th>
+            <th ng-click = "columnSort('opstate')" ng-class="{'sortorder' : reverse, 'sortorder reverse' : !reverse}">Operational State</th>
+            <th ng-click = "columnSort('comstate')" ng-class="{'sortorder' : reverse, 'sortorder reverse' : !reverse}">Commisioned State</th>
+        </tr>
     </thead>
     <tbody>
-    <tr ng-repeat="nodeOpState in $ctrl.nodemanagermetrics.NodeCount | orderBy:'key':false:$ctrl.nodeOpStateOrder">
-        <td>{{nodeOpState.key}}</td>
-        <td ng-repeat="nodeState in nodeOpState.value | orderBy:'key':false:$ctrl.nodeStateOrder">{{nodeState.value}}</td>
-    </tr>
+        <tr ng-repeat="typestat in nodeStatus|filter:search|orderBy:columnName:reverse">
+            <td>{{typestat.hostname}}</td>
+            <td>{{typestat.opstate}}</td>
+            <td>{{typestat.comstate}}</td>
+        </tr>
     </tbody>
 </table>
+<div>
+    <nav aria-label="...">
+        <ul class="pagination">
+            <li class="page-item" ng-class="{disabled:currentPage==1}"
+                ng-click="handlePagination(currentPage-1,(currentPage==1))">
+                <span class="page-link" tabindex="-1">Previous</span>
+            </li>
+            <li class="page-item active">
+                <span class="page-link">{{currentPage}} </span>
+            </li>
+            <li class="page-item" ng-class="{disabled:lastIndex==currentPage}"
+                ng-click="handlePagination(currentPage+1, (lastIndex==currentPage))">
+                <span class="page-link" tabindex="-1">Next</span>
+            </li>
+        </ul>
+    </nav>
+</div>
 
 <h2>Status</h2>
 <table class="table table-bordered table-striped" class="col-md-6">

--- a/hadoop-hdds/server-scm/src/main/resources/webapps/scm/scm-overview.html
+++ b/hadoop-hdds/server-scm/src/main/resources/webapps/scm/scm-overview.html
@@ -46,9 +46,12 @@
 <table class="table table-bordered table-striped col-md-6">
     <thead>
         <tr>
-            <th ng-click = "columnSort('hostname')" ng-class="{'sortorder' : reverse, 'sortorder reverse' : !reverse}">HostName</th>
-            <th ng-click = "columnSort('opstate')" ng-class="{'sortorder' : reverse, 'sortorder reverse' : !reverse}">Operational State</th>
-            <th ng-click = "columnSort('comstate')" ng-class="{'sortorder' : reverse, 'sortorder reverse' : !reverse}">Commisioned State</th>
+            <th ng-click = "columnSort('hostname')" class="nodeStausInfo"><span ng-class = "{'sorting' : (columnName != 'hostname'), 'sortasc' : (columnName == 'hostname' && !reverse),
+                                        'sortdesc':(columnName == 'hostname' && reverse)}">HostName</span></th>
+            <th ng-click = "columnSort('opstate')" class="nodeStausInfo" ><span ng-class="{'sorting' : (columnName != 'opstate'), 'sortasc' : (columnName == 'opstate' && !reverse),
+                                        'sortdesc':(columnName == 'opstate' && reverse)}">Operational State</span></th>
+            <th ng-click = "columnSort('comstate')" class="nodeStausInfo">  <span ng-class="{'sorting' : (columnName != 'comstate'), 'sortasc' : (columnName == 'comstate' && !reverse),
+                                        'sortdesc':(columnName == 'comstate' && reverse)}">Commisioned State</span> </th>
         </tr>
     </thead>
     <tbody>

--- a/hadoop-hdds/server-scm/src/main/resources/webapps/scm/scm-overview.html
+++ b/hadoop-hdds/server-scm/src/main/resources/webapps/scm/scm-overview.html
@@ -33,9 +33,9 @@
     <div class="col-md-6 text-left">
         <label>Show: </label>
         <select class="form-select" ng-model="RecordsToDisplay" ng-change="UpdateRecordsToShow()">
-            <option value="2" ng-selected="{true}">2</option>
-            <option value="4">4</option>
-            <option value="6">6</option>
+            <option value="10" ng-selected="{true}">10</option>
+            <option value="20">20</option>
+            <option value="50">50</option>
             <option value="All">All</option>
         </select>
     </div>

--- a/hadoop-hdds/server-scm/src/main/resources/webapps/scm/scm.js
+++ b/hadoop-hdds/server-scm/src/main/resources/webapps/scm/scm.js
@@ -24,12 +24,55 @@
         require: {
             overview: "^overview"
         },
-        controller: function ($http) {
+        controller: function ($http,$scope) {
             var ctrl = this;
+            $scope.reverse = true;
+            $scope.columnName = "";
+            let nodeStatusCopy = [];
+            $scope.RecordsToDisplay = "2";
+            $scope.currentPage = 1;
+            $scope.lastIndex = 0;
+
             $http.get("jmx?qry=Hadoop:service=SCMNodeManager,name=SCMNodeManagerInfo")
                 .then(function (result) {
                     ctrl.nodemanagermetrics = result.data.beans[0];
-                });
+                $scope.nodeStatus = ctrl.nodemanagermetrics && ctrl.nodemanagermetrics.NodeStatusInfo && ctrl.nodemanagermetrics.NodeStatusInfo.map(({ key, value}) =>{
+                            return {
+                                hostname: key,
+                                opstate: value[0],
+                                comstate: value[1]
+                            }});
+                nodeStatusCopy = [...$scope.nodeStatus];
+                $scope.lastIndex = Math.ceil(nodeStatusCopy.length/$scope.RecordsToDisplay);
+                $scope.nodeStatus = nodeStatusCopy.slice(0, $scope.RecordsToDisplay);
+                  });
+                /*if option is 'All' display all records else display specified record on page*/
+                $scope.UpdateRecordsToShow = () => {
+                     if($scope.RecordsToDisplay == 'All') {
+                         $scope.lastIndex = 1;
+                         $scope.nodeStatus = nodeStatusCopy;
+                     }
+                     else {
+                         $scope.lastIndex = Math.ceil(nodeStatusCopy.length/$scope.RecordsToDisplay);
+                         $scope.nodeStatus = nodeStatusCopy.slice(0, $scope.RecordsToDisplay);
+                     }
+                     $scope.currentPage=1;
+                }
+                /* Page Slicing  logic */
+                 $scope.handlePagination = (pageIndex, isDisabled) => {
+                    if(!isDisabled) {
+                        let startIndex = 0, endIndex = 0;
+                        $scope.currentPage = pageIndex;
+                        startIndex = (pageIndex * $scope.RecordsToDisplay) - $scope.RecordsToDisplay;
+                        endIndex = startIndex + parseInt($scope.RecordsToDisplay);
+                        $scope.nodeStatus = nodeStatusCopy.slice(startIndex, endIndex);
+                    }
+                 }
+                 /*column sort logic*/
+                $scope.columnSort = (colName) => {
+                    $scope.columnName = colName;
+                    $scope.reverse = !$scope.reverse;
+                }
 
             const nodeOpStateSortOrder = {
                 "IN_SERVICE": "a",

--- a/hadoop-hdds/server-scm/src/main/resources/webapps/scm/scm.js
+++ b/hadoop-hdds/server-scm/src/main/resources/webapps/scm/scm.js
@@ -36,43 +36,43 @@
             $http.get("jmx?qry=Hadoop:service=SCMNodeManager,name=SCMNodeManagerInfo")
                 .then(function (result) {
                     ctrl.nodemanagermetrics = result.data.beans[0];
-                $scope.nodeStatus = ctrl.nodemanagermetrics && ctrl.nodemanagermetrics.NodeStatusInfo && ctrl.nodemanagermetrics.NodeStatusInfo.map(({ key, value}) =>{
-                            return {
-                                hostname: key,
-                                opstate: value[0],
-                                comstate: value[1]
-                            }});
-                nodeStatusCopy = [...$scope.nodeStatus];
-                $scope.lastIndex = Math.ceil(nodeStatusCopy.length/$scope.RecordsToDisplay);
-                $scope.nodeStatus = nodeStatusCopy.slice(0, $scope.RecordsToDisplay);
-                  });
-                /*if option is 'All' display all records else display specified record on page*/
-                $scope.UpdateRecordsToShow = () => {
-                     if($scope.RecordsToDisplay == 'All') {
-                         $scope.lastIndex = 1;
-                         $scope.nodeStatus = nodeStatusCopy;
-                     }
-                     else {
-                         $scope.lastIndex = Math.ceil(nodeStatusCopy.length/$scope.RecordsToDisplay);
-                         $scope.nodeStatus = nodeStatusCopy.slice(0, $scope.RecordsToDisplay);
-                     }
-                     $scope.currentPage=1;
-                }
-                /* Page Slicing  logic */
-                 $scope.handlePagination = (pageIndex, isDisabled) => {
-                    if(!isDisabled) {
-                        let startIndex = 0, endIndex = 0;
-                        $scope.currentPage = pageIndex;
-                        startIndex = (pageIndex * $scope.RecordsToDisplay) - $scope.RecordsToDisplay;
-                        endIndex = startIndex + parseInt($scope.RecordsToDisplay);
-                        $scope.nodeStatus = nodeStatusCopy.slice(startIndex, endIndex);
-                    }
+                    $scope.nodeStatus = ctrl.nodemanagermetrics && ctrl.nodemanagermetrics.NodeStatusInfo &&
+                    ctrl.nodemanagermetrics.NodeStatusInfo.map(({ key, value }) => {
+                                return {
+                                    hostname: key,
+                                    opstate: value[0],
+                                    comstate: value[1]
+                                }});
+                    nodeStatusCopy = [...$scope.nodeStatus];
+                    $scope.lastIndex = Math.ceil(nodeStatusCopy.length / $scope.RecordsToDisplay);
+                    $scope.nodeStatus = nodeStatusCopy.slice(0, $scope.RecordsToDisplay);
+                });
+            /*if option is 'All' display all records else display specified record on page*/
+            $scope.UpdateRecordsToShow = () => {
+                 if($scope.RecordsToDisplay == 'All') {
+                     $scope.lastIndex = 1;
+                     $scope.nodeStatus = nodeStatusCopy;
+                 } else {
+                     $scope.lastIndex = Math.ceil(nodeStatusCopy.length / $scope.RecordsToDisplay);
+                     $scope.nodeStatus = nodeStatusCopy.slice(0, $scope.RecordsToDisplay);
                  }
-                 /*column sort logic*/
-                $scope.columnSort = (colName) => {
-                    $scope.columnName = colName;
-                    $scope.reverse = !$scope.reverse;
+                 $scope.currentPage = 1;
+            }
+            /* Page Slicing  logic */
+            $scope.handlePagination = (pageIndex, isDisabled) => {
+                if(!isDisabled) {
+                    let startIndex = 0, endIndex = 0;
+                    $scope.currentPage = pageIndex;
+                    startIndex = (pageIndex * $scope.RecordsToDisplay) - $scope.RecordsToDisplay;
+                    endIndex = startIndex + parseInt($scope.RecordsToDisplay);
+                    $scope.nodeStatus = nodeStatusCopy.slice(startIndex, endIndex);
                 }
+            }
+             /*column sort logic*/
+            $scope.columnSort = (colName) => {
+                $scope.columnName = colName;
+                $scope.reverse = !$scope.reverse;
+            }
 
             const nodeOpStateSortOrder = {
                 "IN_SERVICE": "a",

--- a/hadoop-hdds/server-scm/src/main/resources/webapps/scm/scm.js
+++ b/hadoop-hdds/server-scm/src/main/resources/webapps/scm/scm.js
@@ -29,7 +29,7 @@
             $scope.reverse = true;
             $scope.columnName = "";
             let nodeStatusCopy = [];
-            $scope.RecordsToDisplay = "2";
+            $scope.RecordsToDisplay = "10";
             $scope.currentPage = 1;
             $scope.lastIndex = 0;
 

--- a/hadoop-hdds/server-scm/src/main/resources/webapps/scm/scm.js
+++ b/hadoop-hdds/server-scm/src/main/resources/webapps/scm/scm.js
@@ -26,8 +26,8 @@
         },
         controller: function ($http,$scope) {
             var ctrl = this;
-            $scope.reverse = true;
-            $scope.columnName = "";
+            $scope.reverse = false;
+            $scope.columnName = "hostname";
             let nodeStatusCopy = [];
             $scope.RecordsToDisplay = "10";
             $scope.currentPage = 1;

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/MockNodeManager.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/MockNodeManager.java
@@ -802,6 +802,11 @@ public class MockNodeManager implements NodeManager {
     return nodeInfo;
   }
 
+  @Override
+  public Map<String, List<String>> getNodeStatusInfo() {
+    return null;
+  }
+
   /**
    * Makes it easy to add a container.
    *

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/SimpleMockNodeManager.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/SimpleMockNodeManager.java
@@ -373,6 +373,11 @@ public class SimpleMockNodeManager implements NodeManager {
   }
 
   @Override
+  public Map<String, List<String>> getNodeStatusInfo() {
+    return null;
+  }
+
+  @Override
   public void onMessage(CommandForDatanode commandForDatanode,
                         EventPublisher publisher) {
   }

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/ozone/container/testutils/ReplicationNodeManagerMock.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/ozone/container/testutils/ReplicationNodeManagerMock.java
@@ -86,6 +86,11 @@ public class ReplicationNodeManagerMock implements NodeManager {
     return null;
   }
 
+  @Override
+  public Map<String, List<String>> getNodeStatusInfo() {
+    return null;
+  }
+
   /**
    * Gets all Live Datanodes that is currently communicating with SCM.
    *


### PR DESCRIPTION
What changes were proposed in this pull request?
commit id : 74b79146fcdb288a29e583e0af9270dc983e3d48
This Includes Sorting, Searching & Pagination on SCM UI where page deafult size is 10. we can also set this to 20 or 50 or 'All' records per page as well.
Page slicing & Record Slicing both have been implemented along wth sort & search.

Backend Changes ::
JMX API developed & the response from API is

"NodeStatusInfo" : [ {
"key" : "ozone_datanode_1.ozone_default",
"value" : [ "HEALTHY", "IN_SERVICE" ]
}, {
"key" : "ozone_datanode_3.ozone_default",
"value" : [ "HEALTHY", "IN_SERVICE" ]
}, {
"key" : "ozone_datanode_2.ozone_default",
"value" : [ "HEALTHY", "IN_SERVICE" ]
} ]

Note: HDDS 7816 JIRA includes both UI & Backend changes .

What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-7816

How was this patch tested?

Manually
Attached screenshot for reference
![image](https://user-images.githubusercontent.com/112392916/220050319-2a52c90e-88a4-464e-9bb2-f7988fcbfcf3.png)



Search:
![image](https://user-images.githubusercontent.com/112392916/220050404-0925bb43-c4c3-4218-ae35-6dc8c3c806ea.png)


Sort:
![image](https://user-images.githubusercontent.com/112392916/220050530-6fa49d58-bd74-4ac5-bffd-28ae3861d637.png)

