### PR TITLE
HDDS-8433. Intermittent failure in TestOzoneManagerSnapshotAcl

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/snapshot/TestOzoneManagerSnapshotAcl.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/snapshot/TestOzoneManagerSnapshotAcl.java
@@ -49,7 +49,6 @@ import org.apache.hadoop.ozone.om.helpers.SnapshotInfo;
 import org.apache.hadoop.ozone.security.acl.OzoneObj;
 import org.apache.hadoop.ozone.security.acl.OzoneObjInfo;
 import org.apache.hadoop.security.UserGroupInformation;
-import org.apache.ozone.test.tag.Flaky;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
@@ -73,7 +72,6 @@ import static org.junit.jupiter.params.provider.Arguments.arguments;
  * Test for Snapshot feature with ACL.
  */
 @Timeout(value = 300)
-@Flaky("HDDS-8433")
 public class TestOzoneManagerSnapshotAcl {
 
   private static final String ADMIN_USER = "om";

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/snapshot/TestOzoneManagerSnapshotAcl.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/snapshot/TestOzoneManagerSnapshotAcl.java
@@ -51,7 +51,6 @@ import org.apache.hadoop.ozone.security.acl.OzoneObjInfo;
 import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.ozone.test.tag.Flaky;
 import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Timeout;
@@ -109,7 +108,7 @@ public class TestOzoneManagerSnapshotAcl {
     conf.setBoolean(OZONE_ACL_ENABLED, true);
     conf.set(OZONE_ACL_AUTHORIZER_CLASS, OZONE_ACL_AUTHORIZER_CLASS_NATIVE);
     final String omServiceId = "om-service-test-1"
-        + RandomStringUtils.randomNumeric(5);
+        + RandomStringUtils.randomNumeric(32);
 
     cluster = MiniOzoneCluster.newOMHABuilder(conf)
         .setClusterId(UUID.randomUUID().toString())
@@ -137,11 +136,6 @@ public class TestOzoneManagerSnapshotAcl {
     // stop the deletion services so that keys can still be read
     keyManager.stop();
     OMStorage.getOmDbDir(ozoneManagerConf);
-  }
-
-  @AfterEach
-  public void cleanup() throws IOException {
-    setDefaultAcls();
   }
 
   @AfterAll
@@ -458,7 +452,7 @@ public class TestOzoneManagerSnapshotAcl {
 
   private void createKey(OzoneBucket bucket)
       throws IOException {
-    keyName = KEY_PREFIX + RandomStringUtils.randomNumeric(5);
+    keyName = KEY_PREFIX + RandomStringUtils.randomNumeric(32);
     byte[] data = RandomStringUtils.randomAscii(1).getBytes(UTF_8);
     final OzoneOutputStream fileKey = bucket.createKey(keyName, data.length);
     fileKey.write(data);
@@ -469,7 +463,7 @@ public class TestOzoneManagerSnapshotAcl {
       throws IOException {
     final String snapshotPrefix = "snapshot-";
     final String snapshotName =
-        snapshotPrefix + RandomStringUtils.randomNumeric(5);
+        snapshotPrefix + RandomStringUtils.randomNumeric(32);
     objectStore.createSnapshot(volumeName, bucketName, snapshotName);
     snapshotKeyPrefix = OmSnapshotManager
         .getSnapshotPrefix(snapshotName);
@@ -527,7 +521,7 @@ public class TestOzoneManagerSnapshotAcl {
   private void createBucket(BucketLayout bucketLayout,
       OzoneVolume volume) throws IOException {
     final String bucketPrefix = "bucket-";
-    bucketName = bucketPrefix + RandomStringUtils.randomNumeric(5);
+    bucketName = bucketPrefix + RandomStringUtils.randomNumeric(32);
     final BucketArgs bucketArgs = BucketArgs.newBuilder()
         .setOwner(ADMIN)
         .setBucketLayout(bucketLayout).build();
@@ -536,7 +530,7 @@ public class TestOzoneManagerSnapshotAcl {
 
   private void createVolume() throws IOException {
     final String volumePrefix = "volume-";
-    volumeName = volumePrefix + RandomStringUtils.randomNumeric(5);
+    volumeName = volumePrefix + RandomStringUtils.randomNumeric(32);
     final VolumeArgs volumeArgs = new VolumeArgs.Builder()
         .setAdmin(ADMIN)
         .setOwner(ADMIN)


### PR DESCRIPTION
## What changes were proposed in this pull request?
Fix for a flaky test. Instead of `RandomStringUtils.randomNumeric(5)`, `RandomStringUtils.randomNumeric(32)` is used and unecessary `cleanup()` method is removed. 

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-8433

## How was this patch tested?
[GitHub action](https://github.com/mladjan-gadzic/ozone/actions/workflows/HDDS-8433.yml?page=2) was created that executed one test multiple times. Since #37 run GitHub action was running on latest changes without an intermittent failure. Prior to that it was running on old codebase and it was confirmed that test was flaky.
