### PR TITLE
HDDS-8504. ReplicationManager: Pass used and excluded node separately for Under and Mis-Replication

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ReplicationManagerUtil.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ReplicationManagerUtil.java
@@ -110,7 +110,7 @@ public final class ReplicationManagerUtil {
    */
   public static ExcludedAndUsedNodes getExcludedAndUsedNodes(
       List<ContainerReplica> replicas,
-      Set<DatanodeDetails> toBeRemoved,
+      Set<ContainerReplica> toBeRemoved,
       List<ContainerReplicaOp> pendingReplicaOps,
       ReplicationManager replicationManager) {
     List<DatanodeDetails> excludedNodes = new ArrayList<>();
@@ -123,7 +123,7 @@ public final class ReplicationManagerUtil {
         excludedNodes.add(r.getDatanodeDetails());
         continue;
       }
-      if (toBeRemoved.contains(r.getDatanodeDetails())) {
+      if (toBeRemoved.contains(r)) {
         // This node is currently present, but we plan to remove it so it is not
         // considered used, but must be excluded
         excludedNodes.add(r.getDatanodeDetails());

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ReplicationManagerUtil.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ReplicationManagerUtil.java
@@ -18,14 +18,20 @@
 package org.apache.hadoop.hdds.scm.container.replication;
 
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
+import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.ContainerReplicaProto;
 import org.apache.hadoop.hdds.scm.PlacementPolicy;
 import org.apache.hadoop.hdds.scm.container.ContainerInfo;
+import org.apache.hadoop.hdds.scm.container.ContainerReplica;
 import org.apache.hadoop.hdds.scm.exceptions.SCMException;
+import org.apache.hadoop.hdds.scm.node.NodeStatus;
+import org.apache.hadoop.hdds.scm.node.states.NodeNotFoundException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
 
 /**
  * Utility class for ReplicationManager.
@@ -88,6 +94,98 @@ public final class ReplicationManagerUtil {
             + " any nodes. Number of required Nodes %d, Datasize Required: %d",
         policy.getClass(), requiredNodes, dataSizeRequired),
         SCMException.ResultCodes.FAILED_TO_FIND_SUITABLE_NODE);
+  }
+
+  /**
+   * Given a list of replicas and a set of nodes to be removed, returns an
+   * object container two lists. One is a list of nodes that should be excluded
+   * from being selected as targets for new replicas. The other is a list of
+   * nodes that are currently used by the container and the placement policy
+   * can consider for rack placement
+   * @param replicas List of existing replicas
+   * @param toBeRemoved Set of nodes containing replicas that are to be removed
+   * @param pendingReplicaOps List of pending replica operations
+   * @param replicationManager ReplicationManager instance to get NodeStatus
+   * @return ExcludedAndUsedNodes object containing the excluded and used lists
+   */
+  public static ExcludedAndUsedNodes getExcludedAndUsedNodes(
+      List<ContainerReplica> replicas,
+      Set<DatanodeDetails> toBeRemoved,
+      List<ContainerReplicaOp> pendingReplicaOps,
+      ReplicationManager replicationManager) {
+    List<DatanodeDetails> excludedNodes = new ArrayList<>();
+    List<DatanodeDetails> usedNodes = new ArrayList<>();
+
+    for (ContainerReplica r : replicas) {
+      if (r.getState() == ContainerReplicaProto.State.UNHEALTHY) {
+        // Hosts with an Unhealthy replica cannot receive a new replica, but
+        // they are not considered used as they will be removed later.
+        excludedNodes.add(r.getDatanodeDetails());
+        continue;
+      }
+      if (toBeRemoved.contains(r.getDatanodeDetails())) {
+        // This node is currently present, but we plan to remove it so it is not
+        // considered used, but must be excluded
+        excludedNodes.add(r.getDatanodeDetails());
+        continue;
+      }
+      try {
+        NodeStatus nodeStatus =
+            replicationManager.getNodeStatus(r.getDatanodeDetails());
+        if (nodeStatus.isDecommission()) {
+          // Decommission nodes are going to go away and their replicas need to
+          // be replaced. Therefore we mark them excluded.
+          // Maintenance nodes should return to the cluster, so they would still
+          // be considered used (handled in the catch all at the end of the loop
+          // ).
+          excludedNodes.add(r.getDatanodeDetails());
+          continue;
+        }
+      } catch (NodeNotFoundException e) {
+        LOG.warn("Node {} not found in node manager.", r.getDatanodeDetails());
+        // This should not happen, but if it does, just add the node to the
+        // exclude list
+        excludedNodes.add(r.getDatanodeDetails());
+        continue;
+      }
+      // If we get here, this is a used node
+      usedNodes.add(r.getDatanodeDetails());
+    }
+    for (ContainerReplicaOp pending : pendingReplicaOps) {
+      if (pending.getOpType() == ContainerReplicaOp.PendingOpType.ADD) {
+        // If we are adding a replicas, then its scheduled to become a used node
+        usedNodes.add(pending.getTarget());
+      }
+      if (pending.getOpType() == ContainerReplicaOp.PendingOpType.DELETE) {
+        // If there are any ops pending delete, we cannot use the node, but they
+        // are not considered used as they will be removed later.
+        excludedNodes.add(pending.getTarget());
+      }
+    }
+    return new ExcludedAndUsedNodes(excludedNodes, usedNodes);
+  }
+
+
+  /**
+   * Simple class to hold the excluded and used nodes lists.
+   */
+  public static class ExcludedAndUsedNodes {
+    private List<DatanodeDetails> excludedNodes;
+    private List<DatanodeDetails> usedNodes;
+
+    public ExcludedAndUsedNodes(List<DatanodeDetails> excludedNodes,
+        List<DatanodeDetails> usedNodes) {
+      this.excludedNodes = excludedNodes;
+      this.usedNodes = usedNodes;
+    }
+
+    public List<DatanodeDetails> getExcludedNodes() {
+      return excludedNodes;
+    }
+
+    public List<DatanodeDetails> getUsedNodes() {
+      return usedNodes;
+    }
   }
 
 }

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/ReplicationTestUtil.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/ReplicationTestUtil.java
@@ -284,7 +284,8 @@ public final class ReplicationTestUtil {
         if (nodesRequiredToChoose > 1) {
           throw new IllegalArgumentException("Only one node is allowed");
         }
-        if (excludedNodes.contains(nodeToReturn)) {
+        if (excludedNodes.contains(nodeToReturn)
+            || usedNodes.contains(nodeToReturn)) {
           throw new SCMException("Insufficient Nodes available to choose",
               SCMException.ResultCodes.FAILED_TO_FIND_HEALTHY_NODES);
         }

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestRatisUnderReplicationHandler.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestRatisUnderReplicationHandler.java
@@ -41,9 +41,12 @@ import org.apache.ratis.protocol.exceptions.NotLeaderException;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
@@ -52,10 +55,14 @@ import java.util.concurrent.atomic.AtomicBoolean;
 
 import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.NodeOperationalState.DECOMMISSIONING;
 import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.NodeOperationalState.ENTERING_MAINTENANCE;
+import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.NodeOperationalState.IN_MAINTENANCE;
 import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.NodeOperationalState.IN_SERVICE;
 import static org.apache.hadoop.hdds.scm.container.replication.ReplicationTestUtil.createContainerReplica;
 import static org.apache.hadoop.hdds.scm.container.replication.ReplicationTestUtil.createReplicas;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.times;
 
 /**
  * Tests for {@link RatisUnderReplicationHandler}.
@@ -92,7 +99,7 @@ public class TestRatisUnderReplicationHandler {
       DatanodeDetails, and NodeState as HEALTHY.
     */
     Mockito.when(
-        replicationManager.getNodeStatus(Mockito.any(DatanodeDetails.class)))
+        replicationManager.getNodeStatus(any(DatanodeDetails.class)))
         .thenAnswer(invocationOnMock -> {
           DatanodeDetails dn = invocationOnMock.getArgument(0);
           return new NodeStatus(dn.getPersistedOpState(),
@@ -301,10 +308,77 @@ public class TestRatisUnderReplicationHandler {
 
     // Ensure that the replica with SEQ=2 is the only source sent
     Mockito.verify(replicationManager).sendThrottledReplicationCommand(
-        Mockito.any(ContainerInfo.class),
+        any(ContainerInfo.class),
         Mockito.eq(Collections.singletonList(valid.getDatanodeDetails())),
-        Mockito.any(DatanodeDetails.class), anyInt());
+        any(DatanodeDetails.class), anyInt());
   }
+
+  @Test
+  public void testCorrectUsedAndExcludedNodesPassed() throws IOException {
+    PlacementPolicy mockPolicy = Mockito.mock(PlacementPolicy.class);
+    Mockito.when(mockPolicy.chooseDatanodes(any(), any(), any(),
+        anyInt(), anyLong(), anyLong()))
+        .thenReturn(Collections.singletonList(
+            MockDatanodeDetails.randomDatanodeDetails()));
+
+    ArgumentCaptor<List<DatanodeDetails>> usedNodesCaptor =
+        ArgumentCaptor.forClass(List.class);
+
+    ArgumentCaptor<List<DatanodeDetails>> excludedNodesCaptor =
+        ArgumentCaptor.forClass(List.class);
+
+    RatisUnderReplicationHandler handler =
+        new RatisUnderReplicationHandler(mockPolicy, conf, replicationManager);
+
+    Set<ContainerReplica> replicas = new HashSet<>();
+    ContainerReplica good = createContainerReplica(container.containerID(), 0,
+        IN_SERVICE, State.CLOSED, 1);
+    replicas.add(good);
+
+    ContainerReplica unhealthy = createContainerReplica(
+        container.containerID(), 0, IN_SERVICE, State.UNHEALTHY, 1);
+    replicas.add(unhealthy);
+
+    ContainerReplica decommissioning =
+        createContainerReplica(container.containerID(), 0,
+            DECOMMISSIONING, State.CLOSED, 1);
+    replicas.add(decommissioning);
+
+    ContainerReplica maintenance =
+        createContainerReplica(container.containerID(), 0,
+            IN_MAINTENANCE, State.CLOSED, 1);
+    replicas.add(maintenance);
+
+    List<ContainerReplicaOp> pendingOps = new ArrayList<>();
+    DatanodeDetails pendingAdd = MockDatanodeDetails.randomDatanodeDetails();
+    DatanodeDetails pendingRemove = MockDatanodeDetails.randomDatanodeDetails();
+    pendingOps.add(ContainerReplicaOp.create(
+        ContainerReplicaOp.PendingOpType.ADD, pendingAdd, 0));
+    pendingOps.add(ContainerReplicaOp.create(
+        ContainerReplicaOp.PendingOpType.DELETE, pendingRemove, 0));
+
+    handler.processAndSendCommands(replicas, pendingOps,
+        getUnderReplicatedHealthResult(), 2);
+
+
+    Mockito.verify(mockPolicy, times(1)).chooseDatanodes(
+        usedNodesCaptor.capture(), excludedNodesCaptor.capture(), any(),
+        anyInt(), anyLong(), anyLong());
+
+    List<DatanodeDetails> usedNodes = usedNodesCaptor.getValue();
+    List<DatanodeDetails> excludedNodes = excludedNodesCaptor.getValue();
+
+    Assertions.assertTrue(usedNodes.contains(good.getDatanodeDetails()));
+    Assertions.assertTrue(usedNodes.contains(maintenance.getDatanodeDetails()));
+    Assertions.assertTrue(usedNodes.contains(pendingAdd));
+
+    Assertions.assertTrue(excludedNodes.contains(
+        unhealthy.getDatanodeDetails()));
+    Assertions.assertTrue(excludedNodes.contains(
+        decommissioning.getDatanodeDetails()));
+    Assertions.assertTrue(excludedNodes.contains(pendingRemove));
+  }
+
 
   /**
    * Tests whether the specified expectNumCommands number of commands are

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestReplicationManagerUtil.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestReplicationManagerUtil.java
@@ -80,8 +80,8 @@ public class TestReplicationManagerUtil {
 
     // Take one of the replicas and set it to be removed. It should be on the
     // excluded list rather than the used list.
-    Set<DatanodeDetails> toBeRemoved = new HashSet<>();
-    toBeRemoved.add(remove.getDatanodeDetails());
+    Set<ContainerReplica> toBeRemoved = new HashSet<>();
+    toBeRemoved.add(remove);
 
     // Finally, add a pending add and delete. The add should go onto the used
     // list and the delete added to the excluded nodes.

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestReplicationManagerUtil.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestReplicationManagerUtil.java
@@ -1,0 +1,133 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hdds.scm.container.replication;
+
+import org.apache.hadoop.hdds.protocol.DatanodeDetails;
+import org.apache.hadoop.hdds.protocol.MockDatanodeDetails;
+import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
+import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.ContainerReplicaProto;
+import org.apache.hadoop.hdds.scm.container.ContainerID;
+import org.apache.hadoop.hdds.scm.container.ContainerReplica;
+import org.apache.hadoop.hdds.scm.node.NodeStatus;
+import org.apache.hadoop.hdds.scm.node.states.NodeNotFoundException;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.mockito.Mockito;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.NodeOperationalState.DECOMMISSIONING;
+import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.NodeOperationalState.IN_MAINTENANCE;
+import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.NodeOperationalState.IN_SERVICE;
+import static org.apache.hadoop.hdds.scm.container.replication.ReplicationTestUtil.createContainerReplica;
+
+/**
+ * Tests for ReplicationManagerUtil.
+ */
+public class TestReplicationManagerUtil {
+
+  private ReplicationManager replicationManager;
+
+  @Before
+  public void setup() {
+    replicationManager = Mockito.mock(ReplicationManager.class);
+  }
+
+  @Test
+  public void testGetExcludedAndUsedNodes() throws NodeNotFoundException {
+    ContainerID cid = ContainerID.valueOf(1L);
+    Set<ContainerReplica> replicas = new HashSet<>();
+    ContainerReplica good = createContainerReplica(cid, 0,
+        IN_SERVICE, ContainerReplicaProto.State.CLOSED, 1);
+    replicas.add(good);
+
+    ContainerReplica remove = createContainerReplica(cid, 0,
+        IN_SERVICE, ContainerReplicaProto.State.CLOSED, 1);
+    replicas.add(remove);
+
+    ContainerReplica unhealthy = createContainerReplica(
+        cid, 0, IN_SERVICE, ContainerReplicaProto.State.UNHEALTHY, 1);
+    replicas.add(unhealthy);
+
+    ContainerReplica decommissioning =
+        createContainerReplica(cid, 0,
+            DECOMMISSIONING, ContainerReplicaProto.State.CLOSED, 1);
+    replicas.add(decommissioning);
+
+    ContainerReplica maintenance =
+        createContainerReplica(cid, 0,
+            IN_MAINTENANCE, ContainerReplicaProto.State.CLOSED, 1);
+    replicas.add(maintenance);
+
+    // Take one of the replicas and set it to be removed. It should be on the
+    // excluded list rather than the used list.
+    Set<DatanodeDetails> toBeRemoved = new HashSet<>();
+    toBeRemoved.add(remove.getDatanodeDetails());
+
+    // Finally, add a pending add and delete. The add should go onto the used
+    // list and the delete added to the excluded nodes.
+    DatanodeDetails pendingAdd = MockDatanodeDetails.randomDatanodeDetails();
+    DatanodeDetails pendingDelete = MockDatanodeDetails.randomDatanodeDetails();
+    List<ContainerReplicaOp> pending = new ArrayList<>();
+    pending.add(ContainerReplicaOp.create(
+        ContainerReplicaOp.PendingOpType.ADD, pendingAdd, 0));
+    pending.add(ContainerReplicaOp.create(
+        ContainerReplicaOp.PendingOpType.DELETE, pendingDelete, 0));
+
+    Mockito.when(replicationManager.getNodeStatus(Mockito.any())).thenAnswer(
+        invocation -> {
+          final DatanodeDetails dn = invocation.getArgument(0);
+          for (ContainerReplica r : replicas) {
+            if (r.getDatanodeDetails().equals(dn)) {
+              return new NodeStatus(
+                  r.getDatanodeDetails().getPersistedOpState(),
+                  HddsProtos.NodeState.HEALTHY);
+            }
+          }
+          throw new NodeNotFoundException(dn.getUuidString());
+        });
+
+    ReplicationManagerUtil.ExcludedAndUsedNodes excludedAndUsedNodes =
+        ReplicationManagerUtil.getExcludedAndUsedNodes(
+            new ArrayList<>(replicas), toBeRemoved, pending,
+            replicationManager);
+
+    Assertions.assertEquals(3, excludedAndUsedNodes.getUsedNodes().size());
+    Assertions.assertTrue(excludedAndUsedNodes.getUsedNodes()
+        .contains(good.getDatanodeDetails()));
+    Assertions.assertTrue(excludedAndUsedNodes.getUsedNodes()
+        .contains(maintenance.getDatanodeDetails()));
+    Assertions.assertTrue(excludedAndUsedNodes.getUsedNodes()
+        .contains(pendingAdd));
+
+    Assertions.assertEquals(4, excludedAndUsedNodes.getExcludedNodes().size());
+    Assertions.assertTrue(excludedAndUsedNodes.getExcludedNodes()
+        .contains(unhealthy.getDatanodeDetails()));
+    Assertions.assertTrue(excludedAndUsedNodes.getExcludedNodes()
+        .contains(decommissioning.getDatanodeDetails()));
+    Assertions.assertTrue(excludedAndUsedNodes.getExcludedNodes()
+        .contains(remove.getDatanodeDetails()));
+    Assertions.assertTrue(excludedAndUsedNodes.getExcludedNodes()
+        .contains(pendingDelete));
+  }
+
+}


### PR DESCRIPTION
## What changes were proposed in this pull request?

With [HDDS-7226](https://issues.apache.org/jira/browse/HDDS-7226) merged, the RackAwarePlacementPolicy now supports passing used nodes and excluded nodes separately. This allows it to select the racks correctly when there are one or two used nodes.

We need to change the Ratis under and mis-replication handlers to pass the used nodes and excluded nodes as two separate lists now.

Also the EC under-replication handler should be fixed to pass used nodes separately too.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-8504

## How was this patch tested?

New unit and changed tests
