### PR TITLE
HDDS-7998. Synchronize on containerInfo in ReplicationManager and MoveManager

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ReplicationManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ReplicationManager.java
@@ -661,34 +661,35 @@ public class ReplicationManager implements SCMService {
   protected void processContainer(ContainerInfo containerInfo,
       ReplicationQueue repQueue, ReplicationManagerReport report)
       throws ContainerNotFoundException {
+    synchronized (containerInfo) {
+      ContainerID containerID = containerInfo.containerID();
+      Set<ContainerReplica> replicas = containerManager.getContainerReplicas(
+          containerID);
+      List<ContainerReplicaOp> pendingOps =
+          containerReplicaPendingOps.getPendingOps(containerID);
 
-    ContainerID containerID = containerInfo.containerID();
-    Set<ContainerReplica> replicas = containerManager.getContainerReplicas(
-        containerID);
-    List<ContainerReplicaOp> pendingOps =
-        containerReplicaPendingOps.getPendingOps(containerID);
-
-    // There is a different config for EC and Ratis maintenance
-    // minimum replicas, so we must pass through the correct one.
-    int maintRedundancy = maintenanceRedundancy;
-    if (containerInfo.getReplicationType() == RATIS) {
-      maintRedundancy = ratisMaintenanceMinReplicas;
-    }
-    ContainerCheckRequest checkRequest = new ContainerCheckRequest.Builder()
-        .setContainerInfo(containerInfo)
-        .setContainerReplicas(replicas)
-        .setMaintenanceRedundancy(maintRedundancy)
-        .setReport(report)
-        .setPendingOps(pendingOps)
-        .setReplicationQueue(repQueue)
-        .build();
-    // This will call the chain of container health handlers in turn which
-    // will issue commands as needed, update the report and perhaps add
-    // containers to the over and under replicated queue.
-    boolean handled = containerCheckChain.handleChain(checkRequest);
-    if (!handled) {
-      LOG.debug("Container {} had no actions after passing through the " +
-          "check chain", containerInfo.containerID());
+      // There is a different config for EC and Ratis maintenance
+      // minimum replicas, so we must pass through the correct one.
+      int maintRedundancy = maintenanceRedundancy;
+      if (containerInfo.getReplicationType() == RATIS) {
+        maintRedundancy = ratisMaintenanceMinReplicas;
+      }
+      ContainerCheckRequest checkRequest = new ContainerCheckRequest.Builder()
+          .setContainerInfo(containerInfo)
+          .setContainerReplicas(replicas)
+          .setMaintenanceRedundancy(maintRedundancy)
+          .setReport(report)
+          .setPendingOps(pendingOps)
+          .setReplicationQueue(repQueue)
+          .build();
+      // This will call the chain of container health handlers in turn which
+      // will issue commands as needed, update the report and perhaps add
+      // containers to the over and under replicated queue.
+      boolean handled = containerCheckChain.handleChain(checkRequest);
+      if (!handled) {
+        LOG.debug("Container {} had no actions after passing through the " +
+            "check chain", containerInfo.containerID());
+      }
     }
   }
 

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/UnhealthyReplicationProcessor.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/UnhealthyReplicationProcessor.java
@@ -22,6 +22,7 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.Maps;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
+import org.apache.hadoop.hdds.scm.container.ContainerInfo;
 import org.apache.hadoop.ozone.protocol.commands.SCMCommand;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -123,11 +124,14 @@ public abstract class UnhealthyReplicationProcessor<HealthResult extends
           throws IOException;
 
   private void processContainer(HealthResult healthResult) throws IOException {
-    Set<Pair<DatanodeDetails, SCMCommand<?>>> cmds = getDatanodeCommands(
-            replicationManager, healthResult);
-    for (Map.Entry<DatanodeDetails, SCMCommand<?>> cmd : cmds) {
-      replicationManager.sendDatanodeCommand(cmd.getValue(),
-              healthResult.getContainerInfo(), cmd.getKey());
+    ContainerInfo containerInfo = healthResult.getContainerInfo();
+    synchronized (containerInfo) {
+      Set<Pair<DatanodeDetails, SCMCommand<?>>> cmds = getDatanodeCommands(
+          replicationManager, healthResult);
+      for (Map.Entry<DatanodeDetails, SCMCommand<?>> cmd : cmds) {
+        replicationManager.sendDatanodeCommand(cmd.getValue(),
+            healthResult.getContainerInfo(), cmd.getKey());
+      }
     }
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Keeping in line with the Legacy Replication Manager, we should synchronize on the containerInfo currently being processed within RM and the new MoveManager.

ICR and FCR processing already synchronizes on containerInfo as it processes the container, and in order to get a consistent view of the container as it is processed, Legacy ReplicationManager also synchronized on containerInfo.

By ensuring ICR / FCR, RM and MoveManager synchronize on the containerInfo object, we can ensure that each processing area gets a consistent view of the container pendingOp, replicas and state as it processes the container, and avoid any unexpected consequences around concurrently modifying the container state in SCM.

Replication manager is now split into 2 stages. The "check" stage, and the unhealthy (under, over, mis-replicated) processing stage. Therefore we need to synchronized in two places inside RM.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-7998

## How was this patch tested?

No logic changes, so the existing tests should cover it.
