### PR TITLE
HDDS-8067. [Snapshot] Revisit locks on deletedTable and deletedDirTable

### DIFF
--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmMetadataManagerImpl.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmMetadataManagerImpl.java
@@ -636,7 +636,6 @@ public class OmMetadataManagerImpl implements OMMetadataManager,
     deletedTable = this.store.getTable(DELETED_TABLE, String.class,
         RepeatedOmKeyInfo.class);
     checkTableStatus(deletedTable, DELETED_TABLE, addCacheMetrics);
-    // Currently, deletedTable is the only table that will need the table lock
     tableLockMap.put(DELETED_TABLE, new ReentrantReadWriteLock(true));
 
     openKeyTable =
@@ -675,6 +674,7 @@ public class OmMetadataManagerImpl implements OMMetadataManager,
     deletedDirTable = this.store.getTable(DELETED_DIR_TABLE, String.class,
         OmKeyInfo.class);
     checkTableStatus(deletedDirTable, DELETED_DIR_TABLE, addCacheMetrics);
+    tableLockMap.put(DELETED_DIR_TABLE, new ReentrantReadWriteLock(true));
 
     transactionInfoTable = this.store.getTable(TRANSACTION_INFO_TABLE,
         String.class, TransactionInfo.class);

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmSnapshotManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmSnapshotManager.java
@@ -380,10 +380,13 @@ public final class OmSnapshotManager implements AutoCloseable {
 
     final DBCheckpoint dbCheckpoint;
 
-    // Acquire deletedTable write lock
+    // Acquire active DB deletedDirectoryTable write lock
+    omMetadataManager.getTableLock(OmMetadataManagerImpl.DELETED_DIR_TABLE)
+        .writeLock().lock();
+    // Acquire active DB deletedTable write lock
     omMetadataManager.getTableLock(OmMetadataManagerImpl.DELETED_TABLE)
         .writeLock().lock();
-    // TODO: [SNAPSHOT] HDDS-8067. Acquire deletedDirectoryTable write lock
+
     try {
       // Create DB checkpoint for snapshot
       dbCheckpoint = store.getSnapshot(snapshotInfo.getCheckpointDirName());
@@ -395,9 +398,11 @@ public final class OmSnapshotManager implements AutoCloseable {
       deleteKeysFromDelDirTableInSnapshotScope(omMetadataManager,
           snapshotInfo.getVolumeName(), snapshotInfo.getBucketName());
     } finally {
-      // TODO: [SNAPSHOT] HDDS-8067. Release deletedDirectoryTable write lock
       // Release deletedTable write lock
       omMetadataManager.getTableLock(OmMetadataManagerImpl.DELETED_TABLE)
+          .writeLock().unlock();
+      // Release deletedDirectoryTable write lock
+      omMetadataManager.getTableLock(OmMetadataManagerImpl.DELETED_DIR_TABLE)
           .writeLock().unlock();
     }
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmSnapshotManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmSnapshotManager.java
@@ -380,10 +380,11 @@ public final class OmSnapshotManager implements AutoCloseable {
 
     final DBCheckpoint dbCheckpoint;
 
-    // Acquire active DB deletedDirectoryTable write lock
+    // Acquire active DB deletedDirectoryTable write lock to block
+    // DirDeletingTask
     omMetadataManager.getTableLock(OmMetadataManagerImpl.DELETED_DIR_TABLE)
         .writeLock().lock();
-    // Acquire active DB deletedTable write lock
+    // Acquire active DB deletedTable write lock to block KeyDeletingTask
     omMetadataManager.getTableLock(OmMetadataManagerImpl.DELETED_TABLE)
         .writeLock().lock();
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/key/OMDirectoriesPurgeResponseWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/key/OMDirectoriesPurgeResponseWithFSO.java
@@ -138,13 +138,8 @@ public class OMDirectoriesPurgeResponseWithFSO extends OmKeyResponse {
         deletedKey = omMetadataManager.getOzoneDeletePathKey(
             keyInfo.getObjectID(), deletedKey);
 
-        // TODO: [SNAPSHOT] Acquire deletedTable write table lock
-
         omMetadataManager.getDeletedTable().putWithBatch(batchOperation,
             deletedKey, repeatedOmKeyInfo);
-
-        // TODO: [SNAPSHOT] Release deletedTable write table lock
-
       }
 
       // Delete the visited directory from deleted directory table

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/service/KeyDeletingService.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/service/KeyDeletingService.java
@@ -25,6 +25,7 @@ import org.apache.hadoop.hdds.conf.ConfigurationSource;
 import org.apache.hadoop.hdds.scm.protocol.ScmBlockLocationProtocol;
 import org.apache.hadoop.ozone.common.BlockGroup;
 import org.apache.hadoop.ozone.om.KeyManager;
+import org.apache.hadoop.ozone.om.OmMetadataManagerImpl;
 import org.apache.hadoop.ozone.om.OzoneManager;
 import org.apache.hadoop.hdds.utils.BackgroundTask;
 import org.apache.hadoop.hdds.utils.BackgroundTaskQueue;
@@ -118,15 +119,18 @@ public class KeyDeletingService extends AbstractKeyDeletingService {
       // task.
       if (shouldRun()) {
         getRunCount().incrementAndGet();
+
+        // Acquire active DB deletedTable write lock
+        manager.getMetadataManager().getTableLock(
+            OmMetadataManagerImpl.DELETED_TABLE).writeLock().lock();
+
         try {
           // TODO: [SNAPSHOT] HDDS-7968. Reclaim eligible key blocks in
           //  snapshot's deletedTable when active DB's deletedTable
           //  doesn't have enough entries left.
           //  OM would have to keep track of which snapshot the key is coming
-          //  from. And PurgeKeysRequest would have to be adjusted to be able
-          //  to operate on snapshot checkpoints.
+          //  from if the above would be done inside getPendingDeletionKeys().
 
-          // TODO: [SNAPSHOT] HDDS-8067. Acquire deletedTable write lock
           List<BlockGroup> keyBlocksList = manager
               .getPendingDeletionKeys(keyLimitPerTask);
           if (keyBlocksList != null && !keyBlocksList.isEmpty()) {
@@ -137,9 +141,11 @@ public class KeyDeletingService extends AbstractKeyDeletingService {
         } catch (IOException e) {
           LOG.error("Error while running delete keys background task. Will " +
               "retry at next run.", e);
+        } finally {
+          // Release deletedTable write lock
+          manager.getMetadataManager().getTableLock(
+              OmMetadataManagerImpl.DELETED_TABLE).writeLock().unlock();
         }
-        // TODO: [SNAPSHOT] HDDS-8067. Release deletedTable write lock
-        //  in finally block
       }
       // By design, no one cares about the results of this call back.
       return EmptyTaskResult.newResult();

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/service/KeyDeletingService.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/service/KeyDeletingService.java
@@ -120,7 +120,10 @@ public class KeyDeletingService extends AbstractKeyDeletingService {
       if (shouldRun()) {
         getRunCount().incrementAndGet();
 
-        // Acquire active DB deletedTable write lock
+        // Acquire active DB deletedTable write lock because of the
+        // deletedTable read-write here to avoid interleaving with
+        // the table range delete operation in createOmSnapshotCheckpoint()
+        // that is called from OMSnapshotCreateResponse#addToDBBatch.
         manager.getMetadataManager().getTableLock(
             OmMetadataManagerImpl.DELETED_TABLE).writeLock().lock();
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

During snapshot creation, access to `deletedTable` and `deletedDirectoryTable` would need to be synchronized with `KeyDeletingTask` and `DirDeletingTask` to avoid out-of-order access (read/write) messing up either table.

Here are the code logics that justify the locks:

### `createOmSnapshotCheckpoint` flow, called from `OMSnapshotCreateResponse#addToDBBatch`

1. Acquire `getTableLock(deletedDirectoryTable)` write lock, then acquire`getTableLock(deletedTable)` write lock
2. In `deletedTable`, remove all keys with prefix matching snapshot scope path (bucket)
3. In `deletedDirectoryTable`, remove all keys with prefix matching snapshot scope path (bucket)
4. Release `getTableLock(deletedTable)` write lock, then release`getTableLock(deletedDirectoryTable)` write lock

### `KeyDeletingTask#call` flow

1. Acquire `getTableLock(deletedTable)` write lock
2. `getPendingDeletionKeys()`: (currently) retrieves a number of keys from active DB's `deletedTable`
3. `processKeyDeletes()`: delete key blocks with SCM client `deleteKeyBlocks()`, submits `PurgeKeysRequest` Ratis request which then removes successfully reclaimed keys from active `deletedTable`
4. Release `getTableLock(deletedTable)` write lock

### `DirDeletingTask#call` flow

1. Acquire `getTableLock(deletedDirectoryTable)` write lock
2. Iterate over active `deletedDirectoryTable`, prepare a list of `PurgePathRequest`s, each contains immediate children (keys and dirs) under this directory.
3. ~~Acquire `getTableLock(deletedTable)` write lock~~ Not needed. See https://github.com/apache/ozone/pull/4701#discussion_r1196941252
4. `optimizeDirDeletesAndSubmitRequest()`: recurse further into sub-dirs if batch limit `pathLimitPerTask` isn't reached. Q: Can we refactor the same dir expansion logic? [One](https://github.com/apache/ozone/blob/dd003040a41def491e8de003ef8539ce40854972/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/service/AbstractKeyDeletingService.java#L356-L380), [Two](https://github.com/apache/ozone/blob/fb15c0514252518dcd445936813d1f7ab21b8bc9/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/service/DirectoryDeletingService.java#L136-L158), [Three](https://github.com/apache/ozone/blob/4578a063533bc1396a218a69613a842ff0b32ec6/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/service/SnapshotDeletingService.java#L352-L375) @aswinshakil 
5. Submit `PurgePathRequest`s to Ratis
6. ~~Release `getTableLock(deletedTable)` write lock~~
7. Release `getTableLock(deletedDirectoryTable)` write lock

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-8067

## How was this patch tested?

- All existing tests should pass.