### PR TITLE
HDDS-8471. Ensure replication processors use a single queue for each iteration

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/OverReplicatedProcessor.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/OverReplicatedProcessor.java
@@ -35,15 +35,14 @@ public class OverReplicatedProcessor extends UnhealthyReplicationProcessor
 
   @Override
   protected ContainerHealthResult.OverReplicatedHealthResult
-      dequeueHealthResultFromQueue(ReplicationManager replicationManager) {
-    return replicationManager.dequeueOverReplicatedContainer();
+      dequeueHealthResultFromQueue(ReplicationQueue queue) {
+    return queue.dequeueOverReplicatedContainer();
   }
 
   @Override
-  protected void requeueHealthResultFromQueue(
-          ReplicationManager replicationManager,
-          ContainerHealthResult.OverReplicatedHealthResult healthResult) {
-    replicationManager.requeueOverReplicatedContainer(healthResult);
+  protected void requeueHealthResult(ReplicationQueue queue,
+      ContainerHealthResult.OverReplicatedHealthResult healthResult) {
+    queue.enqueue(healthResult);
   }
   @Override
   protected int sendDatanodeCommands(

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ReplicationQueue.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ReplicationQueue.java
@@ -22,6 +22,8 @@ import java.util.LinkedList;
 import java.util.PriorityQueue;
 import java.util.Queue;
 
+import com.google.common.collect.Queues;
+
 /**
  * Object to encapsulate the under and over replication queues used by
  * replicationManager.
@@ -34,12 +36,12 @@ public class ReplicationQueue {
       overRepQueue;
 
   public ReplicationQueue() {
-    underRepQueue = new PriorityQueue<>(
+    underRepQueue = Queues.synchronizedQueue(new PriorityQueue<>(
         Comparator.comparing(ContainerHealthResult
             .UnderReplicatedHealthResult::getWeightedRedundancy)
         .thenComparing(ContainerHealthResult
-            .UnderReplicatedHealthResult::getRequeueCount));
-    overRepQueue = new LinkedList<>();
+            .UnderReplicatedHealthResult::getRequeueCount)));
+    overRepQueue = Queues.synchronizedQueue(new LinkedList<>());
   }
 
   /**

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/UnderReplicatedProcessor.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/UnderReplicatedProcessor.java
@@ -34,15 +34,14 @@ public class UnderReplicatedProcessor extends UnhealthyReplicationProcessor
 
   @Override
   protected ContainerHealthResult.UnderReplicatedHealthResult
-      dequeueHealthResultFromQueue(ReplicationManager replicationManager) {
-    return replicationManager.dequeueUnderReplicatedContainer();
+      dequeueHealthResultFromQueue(ReplicationQueue queue) {
+    return queue.dequeueUnderReplicatedContainer();
   }
 
   @Override
-  protected void requeueHealthResultFromQueue(
-          ReplicationManager replicationManager,
-          ContainerHealthResult.UnderReplicatedHealthResult healthResult) {
-    replicationManager.requeueUnderReplicatedContainer(healthResult);
+  protected void requeueHealthResult(ReplicationQueue queue,
+      ContainerHealthResult.UnderReplicatedHealthResult healthResult) {
+    queue.enqueue(healthResult);
   }
 
   @Override


### PR DESCRIPTION
## What changes were proposed in this pull request?

Make over/under-replicated processors use a single instance of `ReplicationQueue` for each iteration, even if `ReplicationManager` replaces it with a new queue concurrently.

https://issues.apache.org/jira/browse/HDDS-8471

## How was this patch tested?

CI:
https://github.com/adoroszlai/hadoop-ozone/actions/runs/4821912584