### PR TITLE
HDDS-8339. Recon Show the number of keys marked for Deletion in Recon UI.

### DIFF
--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/api/ClusterStateEndpoint.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/api/ClusterStateEndpoint.java
@@ -148,7 +148,7 @@ public class ClusterStateEndpoint {
     }
 
     Long totalKeys = 0L;
-    Long deletedKeys = 0L;
+    Long keysPendingDeletion = 0L;
     Long deletedDirs = 0L;
 
     if (keyRecord != null) {
@@ -158,14 +158,14 @@ public class ClusterStateEndpoint {
       totalKeys += fileRecord.getValue();
     }
     if (deletedKeyRecord != null) {
-      deletedKeys += deletedKeyRecord.getValue();
+      keysPendingDeletion += deletedKeyRecord.getValue();
     }
     if (deletedDirRecord != null) {
       deletedDirs += deletedDirRecord.getValue();
     }
 
     builder.setKeys(totalKeys);
-    builder.setDeletedKeys(deletedKeys);
+    builder.setKeysPendingDeletion(keysPendingDeletion);
     builder.setDeletedDirs(deletedDirs);
 
     // Subtract deleted containers from total containers.

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/api/types/ClusterStateResponse.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/api/types/ClusterStateResponse.java
@@ -93,8 +93,8 @@ public final class ClusterStateResponse {
   /**
    * Total count of keys marked for deletion in the cluster.
    */
-  @JsonProperty("deletedKeys")
-  private long deletedKeys;
+  @JsonProperty("keysPendingDeletion")
+  private long keysPendingDeletion;
 
   /**
    * Total count of directories marked for deletion in the cluster.
@@ -122,7 +122,7 @@ public final class ClusterStateResponse {
     this.containers = b.containers;
     this.missingContainers = b.missingContainers;
     this.openContainers = b.openContainers;
-    this.deletedKeys = b.deletedKeys;
+    this.keysPendingDeletion = b.keysPendingDeletion;
     this.deletedDirs = b.deletedDirs;
     this.deletedContainers = b.deletedContainers;
   }
@@ -143,7 +143,7 @@ public final class ClusterStateResponse {
     private long volumes;
     private long buckets;
     private long keys;
-    private long deletedKeys;
+    private long keysPendingDeletion;
     private long deletedDirs;
 
     public Builder() {
@@ -158,7 +158,7 @@ public final class ClusterStateResponse {
       this.pipelines = 0;
       this.totalDatanodes = 0;
       this.healthyDatanodes = 0;
-      this.deletedKeys = 0;
+      this.keysPendingDeletion = 0;
       this.deletedDirs = 0;
     }
 
@@ -212,8 +212,8 @@ public final class ClusterStateResponse {
       return this;
     }
 
-    public void setDeletedKeys(long deletedKeys) {
-      this.deletedKeys = deletedKeys;
+    public void setKeysPendingDeletion(long keysPendingDeletion) {
+      this.keysPendingDeletion = keysPendingDeletion;
     }
 
     public void setDeletedDirs(long deletedDirs) {
@@ -276,8 +276,8 @@ public final class ClusterStateResponse {
     return keys;
   }
 
-  public long getDeletedKeys() {
-    return deletedKeys;
+  public long getKeysPendingDeletion() {
+    return keysPendingDeletion;
   }
 
   public long getDeletedDirs() {

--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/api/db.json
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/api/db.json
@@ -14,7 +14,8 @@
     "deletedContainers": 4,
     "volumes": 5,
     "buckets": 156,
-    "keys": 253000
+    "keys": 253000,
+    "keysPendingDeletion": 1000
   },
   "datanodes": {
     "totalCount": 12,

--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/views/overview/overview.tsx
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/views/overview/overview.tsx
@@ -42,6 +42,7 @@ interface IClusterStateResponse {
   keys: number;
   openContainers: number;
   deletedContainers: number;
+  keysPendingDeletion: number;
 }
 
 interface IOverviewState {
@@ -60,6 +61,7 @@ interface IOverviewState {
   omStatus: string;
   openContainers: number;
   deletedContainers: number;
+  keysPendingDeletion: number;
 }
 
 export class Overview extends React.Component<Record<string, object>, IOverviewState> {
@@ -87,7 +89,8 @@ export class Overview extends React.Component<Record<string, object>, IOverviewS
       lastUpdatedOMDBFull: 0,
       omStatus: '',
       openContainers: 0,
-      deletedContainers: 0
+      deletedContainers: 0,
+      keysPendingDeletion: 0
     };
     this.autoReload = new AutoReloadHelper(this._loadData);
   }
@@ -118,6 +121,7 @@ export class Overview extends React.Component<Record<string, object>, IOverviewS
         keys: clusterState.keys,
         missingContainersCount,
         openContainers: clusterState.openContainers,
+        keysPendingDeletion: clusterState.keysPendingDeletion,
         deletedContainers: clusterState.deletedContainers,
         lastRefreshed: Number(moment()),
         lastUpdatedOMDBDelta: omDBDeltaObject && omDBDeltaObject.lastUpdatedTimestamp,
@@ -162,7 +166,7 @@ export class Overview extends React.Component<Record<string, object>, IOverviewS
 
   render() {
     const {loading, datanodes, pipelines, storageReport, containers, volumes, buckets,
-      keys, missingContainersCount, lastRefreshed, lastUpdatedOMDBDelta, lastUpdatedOMDBFull, omStatus, openContainers, deletedContainers } = this.state;
+      keys, missingContainersCount, lastRefreshed, lastUpdatedOMDBDelta, lastUpdatedOMDBFull, omStatus, openContainers, deletedContainers, keysPendingDeletion} = this.state;
       
     const datanodesElement = (
       <span>
@@ -233,6 +237,9 @@ export class Overview extends React.Component<Record<string, object>, IOverviewS
           </Col>
           <Col xs={24} sm={18} md={12} lg={12} xl={6}>
             <OverviewCard loading={loading} title='Deleted Containers' data={deletedContainers.toString()} icon='delete' />
+          </Col>
+          <Col xs={24} sm={18} md={12} lg={12} xl={6}>
+            <OverviewCard loading={loading} title='Pending Key Deletions' data={keysPendingDeletion.toString()} icon='delete' />
           </Col>
         </Row>
       </div>

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/api/TestEndpoints.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/api/TestEndpoints.java
@@ -642,7 +642,7 @@ public class TestEndpoints extends AbstractReconSqlDBTest {
     Assertions.assertEquals(2, clusterStateResponse.getVolumes());
     Assertions.assertEquals(2, clusterStateResponse.getBuckets());
     Assertions.assertEquals(3, clusterStateResponse.getKeys());
-    Assertions.assertEquals(3, clusterStateResponse.getDeletedKeys());
+    Assertions.assertEquals(3, clusterStateResponse.getKeysPendingDeletion());
     Assertions.assertEquals(3, clusterStateResponse.getDeletedDirs());
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?
This information will be displayed on the overview page of recon which gets populated with the information provided by the ClusterStateEndpoint This information can be useful for auditing, compliance, and troubleshooting purposes. Hence in short the main purpose is to get a quick idea of the deletion progress.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-8339

## How was this patch tested?
Manually

![image](https://user-images.githubusercontent.com/112169209/236461046-b0812f1c-5cc3-44e5-8e97-c25a20a31797.png)





