### PR TITLE
HDDS-8119. Remove loosely related AutoCloseable from SendContainerOutputStream

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/replication/SendContainerOutputStream.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/replication/SendContainerOutputStream.java
@@ -18,31 +18,21 @@
 package org.apache.hadoop.ozone.container.replication;
 
 import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.SendContainerRequest;
-import org.apache.hadoop.hdds.utils.IOUtils;
 import org.apache.ratis.thirdparty.com.google.protobuf.ByteString;
 import org.apache.ratis.thirdparty.io.grpc.stub.StreamObserver;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import java.io.IOException;
 
 /**
  * Output stream adapter for SendContainerResponse.
  */
 class SendContainerOutputStream extends GrpcOutputStream<SendContainerRequest> {
 
-  private static final Logger LOG =
-      LoggerFactory.getLogger(SendContainerOutputStream.class);
-
   private final CopyContainerCompression compression;
-  private final AutoCloseable client;
 
   SendContainerOutputStream(
-      AutoCloseable client, StreamObserver<SendContainerRequest> streamObserver,
+      StreamObserver<SendContainerRequest> streamObserver,
       long containerId, int bufferSize, CopyContainerCompression compression) {
     super(streamObserver, containerId, bufferSize);
     this.compression = compression;
-    this.client = client;
   }
 
   @Override
@@ -54,14 +44,5 @@ class SendContainerOutputStream extends GrpcOutputStream<SendContainerRequest> {
         .setCompression(compression.toProto())
         .build();
     getStreamObserver().onNext(request);
-  }
-
-  @Override
-  public void close() throws IOException {
-    try {
-      super.close();
-    } finally {
-      IOUtils.close(LOG, client);
-    }
   }
 }

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/replication/TestSendContainerOutputStream.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/replication/TestSendContainerOutputStream.java
@@ -21,7 +21,6 @@ import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.SendContai
 import org.apache.ratis.thirdparty.com.google.protobuf.ByteString;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
-import org.mockito.Mock;
 
 import java.io.OutputStream;
 
@@ -35,23 +34,20 @@ import static org.mockito.Mockito.verify;
 class TestSendContainerOutputStream
     extends GrpcOutputStreamTest<SendContainerRequest> {
 
-  @Mock
-  private AutoCloseable client;
-
   TestSendContainerOutputStream() {
     super(SendContainerRequest.class);
   }
 
   @Override
   protected OutputStream createSubject() {
-    return new SendContainerOutputStream(client, getObserver(),
+    return new SendContainerOutputStream(getObserver(),
         getContainerId(), getBufferSize(), NO_COMPRESSION);
   }
 
   @ParameterizedTest
   @EnumSource
   void usesCompression(CopyContainerCompression compression) throws Exception {
-    OutputStream subject = new SendContainerOutputStream(client,
+    OutputStream subject = new SendContainerOutputStream(
         getObserver(), getContainerId(), getBufferSize(), compression);
 
     byte[] bytes = getRandomBytes(16);


### PR DESCRIPTION
## What changes were proposed in this pull request?

Minor refactoring to simplify closing of `GrpcReplicationClient`.

https://issues.apache.org/jira/browse/HDDS-8119

## How was this patch tested?

Existing unit/integration tests.

https://github.com/adoroszlai/hadoop-ozone/actions/runs/4368446905