### PR TITLE
HDDS-8304. [Snapshot] Reduce flakiness in testSkipTrackingWithZeroSnapshot

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/freon/TestOMSnapshotDAG.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/freon/TestOMSnapshotDAG.java
@@ -304,10 +304,12 @@ public class TestOMSnapshotDAG {
     // Verify that no compaction log entry has been written
     Path logPath = Paths.get(omMetadataDir, compactionLogDirName);
     File[] fileList = logPath.toFile().listFiles();
-    Assertions.assertNotNull(fileList);
-    for (File file : fileList) {
-      if (file != null && file.isFile() && file.getName().endsWith(".log")) {
-        Assertions.assertEquals(0L, file.length());
+    // fileList can be null when compaction log directory is not even created
+    if (fileList != null) {
+      for (File file : fileList) {
+        if (file != null && file.isFile() && file.getName().endsWith(".log")) {
+          Assertions.assertEquals(0L, file.length());
+        }
       }
     }
     // Verify that no SST has been backed up


### PR DESCRIPTION
## What changes were proposed in this pull request?

- `#testSkipTrackingWithZeroSnapshot` fails occasionally presumably because the compaction log directory isn't created yet.

e.g. https://github.com/apache/ozone/actions/runs/4540058938/jobs/8001489891?pr=3980

```
Error:  Tests run: 2, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 52.179 s <<< FAILURE! - in org.apache.hadoop.ozone.freon.TestOMSnapshotDAG
Error:  org.apache.hadoop.ozone.freon.TestOMSnapshotDAG.testSkipTrackingWithZeroSnapshot  Time elapsed: 11.135 s  <<< FAILURE!
org.opentest4j.AssertionFailedError: expected: not <null>
	at org.junit.jupiter.api.AssertionUtils.fail(AssertionUtils.java:39)
	at org.junit.jupiter.api.Assertions.fail(Assertions.java:134)
	at org.junit.jupiter.api.AssertNotNull.failNull(AssertNotNull.java:47)
	at org.junit.jupiter.api.AssertNotNull.assertNotNull(AssertNotNull.java:36)
	at org.junit.jupiter.api.AssertNotNull.assertNotNull(AssertNotNull.java:31)
	at org.junit.jupiter.api.Assertions.assertNotNull(Assertions.java:300)
	at org.apache.hadoop.ozone.freon.TestOMSnapshotDAG.testSkipTrackingWithZeroSnapshot(TestOMSnapshotDAG.java:307)
```

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-8304

## How was this patch tested?

- Modified test itself.