### PR TITLE
HDDS-8075. ECReconstructionCoordinatorTask.runTask should catch Exception instead of IOException

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/ec/reconstruction/ECReconstructionCoordinatorTask.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/ec/reconstruction/ECReconstructionCoordinatorTask.java
@@ -22,7 +22,6 @@ import org.apache.hadoop.util.Time;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.IOException;
 import java.util.Objects;
 
 /**
@@ -74,7 +73,7 @@ public class ECReconstructionCoordinatorTask
       long elapsed = Time.monotonicNow() - start;
       LOG.info("Completed {} in {} ms", reconstructionCommandInfo, elapsed);
       setStatus(Status.DONE);
-    } catch (IOException e) {
+    } catch (Exception e) {
       long elapsed = Time.monotonicNow() - start;
       LOG.warn("Failed {} after {} ms", reconstructionCommandInfo, elapsed, e);
       setStatus(Status.FAILED);


### PR DESCRIPTION
## What changes were proposed in this pull request?

ECReconstructionCoordinatorTask.runTask() catches IOException, but any RuntimeExceptions fall threw the handler and are not logged correctly.

The handler should catch Exception to ensure any Runtime Exception caused by precondition checks are caught and handled too.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-8075

## How was this patch tested?

No tests added.
