### PR TITLE
HDDS-8110. ReplicationManager: Introduce basic limits on ReplicateContainer commands

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/replication/AbstractReplicationTask.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/replication/AbstractReplicationTask.java
@@ -55,6 +55,8 @@ public abstract class AbstractReplicationTask {
 
   private ReplicationCommandPriority priority = NORMAL;
 
+  private boolean shouldOnlyRunOnInServiceDatanodes = true;
+
   protected AbstractReplicationTask(long containerID,
       long deadlineMsSinceEpoch, long term) {
     this(containerID, deadlineMsSinceEpoch, term,
@@ -119,5 +121,23 @@ public abstract class AbstractReplicationTask {
    */
   public ReplicationCommandPriority getPriority() {
     return priority;
+  }
+
+  /**
+   * Returns true if the task should only run on in service datanodes. False
+   * otherwise.
+   */
+  public boolean shouldOnlyRunOnInServiceDatanodes() {
+    return shouldOnlyRunOnInServiceDatanodes;
+  }
+
+  /**
+   * Set whether the task should only run on in service datanodes. Passing false
+   * allows the task to run on out of service datanodes as well.
+   * @param runOnInServiceOnly
+   */
+  protected void setShouldOnlyRunOnInServiceDatanodes(
+      boolean runOnInServiceOnly) {
+    this.shouldOnlyRunOnInServiceDatanodes = runOnInServiceOnly;
   }
 }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/replication/ReplicationSupervisor.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/replication/ReplicationSupervisor.java
@@ -193,7 +193,8 @@ public class ReplicationSupervisor {
         if (context != null) {
           DatanodeDetails dn = context.getParent().getDatanodeDetails();
           if (dn != null && dn.getPersistedOpState() !=
-              HddsProtos.NodeOperationalState.IN_SERVICE) {
+              HddsProtos.NodeOperationalState.IN_SERVICE
+              && task.shouldOnlyRunOnInServiceDatanodes()) {
             LOG.info("Dn is of {} state. Ignore {}",
                 dn.getPersistedOpState(), this);
             return;

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/replication/ReplicationTask.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/replication/ReplicationTask.java
@@ -42,6 +42,13 @@ public class ReplicationTask extends AbstractReplicationTask {
     setPriority(cmd.getPriority());
     this.cmd = cmd;
     this.replicator = replicator;
+    if (cmd.getTargetDatanode() != null) {
+      // Only push replication will have a target datanode set, and it must be
+      // sent to the source datanode to be executed. It is possible the source
+      // is out of service, so we need to set the flag to allow the command to
+      // run.
+      setShouldOnlyRunOnInServiceDatanodes(false);
+    }
   }
 
   /**

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/AllSourcesOverloadedException.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/AllSourcesOverloadedException.java
@@ -1,3 +1,20 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.hadoop.hdds.scm.container.replication;
 
 import java.io.IOException;

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/AllSourcesOverloadedException.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/AllSourcesOverloadedException.java
@@ -1,0 +1,14 @@
+package org.apache.hadoop.hdds.scm.container.replication;
+
+import java.io.IOException;
+
+/**
+ * Exception class used to indicate that all sources are overloaded.
+ */
+public class AllSourcesOverloadedException extends IOException {
+
+  public AllSourcesOverloadedException(String message) {
+    super(message);
+  }
+
+}

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ECMisReplicationHandler.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ECMisReplicationHandler.java
@@ -22,7 +22,6 @@ import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.hdds.scm.PlacementPolicy;
 import org.apache.hadoop.hdds.scm.container.ContainerInfo;
 import org.apache.hadoop.hdds.scm.container.ContainerReplica;
-import org.apache.hadoop.hdds.scm.node.NodeManager;
 import org.apache.hadoop.ozone.protocol.commands.ReplicateContainerCommand;
 
 import java.io.IOException;

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ECMisReplicationHandler.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ECMisReplicationHandler.java
@@ -36,8 +36,9 @@ import java.util.Set;
 public class ECMisReplicationHandler extends MisReplicationHandler {
   public ECMisReplicationHandler(
           PlacementPolicy<ContainerReplica> containerPlacement,
-          ConfigurationSource conf, NodeManager nodeManager, boolean push) {
-    super(containerPlacement, conf, nodeManager, push);
+          ConfigurationSource conf, ReplicationManager replicationManager,
+          boolean push) {
+    super(containerPlacement, conf, replicationManager, push);
   }
 
   @Override

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/LegacyReplicationManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/LegacyReplicationManager.java
@@ -1449,10 +1449,8 @@ public class LegacyReplicationManager {
 
     final ContainerID id = container.containerID();
     final long containerID = id.getId();
-    final boolean push = rmConf.isPush();
     final ReplicateContainerCommand replicateCommand =
         ReplicateContainerCommand.fromSources(containerID, sources);
-    final DatanodeDetails source = sources.get(0); // TODO randomize
     LOG.info("Sending {} to {}", replicateCommand, target);
 
     final boolean sent = sendAndTrackDatanodeCommand(target, replicateCommand,

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/LegacyReplicationManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/LegacyReplicationManager.java
@@ -1450,14 +1450,12 @@ public class LegacyReplicationManager {
     final ContainerID id = container.containerID();
     final long containerID = id.getId();
     final boolean push = rmConf.isPush();
-    final ReplicateContainerCommand replicateCommand = push
-        ? ReplicateContainerCommand.toTarget(containerID, target)
-        : ReplicateContainerCommand.fromSources(containerID, sources);
+    final ReplicateContainerCommand replicateCommand =
+        ReplicateContainerCommand.fromSources(containerID, sources);
     final DatanodeDetails source = sources.get(0); // TODO randomize
-    final DatanodeDetails receiver = push ? source : target;
-    LOG.info("Sending {} to {}", replicateCommand, receiver);
+    LOG.info("Sending {} to {}", replicateCommand, target);
 
-    final boolean sent = sendAndTrackDatanodeCommand(receiver, replicateCommand,
+    final boolean sent = sendAndTrackDatanodeCommand(target, replicateCommand,
         action -> addInflight(InflightType.REPLICATION, id, action));
 
     if (sent) {

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/RatisMisReplicationHandler.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/RatisMisReplicationHandler.java
@@ -38,8 +38,9 @@ public class RatisMisReplicationHandler extends MisReplicationHandler {
 
   public RatisMisReplicationHandler(
           PlacementPolicy<ContainerReplica> containerPlacement,
-          ConfigurationSource conf, NodeManager nodeManager, boolean push) {
-    super(containerPlacement, conf, nodeManager, push);
+          ConfigurationSource conf, ReplicationManager replicationManager,
+          boolean push) {
+    super(containerPlacement, conf, replicationManager, push);
   }
 
   @Override

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/RatisMisReplicationHandler.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/RatisMisReplicationHandler.java
@@ -23,7 +23,6 @@ import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.hdds.scm.PlacementPolicy;
 import org.apache.hadoop.hdds.scm.container.ContainerInfo;
 import org.apache.hadoop.hdds.scm.container.ContainerReplica;
-import org.apache.hadoop.hdds.scm.node.NodeManager;
 import org.apache.hadoop.ozone.protocol.commands.ReplicateContainerCommand;
 
 import java.io.IOException;

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ReplicationManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ReplicationManager.java
@@ -74,6 +74,8 @@ import org.slf4j.LoggerFactory;
 import java.io.IOException;
 import java.time.Clock;
 import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -174,6 +176,7 @@ public class ReplicationManager implements SCMService {
   private final UnderReplicatedProcessor underReplicatedProcessor;
   private final OverReplicatedProcessor overReplicatedProcessor;
   private final HealthCheck containerCheckChain;
+  private final int datanodeReplicationLimit;
 
   /**
    * Constructs ReplicationManager instance with the given configuration.
@@ -224,6 +227,7 @@ public class ReplicationManager implements SCMService {
     this.replicationQueue = new ReplicationQueue();
     this.maintenanceRedundancy = rmConf.maintenanceRemainingRedundancy;
     this.ratisMaintenanceMinReplicas = rmConf.getMaintenanceReplicaMinimum();
+    this.datanodeReplicationLimit = rmConf.getDatanodeReplicationLimit();
 
     ecUnderReplicationHandler = new ECUnderReplicationHandler(
         ecContainerPlacement, conf, nodeManager, this);
@@ -232,7 +236,7 @@ public class ReplicationManager implements SCMService {
     ecMisReplicationHandler = new ECMisReplicationHandler(ecContainerPlacement,
         conf, nodeManager, rmConf.isPush());
     ratisUnderReplicationHandler = new RatisUnderReplicationHandler(
-        ratisContainerPlacement, conf, nodeManager, this);
+        ratisContainerPlacement, conf, this);
     ratisOverReplicationHandler =
         new RatisOverReplicationHandler(ratisContainerPlacement, nodeManager);
     underReplicatedProcessor =
@@ -431,6 +435,55 @@ public class ReplicationManager implements SCMService {
         new DeleteContainerCommand(container.containerID(), force);
     deleteCommand.setReplicaIndex(replicaIndex);
     sendDatanodeCommand(deleteCommand, container, datanode);
+  }
+
+  /**
+   * Create a ReplicateContainerCommand for the given container and to push the
+   * container to the target datanode. The list of sources are checked to ensure
+   * the datanode has sufficient capacity to accept the container command, and
+   * then the command is sent to the datanode with the fewest pending commands.
+   * If all sources are overloaded, an AllSourcesOverloadedException is thrown.
+   * @param containerID The containerID to be replicated
+   * @param sources The list of datanodes that can be used as sources
+   * @param target The target datanode where the container should be replicated
+   * @param replicaIndex The index of the container replica to be replicated
+   * @return A pair containing the datanode that the command was sent to, and
+   *         the command created.
+   * @throws AllSourcesOverloadedException
+   */
+  public Pair<DatanodeDetails, SCMCommand<?>>
+      createThrottledReplicationCommand(long containerID,
+      List<DatanodeDetails> sources, DatanodeDetails target, int replicaIndex)
+      throws AllSourcesOverloadedException {
+    LOG.info("IN the real RM impt");
+    List<Pair<Integer, DatanodeDetails>> sourceWithCmds = new ArrayList<>();
+    for (DatanodeDetails source : sources)  {
+      try {
+        int commandCount = nodeManager.getTotalDatanodeCommandCount(source,
+            Type.replicateContainerCommand);
+        if (commandCount >= datanodeReplicationLimit) {
+          LOG.debug("Source {} has reached the maximum number of queued " +
+              "replication commands ({})", source, datanodeReplicationLimit);
+          continue;
+        }
+        sourceWithCmds.add(Pair.of(commandCount, source));
+      } catch (NodeNotFoundException e) {
+        LOG.error("Node {} not found in NodeManager. Should not happen",
+            source, e);
+      }
+    }
+    if (sourceWithCmds.isEmpty()) {
+      throw new AllSourcesOverloadedException("No sources with capacity " +
+          "available for replication of container " + containerID + " to " +
+          target);
+    }
+    // Put the least loaded source first
+    sourceWithCmds.sort(Comparator.comparingInt(Pair::getLeft));
+
+    ReplicateContainerCommand cmd =
+        ReplicateContainerCommand.toTarget(containerID, target);
+    cmd.setReplicaIndex(replicaIndex);
+    return Pair.of(sourceWithCmds.get(0).getRight(), cmd);
   }
 
   /**
@@ -1015,13 +1068,13 @@ public class ReplicationManager implements SCMService {
 
     @Config(key = "push",
         type = ConfigType.BOOLEAN,
-        defaultValue = "false",
+        defaultValue = "true",
         tags = { SCM, DATANODE },
         description = "If false, replication happens by asking the target to " +
             "pull from source nodes.  If true, the source node is asked to " +
             "push to the target node."
     )
-    private boolean push;
+    private boolean push = true;
 
     @PostConstruct
     public void validate() {
@@ -1030,6 +1083,25 @@ public class ReplicationManager implements SCMService {
             + commandDeadlineFactor
             + " and must be greater than 0 and less than equal to 1");
       }
+    }
+
+    @Config(key = "datanode.replication.limit",
+        type = ConfigType.INT,
+        defaultValue = "20",
+        tags = { SCM, DATANODE },
+        description = "A limit to restrict the total number of replication " +
+            "commands queued on a datanode. Note this is intended to be a " +
+            " temporary config until we have a more dynamic way of limiting " +
+            "load."
+    )
+    private int datanodeReplicationLimit = 20;
+
+    public int getDatanodeReplicationLimit() {
+      return datanodeReplicationLimit;
+    }
+
+    public void setDatanodeReplicationLimit(int limit) {
+      this.datanodeReplicationLimit = limit;
     }
 
     public void setMaintenanceRemainingRedundancy(int redundancy) {

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ReplicationManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ReplicationManager.java
@@ -230,7 +230,7 @@ public class ReplicationManager implements SCMService {
     this.datanodeReplicationLimit = rmConf.getDatanodeReplicationLimit();
 
     ecUnderReplicationHandler = new ECUnderReplicationHandler(
-        ecContainerPlacement, conf, nodeManager, this);
+        ecContainerPlacement, conf, this);
     ecOverReplicationHandler =
         new ECOverReplicationHandler(ecContainerPlacement, nodeManager);
     ecMisReplicationHandler = new ECMisReplicationHandler(ecContainerPlacement,

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ReplicationManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ReplicationManager.java
@@ -234,7 +234,7 @@ public class ReplicationManager implements SCMService {
     ecOverReplicationHandler =
         new ECOverReplicationHandler(ecContainerPlacement, nodeManager);
     ecMisReplicationHandler = new ECMisReplicationHandler(ecContainerPlacement,
-        conf, nodeManager, rmConf.isPush());
+        conf, this, rmConf.isPush());
     ratisUnderReplicationHandler = new RatisUnderReplicationHandler(
         ratisContainerPlacement, conf, this);
     ratisOverReplicationHandler =

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ReplicationManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ReplicationManager.java
@@ -455,7 +455,6 @@ public class ReplicationManager implements SCMService {
       createThrottledReplicationCommand(long containerID,
       List<DatanodeDetails> sources, DatanodeDetails target, int replicaIndex)
       throws AllSourcesOverloadedException {
-    LOG.info("IN the real RM impt");
     List<Pair<Integer, DatanodeDetails>> sourceWithCmds = new ArrayList<>();
     for (DatanodeDetails source : sources)  {
       try {

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestECMisReplicationHandler.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestECMisReplicationHandler.java
@@ -26,6 +26,7 @@ import org.apache.hadoop.hdds.scm.PlacementPolicy;
 import org.apache.hadoop.hdds.scm.container.ContainerReplica;
 import org.apache.hadoop.hdds.scm.exceptions.SCMException;
 import org.apache.hadoop.hdds.scm.node.NodeManager;
+import org.apache.hadoop.hdds.scm.node.states.NodeNotFoundException;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -52,7 +53,7 @@ public class TestECMisReplicationHandler extends TestMisReplicationHandler {
 
 
   @BeforeEach
-  public void setup() {
+  public void setup() throws NodeNotFoundException {
     ECReplicationConfig repConfig = new ECReplicationConfig(DATA, PARITY);
     setup(repConfig);
   }
@@ -168,8 +169,8 @@ public class TestECMisReplicationHandler extends TestMisReplicationHandler {
   @Override
   protected MisReplicationHandler getMisreplicationHandler(
           PlacementPolicy placementPolicy, OzoneConfiguration conf,
-          NodeManager nodeManager) {
-    return new ECMisReplicationHandler(placementPolicy, conf, nodeManager,
-        false);
+          ReplicationManager replicationManager) {
+    return new ECMisReplicationHandler(placementPolicy, conf,
+        replicationManager, false);
   }
 }

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestECUnderReplicationHandler.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestECUnderReplicationHandler.java
@@ -583,13 +583,10 @@ public class TestECUnderReplicationHandler {
         testUnderReplicationWithMissingIndexes(Collections.emptyList(),
             availableReplicas, 1, 0, policy);
     Assertions.assertEquals(1, cmds.size());
-    ReplicateContainerCommand cmd =
-        (ReplicateContainerCommand) cmds.iterator().next().getValue();
-
-    List<DatanodeDetails> sources = cmd.getSourceDatanodes();
-    Assertions.assertEquals(1, sources.size());
-    Assertions.assertEquals(decomReplica.getDatanodeDetails(),
-        cmd.getSourceDatanodes().get(0));
+    // With push replication the command should always be sent to the
+    // decommissioning source.
+    DatanodeDetails target = cmds.iterator().next().getKey();
+    Assertions.assertEquals(decomReplica.getDatanodeDetails(), target);
   }
 
   @Test
@@ -612,13 +609,10 @@ public class TestECUnderReplicationHandler {
         availableReplicas, 0, 1, policy);
 
     Assertions.assertEquals(1, cmds.size());
-    ReplicateContainerCommand cmd =
-        (ReplicateContainerCommand) cmds.iterator().next().getValue();
-
-    List<DatanodeDetails> sources = cmd.getSourceDatanodes();
-    Assertions.assertEquals(1, sources.size());
-    Assertions.assertEquals(maintReplica.getDatanodeDetails(),
-        cmd.getSourceDatanodes().get(0));
+    // With push replication the command should always be sent to the
+    // entering_maintenance source.
+    DatanodeDetails target = cmds.iterator().next().getKey();
+    Assertions.assertEquals(maintReplica.getDatanodeDetails(), target);
   }
 
   public Set<Pair<DatanodeDetails, SCMCommand<?>>>

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestECUnderReplicationHandler.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestECUnderReplicationHandler.java
@@ -36,6 +36,7 @@ import org.apache.hadoop.hdds.scm.net.NodeSchema;
 import org.apache.hadoop.hdds.scm.net.NodeSchemaManager;
 import org.apache.hadoop.hdds.scm.node.NodeManager;
 import org.apache.hadoop.hdds.scm.node.NodeStatus;
+import org.apache.hadoop.hdds.scm.node.states.NodeNotFoundException;
 import org.apache.hadoop.ozone.container.common.SCMTestUtils;
 import org.apache.hadoop.ozone.protocol.commands.DeleteContainerCommand;
 import org.apache.hadoop.ozone.protocol.commands.ReconstructECContainersCommand;
@@ -65,6 +66,7 @@ import static org.apache.hadoop.hdds.scm.net.NetConstants.LEAF_SCHEMA;
 import static org.apache.hadoop.hdds.scm.net.NetConstants.RACK_SCHEMA;
 import static org.apache.hadoop.hdds.scm.net.NetConstants.ROOT_SCHEMA;
 import static org.junit.Assert.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.anyLong;
@@ -87,7 +89,8 @@ public class TestECUnderReplicationHandler {
   private int remainingMaintenanceRedundancy = 1;
 
   @BeforeEach
-  public void setup() {
+  public void setup() throws NodeNotFoundException,
+      AllSourcesOverloadedException {
     nodeManager = new MockNodeManager(true, 10) {
       @Override
       public NodeStatus getNodeStatus(DatanodeDetails dd) {
@@ -100,6 +103,26 @@ public class TestECUnderReplicationHandler {
         new ReplicationManager.ReplicationManagerConfiguration();
     Mockito.when(replicationManager.getConfig())
         .thenReturn(rmConf);
+
+    Mockito.when(replicationManager.getNodeStatus(any(DatanodeDetails.class)))
+        .thenAnswer(invocation -> {
+          DatanodeDetails dd = invocation.getArgument(0);
+          return new NodeStatus(dd.getPersistedOpState(),
+              HddsProtos.NodeState.HEALTHY, 0);
+        });
+
+    Mockito.when(replicationManager.createThrottledReplicationCommand(
+            Mockito.anyLong(), Mockito.anyList(),
+            Mockito.any(DatanodeDetails.class), Mockito.anyInt()))
+        .thenAnswer(invocationOnMock -> {
+          List<DatanodeDetails> sources = invocationOnMock.getArgument(1);
+          ReplicateContainerCommand command = ReplicateContainerCommand
+              .toTarget(invocationOnMock.getArgument(0),
+                  invocationOnMock.getArgument(2));
+          command.setReplicaIndex(invocationOnMock.getArgument(3));
+          return Pair.of(sources.get(0), command);
+        });
+
     conf = SCMTestUtils.getConf();
     repConfig = new ECReplicationConfig(DATA, PARITY);
     container = ReplicationTestUtil
@@ -162,7 +185,22 @@ public class TestECUnderReplicationHandler {
     ReplicateContainerCommand cmd = (ReplicateContainerCommand) cmds
         .iterator().next().getValue();
     Assertions.assertEquals(1, cmd.getReplicaIndex());
+  }
 
+  @Test
+  public void testUnderReplicationWithDecomNodesOverloaded()
+      throws IOException {
+    Set<ContainerReplica> availableReplicas = ReplicationTestUtil
+        .createReplicas(Pair.of(DECOMMISSIONING, 1), Pair.of(IN_SERVICE, 2),
+            Pair.of(IN_SERVICE, 3), Pair.of(IN_SERVICE, 4),
+            Pair.of(IN_SERVICE, 5));
+    Mockito.when(replicationManager.createThrottledReplicationCommand(
+            anyLong(), anyList(), any(), anyInt()))
+        .thenThrow(new AllSourcesOverloadedException("Overloaded"));
+
+    Assertions.assertThrows(AllSourcesOverloadedException.class, () ->
+        testUnderReplicationWithMissingIndexes(
+            Lists.emptyList(), availableReplicas, 1, 0, policy));
   }
 
   @Test
@@ -283,7 +321,7 @@ public class TestECUnderReplicationHandler {
 
     ECUnderReplicationHandler ecURH =
         new ECUnderReplicationHandler(
-            noNodesPolicy, conf, nodeManager, replicationManager);
+            noNodesPolicy, conf, replicationManager);
     ContainerHealthResult.UnderReplicatedHealthResult underRep =
         new ContainerHealthResult.UnderReplicatedHealthResult(container,
             1, false, false, false);
@@ -352,7 +390,7 @@ public class TestECUnderReplicationHandler {
 
     ECUnderReplicationHandler ecURH =
         new ECUnderReplicationHandler(
-            sameNodePolicy, conf, nodeManager, replicationManager);
+            sameNodePolicy, conf, replicationManager);
     ContainerHealthResult.UnderReplicatedHealthResult underRep =
         new ContainerHealthResult.UnderReplicatedHealthResult(container,
             1, false, false, false);
@@ -404,7 +442,7 @@ public class TestECUnderReplicationHandler {
 
     ECUnderReplicationHandler ecURH =
         new ECUnderReplicationHandler(
-            sameNodePolicy, conf, nodeManager, replicationManager);
+            sameNodePolicy, conf, replicationManager);
 
     ContainerHealthResult.UnderReplicatedHealthResult underRep =
         new ContainerHealthResult.UnderReplicatedHealthResult(container,
@@ -513,7 +551,7 @@ public class TestECUnderReplicationHandler {
         Mockito.mock(ContainerHealthResult.UnderReplicatedHealthResult.class);
     Mockito.when(result.getContainerInfo()).thenReturn(container);
     ECUnderReplicationHandler handler = new ECUnderReplicationHandler(
-        ecPlacementPolicy, conf, nodeManager, replicationManager);
+        ecPlacementPolicy, conf, replicationManager);
 
     Set<Pair<DatanodeDetails, SCMCommand<?>>> commands =
         handler.processAndCreateCommands(availableReplicas,
@@ -562,7 +600,7 @@ public class TestECUnderReplicationHandler {
         Mockito.mock(ContainerHealthResult.UnderReplicatedHealthResult.class);
     Mockito.when(result.getContainerInfo()).thenReturn(container);
     ECUnderReplicationHandler handler = new ECUnderReplicationHandler(
-        ecPlacementPolicy, conf, nodeManager, replicationManager);
+        ecPlacementPolicy, conf, replicationManager);
 
     Set<Pair<DatanodeDetails, SCMCommand<?>>> commands =
         handler.processAndCreateCommands(availableReplicas, pendingOps, result,
@@ -622,7 +660,7 @@ public class TestECUnderReplicationHandler {
       PlacementPolicy placementPolicy) throws IOException {
     ECUnderReplicationHandler ecURH =
         new ECUnderReplicationHandler(
-            placementPolicy, conf, nodeManager, replicationManager);
+            placementPolicy, conf, replicationManager);
     ContainerHealthResult.UnderReplicatedHealthResult result =
         Mockito.mock(ContainerHealthResult.UnderReplicatedHealthResult.class);
     Mockito.when(result.isUnrecoverable()).thenReturn(false);

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestRatisMisReplicationHandler.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestRatisMisReplicationHandler.java
@@ -27,7 +27,6 @@ import org.apache.hadoop.hdds.scm.ContainerPlacementStatus;
 import org.apache.hadoop.hdds.scm.PlacementPolicy;
 import org.apache.hadoop.hdds.scm.container.ContainerReplica;
 import org.apache.hadoop.hdds.scm.exceptions.SCMException;
-import org.apache.hadoop.hdds.scm.node.NodeManager;
 import org.apache.hadoop.hdds.scm.node.states.NodeNotFoundException;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
@@ -43,8 +42,11 @@ import java.util.Set;
 
 import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.NodeOperationalState.IN_MAINTENANCE;
 import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.NodeOperationalState.IN_SERVICE;
+import static org.junit.Assert.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.anyLong;
 
 /**
  * Tests the RatisReplicationHandling functionality.
@@ -52,7 +54,8 @@ import static org.mockito.ArgumentMatchers.anyList;
 public class TestRatisMisReplicationHandler extends TestMisReplicationHandler {
 
   @BeforeEach
-  public void setup() throws NodeNotFoundException {
+  public void setup() throws NodeNotFoundException,
+      AllSourcesOverloadedException {
     RatisReplicationConfig repConfig = RatisReplicationConfig
             .getInstance(ReplicationFactor.THREE);
     setup(repConfig);
@@ -170,11 +173,27 @@ public class TestRatisMisReplicationHandler extends TestMisReplicationHandler {
             pendingOp, 0, 1, 0);
   }
 
+
+  @Test
+  public void testAllSourcesOverloaded() throws IOException {
+    ReplicationManager replicationManager = getReplicationManager();
+    Mockito.when(replicationManager.createThrottledReplicationCommand(
+            anyLong(), anyList(), any(), anyInt()))
+        .thenThrow(new AllSourcesOverloadedException("Overloaded"));
+
+    Set<ContainerReplica> availableReplicas = ReplicationTestUtil
+        .createReplicas(Pair.of(IN_SERVICE, 0), Pair.of(IN_SERVICE, 0),
+            Pair.of(IN_SERVICE, 0));
+    assertThrows(AllSourcesOverloadedException.class,
+        () -> testMisReplication(availableReplicas, Collections.emptyList(),
+            0, 1, 1));
+  }
+
   @Override
   protected MisReplicationHandler getMisreplicationHandler(
           PlacementPolicy placementPolicy, OzoneConfiguration conf,
           ReplicationManager replicationManager) {
     return new RatisMisReplicationHandler(placementPolicy, conf,
-        replicationManager, false);
+        replicationManager, true);
   }
 }

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestRatisMisReplicationHandler.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestRatisMisReplicationHandler.java
@@ -28,6 +28,7 @@ import org.apache.hadoop.hdds.scm.PlacementPolicy;
 import org.apache.hadoop.hdds.scm.container.ContainerReplica;
 import org.apache.hadoop.hdds.scm.exceptions.SCMException;
 import org.apache.hadoop.hdds.scm.node.NodeManager;
+import org.apache.hadoop.hdds.scm.node.states.NodeNotFoundException;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -51,7 +52,7 @@ import static org.mockito.ArgumentMatchers.anyList;
 public class TestRatisMisReplicationHandler extends TestMisReplicationHandler {
 
   @BeforeEach
-  public void setup() {
+  public void setup() throws NodeNotFoundException {
     RatisReplicationConfig repConfig = RatisReplicationConfig
             .getInstance(ReplicationFactor.THREE);
     setup(repConfig);
@@ -172,8 +173,8 @@ public class TestRatisMisReplicationHandler extends TestMisReplicationHandler {
   @Override
   protected MisReplicationHandler getMisreplicationHandler(
           PlacementPolicy placementPolicy, OzoneConfiguration conf,
-          NodeManager nodeManager) {
-    return new RatisMisReplicationHandler(placementPolicy, conf, nodeManager,
-        false);
+          ReplicationManager replicationManager) {
+    return new RatisMisReplicationHandler(placementPolicy, conf,
+        replicationManager, false);
   }
 }

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestRatisUnderReplicationHandler.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestRatisUnderReplicationHandler.java
@@ -26,7 +26,6 @@ import org.apache.hadoop.hdds.protocol.DatanodeDetails;
 import org.apache.hadoop.hdds.protocol.MockDatanodeDetails;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.ContainerReplicaProto.State;
-import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.ReplicateContainerCommandProto;
 import org.apache.hadoop.hdds.scm.PlacementPolicy;
 import org.apache.hadoop.hdds.scm.container.ContainerInfo;
 import org.apache.hadoop.hdds.scm.container.ContainerReplica;
@@ -36,6 +35,7 @@ import org.apache.hadoop.hdds.scm.node.NodeManager;
 import org.apache.hadoop.hdds.scm.node.NodeStatus;
 import org.apache.hadoop.hdds.scm.node.states.NodeNotFoundException;
 import org.apache.hadoop.ozone.container.common.SCMTestUtils;
+import org.apache.hadoop.ozone.protocol.commands.ReplicateContainerCommand;
 import org.apache.hadoop.ozone.protocol.commands.SCMCommand;
 import org.junit.Assert;
 import org.junit.Before;
@@ -52,6 +52,7 @@ import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.NodeOperationalSt
 import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.NodeOperationalState.IN_SERVICE;
 import static org.apache.hadoop.hdds.scm.container.replication.ReplicationTestUtil.createContainerReplica;
 import static org.apache.hadoop.hdds.scm.container.replication.ReplicationTestUtil.createReplicas;
+import static org.junit.Assert.fail;
 
 /**
  * Tests for {@link RatisUnderReplicationHandler}.
@@ -66,7 +67,7 @@ public class TestRatisUnderReplicationHandler {
   private ReplicationManager replicationManager;
 
   @Before
-  public void setup() throws NodeNotFoundException {
+  public void setup() throws NodeNotFoundException, AllSourcesOverloadedException {
     container = ReplicationTestUtil.createContainer(
         HddsProtos.LifeCycleState.CLOSED, RATIS_REPLICATION_CONFIG);
 
@@ -79,14 +80,26 @@ public class TestRatisUnderReplicationHandler {
         .thenReturn(new ReplicationManagerConfiguration());
 
     /*
-     Return NodeStatus with NodeOperationalState as specified in
-     DatanodeDetails, and NodeState as HEALTHY.
-     */
-    Mockito.when(nodeManager.getNodeStatus(Mockito.any(DatanodeDetails.class)))
+      Return NodeStatus with NodeOperationalState as specified in
+      DatanodeDetails, and NodeState as HEALTHY.
+    */
+    Mockito.when(replicationManager.getNodeStatus(Mockito.any(DatanodeDetails.class)))
         .thenAnswer(invocationOnMock -> {
           DatanodeDetails dn = invocationOnMock.getArgument(0);
           return new NodeStatus(dn.getPersistedOpState(),
               HddsProtos.NodeState.HEALTHY);
+        });
+
+    Mockito.when(replicationManager.createThrottledReplicationCommand(
+        Mockito.anyLong(), Mockito.anyList(),
+            Mockito.any(DatanodeDetails.class), Mockito.anyInt()))
+        .thenAnswer(invocationOnMock -> {
+          List<DatanodeDetails> sources = invocationOnMock.getArgument(1);
+          ReplicateContainerCommand command = ReplicateContainerCommand
+              .toTarget(invocationOnMock.getArgument(0),
+              invocationOnMock.getArgument(2));
+          command.setReplicaIndex(invocationOnMock.getArgument(3));
+          return Pair.of(sources.get(0), command);
         });
   }
 
@@ -189,8 +202,7 @@ public class TestRatisUnderReplicationHandler {
     policy = ReplicationTestUtil.getNoNodesTestPlacementPolicy(nodeManager,
         conf);
     RatisUnderReplicationHandler handler =
-        new RatisUnderReplicationHandler(policy, conf, nodeManager,
-            replicationManager);
+        new RatisUnderReplicationHandler(policy, conf, replicationManager);
 
     Set<ContainerReplica> replicas
         = createReplicas(container.containerID(), State.CLOSED, 0, 0);
@@ -226,16 +238,10 @@ public class TestRatisUnderReplicationHandler {
         testProcessing(replicas, Collections.emptyList(),
             getUnderReplicatedHealthResult(), 2, 1);
     Assert.assertEquals(1, commands.size());
-    // only 1 command is present, get it and cast it to
-    // ReplicateContainerCommandProto
-    ReplicateContainerCommandProto command =
-        (ReplicateContainerCommandProto) commands.stream().findFirst().get()
-            .getValue().getProto();
+    Pair<DatanodeDetails, SCMCommand<?>> command = commands.stream()
+        .findFirst().get();
 
-    // assert that the only source DN is the DN that hosts closedReplica
-    Assert.assertEquals(1, command.getSourcesCount());
-    Assert.assertEquals(closedReplica.getDatanodeDetails().getUuidString(),
-        command.getSources(0).getUuid());
+    Assert.assertEquals(closedReplica.getDatanodeDetails(), command.getKey());
   }
 
   /**
@@ -256,8 +262,7 @@ public class TestRatisUnderReplicationHandler {
       ContainerHealthResult healthResult,
       int minHealthyForMaintenance, int expectNumCommands) throws IOException {
     RatisUnderReplicationHandler handler =
-        new RatisUnderReplicationHandler(policy, conf, nodeManager,
-            replicationManager);
+        new RatisUnderReplicationHandler(policy, conf, replicationManager);
 
     Set<Pair<DatanodeDetails, SCMCommand<?>>> commands =
         handler.processAndCreateCommands(replicas, pendingOps,

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestRatisUnderReplicationHandler.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestRatisUnderReplicationHandler.java
@@ -52,7 +52,6 @@ import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.NodeOperationalSt
 import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.NodeOperationalState.IN_SERVICE;
 import static org.apache.hadoop.hdds.scm.container.replication.ReplicationTestUtil.createContainerReplica;
 import static org.apache.hadoop.hdds.scm.container.replication.ReplicationTestUtil.createReplicas;
-import static org.junit.Assert.fail;
 
 /**
  * Tests for {@link RatisUnderReplicationHandler}.
@@ -67,7 +66,8 @@ public class TestRatisUnderReplicationHandler {
   private ReplicationManager replicationManager;
 
   @Before
-  public void setup() throws NodeNotFoundException, AllSourcesOverloadedException {
+  public void setup() throws NodeNotFoundException,
+      AllSourcesOverloadedException {
     container = ReplicationTestUtil.createContainer(
         HddsProtos.LifeCycleState.CLOSED, RATIS_REPLICATION_CONFIG);
 
@@ -83,7 +83,8 @@ public class TestRatisUnderReplicationHandler {
       Return NodeStatus with NodeOperationalState as specified in
       DatanodeDetails, and NodeState as HEALTHY.
     */
-    Mockito.when(replicationManager.getNodeStatus(Mockito.any(DatanodeDetails.class)))
+    Mockito.when(
+        replicationManager.getNodeStatus(Mockito.any(DatanodeDetails.class)))
         .thenAnswer(invocationOnMock -> {
           DatanodeDetails dn = invocationOnMock.getArgument(0);
           return new NodeStatus(dn.getPersistedOpState(),

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestReplicationManager.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestReplicationManager.java
@@ -81,6 +81,7 @@ import static org.apache.hadoop.hdds.scm.container.replication.ReplicationTestUt
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.eq;
 
 /**
  * Tests for the ReplicationManager.
@@ -845,6 +846,56 @@ public class TestReplicationManager {
     Assertions.assertEquals(src.getUuid(), sentCommand.getDatanodeId());
     Assertions.assertEquals(target,
         replicateContainerCommand.getTargetDatanode());
+  }
+
+  @Test
+  public void testCreateThrottledReplicateContainerCommand()
+      throws AllSourcesOverloadedException, NodeNotFoundException {
+    Map<DatanodeDetails, Integer> sourceNodes = new HashMap<>();
+    DatanodeDetails cmdTarget = MockDatanodeDetails.randomDatanodeDetails();
+    sourceNodes.put(cmdTarget, 0);
+    for (int i = 1; i < 3; i++) {
+      sourceNodes.put(MockDatanodeDetails.randomDatanodeDetails(), i * 5);
+    }
+
+    Mockito.when(nodeManager.getTotalDatanodeCommandCount(any(),
+            eq(SCMCommandProto.Type.replicateContainerCommand)))
+        .thenAnswer(invocation -> {
+          DatanodeDetails dn = invocation.getArgument(0);
+          return sourceNodes.get(dn);
+        });
+
+    DatanodeDetails destination = MockDatanodeDetails.randomDatanodeDetails();
+    Pair<DatanodeDetails, SCMCommand<?>> cmd = replicationManager
+        .createThrottledReplicationCommand(
+            1L, new ArrayList<>(sourceNodes.keySet()), destination, 0);
+    Assertions.assertEquals(cmdTarget, cmd.getLeft());
+    Assertions.assertEquals(destination,
+        ((ReplicateContainerCommand) cmd.getRight()).getTargetDatanode());
+    Assertions.assertEquals(0,
+        ((ReplicateContainerCommand) cmd.getRight()).getReplicaIndex());
+  }
+
+  @Test(expected = AllSourcesOverloadedException.class)
+  public void testCreateThrottledReplicateContainerCommandThrowsWhenNoSources()
+      throws AllSourcesOverloadedException, NodeNotFoundException {
+    int limit = replicationManager.getConfig().getDatanodeReplicationLimit();
+    Map<DatanodeDetails, Integer> sourceNodes = new HashMap<>();
+    for (int i = 0; i < 3; i++) {
+      sourceNodes.put(MockDatanodeDetails.randomDatanodeDetails(), limit + 1);
+    }
+
+    Mockito.when(nodeManager.getTotalDatanodeCommandCount(any(),
+            eq(SCMCommandProto.Type.replicateContainerCommand)))
+        .thenAnswer(invocation -> {
+          DatanodeDetails dn = invocation.getArgument(0);
+          return sourceNodes.get(dn);
+        });
+
+    DatanodeDetails destination = MockDatanodeDetails.randomDatanodeDetails();
+    Pair<DatanodeDetails, SCMCommand<?>> cmd = replicationManager
+        .createThrottledReplicationCommand(
+            1L, new ArrayList<>(sourceNodes.keySet()), destination, 0);
   }
 
   @SafeVarargs

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestReplicationManager.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestReplicationManager.java
@@ -893,8 +893,7 @@ public class TestReplicationManager {
         });
 
     DatanodeDetails destination = MockDatanodeDetails.randomDatanodeDetails();
-    Pair<DatanodeDetails, SCMCommand<?>> cmd = replicationManager
-        .createThrottledReplicationCommand(
+    replicationManager.createThrottledReplicationCommand(
             1L, new ArrayList<>(sourceNodes.keySet()), destination, 0);
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Create a configuration on Replication Manager that sets the limit of inflight replicate container commands to 20. The intention is to revisit this limit later to make it more dynamic, but this is a starting point.

Then create a method on ReplicationManager createThrottledReplicateContainerCommand, which create the replicateContainerCommands and take into consideration the pending commands on the target datanode. If not targets for the command have capacity, it will throw an exception.

Adjust the various places in ReplicationManager which send the replicateContainer commands to use the new method.

Additionally switch the default replication mode to Push (rather than download) and ensure the LegacyReplicationManager continues to use download as before.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-8110

## How was this patch tested?

Some changes to existing tests and a few new tests added.
