### PR TITLE
HDDS-8134. Certificate clients are not correctly closed.

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/HddsDatanodeService.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/HddsDatanodeService.java
@@ -355,6 +355,7 @@ public class HddsDatanodeService extends GenericCli implements ServicePlugin {
 
     CertificateClient.InitResponse response = certClient.init();
     if (response.equals(CertificateClient.InitResponse.REINIT)) {
+      certClient.close();
       LOG.info("Re-initialize certificate client.");
       certClient = new DNCertificateClient(secConf, datanodeDetails, null,
           this::saveNewCertId, this::terminateDatanode);

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/HddsDatanodeService.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/HddsDatanodeService.java
@@ -583,7 +583,11 @@ public class HddsDatanodeService extends GenericCli implements ServicePlugin {
   }
 
   @VisibleForTesting
-  public void setCertificateClient(CertificateClient client) {
+  public void setCertificateClient(CertificateClient client)
+      throws IOException {
+    if (dnCertClient != null) {
+      dnCertClient.close();
+    }
     dnCertClient = client;
   }
 

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/TestHddsSecureDatanodeInit.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/TestHddsSecureDatanodeInit.java
@@ -274,7 +274,6 @@ public class TestHddsSecureDatanodeInit {
   }
 
   @Test
-  @Disabled("HDDS-7874")
   public void testCertificateRotation() throws Exception {
     // save the certificate on dn
     certCodec.writeCertificate(certHolder);

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/TestHddsSecureDatanodeInit.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/TestHddsSecureDatanodeInit.java
@@ -60,7 +60,6 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 /**

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/TestHddsSecureDatanodeInit.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/TestHddsSecureDatanodeInit.java
@@ -17,6 +17,7 @@
 package org.apache.hadoop.ozone;
 
 import java.io.File;
+import java.io.IOException;
 import java.nio.file.Paths;
 import java.security.KeyPair;
 import java.security.PrivateKey;
@@ -57,6 +58,7 @@ import static org.mockito.Mockito.when;
 import org.bouncycastle.cert.X509CertificateHolder;
 import org.junit.Assert;
 import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.BeforeAll;
@@ -141,6 +143,11 @@ public class TestHddsSecureDatanodeInit {
     client = new DNCertificateClient(securityConfig, datanodeDetails,
         certHolder.getSerialNumber().toString(), null, null);
     service.setCertificateClient(client);
+  }
+
+  @AfterEach
+  public void tearDownClient() throws IOException {
+    client.close();
   }
 
   @Test

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/TestHddsSecureDatanodeInit.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/TestHddsSecureDatanodeInit.java
@@ -356,7 +356,6 @@ public class TestHddsSecureDatanodeInit {
    * Test unexpected SCMGetCertResponseProto returned from SCM.
    */
   @Test
-  @Disabled("HDDS-7874")
   public void testCertificateRotationRecoverableFailure() throws Exception {
     // save the certificate on dn
     certCodec.writeCertificate(certHolder);

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/TestHddsSecureDatanodeInit.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/TestHddsSecureDatanodeInit.java
@@ -128,7 +128,7 @@ public class TestHddsSecureDatanodeInit {
   }
 
   @BeforeEach
-  public void setUpDNCertClient() {
+  public void setUpDNCertClient() throws IOException {
 
     FileUtils.deleteQuietly(Paths.get(
         securityConfig.getKeyLocation(DN_COMPONENT).toString(),

--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/security/token/TestOzoneBlockTokenSecretManager.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/security/token/TestOzoneBlockTokenSecretManager.java
@@ -134,8 +134,9 @@ public class TestOzoneBlockTokenSecretManager {
   }
 
   @After
-  public void tearDown() {
+  public void tearDown() throws IOException {
     secretManager = null;
+    client.close();
   }
 
   @Test

--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/security/x509/certificate/client/TestDefaultCertificateClient.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/security/x509/certificate/client/TestDefaultCertificateClient.java
@@ -29,7 +29,6 @@ import org.apache.hadoop.hdds.security.x509.exception.CertificateException;
 import org.apache.hadoop.hdds.security.x509.keys.KeyCodec;
 import org.bouncycastle.cert.X509CertificateHolder;
 import org.bouncycastle.pkcs.PKCS10CertificationRequest;
-import org.junit.Assert;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -45,9 +44,11 @@ import java.security.PublicKey;
 import java.security.Signature;
 import java.security.cert.X509Certificate;
 import java.time.Duration;
+import java.util.Arrays;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.UUID;
+import java.util.function.Predicate;
 
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.RandomStringUtils;
@@ -59,6 +60,7 @@ import org.apache.hadoop.hdds.security.x509.keys.HDDSKeyGenerator;
 import org.apache.hadoop.security.ssl.KeyStoreTestUtil;
 import org.apache.ozone.test.GenericTestUtils;
 import org.apache.ozone.test.LambdaTestUtils;
+import org.junit.jupiter.api.io.TempDir;
 import org.slf4j.Logger;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
@@ -68,12 +70,15 @@ import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_NAMES;
 import static org.apache.hadoop.hdds.security.x509.certificate.client.CertificateClient.InitResponse.FAILURE;
 import static org.apache.hadoop.hdds.security.x509.certificate.client.CertificateClient.InitResponse.REINIT;
 import static org.apache.hadoop.hdds.security.x509.certificate.utils.CertificateCodec.getPEMEncodedString;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.ArgumentMatchers.anyObject;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.mock;
@@ -436,11 +441,10 @@ public class TestDefaultCertificateClient {
 
           @Override
           public String signAndStoreCertificate(
-              PKCS10CertificationRequest request, Path certificatePath)
-              throws CertificateException {
+              PKCS10CertificationRequest request, Path certificatePath) {
             return null;
           }
-        };) {
+        }) {
 
       InitResponse resp = client.init();
       verify(mockLogger, atLeastOnce()).info(anyString());
@@ -459,7 +463,7 @@ public class TestDefaultCertificateClient {
     dnCertClient.storeCertificate(
         getPEMEncodedString(cert), CAType.SUBORDINATE);
     Duration duration = dnCertClient.timeBeforeExpiryGracePeriod(cert);
-    Assert.assertTrue(duration.isZero());
+    assertTrue(duration.isZero());
 
     cert = KeyStoreTestUtil.generateCertificate("CN=Test",
         keyPair, (int) (gracePeriod.toDays() + 1),
@@ -467,7 +471,7 @@ public class TestDefaultCertificateClient {
     dnCertClient.storeCertificate(
         getPEMEncodedString(cert), CAType.SUBORDINATE);
     duration = dnCertClient.timeBeforeExpiryGracePeriod(cert);
-    Assert.assertTrue(duration.toMillis() < Duration.ofDays(1).toMillis() &&
+    assertTrue(duration.toMillis() < Duration.ofDays(1).toMillis() &&
         duration.toMillis() > Duration.ofHours(23).plusMinutes(59).toMillis());
   }
 
@@ -491,15 +495,15 @@ public class TestDefaultCertificateClient {
             .setX509Certificate(pemCert)
             .setX509CACertificate(pemCert)
             .build();
-    when(scmClient.getDataNodeCertificateChain(anyObject(), anyString()))
+    when(scmClient.getDataNodeCertificateChain(any(), anyString()))
         .thenReturn(responseProto);
 
     String certID = dnCertClient.getCertificate().getSerialNumber().toString();
     // a success renew
     String newCertId = dnCertClient.renewAndStoreKeyAndCertificate(true);
-    Assert.assertFalse(certID.equals(newCertId));
-    Assert.assertTrue(dnCertClient.getCertificate().getSerialNumber()
-        .toString().equals(certID));
+    assertNotEquals(certID, newCertId);
+    assertEquals(dnCertClient.getCertificate().getSerialNumber()
+        .toString(), certID);
 
     File newKeyDir = new File(dnSecurityConfig.getKeyLocation(
         dnCertClient.getComponentName()).toString() +
@@ -515,11 +519,11 @@ public class TestDefaultCertificateClient {
             HddsConfigKeys.HDDS_BACKUP_KEY_CERT_DIR_NAME_SUFFIX);
 
     // backup directories exist
-    Assert.assertTrue(backupKeyDir.exists());
-    Assert.assertTrue(backupCertDir.exists());
+    assertTrue(backupKeyDir.exists());
+    assertTrue(backupCertDir.exists());
     // new directories should not exist
-    Assert.assertFalse(newKeyDir.exists());
-    Assert.assertFalse(newCertDir.exists());
+    assertFalse(newKeyDir.exists());
+    assertFalse(newCertDir.exists());
 
     // cleanup backup key and cert dir
     dnCertClient.cleanBackupDir();
@@ -539,5 +543,54 @@ public class TestDefaultCertificateClient {
         certCodec, false);
     // a success renew after auto cleanup new key and cert dir
     dnCertClient.renewAndStoreKeyAndCertificate(true);
+  }
+
+  @Test
+  public void testCloseCertificateClient(@TempDir File metaDir)
+      throws Exception {
+    OzoneConfiguration ozoneConf = new OzoneConfiguration();
+    ozoneConf.set(HDDS_METADATA_DIR_NAME, metaDir.getPath());
+    SecurityConfig conf = new SecurityConfig(ozoneConf);
+    String compName = "test";
+
+    CertificateCodec certCodec = new CertificateCodec(conf, compName);
+    X509Certificate cert = generateX509Cert(null);
+    certCodec.writeCertificate(new X509CertificateHolder(cert.getEncoded()));
+
+    Logger logger = mock(Logger.class);
+    String certId = cert.getSerialNumber().toString();
+    DefaultCertificateClient client = new DefaultCertificateClient(
+        conf, logger, certId, compName, null, null
+    ) {
+
+      @Override
+      protected String signAndStoreCertificate(
+          PKCS10CertificationRequest request, Path certificatePath) {
+        return "";
+      }
+    };
+
+    Thread[] threads = new Thread[Thread.activeCount()];
+    Thread.enumerate(threads);
+    Predicate<Thread> monitorFilterPredicate =
+        t -> t != null
+            && t.getName().equals(compName + "-CertificateLifetimeMonitor");
+    long monitorThreadCount = Arrays.stream(threads)
+        .filter(monitorFilterPredicate)
+        .count();
+    assertThat(monitorThreadCount, is(1L));
+    Thread monitor = Arrays.stream(threads)
+        .filter(monitorFilterPredicate)
+        .findFirst()
+        .get(); // we should have one otherwise prev assertion fails.
+
+    client.close();
+    monitor.join();
+
+    threads = new Thread[Thread.activeCount()];
+    monitorThreadCount = Arrays.stream(threads)
+        .filter(monitorFilterPredicate)
+        .count();
+    assertThat(monitorThreadCount, is(0L));
   }
 }

--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/security/x509/certificate/client/TestDefaultCertificateClient.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/security/x509/certificate/client/TestDefaultCertificateClient.java
@@ -125,7 +125,8 @@ public class TestDefaultCertificateClient {
   }
 
   @AfterEach
-  public void tearDown() {
+  public void tearDown() throws IOException {
+    dnCertClient.close();
     dnCertClient = null;
     FileUtils.deleteQuietly(dnMetaDirPath.toFile());
   }

--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/security/x509/certificate/client/TestDefaultCertificateClient.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/security/x509/certificate/client/TestDefaultCertificateClient.java
@@ -545,6 +545,20 @@ public class TestDefaultCertificateClient {
     dnCertClient.renewAndStoreKeyAndCertificate(true);
   }
 
+  /**
+   * This test aims to test the side effects of having an executor in the
+   * background that renews the component certificate if needed.
+   * During close, we need to shut down this executor in order to ensure that
+   * there are no racing threads that are renewing the same set of certificates.
+   *
+   * The test checks if at instantiation the thread is created and there
+   * is only one thread that are being created, while it also checks that after
+   * close the thread is closed, and is not there anymore.
+   *
+   * @param metaDir the temporary folder for metadata persistence.
+   *
+   * @throws Exception in case an unexpected error happens.
+   */
   @Test
   public void testCloseCertificateClient(@TempDir File metaDir)
       throws Exception {

--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/security/x509/certificate/client/TestDnCertificateClientInit.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/security/x509/certificate/client/TestDnCertificateClientInit.java
@@ -34,6 +34,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
+import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -99,7 +100,8 @@ public class TestDnCertificateClientInit {
   }
 
   @AfterEach
-  public void tearDown() {
+  public void tearDown() throws IOException {
+    dnCertificateClient.close();
     dnCertificateClient = null;
     FileUtils.deleteQuietly(metaDirPath.toFile());
   }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/StorageContainerManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/StorageContainerManager.java
@@ -904,7 +904,11 @@ public final class StorageContainerManager extends ServiceRuntimeInfoImpl
   }
 
   @VisibleForTesting
-  public void setScmCertificateClient(CertificateClient client) {
+  public void setScmCertificateClient(CertificateClient client)
+      throws IOException {
+    if (scmCertificateClient != null) {
+      scmCertificateClient.close();
+    }
     scmCertificateClient = client;
   }
 
@@ -1646,6 +1650,14 @@ public final class StorageContainerManager extends ServiceRuntimeInfoImpl
     scmSafeModeManager.stop();
     serviceManager.stop();
     RatisDropwizardExports.clear(ratisMetricsMap, ratisReporterList);
+
+    if (scmCertificateClient != null) {
+      try {
+        scmCertificateClient.close();
+      } catch (IOException ioe) {
+        LOG.error("Closing certificate client failed", ioe);
+      }
+    }
 
     try {
       LOG.info("Stopping SCM MetadataStore.");

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/MiniOzoneClusterImpl.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/MiniOzoneClusterImpl.java
@@ -489,7 +489,11 @@ public class MiniOzoneClusterImpl implements MiniOzoneCluster {
   @Override
   public void startHddsDatanodes() {
     hddsDatanodes.forEach((datanode) -> {
-      datanode.setCertificateClient(getCAClient());
+      try {
+        datanode.setCertificateClient(getCAClient());
+      } catch (IOException e) {
+        LOG.error("Exception while setting certificate client to DataNode.", e);
+      }
       datanode.start();
     });
   }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/server/TestContainerServer.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/server/TestContainerServer.java
@@ -66,6 +66,7 @@ import org.apache.ratis.rpc.RpcType;
 import static org.apache.ratis.rpc.SupportedRpcType.GRPC;
 import org.apache.ratis.util.function.CheckedBiConsumer;
 import org.junit.Assert;
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.apache.ozone.test.tag.Slow;
 import org.junit.jupiter.api.Disabled;
@@ -89,6 +90,11 @@ public class TestContainerServer {
     CONF.set(HddsConfigKeys.HDDS_METADATA_DIR_NAME, TEST_DIR);
     caClient = new DNCertificateClient(new SecurityConfig(CONF),
         null, null, null, null);
+  }
+
+  @AfterAll
+  public static void tearDown() throws Exception {
+    caClient.close();
   }
 
   @Test

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestSecureOzoneManager.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestSecureOzoneManager.java
@@ -129,6 +129,7 @@ public class TestSecureOzoneManager {
     Assert.assertNotNull(client.getPrivateKey());
     Assert.assertNotNull(client.getPublicKey());
     Assert.assertNull(client.getCertificate());
+    client.close();
 
     // Case 2: If key pair already exist than response should be RECOVER.
     client =
@@ -137,6 +138,7 @@ public class TestSecureOzoneManager {
     Assert.assertNotNull(client.getPrivateKey());
     Assert.assertNotNull(client.getPublicKey());
     Assert.assertNull(client.getCertificate());
+    client.close();
 
     // Case 3: When public key as well as certificate is missing.
     client =
@@ -147,6 +149,7 @@ public class TestSecureOzoneManager {
     Assert.assertNotNull(client.getPrivateKey());
     Assert.assertNull(client.getPublicKey());
     Assert.assertNull(client.getCertificate());
+    client.close();
 
     // Case 4: When private key and certificate is missing.
     client =
@@ -159,6 +162,7 @@ public class TestSecureOzoneManager {
     Assert.assertNull(client.getPrivateKey());
     Assert.assertNotNull(client.getPublicKey());
     Assert.assertNull(client.getCertificate());
+    client.close();
 
     // Case 5: When only certificate is present.
     FileUtils.deleteQuietly(Paths.get(securityConfig.getKeyLocation(COMPONENT)
@@ -177,6 +181,7 @@ public class TestSecureOzoneManager {
     Assert.assertNull(client.getPrivateKey());
     Assert.assertNull(client.getPublicKey());
     Assert.assertNotNull(client.getCertificate());
+    client.close();
 
     // Case 6: When private key and certificate is present.
     client =
@@ -188,6 +193,7 @@ public class TestSecureOzoneManager {
     Assert.assertNotNull(client.getPrivateKey());
     Assert.assertNotNull(client.getPublicKey());
     Assert.assertNotNull(client.getCertificate());
+    client.close();
 
     // Case 7 When keypair and certificate is present.
     client =
@@ -196,6 +202,7 @@ public class TestSecureOzoneManager {
     Assert.assertNotNull(client.getPrivateKey());
     Assert.assertNotNull(client.getPublicKey());
     Assert.assertNotNull(client.getCertificate());
+    client.close();
   }
 
   /**

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
@@ -1063,8 +1063,11 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
    * For testing purpose only.
    */
   @VisibleForTesting
-  public void setCertClient(CertificateClient certClient) {
+  public void setCertClient(CertificateClient certClient) throws IOException {
     // TODO: Initialize it in constructor with implementation for certClient.
+    if (certClient != null) {
+      certClient.close();
+    }
     this.certClient = certClient;
   }
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
@@ -1066,7 +1066,7 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
   public void setCertClient(CertificateClient certClient) throws IOException {
     // TODO: Initialize it in constructor with implementation for certClient.
     if (certClient != null) {
-      certClient.close();
+      this.certClient.close();
     }
     this.certClient = certClient;
   }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
@@ -1063,12 +1063,11 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
    * For testing purpose only.
    */
   @VisibleForTesting
-  public void setCertClient(CertificateClient certClient) throws IOException {
-    // TODO: Initialize it in constructor with implementation for certClient.
+  public void setCertClient(CertificateClient newClient) throws IOException {
     if (certClient != null) {
-      this.certClient.close();
+      certClient.close();
     }
-    this.certClient = certClient;
+    certClient = newClient;
   }
 
   /**

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/ratis/TestOzoneManagerRatisServer.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/ratis/TestOzoneManagerRatisServer.java
@@ -18,6 +18,7 @@
 
 package org.apache.hadoop.ozone.om.ratis;
 
+import java.io.IOException;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.nio.file.Path;
@@ -135,10 +136,11 @@ public class TestOzoneManagerRatisServer {
   }
 
   @After
-  public void shutdown() {
+  public void shutdown() throws IOException {
     if (omRatisServer != null) {
       omRatisServer.stop();
     }
+    certClient.close();
   }
 
   /**

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/security/TestOmCertificateClientInit.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/security/TestOmCertificateClientInit.java
@@ -36,6 +36,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
+import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -108,7 +109,8 @@ public class TestOmCertificateClientInit {
   }
 
   @AfterEach
-  public void tearDown() {
+  public void tearDown() throws IOException {
+    omCertificateClient.close();
     omCertificateClient = null;
     FileUtils.deleteQuietly(metaDirPath.toFile());
   }

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/security/TestOzoneDelegationTokenSecretManager.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/security/TestOzoneDelegationTokenSecretManager.java
@@ -175,6 +175,7 @@ public class TestOzoneDelegationTokenSecretManager {
   @After
   public void tearDown() throws IOException {
     secretManager.stop();
+    certificateClient.close();
   }
 
   @Test

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/ReconServer.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/ReconServer.java
@@ -174,6 +174,7 @@ public class ReconServer extends GenericCli {
     CertificateClient.InitResponse response = certClient.init();
     if (response.equals(CertificateClient.InitResponse.REINIT)) {
       LOG.info("Re-initialize certificate client.");
+      certClient.close();
       reconStorage.unsetReconCertSerialId();
       reconStorage.persistCurrentState();
       certClient = new ReconCertificateClient(new SecurityConfig(configuration),
@@ -278,6 +279,13 @@ public class ReconServer extends GenericCli {
         } catch (Exception ex) {
           LOG.error("Recon Container Key DB close failed", ex);
         }
+      }
+    }
+    if (certClient != null) {
+      try {
+        certClient.close();
+      } catch (IOException ioe) {
+        LOG.error("Failed to close certificate client.", ioe);
       }
     }
   }

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/spi/impl/StorageContainerServiceProviderImpl.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/spi/impl/StorageContainerServiceProviderImpl.java
@@ -201,15 +201,13 @@ public class StorageContainerServiceProviderImpl
             SecurityConfig secConf = new SecurityConfig(configuration);
             try (ReconCertificateClient certClient =
                      new ReconCertificateClient(
-                         secConf, reconStorage, null, null)) {
-              try (
-                  SCMSnapshotDownloader downloadClient = new InterSCMGrpcClient(
-                      hostAddress, grpcPort, configuration, certClient)) {
-                downloadClient.download(targetFile.toPath()).get();
-              } catch (ExecutionException | InterruptedException e) {
-                LOG.error("Rocks DB checkpoint downloading failed", e);
-                throw new IOException(e);
-              }
+                         secConf, reconStorage, null, null);
+                 SCMSnapshotDownloader downloadClient = new InterSCMGrpcClient(
+                     hostAddress, grpcPort, configuration, certClient)) {
+              downloadClient.download(targetFile.toPath()).get();
+            } catch (ExecutionException | InterruptedException e) {
+              LOG.error("Rocks DB checkpoint downloading failed", e);
+              throw new IOException(e);
             }
             LOG.info("Downloaded SCM Snapshot from Leader SCM");
             break;


### PR DESCRIPTION
## What changes were proposed in this pull request?

[HDDS-7874](https://issues.apache.org/jira/browse/HDDS-7874) revealed that the Certificate client instances in the system are not closed properly.
This PR adds the close() call for all CertificateClient instances that are created either in tests or during normal operations, to ensure that the internal certificate lifetime monitor task executor thread is shut down correctly once the client is not used anymore.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-8134

## How was this patch tested?
Existing tests should cover.
Added an additional test to check on the bg thread creation and closing the CertClient
Also I ran the TestHddsSecureDatanodeInit.testCertificateRotation test 300 times without failure locally, before patch, from 100 runs I was able to see 4 failures.