### PR TITLE
HDDS-8155. SCM Block deleting service add transaction blocks for stale/dead/decommissioning DNs

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/block/DeletedBlockLog.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/block/DeletedBlockLog.java
@@ -17,6 +17,7 @@
  */
 package org.apache.hadoop.hdds.scm.block;
 
+import java.util.Set;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
 import org.apache.hadoop.hdds.protocol.proto
     .StorageContainerDatanodeProtocolProtos.ContainerBlocksDeletionACKProto
@@ -46,12 +47,12 @@ public interface DeletedBlockLog extends Closeable {
    * stop.
    *
    * @param blockDeletionLimit Maximum number of blocks to fetch
-   * @param dnUUIDMap map of uuid and DN details
+   * @param dnList healthy dn list
    * @return Mapping from containerId to latest transactionId for the container.
    * @throws IOException
    */
   DatanodeDeletedBlockTransactions getTransactions(
-      int blockDeletionLimit, Map<UUID, DatanodeDetails> dnUUIDMap)
+      int blockDeletionLimit, Set<DatanodeDetails> dnList)
       throws IOException, TimeoutException;
 
   /**

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/block/DeletedBlockLog.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/block/DeletedBlockLog.java
@@ -17,6 +17,7 @@
  */
 package org.apache.hadoop.hdds.scm.block;
 
+import org.apache.hadoop.hdds.protocol.DatanodeDetails;
 import org.apache.hadoop.hdds.protocol.proto
     .StorageContainerDatanodeProtocolProtos.ContainerBlocksDeletionACKProto
     .DeleteBlockTransactionResult;
@@ -43,11 +44,14 @@ public interface DeletedBlockLog extends Closeable {
    * Scan entire log once and returns TXs to DatanodeDeletedBlockTransactions.
    * Once DatanodeDeletedBlockTransactions is full, the scan behavior will
    * stop.
+   *
    * @param blockDeletionLimit Maximum number of blocks to fetch
+   * @param dnUUIDMap map of uuid and DN details
    * @return Mapping from containerId to latest transactionId for the container.
    * @throws IOException
    */
-  DatanodeDeletedBlockTransactions getTransactions(int blockDeletionLimit)
+  DatanodeDeletedBlockTransactions getTransactions(
+      int blockDeletionLimit, Map<UUID, DatanodeDetails> dnUUIDMap)
       throws IOException, TimeoutException;
 
   /**

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/block/DeletedBlockLogImpl.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/block/DeletedBlockLogImpl.java
@@ -401,8 +401,10 @@ public class DeletedBlockLogImpl
   public void close() throws IOException {
   }
 
-  private void getTransaction(DeletedBlocksTransaction tx,
-      DatanodeDeletedBlockTransactions transactions) {
+  private void getTransaction(
+      DeletedBlocksTransaction tx,
+      DatanodeDeletedBlockTransactions transactions,
+      Map<UUID, DatanodeDetails> dnUUIDMap) {
     try {
       DeletedBlocksTransaction updatedTxn = DeletedBlocksTransaction
           .newBuilder(tx)
@@ -413,6 +415,9 @@ public class DeletedBlockLogImpl
               ContainerID.valueOf(updatedTxn.getContainerID()));
       for (ContainerReplica replica : replicas) {
         UUID dnID = replica.getDatanodeDetails().getUuid();
+        if (!dnUUIDMap.containsKey(dnID)) {
+          continue;
+        }
         Set<UUID> dnsWithTransactionCommitted =
             transactionToDNsCommitMap.get(updatedTxn.getTxID());
         if (dnsWithTransactionCommitted == null || !dnsWithTransactionCommitted
@@ -429,7 +434,8 @@ public class DeletedBlockLogImpl
 
   @Override
   public DatanodeDeletedBlockTransactions getTransactions(
-      int blockDeletionLimit) throws IOException, TimeoutException {
+      int blockDeletionLimit, Map<UUID, DatanodeDetails> dnUUIDMap)
+      throws IOException, TimeoutException {
     lock.lock();
     try {
       DatanodeDeletedBlockTransactions transactions =
@@ -455,7 +461,7 @@ public class DeletedBlockLogImpl
               txIDs.add(txn.getTxID());
             } else if (txn.getCount() > -1 && txn.getCount() <= maxRetry
                 && !containerManager.getContainer(id).isOpen()) {
-              getTransaction(txn, transactions);
+              getTransaction(txn, transactions, dnUUIDMap);
               transactionToDNsCommitMap
                   .putIfAbsent(txn.getTxID(), new LinkedHashSet<>());
             }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/block/DeletedBlockLogImpl.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/block/DeletedBlockLogImpl.java
@@ -404,7 +404,7 @@ public class DeletedBlockLogImpl
   private void getTransaction(
       DeletedBlocksTransaction tx,
       DatanodeDeletedBlockTransactions transactions,
-      Map<UUID, DatanodeDetails> dnUUIDMap) {
+      Set<DatanodeDetails> dnList) {
     try {
       DeletedBlocksTransaction updatedTxn = DeletedBlocksTransaction
           .newBuilder(tx)
@@ -415,7 +415,7 @@ public class DeletedBlockLogImpl
               ContainerID.valueOf(updatedTxn.getContainerID()));
       for (ContainerReplica replica : replicas) {
         UUID dnID = replica.getDatanodeDetails().getUuid();
-        if (!dnUUIDMap.containsKey(dnID)) {
+        if (!dnList.contains(replica.getDatanodeDetails())) {
           continue;
         }
         Set<UUID> dnsWithTransactionCommitted =
@@ -434,7 +434,7 @@ public class DeletedBlockLogImpl
 
   @Override
   public DatanodeDeletedBlockTransactions getTransactions(
-      int blockDeletionLimit, Map<UUID, DatanodeDetails> dnUUIDMap)
+      int blockDeletionLimit, Set<DatanodeDetails> dnList)
       throws IOException, TimeoutException {
     lock.lock();
     try {
@@ -461,7 +461,7 @@ public class DeletedBlockLogImpl
               txIDs.add(txn.getTxID());
             } else if (txn.getCount() > -1 && txn.getCount() <= maxRetry
                 && !containerManager.getContainer(id).isOpen()) {
-              getTransaction(txn, transactions, dnUUIDMap);
+              getTransaction(txn, transactions, dnList);
               transactionToDNsCommitMap
                   .putIfAbsent(txn.getTxID(), new LinkedHashSet<>());
             }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/block/SCMBlockDeletingService.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/block/SCMBlockDeletingService.java
@@ -32,6 +32,7 @@ import java.util.stream.Collectors;
 import org.apache.hadoop.hdds.conf.ConfigurationSource;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.DeletedBlocksTransaction;
+import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.SCMCommandProto.Type;
 import org.apache.hadoop.hdds.scm.ScmConfig;
 import org.apache.hadoop.hdds.scm.events.SCMEvents;
 import org.apache.hadoop.hdds.scm.ha.SCMContext;
@@ -134,14 +135,18 @@ public class SCMBlockDeletingService extends BackgroundService
       if (LOG.isDebugEnabled()) {
         LOG.debug("Running DeletedBlockTransactionScanner");
       }
-      // TODO - DECOMM - should we be deleting blocks from decom nodes
-      //        and what about entering maintenance.
+      // When DN node is healthy and in-service, and previous commands 
+      // are handled for deleteBlocks Type, then it will be considered
       List<DatanodeDetails> datanodes =
           nodeManager.getNodes(NodeStatus.inServiceHealthy());
+      Map<UUID, DatanodeDetails> dnUUIDMap = datanodes.stream().filter(
+          dn -> nodeManager.getCommandQueueCount(dn.getUuid(),
+              Type.deleteBlocksCommand) <= 0).collect(
+          Collectors.toMap(DatanodeDetails::getUuid, dn -> dn));
       if (datanodes != null) {
         try {
           DatanodeDeletedBlockTransactions transactions =
-              deletedBlockLog.getTransactions(blockDeleteLimitSize);
+              deletedBlockLog.getTransactions(blockDeleteLimitSize, dnUUIDMap);
 
           if (transactions.isEmpty()) {
             return EmptyTaskResult.newResult();
@@ -156,10 +161,6 @@ public class SCMBlockDeletingService extends BackgroundService
               processedTxIDs.addAll(dnTXs.stream()
                   .map(DeletedBlocksTransaction::getTxID)
                   .collect(Collectors.toSet()));
-              // TODO commandQueue needs a cap.
-              // We should stop caching new commands if num of un-processed
-              // command is bigger than a limit, e.g 50. In case datanode goes
-              // offline for sometime, the cached commands be flooded.
               SCMCommand<?> command = new DeleteBlocksCommand(dnTXs);
               command.setTerm(scmContext.getTermOfLeader());
               eventPublisher.fireEvent(SCMEvents.DATANODE_COMMAND,

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/block/SCMBlockDeletingService.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/block/SCMBlockDeletingService.java
@@ -135,15 +135,16 @@ public class SCMBlockDeletingService extends BackgroundService
       if (LOG.isDebugEnabled()) {
         LOG.debug("Running DeletedBlockTransactionScanner");
       }
-      // When DN node is healthy and in-service, and previous commands 
-      // are handled for deleteBlocks Type, then it will be considered
       List<DatanodeDetails> datanodes =
           nodeManager.getNodes(NodeStatus.inServiceHealthy());
-      Map<UUID, DatanodeDetails> dnUUIDMap = datanodes.stream().filter(
-          dn -> nodeManager.getCommandQueueCount(dn.getUuid(),
-              Type.deleteBlocksCommand) <= 0).collect(
-          Collectors.toMap(DatanodeDetails::getUuid, dn -> dn));
       if (datanodes != null) {
+        // When DN node is healthy and in-service, and previous commands 
+        // are handled for deleteBlocks Type, then it will be considered
+        // in this iteration
+        Map<UUID, DatanodeDetails> dnUUIDMap = datanodes.stream().filter(
+            dn -> nodeManager.getCommandQueueCount(dn.getUuid(),
+                Type.deleteBlocksCommand) == 0).collect(
+            Collectors.toMap(DatanodeDetails::getUuid, dn -> dn));
         try {
           DatanodeDeletedBlockTransactions transactions =
               deletedBlockLog.getTransactions(blockDeleteLimitSize, dnUUIDMap);
@@ -177,7 +178,6 @@ public class SCMBlockDeletingService extends BackgroundService
               }
             }
           }
-          // TODO: Fix ME!!!
           LOG.info("Totally added {} blocks to be deleted for"
                   + " {} datanodes, task elapsed time: {}ms",
               transactions.getBlocksDeleted(),

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/block/SCMBlockDeletingService.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/block/SCMBlockDeletingService.java
@@ -141,13 +141,12 @@ public class SCMBlockDeletingService extends BackgroundService
         // When DN node is healthy and in-service, and previous commands 
         // are handled for deleteBlocks Type, then it will be considered
         // in this iteration
-        Map<UUID, DatanodeDetails> dnUUIDMap = datanodes.stream().filter(
+        final Set<DatanodeDetails> included = datanodes.stream().filter(
             dn -> nodeManager.getCommandQueueCount(dn.getUuid(),
-                Type.deleteBlocksCommand) == 0).collect(
-            Collectors.toMap(DatanodeDetails::getUuid, dn -> dn));
+                Type.deleteBlocksCommand) == 0).collect(Collectors.toSet());
         try {
           DatanodeDeletedBlockTransactions transactions =
-              deletedBlockLog.getTransactions(blockDeleteLimitSize, dnUUIDMap);
+              deletedBlockLog.getTransactions(blockDeleteLimitSize, included);
 
           if (transactions.isEmpty()) {
             return EmptyTaskResult.newResult();

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/DeadNodeHandler.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/DeadNodeHandler.java
@@ -87,6 +87,9 @@ public class DeadNodeHandler implements EventHandler<DatanodeDetails> {
       if (!nodeManager.getNodeStatus(datanodeDetails).isInMaintenance()) {
         removeContainerReplicas(datanodeDetails);
       }
+      
+      // remove commands in command queue for the DN
+      nodeManager.getCommandQueue(datanodeDetails.getUuid());
 
       //move dead datanode out of ClusterNetworkTopology
       NetworkTopology nt = nodeManager.getClusterNetworkTopologyMap();

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/DeadNodeHandler.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/DeadNodeHandler.java
@@ -19,6 +19,7 @@
 package org.apache.hadoop.hdds.scm.node;
 
 import java.io.IOException;
+import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.TimeoutException;
 
@@ -35,6 +36,7 @@ import org.apache.hadoop.hdds.scm.pipeline.PipelineNotFoundException;
 import org.apache.hadoop.hdds.server.events.EventHandler;
 import org.apache.hadoop.hdds.server.events.EventPublisher;
 
+import org.apache.hadoop.ozone.protocol.commands.SCMCommand;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -89,7 +91,10 @@ public class DeadNodeHandler implements EventHandler<DatanodeDetails> {
       }
       
       // remove commands in command queue for the DN
-      nodeManager.getCommandQueue(datanodeDetails.getUuid());
+      final List<SCMCommand> cmdList = nodeManager.getCommandQueue(
+          datanodeDetails.getUuid());
+      LOG.info("Clearing command queue of size {} for DN {}",
+          cmdList.size(), datanodeDetails);
 
       //move dead datanode out of ClusterNetworkTopology
       NetworkTopology nt = nodeManager.getClusterNetworkTopologyMap();

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/block/TestDeletedBlockLog.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/block/TestDeletedBlockLog.java
@@ -448,7 +448,8 @@ public class TestDeletedBlockLog {
     addTransactions(deletedBlocks, true);
     Map<UUID, DatanodeDetails> dnuuidMap = dnList.subList(0, 1).stream()
         .collect(Collectors.toMap(DatanodeDetails::getUuid, dn -> dn));
-    DatanodeDeletedBlockTransactions transactions = deletedBlockLog.getTransactions(
+    DatanodeDeletedBlockTransactions transactions
+        = deletedBlockLog.getTransactions(
         30 * BLOCKS_PER_TXN * THREE, dnuuidMap);
     Assertions.assertEquals(1, transactions.getDatanodeTransactionMap().size());
   }

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/block/TestDeletedBlockLog.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/block/TestDeletedBlockLog.java
@@ -295,8 +295,10 @@ public class TestDeletedBlockLog {
 
   private List<DeletedBlocksTransaction> getTransactions(
       int maximumAllowedBlocksNum) throws IOException, TimeoutException {
+    Map<UUID, DatanodeDetails> dnuuidMap = dnList.stream().collect(
+        Collectors.toMap(DatanodeDetails::getUuid, dn -> dn));
     DatanodeDeletedBlockTransactions transactions =
-        deletedBlockLog.getTransactions(maximumAllowedBlocksNum);
+        deletedBlockLog.getTransactions(maximumAllowedBlocksNum, dnuuidMap);
     List<DeletedBlocksTransaction> txns = new LinkedList<>();
     for (DatanodeDetails dn : dnList) {
       txns.addAll(Optional.ofNullable(
@@ -460,8 +462,10 @@ public class TestDeletedBlockLog {
     // For the first 30 txn, deletedBlockLog only has the txn from dn1 and dn2
     // For the rest txn, txn will be got from all dns.
     // Committed txn will be: 1-40. 1-40. 31-40
+    Map<UUID, DatanodeDetails> dnuuidMap = dnList.stream().collect(
+        Collectors.toMap(DatanodeDetails::getUuid, dn -> dn));
     commitTransactions(deletedBlockLog.getTransactions(
-        30 * BLOCKS_PER_TXN * THREE));
+        30 * BLOCKS_PER_TXN * THREE, dnuuidMap));
 
     // The rest txn shall be: 41-50. 41-50. 41-50
     List<DeletedBlocksTransaction> blocks = getAllTransactions();

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/block/TestDeletedBlockLog.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/block/TestDeletedBlockLog.java
@@ -443,6 +443,17 @@ public class TestDeletedBlockLog {
   }
 
   @Test
+  public void testDNOnlyOneNodeHealthy() throws Exception {
+    Map<Long, List<Long>> deletedBlocks = generateData(50);
+    addTransactions(deletedBlocks, true);
+    Map<UUID, DatanodeDetails> dnuuidMap = dnList.subList(0, 1).stream()
+        .collect(Collectors.toMap(DatanodeDetails::getUuid, dn -> dn));
+    DatanodeDeletedBlockTransactions transactions = deletedBlockLog.getTransactions(
+        30 * BLOCKS_PER_TXN * THREE, dnuuidMap);
+    Assertions.assertEquals(1, transactions.getDatanodeTransactionMap().size());
+  }
+
+  @Test
   public void testInadequateReplicaCommit() throws Exception {
     Map<Long, List<Long>> deletedBlocks = generateData(50);
     addTransactions(deletedBlocks, true);

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/block/TestDeletedBlockLog.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/block/TestDeletedBlockLog.java
@@ -295,10 +295,9 @@ public class TestDeletedBlockLog {
 
   private List<DeletedBlocksTransaction> getTransactions(
       int maximumAllowedBlocksNum) throws IOException, TimeoutException {
-    Map<UUID, DatanodeDetails> dnuuidMap = dnList.stream().collect(
-        Collectors.toMap(DatanodeDetails::getUuid, dn -> dn));
     DatanodeDeletedBlockTransactions transactions =
-        deletedBlockLog.getTransactions(maximumAllowedBlocksNum, dnuuidMap);
+        deletedBlockLog.getTransactions(maximumAllowedBlocksNum,
+            dnList.stream().collect(Collectors.toSet()));
     List<DeletedBlocksTransaction> txns = new LinkedList<>();
     for (DatanodeDetails dn : dnList) {
       txns.addAll(Optional.ofNullable(
@@ -446,11 +445,10 @@ public class TestDeletedBlockLog {
   public void testDNOnlyOneNodeHealthy() throws Exception {
     Map<Long, List<Long>> deletedBlocks = generateData(50);
     addTransactions(deletedBlocks, true);
-    Map<UUID, DatanodeDetails> dnuuidMap = dnList.subList(0, 1).stream()
-        .collect(Collectors.toMap(DatanodeDetails::getUuid, dn -> dn));
     DatanodeDeletedBlockTransactions transactions
         = deletedBlockLog.getTransactions(
-        30 * BLOCKS_PER_TXN * THREE, dnuuidMap);
+        30 * BLOCKS_PER_TXN * THREE,
+        dnList.subList(0, 1).stream().collect(Collectors.toSet()));
     Assertions.assertEquals(1, transactions.getDatanodeTransactionMap().size());
   }
 
@@ -474,10 +472,9 @@ public class TestDeletedBlockLog {
     // For the first 30 txn, deletedBlockLog only has the txn from dn1 and dn2
     // For the rest txn, txn will be got from all dns.
     // Committed txn will be: 1-40. 1-40. 31-40
-    Map<UUID, DatanodeDetails> dnuuidMap = dnList.stream().collect(
-        Collectors.toMap(DatanodeDetails::getUuid, dn -> dn));
     commitTransactions(deletedBlockLog.getTransactions(
-        30 * BLOCKS_PER_TXN * THREE, dnuuidMap));
+        30 * BLOCKS_PER_TXN * THREE,
+        dnList.stream().collect(Collectors.toSet())));
 
     // The rest txn shall be: 41-50. 41-50. 41-50
     List<DeletedBlocksTransaction> blocks = getAllTransactions();

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/node/TestDeadNodeHandler.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/node/TestDeadNodeHandler.java
@@ -25,6 +25,7 @@ import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_DATANODE_RATIS_VOLU
 import java.io.File;
 import java.io.IOException;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
@@ -63,6 +64,8 @@ import org.apache.hadoop.hdds.server.events.EventPublisher;
 
 import org.apache.hadoop.hdds.server.events.EventQueue;
 import org.apache.hadoop.ozone.OzoneConsts;
+import org.apache.hadoop.ozone.protocol.commands.CommandForDatanode;
+import org.apache.hadoop.ozone.protocol.commands.DeleteBlocksCommand;
 import org.apache.hadoop.security.authentication.client
     .AuthenticationException;
 import org.apache.ozone.test.GenericTestUtils;
@@ -247,6 +250,8 @@ public class TestDeadNodeHandler {
 
     // Now set the node to anything other than IN_MAINTENANCE and the relevant
     // replicas should be removed
+    DeleteBlocksCommand cmd = new DeleteBlocksCommand(Collections.emptyList());
+    nodeManager.addDatanodeCommand(datanode1.getUuid(), cmd);
     nodeManager.setNodeOperationalState(datanode1,
         HddsProtos.NodeOperationalState.IN_SERVICE);
     deadNodeHandler.onMessage(datanode1, publisher);
@@ -254,6 +259,8 @@ public class TestDeadNodeHandler {
     //deadNodeHandler.onMessage call will not change this
     Assertions.assertFalse(
         nodeManager.getClusterNetworkTopologyMap().contains(datanode1));
+    Assertions.assertEquals(0, 
+        nodeManager.getCommandQueueCount(datanode1.getUuid(), cmd.getType()));
 
     container1Replicas = containerManager
         .getContainerReplicas(ContainerID.valueOf(container1.getContainerID()));

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/node/TestDeadNodeHandler.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/node/TestDeadNodeHandler.java
@@ -64,7 +64,6 @@ import org.apache.hadoop.hdds.server.events.EventPublisher;
 
 import org.apache.hadoop.hdds.server.events.EventQueue;
 import org.apache.hadoop.ozone.OzoneConsts;
-import org.apache.hadoop.ozone.protocol.commands.CommandForDatanode;
 import org.apache.hadoop.ozone.protocol.commands.DeleteBlocksCommand;
 import org.apache.hadoop.security.authentication.client
     .AuthenticationException;
@@ -246,7 +245,6 @@ public class TestDeadNodeHandler {
             .getContainerReplicas(
                 ContainerID.valueOf(container3.getContainerID()));
     Assertions.assertEquals(1, container3Replicas.size());
-
 
     // Now set the node to anything other than IN_MAINTENANCE and the relevant
     // replicas should be removed

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/TestECContainerRecovery.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/TestECContainerRecovery.java
@@ -246,12 +246,15 @@ public class TestECContainerRecovery {
     cluster.restartHddsDatanode(pipeline.getFirstNode(), true);
     // Check container is over replicated.
     waitForContainerCount(6, container.containerID(), scm);
+
+    // Resume RM and wait the over replicated replica deleted.
+    // ReplicationManager fix container replica state if different
+    scm.getReplicationManager().start();
+
     // Wait for all the replicas to be closed.
     container = scm.getContainerInfo(container.getContainerID());
     waitForDNContainerState(container, scm);
 
-    // Resume RM and wait the over replicated replica deleted.
-    scm.getReplicationManager().start();
     waitForContainerCount(5, container.containerID(), scm);
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

1. Filter of transactions belonging to healthy and In-Service DN, and previous delete transaction command already handled in heartbeat
2. Removal of commands in command queue for the DN which is dead

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-8155

## How was this patch tested?

Unit test is added for the cases, integration test for success and E2E test observing the behavior for DN down case for retry
