### PR TITLE
HDDS-8658. ReplicationManager: Change default command timeout to 10 minutes

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ReplicationManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ReplicationManager.java
@@ -1135,7 +1135,7 @@ public class ReplicationManager implements SCMService {
         description = "Timeout for the container replication/deletion commands "
             + "sent to datanodes. After this timeout the command will be "
             + "retried.")
-    private long eventTimeout = Duration.ofMinutes(30).toMillis();
+    private long eventTimeout = Duration.ofMinutes(10).toMillis();
     public void setInterval(Duration interval) {
       this.interval = interval.toMillis();
     }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ReplicationManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ReplicationManager.java
@@ -1130,7 +1130,7 @@ public class ReplicationManager implements SCMService {
      */
     @Config(key = "event.timeout",
         type = ConfigType.TIME,
-        defaultValue = "30m",
+        defaultValue = "10m",
         tags = {SCM, OZONE},
         description = "Timeout for the container replication/deletion commands "
             + "sent to datanodes. After this timeout the command will be "

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestLegacyReplicationManager.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestLegacyReplicationManager.java
@@ -316,18 +316,6 @@ public class TestLegacyReplicationManager {
       replicationManager.start();
       Assertions.assertTrue(replicationManager.isRunning());
     }
-
-    @Test
-    public void testGeneratedConfig() {
-      ReplicationManagerConfiguration rmc = OzoneConfiguration.newInstanceOf(
-          ReplicationManagerConfiguration.class);
-
-      //default is not included in ozone-site.xml but generated from annotation
-      //to the ozone-site-generated.xml which should be loaded by the
-      // OzoneConfiguration.
-      Assertions.assertEquals(1800000, rmc.getEventTimeout());
-
-    }
   }
 
   /**


### PR DESCRIPTION
## What changes were proposed in this pull request?

In Replication Manager, a deadline is set on commands sent to a datanode. If the command has not completed within the timeout, RM assumes it is lost and will schedule a new command to another random node.

Right now the default is set to 30 minutes as the legacy RM scheduled a lot of work onto the DNs and it could take a long time to complete. The new RM throttles the work sent, so a large queue on the DNs should not be possible.

We should change the default event timeout to 10 minutes instead of 30.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-8658

## How was this patch tested?

Existing tests. This is a simple config default change.
