### PR TITLE
HDDS-8393. [Recon] Include Roboto font using fontsource instead

### DIFF
--- a/hadoop-ozone/recon/pom.xml
+++ b/hadoop-ozone/recon/pom.xml
@@ -169,6 +169,9 @@
                   <filtering>true</filtering>
                 </resource>
               </resources>
+              <nonFilteredFileExtensions>
+                <nonFilteredFileExtension>woff2</nonFilteredFileExtension>
+              </nonFilteredFileExtensions>
             </configuration>
           </execution>
         </executions>

--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/WEB-INF/web.xml
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/WEB-INF/web.xml
@@ -25,4 +25,8 @@
     <filter-name>guiceFilter</filter-name>
     <url-pattern>/*</url-pattern>
   </filter-mapping>
+  <mime-mapping>
+    <extension>woff2</extension>
+    <mime-type>font/woff2</mime-type>
+  </mime-mapping>
 </web-app>

--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/package.json
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "dependencies": {
     "@babel/core": "^7.0.0",
+    "@fontsource/roboto": "^4.5.8",
     "@types/classnames": "^2.2.10",
     "@types/jest": "24.0.12",
     "@types/node": "11.13.9",

--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/pnpm-lock.yaml
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/pnpm-lock.yaml
@@ -1,5 +1,6 @@
 dependencies:
   '@babel/core': 7.10.2
+  '@fontsource/roboto': 4.5.8
   '@types/classnames': 2.2.10
   '@types/jest': 24.0.12
   '@types/node': 11.13.9
@@ -1980,6 +1981,10 @@ packages:
     dev: false
     resolution:
       integrity: sha512-6U71C2Wp7r5XtFtQzYrW5iKFT67OixrSxjI4MptCHzdSVlgabczzqLe0ZSgnub/5Kp4hSbpDB1tMytZY9pwxxA==
+  /@fontsource/roboto/4.5.8:
+    dev: false
+    resolution:
+      integrity: sha512-CnD7zLItIzt86q4Sj3kZUiLcBk1dSk81qcqgMGaZe7SQ1P8hFNxhMl5AZthK1zrDM5m74VVhaOpuMGIL4gagaA==
   /@hapi/address/2.1.4:
     dev: false
     resolution:
@@ -17122,6 +17127,7 @@ packages:
       integrity: sha1-xWK9MRNkPzRDokXRJAa4i2m5qf8=
 specifiers:
   '@babel/core': ^7.0.0
+  '@fontsource/roboto': ^4.5.8
   '@types/classnames': ^2.2.10
   '@types/jest': 24.0.12
   '@types/node': 11.13.9

--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/public/index.html
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/public/index.html
@@ -36,7 +36,6 @@
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
 
-    <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:300,400,500" />
     <title>Ozone Recon</title>
   </head>
   <body>

--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/public/static/media/LICENSE
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/public/static/media/LICENSE
@@ -1,0 +1,15 @@
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/index.tsx
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/index.tsx
@@ -18,6 +18,9 @@
 
 import React from 'react';
 import ReactDOM from 'react-dom';
+import "@fontsource/roboto/300.css";
+import "@fontsource/roboto/400.css";
+import "@fontsource/roboto/500.css";
 import './index.less';
 import App from './app';
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

The direct link for the Google Roboto font has been replaced with the use of the Fontsource module. 

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-8393

Please replace this section with the link to the Apache JIRA)

## How was this patch tested?

Manual testing
