### PR TITLE
HDDS-8459. Ratis under replication handling in a rack aware environment doesn't work

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ContainerHealthResult.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ContainerHealthResult.java
@@ -260,14 +260,19 @@ public class ContainerHealthResult {
      * replication queue.
      */
     private static final int MIS_REP_REDUNDANCY = 6;
+    private final String misReplicatedReason;
 
     public MisReplicatedHealthResult(ContainerInfo containerInfo,
-        boolean replicatedOkAfterPending) {
+        boolean replicatedOkAfterPending, String misReplicatedReason) {
       super(containerInfo, MIS_REP_REDUNDANCY, false,
           replicatedOkAfterPending, false,
           HealthState.MIS_REPLICATED);
+      this.misReplicatedReason = misReplicatedReason;
     }
 
+    public String getMisReplicatedReason() {
+      return misReplicatedReason;
+    }
   }
 
   /**

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/RatisContainerReplicaCount.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/RatisContainerReplicaCount.java
@@ -192,7 +192,7 @@ public class RatisContainerReplicaCount implements ContainerReplicaCount {
    * state + Number of replicas that don't match the container's state but
    * their state is not UNHEALTHY (also called mismatched replicas).
    * For example, consider a CLOSED container with the following replicas:
-   * {CLOSED, CLOSING, OPEN, CLOSED, UNHEALTHY}
+   * {CLOSED, CLOSING, OPEN, UNHEALTHY}
    * In this case, healthy replica count equals 3. Calculation:
    * 1 CLOSED -> 1 matching replica.
    * 1 OPEN, 1 CLOSING -> 2 mismatched replicas.

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/health/ECReplicationCheckHandler.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/health/ECReplicationCheckHandler.java
@@ -115,7 +115,9 @@ public class ECReplicationCheckHandler extends AbstractCheck {
         request.getReplicationQueue().enqueue(misRepHealth);
       }
       LOG.debug("Container {} is Mis Replicated. isReplicatedOkAfterPending "
-          + "is [{}]", container, misRepHealth.isReplicatedOkAfterPending());
+              + "is [{}]. Reason for mis replication is [{}].", container,
+          misRepHealth.isReplicatedOkAfterPending(),
+          misRepHealth.getMisReplicatedReason());
       return true;
     }
     // Should not get here, but in case it does the container is not healthy,
@@ -175,7 +177,8 @@ public class ECReplicationCheckHandler extends AbstractCheck {
           replicas, container.getReplicationConfig().getRequiredNodes(),
           request.getPendingOps());
       return new ContainerHealthResult.MisReplicatedHealthResult(
-          container, placementAfterPending.isPolicySatisfied());
+          container, placementAfterPending.isPolicySatisfied(),
+          placementAfterPending.misReplicatedReason());
     }
     // No issues detected, so return healthy.
     return new ContainerHealthResult.HealthyResult(container);

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/balancer/TestMoveManager.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/balancer/TestMoveManager.java
@@ -245,7 +245,7 @@ public class TestMoveManager {
           } else {
             // after move
             return new ContainerHealthResult.MisReplicatedHealthResult(
-                containerInfo, false);
+                containerInfo, false, null);
           }
         });
 
@@ -483,7 +483,7 @@ public class TestMoveManager {
 
     Mockito.when(replicationManager.getContainerReplicationHealth(any(), any()))
         .thenReturn(new ContainerHealthResult
-            .MisReplicatedHealthResult(containerInfo, false));
+            .MisReplicatedHealthResult(containerInfo, false, null));
 
     ContainerReplicaOp op = new ContainerReplicaOp(
         ADD, tgt, 0, clock.millis() + 1000);

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestRatisContainerReplicaCount.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestRatisContainerReplicaCount.java
@@ -572,6 +572,29 @@ class TestRatisContainerReplicaCount {
     validate(withUnhealthy, true, 0, false);
   }
 
+  /**
+   * Scenario: A CLOSED RATIS container with 2 CLOSED and 1 UNHEALTHY replicas.
+   * Expectation: If considerUnhealthy is false, this container is not
+   * sufficiently replicated and replicaDelta is 1.
+   */
+  @Test
+  public void testUnderReplicationBecauseOfUnhealthyReplica() {
+    ContainerInfo container =
+        createContainerInfo(RatisReplicationConfig.getInstance(
+                HddsProtos.ReplicationFactor.THREE), 1L,
+            HddsProtos.LifeCycleState.CLOSED);
+    Set<ContainerReplica> replicas =
+        createReplicas(container.containerID(), CLOSED, 0, 0);
+    ContainerReplica unhealthyReplica = createContainerReplica(
+        ContainerID.valueOf(1L), 0, IN_SERVICE, UNHEALTHY);
+    replicas.add(unhealthyReplica);
+    RatisContainerReplicaCount withoutUnhealthy =
+        new RatisContainerReplicaCount(container, replicas,
+            Collections.emptyList(), 2,
+            false);
+    validate(withoutUnhealthy, false, 1, false);
+  }
+
   @Test
   void testIsHealthyWithMaintReplicaIsHealthy() {
     Set<ContainerReplica> replica =

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestReplicationManager.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestReplicationManager.java
@@ -318,8 +318,6 @@ public class TestReplicationManager {
         ReplicationManagerReport.HealthState.UNDER_REPLICATED));
     Assert.assertEquals(1, repReport.getStat(
         ReplicationManagerReport.HealthState.OVER_REPLICATED));
-    Assert.assertEquals(1, repReport.getStat(
-        ReplicationManagerReport.HealthState.UNHEALTHY));
     Assert.assertEquals(0, repQueue.underReplicatedQueueSize());
     Assert.assertEquals(1, repQueue.overReplicatedQueueSize());
 
@@ -359,8 +357,6 @@ public class TestReplicationManager {
         ReplicationManagerReport.HealthState.UNDER_REPLICATED));
     Assert.assertEquals(1, repReport.getStat(
         ReplicationManagerReport.HealthState.OVER_REPLICATED));
-    Assert.assertEquals(1, repReport.getStat(
-        ReplicationManagerReport.HealthState.UNHEALTHY));
     Assert.assertEquals(0, repQueue.underReplicatedQueueSize());
     Assert.assertEquals(1, repQueue.overReplicatedQueueSize());
 
@@ -372,6 +368,8 @@ public class TestReplicationManager {
     handler.processAndSendCommands(replicas, Collections.emptyList(),
         repQueue.dequeueOverReplicatedContainer(), 2);
     Assert.assertTrue(commandsSent.iterator().hasNext());
+
+    // unhealthy replica can't be deleted because it has a unique origin DN
     Assert.assertNotEquals(unhealthy.getDatanodeDetails().getUuid(),
         commandsSent.iterator().next().getKey());
     Assert.assertEquals(SCMCommandProto.Type.deleteContainerCommand,


### PR DESCRIPTION
## What changes were proposed in this pull request?

The scenario is described in the jira: https://issues.apache.org/jira/browse/HDDS-8459.
The fix here is using the correct `RatisContainerReplicaCount` object in `RatisUnderReplicationHandler`. And also to consider `UNHEALTHY` replicas when checking for over replication in `RatisReplicationCheckHandler` to fix the subsequent over replication.

## How was this patch tested?

Added and modified unit tests. Also tested manually using docker compose.
Draft only because CI is still running in my fork: https://github.com/siddhantsangwan/ozone/actions/runs/4798311173/jobs/8536433251