### PR TITLE
HDDS-7983. Intermittent OutOfMemoryError in TestOzoneRpcClientWithRatis#testUploadWithStreamAndMemoryMappedBuffer.

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestContainerStateMachineStream.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestContainerStateMachineStream.java
@@ -124,7 +124,7 @@ public class TestContainerStateMachineStream {
         MiniOzoneCluster.newBuilder(conf)
             .setNumDatanodes(3)
             .setHbInterval(200)
-            .setDataStreamMinPacketSize(1) // 1MB
+            .setDataStreamMinPacketSize(1024)
             .setBlockSize(BLOCK_SIZE)
             .setChunkSize(CHUNK_SIZE)
             .setStreamBufferFlushSize(FLUSH_SIZE)

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestContainerStateMachineStream.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestContainerStateMachineStream.java
@@ -124,7 +124,7 @@ public class TestContainerStateMachineStream {
         MiniOzoneCluster.newBuilder(conf)
             .setNumDatanodes(3)
             .setHbInterval(200)
-            .setDataStreamMinPacketSize(1024)
+            .setDataStreamMinPacketSize(1) // 1MB
             .setBlockSize(BLOCK_SIZE)
             .setChunkSize(CHUNK_SIZE)
             .setStreamBufferFlushSize(FLUSH_SIZE)

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestOzoneRpcClientAbstract.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestOzoneRpcClientAbstract.java
@@ -205,7 +205,7 @@ public abstract class TestOzoneRpcClientAbstract {
         .setTotalPipelineNumLimit(10)
         .setScmId(scmId)
         .setClusterId(clusterId)
-        .setDataStreamMinPacketSize(1024)
+        .setDataStreamMinPacketSize(1) // 1MB
         .build();
     cluster.waitForClusterToBeReady();
     ozClient = OzoneClientFactory.getRpcClient(conf);


### PR DESCRIPTION
## What changes were proposed in this pull request?

- setDataStreamMinPacketSize to 1 MB in the tests

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-7983

## How was this patch tested?

Fixing existing tests.