### PR TITLE
HDDS-8087. Intermittent crash in TestHddsDatanodeService

### DIFF
--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/TestHddsDatanodeService.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/TestHddsDatanodeService.java
@@ -31,6 +31,7 @@ import org.junit.jupiter.api.AfterEach;
 
 import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_BLOCK_TOKEN_ENABLED;
 import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_CONTAINER_TOKEN_ENABLED;
+import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_NAMES;
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_SECURITY_ENABLED_KEY;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -52,6 +53,7 @@ public class TestHddsDatanodeService {
     testDir = GenericTestUtils.getRandomizedTestDir();
     conf = new OzoneConfiguration();
     conf.set(HddsConfigKeys.OZONE_METADATA_DIRS, testDir.getPath());
+    conf.set(OZONE_SCM_NAMES, "localhost");
     conf.setClass(OzoneConfigKeys.HDDS_DATANODE_PLUGINS_KEY, MockService.class,
         ServicePlugin.class);
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

`TestHddsDatanodeService` intermittently exits with:

```
[Datanode State Machine Task Thread - 0] ERROR datanode.InitDatanodeState (InitDatanodeState.java:call(84)) - Failed to get SCM addresses: ozone.scm.names need to be a set of valid DNS names or IP addresses. Empty address list found.
[Datanode State Machine Daemon Thread] ERROR statemachine.StateContext (StateContext.java:execute(675)) - Critical error occurred in StateMachine, setting shutDownMachine
[Datanode State Machine Daemon Thread] ERROR statemachine.DatanodeStateMachine (DatanodeStateMachine.java:startStateMachineThread(334)) - DatanodeStateMachine Shutdown due to an critical error
[Datanode State Machine Daemon Thread] INFO  util.ExitUtil (ExitUtil.java:terminate(210)) - Exiting with status 1: ExitException
```

Since the test is fast, the background thread usually does not get a chance to trigger the exit.  It can be reproduced consistently by adding some sleep after:

https://github.com/apache/ozone/blob/888c6dca5b9c6cc3690b063666fa67a39f1b2a69/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/TestHddsDatanodeService.java#L77

https://issues.apache.org/jira/browse/HDDS-8087

## How was this patch tested?

Passed locally with 1 second sleep, 100 repetitions:

```
Tests run: 100, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 126.957 s - in org.apache.hadoop.ozone.TestHddsDatanodeService
```

Regular CI:
https://github.com/adoroszlai/hadoop-ozone/actions/runs/4343223145