### PR TITLE
HDDS-8345. [Snapshot] Remove snapshot from SnapshotChainManager in case couldn't add it to the cache/DB or any other failure.

### DIFF
--- a/hadoop-hdds/rocksdb-checkpoint-differ/src/main/java/org/apache/ozone/rocksdiff/RocksDBCheckpointDiffer.java
+++ b/hadoop-hdds/rocksdb-checkpoint-differ/src/main/java/org/apache/ozone/rocksdiff/RocksDBCheckpointDiffer.java
@@ -1062,7 +1062,7 @@ public class RocksDBCheckpointDiffer implements AutoCloseable {
     } catch (RocksDBException e) {
       LOG.warn("Can't get num of keys in SST '{}': {}", file, e.getMessage());
     } catch (FileNotFoundException e) {
-      LOG.info("Can't find SST '{}'", file, e);
+      LOG.info("Can't find SST '{}'", file);
     }
     CompactionNode fileNode = new CompactionNode(
         file, snapshotID, numKeys, seqNum);

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/SnapshotChainManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/SnapshotChainManager.java
@@ -84,7 +84,7 @@ public class SnapshotChainManager {
     if (prevGlobalID != null &&
         !snapshotChainGlobal.containsKey(prevGlobalID)) {
       throw new IOException("Snapshot Chain corruption: "
-          + " previous snapshotID given but no associated snapshot "
+          + "previous snapshotID given but no associated snapshot "
           + "found in snapshot chain: SnapshotID "
           + prevGlobalID);
     }


### PR DESCRIPTION
## What changes were proposed in this pull request?
This change is to remove snapshot from the `SnapshotChainManager `in case of any failure.It is possible that `createSnapshot` request fails after snapshot gets added to snapshot chain manager because couldn't add it to cache/DB. In this scenario,` SnapshotChainManager#globalSnapshotId` will point to failed `createSnapshot` request's snapshotId but in actual it doesn't exist in the `SnapshotInfo` table. If it doesn't get removed, OM restart will crash on `SnapshotChainManager#loadFromSnapshotInfoTable` because it could not find the previous snapshot which doesn't exist because it was never added to the `SnapshotInfo` table.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-8345

## How was this patch tested?
It was tested manually by injecting fault before [line](https://github.com/apache/ozone/blob/e8fbdaaca2a32c67aeb5ba8fbd23bb2a271480f2/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/snapshot/OMSnapshotCreateRequest.java#L173) and restart the OM node. Verified that OM restarts successfully after the change.
