### PR TITLE
HDDS-8371. Avoid concatenating unexpected a full path and prefix

### DIFF
--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/KeyManagerImpl.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/KeyManagerImpl.java
@@ -1896,9 +1896,8 @@ public class KeyManagerImpl implements KeyManager {
             parentInfo.getObjectID())) {
           break;
         }
-        fileInfo.setFileName(fileInfo.getKeyName());
         String fullKeyPath = OMFileRequest.getAbsolutePath(
-            parentInfo.getKeyName(), fileInfo.getKeyName());
+            parentInfo.getKeyName(), fileInfo.getFileName());
         fileInfo.setKeyName(fullKeyPath);
 
         files.add(fileInfo);

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneListStatusHelper.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneListStatusHelper.java
@@ -314,9 +314,8 @@ public class OzoneListStatusHelper {
       } else {
         Preconditions.checkArgument(value instanceof OmKeyInfo);
         keyInfo = (OmKeyInfo) value;
-        keyInfo.setFileName(keyInfo.getKeyName());
         String fullKeyPath = OMFileRequest.getAbsolutePath(prefixPath,
-            keyInfo.getKeyName());
+            keyInfo.getFileName());
         keyInfo.setKeyName(fullKeyPath);
       }
       return new OzoneFileStatus(keyInfo, scmBlockSize, entryType.isDir());


### PR DESCRIPTION
## What changes were proposed in this pull request?
This is a workaround for HDDS-8371 when we have a dirty OMKeyInfo entry in the keyTable. The dirty in this context means keyName includes a prefix to the key in the keyName. As the listStatus API assumes non-prefixed keys to concatenate keys, we eventually get a wrong result from listStatus.

As a workaround, we can use fileName instead of keyName. I noticed keyInfo#fileName is not dirty in this case, which means does not include the prefix.

I think this is a short-term fix for this problem. But I'm not confident about how this change is valuable because it is something ad-hoc. The background is described as the above and Jira, so could you give me some comments?

For the root cause, I don't make sure whether this is from persistent information or dynamically generated information, but it seems OMKeyInfo#fromPersistedFormat() returns the dirty result. We need to fix the root cause later by reviewing the write path for keys.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-8371

## How was this patch tested?
- `mvn test` locally
- Unit Test triggered by CI