### PR TITLE
HDDS-8455. Om supports read only administrators.

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/OzoneConfigKeys.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/OzoneConfigKeys.java
@@ -175,9 +175,9 @@ public final class OzoneConfigKeys {
           "ozone.s3.administrators.groups";
 
   public static final String OZONE_SUPER_READ_USERNAMES =
-          "ozone.super.read.usernames";
+          "ozone.readonly.administrators";
   public static final String OZONE_SUPER_READ_GROUPS =
-          "ozone.super.read.groups";
+          "ozone.readonly.administrators.groups";
 
   /**
    * Used only for testing purpose. Results in making every user an admin.

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/OzoneConfigKeys.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/OzoneConfigKeys.java
@@ -174,9 +174,9 @@ public final class OzoneConfigKeys {
   public static final String OZONE_S3_ADMINISTRATORS_GROUPS =
           "ozone.s3.administrators.groups";
 
-  public static final String OZONE_SUPER_READ_USERNAMES =
+  public static final String OZONE_READONLY_ADMINISTRATORS =
           "ozone.readonly.administrators";
-  public static final String OZONE_SUPER_READ_GROUPS =
+  public static final String OZONE_READONLY_ADMINISTRATORS_GROUPS =
           "ozone.readonly.administrators.groups";
 
   /**

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/OzoneConfigKeys.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/OzoneConfigKeys.java
@@ -173,6 +173,12 @@ public final class OzoneConfigKeys {
           "ozone.s3.administrators";
   public static final String OZONE_S3_ADMINISTRATORS_GROUPS =
           "ozone.s3.administrators.groups";
+
+  public static final String OZONE_SUPER_READ_USERNAMES =
+          "ozone.super.read.usernames";
+  public static final String OZONE_SUPER_READ_GROUPS =
+          "ozone.super.read.groups";
+
   /**
    * Used only for testing purpose. Results in making every user an admin.
    * */

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/OzoneConfigKeys.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/OzoneConfigKeys.java
@@ -170,14 +170,14 @@ public final class OzoneConfigKeys {
       "ozone.administrators.groups";
 
   public static final String OZONE_S3_ADMINISTRATORS =
-          "ozone.s3.administrators";
+      "ozone.s3.administrators";
   public static final String OZONE_S3_ADMINISTRATORS_GROUPS =
-          "ozone.s3.administrators.groups";
+      "ozone.s3.administrators.groups";
 
   public static final String OZONE_READONLY_ADMINISTRATORS =
-          "ozone.readonly.administrators";
+      "ozone.readonly.administrators";
   public static final String OZONE_READONLY_ADMINISTRATORS_GROUPS =
-          "ozone.readonly.administrators.groups";
+      "ozone.readonly.administrators.groups";
 
   /**
    * Used only for testing purpose. Results in making every user an admin.

--- a/hadoop-hdds/common/src/main/resources/ozone-default.xml
+++ b/hadoop-hdds/common/src/main/resources/ozone-default.xml
@@ -1636,6 +1636,24 @@
   </property>
 
   <property>
+    <name>ozone.super.read.usernames</name>
+    <value/>
+    <description>
+      Ozone super read users delimited by the comma.
+      If set, This is the list of users are allowed to read operations skip checkAccess.
+    </description>
+  </property>
+
+  <property>
+    <name>ozone.super.read.groups</name>
+    <value/>
+    <description>
+      Ozone super read groups delimited by the comma.
+      If set, This is the list of groups are allowed to read operations skip checkAccess.
+    </description>
+  </property>
+
+  <property>
     <name>ozone.s3g.volume.name</name>
     <value>s3v</value>
     <tag>OZONE, S3GATEWAY</tag>

--- a/hadoop-hdds/common/src/main/resources/ozone-default.xml
+++ b/hadoop-hdds/common/src/main/resources/ozone-default.xml
@@ -1636,7 +1636,7 @@
   </property>
 
   <property>
-    <name>ozone.super.read.usernames</name>
+    <name>ozone.readonly.administrators</name>
     <value/>
     <description>
       Ozone super read users delimited by the comma.
@@ -1645,7 +1645,7 @@
   </property>
 
   <property>
-    <name>ozone.super.read.groups</name>
+    <name>ozone.readonly.administrators.groups</name>
     <value/>
     <description>
       Ozone super read groups delimited by the comma.

--- a/hadoop-hdds/common/src/main/resources/ozone-default.xml
+++ b/hadoop-hdds/common/src/main/resources/ozone-default.xml
@@ -1639,7 +1639,7 @@
     <name>ozone.readonly.administrators</name>
     <value/>
     <description>
-      Ozone super read users delimited by the comma.
+      Ozone read only admin users delimited by the comma.
       If set, This is the list of users are allowed to read operations skip checkAccess.
     </description>
   </property>
@@ -1648,7 +1648,7 @@
     <name>ozone.readonly.administrators.groups</name>
     <value/>
     <description>
-      Ozone super read groups delimited by the comma.
+      Ozone read only admin groups delimited by the comma.
       If set, This is the list of groups are allowed to read operations skip checkAccess.
     </description>
   </property>

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/server/OzoneAdmins.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/server/OzoneAdmins.java
@@ -43,14 +43,6 @@ public class OzoneAdmins {
    * Ozone super user / admin group list.
    */
   private final Set<String> adminGroups;
-  /**
-   * Ozone super only read user / admin username list.
-   */
-  private final Set<String> superReadUsernames;
-  /**
-   * Ozone super only read user / admin group list.
-   */
-  private final Set<String> superReadGroups;
 
   public OzoneAdmins(Collection<String> adminUsernames) {
     this(adminUsernames, null);
@@ -58,32 +50,14 @@ public class OzoneAdmins {
 
   public OzoneAdmins(Collection<String> adminUsernames,
       Collection<String> adminGroups) {
-    this(adminUsernames, adminGroups, null, null);
-  }
-
-  public OzoneAdmins(Collection<String> adminUsernames,
-       Collection<String> adminGroups,
-       Collection<String> superReadUsernames,
-       Collection<String> superReadGroups) {
     setAdminUsernames(adminUsernames);
     this.adminGroups = adminGroups != null ?
         Collections.unmodifiableSet(new LinkedHashSet<>(adminGroups)) :
-        Collections.emptySet();
-    this.superReadUsernames = superReadUsernames != null ?
-        Collections.unmodifiableSet(new LinkedHashSet<>(superReadUsernames)) :
-        Collections.emptySet();
-    this.superReadGroups = superReadGroups != null ?
-        Collections.unmodifiableSet(new LinkedHashSet<>(superReadGroups)) :
         Collections.emptySet();
   }
 
   private boolean hasAdminGroup(Collection<String> userGroups) {
     return !Sets.intersection(adminGroups,
-        new LinkedHashSet<>(userGroups)).isEmpty();
-  }
-
-  private boolean hasSuperReadGroup(Collection<String> userGroups) {
-    return !Sets.intersection(superReadGroups,
         new LinkedHashSet<>(userGroups)).isEmpty();
   }
 
@@ -100,12 +74,6 @@ public class OzoneAdmins {
         || hasAdminGroup(user.getGroups());
   }
 
-  public boolean isSuperRead(UserGroupInformation user) {
-    return superReadUsernames.contains(user.getShortUserName())
-        || superReadUsernames.contains(user.getUserName())
-        || hasSuperReadGroup(user.getGroups());
-  }
-
   public Collection<String> getAdminGroups() {
     return adminGroups;
   }
@@ -118,13 +86,5 @@ public class OzoneAdmins {
     this.adminUsernames = adminUsernames != null ?
         Collections.unmodifiableSet(new LinkedHashSet<>(adminUsernames)) :
         Collections.emptySet();
-  }
-
-  public Collection<String> getSuperReadGroups() {
-    return superReadGroups;
-  }
-
-  public Set<String> getSuperReadUsernames() {
-    return superReadUsernames;
   }
 }

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/server/OzoneAdmins.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/server/OzoneAdmins.java
@@ -87,4 +87,5 @@ public class OzoneAdmins {
         Collections.unmodifiableSet(new LinkedHashSet<>(adminUsernames)) :
         Collections.emptySet();
   }
+
 }

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/server/OzoneAdmins.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/server/OzoneAdmins.java
@@ -43,6 +43,14 @@ public class OzoneAdmins {
    * Ozone super user / admin group list.
    */
   private final Set<String> adminGroups;
+  /**
+   * Ozone super only read user / admin username list.
+   */
+  private final Set<String> superReadUsernames;
+  /**
+   * Ozone super only read user / admin group list.
+   */
+  private final Set<String> superReadGroups;
 
   public OzoneAdmins(Collection<String> adminUsernames) {
     this(adminUsernames, null);
@@ -50,14 +58,32 @@ public class OzoneAdmins {
 
   public OzoneAdmins(Collection<String> adminUsernames,
       Collection<String> adminGroups) {
+    this(adminUsernames, adminGroups, null, null);
+  }
+
+  public OzoneAdmins(Collection<String> adminUsernames,
+       Collection<String> adminGroups,
+       Collection<String> superReadUsernames,
+       Collection<String> superReadGroups) {
     setAdminUsernames(adminUsernames);
     this.adminGroups = adminGroups != null ?
         Collections.unmodifiableSet(new LinkedHashSet<>(adminGroups)) :
+        Collections.emptySet();
+    this.superReadUsernames = superReadUsernames != null ?
+        Collections.unmodifiableSet(new LinkedHashSet<>(superReadUsernames)) :
+        Collections.emptySet();
+    this.superReadGroups = superReadGroups != null ?
+        Collections.unmodifiableSet(new LinkedHashSet<>(superReadGroups)) :
         Collections.emptySet();
   }
 
   private boolean hasAdminGroup(Collection<String> userGroups) {
     return !Sets.intersection(adminGroups,
+        new LinkedHashSet<>(userGroups)).isEmpty();
+  }
+
+  private boolean hasSuperReadGroup(Collection<String> userGroups) {
+    return !Sets.intersection(superReadGroups,
         new LinkedHashSet<>(userGroups)).isEmpty();
   }
 
@@ -74,6 +100,12 @@ public class OzoneAdmins {
         || hasAdminGroup(user.getGroups());
   }
 
+  public boolean isSuperRead(UserGroupInformation user) {
+    return superReadUsernames.contains(user.getShortUserName())
+        || superReadUsernames.contains(user.getUserName())
+        || hasSuperReadGroup(user.getGroups());
+  }
+
   public Collection<String> getAdminGroups() {
     return adminGroups;
   }
@@ -88,4 +120,11 @@ public class OzoneAdmins {
         Collections.emptySet();
   }
 
+  public Collection<String> getSuperReadGroups() {
+    return superReadGroups;
+  }
+
+  public Set<String> getSuperReadUsernames() {
+    return superReadUsernames;
+  }
 }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmMetadataReader.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmMetadataReader.java
@@ -44,6 +44,7 @@ import org.apache.hadoop.util.ReflectionUtils;
 import org.apache.hadoop.util.Time;
 import org.slf4j.Logger;
 import java.net.InetAddress;
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 
@@ -114,8 +115,8 @@ public class OmMetadataReader implements IOmMetadataReader, Auditor {
         authorizer.setBucketManager(bucketManager);
         authorizer.setKeyManager(keyManager);
         authorizer.setPrefixManager(prefixManager);
-        authorizer.setOzoneAdmins(
-            new OzoneAdmins(ozoneManager.getOmAdminUsernames()));
+        authorizer.setOzoneAdmins(ozoneManager.getOmAdmins());
+        authorizer.setOzoneSuperReadAdmins(getOmSuperReadAdmins(configuration));
         authorizer.setAllowListAllVolumes(allowListAllVolumes);
       } else {
         isNativeAuthorizerEnabled = false;
@@ -579,5 +580,12 @@ public class OmMetadataReader implements IOmMetadataReader, Auditor {
     return ResourceType.KEY;
   }
 
-  
+  private OzoneAdmins getOmSuperReadAdmins(OzoneConfiguration configuration) {
+    // Get super read list
+    Collection<String> omSuperReadUsernames =
+            OzoneConfigUtil.getOzoneSuperReadUserNamesFromConfig(configuration);
+    Collection<String> omSuperReadGroups =
+            OzoneConfigUtil.getOzoneSuperReadGroupsFromConfig(configuration);
+    return new OzoneAdmins(omSuperReadUsernames, omSuperReadGroups);
+  }
 }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmMetadataReader.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmMetadataReader.java
@@ -583,9 +583,12 @@ public class OmMetadataReader implements IOmMetadataReader, Auditor {
   private OzoneAdmins getOmReadOnlyAdmins(OzoneConfiguration configuration) {
     // Get read only admin list
     Collection<String> omReadOnlyAdmins =
-        OzoneConfigUtil.getOzoneReadOnlyAdminsFromConfig(configuration);
+        OzoneConfigUtil.getOzoneReadOnlyAdminsFromConfig(
+            configuration);
     Collection<String> omReadOnlyAdminsGroups =
-        OzoneConfigUtil.getOzoneReadOnlyAdminsGroupsFromConfig(configuration);
-    return new OzoneAdmins(omReadOnlyAdmins, omReadOnlyAdminsGroups);
+        OzoneConfigUtil.getOzoneReadOnlyAdminsGroupsFromConfig(
+            configuration);
+    return new OzoneAdmins(omReadOnlyAdmins,
+        omReadOnlyAdminsGroups);
   }
 }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmMetadataReader.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmMetadataReader.java
@@ -583,9 +583,9 @@ public class OmMetadataReader implements IOmMetadataReader, Auditor {
   private OzoneAdmins getOmReadOnlyAdmins(OzoneConfiguration configuration) {
     // Get read only admin list
     Collection<String> omReadOnlyAdmins =
-            OzoneConfigUtil.getOzoneReadOnlyAdminsFromConfig(configuration);
+        OzoneConfigUtil.getOzoneReadOnlyAdminsFromConfig(configuration);
     Collection<String> omReadOnlyAdminsGroups =
-            OzoneConfigUtil.getOzoneReadOnlyAdminsGroupsFromConfig(configuration);
+        OzoneConfigUtil.getOzoneReadOnlyAdminsGroupsFromConfig(configuration);
     return new OzoneAdmins(omReadOnlyAdmins, omReadOnlyAdminsGroups);
   }
 }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmMetadataReader.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmMetadataReader.java
@@ -116,7 +116,7 @@ public class OmMetadataReader implements IOmMetadataReader, Auditor {
         authorizer.setKeyManager(keyManager);
         authorizer.setPrefixManager(prefixManager);
         authorizer.setOzoneAdmins(ozoneManager.getOmAdmins());
-        authorizer.setOzoneSuperReadAdmins(getOmSuperReadAdmins(configuration));
+        authorizer.setOzoneReadOnlyAdmins(getOmReadOnlyAdmins(configuration));
         authorizer.setAllowListAllVolumes(allowListAllVolumes);
       } else {
         isNativeAuthorizerEnabled = false;
@@ -580,12 +580,12 @@ public class OmMetadataReader implements IOmMetadataReader, Auditor {
     return ResourceType.KEY;
   }
 
-  private OzoneAdmins getOmSuperReadAdmins(OzoneConfiguration configuration) {
-    // Get super read list
-    Collection<String> omSuperReadUsernames =
-            OzoneConfigUtil.getOzoneSuperReadUserNamesFromConfig(configuration);
-    Collection<String> omSuperReadGroups =
-            OzoneConfigUtil.getOzoneSuperReadGroupsFromConfig(configuration);
-    return new OzoneAdmins(omSuperReadUsernames, omSuperReadGroups);
+  private OzoneAdmins getOmReadOnlyAdmins(OzoneConfiguration configuration) {
+    // Get read only admin list
+    Collection<String> omReadOnlyAdmins =
+            OzoneConfigUtil.getOzoneReadOnlyAdminsFromConfig(configuration);
+    Collection<String> omReadOnlyAdminsGroups =
+            OzoneConfigUtil.getOzoneReadOnlyAdminsGroupsFromConfig(configuration);
+    return new OzoneAdmins(omReadOnlyAdmins, omReadOnlyAdminsGroups);
   }
 }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneConfigUtil.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneConfigUtil.java
@@ -83,7 +83,7 @@ public final class OzoneConfigUtil {
    * Return list of Ozone Read only admin Usernames from config.
    */
   static Collection<String> getOzoneReadOnlyAdminsFromConfig(
-          OzoneConfiguration conf) {
+      OzoneConfiguration conf) {
     return conf.getTrimmedStringCollection(OZONE_READONLY_ADMINISTRATORS);
   }
 
@@ -105,7 +105,7 @@ public final class OzoneConfigUtil {
   }
 
   static Collection<String> getOzoneReadOnlyAdminsGroupsFromConfig(
-          OzoneConfiguration conf) {
+      OzoneConfiguration conf) {
     return conf.getTrimmedStringCollection(OZONE_READONLY_ADMINISTRATORS_GROUPS);
   }
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneConfigUtil.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneConfigUtil.java
@@ -33,8 +33,8 @@ import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_ADMINISTRATORS;
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_ADMINISTRATORS_GROUPS;
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_S3_ADMINISTRATORS;
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_S3_ADMINISTRATORS_GROUPS;
-import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_SUPER_READ_USERNAMES;
-import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_SUPER_READ_GROUPS;
+import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_READONLY_ADMINISTRATORS;
+import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_READONLY_ADMINISTRATORS_GROUPS;
 
 /**
  * Utility class for ozone configurations.
@@ -80,11 +80,11 @@ public final class OzoneConfigUtil {
   }
 
   /**
-   * Return list of Ozone Super Read Usernames from config.
+   * Return list of Ozone Read only admin Usernames from config.
    */
-  static Collection<String> getOzoneSuperReadUserNamesFromConfig(
+  static Collection<String> getOzoneReadOnlyAdminsFromConfig(
           OzoneConfiguration conf) {
-    return conf.getTrimmedStringCollection(OZONE_SUPER_READ_USERNAMES);
+    return conf.getTrimmedStringCollection(OZONE_READONLY_ADMINISTRATORS);
   }
 
   static Collection<String> getOzoneAdminsGroupsFromConfig(
@@ -104,9 +104,9 @@ public final class OzoneConfigUtil {
     return s3AdminsGroup;
   }
 
-  static Collection<String> getOzoneSuperReadGroupsFromConfig(
+  static Collection<String> getOzoneReadOnlyAdminsGroupsFromConfig(
           OzoneConfiguration conf) {
-    return conf.getTrimmedStringCollection(OZONE_SUPER_READ_GROUPS);
+    return conf.getTrimmedStringCollection(OZONE_READONLY_ADMINISTRATORS_GROUPS);
   }
 
   public static ReplicationConfig resolveReplicationConfigPreference(

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneConfigUtil.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneConfigUtil.java
@@ -106,7 +106,8 @@ public final class OzoneConfigUtil {
 
   static Collection<String> getOzoneReadOnlyAdminsGroupsFromConfig(
       OzoneConfiguration conf) {
-    return conf.getTrimmedStringCollection(OZONE_READONLY_ADMINISTRATORS_GROUPS);
+    return conf.getTrimmedStringCollection(
+        OZONE_READONLY_ADMINISTRATORS_GROUPS);
   }
 
   public static ReplicationConfig resolveReplicationConfigPreference(

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneConfigUtil.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneConfigUtil.java
@@ -29,7 +29,12 @@ import org.slf4j.LoggerFactory;
 import java.io.IOException;
 import java.util.Collection;
 
-import static org.apache.hadoop.ozone.OzoneConfigKeys.*;
+import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_ADMINISTRATORS;
+import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_ADMINISTRATORS_GROUPS;
+import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_S3_ADMINISTRATORS;
+import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_S3_ADMINISTRATORS_GROUPS;
+import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_SUPER_READ_USERNAMES;
+import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_SUPER_READ_GROUPS;
 
 /**
  * Utility class for ozone configurations.

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneConfigUtil.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneConfigUtil.java
@@ -29,10 +29,7 @@ import org.slf4j.LoggerFactory;
 import java.io.IOException;
 import java.util.Collection;
 
-import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_ADMINISTRATORS;
-import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_ADMINISTRATORS_GROUPS;
-import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_S3_ADMINISTRATORS;
-import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_S3_ADMINISTRATORS_GROUPS;
+import static org.apache.hadoop.ozone.OzoneConfigKeys.*;
 
 /**
  * Utility class for ozone configurations.
@@ -77,6 +74,14 @@ public final class OzoneConfigUtil {
     return ozAdmins;
   }
 
+  /**
+   * Return list of Ozone Super Read Usernames from config.
+   */
+  static Collection<String> getOzoneSuperReadUserNamesFromConfig(
+          OzoneConfiguration conf) {
+    return conf.getTrimmedStringCollection(OZONE_SUPER_READ_USERNAMES);
+  }
+
   static Collection<String> getOzoneAdminsGroupsFromConfig(
       OzoneConfiguration conf) {
     return conf.getTrimmedStringCollection(OZONE_ADMINISTRATORS_GROUPS);
@@ -92,6 +97,11 @@ public final class OzoneConfigUtil {
               .getTrimmedStringCollection(OZONE_ADMINISTRATORS_GROUPS);
     }
     return s3AdminsGroup;
+  }
+
+  static Collection<String> getOzoneSuperReadGroupsFromConfig(
+          OzoneConfiguration conf) {
+    return conf.getTrimmedStringCollection(OZONE_SUPER_READ_GROUPS);
   }
 
   public static ReplicationConfig resolveReplicationConfigPreference(

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
@@ -625,12 +625,7 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
     Collection<String> omAdminGroups =
         OzoneConfigUtil.getOzoneAdminsGroupsFromConfig(configuration);
     LOG.info("OM start with adminUsers: {}", omAdminUsernames);
-    // Get super read list
-    Collection<String> omSuperReadUsernames =
-            OzoneConfigUtil.getOzoneSuperReadUserNamesFromConfig(configuration);
-    Collection<String> omSuperReadGroups =
-            OzoneConfigUtil.getOzoneSuperReadGroupsFromConfig(configuration);
-    omAdmins = new OzoneAdmins(omAdminUsernames, omAdminGroups, omSuperReadUsernames, omSuperReadGroups);
+    omAdmins = new OzoneAdmins(omAdminUsernames, omAdminGroups);
 
     Collection<String> s3AdminUsernames =
             OzoneConfigUtil.getS3AdminsFromConfig(configuration);
@@ -4037,6 +4032,13 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
 
   public Collection<String> getOmAdminGroups() {
     return omAdmins.getAdminGroups();
+  }
+
+  /**
+   * Return OzoneAdmins
+   */
+  public OzoneAdmins getOmAdmins() {
+    return omAdmins;
   }
 
   /**

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
@@ -625,7 +625,12 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
     Collection<String> omAdminGroups =
         OzoneConfigUtil.getOzoneAdminsGroupsFromConfig(configuration);
     LOG.info("OM start with adminUsers: {}", omAdminUsernames);
-    omAdmins = new OzoneAdmins(omAdminUsernames, omAdminGroups);
+    // Get super read list
+    Collection<String> omSuperReadUsernames =
+            OzoneConfigUtil.getOzoneSuperReadUserNamesFromConfig(configuration);
+    Collection<String> omSuperReadGroups =
+            OzoneConfigUtil.getOzoneSuperReadGroupsFromConfig(configuration);
+    omAdmins = new OzoneAdmins(omAdminUsernames, omAdminGroups, omSuperReadUsernames, omSuperReadGroups);
 
     Collection<String> s3AdminUsernames =
             OzoneConfigUtil.getS3AdminsFromConfig(configuration);

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
@@ -4035,7 +4035,7 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
   }
 
   /**
-   * Return OzoneAdmins
+   * Return OzoneAdmins.
    */
   public OzoneAdmins getOmAdmins() {
     return omAdmins;

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/security/acl/OzoneNativeAuthorizer.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/security/acl/OzoneNativeAuthorizer.java
@@ -50,7 +50,7 @@ public class OzoneNativeAuthorizer implements IAccessAuthorizer {
   private KeyManager keyManager;
   private PrefixManager prefixManager;
   private OzoneAdmins ozAdmins;
-  private OzoneAdmins ozSuperReadAdmins;
+  private OzoneAdmins ozReadOnlyAdmins;
   private boolean allowListAllVolumes;
 
   public OzoneNativeAuthorizer() {
@@ -98,11 +98,12 @@ public class OzoneNativeAuthorizer implements IAccessAuthorizer {
 
     boolean isOwner = isOwner(context.getClientUgi(), context.getOwnerName());
 
-    boolean isSuperReadAdmin = isAdmin(ozSuperReadAdmins,
+    boolean isReadOnlyAdmin = isAdmin(ozReadOnlyAdmins,
         context.getClientUgi());
 
-    // bypass read checks for super read users
-    if (isSuperReadAdmin && (context.getAclRights() == ACLType.READ
+    // bypass read checks for read only admin users
+    if (isReadOnlyAdmin
+        && (context.getAclRights() == ACLType.READ
         || context.getAclRights() == ACLType.READ_ACL
         || context.getAclRights() == ACLType.LIST)) {
       return true;
@@ -205,8 +206,8 @@ public class OzoneNativeAuthorizer implements IAccessAuthorizer {
     this.ozAdmins = ozoneAdmins;
   }
 
-  public void setOzoneSuperReadAdmins(OzoneAdmins ozoneSuperReadAdmins) {
-    this.ozSuperReadAdmins = ozoneSuperReadAdmins;
+  public void setOzoneReadOnlyAdmins(OzoneAdmins ozReadOnlyAdmins) {
+    this.ozReadOnlyAdmins = ozReadOnlyAdmins;
   }
 
   public OzoneAdmins getOzoneAdmins() {

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/security/acl/OzoneNativeAuthorizer.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/security/acl/OzoneNativeAuthorizer.java
@@ -204,8 +204,8 @@ public class OzoneNativeAuthorizer implements IAccessAuthorizer {
     this.ozAdmins = ozoneAdmins;
   }
 
-  public void setOzoneReadOnlyAdmins(OzoneAdmins ozReadOnlyAdmins) {
-    this.ozReadOnlyAdmins = ozReadOnlyAdmins;
+  public void setOzoneReadOnlyAdmins(OzoneAdmins ozoneReadOnlyAdmins) {
+    this.ozReadOnlyAdmins = ozoneReadOnlyAdmins;
   }
 
   public OzoneAdmins getOzoneAdmins() {

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/security/acl/OzoneNativeAuthorizer.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/security/acl/OzoneNativeAuthorizer.java
@@ -100,14 +100,16 @@ public class OzoneNativeAuthorizer implements IAccessAuthorizer {
     boolean isListAllVolume = ((context.getAclRights() == ACLType.LIST) &&
         objInfo.getVolumeName().equals(OzoneConsts.OZONE_ROOT));
     if (isListAllVolume) {
-      return getAllowListAllVolumes() || isAdmin(ozSuperReadAdmins, context.getClientUgi());
+      return getAllowListAllVolumes()
+          || isAdmin(ozSuperReadAdmins, context.getClientUgi());
     }
 
     ACLType parentAclRight = OzoneAclUtils.getParentNativeAcl(
         context.getAclRights(), objInfo.getResourceType());
 
     // bypass only read checks for super read
-    if (isAdmin(ozSuperReadAdmins, context.getClientUgi()) && parentAclRight == ACLType.READ) {
+    if (isAdmin(ozSuperReadAdmins, context.getClientUgi())
+        && parentAclRight == ACLType.READ) {
       return true;
     }
     
@@ -225,13 +227,14 @@ public class OzoneNativeAuthorizer implements IAccessAuthorizer {
     return false;
   }
 
-  private boolean isAdmin(OzoneAdmins ozAdmins, UserGroupInformation callerUgi) {
+  private boolean isAdmin(OzoneAdmins pOzAdmins,
+                      UserGroupInformation callerUgi) {
     Preconditions.checkNotNull(callerUgi, "callerUgi should not be null!");
 
-    if (ozAdmins == null) {
+    if (pOzAdmins == null) {
       return false;
     }
 
-    return ozAdmins.isAdmin(callerUgi);
+    return pOzAdmins.isAdmin(callerUgi);
   }
 }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/security/acl/OzoneNativeAuthorizer.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/security/acl/OzoneNativeAuthorizer.java
@@ -201,8 +201,8 @@ public class OzoneNativeAuthorizer implements IAccessAuthorizer {
     this.ozAdmins = ozoneAdmins;
   }
 
-  public void setOzoneSuperReadAdmins(OzoneAdmins ozSuperReadAdmins) {
-    this.ozSuperReadAdmins = ozSuperReadAdmins;
+  public void setOzoneSuperReadAdmins(OzoneAdmins ozoneSuperReadAdmins) {
+    this.ozSuperReadAdmins = ozoneSuperReadAdmins;
   }
 
   public OzoneAdmins getOzoneAdmins() {

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/security/acl/OzoneNativeAuthorizer.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/security/acl/OzoneNativeAuthorizer.java
@@ -96,12 +96,9 @@ public class OzoneNativeAuthorizer implements IAccessAuthorizer {
       return true;
     }
 
-    boolean isOwner = isOwner(context.getClientUgi(), context.getOwnerName());
-
+    // bypass read checks for read only admin users
     boolean isReadOnlyAdmin = isAdmin(ozReadOnlyAdmins,
         context.getClientUgi());
-
-    // bypass read checks for read only admin users
     if (isReadOnlyAdmin
         && (context.getAclRights() == ACLType.READ
         || context.getAclRights() == ACLType.READ_ACL
@@ -109,6 +106,7 @@ public class OzoneNativeAuthorizer implements IAccessAuthorizer {
       return true;
     }
 
+    boolean isOwner = isOwner(context.getClientUgi(), context.getOwnerName());
     boolean isListAllVolume = ((context.getAclRights() == ACLType.LIST) &&
         objInfo.getVolumeName().equals(OzoneConsts.OZONE_ROOT));
     if (isListAllVolume) {

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/security/acl/TestOzoneAdministrators.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/security/acl/TestOzoneAdministrators.java
@@ -97,6 +97,21 @@ public class TestOzoneAdministrators {
         asList(new String[]{"testuser2", "testuser3"})));
     Assert.assertFalse("mismatching admins are not allowed perform " +
         "admin operations", nativeAuthorizer.checkAccess(obj, context));
+
+    nativeAuthorizer.setOzoneAdmins(new OzoneAdmins(
+            null, null, Collections.singletonList("testuser"), null));
+    if (context.getAclRights() == IAccessAuthorizer.ACLType.LIST) {
+      Assert.assertTrue("matching super read user are allowed to preform" +
+        "read operations", nativeAuthorizer.checkAccess(obj, context));
+    } else if (context.getAclRights() == IAccessAuthorizer.ACLType.CREATE) {
+      Assert.assertFalse("mismatching super read user are allowed to preform" +
+        "read operations", nativeAuthorizer.checkAccess(obj, context));
+    }
+
+    nativeAuthorizer.setOzoneAdmins(new OzoneAdmins(
+      null, null, Collections.singletonList("testuser1"), null));
+    Assert.assertFalse("mismatching super read user are allowed to preform" +
+        "read operations", nativeAuthorizer.checkAccess(obj, context));
   }
 
   private void testGroupAdminOperations(OzoneObj obj, RequestContext context)
@@ -112,6 +127,21 @@ public class TestOzoneAdministrators {
     Assert.assertFalse("Users from mismatching admin groups " +
         "are allowed to perform admin operations",
             nativeAuthorizer.checkAccess(obj, context));
+
+    nativeAuthorizer.setOzoneAdmins(
+            new OzoneAdmins(null, null, null, Collections.singletonList("testgroup")));
+    if (context.getAclRights() == IAccessAuthorizer.ACLType.LIST) {
+      Assert.assertTrue("matching super read groups are allowed to preform" +
+          "read operations", nativeAuthorizer.checkAccess(obj, context));
+    } else if (context.getAclRights() == IAccessAuthorizer.ACLType.CREATE) {
+      Assert.assertFalse("mismatching super read groups are allowed to preform" +
+          "read operations", nativeAuthorizer.checkAccess(obj, context));
+    }
+
+    nativeAuthorizer.setOzoneAdmins(
+            new OzoneAdmins(null, null, null, Collections.singletonList("testgroup1")));
+    Assert.assertFalse("mismatching super read groups are allowed to preform" +
+        "read operations", nativeAuthorizer.checkAccess(obj, context));
   }
 
   private RequestContext getUserRequestContext(String username,

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/security/acl/TestOzoneAdministrators.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/security/acl/TestOzoneAdministrators.java
@@ -98,8 +98,8 @@ public class TestOzoneAdministrators {
     Assert.assertFalse("mismatching admins are not allowed perform " +
         "admin operations", nativeAuthorizer.checkAccess(obj, context));
 
-    nativeAuthorizer.setOzoneAdmins(new OzoneAdmins(
-            null, null, Collections.singletonList("testuser"), null));
+    nativeAuthorizer.setOzoneSuperReadAdmins(new OzoneAdmins(
+        Collections.singletonList("testuser"), null));
     if (context.getAclRights() == IAccessAuthorizer.ACLType.LIST) {
       Assert.assertTrue("matching super read user are allowed to preform" +
         "read operations", nativeAuthorizer.checkAccess(obj, context));
@@ -108,8 +108,8 @@ public class TestOzoneAdministrators {
         "read operations", nativeAuthorizer.checkAccess(obj, context));
     }
 
-    nativeAuthorizer.setOzoneAdmins(new OzoneAdmins(
-      null, null, Collections.singletonList("testuser1"), null));
+    nativeAuthorizer.setOzoneSuperReadAdmins(new OzoneAdmins(
+      Collections.singletonList("testuser1"), null));
     Assert.assertFalse("mismatching super read user are allowed to preform" +
         "read operations", nativeAuthorizer.checkAccess(obj, context));
   }
@@ -128,8 +128,8 @@ public class TestOzoneAdministrators {
         "are allowed to perform admin operations",
             nativeAuthorizer.checkAccess(obj, context));
 
-    nativeAuthorizer.setOzoneAdmins(
-            new OzoneAdmins(null, null, null, Collections.singletonList("testgroup")));
+    nativeAuthorizer.setOzoneSuperReadAdmins(new OzoneAdmins(
+        null, Collections.singletonList("testgroup")));
     if (context.getAclRights() == IAccessAuthorizer.ACLType.LIST) {
       Assert.assertTrue("matching super read groups are allowed to preform" +
           "read operations", nativeAuthorizer.checkAccess(obj, context));
@@ -138,8 +138,8 @@ public class TestOzoneAdministrators {
           "read operations", nativeAuthorizer.checkAccess(obj, context));
     }
 
-    nativeAuthorizer.setOzoneAdmins(
-            new OzoneAdmins(null, null, null, Collections.singletonList("testgroup1")));
+    nativeAuthorizer.setOzoneSuperReadAdmins(new OzoneAdmins(
+        null, Collections.singletonList("testgroup1")));
     Assert.assertFalse("mismatching super read groups are allowed to preform" +
         "read operations", nativeAuthorizer.checkAccess(obj, context));
   }

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/security/acl/TestOzoneAdministrators.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/security/acl/TestOzoneAdministrators.java
@@ -72,6 +72,52 @@ public class TestOzoneAdministrators {
     }
   }
 
+  @Test
+  public void testBucketOperation() throws Exception {
+    UserGroupInformation.createUserForTesting("testuser",
+        new String[]{"testgroup"});
+    try {
+      OzoneObj obj = getTestBucketObj("testbucket");
+      RequestContext createcontext = getUserRequestContext("testuser",
+          IAccessAuthorizer.ACLType.CREATE);
+      testAdminOperations(obj, createcontext);
+      testGroupAdminOperations(obj, createcontext);
+
+      RequestContext readaclcontext = getUserRequestContext("testuser",
+          IAccessAuthorizer.ACLType.READ_ACL);
+      testAdminOperations(obj, readaclcontext);
+      testGroupAdminOperations(obj, readaclcontext);
+
+      RequestContext listcontext = getUserRequestContext("testuser",
+          IAccessAuthorizer.ACLType.LIST);
+      testAdminOperations(obj, listcontext);
+      testGroupAdminOperations(obj, listcontext);
+
+      RequestContext readcontext = getUserRequestContext("testuser",
+          IAccessAuthorizer.ACLType.READ);
+      testAdminOperations(obj, readcontext);
+      testGroupAdminOperations(obj, readcontext);
+
+      RequestContext writeaclcontext = getUserRequestContext("testuser",
+          IAccessAuthorizer.ACLType.WRITE_ACL);
+      testAdminOperations(obj, writeaclcontext);
+      testGroupAdminOperations(obj, writeaclcontext);
+
+      RequestContext deletecontext = getUserRequestContext("testuser",
+          IAccessAuthorizer.ACLType.DELETE);
+      testAdminOperations(obj, deletecontext);
+      testGroupAdminOperations(obj, deletecontext);
+
+      RequestContext writecontext = getUserRequestContext("testuser",
+          IAccessAuthorizer.ACLType.WRITE);
+      testAdminOperations(obj, writecontext);
+      testGroupAdminOperations(obj, writecontext);
+    } finally {
+      UserGroupInformation.reset();
+    }
+  }
+
+
   private void testAdminOperations(OzoneObj obj, RequestContext context)
       throws OMException {
     nativeAuthorizer.setOzoneAdmins(new OzoneAdmins(Collections.emptyList()));
@@ -98,19 +144,31 @@ public class TestOzoneAdministrators {
     Assert.assertFalse("mismatching admins are not allowed perform " +
         "admin operations", nativeAuthorizer.checkAccess(obj, context));
 
-    nativeAuthorizer.setOzoneSuperReadAdmins(new OzoneAdmins(
+    nativeAuthorizer.setOzoneReadOnlyAdmins(new OzoneAdmins(
         Collections.singletonList("testuser"), null));
     if (context.getAclRights() == IAccessAuthorizer.ACLType.LIST) {
-      Assert.assertTrue("matching super read user are allowed to preform" +
+      Assert.assertTrue("matching read only user are allowed to preform" +
           "read operations", nativeAuthorizer.checkAccess(obj, context));
     } else if (context.getAclRights() == IAccessAuthorizer.ACLType.CREATE) {
-      Assert.assertFalse("mismatching super read user are allowed to preform" +
+      Assert.assertFalse("mismatching read only user are allowed to preform" +
+          "read operations", nativeAuthorizer.checkAccess(obj, context));
+    } else if (context.getAclRights() == IAccessAuthorizer.ACLType.READ_ACL) {
+      Assert.assertTrue("matching read only user are allowed to preform" +
+          "read operations", nativeAuthorizer.checkAccess(obj, context));
+    } else if (context.getAclRights() == IAccessAuthorizer.ACLType.READ) {
+      Assert.assertTrue("matching read only user are allowed to preform" +
+          "read operations", nativeAuthorizer.checkAccess(obj, context));
+    } else if (context.getAclRights() == IAccessAuthorizer.ACLType.DELETE) {
+      Assert.assertFalse("mismatching read only user are allowed to preform" +
+          "read operations", nativeAuthorizer.checkAccess(obj, context));
+    } else if (context.getAclRights() == IAccessAuthorizer.ACLType.WRITE) {
+      Assert.assertFalse("mismatching read only user are allowed to preform" +
           "read operations", nativeAuthorizer.checkAccess(obj, context));
     }
 
-    nativeAuthorizer.setOzoneSuperReadAdmins(new OzoneAdmins(
+    nativeAuthorizer.setOzoneReadOnlyAdmins(new OzoneAdmins(
         Collections.singletonList("testuser1"), null));
-    Assert.assertFalse("mismatching super read user are allowed to preform" +
+    Assert.assertFalse("mismatching read only user are allowed to preform" +
         "read operations", nativeAuthorizer.checkAccess(obj, context));
   }
 
@@ -128,20 +186,34 @@ public class TestOzoneAdministrators {
         "are allowed to perform admin operations",
             nativeAuthorizer.checkAccess(obj, context));
 
-    nativeAuthorizer.setOzoneSuperReadAdmins(new OzoneAdmins(
+    nativeAuthorizer.setOzoneReadOnlyAdmins(new OzoneAdmins(
         null, Collections.singletonList("testgroup")));
     if (context.getAclRights() == IAccessAuthorizer.ACLType.LIST) {
-      Assert.assertTrue("matching super read groups are allowed to preform" +
+      Assert.assertTrue("matching read only groups are allowed to preform" +
           "read operations", nativeAuthorizer.checkAccess(obj, context));
     } else if (context.getAclRights() == IAccessAuthorizer.ACLType.CREATE) {
-      Assert.assertFalse("mismatching super read groups are allowed to " +
+      Assert.assertFalse("mismatching read only groups are allowed to " +
+          "preform read operations",
+              nativeAuthorizer.checkAccess(obj, context));
+    }else if (context.getAclRights() == IAccessAuthorizer.ACLType.READ_ACL) {
+      Assert.assertTrue("matching read only groups are allowed to preform" +
+          "read operations", nativeAuthorizer.checkAccess(obj, context));
+    } else if (context.getAclRights() == IAccessAuthorizer.ACLType.READ) {
+      Assert.assertTrue("matching read only groups are allowed to preform" +
+          "read operations", nativeAuthorizer.checkAccess(obj, context));
+    } else if (context.getAclRights() == IAccessAuthorizer.ACLType.DELETE) {
+      Assert.assertFalse("mismatching read only groups are allowed to " +
+          "preform read operations",
+              nativeAuthorizer.checkAccess(obj, context));
+    } else if (context.getAclRights() == IAccessAuthorizer.ACLType.WRITE) {
+      Assert.assertFalse("mismatching read only groups are allowed to " +
           "preform read operations",
               nativeAuthorizer.checkAccess(obj, context));
     }
 
-    nativeAuthorizer.setOzoneSuperReadAdmins(new OzoneAdmins(
+    nativeAuthorizer.setOzoneReadOnlyAdmins(new OzoneAdmins(
         null, Collections.singletonList("testgroup1")));
-    Assert.assertFalse("mismatching super read groups are allowed to preform" +
+    Assert.assertFalse("mismatching read only groups are allowed to preform" +
         "read operations", nativeAuthorizer.checkAccess(obj, context));
   }
 
@@ -159,5 +231,12 @@ public class TestOzoneAdministrators {
         .setResType(OzoneObj.ResourceType.VOLUME)
         .setStoreType(OzoneObj.StoreType.OZONE)
         .setVolumeName(volumename).build();
+  }
+
+  private OzoneObj getTestBucketObj(String bucketname) {
+    return OzoneObjInfo.Builder.newBuilder()
+        .setResType(OzoneObj.ResourceType.BUCKET)
+        .setStoreType(OzoneObj.StoreType.OZONE)
+        .setVolumeName(bucketname).build();
   }
 }

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/security/acl/TestOzoneAdministrators.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/security/acl/TestOzoneAdministrators.java
@@ -102,14 +102,14 @@ public class TestOzoneAdministrators {
         Collections.singletonList("testuser"), null));
     if (context.getAclRights() == IAccessAuthorizer.ACLType.LIST) {
       Assert.assertTrue("matching super read user are allowed to preform" +
-        "read operations", nativeAuthorizer.checkAccess(obj, context));
+          "read operations", nativeAuthorizer.checkAccess(obj, context));
     } else if (context.getAclRights() == IAccessAuthorizer.ACLType.CREATE) {
       Assert.assertFalse("mismatching super read user are allowed to preform" +
-        "read operations", nativeAuthorizer.checkAccess(obj, context));
+          "read operations", nativeAuthorizer.checkAccess(obj, context));
     }
 
     nativeAuthorizer.setOzoneSuperReadAdmins(new OzoneAdmins(
-      Collections.singletonList("testuser1"), null));
+        Collections.singletonList("testuser1"), null));
     Assert.assertFalse("mismatching super read user are allowed to preform" +
         "read operations", nativeAuthorizer.checkAccess(obj, context));
   }
@@ -134,8 +134,8 @@ public class TestOzoneAdministrators {
       Assert.assertTrue("matching super read groups are allowed to preform" +
           "read operations", nativeAuthorizer.checkAccess(obj, context));
     } else if (context.getAclRights() == IAccessAuthorizer.ACLType.CREATE) {
-      Assert.assertFalse("mismatching super read groups are allowed to preform" +
-          "read operations", nativeAuthorizer.checkAccess(obj, context));
+      Assert.assertFalse("mismatching super read groups are allowed to " +
+          "preform read operations", nativeAuthorizer.checkAccess(obj, context));
     }
 
     nativeAuthorizer.setOzoneSuperReadAdmins(new OzoneAdmins(

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/security/acl/TestOzoneAdministrators.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/security/acl/TestOzoneAdministrators.java
@@ -83,7 +83,8 @@ public class TestOzoneAdministrators {
       context = getUserRequestContext("testuser",
           IAccessAuthorizer.ACLType.WRITE);
       RequestContext finalContext = context;
-      // ACLType is WRITE, execute volumeManager.checkAccess, volumeManager is null
+      // ACLType is WRITE
+      // execute volumeManager.checkAccess volumeManager is null
       Assert.assertThrows(NullPointerException.class,
           () -> nativeAuthorizer.checkAccess(obj, finalContext));
 

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/security/acl/TestOzoneAdministrators.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/security/acl/TestOzoneAdministrators.java
@@ -135,7 +135,8 @@ public class TestOzoneAdministrators {
           "read operations", nativeAuthorizer.checkAccess(obj, context));
     } else if (context.getAclRights() == IAccessAuthorizer.ACLType.CREATE) {
       Assert.assertFalse("mismatching super read groups are allowed to " +
-          "preform read operations", nativeAuthorizer.checkAccess(obj, context));
+          "preform read operations",
+              nativeAuthorizer.checkAccess(obj, context));
     }
 
     nativeAuthorizer.setOzoneSuperReadAdmins(new OzoneAdmins(

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/security/acl/TestOzoneAdministrators.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/security/acl/TestOzoneAdministrators.java
@@ -204,8 +204,8 @@ public class TestOzoneAdministrators {
 
   private OzoneObj getTestBucketobj(String bucketname) {
     return OzoneObjInfo.Builder.newBuilder()
-            .setResType(OzoneObj.ResourceType.BUCKET)
-            .setStoreType(OzoneObj.StoreType.OZONE)
-            .setVolumeName(bucketname).build();
+        .setResType(OzoneObj.ResourceType.BUCKET)
+        .setStoreType(OzoneObj.StoreType.OZONE)
+        .setVolumeName(bucketname).build();
   }
 }

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/security/acl/TestOzoneAdministrators.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/security/acl/TestOzoneAdministrators.java
@@ -72,52 +72,6 @@ public class TestOzoneAdministrators {
     }
   }
 
-  @Test
-  public void testBucketOperation() throws Exception {
-    UserGroupInformation.createUserForTesting("testuser",
-        new String[]{"testgroup"});
-    try {
-      OzoneObj obj = getTestBucketObj("testbucket");
-      RequestContext createcontext = getUserRequestContext("testuser",
-          IAccessAuthorizer.ACLType.CREATE);
-      testAdminOperations(obj, createcontext);
-      testGroupAdminOperations(obj, createcontext);
-
-      RequestContext readaclcontext = getUserRequestContext("testuser",
-          IAccessAuthorizer.ACLType.READ_ACL);
-      testAdminOperations(obj, readaclcontext);
-      testGroupAdminOperations(obj, readaclcontext);
-
-      RequestContext listcontext = getUserRequestContext("testuser",
-          IAccessAuthorizer.ACLType.LIST);
-      testAdminOperations(obj, listcontext);
-      testGroupAdminOperations(obj, listcontext);
-
-      RequestContext readcontext = getUserRequestContext("testuser",
-          IAccessAuthorizer.ACLType.READ);
-      testAdminOperations(obj, readcontext);
-      testGroupAdminOperations(obj, readcontext);
-
-      RequestContext writeaclcontext = getUserRequestContext("testuser",
-          IAccessAuthorizer.ACLType.WRITE_ACL);
-      testAdminOperations(obj, writeaclcontext);
-      testGroupAdminOperations(obj, writeaclcontext);
-
-      RequestContext deletecontext = getUserRequestContext("testuser",
-          IAccessAuthorizer.ACLType.DELETE);
-      testAdminOperations(obj, deletecontext);
-      testGroupAdminOperations(obj, deletecontext);
-
-      RequestContext writecontext = getUserRequestContext("testuser",
-          IAccessAuthorizer.ACLType.WRITE);
-      testAdminOperations(obj, writecontext);
-      testGroupAdminOperations(obj, writecontext);
-    } finally {
-      UserGroupInformation.reset();
-    }
-  }
-
-
   private void testAdminOperations(OzoneObj obj, RequestContext context)
       throws OMException {
     nativeAuthorizer.setOzoneAdmins(new OzoneAdmins(Collections.emptyList()));
@@ -152,18 +106,6 @@ public class TestOzoneAdministrators {
     } else if (context.getAclRights() == IAccessAuthorizer.ACLType.CREATE) {
       Assert.assertFalse("mismatching read only user are allowed to preform" +
           "read operations", nativeAuthorizer.checkAccess(obj, context));
-    } else if (context.getAclRights() == IAccessAuthorizer.ACLType.READ_ACL) {
-      Assert.assertTrue("matching read only user are allowed to preform" +
-          "read operations", nativeAuthorizer.checkAccess(obj, context));
-    } else if (context.getAclRights() == IAccessAuthorizer.ACLType.READ) {
-      Assert.assertTrue("matching read only user are allowed to preform" +
-          "read operations", nativeAuthorizer.checkAccess(obj, context));
-    } else if (context.getAclRights() == IAccessAuthorizer.ACLType.DELETE) {
-      Assert.assertFalse("mismatching read only user are allowed to preform" +
-          "read operations", nativeAuthorizer.checkAccess(obj, context));
-    } else if (context.getAclRights() == IAccessAuthorizer.ACLType.WRITE) {
-      Assert.assertFalse("mismatching read only user are allowed to preform" +
-          "read operations", nativeAuthorizer.checkAccess(obj, context));
     }
 
     nativeAuthorizer.setOzoneReadOnlyAdmins(new OzoneAdmins(
@@ -195,20 +137,6 @@ public class TestOzoneAdministrators {
       Assert.assertFalse("mismatching read only groups are allowed to " +
           "preform read operations",
               nativeAuthorizer.checkAccess(obj, context));
-    }else if (context.getAclRights() == IAccessAuthorizer.ACLType.READ_ACL) {
-      Assert.assertTrue("matching read only groups are allowed to preform" +
-          "read operations", nativeAuthorizer.checkAccess(obj, context));
-    } else if (context.getAclRights() == IAccessAuthorizer.ACLType.READ) {
-      Assert.assertTrue("matching read only groups are allowed to preform" +
-          "read operations", nativeAuthorizer.checkAccess(obj, context));
-    } else if (context.getAclRights() == IAccessAuthorizer.ACLType.DELETE) {
-      Assert.assertFalse("mismatching read only groups are allowed to " +
-          "preform read operations",
-              nativeAuthorizer.checkAccess(obj, context));
-    } else if (context.getAclRights() == IAccessAuthorizer.ACLType.WRITE) {
-      Assert.assertFalse("mismatching read only groups are allowed to " +
-          "preform read operations",
-              nativeAuthorizer.checkAccess(obj, context));
     }
 
     nativeAuthorizer.setOzoneReadOnlyAdmins(new OzoneAdmins(
@@ -231,12 +159,5 @@ public class TestOzoneAdministrators {
         .setResType(OzoneObj.ResourceType.VOLUME)
         .setStoreType(OzoneObj.StoreType.OZONE)
         .setVolumeName(volumename).build();
-  }
-
-  private OzoneObj getTestBucketObj(String bucketname) {
-    return OzoneObjInfo.Builder.newBuilder()
-        .setResType(OzoneObj.ResourceType.BUCKET)
-        .setStoreType(OzoneObj.StoreType.OZONE)
-        .setVolumeName(bucketname).build();
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?
Currently, there are admin users in the zone, which is a list of super read and super write users. As an administrator list, sometimes a only super read user list is also required

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-8413

## How was this patch tested?
- unit test
Existing test classes.

- Functional test

etc: ozone-site.xml (add)
```
<property>
      <name>ozone.super.read.usernames</name>
      <value>bigdata_qa</value>
   </property>
```

```
[hadoop@presto-test-006 ~]$ export HADOOP_USER_NAME=test
[hadoop@presto-test-006 ~]$ om-current/bin/ozone sh key getacl vol-test/bucket-test/key-hosts-test8
PERMISSION_DENIED User test doesn't have READ permission to access volume Volume:vol-test Bucket:bucket-test Key:key-hosts-test8

[hadoop@presto-test-006 ~]$ export HADOOP_USER_NAME=bigdata_qa
[hadoop@presto-test-006 ~]$ om-current/bin/ozone sh key getacl vol-test/bucket-test/key-hosts-test8
[ {
  "type" : "USER",
  "name" : "hadoop",
  "aclScope" : "ACCESS",
  "aclList" : [ "ALL" ]
} ]
```

