### PR TITLE
HDDS-8680. Optimize getting open pipelines from pipelineManager

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/PipelineStateMap.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/PipelineStateMap.java
@@ -276,6 +276,9 @@ class PipelineStateMap {
     if (state == PipelineState.OPEN) {
       pipelines = new ArrayList<>(query2OpenPipelines.getOrDefault(
           replicationConfig, Collections.emptyList()));
+      if (excludeDns.isEmpty() && excludePipelines.isEmpty()) {
+        return pipelines;
+      }
     } else {
       pipelines = new ArrayList<>(pipelineMap.values());
     }


### PR DESCRIPTION
## What changes were proposed in this pull request?

In the WriteableECContainerProvider, we need to get the list of open pipelines on each block allocation request.

Open pipelines for a replication config can be retrieved efficiently from the PipelineStateMap.query2OpenPipelines variable.

However the list then needs to be filtered to remove excluded datanodes or pipelines. In the common case, these exclusions will be empty, so we can optimize this by skipping the iterator if there is nothing to filter out.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-8680

## How was this patch tested?

Existing tests should cover this.