### PR TITLE
HDDS-8274. Intermittent timeout in acceptance-MR test setup

### DIFF
--- a/hadoop-ozone/dist/src/main/smoketest/createmrenv.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/createmrenv.robot
@@ -18,7 +18,7 @@ Documentation       Create directories required for MR test
 Library             OperatingSystem
 Resource            commonlib.robot
 Resource            lib/fs.robot
-Test Timeout        2 minute
+Test Timeout        5 minutes
 
 
 *** Variables ***


### PR DESCRIPTION
## What changes were proposed in this pull request?

Increase timeout for the setup required for MapReduce test to prevent intermittent failure.

https://issues.apache.org/jira/browse/HDDS-8274

## How was this patch tested?

Regular CI:
https://github.com/adoroszlai/hadoop-ozone/actions/runs/4515003631