### PR TITLE
HDDS-8351. ReplicationManager: Use RM exclude list when getting target nodes for reconstruction

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ECUnderReplicationHandler.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ECUnderReplicationHandler.java
@@ -141,6 +141,7 @@ public class ECUnderReplicationHandler implements UnhealthyReplicationHandler {
             ContainerReplicaOp.PendingOpType.ADD)
         .map(ContainerReplicaOp::getTarget)
         .collect(Collectors.toList()));
+    excludedNodes.addAll(replicationManager.getExcludedNodes());
 
     final ContainerID id = container.containerID();
     int commandsSent = 0;


### PR DESCRIPTION
## What changes were proposed in this pull request?

Use the exclude list added in HDDS-8334 when getting the target nodes from the placement policy for EC Reconstruction commands in the ECUnderReplicationHandler.

https://issues.apache.org/jira/browse/HDDS-8351

## How was this patch tested?

Added unit test.

https://github.com/adoroszlai/hadoop-ozone/actions/runs/4595979508