### PR TITLE
HDDS-8154. Perf: Reuse Mac instances in S3 token validation

### DIFF
--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/security/AWSV4AuthValidator.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/security/AWSV4AuthValidator.java
@@ -53,7 +53,7 @@ final class AWSV4AuthValidator {
         } catch (NoSuchAlgorithmException nsa) {
           throw new IllegalArgumentException(
               "Failed to initialize Mac instance that implements the " +
-                  HMAC_SHA256_ALGORITHM + " algorithm" + nsa);
+                  HMAC_SHA256_ALGORITHM + " algorithm.", nsa);
         }
       });
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/security/AWSV4AuthValidator.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/security/AWSV4AuthValidator.java
@@ -43,6 +43,20 @@ final class AWSV4AuthValidator {
   private AWSV4AuthValidator() {
   }
 
+  /**
+   * ThreadLocal cache of Mac instances.
+   */
+  private static final ThreadLocal<Mac> THREAD_LOCAL_MAC =
+      ThreadLocal.withInitial(() -> {
+        try {
+          return Mac.getInstance(HMAC_SHA256_ALGORITHM);
+        } catch (NoSuchAlgorithmException nsa) {
+          throw new IllegalArgumentException(
+              "Failed to initialize Mac instance that implements the " +
+                  HMAC_SHA256_ALGORITHM + " algorithm" + nsa);
+        }
+      });
+
   public static String hash(String payload) throws NoSuchAlgorithmException {
     MessageDigest md = MessageDigest.getInstance("SHA-256");
     md.update(payload.getBytes(StandardCharsets.UTF_8));
@@ -52,7 +66,9 @@ final class AWSV4AuthValidator {
   private static byte[] sign(byte[] key, String msg) {
     try {
       SecretKeySpec signingKey = new SecretKeySpec(key, HMAC_SHA256_ALGORITHM);
-      Mac mac = Mac.getInstance(HMAC_SHA256_ALGORITHM);
+      // Returns the cached Mac instance for the current thread or creates a
+      // new one if none exists.
+      Mac mac = THREAD_LOCAL_MAC.get();
       mac.init(signingKey);
       return mac.doFinal(msg.getBytes(StandardCharsets.UTF_8));
     } catch (GeneralSecurityException gse) {


### PR DESCRIPTION
## What changes were proposed in this pull request?

Due to the high cost of creating and initializing Mac instances, S3 token validation can be a bottleneck in OM latencies for S3 use cases.

```
Mac mac = Mac.getInstance(HMAC_SHA256_ALGORITHM);
mac.init(signingKey); 
```

<img width="1711" alt="Screen Shot 2023-03-13 at 11 33 35 AM" src="https://user-images.githubusercontent.com/46785609/226329642-35954efd-7052-4ea6-b314-c5971aff51f5.png">

Caching Mac instances in ThreadLocal (as they are stateful) and reusing them eliminates the need to create and initialize these objects from scratch, mitigating the high cost of S3 token validation and significantly reducing overhead while improving overall performance.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-8154

## How was this patch tested?

Existing UTs
