### PR TITLE
HDDS-8359. ReplicationManager: Fix getContainerReplicationHealth() so that it builds ContainerCheckRequest correctly

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ReplicationManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ReplicationManager.java
@@ -994,14 +994,16 @@ public class ReplicationManager implements SCMService {
    */
   public ContainerHealthResult getContainerReplicationHealth(
       ContainerInfo containerInfo, Set<ContainerReplica> replicas) {
-    ContainerCheckRequest request = new ContainerCheckRequest.Builder()
+    ContainerCheckRequest.Builder request = new ContainerCheckRequest.Builder()
         .setContainerInfo(containerInfo)
         .setContainerReplicas(replicas)
-        .build();
+        .setPendingOps(getPendingReplicationOps(containerInfo.containerID()));
     if (containerInfo.getReplicationConfig().getReplicationType() == EC) {
-      return ecReplicationCheckHandler.checkHealth(request);
+      request.setMaintenanceRedundancy(maintenanceRedundancy);
+      return ecReplicationCheckHandler.checkHealth(request.build());
     } else {
-      return ratisReplicationCheckHandler.checkHealth(request);
+      request.setMaintenanceRedundancy(ratisMaintenanceMinReplicas);
+      return ratisReplicationCheckHandler.checkHealth(request.build());
     }
   }
 

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestReplicationManager.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestReplicationManager.java
@@ -404,6 +404,37 @@ public class TestReplicationManager {
         ReplicationManagerReport.HealthState.UNDER_REPLICATED));
   }
 
+  /**
+   * {@link
+   * ReplicationManager#getContainerReplicationHealth(ContainerInfo, Set)}
+   * should return under replicated result for an under replicated container.
+   */
+  @Test
+  public void testGetContainerReplicationHealthForUnderReplicatedContainer() {
+    ContainerInfo container = createContainerInfo(repConfig, 1,
+        HddsProtos.LifeCycleState.CLOSED);
+    Set<ContainerReplica> replicas =
+        addReplicas(container, ContainerReplicaProto.State.CLOSED, 1, 2, 3, 4);
+
+    ContainerHealthResult result =
+        replicationManager.getContainerReplicationHealth(container, replicas);
+    Assert.assertEquals(ContainerHealthResult.HealthState.UNDER_REPLICATED,
+        result.getHealthState());
+
+    // Test the same for a RATIS container
+    RatisReplicationConfig ratisRepConfig =
+        RatisReplicationConfig.getInstance(THREE);
+    container = createContainerInfo(ratisRepConfig, 1L,
+        HddsProtos.LifeCycleState.CLOSED);
+    replicas = addReplicas(container, ContainerReplicaProto.State.CLOSED, 0,
+        0);
+
+    result =
+        replicationManager.getContainerReplicationHealth(container, replicas);
+    Assert.assertEquals(ContainerHealthResult.HealthState.UNDER_REPLICATED,
+        result.getHealthState());
+  }
+
   @Test
   public void testUnderReplicatedContainerFixedByPending()
       throws ContainerNotFoundException {


### PR DESCRIPTION
## What changes were proposed in this pull request?

`getContainerReplicationHealth()` in `ReplicationManager` does not set `pendingOps` and `maintenanceRedundancy` when building `ContainerCheckRequest`. This leads to errors such as:

```
scm_1         | java.lang.NullPointerException
scm_1         | 	at java.base/java.util.Collections$UnmodifiableCollection.<init>(Collections.java:1030)
scm_1         | 	at java.base/java.util.Collections$UnmodifiableList.<init>(Collections.java:1303)
scm_1         | 	at java.base/java.util.Collections.unmodifiableList(Collections.java:1290)
scm_1         | 	at org.apache.hadoop.hdds.scm.container.replication.ContainerCheckRequest.<init>(ContainerCheckRequest.java:45)
scm_1         | 	at org.apache.hadoop.hdds.scm.container.replication.ContainerCheckRequest.<init>(ContainerCheckRequest.java:31)
scm_1         | 	at org.apache.hadoop.hdds.scm.container.replication.ContainerCheckRequest$Builder.build(ContainerCheckRequest.java:119)
scm_1         | 	at org.apache.hadoop.hdds.scm.container.replication.ReplicationManager.getContainerReplicationHealth(ReplicationManager.java:923)
scm_1         | 	at org.apache.hadoop.hdds.scm.container.balancer.MoveManager.move(MoveManager.java:253)
...
```

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-8359

## How was this patch tested?

Added UT.