### PR TITLE
HDDS-8012. Clean up after link loop test

### DIFF
--- a/hadoop-ozone/dist/src/main/smoketest/basic/links.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/basic/links.robot
@@ -70,6 +70,7 @@ ACL verified on source bucket
                         Should Contain              ${result}         PERMISSION_DENIED
 
 Create link loop
+    Run Keyword if      '${SECURITY_ENABLED}' == 'true'    Kinit test user     testuser     testuser.keytab
                         Execute                     ozone sh bucket link ${target}/loop1 ${target}/loop2
                         Execute                     ozone sh bucket link ${target}/loop2 ${target}/loop3
                         Execute                     ozone sh bucket link ${target}/loop3 ${target}/loop1

--- a/hadoop-ozone/dist/src/main/smoketest/basic/links.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/basic/links.robot
@@ -69,6 +69,16 @@ ACL verified on source bucket
     ${result} =         Execute And Ignore Error    ozone sh key list ${target}/link-to-unreadable-bucket
                         Should Contain              ${result}         PERMISSION_DENIED
 
+Create link loop
+                        Execute                     ozone sh bucket link ${target}/loop1 ${target}/loop2
+                        Execute                     ozone sh bucket link ${target}/loop2 ${target}/loop3
+                        Execute                     ozone sh bucket link ${target}/loop3 ${target}/loop1
+
+Delete link loop
+                        Execute                     ozone sh bucket delete ${target}/loop1
+                        Execute                     ozone sh bucket delete ${target}/loop2
+                        Execute                     ozone sh bucket delete ${target}/loop3
+
 *** Test Cases ***
 Link to non-existent bucket
                         Execute                     ozone sh bucket link ${source}/no-such-bucket ${target}/dangling-link
@@ -140,11 +150,10 @@ ACL verified on source bucket
     Run Keyword if    '${SECURITY_ENABLED}' == 'true'    ACL verified on source bucket
 
 Loop in link chain is detected
-                        Execute                     ozone sh bucket link ${target}/loop1 ${target}/loop2
-                        Execute                     ozone sh bucket link ${target}/loop2 ${target}/loop3
-                        Execute                     ozone sh bucket link ${target}/loop3 ${target}/loop1
+    [setup]             Create link loop
     ${result} =         Execute And Ignore Error    ozone sh key list ${target}/loop2
                         Should Contain              ${result}    DETECTED_LOOP
+    [teardown]          Delete link loop
 
 Multiple links to same bucket are allowed
     Execute                         ozone sh bucket link ${source}/bucket1 ${target}/link3


### PR DESCRIPTION
## What changes were proposed in this pull request?

Robot test for bucket links creates a loop of links, and verifies it is detected, i.e. infinite loop is avoided when trying to read from the link.  This PR adds cleanup to remove the loop after the test, to avoid errors in OM log:

```
om_1        | 2023-02-22 14:29:00,002 [Trash Emptier] ERROR om.TrashOzoneFileSystem: Couldn't perform fs operation fs.listStatus()/fs.exists()
om_1        | DETECTED_LOOP_IN_BUCKET_LINKS org.apache.hadoop.ozone.om.exceptions.OMException: Detected loop in bucket links. Bucket name: loop1, Volume name: 15904-target
om_1        | 	at org.apache.hadoop.ozone.om.OzoneManagerUtils.getBucketLayout(OzoneManagerUtils.java:110)
om_1        | 	at org.apache.hadoop.ozone.om.OzoneManagerUtils.getBucketLayout(OzoneManagerUtils.java:127)
om_1        | 	at org.apache.hadoop.ozone.om.OzoneManagerUtils.getBucketLayout(OzoneManagerUtils.java:127)
om_1        | 	at org.apache.hadoop.ozone.om.OzoneManagerUtils.getBucketLayout(OzoneManagerUtils.java:127)
om_1        | 	at org.apache.hadoop.ozone.om.OzoneManagerUtils.getBucketLayout(OzoneManagerUtils.java:84)
om_1        | 	at org.apache.hadoop.ozone.om.KeyManagerImpl.getOzoneFileStatus(KeyManagerImpl.java:1107)
om_1        | 	at org.apache.hadoop.ozone.om.KeyManagerImpl.getFileStatus(KeyManagerImpl.java:1080)
om_1        | 	at org.apache.hadoop.ozone.om.KeyManagerImpl.getFileStatus(KeyManagerImpl.java:1055)
om_1        | 	at org.apache.hadoop.ozone.om.TrashOzoneFileSystem.getFileStatus(TrashOzoneFileSystem.java:282)
om_1        | 	at org.apache.hadoop.ozone.om.TrashOzoneFileSystem.exists(TrashOzoneFileSystem.java:338)
om_1        | 	at org.apache.hadoop.ozone.om.TrashOzoneFileSystem.getTrashRoots(TrashOzoneFileSystem.java:318)
om_1        | 	at org.apache.hadoop.ozone.om.TrashPolicyOzone$Emptier.run(TrashPolicyOzone.java:313)
om_1        | 	at java.base/java.lang.Thread.run(Thread.java:829)
```

https://issues.apache.org/jira/browse/HDDS-8012

## How was this patch tested?

Regular CI:
https://github.com/adoroszlai/hadoop-ozone/actions/runs/4247452973

Verified the error does not appear in OM logs.