### PR TITLE
HDDS-8263. [JDK17] Bump guice to 5.1.0, maven-shade-plugin to 3.4.1, remove guice-multibindings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -123,7 +123,7 @@ jobs:
     if: needs.build-info.outputs.needs-compile == 'true'
     strategy:
       matrix:
-        java: [ 11 ]
+        java: [ 11, 17 ]
       fail-fast: false
     steps:
       - name: Download Ozone source tarball

--- a/hadoop-ozone/dist/src/main/license/bin/LICENSE.txt
+++ b/hadoop-ozone/dist/src/main/license/bin/LICENSE.txt
@@ -292,7 +292,6 @@ Apache License 2.0
    com.google.guava:guava
    com.google.guava:listenablefuture
    com.google.inject.extensions:guice-assistedinject
-   com.google.inject.extensions:guice-multibindings
    com.google.inject.extensions:guice-servlet
    com.google.inject:guice
    com.google.j2objc:j2objc-annotations

--- a/hadoop-ozone/dist/src/main/license/bin/NOTICE.txt
+++ b/hadoop-ozone/dist/src/main/license/bin/NOTICE.txt
@@ -504,16 +504,6 @@ Copyright 2007 The Apache Software Foundation
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).
 
-com.google.inject.extensions:guice-multibindings
-====================
-
-
-Google Guice - Extensions - MultiBindings
-Copyright 2006-2015 Google, Inc.
-
-This product includes software developed at
-The Apache Software Foundation (http://www.apache.org/).
-
 
 ====================
 ratis-thirdparty-misc is a shaded dependency which includes additional 3rd party dependencies in shaded form.

--- a/hadoop-ozone/dist/src/main/license/jar-report.txt
+++ b/hadoop-ozone/dist/src/main/license/jar-report.txt
@@ -54,7 +54,6 @@ share/ozone/lib/guava-jre.jar
 share/ozone/lib/guice-assistedinject.jar
 share/ozone/lib/guice-bridge.jar
 share/ozone/lib/guice.jar
-share/ozone/lib/guice-multibindings.jar
 share/ozone/lib/guice-servlet.jar
 share/ozone/lib/hadoop-annotations.jar
 share/ozone/lib/hadoop-auth.jar

--- a/hadoop-ozone/recon-codegen/pom.xml
+++ b/hadoop-ozone/recon-codegen/pom.xml
@@ -37,10 +37,6 @@
       <artifactId>derby</artifactId>
     </dependency>
     <dependency>
-      <groupId>com.google.inject.extensions</groupId>
-      <artifactId>guice-multibindings</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.springframework</groupId>
       <artifactId>spring-jdbc</artifactId>
       <version>${spring.version}</version>

--- a/pom.xml
+++ b/pom.xml
@@ -206,7 +206,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
     <compile-testing.version>0.19</compile-testing.version>
     <errorprone-annotations.version>2.2.0</errorprone-annotations.version>
     <guava.version>31.1-jre</guava.version>
-    <guice.version>4.0</guice.version>
+    <guice.version>5.1.0</guice.version>
     <gson.version>2.9.0</gson.version>
 
     <objenesis.version>1.0</objenesis.version>
@@ -258,7 +258,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
     <maven-compiler-plugin.version>3.1</maven-compiler-plugin.version>
     <maven-install-plugin.version>2.5.1</maven-install-plugin.version>
     <maven-resources-plugin.version>3.1.0</maven-resources-plugin.version>
-    <maven-shade-plugin.version>3.2.4</maven-shade-plugin.version>
+    <maven-shade-plugin.version>3.4.1</maven-shade-plugin.version>
     <maven-jar-plugin.version>2.5</maven-jar-plugin.version>
     <maven-war-plugin.version>3.1.0</maven-war-plugin.version>
     <maven-source-plugin.version>2.3</maven-source-plugin.version>
@@ -989,11 +989,6 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
       <dependency>
         <groupId>com.google.inject.extensions</groupId>
         <artifactId>guice-assistedinject</artifactId>
-        <version>${guice.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>com.google.inject.extensions</groupId>
-        <artifactId>guice-multibindings</artifactId>
         <version>${guice.version}</version>
       </dependency>
       <dependency>


### PR DESCRIPTION
## What changes were proposed in this pull request?

In order to support compilation of Ozone under JDK 17, the following changes are required:

- Bump maven-shade-plugin to 3.4.1
- Bump guice to 5.1.0
  - Remove guice-multibindings (no longer exists [since guice 4.2](https://github.com/google/guice/wiki/Multibindings))

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-8263

## How was this patch tested?

- Compilation passed with JDK 17 on CI on my fork's [other test branch](https://github.com/smengcl/hadoop-ozone/commits/HDDS-8248-jdk17-compile)
  - https://github.com/smengcl/hadoop-ozone/actions/runs/4497681697/jobs/7913886545
- Compilation passed locally with Zulu JDK 1.8.0_362 aarch64
- Compilation should pass in this PR CI with JDK 11 (unchanged)