### PR TITLE
HDDS-8506. LeaseRecovery failing with NullPointer exception.

### DIFF
--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/file/OMRecoverLeaseRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/file/OMRecoverLeaseRequest.java
@@ -90,15 +90,15 @@ public class OMRecoverLeaseRequest extends OMKeyRequest {
 
   @Override
   public OMRequest preExecute(OzoneManager ozoneManager) throws IOException {
-    RecoverLeaseRequest recoverLeaseRequest = getOmRequest()
-        .getRecoverLeaseRequest();
+    OMRequest request = super.preExecute(ozoneManager);
+    RecoverLeaseRequest recoverLeaseRequest = request.getRecoverLeaseRequest();
 
     String keyPath = recoverLeaseRequest.getKeyName();
     String normalizedKeyPath =
         validateAndNormalizeKey(ozoneManager.getEnableFileSystemPaths(),
             keyPath, getBucketLayout());
 
-    return getOmRequest().toBuilder()
+    return request.toBuilder()
         .setRecoverLeaseRequest(
             recoverLeaseRequest.toBuilder()
                 .setKeyName(normalizedKeyPath))

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/file/TestOMRecoverLeaseRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/file/TestOMRecoverLeaseRequest.java
@@ -41,19 +41,15 @@ import org.junit.Assert;
 import org.junit.Test;
 
 import java.io.IOException;
-import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
-import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_ACL_ENABLED;
 import static org.junit.Assert.assertNotNull;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.doReturn;
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 /**
@@ -76,8 +72,11 @@ public class TestOMRecoverLeaseRequest extends TestOMKeyRequest {
   @Test
   public void testRecoverHsyncFile() throws Exception {
     when(ozoneManager.getAclsEnabled()).thenReturn(true);
-    when(ozoneManager.getVolumeOwner(anyString(), any(IAccessAuthorizer.ACLType.class), any(
-        OzoneObj.ResourceType.class))).thenReturn("user");
+    when(ozoneManager.getVolumeOwner(
+        anyString(),
+        any(IAccessAuthorizer.ACLType.class), any(
+        OzoneObj.ResourceType.class)))
+        .thenReturn("user");
     InetSocketAddress address = new InetSocketAddress("localhost", 10000);
     when(ozoneManager.getOmRpcServerAddr()).thenReturn(address);
     populateNamespace(true, true);


### PR DESCRIPTION
## What changes were proposed in this pull request?

preExecute() to fill in userInfo to avoid NPE in follower OM.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-8506

## How was this patch tested?

Unit test is updated to enable ACL (fails in ACL check code) and verify preExecute() does fill in userInfo properly.