### PR TITLE
HDDS-8098. Make Schema V3 as default in ozone debug ldb for container db.

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestLDBCli.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestLDBCli.java
@@ -116,7 +116,7 @@ public class TestLDBCli {
       keyTable.put(key.getBytes(UTF_8), arr);
     }
     rdbParser.setDbPath(dbStore.getDbLocation().getAbsolutePath());
-    DBScanner.setParent(rdbParser);
+    dbScanner.setParent(rdbParser);
     DBScanner.setLimit(100);
     Assert.assertEquals(5, getKeyNames(dbScanner).size());
     Assert.assertTrue(getKeyNames(dbScanner).contains("key1"));
@@ -248,7 +248,7 @@ public class TestLDBCli {
     }
 
     rdbParser.setDbPath(dbStore.getDbLocation().getAbsolutePath());
-    DBScanner.setParent(rdbParser);
+    dbScanner.setParent(rdbParser);
     dbScanner.setTableName("block_data");
     DBScanner.setDnDBSchemaVersion("V3");
     DBScanner.setWithKey(true);
@@ -314,7 +314,7 @@ public class TestLDBCli {
     }
 
     rdbParser.setDbPath(dbStore.getDbLocation().getAbsolutePath());
-    DBScanner.setParent(rdbParser);
+    dbScanner.setParent(rdbParser);
     dbScanner.setTableName("block_data");
     DBScanner.setDnDBSchemaVersion("V2");
     DBScanner.setWithKey(true);

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestLDBCli.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestLDBCli.java
@@ -116,7 +116,7 @@ public class TestLDBCli {
       keyTable.put(key.getBytes(UTF_8), arr);
     }
     rdbParser.setDbPath(dbStore.getDbLocation().getAbsolutePath());
-    dbScanner.setParent(rdbParser);
+    DBScanner.setParent(rdbParser);
     DBScanner.setLimit(100);
     Assert.assertEquals(5, getKeyNames(dbScanner).size());
     Assert.assertTrue(getKeyNames(dbScanner).contains("key1"));
@@ -248,7 +248,7 @@ public class TestLDBCli {
     }
 
     rdbParser.setDbPath(dbStore.getDbLocation().getAbsolutePath());
-    dbScanner.setParent(rdbParser);
+    DBScanner.setParent(rdbParser);
     dbScanner.setTableName("block_data");
     DBScanner.setDnDBSchemaVersion("V3");
     DBScanner.setWithKey(true);
@@ -314,7 +314,7 @@ public class TestLDBCli {
     }
 
     rdbParser.setDbPath(dbStore.getDbLocation().getAbsolutePath());
-    dbScanner.setParent(rdbParser);
+    DBScanner.setParent(rdbParser);
     dbScanner.setTableName("block_data");
     DBScanner.setDnDBSchemaVersion("V2");
     DBScanner.setWithKey(true);

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/DBScanner.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/DBScanner.java
@@ -209,8 +209,8 @@ public class DBScanner implements Callable<Void>, SubcommandWithParent {
     return parent;
   }
 
-  public void setParent(RDBParser parent) {
-    this.parent = parent;
+  public static void setParent(RDBParser parent) {
+    DBScanner.parent = parent;
   }
 
   public static void setLimit(int limit) {

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/DBScanner.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/DBScanner.java
@@ -95,7 +95,7 @@ public class DBScanner implements Callable<Void>, SubcommandWithParent {
 
   @CommandLine.Option(names = {"--dnSchema", "-d", "--dn-schema"},
       description = "Datanode DB Schema Version : V1/V2/V3",
-      defaultValue = "V2")
+      defaultValue = "V3")
   private static String dnDBSchemaVersion;
 
   @CommandLine.Option(names = {"--container-id", "-cid"},
@@ -112,7 +112,7 @@ public class DBScanner implements Callable<Void>, SubcommandWithParent {
 
 
   @CommandLine.ParentCommand
-  private RDBParser parent;
+  private static RDBParser parent;
 
   private HashMap<String, DBColumnFamilyDefinition> columnFamilyMap;
 
@@ -154,7 +154,8 @@ public class DBScanner implements Callable<Void>, SubcommandWithParent {
       }
 
       boolean schemaV3 = dnDBSchemaVersion != null &&
-          dnDBSchemaVersion.equals("V3");
+              dnDBSchemaVersion.equals("V3") &&
+              parent.getDbPath().contains(OzoneConsts.CONTAINER_DB_NAME);
       while (iterator.get().isValid()) {
         StringBuilder result = new StringBuilder();
         if (withKey) {
@@ -318,7 +319,8 @@ public class DBScanner implements Callable<Void>, SubcommandWithParent {
         }
         ManagedRocksIterator iterator;
         if (containerId > 0 && dnDBSchemaVersion != null &&
-            dnDBSchemaVersion.equals("V3")) {
+            dnDBSchemaVersion.equals("V3") &&
+                parent.getDbPath().contains(OzoneConsts.CONTAINER_DB_NAME)) {
           ManagedReadOptions readOptions = new ManagedReadOptions();
           readOptions.setIterateUpperBound(new ManagedSlice(
               FixedLengthStringUtils.string2Bytes(


### PR DESCRIPTION

## What changes were proposed in this pull request?

Change default schema to V3 for ozone debug ldb container db. For V2 containers need to give option "-d=V2" while running tool.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-8098

## How was this patch tested?

Patch tested using TestLDBCli test cases for both testDNDBSchemaV3() and testDNDBSchemaV2() as well as built locally and tested using docker compose by running ldb commands.
