### PR TITLE
HDDS-8090. When getBlock from a datanode fails, retry other datanodes.

### DIFF
--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/storage/BlockInputStream.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/storage/BlockInputStream.java
@@ -269,7 +269,7 @@ public class BlockInputStream extends BlockExtendedInputStream {
     final List<ChunkInfo> chunks = b.getBlockData().getChunksList();
     for (int i = 0; i < chunks.size(); i++) {
       final ChunkInfo c = chunks.get(i);
-      if (c.getLen() < 0) {
+      if (c.getLen() <= 0) {
         throw new IOException("Failed to get chunkInfo["
             + i + "]: len == " + c.getLen());
       }

--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/storage/BlockInputStream.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/storage/BlockInputStream.java
@@ -258,7 +258,7 @@ public class BlockInputStream extends BlockExtendedInputStream {
   }
 
   private static final List<CheckedBiFunction> VALIDATORS
-      = ContainerProtocolCalls.getValidatorList(
+      = ContainerProtocolCalls.toValidatorList(
           (request, response) -> validate(response));
 
   static void validate(ContainerCommandResponseProto response)

--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/storage/BlockInputStream.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/storage/BlockInputStream.java
@@ -257,8 +257,9 @@ public class BlockInputStream extends BlockExtendedInputStream {
     }
   }
 
-  static final List<CheckedBiFunction> VALIDATORS = ContainerProtocolCalls
-      .getValidatorList((request, response) -> validate(response));
+  private static final List<CheckedBiFunction> VALIDATORS
+      = ContainerProtocolCalls.getValidatorList(
+          (request, response) -> validate(response));
 
   static void validate(ContainerCommandResponseProto response)
       throws IOException {

--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/storage/BlockInputStream.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/storage/BlockInputStream.java
@@ -31,6 +31,7 @@ import com.google.common.base.Preconditions;
 import org.apache.hadoop.hdds.client.BlockID;
 import org.apache.hadoop.hdds.client.ReplicationConfig;
 import org.apache.hadoop.hdds.client.StandaloneReplicationConfig;
+import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.ContainerCommandResponseProto;
 import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.ChunkInfo;
 import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.DatanodeBlockID;
 import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.GetBlockResponseProto;
@@ -232,7 +233,6 @@ public class BlockInputStream extends BlockExtendedInputStream {
           .build();
     }
     acquireClient();
-    List<ChunkInfo> chunks;
     try {
       if (LOG.isDebugEnabled()) {
         LOG.debug("Initializing BlockInputStream for get key to access {}",
@@ -249,14 +249,31 @@ public class BlockInputStream extends BlockExtendedInputStream {
         blkIDBuilder.setReplicaIndex(replicaIndex);
       }
       GetBlockResponseProto response = ContainerProtocolCalls
-          .getBlock(xceiverClient, blkIDBuilder.build(), token);
+          .getBlock(xceiverClient, VALIDATORS, blkIDBuilder.build(), token);
 
-      chunks = response.getBlockData().getChunksList();
+      return response.getBlockData().getChunksList();
     } finally {
       releaseClient();
     }
+  }
 
-    return chunks;
+  static final List<CheckedBiFunction> VALIDATORS = ContainerProtocolCalls
+      .getValidatorList((request, response) -> validate(response));
+
+  static void validate(ContainerCommandResponseProto response)
+      throws IOException {
+    if (!response.hasGetBlock()) {
+      throw new IllegalArgumentException("Not GetBlock: response=" + response);
+    }
+    final GetBlockResponseProto b = response.getGetBlock();
+    final List<ChunkInfo> chunks = b.getBlockData().getChunksList();
+    for (int i = 0; i < chunks.size(); i++) {
+      final ChunkInfo c = chunks.get(i);
+      if (c.getLen() < 0) {
+        throw new IOException("Failed to get chunkInfo["
+            + i + "]: len == " + c.getLen());
+      }
+    }
   }
 
   protected void acquireClient() throws IOException {

--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/storage/ChunkInputStream.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/storage/ChunkInputStream.java
@@ -425,7 +425,7 @@ public class ChunkInputStream extends InputStream
     ReadChunkResponseProto readChunkResponse;
 
     List<CheckedBiFunction> validators =
-        ContainerProtocolCalls.getValidatorList(validator);
+        ContainerProtocolCalls.toValidatorList(validator);
 
     readChunkResponse = ContainerProtocolCalls.readChunk(xceiverClient,
         readChunkInfo, blockID, validators, token);

--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/storage/ChunkInputStream.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/storage/ChunkInputStream.java
@@ -425,8 +425,7 @@ public class ChunkInputStream extends InputStream
     ReadChunkResponseProto readChunkResponse;
 
     List<CheckedBiFunction> validators =
-        ContainerProtocolCalls.getValidatorList();
-    validators.add(validator);
+        ContainerProtocolCalls.getValidatorList(validator);
 
     readChunkResponse = ContainerProtocolCalls.readChunk(xceiverClient,
         readChunkInfo, blockID, validators, token);

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/storage/ContainerProtocolCalls.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/storage/ContainerProtocolCalls.java
@@ -20,12 +20,14 @@ package org.apache.hadoop.hdds.scm.storage;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ExecutionException;
+import java.util.function.BiConsumer;
 
 import org.apache.hadoop.hdds.annotation.InterfaceStability;
 import org.apache.hadoop.hdds.client.BlockID;
@@ -67,6 +69,7 @@ import org.apache.hadoop.security.token.Token;
 
 import org.apache.hadoop.security.token.TokenIdentifier;
 import org.apache.ratis.thirdparty.com.google.protobuf.ByteString;
+import org.apache.ratis.util.function.CheckedFunction;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -128,36 +131,72 @@ public final class ContainerProtocolCalls  {
     return response.getListBlock();
   }
 
+  static <T> T tryEachDatanode(Pipeline pipeline,
+      CheckedFunction<DatanodeDetails, T, IOException> op,
+      BiConsumer<DatanodeDetails, IOException> exceptionHandler)
+      throws IOException {
+    final Set<DatanodeDetails> excluded = new HashSet<>();
+    for (; ;) {
+      final DatanodeDetails d = pipeline.getClosestNode(excluded);
+
+      try {
+        return op.apply(d);
+      } catch (IOException e) {
+        excluded.add(d);
+        if (excluded.size() < pipeline.size()) {
+          exceptionHandler.accept(d, e);
+        } else {
+          throw e;
+        }
+      }
+    }
+  }
+
   /**
    * Calls the container protocol to get a container block.
    *
    * @param xceiverClient client to perform call
+   * @param validators functions to validate the response
    * @param datanodeBlockID blockID to identify container
    * @param token a token for this block (may be null)
    * @return container protocol get block response
    * @throws IOException if there is an I/O error while performing the call
    */
   public static GetBlockResponseProto getBlock(XceiverClientSpi xceiverClient,
+      List<CheckedBiFunction> validators,
       DatanodeBlockID datanodeBlockID,
       Token<? extends TokenIdentifier> token) throws IOException {
     GetBlockRequestProto.Builder readBlockRequest = GetBlockRequestProto
         .newBuilder()
         .setBlockID(datanodeBlockID);
-    String id = xceiverClient.getPipeline().getFirstNode().getUuidString();
-
     ContainerCommandRequestProto.Builder builder = ContainerCommandRequestProto
         .newBuilder()
         .setCmdType(Type.GetBlock)
         .setContainerID(datanodeBlockID.getContainerID())
-        .setDatanodeUuid(id)
         .setGetBlock(readBlockRequest);
     if (token != null) {
       builder.setEncodedToken(token.encodeToUrlString());
     }
 
-    ContainerCommandRequestProto request = builder.build();
+    return tryEachDatanode(xceiverClient.getPipeline(),
+        d -> getBlock(xceiverClient, validators, builder, d),
+        (d, e) -> LOG.warn("Failed to getBlock from " + d, e));
+  }
+
+  public static GetBlockResponseProto getBlock(XceiverClientSpi xceiverClient,
+      DatanodeBlockID datanodeBlockID,
+      Token<? extends TokenIdentifier> token) throws IOException {
+    return getBlock(xceiverClient, getValidatorList(), datanodeBlockID, token);
+  }
+
+  private static GetBlockResponseProto getBlock(XceiverClientSpi xceiverClient,
+      List<CheckedBiFunction> validators,
+      ContainerCommandRequestProto.Builder builder,
+      DatanodeDetails datanode) throws IOException {
+    final ContainerCommandRequestProto request = builder
+        .setDatanodeUuid(datanode.getUuidString()).build();
     ContainerCommandResponseProto response =
-        xceiverClient.sendCommand(request, getValidatorList());
+        xceiverClient.sendCommand(request, validators);
     return response.getGetBlock();
   }
 
@@ -285,44 +324,35 @@ public final class ContainerProtocolCalls  {
             .setBlockID(blockID.getDatanodeBlockIDProtobuf())
             .setChunkData(chunk)
             .setReadChunkVersion(ContainerProtos.ReadChunkVersion.V1);
-    final Pipeline pipeline = xceiverClient.getPipeline();
-    final Set<DatanodeDetails> excluded = new HashSet<>();
-    for (; ;) {
-      final DatanodeDetails d = pipeline.getClosestNode(excluded);
-
-      try {
-        return readChunk(xceiverClient, chunk, blockID,
-            validators, token, readChunkRequest, d);
-      } catch (IOException e) {
-        excluded.add(d);
-        if (excluded.size() < pipeline.size()) {
-          LOG.warn(toErrorMessage(chunk, blockID, d), e);
-        } else {
-          throw e;
-        }
-      }
+    ContainerCommandRequestProto.Builder builder =
+        ContainerCommandRequestProto.newBuilder().setCmdType(Type.ReadChunk)
+            .setContainerID(blockID.getContainerID())
+            .setReadChunk(readChunkRequest);
+    if (token != null) {
+      builder.setEncodedToken(token.encodeToUrlString());
     }
+
+    return tryEachDatanode(xceiverClient.getPipeline(),
+        d -> readChunk(xceiverClient, chunk, blockID,
+            validators, builder, d),
+        (d, e) -> LOG.warn(toErrorMessage(chunk, blockID, d), e));
   }
 
   private static ContainerProtos.ReadChunkResponseProto readChunk(
       XceiverClientSpi xceiverClient, ChunkInfo chunk, BlockID blockID,
       List<CheckedBiFunction> validators,
-      Token<? extends TokenIdentifier> token,
-      ReadChunkRequestProto.Builder readChunkRequest,
+      ContainerCommandRequestProto.Builder builder,
       DatanodeDetails d) throws IOException {
     final String id = d.getUuidString();
-    ContainerCommandRequestProto.Builder builder =
-        ContainerCommandRequestProto.newBuilder().setCmdType(Type.ReadChunk)
-            .setContainerID(blockID.getContainerID())
-            .setDatanodeUuid(id).setReadChunk(readChunkRequest);
-    if (token != null) {
-      builder.setEncodedToken(token.encodeToUrlString());
-    }
-    ContainerCommandRequestProto request = builder.build();
+    final ContainerCommandRequestProto request = builder
+        .setDatanodeUuid(d.getUuidString()).build();
     ContainerCommandResponseProto reply =
         xceiverClient.sendCommand(request, validators);
     final ReadChunkResponseProto response = reply.getReadChunk();
     final long readLen = getLen(response);
+    if (readLen == -1) {
+      throw new IOException(toErrorMessage(chunk, blockID, d) + ": eof");
+    }
     if (readLen != chunk.getLen()) {
       throw new IOException(toErrorMessage(chunk, blockID, d)
           + ": readLen=" + readLen);
@@ -687,12 +717,28 @@ public final class ContainerProtocolCalls  {
   }
 
   public static List<CheckedBiFunction> getValidatorList() {
-    List<CheckedBiFunction> validators = new ArrayList<>(1);
+    return VALIDATORS;
+  }
+
+  static final List<CheckedBiFunction> VALIDATORS = createValidatorList();
+
+  private static List<CheckedBiFunction> createValidatorList() {
     CheckedBiFunction<ContainerProtos.ContainerCommandRequestProto,
         ContainerProtos.ContainerCommandResponseProto, IOException>
         validator = (request, response) -> validateContainerResponse(response);
+    return Collections.singletonList(validator);
+  }
+
+  public static List<CheckedBiFunction> getValidatorList(
+      CheckedBiFunction<ContainerCommandRequestProto,
+          ContainerCommandResponseProto, IOException> validator) {
+    final List<CheckedBiFunction> defaults
+        = ContainerProtocolCalls.getValidatorList();
+    final List<CheckedBiFunction> validators
+        = new ArrayList<>(defaults.size() + 1);
+    validators.addAll(defaults);
     validators.add(validator);
-    return validators;
+    return Collections.unmodifiableList(validators);
   }
 
   public static HashMap<DatanodeDetails, GetBlockResponseProto>

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/storage/ContainerProtocolCalls.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/storage/ContainerProtocolCalls.java
@@ -731,7 +731,7 @@ public final class ContainerProtocolCalls  {
     return Collections.singletonList(validator);
   }
 
-  public static List<CheckedBiFunction> getValidatorList(
+  public static List<CheckedBiFunction> toValidatorList(
       CheckedBiFunction<ContainerCommandRequestProto,
           ContainerCommandResponseProto, IOException> validator) {
     final List<CheckedBiFunction> defaults

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/storage/ContainerProtocolCalls.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/storage/ContainerProtocolCalls.java
@@ -343,16 +343,12 @@ public final class ContainerProtocolCalls  {
       List<CheckedBiFunction> validators,
       ContainerCommandRequestProto.Builder builder,
       DatanodeDetails d) throws IOException {
-    final String id = d.getUuidString();
     final ContainerCommandRequestProto request = builder
         .setDatanodeUuid(d.getUuidString()).build();
     ContainerCommandResponseProto reply =
         xceiverClient.sendCommand(request, validators);
     final ReadChunkResponseProto response = reply.getReadChunk();
     final long readLen = getLen(response);
-    if (readLen == -1) {
-      throw new IOException(toErrorMessage(chunk, blockID, d) + ": eof");
-    }
     if (readLen != chunk.getLen()) {
       throw new IOException(toErrorMessage(chunk, blockID, d)
           + ": readLen=" + readLen);

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/io/ECKeyOutputStream.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/io/ECKeyOutputStream.java
@@ -117,7 +117,7 @@ public final class ECKeyOutputStream extends KeyOutputStream {
   }
 
   private ECKeyOutputStream(Builder builder) {
-    super(builder.getClientMetrics());
+    super(builder.getReplicationConfig(), builder.getClientMetrics());
     this.config = builder.getClientConfig();
     this.bufferPool = builder.getByteBufferPool();
     // For EC, cell/chunk size and buffer size can be same for now.

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/scm/TestXceiverClientGrpc.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/scm/TestXceiverClientGrpc.java
@@ -106,6 +106,48 @@ public class TestXceiverClientGrpc {
   }
 
   @Test
+  @Timeout(5)
+  public void testGetBlockRetryAlNodes() {
+    final ArrayList<DatanodeDetails> allDNs = new ArrayList<>(dns);
+    Assertions.assertTrue(allDNs.size() > 1);
+    try(XceiverClientGrpc client = new XceiverClientGrpc(pipeline, conf) {
+      @Override
+      public XceiverClientReply sendCommandAsync(
+          ContainerProtos.ContainerCommandRequestProto request,
+          DatanodeDetails dn) throws IOException {
+        allDNs.remove(dn);
+        throw new IOException("Failed " + dn);
+      }
+    }) {
+      invokeXceiverClientGetBlock(client);
+    } catch (IOException e) {
+      e.printStackTrace();
+    }
+    Assertions.assertEquals(0, allDNs.size());
+  }
+
+  @Test
+  @Timeout(5)
+  public void testReadChunkRetryAllNodes() {
+    final ArrayList<DatanodeDetails> allDNs = new ArrayList<>(dns);
+    Assertions.assertTrue(allDNs.size() > 1);
+    try(XceiverClientGrpc client = new XceiverClientGrpc(pipeline, conf) {
+      @Override
+      public XceiverClientReply sendCommandAsync(
+          ContainerProtos.ContainerCommandRequestProto request,
+          DatanodeDetails dn) throws IOException {
+        allDNs.remove(dn);
+        throw new IOException("Failed " + dn);
+      }
+    }) {
+      invokeXceiverClientReadChunk(client);
+    } catch (IOException e) {
+      e.printStackTrace();
+    }
+    Assertions.assertEquals(0, allDNs.size());
+  }
+
+  @Test
   public void testFirstNodeIsCorrectWithTopologyForCommandTarget()
       throws IOException {
     final Set<DatanodeDetails> seenDNs = new HashSet<>();

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/scm/TestXceiverClientGrpc.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/scm/TestXceiverClientGrpc.java
@@ -92,7 +92,7 @@ public class TestXceiverClientGrpc {
     // the DNs on each call with a new client. This test will timeout if this
     // is not happening.
     while (allDNs.size() > 0) {
-      XceiverClientGrpc client = new XceiverClientGrpc(pipeline, conf) {
+      try (XceiverClientGrpc client = new XceiverClientGrpc(pipeline, conf) {
         @Override
         public XceiverClientReply sendCommandAsync(
             ContainerProtos.ContainerCommandRequestProto request,
@@ -100,8 +100,9 @@ public class TestXceiverClientGrpc {
           allDNs.remove(dn);
           return buildValidResponse();
         }
-      };
-      invokeXceiverClientGetBlock(client);
+      }) {
+        invokeXceiverClientGetBlock(client);
+      }
     }
   }
 
@@ -157,7 +158,7 @@ public class TestXceiverClientGrpc {
     // each time. The logic should always use the sorted node, so we can check
     // only a single DN is ever seen after 100 calls.
     for (int i = 0; i < 100; i++) {
-      XceiverClientGrpc client = new XceiverClientGrpc(pipeline, conf) {
+      try (XceiverClientGrpc client = new XceiverClientGrpc(pipeline, conf) {
         @Override
         public XceiverClientReply sendCommandAsync(
             ContainerProtos.ContainerCommandRequestProto request,
@@ -165,8 +166,9 @@ public class TestXceiverClientGrpc {
           seenDNs.add(dn);
           return buildValidResponse();
         }
-      };
-      invokeXceiverClientGetBlock(client);
+      }) {
+        invokeXceiverClientGetBlock(client);
+      }
     }
     Assertions.assertEquals(1, seenDNs.size());
   }
@@ -177,7 +179,7 @@ public class TestXceiverClientGrpc {
     // DN is seen, indicating the same DN connection is reused.
     for (int i = 0; i < 100; i++) {
       final Set<DatanodeDetails> seenDNs = new HashSet<>();
-      XceiverClientGrpc client = new XceiverClientGrpc(pipeline, conf) {
+      try (XceiverClientGrpc client = new XceiverClientGrpc(pipeline, conf) {
         @Override
         public XceiverClientReply sendCommandAsync(
             ContainerProtos.ContainerCommandRequestProto request,
@@ -185,11 +187,12 @@ public class TestXceiverClientGrpc {
           seenDNs.add(dn);
           return buildValidResponse();
         }
-      };
-      invokeXceiverClientGetBlock(client);
-      invokeXceiverClientGetBlock(client);
-      invokeXceiverClientReadChunk(client);
-      invokeXceiverClientReadSmallFile(client);
+      }) {
+        invokeXceiverClientGetBlock(client);
+        invokeXceiverClientGetBlock(client);
+        invokeXceiverClientReadChunk(client);
+        invokeXceiverClientReadSmallFile(client);
+      }
       Assertions.assertEquals(1, seenDNs.size());
     }
   }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/scm/TestXceiverClientGrpc.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/scm/TestXceiverClientGrpc.java
@@ -110,7 +110,7 @@ public class TestXceiverClientGrpc {
   public void testGetBlockRetryAlNodes() {
     final ArrayList<DatanodeDetails> allDNs = new ArrayList<>(dns);
     Assertions.assertTrue(allDNs.size() > 1);
-    try(XceiverClientGrpc client = new XceiverClientGrpc(pipeline, conf) {
+    try (XceiverClientGrpc client = new XceiverClientGrpc(pipeline, conf) {
       @Override
       public XceiverClientReply sendCommandAsync(
           ContainerProtos.ContainerCommandRequestProto request,
@@ -131,7 +131,7 @@ public class TestXceiverClientGrpc {
   public void testReadChunkRetryAllNodes() {
     final ArrayList<DatanodeDetails> allDNs = new ArrayList<>(dns);
     Assertions.assertTrue(allDNs.size() > 1);
-    try(XceiverClientGrpc client = new XceiverClientGrpc(pipeline, conf) {
+    try (XceiverClientGrpc client = new XceiverClientGrpc(pipeline, conf) {
       @Override
       public XceiverClientReply sendCommandAsync(
           ContainerProtos.ContainerCommandRequestProto request,


### PR DESCRIPTION
## What changes were proposed in this pull request?

Similar to [HDDS-8024](https://issues.apache.org/jira/browse/HDDS-8024), the client should retry other datanodes if it has failed to getBlock from a datanode.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-8090

## How was this patch tested?

This is to fix TestHSync