### PR TITLE
HDDS-8185. ozone admin datanode list should have a json option for output

### DIFF
--- a/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/datanode/ListInfoSubcommand.java
+++ b/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/datanode/ListInfoSubcommand.java
@@ -94,7 +94,6 @@ public class ListInfoSubcommand extends ScmSubcommand {
       allNodes = allNodes.filter(p -> p.getHealthState().toString()
           .compareToIgnoreCase(nodeState) == 0);
     }
-    //allNodes.forEach(this::printDatanodeInfo);
 
     if (json) {
       List<DatanodeWithAttributes> datanodeList = allNodes.collect(Collectors.toList());

--- a/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/datanode/ListInfoSubcommand.java
+++ b/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/datanode/ListInfoSubcommand.java
@@ -24,6 +24,7 @@ import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.hdds.scm.cli.ScmSubcommand;
 import org.apache.hadoop.hdds.scm.client.ScmClient;
 import org.apache.hadoop.hdds.scm.pipeline.Pipeline;
+import org.apache.hadoop.hdds.server.JsonUtils;
 import picocli.CommandLine;
 
 import java.io.IOException;
@@ -65,6 +66,11 @@ public class ListInfoSubcommand extends ScmSubcommand {
       defaultValue = "")
   private String nodeState;
 
+  @CommandLine.Option(names = { "--json" },
+       description = "Show info in json format",
+       defaultValue = "false")
+  private boolean json;
+
   private List<Pipeline> pipelines;
 
 
@@ -88,7 +94,14 @@ public class ListInfoSubcommand extends ScmSubcommand {
       allNodes = allNodes.filter(p -> p.getHealthState().toString()
           .compareToIgnoreCase(nodeState) == 0);
     }
-    allNodes.forEach(this::printDatanodeInfo);
+    //allNodes.forEach(this::printDatanodeInfo);
+
+    if (json) {
+      List<DatanodeWithAttributes> datanodeList = allNodes.collect(Collectors.toList());
+      System.out.print(JsonUtils.toJsonStringWithDefaultPrettyPrinter(datanodeList));
+    } else {
+      allNodes.forEach(this::printDatanodeInfo);
+    }
   }
 
   private List<DatanodeWithAttributes> getAllNodes(ScmClient scmClient)

--- a/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/datanode/ListInfoSubcommand.java
+++ b/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/datanode/ListInfoSubcommand.java
@@ -96,8 +96,10 @@ public class ListInfoSubcommand extends ScmSubcommand {
     }
 
     if (json) {
-      List<DatanodeWithAttributes> datanodeList = allNodes.collect(Collectors.toList());
-      System.out.print(JsonUtils.toJsonStringWithDefaultPrettyPrinter(datanodeList));
+      List<DatanodeWithAttributes> datanodeList = allNodes.collect(
+              Collectors.toList());
+      System.out.print(
+              JsonUtils.toJsonStringWithDefaultPrettyPrinter(datanodeList));
     } else {
       allNodes.forEach(this::printDatanodeInfo);
     }

--- a/hadoop-ozone/dist/src/main/smoketest/admincli/datanode.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/admincli/datanode.robot
@@ -62,3 +62,9 @@ Incomplete command
 #List datanodes on unknown host
 #    ${output} =         Execute And Ignore Error     ozone admin --verbose datanode list --scm unknown-host
 #                        Should contain   ${output}   Invalid host name
+
+List datanodes as JSON
+    ${output} =         Execute          ozone admin datanode list --json | jq -r '.'
+                        Should contain   ${output}    datanodeDetails
+                        Should contain   ${output}    healthState
+                        Should contain   ${output}    opState


### PR DESCRIPTION
## What changes were proposed in this pull request?

Json formatting option added for `ozone admin datanode list` command 
```
bash-4.2$ ozone admin datanode list --help
Usage: ozone admin datanode list [-hV] [--json] [-id=<scmServiceId>]
                                 [--id=<uuid>] [--ip=<ipaddress>]
                                 [--node-state=<nodeState>]
                                 [--operational-state=<nodeOperationalState>]
                                 [--scm=<scm>]
List info of datanodes
  -h, --help             Show this help message and exit.
      -id, --service-id=<scmServiceId>
                         ServiceId of SCM HA Cluster
      --id=<uuid>        Show info by datanode UUID.
      --ip=<ipaddress>   Show info by ip address.
      --json             Show info in json format
      --node-state=<nodeState>
                         Show info by datanode NodeState( HEALTHY, STALE, DEAD)
      --operational-state=<nodeOperationalState>
                         Show info by datanode NodeOperationalState(IN_SERVICE,
                           DECOMMISSIONING, DECOMMISSIONED,
                           ENTERING_MAINTENANCE, IN_MAINTENANCE).
      --scm=<scm>        The destination scm (host:port)
  -V, --version          Print version information and exit.
```

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-8185

## How was this patch tested?

Tested using apache docker build -
```
bash-4.2$ ozone admin datanode list --json | more
[ {
  "datanodeDetails" : {
    "level" : 0,
    "cost" : 0,
    "uuid" : "a288046d-c3fb-41b7-b25d-00e3da71fcc6",
    "uuidString" : "a288046d-c3fb-41b7-b25d-00e3da71fcc6",
    "ipAddress" : "172.18.0.4",
    "hostName" : "ozone_datanode_1.ozone_default",
    "ports" : [ {
      "name" : "REPLICATION",
      "value" : 9886
    }, {
      "name" : "RATIS",
      "value" : 9858
    }, {
      "name" : "RATIS_ADMIN",
      "value" : 9857
    }, {
      "name" : "RATIS_SERVER",
      "value" : 9856
    }, {
      "name" : "RATIS_DATASTREAM",
      "value" : 9855
    }, {
      "name" : "STANDALONE",
      "value" : 9859
    } ],
    "setupTime" : 0,
    "persistedOpState" : "IN_SERVICE",
    "persistedOpStateExpiryEpochSec" : 0,
    "initialVersion" : 0,
    "currentVersion" : 1,
    "signature" : -413780670,
    "decomissioned" : false,
    "networkLocation" : "/default-rack",
    "networkName" : "a288046d-c3fb-41b7-b25d-00e3da71fcc6",
    "networkFullPath" : "/default-rack/a288046d-c3fb-41b7-b25d-00e3da71fcc6",
    "numOfLeaves" : 1
  },
  "healthState" : "HEALTHY",
  "opState" : "IN_SERVICE"
}, {
  "datanodeDetails" : {
    "level" : 0,
    "cost" : 0,
    "uuid" : "ea12974c-febe-4bc1-a091-ffa6a2290adc",
    "uuidString" : "ea12974c-febe-4bc1-a091-ffa6a2290adc",
    "ipAddress" : "172.18.0.7",
    "hostName" : "ozone_datanode_4.ozone_default",
    "ports" : [ {
      "name" : "REPLICATION",
      "value" : 9886
    }, {
--More--
```
Added robot tests in - `hadoop-ozone/dist/src/main/smoketest/admincli/datanode.robot`