### PR TITLE
HDDS-8108. gRPC channel created for replication client not shutdown properly

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/replication/GrpcContainerUploader.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/replication/GrpcContainerUploader.java
@@ -17,6 +17,7 @@
  */
 package org.apache.hadoop.ozone.container.replication;
 
+import com.google.common.annotations.VisibleForTesting;
 import org.apache.hadoop.hdds.conf.ConfigurationSource;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails.Port;
@@ -24,6 +25,7 @@ import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.SendContai
 import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.SendContainerResponse;
 import org.apache.hadoop.hdds.security.x509.SecurityConfig;
 import org.apache.hadoop.hdds.security.x509.certificate.client.CertificateClient;
+import org.apache.hadoop.hdds.utils.IOUtils;
 import org.apache.ratis.thirdparty.io.grpc.stub.StreamObserver;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -53,18 +55,32 @@ public class GrpcContainerUploader implements ContainerUploader {
   public OutputStream startUpload(long containerId, DatanodeDetails target,
       CompletableFuture<Void> callback, CopyContainerCompression compression)
       throws IOException {
-    GrpcReplicationClient client =
-        new GrpcReplicationClient(target.getIpAddress(),
-            target.getPort(Port.Name.REPLICATION).getValue(),
-            securityConfig, certClient, compression);
-    StreamObserver<SendContainerRequest> requestStream = client.upload(
-        new SendContainerResponseStreamObserver(containerId, target, callback));
-    return new SendContainerOutputStream(requestStream, containerId,
-        GrpcReplicationService.BUFFER_SIZE, compression);
+    GrpcReplicationClient client = null;
+    try {
+      client = createReplicationClient(target, compression);
+      StreamObserver<SendContainerRequest> requestStream = client.upload(
+          new SendContainerResponseStreamObserver(containerId, target,
+              callback));
+      return new SendContainerOutputStream(client, requestStream, containerId,
+          GrpcReplicationService.BUFFER_SIZE, compression);
+    } catch (Exception e) {
+      IOUtils.close(LOG, client);
+      throw e;
+    }
+  }
+
+  @VisibleForTesting
+  protected GrpcReplicationClient createReplicationClient(
+      DatanodeDetails target, CopyContainerCompression compression)
+      throws IOException {
+    return new GrpcReplicationClient(target.getIpAddress(),
+        target.getPort(Port.Name.REPLICATION).getValue(),
+        securityConfig, certClient, compression);
   }
 
   /**
-   *
+   * Observes gRPC response for SendContainer request, notifies callback on
+   * completion/error.
    */
   private static class SendContainerResponseStreamObserver
       implements StreamObserver<SendContainerResponse> {

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/replication/SendContainerOutputStream.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/replication/SendContainerOutputStream.java
@@ -18,21 +18,31 @@
 package org.apache.hadoop.ozone.container.replication;
 
 import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.SendContainerRequest;
+import org.apache.hadoop.hdds.utils.IOUtils;
 import org.apache.ratis.thirdparty.com.google.protobuf.ByteString;
 import org.apache.ratis.thirdparty.io.grpc.stub.StreamObserver;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
 
 /**
  * Output stream adapter for SendContainerResponse.
  */
 class SendContainerOutputStream extends GrpcOutputStream<SendContainerRequest> {
 
+  private static final Logger LOG =
+      LoggerFactory.getLogger(SendContainerOutputStream.class);
+
   private final CopyContainerCompression compression;
+  private final AutoCloseable client;
 
   SendContainerOutputStream(
-      StreamObserver<SendContainerRequest> streamObserver,
+      AutoCloseable client, StreamObserver<SendContainerRequest> streamObserver,
       long containerId, int bufferSize, CopyContainerCompression compression) {
     super(streamObserver, containerId, bufferSize);
     this.compression = compression;
+    this.client = client;
   }
 
   @Override
@@ -44,5 +54,14 @@ class SendContainerOutputStream extends GrpcOutputStream<SendContainerRequest> {
         .setCompression(compression.toProto())
         .build();
     getStreamObserver().onNext(request);
+  }
+
+  @Override
+  public void close() throws IOException {
+    try {
+      super.close();
+    } finally {
+      IOUtils.close(LOG, client);
+    }
   }
 }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/replication/SimpleContainerDownloader.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/replication/SimpleContainerDownloader.java
@@ -25,7 +25,6 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ExecutionException;
 
 import org.apache.hadoop.hdds.conf.ConfigurationSource;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
@@ -34,6 +33,7 @@ import org.apache.hadoop.hdds.security.x509.SecurityConfig;
 import org.apache.hadoop.hdds.security.x509.certificate.client.CertificateClient;
 
 import com.google.common.annotations.VisibleForTesting;
+import org.apache.hadoop.hdds.utils.IOUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -72,18 +72,19 @@ public class SimpleContainerDownloader implements ContainerDownloader {
         shuffleDatanodes(sourceDatanodes);
 
     for (DatanodeDetails datanode : shuffledDatanodes) {
+      GrpcReplicationClient client = null;
       try {
+        client = createReplicationClient(datanode, compression);
         CompletableFuture<Path> result =
-            downloadContainer(containerId, datanode, downloadDir, compression);
+            downloadContainer(client, containerId, downloadDir);
         return result.get();
-      } catch (ExecutionException | IOException e) {
-        LOG.error("Error on replicating container: {} from {}/{}", containerId,
-            datanode.getHostName(), datanode.getIpAddress(), e);
       } catch (InterruptedException e) {
+        logError(e, containerId, datanode);
         Thread.currentThread().interrupt();
-      } catch (Exception ex) {
-        LOG.error("Container {} download from datanode {} was unsuccessful. "
-                + "Trying the next datanode", containerId, datanode, ex);
+      } catch (Exception e) {
+        logError(e, containerId, datanode);
+      } finally {
+        IOUtils.close(LOG, client);
       }
     }
     LOG.error("Container {} could not be downloaded from any datanode",
@@ -91,9 +92,16 @@ public class SimpleContainerDownloader implements ContainerDownloader {
     return null;
   }
 
+  private static void logError(Exception e,
+      long containerId, DatanodeDetails datanode) {
+    LOG.error("Error on replicating container: {} from {}", containerId,
+        datanode, e);
+  }
+
   //There is a chance for the download is successful but import is failed,
   //due to data corruption. We need a random selected datanode to have a
   //chance to succeed next time.
+  @VisibleForTesting
   protected List<DatanodeDetails> shuffleDatanodes(
       List<DatanodeDetails> sourceDatanodes) {
 
@@ -106,25 +114,18 @@ public class SimpleContainerDownloader implements ContainerDownloader {
   }
 
   @VisibleForTesting
-  protected CompletableFuture<Path> downloadContainer(long containerId,
-      DatanodeDetails datanode, Path downloadDir,
-      CopyContainerCompression compression) throws IOException {
-    CompletableFuture<Path> result;
-    GrpcReplicationClient grpcReplicationClient =
-        new GrpcReplicationClient(datanode.getIpAddress(),
-            datanode.getPort(Name.REPLICATION).getValue(),
-            securityConfig, certClient, compression);
+  protected GrpcReplicationClient createReplicationClient(
+      DatanodeDetails datanode, CopyContainerCompression compression
+  ) throws IOException {
+    return new GrpcReplicationClient(datanode.getIpAddress(),
+        datanode.getPort(Name.REPLICATION).getValue(),
+        securityConfig, certClient, compression);
+  }
 
-    result = grpcReplicationClient.download(containerId, downloadDir)
-        .whenComplete((r, ex) -> {
-          try {
-            grpcReplicationClient.close();
-          } catch (Exception e) {
-            LOG.error("Couldn't close Grpc replication client", e);
-          }
-        });
-
-    return result;
+  @VisibleForTesting
+  protected CompletableFuture<Path> downloadContainer(
+      GrpcReplicationClient client, long containerId, Path downloadDir) {
+    return client.download(containerId, downloadDir);
   }
 
   @Override

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/replication/TestGrpcContainerUploader.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/replication/TestGrpcContainerUploader.java
@@ -1,0 +1,156 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.ozone.container.replication;
+
+import org.apache.commons.lang3.RandomUtils;
+import org.apache.hadoop.hdds.conf.InMemoryConfiguration;
+import org.apache.hadoop.hdds.protocol.DatanodeDetails;
+import org.apache.hadoop.hdds.protocol.MockDatanodeDetails;
+import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.SendContainerRequest;
+import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.SendContainerResponse;
+import org.apache.ratis.thirdparty.io.grpc.stub.StreamObserver;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.util.concurrent.CompletableFuture;
+
+import static org.apache.hadoop.ozone.container.replication.CopyContainerCompression.NO_COMPRESSION;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Tests for {@link GrpcContainerUploader}.
+ */
+class TestGrpcContainerUploader {
+
+  @Test
+  void successfulReplication() throws Exception {
+    // GIVEN
+    GrpcReplicationClient client = mock(GrpcReplicationClient.class);
+    ArgumentCaptor<StreamObserver<SendContainerResponse>> captor =
+        ArgumentCaptor.forClass(StreamObserver.class);
+    when(client.upload(captor.capture()))
+        .thenReturn(new NoopObserver() {
+          @Override
+          public void onNext(SendContainerRequest value) {
+            captor.getValue()
+                .onNext(SendContainerResponse.getDefaultInstance());
+          }
+        });
+
+    CompletableFuture<Void> callback = new CompletableFuture<>();
+    GrpcContainerUploader subject = createSubject(client);
+
+    // WHEN
+    OutputStream out = startUpload(subject, callback);
+    out.close();
+
+    // THEN
+    verify(client).close();
+  }
+
+  @Test
+  void errorInResponse() throws Exception {
+    // GIVEN
+    GrpcReplicationClient client = mock(GrpcReplicationClient.class);
+    ArgumentCaptor<StreamObserver<SendContainerResponse>> captor =
+        ArgumentCaptor.forClass(StreamObserver.class);
+    when(client.upload(captor.capture()))
+        .thenReturn(new NoopObserver() {
+          @Override
+          public void onNext(SendContainerRequest value) {
+            captor.getValue().onError(new RuntimeException("testing"));
+          }
+        });
+
+    CompletableFuture<Void> callback = new CompletableFuture<>();
+    GrpcContainerUploader subject = createSubject(client);
+
+    // WHEN
+    OutputStream out = startUpload(subject, callback);
+    out.write(RandomUtils.nextBytes(4));
+    out.close();
+
+    // THEN
+    assertTrue(callback.isCompletedExceptionally());
+    verify(client).close();
+  }
+
+  @Test
+  void immediateError() throws Exception {
+    // GIVEN
+    GrpcReplicationClient client = mock(GrpcReplicationClient.class);
+    when(client.upload(any()))
+        .thenThrow(new RuntimeException("testing"));
+
+    CompletableFuture<Void> callback = new CompletableFuture<>();
+    GrpcContainerUploader subject = createSubject(client);
+
+    // WHEN
+    assertThrows(RuntimeException.class, () -> startUpload(subject, callback));
+
+    // THEN
+    verify(client).close();
+  }
+
+  private static GrpcContainerUploader createSubject(
+      GrpcReplicationClient client) {
+
+    return new GrpcContainerUploader(new InMemoryConfiguration(), null) {
+      @Override
+      protected GrpcReplicationClient createReplicationClient(
+          DatanodeDetails target, CopyContainerCompression compression) {
+        return client;
+      }
+    };
+  }
+
+  private static OutputStream startUpload(GrpcContainerUploader subject,
+      CompletableFuture<Void> callback) throws IOException {
+    DatanodeDetails target = MockDatanodeDetails.randomDatanodeDetails();
+    return subject.startUpload(1, target, callback, NO_COMPRESSION);
+  }
+
+  /**
+   * Empty implementation.
+   */
+  private static class NoopObserver
+      implements StreamObserver<SendContainerRequest> {
+
+    @Override
+    public void onNext(SendContainerRequest value) {
+      // override if needed
+    }
+
+    @Override
+    public void onError(Throwable t) {
+      // override if needed
+    }
+
+    @Override
+    public void onCompleted() {
+      // override if needed
+    }
+  }
+}

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/replication/TestSendContainerOutputStream.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/replication/TestSendContainerOutputStream.java
@@ -21,6 +21,7 @@ import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.SendContai
 import org.apache.ratis.thirdparty.com.google.protobuf.ByteString;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
+import org.mockito.Mock;
 
 import java.io.OutputStream;
 
@@ -34,20 +35,23 @@ import static org.mockito.Mockito.verify;
 class TestSendContainerOutputStream
     extends GrpcOutputStreamTest<SendContainerRequest> {
 
+  @Mock
+  private AutoCloseable client;
+
   TestSendContainerOutputStream() {
     super(SendContainerRequest.class);
   }
 
   @Override
   protected OutputStream createSubject() {
-    return new SendContainerOutputStream(getObserver(),
+    return new SendContainerOutputStream(client, getObserver(),
         getContainerId(), getBufferSize(), NO_COMPRESSION);
   }
 
   @ParameterizedTest
   @EnumSource
   void usesCompression(CopyContainerCompression compression) throws Exception {
-    OutputStream subject = new SendContainerOutputStream(
+    OutputStream subject = new SendContainerOutputStream(client,
         getObserver(), getContainerId(), getBufferSize(), compression);
 
     byte[] bytes = getRandomBytes(16);


### PR DESCRIPTION
## What changes were proposed in this pull request?

Ensure `GrpcReplicationClient` is closed to fix leak.

HDDS-8108  (but reported as early as HDDS-1615)

## How was this patch tested?

Added unit tests.

https://github.com/adoroszlai/hadoop-ozone/actions/runs/4364237406