### PR TITLE
HDDS-8395. Prepare a dedicated MetricsSystem for XceiverClientMetrics

### DIFF
--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/XceiverClientMetrics.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/XceiverClientMetrics.java
@@ -23,7 +23,7 @@ import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos;
 import org.apache.hadoop.metrics2.MetricsSystem;
 import org.apache.hadoop.metrics2.annotation.Metric;
 import org.apache.hadoop.metrics2.annotation.Metrics;
-import org.apache.hadoop.metrics2.lib.DefaultMetricsSystem;
+import org.apache.hadoop.metrics2.impl.MetricsSystemImpl;
 import org.apache.hadoop.metrics2.lib.MetricsRegistry;
 import org.apache.hadoop.metrics2.lib.MutableCounterLong;
 import org.apache.hadoop.metrics2.lib.MutableRate;
@@ -34,8 +34,11 @@ import org.apache.hadoop.metrics2.lib.MutableRate;
 @InterfaceAudience.Private
 @Metrics(about = "Storage Container Client Metrics", context = "dfs")
 public class XceiverClientMetrics {
+  @VisibleForTesting
   public static final String SOURCE_NAME = XceiverClientMetrics.class
       .getSimpleName();
+  @VisibleForTesting
+  public static final MetricsSystem METRICS_SYSTEM = new MetricsSystemImpl();
 
   private @Metric MutableCounterLong pendingOps;
   private @Metric MutableCounterLong totalOps;
@@ -75,10 +78,9 @@ public class XceiverClientMetrics {
   }
 
   public static XceiverClientMetrics create() {
-    DefaultMetricsSystem.initialize(SOURCE_NAME);
-    MetricsSystem ms = DefaultMetricsSystem.instance();
-    return ms.register(SOURCE_NAME, "Storage Container Client Metrics",
-        new XceiverClientMetrics());
+    METRICS_SYSTEM.init(SOURCE_NAME);
+    return METRICS_SYSTEM.register(SOURCE_NAME,
+        "Storage Container Client Metrics", new XceiverClientMetrics());
   }
 
   public void incrPendingContainerOpsMetrics(ContainerProtos.Type type) {
@@ -126,7 +128,6 @@ public class XceiverClientMetrics {
   }
 
   public void unRegister() {
-    MetricsSystem ms = DefaultMetricsSystem.instance();
-    ms.unregisterSource(SOURCE_NAME);
+    METRICS_SYSTEM.unregisterSource(SOURCE_NAME);
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

This change would let Ozone avoid initializing `DefaultMetricsSystem` twice.

Currently, we see the following warning when we launch S3 Gateway.

```
ozone-s3g-df95ff75c-4jm4c: 2023-04-07 12:49:54,343 [qtp6519275-23] WARN impl.MetricsSystemImpl: S3Gateway metrics system already initialized! 
```

`DefaultMetricsSystem` is a singleton. It means it should be initialized only once per JVM.

- https://github.com/apache/hadoop/blob/rel/release-3.3.5/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/metrics2/lib/DefaultMetricsSystem.java#L52-L63
- https://github.com/apache/hadoop/blob/rel/release-3.3.5/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/metrics2/impl/MetricsSystemImpl.java#L150-L153

However, on S3 Gateway, it is initialized twice. One is for S3 Gateway's metrics and the other one is for an Ozone client.

- https://github.com/apache/ozone/blob/ozone-1.3.0/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/Gateway.java#L94
- https://github.com/apache/ozone/blob/ozone-1.3.0/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/XceiverClientMetrics.java#L76

Checking similar usage, I found some components create a dedicated metrics system. This PR follows the manner.

- https://github.com/apache/hadoop/blob/rel/release-3.3.5/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AInstrumentation.java#L245-L254
- https://github.com/apache/hadoop/blob/rel/release-3.3.5/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azure/metrics/AzureFileSystemMetricsSystem.java

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-8395

## How was this patch tested?

I checked that I don't see the warning with this patch applied.