### PR TITLE
HDDS-8168. Make deadlines inside MoveManager for move commands configurable

### DIFF
--- a/hadoop-hdds/interface-client/src/main/proto/hdds.proto
+++ b/hadoop-hdds/interface-client/src/main/proto/hdds.proto
@@ -451,7 +451,6 @@ message ContainerBalancerConfigurationProto {
 
     required bool shouldRun = 18;
     optional int32 nextIterationIndex = 19;
-
     optional int64 moveReplicationTimeout = 20;
 }
 

--- a/hadoop-hdds/interface-client/src/main/proto/hdds.proto
+++ b/hadoop-hdds/interface-client/src/main/proto/hdds.proto
@@ -451,6 +451,8 @@ message ContainerBalancerConfigurationProto {
 
     required bool shouldRun = 18;
     optional int32 nextIterationIndex = 19;
+
+    optional int64 moveReplicationTimeout = 20;
 }
 
 message TransferLeadershipRequestProto {

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/balancer/ContainerBalancer.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/balancer/ContainerBalancer.java
@@ -409,6 +409,18 @@ public class ContainerBalancer extends StatefulService {
               "should be greater than hdds.datanode.du.refresh.period {}",
           conf.getBalancingInterval(), refreshPeriod);
     }
+
+    // "move.replication.timeout" should be lesser than "move.timeout"
+    if (conf.getMoveReplicationTimeout().toMillis() >=
+        conf.getMoveTimeout().toMillis()) {
+      LOG.warn("hdds.container.balancer.move.replication.timeout {} should " +
+              "be lesser than hdds.container.balancer.move.timeout {}.",
+          conf.getMoveReplicationTimeout().toMinutes(),
+          conf.getMoveTimeout().toMinutes());
+      throw new InvalidContainerBalancerConfigurationException(
+          "hdds.container.balancer.move.replication.timeout should " +
+          "be lesser than hdds.container.balancer.move.timeout.");
+    }
   }
 
   public ContainerBalancerMetrics getMetrics() {

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/balancer/ContainerBalancer.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/balancer/ContainerBalancer.java
@@ -414,12 +414,12 @@ public class ContainerBalancer extends StatefulService {
     if (conf.getMoveReplicationTimeout().toMillis() >=
         conf.getMoveTimeout().toMillis()) {
       LOG.warn("hdds.container.balancer.move.replication.timeout {} should " +
-              "be lesser than hdds.container.balancer.move.timeout {}.",
+              "be less than hdds.container.balancer.move.timeout {}.",
           conf.getMoveReplicationTimeout().toMinutes(),
           conf.getMoveTimeout().toMinutes());
       throw new InvalidContainerBalancerConfigurationException(
           "hdds.container.balancer.move.replication.timeout should " +
-          "be lesser than hdds.container.balancer.move.timeout.");
+          "be less than hdds.container.balancer.move.timeout.");
     }
   }
 

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/balancer/ContainerBalancerConfiguration.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/balancer/ContainerBalancerConfiguration.java
@@ -93,24 +93,24 @@ public final class ContainerBalancerConfiguration {
       "to exclude from balancing. For example \"1, 4, 5\" or \"1,4,5\".")
   private String excludeContainers = "";
 
-  @Config(key = "move.timeout", type = ConfigType.TIME, defaultValue = "90m",
+  @Config(key = "move.timeout", type = ConfigType.TIME, defaultValue = "65m",
       tags = {ConfigTag.BALANCER}, description =
       "The amount of time to allow a single container to move " +
           "from source to target.")
-  private long moveTimeout = Duration.ofMinutes(90).toMillis();
+  private long moveTimeout = Duration.ofMinutes(65).toMillis();
 
   @Config(key = "move.replication.timeout", type = ConfigType.TIME,
-      defaultValue = "60m", tags = {ConfigTag.BALANCER}, description = "The " +
+      defaultValue = "50m", tags = {ConfigTag.BALANCER}, description = "The " +
       "amount of time to allow a single container's replication from source " +
       "to target as part of container move. For example, if \"hdds.container" +
-      ".balancer.move.timeout\" is 90 minutes, then out of those 90 minutes " +
-      "60 minutes will be the deadline for replication to complete.")
-  private long moveReplicationTimeout = Duration.ofMinutes(60).toMillis();
+      ".balancer.move.timeout\" is 65 minutes, then out of those 65 minutes " +
+      "50 minutes will be the deadline for replication to complete.")
+  private long moveReplicationTimeout = Duration.ofMinutes(50).toMillis();
 
   @Config(key = "balancing.iteration.interval", type = ConfigType.TIME,
-      defaultValue = "160m", tags = {ConfigTag.BALANCER}, description =
+      defaultValue = "70m", tags = {ConfigTag.BALANCER}, description =
       "The interval period between each iteration of Container Balancer.")
-  private long balancingInterval = Duration.ofMinutes(160).toMillis();
+  private long balancingInterval = Duration.ofMinutes(70).toMillis();
 
   @Config(key = "include.datanodes", type = ConfigType.STRING, defaultValue =
       "", tags = {ConfigTag.BALANCER}, description = "A list of Datanode " +

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/balancer/ContainerBalancerConfiguration.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/balancer/ContainerBalancerConfiguration.java
@@ -108,9 +108,9 @@ public final class ContainerBalancerConfiguration {
   private long moveReplicationTimeout = Duration.ofMinutes(60).toMillis();
 
   @Config(key = "balancing.iteration.interval", type = ConfigType.TIME,
-      defaultValue = "130m", tags = {ConfigTag.BALANCER}, description =
+      defaultValue = "160m", tags = {ConfigTag.BALANCER}, description =
       "The interval period between each iteration of Container Balancer.")
-  private long balancingInterval = Duration.ofMinutes(130).toMillis();
+  private long balancingInterval = Duration.ofMinutes(160).toMillis();
 
   @Config(key = "include.datanodes", type = ConfigType.STRING, defaultValue =
       "", tags = {ConfigTag.BALANCER}, description = "A list of Datanode " +

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/balancer/ContainerBalancerConfiguration.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/balancer/ContainerBalancerConfiguration.java
@@ -93,16 +93,24 @@ public final class ContainerBalancerConfiguration {
       "to exclude from balancing. For example \"1, 4, 5\" or \"1,4,5\".")
   private String excludeContainers = "";
 
-  @Config(key = "move.timeout", type = ConfigType.TIME, defaultValue = "30m",
+  @Config(key = "move.timeout", type = ConfigType.TIME, defaultValue = "90m",
       tags = {ConfigTag.BALANCER}, description =
       "The amount of time to allow a single container to move " +
           "from source to target.")
-  private long moveTimeout = Duration.ofMinutes(30).toMillis();
+  private long moveTimeout = Duration.ofMinutes(90).toMillis();
+
+  @Config(key = "move.replication.timeout", type = ConfigType.TIME,
+      defaultValue = "60m", tags = {ConfigTag.BALANCER}, description = "The " +
+      "amount of time to allow a single container's replication from source " +
+      "to target as part of container move. For example, if \"hdds.container" +
+      ".balancer.move.timeout\" is 90 minutes, then out of those 90 minutes " +
+      "60 minutes will be the deadline for replication to complete.")
+  private long moveReplicationTimeout = Duration.ofMinutes(60).toMillis();
 
   @Config(key = "balancing.iteration.interval", type = ConfigType.TIME,
-      defaultValue = "70m", tags = {ConfigTag.BALANCER}, description =
+      defaultValue = "130m", tags = {ConfigTag.BALANCER}, description =
       "The interval period between each iteration of Container Balancer.")
-  private long balancingInterval = Duration.ofMinutes(70).toMillis();
+  private long balancingInterval = Duration.ofMinutes(130).toMillis();
 
   @Config(key = "include.datanodes", type = ConfigType.STRING, defaultValue =
       "", tags = {ConfigTag.BALANCER}, description = "A list of Datanode " +
@@ -326,6 +334,14 @@ public final class ContainerBalancerConfiguration {
     this.moveTimeout = millis;
   }
 
+  public Duration getMoveReplicationTimeout() {
+    return Duration.ofMillis(moveReplicationTimeout);
+  }
+
+  public void setMoveReplicationTimeout(long millis) {
+    this.moveReplicationTimeout = millis;
+  }
+
   public Duration getBalancingInterval() {
     return Duration.ofMillis(balancingInterval);
   }
@@ -423,7 +439,8 @@ public final class ContainerBalancerConfiguration {
         .setIncludeDatanodes(includeNodes)
         .setExcludeDatanodes(excludeNodes)
         .setMoveNetworkTopologyEnable(networkTopologyEnable)
-        .setTriggerDuBeforeMoveEnable(triggerDuEnable);
+        .setTriggerDuBeforeMoveEnable(triggerDuEnable)
+        .setMoveReplicationTimeout(moveReplicationTimeout);
     return builder;
   }
 
@@ -471,6 +488,9 @@ public final class ContainerBalancerConfiguration {
     }
     if (proto.hasTriggerDuBeforeMoveEnable()) {
       config.setTriggerDuEnable(proto.getTriggerDuBeforeMoveEnable());
+    }
+    if (proto.hasMoveReplicationTimeout()) {
+      config.setMoveReplicationTimeout(proto.getMoveReplicationTimeout());
     }
     return config;
   }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/balancer/ContainerBalancerTask.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/balancer/ContainerBalancerTask.java
@@ -134,7 +134,7 @@ public class ContainerBalancerTask implements Runnable {
     this.nodeManager = scm.getScmNodeManager();
     this.containerManager = scm.getContainerManager();
     this.replicationManager = scm.getReplicationManager();
-    this.moveManager = new MoveManager(replicationManager, containerManager);
+    this.moveManager = scm.getMoveManager();
     this.ozoneConfiguration = scm.getConfiguration();
     this.containerBalancer = containerBalancer;
     this.config = config;
@@ -1086,11 +1086,6 @@ public class ContainerBalancerTask implements Runnable {
   @VisibleForTesting
   void setConfig(ContainerBalancerConfiguration config) {
     this.config = config;
-  }
-
-  @VisibleForTesting
-  void setMoveManager(MoveManager moveManager) {
-    this.moveManager = moveManager;
   }
 
   @VisibleForTesting

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/balancer/ContainerBalancerTask.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/balancer/ContainerBalancerTask.java
@@ -135,8 +135,8 @@ public class ContainerBalancerTask implements Runnable {
     this.containerManager = scm.getContainerManager();
     this.replicationManager = scm.getReplicationManager();
     this.moveManager = scm.getMoveManager();
-    this.moveManager.setMoveDeadline(config.getMoveTimeout().toMillis());
-    this.moveManager.setReplicationDeadline(
+    this.moveManager.setMoveTimeout(config.getMoveTimeout().toMillis());
+    this.moveManager.setReplicationTimeout(
         config.getMoveReplicationTimeout().toMillis());
     this.ozoneConfiguration = scm.getConfiguration();
     this.containerBalancer = containerBalancer;

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/balancer/ContainerBalancerTask.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/balancer/ContainerBalancerTask.java
@@ -135,6 +135,9 @@ public class ContainerBalancerTask implements Runnable {
     this.containerManager = scm.getContainerManager();
     this.replicationManager = scm.getReplicationManager();
     this.moveManager = scm.getMoveManager();
+    this.moveManager.setMoveDeadline(config.getMoveTimeout().toMillis());
+    this.moveManager.setReplicationDeadline(
+        config.getMoveReplicationTimeout().toMillis());
     this.ozoneConfiguration = scm.getConfiguration();
     this.containerBalancer = containerBalancer;
     this.config = config;

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/balancer/MoveManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/balancer/MoveManager.java
@@ -109,8 +109,11 @@ public final class MoveManager implements
   // TODO - Should pending ops notify under lock to allow MM to schedule a
   //        delete after the move, but before anything else can, eg RM?
 
-  // TODO - these need to be config defined somewhere, probably in the balancer
-  private static final long MOVE_DEADLINE = 1000 * 60 * 60; // 1 hour
+  /*
+  moveDeadline and replicationDeadline are set by ContainerBalancer.
+   */
+  private long moveDeadline = 1000 * 90 * 60;
+  private long replicationDeadline = 1000 * 60 * 60;
   private static final double MOVE_DEADLINE_FACTOR = 0.95;
 
   private final ReplicationManager replicationManager;
@@ -320,8 +323,11 @@ public final class MoveManager implements
         try {
           handleSuccessfulAdd(containerID);
         } catch (ContainerNotFoundException | NodeNotFoundException |
-                 ContainerReplicaNotFoundException e) {
-          LOG.warn("Can not handle successful Add for move", e);
+                 ContainerReplicaNotFoundException | NotLeaderException e) {
+          LOG.warn("Failed to handle successful Add for container {} being " +
+              "moved from source {} to target {}.", containerID,
+              mdnp.getSrc(), mdnp.getTgt(), e);
+          pair.getLeft().complete(MoveResult.FAIL_UNEXPECTED_ERROR);
         }
       } else if (
             opType.equals(PendingOpType.DELETE) && mdnp.getSrc().equals(dn)) {
@@ -355,8 +361,8 @@ public final class MoveManager implements
 
   private void handleSuccessfulAdd(final ContainerID cid)
       throws ContainerNotFoundException,
-      ContainerReplicaNotFoundException, NodeNotFoundException {
-
+      ContainerReplicaNotFoundException, NodeNotFoundException,
+      NotLeaderException {
     Pair<CompletableFuture<MoveResult>, MoveDataNodePair> pair =
         pendingMoves.get(cid);
     if (pair == null) {
@@ -442,8 +448,8 @@ public final class MoveManager implements
         containerInfo.containerID(), src);
     long now = clock.millis();
     replicationManager.sendLowPriorityReplicateContainerCommand(containerInfo,
-        replicaIndex, src, tgt, now + MOVE_DEADLINE,
-        now + Math.round(MOVE_DEADLINE * MOVE_DEADLINE_FACTOR));
+        replicaIndex, src, tgt, now + replicationDeadline,
+        now + Math.round(replicationDeadline * MOVE_DEADLINE_FACTOR));
   }
 
   /**
@@ -451,20 +457,19 @@ public final class MoveManager implements
    * datanode.
    *
    * @param containerInfo Container to be deleted
-   * @param datanode      The datanode on which the replica should be deleted
+   * @param datanode The datanode on which the replica should be deleted
    */
   private void sendDeleteCommand(
       final ContainerInfo containerInfo, final DatanodeDetails datanode)
-      throws ContainerReplicaNotFoundException, ContainerNotFoundException {
+      throws ContainerReplicaNotFoundException, ContainerNotFoundException,
+      NotLeaderException {
     int replicaIndex = getContainerReplicaIndex(
         containerInfo.containerID(), datanode);
-    try {
-      replicationManager.sendDeleteCommand(
-          containerInfo, replicaIndex, datanode, true);
-    } catch (NotLeaderException nle) {
-      LOG.warn("Skipped deleting the container as this SCM is not the leader.",
-          nle);
-    }
+    long deleteDeadline = moveDeadline - replicationDeadline;
+    long now = clock.millis();
+    replicationManager.sendDeleteCommand(
+        containerInfo, replicaIndex, datanode, true, now + deleteDeadline,
+        now + Math.round(deleteDeadline * MOVE_DEADLINE_FACTOR));
   }
 
   private int getContainerReplicaIndex(
@@ -487,5 +492,13 @@ public final class MoveManager implements
     } else {
       notifyContainerOpCompleted(op, containerID);
     }
+  }
+
+  void setMoveDeadline(long moveDeadline) {
+    this.moveDeadline = moveDeadline;
+  }
+
+  void setReplicationDeadline(long replicationDeadline) {
+    this.replicationDeadline = replicationDeadline;
   }
 }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/balancer/MoveManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/balancer/MoveManager.java
@@ -110,10 +110,10 @@ public final class MoveManager implements
   //        delete after the move, but before anything else can, eg RM?
 
   /*
-  moveDeadline and replicationDeadline are set by ContainerBalancer.
+  moveTimeout and replicationTimeout are set by ContainerBalancer.
    */
-  private long moveDeadline = 1000 * 90 * 60;
-  private long replicationDeadline = 1000 * 60 * 60;
+  private long moveTimeout = 1000 * 90 * 60;
+  private long replicationTimeout = 1000 * 60 * 60;
   private static final double MOVE_DEADLINE_FACTOR = 0.95;
 
   private final ReplicationManager replicationManager;
@@ -448,8 +448,8 @@ public final class MoveManager implements
         containerInfo.containerID(), src);
     long now = clock.millis();
     replicationManager.sendLowPriorityReplicateContainerCommand(containerInfo,
-        replicaIndex, src, tgt, now + replicationDeadline,
-        now + Math.round(replicationDeadline * MOVE_DEADLINE_FACTOR));
+        replicaIndex, src, tgt, now + replicationTimeout,
+        now + Math.round(replicationTimeout * MOVE_DEADLINE_FACTOR));
   }
 
   /**
@@ -465,11 +465,11 @@ public final class MoveManager implements
       NotLeaderException {
     int replicaIndex = getContainerReplicaIndex(
         containerInfo.containerID(), datanode);
-    long deleteDeadline = moveDeadline - replicationDeadline;
+    long deleteTimeout = moveTimeout - replicationTimeout;
     long now = clock.millis();
     replicationManager.sendDeleteCommand(
-        containerInfo, replicaIndex, datanode, true, now + deleteDeadline,
-        now + Math.round(deleteDeadline * MOVE_DEADLINE_FACTOR));
+        containerInfo, replicaIndex, datanode, true, now + deleteTimeout,
+        now + Math.round(deleteTimeout * MOVE_DEADLINE_FACTOR));
   }
 
   private int getContainerReplicaIndex(
@@ -494,11 +494,11 @@ public final class MoveManager implements
     }
   }
 
-  void setMoveDeadline(long moveDeadline) {
-    this.moveDeadline = moveDeadline;
+  void setMoveTimeout(long moveTimeout) {
+    this.moveTimeout = moveTimeout;
   }
 
-  void setReplicationDeadline(long replicationDeadline) {
-    this.replicationDeadline = replicationDeadline;
+  void setReplicationTimeout(long replicationTimeout) {
+    this.replicationTimeout = replicationTimeout;
   }
 }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/balancer/MoveManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/balancer/MoveManager.java
@@ -112,8 +112,8 @@ public final class MoveManager implements
   /*
   moveTimeout and replicationTimeout are set by ContainerBalancer.
    */
-  private long moveTimeout = 1000 * 90 * 60;
-  private long replicationTimeout = 1000 * 60 * 60;
+  private long moveTimeout = 1000 * 65 * 60;
+  private long replicationTimeout = 1000 * 50 * 60;
   private static final double MOVE_DEADLINE_FACTOR = 0.95;
 
   private final ReplicationManager replicationManager;

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ReplicationManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ReplicationManager.java
@@ -438,6 +438,35 @@ public class ReplicationManager implements SCMService {
   }
 
   /**
+   * Send a delete command with a deadline for the specified container.
+   * @param container container to be deleted
+   * @param replicaIndex index of the replica to be deleted
+   * @param datanode datanode that hosts the replica to be deleted
+   * @param force true to force delete a container that is open or not empty
+   * @param scmDeadlineEpochMs The epoch time in ms, after which the command
+   *                           will be discarded from the SCMPendingOps table.
+   * @param datanodeDeadlineEpochMs The epoch time in ms, after which the
+   *                                command will be discarded on the datanode if
+   *                                it has not been processed.
+   * @throws NotLeaderException when this SCM is not the leader
+   */
+  public void sendDeleteCommand(final ContainerInfo container,
+      int replicaIndex, final DatanodeDetails datanode, boolean force,
+      long scmDeadlineEpochMs, long datanodeDeadlineEpochMs)
+      throws NotLeaderException {
+    LOG.debug("Sending delete command for container {} and index {} on {} " +
+            "with SCM deadline {} and Datanode deadline {}.",
+        container, replicaIndex, datanode, scmDeadlineEpochMs,
+        datanodeDeadlineEpochMs);
+
+    final DeleteContainerCommand deleteCommand =
+        new DeleteContainerCommand(container.containerID(), force);
+    deleteCommand.setReplicaIndex(replicaIndex);
+    sendDatanodeCommand(deleteCommand, container, datanode,
+        scmDeadlineEpochMs, datanodeDeadlineEpochMs);
+  }
+
+  /**
    * Create a ReplicateContainerCommand for the given container and to push the
    * container to the target datanode. The list of sources are checked to ensure
    * the datanode has sufficient capacity to accept the container command, and

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/StorageContainerManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/StorageContainerManager.java
@@ -46,6 +46,7 @@ import org.apache.hadoop.hdds.scm.container.ContainerManager;
 import org.apache.hadoop.hdds.scm.container.ContainerManagerImpl;
 import org.apache.hadoop.hdds.scm.PlacementPolicyValidateProxy;
 import org.apache.hadoop.hdds.scm.container.ContainerReplica;
+import org.apache.hadoop.hdds.scm.container.balancer.MoveManager;
 import org.apache.hadoop.hdds.scm.container.replication.ContainerReplicaPendingOps;
 import org.apache.hadoop.hdds.scm.container.replication.DatanodeCommandCountUpdatedHandler;
 import org.apache.hadoop.hdds.scm.container.replication.LegacyReplicationManager;
@@ -287,6 +288,8 @@ public final class StorageContainerManager extends ServiceRuntimeInfoImpl
   private final SCMHANodeDetails scmHANodeDetails;
 
   private ContainerBalancer containerBalancer;
+  // MoveManager is used by ContainerBalancer to schedule container moves
+  private final MoveManager moveManager;
   private StatefulServiceStateManager statefulServiceStateManager;
   // Used to keep track of pending replication and pending deletes for
   // container replicas.
@@ -403,6 +406,8 @@ public final class StorageContainerManager extends ServiceRuntimeInfoImpl
 
     initializeEventHandlers();
 
+    moveManager = new MoveManager(replicationManager, containerManager);
+    containerReplicaPendingOps.registerSubscriber(moveManager);
     containerBalancer = new ContainerBalancer(this);
     LOG.info(containerBalancer.toString());
 
@@ -1766,6 +1771,10 @@ public final class StorageContainerManager extends ServiceRuntimeInfoImpl
   @Override
   public ContainerBalancer getContainerBalancer() {
     return containerBalancer;
+  }
+
+  public MoveManager getMoveManager() {
+    return moveManager;
   }
 
   /**

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/balancer/TestContainerBalancer.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/balancer/TestContainerBalancer.java
@@ -20,13 +20,10 @@ package org.apache.hadoop.hdds.scm.container.balancer;
 
 import com.google.protobuf.ByteString;
 import java.io.IOException;
-import java.time.Clock;
-import java.time.ZoneId;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.TimeoutException;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
-import org.apache.hadoop.hdds.scm.container.replication.ReplicationManager;
 import org.apache.hadoop.hdds.scm.ha.SCMContext;
 import org.apache.hadoop.hdds.scm.ha.SCMServiceManager;
 import org.apache.hadoop.hdds.scm.ha.StatefulServiceStateManager;
@@ -84,12 +81,7 @@ public class TestContainerBalancer {
     when(scm.getConfiguration()).thenReturn(conf);
     when(scm.getStatefulServiceStateManager()).thenReturn(serviceStateManager);
     when(scm.getSCMServiceManager()).thenReturn(mock(SCMServiceManager.class));
-
-    ReplicationManager replicationManager =
-        Mockito.mock(ReplicationManager.class);
-    when(scm.getReplicationManager()).thenReturn(replicationManager);
-    when(replicationManager.getClock()).thenReturn(
-        Clock.system(ZoneId.systemDefault()));
+    when(scm.getMoveManager()).thenReturn(Mockito.mock(MoveManager.class));
 
     /*
     When StatefulServiceStateManager#saveConfiguration is called, save to

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/balancer/TestContainerBalancer.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/balancer/TestContainerBalancer.java
@@ -22,6 +22,7 @@ import com.google.protobuf.ByteString;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.scm.ha.SCMContext;
@@ -190,6 +191,30 @@ public class TestContainerBalancer {
     containerBalancer.stop();
     Assertions.assertTrue(containerBalancer.getBalancerStatus()
         == ContainerBalancerTask.Status.STOPPED);
+  }
+
+  /**
+   * This tests that ContainerBalancer rejects certain invalid configurations
+   * while starting. It should fail to start in some cases.
+   */
+  @Test
+  public void testValidationOfConfigurations() {
+    OzoneConfiguration conf = new OzoneConfiguration();
+
+    conf.setTimeDuration(
+        "hdds.container.balancer.move.replication.timeout", 60,
+        TimeUnit.MINUTES);
+
+    conf.setTimeDuration("hdds.container.balancer.move.timeout", 59,
+        TimeUnit.MINUTES);
+
+    balancerConfiguration =
+        conf.getObject(ContainerBalancerConfiguration.class);
+    Assertions.assertThrowsExactly(
+        InvalidContainerBalancerConfigurationException.class,
+        () -> containerBalancer.startBalancer(balancerConfiguration),
+        "hdds.container.balancer.move.replication.timeout should " +
+            "be lesser than hdds.container.balancer.move.timeout.");
   }
 
   private void startBalancer(ContainerBalancerConfiguration config)

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/balancer/TestContainerBalancer.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/balancer/TestContainerBalancer.java
@@ -214,7 +214,7 @@ public class TestContainerBalancer {
         InvalidContainerBalancerConfigurationException.class,
         () -> containerBalancer.startBalancer(balancerConfiguration),
         "hdds.container.balancer.move.replication.timeout should " +
-            "be lesser than hdds.container.balancer.move.timeout.");
+            "be less than hdds.container.balancer.move.timeout.");
   }
 
   private void startBalancer(ContainerBalancerConfiguration config)

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/balancer/TestContainerBalancerTask.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/balancer/TestContainerBalancerTask.java
@@ -128,6 +128,10 @@ public class TestContainerBalancerTask {
     serviceStateManager = Mockito.mock(StatefulServiceStateManagerImpl.class);
     SCMServiceManager scmServiceManager = Mockito.mock(SCMServiceManager.class);
     moveManager = Mockito.mock(MoveManager.class);
+    Mockito.when(moveManager.move(any(ContainerID.class),
+            any(DatanodeDetails.class), any(DatanodeDetails.class)))
+        .thenReturn(CompletableFuture.completedFuture(
+            MoveManager.MoveResult.COMPLETED));
 
     // these configs will usually be specified in each test
     balancerConfiguration =
@@ -194,6 +198,7 @@ public class TestContainerBalancerTask {
     when(scm.getSCMServiceManager()).thenReturn(scmServiceManager);
     when(scm.getPlacementPolicyValidateProxy())
         .thenReturn(placementPolicyValidateProxy);
+    when(scm.getMoveManager()).thenReturn(moveManager);
 
     /*
     When StatefulServiceStateManager#saveConfiguration is called, save to
@@ -219,12 +224,6 @@ public class TestContainerBalancerTask {
     ContainerBalancer sb = new ContainerBalancer(scm);
     containerBalancerTask = new ContainerBalancerTask(scm, 0, sb,
         sb.getMetrics(), balancerConfiguration);
-
-    containerBalancerTask.setMoveManager(moveManager);
-    Mockito.when(moveManager.move(any(ContainerID.class),
-            any(DatanodeDetails.class), any(DatanodeDetails.class)))
-        .thenReturn(CompletableFuture.completedFuture(
-            MoveManager.MoveResult.COMPLETED));
   }
 
   @Test

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/balancer/TestMoveManager.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/balancer/TestMoveManager.java
@@ -110,7 +110,6 @@ public class TestMoveManager {
     Mockito.when(replicationManager.getClock()).thenReturn(clock);
 
     moveManager = new MoveManager(replicationManager, containerManager);
-    moveManager.onLeaderReady();
   }
 
   @Test

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/balancer/TestMoveManager.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/balancer/TestMoveManager.java
@@ -36,14 +36,12 @@ import org.apache.hadoop.hdds.scm.container.replication.ReplicationTestUtil;
 import org.apache.hadoop.hdds.scm.node.NodeStatus;
 import org.apache.hadoop.hdds.scm.node.states.NodeNotFoundException;
 import org.apache.ozone.test.TestClock;
-import org.apache.ratis.protocol.exceptions.NotLeaderException;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.jupiter.api.Assertions;
 import org.mockito.Mockito;
 
-import java.io.IOException;
 import java.time.Instant;
 import java.time.ZoneId;
 import java.util.ArrayList;
@@ -61,10 +59,8 @@ import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationFactor
 import static org.apache.hadoop.hdds.scm.container.replication.ContainerReplicaOp.PendingOpType.ADD;
 import static org.apache.hadoop.hdds.scm.container.replication.ContainerReplicaOp.PendingOpType.DELETE;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyLong;
-import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 
 /**


### PR DESCRIPTION
## What changes were proposed in this pull request?

MoveManager currently has a hardcoded deadline of 60 minutes. We should make this configurable, and that configuration should be present in ContainerBalancerConfiguration.
Move is replication + deletion. Replication involves copying between two datanodes so it's generally more expensive than deletion. So we probably need to have an additional configuration for deciding how much time out of the total move deadline is allowed for replication. The rest will be allowed for deletion. Move deadline's configuration is "hdds.container.balancer.move.timeout".

Changes introduced:
1. Added a new configuration "hdds.container.balancer.move.replication.timeout". Made MoveManager use this configuration.
2. Added validations for this configuration in ContainerBalancer.
3. Added this configuration to ContainerBalancerConfigurationProto.
4. Other small changes.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-8168

## How was this patch tested?
Added unit tests