### PR TITLE
HDDS-8139. Datanodes should not drop block delete transactions based on transaction ID

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/DeleteBlocksCommandHandler.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/DeleteBlocksCommandHandler.java
@@ -487,8 +487,9 @@ public class DeleteBlocksCommandHandler implements CommandHandler {
 
     if (delTX.getTxID() <= containerData.getDeleteTransactionId()) {
       LOG.info(String.format("Delete blocks for containerId: %d"
-              + " is outdated & retried, %d < %d", containerId,
-          delTX.getTxID(), containerData.getDeleteTransactionId()));
+              + " is outdated, either received out of order or retried,"
+              + " %d < %d", containerId, delTX.getTxID(),
+          containerData.getDeleteTransactionId()));
     }
   }
 

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/DeleteBlocksCommandHandler.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/DeleteBlocksCommandHandler.java
@@ -487,8 +487,8 @@ public class DeleteBlocksCommandHandler implements CommandHandler {
 
     if (delTX.getTxID() <= containerData.getDeleteTransactionId()) {
       LOG.info(String.format("Delete blocks for containerId: %d"
-              + " is outdated, either received out of order or retried,"
-              + " %d < %d", containerId, delTX.getTxID(),
+              + " is either received out of order or retried,"
+              + " %d <= %d", containerId, delTX.getTxID(),
           containerData.getDeleteTransactionId()));
     }
   }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/DeleteBlocksCommandHandler.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/DeleteBlocksCommandHandler.java
@@ -368,9 +368,7 @@ public class DeleteBlocksCommandHandler implements CommandHandler {
       int newDeletionBlocks, long txnID, DeletionMarker marker)
       throws IOException {
     long containerId = delTX.getContainerID();
-    if (!isTxnIdValid(containerId, containerData, delTX)) {
-      return;
-    }
+    logDeleteTransaction(containerId, containerData, delTX);
     try (DBHandle containerDB = BlockUtils.getDB(containerData, conf)) {
       DeleteTransactionStore<?> store =
           (DeleteTransactionStore<?>) containerDB.getStore();
@@ -391,9 +389,7 @@ public class DeleteBlocksCommandHandler implements CommandHandler {
       KeyValueContainerData containerData, DeletedBlocksTransaction delTX)
       throws IOException {
     long containerId = delTX.getContainerID();
-    if (!isTxnIdValid(containerId, containerData, delTX)) {
-      return;
-    }
+    logDeleteTransaction(containerId, containerData, delTX);
     int newDeletionBlocks = 0;
     try (DBHandle containerDB = BlockUtils.getDB(containerData, conf)) {
       Table<String, BlockData> blockDataTable =
@@ -482,23 +478,18 @@ public class DeleteBlocksCommandHandler implements CommandHandler {
     }
   }
 
-  private boolean isTxnIdValid(long containerId,
+  private void logDeleteTransaction(long containerId,
       KeyValueContainerData containerData, DeletedBlocksTransaction delTX) {
-    boolean b = true;
     if (LOG.isDebugEnabled()) {
-      LOG.debug("Processing Container : {}, DB path : {}", containerId,
-          containerData.getMetadataPath());
+      LOG.debug("Processing Container : {}, DB path : {}, transaction {}",
+          containerId, containerData.getMetadataPath(), delTX.getTxID());
     }
 
     if (delTX.getTxID() <= containerData.getDeleteTransactionId()) {
-      if (LOG.isDebugEnabled()) {
-        LOG.debug(String.format("Ignoring delete blocks for containerId: %d."
-                + " Outdated delete transactionId %d < %d", containerId,
-            delTX.getTxID(), containerData.getDeleteTransactionId()));
-      }
-      b = false;
+      LOG.info(String.format("Delete blocks for containerId: %d"
+              + " is outdated & retried, %d < %d", containerId,
+          delTX.getTxID(), containerData.getDeleteTransactionId()));
     }
-    return b;
   }
 
   @Override


### PR DESCRIPTION
## What changes were proposed in this pull request?

Remove the check for "delete transactionId" to be in order and skip any transaction coming out of order


## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-8139

## How was this patch tested?

This is tested for impact using E2E setup and observing frequency of logs for out-of-order or retry of deleteTransactionId comming again. 
Result: Its observed only once when had many blocks, but its not coming repeated always. So no impact is observed.

