### PR TITLE
HDDS-8554. Thread pool size needs to be decreased in different order in ReplicationSupervisor

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/replication/ReplicationSupervisor.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/replication/ReplicationSupervisor.java
@@ -161,8 +161,13 @@ public final class ReplicationSupervisor {
                 .build());
         executor = tpe;
         executorThreadUpdater = threadCount -> {
-          tpe.setMaximumPoolSize(threadCount);
-          tpe.setCorePoolSize(threadCount);
+          if (threadCount < tpe.getCorePoolSize()) {
+            tpe.setCorePoolSize(threadCount);
+            tpe.setMaximumPoolSize(threadCount);
+          } else {
+            tpe.setMaximumPoolSize(threadCount);
+            tpe.setCorePoolSize(threadCount);
+          }
         };
       }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

https://github.com/apache/ozone/blob/a455597815a4a12ded9479f334780a83116a2123/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/replication/ReplicationSupervisor.java#L164-L165

The above code works when increasing thread pool size, but fails when decreasing it, because maximum cannot be set to less than core.  Seen in `TestDecommissionAndMaintenance` logs:

```
java.lang.IllegalArgumentException
	at java.util.concurrent.ThreadPoolExecutor.setMaximumPoolSize(ThreadPoolExecutor.java:1680)
	at org.apache.hadoop.ozone.container.replication.ReplicationSupervisor$Builder.lambda$build$1(ReplicationSupervisor.java:164)
	at org.apache.hadoop.ozone.container.replication.ReplicationSupervisor.nodeStateUpdated(ReplicationSupervisor.java:294)
```

Core pool size needs to be decreased first to satisfy preconditions.

https://issues.apache.org/jira/browse/HDDS-8554

## How was this patch tested?

Added unit test.  `TestDecommissionAndMaintenance` no longer logs this error.