### PR TITLE
HDDS-8078. Github CI: Allow PR title starting with Revert

### DIFF
--- a/dev-support/ci/pr_title_check.bats
+++ b/dev-support/ci/pr_title_check.bats
@@ -69,7 +69,7 @@ load bats-assert/load.bash
 
   # starts with 'Revert "'
   run dev-support/ci/pr_title_check.sh 'Revert "HDDS-1234. Hello World"'
-  assert_output 'OK'
+  assert_output -e 'OK$'
 }
 
 @test "check illegal PR title examples" {

--- a/dev-support/ci/pr_title_check.bats
+++ b/dev-support/ci/pr_title_check.bats
@@ -136,4 +136,8 @@ load bats-assert/load.bash
   # Invalid revert title 5
   run dev-support/ci/pr_title_check.sh 'Revert: "HDDS-1234. Hello World"'
   assert_output 'Fail: must start with HDDS'
+
+  # Invalid revert title 6
+  run dev-support/ci/pr_title_check.sh 'Revert "Hello World"'
+  assert_output -e 'Fail: must start with HDDS$'
 }

--- a/dev-support/ci/pr_title_check.bats
+++ b/dev-support/ci/pr_title_check.bats
@@ -66,6 +66,10 @@ load bats-assert/load.bash
   # case in summary does not matter
   run dev-support/ci/pr_title_check.sh 'HDDS-1234. hello world in lower case'
   assert_output 'OK'
+
+  # starts with 'Revert "'
+  run dev-support/ci/pr_title_check.sh 'Revert "HDDS-1234. Hello World"'
+  assert_output 'OK'
 }
 
 @test "check illegal PR title examples" {
@@ -112,4 +116,24 @@ load bats-assert/load.bash
   # double spaces in summary
   run dev-support/ci/pr_title_check.sh 'HDDS-1234. Hello  World'
   assert_output 'Fail: two consecutive spaces'
+
+  # Invalid revert title 1
+  run dev-support/ci/pr_title_check.sh 'revert "HDDS-1234. Hello World'
+  assert_output 'Fail: must start with HDDS'
+
+  # Invalid revert title 2
+  run dev-support/ci/pr_title_check.sh 'Revert"HDDS-1234. Hello World'
+  assert_output 'Fail: must start with HDDS'
+
+  # Invalid revert title 3
+  run dev-support/ci/pr_title_check.sh 'Revert HDDS-1234. Hello World'
+  assert_output 'Fail: must start with HDDS'
+
+  # Invalid revert title 4
+  run dev-support/ci/pr_title_check.sh 'Revert: HDDS-1234. Hello World'
+  assert_output 'Fail: must start with HDDS'
+
+  # Invalid revert title 5
+  run dev-support/ci/pr_title_check.sh 'Revert: "HDDS-1234. Hello World"'
+  assert_output 'Fail: must start with HDDS'
 }

--- a/dev-support/ci/pr_title_check.sh
+++ b/dev-support/ci/pr_title_check.sh
@@ -37,6 +37,10 @@ assertNotMatch() {
 
 # strip starting 'Revert "', if any
 TITLE=${TITLE#Revert \"}
+if [ "$1" != "${TITLE}" ]; then
+  echo "Leading 'Revert \"' in the PR title has been stripped solely for this title checking purpose. Performing actual title check on:"
+  echo "${TITLE}"
+fi
 
 assertMatch    '^HDDS'                             'Fail: must start with HDDS'
 assertMatch    '^HDDS-'                            'Fail: missing dash in Jira'

--- a/dev-support/ci/pr_title_check.sh
+++ b/dev-support/ci/pr_title_check.sh
@@ -35,6 +35,9 @@ assertNotMatch() {
     fi
 }
 
+# strip starting 'Revert "', if any
+TITLE=${TITLE#Revert \"}
+
 assertMatch    '^HDDS'                             'Fail: must start with HDDS'
 assertMatch    '^HDDS-'                            'Fail: missing dash in Jira'
 assertNotMatch '^HDDS-0'                           'Fail: leading zero in Jira'


### PR DESCRIPTION
## What changes were proposed in this pull request?

Allow PR title starting with `Revert "` to pass the PR CI title check.

Support the default title generated by Github's built-in revert PR feature.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-8078

## How was this patch tested?

- Apache CI
- Added test cases
- CI run on a fork with `Revert "` in PR title has passed:
  - https://github.com/smengcl/hadoop-ozone/actions/runs/4329335098/jobs/7559813493