### PR TITLE
HDDS-8145. ReadReplicas should close client

### DIFF
--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/ReadReplicas.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/ReadReplicas.java
@@ -219,19 +219,18 @@ public class ReadReplicas extends KeyHandler implements SubcommandWithParent {
   private OzoneInputStream getInputStreamWithoutChecksum(
       Map<OmKeyLocationInfo, Map<DatanodeDetails, OzoneInputStream>>
           replicasWithoutChecksum, String datanodeUUID, BlockID blockID) {
-    OzoneInputStream is = new OzoneInputStream();
     for (Map.Entry<OmKeyLocationInfo, Map<DatanodeDetails, OzoneInputStream>>
         block : replicasWithoutChecksum.entrySet()) {
       if (block.getKey().getBlockID().equals(blockID)) {
         for (Map.Entry<DatanodeDetails, OzoneInputStream>
             replica : block.getValue().entrySet()) {
           if (replica.getKey().getUuidString().equals(datanodeUUID)) {
-            is = replica.getValue();
+            return replica.getValue();
           }
         }
       }
     }
-    return is;
+    return new OzoneInputStream();
   }
 
   @NotNull

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/ReadReplicas.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/ReadReplicas.java
@@ -88,6 +88,8 @@ public class ReadReplicas extends KeyHandler implements SubcommandWithParent {
   protected void execute(OzoneClient client, OzoneAddress address)
       throws IOException, OzoneClientException {
 
+    address.ensureKeyAddress();
+
     boolean isChecksumVerifyEnabled
         = getConf().getBoolean("ozone.client.verify.checksum", true);
     OzoneConfiguration configuration = new OzoneConfiguration(getConf());
@@ -106,7 +108,6 @@ public class ReadReplicas extends KeyHandler implements SubcommandWithParent {
         noChecksumClient = client.getObjectStore().getClientProxy();
       }
 
-      address.ensureKeyAddress();
       String volumeName = address.getVolumeName();
       String bucketName = address.getBucketName();
       String keyName = address.getKeyName();

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/ReadReplicas.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/ReadReplicas.java
@@ -79,8 +79,8 @@ public class ReadReplicas extends KeyHandler implements SubcommandWithParent {
   private static final String JSON_PROPERTY_REPLICA_UUID = "uuid";
   private static final String JSON_PROPERTY_REPLICA_EXCEPTION = "exception";
 
-  private ClientProtocol clientProtocol;
-  private ClientProtocol clientProtocolWithoutChecksum;
+  private ClientProtocol checksumClient;
+  private ClientProtocol noChecksumClient;
 
   @Override
   public Class<?> getParentType() {
@@ -100,11 +100,11 @@ public class ReadReplicas extends KeyHandler implements SubcommandWithParent {
     RpcClient newClient = new RpcClient(configuration, null);
     try {
       if (isChecksumVerifyEnabled) {
-        clientProtocol = client.getObjectStore().getClientProxy();
-        clientProtocolWithoutChecksum = newClient;
+        checksumClient = client.getObjectStore().getClientProxy();
+        noChecksumClient = newClient;
       } else {
-        clientProtocol = newClient;
-        clientProtocolWithoutChecksum = client.getObjectStore().getClientProxy();
+        checksumClient = newClient;
+        noChecksumClient = client.getObjectStore().getClientProxy();
       }
 
       address.ensureKeyAddress();
@@ -115,13 +115,13 @@ public class ReadReplicas extends KeyHandler implements SubcommandWithParent {
       String directoryName = createDirectory(volumeName, bucketName, keyName);
 
       OzoneKeyDetails keyInfoDetails
-          = clientProtocol.getKeyDetails(volumeName, bucketName, keyName);
+          = checksumClient.getKeyDetails(volumeName, bucketName, keyName);
 
-      Map<OmKeyLocationInfo, Map<DatanodeDetails, OzoneInputStream>> replicas
-          = clientProtocol.getKeysEveryReplicas(volumeName, bucketName, keyName);
+      Map<OmKeyLocationInfo, Map<DatanodeDetails, OzoneInputStream>> replicas =
+          checksumClient.getKeysEveryReplicas(volumeName, bucketName, keyName);
 
       Map<OmKeyLocationInfo, Map<DatanodeDetails, OzoneInputStream>>
-          replicasWithoutChecksum = clientProtocolWithoutChecksum
+          replicasWithoutChecksum = noChecksumClient
           .getKeysEveryReplicas(volumeName, bucketName, keyName);
 
       JsonObject result = new JsonObject();

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/ReadReplicas.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/ReadReplicas.java
@@ -198,6 +198,7 @@ public class ReadReplicas extends KeyHandler implements SubcommandWithParent {
           if (cause instanceof OzoneChecksumException) {
             BlockID blockID = block.getKey().getBlockID();
             String datanodeUUID = replica.getKey().getUuidString();
+            is.close();
             is = getInputStreamWithoutChecksum(replicasWithoutChecksum,
                 datanodeUUID, blockID);
             Files.copy(is, replicaFile.toPath(),

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/ReadReplicas.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/ReadReplicas.java
@@ -79,9 +79,6 @@ public class ReadReplicas extends KeyHandler implements SubcommandWithParent {
   private static final String JSON_PROPERTY_REPLICA_UUID = "uuid";
   private static final String JSON_PROPERTY_REPLICA_EXCEPTION = "exception";
 
-  private ClientProtocol checksumClient;
-  private ClientProtocol noChecksumClient;
-
   @Override
   public Class<?> getParentType() {
     return OzoneDebug.class;
@@ -99,6 +96,8 @@ public class ReadReplicas extends KeyHandler implements SubcommandWithParent {
 
     RpcClient newClient = new RpcClient(configuration, null);
     try {
+      ClientProtocol noChecksumClient;
+      ClientProtocol checksumClient;
       if (isChecksumVerifyEnabled) {
         checksumClient = client.getObjectStore().getClientProxy();
         noChecksumClient = newClient;


### PR DESCRIPTION
## What changes were proposed in this pull request?

1. Close `RpcClient` created for read with/without checksums
2. Verify key address before doing any work
3. Close all `OzoneInputStream` instances
4. Do not stop on `StatusRuntimeException`
5. Minor other refactoring

https://issues.apache.org/jira/browse/HDDS-8145

## How was this patch tested?

Existing acceptance tests.

https://github.com/adoroszlai/hadoop-ozone/actions/runs/4398379780