### PR TITLE
HDDS-8355. Intermittent failure in TestOMRatisSnapshots#testInstallSnapshot

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOMRatisSnapshots.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOMRatisSnapshots.java
@@ -160,7 +160,6 @@ public class TestOMRatisSnapshots {
   }
 
   @Test
-  //@Flaky("HDDS-8355")
   public void testInstallSnapshot() throws Exception {
     // Get the leader OM
     String leaderOMNodeId = OmFailoverProxyUtil

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOMRatisSnapshots.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOMRatisSnapshots.java
@@ -676,8 +676,8 @@ public class TestOMRatisSnapshots {
   private void assertLogCapture(GenericTestUtils.LogCapturer logCapture,
                               String msg)
       throws InterruptedException, TimeoutException {
-      GenericTestUtils.waitFor(() -> {
-          return logCapture.getOutput().contains(msg);
+    GenericTestUtils.waitFor(() -> {
+        return logCapture.getOutput().contains(msg);
       }, 100, 5000);
   }
 

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOMRatisSnapshots.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOMRatisSnapshots.java
@@ -160,7 +160,7 @@ public class TestOMRatisSnapshots {
   }
 
   @Test
-  @Flaky("HDDS-8355")
+  //@Flaky("HDDS-8355")
   public void testInstallSnapshot() throws Exception {
     // Get the leader OM
     String leaderOMNodeId = OmFailoverProxyUtil

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOMRatisSnapshots.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOMRatisSnapshots.java
@@ -676,8 +676,8 @@ public class TestOMRatisSnapshots {
                               String msg)
       throws InterruptedException, TimeoutException {
     GenericTestUtils.waitFor(() -> {
-        return logCapture.getOutput().contains(msg);
-      }, 100, 5000);
+      return logCapture.getOutput().contains(msg);
+    }, 100, 5000);
   }
 
   private static class DummyExitManager extends ExitManager {


### PR DESCRIPTION
## What changes were proposed in this pull request?

This test was flaky because one thread trys to read the log output from another thread before the log has been generated.

I confirmed this by hitting a breakpoint on the assertion failure, then looking at the log and seeing that it had subsequently been updated by another thread.

The fix is to poll the log for a few seconds until it is updated to the expected contents.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-8355

## How was this patch tested?

Without the fix, I was able to reproduce the problem by running the test class 5 times repeatedly in intellij.

With the fix, I was unable to reproduce the problem after running it in intellij 50 times.

I also ran the CI 25 times without this failing.
