### PR TITLE
HDDS-7867. Clean up replication logs

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/ec/reconstruction/ECReconstructionCommandInfo.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/ec/reconstruction/ECReconstructionCommandInfo.java
@@ -29,6 +29,7 @@ import java.util.stream.IntStream;
 
 import static java.util.Collections.unmodifiableSortedMap;
 import static java.util.stream.Collectors.toMap;
+import static org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.SCMCommandProto.Type.reconstructECContainersCommand;
 
 /**
  * This class is to keep the required EC reconstruction info.
@@ -86,12 +87,12 @@ public class ECReconstructionCommandInfo {
 
   @Override
   public String toString() {
-    return "ECReconstructionCommand{"
-        + "containerID=" + containerID
+    return reconstructECContainersCommand
+        + ": containerID=" + containerID
         + ", replication=" + ecReplicationConfig.getReplication()
         + ", missingIndexes=" + Arrays.toString(missingContainerIndexes)
         + ", sources=" + sourceNodeMap
-        + ", targets=" + targetNodeMap + "}";
+        + ", targets=" + targetNodeMap;
   }
 
   public long getTerm() {

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/ec/reconstruction/ECReconstructionCoordinatorTask.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/ec/reconstruction/ECReconstructionCoordinatorTask.java
@@ -33,6 +33,7 @@ public class ECReconstructionCoordinatorTask
       LoggerFactory.getLogger(ECReconstructionCoordinatorTask.class);
   private final ECReconstructionCoordinator reconstructionCoordinator;
   private final ECReconstructionCommandInfo reconstructionCommandInfo;
+  private final String debugString;
 
   public ECReconstructionCoordinatorTask(
       ECReconstructionCoordinator coordinator,
@@ -42,6 +43,7 @@ public class ECReconstructionCoordinatorTask
         reconstructionCommandInfo.getTerm());
     this.reconstructionCoordinator = coordinator;
     this.reconstructionCommandInfo = reconstructionCommandInfo;
+    debugString = reconstructionCommandInfo.toString();
   }
 
   @Override
@@ -81,8 +83,8 @@ public class ECReconstructionCoordinatorTask
   }
 
   @Override
-  public String toString() {
-    return "ECReconstructionTask{info=" + reconstructionCommandInfo + '}';
+  protected Object getCommandForDebug() {
+    return debugString;
   }
 
   @Override

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/replication/AbstractReplicationTask.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/replication/AbstractReplicationTask.java
@@ -140,4 +140,23 @@ public abstract class AbstractReplicationTask {
       boolean runOnInServiceOnly) {
     this.shouldOnlyRunOnInServiceDatanodes = runOnInServiceOnly;
   }
+
+  /**
+   * Hook for subclasses to provide info about the command.
+   * @return string representation of the command
+   */
+  protected Object getCommandForDebug() {
+    return "";
+  };
+
+  @Override
+  public String toString() {
+    StringBuilder sb = new StringBuilder()
+        .append(getStatus()).append(" ")
+        .append(getCommandForDebug());
+    if (getStatus() == Status.QUEUED) {
+      sb.append(", queued at ").append(getQueued());
+    }
+    return sb.toString();
+  }
 }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/replication/GrpcContainerUploader.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/replication/GrpcContainerUploader.java
@@ -105,7 +105,7 @@ public class GrpcContainerUploader implements ContainerUploader {
 
     @Override
     public void onNext(SendContainerResponse sendContainerResponse) {
-      LOG.info("Response for upload container {} to {}", containerId, target);
+      LOG.debug("Response for upload container {} to {}", containerId, target);
     }
 
     @Override

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/replication/GrpcReplicationService.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/replication/GrpcReplicationService.java
@@ -67,7 +67,7 @@ public class GrpcReplicationService extends
           responseObserver, containerID, BUFFER_SIZE);
       source.copyData(containerID, outputStream, compression);
     } catch (IOException e) {
-      LOG.error("Error streaming container {}", containerID, e);
+      LOG.warn("Error streaming container {}", containerID, e);
       responseObserver.onError(e);
     } finally {
       // output may have already been closed, ignore such errors

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/replication/PushReplicator.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/replication/PushReplicator.java
@@ -66,6 +66,7 @@ public class PushReplicator implements ContainerReplicator {
           uploader.startUpload(containerID, target, fut, compression));
       source.copyData(containerID, output, compression);
       fut.get();
+
       task.setTransferredBytes(output.getByteCount());
       task.setStatus(Status.DONE);
     } catch (Exception e) {

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/replication/ReplicationTask.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/replication/ReplicationTask.java
@@ -30,6 +30,7 @@ public class ReplicationTask extends AbstractReplicationTask {
 
   private final ReplicateContainerCommand cmd;
   private final ContainerReplicator replicator;
+  private final String debugString;
 
   /**
    * Counter for the transferred bytes.
@@ -49,6 +50,7 @@ public class ReplicationTask extends AbstractReplicationTask {
       // run.
       setShouldOnlyRunOnInServiceDatanodes(false);
     }
+    debugString = cmd.toString();
   }
 
   /**
@@ -90,12 +92,17 @@ public class ReplicationTask extends AbstractReplicationTask {
   }
 
   @Override
+  protected Object getCommandForDebug() {
+    return debugString;
+  }
+
+  @Override
   public String toString() {
-    return "ReplicationTask{" +
-        "status=" + getStatus() +
-        ", cmd={" + cmd + "}" +
-        ", queued=" + getQueued() +
-        '}';
+    String str = super.toString();
+    if (transferredBytes > 0) {
+      str += ", transferred " + transferredBytes + " bytes";
+    }
+    return str;
   }
 
   public long getTransferredBytes() {
@@ -108,10 +115,6 @@ public class ReplicationTask extends AbstractReplicationTask {
 
   DatanodeDetails getTarget() {
     return cmd.getTargetDatanode();
-  }
-
-  ReplicateContainerCommand getCommand() {
-    return cmd;
   }
 
   @Override

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/protocol/commands/ReplicateContainerCommand.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/protocol/commands/ReplicateContainerCommand.java
@@ -164,14 +164,14 @@ public final class ReplicateContainerCommand
   public String toString() {
     StringBuilder sb = new StringBuilder();
     sb.append(getType());
-    sb.append(": containerId: ").append(getContainerID());
-    sb.append(", replicaIndex: ").append(getReplicaIndex());
+    sb.append(": containerId=").append(getContainerID());
+    sb.append(", replicaIndex=").append(getReplicaIndex());
     if (targetDatanode != null) {
-      sb.append(", targetNode: ").append(targetDatanode);
+      sb.append(", targetNode=").append(targetDatanode);
     } else {
-      sb.append(", sourceNodes: ").append(sourceDatanodes);
+      sb.append(", sourceNodes=").append(sourceDatanodes);
     }
-    sb.append(", priority: ").append(priority);
+    sb.append(", priority=").append(priority);
     return sb.toString();
   }
 }

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/replication/GrpcOutputStreamTest.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/replication/GrpcOutputStreamTest.java
@@ -35,6 +35,7 @@ import java.util.Random;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -156,6 +157,16 @@ abstract class GrpcOutputStreamTest<T> {
     subject.close();
 
     verifyResponses(concat(bytes1, bytes2));
+  }
+
+  @Test
+  void rejectsWriteAfterClose() throws IOException {
+    subject.close();
+
+    assertThrows(IllegalStateException.class, () -> subject.write(42));
+    assertThrows(IllegalStateException.class, () -> writeBytes(subject, 42));
+
+    subject.close(); // close is idempotent
   }
 
   private void verifyResponses(byte[] bytes) {

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/UnhealthyReplicationProcessor.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/UnhealthyReplicationProcessor.java
@@ -110,8 +110,10 @@ public abstract class UnhealthyReplicationProcessor<HealthResult extends
     failedOnes.forEach(result ->
         requeueHealthResultFromQueue(replicationManager, result));
 
-    LOG.info("Processed {} containers with health state counts {}," +
-             "failed processing {}", processed, healthStateCntMap, failed);
+    if (processed > 0 || failed > 0) {
+      LOG.info("Processed {} containers with health state counts {}, " +
+          "failed processing {}", processed, healthStateCntMap, failed);
+    }
   }
 
   /**

--- a/hadoop-ozone/dist/src/main/compose/ozonesecure/docker-config
+++ b/hadoop-ozone/dist/src/main/compose/ozonesecure/docker-config
@@ -79,8 +79,7 @@ OZONE-SITE.XML_ozone.httpfs.kerberos.keytab.file=/etc/security/keytabs/httpfs.ke
 OZONE-SITE.XML_ozone.httpfs.kerberos.principal=httpfs/httpfs@EXAMPLE.COM
 
 OZONE-SITE.XML_hdds.scm.replication.thread.interval=5s
-OZONE-SITE.XML_hdds.scm.replication.event.timeout=10s
-OZONE-SITE.XML_hdds.scm.replication.push=true
+OZONE-SITE.XML_hdds.scm.replication.enable.legacy=false
 OZONE-SITE.XML_ozone.scm.stale.node.interval=30s
 OZONE-SITE.XML_ozone.scm.dead.node.interval=45s
 OZONE-SITE.XML_hdds.container.report.interval=60s


### PR DESCRIPTION
## What changes were proposed in this pull request?

* Change some verbose messages to debug level.
* Change some error messages to warn (replication failures are "expected").
* Add some missing info level logs.
* Improve content of some messages.
* Only log containers processed if there were any (in `UnhealthyReplicationProcessor`)
* Disable legacy replication manager in `ozonesecure` env. to exercise push replication 
* Avoid duplicate execution of `close()` in `GrpcOutputStream` (mostly to prevent confusing duplicate log messages)

https://issues.apache.org/jira/browse/HDDS-7867

## How was this patch tested?

Checked logs of replication in `ozonesecure`.

Regular CI:
https://github.com/adoroszlai/hadoop-ozone/actions/runs/4414527872