### PR TITLE
HDDS-8070. DBCheckpointMetrics is not unregistered during OM stop.

### DIFF
--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/DBCheckpointMetrics.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/DBCheckpointMetrics.java
@@ -53,6 +53,11 @@ public class DBCheckpointMetrics {
         new DBCheckpointMetrics());
   }
 
+  public void unRegister() {
+    MetricsSystem ms = DefaultMetricsSystem.instance();
+    ms.unregisterSource(SOURCE_NAME);
+  }
+
   @VisibleForTesting
   public void setLastCheckpointCreationTimeTaken(long val) {
     this.lastCheckpointCreationTimeTaken.set(val);

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OMMetrics.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OMMetrics.java
@@ -1309,6 +1309,9 @@ public class OMMetrics implements OmMetadataReaderMetrics {
   }
 
   public void unRegister() {
+    if (dbCheckpointMetrics != null) {
+      dbCheckpointMetrics.unRegister();
+    }
     MetricsSystem ms = DefaultMetricsSystem.instance();
     ms.unregisterSource(SOURCE_NAME);
   }


### PR DESCRIPTION
https://issues.apache.org/jira/browse/HDDS-8070


## How was this patch tested?
It's tested by [TestOzoneManagerListVolumesSecure.java](https://github.com/apache/ozone/pull/2466/files#diff-98e0e9e15effe6120b4dcae2999f826e671701b9e8d5ca2bb09d6bdb9fe867fe)
