### PR TITLE
HDDS-8482. Let Ozone shell support multiple OM services

### DIFF
--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/OzoneAddress.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/OzoneAddress.java
@@ -146,7 +146,7 @@ public class OzoneAddress {
                   + ozoneURI.getHost() + "' is a logical (HA) OzoneManager "
                   + "and does not use port information.");
         }
-        client = createRpcClient(conf);
+        client = createRpcClientFromServiceId(ozoneURI.getHost(), conf);
       } else if (ozoneURI.getPort() == -1) {
         client = createRpcClientFromHostPort(ozoneURI.getHost(),
             OmUtils.getOmRpcPort(conf), conf);

--- a/hadoop-ozone/tools/src/test/java/org/apache/hadoop/ozone/shell/TestOzoneAddressClientCreation.java
+++ b/hadoop-ozone/tools/src/test/java/org/apache/hadoop/ozone/shell/TestOzoneAddressClientCreation.java
@@ -65,6 +65,18 @@ public class TestOzoneAddressClientCreation {
   }
 
   @Test
+  public void explicitHaMultipleServiceId()
+      throws OzoneClientException, IOException {
+    TestableOzoneAddress address =
+        new TestableOzoneAddress("o3://service1/vol1/bucket1/key1");
+    address.createClient(
+        new InMemoryConfiguration(OZONE_OM_SERVICE_IDS_KEY,
+            "service1,service2"));
+    Assert.assertFalse(address.simpleCreation);
+    Assert.assertEquals("service1", address.serviceId);
+  }
+
+  @Test
   public void explicitNonHAHostPort() throws OzoneClientException, IOException {
     TestableOzoneAddress address =
         new TestableOzoneAddress("o3://om:9862/vol1/bucket1/key1");


### PR DESCRIPTION
## What changes were proposed in this pull request?

Ozone cli support multiple ozone.om.service.ids

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-8482


## How was this patch tested?

manual tests passed.

without pr:
```bash
$ ozone sh vol ls o3://ozone1
Following ServiceID's [ozone1, ozone2] are defined in the configuration. Use the method getRpcClient which takes serviceID and configuration as param
```

with pr:
```bash
# case1
$ ozone sh vol ls o3://ozone1
[ {
  "metadata" : { }...
]

# case2
$ ozone sh vol ls o3://ozone2
[ {
  "metadata" : { }...
]

# case3
ozone sh vol ls
Service ID or host name must not be omitted when multiple ozone.om.service.ids is defined  
```