### PR TITLE
HDDS-8638. Support CryptoOutputStream and CipherOutputStream in createStreamKey

### DIFF
--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/storage/AbstractDataStreamOutput.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/storage/AbstractDataStreamOutput.java
@@ -18,11 +18,11 @@
 
 package org.apache.hadoop.hdds.scm.storage;
 
-import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import org.apache.hadoop.hdds.scm.client.HddsClientUtils;
 import org.apache.hadoop.hdds.scm.container.common.helpers.StorageContainerException;
 import org.apache.hadoop.io.retry.RetryPolicy;
+import org.apache.hadoop.ozone.client.io.ByteBufferOutputStream;
 import org.apache.ratis.protocol.exceptions.AlreadyClosedException;
 import org.apache.ratis.protocol.exceptions.RaftRetryFailureException;
 
@@ -35,7 +35,7 @@ import java.util.Objects;
  * This class is used for error handling methods.
  */
 public abstract class AbstractDataStreamOutput
-    implements ByteBufferStreamOutput {
+    extends ByteBufferOutputStream {
 
   private final Map<Class<? extends Throwable>, RetryPolicy> retryPolicyMap;
   private int retryCount;
@@ -46,11 +46,6 @@ public abstract class AbstractDataStreamOutput
     this.retryPolicyMap = retryPolicyMap;
     this.isException = false;
     this.retryCount = 0;
-  }
-
-  @VisibleForTesting
-  public int getRetryCount() {
-    return retryCount;
   }
 
   protected void resetRetryCount() {

--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/storage/ByteBufferStreamOutput.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/storage/ByteBufferStreamOutput.java
@@ -23,33 +23,35 @@ import java.io.IOException;
 import java.nio.ByteBuffer;
 
 /**
-* This interface is for writing an output stream of ByteBuffers.
-* An ByteBufferStreamOutput accepts nio ByteBuffer and sends them to some sink.
-*/
+ * This interface is similar to {@link java.io.OutputStream}
+ * except that this class support {@link ByteBuffer} instead of byte[].
+ */
 public interface ByteBufferStreamOutput extends Closeable {
   /**
-   * Try to write all the bytes in ByteBuf b to DataStream.
+   * Similar to {@link java.io.OutputStream#write(byte[])},
+   * except that the parameter of this method is a {@link ByteBuffer}.
    *
-   * @param b the data.
+   * @param buffer the buffer containing data to be written.
    * @exception IOException if an I/O error occurs.
    */
-  default void write(ByteBuffer b) throws IOException {
+  default void write(ByteBuffer buffer) throws IOException {
+    final ByteBuffer b = buffer.asReadOnlyBuffer();
     write(b, b.position(), b.remaining());
   }
 
   /**
-   * Try to write the [off:off + len) slice in ByteBuf b to DataStream.
+   * Similar to {@link java.io.OutputStream#write(byte[], int, int)},
+   * except that the parameter of this method is a {@link ByteBuffer}.
    *
-   * @param b the data.
-   * @param off the start offset in the data.
+   * @param buffer the buffer containing data to be written.
+   * @param off the start offset.
    * @param len the number of bytes to write.
    * @exception  IOException  if an I/O error occurs.
    */
-  void write(ByteBuffer b, int off, int len) throws IOException;
+  void write(ByteBuffer buffer, int off, int len) throws IOException;
 
   /**
-   * Flushes this DataStream output and forces any buffered output bytes
-   * to be written out.
+   * Flush this output and force any buffered output bytes to be written out.
    *
    * @exception  IOException  if an I/O error occurs.
    */

--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/ozone/client/io/ByteArrayStreamOutput.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/ozone/client/io/ByteArrayStreamOutput.java
@@ -38,12 +38,14 @@ public abstract class ByteArrayStreamOutput extends OutputStream
   @Override
   public void write(ByteBuffer buffer, int off, int len) throws IOException {
     if (len == 0) {
-      // noop, avoid creating an array
-    } else if (buffer.hasArray()) {
+      return;
+    }
+
+    if (buffer.hasArray()) {
       write(buffer.array(), off, len);
     } else {
       final byte[] array = new byte[Math.min(ARRAY_SIZE_LIMIT, len)];
-      for (; len > 0; ) {
+      for (; len > 0;) {
         final ByteBuffer readonly = buffer.asReadOnlyBuffer();
         final int writeSize = Math.min(array.length, len);
         readonly.position(off);

--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/ozone/client/io/ByteArrayStreamOutput.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/ozone/client/io/ByteArrayStreamOutput.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.apache.hadoop.ozone.client.io;
+
+import org.apache.hadoop.hdds.scm.storage.ByteBufferStreamOutput;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.ByteBuffer;
+
+/**
+ * An {@link OutputStream} supporting {@link ByteBufferStreamOutput}.
+ * The subclass classes of this class must implement and optimize
+ * the {@link OutputStream#write(byte[], int, int)} method
+ * and optionally override
+ * the {@link ByteBufferStreamOutput#write(ByteBuffer, int, int)} method.
+ */
+public abstract class ByteArrayStreamOutput extends OutputStream
+    implements ByteBufferStreamOutput {
+  @Override
+  public void write(ByteBuffer buffer, int off, int len) throws IOException {
+    if (buffer.hasArray()) {
+      write(buffer.array(), off, len);
+    } else {
+      final byte[] array = new byte[len];
+      final ByteBuffer readonly = buffer.asReadOnlyBuffer();
+      readonly.position(off).limit(off + len);
+      readonly.get(array);
+      write(array);
+    }
+  }
+
+  @Override
+  public void write(int b) throws IOException {
+    write(new byte[]{(byte) b});
+  }
+}

--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/ozone/client/io/ByteBufferOutputStream.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/ozone/client/io/ByteBufferOutputStream.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.apache.hadoop.ozone.client.io;
+
+import org.apache.hadoop.hdds.scm.storage.ByteBufferStreamOutput;
+
+import javax.annotation.Nonnull;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.ByteBuffer;
+
+/**
+ * A {@link ByteBufferStreamOutput} supporting {@link OutputStream}.
+ * The subclass classes of this class must implement and optimize
+ * the {@link ByteBufferStreamOutput#write(ByteBuffer, int, int)} method
+ * and optionally override
+ * the {@link OutputStream#write(byte[], int, int)} method.
+ */
+public abstract class ByteBufferOutputStream extends OutputStream
+    implements ByteBufferStreamOutput {
+  @Override
+  public void write(@Nonnull byte[] byteArray) throws IOException {
+    write(ByteBuffer.wrap(byteArray));
+  }
+
+  @Override
+  public void write(int b) throws IOException {
+    write(new byte[]{(byte) b});
+  }
+}

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/io/KeyDataStreamOutput.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/io/KeyDataStreamOutput.java
@@ -43,6 +43,7 @@ import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.Collection;
 import java.util.List;
+import java.util.UUID;
 
 /**
  * Maintaining a list of BlockInputStream. Write based on offset.
@@ -407,7 +408,7 @@ public class KeyDataStreamOutput extends AbstractDataStreamOutput {
     private XceiverClientFactory xceiverManager;
     private OzoneManagerProtocol omClient;
     private int chunkSize;
-    private String requestID;
+    private final String requestID = UUID.randomUUID().toString();
     private String multipartUploadID;
     private int multipartNumber;
     private boolean isMultipartKey;
@@ -442,11 +443,6 @@ public class KeyDataStreamOutput extends AbstractDataStreamOutput {
 
     public Builder setChunkSize(int size) {
       this.chunkSize = size;
-      return this;
-    }
-
-    public Builder setRequestID(String id) {
-      this.requestID = id;
       return this;
     }
 

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/io/KeyOutputStream.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/io/KeyOutputStream.java
@@ -23,6 +23,7 @@ import java.io.OutputStream;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
@@ -93,8 +94,6 @@ public class KeyOutputStream extends OutputStream implements Syncable {
 
   private long clientID;
 
-  private OzoneManagerProtocol omClient;
-
   public KeyOutputStream(ReplicationConfig replicationConfig,
       ContainerClientMetrics clientMetrics) {
     this.replication = replicationConfig;
@@ -138,7 +137,7 @@ public class KeyOutputStream extends OutputStream implements Syncable {
       OzoneClientConfig config,
       OpenKeySession handler,
       XceiverClientFactory xceiverClientManager,
-      OzoneManagerProtocol omClient, int chunkSize,
+      OzoneManagerProtocol omClient,
       String requestId, ReplicationConfig replicationConfig,
       String uploadID, int partNumber, boolean isMultipart,
       boolean unsafeByteBufferConversion,
@@ -163,7 +162,6 @@ public class KeyOutputStream extends OutputStream implements Syncable {
     this.isException = false;
     this.writeOffset = 0;
     this.clientID = handler.getId();
-    this.omClient = omClient;
   }
 
   /**
@@ -579,8 +577,7 @@ public class KeyOutputStream extends OutputStream implements Syncable {
     private OpenKeySession openHandler;
     private XceiverClientFactory xceiverManager;
     private OzoneManagerProtocol omClient;
-    private int chunkSize;
-    private String requestID;
+    private final String requestID = UUID.randomUUID().toString();
     private String multipartUploadID;
     private int multipartNumber;
     private boolean isMultipartKey;
@@ -634,22 +631,8 @@ public class KeyOutputStream extends OutputStream implements Syncable {
       return this;
     }
 
-    public int getChunkSize() {
-      return chunkSize;
-    }
-
-    public Builder setChunkSize(int size) {
-      this.chunkSize = size;
-      return this;
-    }
-
     public String getRequestID() {
       return requestID;
-    }
-
-    public Builder setRequestID(String id) {
-      this.requestID = id;
-      return this;
     }
 
     public boolean isMultipartKey() {
@@ -703,7 +686,6 @@ public class KeyOutputStream extends OutputStream implements Syncable {
           openHandler,
           xceiverManager,
           omClient,
-          chunkSize,
           requestID,
           replicationConfig,
           multipartUploadID,

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/io/OzoneDataStreamOutput.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/io/OzoneDataStreamOutput.java
@@ -24,9 +24,8 @@ import java.nio.ByteBuffer;
 
 /**
  * OzoneDataStreamOutput is used to write data into Ozone.
- * It uses SCM's {@link KeyDataStreamOutput} for writing the data.
  */
-public class OzoneDataStreamOutput implements ByteBufferStreamOutput {
+public class OzoneDataStreamOutput extends ByteBufferOutputStream {
 
   private final ByteBufferStreamOutput byteBufferStreamOutput;
 

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/io/OzoneOutputStream.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/io/OzoneOutputStream.java
@@ -28,9 +28,8 @@ import java.util.Optional;
 
 /**
  * OzoneOutputStream is used to write data into Ozone.
- * It uses SCM's {@link KeyOutputStream} for writing the data.
  */
-public class OzoneOutputStream extends OutputStream {
+public class OzoneOutputStream extends ByteArrayStreamOutput {
 
   private final OutputStream outputStream;
   private final Syncable syncable;

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/rpc/RpcClient.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/rpc/RpcClient.java
@@ -2155,7 +2155,7 @@ public class RpcClient implements ClientProtocol {
             openKey.getOpenVersion());
     final OzoneOutputStream out = createSecureOutputStream(
         openKey, keyOutputStream, null);
-    return new OzoneDataStreamOutput(out != null? out: keyOutputStream);
+    return new OzoneDataStreamOutput(out != null ? out : keyOutputStream);
   }
 
   private OzoneOutputStream createOutputStream(OpenKeySession openKey)
@@ -2168,7 +2168,7 @@ public class RpcClient implements ClientProtocol {
             openKey.getOpenVersion());
     final OzoneOutputStream out = createSecureOutputStream(
         openKey, keyOutputStream, keyOutputStream);
-    return out != null? out: new OzoneOutputStream(keyOutputStream);
+    return out != null ? out : new OzoneOutputStream(keyOutputStream);
   }
 
   private OzoneOutputStream createSecureOutputStream(OpenKeySession openKey,
@@ -2187,8 +2187,8 @@ public class RpcClient implements ClientProtocol {
         final GDPRSymmetricKey gk = getGDPRSymmetricKey(
             openKey.getKeyInfo().getMetadata(), Cipher.ENCRYPT_MODE);
         if (gk != null) {
-          return new OzoneOutputStream(
-              new CipherOutputStream(keyOutputStream, gk.getCipher()), syncable);
+          return new OzoneOutputStream(new CipherOutputStream(
+              keyOutputStream, gk.getCipher()), syncable);
         }
       }  catch (Exception ex) {
         throw new IOException(ex);

--- a/hadoop-ozone/dist/src/main/smoketest/gdpr/gdpr.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/gdpr/gdpr.robot
@@ -66,6 +66,11 @@ Test GDPR with --enforcegdpr=true
     ${result} =     Execute             ozone sh key info /${volume}/mybucket2/mykey | jq -r '. | select(.name=="mykey") | .metadata | .gdprEnabled'
                     Should Be Equal     ${result}       true
                     Execute             ozone sh key delete /${volume}/mybucket2/mykey
+                    Execute             ozone sh key put --stream /${volume}/mybucket2/myStreamKey /opt/hadoop/NOTICE.txt
+                    Execute             rm -f NOTICE.txt.1
+    ${result} =     Execute             ozone sh key info /${volume}/mybucket2/myStreamKey | jq -r '. | select(.name=="myStreamKey") | .metadata | .gdprEnabled'
+                    Should Be Equal     ${result}       true
+                    Execute             ozone sh key delete /${volume}/mybucket2/myStreamKey
 
 Test GDPR with -g=true
     [arguments]     ${volume}

--- a/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/OzoneFSDataStreamOutput.java
+++ b/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/OzoneFSDataStreamOutput.java
@@ -18,16 +18,15 @@
 package org.apache.hadoop.fs.ozone;
 
 import org.apache.hadoop.hdds.scm.storage.ByteBufferStreamOutput;
+import org.apache.hadoop.ozone.client.io.ByteBufferOutputStream;
 
 import java.io.IOException;
-import java.io.OutputStream;
 import java.nio.ByteBuffer;
 
 /**
  * The ByteBuffer output stream for Ozone file system.
  */
-public class OzoneFSDataStreamOutput extends OutputStream
-    implements ByteBufferStreamOutput {
+public class OzoneFSDataStreamOutput extends ByteBufferOutputStream {
 
   private final ByteBufferStreamOutput byteBufferStreamOutput;
 
@@ -48,34 +47,6 @@ public class OzoneFSDataStreamOutput extends OutputStream
   public void write(ByteBuffer b, int off, int len)
       throws IOException {
     byteBufferStreamOutput.write(b, off, len);
-  }
-
-  @Override
-  public void write(byte[] b, int off, int len)
-      throws IOException {
-    write(ByteBuffer.wrap(b));
-  }
-
-  /**
-   * Writes the specified byte to this output stream. The general
-   * contract for <code>write</code> is that one byte is written
-   * to the output stream. The byte to be written is the eight
-   * low-order bits of the argument <code>b</code>. The 24
-   * high-order bits of <code>b</code> are ignored.
-   * <p>
-   * Subclasses of <code>OutputStream</code> must provide an
-   * implementation for this method.
-   *
-   * @param b the <code>byte</code>.
-   * @throws IOException if an I/O error occurs. In particular,
-   *                     an <code>IOException</code> may be thrown if the
-   *                     output stream has been closed.
-   */
-  @Override
-  public void write(int b) throws IOException {
-    byte[] singleBytes = new byte[1];
-    singleBytes[0] = (byte) b;
-    byteBufferStreamOutput.write(ByteBuffer.wrap(singleBytes));
   }
 
   /**


### PR DESCRIPTION
## What changes were proposed in this pull request?

Currently, ClientProtocol.createStreamKey returns OzoneDataStreamOutput which is not an OutputStream. Therefore, it does not support CryptoOutputStream and CipherOutputStream since they requires OutputStream.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-8638

## How was this patch tested?

Added new tests.