### PR TITLE
HDDS-8615. Explicitly show EC block type in 'ozone debug chunkinfo'

### DIFF
--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/ChunkKeyHandler.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/ChunkKeyHandler.java
@@ -31,6 +31,7 @@ import com.google.gson.JsonObject;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
 import org.apache.hadoop.hdds.cli.SubcommandWithParent;
+import org.apache.hadoop.hdds.client.ECReplicationConfig;
 import org.apache.hadoop.hdds.client.StandaloneReplicationConfig;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
 import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos;
@@ -67,7 +68,7 @@ import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationFactor
 public class ChunkKeyHandler extends KeyHandler implements
     SubcommandWithParent {
 
-  private  XceiverClientManager xceiverClientManager;
+  private XceiverClientManager xceiverClientManager;
   private XceiverClientSpi xceiverClient;
   private OzoneManagerProtocol ozoneManagerClient;
 
@@ -115,11 +116,17 @@ public class ChunkKeyHandler extends KeyHandler implements
         ContainerChunkInfo containerChunkInfo = new ContainerChunkInfo();
         long containerId = keyLocation.getContainerID();
         chunkPaths.clear();
-        Pipeline pipeline = keyLocation.getPipeline();
-        if (pipeline.getType() != HddsProtos.ReplicationType.STAND_ALONE) {
-          pipeline = Pipeline.newBuilder(pipeline)
+        Pipeline keyPipeline = keyLocation.getPipeline();
+        boolean isECKey =
+            keyPipeline.getReplicationConfig().getReplicationType() ==
+                HddsProtos.ReplicationType.EC;
+        Pipeline pipeline;
+        if (keyPipeline.getType() != HddsProtos.ReplicationType.STAND_ALONE) {
+          pipeline = Pipeline.newBuilder(keyPipeline)
               .setReplicationConfig(StandaloneReplicationConfig
                   .getInstance(ONE)).build();
+        } else {
+          pipeline = keyPipeline;
         }
         xceiverClient = xceiverClientManager.acquireClientForReadData(pipeline);
         // Datanode is queried to get chunk information.Thus querying the
@@ -161,11 +168,17 @@ public class ChunkKeyHandler extends KeyHandler implements
           }
           containerChunkInfoVerbose.setContainerPath(containerData
               .getContainerPath());
-          containerChunkInfoVerbose.setPipeline(keyLocation.getPipeline());
+          containerChunkInfoVerbose.setPipeline(keyPipeline);
           containerChunkInfoVerbose.setChunkInfos(chunkDetailsList);
           containerChunkInfo.setFiles(chunkPaths);
-          containerChunkInfo.setPipelineID(
-              keyLocation.getPipeline().getId().getId());
+          containerChunkInfo.setPipelineID(keyPipeline.getId().getId());
+          if (isECKey) {
+            ChunkType blockChunksType =
+                isECParityBlock(keyPipeline, entry.getKey()) ?
+                    ChunkType.PARITY : ChunkType.DATA;
+            containerChunkInfoVerbose.setChunkType(blockChunksType);
+            containerChunkInfo.setChunkType(blockChunksType);
+          }
           Gson gson = new GsonBuilder().create();
           if (isVerbose()) {
             element = gson.toJsonTree(containerChunkInfoVerbose);
@@ -190,6 +203,13 @@ public class ChunkKeyHandler extends KeyHandler implements
       String prettyJson = gson2.toJson(result);
       System.out.println(prettyJson);
     }
+  }
+
+  private boolean isECParityBlock(Pipeline pipeline, DatanodeDetails dn) {
+    //index is 1-based,
+    //e.g. for RS-3-2 we will have data indexes 1,2,3 and parity indexes 4,5
+    return pipeline.getReplicaIndex(dn) >
+        ((ECReplicationConfig) pipeline.getReplicationConfig()).getData();
   }
 
   @Override

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/ChunkType.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/ChunkType.java
@@ -1,0 +1,24 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with this
+ * work for additional information regarding copyright ownership.  The ASF
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.hadoop.ozone.debug;
+
+/**
+ * The type of chunks of an Erasure Coded key.
+ */
+public enum ChunkType {
+  DATA, PARITY
+}

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/ContainerChunkInfo.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/ContainerChunkInfo.java
@@ -35,6 +35,7 @@ public class ContainerChunkInfo {
   private HashSet<String> files;
   private UUID pipelineID;
   private Pipeline pipeline;
+  private ChunkType chunkType;
 
   public void setFiles(HashSet<String> files) {
     this.files = files;
@@ -60,6 +61,9 @@ public class ContainerChunkInfo {
     this.chunkInfos = chunkInfos;
   }
 
+  public void setChunkType(ChunkType chunkType) {
+    this.chunkType = chunkType;
+  }
 
   @Override
   public String toString() {
@@ -75,6 +79,8 @@ public class ContainerChunkInfo {
             + "files="
             + files
             + "PipelineID="
-            + pipelineID;
+            + pipelineID
+            + "ChunkType="
+            + chunkType;
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?
The output of `ozone debug chunkinfo` now shows the type of chunks in an EC block


https://issues.apache.org/jira/browse/HDDS-8615


## How was this patch tested?
Manually. Now the output of  `ozone debug chunkinfo` looks as follows:
```
...
      {
        "Datanode-HostName": "ozone-datanode-7.ozone_default",
        "Datanode-IP": "172.27.0.13",
        "Container-ID": 1,
        "Block-ID": 111677748019200001,
        "Locations": {
          "files": [
            "/data/hdds/hdds/CID-5fc1a1ae-41c9-436f-81c7-fbd53389ddc4/current/containerDir0/1/chunks/111677748019200001.block"
          ],
          "pipelineID": "413af33b-2975-49b1-a850-b8f8378ffc0b",
          "chunkType": "PARITY"
        }
      }
...
```

