### PR TITLE
HDDS-8273. EC: Validate replication config at server-side

### DIFF
--- a/hadoop-ozone/dist/src/main/smoketest/ec/basic.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/ec/basic.robot
@@ -99,3 +99,12 @@ Test Invalid Replication Parameters
     ${message} =    Execute And Ignore Error    ozone sh key put --replication=rs-3-2-1024k --type=STAND_ALONE /${VOLUME}/foo/bar /tmp/1mb
                     Should contain              ${message}          STAND_ALONE
                     Should contain              ${message}          Invalid value
+
+Invalid Replication With Misconfigured Client
+    # client disabled replication config validation
+    # 2-1 is unsupported EC scheme
+    ${message} =    Execute And Ignore Error    ozone sh -Dozone.replication.allowed-configs="" bucket create --replication=rs-2-1-1024k --type=EC /${VOLUME}/invalid
+                    Should contain              ${message}          INVALID_REQUEST Invalid replication config
+    # 1024 is unsupported EC chunk size
+    ${message} =    Execute And Ignore Error    ozone sh -Dozone.replication.allowed-configs="" key put --replication=rs-3-2-1024 --type=EC /${VOLUME}/ecbucket/invalid /tmp/1mb
+                    Should contain              ${message}          INVALID_REQUEST Invalid replication config

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestHSync.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestHSync.java
@@ -258,7 +258,7 @@ public class TestHSync {
     builder.setDefaultReplicationConfig(
         new DefaultReplicationConfig(
             new ECReplicationConfig(
-                3, 2, ECReplicationConfig.EcCodec.RS, 1024)));
+                3, 2, ECReplicationConfig.EcCodec.RS, (int) OzoneConsts.MB)));
     BucketArgs omBucketArgs = builder.build();
     String ecBucket = UUID.randomUUID().toString();
     TestDataUtil.createBucket(client, bucket.getVolumeName(), omBucketArgs,

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFSInputStream.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFSInputStream.java
@@ -119,7 +119,7 @@ public class TestOzoneFSInputStream {
     builder.setDefaultReplicationConfig(
         new DefaultReplicationConfig(
             new ECReplicationConfig(3, 2, ECReplicationConfig.EcCodec.RS,
-                1024)));
+                (int) OzoneConsts.MB)));
     BucketArgs omBucketArgs = builder.build();
     String ecBucket = UUID.randomUUID().toString();
     TestDataUtil.createBucket(client, bucket.getVolumeName(), omBucketArgs,

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestRootedOzoneFileSystem.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestRootedOzoneFileSystem.java
@@ -2130,7 +2130,7 @@ public class TestRootedOzoneFileSystem {
     long length = contentSummary.getLength();
     long spaceConsumed = contentSummary.getSpaceConsumed();
     long expectDiskUsage = QuotaUtil.getReplicatedSize(length,
-            new ECReplicationConfig(3, 2, RS, 1024));
+        new ECReplicationConfig(3, 2, RS, (int) OzoneConsts.MB));
     Assert.assertEquals(expectDiskUsage, spaceConsumed);
     //clean up
     ofs.delete(filePath, true);

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestOzoneClientMultipartUploadWithFSO.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestOzoneClientMultipartUploadWithFSO.java
@@ -332,7 +332,7 @@ public class TestOzoneClientMultipartUploadWithFSO {
     bucketArgs.setDefaultReplicationConfig(
         new DefaultReplicationConfig(
             new ECReplicationConfig(3, 2, ECReplicationConfig.EcCodec.RS,
-                1024)));
+                (int) OzoneConsts.MB)));
 
     volume.createBucket(myBucket, bucketArgs.build());
     return volume.getBucket(myBucket);

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestOzoneRpcClientAbstract.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestOzoneRpcClientAbstract.java
@@ -41,6 +41,7 @@ import java.util.stream.Stream;
 import org.apache.hadoop.conf.StorageUnit;
 import org.apache.hadoop.hdds.client.DefaultReplicationConfig;
 import org.apache.hadoop.hdds.client.ECReplicationConfig;
+import org.apache.hadoop.hdds.client.ECReplicationConfig.EcCodec;
 import org.apache.hadoop.hdds.client.OzoneQuota;
 import org.apache.hadoop.hdds.client.RatisReplicationConfig;
 import org.apache.hadoop.hdds.client.ReplicationConfig;
@@ -4087,7 +4088,7 @@ public abstract class TestOzoneRpcClientAbstract {
             HddsProtos.ReplicationFactor.ONE),
         currentReplicationConfig);
     ECReplicationConfig ecReplicationConfig =
-        new ECReplicationConfig(3, 2, ECReplicationConfig.EcCodec.RS, 1024);
+        new ECReplicationConfig(3, 2, EcCodec.RS, (int) OzoneConsts.MB);
     bucket.setReplicationConfig(ecReplicationConfig);
 
     // Get the bucket and check the updated config.

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOmMetrics.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOmMetrics.java
@@ -323,14 +323,14 @@ public class TestOmMetrics {
     writeClient.deleteKey(keyArgs);
 
     keyArgs = createKeyArgs(volumeName, bucketName,
-        new ECReplicationConfig("rs-6-4-1024K"));
+        new ECReplicationConfig("rs-6-3-1024K"));
     try {
       keySession = writeClient.openKey(keyArgs);
       writeClient.commitKey(keyArgs, keySession.getId());
     } catch (Exception e) {
       //Expected Failure in preExecute due to not enough datanode
       Assertions.assertTrue(e.getMessage()
-          .contains("No enough datanodes to choose"));
+          .contains("No enough datanodes to choose"), e::getMessage);
     }
 
     omMetrics = getMetrics("OMMetrics");

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneConfigUtil.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneConfigUtil.java
@@ -21,6 +21,7 @@ import org.apache.hadoop.hdds.client.DefaultReplicationConfig;
 import org.apache.hadoop.hdds.client.ReplicationConfig;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
+import org.apache.hadoop.ozone.om.exceptions.OMException;
 import org.apache.hadoop.security.UserGroupInformation;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -98,18 +99,20 @@ public final class OzoneConfigUtil {
       HddsProtos.ReplicationFactor clientFactor,
       HddsProtos.ECReplicationConfig clientECReplicationConfig,
       DefaultReplicationConfig bucketDefaultReplicationConfig,
-      ReplicationConfig omDefaultReplicationConfig) {
+      OzoneManager ozoneManager) throws OMException {
     ReplicationConfig replicationConfig = null;
     if (clientType != HddsProtos.ReplicationType.NONE) {
       // Client passed the replication config, so let's use it.
       replicationConfig = ReplicationConfig
           .fromProto(clientType, clientFactor, clientECReplicationConfig);
+
+      ozoneManager.validateReplicationConfig(replicationConfig);
     } else if (bucketDefaultReplicationConfig != null) {
       // type is NONE, so, let's look for the bucket defaults.
       replicationConfig = bucketDefaultReplicationConfig.getReplicationConfig();
     } else {
       // if bucket defaults also not available, then use server defaults.
-      replicationConfig = omDefaultReplicationConfig;
+      replicationConfig = ozoneManager.getDefaultReplicationConfig();
     }
     return replicationConfig;
   }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/bucket/OMBucketCreateRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/bucket/OMBucketCreateRequest.java
@@ -22,6 +22,7 @@ import org.apache.hadoop.crypto.CipherSuite;
 import org.apache.hadoop.crypto.key.KeyProvider;
 import org.apache.hadoop.crypto.key.KeyProviderCryptoExtension;
 import org.apache.hadoop.fs.CommonConfigurationKeys;
+import org.apache.hadoop.hdds.client.DefaultReplicationConfig;
 import org.apache.hadoop.hdds.utils.db.cache.CacheKey;
 import org.apache.hadoop.hdds.utils.db.cache.CacheValue;
 import org.apache.hadoop.ozone.ClientVersion;
@@ -125,6 +126,12 @@ public class OMBucketCreateRequest extends OMClientRequest {
     if (hasSourceBucket && bucketInfo.hasBeinfo()) {
       throw new OMException("Encryption cannot be set for bucket links",
           OMException.ResultCodes.INVALID_REQUEST);
+    }
+
+    if (bucketInfo.hasDefaultReplicationConfig()) {
+      DefaultReplicationConfig drc = DefaultReplicationConfig.fromProto(
+          bucketInfo.getDefaultReplicationConfig());
+      ozoneManager.validateReplicationConfig(drc.getReplicationConfig());
     }
 
     newCreateBucketRequest.setBucketInfo(newBucketInfo.build());

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/file/OMFileCreateRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/file/OMFileCreateRequest.java
@@ -127,7 +127,7 @@ public class OMFileCreateRequest extends OMKeyRequest {
         .resolveReplicationConfigPreference(type, factor,
             keyArgs.getEcReplicationConfig(),
             bucketInfo.getDefaultReplicationConfig(),
-            ozoneManager.getDefaultReplicationConfig());
+            ozoneManager);
 
     // TODO: Here we are allocating block with out any check for
     //  bucket/key/volume or not and also with out any authorization checks.
@@ -248,7 +248,7 @@ public class OMFileCreateRequest extends OMKeyRequest {
           .resolveReplicationConfigPreference(keyArgs.getType(),
               keyArgs.getFactor(), keyArgs.getEcReplicationConfig(),
               omBucketInfo.getDefaultReplicationConfig(),
-              ozoneManager.getDefaultReplicationConfig());
+              ozoneManager);
 
       omKeyInfo = prepareKeyInfo(omMetadataManager, keyArgs, dbKeyInfo,
           keyArgs.getDataSize(), locations, getFileEncryptionInfo(keyArgs),

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/file/OMFileCreateRequestWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/file/OMFileCreateRequestWithFSO.java
@@ -171,7 +171,7 @@ public class OMFileCreateRequestWithFSO extends OMFileCreateRequest {
           .resolveReplicationConfigPreference(keyArgs.getType(),
               keyArgs.getFactor(), keyArgs.getEcReplicationConfig(),
               bucketInfo.getDefaultReplicationConfig(),
-              ozoneManager.getDefaultReplicationConfig());
+              ozoneManager);
 
       OmKeyInfo omFileInfo = prepareFileInfo(omMetadataManager, keyArgs,
               dbFileInfo, keyArgs.getDataSize(), locations,

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyCreateRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyCreateRequest.java
@@ -134,7 +134,7 @@ public class OMKeyCreateRequest extends OMKeyRequest {
           .resolveReplicationConfigPreference(type, factor,
               keyArgs.getEcReplicationConfig(),
               bucketInfo.getDefaultReplicationConfig(),
-              ozoneManager.getDefaultReplicationConfig());
+              ozoneManager);
 
       // TODO: Here we are allocating block with out any check for
       //  bucket/key/volume or not and also with out any authorization checks.
@@ -271,7 +271,7 @@ public class OMKeyCreateRequest extends OMKeyRequest {
           .resolveReplicationConfigPreference(keyArgs.getType(),
               keyArgs.getFactor(), keyArgs.getEcReplicationConfig(),
               bucketInfo.getDefaultReplicationConfig(),
-              ozoneManager.getDefaultReplicationConfig());
+              ozoneManager);
 
       omKeyInfo = prepareKeyInfo(omMetadataManager, keyArgs, dbKeyInfo,
           keyArgs.getDataSize(), locations, getFileEncryptionInfo(keyArgs),

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyCreateRequestWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyCreateRequestWithFSO.java
@@ -157,7 +157,7 @@ public class OMKeyCreateRequestWithFSO extends OMKeyCreateRequest {
           .resolveReplicationConfigPreference(keyArgs.getType(),
               keyArgs.getFactor(), keyArgs.getEcReplicationConfig(),
               bucketInfo.getDefaultReplicationConfig(),
-              ozoneManager.getDefaultReplicationConfig());
+              ozoneManager);
 
       OmKeyInfo omFileInfo = prepareFileInfo(omMetadataManager, keyArgs,
               dbFileInfo, keyArgs.getDataSize(), locations,

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3InitiateMultipartUploadRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3InitiateMultipartUploadRequest.java
@@ -182,7 +182,7 @@ public class S3InitiateMultipartUploadRequest extends OMKeyRequest {
               keyArgs.getFactor(), keyArgs.getEcReplicationConfig(),
               bucketInfo != null ?
                   bucketInfo.getDefaultReplicationConfig() :
-                  null, ozoneManager.getDefaultReplicationConfig());
+                  null, ozoneManager);
 
       multipartKeyInfo = new OmMultipartKeyInfo.Builder()
           .setUploadID(keyArgs.getMultipartUploadID())

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3InitiateMultipartUploadRequestWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3InitiateMultipartUploadRequestWithFSO.java
@@ -163,7 +163,7 @@ public class S3InitiateMultipartUploadRequestWithFSO
               keyArgs.getFactor(), keyArgs.getEcReplicationConfig(),
               bucketInfo != null ?
                   bucketInfo.getDefaultReplicationConfig() :
-                  null, ozoneManager.getDefaultReplicationConfig());
+                  null, ozoneManager);
 
       multipartKeyInfo = new OmMultipartKeyInfo.Builder()
           .setUploadID(keyArgs.getMultipartUploadID())

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/ratis/TestOzoneManagerDoubleBufferWithOMResponse.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/ratis/TestOzoneManagerDoubleBufferWithOMResponse.java
@@ -39,6 +39,7 @@ import org.apache.hadoop.ozone.om.request.bucket.OMBucketDeleteRequest;
 import org.apache.hadoop.ozone.om.request.volume.OMVolumeCreateRequest;
 import org.apache.hadoop.ozone.om.response.OMClientResponse;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos;
+import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.BucketInfo;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -63,6 +64,7 @@ import org.apache.hadoop.util.Daemon;
 import org.mockito.Mockito;
 
 import static org.apache.hadoop.ozone.OzoneConsts.TRANSACTION_INFO_KEY;
+import static org.apache.hadoop.ozone.om.request.OMRequestTestUtils.newBucketInfoBuilder;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.fail;
 import static org.mockito.ArgumentMatchers.any;
@@ -467,9 +469,11 @@ public class TestOzoneManagerDoubleBufferWithOMResponse {
   private OMBucketCreateResponse createBucket(String volumeName,
       String bucketName, long transactionID)  {
 
+    BucketInfo.Builder bucketInfo =
+        newBucketInfoBuilder(bucketName, volumeName)
+            .setStorageType(OzoneManagerProtocolProtos.StorageTypeProto.DISK);
     OzoneManagerProtocolProtos.OMRequest omRequest =
-        OMRequestTestUtils.createBucketRequest(bucketName, volumeName, false,
-            OzoneManagerProtocolProtos.StorageTypeProto.DISK);
+        OMRequestTestUtils.newCreateBucketRequest(bucketInfo).build();
 
     OMBucketCreateRequest omBucketCreateRequest =
         new OMBucketCreateRequest(omRequest);

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/TestOMClientRequestWithUserInfo.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/TestOMClientRequestWithUserInfo.java
@@ -24,6 +24,8 @@ import java.util.UUID;
 
 import mockit.Mock;
 import mockit.MockUp;
+import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.BucketInfo;
+import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMRequest;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
@@ -42,6 +44,8 @@ import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos;
 import org.apache.hadoop.ozone.om.request.bucket.OMBucketCreateRequest;
 import org.apache.hadoop.security.UserGroupInformation;
 
+import static org.apache.hadoop.ozone.om.request.OMRequestTestUtils.newBucketInfoBuilder;
+import static org.apache.hadoop.ozone.om.request.OMRequestTestUtils.newCreateBucketRequest;
 import static org.mockito.Mockito.when;
 
 /**
@@ -93,16 +97,18 @@ public class TestOMClientRequestWithUserInfo {
 
     String bucketName = UUID.randomUUID().toString();
     String volumeName = UUID.randomUUID().toString();
-    OzoneManagerProtocolProtos.OMRequest omRequest =
-        OMRequestTestUtils.createBucketRequest(bucketName, volumeName, true,
-            OzoneManagerProtocolProtos.StorageTypeProto.DISK);
+    BucketInfo.Builder bucketInfo =
+        newBucketInfoBuilder(bucketName, volumeName)
+            .setIsVersionEnabled(true)
+            .setStorageType(OzoneManagerProtocolProtos.StorageTypeProto.DISK);
+    OMRequest omRequest = newCreateBucketRequest(bucketInfo).build();
 
     OMBucketCreateRequest omBucketCreateRequest =
         new OMBucketCreateRequest(omRequest);
 
     Assert.assertFalse(omRequest.hasUserInfo());
 
-    OzoneManagerProtocolProtos.OMRequest modifiedRequest =
+    OMRequest modifiedRequest =
         omBucketCreateRequest.preExecute(ozoneManager);
 
     Assert.assertTrue(modifiedRequest.hasUserInfo());

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/bucket/TestBucketRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/bucket/TestBucketRequest.java
@@ -38,6 +38,7 @@ import org.apache.hadoop.ozone.om.OzoneManager;
 import org.apache.hadoop.ozone.om.ratis.utils.OzoneManagerDoubleBufferHelper;
 
 
+import static org.apache.hadoop.ozone.om.request.OMRequestTestUtils.setupReplicationConfigValidation;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -78,6 +79,9 @@ public class TestBucketRequest {
     when(ozoneManager.getOMDefaultBucketLayout()).thenReturn(
         BucketLayout.fromString(
             OMConfigKeys.OZONE_DEFAULT_BUCKET_LAYOUT_DEFAULT));
+
+    setupReplicationConfigValidation(ozoneManager, ozoneConfiguration);
+
     OMLayoutVersionManager lvm = mock(OMLayoutVersionManager.class);
     when(lvm.getMetadataLayoutVersion()).thenReturn(0);
     when(ozoneManager.getVersionManager()).thenReturn(lvm);

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/bucket/TestOMBucketCreateRequestWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/bucket/TestOMBucketCreateRequestWithFSO.java
@@ -24,14 +24,17 @@ import org.apache.hadoop.ozone.om.helpers.BucketLayout;
 import org.apache.hadoop.ozone.om.helpers.OmBucketInfo;
 import org.apache.hadoop.ozone.om.request.OMRequestTestUtils;
 import org.apache.hadoop.ozone.om.response.OMClientResponse;
+import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMRequest;
-import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.StorageTypeProto;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
 import java.util.UUID;
 
+import static org.apache.hadoop.ozone.om.request.OMRequestTestUtils.newBucketInfoBuilder;
+import static org.apache.hadoop.ozone.om.request.OMRequestTestUtils.newCreateBucketRequest;
+import static org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.BucketLayoutProto.FILE_SYSTEM_OPTIMIZED;
 import static org.mockito.Mockito.when;
 
 /**
@@ -109,18 +112,16 @@ public class TestOMBucketCreateRequestWithFSO
       throws Exception {
     addCreateVolumeToTable(volumeName, omMetadataManager);
 
-    OMRequest originalRequest;
+    OzoneManagerProtocolProtos.BucketInfo.Builder bucketInfo =
+        newBucketInfoBuilder(bucketName, volumeName);
 
     if (layoutFSOFromCli) {
-      originalRequest =
-          OMRequestTestUtils.createBucketReqFSO(bucketName, volumeName,
-              false, StorageTypeProto.SSD);
-    } else {
-      originalRequest = OMRequestTestUtils
-          .createBucketRequest(bucketName, volumeName,
-              false, StorageTypeProto.SSD);
+      bucketInfo
+          .setBucketLayout(FILE_SYSTEM_OPTIMIZED)
+          .addMetadata(OMRequestTestUtils.fsoMetadata());
     }
 
+    OMRequest originalRequest = newCreateBucketRequest(bucketInfo).build();
     OMBucketCreateRequest omBucketCreateRequest =
         new OMBucketCreateRequest(originalRequest);
 

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMKeyCreateRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMKeyCreateRequest.java
@@ -58,6 +58,7 @@ import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_ENABLE_FILESYSTEM
 import static org.apache.hadoop.ozone.om.request.OMRequestTestUtils.addVolumeAndBucketToDB;
 import static org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.Status.NOT_A_FILE;
 import static org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.Status.OK;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.fail;
 import static org.mockito.Mockito.when;
 
@@ -123,6 +124,15 @@ public class TestOMKeyCreateRequest extends TestOMKeyRequest {
     }
   }
 
+  @Test
+  public void preExecuteRejectsInvalidReplication() {
+    ECReplicationConfig invalidReplication = new ECReplicationConfig(1, 2);
+    OMException e = assertThrows(OMException.class,
+        () -> preExecuteTest(false, 0, invalidReplication));
+
+    Assert.assertEquals(OMException.ResultCodes.INVALID_REQUEST,
+        e.getResult());
+  }
 
   @Test
   public void testValidateAndUpdateCache() throws Exception {

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMKeyRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMKeyRequest.java
@@ -69,6 +69,7 @@ import org.apache.hadoop.ozone.om.ScmClient;
 import org.apache.hadoop.hdds.security.token.OzoneBlockTokenSecretManager;
 import org.apache.hadoop.util.Time;
 
+import static org.apache.hadoop.ozone.om.request.OMRequestTestUtils.setupReplicationConfigValidation;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyLong;
@@ -142,6 +143,8 @@ public class TestOMKeyRequest {
     when(ozoneManager.getBucketInfo(anyString(), anyString())).thenReturn(
         new OmBucketInfo.Builder().setVolumeName("").setBucketName("").build());
     Mockito.doNothing().when(auditLogger).logWrite(any(AuditMessage.class));
+
+    setupReplicationConfigValidation(ozoneManager, ozoneConfiguration);
 
     scmClient = Mockito.mock(ScmClient.class);
     ozoneBlockTokenSecretManager =


### PR DESCRIPTION
## What changes were proposed in this pull request?

Validate the replication config provided by client, at the server-side.

https://issues.apache.org/jira/browse/HDDS-8273

## How was this patch tested?

Added unit test and acceptance test.

CI (before acceptance test):
https://github.com/adoroszlai/hadoop-ozone/actions/runs/4572695466

CI (with acceptance test, in progress):
https://github.com/adoroszlai/hadoop-ozone/actions/runs/4573559120