### PR TITLE
HDDS-8494. Adjust replication queue limits for out-of-service nodes

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/protocol/DatanodeDetails.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/protocol/DatanodeDetails.java
@@ -238,14 +238,27 @@ public class DatanodeDetails extends NodeImpl implements
   }
 
   /**
-   * Checks if the OperationalState is Node is Decomissioned or Decomissioning.
-   * @return True if OperationalState is Decommissioned or Decomissioning.
+   * @return true if the node is or being decommissioned
    */
-  public boolean isDecomissioned() {
-    return this.getPersistedOpState() ==
-            HddsProtos.NodeOperationalState.DECOMMISSIONED ||
-            this.getPersistedOpState() ==
-            HddsProtos.NodeOperationalState.DECOMMISSIONING;
+  public boolean isDecommissioned() {
+    return isDecommission(getPersistedOpState());
+  }
+
+  public static boolean isDecommission(HddsProtos.NodeOperationalState state) {
+    return state == HddsProtos.NodeOperationalState.DECOMMISSIONED ||
+        state == HddsProtos.NodeOperationalState.DECOMMISSIONING;
+  }
+
+  /**
+   * @return true if node is in or entering maintenance
+   */
+  public boolean isMaintenance() {
+    return isMaintenance(getPersistedOpState());
+  }
+
+  public static boolean isMaintenance(HddsProtos.NodeOperationalState state) {
+    return state == HddsProtos.NodeOperationalState.IN_MAINTENANCE ||
+        state == HddsProtos.NodeOperationalState.ENTERING_MAINTENANCE;
   }
 
   /**

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/DatanodeStateMachine.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/DatanodeStateMachine.java
@@ -196,8 +196,12 @@ public class DatanodeStateMachine implements Closeable {
 
     ReplicationConfig replicationConfig =
         conf.getObject(ReplicationConfig.class);
-    supervisor = new ReplicationSupervisor(context, replicationConfig, clock,
-        dnConf.getCommandQueueLimit());
+    supervisor = ReplicationSupervisor.newBuilder()
+        .stateContext(context)
+        .datanodeConfig(dnConf)
+        .replicationConfig(replicationConfig)
+        .clock(clock)
+        .build();
 
     replicationSupervisorMetrics =
         ReplicationSupervisorMetrics.create(supervisor);
@@ -227,7 +231,8 @@ public class DatanodeStateMachine implements Closeable {
             dnConf.getCommandQueueLimit()))
         .addHandler(new ClosePipelineCommandHandler())
         .addHandler(new CreatePipelineCommandHandler(conf))
-        .addHandler(new SetNodeOperationalStateCommandHandler(conf))
+        .addHandler(new SetNodeOperationalStateCommandHandler(conf,
+            supervisor::nodeStateUpdated))
         .addHandler(new FinalizeNewLayoutVersionCommandHandler())
         .addHandler(new RefreshVolumeUsageCommandHandler())
         .setConnectionManager(connectionManager)

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/replication/ReplicationSupervisor.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/replication/ReplicationSupervisor.java
@@ -19,6 +19,7 @@ package org.apache.hadoop.ozone.container.replication;
 
 import java.time.Clock;
 import java.time.Instant;
+import java.time.ZoneId;
 import java.util.Comparator;
 import java.util.Map;
 import java.util.Objects;
@@ -31,10 +32,15 @@ import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.IntConsumer;
 
+import org.apache.hadoop.hdds.conf.ConfigurationSource;
+import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.ReplicationCommandPriority;
+import org.apache.hadoop.ozone.container.common.statemachine.DatanodeConfiguration;
 import org.apache.hadoop.ozone.container.common.statemachine.StateContext;
 import org.apache.hadoop.ozone.container.replication.ReplicationServer.ReplicationConfig;
 import org.apache.hadoop.ozone.container.replication.AbstractReplicationTask.Status;
@@ -44,10 +50,13 @@ import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import static org.apache.hadoop.hdds.protocol.DatanodeDetails.isDecommission;
+import static org.apache.hadoop.hdds.protocol.DatanodeDetails.isMaintenance;
+
 /**
  * Single point to schedule the downloading tasks based on priorities.
  */
-public class ReplicationSupervisor {
+public final class ReplicationSupervisor {
 
   private static final Logger LOG =
       LoggerFactory.getLogger(ReplicationSupervisor.class);
@@ -74,45 +83,131 @@ public class ReplicationSupervisor {
    */
   private final Set<AbstractReplicationTask> inFlight;
 
-  private final Map<Class, AtomicInteger> taskCounter =
+  private final Map<Class<?>, AtomicInteger> taskCounter =
       new ConcurrentHashMap<>();
   private int maxQueueSize;
 
-  @VisibleForTesting
-  ReplicationSupervisor(
-      StateContext context, ExecutorService executor, Clock clock,
-      int maxQueueSize) {
-    this.inFlight = ConcurrentHashMap.newKeySet();
-    this.executor = executor;
-    this.context = context;
-    this.clock = clock;
-    this.maxQueueSize = maxQueueSize;
-  }
+  private final AtomicReference<HddsProtos.NodeOperationalState> state
+      = new AtomicReference<>();
+  private final IntConsumer executorThreadUpdater;
+  private final ReplicationConfig replicationConfig;
+  private final DatanodeConfiguration datanodeConfig;
 
-  public ReplicationSupervisor(
-      StateContext context, ReplicationConfig replicationConfig, Clock clock,
-      int maxQueueSize) {
-    this(context,
-        new ThreadPoolExecutor(
+  /**
+   * Builder for {@link ReplicationSupervisor}.
+   */
+  public static class Builder {
+    private StateContext context;
+    private ReplicationConfig replicationConfig;
+    private DatanodeConfiguration datanodeConfig;
+    private ExecutorService executor;
+    private Clock clock;
+    private IntConsumer executorThreadUpdater = threadCount -> { };
+
+    public Builder clock(Clock newClock) {
+      clock = newClock;
+      return this;
+    }
+
+    public Builder executor(ExecutorService newExecutor) {
+      executor = newExecutor;
+      return this;
+    }
+
+    public Builder replicationConfig(ReplicationConfig newReplicationConfig) {
+      replicationConfig = newReplicationConfig;
+      return this;
+    }
+
+    public Builder datanodeConfig(DatanodeConfiguration newDatanodeConfig) {
+      datanodeConfig = newDatanodeConfig;
+      return this;
+    }
+
+    public Builder stateContext(StateContext newContext) {
+      context = newContext;
+      return this;
+    }
+
+    public Builder executorThreadUpdater(IntConsumer newUpdater) {
+      executorThreadUpdater = newUpdater;
+      return this;
+    }
+
+    public ReplicationSupervisor build() {
+      if (replicationConfig == null || datanodeConfig == null) {
+        ConfigurationSource conf = new OzoneConfiguration();
+        if (replicationConfig == null) {
+          replicationConfig =
+              conf.getObject(ReplicationServer.ReplicationConfig.class);
+        }
+        if (datanodeConfig == null) {
+          datanodeConfig = conf.getObject(DatanodeConfiguration.class);
+        }
+      }
+
+      if (clock == null) {
+        clock = Clock.system(ZoneId.systemDefault());
+      }
+
+      if (executor == null) {
+        ThreadPoolExecutor tpe = new ThreadPoolExecutor(
             replicationConfig.getReplicationMaxStreams(),
-            replicationConfig.getReplicationMaxStreams(), 60, TimeUnit.SECONDS,
+            replicationConfig.getReplicationMaxStreams(),
+            60, TimeUnit.SECONDS,
             new PriorityBlockingQueue<>(),
             new ThreadFactoryBuilder().setDaemon(true)
                 .setNameFormat("ContainerReplicationThread-%d")
-                .build()),
-        clock, maxQueueSize);
+                .build());
+        executor = tpe;
+        executorThreadUpdater = threadCount -> {
+          tpe.setMaximumPoolSize(threadCount);
+          tpe.setCorePoolSize(threadCount);
+        };
+      }
+
+      return new ReplicationSupervisor(context, executor, replicationConfig,
+          datanodeConfig, clock, executorThreadUpdater);
+    }
+  }
+
+  public static Builder newBuilder() {
+    return new Builder();
+  }
+
+  private ReplicationSupervisor(StateContext context, ExecutorService executor,
+      ReplicationConfig replicationConfig, DatanodeConfiguration datanodeConfig,
+      Clock clock, IntConsumer executorThreadUpdater) {
+    this.inFlight = ConcurrentHashMap.newKeySet();
+    this.context = context;
+    this.executor = executor;
+    this.replicationConfig = replicationConfig;
+    this.datanodeConfig = datanodeConfig;
+    maxQueueSize = datanodeConfig.getCommandQueueLimit();
+    this.clock = clock;
+    this.executorThreadUpdater = executorThreadUpdater;
+
+    // set initial state
+    if (context != null) {
+      DatanodeDetails dn = context.getParent().getDatanodeDetails();
+      if (dn != null) {
+        nodeStateUpdated(dn.getPersistedOpState());
+      }
+    }
   }
 
   /**
    * Queue an asynchronous download of the given container.
    */
   public void addTask(AbstractReplicationTask task) {
-    if (getTotalInFlightReplications() >= maxQueueSize) {
+    final int max = maxQueueSize;
+    if (getTotalInFlightReplications() >= max) {
       LOG.warn("Ignored {} command for container {} in Replication Supervisor"
               + "as queue reached max size of {}.",
-          task.getClass(), task.getContainerId(), maxQueueSize);
+          task.getClass(), task.getContainerId(), max);
       return;
     }
+
     if (inFlight.add(task)) {
       if (task.getPriority() != ReplicationCommandPriority.LOW) {
         // Low priority tasks are not included in the replication queue sizes
@@ -178,10 +273,32 @@ public class ReplicationSupervisor {
     return inFlight.size();
   }
 
+  public int getMaxQueueSize() {
+    return maxQueueSize;
+  }
+
+  public void nodeStateUpdated(HddsProtos.NodeOperationalState newState) {
+    if (state.getAndSet(newState) != newState) {
+      int threadCount = replicationConfig.getReplicationMaxStreams();
+      int newMaxQueueSize = datanodeConfig.getCommandQueueLimit();
+
+      if (isMaintenance(newState) || isDecommission(newState)) {
+        threadCount *= 2;
+        newMaxQueueSize *= 2;
+      }
+
+      LOG.info("Node state updated to {}, scaling executor pool size to {}",
+          newState, threadCount);
+
+      maxQueueSize = newMaxQueueSize;
+      executorThreadUpdater.accept(threadCount);
+    }
+  }
+
   /**
    * An executable form of a replication task with status handling.
    */
-  public final class TaskRunner implements Comparable, Runnable {
+  public final class TaskRunner implements Comparable<TaskRunner>, Runnable {
     private final AbstractReplicationTask task;
 
     public TaskRunner(AbstractReplicationTask task) {
@@ -257,8 +374,8 @@ public class ReplicationSupervisor {
     }
 
     @Override
-    public int compareTo(Object o) {
-      return TASK_RUNNER_COMPARATOR.compare(this, (TaskRunner) o);
+    public int compareTo(TaskRunner o) {
+      return TASK_RUNNER_COMPARATOR.compare(this, o);
     }
 
     @Override

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/replication/ReplicationSupervisorScheduling.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/replication/ReplicationSupervisorScheduling.java
@@ -17,8 +17,6 @@
  */
 package org.apache.hadoop.ozone.container.replication;
 
-import java.time.Clock;
-import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -26,7 +24,6 @@ import java.util.Map;
 import java.util.Random;
 import java.util.UUID;
 
-import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
 import org.apache.hadoop.hdds.protocol.MockDatanodeDetails;
 
@@ -47,9 +44,6 @@ public class ReplicationSupervisorScheduling {
 
   @Test
   public void test() throws InterruptedException {
-    OzoneConfiguration conf = new OzoneConfiguration();
-    ReplicationServer.ReplicationConfig replicationConfig
-        = conf.getObject(ReplicationServer.ReplicationConfig.class);
     List<DatanodeDetails> datanodes = new ArrayList<>();
     datanodes.add(MockDatanodeDetails.randomDatanodeDetails());
     datanodes.add(MockDatanodeDetails.randomDatanodeDetails());
@@ -110,8 +104,7 @@ public class ReplicationSupervisorScheduling {
       }
     };
 
-    ReplicationSupervisor rs = new ReplicationSupervisor(null,
-        replicationConfig, Clock.system(ZoneId.systemDefault()), 1000);
+    ReplicationSupervisor rs = ReplicationSupervisor.newBuilder().build();
 
     final long start = System.currentTimeMillis();
 

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/LegacyReplicationManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/LegacyReplicationManager.java
@@ -2189,7 +2189,7 @@ public class LegacyReplicationManager {
         final long dataSizeRequired = Math.max(container.getUsedBytes(),
             currentContainerSize);
         final List<DatanodeDetails> excludeList = replicas.stream()
-                .filter(r -> !r.getDatanodeDetails().isDecomissioned())
+                .filter(r -> !r.getDatanodeDetails().isDecommissioned())
             .map(ContainerReplica::getDatanodeDetails)
             .collect(Collectors.toList());
         excludeList.addAll(replicationInFlight);

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ReplicationManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ReplicationManager.java
@@ -89,6 +89,8 @@ import java.util.concurrent.locks.ReentrantLock;
 import static org.apache.hadoop.hdds.conf.ConfigTag.DATANODE;
 import static org.apache.hadoop.hdds.conf.ConfigTag.OZONE;
 import static org.apache.hadoop.hdds.conf.ConfigTag.SCM;
+import static org.apache.hadoop.hdds.protocol.DatanodeDetails.isDecommission;
+import static org.apache.hadoop.hdds.protocol.DatanodeDetails.isMaintenance;
 import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationType.EC;
 import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationType.RATIS;
 
@@ -533,7 +535,7 @@ public class ReplicationManager implements SCMService {
     datanodes.sort(Comparator.comparingInt(Pair::getLeft));
     DatanodeDetails datanode = datanodes.get(0).getRight();
     int currentCount = datanodes.get(0).getLeft();
-    if (currentCount + additionalCmdCount >= datanodeReplicationLimit) {
+    if (currentCount + additionalCmdCount >= getReplicationLimit(datanode)) {
       addExcludedNode(datanode);
     }
     return datanode;
@@ -555,8 +557,8 @@ public class ReplicationManager implements SCMService {
         = new ArrayList<>();
     for (DatanodeDetails dn : datanodes) {
       try {
-        int totalCount = getDatanodeQueuedReplicationCount(dn);
-        if (totalCount >= datanodeReplicationLimit) {
+        int totalCount = getQueuedReplicationCount(dn);
+        if (totalCount >= getReplicationLimit(dn)) {
           LOG.debug("Datanode {} has reached the maximum number of queued " +
               "commands, replication + reconstruction * {}: {})",
               dn, reconstructionCommandWeight, totalCount);
@@ -572,7 +574,7 @@ public class ReplicationManager implements SCMService {
     return datanodeWithCommandCount;
   }
 
-  private int getDatanodeQueuedReplicationCount(DatanodeDetails datanode)
+  private int getQueuedReplicationCount(DatanodeDetails datanode)
       throws NodeNotFoundException {
     Map<Type, Integer> counts = nodeManager.getTotalDatanodeCommandCounts(
         datanode, Type.replicateContainerCommand,
@@ -784,10 +786,9 @@ public class ReplicationManager implements SCMService {
     LOG.debug("Received a notification that the DN command count " +
         "has been updated for {}", datanode);
     // If there is an existing mapping, we may need to remove it
-    excludedNodes.computeIfPresent(datanode, (k, v) -> {
+    excludedNodes.computeIfPresent(datanode, (dn, v) -> {
       try {
-        if (getDatanodeQueuedReplicationCount(datanode)
-            < datanodeReplicationLimit) {
+        if (getQueuedReplicationCount(dn) < getReplicationLimit(dn)) {
           // Returning null removes the entry from the map
           return null;
         } else {
@@ -1407,6 +1408,15 @@ public class ReplicationManager implements SCMService {
   
   public ContainerReplicaPendingOps getContainerReplicaPendingOps() {
     return containerReplicaPendingOps;
+  }
+
+  private int getReplicationLimit(DatanodeDetails datanode) {
+    HddsProtos.NodeOperationalState state = datanode.getPersistedOpState();
+    int limit = datanodeReplicationLimit;
+    if (isMaintenance(state) || isDecommission(state)) {
+      limit *= 2;
+    }
+    return limit;
   }
 
   /**

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ReplicationManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ReplicationManager.java
@@ -590,10 +590,12 @@ public class ReplicationManager implements SCMService {
     for (DatanodeDetails dn : datanodes) {
       try {
         int totalCount = getQueuedReplicationCount(dn);
-        if (totalCount >= getReplicationLimit(dn)) {
-          LOG.debug("Datanode {} has reached the maximum number of queued " +
-              "commands, replication + reconstruction * {}: {})",
-              dn, reconstructionCommandWeight, totalCount);
+        int replicationLimit = getReplicationLimit(dn);
+        if (totalCount >= replicationLimit) {
+          LOG.debug("Datanode {} has reached the maximum of {} queued " +
+              "commands for state {}, replication + reconstruction * {}: {}",
+              dn, replicationLimit, dn.getPersistedOpState(),
+              reconstructionCommandWeight, totalCount);
           addExcludedNode(dn);
           continue;
         }

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestReplicationManager.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestReplicationManager.java
@@ -1161,7 +1161,7 @@ public class TestReplicationManager {
         MockDatanodeDetails.randomDatanodeDetails(), 1);
 
     Set<DatanodeDetails> excluded = replicationManager.getExcludedNodes();
-    Assert.assertEquals(excluded.size(), 1);
+    Assert.assertEquals(1, excluded.size());
     // dn 3 was at the limit already, so should be added when filtering the
     // nodes
     Assert.assertTrue(excluded.contains(dn3));
@@ -1184,20 +1184,19 @@ public class TestReplicationManager {
         container, dn1, dn2);
     replicationManager.sendThrottledReconstructionCommand(container, command);
     excluded = replicationManager.getExcludedNodes();
-    Assert.assertEquals(excluded.size(), 1);
+    Assert.assertEquals(1, excluded.size());
     // dn 2 reached the limit from the reconstruction command
     Assert.assertTrue(excluded.contains(dn2));
 
     // Update received for DN2, it should be cleared from the excluded list.
     replicationManager.datanodeCommandCountUpdated(dn2);
     excluded = replicationManager.getExcludedNodes();
-    Assert.assertEquals(excluded.size(), 0);
+    Assert.assertEquals(0, excluded.size());
 
     // Finally, update received for DN1 - it is not excluded and should not
     // be added or cause any problems by not being there
     replicationManager.datanodeCommandCountUpdated(dn1);
-    Assert.assertEquals(excluded.size(), 0);
-    Assert.assertFalse(excluded.contains(dn1));
+    Assert.assertEquals(0, excluded.size());
   }
 
   @Test


### PR DESCRIPTION
## What changes were proposed in this pull request?

When a datanode switches to a decommissioning state, it will adjust the size of the replication supervisor thread pool higher, and if the node returns to the In Service state, it will return to the lower thread pool limit.

Similarly when scheduling commands, SCM can allocate more commands to the decommissioning host, as it should process them more quickly due to the lower load and increased threadpool.

 * Scale the size of executor thread pool and command queue for replication in datanode if state changes between in-service and out-of-service
 * Similarly scale the limit of pending replication commands at SCM
 * Simplify `TestReplicationSupervisor#testMaxQueueSize` to avoid the use of thread pool (possible source of intermittent failures recently [1](https://github.com/apache/ozone/actions/runs/4866567976/jobs/8678244002#step:6:1219), [2](https://github.com/apache/ozone/actions/runs/4869395310/jobs/8683855578#step:6:1219), [3](https://github.com/apache/ozone/actions/runs/4870358276/jobs/8686015439#step:6:1219))

https://issues.apache.org/jira/browse/HDDS-8494

## How was this patch tested?

Added unit test.

Tested in `ozone` compose environment with 6 nodes: created RATIS and EC keys, decommissioned and recommissioned one of the datanodes.

````
2023-05-02 16:37:20,303 [Command processor thread] INFO replication.ReplicationSupervisor: Node state updated to DECOMMISSIONING, scaling executor pool size to 20
...
2023-05-02 16:39:16,353 [Command processor thread] INFO replication.ReplicationSupervisor: Node state updated to IN_SERVICE, scaling executor pool size to 10
```