### PR TITLE
HDDS-8495. Fix permissions and path handling for ozone sh token get command

### DIFF
--- a/hadoop-ozone/dist/src/main/smoketest/security/ozone-secure-token.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/security/ozone-secure-token.robot
@@ -36,8 +36,8 @@ Get and use Token in Secure Cluster
     Run Keyword                  Kinit test user     testuser  testuser.keytab
 
 Get Token in Unsecure Cluster
-    ${output} =                  Execute             ozone sh token get
-    Should Contain               ${output}           ozone sh token get
+    ${output} =                  Execute             ozone sh token get -t /tmp/ozone.token
+    Should Contain               ${output}           ozone sh token get -t /tmp/ozone.token
     Should Contain               ${output}           only when security is enabled
 
 # should be executed after Get Token

--- a/hadoop-ozone/dist/src/main/smoketest/security/ozone-secure-token.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/security/ozone-secure-token.robot
@@ -37,7 +37,7 @@ Get and use Token in Secure Cluster
 
 Get Token in Unsecure Cluster
     ${output} =                  Execute             ozone sh token get -t /tmp/ozone.token
-    Should Contain               ${output}           ozone sh token get -t /tmp/ozone.token
+    Should Contain               ${output}           ozone sh token get
     Should Contain               ${output}           only when security is enabled
 
 # should be executed after Get Token

--- a/hadoop-ozone/dist/src/main/smoketest/security/ozone-secure-token.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/security/ozone-secure-token.robot
@@ -42,7 +42,7 @@ Get Token in Unsecure Cluster
 
 # should be executed after Get Token
 Print Valid Token File
-    ${output} =                  Execute             ozone sh token print
+    ${output} =                  Execute             ozone sh token print -t ./ozone.token
     Should Not Be Empty          ${output}
 
 Print Nonexistent Token File
@@ -50,20 +50,20 @@ Print Nonexistent Token File
     Should Contain               ${output}           operation failed as token file: /asdf
 
 Renew Token in Secure Cluster
-    ${output} =                  Execute             ozone sh token renew
+    ${output} =                  Execute             ozone sh token renew -t ./ozone.token
     Should contain               ${output}           Token renewed successfully
 
 Renew Token in Unsecure Cluster
-    ${output} =                  Execute             ozone sh token renew
+    ${output} =                  Execute             ozone sh token renew -t ./ozone.token
     Should Contain               ${output}           ozone sh token renew
     Should Contain               ${output}           only when security is enabled
 
 Cancel Token in Secure Cluster
-    ${output} =                  Execute             ozone sh token cancel
+    ${output} =                  Execute             ozone sh token cancel -t ./ozone.token
     Should contain               ${output}           Token canceled successfully
 
 Cancel Token in Unsecure Cluster
-    ${output} =                  Execute             ozone sh token cancel
+    ${output} =                  Execute             ozone sh token cancel -t ./ozone.token
     Should Contain               ${output}           ozone sh token cancel
     Should Contain               ${output}           only when security is enabled
 

--- a/hadoop-ozone/dist/src/main/smoketest/security/ozone-secure-token.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/security/ozone-secure-token.robot
@@ -24,10 +24,10 @@ Test Timeout        5 minutes
 *** Keywords ***
 Get and use Token in Secure Cluster
     Run Keyword   Kinit test user     testuser     testuser.keytab
-    Execute                      ozone sh token get -t /tmp/ozone.token
-    File Should Not Be Empty     /tmp/ozone.token
+    Execute                      ozone sh token get -t ./ozone.token
+    File Should Not Be Empty     ./ozone.token
     Execute                      kdestroy
-    Set Environment Variable     HADOOP_TOKEN_FILE_LOCATION    /tmp/ozone.token
+    Set Environment Variable     HADOOP_TOKEN_FILE_LOCATION    ./ozone.token
     ${output} =                  Execute             ozone sh volume list /
     Should not contain           ${output}           Client cannot authenticate
     Remove Environment Variable  HADOOP_TOKEN_FILE_LOCATION
@@ -36,7 +36,7 @@ Get and use Token in Secure Cluster
     Run Keyword                  Kinit test user     testuser  testuser.keytab
 
 Get Token in Unsecure Cluster
-    ${output} =                  Execute             ozone sh token get -t /tmp/ozone.token
+    ${output} =                  Execute             ozone sh token get -t ./ozone.token
     Should Contain               ${output}           ozone sh token get
     Should Contain               ${output}           only when security is enabled
 

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/token/GetTokenHandler.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/token/GetTokenHandler.java
@@ -28,6 +28,10 @@ import org.apache.hadoop.ozone.shell.Shell;
 import org.apache.hadoop.security.token.Token;
 import picocli.CommandLine;
 import picocli.CommandLine.Command;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.attribute.PosixFilePermissions;
 
 import java.io.IOException;
 import java.util.Objects;
@@ -74,5 +78,10 @@ public class GetTokenHandler extends Handler {
       out().println(token.toString());
       tokenFile.persistToken(token);
     }
+
+    // Set file permission to be readable by only the user who owns the file
+    Path tokenFilePath = Paths.get(tokenFile.getTokenFilePath());
+    Files.setPosixFilePermissions(tokenFilePath,
+        PosixFilePermissions.fromString("rw-------"));
   }
 }

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/token/TokenOption.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/token/TokenOption.java
@@ -36,9 +36,8 @@ import java.io.IOException;
 public class TokenOption {
 
   @CommandLine.Option(names = {"--token", "-t"},
-      description = "file containing encoded token",
-      defaultValue = "/tmp/ozone.token",
-      showDefaultValue = CommandLine.Help.Visibility.ALWAYS)
+      required = true,
+      description = "file containing encoded token")
   private File tokenFile;
 
   public boolean exists() {
@@ -76,5 +75,9 @@ public class TokenOption {
             " successfully!");
       }
     }
+  }
+
+  public String getTokenFilePath() {
+    return tokenFile.getAbsolutePath();
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

The CLI command: `ozone sh token get` does a few things wrong:

1. Writes to `/tmp/ozone.token` and the permissions allow another user to read it.
2. A second user cannot run the command as the `/tmp` folder does not allow another user to delete the file.

We will require a fix that would:

1. Require the user to enter the path to which the token will be written.
2. Set the permission for the file to be readable by only the user who owns the file.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-8495

## How was this patch tested?

- Existing Robot tests. 
- The patch has also been tested over a cluster with the basic Ozone services running.
- Green Git CI/CD: https://github.com/tanvipenumudy/ozone/actions/runs/4817911817/

