### PR TITLE
HDDS-8285. Eliminate leftover Guava Optional from CacheValue

### DIFF
--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/TypedTable.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/TypedTable.java
@@ -26,7 +26,6 @@ import java.util.List;
 import java.util.Map;
 
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.base.Optional;
 import org.apache.hadoop.hdds.utils.MetadataKeyFilters;
 import org.apache.hadoop.hdds.utils.TableCacheMetrics;
 import org.apache.hadoop.hdds.utils.db.cache.CacheKey;
@@ -110,7 +109,7 @@ public class TypedTable<KEY, VALUE> implements Table<KEY, VALUE> {
           // NEVER. Setting epoch value -1, so that when it is marked for
           // delete, this will be considered for cleanup.
           cache.loadInitial(new CacheKey<>(kv.getKey()),
-              new CacheValue<>(Optional.of(kv.getValue()), EPOCH_DEFAULT));
+              CacheValue.get(EPOCH_DEFAULT, kv.getValue()));
         }
       }
     } else {

--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/utils/db/TestTypedRDBTableStore.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/utils/db/TestTypedRDBTableStore.java
@@ -28,7 +28,6 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Set;
 
-import com.google.common.base.Optional;
 
 import org.apache.hadoop.hdds.StringUtils;
 import org.apache.hadoop.hdds.utils.db.managed.ManagedColumnFamilyOptions;
@@ -249,8 +248,7 @@ public class TestTypedRDBTableStore {
         String key = Integer.toString(x);
         String value = Integer.toString(x);
         testTable.addCacheEntry(new CacheKey<>(key),
-            new CacheValue<>(Optional.of(value),
-            x));
+            CacheValue.get(x, value));
       }
 
       // As we have added to cache, so get should return value even if it
@@ -275,11 +273,10 @@ public class TestTypedRDBTableStore {
         String value = Integer.toString(x);
         if (x % 2 == 0) {
           testTable.addCacheEntry(new CacheKey<>(key),
-              new CacheValue<>(Optional.of(value), x));
+              CacheValue.get(x, value));
         } else {
           testTable.addCacheEntry(new CacheKey<>(key),
-              new CacheValue<>(Optional.absent(),
-              x));
+              CacheValue.get(x));
         }
       }
 
@@ -363,11 +360,11 @@ public class TestTypedRDBTableStore {
           RandomStringUtils.random(10);
       String value = RandomStringUtils.random(10);
       testTable.addCacheEntry(new CacheKey<>(key),
-          new CacheValue<>(Optional.of(value), 1L));
+          CacheValue.get(1L, value));
       Assertions.assertTrue(testTable.isExist(key));
 
       testTable.addCacheEntry(new CacheKey<>(key),
-          new CacheValue<>(Optional.absent(), 1L));
+          CacheValue.get(1L));
       Assertions.assertFalse(testTable.isExist(key));
     }
   }
@@ -403,7 +400,7 @@ public class TestTypedRDBTableStore {
       Assertions.assertArrayEquals(value, testTable.get(key));
       Assertions.assertNotSame(value, actualValue);
       testTable.addCacheEntry(new CacheKey<>(key),
-              new CacheValue<>(Optional.of(value), 1L));
+              CacheValue.get(1L, value));
       Assertions.assertSame(value, testTable.get(key));
     }
   }

--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/utils/db/cache/TestTableCache.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/utils/db/cache/TestTableCache.java
@@ -23,7 +23,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 
-import com.google.common.base.Optional;
 import org.apache.ozone.test.GenericTestUtils;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
@@ -60,7 +59,7 @@ public class TestTableCache {
 
     for (int i = 0; i < 10; i++) {
       tableCache.put(new CacheKey<>(Integer.toString(i)),
-          new CacheValue<>(Optional.of(Integer.toString(i)), i));
+          CacheValue.get(i, Integer.toString(i)));
     }
 
 
@@ -105,9 +104,9 @@ public class TestTableCache {
     // putting cache with same epoch and different keyNames
     for (int i = 0; i < 3; i++) {
       tableCache.put(new CacheKey<>(Integer.toString(i).concat("A")),
-              new CacheValue<>(Optional.absent(), i));
+              CacheValue.get(i));
       tableCache.put(new CacheKey<>(Integer.toString(i).concat("B")),
-              new CacheValue<>(Optional.of(Integer.toString(i)), i));
+              CacheValue.get(i, Integer.toString(i)));
     }
 
     // Epoch entries should be like (long, (key1, key2, ...))
@@ -165,7 +164,7 @@ public class TestTableCache {
         epochs.add(i);
       }
       tableCache.put(new CacheKey<>(Long.toString(i)),
-          new CacheValue<>(Optional.of(Long.toString(i)), i));
+          CacheValue.get(i, Long.toString(i)));
       totalCount++;
     }
 
@@ -206,20 +205,20 @@ public class TestTableCache {
     createTableCache(cacheType);
 
     tableCache.put(new CacheKey<>(Long.toString(0)),
-          new CacheValue<>(Optional.of(Long.toString(0)), 0));
+          CacheValue.get(0, Long.toString(0)));
     tableCache.put(new CacheKey<>(Long.toString(1)),
-        new CacheValue<>(Optional.of(Long.toString(1)), 1));
+        CacheValue.get(1, Long.toString(1)));
     tableCache.put(new CacheKey<>(Long.toString(2)),
-        new CacheValue<>(Optional.of(Long.toString(2)), 2));
+        CacheValue.get(2, Long.toString(2)));
 
 
     //Override first 2 entries
     // This is to simulate a case like create mpu key, commit part1, commit
     // part2. They override the same key.
     tableCache.put(new CacheKey<>(Long.toString(0)),
-        new CacheValue<>(Optional.of(Long.toString(0)), 3));
+        CacheValue.get(3, Long.toString(0)));
     tableCache.put(new CacheKey<>(Long.toString(1)),
-        new CacheValue<>(Optional.of(Long.toString(1)), 4));
+        CacheValue.get(4, Long.toString(1)));
 
 
 
@@ -249,7 +248,7 @@ public class TestTableCache {
 
     // Add a new entry.
     tableCache.put(new CacheKey<>(Long.toString(5)),
-        new CacheValue<>(Optional.of(Long.toString(5)), 5));
+        CacheValue.get(5, Long.toString(5)));
 
     epochs = new ArrayList<>();
     epochs.add(5L);
@@ -273,24 +272,24 @@ public class TestTableCache {
     createTableCache(cacheType);
 
     tableCache.put(new CacheKey<>(Long.toString(0)),
-        new CacheValue<>(Optional.of(Long.toString(0)), 0));
+        CacheValue.get(0, Long.toString(0)));
     tableCache.put(new CacheKey<>(Long.toString(1)),
-        new CacheValue<>(Optional.of(Long.toString(1)), 1));
+        CacheValue.get(1, Long.toString(1)));
     tableCache.put(new CacheKey<>(Long.toString(2)),
-        new CacheValue<>(Optional.of(Long.toString(2)), 2));
+        CacheValue.get(2, Long.toString(2)));
 
 
     // Override entries
     tableCache.put(new CacheKey<>(Long.toString(0)),
-        new CacheValue<>(Optional.of(Long.toString(0)), 3));
+        CacheValue.get(3, Long.toString(0)));
     tableCache.put(new CacheKey<>(Long.toString(1)),
-        new CacheValue<>(Optional.of(Long.toString(1)), 4));
+        CacheValue.get(4, Long.toString(1)));
 
     // Finally, mark them for deleted
     tableCache.put(new CacheKey<>(Long.toString(0)),
-        new CacheValue<>(Optional.absent(), 5));
+        CacheValue.get(5));
     tableCache.put(new CacheKey<>(Long.toString(1)),
-        new CacheValue<>(Optional.absent(), 6));
+        CacheValue.get(6));
 
     // So now our cache epoch entries looks like
     // 0-0, 1-1, 2-2, 0-3, 1-4, 0-5, 1-6
@@ -332,7 +331,7 @@ public class TestTableCache {
 
     // Add a new entry, now old override entries will be cleaned up.
     tableCache.put(new CacheKey<>(Long.toString(3)),
-        new CacheValue<>(Optional.of(Long.toString(3)), 7));
+        CacheValue.get(7, Long.toString(3)));
 
     epochs = new ArrayList<>();
     epochs.add(7L);
@@ -451,14 +450,14 @@ public class TestTableCache {
     // In non-HA epoch entries might be out of order.
     // Scenario is like create vol, set vol, set vol, delete vol
     tableCache.put(new CacheKey<>(Long.toString(0)),
-        new CacheValue<>(Optional.of(Long.toString(0)), 0));
+        CacheValue.get(0, Long.toString(0)));
     tableCache.put(new CacheKey<>(Long.toString(0)),
-        new CacheValue<>(Optional.of(Long.toString(1)), 1));
+        CacheValue.get(1, Long.toString(1)));
     tableCache.put(new CacheKey<>(Long.toString(0)),
-        new CacheValue<>(Optional.of(Long.toString(2)), 3));
+        CacheValue.get(3, Long.toString(2)));
 
     tableCache.put(new CacheKey<>(Long.toString(0)),
-        new CacheValue<>(Optional.absent(), 2));
+        CacheValue.get(2));
 
     List<Long> epochs = new ArrayList<>();
     epochs.add(0L);
@@ -484,17 +483,17 @@ public class TestTableCache {
 
     // In non-HA epoch entries might be out of order.
     tableCache.put(new CacheKey<>(Long.toString(0)),
-        new CacheValue<>(Optional.of(Long.toString(0)), 0));
+        CacheValue.get(0, Long.toString(0)));
     tableCache.put(new CacheKey<>(Long.toString(0)),
-        new CacheValue<>(Optional.of(Long.toString(1)), 1));
+        CacheValue.get(1, Long.toString(1)));
     tableCache.put(new CacheKey<>(Long.toString(0)),
-        new CacheValue<>(Optional.of(Long.toString(3)), 3));
+        CacheValue.get(3, Long.toString(3)));
 
     tableCache.put(new CacheKey<>(Long.toString(0)),
-          new CacheValue<>(Optional.of(Long.toString(2)), 2));
+          CacheValue.get(2, Long.toString(2)));
 
     tableCache.put(new CacheKey<>(Long.toString(1)),
-        new CacheValue<>(Optional.of(Long.toString(1)), 4));
+        CacheValue.get(4, Long.toString(1)));
 
     List<Long> epochs = new ArrayList<>();
     epochs.add(0L);
@@ -548,9 +547,9 @@ public class TestTableCache {
     createTableCache(cacheType);
 
     tableCache.put(new CacheKey<>("0"),
-        new CacheValue<>(Optional.of("0"), 0));
+        CacheValue.get(0, "0"));
     tableCache.put(new CacheKey<>("1"),
-        new CacheValue<>(Optional.of("1"), 1));
+        CacheValue.get(1, "1"));
 
     Assertions.assertNotNull(tableCache.get(new CacheKey<>("0")));
     Assertions.assertNotNull(tableCache.get(new CacheKey<>("0")));
@@ -569,7 +568,7 @@ public class TestTableCache {
     int counter = 1;
     while (counter <= count) {
       tableCache.put(new CacheKey<>(Integer.toString(startVal)),
-          new CacheValue<>(Optional.of(Integer.toString(startVal)), startVal));
+          CacheValue.get(startVal, Integer.toString(startVal)));
       startVal++;
       counter++;
       Thread.sleep(sleep);

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestKeyManagerImpl.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestKeyManagerImpl.java
@@ -98,7 +98,6 @@ import org.apache.ozone.test.GenericTestUtils;
 import org.apache.ozone.test.LambdaTestUtils;
 import org.apache.hadoop.util.Time;
 
-import com.google.common.base.Optional;
 import com.google.common.collect.Sets;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.RandomStringUtils;
@@ -1004,7 +1003,7 @@ public class TestKeyManagerImpl {
           .getOzoneKey(VOLUME_NAME, BUCKET_NAME, prefixKeyInCache + i);
       metadataManager.getKeyTable(getDefaultBucketLayout())
           .addCacheEntry(new CacheKey<>(key),
-              new CacheValue<>(Optional.absent(), 2L));
+              CacheValue.get(2L));
     }
   }
 
@@ -1074,7 +1073,7 @@ public class TestKeyManagerImpl {
           keyNameDir1Subdir1 + OZONE_URI_DELIMITER + prefixKeyInCache + i);
       metadataManager.getKeyTable(getDefaultBucketLayout())
           .addCacheEntry(new CacheKey<>(key),
-              new CacheValue<>(Optional.absent(), 2L));
+              CacheValue.get(2L));
     }
   }
 
@@ -1102,7 +1101,7 @@ public class TestKeyManagerImpl {
         // Mark as deleted in cache.
         metadataManager.getKeyTable(getDefaultBucketLayout())
             .addCacheEntry(new CacheKey<>(key),
-                new CacheValue<>(Optional.absent(), 2L));
+                CacheValue.get(2L));
         deletedKeySet.add(key);
       }
     }
@@ -1138,7 +1137,7 @@ public class TestKeyManagerImpl {
             metadataManager.getOzoneKey(VOLUME_NAME, BUCKET_NAME, key);
         metadataManager.getKeyTable(getDefaultBucketLayout())
             .addCacheEntry(new CacheKey<>(ozoneKey),
-                new CacheValue<>(Optional.absent(), 2L));
+                CacheValue.get(2L));
         deletedKeySet.add(key);
       }
       doDelete = !doDelete;
@@ -1187,7 +1186,7 @@ public class TestKeyManagerImpl {
           metadataManager.getOzoneKey(VOLUME_NAME, BUCKET_NAME, key);
       metadataManager.getKeyTable(getDefaultBucketLayout())
           .addCacheEntry(new CacheKey<>(ozoneKey),
-              new CacheValue<>(Optional.absent(), 2L));
+              CacheValue.get(2L));
       deletedKeySet.add(key);
     }
     // Update existKeySet

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/ratis/TestOzoneManagerRatisRequest.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/ratis/TestOzoneManagerRatisRequest.java
@@ -17,7 +17,6 @@
  */
 package org.apache.hadoop.ozone.om.ratis;
 
-import com.google.common.base.Optional;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.utils.db.cache.CacheKey;
 import org.apache.hadoop.hdds.utils.db.cache.CacheValue;
@@ -64,15 +63,14 @@ public class TestOzoneManagerRatisRequest {
     String bucketName = "invalidBuck";
 
     // Add entry to Volume Table.
+    OmVolumeArgs omVolumeArgs = OmVolumeArgs.newBuilder()
+        .setVolume(volumeName)
+        .setOwnerName("owner")
+        .setAdminName("admin")
+        .build();
     omMetadataManager.getVolumeTable().addCacheEntry(
         new CacheKey<>(omMetadataManager.getVolumeKey(volumeName)),
-        new CacheValue<>(
-            Optional.of(
-                OmVolumeArgs.newBuilder()
-                    .setVolume(volumeName)
-                    .setOwnerName("owner")
-                    .setAdminName("admin")
-                    .build()), 100L));
+        CacheValue.get(100L, omVolumeArgs));
 
     OzoneManagerProtocolProtos.OMRequest omRequest = OMRequestTestUtils
         .createCompleteMPURequest(volumeName, bucketName, "mpuKey", "mpuKeyID",

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmMetadataManagerImpl.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmMetadataManagerImpl.java
@@ -34,7 +34,6 @@ import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import com.google.common.base.Optional;
 import org.apache.hadoop.hdds.client.BlockID;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.utils.TableCacheMetrics;
@@ -1601,13 +1600,13 @@ public class OmMetadataManagerImpl implements OMMetadataManager,
   @Override
   public void put(String kerberosId, S3SecretValue secretValue, long txId) {
     s3SecretTable.addCacheEntry(new CacheKey<>(kerberosId),
-        new CacheValue<>(Optional.of(secretValue), txId));
+        CacheValue.get(txId, secretValue));
   }
 
   @Override
   public void invalidate(String id, long txId) {
     s3SecretTable.addCacheEntry(new CacheKey<>(id),
-        new CacheValue<>(Optional.absent(), txId));
+        CacheValue.get(txId));
   }
 
   @Override

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
@@ -4214,10 +4214,10 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
       // Add to cache.
       metadataManager.getVolumeTable().addCacheEntry(
           new CacheKey<>(dbVolumeKey),
-          new CacheValue<>(Optional.of(omVolumeArgs), transactionID));
+          CacheValue.get(transactionID, omVolumeArgs));
       metadataManager.getUserTable().addCacheEntry(
           new CacheKey<>(dbUserKey),
-          new CacheValue<>(Optional.of(userVolumeInfo), transactionID));
+          CacheValue.get(transactionID, userVolumeInfo));
       LOG.info("Created Volume {} With Owner {} required for S3Gateway " +
               "operations.", s3VolumeName, userName);
     }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/bucket/OMBucketCreateRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/bucket/OMBucketCreateRequest.java
@@ -18,7 +18,6 @@
 
 package org.apache.hadoop.ozone.om.request.bucket;
 
-import com.google.common.base.Optional;
 import org.apache.hadoop.crypto.CipherSuite;
 import org.apache.hadoop.crypto.key.KeyProvider;
 import org.apache.hadoop.crypto.key.KeyProviderCryptoExtension;
@@ -230,9 +229,9 @@ public class OMBucketCreateRequest extends OMClientRequest {
 
       // Update table cache.
       metadataManager.getVolumeTable().addCacheEntry(new CacheKey<>(volumeKey),
-          new CacheValue<>(Optional.of(omVolumeArgs), transactionLogIndex));
+          CacheValue.get(transactionLogIndex, omVolumeArgs));
       metadataManager.getBucketTable().addCacheEntry(new CacheKey<>(bucketKey),
-          new CacheValue<>(Optional.of(omBucketInfo), transactionLogIndex));
+          CacheValue.get(transactionLogIndex, omBucketInfo));
 
       omResponse.setCreateBucketResponse(
           CreateBucketResponse.newBuilder().build());

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/bucket/OMBucketDeleteRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/bucket/OMBucketDeleteRequest.java
@@ -22,7 +22,6 @@ import java.io.IOException;
 import java.util.Iterator;
 import java.util.Map;
 
-import com.google.common.base.Optional;
 import org.apache.hadoop.hdds.utils.db.Table;
 import org.apache.hadoop.hdds.utils.db.TableIterator;
 import org.apache.hadoop.ozone.om.helpers.BucketLayout;
@@ -161,7 +160,7 @@ public class OMBucketDeleteRequest extends OMClientRequest {
       // Update table cache.
       omMetadataManager.getBucketTable().addCacheEntry(
           new CacheKey<>(bucketKey),
-          new CacheValue<>(Optional.absent(), transactionLogIndex));
+          CacheValue.get(transactionLogIndex));
 
       omResponse.setDeleteBucketResponse(
           DeleteBucketResponse.newBuilder().build());
@@ -178,7 +177,7 @@ public class OMBucketDeleteRequest extends OMClientRequest {
       // Update table cache.
       omMetadataManager.getVolumeTable().addCacheEntry(
           new CacheKey<>(volumeKey),
-          new CacheValue<>(Optional.of(omVolumeArgs), transactionLogIndex));
+          CacheValue.get(transactionLogIndex, omVolumeArgs));
 
       // Add to double buffer.
       omClientResponse = new OMBucketDeleteResponse(omResponse.build(),

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/bucket/OMBucketSetOwnerRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/bucket/OMBucketSetOwnerRequest.java
@@ -17,7 +17,6 @@
  */
 package org.apache.hadoop.ozone.om.request.bucket;
 
-import com.google.common.base.Optional;
 import com.google.common.base.Preconditions;
 import org.apache.hadoop.hdds.utils.db.cache.CacheKey;
 import org.apache.hadoop.hdds.utils.db.cache.CacheValue;
@@ -161,7 +160,7 @@ public class OMBucketSetOwnerRequest extends OMClientRequest {
       // Update table cache.
       omMetadataManager.getBucketTable().addCacheEntry(
           new CacheKey<>(bucketKey),
-          new CacheValue<>(Optional.of(omBucketInfo), transactionLogIndex));
+          CacheValue.get(transactionLogIndex, omBucketInfo));
 
       omResponse.setSetBucketPropertyResponse(
           SetBucketPropertyResponse.newBuilder().setResponse(true).build());

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/bucket/OMBucketSetPropertyRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/bucket/OMBucketSetPropertyRequest.java
@@ -21,7 +21,6 @@ package org.apache.hadoop.ozone.om.request.bucket;
 import java.io.IOException;
 import java.util.List;
 
-import com.google.common.base.Optional;
 import com.google.common.base.Preconditions;
 import org.apache.hadoop.hdds.client.DefaultReplicationConfig;
 import org.apache.hadoop.ozone.OzoneConsts;
@@ -231,7 +230,7 @@ public class OMBucketSetPropertyRequest extends OMClientRequest {
       // Update table cache.
       omMetadataManager.getBucketTable().addCacheEntry(
           new CacheKey<>(bucketKey),
-          new CacheValue<>(Optional.of(omBucketInfo), transactionLogIndex));
+          CacheValue.get(transactionLogIndex, omBucketInfo));
 
       omResponse.setSetBucketPropertyResponse(
           SetBucketPropertyResponse.newBuilder().build());

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/bucket/acl/OMBucketAclRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/bucket/acl/OMBucketAclRequest.java
@@ -22,7 +22,6 @@ import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 
-import com.google.common.base.Optional;
 import org.apache.hadoop.ozone.OzoneAcl;
 import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.hadoop.ozone.audit.AuditLogger;
@@ -132,7 +131,7 @@ public abstract class OMBucketAclRequest extends OMClientRequest {
         // update cache.
         omMetadataManager.getBucketTable().addCacheEntry(
             new CacheKey<>(dbBucketKey),
-            new CacheValue<>(Optional.of(omBucketInfo), transactionLogIndex));
+            CacheValue.get(transactionLogIndex, omBucketInfo));
       }
 
       omClientResponse = onSuccess(omResponse, omBucketInfo, operationResult);

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMAllocateBlockRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMAllocateBlockRequest.java
@@ -23,7 +23,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
-import com.google.common.base.Optional;
 import com.google.common.base.Preconditions;
 import org.apache.hadoop.hdds.client.ReplicationConfig;
 import org.apache.hadoop.ozone.om.helpers.BucketLayout;
@@ -236,7 +235,7 @@ public class OMAllocateBlockRequest extends OMKeyRequest {
       // Add to cache.
       omMetadataManager.getOpenKeyTable(getBucketLayout()).addCacheEntry(
           new CacheKey<>(openKeyName),
-          new CacheValue<>(Optional.of(openKeyInfo), trxnLogIndex));
+          CacheValue.get(trxnLogIndex, openKeyInfo));
 
       omResponse.setAllocateBlockResponse(AllocateBlockResponse.newBuilder()
           .setKeyLocation(blockLocation).build());

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyDeleteRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyDeleteRequest.java
@@ -21,7 +21,6 @@ package org.apache.hadoop.ozone.om.request.key;
 import java.io.IOException;
 import java.util.Map;
 
-import com.google.common.base.Optional;
 import org.apache.hadoop.ozone.om.helpers.BucketLayout;
 import org.apache.hadoop.ozone.om.helpers.OmBucketInfo;
 import org.apache.hadoop.ozone.om.ratis.utils.OzoneManagerDoubleBufferHelper;
@@ -159,7 +158,7 @@ public class OMKeyDeleteRequest extends OMKeyRequest {
       omMetadataManager.getKeyTable(getBucketLayout()).addCacheEntry(
           new CacheKey<>(
               omMetadataManager.getOzoneKey(volumeName, bucketName, keyName)),
-          new CacheValue<>(Optional.absent(), trxnLogIndex));
+          CacheValue.get(trxnLogIndex));
 
       omBucketInfo = getBucketInfo(omMetadataManager, volumeName, bucketName);
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyDeleteRequestWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyDeleteRequestWithFSO.java
@@ -18,7 +18,6 @@
 
 package org.apache.hadoop.ozone.om.request.key;
 
-import com.google.common.base.Optional;
 import org.apache.hadoop.hdds.utils.db.cache.CacheKey;
 import org.apache.hadoop.hdds.utils.db.cache.CacheValue;
 import org.apache.hadoop.ozone.audit.AuditLogger;
@@ -145,12 +144,12 @@ public class OMKeyDeleteRequestWithFSO extends OMKeyDeleteRequest {
         // Update dir cache.
         omMetadataManager.getDirectoryTable().addCacheEntry(
                 new CacheKey<>(ozonePathKey),
-                new CacheValue<>(Optional.absent(), trxnLogIndex));
+                CacheValue.get(trxnLogIndex));
       } else {
         // Update table cache.
         omMetadataManager.getKeyTable(getBucketLayout()).addCacheEntry(
                 new CacheKey<>(ozonePathKey),
-                new CacheValue<>(Optional.absent(), trxnLogIndex));
+                CacheValue.get(trxnLogIndex));
       }
 
       omBucketInfo = getBucketInfo(omMetadataManager, volumeName, bucketName);

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyRenameRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyRenameRequest.java
@@ -21,7 +21,6 @@ package org.apache.hadoop.ozone.om.request.key;
 import java.io.IOException;
 import java.util.Map;
 
-import com.google.common.base.Optional;
 import com.google.common.base.Preconditions;
 import org.apache.hadoop.ozone.OmUtils;
 import org.apache.hadoop.ozone.OzoneConsts;
@@ -201,10 +200,10 @@ public class OMKeyRenameRequest extends OMKeyRequest {
           omMetadataManager.getKeyTable(getBucketLayout());
 
       keyTable.addCacheEntry(new CacheKey<>(fromKey),
-          new CacheValue<>(Optional.absent(), trxnLogIndex));
+          CacheValue.get(trxnLogIndex));
 
       keyTable.addCacheEntry(new CacheKey<>(toKey),
-          new CacheValue<>(Optional.of(fromKeyValue), trxnLogIndex));
+          CacheValue.get(trxnLogIndex, fromKeyValue));
 
       omClientResponse = new OMKeyRenameResponse(omResponse
           .setRenameKeyResponse(RenameKeyResponse.newBuilder()).build(),

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyRenameRequestWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyRenameRequestWithFSO.java
@@ -18,7 +18,6 @@
 
 package org.apache.hadoop.ozone.om.request.key;
 
-import com.google.common.base.Optional;
 import org.apache.hadoop.hdds.utils.db.Table;
 import org.apache.hadoop.hdds.utils.db.cache.CacheKey;
 import org.apache.hadoop.hdds.utils.db.cache.CacheValue;
@@ -295,20 +294,20 @@ public class OMKeyRenameRequestWithFSO extends OMKeyRenameRequest {
     // Add from_key and to_key details into cache.
     if (isRenameDirectory) {
       dirTable.addCacheEntry(new CacheKey<>(dbFromKey),
-              new CacheValue<>(Optional.absent(), trxnLogIndex));
+              CacheValue.get(trxnLogIndex));
 
       dirTable.addCacheEntry(new CacheKey<>(dbToKey),
-              new CacheValue<>(Optional.of(OMFileRequest.
-                              getDirectoryInfo(fromKeyValue)), trxnLogIndex));
+          CacheValue.get(trxnLogIndex,
+              OMFileRequest.getDirectoryInfo(fromKeyValue)));
     } else {
       Table<String, OmKeyInfo> keyTable =
           metadataMgr.getKeyTable(getBucketLayout());
 
       keyTable.addCacheEntry(new CacheKey<>(dbFromKey),
-              new CacheValue<>(Optional.absent(), trxnLogIndex));
+              CacheValue.get(trxnLogIndex));
 
       keyTable.addCacheEntry(new CacheKey<>(dbToKey),
-              new CacheValue<>(Optional.of(fromKeyValue), trxnLogIndex));
+              CacheValue.get(trxnLogIndex, fromKeyValue));
     }
 
     OMClientResponse omClientResponse = new OMKeyRenameResponseWithFSO(
@@ -330,8 +329,8 @@ public class OMKeyRenameRequestWithFSO extends OMKeyRenameRequest {
       String dbToKeyParent = omMetadataManager.getOzonePathKey(volumeId,
           bucketId, keyParent.getParentObjectID(), keyParent.getFileName());
       dirTable.addCacheEntry(new CacheKey<>(dbToKeyParent),
-          new CacheValue<>(Optional.of(OMFileRequest
-              .getDirectoryInfo(keyParent)), trxnLogIndex));
+          CacheValue.get(trxnLogIndex,
+              OMFileRequest.getDirectoryInfo(keyParent)));
     } else {
       // For FSO a bucket is root of the filesystem, so rename an
       // object at the root of a bucket need change bucket's modificationTime
@@ -344,7 +343,7 @@ public class OMKeyRenameRequestWithFSO extends OMKeyRenameRequest {
           bucketInfo.getVolumeName(), bucketInfo.getBucketName());
       omMetadataManager.getBucketTable().addCacheEntry(
           new CacheKey<>(bucketKey),
-          new CacheValue<>(Optional.of(bucketInfo), trxnLogIndex));
+          CacheValue.get(trxnLogIndex, bucketInfo));
     }
   }
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeysDeleteRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeysDeleteRequest.java
@@ -18,7 +18,6 @@
 
 package org.apache.hadoop.ozone.om.request.key;
 
-import com.google.common.base.Optional;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.hadoop.hdds.utils.db.cache.CacheKey;
 import org.apache.hadoop.hdds.utils.db.cache.CacheValue;
@@ -275,7 +274,7 @@ public class OMKeysDeleteRequest extends OMKeyRequest {
           new CacheKey<>(omMetadataManager
               .getOzoneKey(omKeyInfo.getVolumeName(), omKeyInfo.getBucketName(),
                   omKeyInfo.getKeyName())),
-          new CacheValue<>(Optional.absent(), trxnLogIndex));
+          CacheValue.get(trxnLogIndex));
 
       omKeyInfo.setUpdateID(trxnLogIndex, ozoneManager.isRatisEnabled());
       quotaReleased += sumBlockLengths(omKeyInfo);

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeysRenameRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeysRenameRequest.java
@@ -18,7 +18,6 @@
 
 package org.apache.hadoop.ozone.om.request.key;
 
-import com.google.common.base.Optional;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.hadoop.hdds.utils.db.Table;
 import org.apache.hadoop.hdds.utils.db.cache.CacheKey;
@@ -206,9 +205,9 @@ public class OMKeysRenameRequest extends OMKeyRequest {
         Table<String, OmKeyInfo> keyTable =
             omMetadataManager.getKeyTable(getBucketLayout());
         keyTable.addCacheEntry(new CacheKey<>(fromKey),
-            new CacheValue<>(Optional.absent(), trxnLogIndex));
+            CacheValue.get(trxnLogIndex));
         keyTable.addCacheEntry(new CacheKey<>(toKey),
-            new CacheValue<>(Optional.of(fromKeyValue), trxnLogIndex));
+            CacheValue.get(trxnLogIndex, fromKeyValue));
         renamedKeys.put(fromKeyName, toKeyName);
         fromKeyAndToKeyInfo.put(fromKeyName, fromKeyValue);
       }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMOpenKeysDeleteRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMOpenKeysDeleteRequest.java
@@ -17,7 +17,6 @@
  */
 package org.apache.hadoop.ozone.om.request.key;
 
-import com.google.common.base.Optional;
 import org.apache.hadoop.hdds.utils.db.cache.CacheKey;
 import org.apache.hadoop.hdds.utils.db.cache.CacheValue;
 import org.apache.hadoop.ozone.om.OMMetadataManager;
@@ -174,7 +173,7 @@ public class OMOpenKeysDeleteRequest extends OMKeyRequest {
           // Update openKeyTable cache.
           omMetadataManager.getOpenKeyTable(getBucketLayout()).addCacheEntry(
               new CacheKey<>(fullKeyName),
-              new CacheValue<>(Optional.absent(), trxnLogIndex));
+              CacheValue.get(trxnLogIndex));
 
           ozoneManager.getMetrics().incNumOpenKeysDeleted();
           LOG.debug("Open key {} deleted.", fullKeyName);

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OmKeysDeleteRequestWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OmKeysDeleteRequestWithFSO.java
@@ -17,7 +17,6 @@
  */
 package org.apache.hadoop.ozone.om.request.key;
 
-import com.google.common.base.Optional;
 import org.apache.hadoop.hdds.utils.db.cache.CacheKey;
 import org.apache.hadoop.hdds.utils.db.cache.CacheValue;
 import org.apache.hadoop.ozone.om.OMMetadataManager;
@@ -109,7 +108,7 @@ public class OmKeysDeleteRequestWithFSO extends OMKeysDeleteRequest {
               .getOzonePathKey(volumeId, bucketId,
                       omKeyInfo.getParentObjectID(),
                       omKeyInfo.getFileName())),
-          new CacheValue<>(Optional.absent(), trxnLogIndex));
+          CacheValue.get(trxnLogIndex));
 
       omKeyInfo.setUpdateID(trxnLogIndex, ozoneManager.isRatisEnabled());
       quotaReleased += sumBlockLengths(omKeyInfo);
@@ -124,7 +123,7 @@ public class OmKeysDeleteRequestWithFSO extends OMKeysDeleteRequest {
               omMetadataManager.getOzonePathKey(volumeId, bucketId,
                       omKeyInfo.getParentObjectID(),
                   omKeyInfo.getFileName())),
-          new CacheValue<>(Optional.absent(), trxnLogIndex));
+          CacheValue.get(trxnLogIndex));
 
       omKeyInfo.setUpdateID(trxnLogIndex, ozoneManager.isRatisEnabled());
       quotaReleased += sumBlockLengths(omKeyInfo);

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/acl/OMKeyAclRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/acl/OMKeyAclRequest.java
@@ -21,7 +21,6 @@ package org.apache.hadoop.ozone.om.request.key.acl;
 import java.io.IOException;
 import java.util.Map;
 
-import com.google.common.base.Optional;
 import org.apache.hadoop.ozone.audit.AuditLogger;
 import org.apache.hadoop.ozone.om.OMMetadataManager;
 import org.apache.hadoop.ozone.om.OzoneManager;
@@ -126,7 +125,7 @@ public abstract class OMKeyAclRequest extends OMClientRequest {
       // update cache.
       omMetadataManager.getKeyTable(getBucketLayout())
           .addCacheEntry(new CacheKey<>(dbKey),
-              new CacheValue<>(Optional.of(omKeyInfo), trxnLogIndex));
+              CacheValue.get(trxnLogIndex, omKeyInfo));
 
       omClientResponse = onSuccess(omResponse, omKeyInfo, operationResult);
       result = Result.SUCCESS;

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/acl/OMKeyAclRequestWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/acl/OMKeyAclRequestWithFSO.java
@@ -17,7 +17,6 @@
  */
 package org.apache.hadoop.ozone.om.request.key.acl;
 
-import com.google.common.base.Optional;
 import org.apache.hadoop.hdds.utils.db.Table;
 import org.apache.hadoop.hdds.utils.db.cache.CacheKey;
 import org.apache.hadoop.hdds.utils.db.cache.CacheValue;
@@ -121,12 +120,12 @@ public abstract class OMKeyAclRequestWithFSO extends OMKeyAclRequest {
         Table<String, OmDirectoryInfo> dirTable =
             omMetadataManager.getDirectoryTable();
         dirTable.addCacheEntry(new CacheKey<>(dbKey),
-            new CacheValue<>(Optional.of(OMFileRequest.
-                getDirectoryInfo(omKeyInfo)), trxnLogIndex));
+            CacheValue.get(trxnLogIndex,
+                OMFileRequest.getDirectoryInfo(omKeyInfo)));
       } else {
         omMetadataManager.getKeyTable(getBucketLayout())
             .addCacheEntry(new CacheKey<>(dbKey),
-                new CacheValue<>(Optional.of(omKeyInfo), trxnLogIndex));
+                CacheValue.get(trxnLogIndex, omKeyInfo));
       }
       omClientResponse = onSuccess(omResponse, omKeyInfo, operationResult,
           isDirectory, volumeId, bucketId);

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/acl/prefix/OMPrefixAclRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/acl/prefix/OMPrefixAclRequest.java
@@ -21,7 +21,6 @@ package org.apache.hadoop.ozone.om.request.key.acl.prefix;
 import java.io.IOException;
 import java.util.Map;
 
-import com.google.common.base.Optional;
 import org.apache.hadoop.ozone.audit.AuditLogger;
 import org.apache.hadoop.ozone.om.OMMetadataManager;
 import org.apache.hadoop.ozone.om.OMMetrics;
@@ -120,13 +119,12 @@ public abstract class OMPrefixAclRequest extends OMClientRequest {
           omPrefixInfo.getAcls().size() == 0) {
         omMetadataManager.getPrefixTable().addCacheEntry(
             new CacheKey<>(prefixPath),
-            new CacheValue<>(Optional.absent(), trxnLogIndex));
+            CacheValue.get(trxnLogIndex));
       } else {
         // update cache.
         omMetadataManager.getPrefixTable().addCacheEntry(
             new CacheKey<>(prefixPath),
-            new CacheValue<>(Optional.of(omPrefixInfo),
-                trxnLogIndex));
+            CacheValue.get(trxnLogIndex, omPrefixInfo));
       }
 
       opResult  = operationResult.isSuccess();

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3InitiateMultipartUploadRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3InitiateMultipartUploadRequest.java
@@ -18,7 +18,6 @@
 
 package org.apache.hadoop.ozone.om.request.s3.multipart;
 
-import com.google.common.base.Optional;
 import com.google.common.base.Preconditions;
 import org.apache.hadoop.hdds.client.ReplicationConfig;
 import org.apache.hadoop.ozone.audit.OMAction;
@@ -214,10 +213,10 @@ public class S3InitiateMultipartUploadRequest extends OMKeyRequest {
       // Add to cache
       omMetadataManager.getOpenKeyTable(getBucketLayout()).addCacheEntry(
           new CacheKey<>(multipartKey),
-          new CacheValue<>(Optional.of(omKeyInfo), transactionLogIndex));
+          CacheValue.get(transactionLogIndex, omKeyInfo));
       omMetadataManager.getMultipartInfoTable().addCacheEntry(
           new CacheKey<>(multipartKey),
-          new CacheValue<>(Optional.of(multipartKeyInfo), transactionLogIndex));
+          CacheValue.get(transactionLogIndex, multipartKeyInfo));
 
       omClientResponse =
           new S3InitiateMultipartUploadResponse(

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3MultipartUploadAbortRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3MultipartUploadAbortRequest.java
@@ -22,7 +22,6 @@ import java.io.IOException;
 import java.util.Iterator;
 import java.util.Map;
 
-import com.google.common.base.Optional;
 import org.apache.hadoop.ozone.om.helpers.BucketLayout;
 import org.apache.hadoop.ozone.om.helpers.OmBucketInfo;
 import org.apache.hadoop.ozone.om.helpers.QuotaUtil;
@@ -186,10 +185,10 @@ public class S3MultipartUploadAbortRequest extends OMKeyRequest {
       // in delete table are not used by any read/write operations.
       omMetadataManager.getOpenKeyTable(getBucketLayout())
           .addCacheEntry(new CacheKey<>(multipartOpenKey),
-              new CacheValue<>(Optional.absent(), trxnLogIndex));
+              CacheValue.get(trxnLogIndex));
       omMetadataManager.getMultipartInfoTable()
           .addCacheEntry(new CacheKey<>(multipartKey),
-              new CacheValue<>(Optional.absent(), trxnLogIndex));
+              CacheValue.get(trxnLogIndex));
 
       omClientResponse = getOmClientResponse(ozoneManager, multipartKeyInfo,
           multipartKey, multipartOpenKey, omResponse, omBucketInfo);

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3MultipartUploadCommitPartRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3MultipartUploadCommitPartRequest.java
@@ -19,7 +19,6 @@
 package org.apache.hadoop.ozone.om.request.s3.multipart;
 
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.base.Optional;
 import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.hadoop.ozone.audit.OMAction;
 import org.apache.hadoop.ozone.om.OMMetadataManager;
@@ -219,12 +218,11 @@ public class S3MultipartUploadCommitPartRequest extends OMKeyRequest {
       // read/write requests that info for validation.
       omMetadataManager.getMultipartInfoTable().addCacheEntry(
           new CacheKey<>(multipartKey),
-          new CacheValue<>(Optional.of(multipartKeyInfo),
-              trxnLogIndex));
+          CacheValue.get(trxnLogIndex, multipartKeyInfo));
 
       omMetadataManager.getOpenKeyTable(getBucketLayout()).addCacheEntry(
           new CacheKey<>(openKey),
-          new CacheValue<>(Optional.absent(), trxnLogIndex));
+          CacheValue.get(trxnLogIndex));
 
       omBucketInfo = getBucketInfo(omMetadataManager, volumeName, bucketName);
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3MultipartUploadCompleteRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3MultipartUploadCompleteRequest.java
@@ -18,7 +18,6 @@
 
 package org.apache.hadoop.ozone.om.request.s3.multipart;
 
-import com.google.common.base.Optional;
 import org.apache.commons.codec.digest.DigestUtils;
 import org.apache.commons.lang3.StringUtils;
 
@@ -458,7 +457,7 @@ public class S3MultipartUploadCompleteRequest extends OMKeyRequest {
     // Add key entry to file table.
     omMetadataManager.getKeyTable(getBucketLayout())
         .addCacheEntry(new CacheKey<>(dbOzoneKey),
-            new CacheValue<>(Optional.of(omKeyInfo), transactionLogIndex));
+            CacheValue.get(transactionLogIndex, omKeyInfo));
   }
 
   private int getPartsListSize(String requestedVolume,
@@ -575,10 +574,10 @@ public class S3MultipartUploadCompleteRequest extends OMKeyRequest {
     omMetadataManager.getOpenKeyTable(getBucketLayout())
         .addCacheEntry(
             new CacheKey<>(dbMultipartOpenKey),
-            new CacheValue<>(Optional.absent(), transactionLogIndex));
+            CacheValue.get(transactionLogIndex));
     omMetadataManager.getMultipartInfoTable().addCacheEntry(
         new CacheKey<>(dbMultipartKey),
-        new CacheValue<>(Optional.absent(), transactionLogIndex));
+        CacheValue.get(transactionLogIndex));
 
     // Here, omBucketInfo can be null if its size has not changed. No need to
     // update the bucket info unless its size has changed. We never want to
@@ -586,7 +585,7 @@ public class S3MultipartUploadCompleteRequest extends OMKeyRequest {
     if (omBucketInfo != null) {
       omMetadataManager.getBucketTable().addCacheEntry(
           new CacheKey<>(dbBucketKey),
-          new CacheValue<>(Optional.of(omBucketInfo), transactionLogIndex));
+          CacheValue.get(transactionLogIndex, omBucketInfo));
     }
   }
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/tenant/OMSetRangerServiceVersionRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/tenant/OMSetRangerServiceVersionRequest.java
@@ -35,7 +35,6 @@ import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.SetRang
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.google.common.base.Optional;
 
 /**
  * Handles OMSetRangerServiceVersionRequest.
@@ -68,7 +67,7 @@ public class OMSetRangerServiceVersionRequest extends OMClientRequest {
 
     omMetadataManager.getMetaTable().addCacheEntry(
         new CacheKey<>(OzoneConsts.RANGER_OZONE_SERVICE_VERSION_KEY),
-        new CacheValue<>(Optional.of(proposedVersionStr), transactionLogIndex));
+        CacheValue.get(transactionLogIndex, proposedVersionStr));
     omResponse.setSetRangerServiceVersionResponse(
         SetRangerServiceVersionResponse.newBuilder().build());
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/tenant/OMTenantAssignAdminRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/tenant/OMTenantAssignAdminRequest.java
@@ -205,8 +205,7 @@ public class OMTenantAssignAdminRequest extends OMClientRequest {
               .build();
       omMetadataManager.getTenantAccessIdTable().addCacheEntry(
           new CacheKey<>(accessId),
-          new CacheValue<>(Optional.of(newOmDBAccessIdInfo),
-              transactionLogIndex));
+          CacheValue.get(transactionLogIndex, newOmDBAccessIdInfo));
 
       // Update tenant cache
       multiTenantManager.getCacheOp().assignTenantAdmin(accessId, delegated);

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/tenant/OMTenantAssignUserAccessIdRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/tenant/OMTenantAssignUserAccessIdRequest.java
@@ -18,7 +18,6 @@
  */
 package org.apache.hadoop.ozone.om.request.s3.tenant;
 
-import com.google.common.base.Optional;
 import com.google.common.base.Preconditions;
 import org.apache.commons.codec.digest.DigestUtils;
 import org.apache.hadoop.hdds.utils.db.cache.CacheKey;
@@ -284,7 +283,7 @@ public class OMTenantAssignUserAccessIdRequest extends OMClientRequest {
           .build();
       omMetadataManager.getTenantAccessIdTable().addCacheEntry(
           new CacheKey<>(accessId),
-          new CacheValue<>(Optional.of(omDBAccessIdInfo), transactionLogIndex));
+          CacheValue.get(transactionLogIndex, omDBAccessIdInfo));
 
       // Add to principalToAccessIdsTable
       if (principalInfo == null) {
@@ -296,8 +295,7 @@ public class OMTenantAssignUserAccessIdRequest extends OMClientRequest {
       }
       omMetadataManager.getPrincipalToAccessIdsTable().addCacheEntry(
           new CacheKey<>(userPrincipal),
-          new CacheValue<>(Optional.of(principalInfo),
-              transactionLogIndex));
+          CacheValue.get(transactionLogIndex, principalInfo));
 
       // Expect accessId absence from S3SecretTable
       ozoneManager.getS3SecretManager()

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/tenant/OMTenantCreateRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/tenant/OMTenantCreateRequest.java
@@ -18,7 +18,6 @@
  */
 package org.apache.hadoop.ozone.om.request.s3.tenant;
 
-import com.google.common.base.Optional;
 import com.google.common.base.Preconditions;
 import org.apache.hadoop.hdds.utils.db.cache.CacheKey;
 import org.apache.hadoop.hdds.utils.db.cache.CacheValue;
@@ -312,7 +311,7 @@ public class OMTenantCreateRequest extends OMVolumeRequest {
           bucketNamespacePolicyName, bucketPolicyName);
       omMetadataManager.getTenantStateTable().addCacheEntry(
           new CacheKey<>(tenantId),
-          new CacheValue<>(Optional.of(omDBTenantState), transactionLogIndex));
+          CacheValue.get(transactionLogIndex, omDBTenantState));
 
       // Update tenant cache
       multiTenantManager.getCacheOp().createTenant(

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/tenant/OMTenantDeleteRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/tenant/OMTenantDeleteRequest.java
@@ -18,7 +18,6 @@
  */
 package org.apache.hadoop.ozone.om.request.s3.tenant;
 
-import com.google.common.base.Optional;
 import com.google.common.base.Preconditions;
 import org.apache.hadoop.hdds.utils.db.cache.CacheKey;
 import org.apache.hadoop.hdds.utils.db.cache.CacheValue;
@@ -164,7 +163,7 @@ public class OMTenantDeleteRequest extends OMVolumeRequest {
       // Invalidate cache entry
       omMetadataManager.getTenantStateTable().addCacheEntry(
           new CacheKey<>(tenantId),
-          new CacheValue<>(Optional.absent(), transactionLogIndex));
+          CacheValue.get(transactionLogIndex));
 
       // Decrement volume refCount
       if (decVolumeRefCount) {
@@ -183,7 +182,7 @@ public class OMTenantDeleteRequest extends OMVolumeRequest {
         final String dbVolumeKey = omMetadataManager.getVolumeKey(volumeName);
         omMetadataManager.getVolumeTable().addCacheEntry(
             new CacheKey<>(dbVolumeKey),
-            new CacheValue<>(Optional.of(omVolumeArgs), transactionLogIndex));
+            CacheValue.get(transactionLogIndex, omVolumeArgs));
 
         // TODO: Set response dbVolumeKey?
       }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/tenant/OMTenantRevokeAdminRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/tenant/OMTenantRevokeAdminRequest.java
@@ -195,8 +195,7 @@ public class OMTenantRevokeAdminRequest extends OMClientRequest {
               .build();
       omMetadataManager.getTenantAccessIdTable().addCacheEntry(
           new CacheKey<>(accessId),
-          new CacheValue<>(Optional.of(newOmDBAccessIdInfo),
-              transactionLogIndex));
+          CacheValue.get(transactionLogIndex, newOmDBAccessIdInfo));
 
       // Update tenant cache
       multiTenantManager.getCacheOp().revokeTenantAdmin(accessId);

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/security/OMCancelDelegationTokenRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/security/OMCancelDelegationTokenRequest.java
@@ -18,7 +18,6 @@
 
 package org.apache.hadoop.ozone.om.request.security;
 
-import com.google.common.base.Optional;
 import org.apache.hadoop.ozone.audit.AuditLogger;
 import org.apache.hadoop.ozone.audit.OMAction;
 import org.apache.hadoop.ozone.om.OMMetadataManager;
@@ -111,7 +110,7 @@ public class OMCancelDelegationTokenRequest extends OMClientRequest {
       // Update Cache.
       omMetadataManager.getDelegationTokenTable().addCacheEntry(
           new CacheKey<>(ozoneTokenIdentifier),
-          new CacheValue<>(Optional.absent(), transactionLogIndex));
+          CacheValue.get(transactionLogIndex));
 
       omClientResponse =
           new OMCancelDelegationTokenResponse(ozoneTokenIdentifier,

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/security/OMGetDelegationTokenRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/security/OMGetDelegationTokenRequest.java
@@ -18,7 +18,6 @@
 
 package org.apache.hadoop.ozone.om.request.security;
 
-import com.google.common.base.Optional;
 import org.apache.hadoop.io.Text;
 import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.hadoop.ozone.audit.AuditLogger;
@@ -185,7 +184,7 @@ public class OMGetDelegationTokenRequest extends OMClientRequest {
      // Update Cache.
       omMetadataManager.getDelegationTokenTable().addCacheEntry(
           new CacheKey<>(ozoneTokenIdentifier),
-          new CacheValue<>(Optional.of(renewTime), transactionLogIndex));
+          CacheValue.get(transactionLogIndex, renewTime));
 
       omClientResponse =
           new OMGetDelegationTokenResponse(ozoneTokenIdentifier, renewTime,

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/security/OMRenewDelegationTokenRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/security/OMRenewDelegationTokenRequest.java
@@ -28,7 +28,6 @@ import org.apache.hadoop.ozone.om.request.util.OmResponseUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.google.common.base.Optional;
 import org.apache.hadoop.ozone.om.OMMetadataManager;
 import org.apache.hadoop.ozone.om.OzoneManager;
 import org.apache.hadoop.ozone.om.ratis.utils.OzoneManagerDoubleBufferHelper;
@@ -168,7 +167,7 @@ public class OMRenewDelegationTokenRequest extends OMClientRequest {
       // Update Cache.
       omMetadataManager.getDelegationTokenTable().addCacheEntry(
           new CacheKey<>(ozoneTokenIdentifier),
-          new CacheValue<>(Optional.of(renewTime), transactionLogIndex));
+          CacheValue.get(transactionLogIndex, renewTime));
 
       omClientResponse =
           new OMRenewDelegationTokenResponse(ozoneTokenIdentifier, renewTime,

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/snapshot/OMSnapshotCreateRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/snapshot/OMSnapshotCreateRequest.java
@@ -18,7 +18,6 @@
 
 package org.apache.hadoop.ozone.om.request.snapshot;
 
-import com.google.common.base.Optional;
 import org.apache.commons.lang.StringUtils;
 import org.apache.hadoop.hdds.utils.db.RDBStore;
 import org.apache.hadoop.hdds.utils.db.cache.CacheKey;
@@ -173,7 +172,7 @@ public class OMSnapshotCreateRequest extends OMClientRequest {
 
       omMetadataManager.getSnapshotInfoTable()
           .addCacheEntry(new CacheKey<>(key),
-            new CacheValue<>(Optional.of(snapshotInfo), transactionLogIndex));
+            CacheValue.get(transactionLogIndex, snapshotInfo));
 
       omResponse.setCreateSnapshotResponse(
           CreateSnapshotResponse.newBuilder()

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/snapshot/OMSnapshotDeleteRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/snapshot/OMSnapshotDeleteRequest.java
@@ -18,7 +18,6 @@
 
 package org.apache.hadoop.ozone.om.request.snapshot;
 
-import com.google.common.base.Optional;
 import org.apache.hadoop.hdds.utils.db.cache.CacheKey;
 import org.apache.hadoop.hdds.utils.db.cache.CacheValue;
 import org.apache.hadoop.ozone.OmUtils;
@@ -178,7 +177,7 @@ public class OMSnapshotDeleteRequest extends OMClientRequest {
       // Update table cache first
       omMetadataManager.getSnapshotInfoTable().addCacheEntry(
           new CacheKey<>(tableKey),
-          new CacheValue<>(Optional.of(snapshotInfo), transactionLogIndex));
+          CacheValue.get(transactionLogIndex, snapshotInfo));
 
       omResponse.setDeleteSnapshotResponse(
           DeleteSnapshotResponse.newBuilder());

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/upgrade/OMFinalizeUpgradeRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/upgrade/OMFinalizeUpgradeRequest.java
@@ -43,7 +43,6 @@ import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 
-import com.google.common.base.Optional;
 
 /**
  * Handles finalizeUpgrade request.
@@ -95,8 +94,7 @@ public class OMFinalizeUpgradeRequest extends OMClientRequest {
       int lV = ozoneManager.getVersionManager().getMetadataLayoutVersion();
       omMetadataManager.getMetaTable().addCacheEntry(
           new CacheKey<>(LAYOUT_VERSION_KEY),
-          new CacheValue<>(Optional.of(String.valueOf(lV)),
-              transactionLogIndex));
+          CacheValue.get(transactionLogIndex, String.valueOf(lV)));
 
       FinalizeUpgradeResponse omResponse =
           FinalizeUpgradeResponse.newBuilder()

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/volume/OMVolumeDeleteRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/volume/OMVolumeDeleteRequest.java
@@ -20,7 +20,6 @@ package org.apache.hadoop.ozone.om.request.volume;
 
 import java.io.IOException;
 
-import com.google.common.base.Optional;
 import com.google.common.base.Preconditions;
 import org.apache.hadoop.ozone.om.ratis.utils.OzoneManagerDoubleBufferHelper;
 import org.apache.hadoop.ozone.om.request.util.OmResponseUtil;
@@ -131,11 +130,10 @@ public class OMVolumeDeleteRequest extends OMVolumeRequest {
           transactionLogIndex);
 
       omMetadataManager.getUserTable().addCacheEntry(new CacheKey<>(dbUserKey),
-          new CacheValue<>(Optional.of(newVolumeList), transactionLogIndex));
+          CacheValue.get(transactionLogIndex, newVolumeList));
 
       omMetadataManager.getVolumeTable().addCacheEntry(
-          new CacheKey<>(dbVolumeKey), new CacheValue<>(Optional.absent(),
-              transactionLogIndex));
+          new CacheKey<>(dbVolumeKey), CacheValue.get(transactionLogIndex));
 
       omResponse.setDeleteVolumeResponse(
           DeleteVolumeResponse.newBuilder().build());

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/volume/OMVolumeRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/volume/OMVolumeRequest.java
@@ -18,7 +18,6 @@
 
 package org.apache.hadoop.ozone.om.request.volume;
 
-import com.google.common.base.Optional;
 import org.apache.hadoop.ozone.om.OMMetadataManager;
 import org.apache.hadoop.ozone.om.exceptions.OMException;
 import org.apache.hadoop.ozone.om.helpers.OmVolumeArgs;
@@ -138,11 +137,11 @@ public abstract class OMVolumeRequest extends OMClientRequest {
       String dbUserKey, long transactionLogIndex) {
     // Update cache: Update user and volume cache.
     omMetadataManager.getUserTable().addCacheEntry(new CacheKey<>(dbUserKey),
-        new CacheValue<>(Optional.of(volumeList), transactionLogIndex));
+        CacheValue.get(transactionLogIndex, volumeList));
 
     omMetadataManager.getVolumeTable().addCacheEntry(
         new CacheKey<>(dbVolumeKey),
-        new CacheValue<>(Optional.of(omVolumeArgs), transactionLogIndex));
+        CacheValue.get(transactionLogIndex, omVolumeArgs));
   }
 
   /**

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/volume/OMVolumeSetOwnerRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/volume/OMVolumeSetOwnerRequest.java
@@ -18,7 +18,6 @@
 
 package org.apache.hadoop.ozone.om.request.volume;
 
-import com.google.common.base.Optional;
 import com.google.common.base.Preconditions;
 import org.apache.hadoop.hdds.utils.db.cache.CacheKey;
 import org.apache.hadoop.hdds.utils.db.cache.CacheValue;
@@ -165,15 +164,13 @@ public class OMVolumeSetOwnerRequest extends OMVolumeRequest {
       // Update cache.
       omMetadataManager.getUserTable().addCacheEntry(
           new CacheKey<>(omMetadataManager.getUserKey(newOwner)),
-          new CacheValue<>(Optional.of(newOwnerVolumeList),
-              transactionLogIndex));
+          CacheValue.get(transactionLogIndex, newOwnerVolumeList));
       omMetadataManager.getUserTable().addCacheEntry(
           new CacheKey<>(omMetadataManager.getUserKey(oldOwner)),
-          new CacheValue<>(Optional.of(oldOwnerVolumeList),
-              transactionLogIndex));
+          CacheValue.get(transactionLogIndex, oldOwnerVolumeList));
       omMetadataManager.getVolumeTable().addCacheEntry(
           new CacheKey<>(omMetadataManager.getVolumeKey(volume)),
-          new CacheValue<>(Optional.of(omVolumeArgs), transactionLogIndex));
+          CacheValue.get(transactionLogIndex, omVolumeArgs));
 
       omResponse.setSetVolumePropertyResponse(
           SetVolumePropertyResponse.newBuilder().setResponse(true).build());

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/volume/OMVolumeSetQuotaRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/volume/OMVolumeSetQuotaRequest.java
@@ -22,7 +22,6 @@ import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 
-import com.google.common.base.Optional;
 import com.google.common.base.Preconditions;
 import org.apache.hadoop.ozone.om.exceptions.OMException;
 import org.apache.hadoop.ozone.om.helpers.OmBucketInfo;
@@ -152,7 +151,7 @@ public class OMVolumeSetQuotaRequest extends OMVolumeRequest {
       // update cache.
       omMetadataManager.getVolumeTable().addCacheEntry(
           new CacheKey<>(omMetadataManager.getVolumeKey(volume)),
-          new CacheValue<>(Optional.of(omVolumeArgs), transactionLogIndex));
+          CacheValue.get(transactionLogIndex, omVolumeArgs));
 
       omResponse.setSetVolumePropertyResponse(
           SetVolumePropertyResponse.newBuilder().build());

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/volume/acl/OMVolumeAclRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/volume/acl/OMVolumeAclRequest.java
@@ -18,7 +18,6 @@
 
 package org.apache.hadoop.ozone.om.request.volume.acl;
 
-import com.google.common.base.Optional;
 import org.apache.hadoop.hdds.scm.storage.CheckedBiFunction;
 import org.apache.hadoop.ozone.OzoneAcl;
 import org.apache.hadoop.ozone.OzoneConsts;
@@ -116,7 +115,7 @@ public abstract class OMVolumeAclRequest extends OMVolumeRequest {
         // update cache.
         omMetadataManager.getVolumeTable().addCacheEntry(
             new CacheKey<>(omMetadataManager.getVolumeKey(volume)),
-            new CacheValue<>(Optional.of(omVolumeArgs), trxnLogIndex));
+            CacheValue.get(trxnLogIndex, omVolumeArgs));
       }
 
       omClientResponse = onSuccess(omResponse, omVolumeArgs, applyAcl);

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestKeyManagerUnit.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestKeyManagerUnit.java
@@ -32,7 +32,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 
-import com.google.common.base.Optional;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.RandomUtils;
 import org.apache.hadoop.hdds.HddsConfigKeys;
@@ -337,8 +336,8 @@ public class TestKeyManagerUnit {
 
     metadataManager.getMultipartInfoTable().addCacheEntry(
         new CacheKey<>(metadataManager.getMultipartKey(volume, bucket, key,
-            uploadID)), new CacheValue<>(Optional.of(multipartKeyInfo),
-            RandomUtils.nextInt()));
+            uploadID)),
+        CacheValue.get(RandomUtils.nextInt(), multipartKeyInfo));
     return new OmMultipartInfo(volume, bucket, key, uploadID);
   }
 
@@ -346,8 +345,7 @@ public class TestKeyManagerUnit {
       String volume, String bucket, String key, String uploadID) {
     metadataManager.getMultipartInfoTable().addCacheEntry(
         new CacheKey<>(metadataManager.getMultipartKey(volume, bucket, key,
-            uploadID)), new CacheValue<>(Optional.absent(),
-            RandomUtils.nextInt()));
+            uploadID)), CacheValue.get(RandomUtils.nextInt()));
   }
 
   @Test

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestOMMultiTenantManagerImpl.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestOMMultiTenantManagerImpl.java
@@ -29,8 +29,8 @@ import java.io.IOException;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
-import com.google.common.base.Optional;
 
+import com.google.common.base.Optional;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.ozone.om.exceptions.OMException;
 import org.apache.hadoop.ozone.om.helpers.OmDBAccessIdInfo;

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestOmMetadataManager.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestOmMetadataManager.java
@@ -16,7 +16,6 @@
  */
 
 package org.apache.hadoop.ozone.om;
-import com.google.common.base.Optional;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.protocol.StorageType;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
@@ -335,7 +334,7 @@ public class TestOmMetadataManager {
 
     omMetadataManager.getBucketTable().addCacheEntry(
         new CacheKey<>(omMetadataManager.getBucketKey(volumeName, bucketName)),
-        new CacheValue<>(Optional.of(omBucketInfo), 1));
+        CacheValue.get(1, omBucketInfo));
   }
 
   @Test
@@ -501,7 +500,7 @@ public class TestOmMetadataManager {
         // Mark as deleted in cache.
         omMetadataManager.getKeyTable(getDefaultBucketLayout()).addCacheEntry(
             new CacheKey<>(key),
-            new CacheValue<>(Optional.absent(), 100L));
+            CacheValue.get(100L));
         deleteKeySet.add(key);
       }
     }

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/OMRequestTestUtils.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/OMRequestTestUtils.java
@@ -25,7 +25,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
 
-import com.google.common.base.Optional;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hdds.client.BlockID;
 import org.apache.hadoop.hdds.client.ReplicationConfig;
@@ -261,7 +260,7 @@ public final class OMRequestTestUtils {
       if (addToCache) {
         omMetadataManager.getOpenKeyTable(getDefaultBucketLayout())
             .addCacheEntry(new CacheKey<>(ozoneKey),
-                new CacheValue<>(Optional.of(omKeyInfo), trxnLogIndex));
+                CacheValue.get(trxnLogIndex, omKeyInfo));
       }
       omMetadataManager.getOpenKeyTable(getDefaultBucketLayout())
           .put(ozoneKey, omKeyInfo);
@@ -271,7 +270,7 @@ public final class OMRequestTestUtils {
       if (addToCache) {
         omMetadataManager.getKeyTable(getDefaultBucketLayout())
             .addCacheEntry(new CacheKey<>(ozoneKey),
-                new CacheValue<>(Optional.of(omKeyInfo), trxnLogIndex));
+                CacheValue.get(trxnLogIndex, omKeyInfo));
       }
       omMetadataManager.getKeyTable(getDefaultBucketLayout())
           .put(ozoneKey, omKeyInfo);
@@ -300,7 +299,7 @@ public final class OMRequestTestUtils {
 
     omMetadataManager.getKeyTable(getDefaultBucketLayout()).addCacheEntry(
         new CacheKey<>(omMetadataManager.getOzoneKey(volumeName, bucketName,
-            keyName)), new CacheValue<>(Optional.of(omKeyInfo), 1L));
+            keyName)), CacheValue.get(1L, omKeyInfo));
   }
 
   /**
@@ -345,7 +344,7 @@ public final class OMRequestTestUtils {
     if (addToCache) {
       omMetadataManager.getDirectoryTable().addCacheEntry(
               new CacheKey<>(ozoneKey),
-              new CacheValue<>(Optional.of(omDirInfo), trxnLogIndex));
+              CacheValue.get(trxnLogIndex, omDirInfo));
     }
     omMetadataManager.getDirectoryTable().put(ozoneKey, omDirInfo);
   }
@@ -383,7 +382,7 @@ public final class OMRequestTestUtils {
     if (addToCache) {
       omMetadataManager.getSnapshotInfoTable().addCacheEntry(
           new CacheKey<>(key),
-          new CacheValue<>(Optional.of(snapshotInfo), txnID));
+          CacheValue.get(txnID, snapshotInfo));
     }
     omMetadataManager.getSnapshotInfoTable().put(key, snapshotInfo);
   }
@@ -492,7 +491,7 @@ public final class OMRequestTestUtils {
     // Add to cache.
     omMetadataManager.getVolumeTable().addCacheEntry(
         new CacheKey<>(omMetadataManager.getVolumeKey(volumeName)),
-        new CacheValue<>(Optional.of(omVolumeArgs), 1L));
+        CacheValue.get(1L, omVolumeArgs));
   }
 
   /**
@@ -516,7 +515,7 @@ public final class OMRequestTestUtils {
     // Add to cache.
     omMetadataManager.getVolumeTable().addCacheEntry(
         new CacheKey<>(omMetadataManager.getVolumeKey(volumeName)),
-            new CacheValue<>(Optional.of(omVolumeArgs), 1L));
+            CacheValue.get(1L, omVolumeArgs));
   }
 
   /**
@@ -557,7 +556,7 @@ public final class OMRequestTestUtils {
     // Add to cache.
     omMetadataManager.getBucketTable().addCacheEntry(
         new CacheKey<>(omMetadataManager.getBucketKey(volumeName, bucketName)),
-        new CacheValue<>(Optional.of(omBucketInfo), 1L));
+        CacheValue.get(1L, omBucketInfo));
   }
 
   /**
@@ -579,7 +578,7 @@ public final class OMRequestTestUtils {
     // Add to cache.
     omMetadataManager.getBucketTable().addCacheEntry(
         new CacheKey<>(omMetadataManager.getBucketKey(volumeName, bucketName)),
-        new CacheValue<>(Optional.of(omBucketInfo), 1L));
+        CacheValue.get(1L, omBucketInfo));
   }
 
   public static OzoneManagerProtocolProtos.OMRequest createBucketRequest(
@@ -1178,7 +1177,7 @@ public final class OMRequestTestUtils {
         .put(dbKey, omKeyInfo);
     omMetadataManager.getKeyTable(getDefaultBucketLayout()).addCacheEntry(
         new CacheKey<>(dbKey),
-        new CacheValue<>(Optional.of(omKeyInfo), 1L));
+        CacheValue.get(1L, omKeyInfo));
   }
 
   /**
@@ -1195,7 +1194,7 @@ public final class OMRequestTestUtils {
     omMetadataManager.getBucketTable().put(dbBucketKey, omBucketInfo);
     omMetadataManager.getBucketTable().addCacheEntry(
         new CacheKey<>(dbBucketKey),
-        new CacheValue<>(Optional.of(omBucketInfo), 1L));
+        CacheValue.get(1L, omBucketInfo));
   }
 
   /**
@@ -1211,7 +1210,7 @@ public final class OMRequestTestUtils {
     omMetadataManager.getVolumeTable().put(dbVolumeKey, omVolumeArgs);
     omMetadataManager.getVolumeTable().addCacheEntry(
         new CacheKey<>(dbVolumeKey),
-        new CacheValue<>(Optional.of(omVolumeArgs), 1L));
+        CacheValue.get(1L, omVolumeArgs));
   }
 
   /**
@@ -1279,7 +1278,7 @@ public final class OMRequestTestUtils {
       if (addToCache) {
         omMetadataManager.getOpenKeyTable(BucketLayout.FILE_SYSTEM_OPTIMIZED)
             .addCacheEntry(new CacheKey<>(ozoneDBKey),
-                new CacheValue<>(Optional.of(omKeyInfo), trxnLogIndex));
+                CacheValue.get(trxnLogIndex, omKeyInfo));
       }
       omMetadataManager.getOpenKeyTable(BucketLayout.FILE_SYSTEM_OPTIMIZED)
           .put(ozoneDBKey, omKeyInfo);
@@ -1292,7 +1291,7 @@ public final class OMRequestTestUtils {
       if (addToCache) {
         omMetadataManager.getKeyTable(BucketLayout.FILE_SYSTEM_OPTIMIZED)
             .addCacheEntry(new CacheKey<>(ozoneDBKey),
-                new CacheValue<>(Optional.of(omKeyInfo), trxnLogIndex));
+                CacheValue.get(trxnLogIndex, omKeyInfo));
       }
       omMetadataManager.getKeyTable(BucketLayout.FILE_SYSTEM_OPTIMIZED)
           .put(ozoneDBKey, omKeyInfo);

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/file/TestOMDirectoryCreateRequestWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/file/TestOMDirectoryCreateRequestWithFSO.java
@@ -18,7 +18,6 @@
 
 package org.apache.hadoop.ozone.om.request.file;
 
-import com.google.common.base.Optional;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
@@ -430,7 +429,7 @@ public class TestOMDirectoryCreateRequestWithFSO {
     ++txnID;
     omMetadataManager.getKeyTable(getBucketLayout())
         .addCacheEntry(new CacheKey<>(ozoneFileName),
-            new CacheValue<>(Optional.of(omKeyInfo), txnID));
+            CacheValue.get(txnID, omKeyInfo));
     omMetadataManager.getKeyTable(getBucketLayout())
         .put(ozoneFileName, omKeyInfo);
 
@@ -509,7 +508,7 @@ public class TestOMDirectoryCreateRequestWithFSO {
     ++txnID;
     omMetadataManager.getKeyTable(getBucketLayout())
         .addCacheEntry(new CacheKey<>(ozoneKey),
-            new CacheValue<>(Optional.of(omKeyInfo), txnID));
+            CacheValue.get(txnID, omKeyInfo));
     omMetadataManager.getKeyTable(getBucketLayout()).put(ozoneKey, omKeyInfo);
 
     OMRequest omRequest = createDirectoryRequest(volumeName, bucketName,

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMDirectoriesPurgeRequestAndResponse.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMDirectoriesPurgeRequestAndResponse.java
@@ -18,7 +18,6 @@
 
 package org.apache.hadoop.ozone.om.request.key;
 
-import com.google.common.base.Optional;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
@@ -100,7 +99,7 @@ public class TestOMDirectoriesPurgeRequestAndResponse extends TestOMKeyRequest {
     omBucketInfo.incrUsedBytes(omKeyInfo.getDataSize());
     omBucketInfo.incrUsedNamespace(1L);
     omMetadataManager.getBucketTable().addCacheEntry(new CacheKey<>(bucketKey),
-        new CacheValue<>(Optional.of(omBucketInfo), 1L));
+        CacheValue.get(1L, omBucketInfo));
     omMetadataManager.getBucketTable().put(bucketKey, omBucketInfo);
   }
 
@@ -237,7 +236,7 @@ public class TestOMDirectoriesPurgeRequestAndResponse extends TestOMKeyRequest {
     omBucketInfo.incrUsedBytes(1000);
     omBucketInfo.incrUsedNamespace(100L);
     omMetadataManager.getBucketTable().addCacheEntry(new CacheKey<>(bucketKey),
-        new CacheValue<>(Optional.of(omBucketInfo), 1L));
+        CacheValue.get(1L, omBucketInfo));
     omMetadataManager.getBucketTable().put(bucketKey, omBucketInfo);
 
     // prevalidate bucket

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/snapshot/TestOMSnapshotDeleteRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/snapshot/TestOMSnapshotDeleteRequest.java
@@ -20,7 +20,6 @@
 
 package org.apache.hadoop.ozone.om.request.snapshot;
 
-import com.google.common.base.Optional;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.utils.db.cache.CacheKey;
 import org.apache.hadoop.hdds.utils.db.cache.CacheValue;
@@ -204,7 +203,7 @@ public class TestOMSnapshotDeleteRequest {
         snapshotInfo.getSnapshotStatus());
     omMetadataManager.getSnapshotInfoTable().addCacheEntry(
         new CacheKey<>(key),
-        new CacheValue<>(Optional.of(snapshotInfo), 1L));
+        CacheValue.get(1L, snapshotInfo));
 
     // Trigger validateAndUpdateCache
     OMClientResponse omClientResponse =

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/TestCleanupTableInfo.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/TestCleanupTableInfo.java
@@ -17,7 +17,6 @@
 
 package org.apache.hadoop.ozone.om.response;
 
-import com.google.common.base.Optional;
 import com.google.common.collect.Iterators;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.hadoop.hdds.client.BlockID;
@@ -246,7 +245,7 @@ public class TestCleanupTableInfo {
     om.getMetadataManager().getVolumeTable().put(volumeKey, volumeArgs);
     om.getMetadataManager().getVolumeTable().addCacheEntry(
         new CacheKey<>(volumeKey),
-        new CacheValue<>(Optional.of(volumeArgs), 2)
+        CacheValue.get(2, volumeArgs)
     );
   }
 
@@ -264,7 +263,7 @@ public class TestCleanupTableInfo {
     om.getMetadataManager().getBucketTable().put(bucketKey, bucketInfo);
     om.getMetadataManager().getBucketTable().addCacheEntry(
         new CacheKey<>(bucketKey),
-        new CacheValue<>(Optional.of(bucketInfo), 1)
+        CacheValue.get(1, bucketInfo)
     );
   }
 

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/file/TestOMDirectoryCreateResponseWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/file/TestOMDirectoryCreateResponseWithFSO.java
@@ -18,7 +18,6 @@
 
 package org.apache.hadoop.ozone.om.response.file;
 
-import com.google.common.base.Optional;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.protocol.StorageType;
 import org.apache.hadoop.hdds.utils.db.BatchOperation;
@@ -129,7 +128,7 @@ public class TestOMDirectoryCreateResponseWithFSO {
 
     omMetadataManager.getVolumeTable().addCacheEntry(
             new CacheKey<>(omMetadataManager.getVolumeKey(volumeName)),
-            new CacheValue<>(Optional.of(volumeArgs), 1));
+            CacheValue.get(1, volumeArgs));
   }
   private void addBucketToDB(String volumeName, String bucketName)
           throws IOException {
@@ -144,6 +143,6 @@ public class TestOMDirectoryCreateResponseWithFSO {
     omMetadataManager.getBucketTable().addCacheEntry(
             new CacheKey<>(omMetadataManager.getBucketKey(
                     volumeName, bucketName)),
-            new CacheValue<>(Optional.of(omBucketInfo), 1));
+            CacheValue.get(1, omBucketInfo));
   }
 }

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/key/TestOMKeyResponse.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/key/TestOMKeyResponse.java
@@ -22,7 +22,6 @@ import java.io.IOException;
 import java.util.Random;
 import java.util.UUID;
 
-import com.google.common.base.Optional;
 import org.apache.hadoop.hdds.protocol.StorageType;
 import org.apache.hadoop.hdds.utils.db.cache.CacheKey;
 import org.apache.hadoop.hdds.utils.db.cache.CacheValue;
@@ -94,7 +93,7 @@ public class TestOMKeyResponse {
 
     omMetadataManager.getVolumeTable().addCacheEntry(
             new CacheKey<>(omMetadataManager.getVolumeKey(volumeName)),
-            new CacheValue<>(Optional.of(volumeArgs), 1));
+            CacheValue.get(1, volumeArgs));
 
     omBucketInfo = OmBucketInfo.newBuilder()
             .setVolumeName(volumeName)
@@ -107,7 +106,7 @@ public class TestOMKeyResponse {
     omMetadataManager.getBucketTable().addCacheEntry(
             new CacheKey<>(omMetadataManager.getBucketKey(
                     volumeName, bucketName)),
-            new CacheValue<>(Optional.of(omBucketInfo), 1));
+            CacheValue.get(1, omBucketInfo));
   }
 
   @NotNull

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/key/TestOMKeysDeleteResponseWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/key/TestOMKeysDeleteResponseWithFSO.java
@@ -18,7 +18,6 @@
 
 package org.apache.hadoop.ozone.om.response.key;
 
-import com.google.common.base.Optional;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.hdds.utils.db.cache.CacheKey;
 import org.apache.hadoop.hdds.utils.db.cache.CacheValue;
@@ -167,7 +166,7 @@ public class TestOMKeysDeleteResponseWithFSO
   private void deleteBucket() throws IOException {
     omMetadataManager.getBucketTable().addCacheEntry(
         new CacheKey<>(omMetadataManager.getBucketKey(volumeName, bucketName)),
-        new CacheValue<>(Optional.absent(), 10001));
+        CacheValue.get(10001));
 
     OMBucketDeleteResponse omBucketDeleteResponse =
         new OMBucketDeleteResponse(OMResponse.newBuilder()

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/s3/multipart/TestS3MultipartResponse.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/s3/multipart/TestS3MultipartResponse.java
@@ -25,7 +25,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
 
-import com.google.common.base.Optional;
 import org.apache.hadoop.hdds.client.RatisReplicationConfig;
 import org.apache.hadoop.hdds.protocol.StorageType;
 import org.apache.hadoop.hdds.utils.db.cache.CacheKey;
@@ -358,7 +357,7 @@ public class TestS3MultipartResponse {
 
     omMetadataManager.getVolumeTable().addCacheEntry(
             new CacheKey<>(omMetadataManager.getVolumeKey(volumeName)),
-            new CacheValue<>(Optional.of(volumeArgs), 1));
+            CacheValue.get(1, volumeArgs));
   }
 
   public void addBucketToDB(String volumeName, String bucketName)
@@ -374,6 +373,6 @@ public class TestS3MultipartResponse {
     omMetadataManager.getBucketTable().addCacheEntry(
             new CacheKey<>(omMetadataManager.getBucketKey(
                     volumeName, bucketName)),
-            new CacheValue<>(Optional.of(omBucketInfo), 1));
+            CacheValue.get(1, omBucketInfo));
   }
 }

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/security/acl/TestOzoneNativeAuthorizer.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/security/acl/TestOzoneNativeAuthorizer.java
@@ -16,7 +16,6 @@
  */
 package org.apache.hadoop.ozone.security.acl;
 
-import com.google.common.base.Optional;
 import org.apache.commons.lang3.RandomUtils;
 import org.apache.hadoop.hdds.client.StandaloneReplicationConfig;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
@@ -312,7 +311,7 @@ public class TestOzoneNativeAuthorizer {
     omVolumeArgs.setAcls(ozoneAcls);
 
     metadataManager.getVolumeTable().addCacheEntry(new CacheKey<>(volumeKey),
-        new CacheValue<>(Optional.of(omVolumeArgs), 1L));
+        CacheValue.get(1L, omVolumeArgs));
   }
 
   private void setBucketAcl(List<OzoneAcl> ozoneAcls) throws IOException {
@@ -322,7 +321,7 @@ public class TestOzoneNativeAuthorizer {
     omBucketInfo.setAcls(ozoneAcls);
 
     metadataManager.getBucketTable().addCacheEntry(new CacheKey<>(bucketKey),
-        new CacheValue<>(Optional.of(omBucketInfo), 1L));
+        CacheValue.get(1L, omBucketInfo));
   }
 
   private void addVolumeAcl(OzoneAcl ozoneAcl) throws IOException {
@@ -333,7 +332,7 @@ public class TestOzoneNativeAuthorizer {
     omVolumeArgs.addAcl(ozoneAcl);
 
     metadataManager.getVolumeTable().addCacheEntry(new CacheKey<>(volumeKey),
-        new CacheValue<>(Optional.of(omVolumeArgs), 1L));
+        CacheValue.get(1L, omVolumeArgs));
   }
 
   private void addBucketAcl(OzoneAcl ozoneAcl) throws IOException {
@@ -343,7 +342,7 @@ public class TestOzoneNativeAuthorizer {
     omBucketInfo.addAcl(ozoneAcl);
 
     metadataManager.getBucketTable().addCacheEntry(new CacheKey<>(bucketKey),
-        new CacheValue<>(Optional.of(omBucketInfo), 1L));
+        CacheValue.get(1L, omBucketInfo));
   }
 
   private void resetAclsAndValidateAccess(OzoneObj obj,

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/security/acl/TestParentAcl.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/security/acl/TestParentAcl.java
@@ -18,7 +18,6 @@
 
 package org.apache.hadoop.ozone.security.acl;
 
-import com.google.common.base.Optional;
 import org.apache.commons.lang3.RandomUtils;
 import org.apache.hadoop.hdds.client.StandaloneReplicationConfig;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
@@ -267,7 +266,7 @@ public class TestParentAcl {
     omVolumeArgs.addAcl(ozoneAcl);
 
     metadataManager.getVolumeTable().addCacheEntry(new CacheKey<>(volumeKey),
-        new CacheValue<>(Optional.of(omVolumeArgs), 1L));
+        CacheValue.get(1L, omVolumeArgs));
   }
 
   private List<OzoneAcl> getVolumeAcls(String vol) throws IOException {
@@ -286,7 +285,7 @@ public class TestParentAcl {
     omVolumeArgs.setAcls(ozoneAcls);
 
     metadataManager.getVolumeTable().addCacheEntry(new CacheKey<>(volumeKey),
-        new CacheValue<>(Optional.of(omVolumeArgs), 1L));
+        CacheValue.get(1L, omVolumeArgs));
   }
 
   private void addKeyAcl(String vol, String buck, String key,
@@ -299,7 +298,7 @@ public class TestParentAcl {
 
     metadataManager.getKeyTable(getBucketLayout())
         .addCacheEntry(new CacheKey<>(objKey),
-            new CacheValue<>(Optional.of(omKeyInfo), 1L));
+            CacheValue.get(1L, omKeyInfo));
   }
 
   private void setKeyAcl(String vol, String buck, String key,
@@ -311,7 +310,7 @@ public class TestParentAcl {
 
     metadataManager.getKeyTable(getBucketLayout())
         .addCacheEntry(new CacheKey<>(objKey),
-            new CacheValue<>(Optional.of(omKeyInfo), 1L));
+            CacheValue.get(1L, omKeyInfo));
   }
 
   private void addBucketAcl(String vol, String buck, OzoneAcl ozoneAcl)
@@ -322,7 +321,7 @@ public class TestParentAcl {
     omBucketInfo.addAcl(ozoneAcl);
 
     metadataManager.getBucketTable().addCacheEntry(new CacheKey<>(bucketKey),
-        new CacheValue<>(Optional.of(omBucketInfo), 1L));
+        CacheValue.get(1L, omBucketInfo));
   }
 
   private List<OzoneAcl> getBucketAcls(String vol, String buck)
@@ -341,7 +340,7 @@ public class TestParentAcl {
     omBucketInfo.setAcls(ozoneAcls);
 
     metadataManager.getBucketTable().addCacheEntry(new CacheKey<>(bucketKey),
-        new CacheValue<>(Optional.of(omBucketInfo), 1L));
+        CacheValue.get(1L, omBucketInfo));
   }
 
   private static OzoneObjInfo createVolume(String volumeName)


### PR DESCRIPTION
## What changes were proposed in this pull request?

HDDS-7969 improved `CacheValue` to avoid use of `Optional`.  It replaced the old constructor with the new factory methods only in a few places.  This change replaces all remaining usage, but keeps the deprecated constructor (can be removed in the future).

https://issues.apache.org/jira/browse/HDDS-8285

## How was this patch tested?

Regular CI:
https://github.com/adoroszlai/hadoop-ozone/actions/runs/4531321429