### PR TITLE
HDDS-8320. Remove exclusion of jackson from ranger-intg

### DIFF
--- a/hadoop-ozone/ozone-manager/pom.xml
+++ b/hadoop-ozone/ozone-manager/pom.xml
@@ -186,10 +186,6 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
           <artifactId>*</artifactId>
         </exclusion>
         <exclusion>
-          <groupId>org.codehaus.jackson</groupId>
-          <artifactId>*</artifactId>
-        </exclusion>
-        <exclusion>
           <groupId>org.elasticsearch</groupId>
           <artifactId>*</artifactId>
         </exclusion>

--- a/hadoop-ozone/ozone-manager/pom.xml
+++ b/hadoop-ozone/ozone-manager/pom.xml
@@ -157,6 +157,13 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
       <artifactId>jersey-client</artifactId>
     </dependency>
 
+    <!-- Overriding ranger-intg jackson version -->
+    <dependency>
+      <groupId>org.codehaus.jackson</groupId>
+      <artifactId>jackson-core-asl</artifactId>
+      <version>${jackson1.version}</version>
+    </dependency>
+
     <dependency>
       <groupId>org.apache.ranger</groupId>
       <artifactId>ranger-intg</artifactId>

--- a/hadoop-ozone/ozone-manager/pom.xml
+++ b/hadoop-ozone/ozone-manager/pom.xml
@@ -186,6 +186,10 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
           <artifactId>*</artifactId>
         </exclusion>
         <exclusion>
+          <groupId>org.codehaus.jackson</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+        <exclusion>
           <groupId>org.elasticsearch</groupId>
           <artifactId>*</artifactId>
         </exclusion>

--- a/pom.xml
+++ b/pom.xml
@@ -159,6 +159,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
     <jersey2.version>2.34</jersey2.version>
 
     <!-- jackson versions -->
+    <jackson1.version>1.9.13</jackson1.version>
     <jackson2-bom.version>2.13.4.20221013</jackson2-bom.version>
     <woodstox.version>5.4.0</woodstox.version>
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

It turns out excluding jackson in HDDS-7924 might have broken actual ranger-intg client usage:

```
E           23/03/28 20:05:54 INFO rpc.RpcClient: Creating Tenant: 'tenant303241680030324', with new volume: 'tenant303241680030324'
E           	at org.apache.ranger.plugin.util.RangerRESTClient.buildClient(RangerRESTClient.java:232)
E           	at org.apache.ranger.plugin.util.RangerRESTClient.getClient(RangerRESTClient.java:215)
E           	at org.apache.ranger.plugin.util.RangerRESTClient.post(RangerRESTClient.java:576)
E           	at org.apache.ranger.RangerClient.invokeREST(RangerClient.java:422)
E           	at org.apache.ranger.RangerClient.lambda$responseHandler$0(RangerClient.java:464)
E           	at org.apache.ranger.RangerClient.responseHandler(RangerClient.java:462)
E           	at org.apache.ranger.RangerClient.callAPI(RangerClient.java:527)
E           	at org.apache.ranger.RangerClient.createRole(RangerClient.java:334)
E           Caused by: java.lang.ClassNotFoundException: org.codehaus.jackson.jaxrs.JacksonJsonProvider
E           	... 26 more
```

Unfortunately our acceptance tests didn't cover the actual Ranger client testing because the infra is not there yet. iirc @djordje-mijatovic is trying to improve the docker dev env to spin up actual Ranger, at which point we could write new acceptance tests that uses ranger-intg client to run against actual Ranger Admin Server so that we can avoid such issues in the future.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-8320

## How was this patch tested?

- Pending internal system tests to pass.
- New acceptance tests to be added after Ranger docker dev env is ready. Filed HDDS-8321 for it.
