### PR TITLE
HDDS-8152. Reduce S3 acceptance test setup time

### DIFF
--- a/hadoop-ozone/dist/src/main/smoketest/s3/bucketlist.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/s3/bucketlist.robot
@@ -41,6 +41,8 @@ Get bucket info with Ozone Shell to check the owner field
                         # Also see "Setup dummy credentials for S3" in commonawslib.robot
 
 List buckets with empty access id
-                        Execute                    aws configure set aws_access_key_id ''
+    [setup]             Save AWS access key
+                        Execute     aws configure set aws_access_key_id ''
     ${result} =         Execute AWSS3APICli and checkrc         list-buckets    255
                         Should contain            ${result}         The authorization header you provided is invalid
+    [teardown]          Restore AWS access key


### PR DESCRIPTION
## What changes were proposed in this pull request?

Define "S3 tests set up" variable to indicate whether the common setup was done already.  Previously it relied on Ozone RPC calls, which can take a few seconds.  Also avoids repeatedly getting S3 secret to configure aws client.

https://issues.apache.org/jira/browse/HDDS-8152

## How was this patch tested?

https://github.com/adoroszlai/hadoop-ozone/actions/runs/4406584085

Compare time elapsed in "Setup S3 tests", the first step in each S3 test:

### Before

![before](https://user-images.githubusercontent.com/6454655/224801456-cea8911a-0cd4-4408-8cfe-7e960bdc95d5.png)

### After

![after](https://user-images.githubusercontent.com/6454655/224801451-da37a5e1-9416-470c-80bb-a349d32524f2.png)