### PR TITLE
HDDS-6802. Pipeline list SubCommand should provide a JSON output option

### DIFF
--- a/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/pipeline/ListPipelinesSubcommand.java
+++ b/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/pipeline/ListPipelinesSubcommand.java
@@ -28,11 +28,14 @@ import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.scm.cli.ScmSubcommand;
 import org.apache.hadoop.hdds.scm.client.ScmClient;
 import org.apache.hadoop.hdds.scm.pipeline.Pipeline;
+import org.apache.hadoop.hdds.server.JsonUtils;
 import picocli.CommandLine;
 
 import java.io.IOException;
+import java.util.List;
 import java.util.Optional;
 import java.util.function.Predicate;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 /**
@@ -68,6 +71,11 @@ public class ListPipelinesSubcommand extends ScmSubcommand {
       defaultValue = "")
   private String state;
 
+  @CommandLine.Option(names = { "--json" },
+            defaultValue = "false",
+            description = "Format output as JSON")
+    private boolean json;
+
   @Override
   public void execute(ScmClient scmClient) throws IOException {
     Optional<Predicate<? super Pipeline>> replicationFilter =
@@ -81,7 +89,14 @@ public class ListPipelinesSubcommand extends ScmSubcommand {
       stream = stream.filter(p -> p.getPipelineState().toString()
           .compareToIgnoreCase(state) == 0);
     }
-    stream.forEach(System.out::println);
+
+    if (json) {
+      List<Pipeline> pipelineList = stream.collect(Collectors.toList());
+      System.out.print(
+              JsonUtils.toJsonStringWithDefaultPrettyPrinter(pipelineList));
+    } else {
+      stream.forEach(System.out::println);
+    }
   }
 
   private Optional<Predicate<? super Pipeline>> getReplicationFilter() {


### PR DESCRIPTION
## What changes were proposed in this pull request?

Currently the Pipeline list SubCommand provides a list of pipelines on the console, but it does not provide a JSON output option. We should allow for JSON output to ensure compatibility and so the output can be consumed programmatically.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-6802

## How was this patch tested?

This patch was tested using docker-compose. Here is the output -

```
bash-4.2$ ozone admin pipeline list --json | more
[ {
  "id" : {
    "id" : "ec954f5b-355d-477c-9905-09718d77da9c"
  },
  "replicationConfig" : {
    "replicationFactor" : "ONE",
    "requiredNodes" : 1,
    "replicationType" : "RATIS"
  },
  "nodesInOrder" : [ {
    "level" : 0,
    "cost" : 0,
    "uuid" : "955f219c-e422-415b-9f83-0431588552b4",
    "uuidString" : "955f219c-e422-415b-9f83-0431588552b4",
    "ipAddress" : "172.18.0.11",
    "hostName" : "ozone_datanode_6.ozone_default",
    "ports" : [ {
      "name" : "REPLICATION",
      "value" : 9886
    }, {
      "name" : "RATIS",
      "value" : 9858
    }, {
      "name" : "RATIS_ADMIN",
      "value" : 9857
    }, {
      "name" : "RATIS_SERVER",
      "value" : 9856
    }, {
      "name" : "RATIS_DATASTREAM",
      "value" : 9855
    }, {
      "name" : "STANDALONE",
      "value" : 9859
    } ],
    "setupTime" : 0,
    "persistedOpState" : "IN_SERVICE",
    "persistedOpStateExpiryEpochSec" : 0,
    "initialVersion" : 0,
    "currentVersion" : 1,
    "signature" : 131170440,
    "decomissioned" : false,
    "networkLocation" : "/default-rack",
    "networkFullPath" : "/default-rack/955f219c-e422-415b-9f83-0431588552b4",
    "numOfLeaves" : 1,
    "networkName" : "955f219c-e422-415b-9f83-0431588552b4"
  } ],
  "leaderId" : "955f219c-e422-415b-9f83-0431588552b4",
  "creationTimestamp" : "2023-03-03T11:39:57.478Z",
  "suggestedLeaderId" : "955f219c-e422-415b-9f83-0431588552b4",
  "empty" : false,
  "open" : true,
  "type" : "RATIS",
--More--
```