### PR TITLE
HDDS-8637. Add a null check for KeyValueContainerData#setSchemaVersion

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/KeyValueContainerData.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/KeyValueContainerData.java
@@ -130,7 +130,11 @@ public class KeyValueContainerData extends ContainerData {
    * container's database.
    */
   public void setSchemaVersion(String version) {
-    schemaVersion = version;
+    if (version == null) {
+      schemaVersion = OzoneConsts.SCHEMA_V1;
+    } else {
+      schemaVersion = version;
+    }
   }
 
   /**


### PR DESCRIPTION
## What changes were proposed in this pull request?
I've found a NullPointerException while replicating V1 containers in Ozone 1.3.0. V1 containers do not have the schemaVersion field in the .container file, so that's why the cause of the exception.
Forward compatibility for handling V1 container schema was discussed at HDDS-3869: https://github.com/apache/ozone/pull/1298/files#r476042841 https://github.com/apache/ozone/pull/1298#discussion_r485223401.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-8637

## How was this patch tested?
will be checked by CI triggers
