### PR TITLE
HDDS-7979. Replace import from shaded Guava

### DIFF
--- a/hadoop-ozone/httpfsgateway/src/main/java/org/apache/ozone/lib/servlet/ServerWebApp.java
+++ b/hadoop-ozone/httpfsgateway/src/main/java/org/apache/ozone/lib/servlet/ServerWebApp.java
@@ -18,9 +18,9 @@
 
 package org.apache.ozone.lib.servlet;
 
+import com.google.common.annotations.VisibleForTesting;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hdds.annotation.InterfaceAudience;
-import org.apache.ratis.thirdparty.com.google.common.annotations.VisibleForTesting;
 import org.apache.ozone.lib.server.Server;
 import org.apache.ozone.lib.server.ServerException;
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Changed `VisibleForTesting` import to `com.google.common.annotations.VisibleForTesting`.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-7979

## How was this patch tested?

Built the project successfully, green CI on my fork: https://github.com/dombizita/ozone/actions/runs/4258016809
