### PR TITLE
HDDS-8352. OM crash with NPE in OMKeyCommitRequest due to missing user info

### DIFF
--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyCommitRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyCommitRequest.java
@@ -105,7 +105,8 @@ public class OMKeyCommitRequest extends OMKeyRequest {
 
     return getOmRequest().toBuilder()
         .setCommitKeyRequest(commitKeyRequest.toBuilder()
-            .setKeyArgs(newKeyArgs)).setUserInfo(getUserInfo()).build();
+            .setKeyArgs(newKeyArgs))
+        .setUserInfo(getUserIfNotExists(ozoneManager)).build();
   }
 
   @Override

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyCommitRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyCommitRequest.java
@@ -81,7 +81,8 @@ public class OMKeyCommitRequest extends OMKeyRequest {
 
   @Override
   public OMRequest preExecute(OzoneManager ozoneManager) throws IOException {
-    CommitKeyRequest commitKeyRequest = getOmRequest().getCommitKeyRequest();
+    OMRequest request = super.preExecute(ozoneManager);
+    CommitKeyRequest commitKeyRequest = request.getCommitKeyRequest();
     Preconditions.checkNotNull(commitKeyRequest);
 
     KeyArgs keyArgs = commitKeyRequest.getKeyArgs();
@@ -103,10 +104,9 @@ public class OMKeyCommitRequest extends OMKeyRequest {
         keyArgs.toBuilder().setModificationTime(Time.now())
             .setKeyName(keyPath);
 
-    return getOmRequest().toBuilder()
+    return request.toBuilder()
         .setCommitKeyRequest(commitKeyRequest.toBuilder()
-            .setKeyArgs(newKeyArgs))
-        .setUserInfo(getUserIfNotExists(ozoneManager)).build();
+            .setKeyArgs(newKeyArgs)).build();
   }
 
   @Override


### PR DESCRIPTION
## What changes were proposed in this pull request?

- while set userInfo in create request in pre-execute, getUserIfNotExist() method is used to populate process userName for non-rpc call for HSync feature, where it can be triggered during OpenKeyCleanupService additionally.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-8352

## How was this patch tested?

verified impact of existing test cases in integration test.
