### PR TITLE
HDDS-8255. Remove unnecessary sleep at secure container startup

### DIFF
--- a/hadoop-ozone/dist/src/main/compose/ozonesecure-ha/docker-config
+++ b/hadoop-ozone/dist/src/main/compose/ozonesecure-ha/docker-config
@@ -154,7 +154,6 @@ KMS-SITE.XML_hadoop.kms.proxyuser.s3g.hosts=*
 OZONE_DATANODE_SECURE_USER=root
 JAVA_HOME=/usr/lib/jvm/jre
 JSVC_HOME=/usr/bin
-SLEEP_SECONDS=5
 
 OZONE_CONF_DIR=/etc/hadoop
 OZONE_LOG_DIR=/var/log/hadoop

--- a/hadoop-ozone/dist/src/main/compose/ozonesecure-mr/docker-config
+++ b/hadoop-ozone/dist/src/main/compose/ozonesecure-mr/docker-config
@@ -142,7 +142,6 @@ CAPACITY-SCHEDULER.XML_yarn.scheduler.capacity.queue-mappings-override.enable=fa
 OZONE_DATANODE_SECURE_USER=root
 JAVA_HOME=/usr/lib/jvm/jre
 JSVC_HOME=/usr/bin
-SLEEP_SECONDS=5
 
 HADOOP_CLASSPATH=/opt/ozone/share/ozone/lib/ozone-filesystem-hadoop3-@project.version@.jar
 OZONE_CLASSPATH=


### PR DESCRIPTION
## What changes were proposed in this pull request?

Get rid of unnecessary 5 seconds sleep at container startup in `ozonesecure-ha` and `ozonesecure-mr` environments, which also caused the following warning:

```
ozone.scm.client.address should be set in ozone-site.xml or with the --scm option
```

See [details](https://issues.apache.org/jira/browse/HDDS-8255?focusedCommentId=17703983&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-17703983) in Jira.

https://issues.apache.org/jira/browse/HDDS-8255

## How was this patch tested?

Tested locally:

```
$ cd hadoop-ozone/dist/target/ozone-1.4.0-SNAPSHOT/compose/ozonesecure-ha
$ SCM=scm1.org
$ docker-compose up -d ${SCM}; for i in {1..5}; do docker-compose exec ${SCM} grep scm.service /etc/hadoop/ozone-site.xml; sleep 1; done
Starting ozonesecure-ha_scm1.org_1 ... done
<property><name>ozone.scm.service.ids</name><value>scmservice</value></property>
<property><name>ozone.scm.service.ids</name><value>scmservice</value></property>
<property><name>ozone.scm.service.ids</name><value>scmservice</value></property>
<property><name>ozone.scm.service.ids</name><value>scmservice</value></property>
<property><name>ozone.scm.service.ids</name><value>scmservice</value></property>
```

Regular CI:
https://github.com/adoroszlai/hadoop-ozone/actions/runs/4498660857

Verified that warning is no longer printed after containers are created:
https://github.com/adoroszlai/hadoop-ozone/actions/runs/4498660857/jobs/7915847876#step:5:90
https://github.com/adoroszlai/hadoop-ozone/actions/runs/4498660857/jobs/7915848282#step:5:644