### PR TITLE
HDDS-8209. Synchronize tarball creation with background processes.

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/lock/BootstrapStateHandler.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/lock/BootstrapStateHandler.java
@@ -19,7 +19,10 @@
 package org.apache.hadoop.ozone.lock;
 
 /** Bootstrap state lock interface. */
-public interface BootstrapStateHandler {
-  void lockBootstrapState() throws InterruptedException;
+public interface BootstrapStateHandler extends AutoCloseable {
+  BootstrapStateHandler lockBootstrapState() throws InterruptedException;
   void unlockBootstrapState();
+  default void close() {
+    unlockBootstrapState();
+  }
 }

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/lock/BootstrapStateHandler.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/lock/BootstrapStateHandler.java
@@ -1,0 +1,25 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.ozone.lock;
+
+/** Bootstrap state lock interface. */
+public interface BootstrapStateHandler {
+  void lockBootstrapState() throws InterruptedException;
+  void unlockBootstrapState();
+}

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/lock/BootstrapStateHandler.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/lock/BootstrapStateHandler.java
@@ -22,7 +22,7 @@ import java.util.concurrent.Semaphore;
 
 /** Bootstrap state lock interface. */
 public interface BootstrapStateHandler {
-  Lock getLock();
+  Lock getBoostrapStateLock();
 
   static class Lock implements AutoCloseable {
     private Semaphore semaphore = new Semaphore(1);

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/lock/BootstrapStateHandler.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/lock/BootstrapStateHandler.java
@@ -20,11 +20,12 @@ package org.apache.hadoop.ozone.lock;
 
 import java.util.concurrent.Semaphore;
 
-/** Bootstrap state lock interface. */
+/** Bootstrap state handler interface. */
 public interface BootstrapStateHandler {
   Lock getBoostrapStateLock();
 
-  static class Lock implements AutoCloseable {
+  /** Bootstrap state handler lock implementation. */
+  class Lock implements AutoCloseable {
     private Semaphore semaphore = new Semaphore(1);
     public Lock lock() throws InterruptedException {
       semaphore.acquire();

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/lock/BootstrapStateHandler.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/lock/BootstrapStateHandler.java
@@ -18,11 +18,23 @@
 
 package org.apache.hadoop.ozone.lock;
 
+import java.util.concurrent.Semaphore;
+
 /** Bootstrap state lock interface. */
-public interface BootstrapStateHandler extends AutoCloseable {
-  BootstrapStateHandler lockBootstrapState() throws InterruptedException;
-  void unlockBootstrapState();
-  default void close() {
-    unlockBootstrapState();
+public interface BootstrapStateHandler {
+  Lock getLock();
+
+  static class Lock implements AutoCloseable {
+    private Semaphore semaphore = new Semaphore(1);
+    public Lock lock() throws InterruptedException {
+      semaphore.acquire();
+      return this;
+    }
+    public void unlock() {
+      semaphore.release();
+    }
+    public void close() {
+      unlock();
+    }
   }
 }

--- a/hadoop-hdds/rocksdb-checkpoint-differ/src/main/java/org/apache/ozone/rocksdiff/RocksDBCheckpointDiffer.java
+++ b/hadoop-hdds/rocksdb-checkpoint-differ/src/main/java/org/apache/ozone/rocksdiff/RocksDBCheckpointDiffer.java
@@ -1164,7 +1164,7 @@ public class RocksDBCheckpointDiffer implements AutoCloseable,
 
     Set<String> sstFileNodesRemoved =
         pruneSstFileNodesFromDag(lastCompactionSstFiles);
-    try (BootstrapStateHandler.Lock lock = getLock().lock()) {
+    try (BootstrapStateHandler.Lock lock = getBoostrapStateLock().lock()) {
       removeSstFiles(sstFileNodesRemoved);
       deleteOlderSnapshotsCompactionFiles(olderSnapshotsLogFilePaths);
     } catch (InterruptedException e) {
@@ -1472,7 +1472,7 @@ public class RocksDBCheckpointDiffer implements AutoCloseable,
           .map(node -> node.getFileName())
           .collect(Collectors.toSet());
     }
-    try (BootstrapStateHandler.Lock lock = getLock().lock()) {
+    try (BootstrapStateHandler.Lock lock = getBoostrapStateLock().lock()) {
       removeSstFiles(nonLeafSstFiles);
     } catch (InterruptedException e) {
       throw new RuntimeException(e);
@@ -1521,7 +1521,7 @@ public class RocksDBCheckpointDiffer implements AutoCloseable,
   }
 
   @Override
-  public BootstrapStateHandler.Lock getLock() {
+  public BootstrapStateHandler.Lock getBoostrapStateLock() {
     return lock;
   }
 }

--- a/hadoop-hdds/rocksdb-checkpoint-differ/src/test/java/org/apache/ozone/rocksdiff/TestRocksDBCheckpointDiffer.java
+++ b/hadoop-hdds/rocksdb-checkpoint-differ/src/test/java/org/apache/ozone/rocksdiff/TestRocksDBCheckpointDiffer.java
@@ -1132,8 +1132,8 @@ public class TestRocksDBCheckpointDiffer {
       throws InterruptedException, ExecutionException, TimeoutException {
 
     Future<Boolean> future;
-    try (BootstrapStateHandler.Lock lock = differ.getBoostrapStateLock().lock()) {
-
+    try (BootstrapStateHandler.Lock lock =
+        differ.getBoostrapStateLock().lock()) {
       future = executorService.submit(
           () -> {
             c.accept(differ);

--- a/hadoop-hdds/rocksdb-checkpoint-differ/src/test/java/org/apache/ozone/rocksdiff/TestRocksDBCheckpointDiffer.java
+++ b/hadoop-hdds/rocksdb-checkpoint-differ/src/test/java/org/apache/ozone/rocksdiff/TestRocksDBCheckpointDiffer.java
@@ -1132,7 +1132,7 @@ public class TestRocksDBCheckpointDiffer {
       throws InterruptedException, ExecutionException, TimeoutException {
 
     Future<Boolean> future;
-    try (BootstrapStateHandler.Lock lock = differ.getLock().lock()) {
+    try (BootstrapStateHandler.Lock lock = differ.getBoostrapStateLock().lock()) {
 
       future = executorService.submit(
           () -> {

--- a/hadoop-hdds/rocksdb-checkpoint-differ/src/test/java/org/apache/ozone/rocksdiff/TestRocksDBCheckpointDiffer.java
+++ b/hadoop-hdds/rocksdb-checkpoint-differ/src/test/java/org/apache/ozone/rocksdiff/TestRocksDBCheckpointDiffer.java
@@ -1132,6 +1132,7 @@ public class TestRocksDBCheckpointDiffer {
       throws InterruptedException, ExecutionException, TimeoutException {
 
     Future<Boolean> future;
+    // Take the lock and start the consumer.
     try (BootstrapStateHandler.Lock lock =
         differ.getBoostrapStateLock().lock()) {
       future = executorService.submit(

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOMDbCheckpointServlet.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOMDbCheckpointServlet.java
@@ -115,6 +115,7 @@ public class TestOMDbCheckpointServlet {
   private HttpServletRequest requestMock = null;
   private HttpServletResponse responseMock = null;
   private OMDBCheckpointServlet omDbCheckpointServletMock = null;
+  private BootstrapStateHandler.Lock lock;
   private File metaDir;
   private String snapshotDirName;
   private String snapshotDirName2;
@@ -180,6 +181,7 @@ public class TestOMDbCheckpointServlet {
     omDbCheckpointServletMock =
         mock(OMDBCheckpointServlet.class);
 
+    lock = new OMDBCheckpointServlet.Lock(cluster.getOzoneManager());
     doCallRealMethod().when(omDbCheckpointServletMock).init();
 
     requestMock = mock(HttpServletRequest.class);
@@ -202,6 +204,9 @@ public class TestOMDbCheckpointServlet {
 
     doCallRealMethod().when(omDbCheckpointServletMock)
         .writeDbDataToStream(any(), any(), any(), any(), any());
+
+    when(omDbCheckpointServletMock.getBoostrapStateLock())
+        .thenReturn(lock);
   }
 
   @Test

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOMDbCheckpointServlet.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOMDbCheckpointServlet.java
@@ -639,7 +639,8 @@ public class TestOMDbCheckpointServlet {
 
     // Confirm the other processes are locked out when the bootstrap
     //  servlet takes the lock.
-    try (BootstrapStateHandler.Lock lock = spyServlet.getBoostrapStateLock().lock()) {
+    try (BootstrapStateHandler.Lock lock =
+        spyServlet.getBoostrapStateLock().lock()) {
       confirmServletLocksOutOtherHandler(keyDeletingService, executorService);
       confirmServletLocksOutOtherHandler(snapshotDeletingService,
           executorService);
@@ -679,7 +680,8 @@ public class TestOMDbCheckpointServlet {
   private void confirmOtherHandlerLocksOutServlet(BootstrapStateHandler handler,
       BootstrapStateHandler servlet, ExecutorService executorService)
       throws InterruptedException {
-    try (BootstrapStateHandler.Lock lock = handler.getBoostrapStateLock().lock()) {
+    try (BootstrapStateHandler.Lock lock =
+        handler.getBoostrapStateLock().lock()) {
       Future<Boolean> test = checkLock(servlet, executorService);
       // Servlet should fail to lock when other handler has taken it.
       Assert.assertThrows(TimeoutException.class,

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOMDbCheckpointServlet.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOMDbCheckpointServlet.java
@@ -41,6 +41,10 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.UUID;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -54,6 +58,7 @@ import org.apache.hadoop.ozone.MiniOzoneCluster;
 import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.hadoop.ozone.TestDataUtil;
 import org.apache.hadoop.ozone.client.OzoneBucket;
+import org.apache.hadoop.ozone.lock.BootstrapStateHandler;
 import org.apache.hadoop.ozone.om.helpers.SnapshotInfo;
 import org.apache.hadoop.ozone.om.protocol.OzoneManagerProtocol;
 import org.apache.hadoop.security.UserGroupInformation;
@@ -91,7 +96,9 @@ import static org.apache.hadoop.ozone.om.OmSnapshotManager.getSnapshotPath;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doCallRealMethod;
 import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -595,5 +602,96 @@ public class TestOMDbCheckpointServlet {
     String file0 = files[0].substring(shortSnapshotLocation.length() + 1);
     String file1 = files[1];
     Assert.assertEquals("hl filenames are the same", file0, file1);
+  }
+
+  @Test
+  public void testBootstrapLocking() throws Exception {
+    cluster = MiniOzoneCluster.newBuilder(conf).setNumDatanodes(1).build();
+    cluster.waitForClusterToBeReady();
+
+    BootstrapStateHandler keyDeletingService =
+        cluster.getOzoneManager().getKeyManager().getDeletingService();
+    BootstrapStateHandler snapshotDeletingService =
+        cluster.getOzoneManager().getKeyManager().getSnapshotDeletingService();
+    BootstrapStateHandler sstFilteringService =
+        cluster.getOzoneManager().getKeyManager()
+            .getSnapshotSstFilteringService();
+    BootstrapStateHandler differ =
+        cluster.getOzoneManager().getMetadataManager()
+            .getStore().getRocksDBCheckpointDiffer();
+    ExecutorService executorService = Executors.newCachedThreadPool();
+
+    OMDBCheckpointServlet omDbCheckpointServlet = new OMDBCheckpointServlet();
+
+    OMDBCheckpointServlet spyServlet = spy(omDbCheckpointServlet);
+    ServletContext servletContext = mock(ServletContext.class);
+    when(servletContext.getAttribute(OzoneConsts.OM_CONTEXT_ATTRIBUTE))
+        .thenReturn(cluster.getOzoneManager());
+    doReturn(servletContext).when(spyServlet).getServletContext();
+
+
+    spyServlet.init();
+
+    // Confirm the other processes are locked out when the bootstrap
+    //  servlet takes the lock.
+    spyServlet.lockBootstrapState();
+    confirmServletLocksOutOtherHandler(keyDeletingService, executorService);
+    confirmServletLocksOutOtherHandler(snapshotDeletingService,
+        executorService);
+    confirmServletLocksOutOtherHandler(sstFilteringService, executorService);
+    confirmServletLocksOutOtherHandler(differ, executorService);
+    spyServlet.unlockBootstrapState();
+
+    // Confirm the bootstrap servlet is locked out when any of the other
+    //  processes takes the lock.
+    confirmOtherHandlerLocksOutServlet(keyDeletingService, spyServlet,
+        executorService);
+    confirmOtherHandlerLocksOutServlet(snapshotDeletingService, spyServlet,
+        executorService);
+    confirmOtherHandlerLocksOutServlet(sstFilteringService, spyServlet,
+        executorService);
+    confirmOtherHandlerLocksOutServlet(differ, spyServlet,
+        executorService);
+
+    // Confirm that servlet takes the lock when none of the other
+    //  processes have it.
+    Future<Boolean> servletTest = checkLock(spyServlet, executorService);
+    Assert.assertTrue(servletTest.get(10000, TimeUnit.MILLISECONDS));
+
+    executorService.shutdownNow();
+
+  }
+
+  private void confirmServletLocksOutOtherHandler(BootstrapStateHandler handler,
+      ExecutorService executorService) {
+    Future<Boolean> test = checkLock(handler, executorService);
+    // handler should fail to take the lock because the servlet has taken theirs
+    Assert.assertThrows(TimeoutException.class,
+         () -> test.get(500, TimeUnit.MILLISECONDS));
+  }
+
+  private void confirmOtherHandlerLocksOutServlet(BootstrapStateHandler handler,
+      BootstrapStateHandler servlet, ExecutorService executorService)
+      throws InterruptedException {
+    handler.lockBootstrapState();
+    Future<Boolean> test = checkLock(servlet, executorService);
+    // servlet should fail to lock when other handler has taken theirs
+    Assert.assertThrows(TimeoutException.class,
+        () -> test.get(500, TimeUnit.MILLISECONDS));
+    handler.unlockBootstrapState();
+  }
+
+  private Future<Boolean> checkLock(BootstrapStateHandler handler,
+      ExecutorService executorService) {
+    return executorService.submit(() -> {
+      try {
+        handler.lockBootstrapState();
+        handler.unlockBootstrapState();
+        return true;
+      } catch (InterruptedException e) {
+      }
+      return false;
+    });
+
   }
 }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOMDbCheckpointServlet.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOMDbCheckpointServlet.java
@@ -634,7 +634,7 @@ public class TestOMDbCheckpointServlet {
 
     // Confirm the other processes are locked out when the bootstrap
     //  servlet takes the lock.
-    try (BootstrapStateHandler.Lock lock = spyServlet.getLock().lock()) {
+    try (BootstrapStateHandler.Lock lock = spyServlet.getBoostrapStateLock().lock()) {
       confirmServletLocksOutOtherHandler(keyDeletingService, executorService);
       confirmServletLocksOutOtherHandler(snapshotDeletingService,
           executorService);
@@ -674,7 +674,7 @@ public class TestOMDbCheckpointServlet {
   private void confirmOtherHandlerLocksOutServlet(BootstrapStateHandler handler,
       BootstrapStateHandler servlet, ExecutorService executorService)
       throws InterruptedException {
-    try (BootstrapStateHandler.Lock lock = handler.getLock().lock()) {
+    try (BootstrapStateHandler.Lock lock = handler.getBoostrapStateLock().lock()) {
       Future<Boolean> test = checkLock(servlet, executorService);
       // Servlet should fail to lock when other handler has taken it.
       Assert.assertThrows(TimeoutException.class,
@@ -687,8 +687,8 @@ public class TestOMDbCheckpointServlet {
       ExecutorService executorService) {
     return executorService.submit(() -> {
       try {
-        handler.getLock().lock();
-        handler.getLock().unlock();
+        handler.getBoostrapStateLock().lock();
+        handler.getBoostrapStateLock().unlock();
         return true;
       } catch (InterruptedException e) {
       }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/KeyManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/KeyManager.java
@@ -28,6 +28,8 @@ import org.apache.hadoop.ozone.om.helpers.OmMultipartUploadListParts;
 import org.apache.hadoop.ozone.om.fs.OzoneManagerFS;
 import org.apache.hadoop.hdds.utils.BackgroundService;
 import org.apache.hadoop.ozone.om.helpers.RepeatedOmKeyInfo;
+import org.apache.hadoop.ozone.om.service.KeyDeletingService;
+import org.apache.hadoop.ozone.om.service.SnapshotDeletingService;
 
 import java.io.IOException;
 import java.time.Duration;
@@ -153,7 +155,7 @@ public interface KeyManager extends OzoneManagerFS, IOzoneAcl {
    * Returns the instance of Deleting Service.
    * @return Background service.
    */
-  BackgroundService getDeletingService();
+  KeyDeletingService getDeletingService();
 
 
   OmMultipartUploadList listMultipartUploads(String volumeName,
@@ -246,11 +248,11 @@ public interface KeyManager extends OzoneManagerFS, IOzoneAcl {
    * Returns the instance of Snapshot SST Filtering service.
    * @return Background service.
    */
-  BackgroundService getSnapshotSstFilteringService();
+  SstFilteringService getSnapshotSstFilteringService();
 
   /**
    * Returns the instance of Snapshot Deleting service.
    * @return Background service.
    */
-  BackgroundService getSnapshotDeletingService();
+  SnapshotDeletingService getSnapshotDeletingService();
 }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/KeyManagerImpl.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/KeyManagerImpl.java
@@ -165,10 +165,10 @@ public class KeyManagerImpl implements KeyManager {
   private final OzoneBlockTokenSecretManager secretManager;
   private final boolean grpcBlockTokenEnabled;
 
-  private BackgroundService keyDeletingService;
+  private KeyDeletingService keyDeletingService;
 
-  private BackgroundService snapshotSstFilteringService;
-  private BackgroundService snapshotDeletingService;
+  private SstFilteringService snapshotSstFilteringService;
+  private SnapshotDeletingService snapshotDeletingService;
 
   private final KeyProviderCryptoExtension kmsProvider;
   private final boolean enableFileSystemPaths;
@@ -630,7 +630,7 @@ public class KeyManagerImpl implements KeyManager {
   }
 
   @Override
-  public BackgroundService getDeletingService() {
+  public KeyDeletingService getDeletingService() {
     return keyDeletingService;
   }
 
@@ -643,11 +643,11 @@ public class KeyManagerImpl implements KeyManager {
     return openKeyCleanupService;
   }
 
-  public BackgroundService getSnapshotSstFilteringService() {
+  public SstFilteringService getSnapshotSstFilteringService() {
     return snapshotSstFilteringService;
   }
 
-  public BackgroundService getSnapshotDeletingService() {
+  public SnapshotDeletingService getSnapshotDeletingService() {
     return snapshotDeletingService;
   }
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OMDBCheckpointServlet.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OMDBCheckpointServlet.java
@@ -83,7 +83,7 @@ public class OMDBCheckpointServlet extends DBCheckpointServlet
   private static final Logger LOG =
       LoggerFactory.getLogger(OMDBCheckpointServlet.class);
   private static final long serialVersionUID = 1L;
-  private BootstrapStateHandler.Lock lock;
+  private transient BootstrapStateHandler.Lock lock;
 
   @Override
   public void init() throws ServletException {
@@ -301,15 +301,14 @@ public class OMDBCheckpointServlet extends DBCheckpointServlet
     return lock;
   }
 
-  static class Lock extends BootstrapStateHandler.Lock
-      {
+  static class Lock extends BootstrapStateHandler.Lock {
     private final BootstrapStateHandler keyDeletingService;
     private final BootstrapStateHandler sstFilteringService;
     private final BootstrapStateHandler rocksDbCheckpointDiffer;
     private final BootstrapStateHandler snapshotDeletingService;
     private final OzoneManager om;
 
-    public Lock(OzoneManager om) {
+    Lock(OzoneManager om) {
       this.om = om;
       keyDeletingService = om.getKeyManager().getDeletingService();
       sstFilteringService = om.getKeyManager().getSnapshotSstFilteringService();

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OMDBCheckpointServlet.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OMDBCheckpointServlet.java
@@ -134,7 +134,7 @@ public class OMDBCheckpointServlet extends DBCheckpointServlet
     // Map of link to path.
     Map<Path, Path> hardLinkFiles = new HashMap<>();
 
-    try (BootstrapStateHandler.Lock lock = getLock().lock();
+    try (BootstrapStateHandler.Lock lock = getBoostrapStateLock().lock();
          TarArchiveOutputStream archiveOutputStream =
              new TarArchiveOutputStream(destination)) {
       archiveOutputStream
@@ -297,7 +297,7 @@ public class OMDBCheckpointServlet extends DBCheckpointServlet
   }
 
   @Override
-  public BootstrapStateHandler.Lock getLock() {
+  public BootstrapStateHandler.Lock getBoostrapStateLock() {
     return lock;
   }
 
@@ -323,10 +323,10 @@ public class OMDBCheckpointServlet extends DBCheckpointServlet
     public BootstrapStateHandler.Lock lock()
         throws InterruptedException {
       // First lock all the handlers.
-      keyDeletingService.getLock().lock();
-      sstFilteringService.getLock().lock();
-      rocksDbCheckpointDiffer.getLock().lock();
-      snapshotDeletingService.getLock().lock();
+      keyDeletingService.getBoostrapStateLock().lock();
+      sstFilteringService.getBoostrapStateLock().lock();
+      rocksDbCheckpointDiffer.getBoostrapStateLock().lock();
+      snapshotDeletingService.getBoostrapStateLock().lock();
 
       // Then wait for the double buffer to be flushed.
       om.getOmRatisServer().getOmStateMachine().awaitDoubleBufferFlush();
@@ -335,10 +335,10 @@ public class OMDBCheckpointServlet extends DBCheckpointServlet
 
     @Override
     public void unlock() {
-      snapshotDeletingService.getLock().unlock();
-      rocksDbCheckpointDiffer.getLock().unlock();
-      sstFilteringService.getLock().unlock();
-      keyDeletingService.getLock().unlock();
+      snapshotDeletingService.getBoostrapStateLock().unlock();
+      rocksDbCheckpointDiffer.getBoostrapStateLock().unlock();
+      sstFilteringService.getBoostrapStateLock().unlock();
+      keyDeletingService.getBoostrapStateLock().unlock();
     }
   }
 }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OMDBCheckpointServlet.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OMDBCheckpointServlet.java
@@ -315,7 +315,6 @@ public class OMDBCheckpointServlet extends DBCheckpointServlet
       rocksDbCheckpointDiffer = om.getMetadataManager().getStore()
           .getRocksDBCheckpointDiffer();
       snapshotDeletingService = om.getKeyManager().getSnapshotDeletingService();
-
     }
 
     @Override

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/SstFilteringService.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/SstFilteringService.java
@@ -157,11 +157,8 @@ public class SstFilteringService extends BackgroundService
                       new File(snapshotCheckpointDir),
                       dbName, true, Optional.of(Boolean.TRUE), false)) {
             RocksDatabase db = rdbStore.getDb();
-            try {
-              lockBootstrapState();
+            try (BootstrapStateHandler handler =  lockBootstrapState()) {
               db.deleteFilesNotMatchingPrefix(prefixPairs, filterFunction);
-            } finally {
-              unlockBootstrapState();
             }
           }
 
@@ -229,8 +226,10 @@ public class SstFilteringService extends BackgroundService
 
 
   @Override
-  public void lockBootstrapState() throws InterruptedException {
+  public BootstrapStateHandler lockBootstrapState()
+      throws InterruptedException {
     bootstrapStateLock.acquire();
+    return this;
   }
 
   @Override

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/SstFilteringService.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/SstFilteringService.java
@@ -157,7 +157,7 @@ public class SstFilteringService extends BackgroundService
                       new File(snapshotCheckpointDir),
                       dbName, true, Optional.of(Boolean.TRUE), false)) {
             RocksDatabase db = rdbStore.getDb();
-            try (BootstrapStateHandler.Lock lock = getLock().lock()) {
+            try (BootstrapStateHandler.Lock lock = getBoostrapStateLock().lock()) {
               db.deleteFilesNotMatchingPrefix(prefixPairs, filterFunction);
             }
           }
@@ -225,7 +225,7 @@ public class SstFilteringService extends BackgroundService
   }
 
   @Override
-  public BootstrapStateHandler.Lock getLock() {
+  public BootstrapStateHandler.Lock getBoostrapStateLock() {
     return lock;
   }
 }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/SstFilteringService.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/SstFilteringService.java
@@ -157,7 +157,8 @@ public class SstFilteringService extends BackgroundService
                       new File(snapshotCheckpointDir),
                       dbName, true, Optional.of(Boolean.TRUE), false)) {
             RocksDatabase db = rdbStore.getDb();
-            try (BootstrapStateHandler.Lock lock = getBoostrapStateLock().lock()) {
+            try (BootstrapStateHandler.Lock lock =
+                getBoostrapStateLock().lock()) {
               db.deleteFilesNotMatchingPrefix(prefixPairs, filterFunction);
             }
           }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/SstFilteringService.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/SstFilteringService.java
@@ -178,8 +178,6 @@ public class SstFilteringService extends BackgroundService
       return BackgroundTaskResult.EmptyTaskResult.newResult();
     }
 
-
-
     /**
      * @param snapshotInfo
      * @return a list of pairs (tableName,keyPrefix).

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/snapshot/OMSnapshotMoveDeletedKeysResponse.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/snapshot/OMSnapshotMoveDeletedKeysResponse.java
@@ -20,7 +20,7 @@ package org.apache.hadoop.ozone.om.response.snapshot;
 
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.hdds.utils.db.BatchOperation;
-import org.apache.hadoop.hdds.utils.db.DBStore;
+import org.apache.hadoop.hdds.utils.db.RDBStore;
 import org.apache.hadoop.ozone.om.OMMetadataManager;
 import org.apache.hadoop.ozone.om.OmSnapshot;
 import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
@@ -79,13 +79,16 @@ public class OMSnapshotMoveDeletedKeysResponse extends OMClientResponse {
       BatchOperation batchOperation) throws IOException {
 
     if (nextSnapshot != null) {
-      DBStore nextSnapshotStore = nextSnapshot.getMetadataManager().getStore();
+      RDBStore nextSnapshotStore =
+          (RDBStore) nextSnapshot.getMetadataManager().getStore();
       // Init Batch Operation for snapshot db.
       try (BatchOperation writeBatch = nextSnapshotStore.initBatchOperation()) {
         processKeys(writeBatch, nextSnapshot.getMetadataManager(),
             nextDBKeysList, true);
         processDirs(writeBatch, nextSnapshot.getMetadataManager());
         nextSnapshotStore.commitBatchOperation(writeBatch);
+        nextSnapshotStore.getDb().flushWal(true);
+        nextSnapshotStore.getDb().flush();
       }
     } else {
       // Handle the case where there is no next Snapshot.
@@ -94,12 +97,15 @@ public class OMSnapshotMoveDeletedKeysResponse extends OMClientResponse {
     }
 
     // Update From Snapshot Deleted Table.
-    DBStore fromSnapshotStore = fromSnapshot.getMetadataManager().getStore();
+    RDBStore fromSnapshotStore =
+        (RDBStore) fromSnapshot.getMetadataManager().getStore();
     try (BatchOperation fromSnapshotBatchOp =
              fromSnapshotStore.initBatchOperation()) {
       processKeys(fromSnapshotBatchOp, fromSnapshot.getMetadataManager(),
           reclaimKeysList, false);
       fromSnapshotStore.commitBatchOperation(fromSnapshotBatchOp);
+      fromSnapshotStore.getDb().flushWal(true);
+      fromSnapshotStore.getDb().flush();
     }
   }
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/service/AbstractKeyDeletingService.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/service/AbstractKeyDeletingService.java
@@ -487,11 +487,8 @@ public abstract class AbstractKeyDeletingService extends BackgroundService
         .setClientId(clientId.toString())
         .build();
 
-    try {
-      lockBootstrapState();
+    try (BootstrapStateHandler handler = lockBootstrapState()) {
       submitRequest(omRequest);
-    } finally {
-      unlockBootstrapState();
     }
   }
 
@@ -521,8 +518,9 @@ public abstract class AbstractKeyDeletingService extends BackgroundService
   }
 
   @Override
-  public void lockBootstrapState() throws InterruptedException {
+  public BootstrapStateHandler lockBootstrapState() throws InterruptedException {
     bootstrapStateLock.acquire();
+    return this;
   }
 
   @Override

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/service/AbstractKeyDeletingService.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/service/AbstractKeyDeletingService.java
@@ -518,7 +518,7 @@ public abstract class AbstractKeyDeletingService extends BackgroundService
     }
   }
 
-  public BootstrapStateHandler.Lock getLock() {
+  public BootstrapStateHandler.Lock getBoostrapStateLock() {
     return lock;
   }
 }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/service/AbstractKeyDeletingService.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/service/AbstractKeyDeletingService.java
@@ -76,7 +76,8 @@ public abstract class AbstractKeyDeletingService extends BackgroundService
   private final AtomicLong movedDirsCount;
   private final AtomicLong movedFilesCount;
   private final AtomicLong runCount;
-  private final Semaphore bootstrapStateLock = new Semaphore(1);
+  private final BootstrapStateHandler.Lock lock =
+      new BootstrapStateHandler.Lock();
 
   public AbstractKeyDeletingService(String serviceName, long interval,
       TimeUnit unit, int threadPoolSize, long serviceTimeout,
@@ -487,7 +488,7 @@ public abstract class AbstractKeyDeletingService extends BackgroundService
         .setClientId(clientId.toString())
         .build();
 
-    try (BootstrapStateHandler handler = lockBootstrapState()) {
+    try (BootstrapStateHandler.Lock lock = new BootstrapStateHandler.Lock()) {
       submitRequest(omRequest);
     }
   }
@@ -517,14 +518,7 @@ public abstract class AbstractKeyDeletingService extends BackgroundService
     }
   }
 
-  @Override
-  public BootstrapStateHandler lockBootstrapState() throws InterruptedException {
-    bootstrapStateLock.acquire();
-    return this;
-  }
-
-  @Override
-  public void unlockBootstrapState() {
-    bootstrapStateLock.release();
+  public BootstrapStateHandler.Lock getLock() {
+    return lock;
   }
 }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/service/AbstractKeyDeletingService.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/service/AbstractKeyDeletingService.java
@@ -19,6 +19,7 @@ package org.apache.hadoop.ozone.om.service;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.protobuf.ServiceException;
 import org.apache.commons.lang3.tuple.Pair;
+import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.hdds.scm.protocol.ScmBlockLocationProtocol;
 import org.apache.hadoop.hdds.utils.BackgroundService;
 import org.apache.hadoop.hdds.utils.db.BatchOperation;
@@ -26,6 +27,7 @@ import org.apache.hadoop.hdds.utils.db.DBStore;
 import org.apache.hadoop.hdds.utils.db.Table;
 import org.apache.hadoop.ozone.ClientVersion;
 import org.apache.hadoop.ozone.common.BlockGroup;
+import org.apache.hadoop.ozone.lock.BootstrapStateHandler;
 import org.apache.hadoop.ozone.common.DeleteBlockGroupResult;
 import org.apache.hadoop.ozone.om.KeyManager;
 import org.apache.hadoop.ozone.om.OMMetadataManager;
@@ -33,11 +35,15 @@ import org.apache.hadoop.ozone.om.OzoneManager;
 import org.apache.hadoop.ozone.om.helpers.OMRatisHelper;
 import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
 import org.apache.hadoop.ozone.om.helpers.RepeatedOmKeyInfo;
+import org.apache.hadoop.ozone.om.helpers.SnapshotInfo;
+import org.apache.hadoop.ozone.om.ratis.OzoneManagerRatisServer;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.DeletedKeys;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMRequest;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.PurgeKeysRequest;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.PurgePathRequest;
+import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.SnapshotMoveKeyInfos;
+import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.SnapshotMoveDeletedKeysRequest;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.Type;
 import org.apache.hadoop.util.Time;
 import org.apache.ratis.protocol.ClientId;
@@ -49,6 +55,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
+import java.util.concurrent.Semaphore;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
@@ -59,7 +66,8 @@ import static org.apache.hadoop.ozone.OzoneConsts.OM_KEY_PREFIX;
  * Abstracts common code from KeyDeletingService and DirectoryDeletingService
  * which is now used by SnapshotDeletingService as well.
  */
-public abstract class AbstractKeyDeletingService extends BackgroundService {
+public abstract class AbstractKeyDeletingService extends BackgroundService
+    implements BootstrapStateHandler {
 
   private final OzoneManager ozoneManager;
   private final ScmBlockLocationProtocol scmClient;
@@ -68,6 +76,7 @@ public abstract class AbstractKeyDeletingService extends BackgroundService {
   private final AtomicLong movedDirsCount;
   private final AtomicLong movedFilesCount;
   private final AtomicLong runCount;
+  private final Semaphore bootstrapStateLock = new Semaphore(1);
 
   public AbstractKeyDeletingService(String serviceName, long interval,
       TimeUnit unit, int threadPoolSize, long serviceTimeout,
@@ -453,5 +462,71 @@ public abstract class AbstractKeyDeletingService extends BackgroundService {
   @VisibleForTesting
   public long getMovedFilesCount() {
     return movedFilesCount.get();
+  }
+
+  protected void submitSnapshotMoveDeletedKeys(SnapshotInfo snapInfo,
+      List<SnapshotMoveKeyInfos> toReclaimList,
+      List<SnapshotMoveKeyInfos> toNextDBList,
+      List<HddsProtos.KeyValue> renamedList,
+      List<String> dirsToMove) throws InterruptedException {
+
+    SnapshotMoveDeletedKeysRequest.Builder moveDeletedKeysBuilder =
+        SnapshotMoveDeletedKeysRequest.newBuilder()
+            .setFromSnapshot(snapInfo.getProtobuf());
+
+    SnapshotMoveDeletedKeysRequest moveDeletedKeys = moveDeletedKeysBuilder
+        .addAllReclaimKeys(toReclaimList)
+        .addAllNextDBKeys(toNextDBList)
+        .addAllRenamedKeys(renamedList)
+        .addAllDeletedDirsToMove(dirsToMove)
+        .build();
+
+    OMRequest omRequest = OMRequest.newBuilder()
+        .setCmdType(Type.SnapshotMoveDeletedKeys)
+        .setSnapshotMoveDeletedKeysRequest(moveDeletedKeys)
+        .setClientId(clientId.toString())
+        .build();
+
+    try {
+      lockBootstrapState();
+      submitRequest(omRequest);
+    } finally {
+      unlockBootstrapState();
+    }
+  }
+
+  protected void submitRequest(OMRequest omRequest) {
+    try {
+      if (isRatisEnabled()) {
+        OzoneManagerRatisServer server = ozoneManager.getOmRatisServer();
+
+        RaftClientRequest raftClientRequest = RaftClientRequest.newBuilder()
+            .setClientId(clientId)
+            .setServerId(server.getRaftPeerId())
+            .setGroupId(server.getRaftGroupId())
+            .setCallId(getRunCount().get())
+            .setMessage(Message.valueOf(
+                OMRatisHelper.convertRequestToByteString(omRequest)))
+            .setType(RaftClientRequest.writeRequestType())
+            .build();
+
+        server.submitRequest(omRequest, raftClientRequest);
+      } else {
+        ozoneManager.getOmServerProtocol().submitRequest(null, omRequest);
+      }
+    } catch (ServiceException e) {
+      LOG.error("Snapshot Deleting request failed. " +
+          "Will retry at next run.", e);
+    }
+  }
+
+  @Override
+  public void lockBootstrapState() throws InterruptedException {
+    bootstrapStateLock.acquire();
+  }
+
+  @Override
+  public void unlockBootstrapState() {
+    bootstrapStateLock.release();
   }
 }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/service/AbstractKeyDeletingService.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/service/AbstractKeyDeletingService.java
@@ -55,7 +55,6 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
-import java.util.concurrent.Semaphore;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestSstFilteringService.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestSstFilteringService.java
@@ -228,7 +228,7 @@ public class TestSstFilteringService {
     long count;
     // Prevent the new snapshot from being filtered
     try (BootstrapStateHandler.Lock lock =
-             sstFilteringService.getLock().lock()) {
+             sstFilteringService.getBoostrapStateLock().lock()) {
       count = sstFilteringService.getSnapshotFilteredCount().get();
       writeClient.createSnapshot("vol1", "buck2", "snapshot2");
 

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestSstFilteringService.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestSstFilteringService.java
@@ -227,8 +227,8 @@ public class TestSstFilteringService {
 
     long count;
     // Prevent the new snapshot from being filtered
-    try (BootstrapStateHandler handler =
-             sstFilteringService.lockBootstrapState()) {
+    try (BootstrapStateHandler.Lock lock =
+             sstFilteringService.getLock().lock()) {
       count = sstFilteringService.getSnapshotFilteredCount().get();
       writeClient.createSnapshot("vol1", "buck2", "snapshot2");
 

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestSstFilteringService.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestSstFilteringService.java
@@ -64,6 +64,8 @@ import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_DB_PROFILE;
 import static org.apache.hadoop.ozone.OzoneConsts.OM_KEY_PREFIX;
 import static org.apache.hadoop.ozone.OzoneConsts.OM_SNAPSHOT_DIR;
 import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_SNAPSHOT_SST_FILTERING_SERVICE_INTERVAL;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
 
 /**
  * Test SST Filtering Service.
@@ -136,7 +138,7 @@ public class TestSstFilteringService {
     final int keyCount = 100;
     createKeys(keyManager, "vol1", "buck1", keyCount / 2, 1);
     SstFilteringService sstFilteringService =
-        (SstFilteringService) keyManager.getSnapshotSstFilteringService();
+        keyManager.getSnapshotSstFilteringService();
 
     String rocksDbDir = om.getRocksDbDirectory();
 
@@ -221,6 +223,24 @@ public class TestSstFilteringService {
         .readAllLines(Paths.get(dbSnapshots, OzoneConsts.FILTERED_SNAPSHOTS));
     Assert.assertTrue(
         processedSnapshotIds.contains(snapshotInfo.getSnapshotID()));
+
+    // Prevent the new snapshot from being filtered
+    sstFilteringService.lockBootstrapState();
+    long count = sstFilteringService.getSnapshotFilteredCount().get();
+    writeClient.createSnapshot("vol1", "buck2", "snapshot2");
+
+    // Confirm that it is not filtered
+    assertThrows(TimeoutException.class, () -> GenericTestUtils.waitFor(
+        () -> sstFilteringService.getSnapshotFilteredCount().get() > count,
+        1000, 10000));
+    assertEquals(count, sstFilteringService.getSnapshotFilteredCount().get());
+
+    // Now allow filtering
+    sstFilteringService.unlockBootstrapState();
+    GenericTestUtils.waitFor(
+        () -> sstFilteringService.getSnapshotFilteredCount().get() > count,
+        1000, 10000);
+
 
   }
 

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/ratis/TestOzoneManagerDoubleBuffer.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/ratis/TestOzoneManagerDoubleBuffer.java
@@ -66,7 +66,6 @@ import static org.mockito.Mockito.when;
  * This class tests snapshot aware OzoneManagerDoubleBuffer flushing logic.
  */
 class TestOzoneManagerDoubleBuffer {
-
   private OzoneManagerDoubleBuffer doubleBuffer;
   private CreateSnapshotResponse snapshotResponse1 =
       mock(CreateSnapshotResponse.class);
@@ -88,6 +87,7 @@ class TestOzoneManagerDoubleBuffer {
   private File tempDir;
   private OzoneManagerDoubleBuffer.FlushNotifier flushNotifier;
   private OzoneManagerDoubleBuffer.FlushNotifier spyFlushNotifier;
+  private OMMetadataManager omMetadataManager;
 
   @BeforeEach
   public void setup() throws IOException {
@@ -95,7 +95,7 @@ class TestOzoneManagerDoubleBuffer {
     OzoneConfiguration ozoneConfiguration = new OzoneConfiguration();
     ozoneConfiguration.set(OMConfigKeys.OZONE_OM_DB_DIRS,
         tempDir.getAbsolutePath());
-    OMMetadataManager omMetadataManager =
+    omMetadataManager =
         new OmMetadataManagerImpl(ozoneConfiguration);
     OzoneManager ozoneManager = mock(OzoneManager.class);
     when(ozoneManager.getMetrics()).thenReturn(omMetrics);
@@ -145,10 +145,11 @@ class TestOzoneManagerDoubleBuffer {
   }
 
   @AfterEach
-  public void stop() {
+  public void stop() throws Exception {
     if (doubleBuffer != null) {
       doubleBuffer.stop();
     }
+    omMetadataManager.stop();
   }
 
   private static Stream<Arguments> doubleBufferFlushCases() {

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/ratis/TestOzoneManagerDoubleBuffer.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/ratis/TestOzoneManagerDoubleBuffer.java
@@ -66,6 +66,7 @@ import static org.mockito.Mockito.when;
  * This class tests snapshot aware OzoneManagerDoubleBuffer flushing logic.
  */
 class TestOzoneManagerDoubleBuffer {
+
   private OzoneManagerDoubleBuffer doubleBuffer;
   private CreateSnapshotResponse snapshotResponse1 =
       mock(CreateSnapshotResponse.class);
@@ -87,7 +88,6 @@ class TestOzoneManagerDoubleBuffer {
   private File tempDir;
   private OzoneManagerDoubleBuffer.FlushNotifier flushNotifier;
   private OzoneManagerDoubleBuffer.FlushNotifier spyFlushNotifier;
-  private OMMetadataManager omMetadataManager;
 
   @BeforeEach
   public void setup() throws IOException {
@@ -95,7 +95,7 @@ class TestOzoneManagerDoubleBuffer {
     OzoneConfiguration ozoneConfiguration = new OzoneConfiguration();
     ozoneConfiguration.set(OMConfigKeys.OZONE_OM_DB_DIRS,
         tempDir.getAbsolutePath());
-    omMetadataManager =
+    OMMetadataManager omMetadataManager =
         new OmMetadataManagerImpl(ozoneConfiguration);
     OzoneManager ozoneManager = mock(OzoneManager.class);
     when(ozoneManager.getMetrics()).thenReturn(omMetrics);
@@ -145,11 +145,10 @@ class TestOzoneManagerDoubleBuffer {
   }
 
   @AfterEach
-  public void stop() throws Exception {
+  public void stop() {
     if (doubleBuffer != null) {
       doubleBuffer.stop();
     }
-    omMetadataManager.stop();
   }
 
   private static Stream<Arguments> doubleBufferFlushCases() {


### PR DESCRIPTION
## What changes were proposed in this pull request?

### The BootstrapStateHandler

This PR creates a new interface, BootstrapStateHandler.  Each process that manages state that needs to be copied into the bootstrap tarball must implement this interface.

The interface has a single method, getBoostrapStateLock().  The processes managing bootstrap state implement this method, which returns the lock used to protect state that must be changed atomically with respect to the tarball creation process.  

The tarball creation process takes each of these locks before generating the tarball.  That prevents any of the processes from changing the state while the tarball is being created.

Then the tarball creator waits for the double buffer to flush so that any remaining operations that may effect the bootstrap state have completed before the tarball is created.


### The state to protect/synchronize
Outside of the active rocksdb itself, the omSnapshot subsystem uses many types of persistent state data.  I've listed the types below along with an indication of whether they are guarded by a BootstrapStateHandler.Lock.

If there is any type I've forgotten please let me know, so that we can account for it.

#### delete/rename key entries
The sdt, and eventually the kdt, move delete/rename key entries between snapshots.  These are guarded by a BootstrapStateHandler.Lock, (and by waiting for the double buffer flush.)

#### deleted sst files
The rocksdb differ and sst filtering service delete sst files when no longer needed.  These are guarded with by the BootstrapStateHandler.Lock.

The reason for these need to be guarded is that the tarball creation process does a calculation of hard links prior to tarball creation.  That calculation requires a stable set of sst files.  If some get deleted during the process, the hard links calculated may be invalid.

#### compaction logs
These get created by the active rocksdb as sst files are compacted.

These are not currently guarded by a BootstrapStateHandler.Lock.

My reasoning for this is that it would require turning off compactions on the active rocksdb for the duration of the tarball creation.  Before the tarball is created, the BootstrapStateHandler's are locked and a checkpoint of the active fs is taken.  Any compactions that happen after that checkpoint is taken, but before the tarball is finished, will have compaction log entries add to the tarball, that don't correspond to the checkpoint.

This may be a problem.  If so, we'll have to pause compactions on the active fs long enough to make a copy of the compaction logs.  So please include your thoughts when reviewing.

#### intermediate rocksdb snapdiff files

These are just used during the calculation of the snapdiff.  They will not be a part of the tarball.

They are not guarded by a BootstrapStateHandler.Lock.

#### SST filter service history file
This file keeps track of all the snapshots that have been filtered.

It is guarded by a BootstrapStateHandler.Lock.

### Other changes in this PR

#### Flush Snapshot WAL's after moving deleted keys
When deleted keys are moved from one snapshot to another, the double buffer opens and writes to both the corresponding rocksdb images, in addition  to the rocksdb for the active fs.  I've modified that operation to flush the wal for the snapshot rocksdb images.  (The active rocksdb doesn't need to be flushed because the tarball creator takes a rocksdb checkpoint of that image after the doublebuffer is flushed.)

### Moved some methods to the AbstractKeyDeletingService class
The AbstractKeyDeletingService class is the parent class of both the SnapshotDeletingService and the KeyDeletingService.  I moved the submitSnapshotMoveDeletedKeys() and submitRequest() methods from the SnapshotDeletingService class to the AbstractKeyDeletingService class.  This is because thesnapshot delete design includes an optimization that has the KeyDeletingService also moving deleted keys.

Since that operation needs to be protected by a BootstrapStateHandler.Lock, I moved that code in anticipation of when the optimization is implemented.


## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-8209

## How was this patch tested?
added unit tests

I will add a test for the SnapshotDeletingService once this is merged:  https://github.com/apache/ozone/pull/4571

## TODO
As mentioned above, we need to decide if the compaction logs need to be synchronized with the actvie fs checkpoint.
