### PR TITLE
HDDS-8542. In RDBTable, add a put method using RocksDB ByteBuffer APIs.

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/StringUtils.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/StringUtils.java
@@ -17,7 +17,8 @@
  */
 package org.apache.hadoop.hdds;
 
-import java.io.UnsupportedEncodingException;
+import java.nio.ByteBuffer;
+import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -30,6 +31,7 @@ import org.apache.hadoop.hdds.utils.SignalLogger;
 import org.apache.hadoop.hdds.utils.VersionInfo;
 import org.apache.hadoop.net.NetUtils;
 import org.apache.hadoop.util.ShutdownHookManager;
+import org.apache.ratis.thirdparty.io.netty.buffer.Unpooled;
 import org.slf4j.Logger;
 
 /**
@@ -40,9 +42,7 @@ public final class StringUtils {
   private StringUtils() {
   }
 
-  // Using the charset canonical name for String/byte[] conversions is much
-  // more efficient due to use of cached encoders/decoders.
-  private static final String UTF8_CSN = StandardCharsets.UTF_8.name();
+  private static final Charset UTF8 = StandardCharsets.UTF_8;
 
   /**
    * Priority of the StringUtils shutdown hook.
@@ -59,12 +59,11 @@ public final class StringUtils {
    * @return The decoded string
    */
   public static String bytes2String(byte[] bytes, int offset, int length) {
-    try {
-      return new String(bytes, offset, length, UTF8_CSN);
-    } catch (UnsupportedEncodingException e) {
-      // should never happen!
-      throw new IllegalArgumentException("UTF8 encoding is not supported", e);
-    }
+    return new String(bytes, offset, length, UTF8);
+  }
+
+  public static String bytes2String(ByteBuffer bytes) {
+    return Unpooled.wrappedBuffer(bytes.asReadOnlyBuffer()).toString(UTF8);
   }
 
   /**
@@ -82,12 +81,7 @@ public final class StringUtils {
    * Converts a string to a byte array using UTF8 encoding.
    */
   public static byte[] string2Bytes(String str) {
-    try {
-      return str.getBytes(UTF8_CSN);
-    } catch (UnsupportedEncodingException e) {
-      // should never happen!
-      throw new IllegalArgumentException("UTF8 decoding is not supported", e);
-    }
+    return str.getBytes(UTF8);
   }
 
   /**

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/utils/db/Codec.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/utils/db/Codec.java
@@ -20,24 +20,25 @@ package org.apache.hadoop.hdds.utils.db;
 
 import javax.annotation.Nonnull;
 import java.io.IOException;
-import java.nio.ByteBuffer;
+import java.util.function.IntFunction;
 
 /**
  * Codec interface to serialize/deserialize objects to/from bytes.
  * A codec implementation must support the byte[] methods
- * and may optionally support the {@link ByteBuffer} methods.
+ * and may optionally support the {@link CodecBuffer} methods.
  *
  * @param <T> The object type.
  */
 public interface Codec<T> {
   /**
-   * Does this {@link Codec} support the {@link ByteBuffer} methods?
+   * Does this {@link Codec} support the {@link CodecBuffer} methods?
    * If this method returns true, this class must implement both
-   * {@link #toByteBuffer(Object)} and {@link #fromByteBuffer(ByteBuffer)}.
+   * {@link #toCodecBuffer(Object, IntFunction)} and
+   * {@link #fromCodecBuffer(CodecBuffer)}.
    *
-   * @return ture iff this class supports the {@link ByteBuffer} methods.
+   * @return ture iff this class supports the {@link CodecBuffer} methods.
    */
-  default boolean supportByteBuffer() {
+  default boolean supportCodecBuffer() {
     return false;
   }
 
@@ -45,20 +46,32 @@ public interface Codec<T> {
    * Serialize the given object to bytes.
    *
    * @param object The object to be serialized.
-   * @return the serialized bytes.
+   * @param allocator To allocate a buffer.
+   * @return a buffer storing the serialized bytes.
    */
-  default ByteBuffer toByteBuffer(@Nonnull T object) throws IOException {
+  default CodecBuffer toCodecBuffer(@Nonnull T object,
+      IntFunction<CodecBuffer> allocator) throws IOException {
     throw new UnsupportedOperationException();
   }
 
   /**
-   * Deserialize an object from the given buffer.
-   * The position of the given buffer is incremented by the serialized size.
+   * Serialize the given object to bytes.
    *
-   * @param buffer Serialized bytes of an object.
+   * @param object The object to be serialized.
+   * @return a direct buffer storing the serialized bytes.
+   */
+  default CodecBuffer toDirectCodecBuffer(@Nonnull T object)
+      throws IOException {
+    return toCodecBuffer(object, CodecBuffer::allocateDirect);
+  }
+
+  /**
+   * Deserialize an object from the given buffer.
+   *
+   * @param buffer Storing the serialized bytes of an object.
    * @return the deserialized object.
    */
-  default T fromByteBuffer(@Nonnull ByteBuffer buffer) throws IOException {
+  default T fromCodecBuffer(@Nonnull CodecBuffer buffer) throws IOException {
     throw new UnsupportedOperationException();
   }
 

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/utils/db/Codec.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/utils/db/Codec.java
@@ -18,15 +18,49 @@
  */
 package org.apache.hadoop.hdds.utils.db;
 
+import javax.annotation.Nonnull;
 import java.io.IOException;
+import java.nio.ByteBuffer;
 
 /**
- * Codec interface to marshall/unmarshall data to/from a byte[] based
- * key/value store.
+ * Codec interface to serialize/deserialize objects to/from bytes.
+ * A codec implementation must support the byte[] methods
+ * and may optionally support the {@link ByteBuffer} methods.
  *
- * @param <T> Unserialized type
+ * @param <T> The object type.
  */
 public interface Codec<T> {
+  /**
+   * Does this {@link Codec} support the {@link ByteBuffer} methods?
+   * If this method returns true, this class must implement both
+   * {@link #toByteBuffer(Object)} and {@link #fromByteBuffer(ByteBuffer)}.
+   *
+   * @return ture iff this class supports the {@link ByteBuffer} methods.
+   */
+  default boolean supportByteBuffer() {
+    return false;
+  }
+
+  /**
+   * Serialize the given object to bytes.
+   *
+   * @param object The object to be serialized.
+   * @return the serialized bytes.
+   */
+  default ByteBuffer toByteBuffer(@Nonnull T object) throws IOException {
+    throw new UnsupportedOperationException();
+  }
+
+  /**
+   * Deserialize an object from the given buffer.
+   * The position of the given buffer is incremented by the serialized size.
+   *
+   * @param buffer Serialized bytes of an object.
+   * @return the deserialized object.
+   */
+  default T fromByteBuffer(@Nonnull ByteBuffer buffer) throws IOException {
+    throw new UnsupportedOperationException();
+  }
 
   /**
    * Convert object to raw persisted format.
@@ -42,8 +76,13 @@ public interface Codec<T> {
   T fromPersistedFormat(byte[] rawData) throws IOException;
 
   /**
-   * Copy Object from the provided object, and returns a new object.
-   * @param object
+   * Copy the given object.
+   * When the given object is immutable,
+   * the implementation of this method may safely return the given object.
+   *
+   * @param object The object to be copied.
+   * @return the same object if the given object is immutable;
+   *         otherwise, return a new copy of the given object.
    */
   T copyObject(T object);
 }

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/utils/db/Codec.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/utils/db/Codec.java
@@ -81,8 +81,8 @@ public interface Codec<T> {
    * the implementation of this method may safely return the given object.
    *
    * @param object The object to be copied.
-   * @return the same object if the given object is immutable;
-   *         otherwise, return a new copy of the given object.
+   * @return a copy of the given object.  When the given object is immutable,
+   *         the returned object can possibly be the same as the given object.
    */
   T copyObject(T object);
 }

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/utils/db/CodecBuffer.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/utils/db/CodecBuffer.java
@@ -1,0 +1,151 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hdds.utils.db;
+
+import org.apache.ratis.thirdparty.io.netty.buffer.ByteBuf;
+import org.apache.ratis.thirdparty.io.netty.buffer.ByteBufAllocator;
+import org.apache.ratis.thirdparty.io.netty.buffer.PooledByteBufAllocator;
+import org.apache.ratis.thirdparty.io.netty.buffer.Unpooled;
+import org.apache.ratis.util.Preconditions;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.nio.ByteBuffer;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * A buffer used by {@link Codec}
+ * for supporting RocksDB direct {@link ByteBuffer} APIs.
+ */
+public final class CodecBuffer implements AutoCloseable {
+  public static final Logger LOG = LoggerFactory.getLogger(CodecBuffer.class);
+
+  private static final ByteBufAllocator POOL
+      = PooledByteBufAllocator.DEFAULT;
+
+  /** Allocate a direct buffer. */
+  public static CodecBuffer allocateDirect(int exactSize) {
+    return new CodecBuffer(POOL.directBuffer(exactSize, exactSize));
+  }
+
+  /** Allocate a heap buffer. */
+  public static CodecBuffer allocateHeap(int exactSize) {
+    return new CodecBuffer(POOL.heapBuffer(exactSize, exactSize));
+  }
+
+  /** Wrap the given array. */
+  public static CodecBuffer wrap(byte[] array) {
+    return new CodecBuffer(Unpooled.wrappedBuffer(array));
+  }
+
+  private static final AtomicInteger LEAK_COUNT = new AtomicInteger();
+
+  /** Assert the number of leak detected is zero. */
+  public static void assertNoLeaks() {
+    final long leak = LEAK_COUNT.get();
+    if (leak > 0) {
+      throw new AssertionError("Found " + leak + " leaked objects, check logs");
+    }
+  }
+
+  private final ByteBuf buf;
+  private final AtomicBoolean released = new AtomicBoolean();
+
+  private CodecBuffer(ByteBuf buf) {
+    this.buf = buf;
+    assertRefCnt(1);
+  }
+
+  private void assertRefCnt(int expected) {
+    Preconditions.assertSame(expected, buf.refCnt(), "refCnt");
+  }
+
+  @Override
+  protected void finalize() throws Throwable {
+    // leak detection
+    final int capacity = buf.capacity();
+    if (!released.get() && capacity > 0) {
+      final int refCnt = buf.refCnt();
+      if (refCnt > 0) {
+        final int leak = LEAK_COUNT.incrementAndGet();
+        LOG.warn("LEAK {}: {}, refCnt={}, capacity={}",
+            leak, this, refCnt, capacity);
+        buf.release(refCnt);
+      }
+    }
+    super.finalize();
+  }
+
+  @Override
+  public void close() {
+    release();
+  }
+
+  /** Release this buffer and return it back to the pool. */
+  public void release() {
+    final boolean set = released.compareAndSet(false, true);
+    Preconditions.assertTrue(set, () -> "Already released: " + this);
+    if (buf.release()) {
+      assertRefCnt(0);
+    } else {
+      // A zero capacity buffer, possibly singleton, may not be able released.
+      Preconditions.assertSame(0, buf.capacity(), "capacity");
+    }
+  }
+
+  /** @return a readonly {@link ByteBuffer} view of this buffer. */
+  public ByteBuffer asReadOnlyByteBuffer() {
+    assertRefCnt(1);
+    Preconditions.assertTrue(buf.nioBufferCount() > 0);
+    return buf.nioBuffer().asReadOnlyBuffer();
+  }
+
+  /**
+   * Similar to {@link ByteBuffer#putInt(int)}.
+   *
+   * @return this object.
+   */
+  public CodecBuffer putInt(int n) {
+    assertRefCnt(1);
+    buf.writeInt(n);
+    return this;
+  }
+
+  /**
+   * Similar to {@link ByteBuffer#putLong(long)}.
+   *
+   * @return this object.
+   */
+  public CodecBuffer putLong(long n) {
+    assertRefCnt(1);
+    buf.writeLong(n);
+    return this;
+  }
+
+  /**
+   * Similar to {@link ByteBuffer#put(byte[])}.
+   *
+   * @return this object.
+   */
+  public CodecBuffer put(byte[] array) {
+    assertRefCnt(1);
+    buf.writeBytes(array);
+    return this;
+  }
+}

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/TestKeyValueContainer.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/TestKeyValueContainer.java
@@ -27,6 +27,7 @@ import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos;
 
 import org.apache.hadoop.hdds.scm.container.common.helpers
     .StorageContainerException;
+import org.apache.hadoop.hdds.utils.db.CodecBuffer;
 import org.apache.hadoop.hdds.utils.db.DBProfile;
 import org.apache.hadoop.hdds.utils.db.RDBStore;
 import org.apache.hadoop.hdds.utils.db.RocksDatabase.ColumnFamily;
@@ -54,6 +55,7 @@ import org.apache.ozone.test.GenericTestUtils;
 import org.apache.hadoop.util.DiskChecker;
 
 import org.assertj.core.api.Fail;
+import org.junit.After;
 import org.junit.Assert;
 import org.junit.Assume;
 import org.junit.Before;
@@ -157,6 +159,11 @@ public class TestKeyValueContainer {
         datanodeId.toString());
 
     keyValueContainer = new KeyValueContainer(keyValueContainerData, CONF);
+  }
+
+  @After
+  public void after() {
+    CodecBuffer.assertNoLeaks();
   }
 
   @Test

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/ByteArrayCodec.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/ByteArrayCodec.java
@@ -21,7 +21,7 @@ package org.apache.hadoop.hdds.utils.db;
 /**
  * Codec to convert byte array to/from byte array.
  */
-public class ByteArrayCodec implements Codec<byte[]> {
+public final class ByteArrayCodec implements Codec<byte[]> {
 
   @Override
   public byte[] toPersistedFormat(byte[] bytes) {

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/IntegerCodec.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/IntegerCodec.java
@@ -18,27 +18,29 @@
 
 package org.apache.hadoop.hdds.utils.db;
 
-import java.nio.ByteBuffer;
-
 import com.google.common.primitives.Ints;
+
+import javax.annotation.Nonnull;
+import java.util.function.IntFunction;
 
 /**
  * Codec to convert Integer to/from byte array.
  */
 public final class IntegerCodec implements Codec<Integer> {
   @Override
-  public boolean supportByteBuffer() {
+  public boolean supportCodecBuffer() {
     return true;
   }
 
   @Override
-  public ByteBuffer toByteBuffer(Integer object) {
-    return ByteBuffer.wrap(toPersistedFormat(object));
+  public CodecBuffer toCodecBuffer(@Nonnull Integer object,
+      IntFunction<CodecBuffer> allocator) {
+    return allocator.apply(Integer.BYTES).putInt(object);
   }
 
   @Override
-  public Integer fromByteBuffer(ByteBuffer rawData) {
-    return rawData.getInt();
+  public Integer fromCodecBuffer(@Nonnull CodecBuffer buffer) {
+    return buffer.asReadOnlyByteBuffer().getInt();
   }
 
   @Override

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/IntegerCodec.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/IntegerCodec.java
@@ -18,21 +18,36 @@
 
 package org.apache.hadoop.hdds.utils.db;
 
-import java.io.IOException;
+import java.nio.ByteBuffer;
 
 import com.google.common.primitives.Ints;
 
 /**
  * Codec to convert Integer to/from byte array.
  */
-public class IntegerCodec implements Codec<Integer> {
+public final class IntegerCodec implements Codec<Integer> {
   @Override
-  public byte[] toPersistedFormat(Integer object) throws IOException {
+  public boolean supportByteBuffer() {
+    return true;
+  }
+
+  @Override
+  public ByteBuffer toByteBuffer(Integer object) {
+    return ByteBuffer.wrap(toPersistedFormat(object));
+  }
+
+  @Override
+  public Integer fromByteBuffer(ByteBuffer rawData) {
+    return rawData.getInt();
+  }
+
+  @Override
+  public byte[] toPersistedFormat(Integer object) {
     return Ints.toByteArray(object);
   }
 
   @Override
-  public Integer fromPersistedFormat(byte[] rawData) throws IOException {
+  public Integer fromPersistedFormat(byte[] rawData) {
     return Ints.fromByteArray(rawData);
   }
 

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/LongCodec.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/LongCodec.java
@@ -20,25 +20,27 @@ package org.apache.hadoop.hdds.utils.db;
 
 import com.google.common.primitives.Longs;
 
-import java.nio.ByteBuffer;
+import javax.annotation.Nonnull;
+import java.util.function.IntFunction;
 
 /**
  * Codec to convert Long to/from byte array.
  */
 public final class LongCodec implements Codec<Long> {
   @Override
-  public boolean supportByteBuffer() {
+  public boolean supportCodecBuffer() {
     return true;
   }
 
   @Override
-  public ByteBuffer toByteBuffer(Long object) {
-    return ByteBuffer.wrap(toPersistedFormat(object));
+  public CodecBuffer toCodecBuffer(@Nonnull Long object,
+      IntFunction<CodecBuffer> allocator) {
+    return allocator.apply(Long.BYTES).putLong(object);
   }
 
   @Override
-  public Long fromByteBuffer(ByteBuffer rawData) {
-    return rawData.getLong();
+  public Long fromCodecBuffer(@Nonnull CodecBuffer buffer) {
+    return buffer.asReadOnlyByteBuffer().getLong();
   }
 
   @Override

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/LongCodec.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/LongCodec.java
@@ -20,11 +20,26 @@ package org.apache.hadoop.hdds.utils.db;
 
 import com.google.common.primitives.Longs;
 
+import java.nio.ByteBuffer;
 
 /**
  * Codec to convert Long to/from byte array.
  */
-public class LongCodec implements Codec<Long> {
+public final class LongCodec implements Codec<Long> {
+  @Override
+  public boolean supportByteBuffer() {
+    return true;
+  }
+
+  @Override
+  public ByteBuffer toByteBuffer(Long object) {
+    return ByteBuffer.wrap(toPersistedFormat(object));
+  }
+
+  @Override
+  public Long fromByteBuffer(ByteBuffer rawData) {
+    return rawData.getLong();
+  }
 
   @Override
   public byte[] toPersistedFormat(Long object) {

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/RDBStore.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/RDBStore.java
@@ -255,7 +255,7 @@ public class RDBStore implements DBStore {
   }
 
   @Override
-  public Table<byte[], byte[]> getTable(String name) throws IOException {
+  public RDBTable getTable(String name) throws IOException {
     final ColumnFamily handle = db.getColumnFamily(name);
     if (handle == null) {
       throw new IOException("No such table in this DB. TableName : " + name);

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/RDBTable.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/RDBTable.java
@@ -21,6 +21,7 @@ package org.apache.hadoop.hdds.utils.db;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.ByteBuffer;
 import java.util.List;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -39,7 +40,6 @@ import org.slf4j.LoggerFactory;
  */
 @InterfaceAudience.Private
 class RDBTable implements Table<byte[], byte[]> {
-
 
   private static final Logger LOG =
       LoggerFactory.getLogger(RDBTable.class);
@@ -63,6 +63,10 @@ class RDBTable implements Table<byte[], byte[]> {
 
   public ColumnFamily getColumnFamily() {
     return family;
+  }
+
+  public void put(ByteBuffer key, ByteBuffer value) throws IOException {
+    db.put(family, key, value);
   }
 
   @Override

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/RDBTable.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/RDBTable.java
@@ -41,6 +41,7 @@ import org.slf4j.LoggerFactory;
 @InterfaceAudience.Private
 class RDBTable implements Table<byte[], byte[]> {
 
+
   private static final Logger LOG =
       LoggerFactory.getLogger(RDBTable.class);
 

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/RocksDatabase.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/RocksDatabase.java
@@ -45,6 +45,7 @@ import org.slf4j.LoggerFactory;
 import java.io.Closeable;
 import java.io.File;
 import java.io.IOException;
+import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.util.ArrayList;
@@ -432,6 +433,20 @@ public final class RocksDatabase {
   }
 
   public void put(ColumnFamily family, byte[] key, byte[] value)
+      throws IOException {
+    assertClose();
+    try {
+      counter.incrementAndGet();
+      db.get().put(family.getHandle(), writeOptions, key, value);
+    } catch (RocksDBException e) {
+      closeOnError(e, true);
+      throw toIOException(this, "put " + bytes2String(key), e);
+    } finally {
+      counter.decrementAndGet();
+    }
+  }
+
+  public void put(ColumnFamily family, ByteBuffer key, ByteBuffer value)
       throws IOException {
     assertClose();
     try {

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/StringCodec.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/StringCodec.java
@@ -18,7 +18,8 @@
  */
 package org.apache.hadoop.hdds.utils.db;
 
-import java.nio.ByteBuffer;
+import java.util.function.IntFunction;
+import javax.annotation.Nonnull;
 
 import org.apache.hadoop.hdds.StringUtils;
 
@@ -27,18 +28,20 @@ import org.apache.hadoop.hdds.StringUtils;
  */
 public final class StringCodec implements Codec<String> {
   @Override
-  public boolean supportByteBuffer() {
+  public boolean supportCodecBuffer() {
     return true;
   }
 
   @Override
-  public ByteBuffer toByteBuffer(String object) {
-    return ByteBuffer.wrap(toPersistedFormat(object));
+  public CodecBuffer toCodecBuffer(@Nonnull String object,
+      IntFunction<CodecBuffer> allocator) {
+    final byte[] array = toPersistedFormat(object);
+    return allocator.apply(array.length).put(array);
   }
 
   @Override
-  public String fromByteBuffer(ByteBuffer rawData) {
-    return StringUtils.bytes2String(rawData);
+  public String fromCodecBuffer(@Nonnull CodecBuffer buffer) {
+    return StringUtils.bytes2String(buffer.asReadOnlyByteBuffer());
   }
 
   @Override

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/StringCodec.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/StringCodec.java
@@ -18,17 +18,31 @@
  */
 package org.apache.hadoop.hdds.utils.db;
 
-import java.io.IOException;
+import java.nio.ByteBuffer;
 
 import org.apache.hadoop.hdds.StringUtils;
 
 /**
  * Codec to convert String to/from byte array.
  */
-public class StringCodec implements Codec<String> {
+public final class StringCodec implements Codec<String> {
+  @Override
+  public boolean supportByteBuffer() {
+    return true;
+  }
 
   @Override
-  public byte[] toPersistedFormat(String object) throws IOException {
+  public ByteBuffer toByteBuffer(String object) {
+    return ByteBuffer.wrap(toPersistedFormat(object));
+  }
+
+  @Override
+  public String fromByteBuffer(ByteBuffer rawData) {
+    return StringUtils.bytes2String(rawData);
+  }
+
+  @Override
+  public byte[] toPersistedFormat(String object) {
     if (object != null) {
       return StringUtils.string2Bytes(object);
     } else {

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/TypedTable.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/TypedTable.java
@@ -120,8 +120,8 @@ public class TypedTable<KEY, VALUE> implements Table<KEY, VALUE> {
     final Codec<KEY> keyCodec = codecRegistry.getCodec(key);
     final Codec<VALUE> valueCodec = codecRegistry.getCodec(value);
     if (keyCodec.supportCodecBuffer() && valueCodec.supportCodecBuffer()) {
-      try(CodecBuffer k = keyCodec.toDirectCodecBuffer(key);
-          CodecBuffer v = valueCodec.toDirectCodecBuffer(value)) {
+      try (CodecBuffer k = keyCodec.toDirectCodecBuffer(key);
+           CodecBuffer v = valueCodec.toDirectCodecBuffer(value)) {
         rawTable.put(k.asReadOnlyByteBuffer(), v.asReadOnlyByteBuffer());
       }
       return;

--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/utils/TestRDBSnapshotProvider.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/utils/TestRDBSnapshotProvider.java
@@ -21,6 +21,7 @@ package org.apache.hadoop.hdds.utils;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.hadoop.fs.FileUtil;
 import org.apache.hadoop.hdds.StringUtils;
+import org.apache.hadoop.hdds.utils.db.CodecBuffer;
 import org.apache.hadoop.hdds.utils.db.DBCheckpoint;
 import org.apache.hadoop.hdds.utils.db.RDBStore;
 import org.apache.hadoop.hdds.utils.db.Table;
@@ -132,6 +133,7 @@ public class TestRDBSnapshotProvider {
     if (testDir.exists()) {
       FileUtil.fullyDelete(testDir);
     }
+    CodecBuffer.assertNoLeaks();
   }
 
   @Test

--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/utils/db/TestCodec.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/utils/db/TestCodec.java
@@ -14,13 +14,15 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
  */
 package org.apache.hadoop.hdds.utils.db;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
+import java.lang.ref.WeakReference;
 import java.nio.ByteBuffer;
 import java.util.concurrent.ThreadLocalRandom;
 
@@ -28,7 +30,24 @@ import java.util.concurrent.ThreadLocalRandom;
  * Test {@link Codec} implementations.
  */
 public final class TestCodec {
+  static final Logger LOG = LoggerFactory.getLogger(TestCodec.class);
   static final int NUM_LOOPS = 10;
+
+  /** Force gc to check leakage. */
+  static void gc() throws InterruptedException {
+    // use WeakReference to detect gc
+    Object obj = new Object();
+    final WeakReference<Object> weakRef = new WeakReference<>(obj);
+    obj = null;
+
+    // loop until gc has completed.
+    for(int i = 0; weakRef.get() != null; i++) {
+      LOG.info("gc {}", i);
+      System.gc();
+      Thread.sleep(100);
+    }
+    CodecBuffer.assertNoLeaks();
+  }
 
   @Test
   public void testIntegerCodec() throws Exception {
@@ -43,6 +62,7 @@ public final class TestCodec {
       final int original = ThreadLocalRandom.current().nextInt();
       runTest(codec, original, Integer.BYTES);
     }
+    gc();
   }
 
   @Test
@@ -58,6 +78,7 @@ public final class TestCodec {
       final long original = ThreadLocalRandom.current().nextLong();
       runTest(codec, original, Long.BYTES);
     }
+    gc();
   }
 
   @Test
@@ -69,27 +90,41 @@ public final class TestCodec {
       final String original = "test" + ThreadLocalRandom.current().nextLong();
       runTest(codec, original, original.length());
     }
+    gc();
   }
 
   static <T> void runTest(Codec<T> codec, T original,
       Integer serializedSize) throws Exception {
+    Assertions.assertTrue(codec.supportCodecBuffer());
+
+    // serialize to byte[]
     final byte[] array = codec.toPersistedFormat(original);
     if (serializedSize != null) {
       Assertions.assertEquals(serializedSize, array.length);
     }
+    // deserialize from byte[]
     final T fromArray = codec.fromPersistedFormat(array);
     Assertions.assertEquals(original, fromArray);
 
-    final ByteBuffer buffer = codec.toByteBuffer(original);
-    Assertions.assertEquals(array.length, buffer.remaining());
+    // serialize to CodecBuffer
+    final CodecBuffer codecBuffer = codec.toCodecBuffer(
+        original, CodecBuffer::allocateHeap);
+    final ByteBuffer byteBuffer = codecBuffer.asReadOnlyByteBuffer();
+    Assertions.assertEquals(array.length, byteBuffer.remaining());
     for (int i = 0; i < array.length; i++) {
-      Assertions.assertEquals(array[i], buffer.get(i));
+      // assert exact content
+      Assertions.assertEquals(array[i], byteBuffer.get(i));
     }
 
-    final T fromBuffer = codec.fromByteBuffer(buffer);
+    // deserialize from CodecBuffer
+    final T fromBuffer = codec.fromCodecBuffer(codecBuffer);
+    codecBuffer.release();
     Assertions.assertEquals(original, fromBuffer);
 
-    final T fromWrappedArray = codec.fromByteBuffer(ByteBuffer.wrap(array));
+    // deserialize from wrapped buffer
+    final CodecBuffer wrapped = CodecBuffer.wrap(array);
+    final T fromWrappedArray = codec.fromCodecBuffer(wrapped);
+    wrapped.release();
     Assertions.assertEquals(original, fromWrappedArray);
   }
 }

--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/utils/db/TestCodec.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/utils/db/TestCodec.java
@@ -41,7 +41,7 @@ public final class TestCodec {
     obj = null;
 
     // loop until gc has completed.
-    for(int i = 0; weakRef.get() != null; i++) {
+    for (int i = 0; weakRef.get() != null; i++) {
       LOG.info("gc {}", i);
       System.gc();
       Thread.sleep(100);

--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/utils/db/TestCodec.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/utils/db/TestCodec.java
@@ -1,0 +1,95 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package org.apache.hadoop.hdds.utils.db;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.nio.ByteBuffer;
+import java.util.concurrent.ThreadLocalRandom;
+
+/**
+ * Test {@link Codec} implementations.
+ */
+public final class TestCodec {
+  static final int NUM_LOOPS = 10;
+
+  @Test
+  public void testIntegerCodec() throws Exception {
+    final IntegerCodec codec = new IntegerCodec();
+    runTest(codec, 0, Integer.BYTES);
+    runTest(codec, 1, Integer.BYTES);
+    runTest(codec, -1, Integer.BYTES);
+    runTest(codec, Integer.MAX_VALUE, Integer.BYTES);
+    runTest(codec, Integer.MIN_VALUE, Integer.BYTES);
+
+    for (int i = 0; i < NUM_LOOPS; i++) {
+      final int original = ThreadLocalRandom.current().nextInt();
+      runTest(codec, original, Integer.BYTES);
+    }
+  }
+
+  @Test
+  public void testLongCodec() throws Exception {
+    final LongCodec codec = new LongCodec();
+    runTest(codec, 0L, Long.BYTES);
+    runTest(codec, 1L, Long.BYTES);
+    runTest(codec, -1L, Long.BYTES);
+    runTest(codec, Long.MAX_VALUE, Long.BYTES);
+    runTest(codec, Long.MIN_VALUE, Long.BYTES);
+
+    for (int i = 0; i < NUM_LOOPS; i++) {
+      final long original = ThreadLocalRandom.current().nextLong();
+      runTest(codec, original, Long.BYTES);
+    }
+  }
+
+  @Test
+  public void testStringCodec() throws Exception {
+    final StringCodec codec = new StringCodec();
+    runTest(codec, "", 0);
+
+    for (int i = 0; i < NUM_LOOPS; i++) {
+      final String original = "test" + ThreadLocalRandom.current().nextLong();
+      runTest(codec, original, original.length());
+    }
+  }
+
+  static <T> void runTest(Codec<T> codec, T original,
+      Integer serializedSize) throws Exception {
+    final byte[] array = codec.toPersistedFormat(original);
+    if (serializedSize != null) {
+      Assertions.assertEquals(serializedSize, array.length);
+    }
+    final T fromArray = codec.fromPersistedFormat(array);
+    Assertions.assertEquals(original, fromArray);
+
+    final ByteBuffer buffer = codec.toByteBuffer(original);
+    Assertions.assertEquals(array.length, buffer.remaining());
+    for (int i = 0; i < array.length; i++) {
+      Assertions.assertEquals(array[i], buffer.get(i));
+    }
+
+    final T fromBuffer = codec.fromByteBuffer(buffer);
+    Assertions.assertEquals(original, fromBuffer);
+
+    final T fromWrappedArray = codec.fromByteBuffer(ByteBuffer.wrap(array));
+    Assertions.assertEquals(original, fromWrappedArray);
+  }
+}

--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/utils/db/TestRDBStore.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/utils/db/TestRDBStore.java
@@ -97,6 +97,7 @@ public class TestRDBStore {
     if (rdbStore != null) {
       rdbStore.close();
     }
+    CodecBuffer.assertNoLeaks();
   }
 
   public void insertRandomData(RDBStore dbStore, int familyIndex)

--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/utils/db/TestTypedRDBTableStore.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/utils/db/TestTypedRDBTableStore.java
@@ -91,6 +91,7 @@ public class TestTypedRDBTableStore {
     if (rdbStore != null) {
       rdbStore.close();
     }
+    CodecBuffer.assertNoLeaks();
   }
 
   @Test

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/MiniOzoneClusterImpl.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/MiniOzoneClusterImpl.java
@@ -62,6 +62,7 @@ import org.apache.hadoop.hdds.scm.server.SCMStorageConfig;
 import org.apache.hadoop.hdds.scm.server.StorageContainerManager;
 import org.apache.hadoop.hdds.security.x509.certificate.client.CertificateClient;
 import org.apache.hadoop.hdds.utils.IOUtils;
+import org.apache.hadoop.hdds.utils.db.CodecBuffer;
 import org.apache.hadoop.hdds.utils.db.managed.ManagedRocksObjectMetrics;
 import org.apache.hadoop.metrics2.lib.DefaultMetricsSystem;
 import org.apache.hadoop.ozone.client.OzoneClient;
@@ -464,6 +465,7 @@ public class MiniOzoneClusterImpl implements MiniOzoneCluster {
       DefaultMetricsSystem.shutdown();
 
       ManagedRocksObjectMetrics.INSTANCE.assertNoLeaks();
+      CodecBuffer.assertNoLeaks();
     } catch (IOException e) {
       LOG.error("Exception while shutting down the cluster.", e);
     }


### PR DESCRIPTION
## What changes were proposed in this pull request?

- Add a put method to use RocksDB ByteBuffer APIs.
- Support ByteBuffer methods in Codec and some of the implementations.  (Will work on other implementations in other JIRAs.)

## What is the link to the Apache JIRA

HDDS-8542

## How was this patch tested?

Add new tests to test the codec implementations.