### PR TITLE
HDDS-8534. Enable asynchronous service logging

### DIFF
--- a/hadoop-ozone/dist/src/shell/conf/log4j.properties
+++ b/hadoop-ozone/dist/src/shell/conf/log4j.properties
@@ -15,7 +15,7 @@
 # limitations under the License.
 
 # Define some default values that can be overridden by system properties
-hadoop.root.logger=INFO,console
+hadoop.root.logger=INFO,console,ASYNCRFA
 hadoop.log.dir=.
 hadoop.log.file=hadoop.log
 
@@ -46,6 +46,14 @@ log4j.appender.RFA.layout.ConversionPattern=%d{ISO8601} [%t] %p %c: %m%n
 # Debugging Pattern format
 #log4j.appender.RFA.layout.ConversionPattern=%d{ISO8601} [%t] %-5p %c{2} (%F:%M(%L)) - %m%n
 
+#
+# Async Rolling File Appender
+#
+log4j.appender.ASYNCRFA=org.apache.hadoop.ozone.utils.AsyncRFAAppender
+log4j.appender.ASYNCRFA.fileName=${hadoop.log.dir}/${hadoop.log.file}
+log4j.appender.ASYNCRFA.maxFileSize=${hadoop.log.maxfilesize}
+log4j.appender.ASYNCRFA.maxBackupIndex=${hadoop.log.maxbackupindex}
+log4j.appender.ASYNCRFA.conversionPattern=%d{ISO8601} [%t] %p %c: %m%n
 
 #
 # Daily Rolling File Appender

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/utils/AsyncRFAAppender.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/utils/AsyncRFAAppender.java
@@ -1,0 +1,128 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.ozone.utils;
+
+import java.io.IOException;
+
+import org.apache.log4j.AsyncAppender;
+import org.apache.log4j.PatternLayout;
+import org.apache.log4j.RollingFileAppender;
+import org.apache.log4j.spi.LoggingEvent;
+
+/**
+ * The AsyncRFAAppender shall take the required parameters for supplying
+ * RollingFileAppender to AsyncAppender.
+ */
+public class AsyncRFAAppender extends AsyncAppender {
+
+  private String maxFileSize = String.valueOf(10 * 1024 * 1024);
+
+  private int maxBackupIndex = 1;
+
+  private String fileName = null;
+
+  private String conversionPattern = null;
+
+  private boolean blocking = true;
+
+  private int bufferSize = DEFAULT_BUFFER_SIZE;
+
+  private RollingFileAppender rollingFileAppender = null;
+
+  private volatile boolean isRollingFileAppenderAssigned = false;
+
+  @Override
+  public void append(LoggingEvent event) {
+    if (rollingFileAppender == null) {
+      appendRFAToAsyncAppender();
+    }
+    super.append(event);
+  }
+
+  private synchronized void appendRFAToAsyncAppender() {
+    if (!isRollingFileAppenderAssigned) {
+      PatternLayout patternLayout;
+      if (conversionPattern != null) {
+        patternLayout = new PatternLayout(conversionPattern);
+      } else {
+        patternLayout = new PatternLayout();
+      }
+      try {
+        rollingFileAppender =
+            new RollingFileAppender(patternLayout, fileName, true);
+      } catch (IOException e) {
+        throw new RuntimeException(e);
+      }
+      rollingFileAppender.setMaxBackupIndex(maxBackupIndex);
+      rollingFileAppender.setMaxFileSize(maxFileSize);
+      this.addAppender(rollingFileAppender);
+      isRollingFileAppenderAssigned = true;
+      super.setBlocking(blocking);
+      super.setBufferSize(bufferSize);
+    }
+  }
+
+  public String getMaxFileSize() {
+    return maxFileSize;
+  }
+
+  public void setMaxFileSize(String maxFileSize) {
+    this.maxFileSize = maxFileSize;
+  }
+
+  public int getMaxBackupIndex() {
+    return maxBackupIndex;
+  }
+
+  public void setMaxBackupIndex(int maxBackupIndex) {
+    this.maxBackupIndex = maxBackupIndex;
+  }
+
+  public String getFileName() {
+    return fileName;
+  }
+
+  public void setFileName(String fileName) {
+    this.fileName = fileName;
+  }
+
+  public String getConversionPattern() {
+    return conversionPattern;
+  }
+
+  public void setConversionPattern(String conversionPattern) {
+    this.conversionPattern = conversionPattern;
+  }
+
+  public boolean isBlocking() {
+    return blocking;
+  }
+
+  public void setBlocking(boolean blocking) {
+    this.blocking = blocking;
+  }
+
+  public int getBufferSize() {
+    return bufferSize;
+  }
+
+  public void setBufferSize(int bufferSize) {
+    this.bufferSize = bufferSize;
+  }
+}

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/utils/package-info.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/utils/package-info.java
@@ -1,0 +1,23 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * Utility classes for Ozone.
+ */
+package org.apache.hadoop.ozone.utils;


### PR DESCRIPTION
## What changes were proposed in this pull request?

Currently, asynchronous service logging is not supported in Ozone. However, we do support asynchronous audit logging. 
Enabling asynchronous service logging can improve performance by allowing the logging thread to continue executing without waiting for the actual logging operation to complete, reducing the impact of logging on the overall system performance.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-8534

## How was this patch tested?

(Please explain how this patch was tested. Ex: unit tests, manual tests)
