### PR TITLE
HDDS-8674. Allow more EC pipelines based on number of volumes

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/NodeManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/NodeManager.java
@@ -383,6 +383,8 @@ public interface NodeManager extends StorageContainerNodeProtocol,
 
   int minHealthyVolumeNum(List <DatanodeDetails> dnList);
 
+  int totalHealthyVolumeCount();
+
   int pipelineLimit(DatanodeDetails dn);
 
   int minPipelineLimit(List<DatanodeDetails> dn);

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/SCMNodeManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/SCMNodeManager.java
@@ -1132,6 +1132,15 @@ public class SCMNodeManager implements NodeManager {
     return Collections.min(volumeCountList);
   }
 
+  @Override
+  public int totalHealthyVolumeCount() {
+    int sum = 0;
+    for (DatanodeInfo dn : nodeStateManager.getNodes(IN_SERVICE, HEALTHY)) {
+      sum += dn.getHealthyVolumeCount();
+    }
+    return sum;
+  }
+
   /**
    * Returns the pipeline limit for the datanode.
    * if the datanode pipeline limit is set, consider that as the max

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/WritableECContainerProvider.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/WritableECContainerProvider.java
@@ -94,13 +94,13 @@ public class WritableECContainerProvider
   public ContainerInfo getContainer(final long size,
       ECReplicationConfig repConfig, String owner, ExcludeList excludeList)
       throws IOException, TimeoutException {
+    int minimumPipelines = getMinimumPipelines(repConfig);
     synchronized (this) {
       int openPipelineCount = pipelineManager.getPipelineCount(repConfig,
           Pipeline.PipelineState.OPEN);
-      if (openPipelineCount < getMinimumPipelines(repConfig)) {
+      if (openPipelineCount < minimumPipelines) {
         try {
-          return allocateContainer(
-              repConfig, size, owner, excludeList);
+          return allocateContainer(repConfig, size, owner, excludeList);
         } catch (IOException e) {
           LOG.warn("Unable to allocate a container for {} with {} existing "
               + "containers", repConfig, openPipelineCount, e);

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/WritableECContainerProvider.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/WritableECContainerProvider.java
@@ -24,16 +24,16 @@ import org.apache.hadoop.hdds.conf.Config;
 import org.apache.hadoop.hdds.conf.ConfigGroup;
 import org.apache.hadoop.hdds.conf.ConfigTag;
 import org.apache.hadoop.hdds.conf.ConfigType;
-import org.apache.hadoop.hdds.conf.ConfigurationSource;
+import org.apache.hadoop.hdds.conf.PostConstruct;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
 import org.apache.hadoop.hdds.scm.PipelineChoosePolicy;
 import org.apache.hadoop.hdds.scm.PipelineRequestInformation;
-import org.apache.hadoop.hdds.scm.ScmConfigKeys;
 import org.apache.hadoop.hdds.scm.container.ContainerID;
 import org.apache.hadoop.hdds.scm.container.ContainerInfo;
 import org.apache.hadoop.hdds.scm.container.ContainerManager;
 import org.apache.hadoop.hdds.scm.container.ContainerNotFoundException;
 import org.apache.hadoop.hdds.scm.container.common.helpers.ExcludeList;
+import org.apache.hadoop.hdds.scm.node.NodeManager;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -44,7 +44,7 @@ import java.util.List;
 import java.util.NavigableSet;
 import java.util.concurrent.TimeoutException;
 
-import static org.apache.hadoop.hdds.conf.StorageUnit.BYTES;
+import static org.apache.hadoop.hdds.conf.ConfigTag.SCM;
 
 /**
  * Writable Container provider to obtain a writable container for EC pipelines.
@@ -55,23 +55,25 @@ public class WritableECContainerProvider
   private static final Logger LOG = LoggerFactory
       .getLogger(WritableECContainerProvider.class);
 
-  private final ConfigurationSource conf;
+  private final NodeManager nodeManager;
   private final PipelineManager pipelineManager;
   private final PipelineChoosePolicy pipelineChoosePolicy;
   private final ContainerManager containerManager;
   private final long containerSize;
   private final WritableECContainerProviderConfig providerConfig;
 
-  public WritableECContainerProvider(ConfigurationSource conf,
-      PipelineManager pipelineManager, ContainerManager containerManager,
+  public WritableECContainerProvider(WritableECContainerProviderConfig config,
+      long containerSize,
+      NodeManager nodeManager,
+      PipelineManager pipelineManager,
+      ContainerManager containerManager,
       PipelineChoosePolicy pipelineChoosePolicy) {
-    this.conf = conf;
-    this.providerConfig =
-        conf.getObject(WritableECContainerProviderConfig.class);
+    this.providerConfig = config;
+    this.nodeManager = nodeManager;
     this.pipelineManager = pipelineManager;
     this.containerManager = containerManager;
     this.pipelineChoosePolicy = pipelineChoosePolicy;
-    this.containerSize = getConfiguredContainerSize();
+    this.containerSize = containerSize;
   }
 
   /**
@@ -87,7 +89,6 @@ public class WritableECContainerProvider
    *                    not be considered.
    * @return A containerInfo representing a block group with with space for the
    *         write, or null if no container can be allocated.
-   * @throws IOException
    */
   @Override
   public ContainerInfo getContainer(final long size,
@@ -96,7 +97,7 @@ public class WritableECContainerProvider
     synchronized (this) {
       int openPipelineCount = pipelineManager.getPipelineCount(repConfig,
           Pipeline.PipelineState.OPEN);
-      if (openPipelineCount < providerConfig.getMinimumPipelines()) {
+      if (openPipelineCount < getMinimumPipelines(repConfig)) {
         try {
           return allocateContainer(
               repConfig, size, owner, excludeList);
@@ -159,6 +160,16 @@ public class WritableECContainerProvider
     }
   }
 
+  private int getMinimumPipelines(ECReplicationConfig repConfig) {
+    final double factor = providerConfig.getPipelinePerVolumeFactor();
+    int volumeBasedCount = 0;
+    if (factor > 0) {
+      int volumes = nodeManager.totalHealthyVolumeCount();
+      volumeBasedCount = (int) factor * volumes / repConfig.getRequiredNodes();
+    }
+    return Math.max(volumeBasedCount, providerConfig.getMinimumPipelines());
+  }
+
   private ContainerInfo allocateContainer(ReplicationConfig repConfig,
       long size, String owner, ExcludeList excludeList)
       throws IOException, TimeoutException {
@@ -205,17 +216,13 @@ public class WritableECContainerProvider
     return container.getUsedBytes() + size <= containerSize;
   }
 
-  private long getConfiguredContainerSize() {
-    return (long) conf.getStorageSize(
-        ScmConfigKeys.OZONE_SCM_CONTAINER_SIZE,
-        ScmConfigKeys.OZONE_SCM_CONTAINER_SIZE_DEFAULT, BYTES);
-  }
-
   /**
    * Class to hold configuration for WriteableECContainerProvider.
    */
-  @ConfigGroup(prefix = "ozone.scm.ec")
+  @ConfigGroup(prefix = WritableECContainerProviderConfig.PREFIX)
   public static class WritableECContainerProviderConfig {
+
+    private static final String PREFIX = "ozone.scm.ec";
 
     @Config(key = "pipeline.minimum",
         defaultValue = "5",
@@ -233,6 +240,38 @@ public class WritableECContainerProvider
       this.minimumPipelines = minPipelines;
     }
 
+    private static final String PIPELINE_PER_VOLUME_FACTOR_KEY =
+        "pipeline.per.volume.factor";
+    private static final double PIPELINE_PER_VOLUME_FACTOR_DEFAULT = 1;
+    private static final String PIPELINE_PER_VOLUME_FACTOR_DEFAULT_VALUE = "1";
+    private static final String EC_PIPELINE_PER_VOLUME_FACTOR_KEY =
+        PREFIX + "." + PIPELINE_PER_VOLUME_FACTOR_KEY;
+
+    @Config(key = PIPELINE_PER_VOLUME_FACTOR_KEY,
+        type = ConfigType.DOUBLE,
+        defaultValue = PIPELINE_PER_VOLUME_FACTOR_DEFAULT_VALUE,
+        tags = {SCM},
+        description = "TODO"
+    )
+    private double pipelinePerVolumeFactor = PIPELINE_PER_VOLUME_FACTOR_DEFAULT;
+
+    public double getPipelinePerVolumeFactor() {
+      return pipelinePerVolumeFactor;
+    }
+
+    @PostConstruct
+    public void validate() {
+      if (pipelinePerVolumeFactor < 0) {
+        LOG.warn("{} must be non-negative, but was {}. Defaulting to {}",
+            EC_PIPELINE_PER_VOLUME_FACTOR_KEY, pipelinePerVolumeFactor,
+            PIPELINE_PER_VOLUME_FACTOR_DEFAULT);
+        pipelinePerVolumeFactor = PIPELINE_PER_VOLUME_FACTOR_DEFAULT;
+      }
+    }
+
+    public void setPipelinePerVolumeFactor(double v) {
+      pipelinePerVolumeFactor = v;
+    }
   }
 
 }

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/MockNodeManager.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/MockNodeManager.java
@@ -902,6 +902,11 @@ public class MockNodeManager implements NodeManager {
   }
 
   @Override
+  public int totalHealthyVolumeCount() {
+    return healthyNodes.size() * numHealthyDisksPerDatanode;
+  }
+
+  @Override
   public int pipelineLimit(DatanodeDetails dn) {
     // by default 1 single node pipeline and 1 three node pipeline
     return numPipelinePerDatanode;

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/SimpleMockNodeManager.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/SimpleMockNodeManager.java
@@ -367,6 +367,11 @@ public class SimpleMockNodeManager implements NodeManager {
   }
 
   @Override
+  public int totalHealthyVolumeCount() {
+    return 0;
+  }
+
+  @Override
   public int pipelineLimit(DatanodeDetails dn) {
     return 1;
   }

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/ozone/container/testutils/ReplicationNodeManagerMock.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/ozone/container/testutils/ReplicationNodeManagerMock.java
@@ -521,6 +521,11 @@ public class ReplicationNodeManagerMock implements NodeManager {
   }
 
   @Override
+  public int totalHealthyVolumeCount() {
+    return 0;
+  }
+
+  @Override
   public int pipelineLimit(DatanodeDetails dn) {
     return 0;
   }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Currently EC pipelines are limited to 5 per EC scheme, which does not scale with the size of the cluster.

As a simple first step for scaling EC pipeline/container count, `WritableECContainerProvider` should dynamically adjust the limit based on the number of healthy data volumes available in the cluster.

To retain behavior in smaller clusters, the existing `pipeline.minimum` config is used if it is greater than the calculated value.

https://issues.apache.org/jira/browse/HDDS-8674

## How was this patch tested?

Added test case in `TestWritableECContainerProvider`.

https://github.com/adoroszlai/hadoop-ozone/actions/runs/5054873935