### PR TITLE
HDDS-8179. Add toString() method to ECContainerReplicaCount

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ECContainerReplicaCount.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ECContainerReplicaCount.java
@@ -521,6 +521,23 @@ public class ECContainerReplicaCount implements ContainerReplicaCount {
     return isSufficientlyReplicated(false);
   }
 
+  @Override
+  public String toString() {
+    StringBuilder sb = new StringBuilder();
+    sb.append("Container State: ").append(containerInfo.getState())
+        .append(" Replica Count: ").append(replicas.size())
+        .append(" Healthy Count: ").append(healthyIndexes.size())
+        .append(" Unhealthy Count: ").append(unhealthyReplicaDNs.size())
+        .append(" Decommission Count: ").append(decommissionIndexes.size())
+        .append(" Maintenance Count: ").append(maintenanceIndexes.size())
+        .append(" inFlightAdd Count: ").append(pendingAdd.size())
+        .append(" inFightDel Count: ").append(pendingDelete.size())
+        .append(" ReplicationConfig: ").append(repConfig)
+        .append(" remainingMaintenanceRedundancy Count: ")
+        .append(remainingMaintenanceRedundancy);
+    return sb.toString();
+  }
+
   /**
    * Check if there is an entry in the map for all expected replica indexes,
    * and also that the count against each index is greater than zero.


### PR DESCRIPTION
## What changes were proposed in this pull request?

Add a toString method to ECContainerReplicaCount to mirror that in RatisContainerReplicaCount. The count object is logged in the following message in the decommission monitor, and as below the EC object is logging with the default toString():

```
2023-03-14 23:22:38,512 INFO org.apache.hadoop.hdds.scm.node.DatanodeAdminMonitorImpl: Unhealthy Container #15019 org.apache.hadoop.hdds.scm.container.replication.ECContainerReplicaCount@2bd10f2f; Replicas{
```

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-8179

## How was this patch tested?

Simple logging change. No tests added.