### PR TITLE
HDDS-8358. Fix the space usage comparator in ContainerBalancerSelectionCriteria

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/balancer/ContainerBalancerSelectionCriteria.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/balancer/ContainerBalancerSelectionCriteria.java
@@ -120,7 +120,8 @@ public class ContainerBalancerSelectionCriteria {
    * @param second second container to compare
    * @return An integer greater than 0 if first is more used, 0 if they're
    * the same containers or a container is not found, and a value less than 0
-   * if first is not more used than second.
+   * if first is less used than second. If both containers have equal used
+   * space, they're compared using {@link ContainerID#compareTo(ContainerID)}.
    */
   private int isContainerMoreUsed(ContainerID first,
                                   ContainerID second) {

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/balancer/ContainerBalancerSelectionCriteria.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/balancer/ContainerBalancerSelectionCriteria.java
@@ -132,8 +132,10 @@ public class ContainerBalancerSelectionCriteria {
       ContainerInfo secondInfo = containerManager.getContainer(second);
       if (firstInfo.getUsedBytes() > secondInfo.getUsedBytes()) {
         return 1;
-      } else {
+      } else if (firstInfo.getUsedBytes() < secondInfo.getUsedBytes()) {
         return -1;
+      } else {
+        return first.compareTo(second);
       }
     } catch (ContainerNotFoundException e) {
       LOG.warn("Could not retrieve ContainerInfo from container manager for " +

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/balancer/TestContainerBalancerTask.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/balancer/TestContainerBalancerTask.java
@@ -1163,7 +1163,8 @@ public class TestContainerBalancerTask {
 
         // randomly pick a datanode for this replica
         int datanodeIndex = RANDOM.nextInt(0, numberOfNodes);
-        if (nodeUtilizations.get(i) != 0.0d) {
+        // don't put replicas in DNs that are supposed to have 0 utilization
+        if (Math.abs(nodeUtilizations.get(datanodeIndex) - 0.0d) > 0.00001) {
           DatanodeDetails node =
               nodesInCluster.get(datanodeIndex).getDatanodeDetails();
           Set<ContainerReplica> replicas =
@@ -1171,6 +1172,8 @@ public class TestContainerBalancerTask {
           replicas.add(createReplica(container.containerID(), node,
               container.getUsedBytes()));
           cidToReplicasMap.put(container.containerID(), replicas);
+          datanodeToContainersMap.get(nodesInCluster.get(datanodeIndex))
+              .add(container.containerID());
         }
       }
     }


### PR DESCRIPTION
## What changes were proposed in this pull request?

`ContainerBalancerSelectionCriteria` has a Comparator `orderContainersByUsedBytes` which is used for comparing containers on the basis of used space. This comparator calls `isContainerMoreUsed`, which does not have consistent behaviour when used space for two containers is equal.

This bug was exposed when fixing the setup of `TestContainerBalancerTask`.
`createReplicasForContainers()` in `TestContainerBalancerTask` creates additional container replicas but does not add them to `datanodeToContainersMap`, the map being used to track these. This PR intends to fix the bug and the test setup.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-8358