### PR TITLE
HDDS-8514. Improve ozone admin cert list subcommand count limits

### DIFF
--- a/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/cert/ListSubcommand.java
+++ b/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/cert/ListSubcommand.java
@@ -46,6 +46,8 @@ public class ListSubcommand extends ScmCertSubcommand {
   private static final Logger LOG =
       LoggerFactory.getLogger(ListSubcommand.class);
 
+  private static final int MAX_FETCHED_CERTIFICATES = 999;
+
   @Option(names = {"-s", "--start"},
       description = "Certificate serial id to start the iteration",
       defaultValue = "0", showDefaultValue = Visibility.ALWAYS)
@@ -91,6 +93,10 @@ public class ListSubcommand extends ScmCertSubcommand {
         startSerialId, count, isRevoked);
     LOG.info("Certificate list:(Type={}, BatchSize={}, CertCount={})",
         type.toUpperCase(), count, certPemList.size());
+    if (count == certPemList.size()) {
+      LOG.info("The certificate list could be longer than the batch size. " +
+          "Please use the \"-c\" option to see more certificates.");
+    }
     LOG.info(String.format(OUTPUT_FORMAT, "SerialNumber", "Valid From",
         "Expiry", "Subject", "Issuer"));
     for (String certPemStr : certPemList) {

--- a/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/cert/ListSubcommand.java
+++ b/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/cert/ListSubcommand.java
@@ -46,8 +46,6 @@ public class ListSubcommand extends ScmCertSubcommand {
   private static final Logger LOG =
       LoggerFactory.getLogger(ListSubcommand.class);
 
-  private static final int MAX_FETCHED_CERTIFICATES = 999;
-
   @Option(names = {"-s", "--start"},
       description = "Certificate serial id to start the iteration",
       defaultValue = "0", showDefaultValue = Visibility.ALWAYS)
@@ -94,8 +92,8 @@ public class ListSubcommand extends ScmCertSubcommand {
     LOG.info("Certificate list:(Type={}, BatchSize={}, CertCount={})",
         type.toUpperCase(), count, certPemList.size());
     if (count == certPemList.size()) {
-      LOG.info("The certificate list could be longer than the batch size. " +
-          "Please use the \"-c\" option to see more certificates.");
+      LOG.info("The certificate list could be longer than the batch size: {}." +
+          " Please use the \"-c\" option to see more certificates.", count);
     }
     LOG.info(String.format(OUTPUT_FORMAT, "SerialNumber", "Valid From",
         "Expiry", "Subject", "Issuer"));


### PR DESCRIPTION
## What changes were proposed in this pull request?

Add a warning to the user when the list subcommand lists too few certificates that they should increase the batch size.

## What is the link to the Apache JIRA

[HDDS-8514](https://issues.apache.org/jira/browse/HDDS-8514)

## How was this patch tested?

Github actions show no test failures and tried out the command on a local cluster.