### PR TITLE
HDDS-8270. Measure checkAccess latency for Ozone objects

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/util/MetricUtil.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/util/MetricUtil.java
@@ -20,6 +20,7 @@ package org.apache.hadoop.util;
 import org.apache.hadoop.metrics2.lib.MutableRate;
 
 import java.io.IOException;
+import java.util.function.Consumer;
 
 /**
  * Encloses helpers to deal with metrics.
@@ -47,6 +48,17 @@ public final class MetricUtil {
       block.run();
     } finally {
       metric.add(Time.monotonicNowNanos() - start);
+    }
+  }
+
+  public static <T, E extends IOException> T captureLatencyNs(
+      Consumer<Long> latencySetter,
+      CheckedSupplier<T, E> block) throws E {
+    long start = Time.monotonicNowNanos();
+    try {
+      return block.get();
+    } finally {
+      latencySetter.accept(Time.monotonicNowNanos() - start);
     }
   }
 }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OMPerformanceMetrics.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OMPerformanceMetrics.java
@@ -83,6 +83,8 @@ public class OMPerformanceMetrics {
   @Metric(about = "Client requests forcing container info cache refresh")
   private MutableRate forceContainerCacheRefresh;
 
+  @Metric(about = "checkAccess latency in nanoseconds")
+  private MutableRate checkAccessLatencyNs;
 
   public void addLookupLatency(long latencyInNs) {
     lookupLatencyNs.add(latencyInNs);
@@ -139,5 +141,9 @@ public class OMPerformanceMetrics {
 
   public void setForceContainerCacheRefresh(boolean value) {
     forceContainerCacheRefresh.add(value ? 1L : 0L);
+  }
+
+  public MutableRate getCheckAccessLatencyNs() {
+    return checkAccessLatencyNs;
   }
 }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OMPerformanceMetrics.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OMPerformanceMetrics.java
@@ -143,7 +143,7 @@ public class OMPerformanceMetrics {
     forceContainerCacheRefresh.add(value ? 1L : 0L);
   }
 
-  public MutableRate getCheckAccessLatencyNs() {
-    return checkAccessLatencyNs;
+  public void setCheckAccessLatencyNs(long latencyInNs) {
+    checkAccessLatencyNs.add(latencyInNs);
   }
 }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmMetadataReader.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmMetadataReader.java
@@ -486,7 +486,8 @@ public class OmMetadataReader implements IOmMetadataReader, Auditor {
                            boolean throwIfPermissionDenied)
       throws OMException {
 
-    if (!accessAuthorizer.checkAccess(obj, context)) {
+    if (!captureLatencyNs(perfMetrics.getCheckAccessLatencyNs(),
+        () -> accessAuthorizer.checkAccess(obj, context))) {
       if (throwIfPermissionDenied) {
         String volumeName = obj.getVolumeName() != null ?
                 "Volume:" + obj.getVolumeName() + " " : "";

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmMetadataReader.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmMetadataReader.java
@@ -486,8 +486,15 @@ public class OmMetadataReader implements IOmMetadataReader, Auditor {
                            boolean throwIfPermissionDenied)
       throws OMException {
 
-    if (!captureLatencyNs(perfMetrics.getCheckAccessLatencyNs(),
-        () -> accessAuthorizer.checkAccess(obj, context))) {
+    boolean hasAccessPermission;
+    long start = Time.monotonicNowNanos();
+    try {
+      hasAccessPermission = accessAuthorizer.checkAccess(obj, context);
+    } finally {
+      perfMetrics.setCheckAccessLatencyNs(Time.monotonicNowNanos() - start);
+    }
+
+    if (!hasAccessPermission) {
       if (throwIfPermissionDenied) {
         String volumeName = obj.getVolumeName() != null ?
                 "Volume:" + obj.getVolumeName() + " " : "";

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmMetadataReader.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmMetadataReader.java
@@ -486,15 +486,8 @@ public class OmMetadataReader implements IOmMetadataReader, Auditor {
                            boolean throwIfPermissionDenied)
       throws OMException {
 
-    boolean hasAccessPermission;
-    long start = Time.monotonicNowNanos();
-    try {
-      hasAccessPermission = accessAuthorizer.checkAccess(obj, context);
-    } finally {
-      perfMetrics.setCheckAccessLatencyNs(Time.monotonicNowNanos() - start);
-    }
-
-    if (!hasAccessPermission) {
+    if (!captureLatencyNs(perfMetrics::setCheckAccessLatencyNs,
+        () -> accessAuthorizer.checkAccess(obj, context))) {
       if (throwIfPermissionDenied) {
         String volumeName = obj.getVolumeName() != null ?
                 "Volume:" + obj.getVolumeName() + " " : "";


### PR DESCRIPTION
## What changes were proposed in this pull request?

Introducing a new OM performance metric for capturing the latency of the `checkAccess` method in the `OmMetadataReader` class. This metric shall be crucial in measuring the time it takes for the security providers that extend support for Ozone ACLs to verify the access permissions granted for a given Ozone object.

This metric could potentially serve as a valuable tool in identifying any performance bottlenecks and improving efficiency.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-8270

## How was this patch tested?

The patch has been tested over a cluster that has the Ozone services running to see what the metric looks like. A sample screenshot of the Prometheus UI has been attached (for reference) capturing `om_performance_metrics_check_access_latency_ns_avg_time` (in nanoseconds):

![om_performance_metrics_check_access_latency_ns_avg_time](https://user-images.githubusercontent.com/46785609/227445076-74348e34-677f-4942-897f-de89ef673fc4.png)
