### PR TITLE
HDDS-8341. Use SequenceIDGenerator to generate CRL Sequence.

### DIFF
--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/scm/metadata/SCMMetadataStore.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/scm/metadata/SCMMetadataStore.java
@@ -119,7 +119,10 @@ public interface SCMMetadataStore extends DBStoreHAManager {
    * that the CRL Sequence Ids are monotonically increasing.
    *
    * @return Table.
+   *
+   * Deprecated Use SequenceIdGenerator
    */
+  @Deprecated
   Table<String, Long> getCRLSequenceIdTable();
 
   /**

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/StorageContainerManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/StorageContainerManager.java
@@ -188,7 +188,6 @@ import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_EVENT_REPORT_EX
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_EVENT_REPORT_QUEUE_WAIT_THRESHOLD_DEFAULT;
 import static org.apache.hadoop.hdds.security.x509.certificate.authority.CertificateStore.CertType.VALID_CERTS;
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_ADMINISTRATORS;
-import static org.apache.hadoop.ozone.OzoneConsts.CRL_SEQUENCE_ID_KEY;
 import static org.apache.hadoop.ozone.OzoneConsts.SCM_SUB_CA_PREFIX;
 import static org.apache.hadoop.ozone.OzoneConsts.SCM_ROOT_CA_COMPONENT_NAME;
 
@@ -804,7 +803,7 @@ public final class StorageContainerManager extends ServiceRuntimeInfoImpl
     certificateStore =
         new SCMCertStore.Builder().setMetadaStore(scmMetadataStore)
             .setRatisServer(scmHAManager.getRatisServer())
-            .setCRLSequenceId(getLastSequenceIdForCRL()).build();
+            .setSequenceIdGenerator(sequenceIdGen).build();
 
 
     final CertificateServer scmCertificateServer;
@@ -1009,19 +1008,6 @@ public final class StorageContainerManager extends ServiceRuntimeInfoImpl
       }
       LOG.info("SCM login successful.");
     }
-  }
-
-  long getLastSequenceIdForCRL() throws IOException {
-    Long sequenceId =
-        scmMetadataStore.getCRLSequenceIdTable().get(CRL_SEQUENCE_ID_KEY);
-    // If the CRL_SEQUENCE_ID_KEY does not exist in DB return 0 so that new
-    // CRL requests can have sequence id starting from 1.
-    if (sequenceId == null) {
-      return 0L;
-    }
-    // If there exists a last sequence id in the DB, the new incoming
-    // CRL requests must have sequence ids greater than the one stored in the DB
-    return sequenceId;
   }
 
   /**

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/update/server/MockCRLStore.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/update/server/MockCRLStore.java
@@ -56,7 +56,6 @@ import java.util.concurrent.TimeoutException;
 public class MockCRLStore implements CRLStore {
 
   private static final String COMPONENT_NAME = "scm";
-  private static final Long INITIAL_SEQUENCE_ID = 0L;
 
   private OzoneConfiguration config;
   private SCMMetadataStore scmMetadataStore;
@@ -79,7 +78,6 @@ public class MockCRLStore implements CRLStore {
 
     scmMetadataStore = new SCMMetadataStoreImpl(config);
     scmCertStore = new SCMCertStore.Builder().setRatisServer(null)
-        .setCRLSequenceId(INITIAL_SEQUENCE_ID)
         .setMetadaStore(scmMetadataStore)
         .build();
     crlApprover = new DefaultCRLApprover(securityConfig,


### PR DESCRIPTION
## What changes were proposed in this pull request?
Use SequenceIDGenerator to generate CRL Sequence.

Currently, CRLSequenceId is generated by using CRLSequenceIdTable. We can remove CRLSequenceIdTable and use SequenceIDGenerator for CRLSequenceId.


## What is the link to the Apache JIRA
[HDDS-8341](https://issues.apache.org/jira/browse/HDDS-8341)

## How was this patch tested?
Existing unit tests
