### PR TITLE
HDDS-8244. Selective checks: handle change in junit.sh

### DIFF
--- a/dev-support/ci/selective_ci_checks.bats
+++ b/dev-support/ci/selective_ci_checks.bats
@@ -117,6 +117,18 @@ load bats-assert/load.bash
   assert_output -p needs-kubernetes-tests=false
 }
 
+@test "script change including junit.sh" {
+  run dev-support/ci/selective_ci_checks.sh 66093e52c6
+
+  assert_output -p 'basic-checks=["rat","bats","checkstyle","findbugs","unit"]'
+  assert_output -p needs-build=true
+  assert_output -p needs-compile=true
+  assert_output -p needs-compose-tests=false
+  assert_output -p needs-dependency-check=false
+  assert_output -p needs-integration-tests=true
+  assert_output -p needs-kubernetes-tests=false
+}
+
 @test "unit only" {
   run dev-support/ci/selective_ci_checks.sh 1dd1d0ba3
 

--- a/dev-support/ci/selective_ci_checks.sh
+++ b/dev-support/ci/selective_ci_checks.sh
@@ -253,6 +253,7 @@ function get_count_integration_files() {
     local pattern_array=(
         "^hadoop-ozone/dev-support/checks/_mvn_unit_report.sh"
         "^hadoop-ozone/dev-support/checks/integration.sh"
+        "^hadoop-ozone/dev-support/checks/junit.sh"
         "^hadoop-ozone/integration-test"
         "^hadoop-ozone/fault-injection-test/mini-chaos-tests"
         "src/test/java"
@@ -434,6 +435,7 @@ function check_needs_unit_test() {
     local pattern_array=(
         "^hadoop-ozone/dev-support/checks/_mvn_unit_report.sh"
         "^hadoop-ozone/dev-support/checks/unit.sh"
+        "^hadoop-ozone/dev-support/checks/junit.sh"
         "src/test/java"
         "src/test/resources"
     )


### PR DESCRIPTION
## What changes were proposed in this pull request?

Selective CI should not skip _integration_ and _unit_ tests for changes to `junit.sh`, which is a common implementation of these two checks, like it did in [this run](https://github.com/apache/ozone/actions/runs/4490859276?pr=4449).

https://issues.apache.org/jira/browse/HDDS-8244

## How was this patch tested?

Added test case in bats test.

https://github.com/adoroszlai/hadoop-ozone/actions/runs/4491964343/jobs/7901188422#step:6:25