### PR TITLE
HDDS-7588. Intermittent failure in TestObjectStoreWithLegacyFS#testFlatKeyStructureWithOBS

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestObjectStoreWithLegacyFS.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestObjectStoreWithLegacyFS.java
@@ -146,6 +146,7 @@ public class TestObjectStoreWithLegacyFS {
       Table<String, OmKeyInfo> keyTable,
       String dbKey, int expectedCnt, String keyName) {
     int countKeys = 0;
+    int matchingKeys = 0;
     try {
       TableIterator<String, ? extends Table.KeyValue<String, OmKeyInfo>>
           itr = keyTable.iterator();
@@ -157,16 +158,20 @@ public class TestObjectStoreWithLegacyFS {
           break;
         }
         countKeys++;
-        Assert.assertTrue(keyValue.getKey().endsWith(keyName));
+        matchingKeys += keyValue.getKey().endsWith(keyName) ? 1 : 0;
       }
     } catch (IOException ex) {
       LOG.info("Test failed with: " + ex.getMessage(), ex);
       Assert.fail("Test failed with: " + ex.getMessage());
     }
-    if (countKeys != expectedCnt) {
+    if (countKeys > expectedCnt) {
+      Assert.fail("Test failed with: too many keys found, expected "
+          + expectedCnt + " keys, found " + countKeys + " keys");
+    }
+    if (matchingKeys != expectedCnt) {
       LOG.info("Couldn't find KeyName:{} in KeyTable, retrying...", keyName);
     }
-    return countKeys == expectedCnt;
+    return countKeys == expectedCnt && matchingKeys == expectedCnt;
   }
 
   @Test


### PR DESCRIPTION
## What changes were proposed in this pull request?

>  Quoted from javadoc of testFlatKeyStructureWithOBS():
>
> Test verifies that OBS bucket keys should create flat key-value
> structure and intermediate directories shouldn't be created even
> if the OZONE_OM_ENABLE_FILESYSTEM_PATHS flag is TRUE.

It turns out that the previous fix #4040 was not correct, in term of matching the original intention of this test.
I have reverted c119557241967679b1f8754e65cbe54a5d71fb6f on master.

This PR is a 2nd attempt to fix the flaky test `TestObjectStoreWithLegacyFS#testFlatKeyStructureWithOBS`,
without changing the original intention (so it matches with the javadoc).

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-7588

## How was this patch tested?

Full CI: https://github.com/kaijchen/ozone/actions/runs/4221363513
Repeat 1000x: https://github.com/kaijchen/ozone/actions/runs/4221392332
