### PR TITLE
HDDS-8545. [hsync] reject renaming open file

### DIFF
--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/exceptions/OMException.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/exceptions/OMException.java
@@ -262,5 +262,6 @@ public class OMException extends IOException {
     INVALID_SNAPSHOT_ERROR,
     CONTAINS_SNAPSHOT,
     SSL_CONNECTION_FAILURE,
+    RENAME_OPEN_FILE
   }
 }

--- a/hadoop-ozone/interface-client/src/main/proto/OmClientProtocol.proto
+++ b/hadoop-ozone/interface-client/src/main/proto/OmClientProtocol.proto
@@ -476,6 +476,7 @@ enum Status {
 
     CONTAINS_SNAPSHOT = 88;
     SSL_CONNECTION_FAILURE = 89;
+    RENAME_OPEN_FILE = 90;
 }
 
 /**

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyRenameRequestWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyRenameRequestWithFSO.java
@@ -57,6 +57,7 @@ import java.util.Map;
 
 import static org.apache.hadoop.ozone.OmUtils.normalizeKey;
 import static org.apache.hadoop.ozone.om.exceptions.OMException.ResultCodes.KEY_NOT_FOUND;
+import static org.apache.hadoop.ozone.om.exceptions.OMException.ResultCodes.RENAME_OPEN_FILE;
 import static org.apache.hadoop.ozone.om.lock.OzoneManagerLock.Resource.BUCKET_LOCK;
 
 /**
@@ -137,10 +138,15 @@ public class OMKeyRenameRequestWithFSO extends OMKeyRenameRequest {
       OzoneFileStatus fromKeyFileStatus =
               OMFileRequest.getOMKeyInfoIfExists(omMetadataManager, volumeName,
                       bucketName, fromKeyName, 0);
+
       // case-1) fromKeyName should exist, otw throws exception
       if (fromKeyFileStatus == null) {
         // TODO: Add support for renaming open key
         throw new OMException("Key not found " + fromKeyName, KEY_NOT_FOUND);
+      }
+
+      if (fromKeyFileStatus.getKeyInfo().isHsync()) {
+        throw new OMException("Open file cannot be renamed", RENAME_OPEN_FILE);
       }
 
       // source existed

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyRenameRequestWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyRenameRequestWithFSO.java
@@ -146,7 +146,9 @@ public class OMKeyRenameRequestWithFSO extends OMKeyRenameRequest {
       }
 
       if (fromKeyFileStatus.getKeyInfo().isHsync()) {
-        throw new OMException("Open file cannot be renamed", RENAME_OPEN_FILE);
+        throw new OMException("Open file cannot be renamed since it is " +
+            "hsync'ed: volumeName=" + volumeName + ", bucketName=" +
+            bucketName + ", key=" + fromKeyName, RENAME_OPEN_FILE);
       }
 
       // source existed

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMKeyRenameRequestWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMKeyRenameRequestWithFSO.java
@@ -28,6 +28,7 @@ import org.apache.hadoop.ozone.om.helpers.OmDirectoryInfo;
 import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
 import org.apache.hadoop.ozone.om.request.file.OMFileRequest;
 import org.apache.hadoop.ozone.om.request.OMRequestTestUtils;
+import org.apache.hadoop.ozone.om.response.OMClientResponse;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.KeyArgs;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMRequest;
@@ -84,10 +85,11 @@ public class TestOMKeyRenameRequestWithFSO extends TestOMKeyRenameRequest {
             volumeName, bucketName, fromKeyName, toKeyName));
     OMKeyRenameRequest omKeyRenameRequest =
         getOMKeyRenameRequest(modifiedOmRequest);
-    Assert.assertThrows(
-        OMException.class, () ->
+    OMClientResponse response =
             omKeyRenameRequest.validateAndUpdateCache(ozoneManager, 100L,
-            ozoneManagerDoubleBufferHelper));
+            ozoneManagerDoubleBufferHelper);
+    Assert.assertEquals(OzoneManagerProtocolProtos.Status.RENAME_OPEN_FILE,
+        response.getOMResponse().getStatus());
   }
 
   @Override

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMKeyRenameRequestWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMKeyRenameRequestWithFSO.java
@@ -28,6 +28,7 @@ import org.apache.hadoop.ozone.om.helpers.OmDirectoryInfo;
 import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
 import org.apache.hadoop.ozone.om.request.file.OMFileRequest;
 import org.apache.hadoop.ozone.om.request.OMRequestTestUtils;
+import org.apache.hadoop.ozone.om.response.OMClientResponse;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.KeyArgs;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMRequest;
@@ -72,6 +73,20 @@ public class TestOMKeyRenameRequestWithFSO extends TestOMKeyRenameRequest {
         bucketName, txnLogId, omMetadataManager);
     dbToKey = omMetadataManager.getOzonePathKey(volumeId, bucketId,
         toKeyParentInfo.getObjectID(), "toKey");
+  }
+
+  @Test
+  public void testRenameOpenFile() throws Exception {
+    fromKeyInfo.getMetadata().put(OzoneConsts.HSYNC_CLIENT_ID, String.valueOf(1234));
+    addKeyToTable(fromKeyInfo);
+    OMRequest modifiedOmRequest =
+        doPreExecute(createRenameKeyRequest(
+            volumeName, bucketName, fromKeyName, toKeyName));
+    OMKeyRenameRequest omKeyRenameRequest = getOMKeyRenameRequest(modifiedOmRequest);
+    Assert.assertThrows(
+        OMException.class, () ->
+            omKeyRenameRequest.validateAndUpdateCache(ozoneManager, 100L,
+            ozoneManagerDoubleBufferHelper));
   }
 
   @Override

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMKeyRenameRequestWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMKeyRenameRequestWithFSO.java
@@ -28,7 +28,6 @@ import org.apache.hadoop.ozone.om.helpers.OmDirectoryInfo;
 import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
 import org.apache.hadoop.ozone.om.request.file.OMFileRequest;
 import org.apache.hadoop.ozone.om.request.OMRequestTestUtils;
-import org.apache.hadoop.ozone.om.response.OMClientResponse;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.KeyArgs;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMRequest;
@@ -77,12 +76,14 @@ public class TestOMKeyRenameRequestWithFSO extends TestOMKeyRenameRequest {
 
   @Test
   public void testRenameOpenFile() throws Exception {
-    fromKeyInfo.getMetadata().put(OzoneConsts.HSYNC_CLIENT_ID, String.valueOf(1234));
+    fromKeyInfo.getMetadata().put(OzoneConsts.HSYNC_CLIENT_ID,
+        String.valueOf(1234));
     addKeyToTable(fromKeyInfo);
     OMRequest modifiedOmRequest =
         doPreExecute(createRenameKeyRequest(
             volumeName, bucketName, fromKeyName, toKeyName));
-    OMKeyRenameRequest omKeyRenameRequest = getOMKeyRenameRequest(modifiedOmRequest);
+    OMKeyRenameRequest omKeyRenameRequest =
+        getOMKeyRenameRequest(modifiedOmRequest);
     Assert.assertThrows(
         OMException.class, () ->
             omKeyRenameRequest.validateAndUpdateCache(ozoneManager, 100L,


### PR DESCRIPTION
## What changes were proposed in this pull request?

Renaming open files is unsupported. It creates unfortunate behavior where inconsistent copies of files appears in the namespace. So let's stop allowing this.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-8545

## How was this patch tested?

Unit test; Ran HBase integration test to verify it actually function as expected.