### PR TITLE
HDDS-8323. [Snapshot] cancelAllBackgroundWork and close listeners in RDBStore#close

### DIFF
--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/RocksDatabase.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/RocksDatabase.java
@@ -355,6 +355,12 @@ public final class RocksDatabase {
 
   public void close() {
     if (isClosed.compareAndSet(false, true)) {
+      // Wait for all background work to be cancelled first. e.g. RDB compaction
+      db.get().cancelAllBackgroundWork(true);
+
+      // Then close all attached listeners
+      dbOptions.listeners().forEach(listener -> listener.close());
+
       if (columnFamilies != null) {
         columnFamilies.values().stream().forEach(f -> f.markClosed());
       }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Improve DB related handle closure by calling cancelAllBackgroundWork() and explicitly closing all compaction listeners.

Adding snapshot label to this because the DB compaction listener is introduced with Ozone snapshot feature.

Context: https://github.com/apache/ozone/pull/4492#issuecomment-1489502614

It should be safe to call `cancelAllBackgroundWork()`. From RocksDB [wiki](https://github.com/facebook/rocksdb/wiki/RocksDB-FAQ):

> Q: Is it safe to close RocksDB while another thread is issuing read, write or manual compaction requests?
> A: No. The users of RocksDB need to make sure all functions have finished before they close RocksDB. You can speed up the waiting by calling CancelAllBackgroundWork().

I presume any cancelled background work would be picked back up when the DB is loaded next time.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-8323

## How was this patch tested?

- All existing tests should pass. And this should not introduce new test flakiness.