### PR TITLE
HDDS-8406. Add OM DB update data size and sequence metrics

### DIFF
--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/RDBMetrics.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/RDBMetrics.java
@@ -25,6 +25,8 @@ import org.apache.hadoop.metrics2.lib.DefaultMetricsSystem;
 import org.apache.hadoop.metrics2.lib.MutableCounterLong;
 
 import com.google.common.annotations.VisibleForTesting;
+import org.apache.hadoop.metrics2.lib.MutableRollingAverages;
+import org.apache.hadoop.metrics2.lib.MutableStat;
 
 /**
  * Class to hold RocksDB metrics.
@@ -56,6 +58,9 @@ public class RDBMetrics {
   private @Metric MutableCounterLong numDBKeyGetIfExistChecks;
   private @Metric MutableCounterLong numDBKeyGetIfExistMisses;
   private @Metric MutableCounterLong numDBKeyGetIfExistGets;
+  // WAL Update data size and sequence count
+  private @Metric MutableCounterLong walUpdateDataSize;
+  private @Metric MutableCounterLong walUpdateSequenceCount;
 
 
   public long getNumDBKeyGetIfExistGets() {
@@ -99,6 +104,22 @@ public class RDBMetrics {
   @VisibleForTesting
   public long getNumDBKeyMayExistMisses() {
     return numDBKeyMayExistMisses.value();
+  }
+
+  public void incWalUpdateDataSize(long size) {
+    walUpdateDataSize.incr(size);
+  }
+
+  public long getWalUpdateDataSize() {
+    return walUpdateDataSize.value();
+  }
+
+  public void incWalUpdateSequenceCount(long count) {
+    walUpdateSequenceCount.incr(count);
+  }
+
+  public long getWalUpdateSequenceCount() {
+    return walUpdateSequenceCount.value();
   }
 
   public static synchronized void unRegister() {

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/RDBMetrics.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/RDBMetrics.java
@@ -25,8 +25,6 @@ import org.apache.hadoop.metrics2.lib.DefaultMetricsSystem;
 import org.apache.hadoop.metrics2.lib.MutableCounterLong;
 
 import com.google.common.annotations.VisibleForTesting;
-import org.apache.hadoop.metrics2.lib.MutableRollingAverages;
-import org.apache.hadoop.metrics2.lib.MutableStat;
 
 /**
  * Class to hold RocksDB metrics.


### PR DESCRIPTION
https://issues.apache.org/jira/browse/HDDS-8406

## How was this patch tested?

Run freon rk command to generate the OM updates during the test.  From the metrics data, we can see that the average size of rocksdb tx in OM is about 466 bytes(data size/sequence count). 

Initial metrics after om start
![image](https://user-images.githubusercontent.com/19790142/231080359-b5ee21ac-fae8-41cc-9c8f-b463969a9810.png)


metrics after recon fetch DB update from om
![image](https://user-images.githubusercontent.com/19790142/231079498-5593ffd5-b1f8-406d-aff1-8813dca68d27.png)

