### PR TITLE
HDDS-8416. ReplicationManager: RatisUnderReplication handler should filter sources by highest BCSID

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/RatisUnderReplicationHandler.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/RatisUnderReplicationHandler.java
@@ -222,7 +222,10 @@ public class RatisUnderReplicationHandler
     // We should replicate only the max available sequence ID, as replicas with
     // earlier sequence IDs may be stale copies.
     long maxSequenceId = availableSources.stream()
-        .map(ContainerReplica::getSequenceId).max(Long::compareTo).orElse(0L);
+        .map(r -> {
+          Long seqId = r.getSequenceId();
+          return seqId == null ? 0L : seqId;
+        }).max(Long::compareTo).orElse(0L);
 
     return availableSources.stream()
         .filter(r -> r.getSequenceId() == maxSequenceId)

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/RatisUnderReplicationHandler.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/RatisUnderReplicationHandler.java
@@ -224,7 +224,7 @@ public class RatisUnderReplicationHandler
     long maxSequenceId = availableSources.stream()
         .map(r -> {
           Long seqId = r.getSequenceId();
-          return seqId == null ? 0L : seqId;
+          return seqId == null ? Long.valueOf(0L) : seqId;
         }).max(Long::compareTo).orElse(0L);
 
     return availableSources.stream()


### PR DESCRIPTION
## What changes were proposed in this pull request?

In the RatisUnderReplicationHander, the sources are sorted by BSCIS, intending that the highest ID is used as the source for the replication.

However, the list is later sorted by the source command count pending for push replication, or shuffled for pull replication, so the sort is not having the intended effect.

We should remove the sort here, and instead filter out all sources except those with the highest BCSID.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-8416

## How was this patch tested?

New unit test added
