### PR TITLE
HDDS-8112. ECReconstructionCoordinator is not closed

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/DatanodeStateMachine.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/DatanodeStateMachine.java
@@ -94,6 +94,7 @@ public class DatanodeStateMachine implements Closeable {
   private final ExecutorService executorService;
   private final ConfigurationSource conf;
   private final SCMConnectionManager connectionManager;
+  private final ECReconstructionCoordinator ecReconstructionCoordinator;
   private StateContext context;
   private final OzoneContainer container;
   private final DatanodeCRLStore dnCRLStore;
@@ -202,9 +203,8 @@ public class DatanodeStateMachine implements Closeable {
 
     ecReconstructionMetrics = ECReconstructionMetrics.create();
 
-    ECReconstructionCoordinator ecReconstructionCoordinator =
-        new ECReconstructionCoordinator(conf, certClient, context,
-            ecReconstructionMetrics);
+    ecReconstructionCoordinator = new ECReconstructionCoordinator(
+        conf, certClient, context, ecReconstructionMetrics);
 
     // This is created as an instance variable as Mockito needs to access it in
     // a test. The test mocks it in a running mini-cluster.
@@ -390,6 +390,7 @@ public class DatanodeStateMachine implements Closeable {
    */
   @Override
   public void close() throws IOException {
+    IOUtils.close(LOG, ecReconstructionCoordinator);
     if (stateMachineThread != null) {
       stateMachineThread.interrupt();
     }


### PR DESCRIPTION
## What changes were proposed in this pull request?

`DatanodeStateMachine` creates `ECReconstructionCoordinator`, but never closes it.

https://issues.apache.org/jira/browse/HDDS-8112

## How was this patch tested?

Trivial fix.  Existing tests (for regression):

https://github.com/adoroszlai/hadoop-ozone/actions/runs/4366169736