### PR TITLE
HDDS-8502. Recon - getContainers API is not giving expected response with prevKey.

### DIFF
--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/api/ContainerEndpoint.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/api/ContainerEndpoint.java
@@ -145,7 +145,7 @@ public class ContainerEndpoint {
     List<ContainerMetadata> containerMetaDataList =
         // Get the containers starting from the prevKey+1 which will skip the
         // container having prevKey ID
-        containerManager.getContainers(ContainerID.valueOf(prevKey+1), limit)
+        containerManager.getContainers(ContainerID.valueOf(prevKey + 1), limit)
             .stream()
             .map(container -> {
               ContainerMetadata containerMetadata =

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/api/ContainerEndpoint.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/api/ContainerEndpoint.java
@@ -140,18 +140,13 @@ public class ContainerEndpoint {
       // Send back an empty response
       return Response.status(Response.Status.NOT_ACCEPTABLE).build();
     }
-    if (prevKey > 0) {
-      // Increase the limit by 1 to fetch one additional container
-      // since we are excluding the container with the same ID as prevKey
-      limit = limit + 1;
-    }
 
     long containersCount;
     List<ContainerMetadata> containerMetaDataList =
-        containerManager.getContainers(ContainerID.valueOf(prevKey), limit)
+        // Get the containers starting from the prevKey+1 which will skip the
+        // container having prevKey ID
+        containerManager.getContainers(ContainerID.valueOf(prevKey+1), limit)
             .stream()
-            // Exclude the container with the same ID as prevKey
-            .filter(container -> container.getContainerID() != prevKey)
             .map(container -> {
               ContainerMetadata containerMetadata =
                   new ContainerMetadata(container.getContainerID());

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/api/types/ContainersResponse.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/api/types/ContainersResponse.java
@@ -32,13 +32,14 @@ public class ContainersResponse {
   private ContainersResponseData containersResponseData;
 
   public ContainersResponse() {
-    this(0, new ArrayList<>());
+    this(0, new ArrayList<>(), 0);
   }
 
   public ContainersResponse(long totalCount,
-                            Collection<ContainerMetadata> containers) {
+                            Collection<ContainerMetadata> containers,
+                            long prevKey) {
     this.containersResponseData =
-        new ContainersResponseData(totalCount, containers);
+        new ContainersResponseData(totalCount, containers, prevKey);
   }
 
   public ContainersResponseData getContainersResponseData() {
@@ -61,15 +62,23 @@ public class ContainersResponse {
     private long totalCount;
 
     /**
+     * prevKey will be the last key of the previous page.
+     */
+    @JsonProperty("prevKey")
+    private long prevKey;
+
+    /**
      * An array of containers.
      */
     @JsonProperty("containers")
     private Collection<ContainerMetadata> containers;
 
     ContainersResponseData(long totalCount,
-                           Collection<ContainerMetadata> containers) {
+                           Collection<ContainerMetadata> containers,
+                           long prevKey) {
       this.totalCount = totalCount;
       this.containers = containers;
+      this.prevKey = prevKey;
     }
 
     public long getTotalCount() {
@@ -78,6 +87,10 @@ public class ContainersResponse {
 
     public Collection<ContainerMetadata> getContainers() {
       return containers;
+    }
+
+    public long getPrevKey() {
+      return prevKey;
     }
   }
 }

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/api/TestContainerEndpoint.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/api/TestContainerEndpoint.java
@@ -611,6 +611,19 @@ public class TestContainerEndpoint {
     // The results will be limited to 2 containers only
     assertEquals(2, containers.size());
     assertEquals(2, data.getTotalCount());
+
+    // test if prevKey parameter in containerResponse works as expected
+    response = containerEndpoint.getContainers(5, 0L);
+    responseObject = (ContainersResponse) response.getEntity();
+    data = responseObject.getContainersResponseData();
+    containers = new ArrayList<>(data.getContainers());
+    // The results will be limited to 5 containers only
+    // Get the last container ID from the List
+    long expectedLastContainerID =
+        containers.get(containers.size() - 1).getContainerID();
+    long actualLastContainerID = data.getPrevKey();
+    // test if prev-key param works as expected
+    assertEquals(expectedLastContainerID, actualLastContainerID);
   }
 
   @Test
@@ -629,8 +642,9 @@ public class TestContainerEndpoint {
 
     ContainersResponse.ContainersResponseData data =
         responseObject.getContainersResponseData();
-    // Ensure that the total count of containers is 4
-    assertEquals(4, data.getTotalCount());
+    // Ensure that the total count of containers is 3 as containers having
+    // ID's 1,2, will be skipped and the next 3 containers will be returned
+    assertEquals(3, data.getTotalCount());
 
     List<ContainerMetadata> containers = new ArrayList<>(data.getContainers());
 
@@ -638,10 +652,10 @@ public class TestContainerEndpoint {
 
     ContainerMetadata containerMetadata = iterator.next();
 
-    // Ensure that the containers list size is 4
-    assertEquals(4, containers.size());
-    // Ensure that the first container ID is 2
-    assertEquals(2L, containerMetadata.getContainerID());
+    // Ensure that the containers list size is 3
+    assertEquals(3, containers.size());
+    // Ensure that the first container ID is 3
+    assertEquals(3L, containerMetadata.getContainerID());
 
     // test for negative cases
     response = containerEndpoint.getContainers(-1, 0L);

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/api/TestContainerEndpoint.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/api/TestContainerEndpoint.java
@@ -612,7 +612,8 @@ public class TestContainerEndpoint {
     assertEquals(2, containers.size());
     assertEquals(2, data.getTotalCount());
 
-    // test if prevKey parameter in containerResponse works as expected
+    // test if prevKey parameter in containerResponse works as expected for
+    // sequential container Ids
     response = containerEndpoint.getContainers(5, 0L);
     responseObject = (ContainersResponse) response.getEntity();
     data = responseObject.getContainersResponseData();
@@ -621,8 +622,29 @@ public class TestContainerEndpoint {
     // Get the last container ID from the List
     long expectedLastContainerID =
         containers.get(containers.size() - 1).getContainerID();
+    // Get the last container ID from the response
     long actualLastContainerID = data.getPrevKey();
     // test if prev-key param works as expected
+    assertEquals(expectedLastContainerID, actualLastContainerID);
+
+    // test if prevKey/lastContainerID object in containerResponse works
+    // as expected for non-sequential container Ids
+    for (int i = 10; i <= 50; i += 10) {
+      final ContainerInfo info = newContainerInfo(i);
+      reconContainerManager.addNewContainer(
+          new ContainerWithPipeline(info, pipeline));
+    }
+
+    response = containerEndpoint.getContainers(10, 0L);
+    responseObject = (ContainersResponse) response.getEntity();
+    data = responseObject.getContainersResponseData();
+    containers = new ArrayList<>(data.getContainers());
+    // The results will be limited to 10 containers only
+    // Get the last container ID from the List
+    expectedLastContainerID =
+        containers.get(containers.size() - 1).getContainerID();
+    // Get the last container ID from the Response
+    actualLastContainerID = data.getPrevKey();
     assertEquals(expectedLastContainerID, actualLastContainerID);
   }
 
@@ -656,6 +678,13 @@ public class TestContainerEndpoint {
     assertEquals(3, containers.size());
     // Ensure that the first container ID is 3
     assertEquals(3L, containerMetadata.getContainerID());
+
+    // test if prevKey/lastContainerID object in containerResponse works as
+    // expected when both limit and prevKey parameters are provided to method
+    long expectedLastContainerID =
+        containers.get(containers.size() - 1).getContainerID();
+    long actualLastContainerID = data.getPrevKey();
+    assertEquals(expectedLastContainerID, actualLastContainerID);
 
     // test for negative cases
     response = containerEndpoint.getContainers(-1, 0L);


### PR DESCRIPTION
## What changes were proposed in this pull request?

The `getContainers()` method in the container Endpoint has been modified to exclude the container specified by the `prevKey` parameter from the list of containers in the `ContainerResponse`. 

The getContainers() method changes ensure that:

1. **Skipping the container with the same ID as prevKey**: The container stream is filtered to exclude the container matching prevKey, ensuring it is not included in the results.

2. **To increase the prevKey by 1**: We simply add 1 to the current value of prevKey. This is because the container IDs are arranged in ascending order. By doing this, we remove the first container from the list, which corresponds to the container with a Container ID equal to prevKey. As a result, this prevents that particular container from appearing in the API response.

3. **Providing the last container ID in container API Response**: The last container ID is determined based on the fetched container metadata. If no containers were fetched, last container ID is set to prevKey. Otherwise, it is obtained from the ID of the last container in the list. This information enables pagination and using the last container ID as the new prevKey value for subsequent requests.
## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-8502

## How was this patch tested?

- Modified the Existing Unit Tests to test out the imrpovements 
- Manual Testing :- 
```
// JSON response with prevKey=2 

{
  "data": {
    "totalCount": 4,
    "prevKey": 6,
    "containers": [
      {
        "ContainerID": 3,
        "NumberOfKeys": 27,
        "pipelines": null
      },
      {
        "ContainerID": 4,
        "NumberOfKeys": 29,
        "pipelines": null
      },
      {
        "ContainerID": 5,
        "NumberOfKeys": 26,
        "pipelines": null
      },
      {
        "ContainerID": 6,
        "NumberOfKeys": 28,
        "pipelines": null
      },
    ]
  }
}

```

