### PR TITLE
HDDS-8662. Improving S3G-related metrics

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ReplicationManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ReplicationManager.java
@@ -1130,12 +1130,12 @@ public class ReplicationManager implements SCMService {
      */
     @Config(key = "event.timeout",
         type = ConfigType.TIME,
-        defaultValue = "30m",
+        defaultValue = "10m",
         tags = {SCM, OZONE},
         description = "Timeout for the container replication/deletion commands "
             + "sent to datanodes. After this timeout the command will be "
             + "retried.")
-    private long eventTimeout = Duration.ofMinutes(30).toMillis();
+    private long eventTimeout = Duration.ofMinutes(10).toMillis();
     public void setInterval(Duration interval) {
       this.interval = interval.toMillis();
     }

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestLegacyReplicationManager.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestLegacyReplicationManager.java
@@ -316,18 +316,6 @@ public class TestLegacyReplicationManager {
       replicationManager.start();
       Assertions.assertTrue(replicationManager.isRunning());
     }
-
-    @Test
-    public void testGeneratedConfig() {
-      ReplicationManagerConfiguration rmc = OzoneConfiguration.newInstanceOf(
-          ReplicationManagerConfiguration.class);
-
-      //default is not included in ozone-site.xml but generated from annotation
-      //to the ozone-site-generated.xml which should be loaded by the
-      // OzoneConfiguration.
-      Assertions.assertEquals(1800000, rmc.getEventTimeout());
-
-    }
   }
 
   /**

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/BucketEndpoint.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/BucketEndpoint.java
@@ -249,9 +249,11 @@ public class BucketEndpoint extends EndpointBase {
 
     AUDIT.logReadSuccess(buildAuditMessageForSuccess(s3GAction,
         getAuditParameters()));
+    int keyCount =
+        response.getCommonPrefixes().size() + response.getContents().size();
     getMetrics().updateGetBucketSuccessStats(startNanos);
-    response.setKeyCount(
-        response.getCommonPrefixes().size() + response.getContents().size());
+    getMetrics().incListKeyCount(keyCount);
+    response.setKeyCount(keyCount);
     return Response.ok(response).build();
   }
 
@@ -418,25 +420,33 @@ public class BucketEndpoint extends EndpointBase {
     MultiDeleteResponse result = new MultiDeleteResponse();
     if (request.getObjects() != null) {
       for (DeleteObject keyToDelete : request.getObjects()) {
+        long startNanos = Time.monotonicNowNanos();
         try {
           bucket.deleteKey(keyToDelete.getKey());
+          getMetrics().updateDeleteKeySuccessStats(startNanos);
 
           if (!request.isQuiet()) {
             result.addDeleted(new DeletedObject(keyToDelete.getKey()));
           }
         } catch (OMException ex) {
           if (isAccessDenied(ex)) {
+            getMetrics().updateDeleteKeyFailureStats(startNanos);
             result.addError(
                 new Error(keyToDelete.getKey(), "PermissionDenied",
                     ex.getMessage()));
           } else if (ex.getResult() != ResultCodes.KEY_NOT_FOUND) {
+            getMetrics().updateDeleteKeyFailureStats(startNanos);
             result.addError(
                 new Error(keyToDelete.getKey(), "InternalError",
                     ex.getMessage()));
-          } else if (!request.isQuiet()) {
-            result.addDeleted(new DeletedObject(keyToDelete.getKey()));
+          } else {
+            if (request.isQuiet()) {
+              result.addDeleted(new DeletedObject(keyToDelete.getKey()));
+            }
+            getMetrics().updateDeleteKeySuccessStats(startNanos);
           }
         } catch (Exception ex) {
+          getMetrics().updateDeleteKeyFailureStats(startNanos);
           result.addError(
               new Error(keyToDelete.getKey(), "InternalError",
                   ex.getMessage()));

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/ObjectEndpoint.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/ObjectEndpoint.java
@@ -236,9 +236,9 @@ public class ObjectEndpoint extends EndpointBase {
 
       output = getClientProtocol().createKey(volume.getName(), bucketName,
           keyPath, length, replicationConfig, customMetadata);
-      IOUtils.copy(body, output);
-
-      getMetrics().updateCreateKeySuccessStats(startNanos);
+      getMetrics().updatePutKeyMetadataStats(startNanos);
+      long putLength = IOUtils.copyLarge(body, output);
+      getMetrics().incPutKeySuccessLength(putLength);
       return Response.ok().status(HttpStatus.SC_OK)
           .build();
     } catch (OMException ex) {
@@ -281,6 +281,7 @@ public class ObjectEndpoint extends EndpointBase {
       }
       if (output != null) {
         output.close();
+        getMetrics().updateCreateKeySuccessStats(startNanos);
       }
     }
   }
@@ -340,8 +341,10 @@ public class ObjectEndpoint extends EndpointBase {
       if (rangeHeaderVal == null || rangeHeader.isReadFull()) {
         StreamingOutput output = dest -> {
           try (OzoneInputStream key = keyDetails.getContent()) {
-            IOUtils.copy(key, dest);
+            long readLength = IOUtils.copyLarge(key, dest);
+            getMetrics().incGetKeySuccessLength(readLength);
           }
+          getMetrics().updateGetKeySuccessStats(startNanos);
         };
         responseBuilder = Response
             .ok(output)
@@ -357,9 +360,11 @@ public class ObjectEndpoint extends EndpointBase {
         StreamingOutput output = dest -> {
           try (OzoneInputStream ozoneInputStream = keyDetails.getContent()) {
             ozoneInputStream.seek(startOffset);
-            IOUtils.copyLarge(ozoneInputStream, dest, 0,
+            long readLength = IOUtils.copyLarge(ozoneInputStream, dest, 0,
                 copyLength, new byte[bufferSize]);
+            getMetrics().incGetKeySuccessLength(readLength);
           }
+          getMetrics().updateGetKeySuccessStats(startNanos);
         };
         responseBuilder = Response
             .status(Status.PARTIAL_CONTENT)
@@ -399,7 +404,7 @@ public class ObjectEndpoint extends EndpointBase {
         }
       }
       addLastModifiedDate(responseBuilder, keyDetails);
-      getMetrics().updateGetKeySuccessStats(startNanos);
+      getMetrics().updateGetKeyMetadataStats(startNanos);
       return responseBuilder.build();
     } catch (OMException ex) {
       auditSuccess = false;
@@ -747,8 +752,8 @@ public class ObjectEndpoint extends EndpointBase {
                                       String uploadID, InputStream body)
       throws IOException, OS3Exception {
     long startNanos = Time.monotonicNowNanos();
+    String copyHeader = null;
     try {
-      String copyHeader;
       OzoneOutputStream ozoneOutputStream = null;
 
       if ("STREAMING-AWS4-HMAC-SHA256-PAYLOAD"
@@ -783,6 +788,7 @@ public class ObjectEndpoint extends EndpointBase {
 
             String range =
                 headers.getHeaderString(COPY_SOURCE_HEADER_RANGE);
+            long copyLength;
             if (range != null) {
               RangeHeader rangeHeader =
                   RangeHeaderParserUtil.parseRangeHeader(range, 0);
@@ -793,15 +799,20 @@ public class ObjectEndpoint extends EndpointBase {
                     "Bytes to skip: "
                         + rangeHeader.getStartOffset() + " actual: " + skipped);
               }
-              IOUtils.copyLarge(sourceObject, ozoneOutputStream, 0,
+              getMetrics().updateCopyKeyMetadataStats(startNanos);
+              copyLength = IOUtils.copyLarge(sourceObject, ozoneOutputStream, 0,
                   rangeHeader.getEndOffset() - rangeHeader.getStartOffset()
                       + 1);
             } else {
-              IOUtils.copy(sourceObject, ozoneOutputStream);
+              getMetrics().updateCopyKeyMetadataStats(startNanos);
+              copyLength = IOUtils.copyLarge(sourceObject, ozoneOutputStream);
             }
+            getMetrics().incCopyObjectSuccessLength(copyLength);
           }
         } else {
-          IOUtils.copy(body, ozoneOutputStream);
+          getMetrics().updatePutKeyMetadataStats(startNanos);
+          long putLength = IOUtils.copyLarge(body, ozoneOutputStream);
+          getMetrics().incPutKeySuccessLength(putLength);
         }
       } finally {
         if (ozoneOutputStream != null) {
@@ -814,16 +825,21 @@ public class ObjectEndpoint extends EndpointBase {
           ozoneOutputStream.getCommitUploadPartInfo();
       String eTag = omMultipartCommitUploadPartInfo.getPartName();
 
-      getMetrics().updateCreateMultipartKeySuccessStats(startNanos);
       if (copyHeader != null) {
+        getMetrics().updateCopyObjectSuccessStats(startNanos);
         return Response.ok(new CopyPartResult(eTag)).build();
       } else {
+        getMetrics().updateCreateMultipartKeySuccessStats(startNanos);
         return Response.ok().header("ETag",
             eTag).build();
       }
 
     } catch (OMException ex) {
-      getMetrics().updateCreateMultipartKeyFailureStats(startNanos);
+      if (copyHeader != null) {
+        getMetrics().updateCopyObjectFailureStats(startNanos);
+      } else {
+        getMetrics().updateCreateMultipartKeyFailureStats(startNanos);
+      }
       if (ex.getResult() == ResultCodes.NO_SUCH_MULTIPART_UPLOAD_ERROR) {
         throw newError(NO_SUCH_UPLOAD, uploadID, ex);
       } else if (isAccessDenied(ex)) {
@@ -907,12 +923,14 @@ public class ObjectEndpoint extends EndpointBase {
       String destKey, String destBucket,
       ReplicationConfig replication,
             Map<String, String> metadata) throws IOException {
+    long copyLength;
     try (OzoneOutputStream dest =
                  getClientProtocol().createKey(
         volume.getName(), destBucket, destKey, srcKeyLen,
         replication, metadata)) {
-      IOUtils.copy(src, dest);
+      copyLength = IOUtils.copyLarge(src, dest);
     }
+    getMetrics().incCopyObjectSuccessLength(copyLength);
   }
 
   private CopyObjectResponse copyObject(OzoneVolume volume,
@@ -961,6 +979,7 @@ public class ObjectEndpoint extends EndpointBase {
 
       try (OzoneInputStream src = getClientProtocol().getKey(volume.getName(),
           sourceBucket, sourceKey)) {
+        getMetrics().updateCopyKeyMetadataStats(startNanos);
         copy(volume, src, sourceKeyLen, destkey, destBucket, replicationConfig,
                 sourceKeyDetails.getMetadata());
       }
@@ -969,6 +988,8 @@ public class ObjectEndpoint extends EndpointBase {
           volume.getName(), destBucket, destkey);
 
       getMetrics().updateCopyObjectSuccessStats(startNanos);
+      getMetrics().incCopyObjectSuccessLength(copyLength);
+
       CopyObjectResponse copyObjectResponse = new CopyObjectResponse();
       copyObjectResponse.setETag(OzoneUtils.getRequestID());
       copyObjectResponse.setLastModified(destKeyDetails.getModificationTime());

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/metrics/S3GatewayMetrics.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/metrics/S3GatewayMetrics.java
@@ -58,6 +58,8 @@ public final class S3GatewayMetrics implements MetricsSource {
   private @Metric MutableCounterLong putAclFailure;
   private @Metric MutableCounterLong listMultipartUploadsSuccess;
   private @Metric MutableCounterLong listMultipartUploadsFailure;
+  private @Metric MutableCounterLong listKeyCount;
+
 
   // RootEndpoint
   private @Metric MutableCounterLong listS3BucketsSuccess;
@@ -84,6 +86,13 @@ public final class S3GatewayMetrics implements MetricsSource {
   private @Metric MutableCounterLong abortMultipartUploadFailure;
   private @Metric MutableCounterLong deleteKeySuccess;
   private @Metric MutableCounterLong deleteKeyFailure;
+  private @Metric MutableCounterLong copyObjectSuccessLength;
+  private @Metric MutableCounterLong putKeySuccessLength;
+  private @Metric MutableCounterLong getKeySuccessLength;
+
+  // S3Gateway
+  private @Metric MutableCounterLong request;
+  private @Metric MutableCounterLong requestReject;
 
   // S3 Gateway Latency Metrics
   // BucketEndpoint
@@ -226,6 +235,15 @@ public final class S3GatewayMetrics implements MetricsSource {
   @Metric(about = "Latency for failing to delete an S3 object in nanoseconds")
   private MutableRate deleteKeyFailureLatencyNs;
 
+  @Metric(about = "Latency for put metadata of an key in nanoseconds")
+  private MutableRate putKeyMetadataLatencyNs;
+
+  @Metric(about = "Latency for get metadata of an key in nanoseconds")
+  private MutableRate getKeyMetadataLatencyNs;
+
+  @Metric(about = "Latency for copy metadata of an key in nanoseconds")
+  private MutableRate copyKeyMetadataLatencyNs;
+
   /**
    * Private constructor.
    */
@@ -260,6 +278,9 @@ public final class S3GatewayMetrics implements MetricsSource {
   @Override
   public void getMetrics(MetricsCollector collector, boolean all) {
     MetricsRecordBuilder recordBuilder = collector.addRecord(SOURCE_NAME);
+    ///Request Count
+    request.snapshot(recordBuilder, true);
+    requestReject.snapshot(recordBuilder, true);
 
     // BucketEndpoint
     getBucketSuccess.snapshot(recordBuilder, true);
@@ -336,6 +357,22 @@ public final class S3GatewayMetrics implements MetricsSource {
     deleteKeySuccessLatencyNs.snapshot(recordBuilder, true);
     deleteKeyFailure.snapshot(recordBuilder, true);
     deleteKeyFailureLatencyNs.snapshot(recordBuilder, true);
+    putKeyMetadataLatencyNs.snapshot(recordBuilder, true);
+    getKeyMetadataLatencyNs.snapshot(recordBuilder, true);
+    copyKeyMetadataLatencyNs.snapshot(recordBuilder, true);
+    copyObjectSuccessLength.snapshot(recordBuilder, true);
+    putKeySuccessLength.snapshot(recordBuilder, true);
+    getKeySuccessLength.snapshot(recordBuilder, true);
+    listKeyCount.snapshot(recordBuilder, true);
+  }
+
+  // S3 Gateway
+  public void incRequest() {
+    request.incr();
+  }
+
+  public void incRequestReject() {
+    requestReject.incr();
   }
 
   // INC and UPDATE
@@ -394,6 +431,10 @@ public final class S3GatewayMetrics implements MetricsSource {
   public void updatePutAclFailureStats(long startNanos) {
     putAclFailure.incr();
     putAclFailureLatencyNs.add(Time.monotonicNowNanos() - startNanos);
+  }
+
+  public void incListKeyCount(int count) {
+    listKeyCount.incr(count);
   }
 
   public void updateListMultipartUploadsSuccessStats(long startNanos) {
@@ -528,6 +569,30 @@ public final class S3GatewayMetrics implements MetricsSource {
   public void updateDeleteKeyFailureStats(long startNanos) {
     deleteKeyFailure.incr();
     deleteKeyFailureLatencyNs.add(Time.monotonicNowNanos() - startNanos);
+  }
+
+  public void updateGetKeyMetadataStats(long startNanos) {
+    getKeyMetadataLatencyNs.add(Time.monotonicNowNanos() - startNanos);
+  }
+
+  public void updateCopyKeyMetadataStats(long startNanos) {
+    copyKeyMetadataLatencyNs.add(Time.monotonicNowNanos() - startNanos);
+  }
+
+  public void updatePutKeyMetadataStats(long startNanos) {
+    putKeyMetadataLatencyNs.add(Time.monotonicNowNanos() - startNanos);
+  }
+
+  public void incCopyObjectSuccessLength(long bytes) {
+    copyObjectSuccessLength.incr(bytes);
+  }
+
+  public void incPutKeySuccessLength(long bytes) {
+    putKeySuccessLength.incr(bytes);
+  }
+
+  public void incGetKeySuccessLength(long bytes) {
+    getKeySuccessLength.incr(bytes);
   }
 
   // GET


### PR DESCRIPTION
## What changes were proposed in this pull request?
- `Copy/Put/Get` Add Metadata Latency Metrics.
- Adjust the original `Copy/Put/Get` latency metric to the time taken for a complete operation, including metadata time and data time. Currently, these metrics are adjusted to be calculated after stream `close()`, because some data is written to the DN during the `close()` method.
- Add `Copy/Put/Get` IO byte count metric, which can be used to calculate read/write traffic (byte/s)
- Add list_key_count used to measuring the load of user list requests.

### Example

`Copy/Put/Get` Metadata Latency Metrics
```bash
s3_gateway_metrics_copy_key_metadata_latency_ns_avg_time{hostname="VM-8-3-centos"} 0.0
s3_gateway_metrics_copy_key_metadata_latency_ns_num_ops{hostname="VM-8-3-centos"} 0
s3_gateway_metrics_get_key_metadata_latency_ns_avg_time{hostname="VM-8-3-centos"} 0.0
s3_gateway_metrics_get_key_metadata_latency_ns_num_ops{hostname="VM-8-3-centos"} 0
s3_gateway_metrics_put_key_metadata_latency_ns_avg_time{hostname="VM-8-3-centos"} 0.0
s3_gateway_metrics_put_key_metadata_latency_ns_num_ops{hostname="VM-8-3-centos"} 0
```
`Copy/Put/Get` IO byte count metric,
```bash
s3_gateway_metrics_copy_object_success_length{hostname="VM-8-3-centos"} 0
s3_gateway_metrics_get_key_success_length{hostname="VM-8-3-centos"} 0
s3_gateway_metrics_put_key_success_length{hostname="VM-8-3-centos"} 0
```

list_key_count
```bash
s3_gateway_metrics_list_key_count{hostname="VM-8-3-centos"} 0
```

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-8662


## How was this patch tested?

manual tests