### PR TITLE
HDDS-8458. Intermittent timeout in TestBlockDeletion#testBlockDeletion

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/TestBlockDeletion.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/TestBlockDeletion.java
@@ -248,16 +248,14 @@ public class TestBlockDeletion {
 
     // If any container present as not closed, i.e. matches some entry 
     // not closed, then return false for wait
+    ContainerSet containerSet = cluster.getHddsDatanodes().get(0)
+        .getDatanodeStateMachine().getContainer().getContainerSet();
     GenericTestUtils.waitFor(() -> {
       return !(omKeyLocationInfoGroupList.stream().anyMatch((group) ->
-        group.getLocationList().stream().anyMatch((info) -> {
-          ContainerData containerData = cluster.getHddsDatanodes().get(0)
-              .getDatanodeStateMachine().getContainer().getContainerSet()
-              .getContainer(info.getContainerID()).getContainerData();
-          // wait till container is closed, if any not closed, return those
-          return containerData.getState()
-            != ContainerProtos.ContainerDataProto.State.CLOSED;
-        })
+        group.getLocationList().stream().anyMatch((info) -> 
+          containerSet.getContainer(info.getContainerID()).getContainerData()
+              .getState() != ContainerProtos.ContainerDataProto.State.CLOSED
+        )
       ));
     }, 1000, 30000);
     


### PR DESCRIPTION
## What changes were proposed in this pull request?

Thread sleep replaced with waiting for DN container to Closed

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-8458

## How was this patch tested?

Flaky test fix, test case running multiple time
