### PR TITLE
HDDS-8354. Avoid WARNING about ObjectEndpoint#get

### DIFF
--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/ObjectEndpoint.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/ObjectEndpoint.java
@@ -300,7 +300,8 @@ public class ObjectEndpoint extends EndpointBase {
       @PathParam("path") String keyPath,
       @QueryParam("uploadId") String uploadId,
       @QueryParam("max-parts") @DefaultValue("1000") int maxParts,
-      @QueryParam("part-number-marker") String partNumberMarker) throws IOException, OS3Exception {
+      @QueryParam("part-number-marker") String partNumberMarker)
+      throws IOException, OS3Exception {
 
     S3GAction s3GAction = S3GAction.GET_KEY;
     boolean auditSuccess = true;

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/ObjectEndpoint.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/ObjectEndpoint.java
@@ -300,8 +300,7 @@ public class ObjectEndpoint extends EndpointBase {
       @PathParam("path") String keyPath,
       @QueryParam("uploadId") String uploadId,
       @QueryParam("max-parts") @DefaultValue("1000") int maxParts,
-      @QueryParam("part-number-marker") String partNumberMarker,
-      InputStream body) throws IOException, OS3Exception {
+      @QueryParam("part-number-marker") String partNumberMarker) throws IOException, OS3Exception {
 
     S3GAction s3GAction = S3GAction.GET_KEY;
     boolean auditSuccess = true;

--- a/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestListParts.java
+++ b/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestListParts.java
@@ -94,7 +94,7 @@ public class TestListParts {
   @Test
   public void testListParts() throws Exception {
     Response response = REST.get(OzoneConsts.S3_BUCKET, OzoneConsts.KEY,
-        uploadID, 3, "0", null);
+        uploadID, 3, "0");
 
     ListPartsResponse listPartsResponse =
         (ListPartsResponse) response.getEntity();
@@ -107,7 +107,7 @@ public class TestListParts {
   @Test
   public void testListPartsContinuation() throws Exception {
     Response response = REST.get(OzoneConsts.S3_BUCKET, OzoneConsts.KEY,
-        uploadID, 2, "0", null);
+        uploadID, 2, "0");
     ListPartsResponse listPartsResponse =
         (ListPartsResponse) response.getEntity();
 
@@ -116,7 +116,7 @@ public class TestListParts {
 
     // Continue
     response = REST.get(OzoneConsts.S3_BUCKET, OzoneConsts.KEY, uploadID, 2,
-        Integer.toString(listPartsResponse.getNextPartNumberMarker()), null);
+        Integer.toString(listPartsResponse.getNextPartNumberMarker()));
     listPartsResponse = (ListPartsResponse) response.getEntity();
 
     Assert.assertFalse(listPartsResponse.getTruncated());
@@ -128,7 +128,7 @@ public class TestListParts {
   public void testListPartsWithUnknownUploadID() throws Exception {
     try {
       REST.get(OzoneConsts.S3_BUCKET, OzoneConsts.KEY,
-          uploadID, 2, "0", null);
+          uploadID, 2, "0");
     } catch (OS3Exception ex) {
       Assert.assertEquals(S3ErrorTable.NO_SUCH_UPLOAD.getErrorMessage(),
           ex.getErrorMessage());

--- a/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestObjectGet.java
+++ b/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestObjectGet.java
@@ -25,7 +25,6 @@ import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.MultivaluedHashMap;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.UriInfo;
-import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.time.format.DateTimeFormatter;
 
@@ -70,7 +69,6 @@ public class TestObjectGet {
   private HttpHeaders headers;
   private ObjectEndpoint rest;
   private OzoneClient client;
-  private ByteArrayInputStream body;
   private ContainerRequestContext context;
 
   @Before
@@ -89,7 +87,6 @@ public class TestObjectGet {
     rest.setOzoneConfiguration(new OzoneConfiguration());
     headers = Mockito.mock(HttpHeaders.class);
     rest.setHeaders(headers);
-    body = new ByteArrayInputStream(CONTENT.getBytes(UTF_8));
 
     context = Mockito.mock(ContainerRequestContext.class);
     Mockito.when(context.getUriInfo()).thenReturn(Mockito.mock(UriInfo.class));
@@ -101,7 +98,7 @@ public class TestObjectGet {
   @Test
   public void get() throws IOException, OS3Exception {
     //WHEN
-    Response response = rest.get("b1", "key1", null, 0, null, body);
+    Response response = rest.get("b1", "key1", null, 0, null);
 
     //THEN
     OzoneInputStream ozoneInputStream =
@@ -123,7 +120,7 @@ public class TestObjectGet {
   public void inheritRequestHeader() throws IOException, OS3Exception {
     setDefaultHeader();
 
-    Response response = rest.get("b1", "key1", null, 0, null, body);
+    Response response = rest.get("b1", "key1", null, 0, null);
 
     Assert.assertEquals(CONTENT_TYPE1,
         response.getHeaderString("Content-Type"));
@@ -156,8 +153,7 @@ public class TestObjectGet {
 
     Mockito.when(context.getUriInfo().getQueryParameters())
         .thenReturn(queryParameter);
-    body = new ByteArrayInputStream(CONTENT.getBytes(UTF_8));
-    Response response = rest.get("b1", "key1", null, 0, null, body);
+    Response response = rest.get("b1", "key1", null, 0, null);
 
     Assert.assertEquals(CONTENT_TYPE2,
         response.getHeaderString("Content-Type"));
@@ -177,15 +173,14 @@ public class TestObjectGet {
   public void getRangeHeader() throws IOException, OS3Exception {
     Response response;
     Mockito.when(headers.getHeaderString(RANGE_HEADER)).thenReturn("bytes=0-0");
-    body = new ByteArrayInputStream(CONTENT.getBytes(UTF_8));
 
-    response = rest.get("b1", "key1", null, 0, null, body);
+    response = rest.get("b1", "key1", null, 0, null);
     Assert.assertEquals("1", response.getHeaderString("Content-Length"));
     Assert.assertEquals(String.format("bytes 0-0/%s", CONTENT.length()),
         response.getHeaderString("Content-Range"));
 
     Mockito.when(headers.getHeaderString(RANGE_HEADER)).thenReturn("bytes=0-");
-    response = rest.get("b1", "key1", null, 0, null, body);
+    response = rest.get("b1", "key1", null, 0, null);
     Assert.assertEquals(String.valueOf(CONTENT.length()),
         response.getHeaderString("Content-Length"));
     Assert.assertEquals(
@@ -196,8 +191,7 @@ public class TestObjectGet {
   @Test
   public void getStatusCode() throws IOException, OS3Exception {
     Response response;
-    body = new ByteArrayInputStream(CONTENT.getBytes(UTF_8));
-    response = rest.get("b1", "key1", null, 0, null, body);
+    response = rest.get("b1", "key1", null, 0, null);
     Assert.assertEquals(response.getStatus(),
         Response.Status.OK.getStatusCode());
 
@@ -205,7 +199,7 @@ public class TestObjectGet {
     // The 206 (Partial Content) status code indicates that the server is
     //   successfully fulfilling a range request for the target resource
     Mockito.when(headers.getHeaderString(RANGE_HEADER)).thenReturn("bytes=0-1");
-    response = rest.get("b1", "key1", null, 0, null, body);
+    response = rest.get("b1", "key1", null, 0, null);
     Assert.assertEquals(response.getStatus(),
         Response.Status.PARTIAL_CONTENT.getStatusCode());
   }

--- a/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestPermissionCheck.java
+++ b/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestPermissionCheck.java
@@ -263,8 +263,7 @@ public class TestPermissionCheck {
     objectEndpoint.setOzoneConfiguration(conf);
 
     try {
-      objectEndpoint.get("bucketName", "keyPath", null, 1000, "marker",
-          null);
+      objectEndpoint.get("bucketName", "keyPath", null, 1000, "marker");
       Assert.fail("Should fail");
     } catch (Exception e) {
       e.printStackTrace();

--- a/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/metrics/TestS3GatewayMetrics.java
+++ b/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/metrics/TestS3GatewayMetrics.java
@@ -377,7 +377,7 @@ public class TestS3GatewayMetrics {
         .length(), 1, null, body);
     // GET the key from the bucket
     keyEndpoint.get(bucketName, keyName, null, 0,
-        null, body);
+        null);
     long curMetric = metrics.getGetKeySuccess();
     assertEquals(1L, curMetric - oriMetric);
   }
@@ -388,7 +388,7 @@ public class TestS3GatewayMetrics {
     // Fetching a non-existent key
     try {
       keyEndpoint.get(bucketName, "unknownKey", null, 0,
-          null, null);
+          null);
       fail();
     } catch (OS3Exception ex) {
       assertEquals(S3ErrorTable.NO_SUCH_KEY.getCode(), ex.getCode());
@@ -520,7 +520,7 @@ public class TestS3GatewayMetrics {
 
     // Listing out the parts by providing the uploadID
     keyEndpoint.get(bucketName, keyName,
-        uploadID, 3, null, null);
+        uploadID, 3, null);
     long curMetric = metrics.getListPartsSuccess();
     assertEquals(1L, curMetric - oriMetric);
   }
@@ -532,7 +532,7 @@ public class TestS3GatewayMetrics {
     try {
       // Listing out the parts by providing the uploadID after aborting
       keyEndpoint.get(bucketName, keyName,
-          "wrong_id", 3, null, null);
+          "wrong_id", 3, null);
       fail();
     } catch (OS3Exception ex) {
       assertEquals(S3ErrorTable.NO_SUCH_UPLOAD.getCode(), ex.getCode());


### PR DESCRIPTION
## What changes were proposed in this pull request?

Make `ObjectEndpoint#get` not accept an HTTP request body so that we no longer see the following WARNING.

```
ozone-s3g-6bd9d99555-lgmsl: WARNING: The following warnings have been detected: WARNING: A HTTP GET method, public javax.ws.rs.core.Response org.apache.hadoop.ozone.s3.endpoint.ObjectEndpoint.get(java.lang.String,java.lang.String,java.lang.String,int,java.lang.String,java.io.InputStream) throws java.io.IOException,org.apache.hadoop.ozone.s3.exception.OS3Exception, should not consume any entity. 
```

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-8354

## How was this patch tested?

I verified we never observe the warning the master branch with this patch.