### PR TITLE
HDDS-8034. Check container replication health before scheduling move in MoveManager

### DIFF
--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/balancer/TestMoveManager.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/balancer/TestMoveManager.java
@@ -22,6 +22,7 @@ import org.apache.hadoop.hdds.client.RatisReplicationConfig;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
 import org.apache.hadoop.hdds.protocol.MockDatanodeDetails;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
+import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.ContainerReplicaProto;
 import org.apache.hadoop.hdds.scm.container.ContainerID;
 import org.apache.hadoop.hdds.scm.container.ContainerInfo;
 import org.apache.hadoop.hdds.scm.container.ContainerManager;
@@ -218,21 +219,76 @@ public class TestMoveManager {
         containerInfo.containerID());
   }
 
+  /**
+   * Move should fail if the container will not be healthy after move.
+   * Creates a situation where container is healthy before move but mis
+   * replicated after move. Set of replicas after move will not contain the
+   * source replica but will contain the target replica.
+   */
   @Test
-  public void testMoveContainerIsNotHealthy() throws Exception {
+  public void testContainerIsNotHealthyAfterMove() throws Exception {
     replicas.addAll(ReplicationTestUtil
         .createReplicas(containerInfo.containerID(), 0, 0, 0));
-    Iterator<ContainerReplica> iterator = replicas.iterator();
-    src = iterator.next().getDatanodeDetails();
+    ContainerReplica sourceReplica = replicas.iterator().next();
+    src = sourceReplica.getDatanodeDetails();
     tgt = MockDatanodeDetails.randomDatanodeDetails();
     nodes.put(src, NodeStatus.inServiceHealthy());
     nodes.put(tgt, NodeStatus.inServiceHealthy());
 
-    Mockito.when(replicationManager.getContainerReplicationHealth(any(), any()))
-        .thenReturn(new ContainerHealthResult
-            .MisReplicatedHealthResult(containerInfo, false));
+    // Return healthy before move but mis replicated after move
+    Mockito.when(replicationManager.getContainerReplicationHealth(any(),
+            any())).thenAnswer(invocationOnMock -> {
+      Set<ContainerReplica> replicasBeingChecked =
+          invocationOnMock.getArgument(1);
+      if (replicasBeingChecked.contains(sourceReplica)) {
+        // before move
+        return new ContainerHealthResult.HealthyResult(containerInfo);
+      } else {
+        // after move
+        return new ContainerHealthResult.MisReplicatedHealthResult(
+            containerInfo, false);
+      }
+    });
 
-    assertMoveFailsWith(MoveManager.MoveResult.REPLICATION_NOT_HEALTHY,
+    assertMoveFailsWith(
+        MoveManager.MoveResult.REPLICATION_NOT_HEALTHY_AFTER_MOVE,
+        containerInfo.containerID());
+  }
+
+  /**
+   * If the container has issues such as under, over or mis replication
+   * before moving then move should fail.
+   */
+  @Test
+  public void testContainerIsNotHealthyBeforeMove() throws Exception {
+    // return an under replicated health result from replication manager
+    Mockito.when(replicationManager.getContainerReplicationHealth(any(), any()))
+        .thenReturn(new ContainerHealthResult.UnderReplicatedHealthResult(
+            containerInfo, 1, false, false,
+            false));
+
+    // Check for an under replicated ratis container
+    replicas.addAll(ReplicationTestUtil
+        .createReplicas(containerInfo.containerID(), 0, 0));
+    src = replicas.iterator().next().getDatanodeDetails();
+    tgt = MockDatanodeDetails.randomDatanodeDetails();
+    nodes.put(src, NodeStatus.inServiceHealthy());
+    nodes.put(tgt, NodeStatus.inServiceHealthy());
+    assertMoveFailsWith(
+        MoveManager.MoveResult.REPLICATION_NOT_HEALTHY_BEFORE_MOVE,
+        containerInfo.containerID());
+
+    // check for an under replicated EC container
+    containerInfo = ReplicationTestUtil.createContainer(
+        HddsProtos.LifeCycleState.CLOSED, new ECReplicationConfig(3, 2));
+    replicas.clear();
+    replicas.addAll(ReplicationTestUtil.createReplicas(
+        containerInfo.containerID(), ContainerReplicaProto.State.CLOSED,
+        1, 2, 3, 4));
+    src = replicas.iterator().next().getDatanodeDetails();
+    nodes.put(src, NodeStatus.inServiceHealthy());
+    assertMoveFailsWith(
+        MoveManager.MoveResult.REPLICATION_NOT_HEALTHY_BEFORE_MOVE,
         containerInfo.containerID());
   }
 

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/balancer/TestMoveManager.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/balancer/TestMoveManager.java
@@ -236,19 +236,19 @@ public class TestMoveManager {
     nodes.put(tgt, NodeStatus.inServiceHealthy());
 
     // Return healthy before move but mis replicated after move
-    Mockito.when(replicationManager.getContainerReplicationHealth(any(),
-            any())).thenAnswer(invocationOnMock -> {
-      Set<ContainerReplica> replicasBeingChecked =
-          invocationOnMock.getArgument(1);
-      if (replicasBeingChecked.contains(sourceReplica)) {
-        // before move
-        return new ContainerHealthResult.HealthyResult(containerInfo);
-      } else {
-        // after move
-        return new ContainerHealthResult.MisReplicatedHealthResult(
-            containerInfo, false);
-      }
-    });
+    Mockito.when(replicationManager.getContainerReplicationHealth(any(), any()))
+        .thenAnswer(invocationOnMock -> {
+          Set<ContainerReplica> replicasBeingChecked =
+              invocationOnMock.getArgument(1);
+          if (replicasBeingChecked.contains(sourceReplica)) {
+            // before move
+            return new ContainerHealthResult.HealthyResult(containerInfo);
+          } else {
+            // after move
+            return new ContainerHealthResult.MisReplicatedHealthResult(
+                containerInfo, false);
+          }
+        });
 
     assertMoveFailsWith(
         MoveManager.MoveResult.REPLICATION_NOT_HEALTHY_AFTER_MOVE,


### PR DESCRIPTION
## What changes were proposed in this pull request?

`MoveManager#move` already checks if a container has any in-flight (pending) Adds or Deletes before scheduling a move. However, there is some time between the replication thread checking the health of a container and queuing it and the `UnhealthyReplicationProcessor` thread picking containers from the queue and scheduling Adds and Deletes. To be safe, we should also check the container's health in `MoveManager` before scheduling move.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-8034

## How was this patch tested?

Added UT.