### PR TITLE
HDDS-8539. Container DB open, but not found in DatanodeStoreCache

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/utils/DatanodeStoreCache.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/utils/DatanodeStoreCache.java
@@ -106,8 +106,10 @@ public final class DatanodeStoreCache {
 
   public void shutdownCache() {
     if (miniClusterMode) {
-      LOG.info("Skip clearing cache in mini cluster mode. Entries left: {}",
-          new TreeSet<>(datanodeStoreMap.keySet()));
+      if (!datanodeStoreMap.isEmpty()) {
+        LOG.info("Skip clearing cache in mini cluster mode. Entries left: {}",
+            new TreeSet<>(datanodeStoreMap.keySet()));
+      }
       return;
     }
 

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/utils/DatanodeStoreCache.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/utils/DatanodeStoreCache.java
@@ -17,6 +17,7 @@
  */
 package org.apache.hadoop.ozone.container.common.utils;
 
+import com.google.common.annotations.VisibleForTesting;
 import org.apache.hadoop.hdds.conf.ConfigurationSource;
 import org.apache.hadoop.ozone.container.metadata.DatanodeStore;
 import org.apache.hadoop.ozone.container.metadata.DatanodeStoreSchemaThreeImpl;
@@ -25,6 +26,7 @@ import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.util.Map;
+import java.util.TreeSet;
 import java.util.concurrent.ConcurrentHashMap;
 
 /**
@@ -41,6 +43,7 @@ public final class DatanodeStoreCache {
   private final Map<String, RawDB> datanodeStoreMap;
 
   private static DatanodeStoreCache cache;
+  private boolean miniClusterMode;
 
   private DatanodeStoreCache() {
     datanodeStoreMap = new ConcurrentHashMap<>();
@@ -51,6 +54,11 @@ public final class DatanodeStoreCache {
       cache = new DatanodeStoreCache();
     }
     return cache;
+  }
+
+  @VisibleForTesting
+  public static synchronized void setMiniClusterMode() {
+    getInstance().miniClusterMode = true;
   }
 
   public void addDB(String containerDBPath, RawDB db) {
@@ -97,6 +105,12 @@ public final class DatanodeStoreCache {
   }
 
   public void shutdownCache() {
+    if (miniClusterMode) {
+      LOG.info("Skip clearing cache in mini cluster mode. Entries left: {}",
+          new TreeSet<>(datanodeStoreMap.keySet()));
+      return;
+    }
+
     for (Map.Entry<String, RawDB> entry : datanodeStoreMap.entrySet()) {
       try {
         entry.getValue().getStore().stop();

--- a/hadoop-ozone/fault-injection-test/mini-chaos-tests/src/test/java/org/apache/hadoop/ozone/MiniOzoneChaosCluster.java
+++ b/hadoop-ozone/fault-injection-test/mini-chaos-tests/src/test/java/org/apache/hadoop/ozone/MiniOzoneChaosCluster.java
@@ -37,6 +37,7 @@ import org.apache.hadoop.hdds.scm.container.replication.ReplicationManager.Repli
 import org.apache.hadoop.hdds.scm.server.SCMConfigurator;
 import org.apache.hadoop.hdds.scm.server.StorageContainerManager;
 import org.apache.hadoop.metrics2.lib.DefaultMetricsSystem;
+import org.apache.hadoop.ozone.container.common.utils.DatanodeStoreCache;
 import org.apache.hadoop.ozone.failure.FailureManager;
 import org.apache.hadoop.ozone.failure.Failures;
 import org.apache.hadoop.ozone.om.OMConfigKeys;
@@ -295,8 +296,9 @@ public class MiniOzoneChaosCluster extends MiniOzoneHAClusterImpl {
 
     @Override
     public MiniOzoneChaosCluster build() throws IOException {
-
       DefaultMetricsSystem.setMiniClusterMode(true);
+      DatanodeStoreCache.setMiniClusterMode();
+
       initializeConfiguration();
       if (numOfOMs > 1) {
         initOMRatisConf();

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/MiniOzoneClusterImpl.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/MiniOzoneClusterImpl.java
@@ -69,6 +69,7 @@ import org.apache.hadoop.ozone.client.OzoneClientFactory;
 import org.apache.hadoop.ozone.common.Storage.StorageState;
 import org.apache.hadoop.ozone.container.common.DatanodeLayoutStorage;
 import org.apache.hadoop.ozone.container.common.utils.ContainerCache;
+import org.apache.hadoop.ozone.container.common.utils.DatanodeStoreCache;
 import org.apache.hadoop.ozone.container.replication.ReplicationServer.ReplicationConfig;
 import org.apache.hadoop.ozone.om.OMConfigKeys;
 import org.apache.hadoop.ozone.om.OMStorage;
@@ -592,6 +593,7 @@ public class MiniOzoneClusterImpl implements MiniOzoneCluster {
     @Override
     public MiniOzoneCluster build() throws IOException {
       DefaultMetricsSystem.setMiniClusterMode(true);
+      DatanodeStoreCache.setMiniClusterMode();
       initializeConfiguration();
       StorageContainerManager scm = null;
       OzoneManager om = null;

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/MiniOzoneHAClusterImpl.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/MiniOzoneHAClusterImpl.java
@@ -34,6 +34,7 @@ import org.apache.hadoop.hdds.scm.server.StorageContainerManager;
 import org.apache.hadoop.metrics2.lib.DefaultMetricsSystem;
 import org.apache.hadoop.ozone.client.OzoneClient;
 import org.apache.hadoop.ozone.client.OzoneClientFactory;
+import org.apache.hadoop.ozone.container.common.utils.DatanodeStoreCache;
 import org.apache.hadoop.ozone.ha.ConfUtils;
 import org.apache.hadoop.ozone.om.OMConfigKeys;
 import org.apache.hadoop.ozone.om.OzoneManager;
@@ -416,6 +417,7 @@ public class MiniOzoneHAClusterImpl extends MiniOzoneClusterImpl {
       }
 
       DefaultMetricsSystem.setMiniClusterMode(true);
+      DatanodeStoreCache.setMiniClusterMode();
       initializeConfiguration();
       initOMRatisConf();
       SCMHAService scmService;

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/dn/volume/TestDatanodeHddsVolumeFailureDetection.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/dn/volume/TestDatanodeHddsVolumeFailureDetection.java
@@ -300,7 +300,7 @@ public class TestDatanodeHddsVolumeFailureDetection {
     DatanodeTestUtils.injectDataDirFailure(dbDir);
     if (schemaV3) {
       // remove rocksDB from cache
-      DatanodeStoreCache.getInstance().shutdownCache();
+      DatanodeStoreCache.getInstance().removeDB(dbDir.getAbsolutePath());
     }
 
     // simulate bad volume by removing write permission on root dir


### PR DESCRIPTION
## What changes were proposed in this pull request?

Surefire fork intermittently times out in `TestDecommissionAndMaintenance`.

Container DB is added to the cache:

```
2023-05-03 08:18:26,909 [EndpointStateMachine task thread for /0.0.0.0:43723 - 0 ] INFO  utils.DatanodeStoreCache (DatanodeStoreCache.java:addDB(58)) - Added db /home/runner/work/ozone/ozone/hadoop-ozone/integration-test/target/test-dir/MiniOzoneClusterImpl-ff176d5b-bea5-4cbe-a997-8236a6853a89/datanode-0/data-0/containers/hdds/ff176d5b-bea5-4cbe-a997-8236a6853a89/DS-4328e108-8c1a-4a6f-8bff-6f686dd50b24/container.db to cache
```

but then not found and tried to open again, which fails since RocksDB is already open and protected by OS-level lock (`lock hold by current process`):

```
2023-05-03 08:18:57,086 [Command processor thread] ERROR utils.DatanodeStoreCache (DatanodeStoreCache.java:getDB(74)) - Failed to get DB store /home/runner/work/ozone/ozone/hadoop-ozone/integration-test/target/test-dir/MiniOzoneClusterImpl-ff176d5b-bea5-4cbe-a997-8236a6853a89/datanode-0/data-0/containers/hdds/ff176d5b-bea5-4cbe-a997-8236a6853a89/DS-4328e108-8c1a-4a6f-8bff-6f686dd50b24/container.db
java.io.IOException: Failed init RocksDB, db path : /home/runner/work/ozone/ozone/hadoop-ozone/integration-test/target/test-dir/MiniOzoneClusterImpl-ff176d5b-bea5-4cbe-a997-8236a6853a89/datanode-0/data-0/containers/hdds/ff176d5b-bea5-4cbe-a997-8236a6853a89/DS-4328e108-8c1a-4a6f-8bff-6f686dd50b24/container.db, exception :org.rocksdb.RocksDBException lock hold by current process, acquire time 1683101936 acquiring thread 139985634854656: /home/runner/work/ozone/ozone/hadoop-ozone/integration-test/target/test-dir/MiniOzoneClusterImpl-ff176d5b-bea5-4cbe-a997-8236a6853a89/datanode-0/data-0/containers/hdds/ff176d5b-bea5-4cbe-a997-8236a6853a89/DS-4328e108-8c1a-4a6f-8bff-6f686dd50b24/container.db/LOCK: No locks available
	at org.apache.hadoop.hdds.utils.db.RDBStore.<init>(RDBStore.java:182)
	at org.apache.hadoop.hdds.utils.db.DBStoreBuilder.build(DBStoreBuilder.java:212)
	at org.apache.hadoop.ozone.container.metadata.AbstractDatanodeStore.start(AbstractDatanodeStore.java:147)
	at org.apache.hadoop.ozone.container.metadata.AbstractDatanodeStore.<init>(AbstractDatanodeStore.java:99)
	at org.apache.hadoop.ozone.container.metadata.DatanodeStoreSchemaThreeImpl.<init>(DatanodeStoreSchemaThreeImpl.java:66)
	at org.apache.hadoop.ozone.container.common.utils.DatanodeStoreCache.getDB(DatanodeStoreCache.java:69)
	at org.apache.hadoop.ozone.container.keyvalue.helpers.BlockUtils.getDB(BlockUtils.java:132)
```

The problem is that `DatanodeStoreCache` is a singleton, shared between datanodes in integration tests using `MiniOzoneCluster`.  Stopping a datanode clears the cache, affecting all other datanodes.

This change adds a "mini cluster mode" flag in `DatanodeStoreCache`, which prevents clearing the cache when set to true.  Items can still be removed one by one (`removeDB` is called by `DbVolume.shutdown` and `HddsVolume.shutdown`).

https://issues.apache.org/jira/browse/HDDS-8539

## How was this patch tested?

No fork timeout in [100 runs of `TestDecommissionAndMaintenance`](https://github.com/adoroszlai/hadoop-ozone/actions/runs/4897439875) (but there were plenty of other failures, being fixed in other tasks).

CI:
https://github.com/adoroszlai/hadoop-ozone/actions/runs/4900898212