### PR TITLE
HDDS-8417. Cap on queue of commands at DN

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/DatanodeConfiguration.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/DatanodeConfiguration.java
@@ -161,7 +161,8 @@ public class DatanodeConfiguration {
       type = ConfigType.INT,
       defaultValue = "5000",
       tags = {DATANODE},
-      description = "The maximum number of commands queued on a datanode"
+      description = "The default maximum number of commands in the queue " +
+          "and command type's sub-queue on a datanode"
   )
   private int cmdQueueLimit = 5000;
 

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/DatanodeConfiguration.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/DatanodeConfiguration.java
@@ -146,12 +146,24 @@ public class DatanodeConfiguration {
    */
   @Config(key = "block.delete.queue.limit",
       type = ConfigType.INT,
-      defaultValue = "1440",
+      defaultValue = "5",
       tags = {DATANODE},
       description = "The maximum number of block delete commands queued on " +
           " a datanode"
   )
-  private int blockDeleteQueueLimit = 60 * 24;
+  private int blockDeleteQueueLimit = 5;
+
+  /**
+   * The maximum number of commands in queued list.
+   * if the commands limit crosses limit, then command will be ignored.
+   */
+  @Config(key = "command.queue.limit",
+      type = ConfigType.INT,
+      defaultValue = "5000",
+      tags = {DATANODE},
+      description = "The maximum number of commands queued on a datanode"
+  )
+  private int cmdQueueLimit = 5000;
 
   @Config(key = "block.deleting.service.interval",
           defaultValue = "60s",
@@ -548,6 +560,14 @@ public class DatanodeConfiguration {
 
   public void setBlockDeleteQueueLimit(int queueLimit) {
     this.blockDeleteQueueLimit = queueLimit;
+  }
+
+  public int getCommandQueueLimit() {
+    return cmdQueueLimit;
+  }
+
+  public void setCommandQueueLimit(int queueLimit) {
+    this.cmdQueueLimit = queueLimit;
   }
 
   public boolean isChunkDataValidationCheck() {

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/DatanodeStateMachine.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/DatanodeStateMachine.java
@@ -196,7 +196,8 @@ public class DatanodeStateMachine implements Closeable {
 
     ReplicationConfig replicationConfig =
         conf.getObject(ReplicationConfig.class);
-    supervisor = new ReplicationSupervisor(context, replicationConfig, clock);
+    supervisor = new ReplicationSupervisor(context, replicationConfig, clock,
+        dnConf.getCommandQueueLimit());
 
     replicationSupervisorMetrics =
         ReplicationSupervisorMetrics.create(supervisor);
@@ -210,7 +211,7 @@ public class DatanodeStateMachine implements Closeable {
     // a test. The test mocks it in a running mini-cluster.
     reconstructECContainersCommandHandler =
         new ReconstructECContainersCommandHandler(conf, supervisor,
-        ecReconstructionCoordinator, dnConf.getCommandQueueLimit());
+        ecReconstructionCoordinator);
     // When we add new handlers just adding a new handler here should do the
     // trick.
     commandDispatcher = CommandDispatcher.newBuilder()
@@ -219,8 +220,7 @@ public class DatanodeStateMachine implements Closeable {
             conf, dnConf.getBlockDeleteThreads(),
             dnConf.getBlockDeleteQueueLimit()))
         .addHandler(new ReplicateContainerCommandHandler(conf, supervisor,
-            pullReplicatorWithMetrics, pushReplicatorWithMetrics,
-            dnConf.getCommandQueueLimit()))
+            pullReplicatorWithMetrics, pushReplicatorWithMetrics))
         .addHandler(reconstructECContainersCommandHandler)
         .addHandler(new DeleteContainerCommandHandler(
             dnConf.getContainerDeleteThreads(), clock,

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/DatanodeStateMachine.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/DatanodeStateMachine.java
@@ -210,7 +210,7 @@ public class DatanodeStateMachine implements Closeable {
     // a test. The test mocks it in a running mini-cluster.
     reconstructECContainersCommandHandler =
         new ReconstructECContainersCommandHandler(conf, supervisor,
-        ecReconstructionCoordinator);
+        ecReconstructionCoordinator, dnConf.getCommandQueueLimit());
     // When we add new handlers just adding a new handler here should do the
     // trick.
     commandDispatcher = CommandDispatcher.newBuilder()
@@ -219,10 +219,12 @@ public class DatanodeStateMachine implements Closeable {
             conf, dnConf.getBlockDeleteThreads(),
             dnConf.getBlockDeleteQueueLimit()))
         .addHandler(new ReplicateContainerCommandHandler(conf, supervisor,
-            pullReplicatorWithMetrics, pushReplicatorWithMetrics))
+            pullReplicatorWithMetrics, pushReplicatorWithMetrics,
+            dnConf.getCommandQueueLimit()))
         .addHandler(reconstructECContainersCommandHandler)
         .addHandler(new DeleteContainerCommandHandler(
-            dnConf.getContainerDeleteThreads(), clock))
+            dnConf.getContainerDeleteThreads(), clock,
+            dnConf.getCommandQueueLimit()))
         .addHandler(new ClosePipelineCommandHandler())
         .addHandler(new CreatePipelineCommandHandler(conf))
         .addHandler(new SetNodeOperationalStateCommandHandler(conf))

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/StateContext.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/StateContext.java
@@ -152,6 +152,8 @@ public class StateContext {
   private final AtomicLong heartbeatFrequency = new AtomicLong(2000);
 
   private final AtomicLong reconHeartbeatFrequency = new AtomicLong(2000);
+  
+  private final int maxCommandQueueLimit;
   /**
    * Constructs a StateContext.
    *
@@ -163,6 +165,9 @@ public class StateContext {
       DatanodeStateMachine.DatanodeStates
           state, DatanodeStateMachine parent) {
     this.conf = conf;
+    DatanodeConfiguration dnConf =
+        conf.getObject(DatanodeConfiguration.class);
+    maxCommandQueueLimit = dnConf.getCommandQueueLimit();
     this.state = state;
     this.parentDatanodeStateMachine = parent;
     commandQueue = new LinkedList<>();
@@ -795,6 +800,11 @@ public class StateContext {
   public void addCommand(SCMCommand command) {
     lock.lock();
     try {
+      if (commandQueue.size() > maxCommandQueueLimit) {
+        LOG.warn("Ignore command as command queue crosses max limit %d.",
+            maxCommandQueueLimit);
+        return;
+      }
       updateTermOfLeaderSCM(command);
       commandQueue.add(command);
     } finally {

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/StateContext.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/StateContext.java
@@ -800,8 +800,8 @@ public class StateContext {
   public void addCommand(SCMCommand command) {
     lock.lock();
     try {
-      if (commandQueue.size() > maxCommandQueueLimit) {
-        LOG.warn("Ignore command as command queue crosses max limit %d.",
+      if (commandQueue.size() >= maxCommandQueueLimit) {
+        LOG.warn("Ignore command as command queue crosses max limit {}.",
             maxCommandQueueLimit);
         return;
       }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/DeleteContainerCommandHandler.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/DeleteContainerCommandHandler.java
@@ -37,7 +37,6 @@ import java.io.IOException;
 import java.time.Clock;
 import java.util.OptionalLong;
 import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/DeleteContainerCommandHandler.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/DeleteContainerCommandHandler.java
@@ -85,8 +85,8 @@ public class DeleteContainerCommandHandler implements CommandHandler {
       executor.execute(() ->
           handleInternal(command, context, deleteContainerCommand, controller));
     } catch (RejectedExecutionException ex) {
-      LOG.warn("Delete Container command is received for container %s "
-          + "is ignored as command queue reach max size %d.",
+      LOG.warn("Delete Container command is received for container {} "
+          + "is ignored as command queue reach max size {}.",
           deleteContainerCommand.getContainerID(), maxQueueSize);
     }
   }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/DeleteContainerCommandHandler.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/DeleteContainerCommandHandler.java
@@ -64,14 +64,15 @@ public class DeleteContainerCommandHandler implements CommandHandler {
         0L, TimeUnit.MILLISECONDS,
         new LinkedBlockingQueue<>(queueSize),
         new ThreadFactoryBuilder()
-            .setNameFormat("DeleteContainerThread-%d").build()));
-    maxQueueSize = queueSize;
+            .setNameFormat("DeleteContainerThread-%d").build()),
+        queueSize);
   }
 
   protected DeleteContainerCommandHandler(Clock clock,
-      ExecutorService executor) {
+      ExecutorService executor, int queueSize) {
     this.executor = executor;
     this.clock = clock;
+    maxQueueSize = queueSize;
   }
   @Override
   public void handle(final SCMCommand command,

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/ReconstructECContainersCommandHandler.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/ReconstructECContainersCommandHandler.java
@@ -40,18 +40,15 @@ public class ReconstructECContainersCommandHandler implements CommandHandler {
 
   private final ReplicationSupervisor supervisor;
   private final ECReconstructionCoordinator coordinator;
-  private int maxQueueSize;
   private final ConfigurationSource conf;
 
   public ReconstructECContainersCommandHandler(
       ConfigurationSource conf,
       ReplicationSupervisor supervisor,
-      ECReconstructionCoordinator coordinator,
-      int queueSize) {
+      ECReconstructionCoordinator coordinator) {
     this.conf = conf;
     this.supervisor = supervisor;
     this.coordinator = coordinator;
-    maxQueueSize = queueSize;
   }
 
   @Override
@@ -61,13 +58,6 @@ public class ReconstructECContainersCommandHandler implements CommandHandler {
         (ReconstructECContainersCommand) command;
     ECReconstructionCommandInfo reconstructionCommandInfo =
         new ECReconstructionCommandInfo(ecContainersCommand);
-    if (supervisor.getQueueSize() > maxQueueSize) {
-      LOG.warn("ECReconstruction command is received for container %s "
-              + "is ignored as command queue reach max size %d.",
-          reconstructionCommandInfo.getContainerID(),
-          maxQueueSize);
-      return;
-    }
     this.supervisor.addTask(new ECReconstructionCoordinatorTask(
         coordinator, reconstructionCommandInfo));
   }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/ReconstructECContainersCommandHandler.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/ReconstructECContainersCommandHandler.java
@@ -28,22 +28,16 @@ import org.apache.hadoop.ozone.container.ozoneimpl.OzoneContainer;
 import org.apache.hadoop.ozone.container.replication.ReplicationSupervisor;
 import org.apache.hadoop.ozone.protocol.commands.ReconstructECContainersCommand;
 import org.apache.hadoop.ozone.protocol.commands.SCMCommand;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * Command handler for reconstructing the lost EC containers.
  */
 public class ReconstructECContainersCommandHandler implements CommandHandler {
-  static final Logger LOG =
-      LoggerFactory.getLogger(ReconstructECContainersCommandHandler.class);
-
   private final ReplicationSupervisor supervisor;
   private final ECReconstructionCoordinator coordinator;
   private final ConfigurationSource conf;
 
-  public ReconstructECContainersCommandHandler(
-      ConfigurationSource conf,
+  public ReconstructECContainersCommandHandler(ConfigurationSource conf,
       ReplicationSupervisor supervisor,
       ECReconstructionCoordinator coordinator) {
     this.conf = conf;

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/ReplicateContainerCommandHandler.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/ReplicateContainerCommandHandler.java
@@ -54,19 +54,16 @@ public class ReplicateContainerCommandHandler implements CommandHandler {
   private ContainerReplicator downloadReplicator;
 
   private ContainerReplicator pushReplicator;
-  private int maxQueueSize;
 
   public ReplicateContainerCommandHandler(
       ConfigurationSource conf,
       ReplicationSupervisor supervisor,
       ContainerReplicator downloadReplicator,
-      ContainerReplicator pushReplicator,
-      int queueSize) {
+      ContainerReplicator pushReplicator) {
     this.conf = conf;
     this.supervisor = supervisor;
     this.downloadReplicator = downloadReplicator;
     this.pushReplicator = pushReplicator;
-    this.maxQueueSize = queueSize;
   }
 
   @Override
@@ -83,13 +80,6 @@ public class ReplicateContainerCommandHandler implements CommandHandler {
     Preconditions.checkArgument(!sourceDatanodes.isEmpty() || target != null,
         "Replication command is received for container %s "
             + "without source or target datanodes.", containerID);
-    
-    if (supervisor.getQueueSize() > maxQueueSize) {
-      LOG.warn("Replication command is received for container %s "
-          + "is ignored as command queue reach max size %d.", containerID,
-          maxQueueSize);
-      return;
-    }
 
     ContainerReplicator replicator =
         replicateCommand.getTargetDatanode() == null ?

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/replication/ReplicationSupervisor.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/replication/ReplicationSupervisor.java
@@ -107,9 +107,9 @@ public class ReplicationSupervisor {
    * Queue an asynchronous download of the given container.
    */
   public void addTask(AbstractReplicationTask task) {
-    if (getQueueSize() > maxQueueSize) {
-      LOG.warn("Replication supervisor receive command for container %s "
-              + "is ignored as command queue reach max size %d.",
+    if (getQueueSize() >= maxQueueSize) {
+      LOG.warn("Replication supervisor receive command for container {} "
+              + "is ignored as command queue reach max size {}.",
           task.getContainerId(), maxQueueSize);
       return;
     }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/replication/ReplicationSupervisor.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/replication/ReplicationSupervisor.java
@@ -107,10 +107,10 @@ public class ReplicationSupervisor {
    * Queue an asynchronous download of the given container.
    */
   public void addTask(AbstractReplicationTask task) {
-    if (getQueueSize() >= maxQueueSize) {
-      LOG.warn("Replication supervisor receive command for container {} "
-              + "is ignored as command queue reach max size {}.",
-          task.getContainerId(), maxQueueSize);
+    if (getTotalInFlightReplications() >= maxQueueSize) {
+      LOG.warn("Ignored {} command for container {} in Replication Supervisor"
+              + "as queue reached max size of {}.",
+          task.getClass(), task.getContainerId(), maxQueueSize);
       return;
     }
     if (inFlight.add(task)) {

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/statemachine/TestStateContext.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/statemachine/TestStateContext.java
@@ -477,7 +477,8 @@ public class TestStateContext {
 
   @Test
   public void testIsThreadPoolAvailable() throws Exception {
-    StateContext stateContext = new StateContext(new OzoneConfiguration(), null, null);
+    StateContext stateContext = new StateContext(
+        new OzoneConfiguration(), null, null);
 
     int threadPoolSize = 2;
     ExecutorService executorService = Executors.newFixedThreadPool(

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/statemachine/TestStateContext.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/statemachine/TestStateContext.java
@@ -477,7 +477,7 @@ public class TestStateContext {
 
   @Test
   public void testIsThreadPoolAvailable() throws Exception {
-    StateContext stateContext = new StateContext(null, null, null);
+    StateContext stateContext = new StateContext(new OzoneConfiguration(), null, null);
 
     int threadPoolSize = 2;
     ExecutorService executorService = Executors.newFixedThreadPool(

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/TestDeleteContainerCommandHandler.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/TestDeleteContainerCommandHandler.java
@@ -35,7 +35,6 @@ import java.time.ZoneId;
 import java.util.OptionalLong;
 
 import static com.google.common.util.concurrent.MoreExecutors.newDirectExecutorService;
-import static org.mockito.Mockito.atMost;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/replication/ReplicationSupervisorScheduling.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/replication/ReplicationSupervisorScheduling.java
@@ -128,39 +128,4 @@ public class ReplicationSupervisorScheduling {
     Assertions.assertTrue(executionTime < 100_000,
         "Execution was too slow : " + executionTime + " ms");
   }
-
-  @Test
-  public void testMaxQueueSize() throws InterruptedException {
-    OzoneConfiguration conf = new OzoneConfiguration();
-    ReplicationServer.ReplicationConfig replicationConfig
-        = conf.getObject(ReplicationServer.ReplicationConfig.class);
-    List<DatanodeDetails> datanodes = new ArrayList<>();
-    datanodes.add(MockDatanodeDetails.randomDatanodeDetails());
-    datanodes.add(MockDatanodeDetails.randomDatanodeDetails());
-
-    Integer[] count = new Integer[1];
-    count[0] = 0;
-    ContainerReplicator replicator = task -> {
-      try {
-        count[0]++;
-        Thread.sleep(2000);
-      } catch (InterruptedException e) {
-        // no log
-      }
-    };
-
-    ReplicationSupervisor rs = new ReplicationSupervisor(null,
-        replicationConfig, Clock.system(ZoneId.systemDefault()), 2);
-
-    //schedule 100 container replication
-    for (int i = 0; i < 100; i++) {
-      List<DatanodeDetails> sources = new ArrayList<>();
-      sources.add(datanodes.get(random.nextInt(datanodes.size())));
-      rs.addTask(new ReplicationTask(fromSources(i, sources), replicator));
-    }
-    rs.shutdownAfterFinish();
-    // range is checked to handle flaky if execution takes more time
-    // due to task addition slowness
-    Assertions.assertTrue(count[0] <= 20);
-  }
 }

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/replication/ReplicationSupervisorScheduling.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/replication/ReplicationSupervisorScheduling.java
@@ -111,7 +111,7 @@ public class ReplicationSupervisorScheduling {
     };
 
     ReplicationSupervisor rs = new ReplicationSupervisor(null,
-        replicationConfig, Clock.system(ZoneId.systemDefault()));
+        replicationConfig, Clock.system(ZoneId.systemDefault()), 1000);
 
     final long start = System.currentTimeMillis();
 

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/replication/TestReplicationSupervisor.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/replication/TestReplicationSupervisor.java
@@ -282,7 +282,8 @@ public class TestReplicationSupervisor {
   @Test
   public void testDownloadAndImportReplicatorFailure() throws IOException {
     ReplicationSupervisor supervisor =
-        new ReplicationSupervisor(context, newDirectExecutorService(), clock);
+        new ReplicationSupervisor(context, newDirectExecutorService(),
+            clock, 1000);
 
     OzoneConfiguration conf = new OzoneConfiguration();
     // Mock to fetch an exception in the importContainer method.
@@ -397,7 +398,7 @@ public class TestReplicationSupervisor {
         conf.getObject(ReplicationServer.ReplicationConfig.class);
     repConf.setReplicationMaxStreams(1);
     ReplicationSupervisor supervisor =
-        new ReplicationSupervisor(null, repConf, clock);
+        new ReplicationSupervisor(null, repConf, clock, 1000);
 
     final CountDownLatch indicateRunning = new CountDownLatch(1);
     final CountDownLatch completeRunning = new CountDownLatch(1);
@@ -511,7 +512,7 @@ public class TestReplicationSupervisor {
       Function<ReplicationSupervisor, ContainerReplicator> replicatorFactory,
       ExecutorService executor) {
     ReplicationSupervisor supervisor =
-        new ReplicationSupervisor(context, executor, clock);
+        new ReplicationSupervisor(context, executor, clock, 1000);
     replicatorRef.set(replicatorFactory.apply(supervisor));
     return supervisor;
   }

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/replication/TestReplicationSupervisor.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/replication/TestReplicationSupervisor.java
@@ -27,6 +27,7 @@ import java.util.Collections;
 import java.time.Instant;
 import java.time.ZoneId;
 import java.util.List;
+import java.util.Random;
 import java.util.UUID;
 import java.util.concurrent.AbstractExecutorService;
 import java.util.concurrent.CountDownLatch;
@@ -35,6 +36,8 @@ import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.Function;
 
 import org.apache.hadoop.hdds.client.ECReplicationConfig;
@@ -64,6 +67,7 @@ import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.mockito.Mockito;
@@ -73,6 +77,7 @@ import javax.annotation.Nonnull;
 import static com.google.common.util.concurrent.MoreExecutors.newDirectExecutorService;
 import static java.util.Collections.emptyList;
 import static org.apache.hadoop.ozone.container.replication.AbstractReplicationTask.Status.DONE;
+import static org.apache.hadoop.ozone.protocol.commands.ReplicateContainerCommand.fromSources;
 import static org.junit.jupiter.api.Assertions.fail;
 import static org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.ReplicationCommandPriority.LOW;
 import static org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.ReplicationCommandPriority.NORMAL;
@@ -636,5 +641,47 @@ public class TestReplicationSupervisor {
     public void execute(@Nonnull Runnable command) {
       // ignore all tasks
     }
+  }
+
+  @Test
+  public void testMaxQueueSize() throws InterruptedException {
+    OzoneConfiguration conf = new OzoneConfiguration();
+    ReplicationServer.ReplicationConfig replicationConfig
+        = conf.getObject(ReplicationServer.ReplicationConfig.class);
+    List<DatanodeDetails> datanodes = new ArrayList<>();
+    datanodes.add(MockDatanodeDetails.randomDatanodeDetails());
+    datanodes.add(MockDatanodeDetails.randomDatanodeDetails());
+
+    Integer[] count = new Integer[1];
+    count[0] = 0;
+    Lock lock = new ReentrantLock();
+
+    ReplicationSupervisor rs = new ReplicationSupervisor(null,
+        replicationConfig, Clock.system(ZoneId.systemDefault()), 2);
+
+    ContainerReplicator replicator = task -> {
+      try {
+        count[0]++;
+        lock.lock();
+      } finally {
+        lock.unlock();
+      }
+    };
+
+    lock.lock();
+    try {
+      //schedule 100 container replication
+      Random random = new Random();
+      for (int i = 0; i < 100; i++) {
+        List<DatanodeDetails> sources = new ArrayList<>();
+        sources.add(datanodes.get(random.nextInt(datanodes.size())));
+        rs.addTask(new ReplicationTask(fromSources(i, sources), replicator));
+      }
+      // in progress task will be 2
+      Assertions.assertTrue(count[0] == 2);
+    } finally {
+      lock.unlock();
+    }
+    rs.shutdownAfterFinish();
   }
 }

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/ClosedContainerReplicator.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/ClosedContainerReplicator.java
@@ -99,14 +99,14 @@ public class ClosedContainerReplicator extends BaseFreonGenerator implements
       checkDestinationDirectory(dir);
     }
 
-    //logic same as the download+import on the destination datanode
-    initializeReplicationSupervisor(conf);
-
     final ContainerOperationClient containerOperationClient =
         new ContainerOperationClient(conf);
 
     final List<ContainerInfo> containerInfos =
         containerOperationClient.listContainer(0L, 1_000_000);
+
+    //logic same as the download+import on the destination datanode
+    initializeReplicationSupervisor(conf, containerInfos.size() * 2);
 
     replicationTasks = new ArrayList<>();
 
@@ -169,8 +169,8 @@ public class ClosedContainerReplicator extends BaseFreonGenerator implements
   }
 
   @NotNull
-  private void initializeReplicationSupervisor(ConfigurationSource conf)
-      throws IOException {
+  private void initializeReplicationSupervisor(
+      ConfigurationSource conf, int queueSize) throws IOException {
     String fakeDatanodeUuid = datanode;
 
     if (fakeDatanodeUuid.isEmpty()) {
@@ -212,7 +212,7 @@ public class ClosedContainerReplicator extends BaseFreonGenerator implements
     ReplicationServer.ReplicationConfig replicationConfig
         = conf.getObject(ReplicationServer.ReplicationConfig.class);
     supervisor = new ReplicationSupervisor(null, replicationConfig,
-        Clock.system(ZoneId.systemDefault()));
+        Clock.system(ZoneId.systemDefault()), queueSize);
   }
 
   private void replicateContainer(long counter) throws Exception {


### PR DESCRIPTION
## What changes were proposed in this pull request?

- Block Delete Command queue cap to 5
- Other queue is capped to 5000

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-8417

## How was this patch tested?

Impact is tested using existing UT and integration test
