### PR TITLE
HDDS-8525. Provide more info in assertions

### DIFF
--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/ozone/client/io/ECBlockReconstructedStripeInputStream.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/ozone/client/io/ECBlockReconstructedStripeInputStream.java
@@ -277,7 +277,8 @@ public class ECBlockReconstructedStripeInputStream extends ECBlockInputStream {
   }
 
   private void assignBuffers(ByteBuffer[] bufs) {
-    Preconditions.assertTrue(bufs.length == getExpectedBufferCount());
+    Preconditions.assertSame(getExpectedBufferCount(), bufs.length,
+        "buffer count");
 
     if (isOfflineRecovery()) {
       decoderOutputBuffers = bufs;
@@ -409,10 +410,11 @@ public class ECBlockReconstructedStripeInputStream extends ECBlockInputStream {
   }
 
   private void validateBuffers(ByteBuffer[] bufs) {
-    Preconditions.assertTrue(bufs.length == getExpectedBufferCount());
+    Preconditions.assertSame(getExpectedBufferCount(), bufs.length,
+        "buffer count");
     int chunkSize = getRepConfig().getEcChunkSize();
     for (ByteBuffer b : bufs) {
-      Preconditions.assertTrue(b.remaining() == chunkSize);
+      Preconditions.assertSame(chunkSize, b.remaining(), "buf.remaining");
     }
   }
 
@@ -442,7 +444,7 @@ public class ECBlockReconstructedStripeInputStream extends ECBlockInputStream {
     for (int i = dataNum; i < dataNum + parityNum; i++) {
       ByteBuffer b = decoderInputBuffers[i];
       if (b != null) {
-        Preconditions.assertTrue(b.position() == paritySize);
+        Preconditions.assertSame(paritySize, b.position(), "buf.position");
       }
     }
     // The output buffers need their limit set to the parity size
@@ -764,8 +766,10 @@ public class ECBlockReconstructedStripeInputStream extends ECBlockInputStream {
 
     if (isOfflineRecovery()) {
       if (!paddingIndexes.isEmpty()) {
-        paddingIndexes.forEach(i ->
-            Preconditions.assertTrue(!recoveryIndexes.contains(i)));
+        paddingIndexes.forEach(i -> Preconditions.assertTrue(
+            !recoveryIndexes.contains(i),
+            () -> "Padding index " + i + " should not be selected for recovery")
+        );
       }
 
       missingIndexes.addAll(recoveryIndexes);

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/health/EmptyContainerHandler.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/health/EmptyContainerHandler.java
@@ -101,14 +101,15 @@ public class EmptyContainerHandler extends AbstractCheck {
    */
   private void deleteContainerReplicas(final ContainerInfo containerInfo,
       final Set<ContainerReplica> replicas) {
-    Preconditions.assertTrue(containerInfo.getState() ==
-        HddsProtos.LifeCycleState.CLOSED);
-    Preconditions.assertTrue(containerInfo.getNumberOfKeys() == 0);
+    Preconditions.assertSame(HddsProtos.LifeCycleState.CLOSED,
+        containerInfo.getState(), "container state");
+    Preconditions.assertSame(0L, containerInfo.getNumberOfKeys(),
+        "key count");
 
     for (ContainerReplica rp : replicas) {
-      Preconditions.assertTrue(
-          rp.getState() == ContainerReplicaProto.State.CLOSED);
-      Preconditions.assertTrue(rp.getKeyCount() == 0);
+      Preconditions.assertSame(ContainerReplicaProto.State.CLOSED,
+          rp.getState(), "replica state");
+      Preconditions.assertSame(0, rp.getKeyCount(), "replica key count");
 
       try {
         replicationManager.sendDeleteCommand(containerInfo,


### PR DESCRIPTION
## What changes were proposed in this pull request?

To get more info on precondition failures, add explicit message for `assertTrue( == )` or replace with `assertSame`.

(This change is limited to EC and replication classes, excluding `LegacyReplicationManager`.)

https://issues.apache.org/jira/browse/HDDS-8525

## How was this patch tested?

Only CI for any regression:
https://github.com/adoroszlai/hadoop-ozone/actions/runs/4881090501