### PR TITLE
HDDS-8429. Checkpoint is not closed properly in OMDBCheckpointServlet

### DIFF
--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OMDBCheckpointServlet.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OMDBCheckpointServlet.java
@@ -182,6 +182,8 @@ public class OMDBCheckpointServlet extends DBCheckpointServlet {
         waitForDirToExist(path);
         snapshotPaths.add(path);
       }
+    } finally {
+      checkpointMetadataManager.stop();
     }
     return snapshotPaths;
   }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmMetadataManagerImpl.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmMetadataManagerImpl.java
@@ -709,7 +709,7 @@ public class OmMetadataManagerImpl implements OMMetadataManager,
    * Stop metadata manager.
    */
   @Override
-  public void stop() throws Exception {
+  public void stop() throws IOException {
     if (store != null) {
       store.close();
       store = null;


### PR DESCRIPTION
## What changes were proposed in this pull request?

```
$ mvn -am -pl :ozone-integration-test -Dtest='TestOMDbCheckpointServlet' clean test
...
$ grep 'not closed properly' hadoop-ozone/integration-test/target/surefire-reports/org.apache.hadoop.ozone.om.TestOMDbCheckpointServlet-output.txt 
2023-04-15 18:42:50,134 [Finalizer] WARN  managed.ManagedRocksObjectUtils (ManagedRocksObjectUtils.java:assertClosed(54)) - Checkpoint is not closed properly
```

https://issues.apache.org/jira/browse/HDDS-8429

## How was this patch tested?

```
$ mvn -am -pl :ozone-integration-test -Dtest='TestOMDbCheckpointServlet' clean test
...
$ grep 'not closed properly' hadoop-ozone/integration-test/target/surefire-reports/org.apache.hadoop.ozone.om.TestOMDbCheckpointServlet-output.txt 
```

Regular CI:
https://github.com/adoroszlai/hadoop-ozone/actions/runs/4708820465