### PR TITLE
add transitional container count in recon

### DIFF
--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/api/ClusterStateEndpoint.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/api/ClusterStateEndpoint.java
@@ -109,6 +109,22 @@ public class ClusterStateEndpoint {
         this.containerManager.getContainerStateCount(
             HddsProtos.LifeCycleState.OPEN));
 
+    containerStateCounts.setClosingContainersCount(
+        this.containerManager.getContainerStateCount(
+            HddsProtos.LifeCycleState.CLOSING));
+
+    containerStateCounts.setQuasiClosedContainersCount(
+        this.containerManager.getContainerStateCount(
+            HddsProtos.LifeCycleState.QUASI_CLOSED));
+
+    containerStateCounts.setClosedContainersCount(
+        this.containerManager.getContainerStateCount(
+            HddsProtos.LifeCycleState.CLOSED));
+
+    containerStateCounts.setDeletingContainersCount(
+        this.containerManager.getContainerStateCount(
+            HddsProtos.LifeCycleState.DELETING));
+
     containerStateCounts.setDeletedContainersCount(
         this.containerManager.getContainerStateCount(
             HddsProtos.LifeCycleState.DELETED));
@@ -180,6 +196,12 @@ public class ClusterStateEndpoint {
         .setTotalDatanodes(datanodeDetails.size())
         .setHealthyDatanodes(healthyDatanodes)
         .setOpenContainers(containerStateCounts.getOpenContainersCount())
+        .setClosingContainers(containerStateCounts.getClosingContainersCount())
+        .setQuasiClosedContainers(
+            containerStateCounts.getQuasiClosedContainersCount())
+        .setClosedContainers(containerStateCounts.getClosedContainersCount())
+        .setDeletingContainers(
+            containerStateCounts.getDeletingContainersCount())
         .setDeletedContainers(containerStateCounts.getDeletedContainersCount())
         .build();
     return Response.ok(response).build();

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/api/types/ClusterStateResponse.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/api/types/ClusterStateResponse.java
@@ -67,6 +67,30 @@ public final class ClusterStateResponse {
   private int openContainers;
 
   /**
+   * Total count of closing containers in the cluster.
+   */
+  @JsonProperty("closingContainers")
+  private int closingContainers;
+
+  /**
+   * Total count of quasi closed containers in the cluster.
+   */
+  @JsonProperty("quasiClosedContainers")
+  private int quasiClosedContainers;
+
+  /**
+   * Total count of closed containers.
+   */
+  @JsonProperty("closedContainers")
+  private int closedContainers;
+
+  /**
+   * Total count of deleting containers.
+   */
+  @JsonProperty("deletingContainers")
+  private int deletingContainers;
+
+  /**
    * Total count of deleted containers in the cluster.
    */
   @JsonProperty("deletedContainers")
@@ -124,6 +148,10 @@ public final class ClusterStateResponse {
     this.openContainers = b.openContainers;
     this.deletedKeys = b.deletedKeys;
     this.deletedDirs = b.deletedDirs;
+    this.closingContainers = b.closingContainers;
+    this.quasiClosedContainers = b.quasiClosedContainers;
+    this.closedContainers = b.closedContainers;
+    this.deletingContainers = b.deletingContainers;
     this.deletedContainers = b.deletedContainers;
   }
 
@@ -139,6 +167,10 @@ public final class ClusterStateResponse {
     private int containers;
     private int missingContainers;
     private int openContainers;
+    private int closingContainers;
+    private int quasiClosedContainers;
+    private int closedContainers;
+    private int deletingContainers;
     private int deletedContainers;
     private long volumes;
     private long buckets;
@@ -151,6 +183,10 @@ public final class ClusterStateResponse {
       this.containers = 0;
       this.missingContainers = 0;
       this.openContainers = 0;
+      this.closingContainers = 0;
+      this.quasiClosedContainers = 0;
+      this.closedContainers = 0;
+      this.deletingContainers = 0;
       this.deletedContainers = 0;
       this.volumes = 0;
       this.buckets = 0;
@@ -194,6 +230,25 @@ public final class ClusterStateResponse {
 
     public Builder setOpenContainers(int openContainers) {
       this.openContainers = openContainers;
+      return this;
+    }
+
+    public Builder setClosingContainers(int closingContainers) {
+      this.closingContainers = closingContainers;
+      return this;
+    }
+
+    public Builder setQuasiClosedContainers(int quasiClosedContainers) {
+      this.quasiClosedContainers = quasiClosedContainers;
+      return this;
+    }
+    public Builder setClosedContainers(int closedContainers) {
+      this.closedContainers = closedContainers;
+      return this;
+    }
+
+    public Builder setDeletingContainers(int deletingContainers) {
+      this.deletingContainers = deletingContainers;
       return this;
     }
 
@@ -262,6 +317,22 @@ public final class ClusterStateResponse {
 
   public int getOpenContainers() {
     return openContainers;
+  }
+
+  public int getClosingContainers() {
+    return closingContainers;
+  }
+
+  public int getQuasiClosedContainers() {
+    return quasiClosedContainers;
+  }
+
+  public int getClosedContainers() {
+    return closedContainers;
+  }
+
+  public int getDeletingContainers() {
+    return deletingContainers;
   }
 
   public int getDeletedContainers() {

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/api/types/ContainerStateCounts.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/api/types/ContainerStateCounts.java
@@ -26,6 +26,10 @@ public class ContainerStateCounts {
   private int totalContainerCount;
   private int missingContainerCount;
   private int openContainersCount;
+  private int closingContainersCount;
+  private int quasiClosedContainersCount;
+  private int closedContainersCount;
+  private int deletingContainersCount;
   private int deletedContainersCount;
 
   public int getTotalContainerCount() {
@@ -50,6 +54,38 @@ public class ContainerStateCounts {
 
   public void setOpenContainersCount(int openContainersCount) {
     this.openContainersCount = openContainersCount;
+  }
+
+  public int getClosingContainersCount() {
+    return closingContainersCount;
+  }
+
+  public void setClosingContainersCount(int closingContainersCount) {
+    this.closingContainersCount = closingContainersCount;
+  }
+
+  public int getQuasiClosedContainersCount() {
+    return quasiClosedContainersCount;
+  }
+
+  public void setQuasiClosedContainersCount(int quasiClosedContainersCount) {
+    this.quasiClosedContainersCount = quasiClosedContainersCount;
+  }
+
+  public int getClosedContainersCount() {
+    return closedContainersCount;
+  }
+
+  public void setClosedContainersCount(int closedContainersCount) {
+    this.closedContainersCount = closedContainersCount;
+  }
+
+  public int getDeletingContainersCount() {
+    return deletingContainersCount;
+  }
+
+  public void setDeletingContainersCount(int deletingContainersCount) {
+    this.deletingContainersCount = deletingContainersCount;
   }
 
   public int getDeletedContainersCount() {

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/api/TestContainerStateCounts.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/api/TestContainerStateCounts.java
@@ -69,6 +69,9 @@ public class TestContainerStateCounts extends AbstractReconSqlDBTest {
   private static final int NUM_OPEN_CONTAINERS = 3;
   private static final int NUM_DELETED_CONTAINERS = 4;
   private static final int NUM_CLOSED_CONTAINERS = 3;
+  private static final int NUM_QUASI_CLOSED_CONTAINERS = 5;
+  private static final int NUM_CLOSING_CONTAINERS = 6;
+  private static final int NUM_DELETING_CONTAINERS = 7;
 
 
   @BeforeEach
@@ -117,6 +120,12 @@ public class TestContainerStateCounts extends AbstractReconSqlDBTest {
         HddsProtos.LifeCycleState.DELETED);
     putContainerInfos(NUM_CLOSED_CONTAINERS,
         HddsProtos.LifeCycleState.CLOSED);
+    putContainerInfos(NUM_CLOSING_CONTAINERS,
+        HddsProtos.LifeCycleState.CLOSING);
+    putContainerInfos(NUM_QUASI_CLOSED_CONTAINERS,
+        HddsProtos.LifeCycleState.QUASI_CLOSED);
+    putContainerInfos(NUM_DELETING_CONTAINERS,
+        HddsProtos.LifeCycleState.DELETING);
 
     // Get the cluster state using the ClusterStateEndpoint
     Response response1 = clusterStateEndpoint.getClusterState();
@@ -124,8 +133,14 @@ public class TestContainerStateCounts extends AbstractReconSqlDBTest {
         (ClusterStateResponse) response1.getEntity();
 
     // Calculate expected counts
-    int expectedTotalContainers = NUM_OPEN_CONTAINERS + NUM_CLOSED_CONTAINERS;
+    int expectedTotalContainers = NUM_OPEN_CONTAINERS + NUM_CLOSED_CONTAINERS
+        + NUM_CLOSING_CONTAINERS + NUM_QUASI_CLOSED_CONTAINERS
+        + NUM_DELETING_CONTAINERS;
     int expectedOpenContainers = NUM_OPEN_CONTAINERS;
+    int expectedClosingContainers = NUM_CLOSING_CONTAINERS;
+    int expectedQuasiClosedContainers = NUM_QUASI_CLOSED_CONTAINERS;
+    int expectedClosedContainers = NUM_CLOSED_CONTAINERS;
+    int expectedDeletingContainers = NUM_DELETING_CONTAINERS;
     int expectedDeletedContainers = NUM_DELETED_CONTAINERS;
 
     // Verify counts using assertions
@@ -133,6 +148,14 @@ public class TestContainerStateCounts extends AbstractReconSqlDBTest {
         clusterStateResponse1.getContainers());
     Assertions.assertEquals(expectedOpenContainers,
         clusterStateResponse1.getOpenContainers());
+    Assertions.assertEquals(expectedClosingContainers,
+        clusterStateResponse1.getClosingContainers());
+    Assertions.assertEquals(expectedQuasiClosedContainers,
+        clusterStateResponse1.getQuasiClosedContainers());
+    Assertions.assertEquals(expectedClosedContainers,
+        clusterStateResponse1.getClosedContainers());
+    Assertions.assertEquals(expectedDeletingContainers,
+        clusterStateResponse1.getDeletingContainers());
     Assertions.assertEquals(expectedDeletedContainers,
         clusterStateResponse1.getDeletedContainers());
   }


### PR DESCRIPTION
## What changes were proposed in this pull request?
This PR adds additional container information to Recon, which shows the total count of containers in some states, including CLOSING, QUASI_CLOSED, CLOSED, and DELETING.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-8411

## How was this patch tested?
Unit test
<img width="1511" alt="Screen Shot 2023-04-19 at 4 20 44 PM" src="https://user-images.githubusercontent.com/107598572/233014278-84a77a52-4fbf-4ea8-aca9-cb04d7eb5176.png">


