### PR TITLE
HDDS-8535. ReplicationManager: Unhealthy containers could block EC recovery in small clusters

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ECContainerReplicaCount.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ECContainerReplicaCount.java
@@ -78,7 +78,6 @@ public class ECContainerReplicaCount implements ContainerReplicaCount {
   private final Map<Integer, Integer> decommissionIndexes = new HashMap<>();
   private final Map<Integer, Integer> maintenanceIndexes = new HashMap<>();
   private final Set<DatanodeDetails> unhealthyReplicaDNs;
-  private final Set<ContainerReplica> unhealthyReplicas;
   private final List<ContainerReplica> replicas;
 
   public ECContainerReplicaCount(ContainerInfo containerInfo,
@@ -100,11 +99,9 @@ public class ECContainerReplicaCount implements ContainerReplicaCount {
         = Math.min(repConfig.getParity(), remainingMaintenanceRedundancy);
 
     unhealthyReplicaDNs = new HashSet<>();
-    unhealthyReplicas = new HashSet<>();
     for (ContainerReplica r : replicas) {
       if (r.getState() == ContainerReplicaProto.State.UNHEALTHY) {
         unhealthyReplicaDNs.add(r.getDatanodeDetails());
-        unhealthyReplicas.add(r);
       }
     }
 
@@ -173,10 +170,6 @@ public class ECContainerReplicaCount implements ContainerReplicaCount {
   @Override
   public int getMaintenanceCount() {
     return maintenanceIndexes.size();
-  }
-
-  Set<ContainerReplica> getUnhealthyReplicas() {
-    return unhealthyReplicas;
   }
 
   /**

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ECContainerReplicaCount.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ECContainerReplicaCount.java
@@ -78,6 +78,7 @@ public class ECContainerReplicaCount implements ContainerReplicaCount {
   private final Map<Integer, Integer> decommissionIndexes = new HashMap<>();
   private final Map<Integer, Integer> maintenanceIndexes = new HashMap<>();
   private final Set<DatanodeDetails> unhealthyReplicaDNs;
+  private final Set<ContainerReplica> unhealthyReplicas;
   private final List<ContainerReplica> replicas;
 
   public ECContainerReplicaCount(ContainerInfo containerInfo,
@@ -99,9 +100,11 @@ public class ECContainerReplicaCount implements ContainerReplicaCount {
         = Math.min(repConfig.getParity(), remainingMaintenanceRedundancy);
 
     unhealthyReplicaDNs = new HashSet<>();
+    unhealthyReplicas = new HashSet<>();
     for (ContainerReplica r : replicas) {
       if (r.getState() == ContainerReplicaProto.State.UNHEALTHY) {
         unhealthyReplicaDNs.add(r.getDatanodeDetails());
+        unhealthyReplicas.add(r);
       }
     }
 
@@ -170,6 +173,10 @@ public class ECContainerReplicaCount implements ContainerReplicaCount {
   @Override
   public int getMaintenanceCount() {
     return maintenanceIndexes.size();
+  }
+
+  Set<ContainerReplica> getUnhealthyReplicas() {
+    return unhealthyReplicas;
   }
 
   /**
@@ -520,6 +527,8 @@ public class ECContainerReplicaCount implements ContainerReplicaCount {
   public boolean isSufficientlyReplicated() {
     return isSufficientlyReplicated(false);
   }
+
+
 
   @Override
   public String toString() {

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ECUnderReplicationHandler.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ECUnderReplicationHandler.java
@@ -24,7 +24,7 @@ import org.apache.hadoop.hdds.conf.ConfigurationSource;
 import org.apache.hadoop.hdds.conf.StorageUnit;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
-import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos;
+import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.ContainerReplicaProto.State;
 import org.apache.hadoop.hdds.scm.PlacementPolicy;
 import org.apache.hadoop.hdds.scm.ScmConfigKeys;
 import org.apache.hadoop.hdds.scm.container.ContainerID;
@@ -43,6 +43,7 @@ import org.slf4j.LoggerFactory;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -206,6 +207,17 @@ public class ECUnderReplicationHandler implements UnhealthyReplicationHandler {
               "OverReplication handler", container);
           replicationManager.processOverReplicatedContainer(result);
         }
+
+        /* If we get here, the scenario is:
+        1. Under replicated.
+        2. Not over replicated.
+        3. Placement Policy not able to find enough targets.
+        Check if there are some UNHEALTHY replicas. In a small cluster, these
+        UNHEALTHY replicas could block DNs that could otherwise be targets
+        for new EC replicas. Deleting an UNHEALTHY replica can make its host DN
+        available as a target.
+        */
+        checkAndRemoveUnhealthyReplica(replicaCount, deletionInFlight);
         // As we want to re-queue and try again later, we just re-throw
         throw e;
       }
@@ -224,8 +236,7 @@ public class ECUnderReplicationHandler implements UnhealthyReplicationHandler {
   private Map<Integer, Pair<ContainerReplica, NodeStatus>> filterSources(
       Set<ContainerReplica> replicas, List<DatanodeDetails> deletionInFlight) {
     return replicas.stream().filter(r -> r
-            .getState() == StorageContainerDatanodeProtocolProtos
-            .ContainerReplicaProto.State.CLOSED)
+            .getState() == State.CLOSED)
         // Exclude stale and dead nodes. This is particularly important for
         // maintenance nodes, as the replicas will remain present in the
         // container manager, even when they go dead.
@@ -540,5 +551,101 @@ public class ECUnderReplicationHandler implements UnhealthyReplicationHandler {
       dst[i] = src.get(i).byteValue();
     }
     return dst;
+  }
+
+  /**
+   * Deletes one UNHEALTHY replica so that its host datanode becomes available
+   * to host a healthy replica. This can be helpful if reconstruction or
+   * replication is blocked because DNs that follow the placement policy are
+   * not available as targets.
+   * @param replicaCount ECContainerReplicaCount object of this container
+   * @param deletionInFlight pending deletes of this container's replicas
+   */
+  private void checkAndRemoveUnhealthyReplica(
+      ECContainerReplicaCount replicaCount,
+      List<DatanodeDetails> deletionInFlight) {
+    if (!deletionInFlight.isEmpty()) {
+      LOG.debug("There are {} pending deletes. Completing them could " +
+          "free up nodes to fix under replication. Not deleting UNHEALTHY" +
+          " replicas in this iteration.", deletionInFlight.size());
+      return;
+    }
+
+    ContainerInfo container = replicaCount.getContainer();
+    // ensure that the container is recoverable
+    if (replicaCount.isUnrecoverable()) {
+      LOG.warn("Cannot recover container {}.", container);
+      return;
+    }
+
+    Set<ContainerReplica> unhealthyReplicas =
+        replicaCount.getUnhealthyReplicas();
+    if (unhealthyReplicas.isEmpty()) {
+      LOG.debug("Container {} does not have any UNHEALTHY replicas.",
+          container.containerID());
+      return;
+    }
+
+    // remove replicas that aren't on IN_SERVICE and HEALTHY DNs
+    // the leftover replicas will be eligible for deletion
+    Iterator<ContainerReplica> iterator = replicaCount.getReplicas().iterator();
+    Set<Integer> closedReplicas = new HashSet<>();
+    while (iterator.hasNext()) {
+      ContainerReplica replica = iterator.next();
+      DatanodeDetails datanodeDetails = replica.getDatanodeDetails();
+      NodeStatus nodeStatus;
+      boolean removed = false;
+      try {
+        nodeStatus = replicationManager.getNodeStatus(datanodeDetails);
+        if (!nodeStatus.isHealthy() || !nodeStatus.isInService()) {
+          iterator.remove();
+          removed = true;
+        }
+      } catch (NodeNotFoundException e) {
+        LOG.debug("Skipping replica {} when trying to unblock under " +
+            "replication handling.", replica, e);
+        iterator.remove();
+        removed = true;
+      }
+
+      // collect CLOSED replicas for later
+      if (!removed && replica.getState().equals(State.CLOSED)) {
+        closedReplicas.add(replica.getReplicaIndex());
+      }
+    }
+
+    /*
+    If an index has both an UNHEALTHY and CLOSED replica, prefer deleting the
+    UNHEALTHY replica of this index and return. Otherwise, delete any UNHEALTHY
+    replica.
+    */
+    for (ContainerReplica unhealthyReplica : unhealthyReplicas) {
+      if (closedReplicas.contains(unhealthyReplica.getReplicaIndex())) {
+        try {
+          replicationManager.sendThrottledDeleteCommand(
+              replicaCount.getContainer(), unhealthyReplica.getReplicaIndex(),
+              unhealthyReplica.getDatanodeDetails(), true);
+          return;
+        } catch (NotLeaderException | CommandTargetOverloadedException e) {
+          LOG.debug("Skipping sending a delete command for replica {} to " +
+                  "Datanode {}.", unhealthyReplica,
+              unhealthyReplica.getDatanodeDetails());
+        }
+      }
+    }
+
+    // just delete any UNHEALTHY replica
+    for (ContainerReplica unhealthyReplica : unhealthyReplicas) {
+      try {
+        replicationManager.sendThrottledDeleteCommand(
+            replicaCount.getContainer(), unhealthyReplica.getReplicaIndex(),
+            unhealthyReplica.getDatanodeDetails(), true);
+        return;
+      } catch (NotLeaderException | CommandTargetOverloadedException e) {
+        LOG.debug("Skipping sending a delete command for replica {} to " +
+                "Datanode {}.", unhealthyReplica,
+            unhealthyReplica.getDatanodeDetails());
+      }
+    }
   }
 }

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestECUnderReplicationHandler.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestECUnderReplicationHandler.java
@@ -27,6 +27,7 @@ import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.SCMCommandProto;
 import org.apache.hadoop.hdds.scm.ContainerPlacementStatus;
 import org.apache.hadoop.hdds.scm.PlacementPolicy;
+import org.apache.hadoop.hdds.scm.container.ContainerID;
 import org.apache.hadoop.hdds.scm.container.ContainerInfo;
 import org.apache.hadoop.hdds.scm.container.ContainerReplica;
 import org.apache.hadoop.hdds.scm.container.MockNodeManager;
@@ -50,7 +51,9 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
 import org.mockito.Mockito;
+import org.mockito.stubbing.Answer;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -69,6 +72,7 @@ import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.NodeOperationalSt
 import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.NodeOperationalState.IN_MAINTENANCE;
 import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.NodeOperationalState.IN_SERVICE;
 import static org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.ContainerReplicaProto.State.CLOSED;
+import static org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.ContainerReplicaProto.State.UNHEALTHY;
 import static org.apache.hadoop.hdds.scm.net.NetConstants.LEAF_SCHEMA;
 import static org.apache.hadoop.hdds.scm.net.NetConstants.RACK_SCHEMA;
 import static org.apache.hadoop.hdds.scm.net.NetConstants.ROOT_SCHEMA;
@@ -471,7 +475,8 @@ public class TestECUnderReplicationHandler {
       Set<Pair<DatanodeDetails, SCMCommand<?>>> expectedDelete =
           new HashSet<>();
       expectedDelete.add(Pair.of(overRepReplica.getDatanodeDetails(),
-          createDeleteContainerCommand(container, overRepReplica)));
+          createDeleteContainerCommand(container,
+              overRepReplica.getReplicaIndex())));
 
       Mockito.when(replicationManager.processOverReplicatedContainer(
           underRep)).thenAnswer(invocationOnMock -> {
@@ -485,6 +490,116 @@ public class TestECUnderReplicationHandler {
       Mockito.verify(replicationManager, times(1))
           .processOverReplicatedContainer(underRep);
       Assertions.assertEquals(true, expectedDelete.equals(commandsSent));
+    }
+  }
+
+  /**
+   * Tests that under replication handling tries to delete an UNHEALTHY
+   * replica if no target datanodes are found. It should delete only
+   * one UNHEALTHY replica so that the replica's host DN becomes available as a
+   * target for reconstruction/replication of a healthy replica.
+   */
+  @Test
+  public void testUnhealthyNodeDeletedIfNoTargetsFound()
+      throws IOException {
+    PlacementPolicy noNodesPolicy = ReplicationTestUtil
+        .getNoNodesTestPlacementPolicy(nodeManager, conf);
+
+    ContainerReplica decomReplica =
+        ReplicationTestUtil.createContainerReplica(container.containerID(),
+            5, DECOMMISSIONING, CLOSED);
+    ContainerReplica maintReplica =
+        ReplicationTestUtil.createContainerReplica(container.containerID(),
+            5, ENTERING_MAINTENANCE, CLOSED);
+
+    List<ContainerReplica> replicasToAdd = new ArrayList<>();
+    replicasToAdd.add(null);
+    replicasToAdd.add(decomReplica);
+    replicasToAdd.add(maintReplica);
+
+    ECUnderReplicationHandler ecURH =
+        new ECUnderReplicationHandler(
+            noNodesPolicy, conf, replicationManager);
+    ContainerHealthResult.UnderReplicatedHealthResult underRep =
+        new ContainerHealthResult.UnderReplicatedHealthResult(container,
+            1, false, false, false);
+    ContainerReplica unhealthyReplica =
+        ReplicationTestUtil.createContainerReplica(container.containerID(),
+            4, IN_SERVICE, UNHEALTHY);
+
+    /*
+     The underRepHandler processes in stages. First missing indexes, then
+     decommission and then maintenance. If a stage cannot find new nodes and
+     there are no commands created yet, then we should either throw, or pass
+     control to the over rep handler if the container is also over
+     replicated, or try to delete an UNHEALTHY replica if one is present.
+     In this loop we first have the container under replicated with a missing
+     index, then with a decommissioning index, and finally with a maintenance
+     index. In all cases, initially there are no UNHEALTHY replicas, so it
+     should throw an exception. Then we add 2 UNHEALTHY replicas, so
+     it should return the command to delete one.
+     */
+    for (ContainerReplica toAdd : replicasToAdd) {
+      Mockito.clearInvocations(replicationManager);
+      Set<ContainerReplica> existingReplicas = ReplicationTestUtil
+          .createReplicas(Pair.of(IN_SERVICE, 5),
+              Pair.of(IN_SERVICE, 2), Pair.of(IN_SERVICE, 3),
+              Pair.of(IN_SERVICE, 4));
+      if (toAdd != null) {
+        existingReplicas.add(toAdd);
+      }
+
+      Assert.assertThrows(SCMException.class,
+          () -> ecURH.processAndSendCommands(existingReplicas,
+              Collections.emptyList(), underRep, 2));
+
+      /*
+      Now, for the same container, also add an UNHEALTHY replica. The handler
+      should catch the SCMException that says no targets were found and try
+      to handle it by deleting the UNHEALTHY replica.
+      */
+      existingReplicas.add(unhealthyReplica);
+      existingReplicas.add(
+          ReplicationTestUtil.createContainerReplica(container.containerID(),
+              1, IN_SERVICE, UNHEALTHY));
+
+      /*
+      Mock such that when replication manager is called to send a delete
+      command, we add the command to commandsSet and later use it for
+      assertions.
+      */
+      commandsSent.clear();
+      Mockito.doAnswer(invocation -> {
+            commandsSent.add(Pair.of(invocation.getArgument(2),
+                createDeleteContainerCommand(invocation.getArgument(0),
+                    invocation.getArgument(1))));
+            return null;
+          })
+          .when(replicationManager)
+          .sendThrottledDeleteCommand(Mockito.any(ContainerInfo.class),
+              Mockito.anyInt(), Mockito.any(DatanodeDetails.class),
+              Mockito.eq(true));
+
+      assertThrows(SCMException.class,
+          () -> ecURH.processAndSendCommands(existingReplicas,
+              Collections.emptyList(), underRep, 2));
+      Mockito.verify(replicationManager, times(1))
+          .sendThrottledDeleteCommand(container,
+              unhealthyReplica.getReplicaIndex(),
+              unhealthyReplica.getDatanodeDetails(), true);
+      Assertions.assertEquals(1, commandsSent.size());
+      Pair<DatanodeDetails, SCMCommand<?>> command =
+          commandsSent.iterator().next();
+      Assertions.assertEquals(SCMCommandProto.Type.deleteContainerCommand,
+          command.getValue().getType());
+      DeleteContainerCommand deleteCommand =
+          (DeleteContainerCommand) command.getValue();
+      Assertions.assertEquals(unhealthyReplica.getDatanodeDetails(),
+          command.getKey());
+      Assertions.assertEquals(container.containerID(),
+          ContainerID.valueOf(deleteCommand.getContainerID()));
+      Assertions.assertEquals(unhealthyReplica.getReplicaIndex(),
+          deleteCommand.getReplicaIndex());
     }
   }
 
@@ -725,7 +840,8 @@ public class TestECUnderReplicationHandler {
 
     Set<Pair<DatanodeDetails, SCMCommand<?>>> expectedDelete = new HashSet<>();
     expectedDelete.add(Pair.of(overRepReplica.getDatanodeDetails(),
-        createDeleteContainerCommand(container, overRepReplica)));
+        createDeleteContainerCommand(container,
+            overRepReplica.getReplicaIndex())));
 
     Mockito.when(replicationManager.processOverReplicatedContainer(
         underRep)).thenAnswer(invocationOnMock -> {
@@ -966,10 +1082,10 @@ public class TestECUnderReplicationHandler {
   }
 
   private DeleteContainerCommand createDeleteContainerCommand(
-      ContainerInfo containerInfo, ContainerReplica replica) {
+      ContainerInfo containerInfo, int replicaIndex) {
     DeleteContainerCommand deleteCommand =
         new DeleteContainerCommand(containerInfo.getContainerID(), true);
-    deleteCommand.setReplicaIndex(replica.getReplicaIndex());
+    deleteCommand.setReplicaIndex(replicaIndex);
     return deleteCommand;
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

With EC containers, if there is a small cluster of say 6 nodes with EC-3-2, a container will require 5 nodes. If 2 containers become unhealthy, reconstruction will be required to recover the 2 containers, but there is only 1 spare node.
This means one will get recovered, and we will have 4 "good" containers and 2 `UNHEALTHY` and the container will remain stuck like this because `UNHEALTHY` containers are only removed once the container has no over or under replication.
A similar problem was resolved previously where an EC container with both over and under replication can meet the same problem, where under replication cannot proceed due to insufficient spare nodes. In that case, the solution was to check for this case, and call the over-replication handler to clear up the excess replicas. 

This PR is still in draft state for some early reviews while I write tests and think about edge cases. Here, we try to delete an `UNHEALTHY` replica in the same handler to free up a DN. Then we throw the exception so that this container gets queued again in the under replication queue. Perhaps it's better to throw first if over replication handling is invoked, so we don't delete multiple replicas in one go.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-8535

## How was this patch tested?

Wrote one UT.