### PR TITLE
HDDS-7781. Change Get Key Info to return HSync info

### DIFF
--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmKeyInfo.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmKeyInfo.java
@@ -668,6 +668,7 @@ public final class OmKeyInfo extends WithParentObjectId {
     if (encInfo != null) {
       kb.setFileEncryptionInfo(OMPBHelper.convert(encInfo));
     }
+    kb.setIsFile(isFile);
     return kb.build();
   }
 

--- a/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/om/helpers/TestOmKeyInfo.java
+++ b/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/om/helpers/TestOmKeyInfo.java
@@ -82,6 +82,7 @@ public class TestOmKeyInfo {
 
     // EC Config
     key = createOmKeyInfo(new ECReplicationConfig(3, 2));
+    Assert.assertFalse(key.isHsync());
     omKeyProto = key.getProtobuf(ClientVersion.CURRENT_VERSION);
 
     Assert.assertEquals(3, omKeyProto.getEcReplicationConfig().getData());
@@ -112,6 +113,7 @@ public class TestOmKeyInfo {
         .setReplicationConfig(replicationConfig)
         .addMetadata("key1", "value1")
         .addMetadata("key2", "value2")
+        .setHSync(false)
         .build();
   }
 

--- a/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/om/helpers/TestOmKeyInfo.java
+++ b/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/om/helpers/TestOmKeyInfo.java
@@ -27,6 +27,7 @@ import org.apache.hadoop.hdds.scm.pipeline.Pipeline;
 import org.apache.hadoop.hdds.scm.pipeline.PipelineID;
 import org.apache.hadoop.ozone.ClientVersion;
 import org.apache.hadoop.ozone.OzoneAcl;
+import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.hadoop.ozone.om.helpers.OmKeyInfo.Builder;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos;
 import org.apache.hadoop.ozone.security.acl.IAccessAuthorizer;
@@ -59,6 +60,10 @@ public class TestOmKeyInfo {
         key.getProtobuf(ClientVersion.CURRENT_VERSION));
 
     Assert.assertEquals(key, keyAfterSerialization);
+
+    Assert.assertFalse(key.isHsync());
+    key.getMetadata().put(OzoneConsts.HSYNC_CLIENT_ID, "clientid");
+    Assert.assertTrue(key.isHsync());
   }
 
   @Test
@@ -113,7 +118,6 @@ public class TestOmKeyInfo {
         .setReplicationConfig(replicationConfig)
         .addMetadata("key1", "value1")
         .addMetadata("key2", "value2")
-        .setHSync(false)
         .build();
   }
 

--- a/hadoop-ozone/interface-client/src/main/proto/OmClientProtocol.proto
+++ b/hadoop-ozone/interface-client/src/main/proto/OmClientProtocol.proto
@@ -1017,6 +1017,7 @@ message KeyInfo {
     optional hadoop.hdds.ECReplicationConfig ecReplicationConfig = 17;
     optional FileChecksumProto fileChecksum = 18;
     optional bool isFile = 19;
+    optional bool isHsync = 20;
 }
 
 message DirectoryInfo {

--- a/hadoop-ozone/interface-client/src/main/proto/OmClientProtocol.proto
+++ b/hadoop-ozone/interface-client/src/main/proto/OmClientProtocol.proto
@@ -1017,7 +1017,6 @@ message KeyInfo {
     optional hadoop.hdds.ECReplicationConfig ecReplicationConfig = 17;
     optional FileChecksumProto fileChecksum = 18;
     optional bool isFile = 19;
-    optional bool isHsync = 20;
 }
 
 message DirectoryInfo {


### PR DESCRIPTION
## What changes were proposed in this pull request?

Add a isHsync field in OmKeyInfo. This field is not persisted in RocksDB but rather is inferred from the metadata if it has HSYNC_CLIENT_ID field.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-7781

## How was this patch tested?

Unit tests