### PR TITLE
HDDS-8160. [Snapshot] Skip the compaction entry from log and DAG if compaction input and output files are exactly same

### DIFF
--- a/hadoop-hdds/rocksdb-checkpoint-differ/src/main/java/org/apache/ozone/rocksdiff/RocksDBCheckpointDiffer.java
+++ b/hadoop-hdds/rocksdb-checkpoint-differ/src/main/java/org/apache/ozone/rocksdiff/RocksDBCheckpointDiffer.java
@@ -461,6 +461,15 @@ public class RocksDBCheckpointDiffer implements AutoCloseable {
             return;
           }
 
+          if (new HashSet<>(compactionJobInfo.inputFiles())
+              .equals(new HashSet<>(compactionJobInfo.outputFiles()))) {
+            LOG.info("Skipped the compaction entry. Compaction input files: " +
+                "{} and output files: {} are same.",
+                compactionJobInfo.inputFiles(),
+                compactionJobInfo.outputFiles());
+            return;
+          }
+
           final StringBuilder sb = new StringBuilder();
 
           if (LOG.isDebugEnabled()) {


### PR DESCRIPTION
## What changes were proposed in this pull request?
While working on [HDDS-8069](https://issues.apache.org/jira/browse/HDDS-8069) and going through the logs for it, we saw that there were some compaction entries in which input and output compaction files were exactly same. Which causes the loop in the DAG and make it non-DAG.
This change is to skip the compaction entry from being written to compaction log and file nodes get added to DAG, if input and output files are exactly the same.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-8160

## How was this patch tested?
Existing Unit tests and Acceptance tests.
