### PR TITLE
HDDS-8645. Change TestOzoneManagerHASnapshot to not subclass TestOzoneManagerHA

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerHASnapshot.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerHASnapshot.java
@@ -30,6 +30,7 @@ import org.apache.hadoop.ozone.client.OzoneBucket;
 import org.apache.hadoop.ozone.client.OzoneClient;
 import org.apache.hadoop.ozone.client.io.OzoneOutputStream;
 import org.apache.hadoop.ozone.om.helpers.SnapshotInfo;
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
@@ -79,6 +80,13 @@ public class TestOzoneManagerHASnapshot {
     ozoneBucket = TestDataUtil.createVolumeAndBucket(client);
     volumeName = ozoneBucket.getVolumeName();
     bucketName = ozoneBucket.getName();
+  }
+
+  @AfterAll
+  public static void cleanUp() {
+    if (cluster != null) {
+      cluster.shutdown();
+    }
   }
 
   /**

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerHASnapshot.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerHASnapshot.java
@@ -19,11 +19,18 @@
 package org.apache.hadoop.ozone.om;
 
 import org.apache.commons.lang3.RandomStringUtils;
+import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.utils.db.Table;
 import org.apache.hadoop.hdds.utils.db.TableIterator;
+import org.apache.hadoop.ozone.MiniOzoneCluster;
+import org.apache.hadoop.ozone.MiniOzoneHAClusterImpl;
+import org.apache.hadoop.ozone.TestDataUtil;
+import org.apache.hadoop.ozone.client.ObjectStore;
 import org.apache.hadoop.ozone.client.OzoneBucket;
+import org.apache.hadoop.ozone.client.OzoneClient;
+import org.apache.hadoop.ozone.client.io.OzoneOutputStream;
 import org.apache.hadoop.ozone.om.helpers.SnapshotInfo;
-import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 
@@ -31,7 +38,9 @@ import java.io.IOException;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.UUID;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.apache.hadoop.ozone.OzoneConsts.OM_KEY_PREFIX;
 import static org.awaitility.Awaitility.await;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -42,8 +51,35 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * Tests snapshot in OM HA setup.
  */
 @Timeout(300)
-@Disabled("HDDS-8645")
-public class TestOzoneManagerHASnapshot extends TestOzoneManagerHA {
+public class TestOzoneManagerHASnapshot {
+  private static MiniOzoneHAClusterImpl cluster;
+  private static OzoneClient client;
+  private static String volumeName;
+  private static String bucketName;
+  private static ObjectStore store;
+  private static OzoneBucket ozoneBucket;
+
+  @BeforeAll
+  public static void staticInit() throws Exception {
+    OzoneConfiguration conf = new OzoneConfiguration();
+    String clusterId = UUID.randomUUID().toString();
+    String scmId = UUID.randomUUID().toString();
+    conf.setBoolean(OMConfigKeys.OZONE_FILESYSTEM_SNAPSHOT_ENABLED_KEY, true);
+
+    cluster = (MiniOzoneHAClusterImpl) MiniOzoneCluster.newOMHABuilder(conf)
+        .setClusterId(clusterId)
+        .setScmId(scmId)
+        .setOMServiceId("om-service-test")
+        .setNumOfOzoneManagers(3)
+        .build();
+
+    cluster.waitForClusterToBeReady();
+    client = cluster.newClient();
+    store = client.getObjectStore();
+    ozoneBucket = TestDataUtil.createVolumeAndBucket(client);
+    volumeName = ozoneBucket.getVolumeName();
+    bucketName = ozoneBucket.getName();
+  }
 
   /**
    * Test snapshotNames are unique among OM nodes when snapshotName is not
@@ -51,14 +87,8 @@ public class TestOzoneManagerHASnapshot extends TestOzoneManagerHA {
    */
   @Test
   public void testSnapshotNameConsistency() throws Exception {
-    OzoneBucket ozoneBucket = setupBucket();
-    String volumeName = ozoneBucket.getVolumeName();
-    String bucketName = ozoneBucket.getName();
-
-    createKey(ozoneBucket);
-
-    getObjectStore().createSnapshot(volumeName, bucketName, "");
-    List<OzoneManager> ozoneManagers = getCluster().getOzoneManagersList();
+    store.createSnapshot(volumeName, bucketName, "");
+    List<OzoneManager> ozoneManagers = cluster.getOzoneManagersList();
     List<String> snapshotNames = new ArrayList<>();
 
     for (OzoneManager ozoneManager : ozoneManagers) {
@@ -97,27 +127,37 @@ public class TestOzoneManagerHASnapshot extends TestOzoneManagerHA {
     List<String> bucketNames = new ArrayList<>();
 
     for (int i = 0; i < 10; i++) {
-      OzoneBucket ozoneBucket = setupBucket();
-      ozoneBuckets.add(ozoneBucket);
-      volumeNames.add(ozoneBucket.getVolumeName());
-      bucketNames.add(ozoneBucket.getName());
+      OzoneBucket bucket = TestDataUtil.createVolumeAndBucket(client);
+      ozoneBuckets.add(bucket);
+      volumeNames.add(bucket.getVolumeName());
+      bucketNames.add(bucket.getName());
     }
 
     for (int i = 0; i < 100; i++) {
       int index = i % 10;
-      createKey(ozoneBuckets.get(index));
+      createFileKey(ozoneBuckets.get(index),
+          "key-" + RandomStringUtils.randomNumeric(3));
       String snapshot1 = "snapshot-" + RandomStringUtils.randomNumeric(5);
-      getObjectStore().createSnapshot(volumeNames.get(index),
+      store.createSnapshot(volumeNames.get(index),
           bucketNames.get(index), snapshot1);
     }
 
     // Restart leader OM
-    OzoneManager omLeader = getCluster().getOMLeader();
-    getCluster().shutdownOzoneManager(omLeader);
-    getCluster().restartOzoneManager(omLeader, true);
+    OzoneManager omLeader = cluster.getOMLeader();
+    cluster.shutdownOzoneManager(omLeader);
+    cluster.restartOzoneManager(omLeader, true);
 
     await().atMost(Duration.ofSeconds(180))
-        .until(() -> getCluster().getOMLeader() != null);
-    assertNotNull(getCluster().getOMLeader());
+        .until(() -> cluster.getOMLeader() != null);
+    assertNotNull(cluster.getOMLeader());
+  }
+
+
+  private void createFileKey(OzoneBucket bucket, String keyName)
+      throws IOException {
+    byte[] value = RandomStringUtils.randomAscii(10240).getBytes(UTF_8);
+    try (OzoneOutputStream fileKey = bucket.createKey(keyName, value.length)) {
+      fileKey.write(value);
+    }
   }
 }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerHASnapshot.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerHASnapshot.java
@@ -20,6 +20,7 @@ package org.apache.hadoop.ozone.om;
 
 import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import org.apache.hadoop.hdds.utils.IOUtils;
 import org.apache.hadoop.hdds.utils.db.Table;
 import org.apache.hadoop.hdds.utils.db.TableIterator;
 import org.apache.hadoop.ozone.MiniOzoneCluster;
@@ -84,6 +85,7 @@ public class TestOzoneManagerHASnapshot {
 
   @AfterAll
   public static void cleanUp() {
+    IOUtils.closeQuietly(client);
     if (cluster != null) {
       cluster.shutdown();
     }


### PR DESCRIPTION
## What changes were proposed in this pull request?
`TestOzoneManagerHASnapshot` intermittently fails because DB is getting closed due to Ratis's consistence state. 
```
Error:  org.apache.hadoop.ozone.om.TestOzoneManagerHASnapshot.testSnapshotNameConsistency  Time elapsed: 3.094 s  <<< ERROR!
java.lang.RuntimeException: java.io.IOException: Rocks Database is closed
	at org.apache.hadoop.ozone.om.TestOzoneManagerHASnapshot.lambda$testSnapshotNameConsistency$0(TestOzoneManagerHASnapshot.java:76)
	at org.awaitility.core.CallableCondition$ConditionEvaluationWrapper.eval(CallableCondition.java:99)
	at org.awaitility.core.ConditionAwaiter$ConditionPoller.call(ConditionAwaiter.java:248)
	at org.awaitility.core.ConditionAwaiter$ConditionPoller.call(ConditionAwaiter.java:235)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at java.lang.Thread.run(Thread.java:750)
	Suppressed: org.apache.ratis.util.ExitUtils$ExitException: Cannot load OM DB as it is in an inconsistent state.
		at org.apache.ratis.util.ExitUtils.terminate(ExitUtils.java:141)
		at org.apache.ratis.util.ExitUtils.terminate(ExitUtils.java:151)
		at org.apache.ratis.util.ExitUtils.terminate(ExitUtils.java:155)
```

`TestOzoneManagerHASnapshot` inherits `TestOzoneManagerHA` and uses cluster created by the base class which is statically initialized by `BeforeAll`.  Although we don't run test parallelly, there is some possibility one test is interfering with other one and causing inconsistency.

This change is to create mini cluster for `TestOzoneManagerHASnapshot` instead of using inherited one.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-8645

## How was this patch tested?
Ran this test 25 times in workflow and it passed all the time.
Run 1: https://github.com/hemantk-12/ozone/actions/runs/5019667607/jobs/9000405979
Run 2: https://github.com/hemantk-12/ozone/actions/runs/5019724655/jobs/9000519201

I tired to run 50 times too but it failed due to disk space: https://github.com/hemantk-12/ozone/actions/runs/5019375127/jobs/8999791082 

CI/CD passed in one go on fork
Run 1: https://github.com/hemantk-12/ozone/actions/runs/5019860313
Run 2: https://github.com/hemantk-12/ozone/actions/runs/5026615405

