### PR TITLE
HDDS-8275. ManagedWriteBatch is not closed properly in SCMHADBTransactionBuffer

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMHADBTransactionBufferImpl.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMHADBTransactionBufferImpl.java
@@ -21,6 +21,7 @@ import org.apache.hadoop.hdds.scm.block.DeletedBlockLog;
 import org.apache.hadoop.hdds.scm.block.DeletedBlockLogImpl;
 import org.apache.hadoop.hdds.scm.metadata.SCMMetadataStore;
 import org.apache.hadoop.hdds.scm.server.StorageContainerManager;
+import org.apache.hadoop.hdds.utils.IOUtils;
 import org.apache.hadoop.hdds.utils.TransactionInfo;
 import org.apache.hadoop.hdds.utils.db.BatchOperation;
 import org.apache.hadoop.hdds.utils.db.Table;
@@ -134,6 +135,8 @@ public class SCMHADBTransactionBufferImpl implements SCMHADBTransactionBuffer {
 
     rwLock.writeLock().lock();
     try {
+      IOUtils.closeQuietly(currentBatchOperation);
+
       // initialize a batch operation during construction time
       currentBatchOperation = this.metadataStore.getStore().
           initBatchOperation();

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMHADBTransactionBufferStub.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMHADBTransactionBufferStub.java
@@ -97,15 +97,17 @@ public class SCMHADBTransactionBufferStub implements SCMHADBTransactionBuffer {
 
   @Override
   public void flush() throws IOException {
-    if (dbStore != null) {
-      rwLock.writeLock().lock();
-      try {
+    rwLock.writeLock().lock();
+    try {
+      if (dbStore != null) {
         dbStore.commitBatchOperation(getCurrentBatchOperation());
+      }
+      if (currentBatchOperation != null) {
         currentBatchOperation.close();
         currentBatchOperation = null;
-      } finally {
-        rwLock.writeLock().unlock();
       }
+    } finally {
+      rwLock.writeLock().unlock();
     }
   }
 

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMHAManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMHAManager.java
@@ -28,7 +28,7 @@ import java.io.IOException;
 /**
  * SCMHAManager provides HA service for SCM.
  */
-public interface SCMHAManager {
+public interface SCMHAManager extends AutoCloseable {
 
   /**
    * Starts HA service.

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMHAManagerImpl.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMHAManagerImpl.java
@@ -340,7 +340,15 @@ public class SCMHAManagerImpl implements SCMHAManager {
     if (ratisServer != null) {
       ratisServer.stop();
       grpcServer.stop();
+      close();
     }
+  }
+
+  /**
+   * Releases resources that are allocated even if not {@link #start()}ed.
+   */
+  @Override
+  public void close() {
     IOUtils.close(LOG, transactionBuffer);
   }
 

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMHAManagerImpl.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMHAManagerImpl.java
@@ -30,6 +30,7 @@ import org.apache.hadoop.hdds.utils.HAUtils;
 
 import com.google.common.annotations.VisibleForTesting;
 import org.apache.hadoop.hdds.scm.metadata.SCMDBDefinition;
+import org.apache.hadoop.hdds.utils.IOUtils;
 import org.apache.hadoop.hdds.utils.TransactionInfo;
 import org.apache.hadoop.hdds.utils.db.DBCheckpoint;
 import org.apache.hadoop.ozone.OzoneConsts;
@@ -340,6 +341,7 @@ public class SCMHAManagerImpl implements SCMHAManager {
       ratisServer.stop();
       grpcServer.stop();
     }
+    IOUtils.close(LOG, transactionBuffer);
   }
 
   @Override

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMHAManagerStub.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMHAManagerStub.java
@@ -30,6 +30,7 @@ import org.apache.hadoop.hdds.protocol.proto.SCMRatisProtocol.RequestType;
 import org.apache.hadoop.hdds.scm.AddSCMRequest;
 import org.apache.hadoop.hdds.scm.RemoveSCMRequest;
 import org.apache.hadoop.hdds.scm.metadata.DBTransactionBuffer;
+import org.apache.hadoop.hdds.utils.IOUtils;
 import org.apache.hadoop.hdds.utils.db.DBCheckpoint;
 import org.apache.hadoop.hdds.utils.db.DBStore;
 import org.apache.ratis.grpc.GrpcTlsConfig;
@@ -52,7 +53,7 @@ public final class SCMHAManagerStub implements SCMHAManager {
 
   private final SCMRatisServer ratisServer;
   private boolean isLeader;
-  private DBTransactionBuffer transactionBuffer;
+  private final DBTransactionBuffer transactionBuffer;
 
   public static SCMHAManager getInstance(boolean isLeader) {
     return new SCMHAManagerStub(isLeader);
@@ -89,6 +90,11 @@ public final class SCMHAManagerStub implements SCMHAManager {
   @Override
   public void stop() throws IOException {
     ratisServer.stop();
+  }
+
+  @Override
+  public void close() {
+    IOUtils.closeQuietly(transactionBuffer);
   }
 
   /**


### PR DESCRIPTION
## What changes were proposed in this pull request?

* Close `DBTransactionBuffer` in `SCMHAManagerImpl`
* Close `SCMHAManager` even if SCM is not started, since it needs to close the eagerly created `DBTransactionBuffer`
* Similarly, `ReplicationManager` is eagerly started, so it needs to be stopped even if SCM is not started
* Close previous `BatchOperation` in `SCMHADBTransactionBufferImpl`, as new one is created when snapshot is installed
* Close `ManagedWriteBatch` in `SCMHADBTransactionBufferStub` (used for tests and Recon) even if `DBStore` is not created

https://issues.apache.org/jira/browse/HDDS-8275

## How was this patch tested?

`TestSCMInstallSnapshot` and `TestSCMInstallSnapshotWithHA` do not log not properly closed `ManagedWriteBatch`.

```
[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 120.839 s - in org.apache.hadoop.ozone.scm.TestSCMInstallSnapshotWithHA
[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 30.012 s - in org.apache.hadoop.hdds.scm.TestSCMInstallSnapshot
...
$ grep -c 'not closed' hadoop-ozone/integration-test/target/surefire-reports/*output.txt
hadoop-ozone/integration-test/target/surefire-reports/org.apache.hadoop.hdds.scm.TestSCMInstallSnapshot-output.txt:0
hadoop-ozone/integration-test/target/surefire-reports/org.apache.hadoop.ozone.scm.TestSCMInstallSnapshotWithHA-output.txt:0
```

Regular CI:
https://github.com/adoroszlai/hadoop-ozone/actions/runs/4517815043