### PR TITLE
HDDS-8480. DB not closed properly in ContainerMapper

### DIFF
--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/fsck/ContainerMapper.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/fsck/ContainerMapper.java
@@ -45,14 +45,6 @@ import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_DB_DIRS;
 
 public class ContainerMapper {
 
-
-  private static Table getMetaTable(OzoneConfiguration configuration)
-      throws IOException {
-    OmMetadataManagerImpl metadataManager =
-        new OmMetadataManagerImpl(configuration);
-    return metadataManager.getKeyTable(getBucketLayout());
-  }
-
   public static void main(String[] args) throws IOException {
     String path = args[0];
     if (path == null) {
@@ -84,8 +76,12 @@ public class ContainerMapper {
     String path = configuration.get(OZONE_OM_DB_DIRS);
     if (path == null || path.isEmpty()) {
       throw new IOException(OZONE_OM_DB_DIRS + "should be set ");
-    } else {
-      Table keyTable = getMetaTable(configuration);
+    }
+    OmMetadataManagerImpl metadataManager =
+        new OmMetadataManagerImpl(configuration);
+    try {
+      Table<String, OmKeyInfo> keyTable =
+          metadataManager.getKeyTable(getBucketLayout());
       Map<Long, List<Map<Long, BlockIdDetails>>> dataMap = new HashMap<>();
 
       if (keyTable != null) {
@@ -131,6 +127,8 @@ public class ContainerMapper {
 
       return dataMap;
 
+    } finally {
+      metadataManager.stop();
     }
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Close DB after use in `ContainerMapper` to fix:

```
2023-04-22 04:44:53,929 [Finalizer] WARN  managed.ManagedRocksObjectUtils (ManagedRocksObjectUtils.java:assertClosed(54)) - Checkpoint is not closed properly
 StackTrace for unclosed instance: org.apache.hadoop.hdds.utils.db.managed.ManagedObject.<init>(ManagedObject.java:35)
...
org.apache.hadoop.hdds.utils.db.RDBStore.<init>(RDBStore.java:174)
org.apache.hadoop.hdds.utils.db.DBStoreBuilder.build(DBStoreBuilder.java:229)
org.apache.hadoop.ozone.om.OmMetadataManagerImpl.loadDB(OmMetadataManagerImpl.java:554)
org.apache.hadoop.ozone.om.OmMetadataManagerImpl.loadDB(OmMetadataManagerImpl.java:522)
org.apache.hadoop.ozone.om.OmMetadataManagerImpl.start(OmMetadataManagerImpl.java:512)
org.apache.hadoop.ozone.om.OmMetadataManagerImpl.<init>(OmMetadataManagerImpl.java:321)
org.apache.hadoop.ozone.fsck.ContainerMapper.getMetaTable(ContainerMapper.java:51)
org.apache.hadoop.ozone.fsck.ContainerMapper.parseOmDB(ContainerMapper.java:88)
org.apache.hadoop.ozone.fsck.TestContainerMapper.testContainerMapper(TestContainerMapper.java:132)
```

https://issues.apache.org/jira/browse/HDDS-8480

## How was this patch tested?

CI
https://github.com/adoroszlai/hadoop-ozone/actions/runs/4776916953