### PR TITLE
HDDS-8479. XceiverClient not closed properly in tests

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestContainerReplicationEndToEnd.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestContainerReplicationEndToEnd.java
@@ -135,6 +135,9 @@ public class TestContainerReplicationEndToEnd {
   @AfterClass
   public static void shutdown() {
     IOUtils.closeQuietly(client);
+    if (xceiverClientManager != null) {
+      xceiverClientManager.close();
+    }
     if (cluster != null) {
       cluster.shutdown();
     }
@@ -184,8 +187,6 @@ public class TestContainerReplicationEndToEnd {
     Thread.sleep(2 * containerReportInterval);
     DatanodeDetails oldReplicaNode = pipeline.getFirstNode();
     // now move the container to the closed on the datanode.
-    XceiverClientSpi xceiverClient =
-        xceiverClientManager.acquireClient(pipeline);
     ContainerProtos.ContainerCommandRequestProto.Builder request =
         ContainerProtos.ContainerCommandRequestProto.newBuilder();
     request.setDatanodeUuid(pipeline.getFirstNode().getUuidString());
@@ -193,7 +194,13 @@ public class TestContainerReplicationEndToEnd {
     request.setContainerID(containerID);
     request.setCloseContainer(
         ContainerProtos.CloseContainerRequestProto.getDefaultInstance());
-    xceiverClient.sendCommand(request.build());
+    XceiverClientSpi xceiverClient =
+        xceiverClientManager.acquireClient(pipeline);
+    try {
+      xceiverClient.sendCommand(request.build());
+    } finally {
+      xceiverClientManager.releaseClient(xceiverClient, false);
+    }
     // wait for container to move to closed state in SCM
     Thread.sleep(2 * containerReportInterval);
     Assert.assertTrue(

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestDeleteWithSlowFollower.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestDeleteWithSlowFollower.java
@@ -263,17 +263,13 @@ public class TestDeleteWithSlowFollower {
     ContainerStateMachine stateMachine =
         (ContainerStateMachine) RatisTestHelper
             .getStateMachine(leader, pipeline);
-    OmKeyArgs keyArgs = new OmKeyArgs.Builder().setVolumeName(volumeName).
-        setBucketName(bucketName)
-        .setReplicationConfig(
-            RatisReplicationConfig
-                .getInstance(THREE))
-        .setKeyName(keyName)
-        .build();
+    OmKeyArgs keyArgs = new OmKeyArgs.Builder()
+        .setVolumeName(volumeName).setBucketName(bucketName)
+        .setReplicationConfig(RatisReplicationConfig.getInstance(THREE))
+        .setKeyName(keyName).build();
     OmKeyInfo info = cluster.getOzoneManager().lookupKey(keyArgs);
-    BlockID blockID =
-        info.getKeyLocationVersions().get(0).getLocationList().get(0)
-            .getBlockID();
+    BlockID blockID = info.getKeyLocationVersions().get(0)
+        .getLocationList().get(0).getBlockID();
     OzoneContainer ozoneContainer;
     final DatanodeStateMachine dnStateMachine =
         leader.getDatanodeStateMachine();


### PR DESCRIPTION
## What changes were proposed in this pull request?

Found few more cases where `XceiverClient` was not closed properly.

https://issues.apache.org/jira/browse/HDDS-8479

## How was this patch tested?

Ran the tests locally, searched for `was not shutdown` in logs.

CI:
https://github.com/adoroszlai/hadoop-ozone/actions/runs/4771197291