### PR TITLE
HDDS-8039. Allow container inspector to run from ozone debug.

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/impl/ContainerSet.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/impl/ContainerSet.java
@@ -48,7 +48,7 @@ import static org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.Con
 /**
  * Class that manages Containers created on the datanode.
  */
-public class ContainerSet {
+public class ContainerSet implements Iterable<Container<?>> {
 
   private static final Logger LOG = LoggerFactory.getLogger(ContainerSet.class);
 
@@ -201,6 +201,11 @@ public class ContainerSet {
    * @return {@literal Iterator<Container<?>>}
    */
   public Iterator<Container<?>> getContainerIterator() {
+    return iterator();
+  }
+
+  @Override
+  public Iterator<Container<?>> iterator() {
     return containerMap.values().iterator();
   }
 

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/volume/MutableVolumeSet.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/volume/MutableVolumeSet.java
@@ -165,6 +165,8 @@ public class MutableVolumeSet implements VolumeSet {
     }
 
     for (String locationString : rawLocations) {
+      LOG.info("Start initializing raw location {}", locationString);
+
       try {
         StorageLocation location = StorageLocation.parse(locationString);
 

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/volume/MutableVolumeSet.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/volume/MutableVolumeSet.java
@@ -165,8 +165,6 @@ public class MutableVolumeSet implements VolumeSet {
     }
 
     for (String locationString : rawLocations) {
-      LOG.info("Start initializing raw location {}", locationString);
-
       try {
         StorageLocation location = StorageLocation.parse(locationString);
 

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/KeyValueContainerMetadataInspector.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/KeyValueContainerMetadataInspector.java
@@ -233,7 +233,7 @@ public class KeyValueContainerMetadataInspector implements ContainerInspector {
 
   static long getLong(String key, JsonObject json) {
     final JsonElement e = json.get(key);
-    return e == null || e.isJsonNull()? 0 : e.getAsLong();
+    return e == null || e.isJsonNull() ? 0 : e.getAsLong();
   }
 
   static void checkDeleteCounts(JsonObject dBMetadata, JsonObject aggregates,

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/KeyValueContainerMetadataInspector.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/KeyValueContainerMetadataInspector.java
@@ -425,8 +425,8 @@ public class KeyValueContainerMetadataInspector implements ContainerInspector {
       final BooleanSupplier deleteCountRepairAction = () -> {
         final String key = containerData.getPendingDeleteBlockCountKey();
         try {
-          // reset delete block count to 0 in metadata table
-          metadataTable.put(key, 0L);
+          // set delete block count metadata table to delete transaction count
+          metadataTable.put(key, deleteTransactionCount);
           return true;
         } catch (IOException ex) {
           LOG.error("Failed to reset {} for container {}.",

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/ozoneimpl/ContainerController.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/ozoneimpl/ContainerController.java
@@ -196,6 +196,10 @@ public class ContainerController {
     return containerSet.getContainerIterator();
   }
 
+  public Iterable<Container<?>> getContainerSet() {
+    return containerSet;
+  }
+
   /**
    * Return an iterator of containers which are associated with the specified
    * <code>volume</code>.

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/ContainerTestVersionInfo.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/ContainerTestVersionInfo.java
@@ -65,6 +65,11 @@ public class ContainerTestVersionInfo {
         .collect(toList());
   }
 
+  @Override
+  public String toString() {
+    return "schema=" + schemaVersion + ", layout=" + layout;
+  }
+
   public static List<ContainerTestVersionInfo> getLayoutList() {
     return layoutList;
   }

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/TestKeyValueContainerIntegrityChecks.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/TestKeyValueContainerIntegrityChecks.java
@@ -58,7 +58,7 @@ import static org.junit.Assert.assertNotNull;
  */
 public class TestKeyValueContainerIntegrityChecks {
 
-  private static final Logger LOG =
+  static final Logger LOG =
       LoggerFactory.getLogger(TestKeyValueContainerIntegrityChecks.class);
 
   private final ContainerLayoutTestInfo containerLayoutTestInfo;
@@ -75,6 +75,7 @@ public class TestKeyValueContainerIntegrityChecks {
 
   public TestKeyValueContainerIntegrityChecks(
       ContainerTestVersionInfo versionInfo) {
+    LOG.info("new {} for {}", getClass().getSimpleName(), versionInfo);
     this.conf = new OzoneConfiguration();
     ContainerTestVersionInfo.setTestSchemaVersion(
         versionInfo.getSchemaVersion(), conf);

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/TestKeyValueContainerMetadataInspector.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/TestKeyValueContainerMetadataInspector.java
@@ -202,7 +202,7 @@ public class TestKeyValueContainerMetadataInspector
         Arrays.asList(1, 6, 3));
     LOG.info("deleteTransactions = {}", deleteTransactions);
 
-    setDBBlockAndByteCounts(container.getContainerData(), createBlocks,
+    setDB(container.getContainerData(), createBlocks,
         setBytes, deleteCount, deleteTransactions);
     inspectThenRepairOnCorrectContainer(container.getContainerData());
   }
@@ -221,7 +221,7 @@ public class TestKeyValueContainerMetadataInspector
         .mapToLong(DeletedBlocksTransaction::getLocalIDCount).sum();
     LOG.info("deleteTransactions = {}", deleteTransactions);
 
-    setDBBlockAndByteCounts(container.getContainerData(), createBlocks,
+    setDB(container.getContainerData(), createBlocks,
         setBytes, deleteCount, deleteTransactions);
     inspectThenRepairOnIncorrectContainer(container.getContainerData(),
         createBlocks, createBlocks, setBytes,
@@ -241,7 +241,7 @@ public class TestKeyValueContainerMetadataInspector
         .mapToLong(DeletedBlocksTransaction::getLocalIDCount).sum();
     LOG.info("deleteTransactions = {}", deleteTransactions);
 
-    setDBBlockAndByteCounts(container.getContainerData(), createBlocks,
+    setDB(container.getContainerData(), createBlocks,
         setBytes, deleteCount, deleteTransactions);
     inspectThenRepairOnIncorrectContainer(container.getContainerData(),
         createBlocks, createBlocks, setBytes,
@@ -363,9 +363,9 @@ public class TestKeyValueContainerMetadataInspector
   }
 
   /**
-     * Checks the erorr list in the provided JsonReport for an error matching
-     * the template passed in with the parameters.
-     */
+   * Checks the erorr list in the provided JsonReport for an error matching
+   * the template passed in with the parameters.
+   */
   private void checkJsonErrorsReport(JsonObject jsonReport,
       String propertyValue, JsonPrimitive correctExpected,
       JsonPrimitive correctActual, boolean correctRepair) {
@@ -402,11 +402,11 @@ public class TestKeyValueContainerMetadataInspector
 
   public void setDBBlockAndByteCounts(KeyValueContainerData containerData,
       long blockCount, long byteCount) throws Exception {
-    setDBBlockAndByteCounts(containerData, blockCount, byteCount,
+    setDB(containerData, blockCount, byteCount,
         0, Collections.emptyList());
   }
 
-  public void setDBBlockAndByteCounts(KeyValueContainerData containerData,
+  public void setDB(KeyValueContainerData containerData,
       long blockCount, long byteCount,
       long dbDeleteCount, List<DeletedBlocksTransaction> deleteTransactions)
       throws Exception {

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/TestKeyValueContainerMetadataInspector.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/TestKeyValueContainerMetadataInspector.java
@@ -22,6 +22,8 @@ import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonPrimitive;
+import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.DeletedBlocksTransaction;
+import org.apache.hadoop.hdds.utils.db.BatchOperation;
 import org.apache.hadoop.hdds.utils.db.Table;
 import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.hadoop.ozone.container.common.interfaces.ContainerInspector;
@@ -29,12 +31,20 @@ import org.apache.hadoop.ozone.container.common.interfaces.DBHandle;
 import org.apache.hadoop.ozone.container.common.utils.ContainerInspectorUtil;
 import org.apache.hadoop.ozone.container.keyvalue.helpers.BlockUtils;
 import org.apache.hadoop.ozone.container.keyvalue.helpers.KeyValueContainerUtil;
+import org.apache.hadoop.ozone.container.metadata.DatanodeStore;
+import org.apache.hadoop.ozone.container.metadata.DatanodeStoreSchemaThreeImpl;
+import org.apache.hadoop.ozone.container.metadata.DatanodeStoreSchemaTwoImpl;
 import org.apache.log4j.PatternLayout;
 import org.apache.ozone.test.GenericTestUtils;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
 
 /**
  * Tests for {@link KeyValueContainerMetadataInspector}.
@@ -113,7 +123,7 @@ public class TestKeyValueContainerMetadataInspector
     KeyValueContainer container = createClosedContainer(createBlocks);
     setDBBlockAndByteCounts(container.getContainerData(), setBlocks, setBytes);
     inspectThenRepairOnIncorrectContainer(container.getContainerData(),
-        createBlocks, setBlocks, setBytes);
+        createBlocks, setBlocks, setBytes, 0, 0, true);
   }
 
   @Test
@@ -126,7 +136,7 @@ public class TestKeyValueContainerMetadataInspector
     KeyValueContainer container = createOpenContainer(createBlocks);
     setDBBlockAndByteCounts(container.getContainerData(), setBlocks, setBytes);
     inspectThenRepairOnIncorrectContainer(container.getContainerData(),
-        createBlocks, setBlocks, setBytes);
+        createBlocks, setBlocks, setBytes, 0, 0, true);
   }
 
   @Test
@@ -151,6 +161,93 @@ public class TestKeyValueContainerMetadataInspector
     inspectThenRepairOnCorrectContainer(container.getContainerData());
   }
 
+  static class DeletedBlocksTransactionGeneratorForTesting {
+    private long txId = 100;
+    private long localId = 2000;
+
+    DeletedBlocksTransaction next(long containerId, int numBlocks) {
+      final DeletedBlocksTransaction.Builder b
+          = DeletedBlocksTransaction.newBuilder()
+          .setContainerID(containerId)
+          .setTxID(txId++)
+          .setCount(0);
+      for (int i = 0; i < numBlocks; i++) {
+        b.addLocalID(localId++);
+      }
+      return b.build();
+    }
+
+    List<DeletedBlocksTransaction> generate(
+        long containerId, List<Integer> numBlocks) {
+      final List<DeletedBlocksTransaction> transactions = new ArrayList<>();
+      for (int n : numBlocks) {
+        transactions.add(next(containerId, n));
+      }
+      return transactions;
+    }
+  }
+
+  static final DeletedBlocksTransactionGeneratorForTesting GENERATOR
+      = new DeletedBlocksTransactionGeneratorForTesting();
+
+  @Test
+  public void testCorrectDeleteWithTransaction() throws Exception {
+    final int createBlocks = 4;
+    final int setBytes = CHUNK_LEN * CHUNKS_PER_BLOCK * createBlocks;
+    final int deleteCount = 10;
+
+    final KeyValueContainer container = createClosedContainer(createBlocks);
+    final List<DeletedBlocksTransaction> deleteTransactions
+        = GENERATOR.generate(container.getContainerData().getContainerID(),
+        Arrays.asList(1, 6, 3));
+    LOG.info("deleteTransactions = {}", deleteTransactions);
+
+    setDBBlockAndByteCounts(container.getContainerData(), createBlocks,
+        setBytes, deleteCount, deleteTransactions);
+    inspectThenRepairOnCorrectContainer(container.getContainerData());
+  }
+
+  @Test
+  public void testIncorrectDeleteWithTransaction() throws Exception {
+    final int createBlocks = 4;
+    final int setBytes = CHUNK_LEN * CHUNKS_PER_BLOCK * createBlocks;
+    final int deleteCount = 10;
+
+    final KeyValueContainer container = createClosedContainer(createBlocks);
+    final List<DeletedBlocksTransaction> deleteTransactions
+        = GENERATOR.generate(container.getContainerData().getContainerID(),
+        Arrays.asList(1, 3));
+    final long numDeletedLocalIds = deleteTransactions.stream()
+        .mapToLong(DeletedBlocksTransaction::getLocalIDCount).sum();
+    LOG.info("deleteTransactions = {}", deleteTransactions);
+
+    setDBBlockAndByteCounts(container.getContainerData(), createBlocks,
+        setBytes, deleteCount, deleteTransactions);
+    inspectThenRepairOnIncorrectContainer(container.getContainerData(),
+        createBlocks, createBlocks, setBytes,
+        deleteCount, numDeletedLocalIds, numDeletedLocalIds == 0);
+  }
+
+  @Test
+  public void testIncorrectDeleteWithoutTransaction() throws Exception {
+    final int createBlocks = 4;
+    final int setBytes = CHUNK_LEN * CHUNKS_PER_BLOCK * createBlocks;
+    final int deleteCount = 10;
+
+    final KeyValueContainer container = createClosedContainer(createBlocks);
+    final List<DeletedBlocksTransaction> deleteTransactions
+        = Collections.emptyList();
+    final long numDeletedLocalIds = deleteTransactions.stream()
+        .mapToLong(DeletedBlocksTransaction::getLocalIDCount).sum();
+    LOG.info("deleteTransactions = {}", deleteTransactions);
+
+    setDBBlockAndByteCounts(container.getContainerData(), createBlocks,
+        setBytes, deleteCount, deleteTransactions);
+    inspectThenRepairOnIncorrectContainer(container.getContainerData(),
+        createBlocks, createBlocks, setBytes,
+        deleteCount, numDeletedLocalIds, numDeletedLocalIds == 0);
+  }
+
   public void inspectThenRepairOnCorrectContainer(
       KeyValueContainerData containerData) throws Exception {
     // No output for correct containers.
@@ -172,7 +269,8 @@ public class TestKeyValueContainerMetadataInspector
    */
   public void inspectThenRepairOnIncorrectContainer(
       KeyValueContainerData containerData, int createdBlocks, int setBlocks,
-      int setBytes) throws Exception {
+      int setBytes, int deleteCount, long numDeletedLocalIds,
+      boolean shouldRepair) throws Exception {
     int createdBytes = CHUNK_LEN * CHUNKS_PER_BLOCK * createdBlocks;
     int createdFiles = 0;
     switch (getChunkLayout()) {
@@ -194,7 +292,7 @@ public class TestKeyValueContainerMetadataInspector
 
     checkJsonReportForIncorrectContainer(inspectJson,
         containerState, createdBlocks, setBlocks, createdBytes, setBytes,
-        createdFiles, false);
+        createdFiles, deleteCount, numDeletedLocalIds, false);
     // Container should not have been modified in inspect mode.
     checkDBBlockAndByteCounts(containerData, setBlocks, setBytes);
 
@@ -203,7 +301,7 @@ public class TestKeyValueContainerMetadataInspector
         KeyValueContainerMetadataInspector.Mode.REPAIR);
     checkJsonReportForIncorrectContainer(repairJson,
         containerState, createdBlocks, setBlocks, createdBytes, setBytes,
-        createdFiles, true);
+        createdFiles, deleteCount, numDeletedLocalIds, shouldRepair);
     // Metadata keys should have been fixed.
     checkDBBlockAndByteCounts(containerData, createdBlocks, createdBytes);
   }
@@ -212,6 +310,7 @@ public class TestKeyValueContainerMetadataInspector
   private void checkJsonReportForIncorrectContainer(JsonObject inspectJson,
       String expectedContainerState, long createdBlocks,
       long setBlocks, long createdBytes, long setBytes, long createdFiles,
+      long deleteCount, long deleteTransactions,
       boolean shouldRepair) {
     // Check main container properties.
     Assert.assertEquals(inspectJson.get("containerID").getAsLong(),
@@ -232,7 +331,7 @@ public class TestKeyValueContainerMetadataInspector
         jsonAggregates.get("blockCount").getAsLong());
     Assert.assertEquals(createdBytes,
         jsonAggregates.get("usedBytes").getAsLong());
-    Assert.assertEquals(0,
+    Assert.assertEquals(deleteTransactions,
         jsonAggregates.get("pendingDeleteBlocks").getAsLong());
 
     // Check chunks directory.
@@ -243,17 +342,30 @@ public class TestKeyValueContainerMetadataInspector
 
     // Check errors.
     checkJsonErrorsReport(inspectJson, "dBMetadata.#BLOCKCOUNT",
-        new JsonPrimitive(createdBlocks), new JsonPrimitive(setBlocks),
-        shouldRepair);
+        createdBlocks, setBlocks, shouldRepair);
     checkJsonErrorsReport(inspectJson, "dBMetadata.#BYTESUSED",
-        new JsonPrimitive(createdBytes), new JsonPrimitive(setBytes),
-        shouldRepair);
+        createdBytes, setBytes, shouldRepair);
+    checkJsonErrorsReport(inspectJson, "dBMetadata.#PENDINGDELETEBLOCKCOUNT",
+        deleteCount, deleteTransactions, shouldRepair);
+  }
+
+  private void checkJsonErrorsReport(
+      JsonObject jsonReport, String propertyValue,
+      long correctExpected, long correctActual,
+      boolean correctRepair) {
+    if (correctExpected == correctActual) {
+      return;
+    }
+    checkJsonErrorsReport(jsonReport, propertyValue,
+        new JsonPrimitive(correctExpected),
+        new JsonPrimitive(correctActual),
+        correctRepair);
   }
 
   /**
-   * Checks the erorr list in the provided JsonReport for an error matching
-   * the template passed in with the parameters.
-   */
+     * Checks the erorr list in the provided JsonReport for an error matching
+     * the template passed in with the parameters.
+     */
   private void checkJsonErrorsReport(JsonObject jsonReport,
       String propertyValue, JsonPrimitive correctExpected,
       JsonPrimitive correctActual, boolean correctRepair) {
@@ -290,11 +402,53 @@ public class TestKeyValueContainerMetadataInspector
 
   public void setDBBlockAndByteCounts(KeyValueContainerData containerData,
       long blockCount, long byteCount) throws Exception {
+    setDBBlockAndByteCounts(containerData, blockCount, byteCount,
+        0, Collections.emptyList());
+  }
+
+  public void setDBBlockAndByteCounts(KeyValueContainerData containerData,
+      long blockCount, long byteCount,
+      long dbDeleteCount, List<DeletedBlocksTransaction> deleteTransactions)
+      throws Exception {
     try (DBHandle db = BlockUtils.getDB(containerData, getConf())) {
       Table<String, Long> metadataTable = db.getStore().getMetadataTable();
       // Don't care about in memory state. Just change the DB values.
       metadataTable.put(containerData.getBlockCountKey(), blockCount);
       metadataTable.put(containerData.getBytesUsedKey(), byteCount);
+      metadataTable.put(containerData.getPendingDeleteBlockCountKey(),
+          dbDeleteCount);
+
+      final DatanodeStore store = db.getStore();
+      LOG.info("store {}", store.getClass().getSimpleName());
+      if (store instanceof DatanodeStoreSchemaTwoImpl) {
+        final DatanodeStoreSchemaTwoImpl s2store
+            = (DatanodeStoreSchemaTwoImpl)store;
+        final Table<Long, DeletedBlocksTransaction> delTxTable
+            = s2store.getDeleteTransactionTable();
+        try (BatchOperation batch = store.getBatchHandler()
+            .initBatchOperation()) {
+          for (DeletedBlocksTransaction t : deleteTransactions) {
+            delTxTable.putWithBatch(batch, t.getTxID(), t);
+          }
+          store.getBatchHandler().commitBatchOperation(batch);
+        }
+      } else if (store instanceof DatanodeStoreSchemaThreeImpl) {
+        final DatanodeStoreSchemaThreeImpl s3store
+            = (DatanodeStoreSchemaThreeImpl)store;
+        final Table<String, DeletedBlocksTransaction> delTxTable
+            = s3store.getDeleteTransactionTable();
+        try (BatchOperation batch = store.getBatchHandler()
+            .initBatchOperation()) {
+          for (DeletedBlocksTransaction t : deleteTransactions) {
+            final String key = containerData.getDeleteTxnKey(t.getTxID());
+            delTxTable.putWithBatch(batch, key, t);
+          }
+          store.getBatchHandler().commitBatchOperation(batch);
+        }
+      } else {
+        throw new UnsupportedOperationException(
+            "Unsupported store class " + store.getClass().getSimpleName());
+      }
     }
   }
 

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/container/ContainerCommands.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/container/ContainerCommands.java
@@ -79,6 +79,7 @@ import java.util.stream.Stream;
         ListSubcommand.class,
         InfoSubcommand.class,
         ExportSubcommand.class,
+        InspectSubcommand.class
     })
 @MetaInfServices(SubcommandWithParent.class)
 public class ContainerCommands implements Callable<Void>, SubcommandWithParent {
@@ -105,6 +106,10 @@ public class ContainerCommands implements Callable<Void>, SubcommandWithParent {
   @Override
   public Class<?> getParentType() {
     return OzoneDebug.class;
+  }
+
+  OzoneConfiguration getOzoneConf() {
+    return parent.getOzoneConf();
   }
 
   public void loadContainersFromVolumes() throws IOException {

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/container/InspectSubcommand.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/container/InspectSubcommand.java
@@ -1,0 +1,76 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.apache.hadoop.ozone.debug.container;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.JsonObject;
+import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import org.apache.hadoop.ozone.OzoneConsts;
+import org.apache.hadoop.ozone.container.common.impl.ContainerData;
+import org.apache.hadoop.ozone.container.common.interfaces.Container;
+import org.apache.hadoop.ozone.container.keyvalue.KeyValueContainerData;
+import org.apache.hadoop.ozone.container.keyvalue.KeyValueContainerMetadataInspector;
+import org.apache.hadoop.ozone.container.keyvalue.helpers.BlockUtils;
+import org.apache.hadoop.ozone.container.metadata.DatanodeStore;
+import picocli.CommandLine;
+import picocli.CommandLine.Command;
+
+import java.util.Iterator;
+import java.util.concurrent.Callable;
+
+/**
+ * {@code ozone debug container inspect},
+ * a command to run {@link KeyValueContainerMetadataInspector}.
+ */
+@Command(
+    name = "inspect",
+    description = "Check the deletion information for all the containers.")
+public class InspectSubcommand implements Callable<Void> {
+
+  @CommandLine.ParentCommand
+  private ContainerCommands parent;
+
+  @Override
+  public Void call() throws Exception {
+    final OzoneConfiguration conf = parent.getOzoneConf();
+    parent.loadContainersFromVolumes();
+
+    final Gson gson = new GsonBuilder()
+        .setPrettyPrinting()
+        .serializeNulls()
+        .create();
+
+    for(Container<?> container : parent.getController().getContainerSet()) {
+      final ContainerData data = container.getContainerData();
+      if (!(data instanceof KeyValueContainerData)) {
+        continue;
+      }
+      final KeyValueContainerData kvData = (KeyValueContainerData)data;
+      try(DatanodeStore store = BlockUtils.getUncachedDatanodeStore(
+          kvData, conf, true)) {
+        final JsonObject json = KeyValueContainerMetadataInspector
+            .inspectContainer(kvData, store);
+        System.out.println(gson.toJson(json));
+      }
+    }
+
+    return null;
+  }
+}

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/container/InspectSubcommand.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/container/InspectSubcommand.java
@@ -22,7 +22,6 @@ import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.JsonObject;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
-import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.hadoop.ozone.container.common.impl.ContainerData;
 import org.apache.hadoop.ozone.container.common.interfaces.Container;
 import org.apache.hadoop.ozone.container.keyvalue.KeyValueContainerData;
@@ -32,7 +31,6 @@ import org.apache.hadoop.ozone.container.metadata.DatanodeStore;
 import picocli.CommandLine;
 import picocli.CommandLine.Command;
 
-import java.util.Iterator;
 import java.util.concurrent.Callable;
 
 /**
@@ -57,13 +55,13 @@ public class InspectSubcommand implements Callable<Void> {
         .serializeNulls()
         .create();
 
-    for(Container<?> container : parent.getController().getContainerSet()) {
+    for (Container<?> container : parent.getController().getContainerSet()) {
       final ContainerData data = container.getContainerData();
       if (!(data instanceof KeyValueContainerData)) {
         continue;
       }
-      final KeyValueContainerData kvData = (KeyValueContainerData)data;
-      try(DatanodeStore store = BlockUtils.getUncachedDatanodeStore(
+      final KeyValueContainerData kvData = (KeyValueContainerData) data;
+      try (DatanodeStore store = BlockUtils.getUncachedDatanodeStore(
           kvData, conf, true)) {
         final JsonObject json = KeyValueContainerMetadataInspector
             .inspectContainer(kvData, store);

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/container/InspectSubcommand.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/container/InspectSubcommand.java
@@ -37,7 +37,8 @@ import java.util.concurrent.Callable;
  */
 @Command(
     name = "inspect",
-    description = "Check the deletion information for all the containers.")
+    description
+        = "Check the metadata of all container replicas on this datanode.")
 public class InspectSubcommand implements Callable<Void> {
 
   @CommandLine.ParentCommand


### PR DESCRIPTION
## What changes were proposed in this pull request?

The KeyValueContainerMetadataInspector currently can be run by the option
`-Dozone.datanode.container.metadata.inspector=inspect` on datanode startup.

In this JIRA, we will allow to run with the `ozone debug` command.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-8039

## How was this patch tested?

Will add some new tests.