### PR TITLE
HDDS-8407. Intermittent failure in TestOzoneFileSystem#testTrash

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFileSystem.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFileSystem.java
@@ -1678,7 +1678,8 @@ public class TestOzoneFileSystem {
     }, 1000, 120000);
 
     // userTrash path will contain the checkpoint folder
-    Assert.assertEquals(1, fs.listStatus(userTrash).length);
+    FileStatus[] statusList = fs.listStatus(userTrash);
+    Assert.assertTrue(1 <= statusList.length);
 
     // wait for deletion of checkpoint dir
     GenericTestUtils.waitFor(() -> {

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFileSystem.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFileSystem.java
@@ -1675,7 +1675,7 @@ public class TestOzoneFileSystem {
 
     // userTrash path will contain the checkpoint folder
     FileStatus[] statusList = fs.listStatus(userTrash);
-    Assert.assertTrue(1 <= statusList.length);
+    Assert.assertNotEquals(Arrays.toString(statusList), 0, statusList.length);
 
     // wait for deletion of checkpoint dir
     GenericTestUtils.waitFor(() -> {


### PR DESCRIPTION
## What changes were proposed in this pull request?

Allow multiple trash checkpoints to account for items deleted for other test cases.

https://issues.apache.org/jira/browse/HDDS-8407

## How was this patch tested?

No failures of `testTrash` in 100 runs (only `testListStatusWithIntermediateDir` failed once, being fixed in HDDS-8370):
https://github.com/adoroszlai/hadoop-ozone/actions/runs/4691530928

Regular CI:
https://github.com/adoroszlai/hadoop-ozone/actions/runs/4692326817