### PR TITLE
HDDS-7226. Implement Changed placement policy interface to allow existing nodes to be specified for Rack Aware Policy.

### DIFF
--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/TestSCMCommonPlacementPolicy.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/TestSCMCommonPlacementPolicy.java
@@ -43,6 +43,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
@@ -430,7 +431,27 @@ public class TestSCMCommonPlacementPolicy {
     Assertions.assertEquals(replicasToRemove.size(), 0);
   }
 
-
+  @Test
+  public void testIdentityUsedNodesWhenUsedNotPassed() throws SCMException {
+    AtomicBoolean usedNodesIdentity = new AtomicBoolean(true);
+    DummyPlacementPolicy dummyPlacementPolicy =
+        new DummyPlacementPolicy(nodeManager, conf, 5) {
+          @Override
+          protected List<DatanodeDetails> chooseDatanodesInternal(
+              List<DatanodeDetails> usedNodes,
+              List<DatanodeDetails> excludedNodes,
+              List<DatanodeDetails> favoredNodes,
+              int nodesRequired, long metadataSizeRequired,
+              long dataSizeRequired) {
+            usedNodesIdentity.set(usedNodesPassed(usedNodes));
+            return null;
+          }
+        };
+    dummyPlacementPolicy.chooseDatanodes(null, null, 1, 1, 1);
+    Assertions.assertFalse(usedNodesIdentity.get());
+    dummyPlacementPolicy.chooseDatanodes(null, null, null, 1, 1, 1);
+    Assertions.assertTrue(usedNodesIdentity.get());
+  }
 
   private static class DummyPlacementPolicy extends SCMCommonPlacementPolicy {
     private Map<DatanodeDetails, Node> rackMap;

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/placement/algorithms/TestSCMContainerPlacementRackAware.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/placement/algorithms/TestSCMContainerPlacementRackAware.java
@@ -588,4 +588,183 @@ public class TestSCMContainerPlacementRackAware {
       dnInfos.get(index).setNodeStatus(new NodeStatus(DECOMMISSIONED, HEALTHY));
     }
   }
+
+  @ParameterizedTest
+  @ValueSource(ints = {NODE_PER_RACK + 1, 2 * NODE_PER_RACK + 1})
+  public void chooseNodeWithUsedNodesMultipleRack(int datanodeCount)
+      throws SCMException {
+    assumeTrue(datanodeCount > NODE_PER_RACK);
+    setup(datanodeCount);
+    int nodeNum = 1;
+    List<DatanodeDetails> excludedNodes = new ArrayList<>();
+    List<DatanodeDetails> usedNodes = new ArrayList<>();
+
+    // 2 replicas, two existing datanodes on same rack
+    usedNodes.add(datanodes.get(0));
+    usedNodes.add(datanodes.get(1));
+
+    List<DatanodeDetails> datanodeDetails = policy.chooseDatanodes(usedNodes,
+        excludedNodes, null, nodeNum, 0, 5);
+    Assertions.assertEquals(nodeNum, datanodeDetails.size());
+
+    // New DN should be on different rack than DN0 & DN1
+    Assertions.assertTrue(!cluster.isSameParent(
+        datanodes.get(0), datanodeDetails.get(0)) &&
+        !cluster.isSameParent(datanodes.get(1), datanodeDetails.get(0)));
+
+    // 2 replicas, two existing datanodes on different rack
+    usedNodes.clear();
+    // 1st Replica on rack0
+    usedNodes.add(datanodes.get(0));
+    // 2nd Replica on rack1
+    usedNodes.add(datanodes.get(5));
+
+    datanodeDetails = policy.chooseDatanodes(usedNodes,
+        excludedNodes, null, nodeNum, 0, 5);
+    Assertions.assertEquals(nodeNum, datanodeDetails.size());
+
+    // New replica should be either on rack0 or rack1
+    Assertions.assertTrue(cluster.isSameParent(
+        datanodes.get(0), datanodeDetails.get(0)) ||
+        cluster.isSameParent(datanodes.get(1), datanodeDetails.get(0)));
+  }
+
+  @Test
+  public void chooseSingleNodeRackWithUsedAndExcludeNodes()
+      throws SCMException {
+    int datanodeCount = 5;
+    setup(datanodeCount);
+    int nodeNum = 1;
+    List<DatanodeDetails> excludedNodes = new ArrayList<>();
+    List<DatanodeDetails> usedNodes = new ArrayList<>();
+
+    // 2 replicas, two existing datanodes on same rack
+    usedNodes.add(datanodes.get(0));
+    usedNodes.add(datanodes.get(1));
+    excludedNodes.add(datanodes.get(2));
+
+    List<DatanodeDetails> datanodeDetails = policy.chooseDatanodes(usedNodes,
+        excludedNodes, null, nodeNum, 0, 5);
+    Assertions.assertEquals(nodeNum, datanodeDetails.size());
+
+    Assertions.assertTrue(cluster.isSameParent(
+        datanodes.get(0), datanodeDetails.get(0)) &&
+        cluster.isSameParent(datanodes.get(1), datanodeDetails.get(0)) &&
+        excludedNodes.get(0).getUuid() != datanodeDetails.get(0).getUuid());
+
+    // Required 2 DN for 2 replica
+    nodeNum = 2;
+    // One replica exist
+    usedNodes.clear();
+    // 1st Replica on rack0
+    usedNodes.add(datanodes.get(0));
+
+    datanodeDetails = policy.chooseDatanodes(usedNodes,
+        excludedNodes, null, nodeNum, 0, 5);
+    Assertions.assertEquals(nodeNum, datanodeDetails.size());
+
+    Assertions.assertTrue(excludedNodes.get(0).getUuid() !=
+        datanodeDetails.get(0).getUuid() &&
+        excludedNodes.get(0).getUuid() != datanodeDetails.get(1).getUuid());
+
+    nodeNum = 3;
+    // No replica exist
+    usedNodes.clear();
+
+    datanodeDetails = policy.chooseDatanodes(usedNodes,
+        excludedNodes, null, nodeNum, 0, 5);
+    Assertions.assertEquals(nodeNum, datanodeDetails.size());
+
+    Assertions.assertTrue(excludedNodes.get(0).getUuid() !=
+        datanodeDetails.get(0).getUuid() &&
+        excludedNodes.get(0).getUuid() != datanodeDetails.get(1).getUuid());
+  }
+
+  @ParameterizedTest
+  @MethodSource("numDatanodes")
+  public void chooseNodeWithUsedAndExcludeNodesMultipleRack(int datanodeCount)
+      throws SCMException {
+    assumeTrue(datanodeCount > NODE_PER_RACK);
+    setup(datanodeCount);
+    int nodeNum = 2;
+    List<DatanodeDetails> excludedNodes = new ArrayList<>();
+    List<DatanodeDetails> usedNodes = new ArrayList<>();
+
+    // 1 replica
+    usedNodes.add(datanodes.get(0));
+    // 1 exclude node
+    excludedNodes.add(datanodes.get(1));
+
+    List<DatanodeDetails> datanodeDetails = policy.chooseDatanodes(usedNodes,
+        excludedNodes, null, nodeNum, 0, 5);
+
+    Assertions.assertEquals(nodeNum, datanodeDetails.size());
+
+    // Exclude node should not be returned
+    Assertions.assertTrue(excludedNodes.get(0).getUuid() !=
+        datanodeDetails.get(0).getUuid() && excludedNodes.get(0).getUuid() !=
+        datanodeDetails.get(1).getUuid());
+
+    usedNodes.clear();
+    excludedNodes.clear();
+    // 1 replica
+    // Multiple exclude nodes
+    usedNodes.add(datanodes.get(0));
+    excludedNodes.add(datanodes.get(1));
+    excludedNodes.add(datanodes.get(2));
+
+    datanodeDetails = policy.chooseDatanodes(usedNodes,
+        excludedNodes, null, nodeNum, 0, 5);
+
+    Assertions.assertEquals(nodeNum, datanodeDetails.size());
+
+    Assertions.assertTrue(excludedNodes.get(0).getUuid() !=
+        datanodeDetails.get(0).getUuid() && excludedNodes.get(1).getUuid() !=
+        datanodeDetails.get(0).getUuid());
+
+    Assertions.assertTrue(excludedNodes.get(0).getUuid() !=
+        datanodeDetails.get(1).getUuid() && excludedNodes.get(1).getUuid() !=
+        datanodeDetails.get(1).getUuid());
+  }
+
+  @ParameterizedTest
+  @MethodSource("numDatanodes")
+  public void chooseNodeWithOnlyExcludeAndNoUsedNodes(int datanodeCount)
+      throws SCMException {
+    assumeTrue(datanodeCount > NODE_PER_RACK);
+    setup(datanodeCount);
+    int nodeNum = 3;
+    List<DatanodeDetails> excludedNodes = new ArrayList<>();
+    // 1 exclude node
+    excludedNodes.add(datanodes.get(1));
+
+    List<DatanodeDetails> datanodeDetails = policy.chooseDatanodes(null,
+        excludedNodes, null, nodeNum, 0, 5);
+
+    Assertions.assertEquals(nodeNum, datanodeDetails.size());
+
+    // Exclude node should not be returned
+    Assertions.assertTrue(excludedNodes.get(0).getUuid() !=
+        datanodeDetails.get(0).getUuid() && excludedNodes.get(0).getUuid() !=
+        datanodeDetails.get(1).getUuid());
+
+    excludedNodes.clear();
+    // Multiple exclude nodes
+    excludedNodes.add(datanodes.get(1));
+    excludedNodes.add(datanodes.get(2));
+
+    datanodeDetails = policy.chooseDatanodes(null,
+        excludedNodes, null, nodeNum, 0, 5);
+
+    Assertions.assertEquals(nodeNum, datanodeDetails.size());
+
+    // Exclude node should not be returned
+    Assertions.assertTrue(excludedNodes.get(0).getUuid() !=
+        datanodeDetails.get(0).getUuid() && excludedNodes.get(0).getUuid() !=
+        datanodeDetails.get(1).getUuid());
+
+    Assertions.assertTrue(excludedNodes.get(1).getUuid() !=
+        datanodeDetails.get(0).getUuid() && excludedNodes.get(1).getUuid() !=
+        datanodeDetails.get(1).getUuid());
+  }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Handle rack aware algorithm to use "usedNodes and excludeNodes" to determine racks for the replica to be placed. This change will ensure that existing algorithm also will continue to work when usedNode is not passed to invoke PlacementPolicy interface.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-7226

## How was this patch tested?

Added Unit tests.
