### PR TITLE
HDDS-7958. Ozone client not closed in integration tests

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/utils/IOUtils.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/utils/IOUtils.java
@@ -75,6 +75,9 @@ public final class IOUtils {
     }
   }
 
+  /**
+   * Close each argument, swallowing exceptions.
+   */
   public static void closeQuietly(AutoCloseable... closeables) {
     close(null, closeables);
   }

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/utils/IOUtils.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/utils/IOUtils.java
@@ -68,4 +68,8 @@ public final class IOUtils {
     }
   }
 
+  public static void closeQuietly(AutoCloseable... closeables) {
+    close(null, closeables);
+  }
+
 }

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/utils/IOUtils.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/utils/IOUtils.java
@@ -20,6 +20,8 @@ package org.apache.hadoop.hdds.utils;
 
 import org.slf4j.Logger;
 
+import java.io.Closeable;
+
 /**
  * Static helper utilities for IO / Closable classes.
  */
@@ -36,9 +38,11 @@ public final class IOUtils {
    *                   null.
    * @param closeables the objects to close
    */
-  public static void cleanupWithLogger(Logger logger,
-      java.io.Closeable... closeables) {
-    for (java.io.Closeable c : closeables) {
+  public static void cleanupWithLogger(Logger logger, Closeable... closeables) {
+    if (closeables == null) {
+      return;
+    }
+    for (Closeable c : closeables) {
       if (c != null) {
         try {
           c.close();
@@ -55,6 +59,9 @@ public final class IOUtils {
    * Close each argument, catching exceptions and logging them as error.
    */
   public static void close(Logger logger, AutoCloseable... closeables) {
+    if (closeables == null) {
+      return;
+    }
     for (AutoCloseable c : closeables) {
       if (c != null) {
         try {

--- a/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/utils/TestIOUtils.java
+++ b/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/utils/TestIOUtils.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hdds.utils;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayOutputStream;
+
+/**
+ * Tests for {@link IOUtils}.
+ */
+class TestIOUtils {
+
+  @Test
+  void closeQuietlyNull() {
+    ByteArrayOutputStream out = null;
+    IOUtils.closeQuietly(out);
+  }
+
+}

--- a/hadoop-ozone/fault-injection-test/mini-chaos-tests/src/test/java/org/apache/hadoop/ozone/TestMiniChaosOzoneCluster.java
+++ b/hadoop-ozone/fault-injection-test/mini-chaos-tests/src/test/java/org/apache/hadoop/ozone/TestMiniChaosOzoneCluster.java
@@ -136,7 +136,7 @@ public class TestMiniChaosOzoneCluster extends GenericCli {
     cluster.waitForClusterToBeReady();
 
     String volumeName = RandomStringUtils.randomAlphabetic(10).toLowerCase();
-    ObjectStore store = cluster.getRpcClient().getObjectStore();
+    ObjectStore store = cluster.getClient().getObjectStore();
     store.createVolume(volumeName);
     OzoneVolume volume = store.getVolume(volumeName);
 

--- a/hadoop-ozone/fault-injection-test/mini-chaos-tests/src/test/java/org/apache/hadoop/ozone/TestMiniChaosOzoneCluster.java
+++ b/hadoop-ozone/fault-injection-test/mini-chaos-tests/src/test/java/org/apache/hadoop/ozone/TestMiniChaosOzoneCluster.java
@@ -136,7 +136,7 @@ public class TestMiniChaosOzoneCluster extends GenericCli {
     cluster.waitForClusterToBeReady();
 
     String volumeName = RandomStringUtils.randomAlphabetic(10).toLowerCase();
-    ObjectStore store = cluster.getClient().getObjectStore();
+    ObjectStore store = cluster.newClient().getObjectStore();
     store.createVolume(volumeName);
     OzoneVolume volume = store.getVolume(volumeName);
 

--- a/hadoop-ozone/fault-injection-test/mini-chaos-tests/src/test/java/org/apache/hadoop/ozone/TestMiniChaosOzoneCluster.java
+++ b/hadoop-ozone/fault-injection-test/mini-chaos-tests/src/test/java/org/apache/hadoop/ozone/TestMiniChaosOzoneCluster.java
@@ -21,8 +21,10 @@ import org.apache.hadoop.hdds.client.DefaultReplicationConfig;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.hadoop.hdds.cli.GenericCli;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import org.apache.hadoop.hdds.utils.IOUtils;
 import org.apache.hadoop.ozone.client.BucketArgs;
 import org.apache.hadoop.ozone.client.ObjectStore;
+import org.apache.hadoop.ozone.client.OzoneClient;
 import org.apache.hadoop.ozone.client.OzoneVolume;
 import org.apache.hadoop.ozone.failure.Failures;
 import org.apache.hadoop.ozone.freon.FreonReplicationOptions;
@@ -108,6 +110,7 @@ public class TestMiniChaosOzoneCluster extends GenericCli {
       AllowedBucketLayouts.FILE_SYSTEM_OPTIMIZED;
 
   private static MiniOzoneChaosCluster cluster;
+  private static OzoneClient client;
   private static MiniOzoneLoadGenerator loadGenerator;
 
   private static String omServiceId = null;
@@ -135,8 +138,9 @@ public class TestMiniChaosOzoneCluster extends GenericCli {
     cluster = chaosBuilder.build();
     cluster.waitForClusterToBeReady();
 
+    client = cluster.newClient();
+    ObjectStore store = client.getObjectStore();
     String volumeName = RandomStringUtils.randomAlphabetic(10).toLowerCase();
-    ObjectStore store = cluster.newClient().getObjectStore();
     store.createVolume(volumeName);
     OzoneVolume volume = store.getVolume(volumeName);
 
@@ -194,6 +198,8 @@ public class TestMiniChaosOzoneCluster extends GenericCli {
     if (loadGenerator != null) {
       loadGenerator.shutdownLoadGenerator();
     }
+
+    IOUtils.closeQuietly(client);
 
     if (cluster != null) {
       cluster.shutdown();

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestDirectoryDeletingServiceWithFSO.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestDirectoryDeletingServiceWithFSO.java
@@ -91,7 +91,7 @@ public class TestDirectoryDeletingServiceWithFSO {
         .setNumDatanodes(3)
         .build();
     cluster.waitForClusterToBeReady();
-    client = cluster.getClient();
+    client = cluster.newClient();
 
     // create a volume and a bucket to be used by OzoneFileSystem
     OzoneBucket bucket = TestDataUtil.createVolumeAndBucket(client,

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestDirectoryDeletingServiceWithFSO.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestDirectoryDeletingServiceWithFSO.java
@@ -18,7 +18,6 @@
 
 package org.apache.hadoop.fs.ozone;
 
-import org.apache.commons.io.IOUtils;
 import org.apache.hadoop.fs.CommonConfigurationKeysPublic;
 import org.apache.hadoop.fs.FSDataOutputStream;
 import org.apache.hadoop.fs.FileStatus;
@@ -26,11 +25,13 @@ import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.contract.ContractTestUtils;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import org.apache.hadoop.hdds.utils.IOUtils;
 import org.apache.hadoop.hdds.utils.db.Table;
 import org.apache.hadoop.ozone.MiniOzoneCluster;
 import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.hadoop.ozone.TestDataUtil;
 import org.apache.hadoop.ozone.client.OzoneBucket;
+import org.apache.hadoop.ozone.client.OzoneClient;
 import org.apache.hadoop.ozone.om.service.DirectoryDeletingService;
 import org.apache.hadoop.ozone.om.service.KeyDeletingService;
 import org.apache.hadoop.ozone.om.OMConfigKeys;
@@ -75,6 +76,7 @@ public class TestDirectoryDeletingServiceWithFSO {
   private static FileSystem fs;
   private static String volumeName;
   private static String bucketName;
+  private static OzoneClient client;
 
   @BeforeAll
   public static void init() throws Exception {
@@ -89,9 +91,10 @@ public class TestDirectoryDeletingServiceWithFSO {
         .setNumDatanodes(3)
         .build();
     cluster.waitForClusterToBeReady();
+    client = cluster.getClient();
 
     // create a volume and a bucket to be used by OzoneFileSystem
-    OzoneBucket bucket = TestDataUtil.createVolumeAndBucket(cluster,
+    OzoneBucket bucket = TestDataUtil.createVolumeAndBucket(client,
         BucketLayout.FILE_SYSTEM_OPTIMIZED);
     volumeName = bucket.getVolumeName();
     bucketName = bucket.getName();
@@ -109,6 +112,7 @@ public class TestDirectoryDeletingServiceWithFSO {
 
   @AfterAll
   public static void teardown() {
+    IOUtils.closeQuietly(client);
     if (cluster != null) {
       cluster.shutdown();
     }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestHSync.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestHSync.java
@@ -23,6 +23,8 @@ import java.io.IOException;
 import java.security.GeneralSecurityException;
 import java.util.UUID;
 import java.util.concurrent.ThreadLocalRandom;
+
+import org.apache.hadoop.hdds.utils.IOUtils;
 import org.apache.hadoop.conf.StorageUnit;
 import org.apache.hadoop.crypto.CipherSuite;
 import org.apache.hadoop.crypto.CryptoCodec;
@@ -43,6 +45,7 @@ import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.hadoop.ozone.TestDataUtil;
 import org.apache.hadoop.ozone.client.BucketArgs;
 import org.apache.hadoop.ozone.client.OzoneBucket;
+import org.apache.hadoop.ozone.client.OzoneClient;
 import org.apache.hadoop.ozone.client.io.ECKeyOutputStream;
 import org.apache.hadoop.ozone.client.io.KeyOutputStream;
 import org.apache.hadoop.ozone.client.io.OzoneOutputStream;
@@ -82,6 +85,7 @@ public class TestHSync {
   private static OzoneBucket bucket;
 
   private static final OzoneConfiguration CONF = new OzoneConfiguration();
+  private static OzoneClient client;
 
   @BeforeAll
   public static void init() throws Exception {
@@ -106,13 +110,15 @@ public class TestHSync {
         .setDataStreamStreamWindowSize(5 * chunkSize)
         .build();
     cluster.waitForClusterToBeReady();
+    client = cluster.getClient();
 
     // create a volume and a bucket to be used by OzoneFileSystem
-    bucket = TestDataUtil.createVolumeAndBucket(cluster, layout);
+    bucket = TestDataUtil.createVolumeAndBucket(client, layout);
   }
 
   @AfterAll
   public static void teardown() {
+    IOUtils.closeQuietly(client);
     if (cluster != null) {
       cluster.shutdown();
     }
@@ -255,7 +261,7 @@ public class TestHSync {
                 3, 2, ECReplicationConfig.EcCodec.RS, 1024)));
     BucketArgs omBucketArgs = builder.build();
     String ecBucket = UUID.randomUUID().toString();
-    TestDataUtil.createBucket(cluster, bucket.getVolumeName(), omBucketArgs,
+    TestDataUtil.createBucket(client, bucket.getVolumeName(), omBucketArgs,
         ecBucket);
     String ecUri = String.format("%s://%s.%s/",
         OzoneConsts.OZONE_URI_SCHEME, ecBucket, bucket.getVolumeName());

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestHSync.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestHSync.java
@@ -110,7 +110,7 @@ public class TestHSync {
         .setDataStreamStreamWindowSize(5 * chunkSize)
         .build();
     cluster.waitForClusterToBeReady();
-    client = cluster.getClient();
+    client = cluster.newClient();
 
     // create a volume and a bucket to be used by OzoneFileSystem
     bucket = TestDataUtil.createVolumeAndBucket(client, layout);

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFSBucketLayout.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFSBucketLayout.java
@@ -17,13 +17,14 @@
  */
 package org.apache.hadoop.fs.ozone;
 
-import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.scm.OzoneClientConfig;
+import org.apache.hadoop.hdds.utils.IOUtils;
 import org.apache.hadoop.ozone.OzoneConfigKeys;
 import org.apache.hadoop.ozone.client.ObjectStore;
 import org.apache.hadoop.ozone.client.OzoneBucket;
+import org.apache.hadoop.ozone.client.OzoneClient;
 import org.apache.hadoop.ozone.om.exceptions.OMException;
 import org.apache.hadoop.ozone.om.helpers.BucketLayout;
 import org.junit.BeforeClass;
@@ -63,6 +64,7 @@ public class TestOzoneFSBucketLayout {
   private static String defaultBucketLayout;
   private static MiniOzoneCluster cluster = null;
   private static ObjectStore objectStore;
+  private static OzoneClient client;
   private BasicRootedOzoneClientAdapterImpl adapter;
   private static String rootPath;
   private static String volumeName;
@@ -116,19 +118,21 @@ public class TestOzoneFSBucketLayout {
         .setNumDatanodes(3)
         .build();
     cluster.waitForClusterToBeReady();
-    objectStore = cluster.getClient().getObjectStore();
+    client = cluster.getClient();
+    objectStore = client.getObjectStore();
     rootPath = String.format("%s://%s/",
         OzoneConsts.OZONE_OFS_URI_SCHEME, conf.get(OZONE_OM_ADDRESS_KEY));
 
     // create a volume and a bucket to be used by RootedOzoneFileSystem (OFS)
     volumeName =
-        TestDataUtil.createVolumeAndBucket(cluster)
+        TestDataUtil.createVolumeAndBucket(client)
             .getVolumeName();
     volumePath = new Path(OZONE_URI_DELIMITER, volumeName);
   }
 
   @AfterClass
   public static void teardown() throws IOException {
+    IOUtils.closeQuietly(client);
     // Tear down the cluster after EACH set of parameters
     if (cluster != null) {
       cluster.shutdown();

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFSBucketLayout.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFSBucketLayout.java
@@ -118,7 +118,7 @@ public class TestOzoneFSBucketLayout {
         .setNumDatanodes(3)
         .build();
     cluster.waitForClusterToBeReady();
-    client = cluster.getClient();
+    client = cluster.newClient();
     objectStore = client.getObjectStore();
     rootPath = String.format("%s://%s/",
         OzoneConsts.OZONE_OFS_URI_SCHEME, conf.get(OZONE_OM_ADDRESS_KEY));

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFSInputStream.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFSInputStream.java
@@ -45,6 +45,7 @@ import org.apache.hadoop.ozone.client.BucketArgs;
 import org.apache.hadoop.ozone.client.OzoneBucket;
 
 import org.apache.commons.lang3.RandomStringUtils;
+import org.apache.hadoop.ozone.client.OzoneClient;
 import org.apache.hadoop.ozone.om.OMConfigKeys;
 import org.apache.hadoop.ozone.om.helpers.BucketLayout;
 import org.junit.AfterClass;
@@ -67,6 +68,7 @@ public class TestOzoneFSInputStream {
   @Rule
   public Timeout timeout = Timeout.seconds(300);
   private static MiniOzoneCluster cluster = null;
+  private static OzoneClient client;
   private static FileSystem fs;
   private static FileSystem ecFs;
   private static Path filePath = null;
@@ -93,9 +95,10 @@ public class TestOzoneFSInputStream {
         .setStreamBufferMaxSize(4) // MB
         .build();
     cluster.waitForClusterToBeReady();
+    client = cluster.getClient();
 
     // create a volume and a bucket to be used by OzoneFileSystem
-    OzoneBucket bucket = TestDataUtil.createVolumeAndBucket(cluster);
+    OzoneBucket bucket = TestDataUtil.createVolumeAndBucket(client);
 
     // Set the fs.defaultFS and start the filesystem
     String uri = String.format("%s://%s.%s/",
@@ -119,7 +122,7 @@ public class TestOzoneFSInputStream {
                 1024)));
     BucketArgs omBucketArgs = builder.build();
     String ecBucket = UUID.randomUUID().toString();
-    TestDataUtil.createBucket(cluster, bucket.getVolumeName(), omBucketArgs,
+    TestDataUtil.createBucket(client, bucket.getVolumeName(), omBucketArgs,
         ecBucket);
     String ecUri = String.format("%s://%s.%s/",
         OzoneConsts.OZONE_URI_SCHEME, ecBucket, bucket.getVolumeName());
@@ -132,6 +135,7 @@ public class TestOzoneFSInputStream {
    */
   @AfterClass
   public static void shutdown() throws IOException {
+    IOUtils.cleanupWithLogger(null, client);
     fs.close();
     ecFs.close();
     cluster.shutdown();

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFSInputStream.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFSInputStream.java
@@ -95,7 +95,7 @@ public class TestOzoneFSInputStream {
         .setStreamBufferMaxSize(4) // MB
         .build();
     cluster.waitForClusterToBeReady();
-    client = cluster.getClient();
+    client = cluster.newClient();
 
     // create a volume and a bucket to be used by OzoneFileSystem
     OzoneBucket bucket = TestDataUtil.createVolumeAndBucket(client);

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFSWithObjectStoreCreate.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFSWithObjectStoreCreate.java
@@ -94,7 +94,7 @@ public class TestOzoneFSWithObjectStoreCreate {
         .setNumDatanodes(3)
         .build();
     cluster.waitForClusterToBeReady();
-    client = cluster.getClient();
+    client = cluster.newClient();
   }
 
   @AfterClass

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFSWithObjectStoreCreate.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFSWithObjectStoreCreate.java
@@ -454,7 +454,7 @@ public class TestOzoneFSWithObjectStoreCreate {
     FSDataInputStream fsDataInputStream = o3fs.open(new Path(key));
     read = new byte[length];
     fsDataInputStream.read(read, 0, length);
-    ozoneInputStream.close();
+    fsDataInputStream.close();
 
     Assert.assertEquals(inputString, new String(read, UTF_8));
   }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFSWithObjectStoreCreate.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFSWithObjectStoreCreate.java
@@ -18,7 +18,6 @@
 
 package org.apache.hadoop.fs.ozone;
 
-import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.hadoop.fs.FSDataInputStream;
 import org.apache.hadoop.fs.FileAlreadyExistsException;
@@ -26,10 +25,12 @@ import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import org.apache.hadoop.hdds.utils.IOUtils;
 import org.apache.hadoop.ozone.MiniOzoneCluster;
 import org.apache.hadoop.ozone.OmUtils;
 import org.apache.hadoop.ozone.TestDataUtil;
 import org.apache.hadoop.ozone.client.OzoneBucket;
+import org.apache.hadoop.ozone.client.OzoneClient;
 import org.apache.hadoop.ozone.client.OzoneKey;
 import org.apache.hadoop.ozone.client.OzoneVolume;
 import org.apache.hadoop.ozone.client.io.OzoneInputStream;
@@ -74,6 +75,7 @@ public class TestOzoneFSWithObjectStoreCreate {
   private String rootPath;
 
   private static MiniOzoneCluster cluster = null;
+  private static OzoneClient client;
 
   private OzoneFileSystem o3fs;
 
@@ -92,10 +94,12 @@ public class TestOzoneFSWithObjectStoreCreate {
         .setNumDatanodes(3)
         .build();
     cluster.waitForClusterToBeReady();
+    client = cluster.getClient();
   }
 
   @AfterClass
   public static void teardownClass() {
+    IOUtils.closeQuietly(client);
     if (cluster != null) {
       cluster.shutdown();
     }
@@ -109,7 +113,7 @@ public class TestOzoneFSWithObjectStoreCreate {
     OzoneConfiguration conf = cluster.getConf();
 
     // create a volume and a bucket to be used by OzoneFileSystem
-    TestDataUtil.createVolumeAndBucket(cluster, volumeName, bucketName);
+    TestDataUtil.createVolumeAndBucket(client, volumeName, bucketName);
 
     rootPath = String.format("%s://%s.%s/", OZONE_URI_SCHEME, bucketName,
         volumeName);
@@ -125,7 +129,7 @@ public class TestOzoneFSWithObjectStoreCreate {
   public void test() throws Exception {
 
     OzoneVolume ozoneVolume =
-        cluster.getRpcClient().getObjectStore().getVolume(volumeName);
+        client.getObjectStore().getVolume(volumeName);
 
     OzoneBucket ozoneBucket = ozoneVolume.getBucket(bucketName);
 
@@ -163,7 +167,7 @@ public class TestOzoneFSWithObjectStoreCreate {
   @Test
   public void testObjectStoreCreateWithO3fs() throws Exception {
     OzoneVolume ozoneVolume =
-        cluster.getRpcClient().getObjectStore().getVolume(volumeName);
+        client.getObjectStore().getVolume(volumeName);
 
     OzoneBucket ozoneBucket = ozoneVolume.getBucket(bucketName);
 
@@ -248,7 +252,7 @@ public class TestOzoneFSWithObjectStoreCreate {
   public void testKeyCreationFailDuetoDirectoryCreationBeforeCommit()
       throws Exception {
     OzoneVolume ozoneVolume =
-        cluster.getRpcClient().getObjectStore().getVolume(volumeName);
+        client.getObjectStore().getVolume(volumeName);
 
     OzoneBucket ozoneBucket = ozoneVolume.getBucket(bucketName);
 
@@ -277,7 +281,7 @@ public class TestOzoneFSWithObjectStoreCreate {
   public void testMPUFailDuetoDirectoryCreationBeforeComplete()
       throws Exception {
     OzoneVolume ozoneVolume =
-        cluster.getRpcClient().getObjectStore().getVolume(volumeName);
+        client.getObjectStore().getVolume(volumeName);
 
     OzoneBucket ozoneBucket = ozoneVolume.getBucket(bucketName);
 
@@ -343,7 +347,7 @@ public class TestOzoneFSWithObjectStoreCreate {
     }
 
     OzoneVolume ozoneVolume =
-        cluster.getRpcClient().getObjectStore().getVolume(volumeName);
+        client.getObjectStore().getVolume(volumeName);
     OzoneBucket ozoneBucket = ozoneVolume.getBucket(bucketName);
     ozoneBucket.createDirectory("t1/t2");
     try {
@@ -360,7 +364,7 @@ public class TestOzoneFSWithObjectStoreCreate {
   public void testListKeysWithNotNormalizedPath() throws Exception {
 
     OzoneVolume ozoneVolume =
-        cluster.getRpcClient().getObjectStore().getVolume(volumeName);
+        client.getObjectStore().getVolume(volumeName);
 
     OzoneBucket ozoneBucket = ozoneVolume.getBucket(bucketName);
 

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFileChecksum.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFileChecksum.java
@@ -18,7 +18,6 @@
 package org.apache.hadoop.fs.ozone;
 
 import com.google.common.collect.ImmutableList;
-import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.hadoop.fs.CommonConfigurationKeysPublic;
 import org.apache.hadoop.fs.FileChecksum;
@@ -29,11 +28,13 @@ import org.apache.hadoop.hdds.client.ECReplicationConfig;
 import org.apache.hadoop.hdds.client.ReplicationType;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.protocol.StorageType;
+import org.apache.hadoop.hdds.utils.IOUtils;
 import org.apache.hadoop.ozone.MiniOzoneCluster;
 import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.hadoop.ozone.TestDataUtil;
 import org.apache.hadoop.ozone.client.BucketArgs;
 import org.apache.hadoop.ozone.client.OzoneBucket;
+import org.apache.hadoop.ozone.client.OzoneClient;
 import org.apache.hadoop.ozone.om.helpers.BucketLayout;
 import org.apache.hadoop.util.StringUtils;
 import org.junit.Rule;
@@ -69,6 +70,7 @@ public class TestOzoneFileChecksum {
   private RootedOzoneFileSystem ofs;
   private BasicRootedOzoneClientAdapterImpl adapter;
   private String rootPath;
+  private OzoneClient client;
 
   @BeforeEach
   public void setup() throws IOException,
@@ -78,6 +80,7 @@ public class TestOzoneFileChecksum {
         .setNumDatanodes(5)
         .build();
     cluster.waitForClusterToBeReady();
+    client = cluster.getClient();
     rootPath = String.format("%s://%s/",
         OzoneConsts.OZONE_OFS_URI_SCHEME, conf.get(OZONE_OM_ADDRESS_KEY));
     conf.set(CommonConfigurationKeysPublic.FS_DEFAULT_NAME_KEY, rootPath);
@@ -88,6 +91,7 @@ public class TestOzoneFileChecksum {
 
   @AfterEach
   public void teardown() {
+    IOUtils.closeQuietly(client);
     if (cluster != null) {
       cluster.shutdown();
     }
@@ -114,8 +118,8 @@ public class TestOzoneFileChecksum {
 
     String vol2 = UUID.randomUUID().toString();
     String legacyBucket = UUID.randomUUID().toString();
-    TestDataUtil.createVolumeAndBucket(cluster, vol2,
-        legacyBucket, BucketLayout.LEGACY, omBucketArgs1);
+    TestDataUtil.createVolumeAndBucket(client, vol2,
+        legacyBucket, omBucketArgs1);
 
     try (OzoneFSOutputStream file = adapter.createFile(vol2 +
         "/" + legacyBucket + "/test", (short) 3, true, false)) {
@@ -139,7 +143,7 @@ public class TestOzoneFileChecksum {
     String vol = UUID.randomUUID().toString();
     String ecBucket = UUID.randomUUID().toString();
     final OzoneBucket bucket101 = TestDataUtil
-        .createVolumeAndBucket(cluster, vol, ecBucket, BucketLayout.LEGACY,
+        .createVolumeAndBucket(client, vol, ecBucket,
             omBucketArgs);
 
     Assertions.assertEquals(ReplicationType.EC.name(),

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFileChecksum.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFileChecksum.java
@@ -80,7 +80,7 @@ public class TestOzoneFileChecksum {
         .setNumDatanodes(5)
         .build();
     cluster.waitForClusterToBeReady();
-    client = cluster.getClient();
+    client = cluster.newClient();
     rootPath = String.format("%s://%s/",
         OzoneConsts.OZONE_OFS_URI_SCHEME, conf.get(OZONE_OM_ADDRESS_KEY));
     conf.set(CommonConfigurationKeysPublic.FS_DEFAULT_NAME_KEY, rootPath);

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFileInterfaces.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFileInterfaces.java
@@ -29,7 +29,6 @@ import java.util.UUID;
 
 import org.apache.hadoop.conf.StorageUnit;
 import org.apache.hadoop.fs.BlockLocation;
-import org.apache.hadoop.fs.CommonConfigurationKeysPublic;
 import org.apache.hadoop.fs.FSDataInputStream;
 import org.apache.hadoop.fs.FSDataOutputStream;
 import org.apache.hadoop.fs.FileStatus;
@@ -60,6 +59,8 @@ import org.apache.hadoop.util.Time;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import org.apache.hadoop.hdds.utils.IOUtils;
 import org.apache.commons.lang3.RandomStringUtils;
+
+import static org.apache.hadoop.fs.CommonConfigurationKeysPublic.FS_DEFAULT_NAME_KEY;
 import static org.apache.hadoop.fs.ozone.Constants.OZONE_DEFAULT_USER;
 
 import org.junit.After;
@@ -186,7 +187,7 @@ public class TestOzoneFileInterfaces {
             volumeName);
     if (setDefaultFs) {
       // Set the fs.defaultFS and start the filesystem
-      conf.set(CommonConfigurationKeysPublic.FS_DEFAULT_NAME_KEY, rootPath);
+      conf.set(FS_DEFAULT_NAME_KEY, rootPath);
       fs = FileSystem.get(conf);
     } else {
       fs = FileSystem.get(new URI(rootPath + "/test.txt"), conf);
@@ -569,7 +570,7 @@ public class TestOzoneFileInterfaces {
           OzoneConsts.OZONE_URI_SCHEME, obsBucket, obsVolume);
 
       OzoneConfiguration config = (OzoneConfiguration) fs.getConf();
-      config.set(CommonConfigurationKeysPublic.FS_DEFAULT_NAME_KEY, obsRootPath);
+      config.set(FS_DEFAULT_NAME_KEY, obsRootPath);
 
       try {
         fs = FileSystem.get(fs.getConf());

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFileInterfaces.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFileInterfaces.java
@@ -177,7 +177,7 @@ public class TestOzoneFileInterfaces {
     OzoneConfiguration conf = cluster.getConf();
 
     // create a volume and a bucket to be used by OzoneFileSystem
-    try (OzoneClient client = cluster.getClient()) {
+    try (OzoneClient client = cluster.newClient()) {
       TestDataUtil.createVolumeAndBucket(client, volumeName, bucketName,
           getBucketLayout());
     }
@@ -554,7 +554,7 @@ public class TestOzoneFileInterfaces {
   public void testFileSystemWithObjectStoreLayout() throws IOException {
     String obsVolume = UUID.randomUUID().toString();
 
-    try (OzoneClient client = cluster.getClient()) {
+    try (OzoneClient client = cluster.newClient()) {
       ObjectStore store = client.getObjectStore();
 
       // Create volume and bucket

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFileSystem.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFileSystem.java
@@ -18,7 +18,6 @@
 
 package org.apache.hadoop.fs.ozone;
 
-import org.apache.commons.io.IOUtils;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.CommonConfigurationKeysPublic;
 import org.apache.hadoop.fs.FSDataInputStream;
@@ -40,6 +39,7 @@ import org.apache.hadoop.hdds.client.ReplicationType;
 import org.apache.hadoop.hdds.client.StandaloneReplicationConfig;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
+import org.apache.hadoop.hdds.utils.IOUtils;
 import org.apache.hadoop.ozone.MiniOzoneCluster;
 import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.hadoop.ozone.TestDataUtil;
@@ -183,7 +183,7 @@ public class TestOzoneFileSystem {
     writeClient = client.getObjectStore()
         .getClientProxy().getOzoneManagerClient();
     // create a volume and a bucket to be used by OzoneFileSystem
-    ozoneBucket = TestDataUtil.createVolumeAndBucket(cluster, bucketLayout);
+    ozoneBucket = TestDataUtil.createVolumeAndBucket(client, bucketLayout);
     volumeName = ozoneBucket.getVolumeName();
     bucketName = ozoneBucket.getName();
 
@@ -1515,7 +1515,7 @@ public class TestOzoneFileSystem {
   public void testCreateKeyShouldUseRefreshedBucketReplicationConfig()
       throws IOException {
     OzoneBucket bucket =
-        TestDataUtil.createVolumeAndBucket(cluster, bucketLayout);
+        TestDataUtil.createVolumeAndBucket(client, bucketLayout);
     final TestClock testClock = new TestClock(Instant.now(), ZoneOffset.UTC);
 
     String rootPath = String

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFileSystem.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFileSystem.java
@@ -179,7 +179,7 @@ public class TestOzoneFileSystem {
             .build();
     cluster.waitForClusterToBeReady();
 
-    client = cluster.getRpcClient();
+    client = cluster.getClient();
     writeClient = client.getObjectStore()
         .getClientProxy().getOzoneManagerClient();
     // create a volume and a bucket to be used by OzoneFileSystem

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFileSystem.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFileSystem.java
@@ -179,7 +179,7 @@ public class TestOzoneFileSystem {
             .build();
     cluster.waitForClusterToBeReady();
 
-    client = cluster.getClient();
+    client = cluster.newClient();
     writeClient = client.getObjectStore()
         .getClientProxy().getOzoneManagerClient();
     // create a volume and a bucket to be used by OzoneFileSystem

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFileSystemMetrics.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFileSystemMetrics.java
@@ -18,6 +18,7 @@
 
 package org.apache.hadoop.fs.ozone;
 
+import org.apache.hadoop.hdds.utils.IOUtils;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.hadoop.fs.CommonConfigurationKeysPublic;
 import org.apache.hadoop.fs.FSDataOutputStream;
@@ -28,6 +29,7 @@ import org.apache.hadoop.ozone.MiniOzoneCluster;
 import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.hadoop.ozone.TestDataUtil;
 import org.apache.hadoop.ozone.client.OzoneBucket;
+import org.apache.hadoop.ozone.client.OzoneClient;
 import org.apache.hadoop.ozone.client.io.OzoneOutputStream;
 import org.apache.hadoop.ozone.om.OMConfigKeys;
 import org.apache.hadoop.ozone.om.helpers.BucketLayout;
@@ -52,6 +54,7 @@ public class TestOzoneFileSystemMetrics {
   @Rule
   public Timeout timeout = Timeout.seconds(300);
   private static MiniOzoneCluster cluster = null;
+  private static OzoneClient client;
   private static FileSystem fs;
   private static OzoneBucket bucket;
 
@@ -81,9 +84,10 @@ public class TestOzoneFileSystemMetrics {
         .setStreamBufferMaxSize(4) // MB
         .build();
     cluster.waitForClusterToBeReady();
+    client = cluster.getClient();
 
     // create a volume and a bucket to be used by OzoneFileSystem
-    bucket = TestDataUtil.createVolumeAndBucket(cluster);
+    bucket = TestDataUtil.createVolumeAndBucket(client);
 
     // Set the fs.defaultFS and start the filesystem
     String uri = String.format("%s://%s.%s/",
@@ -97,6 +101,7 @@ public class TestOzoneFileSystemMetrics {
    */
   @AfterClass
   public static void shutdown() throws IOException {
+    IOUtils.closeQuietly(client);
     fs.close();
     cluster.shutdown();
   }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFileSystemMetrics.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFileSystemMetrics.java
@@ -84,7 +84,7 @@ public class TestOzoneFileSystemMetrics {
         .setStreamBufferMaxSize(4) // MB
         .build();
     cluster.waitForClusterToBeReady();
-    client = cluster.getClient();
+    client = cluster.newClient();
 
     // create a volume and a bucket to be used by OzoneFileSystem
     bucket = TestDataUtil.createVolumeAndBucket(client);

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFileSystemMissingParent.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFileSystemMissingParent.java
@@ -62,7 +62,7 @@ public class TestOzoneFileSystemMissingParent {
 
     cluster = MiniOzoneCluster.newBuilder(conf).setNumDatanodes(3).build();
     cluster.waitForClusterToBeReady();
-    client = cluster.getClient();
+    client = cluster.newClient();
 
     OzoneBucket bucket = TestDataUtil.createVolumeAndBucket(client);
 

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFileSystemMissingParent.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFileSystemMissingParent.java
@@ -18,6 +18,7 @@
 
 package org.apache.hadoop.fs.ozone;
 
+import org.apache.hadoop.hdds.utils.IOUtils;
 import org.apache.hadoop.fs.CommonConfigurationKeysPublic;
 import org.apache.hadoop.fs.FSDataOutputStream;
 import org.apache.hadoop.fs.FileSystem;
@@ -27,6 +28,7 @@ import org.apache.hadoop.ozone.MiniOzoneCluster;
 import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.hadoop.ozone.TestDataUtil;
 import org.apache.hadoop.ozone.client.OzoneBucket;
+import org.apache.hadoop.ozone.client.OzoneClient;
 import org.apache.hadoop.ozone.om.OMConfigKeys;
 import org.apache.hadoop.ozone.om.exceptions.OMException;
 import org.apache.ozone.test.LambdaTestUtils;
@@ -49,6 +51,7 @@ public class TestOzoneFileSystemMissingParent {
   private static MiniOzoneCluster cluster;
   private static Path bucketPath;
   private static FileSystem fs;
+  private static OzoneClient client;
 
   @BeforeClass
   public static void init() throws Exception {
@@ -59,8 +62,9 @@ public class TestOzoneFileSystemMissingParent {
 
     cluster = MiniOzoneCluster.newBuilder(conf).setNumDatanodes(3).build();
     cluster.waitForClusterToBeReady();
+    client = cluster.getClient();
 
-    OzoneBucket bucket = TestDataUtil.createVolumeAndBucket(cluster);
+    OzoneBucket bucket = TestDataUtil.createVolumeAndBucket(client);
 
     String volumeName = bucket.getVolumeName();
     Path volumePath = new Path(OZONE_URI_DELIMITER, volumeName);
@@ -83,6 +87,7 @@ public class TestOzoneFileSystemMissingParent {
 
   @AfterClass
   public static void tearDown() {
+    IOUtils.closeQuietly(client);
     if (cluster != null) {
       cluster.shutdown();
       cluster = null;

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFileSystemPrefixParser.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFileSystemPrefixParser.java
@@ -18,7 +18,7 @@
 
 package org.apache.hadoop.fs.ozone;
 
-import org.apache.commons.io.IOUtils;
+import org.apache.hadoop.hdds.utils.IOUtils;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.hadoop.fs.FSDataOutputStream;
 import org.apache.hadoop.fs.FileSystem;
@@ -27,6 +27,7 @@ import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.ozone.MiniOzoneCluster;
 import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.hadoop.ozone.TestDataUtil;
+import org.apache.hadoop.ozone.client.OzoneClient;
 import org.apache.hadoop.ozone.debug.PrefixParser;
 import org.apache.hadoop.ozone.om.OMStorage;
 import org.apache.hadoop.ozone.om.helpers.BucketLayout;
@@ -69,8 +70,10 @@ public class TestOzoneFileSystemPrefixParser {
     cluster.waitForClusterToBeReady();
 
     // create a volume and a bucket to be used by OzoneFileSystem
-    TestDataUtil.createVolumeAndBucket(cluster, volumeName, bucketName,
-        BucketLayout.FILE_SYSTEM_OPTIMIZED);
+    try (OzoneClient client = cluster.getClient()) {
+      TestDataUtil.createVolumeAndBucket(client, volumeName, bucketName,
+          BucketLayout.FILE_SYSTEM_OPTIMIZED);
+    }
 
     String rootPath = String
         .format("%s://%s.%s/", OzoneConsts.OZONE_URI_SCHEME, bucketName,

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFileSystemPrefixParser.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFileSystemPrefixParser.java
@@ -70,7 +70,7 @@ public class TestOzoneFileSystemPrefixParser {
     cluster.waitForClusterToBeReady();
 
     // create a volume and a bucket to be used by OzoneFileSystem
-    try (OzoneClient client = cluster.getClient()) {
+    try (OzoneClient client = cluster.newClient()) {
       TestDataUtil.createVolumeAndBucket(client, volumeName, bucketName,
           BucketLayout.FILE_SYSTEM_OPTIMIZED);
     }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFileSystemWithLinks.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFileSystemWithLinks.java
@@ -111,7 +111,7 @@ public class TestOzoneFileSystemWithLinks {
         .build();
     cluster.waitForClusterToBeReady();
 
-    client = cluster.getRpcClient();
+    client = cluster.getClient();
     writeClient = client.getObjectStore()
         .getClientProxy().getOzoneManagerClient();
     // create a volume and a bucket to be used by OzoneFileSystem

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFileSystemWithLinks.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFileSystemWithLinks.java
@@ -17,8 +17,8 @@
  */
 package org.apache.hadoop.fs.ozone;
 
-import org.apache.commons.io.IOUtils;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import org.apache.hadoop.hdds.utils.IOUtils;
 import org.apache.hadoop.ozone.MiniOzoneCluster;
 import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.hadoop.ozone.TestDataUtil;
@@ -88,6 +88,7 @@ public class TestOzoneFileSystemWithLinks {
   private static BucketLayout bucketLayout = BucketLayout.DEFAULT;
 
   private static MiniOzoneCluster cluster;
+  private static OzoneClient client;
   private static OzoneManagerProtocol writeClient;
   private static FileSystem fs;
   private static OzoneFileSystem o3fs;
@@ -110,11 +111,12 @@ public class TestOzoneFileSystemWithLinks {
         .build();
     cluster.waitForClusterToBeReady();
 
-    writeClient = cluster.getRpcClient().getObjectStore()
+    client = cluster.getRpcClient();
+    writeClient = client.getObjectStore()
         .getClientProxy().getOzoneManagerClient();
     // create a volume and a bucket to be used by OzoneFileSystem
     OzoneBucket bucket =
-        TestDataUtil.createVolumeAndBucket(cluster, bucketLayout);
+        TestDataUtil.createVolumeAndBucket(client, bucketLayout);
     volumeName = bucket.getVolumeName();
     bucketName = bucket.getName();
 
@@ -133,6 +135,7 @@ public class TestOzoneFileSystemWithLinks {
 
   @AfterClass
   public static void teardown() {
+    IOUtils.closeQuietly(client);
     if (cluster != null) {
       cluster.shutdown();
     }
@@ -180,7 +183,6 @@ public class TestOzoneFileSystemWithLinks {
   public void testLoopInLinkBuckets() throws Exception {
     String linksVolume = UUID.randomUUID().toString();
 
-    OzoneClient client = cluster.getClient();
     ObjectStore store = client.getObjectStore();
 
     // Create volume

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFileSystemWithLinks.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFileSystemWithLinks.java
@@ -111,7 +111,7 @@ public class TestOzoneFileSystemWithLinks {
         .build();
     cluster.waitForClusterToBeReady();
 
-    client = cluster.getClient();
+    client = cluster.newClient();
     writeClient = client.getObjectStore()
         .getClientProxy().getOzoneManagerClient();
     // create a volume and a bucket to be used by OzoneFileSystem

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFileSystemWithStreaming.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFileSystemWithStreaming.java
@@ -86,7 +86,7 @@ public class TestOzoneFileSystemWithStreaming {
         .setDataStreamStreamWindowSize(5 * chunkSize)
         .build();
     cluster.waitForClusterToBeReady();
-    client = cluster.getClient();
+    client = cluster.newClient();
 
     // create a volume and a bucket to be used by OzoneFileSystem
     bucket = TestDataUtil.createVolumeAndBucket(client, layout);

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFileSystemWithStreaming.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFileSystemWithStreaming.java
@@ -19,6 +19,8 @@
 package org.apache.hadoop.fs.ozone;
 
 import java.util.concurrent.ThreadLocalRandom;
+
+import org.apache.hadoop.hdds.utils.IOUtils;
 import org.apache.hadoop.conf.StorageUnit;
 import org.apache.hadoop.fs.CommonConfigurationKeysPublic;
 import org.apache.hadoop.fs.FSDataInputStream;
@@ -29,6 +31,7 @@ import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.ozone.MiniOzoneCluster;
 import org.apache.hadoop.ozone.TestDataUtil;
 import org.apache.hadoop.ozone.client.OzoneBucket;
+import org.apache.hadoop.ozone.client.OzoneClient;
 import org.apache.hadoop.ozone.om.helpers.BucketLayout;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
@@ -56,6 +59,7 @@ public class TestOzoneFileSystemWithStreaming {
   private static OzoneBucket bucket;
 
   private static final OzoneConfiguration CONF = new OzoneConfiguration();
+  private static OzoneClient client;
 
   @BeforeAll
   public static void init() throws Exception {
@@ -82,13 +86,15 @@ public class TestOzoneFileSystemWithStreaming {
         .setDataStreamStreamWindowSize(5 * chunkSize)
         .build();
     cluster.waitForClusterToBeReady();
+    client = cluster.getClient();
 
     // create a volume and a bucket to be used by OzoneFileSystem
-    bucket = TestDataUtil.createVolumeAndBucket(cluster, layout);
+    bucket = TestDataUtil.createVolumeAndBucket(client, layout);
   }
 
   @AfterAll
   public static void teardown() {
+    IOUtils.closeQuietly(client);
     if (cluster != null) {
       cluster.shutdown();
     }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFsHAURLs.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFsHAURLs.java
@@ -17,6 +17,7 @@
 
 package org.apache.hadoop.fs.ozone;
 
+import org.apache.hadoop.hdds.utils.IOUtils;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.hadoop.fs.CommonConfigurationKeysPublic;
 import org.apache.hadoop.fs.FileSystem;
@@ -29,6 +30,7 @@ import org.apache.hadoop.ozone.MiniOzoneCluster;
 import org.apache.hadoop.ozone.MiniOzoneHAClusterImpl;
 import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.hadoop.ozone.client.ObjectStore;
+import org.apache.hadoop.ozone.client.OzoneClient;
 import org.apache.hadoop.ozone.client.OzoneClientFactory;
 import org.apache.hadoop.ozone.client.OzoneVolume;
 import org.apache.hadoop.ozone.ha.ConfUtils;
@@ -87,6 +89,7 @@ public class TestOzoneFsHAURLs {
       "fs." + OzoneConsts.OZONE_URI_SCHEME + ".impl";
   private final String o3fsImplValue =
       "org.apache.hadoop.fs.ozone.OzoneFileSystem";
+  private static OzoneClient client;
 
   @BeforeClass
   public static void initClass() throws Exception {
@@ -121,6 +124,7 @@ public class TestOzoneFsHAURLs {
         .setNumOfOzoneManagers(numOfOMs)
         .build();
     cluster.waitForClusterToBeReady();
+    client = OzoneClientFactory.getRpcClient(omServiceId, conf);
 
     om = cluster.getOzoneManager();
   }
@@ -134,8 +138,7 @@ public class TestOzoneFsHAURLs {
     Assert.assertEquals(LifeCycle.State.RUNNING, om.getOmRatisServerState());
 
     volumeName = "volume" + RandomStringUtils.randomNumeric(5);
-    ObjectStore objectStore =
-        OzoneClientFactory.getRpcClient(omServiceId, conf).getObjectStore();
+    ObjectStore objectStore = client.getObjectStore();
     objectStore.createVolume(volumeName);
 
     OzoneVolume retVolumeinfo = objectStore.getVolume(volumeName);
@@ -158,6 +161,7 @@ public class TestOzoneFsHAURLs {
 
   @AfterClass
   public static void shutdown() {
+    IOUtils.closeQuietly(client);
     if (cluster != null) {
       cluster.shutdown();
     }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestRootedDDSWithFSO.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestRootedDDSWithFSO.java
@@ -93,7 +93,7 @@ public class TestRootedDDSWithFSO {
         .setNumDatanodes(3)
         .build();
     cluster.waitForClusterToBeReady();
-    client = cluster.getClient();
+    client = cluster.newClient();
 
     // create a volume and a bucket to be used by OzoneFileSystem
     OzoneBucket bucket =

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestRootedDDSWithFSO.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestRootedDDSWithFSO.java
@@ -18,18 +18,19 @@
 
 package org.apache.hadoop.fs.ozone;
 
-import org.apache.commons.io.IOUtils;
 import org.apache.hadoop.fs.CommonConfigurationKeysPublic;
 import org.apache.hadoop.fs.FSDataOutputStream;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import org.apache.hadoop.hdds.utils.IOUtils;
 import org.apache.hadoop.hdds.utils.db.Table;
 import org.apache.hadoop.ozone.MiniOzoneCluster;
 import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.hadoop.ozone.TestDataUtil;
 import org.apache.hadoop.ozone.client.OzoneBucket;
+import org.apache.hadoop.ozone.client.OzoneClient;
 import org.apache.hadoop.ozone.om.service.DirectoryDeletingService;
 import org.apache.hadoop.ozone.om.OMConfigKeys;
 import org.apache.hadoop.ozone.om.OMMetrics;
@@ -75,6 +76,7 @@ public class TestRootedDDSWithFSO {
   private static String bucketName;
   private static Path volumePath;
   private static Path bucketPath;
+  private static OzoneClient client;
 
   @BeforeClass
   public static void init() throws Exception {
@@ -91,10 +93,11 @@ public class TestRootedDDSWithFSO {
         .setNumDatanodes(3)
         .build();
     cluster.waitForClusterToBeReady();
+    client = cluster.getClient();
 
     // create a volume and a bucket to be used by OzoneFileSystem
     OzoneBucket bucket =
-        TestDataUtil.createVolumeAndBucket(cluster, getFSOBucketLayout());
+        TestDataUtil.createVolumeAndBucket(client, getFSOBucketLayout());
     volumeName = bucket.getVolumeName();
     volumePath = new Path(OZONE_URI_DELIMITER, volumeName);
     bucketName = bucket.getName();
@@ -113,6 +116,7 @@ public class TestRootedDDSWithFSO {
 
   @AfterClass
   public static void teardown() {
+    IOUtils.closeQuietly(client);
     if (cluster != null) {
       cluster.shutdown();
     }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestRootedOzoneFileSystem.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestRootedOzoneFileSystem.java
@@ -18,7 +18,6 @@
 
 package org.apache.hadoop.fs.ozone;
 
-import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.commons.lang3.RandomUtils;
 import org.apache.hadoop.fs.CommonConfigurationKeysPublic;
@@ -44,6 +43,7 @@ import org.apache.hadoop.hdds.client.StandaloneReplicationConfig;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.protocol.StorageType;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
+import org.apache.hadoop.hdds.utils.IOUtils;
 import org.apache.hadoop.ozone.MiniOzoneCluster;
 import org.apache.hadoop.ozone.OFSPath;
 import org.apache.hadoop.ozone.OzoneAcl;
@@ -180,7 +180,7 @@ public class TestRootedOzoneFileSystem {
   public void createVolumeAndBucket() throws IOException {
     // create a volume and a bucket to be used by RootedOzoneFileSystem (OFS)
     OzoneBucket bucket =
-        TestDataUtil.createVolumeAndBucket(cluster, bucketLayout);
+        TestDataUtil.createVolumeAndBucket(client, bucketLayout);
     volumeName = bucket.getVolumeName();
     volumePath = new Path(OZONE_URI_DELIMITER, volumeName);
     bucketName = bucket.getName();
@@ -978,7 +978,7 @@ public class TestRootedOzoneFileSystem {
     }
     OFSPath ofsPath = new OFSPath(key, conf);
     String keyInBucket = ofsPath.getKeyName();
-    return cluster.getClient().getObjectStore().getVolume(volumeName)
+    return client.getObjectStore().getVolume(volumeName)
         .getBucket(bucketName).getKey(keyInBucket);
   }
 
@@ -1649,7 +1649,7 @@ public class TestRootedOzoneFileSystem {
 
     // Create a new volume and a new bucket
     OzoneBucket bucket3 =
-        TestDataUtil.createVolumeAndBucket(cluster, bucketLayout);
+        TestDataUtil.createVolumeAndBucket(client, bucketLayout);
     OzoneVolume volume3 = objectStore.getVolume(bucket3.getVolumeName());
     // Need to setOwner to current test user so it has permission to list vols
     volume3.setOwner(username);
@@ -1744,7 +1744,7 @@ public class TestRootedOzoneFileSystem {
     }
     // create second bucket and write a key in it.
     OzoneBucket bucket2 =
-        TestDataUtil.createVolumeAndBucket(cluster, bucketLayout);
+        TestDataUtil.createVolumeAndBucket(client, bucketLayout);
     String volumeName2 = bucket2.getVolumeName();
     Path volumePath2 = new Path(OZONE_URI_DELIMITER, volumeName2);
     String bucketName2 = bucket2.getName();
@@ -2032,7 +2032,7 @@ public class TestRootedOzoneFileSystem {
     String vol = UUID.randomUUID().toString();
     String buck = UUID.randomUUID().toString();
     final OzoneBucket bucket100 = TestDataUtil
-        .createVolumeAndBucket(cluster, vol, buck, BucketLayout.LEGACY,
+        .createVolumeAndBucket(client, vol, buck,
             omBucketArgs);
     Assert.assertEquals(ReplicationType.STAND_ALONE.name(),
         bucket100.getReplicationConfig().getReplicationType().name());
@@ -2063,7 +2063,7 @@ public class TestRootedOzoneFileSystem {
     String vol = UUID.randomUUID().toString();
     String buck = UUID.randomUUID().toString();
     final OzoneBucket bucket101 = TestDataUtil
-        .createVolumeAndBucket(cluster, vol, buck, BucketLayout.LEGACY,
+        .createVolumeAndBucket(client, vol, buck,
             omBucketArgs);
     Assert.assertEquals(ReplicationType.EC.name(),
         bucket101.getReplicationConfig().getReplicationType().name());
@@ -2218,7 +2218,7 @@ public class TestRootedOzoneFileSystem {
   public void testSnapshotRead() throws Exception {
     // Init data
     OzoneBucket bucket1 =
-        TestDataUtil.createVolumeAndBucket(cluster, bucketLayout);
+        TestDataUtil.createVolumeAndBucket(client, bucketLayout);
     Path volume1Path = new Path(OZONE_URI_DELIMITER, bucket1.getVolumeName());
     Path bucket1Path = new Path(volume1Path, bucket1.getName());
     Path file1 = new Path(bucket1Path, "key1");
@@ -2228,7 +2228,7 @@ public class TestRootedOzoneFileSystem {
     ContractTestUtils.touch(fs, file2);
 
     OzoneBucket bucket2 =
-        TestDataUtil.createVolumeAndBucket(cluster, bucketLayout);
+        TestDataUtil.createVolumeAndBucket(client, bucketLayout);
     Path volume2Path = new Path(OZONE_URI_DELIMITER, bucket2.getVolumeName());
     Path bucket2Path = new Path(volume2Path, bucket2.getName());
 

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestRootedOzoneFileSystem.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestRootedOzoneFileSystem.java
@@ -260,7 +260,7 @@ public class TestRootedOzoneFileSystem {
         .setNumDatanodes(5)
         .build();
     cluster.waitForClusterToBeReady();
-    client = cluster.getClient();
+    client = cluster.newClient();
     objectStore = client.getObjectStore();
 
     rootPath = String.format("%s://%s/",

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/contract/OzoneContract.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/contract/OzoneContract.java
@@ -126,7 +126,7 @@ class OzoneContract extends AbstractFSContract {
       cluster.waitForClusterToBeReady();
       cluster.waitForPipelineTobeReady(HddsProtos.ReplicationFactor.THREE,
               180000);
-      client = cluster.getClient();
+      client = cluster.newClient();
     } catch (Exception e) {
       throw new IOException(e);
     }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/contract/OzoneContract.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/contract/OzoneContract.java
@@ -23,6 +23,7 @@ import java.time.Duration;
 import java.util.Arrays;
 import java.util.List;
 
+import org.apache.hadoop.hdds.utils.IOUtils;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
@@ -36,6 +37,7 @@ import org.apache.hadoop.ozone.MiniOzoneCluster;
 import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.hadoop.ozone.TestDataUtil;
 import org.apache.hadoop.ozone.client.OzoneBucket;
+import org.apache.hadoop.ozone.client.OzoneClient;
 import org.apache.hadoop.ozone.om.OMConfigKeys;
 
 import org.apache.hadoop.ozone.om.helpers.BucketLayout;
@@ -67,6 +69,7 @@ class OzoneContract extends AbstractFSContract {
   private static final String CONTRACT_XML = "contract/ozone.xml";
 
   private static boolean fsOptimizedServer;
+  private static OzoneClient client;
 
   OzoneContract(Configuration conf) {
     super(conf);
@@ -123,6 +126,7 @@ class OzoneContract extends AbstractFSContract {
       cluster.waitForClusterToBeReady();
       cluster.waitForPipelineTobeReady(HddsProtos.ReplicationFactor.THREE,
               180000);
+      client = cluster.getClient();
     } catch (Exception e) {
       throw new IOException(e);
     }
@@ -135,9 +139,9 @@ class OzoneContract extends AbstractFSContract {
   @Override
   public FileSystem getTestFileSystem() throws IOException {
     //assumes cluster is not null
-    Assert.assertNotNull("cluster not created", cluster);
+    Assert.assertNotNull("cluster not created", client);
 
-    OzoneBucket bucket = TestDataUtil.createVolumeAndBucket(cluster);
+    OzoneBucket bucket = TestDataUtil.createVolumeAndBucket(client);
 
     String uri = String.format("%s://%s.%s/",
         OzoneConsts.OZONE_URI_SCHEME, bucket.getName(), bucket.getVolumeName());
@@ -148,6 +152,7 @@ class OzoneContract extends AbstractFSContract {
   }
 
   public static void destroyCluster() throws IOException {
+    IOUtils.closeQuietly(client);
     if (cluster != null) {
       cluster.shutdown();
       cluster = null;

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/container/metrics/TestSCMContainerManagerMetrics.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/container/metrics/TestSCMContainerManagerMetrics.java
@@ -67,7 +67,7 @@ public class TestSCMContainerManagerMetrics {
     conf.setBoolean(HDDS_SCM_SAFEMODE_PIPELINE_CREATION, false);
     cluster = MiniOzoneCluster.newBuilder(conf).setNumDatanodes(1).build();
     cluster.waitForClusterToBeReady();
-    client = cluster.getClient();
+    client = cluster.newClient();
     scm = cluster.getStorageContainerManager();
   }
 

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/container/metrics/TestSCMContainerManagerMetrics.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/container/metrics/TestSCMContainerManagerMetrics.java
@@ -17,6 +17,7 @@
 
 package org.apache.hadoop.hdds.scm.container.metrics;
 
+import org.apache.hadoop.hdds.utils.IOUtils;
 import org.apache.commons.lang3.RandomUtils;
 import org.apache.hadoop.hdds.client.RatisReplicationConfig;
 import org.apache.hadoop.hdds.client.ReplicationFactor;
@@ -31,6 +32,7 @@ import org.apache.hadoop.hdds.scm.server.StorageContainerManager;
 import org.apache.hadoop.metrics2.MetricsRecordBuilder;
 import org.apache.hadoop.ozone.MiniOzoneCluster;
 import org.apache.hadoop.ozone.OzoneConsts;
+import org.apache.hadoop.ozone.client.OzoneClient;
 import org.apache.hadoop.ozone.client.io.OzoneOutputStream;
 import org.apache.ozone.test.GenericTestUtils;
 import org.junit.jupiter.api.AfterEach;
@@ -56,6 +58,7 @@ public class TestSCMContainerManagerMetrics {
 
   private MiniOzoneCluster cluster;
   private StorageContainerManager scm;
+  private OzoneClient client;
 
   @BeforeEach
   public void setup() throws Exception {
@@ -64,12 +67,14 @@ public class TestSCMContainerManagerMetrics {
     conf.setBoolean(HDDS_SCM_SAFEMODE_PIPELINE_CREATION, false);
     cluster = MiniOzoneCluster.newBuilder(conf).setNumDatanodes(1).build();
     cluster.waitForClusterToBeReady();
+    client = cluster.getClient();
     scm = cluster.getStorageContainerManager();
   }
 
 
   @AfterEach
   public void teardown() {
+    IOUtils.closeQuietly(client);
     cluster.shutdown();
   }
 
@@ -142,11 +147,11 @@ public class TestSCMContainerManagerMetrics {
         getLongCounter("NumContainerReportsProcessedSuccessful", metrics));
 
     // Create key should create container on DN.
-    cluster.getRpcClient().getObjectStore().getClientProxy()
+    client.getObjectStore().getClientProxy()
         .createVolume(volumeName);
-    cluster.getRpcClient().getObjectStore().getClientProxy()
+    client.getObjectStore().getClientProxy()
         .createBucket(volumeName, bucketName);
-    OzoneOutputStream ozoneOutputStream = cluster.getRpcClient()
+    OzoneOutputStream ozoneOutputStream = client
         .getObjectStore().getClientProxy().createKey(volumeName, bucketName,
             key, 0, ReplicationType.RATIS, ReplicationFactor.ONE,
             new HashMap<>());

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/storage/TestContainerCommandsEC.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/storage/TestContainerCommandsEC.java
@@ -49,6 +49,7 @@ import org.apache.hadoop.hdds.security.token.OzoneBlockTokenSecretManager;
 import org.apache.hadoop.hdds.security.x509.SecurityConfig;
 import org.apache.hadoop.hdds.security.x509.certificate.client.CertificateClient;
 import org.apache.hadoop.hdds.security.x509.certificate.client.CertificateClientTestImpl;
+import org.apache.hadoop.hdds.utils.IOUtils;
 import org.apache.hadoop.ozone.MiniOzoneCluster;
 import org.apache.hadoop.ozone.OzoneConfigKeys;
 import org.apache.hadoop.ozone.client.ObjectStore;
@@ -164,6 +165,7 @@ public class TestContainerCommandsEC {
 
   @AfterAll
   public static void stop() throws IOException {
+    IOUtils.closeQuietly(rpcClient);
     stopCluster();
   }
 

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/storage/TestContainerCommandsEC.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/storage/TestContainerCommandsEC.java
@@ -49,7 +49,6 @@ import org.apache.hadoop.hdds.security.token.OzoneBlockTokenSecretManager;
 import org.apache.hadoop.hdds.security.x509.SecurityConfig;
 import org.apache.hadoop.hdds.security.x509.certificate.client.CertificateClient;
 import org.apache.hadoop.hdds.security.x509.certificate.client.CertificateClientTestImpl;
-import org.apache.hadoop.hdds.utils.IOUtils;
 import org.apache.hadoop.ozone.MiniOzoneCluster;
 import org.apache.hadoop.ozone.OzoneConfigKeys;
 import org.apache.hadoop.ozone.client.ObjectStore;
@@ -160,12 +159,10 @@ public class TestContainerCommandsEC {
     config.setBoolean(HDDS_CONTAINER_TOKEN_ENABLED, true);
     startCluster(config);
     prepareData(KEY_SIZE_RANGES);
-    rpcClient = OzoneClientFactory.getRpcClient(config);
   }
 
   @AfterAll
   public static void stop() throws IOException {
-    IOUtils.closeQuietly(rpcClient);
     stopCluster();
   }
 

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/upgrade/TestHDDSUpgrade.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/upgrade/TestHDDSUpgrade.java
@@ -208,17 +208,18 @@ public class TestHDDSUpgrade {
    */
   private void createKey() throws IOException {
     final String uniqueId = "testhddsupgrade";
-    OzoneClient client = OzoneClientFactory.getRpcClient(conf);
-    ObjectStore objectStore = client.getObjectStore();
-    objectStore.createVolume(uniqueId);
-    objectStore.getVolume(uniqueId).createBucket(uniqueId);
-    OzoneOutputStream key =
-        objectStore.getVolume(uniqueId).getBucket(uniqueId)
-            .createKey(uniqueId, 1024, ReplicationType.RATIS,
-                ReplicationFactor.THREE, new HashMap<>());
-    key.write(uniqueId.getBytes(UTF_8));
-    key.flush();
-    key.close();
+    try (OzoneClient client = OzoneClientFactory.getRpcClient(conf)) {
+      ObjectStore objectStore = client.getObjectStore();
+      objectStore.createVolume(uniqueId);
+      objectStore.getVolume(uniqueId).createBucket(uniqueId);
+      OzoneOutputStream key =
+          objectStore.getVolume(uniqueId).getBucket(uniqueId)
+              .createKey(uniqueId, 1024, ReplicationType.RATIS,
+                  ReplicationFactor.THREE, new HashMap<>());
+      key.write(uniqueId.getBytes(UTF_8));
+      key.flush();
+      key.close();
+    }
   }
 
   /*

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/upgrade/TestHDDSUpgrade.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/upgrade/TestHDDSUpgrade.java
@@ -328,7 +328,7 @@ public class TestHDDSUpgrade {
 
     // Test that we can use a pipeline after upgrade.
     // Will fail with exception if there are no pipelines.
-    try (OzoneClient client = cluster.getClient()) {
+    try (OzoneClient client = cluster.newClient()) {
       ObjectStore store = client.getObjectStore();
       store.createVolume("vol1");
       store.getVolume("vol1").createBucket("buc1");

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/upgrade/TestHDDSUpgrade.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/upgrade/TestHDDSUpgrade.java
@@ -327,12 +327,13 @@ public class TestHDDSUpgrade {
 
     // Test that we can use a pipeline after upgrade.
     // Will fail with exception if there are no pipelines.
-    ObjectStore store = cluster.getClient().getObjectStore();
-    store.createVolume("vol1");
-    store.getVolume("vol1").createBucket("buc1");
-    store.getVolume("vol1").getBucket("buc1").createKey("key1", 100,
-        ReplicationType.RATIS, ReplicationFactor.THREE, new HashMap<>());
-
+    try (OzoneClient client = cluster.getClient()) {
+      ObjectStore store = client.getObjectStore();
+      store.createVolume("vol1");
+      store.getVolume("vol1").createBucket("buc1");
+      store.getVolume("vol1").getBucket("buc1").createKey("key1", 100,
+          ReplicationType.RATIS, ReplicationFactor.THREE, new HashMap<>());
+    }
   }
 
   /*

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/MiniOzoneCluster.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/MiniOzoneCluster.java
@@ -179,15 +179,6 @@ public interface MiniOzoneCluster {
   OzoneClient getClient() throws IOException;
 
   /**
-   * Returns an RPC based {@link OzoneClient} to access the
-   * {@link MiniOzoneCluster}.
-   *
-   * @return {@link OzoneClient}
-   * @throws IOException
-   */
-  OzoneClient getRpcClient() throws IOException;
-
-  /**
    * Returns StorageContainerLocationClient to communicate with
    * {@link StorageContainerManager} associated with the MiniOzoneCluster.
    *

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/MiniOzoneCluster.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/MiniOzoneCluster.java
@@ -172,11 +172,11 @@ public interface MiniOzoneCluster {
 
   /**
    * Returns an {@link OzoneClient} to access the {@link MiniOzoneCluster}.
+   * The caller is responsible for closing the client after use.
    *
    * @return {@link OzoneClient}
-   * @throws IOException
    */
-  OzoneClient getClient() throws IOException;
+  OzoneClient newClient() throws IOException;
 
   /**
    * Returns StorageContainerLocationClient to communicate with

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/MiniOzoneClusterImpl.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/MiniOzoneClusterImpl.java
@@ -28,8 +28,10 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.OptionalInt;
+import java.util.Set;
 import java.util.UUID;
 import java.util.Iterator;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
@@ -59,6 +61,7 @@ import org.apache.hadoop.hdds.scm.server.SCMConfigurator;
 import org.apache.hadoop.hdds.scm.server.SCMStorageConfig;
 import org.apache.hadoop.hdds.scm.server.StorageContainerManager;
 import org.apache.hadoop.hdds.security.x509.certificate.client.CertificateClient;
+import org.apache.hadoop.hdds.utils.IOUtils;
 import org.apache.hadoop.metrics2.lib.DefaultMetricsSystem;
 import org.apache.hadoop.ozone.client.OzoneClient;
 import org.apache.hadoop.ozone.client.OzoneClientFactory;
@@ -126,6 +129,7 @@ public class MiniOzoneClusterImpl implements MiniOzoneCluster {
   // Timeout for the cluster to be ready
   private int waitForClusterToBeReadyTimeout = 120000; // 2 min
   private CertificateClient caClient;
+  private final Set<AutoCloseable> clients = ConcurrentHashMap.newKeySet();
 
   /**
    * Creates a new MiniOzoneCluster with Recon.
@@ -318,6 +322,12 @@ public class MiniOzoneClusterImpl implements MiniOzoneCluster {
 
   @Override
   public OzoneClient newClient() throws IOException {
+    OzoneClient client = createClient();
+    clients.add(client);
+    return client;
+  }
+
+  protected OzoneClient createClient() throws IOException {
     return OzoneClientFactory.getRpcClient(conf);
   }
 
@@ -443,6 +453,7 @@ public class MiniOzoneClusterImpl implements MiniOzoneCluster {
   public void shutdown() {
     try {
       LOG.info("Shutting down the Mini Ozone Cluster");
+      IOUtils.closeQuietly(clients.toArray(new AutoCloseable[0]));
       File baseDir = new File(GenericTestUtils.getTempPath(
           MiniOzoneClusterImpl.class.getSimpleName() + "-" +
               getClusterId()));

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/MiniOzoneClusterImpl.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/MiniOzoneClusterImpl.java
@@ -321,11 +321,6 @@ public class MiniOzoneClusterImpl implements MiniOzoneCluster {
     return OzoneClientFactory.getRpcClient(conf);
   }
 
-  @Override
-  public OzoneClient getRpcClient() throws IOException {
-    return OzoneClientFactory.getRpcClient(conf);
-  }
-
   /**
    * Returns an RPC proxy connected to this cluster's StorageContainerManager
    * for accessing container location information.  Callers take ownership of

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/MiniOzoneClusterImpl.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/MiniOzoneClusterImpl.java
@@ -317,7 +317,7 @@ public class MiniOzoneClusterImpl implements MiniOzoneCluster {
   }
 
   @Override
-  public OzoneClient getClient() throws IOException {
+  public OzoneClient newClient() throws IOException {
     return OzoneClientFactory.getRpcClient(conf);
   }
 

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/MiniOzoneHAClusterImpl.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/MiniOzoneHAClusterImpl.java
@@ -127,7 +127,7 @@ public class MiniOzoneHAClusterImpl extends MiniOzoneClusterImpl {
   }
 
   @Override
-  public OzoneClient newClient() throws IOException {
+  protected OzoneClient createClient() throws IOException {
     String omServiceId = omhaService.getServiceId();
     if (omServiceId == null) {
       // Non-HA cluster.

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/MiniOzoneHAClusterImpl.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/MiniOzoneHAClusterImpl.java
@@ -127,7 +127,7 @@ public class MiniOzoneHAClusterImpl extends MiniOzoneClusterImpl {
   }
 
   @Override
-  public OzoneClient getClient() throws IOException {
+  public OzoneClient newClient() throws IOException {
     String omServiceId = omhaService.getServiceId();
     if (omServiceId == null) {
       // Non-HA cluster.

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/MiniOzoneHAClusterImpl.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/MiniOzoneHAClusterImpl.java
@@ -127,7 +127,7 @@ public class MiniOzoneHAClusterImpl extends MiniOzoneClusterImpl {
   }
 
   @Override
-  public OzoneClient getRpcClient() throws IOException {
+  public OzoneClient getClient() throws IOException {
     String omServiceId = omhaService.getServiceId();
     if (omServiceId == null) {
       // Non-HA cluster.

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/RatisTestHelper.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/RatisTestHelper.java
@@ -123,10 +123,11 @@ public interface RatisTestHelper {
       RpcType rpc, DatanodeDetails dd, Pipeline pipeline) throws IOException {
     final RaftPeer p = RatisHelper.toRaftPeer(dd);
     final OzoneConfiguration conf = new OzoneConfiguration();
-    final RaftClient client = RatisHelper.newRaftClient(
-        rpc, p, RatisHelper.createRetryPolicy(conf), conf);
-    client.getGroupManagementApi(p.getId())
-        .add(RatisHelper.newRaftGroup(pipeline));
+    try (final RaftClient client = RatisHelper.newRaftClient(
+        rpc, p, RatisHelper.createRetryPolicy(conf), conf)) {
+      client.getGroupManagementApi(p.getId())
+          .add(RatisHelper.newRaftGroup(pipeline));
+    }
   }
 
   static RaftServer.Division getRaftServerDivision(

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/RatisTestHelper.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/RatisTestHelper.java
@@ -123,7 +123,7 @@ public interface RatisTestHelper {
       RpcType rpc, DatanodeDetails dd, Pipeline pipeline) throws IOException {
     final RaftPeer p = RatisHelper.toRaftPeer(dd);
     final OzoneConfiguration conf = new OzoneConfiguration();
-    try (final RaftClient client = RatisHelper.newRaftClient(
+    try (RaftClient client = RatisHelper.newRaftClient(
         rpc, p, RatisHelper.createRetryPolicy(conf), conf)) {
       client.getGroupManagementApi(p.getId())
           .add(RatisHelper.newRaftGroup(pipeline));

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/TestDataUtil.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/TestDataUtil.java
@@ -48,13 +48,13 @@ public final class TestDataUtil {
   private TestDataUtil() {
   }
 
-  public static OzoneBucket createVolumeAndBucket(MiniOzoneCluster cluster,
+  public static OzoneBucket createVolumeAndBucket(OzoneClient client,
       String volumeName, String bucketName) throws IOException {
-    return createVolumeAndBucket(cluster, volumeName, bucketName,
+    return createVolumeAndBucket(client, volumeName, bucketName,
         BucketLayout.LEGACY);
   }
 
-  public static OzoneBucket createVolumeAndBucket(MiniOzoneCluster cluster,
+  public static OzoneBucket createVolumeAndBucket(OzoneClient client,
       String volumeName, String bucketName, BucketLayout bucketLayout)
       throws IOException {
     BucketArgs omBucketArgs;
@@ -65,17 +65,15 @@ public final class TestDataUtil {
     }
     omBucketArgs = builder.build();
 
-    return createVolumeAndBucket(cluster, volumeName, bucketName, bucketLayout,
+    return createVolumeAndBucket(client, volumeName, bucketName,
         omBucketArgs);
   }
 
-  public static OzoneBucket createVolumeAndBucket(MiniOzoneCluster cluster,
-      String volumeName, String bucketName, BucketLayout bucketLayout,
+  public static OzoneBucket createVolumeAndBucket(OzoneClient client,
+      String volumeName, String bucketName,
       BucketArgs omBucketArgs) throws IOException {
     String userName = "user" + RandomStringUtils.randomNumeric(5);
     String adminName = "admin" + RandomStringUtils.randomNumeric(5);
-
-    OzoneClient client = cluster.getClient();
 
     VolumeArgs volumeArgs =
         VolumeArgs.newBuilder().setAdmin(adminName).setOwner(userName).build();
@@ -122,29 +120,28 @@ public final class TestDataUtil {
     }
   }
 
-  public static OzoneBucket createVolumeAndBucket(MiniOzoneCluster cluster)
+  public static OzoneBucket createVolumeAndBucket(OzoneClient client)
       throws IOException {
-    return createVolumeAndBucket(cluster, BucketLayout.LEGACY);
+    return createVolumeAndBucket(client, BucketLayout.LEGACY);
   }
 
-  public static OzoneBucket createBucket(MiniOzoneCluster cluster,
+  public static OzoneBucket createBucket(OzoneClient client,
       String vol, BucketArgs bucketArgs, String bukName)
       throws IOException {
-    OzoneClient client = cluster.getClient();
     ObjectStore objectStore = client.getObjectStore();
     OzoneVolume volume = objectStore.getVolume(vol);
     volume.createBucket(bukName, bucketArgs);
     return volume.getBucket(bukName);
   }
 
-  public static OzoneBucket createVolumeAndBucket(MiniOzoneCluster cluster,
+  public static OzoneBucket createVolumeAndBucket(OzoneClient client,
       BucketLayout bucketLayout) throws IOException {
     final int attempts = 5;
     for (int i = 0; i < attempts; i++) {
       try {
         String volumeName = "volume" + RandomStringUtils.randomNumeric(5);
         String bucketName = "bucket" + RandomStringUtils.randomNumeric(5);
-        return createVolumeAndBucket(cluster, volumeName, bucketName,
+        return createVolumeAndBucket(client, volumeName, bucketName,
             bucketLayout);
       } catch (OMException e) {
         if (e.getResult() != OMException.ResultCodes.VOLUME_ALREADY_EXISTS

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/TestSecureOzoneCluster.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/TestSecureOzoneCluster.java
@@ -1355,8 +1355,10 @@ public final class TestSecureOzoneCluster {
             CertificateCodec.getPEMEncodedString(caCert)));
       }
 
-      try (OzoneClient ignored = OzoneClientFactory.getRpcClient(conf)) {
-        // get new client, it should succeed.
+      // get new client, it should succeed.
+      try {
+        OzoneClient client1 = OzoneClientFactory.getRpcClient(conf);
+        client1.close();
       } catch (Exception e) {
         System.out.println("OzoneClientFactory.getRpcClient failed for " +
             e.getMessage());
@@ -1366,8 +1368,10 @@ public final class TestSecureOzoneCluster {
       // Wait for old OM certificate to expire
       GenericTestUtils.waitFor(() -> omCert.getNotAfter().before(new Date()),
           500, certLifetime * 1000);
-      try (OzoneClient ignored = OzoneClientFactory.getRpcClient(conf)) {
-        // get new client, it should succeed too.
+      // get new client, it should succeed too.
+      try {
+        OzoneClient client1 = OzoneClientFactory.getRpcClient(conf);
+        client1.close();
       } catch (Exception e) {
         System.out.println("OzoneClientFactory.getRpcClient failed for " +
             e.getMessage());

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/TestStorageContainerManagerHelper.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/TestStorageContainerManagerHelper.java
@@ -28,6 +28,7 @@ import org.apache.hadoop.hdds.scm.container.common.helpers.ContainerWithPipeline
 import org.apache.hadoop.hdds.utils.MetadataKeyFilters.KeyPrefixFilter;
 import org.apache.hadoop.hdds.utils.db.Table;
 import org.apache.hadoop.ozone.client.OzoneBucket;
+import org.apache.hadoop.ozone.client.OzoneClient;
 import org.apache.hadoop.ozone.container.common.helpers.BlockData;
 import org.apache.hadoop.ozone.container.common.interfaces.DBHandle;
 import org.apache.hadoop.ozone.container.keyvalue.KeyValueContainerData;
@@ -74,27 +75,30 @@ public class TestStorageContainerManagerHelper {
       throws Exception {
     Map<String, OmKeyInfo> keyLocationMap = Maps.newHashMap();
 
-    OzoneBucket bucket = TestDataUtil.createVolumeAndBucket(cluster);
-    // Write 20 keys in bucketName.
-    Set<String> keyNames = Sets.newHashSet();
-    for (int i = 0; i < numOfKeys; i++) {
-      String keyName = RandomStringUtils.randomAlphabetic(5) + i;
-      keyNames.add(keyName);
+    try (OzoneClient client = cluster.getClient()) {
+      OzoneBucket bucket = TestDataUtil.createVolumeAndBucket(client);
+      // Write 20 keys in bucketName.
+      Set<String> keyNames = Sets.newHashSet();
+      for (int i = 0; i < numOfKeys; i++) {
+        String keyName = RandomStringUtils.randomAlphabetic(5) + i;
+        keyNames.add(keyName);
 
-      TestDataUtil
-          .createKey(bucket, keyName, RandomStringUtils.randomAlphabetic(5));
+        TestDataUtil
+            .createKey(bucket, keyName, RandomStringUtils.randomAlphabetic(5));
+      }
+
+      for (String key : keyNames) {
+        OmKeyArgs arg = new OmKeyArgs.Builder()
+            .setVolumeName(bucket.getVolumeName())
+            .setBucketName(bucket.getName())
+            .setKeyName(key)
+            .build();
+        OmKeyInfo location = cluster.getOzoneManager()
+            .lookupKey(arg);
+        keyLocationMap.put(key, location);
+      }
     }
 
-    for (String key : keyNames) {
-      OmKeyArgs arg = new OmKeyArgs.Builder()
-          .setVolumeName(bucket.getVolumeName())
-          .setBucketName(bucket.getName())
-          .setKeyName(key)
-          .build();
-      OmKeyInfo location = cluster.getOzoneManager()
-          .lookupKey(arg);
-      keyLocationMap.put(key, location);
-    }
     return keyLocationMap;
   }
 

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/TestStorageContainerManagerHelper.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/TestStorageContainerManagerHelper.java
@@ -75,7 +75,7 @@ public class TestStorageContainerManagerHelper {
       throws Exception {
     Map<String, OmKeyInfo> keyLocationMap = Maps.newHashMap();
 
-    try (OzoneClient client = cluster.getClient()) {
+    try (OzoneClient client = cluster.newClient()) {
       OzoneBucket bucket = TestDataUtil.createVolumeAndBucket(client);
       // Write 20 keys in bucketName.
       Set<String> keyNames = Sets.newHashSet();

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/TestOzoneClientFactory.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/TestOzoneClientFactory.java
@@ -58,11 +58,11 @@ public class TestOzoneClientFactory {
         @Override
         public Void run() throws IOException {
           conf.set("ozone.security.enabled", "true");
-          OzoneClient ozoneClient =
+          try (OzoneClient ozoneClient =
               OzoneClientFactory.getRpcClient("localhost",
-                  Integer.parseInt(omPort),
-                  conf);
-          ozoneClient.getObjectStore().listVolumes("/");
+                  Integer.parseInt(omPort), conf)) {
+            ozoneClient.getObjectStore().listVolumes("/");
+          }
           return null;
         }
       });

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/Test2WayCommitInRatis.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/Test2WayCommitInRatis.java
@@ -31,6 +31,7 @@ import org.apache.hadoop.hdds.scm.container.common.helpers.ContainerWithPipeline
 import org.apache.hadoop.hdds.scm.pipeline.Pipeline;
 import org.apache.hadoop.hdds.scm.protocolPB.
         StorageContainerLocationProtocolClientSideTranslatorPB;
+import org.apache.hadoop.hdds.utils.IOUtils;
 import org.apache.hadoop.ozone.HddsDatanodeService;
 import org.apache.hadoop.ozone.MiniOzoneCluster;
 import org.apache.hadoop.ozone.OzoneConsts;
@@ -131,6 +132,7 @@ public class Test2WayCommitInRatis {
    * Shutdown MiniDFSCluster.
    */
   private void shutdown() {
+    IOUtils.closeQuietly(client);
     if (cluster != null) {
       cluster.shutdown();
     }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestBCSID.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestBCSID.java
@@ -22,6 +22,7 @@ import org.apache.hadoop.hdds.client.ReplicationFactor;
 import org.apache.hadoop.hdds.client.ReplicationType;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
+import org.apache.hadoop.hdds.utils.IOUtils;
 import org.apache.hadoop.ozone.MiniOzoneCluster;
 import org.apache.hadoop.ozone.client.ObjectStore;
 import org.apache.hadoop.ozone.client.OzoneClient;
@@ -109,6 +110,7 @@ public class TestBCSID {
    */
   @AfterClass
   public static void shutdown() {
+    IOUtils.closeQuietly(client);
     if (cluster != null) {
       cluster.shutdown();
     }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestBlockDataStreamOutput.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestBlockDataStreamOutput.java
@@ -26,6 +26,7 @@ import org.apache.hadoop.hdds.scm.XceiverClientManager;
 import org.apache.hadoop.hdds.scm.XceiverClientMetrics;
 import org.apache.hadoop.hdds.scm.storage.BlockDataStreamOutput;
 import org.apache.hadoop.hdds.scm.storage.ByteBufferStreamOutput;
+import org.apache.hadoop.hdds.utils.IOUtils;
 import org.apache.hadoop.ozone.MiniOzoneCluster;
 import org.apache.hadoop.ozone.OzoneConfigKeys;
 import org.apache.hadoop.ozone.client.ObjectStore;
@@ -127,6 +128,7 @@ public class TestBlockDataStreamOutput {
    */
   @AfterClass
   public static void shutdown() {
+    IOUtils.closeQuietly(client);
     if (cluster != null) {
       cluster.shutdown();
     }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestBlockOutputStream.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestBlockOutputStream.java
@@ -124,7 +124,7 @@ public class TestBlockOutputStream {
    */
   @AfterAll
   public static void shutdown() {
-    IOUtils.close(null, client);
+    IOUtils.closeQuietly(client);
     if (cluster != null) {
       cluster.shutdown();
     }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestBlockOutputStreamFlushDelay.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestBlockOutputStreamFlushDelay.java
@@ -116,7 +116,7 @@ public class TestBlockOutputStreamFlushDelay {
    */
   @AfterAll
   public static void shutdown() {
-    IOUtils.close(null, client);
+    IOUtils.closeQuietly(client);
     if (cluster != null) {
       cluster.shutdown();
     }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestBlockOutputStreamWithFailures.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestBlockOutputStreamWithFailures.java
@@ -151,7 +151,7 @@ public class TestBlockOutputStreamWithFailures {
    */
   @AfterEach
   public void shutdown() {
-    IOUtils.close(null, client);
+    IOUtils.closeQuietly(client);
     if (cluster != null) {
       cluster.shutdown();
     }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestBlockOutputStreamWithFailuresFlushDelay.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestBlockOutputStreamWithFailuresFlushDelay.java
@@ -151,7 +151,7 @@ public class TestBlockOutputStreamWithFailuresFlushDelay {
    */
   @AfterEach
   public void shutdown() {
-    IOUtils.close(null, client);
+    IOUtils.closeQuietly(client);
     if (cluster != null) {
       cluster.shutdown();
     }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestCloseContainerHandlingByClient.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestCloseContainerHandlingByClient.java
@@ -331,9 +331,10 @@ public class TestCloseContainerHandlingByClient {
         keyInfo.getKeyLocationVersions().get(0).getBlocksLatestVersionOnly();
     OzoneVolume volume = objectStore.getVolume(volumeName);
     OzoneBucket bucket = volume.getBucket(bucketName);
-    OzoneInputStream inputStream = bucket.readKey(keyName);
     byte[] readData = new byte[keyLen];
-    inputStream.read(readData);
+    try (OzoneInputStream inputStream = bucket.readKey(keyName)) {
+      inputStream.read(readData);
+    }
     Assert.assertArrayEquals(writtenData, readData);
 
     // Though we have written only block initially, the close will hit

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestCloseContainerHandlingByClient.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestCloseContainerHandlingByClient.java
@@ -31,6 +31,7 @@ import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.ChecksumType;
 import org.apache.hadoop.hdds.scm.OzoneClientConfig;
 import org.apache.hadoop.hdds.scm.ScmConfigKeys;
+import org.apache.hadoop.hdds.utils.IOUtils;
 import org.apache.hadoop.ozone.MiniOzoneCluster;
 import org.apache.hadoop.ozone.OzoneConfigKeys;
 import org.apache.hadoop.ozone.OzoneConsts;
@@ -122,6 +123,7 @@ public class TestCloseContainerHandlingByClient {
    */
   @AfterClass
   public static void shutdown() {
+    IOUtils.closeQuietly(client);
     if (cluster != null) {
       cluster.shutdown();
     }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestCommitWatcher.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestCommitWatcher.java
@@ -29,8 +29,9 @@ import org.apache.hadoop.conf.StorageUnit;
 import org.apache.hadoop.hdds.client.BlockID;
 import org.apache.hadoop.hdds.conf.DatanodeRatisServerConfig;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
-import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos;
 import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.ChecksumType;
+import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.ContainerCommandRequestProto;
+import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.ContainerCommandResponseProto;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.hdds.ratis.conf.RatisClientConfig;
 import org.apache.hadoop.hdds.scm.OzoneClientConfig;
@@ -57,12 +58,16 @@ import org.apache.hadoop.ozone.container.ContainerTestHelper;
 
 import static java.util.Collections.singletonList;
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_STALENODE_INTERVAL;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
 import org.apache.ratis.protocol.exceptions.AlreadyClosedException;
 import org.apache.ratis.protocol.exceptions.NotReplicatedException;
 import org.apache.ratis.protocol.exceptions.RaftRetryFailureException;
 import org.apache.ratis.protocol.exceptions.TimeoutIOException;
 import org.junit.After;
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -172,172 +177,170 @@ public class TestCommitWatcher {
   public void testReleaseBuffers() throws Exception {
     int capacity = 2;
     BufferPool bufferPool = new BufferPool(chunkSize, capacity);
-    XceiverClientManager clientManager = new XceiverClientManager(conf);
-    ContainerWithPipeline container = storageContainerLocationClient
-        .allocateContainer(HddsProtos.ReplicationType.RATIS,
-            HddsProtos.ReplicationFactor.THREE, OzoneConsts.OZONE);
-    Pipeline pipeline = container.getPipeline();
-    long containerId = container.getContainerInfo().getContainerID();
-    XceiverClientSpi xceiverClient = clientManager.acquireClient(pipeline);
-    Assert.assertEquals(1, xceiverClient.getRefcount());
-    Assert.assertTrue(xceiverClient instanceof XceiverClientRatis);
-    XceiverClientRatis ratisClient = (XceiverClientRatis) xceiverClient;
-    CommitWatcher watcher = new CommitWatcher(bufferPool, ratisClient);
-    BlockID blockID = ContainerTestHelper.getTestBlockID(containerId);
-    List<XceiverClientReply> replies = new ArrayList<>();
-    long length = 0;
-    List<CompletableFuture<ContainerProtos.ContainerCommandResponseProto>>
-        futures = new ArrayList<>();
-    for (int i = 0; i < capacity; i++) {
-      ContainerProtos.ContainerCommandRequestProto writeChunkRequest =
-          ContainerTestHelper
-              .getWriteChunkRequest(pipeline, blockID, chunkSize);
-      // add the data to the buffer pool
-      final ChunkBuffer byteBuffer = bufferPool.allocateBuffer(0);
-      byteBuffer.put(writeChunkRequest.getWriteChunk().getData());
-      ratisClient.sendCommandAsync(writeChunkRequest);
-      ContainerProtos.ContainerCommandRequestProto putBlockRequest =
-          ContainerTestHelper
-              .getPutBlockRequest(pipeline, writeChunkRequest.getWriteChunk());
-      XceiverClientReply reply = ratisClient.sendCommandAsync(putBlockRequest);
-      final List<ChunkBuffer> bufferList = singletonList(byteBuffer);
-      length += byteBuffer.position();
-      CompletableFuture<ContainerProtos.ContainerCommandResponseProto> future =
-          reply.getResponse().thenApply(v -> {
-            watcher.updateCommitInfoMap(reply.getLogIndex(), bufferList);
-            return v;
-          });
-      futures.add(future);
-      watcher.getFutureMap().put(length, future);
-      replies.add(reply);
-    }
+    try (XceiverClientManager mgr = new XceiverClientManager(conf)) {
+      ContainerWithPipeline container = storageContainerLocationClient
+          .allocateContainer(HddsProtos.ReplicationType.RATIS,
+              HddsProtos.ReplicationFactor.THREE, OzoneConsts.OZONE);
+      Pipeline pipeline = container.getPipeline();
+      long containerId = container.getContainerInfo().getContainerID();
+      try (XceiverClientSpi xceiverClient = mgr.acquireClient(pipeline)) {
+        assertEquals(1, xceiverClient.getRefcount());
+        assertTrue(xceiverClient instanceof XceiverClientRatis);
+        XceiverClientRatis ratisClient = (XceiverClientRatis) xceiverClient;
+        CommitWatcher watcher = new CommitWatcher(bufferPool, ratisClient);
+        BlockID blockID = ContainerTestHelper.getTestBlockID(containerId);
+        List<XceiverClientReply> replies = new ArrayList<>();
+        long length = 0;
+        List<CompletableFuture<ContainerCommandResponseProto>>
+            futures = new ArrayList<>();
+        for (int i = 0; i < capacity; i++) {
+          ContainerCommandRequestProto writeChunkRequest =
+              ContainerTestHelper
+                  .getWriteChunkRequest(pipeline, blockID, chunkSize);
+          // add the data to the buffer pool
+          final ChunkBuffer byteBuffer = bufferPool.allocateBuffer(0);
+          byteBuffer.put(writeChunkRequest.getWriteChunk().getData());
+          ratisClient.sendCommandAsync(writeChunkRequest);
+          ContainerCommandRequestProto putBlockRequest =
+              ContainerTestHelper.getPutBlockRequest(pipeline,
+                  writeChunkRequest.getWriteChunk());
+          XceiverClientReply reply =
+              ratisClient.sendCommandAsync(putBlockRequest);
+          final List<ChunkBuffer> bufferList = singletonList(byteBuffer);
+          length += byteBuffer.position();
+          CompletableFuture<ContainerCommandResponseProto> future =
+              reply.getResponse().thenApply(v -> {
+                watcher.updateCommitInfoMap(reply.getLogIndex(), bufferList);
+                return v;
+              });
+          futures.add(future);
+          watcher.getFutureMap().put(length, future);
+          replies.add(reply);
+        }
 
-    Assert.assertTrue(replies.size() == 2);
-    // wait on the 1st putBlock to complete
-    CompletableFuture<ContainerProtos.ContainerCommandResponseProto> future1 =
-        futures.get(0);
-    CompletableFuture<ContainerProtos.ContainerCommandResponseProto> future2 =
-        futures.get(1);
-    future1.get();
-    Assert.assertNotNull(watcher.getFutureMap().get((long) chunkSize));
-    Assert.assertTrue(
-        watcher.getFutureMap().get((long) chunkSize).equals(future1));
-    // wait on 2nd putBlock to complete
-    future2.get();
-    Assert.assertNotNull(watcher.getFutureMap().get((long) 2 * chunkSize));
-    Assert.assertTrue(
-            watcher.getFutureMap().get((long) 2 * chunkSize).equals(future2));
-    Assert.assertTrue(watcher.
-            getCommitIndex2flushedDataMap().size() == 2);
-    watcher.watchOnFirstIndex();
-    Assert.assertFalse(watcher.getCommitIndex2flushedDataMap()
+        assertEquals(2, replies.size());
+        // wait on the 1st putBlock to complete
+        CompletableFuture<ContainerCommandResponseProto> future1 =
+            futures.get(0);
+        CompletableFuture<ContainerCommandResponseProto> future2 =
+            futures.get(1);
+        future1.get();
+        assertEquals(future1, watcher.getFutureMap().get((long) chunkSize));
+        // wait on 2nd putBlock to complete
+        future2.get();
+        assertEquals(future2, watcher.getFutureMap().get((long) 2 * chunkSize));
+        assertEquals(2, watcher.
+            getCommitIndex2flushedDataMap().size());
+        watcher.watchOnFirstIndex();
+        assertFalse(watcher.getCommitIndex2flushedDataMap()
             .containsKey(replies.get(0).getLogIndex()));
-    Assert.assertFalse(watcher.getFutureMap().containsKey(chunkSize));
-    Assert.assertTrue(watcher.getTotalAckDataLength() >= chunkSize);
-    watcher.watchOnLastIndex();
-    Assert.assertFalse(watcher.getCommitIndex2flushedDataMap()
-        .containsKey(replies.get(1).getLogIndex()));
-    Assert.assertFalse(watcher.getFutureMap().containsKey(2 * chunkSize));
-    Assert.assertTrue(watcher.getTotalAckDataLength() == 2 * chunkSize);
-    Assert.assertTrue(watcher.getFutureMap().isEmpty());
-    Assert.assertTrue(watcher.getCommitIndex2flushedDataMap().isEmpty());
+        assertFalse(watcher.getFutureMap().containsKey((long) chunkSize));
+        assertTrue(watcher.getTotalAckDataLength() >= chunkSize);
+        watcher.watchOnLastIndex();
+        assertFalse(watcher.getCommitIndex2flushedDataMap()
+            .containsKey(replies.get(1).getLogIndex()));
+        assertFalse(watcher.getFutureMap().containsKey((long) 2 * chunkSize));
+        assertEquals(2 * chunkSize, watcher.getTotalAckDataLength());
+        assertTrue(watcher.getFutureMap().isEmpty());
+        assertTrue(watcher.getCommitIndex2flushedDataMap().isEmpty());
+      }
+    }
   }
 
   @Test
   public void testReleaseBuffersOnException() throws Exception {
     int capacity = 2;
     BufferPool bufferPool = new BufferPool(chunkSize, capacity);
-    XceiverClientManager clientManager = new XceiverClientManager(conf);
-    ContainerWithPipeline container = storageContainerLocationClient
-        .allocateContainer(HddsProtos.ReplicationType.RATIS,
-            HddsProtos.ReplicationFactor.THREE, OzoneConsts.OZONE);
-    Pipeline pipeline = container.getPipeline();
-    long containerId = container.getContainerInfo().getContainerID();
-    XceiverClientSpi xceiverClient = clientManager.acquireClient(pipeline);
-    Assert.assertEquals(1, xceiverClient.getRefcount());
-    Assert.assertTrue(xceiverClient instanceof XceiverClientRatis);
-    XceiverClientRatis ratisClient = (XceiverClientRatis) xceiverClient;
-    CommitWatcher watcher = new CommitWatcher(bufferPool, ratisClient);
-    BlockID blockID = ContainerTestHelper.getTestBlockID(containerId);
-    List<XceiverClientReply> replies = new ArrayList<>();
-    long length = 0;
-    List<CompletableFuture<ContainerProtos.ContainerCommandResponseProto>>
-        futures = new ArrayList<>();
-    for (int i = 0; i < capacity; i++) {
-      ContainerProtos.ContainerCommandRequestProto writeChunkRequest =
-          ContainerTestHelper
-              .getWriteChunkRequest(pipeline, blockID, chunkSize);
-      // add the data to the buffer pool
-      final ChunkBuffer byteBuffer = bufferPool.allocateBuffer(0);
-      byteBuffer.put(writeChunkRequest.getWriteChunk().getData());
-      ratisClient.sendCommandAsync(writeChunkRequest);
-      ContainerProtos.ContainerCommandRequestProto putBlockRequest =
-          ContainerTestHelper
-              .getPutBlockRequest(pipeline, writeChunkRequest.getWriteChunk());
-      XceiverClientReply reply = ratisClient.sendCommandAsync(putBlockRequest);
-      final List<ChunkBuffer> bufferList = singletonList(byteBuffer);
-      length += byteBuffer.position();
-      CompletableFuture<ContainerProtos.ContainerCommandResponseProto> future =
-          reply.getResponse().thenApply(v -> {
-            watcher.updateCommitInfoMap(reply.getLogIndex(), bufferList);
-            return v;
-          });
-      futures.add(future);
-      watcher.getFutureMap().put(length, future);
-      replies.add(reply);
-    }
+    try (XceiverClientManager mgr = new XceiverClientManager(conf)) {
+      ContainerWithPipeline container = storageContainerLocationClient
+          .allocateContainer(HddsProtos.ReplicationType.RATIS,
+              HddsProtos.ReplicationFactor.THREE, OzoneConsts.OZONE);
+      Pipeline pipeline = container.getPipeline();
+      long containerId = container.getContainerInfo().getContainerID();
+      try (XceiverClientSpi xceiverClient = mgr.acquireClient(pipeline)) {
+        assertEquals(1, xceiverClient.getRefcount());
+        assertTrue(xceiverClient instanceof XceiverClientRatis);
+        XceiverClientRatis ratisClient = (XceiverClientRatis) xceiverClient;
+        CommitWatcher watcher = new CommitWatcher(bufferPool, ratisClient);
+        BlockID blockID = ContainerTestHelper.getTestBlockID(containerId);
+        List<XceiverClientReply> replies = new ArrayList<>();
+        long length = 0;
+        List<CompletableFuture<ContainerCommandResponseProto>>
+            futures = new ArrayList<>();
+        for (int i = 0; i < capacity; i++) {
+          ContainerCommandRequestProto writeChunkRequest =
+              ContainerTestHelper
+                  .getWriteChunkRequest(pipeline, blockID, chunkSize);
+          // add the data to the buffer pool
+          final ChunkBuffer byteBuffer = bufferPool.allocateBuffer(0);
+          byteBuffer.put(writeChunkRequest.getWriteChunk().getData());
+          ratisClient.sendCommandAsync(writeChunkRequest);
+          ContainerCommandRequestProto putBlockRequest =
+              ContainerTestHelper.getPutBlockRequest(pipeline,
+                  writeChunkRequest.getWriteChunk());
+          XceiverClientReply reply =
+              ratisClient.sendCommandAsync(putBlockRequest);
+          final List<ChunkBuffer> bufferList = singletonList(byteBuffer);
+          length += byteBuffer.position();
+          CompletableFuture<ContainerCommandResponseProto> future =
+              reply.getResponse().thenApply(v -> {
+                watcher.updateCommitInfoMap(reply.getLogIndex(), bufferList);
+                return v;
+              });
+          futures.add(future);
+          watcher.getFutureMap().put(length, future);
+          replies.add(reply);
+        }
 
-    Assert.assertTrue(replies.size() == 2);
-    // wait on the 1st putBlock to complete
-    CompletableFuture<ContainerProtos.ContainerCommandResponseProto> future1 =
-        futures.get(0);
-    CompletableFuture<ContainerProtos.ContainerCommandResponseProto> future2 =
-        futures.get(1);
-    future1.get();
-    Assert.assertNotNull(watcher.getFutureMap().get((long) chunkSize));
-    Assert.assertTrue(
-        watcher.getFutureMap().get((long) chunkSize).equals(future1));
-    // wait on 2nd putBlock to complete
-    future2.get();
-    Assert.assertNotNull(watcher.getFutureMap().get((long) 2 * chunkSize));
-    Assert.assertTrue(
-        watcher.getFutureMap().get((long) 2 * chunkSize).equals(future2));
-    Assert.assertTrue(watcher.getCommitIndex2flushedDataMap().size() == 2);
-    watcher.watchOnFirstIndex();
-    Assert.assertFalse(watcher.getCommitIndex2flushedDataMap()
-        .containsKey(replies.get(0).getLogIndex()));
-    Assert.assertFalse(watcher.getFutureMap().containsKey(chunkSize));
-    Assert.assertTrue(watcher.getTotalAckDataLength() >= chunkSize);
-    cluster.shutdownHddsDatanode(pipeline.getNodes().get(0));
-    cluster.shutdownHddsDatanode(pipeline.getNodes().get(1));
-    try {
-      // just watch for a higher index so as to ensure, it does an actual
-      // call to Ratis. Otherwise, it may just return in case the commitInfoMap
-      // is updated to the latest index in putBlock response.
-      watcher.watchForCommit(replies.get(1).getLogIndex() + 100);
-      Assert.fail("Expected exception not thrown");
-    } catch (IOException ioe) {
-      // with retry count set to noRetry and a lower watch request
-      // timeout, watch request will eventually
-      // fail with TimeoutIOException from ratis client or the client
-      // can itself get AlreadyClosedException from the Ratis Server
-      // and the write may fail with RaftRetryFailureException
-      Throwable t = HddsClientUtils.checkForException(ioe);
-      Assert.assertTrue("Unexpected exception: " + t.getClass(),
-          t instanceof RaftRetryFailureException ||
-          t instanceof TimeoutIOException ||
-          t instanceof AlreadyClosedException ||
-          t instanceof NotReplicatedException);
-    }
-    if (ratisClient.getReplicatedMinCommitIndex() < replies.get(1)
-        .getLogIndex()) {
-      Assert.assertTrue(watcher.getTotalAckDataLength() == chunkSize);
-      Assert.assertTrue(watcher.getCommitIndex2flushedDataMap().size() == 1);
-      Assert.assertTrue(watcher.getFutureMap().size() == 1);
-    } else {
-      Assert.assertTrue(watcher.getTotalAckDataLength() == 2 * chunkSize);
-      Assert.assertTrue(watcher.getFutureMap().isEmpty());
-      Assert.assertTrue(watcher.getCommitIndex2flushedDataMap().isEmpty());
+        assertEquals(2, replies.size());
+        // wait on the 1st putBlock to complete
+        CompletableFuture<ContainerCommandResponseProto> future1 =
+            futures.get(0);
+        CompletableFuture<ContainerCommandResponseProto> future2 =
+            futures.get(1);
+        future1.get();
+        assertEquals(future1, watcher.getFutureMap().get((long) chunkSize));
+        // wait on 2nd putBlock to complete
+        future2.get();
+        assertEquals(future2, watcher.getFutureMap().get((long) 2 * chunkSize));
+        assertEquals(2, watcher.getCommitIndex2flushedDataMap().size());
+        watcher.watchOnFirstIndex();
+        assertFalse(watcher.getCommitIndex2flushedDataMap()
+            .containsKey(replies.get(0).getLogIndex()));
+        assertFalse(watcher.getFutureMap().containsKey((long) chunkSize));
+        assertTrue(watcher.getTotalAckDataLength() >= chunkSize);
+        cluster.shutdownHddsDatanode(pipeline.getNodes().get(0));
+        cluster.shutdownHddsDatanode(pipeline.getNodes().get(1));
+        try {
+          // just watch for a higher index so as to ensure, it does an actual
+          // call to Ratis. Otherwise, it may just return in case the
+          // commitInfoMap is updated to the latest index in putBlock response.
+          watcher.watchForCommit(replies.get(1).getLogIndex() + 100);
+          fail("Expected exception not thrown");
+        } catch (IOException ioe) {
+          // with retry count set to noRetry and a lower watch request
+          // timeout, watch request will eventually
+          // fail with TimeoutIOException from ratis client or the client
+          // can itself get AlreadyClosedException from the Ratis Server
+          // and the write may fail with RaftRetryFailureException
+          Throwable t = HddsClientUtils.checkForException(ioe);
+          assertTrue("Unexpected exception: " + t.getClass(),
+              t instanceof RaftRetryFailureException ||
+                  t instanceof TimeoutIOException ||
+                  t instanceof AlreadyClosedException ||
+                  t instanceof NotReplicatedException);
+        }
+        if (ratisClient.getReplicatedMinCommitIndex() < replies.get(1)
+            .getLogIndex()) {
+          assertEquals(chunkSize, watcher.getTotalAckDataLength());
+          assertEquals(1, watcher.getCommitIndex2flushedDataMap().size());
+          assertEquals(1, watcher.getFutureMap().size());
+        } else {
+          assertEquals(2 * chunkSize, watcher.getTotalAckDataLength());
+          assertTrue(watcher.getFutureMap().isEmpty());
+          assertTrue(watcher.getCommitIndex2flushedDataMap().isEmpty());
+        }
+      }
     }
   }
 }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestCommitWatcher.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestCommitWatcher.java
@@ -45,6 +45,7 @@ import org.apache.hadoop.hdds.scm.pipeline.Pipeline;
 import org.apache.hadoop.hdds.scm.protocolPB.StorageContainerLocationProtocolClientSideTranslatorPB;
 import org.apache.hadoop.hdds.scm.storage.BufferPool;
 import org.apache.hadoop.hdds.scm.storage.CommitWatcher;
+import org.apache.hadoop.hdds.utils.IOUtils;
 import org.apache.hadoop.ozone.MiniOzoneCluster;
 import org.apache.hadoop.ozone.OzoneConfigKeys;
 import org.apache.hadoop.ozone.OzoneConsts;
@@ -161,6 +162,7 @@ public class TestCommitWatcher {
    */
   @After
   public void shutdown() {
+    IOUtils.closeQuietly(client);
     if (cluster != null) {
       cluster.shutdown();
     }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestContainerReplicationEndToEnd.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestContainerReplicationEndToEnd.java
@@ -30,6 +30,7 @@ import org.apache.hadoop.hdds.scm.container.ContainerID;
 import org.apache.hadoop.hdds.scm.container.replication.ReplicationManager.ReplicationManagerConfiguration;
 import org.apache.hadoop.hdds.scm.pipeline.Pipeline;
 import org.apache.hadoop.hdds.scm.pipeline.PipelineID;
+import org.apache.hadoop.hdds.utils.IOUtils;
 import org.apache.hadoop.ozone.HddsDatanodeService;
 import org.apache.hadoop.ozone.MiniOzoneCluster;
 import org.apache.hadoop.ozone.client.ObjectStore;
@@ -133,6 +134,7 @@ public class TestContainerReplicationEndToEnd {
    */
   @AfterClass
   public static void shutdown() {
+    IOUtils.closeQuietly(client);
     if (cluster != null) {
       cluster.shutdown();
     }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestContainerStateMachine.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestContainerStateMachine.java
@@ -32,6 +32,7 @@ import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos;
 import org.apache.hadoop.hdds.scm.OzoneClientConfig;
 import org.apache.hadoop.hdds.scm.ScmConfigKeys;
 import org.apache.hadoop.hdds.security.x509.certificate.client.CertificateClientTestImpl;
+import org.apache.hadoop.hdds.utils.IOUtils;
 import org.apache.hadoop.ozone.MiniOzoneCluster;
 import org.apache.hadoop.ozone.OzoneConfigKeys;
 import org.apache.hadoop.ozone.client.ObjectStore;
@@ -130,6 +131,7 @@ public class TestContainerStateMachine {
    */
   @After
   public void shutdown() {
+    IOUtils.closeQuietly(client);
     if (cluster != null) {
       cluster.shutdown();
     }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestContainerStateMachineFailureOnRead.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestContainerStateMachineFailureOnRead.java
@@ -35,6 +35,7 @@ import org.apache.hadoop.hdds.ratis.conf.RatisClientConfig;
 import org.apache.hadoop.hdds.scm.XceiverClientRatis;
 import org.apache.hadoop.hdds.scm.pipeline.Pipeline;
 import org.apache.hadoop.hdds.scm.pipeline.PipelineNotFoundException;
+import org.apache.hadoop.hdds.utils.IOUtils;
 import org.apache.hadoop.ozone.HddsDatanodeService;
 import org.apache.hadoop.ozone.MiniOzoneCluster;
 import org.apache.hadoop.ozone.RatisTestHelper;
@@ -74,6 +75,7 @@ public class TestContainerStateMachineFailureOnRead {
   private String volumeName;
   private String bucketName;
   private OzoneConfiguration conf;
+  private OzoneClient client;
 
   @BeforeEach
   public void setup() throws Exception {
@@ -120,7 +122,7 @@ public class TestContainerStateMachineFailureOnRead {
         .setHbInterval(200)
         .build();
     cluster.waitForClusterToBeReady();
-    OzoneClient client = OzoneClientFactory.getRpcClient(conf);
+    client = OzoneClientFactory.getRpcClient(conf);
     objectStore = client.getObjectStore();
     volumeName = "testcontainerstatemachinefailures";
     bucketName = volumeName;
@@ -131,6 +133,7 @@ public class TestContainerStateMachineFailureOnRead {
 
   @AfterEach
   public void teardown() throws Exception {
+    IOUtils.closeQuietly(client);
     if (cluster != null) {
       cluster.shutdown();
     }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestContainerStateMachineFailures.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestContainerStateMachineFailures.java
@@ -48,6 +48,7 @@ import org.apache.hadoop.hdds.scm.XceiverClientSpi;
 import org.apache.hadoop.hdds.scm.client.HddsClientUtils;
 import org.apache.hadoop.hdds.scm.container.common.helpers.ContainerNotOpenException;
 import org.apache.hadoop.hdds.scm.pipeline.Pipeline;
+import org.apache.hadoop.hdds.utils.IOUtils;
 import org.apache.hadoop.ozone.HddsDatanodeService;
 import org.apache.hadoop.ozone.MiniOzoneCluster;
 import org.apache.hadoop.ozone.OzoneConfigKeys;
@@ -177,6 +178,7 @@ public class TestContainerStateMachineFailures {
    */
   @AfterAll
   public static void shutdown() {
+    IOUtils.closeQuietly(client);
     if (cluster != null) {
       cluster.shutdown();
     }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestContainerStateMachineFailures.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestContainerStateMachineFailures.java
@@ -790,13 +790,11 @@ public class TestContainerStateMachineFailures {
 
       Assert.assertEquals(locationCount,
           keyInfo.getLatestVersionLocations().getLocationListCount());
-      OzoneInputStream
-          o = objectStore
-          .getVolume(volumeName)
-          .getBucket(bucketName)
-          .readKey(key);
       byte[] buffer = new byte[1024];
-      o.read(buffer, 0, 1024);
+      try (OzoneInputStream o = objectStore.getVolume(volumeName)
+          .getBucket(bucketName).readKey(key)) {
+        o.read(buffer, 0, 1024);
+      }
       int end = ArrayUtils.indexOf(buffer, (byte) 0);
       String response = new String(buffer, 0,
           end,

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestContainerStateMachineFlushDelay.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestContainerStateMachineFlushDelay.java
@@ -24,6 +24,7 @@ import org.apache.hadoop.hdds.client.ReplicationType;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos;
 import org.apache.hadoop.hdds.security.x509.certificate.client.CertificateClientTestImpl;
+import org.apache.hadoop.hdds.utils.IOUtils;
 import org.apache.hadoop.ozone.MiniOzoneCluster;
 import org.apache.hadoop.ozone.OzoneConfigKeys;
 import org.apache.hadoop.ozone.client.ObjectStore;
@@ -133,6 +134,7 @@ public class TestContainerStateMachineFlushDelay {
    */
   @After
   public void shutdown() {
+    IOUtils.closeQuietly(client);
     if (cluster != null) {
       cluster.shutdown();
     }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestContainerStateMachineStream.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestContainerStateMachineStream.java
@@ -24,6 +24,7 @@ import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.hdds.ratis.conf.RatisClientConfig;
 import org.apache.hadoop.hdds.scm.OzoneClientConfig;
+import org.apache.hadoop.hdds.utils.IOUtils;
 import org.apache.hadoop.ozone.HddsDatanodeService;
 import org.apache.hadoop.ozone.MiniOzoneCluster;
 import org.apache.hadoop.ozone.OzoneConfigKeys;
@@ -149,6 +150,7 @@ public class TestContainerStateMachineStream {
    */
   @After
   public void shutdown() {
+    IOUtils.closeQuietly(client);
     if (cluster != null) {
       cluster.shutdown();
     }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestDeleteWithSlowFollower.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestDeleteWithSlowFollower.java
@@ -39,6 +39,7 @@ import org.apache.hadoop.hdds.scm.XceiverClientSpi;
 import org.apache.hadoop.hdds.scm.container.common.helpers.StorageContainerException;
 import org.apache.hadoop.hdds.scm.ha.SCMHAUtils;
 import org.apache.hadoop.hdds.scm.pipeline.Pipeline;
+import org.apache.hadoop.hdds.utils.IOUtils;
 import org.apache.hadoop.ozone.HddsDatanodeService;
 import org.apache.hadoop.ozone.MiniOzoneCluster;
 import org.apache.hadoop.ozone.OzoneConfigKeys;
@@ -178,6 +179,7 @@ public class TestDeleteWithSlowFollower {
    */
   @AfterClass
   public static void shutdown() {
+    IOUtils.closeQuietly(client);
     if (cluster != null) {
       cluster.shutdown();
     }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestDiscardPreallocatedBlocks.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestDiscardPreallocatedBlocks.java
@@ -33,6 +33,7 @@ import org.apache.hadoop.hdds.scm.ScmConfigKeys;
 import org.apache.hadoop.hdds.scm.container.ContainerID;
 import org.apache.hadoop.hdds.scm.container.ContainerInfo;
 import org.apache.hadoop.hdds.scm.pipeline.Pipeline;
+import org.apache.hadoop.hdds.utils.IOUtils;
 import org.apache.hadoop.ozone.MiniOzoneCluster;
 import org.apache.hadoop.ozone.OzoneConfigKeys;
 import org.apache.hadoop.ozone.OzoneConsts;
@@ -121,6 +122,7 @@ public class TestDiscardPreallocatedBlocks {
 
   @AfterClass
   public static void shutdown() {
+    IOUtils.closeQuietly(client);
     if (cluster != null) {
       cluster.shutdown();
     }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestECKeyOutputStream.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestECKeyOutputStream.java
@@ -30,6 +30,7 @@ import org.apache.hadoop.hdds.scm.OzoneClientConfig;
 import org.apache.hadoop.hdds.scm.cli.ContainerOperationClient;
 import org.apache.hadoop.hdds.scm.pipeline.Pipeline;
 import org.apache.hadoop.hdds.scm.pipeline.PipelineManager;
+import org.apache.hadoop.hdds.utils.IOUtils;
 import org.apache.hadoop.ozone.MiniOzoneCluster;
 import org.apache.hadoop.ozone.OzoneConfigKeys;
 import org.apache.hadoop.ozone.client.BucketArgs;
@@ -135,6 +136,7 @@ public class TestECKeyOutputStream {
    */
   @AfterClass
   public static void shutdown() {
+    IOUtils.closeQuietly(client);
     if (cluster != null) {
       cluster.shutdown();
     }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestFailureHandlingByClient.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestFailureHandlingByClient.java
@@ -39,6 +39,7 @@ import org.apache.hadoop.hdds.scm.ScmConfigKeys;
 import org.apache.hadoop.hdds.scm.container.ContainerID;
 import org.apache.hadoop.hdds.scm.container.ContainerInfo;
 import org.apache.hadoop.hdds.scm.pipeline.Pipeline;
+import org.apache.hadoop.hdds.utils.IOUtils;
 import org.apache.hadoop.net.DNSToSwitchMapping;
 import org.apache.hadoop.net.NetUtils;
 import org.apache.hadoop.net.StaticMapping;
@@ -157,6 +158,7 @@ public class TestFailureHandlingByClient {
    */
   @AfterEach
   public void shutdown() {
+    IOUtils.closeQuietly(client);
     if (cluster != null) {
       cluster.shutdown();
     }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestFailureHandlingByClientFlushDelay.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestFailureHandlingByClientFlushDelay.java
@@ -31,6 +31,7 @@ import org.apache.hadoop.hdds.scm.ScmConfigKeys;
 import org.apache.hadoop.hdds.scm.container.ContainerID;
 import org.apache.hadoop.hdds.scm.container.ContainerInfo;
 import org.apache.hadoop.hdds.scm.pipeline.Pipeline;
+import org.apache.hadoop.hdds.utils.IOUtils;
 import org.apache.hadoop.net.DNSToSwitchMapping;
 import org.apache.hadoop.net.NetUtils;
 import org.apache.hadoop.net.StaticMapping;
@@ -159,6 +160,7 @@ public class TestFailureHandlingByClientFlushDelay {
    */
   @After
   public void shutdown() {
+    IOUtils.closeQuietly(client);
     if (cluster != null) {
       cluster.shutdown();
     }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestHybridPipelineOnDatanode.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestHybridPipelineOnDatanode.java
@@ -26,6 +26,7 @@ import org.apache.hadoop.hdds.protocol.DatanodeDetails;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.hdds.scm.pipeline.PipelineID;
 import org.apache.hadoop.hdds.scm.pipeline.Pipeline;
+import org.apache.hadoop.hdds.utils.IOUtils;
 import org.apache.hadoop.ozone.MiniOzoneCluster;
 import org.apache.hadoop.ozone.client.ObjectStore;
 import org.apache.hadoop.ozone.client.OzoneClient;
@@ -89,6 +90,7 @@ public class TestHybridPipelineOnDatanode {
    */
   @AfterClass
   public static void shutdown() {
+    IOUtils.closeQuietly(client);
     if (cluster != null) {
       cluster.shutdown();
     }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestMultiBlockWritesWithDnFailures.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestMultiBlockWritesWithDnFailures.java
@@ -27,6 +27,7 @@ import org.apache.hadoop.hdds.ratis.conf.RatisClientConfig;
 import org.apache.hadoop.hdds.scm.container.ContainerID;
 import org.apache.hadoop.hdds.scm.container.ContainerInfo;
 import org.apache.hadoop.hdds.scm.pipeline.Pipeline;
+import org.apache.hadoop.hdds.utils.IOUtils;
 import org.apache.hadoop.ozone.MiniOzoneCluster;
 import org.apache.hadoop.ozone.OzoneConfigKeys;
 import org.apache.hadoop.ozone.OzoneConsts;
@@ -136,6 +137,7 @@ public class TestMultiBlockWritesWithDnFailures {
    */
   @After
   public void shutdown() {
+    IOUtils.closeQuietly(client);
     if (cluster != null) {
       cluster.shutdown();
     }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestOzoneAtRestEncryption.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestOzoneAtRestEncryption.java
@@ -496,47 +496,48 @@ public class TestOzoneAtRestEncryption {
     completeMultipartUpload(bucket, keyName, uploadID, partsMap);
 
     // Create an input stream to read the data
-    OzoneInputStream inputStream = bucket.readKey(keyName);
+    try (OzoneInputStream inputStream = bucket.readKey(keyName)) {
 
-    Assert.assertTrue(inputStream.getInputStream()
-        instanceof MultipartInputStream);
+      Assert.assertTrue(inputStream.getInputStream()
+          instanceof MultipartInputStream);
 
-    // Test complete read
-    byte[] completeRead = new byte[keySize];
-    int bytesRead = inputStream.read(completeRead, 0, keySize);
-    Assert.assertEquals(bytesRead, keySize);
-    Assert.assertArrayEquals(inputData, completeRead);
+      // Test complete read
+      byte[] completeRead = new byte[keySize];
+      int bytesRead = inputStream.read(completeRead, 0, keySize);
+      Assert.assertEquals(bytesRead, keySize);
+      Assert.assertArrayEquals(inputData, completeRead);
 
-    // Read different data lengths and starting from different offsets and
-    // verify the data matches.
-    Random random = new Random();
-    int randomSize = random.nextInt(keySize / 2);
-    int randomOffset = random.nextInt(keySize - randomSize);
+      // Read different data lengths and starting from different offsets and
+      // verify the data matches.
+      Random random = new Random();
+      int randomSize = random.nextInt(keySize / 2);
+      int randomOffset = random.nextInt(keySize - randomSize);
 
-    int[] readDataSizes = {keySize, keySize / 3 + 1, BLOCK_SIZE,
-        BLOCK_SIZE * 2 + 1, CHUNK_SIZE, CHUNK_SIZE / 4 - 1,
-        DEFAULT_CRYPTO_BUFFER_SIZE, DEFAULT_CRYPTO_BUFFER_SIZE / 2, 1,
-        randomSize};
+      int[] readDataSizes = {keySize, keySize / 3 + 1, BLOCK_SIZE,
+          BLOCK_SIZE * 2 + 1, CHUNK_SIZE, CHUNK_SIZE / 4 - 1,
+          DEFAULT_CRYPTO_BUFFER_SIZE, DEFAULT_CRYPTO_BUFFER_SIZE / 2, 1,
+          randomSize};
 
-    int[] readFromPositions = {0, DEFAULT_CRYPTO_BUFFER_SIZE + 10, CHUNK_SIZE,
-        BLOCK_SIZE - DEFAULT_CRYPTO_BUFFER_SIZE + 1, BLOCK_SIZE, keySize / 3,
-        keySize - 1, randomOffset};
+      int[] readFromPositions = {0, DEFAULT_CRYPTO_BUFFER_SIZE + 10, CHUNK_SIZE,
+          BLOCK_SIZE - DEFAULT_CRYPTO_BUFFER_SIZE + 1, BLOCK_SIZE, keySize / 3,
+          keySize - 1, randomOffset};
 
-    for (int readDataLen : readDataSizes) {
-      for (int readFromPosition : readFromPositions) {
-        // Check that offset + buffer size does not exceed the key size
-        if (readFromPosition + readDataLen > keySize) {
-          continue;
+      for (int readDataLen : readDataSizes) {
+        for (int readFromPosition : readFromPositions) {
+          // Check that offset + buffer size does not exceed the key size
+          if (readFromPosition + readDataLen > keySize) {
+            continue;
+          }
+
+          byte[] readData = new byte[readDataLen];
+          inputStream.seek(readFromPosition);
+          int actualReadLen = inputStream.read(readData, 0, readDataLen);
+
+          assertReadContent(inputData, readData, readFromPosition);
+          Assert.assertEquals(readFromPosition + readDataLen,
+              inputStream.getPos());
+          Assert.assertEquals(readDataLen, actualReadLen);
         }
-
-        byte[] readData = new byte[readDataLen];
-        inputStream.seek(readFromPosition);
-        int actualReadLen = inputStream.read(readData, 0, readDataLen);
-
-        assertReadContent(inputData, readData, readFromPosition);
-        Assert.assertEquals(readFromPosition + readDataLen,
-            inputStream.getPos());
-        Assert.assertEquals(readDataLen, actualReadLen);
       }
     }
   }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestOzoneAtRestEncryption.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestOzoneAtRestEncryption.java
@@ -614,7 +614,7 @@ public class TestOzoneAtRestEncryption {
     KeyProvider kp3 = ozClient.getObjectStore().getKeyProvider();
     Assert.assertNotEquals(kp3, kpSpy);
     // Restore ozClient and store
-    TestOzoneRpcClient.setOzClient(OzoneClientFactory.getRpcClient(conf));
-    TestOzoneRpcClient.setStore(ozClient.getObjectStore());
+    ozClient = OzoneClientFactory.getRpcClient(conf);
+    store = ozClient.getObjectStore();
   }
 }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestOzoneAtRestEncryption.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestOzoneAtRestEncryption.java
@@ -614,7 +614,7 @@ public class TestOzoneAtRestEncryption {
     KeyProvider kp3 = ozClient.getObjectStore().getKeyProvider();
     Assert.assertNotEquals(kp3, kpSpy);
     // Restore ozClient and store
-    ozClient = OzoneClientFactory.getRpcClient(conf);
-    store = ozClient.getObjectStore();
+    TestOzoneRpcClient.setOzClient(OzoneClientFactory.getRpcClient(conf));
+    TestOzoneRpcClient.setStore(ozClient.getObjectStore());
   }
 }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestOzoneClientRetriesOnExceptionFlushDelay.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestOzoneClientRetriesOnExceptionFlushDelay.java
@@ -34,6 +34,7 @@ import org.apache.hadoop.hdds.scm.container.ContainerID;
 import org.apache.hadoop.hdds.scm.container.ContainerInfo;
 import org.apache.hadoop.hdds.scm.pipeline.Pipeline;
 import org.apache.hadoop.hdds.scm.storage.BlockOutputStream;
+import org.apache.hadoop.hdds.utils.IOUtils;
 import org.apache.hadoop.ozone.MiniOzoneCluster;
 import org.apache.hadoop.ozone.client.ObjectStore;
 import org.apache.hadoop.ozone.client.OzoneClient;
@@ -128,6 +129,7 @@ public class TestOzoneClientRetriesOnExceptionFlushDelay {
    */
   @After
   public void shutdown() {
+    IOUtils.closeQuietly(client);
     if (cluster != null) {
       cluster.shutdown();
     }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestOzoneClientRetriesOnExceptions.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestOzoneClientRetriesOnExceptions.java
@@ -37,6 +37,7 @@ import org.apache.hadoop.hdds.scm.container.ContainerInfo;
 import org.apache.hadoop.hdds.scm.container.common.helpers.ContainerNotOpenException;
 import org.apache.hadoop.hdds.scm.pipeline.Pipeline;
 import org.apache.hadoop.hdds.scm.storage.BlockOutputStream;
+import org.apache.hadoop.hdds.utils.IOUtils;
 import org.apache.hadoop.ozone.MiniOzoneCluster;
 import org.apache.hadoop.ozone.client.ObjectStore;
 import org.apache.hadoop.ozone.client.OzoneClient;
@@ -136,6 +137,7 @@ public class TestOzoneClientRetriesOnExceptions {
    */
   @After
   public void shutdown() {
+    IOUtils.closeQuietly(client);
     if (cluster != null) {
       cluster.shutdown();
     }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestOzoneRpcClientWithKeyLatestVersion.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestOzoneRpcClientWithKeyLatestVersion.java
@@ -184,9 +184,10 @@ public class TestOzoneRpcClientWithKeyLatestVersion {
       String keyName, String value) throws Exception {
     OzoneVolume volume = objectStore.getVolume(volumeName);
     OzoneBucket ozoneBucket = volume.getBucket(bucketName);
-    OzoneInputStream is = ozoneBucket.readKey(keyName);
     byte[] fileContent = new byte[value.getBytes(UTF_8).length];
-    is.read(fileContent);
+    try (OzoneInputStream is = ozoneBucket.readKey(keyName)) {
+      is.read(fileContent);
+    }
     Assert.assertEquals(value, new String(fileContent, UTF_8));
   }
 

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestValidateBCSIDOnRestart.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestValidateBCSIDOnRestart.java
@@ -35,6 +35,7 @@ import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.hdds.ratis.conf.RatisClientConfig;
 import org.apache.hadoop.hdds.scm.OzoneClientConfig;
 import org.apache.hadoop.hdds.scm.XceiverClientManager;
+import org.apache.hadoop.hdds.utils.IOUtils;
 import org.apache.hadoop.ozone.HddsDatanodeService;
 import org.apache.hadoop.ozone.MiniOzoneCluster;
 import org.apache.hadoop.ozone.client.ObjectStore;
@@ -139,6 +140,7 @@ public class TestValidateBCSIDOnRestart {
    */
   @AfterClass
   public static void shutdown() {
+    IOUtils.closeQuietly(client);
     if (cluster != null) {
       cluster.shutdown();
     }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestWatchForCommit.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestWatchForCommit.java
@@ -252,127 +252,130 @@ public class TestWatchForCommit {
 
   @Test
   public void testWatchForCommitForRetryfailure() throws Exception {
-    XceiverClientManager clientManager = new XceiverClientManager(conf);
-    ContainerWithPipeline container1 = storageContainerLocationClient
-        .allocateContainer(HddsProtos.ReplicationType.RATIS,
-            HddsProtos.ReplicationFactor.THREE, OzoneConsts.OZONE);
-    XceiverClientSpi xceiverClient = clientManager
-        .acquireClient(container1.getPipeline());
-    Assert.assertEquals(1, xceiverClient.getRefcount());
-    Assert.assertEquals(container1.getPipeline(),
-        xceiverClient.getPipeline());
-    Pipeline pipeline = xceiverClient.getPipeline();
-    TestHelper.createPipelineOnDatanode(pipeline, cluster);
-    XceiverClientReply reply = xceiverClient.sendCommandAsync(
-        ContainerTestHelper.getCreateContainerRequest(
-            container1.getContainerInfo().getContainerID(),
-            xceiverClient.getPipeline()));
-    reply.getResponse().get();
-    long index = reply.getLogIndex();
-    cluster.shutdownHddsDatanode(pipeline.getNodes().get(0));
-    cluster.shutdownHddsDatanode(pipeline.getNodes().get(1));
-    // again write data with more than max buffer limit. This wi
-    try {
-      // just watch for a log index which in not updated in the commitInfo Map
-      // as well as there is no logIndex generate in Ratis.
-      // The basic idea here is just to test if its throws an exception.
-      xceiverClient
-          .watchForCommit(index + new Random().nextInt(100) + 10);
-      Assert.fail("expected exception not thrown");
-    } catch (Exception e) {
-      Assert.assertTrue(e instanceof ExecutionException);
-      // since the timeout value is quite long, the watch request will either
-      // fail with NotReplicated exceptio, RetryFailureException or
-      // RuntimeException
-      Assert.assertFalse(HddsClientUtils
-          .checkForException(e) instanceof TimeoutException);
+    try (XceiverClientManager clientManager = new XceiverClientManager(conf)) {
+      ContainerWithPipeline container1 = storageContainerLocationClient
+          .allocateContainer(HddsProtos.ReplicationType.RATIS,
+              HddsProtos.ReplicationFactor.THREE, OzoneConsts.OZONE);
+      XceiverClientSpi xceiverClient = clientManager
+          .acquireClient(container1.getPipeline());
+      Assert.assertEquals(1, xceiverClient.getRefcount());
+      Assert.assertEquals(container1.getPipeline(),
+          xceiverClient.getPipeline());
+      Pipeline pipeline = xceiverClient.getPipeline();
+      TestHelper.createPipelineOnDatanode(pipeline, cluster);
+      XceiverClientReply reply = xceiverClient.sendCommandAsync(
+          ContainerTestHelper.getCreateContainerRequest(
+              container1.getContainerInfo().getContainerID(),
+              xceiverClient.getPipeline()));
+      reply.getResponse().get();
+      long index = reply.getLogIndex();
+      cluster.shutdownHddsDatanode(pipeline.getNodes().get(0));
+      cluster.shutdownHddsDatanode(pipeline.getNodes().get(1));
+      // again write data with more than max buffer limit. This wi
+      try {
+        // just watch for a log index which in not updated in the commitInfo Map
+        // as well as there is no logIndex generate in Ratis.
+        // The basic idea here is just to test if its throws an exception.
+        xceiverClient
+            .watchForCommit(index + new Random().nextInt(100) + 10);
+        Assert.fail("expected exception not thrown");
+      } catch (Exception e) {
+        Assert.assertTrue(e instanceof ExecutionException);
+        // since the timeout value is quite long, the watch request will either
+        // fail with NotReplicated exceptio, RetryFailureException or
+        // RuntimeException
+        Assert.assertFalse(HddsClientUtils
+            .checkForException(e) instanceof TimeoutException);
+      }
+      clientManager.releaseClient(xceiverClient, false);
     }
-    clientManager.releaseClient(xceiverClient, false);
   }
 
   @Test
   public void test2WayCommitForTimeoutException() throws Exception {
     GenericTestUtils.LogCapturer logCapturer =
         GenericTestUtils.LogCapturer.captureLogs(XceiverClientRatis.LOG);
-    XceiverClientManager clientManager = new XceiverClientManager(conf);
+    try (XceiverClientManager clientManager = new XceiverClientManager(conf)) {
 
-    ContainerWithPipeline container1 = storageContainerLocationClient
-        .allocateContainer(HddsProtos.ReplicationType.RATIS,
-            HddsProtos.ReplicationFactor.THREE, OzoneConsts.OZONE);
-    XceiverClientSpi xceiverClient = clientManager
-        .acquireClient(container1.getPipeline());
-    Assert.assertEquals(1, xceiverClient.getRefcount());
-    Assert.assertEquals(container1.getPipeline(),
-        xceiverClient.getPipeline());
-    Pipeline pipeline = xceiverClient.getPipeline();
-    TestHelper.createPipelineOnDatanode(pipeline, cluster);
-    XceiverClientRatis ratisClient = (XceiverClientRatis) xceiverClient;
-    XceiverClientReply reply = xceiverClient.sendCommandAsync(
-        ContainerTestHelper.getCreateContainerRequest(
-            container1.getContainerInfo().getContainerID(),
-            xceiverClient.getPipeline()));
-    reply.getResponse().get();
-    Assert.assertEquals(3, ratisClient.getCommitInfoMap().size());
-    List<DatanodeDetails> nodesInPipeline = pipeline.getNodes();
-    for (HddsDatanodeService dn : cluster.getHddsDatanodes()) {
-      // shutdown the ratis follower
-      if (nodesInPipeline.contains(dn.getDatanodeDetails())
-          && RatisTestHelper.isRatisFollower(dn, pipeline)) {
-        cluster.shutdownHddsDatanode(dn.getDatanodeDetails());
-        break;
+      ContainerWithPipeline container1 = storageContainerLocationClient
+          .allocateContainer(HddsProtos.ReplicationType.RATIS,
+              HddsProtos.ReplicationFactor.THREE, OzoneConsts.OZONE);
+      XceiverClientSpi xceiverClient = clientManager
+          .acquireClient(container1.getPipeline());
+      Assert.assertEquals(1, xceiverClient.getRefcount());
+      Assert.assertEquals(container1.getPipeline(),
+          xceiverClient.getPipeline());
+      Pipeline pipeline = xceiverClient.getPipeline();
+      TestHelper.createPipelineOnDatanode(pipeline, cluster);
+      XceiverClientRatis ratisClient = (XceiverClientRatis) xceiverClient;
+      XceiverClientReply reply = xceiverClient.sendCommandAsync(
+          ContainerTestHelper.getCreateContainerRequest(
+              container1.getContainerInfo().getContainerID(),
+              xceiverClient.getPipeline()));
+      reply.getResponse().get();
+      Assert.assertEquals(3, ratisClient.getCommitInfoMap().size());
+      List<DatanodeDetails> nodesInPipeline = pipeline.getNodes();
+      for (HddsDatanodeService dn : cluster.getHddsDatanodes()) {
+        // shutdown the ratis follower
+        if (nodesInPipeline.contains(dn.getDatanodeDetails())
+            && RatisTestHelper.isRatisFollower(dn, pipeline)) {
+          cluster.shutdownHddsDatanode(dn.getDatanodeDetails());
+          break;
+        }
       }
-    }
-    reply = xceiverClient.sendCommandAsync(ContainerTestHelper
-        .getCloseContainer(pipeline,
-            container1.getContainerInfo().getContainerID()));
-    reply.getResponse().get();
-    xceiverClient.watchForCommit(reply.getLogIndex());
+      reply = xceiverClient.sendCommandAsync(ContainerTestHelper
+          .getCloseContainer(pipeline,
+              container1.getContainerInfo().getContainerID()));
+      reply.getResponse().get();
+      xceiverClient.watchForCommit(reply.getLogIndex());
 
-    // commitInfo Map will be reduced to 2 here
-    Assert.assertEquals(2, ratisClient.getCommitInfoMap().size());
-    clientManager.releaseClient(xceiverClient, false);
-    Assert.assertTrue(logCapturer.getOutput().contains("3 way commit failed"));
-    Assert.assertTrue(logCapturer.getOutput().contains("TimeoutException"));
-    Assert
-        .assertTrue(logCapturer.getOutput().contains("Committed by majority"));
+      // commitInfo Map will be reduced to 2 here
+      Assert.assertEquals(2, ratisClient.getCommitInfoMap().size());
+      clientManager.releaseClient(xceiverClient, false);
+      Assert.assertTrue(logCapturer.getOutput().contains("3 way commit failed"));
+      Assert.assertTrue(logCapturer.getOutput().contains("TimeoutException"));
+      Assert
+          .assertTrue(logCapturer.getOutput().contains("Committed by majority"));
+    }
     logCapturer.stopCapturing();
   }
 
   @Test
   public void testWatchForCommitForGroupMismatchException() throws Exception {
-    XceiverClientManager clientManager = new XceiverClientManager(conf);
-    ContainerWithPipeline container1 = storageContainerLocationClient
-        .allocateContainer(HddsProtos.ReplicationType.RATIS,
-            HddsProtos.ReplicationFactor.THREE, OzoneConsts.OZONE);
-    XceiverClientSpi xceiverClient = clientManager
-        .acquireClient(container1.getPipeline());
-    Assert.assertEquals(1, xceiverClient.getRefcount());
-    Assert.assertEquals(container1.getPipeline(),
-        xceiverClient.getPipeline());
-    Pipeline pipeline = xceiverClient.getPipeline();
-    XceiverClientRatis ratisClient = (XceiverClientRatis) xceiverClient;
-    long containerId = container1.getContainerInfo().getContainerID();
-    XceiverClientReply reply = xceiverClient.sendCommandAsync(
-        ContainerTestHelper.getCreateContainerRequest(containerId,
-            xceiverClient.getPipeline()));
-    reply.getResponse().get();
-    Assert.assertEquals(3, ratisClient.getCommitInfoMap().size());
-    List<Pipeline> pipelineList = new ArrayList<>();
-    pipelineList.add(pipeline);
-    TestHelper.waitForPipelineClose(pipelineList, cluster);
-    try {
-      // just watch for a log index which in not updated in the commitInfo Map
-      // as well as there is no logIndex generate in Ratis.
-      // The basic idea here is just to test if its throws an exception.
-      xceiverClient
-          .watchForCommit(reply.getLogIndex() +
-                  new Random().nextInt(100) + 10);
-      Assert.fail("Expected exception not thrown");
-    } catch (Exception e) {
-      Assert.assertTrue(HddsClientUtils
-          .checkForException(e) instanceof GroupMismatchException);
+    try (XceiverClientManager clientManager = new XceiverClientManager(conf)) {
+      ContainerWithPipeline container1 = storageContainerLocationClient
+          .allocateContainer(HddsProtos.ReplicationType.RATIS,
+              HddsProtos.ReplicationFactor.THREE, OzoneConsts.OZONE);
+      XceiverClientSpi xceiverClient = clientManager
+          .acquireClient(container1.getPipeline());
+      Assert.assertEquals(1, xceiverClient.getRefcount());
+      Assert.assertEquals(container1.getPipeline(),
+          xceiverClient.getPipeline());
+      Pipeline pipeline = xceiverClient.getPipeline();
+      XceiverClientRatis ratisClient = (XceiverClientRatis) xceiverClient;
+      long containerId = container1.getContainerInfo().getContainerID();
+      XceiverClientReply reply = xceiverClient.sendCommandAsync(
+          ContainerTestHelper.getCreateContainerRequest(containerId,
+              xceiverClient.getPipeline()));
+      reply.getResponse().get();
+      Assert.assertEquals(3, ratisClient.getCommitInfoMap().size());
+      List<Pipeline> pipelineList = new ArrayList<>();
+      pipelineList.add(pipeline);
+      TestHelper.waitForPipelineClose(pipelineList, cluster);
+      try {
+        // just watch for a log index which in not updated in the commitInfo Map
+        // as well as there is no logIndex generate in Ratis.
+        // The basic idea here is just to test if its throws an exception.
+        xceiverClient
+            .watchForCommit(reply.getLogIndex() +
+                new Random().nextInt(100) + 10);
+        Assert.fail("Expected exception not thrown");
+      } catch (Exception e) {
+        Assert.assertTrue(HddsClientUtils
+            .checkForException(e) instanceof GroupMismatchException);
+      }
+      clientManager.releaseClient(xceiverClient, false);
     }
-    clientManager.releaseClient(xceiverClient, false);
   }
 
   private OzoneOutputStream createKey(String keyName, ReplicationType type,

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestWatchForCommit.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestWatchForCommit.java
@@ -332,10 +332,10 @@ public class TestWatchForCommit {
       // commitInfo Map will be reduced to 2 here
       Assert.assertEquals(2, ratisClient.getCommitInfoMap().size());
       clientManager.releaseClient(xceiverClient, false);
-      Assert.assertTrue(logCapturer.getOutput().contains("3 way commit failed"));
-      Assert.assertTrue(logCapturer.getOutput().contains("TimeoutException"));
-      Assert
-          .assertTrue(logCapturer.getOutput().contains("Committed by majority"));
+      String output = logCapturer.getOutput();
+      Assert.assertTrue(output.contains("3 way commit failed"));
+      Assert.assertTrue(output.contains("TimeoutException"));
+      Assert.assertTrue(output.contains("Committed by majority"));
     }
     logCapturer.stopCapturing();
   }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestWatchForCommit.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestWatchForCommit.java
@@ -47,6 +47,7 @@ import org.apache.hadoop.hdds.scm.pipeline.Pipeline;
 import org.apache.hadoop.hdds.scm.protocolPB.StorageContainerLocationProtocolClientSideTranslatorPB;
 import org.apache.hadoop.hdds.scm.storage.BlockOutputStream;
 import org.apache.hadoop.hdds.scm.storage.RatisBlockOutputStream;
+import org.apache.hadoop.hdds.utils.IOUtils;
 import org.apache.hadoop.ozone.HddsDatanodeService;
 import org.apache.hadoop.ozone.MiniOzoneCluster;
 import org.apache.hadoop.ozone.OzoneConsts;
@@ -161,6 +162,7 @@ public class TestWatchForCommit {
    */
   @AfterEach
   public void shutdown() {
+    IOUtils.closeQuietly(client);
     if (cluster != null) {
       cluster.shutdown();
     }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/read/TestInputStreamBase.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/read/TestInputStreamBase.java
@@ -141,7 +141,7 @@ public abstract class TestInputStreamBase {
    */
   @After
   public void shutdown() {
-    IOUtils.close(null, client);
+    IOUtils.closeQuietly(client);
     if (cluster != null) {
       cluster.shutdown();
     }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/TestContainerReplication.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/TestContainerReplication.java
@@ -40,6 +40,7 @@ import org.apache.hadoop.hdds.scm.container.replication.ReplicationManager.Repli
 import org.apache.hadoop.hdds.scm.container.placement.algorithms.SCMContainerPlacementCapacity;
 import org.apache.hadoop.hdds.scm.container.placement.algorithms.SCMContainerPlacementRackAware;
 import org.apache.hadoop.hdds.scm.container.placement.algorithms.SCMContainerPlacementRandom;
+import org.apache.hadoop.hdds.utils.IOUtils;
 import org.apache.hadoop.ozone.MiniOzoneCluster;
 import org.apache.hadoop.ozone.client.ObjectStore;
 import org.apache.hadoop.ozone.client.OzoneBucket;
@@ -105,6 +106,7 @@ public class TestContainerReplication {
 
   @After
   public void tearDown() {
+    IOUtils.closeQuietly(client);
     if (cluster != null) {
       cluster.shutdown();
     }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/TestECContainerRecovery.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/TestECContainerRecovery.java
@@ -33,6 +33,7 @@ import org.apache.hadoop.hdds.scm.container.ContainerReplica;
 import org.apache.hadoop.hdds.scm.container.replication.ReplicationManager;
 import org.apache.hadoop.hdds.scm.pipeline.Pipeline;
 import org.apache.hadoop.hdds.scm.server.StorageContainerManager;
+import org.apache.hadoop.hdds.utils.IOUtils;
 import org.apache.hadoop.ozone.HddsDatanodeService;
 import org.apache.hadoop.ozone.MiniOzoneCluster;
 import org.apache.hadoop.ozone.OzoneConfigKeys;
@@ -157,6 +158,7 @@ public class TestECContainerRecovery {
    */
   @AfterAll
   public static void shutdown() {
+    IOUtils.closeQuietly(client);
     if (cluster != null) {
       cluster.shutdown();
     }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/TestBlockDeletion.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/TestBlockDeletion.java
@@ -154,7 +154,7 @@ public class TestBlockDeletion {
         .setHbInterval(200)
         .build();
     cluster.waitForClusterToBeReady();
-    client = cluster.getClient();
+    client = cluster.newClient();
     store = client.getObjectStore();
     om = cluster.getOzoneManager();
     writeClient = store

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/TestBlockDeletion.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/TestBlockDeletion.java
@@ -18,6 +18,8 @@
 package org.apache.hadoop.ozone.container.common.statemachine.commandhandler;
 
 import java.util.stream.Stream;
+
+import org.apache.hadoop.hdds.utils.IOUtils;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.hadoop.hdds.client.ECReplicationConfig;
 import org.apache.hadoop.hdds.client.RatisReplicationConfig;
@@ -43,7 +45,7 @@ import org.apache.hadoop.ozone.MiniOzoneCluster;
 import org.apache.hadoop.ozone.OzoneTestUtils;
 import org.apache.hadoop.ozone.client.ObjectStore;
 import org.apache.hadoop.ozone.client.OzoneBucket;
-import org.apache.hadoop.ozone.client.OzoneClientFactory;
+import org.apache.hadoop.ozone.client.OzoneClient;
 import org.apache.hadoop.ozone.client.OzoneVolume;
 import org.apache.hadoop.ozone.client.io.OzoneOutputStream;
 import org.apache.hadoop.ozone.container.common.helpers.BlockData;
@@ -109,6 +111,7 @@ public class TestBlockDeletion {
   private Set<Long> containerIdsWithDeletedBlocks;
   private long maxTransactionId = 0;
   private ScmBlockDeletingServiceMetrics metrics;
+  private OzoneClient client;
 
   @BeforeEach
   public void init() throws Exception {
@@ -151,9 +154,10 @@ public class TestBlockDeletion {
         .setHbInterval(200)
         .build();
     cluster.waitForClusterToBeReady();
-    store = OzoneClientFactory.getRpcClient(conf).getObjectStore();
+    client = cluster.getClient();
+    store = client.getObjectStore();
     om = cluster.getOzoneManager();
-    writeClient = cluster.getRpcClient().getObjectStore()
+    writeClient = store
         .getClientProxy().getOzoneManagerClient();
     scm = cluster.getStorageContainerManager();
     containerIdsWithDeletedBlocks = new HashSet<>();
@@ -163,6 +167,7 @@ public class TestBlockDeletion {
 
   @AfterEach
   public void cleanup() throws IOException {
+    IOUtils.closeQuietly(client);
     if (cluster != null) {
       cluster.shutdown();
     }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/TestCloseContainerByPipeline.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/TestCloseContainerByPipeline.java
@@ -26,6 +26,7 @@ import org.apache.hadoop.hdds.scm.ScmConfigKeys;
 import org.apache.hadoop.hdds.scm.container.ContainerID;
 import org.apache.hadoop.hdds.scm.container.ContainerInfo;
 import org.apache.hadoop.hdds.scm.pipeline.Pipeline;
+import org.apache.hadoop.hdds.utils.IOUtils;
 import org.apache.hadoop.ozone.HddsDatanodeService;
 import org.apache.hadoop.ozone.MiniOzoneCluster;
 import org.apache.hadoop.ozone.client.ObjectStore;
@@ -101,6 +102,7 @@ public class TestCloseContainerByPipeline {
    */
   @AfterAll
   public static void shutdown() {
+    IOUtils.closeQuietly(client);
     if (cluster != null) {
       cluster.shutdown();
     }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/TestCloseContainerHandler.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/TestCloseContainerHandler.java
@@ -93,15 +93,16 @@ public class TestCloseContainerHandler {
     cluster.waitForClusterToBeReady();
 
     //the easiest way to create an open container is creating a key
-    OzoneClient client = OzoneClientFactory.getRpcClient(conf);
-    ObjectStore objectStore = client.getObjectStore();
-    objectStore.createVolume("test");
-    objectStore.getVolume("test").createBucket("test");
-    OzoneOutputStream key = objectStore.getVolume("test").getBucket("test")
-        .createKey("test", 1024, ReplicationType.RATIS,
-            ReplicationFactor.ONE, new HashMap<>());
-    key.write("test".getBytes(UTF_8));
-    key.close();
+    try (OzoneClient client = OzoneClientFactory.getRpcClient(conf)) {
+      ObjectStore objectStore = client.getObjectStore();
+      objectStore.createVolume("test");
+      objectStore.getVolume("test").createBucket("test");
+      OzoneOutputStream key = objectStore.getVolume("test").getBucket("test")
+          .createKey("test", 1024, ReplicationType.RATIS,
+              ReplicationFactor.ONE, new HashMap<>());
+      key.write("test".getBytes(UTF_8));
+      key.close();
+    }
 
     //get the name of a valid container
     OmKeyArgs keyArgs =

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/TestDeleteContainerHandler.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/TestDeleteContainerHandler.java
@@ -28,6 +28,7 @@ import org.apache.hadoop.hdds.scm.container.ContainerID;
 import org.apache.hadoop.hdds.scm.container.ContainerInfo;
 import org.apache.hadoop.hdds.scm.node.NodeManager;
 import org.apache.hadoop.hdds.scm.pipeline.Pipeline;
+import org.apache.hadoop.hdds.utils.IOUtils;
 import org.apache.hadoop.ozone.HddsDatanodeService;
 import org.apache.hadoop.ozone.MiniOzoneCluster;
 import org.apache.hadoop.ozone.client.ObjectStore;
@@ -65,6 +66,7 @@ import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_CONTAINER_SIZE;
  */
 public class TestDeleteContainerHandler {
 
+  private static OzoneClient client;
   /**
     * Set a timeout for each test.
     */
@@ -90,7 +92,7 @@ public class TestDeleteContainerHandler {
     cluster.waitForClusterToBeReady();
     cluster.waitForPipelineTobeReady(ONE, 30000);
 
-    OzoneClient client = OzoneClientFactory.getRpcClient(conf);
+    client = OzoneClientFactory.getRpcClient(conf);
     objectStore = client.getObjectStore();
     objectStore.createVolume(volumeName);
     objectStore.getVolume(volumeName).createBucket(bucketName);
@@ -98,6 +100,7 @@ public class TestDeleteContainerHandler {
 
   @AfterClass
   public static void shutdown() {
+    IOUtils.closeQuietly(client);
     if (cluster != null) {
       try {
         cluster.shutdown();

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/TestRefreshVolumeUsageHandler.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/TestRefreshVolumeUsageHandler.java
@@ -93,45 +93,46 @@ public class TestRefreshVolumeUsageHandler {
         .getScmNodeStat().getScmUsed().get();
 
     //creating a key to take some storage space
-    OzoneClient client = OzoneClientFactory.getRpcClient(conf);
-    ObjectStore objectStore = client.getObjectStore();
-    objectStore.createVolume("test");
-    objectStore.getVolume("test").createBucket("test");
-    OzoneOutputStream key = objectStore.getVolume("test").getBucket("test")
-        .createKey("test", 4096, ReplicationType.RATIS,
-            ReplicationFactor.ONE, new HashMap<>());
-    key.write("test".getBytes(UTF_8));
-    key.close();
+    try (OzoneClient client = OzoneClientFactory.getRpcClient(conf)) {
+      ObjectStore objectStore = client.getObjectStore();
+      objectStore.createVolume("test");
+      objectStore.getVolume("test").createBucket("test");
+      OzoneOutputStream key = objectStore.getVolume("test").getBucket("test")
+          .createKey("test", 4096, ReplicationType.RATIS,
+              ReplicationFactor.ONE, new HashMap<>());
+      key.write("test".getBytes(UTF_8));
+      key.close();
 
-    //a new key is created , but the datanode default REFRESH_PERIOD is 1 hour,
-    //still the cache is updated, so the scm will eventually get the new
-    //used space from the datanode through node report.
-    Assert.assertTrue(cluster.getStorageContainerManager()
-            .getScmNodeManager().getUsageInfo(datanodeDetails)
-            .getScmNodeStat().getScmUsed().isEqual(currentScmUsed));
+      //a new key is created , but the datanode default REFRESH_PERIOD is 1 hour,
+      //still the cache is updated, so the scm will eventually get the new
+      //used space from the datanode through node report.
+      Assert.assertTrue(cluster.getStorageContainerManager()
+          .getScmNodeManager().getUsageInfo(datanodeDetails)
+          .getScmNodeStat().getScmUsed().isEqual(currentScmUsed));
 
-    try {
+      try {
+        GenericTestUtils.waitFor(() -> isUsageInfoRefreshed(cluster,
+            datanodeDetails, currentScmUsed), 500, 5 * 1000);
+      } catch (TimeoutException te) {
+        //no op
+      } catch (InterruptedException ie) {
+        //no op
+      }
+
+      //after waiting for several node report , this usage info
+      //in SCM should be updated as we have updated the DN's cached usage info.
+      Assert.assertTrue(cluster.getStorageContainerManager()
+          .getScmNodeManager().getUsageInfo(datanodeDetails)
+          .getScmNodeStat().getScmUsed().isGreater(currentScmUsed));
+
+      //send refresh volume usage command to datanode
+      cluster.getStorageContainerManager()
+          .getScmNodeManager().refreshAllHealthyDnUsageInfo();
+
+      //waiting for the new usage info is refreshed
       GenericTestUtils.waitFor(() -> isUsageInfoRefreshed(cluster,
           datanodeDetails, currentScmUsed), 500, 5 * 1000);
-    } catch (TimeoutException te) {
-      //no op
-    } catch (InterruptedException ie) {
-      //no op
     }
-
-    //after waiting for several node report , this usage info
-    //in SCM should be updated as we have updated the DN's cached usage info.
-    Assert.assertTrue(cluster.getStorageContainerManager()
-        .getScmNodeManager().getUsageInfo(datanodeDetails)
-        .getScmNodeStat().getScmUsed().isGreater(currentScmUsed));
-
-    //send refresh volume usage command to datanode
-    cluster.getStorageContainerManager()
-        .getScmNodeManager().refreshAllHealthyDnUsageInfo();
-
-    //waiting for the new usage info is refreshed
-    GenericTestUtils.waitFor(() -> isUsageInfoRefreshed(cluster,
-        datanodeDetails, currentScmUsed), 500, 5 * 1000);
   }
 
   private static Boolean isUsageInfoRefreshed(MiniOzoneCluster cluster,

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/TestRefreshVolumeUsageHandler.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/TestRefreshVolumeUsageHandler.java
@@ -103,7 +103,7 @@ public class TestRefreshVolumeUsageHandler {
       key.write("test".getBytes(UTF_8));
       key.close();
 
-      //a new key is created , but the datanode default REFRESH_PERIOD is 1 hour,
+      //a new key is created, but the datanode default REFRESH_PERIOD is 1 hour,
       //still the cache is updated, so the scm will eventually get the new
       //used space from the datanode through node report.
       Assert.assertTrue(cluster.getStorageContainerManager()

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/ozoneimpl/TestOzoneContainer.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/ozoneimpl/TestOzoneContainer.java
@@ -84,9 +84,10 @@ public class TestOzoneContainer {
       //Set clusterId and manually start ozone container.
       container.start(UUID.randomUUID().toString());
 
-      XceiverClientGrpc client = new XceiverClientGrpc(pipeline, conf);
-      client.connect();
-      createContainerForTesting(client, containerID);
+      try (XceiverClientGrpc client = new XceiverClientGrpc(pipeline, conf)) {
+        client.connect();
+        createContainerForTesting(client, containerID);
+      }
     } finally {
       if (container != null) {
         container.stop();

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/ozoneimpl/TestSecureOzoneContainer.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/ozoneimpl/TestSecureOzoneContainer.java
@@ -162,8 +162,7 @@ public class TestSecureOzoneContainer {
       secretManager.start(caClient);
 
       ugi.doAs((PrivilegedAction<Void>) () -> {
-        try {
-          XceiverClientGrpc client = new XceiverClientGrpc(pipeline, conf);
+        try (XceiverClientGrpc client = new XceiverClientGrpc(pipeline, conf)) {
           client.connect();
 
           Token<?> token = null;

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/dn/volume/TestDatanodeHddsVolumeFailureDetection.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/dn/volume/TestDatanodeHddsVolumeFailureDetection.java
@@ -26,6 +26,7 @@ import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.hdds.scm.cli.ContainerOperationClient;
 import org.apache.hadoop.hdds.scm.client.ScmClient;
 import org.apache.hadoop.hdds.scm.container.common.helpers.ContainerWithPipeline;
+import org.apache.hadoop.hdds.utils.IOUtils;
 import org.apache.hadoop.ozone.HddsDatanodeService;
 import org.apache.hadoop.ozone.MiniOzoneCluster;
 import org.apache.hadoop.ozone.OzoneConsts;
@@ -150,6 +151,7 @@ public class TestDatanodeHddsVolumeFailureDetection {
 
   @After
   public void shutdown() throws IOException {
+    IOUtils.closeQuietly(scmClient);
     if (ozClient != null) {
       ozClient.close();
     }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/freon/TestHadoopDirTreeGenerator.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/freon/TestHadoopDirTreeGenerator.java
@@ -21,8 +21,10 @@ import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import org.apache.hadoop.hdds.utils.IOUtils;
 import org.apache.hadoop.ozone.MiniOzoneCluster;
 import org.apache.hadoop.ozone.client.ObjectStore;
+import org.apache.hadoop.ozone.client.OzoneClient;
 import org.apache.hadoop.ozone.client.OzoneClientFactory;
 import org.apache.hadoop.ozone.client.OzoneVolume;
 import org.apache.hadoop.ozone.om.OMConfigKeys;
@@ -54,6 +56,7 @@ public class TestHadoopDirTreeGenerator {
   private ObjectStore store = null;
   private static final Logger LOG =
           LoggerFactory.getLogger(TestHadoopDirTreeGenerator.class);
+  private OzoneClient client;
 
   @Before
   public void setup() {
@@ -69,6 +72,7 @@ public class TestHadoopDirTreeGenerator {
    * Shutdown MiniDFSCluster.
    */
   private void shutdown() throws IOException {
+    IOUtils.closeQuietly(client);
     if (cluster != null) {
       cluster.shutdown();
       FileUtils.deleteDirectory(new File(path));
@@ -88,7 +92,8 @@ public class TestHadoopDirTreeGenerator {
     cluster.waitForClusterToBeReady();
     cluster.waitTobeOutOfSafeMode();
 
-    store = OzoneClientFactory.getRpcClient(conf).getObjectStore();
+    client = OzoneClientFactory.getRpcClient(conf);
+    store = client.getObjectStore();
   }
 
   protected OzoneConfiguration getOzoneConfiguration() {

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/freon/TestHadoopNestedDirGenerator.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/freon/TestHadoopNestedDirGenerator.java
@@ -21,8 +21,10 @@ import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import org.apache.hadoop.hdds.utils.IOUtils;
 import org.apache.hadoop.ozone.MiniOzoneCluster;
 import org.apache.hadoop.ozone.client.ObjectStore;
+import org.apache.hadoop.ozone.client.OzoneClient;
 import org.apache.hadoop.ozone.client.OzoneClientFactory;
 import org.apache.hadoop.ozone.client.OzoneVolume;
 import org.apache.hadoop.ozone.om.OMConfigKeys;
@@ -55,6 +57,8 @@ public class TestHadoopNestedDirGenerator {
   private ObjectStore store = null;
   private static final Logger LOG =
           LoggerFactory.getLogger(TestHadoopNestedDirGenerator.class);
+  private OzoneClient client;
+
   @Before
     public void setup() {
     path = getTempPath(TestHadoopNestedDirGenerator.class.getSimpleName());
@@ -69,6 +73,7 @@ public class TestHadoopNestedDirGenerator {
      */
 
   private void shutdown() throws IOException {
+    IOUtils.closeQuietly(client);
     if (cluster != null) {
       cluster.shutdown();
       FileUtils.deleteDirectory(new File(path));
@@ -88,7 +93,8 @@ public class TestHadoopNestedDirGenerator {
     cluster = MiniOzoneCluster.newBuilder(conf).setNumDatanodes(5).build();
     cluster.waitForClusterToBeReady();
     cluster.waitTobeOutOfSafeMode();
-    store = OzoneClientFactory.getRpcClient(conf).getObjectStore();
+    client = OzoneClientFactory.getRpcClient(conf);
+    store = client.getObjectStore();
   }
 
   @Test

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/freon/TestOMSnapshotDAG.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/freon/TestOMSnapshotDAG.java
@@ -103,7 +103,7 @@ public class TestOMSnapshotDAG {
 
     cluster = MiniOzoneCluster.newBuilder(conf).setNumDatanodes(3).build();
     cluster.waitForClusterToBeReady();
-    client = cluster.getClient();
+    client = cluster.newClient();
     store = client.getObjectStore();
 
     GenericTestUtils.setLogLevel(RaftLog.LOG, Level.INFO);

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/freon/TestOMSnapshotDAG.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/freon/TestOMSnapshotDAG.java
@@ -17,6 +17,7 @@
  */
 package org.apache.hadoop.ozone.freon;
 
+import org.apache.hadoop.hdds.utils.IOUtils;
 import org.apache.hadoop.hdds.conf.DatanodeRatisServerConfig;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.ratis.conf.RatisClientConfig;
@@ -25,6 +26,7 @@ import org.apache.hadoop.ozone.MiniOzoneCluster;
 import org.apache.hadoop.ozone.OzoneConfigKeys;
 import org.apache.hadoop.ozone.client.ObjectStore;
 import org.apache.hadoop.ozone.client.OzoneBucket;
+import org.apache.hadoop.ozone.client.OzoneClient;
 import org.apache.hadoop.ozone.client.OzoneVolume;
 import org.apache.hadoop.ozone.om.OMMetadataManager;
 import org.apache.hadoop.ozone.om.OMStorage;
@@ -71,6 +73,7 @@ public class TestOMSnapshotDAG {
   private static MiniOzoneCluster cluster;
   private static OzoneConfiguration conf;
   private static ObjectStore store;
+  private static OzoneClient client;
   private final File metaDir = OMStorage.getOmDbDir(conf);
 
   /**
@@ -100,8 +103,8 @@ public class TestOMSnapshotDAG {
 
     cluster = MiniOzoneCluster.newBuilder(conf).setNumDatanodes(3).build();
     cluster.waitForClusterToBeReady();
-
-    store = cluster.getClient().getObjectStore();
+    client = cluster.getClient();
+    store = client.getObjectStore();
 
     GenericTestUtils.setLogLevel(RaftLog.LOG, Level.INFO);
     GenericTestUtils.setLogLevel(RaftServer.LOG, Level.INFO);
@@ -112,6 +115,7 @@ public class TestOMSnapshotDAG {
    */
   @AfterAll
   public static void shutdown() {
+    IOUtils.closeQuietly(client);
     if (cluster != null) {
       cluster.shutdown();
     }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/freon/TestOmBucketReadWriteFileOps.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/freon/TestOmBucketReadWriteFileOps.java
@@ -21,9 +21,11 @@ import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import org.apache.hadoop.hdds.utils.IOUtils;
 import org.apache.hadoop.ozone.MiniOzoneCluster;
 import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.hadoop.ozone.client.ObjectStore;
+import org.apache.hadoop.ozone.client.OzoneClient;
 import org.apache.hadoop.ozone.client.OzoneClientFactory;
 import org.apache.hadoop.ozone.client.OzoneVolume;
 import org.apache.hadoop.ozone.om.OMConfigKeys;
@@ -55,6 +57,7 @@ public class TestOmBucketReadWriteFileOps {
   private ObjectStore store = null;
   private static final Logger LOG =
       LoggerFactory.getLogger(TestOmBucketReadWriteFileOps.class);
+  private OzoneClient client;
 
   @Before
   public void setup() {
@@ -70,6 +73,7 @@ public class TestOmBucketReadWriteFileOps {
    * Shutdown MiniDFSCluster.
    */
   private void shutdown() throws IOException {
+    IOUtils.closeQuietly(client);
     if (cluster != null) {
       cluster.shutdown();
       FileUtils.deleteDirectory(new File(path));
@@ -89,7 +93,8 @@ public class TestOmBucketReadWriteFileOps {
     cluster.waitForClusterToBeReady();
     cluster.waitTobeOutOfSafeMode();
 
-    store = OzoneClientFactory.getRpcClient(conf).getObjectStore();
+    client = OzoneClientFactory.getRpcClient(conf);
+    store = client.getObjectStore();
   }
 
   protected OzoneConfiguration getOzoneConfiguration() {

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/freon/TestOmBucketReadWriteKeyOps.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/freon/TestOmBucketReadWriteKeyOps.java
@@ -18,10 +18,12 @@ package org.apache.hadoop.ozone.freon;
 
 import org.apache.commons.io.FileUtils;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import org.apache.hadoop.hdds.utils.IOUtils;
 import org.apache.hadoop.ozone.MiniOzoneCluster;
 
 import org.apache.hadoop.ozone.client.ObjectStore;
 import org.apache.hadoop.ozone.client.OzoneBucket;
+import org.apache.hadoop.ozone.client.OzoneClient;
 import org.apache.hadoop.ozone.client.OzoneClientFactory;
 import org.apache.hadoop.ozone.client.OzoneVolume;
 import org.apache.hadoop.ozone.client.OzoneKey;
@@ -57,6 +59,7 @@ public class TestOmBucketReadWriteKeyOps {
   private ObjectStore store = null;
   private static final Logger LOG =
       LoggerFactory.getLogger(TestOmBucketReadWriteKeyOps.class);
+  private OzoneClient client;
 
   @Before
   public void setup() {
@@ -72,6 +75,7 @@ public class TestOmBucketReadWriteKeyOps {
    * Shutdown MiniDFSCluster.
    */
   private void shutdown() {
+    IOUtils.closeQuietly(client);
     if (cluster != null) {
       cluster.shutdown();
     }
@@ -90,7 +94,8 @@ public class TestOmBucketReadWriteKeyOps {
     cluster.waitForClusterToBeReady();
     cluster.waitTobeOutOfSafeMode();
 
-    store = OzoneClientFactory.getRpcClient(conf).getObjectStore();
+    client = OzoneClientFactory.getRpcClient(conf);
+    store = client.getObjectStore();
   }
 
   private OzoneConfiguration getOzoneConfiguration() {

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/fsck/TestContainerMapper.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/fsck/TestContainerMapper.java
@@ -24,6 +24,7 @@ import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.conf.StorageUnit;
 import org.apache.hadoop.hdds.scm.ScmConfigKeys;
 import org.apache.hadoop.hdds.scm.protocolPB.StorageContainerLocationProtocolClientSideTranslatorPB;
+import org.apache.hadoop.hdds.utils.IOUtils;
 import org.apache.hadoop.ozone.MiniOzoneCluster;
 import org.apache.hadoop.ozone.client.BucketArgs;
 import org.apache.hadoop.ozone.client.ObjectStore;
@@ -143,6 +144,7 @@ public class TestContainerMapper {
 
   @AfterClass
   public static void shutdown() throws IOException {
+    IOUtils.closeQuietly(ozClient);
     cluster.shutdown();
     FileUtils.deleteFully(new File(dbPath));
   }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestBucketLayoutWithOlderClient.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestBucketLayoutWithOlderClient.java
@@ -16,11 +16,13 @@
  */
 package org.apache.hadoop.ozone.om;
 
+import org.apache.hadoop.hdds.utils.IOUtils;
 import org.apache.hadoop.ozone.MiniOzoneCluster;
 import org.apache.hadoop.ozone.ClientVersion;
 import org.apache.hadoop.ozone.TestDataUtil;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.ozone.client.OzoneBucket;
+import org.apache.hadoop.ozone.client.OzoneClient;
 import org.apache.hadoop.ozone.om.helpers.BucketLayout;
 import org.apache.hadoop.ozone.om.helpers.OmBucketInfo;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos;
@@ -44,6 +46,7 @@ public class TestBucketLayoutWithOlderClient {
   private static String clusterId;
   private static String scmId;
   private static String omId;
+  private static OzoneClient client;
 
   @Rule
   public Timeout timeout = new Timeout(1200000);
@@ -65,19 +68,20 @@ public class TestBucketLayoutWithOlderClient {
     cluster = MiniOzoneCluster.newBuilder(conf).setClusterId(clusterId)
         .setScmId(scmId).setOmId(omId).build();
     cluster.waitForClusterToBeReady();
+    client = cluster.getClient();
   }
 
   @Test
   public void testCreateBucketWithOlderClient() throws Exception {
     // create a volume and a bucket without bucket layout argument
-    OzoneBucket bucket = TestDataUtil.createVolumeAndBucket(cluster, null);
+    OzoneBucket bucket = TestDataUtil.createVolumeAndBucket(client, null);
     String volumeName = bucket.getVolumeName();
     // OM defaulted bucket layout
     Assert.assertEquals(BucketLayout.OBJECT_STORE, bucket.getBucketLayout());
 
     // Sets bucket layout explicitly.
     OzoneBucket fsobucket = TestDataUtil
-        .createVolumeAndBucket(cluster, BucketLayout.FILE_SYSTEM_OPTIMIZED);
+        .createVolumeAndBucket(client, BucketLayout.FILE_SYSTEM_OPTIMIZED);
     Assert.assertEquals(BucketLayout.FILE_SYSTEM_OPTIMIZED,
         fsobucket.getBucketLayout());
 
@@ -119,6 +123,7 @@ public class TestBucketLayoutWithOlderClient {
    */
   @AfterClass
   public static void shutdown() {
+    IOUtils.closeQuietly(client);
     if (cluster != null) {
       cluster.shutdown();
     }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestBucketLayoutWithOlderClient.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestBucketLayoutWithOlderClient.java
@@ -68,7 +68,7 @@ public class TestBucketLayoutWithOlderClient {
     cluster = MiniOzoneCluster.newBuilder(conf).setClusterId(clusterId)
         .setScmId(scmId).setOmId(omId).build();
     cluster.waitForClusterToBeReady();
-    client = cluster.getClient();
+    client = cluster.newClient();
   }
 
   @Test

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestBucketOwner.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestBucketOwner.java
@@ -82,7 +82,7 @@ public class TestBucketOwner {
     cluster = MiniOzoneCluster.newBuilder(conf).setClusterId(clusterId)
             .setScmId(scmId).setOmId(omId).build();
     cluster.waitForClusterToBeReady();
-    try (OzoneClient client = cluster.getClient()) {
+    try (OzoneClient client = cluster.newClient()) {
       ObjectStore objectStore = client.getObjectStore();
     /* r = READ, w = WRITE, c = CREATE, d = DELETE
        l = LIST, a = ALL, n = NONE, x = READ_ACL, y = WRITE_ACL */
@@ -90,7 +90,7 @@ public class TestBucketOwner {
       createVolumeWithOwnerAndAcl(objectStore, "volume1", "user2", aclWorldAll);
     }
     UserGroupInformation.setLoginUser(user1);
-    try (OzoneClient client = cluster.getClient()) {
+    try (OzoneClient client = cluster.newClient()) {
       ObjectStore objectStore = client.getObjectStore();
       OzoneVolume volume = objectStore.getVolume("volume1");
       BucketArgs omBucketArgs = BucketArgs.newBuilder()
@@ -112,7 +112,7 @@ public class TestBucketOwner {
   public void testBucketOwner() throws Exception {
     // Test Key Operations as Bucket Owner,  Non-Volume Owner
     UserGroupInformation.setLoginUser(user1);
-    try (OzoneClient client = cluster.getClient()) {
+    try (OzoneClient client = cluster.newClient()) {
       OzoneVolume volume = client.getObjectStore()
           .getVolume("volume1");
       OzoneBucket ozoneBucket = volume.getBucket("bucket1");
@@ -139,7 +139,7 @@ public class TestBucketOwner {
     // Test Key Operations Non-Bucket Owner, Non-Volume Owner
     //Key Create
     UserGroupInformation.setLoginUser(user3);
-    try (OzoneClient client = cluster.getClient()) {
+    try (OzoneClient client = cluster.newClient()) {
       OzoneVolume volume = client.getObjectStore()
               .getVolume("volume1");
       OzoneBucket ozoneBucket = volume.getBucket("bucket1");
@@ -149,7 +149,7 @@ public class TestBucketOwner {
       LOG.info(ex.getMessage());
     }
     //Key Delete - should fail
-    try (OzoneClient client = cluster.getClient()) {
+    try (OzoneClient client = cluster.newClient()) {
       OzoneVolume volume = client.getObjectStore()
               .getVolume("volume1");
       OzoneBucket ozoneBucket = volume.getBucket("bucket1");
@@ -159,7 +159,7 @@ public class TestBucketOwner {
       LOG.info(ex.getMessage());
     }
     //Key Rename - should fail
-    try (OzoneClient client = cluster.getClient()) {
+    try (OzoneClient client = cluster.newClient()) {
       OzoneVolume volume = client.getObjectStore()
               .getVolume("volume1");
       OzoneBucket ozoneBucket = volume.getBucket("bucket1");
@@ -169,7 +169,7 @@ public class TestBucketOwner {
       LOG.info(ex.getMessage());
     }
     //List Keys - should fail
-    try (OzoneClient client = cluster.getClient()) {
+    try (OzoneClient client = cluster.newClient()) {
       OzoneVolume volume = client.getObjectStore()
               .getVolume("volume1");
       OzoneBucket ozoneBucket = volume.getBucket("bucket1");
@@ -179,7 +179,7 @@ public class TestBucketOwner {
       LOG.info(ex.getMessage());
     }
     //Get Acls - should fail
-    try (OzoneClient client = cluster.getClient()) {
+    try (OzoneClient client = cluster.newClient()) {
       OzoneVolume volume = client.getObjectStore()
               .getVolume("volume1");
       OzoneBucket ozoneBucket = volume.getBucket("bucket1");
@@ -189,7 +189,7 @@ public class TestBucketOwner {
       LOG.info(ex.getMessage());
     }
     //Add Acls - should fail
-    try (OzoneClient client = cluster.getClient()) {
+    try (OzoneClient client = cluster.newClient()) {
       OzoneVolume volume = client.getObjectStore()
               .getVolume("volume1");
       OzoneBucket ozoneBucket = volume.getBucket("bucket1");
@@ -206,7 +206,7 @@ public class TestBucketOwner {
   public void testVolumeOwner() throws Exception {
     //Test Key Operations for Volume Owner
     UserGroupInformation.setLoginUser(user2);
-    try (OzoneClient client = cluster.getClient()) {
+    try (OzoneClient client = cluster.newClient()) {
       OzoneVolume volume = client.getObjectStore().getVolume("volume1");
       OzoneBucket ozoneBucket = volume.getBucket("bucket1");
       //Key Create

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestBucketOwner.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestBucketOwner.java
@@ -68,8 +68,6 @@ public class TestBucketOwner {
       .createUserForTesting("user2", new String[] {"test2"});
   private static UserGroupInformation user3 = UserGroupInformation
       .createUserForTesting("user3", new String[] {"test3"});
-  private static OzoneClient client;
-  private static ObjectStore objectStore;
 
   @BeforeClass
   public static void init() throws Exception {
@@ -84,21 +82,23 @@ public class TestBucketOwner {
     cluster = MiniOzoneCluster.newBuilder(conf).setClusterId(clusterId)
             .setScmId(scmId).setOmId(omId).build();
     cluster.waitForClusterToBeReady();
-    client = cluster.getClient();
-    objectStore = client.getObjectStore();
+    try (OzoneClient client = cluster.getClient()) {
+      ObjectStore objectStore = client.getObjectStore();
     /* r = READ, w = WRITE, c = CREATE, d = DELETE
        l = LIST, a = ALL, n = NONE, x = READ_ACL, y = WRITE_ACL */
-    String aclWorldAll = "world::a";
-    createVolumeWithOwnerAndAcl(objectStore, "volume1", "user2", aclWorldAll);
+      String aclWorldAll = "world::a";
+      createVolumeWithOwnerAndAcl(objectStore, "volume1", "user2", aclWorldAll);
+    }
     UserGroupInformation.setLoginUser(user1);
-    client = cluster.getClient();
-    objectStore = client.getObjectStore();
-    OzoneVolume volume = objectStore.getVolume("volume1");
-    BucketArgs omBucketArgs = BucketArgs.newBuilder()
-            .setStorageType(StorageType.DISK).setOwner("user1").build();
-    volume.createBucket("bucket1", omBucketArgs);
-    volume.createBucket("bucket2", omBucketArgs);
-    volume.createBucket("bucket3", omBucketArgs);
+    try (OzoneClient client = cluster.getClient()) {
+      ObjectStore objectStore = client.getObjectStore();
+      OzoneVolume volume = objectStore.getVolume("volume1");
+      BucketArgs omBucketArgs = BucketArgs.newBuilder()
+          .setStorageType(StorageType.DISK).setOwner("user1").build();
+      volume.createBucket("bucket1", omBucketArgs);
+      volume.createBucket("bucket2", omBucketArgs);
+      volume.createBucket("bucket3", omBucketArgs);
+    }
   }
 
   @AfterClass
@@ -112,24 +112,26 @@ public class TestBucketOwner {
   public void testBucketOwner() throws Exception {
     // Test Key Operations as Bucket Owner,  Non-Volume Owner
     UserGroupInformation.setLoginUser(user1);
-    OzoneVolume volume = cluster.getClient().getObjectStore()
-            .getVolume("volume1");
-    OzoneBucket ozoneBucket = volume.getBucket("bucket1");
-    //Key Create
-    createKey(ozoneBucket, "key1", 10, new byte[10]);
-    createKey(ozoneBucket, "key2", 10, new byte[10]);
-    //Key Delete
-    ozoneBucket.deleteKey("key1");
-    //Bucket Delete
-    volume.deleteBucket("bucket3");
-    //List Keys
-    ozoneBucket.listKeys("key");
-    //Get Acls
-    ozoneBucket.getAcls();
-    //Add Acls
-    OzoneAcl acl = new OzoneAcl(USER, "testuser",
-        IAccessAuthorizer.ACLType.ALL, DEFAULT);
-    ozoneBucket.addAcl(acl);
+    try (OzoneClient client = cluster.getClient()) {
+      OzoneVolume volume = client.getObjectStore()
+          .getVolume("volume1");
+      OzoneBucket ozoneBucket = volume.getBucket("bucket1");
+      //Key Create
+      createKey(ozoneBucket, "key1", 10, new byte[10]);
+      createKey(ozoneBucket, "key2", 10, new byte[10]);
+      //Key Delete
+      ozoneBucket.deleteKey("key1");
+      //Bucket Delete
+      volume.deleteBucket("bucket3");
+      //List Keys
+      ozoneBucket.listKeys("key");
+      //Get Acls
+      ozoneBucket.getAcls();
+      //Add Acls
+      OzoneAcl acl = new OzoneAcl(USER, "testuser",
+          IAccessAuthorizer.ACLType.ALL, DEFAULT);
+      ozoneBucket.addAcl(acl);
+    }
   }
 
   @Test
@@ -137,61 +139,60 @@ public class TestBucketOwner {
     // Test Key Operations Non-Bucket Owner, Non-Volume Owner
     //Key Create
     UserGroupInformation.setLoginUser(user3);
-    OzoneBucket ozoneBucket;
-    try {
-      OzoneVolume volume = cluster.getClient().getObjectStore()
+    try (OzoneClient client = cluster.getClient()) {
+      OzoneVolume volume = client.getObjectStore()
               .getVolume("volume1");
-      ozoneBucket = volume.getBucket("bucket1");
+      OzoneBucket ozoneBucket = volume.getBucket("bucket1");
       createKey(ozoneBucket, "key3", 10, new byte[10]);
       fail("Create key as non-volume and non-bucket owner should fail");
     } catch (Exception ex) {
       LOG.info(ex.getMessage());
     }
     //Key Delete - should fail
-    try {
-      OzoneVolume volume = cluster.getClient().getObjectStore()
+    try (OzoneClient client = cluster.getClient()) {
+      OzoneVolume volume = client.getObjectStore()
               .getVolume("volume1");
-      ozoneBucket = volume.getBucket("bucket1");
+      OzoneBucket ozoneBucket = volume.getBucket("bucket1");
       ozoneBucket.deleteKey("key2");
       fail("Delete key as non-volume and non-bucket owner should fail");
     } catch (Exception ex) {
       LOG.info(ex.getMessage());
     }
     //Key Rename - should fail
-    try {
-      OzoneVolume volume = cluster.getClient().getObjectStore()
+    try (OzoneClient client = cluster.getClient()) {
+      OzoneVolume volume = client.getObjectStore()
               .getVolume("volume1");
-      ozoneBucket = volume.getBucket("bucket1");
+      OzoneBucket ozoneBucket = volume.getBucket("bucket1");
       ozoneBucket.renameKey("key2", "key4");
       fail("Rename key as non-volume and non-bucket owner should fail");
     } catch (Exception ex) {
       LOG.info(ex.getMessage());
     }
     //List Keys - should fail
-    try {
-      OzoneVolume volume = cluster.getClient().getObjectStore()
+    try (OzoneClient client = cluster.getClient()) {
+      OzoneVolume volume = client.getObjectStore()
               .getVolume("volume1");
-      ozoneBucket = volume.getBucket("bucket1");
+      OzoneBucket ozoneBucket = volume.getBucket("bucket1");
       ozoneBucket.listKeys("key");
       fail("List keys as non-volume and non-bucket owner should fail");
     } catch (Exception ex) {
       LOG.info(ex.getMessage());
     }
     //Get Acls - should fail
-    try {
-      OzoneVolume volume = cluster.getClient().getObjectStore()
+    try (OzoneClient client = cluster.getClient()) {
+      OzoneVolume volume = client.getObjectStore()
               .getVolume("volume1");
-      ozoneBucket = volume.getBucket("bucket1");
+      OzoneBucket ozoneBucket = volume.getBucket("bucket1");
       ozoneBucket.getAcls();
       fail("Get Acls as non-volume and non-bucket owner should fail");
     } catch (Exception ex) {
       LOG.info(ex.getMessage());
     }
     //Add Acls - should fail
-    try {
-      OzoneVolume volume = cluster.getClient().getObjectStore()
+    try (OzoneClient client = cluster.getClient()) {
+      OzoneVolume volume = client.getObjectStore()
               .getVolume("volume1");
-      ozoneBucket = volume.getBucket("bucket1");
+      OzoneBucket ozoneBucket = volume.getBucket("bucket1");
       OzoneAcl acl = new OzoneAcl(USER, "testuser1",
               IAccessAuthorizer.ACLType.ALL, DEFAULT);
       ozoneBucket.addAcl(acl);
@@ -205,23 +206,24 @@ public class TestBucketOwner {
   public void testVolumeOwner() throws Exception {
     //Test Key Operations for Volume Owner
     UserGroupInformation.setLoginUser(user2);
-    OzoneVolume volume = cluster.getClient().getObjectStore()
-            .getVolume("volume1");
-    OzoneBucket ozoneBucket = volume.getBucket("bucket1");
-    //Key Create
-    createKey(ozoneBucket, "key2", 10, new byte[10]);
-    //Key Delete
-    ozoneBucket.deleteKey("key2");
-    //List Keys
-    ozoneBucket.listKeys("key");
-    //Get Acls
-    ozoneBucket.getAcls();
-    //Add Acls
-    OzoneAcl acl = new OzoneAcl(USER, "testuser2",
-            IAccessAuthorizer.ACLType.ALL, DEFAULT);
-    ozoneBucket.addAcl(acl);
-    //Bucket Delete
-    volume.deleteBucket("bucket2");
+    try (OzoneClient client = cluster.getClient()) {
+      OzoneVolume volume = client.getObjectStore().getVolume("volume1");
+      OzoneBucket ozoneBucket = volume.getBucket("bucket1");
+      //Key Create
+      createKey(ozoneBucket, "key2", 10, new byte[10]);
+      //Key Delete
+      ozoneBucket.deleteKey("key2");
+      //List Keys
+      ozoneBucket.listKeys("key");
+      //Get Acls
+      ozoneBucket.getAcls();
+      //Add Acls
+      OzoneAcl acl = new OzoneAcl(USER, "testuser2",
+          IAccessAuthorizer.ACLType.ALL, DEFAULT);
+      ozoneBucket.addAcl(acl);
+      //Bucket Delete
+      volume.deleteBucket("bucket2");
+    }
   }
 
   private static void createVolumeWithOwnerAndAcl(ObjectStore store,

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestContainerReportWithKeys.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestContainerReportWithKeys.java
@@ -26,6 +26,7 @@ import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.hdds.scm.container.ContainerID;
 import org.apache.hadoop.hdds.scm.container.ContainerInfo;
 import org.apache.hadoop.hdds.scm.container.ContainerReplica;
+import org.apache.hadoop.hdds.utils.IOUtils;
 import org.apache.hadoop.ozone.MiniOzoneCluster;
 import org.apache.hadoop.ozone.client.ObjectStore;
 import org.apache.hadoop.ozone.client.OzoneClient;
@@ -65,6 +66,7 @@ public class TestContainerReportWithKeys {
   private static final Logger LOG = LoggerFactory.getLogger(
       TestContainerReportWithKeys.class);
   private static MiniOzoneCluster cluster = null;
+  private static OzoneClient client;
   private static OzoneConfiguration conf;
   private static StorageContainerManager scm;
 
@@ -83,6 +85,7 @@ public class TestContainerReportWithKeys {
     conf = new OzoneConfiguration();
     cluster = MiniOzoneCluster.newBuilder(conf).build();
     cluster.waitForClusterToBeReady();
+    client = OzoneClientFactory.getRpcClient(conf);
     scm = cluster.getStorageContainerManager();
   }
 
@@ -91,6 +94,7 @@ public class TestContainerReportWithKeys {
    */
   @AfterClass
   public static void shutdown() {
+    IOUtils.closeQuietly(client);
     if (cluster != null) {
       cluster.shutdown();
     }
@@ -103,7 +107,6 @@ public class TestContainerReportWithKeys {
     final String keyName = "key" + RandomStringUtils.randomNumeric(5);
     final int keySize = 100;
 
-    OzoneClient client = OzoneClientFactory.getRpcClient(conf);
     ObjectStore objectStore = client.getObjectStore();
     objectStore.createVolume(volumeName);
     objectStore.getVolume(volumeName).createBucket(bucketName);

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestKeyPurging.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestKeyPurging.java
@@ -21,9 +21,11 @@ package org.apache.hadoop.ozone.om;
 import org.apache.hadoop.hdds.client.ReplicationFactor;
 import org.apache.hadoop.hdds.client.ReplicationType;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import org.apache.hadoop.hdds.utils.IOUtils;
 import org.apache.hadoop.ozone.MiniOzoneCluster;
 import org.apache.hadoop.ozone.client.ObjectStore;
 import org.apache.hadoop.ozone.client.OzoneBucket;
+import org.apache.hadoop.ozone.client.OzoneClient;
 import org.apache.hadoop.ozone.client.OzoneClientFactory;
 import org.apache.hadoop.ozone.client.OzoneVolume;
 import org.apache.hadoop.ozone.client.io.OzoneOutputStream;
@@ -65,6 +67,7 @@ public class TestKeyPurging {
 
   private static final int NUM_KEYS = 10;
   private static final int KEY_SIZE = 100;
+  private OzoneClient client;
 
   @Before
   public void setup() throws Exception {
@@ -82,12 +85,14 @@ public class TestKeyPurging {
         .setHbInterval(200)
         .build();
     cluster.waitForClusterToBeReady();
-    store = OzoneClientFactory.getRpcClient(conf).getObjectStore();
+    client = OzoneClientFactory.getRpcClient(conf);
+    store = client.getObjectStore();
     om = cluster.getOzoneManager();
   }
 
   @After
   public void shutdown() {
+    IOUtils.closeQuietly(client);
     if (cluster != null) {
       cluster.shutdown();
     }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestListKeysWithFSO.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestListKeysWithFSO.java
@@ -90,7 +90,7 @@ public class TestListKeysWithFSO {
     cluster = MiniOzoneCluster.newBuilder(conf).setClusterId(clusterId)
         .setScmId(scmId).setOmId(omId).build();
     cluster.waitForClusterToBeReady();
-    client = cluster.getClient();
+    client = cluster.newClient();
 
     // create a volume and a LEGACY bucket
     legacyOzoneBucket = TestDataUtil

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestListKeysWithFSO.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestListKeysWithFSO.java
@@ -16,6 +16,7 @@
  */
 package org.apache.hadoop.ozone.om;
 
+import org.apache.hadoop.hdds.utils.IOUtils;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.protocol.StorageType;
@@ -64,6 +65,7 @@ public class TestListKeysWithFSO {
   private static OzoneBucket fsoOzoneBucket;
   private static OzoneBucket legacyOzoneBucket2;
   private static OzoneBucket fsoOzoneBucket2;
+  private static OzoneClient client;
 
   @Rule
   public Timeout timeout = new Timeout(1200000);
@@ -88,13 +90,13 @@ public class TestListKeysWithFSO {
     cluster = MiniOzoneCluster.newBuilder(conf).setClusterId(clusterId)
         .setScmId(scmId).setOmId(omId).build();
     cluster.waitForClusterToBeReady();
+    client = cluster.getClient();
 
     // create a volume and a LEGACY bucket
     legacyOzoneBucket = TestDataUtil
-        .createVolumeAndBucket(cluster, BucketLayout.LEGACY);
+        .createVolumeAndBucket(client, BucketLayout.LEGACY);
     String volumeName = legacyOzoneBucket.getVolumeName();
 
-    OzoneClient client = cluster.getClient();
     OzoneVolume ozoneVolume = client.getObjectStore().getVolume(volumeName);
 
     // create buckets
@@ -125,6 +127,7 @@ public class TestListKeysWithFSO {
 
   @AfterClass
   public static void teardownClass() {
+    IOUtils.closeQuietly(client);
     if (cluster != null) {
       cluster.shutdown();
     }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestListStatus.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestListStatus.java
@@ -74,7 +74,7 @@ public class TestListStatus {
     cluster = MiniOzoneCluster.newBuilder(conf).setClusterId(clusterId)
         .setScmId(scmId).setOmId(omId).build();
     cluster.waitForClusterToBeReady();
-    client = cluster.getClient();
+    client = cluster.newClient();
 
     // create a volume and a LEGACY bucket
     fsoOzoneBucket = TestDataUtil

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestListStatus.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestListStatus.java
@@ -16,12 +16,14 @@
  */
 package org.apache.hadoop.ozone.om;
 
+import org.apache.hadoop.hdds.utils.IOUtils;
 import org.apache.hadoop.hdds.client.RatisReplicationConfig;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.ozone.MiniOzoneCluster;
 import org.apache.hadoop.ozone.TestDataUtil;
 import org.apache.hadoop.ozone.client.OzoneBucket;
+import org.apache.hadoop.ozone.client.OzoneClient;
 import org.apache.hadoop.ozone.client.io.OzoneOutputStream;
 import org.apache.hadoop.ozone.om.helpers.BucketLayout;
 import org.apache.hadoop.ozone.om.helpers.OzoneFileStatus;
@@ -50,6 +52,7 @@ public class TestListStatus {
   private static String scmId;
   private static String omId;
   private static OzoneBucket fsoOzoneBucket;
+  private static OzoneClient client;
 
   @Rule
   public Timeout timeout = new Timeout(1200000);
@@ -71,10 +74,11 @@ public class TestListStatus {
     cluster = MiniOzoneCluster.newBuilder(conf).setClusterId(clusterId)
         .setScmId(scmId).setOmId(omId).build();
     cluster.waitForClusterToBeReady();
+    client = cluster.getClient();
 
     // create a volume and a LEGACY bucket
     fsoOzoneBucket = TestDataUtil
-        .createVolumeAndBucket(cluster, BucketLayout.FILE_SYSTEM_OPTIMIZED);
+        .createVolumeAndBucket(client, BucketLayout.FILE_SYSTEM_OPTIMIZED);
 
     // Set the number of keys to be processed during batch operate.
     conf.setInt(OZONE_FS_ITERATE_BATCH_SIZE, 5);
@@ -84,6 +88,7 @@ public class TestListStatus {
 
   @AfterClass
   public static void teardownClass() {
+    IOUtils.closeQuietly(client);
     if (cluster != null) {
       cluster.shutdown();
     }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOMBucketLayoutUpgrade.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOMBucketLayoutUpgrade.java
@@ -20,9 +20,11 @@ package org.apache.hadoop.ozone.om;
 
 import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import org.apache.hadoop.hdds.utils.IOUtils;
 import org.apache.hadoop.ozone.MiniOzoneCluster;
 import org.apache.hadoop.ozone.MiniOzoneHAClusterImpl;
 import org.apache.hadoop.ozone.client.ObjectStore;
+import org.apache.hadoop.ozone.client.OzoneClient;
 import org.apache.hadoop.ozone.client.OzoneClientFactory;
 import org.apache.hadoop.ozone.client.protocol.ClientProtocol;
 import org.apache.hadoop.ozone.om.exceptions.OMException;
@@ -81,6 +83,7 @@ public class TestOMBucketLayoutUpgrade {
 
   private static final Logger LOG =
       LoggerFactory.getLogger(TestOMBucketLayoutUpgrade.class);
+  private OzoneClient client;
 
   /**
    * Defines a "from" layout version to finalize from.
@@ -120,8 +123,8 @@ public class TestOMBucketLayoutUpgrade {
 
     cluster.waitForClusterToBeReady();
     ozoneManager = cluster.getOzoneManager();
-    ObjectStore objectStore = OzoneClientFactory.getRpcClient(omServiceId, conf)
-        .getObjectStore();
+    client = OzoneClientFactory.getRpcClient(omServiceId, conf);
+    ObjectStore objectStore = client.getObjectStore();
     clientProtocol = objectStore.getClientProxy();
     omClient = clientProtocol.getOzoneManagerClient();
 
@@ -139,6 +142,7 @@ public class TestOMBucketLayoutUpgrade {
    */
   @After
   public void shutdown() {
+    IOUtils.closeQuietly(client);
     if (cluster != null) {
       cluster.shutdown();
     }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOMEpochForNonRatis.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOMEpochForNonRatis.java
@@ -19,6 +19,8 @@ package org.apache.hadoop.ozone.om;
 
 import java.util.HashMap;
 import java.util.UUID;
+
+import org.apache.hadoop.hdds.utils.IOUtils;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.hadoop.hdds.client.ReplicationFactor;
 import org.apache.hadoop.hdds.client.ReplicationType;
@@ -57,6 +59,7 @@ public class TestOMEpochForNonRatis {
   private static String clusterId;
   private static String scmId;
   private static String omId;
+  private static OzoneClient client;
 
   @Rule
   public Timeout timeout = Timeout.seconds(240);
@@ -74,7 +77,7 @@ public class TestOMEpochForNonRatis {
         .setOmId(omId)
         .build();
     cluster.waitForClusterToBeReady();
-
+    client = cluster.getClient();
   }
 
   /**
@@ -82,6 +85,7 @@ public class TestOMEpochForNonRatis {
    */
   @AfterClass
   public static void shutdown() {
+    IOUtils.closeQuietly(client);
     if (cluster != null) {
       cluster.shutdown();
     }
@@ -98,7 +102,6 @@ public class TestOMEpochForNonRatis {
     String keyName = "key" + RandomStringUtils.randomNumeric(5);
 
     OzoneManager om = cluster.getOzoneManager();
-    OzoneClient client = cluster.getClient();
     ObjectStore objectStore = client.getObjectStore();
 
     UserGroupInformation ugi = UserGroupInformation.getCurrentUser();
@@ -160,7 +163,6 @@ public class TestOMEpochForNonRatis {
     // Create a volume and check the objectID has the epoch as
     // EPOCH_FOR_RATIS_NOT_ENABLED in the first 2 bits.
 
-    OzoneClient client = cluster.getClient();
     ObjectStore objectStore = client.getObjectStore();
 
     String volumeName = "volume" + RandomStringUtils.randomNumeric(5);

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOMEpochForNonRatis.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOMEpochForNonRatis.java
@@ -77,7 +77,7 @@ public class TestOMEpochForNonRatis {
         .setOmId(omId)
         .build();
     cluster.waitForClusterToBeReady();
-    client = cluster.getClient();
+    client = cluster.newClient();
   }
 
   /**

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOMRatisSnapshots.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOMRatisSnapshots.java
@@ -29,12 +29,14 @@ import java.util.concurrent.Future;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.conf.StorageUnit;
+import org.apache.hadoop.hdds.utils.IOUtils;
 import org.apache.hadoop.hdds.utils.db.DBCheckpoint;
 import org.apache.hadoop.ozone.MiniOzoneCluster;
 import org.apache.hadoop.ozone.MiniOzoneHAClusterImpl;
 import org.apache.hadoop.ozone.client.BucketArgs;
 import org.apache.hadoop.ozone.client.ObjectStore;
 import org.apache.hadoop.ozone.client.OzoneBucket;
+import org.apache.hadoop.ozone.client.OzoneClient;
 import org.apache.hadoop.ozone.client.OzoneClientFactory;
 import org.apache.hadoop.ozone.client.OzoneKeyDetails;
 import org.apache.hadoop.ozone.client.OzoneVolume;
@@ -84,6 +86,7 @@ public class TestOMRatisSnapshots {
   // buckets.
   private static final BucketLayout TEST_BUCKET_LAYOUT =
       BucketLayout.OBJECT_STORE;
+  private OzoneClient client;
 
   /**
    * Create a MiniOzoneCluster for testing. The cluster initially has one
@@ -114,8 +117,8 @@ public class TestOMRatisSnapshots {
         .setNumOfActiveOMs(2)
         .build();
     cluster.waitForClusterToBeReady();
-    objectStore = OzoneClientFactory.getRpcClient(omServiceId, conf)
-        .getObjectStore();
+    client = OzoneClientFactory.getRpcClient(omServiceId, conf);
+    objectStore = client.getObjectStore();
 
     volumeName = "volume" + RandomStringUtils.randomNumeric(5);
     bucketName = "bucket" + RandomStringUtils.randomNumeric(5);
@@ -138,6 +141,7 @@ public class TestOMRatisSnapshots {
    */
   @AfterEach
   public void shutdown() {
+    IOUtils.closeQuietly(client);
     if (cluster != null) {
       cluster.shutdown();
     }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOMStartupWithBucketLayout.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOMStartupWithBucketLayout.java
@@ -16,10 +16,12 @@
  */
 package org.apache.hadoop.ozone.om;
 
+import org.apache.hadoop.hdds.utils.IOUtils;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.ozone.MiniOzoneCluster;
 import org.apache.hadoop.ozone.TestDataUtil;
 import org.apache.hadoop.ozone.client.OzoneBucket;
+import org.apache.hadoop.ozone.client.OzoneClient;
 import org.apache.hadoop.ozone.om.helpers.BucketLayout;
 import org.junit.Assert;
 import org.junit.Rule;
@@ -40,6 +42,7 @@ public class TestOMStartupWithBucketLayout {
   public Timeout timeout = Timeout.seconds(300);
 
   private static MiniOzoneCluster cluster;
+  private static OzoneClient client;
 
   public static void startCluster(OzoneConfiguration conf)
       throws Exception {
@@ -49,6 +52,7 @@ public class TestOMStartupWithBucketLayout {
     cluster = MiniOzoneCluster.newBuilder(conf).setClusterId(clusterId)
         .setScmId(scmId).setOmId(omId).withoutDatanodes().build();
     cluster.waitForClusterToBeReady();
+    client = cluster.getClient();
   }
 
   public static void restartCluster()
@@ -59,6 +63,7 @@ public class TestOMStartupWithBucketLayout {
   }
 
   public static void teardown() {
+    IOUtils.closeQuietly(client);
     if (cluster != null) {
       cluster.shutdown();
     }
@@ -74,19 +79,19 @@ public class TestOMStartupWithBucketLayout {
       startCluster(conf);
 
       // 2. create bucket with FSO bucket layout and verify
-      OzoneBucket bucket1 = TestDataUtil.createVolumeAndBucket(cluster,
+      OzoneBucket bucket1 = TestDataUtil.createVolumeAndBucket(client,
           BucketLayout.FILE_SYSTEM_OPTIMIZED);
       verifyBucketLayout(bucket1, BucketLayout.FILE_SYSTEM_OPTIMIZED);
 
       // 3. verify OM default behavior with empty
       restartCluster();
-      OzoneBucket bucket2 = TestDataUtil.createVolumeAndBucket(cluster,
+      OzoneBucket bucket2 = TestDataUtil.createVolumeAndBucket(client,
           null);
       verifyBucketLayout(bucket2, BucketLayout.FILE_SYSTEM_OPTIMIZED);
 
       // 4. create bucket with OBS bucket layout and verify
       restartCluster();
-      OzoneBucket bucket3 = TestDataUtil.createVolumeAndBucket(cluster,
+      OzoneBucket bucket3 = TestDataUtil.createVolumeAndBucket(client,
           BucketLayout.OBJECT_STORE);
       verifyBucketLayout(bucket3, BucketLayout.OBJECT_STORE);
 
@@ -118,19 +123,19 @@ public class TestOMStartupWithBucketLayout {
       startCluster(conf);
 
       // 2. create bucket with FSO bucket layout and verify
-      OzoneBucket bucket1 = TestDataUtil.createVolumeAndBucket(cluster,
+      OzoneBucket bucket1 = TestDataUtil.createVolumeAndBucket(client,
           BucketLayout.FILE_SYSTEM_OPTIMIZED);
       verifyBucketLayout(bucket1, BucketLayout.FILE_SYSTEM_OPTIMIZED);
 
       // 3. verify OM default behavior with empty
       restartCluster();
-      OzoneBucket bucket2 = TestDataUtil.createVolumeAndBucket(cluster,
+      OzoneBucket bucket2 = TestDataUtil.createVolumeAndBucket(client,
           null);
       verifyBucketLayout(bucket2, BucketLayout.OBJECT_STORE);
 
       // 4. create bucket with OBS bucket layout and verify
       restartCluster();
-      OzoneBucket bucket3 = TestDataUtil.createVolumeAndBucket(cluster,
+      OzoneBucket bucket3 = TestDataUtil.createVolumeAndBucket(client,
           BucketLayout.OBJECT_STORE);
       verifyBucketLayout(bucket3, BucketLayout.OBJECT_STORE);
 

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOMStartupWithBucketLayout.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOMStartupWithBucketLayout.java
@@ -52,7 +52,7 @@ public class TestOMStartupWithBucketLayout {
     cluster = MiniOzoneCluster.newBuilder(conf).setClusterId(clusterId)
         .setScmId(scmId).setOmId(omId).withoutDatanodes().build();
     cluster.waitForClusterToBeReady();
-    client = cluster.getClient();
+    client = cluster.newClient();
   }
 
   public static void restartCluster()

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOMUpgradeFinalization.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOMUpgradeFinalization.java
@@ -35,9 +35,11 @@ import java.util.UUID;
 import java.util.concurrent.TimeoutException;
 
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import org.apache.hadoop.hdds.utils.IOUtils;
 import org.apache.hadoop.ozone.MiniOzoneCluster;
 import org.apache.hadoop.ozone.MiniOzoneHAClusterImpl;
 import org.apache.hadoop.ozone.client.ObjectStore;
+import org.apache.hadoop.ozone.client.OzoneClient;
 import org.apache.hadoop.ozone.client.OzoneClientFactory;
 import org.apache.hadoop.ozone.client.protocol.ClientProtocol;
 import org.apache.hadoop.ozone.om.protocol.OzoneManagerProtocol;
@@ -70,6 +72,7 @@ public class TestOMUpgradeFinalization {
   private OzoneManager ozoneManager;
   private ClientProtocol clientProtocol;
   private int fromLayoutVersion;
+  private OzoneClient client;
 
   /**
    * Defines a "from" layout version to finalize from.
@@ -110,8 +113,8 @@ public class TestOMUpgradeFinalization {
 
     cluster.waitForClusterToBeReady();
     ozoneManager = cluster.getOzoneManager();
-    ObjectStore objectStore = OzoneClientFactory.getRpcClient(omServiceId, conf)
-        .getObjectStore();
+    client = OzoneClientFactory.getRpcClient(omServiceId, conf);
+    ObjectStore objectStore = client.getObjectStore();
     clientProtocol = objectStore.getClientProxy();
   }
 
@@ -120,6 +123,7 @@ public class TestOMUpgradeFinalization {
    */
   @After
   public void shutdown() {
+    IOUtils.closeQuietly(client);
     if (cluster != null) {
       cluster.shutdown();
     }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestObjectStore.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestObjectStore.java
@@ -65,7 +65,7 @@ public class TestObjectStore {
     cluster = MiniOzoneCluster.newBuilder(conf).setClusterId(clusterId)
         .setScmId(scmId).setOmId(omId).build();
     cluster.waitForClusterToBeReady();
-    client = cluster.getClient();
+    client = cluster.newClient();
   }
 
   /**

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestObjectStore.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestObjectStore.java
@@ -16,6 +16,7 @@
  */
 package org.apache.hadoop.ozone.om;
 
+import org.apache.hadoop.hdds.utils.IOUtils;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.ozone.MiniOzoneCluster;
 import org.apache.hadoop.ozone.client.BucketArgs;
@@ -44,6 +45,7 @@ public class TestObjectStore {
   private static String clusterId;
   private static String scmId;
   private static String omId;
+  private static OzoneClient client;
 
   @Rule
   public Timeout timeout = new Timeout(1200000);
@@ -63,6 +65,7 @@ public class TestObjectStore {
     cluster = MiniOzoneCluster.newBuilder(conf).setClusterId(clusterId)
         .setScmId(scmId).setOmId(omId).build();
     cluster.waitForClusterToBeReady();
+    client = cluster.getClient();
   }
 
   /**
@@ -70,6 +73,7 @@ public class TestObjectStore {
    */
   @AfterClass
   public static void shutdown() {
+    IOUtils.closeQuietly(client);
     if (cluster != null) {
       cluster.shutdown();
     }
@@ -79,7 +83,6 @@ public class TestObjectStore {
   public void testCreateBucketWithBucketLayout() throws Exception {
     String sampleVolumeName = UUID.randomUUID().toString();
     String sampleBucketName = UUID.randomUUID().toString();
-    OzoneClient client = cluster.getClient();
     ObjectStore store = client.getObjectStore();
     store.createVolume(sampleVolumeName);
     OzoneVolume volume = store.getVolume(sampleVolumeName);
@@ -138,7 +141,6 @@ public class TestObjectStore {
     // Chained link bucket
     String linkBucket3Name = UUID.randomUUID().toString();
 
-    OzoneClient client = cluster.getClient();
     ObjectStore store = client.getObjectStore();
 
     // Create volume
@@ -178,7 +180,6 @@ public class TestObjectStore {
     // Does not exist
     String sourceBucketName = UUID.randomUUID().toString();
 
-    OzoneClient client = cluster.getClient();
     ObjectStore store = client.getObjectStore();
 
     // Create volume
@@ -205,7 +206,6 @@ public class TestObjectStore {
   public void testLoopInLinkBuckets() throws Exception {
     String volumeName = UUID.randomUUID().toString();
 
-    OzoneClient client = cluster.getClient();
     ObjectStore store = client.getObjectStore();
 
     // Create volume

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestObjectStoreWithFSO.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestObjectStoreWithFSO.java
@@ -608,7 +608,7 @@ public class TestObjectStoreWithFSO {
     FSDataInputStream fsDataInputStream = o3fs.open(new Path(key));
     read = new byte[length];
     fsDataInputStream.read(read, 0, length);
-    ozoneInputStream.close();
+    fsDataInputStream.close();
 
     Assert.assertEquals(inputString, new String(read, StandardCharsets.UTF_8));
   }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestObjectStoreWithFSO.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestObjectStoreWithFSO.java
@@ -111,7 +111,7 @@ public class TestObjectStoreWithFSO {
     cluster = MiniOzoneCluster.newBuilder(conf).setClusterId(clusterId)
         .setScmId(scmId).setOmId(omId).build();
     cluster.waitForClusterToBeReady();
-    client = cluster.getClient();
+    client = cluster.newClient();
     // create a volume and a bucket to be used by OzoneFileSystem
     OzoneBucket bucket = TestDataUtil
         .createVolumeAndBucket(client, BucketLayout.FILE_SYSTEM_OPTIMIZED);

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestObjectStoreWithFSO.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestObjectStoreWithFSO.java
@@ -16,6 +16,7 @@
  */
 package org.apache.hadoop.ozone.om;
 
+import org.apache.hadoop.hdds.utils.IOUtils;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.hadoop.fs.ozone.OzoneFileSystem;
 import org.apache.hadoop.fs.CommonConfigurationKeysPublic;
@@ -88,6 +89,7 @@ public class TestObjectStoreWithFSO {
   private static String volumeName;
   private static String bucketName;
   private static FileSystem fs;
+  private static OzoneClient client;
 
   @Rule
   public Timeout timeout = new Timeout(1200000);
@@ -109,9 +111,10 @@ public class TestObjectStoreWithFSO {
     cluster = MiniOzoneCluster.newBuilder(conf).setClusterId(clusterId)
         .setScmId(scmId).setOmId(omId).build();
     cluster.waitForClusterToBeReady();
+    client = cluster.getClient();
     // create a volume and a bucket to be used by OzoneFileSystem
     OzoneBucket bucket = TestDataUtil
-        .createVolumeAndBucket(cluster, BucketLayout.FILE_SYSTEM_OPTIMIZED);
+        .createVolumeAndBucket(client, BucketLayout.FILE_SYSTEM_OPTIMIZED);
     volumeName = bucket.getVolumeName();
     bucketName = bucket.getName();
 
@@ -158,8 +161,6 @@ public class TestObjectStoreWithFSO {
     String parent = "a/b/c/";
     String file = "key" + RandomStringUtils.randomNumeric(5);
     String key = parent + file;
-
-    OzoneClient client = cluster.getClient();
 
     ObjectStore objectStore = client.getObjectStore();
     OzoneVolume ozoneVolume = objectStore.getVolume(volumeName);
@@ -221,15 +222,13 @@ public class TestObjectStoreWithFSO {
   public void testDeleteBucketWithKeys() throws Exception {
     // Create temporary volume and bucket for this test.
     OzoneBucket testBucket = TestDataUtil
-        .createVolumeAndBucket(cluster, BucketLayout.FILE_SYSTEM_OPTIMIZED);
+        .createVolumeAndBucket(client, BucketLayout.FILE_SYSTEM_OPTIMIZED);
     String testVolumeName = testBucket.getVolumeName();
     String testBucketName = testBucket.getName();
 
     String parent = "a/b/c/";
     String file = "key" + RandomStringUtils.randomNumeric(5);
     String key = parent + file;
-
-    OzoneClient client = cluster.getClient();
 
     ObjectStore objectStore = client.getObjectStore();
     OzoneVolume ozoneVolume = objectStore.getVolume(testVolumeName);
@@ -289,7 +288,7 @@ public class TestObjectStoreWithFSO {
         .isBucketEmpty(testVolumeName, testBucketName));
     ozoneVolume.deleteBucket(testBucketName);
     // Cleanup the Volume.
-    cluster.getClient().getObjectStore().deleteVolume(testVolumeName);
+    client.getObjectStore().deleteVolume(testVolumeName);
   }
 
   @Test
@@ -297,8 +296,6 @@ public class TestObjectStoreWithFSO {
     String parent = "a/b/c/";
     String fileName = "key" + RandomStringUtils.randomNumeric(5);
     String key = parent + fileName;
-
-    OzoneClient client = cluster.getClient();
 
     ObjectStore objectStore = client.getObjectStore();
     OzoneVolume ozoneVolume = objectStore.getVolume(volumeName);
@@ -394,8 +391,6 @@ public class TestObjectStoreWithFSO {
    */
   @Test
   public void testListKeysAtDifferentLevels() throws Exception {
-    OzoneClient client = cluster.getClient();
-
     ObjectStore objectStore = client.getObjectStore();
     OzoneVolume ozoneVolume = objectStore.getVolume(volumeName);
     Assert.assertTrue(ozoneVolume.getName().equals(volumeName));
@@ -508,8 +503,6 @@ public class TestObjectStoreWithFSO {
 
   @Test
   public void testListKeysWithNotNormalizedPath() throws Exception {
-    OzoneClient client = cluster.getClient();
-
     ObjectStore objectStore = client.getObjectStore();
     OzoneVolume ozoneVolume = objectStore.getVolume(volumeName);
     Assert.assertTrue(ozoneVolume.getName().equals(volumeName));
@@ -624,7 +617,6 @@ public class TestObjectStoreWithFSO {
   public void testRenameKey() throws IOException {
     String fromKeyName = UUID.randomUUID().toString();
     String value = "sample value";
-    OzoneClient client = cluster.getClient();
 
     ObjectStore objectStore = client.getObjectStore();
     OzoneVolume volume = objectStore.getVolume(volumeName);
@@ -665,7 +657,6 @@ public class TestObjectStoreWithFSO {
     String newKeyName2 = "dir1/key2";
 
     String value = "sample value";
-    OzoneClient client = cluster.getClient();
     ObjectStore objectStore = client.getObjectStore();
     OzoneVolume volume = objectStore.getVolume(volumeName);
     OzoneBucket bucket = volume.getBucket(bucketName);
@@ -690,7 +681,6 @@ public class TestObjectStoreWithFSO {
     String keyName2 = "dir1/dir2/file2";
 
     String value = "sample value";
-    OzoneClient client = cluster.getClient();
     ObjectStore objectStore = client.getObjectStore();
     OzoneVolume volume = objectStore.getVolume(volumeName);
     OzoneBucket bucket = volume.getBucket(bucketName);
@@ -709,7 +699,6 @@ public class TestObjectStoreWithFSO {
   public void testCreateBucketWithBucketLayout() throws Exception {
     String sampleVolumeName = UUID.randomUUID().toString();
     String sampleBucketName = UUID.randomUUID().toString();
-    OzoneClient client = cluster.getClient();
     ObjectStore store = client.getObjectStore();
     store.createVolume(sampleVolumeName);
     OzoneVolume volume = store.getVolume(sampleVolumeName);
@@ -864,6 +853,7 @@ public class TestObjectStoreWithFSO {
    */
   @AfterClass
   public static void shutdown() {
+    IOUtils.closeQuietly(client);
     if (cluster != null) {
       cluster.shutdown();
     }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestObjectStoreWithLegacyFS.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestObjectStoreWithLegacyFS.java
@@ -18,6 +18,7 @@
 
 package org.apache.hadoop.ozone.om;
 
+import org.apache.hadoop.hdds.utils.IOUtils;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.commons.lang3.RandomUtils;
 import org.apache.hadoop.hdds.client.RatisReplicationConfig;
@@ -31,6 +32,7 @@ import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.hadoop.ozone.TestDataUtil;
 import org.apache.hadoop.ozone.client.BucketArgs;
 import org.apache.hadoop.ozone.client.OzoneBucket;
+import org.apache.hadoop.ozone.client.OzoneClient;
 import org.apache.hadoop.ozone.client.OzoneVolume;
 import org.apache.hadoop.ozone.client.io.OzoneOutputStream;
 import org.apache.hadoop.ozone.om.exceptions.OMException;
@@ -66,6 +68,7 @@ public class TestObjectStoreWithLegacyFS {
   public Timeout timeout = Timeout.seconds(200);
 
   private static MiniOzoneCluster cluster = null;
+  private static OzoneClient client;
 
   private String volumeName;
 
@@ -87,6 +90,7 @@ public class TestObjectStoreWithLegacyFS {
         .setNumDatanodes(3)
         .build();
     cluster.waitForClusterToBeReady();
+    client = cluster.getClient();
   }
 
   /**
@@ -94,6 +98,7 @@ public class TestObjectStoreWithLegacyFS {
    */
   @AfterClass
   public static void shutdown() {
+    IOUtils.closeQuietly(client);
     if (cluster != null) {
       cluster.shutdown();
     }
@@ -105,10 +110,9 @@ public class TestObjectStoreWithLegacyFS {
     bucketName = RandomStringUtils.randomAlphabetic(10).toLowerCase();
 
     // create a volume and a bucket to be used by OzoneFileSystem
-    TestDataUtil.createVolumeAndBucket(cluster, volumeName, bucketName,
+    TestDataUtil.createVolumeAndBucket(client, volumeName, bucketName,
         BucketLayout.OBJECT_STORE);
-    volume =
-        cluster.getRpcClient().getObjectStore().getVolume(volumeName);
+    volume = client.getObjectStore().getVolume(volumeName);
   }
 
   /**

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestObjectStoreWithLegacyFS.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestObjectStoreWithLegacyFS.java
@@ -90,7 +90,7 @@ public class TestObjectStoreWithLegacyFS {
         .setNumDatanodes(3)
         .build();
     cluster.waitForClusterToBeReady();
-    client = cluster.getClient();
+    client = cluster.newClient();
   }
 
   /**

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOmAcls.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOmAcls.java
@@ -16,6 +16,7 @@
  */
 package org.apache.hadoop.ozone.om;
 
+import org.apache.hadoop.hdds.utils.IOUtils;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.ozone.MiniOzoneCluster;
 import org.apache.hadoop.ozone.TestDataUtil;
@@ -23,6 +24,7 @@ import org.apache.hadoop.ozone.audit.AuditEventStatus;
 import org.apache.hadoop.ozone.audit.OMAction;
 import org.apache.hadoop.ozone.client.ObjectStore;
 import org.apache.hadoop.ozone.client.OzoneBucket;
+import org.apache.hadoop.ozone.client.OzoneClient;
 import org.apache.hadoop.ozone.om.exceptions.OMException;
 import org.apache.hadoop.ozone.om.exceptions.OMException.ResultCodes;
 import org.apache.hadoop.ozone.security.acl.IAccessAuthorizer;
@@ -67,6 +69,7 @@ public class TestOmAcls {
   private static boolean keyAclAllow = true;
   private static boolean prefixAclAllow = true;
   private static MiniOzoneCluster cluster = null;
+  private static OzoneClient client;
   private static GenericTestUtils.LogCapturer logCapturer;
 
   static {
@@ -94,12 +97,14 @@ public class TestOmAcls {
         .setOmId(omId)
         .build();
     cluster.waitForClusterToBeReady();
+    client = cluster.getClient();
     logCapturer =
         GenericTestUtils.LogCapturer.captureLogs(OzoneManager.getLogger());
   }
 
   @AfterClass
   public static void shutdown() {
+    IOUtils.closeQuietly(client);
     if (cluster != null) {
       cluster.shutdown();
     }
@@ -122,7 +127,7 @@ public class TestOmAcls {
     TestOmAcls.volumeAclAllow = false;
 
     OMException exception = assertThrows(OMException.class,
-            () -> TestDataUtil.createVolumeAndBucket(cluster));
+            () -> TestDataUtil.createVolumeAndBucket(client));
     assertEquals(ResultCodes.PERMISSION_DENIED, exception.getResult());
 
     assertTrue(logCapturer.getOutput()
@@ -132,9 +137,9 @@ public class TestOmAcls {
 
   @Test
   public void testReadVolumePermissionDenied() throws Exception {
-    OzoneBucket bucket = TestDataUtil.createVolumeAndBucket(cluster);
+    OzoneBucket bucket = TestDataUtil.createVolumeAndBucket(client);
     TestOmAcls.volumeAclAllow = false;
-    ObjectStore objectStore = cluster.getClient().getObjectStore();
+    ObjectStore objectStore = client.getObjectStore();
     OMException exception = assertThrows(OMException.class, () ->
             objectStore.getVolume(bucket.getVolumeName()));
     assertEquals(ResultCodes.PERMISSION_DENIED, exception.getResult());
@@ -149,7 +154,7 @@ public class TestOmAcls {
     TestOmAcls.bucketAclAllow = false;
 
     OMException exception = assertThrows(OMException.class,
-            () -> TestDataUtil.createVolumeAndBucket(cluster));
+            () -> TestDataUtil.createVolumeAndBucket(client));
     assertEquals(ResultCodes.PERMISSION_DENIED, exception.getResult());
 
     assertTrue(logCapturer.getOutput()
@@ -159,9 +164,9 @@ public class TestOmAcls {
 
   @Test
   public void testReadBucketPermissionDenied() throws Exception {
-    OzoneBucket bucket = TestDataUtil.createVolumeAndBucket(cluster);
+    OzoneBucket bucket = TestDataUtil.createVolumeAndBucket(client);
     TestOmAcls.bucketAclAllow = false;
-    ObjectStore objectStore = cluster.getClient().getObjectStore();
+    ObjectStore objectStore = client.getObjectStore();
     OMException exception = assertThrows(OMException.class,
             () -> objectStore.getVolume(
                     bucket.getVolumeName()).getBucket(bucket.getName())
@@ -177,7 +182,7 @@ public class TestOmAcls {
   public void testCreateKeyPermissionDenied() throws Exception {
     TestOmAcls.keyAclAllow = false;
 
-    OzoneBucket bucket = TestDataUtil.createVolumeAndBucket(cluster);
+    OzoneBucket bucket = TestDataUtil.createVolumeAndBucket(client);
 
     OMException exception = assertThrows(OMException.class,
             () -> TestDataUtil.createKey(bucket, "testKey", "testcontent"));
@@ -188,7 +193,7 @@ public class TestOmAcls {
 
   @Test
   public void testReadKeyPermissionDenied() throws Exception {
-    OzoneBucket bucket = TestDataUtil.createVolumeAndBucket(cluster);
+    OzoneBucket bucket = TestDataUtil.createVolumeAndBucket(client);
     TestDataUtil.createKey(bucket, "testKey", "testcontent");
 
     TestOmAcls.keyAclAllow = false;
@@ -203,7 +208,7 @@ public class TestOmAcls {
 
   @Test
   public void testSetACLPermissionDenied() throws Exception {
-    OzoneBucket bucket = TestDataUtil.createVolumeAndBucket(cluster);
+    OzoneBucket bucket = TestDataUtil.createVolumeAndBucket(client);
 
     TestOmAcls.bucketAclAllow = false;
 

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOmAcls.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOmAcls.java
@@ -97,7 +97,7 @@ public class TestOmAcls {
         .setOmId(omId)
         .build();
     cluster.waitForClusterToBeReady();
-    client = cluster.getClient();
+    client = cluster.newClient();
     logCapturer =
         GenericTestUtils.LogCapturer.captureLogs(OzoneManager.getLogger());
   }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOmBlockVersioning.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOmBlockVersioning.java
@@ -20,12 +20,14 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.apache.hadoop.hdds.utils.IOUtils;
 import org.apache.hadoop.hdds.client.StandaloneReplicationConfig;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.scm.container.common.helpers.ExcludeList;
 import org.apache.hadoop.ozone.MiniOzoneCluster;
 import org.apache.hadoop.ozone.TestDataUtil;
 import org.apache.hadoop.ozone.client.OzoneBucket;
+import org.apache.hadoop.ozone.client.OzoneClient;
 import org.apache.hadoop.ozone.om.helpers.OmKeyArgs;
 import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
 import org.apache.hadoop.ozone.om.helpers.OmKeyLocationInfo;
@@ -56,6 +58,7 @@ public class TestOmBlockVersioning {
   @Rule
   public Timeout timeout = Timeout.seconds(300);
   private static MiniOzoneCluster cluster = null;
+  private static OzoneClient client;
   private static OzoneConfiguration conf;
   private static OzoneManager ozoneManager;
   private static OzoneManagerProtocol writeClient;
@@ -75,8 +78,9 @@ public class TestOmBlockVersioning {
     conf = new OzoneConfiguration();
     cluster = MiniOzoneCluster.newBuilder(conf).build();
     cluster.waitForClusterToBeReady();
+    client = cluster.getClient();
     ozoneManager = cluster.getOzoneManager();
-    writeClient = cluster.getRpcClient().getObjectStore()
+    writeClient = client.getObjectStore()
         .getClientProxy().getOzoneManagerClient();
   }
 
@@ -85,6 +89,7 @@ public class TestOmBlockVersioning {
    */
   @AfterClass
   public static void shutdown() {
+    IOUtils.closeQuietly(client);
     if (cluster != null) {
       cluster.shutdown();
     }
@@ -97,7 +102,7 @@ public class TestOmBlockVersioning {
     String keyName = "key" + RandomStringUtils.randomNumeric(5);
 
     OzoneBucket bucket =
-        TestDataUtil.createVolumeAndBucket(cluster, volumeName, bucketName);
+        TestDataUtil.createVolumeAndBucket(client, volumeName, bucketName);
     // Versioning isn't supported currently, but just preserving old behaviour
     bucket.setVersioning(true);
 
@@ -178,7 +183,7 @@ public class TestOmBlockVersioning {
     String keyName = "key" + RandomStringUtils.randomNumeric(5);
 
     OzoneBucket bucket =
-        TestDataUtil.createVolumeAndBucket(cluster, volumeName, bucketName);
+        TestDataUtil.createVolumeAndBucket(client, volumeName, bucketName);
 
     OmKeyArgs omKeyArgs = new OmKeyArgs.Builder()
         .setVolumeName(volumeName)

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOmBlockVersioning.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOmBlockVersioning.java
@@ -78,7 +78,7 @@ public class TestOmBlockVersioning {
     conf = new OzoneConfiguration();
     cluster = MiniOzoneCluster.newBuilder(conf).build();
     cluster.waitForClusterToBeReady();
-    client = cluster.getClient();
+    client = cluster.newClient();
     ozoneManager = cluster.getOzoneManager();
     writeClient = client.getObjectStore()
         .getClientProxy().getOzoneManagerClient();

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOmMetrics.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOmMetrics.java
@@ -31,6 +31,7 @@ import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 
+import org.apache.hadoop.hdds.utils.IOUtils;
 import org.apache.hadoop.hdds.HddsConfigKeys;
 import org.apache.hadoop.hdds.client.BlockID;
 import org.apache.hadoop.hdds.client.ContainerBlockID;
@@ -48,6 +49,7 @@ import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.ozone.OzoneAcl;
 import org.apache.hadoop.ozone.TestDataUtil;
 import org.apache.hadoop.ozone.client.ObjectStore;
+import org.apache.hadoop.ozone.client.OzoneClient;
 import org.apache.hadoop.ozone.om.exceptions.OMException;
 import org.apache.hadoop.ozone.om.helpers.OmBucketArgs;
 import org.apache.hadoop.ozone.om.helpers.OmBucketInfo;
@@ -89,6 +91,7 @@ public class TestOmMetrics {
    */
   private final OMException exception =
       new OMException("dummyException", OMException.ResultCodes.TIMEOUT);
+  private OzoneClient client;
 
   /**
    * Create a MiniDFSCluster for testing.
@@ -105,7 +108,8 @@ public class TestOmMetrics {
     cluster = clusterBuilder.build();
     cluster.waitForClusterToBeReady();
     ozoneManager = cluster.getOzoneManager();
-    writeClient = cluster.getRpcClient().getObjectStore()
+    client = cluster.getClient();
+    writeClient = client.getObjectStore()
         .getClientProxy().getOzoneManagerClient();
   }
 
@@ -114,6 +118,7 @@ public class TestOmMetrics {
    */
   @After
   public void shutdown() {
+    IOUtils.closeQuietly(client);
     if (cluster != null) {
       cluster.shutdown();
     }
@@ -281,7 +286,7 @@ public class TestOmMetrics {
     KeyManager keyManager = (KeyManager) HddsWhiteboxTestUtils
         .getInternalState(ozoneManager, "keyManager");
     KeyManager mockKm = Mockito.spy(keyManager);
-    TestDataUtil.createVolumeAndBucket(cluster, volumeName, bucketName);
+    TestDataUtil.createVolumeAndBucket(client, volumeName, bucketName);
     OmKeyArgs keyArgs = createKeyArgs(volumeName, bucketName,
         RatisReplicationConfig.getInstance(HddsProtos.ReplicationFactor.THREE));
     doKeyOps(keyArgs);
@@ -474,7 +479,7 @@ public class TestOmMetrics {
     startCluster();
     try {
       // Create a volume.
-      cluster.getClient().getObjectStore().createVolume("volumeacl");
+      client.getObjectStore().createVolume("volumeacl");
 
       OzoneObj volObj = new OzoneObjInfo.Builder().setVolumeName("volumeacl")
           .setResType(VOLUME).setStoreType(OZONE).build();
@@ -502,7 +507,7 @@ public class TestOmMetrics {
       assertCounter("NumRemoveAcl", 1L, omMetrics);
 
     } finally {
-      cluster.getClient().getObjectStore().deleteVolume("volumeacl");
+      client.getObjectStore().deleteVolume("volumeacl");
     }
   }
 
@@ -513,7 +518,7 @@ public class TestOmMetrics {
     conf.setBoolean(HddsConfigKeys.HDDS_SCM_SAFEMODE_ENABLED, true);
     startCluster();
 
-    ObjectStore objectStore = cluster.getClient().getObjectStore();
+    ObjectStore objectStore = client.getObjectStore();
     // Create a volume.
     objectStore.createVolume("volumeacl");
     // Create a bucket.

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOmMetrics.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOmMetrics.java
@@ -108,7 +108,7 @@ public class TestOmMetrics {
     cluster = clusterBuilder.build();
     cluster.waitForClusterToBeReady();
     ozoneManager = cluster.getOzoneManager();
-    client = cluster.getClient();
+    client = cluster.newClient();
     writeClient = client.getObjectStore()
         .getClientProxy().getOzoneManagerClient();
   }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOmSnapshot.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOmSnapshot.java
@@ -166,7 +166,7 @@ public class TestOmSnapshot {
         .setNumOfOzoneManagers(3)
         .build();
     cluster.waitForClusterToBeReady();
-    client = cluster.getClient();
+    client = cluster.newClient();
     // create a volume and a bucket to be used by OzoneFileSystem
     ozoneBucket = TestDataUtil
         .createVolumeAndBucket(client, bucketLayout);

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOmSnapshot.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOmSnapshot.java
@@ -18,6 +18,7 @@
 package org.apache.hadoop.ozone.om;
 import java.util.List;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import org.apache.hadoop.hdds.utils.IOUtils;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.hadoop.hdds.client.StandaloneReplicationConfig;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
@@ -92,6 +93,7 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 @SuppressFBWarnings("RV_RETURN_VALUE_IGNORED_NO_SIDE_EFFECT")
 public class TestOmSnapshot {
   private static MiniOzoneCluster cluster = null;
+  private static OzoneClient client;
   private static String volumeName;
   private static String bucketName;
   private static OzoneManagerProtocol writeClient;
@@ -164,9 +166,10 @@ public class TestOmSnapshot {
         .setNumOfOzoneManagers(3)
         .build();
     cluster.waitForClusterToBeReady();
+    client = cluster.getClient();
     // create a volume and a bucket to be used by OzoneFileSystem
     ozoneBucket = TestDataUtil
-        .createVolumeAndBucket(cluster, bucketLayout);
+        .createVolumeAndBucket(client, bucketLayout);
     volumeName = ozoneBucket.getVolumeName();
     bucketName = ozoneBucket.getName();
 
@@ -176,7 +179,6 @@ public class TestOmSnapshot {
     OzoneConfiguration leaderConfig = leaderOzoneManager.getConfiguration();
     cluster.setConf(leaderConfig);
 
-    OzoneClient client = cluster.getClient();
     store = client.getObjectStore();
     writeClient = store.getClientProxy().getOzoneManagerClient();
 
@@ -190,6 +192,7 @@ public class TestOmSnapshot {
 
   @AfterClass
   public static void tearDown() throws Exception {
+    IOUtils.closeQuietly(client);
     if (cluster != null) {
       cluster.shutdown();
     }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOmSnapshotFileSystem.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOmSnapshotFileSystem.java
@@ -358,7 +358,7 @@ public class TestOmSnapshotFileSystem {
     FSDataInputStream fsDataInputStream = o3fsNew.open(new Path(key));
     read = new byte[length];
     fsDataInputStream.read(read, 0, length);
-    ozoneInputStream.close();
+    fsDataInputStream.close();
 
     Assert.assertEquals(inputString, new String(read, StandardCharsets.UTF_8));
   }
@@ -501,8 +501,7 @@ public class TestOmSnapshotFileSystem {
     String snapshotKeyPrefix = createSnapshot();
     Path fileInSnapshot = new Path(snapshotKeyPrefix + parent + keyName);
 
-    try {
-      FSDataInputStream inputStream = fs.open(fileInSnapshot);
+    try (FSDataInputStream inputStream = fs.open(fileInSnapshot)) {
       ByteBuffer buffer = ByteBuffer.allocate(1024 * 1024);
       inputStream.read(buffer);
       byte[] readBytes = new byte[strBytes.length];

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOmSnapshotFileSystem.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOmSnapshotFileSystem.java
@@ -90,6 +90,8 @@ import static org.junit.Assert.assertTrue;
 @RunWith(Parameterized.class)
 public class TestOmSnapshotFileSystem {
   private static MiniOzoneCluster cluster = null;
+  private static OzoneClient client;
+  private static ObjectStore objectStore;
   private static OzoneConfiguration conf;
   private static String volumeName;
   private static String bucketName;
@@ -109,7 +111,6 @@ public class TestOmSnapshotFileSystem {
 
   @Rule
   public Timeout timeout = new Timeout(120, TimeUnit.SECONDS);
-  private OzoneClient client;
 
   @Parameterized.Parameters
   public static Collection<Object[]> data() {
@@ -141,7 +142,7 @@ public class TestOmSnapshotFileSystem {
   /**
    * Create a MiniDFSCluster for testing.
    */
-  private void init() throws Exception {
+  private static void init() throws Exception {
     conf = new OzoneConfiguration();
     String clusterId = UUID.randomUUID().toString();
     String scmId = UUID.randomUUID().toString();
@@ -170,7 +171,7 @@ public class TestOmSnapshotFileSystem {
     fs = FileSystem.get(conf);
     o3fs = (OzoneFileSystem) fs;
 
-    ObjectStore objectStore = client.getObjectStore();
+    objectStore = client.getObjectStore();
     writeClient = objectStore.getClientProxy().getOzoneManagerClient();
     ozoneManager = cluster.getOzoneManager();
     metaDir = OMStorage.getOmDbDir(conf);
@@ -191,7 +192,6 @@ public class TestOmSnapshotFileSystem {
   @Test
   // based on TestObjectStoreWithFSO:testListKeysAtDifferentLevels
   public void testListKeysAtDifferentLevels() throws Exception {
-    ObjectStore objectStore = client.getObjectStore();
     OzoneVolume ozoneVolume = objectStore.getVolume(volumeName);
     Assert.assertTrue(ozoneVolume.getName().equals(volumeName));
     OzoneBucket ozoneBucket = ozoneVolume.getBucket(bucketName);

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOmSnapshotFileSystem.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOmSnapshotFileSystem.java
@@ -154,7 +154,7 @@ public class TestOmSnapshotFileSystem {
     cluster = MiniOzoneCluster.newBuilder(conf).setClusterId(clusterId)
         .setScmId(scmId).setOmId(omId).build();
     cluster.waitForClusterToBeReady();
-    client = cluster.getClient();
+    client = cluster.newClient();
     // create a volume and a bucket to be used by OzoneFileSystem
     OzoneBucket bucket = TestDataUtil
         .createVolumeAndBucket(client, bucketLayout);

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerHA.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerHA.java
@@ -352,11 +352,11 @@ public abstract class TestOzoneManagerHA {
         ozoneKeyDetails.getVolumeName());
     Assert.assertEquals(data.length(), ozoneKeyDetails.getDataSize());
 
-    OzoneInputStream ozoneInputStream = ozoneBucket.readKey(keyName);
-
-    byte[] fileContent = new byte[data.getBytes(UTF_8).length];
-    ozoneInputStream.read(fileContent);
-    Assert.assertEquals(data, new String(fileContent, UTF_8));
+    try (OzoneInputStream ozoneInputStream = ozoneBucket.readKey(keyName)) {
+      byte[] fileContent = new byte[data.getBytes(UTF_8).length];
+      ozoneInputStream.read(fileContent);
+      Assert.assertEquals(data, new String(fileContent, UTF_8));
+    }
   }
 
   protected void createKeyTest(boolean checkSuccess) throws Exception {
@@ -394,11 +394,11 @@ public abstract class TestOzoneManagerHA {
       ozoneOutputStream.write(value.getBytes(UTF_8), 0, value.length());
       ozoneOutputStream.close();
 
-      OzoneInputStream ozoneInputStream = ozoneBucket.readKey(keyName);
-
-      byte[] fileContent = new byte[value.getBytes(UTF_8).length];
-      ozoneInputStream.read(fileContent);
-      Assert.assertEquals(value, new String(fileContent, UTF_8));
+      try (OzoneInputStream ozoneInputStream = ozoneBucket.readKey(keyName)) {
+        byte[] fileContent = new byte[value.getBytes(UTF_8).length];
+        ozoneInputStream.read(fileContent);
+        Assert.assertEquals(value, new String(fileContent, UTF_8));
+      }
 
     } catch (IOException e) {
       if (!checkSuccess) {

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerHA.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerHA.java
@@ -197,7 +197,7 @@ public abstract class TestOzoneManagerHA {
   @AfterEach
   public void resetCluster()
       throws IOException {
-    IOUtils.close(null, client);
+    IOUtils.closeQuietly(client);
     if (cluster != null) {
       cluster.restartOzoneManager();
     }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerHA.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerHA.java
@@ -20,12 +20,14 @@ import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.hadoop.hdds.client.ReplicationFactor;
 import org.apache.hadoop.hdds.client.ReplicationType;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import org.apache.hadoop.hdds.utils.IOUtils;
 import org.apache.hadoop.ipc.RemoteException;
 import org.apache.hadoop.ozone.MiniOzoneCluster;
 import org.apache.hadoop.ozone.MiniOzoneHAClusterImpl;
 import org.apache.hadoop.ozone.OzoneConfigKeys;
 import org.apache.hadoop.ozone.client.ObjectStore;
 import org.apache.hadoop.ozone.client.OzoneBucket;
+import org.apache.hadoop.ozone.client.OzoneClient;
 import org.apache.hadoop.ozone.client.OzoneKeyDetails;
 import org.apache.hadoop.ozone.client.OzoneVolume;
 import org.apache.hadoop.ozone.client.VolumeArgs;
@@ -82,6 +84,7 @@ public abstract class TestOzoneManagerHA {
   private static final int IPC_CLIENT_CONNECT_MAX_RETRIES = 4;
   private static final long SNAPSHOT_THRESHOLD = 50;
   private static final Duration RETRY_CACHE_DURATION = Duration.ofSeconds(30);
+  private static OzoneClient client;
 
 
   public MiniOzoneHAClusterImpl getCluster() {
@@ -90,6 +93,10 @@ public abstract class TestOzoneManagerHA {
 
   public ObjectStore getObjectStore() {
     return objectStore;
+  }
+
+  public static OzoneClient getClient() {
+    return client;
   }
 
   public OzoneConfiguration getConf() {
@@ -179,8 +186,8 @@ public abstract class TestOzoneManagerHA {
 
     cluster = (MiniOzoneHAClusterImpl) clusterBuilder.build();
     cluster.waitForClusterToBeReady();
-    objectStore = OzoneClientFactory.getRpcClient(omServiceId, conf)
-        .getObjectStore();
+    client = OzoneClientFactory.getRpcClient(omServiceId, conf);
+    objectStore = client.getObjectStore();
   }
 
 
@@ -190,6 +197,7 @@ public abstract class TestOzoneManagerHA {
   @AfterEach
   public void resetCluster()
       throws IOException {
+    IOUtils.close(null, client);
     if (cluster != null) {
       cluster.restartOzoneManager();
     }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerHAMetadataOnly.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerHAMetadataOnly.java
@@ -157,7 +157,7 @@ public class TestOzoneManagerHAMetadataOnly extends TestOzoneManagerHA {
    */
   @Test
   public void testOMProxyProviderInitialization() throws Exception {
-    OzoneClient rpcClient = getCluster().getRpcClient();
+    OzoneClient rpcClient = getClient();
 
     HadoopRpcOMFailoverProxyProvider omFailoverProxyProvider =
         OmFailoverProxyUtil.getFailoverProxyProvider(
@@ -352,8 +352,7 @@ public class TestOzoneManagerHAMetadataOnly extends TestOzoneManagerHA {
       OzoneManager ozoneManager = getCluster().getOzoneManager(i);
 
       // Get the ObjectStore and FailoverProxyProvider for OM at index i
-      final ObjectStore store = OzoneClientFactory.getRpcClient(
-          getOmServiceId(), getConf()).getObjectStore();
+      final ObjectStore store = getClient().getObjectStore();
       final HadoopRpcOMFailoverProxyProvider proxyProvider =
           OmFailoverProxyUtil.getFailoverProxyProvider(store.getClientProxy());
 

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerHAMetadataOnly.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerHAMetadataOnly.java
@@ -25,7 +25,6 @@ import org.apache.hadoop.ozone.client.ObjectStore;
 import org.apache.hadoop.ozone.client.OzoneBucket;
 import org.apache.hadoop.ozone.client.BucketArgs;
 import org.apache.hadoop.ozone.client.OzoneVolume;
-import org.apache.hadoop.ozone.client.OzoneClientFactory;
 import org.apache.hadoop.ozone.client.OzoneClient;
 import org.apache.hadoop.ozone.client.VolumeArgs;
 import org.apache.hadoop.ozone.om.exceptions.OMException;

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerHAWithData.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerHAWithData.java
@@ -390,11 +390,11 @@ public class TestOzoneManagerHAWithData extends TestOzoneManagerHA {
     Assertions.assertTrue(omMultipartUploadCompleteInfo.getHash() != null);
 
 
-    OzoneInputStream ozoneInputStream = ozoneBucket.readKey(keyName);
-
-    byte[] fileContent = new byte[value.getBytes(UTF_8).length];
-    ozoneInputStream.read(fileContent);
-    Assertions.assertEquals(value, new String(fileContent, UTF_8));
+    try (OzoneInputStream ozoneInputStream = ozoneBucket.readKey(keyName)) {
+      byte[] fileContent = new byte[value.getBytes(UTF_8).length];
+      ozoneInputStream.read(fileContent);
+      Assertions.assertEquals(value, new String(fileContent, UTF_8));
+    }
   }
 
   @Test

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerListVolumes.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerListVolumes.java
@@ -109,7 +109,7 @@ public class TestOzoneManagerListVolumes {
     cluster.waitForClusterToBeReady();
 
     // Create volumes with non-default owners and ACLs
-    try (OzoneClient client = cluster.getClient()) {
+    try (OzoneClient client = cluster.newClient()) {
       ObjectStore objectStore = client.getObjectStore();
 
       /* r = READ, w = WRITE, c = CREATE, d = DELETE
@@ -187,7 +187,7 @@ public class TestOzoneManagerListVolumes {
   private void checkUser(UserGroupInformation user,
       List<String> expectVol, boolean expectListAllSuccess,
                          boolean expectListByUserSuccess) throws IOException {
-    try (OzoneClient client = cluster.getClient()) {
+    try (OzoneClient client = cluster.newClient()) {
       checkUser(client, user,
           expectVol, expectListAllSuccess, expectListByUserSuccess);
     }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerListVolumes.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerListVolumes.java
@@ -28,6 +28,7 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.TimeoutException;
 
+import org.apache.hadoop.hdds.utils.IOUtils;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.ozone.MiniOzoneCluster;
 import org.apache.hadoop.ozone.OzoneAcl;
@@ -62,6 +63,7 @@ import org.junit.rules.Timeout;
 public class TestOzoneManagerListVolumes {
 
   private static MiniOzoneCluster cluster;
+  private static OzoneClient client;
 
   @Rule
   public Timeout timeout = Timeout.seconds(120);
@@ -107,9 +109,9 @@ public class TestOzoneManagerListVolumes {
         .setClusterId(clusterId).setScmId(scmId).setOmId(omId)
         .build();
     cluster.waitForClusterToBeReady();
+    client = cluster.getClient();
 
     // Create volumes with non-default owners and ACLs
-    OzoneClient client = cluster.getClient();
     ObjectStore objectStore = client.getObjectStore();
 
     /* r = READ, w = WRITE, c = CREATE, d = DELETE
@@ -129,6 +131,7 @@ public class TestOzoneManagerListVolumes {
 
   @AfterClass
   public static void shutdownClass() {
+    IOUtils.closeQuietly(client);
     if (cluster != null) {
       cluster.shutdown();
     }
@@ -186,7 +189,6 @@ public class TestOzoneManagerListVolumes {
       List<String> expectVol, boolean expectListAllSuccess,
                          boolean expectListByUserSuccess) throws IOException {
 
-    OzoneClient client = cluster.getClient();
     ObjectStore objectStore = client.getObjectStore();
 
     // `ozone sh volume list` shall return volumes with LIST permission of user.

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerRestart.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerRestart.java
@@ -23,6 +23,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
 
+import org.apache.hadoop.hdds.utils.IOUtils;
 import org.apache.hadoop.hdds.client.ReplicationFactor;
 import org.apache.hadoop.hdds.client.ReplicationType;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
@@ -65,6 +66,7 @@ public class TestOzoneManagerRestart {
   private static String clusterId;
   private static String scmId;
   private static String omId;
+  private static OzoneClient client;
 
   @Rule
   public Timeout timeout = Timeout.seconds(240);
@@ -94,7 +96,7 @@ public class TestOzoneManagerRestart {
         .setOmId(omId)
         .build();
     cluster.waitForClusterToBeReady();
-
+    client = cluster.getClient();
   }
 
   /**
@@ -102,6 +104,7 @@ public class TestOzoneManagerRestart {
    */
   @AfterClass
   public static void shutdown() {
+    IOUtils.closeQuietly(client);
     if (cluster != null) {
       cluster.shutdown();
     }
@@ -111,7 +114,6 @@ public class TestOzoneManagerRestart {
   public void testRestartOMWithVolumeOperation() throws Exception {
     String volumeName = "volume" + RandomStringUtils.randomNumeric(5);
 
-    OzoneClient client = cluster.getClient();
     ObjectStore objectStore = client.getObjectStore();
 
     objectStore.createVolume(volumeName);
@@ -141,8 +143,6 @@ public class TestOzoneManagerRestart {
   public void testRestartOMWithBucketOperation() throws Exception {
     String volumeName = "volume" + RandomStringUtils.randomNumeric(5);
     String bucketName = "bucket" + RandomStringUtils.randomNumeric(5);
-
-    OzoneClient client = cluster.getClient();
 
     ObjectStore objectStore = client.getObjectStore();
 
@@ -183,8 +183,6 @@ public class TestOzoneManagerRestart {
 
     String newKey1 = "key1new" + RandomStringUtils.randomNumeric(5);
     String newKey2 = "key2new" + RandomStringUtils.randomNumeric(5);
-
-    OzoneClient client = cluster.getClient();
 
     ObjectStore objectStore = client.getObjectStore();
 

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerRestart.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerRestart.java
@@ -96,7 +96,7 @@ public class TestOzoneManagerRestart {
         .setOmId(omId)
         .build();
     cluster.waitForClusterToBeReady();
-    client = cluster.getClient();
+    client = cluster.newClient();
   }
 
   /**

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestRecursiveAclWithFSO.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestRecursiveAclWithFSO.java
@@ -85,7 +85,7 @@ public class TestRecursiveAclWithFSO {
     List<String> keys = new ArrayList<>();
     // Create volumes with user1
 
-    OzoneClient client = cluster.getClient();
+    OzoneClient client = cluster.newClient();
     ObjectStore objectStore = client.getObjectStore();
 
     /* r = READ, w = WRITE, c = CREATE, d = DELETE
@@ -95,7 +95,7 @@ public class TestRecursiveAclWithFSO {
 
     // Login as user1, create directories and keys
     UserGroupInformation.setLoginUser(user1);
-    client = cluster.getClient();
+    client = cluster.newClient();
     objectStore = client.getObjectStore();
 
     OzoneVolume volume = objectStore.getVolume("volume1");
@@ -168,7 +168,7 @@ public class TestRecursiveAclWithFSO {
     List<OzoneAcl> aclList1;
 
     UserGroupInformation.setLoginUser(user2);
-    client = cluster.getClient();
+    client = cluster.newClient();
     objectStore = client.getObjectStore();
     volume = objectStore.getVolume("volume1");
     ozoneBucket = volume.getBucket("bucket1");

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestScmSafeMode.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestScmSafeMode.java
@@ -108,7 +108,7 @@ public class TestScmSafeMode {
     cluster = builder.build();
     cluster.startHddsDatanodes();
     cluster.waitForClusterToBeReady();
-    client = cluster.getClient();
+    client = cluster.newClient();
     om = cluster.getOzoneManager();
     storageContainerLocationClient = cluster
         .getStorageContainerLocationClient();

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestScmSafeMode.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestScmSafeMode.java
@@ -17,6 +17,7 @@
  */
 package org.apache.hadoop.ozone.om;
 
+import org.apache.hadoop.hdds.utils.IOUtils;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.hadoop.hdds.HddsConfigKeys;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
@@ -37,6 +38,7 @@ import org.apache.hadoop.ozone.MiniOzoneCluster;
 import org.apache.hadoop.ozone.TestStorageContainerManagerHelper;
 import org.apache.hadoop.ozone.client.ObjectStore;
 import org.apache.hadoop.ozone.client.OzoneBucket;
+import org.apache.hadoop.ozone.client.OzoneClient;
 import org.apache.hadoop.ozone.client.OzoneVolume;
 import org.apache.hadoop.ozone.common.statemachine.InvalidStateTransitionException;
 import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
@@ -75,6 +77,7 @@ public class TestScmSafeMode {
   private static final Logger LOG = LoggerFactory
       .getLogger(TestScmSafeMode.class);
   private MiniOzoneCluster cluster = null;
+  private OzoneClient client;
   private MiniOzoneCluster.Builder builder = null;
   private OzoneConfiguration conf;
   private OzoneManager om;
@@ -105,6 +108,7 @@ public class TestScmSafeMode {
     cluster = builder.build();
     cluster.startHddsDatanodes();
     cluster.waitForClusterToBeReady();
+    client = cluster.getClient();
     om = cluster.getOzoneManager();
     storageContainerLocationClient = cluster
         .getStorageContainerLocationClient();
@@ -115,6 +119,7 @@ public class TestScmSafeMode {
    */
   @After
   public void shutdown() {
+    IOUtils.closeQuietly(client);
     if (cluster != null) {
       try {
         cluster.shutdown();
@@ -138,7 +143,7 @@ public class TestScmSafeMode {
     String bucketName = "bucket" + RandomStringUtils.randomNumeric(5);
     String keyName = "key" + RandomStringUtils.randomNumeric(5);
 
-    ObjectStore store = cluster.getRpcClient().getObjectStore();
+    ObjectStore store = client.getObjectStore();
     store.createVolume(volumeName);
     OzoneVolume volume = store.getVolume(volumeName);
     volume.createBucket(bucketName);
@@ -163,7 +168,7 @@ public class TestScmSafeMode {
 
 
     final OzoneBucket bucket1 =
-        cluster.getRpcClient().getObjectStore().getVolume(volumeName)
+        client.getObjectStore().getVolume(volumeName)
             .getBucket(bucketName);
 
 // As cluster is restarted with out datanodes restart

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/multitenant/TestMultiTenantVolume.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/multitenant/TestMultiTenantVolume.java
@@ -18,6 +18,7 @@
 package org.apache.hadoop.ozone.om.multitenant;
 
 import com.google.protobuf.ServiceException;
+import org.apache.hadoop.hdds.utils.IOUtils;
 import org.apache.hadoop.hdds.client.OzoneQuota;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.scm.client.HddsClientUtils;
@@ -25,6 +26,7 @@ import org.apache.hadoop.ozone.MiniOzoneCluster;
 import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.hadoop.ozone.client.ObjectStore;
 import org.apache.hadoop.ozone.client.OzoneBucket;
+import org.apache.hadoop.ozone.client.OzoneClient;
 import org.apache.hadoop.ozone.client.OzoneVolume;
 import org.apache.hadoop.ozone.client.rpc.RpcClient;
 import org.apache.hadoop.ozone.om.OMMultiTenantManagerImpl;
@@ -63,6 +65,7 @@ public class TestMultiTenantVolume {
   private static final String USER_PRINCIPAL = "username";
   private static final String BUCKET_NAME = "bucket";
   private static final String ACCESS_ID = "tenant$username";
+  private static OzoneClient client;
 
   @BeforeClass
   public static void initClusterProvider() throws Exception {
@@ -74,6 +77,7 @@ public class TestMultiTenantVolume {
         .withoutDatanodes()
         .setOmLayoutVersion(OMLayoutFeature.INITIAL_VERSION.layoutVersion());
     cluster = builder.build();
+    client = cluster.getClient();
     s3VolumeName = HddsClientUtils.getDefaultS3VolumeName(conf);
 
     preFinalizationChecks(getStoreForAccessID(ACCESS_ID));
@@ -82,6 +86,7 @@ public class TestMultiTenantVolume {
 
   @AfterClass
   public static void shutdownClusterProvider() {
+    IOUtils.closeQuietly(client);
     cluster.shutdown();
   }
 
@@ -136,11 +141,11 @@ public class TestMultiTenantVolume {
       throws IOException, InterruptedException, TimeoutException {
 
     // Trigger OM upgrade finalization. Ref: FinalizeUpgradeSubCommand#call
-    final OzoneManagerProtocol client = cluster.getRpcClient().getObjectStore()
+    final OzoneManagerProtocol omClient = client.getObjectStore()
         .getClientProxy().getOzoneManagerClient();
     final String upgradeClientID = "Test-Upgrade-Client-" + UUID.randomUUID();
     UpgradeFinalizer.StatusAndMessages finalizationResponse =
-        client.finalizeUpgrade(upgradeClientID);
+        omClient.finalizeUpgrade(upgradeClientID);
 
     // The status should transition as soon as the client call above returns
     Assert.assertTrue(isStarting(finalizationResponse.status()));
@@ -150,7 +155,7 @@ public class TestMultiTenantVolume {
     GenericTestUtils.waitFor(() -> {
       try {
         final UpgradeFinalizer.StatusAndMessages progress =
-            client.queryUpgradeFinalizationProgress(
+            omClient.queryUpgradeFinalizationProgress(
                 upgradeClientID, false, false);
         return isDone(progress.status());
       } catch (IOException e) {
@@ -166,7 +171,7 @@ public class TestMultiTenantVolume {
     final String bucketName = "bucket";
 
     // Default client not belonging to a tenant should end up in the S3 volume.
-    ObjectStore store = cluster.getClient().getObjectStore();
+    ObjectStore store = client.getObjectStore();
     Assert.assertEquals(s3VolumeName, store.getS3Volume().getName());
 
     // Create bucket.

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/multitenant/TestMultiTenantVolume.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/multitenant/TestMultiTenantVolume.java
@@ -77,7 +77,7 @@ public class TestMultiTenantVolume {
         .withoutDatanodes()
         .setOmLayoutVersion(OMLayoutFeature.INITIAL_VERSION.layoutVersion());
     cluster = builder.build();
-    client = cluster.getClient();
+    client = cluster.newClient();
     s3VolumeName = HddsClientUtils.getDefaultS3VolumeName(conf);
 
     preFinalizationChecks(getStoreForAccessID(ACCESS_ID));

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/multitenant/TestMultiTenantVolume.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/multitenant/TestMultiTenantVolume.java
@@ -246,11 +246,11 @@ public class TestMultiTenantVolume {
     OzoneConfiguration conf = cluster.getOzoneManager().getConfiguration();
     // Manually construct an object store instead of using the cluster
     // provided one so we can specify the access ID.
-    RpcClient client = new RpcClient(conf, null);
+    RpcClient rpcClient = new RpcClient(conf, null);
     // userPrincipal is set to be the same as accessId for the test
-    client.setThreadLocalS3Auth(
+    rpcClient.setThreadLocalS3Auth(
         new S3Auth("unused1", "unused2", accessID, accessID));
-    return new ObjectStore(conf, client);
+    return new ObjectStore(conf, rpcClient);
   }
 
   @Test

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/snapshot/TestOzoneManagerSnapshotAcl.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/snapshot/TestOzoneManagerSnapshotAcl.java
@@ -130,7 +130,7 @@ public class TestOzoneManagerSnapshotAcl {
         new OzoneConfiguration(cluster.getConf());
     clientConf.set(FS_DEFAULT_NAME_KEY, hostPrefix);
 
-    client = cluster.getClient();
+    client = cluster.newClient();
     objectStore = client.getObjectStore();
 
     final KeyManagerImpl keyManager = (KeyManagerImpl) HddsWhiteboxTestUtils

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/snapshot/TestOzoneManagerSnapshotAcl.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/snapshot/TestOzoneManagerSnapshotAcl.java
@@ -25,6 +25,7 @@ import java.util.UUID;
 import java.util.concurrent.TimeoutException;
 import java.util.stream.Stream;
 
+import org.apache.hadoop.hdds.utils.IOUtils;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.scm.HddsWhiteboxTestUtils;
@@ -96,6 +97,7 @@ public class TestOzoneManagerSnapshotAcl {
   private static ObjectStore objectStore;
   private static File metaDir;
   private static OzoneManager ozoneManager;
+  private static OzoneClient client;
   private String volumeName;
   private String bucketName;
   private static final String KEY_PREFIX = "key-";
@@ -128,7 +130,7 @@ public class TestOzoneManagerSnapshotAcl {
         new OzoneConfiguration(cluster.getConf());
     clientConf.set(FS_DEFAULT_NAME_KEY, hostPrefix);
 
-    final OzoneClient client = cluster.getClient();
+    client = cluster.getClient();
     objectStore = client.getObjectStore();
 
     final KeyManagerImpl keyManager = (KeyManagerImpl) HddsWhiteboxTestUtils
@@ -146,6 +148,7 @@ public class TestOzoneManagerSnapshotAcl {
 
   @AfterAll
   public static void tearDown() throws Exception {
+    IOUtils.closeQuietly(client);
     if (cluster != null) {
       cluster.shutdown();
     }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/snapshot/TestOzoneManagerSnapshotProvider.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/snapshot/TestOzoneManagerSnapshotProvider.java
@@ -22,10 +22,12 @@ import java.util.UUID;
 
 import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import org.apache.hadoop.hdds.utils.IOUtils;
 import org.apache.hadoop.hdds.utils.db.DBCheckpoint;
 import org.apache.hadoop.ozone.MiniOzoneCluster;
 import org.apache.hadoop.ozone.MiniOzoneHAClusterImpl;
 import org.apache.hadoop.ozone.client.ObjectStore;
+import org.apache.hadoop.ozone.client.OzoneClient;
 import org.apache.hadoop.ozone.client.OzoneClientFactory;
 import org.apache.hadoop.ozone.client.OzoneVolume;
 import org.apache.hadoop.ozone.client.VolumeArgs;
@@ -57,6 +59,7 @@ public class TestOzoneManagerSnapshotProvider {
 
   @Rule
   public Timeout timeout = Timeout.seconds(300);
+  private OzoneClient client;
 
   /**
    * Create a MiniDFSCluster for testing.
@@ -76,8 +79,8 @@ public class TestOzoneManagerSnapshotProvider {
         .setNumOfOzoneManagers(numOfOMs)
         .build();
     cluster.waitForClusterToBeReady();
-    objectStore = OzoneClientFactory.getRpcClient(omServiceId, conf)
-        .getObjectStore();
+    client = OzoneClientFactory.getRpcClient(omServiceId, conf);
+    objectStore = client.getObjectStore();
   }
 
   /**
@@ -85,6 +88,7 @@ public class TestOzoneManagerSnapshotProvider {
    */
   @After
   public void shutdown() {
+    IOUtils.closeQuietly(client);
     if (cluster != null) {
       cluster.shutdown();
     }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/snapshot/TestOzoneSnapshotRestore.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/snapshot/TestOzoneSnapshotRestore.java
@@ -19,6 +19,7 @@
 
 package org.apache.hadoop.ozone.om.snapshot;
 
+import org.apache.hadoop.hdds.utils.IOUtils;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.hadoop.fs.ozone.OzoneFsShell;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
@@ -74,6 +75,7 @@ public class TestOzoneSnapshotRestore {
   private File metaDir;
   private OzoneManager leaderOzoneManager;
   private OzoneConfiguration clientConf;
+  private OzoneClient client;
 
   private static Stream<Arguments> bucketTypes() {
     return Stream.of(
@@ -112,7 +114,7 @@ public class TestOzoneSnapshotRestore {
     clientConf = new OzoneConfiguration(cluster.getConf());
     clientConf.set(FS_DEFAULT_NAME_KEY, hostPrefix);
 
-    OzoneClient client = cluster.getClient();
+    client = cluster.getClient();
     store = client.getObjectStore();
 
     KeyManagerImpl keyManager = (KeyManagerImpl) HddsWhiteboxTestUtils
@@ -126,6 +128,7 @@ public class TestOzoneSnapshotRestore {
 
   @AfterEach
   public void tearDown() throws Exception {
+    IOUtils.closeQuietly(client);
     if (cluster != null) {
       cluster.shutdown();
     }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/snapshot/TestOzoneSnapshotRestore.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/snapshot/TestOzoneSnapshotRestore.java
@@ -114,7 +114,7 @@ public class TestOzoneSnapshotRestore {
     clientConf = new OzoneConfiguration(cluster.getConf());
     clientConf.set(FS_DEFAULT_NAME_KEY, hostPrefix);
 
-    client = cluster.getClient();
+    client = cluster.newClient();
     store = client.getObjectStore();
 
     KeyManagerImpl keyManager = (KeyManagerImpl) HddsWhiteboxTestUtils

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/parser/TestOzoneHARatisLogParser.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/parser/TestOzoneHARatisLogParser.java
@@ -22,8 +22,10 @@ import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.scm.ha.RatisUtil;
 import org.apache.hadoop.hdds.scm.ha.SCMRatisRequest;
 import org.apache.hadoop.hdds.scm.server.StorageContainerManager;
+import org.apache.hadoop.hdds.utils.IOUtils;
 import org.apache.hadoop.ozone.MiniOzoneHAClusterImpl;
 import org.apache.hadoop.ozone.client.ObjectStore;
+import org.apache.hadoop.ozone.client.OzoneClient;
 import org.apache.hadoop.ozone.client.OzoneClientFactory;
 import org.apache.hadoop.ozone.om.helpers.OMRatisHelper;
 import org.apache.hadoop.ozone.MiniOzoneCluster;
@@ -55,6 +57,7 @@ class TestOzoneHARatisLogParser {
   private MiniOzoneHAClusterImpl cluster = null;
   private final ByteArrayOutputStream out = new ByteArrayOutputStream();
   private final ByteArrayOutputStream err = new ByteArrayOutputStream();
+  private OzoneClient client;
 
   @BeforeEach
   void setup() throws Exception {
@@ -72,8 +75,8 @@ class TestOzoneHARatisLogParser {
         .setNumOfStorageContainerManagers(3)
         .build();
     cluster.waitForClusterToBeReady();
-    ObjectStore objectStore = OzoneClientFactory.getRpcClient(omServiceId, conf)
-        .getObjectStore();
+    client = OzoneClientFactory.getRpcClient(omServiceId, conf);
+    ObjectStore objectStore = client.getObjectStore();
     performFewRequests(objectStore);
     System.setOut(new PrintStream(out, false, UTF_8.name()));
     System.setErr(new PrintStream(err, false, UTF_8.name()));
@@ -88,6 +91,7 @@ class TestOzoneHARatisLogParser {
 
   @AfterEach
   void destroy() throws Exception {
+    IOUtils.closeQuietly(client);
     if (cluster != null) {
       cluster.shutdown();
     }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/recon/TestReconWithOzoneManagerFSO.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/recon/TestReconWithOzoneManagerFSO.java
@@ -20,6 +20,7 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 
 import java.util.UUID;
 
+import org.apache.hadoop.hdds.utils.IOUtils;
 import org.apache.hadoop.hdds.client.ReplicationFactor;
 import org.apache.hadoop.hdds.client.ReplicationType;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
@@ -27,6 +28,7 @@ import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.hdds.scm.server.OzoneStorageContainerManager;
 import org.apache.hadoop.ozone.MiniOzoneCluster;
 import org.apache.hadoop.ozone.client.ObjectStore;
+import org.apache.hadoop.ozone.client.OzoneClient;
 import org.apache.hadoop.ozone.client.OzoneVolume;
 import org.apache.hadoop.ozone.client.io.OzoneOutputStream;
 import org.apache.hadoop.ozone.container.ContainerTestHelper;
@@ -53,6 +55,7 @@ import javax.ws.rs.core.Response;
  */
 public class TestReconWithOzoneManagerFSO {
 
+  private static OzoneClient client;
   /**
    * Set a timeout for each test.
    */
@@ -75,11 +78,13 @@ public class TestReconWithOzoneManagerFSO {
     cluster.waitForClusterToBeReady();
     cluster.waitForPipelineTobeReady(HddsProtos.ReplicationFactor.ONE, 30000);
 
-    store = cluster.getClient().getObjectStore();
+    client = cluster.getClient();
+    store = client.getObjectStore();
   }
 
   @AfterClass
   public static void shutdown() {
+    IOUtils.closeQuietly(client);
     if (cluster != null) {
       cluster.shutdown();
     }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/recon/TestReconWithOzoneManagerFSO.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/recon/TestReconWithOzoneManagerFSO.java
@@ -78,7 +78,7 @@ public class TestReconWithOzoneManagerFSO {
     cluster.waitForClusterToBeReady();
     cluster.waitForPipelineTobeReady(HddsProtos.ReplicationFactor.ONE, 30000);
 
-    client = cluster.getClient();
+    client = cluster.newClient();
     store = client.getObjectStore();
   }
 

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/recon/TestReconWithOzoneManagerHA.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/recon/TestReconWithOzoneManagerHA.java
@@ -27,6 +27,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import org.apache.hadoop.hdds.client.ReplicationFactor;
 import org.apache.hadoop.hdds.client.ReplicationType;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import org.apache.hadoop.hdds.utils.IOUtils;
 import org.apache.hadoop.hdds.utils.db.RocksDBConfiguration;
 import org.apache.hadoop.hdds.utils.db.Table;
 import org.apache.hadoop.hdds.utils.db.TableIterator;
@@ -34,6 +35,7 @@ import org.apache.hadoop.ozone.MiniOzoneCluster;
 import org.apache.hadoop.ozone.MiniOzoneHAClusterImpl;
 import org.apache.hadoop.ozone.client.BucketArgs;
 import org.apache.hadoop.ozone.client.ObjectStore;
+import org.apache.hadoop.ozone.client.OzoneClient;
 import org.apache.hadoop.ozone.client.OzoneClientFactory;
 import org.apache.hadoop.ozone.client.io.OzoneOutputStream;
 import org.apache.hadoop.ozone.om.OMConfigKeys;
@@ -61,6 +63,7 @@ public class TestReconWithOzoneManagerHA {
   private ObjectStore objectStore;
   private static final String OM_SERVICE_ID = "omService1";
   private static final String VOL_NAME = "testrecon";
+  private OzoneClient client;
 
   @Before
   public void setup() throws Exception {
@@ -81,8 +84,8 @@ public class TestReconWithOzoneManagerHA {
         .includeRecon(true)
         .build();
     cluster.waitForClusterToBeReady();
-    objectStore = OzoneClientFactory.getRpcClient(OM_SERVICE_ID, conf)
-        .getObjectStore();
+    client = OzoneClientFactory.getRpcClient(OM_SERVICE_ID, conf);
+    objectStore = client.getObjectStore();
     objectStore.createVolume(VOL_NAME);
     // TODO: HDDS-5463
     //  Recon's container ID to key mapping does not yet support FSO buckets.
@@ -93,6 +96,7 @@ public class TestReconWithOzoneManagerHA {
 
   @After
   public void tearDown() {
+    IOUtils.closeQuietly(client);
     if (cluster != null) {
       cluster.shutdown();
     }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/scm/TestCloseContainer.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/scm/TestCloseContainer.java
@@ -89,7 +89,7 @@ public class TestCloseContainer {
         .setNumDatanodes(numOfDatanodes)
         .build();
     cluster.waitForClusterToBeReady();
-    client = cluster.getClient();
+    client = cluster.newClient();
 
     bucket = TestDataUtil.createVolumeAndBucket(client, volName, bucketName);
   }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/scm/TestCloseContainer.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/scm/TestCloseContainer.java
@@ -17,6 +17,7 @@
  */
 package org.apache.hadoop.ozone.scm;
 
+import org.apache.hadoop.hdds.utils.IOUtils;
 import org.apache.hadoop.hdds.client.ReplicationFactor;
 import org.apache.hadoop.hdds.client.ReplicationType;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
@@ -29,6 +30,7 @@ import org.apache.hadoop.hdds.scm.server.StorageContainerManager;
 import org.apache.hadoop.ozone.MiniOzoneCluster;
 import org.apache.hadoop.ozone.TestDataUtil;
 import org.apache.hadoop.ozone.client.OzoneBucket;
+import org.apache.hadoop.ozone.client.OzoneClient;
 import org.apache.ozone.test.GenericTestUtils;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -61,6 +63,7 @@ public class TestCloseContainer {
   private static String volName = "vol1";
   private OzoneBucket bucket;
   private MiniOzoneCluster cluster;
+  private OzoneClient client;
 
   @BeforeEach
   public void setUp() throws Exception {
@@ -86,12 +89,14 @@ public class TestCloseContainer {
         .setNumDatanodes(numOfDatanodes)
         .build();
     cluster.waitForClusterToBeReady();
+    client = cluster.getClient();
 
-    bucket = TestDataUtil.createVolumeAndBucket(cluster, volName, bucketName);
+    bucket = TestDataUtil.createVolumeAndBucket(client, volName, bucketName);
   }
 
   @AfterEach
   public void cleanup() {
+    IOUtils.closeQuietly(client);
     if (cluster != null) {
       cluster.shutdown();
     }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/scm/TestSCMContainerPlacementPolicyMetrics.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/scm/TestSCMContainerPlacementPolicyMetrics.java
@@ -29,6 +29,7 @@ import org.apache.hadoop.hdds.scm.container.placement.algorithms
     .SCMContainerPlacementMetrics;
 import org.apache.hadoop.hdds.scm.pipeline.Pipeline;
 import org.apache.hadoop.hdds.scm.pipeline.PipelineManager;
+import org.apache.hadoop.hdds.utils.IOUtils;
 import org.apache.hadoop.metrics2.MetricsRecordBuilder;
 import org.apache.hadoop.net.DNSToSwitchMapping;
 import org.apache.hadoop.net.NetUtils;
@@ -160,6 +161,7 @@ public class TestSCMContainerPlacementPolicyMetrics {
 
   @AfterEach
   public void teardown() {
+    IOUtils.closeQuietly(ozClient);
     cluster.shutdown();
   }
 }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/scm/TestStorageContainerManagerHA.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/scm/TestStorageContainerManagerHA.java
@@ -177,7 +177,8 @@ public class TestStorageContainerManagerHA {
       Assert.assertFalse(key.getCreationTime().isBefore(testStartTime));
       Assert.assertFalse(key.getModificationTime().isBefore(testStartTime));
       is.close();
-      final OmKeyArgs keyArgs = new OmKeyArgs.Builder().setVolumeName(volumeName)
+      final OmKeyArgs keyArgs = new OmKeyArgs.Builder()
+          .setVolumeName(volumeName)
           .setBucketName(bucketName)
           .setReplicationConfig(RatisReplicationConfig.getInstance(
               HddsProtos.ReplicationFactor.ONE))
@@ -187,7 +188,8 @@ public class TestStorageContainerManagerHA {
       final List<OmKeyLocationInfo> keyLocationInfos =
           keyInfo.getKeyLocationVersions().get(0).getBlocksLatestVersionOnly();
       long index = -1;
-      for (StorageContainerManager scm : cluster.getStorageContainerManagers()) {
+      for (StorageContainerManager scm : cluster
+          .getStorageContainerManagers()) {
         if (scm.checkLeader()) {
           index = getLastAppliedIndex(scm);
         }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/scm/TestStorageContainerManagerHA.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/scm/TestStorageContainerManagerHA.java
@@ -153,7 +153,7 @@ public class TestStorageContainerManagerHA {
     String volumeName = UUID.randomUUID().toString();
     String bucketName = UUID.randomUUID().toString();
     Instant testStartTime = Instant.now();
-    try (OzoneClient client = cluster.getClient()) {
+    try (OzoneClient client = cluster.newClient()) {
       ObjectStore store = client.getObjectStore();
       String value = "sample value";
       store.createVolume(volumeName);

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/scm/TestStorageContainerManagerHA.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/scm/TestStorageContainerManagerHA.java
@@ -32,7 +32,7 @@ import org.apache.hadoop.ozone.MiniOzoneCluster;
 import org.apache.hadoop.ozone.MiniOzoneHAClusterImpl;
 import org.apache.hadoop.ozone.client.ObjectStore;
 import org.apache.hadoop.ozone.client.OzoneBucket;
-import org.apache.hadoop.ozone.client.OzoneClientFactory;
+import org.apache.hadoop.ozone.client.OzoneClient;
 import org.apache.hadoop.ozone.client.OzoneKey;
 import org.apache.hadoop.ozone.client.OzoneVolume;
 import org.apache.hadoop.ozone.client.io.OzoneInputStream;
@@ -153,60 +153,61 @@ public class TestStorageContainerManagerHA {
     String volumeName = UUID.randomUUID().toString();
     String bucketName = UUID.randomUUID().toString();
     Instant testStartTime = Instant.now();
-    ObjectStore store =
-        OzoneClientFactory.getRpcClient(cluster.getConf()).getObjectStore();
-    String value = "sample value";
-    store.createVolume(volumeName);
-    OzoneVolume volume = store.getVolume(volumeName);
-    volume.createBucket(bucketName);
-    OzoneBucket bucket = volume.getBucket(bucketName);
+    try (OzoneClient client = cluster.getClient()) {
+      ObjectStore store = client.getObjectStore();
+      String value = "sample value";
+      store.createVolume(volumeName);
+      OzoneVolume volume = store.getVolume(volumeName);
+      volume.createBucket(bucketName);
+      OzoneBucket bucket = volume.getBucket(bucketName);
 
-    String keyName = UUID.randomUUID().toString();
+      String keyName = UUID.randomUUID().toString();
 
-    OzoneOutputStream out = bucket
-        .createKey(keyName, value.getBytes(UTF_8).length, RATIS, ONE,
-            new HashMap<>());
-    out.write(value.getBytes(UTF_8));
-    out.close();
-    OzoneKey key = bucket.getKey(keyName);
-    Assert.assertEquals(keyName, key.getName());
-    OzoneInputStream is = bucket.readKey(keyName);
-    byte[] fileContent = new byte[value.getBytes(UTF_8).length];
-    is.read(fileContent);
-    Assert.assertEquals(value, new String(fileContent, UTF_8));
-    Assert.assertFalse(key.getCreationTime().isBefore(testStartTime));
-    Assert.assertFalse(key.getModificationTime().isBefore(testStartTime));
-    is.close();
-    final OmKeyArgs keyArgs = new OmKeyArgs.Builder().setVolumeName(volumeName)
-        .setBucketName(bucketName)
-        .setReplicationConfig(RatisReplicationConfig.getInstance(
-            HddsProtos.ReplicationFactor.ONE))
-        .setKeyName(keyName)
-        .build();
-    final OmKeyInfo keyInfo = cluster.getOzoneManager().lookupKey(keyArgs);
-    final List<OmKeyLocationInfo> keyLocationInfos =
-        keyInfo.getKeyLocationVersions().get(0).getBlocksLatestVersionOnly();
-    long index = -1;
-    for (StorageContainerManager scm : cluster.getStorageContainerManagers()) {
-      if (scm.checkLeader()) {
-        index = getLastAppliedIndex(scm);
+      OzoneOutputStream out = bucket
+          .createKey(keyName, value.getBytes(UTF_8).length, RATIS, ONE,
+              new HashMap<>());
+      out.write(value.getBytes(UTF_8));
+      out.close();
+      OzoneKey key = bucket.getKey(keyName);
+      Assert.assertEquals(keyName, key.getName());
+      OzoneInputStream is = bucket.readKey(keyName);
+      byte[] fileContent = new byte[value.getBytes(UTF_8).length];
+      is.read(fileContent);
+      Assert.assertEquals(value, new String(fileContent, UTF_8));
+      Assert.assertFalse(key.getCreationTime().isBefore(testStartTime));
+      Assert.assertFalse(key.getModificationTime().isBefore(testStartTime));
+      is.close();
+      final OmKeyArgs keyArgs = new OmKeyArgs.Builder().setVolumeName(volumeName)
+          .setBucketName(bucketName)
+          .setReplicationConfig(RatisReplicationConfig.getInstance(
+              HddsProtos.ReplicationFactor.ONE))
+          .setKeyName(keyName)
+          .build();
+      final OmKeyInfo keyInfo = cluster.getOzoneManager().lookupKey(keyArgs);
+      final List<OmKeyLocationInfo> keyLocationInfos =
+          keyInfo.getKeyLocationVersions().get(0).getBlocksLatestVersionOnly();
+      long index = -1;
+      for (StorageContainerManager scm : cluster.getStorageContainerManagers()) {
+        if (scm.checkLeader()) {
+          index = getLastAppliedIndex(scm);
+        }
       }
-    }
-    Assert.assertFalse(index == -1);
-    long finalIndex = index;
-    // Ensure all follower scms have caught up with the leader
-    GenericTestUtils.waitFor(() -> areAllScmInSync(finalIndex), 100, 10000);
-    final long containerID = keyLocationInfos.get(0).getContainerID();
-    for (int k = 0; k < numOfSCMs; k++) {
-      StorageContainerManager scm =
-          cluster.getStorageContainerManagers().get(k);
-      // flush to DB on each SCM
-      ((SCMRatisServerImpl) scm.getScmHAManager().getRatisServer())
-          .getStateMachine().takeSnapshot();
-      Assert.assertTrue(scm.getContainerManager()
-          .containerExist(ContainerID.valueOf(containerID)));
-      Assert.assertNotNull(scm.getScmMetadataStore().getContainerTable()
-          .get(ContainerID.valueOf(containerID)));
+      Assert.assertFalse(index == -1);
+      long finalIndex = index;
+      // Ensure all follower scms have caught up with the leader
+      GenericTestUtils.waitFor(() -> areAllScmInSync(finalIndex), 100, 10000);
+      final long containerID = keyLocationInfos.get(0).getContainerID();
+      for (int k = 0; k < numOfSCMs; k++) {
+        StorageContainerManager scm =
+            cluster.getStorageContainerManagers().get(k);
+        // flush to DB on each SCM
+        ((SCMRatisServerImpl) scm.getScmHAManager().getRatisServer())
+            .getStateMachine().takeSnapshot();
+        Assert.assertTrue(scm.getContainerManager()
+            .containerExist(ContainerID.valueOf(containerID)));
+        Assert.assertNotNull(scm.getScmMetadataStore().getContainerTable()
+            .get(ContainerID.valueOf(containerID)));
+      }
     }
   }
 

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/scm/TestXceiverClientManager.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/scm/TestXceiverClientManager.java
@@ -150,7 +150,7 @@ public class TestXceiverClientManager {
           container1.getContainerInfo().getPipelineID().getId().toString()
               + container1.getContainerInfo().getReplicationType());
       Assertions.assertEquals(null, nonExistent1);
-      // However container call should succeed because of refcount on the client.
+      // However container call should succeed because of refcount on the client
       ContainerProtocolCalls.createContainer(client1,
           container1.getContainerInfo().getContainerID(), null);
 
@@ -256,7 +256,7 @@ public class TestXceiverClientManager {
       Assertions.assertNotEquals(client1, client2);
       Assertions.assertEquals(1, client2.getRefcount());
 
-      // on releasing the old client the entry in cache should not be invalidated
+      // on releasing the old client the cache entry should not be invalidated
       clientManager.releaseClient(client1, true);
       Assertions.assertEquals(0, client1.getRefcount());
       Assertions.assertNotNull(cache.getIfPresent(

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/scm/TestXceiverClientManager.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/scm/TestXceiverClientManager.java
@@ -80,34 +80,35 @@ public class TestXceiverClientManager {
         TestXceiverClientManager.class.getName() + UUID.randomUUID());
     conf.set(HDDS_METADATA_DIR_NAME, metaDir);
 
-    XceiverClientManager clientManager = new XceiverClientManager(conf);
+    try (XceiverClientManager clientManager = new XceiverClientManager(conf)) {
 
-    ContainerWithPipeline container1 = storageContainerLocationClient
-        .allocateContainer(
-            SCMTestUtils.getReplicationType(conf),
-            HddsProtos.ReplicationFactor.ONE,
-            OzoneConsts.OZONE);
-    XceiverClientSpi client1 = clientManager
-        .acquireClient(container1.getPipeline());
-    Assertions.assertEquals(1, client1.getRefcount());
+      ContainerWithPipeline container1 = storageContainerLocationClient
+          .allocateContainer(
+              SCMTestUtils.getReplicationType(conf),
+              HddsProtos.ReplicationFactor.ONE,
+              OzoneConsts.OZONE);
+      XceiverClientSpi client1 = clientManager
+          .acquireClient(container1.getPipeline());
+      Assertions.assertEquals(1, client1.getRefcount());
 
-    ContainerWithPipeline container2 = storageContainerLocationClient
-        .allocateContainer(
-            SCMTestUtils.getReplicationType(conf),
-            HddsProtos.ReplicationFactor.THREE,
-            OzoneConsts.OZONE);
-    XceiverClientSpi client2 = clientManager
-        .acquireClient(container2.getPipeline());
-    Assertions.assertEquals(1, client2.getRefcount());
+      ContainerWithPipeline container2 = storageContainerLocationClient
+          .allocateContainer(
+              SCMTestUtils.getReplicationType(conf),
+              HddsProtos.ReplicationFactor.THREE,
+              OzoneConsts.OZONE);
+      XceiverClientSpi client2 = clientManager
+          .acquireClient(container2.getPipeline());
+      Assertions.assertEquals(1, client2.getRefcount());
 
-    XceiverClientSpi client3 = clientManager
-        .acquireClient(container1.getPipeline());
-    Assertions.assertEquals(2, client3.getRefcount());
-    Assertions.assertEquals(2, client1.getRefcount());
-    Assertions.assertEquals(client1, client3);
-    clientManager.releaseClient(client1, false);
-    clientManager.releaseClient(client2, false);
-    clientManager.releaseClient(client3, false);
+      XceiverClientSpi client3 = clientManager
+          .acquireClient(container1.getPipeline());
+      Assertions.assertEquals(2, client3.getRefcount());
+      Assertions.assertEquals(2, client1.getRefcount());
+      Assertions.assertEquals(client1, client3);
+      clientManager.releaseClient(client1, false);
+      clientManager.releaseClient(client2, false);
+      clientManager.releaseClient(client3, false);
+    }
   }
 
   @Test
@@ -118,53 +119,54 @@ public class TestXceiverClientManager {
     String metaDir = GenericTestUtils.getTempPath(
         TestXceiverClientManager.class.getName() + UUID.randomUUID());
     conf.set(HDDS_METADATA_DIR_NAME, metaDir);
-    XceiverClientManager clientManager =
-        new XceiverClientManager(conf, clientConfig, null);
-    Cache<String, XceiverClientSpi> cache =
-        clientManager.getClientCache();
+    try (XceiverClientManager clientManager =
+        new XceiverClientManager(conf, clientConfig, null)) {
+      Cache<String, XceiverClientSpi> cache =
+          clientManager.getClientCache();
 
-    ContainerWithPipeline container1 =
-        storageContainerLocationClient.allocateContainer(
-            SCMTestUtils.getReplicationType(conf),
-            HddsProtos.ReplicationFactor.ONE,
-            OzoneConsts.OZONE);
-    XceiverClientSpi client1 = clientManager
-        .acquireClient(container1.getPipeline());
-    Assertions.assertEquals(1, client1.getRefcount());
-    Assertions.assertEquals(container1.getPipeline(),
-        client1.getPipeline());
+      ContainerWithPipeline container1 =
+          storageContainerLocationClient.allocateContainer(
+              SCMTestUtils.getReplicationType(conf),
+              HddsProtos.ReplicationFactor.ONE,
+              OzoneConsts.OZONE);
+      XceiverClientSpi client1 = clientManager
+          .acquireClient(container1.getPipeline());
+      Assertions.assertEquals(1, client1.getRefcount());
+      Assertions.assertEquals(container1.getPipeline(),
+          client1.getPipeline());
 
-    ContainerWithPipeline container2 =
-        storageContainerLocationClient.allocateContainer(
-            SCMTestUtils.getReplicationType(conf),
-            HddsProtos.ReplicationFactor.THREE,
-            OzoneConsts.OZONE);
-    XceiverClientSpi client2 = clientManager
-        .acquireClient(container2.getPipeline());
-    Assertions.assertEquals(1, client2.getRefcount());
-    Assertions.assertNotEquals(client1, client2);
+      ContainerWithPipeline container2 =
+          storageContainerLocationClient.allocateContainer(
+              SCMTestUtils.getReplicationType(conf),
+              HddsProtos.ReplicationFactor.THREE,
+              OzoneConsts.OZONE);
+      XceiverClientSpi client2 = clientManager
+          .acquireClient(container2.getPipeline());
+      Assertions.assertEquals(1, client2.getRefcount());
+      Assertions.assertNotEquals(client1, client2);
 
-    // least recent container (i.e containerName1) is evicted
-    XceiverClientSpi nonExistent1 = cache.getIfPresent(
-        container1.getContainerInfo().getPipelineID().getId().toString()
-            + container1.getContainerInfo().getReplicationType());
-    Assertions.assertEquals(null, nonExistent1);
-    // However container call should succeed because of refcount on the client.
-    ContainerProtocolCalls.createContainer(client1,
-        container1.getContainerInfo().getContainerID(), null);
+      // least recent container (i.e containerName1) is evicted
+      XceiverClientSpi nonExistent1 = cache.getIfPresent(
+          container1.getContainerInfo().getPipelineID().getId().toString()
+              + container1.getContainerInfo().getReplicationType());
+      Assertions.assertEquals(null, nonExistent1);
+      // However container call should succeed because of refcount on the client.
+      ContainerProtocolCalls.createContainer(client1,
+          container1.getContainerInfo().getContainerID(), null);
 
-    // After releasing the client, this connection should be closed
-    // and any container operations should fail
-    clientManager.releaseClient(client1, false);
+      // After releasing the client, this connection should be closed
+      // and any container operations should fail
+      clientManager.releaseClient(client1, false);
 
-    // Create container should throw exception on closed client
-    Throwable t = Assertions.assertThrows(IOException.class,
-        () -> ContainerProtocolCalls.createContainer(client1,
-            container1.getContainerInfo().getContainerID(), null));
-    Assertions.assertTrue(
-        t.getMessage().contains("This channel is not connected"));
+      // Create container should throw exception on closed client
+      Throwable t = Assertions.assertThrows(IOException.class,
+          () -> ContainerProtocolCalls.createContainer(client1,
+              container1.getContainerInfo().getContainerID(), null));
+      Assertions.assertTrue(
+          t.getMessage().contains("This channel is not connected"));
 
-    clientManager.releaseClient(client2, false);
+      clientManager.releaseClient(client2, false);
+    }
   }
 
   @Test
@@ -175,47 +177,48 @@ public class TestXceiverClientManager {
     String metaDir = GenericTestUtils.getTempPath(
         TestXceiverClientManager.class.getName() + UUID.randomUUID());
     conf.set(HDDS_METADATA_DIR_NAME, metaDir);
-    XceiverClientManager clientManager =
-        new XceiverClientManager(conf, clientConfig, null);
-    Cache<String, XceiverClientSpi> cache =
-        clientManager.getClientCache();
+    try (XceiverClientManager clientManager =
+        new XceiverClientManager(conf, clientConfig, null)) {
+      Cache<String, XceiverClientSpi> cache =
+          clientManager.getClientCache();
 
-    ContainerWithPipeline container1 =
-        storageContainerLocationClient.allocateContainer(
-            SCMTestUtils.getReplicationType(conf),
-            HddsProtos.ReplicationFactor.ONE,
-            OzoneConsts.OZONE);
-    XceiverClientSpi client1 = clientManager
-        .acquireClient(container1.getPipeline());
-    Assertions.assertEquals(1, client1.getRefcount());
+      ContainerWithPipeline container1 =
+          storageContainerLocationClient.allocateContainer(
+              SCMTestUtils.getReplicationType(conf),
+              HddsProtos.ReplicationFactor.ONE,
+              OzoneConsts.OZONE);
+      XceiverClientSpi client1 = clientManager
+          .acquireClient(container1.getPipeline());
+      Assertions.assertEquals(1, client1.getRefcount());
 
-    clientManager.releaseClient(client1, false);
-    Assertions.assertEquals(0, client1.getRefcount());
+      clientManager.releaseClient(client1, false);
+      Assertions.assertEquals(0, client1.getRefcount());
 
-    ContainerWithPipeline container2 =
-        storageContainerLocationClient.allocateContainer(
-            SCMTestUtils.getReplicationType(conf),
-            HddsProtos.ReplicationFactor.THREE,
-            OzoneConsts.OZONE);
-    XceiverClientSpi client2 = clientManager
-        .acquireClient(container2.getPipeline());
-    Assertions.assertEquals(1, client2.getRefcount());
-    Assertions.assertNotEquals(client1, client2);
+      ContainerWithPipeline container2 =
+          storageContainerLocationClient.allocateContainer(
+              SCMTestUtils.getReplicationType(conf),
+              HddsProtos.ReplicationFactor.THREE,
+              OzoneConsts.OZONE);
+      XceiverClientSpi client2 = clientManager
+          .acquireClient(container2.getPipeline());
+      Assertions.assertEquals(1, client2.getRefcount());
+      Assertions.assertNotEquals(client1, client2);
 
-    // now client 1 should be evicted
-    XceiverClientSpi nonExistent = cache.getIfPresent(
-        container1.getContainerInfo().getPipelineID().getId().toString()
-            + container1.getContainerInfo().getReplicationType());
-    Assertions.assertEquals(null, nonExistent);
+      // now client 1 should be evicted
+      XceiverClientSpi nonExistent = cache.getIfPresent(
+          container1.getContainerInfo().getPipelineID().getId().toString()
+              + container1.getContainerInfo().getReplicationType());
+      Assertions.assertEquals(null, nonExistent);
 
-    // Any container operation should now fail
-    Throwable t = Assertions.assertThrows(IOException.class,
-        () -> ContainerProtocolCalls.createContainer(client1,
-            container1.getContainerInfo().getContainerID(), null));
-    Assertions.assertTrue(
-        t.getMessage().contains("This channel is not connected"));
+      // Any container operation should now fail
+      Throwable t = Assertions.assertThrows(IOException.class,
+          () -> ContainerProtocolCalls.createContainer(client1,
+              container1.getContainerInfo().getContainerID(), null));
+      Assertions.assertTrue(
+          t.getMessage().contains("This channel is not connected"));
 
-    clientManager.releaseClient(client2, false);
+      clientManager.releaseClient(client2, false);
+    }
   }
 
   @Test
@@ -223,40 +226,41 @@ public class TestXceiverClientManager {
     OzoneConfiguration conf = new OzoneConfiguration();
     ScmClientConfig clientConfig = conf.getObject(ScmClientConfig.class);
     clientConfig.setMaxSize(1);
-    XceiverClientManager clientManager =
-        new XceiverClientManager(conf, clientConfig, null);
-    Cache<String, XceiverClientSpi> cache =
-        clientManager.getClientCache();
+    try (XceiverClientManager clientManager =
+        new XceiverClientManager(conf, clientConfig, null)) {
+      Cache<String, XceiverClientSpi> cache =
+          clientManager.getClientCache();
 
-    // client is added in cache
-    ContainerWithPipeline container1 =
-        storageContainerLocationClient.allocateContainer(
-            SCMTestUtils.getReplicationType(conf),
-            SCMTestUtils.getReplicationFactor(conf),
-            OzoneConsts.OZONE);
-    XceiverClientSpi client1 =
-        clientManager.acquireClient(container1.getPipeline());
-    clientManager.acquireClient(container1.getPipeline());
-    Assertions.assertEquals(2, client1.getRefcount());
+      // client is added in cache
+      ContainerWithPipeline container1 =
+          storageContainerLocationClient.allocateContainer(
+              SCMTestUtils.getReplicationType(conf),
+              SCMTestUtils.getReplicationFactor(conf),
+              OzoneConsts.OZONE);
+      XceiverClientSpi client1 =
+          clientManager.acquireClient(container1.getPipeline());
+      clientManager.acquireClient(container1.getPipeline());
+      Assertions.assertEquals(2, client1.getRefcount());
 
-    // client should be invalidated in the cache
-    clientManager.releaseClient(client1, true);
-    Assertions.assertEquals(1, client1.getRefcount());
-    Assertions.assertNull(cache.getIfPresent(
-        container1.getContainerInfo().getPipelineID().getId().toString()
-            + container1.getContainerInfo().getReplicationType()));
+      // client should be invalidated in the cache
+      clientManager.releaseClient(client1, true);
+      Assertions.assertEquals(1, client1.getRefcount());
+      Assertions.assertNull(cache.getIfPresent(
+          container1.getContainerInfo().getPipelineID().getId().toString()
+              + container1.getContainerInfo().getReplicationType()));
 
-    // new client should be added in cache
-    XceiverClientSpi client2 =
-        clientManager.acquireClient(container1.getPipeline());
-    Assertions.assertNotEquals(client1, client2);
-    Assertions.assertEquals(1, client2.getRefcount());
+      // new client should be added in cache
+      XceiverClientSpi client2 =
+          clientManager.acquireClient(container1.getPipeline());
+      Assertions.assertNotEquals(client1, client2);
+      Assertions.assertEquals(1, client2.getRefcount());
 
-    // on releasing the old client the entry in cache should not be invalidated
-    clientManager.releaseClient(client1, true);
-    Assertions.assertEquals(0, client1.getRefcount());
-    Assertions.assertNotNull(cache.getIfPresent(
-        container1.getContainerInfo().getPipelineID().getId().toString()
-            + container1.getContainerInfo().getReplicationType()));
+      // on releasing the old client the entry in cache should not be invalidated
+      clientManager.releaseClient(client1, true);
+      Assertions.assertEquals(0, client1.getRefcount());
+      Assertions.assertNotNull(cache.getIfPresent(
+          container1.getContainerInfo().getPipelineID().getId().toString()
+              + container1.getContainerInfo().getReplicationType()));
+    }
   }
 }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/scm/TestXceiverClientManager.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/scm/TestXceiverClientManager.java
@@ -239,7 +239,8 @@ public class TestXceiverClientManager {
               OzoneConsts.OZONE);
       XceiverClientSpi client1 =
           clientManager.acquireClient(container1.getPipeline());
-      clientManager.acquireClient(container1.getPipeline());
+      XceiverClientSpi client1SecondRef =
+          clientManager.acquireClient(container1.getPipeline());
       Assertions.assertEquals(2, client1.getRefcount());
 
       // client should be invalidated in the cache
@@ -261,6 +262,10 @@ public class TestXceiverClientManager {
       Assertions.assertNotNull(cache.getIfPresent(
           container1.getContainerInfo().getPipelineID().getId().toString()
               + container1.getContainerInfo().getReplicationType()));
+
+      // cleanup
+      clientManager.releaseClient(client1SecondRef, false);
+      clientManager.releaseClient(client2, false);
     }
   }
 }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/scm/node/TestDecommissionAndMaintenance.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/scm/node/TestDecommissionAndMaintenance.java
@@ -107,7 +107,7 @@ public class TestDecommissionAndMaintenance {
   private PipelineManager pm;
   private StorageContainerManager scm;
 
-  private OzoneClient ozoneClient;
+  private OzoneClient client;
   private ContainerOperationClient scmClient;
 
   private static MiniOzoneClusterProvider clusterProvider;
@@ -159,14 +159,14 @@ public class TestDecommissionAndMaintenance {
   public void setUp() throws Exception {
     cluster = clusterProvider.provide();
     setManagers();
-    ozoneClient = cluster.getClient();
-    bucket = TestDataUtil.createVolumeAndBucket(cluster, volName, bucketName);
+    client = cluster.getClient();
+    bucket = TestDataUtil.createVolumeAndBucket(client, volName, bucketName);
     scmClient = new ContainerOperationClient(cluster.getConf());
   }
 
   @AfterEach
   public void tearDown() throws InterruptedException, IOException {
-    IOUtils.close(LOG, ozoneClient);
+    IOUtils.close(LOG, client);
     IOUtils.close(LOG, scmClient);
     if (cluster != null) {
       clusterProvider.destroy(cluster);

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/scm/node/TestDecommissionAndMaintenance.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/scm/node/TestDecommissionAndMaintenance.java
@@ -159,7 +159,7 @@ public class TestDecommissionAndMaintenance {
   public void setUp() throws Exception {
     cluster = clusterProvider.provide();
     setManagers();
-    client = cluster.getClient();
+    client = cluster.newClient();
     bucket = TestDataUtil.createVolumeAndBucket(client, volName, bucketName);
     scmClient = new ContainerOperationClient(cluster.getConf());
   }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/scm/node/TestDecommissionAndMaintenance.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/scm/node/TestDecommissionAndMaintenance.java
@@ -36,10 +36,12 @@ import org.apache.hadoop.hdds.scm.node.NodeStatus;
 import org.apache.hadoop.hdds.scm.pipeline.Pipeline;
 import org.apache.hadoop.hdds.scm.pipeline.PipelineManager;
 import org.apache.hadoop.hdds.scm.server.StorageContainerManager;
+import org.apache.hadoop.hdds.utils.IOUtils;
 import org.apache.hadoop.ozone.MiniOzoneClusterProvider;
 import org.apache.hadoop.ozone.MiniOzoneCluster;
 import org.apache.hadoop.ozone.TestDataUtil;
 import org.apache.hadoop.ozone.client.OzoneBucket;
+import org.apache.hadoop.ozone.client.OzoneClient;
 import org.apache.ozone.test.GenericTestUtils;
 import org.apache.ozone.test.tag.Flaky;
 import org.junit.jupiter.api.AfterEach;
@@ -105,6 +107,7 @@ public class TestDecommissionAndMaintenance {
   private PipelineManager pm;
   private StorageContainerManager scm;
 
+  private OzoneClient ozoneClient;
   private ContainerOperationClient scmClient;
 
   private static MiniOzoneClusterProvider clusterProvider;
@@ -156,12 +159,15 @@ public class TestDecommissionAndMaintenance {
   public void setUp() throws Exception {
     cluster = clusterProvider.provide();
     setManagers();
+    ozoneClient = cluster.getClient();
     bucket = TestDataUtil.createVolumeAndBucket(cluster, volName, bucketName);
     scmClient = new ContainerOperationClient(cluster.getConf());
   }
 
   @AfterEach
   public void tearDown() throws InterruptedException, IOException {
+    IOUtils.close(LOG, ozoneClient);
+    IOUtils.close(LOG, scmClient);
     if (cluster != null) {
       clusterProvider.destroy(cluster);
     }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/scm/pipeline/TestSCMPipelineBytesWrittenMetrics.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/scm/pipeline/TestSCMPipelineBytesWrittenMetrics.java
@@ -78,7 +78,7 @@ public class TestSCMPipelineBytesWrittenMetrics {
         .setNumDatanodes(3)
         .build();
     cluster.waitForClusterToBeReady();
-    client = cluster.getClient();
+    client = cluster.newClient();
   }
 
   private void writeNumBytes(int numBytes) throws Exception {

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/scm/pipeline/TestSCMPipelineBytesWrittenMetrics.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/scm/pipeline/TestSCMPipelineBytesWrittenMetrics.java
@@ -25,10 +25,12 @@ import org.apache.hadoop.hdds.client.ReplicationType;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.scm.pipeline.Pipeline;
 import org.apache.hadoop.hdds.scm.pipeline.SCMPipelineMetrics;
+import org.apache.hadoop.hdds.utils.IOUtils;
 import org.apache.hadoop.metrics2.MetricsRecordBuilder;
 import org.apache.hadoop.ozone.MiniOzoneCluster;
 import org.apache.hadoop.ozone.client.ObjectStore;
 import org.apache.hadoop.ozone.client.OzoneBucket;
+import org.apache.hadoop.ozone.client.OzoneClient;
 import org.apache.hadoop.ozone.client.OzoneClientFactory;
 import org.apache.hadoop.ozone.client.OzoneKeyDetails;
 import org.apache.hadoop.ozone.client.OzoneVolume;
@@ -62,6 +64,7 @@ public class TestSCMPipelineBytesWrittenMetrics {
 
   private MiniOzoneCluster cluster;
   private OzoneConfiguration conf;
+  private OzoneClient client;
 
   @BeforeEach
   public void setup() throws Exception {
@@ -76,10 +79,11 @@ public class TestSCMPipelineBytesWrittenMetrics {
         .setNumDatanodes(3)
         .build();
     cluster.waitForClusterToBeReady();
+    client = cluster.getClient();
   }
 
   private void writeNumBytes(int numBytes) throws Exception {
-    ObjectStore store = OzoneClientFactory.getRpcClient(conf).getObjectStore();
+    ObjectStore store = client.getObjectStore();
 
     String volumeName = UUID.randomUUID().toString();
     String bucketName = UUID.randomUUID().toString();
@@ -137,6 +141,7 @@ public class TestSCMPipelineBytesWrittenMetrics {
 
   @AfterEach
   public void teardown() {
+    IOUtils.closeQuietly(client);
     cluster.shutdown();
   }
 }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/scm/pipeline/TestSCMPipelineBytesWrittenMetrics.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/scm/pipeline/TestSCMPipelineBytesWrittenMetrics.java
@@ -31,7 +31,6 @@ import org.apache.hadoop.ozone.MiniOzoneCluster;
 import org.apache.hadoop.ozone.client.ObjectStore;
 import org.apache.hadoop.ozone.client.OzoneBucket;
 import org.apache.hadoop.ozone.client.OzoneClient;
-import org.apache.hadoop.ozone.client.OzoneClientFactory;
 import org.apache.hadoop.ozone.client.OzoneKeyDetails;
 import org.apache.hadoop.ozone.client.OzoneVolume;
 import org.apache.hadoop.ozone.client.io.OzoneOutputStream;

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/shell/TestNSSummaryAdmin.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/shell/TestNSSummaryAdmin.java
@@ -62,7 +62,7 @@ public class TestNSSummaryAdmin extends StandardOutputTestBase {
     cluster = MiniOzoneCluster.newBuilder(conf)
         .withoutDatanodes().includeRecon(true).build();
     cluster.waitForClusterToBeReady();
-    client = cluster.getClient();
+    client = cluster.newClient();
     store = client.getObjectStore();
 
     // Client uses server conf for this test

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/shell/TestNSSummaryAdmin.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/shell/TestNSSummaryAdmin.java
@@ -18,12 +18,14 @@
 
 package org.apache.hadoop.ozone.shell;
 
+import org.apache.hadoop.hdds.utils.IOUtils;
 import org.apache.hadoop.hdds.cli.OzoneAdmin;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.ozone.MiniOzoneCluster;
 import org.apache.hadoop.ozone.StandardOutputTestBase;
 import org.apache.hadoop.ozone.client.BucketArgs;
 import org.apache.hadoop.ozone.client.ObjectStore;
+import org.apache.hadoop.ozone.client.OzoneClient;
 import org.apache.hadoop.ozone.client.OzoneVolume;
 import org.apache.hadoop.ozone.om.helpers.BucketLayout;
 import org.apache.hadoop.ozone.om.request.OMRequestTestUtils;
@@ -50,6 +52,7 @@ public class TestNSSummaryAdmin extends StandardOutputTestBase {
   private static String volumeName;
   private static String bucketOBS;
   private static String bucketFSO;
+  private static OzoneClient client;
 
   @BeforeClass
   public static void init() throws Exception {
@@ -59,7 +62,8 @@ public class TestNSSummaryAdmin extends StandardOutputTestBase {
     cluster = MiniOzoneCluster.newBuilder(conf)
         .withoutDatanodes().includeRecon(true).build();
     cluster.waitForClusterToBeReady();
-    store = cluster.getClient().getObjectStore();
+    client = cluster.getClient();
+    store = client.getObjectStore();
 
     // Client uses server conf for this test
     ozoneAdmin = new OzoneAdmin(conf);
@@ -72,6 +76,7 @@ public class TestNSSummaryAdmin extends StandardOutputTestBase {
 
   @AfterClass
   public static void shutdown() {
+    IOUtils.closeQuietly(client);
     if (cluster != null) {
       cluster.shutdown();
     }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/shell/TestOzoneShellHA.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/shell/TestOzoneShellHA.java
@@ -165,7 +165,7 @@ public class TestOzoneShellHA {
         .setNumDatanodes(numDNs)
         .build();
     cluster.waitForClusterToBeReady();
-    client = cluster.getClient();
+    client = cluster.newClient();
   }
 
   /**

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/shell/TestOzoneShellHA.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/shell/TestOzoneShellHA.java
@@ -28,6 +28,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.UUID;
 
+import org.apache.hadoop.hdds.utils.IOUtils;
 import org.apache.hadoop.fs.FileChecksum;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
@@ -44,6 +45,7 @@ import org.apache.hadoop.ozone.MiniOzoneCluster;
 import org.apache.hadoop.ozone.MiniOzoneHAClusterImpl;
 import org.apache.hadoop.ozone.client.ObjectStore;
 import org.apache.hadoop.ozone.client.OzoneBucket;
+import org.apache.hadoop.ozone.client.OzoneClient;
 import org.apache.hadoop.ozone.client.OzoneKeyDetails;
 import org.apache.hadoop.ozone.client.OzoneVolume;
 import org.apache.hadoop.ozone.client.io.ECKeyOutputStream;
@@ -111,6 +113,7 @@ public class TestOzoneShellHA {
   private static File testFile;
   private static String testFilePathString;
   private static MiniOzoneCluster cluster = null;
+  private static OzoneClient client;
   private OzoneShell ozoneShell = null;
   private OzoneAdmin ozoneAdminShell = null;
   private S3Shell s3Shell = null;
@@ -162,6 +165,7 @@ public class TestOzoneShellHA {
         .setNumDatanodes(numDNs)
         .build();
     cluster.waitForClusterToBeReady();
+    client = cluster.getClient();
   }
 
   /**
@@ -169,6 +173,7 @@ public class TestOzoneShellHA {
    */
   @AfterClass
   public static void shutdown() {
+    IOUtils.closeQuietly(client);
     if (cluster != null) {
       cluster.shutdown();
     }
@@ -730,7 +735,7 @@ public class TestOzoneShellHA {
   @Test
   @SuppressWarnings("methodlength")
   public void testShQuota() throws Exception {
-    ObjectStore objectStore = cluster.getClient().getObjectStore();
+    ObjectStore objectStore = client.getObjectStore();
 
     // Test create with no quota
     String[] args = new String[]{"volume", "create", "vol"};
@@ -958,7 +963,7 @@ public class TestOzoneShellHA {
     execute(ozoneShell, args);
 
     OzoneVolume volume =
-        cluster.getClient().getObjectStore().getVolume(volumeName);
+        client.getObjectStore().getVolume(volumeName);
     OzoneBucket bucket = volume.getBucket("bucket0");
     try (OzoneOutputStream out = bucket.createKey("myKey", 2000)) {
       Assert.assertTrue(out.getOutputStream() instanceof ECKeyOutputStream);
@@ -983,7 +988,7 @@ public class TestOzoneShellHA {
     execute(ozoneShell, args);
 
     OzoneKeyDetails key =
-        cluster.getClient().getObjectStore().getVolume(volumeName)
+        client.getObjectStore().getVolume(volumeName)
             .getBucket(bucketName).getKey(keyName);
     assertEquals(HddsProtos.ReplicationType.EC,
         key.getReplicationConfig().getReplicationType());
@@ -999,7 +1004,7 @@ public class TestOzoneShellHA {
     execute(ozoneShell, args);
 
     OzoneVolume volume =
-        cluster.getClient().getObjectStore().getVolume(volumeName);
+        client.getObjectStore().getVolume(volumeName);
     OzoneBucket bucket = volume.getBucket("bucket1");
     try (OzoneOutputStream out = bucket.createKey("myKey", 2000)) {
       Assert.assertTrue(out.getOutputStream() instanceof KeyOutputStream);
@@ -1016,7 +1021,7 @@ public class TestOzoneShellHA {
     execute(ozoneShell, args);
 
     OzoneVolume volume =
-        cluster.getClient().getObjectStore().getVolume(volumeName);
+        client.getObjectStore().getVolume(volumeName);
     OzoneBucket bucket = volume.getBucket("bucket0");
     try (OzoneOutputStream out = bucket.createKey("myNonECKey", 1024)) {
       Assert.assertFalse(out.getOutputStream().getClass().getName()


### PR DESCRIPTION
## What changes were proposed in this pull request?

Update lots of integration tests to properly close `OzoneClient`, `OzoneInputStream`, `ScmClient`, `XceiverClient*` after use.

https://issues.apache.org/jira/browse/HDDS-7958

## How was this patch tested?

Ran integration tests, checked for `ManagedChannelImpl ... was not shutdown` reports.

https://github.com/adoroszlai/hadoop-ozone/actions/runs/4379443303