### PR TITLE
HDDS-8493. Intermittent timeout in TestDecommissionAndMaintenance#testSCMHandlesRestartForMaintenanceNode

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/scm/node/TestDecommissionAndMaintenance.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/scm/node/TestDecommissionAndMaintenance.java
@@ -93,7 +93,7 @@ public class TestDecommissionAndMaintenance {
   private static final Logger LOG =
       LoggerFactory.getLogger(TestDecommissionAndMaintenance.class);
 
-  private static int numOfDatanodes = 7;
+  private static final int DATANODE_COUNT = 7;
   private static String bucketName = "bucket1";
   private static String volName = "vol1";
   private static RatisReplicationConfig ratisRepConfig =
@@ -144,7 +144,7 @@ public class TestDecommissionAndMaintenance {
     conf.setFromObject(replicationConf);
 
     MiniOzoneCluster.Builder builder = MiniOzoneCluster.newBuilder(conf)
-        .setNumDatanodes(numOfDatanodes);
+        .setNumDatanodes(DATANODE_COUNT);
 
     clusterProvider = new MiniOzoneClusterProvider(conf, builder, 7);
   }
@@ -587,8 +587,9 @@ public class TestDecommissionAndMaintenance {
     cluster.restartStorageContainerManager(false);
     setManagers();
 
-    GenericTestUtils.waitFor(()
-        -> nm.getNodeCount(IN_SERVICE, null) == 5, 200, 30000);
+    GenericTestUtils.waitFor(
+        () -> nm.getNodeCount(IN_SERVICE, null) == DATANODE_COUNT - 1,
+        200, 30000);
 
     // Ensure there are 3 replicas not including the dead node, indicating a new
     // replica was created


### PR DESCRIPTION
## What changes were proposed in this pull request?

3e0cb27632d increased the number of datanodes in the mini cluster of `TestDecommissionAndMaintenance` from 6 to 7.  However, `testSCMHandlesRestartForMaintenanceNode` still expects 5 in-service datanodes after shutting down one, as originally introduced in 42d53bce288.

This change simply makes the same increase in the expected number of nodes (5 to 6).

https://issues.apache.org/jira/browse/HDDS-8493

## How was this patch tested?

Ran locally:

```
$ mvn -am -pl :ozone-integration-test -Dtest='TestDecommissionAndMaintenance#testSCMHandlesRestartForMaintenanceNode' clean test
...
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 43.132 s - in org.apache.hadoop.ozone.scm.node.TestDecommissionAndMaintenance
```