### PR TITLE
HDDS-7918. EC: ECBlockReconstructedStripeInputStream should check for spare replicas before failing an index

### DIFF
--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/ozone/client/io/BadDataLocationException.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/ozone/client/io/BadDataLocationException.java
@@ -29,7 +29,7 @@ import java.util.List;
  */
 public class BadDataLocationException extends IOException {
 
-  private List<DatanodeDetails> failedLocations = new ArrayList<>();
+  private final List<DatanodeDetails> failedLocations = new ArrayList<>();
   private int failedLocationIndex;
 
   public BadDataLocationException(DatanodeDetails dn) {
@@ -51,6 +51,13 @@ public class BadDataLocationException extends IOException {
   public BadDataLocationException(DatanodeDetails dn, Throwable ex) {
     super(ex);
     failedLocations.add(dn);
+  }
+
+  public BadDataLocationException(int failedIndex,
+      Throwable ex, List<DatanodeDetails> failedLocations) {
+    super(ex);
+    failedLocationIndex = failedIndex;
+    this.failedLocations.addAll(failedLocations);
   }
 
   public BadDataLocationException(DatanodeDetails dn, int failedIndex,

--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/ozone/client/io/ECBlockInputStream.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/ozone/client/io/ECBlockInputStream.java
@@ -334,7 +334,7 @@ public class ECBlockInputStream extends BlockExtendedInputStream {
     }
   }
 
-  private boolean shouldRetryFailedRead(int failedIndex) {
+  protected boolean shouldRetryFailedRead(int failedIndex) {
     Deque<DatanodeDetails> spareLocations = spareDataLocations.get(failedIndex);
     if (spareLocations != null && spareLocations.size() > 0) {
       failedLocations.add(dataLocations[failedIndex]);
@@ -470,7 +470,7 @@ public class ECBlockInputStream extends BlockExtendedInputStream {
     seeked = true;
   }
 
-  private void closeStream(int i) {
+  protected void closeStream(int i) {
     if (blockStreams[i] != null) {
       try {
         blockStreams[i].close();

--- a/hadoop-hdds/client/src/test/java/org/apache/hadoop/ozone/client/io/ECStreamTestUtil.java
+++ b/hadoop-hdds/client/src/test/java/org/apache/hadoop/ozone/client/io/ECStreamTestUtil.java
@@ -223,7 +223,7 @@ public final class ECStreamTestUtil {
         new LinkedHashMap<>();
     private List<ByteBuffer> blockStreamData;
     // List of EC indexes that should fail immediately on read
-    private List<Integer> failIndexes = new ArrayList<>();
+    private final List<Integer> failIndexes = new ArrayList<>();
 
     private Pipeline currentPipeline;
 
@@ -249,8 +249,9 @@ public final class ECStreamTestUtil {
       this.currentPipeline = pipeline;
     }
 
-    public synchronized void setFailIndexes(List<Integer> fail) {
-      failIndexes.addAll(fail);
+    // fail each index in the list once
+    public synchronized void setFailIndexes(Integer... fail) {
+      failIndexes.addAll(Arrays.asList(fail));
     }
 
     public synchronized BlockExtendedInputStream create(
@@ -264,7 +265,7 @@ public final class ECStreamTestUtil {
       TestBlockInputStream stream = new TestBlockInputStream(
           blockInfo.getBlockID(), blockInfo.getLength(),
           blockStreamData.get(repInd - 1), repInd);
-      if (failIndexes.contains(repInd)) {
+      if (failIndexes.remove(Integer.valueOf(repInd))) {
         stream.setShouldError(true);
       }
       blockStreams.put(repInd, stream);

--- a/hadoop-hdds/client/src/test/java/org/apache/hadoop/ozone/client/io/TestECBlockReconstructedStripeInputStream.java
+++ b/hadoop-hdds/client/src/test/java/org/apache/hadoop/ozone/client/io/TestECBlockReconstructedStripeInputStream.java
@@ -20,6 +20,7 @@ package org.apache.hadoop.ozone.client.io;
 import com.google.common.collect.ImmutableSet;
 import org.apache.hadoop.hdds.client.ECReplicationConfig;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
+import org.apache.hadoop.hdds.protocol.MockDatanodeDetails;
 import org.apache.hadoop.hdds.scm.storage.BlockLocationInfo;
 import org.apache.hadoop.io.ByteBufferPool;
 import org.apache.hadoop.io.ElasticByteBufferPool;
@@ -490,6 +491,71 @@ public class TestECBlockReconstructedStripeInputStream {
   }
 
   @Test
+  void testNoErrorIfSpareLocationToRead() throws IOException {
+    int chunkSize = repConfig.getEcChunkSize();
+    int blockLength = chunkSize * 3 - 1;
+
+    ByteBuffer[] dataBufs = allocateBuffers(repConfig.getData(), 3 * ONEMB);
+    ECStreamTestUtil
+        .randomFill(dataBufs, repConfig.getEcChunkSize(), dataGen, blockLength);
+    ByteBuffer[] parity = generateParity(dataBufs, repConfig);
+
+    // We have a length that is less than a stripe, so chunks 1 and 2 are full.
+    // Block 1 is lost and needs recovered
+    // from the parity and padded blocks 2 and 3.
+
+    List<Map<DatanodeDetails, Integer>> locations = new ArrayList<>();
+    // Two data missing
+    locations.add(ECStreamTestUtil.createIndexMap(3, 4, 5));
+    // Two data missing
+    locations.add(ECStreamTestUtil.createIndexMap(1, 4, 5));
+    // One data missing - the last one
+    locations.add(ECStreamTestUtil.createIndexMap(1, 2, 5));
+    // One data and one parity missing
+    locations.add(ECStreamTestUtil.createIndexMap(2, 3, 4));
+    // One data and one parity missing
+    locations.add(ECStreamTestUtil.createIndexMap(1, 2, 4));
+    // No indexes missing
+    locations.add(ECStreamTestUtil.createIndexMap(1, 2, 3, 4, 5));
+
+    DatanodeDetails spare = MockDatanodeDetails.randomDatanodeDetails();
+
+    for (Map<DatanodeDetails, Integer> dnMap : locations) {
+      streamFactory = new TestBlockInputStreamFactory();
+      addDataStreamsToFactory(dataBufs, parity);
+      ByteBuffer[] bufs = allocateByteBuffers(repConfig);
+
+      // this index fails, but has spare replica
+      int failing = dnMap.values().iterator().next();
+      streamFactory.setFailIndexes(failing);
+      dnMap.put(spare, failing);
+
+      BlockLocationInfo keyInfo =
+          ECStreamTestUtil.createKeyInfo(repConfig, blockLength, dnMap);
+      streamFactory.setCurrentPipeline(keyInfo.getPipeline());
+
+      dataGen = new SplittableRandom(randomSeed);
+      try (ECBlockReconstructedStripeInputStream ecb =
+               createInputStream(keyInfo)) {
+        int read = ecb.read(bufs);
+        Assertions.assertEquals(blockLength, read);
+        ECStreamTestUtil.assertBufferMatches(bufs[0], dataGen);
+        ECStreamTestUtil.assertBufferMatches(bufs[1], dataGen);
+        ECStreamTestUtil.assertBufferMatches(bufs[2], dataGen);
+        // Check the underlying streams have been advanced by 1 chunk:
+        for (TestBlockInputStream bis : streamFactory.getBlockStreams()) {
+          Assertions.assertEquals(0, bis.getRemaining());
+        }
+        Assertions.assertEquals(ecb.getPos(), blockLength);
+        clearBuffers(bufs);
+        // A further read should give EOF
+        read = ecb.read(bufs);
+        Assertions.assertEquals(-1, read);
+      }
+    }
+  }
+
+  @Test
   public void testSeek() throws IOException {
     // Generate the input data for 3 full stripes and generate the parity
     // and a partial stripe
@@ -688,7 +754,7 @@ public class TestECBlockReconstructedStripeInputStream {
     streamFactory = new TestBlockInputStreamFactory();
     addDataStreamsToFactory(dataBufs, parity);
     // Fail all the indexes containing data on their first read.
-    streamFactory.setFailIndexes(indexesToList(1, 4, 5));
+    streamFactory.setFailIndexes(1, 4, 5);
     // The locations contain the padded indexes, as will often be the case
     // when containers are reported by SCM.
     Map<DatanodeDetails, Integer> dnMap =
@@ -757,14 +823,6 @@ public class TestECBlockReconstructedStripeInputStream {
       BlockLocationInfo keyInfo) {
     return new ECBlockReconstructedStripeInputStream(repConfig, keyInfo, true,
         null, null, streamFactory, bufferPool, ecReconstructExecutor);
-  }
-
-  private List<Integer> indexesToList(int... indexes) {
-    List<Integer> list = new ArrayList<>();
-    for (int i : indexes) {
-      list.add(i);
-    }
-    return list;
   }
 
   private void addDataStreamsToFactory(ByteBuffer[] data, ByteBuffer[] parity) {


### PR DESCRIPTION
## What changes were proposed in this pull request?

Let `ECBlockReconstructedStripeInputStream` check if there are any other locations it can read a given replica index from before failing the index.

https://issues.apache.org/jira/browse/HDDS-7918

## How was this patch tested?

Added unit test.

Regular CI:
https://github.com/adoroszlai/hadoop-ozone/actions/runs/4477112023