### PR TITLE
HDDS-8385. Ozone can't process snapshot when service UID > 2097151.

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/TarContainerPacker.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/TarContainerPacker.java
@@ -272,7 +272,9 @@ public class TarContainerPacker
   }
 
   private static ArchiveOutputStream tar(OutputStream output) {
-    return new TarArchiveOutputStream(output);
+    TarArchiveOutputStream os = new TarArchiveOutputStream(output);
+    os.setBigNumberMode(TarArchiveOutputStream.BIGNUMBER_POSIX);
+    return os;
   }
 
   @VisibleForTesting

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/TestTarContainerPacker.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/TestTarContainerPacker.java
@@ -35,7 +35,6 @@ import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import org.apache.commons.compress.archivers.ArchiveOutputStream;
 import org.apache.commons.compress.archivers.tar.TarArchiveOutputStream;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.ozone.container.common.impl.ContainerLayoutVersion;
@@ -381,7 +380,9 @@ public class TestTarContainerPacker {
     File targetFile = TEMP_DIR.resolve("container.tar").toFile();
     try (FileOutputStream output = new FileOutputStream(targetFile);
          OutputStream compressed = packer.compress(output);
-         ArchiveOutputStream archive = new TarArchiveOutputStream(compressed)) {
+         TarArchiveOutputStream archive =
+             new TarArchiveOutputStream(compressed)) {
+      archive.setBigNumberMode(TarArchiveOutputStream.BIGNUMBER_POSIX);
       TarContainerPacker.includeFile(file, entryName, archive);
     }
     return targetFile;

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/HddsServerUtil.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/HddsServerUtil.java
@@ -532,10 +532,12 @@ public final class HddsServerUtil {
   public static void writeDBCheckpointToStream(DBCheckpoint checkpoint,
       OutputStream destination)
       throws IOException {
-    try (ArchiveOutputStream archiveOutputStream =
+    try (TarArchiveOutputStream archiveOutputStream =
             new TarArchiveOutputStream(destination);
         Stream<Path> files =
             Files.list(checkpoint.getCheckpointLocation())) {
+      archiveOutputStream.setBigNumberMode(
+          TarArchiveOutputStream.BIGNUMBER_POSIX);
       for (Path path : files.collect(Collectors.toList())) {
         if (path != null) {
           Path fileName = path.getFileName();

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OMDBCheckpointServlet.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OMDBCheckpointServlet.java
@@ -129,6 +129,8 @@ public class OMDBCheckpointServlet extends DBCheckpointServlet {
             new TarArchiveOutputStream(destination)) {
       archiveOutputStream
           .setLongFileMode(TarArchiveOutputStream.LONGFILE_POSIX);
+      archiveOutputStream
+          .setBigNumberMode(TarArchiveOutputStream.BIGNUMBER_POSIX);
       writeFilesToArchive(copyFiles, hardLinkFiles, archiveOutputStream);
     }
   }

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/ReconUtils.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/ReconUtils.java
@@ -109,6 +109,7 @@ public class ReconUtils {
       String fileName = sourceDir.concat(".tar");
       fileOutputStream = new FileOutputStream(fileName);
       tarOs = new TarArchiveOutputStream(fileOutputStream);
+      tarOs.setBigNumberMode(TarArchiveOutputStream.BIGNUMBER_POSIX);
       File folder = new File(sourceDir);
       File[] filesInDir = folder.listFiles();
       if (filesInDir != null) {


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fix OM HA RatisSnapshot creation to support large group ID's

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-8385

## How was this patch tested?

Reproduced the problem by setting the group id of one of the snapshot files like so:

```
chgrp 1301600003 omNode-1/db.snapshots/checkpointState/om.db-c3e20908-b7ea-4650-a538-352c832ceeaa/000051.sst
```

Then confirmed the problem no longer occurs after the fix
