### PR TITLE
HDDS-8335. ReplicationManager: EC Mis and Under replication handlers should handle overloaded exceptions

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ECUnderReplicationHandler.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ECUnderReplicationHandler.java
@@ -159,17 +159,19 @@ public class ECUnderReplicationHandler implements UnhealthyReplicationHandler {
               .collect(Collectors.toList());
 
       try {
-        InsufficientDatanodesException firstException = null;
+        IOException firstException = null;
         try {
           commandsSent += processMissingIndexes(replicaCount, sources,
               availableSourceNodes, excludedNodes);
-        } catch (InsufficientDatanodesException e) {
+        } catch (InsufficientDatanodesException
+            | CommandTargetOverloadedException  e) {
           firstException = e;
         }
         try {
           commandsSent += processDecommissioningIndexes(replicaCount, sources,
               availableSourceNodes, excludedNodes);
-        } catch (InsufficientDatanodesException e) {
+        } catch (InsufficientDatanodesException
+            | CommandTargetOverloadedException e) {
           if (firstException == null) {
             firstException = e;
           }
@@ -177,7 +179,8 @@ public class ECUnderReplicationHandler implements UnhealthyReplicationHandler {
         try {
           commandsSent += processMaintenanceOnlyIndexes(replicaCount, sources,
               excludedNodes);
-        } catch (InsufficientDatanodesException e) {
+        } catch (InsufficientDatanodesException
+            | CommandTargetOverloadedException e) {
           if (firstException == null) {
             firstException = e;
           }
@@ -313,6 +316,11 @@ public class ECUnderReplicationHandler implements UnhealthyReplicationHandler {
                 sourceDatanodesWithIndex, selectedDatanodes,
                 int2byte(missingIndexes),
                 repConfig);
+        // This can throw a CommandTargetOverloadedException, but there is no
+        // point in retrying here. The sources we picked already have the
+        // overloaded nodes excluded, so we should not get an overloaded
+        // exception, but it could happen due to other threads adding work to
+        // the DNs. If it happens here, we just let the exception bubble up.
         replicationManager.sendThrottledReconstructionCommand(
             container, reconstructionCommand);
         for (int i = 0; i < missingIndexes.size(); i++) {
@@ -363,6 +371,7 @@ public class ECUnderReplicationHandler implements UnhealthyReplicationHandler {
         excludedNodes.addAll(selectedDatanodes);
         Iterator<DatanodeDetails> iterator = selectedDatanodes.iterator();
         // In this case we need to do one to one copy.
+        CommandTargetOverloadedException overloadedException = null;
         for (Integer decomIndex : decomIndexes) {
           Pair<ContainerReplica, NodeStatus> source = sources.get(decomIndex);
           if (source == null) {
@@ -380,9 +389,19 @@ public class ECUnderReplicationHandler implements UnhealthyReplicationHandler {
                 selectedDatanodes, excludedNodes, decomIndexes);
             break;
           }
-          createReplicateCommand(
-              container, iterator, sourceReplica, replicaCount);
-          commandsSent++;
+          try {
+            createReplicateCommand(
+                container, iterator, sourceReplica, replicaCount);
+            commandsSent++;
+          } catch (CommandTargetOverloadedException e) {
+            LOG.debug("Unable to send Replicate command for container {}" +
+                " because the source node {} is overloaded.",
+                container.getContainerID(), sourceReplica.getDatanodeDetails());
+            overloadedException = e;
+          }
+        }
+        if (overloadedException != null) {
+          throw overloadedException;
         }
       }
       if (selectedDatanodes.size() != decomIndexes.size()) {
@@ -432,6 +451,7 @@ public class ECUnderReplicationHandler implements UnhealthyReplicationHandler {
     int commandsSent = 0;
     // copy replica from source maintenance DN to a target DN
 
+    CommandTargetOverloadedException overloadedException = null;
     for (Integer maintIndex : maintIndexes) {
       if (additionalMaintenanceCopiesNeeded <= 0) {
         break;
@@ -452,9 +472,20 @@ public class ECUnderReplicationHandler implements UnhealthyReplicationHandler {
             targets, excludedNodes, maintIndexes);
         break;
       }
-      createReplicateCommand(container, iterator, sourceReplica, replicaCount);
-      commandsSent++;
-      additionalMaintenanceCopiesNeeded -= 1;
+      try {
+        createReplicateCommand(
+            container, iterator, sourceReplica, replicaCount);
+        commandsSent++;
+        additionalMaintenanceCopiesNeeded -= 1;
+      } catch (CommandTargetOverloadedException e) {
+        LOG.debug("Unable to send Replicate command for container {}" +
+            " because the source node {} is overloaded.",
+            container.getContainerID(), sourceReplica.getDatanodeDetails());
+        overloadedException = e;
+      }
+    }
+    if (overloadedException != null) {
+      throw overloadedException;
     }
     if (targets.size() != maintIndexes.size()) {
       LOG.debug("Insufficient nodes were returned from the placement policy" +

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ECUnderReplicationHandler.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ECUnderReplicationHandler.java
@@ -395,8 +395,9 @@ public class ECUnderReplicationHandler implements UnhealthyReplicationHandler {
             commandsSent++;
           } catch (CommandTargetOverloadedException e) {
             LOG.debug("Unable to send Replicate command for container {}" +
-                " because the source node {} is overloaded.",
-                container.getContainerID(), sourceReplica.getDatanodeDetails());
+                " index {} because the source node {} is overloaded.",
+                container.getContainerID(), sourceReplica.getReplicaIndex(),
+                sourceReplica.getDatanodeDetails());
             overloadedException = e;
           }
         }
@@ -479,8 +480,9 @@ public class ECUnderReplicationHandler implements UnhealthyReplicationHandler {
         additionalMaintenanceCopiesNeeded -= 1;
       } catch (CommandTargetOverloadedException e) {
         LOG.debug("Unable to send Replicate command for container {}" +
-            " because the source node {} is overloaded.",
-            container.getContainerID(), sourceReplica.getDatanodeDetails());
+            " index {} because the source node {} is overloaded.",
+            container.getContainerID(), sourceReplica.getReplicaIndex(),
+            sourceReplica.getDatanodeDetails());
         overloadedException = e;
       }
     }

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestECMisReplicationHandler.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestECMisReplicationHandler.java
@@ -189,6 +189,18 @@ public class TestECMisReplicationHandler extends TestMisReplicationHandler {
   }
 
   @Test
+  public void testFirstSourcesOverloaded() {
+    setThrowThrottledException(true);
+    Set<ContainerReplica> availableReplicas = ReplicationTestUtil
+        .createReplicas(Pair.of(IN_SERVICE, 1), Pair.of(IN_SERVICE, 2),
+            Pair.of(IN_SERVICE, 3), Pair.of(IN_SERVICE, 4),
+            Pair.of(IN_SERVICE, 5));
+    assertThrows(CommandTargetOverloadedException.class,
+        () -> testMisReplication(availableReplicas, mockPlacementPolicy(),
+            Collections.emptyList(), 0, 2, 2, 1));
+  }
+
+  @Test
   public void commandsForFewerThanRequiredNodes() throws IOException {
     Set<ContainerReplica> availableReplicas = ReplicationTestUtil
         .createReplicas(Pair.of(IN_SERVICE, 1), Pair.of(IN_SERVICE, 2),

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestECUnderReplicationHandler.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestECUnderReplicationHandler.java
@@ -60,6 +60,7 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import static java.util.Collections.singleton;
 import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.NodeOperationalState.DECOMMISSIONING;
@@ -94,6 +95,10 @@ public class TestECUnderReplicationHandler {
   private PlacementPolicy ecPlacementPolicy;
   private int remainingMaintenanceRedundancy = 1;
   private Set<Pair<DatanodeDetails, SCMCommand<?>>> commandsSent;
+  private AtomicBoolean throwOverloadedExceptionOnReplication
+      = new AtomicBoolean(false);
+  private AtomicBoolean throwOverloadedExceptionOnReconstruction
+      = new AtomicBoolean(false);
 
   @BeforeEach
   public void setup() throws NodeNotFoundException,
@@ -122,9 +127,11 @@ public class TestECUnderReplicationHandler {
     ReplicationTestUtil.mockRMSendDatanodeCommand(
         replicationManager, commandsSent);
     ReplicationTestUtil.mockRMSendThrottleReplicateCommand(
-        replicationManager, commandsSent);
+        replicationManager, commandsSent,
+        throwOverloadedExceptionOnReplication);
     ReplicationTestUtil.mockSendThrottledReconstructionCommand(
-        replicationManager, commandsSent);
+        replicationManager, commandsSent,
+        throwOverloadedExceptionOnReconstruction);
 
     conf = SCMTestUtils.getConf();
     repConfig = new ECReplicationConfig(DATA, PARITY);
@@ -495,6 +502,30 @@ public class TestECUnderReplicationHandler {
   }
 
   @Test
+  public void testOverloadedReconstructionContinuesNextStages() {
+    Set<ContainerReplica> availableReplicas = ReplicationTestUtil
+        .createReplicas(Pair.of(IN_SERVICE, 1),
+            Pair.of(IN_SERVICE, 2), Pair.of(DECOMMISSIONING, 3));
+    ECUnderReplicationHandler ecURH = new ECUnderReplicationHandler(
+        policy, conf, replicationManager);
+
+    ContainerHealthResult.UnderReplicatedHealthResult underRep =
+        new ContainerHealthResult.UnderReplicatedHealthResult(container,
+            0, false, false, false);
+
+    // Setup so reconstruction fails, but we should still get a replicate
+    // command for the decommissioning node and an exception thrown.
+    throwOverloadedExceptionOnReconstruction.set(true);
+    assertThrows(CommandTargetOverloadedException.class, () ->
+        ecURH.processAndSendCommands(availableReplicas, Collections.emptyList(),
+            underRep, 1));
+    Assertions.assertEquals(1, commandsSent.size());
+    SCMCommand<?> cmd = commandsSent.iterator().next().getValue();
+    Assertions.assertEquals(
+        SCMCommandProto.Type.replicateContainerCommand, cmd.getType());
+  }
+
+  @Test
   public void testPartialDecommissionIfNotEnoughNodes() {
     Set<ContainerReplica> availableReplicas = ReplicationTestUtil
         .createReplicas(Pair.of(IN_SERVICE, 1),
@@ -510,6 +541,29 @@ public class TestECUnderReplicationHandler {
             0, true, false, false);
 
     assertThrows(InsufficientDatanodesException.class, () ->
+        ecURH.processAndSendCommands(availableReplicas, Collections.emptyList(),
+            underRep, 1));
+    Assertions.assertEquals(1, commandsSent.size());
+    SCMCommand<?> cmd = commandsSent.iterator().next().getValue();
+    Assertions.assertEquals(
+        SCMCommandProto.Type.replicateContainerCommand, cmd.getType());
+  }
+
+  @Test
+  public void testPartialDecommissionOverloadedNodes() {
+    Set<ContainerReplica> availableReplicas = ReplicationTestUtil
+        .createReplicas(Pair.of(IN_SERVICE, 1),
+            Pair.of(IN_SERVICE, 2), Pair.of(IN_SERVICE, 3),
+            Pair.of(DECOMMISSIONING, 4), Pair.of(DECOMMISSIONING, 5));
+    ECUnderReplicationHandler ecURH = new ECUnderReplicationHandler(
+        policy, conf, replicationManager);
+
+    ContainerHealthResult.UnderReplicatedHealthResult underRep =
+        new ContainerHealthResult.UnderReplicatedHealthResult(container,
+            0, true, false, false);
+
+    throwOverloadedExceptionOnReplication.set(true);
+    assertThrows(CommandTargetOverloadedException.class, () ->
         ecURH.processAndSendCommands(availableReplicas, Collections.emptyList(),
             underRep, 1));
     Assertions.assertEquals(1, commandsSent.size());
@@ -535,6 +589,30 @@ public class TestECUnderReplicationHandler {
             0, false, false, false);
 
     assertThrows(InsufficientDatanodesException.class, () ->
+        ecURH.processAndSendCommands(availableReplicas, Collections.emptyList(),
+            underRep, 2));
+    Assertions.assertEquals(1, commandsSent.size());
+    SCMCommand<?> cmd = commandsSent.iterator().next().getValue();
+    Assertions.assertEquals(
+        SCMCommandProto.Type.replicateContainerCommand, cmd.getType());
+  }
+
+  @Test
+  public void testPartialMaintenanceOverloadedNodes() {
+    Set<ContainerReplica> availableReplicas = ReplicationTestUtil
+        .createReplicas(Pair.of(IN_SERVICE, 1),
+            Pair.of(IN_SERVICE, 2), Pair.of(IN_SERVICE, 3),
+            Pair.of(ENTERING_MAINTENANCE, 4),
+            Pair.of(ENTERING_MAINTENANCE, 5));
+    ECUnderReplicationHandler ecURH = new ECUnderReplicationHandler(
+        policy, conf, replicationManager);
+
+    ContainerHealthResult.UnderReplicatedHealthResult underRep =
+        new ContainerHealthResult.UnderReplicatedHealthResult(container,
+            0, false, false, false);
+
+    throwOverloadedExceptionOnReplication.set(true);
+    assertThrows(CommandTargetOverloadedException.class, () ->
         ecURH.processAndSendCommands(availableReplicas, Collections.emptyList(),
             underRep, 2));
     Assertions.assertEquals(1, commandsSent.size());

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestMisReplicationHandler.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestMisReplicationHandler.java
@@ -45,6 +45,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
@@ -91,7 +92,7 @@ public abstract class TestMisReplicationHandler {
     ReplicationTestUtil.mockRMSendDatanodeCommand(
         replicationManager, commandsSent);
     ReplicationTestUtil.mockRMSendThrottleReplicateCommand(
-        replicationManager, commandsSent);
+        replicationManager, commandsSent, new AtomicBoolean(false));
 
     container = ReplicationTestUtil
             .createContainer(HddsProtos.LifeCycleState.CLOSED, repConfig);

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestMisReplicationHandler.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestMisReplicationHandler.java
@@ -70,6 +70,7 @@ public abstract class TestMisReplicationHandler {
   private OzoneConfiguration conf;
   private ReplicationManager replicationManager;
   private Set<Pair<DatanodeDetails, SCMCommand<?>>> commandsSent;
+  private AtomicBoolean throwThrottledException = new AtomicBoolean(false);
 
   protected void setup(ReplicationConfig repConfig)
       throws NodeNotFoundException, CommandTargetOverloadedException,
@@ -92,7 +93,7 @@ public abstract class TestMisReplicationHandler {
     ReplicationTestUtil.mockRMSendDatanodeCommand(
         replicationManager, commandsSent);
     ReplicationTestUtil.mockRMSendThrottleReplicateCommand(
-        replicationManager, commandsSent, new AtomicBoolean(false));
+        replicationManager, commandsSent, throwThrottledException);
 
     container = ReplicationTestUtil
             .createContainer(HddsProtos.LifeCycleState.CLOSED, repConfig);
@@ -103,6 +104,10 @@ public abstract class TestMisReplicationHandler {
 
   protected ReplicationManager getReplicationManager() {
     return replicationManager;
+  }
+
+  protected void setThrowThrottledException(boolean showThrow) {
+    throwThrottledException.set(showThrow);
   }
 
   static PlacementPolicy<?> mockPlacementPolicy() {

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestRatisUnderReplicationHandler.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestRatisUnderReplicationHandler.java
@@ -48,6 +48,7 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.NodeOperationalState.DECOMMISSIONING;
 import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.NodeOperationalState.ENTERING_MAINTENANCE;
@@ -96,7 +97,7 @@ public class TestRatisUnderReplicationHandler {
 
     commandsSent = new HashSet<>();
     ReplicationTestUtil.mockRMSendThrottleReplicateCommand(
-        replicationManager, commandsSent);
+        replicationManager, commandsSent, new AtomicBoolean(false));
     ReplicationTestUtil.mockRMSendDatanodeCommand(replicationManager,
         commandsSent);
   }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Both ECUnderReplicationHandler and ECMisReplicationHandler could hit a CommandTargetOverloaded exception when attempting to replicate a specific index from source to destination. When that happens, instead of failing immediately, it should attempt to replicate any other pending index it has, and then re-throw the last exception so the container is re-queued.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-8335

## How was this patch tested?

New unit tests added
