### PR TITLE
HDDS-8510. Intermittent timeout in TestRootedOzoneFileSystem#testSnapshotDiff

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOmSnapshot.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOmSnapshot.java
@@ -163,10 +163,6 @@ public class TestOmSnapshot {
     conf.setBoolean(OMConfigKeys.OZONE_OM_SNAPSHOT_FORCE_FULL_DIFF,
         forceFullSnapshotDiff);
     conf.setEnum(HDDS_DB_PROFILE, DBProfile.TEST);
-    conf.setTimeDuration(
-        OMConfigKeys.OZONE_OM_SNAPSHOT_DIFF_JOB_DEFAULT_WAIT_TIME,
-        TimeUnit.SECONDS.toMillis(1),
-        TimeUnit.MILLISECONDS);
 
     cluster = MiniOzoneCluster.newOMHABuilder(conf)
         .setClusterId(clusterId)

--- a/hadoop-ozone/integration-test/src/test/resources/ozone-site.xml
+++ b/hadoop-ozone/integration-test/src/test/resources/ozone-site.xml
@@ -46,4 +46,9 @@
     <value>1s</value>
   </property>
 
+  <property>
+    <name>ozone.om.snapshot.diff.job.default.wait.time</name>
+    <value>1s</value>
+  </property>
+
 </configuration>

--- a/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicOzoneClientAdapterImpl.java
+++ b/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicOzoneClientAdapterImpl.java
@@ -694,15 +694,16 @@ public class BasicOzoneClientAdapterImpl implements OzoneClientAdapter {
   private SnapshotDiffReportOzone getSnapshotDiffReportOnceComplete(
       String fromSnapshot, String toSnapshot, String token)
       throws IOException, InterruptedException {
-    SnapshotDiffResponse snapshotDiffResponse = null;
-    do {
+    SnapshotDiffResponse snapshotDiffResponse;
+    while (true) {
       snapshotDiffResponse =
           objectStore.snapshotDiff(volume.getName(), bucket.getName(),
               fromSnapshot, toSnapshot, token, -1, false);
+      if (snapshotDiffResponse.getJobStatus() == DONE) {
+        break;
+      }
       Thread.sleep(snapshotDiffResponse.getWaitTimeInMs());
-    } while (snapshotDiffResponse.getJobStatus() != DONE);
-    SnapshotDiffReportOzone report =
-        snapshotDiffResponse.getSnapshotDiffReport();
-    return report;
+    }
+    return snapshotDiffResponse.getSnapshotDiffReport();
   }
 }

--- a/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicRootedOzoneClientAdapterImpl.java
+++ b/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicRootedOzoneClientAdapterImpl.java
@@ -1343,16 +1343,17 @@ public class BasicRootedOzoneClientAdapterImpl
   private SnapshotDiffReportOzone getSnapshotDiffReportOnceComplete(
       String fromSnapshot, String toSnapshot, String volume, String bucket,
       String token) throws IOException, InterruptedException {
-    SnapshotDiffResponse snapshotDiffResponse = null;
-    do {
+    SnapshotDiffResponse snapshotDiffResponse;
+    while (true) {
       snapshotDiffResponse =
           objectStore.snapshotDiff(volume, bucket, fromSnapshot, toSnapshot,
               token, -1, false);
+      if (snapshotDiffResponse.getJobStatus() == DONE) {
+        break;
+      }
       Thread.sleep(snapshotDiffResponse.getWaitTimeInMs());
-    } while (snapshotDiffResponse.getJobStatus() != DONE);
-    SnapshotDiffReportOzone report =
-        snapshotDiffResponse.getSnapshotDiffReport();
-    return report;
+    }
+    return snapshotDiffResponse.getSnapshotDiffReport();
   }
 
   public boolean recoverLease(final Path f) throws IOException {


### PR DESCRIPTION
## What changes were proposed in this pull request?

Frequent timeout of `TestRootedOzoneFileSystem` (fork is killed after 20 minutes) is caused by increased snapshot diff wait time (1 minute instead of 1 second, changed in #4511).

```
[INFO] Running org.apache.hadoop.fs.ozone.TestRootedOzoneFileSystem
...
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-surefire-plugin:3.0.0-M5:test (default-test) on project ozone-integration-test: There was a timeout in the fork -> [Help 1]
```

Thread dump excerpt:

```
"Time-limited test" 
   java.lang.Thread.State: TIMED_WAITING
        at java.lang.Thread.sleep(Native Method)
        at org.apache.hadoop.fs.ozone.BasicRootedOzoneClientAdapterImpl.getSnapshotDiffReportOnceComplete(BasicRootedOzoneClientAdapterImpl.java:1351)
        at org.apache.hadoop.fs.ozone.BasicRootedOzoneClientAdapterImpl.getSnapshotDiffReport(BasicRootedOzoneClientAdapterImpl.java:1318)
        at org.apache.hadoop.fs.ozone.BasicRootedOzoneFileSystem.getSnapshotDiffReport(BasicRootedOzoneFileSystem.java:1515)
        at org.apache.hadoop.fs.ozone.TestRootedOzoneFileSystem.testSnapshotDiff(TestRootedOzoneFileSystem.java:2478)
```

Locally running only `TestRootedOzoneFileSystem.testSnapshotDiff` takes more than 16 minutes:

```
$ mvn -am -pl :ozone-integration-test -Dtest='TestRootedOzoneFileSystem#testSnapshotDiff' clean test
...
Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 985.776 s - in org.apache.hadoop.fs.ozone.TestRootedOzoneFileSystem
```

CI is successful in few cases, but almost reaches 20 minutes:

```
Tests run: 245, Failures: 0, Errors: 0, Skipped: 9, Time elapsed: 1,173.755 s - in org.apache.hadoop.fs.ozone.TestRootedOzoneFileSystem
```

Before HDDS-8322 it was around 6-7 minutes:

```
Tests run: 245, Failures: 0, Errors: 0, Skipped: 9, Time elapsed: 424.886 s - in org.apache.hadoop.fs.ozone.TestRootedOzoneFileSystem
```

This PR:

 * fixes timeout by setting 1 second snapshot diff wait time for all integration tests, not just `TestOmSnapshot`
 * changes wait loop to allow exit before first sleep

https://issues.apache.org/jira/browse/HDDS-8510

## How was this patch tested?

```
$ mvn -am -pl :ozone-integration-test -Dtest='TestRootedOzoneFileSystem#testSnapshotDiff' clean test
...
Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 100.248 s - in org.apache.hadoop.fs.ozone.TestRootedOzoneFileSystem
```

CI:
https://github.com/adoroszlai/hadoop-ozone/actions/runs/4838984327

```
Tests run: 245, Failures: 0, Errors: 0, Skipped: 9, Time elapsed: 417.506 s - in org.apache.hadoop.fs.ozone.TestRootedOzoneFileSystem
```