### PR TITLE
HDDS-8547. Support Trash for FSO bucket using ozone sh command.

### DIFF
--- a/hadoop-ozone/dist/src/main/smoketest/basic/links.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/basic/links.robot
@@ -105,7 +105,7 @@ Key list passthrough
                         Should Contain              ${source_list}    key2
 
 Key delete passthrough
-                        Execute                     ozone sh key delete ${target}/link1/key2
+                        Execute                     ozone sh key delete --skipTrash ${target}/link1/key2
     ${source_list} =    Execute                     ozone sh key list ${source}/bucket1 | jq -r '.[].name'
                         Should Not Contain          ${source_list}    key2
 

--- a/hadoop-ozone/dist/src/main/smoketest/basic/ozone-shell-lib.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/basic/ozone-shell-lib.robot
@@ -206,6 +206,7 @@ Test prefix Acls
     Should Match Regexp                 ${result}       \"type\" : \"GROUP\",\n.*\"name\" : \"superuser1\",\n.*\"aclScope\" : \"ACCESS\",\n.*\"aclList\" : . \"ALL\" .
 
 Test Delete key with and without Trash
+    [arguments]    ${protocol}         ${server}       ${volume}
                    Execute               ozone sh bucket create ${protocol}${server}/${volume}/bfso --layout FILE_SYSTEM_OPTIMIZED
                    Execute               ozone sh key put -t RATIS ${protocol}${server}/${volume}/bfso/key1 /opt/hadoop/NOTICE.txt
                    Execute               ozone sh key delete --skipTrash ${protocol}${server}/${volume}/bso/key1

--- a/hadoop-ozone/dist/src/main/smoketest/basic/ozone-shell-lib.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/basic/ozone-shell-lib.robot
@@ -151,13 +151,13 @@ Test key handling
                     Execute             diff -q /opt/hadoop/NOTICE.txt /tmp/key1_RATIS
     ${result} =     Execute             ozone sh key info ${protocol}${server}/${volume}/bb1/key1_RATIS | jq -r '. | select(.name=="key1_RATIS")'
                     Should contain      ${result}       RATIS
-                    Execute             ozone sh key delete ${protocol}${server}/${volume}/bb1/key1_RATIS
+                    Execute             ozone sh key delete --skipTrash ${protocol}${server}/${volume}/bb1/key1_RATIS
 
                     Execute             ozone sh key cp ${protocol}${server}/${volume}/bb1 key1 key1-copy
                     Execute             rm -f /tmp/key1-copy
                     Execute             ozone sh key get ${protocol}${server}/${volume}/bb1/key1-copy /tmp/key1-copy
                     Execute             diff -q /opt/hadoop/NOTICE.txt /tmp/key1-copy
-                    Execute             ozone sh key delete ${protocol}${server}/${volume}/bb1/key1-copy
+                    Execute             ozone sh key delete --skipTrash ${protocol}${server}/${volume}/bb1/key1-copy
 
     ${result} =     Execute And Ignore Error    ozone sh key get ${protocol}${server}/${volume}/bb1/key1 /tmp/NOTICE.txt.1
                     Should Contain      ${result}       NOTICE.txt.1 exists
@@ -170,7 +170,7 @@ Test key handling
                     Execute             ozone sh key rename ${protocol}${server}/${volume}/bb1 key1 key2
     ${result} =     Execute             ozone sh key list ${protocol}${server}/${volume}/bb1 | jq -r '.[].name'
                     Should Be Equal     ${result}       key2
-                    Execute             ozone sh key delete ${protocol}${server}/${volume}/bb1/key2
+                    Execute             ozone sh key delete --skipTrash ${protocol}${server}/${volume}/bb1/key2
 
 Test key Acls
     [arguments]     ${protocol}         ${server}       ${volume}

--- a/hadoop-ozone/dist/src/main/smoketest/basic/ozone-shell-lib.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/basic/ozone-shell-lib.robot
@@ -86,6 +86,7 @@ Test ozone shell
                     Should Be Equal     ${result}       -1
                     Execute             ozone sh bucket delete ${protocol}${server}/${volume}/bb1
                     Execute             ozone sh volume delete ${protocol}${server}/${volume}
+                    Run Keyword         Test Delete key with and without Trash   ${protocol}       ${server}       ${volume}
 
 Test ozone shell errors
     [arguments]     ${protocol}         ${server}       ${volume}

--- a/hadoop-ozone/dist/src/main/smoketest/basic/ozone-shell-lib.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/basic/ozone-shell-lib.robot
@@ -86,7 +86,6 @@ Test ozone shell
                     Should Be Equal     ${result}       -1
                     Execute             ozone sh bucket delete ${protocol}${server}/${volume}/bb1
                     Execute             ozone sh volume delete ${protocol}${server}/${volume}
-                    Run Keyword         Test Delete key with and without Trash   ${protocol}       ${server}       ${volume}
 
 Test ozone shell errors
     [arguments]     ${protocol}         ${server}       ${volume}
@@ -208,9 +207,10 @@ Test prefix Acls
 
 Test Delete key with and without Trash
     [arguments]    ${protocol}         ${server}       ${volume}
+                   Execute               ozone sh volume create ${protocol}${server}/${volume}
                    Execute               ozone sh bucket create ${protocol}${server}/${volume}/bfso --layout FILE_SYSTEM_OPTIMIZED
                    Execute               ozone sh key put -t RATIS ${protocol}${server}/${volume}/bfso/key1 /opt/hadoop/NOTICE.txt
-                   Execute               ozone sh key delete --skipTrash ${protocol}${server}/${volume}/bso/key1
+                   Execute               ozone sh key delete --skipTrash ${protocol}${server}/${volume}/bfso/key1
     ${result} =    Execute               ozone sh key list ${protocol}${server}/${volume}/bfso
                    Should not contain    ${result}     key1
                    Execute               ozone sh bucket create ${protocol}${server}/${volume}/obsbkt --layout OBJECT_STORE

--- a/hadoop-ozone/dist/src/main/smoketest/basic/ozone-shell-lib.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/basic/ozone-shell-lib.robot
@@ -204,3 +204,20 @@ Test prefix Acls
     ${result} =     Execute             ozone sh key getacl ${protocol}${server}/${volume}/bb1/prefix1/key1
     Should Match Regexp                 ${result}       \"type\" : \"USER\",\n.*\"name\" : \"superuser1\",\n.*\"aclScope\" : \"ACCESS\",\n.*\"aclList\" : . \"READ\", \"WRITE\", \"READ_ACL\", \"WRITE_ACL\"
     Should Match Regexp                 ${result}       \"type\" : \"GROUP\",\n.*\"name\" : \"superuser1\",\n.*\"aclScope\" : \"ACCESS\",\n.*\"aclList\" : . \"ALL\" .
+
+Test Delete key with and without Trash
+                   Execute               ozone sh bucket create ${protocol}${server}/${volume}/bfso --layout FILE_SYSTEM_OPTIMIZED
+                   Execute               ozone sh key put -t RATIS ${protocol}${server}/${volume}/bfso/key1 /opt/hadoop/NOTICE.txt
+                   Execute               ozone sh key delete --skipTrash ${protocol}${server}/${volume}/bso/key1
+    ${result} =    Execute               ozone sh key list ${protocol}${server}/${volume}/bfso
+                   Should not contain    ${result}     key1
+                   Execute               ozone sh bucket create ${protocol}${server}/${volume}/obsbkt --layout OBJECT_STORE
+                   Execute               ozone sh key put -t RATIS ${protocol}${server}/${volume}/obsbkt/key2 /opt/hadoop/NOTICE.txt
+                   Execute               ozone sh key delete ${protocol}${server}/${volume}/obsbkt/key2
+    ${result} =    Execute               ozone sh key list ${protocol}${server}/${volume}/obsbkt
+                   Should not contain    ${result}     key2
+                   Execute               ozone sh key put -t RATIS ${protocol}${server}/${volume}/bfso/key3 /opt/hadoop/NOTICE.txt
+                   Execute               ozone sh key delete ${protocol}${server}/${volume}/bfso/key3
+    ${result} =    Execute               ozone sh key list ${protocol}${server}/${volume}/bfso
+                   Should Contain Any    ${result}     .Trash/hadoop    .Trash/testuser    .Trash/root
+                   Should contain        ${result}     key3

--- a/hadoop-ozone/dist/src/main/smoketest/basic/ozone-shell.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/basic/ozone-shell.robot
@@ -43,3 +43,7 @@ RpcClient prefix acls
 
 RpcClient without host
     Test ozone shell      o3://            ${EMPTY}    ${prefix}-without-host
+
+RpcClient Delete key
+   Test Delete key with and without Trash       o3://            om:9862      ${prefix}-with-del
+

--- a/hadoop-ozone/dist/src/main/smoketest/security/ozone-secure-fs.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/security/ozone-secure-fs.robot
@@ -70,7 +70,7 @@ Create bucket with non-admin owner(testuser2)
                   Should not contain  ${result}       PERMISSION_DENIED
     ${result} =   Execute     ozone sh key list ${volume4}/bucket1
                   Should not contain  ${result}       PERMISSION_DENIED
-    ${result} =   Execute     ozone sh key delete ${volume4}/bucket1/key1
+    ${result} =   Execute     ozone sh key delete --skipTrash ${volume4}/bucket1/key1
                   Should not contain  ${result}       PERMISSION_DENIED
     ${result} =   Execute     ozone sh bucket delete ${volume4}/bucket1
                   Should not contain  ${result}       PERMISSION_DENIED

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/shell/TestOzoneShellHA.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/shell/TestOzoneShellHA.java
@@ -54,6 +54,7 @@ import org.apache.hadoop.ozone.client.io.OzoneOutputStream;
 import org.apache.hadoop.ozone.ha.ConfUtils;
 import org.apache.hadoop.ozone.om.OMConfigKeys;
 import org.apache.hadoop.ozone.om.OzoneManager;
+import org.apache.hadoop.ozone.om.helpers.BucketLayout;
 import org.apache.hadoop.ozone.shell.s3.S3Shell;
 import org.apache.ozone.test.GenericTestUtils;
 import org.apache.ozone.test.LambdaTestUtils;
@@ -332,13 +333,17 @@ public class TestOzoneShellHA {
   /**
    * Helper function to generate keys for testing shell command of keys.
    */
-  private void generateKeys(String volumeName, String bucketName) {
+  private void generateKeys(String volumeName, String bucketName,
+                            String bucketLayout) {
     String[] args = new String[] {
         "volume", "create", "o3://" + omServiceId + volumeName};
     execute(ozoneShell, args);
 
-    args = new String[] {
-        "bucket", "create", "o3://" + omServiceId + volumeName + bucketName};
+    args = (Strings.isNullOrEmpty(bucketLayout)) ?
+            new String[] {"bucket", "create", "o3://" + omServiceId +
+                    volumeName + bucketName } :
+            new String[] {"bucket", "create", "o3://" + omServiceId +
+                    volumeName + bucketName, "--layout", bucketLayout};
     execute(ozoneShell, args);
 
     String keyName = volumeName + bucketName + OZONE_URI_DELIMITER + "key";
@@ -464,7 +469,7 @@ public class TestOzoneShellHA {
   @Test
   public void testOzoneShCmdList() throws UnsupportedEncodingException {
     // Part of listing keys test.
-    generateKeys("/volume4", "/bucket");
+    generateKeys("/volume4", "/bucket", "");
     final String destinationBucket = "o3://" + omServiceId + "/volume4/bucket";
 
     // Test case 1: test listing keys
@@ -516,7 +521,7 @@ public class TestOzoneShellHA {
   @Test
   public void testOzoneAdminCmdList() throws UnsupportedEncodingException {
     // Part of listing keys test.
-    generateKeys("/volume6", "/bucket");
+    generateKeys("/volume6", "/bucket", "");
     // Test case 1: list OPEN container
     String state = "--state=OPEN";
     String[] args = new String[] {"container", "list", "--scm",
@@ -1123,6 +1128,127 @@ public class TestOzoneShellHA {
           e.getCause().getMessage());
     }
   }
+
+
+  @Test
+  public void testKeyDeleteOrSkipTrashWhenTrashEnableFSO()
+          throws UnsupportedEncodingException {
+    // Create 100 keys
+    generateKeys("/volumefso1", "/bucket1",
+        BucketLayout.FILE_SYSTEM_OPTIMIZED.toString());
+
+    // Enable trash
+    String trashConfKey = generateSetConfString(
+        OMConfigKeys.OZONE_FS_TRASH_INTERVAL_KEY, "1");
+    String[] args =
+        new String[] {trashConfKey, "key", "delete",
+            "/volumefso1/bucket1/key4"};
+
+    // Delete one key from FSO bucket
+    execute(ozoneShell, args);
+
+    // Get key list in .Trash path
+    String prefixKey = "--prefix=.Trash";
+    args = new String[] {"key", "list", prefixKey, "o3://" +
+          omServiceId + "/volumefso1/bucket1/"};
+    out.reset();
+    execute(ozoneShell, args);
+
+    // One key should be present in .Trash
+    Assert.assertEquals(1, getNumOfKeys());
+
+    args = new String[] {"key", "list", "o3://" + omServiceId +
+          "/volumefso1/bucket1/", "-l ", "110"};
+    out.reset();
+    execute(ozoneShell, args);
+
+    // Total number of keys still 100.
+    Assert.assertEquals(100, getNumOfKeys());
+
+    // Skip Trash
+    args = new String[] {trashConfKey, "key", "delete",
+        "/volumefso1/bucket1/key5", "--skipTrash"};
+    execute(ozoneShell, args);
+
+    // .Trash should still contain 1 key
+    prefixKey = "--prefix=.Trash";
+    args = new String[] {"key", "list", prefixKey, "o3://" +
+          omServiceId + "/volumefso1/bucket1/"};
+    out.reset();
+    execute(ozoneShell, args);
+    Assert.assertEquals(1, getNumOfKeys());
+
+    args = new String[] {"key", "list", "o3://" + omServiceId +
+          "/volumefso1/bucket1/", "-l ", "110"};
+    out.reset();
+    execute(ozoneShell, args);
+    // Total number of keys now will be 99 as
+    // 1 key deleted without trash
+    Assert.assertEquals(99, getNumOfKeys());
+  }
+
+  @Test
+  public void testKeyDeleteWhenTrashDisableFSO()
+      throws UnsupportedEncodingException {
+    // Create 100 keys
+    generateKeys("/volumefso2", "/bucket2",
+        BucketLayout.FILE_SYSTEM_OPTIMIZED.toString());
+    // Disable trash
+    String trashConfKey = generateSetConfString(
+        OMConfigKeys.OZONE_FS_TRASH_INTERVAL_KEY, "0");
+    String[] args =
+            new String[] {trashConfKey, "key",
+                "delete", "/volumefso2/bucket2/key4"};
+
+    execute(ozoneShell, args);
+
+    // Check in .Trash path number of keys
+    final String prefixKey = "--prefix=.Trash";
+    args = new String[] {"key", "list", prefixKey,
+        "o3://" + omServiceId + "/volumefso2/bucket2/"};
+    out.reset();
+    execute(ozoneShell, args);
+
+    // No key should be present in .Trash
+    Assert.assertEquals(0, getNumOfKeys());
+
+    args = new String[] {"key", "list", "o3://" +
+          omServiceId + "/volumefso2/bucket2/"};
+    out.reset();
+    execute(ozoneShell, args);
+
+    // Number of keys remain as 99
+    Assert.assertEquals(99, getNumOfKeys());
+  }
+
+  @Test
+  public void testKeyDeleteWhenTrashEnableOBS()
+      throws UnsupportedEncodingException {
+    generateKeys("/volumeobs1", "/bucket1",
+        BucketLayout.OBJECT_STORE.toString());
+
+    String trashConfKey = generateSetConfString(
+        OMConfigKeys.OZONE_FS_TRASH_INTERVAL_KEY, "1");
+    String[] args =
+            new String[] {trashConfKey, "key",
+                "delete", "/volumeobs1/bucket1/key4"};
+    execute(ozoneShell, args);
+
+    final String prefixKey = "--prefix=.Trash";
+    args = new String[] {"key", "list", prefixKey, "o3://" +
+          omServiceId + "/volumeobs1/bucket1/"};
+    out.reset();
+    execute(ozoneShell, args);
+    Assert.assertEquals(0, getNumOfKeys());
+
+    args = new String[] {"key", "list", "o3://" +
+          omServiceId + "/volumeobs1/bucket1/"};
+    out.reset();
+    execute(ozoneShell, args);
+
+    Assert.assertEquals(99, getNumOfKeys());
+  }
+
 
   private void getVolume(String volumeName) {
     String[] args = new String[] {"volume", "create",

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/keys/DeleteKeyHandler.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/keys/DeleteKeyHandler.java
@@ -18,15 +18,28 @@
 
 package org.apache.hadoop.ozone.shell.keys;
 
+import java.util.Iterator;
+
+import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.ozone.client.OzoneBucket;
 import org.apache.hadoop.ozone.client.OzoneClient;
 import org.apache.hadoop.ozone.client.OzoneClientException;
+import org.apache.hadoop.ozone.client.OzoneKey;
+import org.apache.hadoop.ozone.client.OzoneKeyDetails;
 import org.apache.hadoop.ozone.client.OzoneVolume;
 import org.apache.hadoop.ozone.shell.OzoneAddress;
-
+import org.apache.hadoop.ozone.om.OMConfigKeys;
+import org.apache.hadoop.ozone.om.helpers.OzoneFSUtils;
+import org.apache.hadoop.security.UserGroupInformation;
+import picocli.CommandLine;
 import picocli.CommandLine.Command;
 
 import java.io.IOException;
+
+import static org.apache.hadoop.fs.CommonConfigurationKeysPublic.FS_TRASH_INTERVAL_DEFAULT;
+import static org.apache.hadoop.fs.CommonConfigurationKeysPublic.FS_TRASH_INTERVAL_KEY;
+import static org.apache.hadoop.fs.FileSystem.TRASH_PREFIX;
+import static org.apache.hadoop.ozone.OzoneConsts.OZONE_URI_DELIMITER;
 
 /**
  * Executes Delete Key.
@@ -34,6 +47,12 @@ import java.io.IOException;
 @Command(name = "delete",
     description = "deletes an existing key")
 public class DeleteKeyHandler extends KeyHandler {
+
+  @CommandLine.Option(names = "--skipTrash",
+          description = "Specify whether to skip Trash ")
+  private boolean skipTrash = false;
+
+  private static final Path CURRENT = new Path("Current");
 
   @Override
   protected void execute(OzoneClient client, OzoneAddress address)
@@ -45,6 +64,81 @@ public class DeleteKeyHandler extends KeyHandler {
 
     OzoneVolume vol = client.getObjectStore().getVolume(volumeName);
     OzoneBucket bucket = vol.getBucket(bucketName);
-    bucket.deleteKey(keyName);
+
+    float hadoopTrashInterval = getConf().getFloat(
+        FS_TRASH_INTERVAL_KEY, FS_TRASH_INTERVAL_DEFAULT);
+
+    long trashInterval =
+            (long) (getConf().getFloat(
+                    OMConfigKeys.OZONE_FS_TRASH_INTERVAL_KEY,
+                    hadoopTrashInterval) * 10000);
+
+    // If Bucket layout is FSO and Trash is enabled
+    // In this case during delete operation move key to trash
+    if (bucket.getBucketLayout().isFileSystemOptimized() && trashInterval > 0
+        && !skipTrash && !keyName.contains(".Trash")) {
+
+      keyName = OzoneFSUtils.removeTrailingSlashIfNeeded(keyName);
+      try {
+        // Check if key exists in Ozone
+        OzoneKeyDetails key = bucket.getKey(keyName);
+        if (key == null) {
+          out().printf("Key not found %s", keyName);
+          return;
+        }
+        // Check whether directory is empty or not
+        Iterator<? extends OzoneKey> ozoneKeyIterator =
+            bucket.listKeys(keyName, keyName);
+        int count = 0;
+        while (ozoneKeyIterator.hasNext()) {
+          ozoneKeyIterator.next();
+          if (++count > 1) {
+            // Assume FSO Tree: /a/b1/c1/k1.txt
+            // And we are trying to delete key /a/b1/c1
+            // In this case count is 2  which is greater than 1
+            // /a/b1/c1/ and /a/b1/c1/k1.txt
+            out().printf("Directory is not empty");
+            return;
+          }
+        }
+      } catch (Exception e) {
+        out().printf("Key not found %s", keyName);
+        return;
+      }
+
+      final String username =
+              UserGroupInformation.getCurrentUser().getShortUserName();
+      Path trashRoot = new Path(OZONE_URI_DELIMITER, TRASH_PREFIX);
+      Path userTrash = new Path(trashRoot, username);
+      Path userTrashCurrent = new Path(userTrash, CURRENT);
+
+      String trashDirectory = (keyName.contains("/")
+          ? new Path(userTrashCurrent, keyName.substring(0,
+          keyName.lastIndexOf("/")))
+          : userTrashCurrent).toUri().getPath();
+
+      String toKeyName = new Path(userTrashCurrent, keyName).toUri().getPath();
+      OzoneKeyDetails toKeyDetails = null;
+      try {
+        // check whether key already exist in trash
+        toKeyDetails = bucket.getKey(toKeyName);
+      } catch (IOException e) {
+        // Key doesn't exist inside trash.
+      }
+
+      if (toKeyDetails != null) {
+        // if key(directory) already exist in trash, just delete the key
+        bucket.deleteKey(keyName);
+        return;
+      }
+      // Create directory inside trash
+      bucket.createDirectory(trashDirectory);
+      // Rename key to move inside trash folder
+      bucket.renameKey(keyName, toKeyName);
+      out().printf("Key moved inside Trash: %s", toKeyName);
+
+    } else {
+      bucket.deleteKey(keyName);
+    }
   }
 }

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/keys/DeleteKeyHandler.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/keys/DeleteKeyHandler.java
@@ -87,8 +87,7 @@ public class DeleteKeyHandler extends KeyHandler {
         !keyName.contains(TRASH_PREFIX)) {
       keyName = OzoneFSUtils.removeTrailingSlashIfNeeded(keyName);
         // Check if key exists in Ozone
-      boolean bKeyExist = isKeyExist(bucket, keyName);
-      if (!bKeyExist) {
+      if (!isKeyExist(bucket, keyName)) {
         out().printf("Key not found %s %n", keyName);
         return;
       }
@@ -114,9 +113,7 @@ public class DeleteKeyHandler extends KeyHandler {
           : userTrashCurrent).toUri().getPath();
 
       String toKeyName = new Path(userTrashCurrent, keyName).toUri().getPath();
-      bKeyExist = isKeyExist(bucket, toKeyName);
-
-      if (bKeyExist) {
+      if (isKeyExist(bucket, toKeyName)) {
         if (bucket.getFileStatus(toKeyName).isDirectory()) {
           // if directory already exist in trash, just delete the directory
           bucket.deleteKey(keyName);
@@ -129,8 +126,7 @@ public class DeleteKeyHandler extends KeyHandler {
       }
 
       // Check whether trash directory already exist inside bucket
-      bKeyExist = isKeyExist(bucket, trashDirectory);
-      if (!bKeyExist) {
+      if (!isKeyExist(bucket, trashDirectory)) {
         // Trash directory doesn't exist
         // Create directory inside trash
         bucket.createDirectory(trashDirectory);
@@ -156,9 +152,6 @@ public class DeleteKeyHandler extends KeyHandler {
     } catch (IOException e) {
       return false;
     }
-    if (keyDetails == null) {
-      return false;
-    }
-    return true;
+    return (keyDetails != null);
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

When trash is enabled and user runs ozone sh key delete, the key should be moved inside trash instead of permanent delete immediately.
Currently using fs command when trash is enabled and user deletes the file for FSO bucket it goes inside Trash.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-8547

## How was this patch tested?

Added new integration and robot test.
