### PR TITLE
HDDS-7552. incorrect client implementation writing container to another DN can cause dataloss

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/AbstractContainerReportHandler.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/AbstractContainerReportHandler.java
@@ -413,6 +413,15 @@ public class AbstractContainerReportHandler {
   protected boolean validateOpenContainerReplica(
       ContainerInfo container, DatanodeDetails dd, NodeManager nodeManager,
       EventPublisher publisher) {
+    if (container == null) {
+      // container not present, no need validate, its validated outside
+      return true;
+    }
+    if (container.getReplicationConfig().getReplicationType()
+        == HddsProtos.ReplicationType.EC) {
+      // EC construction mechanism do not follow raits pipeline
+      return true;
+    }
     if (container.getState() == HddsProtos.LifeCycleState.OPEN) {
       if (!nodeManager.getPipelines(dd).contains(
           container.getPipelineID())) {

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/ContainerReportHandler.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/ContainerReportHandler.java
@@ -185,11 +185,13 @@ public class ContainerReportHandler extends AbstractContainerReportHandler
 
           boolean alreadyInDn = expectedContainersInDatanode.remove(cid);
           if (!alreadyInDn) {
-            if (validateOpenContainerReplica(container, datanodeDetails,
-                nodeManager, publisher)) {
-              // This is a new Container not in the nodeManager -> dn map yet
-              nodeManager.addContainer(datanodeDetails, cid);
+            if (!validateOpenContainerReplica(
+                container, datanodeDetails, nodeManager, publisher)) {
+              // container replica is invalid
+              continue;
             }
+            // This is a new Container not in the nodeManager -> dn map yet
+            nodeManager.addContainer(datanodeDetails, cid);
           }
           if (container == null || ContainerReportValidator
                   .validate(container, datanodeDetails, replica)) {

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/ContainerReportHandler.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/ContainerReportHandler.java
@@ -185,8 +185,11 @@ public class ContainerReportHandler extends AbstractContainerReportHandler
 
           boolean alreadyInDn = expectedContainersInDatanode.remove(cid);
           if (!alreadyInDn) {
-            // This is a new Container not in the nodeManager -> dn map yet
-            nodeManager.addContainer(datanodeDetails, cid);
+            if (validateOpenContainerReplica(container, datanodeDetails,
+                nodeManager, publisher)) {
+              // This is a new Container not in the nodeManager -> dn map yet
+              nodeManager.addContainer(datanodeDetails, cid);
+            }
           }
           if (container == null || ContainerReportValidator
                   .validate(container, datanodeDetails, replica)) {

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/IncrementalContainerReportHandler.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/IncrementalContainerReportHandler.java
@@ -94,10 +94,11 @@ public class IncrementalContainerReportHandler extends
                 ContainerReplicaProto.State.DELETED)) {
               nodeManager.removeContainer(dd, id);
             } else {
-              if (validateOpenContainerReplica(container, dd, nodeManager,
+              if (!validateOpenContainerReplica(container, dd, nodeManager,
                   publisher)) {
-                nodeManager.addContainer(dd, id);
+                continue;
               }
+              nodeManager.addContainer(dd, id);
             }
           }
           if (ContainerReportValidator.validate(container, dd, replicaProto)) {

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/IncrementalContainerReportHandler.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/IncrementalContainerReportHandler.java
@@ -22,7 +22,6 @@ import java.io.IOException;
 import java.util.concurrent.TimeoutException;
 
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
-import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos
     .ContainerReplicaProto;
 import org.apache.hadoop.hdds.scm.container.report.ContainerReportValidator;

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/IncrementalContainerReportHandler.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/IncrementalContainerReportHandler.java
@@ -22,6 +22,7 @@ import java.io.IOException;
 import java.util.concurrent.TimeoutException;
 
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
+import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos
     .ContainerReplicaProto;
 import org.apache.hadoop.hdds.scm.container.report.ContainerReportValidator;
@@ -93,7 +94,10 @@ public class IncrementalContainerReportHandler extends
                 ContainerReplicaProto.State.DELETED)) {
               nodeManager.removeContainer(dd, id);
             } else {
-              nodeManager.addContainer(dd, id);
+              if (validateOpenContainerReplica(container, dd, nodeManager,
+                  publisher)) {
+                nodeManager.addContainer(dd, id);
+              }
             }
           }
           if (ContainerReportValidator.validate(container, dd, replicaProto)) {

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/TestContainerReportHandler.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/TestContainerReportHandler.java
@@ -16,6 +16,8 @@
  */
 package org.apache.hadoop.hdds.scm.container;
 
+import java.util.ArrayList;
+import java.util.List;
 import org.apache.hadoop.fs.FileUtil;
 import org.apache.hadoop.hdds.HddsConfigKeys;
 import org.apache.hadoop.hdds.client.ECReplicationConfig;
@@ -551,13 +553,17 @@ public class TestContainerReportHandler {
         nodeManager, containerManager);
     final Iterator<DatanodeDetails> nodeIterator = nodeManager.getNodes(
         NodeStatus.inServiceHealthy()).iterator();
-
-    Pipeline pipeline = pipelineManager.createPipeline(
-        RatisReplicationConfig.getInstance(HddsProtos.ReplicationFactor.THREE));
-
     final DatanodeDetails datanodeOne = nodeIterator.next();
     final DatanodeDetails datanodeTwo = nodeIterator.next();
     final DatanodeDetails datanodeThree = nodeIterator.next();
+    List<DatanodeDetails> dnList = new ArrayList<>();
+    dnList.add(datanodeOne);
+    dnList.add(datanodeTwo);
+    dnList.add(datanodeThree);
+    Pipeline pipeline = pipelineManager.createPipeline(
+        RatisReplicationConfig.getInstance(HddsProtos.ReplicationFactor.THREE),
+        dnList);
+
 
     final ContainerReplicaProto.State replicaState
         = ContainerReplicaProto.State.OPEN;

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/MockPipelineManager.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/MockPipelineManager.java
@@ -90,12 +90,22 @@ public class MockPipelineManager implements PipelineManager {
   @Override
   public Pipeline createPipeline(final ReplicationConfig replicationConfig,
       final List<DatanodeDetails> nodes) {
-    return Pipeline.newBuilder()
+    final Pipeline pipeline = Pipeline.newBuilder()
         .setId(PipelineID.randomId())
         .setReplicationConfig(replicationConfig)
         .setNodes(nodes)
         .setState(Pipeline.PipelineState.OPEN)
         .build();
+
+    try {
+      stateManager.addPipeline(pipeline.getProtobufMessage(
+          ClientVersion.CURRENT_VERSION));
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    } catch (TimeoutException e) {
+      throw new RuntimeException(e);
+    }
+    return pipeline;
   }
 
   @Override

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/TestContainerStateMachineIdempotency.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/TestContainerStateMachineIdempotency.java
@@ -165,7 +165,7 @@ public class TestContainerStateMachineIdempotency {
         return logCapturer.getOutput().contains(
             "Sending delete container command for open container " +
                 "pipeline does not belongs to DN");
-      }, 200, 20000);
+      }, 200, 10000);
       logCapturer.stopCapturing();
 
     } catch (IOException ioe) {


### PR DESCRIPTION
## What changes were proposed in this pull request?

SCM ICR/FCR, if container is open and its corresponding pipeline is not present for DN where write is triggered creating container, that container is invalid, and sending command to delete the container.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-7552

## How was this patch tested?

Changes verified using Integration Test verifying if container write is done to different pipeline, SCM should reject the container and should delete
