### PR TITLE
HDDS-8020. File checksum helper leaking client

### DIFF
--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/checksum/ECFileChecksumHelper.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/checksum/ECFileChecksumHelper.java
@@ -179,7 +179,6 @@ public class ECFileChecksumHelper extends BaseFileChecksumHelper {
         .setNodes(nodes)
         .build();
 
-    boolean success = false;
     List<ContainerProtos.ChunkInfo> chunks;
     XceiverClientSpi xceiverClientSpi = null;
     try {
@@ -196,9 +195,8 @@ public class ECFileChecksumHelper extends BaseFileChecksumHelper {
           .getBlock(xceiverClientSpi, datanodeBlockID, token);
 
       chunks = response.getBlockData().getChunksList();
-      success = true;
     } finally {
-      if (!success && xceiverClientSpi != null) {
+      if (xceiverClientSpi != null) {
         getXceiverClientFactory().releaseClientForReadData(
             xceiverClientSpi, false);
       }

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/checksum/ReplicatedFileChecksumHelper.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/checksum/ReplicatedFileChecksumHelper.java
@@ -143,7 +143,6 @@ public class ReplicatedFileChecksumHelper extends BaseFileChecksumHelper {
           .build();
     }
 
-    boolean success = false;
     List<ContainerProtos.ChunkInfo> chunks;
     XceiverClientSpi xceiverClientSpi = null;
     try {
@@ -160,9 +159,8 @@ public class ReplicatedFileChecksumHelper extends BaseFileChecksumHelper {
           .getBlock(xceiverClientSpi, datanodeBlockID, token);
 
       chunks = response.getBlockData().getChunksList();
-      success = true;
     } finally {
-      if (!success && xceiverClientSpi != null) {
+      if (xceiverClientSpi != null) {
         getXceiverClientFactory().releaseClientForReadData(
             xceiverClientSpi, false);
       }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Let file checksum helper release client in case of success to prevent memleak.

(It seems logic for releasing client was copied from `BlockInputStream`, which has been fixed in HDDS-7931 since then.)

https://issues.apache.org/jira/browse/HDDS-8020

## How was this patch tested?

```
mvn clean test -am -pl :ozone-integration-test -Dtest='TestOzoneFileChecksum'
```

Verified no warning about `ManagedChannelImpl was not shutdown properly` appears in test log.

CI:
https://github.com/adoroszlai/hadoop-ozone/actions/runs/4257319915