### PR TITLE
HDDS-7890. Refactor ContainerDeletionChoosingPolicy implementations

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/impl/RandomContainerDeletionChoosingPolicy.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/impl/RandomContainerDeletionChoosingPolicy.java
@@ -17,63 +17,21 @@
  */
 package org.apache.hadoop.ozone.container.common.impl;
 
-import com.google.common.base.Preconditions;
-import org.apache.commons.lang3.ArrayUtils;
-import org.apache.hadoop.hdds.scm.container.common.helpers
-    .StorageContainerException;
-import org.apache.hadoop.ozone.container.common.interfaces
-    .ContainerDeletionChoosingPolicy;
+import org.apache.hadoop.ozone.container.common.interfaces.ContainerDeletionChoosingPolicyTemplate;
 import org.apache.hadoop.ozone.container.keyvalue.KeyValueContainerData;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.apache.hadoop.ozone.container.keyvalue.statemachine.background.BlockDeletingService.ContainerBlockInfo;
 
-import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
-import java.util.Map;
 
 /**
  * Randomly choosing containers for block deletion.
  */
 public class RandomContainerDeletionChoosingPolicy
-    implements ContainerDeletionChoosingPolicy {
-  private static final Logger LOG =
-      LoggerFactory.getLogger(RandomContainerDeletionChoosingPolicy.class);
+    extends ContainerDeletionChoosingPolicyTemplate {
 
   @Override
-  public List<ContainerBlockInfo> chooseContainerForBlockDeletion(
-      int blockCount, Map<Long, ContainerData> candidateContainers)
-      throws StorageContainerException {
-    Preconditions.checkNotNull(candidateContainers,
-        "Internal assertion: candidate containers cannot be null");
-
-    List<ContainerBlockInfo> result = new ArrayList<>();
-    ContainerData[] values = new ContainerData[candidateContainers.size()];
-    // to get a shuffle list
-    ContainerData[] shuffled = candidateContainers.values().toArray(values);
-    ArrayUtils.shuffle(shuffled);
-
-    // Here we are returning containers based on totalBlocks which is basically
-    // number of blocks to be deleted in an interval. We are also considering
-    // the boundary case where the blocks of the last container exceeds the
-    // number of blocks to be deleted in an interval, there we return that
-    // container but with container we also return an integer so that total
-    // blocks don't exceed the number of blocks to be deleted in an interval.
-
-    for (ContainerData entry : shuffled) {
-      long numBlocksToDelete = Math.min(blockCount,
-          ((KeyValueContainerData) entry).getNumPendingDeletionBlocks());
-      blockCount -= numBlocksToDelete;
-      result.add(new ContainerBlockInfo(entry, numBlocksToDelete));
-      if (LOG.isDebugEnabled()) {
-        LOG.debug("Select container {} for block deletion, "
-                + "pending deletion blocks num: {}.", entry.getContainerID(),
-            ((KeyValueContainerData) entry).getNumPendingDeletionBlocks());
-      }
-      if (blockCount == 0) {
-        break;
-      }
-    }
-    return result;
+  protected void orderByDescendingPriority(
+      List<KeyValueContainerData> candidateContainers) {
+    Collections.shuffle(candidateContainers);
   }
 }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/impl/TopNOrderedContainerDeletionChoosingPolicy.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/impl/TopNOrderedContainerDeletionChoosingPolicy.java
@@ -17,32 +17,18 @@
  */
 package org.apache.hadoop.ozone.container.common.impl;
 
-import com.google.common.base.Preconditions;
-import org.apache.hadoop.hdds.scm.container.common.helpers
-    .StorageContainerException;
-import org.apache.hadoop.ozone.container.common.interfaces
-    .ContainerDeletionChoosingPolicy;
+import org.apache.hadoop.ozone.container.common.interfaces.ContainerDeletionChoosingPolicyTemplate;
 import org.apache.hadoop.ozone.container.keyvalue.KeyValueContainerData;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
-import java.util.Collections;
 import java.util.Comparator;
-import java.util.LinkedList;
 import java.util.List;
-import java.util.Map;
-import java.util.ArrayList;
-import org.apache.hadoop.ozone.container.keyvalue.statemachine.background.BlockDeletingService.ContainerBlockInfo;
 
 /**
  * TopN Ordered choosing policy that choosing containers based on pending
  * deletion blocks' number.
  */
 public class TopNOrderedContainerDeletionChoosingPolicy
-    implements ContainerDeletionChoosingPolicy {
-  private static final Logger LOG =
-      LoggerFactory.getLogger(TopNOrderedContainerDeletionChoosingPolicy.class);
-
+    extends ContainerDeletionChoosingPolicyTemplate {
   /** customized comparator used to compare differentiate container data. **/
   private static final Comparator<KeyValueContainerData>
         KEY_VALUE_CONTAINER_DATA_COMPARATOR = (KeyValueContainerData c1,
@@ -51,42 +37,9 @@ public class TopNOrderedContainerDeletionChoosingPolicy
                   c1.getNumPendingDeletionBlocks());
 
   @Override
-  public List<ContainerBlockInfo> chooseContainerForBlockDeletion(
-      int totalBlocks, Map<Long, ContainerData> candidateContainers)
-      throws StorageContainerException {
-
-    Preconditions.checkNotNull(candidateContainers,
-        "Internal assertion: candidate containers cannot be null");
-
-    List<ContainerBlockInfo> result = new ArrayList<>();
-    List<KeyValueContainerData> orderedList = new LinkedList<>();
-    for (ContainerData entry : candidateContainers.values()) {
-      orderedList.add((KeyValueContainerData)entry);
-    }
-    Collections.sort(orderedList, KEY_VALUE_CONTAINER_DATA_COMPARATOR);
-
+  protected void orderByDescendingPriority(
+      List<KeyValueContainerData> candidateContainers) {
     // get top N list ordered by pending deletion blocks' number
-    // Here we are returning containers based on totalBlocks which is basically
-    // number of blocks to be deleted in an interval. We are also considering
-    // the boundary case where the blocks of the last container exceeds the
-    // number of blocks to be deleted in an interval, there we return that
-    // container but with container we also return an integer so that total
-    // blocks don't exceed the number of blocks to be deleted in an interval.
-
-    for (KeyValueContainerData entry : orderedList) {
-      long numBlocksToDelete =
-          Math.min(totalBlocks, entry.getNumPendingDeletionBlocks());
-      totalBlocks -= numBlocksToDelete;
-      result.add(new ContainerBlockInfo(entry, numBlocksToDelete));
-      if (LOG.isDebugEnabled()) {
-        LOG.debug("Select container {} for block deletion, "
-                + "pending deletion blocks num: {}.", entry.getContainerID(),
-            entry.getNumPendingDeletionBlocks());
-      }
-      if (totalBlocks == 0) {
-        break;
-      }
-    }
-    return result;
+    candidateContainers.sort(KEY_VALUE_CONTAINER_DATA_COMPARATOR);
   }
 }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/interfaces/ContainerDeletionChoosingPolicyTemplate.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/interfaces/ContainerDeletionChoosingPolicyTemplate.java
@@ -1,0 +1,83 @@
+package org.apache.hadoop.ozone.container.common.interfaces;
+
+
+import com.google.common.base.Preconditions;
+import org.apache.hadoop.hdds.scm.container.common.helpers.StorageContainerException;
+import org.apache.hadoop.ozone.container.common.impl.ContainerData;
+import org.apache.hadoop.ozone.container.keyvalue.KeyValueContainerData;
+import org.apache.hadoop.ozone.container.keyvalue.statemachine.background.BlockDeletingService.ContainerBlockInfo;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Abstract class that serves as the template for deletion choosing policy.
+ */
+public abstract class ContainerDeletionChoosingPolicyTemplate
+    implements ContainerDeletionChoosingPolicy {
+
+  private static final Logger LOG =
+      LoggerFactory.getLogger(ContainerDeletionChoosingPolicyTemplate.class);
+
+  @Override
+  public final List<ContainerBlockInfo> chooseContainerForBlockDeletion(
+      int blockCount, Map<Long, ContainerData> candidateContainers)
+      throws StorageContainerException {
+    Preconditions.checkNotNull(candidateContainers,
+        "Internal assertion: candidate containers cannot be null");
+
+    int originalBlockCount = blockCount;
+    List<ContainerBlockInfo> result = new ArrayList<>();
+    List<KeyValueContainerData> orderedList = new LinkedList<>();
+
+    for (ContainerData entry: candidateContainers.values()) {
+      orderedList.add((KeyValueContainerData) entry);
+    }
+
+    orderByDescendingPriority(orderedList);
+
+    // Here we are returning containers based on blockCount which is basically
+    // number of blocks to be deleted in an interval. We are also considering
+    // the boundary case where the blocks of the last container exceeds the
+    // number of blocks to be deleted in an interval, there we return that
+    // container but with container we also return an integer so that total
+    // blocks don't exceed the number of blocks to be deleted in an interval.
+
+    for (KeyValueContainerData entry : orderedList) {
+      if (entry.getNumPendingDeletionBlocks() > 0) {
+        long numBlocksToDelete = Math.min(blockCount,
+            entry.getNumPendingDeletionBlocks());
+        blockCount -= numBlocksToDelete;
+        result.add(new ContainerBlockInfo(entry, numBlocksToDelete));
+        if (LOG.isDebugEnabled()) {
+          LOG.debug("Select container {} for block deletion, "
+              + "pending deletion blocks num: {}.", entry.getContainerID(),
+              entry.getNumPendingDeletionBlocks());
+        }
+        if (blockCount == 0) {
+          break;
+        }
+      } else {
+        LOG.debug("Stop looking for next container, there is no"
+            + " pending deletion block contained in remaining containers.");
+        break;
+      }
+    }
+    LOG.info("Chosen {}/{} blocks from {} candidate containers.",
+        (originalBlockCount - blockCount), blockCount, orderedList.size());
+    return result;
+  }
+
+  /**
+   * Abstract step for ordering the container data to be deleted.
+   * Subclass need to implement the concrete ordering implementation
+   * in descending order (more prioritized -> less prioritized)
+   * @param candidateContainers candidate containers to be ordered
+   */
+  protected abstract void orderByDescendingPriority(
+      List<KeyValueContainerData> candidateContainers);
+}

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/interfaces/ContainerDeletionChoosingPolicyTemplate.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/interfaces/ContainerDeletionChoosingPolicyTemplate.java
@@ -1,3 +1,20 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
 package org.apache.hadoop.ozone.container.common.interfaces;
 
 

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/interfaces/ContainerDeletionChoosingPolicyTemplate.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/interfaces/ContainerDeletionChoosingPolicyTemplate.java
@@ -61,10 +61,6 @@ public abstract class ContainerDeletionChoosingPolicyTemplate
         if (blockCount == 0) {
           break;
         }
-      } else {
-        LOG.debug("Stop looking for next container, there is no"
-            + " pending deletion block contained in remaining containers.");
-        break;
       }
     }
     LOG.info("Chosen {}/{} blocks from {} candidate containers.",


### PR DESCRIPTION
## What changes were proposed in this pull request?

This patch refactor `ContainerDeletionChoosingPolicy` by creating an abstract base class that acts as the template (`ContainerDeletionChoosingPolicyTemplate`) which abstracts out the general container deletion choosing process. `chooseContainerForBlockDeletion` acts as the template method. The concrete classes (e.g. `RandomContainerDeletionChoosingPolicy` and `TopNOrderedContainerDeletionChoosingPolicy`) only need to implement the ordering method (`orderByDescendingPriority`).

Notable changes and considerations:
- There are some additional logging `RandomContainerDeletionChoosingPolicy` regarding the number chosen blocks / total blocks, but it doesn't exist in `TopNOrderedContainerDeletionChoosingPolicy`. I decided to include it in the template class. 
- `RandomContainerDeletionChoosingPolicy` use array and `TopNOrderedContainerDeletionChoosingPolicy` uses list, I decided to use list (based on _Effective Java Item 28: Prefer lists to arrays_)
- `ArraysUtils.shuffle` is replaced with `Collections.shuffle`

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-7890

## How was this patch tested?

Existing CI tests (ensure that there is no regression)
