### PR TITLE
HDDS-7546. [Snapshot] Throw exception if the SnapshotDiff size is huge

### DIFF
--- a/hadoop-hdds/common/src/main/resources/ozone-default.xml
+++ b/hadoop-hdds/common/src/main/resources/ozone-default.xml
@@ -3784,4 +3784,13 @@
       Buffer size for SST Dumptool Pipe which would be used for computing snapdiff when native library is enabled.
     </description>
   </property>
+
+  <property>
+    <name>ozone.om.snapshot.diff.max.allowed.keys.changed.per.job</name>
+    <value>10000000</value>
+    <tag>OZONE, OM</tag>
+    <description>
+      Max numbers of keys changed allowed for a snapshot diff job.
+    </description>
+  </property>
 </configuration>

--- a/hadoop-hdds/rocksdb-checkpoint-differ/src/main/java/org/apache/ozone/rocksdb/util/ManagedSstFileReader.java
+++ b/hadoop-hdds/rocksdb-checkpoint-differ/src/main/java/org/apache/ozone/rocksdb/util/ManagedSstFileReader.java
@@ -49,6 +49,8 @@ public class ManagedSstFileReader {
 
   private final Collection<String> sstFiles;
 
+  private volatile long estimatedTotalKeys = -1;
+
   public ManagedSstFileReader(final Collection<String> sstFiles) {
     this.sstFiles = sstFiles;
   }
@@ -56,9 +58,28 @@ public class ManagedSstFileReader {
   public static <T> Stream<T> getStreamFromIterator(ClosableIterator<T> itr) {
     final Spliterator<T> spliterator =
         Spliterators.spliteratorUnknownSize(itr, 0);
-    return StreamSupport.stream(spliterator, false).onClose(() -> {
-      itr.close();
-    });
+    return StreamSupport.stream(spliterator, false).onClose(itr::close);
+  }
+
+  public long getEstimatedTotalKeys() throws RocksDBException {
+    if (estimatedTotalKeys != -1) {
+      return estimatedTotalKeys;
+    }
+
+    long estimatedSize = 0;
+    synchronized (this) {
+      try (ManagedOptions options = new ManagedOptions()) {
+        for (String sstFile : sstFiles) {
+          SstFileReader fileReader = new SstFileReader(options);
+          fileReader.open(sstFile);
+          estimatedSize += fileReader.getTableProperties().getNumEntries();
+          estimatedSize += fileReader.getTableProperties().getNumDeletions();
+        }
+      }
+    }
+
+    estimatedTotalKeys = estimatedSize;
+    return estimatedTotalKeys;
   }
 
   public Stream<String> getKeyStream() throws RocksDBException,

--- a/hadoop-hdds/rocksdb-checkpoint-differ/src/main/java/org/apache/ozone/rocksdb/util/ManagedSstFileReader.java
+++ b/hadoop-hdds/rocksdb-checkpoint-differ/src/main/java/org/apache/ozone/rocksdb/util/ManagedSstFileReader.java
@@ -68,17 +68,20 @@ public class ManagedSstFileReader {
 
     long estimatedSize = 0;
     synchronized (this) {
+      if (estimatedTotalKeys != -1) {
+        return estimatedTotalKeys;
+      }
+
       try (ManagedOptions options = new ManagedOptions()) {
         for (String sstFile : sstFiles) {
           SstFileReader fileReader = new SstFileReader(options);
           fileReader.open(sstFile);
           estimatedSize += fileReader.getTableProperties().getNumEntries();
-          estimatedSize += fileReader.getTableProperties().getNumDeletions();
         }
       }
+      estimatedTotalKeys = estimatedSize;
     }
 
-    estimatedTotalKeys = estimatedSize;
     return estimatedTotalKeys;
   }
 

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/OMConfigKeys.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/OMConfigKeys.java
@@ -508,4 +508,11 @@ public final class OMConfigKeys {
   public static final long
       OZONE_OM_SNAPSHOT_DIFF_CLEANUP_SERVICE_TIMEOUT_DEFAULT
       = TimeUnit.MINUTES.toMillis(5);
+
+  public static final String
+      OZONE_OM_SNAPSHOT_DIFF_MAX_ALLOWED_KEYS_CHANGED_PER_DIFF_JOB
+      = "ozone.om.snapshot.diff.max.allowed.keys.changed.per.job";
+  public static final long
+      OZONE_OM_SNAPSHOT_DIFF_MAX_ALLOWED_KEYS_CHANGED_PER_DIFF_JOB_DEFAULT
+      = 10_000_000;
 }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/snapshot/SnapshotDiffManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/snapshot/SnapshotDiffManager.java
@@ -91,6 +91,8 @@ import java.util.concurrent.SynchronousQueue;
 import static org.apache.hadoop.ozone.OzoneConsts.OM_KEY_PREFIX;
 import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_SNAPSHOT_DIFF_JOB_DEFAULT_WAIT_TIME;
 import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_SNAPSHOT_DIFF_JOB_DEFAULT_WAIT_TIME_DEFAULT;
+import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_SNAPSHOT_DIFF_MAX_ALLOWED_KEYS_CHANGED_PER_DIFF_JOB;
+import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_SNAPSHOT_DIFF_MAX_ALLOWED_KEYS_CHANGED_PER_DIFF_JOB_DEFAULT;
 import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_SNAPSHOT_DIFF_THREAD_POOL_SIZE;
 import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_SNAPSHOT_DIFF_THREAD_POOL_SIZE_DEFAULT;
 import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_SNAPSHOT_FORCE_FULL_DIFF;
@@ -130,6 +132,7 @@ public class SnapshotDiffManager implements AutoCloseable {
   private final ManagedColumnFamilyOptions familyOptions;
   // TODO: [SNAPSHOT] Use different wait time based of job status.
   private final long defaultWaitTime;
+  private final long maxAllowedKeyChangesForASnapDiff;
 
   /**
    * Global table to keep the diff report. Each key is prefixed by the jobID
@@ -155,9 +158,8 @@ public class SnapshotDiffManager implements AutoCloseable {
    */
   private final String sstBackupDirForSnapDiffJobs;
 
-  private boolean isNativeRocksToolsLoaded;
-
-  private ManagedSSTDumpTool sstDumpTool;
+  private final boolean isNativeRocksToolsLoaded;
+  private final ManagedSSTDumpTool sstDumpTool;
 
   @SuppressWarnings("parameternumber")
   public SnapshotDiffManager(ManagedRocksDB db,
@@ -179,6 +181,12 @@ public class SnapshotDiffManager implements AutoCloseable {
         OZONE_OM_SNAPSHOT_DIFF_JOB_DEFAULT_WAIT_TIME_DEFAULT,
         TimeUnit.MILLISECONDS
     );
+
+    this.maxAllowedKeyChangesForASnapDiff = ozoneManager.getConfiguration()
+        .getLong(
+            OZONE_OM_SNAPSHOT_DIFF_MAX_ALLOWED_KEYS_CHANGED_PER_DIFF_JOB,
+            OZONE_OM_SNAPSHOT_DIFF_MAX_ALLOWED_KEYS_CHANGED_PER_DIFF_JOB_DEFAULT
+        );
 
     int threadPoolSize = ozoneManager.getConfiguration().getInt(
         OZONE_OM_SNAPSHOT_DIFF_THREAD_POOL_SIZE,
@@ -208,6 +216,9 @@ public class SnapshotDiffManager implements AutoCloseable {
     createEmptySnapDiffDir(path);
     this.sstBackupDirForSnapDiffJobs = path.toString();
 
+    this.sstDumpTool = initSSTDumpTool(ozoneManager.getConfiguration());
+    this.isNativeRocksToolsLoaded = sstDumpTool != null;
+
     // Ideally, loadJobsOnStartUp should run only on OM node, since SnapDiff
     // is not HA currently and running this on all the nodes would be
     // inefficient. Especially, when OM node restarts and loses its leadership.
@@ -222,15 +233,14 @@ public class SnapshotDiffManager implements AutoCloseable {
     // When we build snapDiff HA aware, we will revisit this.
     // Details: https://github.com/apache/ozone/pull/4438#discussion_r1149788226
     this.loadJobsOnStartUp();
-    isNativeRocksToolsLoaded = NativeLibraryLoader.getInstance()
-            .loadLibrary(NativeConstants.ROCKS_TOOLS_NATIVE_LIBRARY_NAME);
-    if (isNativeRocksToolsLoaded) {
-      isNativeRocksToolsLoaded = initSSTDumpTool(
-          ozoneManager.getConfiguration());
-    }
   }
 
-  private boolean initSSTDumpTool(OzoneConfiguration conf) {
+  private ManagedSSTDumpTool initSSTDumpTool(OzoneConfiguration conf) {
+    if (!NativeLibraryLoader.getInstance()
+        .loadLibrary(NativeConstants.ROCKS_TOOLS_NATIVE_LIBRARY_NAME)) {
+      return null;
+    }
+
     try {
       int threadPoolSize = conf.getInt(
               OMConfigKeys.OZONE_OM_SNAPSHOT_SST_DUMPTOOL_EXECUTOR_POOL_SIZE,
@@ -247,11 +257,10 @@ public class SnapshotDiffManager implements AutoCloseable {
               .setNameFormat("snapshot-diff-manager-sst-dump-tool-TID-%d")
               .build(),
               new ThreadPoolExecutor.DiscardPolicy());
-      sstDumpTool = new ManagedSSTDumpTool(execService, bufferSize);
+      return new ManagedSSTDumpTool(execService, bufferSize);
     } catch (NativeLibraryNotLoadedException e) {
-      return false;
+      return null;
     }
-    return true;
   }
 
   /**
@@ -727,7 +736,7 @@ public class SnapshotDiffManager implements AutoCloseable {
                                 PersistentMap<byte[], byte[]> newObjIdToKeyMap,
                                 PersistentSet<byte[]> objectIDsToCheck,
                                 Map<String, String> tablePrefixes)
-      throws IOException, NativeLibraryNotLoadedException {
+      throws IOException, NativeLibraryNotLoadedException, RocksDBException {
 
     Set<String> deltaFiles = isNativeRocksToolsLoadedDeltaFilesPair.getRight();
     if (deltaFiles.isEmpty()) {
@@ -738,6 +747,8 @@ public class SnapshotDiffManager implements AutoCloseable {
     boolean isDirectoryTable =
         fsTable.getName().equals(OmMetadataManagerImpl.DIRECTORY_TABLE);
     ManagedSstFileReader sstFileReader = new ManagedSstFileReader(deltaFiles);
+    validateEstimatedKeyChangesAreInLimits(sstFileReader);
+
     try (Stream<String> keysToCheck = nativeRocksToolsLoaded
                  ? sstFileReader.getKeyStreamWithTombstone(sstDumpTool)
                  : sstFileReader.getKeyStream()) {
@@ -840,6 +851,20 @@ public class SnapshotDiffManager implements AutoCloseable {
     }
 
     return deltaFiles;
+  }
+
+  private void validateEstimatedKeyChangesAreInLimits(
+      ManagedSstFileReader sstFileReader
+  ) throws RocksDBException, IOException {
+    if (sstFileReader.getEstimatedTotalKeys() >
+        maxAllowedKeyChangesForASnapDiff) {
+      throw new IOException(
+          String.format("Expected diff contains more than max allowed key " +
+                  "changes for a snapDiff job. EstimatedTotalKeys: %s, " +
+                  "AllowMaxTotalKeys: %s.",
+              sstFileReader.getEstimatedTotalKeys(),
+              maxAllowedKeyChangesForASnapDiff));
+    }
   }
 
   private long generateDiffReport(


### PR DESCRIPTION
## What changes were proposed in this pull request?

This change is to throw exception if estimated keys changed in snapdiff job is more than 10 million.

## What is the link to the Apache JIRA
[HDDS-7546](https://issues.apache.org/jira/browse/HDDS-7546)

## How was this patch tested?
Existing unit tests for now.
