### PR TITLE
HDDS-8616. Underreplication not fixed if all replicas start decommissioning

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/RatisContainerReplicaCount.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/RatisContainerReplicaCount.java
@@ -508,12 +508,12 @@ public class RatisContainerReplicaCount implements ContainerReplicaCount {
   /**
    * Checks whether insufficient replication is because of some replicas
    * being on datanodes that were decommissioned.
-   * @param includePendingAdd if pending adds should be considered
+   *
    * @return true if there is insufficient replication and it's because of
    * decommissioning.
    */
-  private boolean inSufficientDueToDecommission(boolean includePendingAdd) {
-    int delta = redundancyDelta(true, includePendingAdd);
+  private boolean inSufficientDueToDecommission() {
+    int delta = redundancyDelta(true, false);
     return 0 < delta && delta <= getDecommissionCount();
   }
 
@@ -548,7 +548,7 @@ public class RatisContainerReplicaCount implements ContainerReplicaCount {
     UnderReplicatedHealthResult result = new UnderReplicatedHealthResult(
         getContainer(),
         getRemainingRedundancy(),
-        inSufficientDueToDecommission(false),
+        inSufficientDueToDecommission(),
         isSufficientlyReplicated(true),
         isUnrecoverable());
     result.setHasHealthyReplicas(getHealthyReplicaCount() > 0);

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/RatisContainerReplicaCount.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/RatisContainerReplicaCount.java
@@ -512,7 +512,7 @@ public class RatisContainerReplicaCount implements ContainerReplicaCount {
    * @return true if there is insufficient replication and it's because of
    * decommissioning.
    */
-  public boolean inSufficientDueToDecommission(boolean includePendingAdd) {
+  private boolean inSufficientDueToDecommission(boolean includePendingAdd) {
     int delta = redundancyDelta(true, includePendingAdd);
     return 0 < delta && delta <= getDecommissionCount();
   }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/RatisContainerReplicaCount.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/RatisContainerReplicaCount.java
@@ -245,16 +245,20 @@ public class RatisContainerReplicaCount implements ContainerReplicaCount {
 
   @Override
   public String toString() {
-    return "Container State: " + container.getState() +
+    String result = "Container State: " + container.getState() +
         " Replica Count: " + replicas.size() +
-        " Healthy Count: " + healthyReplicaCount +
-        " Unhealthy Count: " + unhealthyReplicaCount +
-        " Decommission Count: " + decommissionCount +
-        " Maintenance Count: " + maintenanceCount +
-        " inFlightAdd Count: " + inFlightAdd +
-        " inFightDel Count: " + inFlightDel +
+        " Healthy (I/D/M): " + healthyReplicaCount +
+            "/" + decommissionCount + "/" + maintenanceCount +
+        " Unhealthy (I/D/M): " + unhealthyReplicaCount +
+            "/" + unhealthyDecommissionCount + "/" + unhealthyMaintenanceCount +
+        " inFlightAdd: " + inFlightAdd +
+        " inFightDel: " + inFlightDel +
         " ReplicationFactor: " + repFactor +
-        " minMaintenance Count: " + minHealthyForMaintenance;
+        " minMaintenance: " + minHealthyForMaintenance;
+    if (considerUnhealthy) {
+      result += " +considerUnhealthy";
+    }
+    return result;
   }
 
   /**

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/RatisContainerReplicaCount.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/RatisContainerReplicaCount.java
@@ -513,11 +513,8 @@ public class RatisContainerReplicaCount implements ContainerReplicaCount {
    * decommissioning.
    */
   public boolean inSufficientDueToDecommission(boolean includePendingAdd) {
-    if (isSufficientlyReplicated(includePendingAdd)) {
-      return false;
-    }
     int delta = redundancyDelta(true, includePendingAdd);
-    return getDecommissionCount() >= delta;
+    return 0 < delta && delta <= getDecommissionCount();
   }
 
   /**

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/RatisContainerReplicaCount.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/RatisContainerReplicaCount.java
@@ -22,6 +22,8 @@ import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.ContainerReplicaProto;
 import org.apache.hadoop.hdds.scm.container.ContainerInfo;
 import org.apache.hadoop.hdds.scm.container.ContainerReplica;
+import org.apache.hadoop.hdds.scm.container.replication.ContainerHealthResult.OverReplicatedHealthResult;
+import org.apache.hadoop.hdds.scm.container.replication.ContainerHealthResult.UnderReplicatedHealthResult;
 
 import java.util.ArrayList;
 import java.util.Comparator;
@@ -557,4 +559,28 @@ public class RatisContainerReplicaCount implements ContainerReplicaCount {
   public boolean isUnrecoverable() {
     return getReplicas().isEmpty();
   }
+
+  public UnderReplicatedHealthResult toUnderHealthResult() {
+    UnderReplicatedHealthResult result = new UnderReplicatedHealthResult(
+        getContainer(),
+        getRemainingRedundancy(),
+        inSufficientDueToDecommission(false),
+        isSufficientlyReplicated(true),
+        isUnrecoverable());
+    result.setHasHealthyReplicas(getHealthyReplicaCount() > 0);
+    return result;
+  }
+
+  public OverReplicatedHealthResult toOverHealthResult() {
+    OverReplicatedHealthResult result = new OverReplicatedHealthResult(
+        getContainer(),
+        getExcessRedundancy(false),
+        !isOverReplicated(true));
+    result.setHasMismatchedReplicas(getMisMatchedReplicaCount() > 0);
+    // FIXME not used in RatisReplicationCheckHandler: OK?
+    result.setIsSafelyOverReplicated(isSafelyOverReplicated());
+    return result;
+
+  }
+
 }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/health/RatisReplicationCheckHandler.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/health/RatisReplicationCheckHandler.java
@@ -187,14 +187,7 @@ public class RatisReplicationCheckHandler extends AbstractCheck {
     boolean sufficientlyReplicated
         = replicaCount.isSufficientlyReplicated(false);
     if (!sufficientlyReplicated) {
-      ContainerHealthResult.UnderReplicatedHealthResult result =
-          new ContainerHealthResult.UnderReplicatedHealthResult(
-              container, replicaCount.getRemainingRedundancy(),
-              replicaCount.inSufficientDueToDecommission(false),
-              replicaCount.isSufficientlyReplicated(true),
-              replicaCount.isUnrecoverable());
-      result.setHasHealthyReplicas(replicaCount.getHealthyReplicaCount() > 0);
-      return result;
+      return replicaCount.toUnderHealthResult();
     }
 
     /*
@@ -209,14 +202,7 @@ public class RatisReplicationCheckHandler extends AbstractCheck {
             minReplicasForMaintenance, true);
     boolean isOverReplicated = consideringUnhealthy.isOverReplicated(false);
     if (isOverReplicated) {
-      boolean repOkWithPending = !consideringUnhealthy.isOverReplicated(true);
-      ContainerHealthResult.OverReplicatedHealthResult result =
-          new ContainerHealthResult.OverReplicatedHealthResult(
-              container, consideringUnhealthy.getExcessRedundancy(false),
-              repOkWithPending);
-      result.setHasMismatchedReplicas(
-          consideringUnhealthy.getMisMatchedReplicaCount() > 0);
-      return result;
+      return consideringUnhealthy.toOverHealthResult();
     }
 
     int requiredNodes = container.getReplicationConfig().getRequiredNodes();

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/health/RatisUnhealthyReplicationCheckHandler.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/health/RatisUnhealthyReplicationCheckHandler.java
@@ -165,29 +165,12 @@ public class RatisUnhealthyReplicationCheckHandler extends AbstractCheck {
     boolean sufficientlyReplicated
         = replicaCount.isSufficientlyReplicated(false);
     if (!sufficientlyReplicated) {
-      ContainerHealthResult.UnderReplicatedHealthResult result =
-          new ContainerHealthResult.UnderReplicatedHealthResult(
-              replicaCount.getContainer(),
-              replicaCount.getRemainingRedundancy(),
-              replicaCount.inSufficientDueToDecommission(false),
-              replicaCount.isSufficientlyReplicated(true),
-              replicaCount.isUnrecoverable());
-      result.setHasHealthyReplicas(replicaCount.getHealthyReplicaCount() > 0);
-      return result;
+      return replicaCount.toUnderHealthResult();
     }
 
     boolean isOverReplicated = replicaCount.isOverReplicated(false);
     if (isOverReplicated) {
-      boolean repOkWithPending = !replicaCount.isOverReplicated(true);
-      ContainerHealthResult.OverReplicatedHealthResult result =
-          new ContainerHealthResult.OverReplicatedHealthResult(
-              replicaCount.getContainer(),
-              replicaCount.getExcessRedundancy(false),
-              repOkWithPending);
-      result.setHasMismatchedReplicas(
-          replicaCount.getMisMatchedReplicaCount() > 0);
-      result.setIsSafelyOverReplicated(replicaCount.isSafelyOverReplicated());
-      return result;
+      return replicaCount.toOverHealthResult();
     }
 
     return new ContainerHealthResult.UnHealthyResult(

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestRatisContainerReplicaCount.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestRatisContainerReplicaCount.java
@@ -515,8 +515,8 @@ class TestRatisContainerReplicaCount {
     assertEquals(1, rcnt.getMisMatchedReplicaCount());
     // CLOSED + CLOSED = 2
     assertEquals(2, rcnt.getMatchingReplicaCount());
-    // UNHEALTHY should be 0 because it is counted as decommissioned
-    assertEquals(0, rcnt.getUnhealthyReplicaCount());
+    // UNHEALTHY decommissioned is counted as unhealthy, too
+    assertEquals(1, rcnt.getUnhealthyReplicaCount());
     // 1 because the UNHEALTHY replica is on a decommissioned node
     assertEquals(1, rcnt.getDecommissionCount());
 
@@ -533,8 +533,8 @@ class TestRatisContainerReplicaCount {
     assertEquals(1, rcnt.getMisMatchedReplicaCount());
     // CLOSED + CLOSED = 2
     assertEquals(2, rcnt.getMatchingReplicaCount());
-    // UNHEALTHY should be 0 because it is counted as decommissioned
-    assertEquals(0, rcnt.getUnhealthyReplicaCount());
+    // UNHEALTHY decommissioned is counted as unhealthy, too
+    assertEquals(1, rcnt.getUnhealthyReplicaCount());
     assertEquals(1, rcnt.getDecommissionCount());
   }
 

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestRatisContainerReplicaCount.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestRatisContainerReplicaCount.java
@@ -515,10 +515,10 @@ class TestRatisContainerReplicaCount {
     assertEquals(1, rcnt.getMisMatchedReplicaCount());
     // CLOSED + CLOSED = 2
     assertEquals(2, rcnt.getMatchingReplicaCount());
-    // UNHEALTHY decommissioned is counted as unhealthy, too
+    // UNHEALTHY decommissioned is counted, too
     assertEquals(1, rcnt.getUnhealthyReplicaCount());
-    // 1 because the UNHEALTHY replica is on a decommissioned node
-    assertEquals(1, rcnt.getDecommissionCount());
+    // due to considerUnhealthy=false
+    assertEquals(0, rcnt.getDecommissionCount());
 
     // Now, test by considering UNHEALTHY replicas
     rcnt = new RatisContainerReplicaCount(container, replicas,
@@ -533,8 +533,9 @@ class TestRatisContainerReplicaCount {
     assertEquals(1, rcnt.getMisMatchedReplicaCount());
     // CLOSED + CLOSED = 2
     assertEquals(2, rcnt.getMatchingReplicaCount());
-    // UNHEALTHY decommissioned is counted as unhealthy, too
+    // UNHEALTHY decommissioned is counted as unhealthy
     assertEquals(1, rcnt.getUnhealthyReplicaCount());
+    // due to considerUnhealthy=true
     assertEquals(1, rcnt.getDecommissionCount());
   }
 

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/scm/node/TestDecommissionAndMaintenance.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/scm/node/TestDecommissionAndMaintenance.java
@@ -140,7 +140,6 @@ public class TestDecommissionAndMaintenance {
     replicationConf.setInterval(Duration.ofSeconds(1));
     replicationConf.setUnderReplicatedInterval(Duration.ofSeconds(1));
     replicationConf.setOverReplicatedInterval(Duration.ofSeconds(1));
-    replicationConf.setEnableLegacy(true); // disable as part of HDDS-8459
     conf.setFromObject(replicationConf);
 
     MiniOzoneCluster.Builder builder = MiniOzoneCluster.newBuilder(conf)


### PR DESCRIPTION
## What changes were proposed in this pull request?

`TestDecommissionAndMaintenance#testContainerIsReplicatedWhenAllNodesGotoMaintenance` fails with the new replication manager (i.e. if legacy is disabled).  If all replicas are starting maintenance, underreplication is not fixed.  `RatisReplicationCheckHandler` skips because there are no healthy replicas, and `RatisUnhealthyReplicationCheckHandler` skips because neither are there any unhealthy ones.  Decommissioning and maintenance replicas are counted separately, and we lose the information regarding their health.

This change fixes the problem by counting healthy/unhealthy decom/maint replicas separately, and including them in total healthy/unhealthy counts (`getHealthyReplicaCount()` and `getUnhealthyReplicaCount()`).

It also includes some refactoring as separate commits, reducing code duplication and duplicate calculation of some values.

https://issues.apache.org/jira/browse/HDDS-8616

## How was this patch tested?

New unit test is added to reproduce the problem.  

Legacy replication manager in `TestDecommissionAndMaintenance` is disabled, since it now passes with the new one.

CI:
https://github.com/adoroszlai/hadoop-ozone/actions/runs/4972183233