### PR TITLE
HDDS-8183. Fix edge case where delimiter is empty string in BucketEndpoint#get

### DIFF
--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/commontypes/EncodingTypeObject.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/commontypes/EncodingTypeObject.java
@@ -17,6 +17,8 @@
  */
 package org.apache.hadoop.ozone.s3.commontypes;
 
+import org.apache.commons.lang3.StringUtils;
+
 import javax.annotation.Nullable;
 
 /**
@@ -45,7 +47,7 @@ public final class EncodingTypeObject {
    */
   @Nullable public static EncodingTypeObject createNullable(
       @Nullable String name, @Nullable String encodingType) {
-    if (name == null) {
+    if (StringUtils.isEmpty(name)) {
       return null;
     }
     return new EncodingTypeObject(name, encodingType);

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/BucketEndpoint.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/BucketEndpoint.java
@@ -196,7 +196,7 @@ public class BucketEndpoint extends EndpointBase {
       String relativeKeyName = next.getName().substring(prefix.length());
 
       int depth = StringUtils.countMatches(relativeKeyName, delimiter);
-      if (delimiter != null) {
+      if (!StringUtils.isEmpty(delimiter)) {
         if (depth > 0) {
           // means key has multiple delimiters in its value.
           // ex: dir/dir1/dir2, where delimiter is "/" and prefix is dir/

--- a/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestBucketList.java
+++ b/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestBucketList.java
@@ -172,6 +172,31 @@ public class TestBucketList {
   }
 
   @Test
+  public void listWithPrefixAndEmptyStrDelimiter() throws OS3Exception, IOException {
+    BucketEndpoint getBucket = new BucketEndpoint();
+
+    OzoneClient ozoneClient =
+      createClientWithKeys("dir1/", "dir1/dir2/", "dir1/dir2/file1", "dir1/dir2/file2");
+
+    getBucket.setClient(ozoneClient);
+
+    ListObjectResponse getBucketResponse =
+      (ListObjectResponse) getBucket.get("b1", "", null, null, 100, "dir1/",
+        null, null, null, null, null).getEntity();
+
+    Assert.assertEquals(4, getBucketResponse.getContents().size());
+    Assert.assertEquals("dir1/",
+      getBucketResponse.getContents().get(0).getKey().getName());
+    Assert.assertEquals("dir1/dir2/",
+      getBucketResponse.getContents().get(1).getKey().getName());
+    Assert.assertEquals("dir1/dir2/file1",
+      getBucketResponse.getContents().get(2).getKey().getName());
+    Assert.assertEquals("dir1/dir2/file2",
+      getBucketResponse.getContents().get(3).getKey().getName());
+
+  }
+
+  @Test
   public void listWithContinuationToken() throws OS3Exception, IOException {
 
     BucketEndpoint getBucket = new BucketEndpoint();

--- a/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestBucketList.java
+++ b/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestBucketList.java
@@ -172,29 +172,31 @@ public class TestBucketList {
   }
 
   @Test
-  public void listWithPrefixAndEmptyStrDelimiter() throws OS3Exception, IOException {
+  public void listWithPrefixAndEmptyStrDelimiter()
+      throws OS3Exception, IOException {
     BucketEndpoint getBucket = new BucketEndpoint();
 
     OzoneClient ozoneClient =
-      createClientWithKeys("dir1/", "dir1/dir2/", "dir1/dir2/file1", "dir1/dir2/file2");
+        createClientWithKeys("dir1/", "dir1/dir2/", "dir1/dir2/file1",
+          "dir1/dir2/file2");
 
     getBucket.setClient(ozoneClient);
 
     // Should behave the same if delimiter is null
     ListObjectResponse getBucketResponse =
-      (ListObjectResponse) getBucket.get("b1", "", null, null, 100, "dir1/",
-        null, null, null, null, null).getEntity();
+        (ListObjectResponse) getBucket.get("b1", "", null, null, 100, "dir1/",
+          null, null, null, null, null).getEntity();
 
     Assert.assertEquals(0, getBucketResponse.getCommonPrefixes().size());
     Assert.assertEquals(4, getBucketResponse.getContents().size());
     Assert.assertEquals("dir1/",
-      getBucketResponse.getContents().get(0).getKey().getName());
+        getBucketResponse.getContents().get(0).getKey().getName());
     Assert.assertEquals("dir1/dir2/",
-      getBucketResponse.getContents().get(1).getKey().getName());
+        getBucketResponse.getContents().get(1).getKey().getName());
     Assert.assertEquals("dir1/dir2/file1",
-      getBucketResponse.getContents().get(2).getKey().getName());
+        getBucketResponse.getContents().get(2).getKey().getName());
     Assert.assertEquals("dir1/dir2/file2",
-      getBucketResponse.getContents().get(3).getKey().getName());
+        getBucketResponse.getContents().get(3).getKey().getName());
 
   }
 

--- a/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestBucketList.java
+++ b/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestBucketList.java
@@ -180,10 +180,12 @@ public class TestBucketList {
 
     getBucket.setClient(ozoneClient);
 
+    // Should behave the same if delimiter is null
     ListObjectResponse getBucketResponse =
       (ListObjectResponse) getBucket.get("b1", "", null, null, 100, "dir1/",
         null, null, null, null, null).getEntity();
 
+    Assert.assertEquals(0, getBucketResponse.getCommonPrefixes().size());
     Assert.assertEquals(4, getBucketResponse.getContents().size());
     Assert.assertEquals("dir1/",
       getBucketResponse.getContents().get(0).getKey().getName());


### PR DESCRIPTION
## What changes were proposed in this pull request?

This patch handles an edge case in `BucketEndpoint#get` where delimiter is an empty string. Some S3 client (e.g. Minio S3 Client) passes empty delimiter for recursive list.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-8183

## How was this patch tested?

Unit test and Manual test.

Empty delimiter is able to return the correct response:

<img width="991" alt="image" src="https://user-images.githubusercontent.com/36403683/225564762-064100a5-7d87-42b6-b170-850e20aace4d.png">

