### PR TITLE
HDDS-8643. Support CodecBuffer for PipelineID codec.

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/pipeline/PipelineID.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/pipeline/PipelineID.java
@@ -20,6 +20,9 @@ package org.apache.hadoop.hdds.scm.pipeline;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
+import org.apache.hadoop.hdds.utils.db.Codec;
+import org.apache.hadoop.hdds.utils.db.DelegatedCodec;
+import org.apache.hadoop.hdds.utils.db.UuidCodec;
 
 import java.util.UUID;
 
@@ -27,8 +30,14 @@ import java.util.UUID;
  * ID for the pipeline, the ID is based on UUID.
  */
 public final class PipelineID {
+  private static final Codec<PipelineID> CODEC = new DelegatedCodec<>(
+      UuidCodec.get(), PipelineID::valueOf, c -> c.id, true);
 
-  private UUID id;
+  public static Codec<PipelineID> getCodec() {
+    return CODEC;
+  }
+
+  private final UUID id;
 
   private PipelineID(UUID id) {
     this.id = id;

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/pipeline/PipelineID.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/pipeline/PipelineID.java
@@ -28,6 +28,8 @@ import java.util.UUID;
 
 /**
  * ID for the pipeline, the ID is based on UUID.
+ * <p>
+ * This class is immutable.
  */
 public final class PipelineID {
   private static final Codec<PipelineID> CODEC = new DelegatedCodec<>(

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/utils/db/LongCodec.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/utils/db/LongCodec.java
@@ -33,6 +33,8 @@ public final class LongCodec implements Codec<Long> {
     return CODEC;
   }
 
+  private LongCodec() { }
+
   @Override
   public boolean supportCodecBuffer() {
     return true;

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/utils/db/LongCodec.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/utils/db/LongCodec.java
@@ -24,7 +24,7 @@ import javax.annotation.Nonnull;
 import java.util.function.IntFunction;
 
 /**
- * Codec to convert Long to/from byte array.
+ * Codec to serialize/deserialize {@link Long}.
  */
 public final class LongCodec implements Codec<Long> {
   private static final LongCodec CODEC = new LongCodec();

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/utils/db/UuidCodec.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/utils/db/UuidCodec.java
@@ -1,0 +1,86 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package org.apache.hadoop.hdds.utils.db;
+
+import javax.annotation.Nonnull;
+import java.nio.ByteBuffer;
+import java.util.UUID;
+import java.util.function.IntFunction;
+
+/**
+ * Codec to serialize/deserialize {@link UUID}.
+ */
+public final class UuidCodec implements Codec<UUID> {
+  private static final int SERIALIZED_SIZE = 16;
+
+  private static final UuidCodec CODEC = new UuidCodec();
+
+  public static UuidCodec get() {
+    return CODEC;
+  }
+
+  public static int getSerializedSize() {
+    return SERIALIZED_SIZE;
+  }
+
+  @Override
+  public boolean supportCodecBuffer() {
+    return true;
+  }
+
+  @Override
+  public CodecBuffer toCodecBuffer(@Nonnull UUID id,
+      IntFunction<CodecBuffer> allocator) {
+    return allocator.apply(SERIALIZED_SIZE)
+        .putLong(id.getMostSignificantBits())
+        .putLong(id.getLeastSignificantBits());
+  }
+
+  @Override
+  public UUID fromCodecBuffer(@Nonnull CodecBuffer buffer) {
+    return getUuid(buffer.asReadOnlyByteBuffer());
+  }
+
+  private static UUID getUuid(ByteBuffer buffer) {
+    return new UUID(buffer.getLong(), buffer.getLong());
+  }
+
+  @Override
+  public byte[] toPersistedFormat(UUID id) {
+    final byte[] array = new byte[SERIALIZED_SIZE];
+    final ByteBuffer buffer = ByteBuffer.wrap(array);
+    buffer.putLong(id.getMostSignificantBits());
+    buffer.putLong(id.getLeastSignificantBits());
+    return array;
+  }
+
+  @Override
+  public UUID fromPersistedFormat(byte[] array) {
+    if (array.length != SERIALIZED_SIZE) {
+      throw new IllegalArgumentException("Unexpected array length: "
+          + array.length + " != " + SERIALIZED_SIZE);
+    }
+    return getUuid(ByteBuffer.wrap(array));
+  }
+
+  @Override
+  public UUID copyObject(UUID object) {
+    return object;
+  }
+}

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/utils/db/UuidCodec.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/utils/db/UuidCodec.java
@@ -39,6 +39,8 @@ public final class UuidCodec implements Codec<UUID> {
     return SERIALIZED_SIZE;
   }
 
+  private UuidCodec() { }
+
   @Override
   public boolean supportCodecBuffer() {
     return true;

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/hdds/datanode/metadata/CRLDBDefinition.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/hdds/datanode/metadata/CRLDBDefinition.java
@@ -44,7 +44,7 @@ public class CRLDBDefinition implements DBDefinition {
       new DBColumnFamilyDefinition<>(
           "pendingCrls",
           Long.class,
-          new LongCodec(),
+          LongCodec.get(),
           CRLInfo.class,
           new CRLInfoCodec());
 
@@ -55,7 +55,7 @@ public class CRLDBDefinition implements DBDefinition {
           String.class,
           new StringCodec(),
           Long.class,
-          new LongCodec());
+          LongCodec.get());
 
   @Override
   public String getName() {

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/CodecRegistry.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/CodecRegistry.java
@@ -50,7 +50,7 @@ public final class CodecRegistry {
   public static Builder newBuilder() {
     return new Builder()
         .addCodec(String.class, new StringCodec())
-        .addCodec(Long.class, new LongCodec())
+        .addCodec(Long.class, LongCodec.get())
         .addCodec(Integer.class, new IntegerCodec())
         .addCodec(byte[].class, new ByteArrayCodec());
   }

--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/utils/db/TestCodec.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/utils/db/TestCodec.java
@@ -27,6 +27,7 @@ import org.apache.hadoop.hdds.utils.db.RDBBatchOperation.Bytes;
 import java.io.IOException;
 import java.lang.ref.WeakReference;
 import java.nio.ByteBuffer;
+import java.util.UUID;
 import java.util.concurrent.ThreadLocalRandom;
 
 /**
@@ -92,6 +93,20 @@ public final class TestCodec {
     for (int i = 0; i < NUM_LOOPS; i++) {
       final String original = "test" + ThreadLocalRandom.current().nextLong();
       runTest(codec, original, original.length());
+    }
+    gc();
+  }
+
+  @Test
+  public void testUuidCodec() throws Exception {
+    final int size = UuidCodec.getSerializedSize();
+    final UuidCodec codec = UuidCodec.get();
+    runTest(codec, new UUID(0L, 0L), size);
+    runTest(codec, new UUID(-1L, -1L), size);
+
+    for (int i = 0; i < NUM_LOOPS; i++) {
+      final UUID original = UUID.randomUUID();
+      runTest(codec, original, size);
     }
     gc();
   }

--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/utils/db/TestCodec.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/utils/db/TestCodec.java
@@ -71,7 +71,7 @@ public final class TestCodec {
 
   @Test
   public void testLongCodec() throws Exception {
-    final LongCodec codec = new LongCodec();
+    final LongCodec codec = LongCodec.get();
     runTest(codec, 0L, Long.BYTES);
     runTest(codec, 1L, Long.BYTES);
     runTest(codec, -1L, Long.BYTES);

--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/utils/db/TestDBStoreBuilder.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/utils/db/TestDBStoreBuilder.java
@@ -176,7 +176,7 @@ public class TestDBStoreBuilder {
 
       private final DBColumnFamilyDefinition<String, Long> sampleTable =
           new DBColumnFamilyDefinition<>(sampleTableName,
-              String.class, new StringCodec(), Long.class, new LongCodec());
+              String.class, new StringCodec(), Long.class, LongCodec.get());
       {
         ManagedColumnFamilyOptions cfOptions = new ManagedColumnFamilyOptions();
         // reverse the default option for check
@@ -253,7 +253,7 @@ public class TestDBStoreBuilder {
 
       private final DBColumnFamilyDefinition<String, Long> sampleTable =
               new DBColumnFamilyDefinition<>(sampleTableName, String.class,
-                      new StringCodec(), Long.class, new LongCodec());
+                      new StringCodec(), Long.class, LongCodec.get());
 
 
       @Override

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/metadata/SCMDBDefinition.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/metadata/SCMDBDefinition.java
@@ -98,7 +98,7 @@ public class SCMDBDefinition implements DBDefinition {
       new DBColumnFamilyDefinition<>(
           "pipelines",
           PipelineID.class,
-          new PipelineIDCodec(),
+          PipelineID.getCodec(),
           Pipeline.class,
           new PipelineCodec());
 

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/metadata/SCMDBDefinition.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/metadata/SCMDBDefinition.java
@@ -49,7 +49,7 @@ public class SCMDBDefinition implements DBDefinition {
       new DBColumnFamilyDefinition<>(
           "deletedBlocks",
           Long.class,
-          new LongCodec(),
+          LongCodec.get(),
           DeletedBlocksTransaction.class,
           new DeletedBlocksTransactionCodec());
 
@@ -124,7 +124,7 @@ public class SCMDBDefinition implements DBDefinition {
       new DBColumnFamilyDefinition<>(
           "crls",
           Long.class,
-          new LongCodec(),
+          LongCodec.get(),
           CRLInfo.class,
           new CRLInfoCodec());
 
@@ -135,7 +135,7 @@ public class SCMDBDefinition implements DBDefinition {
           String.class,
           new StringCodec(),
           Long.class,
-          new LongCodec());
+          LongCodec.get());
 
   public static final DBColumnFamilyDefinition<String, Long>
       SEQUENCE_ID =
@@ -144,7 +144,7 @@ public class SCMDBDefinition implements DBDefinition {
           String.class,
           new StringCodec(),
           Long.class,
-          new LongCodec());
+          LongCodec.get());
 
   public static final DBColumnFamilyDefinition<ContainerID,
       MoveDataNodePair>

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/metadata/OldPipelineIDCodecForTesting.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/metadata/OldPipelineIDCodecForTesting.java
@@ -29,7 +29,7 @@ import org.apache.hadoop.hdds.utils.db.Codec;
 /**
  * Codec to serialize / deserialize PipelineID.
  */
-public class PipelineIDCodec implements Codec<PipelineID> {
+public class OldPipelineIDCodecForTesting implements Codec<PipelineID> {
 
   @Override
   public byte[] toPersistedFormat(PipelineID object) throws IOException {

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/metadata/TestPipelineIDCodec.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/metadata/TestPipelineIDCodec.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -95,12 +95,7 @@ public class TestPipelineIDCodec {
     long mostSigBits = 0x0000_0000_0000_0000L;
     long leastSigBits = 0x0000_0000_0000_0000L;
     UUID uuid = new UUID(mostSigBits, leastSigBits);
-    PipelineID pid = PipelineID.valueOf(uuid);
-
-    byte[] encoded = new PipelineIDCodec().toPersistedFormat(pid);
-    PipelineID decoded = new PipelineIDCodec().fromPersistedFormat(encoded);
-
-    assertEquals(pid, decoded);
+    assertUuid(uuid);
   }
 
   @Test
@@ -108,23 +103,27 @@ public class TestPipelineIDCodec {
     long mostSigBits = 0xFFFF_FFFF_FFFF_FFFFL;
     long leastSigBits = 0xFFFF_FFFF_FFFF_FFFFL;
     UUID uuid = new UUID(mostSigBits, leastSigBits);
-    PipelineID pid = PipelineID.valueOf(uuid);
-
-    byte[] encoded = new PipelineIDCodec().toPersistedFormat(pid);
-    PipelineID decoded = new PipelineIDCodec().fromPersistedFormat(encoded);
-
-    assertEquals(pid, decoded);
+    assertUuid(uuid);
   }
 
   @Test
   public void testConvertAndReadBackRandomUUID() throws Exception {
     UUID uuid = UUID.randomUUID();
+    assertUuid(uuid);
+  }
+
+  static void assertUuid(UUID uuid) throws Exception {
     PipelineID pid = PipelineID.valueOf(uuid);
 
-    byte[] encoded = new PipelineIDCodec().toPersistedFormat(pid);
-    PipelineID decoded = new PipelineIDCodec().fromPersistedFormat(encoded);
+    final byte[] expected = new OldPipelineIDCodecForTesting()
+        .toPersistedFormat(pid);
+    final byte[] computed = PipelineID.getCodec().toPersistedFormat(pid);
+    assertArrayEquals(expected, computed);
 
+    final PipelineID decoded = new OldPipelineIDCodecForTesting()
+        .fromPersistedFormat(expected);
     assertEquals(pid, decoded);
+    assertEquals(pid, PipelineID.getCodec().fromPersistedFormat(expected));
   }
 
   private void checkPersisting(
@@ -133,9 +132,11 @@ public class TestPipelineIDCodec {
     UUID uuid = new UUID(mostSigBits, leastSigBits);
     PipelineID pid = PipelineID.valueOf(uuid);
 
-    byte[] encoded = new PipelineIDCodec().toPersistedFormat(pid);
-
+    byte[] encoded = new OldPipelineIDCodecForTesting().toPersistedFormat(pid);
     assertArrayEquals(expected, encoded);
+
+    final byte[] computed = PipelineID.getCodec().toPersistedFormat(pid);
+    assertArrayEquals(expected, computed);
   }
 
   private byte b(int i) {

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/codec/OMDBDefinition.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/codec/OMDBDefinition.java
@@ -129,7 +129,7 @@ public class OMDBDefinition implements DBDefinition {
                     OzoneTokenIdentifier.class,
                     new TokenIdentifierCodec(),
                     Long.class,
-                    new LongCodec());
+                    LongCodec.get());
 
   public static final DBColumnFamilyDefinition<String, S3SecretValue>
             S3_SECRET_TABLE =

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/codec/NSSummaryCodec.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/codec/NSSummaryCodec.java
@@ -41,7 +41,7 @@ public class NSSummaryCodec implements Codec<NSSummary> {
 
   private final Codec<Integer> integerCodec = new IntegerCodec();
   private final Codec<Short> shortCodec = new ShortCodec();
-  private final Codec<Long> longCodec = new LongCodec();
+  private final Codec<Long> longCodec = LongCodec.get();
   private final Codec<String> stringCodec = new StringCodec();
   // 1 int fields + 41-length int array
   // + 2 dummy field to track list size/dirName length

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/spi/impl/ReconDBDefinition.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/spi/impl/ReconDBDefinition.java
@@ -63,16 +63,16 @@ public class ReconDBDefinition implements DBDefinition {
       new DBColumnFamilyDefinition<>(
           "containerKeyCountTable",
           Long.class,
-          new LongCodec(),
+          LongCodec.get(),
           Long.class,
-          new LongCodec());
+          LongCodec.get());
 
   public static final DBColumnFamilyDefinition
       <Long, ContainerReplicaHistoryList> REPLICA_HISTORY =
       new DBColumnFamilyDefinition<Long, ContainerReplicaHistoryList>(
           "replica_history",
           Long.class,
-          new LongCodec(),
+          LongCodec.get(),
           ContainerReplicaHistoryList.class,
           new ContainerReplicaHistoryListCodec());
 
@@ -80,7 +80,7 @@ public class ReconDBDefinition implements DBDefinition {
       NAMESPACE_SUMMARY = new DBColumnFamilyDefinition<Long, NSSummary>(
           "namespaceSummaryTable",
           Long.class,
-          new LongCodec(),
+          LongCodec.get(),
           NSSummary.class,
           new NSSummaryCodec());
 
@@ -90,7 +90,7 @@ public class ReconDBDefinition implements DBDefinition {
       new DBColumnFamilyDefinition<Long, ContainerReplicaHistoryList>(
           "replica_history_v2",
           Long.class,
-          new LongCodec(),
+          LongCodec.get(),
           ContainerReplicaHistoryList.class,
           new ContainerReplicaHistoryListCodec());
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

PipelineID only has a UUID field. We will add a UuidCodec and then use DelegatedCodec to support CodecBuffer for PipelineID codec.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-8643

## How was this patch tested?

Add new tests.