### PR TITLE
HDDS-8240. Disable JaCoCo for PRs and in forks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,7 @@ on:
 env:
   FAIL_FAST: ${{ github.event_name == 'pull_request' }}
   MAVEN_OPTS: -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.http.retryHandler.class=standard -Dmaven.wagon.http.retryHandler.count=3
+  OZONE_WITH_COVERAGE: ${{ github.repository == 'apache/ozone' && github.event_name != 'pull_request' }}
 jobs:
   build-info:
     runs-on: ubuntu-20.04
@@ -93,7 +94,7 @@ jobs:
           distribution: 'temurin'
           java-version: ${{ matrix.java }}
       - name: Run a full build
-        run: hadoop-ozone/dev-support/checks/build.sh -Pcoverage -Pdist -Psrc
+        run: hadoop-ozone/dev-support/checks/build.sh -Pdist -Psrc
       - name: Store binaries for tests
         uses: actions/upload-artifact@v3
         with:
@@ -148,6 +149,8 @@ jobs:
           java-version: ${{ matrix.java }}
       - name: Compile Ozone using Java ${{ matrix.java }}
         run: hadoop-ozone/dev-support/checks/build.sh -Dskip.npx -Dskip.installnpx -Djavac.version=${{ matrix.java }}
+        env:
+          OZONE_WITH_COVERAGE: false
       - name: Delete temporary build artifacts before caching
         run: |
           #Never cache local artifacts
@@ -273,7 +276,6 @@ jobs:
         env:
           KEEP_IMAGE: false
           OZONE_ACCEPTANCE_SUITE: ${{ matrix.suite }}
-          OZONE_WITH_COVERAGE: true
           OZONE_VOLUME_OWNER: 1000
       - name: Archive build results
         uses: actions/upload-artifact@v3

--- a/hadoop-ozone/dev-support/checks/build.sh
+++ b/hadoop-ozone/dev-support/checks/build.sh
@@ -16,6 +16,16 @@
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 cd "$DIR/../../.." || exit 1
 
+: ${OZONE_WITH_COVERAGE:="false"}
+
+MAVEN_OPTIONS='-V -B -Dmaven.javadoc.skip=true -DskipTests -DskipDocs --no-transfer-progress'
+
+if [[ "${OZONE_WITH_COVERAGE}" == "true" ]]; then
+  MAVEN_OPTIONS="${MAVEN_OPTIONS} -Pcoverage"
+else
+  MAVEN_OPTIONS="${MAVEN_OPTIONS} -Djacoco.skip"
+fi
+
 export MAVEN_OPTS="-Xmx4096m $MAVEN_OPTS"
-mvn -V -B -Dmaven.javadoc.skip=true -DskipTests -DskipDocs --no-transfer-progress clean install "$@"
+mvn ${MAVEN_OPTIONS} clean install "$@"
 exit $?

--- a/hadoop-ozone/dev-support/checks/findbugs.sh
+++ b/hadoop-ozone/dev-support/checks/findbugs.sh
@@ -16,11 +16,17 @@
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 cd "$DIR/../../.." || exit 1
 
+: ${OZONE_WITH_COVERAGE:="false"}
+
 source "${DIR}/_lib.sh"
 
 install_spotbugs
 
 MAVEN_OPTIONS='-B -fae -Dskip.npx -Dskip.installnpx --no-transfer-progress'
+
+if [[ "${OZONE_WITH_COVERAGE}" != "true" ]]; then
+  MAVEN_OPTIONS="${MAVEN_OPTIONS} -Djacoco.skip"
+fi
 
 #shellcheck disable=SC2086
 mvn ${MAVEN_OPTIONS} test-compile spotbugs:spotbugs "$@"

--- a/hadoop-ozone/dev-support/checks/junit.sh
+++ b/hadoop-ozone/dev-support/checks/junit.sh
@@ -21,6 +21,7 @@ cd "$DIR/../../.." || exit 1
 
 : ${CHECK:="unit"}
 : ${ITERATIONS:="1"}
+: ${OZONE_WITH_COVERAGE:="false"}
 
 declare -i ITERATIONS
 if [[ ${ITERATIONS} -le 0 ]]; then
@@ -29,6 +30,10 @@ fi
 
 export MAVEN_OPTS="-Xmx4096m $MAVEN_OPTS"
 MAVEN_OPTIONS='-B -Dskip.npx -Dskip.installnpx --no-transfer-progress'
+
+if [[ "${OZONE_WITH_COVERAGE}" != "true" ]]; then
+  MAVEN_OPTIONS="${MAVEN_OPTIONS} -Djacoco.skip"
+fi
 
 if [[ "${FAIL_FAST:-}" == "true" ]]; then
   MAVEN_OPTIONS="${MAVEN_OPTIONS} --fail-fast -Dsurefire.skipAfterFailureCount=1"
@@ -71,7 +76,9 @@ for i in $(seq 1 ${ITERATIONS}); do
   fi
 done
 
-#Archive combined jacoco records
-mvn -B -N jacoco:merge -Djacoco.destFile=$REPORT_DIR/jacoco-combined.exec
+if [[ "${OZONE_WITH_COVERAGE}" == "true" ]]; then
+  #Archive combined jacoco records
+  mvn -B -N jacoco:merge -Djacoco.destFile=$REPORT_DIR/jacoco-combined.exec
+fi
 
 exit ${rc}

--- a/hadoop-ozone/dist/src/main/compose/test-all.sh
+++ b/hadoop-ozone/dist/src/main/compose/test-all.sh
@@ -27,7 +27,9 @@ rm "$ALL_RESULT_DIR"/* || true
 
 source "$SCRIPT_DIR"/testlib.sh
 
-if [ "$OZONE_WITH_COVERAGE" ]; then
+: ${OZONE_WITH_COVERAGE:="false"}
+
+if [[ "${OZONE_WITH_COVERAGE}" == "true" ]]; then
    java -cp "$PROJECT_DIR"/share/coverage/$(ls "$PROJECT_DIR"/share/coverage | grep test-util):"$PROJECT_DIR"/share/coverage/jacoco-core.jar org.apache.hadoop.test.JacocoServer &
    DOCKER_BRIDGE_IP=$(docker network inspect bridge --format='{{(index .IPAM.Config 0).Gateway}}')
    export OZONE_OPTS="-javaagent:share/coverage/jacoco-agent.jar=output=tcpclient,address=$DOCKER_BRIDGE_IP,includes=org.apache.hadoop.ozone.*:org.apache.hadoop.hdds.*:org.apache.hadoop.fs.ozone.*"
@@ -39,7 +41,7 @@ cd "$SCRIPT_DIR"
 RESULT=0
 run_test_scripts ${tests} || RESULT=$?
 
-if [ "$OZONE_WITH_COVERAGE" ]; then
+if [[ "${OZONE_WITH_COVERAGE}" == "true" ]]; then
   pkill -f JacocoServer
   cp /tmp/jacoco-combined.exec "$SCRIPT_DIR"/result
 fi


### PR DESCRIPTION
## What changes were proposed in this pull request?

Coverage check is executed only for commits in `apache/ozone`, i.e. neither for pull requests in `apache/ozone`, nor for any event in forks (HDDS-4801).  However, coverage data is still collected during test runs, which (1) uses space unnecessarily in result bundles, and (2) takes a tiny bit of time to execute.  This PR disables JaCoCo for the cases when its output is ignored.

https://issues.apache.org/jira/browse/HDDS-8240

## How was this patch tested?

JaCoCo is executed in CI simulating commit on `apache/ozone` repo:
https://github.com/adoroszlai/hadoop-ozone/actions/runs/4489193839/jobs/7897102199#step:5:3513

but skipped in fork:
https://github.com/adoroszlai/hadoop-ozone/actions/runs/4489001536/jobs/7897164734#step:5:3560

`jacoco*.exec` files are not present in the artifacts produced by the latter.