### PR TITLE
HDDS-8228. Add metric for out of order/retried delete transactions

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/helpers/BlockDeletingServiceMetrics.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/helpers/BlockDeletingServiceMetrics.java
@@ -45,6 +45,9 @@ public final class BlockDeletingServiceMetrics {
   @Metric(about = "The number of failed delete blocks.")
   private MutableCounterLong failureCount;
 
+  @Metric(about = "The number of out of order delete block transaction.")
+  private MutableCounterLong outOfOrderDeleteBlockTransactionCount;
+
   private BlockDeletingServiceMetrics() {
   }
 
@@ -91,12 +94,22 @@ public final class BlockDeletingServiceMetrics {
     return failureCount.value();
   }
 
+  public void incOutOfOrderDeleteBlockTransactionCount() {
+    this.outOfOrderDeleteBlockTransactionCount.incr();
+  }
+
+  public long getOutOfOrderDeleteBlockTransactionCount() {
+    return outOfOrderDeleteBlockTransactionCount.value();
+  }
+
   @Override
   public String toString() {
     StringBuffer buffer = new StringBuffer();
     buffer.append("successCount = " + successCount.value()).append("\t")
         .append("successBytes = " + successBytes.value()).append("\t")
-        .append("failureCount = " + failureCount.value()).append("\t");
+        .append("failureCount = " + failureCount.value()).append("\t")
+        .append("outOfOrderDeleteBlockTransactionCount = "
+            + outOfOrderDeleteBlockTransactionCount.value()).append("\t");
     return buffer.toString();
   }
 }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/DeleteBlocksCommandHandler.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/DeleteBlocksCommandHandler.java
@@ -489,7 +489,7 @@ public class DeleteBlocksCommandHandler implements CommandHandler {
     }
 
     if (delTX.getTxID() <= containerData.getDeleteTransactionId()) {
-      blockDeleteMetrics.incrFailureCount();
+      blockDeleteMetrics.incOutOfOrderDeleteBlockTransactionCount();
       LOG.info(String.format("Delete blocks for containerId: %d"
               + " is either received out of order or retried,"
               + " %d <= %d", containerId, delTX.getTxID(),

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/DeleteBlocksCommandHandler.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/DeleteBlocksCommandHandler.java
@@ -32,6 +32,7 @@ import org.apache.hadoop.hdds.protocol.proto
     .StorageContainerDatanodeProtocolProtos.DeletedBlocksTransaction;
 import org.apache.hadoop.hdds.utils.db.Table;
 import org.apache.hadoop.ozone.container.common.helpers.BlockData;
+import org.apache.hadoop.ozone.container.common.helpers.BlockDeletingServiceMetrics;
 import org.apache.hadoop.ozone.container.common.helpers.ChunkInfoList;
 import org.apache.hadoop.ozone.container.common.helpers
     .DeletedContainerBlocksSummary;
@@ -89,12 +90,14 @@ public class DeleteBlocksCommandHandler implements CommandHandler {
   private final LinkedBlockingQueue<DeleteCmdInfo> deleteCommandQueues;
   private final Daemon handlerThread;
   private final OzoneContainer ozoneContainer;
+  private final BlockDeletingServiceMetrics blockDeleteMetrics;
 
   public DeleteBlocksCommandHandler(OzoneContainer container,
       ConfigurationSource conf, int threadPoolSize, int queueLimit) {
     this.ozoneContainer = container;
     this.containerSet = container.getContainerSet();
     this.conf = conf;
+    this.blockDeleteMetrics = BlockDeletingServiceMetrics.create();
     this.executor = Executors.newFixedThreadPool(
         threadPoolSize, new ThreadFactoryBuilder()
             .setNameFormat("DeleteBlocksCommandHandlerThread-%d").build());
@@ -486,6 +489,7 @@ public class DeleteBlocksCommandHandler implements CommandHandler {
     }
 
     if (delTX.getTxID() <= containerData.getDeleteTransactionId()) {
+      blockDeleteMetrics.incrFailureCount();
       LOG.info(String.format("Delete blocks for containerId: %d"
               + " is either received out of order or retried,"
               + " %d <= %d", containerId, delTX.getTxID(),


### PR DESCRIPTION
## What changes were proposed in this pull request?

- metrics added to count out of order delete transactions received from scm

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-8228

## How was this patch tested?

Patch is verified with E2E to check metrics reporting

<img width="990" alt="image" src="https://user-images.githubusercontent.com/23372859/229807728-2848da99-bdb3-4c00-8623-ea281e5ca6a6.png">

