### PR TITLE
HDDS-8617. Ratis underreplication due to maintenance is not deprioritised

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ContainerHealthResult.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ContainerHealthResult.java
@@ -237,6 +237,33 @@ public class ContainerHealthResult {
     public void setHasHealthyReplicas(boolean hasHealthyReplicas) {
       this.hasHealthyReplicas = hasHealthyReplicas;
     }
+
+    @Override
+    public String toString() {
+      StringBuilder sb = new StringBuilder("UnderReplicatedHealthResult{")
+          .append("containerId=").append(getContainerInfo().getContainerID())
+          .append(", state=").append(getHealthState())
+          .append(", remainingRedundancy=").append(remainingRedundancy);
+      if (dueToDecommission) {
+        sb.append(" +dueToDecommission");
+      }
+      if (sufficientlyReplicatedAfterPending) {
+        sb.append(" +sufficientlyReplicatedAfterPending");
+      }
+      if (unrecoverable) {
+        sb.append(" +unrecoverable");
+      }
+      if (hasHealthyReplicas) {
+        sb.append(" +hasHealthyReplicas");
+      }
+      if (hasUnReplicatedOfflineIndexes) {
+        sb.append(" +hasUnReplicatedOfflineIndexes");
+      }
+      if (requeueCount > 0) {
+        sb.append(" requeued:").append(requeueCount);
+      }
+      return sb.append("}").toString();
+    }
   }
 
   /**

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ContainerHealthResult.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ContainerHealthResult.java
@@ -105,7 +105,7 @@ public class ContainerHealthResult {
     private static final int DECOMMISSION_REDUNDANCY = 5;
 
     private final int remainingRedundancy;
-    private final boolean dueToDecommission;
+    private final boolean dueToOutOfService;
     private final boolean sufficientlyReplicatedAfterPending;
     private final boolean unrecoverable;
     private boolean hasHealthyReplicas;
@@ -113,19 +113,19 @@ public class ContainerHealthResult {
     private int requeueCount = 0;
 
     public UnderReplicatedHealthResult(ContainerInfo containerInfo,
-        int remainingRedundancy, boolean dueToDecommission,
+        int remainingRedundancy, boolean dueToOutOfService,
         boolean replicatedOkWithPending, boolean unrecoverable) {
-      this(containerInfo, remainingRedundancy, dueToDecommission,
+      this(containerInfo, remainingRedundancy, dueToOutOfService,
           replicatedOkWithPending, unrecoverable, HealthState.UNDER_REPLICATED);
     }
 
     protected UnderReplicatedHealthResult(ContainerInfo containerInfo,
-        int remainingRedundancy, boolean dueToDecommission,
+        int remainingRedundancy, boolean dueToOutOfService,
         boolean replicatedOkWithPending, boolean unrecoverable,
         HealthState healthState) {
       super(containerInfo, healthState);
       this.remainingRedundancy = remainingRedundancy;
-      this.dueToDecommission = dueToDecommission;
+      this.dueToOutOfService = dueToOutOfService;
       this.sufficientlyReplicatedAfterPending = replicatedOkWithPending;
       this.unrecoverable = unrecoverable;
     }
@@ -155,7 +155,7 @@ public class ContainerHealthResult {
      */
     public int getWeightedRedundancy() {
       int result = requeueCount;
-      if (dueToDecommission) {
+      if (dueToOutOfService) {
         result += DECOMMISSION_REDUNDANCY;
       } else {
         result += getRemainingRedundancy();
@@ -183,8 +183,8 @@ public class ContainerHealthResult {
      * unavailable.
      * @return True is the under-replication is caused by decommission.
      */
-    public boolean underReplicatedDueToDecommission() {
-      return dueToDecommission;
+    public boolean underReplicatedDueToOutOfService() {
+      return dueToOutOfService;
     }
 
     /**
@@ -244,8 +244,8 @@ public class ContainerHealthResult {
           .append("containerId=").append(getContainerInfo().getContainerID())
           .append(", state=").append(getHealthState())
           .append(", remainingRedundancy=").append(remainingRedundancy);
-      if (dueToDecommission) {
-        sb.append(" +dueToDecommission");
+      if (dueToOutOfService) {
+        sb.append(" +dueToOutOfService");
       }
       if (sufficientlyReplicatedAfterPending) {
         sb.append(" +sufficientlyReplicatedAfterPending");

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/RatisContainerReplicaCount.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/RatisContainerReplicaCount.java
@@ -507,12 +507,12 @@ public class RatisContainerReplicaCount implements ContainerReplicaCount {
 
   /**
    * Checks whether insufficient replication is because of some replicas
-   * being on datanodes that were decommissioned.
+   * being on datanodes that were decommissioned or are in maintenance.
    *
    * @return true if there is insufficient replication and it's because of
    * decommissioning.
    */
-  boolean inSufficientDueToDecommission() {
+  boolean inSufficientDueToOutOfService() {
     int delta = redundancyDelta(true, false);
     return 0 < delta && delta <= getDecommissionCount() + getMaintenanceCount();
   }
@@ -548,7 +548,7 @@ public class RatisContainerReplicaCount implements ContainerReplicaCount {
     UnderReplicatedHealthResult result = new UnderReplicatedHealthResult(
         getContainer(),
         getRemainingRedundancy(),
-        inSufficientDueToDecommission(),
+        inSufficientDueToOutOfService(),
         isSufficientlyReplicated(true),
         isUnrecoverable());
     result.setHasHealthyReplicas(getHealthyReplicaCount() > 0);

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/RatisContainerReplicaCount.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/RatisContainerReplicaCount.java
@@ -512,7 +512,7 @@ public class RatisContainerReplicaCount implements ContainerReplicaCount {
    * @return true if there is insufficient replication and it's because of
    * decommissioning.
    */
-  boolean inSufficientDueToOutOfService() {
+  boolean insufficientDueToOutOfService() {
     int delta = redundancyDelta(true, false);
     return 0 < delta && delta <= getDecommissionCount() + getMaintenanceCount();
   }
@@ -548,7 +548,7 @@ public class RatisContainerReplicaCount implements ContainerReplicaCount {
     UnderReplicatedHealthResult result = new UnderReplicatedHealthResult(
         getContainer(),
         getRemainingRedundancy(),
-        inSufficientDueToOutOfService(),
+        insufficientDueToOutOfService(),
         isSufficientlyReplicated(true),
         isUnrecoverable());
     result.setHasHealthyReplicas(getHealthyReplicaCount() > 0);

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/RatisContainerReplicaCount.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/RatisContainerReplicaCount.java
@@ -514,7 +514,7 @@ public class RatisContainerReplicaCount implements ContainerReplicaCount {
    */
   boolean inSufficientDueToDecommission() {
     int delta = redundancyDelta(true, false);
-    return 0 < delta && delta <= getDecommissionCount();
+    return 0 < delta && delta <= getDecommissionCount() + getMaintenanceCount();
   }
 
   /**

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/RatisContainerReplicaCount.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/RatisContainerReplicaCount.java
@@ -512,7 +512,7 @@ public class RatisContainerReplicaCount implements ContainerReplicaCount {
    * @return true if there is insufficient replication and it's because of
    * decommissioning.
    */
-  private boolean inSufficientDueToDecommission() {
+  boolean inSufficientDueToDecommission() {
     int delta = redundancyDelta(true, false);
     return 0 < delta && delta <= getDecommissionCount();
   }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/health/ECReplicationCheckHandler.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/health/ECReplicationCheckHandler.java
@@ -141,19 +141,19 @@ public class ECReplicationCheckHandler extends AbstractCheck {
     if (!replicaCount.isSufficientlyReplicated(false)) {
       List<Integer> missingIndexes = replicaCount.unavailableIndexes(false);
       int remainingRedundancy = repConfig.getParity();
-      boolean dueToDecommission = true;
+      boolean dueToOutOfService = true;
       if (missingIndexes.size() > 0) {
         // The container has reduced redundancy and will need reconstructed
         // via an EC reconstruction command. Note that it may also have some
         // replicas in decommission / maintenance states, but as the under
         // replication is not caused only by decommission, we say it is not
         // due to decommission/
-        dueToDecommission = false;
+        dueToOutOfService = false;
         remainingRedundancy = repConfig.getParity() - missingIndexes.size();
       }
       ContainerHealthResult.UnderReplicatedHealthResult result =
           new ContainerHealthResult.UnderReplicatedHealthResult(
-              container, remainingRedundancy, dueToDecommission,
+              container, remainingRedundancy, dueToOutOfService,
               replicaCount.isSufficientlyReplicated(true),
               replicaCount.isUnrecoverable());
       if (replicaCount.decommissioningOnlyIndexes(true).size() > 0

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/NodeStatus.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/NodeStatus.java
@@ -18,9 +18,12 @@
 
 package org.apache.hadoop.hdds.scm.node;
 
+import com.google.common.collect.ImmutableSet;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 
+import java.util.EnumSet;
 import java.util.Objects;
+import java.util.Set;
 
 /**
  * This class is used to capture the current status of a datanode. This
@@ -29,6 +32,38 @@ import java.util.Objects;
  * for the operational state (used with maintenance mode).
  */
 public class NodeStatus implements Comparable<NodeStatus> {
+
+  private static final Set<HddsProtos.NodeOperationalState>
+      MAINTENANCE_STATES = ImmutableSet.copyOf(EnumSet.of(
+          HddsProtos.NodeOperationalState.ENTERING_MAINTENANCE,
+          HddsProtos.NodeOperationalState.IN_MAINTENANCE
+      ));
+
+  private static final Set<HddsProtos.NodeOperationalState>
+      DECOMMISSION_STATES = ImmutableSet.copyOf(EnumSet.of(
+          HddsProtos.NodeOperationalState.DECOMMISSIONING,
+          HddsProtos.NodeOperationalState.DECOMMISSIONED
+      ));
+
+  private static final Set<HddsProtos.NodeOperationalState>
+      OUT_OF_SERVICE_STATES = ImmutableSet.copyOf(EnumSet.of(
+          HddsProtos.NodeOperationalState.DECOMMISSIONING,
+          HddsProtos.NodeOperationalState.DECOMMISSIONED,
+          HddsProtos.NodeOperationalState.ENTERING_MAINTENANCE,
+          HddsProtos.NodeOperationalState.IN_MAINTENANCE
+      ));
+
+  public static Set<HddsProtos.NodeOperationalState> maintenanceStates() {
+    return MAINTENANCE_STATES;
+  }
+
+  public static Set<HddsProtos.NodeOperationalState> decommissionStates() {
+    return DECOMMISSION_STATES;
+  }
+
+  public static Set<HddsProtos.NodeOperationalState> outOfServiceStates() {
+    return OUT_OF_SERVICE_STATES;
+  }
 
   private HddsProtos.NodeOperationalState operationalState;
   private HddsProtos.NodeState health;
@@ -104,8 +139,7 @@ public class NodeStatus implements Comparable<NodeStatus> {
    * @return True if the node is in any decommission state, false otherwise
    */
   public boolean isDecommission() {
-    return operationalState == HddsProtos.NodeOperationalState.DECOMMISSIONING
-        || operationalState == HddsProtos.NodeOperationalState.DECOMMISSIONED;
+    return DECOMMISSION_STATES.contains(operationalState);
   }
 
   /**
@@ -132,9 +166,7 @@ public class NodeStatus implements Comparable<NodeStatus> {
    * @return True if the node is in any maintenance state, false otherwise
    */
   public boolean isMaintenance() {
-    return operationalState
-        == HddsProtos.NodeOperationalState.ENTERING_MAINTENANCE
-        || operationalState == HddsProtos.NodeOperationalState.IN_MAINTENANCE;
+    return MAINTENANCE_STATES.contains(operationalState);
   }
 
   /**

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestLegacyReplicationManager.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestLegacyReplicationManager.java
@@ -1604,7 +1604,7 @@ public class TestLegacyReplicationManager {
      * decommissioned replicas.
      */
     @Test
-    public void testUnderReplicatedDueToDecommission()
+    public void testUnderReplicatedDueToOutOfService()
         throws IOException, TimeoutException {
       final ContainerInfo container = createContainer(LifeCycleState.CLOSED);
       addReplica(container, new NodeStatus(IN_SERVICE, HEALTHY), CLOSED);

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestRatisContainerReplicaCount.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestRatisContainerReplicaCount.java
@@ -57,7 +57,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  */
 class TestRatisContainerReplicaCount {
 
-  static Set<HddsProtos.NodeOperationalState> outOfServiceStates() {
+  public static Set<HddsProtos.NodeOperationalState> outOfServiceStates() {
     return EnumSet.of(
         DECOMMISSIONING, DECOMMISSIONED,
         ENTERING_MAINTENANCE, IN_MAINTENANCE);

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestRatisContainerReplicaCount.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestRatisContainerReplicaCount.java
@@ -224,7 +224,7 @@ class TestRatisContainerReplicaCount {
     RatisContainerReplicaCount rcnt =
         new RatisContainerReplicaCount(container, replica, 0, 0, 3, 2);
     validate(rcnt, false, 1, false);
-    assertTrue(rcnt.inSufficientDueToOutOfService());
+    assertTrue(rcnt.insufficientDueToOutOfService());
   }
 
   @Test

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestRatisContainerReplicaCount.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestRatisContainerReplicaCount.java
@@ -217,14 +217,14 @@ class TestRatisContainerReplicaCount {
 
   @ParameterizedTest
   @MethodSource("outOfServiceStates")
-  void testOneDecommissionedReplica(HddsProtos.NodeOperationalState state) {
+  void testOneOutOfServiceReplica(HddsProtos.NodeOperationalState state) {
     Set<ContainerReplica> replica =
         registerNodes(IN_SERVICE, IN_SERVICE, state);
     ContainerInfo container = createContainer(HddsProtos.LifeCycleState.CLOSED);
     RatisContainerReplicaCount rcnt =
         new RatisContainerReplicaCount(container, replica, 0, 0, 3, 2);
     validate(rcnt, false, 1, false);
-    assertTrue(rcnt.inSufficientDueToDecommission());
+    assertTrue(rcnt.inSufficientDueToOutOfService());
   }
 
   @Test

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestRatisContainerReplicaCount.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestRatisContainerReplicaCount.java
@@ -31,7 +31,6 @@ import org.junit.jupiter.params.provider.MethodSource;
 
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.EnumSet;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -57,12 +56,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  */
 class TestRatisContainerReplicaCount {
 
-  public static Set<HddsProtos.NodeOperationalState> outOfServiceStates() {
-    return EnumSet.of(
-        DECOMMISSIONING, DECOMMISSIONED,
-        ENTERING_MAINTENANCE, IN_MAINTENANCE);
-  }
-
   @Test
   void testThreeHealthyReplica() {
     Set<ContainerReplica> replica =
@@ -70,7 +63,7 @@ class TestRatisContainerReplicaCount {
     ContainerInfo container = createContainer(HddsProtos.LifeCycleState.CLOSED);
     RatisContainerReplicaCount rcnt =
         new RatisContainerReplicaCount(container, replica, 0, 0, 3, 2);
-    validate(rcnt, true, 0, false);
+    validate(rcnt, true, 0, false, false);
   }
 
   @Test
@@ -79,7 +72,7 @@ class TestRatisContainerReplicaCount {
     ContainerInfo container = createContainer(HddsProtos.LifeCycleState.CLOSED);
     RatisContainerReplicaCount rcnt =
         new RatisContainerReplicaCount(container, replica, 0, 0, 3, 2);
-    validate(rcnt, false, 1, false);
+    validate(rcnt, false, 1, false, false);
   }
 
   @Test
@@ -88,7 +81,7 @@ class TestRatisContainerReplicaCount {
     ContainerInfo container = createContainer(HddsProtos.LifeCycleState.CLOSED);
     RatisContainerReplicaCount rcnt =
         new RatisContainerReplicaCount(container, replica, 0, 0, 3, 2);
-    validate(rcnt, false, 2, false);
+    validate(rcnt, false, 2, false, false);
   }
 
   @Test
@@ -98,7 +91,7 @@ class TestRatisContainerReplicaCount {
     ContainerInfo container = createContainer(HddsProtos.LifeCycleState.CLOSED);
     RatisContainerReplicaCount rcnt =
         new RatisContainerReplicaCount(container, replica, 1, 0, 3, 2);
-    validate(rcnt, false, 0, false);
+    validate(rcnt, false, 0, false, false);
   }
 
   /**
@@ -113,7 +106,7 @@ class TestRatisContainerReplicaCount {
     ContainerInfo container = createContainer(HddsProtos.LifeCycleState.CLOSED);
     RatisContainerReplicaCount rcnt =
         new RatisContainerReplicaCount(container, replica, 1, 0, 3, 2);
-    validate(rcnt, true, 0, false);
+    validate(rcnt, true, 0, false, false);
   }
 
   /**
@@ -127,7 +120,7 @@ class TestRatisContainerReplicaCount {
     ContainerInfo container = createContainer(HddsProtos.LifeCycleState.CLOSED);
     RatisContainerReplicaCount rcnt =
         new RatisContainerReplicaCount(container, replica, 0, 1, 3, 2);
-    validate(rcnt, false, 1, false);
+    validate(rcnt, false, 1, false, false);
   }
 
   /**
@@ -141,7 +134,7 @@ class TestRatisContainerReplicaCount {
     ContainerInfo container = createContainer(HddsProtos.LifeCycleState.CLOSED);
     RatisContainerReplicaCount rcnt =
         new RatisContainerReplicaCount(container, replica, 1, 1, 3, 2);
-    validate(rcnt, false, 0, false);
+    validate(rcnt, false, 0, false, false);
   }
 
   @Test
@@ -151,7 +144,7 @@ class TestRatisContainerReplicaCount {
     ContainerInfo container = createContainer(HddsProtos.LifeCycleState.CLOSED);
     RatisContainerReplicaCount rcnt =
         new RatisContainerReplicaCount(container, replica, 0, 0, 3, 2);
-    validate(rcnt, true, -1, true);
+    validate(rcnt, true, -1, true, false);
   }
 
   @Test
@@ -161,7 +154,7 @@ class TestRatisContainerReplicaCount {
     ContainerInfo container = createContainer(HddsProtos.LifeCycleState.CLOSED);
     RatisContainerReplicaCount rcnt =
         new RatisContainerReplicaCount(container, replica, 0, 1, 3, 2);
-    validate(rcnt, true, 0, false);
+    validate(rcnt, true, 0, false, false);
   }
 
   @Test
@@ -171,7 +164,7 @@ class TestRatisContainerReplicaCount {
     ContainerInfo container = createContainer(HddsProtos.LifeCycleState.CLOSED);
     RatisContainerReplicaCount rcnt =
         new RatisContainerReplicaCount(container, replica, 0, 2, 3, 2);
-    validate(rcnt, false, 1, false);
+    validate(rcnt, false, 1, false, false);
   }
 
   @Test
@@ -180,7 +173,7 @@ class TestRatisContainerReplicaCount {
     ContainerInfo container = createContainer(HddsProtos.LifeCycleState.CLOSED);
     RatisContainerReplicaCount rcnt =
         new RatisContainerReplicaCount(container, replica, 0, 0, 1, 2);
-    validate(rcnt, true, 0, false);
+    validate(rcnt, true, 0, false, false);
   }
 
   @Test
@@ -189,7 +182,7 @@ class TestRatisContainerReplicaCount {
     ContainerInfo container = createContainer(HddsProtos.LifeCycleState.CLOSED);
     RatisContainerReplicaCount rcnt =
         new RatisContainerReplicaCount(container, replica, 0, 1, 1, 2);
-    validate(rcnt, false, 1, false);
+    validate(rcnt, false, 1, false, false);
   }
 
   @Test
@@ -198,7 +191,7 @@ class TestRatisContainerReplicaCount {
     ContainerInfo container = createContainer(HddsProtos.LifeCycleState.CLOSED);
     RatisContainerReplicaCount rcnt =
         new RatisContainerReplicaCount(container, replica, 2, 0, 3, 2);
-    validate(rcnt, false, 0, false);
+    validate(rcnt, false, 0, false, false);
   }
 
   /**
@@ -212,19 +205,18 @@ class TestRatisContainerReplicaCount {
     ContainerInfo container = createContainer(HddsProtos.LifeCycleState.CLOSED);
     RatisContainerReplicaCount rcnt =
         new RatisContainerReplicaCount(container, replica, 0, 0, 3, 2);
-    validate(rcnt, true, 0, false);
+    validate(rcnt, true, 0, false, false);
   }
 
   @ParameterizedTest
-  @MethodSource("outOfServiceStates")
-  void testOneOutOfServiceReplica(HddsProtos.NodeOperationalState state) {
+  @MethodSource("org.apache.hadoop.hdds.scm.node.NodeStatus#decommissionStates")
+  void testOneDecommissionReplica(HddsProtos.NodeOperationalState state) {
     Set<ContainerReplica> replica =
         registerNodes(IN_SERVICE, IN_SERVICE, state);
     ContainerInfo container = createContainer(HddsProtos.LifeCycleState.CLOSED);
     RatisContainerReplicaCount rcnt =
         new RatisContainerReplicaCount(container, replica, 0, 0, 3, 2);
-    validate(rcnt, false, 1, false);
-    assertTrue(rcnt.insufficientDueToOutOfService());
+    validate(rcnt, false, 1, false, true);
   }
 
   @Test
@@ -234,17 +226,18 @@ class TestRatisContainerReplicaCount {
     ContainerInfo container = createContainer(HddsProtos.LifeCycleState.CLOSED);
     RatisContainerReplicaCount rcnt =
         new RatisContainerReplicaCount(container, replica, 1, 0, 3, 2);
-    validate(rcnt, false, 0, false);
+    validate(rcnt, false, 0, false, true);
   }
 
-  @Test
-  void testAllDecommissioned() {
+  @ParameterizedTest
+  @MethodSource("org.apache.hadoop.hdds.scm.node.NodeStatus#decommissionStates")
+  void testAllDecommissioned(HddsProtos.NodeOperationalState state) {
     Set<ContainerReplica> replica =
-        registerNodes(DECOMMISSIONED, DECOMMISSIONED, DECOMMISSIONED);
+        registerNodes(state, state, state);
     ContainerInfo container = createContainer(HddsProtos.LifeCycleState.CLOSED);
     RatisContainerReplicaCount rcnt =
         new RatisContainerReplicaCount(container, replica, 0, 0, 3, 2);
-    validate(rcnt, false, 3, false);
+    validate(rcnt, false, 3, false, true);
   }
 
   @Test
@@ -253,7 +246,7 @@ class TestRatisContainerReplicaCount {
     ContainerInfo container = createContainer(HddsProtos.LifeCycleState.CLOSED);
     RatisContainerReplicaCount rcnt =
         new RatisContainerReplicaCount(container, replica, 0, 0, 1, 2);
-    validate(rcnt, false, 1, false);
+    validate(rcnt, false, 1, false, true);
 
   }
 
@@ -263,7 +256,7 @@ class TestRatisContainerReplicaCount {
     ContainerInfo container = createContainer(HddsProtos.LifeCycleState.CLOSED);
     RatisContainerReplicaCount rcnt =
         new RatisContainerReplicaCount(container, replica, 1, 0, 1, 2);
-    validate(rcnt, false, 0, false);
+    validate(rcnt, false, 0, false, true);
   }
 
   @Test
@@ -272,21 +265,23 @@ class TestRatisContainerReplicaCount {
     ContainerInfo container = createContainer(HddsProtos.LifeCycleState.CLOSED);
     RatisContainerReplicaCount rcnt =
         new RatisContainerReplicaCount(container, replica, 0, 0, 1, 2);
-    validate(rcnt, true, 0, false);
+    validate(rcnt, true, 0, false, false);
   }
 
   /**
    * Maintenance tests from here.
    */
 
-  @Test
-  void testOneHealthyTwoMaintenanceMinRepOfTwo() {
+  @ParameterizedTest
+  @MethodSource("org.apache.hadoop.hdds.scm.node.NodeStatus#maintenanceStates")
+  void testOneHealthyTwoMaintenanceMinRepOfTwo(
+      HddsProtos.NodeOperationalState state) {
     Set<ContainerReplica> replica =
-        registerNodes(IN_SERVICE, IN_MAINTENANCE, IN_MAINTENANCE);
+        registerNodes(IN_SERVICE, state, state);
     ContainerInfo container = createContainer(HddsProtos.LifeCycleState.CLOSED);
     RatisContainerReplicaCount rcnt =
         new RatisContainerReplicaCount(container, replica, 0, 0, 3, 2);
-    validate(rcnt, false, 1, false);
+    validate(rcnt, false, 1, false, true);
   }
 
   @Test
@@ -296,7 +291,7 @@ class TestRatisContainerReplicaCount {
     ContainerInfo container = createContainer(HddsProtos.LifeCycleState.CLOSED);
     RatisContainerReplicaCount rcnt =
         new RatisContainerReplicaCount(container, replica, 0, 0, 3, 2);
-    validate(rcnt, false, 1, false);
+    validate(rcnt, false, 1, false, true);
   }
 
   @Test
@@ -306,7 +301,7 @@ class TestRatisContainerReplicaCount {
     ContainerInfo container = createContainer(HddsProtos.LifeCycleState.CLOSED);
     RatisContainerReplicaCount rcnt =
         new RatisContainerReplicaCount(container, replica, 0, 0, 3, 1);
-    validate(rcnt, true, 0, false);
+    validate(rcnt, true, 0, false, false);
   }
 
   @Test
@@ -316,7 +311,7 @@ class TestRatisContainerReplicaCount {
     ContainerInfo container = createContainer(HddsProtos.LifeCycleState.CLOSED);
     RatisContainerReplicaCount rcnt =
         new RatisContainerReplicaCount(container, replica, 1, 0, 3, 2);
-    validate(rcnt, false, 0, false);
+    validate(rcnt, false, 0, false, true);
   }
 
   @Test
@@ -326,7 +321,7 @@ class TestRatisContainerReplicaCount {
     ContainerInfo container = createContainer(HddsProtos.LifeCycleState.CLOSED);
     RatisContainerReplicaCount rcnt =
         new RatisContainerReplicaCount(container, replica, 0, 0, 3, 2);
-    validate(rcnt, false, 2, false);
+    validate(rcnt, false, 2, false, true);
   }
 
   /**
@@ -341,7 +336,7 @@ class TestRatisContainerReplicaCount {
     ContainerInfo container = createContainer(HddsProtos.LifeCycleState.CLOSED);
     RatisContainerReplicaCount rcnt =
         new RatisContainerReplicaCount(container, replica, 0, 0, 3, 2);
-    validate(rcnt, true, 0, false);
+    validate(rcnt, true, 0, false, false);
   }
 
   /**
@@ -357,7 +352,7 @@ class TestRatisContainerReplicaCount {
     ContainerInfo container = createContainer(HddsProtos.LifeCycleState.CLOSED);
     RatisContainerReplicaCount rcnt =
         new RatisContainerReplicaCount(container, replica, 0, 0, 3, 2);
-    validate(rcnt, true, -1, true);
+    validate(rcnt, true, -1, true, false);
     assertTrue(rcnt.isSafelyOverReplicated());
   }
 
@@ -367,7 +362,7 @@ class TestRatisContainerReplicaCount {
     ContainerInfo container = createContainer(HddsProtos.LifeCycleState.CLOSED);
     RatisContainerReplicaCount rcnt =
         new RatisContainerReplicaCount(container, replica, 0, 0, 1, 2);
-    validate(rcnt, false, 1, false);
+    validate(rcnt, false, 1, false, true);
   }
 
   @Test
@@ -376,7 +371,7 @@ class TestRatisContainerReplicaCount {
     ContainerInfo container = createContainer(HddsProtos.LifeCycleState.CLOSED);
     RatisContainerReplicaCount rcnt =
         new RatisContainerReplicaCount(container, replica, 1, 0, 1, 2);
-    validate(rcnt, false, 0, false);
+    validate(rcnt, false, 0, false, true);
   }
 
   @Test
@@ -385,7 +380,7 @@ class TestRatisContainerReplicaCount {
     ContainerInfo container = createContainer(HddsProtos.LifeCycleState.CLOSED);
     RatisContainerReplicaCount rcnt =
         new RatisContainerReplicaCount(container, replica, 0, 0, 1, 2);
-    validate(rcnt, true, 0, false);
+    validate(rcnt, true, 0, false, false);
   }
 
   @Test
@@ -396,7 +391,7 @@ class TestRatisContainerReplicaCount {
     ContainerInfo container = createContainer(HddsProtos.LifeCycleState.CLOSED);
     RatisContainerReplicaCount rcnt =
         new RatisContainerReplicaCount(container, replica, 1, 0, 3, 2);
-    validate(rcnt, false, 1, false);
+    validate(rcnt, false, 1, false, true);
   }
 
   @Test
@@ -447,7 +442,7 @@ class TestRatisContainerReplicaCount {
     RatisContainerReplicaCount rcnt =
         new RatisContainerReplicaCount(container, replicas,
             Collections.emptyList(), 2, false);
-    validate(rcnt, true, 0, false);
+    validate(rcnt, true, 0, false, false);
   }
 
   @Test
@@ -577,11 +572,11 @@ class TestRatisContainerReplicaCount {
         unhealthyReplica.getDatanodeDetails(), 0));
     RatisContainerReplicaCount withoutUnhealthy =
         new RatisContainerReplicaCount(container, replicas, ops, 2, false);
-    validate(withoutUnhealthy, true, 0, false);
+    validate(withoutUnhealthy, true, 0, false, false);
 
     RatisContainerReplicaCount withUnhealthy =
         new RatisContainerReplicaCount(container, replicas, ops, 2, true);
-    validate(withUnhealthy, true, 0, false);
+    validate(withUnhealthy, true, 0, false, false);
   }
 
   /**
@@ -604,7 +599,7 @@ class TestRatisContainerReplicaCount {
         new RatisContainerReplicaCount(container, replicas,
             Collections.emptyList(), 2,
             false);
-    validate(withoutUnhealthy, false, 1, false);
+    validate(withoutUnhealthy, false, 1, false, false);
   }
 
   @Test
@@ -668,12 +663,12 @@ class TestRatisContainerReplicaCount {
 
     RatisContainerReplicaCount withoutUnhealthy =
         new RatisContainerReplicaCount(container, replicas, ops, 2, false);
-    validate(withoutUnhealthy, true, 0, false);
+    validate(withoutUnhealthy, true, 0, false, false);
     assertFalse(withoutUnhealthy.isSafelyOverReplicated());
 
     RatisContainerReplicaCount withUnhealthy =
         new RatisContainerReplicaCount(container, replicas, ops, 2, true);
-    validate(withUnhealthy, true, -1, true);
+    validate(withUnhealthy, true, -1, true, false);
     assertFalse(withUnhealthy.isSafelyOverReplicated());
 
     /*
@@ -695,14 +690,14 @@ class TestRatisContainerReplicaCount {
         new RatisContainerReplicaCount(container, replicas,
             Collections.emptyList(), 2,
             false);
-    validate(withoutUnhealthy, true, 0, false);
+    validate(withoutUnhealthy, true, 0, false, false);
     assertFalse(withoutUnhealthy.isSafelyOverReplicated());
 
     withUnhealthy =
         new RatisContainerReplicaCount(container, replicas,
             Collections.emptyList(), 2,
             true);
-    validate(withUnhealthy, true, -1, true);
+    validate(withUnhealthy, true, -1, true, false);
     // Violates rule 2
     assertFalse(withUnhealthy.isSafelyOverReplicated());
     // now check by adding a CLOSED replica
@@ -712,7 +707,7 @@ class TestRatisContainerReplicaCount {
         new RatisContainerReplicaCount(container, replicas,
             Collections.emptyList(), 2,
             true);
-    validate(withUnhealthy, true, -2, true);
+    validate(withUnhealthy, true, -2, true, false);
     assertTrue(withUnhealthy.isSafelyOverReplicated());
   }
 
@@ -761,10 +756,12 @@ class TestRatisContainerReplicaCount {
 
   private void validate(RatisContainerReplicaCount rcnt,
       boolean sufficientlyReplicated, int replicaDelta,
-      boolean overReplicated) {
+      boolean overReplicated, boolean insufficientDueToOutOfService) {
     assertEquals(sufficientlyReplicated, rcnt.isSufficientlyReplicated());
     assertEquals(overReplicated, rcnt.isOverReplicated());
     assertEquals(replicaDelta, rcnt.additionalReplicaNeeded());
+    assertEquals(insufficientDueToOutOfService,
+        rcnt.insufficientDueToOutOfService());
   }
 
   private Set<ContainerReplica> registerNodes(

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/health/TestClosedWithUnhealthyReplicasHandler.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/health/TestClosedWithUnhealthyReplicasHandler.java
@@ -31,9 +31,8 @@ import org.apache.hadoop.hdds.scm.container.replication.ContainerCheckRequest;
 import org.apache.hadoop.hdds.scm.container.replication.ReplicationManager;
 import org.apache.hadoop.hdds.scm.container.replication.ReplicationTestUtil;
 import org.apache.ratis.protocol.exceptions.NotLeaderException;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 
@@ -45,6 +44,9 @@ import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.LifeCycleState.CL
 import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.NodeOperationalState.IN_SERVICE;
 import static org.apache.hadoop.hdds.scm.container.replication.ReplicationTestUtil.createContainerInfo;
 import static org.apache.hadoop.hdds.scm.container.replication.ReplicationTestUtil.createContainerReplica;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Tests for {@link ClosedWithUnhealthyReplicasHandler}.
@@ -55,7 +57,7 @@ public class TestClosedWithUnhealthyReplicasHandler {
   private ECReplicationConfig ecReplicationConfig;
   private ContainerCheckRequest.Builder requestBuilder;
 
-  @Before
+  @BeforeEach
   public void setup() {
     ecReplicationConfig = new ECReplicationConfig(3, 2);
     replicationManager = Mockito.mock(ReplicationManager.class);
@@ -82,7 +84,7 @@ public class TestClosedWithUnhealthyReplicasHandler {
         .setContainerInfo(containerInfo)
         .build();
 
-    Assert.assertFalse(handler.handle(request));
+    assertFalse(handler.handle(request));
   }
 
   @Test
@@ -103,7 +105,7 @@ public class TestClosedWithUnhealthyReplicasHandler {
         .setContainerInfo(containerInfo)
         .build();
 
-    Assert.assertFalse(handler.handle(request));
+    assertFalse(handler.handle(request));
   }
 
   /**
@@ -135,8 +137,8 @@ public class TestClosedWithUnhealthyReplicasHandler {
         .setContainerInfo(container)
         .build();
 
-    Assert.assertTrue(handler.handle(request));
-    Assert.assertEquals(1, request.getReport().getStat(
+    assertTrue(handler.handle(request));
+    assertEquals(1, request.getReport().getStat(
         ReplicationManagerReport.HealthState.UNHEALTHY));
 
     ArgumentCaptor<Integer> replicaIndexCaptor =
@@ -146,7 +148,7 @@ public class TestClosedWithUnhealthyReplicasHandler {
             DatanodeDetails.class), Mockito.eq(true));
     // replica index that delete was sent for should either be 2 or 5
     replicaIndexCaptor.getAllValues()
-        .forEach(index -> Assert.assertTrue(index == 2 || index == 5));
+        .forEach(index -> assertTrue(index == 2 || index == 5));
   }
 
   /**
@@ -167,7 +169,7 @@ public class TestClosedWithUnhealthyReplicasHandler {
         .setContainerInfo(container)
         .build();
 
-    Assert.assertFalse(handler.handle(request));
+    assertFalse(handler.handle(request));
   }
 
   @Test
@@ -189,6 +191,6 @@ public class TestClosedWithUnhealthyReplicasHandler {
         .setContainerInfo(container)
         .build();
 
-    Assert.assertFalse(handler.handle(request));
+    assertFalse(handler.handle(request));
   }
 }

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/health/TestDeletingContainerHandler.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/health/TestDeletingContainerHandler.java
@@ -33,7 +33,7 @@ import org.apache.hadoop.hdds.scm.container.replication.ContainerReplicaOp;
 import org.apache.hadoop.hdds.scm.container.replication.ReplicationManager;
 import org.apache.hadoop.hdds.scm.container.replication.ReplicationTestUtil;
 import org.apache.ratis.protocol.exceptions.NotLeaderException;
-import org.junit.Assert;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
@@ -94,7 +94,7 @@ public class TestDeletingContainerHandler {
         .setContainerReplicas(containerReplicas)
         .build();
 
-    Assert.assertFalse(deletingContainerHandler.handle(request));
+    Assertions.assertFalse(deletingContainerHandler.handle(request));
   }
 
   @Test
@@ -112,7 +112,7 @@ public class TestDeletingContainerHandler {
         .setContainerReplicas(containerReplicas)
         .build();
 
-    Assert.assertFalse(deletingContainerHandler.handle(request));
+    Assertions.assertFalse(deletingContainerHandler.handle(request));
   }
 
   /**
@@ -145,7 +145,7 @@ public class TestDeletingContainerHandler {
         .setContainerReplicas(containerReplicas)
         .build();
 
-    Assert.assertTrue(deletingContainerHandler.handle(request));
+    Assertions.assertTrue(deletingContainerHandler.handle(request));
     Mockito.verify(replicationManager, Mockito.times(times))
         .updateContainerState(Mockito.any(ContainerID.class),
             Mockito.any(HddsProtos.LifeCycleEvent.class));
@@ -229,7 +229,7 @@ public class TestDeletingContainerHandler {
         .setContainerReplicas(containerReplicas)
         .build();
 
-    Assert.assertTrue(deletingContainerHandler.handle(request));
+    Assertions.assertTrue(deletingContainerHandler.handle(request));
 
     Mockito.verify(replicationManager, Mockito.times(times))
         .sendDeleteCommand(Mockito.any(ContainerInfo.class), Mockito.anyInt(),

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/health/TestECReplicationCheckHandler.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/health/TestECReplicationCheckHandler.java
@@ -36,9 +36,8 @@ import org.apache.hadoop.hdds.scm.container.replication.ContainerHealthResult.He
 import org.apache.hadoop.hdds.scm.container.replication.ContainerReplicaOp;
 import org.apache.hadoop.hdds.scm.container.replication.ReplicationQueue;
 import org.apache.hadoop.hdds.scm.container.replication.ReplicationTestUtil;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 import java.util.ArrayList;
@@ -58,6 +57,9 @@ import static org.apache.hadoop.hdds.scm.container.replication.ContainerReplicaO
 import static org.apache.hadoop.hdds.scm.container.replication.ReplicationTestUtil.createContainerInfo;
 import static org.apache.hadoop.hdds.scm.container.replication.ReplicationTestUtil.createContainerReplica;
 import static org.apache.hadoop.hdds.scm.container.replication.ReplicationTestUtil.createReplicas;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyList;
 
@@ -74,7 +76,7 @@ public class TestECReplicationCheckHandler {
   private ReplicationManagerReport report;
   private PlacementPolicy placementPolicy;
 
-  @Before
+  @BeforeEach
   public void setup() {
     placementPolicy = Mockito.mock(PlacementPolicy.class);
     Mockito.when(placementPolicy.validateContainerPlacement(
@@ -102,11 +104,11 @@ public class TestECReplicationCheckHandler {
         .build();
 
     ContainerHealthResult result = healthCheck.checkHealth(request);
-    Assert.assertEquals(HealthState.HEALTHY, result.getHealthState());
+    assertEquals(HealthState.HEALTHY, result.getHealthState());
 
-    Assert.assertFalse(healthCheck.handle(request));
-    Assert.assertEquals(0, repQueue.underReplicatedQueueSize());
-    Assert.assertEquals(0, repQueue.overReplicatedQueueSize());
+    assertFalse(healthCheck.handle(request));
+    assertEquals(0, repQueue.underReplicatedQueueSize());
+    assertEquals(0, repQueue.overReplicatedQueueSize());
   }
 
   @Test
@@ -120,15 +122,15 @@ public class TestECReplicationCheckHandler {
         .build();
     UnderReplicatedHealthResult result = (UnderReplicatedHealthResult)
         healthCheck.checkHealth(request);
-    Assert.assertEquals(HealthState.UNDER_REPLICATED, result.getHealthState());
-    Assert.assertEquals(1, result.getRemainingRedundancy());
-    Assert.assertFalse(result.isReplicatedOkAfterPending());
-    Assert.assertFalse(result.underReplicatedDueToDecommission());
+    assertEquals(HealthState.UNDER_REPLICATED, result.getHealthState());
+    assertEquals(1, result.getRemainingRedundancy());
+    assertFalse(result.isReplicatedOkAfterPending());
+    assertFalse(result.underReplicatedDueToDecommission());
 
-    Assert.assertTrue(healthCheck.handle(request));
-    Assert.assertEquals(1, repQueue.underReplicatedQueueSize());
-    Assert.assertEquals(0, repQueue.overReplicatedQueueSize());
-    Assert.assertEquals(1, report.getStat(
+    assertTrue(healthCheck.handle(request));
+    assertEquals(1, repQueue.underReplicatedQueueSize());
+    assertEquals(0, repQueue.overReplicatedQueueSize());
+    assertEquals(1, report.getStat(
         ReplicationManagerReport.HealthState.UNDER_REPLICATED));
   }
 
@@ -147,17 +149,17 @@ public class TestECReplicationCheckHandler {
         .build();
     UnderReplicatedHealthResult result = (UnderReplicatedHealthResult)
         healthCheck.checkHealth(request);
-    Assert.assertEquals(HealthState.UNDER_REPLICATED, result.getHealthState());
-    Assert.assertEquals(1, result.getRemainingRedundancy());
-    Assert.assertTrue(result.isReplicatedOkAfterPending());
-    Assert.assertFalse(result.underReplicatedDueToDecommission());
+    assertEquals(HealthState.UNDER_REPLICATED, result.getHealthState());
+    assertEquals(1, result.getRemainingRedundancy());
+    assertTrue(result.isReplicatedOkAfterPending());
+    assertFalse(result.underReplicatedDueToDecommission());
 
-    Assert.assertTrue(healthCheck.handle(request));
+    assertTrue(healthCheck.handle(request));
     // Fixed with pending so nothing added to the queue
-    Assert.assertEquals(0, repQueue.underReplicatedQueueSize());
-    Assert.assertEquals(0, repQueue.overReplicatedQueueSize());
+    assertEquals(0, repQueue.underReplicatedQueueSize());
+    assertEquals(0, repQueue.overReplicatedQueueSize());
     // Still under replicated until the pending complete
-    Assert.assertEquals(1, report.getStat(
+    assertEquals(1, report.getStat(
         ReplicationManagerReport.HealthState.UNDER_REPLICATED));
   }
 
@@ -175,16 +177,16 @@ public class TestECReplicationCheckHandler {
 
     UnderReplicatedHealthResult result = (UnderReplicatedHealthResult)
         healthCheck.checkHealth(request);
-    Assert.assertEquals(HealthState.UNDER_REPLICATED, result.getHealthState());
-    Assert.assertEquals(2, result.getRemainingRedundancy());
-    Assert.assertFalse(result.isReplicatedOkAfterPending());
-    Assert.assertTrue(result.underReplicatedDueToDecommission());
+    assertEquals(HealthState.UNDER_REPLICATED, result.getHealthState());
+    assertEquals(2, result.getRemainingRedundancy());
+    assertFalse(result.isReplicatedOkAfterPending());
+    assertTrue(result.underReplicatedDueToDecommission());
 
-    Assert.assertTrue(healthCheck.handle(request));
-    Assert.assertEquals(1, repQueue.underReplicatedQueueSize());
-    Assert.assertEquals(0, repQueue.overReplicatedQueueSize());
+    assertTrue(healthCheck.handle(request));
+    assertEquals(1, repQueue.underReplicatedQueueSize());
+    assertEquals(0, repQueue.overReplicatedQueueSize());
     // Still under replicated until the pending complete
-    Assert.assertEquals(1, report.getStat(
+    assertEquals(1, report.getStat(
         ReplicationManagerReport.HealthState.UNDER_REPLICATED));
   }
 
@@ -206,17 +208,17 @@ public class TestECReplicationCheckHandler {
 
     UnderReplicatedHealthResult result = (UnderReplicatedHealthResult)
         healthCheck.checkHealth(request);
-    Assert.assertEquals(HealthState.UNDER_REPLICATED, result.getHealthState());
-    Assert.assertEquals(2, result.getRemainingRedundancy());
-    Assert.assertTrue(result.isReplicatedOkAfterPending());
-    Assert.assertTrue(result.underReplicatedDueToDecommission());
+    assertEquals(HealthState.UNDER_REPLICATED, result.getHealthState());
+    assertEquals(2, result.getRemainingRedundancy());
+    assertTrue(result.isReplicatedOkAfterPending());
+    assertTrue(result.underReplicatedDueToDecommission());
 
-    Assert.assertTrue(healthCheck.handle(request));
+    assertTrue(healthCheck.handle(request));
     // Fixed with pending so nothing added to the queue
-    Assert.assertEquals(0, repQueue.underReplicatedQueueSize());
-    Assert.assertEquals(0, repQueue.overReplicatedQueueSize());
+    assertEquals(0, repQueue.underReplicatedQueueSize());
+    assertEquals(0, repQueue.overReplicatedQueueSize());
     // Still under replicated until the pending complete
-    Assert.assertEquals(1, report.getStat(
+    assertEquals(1, report.getStat(
         ReplicationManagerReport.HealthState.UNDER_REPLICATED));
   }
 
@@ -237,15 +239,15 @@ public class TestECReplicationCheckHandler {
         .build();
     UnderReplicatedHealthResult result = (UnderReplicatedHealthResult)
         healthCheck.checkHealth(request);
-    Assert.assertEquals(HealthState.UNDER_REPLICATED, result.getHealthState());
-    Assert.assertEquals(1, result.getRemainingRedundancy());
-    Assert.assertFalse(result.isReplicatedOkAfterPending());
-    Assert.assertFalse(result.underReplicatedDueToDecommission());
+    assertEquals(HealthState.UNDER_REPLICATED, result.getHealthState());
+    assertEquals(1, result.getRemainingRedundancy());
+    assertFalse(result.isReplicatedOkAfterPending());
+    assertFalse(result.underReplicatedDueToDecommission());
 
-    Assert.assertTrue(healthCheck.handle(request));
-    Assert.assertEquals(1, repQueue.underReplicatedQueueSize());
-    Assert.assertEquals(0, repQueue.overReplicatedQueueSize());
-    Assert.assertEquals(1, report.getStat(
+    assertTrue(healthCheck.handle(request));
+    assertEquals(1, repQueue.underReplicatedQueueSize());
+    assertEquals(0, repQueue.overReplicatedQueueSize());
+    assertEquals(1, report.getStat(
         ReplicationManagerReport.HealthState.UNDER_REPLICATED));
   }
 
@@ -261,19 +263,19 @@ public class TestECReplicationCheckHandler {
 
     UnderReplicatedHealthResult result = (UnderReplicatedHealthResult)
         healthCheck.checkHealth(request);
-    Assert.assertEquals(HealthState.UNDER_REPLICATED, result.getHealthState());
-    Assert.assertEquals(-1, result.getRemainingRedundancy());
-    Assert.assertFalse(result.isReplicatedOkAfterPending());
-    Assert.assertFalse(result.underReplicatedDueToDecommission());
-    Assert.assertTrue(result.isUnrecoverable());
+    assertEquals(HealthState.UNDER_REPLICATED, result.getHealthState());
+    assertEquals(-1, result.getRemainingRedundancy());
+    assertFalse(result.isReplicatedOkAfterPending());
+    assertFalse(result.underReplicatedDueToDecommission());
+    assertTrue(result.isUnrecoverable());
 
-    Assert.assertTrue(healthCheck.handle(request));
+    assertTrue(healthCheck.handle(request));
     // Unrecoverable so not added to the queue
-    Assert.assertEquals(0, repQueue.underReplicatedQueueSize());
-    Assert.assertEquals(0, repQueue.overReplicatedQueueSize());
-    Assert.assertEquals(0, report.getStat(
+    assertEquals(0, repQueue.underReplicatedQueueSize());
+    assertEquals(0, repQueue.overReplicatedQueueSize());
+    assertEquals(0, report.getStat(
         ReplicationManagerReport.HealthState.UNDER_REPLICATED));
-    Assert.assertEquals(1, report.getStat(
+    assertEquals(1, report.getStat(
         ReplicationManagerReport.HealthState.MISSING));
   }
 
@@ -299,20 +301,20 @@ public class TestECReplicationCheckHandler {
 
     UnderReplicatedHealthResult result = (UnderReplicatedHealthResult)
         healthCheck.checkHealth(request);
-    Assert.assertEquals(HealthState.UNDER_REPLICATED, result.getHealthState());
-    Assert.assertEquals(-1, result.getRemainingRedundancy());
-    Assert.assertFalse(result.isReplicatedOkAfterPending());
-    Assert.assertFalse(result.underReplicatedDueToDecommission());
-    Assert.assertTrue(result.isUnrecoverable());
-    Assert.assertTrue(result.hasUnreplicatedOfflineIndexes());
+    assertEquals(HealthState.UNDER_REPLICATED, result.getHealthState());
+    assertEquals(-1, result.getRemainingRedundancy());
+    assertFalse(result.isReplicatedOkAfterPending());
+    assertFalse(result.underReplicatedDueToDecommission());
+    assertTrue(result.isUnrecoverable());
+    assertTrue(result.hasUnreplicatedOfflineIndexes());
 
-    Assert.assertTrue(healthCheck.handle(request));
+    assertTrue(healthCheck.handle(request));
     // Unrecoverable so not added to the queue
-    Assert.assertEquals(1, repQueue.underReplicatedQueueSize());
-    Assert.assertEquals(0, repQueue.overReplicatedQueueSize());
-    Assert.assertEquals(0, report.getStat(
+    assertEquals(1, repQueue.underReplicatedQueueSize());
+    assertEquals(0, repQueue.overReplicatedQueueSize());
+    assertEquals(0, report.getStat(
         ReplicationManagerReport.HealthState.UNDER_REPLICATED));
-    Assert.assertEquals(1, report.getStat(
+    assertEquals(1, report.getStat(
         ReplicationManagerReport.HealthState.MISSING));
   }
 
@@ -342,20 +344,20 @@ public class TestECReplicationCheckHandler {
 
     UnderReplicatedHealthResult result = (UnderReplicatedHealthResult)
         healthCheck.checkHealth(request);
-    Assert.assertEquals(HealthState.UNDER_REPLICATED, result.getHealthState());
-    Assert.assertEquals(-1, result.getRemainingRedundancy());
-    Assert.assertFalse(result.isReplicatedOkAfterPending());
-    Assert.assertFalse(result.underReplicatedDueToDecommission());
-    Assert.assertTrue(result.isUnrecoverable());
-    Assert.assertFalse(result.hasUnreplicatedOfflineIndexes());
+    assertEquals(HealthState.UNDER_REPLICATED, result.getHealthState());
+    assertEquals(-1, result.getRemainingRedundancy());
+    assertFalse(result.isReplicatedOkAfterPending());
+    assertFalse(result.underReplicatedDueToDecommission());
+    assertTrue(result.isUnrecoverable());
+    assertFalse(result.hasUnreplicatedOfflineIndexes());
 
-    Assert.assertTrue(healthCheck.handle(request));
+    assertTrue(healthCheck.handle(request));
     // Unrecoverable so not added to the queue
-    Assert.assertEquals(0, repQueue.underReplicatedQueueSize());
-    Assert.assertEquals(0, repQueue.overReplicatedQueueSize());
-    Assert.assertEquals(1, report.getStat(
+    assertEquals(0, repQueue.underReplicatedQueueSize());
+    assertEquals(0, repQueue.overReplicatedQueueSize());
+    assertEquals(1, report.getStat(
         ReplicationManagerReport.HealthState.UNDER_REPLICATED));
-    Assert.assertEquals(1, report.getStat(
+    assertEquals(1, report.getStat(
         ReplicationManagerReport.HealthState.MISSING));
   }
 
@@ -387,15 +389,15 @@ public class TestECReplicationCheckHandler {
 
     UnderReplicatedHealthResult result = (UnderReplicatedHealthResult)
         healthCheck.checkHealth(request);
-    Assert.assertEquals(HealthState.UNDER_REPLICATED, result.getHealthState());
-    Assert.assertEquals(0, result.getRemainingRedundancy());
-    Assert.assertFalse(result.isReplicatedOkAfterPending());
-    Assert.assertFalse(result.underReplicatedDueToDecommission());
+    assertEquals(HealthState.UNDER_REPLICATED, result.getHealthState());
+    assertEquals(0, result.getRemainingRedundancy());
+    assertFalse(result.isReplicatedOkAfterPending());
+    assertFalse(result.underReplicatedDueToDecommission());
 
-    Assert.assertTrue(healthCheck.handle(request));
-    Assert.assertEquals(1, repQueue.underReplicatedQueueSize());
-    Assert.assertEquals(0, repQueue.overReplicatedQueueSize());
-    Assert.assertEquals(1, report.getStat(
+    assertTrue(healthCheck.handle(request));
+    assertEquals(1, repQueue.underReplicatedQueueSize());
+    assertEquals(0, repQueue.overReplicatedQueueSize());
+    assertEquals(1, report.getStat(
         ReplicationManagerReport.HealthState.UNDER_REPLICATED));
   }
 
@@ -424,11 +426,11 @@ public class TestECReplicationCheckHandler {
         .build();
 
     ContainerHealthResult result = healthCheck.checkHealth(request);
-    Assert.assertEquals(HealthState.HEALTHY, result.getHealthState());
+    assertEquals(HealthState.HEALTHY, result.getHealthState());
 
-    Assert.assertFalse(healthCheck.handle(request));
-    Assert.assertEquals(0, repQueue.underReplicatedQueueSize());
-    Assert.assertEquals(0, repQueue.overReplicatedQueueSize());
+    assertFalse(healthCheck.handle(request));
+    assertEquals(0, repQueue.underReplicatedQueueSize());
+    assertEquals(0, repQueue.overReplicatedQueueSize());
   }
 
   @Test
@@ -447,14 +449,14 @@ public class TestECReplicationCheckHandler {
 
     OverReplicatedHealthResult result = (OverReplicatedHealthResult)
         healthCheck.checkHealth(request);
-    Assert.assertEquals(HealthState.OVER_REPLICATED, result.getHealthState());
-    Assert.assertEquals(2, result.getExcessRedundancy());
-    Assert.assertFalse(result.isReplicatedOkAfterPending());
+    assertEquals(HealthState.OVER_REPLICATED, result.getHealthState());
+    assertEquals(2, result.getExcessRedundancy());
+    assertFalse(result.isReplicatedOkAfterPending());
 
-    Assert.assertTrue(healthCheck.handle(request));
-    Assert.assertEquals(0, repQueue.underReplicatedQueueSize());
-    Assert.assertEquals(1, repQueue.overReplicatedQueueSize());
-    Assert.assertEquals(1, report.getStat(
+    assertTrue(healthCheck.handle(request));
+    assertEquals(0, repQueue.underReplicatedQueueSize());
+    assertEquals(1, repQueue.overReplicatedQueueSize());
+    assertEquals(1, report.getStat(
         ReplicationManagerReport.HealthState.OVER_REPLICATED));
   }
 
@@ -480,14 +482,14 @@ public class TestECReplicationCheckHandler {
 
     OverReplicatedHealthResult result = (OverReplicatedHealthResult)
         healthCheck.checkHealth(request);
-    Assert.assertEquals(HealthState.OVER_REPLICATED, result.getHealthState());
-    Assert.assertEquals(2, result.getExcessRedundancy());
-    Assert.assertTrue(result.isReplicatedOkAfterPending());
+    assertEquals(HealthState.OVER_REPLICATED, result.getHealthState());
+    assertEquals(2, result.getExcessRedundancy());
+    assertTrue(result.isReplicatedOkAfterPending());
 
-    Assert.assertTrue(healthCheck.handle(request));
-    Assert.assertEquals(0, repQueue.underReplicatedQueueSize());
-    Assert.assertEquals(0, repQueue.overReplicatedQueueSize());
-    Assert.assertEquals(1, report.getStat(
+    assertTrue(healthCheck.handle(request));
+    assertEquals(0, repQueue.underReplicatedQueueSize());
+    assertEquals(0, repQueue.overReplicatedQueueSize());
+    assertEquals(1, report.getStat(
         ReplicationManagerReport.HealthState.OVER_REPLICATED));
   }
 
@@ -504,14 +506,14 @@ public class TestECReplicationCheckHandler {
         .setContainerInfo(container)
         .build();
     ContainerHealthResult result = healthCheck.checkHealth(request);
-    Assert.assertEquals(HealthState.HEALTHY, result.getHealthState());
+    assertEquals(HealthState.HEALTHY, result.getHealthState());
 
     // As it is maintenance replicas causing the over replication, the container
     // is not really over-replicated.
-    Assert.assertFalse(healthCheck.handle(request));
-    Assert.assertEquals(0, repQueue.underReplicatedQueueSize());
-    Assert.assertEquals(0, repQueue.overReplicatedQueueSize());
-    Assert.assertEquals(0, report.getStat(
+    assertFalse(healthCheck.handle(request));
+    assertEquals(0, repQueue.underReplicatedQueueSize());
+    assertEquals(0, repQueue.overReplicatedQueueSize());
+    assertEquals(0, report.getStat(
         ReplicationManagerReport.HealthState.OVER_REPLICATED));
   }
 
@@ -527,18 +529,18 @@ public class TestECReplicationCheckHandler {
         .setContainerInfo(container)
         .build();
     ContainerHealthResult result = healthCheck.checkHealth(request);
-    Assert.assertEquals(HealthState.UNDER_REPLICATED, result.getHealthState());
-    Assert.assertEquals(1,
+    assertEquals(HealthState.UNDER_REPLICATED, result.getHealthState());
+    assertEquals(1,
         ((UnderReplicatedHealthResult)result).getRemainingRedundancy());
 
     // Under-replicated takes precedence and the over-replication is ignored
     // for now.
-    Assert.assertTrue(healthCheck.handle(request));
-    Assert.assertEquals(1, repQueue.underReplicatedQueueSize());
-    Assert.assertEquals(0, repQueue.overReplicatedQueueSize());
-    Assert.assertEquals(1, report.getStat(
+    assertTrue(healthCheck.handle(request));
+    assertEquals(1, repQueue.underReplicatedQueueSize());
+    assertEquals(0, repQueue.overReplicatedQueueSize());
+    assertEquals(1, report.getStat(
         ReplicationManagerReport.HealthState.UNDER_REPLICATED));
-    Assert.assertEquals(0, report.getStat(
+    assertEquals(0, report.getStat(
         ReplicationManagerReport.HealthState.OVER_REPLICATED));
   }
 
@@ -563,16 +565,16 @@ public class TestECReplicationCheckHandler {
         .build();
 
     ContainerHealthResult result = healthCheck.checkHealth(request);
-    Assert.assertEquals(HealthState.MIS_REPLICATED, result.getHealthState());
+    assertEquals(HealthState.MIS_REPLICATED, result.getHealthState());
 
-    Assert.assertTrue(healthCheck.handle(request));
-    Assert.assertEquals(1, repQueue.underReplicatedQueueSize());
-    Assert.assertEquals(0, repQueue.overReplicatedQueueSize());
-    Assert.assertEquals(0, report.getStat(
+    assertTrue(healthCheck.handle(request));
+    assertEquals(1, repQueue.underReplicatedQueueSize());
+    assertEquals(0, repQueue.overReplicatedQueueSize());
+    assertEquals(0, report.getStat(
         ReplicationManagerReport.HealthState.UNDER_REPLICATED));
-    Assert.assertEquals(0, report.getStat(
+    assertEquals(0, report.getStat(
         ReplicationManagerReport.HealthState.OVER_REPLICATED));
-    Assert.assertEquals(1, report.getStat(
+    assertEquals(1, report.getStat(
         ReplicationManagerReport.HealthState.MIS_REPLICATED));
   }
 
@@ -608,18 +610,18 @@ public class TestECReplicationCheckHandler {
         .build();
 
     ContainerHealthResult result = healthCheck.checkHealth(request);
-    Assert.assertEquals(HealthState.MIS_REPLICATED, result.getHealthState());
+    assertEquals(HealthState.MIS_REPLICATED, result.getHealthState());
 
     // Under-replicated takes precedence and the over-replication is ignored
     // for now.
-    Assert.assertTrue(healthCheck.handle(request));
-    Assert.assertEquals(0, repQueue.underReplicatedQueueSize());
-    Assert.assertEquals(0, repQueue.overReplicatedQueueSize());
-    Assert.assertEquals(0, report.getStat(
+    assertTrue(healthCheck.handle(request));
+    assertEquals(0, repQueue.underReplicatedQueueSize());
+    assertEquals(0, repQueue.overReplicatedQueueSize());
+    assertEquals(0, report.getStat(
         ReplicationManagerReport.HealthState.UNDER_REPLICATED));
-    Assert.assertEquals(0, report.getStat(
+    assertEquals(0, report.getStat(
         ReplicationManagerReport.HealthState.OVER_REPLICATED));
-    Assert.assertEquals(1, report.getStat(
+    assertEquals(1, report.getStat(
         ReplicationManagerReport.HealthState.MIS_REPLICATED));
   }
 
@@ -643,18 +645,18 @@ public class TestECReplicationCheckHandler {
         .build();
 
     ContainerHealthResult result = healthCheck.checkHealth(request);
-    Assert.assertEquals(HealthState.UNDER_REPLICATED, result.getHealthState());
+    assertEquals(HealthState.UNDER_REPLICATED, result.getHealthState());
 
     // Under-replicated takes precedence and the over-replication is ignored
     // for now.
-    Assert.assertTrue(healthCheck.handle(request));
-    Assert.assertEquals(1, repQueue.underReplicatedQueueSize());
-    Assert.assertEquals(0, repQueue.overReplicatedQueueSize());
-    Assert.assertEquals(1, report.getStat(
+    assertTrue(healthCheck.handle(request));
+    assertEquals(1, repQueue.underReplicatedQueueSize());
+    assertEquals(0, repQueue.overReplicatedQueueSize());
+    assertEquals(1, report.getStat(
         ReplicationManagerReport.HealthState.UNDER_REPLICATED));
-    Assert.assertEquals(0, report.getStat(
+    assertEquals(0, report.getStat(
         ReplicationManagerReport.HealthState.OVER_REPLICATED));
-    Assert.assertEquals(0, report.getStat(
+    assertEquals(0, report.getStat(
         ReplicationManagerReport.HealthState.MIS_REPLICATED));
   }
 
@@ -679,18 +681,18 @@ public class TestECReplicationCheckHandler {
         .build();
 
     ContainerHealthResult result = healthCheck.checkHealth(request);
-    Assert.assertEquals(HealthState.OVER_REPLICATED, result.getHealthState());
+    assertEquals(HealthState.OVER_REPLICATED, result.getHealthState());
 
     // Under-replicated takes precedence and the over-replication is ignored
     // for now.
-    Assert.assertTrue(healthCheck.handle(request));
-    Assert.assertEquals(0, repQueue.underReplicatedQueueSize());
-    Assert.assertEquals(1, repQueue.overReplicatedQueueSize());
-    Assert.assertEquals(0, report.getStat(
+    assertTrue(healthCheck.handle(request));
+    assertEquals(0, repQueue.underReplicatedQueueSize());
+    assertEquals(1, repQueue.overReplicatedQueueSize());
+    assertEquals(0, report.getStat(
         ReplicationManagerReport.HealthState.UNDER_REPLICATED));
-    Assert.assertEquals(1, report.getStat(
+    assertEquals(1, report.getStat(
         ReplicationManagerReport.HealthState.OVER_REPLICATED));
-    Assert.assertEquals(0, report.getStat(
+    assertEquals(0, report.getStat(
         ReplicationManagerReport.HealthState.MIS_REPLICATED));
   }
 
@@ -718,14 +720,14 @@ public class TestECReplicationCheckHandler {
         .setPendingOps(pendingOps)
         .build();
     ContainerHealthResult result = healthCheck.checkHealth(request);
-    Assert.assertEquals(HealthState.HEALTHY, result.getHealthState());
+    assertEquals(HealthState.HEALTHY, result.getHealthState());
 
-    Assert.assertFalse(healthCheck.handle(request));
-    Assert.assertEquals(0, repQueue.underReplicatedQueueSize());
-    Assert.assertEquals(0, repQueue.overReplicatedQueueSize());
-    Assert.assertEquals(0, report.getStat(
+    assertFalse(healthCheck.handle(request));
+    assertEquals(0, repQueue.underReplicatedQueueSize());
+    assertEquals(0, repQueue.overReplicatedQueueSize());
+    assertEquals(0, report.getStat(
         ReplicationManagerReport.HealthState.UNDER_REPLICATED));
-    Assert.assertEquals(0, report.getStat(
+    assertEquals(0, report.getStat(
         ReplicationManagerReport.HealthState.OVER_REPLICATED));
   }
 

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/health/TestECReplicationCheckHandler.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/health/TestECReplicationCheckHandler.java
@@ -125,7 +125,7 @@ public class TestECReplicationCheckHandler {
     assertEquals(HealthState.UNDER_REPLICATED, result.getHealthState());
     assertEquals(1, result.getRemainingRedundancy());
     assertFalse(result.isReplicatedOkAfterPending());
-    assertFalse(result.underReplicatedDueToDecommission());
+    assertFalse(result.underReplicatedDueToOutOfService());
 
     assertTrue(healthCheck.handle(request));
     assertEquals(1, repQueue.underReplicatedQueueSize());
@@ -152,7 +152,7 @@ public class TestECReplicationCheckHandler {
     assertEquals(HealthState.UNDER_REPLICATED, result.getHealthState());
     assertEquals(1, result.getRemainingRedundancy());
     assertTrue(result.isReplicatedOkAfterPending());
-    assertFalse(result.underReplicatedDueToDecommission());
+    assertFalse(result.underReplicatedDueToOutOfService());
 
     assertTrue(healthCheck.handle(request));
     // Fixed with pending so nothing added to the queue
@@ -164,7 +164,7 @@ public class TestECReplicationCheckHandler {
   }
 
   @Test
-  public void testUnderReplicatedDueToDecommission() {
+  public void testUnderReplicatedDueToOutOfService() {
     ContainerInfo container = createContainerInfo(repConfig);
     Set<ContainerReplica> replicas = createReplicas(container.containerID(),
         Pair.of(IN_SERVICE, 1), Pair.of(IN_SERVICE, 2),
@@ -180,7 +180,7 @@ public class TestECReplicationCheckHandler {
     assertEquals(HealthState.UNDER_REPLICATED, result.getHealthState());
     assertEquals(2, result.getRemainingRedundancy());
     assertFalse(result.isReplicatedOkAfterPending());
-    assertTrue(result.underReplicatedDueToDecommission());
+    assertTrue(result.underReplicatedDueToOutOfService());
 
     assertTrue(healthCheck.handle(request));
     assertEquals(1, repQueue.underReplicatedQueueSize());
@@ -191,7 +191,7 @@ public class TestECReplicationCheckHandler {
   }
 
   @Test
-  public void testUnderReplicatedDueToDecommissionFixedWithPending() {
+  public void testUnderReplicatedDueToOutOfServiceFixedWithPending() {
     ContainerInfo container = createContainerInfo(repConfig);
     Set<ContainerReplica> replicas = createReplicas(container.containerID(),
         Pair.of(IN_SERVICE, 1), Pair.of(IN_SERVICE, 2),
@@ -211,7 +211,7 @@ public class TestECReplicationCheckHandler {
     assertEquals(HealthState.UNDER_REPLICATED, result.getHealthState());
     assertEquals(2, result.getRemainingRedundancy());
     assertTrue(result.isReplicatedOkAfterPending());
-    assertTrue(result.underReplicatedDueToDecommission());
+    assertTrue(result.underReplicatedDueToOutOfService());
 
     assertTrue(healthCheck.handle(request));
     // Fixed with pending so nothing added to the queue
@@ -223,7 +223,7 @@ public class TestECReplicationCheckHandler {
   }
 
   @Test
-  public void testUnderReplicatedDueToDecommissionAndMissingReplica() {
+  public void testUnderReplicatedDueToOutOfServiceAndMissingReplica() {
     ContainerInfo container = createContainerInfo(repConfig);
     Set<ContainerReplica> replicas = createReplicas(container.containerID(),
         Pair.of(IN_SERVICE, 1), Pair.of(IN_SERVICE, 2),
@@ -242,7 +242,7 @@ public class TestECReplicationCheckHandler {
     assertEquals(HealthState.UNDER_REPLICATED, result.getHealthState());
     assertEquals(1, result.getRemainingRedundancy());
     assertFalse(result.isReplicatedOkAfterPending());
-    assertFalse(result.underReplicatedDueToDecommission());
+    assertFalse(result.underReplicatedDueToOutOfService());
 
     assertTrue(healthCheck.handle(request));
     assertEquals(1, repQueue.underReplicatedQueueSize());
@@ -266,7 +266,7 @@ public class TestECReplicationCheckHandler {
     assertEquals(HealthState.UNDER_REPLICATED, result.getHealthState());
     assertEquals(-1, result.getRemainingRedundancy());
     assertFalse(result.isReplicatedOkAfterPending());
-    assertFalse(result.underReplicatedDueToDecommission());
+    assertFalse(result.underReplicatedDueToOutOfService());
     assertTrue(result.isUnrecoverable());
 
     assertTrue(healthCheck.handle(request));
@@ -304,7 +304,7 @@ public class TestECReplicationCheckHandler {
     assertEquals(HealthState.UNDER_REPLICATED, result.getHealthState());
     assertEquals(-1, result.getRemainingRedundancy());
     assertFalse(result.isReplicatedOkAfterPending());
-    assertFalse(result.underReplicatedDueToDecommission());
+    assertFalse(result.underReplicatedDueToOutOfService());
     assertTrue(result.isUnrecoverable());
     assertTrue(result.hasUnreplicatedOfflineIndexes());
 
@@ -347,7 +347,7 @@ public class TestECReplicationCheckHandler {
     assertEquals(HealthState.UNDER_REPLICATED, result.getHealthState());
     assertEquals(-1, result.getRemainingRedundancy());
     assertFalse(result.isReplicatedOkAfterPending());
-    assertFalse(result.underReplicatedDueToDecommission());
+    assertFalse(result.underReplicatedDueToOutOfService());
     assertTrue(result.isUnrecoverable());
     assertFalse(result.hasUnreplicatedOfflineIndexes());
 
@@ -392,7 +392,7 @@ public class TestECReplicationCheckHandler {
     assertEquals(HealthState.UNDER_REPLICATED, result.getHealthState());
     assertEquals(0, result.getRemainingRedundancy());
     assertFalse(result.isReplicatedOkAfterPending());
-    assertFalse(result.underReplicatedDueToDecommission());
+    assertFalse(result.underReplicatedDueToOutOfService());
 
     assertTrue(healthCheck.handle(request));
     assertEquals(1, repQueue.underReplicatedQueueSize());

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/health/TestRatisReplicationCheckHandler.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/health/TestRatisReplicationCheckHandler.java
@@ -308,9 +308,8 @@ public class TestRatisReplicationCheckHandler {
   @Test
   public void testUnderReplicatedAndUnrecoverable() {
     ContainerInfo container = createContainerInfo(repConfig);
-    Set<ContainerReplica> replicas = Collections.EMPTY_SET;
 
-    requestBuilder.setContainerReplicas(replicas)
+    requestBuilder.setContainerReplicas(Collections.emptySet())
         .setContainerInfo(container);
     UnderReplicatedHealthResult result = (UnderReplicatedHealthResult)
         healthCheck.checkHealth(requestBuilder.build());

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/health/TestRatisReplicationCheckHandler.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/health/TestRatisReplicationCheckHandler.java
@@ -137,7 +137,7 @@ public class TestRatisReplicationCheckHandler {
     assertEquals(HealthState.UNDER_REPLICATED, result.getHealthState());
     assertEquals(1, result.getRemainingRedundancy());
     assertFalse(result.isReplicatedOkAfterPending());
-    assertFalse(result.underReplicatedDueToDecommission());
+    assertFalse(result.underReplicatedDueToOutOfService());
 
     assertTrue(healthCheck.handle(requestBuilder.build()));
     assertEquals(1, repQueue.underReplicatedQueueSize());
@@ -162,7 +162,7 @@ public class TestRatisReplicationCheckHandler {
     assertEquals(HealthState.UNDER_REPLICATED, result.getHealthState());
     assertEquals(1, result.getRemainingRedundancy());
     assertFalse(result.isReplicatedOkAfterPending());
-    assertFalse(result.underReplicatedDueToDecommission());
+    assertFalse(result.underReplicatedDueToOutOfService());
 
     assertTrue(healthCheck.handle(requestBuilder.build()));
     assertEquals(1, repQueue.underReplicatedQueueSize());
@@ -187,7 +187,7 @@ public class TestRatisReplicationCheckHandler {
     assertEquals(HealthState.UNDER_REPLICATED, result.getHealthState());
     assertEquals(1, result.getRemainingRedundancy());
     assertTrue(result.isReplicatedOkAfterPending());
-    assertFalse(result.underReplicatedDueToDecommission());
+    assertFalse(result.underReplicatedDueToOutOfService());
 
     assertTrue(healthCheck.handle(requestBuilder.build()));
     // Fixed with pending, so nothing added to the queue
@@ -199,7 +199,7 @@ public class TestRatisReplicationCheckHandler {
   }
 
   @Test
-  public void testUnderReplicatedDueToDecommission() {
+  public void testUnderReplicatedDueToOutOfService() {
     ContainerInfo container = createContainerInfo(repConfig);
     Set<ContainerReplica> replicas = createReplicas(container.containerID(),
         Pair.of(IN_SERVICE, 0), Pair.of(DECOMMISSIONING, 0),
@@ -212,7 +212,7 @@ public class TestRatisReplicationCheckHandler {
     assertEquals(HealthState.UNDER_REPLICATED, result.getHealthState());
     assertEquals(2, result.getRemainingRedundancy());
     assertFalse(result.isReplicatedOkAfterPending());
-    assertTrue(result.underReplicatedDueToDecommission());
+    assertTrue(result.underReplicatedDueToOutOfService());
 
     assertTrue(healthCheck.handle(requestBuilder.build()));
     assertEquals(1, repQueue.underReplicatedQueueSize());
@@ -245,7 +245,7 @@ public class TestRatisReplicationCheckHandler {
 
     assertEquals(2, result.getRemainingRedundancy());
     assertFalse(result.isReplicatedOkAfterPending());
-    assertTrue(result.underReplicatedDueToDecommission());
+    assertTrue(result.underReplicatedDueToOutOfService());
 
     assertTrue(healthCheck.handle(checkRequest));
     assertEquals(1, repQueue.underReplicatedQueueSize());
@@ -255,7 +255,7 @@ public class TestRatisReplicationCheckHandler {
   }
 
   @Test
-  public void testUnderReplicatedDueToDecommissionFixedWithPending() {
+  public void testUnderReplicatedDueToOutOfServiceFixedWithPending() {
     ContainerInfo container = createContainerInfo(repConfig);
     Set<ContainerReplica> replicas = createReplicas(container.containerID(),
         Pair.of(IN_SERVICE, 0), Pair.of(IN_SERVICE, 0),
@@ -272,7 +272,7 @@ public class TestRatisReplicationCheckHandler {
     assertEquals(HealthState.UNDER_REPLICATED, result.getHealthState());
     assertEquals(2, result.getRemainingRedundancy());
     assertTrue(result.isReplicatedOkAfterPending());
-    assertTrue(result.underReplicatedDueToDecommission());
+    assertTrue(result.underReplicatedDueToOutOfService());
 
     assertTrue(healthCheck.handle(requestBuilder.build()));
     // Nothing queued as inflight replicas will fix it.
@@ -284,7 +284,7 @@ public class TestRatisReplicationCheckHandler {
   }
 
   @Test
-  public void testUnderReplicatedDueToDecommissionAndMissing() {
+  public void testUnderReplicatedDueToOutOfServiceAndMissing() {
     ContainerInfo container = createContainerInfo(repConfig);
     Set<ContainerReplica> replicas = createReplicas(container.containerID(),
         Pair.of(IN_SERVICE, 0), Pair.of(DECOMMISSIONED, 0));
@@ -300,7 +300,7 @@ public class TestRatisReplicationCheckHandler {
     assertEquals(HealthState.UNDER_REPLICATED, result.getHealthState());
     assertEquals(1, result.getRemainingRedundancy());
     assertFalse(result.isReplicatedOkAfterPending());
-    assertFalse(result.underReplicatedDueToDecommission());
+    assertFalse(result.underReplicatedDueToOutOfService());
 
     assertTrue(healthCheck.handle(requestBuilder.build()));
     assertEquals(1, repQueue.underReplicatedQueueSize());
@@ -320,7 +320,7 @@ public class TestRatisReplicationCheckHandler {
     assertEquals(HealthState.UNDER_REPLICATED, result.getHealthState());
     assertEquals(0, result.getRemainingRedundancy());
     assertFalse(result.isReplicatedOkAfterPending());
-    assertFalse(result.underReplicatedDueToDecommission());
+    assertFalse(result.underReplicatedDueToOutOfService());
     assertTrue(result.isUnrecoverable());
 
     assertTrue(healthCheck.handle(requestBuilder.build()));
@@ -354,7 +354,7 @@ public class TestRatisReplicationCheckHandler {
     assertEquals(HealthState.UNDER_REPLICATED, result.getHealthState());
     assertEquals(1, result.getRemainingRedundancy());
     assertFalse(result.isReplicatedOkAfterPending());
-    assertFalse(result.underReplicatedDueToDecommission());
+    assertFalse(result.underReplicatedDueToOutOfService());
 
     assertTrue(healthCheck.handle(requestBuilder.build()));
     assertEquals(1, repQueue.underReplicatedQueueSize());
@@ -398,7 +398,7 @@ public class TestRatisReplicationCheckHandler {
     assertEquals(HealthState.UNDER_REPLICATED, result.getHealthState());
     assertEquals(0, result.getRemainingRedundancy());
     assertFalse(result.isReplicatedOkAfterPending());
-    assertFalse(result.underReplicatedDueToDecommission());
+    assertFalse(result.underReplicatedDueToOutOfService());
 
     assertFalse(healthCheck.handle(requestBuilder.build()));
     assertEquals(0, repQueue.underReplicatedQueueSize());
@@ -420,7 +420,7 @@ public class TestRatisReplicationCheckHandler {
     assertEquals(HealthState.UNDER_REPLICATED, result.getHealthState());
     assertEquals(0, result.getRemainingRedundancy());
     assertFalse(result.isReplicatedOkAfterPending());
-    assertFalse(result.underReplicatedDueToDecommission());
+    assertFalse(result.underReplicatedDueToOutOfService());
 
     assertFalse(healthCheck.handle(requestBuilder.build()));
     assertEquals(0, repQueue.underReplicatedQueueSize());
@@ -705,7 +705,7 @@ public class TestRatisReplicationCheckHandler {
     assertEquals(HealthState.UNDER_REPLICATED, result.getHealthState());
     assertEquals(1, result.getRemainingRedundancy());
     assertFalse(result.isReplicatedOkAfterPending());
-    assertFalse(result.underReplicatedDueToDecommission());
+    assertFalse(result.underReplicatedDueToOutOfService());
 
     assertTrue(healthCheck.handle(requestBuilder.build()));
     assertEquals(1, repQueue.underReplicatedQueueSize());
@@ -749,7 +749,7 @@ public class TestRatisReplicationCheckHandler {
     assertEquals(HealthState.UNDER_REPLICATED, result.getHealthState());
     assertEquals(1, result.getRemainingRedundancy());
     assertTrue(result.isReplicatedOkAfterPending());
-    assertFalse(result.underReplicatedDueToDecommission());
+    assertFalse(result.underReplicatedDueToOutOfService());
 
     assertTrue(healthCheck.handle(requestBuilder.build()));
     assertEquals(0, repQueue.underReplicatedQueueSize());

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/health/TestRatisReplicationCheckHandler.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/health/TestRatisReplicationCheckHandler.java
@@ -39,6 +39,8 @@ import org.apache.hadoop.hdds.scm.container.replication.ContainerReplicaOp;
 import org.apache.hadoop.hdds.scm.container.replication.ReplicationQueue;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.Mockito;
 
 import java.io.IOException;
@@ -219,14 +221,14 @@ public class TestRatisReplicationCheckHandler {
         ReplicationManagerReport.HealthState.UNDER_REPLICATED));
   }
 
-  @Test
-  public void testUnderReplicatedDueToAllDecommissioning() {
-    Pair<HddsProtos.NodeOperationalState, Integer> state =
-        Pair.of(DECOMMISSIONING, 0);
+  @ParameterizedTest
+  @MethodSource("org.apache.hadoop.hdds.scm.container.replication.TestRatisContainerReplicaCount#outOfServiceStates")
+  void testUnderReplicatedDueToAllOutOfService(HddsProtos.NodeOperationalState state) {
+    Pair<HddsProtos.NodeOperationalState, Integer> pair = Pair.of(state, 0);
 
     ContainerInfo container = createContainerInfo(repConfig);
     Set<ContainerReplica> replicas = createReplicas(container.containerID(),
-        state, state, state);
+        pair, pair, pair);
 
     ContainerCheckRequest checkRequest = requestBuilder
         .setContainerReplicas(replicas)

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/health/TestRatisReplicationCheckHandler.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/health/TestRatisReplicationCheckHandler.java
@@ -222,8 +222,10 @@ public class TestRatisReplicationCheckHandler {
   }
 
   @ParameterizedTest
-  @MethodSource("org.apache.hadoop.hdds.scm.container.replication.TestRatisContainerReplicaCount#outOfServiceStates")
-  void testUnderReplicatedDueToAllOutOfService(HddsProtos.NodeOperationalState state) {
+  @MethodSource("org.apache.hadoop.hdds.scm.container.replication." +
+      "TestRatisContainerReplicaCount#outOfServiceStates")
+  void testUnderReplicatedDueToAllOutOfService(
+      HddsProtos.NodeOperationalState state) {
     Pair<HddsProtos.NodeOperationalState, Integer> pair = Pair.of(state, 0);
 
     ContainerInfo container = createContainerInfo(repConfig);

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/health/TestRatisReplicationCheckHandler.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/health/TestRatisReplicationCheckHandler.java
@@ -37,9 +37,8 @@ import org.apache.hadoop.hdds.scm.container.replication.ContainerHealthResult.Ov
 import org.apache.hadoop.hdds.scm.container.replication.ContainerHealthResult.UnderReplicatedHealthResult;
 import org.apache.hadoop.hdds.scm.container.replication.ContainerReplicaOp;
 import org.apache.hadoop.hdds.scm.container.replication.ReplicationQueue;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 import java.io.IOException;
@@ -58,6 +57,9 @@ import static org.apache.hadoop.hdds.scm.container.replication.ContainerReplicaO
 import static org.apache.hadoop.hdds.scm.container.replication.ReplicationTestUtil.createContainerInfo;
 import static org.apache.hadoop.hdds.scm.container.replication.ReplicationTestUtil.createContainerReplica;
 import static org.apache.hadoop.hdds.scm.container.replication.ReplicationTestUtil.createReplicas;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Tests for the RatisReplicationCheckHandler class.
@@ -72,7 +74,7 @@ public class TestRatisReplicationCheckHandler {
   private ReplicationManagerReport report;
   private int maintenanceRedundancy = 2;
 
-  @Before
+  @BeforeEach
   public void setup() throws IOException {
     containerPlacementPolicy = Mockito.mock(PlacementPolicy.class);
     Mockito.when(containerPlacementPolicy.validateContainerPlacement(
@@ -100,9 +102,9 @@ public class TestRatisReplicationCheckHandler {
 
     requestBuilder.setContainerReplicas(replicas)
         .setContainerInfo(container);
-    Assert.assertFalse(healthCheck.handle(requestBuilder.build()));
-    Assert.assertEquals(0, repQueue.underReplicatedQueueSize());
-    Assert.assertEquals(0, repQueue.overReplicatedQueueSize());
+    assertFalse(healthCheck.handle(requestBuilder.build()));
+    assertEquals(0, repQueue.underReplicatedQueueSize());
+    assertEquals(0, repQueue.overReplicatedQueueSize());
   }
 
   @Test
@@ -114,11 +116,11 @@ public class TestRatisReplicationCheckHandler {
         .setContainerInfo(container);
     ContainerHealthResult result =
         healthCheck.checkHealth(requestBuilder.build());
-    Assert.assertEquals(HealthState.HEALTHY, result.getHealthState());
+    assertEquals(HealthState.HEALTHY, result.getHealthState());
 
-    Assert.assertFalse(healthCheck.handle(requestBuilder.build()));
-    Assert.assertEquals(0, repQueue.underReplicatedQueueSize());
-    Assert.assertEquals(0, repQueue.overReplicatedQueueSize());
+    assertFalse(healthCheck.handle(requestBuilder.build()));
+    assertEquals(0, repQueue.underReplicatedQueueSize());
+    assertEquals(0, repQueue.overReplicatedQueueSize());
   }
 
   @Test
@@ -130,15 +132,15 @@ public class TestRatisReplicationCheckHandler {
         .setContainerInfo(container);
     UnderReplicatedHealthResult result = (UnderReplicatedHealthResult)
         healthCheck.checkHealth(requestBuilder.build());
-    Assert.assertEquals(HealthState.UNDER_REPLICATED, result.getHealthState());
-    Assert.assertEquals(1, result.getRemainingRedundancy());
-    Assert.assertFalse(result.isReplicatedOkAfterPending());
-    Assert.assertFalse(result.underReplicatedDueToDecommission());
+    assertEquals(HealthState.UNDER_REPLICATED, result.getHealthState());
+    assertEquals(1, result.getRemainingRedundancy());
+    assertFalse(result.isReplicatedOkAfterPending());
+    assertFalse(result.underReplicatedDueToDecommission());
 
-    Assert.assertTrue(healthCheck.handle(requestBuilder.build()));
-    Assert.assertEquals(1, repQueue.underReplicatedQueueSize());
-    Assert.assertEquals(0, repQueue.overReplicatedQueueSize());
-    Assert.assertEquals(1, report.getStat(
+    assertTrue(healthCheck.handle(requestBuilder.build()));
+    assertEquals(1, repQueue.underReplicatedQueueSize());
+    assertEquals(0, repQueue.overReplicatedQueueSize());
+    assertEquals(1, report.getStat(
         ReplicationManagerReport.HealthState.UNDER_REPLICATED));
   }
 
@@ -155,15 +157,15 @@ public class TestRatisReplicationCheckHandler {
         .setPendingOps(pending);
     UnderReplicatedHealthResult result = (UnderReplicatedHealthResult)
         healthCheck.checkHealth(requestBuilder.build());
-    Assert.assertEquals(HealthState.UNDER_REPLICATED, result.getHealthState());
-    Assert.assertEquals(1, result.getRemainingRedundancy());
-    Assert.assertFalse(result.isReplicatedOkAfterPending());
-    Assert.assertFalse(result.underReplicatedDueToDecommission());
+    assertEquals(HealthState.UNDER_REPLICATED, result.getHealthState());
+    assertEquals(1, result.getRemainingRedundancy());
+    assertFalse(result.isReplicatedOkAfterPending());
+    assertFalse(result.underReplicatedDueToDecommission());
 
-    Assert.assertTrue(healthCheck.handle(requestBuilder.build()));
-    Assert.assertEquals(1, repQueue.underReplicatedQueueSize());
-    Assert.assertEquals(0, repQueue.overReplicatedQueueSize());
-    Assert.assertEquals(1, report.getStat(
+    assertTrue(healthCheck.handle(requestBuilder.build()));
+    assertEquals(1, repQueue.underReplicatedQueueSize());
+    assertEquals(0, repQueue.overReplicatedQueueSize());
+    assertEquals(1, report.getStat(
         ReplicationManagerReport.HealthState.UNDER_REPLICATED));
   }
 
@@ -180,17 +182,17 @@ public class TestRatisReplicationCheckHandler {
         .setContainerInfo(container);
     UnderReplicatedHealthResult result = (UnderReplicatedHealthResult)
         healthCheck.checkHealth(requestBuilder.build());
-    Assert.assertEquals(HealthState.UNDER_REPLICATED, result.getHealthState());
-    Assert.assertEquals(1, result.getRemainingRedundancy());
-    Assert.assertTrue(result.isReplicatedOkAfterPending());
-    Assert.assertFalse(result.underReplicatedDueToDecommission());
+    assertEquals(HealthState.UNDER_REPLICATED, result.getHealthState());
+    assertEquals(1, result.getRemainingRedundancy());
+    assertTrue(result.isReplicatedOkAfterPending());
+    assertFalse(result.underReplicatedDueToDecommission());
 
-    Assert.assertTrue(healthCheck.handle(requestBuilder.build()));
+    assertTrue(healthCheck.handle(requestBuilder.build()));
     // Fixed with pending, so nothing added to the queue
-    Assert.assertEquals(0, repQueue.underReplicatedQueueSize());
-    Assert.assertEquals(0, repQueue.overReplicatedQueueSize());
+    assertEquals(0, repQueue.underReplicatedQueueSize());
+    assertEquals(0, repQueue.overReplicatedQueueSize());
     // Still under replicated until the pending complete
-    Assert.assertEquals(1, report.getStat(
+    assertEquals(1, report.getStat(
         ReplicationManagerReport.HealthState.UNDER_REPLICATED));
   }
 
@@ -205,15 +207,15 @@ public class TestRatisReplicationCheckHandler {
         .setContainerInfo(container);
     UnderReplicatedHealthResult result = (UnderReplicatedHealthResult)
         healthCheck.checkHealth(requestBuilder.build());
-    Assert.assertEquals(HealthState.UNDER_REPLICATED, result.getHealthState());
-    Assert.assertEquals(2, result.getRemainingRedundancy());
-    Assert.assertFalse(result.isReplicatedOkAfterPending());
-    Assert.assertTrue(result.underReplicatedDueToDecommission());
+    assertEquals(HealthState.UNDER_REPLICATED, result.getHealthState());
+    assertEquals(2, result.getRemainingRedundancy());
+    assertFalse(result.isReplicatedOkAfterPending());
+    assertTrue(result.underReplicatedDueToDecommission());
 
-    Assert.assertTrue(healthCheck.handle(requestBuilder.build()));
-    Assert.assertEquals(1, repQueue.underReplicatedQueueSize());
-    Assert.assertEquals(0, repQueue.overReplicatedQueueSize());
-    Assert.assertEquals(1, report.getStat(
+    assertTrue(healthCheck.handle(requestBuilder.build()));
+    assertEquals(1, repQueue.underReplicatedQueueSize());
+    assertEquals(0, repQueue.overReplicatedQueueSize());
+    assertEquals(1, report.getStat(
         ReplicationManagerReport.HealthState.UNDER_REPLICATED));
   }
 
@@ -232,21 +234,19 @@ public class TestRatisReplicationCheckHandler {
         .build();
 
     ContainerHealthResult healthResult = healthCheck.checkHealth(checkRequest);
-    Assert.assertEquals(HealthState.UNDER_REPLICATED,
-        healthResult.getHealthState());
-    Assert.assertEquals(UnderReplicatedHealthResult.class,
-        healthResult.getClass());
+    assertEquals(HealthState.UNDER_REPLICATED, healthResult.getHealthState());
+    assertEquals(UnderReplicatedHealthResult.class, healthResult.getClass());
     UnderReplicatedHealthResult result = (UnderReplicatedHealthResult)
         healthResult;
 
-    Assert.assertEquals(2, result.getRemainingRedundancy());
-    Assert.assertFalse(result.isReplicatedOkAfterPending());
-    Assert.assertTrue(result.underReplicatedDueToDecommission());
+    assertEquals(2, result.getRemainingRedundancy());
+    assertFalse(result.isReplicatedOkAfterPending());
+    assertTrue(result.underReplicatedDueToDecommission());
 
-    Assert.assertTrue(healthCheck.handle(checkRequest));
-    Assert.assertEquals(1, repQueue.underReplicatedQueueSize());
-    Assert.assertEquals(0, repQueue.overReplicatedQueueSize());
-    Assert.assertEquals(1, report.getStat(
+    assertTrue(healthCheck.handle(checkRequest));
+    assertEquals(1, repQueue.underReplicatedQueueSize());
+    assertEquals(0, repQueue.overReplicatedQueueSize());
+    assertEquals(1, report.getStat(
         ReplicationManagerReport.HealthState.UNDER_REPLICATED));
   }
 
@@ -265,17 +265,17 @@ public class TestRatisReplicationCheckHandler {
         .setContainerInfo(container);
     UnderReplicatedHealthResult result = (UnderReplicatedHealthResult)
         healthCheck.checkHealth(requestBuilder.build());
-    Assert.assertEquals(HealthState.UNDER_REPLICATED, result.getHealthState());
-    Assert.assertEquals(2, result.getRemainingRedundancy());
-    Assert.assertTrue(result.isReplicatedOkAfterPending());
-    Assert.assertTrue(result.underReplicatedDueToDecommission());
+    assertEquals(HealthState.UNDER_REPLICATED, result.getHealthState());
+    assertEquals(2, result.getRemainingRedundancy());
+    assertTrue(result.isReplicatedOkAfterPending());
+    assertTrue(result.underReplicatedDueToDecommission());
 
-    Assert.assertTrue(healthCheck.handle(requestBuilder.build()));
+    assertTrue(healthCheck.handle(requestBuilder.build()));
     // Nothing queued as inflight replicas will fix it.
-    Assert.assertEquals(0, repQueue.underReplicatedQueueSize());
-    Assert.assertEquals(0, repQueue.overReplicatedQueueSize());
+    assertEquals(0, repQueue.underReplicatedQueueSize());
+    assertEquals(0, repQueue.overReplicatedQueueSize());
     // Still under replicated in the report until pending complete
-    Assert.assertEquals(1, report.getStat(
+    assertEquals(1, report.getStat(
         ReplicationManagerReport.HealthState.UNDER_REPLICATED));
   }
 
@@ -293,15 +293,15 @@ public class TestRatisReplicationCheckHandler {
         .setContainerInfo(container);
     UnderReplicatedHealthResult result = (UnderReplicatedHealthResult)
         healthCheck.checkHealth(requestBuilder.build());
-    Assert.assertEquals(HealthState.UNDER_REPLICATED, result.getHealthState());
-    Assert.assertEquals(1, result.getRemainingRedundancy());
-    Assert.assertFalse(result.isReplicatedOkAfterPending());
-    Assert.assertFalse(result.underReplicatedDueToDecommission());
+    assertEquals(HealthState.UNDER_REPLICATED, result.getHealthState());
+    assertEquals(1, result.getRemainingRedundancy());
+    assertFalse(result.isReplicatedOkAfterPending());
+    assertFalse(result.underReplicatedDueToDecommission());
 
-    Assert.assertTrue(healthCheck.handle(requestBuilder.build()));
-    Assert.assertEquals(1, repQueue.underReplicatedQueueSize());
-    Assert.assertEquals(0, repQueue.overReplicatedQueueSize());
-    Assert.assertEquals(1, report.getStat(
+    assertTrue(healthCheck.handle(requestBuilder.build()));
+    assertEquals(1, repQueue.underReplicatedQueueSize());
+    assertEquals(0, repQueue.overReplicatedQueueSize());
+    assertEquals(1, report.getStat(
         ReplicationManagerReport.HealthState.UNDER_REPLICATED));
   }
 
@@ -314,19 +314,19 @@ public class TestRatisReplicationCheckHandler {
         .setContainerInfo(container);
     UnderReplicatedHealthResult result = (UnderReplicatedHealthResult)
         healthCheck.checkHealth(requestBuilder.build());
-    Assert.assertEquals(HealthState.UNDER_REPLICATED, result.getHealthState());
-    Assert.assertEquals(0, result.getRemainingRedundancy());
-    Assert.assertFalse(result.isReplicatedOkAfterPending());
-    Assert.assertFalse(result.underReplicatedDueToDecommission());
-    Assert.assertTrue(result.isUnrecoverable());
+    assertEquals(HealthState.UNDER_REPLICATED, result.getHealthState());
+    assertEquals(0, result.getRemainingRedundancy());
+    assertFalse(result.isReplicatedOkAfterPending());
+    assertFalse(result.underReplicatedDueToDecommission());
+    assertTrue(result.isUnrecoverable());
 
-    Assert.assertTrue(healthCheck.handle(requestBuilder.build()));
+    assertTrue(healthCheck.handle(requestBuilder.build()));
     // Unrecoverable, so not added to the queue.
-    Assert.assertEquals(0, repQueue.underReplicatedQueueSize());
-    Assert.assertEquals(0, repQueue.overReplicatedQueueSize());
-    Assert.assertEquals(0, report.getStat(
+    assertEquals(0, repQueue.underReplicatedQueueSize());
+    assertEquals(0, repQueue.overReplicatedQueueSize());
+    assertEquals(0, report.getStat(
         ReplicationManagerReport.HealthState.UNDER_REPLICATED));
-    Assert.assertEquals(1, report.getStat(
+    assertEquals(1, report.getStat(
         ReplicationManagerReport.HealthState.MISSING));
   }
 
@@ -348,15 +348,15 @@ public class TestRatisReplicationCheckHandler {
     UnderReplicatedHealthResult result = (UnderReplicatedHealthResult)
         healthCheck.checkHealth(requestBuilder.build());
 
-    Assert.assertEquals(HealthState.UNDER_REPLICATED, result.getHealthState());
-    Assert.assertEquals(1, result.getRemainingRedundancy());
-    Assert.assertFalse(result.isReplicatedOkAfterPending());
-    Assert.assertFalse(result.underReplicatedDueToDecommission());
+    assertEquals(HealthState.UNDER_REPLICATED, result.getHealthState());
+    assertEquals(1, result.getRemainingRedundancy());
+    assertFalse(result.isReplicatedOkAfterPending());
+    assertFalse(result.underReplicatedDueToDecommission());
 
-    Assert.assertTrue(healthCheck.handle(requestBuilder.build()));
-    Assert.assertEquals(1, repQueue.underReplicatedQueueSize());
-    Assert.assertEquals(0, repQueue.overReplicatedQueueSize());
-    Assert.assertEquals(1, report.getStat(
+    assertTrue(healthCheck.handle(requestBuilder.build()));
+    assertEquals(1, repQueue.underReplicatedQueueSize());
+    assertEquals(0, repQueue.overReplicatedQueueSize());
+    assertEquals(1, report.getStat(
         ReplicationManagerReport.HealthState.UNDER_REPLICATED));
   }
 
@@ -370,11 +370,11 @@ public class TestRatisReplicationCheckHandler {
         .setContainerInfo(container);
     ContainerHealthResult result =
         healthCheck.checkHealth(requestBuilder.build());
-    Assert.assertEquals(HealthState.HEALTHY, result.getHealthState());
+    assertEquals(HealthState.HEALTHY, result.getHealthState());
 
-    Assert.assertFalse(healthCheck.handle(requestBuilder.build()));
-    Assert.assertEquals(0, repQueue.underReplicatedQueueSize());
-    Assert.assertEquals(0, repQueue.overReplicatedQueueSize());
+    assertFalse(healthCheck.handle(requestBuilder.build()));
+    assertEquals(0, repQueue.underReplicatedQueueSize());
+    assertEquals(0, repQueue.overReplicatedQueueSize());
   }
 
   @Test
@@ -392,15 +392,15 @@ public class TestRatisReplicationCheckHandler {
     healthy replicas. This handler cannot make a decision about
     replication/deleting replicas when all of them are unhealthy.
      */
-    Assert.assertEquals(HealthState.UNDER_REPLICATED, result.getHealthState());
-    Assert.assertEquals(0, result.getRemainingRedundancy());
-    Assert.assertFalse(result.isReplicatedOkAfterPending());
-    Assert.assertFalse(result.underReplicatedDueToDecommission());
+    assertEquals(HealthState.UNDER_REPLICATED, result.getHealthState());
+    assertEquals(0, result.getRemainingRedundancy());
+    assertFalse(result.isReplicatedOkAfterPending());
+    assertFalse(result.underReplicatedDueToDecommission());
 
-    Assert.assertFalse(healthCheck.handle(requestBuilder.build()));
-    Assert.assertEquals(0, repQueue.underReplicatedQueueSize());
-    Assert.assertEquals(0, repQueue.overReplicatedQueueSize());
-    Assert.assertEquals(0, report.getStat(
+    assertFalse(healthCheck.handle(requestBuilder.build()));
+    assertEquals(0, repQueue.underReplicatedQueueSize());
+    assertEquals(0, repQueue.overReplicatedQueueSize());
+    assertEquals(0, report.getStat(
         ReplicationManagerReport.HealthState.UNDER_REPLICATED));
 
     /*
@@ -414,15 +414,15 @@ public class TestRatisReplicationCheckHandler {
     result = (UnderReplicatedHealthResult) healthCheck.checkHealth(
         requestBuilder.build());
 
-    Assert.assertEquals(HealthState.UNDER_REPLICATED, result.getHealthState());
-    Assert.assertEquals(0, result.getRemainingRedundancy());
-    Assert.assertFalse(result.isReplicatedOkAfterPending());
-    Assert.assertFalse(result.underReplicatedDueToDecommission());
+    assertEquals(HealthState.UNDER_REPLICATED, result.getHealthState());
+    assertEquals(0, result.getRemainingRedundancy());
+    assertFalse(result.isReplicatedOkAfterPending());
+    assertFalse(result.underReplicatedDueToDecommission());
 
-    Assert.assertFalse(healthCheck.handle(requestBuilder.build()));
-    Assert.assertEquals(0, repQueue.underReplicatedQueueSize());
-    Assert.assertEquals(0, repQueue.overReplicatedQueueSize());
-    Assert.assertEquals(0, report.getStat(
+    assertFalse(healthCheck.handle(requestBuilder.build()));
+    assertEquals(0, repQueue.underReplicatedQueueSize());
+    assertEquals(0, repQueue.overReplicatedQueueSize());
+    assertEquals(0, report.getStat(
         ReplicationManagerReport.HealthState.UNDER_REPLICATED));
   }
 
@@ -446,14 +446,14 @@ public class TestRatisReplicationCheckHandler {
         .setContainerInfo(container);
     OverReplicatedHealthResult result = (OverReplicatedHealthResult)
         healthCheck.checkHealth(requestBuilder.build());
-    Assert.assertEquals(HealthState.OVER_REPLICATED, result.getHealthState());
-    Assert.assertEquals(4, result.getExcessRedundancy());
-    Assert.assertFalse(result.isReplicatedOkAfterPending());
+    assertEquals(HealthState.OVER_REPLICATED, result.getHealthState());
+    assertEquals(4, result.getExcessRedundancy());
+    assertFalse(result.isReplicatedOkAfterPending());
 
-    Assert.assertTrue(healthCheck.handle(requestBuilder.build()));
-    Assert.assertEquals(0, repQueue.underReplicatedQueueSize());
-    Assert.assertEquals(1, repQueue.overReplicatedQueueSize());
-    Assert.assertEquals(1, report.getStat(
+    assertTrue(healthCheck.handle(requestBuilder.build()));
+    assertEquals(0, repQueue.underReplicatedQueueSize());
+    assertEquals(1, repQueue.overReplicatedQueueSize());
+    assertEquals(1, report.getStat(
         ReplicationManagerReport.HealthState.OVER_REPLICATED));
   }
 
@@ -470,19 +470,19 @@ public class TestRatisReplicationCheckHandler {
 
     OverReplicatedHealthResult result = (OverReplicatedHealthResult)
         healthCheck.checkHealth(requestBuilder.build());
-    Assert.assertEquals(HealthState.OVER_REPLICATED, result.getHealthState());
-    Assert.assertEquals(1, result.getExcessRedundancy());
-    Assert.assertFalse(result.isReplicatedOkAfterPending());
+    assertEquals(HealthState.OVER_REPLICATED, result.getHealthState());
+    assertEquals(1, result.getExcessRedundancy());
+    assertFalse(result.isReplicatedOkAfterPending());
 
-    Assert.assertTrue(healthCheck.handle(requestBuilder.build()));
-    Assert.assertEquals(0, repQueue.underReplicatedQueueSize());
+    assertTrue(healthCheck.handle(requestBuilder.build()));
+    assertEquals(0, repQueue.underReplicatedQueueSize());
     /*
     We have an excess replica, but we hold off on adding to the over
     replication queue until all the mismatched replicas match the container
     state.
      */
-    Assert.assertEquals(0, repQueue.overReplicatedQueueSize());
-    Assert.assertEquals(1, report.getStat(
+    assertEquals(0, repQueue.overReplicatedQueueSize());
+    assertEquals(1, report.getStat(
         ReplicationManagerReport.HealthState.OVER_REPLICATED));
   }
 
@@ -512,21 +512,21 @@ public class TestRatisReplicationCheckHandler {
         healthCheck.checkHealth(requestBuilder.build());
 
     // there's an excess of 3 UNHEALTHY replicas, so it's over replicated
-    Assert.assertEquals(HealthState.OVER_REPLICATED, result.getHealthState());
+    assertEquals(HealthState.OVER_REPLICATED, result.getHealthState());
     OverReplicatedHealthResult overRepResult =
         (OverReplicatedHealthResult) result;
-    Assert.assertEquals(3, overRepResult.getExcessRedundancy());
-    Assert.assertTrue(overRepResult.hasMismatchedReplicas());
-    Assert.assertFalse(overRepResult.isReplicatedOkAfterPending());
+    assertEquals(3, overRepResult.getExcessRedundancy());
+    assertTrue(overRepResult.hasMismatchedReplicas());
+    assertFalse(overRepResult.isReplicatedOkAfterPending());
 
-    Assert.assertTrue(healthCheck.handle(requestBuilder.build()));
-    Assert.assertEquals(0, repQueue.underReplicatedQueueSize());
+    assertTrue(healthCheck.handle(requestBuilder.build()));
+    assertEquals(0, repQueue.underReplicatedQueueSize());
     // it should not be queued for over replication because there's a mis
     // matched replica
-    Assert.assertEquals(0, repQueue.overReplicatedQueueSize());
-    Assert.assertEquals(1, report.getStat(
+    assertEquals(0, repQueue.overReplicatedQueueSize());
+    assertEquals(1, report.getStat(
         ReplicationManagerReport.HealthState.OVER_REPLICATED));
-    Assert.assertEquals(0, report.getStat(
+    assertEquals(0, report.getStat(
         ReplicationManagerReport.HealthState.UNDER_REPLICATED));
   }
 
@@ -550,19 +550,19 @@ public class TestRatisReplicationCheckHandler {
         healthCheck.checkHealth(requestBuilder.build());
 
     // there's an excess of 3 UNHEALTHY replicas, so it's over replicated
-    Assert.assertEquals(HealthState.OVER_REPLICATED, result.getHealthState());
+    assertEquals(HealthState.OVER_REPLICATED, result.getHealthState());
     OverReplicatedHealthResult overRepResult =
         (OverReplicatedHealthResult) result;
-    Assert.assertEquals(3, overRepResult.getExcessRedundancy());
-    Assert.assertFalse(overRepResult.hasMismatchedReplicas());
-    Assert.assertFalse(overRepResult.isReplicatedOkAfterPending());
+    assertEquals(3, overRepResult.getExcessRedundancy());
+    assertFalse(overRepResult.hasMismatchedReplicas());
+    assertFalse(overRepResult.isReplicatedOkAfterPending());
 
-    Assert.assertTrue(healthCheck.handle(requestBuilder.build()));
-    Assert.assertEquals(0, repQueue.underReplicatedQueueSize());
-    Assert.assertEquals(1, repQueue.overReplicatedQueueSize());
-    Assert.assertEquals(1, report.getStat(
+    assertTrue(healthCheck.handle(requestBuilder.build()));
+    assertEquals(0, repQueue.underReplicatedQueueSize());
+    assertEquals(1, repQueue.overReplicatedQueueSize());
+    assertEquals(1, report.getStat(
         ReplicationManagerReport.HealthState.OVER_REPLICATED));
-    Assert.assertEquals(0, report.getStat(
+    assertEquals(0, report.getStat(
         ReplicationManagerReport.HealthState.UNDER_REPLICATED));
 
   }
@@ -583,16 +583,16 @@ public class TestRatisReplicationCheckHandler {
         .setContainerInfo(container);
     OverReplicatedHealthResult result = (OverReplicatedHealthResult)
         healthCheck.checkHealth(requestBuilder.build());
-    Assert.assertEquals(HealthState.OVER_REPLICATED, result.getHealthState());
-    Assert.assertEquals(1, result.getExcessRedundancy());
-    Assert.assertTrue(result.isReplicatedOkAfterPending());
+    assertEquals(HealthState.OVER_REPLICATED, result.getHealthState());
+    assertEquals(1, result.getExcessRedundancy());
+    assertTrue(result.isReplicatedOkAfterPending());
 
-    Assert.assertTrue(healthCheck.handle(requestBuilder.build()));
-    Assert.assertEquals(0, repQueue.underReplicatedQueueSize());
+    assertTrue(healthCheck.handle(requestBuilder.build()));
+    assertEquals(0, repQueue.underReplicatedQueueSize());
     // Fixed by pending so nothing queued.
-    Assert.assertEquals(0, repQueue.overReplicatedQueueSize());
+    assertEquals(0, repQueue.overReplicatedQueueSize());
     // Still over replicated, so the report should contain it
-    Assert.assertEquals(1, report.getStat(
+    assertEquals(1, report.getStat(
         ReplicationManagerReport.HealthState.OVER_REPLICATED));
   }
 
@@ -608,14 +608,14 @@ public class TestRatisReplicationCheckHandler {
         .setContainerInfo(container);
     OverReplicatedHealthResult result = (OverReplicatedHealthResult)
         healthCheck.checkHealth(requestBuilder.build());
-    Assert.assertEquals(HealthState.OVER_REPLICATED, result.getHealthState());
-    Assert.assertEquals(1, result.getExcessRedundancy());
-    Assert.assertFalse(result.isReplicatedOkAfterPending());
+    assertEquals(HealthState.OVER_REPLICATED, result.getHealthState());
+    assertEquals(1, result.getExcessRedundancy());
+    assertFalse(result.isReplicatedOkAfterPending());
 
-    Assert.assertTrue(healthCheck.handle(requestBuilder.build()));
-    Assert.assertEquals(0, repQueue.underReplicatedQueueSize());
-    Assert.assertEquals(1, repQueue.overReplicatedQueueSize());
-    Assert.assertEquals(1, report.getStat(
+    assertTrue(healthCheck.handle(requestBuilder.build()));
+    assertEquals(0, repQueue.underReplicatedQueueSize());
+    assertEquals(1, repQueue.overReplicatedQueueSize());
+    assertEquals(1, report.getStat(
         ReplicationManagerReport.HealthState.OVER_REPLICATED));
   }
 
@@ -631,14 +631,14 @@ public class TestRatisReplicationCheckHandler {
         .setContainerInfo(container);
     ContainerHealthResult result =
         healthCheck.checkHealth(requestBuilder.build());
-    Assert.assertEquals(HealthState.HEALTHY, result.getHealthState());
+    assertEquals(HealthState.HEALTHY, result.getHealthState());
 
-    Assert.assertFalse(healthCheck.handle(requestBuilder.build()));
-    Assert.assertEquals(0, repQueue.underReplicatedQueueSize());
-    Assert.assertEquals(0, repQueue.overReplicatedQueueSize());
-    Assert.assertEquals(0, report.getStat(
+    assertFalse(healthCheck.handle(requestBuilder.build()));
+    assertEquals(0, repQueue.underReplicatedQueueSize());
+    assertEquals(0, repQueue.overReplicatedQueueSize());
+    assertEquals(0, report.getStat(
         ReplicationManagerReport.HealthState.OVER_REPLICATED));
-    Assert.assertEquals(0, report.getStat(
+    assertEquals(0, report.getStat(
         ReplicationManagerReport.HealthState.UNDER_REPLICATED));
   }
 
@@ -666,21 +666,21 @@ public class TestRatisReplicationCheckHandler {
         healthCheck.checkHealth(requestBuilder.build());
 
     // there's an excess of 3 UNHEALTHY replicas, so it's over replicated
-    Assert.assertEquals(HealthState.OVER_REPLICATED, result.getHealthState());
+    assertEquals(HealthState.OVER_REPLICATED, result.getHealthState());
     OverReplicatedHealthResult overRepResult =
         (OverReplicatedHealthResult) result;
-    Assert.assertEquals(3, overRepResult.getExcessRedundancy());
-    Assert.assertFalse(overRepResult.hasMismatchedReplicas());
-    Assert.assertFalse(overRepResult.isReplicatedOkAfterPending());
+    assertEquals(3, overRepResult.getExcessRedundancy());
+    assertFalse(overRepResult.hasMismatchedReplicas());
+    assertFalse(overRepResult.isReplicatedOkAfterPending());
 
-    Assert.assertTrue(healthCheck.handle(requestBuilder.build()));
-    Assert.assertEquals(0, repQueue.underReplicatedQueueSize());
-    Assert.assertEquals(1, repQueue.overReplicatedQueueSize());
-    Assert.assertEquals(1, report.getStat(
+    assertTrue(healthCheck.handle(requestBuilder.build()));
+    assertEquals(0, repQueue.underReplicatedQueueSize());
+    assertEquals(1, repQueue.overReplicatedQueueSize());
+    assertEquals(1, report.getStat(
         ReplicationManagerReport.HealthState.OVER_REPLICATED));
-    Assert.assertEquals(0, report.getStat(
+    assertEquals(0, report.getStat(
         ReplicationManagerReport.HealthState.UNDER_REPLICATED));
-    Assert.assertEquals(0, report.getStat(
+    assertEquals(0, report.getStat(
         ReplicationManagerReport.HealthState.MIS_REPLICATED));
   }
 
@@ -699,17 +699,17 @@ public class TestRatisReplicationCheckHandler {
         .setContainerInfo(container);
     UnderReplicatedHealthResult result = (UnderReplicatedHealthResult)
         healthCheck.checkHealth(requestBuilder.build());
-    Assert.assertEquals(HealthState.UNDER_REPLICATED, result.getHealthState());
-    Assert.assertEquals(1, result.getRemainingRedundancy());
-    Assert.assertFalse(result.isReplicatedOkAfterPending());
-    Assert.assertFalse(result.underReplicatedDueToDecommission());
+    assertEquals(HealthState.UNDER_REPLICATED, result.getHealthState());
+    assertEquals(1, result.getRemainingRedundancy());
+    assertFalse(result.isReplicatedOkAfterPending());
+    assertFalse(result.underReplicatedDueToDecommission());
 
-    Assert.assertTrue(healthCheck.handle(requestBuilder.build()));
-    Assert.assertEquals(1, repQueue.underReplicatedQueueSize());
-    Assert.assertEquals(0, repQueue.overReplicatedQueueSize());
-    Assert.assertEquals(1, report.getStat(
+    assertTrue(healthCheck.handle(requestBuilder.build()));
+    assertEquals(1, repQueue.underReplicatedQueueSize());
+    assertEquals(0, repQueue.overReplicatedQueueSize());
+    assertEquals(1, report.getStat(
         ReplicationManagerReport.HealthState.UNDER_REPLICATED));
-    Assert.assertEquals(0, report.getStat(
+    assertEquals(0, report.getStat(
         ReplicationManagerReport.HealthState.MIS_REPLICATED));
   }
 
@@ -743,17 +743,17 @@ public class TestRatisReplicationCheckHandler {
         .setPendingOps(pending);
     UnderReplicatedHealthResult result = (UnderReplicatedHealthResult)
         healthCheck.checkHealth(requestBuilder.build());
-    Assert.assertEquals(HealthState.UNDER_REPLICATED, result.getHealthState());
-    Assert.assertEquals(1, result.getRemainingRedundancy());
-    Assert.assertTrue(result.isReplicatedOkAfterPending());
-    Assert.assertFalse(result.underReplicatedDueToDecommission());
+    assertEquals(HealthState.UNDER_REPLICATED, result.getHealthState());
+    assertEquals(1, result.getRemainingRedundancy());
+    assertTrue(result.isReplicatedOkAfterPending());
+    assertFalse(result.underReplicatedDueToDecommission());
 
-    Assert.assertTrue(healthCheck.handle(requestBuilder.build()));
-    Assert.assertEquals(0, repQueue.underReplicatedQueueSize());
-    Assert.assertEquals(0, repQueue.overReplicatedQueueSize());
-    Assert.assertEquals(1, report.getStat(
+    assertTrue(healthCheck.handle(requestBuilder.build()));
+    assertEquals(0, repQueue.underReplicatedQueueSize());
+    assertEquals(0, repQueue.overReplicatedQueueSize());
+    assertEquals(1, report.getStat(
         ReplicationManagerReport.HealthState.UNDER_REPLICATED));
-    Assert.assertEquals(0, report.getStat(
+    assertEquals(0, report.getStat(
         ReplicationManagerReport.HealthState.MIS_REPLICATED));
   }
 
@@ -772,15 +772,15 @@ public class TestRatisReplicationCheckHandler {
         .setContainerInfo(container);
     MisReplicatedHealthResult result = (MisReplicatedHealthResult)
         healthCheck.checkHealth(requestBuilder.build());
-    Assert.assertEquals(HealthState.MIS_REPLICATED, result.getHealthState());
-    Assert.assertFalse(result.isReplicatedOkAfterPending());
+    assertEquals(HealthState.MIS_REPLICATED, result.getHealthState());
+    assertFalse(result.isReplicatedOkAfterPending());
 
-    Assert.assertTrue(healthCheck.handle(requestBuilder.build()));
-    Assert.assertEquals(1, repQueue.underReplicatedQueueSize());
-    Assert.assertEquals(0, repQueue.overReplicatedQueueSize());
-    Assert.assertEquals(0, report.getStat(
+    assertTrue(healthCheck.handle(requestBuilder.build()));
+    assertEquals(1, repQueue.underReplicatedQueueSize());
+    assertEquals(0, repQueue.overReplicatedQueueSize());
+    assertEquals(0, report.getStat(
         ReplicationManagerReport.HealthState.UNDER_REPLICATED));
-    Assert.assertEquals(1, report.getStat(
+    assertEquals(1, report.getStat(
         ReplicationManagerReport.HealthState.MIS_REPLICATED));
   }
 
@@ -814,15 +814,15 @@ public class TestRatisReplicationCheckHandler {
         .setPendingOps(pending);
     MisReplicatedHealthResult result = (MisReplicatedHealthResult)
         healthCheck.checkHealth(requestBuilder.build());
-    Assert.assertEquals(HealthState.MIS_REPLICATED, result.getHealthState());
-    Assert.assertTrue(result.isReplicatedOkAfterPending());
+    assertEquals(HealthState.MIS_REPLICATED, result.getHealthState());
+    assertTrue(result.isReplicatedOkAfterPending());
 
-    Assert.assertTrue(healthCheck.handle(requestBuilder.build()));
-    Assert.assertEquals(0, repQueue.underReplicatedQueueSize());
-    Assert.assertEquals(0, repQueue.overReplicatedQueueSize());
-    Assert.assertEquals(0, report.getStat(
+    assertTrue(healthCheck.handle(requestBuilder.build()));
+    assertEquals(0, repQueue.underReplicatedQueueSize());
+    assertEquals(0, repQueue.overReplicatedQueueSize());
+    assertEquals(0, report.getStat(
         ReplicationManagerReport.HealthState.UNDER_REPLICATED));
-    Assert.assertEquals(1, report.getStat(
+    assertEquals(1, report.getStat(
         ReplicationManagerReport.HealthState.MIS_REPLICATED));
   }
 

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/health/TestRatisReplicationCheckHandler.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/health/TestRatisReplicationCheckHandler.java
@@ -222,8 +222,7 @@ public class TestRatisReplicationCheckHandler {
   }
 
   @ParameterizedTest
-  @MethodSource("org.apache.hadoop.hdds.scm.container.replication." +
-      "TestRatisContainerReplicaCount#outOfServiceStates")
+  @MethodSource("org.apache.hadoop.hdds.scm.node.NodeStatus#outOfServiceStates")
   void testUnderReplicatedDueToAllOutOfService(
       HddsProtos.NodeOperationalState state) {
     Pair<HddsProtos.NodeOperationalState, Integer> pair = Pair.of(state, 0);

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/health/TestRatisUnhealthyReplicationCheckHandler.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/health/TestRatisUnhealthyReplicationCheckHandler.java
@@ -31,9 +31,8 @@ import org.apache.hadoop.hdds.scm.container.replication.ContainerCheckRequest;
 import org.apache.hadoop.hdds.scm.container.replication.ContainerHealthResult;
 import org.apache.hadoop.hdds.scm.container.replication.ContainerReplicaOp;
 import org.apache.hadoop.hdds.scm.container.replication.ReplicationQueue;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.util.Collections;
@@ -45,6 +44,9 @@ import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationFactor
 import static org.apache.hadoop.hdds.scm.container.replication.ReplicationTestUtil.createContainerInfo;
 import static org.apache.hadoop.hdds.scm.container.replication.ReplicationTestUtil.createContainerReplica;
 import static org.apache.hadoop.hdds.scm.container.replication.ReplicationTestUtil.createReplicas;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Tests for {@link RatisUnhealthyReplicationCheckHandler}.
@@ -57,7 +59,7 @@ public class TestRatisUnhealthyReplicationCheckHandler {
   private ReplicationManagerReport report;
   private int maintenanceRedundancy = 2;
 
-  @Before
+  @BeforeEach
   public void setup() throws IOException {
     handler = new RatisUnhealthyReplicationCheckHandler();
     repConfig = RatisReplicationConfig.getInstance(THREE);
@@ -79,9 +81,9 @@ public class TestRatisUnhealthyReplicationCheckHandler {
 
     requestBuilder.setContainerReplicas(replicas)
         .setContainerInfo(container);
-    Assert.assertFalse(handler.handle(requestBuilder.build()));
-    Assert.assertEquals(0, repQueue.underReplicatedQueueSize());
-    Assert.assertEquals(0, repQueue.overReplicatedQueueSize());
+    assertFalse(handler.handle(requestBuilder.build()));
+    assertEquals(0, repQueue.underReplicatedQueueSize());
+    assertEquals(0, repQueue.overReplicatedQueueSize());
   }
 
   @Test
@@ -94,7 +96,7 @@ public class TestRatisUnhealthyReplicationCheckHandler {
     requestBuilder.setContainerReplicas(replicas)
         .setContainerInfo(container);
 
-    Assert.assertFalse(handler.handle(requestBuilder.build()));
+    assertFalse(handler.handle(requestBuilder.build()));
   }
 
   @Test
@@ -107,7 +109,7 @@ public class TestRatisUnhealthyReplicationCheckHandler {
     requestBuilder.setContainerReplicas(replicas)
         .setContainerInfo(container);
 
-    Assert.assertFalse(handler.handle(requestBuilder.build()));
+    assertFalse(handler.handle(requestBuilder.build()));
   }
 
   @Test
@@ -125,7 +127,7 @@ public class TestRatisUnhealthyReplicationCheckHandler {
     requestBuilder.setContainerReplicas(replicas)
         .setContainerInfo(container);
 
-    Assert.assertFalse(handler.handle(requestBuilder.build()));
+    assertFalse(handler.handle(requestBuilder.build()));
   }
 
   @Test
@@ -145,17 +147,17 @@ public class TestRatisUnhealthyReplicationCheckHandler {
     ContainerHealthResult.OverReplicatedHealthResult result =
         (ContainerHealthResult.OverReplicatedHealthResult)
             handler.checkReplication(requestBuilder.build());
-    Assert.assertEquals(ContainerHealthResult.HealthState.OVER_REPLICATED,
+    assertEquals(ContainerHealthResult.HealthState.OVER_REPLICATED,
         result.getHealthState());
-    Assert.assertEquals(1, result.getExcessRedundancy());
-    Assert.assertFalse(result.isReplicatedOkAfterPending());
+    assertEquals(1, result.getExcessRedundancy());
+    assertFalse(result.isReplicatedOkAfterPending());
 
-    Assert.assertTrue(handler.handle(requestBuilder.build()));
-    Assert.assertEquals(0, repQueue.underReplicatedQueueSize());
-    Assert.assertEquals(1, repQueue.overReplicatedQueueSize());
-    Assert.assertEquals(1, report.getStat(
+    assertTrue(handler.handle(requestBuilder.build()));
+    assertEquals(0, repQueue.underReplicatedQueueSize());
+    assertEquals(1, repQueue.overReplicatedQueueSize());
+    assertEquals(1, report.getStat(
         ReplicationManagerReport.HealthState.OVER_REPLICATED));
-    Assert.assertEquals(1,
+    assertEquals(1,
         report.getStat(ReplicationManagerReport.HealthState.UNHEALTHY));
   }
 
@@ -178,18 +180,18 @@ public class TestRatisUnhealthyReplicationCheckHandler {
         result = (ContainerHealthResult.UnderReplicatedHealthResult)
         handler.checkReplication(requestBuilder.build());
 
-    Assert.assertEquals(ContainerHealthResult.HealthState.UNDER_REPLICATED,
+    assertEquals(ContainerHealthResult.HealthState.UNDER_REPLICATED,
         result.getHealthState());
-    Assert.assertEquals(0, result.getRemainingRedundancy());
-    Assert.assertFalse(result.isReplicatedOkAfterPending());
-    Assert.assertFalse(result.underReplicatedDueToDecommission());
+    assertEquals(0, result.getRemainingRedundancy());
+    assertFalse(result.isReplicatedOkAfterPending());
+    assertFalse(result.underReplicatedDueToDecommission());
 
-    Assert.assertTrue(handler.handle(requestBuilder.build()));
-    Assert.assertEquals(1, repQueue.underReplicatedQueueSize());
-    Assert.assertEquals(0, repQueue.overReplicatedQueueSize());
-    Assert.assertEquals(1, report.getStat(
+    assertTrue(handler.handle(requestBuilder.build()));
+    assertEquals(1, repQueue.underReplicatedQueueSize());
+    assertEquals(0, repQueue.overReplicatedQueueSize());
+    assertEquals(1, report.getStat(
         ReplicationManagerReport.HealthState.UNDER_REPLICATED));
-    Assert.assertEquals(1,
+    assertEquals(1,
         report.getStat(ReplicationManagerReport.HealthState.UNHEALTHY));
   }
 
@@ -212,18 +214,18 @@ public class TestRatisUnhealthyReplicationCheckHandler {
         result = (ContainerHealthResult.UnderReplicatedHealthResult)
         handler.checkReplication(requestBuilder.build());
 
-    Assert.assertEquals(ContainerHealthResult.HealthState.UNDER_REPLICATED,
+    assertEquals(ContainerHealthResult.HealthState.UNDER_REPLICATED,
         result.getHealthState());
-    Assert.assertEquals(1, result.getRemainingRedundancy());
-    Assert.assertTrue(result.isReplicatedOkAfterPending());
-    Assert.assertFalse(result.underReplicatedDueToDecommission());
+    assertEquals(1, result.getRemainingRedundancy());
+    assertTrue(result.isReplicatedOkAfterPending());
+    assertFalse(result.underReplicatedDueToDecommission());
 
-    Assert.assertTrue(handler.handle(requestBuilder.build()));
-    Assert.assertEquals(0, repQueue.underReplicatedQueueSize());
-    Assert.assertEquals(0, repQueue.overReplicatedQueueSize());
-    Assert.assertEquals(1, report.getStat(
+    assertTrue(handler.handle(requestBuilder.build()));
+    assertEquals(0, repQueue.underReplicatedQueueSize());
+    assertEquals(0, repQueue.overReplicatedQueueSize());
+    assertEquals(1, report.getStat(
         ReplicationManagerReport.HealthState.UNDER_REPLICATED));
-    Assert.assertEquals(1,
+    assertEquals(1,
         report.getStat(ReplicationManagerReport.HealthState.UNHEALTHY));
   }
 
@@ -246,17 +248,17 @@ public class TestRatisUnhealthyReplicationCheckHandler {
         result = (ContainerHealthResult.UnderReplicatedHealthResult)
         handler.checkReplication(requestBuilder.build());
 
-    Assert.assertEquals(ContainerHealthResult.HealthState.UNDER_REPLICATED,
+    assertEquals(ContainerHealthResult.HealthState.UNDER_REPLICATED,
         result.getHealthState());
-    Assert.assertEquals(1, result.getRemainingRedundancy());
-    Assert.assertFalse(result.isReplicatedOkAfterPending());
+    assertEquals(1, result.getRemainingRedundancy());
+    assertFalse(result.isReplicatedOkAfterPending());
 
-    Assert.assertTrue(handler.handle(requestBuilder.build()));
-    Assert.assertEquals(1, repQueue.underReplicatedQueueSize());
-    Assert.assertEquals(0, repQueue.overReplicatedQueueSize());
-    Assert.assertEquals(1, report.getStat(
+    assertTrue(handler.handle(requestBuilder.build()));
+    assertEquals(1, repQueue.underReplicatedQueueSize());
+    assertEquals(0, repQueue.overReplicatedQueueSize());
+    assertEquals(1, report.getStat(
         ReplicationManagerReport.HealthState.UNDER_REPLICATED));
-    Assert.assertEquals(1,
+    assertEquals(1,
         report.getStat(ReplicationManagerReport.HealthState.UNHEALTHY));
   }
 
@@ -279,17 +281,17 @@ public class TestRatisUnhealthyReplicationCheckHandler {
         result = (ContainerHealthResult.OverReplicatedHealthResult)
         handler.checkReplication(requestBuilder.build());
 
-    Assert.assertEquals(ContainerHealthResult.HealthState.OVER_REPLICATED,
+    assertEquals(ContainerHealthResult.HealthState.OVER_REPLICATED,
         result.getHealthState());
-    Assert.assertEquals(1, result.getExcessRedundancy());
-    Assert.assertTrue(result.isReplicatedOkAfterPending());
+    assertEquals(1, result.getExcessRedundancy());
+    assertTrue(result.isReplicatedOkAfterPending());
 
-    Assert.assertTrue(handler.handle(requestBuilder.build()));
-    Assert.assertEquals(0, repQueue.underReplicatedQueueSize());
-    Assert.assertEquals(0, repQueue.overReplicatedQueueSize());
-    Assert.assertEquals(1, report.getStat(
+    assertTrue(handler.handle(requestBuilder.build()));
+    assertEquals(0, repQueue.underReplicatedQueueSize());
+    assertEquals(0, repQueue.overReplicatedQueueSize());
+    assertEquals(1, report.getStat(
         ReplicationManagerReport.HealthState.OVER_REPLICATED));
-    Assert.assertEquals(1,
+    assertEquals(1,
         report.getStat(ReplicationManagerReport.HealthState.UNHEALTHY));
   }
 
@@ -315,20 +317,20 @@ public class TestRatisUnhealthyReplicationCheckHandler {
         result = (ContainerHealthResult.OverReplicatedHealthResult)
         handler.checkReplication(requestBuilder.build());
 
-    Assert.assertEquals(ContainerHealthResult.HealthState.OVER_REPLICATED,
+    assertEquals(ContainerHealthResult.HealthState.OVER_REPLICATED,
         result.getHealthState());
-    Assert.assertEquals(1, result.getExcessRedundancy());
-    Assert.assertFalse(result.isReplicatedOkAfterPending());
+    assertEquals(1, result.getExcessRedundancy());
+    assertFalse(result.isReplicatedOkAfterPending());
 
     // not safe for over replication because we don't have 3 matching replicas
-    Assert.assertFalse(result.isSafelyOverReplicated());
+    assertFalse(result.isSafelyOverReplicated());
 
-    Assert.assertTrue(handler.handle(requestBuilder.build()));
-    Assert.assertEquals(0, repQueue.underReplicatedQueueSize());
-    Assert.assertEquals(0, repQueue.overReplicatedQueueSize());
-    Assert.assertEquals(1, report.getStat(
+    assertTrue(handler.handle(requestBuilder.build()));
+    assertEquals(0, repQueue.underReplicatedQueueSize());
+    assertEquals(0, repQueue.overReplicatedQueueSize());
+    assertEquals(1, report.getStat(
         ReplicationManagerReport.HealthState.OVER_REPLICATED));
-    Assert.assertEquals(1,
+    assertEquals(1,
         report.getStat(ReplicationManagerReport.HealthState.UNHEALTHY));
   }
 }

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/health/TestRatisUnhealthyReplicationCheckHandler.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/health/TestRatisUnhealthyReplicationCheckHandler.java
@@ -184,7 +184,7 @@ public class TestRatisUnhealthyReplicationCheckHandler {
         result.getHealthState());
     assertEquals(0, result.getRemainingRedundancy());
     assertFalse(result.isReplicatedOkAfterPending());
-    assertFalse(result.underReplicatedDueToDecommission());
+    assertFalse(result.underReplicatedDueToOutOfService());
 
     assertTrue(handler.handle(requestBuilder.build()));
     assertEquals(1, repQueue.underReplicatedQueueSize());
@@ -218,7 +218,7 @@ public class TestRatisUnhealthyReplicationCheckHandler {
         result.getHealthState());
     assertEquals(1, result.getRemainingRedundancy());
     assertTrue(result.isReplicatedOkAfterPending());
-    assertFalse(result.underReplicatedDueToDecommission());
+    assertFalse(result.underReplicatedDueToOutOfService());
 
     assertTrue(handler.handle(requestBuilder.build()));
     assertEquals(0, repQueue.underReplicatedQueueSize());


### PR DESCRIPTION
## What changes were proposed in this pull request?

According to the following javadoc, both decommission and maintenance replicas should be deprioritised:

https://github.com/apache/ozone/blob/6d9002201e58dc995dc133941acaef2af03cb9d2/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ContainerHealthResult.java#L145-L164

but `dueToDecommission=true` is set only based on decommission replicas, ignoring maintenance replicas (`maintenanceCount`):

https://github.com/apache/ozone/blob/6d9002201e58dc995dc133941acaef2af03cb9d2/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/RatisContainerReplicaCount.java#L520-L533

This PR:

 * changes the method to consider the sum of decommission and maintenance replicas,
 * renames the method and related code to refer to out-of-service instead of decommission,
 * upgrades tests to JUnit5 to allow `@ParameterizedTest`, which is used to verify replicas both in decommission and maintenance states,
 * adds some useful `toString()` implementation in under-replicated health result,
 * fixes some typos in javadocs.

https://issues.apache.org/jira/browse/HDDS-8617

## How was this patch tested?

Changed unit tests.

CI:
https://github.com/adoroszlai/hadoop-ozone/actions/runs/5013837236