### PR TITLE
HDDS-7943. Link Datanode WebUIs from the Node Status table on SCM WebUI

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/protocol/DatanodeDetails.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/protocol/DatanodeDetails.java
@@ -802,7 +802,7 @@ public class DatanodeDetails extends NodeImpl implements
      */
     public enum Name {
       STANDALONE, RATIS, REST, REPLICATION, RATIS_ADMIN, RATIS_SERVER,
-      RATIS_DATASTREAM;
+      RATIS_DATASTREAM, HTTP, HTTPS;
 
       public static final Set<Name> ALL_PORTS = ImmutableSet.copyOf(
           Name.values());

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/HddsDatanodeService.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/HddsDatanodeService.java
@@ -44,6 +44,7 @@ import org.apache.hadoop.hdds.security.x509.SecurityConfig;
 import org.apache.hadoop.hdds.security.x509.certificate.client.CertificateClient;
 import org.apache.hadoop.hdds.security.x509.certificate.client.DNCertificateClient;
 import org.apache.hadoop.hdds.security.x509.certificate.utils.CertificateSignRequest;
+import org.apache.hadoop.hdds.server.http.HttpConfig;
 import org.apache.hadoop.hdds.server.http.RatisDropwizardExports;
 import org.apache.hadoop.hdds.tracing.TracingUtil;
 import org.apache.hadoop.hdds.utils.HddsServerUtil;
@@ -67,6 +68,8 @@ import org.apache.hadoop.util.Time;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 
+import static org.apache.hadoop.hdds.protocol.DatanodeDetails.Port.Name.HTTP;
+import static org.apache.hadoop.hdds.protocol.DatanodeDetails.Port.Name.HTTPS;
 import static org.apache.hadoop.ozone.OzoneConfigKeys.HDDS_DATANODE_PLUGINS_KEY;
 import static org.apache.hadoop.ozone.conf.OzoneServiceConfig.DEFAULT_SHUTDOWN_HOOK_PRIORITY;
 import static org.apache.hadoop.ozone.common.Storage.StorageState.INITIALIZED;
@@ -275,6 +278,15 @@ public class HddsDatanodeService extends GenericCli implements ServicePlugin {
       try {
         httpServer = new HddsDatanodeHttpServer(conf);
         httpServer.start();
+        HttpConfig.Policy policy = HttpConfig.getHttpPolicy(conf);
+        if (policy.isHttpEnabled()) {
+          datanodeDetails.setPort(DatanodeDetails.newPort(HTTP,
+                  httpServer.getHttpAddress().getPort()));
+        }
+        if (policy.isHttpsEnabled()) {
+          datanodeDetails.setPort(DatanodeDetails.newPort(HTTPS,
+                  httpServer.getHttpsAddress().getPort()));
+        }
       } catch (Exception ex) {
         LOG.error("HttpServer failed to start.", ex);
       }

--- a/hadoop-hdds/framework/src/main/resources/webapps/static/ozone.css
+++ b/hadoop-hdds/framework/src/main/resources/webapps/static/ozone.css
@@ -53,7 +53,36 @@ body {
 .sortorder.reverse:after {
     content: '\25bc';   // BLACK DOWN-POINTING TRIANGLE
 }
-
+.sorting:after {
+    opacity: 0.2;
+    content: "\e150";
+    position: absolute;
+    top: 8px;
+    right: 8px;
+    display: block;
+    font-family: 'Glyphicons Halflings';
+ }
+.sortasc:after {
+     opacity: 0.5;
+     content: "\e155";
+     position: absolute;
+     top: 8px;
+     right: 8px;
+     display: block;
+     font-family: 'Glyphicons Halflings';
+ }
+ .sortdesc:after {
+     opacity: 0.5;
+     content: "\e156";
+     position: absolute;
+     top: 8px;
+     right: 8px;
+     display: block;
+     font-family: 'Glyphicons Halflings';
+ }
+.nodeStausInfo {
+    position: relative;
+ }
 .wrap-table{
     word-wrap: break-word;
     table-layout: fixed;

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/NodeManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/NodeManager.java
@@ -380,4 +380,9 @@ public interface NodeManager extends StorageContainerNodeProtocol,
   }
 
   default void forceNodesToHealthyReadOnly() { }
+
+  @Override
+  default Map<String, Map<String, String>> getNodeStatusInfo() {
+    return null;
+  }
 }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/NodeManagerMXBean.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/NodeManagerMXBean.java
@@ -42,4 +42,10 @@ public interface NodeManagerMXBean {
    */
   Map<String, Long> getNodeInfo();
 
+  /**
+   @@ -47,6 +46,6 @@ public interface NodeManagerMXBean {
+    * @return Get the NodeStatus table information  like hostname,
+   * Commissioned State & Operational State column for dataNode
+   */
+  Map<String, Map<String, String>> getNodeStatusInfo();
 }

--- a/hadoop-hdds/server-scm/src/main/resources/webapps/scm/scm-overview.html
+++ b/hadoop-hdds/server-scm/src/main/resources/webapps/scm/scm-overview.html
@@ -28,26 +28,58 @@
     </tbody>
 </table>
 
-<h2>Node counts</h2>
-
-<table class="table table-bordered table-striped" class="col-md-6">
+<h2>Node Status</h2>
+<div class="row">
+    <div class="col-md-6 text-left">
+        <label>Show: </label>
+        <select class="form-select" ng-model="RecordsToDisplay" ng-change="UpdateRecordsToShow()">
+            <option value="10" ng-selected="{true}">10</option>
+            <option value="20">20</option>
+            <option value="50">50</option>
+            <option value="All">All</option>
+        </select>
+    </div>
+    <div class="col-md-6 text-right">
+        <label>Search: </label> <input type="text" ng-model="search">
+    </div>
+</div>
+<table class="table table-bordered table-striped col-md-6">
     <thead>
     <tr>
-        <th class="col-md-3"></th>
-        <th>HEALTHY</th>
-        <th>STALE</th>
-        <th>DEAD</th>
-        <th>HEALTHY_READONLY</th>
+        <th ng-click = "columnSort('hostname')" class="nodeStausInfo"><span ng-class = "{'sorting' : (columnName != 'hostname'), 'sortasc' : (columnName == 'hostname' && reverse),
+                                        'sortdesc':(columnName == 'hostname' && !reverse)}">HostName</span></th>
+        <th ng-click = "columnSort('opstate')" class="nodeStausInfo" ><span ng-class="{'sorting' : (columnName != 'opstate'), 'sortasc' : (columnName == 'opstate' && reverse),
+                                        'sortdesc':(columnName == 'opstate' && !reverse)}">Operational State</span></th>
+        <th ng-click = "columnSort('comstate')" class="nodeStausInfo">  <span ng-class="{'sorting' : (columnName != 'comstate'), 'sortasc' : (columnName == 'comstate' && reverse),
+                                        'sortdesc':(columnName == 'comstate' && !reverse)}">Commisioned State</span> </th>
     </tr>
     </thead>
     <tbody>
-    <tr ng-repeat="nodeOpState in $ctrl.nodemanagermetrics.NodeCount | orderBy:'key':false:$ctrl.nodeOpStateOrder">
-        <td>{{nodeOpState.key}}</td>
-        <td ng-repeat="nodeState in nodeOpState.value | orderBy:'key':false:$ctrl.nodeStateOrder">{{nodeState.value}}</td>
+    <tr ng-repeat="typestat in nodeStatus|filter:search|orderBy:columnName:reverse">
+        <td><a href="{{typestat.portval.toLowerCase()}}://{{typestat.hostname}}:{{typestat.portno}}" target="_blank">
+            {{typestat.hostname}}</a></td>
+        <td>{{typestat.opstate}}</td>
+        <td>{{typestat.comstate}}</td>
     </tr>
     </tbody>
 </table>
-
+<div>
+    <nav aria-label="...">
+        <ul class="pagination">
+            <li class="page-item" ng-class="{disabled:currentPage==1}"
+                ng-click="handlePagination(currentPage-1,(currentPage==1))">
+                <span class="page-link" tabindex="-1">Previous</span>
+            </li>
+            <li class="page-item active">
+                <span class="page-link">{{currentPage}} </span>
+            </li>
+            <li class="page-item" ng-class="{disabled:lastIndex==currentPage}"
+                ng-click="handlePagination(currentPage+1, (lastIndex==currentPage))">
+                <span class="page-link" tabindex="-1">Next</span>
+            </li>
+        </ul>
+    </nav>
+</div>
 <h2>Status</h2>
 <table class="table table-bordered table-striped" class="col-md-6">
     <tbody>

--- a/hadoop-hdds/server-scm/src/main/resources/webapps/scm/scm.js
+++ b/hadoop-hdds/server-scm/src/main/resources/webapps/scm/scm.js
@@ -24,12 +24,71 @@
         require: {
             overview: "^overview"
         },
-        controller: function ($http) {
-            var ctrl = this;
-            $http.get("jmx?qry=Hadoop:service=SCMNodeManager,name=SCMNodeManagerInfo")
-                .then(function (result) {
-                    ctrl.nodemanagermetrics = result.data.beans[0];
-                });
+    controller: function ($http,$scope) {
+        var ctrl = this;
+        $scope.reverse = false;
+        $scope.columnName = "hostname";
+        let nodeStatusCopy = [];
+        $scope.RecordsToDisplay = "10";
+        $scope.currentPage = 1;
+        $scope.lastIndex = 0;
+        var protocol = "";
+        var portNo = "";
+
+        $http.get("jmx?qry=Hadoop:service=SCMNodeManager,name=SCMNodeManagerInfo")
+            .then(function (result) {
+            const URLScheme = location.protocol.replace(":" , "");
+            ctrl.nodemanagermetrics = result.data.beans[0];
+
+            $scope.nodeStatus = ctrl.nodemanagermetrics && ctrl.nodemanagermetrics.NodeStatusInfo &&
+                ctrl.nodemanagermetrics.NodeStatusInfo.map(({ key, value }) => {
+                    value.map(({key, value}) => {
+                        if(key == "HTTP") {
+                            protocol = key;
+                            portNo = value;
+                        }
+                        if(key == "HTTPS"){
+                            protocol = key.toLowerCase() === URLScheme ? key : "HTTP";
+                            portNo = value;
+                        }
+                    });
+                return {
+                    hostname: key,
+                    opstate: value && value.find((element) => element.key == "OPSTATE").value,
+                    comstate: value && value.find((element) => element.key == "COMSTATE").value,
+                    portno: portNo,
+                    portval: protocol
+                }});
+            nodeStatusCopy = [...$scope.nodeStatus];
+            $scope.lastIndex = Math.ceil(nodeStatusCopy.length / $scope.RecordsToDisplay);
+            $scope.nodeStatus = nodeStatusCopy.slice(0, $scope.RecordsToDisplay);
+            });
+        /*if option is 'All' display all records else display specified record on page*/
+            $scope.UpdateRecordsToShow = () => {
+                if($scope.RecordsToDisplay == 'All') {
+                    $scope.lastIndex = 1;
+                    $scope.nodeStatus = nodeStatusCopy;
+                } else {
+                    $scope.lastIndex = Math.ceil(nodeStatusCopy.length / $scope.RecordsToDisplay);
+                    $scope.nodeStatus = nodeStatusCopy.slice(0, $scope.RecordsToDisplay);
+            }
+            $scope.currentPage = 1;
+        }
+        /* Page Slicing  logic */
+            $scope.handlePagination = (pageIndex, isDisabled) => {
+                if(!isDisabled) {
+                    let startIndex = 0, endIndex = 0;
+                    $scope.currentPage = pageIndex;
+                    startIndex = (pageIndex * $scope.RecordsToDisplay) - $scope.RecordsToDisplay;
+                    endIndex = startIndex + parseInt($scope.RecordsToDisplay);
+                    $scope.nodeStatus = nodeStatusCopy.slice(startIndex, endIndex);
+            }
+        }
+         /*column sort logic*/
+        $scope.columnSort = (colName) => {
+            $scope.columnName = colName;
+            $scope.reverse = !$scope.reverse;
+        }
 
             const nodeOpStateSortOrder = {
                 "IN_SERVICE": "a",

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/MockNodeManager.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/MockNodeManager.java
@@ -802,6 +802,11 @@ public class MockNodeManager implements NodeManager {
     return nodeInfo;
   }
 
+  @Override
+  public Map<String, Map<String, String>> getNodeStatusInfo() {
+    return null;
+  }
+
   /**
    * Makes it easy to add a container.
    *

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/SimpleMockNodeManager.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/SimpleMockNodeManager.java
@@ -373,6 +373,11 @@ public class SimpleMockNodeManager implements NodeManager {
   }
 
   @Override
+  public Map<String, Map<String, String>> getNodeStatusInfo() {
+    return null;
+  }
+
+  @Override
   public void onMessage(CommandForDatanode commandForDatanode,
                         EventPublisher publisher) {
   }

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/ozone/container/testutils/ReplicationNodeManagerMock.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/ozone/container/testutils/ReplicationNodeManagerMock.java
@@ -86,6 +86,11 @@ public class ReplicationNodeManagerMock implements NodeManager {
     return null;
   }
 
+  @Override
+  public Map<String, Map<String, String>> getNodeStatusInfo() {
+    return null;
+  }
+
   /**
    * Gets all Live Datanodes that is currently communicating with SCM.
    *


### PR DESCRIPTION
## What changes were proposed in this pull request?

Reprsent DataNode Link on SCM UI with HTTP & HTTPS Port
Three configured case for every DN and SCM
1. HTTP_ONLY -> the service does serve its webUI via HTTP
2. HTTPS_ONLY -> the service does serve its webUI via HTTPS
3. HTTP_AND_HTTPS -> the service does serve its webUI via HTTP and HTTPS both based on protocol scheme

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-7943

## How was this patch tested?
Manually with JMX Response
**Response Object:**
[ {
"key" : "ozonesecure_datanode_3.ozonesecure_default",
"value" : [ {
"key" : "HTTPS",
"value" : "9883"
}, {
"key" : "OPSTATE",
"value" : "IN_SERVICE"
}, {
"key" : "COMSTATE",
"value" : "HEALTHY"
}, {
"key" : "HTTP",
"value" : "9882"
} ]
}, {
"key" : "ozonesecure_datanode_2.ozonesecure_default",
"value" : [ {
"key" : "HTTPS",
"value" : "9883"
}, {
"key" : "OPSTATE",
"value" : "IN_SERVICE"
}, {
"key" : "COMSTATE",
"value" : "HEALTHY"
}, {
"key" : "HTTP",
"value" : "9882"
} ]
}, {
"key" : "ozonesecure_datanode_1.ozonesecure_default",
"value" : [ {
"key" : "HTTPS",
"value" : "9883"
}, {
"key" : "OPSTATE",
"value" : "IN_SERVICE"
}, {
"key" : "COMSTATE",
"value" : "HEALTHY"
}, {
"key" : "HTTP",
"value" : "9882"
} ]
} ]
