### PR TITLE
HDDS-8128. Deduplicate the ops in RDBBatchOperation.

### DIFF
--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/RDBBatchOperation.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/RDBBatchOperation.java
@@ -36,6 +36,8 @@ import java.util.function.Supplier;
 
 /**
  * Batch operation implementation for rocks db.
+ * Note that a {@link RDBBatchOperation} object only for one batch.
+ * Also, this class is not threadsafe.
  */
 public class RDBBatchOperation implements BatchOperation {
   static final Logger LOG = LoggerFactory.getLogger(RDBBatchOperation.class);
@@ -67,9 +69,11 @@ public class RDBBatchOperation implements BatchOperation {
    */
   private static final class ByteArray {
     private final byte[] bytes;
+    private final int hash;
 
     ByteArray(byte[] bytes) {
       this.bytes = bytes;
+      this.hash = Arrays.hashCode(bytes);
     }
 
     @Override
@@ -85,7 +89,7 @@ public class RDBBatchOperation implements BatchOperation {
 
     @Override
     public int hashCode() {
-      return Arrays.hashCode(bytes);
+      return hash;
     }
   }
 

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/RDBBatchOperation.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/RDBBatchOperation.java
@@ -18,18 +18,225 @@
  */
 package org.apache.hadoop.hdds.utils.db;
 
+import com.google.common.base.Preconditions;
 import org.apache.hadoop.hdds.utils.db.RocksDatabase.ColumnFamily;
 import org.apache.hadoop.hdds.utils.db.managed.ManagedWriteBatch;
 import org.apache.hadoop.hdds.utils.db.managed.ManagedWriteOptions;
+import org.apache.ratis.util.StringUtils;
+import org.apache.ratis.util.TraditionalBinaryPrefix;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Supplier;
 
 /**
  * Batch operation implementation for rocks db.
  */
 public class RDBBatchOperation implements BatchOperation {
+  static final Logger LOG = LoggerFactory.getLogger(RDBBatchOperation.class);
 
+  private static final Object DELETE_OP = new Object();
+
+  private static void debug(Supplier<String> message) {
+    if (LOG.isTraceEnabled()) {
+      LOG.trace("\n{}", message.get());
+    }
+  }
+
+  private static String byteSize2String(long length) {
+    return TraditionalBinaryPrefix.long2String(length, "B", 2);
+  }
+
+  private static String countSize2String(int count, long size) {
+    return count + " (" + byteSize2String(size) + ")";
+  }
+
+  /**
+   * To implement {@link #equals(Object)} and {@link #hashCode()}
+   * based on the contents of {@link #bytes}.
+   * <p>
+   * Note that it is incorrect to directly use
+   * {@link #bytes#equals(Object)} and {@link #bytes#hashCode()} here since
+   * they do not use the contents of {@link #bytes} in the computations.
+   * These methods simply inherit from {@link Object).
+   */
+  private static final class ByteArray {
+    private final byte[] bytes;
+
+    ByteArray(byte[] bytes) {
+      this.bytes = bytes;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+      if (this == obj) {
+        return true;
+      } else if (obj == null || getClass() != obj.getClass()) {
+        return false;
+      }
+      final ByteArray that = (ByteArray) obj;
+      return Arrays.equals(this.bytes, that.bytes);
+    }
+
+    @Override
+    public int hashCode() {
+      return Arrays.hashCode(bytes);
+    }
+  }
+
+  /** Cache and deduplicate db ops (put/delete). */
+  private class OpCache {
+    /** A cache for a {@link ColumnFamily}. */
+    private class FamilyCache {
+      private final ColumnFamily family;
+      /**
+       * A (dbKey -> dbValue) map, where the dbKey type is {@link ByteArray}
+       * (see the javadoc of ByteArray) and the dbValue type is {@link Object}.
+       * When dbValue is a byte[], it represents a put-op.
+       * Otherwise, it represents a delete-op (dbValue is {@link #DELETE_OP)}).
+       */
+      private final Map<ByteArray, Object> ops = new HashMap<>();
+      private boolean isCommit;
+
+      private long batchSize;
+      private long discardedSize;
+      private int discardedCount;
+      private int putCount;
+      private int delCount;
+
+      FamilyCache(ColumnFamily family) {
+        this.family = family;
+      }
+
+      /** Prepare batch write for the entire family. */
+      void prepareBatchWrite() throws IOException {
+        Preconditions.checkState(!isCommit, "%s is already committed.", this);
+        isCommit = true;
+        for (Map.Entry<ByteArray, Object> op : ops.entrySet()) {
+          final byte[] key = op.getKey().bytes;
+          final Object value = op.getValue();
+          if (value instanceof byte[]) {
+            family.batchPut(writeBatch, key, (byte[])value);
+          } else {
+            family.batchDelete(writeBatch, key);
+          }
+        }
+        ops.clear();
+
+        debug(() -> String.format("  %s %s, #put=%s, #del=%s", this,
+            batchSizeDiscardedString(), putCount, delCount));
+      }
+
+      void putOrDelete(byte[] key, Object val) {
+        Preconditions.checkState(!isCommit, "%s is already committed.", this);
+        final int keyLen = key.length;
+        final int valLen = val instanceof byte[] ? ((byte[]) val).length : 0;
+        batchSize += keyLen + valLen;
+
+        final Object previousVal = ops.put(new ByteArray(key), val);
+        if (previousVal != null) {
+          final boolean isPut = previousVal instanceof byte[];
+          final int preLen = isPut ? ((byte[]) previousVal).length : 0;
+          discardedSize += keyLen + preLen;
+          discardedCount++;
+          debug(() -> String.format("%s overwriting a previous %s", this,
+              isPut ? "put (value: " + byteSize2String(preLen) + ")" : "del"));
+        }
+
+        debug(() -> String.format("%s %s, %s; key=%s", this,
+            valLen == 0 ? delString(keyLen) : putString(keyLen, valLen),
+            batchSizeDiscardedString(),
+            StringUtils.bytes2HexString(key).toUpperCase()));
+      }
+
+      void put(byte[] key, byte[] value) {
+        putCount++;
+        putOrDelete(key, value);
+      }
+
+      void delete(byte[] key) {
+        delCount++;
+        putOrDelete(key, DELETE_OP);
+      }
+
+      String putString(int keySize, int valueSize) {
+        return String.format("put(key: %s, value: %s), #put=%s",
+            byteSize2String(keySize), byteSize2String(valueSize), putCount);
+      }
+
+      String delString(int keySize) {
+        return String.format("del(key: %s), #del=%s",
+            byteSize2String(keySize), delCount);
+      }
+
+      String batchSizeDiscardedString() {
+        return String.format("batchSize=%s, discarded: %s",
+            byteSize2String(batchSize),
+            countSize2String(discardedCount, discardedSize));
+      }
+
+      @Override
+      public String toString() {
+        return name + ": " + family.getName();
+      }
+    }
+
+    /** A (family name -> {@link FamilyCache}) map. */
+    private final Map<String, FamilyCache> name2cache = new HashMap<>();
+
+    void put(ColumnFamily f, byte[] key, byte[] value) {
+      name2cache.computeIfAbsent(f.getName(), k -> new FamilyCache(f))
+          .put(key, value);
+    }
+
+    void delete(ColumnFamily family, byte[] key) {
+      name2cache.computeIfAbsent(family.getName(), k -> new FamilyCache(family))
+          .delete(key);
+    }
+
+    /** Prepare batch write for the entire cache. */
+    void prepareBatchWrite() throws IOException {
+      for (Map.Entry<String, FamilyCache> e : name2cache.entrySet()) {
+        e.getValue().prepareBatchWrite();
+      }
+      name2cache.clear();
+    }
+
+    String getCommitString() {
+      int putCount = 0;
+      int delCount = 0;
+      int opSize = 0;
+      int discardedCount = 0;
+      int discardedSize = 0;
+
+      for (FamilyCache f : name2cache.values()) {
+        putCount += f.putCount;
+        delCount += f.delCount;
+        opSize += f.batchSize;
+        discardedCount += f.discardedCount;
+        discardedSize += f.discardedSize;
+      }
+
+      final int opCount = putCount + delCount;
+      return String.format(
+          "#put=%s, #del=%s, batchSize: %s, discarded: %s, committed: %s",
+          putCount, delCount,
+          countSize2String(opCount, opSize),
+          countSize2String(discardedCount, discardedSize),
+          countSize2String(opCount - discardedCount, opSize - discardedSize));
+    }
+  }
+
+  private static final AtomicInteger BATCH_COUNT = new AtomicInteger();
+
+  private final String name = "Batch-" + BATCH_COUNT.getAndIncrement();
   private final ManagedWriteBatch writeBatch;
+  private final OpCache opCache = new OpCache();
 
   public RDBBatchOperation() {
     writeBatch = new ManagedWriteBatch();
@@ -39,26 +246,38 @@ public class RDBBatchOperation implements BatchOperation {
     this.writeBatch = writeBatch;
   }
 
+  @Override
+  public String toString() {
+    return name;
+  }
+
   public void commit(RocksDatabase db) throws IOException {
+    debug(() -> String.format("%s: commit %s",
+        name, opCache.getCommitString()));
+    opCache.prepareBatchWrite();
     db.batchWrite(writeBatch);
   }
 
   public void commit(RocksDatabase db, ManagedWriteOptions writeOptions)
       throws IOException {
+    debug(() -> String.format("%s: commit-with-writeOptions %s",
+        name, opCache.getCommitString()));
+    opCache.prepareBatchWrite();
     db.batchWrite(writeBatch, writeOptions);
   }
 
   @Override
   public void close() {
+    debug(() -> String.format("%s: close", name));
     writeBatch.close();
   }
 
   public void delete(ColumnFamily family, byte[] key) throws IOException {
-    family.batchDelete(writeBatch, key);
+    opCache.delete(family, key);
   }
 
   public void put(ColumnFamily family, byte[] key, byte[] value)
       throws IOException {
-    family.batchPut(writeBatch, key, value);
+    opCache.put(family, key, value);
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

OM rocksdb uses a lot of space.

This PR adds a cache in RDBBatchOperation for caching the put ops.  When there are multiple ops with the same key, it will overwrite the previous op in the cache so the previous op won't be written into RocksDB.  In a test, the cache can reduce the disk usage in OM rocksdb of a single upload with 1000 parts from 755MB to 23MB.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-8128

## How was this patch tested?

The is an optimization.  The existing test already has covered.  Also have tested this with https://github.com/apache/ozone/compare/ozone-1.3...szetszwo:ozone:multipartUpload manually.