### PR TITLE
HDDS-8333. ReplicationManager: Allow partial EC reconstruction if insufficient nodes available

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ReplicationManagerUtil.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ReplicationManagerUtil.java
@@ -1,0 +1,93 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hdds.scm.container.replication;
+
+import org.apache.hadoop.hdds.protocol.DatanodeDetails;
+import org.apache.hadoop.hdds.scm.PlacementPolicy;
+import org.apache.hadoop.hdds.scm.container.ContainerInfo;
+import org.apache.hadoop.hdds.scm.exceptions.SCMException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.List;
+
+/**
+ * Utility class for ReplicationManager.
+ */
+public final class ReplicationManagerUtil {
+
+  private ReplicationManagerUtil() {
+  }
+
+  private static final Logger LOG = LoggerFactory.getLogger(
+      ReplicationManagerUtil.class);
+
+  /**
+   * Using the passed placement policy attempt to select a list of datanodes to
+   * use as new targets. If the placement policy is unable to select enough
+   * nodes, the number of nodes requested will be reduced by 1 and the placement
+   * policy will be called again. This will continue until the placement policy
+   * is able to select enough nodes or the number of nodes requested is reduced
+   * to zero when an exception will be thrown.
+   * @param policy The placement policy to use to select nodes.
+   * @param requiredNodes The number of nodes required
+   * @param usedNodes Any nodes already used by the container
+   * @param excludedNodes Any Excluded nodes which cannot be selected
+   * @param defaultContainerSize The cluster default max container size
+   * @param container The container to select new replicas for
+   * @return A list of up to requiredNodes datanodes to use as targets for new
+   *         replicas. Note the number of nodes returned may be less than the
+   *         number of nodes requested if the placement policy is unable to
+   *         return enough nodes.
+   * @throws SCMException If no nodes can be selected.
+   */
+  public static List<DatanodeDetails> getTargetDatanodes(PlacementPolicy policy,
+      int requiredNodes, List<DatanodeDetails> usedNodes,
+      List<DatanodeDetails> excludedNodes, long defaultContainerSize,
+      ContainerInfo container) throws SCMException {
+
+    // Ensure that target datanodes have enough space to hold a complete
+    // container.
+    final long dataSizeRequired =
+        Math.max(container.getUsedBytes(), defaultContainerSize);
+
+    int mutableRequiredNodes = requiredNodes;
+    while (mutableRequiredNodes > 0) {
+      try {
+        if (usedNodes == null) {
+          return policy.chooseDatanodes(excludedNodes, null,
+              mutableRequiredNodes, 0, dataSizeRequired);
+        } else {
+          return policy.chooseDatanodes(usedNodes, excludedNodes, null,
+              mutableRequiredNodes, 0, dataSizeRequired);
+        }
+      } catch (IOException e) {
+        LOG.debug("Placement policy was not able to return {} nodes for " +
+            "container {}.",
+            mutableRequiredNodes, container.getContainerID(), e);
+        mutableRequiredNodes--;
+      }
+    }
+    throw new SCMException(String.format("Placement Policy: %s did not return"
+            + " any nodes. Number of required Nodes %d, Datasize Required: %d",
+        policy.getClass(), requiredNodes, dataSizeRequired),
+        SCMException.ResultCodes.FAILED_TO_FIND_SUITABLE_NODE);
+  }
+
+}

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestECUnderReplicationHandler.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestECUnderReplicationHandler.java
@@ -24,7 +24,7 @@ import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
 import org.apache.hadoop.hdds.protocol.MockDatanodeDetails;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
-import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos;
+import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.SCMCommandProto;
 import org.apache.hadoop.hdds.scm.ContainerPlacementStatus;
 import org.apache.hadoop.hdds.scm.PlacementPolicy;
 import org.apache.hadoop.hdds.scm.container.ContainerInfo;
@@ -37,6 +37,7 @@ import org.apache.hadoop.hdds.scm.net.NodeSchemaManager;
 import org.apache.hadoop.hdds.scm.node.NodeManager;
 import org.apache.hadoop.hdds.scm.node.NodeStatus;
 import org.apache.hadoop.hdds.scm.node.states.NodeNotFoundException;
+import org.apache.hadoop.hdds.scm.pipeline.InsufficientDatanodesException;
 import org.apache.hadoop.ozone.container.common.SCMTestUtils;
 import org.apache.hadoop.ozone.protocol.commands.DeleteContainerCommand;
 import org.apache.hadoop.ozone.protocol.commands.ReconstructECContainersCommand;
@@ -461,12 +462,85 @@ public class TestECUnderReplicationHandler {
             return expectedDelete.size();
           });
       commandsSent.clear();
-      ecURH.processAndSendCommands(availableReplicas,
-              Collections.emptyList(), underRep, 2);
+      assertThrows(SCMException.class,
+          () -> ecURH.processAndSendCommands(availableReplicas,
+              Collections.emptyList(), underRep, 2));
       Mockito.verify(replicationManager, times(1))
           .processOverReplicatedContainer(underRep);
       Assertions.assertEquals(true, expectedDelete.equals(commandsSent));
     }
+  }
+
+  @Test
+  public void testPartialReconstructionIfNotEnoughNodes() {
+    Set<ContainerReplica> availableReplicas = ReplicationTestUtil
+        .createReplicas(Pair.of(IN_SERVICE, 1),
+            Pair.of(IN_SERVICE, 2), Pair.of(IN_SERVICE, 3));
+    PlacementPolicy placementPolicy = ReplicationTestUtil
+        .getInsufficientNodesTestPlacementPolicy(nodeManager, conf, 2);
+    ECUnderReplicationHandler ecURH = new ECUnderReplicationHandler(
+        placementPolicy, conf, replicationManager);
+
+    ContainerHealthResult.UnderReplicatedHealthResult underRep =
+        new ContainerHealthResult.UnderReplicatedHealthResult(container,
+            0, false, false, false);
+
+    assertThrows(InsufficientDatanodesException.class, () ->
+        ecURH.processAndSendCommands(availableReplicas, Collections.emptyList(),
+            underRep, 1));
+    Assertions.assertEquals(1, commandsSent.size());
+    ReconstructECContainersCommand cmd = (ReconstructECContainersCommand)
+        commandsSent.iterator().next().getValue();
+    Assertions.assertEquals(1, cmd.getTargetDatanodes().size());
+  }
+
+  @Test
+  public void testPartialDecommissionIfNotEnoughNodes() {
+    Set<ContainerReplica> availableReplicas = ReplicationTestUtil
+        .createReplicas(Pair.of(IN_SERVICE, 1),
+            Pair.of(IN_SERVICE, 2), Pair.of(IN_SERVICE, 3),
+            Pair.of(DECOMMISSIONING, 4), Pair.of(DECOMMISSIONING, 5));
+    PlacementPolicy placementPolicy = ReplicationTestUtil
+        .getInsufficientNodesTestPlacementPolicy(nodeManager, conf, 2);
+    ECUnderReplicationHandler ecURH = new ECUnderReplicationHandler(
+        placementPolicy, conf, replicationManager);
+
+    ContainerHealthResult.UnderReplicatedHealthResult underRep =
+        new ContainerHealthResult.UnderReplicatedHealthResult(container,
+            0, true, false, false);
+
+    assertThrows(InsufficientDatanodesException.class, () ->
+        ecURH.processAndSendCommands(availableReplicas, Collections.emptyList(),
+            underRep, 1));
+    Assertions.assertEquals(1, commandsSent.size());
+    SCMCommand<?> cmd = commandsSent.iterator().next().getValue();
+    Assertions.assertEquals(
+        SCMCommandProto.Type.replicateContainerCommand, cmd.getType());
+  }
+
+  @Test
+  public void testPartialMaintenanceIfNotEnoughNodes() {
+    Set<ContainerReplica> availableReplicas = ReplicationTestUtil
+        .createReplicas(Pair.of(IN_SERVICE, 1),
+            Pair.of(IN_SERVICE, 2), Pair.of(IN_SERVICE, 3),
+            Pair.of(ENTERING_MAINTENANCE, 4),
+            Pair.of(ENTERING_MAINTENANCE, 5));
+    PlacementPolicy placementPolicy = ReplicationTestUtil
+        .getInsufficientNodesTestPlacementPolicy(nodeManager, conf, 2);
+    ECUnderReplicationHandler ecURH = new ECUnderReplicationHandler(
+        placementPolicy, conf, replicationManager);
+
+    ContainerHealthResult.UnderReplicatedHealthResult underRep =
+        new ContainerHealthResult.UnderReplicatedHealthResult(container,
+            0, false, false, false);
+
+    assertThrows(InsufficientDatanodesException.class, () ->
+        ecURH.processAndSendCommands(availableReplicas, Collections.emptyList(),
+            underRep, 2));
+    Assertions.assertEquals(1, commandsSent.size());
+    SCMCommand<?> cmd = commandsSent.iterator().next().getValue();
+    Assertions.assertEquals(
+        SCMCommandProto.Type.replicateContainerCommand, cmd.getType());
   }
 
   @Test
@@ -511,18 +585,20 @@ public class TestECUnderReplicationHandler {
         availableReplicas.add(toAdd);
       }
 
-      ecURH.processAndSendCommands(availableReplicas, Collections.emptyList(),
-          underRep, 2);
+      assertThrows(SCMException.class,
+          () -> ecURH.processAndSendCommands(availableReplicas,
+              Collections.emptyList(), underRep, 2));
 
-      Mockito.verify(replicationManager, times(0))
+      Mockito.verify(replicationManager, times(1))
           .processOverReplicatedContainer(underRep);
       Assertions.assertEquals(1, commandsSent.size());
       Pair<DatanodeDetails, SCMCommand<?>> pair =
           commandsSent.iterator().next();
       Assertions.assertEquals(newNode, pair.getKey());
-      Assertions.assertEquals(StorageContainerDatanodeProtocolProtos
-              .SCMCommandProto.Type.reconstructECContainersCommand,
+      Assertions.assertEquals(
+          SCMCommandProto.Type.reconstructECContainersCommand,
           pair.getValue().getType());
+      Mockito.clearInvocations(replicationManager);
       commandsSent.clear();
     }
   }
@@ -552,9 +628,8 @@ public class TestECUnderReplicationHandler {
         () -> ecURH.processAndSendCommands(availableReplicas,
             Collections.emptyList(), underRep, 1));
 
-    // Now adjust replicas so it is also over replicated. This time rather than
-    // throwing it should call the OverRepHandler and return whatever it
-    // returns, which in this case is a delete command for replica index 4.
+    // Now adjust replicas so it is also over replicated. This time it should
+    // call the OverRepHandler and then throw
     ContainerReplica overRepReplica =
         ReplicationTestUtil.createContainerReplica(container.containerID(),
             4, IN_SERVICE, CLOSED);
@@ -569,8 +644,8 @@ public class TestECUnderReplicationHandler {
           commandsSent.addAll(expectedDelete);
           return expectedDelete.size();
         });
-    ecURH.processAndSendCommands(availableReplicas,
-            Collections.emptyList(), underRep, 1);
+    assertThrows(SCMException.class, () -> ecURH.processAndSendCommands(
+        availableReplicas, Collections.emptyList(), underRep, 1));
     Mockito.verify(replicationManager, times(1))
         .processOverReplicatedContainer(underRep);
     Assertions.assertEquals(true, expectedDelete.equals(commandsSent));
@@ -594,16 +669,17 @@ public class TestECUnderReplicationHandler {
     commandsSent.clear();
 
     // Now add a decommissioning index - we will not get a replicate command
-    // for it, as the placement policy will throw an exception as we catch
-    // and just return the first reconstruction command. This will not goto
-    // the over-rep handler as we have a command already created for the under
-    // replication, even if the container is over replicated too.
+    // for it, as the placement policy will throw an exception which will
+    // come up the stack and be thrown out to indicate this container must be
+    // retried.
     Set<ContainerReplica> replicas = ReplicationTestUtil
         .createReplicas(Pair.of(DECOMMISSIONING, 1),
             Pair.of(IN_SERVICE, 2), Pair.of(IN_SERVICE, 3),
             Pair.of(IN_SERVICE, 4), Pair.of(IN_SERVICE, 4));
-    testUnderReplicationWithMissingIndexes(ImmutableList.of(5),
-        replicas, 0, 0, sameNodePolicy);
+
+    assertThrows(SCMException.class, () ->
+        testUnderReplicationWithMissingIndexes(ImmutableList.of(5), replicas,
+            0, 0, sameNodePolicy));
   }
 
   @Test


### PR DESCRIPTION
## What changes were proposed in this pull request?

If an EC container is missing multiple indexes, and there are not enough nodes to recover all indexes, the process currently fails. It could be possible to recover some of the indexes and it will reduce the chances of data loss.

Therefore, if we cannot select enough nodes to recover all indexes, we should try to select enough nodes to recover N - 1 indexes, or N - 2, as recovering some of them is better than nothing.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-8333

## How was this patch tested?

New unit tests added and some existing tests modified to handle the change in behavior of throwing an exception on partial success.
