### PR TITLE
HDDS-7559. [Snapshot] Skip compaction tracking when no Ozone snapshot exists

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/OzoneConsts.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/OzoneConsts.java
@@ -568,4 +568,22 @@ public final class OzoneConsts {
 
   public static final String FILTERED_SNAPSHOTS = "filtered-snapshots";
 
+  /**
+   * Name of the SST file backup directory placed under metadata dir.
+   * Can be made configurable later.
+   */
+  public static final String DB_COMPACTION_SST_BACKUP_DIR =
+      "compaction-sst-backup";
+
+  /**
+   * Name of the compaction log directory placed under metadata dir.
+   * Can be made configurable later.
+   */
+  public static final String DB_COMPACTION_LOG_DIR = "compaction-log";
+
+  /**
+   * DB snapshot info table name. Referenced in RDBStore.
+   */
+  public static final String SNAPSHOT_INFO_TABLE = "snapshotInfoTable";
+
 }

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/RDBStore.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/RDBStore.java
@@ -49,7 +49,10 @@ import org.rocksdb.TransactionLogIterator.BatchResult;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import static org.apache.hadoop.ozone.OzoneConsts.DB_COMPACTION_LOG_DIR;
+import static org.apache.hadoop.ozone.OzoneConsts.DB_COMPACTION_SST_BACKUP_DIR;
 import static org.apache.hadoop.ozone.OzoneConsts.OM_SNAPSHOT_DIR;
+import static org.apache.hadoop.ozone.OzoneConsts.SNAPSHOT_INFO_TABLE;
 
 /**
  * RocksDB Store that supports creating Tables in DB.
@@ -67,18 +70,6 @@ public class RDBStore implements DBStore {
   private final RDBMetrics rdbMetrics;
   private final RocksDBCheckpointDiffer rocksDBCheckpointDiffer;
   private final String dbJmxBeanName;
-  /**
-   * Name of the SST file backup directory placed under metadata dir.
-   * Can be made configurable later.
-   */
-  private final String dbCompactionSSTBackupDirName = "compaction-sst-backup";
-  /**
-   * Name of the compaction log directory placed under metadata dir.
-   * Can be made configurable later.
-   */
-  private final String dbCompactionLogDirName = "compaction-log";
-  // Can't import OmMetadataManagerImpl (circular dependency otherwise)
-  public static final String SNAPSHOT_INFO_TABLE = "snapshotInfoTable";
 
   @VisibleForTesting
   public RDBStore(File dbFile, ManagedDBOptions options,
@@ -107,8 +98,8 @@ public class RDBStore implements DBStore {
     try {
       if (enableCompactionLog) {
         rocksDBCheckpointDiffer = new RocksDBCheckpointDiffer(
-            dbLocation.getParent(), dbCompactionSSTBackupDirName,
-            dbCompactionLogDirName, dbLocation.toString(),
+            dbLocation.getParent(), DB_COMPACTION_SST_BACKUP_DIR,
+            DB_COMPACTION_LOG_DIR, dbLocation.toString(),
             maxTimeAllowedForSnapshotInDag, compactionDagDaemonInterval);
         rocksDBCheckpointDiffer.setRocksDBForCompactionTracking(dbOptions);
       } else {

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/RDBStore.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/RDBStore.java
@@ -77,6 +77,8 @@ public class RDBStore implements DBStore {
    * Can be made configurable later.
    */
   private final String dbCompactionLogDirName = "compaction-log";
+  // Can't import OmMetadataManagerImpl (circular dependency otherwise)
+  public static final String SNAPSHOT_INFO_TABLE = "snapshotInfoTable";
 
   @VisibleForTesting
   public RDBStore(File dbFile, ManagedDBOptions options,
@@ -159,6 +161,12 @@ public class RDBStore implements DBStore {
       }
 
       if (enableCompactionLog) {
+        ColumnFamily ssInfoTableCF = db.getColumnFamily(SNAPSHOT_INFO_TABLE);
+        Preconditions.checkNotNull(ssInfoTableCF,
+            "SnapshotInfoTable column family handle should not be null");
+        // Set CF handle in differ to be used in DB listener
+        rocksDBCheckpointDiffer.setSnapshotInfoTableCFHandle(
+            ssInfoTableCF.getHandle());
         // Finish the initialization of compaction DAG tracker by setting the
         // sequence number as current compaction log filename.
         rocksDBCheckpointDiffer.setCurrentCompactionLog(

--- a/hadoop-hdds/rocksdb-checkpoint-differ/src/main/java/org/apache/ozone/rocksdiff/RocksDBCheckpointDiffer.java
+++ b/hadoop-hdds/rocksdb-checkpoint-differ/src/main/java/org/apache/ozone/rocksdiff/RocksDBCheckpointDiffer.java
@@ -435,7 +435,12 @@ public class RocksDBCheckpointDiffer implements AutoCloseable {
       return false;
     }
 
-    // SnapshotInfoTable has table cache, but it wouldn't matter in this case.
+    // SnapshotInfoTable has table cache. But that wouldn't matter in this case
+    // because the first SnapshotInfo entry would have been written to the DB
+    // right before checkpoint happens in OMSnapshotCreateResponse.
+    //
+    // Note the goal of compaction DAG is to track all compactions that happened
+    // _after_ a DB checkpoint is taken.
 
     try (ManagedRocksIterator it = ManagedRocksIterator.managed(
         db.newIterator(snapshotInfoTableCFHandle))) {

--- a/hadoop-hdds/rocksdb-checkpoint-differ/src/main/java/org/apache/ozone/rocksdiff/RocksDBCheckpointDiffer.java
+++ b/hadoop-hdds/rocksdb-checkpoint-differ/src/main/java/org/apache/ozone/rocksdiff/RocksDBCheckpointDiffer.java
@@ -28,6 +28,7 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.hadoop.hdds.utils.db.managed.ManagedRocksIterator;
 import org.rocksdb.AbstractEventListener;
 import org.rocksdb.ColumnFamilyDescriptor;
 import org.rocksdb.ColumnFamilyHandle;
@@ -165,6 +166,8 @@ public class RocksDBCheckpointDiffer implements AutoCloseable {
 
   private final ScheduledExecutorService executor;
   private final long maxAllowedTimeInDag;
+
+  private ColumnFamilyHandle snapshotInfoTableCFHandle;
 
   /**
    * Constructor.
@@ -400,13 +403,58 @@ public class RocksDBCheckpointDiffer implements AutoCloseable {
     setRocksDBForCompactionTracking(rocksOptions, new ArrayList<>());
   }
 
+  /**
+   * Set SnapshotInfoTable DB column family handle to be used in DB listener.
+   * @param snapshotInfoTableCFHandle ColumnFamilyHandle
+   */
+  public void setSnapshotInfoTableCFHandle(
+      ColumnFamilyHandle snapshotInfoTableCFHandle) {
+    Preconditions.checkNotNull(snapshotInfoTableCFHandle,
+        "Column family handle should not be null");
+    this.snapshotInfoTableCFHandle = snapshotInfoTableCFHandle;
+  }
+
+  /**
+   * Helper method to check whether the SnapshotInfoTable column family is empty
+   * in a given DB instance.
+   * @param db RocksDB instance
+   * @return true when column family is empty, false otherwise
+   */
+  private boolean isSnapshotInfoTableEmpty(RocksDB db) {
+    // Can't use metadataManager.getSnapshotInfoTable().isEmpty() or use
+    // any wrapper classes here. Any of those introduces circular dependency.
+    // The solution here is to use raw RocksDB API.
+
+    // There is this small gap when the db is open but the handle is not yet set
+    // in RDBStore. Compaction could theoretically happen during that small
+    // window. This condition here aims to handle that (falls back to not
+    // skipping compaction tracking).
+    if (snapshotInfoTableCFHandle == null) {
+      LOG.warn("Snapshot info table column family handle is not set!");
+      // Proceed to log compaction in this case
+      return false;
+    }
+
+    // SnapshotInfoTable has table cache, but it wouldn't matter in this case.
+
+    try (ManagedRocksIterator it = ManagedRocksIterator.managed(
+        db.newIterator(snapshotInfoTableCFHandle))) {
+      it.get().seekToFirst();
+      return !it.get().isValid();
+    }
+  }
+
   private AbstractEventListener newCompactionBeginListener() {
     return new AbstractEventListener() {
       @Override
       public void onCompactionBegin(RocksDB db,
           CompactionJobInfo compactionJobInfo) {
 
-        // TODO: Skip (return) if no snapshot has been taken yet
+        // Skip compaction DAG tracking if the snapshotInfoTable is empty.
+        // i.e. No snapshot exists in OM.
+        if (isSnapshotInfoTableEmpty(db)) {
+          return;
+        }
 
         // Note the current compaction listener implementation does not
         // differentiate which column family each SST store. It is tracking
@@ -452,7 +500,11 @@ public class RocksDBCheckpointDiffer implements AutoCloseable {
       public void onCompactionCompleted(RocksDB db,
           CompactionJobInfo compactionJobInfo) {
 
-        // TODO: Skip (return) if no snapshot has been taken yet
+        // Skip compaction DAG tracking if the snapshotInfoTable is empty.
+        // i.e. No snapshot exists in OM.
+        if (isSnapshotInfoTableEmpty(db)) {
+          return;
+        }
 
         synchronized (compactionListenerWriteLock) {
 

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/freon/TestOMSnapshotDAG.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/freon/TestOMSnapshotDAG.java
@@ -51,6 +51,8 @@ import picocli.CommandLine;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.time.Duration;
 import java.util.HashMap;
 import java.util.List;
@@ -58,6 +60,7 @@ import java.util.Map;
 import java.util.concurrent.TimeoutException;
 import java.util.stream.Collectors;
 
+import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_METADATA_DIRS;
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_S3_VOLUME_NAME_DEFAULT;
 import static org.apache.hadoop.ozone.OzoneConsts.OM_DB_NAME;
 import static org.apache.hadoop.ozone.OzoneConsts.OM_KEY_PREFIX;
@@ -75,6 +78,8 @@ public class TestOMSnapshotDAG {
   private static ObjectStore store;
   private static OzoneClient client;
   private final File metaDir = OMStorage.getOmDbDir(conf);
+  private final String compactionLogDirName = "compaction-log";
+  private final String sstBackUpDirName = "compaction-sst-backup";
 
   /**
    * Create a MiniDFSCluster for testing.
@@ -179,7 +184,7 @@ public class TestOMSnapshotDAG {
         "--num-of-buckets", "1",
         "--num-of-keys", "500",
         "--num-of-threads", "1",
-        "--key-size", "0",  // zero size keys. since we don't need to test DNs
+        "--key-size", "0",  // zero-byte keys since we don't test DNs here
         "--factor", "THREE",
         "--type", "RATIS",
         "--validate-writes"
@@ -268,6 +273,44 @@ public class TestOMSnapshotDAG {
 
     List<String> sstDiffList31Run2 = differ.getSSTDiffList(snap3, snap1);
     Assertions.assertEquals(sstDiffList31, sstDiffList31Run2);
+  }
+
+  @Test
+  public void testSkipTrackingWithZeroSnapshot() throws IOException {
+    // Verify that the listener correctly skips compaction tracking
+    // when there is no snapshot in SnapshotInfoTable.
+
+    // Generate keys
+    RandomKeyGenerator randomKeyGenerator =
+        new RandomKeyGenerator(cluster.getConf());
+    CommandLine cmd = new CommandLine(randomKeyGenerator);
+    // 1000 keys are enough to trigger compaction with 256KB DB CF write buffer
+    cmd.execute("--num-of-volumes", "1",
+        "--num-of-buckets", "1",
+        "--num-of-keys", "1000",
+        "--num-of-threads", "1",
+        "--key-size", "0",  // zero-byte keys since we don't test DNs here
+        "--factor", "THREE",
+        "--type", "RATIS",
+        "--validate-writes"
+    );
+
+    Assertions.assertEquals(1000L, randomKeyGenerator.getNumberOfKeysAdded());
+    Assertions.assertEquals(1000L,
+        randomKeyGenerator.getSuccessfulValidationCount());
+
+    String omMetadataDir =
+        cluster.getOzoneManager().getConfiguration().get(OZONE_METADATA_DIRS);
+    // Verify that no compaction log entry has been written
+    Path logPath = Paths.get(omMetadataDir, compactionLogDirName);
+    for (File file : logPath.toFile().listFiles()) {
+      if (file.isFile() && file.getName().endsWith(".log")) {
+        Assertions.assertEquals(0L, file.length());
+      }
+    }
+    // And no SST has been backed up
+    Path sstBackupPath = Paths.get(omMetadataDir, sstBackUpDirName);
+    Assertions.assertEquals(0L, sstBackupPath.toFile().listFiles().length);
   }
 
 }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/freon/TestOMSnapshotDAG.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/freon/TestOMSnapshotDAG.java
@@ -303,14 +303,18 @@ public class TestOMSnapshotDAG {
         cluster.getOzoneManager().getConfiguration().get(OZONE_METADATA_DIRS);
     // Verify that no compaction log entry has been written
     Path logPath = Paths.get(omMetadataDir, compactionLogDirName);
-    for (File file : logPath.toFile().listFiles()) {
-      if (file.isFile() && file.getName().endsWith(".log")) {
+    File[] fileList = logPath.toFile().listFiles();
+    Assertions.assertNotNull(fileList);
+    for (File file : fileList) {
+      if (file != null && file.isFile() && file.getName().endsWith(".log")) {
         Assertions.assertEquals(0L, file.length());
       }
     }
-    // And no SST has been backed up
+    // Verify that no SST has been backed up
     Path sstBackupPath = Paths.get(omMetadataDir, sstBackUpDirName);
-    Assertions.assertEquals(0L, sstBackupPath.toFile().listFiles().length);
+    fileList = sstBackupPath.toFile().listFiles();
+    Assertions.assertNotNull(fileList);
+    Assertions.assertEquals(0L, fileList.length);
   }
 
 }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/freon/TestOMSnapshotDAG.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/freon/TestOMSnapshotDAG.java
@@ -57,7 +57,6 @@ import java.time.Duration;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.concurrent.TimeoutException;
 import java.util.stream.Collectors;
 
@@ -304,15 +303,14 @@ public class TestOMSnapshotDAG {
         cluster.getOzoneManager().getConfiguration().get(OZONE_METADATA_DIRS);
     // Verify that no compaction log entry has been written
     Path logPath = Paths.get(omMetadataDir, compactionLogDirName);
-    for (File file : Objects.requireNonNull(logPath.toFile().listFiles())) {
+    for (File file : logPath.toFile().listFiles()) {
       if (file.isFile() && file.getName().endsWith(".log")) {
         Assertions.assertEquals(0L, file.length());
       }
     }
     // And no SST has been backed up
     Path sstBackupPath = Paths.get(omMetadataDir, sstBackUpDirName);
-    Assertions.assertEquals(0L,
-        Objects.requireNonNull(sstBackupPath.toFile().listFiles()).length);
+    Assertions.assertEquals(0L, sstBackupPath.toFile().listFiles().length);
   }
 
 }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/freon/TestOMSnapshotDAG.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/freon/TestOMSnapshotDAG.java
@@ -57,6 +57,7 @@ import java.time.Duration;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.concurrent.TimeoutException;
 import java.util.stream.Collectors;
 
@@ -303,14 +304,15 @@ public class TestOMSnapshotDAG {
         cluster.getOzoneManager().getConfiguration().get(OZONE_METADATA_DIRS);
     // Verify that no compaction log entry has been written
     Path logPath = Paths.get(omMetadataDir, compactionLogDirName);
-    for (File file : logPath.toFile().listFiles()) {
+    for (File file : Objects.requireNonNull(logPath.toFile().listFiles())) {
       if (file.isFile() && file.getName().endsWith(".log")) {
         Assertions.assertEquals(0L, file.length());
       }
     }
     // And no SST has been backed up
     Path sstBackupPath = Paths.get(omMetadataDir, sstBackUpDirName);
-    Assertions.assertEquals(0L, sstBackupPath.toFile().listFiles().length);
+    Assertions.assertEquals(0L,
+        Objects.requireNonNull(sstBackupPath.toFile().listFiles()).length);
   }
 
 }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/snapshot/OMSnapshotCreateResponse.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/snapshot/OMSnapshotCreateResponse.java
@@ -65,16 +65,22 @@ public class OMSnapshotCreateResponse extends OMClientResponse {
   public void addToDBBatch(OMMetadataManager omMetadataManager,
       BatchOperation batchOperation) throws IOException {
 
-    // Create the snapshot checkpoint
-    // Also cleans up deletedTable
-    OmSnapshotManager.createOmSnapshotCheckpoint(omMetadataManager,
-        snapshotInfo);
-
-    String key = snapshotInfo.getTableKey();
+    // Note: It is intentional that we write SnapshotInfo to DB _before_
+    // creating snapshot DB checkpoint. Otherwise there could be a
+    // small chance that the DB listeners in RocksDBCheckpointDiffer could skip
+    // the compaction tracking when the checkpoint is _just_ created and another
+    // compaction happens. Even though the worst case if that happens it
+    // would just negatively impact SnapDiff performance because of the missing
+    // compaction DAG nodes. SnapDiff correctness will not be impacted by this.
 
     // Add to db
+    String key = snapshotInfo.getTableKey();
     omMetadataManager.getSnapshotInfoTable().putWithBatch(batchOperation,
         key, snapshotInfo);
+
+    // Create the snapshot checkpoint. Also cleans up some tables.
+    OmSnapshotManager.createOmSnapshotCheckpoint(omMetadataManager,
+        snapshotInfo);
 
     // TODO: [SNAPSHOT] Move to createOmSnapshotCheckpoint and add table lock
     // Remove all entries from renamedKeyTable


### PR DESCRIPTION
## What changes were proposed in this pull request?

Snapshot DAG tracking RocksDB listener optimization 1 of 2.

Only track active DB compaction when there is at least one snapshot in OM DB.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-7559

## How was this patch tested?

- Added new test case.
- Existing test cases where compactions are tracked and utilized should pass.