### PR TITLE
HDDS-8619. hadoop fs operations using ofs:// fails with ClassNotFoundException ProtocolMessageEnum

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -56,7 +56,8 @@ mvn clean verify -DskipTests
 
 ### Useful Maven build options
 
-  * Use `-DskipShade` to skip shaded Ozone FS jar file creation. Saves time, but you can't test integration with other software that uses Ozone as a Hadoop-compatible file system.
+  * Use `-Dbuild-ozonefs=unshaded` to create unshaded Ozone FS jar file.
+  * Use `-Dbuild-ozonefs=false` to skip Ozone FS jar file creation. Saves time, but you can't test integration with other software that uses Ozone as a Hadoop-compatible file system.
   * Use `-DskipRecon` to skip building Recon Web UI. It saves about 2 minutes.
   * Use `-Pdist` to build the binary tarball, similar to the one that gets released
 

--- a/hadoop-ozone/dev-support/checks/sonar.sh
+++ b/hadoop-ozone/dev-support/checks/sonar.sh
@@ -30,4 +30,4 @@ if [ -f "$PROJECT_DIR/target/coverage/all.xml" ]; then
    find "$PROJECT_DIR" -name pom.xml | grep -v target | xargs dirname | xargs -n1 -IDIR cp "$PROJECT_DIR/target/coverage/all.xml" DIR/target/coverage/
 fi
 
-mvn -B verify -DskipShade -DskipTests -Dskip.npx -Dskip.installnpx org.sonarsource.scanner.maven:sonar-maven-plugin:3.6.0.1398:sonar -Dsonar.host.url=https://sonarcloud.io -Dsonar.organization=apache -Dsonar.projectKey=hadoop-ozone
+mvn -B verify -Dbuild-ozonefs=false -DskipTests -Dskip.npx -Dskip.installnpx org.sonarsource.scanner.maven:sonar-maven-plugin:3.6.0.1398:sonar -Dsonar.host.url=https://sonarcloud.io -Dsonar.organization=apache -Dsonar.projectKey=hadoop-ozone

--- a/hadoop-ozone/dist/pom.xml
+++ b/hadoop-ozone/dist/pom.xml
@@ -257,6 +257,10 @@
           <groupId>org.apache.ozone</groupId>
           <artifactId>ozone-filesystem-hadoop3-client</artifactId>
         </dependency>
+        <dependency>
+          <groupId>org.apache.hadoop</groupId>
+          <artifactId>hadoop-client-runtime</artifactId>
+        </dependency>
       </dependencies>
     </profile>
     <profile>

--- a/hadoop-ozone/dist/pom.xml
+++ b/hadoop-ozone/dist/pom.xml
@@ -238,10 +238,30 @@
   </dependencies>
   <profiles>
     <profile>
+      <id>build-with-ozonefs-shaded</id>
+      <activation>
+        <property>
+          <name>build-ozonefs</name>
+          <value>shaded</value>
+        </property>
+      </activation>
+      <dependencies>
+        <dependency>
+          <groupId>org.apache.ozone</groupId>
+          <artifactId>ozone-filesystem-hadoop2</artifactId>
+        </dependency>
+        <dependency>
+          <groupId>org.apache.ozone</groupId>
+          <artifactId>ozone-filesystem-hadoop3-client</artifactId>
+        </dependency>
+      </dependencies>
+    </profile>
+    <profile>
       <id>build-with-ozonefs</id>
       <activation>
         <property>
-          <name>!skipShade</name>
+          <name>build-ozonefs</name>
+          <value>unshaded</value>
         </property>
       </activation>
       <dependencies>
@@ -252,14 +272,6 @@
         <dependency>
           <groupId>org.apache.ozone</groupId>
           <artifactId>ozone-filesystem-hadoop3</artifactId>
-        </dependency>
-        <dependency>
-          <groupId>org.apache.ozone</groupId>
-          <artifactId>ozone-filesystem-hadoop3-client</artifactId>
-        </dependency>
-        <dependency>
-          <groupId>org.apache.hadoop</groupId>
-          <artifactId>hadoop-client-runtime</artifactId>
         </dependency>
       </dependencies>
     </profile>

--- a/hadoop-ozone/dist/src/main/k8s/README.md
+++ b/hadoop-ozone/dist/src/main/k8s/README.md
@@ -21,7 +21,7 @@ Ozone on Kubernetes
 
 To start Ozone in Kubernetes, you need Kubernetes and kubectl installed. You also need to add the [flekszible](https://github.com/elek/flekszible) binary in your path.
 
-1. Build the project `mvn clean install -DskipShade -DskipTests`
+1. Build the project `mvn clean install -Dbuild-ozonefs=false -DskipTests`
 2. `cd <ozone-root>/hadoop-ozone/dist/target/ozone-X.X../kubernetes/examples/ozone`
 3. `source ../testlib.sh`
 4. `regenerate_resources`

--- a/hadoop-ozone/dist/src/main/license/jar-report.txt
+++ b/hadoop-ozone/dist/src/main/license/jar-report.txt
@@ -57,8 +57,6 @@ share/ozone/lib/guice.jar
 share/ozone/lib/guice-servlet.jar
 share/ozone/lib/hadoop-annotations.jar
 share/ozone/lib/hadoop-auth.jar
-share/ozone/lib/hadoop-client-api.jar
-share/ozone/lib/hadoop-client-runtime.jar
 share/ozone/lib/hadoop-common.jar
 share/ozone/lib/hadoop-hdfs-client.jar
 share/ozone/lib/hadoop-hdfs.jar

--- a/hadoop-ozone/dist/src/main/license/jar-report.txt
+++ b/hadoop-ozone/dist/src/main/license/jar-report.txt
@@ -57,6 +57,8 @@ share/ozone/lib/guice.jar
 share/ozone/lib/guice-servlet.jar
 share/ozone/lib/hadoop-annotations.jar
 share/ozone/lib/hadoop-auth.jar
+share/ozone/lib/hadoop-client-api.jar
+share/ozone/lib/hadoop-client-runtime.jar
 share/ozone/lib/hadoop-common.jar
 share/ozone/lib/hadoop-hdfs-client.jar
 share/ozone/lib/hadoop-hdfs.jar

--- a/hadoop-ozone/dist/src/main/smoketest/s3/s3_compatbility_check.sh
+++ b/hadoop-ozone/dist/src/main/smoketest/s3/s3_compatbility_check.sh
@@ -22,7 +22,7 @@ set -e
 
 
 # To run this script
-#    mvn clean install -DskipShade -DskipTests
+#    mvn clean install -Dbuild-ozonefs=false -DskipTests
 #    cd hadoop-ozone/dist/target/ozone-*/smoketest/s3/
 #    python3 -m venv s3env
 #    source s3env/bin/activate

--- a/hadoop-ozone/pom.xml
+++ b/hadoop-ozone/pom.xml
@@ -394,10 +394,11 @@
       </properties>
     </profile>
     <profile>
-      <id>build-with-ozonefs</id>
+      <id>build-with-ozonefs-shaded</id>
       <activation>
         <property>
-          <name>!skipShade</name>
+          <name>build-ozonefs</name>
+          <value>shaded</value>
         </property>
       </activation>
       <modules>
@@ -405,6 +406,20 @@
         <module>ozonefs-hadoop2</module>
         <module>ozonefs-hadoop3</module>
         <module>ozonefs-hadoop3-client</module>
+      </modules>
+    </profile>
+    <profile>
+      <id>build-with-ozonefs-unshaded</id>
+      <activation>
+        <property>
+          <name>build-ozonefs</name>
+          <value>unshaded</value>
+        </property>
+      </activation>
+      <modules>
+        <module>ozonefs-shaded</module>
+        <module>ozonefs-hadoop2</module>
+        <module>ozonefs-hadoop3</module>
       </modules>
     </profile>
     <profile>

--- a/pom.xml
+++ b/pom.xml
@@ -306,6 +306,8 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
     <zstd.version>1.4.9</zstd.version>
 
     <vault.driver.version>5.1.0</vault.driver.version>
+
+    <build-ozonefs>shaded</build-ozonefs>
   </properties>
 
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Adding a way to distribute unshaded ozone filesystem hadoop3 jar to work with hadoop which hasn't shaded it's dependencies. 
Passing the value -Dbuild-ozonefs=unshaded will build unshaded ozone filesystem hadoop3 jar
Passing the value -Dbuild-ozonefs=shaded will build shaded ozone filesystem hadoop3-client jar (This is the default value if nothing is passed)
Passing any other value apart from this will not build ozone filesystem hadoop jars.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-8619

## How was this patch tested?
Manual testing adding jar in classpath
