### PR TITLE
HDDS-8044. Ensure GrpcOutputStream is closed

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/replication/GrpcReplicationService.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/replication/GrpcReplicationService.java
@@ -27,6 +27,7 @@ import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.SendContai
 import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.SendContainerResponse;
 import org.apache.hadoop.hdds.protocol.datanode.proto.IntraDatanodeProtocolServiceGrpc;
 
+import org.apache.hadoop.hdds.utils.IOUtils;
 import org.apache.ratis.thirdparty.io.grpc.stub.StreamObserver;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -60,13 +61,17 @@ public class GrpcReplicationService extends
     CopyContainerCompression compression = fromProto(request.getCompression());
     LOG.info("Streaming container data ({}) to other datanode " +
         "with compression {}", containerID, compression);
+    OutputStream outputStream = null;
     try {
-      OutputStream outputStream = new CopyContainerResponseStream(
+      outputStream = new CopyContainerResponseStream(
           responseObserver, containerID, BUFFER_SIZE);
       source.copyData(containerID, outputStream, compression);
     } catch (IOException e) {
       LOG.error("Error streaming container {}", containerID, e);
       responseObserver.onError(e);
+    } finally {
+      // output may have already been closed, ignore such errors
+      IOUtils.cleanupWithLogger(LOG, outputStream);
     }
   }
 

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/replication/TestGrpcReplicationService.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/replication/TestGrpcReplicationService.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.ozone.container.replication;
+
+import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.CopyContainerRequestProto;
+import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.CopyContainerResponseProto;
+import org.apache.ratis.thirdparty.io.grpc.stub.StreamObserver;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.io.OutputStream;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+/**
+ * Tests {@link GrpcReplicationService}.
+ */
+class TestGrpcReplicationService {
+
+  @Test
+  void closesStreamOnError() {
+    // GIVEN
+    ContainerReplicationSource source = new ContainerReplicationSource() {
+      @Override
+      public void prepare(long containerId) {
+        // no-op
+      }
+
+      @Override
+      public void copyData(long containerId, OutputStream destination,
+          CopyContainerCompression compression) throws IOException {
+        throw new IOException("testing");
+      }
+    };
+    ContainerImporter importer = mock(ContainerImporter.class);
+    GrpcReplicationService subject =
+        new GrpcReplicationService(source, importer);
+
+    CopyContainerRequestProto request = CopyContainerRequestProto.newBuilder()
+        .setContainerID(1)
+        .setReadOffset(0)
+        .setLen(123)
+        .build();
+    StreamObserver<CopyContainerResponseProto> observer =
+        mock(StreamObserver.class);
+
+    // WHEN
+    subject.download(request, observer);
+
+    // THEN
+    // onCompleted is called by GrpcOutputStream#close
+    // so we indirectly verify that the stream is closed
+    verify(observer).onCompleted();
+  }
+
+}


### PR DESCRIPTION
## What changes were proposed in this pull request?

`GrpcOutputStream` is created for replicating container between datanodes.  It is passed into `TarContainerPacker`, which closes it after writing files of the container:

https://github.com/apache/ozone/blob/25ad1f2a4fc944cff098c22edaea1bd9e08344ba/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/TarContainerPacker.java#L160

If an exception happens before `TarContainerPacker#pack` is called (e.g. container not found), `GrpcOutputStream` is left open.

This patch ensures the stream is closed even in such cases.  This applies to pull replication.  Push replication already has such logic:

https://github.com/apache/ozone/blob/25ad1f2a4fc944cff098c22edaea1bd9e08344ba/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/replication/PushReplicator.java#L79

https://issues.apache.org/jira/browse/HDDS-8044

## How was this patch tested?

Added unit test.

https://github.com/adoroszlai/hadoop-ozone/actions/runs/4292108894