### PR TITLE
HDDS-8230. Let ReplicationManager decide the timeout for commands in Datanodes

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/balancer/MoveManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/balancer/MoveManager.java
@@ -114,7 +114,6 @@ public final class MoveManager implements
    */
   private long moveTimeout = 1000 * 65 * 60;
   private long replicationTimeout = 1000 * 50 * 60;
-  private static final double MOVE_DEADLINE_FACTOR = 0.95;
 
   private final ReplicationManager replicationManager;
   private final ContainerManager containerManager;
@@ -448,8 +447,7 @@ public final class MoveManager implements
         containerInfo.containerID(), src);
     long now = clock.millis();
     replicationManager.sendLowPriorityReplicateContainerCommand(containerInfo,
-        replicaIndex, src, tgt, now + replicationTimeout,
-        now + Math.round(replicationTimeout * MOVE_DEADLINE_FACTOR));
+        replicaIndex, src, tgt, now + replicationTimeout);
   }
 
   /**
@@ -468,8 +466,7 @@ public final class MoveManager implements
     long deleteTimeout = moveTimeout - replicationTimeout;
     long now = clock.millis();
     replicationManager.sendDeleteCommand(
-        containerInfo, replicaIndex, datanode, true, now + deleteTimeout,
-        now + Math.round(deleteTimeout * MOVE_DEADLINE_FACTOR));
+        containerInfo, replicaIndex, datanode, true, now + deleteTimeout);
   }
 
   private int getContainerReplicaIndex(

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ReplicationManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ReplicationManager.java
@@ -1095,7 +1095,7 @@ public class ReplicationManager implements SCMService {
       return datanodeTimeoutOffset;
     }
 
-    public void setDatanodeTimeout(long val) {
+    public void setDatanodeTimeoutOffset(long val) {
       datanodeTimeoutOffset = val;
     }
 

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ReplicationManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ReplicationManager.java
@@ -25,7 +25,6 @@ import org.apache.hadoop.hdds.conf.Config;
 import org.apache.hadoop.hdds.conf.ConfigGroup;
 import org.apache.hadoop.hdds.conf.ConfigType;
 import org.apache.hadoop.hdds.conf.ConfigurationSource;
-import org.apache.hadoop.hdds.conf.PostConstruct;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos;
@@ -451,25 +450,21 @@ public class ReplicationManager implements SCMService {
    * @param force true to force delete a container that is open or not empty
    * @param scmDeadlineEpochMs The epoch time in ms, after which the command
    *                           will be discarded from the SCMPendingOps table.
-   * @param datanodeDeadlineEpochMs The epoch time in ms, after which the
-   *                                command will be discarded on the datanode if
-   *                                it has not been processed.
    * @throws NotLeaderException when this SCM is not the leader
    */
   public void sendDeleteCommand(final ContainerInfo container,
       int replicaIndex, final DatanodeDetails datanode, boolean force,
-      long scmDeadlineEpochMs, long datanodeDeadlineEpochMs)
+      long scmDeadlineEpochMs)
       throws NotLeaderException {
     LOG.debug("Sending delete command for container {} and index {} on {} " +
-            "with SCM deadline {} and Datanode deadline {}.",
-        container, replicaIndex, datanode, scmDeadlineEpochMs,
-        datanodeDeadlineEpochMs);
+        "with SCM deadline {}.",
+        container, replicaIndex, datanode, scmDeadlineEpochMs);
 
     final DeleteContainerCommand deleteCommand =
         new DeleteContainerCommand(container.containerID(), force);
     deleteCommand.setReplicaIndex(replicaIndex);
     sendDatanodeCommand(deleteCommand, container, datanode,
-        scmDeadlineEpochMs, datanodeDeadlineEpochMs);
+        scmDeadlineEpochMs);
   }
 
   /**
@@ -584,22 +579,17 @@ public class ReplicationManager implements SCMService {
    * @param target The target to push container replica to
    * @param scmDeadlineEpochMs The epoch time in ms, after which the command
    *                           will be discarded from the SCMPendingOps table.
-   * @param datanodeDeadlineEpochMs The epoch time in ms, after which the
-   *                                command will be discarded on the data if
-   *                                it has not been processed. In general should
-   *                                be less than scmDeadlineEpochMs.
    * @throws NotLeaderException
    */
   public void sendLowPriorityReplicateContainerCommand(
       final ContainerInfo container, int replicaIndex, DatanodeDetails source,
-      DatanodeDetails target, long scmDeadlineEpochMs,
-      long datanodeDeadlineEpochMs) throws NotLeaderException {
+      DatanodeDetails target, long scmDeadlineEpochMs)
+      throws NotLeaderException {
     final ReplicateContainerCommand command = ReplicateContainerCommand
         .toTarget(container.getContainerID(), target);
     command.setReplicaIndex(replicaIndex);
     command.setPriority(ReplicationCommandPriority.LOW);
-    sendDatanodeCommand(command, container, source, scmDeadlineEpochMs,
-        datanodeDeadlineEpochMs);
+    sendDatanodeCommand(command, container, source, scmDeadlineEpochMs);
   }
   /**
    * Sends a command to a datanode with the command deadline set to the default
@@ -613,10 +603,7 @@ public class ReplicationManager implements SCMService {
       ContainerInfo containerInfo, DatanodeDetails target)
       throws NotLeaderException {
     long scmDeadline = clock.millis() + rmConf.eventTimeout;
-    long datanodeDeadline = clock.millis() +
-        Math.round(rmConf.eventTimeout * rmConf.commandDeadlineFactor);
-    sendDatanodeCommand(command, containerInfo, target, scmDeadline,
-        datanodeDeadline);
+    sendDatanodeCommand(command, containerInfo, target, scmDeadline);
   }
 
   /**
@@ -627,21 +614,19 @@ public class ReplicationManager implements SCMService {
    * @param target The datanode which will receive the command.
    * @param scmDeadlineEpochMs The epoch time in ms, after which the command
    *                           will be discarded from the SCMPendingOps table.
-   * @param datanodeDeadlineEpochMs The epoch time in ms, after which the
-   *                                command will be discarded on the datanode if
-   *                                it has not been processed.
    * @throws NotLeaderException
    */
   public void sendDatanodeCommand(SCMCommand<?> command,
       ContainerInfo containerInfo, DatanodeDetails target,
-      long scmDeadlineEpochMs, long datanodeDeadlineEpochMs)
+      long scmDeadlineEpochMs)
       throws NotLeaderException {
+    long datanodeDeadline = scmDeadlineEpochMs - rmConf.getDatanodeTimeout();
     LOG.info("Sending command [{}] for container {} to {} with datanode "
         + "deadline {} and scm deadline {}",
-        command, containerInfo, target, datanodeDeadlineEpochMs,
+        command, containerInfo, target, datanodeDeadline,
         scmDeadlineEpochMs);
     command.setTerm(getScmTerm());
-    command.setDeadline(datanodeDeadlineEpochMs);
+    command.setDeadline(datanodeDeadline);
     nodeManager.addDatanodeCommand(target.getUuid(), command);
     adjustPendingOpsAndMetrics(containerInfo, command, target,
         scmDeadlineEpochMs);
@@ -1078,7 +1063,7 @@ public class ReplicationManager implements SCMService {
         defaultValue = "30m",
         tags = {SCM, OZONE},
         description = "Timeout for the container replication/deletion commands "
-            + "sent  to datanodes. After this timeout the command will be "
+            + "sent to datanodes. After this timeout the command will be "
             + "retried.")
     private long eventTimeout = Duration.ofMinutes(30).toMillis();
     public void setInterval(Duration interval) {
@@ -1090,27 +1075,26 @@ public class ReplicationManager implements SCMService {
     }
 
     /**
-     * Deadline which should be set on commands sent from ReplicationManager
-     * to the datanodes, as a percentage of the event.timeout. If the command
-     * has not been processed on the datanode by this time, it will be dropped
-     * by the datanode and Replication Manager will need to resend it.
+     * When a command has a deadline in SCM, the datanode timeout should be
+     * slightly less. This duration is the number of seconds to subtract from
+     * the SCM deadline to give a datanode deadline.Time a command
      */
-    @Config(key = "command.deadline.factor",
-        type = ConfigType.DOUBLE,
-        defaultValue = "0.9",
+    @Config(key = "event.timeout.on.datanode.before.scm",
+        type = ConfigType.TIME,
+        defaultValue = "30s",
         tags = {SCM, OZONE},
-        description = "Fraction of the hdds.scm.replication.event.timeout "
-            + "from the current time which should be set as a deadline for "
-            + "commands sent from ReplicationManager to datanodes. "
-            + "Commands which are not processed before this deadline will be "
-            + "dropped by the datanodes. Should be a value > 0 and <= 1.")
-    private double commandDeadlineFactor = 0.9;
-    public double getCommandDeadlineFactor() {
-      return commandDeadlineFactor;
+        description = "The amount of time to subtract from "
+            + "hdds.scm.replication.event.timeout to give a deadline on the "
+            + "datanodes which is less than the SCM timeout. This ensures "
+            + "the datanodes will not process a command after SCM believes it "
+            + "should have expired.")
+    private long datanodeTimeout = Duration.ofSeconds(30).toMillis();
+    public long getDatanodeTimeout() {
+      return datanodeTimeout;
     }
 
-    public void setCommandDeadlineFactor(double val) {
-      commandDeadlineFactor = val;
+    public void setDatanodeTimeout(long val) {
+      datanodeTimeout = val;
     }
 
     /**
@@ -1168,15 +1152,6 @@ public class ReplicationManager implements SCMService {
             "push to the target node."
     )
     private boolean push = true;
-
-    @PostConstruct
-    public void validate() {
-      if (!(commandDeadlineFactor > 0) || (commandDeadlineFactor > 1)) {
-        throw new IllegalArgumentException("command.deadline.factor is set to "
-            + commandDeadlineFactor
-            + " and must be greater than 0 and less than equal to 1");
-      }
-    }
 
     @Config(key = "datanode.replication.limit",
         type = ConfigType.INT,

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ReplicationManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ReplicationManager.java
@@ -25,6 +25,7 @@ import org.apache.hadoop.hdds.conf.Config;
 import org.apache.hadoop.hdds.conf.ConfigGroup;
 import org.apache.hadoop.hdds.conf.ConfigType;
 import org.apache.hadoop.hdds.conf.ConfigurationSource;
+import org.apache.hadoop.hdds.conf.PostConstruct;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos;
@@ -1226,6 +1227,19 @@ public class ReplicationManager implements SCMService {
 
     public boolean isPush() {
       return push;
+    }
+
+    @PostConstruct
+    public void validate() {
+      if (datanodeTimeoutOffset < 0) {
+        throw new IllegalArgumentException("event.timeout.datanode.offset is"
+            + " set to " + datanodeTimeoutOffset + " and must be >= 0");
+      }
+      if (datanodeTimeoutOffset >= eventTimeout) {
+        throw new IllegalArgumentException("event.timeout.datanode.offset is"
+            + " set to " + datanodeTimeoutOffset + " and must be <"
+            + " event.timeout, which is set to " + eventTimeout);
+      }
     }
   }
 

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ReplicationManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ReplicationManager.java
@@ -620,7 +620,8 @@ public class ReplicationManager implements SCMService {
       ContainerInfo containerInfo, DatanodeDetails target,
       long scmDeadlineEpochMs)
       throws NotLeaderException {
-    long datanodeDeadline = scmDeadlineEpochMs - rmConf.getDatanodeTimeout();
+    long datanodeDeadline =
+        scmDeadlineEpochMs - rmConf.getDatanodeTimeoutOffset();
     LOG.info("Sending command [{}] for container {} to {} with datanode "
         + "deadline {} and scm deadline {}",
         command, containerInfo, target, datanodeDeadline,
@@ -1077,9 +1078,9 @@ public class ReplicationManager implements SCMService {
     /**
      * When a command has a deadline in SCM, the datanode timeout should be
      * slightly less. This duration is the number of seconds to subtract from
-     * the SCM deadline to give a datanode deadline.Time a command
+     * the SCM deadline to give a datanode deadline.
      */
-    @Config(key = "event.timeout.on.datanode.before.scm",
+    @Config(key = "event.timeout.datanode.offset",
         type = ConfigType.TIME,
         defaultValue = "30s",
         tags = {SCM, OZONE},
@@ -1088,13 +1089,13 @@ public class ReplicationManager implements SCMService {
             + "datanodes which is less than the SCM timeout. This ensures "
             + "the datanodes will not process a command after SCM believes it "
             + "should have expired.")
-    private long datanodeTimeout = Duration.ofSeconds(30).toMillis();
-    public long getDatanodeTimeout() {
-      return datanodeTimeout;
+    private long datanodeTimeoutOffset = Duration.ofSeconds(30).toMillis();
+    public long getDatanodeTimeoutOffset() {
+      return datanodeTimeoutOffset;
     }
 
     public void setDatanodeTimeout(long val) {
-      datanodeTimeout = val;
+      datanodeTimeoutOffset = val;
     }
 
     /**

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/balancer/TestMoveManager.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/balancer/TestMoveManager.java
@@ -305,7 +305,7 @@ public class TestMoveManager {
   public void testReplicationCommandFails() throws Exception {
     Mockito.doThrow(new RuntimeException("test")).when(replicationManager)
             .sendLowPriorityReplicateContainerCommand(
-        any(), anyInt(), any(), any(), anyLong(), anyLong());
+        any(), anyInt(), any(), any(), anyLong());
     CompletableFuture<MoveManager.MoveResult> res = setupSuccessfulMove();
     Assert.assertEquals(
         MoveManager.MoveResult.FAIL_UNEXPECTED_ERROR, res.get());
@@ -336,7 +336,7 @@ public class TestMoveManager {
     moveManager.opCompleted(op, containerInfo.containerID(), false);
 
     Mockito.verify(replicationManager).sendDeleteCommand(
-        eq(containerInfo), eq(0), eq(src), eq(true), anyLong(), anyLong());
+        eq(containerInfo), eq(0), eq(src), eq(true), anyLong());
 
     op = new ContainerReplicaOp(
         DELETE, src, 0, clock.millis() + 1000);
@@ -366,7 +366,7 @@ public class TestMoveManager {
 
     Mockito.verify(replicationManager).sendLowPriorityReplicateContainerCommand(
         eq(containerInfo), eq(srcReplica.getReplicaIndex()), eq(src), eq(tgt),
-        anyLong(), anyLong());
+        anyLong());
 
     ContainerReplicaOp op = new ContainerReplicaOp(
         ADD, tgt, srcReplica.getReplicaIndex(), clock.millis() + 1000);
@@ -374,7 +374,7 @@ public class TestMoveManager {
 
     Mockito.verify(replicationManager).sendDeleteCommand(
         eq(containerInfo), eq(srcReplica.getReplicaIndex()), eq(src),
-        eq(true), anyLong(), anyLong());
+        eq(true), anyLong());
 
     op = new ContainerReplicaOp(
         DELETE, src, srcReplica.getReplicaIndex(), clock.millis() + 1000);
@@ -406,7 +406,7 @@ public class TestMoveManager {
     moveManager.opCompleted(op, containerInfo.containerID(), false);
 
     Mockito.verify(replicationManager).sendDeleteCommand(
-        eq(containerInfo), eq(0), eq(src), eq(true), anyLong(), anyLong());
+        eq(containerInfo), eq(0), eq(src), eq(true), anyLong());
 
     op = new ContainerReplicaOp(
         DELETE, src, 0, clock.millis() + 1000);
@@ -511,7 +511,7 @@ public class TestMoveManager {
         moveManager.move(containerInfo.containerID(), src, tgt);
 
     Mockito.verify(replicationManager).sendLowPriorityReplicateContainerCommand(
-        eq(containerInfo), eq(0), eq(src), eq(tgt), anyLong(), anyLong());
+        eq(containerInfo), eq(0), eq(src), eq(tgt), anyLong());
 
     return res;
   }

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestReplicationManager.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestReplicationManager.java
@@ -785,9 +785,8 @@ public class TestReplicationManager {
     // + evenTime * factor
     ReplicationManager.ReplicationManagerConfiguration rmConf = configuration
         .getObject(ReplicationManager.ReplicationManagerConfiguration.class);
-    long expectedDeadline = clock.millis() +
-        Math.round(rmConf.getEventTimeout() *
-            rmConf.getCommandDeadlineFactor());
+    long expectedDeadline = clock.millis() + rmConf.getEventTimeout() -
+            rmConf.getDatanodeTimeout();
     Assert.assertEquals(expectedDeadline, command.getDeadline());
 
     List<ContainerReplicaOp> ops = containerReplicaPendingOps.getPendingOps(
@@ -835,11 +834,14 @@ public class TestReplicationManager {
             HddsProtos.LifeCycleState.CLOSED, 10, 20);
     DatanodeDetails target = MockDatanodeDetails.randomDatanodeDetails();
     DatanodeDetails src = MockDatanodeDetails.randomDatanodeDetails();
-    long scmDeadline = clock.millis() + 1000;
-    long datanodeDeadline = clock.millis() + 500;
+
+    ReplicationManager.ReplicationManagerConfiguration rmConf = configuration
+        .getObject(ReplicationManager.ReplicationManagerConfiguration.class);
+    long scmDeadline = clock.millis() + rmConf.getEventTimeout();
+    long datanodeDeadline = scmDeadline - rmConf.getDatanodeTimeout();
 
     replicationManager.sendLowPriorityReplicateContainerCommand(containerInfo,
-        0, src, target, scmDeadline, datanodeDeadline);
+        0, src, target, scmDeadline);
 
     ArgumentCaptor<SCMCommand> command =
         ArgumentCaptor.forClass(SCMCommand.class);

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestReplicationManager.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestReplicationManager.java
@@ -786,7 +786,7 @@ public class TestReplicationManager {
     ReplicationManager.ReplicationManagerConfiguration rmConf = configuration
         .getObject(ReplicationManager.ReplicationManagerConfiguration.class);
     long expectedDeadline = clock.millis() + rmConf.getEventTimeout() -
-            rmConf.getDatanodeTimeout();
+            rmConf.getDatanodeTimeoutOffset();
     Assert.assertEquals(expectedDeadline, command.getDeadline());
 
     List<ContainerReplicaOp> ops = containerReplicaPendingOps.getPendingOps(
@@ -838,7 +838,7 @@ public class TestReplicationManager {
     ReplicationManager.ReplicationManagerConfiguration rmConf = configuration
         .getObject(ReplicationManager.ReplicationManagerConfiguration.class);
     long scmDeadline = clock.millis() + rmConf.getEventTimeout();
-    long datanodeDeadline = scmDeadline - rmConf.getDatanodeTimeout();
+    long datanodeDeadline = scmDeadline - rmConf.getDatanodeTimeoutOffset();
 
     replicationManager.sendLowPriorityReplicateContainerCommand(containerInfo,
         0, src, target, scmDeadline);

--- a/hadoop-ozone/fault-injection-test/mini-chaos-tests/src/test/java/org/apache/hadoop/ozone/MiniOzoneChaosCluster.java
+++ b/hadoop-ozone/fault-injection-test/mini-chaos-tests/src/test/java/org/apache/hadoop/ozone/MiniOzoneChaosCluster.java
@@ -270,6 +270,7 @@ public class MiniOzoneChaosCluster extends MiniOzoneHAClusterImpl {
           conf.getObject(ReplicationManagerConfiguration.class);
       replicationConf.setInterval(Duration.ofSeconds(10));
       replicationConf.setEventTimeout(Duration.ofSeconds(20));
+      replicationConf.setDatanodeTimeoutOffset(0);
       conf.setFromObject(replicationConf);
       conf.setInt(OzoneConfigKeys.DFS_RATIS_SNAPSHOT_THRESHOLD_KEY, 100);
       conf.setInt(OzoneConfigKeys.DFS_CONTAINER_RATIS_LOG_PURGE_GAP, 100);

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/TestBlockDeletion.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/TestBlockDeletion.java
@@ -148,7 +148,8 @@ public class TestBlockDeletion {
     conf.setQuietMode(false);
     conf.setTimeDuration("hdds.scm.replication.event.timeout", 100,
         TimeUnit.MILLISECONDS);
-    conf.setTimeDuration("hdds.scm.replication.event.timeout.datanode.offset", 0,
+    conf.setTimeDuration("hdds.scm.replication.event.timeout.datanode.offset",
+        0,
         TimeUnit.MILLISECONDS);
     conf.setInt("hdds.datanode.block.delete.threads.max", 5);
     cluster = MiniOzoneCluster.newBuilder(conf)

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/TestBlockDeletion.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/TestBlockDeletion.java
@@ -148,6 +148,8 @@ public class TestBlockDeletion {
     conf.setQuietMode(false);
     conf.setTimeDuration("hdds.scm.replication.event.timeout", 100,
         TimeUnit.MILLISECONDS);
+    conf.setTimeDuration("hdds.scm.replication.event.timeout.datanode.offset", 0,
+        TimeUnit.MILLISECONDS);
     conf.setInt("hdds.datanode.block.delete.threads.max", 5);
     cluster = MiniOzoneCluster.newBuilder(conf)
         .setNumDatanodes(3)


### PR DESCRIPTION
## What changes were proposed in this pull request?

Right now, "hdds.scm.replication.command.deadline.factor" is a fraction. For long durations such as 60 minutes, the difference between SCM deadline and Datanode deadline will be 60 - 60 * 0.9, which is 6 minutes. This is a significant difference, so perhaps this configuration should be a duration instead, like 30 seconds.

Currently the APIs provided by RM expose the DN deadline as a parameter. We could remove this and just let the RM decide a deadline for commands in the DN.

This PR removes the parameter hdds.scm.replication.command.deadline.factor and also passing the datanodeDeadline via the various methods. Instead we now have hdds.scm.replication.event.timeout.datanode.offset, defaulting to 30s, which is the amount of time we subtract from event.timeout (SCM deadline) to get the datanode deadline.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-8230

## How was this patch tested?

Existing test cover this.