### PR TITLE
HDDS-8173. Fix to remove entries from RocksDB after container gets deleted.

### DIFF
--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/RDBTable.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/RDBTable.java
@@ -210,7 +210,7 @@ class RDBTable implements Table<byte[], byte[]> {
       throws IOException {
     try (TableIterator<byte[], ByteArrayKeyValue> iter = iterator(prefix)) {
       while (iter.hasNext()) {
-        deleteWithBatch(batch, iter.next().getValue());
+        deleteWithBatch(batch, iter.next().getKey());
       }
     }
   }


### PR DESCRIPTION
## What changes were proposed in this pull request?
Currently container entry doesn't get removed from RocksDB after container gets deleted because in `RDBTable#deleteBatchWithPrefix`, `deleteWithBatch` gets called with iterator's `value` instead of the `key`. 

This change is to fix the bug by using correct parameter `key` to call `deleteWithBatch`.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-8173

## How was this patch tested?
* Unit test.
