### PR TITLE
HDDS-8073. Replace Usages of LegacyReplicationManager.MoveResult with MoveManager.MoveResult

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/balancer/ContainerBalancerMetrics.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/balancer/ContainerBalancerMetrics.java
@@ -19,7 +19,6 @@
 
 package org.apache.hadoop.hdds.scm.container.balancer;
 
-import org.apache.hadoop.hdds.scm.container.replication.LegacyReplicationManager.MoveResult;
 import org.apache.hadoop.metrics2.MetricsSystem;
 import org.apache.hadoop.metrics2.annotation.Metric;
 import org.apache.hadoop.metrics2.annotation.Metrics;
@@ -131,8 +130,7 @@ public final class ContainerBalancerMetrics {
   }
 
   public void incrementCurrentIterationContainerMoveMetric(
-      MoveResult result,
-      long valueToAdd) {
+      MoveManager.MoveResult result, long valueToAdd) {
     if (result == null) {
       return;
     }
@@ -145,9 +143,8 @@ public final class ContainerBalancerMetrics {
       this.numContainerMovesTimeoutInLatestIteration.incr(valueToAdd);
       break;
     // TODO: Add metrics for other errors that need to be tracked.
-    case FAIL_NOT_RUNNING:
+    case FAIL_LEADER_NOT_READY:
     case REPLICATION_FAIL_INFLIGHT_REPLICATION:
-    case FAIL_NOT_LEADER:
     case REPLICATION_FAIL_NOT_EXIST_IN_SOURCE:
     case REPLICATION_FAIL_EXIST_IN_TARGET:
     case REPLICATION_FAIL_CONTAINER_NOT_CLOSED:
@@ -157,10 +154,10 @@ public final class ContainerBalancerMetrics {
     case REPLICATION_FAIL_NODE_UNHEALTHY:
     case DELETION_FAIL_NODE_UNHEALTHY:
     case DELETE_FAIL_POLICY:
-    case PLACEMENT_POLICY_NOT_SATISFIED:
-    case UNEXPECTED_REMOVE_SOURCE_AT_INFLIGHT_REPLICATION:
-    case UNEXPECTED_REMOVE_TARGET_AT_INFLIGHT_DELETION:
-    case FAIL_CAN_NOT_RECORD_TO_DB:
+    case REPLICATION_NOT_HEALTHY_BEFORE_MOVE:
+    case REPLICATION_NOT_HEALTHY_AFTER_MOVE:
+    case FAIL_CONTAINER_ALREADY_BEING_MOVED:
+    case FAIL_UNEXPECTED_ERROR:
     default:
       break;
     }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ReplicationManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ReplicationManager.java
@@ -39,6 +39,7 @@ import org.apache.hadoop.hdds.scm.container.ContainerNotFoundException;
 import org.apache.hadoop.hdds.scm.container.ContainerReplica;
 
 import org.apache.hadoop.hdds.scm.container.ReplicationManagerReport;
+import org.apache.hadoop.hdds.scm.container.balancer.MoveManager;
 import org.apache.hadoop.hdds.scm.container.replication.health.MismatchedReplicasHandler;
 import org.apache.hadoop.hdds.scm.container.replication.health.ClosedWithUnhealthyReplicasHandler;
 import org.apache.hadoop.hdds.scm.container.replication.health.ClosingContainerHandler;
@@ -1127,22 +1128,23 @@ public class ReplicationManager implements SCMService {
   /**
   * following functions will be refactored in a separate jira.
   */
-  public CompletableFuture<LegacyReplicationManager.MoveResult> move(
+  public CompletableFuture<MoveManager.MoveResult> move(
       ContainerID cid, DatanodeDetails src, DatanodeDetails tgt)
       throws NodeNotFoundException, ContainerNotFoundException,
       TimeoutException {
-    CompletableFuture<LegacyReplicationManager.MoveResult> ret =
+    CompletableFuture<MoveManager.MoveResult> ret =
         new CompletableFuture<>();
     if (!isRunning()) {
-      ret.complete(LegacyReplicationManager.MoveResult.FAIL_NOT_RUNNING);
+      ret.complete(MoveManager.MoveResult.FAIL_UNEXPECTED_ERROR);
+      LOG.warn("Failing move because Replication Monitor thread's " +
+          "running state is {}", isRunning());
       return ret;
     }
 
     return legacyReplicationManager.move(cid, src, tgt);
   }
 
-  public Map<ContainerID,
-      CompletableFuture<LegacyReplicationManager.MoveResult>>
+  public Map<ContainerID, CompletableFuture<MoveManager.MoveResult>>
       getInflightMove() {
     return legacyReplicationManager.getInflightMove();
   }

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestLegacyReplicationManager.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestLegacyReplicationManager.java
@@ -41,12 +41,12 @@ import org.apache.hadoop.hdds.scm.container.ContainerStateManagerImpl;
 import org.apache.hadoop.hdds.scm.container.ReplicationManagerReport;
 import org.apache.hadoop.hdds.scm.container.SimpleMockNodeManager;
 import org.apache.hadoop.hdds.scm.container.TestContainerManagerImpl;
+import org.apache.hadoop.hdds.scm.container.balancer.MoveManager;
 import org.apache.hadoop.hdds.scm.container.replication.LegacyReplicationManager.LegacyReplicationManagerConfiguration;
 import org.apache.hadoop.hdds.scm.container.replication.ReplicationManager.ReplicationManagerConfiguration;
 import org.apache.hadoop.hdds.scm.PlacementPolicy;
 import org.apache.hadoop.hdds.scm.container.common.helpers.MoveDataNodePair;
 import org.apache.hadoop.hdds.scm.container.placement.algorithms.ContainerPlacementStatusDefault;
-import org.apache.hadoop.hdds.scm.container.replication.LegacyReplicationManager.MoveResult;
 import org.apache.hadoop.hdds.scm.events.SCMEvents;
 import org.apache.hadoop.hdds.scm.ha.SCMHAManagerStub;
 import org.apache.hadoop.hdds.scm.ha.SCMContext;
@@ -1793,7 +1793,7 @@ public class TestLegacyReplicationManager {
       addReplica(container,
               new NodeStatus(IN_SERVICE, HEALTHY), CLOSED);
       DatanodeDetails dn3 = addNode(new NodeStatus(IN_SERVICE, HEALTHY));
-      CompletableFuture<MoveResult> cf =
+      CompletableFuture<MoveManager.MoveResult> cf =
               replicationManager.move(id, dn1.getDatanodeDetails(), dn3);
       Assertions.assertTrue(scmLogs.getOutput().contains(
               "receive a move request about container"));
@@ -1818,7 +1818,8 @@ public class TestLegacyReplicationManager {
       replicationManager.processAll();
       eventQueue.processAll(1000);
 
-      Assertions.assertTrue(cf.isDone() && cf.get() == MoveResult.COMPLETED);
+      Assertions.assertTrue(
+          cf.isDone() && cf.get() == MoveManager.MoveResult.COMPLETED);
     }
 
     /**
@@ -1933,7 +1934,7 @@ public class TestLegacyReplicationManager {
       addReplica(container,
               new NodeStatus(IN_SERVICE, HEALTHY), CLOSED);
       DatanodeDetails dn4 = addNode(new NodeStatus(IN_SERVICE, HEALTHY));
-      CompletableFuture<MoveResult> cf =
+      CompletableFuture<MoveManager.MoveResult> cf =
               replicationManager.move(id, dn1.getDatanodeDetails(), dn4);
       Assertions.assertTrue(scmLogs.getOutput().contains(
               "receive a move request about container"));
@@ -1958,7 +1959,7 @@ public class TestLegacyReplicationManager {
               dn1.getDatanodeDetails()));
 
       Assertions.assertTrue(cf.isDone() &&
-              cf.get() == MoveResult.DELETE_FAIL_POLICY);
+              cf.get() == MoveManager.MoveResult.DELETE_FAIL_POLICY);
     }
 
 
@@ -1978,7 +1979,7 @@ public class TestLegacyReplicationManager {
       addReplica(container,
               new NodeStatus(IN_SERVICE, HEALTHY), CLOSED);
       DatanodeDetails dn3 = addNode(new NodeStatus(IN_SERVICE, HEALTHY));
-      CompletableFuture<MoveResult> cf =
+      CompletableFuture<MoveManager.MoveResult> cf =
               replicationManager.move(id, dn1.getDatanodeDetails(), dn3);
       Assertions.assertTrue(scmLogs.getOutput().contains(
               "receive a move request about container"));
@@ -1988,7 +1989,7 @@ public class TestLegacyReplicationManager {
       eventQueue.processAll(1000);
 
       Assertions.assertTrue(cf.isDone() && cf.get() ==
-              MoveResult.REPLICATION_FAIL_NODE_UNHEALTHY);
+              MoveManager.MoveResult.REPLICATION_FAIL_NODE_UNHEALTHY);
 
       nodeManager.setNodeStatus(dn3, new NodeStatus(IN_SERVICE, HEALTHY));
       cf = replicationManager.move(id, dn1.getDatanodeDetails(), dn3);
@@ -2001,7 +2002,7 @@ public class TestLegacyReplicationManager {
       eventQueue.processAll(1000);
 
       Assertions.assertTrue(cf.isDone() && cf.get() ==
-              MoveResult.DELETION_FAIL_NODE_UNHEALTHY);
+              MoveManager.MoveResult.DELETION_FAIL_NODE_UNHEALTHY);
     }
 
     /**
@@ -2023,7 +2024,7 @@ public class TestLegacyReplicationManager {
       ContainerReplica dn4 = addReplica(container,
               new NodeStatus(IN_SERVICE, HEALTHY), CLOSED);
 
-      CompletableFuture<MoveResult> cf;
+      CompletableFuture<MoveManager.MoveResult> cf;
       //the above move is executed successfully, so there may be some item in
       //inflightReplication or inflightDeletion. here we stop replication
       // manager to clear these states, which may impact the tests below.
@@ -2032,26 +2033,26 @@ public class TestLegacyReplicationManager {
       Thread.sleep(100L);
       cf = replicationManager.move(id, dn1.getDatanodeDetails(), dn3);
       Assertions.assertTrue(cf.isDone() && cf.get() ==
-              MoveResult.FAIL_NOT_RUNNING);
+              MoveManager.MoveResult.FAIL_UNEXPECTED_ERROR);
       replicationManager.start();
       Thread.sleep(100L);
 
       //container in not in OPEN state
       cf = replicationManager.move(id, dn1.getDatanodeDetails(), dn3);
       Assertions.assertTrue(cf.isDone() && cf.get() ==
-              MoveResult.REPLICATION_FAIL_CONTAINER_NOT_CLOSED);
+              MoveManager.MoveResult.REPLICATION_FAIL_CONTAINER_NOT_CLOSED);
       //open -> closing
       containerStateManager.updateContainerState(id.getProtobuf(),
               LifeCycleEvent.FINALIZE);
       cf = replicationManager.move(id, dn1.getDatanodeDetails(), dn3);
       Assertions.assertTrue(cf.isDone() && cf.get() ==
-              MoveResult.REPLICATION_FAIL_CONTAINER_NOT_CLOSED);
+              MoveManager.MoveResult.REPLICATION_FAIL_CONTAINER_NOT_CLOSED);
       //closing -> quasi_closed
       containerStateManager.updateContainerState(id.getProtobuf(),
               LifeCycleEvent.QUASI_CLOSE);
       cf = replicationManager.move(id, dn1.getDatanodeDetails(), dn3);
       Assertions.assertTrue(cf.isDone() && cf.get() ==
-              MoveResult.REPLICATION_FAIL_CONTAINER_NOT_CLOSED);
+              MoveManager.MoveResult.REPLICATION_FAIL_CONTAINER_NOT_CLOSED);
 
       //quasi_closed -> closed
       containerStateManager.updateContainerState(id.getProtobuf(),
@@ -2066,10 +2067,10 @@ public class TestLegacyReplicationManager {
                   new NodeStatus(IN_SERVICE, state));
           cf = replicationManager.move(id, dn1.getDatanodeDetails(), dn3);
           Assertions.assertTrue(cf.isDone() && cf.get() ==
-                  MoveResult.REPLICATION_FAIL_NODE_UNHEALTHY);
+                  MoveManager.MoveResult.REPLICATION_FAIL_NODE_UNHEALTHY);
           cf = replicationManager.move(id, dn3, dn1.getDatanodeDetails());
           Assertions.assertTrue(cf.isDone() && cf.get() ==
-                  MoveResult.REPLICATION_FAIL_NODE_UNHEALTHY);
+                  MoveManager.MoveResult.REPLICATION_FAIL_NODE_UNHEALTHY);
         }
       }
       nodeManager.setNodeStatus(dn3, new NodeStatus(IN_SERVICE, HEALTHY));
@@ -2082,10 +2083,10 @@ public class TestLegacyReplicationManager {
                   new NodeStatus(state, HEALTHY));
           cf = replicationManager.move(id, dn1.getDatanodeDetails(), dn3);
           Assertions.assertTrue(cf.isDone() && cf.get() ==
-                  MoveResult.REPLICATION_FAIL_NODE_NOT_IN_SERVICE);
+                  MoveManager.MoveResult.REPLICATION_FAIL_NODE_NOT_IN_SERVICE);
           cf = replicationManager.move(id, dn3, dn1.getDatanodeDetails());
           Assertions.assertTrue(cf.isDone() && cf.get() ==
-                  MoveResult.REPLICATION_FAIL_NODE_NOT_IN_SERVICE);
+                  MoveManager.MoveResult.REPLICATION_FAIL_NODE_NOT_IN_SERVICE);
         }
       }
       nodeManager.setNodeStatus(dn3, new NodeStatus(IN_SERVICE, HEALTHY));
@@ -2094,12 +2095,12 @@ public class TestLegacyReplicationManager {
       cf = replicationManager.move(id, dn1.getDatanodeDetails(),
               dn2.getDatanodeDetails());
       Assertions.assertTrue(cf.isDone() && cf.get() ==
-              MoveResult.REPLICATION_FAIL_EXIST_IN_TARGET);
+              MoveManager.MoveResult.REPLICATION_FAIL_EXIST_IN_TARGET);
 
       //container does not exist in source datanode
       cf = replicationManager.move(id, dn3, dn3);
       Assertions.assertTrue(cf.isDone() && cf.get() ==
-              MoveResult.REPLICATION_FAIL_NOT_EXIST_IN_SOURCE);
+              MoveManager.MoveResult.REPLICATION_FAIL_NOT_EXIST_IN_SOURCE);
 
       //make container over relplicated to test the
       // case that container is in inflightDeletion
@@ -2110,7 +2111,7 @@ public class TestLegacyReplicationManager {
       eventQueue.processAll(1000);
       cf = replicationManager.move(id, dn1.getDatanodeDetails(), dn3);
       Assertions.assertTrue(cf.isDone() && cf.get() ==
-              MoveResult.REPLICATION_FAIL_INFLIGHT_DELETION);
+              MoveManager.MoveResult.REPLICATION_FAIL_INFLIGHT_DELETION);
       resetReplicationManager();
 
       //make the replica num be 2 to test the case
@@ -2123,7 +2124,7 @@ public class TestLegacyReplicationManager {
       eventQueue.processAll(1000);
       cf = replicationManager.move(id, dn1.getDatanodeDetails(), dn3);
       Assertions.assertTrue(cf.isDone() && cf.get() ==
-              MoveResult.REPLICATION_FAIL_INFLIGHT_REPLICATION);
+              MoveManager.MoveResult.REPLICATION_FAIL_INFLIGHT_REPLICATION);
     }
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR replaces usages of LegacyReplicationManager.MoveResult with corresponding MoveManager.MoveResult results. This will allow Container Balancer to use MoveManager in the future while maintaining compatibility with Legacy Replication Manager. 

```
Legacy -> MoveManager
1. FAIL_NOT_RUNNING, FAIL_NOT_LEADER -> FAIL_LEADER_NOT_READY
2. UNEXPECTED_REMOVE_SOURCE_AT_INFLIGHT_REPLICATION, UNEXPECTED_REMOVE_TARGET_AT_INFLIGHT_DELETION -> FAIL_UNEXPECTED_ERROR
3. FAIL_CAN_NOT_RECORD_TO_DB -> FAIL_UNEXPECTED_ERROR
```
Added logs wherever we're failing with `FAIL_UNEXPECTED_ERROR`.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-8073

## How was this patch tested?

No new tests required.