### PR TITLE
HDDS-8575. Intermittent failure in TestCloseContainerEventHandler.testCloseContainerWithDelayByLeaseManager

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/lease/LeaseManager.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/lease/LeaseManager.java
@@ -267,7 +267,8 @@ public class LeaseManager<T> {
         try {
           // block for event and clear all events as will be 
           // handled by activeLeases before going for next wait
-          leaseKeyBlockingQueue.poll(sleepTime, TimeUnit.MILLISECONDS);
+          // ignore return value
+          T task = leaseKeyBlockingQueue.poll(sleepTime, TimeUnit.MILLISECONDS);
           leaseKeyBlockingQueue.clear();
         } catch (InterruptedException e) {
           LOG.warn("Lease manager is interrupted. Shutting down...", e);

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/lease/LeaseManager.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/lease/LeaseManager.java
@@ -199,7 +199,7 @@ public class LeaseManager<T> {
    * {@link Lease} will be released (callbacks on leases will not be
    * executed).
    */
-  public synchronized void shutdown() {
+  public void shutdown() {
     checkStatus();
     LOG.debug("Shutting down LeaseManager service");
     leaseMonitor.disable();
@@ -266,7 +266,8 @@ public class LeaseManager<T> {
         }
 
         try {
-          semaphore.tryAcquire(sleepTime, TimeUnit.MILLISECONDS);
+          // ignore return value, just used for wait
+          boolean b = semaphore.tryAcquire(sleepTime, TimeUnit.MILLISECONDS);
         } catch (InterruptedException e) {
           LOG.warn("Lease manager is interrupted. Shutting down...", e);
           Thread.currentThread().interrupt();

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/TestCloseContainerEventHandler.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/TestCloseContainerEventHandler.java
@@ -39,6 +39,7 @@ import org.apache.hadoop.hdds.scm.pipeline.PipelineManager;
 import org.apache.hadoop.hdds.scm.pipeline.PipelineNotFoundException;
 import org.apache.hadoop.hdds.server.events.EventPublisher;
 import org.apache.hadoop.ozone.common.statemachine.InvalidStateTransitionException;
+import org.apache.hadoop.ozone.lease.Lease;
 import org.apache.hadoop.ozone.lease.LeaseManager;
 import org.apache.hadoop.ozone.protocol.commands.CloseContainerCommand;
 import org.apache.hadoop.ozone.protocol.commands.CommandForDatanode;
@@ -52,6 +53,7 @@ import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 
+import org.apache.ozone.test.GenericTestUtils;
 import org.junit.Assert;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -137,18 +139,36 @@ public class TestCloseContainerEventHandler {
         .thenReturn(pipeline);
     LeaseManager<Object> leaseManager = new LeaseManager<>("test", timeoutInMs);
     leaseManager.start();
+    LeaseManager mockLeaseManager = Mockito.mock(LeaseManager.class);
+    List<Lease<Object>> leaseList = new ArrayList<>(1);
+    Mockito.when(mockLeaseManager.acquire(any(), anyLong(), any())).thenAnswer(
+        invocation -> {
+          leaseList.add(leaseManager.acquire(
+              invocation.getArgument(0, Object.class),
+              invocation.getArgument(1),
+              invocation.getArgument(2, Callable.class)));
+          return leaseList.get(0);
+        });
     CloseContainerEventHandler closeHandler = new CloseContainerEventHandler(
         pipelineManager, containerManager, scmContext,
-        leaseManager, timeoutInMs);
+        mockLeaseManager, timeoutInMs);
     closeHandler.onMessage(container.containerID(), eventPublisher);
+    Mockito.verify(mockLeaseManager, atLeastOnce())
+        .acquire(any(), anyLong(), any());
+    Assert.assertTrue(leaseList.size() > 0);
     // immediate check if event is published, it should not publish in 500ms
-    Thread.sleep(500);
     Mockito.verify(eventPublisher, never())
         .fireEvent(eq(DATANODE_COMMAND), commandCaptor.capture());
-    Thread.sleep(timeoutInMs * 2);
-    // event publish already after waiting 4+ seconds
-    Mockito.verify(eventPublisher, atLeastOnce())
-        .fireEvent(eq(DATANODE_COMMAND), commandCaptor.capture());
+    // wait for event to happen
+    GenericTestUtils.waitFor(() -> {
+      try {
+        Mockito.verify(eventPublisher, atLeastOnce())
+            .fireEvent(eq(DATANODE_COMMAND), commandCaptor.capture());
+      } catch (Throwable ex) {
+        return false;
+      }
+      return true;
+    }, 1000, (int) timeoutInMs * 3);
     leaseManager.shutdown();
   }
 

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/TestCloseContainerEventHandler.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/TestCloseContainerEventHandler.java
@@ -156,7 +156,7 @@ public class TestCloseContainerEventHandler {
     Mockito.verify(mockLeaseManager, atLeastOnce())
         .acquire(any(), anyLong(), any());
     Assert.assertTrue(leaseList.size() > 0);
-    // immediate check if event is published, it should not publish in 500ms
+    // immediate check if event is published
     Mockito.verify(eventPublisher, never())
         .fireEvent(eq(DATANODE_COMMAND), commandCaptor.capture());
     // wait for event to happen


### PR DESCRIPTION
## What changes were proposed in this pull request?

LeaseManager have concurrency issue that, when new event is added just before monitor thread go for wait, then notification will be missed and object remains in queue indefinitely till further new event comes and notify.

- changed the logic using blocking queue for event notification.
- test case change to validate lease acquire and wait with GenericTestUtils.waitFor

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-8575

## How was this patch tested?

running testcase multiple time
