### PR TITLE
HDDS-8444. Increase timeout of CI build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,7 +62,7 @@ jobs:
     needs:
       - build-info
     runs-on: ubuntu-20.04
-    timeout-minutes: 30
+    timeout-minutes: 45
     if: needs.build-info.outputs.needs-build == 'true'
     strategy:
       matrix:


### PR DESCRIPTION
## What changes were proposed in this pull request?

_build_ check in CI is frequently timing out in forks due to Maven cache miss (but not in `apache/ozone`).  Dependent checks (e.g. acceptance, kubernetes) can only be run after re-try.  To avoid wasting time, I propose increasing time limit for _build_ check from 30 to 45 minutes.

https://issues.apache.org/jira/browse/HDDS-8444

## How was this patch tested?

CI:
https://github.com/adoroszlai/hadoop-ozone/actions/runs/4734224440/jobs/8402851285

_build_ check succeeded in 36m 6s, i.e. would have failed without this change.