### PR TITLE
HDDS-8054. NullPointerException: MethodMetric, Error invoking method getReserved.

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/volume/DbVolume.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/volume/DbVolume.java
@@ -56,9 +56,11 @@ public class DbVolume extends StorageVolume {
     super(b);
 
     this.hddsDbStorePathMap = new HashMap<>();
-    if (!b.getFailedVolume()) {
+    if (!b.getFailedVolume() && getVolumeInfo().isPresent()) {
       LOG.info("Creating DbVolume: {} of storage type : {} capacity : {}",
-          getStorageDir(), b.getStorageType(), getVolumeInfo().getCapacity());
+              getStorageDir(), b.getStorageType(),
+              getVolumeInfo().get().getCapacity());
+
       initialize();
     }
   }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/volume/HddsVolume.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/volume/HddsVolume.java
@@ -111,7 +111,7 @@ public class HddsVolume extends StorageVolume {
   private HddsVolume(Builder b) throws IOException {
     super(b);
 
-    if (!b.getFailedVolume()) {
+    if (!b.getFailedVolume() && getVolumeInfo().isPresent()) {
       this.setState(VolumeState.NOT_INITIALIZED);
       this.volumeIOStats = new VolumeIOStats(b.getVolumeRootStr(),
           this.getStorageDir().toString());
@@ -120,7 +120,8 @@ public class HddsVolume extends StorageVolume {
       this.committedBytes = new AtomicLong(0);
 
       LOG.info("Creating HddsVolume: {} of storage type : {} capacity : {}",
-          getStorageDir(), b.getStorageType(), getVolumeInfo().getCapacity());
+          getStorageDir(), b.getStorageType(),
+              getVolumeInfo().get().getCapacity());
 
       initialize();
     } else {

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/volume/MutableVolumeSet.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/volume/MutableVolumeSet.java
@@ -25,6 +25,7 @@ import java.util.Collection;
 import java.util.EnumMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
@@ -485,22 +486,22 @@ public class MutableVolumeSet implements VolumeSet {
       StorageVolume volume;
       for (Map.Entry<String, StorageVolume> entry : volumeMap.entrySet()) {
         volume = entry.getValue();
-        VolumeInfo volumeInfo = volume.getVolumeInfo();
+        Optional<VolumeInfo> volumeInfo = volume.getVolumeInfo();
         long scmUsed = 0;
         long remaining = 0;
         long capacity = 0;
         String rootDir = "";
         failed = true;
-        if (volumeInfo != null) {
+        if (volumeInfo.isPresent()) {
           try {
-            rootDir = volumeInfo.getRootDir();
-            scmUsed = volumeInfo.getScmUsed();
-            remaining = volumeInfo.getAvailable();
-            capacity = volumeInfo.getCapacity();
+            rootDir = volumeInfo.get().getRootDir();
+            scmUsed = volumeInfo.get().getScmUsed();
+            remaining = volumeInfo.get().getAvailable();
+            capacity = volumeInfo.get().getCapacity();
             failed = false;
           } catch (UncheckedIOException ex) {
             LOG.warn("Failed to get scmUsed and remaining for container " +
-                    "storage location {}", volumeInfo.getRootDir(), ex);
+                    "storage location {}", volumeInfo.get().getRootDir(), ex);
             // reset scmUsed and remaining if df/du failed.
             scmUsed = 0;
             remaining = 0;

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/volume/MutableVolumeSet.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/volume/MutableVolumeSet.java
@@ -486,22 +486,24 @@ public class MutableVolumeSet implements VolumeSet {
       for (Map.Entry<String, StorageVolume> entry : volumeMap.entrySet()) {
         volume = entry.getValue();
         VolumeInfo volumeInfo = volume.getVolumeInfo();
-        long scmUsed;
-        long remaining;
-        long capacity;
-        failed = false;
-        try {
-          scmUsed = volumeInfo.getScmUsed();
-          remaining = volumeInfo.getAvailable();
-          capacity = volumeInfo.getCapacity();
-        } catch (UncheckedIOException ex) {
-          LOG.warn("Failed to get scmUsed and remaining for container " +
-              "storage location {}", volumeInfo.getRootDir(), ex);
-          // reset scmUsed and remaining if df/du failed.
-          scmUsed = 0;
-          remaining = 0;
-          capacity = 0;
-          failed = true;
+        long scmUsed = 0;
+        long remaining = 0;
+        long capacity = 0;
+        failed = true;
+        if (volumeInfo != null) {
+          try {
+            scmUsed = volumeInfo.getScmUsed();
+            remaining = volumeInfo.getAvailable();
+            capacity = volumeInfo.getCapacity();
+            failed = false;
+          } catch (UncheckedIOException ex) {
+            LOG.warn("Failed to get scmUsed and remaining for container " +
+                    "storage location {}", volumeInfo.getRootDir(), ex);
+            // reset scmUsed and remaining if df/du failed.
+            scmUsed = 0;
+            remaining = 0;
+            capacity = 0;
+          }
         }
 
         StorageLocationReport.Builder builder =

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/volume/MutableVolumeSet.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/volume/MutableVolumeSet.java
@@ -489,9 +489,11 @@ public class MutableVolumeSet implements VolumeSet {
         long scmUsed = 0;
         long remaining = 0;
         long capacity = 0;
+        String rootDir = "";
         failed = true;
         if (volumeInfo != null) {
           try {
+            rootDir = volumeInfo.getRootDir();
             scmUsed = volumeInfo.getScmUsed();
             remaining = volumeInfo.getAvailable();
             capacity = volumeInfo.getCapacity();
@@ -508,7 +510,7 @@ public class MutableVolumeSet implements VolumeSet {
 
         StorageLocationReport.Builder builder =
             StorageLocationReport.newBuilder();
-        builder.setStorageLocation(volumeInfo.getRootDir())
+        builder.setStorageLocation(rootDir)
             .setId(volume.getStorageID())
             .setFailed(failed)
             .setCapacity(capacity)

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/volume/StorageVolume.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/volume/StorageVolume.java
@@ -393,7 +393,9 @@ public abstract class StorageVolume
   }
 
   public void refreshVolumeInfo() {
-    volumeInfo.refreshNow();
+    if (volumeInfo != null) {
+      volumeInfo.refreshNow();
+    }
   }
 
   public VolumeInfo getVolumeInfo() {

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/volume/StorageVolume.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/volume/StorageVolume.java
@@ -37,6 +37,7 @@ import javax.annotation.Nullable;
 import java.io.File;
 import java.io.IOException;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Properties;
 import java.util.UUID;
 
@@ -105,7 +106,7 @@ public abstract class StorageVolume
 
   private final File storageDir;
 
-  private final VolumeInfo volumeInfo;
+  private final Optional<VolumeInfo> volumeInfo;
 
   private final VolumeSet volumeSet;
 
@@ -115,10 +116,11 @@ public abstract class StorageVolume
     if (!b.failedVolume) {
       StorageLocation location = StorageLocation.parse(b.volumeRootStr);
       storageDir = new File(location.getUri().getPath(), b.storageDirStr);
-      this.volumeInfo = new VolumeInfo.Builder(b.volumeRootStr, b.conf)
+      this.volumeInfo = Optional.of(
+              new VolumeInfo.Builder(b.volumeRootStr, b.conf)
           .storageType(b.storageType)
           .usageCheckFactory(b.usageCheckFactory)
-          .build();
+          .build());
       this.volumeSet = b.volumeSet;
       this.state = VolumeState.NOT_INITIALIZED;
       this.clusterID = b.clusterID;
@@ -126,7 +128,7 @@ public abstract class StorageVolume
       this.conf = b.conf;
     } else {
       storageDir = new File(b.volumeRootStr);
-      this.volumeInfo = null;
+      this.volumeInfo = Optional.ofNullable(null);
       this.volumeSet = null;
       this.storageID = UUID.randomUUID().toString();
       this.state = VolumeState.FAILED;
@@ -369,19 +371,21 @@ public abstract class StorageVolume
   }
 
   public String getVolumeRootDir() {
-    return volumeInfo != null ? volumeInfo.getRootDir() : null;
+    return volumeInfo.map(VolumeInfo::getRootDir).orElse(null);
   }
 
   public long getCapacity() {
-    return volumeInfo != null ? volumeInfo.getCapacity() : 0;
+    return volumeInfo.map(VolumeInfo::getCapacity).orElse(0L);
   }
 
   public long getAvailable() {
-    return volumeInfo != null ? volumeInfo.getAvailable() : 0;
+    return volumeInfo.map(VolumeInfo::getAvailable).orElse(0L);
+
   }
 
   public long getUsedSpace() {
-    return volumeInfo != null ? volumeInfo.getScmUsed() : 0;
+    return volumeInfo.map(VolumeInfo::getScmUsed).orElse(0L);
+
   }
 
   public File getStorageDir() {
@@ -393,24 +397,25 @@ public abstract class StorageVolume
   }
 
   public void refreshVolumeInfo() {
-    if (volumeInfo != null) {
-      volumeInfo.refreshNow();
+
+    if (volumeInfo.isPresent()) {
+      volumeInfo.get().refreshNow();
     }
   }
 
-  public VolumeInfo getVolumeInfo() {
+  public Optional<VolumeInfo> getVolumeInfo() {
     return this.volumeInfo;
   }
 
   public void incrementUsedSpace(long usedSpace) {
-    if (this.volumeInfo != null) {
-      this.volumeInfo.incrementUsedSpace(usedSpace);
+    if (volumeInfo.isPresent()) {
+      volumeInfo.get().incrementUsedSpace(usedSpace);
     }
   }
 
   public void decrementUsedSpace(long reclaimedSpace) {
-    if (this.volumeInfo != null) {
-      this.volumeInfo.decrementUsedSpace(reclaimedSpace);
+    if (volumeInfo.isPresent()) {
+      volumeInfo.get().decrementUsedSpace(reclaimedSpace);
     }
   }
 
@@ -419,8 +424,8 @@ public abstract class StorageVolume
   }
 
   public StorageType getStorageType() {
-    if (this.volumeInfo != null) {
-      return this.volumeInfo.getStorageType();
+    if (volumeInfo.isPresent()) {
+      return volumeInfo.get().getStorageType();
     }
     return StorageType.DEFAULT;
   }
@@ -463,15 +468,15 @@ public abstract class StorageVolume
 
   public void failVolume() {
     setState(VolumeState.FAILED);
-    if (volumeInfo != null) {
-      volumeInfo.shutdownUsageThread();
+    if (volumeInfo.isPresent()) {
+      volumeInfo.get().shutdownUsageThread();
     }
   }
 
   public void shutdown() {
     setState(VolumeState.NON_EXISTENT);
-    if (volumeInfo != null) {
-      volumeInfo.shutdownUsageThread();
+    if (volumeInfo.isPresent()) {
+      volumeInfo.get().shutdownUsageThread();
     }
   }
 

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/volume/StorageVolume.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/volume/StorageVolume.java
@@ -128,7 +128,7 @@ public abstract class StorageVolume
       this.conf = b.conf;
     } else {
       storageDir = new File(b.volumeRootStr);
-      this.volumeInfo = Optional.ofNullable(null);
+      this.volumeInfo = Optional.empty();
       this.volumeSet = null;
       this.storageID = UUID.randomUUID().toString();
       this.state = VolumeState.FAILED;
@@ -397,10 +397,7 @@ public abstract class StorageVolume
   }
 
   public void refreshVolumeInfo() {
-
-    if (volumeInfo.isPresent()) {
-      volumeInfo.get().refreshNow();
-    }
+    volumeInfo.ifPresent(VolumeInfo::refreshNow);
   }
 
   public Optional<VolumeInfo> getVolumeInfo() {
@@ -408,15 +405,13 @@ public abstract class StorageVolume
   }
 
   public void incrementUsedSpace(long usedSpace) {
-    if (volumeInfo.isPresent()) {
-      volumeInfo.get().incrementUsedSpace(usedSpace);
-    }
+    volumeInfo.ifPresent(volInfo -> volInfo
+            .incrementUsedSpace(usedSpace));
   }
 
   public void decrementUsedSpace(long reclaimedSpace) {
-    if (volumeInfo.isPresent()) {
-      volumeInfo.get().decrementUsedSpace(reclaimedSpace);
-    }
+    volumeInfo.ifPresent(volInfo -> volInfo
+            .decrementUsedSpace(reclaimedSpace));
   }
 
   public VolumeSet getVolumeSet() {
@@ -424,10 +419,8 @@ public abstract class StorageVolume
   }
 
   public StorageType getStorageType() {
-    if (volumeInfo.isPresent()) {
-      return volumeInfo.get().getStorageType();
-    }
-    return StorageType.DEFAULT;
+    return volumeInfo.map(VolumeInfo::getStorageType)
+            .orElse(StorageType.DEFAULT);
   }
 
   public String getStorageID() {
@@ -468,16 +461,12 @@ public abstract class StorageVolume
 
   public void failVolume() {
     setState(VolumeState.FAILED);
-    if (volumeInfo.isPresent()) {
-      volumeInfo.get().shutdownUsageThread();
-    }
+    volumeInfo.ifPresent(VolumeInfo::shutdownUsageThread);
   }
 
   public void shutdown() {
     setState(VolumeState.NON_EXISTENT);
-    if (volumeInfo.isPresent()) {
-      volumeInfo.get().shutdownUsageThread();
-    }
+    volumeInfo.ifPresent(VolumeInfo::shutdownUsageThread);
   }
 
   /**

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/volume/VolumeInfoMetrics.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/volume/VolumeInfoMetrics.java
@@ -104,7 +104,8 @@ public class VolumeInfoMetrics {
    */
   @Metric("Returns the Used space")
   public long getUsed() {
-    return volume.getVolumeInfo().getScmUsed();
+    return volume.getVolumeInfo() != null ?
+            volume.getVolumeInfo().getScmUsed() : 0;
   }
 
   /**
@@ -112,7 +113,8 @@ public class VolumeInfoMetrics {
    */
   @Metric("Returns the Available space")
   public long getAvailable() {
-    return volume.getVolumeInfo().getAvailable();
+    return volume.getVolumeInfo() != null ?
+            volume.getVolumeInfo().getAvailable() : 0;
   }
 
   /**
@@ -120,7 +122,8 @@ public class VolumeInfoMetrics {
    */
   @Metric("Fetches the Reserved Space")
   public long getReserved() {
-    return volume.getVolumeInfo().getReservedInBytes();
+    return volume.getVolumeInfo() != null ?
+            volume.getVolumeInfo().getReservedInBytes() : 0;
   }
 
   /**

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/volume/VolumeInfoMetrics.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/volume/VolumeInfoMetrics.java
@@ -104,8 +104,8 @@ public class VolumeInfoMetrics {
    */
   @Metric("Returns the Used space")
   public long getUsed() {
-    return volume.getVolumeInfo() != null ?
-            volume.getVolumeInfo().getScmUsed() : 0;
+    return volume.getVolumeInfo().map(VolumeInfo::getScmUsed)
+            .orElse(0L);
   }
 
   /**
@@ -113,8 +113,8 @@ public class VolumeInfoMetrics {
    */
   @Metric("Returns the Available space")
   public long getAvailable() {
-    return volume.getVolumeInfo() != null ?
-            volume.getVolumeInfo().getAvailable() : 0;
+    return volume.getVolumeInfo().map(VolumeInfo::getAvailable)
+            .orElse(0L);
   }
 
   /**
@@ -122,8 +122,8 @@ public class VolumeInfoMetrics {
    */
   @Metric("Fetches the Reserved Space")
   public long getReserved() {
-    return volume.getVolumeInfo() != null ?
-            volume.getVolumeInfo().getReservedInBytes() : 0;
+    return volume.getVolumeInfo().map(VolumeInfo::getReservedInBytes)
+            .orElse(0L);
   }
 
   /**

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/volume/TestHddsVolume.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/volume/TestHddsVolume.java
@@ -369,6 +369,23 @@ public class TestHddsVolume {
     assertEquals(0, DatanodeStoreCache.getInstance().size());
   }
 
+  @Test
+  public void testFailedVolumeSpace() throws IOException {
+
+    // Build failed volume
+    HddsVolume volume = volumeBuilder.failedVolume(true).build();
+
+    // In case of failed volume all stats should return 0.
+    assertEquals(0, volume.getVolumeInfoStats().getUsed());
+    assertEquals(0, volume.getVolumeInfoStats().getAvailable());
+    assertEquals(0, volume.getVolumeInfoStats().getCapacity());
+    assertEquals(0, volume.getVolumeInfoStats().getReserved());
+    assertEquals(0, volume.getVolumeInfoStats().getTotalCapacity());
+
+    // Shutdown the volume.
+    volume.shutdown();
+  }
+
   private MutableVolumeSet createDbVolumeSet() throws IOException {
     File dbVolumeDir = folder.newFolder();
     CONF.set(OzoneConfigKeys.HDDS_DATANODE_CONTAINER_DB_DIR,

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/volume/TestHddsVolume.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/volume/TestHddsVolume.java
@@ -371,19 +371,21 @@ public class TestHddsVolume {
 
   @Test
   public void testFailedVolumeSpace() throws IOException {
-
     // Build failed volume
     HddsVolume volume = volumeBuilder.failedVolume(true).build();
+    VolumeInfoMetrics volumeInfoMetrics = volume.getVolumeInfoStats();
 
-    // In case of failed volume all stats should return 0.
-    assertEquals(0, volume.getVolumeInfoStats().getUsed());
-    assertEquals(0, volume.getVolumeInfoStats().getAvailable());
-    assertEquals(0, volume.getVolumeInfoStats().getCapacity());
-    assertEquals(0, volume.getVolumeInfoStats().getReserved());
-    assertEquals(0, volume.getVolumeInfoStats().getTotalCapacity());
-
-    // Shutdown the volume.
-    volume.shutdown();
+    try {
+      // In case of failed volume all stats should return 0.
+      assertEquals(0, volumeInfoMetrics.getUsed());
+      assertEquals(0, volumeInfoMetrics.getAvailable());
+      assertEquals(0, volumeInfoMetrics.getCapacity());
+      assertEquals(0, volumeInfoMetrics.getReserved());
+      assertEquals(0, volumeInfoMetrics.getTotalCapacity());
+    } finally {
+      // Shutdown the volume.
+      volume.shutdown();
+    }
   }
 
   private MutableVolumeSet createDbVolumeSet() throws IOException {

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/volume/TestReservedVolumeSpace.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/volume/TestReservedVolumeSpace.java
@@ -66,13 +66,15 @@ public class TestReservedVolumeSpace {
 
     long volumeCapacity = hddsVolume.getCapacity();
     //Gets the actual total capacity
-    long totalCapacity = hddsVolume.getVolumeInfo()
+    long totalCapacity = hddsVolume.getVolumeInfo().get()
         .getUsageForTesting().getCapacity();
-    long reservedCapacity = hddsVolume.getVolumeInfo().getReservedInBytes();
+    long reservedCapacity = hddsVolume.getVolumeInfo().get()
+            .getReservedInBytes();
     //Volume Capacity with Reserved
     long volumeCapacityReserved = totalCapacity - reservedCapacity;
 
-    long reservedFromVolume = hddsVolume.getVolumeInfo().getReservedInBytes();
+    long reservedFromVolume = hddsVolume.getVolumeInfo().get()
+            .getReservedInBytes();
     long reservedCalculated = (long) Math.ceil(totalCapacity * percentage);
 
     Assert.assertEquals(reservedFromVolume, reservedCalculated);
@@ -92,7 +94,8 @@ public class TestReservedVolumeSpace {
         folder.getRoot() + ":500B");
     HddsVolume hddsVolume = volumeBuilder.conf(conf).build();
 
-    long reservedFromVolume = hddsVolume.getVolumeInfo().getReservedInBytes();
+    long reservedFromVolume = hddsVolume.getVolumeInfo().get()
+            .getReservedInBytes();
     Assert.assertEquals(reservedFromVolume, 500);
   }
 
@@ -101,7 +104,8 @@ public class TestReservedVolumeSpace {
     OzoneConfiguration conf = new OzoneConfiguration();
     HddsVolume hddsVolume = volumeBuilder.conf(conf).build();
 
-    long reservedFromVolume = hddsVolume.getVolumeInfo().getReservedInBytes();
+    long reservedFromVolume = hddsVolume.getVolumeInfo().get()
+            .getReservedInBytes();
     Assert.assertEquals(reservedFromVolume, 0);
   }
 
@@ -114,10 +118,11 @@ public class TestReservedVolumeSpace {
         temp.getRoot() + ":500B");
     HddsVolume hddsVolume = volumeBuilder.conf(conf).build();
 
-    long reservedFromVolume = hddsVolume.getVolumeInfo().getReservedInBytes();
+    long reservedFromVolume = hddsVolume.getVolumeInfo().get()
+            .getReservedInBytes();
     Assert.assertNotEquals(reservedFromVolume, 0);
 
-    long totalCapacity = hddsVolume.getVolumeInfo()
+    long totalCapacity = hddsVolume.getVolumeInfo().get()
         .getUsageForTesting().getCapacity();
     float percentage = conf.getFloat(HDDS_DATANODE_DIR_DU_RESERVED_PERCENT,
         HDDS_DATANODE_DIR_DU_RESERVED_PERCENT_DEFAULT);
@@ -134,7 +139,8 @@ public class TestReservedVolumeSpace {
         folder.getRoot() + ":500C");
     HddsVolume hddsVolume1 = volumeBuilder.conf(conf1).build();
 
-    long reservedFromVolume1 = hddsVolume1.getVolumeInfo().getReservedInBytes();
+    long reservedFromVolume1 = hddsVolume1.getVolumeInfo().get()
+            .getReservedInBytes();
     Assert.assertEquals(reservedFromVolume1, 0);
 
     OzoneConfiguration conf2 = new OzoneConfiguration();
@@ -143,7 +149,8 @@ public class TestReservedVolumeSpace {
     conf2.set(HDDS_DATANODE_DIR_DU_RESERVED_PERCENT, "20");
     HddsVolume hddsVolume2 = volumeBuilder.conf(conf2).build();
 
-    long reservedFromVolume2 = hddsVolume2.getVolumeInfo().getReservedInBytes();
+    long reservedFromVolume2 = hddsVolume2.getVolumeInfo().get()
+            .getReservedInBytes();
     Assert.assertEquals(reservedFromVolume2, 0);
   }
 }

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/volume/TestVolumeSet.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/volume/TestVolumeSet.java
@@ -219,7 +219,8 @@ public class TestVolumeSet {
 
     // Verify that volume usage can be queried during shutdown.
     for (StorageVolume volume : volumesList) {
-      Assert.assertNotNull(volume.getVolumeInfo().getUsageForTesting());
+      Assert.assertNotNull(volume.getVolumeInfo().get()
+              .getUsageForTesting());
       volume.getAvailable();
     }
   }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/TestMiniOzoneCluster.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/TestMiniOzoneCluster.java
@@ -389,7 +389,7 @@ public class TestMiniOzoneCluster {
 
     volumeList.forEach(storageVolume -> Assert.assertEquals(
             (long) StorageSize.parse(reservedSpace).getValue(),
-            storageVolume.getVolumeInfo().getReservedInBytes()));
+            storageVolume.getVolumeInfo().get().getReservedInBytes()));
   }
 
   private static void assertDetailsEquals(DatanodeDetails expected,


### PR DESCRIPTION
## What changes were proposed in this pull request?

In case of failed volume, VolumeInfo object is assigned with null. While using VolumeInfo object we need to validate before accessing it.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-8054
https://issues.apache.org/jira/browse/HDDS-8051
https://issues.apache.org/jira/browse/HDDS-8052
https://issues.apache.org/jira/browse/HDDS-8053

## How was this patch tested?

Code has been built locally and manually tested.
