### PR TITLE
HDDS-8573. Verify default setting for DN root dir to restrict non-admin access

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/recon/ReconConfigKeys.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/recon/ReconConfigKeys.java
@@ -34,6 +34,9 @@ public final class ReconConfigKeys {
 
   public static final String OZONE_RECON_DB_DIR = "ozone.recon.db.dir";
 
+  public static final String OZONE_RECON_DB_DIRS_PERMISSIONS =
+      "ozone.recon.db.dirs.permissions";
+
   public static final String OZONE_RECON_DATANODE_ADDRESS_KEY =
       "ozone.recon.datanode.address";
   public static final String OZONE_RECON_ADDRESS_KEY =

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/recon/ReconConfigKeys.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/recon/ReconConfigKeys.java
@@ -32,6 +32,8 @@ public final class ReconConfigKeys {
 
   public static final String RECON_SCM_CONFIG_PREFIX = "ozone.recon.scmconfig";
 
+  public static final String OZONE_RECON_DB_DIR = "ozone.recon.db.dir";
+
   public static final String OZONE_RECON_DATANODE_ADDRESS_KEY =
       "ozone.recon.datanode.address";
   public static final String OZONE_RECON_ADDRESS_KEY =

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/recon/ReconConfigKeys.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/recon/ReconConfigKeys.java
@@ -31,6 +31,8 @@ public final class ReconConfigKeys {
   }
 
   public static final String RECON_SCM_CONFIG_PREFIX = "ozone.recon.scmconfig";
+  // Recon DB directory permission
+  public static final String RECON_DB_DIR = "ozone.recon.db.dir.perm";
 
   public static final String OZONE_RECON_DATANODE_ADDRESS_KEY =
       "ozone.recon.datanode.address";

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/recon/ReconConfigKeys.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/recon/ReconConfigKeys.java
@@ -31,8 +31,6 @@ public final class ReconConfigKeys {
   }
 
   public static final String RECON_SCM_CONFIG_PREFIX = "ozone.recon.scmconfig";
-  // Recon DB directory permission
-  public static final String RECON_DB_DIR = "ozone.recon.db.dir.permissions";
 
   public static final String OZONE_RECON_DATANODE_ADDRESS_KEY =
       "ozone.recon.datanode.address";

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/recon/ReconConfigKeys.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/recon/ReconConfigKeys.java
@@ -32,7 +32,7 @@ public final class ReconConfigKeys {
 
   public static final String RECON_SCM_CONFIG_PREFIX = "ozone.recon.scmconfig";
   // Recon DB directory permission
-  public static final String RECON_DB_DIR = "ozone.recon.db.dir.perm";
+  public static final String RECON_DB_DIR = "ozone.recon.db.dir.permissions";
 
   public static final String OZONE_RECON_DATANODE_ADDRESS_KEY =
       "ozone.recon.datanode.address";

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/ScmConfigKeys.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/ScmConfigKeys.java
@@ -216,8 +216,6 @@ public final class ScmConfigKeys {
       "hdds.rest.http-address";
   public static final String HDDS_REST_HTTP_ADDRESS_DEFAULT = "0.0.0.0:9880";
   public static final String HDDS_DATANODE_DIR_KEY = "hdds.datanode.dir";
-  public static final String HDDS_DATANODE_DIR_PERMISSION =
-      "hdds.datanode.dir.perm";
   public static final String HDDS_DATANODE_DIR_DU_RESERVED =
       "hdds.datanode.dir.du.reserved";
   public static final String HDDS_DATANODE_DIR_DU_RESERVED_PERCENT =

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/ScmConfigKeys.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/ScmConfigKeys.java
@@ -36,6 +36,10 @@ public final class ScmConfigKeys {
   // performance.
   public static final String OZONE_SCM_DB_DIRS = "ozone.scm.db.dirs";
 
+  // SCM DB directory permission
+  public static final String OZONE_SCM_DB_DIRS_PERMISSIONS =
+      "ozone.scm.db.dirs.permissions";
+
   public static final String DFS_CONTAINER_RATIS_ENABLED_KEY
       = "dfs.container.ratis.enabled";
   public static final boolean DFS_CONTAINER_RATIS_ENABLED_DEFAULT
@@ -212,6 +216,8 @@ public final class ScmConfigKeys {
       "hdds.rest.http-address";
   public static final String HDDS_REST_HTTP_ADDRESS_DEFAULT = "0.0.0.0:9880";
   public static final String HDDS_DATANODE_DIR_KEY = "hdds.datanode.dir";
+  public static final String HDDS_DATANODE_DIR_PERMISSION =
+      "hdds.datanode.dir.perm";
   public static final String HDDS_DATANODE_DIR_DU_RESERVED =
       "hdds.datanode.dir.du.reserved";
   public static final String HDDS_DATANODE_DIR_DU_RESERVED_PERCENT =

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/server/ServerUtils.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/server/ServerUtils.java
@@ -49,7 +49,7 @@ public final class ServerUtils {
 
   // Static variables for config names
   private static final String OZONE_RECON_CONFIG_PERMISSION =
-      "ozone.recon.db.dir.permissions";
+      "ozone.recon.db.dirs.permissions";
   private static final String OZONE_SCM_CONFIG_PERMISSION =
       "ozone.scm.db.dirs.permissions";
   private static final String OZONE_OM_CONFIG_PERMISSION =
@@ -217,14 +217,14 @@ public final class ServerUtils {
 
 
   /**
-   * Retrieves the permissions configuration for a given component name.
+   * Retrieves the permissions' configuration value for a given config key.
    *
-   * @param key  The name of the config.
-   * @param conf The ConfigurationSource object containing the config.
-   * @return The permissions configuration value for the component.
+   * @param key  The configuration key.
+   * @param conf The ConfigurationSource object containing the config
+   * @return The permissions' configuration value for the specified key.
+   * @throws IllegalArgumentException If the configuration value is not defined
    */
-  public static String getPermissions(String key,
-                                      ConfigurationSource conf) {
+  public static String getPermissions(String key, ConfigurationSource conf) {
     String configName = "";
 
     // Assign the appropriate config name based on the KEY
@@ -234,10 +234,10 @@ public final class ServerUtils {
       configName = OZONE_SCM_CONFIG_PERMISSION;
     } else if (key.equals(OzoneConfigKeys.OZONE_OM_DB_DIRS)) {
       configName = OZONE_OM_CONFIG_PERMISSION;
-    } else if (key.equals(OzoneConfigKeys.OZONE_METADATA_DIRS)) {
-      configName = OZONE_METADATA_CONFIG_PERMISSION;
     } else {
-      throw new IllegalArgumentException("Invalid config passed: " + key);
+      // If the permissions are not defined for the config, we make it fall
+      // back to the default permissions for metadata files and directories
+      configName = OZONE_METADATA_CONFIG_PERMISSION;
     }
 
     String configValue = conf.get(configName);

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/server/ServerUtils.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/server/ServerUtils.java
@@ -47,15 +47,6 @@ public final class ServerUtils {
   private static final Logger LOG = LoggerFactory.getLogger(
       ServerUtils.class);
 
-  // Static variables for config names
-  private static final String OZONE_RECON_CONFIG_PERMISSION =
-      "ozone.recon.db.dirs.permissions";
-  private static final String OZONE_SCM_CONFIG_PERMISSION =
-      "ozone.scm.db.dirs.permissions";
-  private static final String OZONE_OM_CONFIG_PERMISSION =
-      "ozone.om.db.dirs.permissions";
-  private static final String OZONE_METADATA_CONFIG_PERMISSION =
-      "ozone.metadata.dirs.permissions";
 
   private ServerUtils() {
   }

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/server/ServerUtils.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/server/ServerUtils.java
@@ -229,15 +229,15 @@ public final class ServerUtils {
 
     // Assign the appropriate config name based on the KEY
     if (key.equals(ReconConfigKeys.OZONE_RECON_DB_DIR)) {
-      configName = OZONE_RECON_CONFIG_PERMISSION;
+      configName = ReconConfigKeys.OZONE_RECON_DB_DIRS_PERMISSIONS;
     } else if (key.equals(ScmConfigKeys.OZONE_SCM_DB_DIRS)) {
-      configName = OZONE_SCM_CONFIG_PERMISSION;
+      configName = ScmConfigKeys.OZONE_SCM_DB_DIRS_PERMISSIONS;
     } else if (key.equals(OzoneConfigKeys.OZONE_OM_DB_DIRS)) {
-      configName = OZONE_OM_CONFIG_PERMISSION;
+      configName = OzoneConfigKeys.OZONE_OM_DB_DIRS_PERMISSIONS;
     } else {
       // If the permissions are not defined for the config, we make it fall
       // back to the default permissions for metadata files and directories
-      configName = OZONE_METADATA_CONFIG_PERMISSION;
+      configName = OzoneConfigKeys.OZONE_METADATA_DIRS_PERMISSIONS;
     }
 
     String configValue = conf.get(configName);

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/server/ServerUtils.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/server/ServerUtils.java
@@ -159,8 +159,10 @@ public final class ServerUtils {
   }
 
   /**
-   * Utility method to get value of a given key that corresponds to a DB
-   * directory.
+   * Utility method to retrieve the value of a key representing a DB directory
+   * and create a File object for the directory. The method also sets the
+   * directory permissions based on the configuration.
+   *
    * @param conf configuration bag
    * @param key Key to test
    * @param componentName Which component's key is this

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/OzoneConfigKeys.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/OzoneConfigKeys.java
@@ -42,6 +42,12 @@ public final class OzoneConfigKeys {
 
   public static final String OZONE_METADATA_DIRS = "ozone.metadata.dirs";
 
+  public static final String OZONE_METADATA_DIRS_PERMISSIONS =
+      "ozone.metadata.dirs.permissions";
+  public static final String OZONE_OM_DB_DIRS_PERMISSIONS =
+      "ozone.om.db.dirs.permissions";
+
+
   public static final String OZONE_OM_DB_DIRS = "ozone.om.db.dirs";
 
   /**

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/OzoneConfigKeys.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/OzoneConfigKeys.java
@@ -42,6 +42,8 @@ public final class OzoneConfigKeys {
 
   public static final String OZONE_METADATA_DIRS = "ozone.metadata.dirs";
 
+  public static final String OZONE_OM_DB_DIRS = "ozone.om.db.dirs";
+
   /**
    *
    * When set to true, allocate a random free port for ozone container,

--- a/hadoop-hdds/common/src/main/resources/ozone-default.xml
+++ b/hadoop-hdds/common/src/main/resources/ozone-default.xml
@@ -673,7 +673,7 @@
     <name>ozone.om.db.dirs.permissions</name>
     <value>750</value>
     <description>
-      Permissions for the metadata directories for Ozone Manager The
+      Permissions for the metadata directories for Ozone Manager. The
       permissions have to be octal or symbolic. If the default permissions are not set
       then the default value of 750 will be used.
     </description>
@@ -742,7 +742,7 @@
     <name>ozone.scm.db.dirs.permissions</name>
     <value>750</value>
     <description>
-      Permissions for the metadata directories for Storage Container Manager The
+      Permissions for the metadata directories for Storage Container Manager. The
       permissions can either be octal or symbolic. If the default permissions are not set
       then the default value of 750 will be used.
     </description>
@@ -2798,7 +2798,7 @@
     <name>ozone.recon.db.dirs.permissions</name>
     <value>750</value>
     <description>
-      Permissions for the metadata directories for Recon The
+      Permissions for the metadata directories for Recon. The
       permissions can either be octal or symbolic. If the default permissions are not set
       then the default value of 750 will be used.
     </description>

--- a/hadoop-hdds/common/src/main/resources/ozone-default.xml
+++ b/hadoop-hdds/common/src/main/resources/ozone-default.xml
@@ -2792,7 +2792,7 @@
     </description>
   </property>
   <property>
-    <name>ozone.recon.db.dir.permissions</name>
+    <name>ozone.recon.db.dirs.permissions</name>
     <value>750</value>
     <description>
       Permissions for the metadata directories for Recon The

--- a/hadoop-hdds/common/src/main/resources/ozone-default.xml
+++ b/hadoop-hdds/common/src/main/resources/ozone-default.xml
@@ -670,6 +670,14 @@
     </description>
   </property>
   <property>
+    <name>ozone.om.db.dirs.permissions</name>
+    <value>750</value>
+    <description>
+      Permissions for the metadata directories for Ozone Manager The
+      permissions have to be octal.
+    </description>
+  </property>
+  <property>
     <name>ozone.metadata.dirs</name>
     <value/>
     <tag>OZONE, OM, SCM, CONTAINER, STORAGE, REQUIRED</tag>
@@ -684,11 +692,11 @@
     </description>
   </property>
   <property>
-    <name>ozone.om.db.dirs.permissions</name>
-    <value>700</value>
+    <name>ozone.metadata.dirs.permissions</name>
+    <value>777</value>
     <description>
-      Permissions for the metadata directories for Ozone Manager The
-      permissions can either be octal or symbolic.
+      Permissions for the metadata directories for fallback location for SCM, OM, Recon and DataNodes
+      to store their metadata. The permissions have to be octal.
     </description>
   </property>
 
@@ -730,7 +738,7 @@
   </property>
   <property>
     <name>ozone.scm.db.dirs.permissions</name>
-    <value>700</value>
+    <value>777</value>
     <description>
       Permissions for the metadata directories for Storage Container Manager The
       permissions can either be octal or symbolic.
@@ -2785,7 +2793,7 @@
   </property>
   <property>
     <name>ozone.recon.db.dir.perm</name>
-    <value>700</value>
+    <value>777</value>
     <description>
       Permissions for the metadata directories for Recon The
       permissions can either be octal or symbolic.

--- a/hadoop-hdds/common/src/main/resources/ozone-default.xml
+++ b/hadoop-hdds/common/src/main/resources/ozone-default.xml
@@ -683,6 +683,14 @@
       dfs.container.ratis.datanode.storage.dir be configured separately.
     </description>
   </property>
+  <property>
+    <name>ozone.om.db.dirs.permissions</name>
+    <value>700</value>
+    <description>
+      Permissions for the metadata directories for Ozone Manager The
+      permissions can either be octal or symbolic.
+    </description>
+  </property>
 
   <property>
     <name>ozone.metastore.rocksdb.statistics</name>
@@ -718,6 +726,14 @@
       If undefined, then the SCM will log a warning and fallback to
       ozone.metadata.dirs. This fallback approach is not recommended for
       production environments.
+    </description>
+  </property>
+  <property>
+    <name>ozone.scm.db.dirs.permissions</name>
+    <value>700</value>
+    <description>
+      Permissions for the metadata directories for Storage Container Manager The
+      permissions can either be octal or symbolic.
     </description>
   </property>
   <property>
@@ -2765,6 +2781,14 @@
       If undefined, then the Recon will log a warning and fallback to
       ozone.metadata.dirs. This fallback approach is not recommended for
       production environments.
+    </description>
+  </property>
+  <property>
+    <name>ozone.recon.db.dir.perm</name>
+    <value>700</value>
+    <description>
+      Permissions for the metadata directories for Recon The
+      permissions can either be octal or symbolic.
     </description>
   </property>
   <property>

--- a/hadoop-hdds/common/src/main/resources/ozone-default.xml
+++ b/hadoop-hdds/common/src/main/resources/ozone-default.xml
@@ -693,7 +693,7 @@
   </property>
   <property>
     <name>ozone.metadata.dirs.permissions</name>
-    <value>777</value>
+    <value>750</value>
     <description>
       Permissions for the metadata directories for fallback location for SCM, OM, Recon and DataNodes
       to store their metadata. The permissions have to be octal.
@@ -738,7 +738,7 @@
   </property>
   <property>
     <name>ozone.scm.db.dirs.permissions</name>
-    <value>777</value>
+    <value>750</value>
     <description>
       Permissions for the metadata directories for Storage Container Manager The
       permissions can either be octal or symbolic.
@@ -2792,8 +2792,8 @@
     </description>
   </property>
   <property>
-    <name>ozone.recon.db.dir.perm</name>
-    <value>777</value>
+    <name>ozone.recon.db.dir.permissions</name>
+    <value>750</value>
     <description>
       Permissions for the metadata directories for Recon The
       permissions can either be octal or symbolic.

--- a/hadoop-hdds/common/src/main/resources/ozone-default.xml
+++ b/hadoop-hdds/common/src/main/resources/ozone-default.xml
@@ -674,7 +674,8 @@
     <value>750</value>
     <description>
       Permissions for the metadata directories for Ozone Manager The
-      permissions have to be octal.
+      permissions have to be octal or symbolic. If the default permissions are not set
+      then the default value of 750 will be used.
     </description>
   </property>
   <property>
@@ -696,7 +697,8 @@
     <value>750</value>
     <description>
       Permissions for the metadata directories for fallback location for SCM, OM, Recon and DataNodes
-      to store their metadata. The permissions have to be octal.
+      to store their metadata. The permissions have to be octal or symbolic. This is the fallback used in case the
+      default permissions for OM,SCM,Recon,Datanode are not set.
     </description>
   </property>
 
@@ -741,7 +743,8 @@
     <value>750</value>
     <description>
       Permissions for the metadata directories for Storage Container Manager The
-      permissions can either be octal or symbolic.
+      permissions can either be octal or symbolic. If the default permissions are not set
+      then the default value of 750 will be used.
     </description>
   </property>
   <property>
@@ -2796,7 +2799,8 @@
     <value>750</value>
     <description>
       Permissions for the metadata directories for Recon The
-      permissions can either be octal or symbolic.
+      permissions can either be octal or symbolic. If the default permissions are not set
+      then the default value of 750 will be used.
     </description>
   </property>
   <property>

--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/server/TestServerUtils.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/server/TestServerUtils.java
@@ -27,7 +27,9 @@ import java.util.Set;
 
 import org.apache.hadoop.hdds.HddsConfigKeys;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import org.apache.hadoop.hdds.recon.ReconConfigKeys;
 import org.apache.hadoop.hdds.scm.ScmConfigKeys;
+import org.apache.hadoop.ozone.OzoneConfigKeys;
 import org.apache.hadoop.test.PathUtils;
 
 import org.apache.commons.io.FileUtils;
@@ -60,21 +62,21 @@ public class TestServerUtils {
     // Create an OzoneConfiguration object and set the permissions
     // for different keys
     OzoneConfiguration conf = new OzoneConfiguration();
-    conf.set("ozone.recon.db.dir.perm", "750");
-    conf.set("ozone.scm.db.dirs.permissions", "775");
-    conf.set("ozone.metadata.dirs.permissions", "770");
-    conf.set("ozone.om.db.dirs.permissions", "700");
+    conf.set(ReconConfigKeys.OZONE_RECON_DB_DIRS_PERMISSIONS, "750");
+    conf.set(ScmConfigKeys.OZONE_SCM_DB_DIRS_PERMISSIONS, "775");
+    conf.set(OzoneConfigKeys.OZONE_METADATA_DIRS_PERMISSIONS, "770");
+    conf.set(OzoneConfigKeys.OZONE_OM_DB_DIRS_PERMISSIONS, "700");
 
     // Test getPermissions for different config names and assert the
     // returned permissions
     assertEquals("750",
-        ServerUtils.getPermissions("ozone.recon.db.dir", conf));
+        ServerUtils.getPermissions(ReconConfigKeys.OZONE_RECON_DB_DIR, conf));
     assertEquals("775",
-        ServerUtils.getPermissions("ozone.scm.db.dirs", conf));
+        ServerUtils.getPermissions(ScmConfigKeys.OZONE_SCM_DB_DIRS, conf));
     assertEquals("770",
-        ServerUtils.getPermissions("ozone.metadata.dirs", conf));
+        ServerUtils.getPermissions(OzoneConfigKeys.OZONE_METADATA_DIRS, conf));
     assertEquals("700",
-        ServerUtils.getPermissions("ozone.om.db.dirs", conf));
+        ServerUtils.getPermissions(OzoneConfigKeys.OZONE_OM_DB_DIRS, conf));
 
   }
 
@@ -86,14 +88,15 @@ public class TestServerUtils {
 
     // Create an OzoneConfiguration object
     OzoneConfiguration conf = new OzoneConfiguration();
-    String key = "ozone.metadata.dirs";
+    String key = OzoneConfigKeys.OZONE_METADATA_DIRS;
     String componentName = "Ozone";
     conf.set(key, filePath);
 
     // Set octal permissions
     String octalPermissionValue = "750";
     String octalExpectedPermissions = "rwxr-x---";
-    conf.set("ozone.metadata.dirs.permissions", octalPermissionValue);
+    conf.set(OzoneConfigKeys.OZONE_METADATA_DIRS_PERMISSIONS,
+        octalPermissionValue);
 
     // Get the directory using ServerUtils method
     File directory =
@@ -127,14 +130,15 @@ public class TestServerUtils {
     String filePath = folder.getRoot().getAbsolutePath();
 
     OzoneConfiguration conf = new OzoneConfiguration();
-    String key = "ozone.metadata.dirs";
+    String key = OzoneConfigKeys.OZONE_METADATA_DIRS;
     String componentName = "Ozone";
     conf.set(key, filePath);
 
     // Set symbolic permissions
     String symbolicPermissionValue = "rwx------";
     String symbolicExpectedPermissions = "rwx------";
-    conf.set("ozone.metadata.dirs.permissions", symbolicPermissionValue);
+    conf.set(OzoneConfigKeys.OZONE_METADATA_DIRS_PERMISSIONS,
+        symbolicPermissionValue);
 
     File directory =
         ServerUtils.getDirectoryFromConfig(conf, key, componentName);
@@ -163,7 +167,7 @@ public class TestServerUtils {
 
     // Create an OzoneConfiguration object
     OzoneConfiguration conf = new OzoneConfiguration();
-    String key = "ozone.metadata.dirs";
+    String key = OzoneConfigKeys.OZONE_METADATA_DIRS;
     String componentName = "Ozone";
     conf.set(key, dir1.getAbsolutePath() + "," + dir2.getAbsolutePath());
 
@@ -178,7 +182,7 @@ public class TestServerUtils {
   public void testGetDirectoryFromConfigWithNoDirectory() {
     // Create an empty OzoneConfiguration object
     OzoneConfiguration conf = new OzoneConfiguration();
-    String key = "ozone.metadata.dirs";
+    String key = OzoneConfigKeys.OZONE_METADATA_DIRS;
     String componentName = "Ozone";
 
     // Get the directory using ServerUtils method

--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/server/TestServerUtils.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/server/TestServerUtils.java
@@ -18,6 +18,12 @@
 package org.apache.hadoop.hdds.server;
 
 import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.attribute.PosixFilePermission;
+import java.nio.file.attribute.PosixFilePermissions;
+import java.util.Set;
 
 import org.apache.hadoop.hdds.HddsConfigKeys;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
@@ -25,17 +31,137 @@ import org.apache.hadoop.hdds.scm.ScmConfigKeys;
 import org.apache.hadoop.test.PathUtils;
 
 import org.apache.commons.io.FileUtils;
-import org.junit.jupiter.api.Test;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+
 
 /**
  * Unit tests for {@link ServerUtils}.
  */
 public class TestServerUtils {
+
+  @Rule
+  public TemporaryFolder folder = new TemporaryFolder();
+
+  /**
+   * Test case for {@link ServerUtils#getPermissions}.
+   * Verifies the retrieval of permissions for different component names.
+   */
+  @Test
+  public void testGetPermissions() {
+    // Create an OzoneConfiguration object and set the permissions
+    // for different keys
+    OzoneConfiguration conf = new OzoneConfiguration();
+    conf.set("ozone.recon.db.dir.perm", "750");
+    conf.set("ozone.scm.db.dirs.permissions", "775");
+    conf.set("ozone.metadata.dirs.permissions", "770");
+    conf.set("ozone.om.db.dirs.permissions", "700");
+
+    // Test getPermissions for different component names and assert the
+    // returned permissions
+    assertEquals("750", ServerUtils.getPermissions("Recon", conf));
+    assertEquals("775", ServerUtils.getPermissions("SCM", conf));
+    assertEquals("770", ServerUtils.getPermissions("Ozone", conf));
+    assertEquals("700", ServerUtils.getPermissions("OM", conf));
+
+  }
+
+  @Test
+  public void testGetPermissionsWithMissingConfiguration() {
+    // Create an empty OzoneConfiguration object
+    OzoneConfiguration conf = new OzoneConfiguration();
+
+    // Test getPermissions with a component name that has no corresponding
+    // configuration and assert the default value is returned
+    assertEquals("750", ServerUtils.getPermissions("Recon", conf));
+  }
+
+  /**
+   * Test case for {@link ServerUtils#getDirectoryFromConfig}.
+   * Verifies the creation of a directory with the expected permissions.
+   *
+   * @throws IOException if an I/O error occurs during the test
+   */
+  @Test
+  public void testGetDirectoryFromConfig() throws IOException {
+    // Create a temporary directory
+    String filePath = folder.getRoot().getAbsolutePath();
+
+    // Create an OzoneConfiguration object
+    OzoneConfiguration conf = new OzoneConfiguration();
+    String key = "ozone.metadata.dirs";
+    String componentName = "Ozone";
+    conf.set(key, filePath);
+
+    // Get the directory using ServerUtils method
+    File directory =
+        ServerUtils.getDirectoryFromConfig(conf, key, componentName);
+
+    // Assert that the directory is not null and exists
+    assertNotNull(directory);
+    assertTrue(directory.exists());
+    assertTrue(directory.isDirectory());
+
+    // Get the path of the directory
+    Path directoryPath = directory.toPath();
+
+    // Define the expected permissions as a string
+    String expectedPermissions = "rwxr-x---";
+
+    // Convert the expected permissions string to a set of PosixFilePermission
+    Set<PosixFilePermission> expectedPermissionSet =
+        PosixFilePermissions.fromString(expectedPermissions);
+
+    // Get the actual permissions of the directory
+    Set<PosixFilePermission> actualPermissionSet =
+        Files.getPosixFilePermissions(directoryPath);
+
+    // Assert that the expected and actual permissions sets are equal
+    assertEquals(expectedPermissionSet, actualPermissionSet);
+  }
+
+  @Test
+  public void testGetDirectoryFromConfigWithMultipleDirectories()
+      throws IOException {
+    // Create temporary directories
+    File dir1 = folder.newFolder("dir1");
+    File dir2 = folder.newFolder("dir2");
+
+    // Create an OzoneConfiguration object
+    OzoneConfiguration conf = new OzoneConfiguration();
+    String key = "ozone.metadata.dirs";
+    String componentName = "Ozone";
+    conf.set(key, dir1.getAbsolutePath() + "," + dir2.getAbsolutePath());
+
+    // Assert that an IllegalArgumentException is thrown because Recon does not
+    // support multiple metadata dirs currently
+    assertThrows(IllegalArgumentException.class, () -> {
+      ServerUtils.getDirectoryFromConfig(conf, key, componentName);
+    });
+  }
+
+  @Test
+  public void testGetDirectoryFromConfigWithNoDirectory() {
+    // Create an empty OzoneConfiguration object
+    OzoneConfiguration conf = new OzoneConfiguration();
+    String key = "ozone.metadata.dirs";
+    String componentName = "Ozone";
+
+    // Get the directory using ServerUtils method
+    File directory =
+        ServerUtils.getDirectoryFromConfig(conf, key, componentName);
+
+    // Assert that the directory is null
+    assertNull(directory);
+  }
 
   /**
    * Test {@link ServerUtils#getScmDbDir}.

--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/server/TestServerUtils.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/server/TestServerUtils.java
@@ -78,16 +78,6 @@ public class TestServerUtils {
 
   }
 
-  @Test
-  public void testGetPermissionsWithInvalidConfig() {
-    OzoneConfiguration conf = new OzoneConfiguration();
-
-    // Attempt to get permissions for an invalid config
-    assertThrows(IllegalArgumentException.class, () -> {
-      ServerUtils.getPermissions("invalidKey", conf);
-    });
-  }
-
   /**
    * Test case for {@link ServerUtils#getDirectoryFromConfig}.
    * Verifies the creation of a directory with the expected permissions.

--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/server/TestServerUtils.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/server/TestServerUtils.java
@@ -53,7 +53,7 @@ public class TestServerUtils {
 
   /**
    * Test case for {@link ServerUtils#getPermissions}.
-   * Verifies the retrieval of permissions for different component names.
+   * Verifies the retrieval of permissions for different configs.
    */
   @Test
   public void testGetPermissions() {
@@ -65,23 +65,27 @@ public class TestServerUtils {
     conf.set("ozone.metadata.dirs.permissions", "770");
     conf.set("ozone.om.db.dirs.permissions", "700");
 
-    // Test getPermissions for different component names and assert the
+    // Test getPermissions for different config names and assert the
     // returned permissions
-    assertEquals("750", ServerUtils.getPermissions("Recon", conf));
-    assertEquals("775", ServerUtils.getPermissions("SCM", conf));
-    assertEquals("770", ServerUtils.getPermissions("Ozone", conf));
-    assertEquals("700", ServerUtils.getPermissions("OM", conf));
+    assertEquals("750",
+        ServerUtils.getPermissions("ozone.recon.db.dir", conf));
+    assertEquals("775",
+        ServerUtils.getPermissions("ozone.scm.db.dirs", conf));
+    assertEquals("770",
+        ServerUtils.getPermissions("ozone.metadata.dirs", conf));
+    assertEquals("700",
+        ServerUtils.getPermissions("ozone.om.db.dirs", conf));
 
   }
 
   @Test
-  public void testGetPermissionsWithMissingConfiguration() {
-    // Create an empty OzoneConfiguration object
+  public void testGetPermissionsWithInvalidConfig() {
     OzoneConfiguration conf = new OzoneConfiguration();
 
-    // Test getPermissions with a component name that has no corresponding
-    // configuration and assert the default value is returned
-    assertEquals("750", ServerUtils.getPermissions("Recon", conf));
+    // Attempt to get permissions for an invalid config
+    assertThrows(IllegalArgumentException.class, () -> {
+      ServerUtils.getPermissions("invalidKey", conf);
+    });
   }
 
   /**

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/OMConfigKeys.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/OMConfigKeys.java
@@ -49,10 +49,6 @@ public final class OMConfigKeys {
   // multiple entries for performance (sharding)..
   public static final String OZONE_OM_DB_DIRS = "ozone.om.db.dirs";
 
-  // OM DB directory permissions.
-  public static final String OZONE_OM_DB_DIRS_PERMISSIONS =
-      "ozone.om.db.dirs.permissions";
-
   public static final String OZONE_OM_HANDLER_COUNT_KEY =
       "ozone.om.handler.count.key";
   public static final int OZONE_OM_HANDLER_COUNT_DEFAULT = 100;

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/OMConfigKeys.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/OMConfigKeys.java
@@ -49,6 +49,10 @@ public final class OMConfigKeys {
   // multiple entries for performance (sharding)..
   public static final String OZONE_OM_DB_DIRS = "ozone.om.db.dirs";
 
+  // SCM DB directory permission
+  public static final String OZONE_OM_DB_DIRS_PERMISSIONS =
+      "ozone.om.db.dirs.permissions";
+
   public static final String OZONE_OM_HANDLER_COUNT_KEY =
       "ozone.om.handler.count.key";
   public static final int OZONE_OM_HANDLER_COUNT_DEFAULT = 100;

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/OMConfigKeys.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/OMConfigKeys.java
@@ -49,6 +49,10 @@ public final class OMConfigKeys {
   // multiple entries for performance (sharding)..
   public static final String OZONE_OM_DB_DIRS = "ozone.om.db.dirs";
 
+  // OM DB directory permissions.
+  public static final String OZONE_OM_DB_DIRS_PERMISSIONS =
+      "ozone.om.db.dirs.permissions";
+
   public static final String OZONE_OM_HANDLER_COUNT_KEY =
       "ozone.om.handler.count.key";
   public static final int OZONE_OM_HANDLER_COUNT_DEFAULT = 100;


### PR DESCRIPTION
## What changes were proposed in this pull request?

The recommendation to set the permissions for the Apache Ozone DN, OM, SCM, Reccon metadata storage directories to 750 or tighter means that only the owner of the directory (in this case, the Hadoop user) and members of the Hadoop group should have access to the directory. By setting the permissions to 750, non-root users will not be able to read or write to the storage directories, which is important for protecting sensitive data.

The table represents the permissions configuration associated with each configuration property :- 
| Configuration Property               | Permissions |
|--------------------------------------|-------------|
| ozone.recon.db.dirs.permissions      | 750         |
| ozone.scm.db.dirs.permissions        | 750         |
| ozone.om.db.dirs.permissions         | 750         |
| ozone.metadata.dirs.permissions      | 750         |

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-8573

## How was this patch tested?
### Unit Tests
### Manually :- 
The final permissions for the **_metadata directory_** will be set according to the configured permissions. In our case, the default is 750, which corresponds to the permissions "rwxr-x---".
```
- Ozone Manager 
bash-4.2$ ls -al
total 12
drwxrwxrwt 1 root   root  4096 May 13 06:28 .
drwxr-xr-x 1 root   root  4096 May 13 06:28 ..
drwxr-x--- 7 hadoop users 4096 May 13 06:28 metadata

- Storage Container Manager 
sh-4.2$ ls -al
total 12
drwxrwxrwt  1 root   root  4096 May 13 06:28 .
drwxr-xr-x  1 root   root  4096 May 13 06:28 ..
drwxr-x--- 10 hadoop users 4096 May 13 06:28 metadata

- Recon 
sh-4.2$ ls -al 
total 12
drwxrwxrwt 1 root   root  4096 May 13 06:28 .
drwxr-xr-x 1 root   root  4096 May 13 06:28 ..
drwxr-x--- 8 hadoop users 4096 May 13 06:29 metadata

- DataNode 
sh-4.2$ ls -al
total 20
drwxrwxrwt 1 root   root  4096 May 13 06:28 .
drwxr-xr-x 1 root   root  4096 May 13 06:28 ..
-rw-r--r-- 1 hadoop users  357 May 13 06:28 datanode.id
drwxr-xr-x 3 hadoop users 4096 May 13 06:28 hdds
drwxr-x--- 6 hadoop users 4096 May 13 06:28 metadata
```

