### PR TITLE
HDDS-8336. ReplicationManager: RatisUnderReplicationHandler should partially recover the container if not enough nodes

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/MisReplicationHandler.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/MisReplicationHandler.java
@@ -90,10 +90,9 @@ public abstract class MisReplicationHandler implements
       }
     }
     throw new SCMException(String.format("Placement Policy: %s did not return"
-                    + " any number of nodes. Number of required "
-                    + "Nodes %d, Datasize Required: %d",
-            containerPlacement.getClass(), requiredNodes, dataSizeRequired),
-            SCMException.ResultCodes.FAILED_TO_FIND_SUITABLE_NODE);
+        + " any nodes. Number of required Nodes %d, Datasize Required: %d",
+        containerPlacement.getClass(), requiredNodes, dataSizeRequired),
+        SCMException.ResultCodes.FAILED_TO_FIND_SUITABLE_NODE);
   }
 
   private Set<ContainerReplica> filterSources(Set<ContainerReplica> replicas) {

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/RatisUnderReplicationHandler.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/RatisUnderReplicationHandler.java
@@ -26,7 +26,9 @@ import org.apache.hadoop.hdds.scm.PlacementPolicy;
 import org.apache.hadoop.hdds.scm.ScmConfigKeys;
 import org.apache.hadoop.hdds.scm.container.ContainerInfo;
 import org.apache.hadoop.hdds.scm.container.ContainerReplica;
+import org.apache.hadoop.hdds.scm.exceptions.SCMException;
 import org.apache.hadoop.hdds.scm.node.states.NodeNotFoundException;
+import org.apache.hadoop.hdds.scm.pipeline.InsufficientDatanodesException;
 import org.apache.hadoop.ozone.protocol.commands.ReplicateContainerCommand;
 import org.apache.ratis.protocol.exceptions.NotLeaderException;
 import org.slf4j.Logger;
@@ -108,13 +110,24 @@ public class RatisUnderReplicationHandler
     // find targets to send replicas to
     List<DatanodeDetails> targetDatanodes =
         getTargets(withUnhealthy, pendingOps);
-    if (targetDatanodes.isEmpty()) {
-      LOG.warn("Cannot replicate container {} because no eligible targets " +
-          "were found.", containerInfo);
-      return 0;
-    }
-    return sendReplicationCommands(
+
+    int commandsSent = sendReplicationCommands(
         containerInfo, sourceDatanodes, targetDatanodes);
+
+    if (targetDatanodes.size() < withUnhealthy.additionalReplicaNeeded()) {
+      // The placement policy failed to find enough targets to satisfy fix
+      // the under replication. There fore even though some commands were sent,
+      // we throw an exception to indicate that the container is still under
+      // replicated and should be re-queued for another attempt later.
+      LOG.debug("Placement policy failed to find enough targets to satisfy " +
+          "under replication for container {}. Targets found: {}, " +
+          "additional replicas needed: {}",
+          containerInfo, targetDatanodes.size(),
+          withUnhealthy.additionalReplicaNeeded());
+      throw new InsufficientDatanodesException(
+          withUnhealthy.additionalReplicaNeeded(), targetDatanodes.size());
+    }
+    return commandsSent;
   }
 
   /**
@@ -235,8 +248,21 @@ public class RatisUnderReplicationHandler
     final long dataSizeRequired =
         Math.max(replicaCount.getContainer().getUsedBytes(),
             currentContainerSize);
-    return placementPolicy.chooseDatanodes(excludeList, null,
-        replicaCount.additionalReplicaNeeded(), 0, dataSizeRequired);
+    int requiredNodes = replicaCount.additionalReplicaNeeded();
+    while (requiredNodes > 0) {
+      try {
+        return placementPolicy.chooseDatanodes(excludeList, null,
+            requiredNodes, 0, dataSizeRequired);
+      } catch (IOException e) {
+        LOG.debug("Placement policy was not able to return {} nodes. ",
+            requiredNodes, e);
+        requiredNodes--;
+      }
+    }
+    throw new SCMException(String.format("Placement Policy: %s did not return"
+            + " any nodes. Number of required Nodes %d, Datasize Required: %d",
+        placementPolicy.getClass(), requiredNodes, dataSizeRequired),
+        SCMException.ResultCodes.FAILED_TO_FIND_SUITABLE_NODE);
   }
 
   private int sendReplicationCommands(

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/ReplicationTestUtil.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/ReplicationTestUtil.java
@@ -42,6 +42,7 @@ import org.mockito.Mockito;
 import org.mockito.stubbing.Answer;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -286,9 +287,7 @@ public final class ReplicationTestUtil {
           throw new SCMException("Insufficient Nodes available to choose",
               SCMException.ResultCodes.FAILED_TO_FIND_HEALTHY_NODES);
         }
-        List<DatanodeDetails> dns = new ArrayList<>();
-        dns.add(nodeToReturn);
-        return dns;
+        return Collections.singletonList(nodeToReturn);
       }
 
       @Override
@@ -310,6 +309,37 @@ public final class ReplicationTestUtil {
               throws SCMException {
         throw new SCMException("No nodes available",
                 FAILED_TO_FIND_SUITABLE_NODE);
+      }
+
+      @Override
+      public DatanodeDetails chooseNode(List<DatanodeDetails> healthyNodes) {
+        return null;
+      }
+    };
+  }
+
+  /**
+   * Placement policy that throws an exception when the number of requested
+   * nodes is greater or equal to throwWhenThisOrMoreNodesRequested, otherwise
+   * returns a random node.
+   */
+  public static PlacementPolicy getInsufficientNodesTestPlacementPolicy(
+      final NodeManager nodeManager, final OzoneConfiguration conf,
+      int throwWhenThisOrMoreNodesRequested) {
+    return new SCMCommonPlacementPolicy(nodeManager, conf) {
+      @Override
+      protected List<DatanodeDetails> chooseDatanodesInternal(
+          List<DatanodeDetails> usedNodes,
+          List<DatanodeDetails> excludedNodes,
+          List<DatanodeDetails> favoredNodes, int nodesRequiredToChoose,
+          long metadataSizeRequired, long dataSizeRequired)
+          throws SCMException {
+        if (nodesRequiredToChoose >= throwWhenThisOrMoreNodesRequested) {
+          throw new SCMException("No nodes available",
+              FAILED_TO_FIND_SUITABLE_NODE);
+        }
+        return Collections
+            .singletonList(MockDatanodeDetails.randomDatanodeDetails());
       }
 
       @Override


### PR DESCRIPTION
## What changes were proposed in this pull request?

In RatisUnderReplicationHandler, if the container is under-replicated by more than 1 replica, then we need to select 2 or more new copies. In the code getTargets():

```
  private List<DatanodeDetails> getTargets(
      RatisContainerReplicaCount replicaCount,
      List<ContainerReplicaOp> pendingOps) throws IOException {
    // DNs that already have replicas cannot be targets and should be excluded
    final List<DatanodeDetails> excludeList =
        replicaCount.getReplicas().stream()
            .map(ContainerReplica::getDatanodeDetails)
            .collect(Collectors.toList());

    // DNs that are already waiting to receive replicas cannot be targets
    final List<DatanodeDetails> pendingReplication =
        pendingOps.stream()
            .filter(containerReplicaOp -> containerReplicaOp.getOpType() ==
                ContainerReplicaOp.PendingOpType.ADD)
            .map(ContainerReplicaOp::getTarget)
            .collect(Collectors.toList());
    excludeList.addAll(pendingReplication);

    /*
    Ensure that target datanodes have enough space to hold a complete
    container.
    */
    final long dataSizeRequired =
        Math.max(replicaCount.getContainer().getUsedBytes(),
            currentContainerSize);
    return placementPolicy.chooseDatanodes(excludeList, null,
        replicaCount.additionalReplicaNeeded(), 0, dataSizeRequired);
}
```

We ask the placement policy for the required number of nodes. If it cannot provide the required number (eg we want 2, but it can only find 1 spare node), it will throw a SCMException. In that case, we should try again requesting one less node to see if we can partially recover. If that fails, try again with another less node until we reach zero.

If we successfully send a command for some but not all new copies, then we should throw an exception at the end so the container is re-queued on the under-rep queue to be tried again in a short while.

Note the class `MisReplicationHandler.getTargetDatanodes()` currently has logic like this

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-8336

## How was this patch tested?

New unit test added
