### PR TITLE
HDDS-8099. Make unlimited length the default in ozone debug ldb.

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestLDBCli.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestLDBCli.java
@@ -117,6 +117,7 @@ public class TestLDBCli {
     }
     rdbParser.setDbPath(dbStore.getDbLocation().getAbsolutePath());
     dbScanner.setParent(rdbParser);
+    DBScanner.setLimit(100);
     Assert.assertEquals(5, getKeyNames(dbScanner).size());
     Assert.assertTrue(getKeyNames(dbScanner).contains("key1"));
     Assert.assertTrue(getKeyNames(dbScanner).contains("key5"));
@@ -253,6 +254,7 @@ public class TestLDBCli {
     DBScanner.setWithKey(true);
 
     // Scan all container
+    DBScanner.setLimit(-1);
     try (GenericTestUtils.SystemOutCapturer capture =
              new GenericTestUtils.SystemOutCapturer()) {
       dbScanner.call();
@@ -264,6 +266,7 @@ public class TestLDBCli {
 
     // Scan container 1
     DBScanner.setContainerId(1);
+    DBScanner.setLimit(2);
     try (GenericTestUtils.SystemOutCapturer capture =
              new GenericTestUtils.SystemOutCapturer()) {
       dbScanner.call();
@@ -275,6 +278,7 @@ public class TestLDBCli {
 
     // Scan container 2
     DBScanner.setContainerId(2);
+    DBScanner.setLimit(2);
     try (GenericTestUtils.SystemOutCapturer capture =
              new GenericTestUtils.SystemOutCapturer()) {
       dbScanner.call();

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/DBScanner.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/DBScanner.java
@@ -82,9 +82,8 @@ public class DBScanner implements Callable<Void>, SubcommandWithParent {
   private static boolean withKey;
 
   @CommandLine.Option(names = {"--length", "-l"},
-          description = "Maximum number of items to list. " +
-              "If -1 dumps the entire table data")
-  private static int limit = 100;
+          description = "Maximum number of items to list.")
+  private static int limit = -1;
 
   @CommandLine.Option(names = {"--out", "-o"},
       description = "File to dump table scan data")


### PR DESCRIPTION
## What changes were proposed in this pull request?

Make unlimited(-1) length the default in ozone debug ldb.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-8099

## How was this patch tested?

Built locally and verified using docker-compose by creating more than 100 keys and run ldb command to see if it returns all data by default without giving "-l -1" option while running command.
