### PR TITLE
HDDS-8091. [addendum] Generate list of config tags from ConfigTag enum - Hadoop 3.1 compatibility fix

### DIFF
--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/conf/HddsConfServlet.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/conf/HddsConfServlet.java
@@ -34,7 +34,6 @@ import org.apache.hadoop.http.HttpServer2;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.gson.Gson;
-import static org.apache.hadoop.hdds.conf.OzoneConfiguration.OZONE_TAGS_SYSTEM_KEY;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -157,8 +156,7 @@ public class HddsConfServlet extends HttpServlet {
 
     switch (cmd) {
     case "getOzoneTags":
-      out.write(gson.toJson(config.get(OZONE_TAGS_SYSTEM_KEY)
-          .split(",")));
+      out.write(gson.toJson(OzoneConfiguration.TAGS));
       break;
     case "getPropertyByTag":
       String tags = request.getParameter("tags");


### PR DESCRIPTION
## What changes were proposed in this pull request?

Make the implementation of HDDS-8091 (#4359) compatible with Hadoop 3.1.  Both `addTags(Properties)` and `HADOOP_TAGS_CUSTOM` were only introduced in Hadoop 3.2.

https://issues.apache.org/jira/browse/HDDS-8091

## How was this patch tested?

Verified SCM web UI still can be used to browse Ozone config by tags.