### PR TITLE
HDDS-8428. Add MS or NS time unit suffix for CSMMetrics

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/helpers/ContainerMetrics.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/helpers/ContainerMetrics.java
@@ -83,7 +83,7 @@ public class ContainerMetrics {
 
       for (int j = 0; j < len; j++) {
         int interval = intervals[j];
-        String quantileName = ContainerProtos.Type.forNumber(i + 1) + "Millis"
+        String quantileName = ContainerProtos.Type.forNumber(i + 1) + "Nanos"
             + interval + "s";
         opsLatQuantiles[i][j] = registry.newQuantiles(quantileName,
             "latency of Container ops", "ops", "latency", interval);

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/helpers/ContainerMetrics.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/helpers/ContainerMetrics.java
@@ -83,7 +83,7 @@ public class ContainerMetrics {
 
       for (int j = 0; j < len; j++) {
         int interval = intervals[j];
-        String quantileName = ContainerProtos.Type.forNumber(i + 1) + "Nanos"
+        String quantileName = ContainerProtos.Type.forNumber(i + 1) + "Millis"
             + interval + "s";
         opsLatQuantiles[i][j] = registry.newQuantiles(quantileName,
             "latency of Container ops", "ops", "latency", interval);

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/transport/server/ratis/CSMMetrics.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/transport/server/ratis/CSMMetrics.java
@@ -209,11 +209,11 @@ public class CSMMetrics {
     numContainerNotOpenVerifyFailures.incr();
   }
 
-  public void recordApplyTransactionNsCompletion(long latencyNanos) {
+  public void recordApplyTransactionCompletionNs(long latencyNanos) {
     applyTransactionNs.add(latencyNanos);
   }
 
-  public void recordWriteStateMachineNsCompletion(long latencyNanos) {
+  public void recordWriteStateMachineCompletionNs(long latencyNanos) {
     writeStateMachineDataNs.add(latencyNanos);
   }
 

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/transport/server/ratis/CSMMetrics.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/transport/server/ratis/CSMMetrics.java
@@ -46,15 +46,8 @@ public class CSMMetrics {
   private @Metric MutableCounterLong numBytesWrittenCount;
   private @Metric MutableCounterLong numBytesCommittedCount;
 
-  @Deprecated
-  //Use {@link transactionLatencyMS} instead
-  private @Metric MutableRate transactionLatency;
-  @Deprecated
-  //Use {@link opsLatencyMS} instead
-  private MutableRate[] opsLatency;
-  private @Metric MutableRate transactionLatencyMS;
-  private MutableRate[] opsLatencyMS;
-
+  private @Metric MutableRate transactionLatencyMs;
+  private MutableRate[] opsLatencyMs;
   private MetricsRegistry registry = null;
 
   // Failure Metrics
@@ -69,25 +62,15 @@ public class CSMMetrics {
   private @Metric MutableCounterLong numDataCacheMiss;
   private @Metric MutableCounterLong numDataCacheHit;
 
-  @Deprecated
-  //Use {@link applyTransactionNs} instead
-  private @Metric MutableRate applyTransaction;
-  @Deprecated
-  //Use {@link writeStateMachineDataNs} instead
-  private @Metric MutableRate writeStateMachineData;
   private @Metric MutableRate applyTransactionNs;
   private @Metric MutableRate writeStateMachineDataNs;
 
   public CSMMetrics() {
     int numCmdTypes = ContainerProtos.Type.values().length;
-    this.opsLatency = new MutableRate[numCmdTypes];
-    this.opsLatencyMS = new MutableRate[numCmdTypes];
+    this.opsLatencyMs = new MutableRate[numCmdTypes];
     this.registry = new MetricsRegistry(CSMMetrics.class.getSimpleName());
     for (int i = 0; i < numCmdTypes; i++) {
-      opsLatency[i] = registry.newRate(
-          ContainerProtos.Type.forNumber(i + 1).toString(),
-          ContainerProtos.Type.forNumber(i + 1) + " op");
-      opsLatencyMS[i] = registry.newRate(
+      opsLatencyMs[i] = registry.newRate(
           ContainerProtos.Type.forNumber(i + 1).toString() + "Ms",
           ContainerProtos.Type.forNumber(i + 1) + " op");
     }
@@ -208,16 +191,14 @@ public class CSMMetrics {
     return numBytesCommittedCount.value();
   }
 
-  public MutableRate getApplyTransactionLatency() {
-    return applyTransaction;
+  public MutableRate getApplyTransactionNsLatency() {
+    return applyTransactionNs;
   }
 
   public void incPipelineLatencyMs(ContainerProtos.Type type,
       long latencyMillis) {
-    opsLatency[type.ordinal()].add(latencyMillis);
-    transactionLatency.add(latencyMillis);
-    opsLatencyMS[type.ordinal()].add(latencyMillis);
-    transactionLatencyMS.add(latencyMillis);
+    opsLatencyMs[type.ordinal()].add(latencyMillis);
+    transactionLatencyMs.add(latencyMillis);
   }
 
   public void incNumStartTransactionVerifyFailures() {
@@ -230,12 +211,10 @@ public class CSMMetrics {
 
   public void recordApplyTransactionNsCompletion(long latencyNanos) {
     applyTransactionNs.add(latencyNanos);
-    applyTransaction.add(latencyNanos);
   }
 
   public void recordWriteStateMachineNsCompletion(long latencyNanos) {
     writeStateMachineDataNs.add(latencyNanos);
-    writeStateMachineData.add(latencyNanos);
   }
 
   public void incNumDataCacheMiss() {

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/transport/server/ratis/CSMMetrics.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/transport/server/ratis/CSMMetrics.java
@@ -209,12 +209,12 @@ public class CSMMetrics {
     numContainerNotOpenVerifyFailures.incr();
   }
 
-  public void recordApplyTransactionCompletion(long latencyNanos) {
-    applyTransaction.add(latencyNanos);
+  public void recordApplyTransactionCompletion(long latencyMillis) {
+    applyTransaction.add(latencyMillis);
   }
 
-  public void recordWriteStateMachineCompletion(long latencyNanos) {
-    writeStateMachineData.add(latencyNanos);
+  public void recordWriteStateMachineCompletion(long latencyMillis) {
+    writeStateMachineData.add(latencyMillis);
   }
 
   public void incNumDataCacheMiss() {

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/transport/server/ratis/CSMMetrics.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/transport/server/ratis/CSMMetrics.java
@@ -191,7 +191,7 @@ public class CSMMetrics {
     return numBytesCommittedCount.value();
   }
 
-  public MutableRate getApplyTransactionNsLatency() {
+  public MutableRate getApplyTransactionLatencyNs() {
     return applyTransactionNs;
   }
 

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/transport/server/ratis/ContainerStateMachine.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/transport/server/ratis/ContainerStateMachine.java
@@ -540,7 +540,7 @@ public class ContainerStateMachine extends BaseStateMachine {
               write.getChunkData().getChunkName());
         }
         raftFuture.complete(r::toByteString);
-        metrics.recordWriteStateMachineNsCompletion(
+        metrics.recordWriteStateMachineCompletionNs(
             Time.monotonicNowNanos() - startTime);
       }
 
@@ -966,7 +966,7 @@ public class ContainerStateMachine extends BaseStateMachine {
               + "{} exception {}", gid, requestProto.getCmdType(), index, t);
         }
         applyTransactionSemaphore.release();
-        metrics.recordApplyTransactionNsCompletion(
+        metrics.recordApplyTransactionCompletionNs(
             Time.monotonicNowNanos() - applyTxnStartTime);
       });
       return applyTransactionFuture;

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/transport/server/ratis/ContainerStateMachine.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/transport/server/ratis/ContainerStateMachine.java
@@ -540,8 +540,8 @@ public class ContainerStateMachine extends BaseStateMachine {
               write.getChunkData().getChunkName());
         }
         raftFuture.complete(r::toByteString);
-        metrics.recordWriteStateMachineCompletion(
-            Time.monotonicNow() - startTime);
+        metrics.recordWriteStateMachineNsCompletion(
+            Time.monotonicNowNanos() - startTime);
       }
 
       writeChunkFutureMap.remove(entryIndex);
@@ -621,7 +621,7 @@ public class ContainerStateMachine extends BaseStateMachine {
   public CompletableFuture<Message> write(LogEntryProto entry) {
     try {
       metrics.incNumWriteStateMachineOps();
-      long writeStateMachineStartTime = Time.monotonicNow();
+      long writeStateMachineStartTime = Time.monotonicNowNanos();
       ContainerCommandRequestProto requestProto =
           getContainerCommandRequestProto(gid,
               entry.getStateMachineLogEntry().getLogData());
@@ -878,7 +878,7 @@ public class ContainerStateMachine extends BaseStateMachine {
           new DispatcherContext.Builder().setTerm(trx.getLogEntry().getTerm())
               .setLogIndex(index);
 
-      long applyTxnStartTime = Time.monotonicNow();
+      long applyTxnStartTime = Time.monotonicNowNanos();
       applyTransactionSemaphore.acquire();
       metrics.incNumApplyTransactionsOps();
       ContainerCommandRequestProto requestProto =
@@ -914,7 +914,7 @@ public class ContainerStateMachine extends BaseStateMachine {
         if (trx.getServerRole() == RaftPeerRole.LEADER
             && trx.getStateMachineContext() != null) {
           long startTime = (long) trx.getStateMachineContext();
-          metrics.incPipelineLatency(cmdType,
+          metrics.incPipelineLatencyMs(cmdType,
               (Time.monotonicNowNanos() - startTime) / 1000000L);
         }
         // ignore close container exception while marking the stateMachine
@@ -966,8 +966,8 @@ public class ContainerStateMachine extends BaseStateMachine {
               + "{} exception {}", gid, requestProto.getCmdType(), index, t);
         }
         applyTransactionSemaphore.release();
-        metrics.recordApplyTransactionCompletion(
-            Time.monotonicNow() - applyTxnStartTime);
+        metrics.recordApplyTransactionNsCompletion(
+            Time.monotonicNowNanos() - applyTxnStartTime);
       });
       return applyTransactionFuture;
     } catch (InterruptedException e) {

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/transport/server/ratis/ContainerStateMachine.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/transport/server/ratis/ContainerStateMachine.java
@@ -541,7 +541,7 @@ public class ContainerStateMachine extends BaseStateMachine {
         }
         raftFuture.complete(r::toByteString);
         metrics.recordWriteStateMachineCompletion(
-            Time.monotonicNowNanos() - startTime);
+            Time.monotonicNow() - startTime);
       }
 
       writeChunkFutureMap.remove(entryIndex);
@@ -621,7 +621,7 @@ public class ContainerStateMachine extends BaseStateMachine {
   public CompletableFuture<Message> write(LogEntryProto entry) {
     try {
       metrics.incNumWriteStateMachineOps();
-      long writeStateMachineStartTime = Time.monotonicNowNanos();
+      long writeStateMachineStartTime = Time.monotonicNow();
       ContainerCommandRequestProto requestProto =
           getContainerCommandRequestProto(gid,
               entry.getStateMachineLogEntry().getLogData());
@@ -878,7 +878,7 @@ public class ContainerStateMachine extends BaseStateMachine {
           new DispatcherContext.Builder().setTerm(trx.getLogEntry().getTerm())
               .setLogIndex(index);
 
-      long applyTxnStartTime = Time.monotonicNowNanos();
+      long applyTxnStartTime = Time.monotonicNow();
       applyTransactionSemaphore.acquire();
       metrics.incNumApplyTransactionsOps();
       ContainerCommandRequestProto requestProto =
@@ -967,7 +967,7 @@ public class ContainerStateMachine extends BaseStateMachine {
         }
         applyTransactionSemaphore.release();
         metrics.recordApplyTransactionCompletion(
-            Time.monotonicNowNanos() - applyTxnStartTime);
+            Time.monotonicNow() - applyTxnStartTime);
       });
       return applyTransactionFuture;
     } catch (InterruptedException e) {

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/common/transport/server/ratis/TestCSMMetrics.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/common/transport/server/ratis/TestCSMMetrics.java
@@ -129,12 +129,12 @@ public class TestCSMMetrics {
       assertCounter("NumBytesCommittedCount", 0L, metric);
       assertCounter("NumStartTransactionVerifyFailures", 0L, metric);
       assertCounter("NumContainerNotOpenVerifyFailures", 0L, metric);
-      assertCounter("WriteChunkNumOps", 0L, metric);
+      assertCounter("WriteChunkMsNumOps", 0L, metric);
       double applyTransactionLatency = getDoubleGauge(
-          "ApplyTransactionAvgTime", metric);
+          "ApplyTransactionNsAvgTime", metric);
       assertTrue(applyTransactionLatency == 0.0);
       double writeStateMachineLatency = getDoubleGauge(
-          "WriteStateMachineDataAvgTime", metric);
+          "WriteStateMachineDataNsAvgTime", metric);
       assertTrue(writeStateMachineLatency == 0.0);
 
       // Write Chunk
@@ -156,7 +156,7 @@ public class TestCSMMetrics {
       assertCounter("NumBytesCommittedCount", 1024L, metric);
       assertCounter("NumStartTransactionVerifyFailures", 0L, metric);
       assertCounter("NumContainerNotOpenVerifyFailures", 0L, metric);
-      assertCounter("WriteChunkNumOps", 1L, metric);
+      assertCounter("WriteChunkMsNumOps", 1L, metric);
 
       //Read Chunk
       ContainerProtos.ContainerCommandRequestProto readChunkRequest =
@@ -171,10 +171,10 @@ public class TestCSMMetrics {
       assertCounter("NumQueryStateMachineOps", 1L, metric);
       assertCounter("NumApplyTransactionOps", 1L, metric);
       applyTransactionLatency = getDoubleGauge(
-          "ApplyTransactionAvgTime", metric);
+          "ApplyTransactionNsAvgTime", metric);
       assertTrue(applyTransactionLatency > 0.0);
       writeStateMachineLatency = getDoubleGauge(
-          "WriteStateMachineDataAvgTime", metric);
+          "WriteStateMachineDataNsAvgTime", metric);
       assertTrue(writeStateMachineLatency > 0.0);
 
     } finally {


### PR DESCRIPTION
## What changes were proposed in this pull request?

Some of the metrics in CMSMetrics are in milliseconds, some are in nanoseconds, and here they are standardized to milliseconds

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-8428

## How was this patch tested?

