### PR TITLE
HDDS-8474. XceiverClient not closed properly in TestContainerStateMachineFailures

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestContainerStateMachineFailures.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestContainerStateMachineFailures.java
@@ -179,6 +179,9 @@ public class TestContainerStateMachineFailures {
   @AfterAll
   public static void shutdown() {
     IOUtils.closeQuietly(client);
+    if (xceiverClientManager != null) {
+      xceiverClientManager.close();
+    }
     if (cluster != null) {
       cluster.shutdown();
     }
@@ -449,6 +452,8 @@ public class TestContainerStateMachineFailures {
       Assert.fail("Expected exception not thrown");
     } catch (IOException e) {
       // Exception should be thrown
+    } finally {
+      xceiverClientManager.releaseClient(xceiverClient, false);
     }
     // Make sure the container is marked unhealthy
     Assert.assertTrue(dn.getDatanodeStateMachine()
@@ -540,6 +545,8 @@ public class TestContainerStateMachineFailures {
       stateMachine.takeSnapshot();
     } catch (IOException ioe) {
       Assert.fail("Exception should not be thrown");
+    } finally {
+      xceiverClientManager.releaseClient(xceiverClient, false);
     }
     FileInfo latestSnapshot = storage.findLatestSnapshot().getFile();
     Assert.assertFalse(snapshot.getPath().equals(latestSnapshot.getPath()));


### PR DESCRIPTION
## What changes were proposed in this pull request?

Relase client in `TestContainerStateMachineFailures` after use.

https://issues.apache.org/jira/browse/HDDS-8474

## How was this patch tested?

Ran `TestContainerStateMachineFailures` locally, searched for gRPC's log:

```
grep 'was not shutdown' hadoop-ozone/integration-test/target/surefire-reports/org.apache.hadoop.ozone.client.rpc.TestContainerStateMachineFailures-output.txt
```