### PR TITLE
HDDS-8337. MisReplicationHandler should throw an exception if partially successful

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/InsufficientDatanodesException.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/InsufficientDatanodesException.java
@@ -33,4 +33,11 @@ public class InsufficientDatanodesException extends IOException {
   public InsufficientDatanodesException(String message) {
     super(message);
   }
+
+  public InsufficientDatanodesException(int required, int available) {
+    super("Not enough datanodes" +
+        ", requested: " + required +
+        ", found: " + available
+    );
+  }
 }

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestECMisReplicationHandler.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestECMisReplicationHandler.java
@@ -26,6 +26,7 @@ import org.apache.hadoop.hdds.scm.PlacementPolicy;
 import org.apache.hadoop.hdds.scm.container.ContainerReplica;
 import org.apache.hadoop.hdds.scm.exceptions.SCMException;
 import org.apache.hadoop.hdds.scm.node.states.NodeNotFoundException;
+import org.apache.hadoop.hdds.scm.pipeline.InsufficientDatanodesException;
 import org.apache.ratis.protocol.exceptions.NotLeaderException;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
@@ -39,6 +40,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 
+import static java.util.Collections.singletonList;
 import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.NodeOperationalState.IN_MAINTENANCE;
 import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.NodeOperationalState.IN_SERVICE;
 import static org.junit.Assert.assertThrows;
@@ -157,12 +159,12 @@ public class TestECMisReplicationHandler extends TestMisReplicationHandler {
             .thenReturn(true);
     Mockito.when(placementPolicy.validateContainerPlacement(anyList(),
             anyInt())).thenReturn(mockedContainerPlacementStatus);
-    List<ContainerReplicaOp> pendingOp = Collections.singletonList(
+    List<ContainerReplicaOp> pendingOp = singletonList(
             ContainerReplicaOp.create(ContainerReplicaOp.PendingOpType.ADD,
                     MockDatanodeDetails.randomDatanodeDetails(), 1));
     testMisReplication(availableReplicas, placementPolicy,
             pendingOp, 0, 1, 0);
-    pendingOp = Collections.singletonList(ContainerReplicaOp
+    pendingOp = singletonList(ContainerReplicaOp
             .create(ContainerReplicaOp.PendingOpType.DELETE, availableReplicas
                     .stream().findAny().get().getDatanodeDetails(), 1));
     testMisReplication(availableReplicas, placementPolicy,
@@ -180,8 +182,24 @@ public class TestECMisReplicationHandler extends TestMisReplicationHandler {
             Pair.of(IN_SERVICE, 3), Pair.of(IN_SERVICE, 4),
             Pair.of(IN_SERVICE, 5));
     assertThrows(CommandTargetOverloadedException.class,
+        () -> testMisReplication(availableReplicas, mockPlacementPolicy(),
+            Collections.emptyList(), 0, 1, 1, 0));
+  }
+
+  @Test
+  public void commandsForFewerThanRequiredNodes() throws IOException {
+    Set<ContainerReplica> availableReplicas = ReplicationTestUtil
+        .createReplicas(Pair.of(IN_SERVICE, 1), Pair.of(IN_SERVICE, 2),
+            Pair.of(IN_SERVICE, 3), Pair.of(IN_SERVICE, 4),
+            Pair.of(IN_SERVICE, 5));
+    PlacementPolicy placementPolicy = Mockito.mock(PlacementPolicy.class);
+    Mockito.when(placementPolicy.chooseDatanodes(
+            any(), any(), any(),
+            Mockito.anyInt(), Mockito.anyLong(), Mockito.anyLong()))
+        .thenReturn(singletonList(availableReplicas.iterator().next()));
+    assertThrows(InsufficientDatanodesException.class,
         () -> testMisReplication(availableReplicas, Collections.emptyList(),
-            0, 1, 1));
+            0, 2, 1));
   }
 
   @Override

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestRatisMisReplicationHandler.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestRatisMisReplicationHandler.java
@@ -185,8 +185,8 @@ public class TestRatisMisReplicationHandler extends TestMisReplicationHandler {
         .createReplicas(Pair.of(IN_SERVICE, 0), Pair.of(IN_SERVICE, 0),
             Pair.of(IN_SERVICE, 0));
     assertThrows(CommandTargetOverloadedException.class,
-        () -> testMisReplication(availableReplicas, Collections.emptyList(),
-            0, 1, 1));
+        () -> testMisReplication(availableReplicas, mockPlacementPolicy(),
+            Collections.emptyList(), 0, 1, 1, 0));
   }
 
   @Override


### PR DESCRIPTION
## What changes were proposed in this pull request?

`MisReplicationHandler` execution may result in fewer than expected (but more than 0) commands to be sent.  It should throw an exception to let `ReplicationManager` requeue the task for retry later.

https://issues.apache.org/jira/browse/HDDS-8337

## How was this patch tested?

Added unit test.

https://github.com/adoroszlai/hadoop-ozone/actions/runs/4610104612