### PR TITLE
HDDS-8642. TestContainerCommandsEC should close ECReconstructionCoordinator

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/storage/TestContainerCommandsEC.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/storage/TestContainerCommandsEC.java
@@ -341,9 +341,6 @@ public class TestContainerCommandsEC {
       }, 500, 30000);
     }
 
-    ECReconstructionCoordinator coordinator = new ECReconstructionCoordinator(
-        config, certClient, null, ECReconstructionMetrics.create());
-
     // Create a reconstruction command to create a new copy of indexes 4 and 5
     // which means 1 to 3 must be available. However we know the block
     // information is missing for index 2. As all containers in the stripe must
@@ -367,10 +364,15 @@ public class TestContainerCommandsEC {
       targetNodeMap.put(EC_DATA + j + 1, targets.get(j));
     }
 
-    // Attempt to reconstruct the container.
-    coordinator.reconstructECContainerGroup(orphanContainerID,
-        (ECReplicationConfig) repConfig,
-        sourceNodeMap, targetNodeMap);
+    try (ECReconstructionCoordinator coordinator =
+        new ECReconstructionCoordinator(config, certClient, null,
+            ECReconstructionMetrics.create())) {
+
+      // Attempt to reconstruct the container.
+      coordinator.reconstructECContainerGroup(orphanContainerID,
+          (ECReplicationConfig) repConfig,
+          sourceNodeMap, targetNodeMap);
+    }
 
     // Check the block listing for the recovered containers 4 or 5 and they
     // should be present but with no blocks as the only block in the container


### PR DESCRIPTION
## What changes were proposed in this pull request?

`ECReconstructionCoordinator` should be closed to avoid:

```
SEVERE: *~*~*~ Previous channel ManagedChannelImpl{logId=1375, target=10.1.1.154:15058} was not shutdown properly!!! ~*~*~*
    Make sure to call shutdown()/shutdownNow() and wait until awaitTermination() returns true.
java.lang.RuntimeException: ManagedChannel allocation site
	...
	at org.apache.hadoop.hdds.scm.XceiverClientGrpc.connectToDatanode(XceiverClientGrpc.java:188)
	...
	at org.apache.hadoop.hdds.scm.XceiverClientManager.getClient(XceiverClientManager.java:224)
	at org.apache.hadoop.hdds.scm.XceiverClientManager.acquireClient(XceiverClientManager.java:168)
	at org.apache.hadoop.hdds.scm.XceiverClientManager.acquireClient(XceiverClientManager.java:141)
	at org.apache.hadoop.ozone.container.ec.reconstruction.ECContainerOperationClient.listBlock(ECContainerOperationClient.java:84)
	at org.apache.hadoop.ozone.container.ec.reconstruction.ECReconstructionCoordinator.getBlockDataMap(ECReconstructionCoordinator.java:436)
	at org.apache.hadoop.ozone.container.ec.reconstruction.ECReconstructionCoordinator.reconstructECContainerGroup(ECReconstructionCoordinator.java:144)
	at org.apache.hadoop.hdds.scm.storage.TestContainerCommandsEC.testOrphanBlock(TestContainerCommandsEC.java:371)
```

https://issues.apache.org/jira/browse/HDDS-8642

## How was this patch tested?

Ran test locally few times, verified no warning related to shutdown.  (Test may intermittently fail due to HDDS-8476, though.)

https://github.com/adoroszlai/hadoop-ozone/actions/runs/5010672609