### PR TITLE
HDDS-7993. [snapshot] Add testcase to handle snapshot name minimum-length

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFsSnapshot.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFsSnapshot.java
@@ -144,7 +144,8 @@ public class TestOzoneFsSnapshot {
    */
   @ParameterizedTest
   @ValueSource(strings = {"snap-1",
-      "snap75795657617173401188448010125899089001363595171500499231286"})
+      "snap75795657617173401188448010125899089001363595171500499231286",
+      "sn1"})
   public void testCreateSnapshotSuccess(String snapshotName)
       throws Exception {
     int res = ToolRunner.run(shell,
@@ -190,7 +191,12 @@ public class TestOzoneFsSnapshot {
             "",
             "",
             "Can not create a Path from an empty string",
-            -1)
+            -1),
+        Arguments.of("6th case: snapshot name length is less than 3 chars",
+             BUCKET_PATH,
+             "s1",
+             "Invalid snapshot name",
+             1)
     );
   }
 

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/snapshot/TestOMSnapshotCreateRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/snapshot/TestOMSnapshotCreateRequest.java
@@ -167,6 +167,8 @@ public class TestOMSnapshotCreateRequest {
             "snap75795657617173401188448010125899089001363595171500499231286";
     String name64 =
             "snap156808943643007724443266605711479126926050896107709081166294";
+    String name2 = "s1";
+    String name3 = "sn1";
 
     // name length = 63
     when(ozoneManager.isOwner(any(), any())).thenReturn(true);
@@ -181,6 +183,20 @@ public class TestOMSnapshotCreateRequest {
     LambdaTestUtils.intercept(OMException.class,
             "Invalid snapshot name: " + name64,
             () -> doPreExecute(omRequest2));
+
+    // name length = 3
+    when(ozoneManager.isOwner(any(), any())).thenReturn(true);
+    OMRequest omRequest3 = OMRequestTestUtils.createSnapshotRequest(
+            volumeName, bucketName, name3);
+    // should not throw any error
+    doPreExecute(omRequest3);
+
+    // name length = 2
+    OMRequest omRequest4 = OMRequestTestUtils.createSnapshotRequest(
+            volumeName, bucketName, name2);
+    LambdaTestUtils.intercept(OMException.class,
+            "Invalid snapshot name: " + name2,
+            () -> doPreExecute(omRequest4));
   }
 
   @Test


### PR DESCRIPTION
## What changes were proposed in this pull request?

Add unit testcase to handle snapshot name minimum-length -

- TestOzoneFsSnapshot#testCreateSnapshotSuccess,testCreateSnapshotFailure
- TestOMSnapshotCreateRequest#testPreExecuteNameLength

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-7993

## How was this patch tested?

Testcase files - 

- hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/snapshot/TestOMSnapshotCreateRequest.java
- hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFsSnapshot.java