### PR TITLE
HDDS-8131. Add Configuration for OM Ratis Log Purge Tuning Parameters.

### DIFF
--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/OMConfigKeys.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/OMConfigKeys.java
@@ -151,6 +151,15 @@ public final class OMConfigKeys {
   public static final String OZONE_OM_RATIS_LOG_PURGE_GAP =
       "ozone.om.ratis.log.purge.gap";
   public static final int OZONE_OM_RATIS_LOG_PURGE_GAP_DEFAULT = 1000000;
+  public static final String OZONE_OM_RATIS_LOG_PURGE_UPTO_SNAPSHOT_INDEX
+      = "ozone.om.ratis.log.purge.upto.snapshot.index";
+  public static final boolean
+      OZONE_OM_RATIS_LOG_PURGE_UPTO_SNAPSHOT_INDEX_DEFAULT = true;
+  public static final String
+      OZONE_OM_RATIS_LOG_PURGE_PRESERVATION_LOG_NUM
+      = "ozone.om.ratis.log.purge.preservation.log.num";
+  public static final long
+      OZONE_OM_RATIS_LOG_PURGE_PRESERVATION_LOG_NUM_DEFAULT = 0L;
 
   public static final String OZONE_OM_RATIS_SNAPSHOT_AUTO_TRIGGER_THRESHOLD_KEY
       = "ozone.om.ratis.snapshot.auto.trigger.threshold";

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/OzoneManagerRatisServer.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/OzoneManagerRatisServer.java
@@ -602,7 +602,21 @@ public final class OzoneManagerRatisServer {
         StorageUnit.BYTES);
     RaftServerConfigKeys.Log.setSegmentSizeMax(properties,
         SizeInBytes.valueOf(raftSegmentSize));
-    RaftServerConfigKeys.Log.setPurgeUptoSnapshotIndex(properties, true);
+
+    // Set to enable RAFT to purge logs up to Snapshot Index
+    RaftServerConfigKeys.Log.setPurgeUptoSnapshotIndex(properties,
+        conf.getBoolean(
+          OMConfigKeys.OZONE_OM_RATIS_LOG_PURGE_UPTO_SNAPSHOT_INDEX,
+          OMConfigKeys.OZONE_OM_RATIS_LOG_PURGE_UPTO_SNAPSHOT_INDEX_DEFAULT
+        )
+    );
+    // Set number of last RAFT logs to not be purged
+    RaftServerConfigKeys.Log.setPurgePreservationLogNum(properties,
+        conf.getLong(
+          OMConfigKeys.OZONE_OM_RATIS_LOG_PURGE_PRESERVATION_LOG_NUM,
+          OMConfigKeys.OZONE_OM_RATIS_LOG_PURGE_PRESERVATION_LOG_NUM_DEFAULT
+        )
+    );
 
     // Set RAFT segment pre-allocated size
     final long raftSegmentPreallocatedSize = (long) conf.getStorageSize(


### PR DESCRIPTION
## What changes were proposed in this pull request?

Currently Ozone Manager enables `raft.server.log.purge.upto.snapshot.index` by default.
However, for OM cluster with large metadata store, there might be a case where OM leader purge its Ratis logs before a slow follower replicated it to its log. This means that the follower needs to download the whole metadata store from the OM leader. This can be problematic if the metadata store in leader is too large.

We should add two configurations in OM to enable/disable Ratis purge parameters:

- `raft.server.log.purge.upto.snapshot.index`
  - Disabling this would guarantee that the OM leader will not purge its Ratis log unless all the logs have been replicated to all the followers (through commitIndex).
  - This would effectively means that there shouldn't be a case where the slow follower needs to download the full metadata from the leader. So no snapshot down from follower. For small OM metadata, it can be faster for follower to download the leader's metadata snapshot than normally replicating and applying the outstanding logs.
  - For a very slow follower / downed follower, the OM leader cannot purge the log until the follower catch up to it. This might increase the disk space usage for OM leader.
  - Default would be `true` to preserve the current OM snapshot behavior
- `raft.server.log.purge.preservation.log.num`
  - [RATIS-1626](https://issues.apache.org/jira/browse/RATIS-1626) introduces logic to preserve the latest n won't-be-purged logs
  - Setting n > 0 while still enabling raft.server.log.purge.upto.snapshot.index should balance a between the cost of preserving & transferring logs and the cost of transferring snapshot.
  - Default would be 0 to preserve the current OM snapshot behavior

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-8131

## How was this patch tested?

Should have already be covered in Ratis test.
