### PR TITLE
HDDS-7952. [Snapshot] Server side changes to add job status and wait time to mimic the async behaviour for snapshot diff API.

### DIFF
--- a/hadoop-hdds/rocksdb-checkpoint-differ/src/main/java/org/apache/ozone/rocksdb/util/RdbUtil.java
+++ b/hadoop-hdds/rocksdb-checkpoint-differ/src/main/java/org/apache/ozone/rocksdb/util/RdbUtil.java
@@ -51,9 +51,9 @@ public final class RdbUtil {
     cfd.add(
         new ColumnFamilyDescriptor("default".getBytes(StandardCharsets.UTF_8)));
     try (ManagedDBOptions options = new ManagedDBOptions();
-         ManagedRocksDB managedRocksDB = ManagedRocksDB.openReadOnly(options,
+         ManagedRocksDB rocksDB = ManagedRocksDB.openReadOnly(options,
              dbLocation, cfd, columnFamilyHandles)) {
-      return managedRocksDB.get().getLiveFilesMetaData().stream()
+      return rocksDB.get().getLiveFilesMetaData().stream()
           .map(lfm -> new File(lfm.path(), lfm.fileName()).getPath())
           .collect(Collectors.toCollection(HashSet::new));
     }

--- a/hadoop-hdds/rocksdb-checkpoint-differ/src/main/java/org/apache/ozone/rocksdb/util/RdbUtil.java
+++ b/hadoop-hdds/rocksdb-checkpoint-differ/src/main/java/org/apache/ozone/rocksdb/util/RdbUtil.java
@@ -18,10 +18,10 @@
 
 package org.apache.ozone.rocksdb.util;
 
+import org.apache.hadoop.hdds.utils.db.managed.ManagedDBOptions;
+import org.apache.hadoop.hdds.utils.db.managed.ManagedRocksDB;
 import org.rocksdb.ColumnFamilyDescriptor;
 import org.rocksdb.ColumnFamilyHandle;
-import org.rocksdb.DBOptions;
-import org.rocksdb.RocksDB;
 import org.rocksdb.RocksDBException;
 
 import java.io.File;
@@ -50,9 +50,10 @@ public final class RdbUtil {
     }
     cfd.add(
         new ColumnFamilyDescriptor("default".getBytes(StandardCharsets.UTF_8)));
-    try (DBOptions options = new DBOptions(); RocksDB rocksDB = RocksDB
-        .openReadOnly(options, dbLocation, cfd, columnFamilyHandles)) {
-      return rocksDB.getLiveFilesMetaData().stream()
+    try (ManagedDBOptions options = new ManagedDBOptions();
+         ManagedRocksDB managedRocksDB = ManagedRocksDB.openReadOnly(options,
+             dbLocation, cfd, columnFamilyHandles)) {
+      return managedRocksDB.get().getLiveFilesMetaData().stream()
           .map(lfm -> new File(lfm.path(), lfm.fileName()).getPath())
           .collect(Collectors.toCollection(HashSet::new));
     }

--- a/hadoop-hdds/rocksdb-checkpoint-differ/src/main/java/org/apache/ozone/rocksdiff/RocksDBCheckpointDiffer.java
+++ b/hadoop-hdds/rocksdb-checkpoint-differ/src/main/java/org/apache/ozone/rocksdiff/RocksDBCheckpointDiffer.java
@@ -666,7 +666,7 @@ public class RocksDBCheckpointDiffer implements AutoCloseable {
    * @return a list of SST files (without extension) in the DB.
    */
   public HashSet<String> readRocksDBLiveFiles(String dbPathArg) {
-    ManagedRocksDB managedRocksDB = null;
+    ManagedRocksDB rocksDB = null;
     HashSet<String> liveFiles = new HashSet<>();
 
     final ColumnFamilyOptions cfOpts = new ColumnFamilyOptions();
@@ -676,12 +676,12 @@ public class RocksDBCheckpointDiffer implements AutoCloseable {
 
     try (ManagedDBOptions managedDBOptions = new ManagedDBOptions()) {
       managedDBOptions.setParanoidChecks(true);
-      managedRocksDB = ManagedRocksDB.openReadOnly(managedDBOptions, dbPathArg,
+      rocksDB = ManagedRocksDB.openReadOnly(managedDBOptions, dbPathArg,
           cfDescriptors, columnFamilyHandles);
       // Note it retrieves only the selected column families by the descriptor
       // i.e. keyTable, directoryTable, fileTable
       List<LiveFileMetaData> liveFileMetaDataList =
-          managedRocksDB.get().getLiveFilesMetaData();
+          rocksDB.get().getLiveFilesMetaData();
       LOG.debug("SST File Metadata for DB: " + dbPathArg);
       for (LiveFileMetaData m : liveFileMetaDataList) {
         LOG.debug("File: {}, Level: {}", m.fileName(), m.level());
@@ -692,8 +692,8 @@ public class RocksDBCheckpointDiffer implements AutoCloseable {
       LOG.error("Error during RocksDB operation: {}", e.getMessage());
       e.printStackTrace();
     } finally {
-      if (managedRocksDB != null) {
-        managedRocksDB.close();
+      if (rocksDB != null) {
+        rocksDB.close();
       }
       cfOpts.close();
     }

--- a/hadoop-hdds/rocksdb-checkpoint-differ/src/main/java/org/apache/ozone/rocksdiff/RocksDBCheckpointDiffer.java
+++ b/hadoop-hdds/rocksdb-checkpoint-differ/src/main/java/org/apache/ozone/rocksdiff/RocksDBCheckpointDiffer.java
@@ -29,6 +29,8 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.hadoop.hdds.utils.db.managed.ManagedRocksIterator;
+import org.apache.hadoop.hdds.utils.db.managed.ManagedDBOptions;
+import org.apache.hadoop.hdds.utils.db.managed.ManagedRocksDB;
 import org.rocksdb.AbstractEventListener;
 import org.rocksdb.ColumnFamilyDescriptor;
 import org.rocksdb.ColumnFamilyHandle;
@@ -664,7 +666,7 @@ public class RocksDBCheckpointDiffer implements AutoCloseable {
    * @return a list of SST files (without extension) in the DB.
    */
   public HashSet<String> readRocksDBLiveFiles(String dbPathArg) {
-    RocksDB rocksDB = null;
+    ManagedRocksDB managedRocksDB = null;
     HashSet<String> liveFiles = new HashSet<>();
 
     final ColumnFamilyOptions cfOpts = new ColumnFamilyOptions();
@@ -672,15 +674,14 @@ public class RocksDBCheckpointDiffer implements AutoCloseable {
         getCFDescriptorList(cfOpts);
     final List<ColumnFamilyHandle> columnFamilyHandles = new ArrayList<>();
 
-    try (DBOptions dbOptions = new DBOptions()
-        .setParanoidChecks(true)) {
-
-      rocksDB = RocksDB.openReadOnly(dbOptions, dbPathArg,
+    try (ManagedDBOptions managedDBOptions = new ManagedDBOptions()) {
+      managedDBOptions.setParanoidChecks(true);
+      managedRocksDB = ManagedRocksDB.openReadOnly(managedDBOptions, dbPathArg,
           cfDescriptors, columnFamilyHandles);
       // Note it retrieves only the selected column families by the descriptor
       // i.e. keyTable, directoryTable, fileTable
       List<LiveFileMetaData> liveFileMetaDataList =
-          rocksDB.getLiveFilesMetaData();
+          managedRocksDB.get().getLiveFilesMetaData();
       LOG.debug("SST File Metadata for DB: " + dbPathArg);
       for (LiveFileMetaData m : liveFileMetaDataList) {
         LOG.debug("File: {}, Level: {}", m.fileName(), m.level());
@@ -691,8 +692,8 @@ public class RocksDBCheckpointDiffer implements AutoCloseable {
       LOG.error("Error during RocksDB operation: {}", e.getMessage());
       e.printStackTrace();
     } finally {
-      if (rocksDB != null) {
-        rocksDB.close();
+      if (managedRocksDB != null) {
+        managedRocksDB.close();
       }
       cfOpts.close();
     }

--- a/hadoop-ozone/dist/src/main/smoketest/snapshot/snapshot-sh.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/snapshot/snapshot-sh.robot
@@ -18,7 +18,7 @@ Documentation       Test for using sh commands with snapshots.
 Library             OperatingSystem
 Resource            ../ozone-lib/shell.robot
 Resource            snapshot-setup.robot
-Test Timeout        5 minutes
+Test Timeout        10 minutes
 
 *** Variables ***
 ${SNAPSHOT_ONE}
@@ -47,6 +47,8 @@ Snapshot Diff
     Set Suite Variable      ${KEY_THREE}        ${key_three}
     ${snapshot_two} =       Create snapshot     ${VOLUME}       ${BUCKET}
     Set Suite Variable      ${SNAPSHOT_TWO}     ${snapshot_two}
+    ${result} =     Execute             ozone sh snapshot snapshotDiff /${VOLUME}/${BUCKET} ${SNAPSHOT_ONE} ${SNAPSHOT_TWO}
+                    Should contain      ${result}       Snapshot diff job is IN_PROGRESS
     ${result} =     Execute             ozone sh snapshot snapshotDiff /${VOLUME}/${BUCKET} ${SNAPSHOT_ONE} ${SNAPSHOT_TWO}
                     Should contain      ${result}       +    ${KEY_TWO}
                     Should contain      ${result}       +    ${KEY_THREE}

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/snapshot/PersistentMap.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/snapshot/PersistentMap.java
@@ -18,8 +18,8 @@
 
 package org.apache.hadoop.ozone.om.snapshot;
 
-import java.util.Iterator;
 import java.util.Map;
+import org.apache.hadoop.util.ClosableIterator;
 
 /**
  * Define an interface for persistent map.
@@ -32,5 +32,5 @@ public interface PersistentMap<K, V> {
 
   void remove(K key);
 
-  Iterator<Map.Entry<K, V>> iterator();
+  ClosableIterator<Map.Entry<K, V>> iterator();
 }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/snapshot/PersistentMap.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/snapshot/PersistentMap.java
@@ -18,6 +18,9 @@
 
 package org.apache.hadoop.ozone.om.snapshot;
 
+import java.util.Iterator;
+import java.util.Map;
+
 /**
  * Define an interface for persistent map.
  */
@@ -28,4 +31,6 @@ public interface PersistentMap<K, V> {
   void put(K key, V value);
 
   void remove(K key);
+
+  Iterator<Map.Entry<K, V>> iterator();
 }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/snapshot/RocksDbPersistentList.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/snapshot/RocksDbPersistentList.java
@@ -26,8 +26,6 @@ import org.apache.hadoop.util.ClosableIterator;
 import org.rocksdb.ColumnFamilyHandle;
 import org.rocksdb.RocksDBException;
 
-import static org.apache.hadoop.ozone.om.snapshot.SnapshotUtils.closeIterator;
-
 /**
  * Persistent list backed by RocksDB.
  */

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/snapshot/RocksDbPersistentList.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/snapshot/RocksDbPersistentList.java
@@ -26,6 +26,8 @@ import org.apache.hadoop.util.ClosableIterator;
 import org.rocksdb.ColumnFamilyHandle;
 import org.rocksdb.RocksDBException;
 
+import static org.apache.hadoop.ozone.om.snapshot.SnapshotUtils.closeIterator;
+
 /**
  * Persistent list backed by RocksDB.
  */

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/snapshot/RocksDbPersistentMap.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/snapshot/RocksDbPersistentMap.java
@@ -23,6 +23,7 @@ import java.util.Map;
 import org.apache.hadoop.hdds.utils.db.CodecRegistry;
 import org.apache.hadoop.hdds.utils.db.managed.ManagedRocksDB;
 import org.apache.hadoop.hdds.utils.db.managed.ManagedRocksIterator;
+import org.apache.hadoop.util.ClosableIterator;
 import org.rocksdb.ColumnFamilyHandle;
 import org.rocksdb.RocksDBException;
 
@@ -84,17 +85,12 @@ public class RocksDbPersistentMap<K, V> implements PersistentMap<K, V> {
   }
 
   @Override
-  public CloseableIterator<Map.Entry<K, V>> iterator() {
+  public ClosableIterator<Map.Entry<K, V>> iterator() {
     ManagedRocksIterator iterator =
         new ManagedRocksIterator(db.get().newIterator(columnFamilyHandle));
     iterator.get().seekToFirst();
 
-    return new CloseableIterator<Map.Entry<K, V>>() {
-      @Override
-      public void close() {
-        iterator.close();
-      }
-
+    return new ClosableIterator<Map.Entry<K, V>>() {
       @Override
       public boolean hasNext() {
         return iterator.get().isValid();
@@ -132,6 +128,11 @@ public class RocksDbPersistentMap<K, V> implements PersistentMap<K, V> {
             throw new IllegalStateException("setValue is not implemented.");
           }
         };
+      }
+
+      @Override
+      public void close() {
+        iterator.close();
       }
     };
   }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/snapshot/RocksDbPersistentMap.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/snapshot/RocksDbPersistentMap.java
@@ -19,8 +19,10 @@
 package org.apache.hadoop.ozone.om.snapshot;
 
 import java.io.IOException;
+import java.util.Map;
 import org.apache.hadoop.hdds.utils.db.CodecRegistry;
 import org.apache.hadoop.hdds.utils.db.managed.ManagedRocksDB;
+import org.apache.hadoop.hdds.utils.db.managed.ManagedRocksIterator;
 import org.rocksdb.ColumnFamilyHandle;
 import org.rocksdb.RocksDBException;
 
@@ -79,5 +81,58 @@ public class RocksDbPersistentMap<K, V> implements PersistentMap<K, V> {
       // TODO: [SNAPSHOT] Fail gracefully.
       throw new RuntimeException(exception);
     }
+  }
+
+  @Override
+  public CloseableIterator<Map.Entry<K, V>> iterator() {
+    ManagedRocksIterator iterator =
+        new ManagedRocksIterator(db.get().newIterator(columnFamilyHandle));
+    iterator.get().seekToFirst();
+
+    return new CloseableIterator<Map.Entry<K, V>>() {
+      @Override
+      public void close() {
+        iterator.close();
+      }
+
+      @Override
+      public boolean hasNext() {
+        return iterator.get().isValid();
+      }
+
+      @Override
+      public Map.Entry<K, V> next() {
+        K key;
+        V value;
+
+        try {
+          key = codecRegistry.asObject(iterator.get().key(), keyType);
+          value = codecRegistry.asObject(iterator.get().value(), valueType);
+        } catch (IOException exception) {
+          // TODO: [SNAPSHOT] Fail gracefully.
+          throw new RuntimeException(exception);
+        }
+
+        // Move iterator to the next.
+        iterator.get().next();
+
+        return new Map.Entry<K, V>() {
+          @Override
+          public K getKey() {
+            return key;
+          }
+
+          @Override
+          public V getValue() {
+            return value;
+          }
+
+          @Override
+          public V setValue(V value) {
+            throw new IllegalStateException("setValue is not implemented.");
+          }
+        };
+      }
+    };
   }
 }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/snapshot/SnapshotDiffJob.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/snapshot/SnapshotDiffJob.java
@@ -1,0 +1,87 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.ozone.om.snapshot;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.IOException;
+import org.apache.hadoop.hdds.utils.db.Codec;
+import org.apache.hadoop.ozone.snapshot.SnapshotDiffResponse.JobStatus;
+
+/**
+ * POJO for Snapshot diff job.
+ */
+public class SnapshotDiffJob {
+  private String jobId;
+  private JobStatus status;
+
+  // Default constructor for Jackson Serializer.
+  public SnapshotDiffJob() {
+
+  }
+
+  public SnapshotDiffJob(String jobId, JobStatus jobStatus) {
+    this.jobId = jobId;
+    this.status = jobStatus;
+  }
+
+  public String getJobId() {
+    return jobId;
+  }
+
+  public JobStatus getStatus() {
+    return status;
+  }
+
+  public void setJobId(String jobId) {
+    this.jobId = jobId;
+  }
+
+  public void setStatus(JobStatus status) {
+    this.status = status;
+  }
+
+  /**
+   * Codec to encode SnapshotDiffJob as byte array.
+   */
+  public static class SnapshotDiffJobCodec implements Codec<SnapshotDiffJob> {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper()
+        .setSerializationInclusion(JsonInclude.Include.NON_NULL)
+        .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+
+    @Override
+    public byte[] toPersistedFormat(SnapshotDiffJob object)
+        throws IOException {
+      return MAPPER.writeValueAsBytes(object);
+    }
+
+    @Override
+    public SnapshotDiffJob fromPersistedFormat(byte[] rawData)
+        throws IOException {
+      return MAPPER.readValue(rawData, SnapshotDiffJob.class);
+    }
+
+    @Override
+    public SnapshotDiffJob copyObject(SnapshotDiffJob object) {
+      // Note: Not really a "copy". from OmDBDiffReportEntryCodec
+      return object;
+    }
+  }
+}

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/snapshot/SnapshotDiffJob.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/snapshot/SnapshotDiffJob.java
@@ -30,15 +30,31 @@ import org.apache.hadoop.ozone.snapshot.SnapshotDiffResponse.JobStatus;
 public class SnapshotDiffJob {
   private String jobId;
   private JobStatus status;
+  private String volume;
+  private String bucket;
+  private String fromSnapshot;
+  private String toSnapshot;
+  private boolean forceFullDiff;
 
   // Default constructor for Jackson Serializer.
   public SnapshotDiffJob() {
 
   }
 
-  public SnapshotDiffJob(String jobId, JobStatus jobStatus) {
+  public SnapshotDiffJob(String jobId,
+                         JobStatus jobStatus,
+                         String volume,
+                         String bucket,
+                         String fromSnapshot,
+                         String toSnapshot,
+                         boolean forceFullDiff) {
     this.jobId = jobId;
     this.status = jobStatus;
+    this.volume = volume;
+    this.bucket = bucket;
+    this.fromSnapshot = fromSnapshot;
+    this.toSnapshot = toSnapshot;
+    this.forceFullDiff = forceFullDiff;
   }
 
   public String getJobId() {
@@ -55,6 +71,46 @@ public class SnapshotDiffJob {
 
   public void setStatus(JobStatus status) {
     this.status = status;
+  }
+
+  public String getVolume() {
+    return volume;
+  }
+
+  public void setVolume(String volume) {
+    this.volume = volume;
+  }
+
+  public String getBucket() {
+    return bucket;
+  }
+
+  public void setBucket(String bucket) {
+    this.bucket = bucket;
+  }
+
+  public String getFromSnapshot() {
+    return fromSnapshot;
+  }
+
+  public void setFromSnapshot(String fromSnapshot) {
+    this.fromSnapshot = fromSnapshot;
+  }
+
+  public String getToSnapshot() {
+    return toSnapshot;
+  }
+
+  public void setToSnapshot(String toSnapshot) {
+    this.toSnapshot = toSnapshot;
+  }
+
+  public boolean isForceFullDiff() {
+    return forceFullDiff;
+  }
+
+  public void setForceFullDiff(boolean forceFullDiff) {
+    this.forceFullDiff = forceFullDiff;
   }
 
   /**

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/snapshot/SnapshotDiffManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/snapshot/SnapshotDiffManager.java
@@ -19,6 +19,7 @@
 package org.apache.hadoop.ozone.om.snapshot;
 
 import java.io.IOException;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -28,8 +29,12 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
 import java.util.stream.Stream;
-import org.apache.commons.lang3.tuple.Pair;
 import org.apache.hadoop.hdds.StringUtils;
 import org.apache.hadoop.hdds.utils.db.CodecRegistry;
 import org.apache.hadoop.hdds.utils.db.IntegerCodec;
@@ -47,10 +52,13 @@ import org.apache.hadoop.ozone.om.helpers.OmDirectoryInfo;
 import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
 import org.apache.hadoop.ozone.om.helpers.SnapshotInfo;
 import org.apache.hadoop.ozone.om.helpers.WithObjectID;
+import org.apache.hadoop.ozone.om.snapshot.SnapshotDiffJob.SnapshotDiffJobCodec;
 import org.apache.hadoop.ozone.snapshot.SnapshotDiffReport;
 import org.apache.hadoop.ozone.snapshot.SnapshotDiffReport.DiffReportEntry;
 import org.apache.hadoop.ozone.snapshot.SnapshotDiffReport.DiffType;
 import org.apache.hadoop.util.ClosableIterator;
+import org.apache.hadoop.ozone.snapshot.SnapshotDiffResponse;
+import org.apache.hadoop.ozone.snapshot.SnapshotDiffResponse.JobStatus;
 import org.apache.ozone.rocksdb.util.ManagedSstFileReader;
 import org.apache.ozone.rocksdb.util.RdbUtil;
 import org.apache.ozone.rocksdiff.DifferSnapshotInfo;
@@ -64,11 +72,16 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import static org.apache.hadoop.ozone.OzoneConsts.OM_KEY_PREFIX;
+import static org.apache.hadoop.ozone.snapshot.SnapshotDiffResponse.JobStatus.DONE;
+import static org.apache.hadoop.ozone.snapshot.SnapshotDiffResponse.JobStatus.FAILED;
+import static org.apache.hadoop.ozone.snapshot.SnapshotDiffResponse.JobStatus.IN_PROGRESS;
+import static org.apache.hadoop.ozone.snapshot.SnapshotDiffResponse.JobStatus.QUEUED;
+import static org.apache.hadoop.ozone.snapshot.SnapshotDiffResponse.JobStatus.REJECTED;
 
 /**
  * Class to generate snapshot diff.
  */
-public class SnapshotDiffManager {
+public class SnapshotDiffManager implements AutoCloseable {
   private static final Logger LOG =
           LoggerFactory.getLogger(SnapshotDiffManager.class);
   private static final String DELIMITER = "-";
@@ -84,6 +97,10 @@ public class SnapshotDiffManager {
   private final ManagedRocksDB db;
   private final CodecRegistry codecRegistry;
   private final ManagedColumnFamilyOptions familyOptions;
+  // TODO: [SNAPSHOT] Use different wait time based of job status.
+  private static final Duration DEFAULT_WAIT_TIME = Duration.ofSeconds(1);
+  // TODO: [SNAPSHOT] Move this to config file.
+  private static final int DEFAULT_THREAD_POOL_SIZE = 10;
 
   /**
    * Global table to keep the diff report. Each key is prefixed by the jobID
@@ -98,7 +115,8 @@ public class SnapshotDiffManager {
    * done. This table is used to make sure that there is only single job for
    * similar type of request at any point of time.
    */
-  private final PersistentMap<String, String> snapDiffJobTable;
+  private final PersistentMap<String, SnapshotDiffJob> snapDiffJobTable;
+  private final ExecutorService executorService;
 
   private final OzoneConfiguration configuration;
 
@@ -120,18 +138,28 @@ public class SnapshotDiffManager {
     // DiffReportEntry codec for Diff Report.
     this.codecRegistry.addCodec(DiffReportEntry.class,
         new OmDBDiffReportEntryCodec());
+    this.codecRegistry.addCodec(SnapshotDiffJob.class,
+        new SnapshotDiffJobCodec());
 
     this.snapDiffJobTable = new RocksDbPersistentMap<>(db,
         snapDiffJobCfh,
         codecRegistry,
         String.class,
-        String.class);
+        SnapshotDiffJob.class);
 
     this.snapDiffReportTable = new RocksDbPersistentMap<>(db,
         snapDiffReportCfh,
         codecRegistry,
         byte[].class,
         byte[].class);
+
+    this.executorService = new ThreadPoolExecutor(DEFAULT_THREAD_POOL_SIZE,
+        DEFAULT_THREAD_POOL_SIZE,
+        0,
+        TimeUnit.SECONDS,
+        new ArrayBlockingQueue<>(DEFAULT_THREAD_POOL_SIZE),
+        new ThreadPoolExecutor.CallerRunsPolicy()
+    );
   }
 
   private Map<String, String> getTablePrefixes(
@@ -172,31 +200,52 @@ public class SnapshotDiffManager {
   }
 
   @SuppressWarnings("parameternumber")
-  public SnapshotDiffReport getSnapshotDiffReport(final String volume,
-                                                  final String bucket,
-                                                  final OmSnapshot fromSnapshot,
-                                                  final OmSnapshot toSnapshot,
-                                                  final SnapshotInfo fsInfo,
-                                                  final SnapshotInfo tsInfo,
-                                                  final int index,
-                                                  final int pageSize,
-                                                  final boolean forceFullDiff)
-      throws IOException, RocksDBException {
-    String diffJobKey = fsInfo.getSnapshotID() + DELIMITER +
+  public SnapshotDiffResponse getSnapshotDiffReport(
+      final String volume,
+      final String bucket,
+      final OmSnapshot fromSnapshot,
+      final OmSnapshot toSnapshot,
+      final SnapshotInfo fsInfo,
+      final SnapshotInfo tsInfo,
+      final int index,
+      final int pageSize,
+      final boolean forceFullDiff
+  ) throws IOException {
+    String snapDiffJobKey = fsInfo.getSnapshotID() + DELIMITER +
         tsInfo.getSnapshotID();
 
-    Pair<String, Boolean> jobIdToJobExist = getOrCreateJobId(diffJobKey);
-    String jobId = jobIdToJobExist.getLeft();
-    boolean jobExist = jobIdToJobExist.getRight();
-
-    // If snapshot diff doesn't exist, we generate the diff report first
-    // and add it to the table for future requests.
-    // This needs to be updated to queuing and job status base.
-    if (!jobExist) {
-      generateSnapshotDiffReport(jobId, volume, bucket, fromSnapshot,
-          toSnapshot, fsInfo, tsInfo, forceFullDiff);
+    SnapshotDiffJob snapDiffJob = getSnapDiffReportStatus(snapDiffJobKey);
+    switch (snapDiffJob.getStatus()) {
+    case QUEUED:
+      return submitSnapDiffJob(snapDiffJobKey, snapDiffJob.getJobId(), volume,
+          bucket, fromSnapshot, toSnapshot, fsInfo, tsInfo, index, pageSize,
+          forceFullDiff);
+    case IN_PROGRESS:
+      return new SnapshotDiffResponse(new SnapshotDiffReport(volume, bucket,
+          fromSnapshot.getName(), toSnapshot.getName(), new ArrayList<>(),
+          null), IN_PROGRESS, DEFAULT_WAIT_TIME.toMillis());
+    case FAILED:
+      return new SnapshotDiffResponse(new SnapshotDiffReport(volume, bucket,
+          fromSnapshot.getName(), toSnapshot.getName(), new ArrayList<>(),
+          null), FAILED, DEFAULT_WAIT_TIME.toMillis());
+    case DONE:
+      SnapshotDiffReport report = createPageResponse(snapDiffJob.getJobId(),
+          volume, bucket, fromSnapshot, toSnapshot, index, pageSize);
+      return new SnapshotDiffResponse(report, DONE, 0L);
+    default:
+      throw new IllegalStateException("Unknown snapshot job status: " +
+          snapDiffJob.getStatus());
     }
+  }
 
+  private SnapshotDiffReport createPageResponse(final String jobId,
+                                                final String volume,
+                                                final String bucket,
+                                                final OmSnapshot fromSnapshot,
+                                                final OmSnapshot toSnapshot,
+                                                final int index,
+                                                final int pageSize)
+      throws IOException {
     List<DiffReportEntry> diffReportList = new ArrayList<>();
 
     boolean hasMoreEntries = true;
@@ -218,33 +267,110 @@ public class SnapshotDiffManager {
         toSnapshot.getName(), diffReportList, tokenString);
   }
 
-  /**
-   * Return the jobId from the table if it exists otherwise create a new one,
-   * add to the table and return that.
-   */
-  private synchronized Pair<String, Boolean> getOrCreateJobId(
-      String diffJobKey) {
-    String jobId = snapDiffJobTable.get(diffJobKey);
+  @SuppressWarnings("parameternumber")
+  private synchronized SnapshotDiffResponse submitSnapDiffJob(
+      final String jobKey,
+      final String jobId,
+      final String volume,
+      final String bucket,
+      final OmSnapshot fromSnapshot,
+      final OmSnapshot toSnapshot,
+      final SnapshotInfo fsInfo,
+      final SnapshotInfo tsInfo,
+      final int index,
+      final int pageSize,
+      final boolean forceFullDiff
+  ) throws IOException {
 
-    if (jobId != null) {
-      return Pair.of(jobId, true);
-    } else {
-      jobId = UUID.randomUUID().toString();
-      snapDiffJobTable.put(diffJobKey, jobId);
-      return Pair.of(jobId, false);
+    SnapshotDiffJob snapDiffJob = snapDiffJobTable.get(jobKey);
+
+    // This is only possible if another thread tired to submit the request,
+    // and it got rejected. In this scenario, return the Rejected job status
+    // with wait time.
+    if (snapDiffJob == null) {
+      LOG.info("Snap diff job has been removed for for volume: {}, " +
+          "bucket: {}, fromSnapshot: {} and toSnapshot: {}.",
+          volume, bucket, fromSnapshot.getName(), toSnapshot.getName());
+      return new SnapshotDiffResponse(new SnapshotDiffReport(volume, bucket,
+          fromSnapshot.getName(), toSnapshot.getName(), new ArrayList<>(),
+          null), REJECTED, DEFAULT_WAIT_TIME.toMillis());
+    }
+
+    // Check again that request is still in queued status. If it is not queued,
+    // return the response accordingly for early return.
+    if (snapDiffJob.getStatus() != QUEUED) {
+      // Same request is submitted by another thread and already completed.
+      if (snapDiffJob.getStatus() == DONE) {
+        SnapshotDiffReport report = createPageResponse(snapDiffJob.getJobId(),
+            volume, bucket, fromSnapshot, toSnapshot, index, pageSize);
+        return new SnapshotDiffResponse(report, DONE, 0L);
+      } else {
+        // Otherwise, return the same status as in DB with wait time.
+        return new SnapshotDiffResponse(new SnapshotDiffReport(volume, bucket,
+            fromSnapshot.getName(), toSnapshot.getName(), new ArrayList<>(),
+            null), snapDiffJob.getStatus(), DEFAULT_WAIT_TIME.toMillis());
+      }
+    }
+
+    LOG.info("Submitting snap diff report generation request for" +
+            " volume: {}, bucket: {}, fromSnapshot: {} and toSnapshot: {}",
+        volume, bucket, fromSnapshot.getName(), toSnapshot.getName());
+
+    // Submit the request to the executor if job is still in queued status.
+    // If executor cannot take any more job, remove the job form DB and return
+    // the Rejected Job status with wait time.
+    try {
+      executorService.execute(() -> generateSnapshotDiffReport(jobKey, jobId,
+          volume, bucket, fromSnapshot, toSnapshot, fsInfo, tsInfo,
+          forceFullDiff));
+      updateJobStatus(jobKey, QUEUED, IN_PROGRESS);
+      return new SnapshotDiffResponse(new SnapshotDiffReport(volume, bucket,
+          fromSnapshot.getName(), toSnapshot.getName(), new ArrayList<>(),
+          null),
+          IN_PROGRESS, DEFAULT_WAIT_TIME.toMillis());
+    } catch (RejectedExecutionException exception) {
+      // Remove the entry from job table so that client can retry.
+      // If entry is not removed, client has to wait till cleanup service
+      // removes the entry even tho there are resources to execute the request
+      // before the cleanup kicks in.
+      snapDiffJobTable.remove(jobKey);
+      LOG.info("Exceeded the snapDiff parallel requests progressing " +
+          "limit. Please retry after {}.", DEFAULT_WAIT_TIME);
+      return new SnapshotDiffResponse(new SnapshotDiffReport(volume, bucket,
+          fromSnapshot.getName(), toSnapshot.getName(), new ArrayList<>(),
+          null), REJECTED, DEFAULT_WAIT_TIME.toMillis());
     }
   }
 
+  /**
+   * Check if there is an existing request for the same `fromSnapshot` and
+   * `toSnapshot`. If yes, then return that response otherwise adds a new entry
+   * to the table for the future requests and returns that.
+   */
+  private synchronized SnapshotDiffJob getSnapDiffReportStatus(
+      String snapDiffJobKey
+  ) {
+    SnapshotDiffJob snapDiffJob = snapDiffJobTable.get(snapDiffJobKey);
+
+    if (snapDiffJob == null) {
+      String jobId = UUID.randomUUID().toString();
+      snapDiffJob = new SnapshotDiffJob(jobId, QUEUED);
+      snapDiffJobTable.put(snapDiffJobKey, snapDiffJob);
+    }
+
+    return snapDiffJob;
+  }
+
   @SuppressWarnings("parameternumber")
-  private void generateSnapshotDiffReport(final String jobId,
+  private void generateSnapshotDiffReport(final String jobKey,
+                                          final String jobId,
                                           final String volume,
                                           final String bucket,
                                           final OmSnapshot fromSnapshot,
                                           final OmSnapshot toSnapshot,
                                           final SnapshotInfo fsInfo,
                                           final SnapshotInfo tsInfo,
-                                          final boolean forceFullDiff)
-      throws RocksDBException {
+                                          final boolean forceFullDiff) {
     ColumnFamilyHandle fromSnapshotColumnFamily = null;
     ColumnFamilyHandle toSnapshotColumnFamily = null;
     ColumnFamilyHandle objectIDsColumnFamily = null;
@@ -258,8 +384,6 @@ public class SnapshotDiffManager {
           createColumnFamily(jobId + TO_SNAP_TABLE_SUFFIX);
       objectIDsColumnFamily =
           createColumnFamily(jobId + UNIQUE_IDS_TABLE_SUFFIX);
-      // ReportId is prepended to column families name to make them unique
-      // for request.
 
       // ObjectId to keyName map to keep key info for fromSnapshot.
       // objectIdToKeyNameMap is used to identify what keys were touched
@@ -344,23 +468,16 @@ public class SnapshotDiffManager {
           objectIDsToCheckMap,
           objectIdToKeyNameMapForFromSnapshot,
           objectIdToKeyNameMapForToSnapshot);
+      updateJobStatus(jobKey, IN_PROGRESS, DONE);
     } catch (IOException | RocksDBException exception) {
+      updateJobStatus(jobKey, IN_PROGRESS, FAILED);
       // TODO: [SNAPSHOT] Fail gracefully.
-      throw new RuntimeException(exception);
+      throw new RuntimeException(exception.getCause());
     } finally {
       // Clean up: drop the intermediate column family and close them.
-      if (fromSnapshotColumnFamily != null) {
-        db.get().dropColumnFamily(fromSnapshotColumnFamily);
-        fromSnapshotColumnFamily.close();
-      }
-      if (toSnapshotColumnFamily != null) {
-        db.get().dropColumnFamily(toSnapshotColumnFamily);
-        toSnapshotColumnFamily.close();
-      }
-      if (objectIDsColumnFamily != null) {
-        db.get().dropColumnFamily(objectIDsColumnFamily);
-        objectIDsColumnFamily.close();
-      }
+      dropAndCloseColumnFamilyHandle(fromSnapshotColumnFamily);
+      dropAndCloseColumnFamilyHandle(toSnapshotColumnFamily);
+      dropAndCloseColumnFamilyHandle(objectIDsColumnFamily);
     }
   }
 
@@ -381,7 +498,7 @@ public class SnapshotDiffManager {
         fsTable.getName().equals(OmMetadataManagerImpl.DIRECTORY_TABLE);
 
     try (Stream<String> keysToCheck = new ManagedSstFileReader(deltaFiles)
-            .getKeyStream()) {
+        .getKeyStream()) {
       keysToCheck.forEach(key -> {
         try {
           final WithObjectID oldKey = fsTable.get(key);
@@ -417,7 +534,7 @@ public class SnapshotDiffManager {
   }
 
   private String getKeyOrDirectoryName(boolean isDirectory,
-      WithObjectID object) {
+                                       WithObjectID object) {
     if (isDirectory) {
       OmDirectoryInfo directoryInfo = (OmDirectoryInfo) object;
       return directoryInfo.getName();
@@ -498,15 +615,13 @@ public class SnapshotDiffManager {
       final PersistentSet<byte[]> objectIDsToCheck,
       final PersistentMap<byte[], byte[]> oldObjIdToKeyMap,
       final PersistentMap<byte[], byte[]> newObjIdToKeyMap
-  ) throws RocksDBException {
-
+  ) throws IOException {
     ColumnFamilyHandle deleteDiffColumnFamily = null;
     ColumnFamilyHandle renameDiffColumnFamily = null;
     ColumnFamilyHandle createDiffColumnFamily = null;
     ColumnFamilyHandle modifyDiffColumnFamily = null;
 
-    // RequestId is prepended to column family name to make it unique
-    // for request.
+    // JobId is prepended to column family name to make it unique for request.
     try {
       deleteDiffColumnFamily =
           createColumnFamily(jobId + DELETE_DIFF_TABLE_SUFFIX);
@@ -615,26 +730,15 @@ public class SnapshotDiffManager {
       index = addToReport(jobId, index, renameDiffs);
       index = addToReport(jobId, index, createDiffs);
       addToReport(jobId, index, modifyDiffs);
-    } catch (IOException e) {
+    } catch (RocksDBException | IOException e) {
       // TODO: [SNAPSHOT] Fail gracefully.
       throw new RuntimeException(e);
     } finally {
-      if (deleteDiffColumnFamily != null) {
-        db.get().dropColumnFamily(deleteDiffColumnFamily);
-        deleteDiffColumnFamily.close();
-      }
-      if (renameDiffColumnFamily != null) {
-        db.get().dropColumnFamily(renameDiffColumnFamily);
-        renameDiffColumnFamily.close();
-      }
-      if (createDiffColumnFamily != null) {
-        db.get().dropColumnFamily(createDiffColumnFamily);
-        createDiffColumnFamily.close();
-      }
-      if (modifyDiffColumnFamily != null) {
-        db.get().dropColumnFamily(modifyDiffColumnFamily);
-        modifyDiffColumnFamily.close();
-      }
+
+      dropAndCloseColumnFamilyHandle(deleteDiffColumnFamily);
+      dropAndCloseColumnFamilyHandle(renameDiffColumnFamily);
+      dropAndCloseColumnFamilyHandle(createDiffColumnFamily);
+      dropAndCloseColumnFamilyHandle(modifyDiffColumnFamily);
     }
   }
 
@@ -669,6 +773,35 @@ public class SnapshotDiffManager {
       }
     }
     return index;
+  }
+
+  private void dropAndCloseColumnFamilyHandle(
+      final ColumnFamilyHandle columnFamilyHandle) {
+
+    if (columnFamilyHandle == null) {
+      return;
+    }
+
+    try {
+      db.get().dropColumnFamily(columnFamilyHandle);
+    } catch (RocksDBException exception) {
+      // TODO: [SNAPSHOT] Fail gracefully.
+      throw new RuntimeException(exception);
+    }
+    columnFamilyHandle.close();
+  }
+
+  private synchronized void updateJobStatus(String jobKey,
+                                            JobStatus oldStatus,
+                                            JobStatus newStatus) {
+    SnapshotDiffJob report = snapDiffJobTable.get(jobKey);
+    if (report.getStatus() != oldStatus) {
+      throw new IllegalStateException("Invalid job status. Current job " +
+          "status is '" + report.getStatus() + "', while '" + oldStatus +
+          "' is expected.");
+    }
+    snapDiffJobTable.put(jobKey,
+        new SnapshotDiffJob(report.getJobId(), newStatus));
   }
 
   private BucketLayout getBucketLayout(final String volume,
@@ -707,5 +840,15 @@ public class SnapshotDiffManager {
       volumeBucketDbPrefix = tablePrefixes.get(OmMetadataManagerImpl.KEY_TABLE);
     }
     return key.startsWith(volumeBucketDbPrefix);
+  }
+
+  @Override
+  public void close() throws Exception {
+    if (familyOptions != null) {
+      familyOptions.close();
+    }
+    if (executorService != null) {
+      executorService.shutdown();
+    }
   }
 }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/snapshot/SnapshotUtils.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/snapshot/SnapshotUtils.java
@@ -1,0 +1,79 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.ozone.om.snapshot;
+
+import java.io.IOException;
+import org.apache.hadoop.ozone.om.OzoneManager;
+import org.apache.hadoop.ozone.om.exceptions.OMException;
+import org.apache.hadoop.ozone.om.helpers.SnapshotInfo;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static org.apache.hadoop.ozone.om.exceptions.OMException.ResultCodes.KEY_NOT_FOUND;
+
+/**
+ * Util class for snapshot diff APIs.
+ */
+public final class SnapshotUtils {
+  private static final Logger LOG =
+      LoggerFactory.getLogger(SnapshotUtils.class);
+
+  private SnapshotUtils() {
+    throw new IllegalStateException("SnapshotUtils should not be initialized.");
+  }
+
+  public static SnapshotInfo getSnapshotInfo(final OzoneManager ozoneManager,
+                                             final String volumeName,
+                                             final String bucketName,
+                                             final String snapshotName)
+      throws IOException {
+    return getSnapshotInfo(ozoneManager,
+        SnapshotInfo.getTableKey(volumeName, bucketName, snapshotName));
+  }
+
+  public static SnapshotInfo getSnapshotInfo(final OzoneManager ozoneManager,
+                                             final String key)
+      throws IOException {
+    SnapshotInfo snapshotInfo;
+    try {
+      snapshotInfo = ozoneManager.getMetadataManager()
+          .getSnapshotInfoTable()
+          .get(key);
+    } catch (IOException e) {
+      LOG.error("Snapshot {}: not found: {}", key, e);
+      throw e;
+    }
+    if (snapshotInfo == null) {
+      throw new OMException(KEY_NOT_FOUND);
+    }
+    return snapshotInfo;
+  }
+
+  public static <E> void closeIterator(final CloseableIterator<E> iterator) {
+    if (iterator == null) {
+      return;
+    }
+
+    try {
+      iterator.close();
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+  }
+}

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/snapshot/SnapshotUtils.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/snapshot/SnapshotUtils.java
@@ -64,16 +64,4 @@ public final class SnapshotUtils {
     }
     return snapshotInfo;
   }
-
-  public static <E> void closeIterator(final CloseableIterator<E> iterator) {
-    if (iterator == null) {
-      return;
-    }
-
-    try {
-      iterator.close();
-    } catch (Exception e) {
-      throw new RuntimeException(e);
-    }
-  }
 }

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/snapshot/TestRocksDbPersistentList.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/snapshot/TestRocksDbPersistentList.java
@@ -94,7 +94,6 @@ public class TestRocksDbPersistentList {
   @Test
   public void testRocksDBPersistentList() throws IOException, RocksDBException {
     ColumnFamilyHandle columnFamily = null;
-
     try {
       CodecRegistry codecRegistry = new CodecRegistry();
       codecRegistry.addCodec(Integer.class, new IntegerCodec());


### PR DESCRIPTION
## What changes were proposed in this pull request?
This change is to offload the snapshot diff process to the background processor and release the request thread. This is needed to make sure that client request doesn't timeout in case diff is huge and takes more than max request timeout.

A fixed size thread pool executor is added to offload the snapDiff processing. Snapdiff jobs are submitted to the executor and request thread is release with a wait time along with job status in response. Client will retry after the wait time in case job status is In_Progress, Rejected or Failed.

Flow of the state machine is as in the following diagram.

![Snap_diff_state_machine](https://user-images.githubusercontent.com/6820020/226994365-2c841284-cf5b-4e56-a459-bdb88a5f9f38.png)

On OM restarts, we load all the `IN_PROGRESS` jobs, which were in progress before OM went down, and send them to executor. We don't need to load `QUEUED` jobs because responses for queued jobs were never returned to client. In short, we don't return queued job status to client. When client re-submits previously queued job, workflow will pick it and execute it.
Other reason why we don't load `QUEUED` jobs on OM restart because queued jobs can be more than what executor can handle and if they get rejected by executor, they will never be picked till next OM restart.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-7952

## How was this patch tested?
Existing UT for now. Will raise a new PR for test.
