### PR TITLE
HDDS-8058. Gracefully handle invalid S3 authorization header.

### DIFF
--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/security/AWSV4AuthValidator.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/security/AWSV4AuthValidator.java
@@ -41,10 +41,10 @@ final class AWSV4AuthValidator {
       LoggerFactory.getLogger(AWSV4AuthValidator.class);
   private static final String HMAC_SHA256_ALGORITHM = "HmacSHA256";
   private static final Pattern STR_TO_SIGN_PATTERN =
-          Pattern.compile("^AWS4[A-Z\\-\\d]+\n" +
+          Pattern.compile("^AWS4-HMAC-SHA256\n" +
                   "\\d{8}T\\d{6}Z\n" +
-                  "\\d{8}/[a-z\\-\\d]+/[a-zA-Z\\d]+/aws4_request\n" +
-                  "[a-fA-F\\d]+$");
+                  "\\d{8}/[a-z\\-\\d]+/[a-z\\d]+/aws4_request\n" +
+                  "[a-fA-F\\d]{64}$");
 
   private AWSV4AuthValidator() {
   }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/security/AWSV4AuthValidator.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/security/AWSV4AuthValidator.java
@@ -41,9 +41,9 @@ final class AWSV4AuthValidator {
       LoggerFactory.getLogger(AWSV4AuthValidator.class);
   private static final String HMAC_SHA256_ALGORITHM = "HmacSHA256";
   private static final Pattern STR_TO_SIGN_PATTERN =
-          Pattern.compile("^AWS4-HMAC-SHA256\n"+
-                  "\\d{8}T\\d{6}Z\n"+
-                  "\\d{8}/[a-z\\-\\d]+/[a-zA-Z0-9]+/aws4_request\n"+
+          Pattern.compile("^AWS4-HMAC-SHA256\n" +
+                  "\\d{8}T\\d{6}Z\n" +
+                  "\\d{8}/[a-z\\-\\d]+/[a-zA-Z0-9]+/aws4_request\n" +
                   "[a-fA-F0-9]+$");
 
   private AWSV4AuthValidator() {
@@ -69,7 +69,7 @@ final class AWSV4AuthValidator {
    * /general/latest/gr/create-signed-request.html#create-string-to-sign
    *
    * */
-  private static boolean validateStrToSign(String strToSign){
+  private static boolean validateStrToSign(String strToSign) {
     return STR_TO_SIGN_PATTERN.matcher(strToSign).find();
   }
 
@@ -124,7 +124,7 @@ final class AWSV4AuthValidator {
    */
   public static boolean validateRequest(String strToSign, String signature,
       String userKey) {
-    if(!validateStrToSign(strToSign)) {
+    if (!validateStrToSign(strToSign)) {
       return false;
     }
     String expectedSignature = Hex.encode(sign(getSigningKey(userKey,

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/security/AWSV4AuthValidator.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/security/AWSV4AuthValidator.java
@@ -41,10 +41,10 @@ final class AWSV4AuthValidator {
       LoggerFactory.getLogger(AWSV4AuthValidator.class);
   private static final String HMAC_SHA256_ALGORITHM = "HmacSHA256";
   private static final Pattern STR_TO_SIGN_PATTERN =
-          Pattern.compile("^AWS4-HMAC-SHA256\n" +
+          Pattern.compile("^AWS4[A-Z\\-\\d]+\n" +
                   "\\d{8}T\\d{6}Z\n" +
-                  "\\d{8}/[a-z\\-\\d]+/[a-zA-Z0-9]+/aws4_request\n" +
-                  "[a-fA-F0-9]+$");
+                  "\\d{8}/[a-z\\-\\d]+/[a-zA-Z\\d]+/aws4_request\n" +
+                  "[a-fA-F\\d]+$");
 
   private AWSV4AuthValidator() {
   }

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/security/TestAWSV4AuthValidator.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/security/TestAWSV4AuthValidator.java
@@ -70,6 +70,55 @@ public class TestAWSV4AuthValidator {
             "wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY",
             true
         },
+        // Invalid Algorithm
+        {
+            "AWS4-ZAVC-HJUA123\n" +
+                "20150830T123600Z\n" +
+                "20150830/us-east-1/iam/aws4_request\n" +
+                "f536975d06c0309214f805bb90ccff089219ecd68b2" +
+                "577efef23edd43b7e1a59",
+            "5d672d79c15b13162d9279b0855cfba" +
+                "6789a8edb4c82c400e06b5924a6f2b5d7",
+            "wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY",
+            false
+        },
+        // Invalid timestamp or non-ISO timestamp format
+        {
+            "AWS4-HMAC-SHA256\n" +
+                "Thu, 21 Feb 2019 00:20:37 -0800\n" +
+                "20190221/us-west-1/s3/aws4_request\n" +
+                "c297c080cce4e0927779823d3fd1f5cae71481a8f7dfc7e18d" +
+                "91851294efc47d",
+            "56ec73ba1974f8feda8365c3caef89c5d4a688d5f9baccf" +
+                "4765f46a14cd745ad",
+            "dbaksbzljandlkandlsd",
+            false
+        },
+        // Invalid scope. Uppercase letters in AWS service.
+        {
+            "AWS4-HMAC-SHA256\n" +
+                "20190221T002037Z\n" +
+                "20190221/us-west-1/S3/aws4_request\n" +
+                "c297c080cce4e0927779823d3fd1f5cae71481a8f7dfc7e18d" +
+                "91851294efc47d",
+            "56ec73ba1974f8feda8365c3caef89c5d4a688d5f9baccf" +
+                "4765f46a14cd745ad",
+            "dbaksbzljandlkandlsd",
+            false
+        },
+        // Invalid hex of canonical request. Less than 64 hex characters.
+        {
+            "AWS4-HMAC-SHA256\n" +
+                "20190221T002037Z\n" +
+                "20190221/us-west-1/s3/aws4_request\n" +
+                "c297c080cce4e0927779823d3fd1f5cae71481a8f7dfc7e18d" +
+                "91851294efc47d",
+            "56ec73ba1974f8feda8365c3caef89c5d4a688d5f9baccf" +
+                "4765f46a14cd745a",
+            "dbaksbzljandlkandlsd",
+            false
+        },
+        // AWS V2 request
         {
             "PUT\n" +
                 "\n" +

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/security/TestAWSV4AuthValidator.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/security/TestAWSV4AuthValidator.java
@@ -24,7 +24,7 @@ import org.junit.runners.Parameterized;
 import java.util.Arrays;
 import java.util.Collection;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertEquals;
 
 /**
  * Test for {@link AWSV4AuthValidator}.
@@ -35,12 +35,14 @@ public class TestAWSV4AuthValidator {
   private String strToSign;
   private String signature;
   private String awsAccessKey;
+  private Boolean result;
 
   public TestAWSV4AuthValidator(String strToSign, String signature,
-      String awsAccessKey) {
+      String awsAccessKey, Boolean result) {
     this.strToSign = strToSign;
     this.signature = signature;
     this.awsAccessKey = awsAccessKey;
+    this.result = result;
   }
 
   @Parameterized.Parameters
@@ -54,7 +56,8 @@ public class TestAWSV4AuthValidator {
                 "91851294efc47d",
             "56ec73ba1974f8feda8365c3caef89c5d4a688d5f9baccf" +
                 "4765f46a14cd745ad",
-            "dbaksbzljandlkandlsd"
+            "dbaksbzljandlkandlsd",
+            true
         },
         {
             "AWS4-HMAC-SHA256\n" +
@@ -64,15 +67,25 @@ public class TestAWSV4AuthValidator {
                 "577efef23edd43b7e1a59",
             "5d672d79c15b13162d9279b0855cfba" +
                 "6789a8edb4c82c400e06b5924a6f2b5d7",
-            "wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY"
+            "wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY",
+            true
+        },
+        {
+            "PUT\n" +
+                "\n" +
+                "application/octet-stream\n" +
+                "Thu, 09 Mar 2023 18:57:26 -0800\n" +
+                "/bucket1/1.txt",
+            "CevEya+7yP3B0zqYoyTz2aVDuP0=",
+            "wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY",
+            false
         }
-
     });
   }
 
   @Test
   public void testValidateRequest() {
-    assertTrue(AWSV4AuthValidator.validateRequest(strToSign, signature,
-        awsAccessKey));
+    assertEquals(result, AWSV4AuthValidator.validateRequest(
+            strToSign, signature, awsAccessKey));
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Added a check in AWSV4AuthValidator.java to ensure that the String to Sign conforms to the AWS V4 format. 
If the authorization header is invalid or conforms to an older version an error would be thrown.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-8058

## How was this patch tested?

Added a test in TestAWSV4AuthValidator.java
Also, Manually tested submitting S3 requests with AWS V4 and V2 headers in ozonesecure dev docker. See attached files for signature calculations.
V2 header : 
```
sh-4.2$ strToSign="PUT\n\n${content_type}\n${date}\n${resource}"
sh-4.2$ echo -en ${strToSign}
PUT

application/octet-stream
Fri, 10 Mar 2023 03:46:36 +0000
/bucket1/1.txt

sh-4.2$ signature=`echo -en ${strToSign} | openssl sha1 -hmac ${s3_secret} -binary | base64`
sh-4.2$ echo ${signature}
qadnu2/QbXgLIH7Z8G0Rs+rzDvA=

sh-4.2$ curl -X PUT -T "${file}" -H "Host: ${host}" -H "Date: ${date}" -H "Content-Type: ${content_type}" -H "Authorization: AWS ${s3_key}:${signature}" -w "%{http_code}" http://${host}:9878${resource}
<?xml version="1.0" encoding="UTF-8"?>
<Error>
  <Code>AccessDenied</Code>
  <Message>User doesn't have the right to access this resource.</Message>
  <Resource>1.txt</Resource>
  <RequestId>1c5e00c6-5aa1-4376-93a6-b82bc6f438ba</RequestId>
</Error>
403
```

V4 header : 
```
...
sh-4.2$ HTTP_CANONICAL_REQUEST="PUT
${HTTP_CANONICAL_REQUEST_URI}\n
${HTTP_CANONICAL_REQUEST_HEADERS}\n
${HTTP_REQUEST_SIGNED_HEADERS}
${HTTP_REQUEST_PAYLOAD_HASH}"

sh-4.2$ echo -en $HTTP_CANONICAL_REQUEST
PUT
/bucket1/1.txt

content-type:application/octet-stream
host::9878
x-amz-content-sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
x-amz-date:20230310T205249Z

content-type;host;x-amz-content-sha256;x-amz-date
e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855

sh-4.2$ stringToSign="AWS4-HMAC-SHA256\n${CURRENT_DATE_ISO8601}\n${CURRENT_DATE_DAY}/${AWS_REGION}/${AWS_SERVICE}/aws4_request\n$(hash_sha256 "${HTTP_CANONICAL_REQUEST}")"
sh-4.2$ echo $stringToSign
AWS4-HMAC-SHA256
20230310T205249Z
20230310/us-east-1/s3/aws4_request
34eab1496779bd03ed30a25f1a186c9b0af029f998f8a3ec12eb3872d3e831cd

...
sh-4.2$ # Create the signature.
sh-4.2$ function create_signature {
  stringToSign="AWS4-HMAC-SHA256\n${CURRENT_DATE_ISO8601}\n${CURRENT_DATE_DAY}/${AWS_REGION}/${AWS_SERVICE}/aws4_request\n$(hash_sha256 "${HTTP_CANONICAL_REQUEST}")"
  dateKey=$(hmac_sha256 key:"AWS4${AWS_SECRET_ACCESS_KEY}" "${CURRENT_DATE_DAY}")
  regionKey=$(hmac_sha256 hexkey:"${dateKey}" "${AWS_REGION}")
  serviceKey=$(hmac_sha256 hexkey:"${regionKey}" "${AWS_SERVICE}")
  signingKey=$(hmac_sha256 hexkey:"${serviceKey}" "aws4_request")
  
  printf "${stringToSign}" | openssl dgst -sha256 -mac HMAC -macopt hexkey:"${signingKey}" | sed 's/(stdin)= //'
}

sh-4.2$ SIGNATURE="$(create_signature)"
sh-4.2$ echo $SIGNATURE 
5e9f39c0fea0b6d5a9dad4f7ee900d0367491993f6047ffe485bc9750bb2ff25

sh-4.2$ HTTP_REQUEST_AUTHORIZATION_HEADER="\
AWS4-HMAC-SHA256 Credential=${AWS_ACCESS_KEY_ID}/${CURRENT_DATE_DAY}/\
${AWS_REGION}/${AWS_SERVICE}/aws4_request, \
SignedHeaders=${HTTP_REQUEST_SIGNED_HEADERS}, Signature=${SIGNATURE}"

sh-4.2$ IN_FILE=./1.txt

sh-4.2$ curl "http://${host}:9878${HTTP_CANONICAL_REQUEST_URI}" \
-H "Authorization: ${HTTP_REQUEST_AUTHORIZATION_HEADER}" \
-H "content-type: ${HTTP_REQUEST_CONTENT_TYPE}" \
-H "x-amz-content-sha256: ${HTTP_REQUEST_PAYLOAD_HASH}" \
-H "x-amz-date: ${CURRENT_DATE_ISO8601}" \
-T ${IN_FILE}

sh-4.2$ ozone fs -ls ofs://om/s3v/bucket1/
Found 2 items
drwxrwxrwx   - om om          0 2023-03-10 21:09 ofs://om/s3v/bucket1/.Trash
-rw-rw-rw-   3 om om         14 2023-03-10 21:11 ofs://om/s3v/bucket1/1.txt
```
<img width="1278" alt="Om_error_for_aws_v2" src="https://user-images.githubusercontent.com/10888329/224435770-33c0007c-b4ae-45da-82d4-2e6861ccd0ce.png">
[aws_v2_sign_calc.txt](https://github.com/apache/ozone/files/10946447/aws_v2_sign_calc.txt)
[aws_v4_sign_calc.txt](https://github.com/apache/ozone/files/10946448/aws_v4_sign_calc.txt)

