### PR TITLE
HDDS-8279. [Snapshot] Switch RocksDB Tools JNI to release build

### DIFF
--- a/hadoop-hdds/rocks-native/pom.xml
+++ b/hadoop-hdds/rocks-native/pom.xml
@@ -274,6 +274,7 @@
                                             <arg line="${project.build.directory}/rocksdb/rocksdb-${rocksdb.version}"/>
                                         </exec>
                                         <exec executable="make" dir="${project.build.directory}/rocksdb/rocksdb-${rocksdb.version}" failonerror="true">
+                                            <arg line="DEBUG_LEVEL=0"/>
                                             <arg line="EXTRA_CXXFLAGS='-fPIC -I${project.build.directory}/snappy/lib -I${project.build.directory}/snappy/snappy-${snappy.version} -I${project.build.directory}/lz4/lz4-${lz4.version}/lib -I${project.build.directory}/zstd/zstd-${zstd.version}/lib -I${project.build.directory}/zstd/zstd-${zstd.version}/lib/dictBuilder -I${project.build.directory}/bzip2/bzip2-${bzip2.version} -I${project.build.directory}/zlib/zlib-${zlib.version}'"/>
                                             <arg line="EXTRA_LDFLAGS='-L${project.build.directory}/snappy/lib -L${project.build.directory}/lz4/lz4-${lz4.version}/lib -L${project.build.directory}/zstd/zstd-${zstd.version}/lib -L${project.build.directory}/bzip2/bzip2-${bzip2.version} -L${project.build.directory}/zlib/zlib-${zlib.version}'"/>
                                             <arg line="-j${system.numCores}"/>

--- a/hadoop-hdds/rocks-native/src/CMakeLists.txt
+++ b/hadoop-hdds/rocks-native/src/CMakeLists.txt
@@ -41,12 +41,12 @@ if(${SST_DUMP_INCLUDE})
     set_target_properties(
             rocksdb
             PROPERTIES
-            IMPORTED_LOCATION ${ROCKSDB_LIB}/librocksdb_debug.a)
+            IMPORTED_LOCATION ${ROCKSDB_LIB}/librocksdb.a)
     ADD_LIBRARY(rocks_tools STATIC IMPORTED)
     set_target_properties(
             rocks_tools
             PROPERTIES
-            IMPORTED_LOCATION ${ROCKSDB_LIB}/librocksdb_tools_debug.a)
+            IMPORTED_LOCATION ${ROCKSDB_LIB}/librocksdb_tools.a)
     ADD_LIBRARY(bz2 STATIC IMPORTED)
     set_target_properties(
             bz2


### PR DESCRIPTION
## What changes were proposed in this pull request?

Currently RocksDB lib and tools JNI is building with `DEBUG_LEVEL=1` (the default).

Explicitly set it to `DEBUG_LEVEL=0` and make appropriate CMakeLists changes.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-8279

## How was this patch tested?

- Compilation passed locally:

```
$ mvn clean install -DskipTests -e -Dmaven.javadoc.skip=true -DskipShade -Drocks_tools_native
...
[INFO] --- antrun:1.3:run (build-rocksjava) @ hdds-rocks-native ---
[INFO] Executing tasks
     [exec] $DEBUG_LEVEL is 0
     [exec] $DEBUG_LEVEL is 0
     [exec]   CC       db_stress_tool/db_stress.o
     [exec]   CC       tools/block_cache_analyzer/block_cache_trace_analyzer.o
     [exec]   CC       tools/trace_analyzer_tool.o
...
[INFO] Apache Ozone HDDS RocksDB Tools .................... SUCCESS [01:23 min]
[INFO] Apache Ozone ....................................... SUCCESS [  0.061 s]
[INFO] Apache Ozone Client Interface ...................... SUCCESS [  7.560 s]
[INFO] Apache Ozone Common ................................ SUCCESS [ 11.063 s]
[INFO] Apache Ozone Storage Interface ..................... SUCCESS [  0.746 s]
[INFO] Apache Ozone Client ................................ SUCCESS [  0.789 s]
[INFO] Apache Ozone Manager Server ........................ SUCCESS [  6.327 s]
[INFO] Apache Ozone FileSystem Common ..................... SUCCESS [  0.516 s]
[INFO] Apache Ozone FileSystem ............................ SUCCESS [  0.214 s]
[INFO] Apache Ozone Recon CodeGen ......................... SUCCESS [  0.276 s]
[INFO] Apache Ozone Recon ................................. SUCCESS [ 55.338 s]
[INFO] Apache Ozone Tools ................................. SUCCESS [  1.271 s]
[INFO] Apache Ozone S3 Gateway ............................ SUCCESS [  1.542 s]
[INFO] Apache Ozone CSI service ........................... SUCCESS [  2.560 s]
[INFO] Apache Ozone Integration Tests ..................... SUCCESS [  1.995 s]
[INFO] Apache Ozone Datanode .............................. SUCCESS [  0.232 s]
[INFO] Apache Ozone Insight Tool .......................... SUCCESS [  0.431 s]
[INFO] Apache Ozone HttpFS ................................ SUCCESS [  0.598 s]
[INFO] Apache Ozone Distribution .......................... SUCCESS [  1.537 s]
[INFO] Apache Ozone Fault Injection Tests ................. SUCCESS [  0.012 s]
[INFO] Apache Ozone Network Tests ......................... SUCCESS [  0.021 s]
[INFO] Apache Ozone Mini Ozone Chaos Tests ................ SUCCESS [  0.403 s]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  03:24 min
[INFO] Finished at: 2023-03-24T15:51:00-07:00
[INFO] ------------------------------------------------------------------------
```

Note: CI is not yet ready to fully build RocksDB without adding too much run time. #4466 