### PR TITLE
HDDS-8424. Restore legacy bucket behavior for directory objects.

### DIFF
--- a/hadoop-ozone/dist/src/main/smoketest/s3/commonawslib.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/s3/commonawslib.robot
@@ -112,6 +112,11 @@ Create bucket with name
     ${result} =          Execute AWSS3APICli  create-bucket --bucket ${bucket}
                          Should contain              ${result}         Location
                          Should contain              ${result}         ${bucket}
+Create legacy bucket
+    ${postfix} =         Generate Ozone String
+    ${legacy_bucket} =   Set Variable               legacy-bucket-${postfix}
+    ${result} =          Execute and checkrc        ozone sh bucket create -l LEGACY s3v/${legacy_bucket}   0
+    [Return]             ${legacy_bucket}
 
 Setup s3 tests
     Return From Keyword if    ${OZONE_S3_TESTS_SET_UP}

--- a/hadoop-ozone/dist/src/main/smoketest/s3/objecthead.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/s3/objecthead.robot
@@ -40,6 +40,12 @@ Head object in non existing bucket
     ${result} =         Execute AWSS3APICli and checkrc    head-object --bucket ${BUCKET}-non-existent --key ${PREFIX}/headobject/key=value/f1   255
                         Should contain          ${result}    404
                         Should contain          ${result}    Not Found
+Head object where path is a directory
+    ${legacy-bucket} =  Create legacy bucket
+    ${result} =         Execute AWSS3APICli and checkrc    put-object --bucket ${legacy-bucket} --key ${PREFIX}/headobject/keyvalue/f1 --body /tmp/testfile   0
+    ${result} =         Execute AWSS3APICli and checkrc    head-object --bucket ${legacy-bucket} --key ${PREFIX}/headobject/keyvalue/   255
+                        Should contain          ${result}    404
+                        Should contain          ${result}    Not Found
 
 Head non existing key
     ${result} =         Execute AWSS3APICli and checkrc    head-object --bucket ${BUCKET} --key ${PREFIX}/non-existent   255

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/KeyManagerImpl.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/KeyManagerImpl.java
@@ -405,6 +405,9 @@ public class KeyManagerImpl implements KeyManager {
         value = getOmKeyInfoFSO(volumeName, bucketName, keyName);
       } else {
         value = getOmKeyInfoDirectoryAware(volumeName, bucketName, keyName);
+        if (bucketLayout.isLegacy() && value != null && !value.isFile()) {
+          value = null; // Legacy buckets do not report key info for directories
+        }
       }
     } catch (IOException ex) {
       if (ex instanceof OMException) {


### PR DESCRIPTION
## What changes were proposed in this pull request?

Legacy buckets returned 404 for HEAD request via S3G for paths (which equates to directory objects if filesystem paths are enabled).
This restores the behavior

## What is the link to the Apache JIRA
http://issues.apache.org/jira/browse/HDDS-8424

## How was this patch tested?

Tested manually, upstream code does not default filesystem paths to be enabled. Will create a separate set of tests for legacy buckets in a separate jira.
