### PR TITLE
HDDS-8259. [hsync] OMKeyRequest: Detect allocated but uncommitted blocks

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestHSync.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestHSync.java
@@ -160,6 +160,28 @@ public class TestHSync {
     }
   }
 
+  @Test
+  public void testUncommittedBlocks() throws Exception {
+    // Set the fs.defaultFS
+    final String rootPath = String.format("%s://%s/",
+        OZONE_OFS_URI_SCHEME, CONF.get(OZONE_OM_ADDRESS_KEY));
+    CONF.set(CommonConfigurationKeysPublic.FS_DEFAULT_NAME_KEY, rootPath);
+
+    final String dir = OZONE_ROOT + bucket.getVolumeName()
+        + OZONE_URI_DELIMITER + bucket.getName();
+    final byte[] data = new byte[1];
+    ThreadLocalRandom.current().nextBytes(data);
+
+    try (FileSystem fs = FileSystem.get(CONF)) {
+        final Path file = new Path(dir, "file");
+        try (FSDataOutputStream outputStream = fs.create(file, true)) {
+          outputStream.hsync();
+          outputStream.write(data);
+          outputStream.hsync();
+        }
+    }
+  }
+
   static void runTestHSync(FileSystem fs, Path file, int initialDataSize)
       throws Exception {
     try (StreamWithLength out = new StreamWithLength(

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestHSync.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestHSync.java
@@ -178,6 +178,8 @@ public class TestHSync {
         outputStream.hsync();
         outputStream.write(data);
         outputStream.hsync();
+        assertTrue(cluster.getOzoneManager().getMetadataManager()
+            .getDeletedTable().isEmpty());
       }
     }
   }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestHSync.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestHSync.java
@@ -173,12 +173,12 @@ public class TestHSync {
     ThreadLocalRandom.current().nextBytes(data);
 
     try (FileSystem fs = FileSystem.get(CONF)) {
-        final Path file = new Path(dir, "file");
-        try (FSDataOutputStream outputStream = fs.create(file, true)) {
-          outputStream.hsync();
-          outputStream.write(data);
-          outputStream.hsync();
-        }
+      final Path file = new Path(dir, "file");
+      try (FSDataOutputStream outputStream = fs.create(file, true)) {
+        outputStream.hsync();
+        outputStream.write(data);
+        outputStream.hsync();
+      }
     }
   }
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyCommitRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyCommitRequest.java
@@ -20,7 +20,6 @@ package org.apache.hadoop.ozone.om.request.key;
 
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -253,13 +252,8 @@ public class OMKeyCommitRequest extends OMKeyRequest {
 
       // let the uncommitted blocks pretend as key's old version blocks
       // which will be deleted as RepeatedOmKeyInfo
-      OmKeyInfo pseudoKeyInfo;
-      if (isHSync) {
-        pseudoKeyInfo = null;
-      } else {
-        pseudoKeyInfo = wrapUncommittedBlocksAsPseudoKey(uncommitted,
-            omKeyInfo);
-      }
+      final OmKeyInfo pseudoKeyInfo = isHSync? null
+          : wrapUncommittedBlocksAsPseudoKey(uncommitted, omKeyInfo);
       if (pseudoKeyInfo != null) {
         long pseudoObjId = ozoneManager.getObjectIdFromTxId(trxnLogIndex);
         String delKeyName = omMetadataManager.getOzoneDeletePathKey(

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyCommitRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyCommitRequest.java
@@ -218,7 +218,7 @@ public class OMKeyCommitRequest extends OMKeyRequest {
       // Update the block length for each block, return the allocated but
       // uncommitted blocks
       List<OmKeyLocationInfo> uncommitted =
-          omKeyInfo.updateLocationInfoList(locationInfoList, false);;
+          omKeyInfo.updateLocationInfoList(locationInfoList, false);
 
       // Set the UpdateID to current transactionLogIndex
       omKeyInfo.setUpdateID(trxnLogIndex, ozoneManager.isRatisEnabled());
@@ -252,7 +252,7 @@ public class OMKeyCommitRequest extends OMKeyRequest {
 
       // let the uncommitted blocks pretend as key's old version blocks
       // which will be deleted as RepeatedOmKeyInfo
-      final OmKeyInfo pseudoKeyInfo = isHSync? null
+      final OmKeyInfo pseudoKeyInfo = isHSync ? null
           : wrapUncommittedBlocksAsPseudoKey(uncommitted, omKeyInfo);
       if (pseudoKeyInfo != null) {
         long pseudoObjId = ozoneManager.getObjectIdFromTxId(trxnLogIndex);

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyCommitRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyCommitRequest.java
@@ -218,12 +218,8 @@ public class OMKeyCommitRequest extends OMKeyRequest {
       omKeyInfo.setModificationTime(commitKeyArgs.getModificationTime());
       // Update the block length for each block, return the allocated but
       // uncommitted blocks
-      List<OmKeyLocationInfo> uncommitted;
-      if (isHSync) {
-        uncommitted = Collections.emptyList();
-      } else {
-        uncommitted = omKeyInfo.updateLocationInfoList(locationInfoList, false);
-      }
+      List<OmKeyLocationInfo> uncommitted =
+          omKeyInfo.updateLocationInfoList(locationInfoList, false);;
 
       // Set the UpdateID to current transactionLogIndex
       omKeyInfo.setUpdateID(trxnLogIndex, ozoneManager.isRatisEnabled());
@@ -257,8 +253,13 @@ public class OMKeyCommitRequest extends OMKeyRequest {
 
       // let the uncommitted blocks pretend as key's old version blocks
       // which will be deleted as RepeatedOmKeyInfo
-      OmKeyInfo pseudoKeyInfo = wrapUncommittedBlocksAsPseudoKey(uncommitted,
-          omKeyInfo);
+      OmKeyInfo pseudoKeyInfo;
+      if (isHSync) {
+        pseudoKeyInfo = null;
+      } else {
+        pseudoKeyInfo = wrapUncommittedBlocksAsPseudoKey(uncommitted,
+            omKeyInfo);
+      }
       if (pseudoKeyInfo != null) {
         long pseudoObjId = ozoneManager.getObjectIdFromTxId(trxnLogIndex);
         String delKeyName = omMetadataManager.getOzoneDeletePathKey(

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyCommitRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyCommitRequest.java
@@ -20,6 +20,7 @@ package org.apache.hadoop.ozone.om.request.key;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -219,7 +220,7 @@ public class OMKeyCommitRequest extends OMKeyRequest {
       // uncommitted blocks
       List<OmKeyLocationInfo> uncommitted;
       if (isHSync) {
-        uncommitted = new ArrayList<>();
+        uncommitted = Collections.emptyList();
       } else {
         uncommitted = omKeyInfo.updateLocationInfoList(locationInfoList, false);
       }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyCommitRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyCommitRequest.java
@@ -217,8 +217,12 @@ public class OMKeyCommitRequest extends OMKeyRequest {
       omKeyInfo.setModificationTime(commitKeyArgs.getModificationTime());
       // Update the block length for each block, return the allocated but
       // uncommitted blocks
-      List<OmKeyLocationInfo> uncommitted = omKeyInfo.updateLocationInfoList(
-          locationInfoList, false);
+      List<OmKeyLocationInfo> uncommitted;
+      if (isHSync) {
+        uncommitted = new ArrayList<>();
+      } else {
+        uncommitted = omKeyInfo.updateLocationInfoList(locationInfoList, false);
+      }
 
       // Set the UpdateID to current transactionLogIndex
       omKeyInfo.setUpdateID(trxnLogIndex, ozoneManager.isRatisEnabled());

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyCommitRequestWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyCommitRequestWithFSO.java
@@ -19,6 +19,7 @@
 package org.apache.hadoop.ozone.om.request.key;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.hadoop.ozone.audit.AuditLogger;
@@ -166,7 +167,7 @@ public class OMKeyCommitRequestWithFSO extends OMKeyCommitRequest {
 
       List<OmKeyLocationInfo> uncommitted;
       if (isHSync) {
-        uncommitted = new ArrayList<>();
+        uncommitted = Collections.emptyList();
       } else {
         uncommitted = omKeyInfo.updateLocationInfoList(locationInfoList, false);
       }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyCommitRequestWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyCommitRequestWithFSO.java
@@ -165,12 +165,8 @@ public class OMKeyCommitRequestWithFSO extends OMKeyCommitRequest {
 
       omKeyInfo.setModificationTime(commitKeyArgs.getModificationTime());
 
-      List<OmKeyLocationInfo> uncommitted;
-      if (isHSync) {
-        uncommitted = Collections.emptyList();
-      } else {
-        uncommitted = omKeyInfo.updateLocationInfoList(locationInfoList, false);
-      }
+      List<OmKeyLocationInfo> uncommitted =
+          omKeyInfo.updateLocationInfoList(locationInfoList, false);
 
       // Set the UpdateID to current transactionLogIndex
       omKeyInfo.setUpdateID(trxnLogIndex, ozoneManager.isRatisEnabled());
@@ -215,8 +211,13 @@ public class OMKeyCommitRequestWithFSO extends OMKeyCommitRequest {
 
       // let the uncommitted blocks pretend as key's old version blocks
       // which will be deleted as RepeatedOmKeyInfo
-      OmKeyInfo pseudoKeyInfo = wrapUncommittedBlocksAsPseudoKey(uncommitted,
-          omKeyInfo);
+      OmKeyInfo pseudoKeyInfo;
+      if (isHSync) {
+        pseudoKeyInfo = null;
+      } else {
+        pseudoKeyInfo = wrapUncommittedBlocksAsPseudoKey(uncommitted,
+            omKeyInfo);
+      }
       if (pseudoKeyInfo != null) {
         String delKeyName = omMetadataManager
             .getOzoneKey(volumeName, bucketName, fileName);

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyCommitRequestWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyCommitRequestWithFSO.java
@@ -18,6 +18,7 @@
 
 package org.apache.hadoop.ozone.om.request.key;
 
+import java.util.ArrayList;
 import java.util.HashMap;
 import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.hadoop.ozone.audit.AuditLogger;
@@ -163,8 +164,12 @@ public class OMKeyCommitRequestWithFSO extends OMKeyCommitRequest {
 
       omKeyInfo.setModificationTime(commitKeyArgs.getModificationTime());
 
-      List<OmKeyLocationInfo> uncommitted = omKeyInfo.updateLocationInfoList(
-          locationInfoList, false);
+      List<OmKeyLocationInfo> uncommitted;
+      if (isHSync) {
+        uncommitted = new ArrayList<>();
+      } else {
+        uncommitted = omKeyInfo.updateLocationInfoList(locationInfoList, false);
+      }
 
       // Set the UpdateID to current transactionLogIndex
       omKeyInfo.setUpdateID(trxnLogIndex, ozoneManager.isRatisEnabled());

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyCommitRequestWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyCommitRequestWithFSO.java
@@ -209,7 +209,7 @@ public class OMKeyCommitRequestWithFSO extends OMKeyCommitRequest {
 
       // let the uncommitted blocks pretend as key's old version blocks
       // which will be deleted as RepeatedOmKeyInfo
-      final OmKeyInfo pseudoKeyInfo = isHSync? null
+      final OmKeyInfo pseudoKeyInfo = isHSync ? null
           : wrapUncommittedBlocksAsPseudoKey(uncommitted, omKeyInfo);
       if (pseudoKeyInfo != null) {
         String delKeyName = omMetadataManager

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyCommitRequestWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyCommitRequestWithFSO.java
@@ -18,8 +18,6 @@
 
 package org.apache.hadoop.ozone.om.request.key;
 
-import java.util.ArrayList;
-import java.util.Collections;
 import java.util.HashMap;
 import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.hadoop.ozone.audit.AuditLogger;
@@ -211,13 +209,8 @@ public class OMKeyCommitRequestWithFSO extends OMKeyCommitRequest {
 
       // let the uncommitted blocks pretend as key's old version blocks
       // which will be deleted as RepeatedOmKeyInfo
-      OmKeyInfo pseudoKeyInfo;
-      if (isHSync) {
-        pseudoKeyInfo = null;
-      } else {
-        pseudoKeyInfo = wrapUncommittedBlocksAsPseudoKey(uncommitted,
-            omKeyInfo);
-      }
+      final OmKeyInfo pseudoKeyInfo = isHSync? null
+          : wrapUncommittedBlocksAsPseudoKey(uncommitted, omKeyInfo);
       if (pseudoKeyInfo != null) {
         String delKeyName = omMetadataManager
             .getOzoneKey(volumeName, bucketName, fileName);


### PR DESCRIPTION
## What changes were proposed in this pull request?

Do not remove uncommitted blocks if hsync.

OM HSync handler leverages existing key commit logic. However, uncommitted blocks (meaning the block that is allocated but not used) is supposed to be removed upon key commit, because key is immutable after commit. But for hsync, key may still be written afterwards so it is not desirable to remove the uncommitted blocks.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-8259

## How was this patch tested?

Added one unit test to ensure the sequence of create-hsync-write-hsync-close is successful.