### PR TITLE
HDDS-7997. [HTTPFSGW] Change ozone-filesystem to a runtime dependency for HttpFS

### DIFF
--- a/hadoop-ozone/dist/src/main/compose/ozone-ha/docker-compose.yaml
+++ b/hadoop-ozone/dist/src/main/compose/ozone-ha/docker-compose.yaml
@@ -103,7 +103,6 @@ services:
   httpfs:
     <<: *common-config
     environment:
-      OZONE_CLASSPATH: "/opt/hadoop/share/ozone/lib/ozone-filesystem-hadoop3-${ozone.version}.jar"
       OZONE-SITE.XML_hdds.scm.safemode.min.datanode: ${OZONE_SAFEMODE_MIN_DATANODES:-1}
       <<: *replication
     ports:

--- a/hadoop-ozone/dist/src/main/compose/ozone/docker-compose.yaml
+++ b/hadoop-ozone/dist/src/main/compose/ozone/docker-compose.yaml
@@ -63,7 +63,6 @@ services:
   httpfs:
     <<: *common-config
     environment:
-      OZONE_CLASSPATH: "/opt/hadoop/share/ozone/lib/ozone-filesystem-hadoop3-${ozone.version}.jar"
       OZONE-SITE.XML_hdds.scm.safemode.min.datanode: ${OZONE_SAFEMODE_MIN_DATANODES:-1}
       <<: *replication
     ports:

--- a/hadoop-ozone/dist/src/main/compose/ozonesecure-ha/docker-compose.yaml
+++ b/hadoop-ozone/dist/src/main/compose/ozonesecure-ha/docker-compose.yaml
@@ -196,7 +196,6 @@ services:
       - ./docker-config
     command: [ "/opt/hadoop/bin/ozone","httpfs" ]
     environment:
-      OZONE_CLASSPATH: "/opt/hadoop/share/ozone/lib/ozone-filesystem-hadoop3-${ozone.version}.jar"
       OZONE-SITE.XML_hdds.scm.safemode.min.datanode: ${OZONE_SAFEMODE_MIN_DATANODES:-1}
       OZONE_OPTS:
     networks:

--- a/hadoop-ozone/dist/src/main/compose/ozonesecure/docker-compose.yaml
+++ b/hadoop-ozone/dist/src/main/compose/ozonesecure/docker-compose.yaml
@@ -76,7 +76,6 @@ services:
       - ./docker-config
     command: [ "/opt/hadoop/bin/ozone","httpfs" ]
     environment:
-      OZONE_CLASSPATH: "/opt/hadoop/share/ozone/lib/ozone-filesystem-hadoop3-${ozone.version}.jar"
       OZONE-SITE.XML_hdds.scm.safemode.min.datanode: ${OZONE_SAFEMODE_MIN_DATANODES:-1}
       OZONE_OPTS:
   s3g:

--- a/hadoop-ozone/httpfsgateway/pom.xml
+++ b/hadoop-ozone/httpfsgateway/pom.xml
@@ -46,7 +46,7 @@
     <dependency>
       <groupId>org.apache.ozone</groupId>
       <artifactId>ozone-filesystem</artifactId>
-      <scope>provided</scope>
+      <scope>runtime</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.hadoop</groupId>


### PR DESCRIPTION
## What changes were proposed in this pull request?

I changed the `ozone-runtime` dependency scope to runtime in the HttpFS module and as a result of in the docker environments with HttpFS I could remove the `ozone-filesystem-hadoop3` jar from the classpath.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-7997

## How was this patch tested?

Built the project successfully, also manually tested the docker environments locally.
green CI on my fork: https://github.com/dombizita/ozone/actions/runs/4257933078

