### PR TITLE
HDDS-8576. Close RocksDB instance in RDBStore if RDBStore's initialization fails after RocksDB instance creation

### DIFF
--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/RocksDatabase.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/RocksDatabase.java
@@ -73,7 +73,7 @@ import static org.rocksdb.RocksDB.listColumnFamilies;
  * When there is a {@link RocksDBException} with error,
  * this class will close the underlying {@link org.rocksdb.RocksObject}s.
  */
-public final class RocksDatabase {
+public final class RocksDatabase implements Closeable {
   static final Logger LOG = LoggerFactory.getLogger(RocksDatabase.class);
 
   public static final String ESTIMATE_NUM_KEYS = "rocksdb.estimate-num-keys";
@@ -354,6 +354,7 @@ public final class RocksDatabase {
     this.counter = counter;
   }
 
+  @Override
   public void close() {
     if (isClosed.compareAndSet(false, true)) {
       // Wait for all background work to be cancelled first. e.g. RDB compaction

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/RocksDatabase.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/RocksDatabase.java
@@ -82,6 +82,7 @@ public final class RocksDatabase implements Closeable {
   private static Map<String, List<ColumnFamilyHandle>> dbNameToCfHandleMap =
       new HashMap<>();
 
+  private final StackTraceElement[] stackTrace;
 
   static IOException toIOException(Object name, String op, RocksDBException e) {
     return HddsServerUtil.toIOException(name + ": Failed to " + op, e);
@@ -353,6 +354,7 @@ public final class RocksDatabase implements Closeable {
     this.descriptors = descriptors;
     this.columnFamilies = columnFamilies;
     this.counter = counter;
+    this.stackTrace = Thread.currentThread().getStackTrace();
   }
 
   @Override
@@ -907,10 +909,8 @@ public final class RocksDatabase implements Closeable {
     if (!isClosed()) {
       String warning = "RocksDatabase is not closed properly.";
       if (LOG.isDebugEnabled()) {
-        String stackTrace =
-            Arrays.toString(Thread.currentThread().getStackTrace());
-        String debugMessage = String
-            .format("%n StackTrace for unclosed instance: %s", stackTrace);
+        String debugMessage = String.format("%n StackTrace for unclosed " +
+            "RocksDatabase instance: %s", Arrays.toString(stackTrace));
         warning = warning.concat(debugMessage);
       }
       LOG.warn(warning);

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/RocksDatabase.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/RocksDatabase.java
@@ -49,6 +49,7 @@ import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
@@ -901,5 +902,19 @@ public final class RocksDatabase implements Closeable {
     return dbNameToCfHandleMap;
   }
 
-
+  @Override
+  protected void finalize() throws Throwable {
+    if (!isClosed()) {
+      String warning = "RocksDatabase is not closed properly.";
+      if (LOG.isDebugEnabled()) {
+        String stackTrace =
+            Arrays.toString(Thread.currentThread().getStackTrace());
+        String debugMessage = String
+            .format("%n StackTrace for unclosed instance: %s", stackTrace);
+        warning = warning.concat(debugMessage);
+      }
+      LOG.warn(warning);
+    }
+    super.finalize();
+  }
 }

--- a/hadoop-hdds/rocksdb-checkpoint-differ/src/main/java/org/apache/ozone/rocksdiff/RocksDBCheckpointDiffer.java
+++ b/hadoop-hdds/rocksdb-checkpoint-differ/src/main/java/org/apache/ozone/rocksdiff/RocksDBCheckpointDiffer.java
@@ -420,8 +420,7 @@ public class RocksDBCheckpointDiffer implements AutoCloseable {
     rocksOptions.setListeners(list);
   }
 
-  public void setRocksDBForCompactionTracking(DBOptions rocksOptions)
-      throws RocksDBException {
+  public void setRocksDBForCompactionTracking(DBOptions rocksOptions) {
     setRocksDBForCompactionTracking(rocksOptions, new ArrayList<>());
   }
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmMetadataManagerImpl.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmMetadataManagerImpl.java
@@ -390,9 +390,9 @@ public class OmMetadataManagerImpl implements OMMetadataManager,
       setStore(loadDB(conf, metaDir, dbName, false,
           java.util.Optional.of(Boolean.TRUE), false));
       initializeOmTables(false);
-    } catch (Exception e) {
+    } catch (IOException e) {
       stop();
-      throw new IOException(e.getCause());
+      throw e;
     }
   }
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmMetadataManagerImpl.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmMetadataManagerImpl.java
@@ -372,22 +372,28 @@ public class OmMetadataManagerImpl implements OMMetadataManager,
   // metadata constructor for snapshots
   OmMetadataManagerImpl(OzoneConfiguration conf, String snapshotDirName,
       boolean isSnapshotInCache) throws IOException {
-    lock = new OmReadOnlyLock();
-    omEpoch = 0;
-    String snapshotDir = OMStorage.getOmDbDir(conf) +
-        OM_KEY_PREFIX + OM_SNAPSHOT_CHECKPOINT_DIR;
-    File metaDir = new File(snapshotDir);
-    String dbName = OM_DB_NAME + snapshotDirName;
-    // The check is only to prevent every snapshot read to perform a disk IO
-    // and check if a checkpoint dir exists. If entry is present in cache,
-    // it is most likely DB entries will get flushed in this wait time.
-    if (isSnapshotInCache) {
-      File checkpoint = Paths.get(metaDir.toPath().toString(), dbName).toFile();
-      RDBCheckpointUtils.waitForCheckpointDirectoryExist(checkpoint);
+    try {
+      lock = new OmReadOnlyLock();
+      omEpoch = 0;
+      String snapshotDir = OMStorage.getOmDbDir(conf) +
+          OM_KEY_PREFIX + OM_SNAPSHOT_CHECKPOINT_DIR;
+      File metaDir = new File(snapshotDir);
+      String dbName = OM_DB_NAME + snapshotDirName;
+      // The check is only to prevent every snapshot read to perform a disk IO
+      // and check if a checkpoint dir exists. If entry is present in cache,
+      // it is most likely DB entries will get flushed in this wait time.
+      if (isSnapshotInCache) {
+        File checkpoint =
+            Paths.get(metaDir.toPath().toString(), dbName).toFile();
+        RDBCheckpointUtils.waitForCheckpointDirectoryExist(checkpoint);
+      }
+      setStore(loadDB(conf, metaDir, dbName, false,
+          java.util.Optional.of(Boolean.TRUE), false));
+      initializeOmTables(false);
+    } catch (Exception e) {
+      stop();
+      throw new IOException(e.getCause());
     }
-    setStore(loadDB(conf, metaDir, dbName, false,
-            java.util.Optional.of(Boolean.TRUE), false));
-    initializeOmTables(false);
   }
 
   @Override

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmSnapshotManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmSnapshotManager.java
@@ -338,13 +338,13 @@ public final class OmSnapshotManager implements AutoCloseable {
               snapshotInfo.getVolumeName(),
               snapshotInfo.getBucketName(),
               snapshotInfo.getName());
-        } catch (Exception e) {
+        } catch (IOException e) {
           // Close RocksDB if snapshotMetadataManager got initialized.
           if (snapshotMetadataManager != null &&
               !snapshotMetadataManager.getStore().isClosed()) {
             snapshotMetadataManager.getStore().close();
           }
-          throw new IOException(e.getCause());
+          throw e;
         }
       }
     };


### PR DESCRIPTION
## What changes were proposed in this pull request?
This change is to close RocksDB instance if RDBStore creations fails after [RocksDB's instance creation](https://github.com/apache/ozone/blob/75f5a28f376516e7252e750e86a10c2f9d874d5a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/RDBStore.java#L112).

It also includes proper closing of `OmMetadataManagerImpl` in its construct and while loading snapshot cache due to any failure.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-8576

## How was this patch tested?
1. Existing tests.


2. Before the change, integration tests I added as part of [HDDS-8389](https://issues.apache.org/jira/browse/HDDS-8389), were failing most of the time.
Failed run example#1: https://github.com/hemantk-12/ozone/actions/runs/4929699855/jobs/8812911004
Failed run example#2: https://github.com/apache/ozone/actions/runs/4919751367/jobs/8787838665
After the change: https://github.com/hemantk-12/ozone/actions/runs/4932359606/jobs/8815309274

