### PR TITLE
HDDS-8499. Add mechanism to notify threads when OM double buffer flushed.

### DIFF
--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/OzoneManagerDoubleBuffer.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/OzoneManagerDoubleBuffer.java
@@ -271,7 +271,8 @@ public final class OzoneManagerDoubleBuffer {
    * Runs in a background thread and batches the transaction in currentBuffer
    * and commit to DB.
    */
-  private void flushTransactions() {
+  @VisibleForTesting
+  void flushTransactions() {
     while (isRunning.get() && canFlush()) {
       flushCurrentBuffer();
     }
@@ -681,11 +682,6 @@ public final class OzoneManagerDoubleBuffer {
   @VisibleForTesting
   int getReadyBufferSize() {
     return readyBuffer.size();
-  }
-
-  @VisibleForTesting
-  void pause() {
-    isRunning.set(false);
   }
 
   @VisibleForTesting

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/OzoneManagerDoubleBuffer.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/OzoneManagerDoubleBuffer.java
@@ -186,7 +186,7 @@ public final class OzoneManagerDoubleBuffer {
       OzoneManagerRatisSnapshot ozoneManagerRatisSnapShot,
       boolean isRatisEnabled, boolean isTracingEnabled,
       Function<Long, Long> indexToTerm, int maxUnFlushedTransactions,
-                                   FlushNotifier flushNotifier) {
+      FlushNotifier flushNotifier) {
     this.currentBuffer = new ConcurrentLinkedQueue<>();
     this.readyBuffer = new ConcurrentLinkedQueue<>();
     this.isRatisEnabled = isRatisEnabled;

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/OzoneManagerDoubleBuffer.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/OzoneManagerDoubleBuffer.java
@@ -631,14 +631,14 @@ public final class OzoneManagerDoubleBuffer {
     try {
       while (currentBuffer.size() == 0) {
         wait(1000L);
-        if  (currentBuffer.size() == 0) {
+        if (currentBuffer.size() == 0) {
           // Both buffers are empty, so notify twice
           flushNotifier.notifyFlush();
           flushNotifier.notifyFlush();
         }
       }
       return true;
-    }  catch (InterruptedException ex) {
+    } catch (InterruptedException ex) {
       Thread.currentThread().interrupt();
       if (isRunning.get()) {
         final String message = "OMDoubleBuffer flush thread " +
@@ -708,7 +708,7 @@ public final class OzoneManagerDoubleBuffer {
 
     int notifyFlush() {
       int retval = flushLatches.size();
-      for (CountDownLatch l: flushLatches) {
+      for (CountDownLatch l : flushLatches) {
         l.countDown();
       }
       return retval;

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/OzoneManagerDoubleBuffer.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/OzoneManagerDoubleBuffer.java
@@ -630,12 +630,11 @@ public final class OzoneManagerDoubleBuffer {
   private synchronized boolean canFlush() {
     try {
       while (currentBuffer.size() == 0) {
+        // canFlush() only gets called when the readyBuffer is empty.
+        // Since both buffers are empty, notify once for each.
+        flushNotifier.notifyFlush();
+        flushNotifier.notifyFlush();
         wait(1000L);
-        if (currentBuffer.size() == 0) {
-          // Both buffers are empty, so notify twice
-          flushNotifier.notifyFlush();
-          flushNotifier.notifyFlush();
-        }
       }
       return true;
     } catch (InterruptedException ex) {

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/OzoneManagerDoubleBuffer.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/OzoneManagerDoubleBuffer.java
@@ -30,6 +30,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Queue;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentLinkedQueue;
@@ -693,9 +694,8 @@ public final class OzoneManagerDoubleBuffer {
   }
 
   static class FlushNotifier {
-    private final ConcurrentHashMap.KeySetView<CountDownLatch,
-        Boolean> flushLatches =
-        new ConcurrentHashMap<>().newKeySet();
+    private final Set<CountDownLatch> flushLatches =
+        ConcurrentHashMap.newKeySet();
 
     void await() throws InterruptedException {
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/OzoneManagerDoubleBuffer.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/OzoneManagerDoubleBuffer.java
@@ -630,7 +630,11 @@ public final class OzoneManagerDoubleBuffer {
     try {
       while (currentBuffer.size() == 0) {
         wait(1000L);
-        flushNotifier.notifyFlush();
+        if  (currentBuffer.size() == 0) {
+          // Both buffers are empty, so notify twice
+          flushNotifier.notifyFlush();
+          flushNotifier.notifyFlush();
+        }
       }
       return true;
     }  catch (InterruptedException ex) {
@@ -699,7 +703,7 @@ public final class OzoneManagerDoubleBuffer {
 
     void await() throws InterruptedException {
 
-      // wait until both the current and ready buffers are flushed
+      // Wait until both the current and ready buffers are flushed.
       CountDownLatch latch = new CountDownLatch(2);
       flushLatches.put(latch, latch);
       latch.await();

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/OzoneManagerDoubleBuffer.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/OzoneManagerDoubleBuffer.java
@@ -31,12 +31,16 @@ import java.util.List;
 import java.util.Map;
 import java.util.Queue;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Function;
 import java.util.stream.Collectors;
+
+import org.apache.hadoop.fs.shell.Count;
 import org.apache.hadoop.hdds.function.SupplierWithIOException;
 import org.apache.hadoop.hdds.tracing.TracingUtil;
 import org.apache.hadoop.hdds.utils.TransactionInfo;
@@ -54,6 +58,7 @@ import org.apache.hadoop.util.Time;
 import org.apache.ratis.util.ExitUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import sun.java2d.SurfaceDataProxy;
 
 import static org.apache.hadoop.ozone.OzoneConsts.TRANSACTION_INFO_KEY;
 
@@ -104,6 +109,8 @@ public final class OzoneManagerDoubleBuffer {
   private final boolean isRatisEnabled;
   private final boolean isTracingEnabled;
   private final Semaphore unFlushedTransactions;
+  private final ConcurrentHashMap<CountDownLatch, Object> flushLatches =
+      new ConcurrentHashMap<>();
 
   /**
    * function which will get term associated with the transaction index.
@@ -295,6 +302,7 @@ public final class OzoneManagerDoubleBuffer {
       }
 
       clearReadyBuffer();
+      notifyWaiters();
     } catch (IOException ex) {
       terminate(ex, 1);
     } catch (Throwable t) {
@@ -611,7 +619,8 @@ public final class OzoneManagerDoubleBuffer {
   private synchronized boolean canFlush() {
     try {
       while (currentBuffer.size() == 0) {
-        wait(Long.MAX_VALUE);
+        wait(1000L);
+        notifyWaiters();
       }
       return true;
     }  catch (InterruptedException ex) {
@@ -648,5 +657,20 @@ public final class OzoneManagerDoubleBuffer {
   @VisibleForTesting
   public OzoneManagerDoubleBufferMetrics getOzoneManagerDoubleBufferMetrics() {
     return ozoneManagerDoubleBufferMetrics;
+  }
+
+  void awaitFlush() throws InterruptedException {
+
+    // wait until both the current and ready buffers are flushed
+    CountDownLatch latch = new CountDownLatch(2);
+    flushLatches.put(latch, latch);
+    latch.await();
+    flushLatches.remove(latch);
+  }
+
+  void notifyWaiters() {
+    for (CountDownLatch l: flushLatches.keySet()) {
+      l.countDown();
+    }
   }
 }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/OzoneManagerStateMachine.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/OzoneManagerStateMachine.java
@@ -718,6 +718,11 @@ public class OzoneManagerStateMachine extends BaseStateMachine {
     return applyTransactionMap.get(transactionIndex);
   }
 
+  /**
+   * Wait until both buffers are flushed.  This is used in cases like
+   * "follower bootstrap tarball creation" where the rocksDb for the active
+   * fs needs to synchronized with the rocksdb's for the snapshots.
+   */
   public void awaitDoubleBufferFlush() throws InterruptedException {
     ozoneManagerDoubleBuffer.awaitFlush();
   }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/OzoneManagerStateMachine.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/OzoneManagerStateMachine.java
@@ -718,4 +718,7 @@ public class OzoneManagerStateMachine extends BaseStateMachine {
     return applyTransactionMap.get(transactionIndex);
   }
 
+  public void awaitDoubleBufferFlush() throws InterruptedException {
+    ozoneManagerDoubleBuffer.awaitFlush();
+  }
 }

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/ratis/TestOzoneManagerDoubleBuffer.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/ratis/TestOzoneManagerDoubleBuffer.java
@@ -53,7 +53,6 @@ import org.mockito.Mockito;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doAnswer;
@@ -244,7 +243,7 @@ class TestOzoneManagerDoubleBuffer {
     ExecutorService executorService = Executors.newCachedThreadPool();
     int transactionIndex = 0;
 
-    // Stop the daemon till to eliminate the race condition.
+    // Stop the daemon to eliminate race conditions.
     doubleBuffer.stopDaemon();
 
     // Confirm clear.
@@ -256,15 +255,14 @@ class TestOzoneManagerDoubleBuffer {
       int c = notifyCounter.incrementAndGet();
       assertEquals(0, doubleBuffer.getReadyBufferSize());
       int threadCount = flushNotifier.notifyFlush();
-      // First time through, it should be initial size.
-      if (c == 1) {
-        //        assertEquals(initialSize, doubleBuffer.getCurrentBufferSize());
-        // assertEquals(initialSize, threadCount);
+      // First time through, threadCount should be 1
+      if (c < 3) {
+        assertEquals(1, threadCount);
       } else {
         //  Every other time it should be 0.
-        assertEquals(0, doubleBuffer.getCurrentBufferSize());
         assertEquals(0, threadCount);
       }
+      assertEquals(0, doubleBuffer.getCurrentBufferSize());
       assertEquals(0, doubleBuffer.getReadyBufferSize());
       return null;
     }).when(spyFlushNotifier).notifyFlush();

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/ratis/TestOzoneManagerDoubleBuffer.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/ratis/TestOzoneManagerDoubleBuffer.java
@@ -260,7 +260,6 @@ class TestOzoneManagerDoubleBuffer {
       return null;
     }).when(spyFlushNotifier).notifyFlush();
 
-
     // Init double buffer.
     for (OMClientResponse omClientResponse : omClientResponses) {
       doubleBuffer.add(omClientResponse, transactionIndex++);
@@ -285,10 +284,10 @@ class TestOzoneManagerDoubleBuffer {
     await = awaitFlush(executorService);
     await.get();
 
-
     // Clean up.
     flusher.cancel(false);
-    assertThrows(java.util.concurrent.CancellationException.class, flusher::get);
+    assertThrows(java.util.concurrent.CancellationException.class,
+        flusher::get);
   }
 
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

In order to support bootstrapping followers, the om snapshot subsystem needs to make consistent copies snapshot, including the deleted keys table which can be updated at any time.

This means that the background processes modifying the deletedKeys tables need to be halted, and then the bootstrapping process needs to wait for the double buffer to be flushed, (so that any remaining mods to the deletedKeys table is up to date.)

This PR adds the mechanism to allow a thread to wait until the double buffer has been flushed.

It is implmented by adding a set of countdown latches one for each thread that is waiting.

The latches are initialized to 2, one for each of the buffers in the "double" buffer.

Each time a buffer is cleared the latches are decremented once, so that when both have been cleared, the waiter will resume.

The other change is to set the double buffer to periodically check for waiters when the double buffers are idle.


## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-8499

## How was this patch tested?

Unit tests added.
