### PR TITLE
HDDS-8187. ReplicationManager: Datanode commands should be sent to nodeManager directly

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ReplicationManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ReplicationManager.java
@@ -61,7 +61,6 @@ import org.apache.hadoop.hdds.scm.server.StorageContainerManager;
 import org.apache.hadoop.hdds.server.events.EventPublisher;
 import org.apache.hadoop.ozone.common.statemachine.InvalidStateTransitionException;
 import org.apache.hadoop.ozone.protocol.commands.CloseContainerCommand;
-import org.apache.hadoop.ozone.protocol.commands.CommandForDatanode;
 import org.apache.hadoop.ozone.protocol.commands.DeleteContainerCommand;
 import org.apache.hadoop.ozone.protocol.commands.ReconstructECContainersCommand;
 import org.apache.hadoop.ozone.protocol.commands.ReplicateContainerCommand;
@@ -565,9 +564,7 @@ public class ReplicationManager implements SCMService {
         scmDeadlineEpochMs);
     command.setTerm(getScmTerm());
     command.setDeadline(datanodeDeadlineEpochMs);
-    final CommandForDatanode<?> datanodeCommand =
-        new CommandForDatanode<>(target.getUuid(), command);
-    eventPublisher.fireEvent(SCMEvents.DATANODE_COMMAND, datanodeCommand);
+    nodeManager.addDatanodeCommand(target.getUuid(), command);
     adjustPendingOpsAndMetrics(containerInfo, command, target,
         scmDeadlineEpochMs);
   }

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestReplicationManager.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestReplicationManager.java
@@ -42,7 +42,6 @@ import org.apache.hadoop.hdds.scm.node.NodeManager;
 import org.apache.hadoop.hdds.scm.node.NodeStatus;
 import org.apache.hadoop.hdds.scm.node.states.NodeNotFoundException;
 import org.apache.hadoop.hdds.server.events.EventPublisher;
-import org.apache.hadoop.ozone.protocol.commands.CommandForDatanode;
 import org.apache.hadoop.ozone.protocol.commands.DeleteContainerCommand;
 import org.apache.hadoop.ozone.protocol.commands.ReconstructECContainersCommand;
 import org.apache.hadoop.ozone.protocol.commands.ReplicateContainerCommand;
@@ -119,17 +118,18 @@ public class TestReplicationManager {
     Mockito.when(ecPlacementPolicy.validateContainerPlacement(
         anyList(), anyInt()))
         .thenReturn(new ContainerPlacementStatusDefault(2, 2, 3));
+
+    scmContext = Mockito.mock(SCMContext.class);
+
+    nodeManager = Mockito.mock(NodeManager.class);
     commandsSent = new HashSet<>();
     eventPublisher = Mockito.mock(EventPublisher.class);
     Mockito.doAnswer(invocation -> {
-      CommandForDatanode<?> command = invocation.getArgument(1);
-      commandsSent.add(Pair.of(command.getDatanodeId(), command.getCommand()));
+      commandsSent.add(Pair.of(invocation.getArgument(0),
+          invocation.getArgument(1)));
       return null;
-    }).when(eventPublisher).fireEvent(eq(SCMEvents.DATANODE_COMMAND), any());
+    }).when(nodeManager).addDatanodeCommand(any(), any());
 
-
-    scmContext = Mockito.mock(SCMContext.class);
-    nodeManager = Mockito.mock(NodeManager.class);
     legacyReplicationManager = Mockito.mock(LegacyReplicationManager.class);
     clock = new TestClock(Instant.now(), ZoneId.systemDefault());
     containerReplicaPendingOps =
@@ -224,8 +224,8 @@ public class TestReplicationManager {
 
     replicationManager.processContainer(container, repQueue, repReport);
 
-    Mockito.verify(eventPublisher, Mockito.times(3))
-        .fireEvent(any(), any());
+    Mockito.verify(nodeManager, Mockito.times(3))
+        .addDatanodeCommand(any(), any());
     Assert.assertEquals(1, repReport.getStat(
         ReplicationManagerReport.HealthState.OVER_REPLICATED));
     Assert.assertEquals(0, repQueue.underReplicatedQueueSize());
@@ -257,8 +257,8 @@ public class TestReplicationManager {
 
     replicationManager.processContainer(container, repQueue, repReport);
 
-    Mockito.verify(eventPublisher, Mockito.times(1))
-        .fireEvent(any(), any());
+    Mockito.verify(nodeManager, Mockito.times(1))
+        .addDatanodeCommand(any(), any());
     Assert.assertEquals(1, repReport.getStat(
         ReplicationManagerReport.HealthState.UNDER_REPLICATED));
     Assert.assertEquals(1, repQueue.underReplicatedQueueSize());
@@ -673,7 +673,7 @@ public class TestReplicationManager {
 
     List<ContainerReplicaOp> ops = containerReplicaPendingOps.getPendingOps(
         containerInfo.containerID());
-    Mockito.verify(eventPublisher).fireEvent(any(), any());
+    Mockito.verify(nodeManager).addDatanodeCommand(any(), any());
     Assertions.assertEquals(1, ops.size());
     Assertions.assertEquals(ContainerReplicaOp.PendingOpType.DELETE,
         ops.get(0).getOpType());
@@ -685,7 +685,7 @@ public class TestReplicationManager {
         .getNumDeletionCmdsSent());
 
     // Repeat with Ratis container, as different metrics should be incremented
-    Mockito.clearInvocations(eventPublisher);
+    Mockito.clearInvocations(nodeManager);
     RatisReplicationConfig ratisRepConfig =
         RatisReplicationConfig.getInstance(THREE);
     containerInfo = ReplicationTestUtil.createContainerInfo(ratisRepConfig, 2,
@@ -697,7 +697,7 @@ public class TestReplicationManager {
         containerInfo, target);
 
     ops = containerReplicaPendingOps.getPendingOps(containerInfo.containerID());
-    Mockito.verify(eventPublisher).fireEvent(any(), any());
+    Mockito.verify(nodeManager).addDatanodeCommand(any(), any());
     Assertions.assertEquals(1, ops.size());
     Assertions.assertEquals(ContainerReplicaOp.PendingOpType.DELETE,
         ops.get(0).getOpType());
@@ -740,7 +740,7 @@ public class TestReplicationManager {
 
     List<ContainerReplicaOp> ops = containerReplicaPendingOps.getPendingOps(
         containerInfo.containerID());
-    Mockito.verify(eventPublisher).fireEvent(any(), any());
+    Mockito.verify(nodeManager).addDatanodeCommand(any(), any());
     Assertions.assertEquals(2, ops.size());
     Set<DatanodeDetails> cmdTargets = new HashSet<>();
     Set<Integer> cmdIndexes = new HashSet<>();
@@ -792,7 +792,7 @@ public class TestReplicationManager {
 
     List<ContainerReplicaOp> ops = containerReplicaPendingOps.getPendingOps(
         containerInfo.containerID());
-    Mockito.verify(eventPublisher).fireEvent(any(), any());
+    Mockito.verify(nodeManager).addDatanodeCommand(any(), any());
     Assertions.assertEquals(1, ops.size());
     Assertions.assertEquals(ContainerReplicaOp.PendingOpType.ADD,
         ops.get(0).getOpType());
@@ -804,7 +804,7 @@ public class TestReplicationManager {
         .getNumReplicationCmdsSent());
 
     // Repeat with Ratis container, as different metrics should be incremented
-    Mockito.clearInvocations(eventPublisher);
+    Mockito.clearInvocations(nodeManager);
     RatisReplicationConfig ratisRepConfig =
         RatisReplicationConfig.getInstance(THREE);
     containerInfo = ReplicationTestUtil.createContainerInfo(ratisRepConfig, 2,
@@ -815,7 +815,7 @@ public class TestReplicationManager {
     replicationManager.sendDatanodeCommand(command, containerInfo, target);
 
     ops = containerReplicaPendingOps.getPendingOps(containerInfo.containerID());
-    Mockito.verify(eventPublisher).fireEvent(any(), any());
+    Mockito.verify(nodeManager).addDatanodeCommand(any(), any());
     Assertions.assertEquals(1, ops.size());
     Assertions.assertEquals(ContainerReplicaOp.PendingOpType.ADD,
         ops.get(0).getOpType());
@@ -841,19 +841,19 @@ public class TestReplicationManager {
     replicationManager.sendLowPriorityReplicateContainerCommand(containerInfo,
         0, src, target, scmDeadline, datanodeDeadline);
 
-    ArgumentCaptor<CommandForDatanode> command =
-        ArgumentCaptor.forClass(CommandForDatanode.class);
-    Mockito.verify(eventPublisher).fireEvent(any(), command.capture());
+    ArgumentCaptor<SCMCommand> command =
+        ArgumentCaptor.forClass(SCMCommand.class);
+    ArgumentCaptor<UUID> targetUUID =
+        ArgumentCaptor.forClass(UUID.class);
+    Mockito.verify(nodeManager).addDatanodeCommand(targetUUID.capture(),
+        command.capture());
 
-    CommandForDatanode sentCommand = command.getValue();
-    Assertions.assertEquals(datanodeDeadline,
-        sentCommand.getCommand().getDeadline());
-    ReplicateContainerCommand replicateContainerCommand =
-        (ReplicateContainerCommand) sentCommand.getCommand();
-    Assertions.assertEquals(LOW, replicateContainerCommand.getPriority());
-    Assertions.assertEquals(src.getUuid(), sentCommand.getDatanodeId());
-    Assertions.assertEquals(target,
-        replicateContainerCommand.getTargetDatanode());
+    ReplicateContainerCommand sentCommand =
+        (ReplicateContainerCommand)command.getValue();
+    Assertions.assertEquals(datanodeDeadline, sentCommand.getDeadline());
+    Assertions.assertEquals(LOW, sentCommand.getPriority());
+    Assertions.assertEquals(src.getUuid(), targetUUID.getValue());
+    Assertions.assertEquals(target, sentCommand.getTargetDatanode());
   }
 
   @Test


### PR DESCRIPTION
## What changes were proposed in this pull request?

In order to keep a consistent count of the number of pending replicate and delete commands, ReplicationManager should send commands to the datanode via the nodeManager.addDatanodeCommand() method rather than publishing them to the event queue.

At the moment, the commands goto the event queue, where they are picked up by NodeManager and added to the datanode command queue. As we are using the counts in the command queue to determine how many commands are pending, the indirection provided by the event queue makes it difficult to keep a consistent count without excessive effort.

There is also no further processing done on the commands in the event queue, they simply go RM -> Event Queue -> Node Manager -> Command Queue.

This change makes RM send the commands to nodeManager directly.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-8187

## How was this patch tested?

Modified existing tests to ensure nodeManager is getting called rather than eventQueue.
