### PR TITLE
HDDS-6241. Follower SCM node repeatedly sending requests to Ratis server.

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/CloseContainerEventHandler.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/CloseContainerEventHandler.java
@@ -68,6 +68,11 @@ public class CloseContainerEventHandler implements EventHandler<ContainerID> {
 
   @Override
   public void onMessage(ContainerID containerID, EventPublisher publisher) {
+    if (!scmContext.isLeader()) {
+      LOG.warn("Skip close container {} since current SCM is not leader.",
+          containerID);
+      return;
+    }
 
     try {
       LOG.info("Close container Event triggered for container : {}, " +
@@ -133,7 +138,7 @@ public class CloseContainerEventHandler implements EventHandler<ContainerID> {
    * @throws ContainerNotFoundException
    */
   private List<DatanodeDetails> getNodes(final ContainerInfo container)
-      throws ContainerNotFoundException, NotLeaderException {
+      throws ContainerNotFoundException {
     try {
       return pipelineManager.getPipeline(container.getPipelineID()).getNodes();
     } catch (PipelineNotFoundException ex) {

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/TestCloseContainerEventHandler.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/TestCloseContainerEventHandler.java
@@ -80,6 +80,7 @@ public class TestCloseContainerEventHandler {
     containerManager = Mockito.mock(ContainerManager.class);
     pipelineManager = Mockito.mock(PipelineManager.class);
     SCMContext scmContext = Mockito.mock(SCMContext.class);
+    Mockito.when(scmContext.isLeader()).thenReturn(true);
     eventPublisher = Mockito.mock(EventPublisher.class);
     eventHandler = new CloseContainerEventHandler(
         pipelineManager, containerManager, scmContext);


### PR DESCRIPTION
## What changes were proposed in this pull request?

There are many NotLeaderException stack trace printed in follower SCM.  We change them to a single line messages here.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-6241

## How was this patch tested?

Just changing some log messages.  No new tests added.