### PR TITLE
HDDS-7842. NPE in StaleRecoveringContainerScrubbingService

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/statemachine/background/StaleRecoveringContainerScrubbingService.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/statemachine/background/StaleRecoveringContainerScrubbingService.java
@@ -23,6 +23,7 @@ import org.apache.hadoop.hdds.utils.BackgroundTask;
 import org.apache.hadoop.hdds.utils.BackgroundTaskQueue;
 import org.apache.hadoop.hdds.utils.BackgroundTaskResult;
 import org.apache.hadoop.ozone.container.common.impl.ContainerSet;
+import org.apache.hadoop.ozone.container.common.interfaces.Container;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -84,8 +85,11 @@ public class StaleRecoveringContainerScrubbingService
 
     @Override
     public BackgroundTaskResult call() throws Exception {
-      containerSet.getContainer(containerID).markContainerUnhealthy();
-      LOG.info("Stale recovering container {} marked UNHEALTHY", containerID);
+      Container con = containerSet.getContainer(containerID);
+      if (null != con) {
+        con.markContainerUnhealthy();
+        LOG.info("Stale recovering container {} marked UNHEALTHY", containerID);
+      }
       return new BackgroundTaskResult.EmptyTaskResult();
     }
   }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Check whether container exists or not before making RECOVERING container unhealthy .

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-7842

## How was this patch tested?

Verified in testScrubbingStaleRecoveringContainers
1.Create few containers in RECOVERING state and store in containerSet.
2.Remove one container using containerSet.removeContainer(containerId)
3.Run StaleRecoveringContainerScrubbingService task.
4.Before fix, since container was already deleted before StaleRecoveringContainerScrubbingService task execution, containerSet.getContainer returns null and throw NPE. After fix it will ignore if container is already removed.
