### PR TITLE
HDDS-8288. Upgrade moment.js to 2.29.4

### DIFF
--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/pnpm-lock.yaml
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/pnpm-lock.yaml
@@ -15,7 +15,7 @@ dependencies:
   filesize: 6.1.0
   less: 3.11.3
   less-loader: 5.0.0_less@3.11.3
-  moment: 2.26.0
+  moment: 2.29.4
   plotly.js: 1.54.2
   pretty-ms: 5.1.0
   react: 16.13.1
@@ -3089,7 +3089,7 @@ packages:
       enquire.js: 2.1.6
       is-mobile: 2.2.1
       lodash: 4.17.15
-      moment: 2.26.0
+      moment: 2.29.4
       omit.js: 1.0.2
       prop-types: 15.7.2
       raf: 3.4.1
@@ -10692,10 +10692,10 @@ packages:
     hasBin: true
     resolution:
       integrity: sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==
-  /moment/2.26.0:
+  /moment/2.29.4:
     dev: false
     resolution:
-      integrity: sha512-oIixUO+OamkUkwjhAVE18rAMfRJNsNe/Stid/gwHSOfHrOtw9EhAY2AHvdKZ/k/MggcYELFCJz/Sn2pL8b8JMw==
+      integrity: sha512-5LC9SOxjSc2HF6vO2CyuTDNivEdoz2IvyJJGj6X8DJ0eFyfszE0QiEd+iXmBvUP3WHxSjFH/vIsA0EN00cgr8w==
   /monotone-convex-hull-2d/1.0.1:
     dependencies:
       robust-orientation: 1.1.3
@@ -13055,7 +13055,7 @@ packages:
     dependencies:
       babel-runtime: 6.26.0
       classnames: 2.2.6
-      moment: 2.26.0
+      moment: 2.29.4
       prop-types: 15.7.2
       rc-trigger: 2.6.5
       rc-util: 4.21.1
@@ -13372,7 +13372,7 @@ packages:
   /rc-time-picker/3.7.3:
     dependencies:
       classnames: 2.2.6
-      moment: 2.26.0
+      moment: 2.29.4
       prop-types: 15.7.2
       raf: 3.4.1
       rc-trigger: 2.6.5


### PR DESCRIPTION
## What changes were proposed in this pull request?
Upgrade moment.js to 2.29.4 due to the CVEs

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-8288


## How was this patch tested?
https://github.com/rohit-kb/ozone/actions/runs/4500928021
Recon UI also seems okay upon thorough exploration.
