### PR TITLE
HDDS-8292. Inconsistent key name handling for FSO bucket files.

### DIFF
--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmDirectoryInfo.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmDirectoryInfo.java
@@ -272,6 +272,7 @@ public class OmDirectoryInfo extends WithParentObjectId implements Cloneable {
    */
   @Override
   public Object clone() throws CloneNotSupportedException {
-    return this.copyObject();
+    OmDirectoryInfo omDirectoryInfo = (OmDirectoryInfo) super.clone();
+    return omDirectoryInfo.copyObject();
   }
 }

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmDirectoryInfo.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmDirectoryInfo.java
@@ -33,7 +33,7 @@ import java.util.Objects;
  * in the user given path and a pointer to its parent directory element in the
  * path. Also, it stores directory node related metdata details.
  */
-public class OmDirectoryInfo extends WithParentObjectId {
+public class OmDirectoryInfo extends WithParentObjectId implements Cloneable {
   private String name; // directory name
 
   private long creationTime;
@@ -265,5 +265,13 @@ public class OmDirectoryInfo extends WithParentObjectId {
     }
 
     return builder.build();
+  }
+
+  /**
+   * Return a new copy of the object.
+   */
+  @Override
+  public Object clone() throws CloneNotSupportedException {
+    return this.copyObject();
   }
 }

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmDirectoryInfo.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmDirectoryInfo.java
@@ -24,6 +24,7 @@ import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos;
 import java.util.BitSet;
 import java.util.HashMap;
 import java.util.LinkedList;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -273,6 +274,19 @@ public class OmDirectoryInfo extends WithParentObjectId implements Cloneable {
   @Override
   public Object clone() throws CloneNotSupportedException {
     OmDirectoryInfo omDirectoryInfo = (OmDirectoryInfo) super.clone();
-    return omDirectoryInfo.copyObject();
+
+    omDirectoryInfo.metadata = new HashMap<>();
+    omDirectoryInfo.acls = new ArrayList<>();
+
+    acls.stream().filter(acl -> acl != null).forEach(acl ->
+            omDirectoryInfo.acls.add(new OzoneAcl(acl.getType(),
+                    acl.getName(), (BitSet) acl.getAclBitSet().clone(),
+                    acl.getAclScope())));
+
+    if (metadata != null) {
+      metadata.forEach((k, v) -> omDirectoryInfo.metadata.put(k, v));
+    }
+
+    return omDirectoryInfo;
   }
 }

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmKeyInfo.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmKeyInfo.java
@@ -795,7 +795,28 @@ public final class OmKeyInfo extends WithParentObjectId implements Cloneable {
   @Override
   public Object clone() throws CloneNotSupportedException {
     OmKeyInfo omKeyInfo = (OmKeyInfo) super.clone();
-    return omKeyInfo.copyObject();
+
+    omKeyInfo.metadata = new HashMap<>();
+    omKeyInfo.keyLocationVersions = new ArrayList<>();
+    omKeyInfo.acls = new ArrayList<>();
+
+    keyLocationVersions.stream().filter(keyLocationVersion ->
+            keyLocationVersion != null).forEach(keyLocationVersion ->
+            omKeyInfo.keyLocationVersions.add(
+                    new OmKeyLocationInfoGroup(keyLocationVersion.getVersion(),
+                            keyLocationVersion.getLocationList(),
+                            keyLocationVersion.isMultipartKey())));
+
+    acls.stream().filter(acl -> acl != null).forEach(acl ->
+            omKeyInfo.acls.add(new OzoneAcl(acl.getType(),
+                    acl.getName(), (BitSet) acl.getAclBitSet().clone(),
+                    acl.getAclScope())));
+
+    if (metadata != null) {
+      metadata.forEach((k, v) -> omKeyInfo.metadata.put(k, v));
+    }
+
+    return omKeyInfo;
   }
 
   /**

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmKeyInfo.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmKeyInfo.java
@@ -48,7 +48,7 @@ import org.slf4j.LoggerFactory;
  * This is returned from OM to client, and client use class to talk to
  * datanode. Also, this is the metadata written to om.db on server side.
  */
-public final class OmKeyInfo extends WithParentObjectId {
+public final class OmKeyInfo extends WithParentObjectId implements Cloneable {
   private static final Logger LOG = LoggerFactory.getLogger(OmKeyInfo.class);
   private final String volumeName;
   private final String bucketName;
@@ -787,6 +787,14 @@ public final class OmKeyInfo extends WithParentObjectId {
     }
 
     return builder.build();
+  }
+
+  /**
+   * Return a new copy of the object.
+   */
+  @Override
+  public Object clone() throws CloneNotSupportedException {
+    return this.copyObject();
   }
 
   /**

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmKeyInfo.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmKeyInfo.java
@@ -794,7 +794,8 @@ public final class OmKeyInfo extends WithParentObjectId implements Cloneable {
    */
   @Override
   public Object clone() throws CloneNotSupportedException {
-    return this.copyObject();
+    OmKeyInfo omKeyInfo = (OmKeyInfo) super.clone();
+    return omKeyInfo.copyObject();
   }
 
   /**

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneListStatusHelper.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneListStatusHelper.java
@@ -18,6 +18,7 @@ package org.apache.hadoop.ozone.om;
 
 import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
+import org.apache.commons.lang3.ObjectUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.hadoop.hdds.utils.db.Table;
 import org.apache.hadoop.hdds.utils.db.TableIterator;
@@ -444,6 +445,11 @@ public class OzoneListStatusHelper {
           continue;
         }
 
+        // Copy cache value to local copy and work on it
+        Value copyOmInfo = ObjectUtils.clone(cacheOmInfo);
+        if (copyOmInfo != null) {
+          cacheOmInfo = copyOmInfo;
+        }
         if (StringUtils.isBlank(startKey)) {
           // startKey is null or empty, then the seekKeyInDB="1024/"
           if (cacheKey.startsWith(prefixKey)) {


### PR DESCRIPTION
## What changes were proposed in this pull request?

ListStatus should use local cache copy. It should not use and update main cache which is used for DB updation.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-8292

## How was this patch tested?

Tested using below steps
1. Create file
2. Commit key
3. Rename file (cache value updated in OM memory, still value to be updated in Rocksdb which in this case happened at step  5)
4. List status is called, which reads from cache as well as updating cache value to full path(which it should not mean to do))-->At this step keyName is becoming wrong.
		If X number of times, List status is called before commit to DB, X number of times keys are appended.
5. Write to DB(commit to DB for rename file operation) -->Since memory value is corrupted it inserts repeated keyName to DB.
After the fix, it works in local cache and doesn't impact doublebuffer cache. RocksDB updates with correct keyName and also ListStatus returns proper result.
