### PR TITLE
HDDS-8466. Disable LegacyReplicationManager by default

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ReplicationManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ReplicationManager.java
@@ -1096,16 +1096,14 @@ public class ReplicationManager implements SCMService {
      */
     @Config(key = "enable.legacy",
         type = ConfigType.BOOLEAN,
-        defaultValue = "true",
+        defaultValue = "false",
         tags = {SCM, OZONE},
-        description = "This configuration decides if " +
-            "LegacyReplicationManager should be used to handle RATIS " +
-            "containers. Default is true, which means " +
-            "LegacyReplicationManager will handle RATIS containers while " +
-            "ReplicationManager will handle EC containers. If false, " +
+        description =
+            "If true, LegacyReplicationManager will handle RATIS containers " +
+            "while ReplicationManager will handle EC containers. If false, " +
             "ReplicationManager will handle both RATIS and EC."
     )
-    private boolean enableLegacy = true;
+    private boolean enableLegacy;
 
     public boolean isLegacyEnabled() {
       return enableLegacy;

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestLegacyReplicationManager.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestLegacyReplicationManager.java
@@ -223,7 +223,7 @@ public class TestLegacyReplicationManager {
         new ContainerPlacementStatusDefault(2, 2, 3));
     clock = new TestClock(Instant.now(), ZoneId.of("UTC"));
     containerReplicaPendingOps = new ContainerReplicaPendingOps(conf, clock);
-    createReplicationManager(new ReplicationManagerConfiguration());
+    createReplicationManager(newRMConfig());
   }
 
   void createReplicationManager(int replicationLimit, int deletionLimit)
@@ -240,7 +240,7 @@ public class TestLegacyReplicationManager {
   void createReplicationManager(
       LegacyReplicationManagerConfiguration conf)
       throws Exception {
-    createReplicationManager(null, conf);
+    createReplicationManager(newRMConfig(), conf);
   }
 
   private void createReplicationManager(ReplicationManagerConfiguration rmConf)
@@ -1680,8 +1680,7 @@ public class TestLegacyReplicationManager {
     public void testNotUnderReplicatedDueToMaintenanceMinRepOne()
         throws Exception {
       replicationManager.stop();
-      ReplicationManagerConfiguration newConf =
-          new ReplicationManagerConfiguration();
+      ReplicationManagerConfiguration newConf = newRMConfig();
       newConf.setMaintenanceReplicaMinimum(1);
       dbStore.close();
       createReplicationManager(newConf);
@@ -1701,8 +1700,7 @@ public class TestLegacyReplicationManager {
     public void testUnderReplicatedDueToMaintenanceMinRepOne()
         throws Exception {
       replicationManager.stop();
-      ReplicationManagerConfiguration newConf =
-          new ReplicationManagerConfiguration();
+      ReplicationManagerConfiguration newConf = newRMConfig();
       newConf.setMaintenanceReplicaMinimum(1);
       dbStore.close();
       createReplicationManager(newConf);
@@ -1827,6 +1825,13 @@ public class TestLegacyReplicationManager {
       assertReplicaScheduled(0);
       assertUnderReplicatedCount(1);
     }
+  }
+
+  private static ReplicationManagerConfiguration newRMConfig() {
+    ReplicationManagerConfiguration conf =
+        new ReplicationManagerConfiguration();
+    conf.setEnableLegacy(true);
+    return conf;
   }
 
   /**

--- a/hadoop-ozone/dist/src/main/compose/ozonesecure/docker-config
+++ b/hadoop-ozone/dist/src/main/compose/ozonesecure/docker-config
@@ -79,7 +79,6 @@ OZONE-SITE.XML_ozone.httpfs.kerberos.keytab.file=/etc/security/keytabs/httpfs.ke
 OZONE-SITE.XML_ozone.httpfs.kerberos.principal=httpfs/httpfs@EXAMPLE.COM
 
 OZONE-SITE.XML_hdds.scm.replication.thread.interval=5s
-OZONE-SITE.XML_hdds.scm.replication.enable.legacy=false
 OZONE-SITE.XML_ozone.scm.stale.node.interval=30s
 OZONE-SITE.XML_ozone.scm.dead.node.interval=45s
 OZONE-SITE.XML_hdds.container.report.interval=60s

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/TestStorageContainerManager.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/TestStorageContainerManager.java
@@ -47,7 +47,7 @@ import org.apache.hadoop.hdds.scm.container.ContainerNotFoundException;
 import org.apache.hadoop.hdds.scm.container.ContainerReportHandler;
 import org.apache.hadoop.hdds.scm.container.IncrementalContainerReportHandler;
 import org.apache.hadoop.hdds.scm.container.common.helpers.ContainerWithPipeline;
-import org.apache.hadoop.hdds.scm.container.replication.LegacyReplicationManager;
+import org.apache.hadoop.hdds.scm.container.replication.ReplicationManager;
 import org.apache.hadoop.hdds.scm.events.SCMEvents;
 import org.apache.hadoop.hdds.scm.exceptions.SCMException;
 import org.apache.hadoop.hdds.scm.ha.RatisUtil;
@@ -103,8 +103,6 @@ import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.io.IOException;
-import java.lang.reflect.Field;
-import java.lang.reflect.Modifier;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.time.Duration;
@@ -129,6 +127,7 @@ import static org.apache.hadoop.fs.CommonConfigurationKeysPublic.NET_TOPOLOGY_NO
 import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_CONTAINER_REPORT_INTERVAL;
 import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_SCM_SAFEMODE_PIPELINE_CREATION;
 import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_COMMAND_STATUS_REPORT_INTERVAL;
+import static org.apache.hadoop.hdds.scm.HddsWhiteboxTestUtils.setInternalState;
 import static org.junit.Assert.fail;
 import static org.mockito.Matchers.argThat;
 import static org.mockito.Matchers.eq;
@@ -803,16 +802,15 @@ public class TestStorageContainerManager {
 
       cluster.restartStorageContainerManager(false);
       scm = cluster.getStorageContainerManager();
+
+      ReplicationManager rm = scm.getReplicationManager();
+
+      NodeManager nodeManager = mock(NodeManager.class);
+      setInternalState(rm, "nodeManager", nodeManager);
+
       EventPublisher publisher = mock(EventPublisher.class);
-      LegacyReplicationManager replicationManager =
-          scm.getReplicationManager().getLegacyReplicationManager();
-      Field f = LegacyReplicationManager.class.
-          getDeclaredField("eventPublisher");
-      f.setAccessible(true);
-      Field modifiersField = Field.class.getDeclaredField("modifiers");
-      modifiersField.setAccessible(true);
-      modifiersField.setInt(f, f.getModifiers() & ~Modifier.FINAL);
-      f.set(replicationManager, publisher);
+      setInternalState(rm.getLegacyReplicationManager(),
+          "eventPublisher", publisher);
 
       UUID dnUuid = cluster.getHddsDatanodes().iterator().next()
           .getDatanodeDetails().getUuid();
@@ -820,9 +818,6 @@ public class TestStorageContainerManager {
       CloseContainerCommand closeContainerCommand =
           new CloseContainerCommand(selectedContainer.getContainerID(),
               selectedContainer.getPipelineID(), false);
-
-      CommandForDatanode commandForDatanode = new CommandForDatanode(
-          dnUuid, closeContainerCommand);
 
       GenericTestUtils.waitFor(() -> {
         SCMContext scmContext
@@ -837,8 +832,14 @@ public class TestStorageContainerManager {
           .getReplicationManager().processAll();
       Thread.sleep(5000);
 
-      verify(publisher).fireEvent(eq(SCMEvents.DATANODE_COMMAND), argThat(new
-          CloseContainerCommandMatcher(dnUuid, commandForDatanode)));
+      if (rm.getConfig().isLegacyEnabled()) {
+        CommandForDatanode commandForDatanode = new CommandForDatanode(
+            dnUuid, closeContainerCommand);
+        verify(publisher).fireEvent(eq(SCMEvents.DATANODE_COMMAND), argThat(new
+            CloseContainerCommandMatcher(dnUuid, commandForDatanode)));
+      } else {
+        verify(nodeManager).addDatanodeCommand(dnUuid, closeContainerCommand);
+      }
     } finally {
       cluster.shutdown();
     }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/TestBlockDeletion.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/TestBlockDeletion.java
@@ -19,6 +19,7 @@ package org.apache.hadoop.ozone.container.common.statemachine.commandhandler;
 
 import java.util.stream.Stream;
 
+import org.apache.hadoop.hdds.scm.container.replication.ReplicationManager;
 import org.apache.hadoop.hdds.utils.IOUtils;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.hadoop.hdds.client.ECReplicationConfig;
@@ -90,6 +91,8 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_COMMAND_STATUS_REPORT_INTERVAL;
 import static org.apache.hadoop.hdds
     .HddsConfigKeys.HDDS_CONTAINER_REPORT_INTERVAL;
+import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_HEARTBEAT_INTERVAL;
+import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_EXPIRED_CONTAINER_REPLICA_OP_SCRUB_INTERVAL;
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_PIPELINE_OWNER_CONTAINER_COUNT;
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_STALENODE_INTERVAL;
 import static org.apache.hadoop.ozone
@@ -120,6 +123,7 @@ public class TestBlockDeletion {
     GenericTestUtils.setLogLevel(DeletedBlockLogImpl.LOG, Level.DEBUG);
     GenericTestUtils.setLogLevel(SCMBlockDeletingService.LOG, Level.DEBUG);
     GenericTestUtils.setLogLevel(LegacyReplicationManager.LOG, Level.DEBUG);
+    GenericTestUtils.setLogLevel(ReplicationManager.LOG, Level.DEBUG);
 
     conf.set("ozone.replication.allowed-configs",
         "^(RATIS/THREE)|(EC/2-1-256k)$");
@@ -137,6 +141,8 @@ public class TestBlockDeletion {
         + ".client.request.write.timeout", 30, TimeUnit.SECONDS);
     conf.setTimeDuration(RatisHelper.HDDS_DATANODE_RATIS_PREFIX_KEY
         + ".client.request.watch.timeout", 30, TimeUnit.SECONDS);
+    conf.setTimeDuration(HDDS_HEARTBEAT_INTERVAL, 50,
+        TimeUnit.MILLISECONDS);
     conf.setTimeDuration(HDDS_CONTAINER_REPORT_INTERVAL, 200,
         TimeUnit.MILLISECONDS);
     conf.setTimeDuration(HDDS_COMMAND_STATUS_REPORT_INTERVAL, 200,
@@ -145,11 +151,13 @@ public class TestBlockDeletion {
         3, TimeUnit.SECONDS);
     conf.setBoolean(ScmConfigKeys.OZONE_SCM_PIPELINE_AUTO_CREATE_FACTOR_ONE,
         false);
+    conf.setTimeDuration(OZONE_SCM_EXPIRED_CONTAINER_REPLICA_OP_SCRUB_INTERVAL,
+        100, TimeUnit.MILLISECONDS);
     conf.setInt(OZONE_SCM_PIPELINE_OWNER_CONTAINER_COUNT, 100);
     conf.setInt(ScmConfigKeys.OZONE_DATANODE_PIPELINE_LIMIT, 1);
     conf.setQuietMode(false);
-    conf.setTimeDuration("hdds.scm.replication.event.timeout", 100,
-        TimeUnit.MILLISECONDS);
+    conf.setTimeDuration("hdds.scm.replication.event.timeout", 2,
+        TimeUnit.SECONDS);
     conf.setTimeDuration("hdds.scm.replication.event.timeout.datanode.offset",
         0,
         TimeUnit.MILLISECONDS);
@@ -308,6 +316,9 @@ public class TestBlockDeletion {
   @Test
   @Flaky("HDDS-8353")
   public void testContainerStatisticsAfterDelete() throws Exception {
+    ReplicationManager replicationManager = scm.getReplicationManager();
+    boolean legacyEnabled = replicationManager.getConfig().isLegacyEnabled();
+
     String volumeName = UUID.randomUUID().toString();
     String bucketName = UUID.randomUUID().toString();
 
@@ -357,12 +368,11 @@ public class TestBlockDeletion {
 
     writeClient.deleteKey(keyArgs);
     // Wait for blocks to be deleted and container reports to be processed
+    GenericTestUtils.waitFor(() ->
+        scm.getContainerManager().getContainers().stream()
+            .allMatch(c -> c.getUsedBytes() == 0 && c.getNumberOfKeys() == 0)
+        , 500, 5000);
     Thread.sleep(5000);
-    containerInfos = scm.getContainerManager().getContainers();
-    containerInfos.stream().forEach(container -> {
-      Assertions.assertEquals(0, container.getUsedBytes());
-      Assertions.assertEquals(0, container.getNumberOfKeys());
-    });
     // Verify that pending block delete num are as expected with resent cmds
     cluster.getHddsDatanodes().forEach(dn -> {
       Map<Long, Container<?>> containerMap = dn.getDatanodeStateMachine()
@@ -375,27 +385,31 @@ public class TestBlockDeletion {
     });
 
     cluster.shutdownHddsDatanode(0);
-    scm.getReplicationManager().processAll();
+    replicationManager.processAll();
     ((EventQueue)scm.getEventQueue()).processAll(1000);
     containerInfos = scm.getContainerManager().getContainers();
     containerInfos.stream().forEach(container ->
         Assertions.assertEquals(HddsProtos.LifeCycleState.DELETING,
             container.getState()));
-    LogCapturer logCapturer =
-        LogCapturer.captureLogs(LegacyReplicationManager.LOG);
+    LogCapturer logCapturer = LogCapturer.captureLogs(
+        legacyEnabled ? LegacyReplicationManager.LOG  : ReplicationManager.LOG);
     logCapturer.clearOutput();
 
-    Thread.sleep(2000);
-    scm.getReplicationManager().processAll();
-    ((EventQueue)scm.getEventQueue()).processAll(1000);
+    Thread.sleep(5000);
+    replicationManager.processAll();
+    ((EventQueue) scm.getEventQueue()).processAll(1000);
+    String expectedOutput = legacyEnabled
+        ? "Resend delete Container"
+        : "Sending delete command for container";
     GenericTestUtils.waitFor(() -> logCapturer.getOutput()
-        .contains("Resend delete Container"), 500, 5000);
+        .contains(expectedOutput), 500, 5000);
+
     cluster.restartHddsDatanode(0, true);
     Thread.sleep(2000);
 
-    scm.getReplicationManager().processAll();
-    ((EventQueue)scm.getEventQueue()).processAll(1000);
     GenericTestUtils.waitFor(() -> {
+      replicationManager.processAll();
+      ((EventQueue)scm.getEventQueue()).processAll(1000);
       List<ContainerInfo> infos = scm.getContainerManager().getContainers();
       try {
         infos.stream().forEach(container -> {
@@ -411,10 +425,11 @@ public class TestBlockDeletion {
           }
         });
       } catch (Throwable e) {
+        LOG.info(e.getMessage());
         return false;
       }
       return true;
-    }, 500, 5000);
+    }, 500, 15000);
     LOG.info(metrics.toString());
   }
 

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/TestBlockDeletion.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/TestBlockDeletion.java
@@ -370,8 +370,8 @@ public class TestBlockDeletion {
     // Wait for blocks to be deleted and container reports to be processed
     GenericTestUtils.waitFor(() ->
         scm.getContainerManager().getContainers().stream()
-            .allMatch(c -> c.getUsedBytes() == 0 && c.getNumberOfKeys() == 0)
-        , 500, 5000);
+            .allMatch(c -> c.getUsedBytes() == 0 && c.getNumberOfKeys() == 0),
+        500, 5000);
     Thread.sleep(5000);
     // Verify that pending block delete num are as expected with resent cmds
     cluster.getHddsDatanodes().forEach(dn -> {

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/scm/node/TestDecommissionAndMaintenance.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/scm/node/TestDecommissionAndMaintenance.java
@@ -140,6 +140,7 @@ public class TestDecommissionAndMaintenance {
     replicationConf.setInterval(Duration.ofSeconds(1));
     replicationConf.setUnderReplicatedInterval(Duration.ofSeconds(1));
     replicationConf.setOverReplicatedInterval(Duration.ofSeconds(1));
+    replicationConf.setEnableLegacy(true); // disable as part of HDDS-8459
     conf.setFromObject(replicationConf);
 
     MiniOzoneCluster.Builder builder = MiniOzoneCluster.newBuilder(conf)


### PR DESCRIPTION
## What changes were proposed in this pull request?

 * Enable the new ReplicationManager by default
 * Except in:
   * `TestLegacyReplicationManager`, since it tests `LegacyReplicationManager`
   * `TestDecommissionAndMaintenance`, which will be fixed for new RM by HDDS-8459
 * Fix `TestStorageContainerManager#testCloseContainerCommandOnRestart` for the new RM flow

https://issues.apache.org/jira/browse/HDDS-8466

## How was this patch tested?

CI:
https://github.com/adoroszlai/hadoop-ozone/actions/runs/4755806209 (before `TestDecommissionAndMaintenance` change)
https://github.com/adoroszlai/hadoop-ozone/actions/runs/4763910111 (final patch)