### PR TITLE
HDDS-8172. ECUnderReplicationHandler should consider commands already sent when processing the container

### DIFF
--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestECContainerReplicaCount.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestECContainerReplicaCount.java
@@ -86,6 +86,15 @@ public class TestECContainerReplicaCount {
     Assertions.assertEquals(1, rcnt.unavailableIndexes(true).size());
     Assertions.assertEquals(5,
         rcnt.unavailableIndexes(true).get(0).intValue());
+
+    // Add a pending add op for the missing replica and ensure it no longer
+    // appears missing
+    ContainerReplicaOp op = new ContainerReplicaOp(
+        ContainerReplicaOp.PendingOpType.ADD,
+        MockDatanodeDetails.randomDatanodeDetails(), 5, Long.MAX_VALUE);
+    rcnt.addPendingOp(op);
+    Assertions.assertTrue(rcnt.isSufficientlyReplicated(true));
+    Assertions.assertEquals(0, rcnt.unavailableIndexes(true).size());
   }
 
   @Test
@@ -201,6 +210,13 @@ public class TestECContainerReplicaCount {
     Assertions.assertEquals(1, rcnt.overReplicatedIndexes(true).size());
     Assertions.assertTrue(rcnt.isOverReplicated(false));
     Assertions.assertEquals(2, rcnt.overReplicatedIndexes(false).size());
+
+    // Add a pending delete op for the excess replica and ensure it now reports
+    // as not over replicated.
+    rcnt.addPendingOp(new ContainerReplicaOp(
+        ContainerReplicaOp.PendingOpType.DELETE,
+        MockDatanodeDetails.randomDatanodeDetails(), 2, Long.MAX_VALUE));
+    Assertions.assertFalse(rcnt.isOverReplicated(true));
   }
 
   @Test

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestECUnderReplicationHandler.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestECUnderReplicationHandler.java
@@ -186,7 +186,8 @@ public class TestECUnderReplicationHandler {
   }
 
 
-  // Test used to reproduce the issue reported in HDDS-8171
+  // Test used to reproduce the issue reported in HDDS-8171 and then adjusted
+  // to ensure only a single command is sent for HDDS-8172.
   @Test
   public void testUnderReplicationWithDecomIndexAndMaintOnSameIndex()
       throws IOException {
@@ -214,10 +215,13 @@ public class TestECUnderReplicationHandler {
             Pair.of(IN_SERVICE, 3), Pair.of(IN_SERVICE, 4),
             Pair.of(IN_SERVICE, 5)));
 
+    // Note that maintenanceIndexes is set to zero as we do not expect any
+    // maintenance commands to be created, as they are solved by the earlier
+    // decommission command.
     Set<Pair<DatanodeDetails, SCMCommand<?>>> cmds =
         testUnderReplicationWithMissingIndexes(
-            Lists.emptyList(), availableReplicas, 1, 2, policy);
-    Assertions.assertEquals(2, cmds.size());
+            Lists.emptyList(), availableReplicas, 1, 0, policy);
+    Assertions.assertEquals(1, cmds.size());
     // Check the replicate command has index 1 set
     for (Pair<DatanodeDetails, SCMCommand<?>> c : cmds) {
       // Ensure neither of the commands are for the dead maintenance node


### PR DESCRIPTION
## What changes were proposed in this pull request?

For an EC container which has 2 replicas for the same index, with one decommissioning and one in_maintenance, the decommission logic in ECUnderReplicationHandler can send a command for the replica, and then the maintenance logic can send another replication command for the same container to a different target. If they both succeed it will likely result in over replication.

To solve this, we probably need to adjust the pending ops between each stage of the processing, so as then the maintenance logic would be "fixed by pending" and avoid sending the second command.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-8172

## How was this patch tested?

Existing tests modified.
