### PR TITLE
HDDS-8324. DN data cache gets removed randomly asking for data from disk

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/transport/server/ratis/ContainerStateMachine.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/transport/server/ratis/ContainerStateMachine.java
@@ -851,7 +851,7 @@ public class ContainerStateMachine extends BaseStateMachine {
               .getFollowerNextIndices()).min().getAsLong();
           LOG.debug("Removing data corresponding to log index {} min index {} "
                   + "from cache", index, minIndex);
-          stateMachineDataCache.removeIf(k -> k >= (Math.min(minIndex, index)));
+          stateMachineDataCache.removeIf(k -> k <= (Math.min(minIndex, index)));
         }
       } catch (Exception e) {
         throw new RuntimeException(e);
@@ -874,7 +874,7 @@ public class ContainerStateMachine extends BaseStateMachine {
       // if waitOnBothFollower is false, remove the entry from the cache
       // as soon as its applied and such entry exists in the cache.
       if (!waitOnBothFollowers) {
-        stateMachineDataCache.removeIf(k -> k >= index);
+        stateMachineDataCache.removeIf(k -> k <= index);
       }
       DispatcherContext.Builder builder =
           new DispatcherContext.Builder().setTerm(trx.getLogEntry().getTerm())
@@ -996,7 +996,7 @@ public class ContainerStateMachine extends BaseStateMachine {
 
   @Override
   public CompletableFuture<Void> truncate(long index) {
-    stateMachineDataCache.removeIf(k -> k >= index);
+    stateMachineDataCache.removeIf(k -> k <= index);
     return CompletableFuture.completedFuture(null);
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

condition to remove DN data cache is changed - removing data with old index

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-8324

## How was this patch tested?

This is tested E2E for integration of ratis with extra. Normally issue will not be observed as fallback mechanism to read from disk is present, and happens randomly when ratis sync to follow is delayed in slow follower / overload condition.
