### PR TITLE
HDDS-7697. Restrict change of bucket properties to owner and admins in NativeACL

### DIFF
--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneAclUtils.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneAclUtils.java
@@ -26,6 +26,7 @@ import java.io.IOException;
 import java.net.InetAddress;
 
 import static org.apache.hadoop.ozone.om.exceptions.OMException.ResultCodes.INVALID_REQUEST;
+import static org.apache.hadoop.ozone.security.acl.OzoneObj.ResourceType.BUCKET;
 
 /**
  * Ozone Acl Wrapper class.
@@ -89,11 +90,13 @@ public final class OzoneAclUtils {
     // only READ access on parent level access. OzoneNativeAuthorizer has
     // different parent level access based on the child level access type
     if (omMetadataReader.isNativeAuthorizerEnabled()) {
-      if (aclType == IAccessAuthorizer.ACLType.CREATE ||
-          aclType == IAccessAuthorizer.ACLType.DELETE ||
-          aclType == IAccessAuthorizer.ACLType.WRITE_ACL) {
+      // For Native, below parent assignment is not used,
+      // overwritten in NativeACL Handler where parent ACL is re-defined
+      if (aclType == IAccessAuthorizer.ACLType.CREATE) {
         parentAclRight = IAccessAuthorizer.ACLType.WRITE;
       } else if (aclType == IAccessAuthorizer.ACLType.READ_ACL ||
+          aclType == IAccessAuthorizer.ACLType.WRITE_ACL ||
+          aclType == IAccessAuthorizer.ACLType.DELETE ||
           aclType == IAccessAuthorizer.ACLType.LIST) {
         parentAclRight = IAccessAuthorizer.ACLType.READ;
       }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneAclUtils.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneAclUtils.java
@@ -104,12 +104,8 @@ public final class OzoneAclUtils {
       // only READ access on parent level access. OzoneNativeAuthorizer has
       // different parent level access based on the child level access type
       IAccessAuthorizer.ACLType parentAclRight = IAccessAuthorizer.ACLType.READ;
-      if (omMetadataReader.isNativeAuthorizerEnabled()) {
+      if (omMetadataReader.isNativeAuthorizerEnabled() && resType == BUCKET) {
         parentAclRight = getParentNativeAcl(aclType, resType);
-        if (!(resType == BUCKET)) {
-          // for key and prefix, volume is always READ
-          parentAclRight = IAccessAuthorizer.ACLType.READ;
-        }
       }
       
       omMetadataReader.checkAcls(OzoneObj.ResourceType.VOLUME, storeType,

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneAclUtils.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneAclUtils.java
@@ -27,6 +27,7 @@ import java.net.InetAddress;
 
 import static org.apache.hadoop.ozone.om.exceptions.OMException.ResultCodes.INVALID_REQUEST;
 import static org.apache.hadoop.ozone.security.acl.OzoneObj.ResourceType.BUCKET;
+import static org.apache.hadoop.ozone.security.acl.OzoneObj.ResourceType.VOLUME;
 
 /**
  * Ozone Acl Wrapper class.
@@ -84,26 +85,6 @@ public final class OzoneAclUtils {
 
     boolean isVolOwner = isOwner(user, volOwner);
 
-    IAccessAuthorizer.ACLType parentAclRight = aclType;
-
-    //OzoneNativeAuthorizer differs from Ranger Authorizer as Ranger requires
-    // only READ access on parent level access. OzoneNativeAuthorizer has
-    // different parent level access based on the child level access type
-    if (omMetadataReader.isNativeAuthorizerEnabled()) {
-      // For Native, below parent assignment is not used,
-      // overwritten in NativeACL Handler where parent ACL is re-defined
-      if (aclType == IAccessAuthorizer.ACLType.CREATE) {
-        parentAclRight = IAccessAuthorizer.ACLType.WRITE;
-      } else if (aclType == IAccessAuthorizer.ACLType.READ_ACL ||
-          aclType == IAccessAuthorizer.ACLType.WRITE_ACL ||
-          aclType == IAccessAuthorizer.ACLType.DELETE ||
-          aclType == IAccessAuthorizer.ACLType.LIST) {
-        parentAclRight = IAccessAuthorizer.ACLType.READ;
-      }
-    } else {
-      parentAclRight =  IAccessAuthorizer.ACLType.READ;
-    }
-
     switch (resType) {
     //For Volume level access we only need to check {OWNER} equal
     // to Volume Owner.
@@ -119,6 +100,18 @@ public final class OzoneAclUtils {
     // volume owner if current ugi user is volume owner else we need check
     //{OWNER} equals bucket owner for bucket/key/prefix.
     case PREFIX:
+      //OzoneNativeAuthorizer differs from Ranger Authorizer as Ranger requires
+      // only READ access on parent level access. OzoneNativeAuthorizer has
+      // different parent level access based on the child level access type
+      IAccessAuthorizer.ACLType parentAclRight = IAccessAuthorizer.ACLType.READ;
+      if (omMetadataReader.isNativeAuthorizerEnabled()) {
+        parentAclRight = getParentNativeAcl(aclType, resType);
+        if (!(resType == BUCKET)) {
+          // for key and prefix, volume is always READ
+          parentAclRight = IAccessAuthorizer.ACLType.READ;
+        }
+      }
+      
       omMetadataReader.checkAcls(OzoneObj.ResourceType.VOLUME, storeType,
           parentAclRight, vol, bucket, key, user,
           remoteAddress, hostName, true,
@@ -139,6 +132,56 @@ public final class OzoneAclUtils {
       throw new OMException("Unexpected object type:" +
               resType, INVALID_REQUEST);
     }
+  }
+
+  /**
+   * get the Parent ACL based on child ACL and resource type.
+   * 
+   * @param aclRight child acl as required
+   * @param resType resource type
+   * @return parent acl
+   */
+  public static IAccessAuthorizer.ACLType getParentNativeAcl(
+      IAccessAuthorizer.ACLType aclRight, OzoneObj.ResourceType resType) {
+    // For volume, parent access has no meaning and not used
+    if (resType == VOLUME) {
+      return IAccessAuthorizer.ACLType.NONE;
+    }
+    
+    // Refined the parent for bucket, keys & prefix
+    // OP         |CHILD       |PARENT
+
+    // CREATE      NONE        WRITE
+    // DELETE      DELETE      READ
+    // WRITE       WRITE       WRITE     (For key/prefix, volume is READ)
+    // WRITE_ACL   WRITE_ACL   READ      (V1 WRITE_ACL=>WRITE)
+
+    // READ        READ        READ
+    // LIST        LIST        READ      (V1 LIST=>READ)
+    // READ_ACL    READ_ACL    READ      (V1 READ_ACL=>READ)
+
+    // for bucket, except CREATE, all cases need READ for volume
+    if (resType == BUCKET) {
+      if (aclRight == IAccessAuthorizer.ACLType.CREATE) {
+        return IAccessAuthorizer.ACLType.WRITE;
+      }
+      return IAccessAuthorizer.ACLType.READ;
+    }
+    
+    // else for key and prefix, bucket permission will be read
+    // except where key/prefix have CREATE and WRITE,
+    // bucket will have WRITE
+    IAccessAuthorizer.ACLType parentAclRight = aclRight;
+    if (aclRight == IAccessAuthorizer.ACLType.CREATE) {
+      parentAclRight = IAccessAuthorizer.ACLType.WRITE;
+    } else if (aclRight == IAccessAuthorizer.ACLType.READ_ACL
+        || aclRight == IAccessAuthorizer.ACLType.LIST
+        || aclRight == IAccessAuthorizer.ACLType.WRITE_ACL
+        || aclRight == IAccessAuthorizer.ACLType.DELETE) {
+      parentAclRight = IAccessAuthorizer.ACLType.READ;
+    }
+
+    return parentAclRight;
   }
 
   private static boolean isOwner(UserGroupInformation callerUgi,

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/bucket/OMBucketSetPropertyRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/bucket/OMBucketSetPropertyRequest.java
@@ -36,6 +36,7 @@ import org.apache.hadoop.ozone.om.request.validation.ValidationCondition;
 import org.apache.hadoop.ozone.om.request.validation.ValidationContext;
 import org.apache.hadoop.ozone.om.upgrade.OMLayoutFeature;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.Type;
+import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.hadoop.util.Time;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -124,9 +125,7 @@ public class OMBucketSetPropertyRequest extends OMClientRequest {
     try {
       // check Acl
       if (ozoneManager.getAclsEnabled()) {
-        checkAcls(ozoneManager, OzoneObj.ResourceType.BUCKET,
-            OzoneObj.StoreType.OZONE, IAccessAuthorizer.ACLType.WRITE,
-            volumeName, bucketName, null);
+        checkAclPermission(ozoneManager, volumeName, bucketName);
       }
 
       // acquire lock.
@@ -266,6 +265,26 @@ public class OMBucketSetPropertyRequest extends OMClientRequest {
           bucketName, volumeName, exception);
       omMetrics.incNumBucketUpdateFails();
       return omClientResponse;
+    }
+  }
+
+  private void checkAclPermission(
+      OzoneManager ozoneManager, String volumeName, String bucketName)
+      throws IOException {
+    if (ozoneManager.getOmMetadataReader().isNativeAuthorizerEnabled()) {
+      UserGroupInformation ugi = createUGI();
+      String bucketOwner = ozoneManager.getBucketOwner(volumeName, bucketName,
+          IAccessAuthorizer.ACLType.READ, OzoneObj.ResourceType.BUCKET);
+      if (!ozoneManager.isAdmin(ugi) &&
+          !ozoneManager.isOwner(ugi, bucketOwner)) {
+        throw new OMException(
+            "Only bucket owners and Ozone admins can set Bucket property",
+            OMException.ResultCodes.PERMISSION_DENIED);
+      }
+    } else { // ranger acl
+      checkAcls(ozoneManager, OzoneObj.ResourceType.BUCKET,
+          OzoneObj.StoreType.OZONE, IAccessAuthorizer.ACLType.WRITE,
+          volumeName, bucketName, null);
     }
   }
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/bucket/OMBucketSetPropertyRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/bucket/OMBucketSetPropertyRequest.java
@@ -278,7 +278,7 @@ public class OMBucketSetPropertyRequest extends OMClientRequest {
       if (!ozoneManager.isAdmin(ugi) &&
           !ozoneManager.isOwner(ugi, bucketOwner)) {
         throw new OMException(
-            "Only bucket owners and Ozone admins can set Bucket property",
+            "Bucket properties are allowed to changed by Admin and Owner",
             OMException.ResultCodes.PERMISSION_DENIED);
       }
     } else { // ranger acl

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/security/acl/TestParentAcl.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/security/acl/TestParentAcl.java
@@ -202,7 +202,7 @@ public class TestParentAcl {
     testParentChild(bucketObj, READ, LIST);
     resetAcl(vol, originalVolAcls, buck, originalBuckAcls, null, null);
 
-    testParentChild(bucketObj, CREATE, CREATE);
+    testParentChild(bucketObj, WRITE, CREATE);
     resetAcl(vol, originalVolAcls, buck, originalBuckAcls, null, null);
 
     testParentChild(bucketObj, READ, READ);

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/security/acl/TestParentAcl.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/security/acl/TestParentAcl.java
@@ -148,11 +148,11 @@ public class TestParentAcl {
     List<OzoneAcl> originalBuckAcls = getBucketAcls(vol, buck);
     List<OzoneAcl> originalKeyAcls = getBucketAcls(vol, buck);
 
-    testParentChild(keyObj, WRITE, WRITE_ACL);
+    testParentChild(keyObj, READ, WRITE_ACL);
     resetAcl(vol, originalVolAcls, buck, originalBuckAcls,
         key, originalKeyAcls);
 
-    testParentChild(keyObj, WRITE, DELETE);
+    testParentChild(keyObj, READ, DELETE);
     resetAcl(vol, originalVolAcls, buck, originalBuckAcls,
         key, originalKeyAcls);
 
@@ -190,10 +190,10 @@ public class TestParentAcl {
 
     List<OzoneAcl> originalVolAcls = getVolumeAcls(vol);
     List<OzoneAcl> originalBuckAcls = getBucketAcls(vol, buck);
-    testParentChild(bucketObj, WRITE, WRITE_ACL);
+    testParentChild(bucketObj, READ, WRITE_ACL);
     resetAcl(vol, originalVolAcls, buck, originalBuckAcls, null, null);
 
-    testParentChild(bucketObj, WRITE, DELETE);
+    testParentChild(bucketObj, READ, DELETE);
     resetAcl(vol, originalVolAcls, buck, originalBuckAcls, null, null);
 
     testParentChild(bucketObj, READ, READ_ACL);
@@ -208,7 +208,7 @@ public class TestParentAcl {
     testParentChild(bucketObj, READ, READ);
     resetAcl(vol, originalVolAcls, buck, originalBuckAcls, null, null);
 
-    testParentChild(bucketObj, WRITE, WRITE);
+    testParentChild(bucketObj, READ, WRITE);
     resetAcl(vol, originalVolAcls, buck, originalBuckAcls, null, null);
   }
 
@@ -263,7 +263,9 @@ public class TestParentAcl {
       Assert.assertFalse(nativeAuthorizer.checkAccess(child, requestContext));
 
       // add the volume acl (grand-parent), now key access is allowed.
-      addVolumeAcl(child.getVolumeName(), parentAcl);
+      OzoneAcl parentVolumeAcl = new OzoneAcl(USER,
+          testUgi1.getUserName(), READ, ACCESS);
+      addVolumeAcl(child.getVolumeName(), parentVolumeAcl);
       Assert.assertTrue(nativeAuthorizer.checkAccess(child, requestContext));
     }
   }

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/security/acl/TestParentAcl.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/security/acl/TestParentAcl.java
@@ -119,17 +119,6 @@ public class TestParentAcl {
         new String[]{"test1"});
   }
 
-  // Refined the parent context
-  // OP         |CHILD       |PARENT
-
-  // CREATE      NONE         WRITE     (parent:'CREATE' when 'create bucket')
-  // DELETE      DELETE       WRITE
-  // WRITE       WRITE        WRITE
-  // WRITE_ACL   WRITE_ACL    WRITE     (V1 WRITE_ACL=>WRITE)
-
-  // READ        READ         READ
-  // LIST        LIST         READ      (V1 LIST=>READ)
-  // READ_ACL    READ_ACL     READ      (V1 READ_ACL=>READ)
   @Test
   @Flaky("HDDS-6335")
   public void testKeyAcl()


### PR DESCRIPTION
## What changes were proposed in this pull request?

1. Volume permission changed to READ for multiple operation (towards Ranger permission similarity)
2. quota set and clear can be done only by admin and owner for Native ACL

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-7697

## How was this patch tested?

UT cases and E2E case is verified
