### PR TITLE
HDDS-8551. Fix the generic type of CodecRegistry.getCodec

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/utils/db/Codec.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/utils/db/Codec.java
@@ -30,6 +30,8 @@ import java.util.function.IntFunction;
  * @param <T> The object type.
  */
 public interface Codec<T> {
+  byte[] EMPTY_BYTE_ARRAY = {};
+
   /**
    * Does this {@link Codec} support the {@link CodecBuffer} methods?
    * If this method returns true, this class must implement both

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/utils/db/CodecBuffer.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/utils/db/CodecBuffer.java
@@ -148,4 +148,15 @@ public final class CodecBuffer implements AutoCloseable {
     buf.writeBytes(array);
     return this;
   }
+
+  /**
+   * Similar to {@link ByteBuffer#put(ByteBuffer)}.
+   *
+   * @return this object.
+   */
+  public CodecBuffer put(ByteBuffer buffer) {
+    assertRefCnt(1);
+    buf.writeBytes(buffer);
+    return this;
+  }
 }

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/ByteStringCodec.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/ByteStringCodec.java
@@ -16,18 +16,40 @@
  * limitations under the License.
  */
 
-package org.apache.hadoop.hdds.scm.metadata;
+package org.apache.hadoop.hdds.utils.db;
 
 import com.google.protobuf.ByteString;
-import org.apache.hadoop.hdds.utils.db.Codec;
 
-import java.io.IOException;
+import javax.annotation.Nonnull;
+import java.util.function.IntFunction;
 
 /**
  * Codec to serialize/deserialize a {@link ByteString}.
  */
 public class ByteStringCodec implements Codec<ByteString> {
-  private static final byte[] EMPTY = {};
+  private static final ByteStringCodec INSTANCE = new ByteStringCodec();
+
+  public static ByteStringCodec getInstance() {
+    return INSTANCE;
+  }
+
+  private ByteStringCodec() {}
+
+  @Override
+  public boolean supportCodecBuffer() {
+    return true;
+  }
+
+  @Override
+  public CodecBuffer toCodecBuffer(@Nonnull ByteString object,
+      IntFunction<CodecBuffer> allocator) {
+    return allocator.apply(object.size()).put(object.asReadOnlyByteBuffer());
+  }
+
+  @Override
+  public ByteString fromCodecBuffer(@Nonnull CodecBuffer buffer) {
+    return ByteString.copyFrom(buffer.asReadOnlyByteBuffer());
+  }
 
   /**
    * Convert object to raw persisted format.
@@ -35,9 +57,9 @@ public class ByteStringCodec implements Codec<ByteString> {
    * @param object The original java object. Should not be null.
    */
   @Override
-  public byte[] toPersistedFormat(ByteString object) throws IOException {
+  public byte[] toPersistedFormat(ByteString object) {
     if (object == null) {
-      return EMPTY;
+      return EMPTY_BYTE_ARRAY;
     }
     return object.toByteArray();
   }
@@ -48,7 +70,7 @@ public class ByteStringCodec implements Codec<ByteString> {
    * @param rawData Byte array from the key/value store. Should not be null.
    */
   @Override
-  public ByteString fromPersistedFormat(byte[] rawData) throws IOException {
+  public ByteString fromPersistedFormat(byte[] rawData) {
     if (rawData == null) {
       return ByteString.EMPTY;
     }

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/ByteStringCodec.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/ByteStringCodec.java
@@ -26,14 +26,14 @@ import java.util.function.IntFunction;
 /**
  * Codec to serialize/deserialize a {@link ByteString}.
  */
-public class ByteStringCodec implements Codec<ByteString> {
+public final class ByteStringCodec implements Codec<ByteString> {
   private static final ByteStringCodec INSTANCE = new ByteStringCodec();
 
   public static ByteStringCodec getInstance() {
     return INSTANCE;
   }
 
-  private ByteStringCodec() {}
+  private ByteStringCodec() { }
 
   @Override
   public boolean supportCodecBuffer() {

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/CodecRegistry.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/CodecRegistry.java
@@ -22,8 +22,11 @@ import java.io.IOException;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.List;
 
 import com.google.common.base.Preconditions;
+
+import org.apache.commons.lang3.ClassUtils;
 
 /**
  * Collection of available codecs.
@@ -52,10 +55,33 @@ public final class CodecRegistry {
         .addCodec(byte[].class, new ByteArrayCodec());
   }
 
-  private final Map<Class<?>, Codec<?>> valueCodecs;
+  private static class CodecMap {
+    private final Map<Class<?>, Codec<?>> map;
+
+    private CodecMap(Map<Class<?>, Codec<?>> map) {
+      this.map = Collections.unmodifiableMap(new HashMap<>(map));
+    }
+
+    <T> Codec<T> get(Class<T> clazz) {
+      final Codec<?> codec = map.get(clazz);
+      return (Codec<T>) codec;
+    }
+
+    Codec<?> get(List<Class<?>> classes) {
+      for (Class<?> clazz : classes) {
+        final Codec<?> codec = get(clazz);
+        if (codec != null) {
+          return codec;
+        }
+      }
+      return null;
+    }
+  }
+
+  private final CodecMap valueCodecs;
 
   private CodecRegistry(Map<Class<?>, Codec<?>> valueCodecs) {
-    this.valueCodecs = Collections.unmodifiableMap(new HashMap<>(valueCodecs));
+    this.valueCodecs = new CodecMap(valueCodecs);
   }
 
   /**
@@ -103,27 +129,39 @@ public final class CodecRegistry {
   }
 
   /**
-   * Get codec for the typed object including class and subclass.
+   * Get a codec for the typed object
+   * including its class and the super classes/interfaces.
+   *
+   * @param <T>    Type of the typed object.
+   * @param <SUPER> A super class/interface type.
    * @param object typed object.
-   * @return Codec for the typed object.
+   * @return Codec for the given object.
    */
-  public <T> Codec<T> getCodec(T object) {
+  public <SUPER, T extends SUPER> Codec<SUPER> getCodec(T object) {
     Class<T> format = (Class<T>) object.getClass();
     return getCodec(format);
   }
 
-
   /**
-   * Get codec for the typed object including class and subclass.
+   * Get a codec for the given class
+   * including its super classes/interfaces.
+   *
    * @param <T>    Type of the typed object.
-   * @return Codec for the typed object.
+   * @param <SUPER> A super class/interface type.
+   * @return Codec for the given class.
    */
-  private <T> Codec<T> getCodec(Class<T> format) {
-    final Codec<?> codec = valueCodecs.get(format);
+  private <SUPER, T extends SUPER> Codec<SUPER> getCodec(Class<T> clazz) {
+    Codec<?> codec = valueCodecs.get(clazz);
+    if (codec == null) {
+      codec = valueCodecs.get(ClassUtils.getAllSuperclasses(clazz));
+    }
+    if (codec == null) {
+      codec = valueCodecs.get(ClassUtils.getAllInterfaces(clazz));
+    }
     if (codec != null) {
-      return (Codec<T>) codec;
+      return (Codec<SUPER>) codec;
     }
     throw new IllegalStateException(
-        "Codec is not registered for type: " + format);
+        "Codec is not registered for type: " + clazz);
   }
 }

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/CodecRegistry.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/CodecRegistry.java
@@ -19,15 +19,11 @@
 package org.apache.hadoop.hdds.utils.db;
 
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.List;
 
 import com.google.common.base.Preconditions;
-
-import org.apache.commons.lang3.ClassUtils;
 
 /**
  * Collection of available codecs.
@@ -123,15 +119,9 @@ public final class CodecRegistry {
    * @return Codec for the typed object.
    */
   private <T> Codec<T> getCodec(Class<T> format) {
-    final List<Class<?>> classes = new ArrayList<>();
-    classes.add(format);
-    classes.addAll(ClassUtils.getAllSuperclasses(format));
-    classes.addAll(ClassUtils.getAllInterfaces(format));
-    for (Class<?> clazz : classes) {
-      final Codec<?> codec = valueCodecs.get(clazz);
-      if (codec != null) {
-        return (Codec<T>) codec;
-      }
+    final Codec<?> codec = valueCodecs.get(format);
+    if (codec != null) {
+      return (Codec<T>) codec;
     }
     throw new IllegalStateException(
         "Codec is not registered for type: " + format);

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/CodecRegistry.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/CodecRegistry.java
@@ -55,7 +55,7 @@ public final class CodecRegistry {
         .addCodec(byte[].class, new ByteArrayCodec());
   }
 
-  private static class CodecMap {
+  private static final class CodecMap {
     private final Map<Class<?>, Codec<?>> map;
 
     private CodecMap(Map<Class<?>, Codec<?>> map) {

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/CodecRegistry.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/CodecRegistry.java
@@ -97,7 +97,7 @@ public final class CodecRegistry {
     if (rawData == null) {
       return null;
     }
-    return getCodec(format).fromPersistedFormat(rawData);
+    return getCodecFromClass(format).fromPersistedFormat(rawData);
   }
 
   /**
@@ -111,7 +111,7 @@ public final class CodecRegistry {
     if (object == null) {
       return null;
     }
-    return getCodec(format).copyObject(object);
+    return getCodecFromClass(format).copyObject(object);
   }
 
   /**
@@ -138,19 +138,7 @@ public final class CodecRegistry {
    * @return Codec for the given object.
    */
   public <SUPER, T extends SUPER> Codec<SUPER> getCodec(T object) {
-    Class<T> format = (Class<T>) object.getClass();
-    return getCodec(format);
-  }
-
-  /**
-   * Get a codec for the given class
-   * including its super classes/interfaces.
-   *
-   * @param <T>    Type of the typed object.
-   * @param <SUPER> A super class/interface type.
-   * @return Codec for the given class.
-   */
-  private <SUPER, T extends SUPER> Codec<SUPER> getCodec(Class<T> clazz) {
+    final Class<T> clazz = (Class<T>) object.getClass();
     Codec<?> codec = valueCodecs.get(clazz);
     if (codec == null) {
       codec = valueCodecs.get(ClassUtils.getAllSuperclasses(clazz));
@@ -160,6 +148,22 @@ public final class CodecRegistry {
     }
     if (codec != null) {
       return (Codec<SUPER>) codec;
+    }
+    throw new IllegalStateException(
+        "Codec is not registered for type: " + clazz);
+  }
+
+  /**
+   * Get a codec for the given class
+   * including its super classes/interfaces.
+   *
+   * @param <T>    Type of the typed object.
+   * @return Codec for the given class.
+   */
+  <T> Codec<T> getCodecFromClass(Class<T> clazz) {
+    final Codec<?> codec = valueCodecs.get(clazz);
+    if (codec != null) {
+      return (Codec<T>) codec;
     }
     throw new IllegalStateException(
         "Codec is not registered for type: " + clazz);

--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/utils/db/TestCodecRegistry.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/utils/db/TestCodecRegistry.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hdds.utils.db;
+
+import com.google.protobuf.ByteString;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Test {@link CodecRegistry}.
+ */
+public final class TestCodecRegistry {
+  static final Logger LOG = LoggerFactory.getLogger(TestCodecRegistry.class);
+
+  private final CodecRegistry registry = CodecRegistry.newBuilder()
+      .addCodec(ByteString.class, ByteStringCodec.getInstance())
+      .build();
+
+  <T> void assertGetCodec(Class<?> expectedCodecClass, T object) {
+    final Codec<T> codec = registry.getCodec(object);
+    LOG.info("object {}", object.getClass());
+    LOG.info("codec {}", codec.getClass());
+    Assertions.assertTrue(expectedCodecClass.isInstance(codec));
+    Assertions.assertSame(expectedCodecClass, codec.getClass());
+  }
+
+  @Test
+  public void testGetCodec() {
+    assertGetCodec(IntegerCodec.class, 1);
+    assertGetCodec(LongCodec.class, 2L);
+    assertGetCodec(StringCodec.class, "3");
+    assertGetCodec(ByteArrayCodec.class, Codec.EMPTY_BYTE_ARRAY);
+    assertGetCodec(ByteStringCodec.class, ByteString.EMPTY);
+  }
+
+  <T> void assertGetCodecFromClass(Class<?> expectedCodecClass, Class<T> format) {
+    final Codec<T> codec = registry.getCodecFromClass(format);
+    LOG.info("format {}", format);
+    LOG.info("codec {}", codec.getClass());
+    Assertions.assertSame(expectedCodecClass, codec.getClass());
+  }
+
+  @Test
+  public void testGetCodecFromClass() {
+    assertGetCodecFromClass(IntegerCodec.class, Integer.class);
+    assertGetCodecFromClass(LongCodec.class, Long.class);
+    assertGetCodecFromClass(StringCodec.class, String.class);
+    assertGetCodecFromClass(ByteArrayCodec.class, byte[].class);
+    assertGetCodecFromClass(ByteStringCodec.class, ByteString.class);
+  }
+}

--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/utils/db/TestCodecRegistry.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/utils/db/TestCodecRegistry.java
@@ -50,7 +50,8 @@ public final class TestCodecRegistry {
     assertGetCodec(ByteStringCodec.class, ByteString.EMPTY);
   }
 
-  <T> void assertGetCodecFromClass(Class<?> expectedCodecClass, Class<T> format) {
+  <T> void assertGetCodecFromClass(Class<?> expectedCodecClass,
+      Class<T> format) {
     final Codec<T> codec = registry.getCodecFromClass(format);
     LOG.info("format {}", format);
     LOG.info("codec {}", codec.getClass());

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/metadata/ByteStringCodec.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/metadata/ByteStringCodec.java
@@ -27,6 +27,7 @@ import java.io.IOException;
  * Codec to serialize/deserialize a {@link ByteString}.
  */
 public class ByteStringCodec implements Codec<ByteString> {
+  private static final byte[] EMPTY = {};
 
   /**
    * Convert object to raw persisted format.
@@ -36,7 +37,7 @@ public class ByteStringCodec implements Codec<ByteString> {
   @Override
   public byte[] toPersistedFormat(ByteString object) throws IOException {
     if (object == null) {
-      return new byte[0];
+      return EMPTY;
     }
     return object.toByteArray();
   }
@@ -64,6 +65,6 @@ public class ByteStringCodec implements Codec<ByteString> {
     if (object == null) {
       return ByteString.EMPTY;
     }
-    return ByteString.copyFrom(object.toByteArray());
+    return object;
   }
 }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/metadata/SCMDBDefinition.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/metadata/SCMDBDefinition.java
@@ -33,6 +33,7 @@ import org.apache.hadoop.hdds.security.x509.crl.CRLInfo;
 import org.apache.hadoop.hdds.scm.pipeline.Pipeline;
 import org.apache.hadoop.hdds.scm.pipeline.PipelineID;
 import org.apache.hadoop.hdds.utils.TransactionInfoCodec;
+import org.apache.hadoop.hdds.utils.db.ByteStringCodec;
 import org.apache.hadoop.hdds.utils.db.DBColumnFamilyDefinition;
 import org.apache.hadoop.hdds.utils.db.DBDefinition;
 import org.apache.hadoop.hdds.utils.db.LongCodec;
@@ -174,7 +175,7 @@ public class SCMDBDefinition implements DBDefinition {
           String.class,
           new StringCodec(),
           ByteString.class,
-          new ByteStringCodec());
+          ByteStringCodec.getInstance());
 
   @Override
   public String getName() {


### PR DESCRIPTION
## What changes were proposed in this pull request?

Do not get codec from super classes and interfaces.

## What is the link to the Apache JIRA

HDDS-8551

## How was this patch tested?

By existing tests.