### PR TITLE
HDDS-534. Remove unsupported jmxget subcommand

### DIFF
--- a/hadoop-hdds/docs/content/tools/_index.md
+++ b/hadoop-hdds/docs/content/tools/_index.md
@@ -55,7 +55,6 @@ Admin commands:
    * **dtutil**    - Operations related to delegation tokens
    * **envvars** - Display computed Hadoop environment variables.
    * **getconf** -  Reads ozone config values from configuration.
-   * **jmxget**  - Get JMX exported values from NameNode or DataNode.
    * **genconf** -  Generate minimally required ozone configs and output to
    ozone-site.xml.
 

--- a/hadoop-hdds/docs/content/tools/_index.zh.md
+++ b/hadoop-hdds/docs/content/tools/_index.zh.md
@@ -49,7 +49,6 @@ Ozone 有一系列管理 Ozone 的命令行工具。
    * **dtutil**    - 进行和 token 有关的操作。
    * **envvars** - 列出 Hadoop 的环境变量。
    * **getconf** -  从 Ozone 配置中读取特定配置值。
-   * **jmxget**  - 从 Ozone 服务中获取 JMX 导出的值。
    * **scmcli** -  SCM 的命令行接口，仅供开发者使用。
    Container Manager.
    * **genconf** -  生成 Ozone 所需的最小配置，并输出到 ozone-site.xml 中。

--- a/hadoop-ozone/dist/src/shell/ozone/ozone
+++ b/hadoop-ozone/dist/src/shell/ozone/ozone
@@ -45,7 +45,6 @@ function ozone_usage
   ozone_add_subcommand "fs" client "run a filesystem command on Ozone file system. Equivalent to 'hadoop fs'"
   ozone_add_subcommand "genconf" client "generate minimally required ozone configs and output to ozone-site.xml in specified path"
   ozone_add_subcommand "getconf" client "get ozone config values from configuration"
-  ozone_add_subcommand "jmxget" admin "get JMX exported values from NameNode or DataNode."
   ozone_add_subcommand "om" daemon "Ozone Manager"
   ozone_add_subcommand "scm" daemon "run the Storage Container Manager service"
   ozone_add_subcommand "s3g" daemon "run the S3 compatible REST gateway"


### PR DESCRIPTION
## What changes were proposed in this pull request?

`ozone jmxget` has never been implemented, but `jmxget` is still listed as a possible subcommand.

```
$ ozone jmxget
ERROR: jmxget is not COMMAND nor fully qualified CLASSNAME.
...

    Admin Commands:

daemonlog     get/set the log level for each daemon
jmxget        get JMX exported values from NameNode or DataNode.

...
```

This PR proposes to remove `jmxget` as an `ozone` subcommand.

https://issues.apache.org/jira/browse/HDDS-534

## How was this patch tested?

```
$ ozone jmxget
ERROR: jmxget is not COMMAND nor fully qualified CLASSNAME.
...

    Admin Commands:

daemonlog     get/set the log level for each daemon

    Client Commands:

...
```

https://github.com/adoroszlai/hadoop-ozone/actions/runs/4286535294