### PR TITLE
HDDS-8639. Clean up OzoneOutputStream and the related code.

### DIFF
--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/io/KeyDataStreamOutput.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/io/KeyDataStreamOutput.java
@@ -20,7 +20,6 @@ package org.apache.hadoop.ozone.client.io;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import org.apache.hadoop.fs.FSExceptionMessages;
-import org.apache.hadoop.fs.FileEncryptionInfo;
 import org.apache.hadoop.hdds.client.ReplicationConfig;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
 import org.apache.hadoop.hdds.scm.OzoneClientConfig;
@@ -69,7 +68,6 @@ public class KeyDataStreamOutput extends AbstractDataStreamOutput {
       LoggerFactory.getLogger(KeyDataStreamOutput.class);
 
   private boolean closed;
-  private FileEncryptionInfo feInfo;
 
   // how much of data is actually written yet to underlying stream
   private long offset;
@@ -127,7 +125,6 @@ public class KeyDataStreamOutput extends AbstractDataStreamOutput {
 
     // Retrieve the file encryption key info, null if file is not in
     // encrypted bucket.
-    this.feInfo = info.getFileEncryptionInfo();
     this.writeOffset = 0;
     this.clientID = handler.getId();
   }
@@ -395,10 +392,6 @@ public class KeyDataStreamOutput extends AbstractDataStreamOutput {
 
   public OmMultipartCommitUploadPartInfo getCommitUploadPartInfo() {
     return blockDataStreamOutputEntryPool.getCommitUploadPartInfo();
-  }
-
-  public FileEncryptionInfo getFileEncryptionInfo() {
-    return feInfo;
   }
 
   @VisibleForTesting

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/io/OzoneOutputStream.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/io/OzoneOutputStream.java
@@ -23,6 +23,8 @@ import org.apache.hadoop.ozone.om.helpers.OmMultipartCommitUploadPartInfo;
 
 import java.io.IOException;
 import java.io.OutputStream;
+import java.util.Objects;
+import java.util.Optional;
 
 /**
  * OzoneOutputStream is used to write data into Ozone.
@@ -34,17 +36,34 @@ public class OzoneOutputStream extends OutputStream {
   private final Syncable syncable;
 
   /**
-   * Constructs OzoneOutputStream with KeyOutputStream.
+   * Constructs an instance with a {@link Syncable} {@link OutputStream}.
    *
-   * @param syncable
+   * @param outputStream an {@link OutputStream} which is {@link Syncable}.
    */
-  public OzoneOutputStream(Syncable syncable) {
-    this((OutputStream)syncable, syncable);
+  public OzoneOutputStream(Syncable outputStream) {
+    this(Optional.of(Objects.requireNonNull(outputStream,
+                "outputStream == null"))
+        .filter(s -> s instanceof OutputStream)
+        .map(s -> (OutputStream)s)
+        .orElseThrow(() -> new IllegalArgumentException(
+            "The parameter syncable is not an OutputStream")),
+        outputStream);
   }
 
+  /**
+   * Constructs an instance with a (non-{@link Syncable}) {@link OutputStream}
+   * with an optional {@link Syncable} object.
+   *
+   * @param outputStream for writing data.
+   * @param syncable an optional parameter
+   *                 for accessing the {@link Syncable} feature.
+   */
   public OzoneOutputStream(OutputStream outputStream, Syncable syncable) {
-    this.outputStream = outputStream;
-    this.syncable = syncable;
+    this.outputStream = Objects.requireNonNull(outputStream,
+        "outputStream == null");
+    this.syncable = syncable != null ? syncable
+        : outputStream instanceof Syncable ? (Syncable) outputStream
+        : null;
   }
 
   @Override
@@ -70,12 +89,10 @@ public class OzoneOutputStream extends OutputStream {
 
   public void hsync() throws IOException {
     if (syncable != null) {
-      if (outputStream != null && outputStream != syncable) {
+      if (outputStream != syncable) {
         outputStream.flush();
       }
       syncable.hsync();
-    } else if (outputStream instanceof Syncable) {
-      ((Syncable)outputStream).hsync();
     } else {
       throw new UnsupportedOperationException(outputStream.getClass()
           + " is not " + Syncable.class.getSimpleName());

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmKeyArgs.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmKeyArgs.java
@@ -22,6 +22,7 @@ import org.apache.hadoop.ozone.OzoneAcl;
 import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.hadoop.ozone.audit.Auditable;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.KeyArgs;
+import org.apache.hadoop.ozone.security.GDPRSymmetricKey;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.ArrayList;
@@ -288,6 +289,14 @@ public final class OmKeyArgs implements Auditable {
 
     public Builder addAllMetadata(Map<String, String> metadatamap) {
       this.metadata.putAll(metadatamap);
+      return this;
+    }
+
+    public Builder addAllMetadataGdpr(Map<String, String> metadatamap) {
+      addAllMetadata(metadatamap);
+      if (Boolean.parseBoolean(metadata.get(OzoneConsts.GDPR_FLAG))) {
+        GDPRSymmetricKey.newDefaultInstance().acceptKeyDetails(metadata::put);
+      }
       return this;
     }
 

--- a/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/security/TestGDPRSymmetricKey.java
+++ b/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/security/TestGDPRSymmetricKey.java
@@ -35,7 +35,7 @@ public class TestGDPRSymmetricKey {
     Assert.assertTrue(gkey.getCipher().getAlgorithm()
         .equalsIgnoreCase(OzoneConsts.GDPR_ALGORITHM_NAME));
 
-    gkey.getKeyDetails().forEach(
+    gkey.acceptKeyDetails(
         (k, v) -> Assert.assertTrue(v.length() > 0));
   }
 
@@ -48,22 +48,19 @@ public class TestGDPRSymmetricKey {
     Assert.assertTrue(gkey.getCipher().getAlgorithm()
         .equalsIgnoreCase(OzoneConsts.GDPR_ALGORITHM_NAME));
 
-    gkey.getKeyDetails().forEach(
+    gkey.acceptKeyDetails(
         (k, v) -> Assert.assertTrue(v.length() > 0));
   }
 
   @Test
   public void testKeyGenerationWithInvalidInput() throws Exception {
-    GDPRSymmetricKey gkey = null;
     try {
-      gkey = new GDPRSymmetricKey(RandomStringUtils.randomAlphabetic(5),
+      new GDPRSymmetricKey(RandomStringUtils.randomAlphabetic(5),
           OzoneConsts.GDPR_ALGORITHM_NAME);
+      Assert.fail("Expect length mismatched");
     } catch (IllegalArgumentException ex) {
       Assert.assertTrue(ex.getMessage()
           .equalsIgnoreCase("Secret must be exactly 16 characters"));
-      Assert.assertTrue(gkey == null);
     }
   }
-
-
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

- Check the parameters (null, class) in OzoneOutputStream constructors and don't have check it again in the code.
- Remove unused feInfo from KeyDataStreamOutput.
- Remove duplicated replicationConfig parameter from RpcClient.createDataStreamOutput(..).
- Add addAllMetadataGdpr to OmKeyArgs.Builder to take care GDPR_FLAG.
- Refactor GDPRSymmetricKey related code.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-8639

## How was this patch tested?

Modified TestGDPRSymmetricKey