### PR TITLE
HDDS-8390. [Snapshot] Added active snapshots check before returning diff report to client and in diff report generation to fail fast.

### DIFF
--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmSnapshotManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmSnapshotManager.java
@@ -87,6 +87,7 @@ import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_SNAPSHOT_DIFF_DB_
 import static org.apache.hadoop.ozone.om.exceptions.OMException.ResultCodes.FILE_NOT_FOUND;
 import static org.apache.hadoop.ozone.om.exceptions.OMException.ResultCodes.INVALID_KEY_NAME;
 import static org.apache.hadoop.ozone.om.snapshot.SnapshotUtils.dropColumnFamilyHandle;
+import static org.apache.hadoop.ozone.om.snapshot.SnapshotUtils.validateSnapshotsExistAndActive;
 
 /**
  * This class is used to manage/create OM snapshots.
@@ -540,12 +541,9 @@ public final class OmSnapshotManager implements AutoCloseable {
                                                     int pageSize,
                                                     boolean forceFullDiff)
       throws IOException {
-    // Validate fromSnapshot and toSnapshot
-    final SnapshotInfo fsInfo = SnapshotUtils.getSnapshotInfo(ozoneManager,
-        volume, bucket, fromSnapshot);
-    final SnapshotInfo tsInfo = SnapshotUtils.getSnapshotInfo(ozoneManager,
-        volume, bucket, toSnapshot);
-    verifySnapshotInfoForSnapDiff(fsInfo, tsInfo);
+
+    validateSnapshotsExistAndActive(ozoneManager, volume, bucket, fromSnapshot,
+        toSnapshot);
 
     int index = getIndexFromToken(token);
     int maxPageSize = ozoneManager.getConfiguration()
@@ -555,31 +553,20 @@ public final class OmSnapshotManager implements AutoCloseable {
       pageSize = maxPageSize;
     }
 
-    final String fsKey = SnapshotInfo.getTableKey(volume, bucket, fromSnapshot);
-    final String tsKey = SnapshotInfo.getTableKey(volume, bucket, toSnapshot);
-    try {
-      final OmSnapshot fs = snapshotCache.get(fsKey);
-      final OmSnapshot ts = snapshotCache.get(tsKey);
-      return snapshotDiffManager.getSnapshotDiffReport(volume, bucket, fs, ts,
-              fsInfo, tsInfo, index, pageSize, forceFullDiff);
-    } catch (ExecutionException e) {
-      throw new IOException(e.getCause());
-    }
-  }
+    SnapshotDiffResponse snapshotDiffReport =
+        snapshotDiffManager.getSnapshotDiffReport(volume, bucket,
+            fromSnapshot, toSnapshot, index, pageSize, forceFullDiff);
 
-  private void verifySnapshotInfoForSnapDiff(final SnapshotInfo fromSnapshot,
-                                             final SnapshotInfo toSnapshot)
-      throws IOException {
-    if ((fromSnapshot.getSnapshotStatus() != SnapshotStatus.SNAPSHOT_ACTIVE) ||
-        (toSnapshot.getSnapshotStatus() != SnapshotStatus.SNAPSHOT_ACTIVE)) {
-      // TODO: [SNAPSHOT] Throw custom snapshot exception.
-      throw new IOException("Cannot generate snapshot diff for non-active " +
-          "snapshots.");
-    }
-    if (fromSnapshot.getCreationTime() > toSnapshot.getCreationTime()) {
-      throw new IOException("fromSnapshot:" + fromSnapshot.getName() +
-          " should be older than to toSnapshot:" + toSnapshot.getName());
-    }
+    // Check again to make sure that from and to snapshots are still active and
+    // were not deleted in between response generation.
+    // Ideally, snapshot diff and snapshot deletion should take an explicit lock
+    // to achieve the synchronization, but it would be complex and expensive.
+    // To avoid the complexity, we just check that snapshots are active
+    // before returning the response. It is like an optimistic lock to achieve
+    // similar behaviour and make sure client gets consistent response.
+    validateSnapshotsExistAndActive(ozoneManager, volume, bucket, fromSnapshot,
+        toSnapshot);
+    return snapshotDiffReport;
   }
 
   private int getIndexFromToken(final String token) throws IOException {


### PR DESCRIPTION
## What changes were proposed in this pull request?
This change is to add the from and to snapshots are active before returning diff report page to the client to achieve synchronization between snapshot diff response generation and snapshot deletion. Also added the same check in diff report generation to fail fast if form, to or both snapshot/s get/s deleted in report generation because it is long running task.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-8390

## How was this patch tested?
Existing snapshot integration tests.
