### PR TITLE
HDDS-8258. RocksIterator not closed properly in KeyValueHandler.logBlocksIfNonZero

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/KeyValueHandler.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/KeyValueHandler.java
@@ -1235,15 +1235,16 @@ public class KeyValueHandler extends Handler {
              = BlockUtils.getDB(
         (KeyValueContainerData) container.getContainerData(),
         conf)) {
-      BlockIterator<BlockData>
-          blockIterator = dbHandle.getStore().
-          getBlockIterator(container.getContainerData().getContainerID());
       StringBuilder stringBuilder = new StringBuilder();
-      while (blockIterator.hasNext()) {
-        nonZero = true;
-        stringBuilder.append(blockIterator.nextBlock());
-        if (stringBuilder.length() > StorageUnit.KB.toBytes(32)) {
-          break;
+      try (BlockIterator<BlockData>
+          blockIterator = dbHandle.getStore().
+          getBlockIterator(container.getContainerData().getContainerID())) {
+        while (blockIterator.hasNext()) {
+          nonZero = true;
+          stringBuilder.append(blockIterator.nextBlock());
+          if (stringBuilder.length() > StorageUnit.KB.toBytes(32)) {
+            break;
+          }
         }
       }
       if (nonZero) {


### PR DESCRIPTION
## What changes were proposed in this pull request?

Close `BlockIterator` in `KeyValueHandler#logBlocksIfNonZero`.

https://issues.apache.org/jira/browse/HDDS-8258

## How was this patch tested?

https://github.com/adoroszlai/hadoop-ozone/actions/runs/4509916244