### PR TITLE
HDDS-8022. Add okio as dependency to the root pom

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -203,6 +203,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
 
     <objenesis.version>1.0</objenesis.version>
     <okhttp.version>2.7.5</okhttp.version>
+    <okio.version>2.8.0</okio.version>
     <mockito1-powermock.version>1.10.19</mockito1-powermock.version>
     <mockito2.version>2.28.2</mockito2.version>
     <hamcrest.version>1.3</hamcrest.version>
@@ -289,6 +290,11 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
 
   <dependencyManagement>
     <dependencies>
+      <dependency>
+        <groupId>com.squareup.okio</groupId>
+        <artifactId>okio</artifactId>
+        <version>${okio.version}</version>
+      </dependency>
       <dependency>
         <groupId>com.squareup.okhttp</groupId>
         <artifactId>okhttp</artifactId>


### PR DESCRIPTION
## What changes were proposed in this pull request?

I added `okio` as a dependency to the root pom (it was already present in the project transitively by another dependency, but without this the version wasn't defined, so different dependencies could bring in different versions of it)

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-8022

## How was this patch tested?

Built the project successfully, green CI on my fork: https://github.com/dombizita/ozone/actions/runs/4257898815
