### PR TITLE
HDDS-8272. DBStore not closed properly in ReconStorageContainerManagerFacade

### DIFF
--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/scm/ReconStorageContainerManagerFacade.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/scm/ReconStorageContainerManagerFacade.java
@@ -79,6 +79,7 @@ import org.apache.hadoop.hdds.server.events.EventQueue;
 import org.apache.hadoop.hdds.server.events.FixedThreadPoolWithAffinityExecutor;
 import org.apache.hadoop.hdds.upgrade.HDDSLayoutVersionManager;
 import org.apache.hadoop.hdds.utils.HddsServerUtil;
+import org.apache.hadoop.hdds.utils.IOUtils;
 import org.apache.hadoop.hdds.utils.db.DBCheckpoint;
 import org.apache.hadoop.hdds.utils.db.DBColumnFamilyDefinition;
 import org.apache.hadoop.hdds.utils.db.DBStore;
@@ -86,7 +87,6 @@ import org.apache.hadoop.hdds.utils.db.DBStoreBuilder;
 import org.apache.hadoop.hdds.utils.db.Table;
 import org.apache.hadoop.hdds.utils.db.Table.KeyValue;
 import org.apache.hadoop.hdds.utils.db.TableIterator;
-import org.apache.hadoop.io.IOUtils;
 import org.apache.hadoop.ozone.recon.ReconServerConfigKeys;
 import org.apache.hadoop.ozone.recon.ReconUtils;
 import org.apache.hadoop.ozone.recon.fsck.ContainerHealthTask;
@@ -426,11 +426,7 @@ public class ReconStorageContainerManagerFacade
     IOUtils.cleanupWithLogger(LOG, pipelineManager);
     LOG.info("Flushing container replica history to DB.");
     containerManager.flushReplicaHistoryMapToDB(true);
-    try {
-      dbStore.close();
-    } catch (Exception e) {
-      LOG.error("Can't close dbStore ", e);
-    }
+    IOUtils.close(LOG, dbStore);
   }
 
   @Override
@@ -636,7 +632,8 @@ public class ReconStorageContainerManagerFacade
     return dbStoreBuilder.build();
   }
 
-  public void setDbStore(DBStore dbStore) {
+  private void setDbStore(DBStore dbStore) {
+    IOUtils.close(LOG, this.dbStore);
     this.dbStore = dbStore;
   }
 

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/scm/ReconStorageContainerManagerFacade.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/scm/ReconStorageContainerManagerFacade.java
@@ -602,7 +602,7 @@ public class ReconStorageContainerManagerFacade
           ReconSCMDBDefinition.NODES.getTable(newStore));
       IOUtils.close(LOG, dbStore);
       deleteOldSCMDB();
-      setDbStore(newStore);
+      dbStore = newStore;
       File newDb = new File(dbFile.getParent() +
           OZONE_URI_DELIMITER + ReconSCMDBDefinition.RECON_SCM_DB_NAME);
       boolean success = dbFile.renameTo(newDb);
@@ -631,10 +631,6 @@ public class ReconStorageContainerManagerFacade
           columnFamily.getValueCodec());
     }
     return dbStoreBuilder.build();
-  }
-
-  private void setDbStore(DBStore dbStore) {
-    this.dbStore = dbStore;
   }
 
   @Override

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/scm/ReconStorageContainerManagerFacade.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/scm/ReconStorageContainerManagerFacade.java
@@ -600,6 +600,7 @@ public class ReconStorageContainerManagerFacade
           ReconSCMDBDefinition.CONTAINERS.getTable(newStore));
       nodeManager.reinitialize(
           ReconSCMDBDefinition.NODES.getTable(newStore));
+      IOUtils.close(LOG, dbStore);
       deleteOldSCMDB();
       setDbStore(newStore);
       File newDb = new File(dbFile.getParent() +
@@ -633,7 +634,6 @@ public class ReconStorageContainerManagerFacade
   }
 
   private void setDbStore(DBStore dbStore) {
-    IOUtils.close(LOG, this.dbStore);
     this.dbStore = dbStore;
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Warning about not closed object can be seen in `TestReconScmSnapshot` and/or `TestReconScmHASnapshot`

Close previous `DBStore` when being replaced in `ReconStorageContainerManagerFacade`.

https://issues.apache.org/jira/browse/HDDS-8272

## How was this patch tested?

CI:
https://github.com/adoroszlai/hadoop-ozone/actions/runs/4510251505