### PR TITLE
HDDS-8281. Add IntelliJ code style scheme import recommendation in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -112,6 +112,14 @@ Basic code conventions followed by Ozone:
 
 These are checked by tools like Checkstyle and RAT.
 
+For IntelliJ users, it is recommended to import and select the Code Style scheme located at:
+
+```
+./hadoop-ozone/dev-support/intellij/ozone-style.xml
+```
+
+See https://www.jetbrains.com/help/idea/configuring-code-style.html#import-code-style for detailed instructions.
+
 ### Check your contribution
 
 The [`hadoop-ozone/dev-support/checks` directory](https://github.com/apache/ozone/tree/master/hadoop-ozone/dev-support/checks) contains scripts to build and check Ozone.  Most of these are executed by CI for every commit and pull request.  Running them before creating a pull request is strongly recommended.  This can be achieved by enabling the `build-branch` workflow in your fork and letting GitHub run all of the checks, but most of the checks can also be run locally.


### PR DESCRIPTION
## What changes were proposed in this pull request?

We have included an IntelliJ code style export since HDDS-3674 (thanks @captainzmc).

Prompted by https://github.com/apache/ozone/pull/4376/files#r1145395241, we should include a few lines of instructions in the markdown doc as well.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-8281

## How was this patch tested?

n/a