### PR TITLE
HDDS-8068. Exception: JMXJsonServlet, getting attribute RatisRoles of Hadoop:service=OzoneManager.

### DIFF
--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
@@ -2915,6 +2915,10 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
     if (isRatisEnabled) {
       try {
         leaderId = omRatisServer.getLeader();
+        if (leaderId == null) {
+          LOG.error("No leader found");
+          return "Exception: Not a leader";
+        }
         serviceList = getServiceList();
       } catch (IOException e) {
         LOG.error("IO-Exception Occurred", e);

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/OzoneManagerRatisServer.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/OzoneManagerRatisServer.java
@@ -736,13 +736,15 @@ public final class OzoneManagerRatisServer {
   public RaftPeer getLeader() {
     try {
       RaftServer.Division division = server.getDivision(raftGroupId);
-      if (division.getInfo().isLeader()) {
-        return division.getPeer();
-      } else {
-        ByteString leaderId = division.getInfo().getRoleInfoProto()
-            .getFollowerInfo().getLeaderInfo().getId().getId();
-        return leaderId.isEmpty() ? null :
-            division.getRaftConf().getPeer(RaftPeerId.valueOf(leaderId));
+      if (division != null) {
+        if (division.getInfo().isLeader()) {
+          return division.getPeer();
+        } else {
+          ByteString leaderId = division.getInfo().getRoleInfoProto()
+                  .getFollowerInfo().getLeaderInfo().getId().getId();
+          return leaderId.isEmpty() ? null :
+                  division.getRaftConf().getPeer(RaftPeerId.valueOf(leaderId));
+        }
       }
     } catch (IOException e) {
       // In this case we return not a leader.


### PR DESCRIPTION

## What changes were proposed in this pull request?

While getting RatisRoles, In some cases when there is an exception we don't get leaderID. In this case we should return error to the caller.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-8068

## How was this patch tested?

Code has been built locally and manually tested.
