### PR TITLE
HDDS-7853. Add support for RemoveSCM in SCMRatisServer.

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/RemoveSCMRequest.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/RemoveSCMRequest.java
@@ -1,0 +1,112 @@
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.apache.hadoop.hdds.scm;
+
+import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
+
+/**
+ * Request class using which SCM can be removed form the HA Ring.
+ */
+public class RemoveSCMRequest {
+
+  private final String clusterId;
+  private final String scmId;
+  private final String ratisAddr;
+
+  public RemoveSCMRequest(String clusterId, String scmId, String addr) {
+    this.clusterId = clusterId;
+    this.scmId = scmId;
+    this.ratisAddr = addr;
+  }
+
+  public static RemoveSCMRequest getFromProtobuf(
+      HddsProtos.RemoveScmRequestProto proto) {
+    return new Builder().setClusterId(proto.getClusterId())
+        .setScmId(proto.getScmId()).setRatisAddr(proto.getRatisAddr()).build();
+  }
+
+  public HddsProtos.RemoveScmRequestProto getProtobuf() {
+    return HddsProtos.RemoveScmRequestProto.newBuilder().setClusterId(clusterId)
+        .setScmId(scmId).setRatisAddr(ratisAddr).build();
+  }
+  /**
+   * Builder for RemoveSCMRequest.
+   */
+  public static class Builder {
+    private String clusterId;
+    private String scmId;
+    private String ratisAddr;
+
+
+    /**
+     * sets the cluster id.
+     * @param cid clusterId to be set
+     * @return Builder for RemoveSCMRequest
+     */
+    public RemoveSCMRequest.Builder setClusterId(String cid) {
+      this.clusterId = cid;
+      return this;
+    }
+
+    /**
+     * sets the scmId.
+     * @param id scmId
+     * @return Builder for RemoveSCMRequest
+     */
+    public RemoveSCMRequest.Builder setScmId(String id) {
+      this.scmId = id;
+      return this;
+    }
+
+    /**
+     * Set ratis address in Scm HA.
+     * @param   addr  address in the format of [ip|hostname]:port
+     * @return  Builder for RemoveSCMRequest
+     */
+    public RemoveSCMRequest.Builder setRatisAddr(String addr) {
+      this.ratisAddr = addr;
+      return this;
+    }
+
+    public RemoveSCMRequest build() {
+      return new RemoveSCMRequest(clusterId, scmId, ratisAddr);
+    }
+  }
+
+  /**
+   * Gets the clusterId from the Version file.
+   * @return ClusterId
+   */
+  public String getClusterId() {
+    return clusterId;
+  }
+
+  /**
+   * Gets the SCM Id from the Version file.
+   * @return SCM Id
+   */
+  public String getScmId() {
+    return scmId;
+  }
+
+  public String getRatisAddr() {
+    return ratisAddr;
+  }
+
+}

--- a/hadoop-hdds/interface-client/src/main/proto/hdds.proto
+++ b/hadoop-hdds/interface-client/src/main/proto/hdds.proto
@@ -265,6 +265,17 @@ message AddScmResponseProto {
     optional string scmId = 2;
 }
 
+message RemoveScmRequestProto {
+    required string clusterId = 1;
+    required string scmId = 2;
+    required string ratisAddr = 3;
+}
+
+message RemoveScmResponseProto {
+    required bool success = 1;
+    optional string scmId = 2;
+}
+
 enum ReplicationType {
     RATIS = 1;
     STAND_ALONE = 2;

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMHAManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMHAManager.java
@@ -77,7 +77,6 @@ public interface SCMHAManager {
    * @throws IOException
    */
   boolean removeSCM(RemoveSCMRequest request) throws IOException;
-  // Change the argument to RemoveSCMRequest
 
   /**
    * Download the latest checkpoint from leader SCM.

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMHAManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMHAManager.java
@@ -18,6 +18,7 @@
 package org.apache.hadoop.hdds.scm.ha;
 
 import org.apache.hadoop.hdds.scm.AddSCMRequest;
+import org.apache.hadoop.hdds.scm.RemoveSCMRequest;
 import org.apache.hadoop.hdds.scm.metadata.DBTransactionBuffer;
 import org.apache.hadoop.hdds.utils.db.DBCheckpoint;
 import org.apache.ratis.server.protocol.TermIndex;
@@ -62,12 +63,21 @@ public interface SCMHAManager {
   void stop() throws IOException;
 
   /**
-   * Adds the SC M instance to the SCM HA group.
+   * Adds the SCM instance to the SCM HA Ring.
    * @param request AddSCM request
    * @return status signying whether the AddSCM request succeeded or not.
    * @throws IOException
    */
   boolean addSCM(AddSCMRequest request) throws IOException;
+
+  /** Remove the SCM instance from the SCM HA Ring.
+   * @param request RemoveSCM request
+   *
+   * @return status signaling whether the RemoveSCM request succeeded or not.
+   * @throws IOException
+   */
+  boolean removeSCM(RemoveSCMRequest request) throws IOException;
+  // Change the argument to RemoveSCMRequest
 
   /**
    * Download the latest checkpoint from leader SCM.

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMHAManagerImpl.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMHAManagerImpl.java
@@ -21,6 +21,7 @@ import com.google.common.base.Preconditions;
 import org.apache.hadoop.hdds.conf.ConfigurationSource;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.scm.AddSCMRequest;
+import org.apache.hadoop.hdds.scm.RemoveSCMRequest;
 import org.apache.hadoop.hdds.scm.metadata.DBTransactionBuffer;
 import org.apache.hadoop.hdds.scm.metadata.SCMDBTransactionBufferImpl;
 import org.apache.hadoop.hdds.scm.metadata.SCMMetadataStore;
@@ -354,6 +355,26 @@ public class SCMHAManagerImpl implements SCMHAManager {
         getRatisServer().getDivision().getGroup().getGroupId());
     return getRatisServer().addSCM(request);
   }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public boolean removeSCM(RemoveSCMRequest request) throws IOException {
+    // Currently we don't support decommission of Primordial SCM
+    // The caller should make sure that the requested node is not Primordial SCM
+
+    String clusterId = scm.getClusterId();
+    if (!request.getClusterId().equals(scm.getClusterId())) {
+      throw new IOException("SCM " + request.getScmId() +
+          " with address " + request.getRatisAddr() +
+          " has cluster Id " + request.getClusterId() +
+          " but leader SCM cluster id is " + clusterId);
+    }
+    Preconditions.checkNotNull(ratisServer.getDivision().getGroup());
+    return ratisServer.removeSCM(request);
+  }
+
 
   void stopServices() throws Exception {
 

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMHAManagerStub.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMHAManagerStub.java
@@ -28,6 +28,7 @@ import com.google.common.base.Preconditions;
 import com.google.protobuf.InvalidProtocolBufferException;
 import org.apache.hadoop.hdds.protocol.proto.SCMRatisProtocol.RequestType;
 import org.apache.hadoop.hdds.scm.AddSCMRequest;
+import org.apache.hadoop.hdds.scm.RemoveSCMRequest;
 import org.apache.hadoop.hdds.scm.metadata.DBTransactionBuffer;
 import org.apache.hadoop.hdds.utils.db.DBCheckpoint;
 import org.apache.hadoop.hdds.utils.db.DBStore;
@@ -128,6 +129,11 @@ public final class SCMHAManagerStub implements SCMHAManager {
 
   @Override
   public boolean addSCM(AddSCMRequest request) throws IOException {
+    return false;
+  }
+
+  @Override
+  public boolean removeSCM(RemoveSCMRequest request) throws IOException {
     return false;
   }
 
@@ -248,6 +254,11 @@ public final class SCMHAManagerStub implements SCMHAManager {
 
     @Override
     public boolean addSCM(AddSCMRequest request) throws IOException {
+      return false;
+    }
+
+    @Override
+    public boolean removeSCM(RemoveSCMRequest request) throws IOException {
       return false;
     }
 

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMRatisServer.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMRatisServer.java
@@ -19,6 +19,7 @@ package org.apache.hadoop.hdds.scm.ha;
 
 import org.apache.hadoop.hdds.protocol.proto.SCMRatisProtocol.RequestType;
 import org.apache.hadoop.hdds.scm.AddSCMRequest;
+import org.apache.hadoop.hdds.scm.RemoveSCMRequest;
 import org.apache.ratis.grpc.GrpcTlsConfig;
 import org.apache.ratis.protocol.exceptions.NotLeaderException;
 import org.apache.ratis.server.RaftServer;
@@ -58,6 +59,8 @@ public interface SCMRatisServer {
   NotLeaderException triggerNotLeaderException();
 
   boolean addSCM(AddSCMRequest request) throws IOException;
+
+  boolean removeSCM(RemoveSCMRequest request) throws  IOException;
 
   SCMStateMachine getSCMStateMachine();
 

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMRatisServerImpl.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMRatisServerImpl.java
@@ -35,6 +35,7 @@ import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.protocol.proto.SCMRatisProtocol.RequestType;
 import org.apache.hadoop.hdds.ratis.RatisHelper;
 import org.apache.hadoop.hdds.scm.AddSCMRequest;
+import org.apache.hadoop.hdds.scm.RemoveSCMRequest;
 import org.apache.hadoop.hdds.scm.ScmConfigKeys;
 import org.apache.hadoop.hdds.scm.server.StorageContainerManager;
 import org.apache.hadoop.hdds.security.x509.SecurityConfig;
@@ -316,6 +317,45 @@ public class SCMRatisServerImpl implements SCMRatisServer {
     } catch (IOException e) {
       LOG.error("Failed to update Ratis configuration and add new peer. " +
           "Cannot add new SCM: {}.", scm.getScmId(), e);
+      throw e;
+    }
+  }
+
+  @Override
+  public boolean removeSCM(RemoveSCMRequest request) throws IOException {
+    final List<RaftPeer> newRaftPeerList =
+        new ArrayList<>(getDivision().getGroup().getPeers());
+    // remove the SCM node from the raft peer list
+
+    final RaftPeer raftPeer = RaftPeer.newBuilder().setId(request.getScmId())
+        .setAddress(request.getRatisAddr()).build();
+
+    newRaftPeerList.remove(raftPeer);
+
+    LOG.info("{}: Submitting SetConfiguration request to Ratis server with" +
+            " updated SCM peers list: {}", request.getScmId(),
+        newRaftPeerList);
+    final SetConfigurationRequest configRequest =
+        new SetConfigurationRequest(clientId, division.getPeer().getId(),
+            division.getGroup().getGroupId(), nextCallId(), newRaftPeerList);
+
+    try {
+      RaftClientReply raftClientReply = server.setConfiguration(configRequest);
+      if (raftClientReply.isSuccess()) {
+        LOG.info("Successfully removed SCM: {}.", request.getScmId());
+      } else {
+        LOG.error("Failed to remove SCM: {}. Ratis reply: {}" +
+            request.getScmId(), raftClientReply);
+        throw new IOException(raftClientReply.getException());
+      }
+      return raftClientReply.isSuccess();
+    } catch (IOException e) {
+      if (e instanceof NotLeaderException) {
+        LOG.debug("Cannot remove peer: {}", request.getScmId(), e);
+      } else {
+        LOG.error("Failed to update Ratis configuration and remove peer. " +
+            "Cannot remove SCM: {}.", request.getScmId(), e);
+      }
       throw e;
     }
   }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMRatisServerImpl.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMRatisServerImpl.java
@@ -324,7 +324,7 @@ public class SCMRatisServerImpl implements SCMRatisServer {
   @Override
   public boolean removeSCM(RemoveSCMRequest request) throws IOException {
     final List<RaftPeer> newRaftPeerList =
-        new ArrayList<>(getDivision().getGroup().getPeers());
+        new ArrayList<>(division.getGroup().getPeers());
     // remove the SCM node from the raft peer list
 
     final RaftPeer raftPeer = RaftPeer.newBuilder().setId(request.getScmId())

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/StorageContainerManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/StorageContainerManager.java
@@ -41,6 +41,7 @@ import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos.NodeState;
 import org.apache.hadoop.hdds.scm.PipelineChoosePolicy;
 import org.apache.hadoop.hdds.scm.PlacementPolicy;
+import org.apache.hadoop.hdds.scm.RemoveSCMRequest;
 import org.apache.hadoop.hdds.scm.ScmUtils;
 import org.apache.hadoop.hdds.scm.container.ContainerManager;
 import org.apache.hadoop.hdds.scm.container.ContainerManagerImpl;
@@ -2069,5 +2070,28 @@ public final class StorageContainerManager extends ServiceRuntimeInfoImpl
     LOG.info("Load conf {} : {}, and now admins are: {}", OZONE_ADMINISTRATORS,
         newVal, admins);
     return String.valueOf(newVal);
+  }
+
+  /**
+   * This will remove the given SCM node from HA Ring by removing it from
+   * Ratis Ring and deleting the related certificates from certificate store.
+   *
+   * @return true if remove was successful, else false.
+   */
+  public boolean removePeerFromHARing(RemoveSCMRequest request)
+      throws IOException {
+    // We cannot remove a node if it's currently leader.
+    if (scmContext.isLeader() && request.getScmId().equals(getScmId())) {
+      throw new IOException("Cannot remove current leader.");
+    }
+
+    // Currently we don't support removal of primordial node.
+    if (request.getScmId().equals(primaryScmNodeId)) {
+      throw new IOException("Removal of primordial node is not supported.");
+    }
+
+    // TODO: Remove the certificate from certificate store.
+    return scmHAManager.removeSCM(request);
+
   }
 }

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/ha/SCMHAManagerImplTest.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/ha/SCMHAManagerImplTest.java
@@ -1,0 +1,196 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with this
+ * work for additional information regarding copyright ownership.  The ASF
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p/>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p/>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package org.apache.hadoop.hdds.scm.ha;
+
+import org.apache.commons.io.FileUtils;
+import org.apache.hadoop.hdds.HddsConfigKeys;
+import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import org.apache.hadoop.hdds.scm.AddSCMRequest;
+import org.apache.hadoop.hdds.scm.RemoveSCMRequest;
+import org.apache.hadoop.hdds.scm.ScmConfigKeys;
+import org.apache.hadoop.hdds.scm.block.BlockManager;
+import org.apache.hadoop.hdds.scm.block.DeletedBlockLog;
+import org.apache.hadoop.hdds.scm.block.DeletedBlockLogImpl;
+import org.apache.hadoop.hdds.scm.metadata.SCMMetadataStore;
+import org.apache.hadoop.hdds.scm.node.NodeDecommissionManager;
+import org.apache.hadoop.hdds.scm.safemode.SCMSafeModeManager;
+import org.apache.hadoop.hdds.scm.server.SCMDatanodeProtocolServer;
+import org.apache.hadoop.hdds.scm.server.StorageContainerManager;
+import org.apache.hadoop.hdds.scm.server.upgrade.FinalizationManager;
+import org.apache.hadoop.hdds.security.x509.certificate.client
+    .CertificateClient;
+import org.apache.hadoop.hdds.utils.TransactionInfo;
+import org.apache.hadoop.hdds.utils.db.BatchOperation;
+import org.apache.hadoop.hdds.utils.db.DBStore;
+import org.apache.hadoop.hdds.utils.db.Table;
+import org.apache.ozone.test.GenericTestUtils;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.UUID;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+
+/**
+ * Test cases to verify {@link org.apache.hadoop.hdds.scm.ha.SCMHAManagerImpl}.
+ */
+class SCMHAManagerImplTest {
+
+  private String storageBaseDir;
+  private String clusterID;
+  private SCMHAManager primarySCMHAManager;
+
+  @BeforeEach
+  public void setup() throws IOException, InterruptedException {
+    storageBaseDir = GenericTestUtils.getTempPath(
+        SCMHAManagerImplTest.class.getSimpleName() + "-" +
+            UUID.randomUUID());
+    clusterID = UUID.randomUUID().toString();
+    OzoneConfiguration conf = getConfig("scm1", 9894);
+    final StorageContainerManager scm = getMockStorageContainerManager(conf);
+    SCMRatisServerImpl.initialize(clusterID, scm.getScmId(),
+        scm.getScmNodeDetails(), conf);
+    scm.getScmHAManager().start();
+    primarySCMHAManager = scm.getScmHAManager();
+    // Wait for Ratis Server to be ready
+    Thread.sleep(5000);
+  }
+
+  private OzoneConfiguration getConfig(String scmId, int ratisPort) {
+    OzoneConfiguration conf = new OzoneConfiguration();
+    conf.set(ScmConfigKeys.OZONE_SCM_HA_RATIS_STORAGE_DIR, storageBaseDir
+        + File.separator + scmId + File.separator + "ratis");
+    conf.set(HddsConfigKeys.OZONE_METADATA_DIRS, storageBaseDir
+        + File.separator + scmId + File.separator + "metadata");
+    conf.set(ScmConfigKeys.OZONE_SCM_RATIS_PORT_KEY, String.valueOf(ratisPort));
+    return conf;
+  }
+
+  @AfterEach
+  public void cleanup() throws IOException {
+    primarySCMHAManager.stop();
+    FileUtils.deleteDirectory(new File(storageBaseDir));
+  }
+
+  @Test
+  public void testAddSCM() throws IOException, InterruptedException {
+    Assertions.assertEquals(1, primarySCMHAManager.getRatisServer()
+        .getDivision().getGroup().getPeers().size());
+
+    final StorageContainerManager scm2 = getMockStorageContainerManager(
+        getConfig("scm2", 9898));
+    scm2.getScmHAManager().getRatisServer().start();
+    // Wait for Ratis Server to be ready
+    Thread.sleep(5000);
+    final AddSCMRequest request = new AddSCMRequest(
+        clusterID, scm2.getScmId(),
+        "localhost:" + scm2.getScmHAManager().getRatisServer().getDivision()
+            .getRaftServer().getServerRpc().getInetSocketAddress().getPort());
+    primarySCMHAManager.addSCM(request);
+    Assertions.assertEquals(2, primarySCMHAManager.getRatisServer()
+        .getDivision().getGroup().getPeers().size());
+    scm2.getScmHAManager().getRatisServer().stop();
+  }
+
+  @Test
+  public void testRemoveSCM() throws IOException, InterruptedException {
+    Assertions.assertEquals(1, primarySCMHAManager.getRatisServer()
+        .getDivision().getGroup().getPeers().size());
+
+    final StorageContainerManager scm2 = getMockStorageContainerManager(
+        getConfig("scm2", 9898));
+    scm2.getScmHAManager().getRatisServer().start();
+    // Wait for Ratis Server to be ready
+    Thread.sleep(5000);
+    final AddSCMRequest addSCMRequest = new AddSCMRequest(
+        clusterID, scm2.getScmId(),
+        "localhost:" + scm2.getScmHAManager().getRatisServer().getDivision()
+            .getRaftServer().getServerRpc().getInetSocketAddress().getPort());
+    primarySCMHAManager.addSCM(addSCMRequest);
+    Assertions.assertEquals(2, primarySCMHAManager.getRatisServer()
+        .getDivision().getGroup().getPeers().size());
+
+    final RemoveSCMRequest removeSCMRequest = new RemoveSCMRequest(
+        clusterID, scm2.getScmId(), "localhost:" +
+        scm2.getScmHAManager().getRatisServer().getDivision()
+            .getRaftServer().getServerRpc().getInetSocketAddress().getPort());
+    primarySCMHAManager.removeSCM(removeSCMRequest);
+    Assertions.assertEquals(1, primarySCMHAManager.getRatisServer()
+        .getDivision().getGroup().getPeers().size());
+    scm2.getScmHAManager().getRatisServer().stop();
+  }
+
+  private StorageContainerManager getMockStorageContainerManager(
+      OzoneConfiguration conf) throws IOException {
+    final String scmID =  UUID.randomUUID().toString();
+
+    final DBStore dbStore = mock(DBStore.class);
+    final SCMContext scmContext = mock(SCMContext.class);
+    final BlockManager blockManager = mock(BlockManager.class);
+    final SCMNodeDetails nodeDetails = mock(SCMNodeDetails.class);
+    final SCMMetadataStore metadataStore = mock(SCMMetadataStore.class);
+    final Table<String, TransactionInfo> txnInfoTable = mock(Table.class);
+    final SCMHANodeDetails scmHANodeDetails = mock(SCMHANodeDetails.class);
+    final SCMServiceManager serviceManager = mock(SCMServiceManager.class);
+    final StorageContainerManager scm = mock(StorageContainerManager.class);
+    final DeletedBlockLog deletedBlockLog = mock(DeletedBlockLogImpl.class);
+    final SCMSafeModeManager safeModeManager = mock(SCMSafeModeManager.class);
+    final CertificateClient certificateClient = mock(CertificateClient.class);
+    final BatchOperation batchOperation = mock(BatchOperation.class);
+    final SequenceIdGenerator sequenceIdGenerator =
+        mock(SequenceIdGenerator.class);
+    final FinalizationManager finalizationManager =
+        mock(FinalizationManager.class);
+    final NodeDecommissionManager decommissionManager =
+        mock(NodeDecommissionManager.class);
+    final SCMDatanodeProtocolServer datanodeProtocolServer =
+        mock(SCMDatanodeProtocolServer.class);
+
+    when(scm.getClusterId()).thenReturn(clusterID);
+    when(scm.getScmId()).thenReturn(scmID);
+    when(scm.getScmMetadataStore()).thenReturn(metadataStore);
+    when(scm.getScmNodeDetails()).thenReturn(nodeDetails);
+    when(scm.getSCMHANodeDetails()).thenReturn(scmHANodeDetails);
+    when(scm.getScmCertificateClient()).thenReturn(certificateClient);
+    when(scm.getScmBlockManager()).thenReturn(blockManager);
+    when(scm.getScmContext()).thenReturn(scmContext);
+    when(scm.getSequenceIdGen()).thenReturn(sequenceIdGenerator);
+    when(scm.getScmDecommissionManager()).thenReturn(decommissionManager);
+    when(scm.getSCMServiceManager()).thenReturn(serviceManager);
+    when(scm.getFinalizationManager()).thenReturn(finalizationManager);
+    when(scm.getScmSafeModeManager()).thenReturn(safeModeManager);
+    when(scm.getDatanodeProtocolServer()).thenReturn(datanodeProtocolServer);
+    when(metadataStore.getStore()).thenReturn(dbStore);
+    when(metadataStore.getTransactionInfoTable()).thenReturn(txnInfoTable);
+    when(scmHANodeDetails.getLocalNodeDetails()).thenReturn(nodeDetails);
+    when(blockManager.getDeletedBlockLog()).thenReturn(deletedBlockLog);
+    when(dbStore.initBatchOperation()).thenReturn(batchOperation);
+    when(nodeDetails.getRatisHostPortStr()).thenReturn("localhost:" +
+        conf.get(ScmConfigKeys.OZONE_SCM_RATIS_PORT_KEY));
+
+    final SCMHAManager manager = new SCMHAManagerImpl(conf, scm);
+    when(scm.getScmHAManager()).thenReturn(manager);
+    return scm;
+  }
+}

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/ha/TestReplicationAnnotation.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/ha/TestReplicationAnnotation.java
@@ -20,6 +20,7 @@ import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.hdds.protocol.proto.SCMRatisProtocol;
 import org.apache.hadoop.hdds.protocol.proto.SCMRatisProtocol.RequestType;
 import org.apache.hadoop.hdds.scm.AddSCMRequest;
+import org.apache.hadoop.hdds.scm.RemoveSCMRequest;
 import org.apache.hadoop.hdds.scm.container.ContainerStateManager;
 import org.apache.hadoop.hdds.security.x509.certificate.authority.CertificateStore;
 import org.apache.hadoop.security.ssl.KeyStoreTestUtil;
@@ -89,6 +90,11 @@ public class TestReplicationAnnotation {
       @Override
       public boolean addSCM(AddSCMRequest request)
           throws IOException {
+        return false;
+      }
+
+      @Override
+      public boolean removeSCM(RemoveSCMRequest request) throws IOException {
         return false;
       }
 

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/ha/TestSCMHAManagerImpl.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/ha/TestSCMHAManagerImpl.java
@@ -55,7 +55,7 @@ import static org.mockito.Mockito.when;
 /**
  * Test cases to verify {@link org.apache.hadoop.hdds.scm.ha.SCMHAManagerImpl}.
  */
-class SCMHAManagerImplTest {
+class TestSCMHAManagerImpl {
 
   private String storageBaseDir;
   private String clusterID;
@@ -64,7 +64,7 @@ class SCMHAManagerImplTest {
   @BeforeEach
   public void setup() throws IOException, InterruptedException {
     storageBaseDir = GenericTestUtils.getTempPath(
-        SCMHAManagerImplTest.class.getSimpleName() + "-" +
+        TestSCMHAManagerImpl.class.getSimpleName() + "-" +
             UUID.randomUUID());
     clusterID = UUID.randomUUID().toString();
     OzoneConfiguration conf = getConfig("scm1", 9894);
@@ -100,17 +100,21 @@ class SCMHAManagerImplTest {
 
     final StorageContainerManager scm2 = getMockStorageContainerManager(
         getConfig("scm2", 9898));
-    scm2.getScmHAManager().getRatisServer().start();
-    // Wait for Ratis Server to be ready
-    Thread.sleep(5000);
-    final AddSCMRequest request = new AddSCMRequest(
-        clusterID, scm2.getScmId(),
-        "localhost:" + scm2.getScmHAManager().getRatisServer().getDivision()
-            .getRaftServer().getServerRpc().getInetSocketAddress().getPort());
-    primarySCMHAManager.addSCM(request);
-    Assertions.assertEquals(2, primarySCMHAManager.getRatisServer()
-        .getDivision().getGroup().getPeers().size());
-    scm2.getScmHAManager().getRatisServer().stop();
+    try {
+      scm2.getScmHAManager().getRatisServer().start();
+      // Wait for Ratis Server to be ready
+      Thread.sleep(5000);
+      final AddSCMRequest request = new AddSCMRequest(
+          clusterID, scm2.getScmId(),
+          "localhost:" + scm2.getScmHAManager().getRatisServer()
+              .getDivision().getRaftServer().getServerRpc()
+              .getInetSocketAddress().getPort());
+      primarySCMHAManager.addSCM(request);
+      Assertions.assertEquals(2, primarySCMHAManager.getRatisServer()
+          .getDivision().getGroup().getPeers().size());
+    } finally {
+      scm2.getScmHAManager().getRatisServer().stop();
+    }
   }
 
   @Test
@@ -120,25 +124,29 @@ class SCMHAManagerImplTest {
 
     final StorageContainerManager scm2 = getMockStorageContainerManager(
         getConfig("scm2", 9898));
-    scm2.getScmHAManager().getRatisServer().start();
-    // Wait for Ratis Server to be ready
-    Thread.sleep(5000);
-    final AddSCMRequest addSCMRequest = new AddSCMRequest(
-        clusterID, scm2.getScmId(),
-        "localhost:" + scm2.getScmHAManager().getRatisServer().getDivision()
-            .getRaftServer().getServerRpc().getInetSocketAddress().getPort());
-    primarySCMHAManager.addSCM(addSCMRequest);
-    Assertions.assertEquals(2, primarySCMHAManager.getRatisServer()
-        .getDivision().getGroup().getPeers().size());
+    try {
+      scm2.getScmHAManager().getRatisServer().start();
+      // Wait for Ratis Server to be ready
+      Thread.sleep(5000);
+      final AddSCMRequest addSCMRequest = new AddSCMRequest(
+          clusterID, scm2.getScmId(),
+          "localhost:" + scm2.getScmHAManager().getRatisServer()
+              .getDivision().getRaftServer().getServerRpc()
+              .getInetSocketAddress().getPort());
+      primarySCMHAManager.addSCM(addSCMRequest);
+      Assertions.assertEquals(2, primarySCMHAManager.getRatisServer()
+          .getDivision().getGroup().getPeers().size());
 
-    final RemoveSCMRequest removeSCMRequest = new RemoveSCMRequest(
-        clusterID, scm2.getScmId(), "localhost:" +
-        scm2.getScmHAManager().getRatisServer().getDivision()
-            .getRaftServer().getServerRpc().getInetSocketAddress().getPort());
-    primarySCMHAManager.removeSCM(removeSCMRequest);
-    Assertions.assertEquals(1, primarySCMHAManager.getRatisServer()
-        .getDivision().getGroup().getPeers().size());
-    scm2.getScmHAManager().getRatisServer().stop();
+      final RemoveSCMRequest removeSCMRequest = new RemoveSCMRequest(
+          clusterID, scm2.getScmId(), "localhost:" +
+          scm2.getScmHAManager().getRatisServer().getDivision()
+              .getRaftServer().getServerRpc().getInetSocketAddress().getPort());
+      primarySCMHAManager.removeSCM(removeSCMRequest);
+      Assertions.assertEquals(1, primarySCMHAManager.getRatisServer()
+          .getDivision().getGroup().getPeers().size());
+    } finally {
+      scm2.getScmHAManager().getRatisServer().stop();
+    }
   }
 
   private StorageContainerManager getMockStorageContainerManager(


### PR DESCRIPTION
## What changes were proposed in this pull request?
This change introduces support for `removeSCM` in `SCMRatisServer`.

As part of SCM decommissioning, the Ratis set configuration should be executed with a new peer list to remove the decommissioning SCM node from the Raft Ring.

`SCMRatisServer` should expose the method to perform remove node which should call Ratis set configuration with a new peer list.

`notifyConfigurationChanged` on `SCMStateMachine` should be idempotent as this can be called during SCM restart while applying the Raft log.


## What is the link to the Apache JIRA
HDDS-7853

## How was this patch tested?
Unit tests added
