### PR TITLE
HDDS-8566. ListSatus should check LIST ACL.

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/snapshot/TestOzoneManagerSnapshotAcl.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/snapshot/TestOzoneManagerSnapshotAcl.java
@@ -409,7 +409,9 @@ public class TestOzoneManagerSnapshotAcl {
         .build();
     objectStore.setAcl(volumeObj, OzoneAcl.parseAcls(
         "user:" + USER1 + ":r," +
-        "user:" + USER2 + ":r"));
+        "user:" + USER1 + ":l," +
+        "user:" + USER2 + ":r," +
+        "user:" + USER2 + ":l"));
 
     final OzoneObj bucketObj = OzoneObjInfo.Builder.newBuilder()
         .setResType(OzoneObj.ResourceType.BUCKET)
@@ -430,6 +432,7 @@ public class TestOzoneManagerSnapshotAcl {
         .build();
     objectStore.setAcl(keyObj, OzoneAcl.parseAcls(
         "user:" + USER1 + ":r," +
+        "user:" + USER1 + ":l," +
         "user:" + USER1 + ":x"));
   }
 
@@ -445,6 +448,7 @@ public class TestOzoneManagerSnapshotAcl {
         "user:" + USER1 + ":r," +
             "user:" + USER1 + ":x," +
             "user:" + USER2 + ":r," +
+            "user:" + USER2 + ":l," +
             "user:" + USER2 + ":x"));
   }
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmMetadataReader.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmMetadataReader.java
@@ -255,7 +255,7 @@ public class OmMetadataReader implements IOmMetadataReader, Auditor {
 
     try {
       if (isAclEnabled) {
-        checkAcls(getResourceType(args), StoreType.OZONE, ACLType.READ,
+        checkAcls(getResourceType(args), StoreType.OZONE, ACLType.LIST,
             bucket.realVolume(), bucket.realBucket(), args.getKeyName());
       }
       metrics.incNumListStatus();


### PR DESCRIPTION
## What changes were proposed in this pull request?

In the listKeys method，ACLType is LIST, but in the listStatus method, ACLType is READ
So it causes inconsistent return information. 
I think listStatus should also check LIST.

```
ozone cli

[hadoop@presto-test-006 ~]$ om-current/bin/ozone sh vol addacl -a user:test:r vol-1-29165
ACL user:test:r[ACCESS] added successfully.
[hadoop@presto-test-006 ~]$ om-current/bin/ozone sh  bucket addacl -a user:test:r vol-1-29165/bucket-188-54163
ACL user:test:r[ACCESS] added successfully.
[hadoop@presto-test-006 ~]$ export HADOOP_USER_NAME=test
[hadoop@presto-test-006 ~]$ om-current/bin/ozone sh key list --prefix=h vol-1-29165/bucket-188-54163/
PERMISSION_DENIED User test doesn't have LIST permission to access bucket Volume:vol-1-29165 Bucket:bucket-188-54163 Key:h

[hadoop@presto-test-006 ~]$ om-current/bin/ozone sh bucket list --prefix=b vol-1-29165/
PERMISSION_DENIED User test doesn't have LIST permission to access volume Volume:vol-1-29165
```

```
[hadoop@bigdata-pre-hdp02.nmg01 ~/hadoop-2.7.2-5504-ozone-client]$ export HADOOP_USER_NAME=test
[hadoop@bigdata-pre-hdp02.nmg01 ~/hadoop-2.7.2-5504-ozone-client]$ ./bin/hadoop fs -ls /vol-1-29165/bucket-188-54163/h*
-rw-rw-rw-   3 test test        243 2023-05-08 14:13 /vol-1-29165/bucket-188-54163/hosts
```

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-8566

## How was this patch tested?

Unit tests.