### PR TITLE
HDDS-8468. Fix Native JDK 11, 17 compile

### DIFF
--- a/hadoop-hdds/rocks-native/pom.xml
+++ b/hadoop-hdds/rocks-native/pom.xml
@@ -384,7 +384,7 @@
         <profile>
             <id>java-11</id>
             <activation>
-                <jdk>[11,17]</jdk>
+                <jdk>[11,]</jdk>
                 <property>
                     <name>rocks_tools_native</name>
                 </property>

--- a/hadoop-hdds/rocks-native/pom.xml
+++ b/hadoop-hdds/rocks-native/pom.xml
@@ -384,13 +384,31 @@
         <profile>
             <id>java-11</id>
             <activation>
-                <jdk>11</jdk>
+                <jdk>[11,17]</jdk>
                 <property>
                     <name>rocks_tools_native</name>
                 </property>
             </activation>
             <build>
                 <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-dependency-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>copy-jars</id>
+                                <phase>process-resources</phase>
+                                <goals>
+                                    <goal>copy-dependencies</goal>
+                                </goals>
+                                <configuration>
+                                    <outputDirectory>${project.build.directory}/dependency</outputDirectory>
+                                    <includeScope>runtime</includeScope>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+
                     <plugin>
                         <groupId>org.codehaus.mojo</groupId>
                         <artifactId>exec-maven-plugin</artifactId>
@@ -404,8 +422,8 @@
                                 <configuration>
                                     <executable>${env.JAVA_HOME}/bin/javac</executable>
                                     <arguments>
-                                        <argument>-classpath</argument>
-                                        <argument>${project.build.outputDirectory}</argument>
+                                        <argument>-cp</argument>
+                                        <argument>${project.build.outputDirectory}:${project.build.directory}/dependency/*</argument>
                                         <argument>-h</argument>
                                         <argument>${project.build.directory}/native/javah</argument>
                                         <argument>${project.basedir}/src/main/java/org/apache/hadoop/hdds/utils/db/managed/ManagedSSTDumpTool.java</argument>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Currently native header file compilation fails for jdk11 & jdk 17. 

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-8468

## How was this patch tested?
Local testing