### PR TITLE
HDDS-8636. Containers in schema V1 fail for replication after the 1.3.0 upgrade

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/OzoneConsts.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/OzoneConsts.java
@@ -291,9 +291,6 @@ public final class OzoneConsts {
   // but have containerID as key prefixes.
   public static final String SCHEMA_V3 = "3";
 
-  public static final String[] SCHEMA_VERSIONS =
-      new String[] {null, SCHEMA_V1, SCHEMA_V2, SCHEMA_V3};
-
   // Supported store types.
   public static final String OZONE = "ozone";
   public static final String S3 = "s3";

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/OzoneConsts.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/OzoneConsts.java
@@ -292,7 +292,7 @@ public final class OzoneConsts {
   public static final String SCHEMA_V3 = "3";
 
   public static final String[] SCHEMA_VERSIONS =
-      new String[] {SCHEMA_V1, SCHEMA_V2, SCHEMA_V3};
+      new String[] {null, SCHEMA_V1, SCHEMA_V2, SCHEMA_V3};
 
   // Supported store types.
   public static final String OZONE = "ozone";

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/DeleteBlocksCommandHandler.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/DeleteBlocksCommandHandler.java
@@ -225,12 +225,12 @@ public class DeleteBlocksCommandHandler implements CommandHandler {
               cont.getContainerData();
           cont.writeLock();
           try {
-            if (containerData.getSchemaVersion().equals(SCHEMA_V1)) {
+            if (containerData.hasSchema(SCHEMA_V1)) {
               markBlocksForDeletionSchemaV1(containerData, tx);
-            } else if (containerData.getSchemaVersion().equals(SCHEMA_V2)) {
+            } else if (containerData.hasSchema(SCHEMA_V2)) {
               markBlocksForDeletionSchemaV2(containerData, tx,
                   newDeletionBlocks, tx.getTxID());
-            } else if (containerData.getSchemaVersion().equals(SCHEMA_V3)) {
+            } else if (containerData.hasSchema(SCHEMA_V3)) {
               markBlocksForDeletionSchemaV3(containerData, tx,
                   newDeletionBlocks, tx.getTxID());
             } else {

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/KeyValueContainer.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/KeyValueContainer.java
@@ -566,8 +566,7 @@ public class KeyValueContainer implements Container<KeyValueContainerData> {
 
       // delete all other temporary data in case of any exception.
       try {
-        if (containerData.getSchemaVersion() != null &&
-            containerData.getSchemaVersion().equals(OzoneConsts.SCHEMA_V3)) {
+        if (containerData.hasSchema(OzoneConsts.SCHEMA_V3)) {
           BlockUtils.removeContainerFromDB(containerData, config);
         }
         FileUtils.deleteDirectory(new File(containerData.getMetadataPath()));
@@ -595,7 +594,7 @@ public class KeyValueContainer implements Container<KeyValueContainerData> {
     //rewriting the yaml file with new checksum calculation.
     update(originalContainerData.getMetadata(), true);
 
-    if (containerData.getSchemaVersion().equals(OzoneConsts.SCHEMA_V3)) {
+    if (containerData.hasSchema(OzoneConsts.SCHEMA_V3)) {
       // load metadata from received dump files before we try to parse kv
       BlockUtils.loadKVContainerDataFromFiles(containerData, config);
     }
@@ -622,7 +621,7 @@ public class KeyValueContainer implements Container<KeyValueContainerData> {
       }
 
       try {
-        if (!containerData.getSchemaVersion().equals(OzoneConsts.SCHEMA_V3)) {
+        if (!containerData.hasSchema(OzoneConsts.SCHEMA_V3)) {
           compactDB();
           // Close DB (and remove from cache) to avoid concurrent modification
           // while packing it.
@@ -898,7 +897,7 @@ public class KeyValueContainer implements Container<KeyValueContainerData> {
   private void packContainerToDestination(OutputStream destination,
       ContainerPacker<KeyValueContainerData> packer)
       throws IOException {
-    if (containerData.getSchemaVersion().equals(OzoneConsts.SCHEMA_V3)) {
+    if (containerData.hasSchema(OzoneConsts.SCHEMA_V3)) {
       // Synchronize the dump and pack operation,
       // so concurrent exports don't get dump files overwritten.
       // We seldom got concurrent exports for a container,

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/KeyValueContainerData.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/KeyValueContainerData.java
@@ -31,10 +31,10 @@ import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos
 import org.apache.hadoop.hdds.utils.MetadataKeyFilters.KeyPrefixFilter;
 import org.apache.hadoop.hdds.utils.db.BatchOperation;
 import org.apache.hadoop.hdds.utils.db.Table;
-import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.hadoop.ozone.container.common.impl.ContainerLayoutVersion;
 import org.apache.hadoop.ozone.container.common.impl.ContainerData;
 import org.apache.hadoop.ozone.container.common.interfaces.DBHandle;
+import org.apache.hadoop.ozone.container.keyvalue.helpers.KeyValueContainerUtil;
 import org.yaml.snakeyaml.nodes.Tag;
 
 
@@ -51,6 +51,7 @@ import static org.apache.hadoop.ozone.OzoneConsts.CONTAINER_DB_TYPE;
 import static org.apache.hadoop.ozone.OzoneConsts.DELETE_TRANSACTION_KEY;
 import static org.apache.hadoop.ozone.OzoneConsts.DELETING_KEY_PREFIX;
 import static org.apache.hadoop.ozone.OzoneConsts.METADATA_PATH;
+import static org.apache.hadoop.ozone.OzoneConsts.SCHEMA_V3;
 import static org.apache.hadoop.ozone.OzoneConsts.SCHEMA_VERSION;
 import static org.apache.hadoop.ozone.OzoneConsts.CONTAINER_BYTES_USED;
 import static org.apache.hadoop.ozone.OzoneConsts.BLOCK_COUNT;
@@ -388,7 +389,7 @@ public class KeyValueContainerData extends ContainerData {
    * @return
    */
   public String startKeyEmpty() {
-    if (schemaVersion.equals(OzoneConsts.SCHEMA_V3)) {
+    if (hasSchema(SCHEMA_V3)) {
       return getContainerKeyPrefix(getContainerID());
     }
     return null;
@@ -400,7 +401,7 @@ public class KeyValueContainerData extends ContainerData {
    * @return
    */
   public String containerPrefix() {
-    if (schemaVersion.equals(OzoneConsts.SCHEMA_V3)) {
+    if (hasSchema(SCHEMA_V3)) {
       return getContainerKeyPrefix(getContainerID());
     }
     return "";
@@ -414,9 +415,14 @@ public class KeyValueContainerData extends ContainerData {
    * @return formatted key
    */
   private String formatKey(String key) {
-    if (schemaVersion.equals(OzoneConsts.SCHEMA_V3)) {
+    if (hasSchema(SCHEMA_V3)) {
       key = getContainerKeyPrefix(getContainerID()) + key;
     }
     return key;
   }
+
+  public boolean hasSchema(String version) {
+    return KeyValueContainerUtil.isSameSchemaVersion(schemaVersion, version);
+  }
+
 }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/KeyValueContainerMetadataInspector.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/KeyValueContainerMetadataInspector.java
@@ -47,6 +47,8 @@ import java.util.List;
 import java.util.function.BooleanSupplier;
 import java.util.stream.Stream;
 
+import static org.apache.hadoop.ozone.container.keyvalue.helpers.KeyValueContainerUtil.isSameSchemaVersion;
+
 /**
  * Container inspector for key value container metadata. It is capable of
  * logging metadata information about a container, and repairing the metadata
@@ -274,7 +276,7 @@ public class KeyValueContainerMetadataInspector implements ContainerInspector {
 
     // Count pending delete blocks.
     final PendingDelete pendingDelete;
-    if (schemaVersion.equals(OzoneConsts.SCHEMA_V1)) {
+    if (isSameSchemaVersion(schemaVersion, OzoneConsts.SCHEMA_V1)) {
       long pendingDeleteBlockCountTotal = 0;
       long pendingDeleteBytes = 0;
       try (BlockIterator<BlockData> blockIter =
@@ -291,12 +293,12 @@ public class KeyValueContainerMetadataInspector implements ContainerInspector {
       }
       pendingDelete = new PendingDelete(
           pendingDeleteBlockCountTotal, pendingDeleteBytes);
-    } else if (schemaVersion.equals(OzoneConsts.SCHEMA_V2)) {
+    } else if (isSameSchemaVersion(schemaVersion, OzoneConsts.SCHEMA_V2)) {
       DatanodeStoreSchemaTwoImpl schemaTwoStore =
           (DatanodeStoreSchemaTwoImpl) store;
       pendingDelete =
           countPendingDeletesSchemaV2(schemaTwoStore, containerData);
-    } else if (schemaVersion.equals(OzoneConsts.SCHEMA_V3)) {
+    } else if (isSameSchemaVersion(schemaVersion, OzoneConsts.SCHEMA_V3)) {
       DatanodeStoreSchemaThreeImpl schemaThreeStore =
           (DatanodeStoreSchemaThreeImpl) store;
       pendingDelete =

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/TarContainerPacker.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/TarContainerPacker.java
@@ -189,7 +189,7 @@ public class TarContainerPacker
   }
 
   public static Path getDbPath(KeyValueContainerData containerData) {
-    if (containerData.getSchemaVersion().equals(SCHEMA_V3)) {
+    if (containerData.hasSchema(SCHEMA_V3)) {
       return DatanodeStoreSchemaThreeImpl.getDumpDir(
           new File(containerData.getMetadataPath())).toPath();
     } else {
@@ -207,7 +207,7 @@ public class TarContainerPacker
     Path dbPath = Paths.get(containerData.getDbFile().getPath());
     Path relativePath = containerPath.relativize(dbPath);
 
-    if (containerData.getSchemaVersion().equals(SCHEMA_V3)) {
+    if (containerData.hasSchema(SCHEMA_V3)) {
       Path metadataDir = KeyValueContainerLocationUtil.getContainerMetaDataPath(
           baseDir.toString()).toPath();
       return DatanodeStoreSchemaThreeImpl.getDumpDir(metadataDir.toFile())

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/helpers/BlockUtils.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/helpers/BlockUtils.java
@@ -48,6 +48,7 @@ import static org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.Res
 import static org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.Result.UNABLE_TO_READ_METADATA_DB;
 import static org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.Result.UNKNOWN_BCSID;
 import static org.apache.hadoop.ozone.container.common.utils.StorageVolumeUtil.onFailure;
+import static org.apache.hadoop.ozone.container.keyvalue.helpers.KeyValueContainerUtil.isSameSchemaVersion;
 
 /**
  * Utils functions to help block functions.
@@ -76,11 +77,11 @@ public final class BlockUtils {
       ConfigurationSource conf, boolean readOnly) throws IOException {
 
     DatanodeStore store;
-    if (schemaVersion.equals(OzoneConsts.SCHEMA_V1)) {
+    if (isSameSchemaVersion(schemaVersion, OzoneConsts.SCHEMA_V1)) {
       store = new DatanodeStoreSchemaOneImpl(conf, containerDBPath, readOnly);
-    } else if (schemaVersion.equals(OzoneConsts.SCHEMA_V2)) {
+    } else if (isSameSchemaVersion(schemaVersion, OzoneConsts.SCHEMA_V2)) {
       store = new DatanodeStoreSchemaTwoImpl(conf, containerDBPath, readOnly);
-    } else if (schemaVersion.equals(OzoneConsts.SCHEMA_V3)) {
+    } else if (isSameSchemaVersion(schemaVersion, OzoneConsts.SCHEMA_V3)) {
       store = new DatanodeStoreSchemaThreeImpl(conf, containerDBPath,
           readOnly);
     } else {
@@ -126,7 +127,7 @@ public final class BlockUtils {
 
     String containerDBPath = containerData.getDbFile().getAbsolutePath();
     try {
-      if (containerData.getSchemaVersion().equals(OzoneConsts.SCHEMA_V3)) {
+      if (containerData.hasSchema(OzoneConsts.SCHEMA_V3)) {
         DatanodeStoreCache cache = DatanodeStoreCache.getInstance();
         Preconditions.checkNotNull(cache);
         return cache.getDB(containerDBPath, conf);
@@ -155,8 +156,7 @@ public final class BlockUtils {
       ConfigurationSource conf) {
     Preconditions.checkNotNull(container);
     Preconditions.checkNotNull(container.getDbFile());
-    Preconditions.checkState(!container.getSchemaVersion()
-        .equals(OzoneConsts.SCHEMA_V3));
+    Preconditions.checkState(!container.hasSchema(OzoneConsts.SCHEMA_V3));
 
     ContainerCache cache = ContainerCache.getInstance(conf);
     Preconditions.checkNotNull(cache);
@@ -183,7 +183,7 @@ public final class BlockUtils {
    */
   public static void addDB(DatanodeStore store, String containerDBPath,
       ConfigurationSource conf, String schemaVersion) {
-    if (schemaVersion.equals(OzoneConsts.SCHEMA_V3)) {
+    if (isSameSchemaVersion(schemaVersion, OzoneConsts.SCHEMA_V3)) {
       DatanodeStoreCache cache = DatanodeStoreCache.getInstance();
       Preconditions.checkNotNull(cache);
       cache.addDB(containerDBPath, new RawDB(store, containerDBPath));

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/helpers/KeyValueContainerLocationUtil.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/helpers/KeyValueContainerLocationUtil.java
@@ -123,7 +123,7 @@ public final class KeyValueContainerLocationUtil {
    * Return containerDB File.
    */
   public static File getContainerDBFile(KeyValueContainerData containerData) {
-    if (containerData.getSchemaVersion().equals(OzoneConsts.SCHEMA_V3)) {
+    if (containerData.hasSchema(OzoneConsts.SCHEMA_V3)) {
       return new File(containerData.getVolume().getDbParentDir(),
           OzoneConsts.CONTAINER_DB_NAME);
     }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/helpers/KeyValueContainerUtil.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/helpers/KeyValueContainerUtil.java
@@ -215,6 +215,12 @@ public final class KeyValueContainerUtil {
     // Verify Checksum
     ContainerUtils.verifyChecksum(kvContainerData, config);
 
+    if (kvContainerData.getSchemaVersion() == null) {
+      // If this container has not specified a schema version, it is in the old
+      // format with one default column family.
+      kvContainerData.setSchemaVersion(OzoneConsts.SCHEMA_V1);
+    }
+
     File dbFile = KeyValueContainerLocationUtil.getContainerDBFile(
         kvContainerData);
     if (!dbFile.exists()) {

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/helpers/KeyValueContainerUtil.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/helpers/KeyValueContainerUtil.java
@@ -55,6 +55,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import static org.apache.hadoop.ozone.OzoneConsts.OZONE_URI_DELIMITER;
+import static org.apache.hadoop.ozone.OzoneConsts.SCHEMA_V1;
 
 /**
  * Class which defines utility methods for KeyValueContainer.
@@ -114,13 +115,13 @@ public final class KeyValueContainerUtil {
     }
 
     DatanodeStore store;
-    if (schemaVersion.equals(OzoneConsts.SCHEMA_V1)) {
+    if (isSameSchemaVersion(schemaVersion, OzoneConsts.SCHEMA_V1)) {
       store = new DatanodeStoreSchemaOneImpl(conf, dbFile.getAbsolutePath(),
           false);
-    } else if (schemaVersion.equals(OzoneConsts.SCHEMA_V2)) {
+    } else if (isSameSchemaVersion(schemaVersion, OzoneConsts.SCHEMA_V2)) {
       store = new DatanodeStoreSchemaTwoImpl(conf, dbFile.getAbsolutePath(),
           false);
-    } else if (schemaVersion.equals(OzoneConsts.SCHEMA_V3)) {
+    } else if (isSameSchemaVersion(schemaVersion, OzoneConsts.SCHEMA_V3)) {
       // We don't create per-container store for schema v3 containers,
       // they should use per-volume db store.
       return;
@@ -153,7 +154,7 @@ public final class KeyValueContainerUtil {
         .getMetadataPath());
     File chunksPath = new File(containerData.getChunksPath());
 
-    if (containerData.getSchemaVersion().equals(OzoneConsts.SCHEMA_V3)) {
+    if (containerData.hasSchema(OzoneConsts.SCHEMA_V3)) {
       // DB failure is catastrophic, the disk needs to be replaced.
       // In case of an exception, LOG the message and rethrow the exception.
       try {
@@ -214,12 +215,6 @@ public final class KeyValueContainerUtil {
     // Verify Checksum
     ContainerUtils.verifyChecksum(kvContainerData, config);
 
-    if (kvContainerData.getSchemaVersion() == null) {
-      // If this container has not specified a schema version, it is in the old
-      // format with one default column family.
-      kvContainerData.setSchemaVersion(OzoneConsts.SCHEMA_V1);
-    }
-
     File dbFile = KeyValueContainerLocationUtil.getContainerDBFile(
         kvContainerData);
     if (!dbFile.exists()) {
@@ -230,7 +225,7 @@ public final class KeyValueContainerUtil {
     }
     kvContainerData.setDbFile(dbFile);
 
-    if (kvContainerData.getSchemaVersion().equals(OzoneConsts.SCHEMA_V3)) {
+    if (kvContainerData.hasSchema(OzoneConsts.SCHEMA_V3)) {
       try (DBHandle db = BlockUtils.getDB(kvContainerData, config)) {
         populateContainerMetadata(kvContainerData, db.getStore());
       }
@@ -435,6 +430,12 @@ public final class KeyValueContainerUtil {
 
   }
 
+  public static boolean isSameSchemaVersion(String schema, String other) {
+    String effective1 = schema != null ? schema : SCHEMA_V1;
+    String effective2 = other != null ? other : SCHEMA_V1;
+    return effective1.equals(effective2);
+  }
+
   /**
    * Utilities for container_delete_service directory
    * which is located under <volume>/hdds/<cluster-id>/tmp/.
@@ -502,8 +503,7 @@ public final class KeyValueContainerUtil {
         KeyValueContainerData keyValueContainerData =
             (KeyValueContainerData) containerData;
 
-        if (keyValueContainerData.getSchemaVersion()
-            .equals(OzoneConsts.SCHEMA_V3)) {
+        if (keyValueContainerData.hasSchema(OzoneConsts.SCHEMA_V3)) {
           // Container file doesn't include the volume
           // so we need to set it here in order to get the db file.
           keyValueContainerData.setVolume(hddsVolume);

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/statemachine/background/BlockDeletingService.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/statemachine/background/BlockDeletingService.java
@@ -294,11 +294,11 @@ public class BlockDeletingService extends BackgroundService {
       long startTime = Time.monotonicNow();
       // Scan container's db and get list of under deletion blocks
       try (DBHandle meta = BlockUtils.getDB(containerData, conf)) {
-        if (containerData.getSchemaVersion().equals(SCHEMA_V1)) {
+        if (containerData.hasSchema(SCHEMA_V1)) {
           crr = deleteViaSchema1(meta, container, dataDir, startTime);
-        } else if (containerData.getSchemaVersion().equals(SCHEMA_V2)) {
+        } else if (containerData.hasSchema(SCHEMA_V2)) {
           crr = deleteViaSchema2(meta, container, dataDir, startTime);
-        } else if (containerData.getSchemaVersion().equals(SCHEMA_V3)) {
+        } else if (containerData.hasSchema(SCHEMA_V3)) {
           crr = deleteViaSchema3(meta, container, dataDir, startTime);
         } else {
           throw new UnsupportedOperationException(

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/TestBlockDeletingService.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/TestBlockDeletingService.java
@@ -87,7 +87,6 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/TestBlockDeletingService.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/TestBlockDeletingService.java
@@ -572,7 +572,7 @@ public class TestBlockDeletingService {
     containerSet.listContainer(0L, 1, containerData);
     Assert.assertEquals(1, containerData.size());
     KeyValueContainerData data = (KeyValueContainerData) containerData.get(0);
-    KeyPrefixFilter filter = Objects.equals(schemaVersion, SCHEMA_V1) ?
+    KeyPrefixFilter filter = isSameSchemaVersion(schemaVersion, SCHEMA_V1) ?
         data.getDeletingBlockKeyFilter() : data.getUnprefixedKeyFilter();
 
     try (DBHandle meta = BlockUtils.getDB(data, conf)) {
@@ -644,7 +644,7 @@ public class TestBlockDeletingService {
   public void testWithUnrecordedBlocks() throws Exception {
     // Skip schemaV1, when markBlocksForDeletionSchemaV1, the unrecorded blocks
     // from received TNXs will be deleted, not in BlockDeletingService
-    Assume.assumeFalse(Objects.equals(schemaVersion, SCHEMA_V1));
+    Assume.assumeFalse(isSameSchemaVersion(schemaVersion, SCHEMA_V1));
 
     int numOfContainers = 2;
     int numOfChunksPerBlock = 1;
@@ -674,7 +674,7 @@ public class TestBlockDeletingService {
     Assert.assertEquals(2, containerData.size());
     KeyValueContainerData ctr1 = (KeyValueContainerData) containerData.get(0);
     KeyValueContainerData ctr2 = (KeyValueContainerData) containerData.get(1);
-    KeyPrefixFilter filter = Objects.equals(schemaVersion, SCHEMA_V1) ?
+    KeyPrefixFilter filter = isSameSchemaVersion(schemaVersion, SCHEMA_V1) ?
         ctr1.getDeletingBlockKeyFilter() : ctr1.getUnprefixedKeyFilter();
 
     // Have two unrecorded blocks onDisk and another two not to simulate the

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/impl/TestContainerPersistence.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/impl/TestContainerPersistence.java
@@ -85,6 +85,7 @@ import org.junit.AfterClass;
 import org.junit.Assert;
 
 import static org.apache.hadoop.ozone.container.common.ContainerTestUtils.createDbInstancesForTestIfNeeded;
+import static org.apache.hadoop.ozone.container.keyvalue.helpers.KeyValueContainerUtil.isSameSchemaVersion;
 import static org.junit.Assert.fail;
 import static org.junit.Assume.assumeFalse;
 import static org.junit.Assume.assumeTrue;
@@ -331,7 +332,7 @@ public class TestContainerPersistence {
 
   @Test
   public void testDeleteContainer() throws IOException {
-    assumeTrue(schemaVersion.equals(OzoneConsts.SCHEMA_V3));
+    assumeTrue(isSameSchemaVersion(schemaVersion, OzoneConsts.SCHEMA_V3));
     long testContainerID = getTestContainerID();
     Container<KeyValueContainerData> container = addContainer(containerSet,
         testContainerID);

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/impl/TestContainerPersistence.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/impl/TestContainerPersistence.java
@@ -270,7 +270,7 @@ public class TestContainerPersistence {
   public void testAddingBlockToDeletedContainer() throws Exception {
     // With schema v3, we don't have a container dedicated db,
     // so skip check the behaviors related to it.
-    assumeFalse(schemaVersion.contains(OzoneConsts.SCHEMA_V3));
+    assumeFalse(isSameSchemaVersion(schemaVersion, OzoneConsts.SCHEMA_V3));
 
     long testContainerID = getTestContainerID();
     Thread.sleep(100);
@@ -380,7 +380,7 @@ public class TestContainerPersistence {
       throws Exception {
     HddsVolume hddsVolume;
     // If !SchemaV3, build hddsVolume
-    if (!schemaVersion.contains(OzoneConsts.SCHEMA_V3)) {
+    if (!isSameSchemaVersion(schemaVersion, OzoneConsts.SCHEMA_V3)) {
       Files.createDirectories(Paths.get(hddsPath));
 
       HddsVolume.Builder volumeBuilder =

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/ContainerTestVersionInfo.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/ContainerTestVersionInfo.java
@@ -26,7 +26,6 @@ import java.util.ArrayList;
 import java.util.List;
 
 import static java.util.stream.Collectors.toList;
-import static org.apache.hadoop.ozone.OzoneConsts.SCHEMA_VERSIONS;
 import static org.apache.hadoop.ozone.container.keyvalue.helpers.KeyValueContainerUtil.isSameSchemaVersion;
 
 /**
@@ -35,6 +34,13 @@ import static org.apache.hadoop.ozone.container.keyvalue.helpers.KeyValueContain
  * - ChunkLayOutVersion: data layout version
  */
 public class ContainerTestVersionInfo {
+  private static final String[] SCHEMA_VERSIONS = new String[] {
+      null,
+      OzoneConsts.SCHEMA_V1,
+      OzoneConsts.SCHEMA_V2,
+      OzoneConsts.SCHEMA_V3,
+  };
+
   private final String schemaVersion;
   private final ContainerLayoutVersion layout;
 

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/ContainerTestVersionInfo.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/ContainerTestVersionInfo.java
@@ -27,6 +27,7 @@ import java.util.List;
 
 import static java.util.stream.Collectors.toList;
 import static org.apache.hadoop.ozone.OzoneConsts.SCHEMA_VERSIONS;
+import static org.apache.hadoop.ozone.container.keyvalue.helpers.KeyValueContainerUtil.isSameSchemaVersion;
 
 /**
  * Class to hold version info for container data and metadata.
@@ -75,7 +76,7 @@ public class ContainerTestVersionInfo {
   }
   public static void setTestSchemaVersion(String schemaVersion,
       OzoneConfiguration conf) {
-    if (schemaVersion.equals(OzoneConsts.SCHEMA_V3)) {
+    if (isSameSchemaVersion(schemaVersion, OzoneConsts.SCHEMA_V3)) {
       ContainerTestUtils.enableSchemaV3(conf);
     } else {
       ContainerTestUtils.disableSchemaV3(conf);

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/TestKeyValueContainer.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/TestKeyValueContainer.java
@@ -89,6 +89,7 @@ import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
 import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_DB_PROFILE;
+import static org.apache.hadoop.ozone.container.keyvalue.helpers.KeyValueContainerUtil.isSameSchemaVersion;
 import static org.apache.hadoop.ozone.container.replication.CopyContainerCompression.NO_COMPRESSION;
 import static org.apache.ratis.util.Preconditions.assertTrue;
 import static org.junit.Assert.assertEquals;
@@ -462,7 +463,7 @@ public class TestKeyValueContainer {
     assertFalse("Container File still exists",
         keyValueContainer.getContainerFile().exists());
 
-    if (schemaVersion.equals(OzoneConsts.SCHEMA_V3)) {
+    if (isSameSchemaVersion(schemaVersion, OzoneConsts.SCHEMA_V3)) {
       assertTrue(keyValueContainer.getContainerDBFile().exists());
     } else {
       assertFalse("Container DB file still exists",
@@ -633,7 +634,7 @@ public class TestKeyValueContainer {
     }
 
     // DBOtions should be different, except SCHEMA-V3
-    if (schemaVersion.equals(OzoneConsts.SCHEMA_V3)) {
+    if (isSameSchemaVersion(schemaVersion, OzoneConsts.SCHEMA_V3)) {
       Assert.assertEquals(
           outProfile1.getDBOptions().compactionReadaheadSize(),
           outProfile2.getDBOptions().compactionReadaheadSize());
@@ -673,7 +674,7 @@ public class TestKeyValueContainer {
 
   @Test
   public void testAutoCompactionSmallSstFile() throws IOException {
-    Assume.assumeTrue(schemaVersion.equals(OzoneConsts.SCHEMA_V3));
+    Assume.assumeTrue(OzoneConsts.SCHEMA_V3.equals(schemaVersion));
     // Create a new HDDS volume
     HddsVolume newVolume = new HddsVolume.Builder(
         folder.newFolder().getAbsolutePath())

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/TestKeyValueContainer.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/TestKeyValueContainer.java
@@ -674,7 +674,8 @@ public class TestKeyValueContainer {
 
   @Test
   public void testAutoCompactionSmallSstFile() throws IOException {
-    Assume.assumeTrue(OzoneConsts.SCHEMA_V3.equals(schemaVersion));
+    Assume.assumeTrue(
+        isSameSchemaVersion(schemaVersion, OzoneConsts.SCHEMA_V3));
     // Create a new HDDS volume
     HddsVolume newVolume = new HddsVolume.Builder(
         folder.newFolder().getAbsolutePath())


### PR DESCRIPTION
## What changes were proposed in this pull request?

> @k5342 found a `NullPointerException` while replicating V1 containers in Ozone 1.3.0.  V1 containers do not have the `schemaVersion` field in the `.container` file

The NPE is fixed by adding and using a comparison function that considers `null` and `V1` to be equal.

https://issues.apache.org/jira/browse/HDDS-8636

## How was this patch tested?

Tested in real cluster:
https://github.com/apache/ozone/pull/4723#issuecomment-1554645068

Updated parameterized unit tests that exercise different schema versions to also test `null` value.

https://github.com/adoroszlai/hadoop-ozone/actions/runs/5032201568