### PR TITLE
HDDS-8364. ReadReplicas may give wrong results with topology-aware read enabled

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/pipeline/Pipeline.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/pipeline/Pipeline.java
@@ -26,6 +26,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -541,6 +542,12 @@ public final class Pipeline {
     public Builder setNodes(List<DatanodeDetails> nodes) {
       this.nodeStatus = new LinkedHashMap<>();
       nodes.forEach(node -> nodeStatus.put(node, -1L));
+      if (nodesInOrder != null) {
+        // nodesInOrder may belong to another pipeline, avoid overwriting it
+        nodesInOrder = new LinkedList<>(nodesInOrder);
+        // drop nodes no longer part of the pipeline
+        nodesInOrder.retainAll(nodes);
+      }
       return this;
     }
 

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/checksum/ECFileChecksumHelper.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/checksum/ECFileChecksumHelper.java
@@ -173,16 +173,12 @@ public class ECFileChecksumHelper extends BaseFileChecksumHelper {
         nodes.add(dn);
       }
     }
-    List<DatanodeDetails> nodesInOrder =
-        new ArrayList<>(pipeline.getNodesInOrder());
-    nodesInOrder.retainAll(nodes);
 
     pipeline = Pipeline.newBuilder(pipeline)
         .setReplicationConfig(StandaloneReplicationConfig
             .getInstance(HddsProtos.ReplicationFactor.THREE))
         .setNodes(nodes)
         .build();
-    pipeline.setNodesInOrder(nodesInOrder);
 
     List<ContainerProtos.ChunkInfo> chunks;
     XceiverClientSpi xceiverClientSpi = null;

--- a/hadoop-ozone/dist/src/main/smoketest/debug/ozone-debug.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/debug/ozone-debug.robot
@@ -20,7 +20,7 @@ Resource            ../lib/os.robot
 
 *** Keywords ***
 Execute read-replicas CLI tool
-    Execute                         ozone debug read-replicas o3://om/${VOLUME}/${BUCKET}/${TESTFILE}
+    Execute                         ozone debug -Dozone.network.topology.aware.read=true read-replicas o3://om/${VOLUME}/${BUCKET}/${TESTFILE}
     ${directory} =                  Execute     ls -d /opt/hadoop/${VOLUME}_${BUCKET}_${TESTFILE}_*/ | tail -n 1
     Directory Should Exist          ${directory}
     File Should Exist               ${directory}/${TESTFILE}_manifest


### PR DESCRIPTION
## What changes were proposed in this pull request?

Due to same root cause as HDDS-8276, `ozone debug read-replicas` may give wrong results with topology-aware read enabled.  It creates a single-node copy of the original pipeline for each replica, but only updates `nodes`, not `nodesInOrder`.  If the replica is stale (offline but not yet dead), read is attempted and fails, and the client checks if there are any fallback nodes.  There should be none left (single-node pipeline), but with topology-aware read enabled the other two nodes are still present in the list.

This PR moves the fix that was originally added for EC file checksum to the pipeline copy builder, so that all usages get fixed (currently only these two cases change nodes in the copy pipeline).

https://issues.apache.org/jira/browse/HDDS-8364

## How was this patch tested?

Updated relevant smoketest to enable topology-aware read for this command, ran locally.

Ran `TestOzoneFileChecksum` for regression.

CI:
https://github.com/adoroszlai/hadoop-ozone/actions/runs/4598039439