### PR TITLE
HDDS-8122. [Snapshot] Disable RocksDB column family auto compaction in SstFilteringService

### DIFF
--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/DBStoreBuilder.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/DBStoreBuilder.java
@@ -327,6 +327,20 @@ public final class DBStoreBuilder {
   }
 
   /**
+   * Pass true to disable auto compaction for Column Family by default.
+   * Sets Disable auto compaction flag for Default Column Family option
+   * @param defaultCFAutoCompaction
+   */
+  public DBStoreBuilder disableDefaultCFAutoCompaction(
+          boolean defaultCFAutoCompaction) {
+    ManagedColumnFamilyOptions defaultCFOptions =
+            getDefaultCfOptions();
+    defaultCFOptions.setDisableAutoCompactions(defaultCFAutoCompaction);
+    setDefaultCFOptions(defaultCFOptions);
+    return this;
+  }
+
+  /**
    * Get default column family options, but with column family write buffer
    * size limit overridden.
    * @param writeBufferSize Specify column family write buffer size.

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/RocksDatabase.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/RocksDatabase.java
@@ -278,7 +278,8 @@ public final class RocksDatabase {
       return codec.fromPersistedFormat(nameBytes);
     }
 
-    protected ColumnFamilyHandle getHandle() {
+    @VisibleForTesting
+    public ColumnFamilyHandle getHandle() {
       return handle;
     }
 

--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/utils/db/TestDBStoreBuilder.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/utils/db/TestDBStoreBuilder.java
@@ -29,6 +29,8 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.junit.Assert;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import java.io.File;
 import java.io.IOException;
@@ -36,6 +38,7 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Optional;
 
 /**
  * Tests RDBStore creation.
@@ -230,6 +233,70 @@ public class TestDBStoreBuilder {
         }
       }
       Assert.assertTrue(checked);
+    }
+  }
+
+  @ParameterizedTest
+  @ValueSource(booleans = {true, false})
+  public void testIfAutoCompactionDisabled(boolean disableAutoCompaction,
+          @TempDir Path tempDir)
+          throws Exception {
+    OzoneConfiguration conf = new OzoneConfiguration();
+    conf.set(HddsConfigKeys.OZONE_METADATA_DIRS, tempDir.toString());
+    File newFolder = new File(tempDir.toString(), "newFolder");
+
+    if (!newFolder.exists()) {
+      Assert.assertTrue(newFolder.mkdirs());
+    }
+
+    String sampleTableName = "sampleTable";
+    final DBDefinition sampleDB = new DBDefinition() {
+
+      private final DBColumnFamilyDefinition<String, Long> sampleTable =
+              new DBColumnFamilyDefinition<>(sampleTableName, String.class,
+                      new StringCodec(), Long.class, new LongCodec());
+
+
+      @Override
+      public String getName() {
+        return "sampleDB";
+      }
+
+      @Override
+      public String getLocationConfigKey() {
+        return null;
+      }
+
+      @Override
+      public DBColumnFamilyDefinition[] getColumnFamilies() {
+        return new DBColumnFamilyDefinition[]{sampleTable};
+      }
+
+      @Override
+      public File getDBLocation(ConfigurationSource conf) {
+        return null;
+      }
+    };
+
+    try (DBStore dbStore = DBStoreBuilder.newBuilder(conf, sampleDB)
+            .setName("SampleStore")
+            .disableDefaultCFAutoCompaction(disableAutoCompaction)
+            .setPath(newFolder.toPath()).build()) {
+      Assert.assertTrue(dbStore instanceof RDBStore);
+
+      RDBStore rdbStore = (RDBStore) dbStore;
+      Collection<RocksDatabase.ColumnFamily> cfFamilies =
+              rdbStore.getColumnFamilies();
+
+      // we also have the default column family, so there are 2
+      Assert.assertEquals(2, cfFamilies.size());
+
+      for (RocksDatabase.ColumnFamily cfFamily : cfFamilies) {
+        // the value should be different from the default value
+        Assertions.assertEquals(cfFamily.getHandle().getDescriptor()
+                .getOptions().disableAutoCompactions(),
+                disableAutoCompaction);
+      }
     }
   }
 }

--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/utils/db/TestDBStoreBuilder.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/utils/db/TestDBStoreBuilder.java
@@ -38,7 +38,6 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.Optional;
 
 /**
  * Tests RDBStore creation.

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOmSnapshot.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOmSnapshot.java
@@ -24,7 +24,6 @@ import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.hdds.scm.HddsWhiteboxTestUtils;
 import org.apache.hadoop.hdds.utils.db.DBProfile;
-import org.apache.hadoop.hdds.utils.db.DBStore;
 import org.apache.hadoop.hdds.utils.db.RDBStore;
 import org.apache.hadoop.ozone.MiniOzoneCluster;
 import org.apache.hadoop.ozone.MiniOzoneHAClusterImpl;
@@ -897,7 +896,7 @@ public class TestOmSnapshot {
             .checkForSnapshot(volumeName, bucketName, snapPrefix))
             .getMetadataManager().getStore();
 
-    for(String table : snapshotDBStore.getTableNames().values()) {
+    for (String table : snapshotDBStore.getTableNames().values()) {
       Assertions.assertTrue(snapshotDBStore.getDb().getColumnFamily(table)
               .getHandle().getDescriptor()
               .getOptions().disableAutoCompactions());

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/SstFilteringService.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/SstFilteringService.java
@@ -45,6 +45,7 @@ import java.nio.file.Paths;
 import java.nio.file.StandardOpenOption;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 
@@ -145,7 +146,7 @@ public class SstFilteringService extends BackgroundService {
 
           RDBStore rdbStore = (RDBStore) OmMetadataManagerImpl
               .loadDB(ozoneManager.getConfiguration(), new File(snapshotDir),
-                  dbName, true);
+                  dbName, true, Optional.of(Boolean.TRUE));
           RocksDatabase db = rdbStore.getDb();
           db.deleteFilesNotMatchingPrefix(prefixPairs, filterFunction);
           rdbStore.close();


### PR DESCRIPTION
## What changes were proposed in this pull request?

1) We need to make sure that Snapshot RocksDB instance are opened with configuration option that turns of the auto-compaction.

2) We open rocksDB for snapshot in RW for file filtering service. This is to delete some irrelevant SST files from the snapshot rocksDB manifest. We need to make sure that one of the configuration option in rocksDB option turns of Auto compaction.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-8102
https://issues.apache.org/jira/browse/HDDS-8122


## How was this patch tested?
Unit Tests & Integration Tests