### PR TITLE
HDDS-8370. Intermittent failure in TestOzoneFileSystem#testListStatusWithIntermediateDir

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFileSystem.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFileSystem.java
@@ -591,13 +591,13 @@ public class TestOzoneFileSystem {
     Path file1 = new Path(parent, "key1");
     Path file2 = new Path(parent, "key2");
 
-    FileStatus[] fileStatuses = o3fs.listStatus(root);
+    FileStatus[] fileStatuses = o3fs.listStatus(root, EXCLUDE_TRASH);
     Assert.assertEquals("Should be empty", 0, fileStatuses.length);
 
     ContractTestUtils.touch(fs, file1);
     ContractTestUtils.touch(fs, file2);
 
-    fileStatuses = o3fs.listStatus(root);
+    fileStatuses = o3fs.listStatus(root, EXCLUDE_TRASH);
     Assert.assertEquals("Should have created parent",
             1, fileStatuses.length);
     Assert.assertEquals("Parent path doesn't match",
@@ -675,7 +675,7 @@ public class TestOzoneFileSystem {
     if (!enabledFileSystemPaths) {
       GenericTestUtils.waitFor(() -> {
         try {
-          return fs.listStatus(parent).length != 0;
+          return fs.listStatus(parent, EXCLUDE_TRASH).length != 0;
         } catch (IOException e) {
           LOG.error("listStatus() Failed", e);
           Assert.fail("listStatus() Failed");
@@ -683,7 +683,7 @@ public class TestOzoneFileSystem {
         }
       }, 1000, 120000);
     }
-    FileStatus[] fileStatuses = fs.listStatus(parent);
+    FileStatus[] fileStatuses = fs.listStatus(parent, EXCLUDE_TRASH);
     // the number of immediate children of root is 1
     Assert.assertEquals(1, fileStatuses.length);
     Assert.assertEquals(fileStatuses[0].isErasureCoded(),
@@ -710,7 +710,7 @@ public class TestOzoneFileSystem {
     // ListStatus on root should return dir1 (even though /dir1 key does not
     // exist) and dir2 only. dir12 is not an immediate child of root and
     // hence should not be listed.
-    FileStatus[] fileStatuses = o3fs.listStatus(root);
+    FileStatus[] fileStatuses = o3fs.listStatus(root, EXCLUDE_TRASH);
     assertEquals("FileStatus should return only the immediate children",
         2, fileStatuses.length);
 
@@ -736,7 +736,7 @@ public class TestOzoneFileSystem {
       paths.add(p.getName());
     }
 
-    FileStatus[] fileStatuses = o3fs.listStatus(root);
+    FileStatus[] fileStatuses = o3fs.listStatus(root, EXCLUDE_TRASH);
     // Added logs for debugging failures, to check any sub-path mismatches.
     Set<String> actualPaths = new TreeSet<>();
     ArrayList<String> actualPathList = new ArrayList<>();
@@ -782,7 +782,7 @@ public class TestOzoneFileSystem {
     TestDataUtil.createKey(ozoneBucket, keyName, "");
     FileStatus[] fileStatuses;
 
-    fileStatuses = fs.listStatus(new Path("/"));
+    fileStatuses = fs.listStatus(new Path("/"), EXCLUDE_TRASH);
     assertEquals(1, fileStatuses.length);
     assertEquals("/dir1", fileStatuses[0].getPath().toUri().getPath());
     assertTrue(fileStatuses[0].isDirectory());

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFileSystem.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFileSystem.java
@@ -120,7 +120,7 @@ public class TestOzoneFileSystem {
       new Path(ROOT, TRASH_PREFIX);
 
   private static final PathFilter EXCLUDE_TRASH =
-      p -> !p.toString().startsWith(TRASH_ROOT.toString());
+      p -> !p.toUri().getPath().startsWith(TRASH_ROOT.toString());
 
   @Parameterized.Parameters
   public static Collection<Object[]> data() {

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFileSystem.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFileSystem.java
@@ -225,8 +225,7 @@ public class TestOzoneFileSystem {
   @After
   public void cleanup() {
     try {
-      Path root = new Path("/");
-      FileStatus[] fileStatuses = fs.listStatus(root);
+      FileStatus[] fileStatuses = fs.listStatus(ROOT);
       for (FileStatus fileStatus : fileStatuses) {
         fs.delete(fileStatus.getPath(), true);
       }
@@ -586,18 +585,17 @@ public class TestOzoneFileSystem {
 
   @Test
   public void testListStatus() throws Exception {
-    Path root = new Path("/");
-    Path parent = new Path(root, "/testListStatus");
+    Path parent = new Path(ROOT, "/testListStatus");
     Path file1 = new Path(parent, "key1");
     Path file2 = new Path(parent, "key2");
 
-    FileStatus[] fileStatuses = o3fs.listStatus(root, EXCLUDE_TRASH);
+    FileStatus[] fileStatuses = o3fs.listStatus(ROOT, EXCLUDE_TRASH);
     Assert.assertEquals("Should be empty", 0, fileStatuses.length);
 
     ContractTestUtils.touch(fs, file1);
     ContractTestUtils.touch(fs, file2);
 
-    fileStatuses = o3fs.listStatus(root, EXCLUDE_TRASH);
+    fileStatuses = o3fs.listStatus(ROOT, EXCLUDE_TRASH);
     Assert.assertEquals("Should have created parent",
             1, fileStatuses.length);
     Assert.assertEquals("Parent path doesn't match",
@@ -634,13 +632,11 @@ public class TestOzoneFileSystem {
     OpenKeySession session = writeClient.openKey(keyArgs);
     writeClient.commitKey(keyArgs, session.getId());
 
-    Path parent = new Path("/");
-
     // Wait until the filestatus is updated
     if (!enabledFileSystemPaths) {
       GenericTestUtils.waitFor(() -> {
         try {
-          return fs.listStatus(parent, EXCLUDE_TRASH).length != 0;
+          return fs.listStatus(ROOT, EXCLUDE_TRASH).length != 0;
         } catch (IOException e) {
           LOG.error("listStatus() Failed", e);
           Assert.fail("listStatus() Failed");
@@ -649,7 +645,7 @@ public class TestOzoneFileSystem {
       }, 1000, 120000);
     }
 
-    FileStatus[] fileStatuses = fs.listStatus(parent, EXCLUDE_TRASH);
+    FileStatus[] fileStatuses = fs.listStatus(ROOT, EXCLUDE_TRASH);
 
     // the number of immediate children of root is 1
     Assert.assertEquals(1, fileStatuses.length);
@@ -670,12 +666,11 @@ public class TestOzoneFileSystem {
             .build();
     OpenKeySession session = writeClient.openKey(keyArgs);
     writeClient.commitKey(keyArgs, session.getId());
-    Path parent = new Path("/");
     // Wait until the filestatus is updated
     if (!enabledFileSystemPaths) {
       GenericTestUtils.waitFor(() -> {
         try {
-          return fs.listStatus(parent, EXCLUDE_TRASH).length != 0;
+          return fs.listStatus(ROOT, EXCLUDE_TRASH).length != 0;
         } catch (IOException e) {
           LOG.error("listStatus() Failed", e);
           Assert.fail("listStatus() Failed");
@@ -683,7 +678,7 @@ public class TestOzoneFileSystem {
         }
       }, 1000, 120000);
     }
-    FileStatus[] fileStatuses = fs.listStatus(parent, EXCLUDE_TRASH);
+    FileStatus[] fileStatuses = fs.listStatus(ROOT, EXCLUDE_TRASH);
     // the number of immediate children of root is 1
     Assert.assertEquals(1, fileStatuses.length);
     Assert.assertEquals(fileStatuses[0].isErasureCoded(),
@@ -700,17 +695,16 @@ public class TestOzoneFileSystem {
    */
   @Test
   public void testListStatusOnRoot() throws Exception {
-    Path root = new Path("/");
-    Path dir1 = new Path(root, "dir1");
+    Path dir1 = new Path(ROOT, "dir1");
     Path dir12 = new Path(dir1, "dir12");
-    Path dir2 = new Path(root, "dir2");
+    Path dir2 = new Path(ROOT, "dir2");
     fs.mkdirs(dir12);
     fs.mkdirs(dir2);
 
     // ListStatus on root should return dir1 (even though /dir1 key does not
     // exist) and dir2 only. dir12 is not an immediate child of root and
     // hence should not be listed.
-    FileStatus[] fileStatuses = o3fs.listStatus(root, EXCLUDE_TRASH);
+    FileStatus[] fileStatuses = o3fs.listStatus(ROOT, EXCLUDE_TRASH);
     assertEquals("FileStatus should return only the immediate children",
         2, fileStatuses.length);
 
@@ -726,17 +720,16 @@ public class TestOzoneFileSystem {
    */
   @Test
   public void testListStatusOnLargeDirectory() throws Exception {
-    Path root = new Path("/");
     deleteRootDir(); // cleanup
     Set<String> paths = new TreeSet<>();
     int numDirs = LISTING_PAGE_SIZE + LISTING_PAGE_SIZE / 2;
     for (int i = 0; i < numDirs; i++) {
-      Path p = new Path(root, String.valueOf(i));
+      Path p = new Path(ROOT, String.valueOf(i));
       fs.mkdirs(p);
       paths.add(p.getName());
     }
 
-    FileStatus[] fileStatuses = o3fs.listStatus(root, EXCLUDE_TRASH);
+    FileStatus[] fileStatuses = o3fs.listStatus(ROOT, EXCLUDE_TRASH);
     // Added logs for debugging failures, to check any sub-path mismatches.
     Set<String> actualPaths = new TreeSet<>();
     ArrayList<String> actualPathList = new ArrayList<>();
@@ -782,7 +775,7 @@ public class TestOzoneFileSystem {
     TestDataUtil.createKey(ozoneBucket, keyName, "");
     FileStatus[] fileStatuses;
 
-    fileStatuses = fs.listStatus(new Path("/"), EXCLUDE_TRASH);
+    fileStatuses = fs.listStatus(ROOT, EXCLUDE_TRASH);
     assertEquals(1, fileStatuses.length);
     assertEquals("/dir1", fileStatuses[0].getPath().toUri().getPath());
     assertTrue(fileStatuses[0].isDirectory());
@@ -805,8 +798,7 @@ public class TestOzoneFileSystem {
    * @throws IOException DB failure
    */
   protected void deleteRootDir() throws IOException {
-    Path root = new Path("/");
-    FileStatus[] fileStatuses = fs.listStatus(root);
+    FileStatus[] fileStatuses = fs.listStatus(ROOT);
 
     if (fileStatuses == null) {
       return;
@@ -816,7 +808,7 @@ public class TestOzoneFileSystem {
       fs.delete(fStatus.getPath(), true);
     }
 
-    fileStatuses = fs.listStatus(root);
+    fileStatuses = fs.listStatus(ROOT);
     if (fileStatuses != null) {
       Assert.assertEquals("Delete root failed!", 0, fileStatuses.length);
     }
@@ -866,19 +858,18 @@ public class TestOzoneFileSystem {
    */
   @Test
   public void testListStatusIteratorWithDir() throws Exception {
-    Path root = new Path("/");
-    Path parent = new Path(root, "testListStatus");
+    Path parent = new Path(ROOT, "testListStatus");
     Path file1 = new Path(parent, "key1");
     Path file2 = new Path(parent, "key2");
     try {
       // Iterator should have no items when dir is empty
-      RemoteIterator<FileStatus> it = o3fs.listStatusIterator(root);
+      RemoteIterator<FileStatus> it = o3fs.listStatusIterator(ROOT);
       Assert.assertFalse(it.hasNext());
 
       ContractTestUtils.touch(fs, file1);
       ContractTestUtils.touch(fs, file2);
       // Iterator should have an item when dir is not empty
-      it = o3fs.listStatusIterator(root);
+      it = o3fs.listStatusIterator(ROOT);
       while (it.hasNext()) {
         FileStatus fileStatus = it.next();
         Assert.assertNotNull(fileStatus);
@@ -925,10 +916,9 @@ public class TestOzoneFileSystem {
    */
   @Test
   public void testListStatusIteratorOnRoot() throws Exception {
-    Path root = new Path("/");
-    Path dir1 = new Path(root, "dir1");
+    Path dir1 = new Path(ROOT, "dir1");
     Path dir12 = new Path(dir1, "dir12");
-    Path dir2 = new Path(root, "dir2");
+    Path dir2 = new Path(ROOT, "dir2");
     try {
       fs.mkdirs(dir12);
       fs.mkdirs(dir2);
@@ -936,7 +926,7 @@ public class TestOzoneFileSystem {
       // ListStatusIterator on root should return dir1
       // (even though /dir1 key does not exist)and dir2 only.
       // dir12 is not an immediate child of root and hence should not be listed.
-      RemoteIterator<FileStatus> it = o3fs.listStatusIterator(root);
+      RemoteIterator<FileStatus> it = o3fs.listStatusIterator(ROOT);
       int iCount = 0;
       while (it.hasNext()) {
         iCount++;
@@ -1120,7 +1110,7 @@ public class TestOzoneFileSystem {
   public void testDeleteRoot() throws IOException {
     Path dir = new Path("/dir");
     fs.mkdirs(dir);
-    assertFalse(fs.delete(new Path("/"), true));
+    assertFalse(fs.delete(ROOT, true));
     assertNotNull(fs.getFileStatus(dir));
   }
 

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFileSystem.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFileSystem.java
@@ -1505,12 +1505,11 @@ public class TestOzoneFileSystem {
   @Test
   public void testGetTrashRoot() throws IOException {
     String username = UserGroupInformation.getCurrentUser().getShortUserName();
-    Path trashRoot = new Path(OZONE_URI_DELIMITER, TRASH_PREFIX);
     // Input path doesn't matter, o3fs.getTrashRoot() only cares about username
     Path inPath1 = new Path("o3fs://bucket2.volume1/path/to/key");
     // Test with current user
     Path outPath1 = o3fs.getTrashRoot(inPath1);
-    Path expectedOutPath1 = new Path(trashRoot, username);
+    Path expectedOutPath1 = new Path(TRASH_ROOT, username);
     Assert.assertEquals(expectedOutPath1, outPath1);
   }
 
@@ -1577,8 +1576,7 @@ public class TestOzoneFileSystem {
   @Test
   public void testGetTrashRoots() throws IOException {
     String username = UserGroupInformation.getCurrentUser().getShortUserName();
-    Path trashRoot = new Path(OZONE_URI_DELIMITER, TRASH_PREFIX);
-    Path userTrash = new Path(trashRoot, username);
+    Path userTrash = new Path(TRASH_ROOT, username);
 
     Collection<FileStatus> res = o3fs.getTrashRoots(false);
     Assert.assertEquals(0, res.size());
@@ -1594,12 +1592,12 @@ public class TestOzoneFileSystem {
 
     // Create a few more random user trash dir
     for (int i = 1; i <= 5; i++) {
-      Path moreUserTrash = new Path(trashRoot, "trashuser" + i);
+      Path moreUserTrash = new Path(TRASH_ROOT, "trashuser" + i);
       fs.mkdirs(moreUserTrash);
     }
 
     // And create a file, which should be ignored
-    fs.create(new Path(trashRoot, "trashuser99"));
+    fs.create(new Path(TRASH_ROOT, "trashuser99"));
 
     // allUsers = false should still return current user trash
     res = o3fs.getTrashRoots(false);
@@ -1630,8 +1628,7 @@ public class TestOzoneFileSystem {
 
     // Construct paths
     String username = UserGroupInformation.getCurrentUser().getShortUserName();
-    Path trashRoot = new Path(OZONE_URI_DELIMITER, TRASH_PREFIX);
-    Path userTrash = new Path(trashRoot, username);
+    Path userTrash = new Path(TRASH_ROOT, username);
     Path userTrashCurrent = new Path(userTrash, "Current");
     Path trashPath = new Path(userTrashCurrent, testKeyName);
 
@@ -1661,8 +1658,7 @@ public class TestOzoneFileSystem {
 
     // Construct paths
     String username = UserGroupInformation.getCurrentUser().getShortUserName();
-    Path trashRoot = new Path(OZONE_URI_DELIMITER, TRASH_PREFIX);
-    Path userTrash = new Path(trashRoot, username);
+    Path userTrash = new Path(TRASH_ROOT, username);
     Path userTrashCurrent = new Path(userTrash, "Current");
     Path trashPath = new Path(userTrashCurrent, testKeyName);
 

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFileSystem.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFileSystem.java
@@ -65,6 +65,7 @@ import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
 import org.junit.rules.Timeout;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -81,6 +82,7 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Iterator;
+import java.util.List;
 import java.util.Set;
 import java.util.TreeSet;
 
@@ -639,10 +641,16 @@ public class TestOzoneFileSystem {
       }, 1000, 120000);
     }
 
-    FileStatus[] fileStatuses = fs.listStatus(parent);
+    List<FileStatus> fileStatuses = new ArrayList<>(Arrays.asList(
+        fs.listStatus(parent)));
+    Path trashRoot = new Path(OZONE_URI_DELIMITER, TRASH_PREFIX);
+    fileStatuses.removeIf(f -> trashRoot.equals(f.getPath()));
 
     // the number of immediate children of root is 1
-    Assert.assertEquals(1, fileStatuses.length);
+    Assertions.assertEquals(1, fileStatuses.size(),
+        () -> "Found " + fileStatuses + " with "
+            + "layout:" + bucketLayout
+            + ", fsPaths:" + enabledFileSystemPaths);
     writeClient.deleteKey(keyArgs);
   }
 

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFileSystem.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFileSystem.java
@@ -27,6 +27,7 @@ import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.InvalidPathException;
 import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.fs.PathFilter;
 import org.apache.hadoop.fs.PathIsNotEmptyDirectoryException;
 import org.apache.hadoop.fs.RemoteIterator;
 import org.apache.hadoop.fs.Trash;
@@ -111,6 +112,15 @@ import static org.junit.Assert.fail;
 public class TestOzoneFileSystem {
 
   private static final float TRASH_INTERVAL = 0.05f; // 3 seconds
+
+  private static final Path ROOT =
+      new Path(OZONE_URI_DELIMITER);
+
+  private static final Path TRASH_ROOT =
+      new Path(ROOT, TRASH_PREFIX);
+
+  private static final PathFilter EXCLUDE_TRASH =
+      p -> !p.toString().startsWith(TRASH_ROOT.toString());
 
   @Parameterized.Parameters
   public static Collection<Object[]> data() {
@@ -630,7 +640,7 @@ public class TestOzoneFileSystem {
     if (!enabledFileSystemPaths) {
       GenericTestUtils.waitFor(() -> {
         try {
-          return fs.listStatus(parent).length != 0;
+          return fs.listStatus(parent, EXCLUDE_TRASH).length != 0;
         } catch (IOException e) {
           LOG.error("listStatus() Failed", e);
           Assert.fail("listStatus() Failed");
@@ -639,7 +649,7 @@ public class TestOzoneFileSystem {
       }, 1000, 120000);
     }
 
-    FileStatus[] fileStatuses = fs.listStatus(parent);
+    FileStatus[] fileStatuses = fs.listStatus(parent, EXCLUDE_TRASH);
 
     // the number of immediate children of root is 1
     Assert.assertEquals(1, fileStatuses.length);

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFileSystem.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFileSystem.java
@@ -648,7 +648,7 @@ public class TestOzoneFileSystem {
     FileStatus[] fileStatuses = fs.listStatus(ROOT, EXCLUDE_TRASH);
 
     // the number of immediate children of root is 1
-    Assert.assertEquals(1, fileStatuses.length);
+    Assert.assertEquals(Arrays.toString(fileStatuses), 1, fileStatuses.length);
     writeClient.deleteKey(keyArgs);
   }
 

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFileSystem.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFileSystem.java
@@ -65,7 +65,6 @@ import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
-import org.junit.jupiter.api.Assertions;
 import org.junit.rules.Timeout;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -82,7 +81,6 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Iterator;
-import java.util.List;
 import java.util.Set;
 import java.util.TreeSet;
 
@@ -641,16 +639,10 @@ public class TestOzoneFileSystem {
       }, 1000, 120000);
     }
 
-    List<FileStatus> fileStatuses = new ArrayList<>(Arrays.asList(
-        fs.listStatus(parent)));
-    Path trashRoot = new Path(OZONE_URI_DELIMITER, TRASH_PREFIX);
-    fileStatuses.removeIf(f -> trashRoot.equals(f.getPath()));
+    FileStatus[] fileStatuses = fs.listStatus(parent);
 
     // the number of immediate children of root is 1
-    Assertions.assertEquals(1, fileStatuses.size(),
-        () -> "Found " + fileStatuses + " with "
-            + "layout:" + bucketLayout
-            + ", fsPaths:" + enabledFileSystemPaths);
+    Assert.assertEquals(1, fileStatuses.length);
     writeClient.deleteKey(keyArgs);
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

`testListStatusWithIntermediateDir` intermittently fails because it finds two entries in the root directory instead of one:

```
AssertionError: expected:<1> but was:<2>
  ...
  at org.apache.hadoop.fs.ozone.TestOzoneFileSystem.testListStatusWithIntermediateDir(TestOzoneFileSystem.java:645)
```

Including the file status list in the assertion message reveals that the unexpected extra entry is `.Trash`:

```
AssertionFailedError: Found [
  FileStatus{path=o3fs://bucket40939.volume15180/.Trash; isDirectory=true; modification_time=1680592792546; access_time=1680592792546; owner=runner; group=runner; permission=rwxrwxrwx; isSymlink=false; hasAcl=false; isEncrypted=false; isErasureCoded=false},
  FileStatus{path=o3fs://bucket40939.volume15180/object-dir; isDirectory=true; modification_time=1680592792548; access_time=1680592792548; owner=runner; group=runner; permission=rwxrwxrwx; isSymlink=false; hasAcl=false; isEncrypted=false; isErasureCoded=false}
] with layout:LEGACY, fsPaths:false ==> expected: <1> but was: <2>
```

Since trash is handled by background thread (cleaning up deleted items from other tests in the same class), it may or may not be present at the time of the test.  This PR changes the test to ignore it.

https://issues.apache.org/jira/browse/HDDS-8370

## How was this patch tested?

No failure of this test in 100/100 runs (but two other tests are still flaky):
https://github.com/adoroszlai/hadoop-ozone/actions/runs/4669634394

Regular CI:
https://github.com/adoroszlai/hadoop-ozone/actions/runs/4681320457