### PR TITLE
HDDS-8253. Set ozone.metadata.dirs to temporary dir if not defined in S3 Gateway

### DIFF
--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/Gateway.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/Gateway.java
@@ -24,7 +24,6 @@ import java.nio.file.Paths;
 
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.StringUtils;
-import org.apache.hadoop.hdds.HddsConfigKeys;
 import org.apache.hadoop.hdds.cli.GenericCli;
 import org.apache.hadoop.hdds.cli.HddsVersionProvider;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/Gateway.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/Gateway.java
@@ -97,7 +97,7 @@ public class Gateway extends GenericCli {
     OzoneConfigurationHolder.setConfiguration(ozoneConfiguration);
     UserGroupInformation.setConfiguration(ozoneConfiguration);
     loginS3GUser(ozoneConfiguration);
-    setHttpBaseDir(ozoneConfiguration);
+    setHttpBaseDir();
     httpServer = new S3GatewayHttpServer(ozoneConfiguration, "s3gateway");
     metrics = S3GatewayMetrics.create();
     start();

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/Gateway.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/Gateway.java
@@ -17,6 +17,7 @@
  */
 package org.apache.hadoop.ozone.s3;
 
+import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -75,18 +76,18 @@ public class Gateway extends GenericCli {
         OzoneConfigKeys.OZONE_HTTP_BASEDIR))) {
       //Setting ozone.http.basedir if not set so that server setup doesn't
       // fail.
-      Path tmpMetaDir = Files.createTempDirectory(Paths.get(""),
-          "ozone_s3g_tmp_base_dir");
+      File tmpMetaDir = Files.createTempDirectory(Paths.get(""),
+          "ozone_s3g_tmp_base_dir").toFile();
       ShutdownHookManager.get().addShutdownHook(() -> {
         try {
-          FileUtils.deleteDirectory(tmpMetaDir.toFile());
+          FileUtils.deleteDirectory(tmpMetaDir);
         } catch (IOException e) {
           LOG.error("Failed to cleanup temporary S3 Gateway Metadir {}",
-              tmpMetaDir.toFile().getAbsolutePath(), e);
+              tmpMetaDir.getAbsolutePath(), e);
         }
       }, 0);
       ozoneConfiguration.set(OzoneConfigKeys.OZONE_HTTP_BASEDIR,
-          tmpMetaDir.toFile().getAbsolutePath());
+          tmpMetaDir.getAbsolutePath());
     }
   }
 

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/Gateway.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/Gateway.java
@@ -20,7 +20,6 @@ package org.apache.hadoop.ozone.s3;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
-import java.nio.file.Path;
 import java.nio.file.Paths;
 
 import org.apache.commons.io.FileUtils;

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/Gateway.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/Gateway.java
@@ -17,18 +17,20 @@
  */
 package org.apache.hadoop.ozone.s3;
 
-import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.hadoop.hdds.HddsConfigKeys;
-import org.apache.hadoop.hdds.StringUtils;
 import org.apache.hadoop.hdds.cli.GenericCli;
 import org.apache.hadoop.hdds.cli.HddsVersionProvider;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.tracing.TracingUtil;
 import org.apache.hadoop.hdds.utils.HddsServerUtil;
+import org.apache.hadoop.ozone.OzoneConfigKeys;
 import org.apache.hadoop.ozone.OzoneSecurityUtil;
 import org.apache.hadoop.ozone.s3.metrics.S3GatewayMetrics;
 import org.apache.hadoop.ozone.util.OzoneNetUtils;
@@ -42,7 +44,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import picocli.CommandLine.Command;
 
-import static org.apache.hadoop.hdds.StringUtils.*;
+import static org.apache.hadoop.hdds.StringUtils.startupShutdownMessage;
 import static org.apache.hadoop.ozone.conf.OzoneServiceConfig.DEFAULT_SHUTDOWN_HOOK_PRIORITY;
 import static org.apache.hadoop.ozone.s3.S3GatewayConfigKeys.OZONE_S3G_KERBEROS_KEYTAB_FILE_KEY;
 import static org.apache.hadoop.ozone.s3.S3GatewayConfigKeys.OZONE_S3G_KERBEROS_PRINCIPAL_KEY;
@@ -76,12 +78,20 @@ public class Gateway extends GenericCli {
     UserGroupInformation.setConfiguration(ozoneConfiguration);
     loginS3GUser(ozoneConfiguration);
 
-    if (org.apache.commons.lang3.StringUtils.isEmpty(
-            ozoneConfiguration.get(HddsConfigKeys.OZONE_METADATA_DIRS))) {
+    if (StringUtils.isEmpty(ozoneConfiguration.get(
+            OzoneConfigKeys.OZONE_METADATA_DIRS))) {
       //Setting ozone.metadata.dirs if not set so that server setup doesn't
       // fail.
-      Path tmpMetaDir = Files.createTempDirectory("ozone_s3g_tmpdir");
-      tmpMetaDir.toFile().deleteOnExit();
+      Path tmpMetaDir = Files.createTempDirectory(Paths.get(""),
+              "ozone_s3g_tmp_meta_dir");
+      Runtime.getRuntime().addShutdownHook(new Thread(() -> {
+        try {
+          FileUtils.deleteDirectory(tmpMetaDir.toFile());
+        } catch (IOException e) {
+          LOG.error("Failed to cleanup temporary S3 Gateway Metadir {}",
+                  tmpMetaDir.toFile().getAbsolutePath(), e);
+        }
+      }));
       ozoneConfiguration.set(HddsConfigKeys.OZONE_METADATA_DIRS,
               tmpMetaDir.toFile().getAbsolutePath());
     }

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/Gateway.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/Gateway.java
@@ -69,7 +69,7 @@ public class Gateway extends GenericCli {
     new Gateway().run(args);
   }
 
-  private void setHttpBaseDir(OzoneConfiguration ozoneConfiguration)
+  private void setHttpBaseDir()
       throws IOException {
     if (StringUtils.isEmpty(ozoneConfiguration.get(
         OzoneConfigKeys.OZONE_HTTP_BASEDIR))) {

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/Gateway.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/Gateway.java
@@ -79,11 +79,11 @@ public class Gateway extends GenericCli {
     loginS3GUser(ozoneConfiguration);
 
     if (StringUtils.isEmpty(ozoneConfiguration.get(
-            OzoneConfigKeys.OZONE_METADATA_DIRS))) {
+            OzoneConfigKeys.OZONE_HTTP_BASEDIR))) {
       //Setting ozone.metadata.dirs if not set so that server setup doesn't
       // fail.
       Path tmpMetaDir = Files.createTempDirectory(Paths.get(""),
-              "ozone_s3g_tmp_meta_dir");
+              "ozone_s3g_tmp_base_dir");
       Runtime.getRuntime().addShutdownHook(new Thread(() -> {
         try {
           FileUtils.deleteDirectory(tmpMetaDir.toFile());
@@ -92,7 +92,7 @@ public class Gateway extends GenericCli {
                   tmpMetaDir.toFile().getAbsolutePath(), e);
         }
       }));
-      ozoneConfiguration.set(HddsConfigKeys.OZONE_METADATA_DIRS,
+      ozoneConfiguration.set(OzoneConfigKeys.OZONE_HTTP_BASEDIR,
               tmpMetaDir.toFile().getAbsolutePath());
     }
 

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/Gateway.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/Gateway.java
@@ -74,8 +74,8 @@ public class Gateway extends GenericCli {
       throws IOException {
     if (StringUtils.isEmpty(ozoneConfiguration.get(
         OzoneConfigKeys.OZONE_HTTP_BASEDIR))) {
-      //Setting ozone.http.basedir if not set so that server setup doesn't
-      // fail.
+      //Setting ozone.http.basedir to cwd if not set so that server setup
+      // doesn't fail.
       File tmpMetaDir = Files.createTempDirectory(Paths.get(""),
           "ozone_s3g_tmp_base_dir").toFile();
       ShutdownHookManager.get().addShutdownHook(() -> {


### PR DESCRIPTION
## What changes were proposed in this pull request?

Currently s3Gateway fails to come up if "ozone.http.basedir" is not defined.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-8253

## How was this patch tested?
Manually tested.
