### PR TITLE
HDDS-8462. Key in deleteTable uniqueness

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestOzoneRpcClientAbstract.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestOzoneRpcClientAbstract.java
@@ -4074,7 +4074,7 @@ public abstract class TestOzoneRpcClientAbstract {
 
     createRequiredForVersioningTest(volumeName, bucketName, keyName, false);
 
-      checkExceptedResultForVersioningTest(volumeName, bucketName, keyName, 1);
+    checkExceptedResultForVersioningTest(volumeName, bucketName, keyName, 1);
 
 
     // Versioning turned on

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestOzoneRpcClientAbstract.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestOzoneRpcClientAbstract.java
@@ -61,6 +61,7 @@ import org.apache.hadoop.hdds.scm.container.ContainerInfo;
 import org.apache.hadoop.hdds.scm.pipeline.Pipeline;
 import org.apache.hadoop.hdds.scm.protocolPB.StorageContainerLocationProtocolClientSideTranslatorPB;
 import org.apache.hadoop.hdds.scm.server.StorageContainerManager;
+import org.apache.hadoop.hdds.utils.db.Table;
 import org.apache.hadoop.ozone.HddsDatanodeService;
 import org.apache.hadoop.ozone.MiniOzoneCluster;
 import org.apache.hadoop.ozone.OmUtils;
@@ -4044,14 +4045,15 @@ public abstract class TestOzoneRpcClientAbstract {
         omKeyInfo.getKeyLocationVersions().size());
 
     if (expectedCount == 1) {
-      RepeatedOmKeyInfo repeatedOmKeyInfo = cluster
-          .getOzoneManager().getMetadataManager()
-          .getDeletedTable().get(cluster.getOzoneManager().getMetadataManager()
+      List<? extends Table.KeyValue<String, RepeatedOmKeyInfo>> rangeKVs
+          = cluster.getOzoneManager().getMetadataManager().getDeletedTable()
+          .getRangeKVs(null, 100,
+              cluster.getOzoneManager().getMetadataManager()
               .getOzoneKey(volumeName, bucketName, keyName));
 
-      Assert.assertNotNull(repeatedOmKeyInfo);
+      Assert.assertTrue(rangeKVs.size() > 0);
       Assert.assertEquals(expectedCount,
-          repeatedOmKeyInfo.getOmKeyInfoList().size());
+          rangeKVs.get(0).getValue().getOmKeyInfoList().size());
     } else {
       // If expectedCount is greater than 1 means versioning enabled,
       // so delete table should be empty.
@@ -4072,7 +4074,7 @@ public abstract class TestOzoneRpcClientAbstract {
 
     createRequiredForVersioningTest(volumeName, bucketName, keyName, false);
 
-    checkExceptedResultForVersioningTest(volumeName, bucketName, keyName, 1);
+      checkExceptedResultForVersioningTest(volumeName, bucketName, keyName, 1);
 
 
     // Versioning turned on

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyCommitRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyCommitRequest.java
@@ -195,8 +195,7 @@ public class OMKeyCommitRequest extends OMKeyRequest {
       // creation and key commit, old versions will be just overwritten and
       // not kept. Bucket versioning will be effective from the first key
       // creation after the knob turned on.
-      Map<String, RepeatedOmKeyInfo> oldKeyVersionsToDeleteMap
-          = new HashMap<>();
+      Map<String, RepeatedOmKeyInfo> oldKeyVersionsToDeleteMap = null;
       OmKeyInfo keyToDelete =
           omMetadataManager.getKeyTable(getBucketLayout()).get(dbOzoneKey);
 
@@ -238,6 +237,9 @@ public class OMKeyCommitRequest extends OMKeyRequest {
             correctedSpace);
         String delKeyName = omMetadataManager.getOzoneDeletePathKey(
             keyToDelete.getObjectID(), dbOzoneKey);
+        if (null == oldKeyVersionsToDeleteMap) {
+          oldKeyVersionsToDeleteMap = new HashMap<>();
+        }
         oldKeyVersionsToDeleteMap.put(delKeyName, oldVerKeyInfo);
       } else {
         checkBucketQuotaInNamespace(omBucketInfo, 1L);
@@ -254,6 +256,9 @@ public class OMKeyCommitRequest extends OMKeyRequest {
         long pseudoObjId = ozoneManager.getObjectIdFromTxId(trxnLogIndex);
         String delKeyName = omMetadataManager.getOzoneDeletePathKey(
             pseudoObjId, dbOzoneKey);
+        if (null == oldKeyVersionsToDeleteMap) {
+          oldKeyVersionsToDeleteMap = new HashMap<>();
+        }
         oldKeyVersionsToDeleteMap.put(delKeyName,
             new RepeatedOmKeyInfo(pseudoKeyInfo));
       }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyCommitRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyCommitRequest.java
@@ -35,7 +35,6 @@ import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
 import org.apache.hadoop.ozone.om.helpers.OmKeyLocationInfo;
 import org.apache.hadoop.ozone.om.helpers.RepeatedOmKeyInfo;
 import org.apache.hadoop.ozone.om.ratis.utils.OzoneManagerDoubleBufferHelper;
-import org.apache.hadoop.ozone.om.request.file.OMFileRequest;
 import org.apache.hadoop.ozone.om.request.util.OmResponseUtil;
 import org.apache.hadoop.ozone.om.request.validation.RequestFeatureValidator;
 import org.apache.hadoop.ozone.om.request.validation.RequestProcessingPhase;
@@ -262,11 +261,6 @@ public class OMKeyCommitRequest extends OMKeyRequest {
 
       omMetadataManager.getKeyTable(getBucketLayout()).addCacheEntry(
           dbOzoneKey, omKeyInfo, trxnLogIndex);
-
-      if (oldKeyVersionsToDelete != null) {
-        OMFileRequest.addDeletedTableCacheEntry(omMetadataManager, dbOzoneKey,
-            oldKeyVersionsToDelete, trxnLogIndex);
-      }
 
       omBucketInfo.incrUsedBytes(correctedSpace);
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyCommitRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyCommitRequest.java
@@ -251,8 +251,9 @@ public class OMKeyCommitRequest extends OMKeyRequest {
       OmKeyInfo pseudoKeyInfo = wrapUncommittedBlocksAsPseudoKey(uncommitted,
           omKeyInfo);
       if (pseudoKeyInfo != null) {
+        long pseudoObjId = ozoneManager.getObjectIdFromTxId(trxnLogIndex);
         String delKeyName = omMetadataManager.getOzoneDeletePathKey(
-            trxnLogIndex, dbOzoneKey);
+            pseudoObjId, dbOzoneKey);
         oldKeyVersionsToDeleteMap.put(delKeyName,
             new RepeatedOmKeyInfo(pseudoKeyInfo));
       }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyCommitRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyCommitRequest.java
@@ -230,9 +230,8 @@ public class OMKeyCommitRequest extends OMKeyRequest {
       if (keyToDelete != null && !omBucketInfo.getIsVersionEnabled()) {
         // Subtract the size of blocks to be overwritten.
         correctedSpace -= keyToDelete.getReplicatedSize();
-        RepeatedOmKeyInfo oldVerKeyInfo = getOldVersionsToCleanUp(dbOzoneKey,
-            keyToDelete, omMetadataManager,
-            trxnLogIndex, ozoneManager.isRatisEnabled());
+        RepeatedOmKeyInfo oldVerKeyInfo = getOldVersionsToCleanUp(
+            keyToDelete, trxnLogIndex, ozoneManager.isRatisEnabled());
         checkBucketQuotaInBytes(omMetadataManager, omBucketInfo,
             correctedSpace);
         String delKeyName = omMetadataManager.getOzoneDeletePathKey(

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyCommitRequestWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyCommitRequestWithFSO.java
@@ -216,11 +216,6 @@ public class OMKeyCommitRequestWithFSO extends OMKeyCommitRequest {
       OMFileRequest.addFileTableCacheEntry(omMetadataManager, dbFileKey,
               omKeyInfo, fileName, trxnLogIndex);
 
-      if (oldKeyVersionsToDelete != null) {
-        OMFileRequest.addDeletedTableCacheEntry(omMetadataManager, dbFileKey,
-                oldKeyVersionsToDelete, trxnLogIndex);
-      }
-
       omBucketInfo.incrUsedBytes(correctedSpace);
 
       omClientResponse = new OMKeyCommitResponseWithFSO(omResponse.build(),

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyCommitRequestWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyCommitRequestWithFSO.java
@@ -209,8 +209,9 @@ public class OMKeyCommitRequestWithFSO extends OMKeyCommitRequest {
       if (pseudoKeyInfo != null) {
         String delKeyName = omMetadataManager
             .getOzoneKey(volumeName, bucketName, fileName);
+        long pseudoObjId = ozoneManager.getObjectIdFromTxId(trxnLogIndex);
         delKeyName = omMetadataManager.getOzoneDeletePathKey(
-            trxnLogIndex, delKeyName);
+            pseudoObjId, delKeyName);
         oldKeyVersionsToDeleteMap.put(delKeyName,
             new RepeatedOmKeyInfo(pseudoKeyInfo));
       }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyCommitRequestWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyCommitRequestWithFSO.java
@@ -184,9 +184,8 @@ public class OMKeyCommitRequestWithFSO extends OMKeyCommitRequest {
       if (keyToDelete != null && !omBucketInfo.getIsVersionEnabled()) {
         // Subtract the size of blocks to be overwritten.
         correctedSpace -= keyToDelete.getReplicatedSize();
-        RepeatedOmKeyInfo oldVerKeyInfo = getOldVersionsToCleanUp(dbFileKey,
-            keyToDelete, omMetadataManager,
-            trxnLogIndex, ozoneManager.isRatisEnabled());
+        RepeatedOmKeyInfo oldVerKeyInfo = getOldVersionsToCleanUp(
+            keyToDelete, trxnLogIndex, ozoneManager.isRatisEnabled());
         checkBucketQuotaInBytes(omMetadataManager, omBucketInfo,
             correctedSpace);
         String delKeyName = omMetadataManager

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyCommitRequestWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyCommitRequestWithFSO.java
@@ -173,8 +173,7 @@ public class OMKeyCommitRequestWithFSO extends OMKeyCommitRequest {
       // creation and key commit, old versions will be just overwritten and
       // not kept. Bucket versioning will be effective from the first key
       // creation after the knob turned on.
-      Map<String, RepeatedOmKeyInfo> oldKeyVersionsToDeleteMap
-          = new HashMap<>();
+      Map<String, RepeatedOmKeyInfo> oldKeyVersionsToDeleteMap = null;
       OmKeyInfo keyToDelete =
           omMetadataManager.getKeyTable(getBucketLayout()).get(dbFileKey);
 
@@ -194,6 +193,9 @@ public class OMKeyCommitRequestWithFSO extends OMKeyCommitRequest {
             .getOzoneKey(volumeName, bucketName, fileName);
         delKeyName = omMetadataManager.getOzoneDeletePathKey(
             keyToDelete.getObjectID(), delKeyName);
+        if (null == oldKeyVersionsToDeleteMap) {
+          oldKeyVersionsToDeleteMap = new HashMap<>();
+        }
         oldKeyVersionsToDeleteMap.put(delKeyName, oldVerKeyInfo);
       } else {
         checkBucketQuotaInNamespace(omBucketInfo, 1L);
@@ -212,6 +214,9 @@ public class OMKeyCommitRequestWithFSO extends OMKeyCommitRequest {
         long pseudoObjId = ozoneManager.getObjectIdFromTxId(trxnLogIndex);
         delKeyName = omMetadataManager.getOzoneDeletePathKey(
             pseudoObjId, delKeyName);
+        if (null == oldKeyVersionsToDeleteMap) {
+          oldKeyVersionsToDeleteMap = new HashMap<>();
+        }
         oldKeyVersionsToDeleteMap.put(delKeyName,
             new RepeatedOmKeyInfo(pseudoKeyInfo));
       }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyRequest.java
@@ -808,13 +808,7 @@ public abstract class OMKeyRequest extends OMClientRequest {
       @Nonnull String dbOzoneKey, @Nonnull OmKeyInfo keyToDelete,
       OMMetadataManager omMetadataManager, long trxnLogIndex,
       boolean isRatisEnabled) throws IOException {
-
-    // Past keys that was deleted but still in deleted table,
-    // waiting for deletion service.
-    RepeatedOmKeyInfo keysToDelete =
-        omMetadataManager.getDeletedTable().get(dbOzoneKey);
-
-    return OmUtils.prepareKeyForDelete(keyToDelete, keysToDelete,
+    return OmUtils.prepareKeyForDelete(keyToDelete, null,
           trxnLogIndex, isRatisEnabled);
   }
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyRequest.java
@@ -805,8 +805,7 @@ public abstract class OMKeyRequest extends OMClientRequest {
    * @throws IOException
    */
   protected RepeatedOmKeyInfo getOldVersionsToCleanUp(
-      @Nonnull String dbOzoneKey, @Nonnull OmKeyInfo keyToDelete,
-      OMMetadataManager omMetadataManager, long trxnLogIndex,
+      @Nonnull OmKeyInfo keyToDelete, long trxnLogIndex,
       boolean isRatisEnabled) throws IOException {
     return OmUtils.prepareKeyForDelete(keyToDelete, null,
           trxnLogIndex, isRatisEnabled);

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3MultipartUploadCompleteRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3MultipartUploadCompleteRequest.java
@@ -225,9 +225,8 @@ public class S3MultipartUploadCompleteRequest extends OMKeyRequest {
         long usedBytesDiff = 0;
         boolean isNamespaceUpdate = false;
         if (keyToDelete != null && !omBucketInfo.getIsVersionEnabled()) {
-          oldKeyVersionsToDelete = getOldVersionsToCleanUp(dbOzoneKey,
-              keyToDelete, omMetadataManager,
-              trxnLogIndex, ozoneManager.isRatisEnabled());
+          oldKeyVersionsToDelete = getOldVersionsToCleanUp(
+              keyToDelete, trxnLogIndex, ozoneManager.isRatisEnabled());
           usedBytesDiff -= keyToDelete.getReplicatedSize();
         } else {
           checkBucketQuotaInNamespace(omBucketInfo, 1L);

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/key/AbstractOMKeyDeleteResponse.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/key/AbstractOMKeyDeleteResponse.java
@@ -115,7 +115,7 @@ public abstract class AbstractOMKeyDeleteResponse extends OmKeyResponse {
    *  file table (which is in prefix format) and adds the fullKey
    *  into the deletedTable
    * @param keyName     (format: objectId/key)
-   * @param deleteKeyName (format: vol/buck/key)
+   * @param deleteKeyName (format: vol/buck/key/objectId)
    * @param omKeyInfo
    * @throws IOException
    */

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/key/AbstractOMKeyDeleteResponse.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/key/AbstractOMKeyDeleteResponse.java
@@ -98,13 +98,13 @@ public abstract class AbstractOMKeyDeleteResponse extends OmKeyResponse {
       // if RepeatedOMKeyInfo structure is null, we create a new instance,
       // if it is not null, then we simply add to the list and store this
       // instance in deletedTable.
-      RepeatedOmKeyInfo repeatedOmKeyInfo =
-          omMetadataManager.getDeletedTable().get(keyName);
-      repeatedOmKeyInfo = OmUtils.prepareKeyForDelete(
-          omKeyInfo, repeatedOmKeyInfo, omKeyInfo.getUpdateID(),
+      RepeatedOmKeyInfo repeatedOmKeyInfo = OmUtils.prepareKeyForDelete(
+          omKeyInfo, null, omKeyInfo.getUpdateID(),
           isRatisEnabled);
+      String delKeyName = omMetadataManager.getOzoneDeletePathKey(
+          omKeyInfo.getObjectID(), keyName);
       omMetadataManager.getDeletedTable().putWithBatch(
-          batchOperation, keyName, repeatedOmKeyInfo);
+          batchOperation, delKeyName, repeatedOmKeyInfo);
     }
   }
 
@@ -115,7 +115,7 @@ public abstract class AbstractOMKeyDeleteResponse extends OmKeyResponse {
    *  file table (which is in prefix format) and adds the fullKey
    *  into the deletedTable
    * @param keyName     (format: objectId/key)
-   * @param fullKeyName (format: vol/buck/key)
+   * @param deleteKeyName (format: vol/buck/key)
    * @param omKeyInfo
    * @throws IOException
    */
@@ -123,7 +123,7 @@ public abstract class AbstractOMKeyDeleteResponse extends OmKeyResponse {
       OMMetadataManager omMetadataManager,
       BatchOperation batchOperation,
       Table<String, ?> fromTable,
-      String keyName, String fullKeyName,
+      String keyName, String deleteKeyName,
       OmKeyInfo omKeyInfo) throws IOException {
 
     // For OmResponse with failure, this should do nothing. This method is
@@ -141,13 +141,11 @@ public abstract class AbstractOMKeyDeleteResponse extends OmKeyResponse {
       // if RepeatedOMKeyInfo structure is null, we create a new instance,
       // if it is not null, then we simply add to the list and store this
       // instance in deletedTable.
-      RepeatedOmKeyInfo repeatedOmKeyInfo =
-          omMetadataManager.getDeletedTable().get(fullKeyName);
-      repeatedOmKeyInfo = OmUtils.prepareKeyForDelete(
-          omKeyInfo, repeatedOmKeyInfo, omKeyInfo.getUpdateID(),
+      RepeatedOmKeyInfo repeatedOmKeyInfo = OmUtils.prepareKeyForDelete(
+          omKeyInfo, null, omKeyInfo.getUpdateID(),
           isRatisEnabled);
       omMetadataManager.getDeletedTable().putWithBatch(
-          batchOperation, fullKeyName, repeatedOmKeyInfo);
+          batchOperation, deleteKeyName, repeatedOmKeyInfo);
     }
   }
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/key/OMDirectoriesPurgeResponseWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/key/OMDirectoriesPurgeResponseWithFSO.java
@@ -135,6 +135,8 @@ public class OMDirectoriesPurgeResponseWithFSO extends OmKeyResponse {
         String deletedKey = omMetadataManager
             .getOzoneKey(keyInfo.getVolumeName(), keyInfo.getBucketName(),
                 keyInfo.getKeyName());
+        deletedKey = omMetadataManager.getOzoneDeletePathKey(
+            keyInfo.getObjectID(), deletedKey);
 
         // TODO: [SNAPSHOT] Acquire deletedTable write table lock
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/key/OMKeyCommitResponse.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/key/OMKeyCommitResponse.java
@@ -118,9 +118,12 @@ public class OMKeyCommitResponse extends OmKeyResponse {
 
   protected void updateDeletedTable(OMMetadataManager omMetadataManager,
       BatchOperation batchOperation) throws IOException {
-    if (this.keysToDelete != null) {
+    if (this.keysToDelete != null
+        && this.keysToDelete.getOmKeyInfoList().size() > 0) {
+      String deleteKey = omMetadataManager.getOzoneDeletePathKey(
+          keysToDelete.getOmKeyInfoList().get(0).getObjectID(), openKeyName);
       omMetadataManager.getDeletedTable().putWithBatch(batchOperation,
-              ozoneKeyName, keysToDelete);
+          deleteKey, keysToDelete);
     }
   }
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/key/OMKeyCommitResponse.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/key/OMKeyCommitResponse.java
@@ -19,6 +19,7 @@
 package org.apache.hadoop.ozone.om.response.key;
 
 import com.google.common.annotations.VisibleForTesting;
+import java.util.Map;
 import org.apache.hadoop.ozone.om.OMMetadataManager;
 import org.apache.hadoop.ozone.om.helpers.BucketLayout;
 import org.apache.hadoop.ozone.om.helpers.OmBucketInfo;
@@ -47,20 +48,22 @@ public class OMKeyCommitResponse extends OmKeyResponse {
   private String ozoneKeyName;
   private String openKeyName;
   private OmBucketInfo omBucketInfo;
-  private RepeatedOmKeyInfo keysToDelete;
+  private Map<String, RepeatedOmKeyInfo> keyToDeleteMap;
 
   private boolean isHSync;
 
-  public OMKeyCommitResponse(@Nonnull OMResponse omResponse,
+  public OMKeyCommitResponse(
+      @Nonnull OMResponse omResponse,
       @Nonnull OmKeyInfo omKeyInfo, String ozoneKeyName, String openKeyName,
-      @Nonnull OmBucketInfo omBucketInfo, RepeatedOmKeyInfo keysToDelete,
-                             boolean isHSync) {
+      @Nonnull OmBucketInfo omBucketInfo,
+      @Nonnull Map<String, RepeatedOmKeyInfo> keyToDeleteMap,
+      boolean isHSync) {
     super(omResponse, omBucketInfo.getBucketLayout());
     this.omKeyInfo = omKeyInfo;
     this.ozoneKeyName = ozoneKeyName;
     this.openKeyName = openKeyName;
     this.omBucketInfo = omBucketInfo;
-    this.keysToDelete = keysToDelete;
+    this.keyToDeleteMap = keyToDeleteMap;
     this.isHSync = isHSync;
   }
 
@@ -112,18 +115,18 @@ public class OMKeyCommitResponse extends OmKeyResponse {
   }
 
   @VisibleForTesting
-  public RepeatedOmKeyInfo getKeysToDelete() {
-    return keysToDelete;
+  public Map<String, RepeatedOmKeyInfo> getKeysToDelete() {
+    return keyToDeleteMap;
   }
 
   protected void updateDeletedTable(OMMetadataManager omMetadataManager,
       BatchOperation batchOperation) throws IOException {
-    if (this.keysToDelete != null
-        && this.keysToDelete.getOmKeyInfoList().size() > 0) {
-      String deleteKey = omMetadataManager.getOzoneDeletePathKey(
-          keysToDelete.getOmKeyInfoList().get(0).getObjectID(), openKeyName);
-      omMetadataManager.getDeletedTable().putWithBatch(batchOperation,
-          deleteKey, keysToDelete);
+    if (this.keyToDeleteMap != null) {
+      for (Map.Entry<String, RepeatedOmKeyInfo> entry : 
+          keyToDeleteMap.entrySet()) {
+        omMetadataManager.getDeletedTable().putWithBatch(batchOperation,
+            entry.getKey(), entry.getValue());
+      }
     }
   }
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/key/OMKeyCommitResponse.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/key/OMKeyCommitResponse.java
@@ -56,7 +56,7 @@ public class OMKeyCommitResponse extends OmKeyResponse {
       @Nonnull OMResponse omResponse,
       @Nonnull OmKeyInfo omKeyInfo, String ozoneKeyName, String openKeyName,
       @Nonnull OmBucketInfo omBucketInfo,
-      @Nonnull Map<String, RepeatedOmKeyInfo> keyToDeleteMap,
+      Map<String, RepeatedOmKeyInfo> keyToDeleteMap,
       boolean isHSync) {
     super(omResponse, omBucketInfo.getBucketLayout());
     this.omKeyInfo = omKeyInfo;

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/key/OMKeyCommitResponseWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/key/OMKeyCommitResponseWithFSO.java
@@ -53,7 +53,7 @@ public class OMKeyCommitResponseWithFSO extends OMKeyCommitResponse {
       @Nonnull OmKeyInfo omKeyInfo,
       String ozoneKeyName, String openKeyName,
       @Nonnull OmBucketInfo omBucketInfo,
-      @Nonnull Map<String, RepeatedOmKeyInfo> deleteKeyMap, long volumeId,
+      Map<String, RepeatedOmKeyInfo> deleteKeyMap, long volumeId,
       boolean isHSync) {
     super(omResponse, omKeyInfo, ozoneKeyName, openKeyName,
             omBucketInfo, deleteKeyMap, isHSync);

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/key/OMKeyCommitResponseWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/key/OMKeyCommitResponseWithFSO.java
@@ -18,6 +18,7 @@
 
 package org.apache.hadoop.ozone.om.response.key;
 
+import java.util.Map;
 import org.apache.hadoop.hdds.utils.db.BatchOperation;
 import org.apache.hadoop.ozone.om.OMMetadataManager;
 import org.apache.hadoop.ozone.om.helpers.BucketLayout;
@@ -47,14 +48,15 @@ public class OMKeyCommitResponseWithFSO extends OMKeyCommitResponse {
   private long volumeId;
 
   @SuppressWarnings("parameternumber")
-  public OMKeyCommitResponseWithFSO(@Nonnull OMResponse omResponse,
-                               @Nonnull OmKeyInfo omKeyInfo,
-                               String ozoneKeyName, String openKeyName,
-                               @Nonnull OmBucketInfo omBucketInfo,
-                               RepeatedOmKeyInfo deleteKeys, long volumeId,
-                                    boolean isHSync) {
+  public OMKeyCommitResponseWithFSO(
+      @Nonnull OMResponse omResponse,
+      @Nonnull OmKeyInfo omKeyInfo,
+      String ozoneKeyName, String openKeyName,
+      @Nonnull OmBucketInfo omBucketInfo,
+      @Nonnull Map<String, RepeatedOmKeyInfo> deleteKeyMap, long volumeId,
+      boolean isHSync) {
     super(omResponse, omKeyInfo, ozoneKeyName, openKeyName,
-            omBucketInfo, deleteKeys, isHSync);
+            omBucketInfo, deleteKeyMap, isHSync);
     this.volumeId = volumeId;
   }
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/key/OMKeyDeleteResponseWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/key/OMKeyDeleteResponseWithFSO.java
@@ -98,6 +98,8 @@ public class OMKeyDeleteResponseWithFSO extends OMKeyDeleteResponse {
       String deletedKey = omMetadataManager
           .getOzoneKey(omKeyInfo.getVolumeName(), omKeyInfo.getBucketName(),
               omKeyInfo.getKeyName());
+      deletedKey = omMetadataManager.getOzoneDeletePathKey(
+          omKeyInfo.getObjectID(), deletedKey);
       addDeletionToBatch(omMetadataManager, batchOperation, keyTable,
           ozoneDbKey, deletedKey, omKeyInfo);
     }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/key/OMKeysDeleteResponseWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/key/OMKeysDeleteResponseWithFSO.java
@@ -83,6 +83,8 @@ public class OMKeysDeleteResponseWithFSO extends OMKeysDeleteResponse {
       String deletedKey = omMetadataManager
           .getOzoneKey(omKeyInfo.getVolumeName(), omKeyInfo.getBucketName(),
               omKeyInfo.getKeyName());
+      deletedKey = omMetadataManager.getOzoneDeletePathKey(
+          omKeyInfo.getObjectID(), deletedKey);
       addDeletionToBatch(omMetadataManager, batchOperation, keyTable,
           ozoneDbKey, deletedKey, omKeyInfo);
     }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/key/OMTrashRecoverResponse.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/key/OMTrashRecoverResponse.java
@@ -55,8 +55,10 @@ public class OMTrashRecoverResponse extends OmKeyResponse {
     String trashKey = omMetadataManager
         .getOzoneKey(omKeyInfo.getVolumeName(),
             omKeyInfo.getBucketName(), omKeyInfo.getKeyName());
+    String deleteKey = omMetadataManager.getOzoneDeletePathKey(
+        omKeyInfo.getObjectID(), trashKey);
     RepeatedOmKeyInfo repeatedOmKeyInfo = omMetadataManager
-        .getDeletedTable().get(trashKey);
+        .getDeletedTable().get(deleteKey);
     if (repeatedOmKeyInfo.getOmKeyInfoList().contains(omKeyInfo)) {
       omMetadataManager.getDeletedTable()
               .deleteWithBatch(batchOperation, omKeyInfo.getKeyName());

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/OMRequestTestUtils.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/OMRequestTestUtils.java
@@ -840,11 +840,8 @@ public final class OMRequestTestUtils {
     // Delete key from KeyTable and put in DeletedKeyTable
     omMetadataManager.getKeyTable(getDefaultBucketLayout()).delete(ozoneKey);
 
-    RepeatedOmKeyInfo repeatedOmKeyInfo =
-        omMetadataManager.getDeletedTable().get(ozoneKey);
-
-    repeatedOmKeyInfo = OmUtils.prepareKeyForDelete(omKeyInfo,
-        repeatedOmKeyInfo, trxnLogIndex, true);
+    RepeatedOmKeyInfo repeatedOmKeyInfo = OmUtils.prepareKeyForDelete(
+        omKeyInfo, null, trxnLogIndex, true);
 
     omMetadataManager.getDeletedTable().put(ozoneKey, repeatedOmKeyInfo);
 

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMKeyCommitRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMKeyCommitRequest.java
@@ -22,6 +22,7 @@ package org.apache.hadoop.ozone.om.request.key;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
@@ -29,6 +30,7 @@ import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.hadoop.ozone.om.helpers.BucketLayout;
 import org.apache.hadoop.ozone.om.helpers.OmBucketInfo;
 import org.apache.hadoop.ozone.om.helpers.OzoneFSUtils;
+import org.apache.hadoop.ozone.om.helpers.RepeatedOmKeyInfo;
 import org.apache.hadoop.ozone.om.request.OMRequestTestUtils;
 import org.apache.hadoop.ozone.om.response.key.OMKeyCommitResponse;
 import org.apache.hadoop.util.Time;
@@ -248,14 +250,15 @@ public class TestOMKeyCommitRequest extends TestOMKeyRequest {
     Assert.assertEquals(OzoneManagerProtocolProtos.Status.OK,
         omClientResponse.getOMResponse().getStatus());
 
-    List<OmKeyInfo> toDeleteKeyList = ((OMKeyCommitResponse) omClientResponse).
-        getKeysToDelete().cloneOmKeyInfoList();
+    Map<String, RepeatedOmKeyInfo> toDeleteKeyList
+        = ((OMKeyCommitResponse) omClientResponse).getKeysToDelete();
 
     // This is the first time to commit key, only the allocated but uncommitted
     // blocks should be deleted.
     Assert.assertEquals(1, toDeleteKeyList.size());
-    Assert.assertEquals(2, toDeleteKeyList.get(0).
-        getKeyLocationVersions().get(0).getLocationList().size());
+    Assert.assertEquals(2, toDeleteKeyList.values().stream().findFirst().get()
+        .cloneOmKeyInfoList().get(0).getKeyLocationVersions().get(0)
+        .getLocationList().size());
 
     // Entry should be deleted from openKey Table.
     omKeyInfo =

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/key/TestOMKeyCommitResponse.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/key/TestOMKeyCommitResponse.java
@@ -18,6 +18,8 @@
 
 package org.apache.hadoop.ozone.om.response.key;
 
+import java.util.List;
+import org.apache.hadoop.hdds.utils.db.Table;
 import org.apache.hadoop.ozone.OmUtils;
 import org.apache.hadoop.ozone.om.helpers.RepeatedOmKeyInfo;
 import org.jetbrains.annotations.NotNull;
@@ -120,10 +122,12 @@ public class TestOMKeyCommitResponse extends TestOMKeyResponse {
     Assert.assertNotNull(keysToDelete);
     testAddToDBBatch();
 
-    RepeatedOmKeyInfo keysInDeleteTable =
-            omMetadataManager.getDeletedTable().get(getOzoneKey());
-    Assert.assertNotNull(keysInDeleteTable);
-    Assert.assertEquals(1, keysInDeleteTable.getOmKeyInfoList().size());
+    List<? extends Table.KeyValue<String, RepeatedOmKeyInfo>> rangeKVs
+        = omMetadataManager.getDeletedTable().getRangeKVs(
+        null, 100, getOzoneKey());
+    Assert.assertTrue(rangeKVs.size() > 0);
+    Assert.assertEquals(1,
+        rangeKVs.get(0).getValue().getOmKeyInfoList().size());
 
   }
 

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/key/TestOMKeyCommitResponse.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/key/TestOMKeyCommitResponse.java
@@ -18,7 +18,9 @@
 
 package org.apache.hadoop.ozone.om.response.key;
 
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import org.apache.hadoop.hdds.utils.db.Table;
 import org.apache.hadoop.ozone.OmUtils;
 import org.apache.hadoop.ozone.om.helpers.RepeatedOmKeyInfo;
@@ -122,9 +124,11 @@ public class TestOMKeyCommitResponse extends TestOMKeyResponse {
     Assert.assertNotNull(keysToDelete);
     testAddToDBBatch();
 
+    String deletedKey = omMetadataManager.getOzoneKey(volumeName,
+        omBucketInfo.getBucketName(), keyName);
     List<? extends Table.KeyValue<String, RepeatedOmKeyInfo>> rangeKVs
         = omMetadataManager.getDeletedTable().getRangeKVs(
-        null, 100, getOzoneKey());
+        null, 100, deletedKey);
     Assert.assertTrue(rangeKVs.size() > 0);
     Assert.assertEquals(1,
         rangeKVs.get(0).getValue().getOmKeyInfoList().size());
@@ -150,7 +154,13 @@ public class TestOMKeyCommitResponse extends TestOMKeyResponse {
           String ozoneKey, RepeatedOmKeyInfo deleteKeys, Boolean isHSync)
           throws IOException {
     Assert.assertNotNull(omBucketInfo);
+    Map<String, RepeatedOmKeyInfo> deleteKeyMap = new HashMap<>();
+    if (null != deleteKeys) {
+      deleteKeys.getOmKeyInfoList().stream().forEach(e -> deleteKeyMap.put(
+          omMetadataManager.getOzoneDeletePathKey(e.getObjectID(), ozoneKey),
+          new RepeatedOmKeyInfo(e)));
+    }
     return new OMKeyCommitResponse(omResponse, omKeyInfo, ozoneKey, openKey,
-            omBucketInfo, deleteKeys, isHSync);
+            omBucketInfo, deleteKeyMap, isHSync);
   }
 }

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/key/TestOMKeyCommitResponseWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/key/TestOMKeyCommitResponseWithFSO.java
@@ -18,6 +18,8 @@
 
 package org.apache.hadoop.ozone.om.response.key;
 
+import java.util.HashMap;
+import java.util.Map;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.ozone.om.helpers.BucketLayout;
 import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
@@ -44,8 +46,15 @@ public class TestOMKeyCommitResponseWithFSO extends TestOMKeyCommitResponse {
           throws IOException {
     Assert.assertNotNull(omBucketInfo);
     long volumeId = omMetadataManager.getVolumeId(omKeyInfo.getVolumeName());
+    Map<String, RepeatedOmKeyInfo> deleteKeyMap = new HashMap<>();
+    if (null != keysToDelete) {
+      String deleteKey = omMetadataManager.getOzoneKey(volumeName, bucketName, keyName);
+      deleteKeys.getOmKeyInfoList().stream().forEach(e -> deleteKeyMap.put(
+          omMetadataManager.getOzoneDeletePathKey(e.getObjectID(), deleteKey),
+          new RepeatedOmKeyInfo(e)));
+    }
     return new OMKeyCommitResponseWithFSO(omResponse, omKeyInfo, ozoneKey,
-        openKey, omBucketInfo, deleteKeys, volumeId, isHSync);
+        openKey, omBucketInfo, deleteKeyMap, volumeId, isHSync);
   }
 
   @NotNull

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/key/TestOMKeyCommitResponseWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/key/TestOMKeyCommitResponseWithFSO.java
@@ -48,7 +48,8 @@ public class TestOMKeyCommitResponseWithFSO extends TestOMKeyCommitResponse {
     long volumeId = omMetadataManager.getVolumeId(omKeyInfo.getVolumeName());
     Map<String, RepeatedOmKeyInfo> deleteKeyMap = new HashMap<>();
     if (null != keysToDelete) {
-      String deleteKey = omMetadataManager.getOzoneKey(volumeName, bucketName, keyName);
+      String deleteKey = omMetadataManager.getOzoneKey(volumeName,
+          bucketName, keyName);
       deleteKeys.getOmKeyInfoList().stream().forEach(e -> deleteKeyMap.put(
           omMetadataManager.getOzoneDeletePathKey(e.getObjectID(), deleteKey),
           new RepeatedOmKeyInfo(e)));

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/key/TestOMKeyDeleteResponse.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/key/TestOMKeyDeleteResponse.java
@@ -124,10 +124,12 @@ public class TestOMKeyDeleteResponse extends TestOMKeyResponse {
 
     Assert.assertFalse(
         omMetadataManager.getKeyTable(getBucketLayout()).isExist(ozoneKey));
-
+    
+    String deletedKey = omMetadataManager.getOzoneKey(volumeName, bucketName,
+        keyName);
     List<? extends Table.KeyValue<String, RepeatedOmKeyInfo>> rangeKVs
         = omMetadataManager.getDeletedTable().getRangeKVs(
-        null, 100, ozoneKey);
+        null, 100, deletedKey);
 
     // Key has blocks, it should not be in deletedKeyTable.
     Assert.assertTrue(rangeKVs.size() > 0);

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/key/TestOMKeyDeleteResponse.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/key/TestOMKeyDeleteResponse.java
@@ -22,9 +22,11 @@ import org.apache.hadoop.hdds.client.BlockID;
 import org.apache.hadoop.hdds.client.RatisReplicationConfig;
 import org.apache.hadoop.hdds.scm.pipeline.Pipeline;
 import org.apache.hadoop.hdds.scm.pipeline.PipelineID;
+import org.apache.hadoop.hdds.utils.db.Table;
 import org.apache.hadoop.ozone.om.helpers.BucketLayout;
 import org.apache.hadoop.ozone.om.helpers.OmBucketInfo;
 import org.apache.hadoop.ozone.om.helpers.OmKeyLocationInfo;
+import org.apache.hadoop.ozone.om.helpers.RepeatedOmKeyInfo;
 import org.apache.hadoop.ozone.om.request.OMRequestTestUtils;
 import org.junit.Assert;
 import org.junit.Test;
@@ -123,11 +125,12 @@ public class TestOMKeyDeleteResponse extends TestOMKeyResponse {
     Assert.assertFalse(
         omMetadataManager.getKeyTable(getBucketLayout()).isExist(ozoneKey));
 
-    String deletedKey = omMetadataManager.getOzoneKey(volumeName, bucketName,
-        keyName);
+    List<? extends Table.KeyValue<String, RepeatedOmKeyInfo>> rangeKVs
+        = omMetadataManager.getDeletedTable().getRangeKVs(
+        null, 100, ozoneKey);
 
     // Key has blocks, it should not be in deletedKeyTable.
-    Assert.assertTrue(omMetadataManager.getDeletedTable().isExist(deletedKey));
+    Assert.assertTrue(rangeKVs.size() > 0);
   }
 
 

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/key/TestOMOpenKeysDeleteResponse.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/key/TestOMOpenKeysDeleteResponse.java
@@ -109,19 +109,26 @@ public class TestOMOpenKeysDeleteResponse extends TestOMKeyResponse {
 
     createAndCommitResponse(keysToDelete, Status.OK);
 
-    for (String key: keysToDelete.keySet()) {
+    for (Map.Entry<String, OmKeyInfo> entry: keysToDelete.entrySet()) {
       // These keys should have been moved from the open key table to the
       // delete table.
       Assert.assertFalse(
-          omMetadataManager.getOpenKeyTable(getBucketLayout()).isExist(key));
-      Assert.assertTrue(omMetadataManager.getDeletedTable().isExist(key));
+          omMetadataManager.getOpenKeyTable(getBucketLayout()).isExist(
+              entry.getKey()));
+      String deleteKey = omMetadataManager.getOzoneDeletePathKey(
+          entry.getValue().getObjectID(), entry.getKey());
+      Assert.assertTrue(omMetadataManager.getDeletedTable().isExist(deleteKey));
     }
 
-    for (String key: keysToKeep.keySet()) {
+    for (Map.Entry<String, OmKeyInfo> entry: keysToKeep.entrySet()) {
       // These keys should not have been moved out of the open key table.
       Assert.assertTrue(
-          omMetadataManager.getOpenKeyTable(getBucketLayout()).isExist(key));
-      Assert.assertFalse(omMetadataManager.getDeletedTable().isExist(key));
+          omMetadataManager.getOpenKeyTable(getBucketLayout()).isExist(
+              entry.getKey()));
+      String deleteKey = omMetadataManager.getOzoneDeletePathKey(
+          entry.getValue().getObjectID(), entry.getKey());
+      Assert.assertFalse(omMetadataManager.getDeletedTable()
+          .isExist(deleteKey));
     }
   }
 

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/service/TestKeyDeletingService.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/service/TestKeyDeletingService.java
@@ -30,6 +30,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.stream.Collectors;
 
+import org.apache.hadoop.hdds.utils.db.Table;
 import org.apache.hadoop.ozone.om.KeyManager;
 import org.apache.hadoop.ozone.om.OMMetadataManager;
 import org.apache.hadoop.ozone.om.OmTestManagers;
@@ -38,6 +39,7 @@ import org.apache.hadoop.ozone.om.ScmBlockLocationTestingClient;
 import org.apache.hadoop.ozone.common.BlockGroup;
 import org.apache.hadoop.ozone.om.helpers.OmKeyLocationInfo;
 import org.apache.hadoop.ozone.om.helpers.OmKeyLocationInfoGroup;
+import org.apache.hadoop.ozone.om.helpers.RepeatedOmKeyInfo;
 import org.apache.hadoop.ozone.om.request.OMRequestTestUtils;
 import org.apache.ratis.util.ExitUtils;
 import org.junit.BeforeClass;
@@ -430,8 +432,14 @@ public class TestKeyDeletingService {
     // key1 belongs to snapshot, so it should not be deleted when
     // KeyDeletingService runs. But key2 can be reclaimed as it doesn't
     // belong to any snapshot scope.
-    Assert.assertTrue(metadataManager.getDeletedTable().isExist(ozoneKey1));
-    Assert.assertFalse(metadataManager.getDeletedTable().isExist(ozoneKey2));
+    List<? extends Table.KeyValue<String, RepeatedOmKeyInfo>> rangeKVs
+        = metadataManager.getDeletedTable().getRangeKVs(
+        null, 100, ozoneKey1);
+    Assert.assertTrue(rangeKVs.size() > 0);
+    rangeKVs
+        = metadataManager.getDeletedTable().getRangeKVs(
+        null, 100, ozoneKey2);
+    Assert.assertTrue(rangeKVs.size() == 0);
   }
 
   private void createVolumeAndBucket(KeyManager keyManager, String volumeName,


### PR DESCRIPTION
## What changes were proposed in this pull request?

1. delete key is appended with objectId to make it unique
2. Removed caching of deleteTable as its not used again due to uniqueness
and removed getting from deleteTable for old key (old key will not be present as delete key is unique)
3. This is to add repeated info and overwrite the same key again in deleteTable, which can cause missing cleanup of latest block appended as there KeyDeletingService has already run in parallel.

Uniqueness for multiple flows:

openKey cleanup: openKey appended with objectId
key commit(unused block and old version): openKey appended with objectId
delete key/keys: dbKey appended with objectId
directoryPurge: key appended with objectId

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-8462

## How was this patch tested?

Unit test and integration test for delete behavior impact
