### PR TITLE
HDDS-8347. Investigate possible race conditions on ContainerInfo in ContainerBalancer

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/container/ContainerInfo.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/container/ContainerInfo.java
@@ -52,7 +52,13 @@ public class ContainerInfo implements Comparator<ContainerInfo>,
   @JsonIgnore
   private PipelineID pipelineID;
   private ReplicationConfig replicationConfig;
-  private long usedBytes;
+  /*
+  usedBytes is a volatile field. Writes and Reads of volatile long are atomic
+  and each read of a volatile will see the last write to that volatile by any
+  thread. Note that operations such as `usedBytes++` are not atomic, even if
+  usedBytes is volatile.
+  */
+  private volatile long usedBytes;
   private long numberOfKeys;
   private Instant lastUsed;
   // The wall-clock ms since the epoch at which the current state enters.

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/balancer/ContainerBalancerSelectionCriteria.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/balancer/ContainerBalancerSelectionCriteria.java
@@ -181,7 +181,8 @@ public class ContainerBalancerSelectionCriteria {
     return !isContainerClosed(container, node) || isECContainer(container) ||
         isContainerReplicatingOrDeleting(containerID) ||
         !findSourceStrategy.canSizeLeaveSource(node, container.getUsedBytes())
-        || breaksMaxSizeToMoveLimit(container, sizeMovedAlready);
+        || breaksMaxSizeToMoveLimit(container.containerID(),
+        container.getUsedBytes(), sizeMovedAlready);
   }
 
   /**
@@ -221,13 +222,14 @@ public class ContainerBalancerSelectionCriteria {
     return false;
   }
 
-  private boolean breaksMaxSizeToMoveLimit(ContainerInfo container,
-      long sizeMovedAlready) {
+  private boolean breaksMaxSizeToMoveLimit(ContainerID containerID,
+                                           long usedBytes,
+                                           long sizeMovedAlready) {
     // check max size to move per iteration limit
-    if (sizeMovedAlready + container.getUsedBytes() >
+    if (sizeMovedAlready + usedBytes >
         balancerConfiguration.getMaxSizeToMovePerIteration()) {
       LOG.debug("Removing container {} because it fails max size " +
-            "to move per iteration check.", container.containerID());
+          "to move per iteration check.", containerID);
       return true;
     }
     return false;


### PR DESCRIPTION
## What changes were proposed in this pull request?

Problem: Container Balancer gets a reference to a Container's `ContainerInfo` from `ContainerManager` in several places throughout the balancer package. We need to investigate if there are possible race conditions with other parts of SCM changing the replicas of a container etc.

In the investigation it was found that in most places, the `ContainerInfo` object's `usedBytes` field is being read through the getter `ContainerInfo#getUsedBytes`. `usedBytes` is written in `AbstractContainerReportHandler#updateContainerUsedAndKeys` when a container report is processed. Since `usedBytes` is a long primitive type and read/write to a long are not atomic, there's a race condition between the balancer thread reading this value and the report handling thread writing to it. This PR proposes making `usedBytes` volatile because read/write to a volatile long are atomic - https://docs.oracle.com/javase/specs/jls/se8/html/jls-17.html#jls-17.7. This should solve the race condition. 

`AbstractFindTargetGreedy` passes a `ContainerInfo` to `PlacementPolicyValidateProxy#validateContainerPlacement`. This method reads the replication type and replication factor from `ContainerInfo`. These values should stay constant, so synchronization is not required here.

I don't think locking on `ContainerInfo` is required in the balancer package except in `MoveManager` where it's already present.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-8347

## How was this patch tested?

Ran existing tests.
Green CI in my fork - https://github.com/siddhantsangwan/ozone/actions/runs/4869037438