### PR TITLE
HDDS-8269. [Snapshot] Enable CI native building and testing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,7 +61,7 @@ jobs:
     needs:
       - build-info
     runs-on: ubuntu-20.04
-    timeout-minutes: 30
+    timeout-minutes: 45
     if: needs.build-info.outputs.needs-build == 'true'
     strategy:
       matrix:
@@ -93,7 +93,7 @@ jobs:
           distribution: 'temurin'
           java-version: ${{ matrix.java }}
       - name: Run a full build
-        run: hadoop-ozone/dev-support/checks/build.sh -Pcoverage -Pdist -Psrc
+        run: hadoop-ozone/dev-support/checks/build.sh -Pcoverage -Pdist -Psrc -Drocks_tools_native
       - name: Store binaries for tests
         uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -147,7 +147,7 @@ jobs:
           distribution: 'temurin'
           java-version: ${{ matrix.java }}
       - name: Compile Ozone using Java ${{ matrix.java }}
-        run: hadoop-ozone/dev-support/checks/build.sh -Dskip.npx -Dskip.installnpx -Djavac.version=${{ matrix.java }}
+        run: hadoop-ozone/dev-support/checks/build.sh -Dskip.npx -Dskip.installnpx -Djavac.version=${{ matrix.java }} -Drocks_tools_native
       - name: Delete temporary build artifacts before caching
         run: |
           #Never cache local artifacts


### PR DESCRIPTION
## What changes were proposed in this pull request?

HDDS-8028 is merged, but the native build (including RocksDB tools) isn't quite triggered and tested on CI.

This aims to enable the native build in CI to facilitate testing in order to prevent regression.

![prebuild-1](https://user-images.githubusercontent.com/50227127/228384506-6f90b6b1-61ac-4044-952f-2bec303a22ea.svg)

- [x] Enable native build in PR CI and post-commit CI.
- [ ] Enable selectively in PRs that changed SnapDiff related modules.
- [ ] Separate non-native and native build. Parallelize CI jobs as much as possible to reduce overall CI run time.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-8269

## How was this patch tested?

- All existing tests shall pass.
