### PR TITLE
HDDS-8170. Let ContainerBalancer consider EC containers for balancing

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/balancer/ContainerBalancer.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/balancer/ContainerBalancer.java
@@ -411,7 +411,7 @@ public class ContainerBalancer extends StatefulService {
     if (conf.getBalancingInterval().toMillis() <= refreshPeriod) {
       LOG.warn("hdds.container.balancer.balancing.iteration.interval {} " +
               "should be greater than hdds.datanode.du.refresh.period {}",
-          conf.getBalancingInterval(), refreshPeriod);
+          conf.getBalancingInterval().toMillis(), refreshPeriod);
     }
 
     // "move.replication.timeout" should be lesser than "move.timeout"

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/balancer/ContainerBalancerSelectionCriteria.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/balancer/ContainerBalancerSelectionCriteria.java
@@ -166,10 +166,8 @@ public class ContainerBalancerSelectionCriteria {
    * .enable.legacy" is true, else false
    */
   private boolean isECContainer(ContainerInfo container) {
-    boolean legacyEnabled = ozoneConfiguration.
-        getBoolean("hdds.scm.replication.enable.legacy", true);
     return container.getReplicationType().equals(HddsProtos.ReplicationType.EC)
-        && legacyEnabled;
+        && replicationManager.getConfig().isLegacyEnabled();
   }
 
   private boolean shouldBeExcluded(ContainerID containerID,

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/balancer/ContainerBalancerSelectionCriteria.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/balancer/ContainerBalancerSelectionCriteria.java
@@ -16,7 +16,6 @@
  */
 package org.apache.hadoop.hdds.scm.container.balancer;
 
-import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.hdds.scm.container.ContainerID;
@@ -50,15 +49,13 @@ public class ContainerBalancerSelectionCriteria {
   private Set<ContainerID> selectedContainers;
   private Set<ContainerID> excludeContainers;
   private FindSourceStrategy findSourceStrategy;
-  private OzoneConfiguration ozoneConfiguration;
 
   public ContainerBalancerSelectionCriteria(
       ContainerBalancerConfiguration balancerConfiguration,
       NodeManager nodeManager,
       ReplicationManager replicationManager,
       ContainerManager containerManager,
-      FindSourceStrategy findSourceStrategy,
-      OzoneConfiguration ozoneConfiguration) {
+      FindSourceStrategy findSourceStrategy) {
     this.balancerConfiguration = balancerConfiguration;
     this.nodeManager = nodeManager;
     this.replicationManager = replicationManager;
@@ -66,7 +63,6 @@ public class ContainerBalancerSelectionCriteria {
     selectedContainers = new HashSet<>();
     excludeContainers = balancerConfiguration.getExcludeContainers();
     this.findSourceStrategy = findSourceStrategy;
-    this.ozoneConfiguration = ozoneConfiguration;
   }
 
   /**

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/balancer/ContainerBalancerSelectionCriteria.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/balancer/ContainerBalancerSelectionCriteria.java
@@ -16,6 +16,7 @@
  */
 package org.apache.hadoop.hdds.scm.container.balancer;
 
+import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.hdds.scm.container.ContainerID;
@@ -49,13 +50,15 @@ public class ContainerBalancerSelectionCriteria {
   private Set<ContainerID> selectedContainers;
   private Set<ContainerID> excludeContainers;
   private FindSourceStrategy findSourceStrategy;
+  private OzoneConfiguration ozoneConfiguration;
 
   public ContainerBalancerSelectionCriteria(
       ContainerBalancerConfiguration balancerConfiguration,
       NodeManager nodeManager,
       ReplicationManager replicationManager,
       ContainerManager containerManager,
-      FindSourceStrategy findSourceStrategy) {
+      FindSourceStrategy findSourceStrategy,
+      OzoneConfiguration ozoneConfiguration) {
     this.balancerConfiguration = balancerConfiguration;
     this.nodeManager = nodeManager;
     this.replicationManager = replicationManager;
@@ -63,6 +66,7 @@ public class ContainerBalancerSelectionCriteria {
     selectedContainers = new HashSet<>();
     excludeContainers = balancerConfiguration.getExcludeContainers();
     this.findSourceStrategy = findSourceStrategy;
+    this.ozoneConfiguration = ozoneConfiguration;
   }
 
   /**
@@ -158,10 +162,14 @@ public class ContainerBalancerSelectionCriteria {
    * Checks whether a Container has the ReplicationType
    * {@link HddsProtos.ReplicationType#EC}.
    * @param container container to check
-   * @return true if the ReplicationType is EC, else false
+   * @return true if the ReplicationType is EC and "hdds.scm.replication
+   * .enable.legacy" is true, else false
    */
   private boolean isECContainer(ContainerInfo container) {
-    return container.getReplicationType().equals(HddsProtos.ReplicationType.EC);
+    boolean legacyEnabled = ozoneConfiguration.
+        getBoolean("hdds.scm.replication.enable.legacy", true);
+    return container.getReplicationType().equals(HddsProtos.ReplicationType.EC)
+        && legacyEnabled;
   }
 
   private boolean shouldBeExcluded(ContainerID containerID,

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/balancer/ContainerBalancerTask.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/balancer/ContainerBalancerTask.java
@@ -463,7 +463,8 @@ public class ContainerBalancerTask implements Runnable {
     }
 
     selectionCriteria = new ContainerBalancerSelectionCriteria(config,
-        nodeManager, replicationManager, containerManager, findSourceStrategy);
+        nodeManager, replicationManager, containerManager, findSourceStrategy,
+        ozoneConfiguration);
     return true;
   }
 

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/balancer/ContainerBalancerTask.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/balancer/ContainerBalancerTask.java
@@ -811,8 +811,7 @@ public class ContainerBalancerTask implements Runnable {
       If LegacyReplicationManager is enabled, ReplicationManager will
       redirect to it. Otherwise, use MoveManager.
        */
-      if (ozoneConfiguration.getBoolean("hdds.scm.replication.enable.legacy",
-          true)) {
+      if (replicationManager.getConfig().isLegacyEnabled()) {
         future = replicationManager
             .move(containerID, source, moveSelection.getTargetNode());
       } else {

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/balancer/ContainerBalancerTask.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/balancer/ContainerBalancerTask.java
@@ -463,8 +463,7 @@ public class ContainerBalancerTask implements Runnable {
     }
 
     selectionCriteria = new ContainerBalancerSelectionCriteria(config,
-        nodeManager, replicationManager, containerManager, findSourceStrategy,
-        ozoneConfiguration);
+        nodeManager, replicationManager, containerManager, findSourceStrategy);
     return true;
   }
 

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/balancer/MoveManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/balancer/MoveManager.java
@@ -158,6 +158,8 @@ public final class MoveManager implements
         // for example , after becoming a new leader, we might need
         // to complete some moves and we know these futures does not
         // exist.
+        LOG.debug("Completing container move for container {} with result {}.",
+            cid, mr);
         future.complete(mr);
       }
     }
@@ -369,6 +371,9 @@ public final class MoveManager implements
     }
     MoveDataNodePair movePair = pair.getRight();
     final DatanodeDetails src = movePair.getSrc();
+    final DatanodeDetails tgt = movePair.getTgt();
+    LOG.debug("Handling successful addition of Container {} from" +
+        " source {} to target {}.", cid, src, tgt);
 
     ContainerInfo containerInfo = containerManager.getContainer(cid);
     synchronized (containerInfo) {

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/balancer/TestContainerBalancerTask.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/balancer/TestContainerBalancerTask.java
@@ -56,7 +56,6 @@ import org.apache.ozone.test.GenericTestUtils;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -294,11 +293,7 @@ public class TestContainerBalancerTask {
       throws IllegalContainerBalancerStateException, IOException,
       InvalidContainerBalancerConfigurationException, TimeoutException,
       NodeNotFoundException {
-    ReplicationManagerConfiguration rmConf =
-        conf.getObject(ReplicationManagerConfiguration.class);
     rmConf.setEnableLegacy(false);
-    conf.setFromObject(rmConf);
-
     startBalancer(balancerConfiguration);
     Mockito.verify(moveManager, atLeastOnce())
         .move(Mockito.any(ContainerID.class),


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR enables balancing EC containers in `ContainerBalancer`. Since `MoveManager` has been integrated with ContainerBalancer now, we can support balancing EC containers.

Changes include:
1. Exclude EC containers from balancing in `ContainerBalancerSelectionCriteria` only if Legacy RM is enabled.
2. Add some `DEBUG` logs in `MoveManager`.
3. Fix a small bug in `ContainerBalancer` where it was logging a `Duration` instead of the long value of a config.
4. Update the setup in `TestContainerBalancerTask` to also create EC containers along with the RATIS containers it was already creating. Change some tests accordingly.
5. Disable Legacy RM in `TestContainerBalancerTask`, except in specific tests where we're testing both Legacy RM and `MoveManager`.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-8170

## How was this patch tested?

Green CI in my fork: https://github.com/siddhantsangwan/ozone/actions/runs/4617711869

Added a UT and did some docker-compose manual testing.

Screenshot showing an EC container with id 6 and replica index 4 being replicated by balancer:
<img width="1476" alt="replicate_ec" src="https://user-images.githubusercontent.com/34305492/230081459-f57c2c12-c633-4d76-b5e4-3ff0abbc0824.png">

Screenshot showing the same container being deleted:
<img width="1476" alt="delete_ec" src="https://user-images.githubusercontent.com/34305492/230081605-c394a307-63f9-41e2-ba11-b0fe333ebbe3.png">