### PR TITLE
HDDS-8626. Config thread pool in ReplicationServer

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/replication/ReplicationServer.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/replication/ReplicationServer.java
@@ -22,6 +22,7 @@ import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import org.apache.hadoop.hdds.conf.Config;
 import org.apache.hadoop.hdds.conf.ConfigGroup;
 import org.apache.hadoop.hdds.conf.ConfigType;
@@ -32,7 +33,6 @@ import org.apache.hadoop.hdds.tracing.GrpcServerInterceptor;
 import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.hadoop.ozone.container.ozoneimpl.ContainerController;
 
-import org.apache.ratis.thirdparty.com.google.common.util.concurrent.ThreadFactoryBuilder;
 import org.apache.ratis.thirdparty.io.grpc.Server;
 import org.apache.ratis.thirdparty.io.grpc.ServerInterceptors;
 import org.apache.ratis.thirdparty.io.grpc.netty.GrpcSslContexts;

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/replication/ReplicationServer.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/replication/ReplicationServer.java
@@ -77,7 +77,7 @@ public class ReplicationServer {
     this.port = replicationConfig.getPort();
 
     int replicationServerWorkers =
-        replicationConfig.getReplicationServerWorkers();
+        replicationConfig.getReplicationMaxStreams();
     this.executor =
         new ThreadPoolExecutor(replicationServerWorkers,
             replicationServerWorkers,
@@ -193,20 +193,6 @@ public class ReplicationServer {
             "executor pool size."
     )
     private double outOfServiceFactor = OUTOFSERVICE_FACTOR_DEFAULT;
-
-    @Config(key = "server.workers", defaultValue = "10", description = "server workers.", tags = {
-        DATANODE, MANAGEMENT})
-    private int replicationServerWorkers;
-
-    public int getReplicationServerWorkers() {
-      return replicationServerWorkers;
-    }
-
-    public ReplicationConfig setReplicationServerWorkers(
-        int replicationServerWorkers) {
-      this.replicationServerWorkers = replicationServerWorkers;
-      return this;
-    }
 
     public double getOutOfServiceFactor() {
       return outOfServiceFactor;


### PR DESCRIPTION
## What changes were proposed in this pull request?

A separate thread pool is used for processing replication server grpc requests. If no thread pool is set, the default thread pool is used, which is now also used by raft GRPC in ratis

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-8626

