### PR TITLE
HDDS-8577. [Snapshot] Disable compaction log when loading metadata for snapshot

### DIFF
--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/DBStoreBuilder.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/DBStoreBuilder.java
@@ -99,7 +99,7 @@ public final class DBStoreBuilder {
   private boolean openReadOnly = false;
   private int maxFSSnapshots = 0;
   private final DBProfile defaultCfProfile;
-  private boolean enableCompactionLog;
+  private boolean enableCompactionDag;
   private boolean createCheckpointDirs = true;
   // this is to track the total size of dbUpdates data since sequence
   // number in request to avoid increase in heap memory.
@@ -210,7 +210,7 @@ public final class DBStoreBuilder {
 
       return new RDBStore(dbFile, rocksDBOption, writeOptions, tableConfigs,
           registry.build(), openReadOnly, maxFSSnapshots, dbJmxBeanNameName,
-          enableCompactionLog, maxDbUpdatesSizeThreshold, createCheckpointDirs,
+          enableCompactionDag, maxDbUpdatesSizeThreshold, createCheckpointDirs,
           configuration);
     } finally {
       tableConfigs.forEach(TableConfig::close);
@@ -268,8 +268,8 @@ public final class DBStoreBuilder {
     return this;
   }
 
-  public DBStoreBuilder setEnableCompactionLog(boolean enableCompactionLog) {
-    this.enableCompactionLog = enableCompactionLog;
+  public DBStoreBuilder setEnableCompactionDag(boolean enableCompactionDag) {
+    this.enableCompactionDag = enableCompactionDag;
     return this;
   }
 

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/RDBStore.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/RDBStore.java
@@ -78,6 +78,7 @@ public class RDBStore implements DBStore {
   // this is to track the total size of dbUpdates data since sequence
   // number in request to avoid increase in heap memory.
   private long maxDbUpdatesSizeThreshold;
+  private final ManagedDBOptions dbOptions;
 
   @SuppressWarnings("parameternumber")
   public RDBStore(File dbFile, ManagedDBOptions dbOptions,
@@ -97,6 +98,7 @@ public class RDBStore implements DBStore {
     dbLocation = dbFile;
     dbJmxBeanName = dbJmxBeanNameName == null ? dbFile.getName() :
         dbJmxBeanNameName;
+    this.dbOptions = dbOptions;
 
     try {
       if (enableCompactionDag) {
@@ -189,6 +191,14 @@ public class RDBStore implements DBStore {
 
   public RocksDBCheckpointDiffer getRocksDBCheckpointDiffer() {
     return rocksDBCheckpointDiffer;
+  }
+
+
+  /**
+   * Returns the RocksDB's DBOptions.
+   */
+  public ManagedDBOptions getDbOptions() {
+    return dbOptions;
   }
 
   @Override

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/RDBStore.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/RDBStore.java
@@ -83,7 +83,7 @@ public class RDBStore implements DBStore {
   public RDBStore(File dbFile, ManagedDBOptions dbOptions,
                   ManagedWriteOptions writeOptions, Set<TableConfig> families,
                   CodecRegistry registry, boolean readOnly, int maxFSSnapshots,
-                  String dbJmxBeanNameName, boolean enableCompactionLog,
+                  String dbJmxBeanNameName, boolean enableCompactionDag,
                   long maxDbUpdatesSizeThreshold,
                   boolean createCheckpointDirs,
                   ConfigurationSource configuration)
@@ -99,9 +99,9 @@ public class RDBStore implements DBStore {
         dbJmxBeanNameName;
 
     try {
-      if (enableCompactionLog) {
+      if (enableCompactionDag) {
         rocksDBCheckpointDiffer = RocksDBCheckpointDifferHolder.getInstance(
-            dbLocation.getParent() + OM_KEY_PREFIX + OM_SNAPSHOT_DIFF_DIR,
+            getSnapshotMetadataDir(),
             DB_COMPACTION_SST_BACKUP_DIR, DB_COMPACTION_LOG_DIR,
             dbLocation.toString(), configuration);
         rocksDBCheckpointDiffer.setRocksDBForCompactionTracking(dbOptions);
@@ -140,7 +140,7 @@ public class RDBStore implements DBStore {
         Files.createDirectories(snapshotsParentDirPath);
       }
 
-      if (enableCompactionLog) {
+      if (enableCompactionDag) {
         ColumnFamily ssInfoTableCF = db.getColumnFamily(SNAPSHOT_INFO_TABLE);
         Preconditions.checkNotNull(ssInfoTableCF,
             "SnapshotInfoTable column family handle should not be null");
@@ -177,6 +177,10 @@ public class RDBStore implements DBStore {
       LOG.debug("[Option] createIfMissing = {}", dbOptions.createIfMissing());
       LOG.debug("[Option] maxOpenFiles= {}", dbOptions.maxOpenFiles());
     }
+  }
+
+  public String getSnapshotMetadataDir() {
+    return dbLocation.getParent() + OM_KEY_PREFIX + OM_SNAPSHOT_DIFF_DIR;
   }
 
   public String getSnapshotsParentDir() {

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOmSnapshot.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOmSnapshot.java
@@ -934,15 +934,20 @@ public class TestOmSnapshot {
     String snapshotName = createSnapshot(volumeName, bucketName);
 
     // RocksDBCheckpointDiffer should be not null for active store metadata.
-    assertNotNull(cluster.getOzoneManager().getMetadataManager().getStore()
-        .getRocksDBCheckpointDiffer());
+    RDBStore activeDbStore =
+        (RDBStore) cluster.getOzoneManager().getMetadataManager().getStore();
+    assertNotNull(activeDbStore.getRocksDBCheckpointDiffer());
+    assertEquals(2,  activeDbStore.getDbOptions().listeners().size());
 
     OmSnapshot omSnapshot = (OmSnapshot) cluster.getOzoneManager()
         .getOmSnapshotManager()
         .checkForSnapshot(volumeName, bucketName, snapshotName);
 
+    RDBStore snapshotDbStore =
+        (RDBStore) omSnapshot.getMetadataManager().getStore();
+            // RocksDBCheckpointDiffer should be null for snapshot metadata.
+    assertNull(snapshotDbStore.getRocksDBCheckpointDiffer());
     // RocksDBCheckpointDiffer should be null for snapshot metadata.
-    assertNull(omSnapshot.getMetadataManager().getStore()
-        .getRocksDBCheckpointDiffer());
+    assertEquals(0, snapshotDbStore.getDbOptions().listeners().size());
   }
 }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOmSnapshot.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOmSnapshot.java
@@ -933,9 +933,9 @@ public class TestOmSnapshot {
   public void testCompactionDagDisableForSnapshotMetadata() throws Exception {
     String snapshotName = createSnapshot(volumeName, bucketName);
 
-    // RocksDBCheckpointDiffer should be not null for active store metadata.
     RDBStore activeDbStore =
         (RDBStore) cluster.getOzoneManager().getMetadataManager().getStore();
+    // RocksDBCheckpointDiffer should be not null for active DB store.
     assertNotNull(activeDbStore.getRocksDBCheckpointDiffer());
     assertEquals(2,  activeDbStore.getDbOptions().listeners().size());
 
@@ -945,9 +945,8 @@ public class TestOmSnapshot {
 
     RDBStore snapshotDbStore =
         (RDBStore) omSnapshot.getMetadataManager().getStore();
-            // RocksDBCheckpointDiffer should be null for snapshot metadata.
+    // RocksDBCheckpointDiffer should be null for snapshot DB store.
     assertNull(snapshotDbStore.getRocksDBCheckpointDiffer());
-    // RocksDBCheckpointDiffer should be null for snapshot metadata.
     assertEquals(0, snapshotDbStore.getDbOptions().listeners().size());
   }
 }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmMetadataManagerImpl.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmMetadataManagerImpl.java
@@ -388,7 +388,7 @@ public class OmMetadataManagerImpl implements OMMetadataManager,
         RDBCheckpointUtils.waitForCheckpointDirectoryExist(checkpoint);
       }
       setStore(loadDB(conf, metaDir, dbName, false,
-          java.util.Optional.of(Boolean.TRUE), false));
+          java.util.Optional.of(Boolean.TRUE), false, false));
       initializeOmTables(false);
     } catch (IOException e) {
       stop();
@@ -530,7 +530,7 @@ public class OmMetadataManagerImpl implements OMMetadataManager,
   public static DBStore loadDB(OzoneConfiguration configuration, File metaDir)
       throws IOException {
     return loadDB(configuration, metaDir, OM_DB_NAME, false,
-            java.util.Optional.empty(), true);
+            java.util.Optional.empty(), true, true);
   }
 
   public static DBStore loadDB(OzoneConfiguration configuration, File metaDir,
@@ -539,13 +539,14 @@ public class OmMetadataManagerImpl implements OMMetadataManager,
                                        disableAutoCompaction)
           throws IOException {
     return loadDB(configuration, metaDir, dbName, readOnly,
-        disableAutoCompaction, true);
+        disableAutoCompaction, true, true);
   }
 
   public static DBStore loadDB(OzoneConfiguration configuration, File metaDir,
                                String dbName, boolean readOnly,
                                java.util.Optional<Boolean>
                                    disableAutoCompaction,
+                               boolean enableCompactionDag,
                                boolean createCheckpointDirs)
       throws IOException {
     final int maxFSSnapshots = configuration.getInt(
@@ -557,7 +558,7 @@ public class OmMetadataManagerImpl implements OMMetadataManager,
         .setOpenReadOnly(readOnly)
         .setPath(Paths.get(metaDir.getPath()))
         .setMaxFSSnapshots(maxFSSnapshots)
-        .setEnableCompactionLog(true)
+        .setEnableCompactionDag(enableCompactionDag)
         .setCreateCheckpointDirs(createCheckpointDirs);
     disableAutoCompaction.ifPresent(
             dbStoreBuilder::disableDefaultCFAutoCompaction);

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/SstFilteringService.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/SstFilteringService.java
@@ -150,7 +150,7 @@ public class SstFilteringService extends BackgroundService {
           try (RDBStore rdbStore = (RDBStore) OmMetadataManagerImpl
               .loadDB(ozoneManager.getConfiguration(),
                       new File(snapshotCheckpointDir),
-                      dbName, true, Optional.of(Boolean.TRUE), false)) {
+                      dbName, true, Optional.of(Boolean.TRUE), false, false)) {
             RocksDatabase db = rdbStore.getDb();
             db.deleteFilesNotMatchingPrefix(prefixPairs, filterFunction);
           }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/snapshot/SnapshotDiffManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/snapshot/SnapshotDiffManager.java
@@ -34,6 +34,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
@@ -55,6 +56,7 @@ import java.util.stream.Stream;
 import org.apache.commons.io.file.PathUtils;
 import org.apache.hadoop.hdds.StringUtils;
 import org.apache.hadoop.hdds.utils.db.CodecRegistry;
+import org.apache.hadoop.hdds.utils.db.RDBStore;
 import org.apache.hadoop.hdds.utils.db.Table;
 import org.apache.hadoop.ozone.OFSPath;
 import org.apache.hadoop.hdds.utils.db.managed.ManagedSSTDumpTool;
@@ -221,7 +223,9 @@ public class SnapshotDiffManager implements AutoCloseable {
             .build()
     );
 
-    Path path = Paths.get(differ.getMetadataDir(), "snapDiff");
+    RDBStore rdbStore = (RDBStore) ozoneManager.getMetadataManager().getStore();
+    Objects.requireNonNull(rdbStore, "DBStore can't be null.");
+    Path path = Paths.get(rdbStore.getSnapshotMetadataDir(), "snapDiff");
     createEmptySnapDiffDir(path);
     this.sstBackupDirForSnapDiffJobs = path.toString();
 


### PR DESCRIPTION
## What changes were proposed in this pull request?
By default, [DBStore object gets created with compaction DAG enabled](https://github.com/apache/ozone/blob/b5ad73aaa8a3a419fdb9cb27d54ea6ee54f71cf0/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmMetadataManagerImpl.java#L560). There is no need for compaction DAG when loading metadata for snapshots.

This change is add `enableCompationDag` to [loadDB()](https://github.com/apache/ozone/blob/master/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmMetadataManagerImpl.java#L545) use it to create DBStore object.

Also change the variable name from `enableCompationLog` to `enableCompationDag` because someone can get confused if it is to enable/disable RocksDB compaction.


## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-8577

## How was this patch tested?
Added test for it.
