### PR TITLE
HDDS-8086. Bump snakeyaml from 1.33 to 2.0

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/net/NodeSchemaLoader.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/net/NodeSchemaLoader.java
@@ -18,6 +18,7 @@
 package org.apache.hadoop.hdds.scm.net;
 
 import org.apache.commons.io.FilenameUtils;
+import org.apache.hadoop.hdds.server.YamlUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.w3c.dom.Document;
@@ -42,7 +43,6 @@ import java.util.List;
 import java.util.Map;
 
 import  org.apache.hadoop.hdds.scm.net.NodeSchema.LayerType;
-import org.yaml.snakeyaml.Yaml;
 
 import static org.apache.commons.collections.EnumerationUtils.toList;
 
@@ -227,10 +227,9 @@ public final class NodeSchemaLoader {
     NodeSchemaLoadResult finalSchema;
 
     try {
-      Yaml yaml = new Yaml();
       NodeSchema nodeTree;
 
-      nodeTree = yaml.loadAs(schemaFile, NodeSchema.class);
+      nodeTree = YamlUtils.loadAs(schemaFile, NodeSchema.class);
 
       List<NodeSchema> schemaList = new ArrayList<>();
       if (nodeTree.getType() != LayerType.ROOT) {

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/server/YamlUtils.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/server/YamlUtils.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hdds.server;
+
+import org.yaml.snakeyaml.LoaderOptions;
+import org.yaml.snakeyaml.Yaml;
+import org.yaml.snakeyaml.inspector.TagInspector;
+import org.yaml.snakeyaml.inspector.TrustedPrefixesTagInspector;
+
+import java.io.InputStream;
+import java.util.Arrays;
+
+/**
+ * YAML utilities.
+ */
+public final class YamlUtils {
+
+  private static final Yaml LOADER = getYamlForLoad();
+
+  private YamlUtils() {
+    // no instances
+  }
+
+  public static <T> T loadAs(InputStream input, Class<? super T> type) {
+    return LOADER.loadAs(input, type);
+  }
+
+  private static Yaml getYamlForLoad() {
+    TagInspector tags = new TrustedPrefixesTagInspector(Arrays.asList(
+        "org.apache.hadoop.ozone.", "org.apache.hadoop.hdds."));
+    LoaderOptions loaderOptions = new LoaderOptions();
+    loaderOptions.setTagInspector(tags);
+    return new Yaml(loaderOptions);
+  }
+}

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/helpers/DatanodeIdYaml.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/helpers/DatanodeIdYaml.java
@@ -32,6 +32,7 @@ import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.collections.MapUtils;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
+import org.apache.hadoop.hdds.server.YamlUtils;
 import org.yaml.snakeyaml.DumperOptions;
 import org.yaml.snakeyaml.Yaml;
 
@@ -71,11 +72,10 @@ public final class DatanodeIdYaml {
       throws IOException {
     DatanodeDetails datanodeDetails;
     try (FileInputStream inputFileStream = new FileInputStream(path)) {
-      Yaml yaml = new Yaml();
       DatanodeDetailsYaml datanodeDetailsYaml;
       try {
         datanodeDetailsYaml =
-            yaml.loadAs(inputFileStream, DatanodeDetailsYaml.class);
+            YamlUtils.loadAs(inputFileStream, DatanodeDetailsYaml.class);
       } catch (Exception e) {
         throw new IOException("Unable to parse yaml file.", e);
       }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/impl/ContainerDataYaml.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/impl/ContainerDataYaml.java
@@ -50,6 +50,8 @@ import static org.apache.hadoop.ozone.container.keyvalue
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.yaml.snakeyaml.DumperOptions;
+import org.yaml.snakeyaml.LoaderOptions;
 import org.yaml.snakeyaml.Yaml;
 import org.yaml.snakeyaml.constructor.AbstractConstruct;
 import org.yaml.snakeyaml.constructor.SafeConstructor;
@@ -217,6 +219,7 @@ public final class ContainerDataYaml {
     private List<String> yamlFields;
 
     ContainerDataRepresenter(List<String> yamlFields) {
+      super(new DumperOptions());
       this.yamlFields = yamlFields;
     }
 
@@ -257,6 +260,7 @@ public final class ContainerDataYaml {
    */
   private static class ContainerDataConstructor extends SafeConstructor {
     ContainerDataConstructor() {
+      super(new LoaderOptions());
       //Adding our own specific constructors for tags.
       // When a new Container type is added, we need to add yamlConstructor
       // for that

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/helpers/TestContainerUtils.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/helpers/TestContainerUtils.java
@@ -91,7 +91,6 @@ public class TestContainerUtils {
 
     // Read should return an empty value if file doesn't exist
     File nonExistFile = new File(tempDir, "non_exist.id");
-    nonExistFile.delete();
     assertThrows(IOException.class,
         () -> ContainerUtils.readDatanodeDetailsFrom(nonExistFile));
 
@@ -113,11 +112,10 @@ public class TestContainerUtils {
     assertWriteRead(tempDir, id1);
   }
 
-  private static void assertWriteRead(File tempDir, DatanodeDetails details)
-      throws IOException {
+  private static void assertWriteRead(@TempDir File tempDir,
+      DatanodeDetails details) throws IOException {
     // Write a single ID to the file and read it out
     File file = new File(tempDir, "valid-values.id");
-    file.delete();
     ContainerUtils.writeDatanodeDetailsTo(details, file);
 
     DatanodeDetails read = ContainerUtils.readDatanodeDetailsFrom(file);
@@ -128,7 +126,6 @@ public class TestContainerUtils {
 
   private void createMalformedIDFile(File malformedFile)
       throws IOException {
-    malformedFile.delete();
     DatanodeDetails id = randomDatanodeDetails();
     ContainerUtils.writeDatanodeDetailsTo(id, malformedFile);
 

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/helpers/TestContainerUtils.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/helpers/TestContainerUtils.java
@@ -17,22 +17,32 @@
  */
 package org.apache.hadoop.ozone.container.common.helpers;
 
+import org.apache.commons.lang3.RandomUtils;
+import org.apache.hadoop.hdds.protocol.DatanodeDetails;
 import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos;
 import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.ContainerCommandRequestProto;
 import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.ContainerCommandResponseProto;
+import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.hdds.scm.ByteStringConversion;
 import org.apache.hadoop.ozone.common.ChunkBuffer;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
+import java.io.File;
+import java.io.FileOutputStream;
 import java.io.IOException;
 import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.apache.hadoop.hdds.protocol.DatanodeDetails.Port;
+import static org.apache.hadoop.hdds.protocol.MockDatanodeDetails.randomDatanodeDetails;
 import static org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.Type.ReadChunk;
 import static org.apache.hadoop.hdds.scm.protocolPB.ContainerCommandResponseBuilders.getReadChunkResponse;
 import static org.apache.hadoop.hdds.HddsUtils.processForDebug;
 import static org.apache.hadoop.ozone.container.ContainerTestHelper.getDummyCommandRequestProto;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
  * Test for {@link ContainerUtils}.
@@ -66,5 +76,72 @@ public class TestContainerUtils {
 
     assertEquals(containerId,
         ContainerUtils.retrieveContainerIdFromTarName(tarName));
+  }
+
+  @Test
+  public void testDatanodeIDPersistent(@TempDir File tempDir) throws Exception {
+    // Generate IDs for testing
+    DatanodeDetails id1 = randomDatanodeDetails();
+    id1.setPort(DatanodeDetails.newPort(Port.Name.STANDALONE, 1));
+    assertWriteRead(tempDir, id1);
+
+    // Add certificate serial  id.
+    id1.setCertSerialId("" + RandomUtils.nextLong());
+    assertWriteRead(tempDir, id1);
+
+    // Read should return an empty value if file doesn't exist
+    File nonExistFile = new File(tempDir, "non_exist.id");
+    nonExistFile.delete();
+    assertThrows(IOException.class,
+        () -> ContainerUtils.readDatanodeDetailsFrom(nonExistFile));
+
+    // Read should fail if the file is malformed
+    File malformedFile = new File(tempDir, "malformed.id");
+    createMalformedIDFile(malformedFile);
+    assertThrows(IOException.class,
+        () -> ContainerUtils.readDatanodeDetailsFrom(malformedFile));
+
+    // Test upgrade scenario - protobuf file instead of yaml
+    File protoFile = new File(tempDir, "valid-proto.id");
+    try (FileOutputStream out = new FileOutputStream(protoFile)) {
+      HddsProtos.DatanodeDetailsProto proto = id1.getProtoBufMessage();
+      proto.writeTo(out);
+    }
+    assertDetailsEquals(id1, ContainerUtils.readDatanodeDetailsFrom(protoFile));
+
+    id1.setInitialVersion(1);
+    assertWriteRead(tempDir, id1);
+  }
+
+  private static void assertWriteRead(File tempDir, DatanodeDetails details)
+      throws IOException {
+    // Write a single ID to the file and read it out
+    File file = new File(tempDir, "valid-values.id");
+    file.delete();
+    ContainerUtils.writeDatanodeDetailsTo(details, file);
+
+    DatanodeDetails read = ContainerUtils.readDatanodeDetailsFrom(file);
+
+    assertDetailsEquals(details, read);
+    assertEquals(details.getCurrentVersion(), read.getCurrentVersion());
+  }
+
+  private void createMalformedIDFile(File malformedFile)
+      throws IOException {
+    malformedFile.delete();
+    DatanodeDetails id = randomDatanodeDetails();
+    ContainerUtils.writeDatanodeDetailsTo(id, malformedFile);
+
+    try (FileOutputStream out = new FileOutputStream(malformedFile)) {
+      out.write("malformed".getBytes(StandardCharsets.UTF_8));
+    }
+  }
+
+  private static void assertDetailsEquals(DatanodeDetails expected,
+      DatanodeDetails actual) {
+    assertEquals(expected, actual);
+    assertEquals(expected.getCertSerialId(), actual.getCertSerialId());
+    assertEquals(expected.getProtoBufMessage(), actual.getProtoBufMessage());
+    assertEquals(expected.getInitialVersion(), actual.getInitialVersion());
   }
 }

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/helpers/TestDatanodeIdYaml.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/helpers/TestDatanodeIdYaml.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.ozone.container.common.helpers;
+
+import org.apache.hadoop.hdds.protocol.DatanodeDetails;
+import org.apache.hadoop.hdds.protocol.MockDatanodeDetails;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.File;
+import java.io.IOException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Tests for {@link DatanodeIdYaml}.
+ */
+class TestDatanodeIdYaml {
+
+  @Test
+  void testWriteRead(@TempDir File dir) throws IOException {
+    DatanodeDetails original = MockDatanodeDetails.randomDatanodeDetails();
+    File file = new File(dir, "datanode.yaml");
+
+    DatanodeIdYaml.createDatanodeIdFile(original, file);
+    DatanodeDetails read = DatanodeIdYaml.readDatanodeIdFile(file);
+
+    assertEquals(original, read);
+    assertEquals(original.toDebugString(), read.toDebugString());
+  }
+
+}

--- a/pom.xml
+++ b/pom.xml
@@ -285,7 +285,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
     <proto-backwards-compatibility.version>1.0.7</proto-backwards-compatibility.version>
 
     <swagger-annotations-version>1.5.4</swagger-annotations-version>
-    <snakeyaml.version>1.33</snakeyaml.version>
+    <snakeyaml.version>2.0</snakeyaml.version>
     <sonar.java.binaries>${basedir}/target/classes</sonar.java.binaries>
 
     <aspectj.version>1.9.7</aspectj.version>


### PR DESCRIPTION
## What changes were proposed in this pull request?

* Upgrade SnakeYaml to 2.0,
  * which disabled global tags by default for security, so we need to explicitly allow HDDS/Ozone classes.  The logic is centralized in `YamlUtils`.
* Add unit test for `DatanodeIdYaml`, because previously serialization problem was found only in acceptance/integration tests.
* Move related test case from `TestMiniOzoneCluster` to `TestContainerUtils`, as it is a unit test, not integration one.

Thanks @rohit-kb for the initial patch.

https://issues.apache.org/jira/browse/HDDS-8086

## How was this patch tested?

https://github.com/adoroszlai/hadoop-ozone/actions/runs/4342661934