### PR TITLE
HDDS-7994. Expose information via the ClusterState endpoint on keys and Directories marked for deletion

### DIFF
--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/api/ClusterStateEndpoint.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/api/ClusterStateEndpoint.java
@@ -46,6 +46,7 @@ import javax.ws.rs.core.Response;
 import java.util.List;
 
 import static org.apache.hadoop.ozone.om.OmMetadataManagerImpl.BUCKET_TABLE;
+import static org.apache.hadoop.ozone.om.OmMetadataManagerImpl.DELETED_TABLE;
 import static org.apache.hadoop.ozone.om.OmMetadataManagerImpl.KEY_TABLE;
 import static org.apache.hadoop.ozone.om.OmMetadataManagerImpl.VOLUME_TABLE;
 import static org.apache.hadoop.ozone.om.OmMetadataManagerImpl.FILE_TABLE;
@@ -118,6 +119,9 @@ public class ClusterStateEndpoint {
     // Keys from FILE_SYSTEM_OPTIMIZED buckets
     GlobalStats fileRecord = globalStatsDao.findById(
         TableCountTask.getRowKeyFromTable(FILE_TABLE));
+    // Keys from the DeletedTable
+    GlobalStats deletedKeyRecord = globalStatsDao.findById(
+        TableCountTask.getRowKeyFromTable(DELETED_TABLE));
 
     if (volumeRecord != null) {
       builder.setVolumes(volumeRecord.getValue());
@@ -127,13 +131,19 @@ public class ClusterStateEndpoint {
     }
 
     Long totalKeys = 0L;
+    Long deletedKeys = 0L;
+
     if (keyRecord != null) {
       totalKeys += keyRecord.getValue();
     }
     if (fileRecord != null) {
       totalKeys += fileRecord.getValue();
     }
+    if (deletedKeyRecord != null) {
+      deletedKeys += deletedKeyRecord.getValue();
+    }
     builder.setKeys(totalKeys);
+    builder.setDeletedKeys(deletedKeys);
 
     ClusterStateResponse response = builder
         .setStorageReport(storageReport)

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/api/ClusterStateEndpoint.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/api/ClusterStateEndpoint.java
@@ -45,11 +45,13 @@ import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import java.util.List;
 
+import static org.apache.hadoop.ozone.om.OmMetadataManagerImpl.DELETED_DIR_TABLE;
 import static org.apache.hadoop.ozone.om.OmMetadataManagerImpl.BUCKET_TABLE;
 import static org.apache.hadoop.ozone.om.OmMetadataManagerImpl.DELETED_TABLE;
 import static org.apache.hadoop.ozone.om.OmMetadataManagerImpl.KEY_TABLE;
 import static org.apache.hadoop.ozone.om.OmMetadataManagerImpl.VOLUME_TABLE;
 import static org.apache.hadoop.ozone.om.OmMetadataManagerImpl.FILE_TABLE;
+
 
 /**
  * Endpoint to fetch current state of ozone cluster.
@@ -122,6 +124,9 @@ public class ClusterStateEndpoint {
     // Keys from the DeletedTable
     GlobalStats deletedKeyRecord = globalStatsDao.findById(
         TableCountTask.getRowKeyFromTable(DELETED_TABLE));
+    // Directories from the DeletedDirectoryTable
+    GlobalStats deletedDirRecord = globalStatsDao.findById(
+        TableCountTask.getRowKeyFromTable(DELETED_DIR_TABLE));
 
     if (volumeRecord != null) {
       builder.setVolumes(volumeRecord.getValue());
@@ -132,6 +137,7 @@ public class ClusterStateEndpoint {
 
     Long totalKeys = 0L;
     Long deletedKeys = 0L;
+    Long deletedDirs = 0L;
 
     if (keyRecord != null) {
       totalKeys += keyRecord.getValue();
@@ -142,8 +148,13 @@ public class ClusterStateEndpoint {
     if (deletedKeyRecord != null) {
       deletedKeys += deletedKeyRecord.getValue();
     }
+    if (deletedDirRecord != null) {
+      deletedDirs += deletedDirRecord.getValue();
+    }
+
     builder.setKeys(totalKeys);
     builder.setDeletedKeys(deletedKeys);
+    builder.setDeletedDirs(deletedDirs);
 
     ClusterStateResponse response = builder
         .setStorageReport(storageReport)

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/api/types/ClusterStateResponse.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/api/types/ClusterStateResponse.java
@@ -85,6 +85,12 @@ public final class ClusterStateResponse {
   private long keys;
 
   /**
+   * Total count of keys marked for deletion in the cluster.
+   */
+  @JsonProperty("deletedKeys")
+  private long deletedKeys;
+
+  /**
    * Returns new builder class that builds a ClusterStateResponse.
    *
    * @return Builder
@@ -104,6 +110,7 @@ public final class ClusterStateResponse {
     this.containers = b.containers;
     this.missingContainers = b.missingContainers;
     this.openContainers = b.openContainers;
+    this.deletedKeys = b.deletedKeys;
   }
 
   /**
@@ -121,6 +128,7 @@ public final class ClusterStateResponse {
     private long volumes;
     private long buckets;
     private long keys;
+    private long deletedKeys;
 
     public Builder() {
       // Default values
@@ -133,6 +141,7 @@ public final class ClusterStateResponse {
       this.pipelines = 0;
       this.totalDatanodes = 0;
       this.healthyDatanodes = 0;
+      this.deletedKeys = 0;
     }
 
     public Builder setPipelines(int pipelines) {
@@ -178,6 +187,10 @@ public final class ClusterStateResponse {
     public Builder setBuckets(long buckets) {
       this.buckets = buckets;
       return this;
+    }
+
+    public void setDeletedKeys(long deletedKeys) {
+      this.deletedKeys = deletedKeys;
     }
 
     public Builder setKeys(long keys) {
@@ -230,5 +243,9 @@ public final class ClusterStateResponse {
 
   public long getKeys() {
     return keys;
+  }
+
+  public long getDeletedKeys() {
+    return deletedKeys;
   }
 }

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/api/types/ClusterStateResponse.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/api/types/ClusterStateResponse.java
@@ -91,6 +91,12 @@ public final class ClusterStateResponse {
   private long deletedKeys;
 
   /**
+   * Total count of directories marked for deletion in the cluster.
+   */
+  @JsonProperty
+  private long deletedDirs;
+
+  /**
    * Returns new builder class that builds a ClusterStateResponse.
    *
    * @return Builder
@@ -129,6 +135,7 @@ public final class ClusterStateResponse {
     private long buckets;
     private long keys;
     private long deletedKeys;
+    private long deletedDirs;
 
     public Builder() {
       // Default values
@@ -142,6 +149,7 @@ public final class ClusterStateResponse {
       this.totalDatanodes = 0;
       this.healthyDatanodes = 0;
       this.deletedKeys = 0;
+      this.deletedDirs = 0;
     }
 
     public Builder setPipelines(int pipelines) {
@@ -191,6 +199,10 @@ public final class ClusterStateResponse {
 
     public void setDeletedKeys(long deletedKeys) {
       this.deletedKeys = deletedKeys;
+    }
+
+    public void setDeletedDirs(long deletedDirs) {
+      this.deletedDirs = deletedDirs;
     }
 
     public Builder setKeys(long keys) {
@@ -247,5 +259,9 @@ public final class ClusterStateResponse {
 
   public long getDeletedKeys() {
     return deletedKeys;
+  }
+
+  public long getDeletedDirs() {
+    return deletedDirs;
   }
 }

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/api/types/ClusterStateResponse.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/api/types/ClusterStateResponse.java
@@ -117,6 +117,7 @@ public final class ClusterStateResponse {
     this.missingContainers = b.missingContainers;
     this.openContainers = b.openContainers;
     this.deletedKeys = b.deletedKeys;
+    this.deletedDirs = b.deletedDirs;
   }
 
   /**

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/OMMetadataManagerTestUtils.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/OMMetadataManagerTestUtils.java
@@ -32,6 +32,7 @@ import static org.mockito.Mockito.when;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
@@ -44,6 +45,7 @@ import org.apache.hadoop.hdds.scm.pipeline.PipelineID;
 import org.apache.hadoop.hdds.utils.db.Table;
 import org.apache.hadoop.ozone.om.OMMetadataManager;
 import org.apache.hadoop.ozone.om.OmMetadataManagerImpl;
+import org.apache.hadoop.ozone.om.helpers.RepeatedOmKeyInfo;
 import org.apache.hadoop.ozone.om.helpers.OmKeyLocationInfo;
 import org.apache.hadoop.ozone.om.helpers.OmKeyLocationInfoGroup;
 import org.apache.hadoop.ozone.om.helpers.OmVolumeArgs;
@@ -256,6 +258,35 @@ public final class OMMetadataManagerTestUtils {
                     .setObjectID(objectId)
                     .setParentObjectID(parentObjectId)
                     .build());
+  }
+
+  /**
+   * Writes deleted key information to the Ozone Manager metadata table.
+   * @param omMetadataManager the Ozone Manager metadata manager
+   * @param keyNames the names of the deleted keys
+   * @param bucketName name of the bucket that used to contain the deleted keys
+   * @param volName name of the volume that used to contain the deleted keys
+   * @throws IOException if there is an error accessing the metadata table
+   */
+  public static void writeDeletedKeysToOm(OMMetadataManager omMetadataManager,
+                                         List<String> keyNames,
+                                         String bucketName,
+                                         String volName) throws IOException {
+    List<OmKeyInfo> infos = new ArrayList<>();
+    for (int i = 0; i < keyNames.size(); i++) {
+      infos.add(new OmKeyInfo.Builder()
+          .setBucketName(bucketName)
+          .setVolumeName(volName)
+          .setKeyName(keyNames.get(i))
+          .setReplicationConfig(StandaloneReplicationConfig.getInstance(ONE))
+          .build());
+    }
+    // Get the Ozone key for the first deleted key
+    String omKey = omMetadataManager.getOzoneKey(volName,
+        bucketName, keyNames.get(0));
+    RepeatedOmKeyInfo repeatedKeyInfo = new RepeatedOmKeyInfo(infos);
+    // Put the deleted key information into the deleted table
+    omMetadataManager.getDeletedTable().put(omKey, repeatedKeyInfo);
   }
 
   /**

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/OMMetadataManagerTestUtils.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/OMMetadataManagerTestUtils.java
@@ -328,6 +328,27 @@ public final class OMMetadataManagerTestUtils {
                     .build());
   }
 
+  public static void writeDeletedDirToOm(OMMetadataManager omMetadataManager,
+                                         String bucketName,
+                                         String volumeName,
+                                         String dirName,
+                                         long parentObjectId,
+                                         long bucketObjectId,
+                                         long volumeObjectId)
+      throws IOException {
+    // DB key in DeletedDirectoryTable => "volumeID/bucketID/parentId/dirName"
+    String omKey = omMetadataManager.getOzonePathKey(volumeObjectId,
+            bucketObjectId, parentObjectId, dirName);
+
+    omMetadataManager.getDeletedDirTable().put(omKey,
+        new OmKeyInfo.Builder()
+            .setBucketName(bucketName)
+            .setVolumeName(volumeName)
+            .setKeyName(dirName)
+            .setReplicationConfig(StandaloneReplicationConfig.getInstance(ONE))
+            .build());
+  }
+
   public static OzoneManagerServiceProviderImpl
       getMockOzoneManagerServiceProvider() throws IOException {
     OzoneManagerServiceProviderImpl omServiceProviderMock =

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/api/TestEndpoints.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/api/TestEndpoints.java
@@ -377,12 +377,16 @@ public class TestEndpoints extends AbstractReconSqlDBTest {
     String volumeKey = reconOMMetadataManager.getVolumeKey("sampleVol2");
     OmVolumeArgs args =
         OmVolumeArgs.newBuilder()
-            .setVolume("sampleVol2").setAdminName("TestUser")
-            .setOwnerName("TestUser").build();
+            .setVolume("sampleVol2")
+            .setAdminName("TestUser")
+            .setOwnerName("TestUser")
+            .build();
     reconOMMetadataManager.getVolumeTable().put(volumeKey, args);
 
     OmBucketInfo bucketInfo = OmBucketInfo.newBuilder()
-        .setVolumeName("sampleVol2").setBucketName("bucketOne").build();
+        .setVolumeName("sampleVol2")
+        .setBucketName("bucketOne")
+        .build();
 
     String bucketKey = reconOMMetadataManager.getBucketKey(
         bucketInfo.getVolumeName(), bucketInfo.getBucketName());

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/api/TestEndpoints.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/api/TestEndpoints.java
@@ -89,6 +89,7 @@ import org.junit.jupiter.api.Test;
 
 import static org.apache.hadoop.hdds.protocol.MockDatanodeDetails.randomDatanodeDetails;
 import static org.apache.hadoop.ozone.container.upgrade.UpgradeUtils.defaultLayoutVersionProto;
+import static org.apache.hadoop.ozone.recon.OMMetadataManagerTestUtils.writeDeletedDirToOm;
 import static org.apache.hadoop.ozone.recon.OMMetadataManagerTestUtils.getRandomPipeline;
 import static org.apache.hadoop.ozone.recon.OMMetadataManagerTestUtils.getTestReconOmMetadataManager;
 import static org.apache.hadoop.ozone.recon.OMMetadataManagerTestUtils.initializeNewOmMetadataManager;
@@ -404,6 +405,14 @@ public class TestEndpoints extends AbstractReconSqlDBTest {
     List<String> deletedKeysList3 = Arrays.asList("key3", "key3", "key3");
     writeDeletedKeysToOm(reconOMMetadataManager,
         deletedKeysList3, "Bucket3", "Volume3");
+
+    // Populate the deletedDirectories table in OM DB
+    writeDeletedDirToOm(reconOMMetadataManager, "Bucket1", "Volume1", "dir1",
+        3L, 2L, 1L);
+    writeDeletedDirToOm(reconOMMetadataManager, "Bucket2", "Volume2", "dir2",
+        6L, 5L, 4L);
+    writeDeletedDirToOm(reconOMMetadataManager, "Bucket3", "Volume3", "dir3",
+        9L, 8L, 7L);
 
     // Truncate global stats table before running each test
     dslContext.truncate(GLOBAL_STATS);

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/api/TestEndpoints.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/api/TestEndpoints.java
@@ -258,6 +258,7 @@ public class TestEndpoints extends AbstractReconSqlDBTest {
     dslContext = getDslContext();
   }
 
+  @SuppressWarnings("checkstyle:MethodLength")
   @BeforeEach
   public void setUp() throws Exception {
     // The following setup runs only once
@@ -627,6 +628,7 @@ public class TestEndpoints extends AbstractReconSqlDBTest {
     Assertions.assertEquals(2, clusterStateResponse.getBuckets());
     Assertions.assertEquals(3, clusterStateResponse.getKeys());
     Assertions.assertEquals(3, clusterStateResponse.getDeletedKeys());
+    Assertions.assertEquals(3, clusterStateResponse.getDeletedDirs());
   }
 
   @Test


### PR DESCRIPTION

## What changes were proposed in this pull request?

- When a key is deleted, it is not immediately removed from the metadata but marked for deletion and moved to the DeletedTable. The KeyDeletingService sends requests to delete the corresponding data blocks associated with the keys. Once Recon detects the deletion, it updates its metadata store to reflect the change and retains a record of the deleted key in the DeletedTable for administrators to query.
- This information can be useful for auditing, compliance, and troubleshooting purposes. **_Hence in short the main purpose is to get a quick idea of the deletion progress._**
- This information will be displayed on the overview page of recon which gets populated with the information provided by the `ClusterStateEndpoint` 
- The Jira is coming out of the following discussion :- https://github.com/apache/ozone/pull/4266#issuecomment-1433096670

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-7994

## How was this patch tested?
Unit Testing 
