### PR TITLE
HDDS-8421. Reduce DN IO times when writeChunk (FilePerBlockStrategy)

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/impl/FilePerBlockStrategy.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/impl/FilePerBlockStrategy.java
@@ -137,22 +137,24 @@ public class FilePerBlockStrategy implements ChunkManager {
         .getContainerData();
 
     File chunkFile = getChunkFile(container, blockID, info);
-    boolean overwrite = validateChunkForOverwrite(chunkFile, info);
     long len = info.getLen();
     long offset = info.getOffset();
-    if (LOG.isDebugEnabled()) {
-      LOG.debug("Writing chunk {} (overwrite: {}) in stage {} to file {}",
-          info, overwrite, stage, chunkFile);
-    }
 
     HddsVolume volume = containerData.getVolume();
 
     FileChannel channel = null;
+    boolean overwrite;
     try {
       channel = files.getChannel(chunkFile, doSyncWrite);
+      overwrite = validateChunkForOverwrite(channel, info);
     } catch (IOException e) {
       onFailure(volume);
       throw e;
+    }
+
+    if (LOG.isDebugEnabled()) {
+      LOG.debug("Writing chunk {} (overwrite: {}) in stage {} to file {}",
+          info, overwrite, stage, chunkFile);
     }
 
     // check whether offset matches block file length if its an overwrite

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/helpers/TestChunkUtils.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/helpers/TestChunkUtils.java
@@ -20,8 +20,10 @@ package org.apache.hadoop.ozone.container.keyvalue.helpers;
 import java.io.File;
 import java.io.IOException;
 import java.nio.ByteBuffer;
+import java.nio.channels.FileChannel;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
 import java.util.Arrays;
 import java.util.LinkedList;
 import java.util.List;
@@ -198,6 +200,17 @@ public class TestChunkUtils {
     Assertions.assertFalse(
         ChunkUtils.validateChunkForOverwrite(tempFile.toFile(),
             new ChunkInfo("chunk", 5, 5)));
+
+    try (FileChannel fileChannel =
+             FileChannel.open(tempFile, StandardOpenOption.READ)) {
+      Assertions.assertTrue(
+          ChunkUtils.validateChunkForOverwrite(fileChannel,
+              new ChunkInfo("chunk", 3, 5)));
+
+      Assertions.assertFalse(
+          ChunkUtils.validateChunkForOverwrite(fileChannel,
+              new ChunkInfo("chunk", 5, 5)));
+    }
   }
 
   @Test


### PR DESCRIPTION
## What changes were proposed in this pull request?

In the `FilePerBlockStrategy#writeChunk` will generate twice IO process.

- The first is to check whether the write operation is an overwrite, will check whether the chunk file is exist (`ChunkUtils#verifyChunkFileExists`).
- The second is write Chunk, will open file and write file.

Those two IO operation can merge to once. just need to check whether is overwrite after open file and before write Chunk

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-8421

## How was this patch tested?

unit test