### PR TITLE
HDDS-8153. Integrate ContainerBalancer with MoveManager

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/balancer/ContainerBalancerConfiguration.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/balancer/ContainerBalancerConfiguration.java
@@ -93,16 +93,16 @@ public final class ContainerBalancerConfiguration {
       "to exclude from balancing. For example \"1, 4, 5\" or \"1,4,5\".")
   private String excludeContainers = "";
 
-  @Config(key = "move.timeout", type = ConfigType.TIME, defaultValue = "30m",
+  @Config(key = "move.timeout", type = ConfigType.TIME, defaultValue = "60m",
       tags = {ConfigTag.BALANCER}, description =
       "The amount of time to allow a single container to move " +
           "from source to target.")
-  private long moveTimeout = Duration.ofMinutes(30).toMillis();
+  private long moveTimeout = Duration.ofMinutes(60).toMillis();
 
   @Config(key = "balancing.iteration.interval", type = ConfigType.TIME,
-      defaultValue = "70m", tags = {ConfigTag.BALANCER}, description =
+      defaultValue = "130m", tags = {ConfigTag.BALANCER}, description =
       "The interval period between each iteration of Container Balancer.")
-  private long balancingInterval = Duration.ofMinutes(70).toMillis();
+  private long balancingInterval = Duration.ofMinutes(130).toMillis();
 
   @Config(key = "include.datanodes", type = ConfigType.STRING, defaultValue =
       "", tags = {ConfigTag.BALANCER}, description = "A list of Datanode " +

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/balancer/ContainerBalancerConfiguration.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/balancer/ContainerBalancerConfiguration.java
@@ -93,16 +93,16 @@ public final class ContainerBalancerConfiguration {
       "to exclude from balancing. For example \"1, 4, 5\" or \"1,4,5\".")
   private String excludeContainers = "";
 
-  @Config(key = "move.timeout", type = ConfigType.TIME, defaultValue = "60m",
+  @Config(key = "move.timeout", type = ConfigType.TIME, defaultValue = "30m",
       tags = {ConfigTag.BALANCER}, description =
       "The amount of time to allow a single container to move " +
           "from source to target.")
-  private long moveTimeout = Duration.ofMinutes(60).toMillis();
+  private long moveTimeout = Duration.ofMinutes(30).toMillis();
 
   @Config(key = "balancing.iteration.interval", type = ConfigType.TIME,
-      defaultValue = "130m", tags = {ConfigTag.BALANCER}, description =
+      defaultValue = "70m", tags = {ConfigTag.BALANCER}, description =
       "The interval period between each iteration of Container Balancer.")
-  private long balancingInterval = Duration.ofMinutes(130).toMillis();
+  private long balancingInterval = Duration.ofMinutes(70).toMillis();
 
   @Config(key = "include.datanodes", type = ConfigType.STRING, defaultValue =
       "", tags = {ConfigTag.BALANCER}, description = "A list of Datanode " +

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/balancer/ContainerBalancerTask.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/balancer/ContainerBalancerTask.java
@@ -26,6 +26,7 @@ import org.apache.hadoop.hdds.scm.container.ContainerID;
 import org.apache.hadoop.hdds.scm.container.ContainerInfo;
 import org.apache.hadoop.hdds.scm.container.ContainerManager;
 import org.apache.hadoop.hdds.scm.container.ContainerNotFoundException;
+import org.apache.hadoop.hdds.scm.container.ContainerReplicaNotFoundException;
 import org.apache.hadoop.hdds.scm.container.placement.metrics.SCMNodeStat;
 import org.apache.hadoop.hdds.scm.container.replication.ReplicationManager;
 import org.apache.hadoop.hdds.scm.ha.SCMContext;
@@ -44,6 +45,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.NavigableSet;
@@ -68,6 +70,7 @@ public class ContainerBalancerTask implements Runnable {
   private NodeManager nodeManager;
   private ContainerManager containerManager;
   private ReplicationManager replicationManager;
+  private MoveManager moveManager;
   private OzoneConfiguration ozoneConfiguration;
   private ContainerBalancer containerBalancer;
   private final SCMContext scmContext;
@@ -131,6 +134,7 @@ public class ContainerBalancerTask implements Runnable {
     this.nodeManager = scm.getScmNodeManager();
     this.containerManager = scm.getContainerManager();
     this.replicationManager = scm.getReplicationManager();
+    this.moveManager = new MoveManager(replicationManager, containerManager);
     this.ozoneConfiguration = scm.getConfiguration();
     this.containerBalancer = containerBalancer;
     this.config = config;
@@ -592,7 +596,7 @@ public class ContainerBalancerTask implements Runnable {
       LOG.warn("Container balancer is interrupted");
       Thread.currentThread().interrupt();
     } catch (TimeoutException e) {
-      long timeoutCounts = cancelAndCountPendingMoves();
+      long timeoutCounts = cancelMovesThatExceedTimeoutDuration();
       LOG.warn("{} Container moves are canceled.", timeoutCounts);
       metrics.incrementNumContainerMovesTimeoutInLatestIteration(timeoutCounts);
     } catch (ExecutionException e) {
@@ -621,18 +625,42 @@ public class ContainerBalancerTask implements Runnable {
         metrics.getNumContainerMovesCompletedInLatestIteration());
   }
 
-  private long cancelAndCountPendingMoves() {
-    return moveSelectionToFutureMap.entrySet().stream()
-        .filter(entry -> !entry.getValue().isDone())
-        .peek(entry -> {
-          LOG.warn("Container move timeout for container {} from source {}" +
-                  " to target {}.",
-              entry.getKey().getContainerID(),
-              containerToSourceMap.get(entry.getKey().getContainerID())
-                  .getUuidString(),
-              entry.getKey().getTargetNode().getUuidString());
-          entry.getValue().cancel(true);
-        }).count();
+  /**
+   * Cancels container moves that are not yet done. Note that if a move
+   * command has already been sent out to a Datanode, we don't yet have the
+   * capability to cancel it. However, those commands in the DN should time out
+   * if they haven't been processed yet.
+   *
+   * @return number of moves that did not complete (timed out) and were
+   * cancelled.
+   */
+  private long cancelMovesThatExceedTimeoutDuration() {
+    Set<Map.Entry<ContainerMoveSelection,
+        CompletableFuture<MoveManager.MoveResult>>>
+        entries = moveSelectionToFutureMap.entrySet();
+    Iterator<Map.Entry<ContainerMoveSelection,
+        CompletableFuture<MoveManager.MoveResult>>>
+        iterator = entries.iterator();
+
+    int numCancelled = 0;
+    // iterate through all moves and cancel ones that aren't done yet
+    while (iterator.hasNext()) {
+      Map.Entry<ContainerMoveSelection,
+          CompletableFuture<MoveManager.MoveResult>>
+          entry = iterator.next();
+      if (!entry.getValue().isDone()) {
+        LOG.warn("Container move timed out for container {} from source {}" +
+                " to target {}.", entry.getKey().getContainerID(),
+            containerToSourceMap.get(entry.getKey().getContainerID())
+                                .getUuidString(),
+            entry.getKey().getTargetNode().getUuidString());
+
+        entry.getValue().cancel(true);
+        numCancelled += 1;
+      }
+    }
+
+    return numCancelled;
   }
 
   /**
@@ -742,13 +770,13 @@ public class ContainerBalancerTask implements Runnable {
   }
 
   /**
-   * Asks {@link ReplicationManager} to move the specified container from
-   * source to target.
+   * Asks {@link ReplicationManager} or {@link MoveManager} to move the
+   * specified container from source to target.
    *
    * @param source the source datanode
    * @param moveSelection the selected container to move and target datanode
    * @return false if an exception occurred or the move completed with a
-   * result other than ReplicationManager.MoveResult.COMPLETED. Returns true
+   * result other than MoveManager.MoveResult.COMPLETED. Returns true
    * if the move completed with MoveResult.COMPLETED or move is not yet done
    */
   private boolean moveContainer(DatanodeDetails source,
@@ -757,48 +785,66 @@ public class ContainerBalancerTask implements Runnable {
     CompletableFuture<MoveManager.MoveResult> future;
     try {
       ContainerInfo containerInfo = containerManager.getContainer(containerID);
-      future = replicationManager
-          .move(containerID, source, moveSelection.getTargetNode())
-          .whenComplete((result, ex) -> {
 
-            metrics.incrementCurrentIterationContainerMoveMetric(result, 1);
-            if (ex != null) {
-              LOG.info("Container move for container {} from source {} to " +
-                      "target {} failed with exceptions {}",
-                  containerID.toString(),
+      ReplicationManager.ReplicationManagerConfiguration rmConf =
+          ozoneConfiguration.getObject(
+              ReplicationManager.ReplicationManagerConfiguration.class);
+      /*
+      If LegacyReplicationManager is enabled, ReplicationManager will
+      redirect to it. Otherwise, use MoveManager.
+       */
+      if (rmConf.isLegacyEnabled()) {
+        future = replicationManager
+            .move(containerID, source, moveSelection.getTargetNode());
+      } else {
+        future = moveManager.move(containerID, source,
+            moveSelection.getTargetNode());
+      }
+
+      future = future.whenComplete((result, ex) -> {
+        metrics.incrementCurrentIterationContainerMoveMetric(result, 1);
+        if (ex != null) {
+          LOG.info("Container move for container {} from source {} to " +
+                  "target {} failed with exceptions.",
+              containerID.toString(),
+              source.getUuidString(),
+              moveSelection.getTargetNode().getUuidString(), ex);
+          metrics.incrementNumContainerMovesFailedInLatestIteration(1);
+        } else {
+          if (result == MoveManager.MoveResult.COMPLETED) {
+            sizeActuallyMovedInLatestIteration +=
+                containerInfo.getUsedBytes();
+            if (LOG.isDebugEnabled()) {
+              LOG.debug("Container move completed for container {} from " +
+                      "source {} to target {}", containerID,
                   source.getUuidString(),
-                  moveSelection.getTargetNode().getUuidString(), ex);
-              metrics.incrementNumContainerMovesFailedInLatestIteration(1);
-            } else {
-              if (result == MoveManager.MoveResult.COMPLETED) {
-                sizeActuallyMovedInLatestIteration +=
-                    containerInfo.getUsedBytes();
-                if (LOG.isDebugEnabled()) {
-                  LOG.debug("Container move completed for container {} from " +
-                          "source {} to target {}", containerID,
-                      source.getUuidString(),
-                      moveSelection.getTargetNode().getUuidString());
-                }
-              } else {
-                LOG.warn(
-                    "Container move for container {} from source {} to target" +
-                        " {} failed: {}",
-                    moveSelection.getContainerID(), source.getUuidString(),
-                    moveSelection.getTargetNode().getUuidString(), result);
-              }
+                  moveSelection.getTargetNode().getUuidString());
             }
-          });
+          } else {
+            LOG.warn(
+                "Container move for container {} from source {} to target" +
+                    " {} failed: {}",
+                moveSelection.getContainerID(), source.getUuidString(),
+                moveSelection.getTargetNode().getUuidString(), result);
+          }
+        }
+      });
     } catch (ContainerNotFoundException e) {
       LOG.warn("Could not find Container {} for container move",
           containerID, e);
       metrics.incrementNumContainerMovesFailedInLatestIteration(1);
       return false;
-    } catch (NodeNotFoundException | TimeoutException e) {
+    } catch (NodeNotFoundException | TimeoutException |
+             ContainerReplicaNotFoundException e) {
       LOG.warn("Container move failed for container {}", containerID, e);
       metrics.incrementNumContainerMovesFailedInLatestIteration(1);
       return false;
     }
 
+    /*
+    If the future hasn't failed yet, put it in moveSelectionToFutureMap for
+    processing later
+     */
     if (future.isDone()) {
       if (future.isCompletedExceptionally()) {
         return false;
@@ -1043,6 +1089,16 @@ public class ContainerBalancerTask implements Runnable {
   @VisibleForTesting
   void setConfig(ContainerBalancerConfiguration config) {
     this.config = config;
+  }
+
+  @VisibleForTesting
+  void setMoveManager(MoveManager moveManager) {
+    this.moveManager = moveManager;
+  }
+
+  @VisibleForTesting
+  void setTaskStatus(Status taskStatus) {
+    this.taskStatus = taskStatus;
   }
 
   public Status getBalancerStatus() {

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/balancer/ContainerBalancerTask.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/balancer/ContainerBalancerTask.java
@@ -134,8 +134,7 @@ public class ContainerBalancerTask implements Runnable {
     this.nodeManager = scm.getScmNodeManager();
     this.containerManager = scm.getContainerManager();
     this.replicationManager = scm.getReplicationManager();
-    this.moveManager = new MoveManager(replicationManager, containerManager,
-        config.getMoveTimeout());
+    this.moveManager = new MoveManager(replicationManager, containerManager);
     this.ozoneConfiguration = scm.getConfiguration();
     this.containerBalancer = containerBalancer;
     this.config = config;
@@ -998,6 +997,7 @@ public class ContainerBalancerTask implements Runnable {
    * Resets some variables and metrics for this iteration.
    */
   private void resetState() {
+    moveManager.resetState();
     this.clusterCapacity = 0L;
     this.clusterRemaining = 0L;
     this.overUtilizedNodes.clear();

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/balancer/MoveManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/balancer/MoveManager.java
@@ -39,6 +39,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.time.Clock;
+import java.time.Duration;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
@@ -110,7 +111,7 @@ public final class MoveManager implements
   //        delete after the move, but before anything else can, eg RM?
 
   // TODO - these need to be config defined somewhere, probably in the balancer
-  private static final long MOVE_DEADLINE = 1000 * 60 * 60; // 1 hour
+  private final long moveDeadline;
   private static final double MOVE_DEADLINE_FACTOR = 0.95;
 
   private final ReplicationManager replicationManager;
@@ -124,10 +125,11 @@ public final class MoveManager implements
   private volatile boolean running = false;
 
   public MoveManager(final ReplicationManager replicationManager,
-      final ContainerManager containerManager) {
+      final ContainerManager containerManager, final Duration moveDeadline) {
     this.replicationManager = replicationManager;
     this.containerManager = containerManager;
     this.clock = replicationManager.getClock();
+    this.moveDeadline = moveDeadline.toMillis();
   }
 
   /**
@@ -469,8 +471,8 @@ public final class MoveManager implements
         containerInfo.containerID(), src);
     long now = clock.millis();
     replicationManager.sendLowPriorityReplicateContainerCommand(containerInfo,
-        replicaIndex, src, tgt, now + MOVE_DEADLINE,
-        now + Math.round(MOVE_DEADLINE * MOVE_DEADLINE_FACTOR));
+        replicaIndex, src, tgt, now + moveDeadline,
+        now + Math.round(moveDeadline * MOVE_DEADLINE_FACTOR));
   }
 
   /**

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/balancer/MoveManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/balancer/MoveManager.java
@@ -46,7 +46,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.TimeoutException;
 
 /**
  * A class which schedules, tracks and completes moves scheduled by the
@@ -125,10 +124,10 @@ public final class MoveManager implements
   private volatile boolean running = false;
 
   public MoveManager(final ReplicationManager replicationManager,
-      final Clock clock, final ContainerManager containerManager) {
+      final ContainerManager containerManager) {
     this.replicationManager = replicationManager;
     this.containerManager = containerManager;
-    this.clock = clock;
+    this.clock = replicationManager.getClock();
   }
 
   /**
@@ -219,7 +218,7 @@ public final class MoveManager implements
   public CompletableFuture<MoveResult> move(
       ContainerID cid, DatanodeDetails src, DatanodeDetails tgt)
       throws ContainerNotFoundException, NodeNotFoundException,
-      TimeoutException, ContainerReplicaNotFoundException {
+      ContainerReplicaNotFoundException {
     CompletableFuture<MoveResult> ret = new CompletableFuture<>();
 
     if (!running) {

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ReplicationManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ReplicationManager.java
@@ -1124,6 +1124,9 @@ public class ReplicationManager implements SCMService {
     return rmConf;
   }
 
+  public Clock getClock() {
+    return clock;
+  }
 
   /**
   * following functions will be refactored in a separate jira.
@@ -1159,8 +1162,12 @@ public class ReplicationManager implements SCMService {
   }
 
   public boolean isContainerReplicatingOrDeleting(ContainerID containerID) {
-    return legacyReplicationManager
-        .isContainerReplicatingOrDeleting(containerID);
+    if (rmConf.isLegacyEnabled()) {
+      return legacyReplicationManager
+          .isContainerReplicatingOrDeleting(containerID);
+    } else {
+      return !getPendingReplicationOps(containerID).isEmpty();
+    }
   }
 
   private ECContainerReplicaCount getECContainerReplicaCount(

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/balancer/TestContainerBalancer.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/balancer/TestContainerBalancer.java
@@ -20,10 +20,13 @@ package org.apache.hadoop.hdds.scm.container.balancer;
 
 import com.google.protobuf.ByteString;
 import java.io.IOException;
+import java.time.Clock;
+import java.time.ZoneId;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.TimeoutException;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import org.apache.hadoop.hdds.scm.container.replication.ReplicationManager;
 import org.apache.hadoop.hdds.scm.ha.SCMContext;
 import org.apache.hadoop.hdds.scm.ha.SCMServiceManager;
 import org.apache.hadoop.hdds.scm.ha.StatefulServiceStateManager;
@@ -81,6 +84,12 @@ public class TestContainerBalancer {
     when(scm.getConfiguration()).thenReturn(conf);
     when(scm.getStatefulServiceStateManager()).thenReturn(serviceStateManager);
     when(scm.getSCMServiceManager()).thenReturn(mock(SCMServiceManager.class));
+
+    ReplicationManager replicationManager =
+        Mockito.mock(ReplicationManager.class);
+    when(scm.getReplicationManager()).thenReturn(replicationManager);
+    when(replicationManager.getClock()).thenReturn(
+        Clock.system(ZoneId.systemDefault()));
 
     /*
     When StatefulServiceStateManager#saveConfiguration is called, save to

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/balancer/TestContainerBalancerTask.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/balancer/TestContainerBalancerTask.java
@@ -60,7 +60,9 @@ import org.slf4j.LoggerFactory;
 import org.slf4j.event.Level;
 
 import java.io.IOException;
+import java.time.Clock;
 import java.time.Duration;
+import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -72,7 +74,9 @@ import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeoutException;
 import java.util.stream.Collectors;
 
+import static org.apache.hadoop.hdds.scm.container.replication.ReplicationManager.ReplicationManagerConfiguration;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.when;
@@ -86,6 +90,7 @@ public class TestContainerBalancerTask {
       LoggerFactory.getLogger(TestContainerBalancerTask.class);
 
   private ReplicationManager replicationManager;
+  private MoveManager moveManager;
   private ContainerManager containerManager;
   private ContainerBalancerTask containerBalancerTask;
   private MockNodeManager mockNodeManager;
@@ -122,6 +127,7 @@ public class TestContainerBalancerTask {
     replicationManager = Mockito.mock(ReplicationManager.class);
     serviceStateManager = Mockito.mock(StatefulServiceStateManagerImpl.class);
     SCMServiceManager scmServiceManager = Mockito.mock(SCMServiceManager.class);
+    moveManager = Mockito.mock(MoveManager.class);
 
     // these configs will usually be specified in each test
     balancerConfiguration =
@@ -157,6 +163,9 @@ public class TestContainerBalancerTask {
         Mockito.any(DatanodeDetails.class)))
         .thenReturn(CompletableFuture.
             completedFuture(MoveManager.MoveResult.COMPLETED));
+
+    Mockito.when(replicationManager.getClock())
+        .thenReturn(Clock.system(ZoneId.systemDefault()));
 
     when(containerManager.getContainerReplicas(Mockito.any(ContainerID.class)))
         .thenAnswer(invocationOnMock -> {
@@ -210,6 +219,12 @@ public class TestContainerBalancerTask {
     ContainerBalancer sb = new ContainerBalancer(scm);
     containerBalancerTask = new ContainerBalancerTask(scm, 0, sb,
         sb.getMetrics(), null);
+
+    containerBalancerTask.setMoveManager(moveManager);
+    Mockito.when(moveManager.move(any(ContainerID.class),
+            any(DatanodeDetails.class), any(DatanodeDetails.class)))
+        .thenReturn(CompletableFuture.completedFuture(
+            MoveManager.MoveResult.COMPLETED));
   }
 
   @Test
@@ -261,6 +276,27 @@ public class TestContainerBalancerTask {
             unBalancedNodesAccordingToBalancer.get(j).getDatanodeDetails());
       }
     }
+  }
+
+  @Test
+  public void testBalancerWithMoveManager()
+      throws IllegalContainerBalancerStateException, IOException,
+      InvalidContainerBalancerConfigurationException, TimeoutException,
+      NodeNotFoundException {
+    ReplicationManagerConfiguration rmConf =
+        conf.getObject(ReplicationManagerConfiguration.class);
+    rmConf.setEnableLegacy(false);
+    conf.setFromObject(rmConf);
+
+    startBalancer(balancerConfiguration);
+    Mockito.verify(moveManager, atLeastOnce())
+        .move(Mockito.any(ContainerID.class),
+            Mockito.any(DatanodeDetails.class),
+            Mockito.any(DatanodeDetails.class));
+
+    Mockito.verify(replicationManager, times(0))
+        .move(Mockito.any(ContainerID.class), Mockito.any(
+            DatanodeDetails.class), Mockito.any(DatanodeDetails.class));
   }
 
   /**
@@ -478,6 +514,18 @@ public class TestContainerBalancerTask {
      containerToTargetMap).
      */
     Mockito.verify(replicationManager, times(numContainers))
+        .move(any(ContainerID.class), any(DatanodeDetails.class),
+            any(DatanodeDetails.class));
+
+    /*
+     Try the same test by disabling LegacyReplicationManager so that
+     MoveManager is used.
+     */
+    conf.setBoolean("hdds.scm.replication.enable.legacy", false);
+    startBalancer(balancerConfiguration);
+    stopBalancer();
+    numContainers = containerBalancerTask.getContainerToTargetMap().size();
+    Mockito.verify(moveManager, times(numContainers))
         .move(any(ContainerID.class), any(DatanodeDetails.class),
             any(DatanodeDetails.class));
   }
@@ -730,8 +778,22 @@ public class TestContainerBalancerTask {
         ContainerBalancerTask.IterationResult.ITERATION_COMPLETED,
         containerBalancerTask.getIterationResult());
     stopBalancer();
+
+    /*
+    Try the same but use MoveManager for container move instead of legacy RM.
+     */
+    conf.setBoolean("hdds.scm.replication.enable.legacy", false);
+    startBalancer(balancerConfiguration);
+    Assertions.assertEquals(
+        ContainerBalancerTask.IterationResult.ITERATION_COMPLETED,
+        containerBalancerTask.getIterationResult());
+    stopBalancer();
   }
 
+  /**
+   * Tests the situation where some container moves time out because they
+   * take longer than "move.timeout".
+   */
   @Test
   public void checkIterationResultTimeout()
       throws NodeNotFoundException, IOException,
@@ -742,7 +804,8 @@ public class TestContainerBalancerTask {
     Mockito.when(replicationManager.move(Mockito.any(ContainerID.class),
             Mockito.any(DatanodeDetails.class),
             Mockito.any(DatanodeDetails.class)))
-        .thenReturn(genCompletableFuture(200), genCompletableFuture(2000));
+        .thenReturn(genCompletableFuture(10))
+        .thenAnswer(invocation -> genCompletableFuture(2000));
 
     balancerConfiguration.setThreshold(10);
     balancerConfiguration.setIterations(1);
@@ -767,6 +830,28 @@ public class TestContainerBalancerTask {
             .getNumContainerMovesTimeoutInLatestIteration() > 1);
     stopBalancer();
 
+    /*
+    Test the same but use MoveManager instead of LegacyReplicationManager.
+    The first move being 10ms falls within the timeout duration of 500ms. It
+    should be successful. The rest should fail.
+     */
+    conf.setBoolean("hdds.scm.replication.enable.legacy", false);
+    Mockito.when(moveManager.move(Mockito.any(ContainerID.class),
+            Mockito.any(DatanodeDetails.class),
+            Mockito.any(DatanodeDetails.class)))
+        .thenReturn(genCompletableFuture(10))
+        .thenAnswer(invocation -> genCompletableFuture(2000));
+
+    startBalancer(balancerConfiguration);
+    Assertions.assertEquals(
+        ContainerBalancerTask.IterationResult.ITERATION_COMPLETED,
+        containerBalancerTask.getIterationResult());
+    Assertions.assertEquals(1,
+        containerBalancerTask.getMetrics()
+            .getNumContainerMovesCompletedInLatestIteration());
+    Assertions.assertTrue(containerBalancerTask.getMetrics()
+        .getNumContainerMovesTimeoutInLatestIteration() > 1);
+    stopBalancer();
   }
 
   @Test
@@ -796,6 +881,23 @@ public class TestContainerBalancerTask {
 
     Assertions.assertTrue(containerBalancerTask.getMetrics()
         .getNumContainerMovesTimeoutInLatestIteration() > 0);
+    Assertions.assertEquals(0, containerBalancerTask.getMetrics()
+        .getNumContainerMovesCompletedInLatestIteration());
+    stopBalancer();
+
+    /*
+    Try the same test with MoveManager instead of LegacyReplicationManager.
+     */
+    Mockito.when(moveManager.move(Mockito.any(ContainerID.class),
+            Mockito.any(DatanodeDetails.class),
+            Mockito.any(DatanodeDetails.class)))
+        .thenReturn(future).thenAnswer(invocation -> future2);
+
+    startBalancer(balancerConfiguration);
+    Assertions.assertTrue(containerBalancerTask.getMetrics()
+        .getNumContainerMovesTimeoutInLatestIteration() > 0);
+    Assertions.assertEquals(0, containerBalancerTask.getMetrics()
+        .getNumContainerMovesCompletedInLatestIteration());
     stopBalancer();
   }
 
@@ -836,9 +938,33 @@ public class TestContainerBalancerTask {
         containerBalancerTask.getIterationResult());
     Assertions.assertTrue(
         containerBalancerTask.getMetrics()
-            .getNumContainerMovesFailed() >= 3);
+            .getNumContainerMovesFailed() >= 4);
     stopBalancer();
 
+    /*
+    Try the same test but with MoveManager instead of ReplicationManager.
+     */
+    Mockito.when(moveManager.move(Mockito.any(ContainerID.class),
+            Mockito.any(DatanodeDetails.class),
+            Mockito.any(DatanodeDetails.class)))
+        .thenThrow(new ContainerNotFoundException("Test Container not found"),
+            new NodeNotFoundException("Test Node not found"))
+        .thenReturn(future).thenReturn(CompletableFuture.supplyAsync(() -> {
+          try {
+            Thread.sleep(200);
+          } catch (Exception ignored) {
+          }
+          throw new RuntimeException("Exception after sleeping");
+        }));
+
+    startBalancer(balancerConfiguration);
+    Assertions.assertEquals(
+        ContainerBalancerTask.IterationResult.ITERATION_COMPLETED,
+        containerBalancerTask.getIterationResult());
+    Assertions.assertTrue(
+        containerBalancerTask.getMetrics()
+            .getNumContainerMovesFailed() >= 4);
+    stopBalancer();
   }
 
   /**
@@ -1019,6 +1145,7 @@ public class TestContainerBalancerTask {
       throws IllegalContainerBalancerStateException, IOException,
       InvalidContainerBalancerConfigurationException, TimeoutException {
     containerBalancerTask.setConfig(config);
+    containerBalancerTask.setTaskStatus(ContainerBalancerTask.Status.RUNNING);
     containerBalancerTask.run();
   }
 

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/balancer/TestMoveManager.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/balancer/TestMoveManager.java
@@ -107,9 +107,9 @@ public class TestMoveManager {
         .thenReturn(pendingOps);
     Mockito.when(replicationManager.getContainerReplicationHealth(any(), any()))
         .thenReturn(new ContainerHealthResult.HealthyResult(containerInfo));
+    Mockito.when(replicationManager.getClock()).thenReturn(clock);
 
-    moveManager = new MoveManager(
-        replicationManager, clock, containerManager);
+    moveManager = new MoveManager(replicationManager, containerManager);
     moveManager.onLeaderReady();
   }
 

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/balancer/TestMoveManager.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/balancer/TestMoveManager.java
@@ -42,6 +42,7 @@ import org.junit.Test;
 import org.junit.jupiter.api.Assertions;
 import org.mockito.Mockito;
 
+import java.time.Duration;
 import java.time.Instant;
 import java.time.ZoneId;
 import java.util.ArrayList;
@@ -109,7 +110,8 @@ public class TestMoveManager {
         .thenReturn(new ContainerHealthResult.HealthyResult(containerInfo));
     Mockito.when(replicationManager.getClock()).thenReturn(clock);
 
-    moveManager = new MoveManager(replicationManager, containerManager);
+    moveManager = new MoveManager(replicationManager, containerManager,
+        Duration.ofMinutes(60));
     moveManager.onLeaderReady();
   }
 

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/balancer/TestMoveManager.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/balancer/TestMoveManager.java
@@ -42,7 +42,6 @@ import org.junit.Test;
 import org.junit.jupiter.api.Assertions;
 import org.mockito.Mockito;
 
-import java.time.Duration;
 import java.time.Instant;
 import java.time.ZoneId;
 import java.util.ArrayList;
@@ -110,8 +109,7 @@ public class TestMoveManager {
         .thenReturn(new ContainerHealthResult.HealthyResult(containerInfo));
     Mockito.when(replicationManager.getClock()).thenReturn(clock);
 
-    moveManager = new MoveManager(replicationManager, containerManager,
-        Duration.ofMinutes(60));
+    moveManager = new MoveManager(replicationManager, containerManager);
     moveManager.onLeaderReady();
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Currently ContainerBalancer uses ReplicationManager#move which internally uses LegacyReplicationManager. This jira proposes integrating MoveManager with ContainerBalancer such that it uses MoveManager#move if "hdds.scm.replication.enable.legacy" is false and ReplicationManager#move if it's true.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-8153

## How was this patch tested?

Added a UT and modified existing ones