### PR TITLE
HDDS-6176. Ozone service WebUI is not accessible with 404 error.

### DIFF
--- a/hadoop-hdds/common/src/main/resources/ozone-default.xml
+++ b/hadoop-hdds/common/src/main/resources/ozone-default.xml
@@ -2935,7 +2935,7 @@
     <description>
       The base dir for HTTP Jetty server to extract contents. If this property
       is not configured, by default, Jetty will create a directory inside the
-      directory named by the ozone.metadata.dirs. While in production environment,
+      directory named by the ${ozone.metadata.dirs}/webserver. While in production environment,
       it's strongly suggested instructing Jetty to use a different parent directory by
       setting this property to the name of the desired parent directory. The value of the
       property will be used to set Jetty context attribute 'org.eclipse.jetty.webapp.basetempdir'.

--- a/hadoop-hdds/common/src/main/resources/ozone-default.xml
+++ b/hadoop-hdds/common/src/main/resources/ozone-default.xml
@@ -2935,11 +2935,10 @@
     <description>
       The base dir for HTTP Jetty server to extract contents. If this property
       is not configured, by default, Jetty will create a directory inside the
-      directory named by the ozone.metadata.dirs（/tmp/metadata)
-      While in production environment, it's strongly suggested to instruct Jetty
-      to use a different parent directory by setting this property to the name
-      of the desired parent directory. The value of the property will be used to
-      set Jetty context attribute 'org.eclipse.jetty.webapp.basetempdir'.
+      directory named by the ozone.metadata.dirs. While in production environment,
+      it's strongly suggested instructing Jetty to use a different parent directory by
+      setting this property to the name of the desired parent directory. The value of the
+      property will be used to set Jetty context attribute 'org.eclipse.jetty.webapp.basetempdir'.
       The directory named by this property must exist and be writeable.
     </description>
   </property>

--- a/hadoop-hdds/common/src/main/resources/ozone-default.xml
+++ b/hadoop-hdds/common/src/main/resources/ozone-default.xml
@@ -2935,7 +2935,7 @@
     <description>
       The base dir for HTTP Jetty server to extract contents. If this property
       is not configured, by default, Jetty will create a directory inside the
-      directory named by the ozone.metadata.dirs System property（/tmp/metadata by default）.
+      directory named by the ozone.metadata.dirs（/tmp/metadata)
       While in production environment, it's strongly suggested to instruct Jetty
       to use a different parent directory by setting this property to the name
       of the desired parent directory. The value of the property will be used to

--- a/hadoop-hdds/common/src/main/resources/ozone-default.xml
+++ b/hadoop-hdds/common/src/main/resources/ozone-default.xml
@@ -2935,7 +2935,7 @@
     <description>
       The base dir for HTTP Jetty server to extract contents. If this property
       is not configured, by default, Jetty will create a directory inside the
-      directory named by the java.io.tmpdir System property（/tmp by default）.
+      directory named by the ozone.metadata.dirs System property（/tmp/metadata by default）.
       While in production environment, it's strongly suggested to instruct Jetty
       to use a different parent directory by setting this property to the name
       of the desired parent directory. The value of the property will be used to

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/server/http/BaseHttpServer.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/server/http/BaseHttpServer.java
@@ -183,7 +183,7 @@ public abstract class BaseHttpServer {
       String baseDir = conf.get(OzoneConfigKeys.OZONE_HTTP_BASEDIR);
 
       if (StringUtils.isEmpty(baseDir)) {
-        baseDir = getOzoneMetaDirPath(conf) + serverDir;
+        baseDir = getOzoneMetaDirPath(conf) + SERVER_DIR;
       }
       createDir(baseDir);
       httpServer.getWebAppContext().setAttribute(JETTY_BASETMPDIR, baseDir);

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/server/http/BaseHttpServer.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/server/http/BaseHttpServer.java
@@ -178,11 +178,14 @@ public abstract class BaseHttpServer {
       }
 
       String baseDir = conf.get(OzoneConfigKeys.OZONE_HTTP_BASEDIR);
-      if (!StringUtils.isEmpty(baseDir)) {
-        createDir(baseDir);
-        httpServer.getWebAppContext().setAttribute(JETTY_BASETMPDIR, baseDir);
-        LOG.info("HTTP server of {} uses base directory {}", name, baseDir);
+
+      if (StringUtils.isEmpty(baseDir)) {
+        baseDir = conf.get(OzoneConfigKeys.OZONE_METADATA_DIRS) + "/webserver";
       }
+      createDir(baseDir);
+      httpServer.getWebAppContext().setAttribute(JETTY_BASETMPDIR, baseDir);
+      LOG.info("HTTP server of {} uses base directory {}", name, baseDir);
+    }
     }
   }
 

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/server/http/BaseHttpServer.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/server/http/BaseHttpServer.java
@@ -43,6 +43,7 @@ import org.apache.commons.lang3.StringUtils;
 import static org.apache.hadoop.hdds.HddsUtils.getHostNameFromConfigKeys;
 import static org.apache.hadoop.hdds.HddsUtils.getPortNumberFromConfigKeys;
 import static org.apache.hadoop.hdds.HddsUtils.createDir;
+import static org.apache.hadoop.hdds.server.ServerUtils.getOzoneMetaDirPath;
 import static org.apache.hadoop.hdds.server.http.HttpConfig.getHttpPolicy;
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_ADMINISTRATORS;
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_ADMINISTRATORS_GROUPS;
@@ -182,7 +183,7 @@ public abstract class BaseHttpServer {
 
       if (StringUtils.isEmpty(baseDir)) {
         baseDir =
-            conf.get(OzoneConfigKeys.OZONE_METADATA_DIRS) + serverDir;
+            conf.get(String.valueOf(getOzoneMetaDirPath(conf))) + serverDir;
       }
       createDir(baseDir);
       httpServer.getWebAppContext().setAttribute(JETTY_BASETMPDIR, baseDir);

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/server/http/BaseHttpServer.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/server/http/BaseHttpServer.java
@@ -182,8 +182,7 @@ public abstract class BaseHttpServer {
       String baseDir = conf.get(OzoneConfigKeys.OZONE_HTTP_BASEDIR);
 
       if (StringUtils.isEmpty(baseDir)) {
-        baseDir =
-            conf.get(String.valueOf(getOzoneMetaDirPath(conf))) + serverDir;
+        baseDir = getOzoneMetaDirPath(conf) + serverDir;
       }
       createDir(baseDir);
       httpServer.getWebAppContext().setAttribute(JETTY_BASETMPDIR, baseDir);

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/server/http/BaseHttpServer.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/server/http/BaseHttpServer.java
@@ -70,6 +70,7 @@ public abstract class BaseHttpServer {
   static final String PROMETHEUS_SINK = "PROMETHEUS_SINK";
   private static final String JETTY_BASETMPDIR =
       "org.eclipse.jetty.webapp.basetempdir";
+  private final String WEB_SERVER_DIR = "/webserver";
 
   private HttpServer2 httpServer;
   private final MutableConfigurationSource conf;
@@ -180,7 +181,8 @@ public abstract class BaseHttpServer {
       String baseDir = conf.get(OzoneConfigKeys.OZONE_HTTP_BASEDIR);
 
       if (StringUtils.isEmpty(baseDir)) {
-        baseDir = conf.get(OzoneConfigKeys.OZONE_METADATA_DIRS) + "/webserver";
+        baseDir =
+            conf.get(OzoneConfigKeys.OZONE_METADATA_DIRS) + WEB_SERVER_DIR;
       }
       createDir(baseDir);
       httpServer.getWebAppContext().setAttribute(JETTY_BASETMPDIR, baseDir);

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/server/http/BaseHttpServer.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/server/http/BaseHttpServer.java
@@ -70,7 +70,7 @@ public abstract class BaseHttpServer {
   static final String PROMETHEUS_SINK = "PROMETHEUS_SINK";
   private static final String JETTY_BASETMPDIR =
       "org.eclipse.jetty.webapp.basetempdir";
-  private final String WEB_SERVER_DIR = "/webserver";
+  private final String serverDir = "/webserver";
 
   private HttpServer2 httpServer;
   private final MutableConfigurationSource conf;
@@ -182,7 +182,7 @@ public abstract class BaseHttpServer {
 
       if (StringUtils.isEmpty(baseDir)) {
         baseDir =
-            conf.get(OzoneConfigKeys.OZONE_METADATA_DIRS) + WEB_SERVER_DIR;
+            conf.get(OzoneConfigKeys.OZONE_METADATA_DIRS) + serverDir;
       }
       createDir(baseDir);
       httpServer.getWebAppContext().setAttribute(JETTY_BASETMPDIR, baseDir);

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/server/http/BaseHttpServer.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/server/http/BaseHttpServer.java
@@ -192,7 +192,7 @@ public abstract class BaseHttpServer {
   }
 
   @VisibleForTesting
-  public String getJettyPath() {
+  public String getJettyBaseTmpDir() {
     return httpServer.getWebAppContext().getAttribute(JETTY_BASETMPDIR)
         .toString();
   }

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/server/http/BaseHttpServer.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/server/http/BaseHttpServer.java
@@ -24,6 +24,7 @@ import java.net.URI;
 import java.util.Optional;
 import java.util.OptionalInt;
 
+import com.google.common.annotations.VisibleForTesting;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hdds.DFSConfigKeysLegacy;
 import org.apache.hadoop.hdds.HddsConfigKeys;
@@ -71,7 +72,7 @@ public abstract class BaseHttpServer {
   static final String PROMETHEUS_SINK = "PROMETHEUS_SINK";
   private static final String JETTY_BASETMPDIR =
       "org.eclipse.jetty.webapp.basetempdir";
-  private final String serverDir = "/webserver";
+  public static final String SERVER_DIR = "/webserver";
 
   private HttpServer2 httpServer;
   private final MutableConfigurationSource conf;
@@ -188,6 +189,12 @@ public abstract class BaseHttpServer {
       httpServer.getWebAppContext().setAttribute(JETTY_BASETMPDIR, baseDir);
       LOG.info("HTTP server of {} uses base directory {}", name, baseDir);
     }
+  }
+
+  @VisibleForTesting
+  public String getJettyPath() {
+    return httpServer.getWebAppContext().getAttribute(JETTY_BASETMPDIR)
+        .toString();
   }
 
   /**

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/server/http/BaseHttpServer.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/server/http/BaseHttpServer.java
@@ -186,7 +186,6 @@ public abstract class BaseHttpServer {
       httpServer.getWebAppContext().setAttribute(JETTY_BASETMPDIR, baseDir);
       LOG.info("HTTP server of {} uses base directory {}", name, baseDir);
     }
-    }
   }
 
   /**

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/TestStorageContainerManagerHttpServer.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/TestStorageContainerManagerHttpServer.java
@@ -56,7 +56,7 @@ public class TestStorageContainerManagerHttpServer {
   public static void setUp() throws Exception {
     File base = new File(BASEDIR);
     FileUtil.fullyDelete(base);
-    File ozoneMetadataDirectory = new File(BASEDIR,"metadata");
+    File ozoneMetadataDirectory = new File(BASEDIR, "metadata");
     ozoneMetadataDirectory.mkdirs();
     conf = new OzoneConfiguration();
     keystoresDir = new File(BASEDIR).getAbsolutePath();
@@ -69,7 +69,8 @@ public class TestStorageContainerManagerHttpServer {
         KeyStoreTestUtil.getClientSSLConfigFileName());
     conf.set(OzoneConfigKeys.OZONE_SERVER_HTTPS_KEYSTORE_RESOURCE_KEY,
         KeyStoreTestUtil.getServerSSLConfigFileName());
-    conf.set(OzoneConfigKeys.OZONE_METADATA_DIRS,ozoneMetadataDirectory.getAbsolutePath());
+    conf.set(OzoneConfigKeys.OZONE_METADATA_DIRS,
+        ozoneMetadataDirectory.getAbsolutePath());
   }
 
   @AfterAll

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/TestStorageContainerManagerHttpServer.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/TestStorageContainerManagerHttpServer.java
@@ -56,7 +56,8 @@ public class TestStorageContainerManagerHttpServer {
   public static void setUp() throws Exception {
     File base = new File(BASEDIR);
     FileUtil.fullyDelete(base);
-    base.mkdirs();
+    File ozoneMetadataDirectory = new File(BASEDIR,"metadata");
+    ozoneMetadataDirectory.mkdirs();
     conf = new OzoneConfiguration();
     keystoresDir = new File(BASEDIR).getAbsolutePath();
     sslConfDir = KeyStoreTestUtil.getClasspathDir(
@@ -68,6 +69,7 @@ public class TestStorageContainerManagerHttpServer {
         KeyStoreTestUtil.getClientSSLConfigFileName());
     conf.set(OzoneConfigKeys.OZONE_SERVER_HTTPS_KEYSTORE_RESOURCE_KEY,
         KeyStoreTestUtil.getServerSSLConfigFileName());
+    conf.set(OzoneConfigKeys.OZONE_METADATA_DIRS,ozoneMetadataDirectory.getAbsolutePath());
   }
 
   @AfterAll

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerHttpServer.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerHttpServer.java
@@ -150,7 +150,8 @@ public class TestOzoneManagerHttpServer {
       // Verify that the jetty directory is set correctly
       String expectedJettyDirLocation =
           ozoneMetadataDirectory.getAbsolutePath() + BaseHttpServer.SERVER_DIR;
-      Assertions.assertEquals(expectedJettyDirLocation, server.getJettyPath());
+      Assertions.assertEquals(expectedJettyDirLocation,
+          server.getJettyBaseTmpDir());
     } finally {
       if (server != null) {
         server.stop();

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerHttpServer.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerHttpServer.java
@@ -27,6 +27,7 @@ import java.util.Collection;
 
 import org.apache.hadoop.fs.FileUtil;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import org.apache.hadoop.hdds.server.http.BaseHttpServer;
 import org.apache.hadoop.hdfs.web.URLConnectionFactory;
 import org.apache.hadoop.http.HttpConfig;
 import org.apache.hadoop.http.HttpConfig.Policy;
@@ -40,6 +41,7 @@ import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameters;
@@ -55,6 +57,7 @@ public class TestOzoneManagerHttpServer {
   private static String sslConfDir;
   private static OzoneConfiguration conf;
   private static URLConnectionFactory connectionFactory;
+  private static File ozoneMetadataDirectory;
 
   @Parameters public static Collection<Object[]> policy() {
     Object[][] params = new Object[][] {
@@ -74,7 +77,12 @@ public class TestOzoneManagerHttpServer {
   @BeforeClass public static void setUp() throws Exception {
     File base = new File(BASEDIR);
     FileUtil.fullyDelete(base);
-    base.mkdirs();
+
+    // Create metadata directory
+    ozoneMetadataDirectory = new File(BASEDIR, "metadata");
+    ozoneMetadataDirectory.mkdirs();
+
+    // Initialize the OzoneConfiguration
     conf = new OzoneConfiguration();
     keystoresDir = new File(BASEDIR).getAbsolutePath();
     sslConfDir = KeyStoreTestUtil.getClasspathDir(
@@ -86,6 +94,14 @@ public class TestOzoneManagerHttpServer {
         KeyStoreTestUtil.getClientSSLConfigFileName());
     conf.set(OzoneConfigKeys.OZONE_SERVER_HTTPS_KEYSTORE_RESOURCE_KEY,
         KeyStoreTestUtil.getServerSSLConfigFileName());
+
+    // Set up OM HTTP and HTTPS addresses
+    conf.set(OzoneConfigKeys.OZONE_METADATA_DIRS,
+        ozoneMetadataDirectory.getAbsolutePath());
+    conf.set(OMConfigKeys.OZONE_OM_HTTP_ADDRESS_KEY, "localhost:0");
+    conf.set(OMConfigKeys.OZONE_OM_HTTPS_ADDRESS_KEY, "localhost:0");
+    conf.set(OMConfigKeys.OZONE_OM_HTTP_BIND_HOST_KEY, "localhost");
+    conf.set(OMConfigKeys.OZONE_OM_HTTPS_BIND_HOST_KEY, "localhost");
   }
 
   @AfterClass public static void tearDown() throws Exception {
@@ -96,11 +112,6 @@ public class TestOzoneManagerHttpServer {
 
   @Test public void testHttpPolicy() throws Exception {
     conf.set(OzoneConfigKeys.OZONE_HTTP_POLICY_KEY, policy.name());
-    conf.set(OMConfigKeys.OZONE_OM_HTTP_ADDRESS_KEY, "localhost:0");
-    conf.set(OMConfigKeys.OZONE_OM_HTTPS_ADDRESS_KEY, "localhost:0");
-    conf.set(OMConfigKeys.OZONE_OM_HTTP_BIND_HOST_KEY, "localhost");
-    conf.set(OMConfigKeys.OZONE_OM_HTTPS_BIND_HOST_KEY, "localhost");
-
     OzoneManagerHttpServer server = null;
     try {
       server = new OzoneManagerHttpServer(conf, null);
@@ -117,7 +128,29 @@ public class TestOzoneManagerHttpServer {
           canAccess("https", server.getHttpsAddress())));
       Assert.assertTrue(implies(policy.isHttpsEnabled(),
           !canAccess("http", server.getHttpsAddress())));
+    } finally {
+      if (server != null) {
+        server.stop();
+      }
+    }
+  }
 
+  @Test
+  // Verify if jetty-dir will be created inside ozoneMetadataDirectory path
+  public void testJettyDirectoryCreation() throws Exception {
+    OzoneManagerHttpServer server = null;
+    try {
+      server = new OzoneManagerHttpServer(conf, null);
+      DefaultMetricsSystem.initialize("TestOzoneManagerHttpServer");
+      server.start();
+      // Checking if the /webserver directory does get created
+      File webServerDir =
+          new File(ozoneMetadataDirectory, BaseHttpServer.SERVER_DIR);
+      Assert.assertTrue(webServerDir.exists());
+      // Verify that the jetty directory is set correctly
+      String expectedJettyDirLocation =
+          ozoneMetadataDirectory.getAbsolutePath() + BaseHttpServer.SERVER_DIR;
+      Assertions.assertEquals(expectedJettyDirLocation, server.getJettyPath());
     } finally {
       if (server != null) {
         server.stop();


### PR DESCRIPTION
## What changes were proposed in this pull request?

A lot of customers were facing issues Ozone service-related WebUI not opening with a 404 error. The issue can be fixed by restarting, but during the restart, a `jetty-0_0_0_0-*/webapp` folder is created, and the customer noticed that such a folder does not exist on the host with access issues. The customer performed manual restarts on each node and observed that the problem was resolved by creating a new `jetty-0_0_0_0-*/webapp` folder. 

After investigating we can confirm that the ozone code is not responsible for the deletion of the contents in the tmp directory. It appears that an external program is responsible for the deletion.

The main culprit for deletion is the Linux program called `systemd-tmpfiles-clean.timer` . This program is designed to clean up temporary files that are generated by the system. By default, it runs daily and removes files and directories that are older than 3 days.

To avoid this issue, it is recommended to configure Jetty to use a dedicated directory for its temporary files and directories, rather than the system's temporary directory. We can do this by changing the `ozone.http.basedir` property in the Ozone Service Advanced Configuration Snippet for the `ozone-conf/ozone-site.xml` file. It is suggested that this property should be set to a directory such as `/data/ozone` that already exists and has sufficient permissions in HDFS.

In case if this property is not set, then fall back to the default property.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-6176

## How was this patch tested?

Added Unit-Tests for directory creation and also checked it manually in a local docker cluster