### PR TITLE
HDDS-8647. Fix problem with performance metric preventing OM taking snapshot.

### DIFF
--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
@@ -635,6 +635,7 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
         OMMultiTenantManager.checkAndEnableMultiTenancy(this, conf);
 
     metrics = OMMetrics.create();
+    perfMetrics = OMPerformanceMetrics.register();
     // Get admin list
     omStarterUser = UserGroupInformation.getCurrentUser().getShortUserName();
     Collection<String> omAdminUsernames =
@@ -807,7 +808,6 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
     }
 
     prefixManager = new PrefixManagerImpl(metadataManager, isRatisEnabled);
-    perfMetrics = OMPerformanceMetrics.register();
     keyManager = new KeyManagerImpl(this, scmClient, configuration,
         perfMetrics);
     omMetadataReader = new OmMetadataReader(keyManager, prefixManager,


### PR DESCRIPTION
## What changes were proposed in this pull request?

OM snapshot installing fails with:
```
2023-05-18 09:35:39,485 ERROR org.apache.hadoop.ozone.om.OzoneManager: Terminating with exit status 1: Failed to reload OM state and instantiate services.
org.apache.hadoop.metrics2.MetricsException: Metrics source OMPerformanceMetrics already exists!
        at org.apache.hadoop.metrics2.lib.DefaultMetricsSystem.newSourceName(DefaultMetricsSystem.java:152)
        at org.apache.hadoop.metrics2.lib.DefaultMetricsSystem.sourceName(DefaultMetricsSystem.java:125)
        at org.apache.hadoop.metrics2.impl.MetricsSystemImpl.register(MetricsSystemImpl.java:229)
        at org.apache.hadoop.ozone.om.OMPerformanceMetrics.register(OMPerformanceMetrics.java:33)
        at org.apache.hadoop.ozone.om.OzoneManager.instantiateServices(OzoneManager.java:779)
        at org.apache.hadoop.ozone.om.OzoneManager.reloadOMState(OzoneManager.java:3808)
        at org.apache.hadoop.ozone.om.OzoneManager.installCheckpoint(OzoneManager.java:3663)
        at org.apache.hadoop.ozone.om.OzoneManager.installCheckpoint(OzoneManager.java:3570)
        at org.apache.hadoop.ozone.om.OzoneManager.installSnapshotFromLeader(OzoneManager.java:3547)
        at org.apache.hadoop.ozone.om.ratis.OzoneManagerStateMachine.lambda$6(OzoneManagerStateMachine.java:478)
        at java.base/java.util.concurrent.CompletableFuture$AsyncSupply.run(CompletableFuture.java:1700)
        at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
        at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628) 

```
## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-8647

## How was this patch tested?

Snapshot installation is already tested well by [TestOMRatisSnapshots](https://github.com/apache/ozone/blob/2443e840c1182a4cb7786ff20eb5b347d0a9dded/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOMRatisSnapshots.java#L89-L89), yet this issue is not caught by the test because MiniCluster mode has to skip the duplicated metric source name (which make sense as multiple services run in the same JVM and MetricsSystem is static)..
```
  synchronized String newSourceName(String name, boolean dupOK) {
    if (sourceNames.map.containsKey(name)) {
      if (dupOK) {
        return name;
      } else if (!miniClusterMode) {
        throw new MetricsException("Metrics source "+ name +" already exists!");
      }
    }
    return sourceNames.uniqueName(name);
  }
```

The fix has been verified manually.