### PR TITLE
HDDS-8473. ReplicationManager: Clear ContainerReplicaPendingOps when RM goes to running state

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ContainerReplicaPendingOps.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ContainerReplicaPendingOps.java
@@ -31,6 +31,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReadWriteLock;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
 
 import static org.apache.hadoop.hdds.scm.container.replication.ContainerReplicaOp.PendingOpType;
 import static org.apache.hadoop.hdds.scm.container.replication.ContainerReplicaOp.PendingOpType.ADD;
@@ -49,6 +50,8 @@ public class ContainerReplicaPendingOps {
   private final ConcurrentHashMap<ContainerID, List<ContainerReplicaOp>>
       pendingOps = new ConcurrentHashMap<>();
   private final Striped<ReadWriteLock> stripedLock = Striped.readWriteLock(64);
+  private final ReentrantReadWriteLock globalLock =
+      new ReentrantReadWriteLock();
   private final ConcurrentHashMap<PendingOpType, AtomicLong>
       pendingOpCount = new ConcurrentHashMap<>();
   private ReplicationManagerMetrics replicationMetrics = null;
@@ -59,8 +62,28 @@ public class ContainerReplicaPendingOps {
       Clock clock) {
     this.config = conf;
     this.clock = clock;
+    resetCounters();
+  }
+
+  private void resetCounters() {
     for (PendingOpType opType: PendingOpType.values()) {
       pendingOpCount.put(opType, new AtomicLong(0));
+    }
+  }
+
+  /**
+   * Clears all pendingOps and resets all the counters to zero.
+   */
+  public void clear() {
+    // We block all other concurrent access with the global lock to prevent
+    // the map and counters getting out of sync if there are concurrent updates
+    // happening when the class is cleared.
+    globalLock.writeLock().lock();
+    try {
+      pendingOps.clear();
+      resetCounters();
+    } finally {
+      globalLock.writeLock().unlock();
     }
   }
 
@@ -74,7 +97,7 @@ public class ContainerReplicaPendingOps {
    */
   public List<ContainerReplicaOp> getPendingOps(ContainerID containerID) {
     Lock lock = readLock(containerID);
-    lock.lock();
+    lock(lock);
     try {
       List<ContainerReplicaOp> ops = pendingOps.get(containerID);
       if (ops == null) {
@@ -82,7 +105,7 @@ public class ContainerReplicaPendingOps {
       }
       return new ArrayList<>(ops);
     } finally {
-      lock.unlock();
+      unlock(lock);
     }
   }
 
@@ -183,7 +206,7 @@ public class ContainerReplicaPendingOps {
       // iterator started. Once we lock on the ContainerID object, no other
       // changes can occur to the list of ops associated with it.
       Lock lock = writeLock(containerID);
-      lock.lock();
+      lock(lock);
       try {
         List<ContainerReplicaOp> ops = pendingOps.get(containerID);
         if (ops == null) {
@@ -205,7 +228,7 @@ public class ContainerReplicaPendingOps {
           pendingOps.remove(containerID);
         }
       } finally {
-        lock.unlock();
+        unlock(lock);
       }
 
       // notify if there are expired ops
@@ -235,7 +258,7 @@ public class ContainerReplicaPendingOps {
       ContainerID containerID, DatanodeDetails target, int replicaIndex,
       long deadlineEpochMillis) {
     Lock lock = writeLock(containerID);
-    lock.lock();
+    lock(lock);
     try {
       List<ContainerReplicaOp> ops = pendingOps.computeIfAbsent(
           containerID, s -> new ArrayList<>());
@@ -243,7 +266,7 @@ public class ContainerReplicaPendingOps {
           target, replicaIndex, deadlineEpochMillis));
       pendingOpCount.get(opType).incrementAndGet();
     } finally {
-      lock.unlock();
+      unlock(lock);
     }
   }
 
@@ -253,7 +276,7 @@ public class ContainerReplicaPendingOps {
     // List of completed ops that subscribers will be notified about
     List<ContainerReplicaOp> completedOps = new ArrayList<>();
     Lock lock = writeLock(containerID);
-    lock.lock();
+    lock(lock);
     try {
       List<ContainerReplicaOp> ops = pendingOps.get(containerID);
       if (ops != null) {
@@ -274,7 +297,7 @@ public class ContainerReplicaPendingOps {
         }
       }
     } finally {
-      lock.unlock();
+      unlock(lock);
     }
 
     if (found) {
@@ -316,6 +339,18 @@ public class ContainerReplicaPendingOps {
 
   private Lock readLock(ContainerID containerID) {
     return stripedLock.get(containerID).readLock();
+  }
+
+  private void lock(Lock lock) {
+    // We always take the global lock in shared / read mode as the only time it
+    // will block is when the class is getting cleared to remove all operations.
+    globalLock.readLock().lock();
+    lock.lock();
+  }
+
+  private void unlock(Lock lock) {
+    globalLock.readLock().unlock();
+    lock.unlock();
   }
 
   private boolean isMetricsNotNull() {

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ReplicationManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ReplicationManager.java
@@ -1366,6 +1366,13 @@ public class ReplicationManager implements SCMService {
         if (serviceStatus != ServiceStatus.RUNNING) {
           LOG.info("Service {} transitions to RUNNING.", getServiceName());
           lastTimeToBeReadyInMillis = clock.millis();
+          // It this SCM was previously a leader and transitioned to a follower
+          // and then back to a leader in a short time, there may be old pending
+          // Ops in the ContainerReplicaPendingOps table. They are no longer
+          // needed as the DN will discard any commands when the term changes.
+          // Therefore we should clear the table so RM starts from a clean
+          // state.
+          containerReplicaPendingOps.clear();
           serviceStatus = ServiceStatus.RUNNING;
         }
         if (rmConf.isLegacyEnabled()) {

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestContainerReplicaPendingOps.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestContainerReplicaPendingOps.java
@@ -73,6 +73,29 @@ public class TestContainerReplicaPendingOps {
   }
 
   @Test
+  public void testClear() {
+    pendingOps.scheduleAddReplica(new ContainerID(1), dn1, 0, deadline);
+    pendingOps.scheduleDeleteReplica(new ContainerID(2), dn1, 0, deadline);
+
+    Assertions.assertEquals(1,
+        pendingOps.getPendingOpCount(ContainerReplicaOp.PendingOpType.ADD));
+    Assertions.assertEquals(1,
+        pendingOps.getPendingOpCount(ContainerReplicaOp.PendingOpType.DELETE));
+
+    pendingOps.clear();
+
+    Assertions.assertEquals(0,
+        pendingOps.getPendingOpCount(ContainerReplicaOp.PendingOpType.ADD));
+    Assertions.assertEquals(0,
+        pendingOps.getPendingOpCount(ContainerReplicaOp.PendingOpType.DELETE));
+    Assertions.assertEquals(0,
+        pendingOps.getPendingOps(new ContainerID(1)).size());
+    Assertions.assertEquals(0,
+        pendingOps.getPendingOps(new ContainerID(2)).size());
+
+  }
+
+  @Test
   public void testCanAddReplicasForAdd() {
     pendingOps.scheduleAddReplica(new ContainerID(1), dn1, 0, deadline);
     pendingOps.scheduleAddReplica(new ContainerID(1), dn2, 0, deadline);

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestReplicationManager.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestReplicationManager.java
@@ -184,6 +184,27 @@ public class TestReplicationManager {
   }
 
   @Test
+  public void testPendingOpsClearedWhenStarting() {
+    containerReplicaPendingOps.scheduleAddReplica(ContainerID.valueOf(1),
+        MockDatanodeDetails.randomDatanodeDetails(), 1, Integer.MAX_VALUE);
+    containerReplicaPendingOps.scheduleDeleteReplica(ContainerID.valueOf(2),
+        MockDatanodeDetails.randomDatanodeDetails(), 1, Integer.MAX_VALUE);
+    Assert.assertEquals(1, containerReplicaPendingOps
+        .getPendingOpCount(ContainerReplicaOp.PendingOpType.ADD));
+    Assert.assertEquals(1, containerReplicaPendingOps
+        .getPendingOpCount(ContainerReplicaOp.PendingOpType.DELETE));
+
+    // Registers against serviceManager and notifies the status has changed.
+    enableProcessAll();
+
+    // Pending ops should be cleared.
+    Assert.assertEquals(0, containerReplicaPendingOps
+        .getPendingOpCount(ContainerReplicaOp.PendingOpType.ADD));
+    Assert.assertEquals(0, containerReplicaPendingOps
+        .getPendingOpCount(ContainerReplicaOp.PendingOpType.DELETE));
+  }
+
+  @Test
   public void testOpenContainerSkipped() throws ContainerNotFoundException {
     ContainerInfo container = createContainerInfo(repConfig, 1,
         HddsProtos.LifeCycleState.OPEN);


### PR DESCRIPTION
## What changes were proposed in this pull request?

ContainerReplicaPendingOps contains a record of all the pending replications which are waiting to complete across the cluster. When SCM steps down as a leader, and a new one takes over, the pending commands on the datanodes are dropped as they check the leader term before they are processed.

This means the contents of ContainerReplicaPendingOps is not needed if the SCM fails back to the original node. Therefore, if the SCM becomes active again, we should clear the pending ops when RM is transitioning to the RUNNING state.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-8473

## How was this patch tested?

New unit tests added.
