### PR TITLE
HDDS-8289. Speed up FSO ListKeys, skip skipToFirst

### DIFF
--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneListStatusHelper.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneListStatusHelper.java
@@ -340,13 +340,9 @@ public class OzoneListStatusHelper {
             String prefixKey, String startKey) throws IOException {
       this.iterType = iterType;
       this.table = table;
-      this.tableIterator = table.iterator();
+      this.tableIterator = table.iterator(prefixKey);
       this.prefixKey = prefixKey;
       this.currentKey = null;
-
-      if (!StringUtils.isBlank(prefixKey)) {
-        tableIterator.seek(prefixKey);
-      }
 
       // only seek for the start key if the start key is lexicographically
       // after the prefix key. For example


### PR DESCRIPTION

## What changes were proposed in this pull request?
When listing keys in FSO, there is no need to seek first if the prefix is provided.

Constructor for RDB Store seeks first if the prefix is not set. ListKeys calls in FSO should forward the prefix to the constructor to avoid wastefully seeks.

```
  public RDBStoreIterator(ManagedRocksIterator iterator, RDBTable table,
      byte[] prefix) {
    this.rocksDBIterator = iterator;
    this.rocksDBTable = table;
    if (prefix != null) {
      this.prefix = Arrays.copyOf(prefix, prefix.length);
    }
    seekToFirst();
  }
```

This is related to https://issues.apache.org/jira/browse/HDDS-8289 but not be sufficient to improve the entire performance issue but should help.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-8289

## How was this patch tested?

Existing tests should cover this.
