### PR TITLE
HDDS-8036. Unprotected flush in SCMHADBTransactionBuffer

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMHADBTransactionBufferStub.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMHADBTransactionBufferStub.java
@@ -24,6 +24,7 @@ import org.apache.hadoop.hdds.utils.db.Table;
 import org.apache.ratis.statemachine.SnapshotInfo;
 
 import java.io.IOException;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
 
 // TODO: Move this class to test package after fixing Recon
 /**
@@ -32,6 +33,7 @@ import java.io.IOException;
 public class SCMHADBTransactionBufferStub implements SCMHADBTransactionBuffer {
   private DBStore dbStore;
   private BatchOperation currentBatchOperation;
+  private final ReentrantReadWriteLock rwLock = new ReentrantReadWriteLock();
 
   public SCMHADBTransactionBufferStub() {
   }
@@ -54,13 +56,23 @@ public class SCMHADBTransactionBufferStub implements SCMHADBTransactionBuffer {
   @Override
   public <KEY, VALUE> void addToBuffer(
       Table<KEY, VALUE> table, KEY key, VALUE value) throws IOException {
-    table.putWithBatch(getCurrentBatchOperation(), key, value);
+    rwLock.readLock().lock();
+    try {
+      table.putWithBatch(getCurrentBatchOperation(), key, value);
+    } finally {
+      rwLock.readLock().unlock();
+    }
   }
 
   @Override
   public <KEY, VALUE> void removeFromBuffer(Table<KEY, VALUE> table, KEY key)
       throws IOException {
-    table.deleteWithBatch(getCurrentBatchOperation(), key);
+    rwLock.readLock().lock();
+    try {
+      table.deleteWithBatch(getCurrentBatchOperation(), key);
+    } finally {
+      rwLock.readLock().unlock();
+    }
   }
 
   @Override
@@ -86,9 +98,14 @@ public class SCMHADBTransactionBufferStub implements SCMHADBTransactionBuffer {
   @Override
   public void flush() throws IOException {
     if (dbStore != null) {
-      dbStore.commitBatchOperation(getCurrentBatchOperation());
-      currentBatchOperation.close();
-      currentBatchOperation = null;
+      rwLock.writeLock().lock();
+      try {
+        dbStore.commitBatchOperation(getCurrentBatchOperation());
+        currentBatchOperation.close();
+        currentBatchOperation = null;
+      } finally {
+        rwLock.writeLock().unlock();
+      }
     }
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Found by  https://issues.apache.org/jira/browse/HDDS-8031?page=com.atlassian.jira.plugin.system.issuetabpanels%3Aall-tabpanel

The issue is found due to the lack of lock protection.
The **addToBuffer/removeFromBuffer** may be concurrently called with **flush**, which may add KV into a closed batch and cause the JVM crash.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-8036

## How was this patch tested?
Original Error test:
https://github.com/Xushaohong/ozone/actions/runs/4280636237/jobs/7452661792

POC fix test:
https://github.com/Xushaohong/ozone/actions/runs/4281772162/jobs/7455208505
