### PR TITLE
HDDS-8357. Exclude spring-jcl to avoid dependency conflict

### DIFF
--- a/hadoop-ozone/dist/src/main/license/bin/LICENSE.txt
+++ b/hadoop-ozone/dist/src/main/license/bin/LICENSE.txt
@@ -442,7 +442,6 @@ Apache License 2.0
    org.rocksdb:rocksdbjni
    org.springframework:spring-beans
    org.springframework:spring-core
-   org.springframework:spring-jcl
    org.springframework:spring-jdbc
    org.springframework:spring-tx
    org.xerial.snappy:snappy-java

--- a/hadoop-ozone/dist/src/main/license/jar-report.txt
+++ b/hadoop-ozone/dist/src/main/license/jar-report.txt
@@ -253,7 +253,6 @@ share/ozone/lib/snakeyaml.jar
 share/ozone/lib/snappy-java.jar
 share/ozone/lib/spring-beans.jar
 share/ozone/lib/spring-core.jar
-share/ozone/lib/spring-jcl.jar
 share/ozone/lib/spring-jdbc.jar
 share/ozone/lib/spring-tx.jar
 share/ozone/lib/sqlite-jdbc.jar

--- a/hadoop-ozone/recon-codegen/pom.xml
+++ b/hadoop-ozone/recon-codegen/pom.xml
@@ -40,6 +40,12 @@
       <groupId>org.springframework</groupId>
       <artifactId>spring-jdbc</artifactId>
       <version>${spring.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>org.springframework</groupId>
+          <artifactId>spring-jcl</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.jooq</groupId>

--- a/hadoop-ozone/recon/pom.xml
+++ b/hadoop-ozone/recon/pom.xml
@@ -339,6 +339,12 @@
       <groupId>org.springframework</groupId>
       <artifactId>spring-jdbc</artifactId>
       <version>${spring.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>org.springframework</groupId>
+          <artifactId>spring-jcl</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>javax.activation</groupId>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Exclude `spring-jcl` so as to suppress the following log.

```
ozone-recon-0: 2023-04-02 14:47:27,640 [main] WARN http.HttpRequestLog: Jetty request log can only be enabled using Log4j 
```

This issue happens because `spring-jcl` introduces [another implementation of LogFactory](https://github.com/spring-projects/spring-framework/blob/v5.3.23/spring-jcl/src/main/java/org/apache/commons/logging/LogFactory.java) and the implementation of `spring-jcl` can be loaded.
This PR takes the approach to exclude `spring-jcl` following [the instruction](https://github.com/spring-projects/spring-framework/blob/v5.3.23/spring-jcl/src/main/java/org/apache/commons/logging/package-info.java).

There would be other approaches.
- Fix [HttpRequestLog](https://github.com/apache/ozone/blob/53d8fe0e57f644989da927b65d00fecdbbfc4138/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/server/http/HttpRequestLog.java#L64-L105)

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-8357

## How was this patch tested?

I verified that the WARN log was gone.
