### PR TITLE
HDDS-7122. Add validation for EC chunk size

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/client/ECReplicationConfig.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/client/ECReplicationConfig.java
@@ -85,7 +85,7 @@ public class ECReplicationConfig implements ReplicationConfig {
    * Create an ECReplicationConfig object from a string representing the
    * various parameters. Acceptable patterns are like:
    *     rs-3-2-1024k
-   *     RS-3-2-2048
+   *     RS-3-2-2048k
    *     XOR-10-4-4096K
    * IllegalArgumentException will be thrown if the passed string does not
    * match the defined pattern.
@@ -95,7 +95,7 @@ public class ECReplicationConfig implements ReplicationConfig {
     final Matcher matcher = STRING_FORMAT.matcher(string);
     if (!matcher.matches()) {
       throw new IllegalArgumentException("EC replication config should be " +
-          "defined in the form rs-3-2-1024k, rs-6-3-1024; or rs-10-4-1024k." +
+          "defined in the form rs-3-2-1024k, rs-6-3-1024k; or rs-10-4-1024k." +
           " Provided configuration was: " + string);
     }
 
@@ -150,7 +150,7 @@ public class ECReplicationConfig implements ReplicationConfig {
     return getCodec() + EC_REPLICATION_PARAMS_DELIMITER
         + getData() + EC_REPLICATION_PARAMS_DELIMITER
         + getParity() + EC_REPLICATION_PARAMS_DELIMITER
-        + getEcChunkSize();
+        + chunkKB();
   }
 
   public HddsProtos.ECReplicationConfig toProto() {
@@ -199,11 +199,16 @@ public class ECReplicationConfig implements ReplicationConfig {
   @Override
   public String toString() {
     return HddsProtos.ReplicationType.EC + "{"
-        + codec + "-" + data + "-" + parity + "-" + ecChunkSize + "}";
+        + codec + "-" + data + "-" + parity + "-" + chunkKB() + "}";
   }
 
   @Override
   public String configFormat() {
-    return HddsProtos.ReplicationType.EC.name() + "/" + data + "-" + parity;
+    return HddsProtos.ReplicationType.EC.name()
+        + "/" + data + "-" + parity + "-" + chunkKB();
+  }
+
+  private String chunkKB() {
+    return ecChunkSize / 1024 + "k";
   }
 }

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/client/ReplicationConfigValidator.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/client/ReplicationConfigValidator.java
@@ -22,7 +22,6 @@ import org.apache.hadoop.hdds.conf.ConfigGroup;
 import org.apache.hadoop.hdds.conf.ConfigTag;
 import org.apache.hadoop.hdds.conf.ConfigType;
 import org.apache.hadoop.hdds.conf.PostConstruct;
-import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 
 import java.util.regex.Pattern;
 
@@ -33,7 +32,9 @@ import java.util.regex.Pattern;
 public class ReplicationConfigValidator {
 
   @Config(key = "allowed-configs",
-      defaultValue = "^((STANDALONE|RATIS)/(ONE|THREE))|(EC/(3-2|6-3|10-4))$",
+      defaultValue = "^((STANDALONE|RATIS)/(ONE|THREE))|"
+          + "(EC/(3-2|6-3|10-4)-(512|1024|2048|4096)k)"
+          + "$",
       type = ConfigType.STRING,
       description = "Regular expression to restrict enabled " +
           "replication schemes",
@@ -53,26 +54,11 @@ public class ReplicationConfigValidator {
     if (validationRegexp == null) {
       return replicationConfig;
     }
-    if (!validationRegexp.matcher(
-            replicationConfig.configFormat()).matches()) {
-      String replication = replicationConfig.getReplication();
-      if (HddsProtos.ReplicationType.EC ==
-                replicationConfig.getReplicationType()) {
-        ECReplicationConfig ecConfig =
-              (ECReplicationConfig) replicationConfig;
-        replication =  ecConfig.getCodec() + "-" + ecConfig.getData() +
-                "-" + ecConfig.getParity() + "-{CHUNK_SIZE}";
-        //EC type checks data-parity
-        throw new IllegalArgumentException(
-                "Invalid data-parity replication config " +
-                        "for type " + replicationConfig.getReplicationType() +
-                        " and replication " + replication + "." +
-                        " Supported data-parity are 3-2,6-3,10-4");
-      }
-      //Non-EC type
+    String input = replicationConfig.configFormat();
+    if (!validationRegexp.matcher(input).matches()) {
       throw new IllegalArgumentException("Invalid replication config " +
-              "for type " + replicationConfig.getReplicationType() +
-              " and replication " + replication);
+          input + ". Config must match the pattern defined by " +
+          "ozone.replication.allowed-configs (" + validationPattern + ")");
     }
     return replicationConfig;
   }

--- a/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/client/TestReplicationConfig.java
+++ b/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/client/TestReplicationConfig.java
@@ -59,11 +59,11 @@ public class TestReplicationConfig {
   public static Stream<Arguments> ecType() {
     return Stream.of(
         arguments("RS", 3, 2, MB),
-        arguments("RS", 3, 2, KB),
+        arguments("RS", 3, 2, 2 * MB),
         arguments("RS", 6, 3, MB),
-        arguments("RS", 6, 3, KB),
+        arguments("RS", 6, 3, 2 * MB),
         arguments("RS", 10, 4, MB),
-        arguments("RS", 10, 4, KB)
+        arguments("RS", 10, 4, 2 * MB)
     );
   }
 
@@ -155,7 +155,7 @@ public class TestReplicationConfig {
         codec) + ECReplicationConfig.EC_REPLICATION_PARAMS_DELIMITER
             + data + ECReplicationConfig.EC_REPLICATION_PARAMS_DELIMITER
             + parity + ECReplicationConfig.EC_REPLICATION_PARAMS_DELIMITER
-            + chunkSize, config.getReplication());
+            + chunkSize/1024 + "k", config.getReplication());
   }
 
   @ParameterizedTest
@@ -391,7 +391,7 @@ public class TestReplicationConfig {
   private String ecDescriptor(String codec, int data, int parity,
       int chunkSize) {
     return codec.toUpperCase() + "-" + data + "-" + parity + "-" +
-        (chunkSize == MB ? "1024K" : "1024");
+        (chunkSize / 1024) + "k";
   }
 
 }

--- a/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/client/TestReplicationConfig.java
+++ b/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/client/TestReplicationConfig.java
@@ -155,7 +155,7 @@ public class TestReplicationConfig {
         codec) + ECReplicationConfig.EC_REPLICATION_PARAMS_DELIMITER
             + data + ECReplicationConfig.EC_REPLICATION_PARAMS_DELIMITER
             + parity + ECReplicationConfig.EC_REPLICATION_PARAMS_DELIMITER
-            + chunkSize/1024 + "k", config.getReplication());
+            + chunkSize / 1024 + "k", config.getReplication());
   }
 
   @ParameterizedTest

--- a/hadoop-ozone/client/src/test/java/org/apache/hadoop/ozone/client/TestOzoneClient.java
+++ b/hadoop-ozone/client/src/test/java/org/apache/hadoop/ozone/client/TestOzoneClient.java
@@ -20,6 +20,7 @@ package org.apache.hadoop.ozone.client;
 
 import org.apache.hadoop.conf.StorageUnit;
 import org.apache.hadoop.hdds.client.ECReplicationConfig;
+import org.apache.hadoop.hdds.client.ReplicationConfigValidator;
 import org.apache.hadoop.hdds.client.ReplicationType;
 import org.apache.hadoop.hdds.conf.ConfigurationSource;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
@@ -193,6 +194,10 @@ public class TestOzoneClient {
   public void testPutKeyWithECReplicationConfig() throws IOException {
     close();
     OzoneConfiguration config = new OzoneConfiguration();
+    ReplicationConfigValidator validator =
+        config.getObject(ReplicationConfigValidator.class);
+    validator.disableValidation();
+    config.setFromObject(validator);
     config.setStorageSize(OzoneConfigKeys.OZONE_SCM_BLOCK_SIZE, 2,
         StorageUnit.KB);
     int data = 3;

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestRootedOzoneFileSystem.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestRootedOzoneFileSystem.java
@@ -337,7 +337,7 @@ public class TestRootedOzoneFileSystem {
     // write some test data into bucket
     try (OzoneOutputStream outputStream = objectStore.getVolume(volumeName).
             getBucket(bucketName).createKey(key, 1,
-                    new ECReplicationConfig("RS-3-2-1024"),
+                    new ECReplicationConfig("RS-3-2-1024k"),
                     new HashMap<>())) {
       outputStream.write(RandomUtils.nextBytes(1));
     }
@@ -2058,7 +2058,7 @@ public class TestRootedOzoneFileSystem {
     builder.setBucketLayout(BucketLayout.LEGACY);
     builder.setDefaultReplicationConfig(
         new DefaultReplicationConfig(
-            new ECReplicationConfig("RS-3-2-1024")));
+            new ECReplicationConfig("RS-3-2-1024k")));
     BucketArgs omBucketArgs = builder.build();
     String vol = UUID.randomUUID().toString();
     String buck = UUID.randomUUID().toString();
@@ -2117,7 +2117,7 @@ public class TestRootedOzoneFileSystem {
     // write some test data into bucket
     try (OzoneOutputStream outputStream = objectStore.getVolume(volumeName).
             getBucket(bucketName).createKey(key, 1,
-                    new ECReplicationConfig("RS-3-2-1024"),
+                    new ECReplicationConfig("RS-3-2-1024k"),
                     new HashMap<>())) {
       outputStream.write(RandomUtils.nextBytes(1));
     }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/storage/TestContainerCommandsEC.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/storage/TestContainerCommandsEC.java
@@ -125,7 +125,7 @@ public class TestContainerCommandsEC {
   private static final int EC_DATA = 3;
   private static final int EC_PARITY = 2;
   private static final EcCodec EC_CODEC = EcCodec.RS;
-  private static final int EC_CHUNK_SIZE = 1024;
+  private static final int EC_CHUNK_SIZE = 1024 * 1024;
   private static final int STRIPE_DATA_SIZE = EC_DATA * EC_CHUNK_SIZE;
   private static final int NUM_DN = EC_DATA + EC_PARITY + 3;
   private static byte[][] inputChunks = new byte[EC_DATA][EC_CHUNK_SIZE];
@@ -533,7 +533,8 @@ public class TestContainerCommandsEC {
       inputChunks[i] = getBytesWith(i + 1, EC_CHUNK_SIZE);
     }
     try (OzoneOutputStream out = bucket.createKey(keyString, 4096,
-        new ECReplicationConfig(3, 2, EcCodec.RS, 1024), new HashMap<>())) {
+        new ECReplicationConfig(3, 2, EcCodec.RS, EC_CHUNK_SIZE),
+        new HashMap<>())) {
       Assert.assertTrue(out.getOutputStream() instanceof KeyOutputStream);
       for (int i = 0; i < numChunks; i++) {
         out.write(inputChunks[i]);

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestECKeyOutputStream.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestECKeyOutputStream.java
@@ -87,7 +87,7 @@ public class TestECKeyOutputStream {
    */
   @BeforeClass
   public static void init() throws Exception {
-    chunkSize = 1024;
+    chunkSize = 1024 * 1024;
     flushSize = 2 * chunkSize;
     maxFlushSize = 2 * flushSize;
     blockSize = 2 * maxFlushSize;

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/TestECContainerRecovery.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/TestECContainerRecovery.java
@@ -97,7 +97,7 @@ public class TestECContainerRecovery {
    */
   @BeforeAll
   public static void init() throws Exception {
-    chunkSize = 1024;
+    chunkSize = 1024 * 1024;
     flushSize = 2 * chunkSize;
     maxFlushSize = 2 * flushSize;
     blockSize = 2 * maxFlushSize;

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/TestBlockDeletion.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/TestBlockDeletion.java
@@ -120,7 +120,8 @@ public class TestBlockDeletion {
     GenericTestUtils.setLogLevel(SCMBlockDeletingService.LOG, Level.DEBUG);
     GenericTestUtils.setLogLevel(LegacyReplicationManager.LOG, Level.DEBUG);
 
-    conf.set("ozone.replication.allowed-configs", "^(RATIS/THREE)|(EC/2-1)$");
+    conf.set("ozone.replication.allowed-configs",
+        "^(RATIS/THREE)|(EC/2-1-256k)$");
     conf.setTimeDuration(OZONE_BLOCK_DELETING_SERVICE_INTERVAL, 100,
         TimeUnit.MILLISECONDS);
     DatanodeConfiguration datanodeConfiguration = conf.getObject(


### PR DESCRIPTION
## What changes were proposed in this pull request?

Limit EC chunk size to a few sensible options between 512KB and 4MB by default, but allow admins to override it in config.

Change EC replication string to display chunk size in KBs.

https://issues.apache.org/jira/browse/HDDS-7122

## How was this patch tested?

Updated unit tests.

https://github.com/adoroszlai/hadoop-ozone/actions/runs/4503959940