### PR TITLE
HDDS-8320. Fix ranger jackson version conflict

### DIFF
--- a/hadoop-ozone/dist/src/main/license/jar-report.txt
+++ b/hadoop-ozone/dist/src/main/license/jar-report.txt
@@ -93,11 +93,14 @@ share/ozone/lib/ion-java.jar
 share/ozone/lib/istack-commons-runtime.jar
 share/ozone/lib/j2objc-annotations.jar
 share/ozone/lib/jackson-annotations.jar
+share/ozone/lib/jackson-core-asl.jar
 share/ozone/lib/jackson-core.jar
 share/ozone/lib/jackson-databind.jar
 share/ozone/lib/jackson-dataformat-cbor.jar
 share/ozone/lib/jackson-dataformat-xml.jar
 share/ozone/lib/jackson-datatype-jsr310.jar
+share/ozone/lib/jackson-jaxrs.jar
+share/ozone/lib/jackson-mapper-asl.jar
 share/ozone/lib/jackson-module-jaxb-annotations.jar
 share/ozone/lib/jaeger-client.jar
 share/ozone/lib/jaeger-core.jar

--- a/hadoop-ozone/ozone-manager/pom.xml
+++ b/hadoop-ozone/ozone-manager/pom.xml
@@ -157,6 +157,33 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
       <artifactId>jersey-client</artifactId>
     </dependency>
 
+    <!-- Overrider ranger-intg jackson version -->
+    <dependency>
+      <groupId>org.codehaus.jackson</groupId>
+      <artifactId>jackson-core-asl</artifactId>
+      <version>${jackson1.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.codehaus.jackson</groupId>
+      <artifactId>jackson-mapper-asl</artifactId>
+      <version>${jackson1.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.codehaus.jackson</groupId>
+      <artifactId>jackson-jaxrs</artifactId>
+      <version>${jackson-jaxr.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>org.codehaus.jackson</groupId>
+          <artifactId>jackson-core-asl</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.codehaus.jackson</groupId>
+          <artifactId>jackson-mapper-asl</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+
     <dependency>
       <groupId>org.apache.ranger</groupId>
       <artifactId>ranger-intg</artifactId>
@@ -183,10 +210,6 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
         </exclusion>
         <exclusion>
           <groupId>org.apache.lucene</groupId>
-          <artifactId>*</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>org.codehaus.jackson</groupId>
           <artifactId>*</artifactId>
         </exclusion>
         <exclusion>

--- a/pom.xml
+++ b/pom.xml
@@ -159,6 +159,8 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
     <jersey2.version>2.34</jersey2.version>
 
     <!-- jackson versions -->
+    <jackson1.version>1.9.13</jackson1.version>
+    <jackson-jaxr.version>1.9.13</jackson-jaxr.version>
     <jackson2-bom.version>2.13.4.20221013</jackson2-bom.version>
     <woodstox.version>5.4.0</woodstox.version>
 


### PR DESCRIPTION
## What changes were proposed in this pull request?
Ranger depends on jackson version 1.9.13. Please check https://github.com/apache/ozone/pull/4497

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-8320

## How was this patch tested?
Ozone Internal tests