### PR TITLE
HDDS-8167. Inject MoveManager into ContainerBalancer

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/balancer/ContainerBalancerTask.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/balancer/ContainerBalancerTask.java
@@ -134,7 +134,7 @@ public class ContainerBalancerTask implements Runnable {
     this.nodeManager = scm.getScmNodeManager();
     this.containerManager = scm.getContainerManager();
     this.replicationManager = scm.getReplicationManager();
-    this.moveManager = new MoveManager(replicationManager, containerManager);
+    this.moveManager = scm.getMoveManager();
     this.ozoneConfiguration = scm.getConfiguration();
     this.containerBalancer = containerBalancer;
     this.config = config;
@@ -1086,11 +1086,6 @@ public class ContainerBalancerTask implements Runnable {
   @VisibleForTesting
   void setConfig(ContainerBalancerConfiguration config) {
     this.config = config;
-  }
-
-  @VisibleForTesting
-  void setMoveManager(MoveManager moveManager) {
-    this.moveManager = moveManager;
   }
 
   @VisibleForTesting

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/StorageContainerManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/StorageContainerManager.java
@@ -46,6 +46,7 @@ import org.apache.hadoop.hdds.scm.container.ContainerManager;
 import org.apache.hadoop.hdds.scm.container.ContainerManagerImpl;
 import org.apache.hadoop.hdds.scm.PlacementPolicyValidateProxy;
 import org.apache.hadoop.hdds.scm.container.ContainerReplica;
+import org.apache.hadoop.hdds.scm.container.balancer.MoveManager;
 import org.apache.hadoop.hdds.scm.container.replication.ContainerReplicaPendingOps;
 import org.apache.hadoop.hdds.scm.container.replication.DatanodeCommandCountUpdatedHandler;
 import org.apache.hadoop.hdds.scm.container.replication.LegacyReplicationManager;
@@ -287,6 +288,8 @@ public final class StorageContainerManager extends ServiceRuntimeInfoImpl
   private final SCMHANodeDetails scmHANodeDetails;
 
   private ContainerBalancer containerBalancer;
+  // MoveManager is used by ContainerBalancer to schedule container moves
+  private final MoveManager moveManager;
   private StatefulServiceStateManager statefulServiceStateManager;
   // Used to keep track of pending replication and pending deletes for
   // container replicas.
@@ -403,6 +406,8 @@ public final class StorageContainerManager extends ServiceRuntimeInfoImpl
 
     initializeEventHandlers();
 
+    moveManager = new MoveManager(replicationManager, containerManager);
+    containerReplicaPendingOps.registerSubscriber(moveManager);
     containerBalancer = new ContainerBalancer(this);
     LOG.info(containerBalancer.toString());
 
@@ -1766,6 +1771,10 @@ public final class StorageContainerManager extends ServiceRuntimeInfoImpl
   @Override
   public ContainerBalancer getContainerBalancer() {
     return containerBalancer;
+  }
+
+  public MoveManager getMoveManager() {
+    return moveManager;
   }
 
   /**

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/balancer/TestContainerBalancer.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/balancer/TestContainerBalancer.java
@@ -20,13 +20,10 @@ package org.apache.hadoop.hdds.scm.container.balancer;
 
 import com.google.protobuf.ByteString;
 import java.io.IOException;
-import java.time.Clock;
-import java.time.ZoneId;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.TimeoutException;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
-import org.apache.hadoop.hdds.scm.container.replication.ReplicationManager;
 import org.apache.hadoop.hdds.scm.ha.SCMContext;
 import org.apache.hadoop.hdds.scm.ha.SCMServiceManager;
 import org.apache.hadoop.hdds.scm.ha.StatefulServiceStateManager;
@@ -84,12 +81,7 @@ public class TestContainerBalancer {
     when(scm.getConfiguration()).thenReturn(conf);
     when(scm.getStatefulServiceStateManager()).thenReturn(serviceStateManager);
     when(scm.getSCMServiceManager()).thenReturn(mock(SCMServiceManager.class));
-
-    ReplicationManager replicationManager =
-        Mockito.mock(ReplicationManager.class);
-    when(scm.getReplicationManager()).thenReturn(replicationManager);
-    when(replicationManager.getClock()).thenReturn(
-        Clock.system(ZoneId.systemDefault()));
+    when(scm.getMoveManager()).thenReturn(Mockito.mock(MoveManager.class));
 
     /*
     When StatefulServiceStateManager#saveConfiguration is called, save to

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/balancer/TestContainerBalancerTask.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/balancer/TestContainerBalancerTask.java
@@ -128,6 +128,10 @@ public class TestContainerBalancerTask {
     serviceStateManager = Mockito.mock(StatefulServiceStateManagerImpl.class);
     SCMServiceManager scmServiceManager = Mockito.mock(SCMServiceManager.class);
     moveManager = Mockito.mock(MoveManager.class);
+    Mockito.when(moveManager.move(any(ContainerID.class),
+            any(DatanodeDetails.class), any(DatanodeDetails.class)))
+        .thenReturn(CompletableFuture.completedFuture(
+            MoveManager.MoveResult.COMPLETED));
 
     // these configs will usually be specified in each test
     balancerConfiguration =
@@ -194,6 +198,7 @@ public class TestContainerBalancerTask {
     when(scm.getSCMServiceManager()).thenReturn(scmServiceManager);
     when(scm.getPlacementPolicyValidateProxy())
         .thenReturn(placementPolicyValidateProxy);
+    when(scm.getMoveManager()).thenReturn(moveManager);
 
     /*
     When StatefulServiceStateManager#saveConfiguration is called, save to
@@ -219,12 +224,6 @@ public class TestContainerBalancerTask {
     ContainerBalancer sb = new ContainerBalancer(scm);
     containerBalancerTask = new ContainerBalancerTask(scm, 0, sb,
         sb.getMetrics(), balancerConfiguration);
-
-    containerBalancerTask.setMoveManager(moveManager);
-    Mockito.when(moveManager.move(any(ContainerID.class),
-            any(DatanodeDetails.class), any(DatanodeDetails.class)))
-        .thenReturn(CompletableFuture.completedFuture(
-            MoveManager.MoveResult.COMPLETED));
   }
 
   @Test

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/balancer/TestMoveManager.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/balancer/TestMoveManager.java
@@ -110,7 +110,6 @@ public class TestMoveManager {
     Mockito.when(replicationManager.getClock()).thenReturn(clock);
 
     moveManager = new MoveManager(replicationManager, containerManager);
-    moveManager.onLeaderReady();
   }
 
   @Test


### PR DESCRIPTION
## What changes were proposed in this pull request?

Right now, `MoveManager` is instantiated in `ContainerBalancer` and it does not register with `ContainerReplicaPendingOps` as a subscriber. In this PR, we instantiate it inside StorageContainerManager and register it as a subscriber to `ContainerReplicaPendingOps`. Also removed the `running` state inside `MoveManager` and restricted `MoveManager#move` to its package.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-8167

## How was this patch tested?
Existing tests.