### PR TITLE
HDDS-8290. [Snapshot] Merge entries from snapshotRenamedKeyTable to next snapshot.

### DIFF
--- a/hadoop-ozone/interface-client/src/main/proto/OmClientProtocol.proto
+++ b/hadoop-ozone/interface-client/src/main/proto/OmClientProtocol.proto
@@ -1710,6 +1710,7 @@ message SnapshotMoveDeletedKeysRequest {
   optional SnapshotInfo fromSnapshot = 1;
   repeated SnapshotMoveKeyInfos nextDBKeys = 2;
   repeated SnapshotMoveKeyInfos reclaimKeys = 3;
+  repeated hadoop.hdds.KeyValue renamedKeys = 4;
 }
 
 message SnapshotMoveKeyInfos {

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/snapshot/OMSnapshotMoveDeletedKeysRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/snapshot/OMSnapshotMoveDeletedKeysRequest.java
@@ -19,6 +19,7 @@
 
 package org.apache.hadoop.ozone.om.request.snapshot;
 
+import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.ozone.om.OmMetadataManagerImpl;
 import org.apache.hadoop.ozone.om.OmSnapshot;
 import org.apache.hadoop.ozone.om.OmSnapshotManager;
@@ -88,6 +89,8 @@ public class OMSnapshotMoveDeletedKeysRequest extends OMClientRequest {
           moveDeletedKeysRequest.getNextDBKeysList();
       List<SnapshotMoveKeyInfos> reclaimKeysList =
           moveDeletedKeysRequest.getReclaimKeysList();
+      List<HddsProtos.KeyValue> renamedKeysList =
+          moveDeletedKeysRequest.getRenamedKeysList();
 
       OmSnapshot omNextSnapshot = null;
 
@@ -100,7 +103,7 @@ public class OMSnapshotMoveDeletedKeysRequest extends OMClientRequest {
 
       omClientResponse = new OMSnapshotMoveDeletedKeysResponse(
           omResponse.build(), omFromSnapshot, omNextSnapshot,
-          nextDBKeysList, reclaimKeysList);
+          nextDBKeysList, reclaimKeysList, renamedKeysList);
 
     } catch (IOException ex) {
       omClientResponse = new OMSnapshotMoveDeletedKeysResponse(

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/service/SnapshotDeletingService.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/service/SnapshotDeletingService.java
@@ -21,6 +21,7 @@ package org.apache.hadoop.ozone.om.service;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.protobuf.ServiceException;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.hdds.utils.BackgroundService;
 import org.apache.hadoop.hdds.utils.BackgroundTask;
 import org.apache.hadoop.hdds.utils.BackgroundTaskQueue;
@@ -190,6 +191,7 @@ public class SnapshotDeletingService extends BackgroundService {
           // or keep it in current snapshot deleted table.
           List<SnapshotMoveKeyInfos> toReclaimList = new ArrayList<>();
           List<SnapshotMoveKeyInfos> toNextDBList = new ArrayList<>();
+          List<HddsProtos.KeyValue> renamedKeysList = new ArrayList<>();
 
           try (TableIterator<String, ? extends Table.KeyValue<String,
               RepeatedOmKeyInfo>> deletedIterator = snapshotDeletedTable
@@ -222,9 +224,11 @@ public class SnapshotDeletingService extends BackgroundService {
               SnapshotMoveKeyInfos.Builder toNextDb = SnapshotMoveKeyInfos
                   .newBuilder()
                   .setKey(deletedKey);
+              HddsProtos.KeyValue.Builder renamedKey = HddsProtos.KeyValue
+                  .newBuilder();
 
               for (OmKeyInfo keyInfo: repeatedOmKeyInfo.getOmKeyInfoList()) {
-                splitRepeatedOmKeyInfo(toReclaim, toNextDb,
+                splitRepeatedOmKeyInfo(toReclaim, toNextDb, renamedKey,
                     keyInfo, previousKeyTable, renamedKeyTable,
                     bucketInfo, volumeId);
               }
@@ -237,10 +241,13 @@ public class SnapshotDeletingService extends BackgroundService {
               }
               toNextDBList.add(toNextDb.build());
               deletionCount++;
+              if (renamedKey.hasKey() && renamedKey.hasValue()) {
+                renamedKeysList.add(renamedKey.build());
+              }
             }
             // Submit Move request to OM.
             submitSnapshotMoveDeletedKeys(snapInfo, toReclaimList,
-                toNextDBList);
+                toNextDBList, renamedKeysList);
             snapshotLimit--;
             successRunCount.incrementAndGet();
           } catch (IOException ex) {
@@ -275,13 +282,16 @@ public class SnapshotDeletingService extends BackgroundService {
       }
     }
 
+    @SuppressWarnings("checkstyle:ParameterNumber")
     private void splitRepeatedOmKeyInfo(SnapshotMoveKeyInfos.Builder toReclaim,
-        SnapshotMoveKeyInfos.Builder toNextDb, OmKeyInfo keyInfo,
+        SnapshotMoveKeyInfos.Builder toNextDb,
+        HddsProtos.KeyValue.Builder renamedKey, OmKeyInfo keyInfo,
         Table<String, OmKeyInfo> previousKeyTable,
         Table<String, String> renamedKeyTable,
         OmBucketInfo bucketInfo, long volumeId) throws IOException {
+
       if (checkKeyReclaimable(previousKeyTable, renamedKeyTable,
-          keyInfo, bucketInfo, volumeId)) {
+          keyInfo, bucketInfo, volumeId, renamedKey)) {
         // Move to next non deleted snapshot's deleted table
         toNextDb.addKeyInfos(keyInfo.getProtobuf(
             ClientVersion.CURRENT_VERSION));
@@ -294,16 +304,18 @@ public class SnapshotDeletingService extends BackgroundService {
 
     private void submitSnapshotMoveDeletedKeys(SnapshotInfo snapInfo,
         List<SnapshotMoveKeyInfos> toReclaimList,
-        List<SnapshotMoveKeyInfos> toNextDBList) {
+        List<SnapshotMoveKeyInfos> toNextDBList,
+        List<HddsProtos.KeyValue> renamedKeysList) {
 
       SnapshotMoveDeletedKeysRequest.Builder moveDeletedKeysBuilder =
           SnapshotMoveDeletedKeysRequest.newBuilder()
               .setFromSnapshot(snapInfo.getProtobuf());
 
-      SnapshotMoveDeletedKeysRequest moveDeletedKeys =
-          moveDeletedKeysBuilder.addAllReclaimKeys(toReclaimList)
-          .addAllNextDBKeys(toNextDBList).build();
-
+      SnapshotMoveDeletedKeysRequest moveDeletedKeys = moveDeletedKeysBuilder
+          .addAllReclaimKeys(toReclaimList)
+          .addAllNextDBKeys(toNextDBList)
+          .addAllRenamedKeys(renamedKeysList)
+          .build();
 
       OMRequest omRequest = OMRequest.newBuilder()
           .setCmdType(Type.SnapshotMoveDeletedKeys)
@@ -318,7 +330,8 @@ public class SnapshotDeletingService extends BackgroundService {
         Table<String, OmKeyInfo> previousKeyTable,
         Table<String, String> renamedKeyTable,
         OmKeyInfo deletedKeyInfo, OmBucketInfo bucketInfo,
-        long volumeId) throws IOException {
+        long volumeId, HddsProtos.KeyValue.Builder renamedKeyBuilder)
+        throws IOException {
 
       String dbKey;
       // Handle case when the deleted snapshot is the first snapshot.
@@ -345,7 +358,13 @@ public class SnapshotDeletingService extends BackgroundService {
             deletedKeyInfo.getKeyName());
       }
 
-      // renamedKeyTable: volumeName/bucketName/objectID -> OMRenameKeyInfo
+      /*
+       snapshotRenamedKeyTable:
+       1) /volumeName/bucketName/objectID ->
+                   /volumeId/bucketId/parentId/fileName (FSO)
+       2) /volumeName/bucketName/objectID ->
+                  /volumeName/bucketName/keyName (non-FSO)
+      */
       String dbRenameKey = ozoneManager.getMetadataManager().getRenameKey(
           deletedKeyInfo.getVolumeName(), deletedKeyInfo.getBucketName(),
           deletedKeyInfo.getObjectID());
@@ -355,6 +374,9 @@ public class SnapshotDeletingService extends BackgroundService {
       // Check key exists in renamedKeyTable of the Snapshot
       String renamedKey = renamedKeyTable.getIfExist(dbRenameKey);
 
+      if (renamedKey != null) {
+        renamedKeyBuilder.setKey(dbRenameKey).setValue(renamedKey);
+      }
       // previousKeyTable is fileTable if the bucket is FSO,
       // otherwise it is the keyTable.
       OmKeyInfo prevKeyInfo = renamedKey != null ? previousKeyTable


### PR DESCRIPTION
## What changes were proposed in this pull request?

To move entries from the current snapshot's `snapshotRenamedKeyTable` to the next snapshot's `snapshotRenamedKeyTable` inside `SnapshotDeletingService`

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-8290

## How was this patch tested?

The patch was tested with existing tests.
