### PR TITLE
HDDS-8029. [hsync] Outputstream in encrypted buckets do not return the correct stream capabilities.

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestHSync.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestHSync.java
@@ -281,7 +281,8 @@ public class TestHSync {
     OzoneOutputStream oos = new OzoneOutputStream(cos);
     OzoneFSOutputStream ofso = new OzoneFSOutputStream(oos);
 
-    try (CapableOzoneFSOutputStream cofsos = new CapableOzoneFSOutputStream(ofso)) {
+    try (CapableOzoneFSOutputStream cofsos =
+        new CapableOzoneFSOutputStream(ofso)) {
       if (isEC) {
         assertTrue(cofsos.hasCapability(StreamCapabilities.HFLUSH));
       } else {

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestHSync.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestHSync.java
@@ -280,12 +280,13 @@ public class TestHSync {
         new CryptoOutputStream(kos, codec, new byte[0], new byte[0]);
     OzoneOutputStream oos = new OzoneOutputStream(cos);
     OzoneFSOutputStream ofso = new OzoneFSOutputStream(oos);
-    CapableOzoneFSOutputStream cofsos = new CapableOzoneFSOutputStream(ofso);
 
-    if (isEC) {
-      assertTrue(cofsos.hasCapability(StreamCapabilities.HFLUSH));
-    } else {
-      assertFalse(cofsos.hasCapability(StreamCapabilities.HFLUSH));
+    try (CapableOzoneFSOutputStream cofsos = new CapableOzoneFSOutputStream(ofso)) {
+      if (isEC) {
+        assertTrue(cofsos.hasCapability(StreamCapabilities.HFLUSH));
+      } else {
+        assertFalse(cofsos.hasCapability(StreamCapabilities.HFLUSH));
+      }
     }
   }
 }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestHSync.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestHSync.java
@@ -284,9 +284,9 @@ public class TestHSync {
     try (CapableOzoneFSOutputStream cofsos =
         new CapableOzoneFSOutputStream(ofso)) {
       if (isEC) {
-        assertTrue(cofsos.hasCapability(StreamCapabilities.HFLUSH));
-      } else {
         assertFalse(cofsos.hasCapability(StreamCapabilities.HFLUSH));
+      } else {
+        assertTrue(cofsos.hasCapability(StreamCapabilities.HFLUSH));
       }
     }
   }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestHSync.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestHSync.java
@@ -267,9 +267,9 @@ public class TestHSync {
       GeneralSecurityException {
     KeyOutputStream kos;
     if (isEC) {
-      kos = mock(KeyOutputStream.class);
-    } else {
       kos = mock(ECKeyOutputStream.class);
+    } else {
+      kos = mock(KeyOutputStream.class);
     }
     CryptoCodec codec = mock(CryptoCodec.class);
     when(codec.getCipherSuite()).thenReturn(CipherSuite.AES_CTR_NOPADDING);

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestHSync.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestHSync.java
@@ -20,9 +20,14 @@ package org.apache.hadoop.fs.ozone;
 
 import java.io.Closeable;
 import java.io.IOException;
+import java.security.GeneralSecurityException;
 import java.util.UUID;
 import java.util.concurrent.ThreadLocalRandom;
 import org.apache.hadoop.conf.StorageUnit;
+import org.apache.hadoop.crypto.CipherSuite;
+import org.apache.hadoop.crypto.CryptoCodec;
+import org.apache.hadoop.crypto.CryptoOutputStream;
+import org.apache.hadoop.crypto.Encryptor;
 import org.apache.hadoop.fs.CommonConfigurationKeysPublic;
 import org.apache.hadoop.fs.FSDataInputStream;
 import org.apache.hadoop.fs.FSDataOutputStream;
@@ -38,6 +43,9 @@ import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.hadoop.ozone.TestDataUtil;
 import org.apache.hadoop.ozone.client.BucketArgs;
 import org.apache.hadoop.ozone.client.OzoneBucket;
+import org.apache.hadoop.ozone.client.io.ECKeyOutputStream;
+import org.apache.hadoop.ozone.client.io.KeyOutputStream;
+import org.apache.hadoop.ozone.client.io.OzoneOutputStream;
 import org.apache.hadoop.ozone.om.helpers.BucketLayout;
 
 import org.junit.jupiter.api.AfterAll;
@@ -56,6 +64,8 @@ import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_RATIS_ENABLE_KEY;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 /**
  * Test HSync.
@@ -216,6 +226,8 @@ public class TestHSync {
       assertTrue(os.hasCapability(StreamCapabilities.HSYNC),
           "KeyOutputStream should support hsync()!");
     }
+
+    testEncryptedStreamCapabilities(false);
   }
 
   @Test
@@ -247,6 +259,32 @@ public class TestHSync {
           "ECKeyOutputStream should not support hflush()!");
       assertFalse(os.hasCapability(StreamCapabilities.HSYNC),
           "ECKeyOutputStream should not support hsync()!");
+    }
+    testEncryptedStreamCapabilities(true);
+  }
+
+  private void testEncryptedStreamCapabilities(boolean isEC) throws IOException,
+      GeneralSecurityException {
+    KeyOutputStream kos;
+    if (isEC) {
+      kos = mock(KeyOutputStream.class);
+    } else {
+      kos = mock(ECKeyOutputStream.class);
+    }
+    CryptoCodec codec = mock(CryptoCodec.class);
+    when(codec.getCipherSuite()).thenReturn(CipherSuite.AES_CTR_NOPADDING);
+    when(codec.getConf()).thenReturn(CONF);
+    Encryptor encryptor = mock(Encryptor.class);
+    when(codec.createEncryptor()).thenReturn(encryptor);
+    CryptoOutputStream cos = new CryptoOutputStream(kos, codec, new byte[0], new byte[0]);
+    OzoneOutputStream oos = new OzoneOutputStream(cos);
+    OzoneFSOutputStream ofso = new OzoneFSOutputStream(oos);
+    CapableOzoneFSOutputStream cofsos = new CapableOzoneFSOutputStream(ofso);
+
+    if (isEC) {
+      assertTrue(cofsos.hasCapability(StreamCapabilities.HFLUSH));
+    } else {
+      assertFalse(cofsos.hasCapability(StreamCapabilities.HFLUSH));
     }
   }
 }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestHSync.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestHSync.java
@@ -276,7 +276,8 @@ public class TestHSync {
     when(codec.getConf()).thenReturn(CONF);
     Encryptor encryptor = mock(Encryptor.class);
     when(codec.createEncryptor()).thenReturn(encryptor);
-    CryptoOutputStream cos = new CryptoOutputStream(kos, codec, new byte[0], new byte[0]);
+    CryptoOutputStream cos =
+        new CryptoOutputStream(kos, codec, new byte[0], new byte[0]);
     OzoneOutputStream oos = new OzoneOutputStream(cos);
     OzoneFSOutputStream ofso = new OzoneFSOutputStream(oos);
     CapableOzoneFSOutputStream cofsos = new CapableOzoneFSOutputStream(ofso);

--- a/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/CapableOzoneFSOutputStream.java
+++ b/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/CapableOzoneFSOutputStream.java
@@ -53,7 +53,7 @@ public class CapableOzoneFSOutputStream  extends OzoneFSOutputStream
     return hasWrappedCapability(os, capability);
   }
 
-  private boolean hasWrappedCapability(OutputStream os, String capability) {
+  private static boolean hasWrappedCapability(OutputStream os, String capability) {
     if (os instanceof ECKeyOutputStream) {
       return false;
     } else if (os instanceof KeyOutputStream) {

--- a/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/CapableOzoneFSOutputStream.java
+++ b/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/CapableOzoneFSOutputStream.java
@@ -53,7 +53,8 @@ public class CapableOzoneFSOutputStream  extends OzoneFSOutputStream
     return hasWrappedCapability(os, capability);
   }
 
-  private static boolean hasWrappedCapability(OutputStream os, String capability) {
+  private static boolean hasWrappedCapability(OutputStream os,
+      String capability) {
     if (os instanceof ECKeyOutputStream) {
       return false;
     } else if (os instanceof KeyOutputStream) {

--- a/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/CapableOzoneFSOutputStream.java
+++ b/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/CapableOzoneFSOutputStream.java
@@ -44,6 +44,15 @@ public class CapableOzoneFSOutputStream  extends OzoneFSOutputStream
   @Override
   public boolean hasCapability(String capability) {
     OutputStream os = getWrappedOutputStream().getOutputStream();
+
+    if (os instanceof CryptoOutputStream) {
+      OutputStream wrapped = ((CryptoOutputStream) os).getWrappedStream();
+      return hasWrappedCapability(wrapped, capability);
+    }
+    return hasWrappedCapability(os, capability);
+  }
+
+  private boolean hasWrappedCapability(OutputStream os, String capability) {
     if (os instanceof ECKeyOutputStream) {
       return false;
     } else if (os instanceof KeyOutputStream) {
@@ -55,7 +64,7 @@ public class CapableOzoneFSOutputStream  extends OzoneFSOutputStream
         return false;
       }
     }
-    // deal with CryptoOutputStream
+    // this is unexpected. try last resort
     return StoreImplementationUtils.hasCapability(os, capability);
   }
 }

--- a/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/CapableOzoneFSOutputStream.java
+++ b/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/CapableOzoneFSOutputStream.java
@@ -17,6 +17,7 @@
  */
 package org.apache.hadoop.fs.ozone;
 
+import org.apache.hadoop.crypto.CryptoOutputStream;
 import org.apache.hadoop.fs.StreamCapabilities;
 import org.apache.hadoop.fs.impl.StoreImplementationUtils;
 import org.apache.hadoop.ozone.client.io.ECKeyOutputStream;


### PR DESCRIPTION

## What changes were proposed in this pull request?
StreamCapabilities.hasCapability(HSYNC) does not return true for encrypted buckets.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-8029

## How was this patch tested?

Unit test + Manually tested on a HBase cluster