### PR TITLE
HDDS-8048: DATASTREAM is not listed as supported tag in ozone-default.xml

### DIFF
--- a/hadoop-hdds/common/src/main/resources/ozone-default.xml
+++ b/hadoop-hdds/common/src/main/resources/ozone-default.xml
@@ -22,7 +22,7 @@
 
 <!--Tags supported are OZONE, CBLOCK, MANAGEMENT, SECURITY, PERFORMANCE,   -->
 <!--DEBUG, CLIENT, SERVER, OM, SCM, CRITICAL, RATIS, CONTAINER, REQUIRED, -->
-<!--REST, STORAGE, PIPELINE, STANDALONE                                    -->
+<!--REST, STORAGE, PIPELINE, STANDALONE, DATASTREAM                        -->
 
 <configuration>
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Add `DATASTREAM` tag as a supported one described in the `ozone-default.xml` comment.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-8048

## How was this patch tested?

No tests are required. Just update a comment.
