### PR TITLE
HDDS-8245. Info log for keyDeletingService when nonzero number of keys are deleted.

### DIFF
--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/service/KeyDeletingService.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/service/KeyDeletingService.java
@@ -178,8 +178,8 @@ public class KeyDeletingService extends BackgroundService {
                 //  OMRequest model.
                 delCount = deleteAllKeys(results);
               }
-              if (LOG.isDebugEnabled()) {
-                LOG.debug("Number of keys deleted: {}, elapsed time: {}ms",
+              if (delCount > 0) {
+                LOG.info("Number of keys deleted: {}, elapsed time: {}ms",
                     delCount, Time.monotonicNow() - startTime);
               }
               deletedKeyCount.addAndGet(delCount);


### PR DESCRIPTION
## What changes were proposed in this pull request?

The directory deleting service has an info log that displays a summary of the run when some amount data is deleted. The key deleting service only logs this at the debug level. It should have an info log that prints a summary of the number of keys deleted if it is nonzero.

For reference, the corresponding line in directory deleting service is [here](https://github.com/apache/ozone/blob/5eead92666b374c4bb912f332488acb23f9a81df/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/service/DirectoryDeletingService.java#L208)

## What is the link to the Apache JIRA

HDDS-8245

## How was this patch tested?

No tests added since this is a simple logging change.
