### PR TITLE
HDDS-8047. [hsync] PutBlock request has lots of redundant metadata.

### DIFF
--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/storage/BlockOutputStream.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/storage/BlockOutputStream.java
@@ -54,6 +54,8 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import static org.apache.hadoop.hdds.scm.storage.ContainerProtocolCalls.putBlockAsync;
 import static org.apache.hadoop.hdds.scm.storage.ContainerProtocolCalls.writeChunkAsync;
+import static org.apache.hadoop.ozone.container.common.helpers.BlockData.FLAG_INCREMENTAL_CHUNKS;
+
 import org.apache.ratis.thirdparty.com.google.protobuf.ByteString;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -156,8 +158,10 @@ public class BlockOutputStream extends OutputStream {
     if (replicationIndex > 0) {
       blkIDBuilder.setReplicaIndex(replicationIndex);
     }
-    this.containerBlockData = BlockData.newBuilder().setBlockID(
-        blkIDBuilder.build()).addMetadata(keyValue);
+    this.containerBlockData = BlockData.newBuilder()
+        .setBlockID(blkIDBuilder.build())
+        .setFlags(FLAG_INCREMENTAL_CHUNKS)
+        .addMetadata(keyValue);
     this.xceiverClient = xceiverClientManager.acquireClient(pipeline);
     this.bufferPool = bufferPool;
     this.token = token;

--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/storage/BlockOutputStream.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/storage/BlockOutputStream.java
@@ -459,6 +459,11 @@ public class BlockOutputStream extends OutputStream {
         ContainerCommandResponseProto> flushFuture = null;
     try {
       BlockData blockData = containerBlockData.build();
+
+      // optimization for Ratis-based blocks:
+      // clear chunk info so that next PutBlock does not send it over again.
+      containerBlockData.clearChunks();
+
       XceiverClientReply asyncReply =
           putBlockAsync(xceiverClient, blockData, close, token);
       CompletableFuture<ContainerProtos.ContainerCommandResponseProto> future =

--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/storage/ECBlockOutputStream.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/storage/ECBlockOutputStream.java
@@ -216,6 +216,7 @@ public class ECBlockOutputStream extends BlockOutputStream {
    * @param force true if no data was written since most recent putBlock and
    *            stream is being closed
    */
+  @Override
   public CompletableFuture<ContainerProtos.
       ContainerCommandResponseProto> executePutBlock(boolean close,
       boolean force) throws IOException {

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/container/common/helpers/BlockData.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/container/common/helpers/BlockData.java
@@ -56,7 +56,7 @@ public class BlockData {
    */
   private long size;
 
-  public static long FLAG_INCREMENTAL_CHUNKS = 0x01;
+  public static final long FLAG_INCREMENTAL_CHUNKS = 0x01;
 
   /**
    * Constructs a BlockData Object.

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/container/common/helpers/BlockData.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/container/common/helpers/BlockData.java
@@ -33,6 +33,7 @@ import java.util.ArrayList;
  */
 public class BlockData {
   private final BlockID blockID;
+  private long flag;
   private final Map<String, String> metadata;
 
   /**
@@ -55,6 +56,8 @@ public class BlockData {
    */
   private long size;
 
+  public static long FLAG_INCREMENTAL_CHUNKS = 0x01;
+
   /**
    * Constructs a BlockData Object.
    *
@@ -63,6 +66,7 @@ public class BlockData {
   public BlockData(BlockID blockID) {
     this.blockID = blockID;
     this.metadata = new TreeMap<>();
+    this.flag = FLAG_INCREMENTAL_CHUNKS;
     this.size = 0;
   }
 
@@ -85,6 +89,7 @@ public class BlockData {
       IOException {
     BlockData blockData = new BlockData(
         BlockID.getFromProtobuf(data.getBlockID()));
+    blockData.setFlag(data.getFlags());
     for (int x = 0; x < data.getMetadataCount(); x++) {
       blockData.addMetadata(data.getMetadata(x).getKey(),
           data.getMetadata(x).getValue());
@@ -104,6 +109,7 @@ public class BlockData {
     ContainerProtos.BlockData.Builder builder =
         ContainerProtos.BlockData.newBuilder();
     builder.setBlockID(this.blockID.getDatanodeBlockIDProtobuf());
+    builder.setFlags(this.flag);
     for (Map.Entry<String, String> entry : metadata.entrySet()) {
       ContainerProtos.KeyValue.Builder keyValBuilder =
           ContainerProtos.KeyValue.newBuilder();
@@ -113,6 +119,10 @@ public class BlockData {
     builder.addAllChunks(getChunks());
     builder.setSize(size);
     return builder.build();
+  }
+
+  public void setFlag(long flag) {
+    this.flag = flag;
   }
 
   /**
@@ -153,6 +163,10 @@ public class BlockData {
   @SuppressWarnings("unchecked")
   private List<ContainerProtos.ChunkInfo> castChunkList() {
     return (List<ContainerProtos.ChunkInfo>)chunkList;
+  }
+
+  public long getFlag() {
+    return flag;
   }
 
   /**
@@ -281,6 +295,7 @@ public class BlockData {
   public void appendTo(StringBuilder sb) {
     sb.append("[blockId=");
     blockID.appendTo(sb);
+    sb.append(", flag=").append(flag);
     sb.append(", size=").append(size);
     sb.append("]");
   }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/impl/BlockManagerImpl.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/impl/BlockManagerImpl.java
@@ -212,8 +212,10 @@ public class BlockManagerImpl implements BlockManager {
       existingBlockData = blockDataTable.get(blockKey);
     }
 
+    // if client does not support FLAG_INCREMENTAL_CHUNKS or
     // if the block is new, the BlockData will be stored in its entirety.
-    if (existingBlockData == null) {
+    if ((data.getFlag() & BlockData.FLAG_INCREMENTAL_CHUNKS) != 0 ||
+        existingBlockData == null) {
       blockDataTable.putWithBatch(batch, blockKey, data);
     } else {
       // otherwise, the chunk is appended to an existing block

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/impl/BlockManagerImpl.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/impl/BlockManagerImpl.java
@@ -214,7 +214,7 @@ public class BlockManagerImpl implements BlockManager {
 
     // if client does not support FLAG_INCREMENTAL_CHUNKS or
     // if the block is new, the BlockData will be stored in its entirety.
-    if ((data.getFlag() & BlockData.FLAG_INCREMENTAL_CHUNKS) != 0 ||
+    if ((data.getFlag() & BlockData.FLAG_INCREMENTAL_CHUNKS) == 0 ||
         existingBlockData == null) {
       blockDataTable.putWithBatch(batch, blockKey, data);
     } else {

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/helpers/TestBlockData.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/helpers/TestBlockData.java
@@ -32,6 +32,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.ThreadLocalRandom;
 
+import static org.apache.hadoop.ozone.container.common.helpers.BlockData.FLAG_INCREMENTAL_CHUNKS;
 import static org.junit.Assert.assertEquals;
 
 /**
@@ -131,6 +132,7 @@ public class TestBlockData {
       computed.setChunks(expected);
       assertChunks(expected, computed);
     }
+    assertEquals(computed.getFlag(), FLAG_INCREMENTAL_CHUNKS);
   }
 
   @Test
@@ -138,7 +140,7 @@ public class TestBlockData {
     final BlockID blockID = new BlockID(5, 123);
     blockID.setBlockCommitSequenceId(42);
     final BlockData subject = new BlockData(blockID);
-    assertEquals("[blockId=conID: 5 locID: 123 bcsId: 42, size=0]",
+    assertEquals("[blockId=conID: 5 locID: 123 bcsId: 42, flag=1, size=0]",
         subject.toString());
   }
 }

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/impl/TestContainerPersistence.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/impl/TestContainerPersistence.java
@@ -816,9 +816,11 @@ public class TestContainerPersistence {
     blockData.setFlag(0);
     blockManager.putBlock(container, blockData);
 
+    // chunk info should be overwritten by the 2nd PutBlock
     BlockData readBlockData =
         blockManager.getBlock(container, blockID1);
-    assertEquals(chunkList.get(0).getLen()*2, readBlockData.getSize());
+    assertEquals(chunkList.get(0).getLen() * 2,
+        readBlockData.getSize());
   }
 
   /**

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestHSync.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestHSync.java
@@ -25,6 +25,7 @@ import java.util.UUID;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.atomic.AtomicReference;
 
+import org.apache.hadoop.hdds.scm.storage.BlockOutputStream;
 import org.apache.hadoop.hdds.utils.IOUtils;
 import org.apache.hadoop.conf.StorageUnit;
 import org.apache.hadoop.crypto.CipherSuite;
@@ -51,9 +52,11 @@ import org.apache.hadoop.ozone.client.OzoneClient;
 import org.apache.hadoop.ozone.client.io.ECKeyOutputStream;
 import org.apache.hadoop.ozone.client.io.KeyOutputStream;
 import org.apache.hadoop.ozone.client.io.OzoneOutputStream;
+import org.apache.hadoop.ozone.container.keyvalue.impl.BlockManagerImpl;
 import org.apache.hadoop.ozone.om.helpers.BucketLayout;
-
 import org.apache.hadoop.util.Time;
+
+import org.apache.ozone.test.GenericTestUtils;
 import org.apache.ozone.test.tag.Flaky;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Assertions;
@@ -62,6 +65,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.slf4j.event.Level;
 
 import static org.apache.hadoop.ozone.OzoneConsts.OZONE_OFS_URI_SCHEME;
 import static org.apache.hadoop.ozone.OzoneConsts.OZONE_ROOT;
@@ -147,6 +151,8 @@ public class TestHSync {
   @Test
   @Flaky("HDDS-8024")
   public void testOfsHSync() throws Exception {
+    GenericTestUtils.setLogLevel(BlockOutputStream.LOG, Level.DEBUG);
+    GenericTestUtils.setLogLevel(BlockManagerImpl.LOG, Level.DEBUG);
     // Set the fs.defaultFS
     final String rootPath = String.format("%s://%s/",
         OZONE_OFS_URI_SCHEME, CONF.get(OZONE_OM_ADDRESS_KEY));


### PR DESCRIPTION
## What changes were proposed in this pull request?

In this PR,
Client removes ChunkInfo that are already sent in previous PutBlock requests. DataNode then append ChunkInfo to an existing block.

The BlockManagerImpl refactors a bulk of code into a standalone method, updateDBForPutBlock(), but for the most part, it simply does what's described above.

With this change, the client side overhead is dramatically reduced. The DataNode ratis log overhead is dramatically reduced too. However, there is still a lot of deserialization overhead because DataNode needs to read BlockData from rocksdb so it can append ChunkInfo. The caching mechanism that is similar to what OM has may be the solution. But that's a bigger change and I plan to pursue in a follow-up change.



## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-8047

## How was this patch tested?
This is performance optimization. Existing tests covers all.