### PR TITLE
HDDS-8397. openKey need not setKeyArgs twice

### DIFF
--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocolPB/OzoneManagerProtocolClientSideTranslatorPB.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocolPB/OzoneManagerProtocolClientSideTranslatorPB.java
@@ -677,7 +677,6 @@ public final class OzoneManagerProtocolClientSideTranslatorPB
     if (args.getMetadata() != null && args.getMetadata().size() > 0) {
       keyArgs.addAllMetadata(KeyValueUtil.toProtobuf(args.getMetadata()));
     }
-    req.setKeyArgs(keyArgs.build());
 
     if (args.getMultipartUploadID() != null) {
       keyArgs.setMultipartUploadID(args.getMultipartUploadID());


### PR DESCRIPTION
## What changes were proposed in this pull request?

openKey need not setKeyArgs two twice, `setKeyArgs` duplicated with line 693

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-8397

## How was this patch tested?

