### PR TITLE
HDDS-8150. RpcClientTest and ConfigurationSourceTest not run due to naming convention

### DIFF
--- a/hadoop-hdds/config/src/test/java/org/apache/hadoop/hdds/conf/TestConfigurationSource.java
+++ b/hadoop-hdds/config/src/test/java/org/apache/hadoop/hdds/conf/TestConfigurationSource.java
@@ -23,7 +23,7 @@ import org.junit.jupiter.api.Test;
 
 import java.util.Map;
 
-class ConfigurationSourceTest {
+class TestConfigurationSource {
 
   @Test
   void getPropsMatchPrefixAndTrimPrefix() {

--- a/hadoop-ozone/client/src/test/java/org/apache/hadoop/ozone/client/rpc/TestRpcClient.java
+++ b/hadoop-ozone/client/src/test/java/org/apache/hadoop/ozone/client/rpc/TestRpcClient.java
@@ -38,7 +38,7 @@ import static org.junit.Assert.assertThrows;
  * Run RPC Client tests.
  */
 @RunWith(Parameterized.class)
-public class RpcClientTest {
+public class TestRpcClient {
   private enum ValidateOmVersionTestCases {
     NULL_EXPECTED_NO_OM(
         null, // Expected version
@@ -200,7 +200,7 @@ public class RpcClientTest {
 
   private ValidateOmVersionTestCases testCase;
 
-  public RpcClientTest(ValidateOmVersionTestCases testCase) {
+  public TestRpcClient(ValidateOmVersionTestCases testCase) {
     this.testCase = testCase;
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Rename `RpcClientTest` and `ConfigurationSourceTest` to include them in CI runs.

https://issues.apache.org/jira/browse/HDDS-8150

## How was this patch tested?

Locally ran these tests, as well as checkstyle.