### PR TITLE
HDDS-8045. Dependency convergence error for zookeeper

### DIFF
--- a/hadoop-ozone/dist/src/main/license/bin/LICENSE.txt
+++ b/hadoop-ozone/dist/src/main/license/bin/LICENSE.txt
@@ -296,6 +296,7 @@ Apache License 2.0
    com.google.inject.extensions:guice-servlet
    com.google.inject:guice
    com.google.j2objc:j2objc-annotations
+   com.googlecode.json-simple:json-simple
    com.jolbox:bonecp
    com.lmax:disruptor
    com.nimbusds:nimbus-jose-jwt
@@ -366,6 +367,8 @@ Apache License 2.0
    org.apache.commons:commons-lang3
    org.apache.commons:commons-pool2
    org.apache.commons:commons-text
+   org.apache.curator:curator-client
+   org.apache.curator:curator-framework
    org.apache.derby:derby
    org.apache.hadoop:hadoop-annotations
    org.apache.hadoop:hadoop-auth
@@ -411,6 +414,8 @@ Apache License 2.0
    org.apache.ratis:ratis-thirdparty-misc
    org.apache.ratis:ratis-tools
    org.apache.thrift:libthrift
+   org.apache.zookeeper:zookeeper
+   org.apache.zookeeper:zookeeper-jute
    org.codehaus.jackson:jackson-core-asl
    org.codehaus.jackson:jackson-jaxrs
    org.codehaus.jackson:jackson-mapper-asl

--- a/hadoop-ozone/dist/src/main/license/jar-report.txt
+++ b/hadoop-ozone/dist/src/main/license/jar-report.txt
@@ -270,4 +270,5 @@ share/ozone/lib/txw2.jar
 share/ozone/lib/weld-servlet.Final.jar
 share/ozone/lib/woodstox-core.jar
 share/ozone/lib/zookeeper.jar
+share/ozone/lib/zookeeper-jute.jar
 share/ozone/lib/zstd-jni.jar

--- a/hadoop-ozone/httpfsgateway/pom.xml
+++ b/hadoop-ozone/httpfsgateway/pom.xml
@@ -115,13 +115,17 @@
       <groupId>org.apache.curator</groupId>
       <artifactId>curator-framework</artifactId>
       <scope>runtime</scope>
-      <version>2.4.0</version>
+      <version>4.2.0</version>
       <!-- These were excluded as non of them is used in the HttpFS module, but all of them would be a new unnecessary
        dependency to the Ozone project, we would also need to update the jar-report.txt with that. -->
       <exclusions>
         <exclusion>
           <groupId>org.apache.commons</groupId>
           <artifactId>commons-math</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.apache.yetus</groupId>
+          <artifactId>audience-annotations</artifactId>
         </exclusion>
         <exclusion>
           <groupId>org.slf4j</groupId>
@@ -140,8 +144,8 @@
           <artifactId>log4j</artifactId>
         </exclusion>
         <exclusion>
-          <groupId>org.jboss.netty</groupId>
-          <artifactId>netty</artifactId>
+          <groupId>io.netty</groupId>
+          <artifactId>*</artifactId>
         </exclusion>
       </exclusions>
     </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -213,6 +213,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
     <junit4.version>4.13.1</junit4.version>
     <junit.jupiter.version>5.8.2</junit.jupiter.version>
     <junit.platform.version>1.8.2</junit.platform.version>
+    <zookeeper.version>3.5.6</zookeeper.version>
 
     <!-- Maven protoc compiler -->
     <protobuf-maven-plugin.version>0.5.1</protobuf-maven-plugin.version>
@@ -1198,6 +1199,11 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
         <groupId>org.apache.commons</groupId>
         <artifactId>commons-text</artifactId>
         <version>${commons-text.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.zookeeper</groupId>
+        <artifactId>zookeeper</artifactId>
+        <version>${zookeeper.version}</version>
       </dependency>
       <dependency>
         <groupId>org.slf4j</groupId>


### PR DESCRIPTION
## What changes were proposed in this pull request?

After merge from `master` we'll have dependency convergence error for Zookeeper.

This change prepares for that by upgrading Curator on the feature branch.

https://issues.apache.org/jira/browse/HDDS-8045

## How was this patch tested?

```
git merge --no-edit origin/master
mvn -DskipTests clean package
hadoop-ozone/dev-support/checks/dependency.sh
```

Regular CI:
https://github.com/adoroszlai/hadoop-ozone/actions/runs/4294938025