### PR TITLE
HDDS-8532. Add config for factor of scaling up replication queue/threads in decommissioning nodes

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/replication/ReplicationServer.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/replication/ReplicationServer.java
@@ -41,6 +41,7 @@ import org.slf4j.LoggerFactory;
 
 import static org.apache.hadoop.hdds.conf.ConfigTag.DATANODE;
 import static org.apache.hadoop.hdds.conf.ConfigTag.MANAGEMENT;
+import static org.apache.hadoop.hdds.conf.ConfigTag.SCM;
 
 /**
  * Separated network server for server2server container replication.
@@ -135,6 +136,14 @@ public class ReplicationServer {
         PREFIX + "." + STREAMS_LIMIT_KEY;
 
     public static final int REPLICATION_MAX_STREAMS_DEFAULT = 10;
+    private static final String OUTOFSERVICE_FACTOR_KEY =
+        "outofservice.limit.factor";
+    private static final double OUTOFSERVICE_FACTOR_MIN = 1;
+    static final double OUTOFSERVICE_FACTOR_DEFAULT = 2;
+    private static final String OUTOFSERVICE_FACTOR_DEFAULT_VALUE = "2.0";
+    private static final double OUTOFSERVICE_FACTOR_MAX = 10;
+    static final String REPLICATION_OUTOFSERVICE_FACTOR_KEY =
+        PREFIX + "." + OUTOFSERVICE_FACTOR_KEY;
 
     /**
      * The maximum number of replication commands a single datanode can execute
@@ -153,6 +162,25 @@ public class ReplicationServer {
         description = "Port used for the server2server replication server",
         tags = {DATANODE, MANAGEMENT})
     private int port;
+
+    @Config(key = OUTOFSERVICE_FACTOR_KEY,
+        type = ConfigType.DOUBLE,
+        defaultValue = OUTOFSERVICE_FACTOR_DEFAULT_VALUE,
+        tags = {DATANODE, SCM},
+        description = "Decommissioning and maintenance nodes can handle more" +
+            "replication commands than in-service nodes due to reduced load. " +
+            "This multiplier determines the increased queue capacity and " +
+            "executor pool size."
+    )
+    private double outOfServiceFactor = OUTOFSERVICE_FACTOR_DEFAULT;
+
+    public double getOutOfServiceFactor() {
+      return outOfServiceFactor;
+    }
+
+    public int scaleOutOfServiceLimit(int original) {
+      return (int) Math.ceil(original * outOfServiceFactor);
+    }
 
     public int getPort() {
       return port;
@@ -178,6 +206,18 @@ public class ReplicationServer {
                 "and was set to {}. Defaulting to {}",
             replicationMaxStreams, REPLICATION_MAX_STREAMS_DEFAULT);
         replicationMaxStreams = REPLICATION_MAX_STREAMS_DEFAULT;
+      }
+
+      if (outOfServiceFactor < OUTOFSERVICE_FACTOR_MIN ||
+          outOfServiceFactor > OUTOFSERVICE_FACTOR_MAX) {
+        LOG.warn(
+            "{} must be between {} and {} but was set to {}. Defaulting to {}",
+            REPLICATION_OUTOFSERVICE_FACTOR_KEY,
+            OUTOFSERVICE_FACTOR_MIN,
+            OUTOFSERVICE_FACTOR_MAX,
+            outOfServiceFactor,
+            OUTOFSERVICE_FACTOR_DEFAULT);
+        outOfServiceFactor = OUTOFSERVICE_FACTOR_DEFAULT;
       }
     }
 

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/replication/ReplicationSupervisor.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/replication/ReplicationSupervisor.java
@@ -288,8 +288,9 @@ public final class ReplicationSupervisor {
       int newMaxQueueSize = datanodeConfig.getCommandQueueLimit();
 
       if (isMaintenance(newState) || isDecommission(newState)) {
-        threadCount *= 2;
-        newMaxQueueSize *= 2;
+        threadCount = replicationConfig.scaleOutOfServiceLimit(threadCount);
+        newMaxQueueSize =
+            replicationConfig.scaleOutOfServiceLimit(newMaxQueueSize);
       }
 
       LOG.info("Node state updated to {}, scaling executor pool size to {}",

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/replication/TestReplicationConfig.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/replication/TestReplicationConfig.java
@@ -21,7 +21,9 @@ import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.ozone.container.replication.ReplicationServer.ReplicationConfig;
 import org.junit.jupiter.api.Test;
 
+import static org.apache.hadoop.ozone.container.replication.ReplicationServer.ReplicationConfig.OUTOFSERVICE_FACTOR_DEFAULT;
 import static org.apache.hadoop.ozone.container.replication.ReplicationServer.ReplicationConfig.REPLICATION_MAX_STREAMS_DEFAULT;
+import static org.apache.hadoop.ozone.container.replication.ReplicationServer.ReplicationConfig.REPLICATION_OUTOFSERVICE_FACTOR_KEY;
 import static org.apache.hadoop.ozone.container.replication.ReplicationServer.ReplicationConfig.REPLICATION_STREAMS_LIMIT_KEY;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -34,22 +36,30 @@ public class TestReplicationConfig {
   public void acceptsValidValues() {
     // GIVEN
     int validReplicationLimit = 123;
+    double validOutOfServiceFactor = 3.0;
     OzoneConfiguration conf = new OzoneConfiguration();
     conf.setInt(REPLICATION_STREAMS_LIMIT_KEY, validReplicationLimit);
+    conf.setDouble(REPLICATION_OUTOFSERVICE_FACTOR_KEY,
+        validOutOfServiceFactor);
 
     // WHEN
     ReplicationConfig subject = conf.getObject(ReplicationConfig.class);
 
     // THEN
     assertEquals(validReplicationLimit, subject.getReplicationMaxStreams());
+    assertEquals(validOutOfServiceFactor, subject.getOutOfServiceFactor(),
+        0.001);
   }
 
   @Test
   public void overridesInvalidValues() {
     // GIVEN
     int invalidReplicationLimit = -5;
+    double invalidOutOfServiceFactor = 0.5;
     OzoneConfiguration conf = new OzoneConfiguration();
     conf.setInt(REPLICATION_STREAMS_LIMIT_KEY, invalidReplicationLimit);
+    conf.setDouble(REPLICATION_OUTOFSERVICE_FACTOR_KEY,
+        invalidOutOfServiceFactor);
 
     // WHEN
     ReplicationConfig subject = conf.getObject(ReplicationConfig.class);
@@ -57,6 +67,8 @@ public class TestReplicationConfig {
     // THEN
     assertEquals(REPLICATION_MAX_STREAMS_DEFAULT,
         subject.getReplicationMaxStreams());
+    assertEquals(OUTOFSERVICE_FACTOR_DEFAULT,
+        subject.getOutOfServiceFactor(), 0.001);
   }
 
   @Test
@@ -70,6 +82,8 @@ public class TestReplicationConfig {
     // THEN
     assertEquals(REPLICATION_MAX_STREAMS_DEFAULT,
         subject.getReplicationMaxStreams());
+    assertEquals(OUTOFSERVICE_FACTOR_DEFAULT,
+        subject.getOutOfServiceFactor(), 0.001);
   }
 
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

HDDS-8494 doubled the replication thread pool and queue size of decommissioning/maintenance nodes.  This PR makes the factor configurable.  The same config applies to both datanodes and SCM.

https://issues.apache.org/jira/browse/HDDS-8532

## How was this patch tested?

https://github.com/adoroszlai/hadoop-ozone/actions/runs/4907548631