### PR TITLE
HDDS-8682. EC: Avoid O(n) array.remove(element) when filtering pipelines in WritableECContainerProvider

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/PipelineChoosePolicy.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/PipelineChoosePolicy.java
@@ -42,6 +42,8 @@ public interface PipelineChoosePolicy {
    * @return Index in the list of the chosen pipeline, or -1 if no pipeline
    *         could be selected.
    */
-  int choosePipelineIndex(List<Pipeline> pipelineList,
-      PipelineRequestInformation pri);
+  default int choosePipelineIndex(List<Pipeline> pipelineList,
+      PipelineRequestInformation pri) {
+    return pipelineList == null || pipelineList.isEmpty() ? -1 : 0;
+  }
 }

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/PipelineChoosePolicy.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/PipelineChoosePolicy.java
@@ -30,8 +30,18 @@ public interface PipelineChoosePolicy {
    * Given an initial list of pipelines, return one of the pipelines.
    *
    * @param pipelineList list of pipelines.
-   * @return one of the pipelines.
+   * @return one of the pipelines or null if no pipeline can be selected.
    */
   Pipeline choosePipeline(List<Pipeline> pipelineList,
+      PipelineRequestInformation pri);
+
+  /**
+   * Given a list of pipelines, return the index of the chosen pipeline.
+   * @param pipelineList List of pipelines
+   * @param pri          PipelineRequestInformation
+   * @return Index in the list of the chosen pipeline, or -1 if no pipeline
+   *         could be selected.
+   */
+  int choosePipelineIndex(List<Pipeline> pipelineList,
       PipelineRequestInformation pri);
 }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/choose/algorithms/HealthyPipelineChoosePolicy.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/choose/algorithms/HealthyPipelineChoosePolicy.java
@@ -17,23 +17,27 @@
 
 package org.apache.hadoop.hdds.scm.pipeline.choose.algorithms;
 
+import org.apache.hadoop.hdds.scm.PipelineChoosePolicy;
 import org.apache.hadoop.hdds.scm.PipelineRequestInformation;
 import org.apache.hadoop.hdds.scm.pipeline.Pipeline;
 
+import java.util.ArrayList;
 import java.util.List;
 
 /**
  * The healthy pipeline choose policy that chooses pipeline
  * until return healthy pipeline.
  */
-public class HealthyPipelineChoosePolicy extends RandomPipelineChoosePolicy {
+public class HealthyPipelineChoosePolicy implements PipelineChoosePolicy {
+
+  private PipelineChoosePolicy randomPolicy = new RandomPipelineChoosePolicy();
 
   @Override
   public Pipeline choosePipeline(List<Pipeline> pipelineList,
       PipelineRequestInformation pri) {
     Pipeline fallback = null;
     while (pipelineList.size() > 0) {
-      Pipeline pipeline = super.choosePipeline(pipelineList, pri);
+      Pipeline pipeline = randomPolicy.choosePipeline(pipelineList, pri);
       if (pipeline.isHealthy()) {
         return pipeline;
       } else {
@@ -47,9 +51,8 @@ public class HealthyPipelineChoosePolicy extends RandomPipelineChoosePolicy {
   @Override
   public int choosePipelineIndex(List<Pipeline> pipelineList,
       PipelineRequestInformation pri) {
-    // As this class modified the passed in list, returning an index
-    // doesn't really make sense here. Throwing an exception incase any future
-    // code attempts to use this implementation.
-    throw new UnsupportedOperationException();
+    List<Pipeline> mutableList = new ArrayList<>(pipelineList);
+    Pipeline pipeline = choosePipeline(mutableList, pri);
+    return pipelineList.indexOf(pipeline);
   }
 }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/choose/algorithms/HealthyPipelineChoosePolicy.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/choose/algorithms/HealthyPipelineChoosePolicy.java
@@ -43,4 +43,13 @@ public class HealthyPipelineChoosePolicy extends RandomPipelineChoosePolicy {
     }
     return fallback;
   }
+
+  @Override
+  public int choosePipelineIndex(List<Pipeline> pipelineList,
+      PipelineRequestInformation pri) {
+    // As this class modified the passed in list, returning an index
+    // doesn't really make sense here. Throwing an exception incase any future
+    // code attempts to use this implementation.
+    throw new UnsupportedOperationException();
+  }
 }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/choose/algorithms/RandomPipelineChoosePolicy.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/choose/algorithms/RandomPipelineChoosePolicy.java
@@ -34,6 +34,19 @@ public class RandomPipelineChoosePolicy implements PipelineChoosePolicy {
   @SuppressWarnings("java:S2245") // no need for secure random
   public Pipeline choosePipeline(List<Pipeline> pipelineList,
       PipelineRequestInformation pri) {
-    return pipelineList.get((int) (Math.random() * pipelineList.size()));
+    return pipelineList.get(choosePipelineIndex(pipelineList, pri));
+  }
+
+  /**
+   * Given a list of pipelines, return the index of the chosen pipeline.
+   * @param pipelineList List of pipelines
+   * @param pri          PipelineRequestInformation
+   * @return Index in the list of the chosen pipeline, or -1 if no pipeline
+   *         could be selected.
+   */
+  @Override
+  public int choosePipelineIndex(List<Pipeline> pipelineList,
+      PipelineRequestInformation pri) {
+    return (int) (Math.random() * pipelineList.size());
   }
 }

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestWritableECContainerProvider.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestWritableECContainerProvider.java
@@ -36,18 +36,22 @@ import org.apache.hadoop.hdds.scm.ha.SCMHAManager;
 import org.apache.hadoop.hdds.scm.ha.SCMHAManagerStub;
 import org.apache.hadoop.hdds.scm.metadata.SCMDBDefinition;
 import org.apache.hadoop.hdds.scm.pipeline.WritableECContainerProvider.WritableECContainerProviderConfig;
+import org.apache.hadoop.hdds.scm.pipeline.choose.algorithms.HealthyPipelineChoosePolicy;
 import org.apache.hadoop.hdds.scm.pipeline.choose.algorithms.RandomPipelineChoosePolicy;
 import org.apache.hadoop.hdds.utils.db.DBStore;
 import org.apache.hadoop.hdds.utils.db.DBStoreBuilder;
 import org.apache.ozone.test.GenericTestUtils;
 import org.junit.Assert;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.runners.Parameterized;
 import org.mockito.Mockito;
 
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -76,8 +80,6 @@ public class TestWritableECContainerProvider {
   private PipelineManager pipelineManager;
   private final ContainerManager containerManager
       = Mockito.mock(ContainerManager.class);
-  private final PipelineChoosePolicy pipelineChoosingPolicy
-      = new RandomPipelineChoosePolicy();
 
   private OzoneConfiguration conf;
   private DBStore dbStore;
@@ -88,6 +90,14 @@ public class TestWritableECContainerProvider {
 
   private Map<ContainerID, ContainerInfo> containers;
   private WritableECContainerProviderConfig providerConf;
+
+  @Parameterized.Parameters
+  public static Collection<PipelineChoosePolicy> policies() {
+    Collection<PipelineChoosePolicy> policies = new ArrayList<>();
+    policies.add(new RandomPipelineChoosePolicy());
+    policies.add(new HealthyPipelineChoosePolicy());
+    return policies;
+  }
 
   @BeforeEach
   public void setup() throws IOException {
@@ -107,8 +117,6 @@ public class TestWritableECContainerProvider {
     pipelineManager =
         new MockPipelineManager(dbStore, scmhaManager, nodeManager);
 
-    provider = createSubject();
-
     Mockito.doAnswer(call -> {
       Pipeline pipeline = (Pipeline)call.getArguments()[2];
       ContainerInfo container = createContainer(pipeline,
@@ -126,20 +134,23 @@ public class TestWritableECContainerProvider {
 
   }
 
-  private WritableContainerProvider<ECReplicationConfig> createSubject() {
-    return createSubject(pipelineManager);
+  private WritableContainerProvider<ECReplicationConfig> createSubject(
+      PipelineChoosePolicy policy) {
+    return createSubject(pipelineManager, policy);
   }
 
   private WritableContainerProvider<ECReplicationConfig> createSubject(
-      PipelineManager customPipelineManager) {
+      PipelineManager customPipelineManager, PipelineChoosePolicy policy) {
     return new WritableECContainerProvider(providerConf, getMaxContainerSize(),
         nodeManager, customPipelineManager, containerManager,
-        pipelineChoosingPolicy);
+        policy);
   }
 
-  @Test
-  void testPipelinesCreatedBasedOnTotalDiskCount()
+  @ParameterizedTest
+  @MethodSource("policies")
+  void testPipelinesCreatedBasedOnTotalDiskCount(PipelineChoosePolicy policy)
       throws IOException, TimeoutException {
+    provider = createSubject(policy);
     providerConf.setMinimumPipelines(1);
     nodeManager.setNumHealthyVolumes(20);
 
@@ -149,9 +160,11 @@ public class TestWritableECContainerProvider {
     assertReusesExisting(allocated, pipelineLimit);
   }
 
-  @Test
-  void testPipelinesCreatedBasedOnTotalDiskCountWithFactor()
-      throws IOException, TimeoutException {
+  @ParameterizedTest
+  @MethodSource("policies")
+  void testPipelinesCreatedBasedOnTotalDiskCountWithFactor(
+      PipelineChoosePolicy policy) throws IOException, TimeoutException {
+    provider = createSubject(policy);
     int factor = 10;
     providerConf.setMinimumPipelines(1);
     providerConf.setPipelinePerVolumeFactor(factor);
@@ -163,9 +176,11 @@ public class TestWritableECContainerProvider {
     assertReusesExisting(allocated, pipelineLimit);
   }
 
-  @Test
-  void testPipelinesCreatedUpToMinLimitAndRandomPipelineReturned()
-      throws IOException, TimeoutException {
+  @ParameterizedTest
+  @MethodSource("policies")
+  void testPipelinesCreatedUpToMinLimitAndRandomPipelineReturned(
+      PipelineChoosePolicy policy) throws IOException, TimeoutException {
+    provider = createSubject(policy);
     int minimumPipelines = providerConf.getMinimumPipelines();
     Set<ContainerInfo> allocated = assertDistinctContainers(minimumPipelines);
     assertReusesExisting(allocated, minimumPipelines);
@@ -194,9 +209,11 @@ public class TestWritableECContainerProvider {
     }
   }
 
-  @Test
-  public void testPiplineLimitIgnoresExcludedPipelines()
-      throws IOException, TimeoutException {
+  @ParameterizedTest
+  @MethodSource("policies")
+  public void testPiplineLimitIgnoresExcludedPipelines(
+      PipelineChoosePolicy policy) throws IOException, TimeoutException {
+    provider = createSubject(policy);
     Set<ContainerInfo> allocatedContainers = new HashSet<>();
     for (int i = 0; i < providerConf.getMinimumPipelines(); i++) {
       ContainerInfo container = provider.getContainer(
@@ -216,9 +233,11 @@ public class TestWritableECContainerProvider {
     assertTrue(allocatedContainers.contains(c));
   }
 
-  @Test
-  public void testNewPipelineCreatedIfAllPipelinesExcluded()
-      throws IOException, TimeoutException {
+  @ParameterizedTest
+  @MethodSource("policies")
+  public void testNewPipelineCreatedIfAllPipelinesExcluded(
+      PipelineChoosePolicy policy) throws IOException, TimeoutException {
+    provider = createSubject(policy);
     Set<ContainerInfo> allocatedContainers = new HashSet<>();
     for (int i = 0; i < providerConf.getMinimumPipelines(); i++) {
       ContainerInfo container = provider.getContainer(
@@ -236,9 +255,11 @@ public class TestWritableECContainerProvider {
     assertFalse(allocatedContainers.contains(c));
   }
 
-  @Test
-  public void testNewPipelineCreatedIfAllContainersExcluded()
-      throws IOException, TimeoutException {
+  @ParameterizedTest
+  @MethodSource("policies")
+  public void testNewPipelineCreatedIfAllContainersExcluded(
+      PipelineChoosePolicy policy) throws IOException, TimeoutException {
+    provider = createSubject(policy);
     Set<ContainerInfo> allocatedContainers = new HashSet<>();
     for (int i = 0; i < providerConf.getMinimumPipelines(); i++) {
       ContainerInfo container = provider.getContainer(
@@ -256,9 +277,10 @@ public class TestWritableECContainerProvider {
     assertFalse(allocatedContainers.contains(c));
   }
 
-  @Test
-  public void testUnableToCreateAnyPipelinesThrowsException()
-      throws IOException {
+  @ParameterizedTest
+  @MethodSource("policies")
+  public void testUnableToCreateAnyPipelinesThrowsException(
+      PipelineChoosePolicy policy) throws IOException {
     pipelineManager = new MockPipelineManager(
         dbStore, scmhaManager, nodeManager) {
       @Override
@@ -268,7 +290,7 @@ public class TestWritableECContainerProvider {
         throw new IOException("Cannot create pipelines");
       }
     };
-    provider = createSubject();
+    provider = createSubject(policy);
 
     try {
       provider.getContainer(1, repConfig, OWNER, new ExcludeList());
@@ -278,9 +300,10 @@ public class TestWritableECContainerProvider {
     }
   }
 
-  @Test
-  public void testExistingPipelineReturnedWhenNewCannotBeCreated()
-      throws IOException, TimeoutException {
+  @ParameterizedTest
+  @MethodSource("policies")
+  public void testExistingPipelineReturnedWhenNewCannotBeCreated(
+      PipelineChoosePolicy policy) throws IOException, TimeoutException {
     pipelineManager = new MockPipelineManager(
         dbStore, scmhaManager, nodeManager) {
 
@@ -298,7 +321,7 @@ public class TestWritableECContainerProvider {
         return super.createPipeline(repConfig);
       }
     };
-    provider = createSubject();
+    provider = createSubject(policy);
 
     try {
       provider.getContainer(1, repConfig, OWNER, new ExcludeList());
@@ -317,9 +340,11 @@ public class TestWritableECContainerProvider {
     }
   }
 
-  @Test
-  public void testNewContainerAllocatedAndPipelinesClosedIfNoSpaceInExisting()
-      throws IOException, TimeoutException {
+  @ParameterizedTest
+  @MethodSource("policies")
+  public void testNewContainerAllocatedAndPipelinesClosedIfNoSpaceInExisting(
+      PipelineChoosePolicy policy) throws IOException, TimeoutException {
+    provider = createSubject(policy);
     Set<ContainerInfo> allocatedContainers =
         assertDistinctContainers(providerConf.getMinimumPipelines());
     // Update all the containers to make them nearly full, but with enough space
@@ -349,9 +374,10 @@ public class TestWritableECContainerProvider {
     }
   }
 
-  @Test
-  public void testPipelineNotFoundWhenAttemptingToUseExisting()
-      throws IOException, TimeoutException {
+  @ParameterizedTest
+  @MethodSource("policies")
+  public void testPipelineNotFoundWhenAttemptingToUseExisting(
+      PipelineChoosePolicy policy) throws IOException, TimeoutException {
     // Ensure PM throws PNF exception when we ask for the containers in the
     // pipeline
     pipelineManager = new MockPipelineManager(
@@ -363,7 +389,7 @@ public class TestWritableECContainerProvider {
         throw new PipelineNotFoundException("Simulated exception");
       }
     };
-    provider = createSubject();
+    provider = createSubject(policy);
 
     Set<ContainerInfo> allocatedContainers =
         assertDistinctContainers(providerConf.getMinimumPipelines());
@@ -376,9 +402,11 @@ public class TestWritableECContainerProvider {
     assertFalse(allocatedContainers.contains(newContainer));
   }
 
-  @Test
-  public void testContainerNotFoundWhenAttemptingToUseExisting()
-      throws IOException, TimeoutException {
+  @ParameterizedTest
+  @MethodSource("policies")
+  public void testContainerNotFoundWhenAttemptingToUseExisting(
+      PipelineChoosePolicy policy) throws IOException, TimeoutException {
+    provider = createSubject(policy);
     Set<ContainerInfo> allocatedContainers =
         assertDistinctContainers(providerConf.getMinimumPipelines());
 
@@ -400,12 +428,14 @@ public class TestWritableECContainerProvider {
     }
   }
 
-  @Test
-  public void testPipelineOpenButContainerRemovedFromIt()
-      throws IOException, TimeoutException {
+  @ParameterizedTest
+  @MethodSource("policies")
+  public void testPipelineOpenButContainerRemovedFromIt(
+      PipelineChoosePolicy policy) throws IOException, TimeoutException {
     // This can happen if the container close process is triggered from the DN.
     // When tha happens, CM will change the container state to CLOSING and
     // remove it from the container list in pipeline Manager.
+    provider = createSubject(policy);
     Set<ContainerInfo> allocatedContainers = new HashSet<>();
     for (int i = 0; i < providerConf.getMinimumPipelines(); i++) {
       ContainerInfo container = provider.getContainer(
@@ -425,11 +455,12 @@ public class TestWritableECContainerProvider {
     }
   }
 
-  @Test
-  public void testExcludedNodesPassedToCreatePipelineIfProvided()
-      throws IOException, TimeoutException {
+  @ParameterizedTest
+  @MethodSource("policies")
+  public void testExcludedNodesPassedToCreatePipelineIfProvided(
+      PipelineChoosePolicy policy) throws IOException, TimeoutException {
     PipelineManager pipelineManagerSpy = Mockito.spy(pipelineManager);
-    provider = createSubject(pipelineManagerSpy);
+    provider = createSubject(pipelineManagerSpy, policy);
     ExcludeList excludeList = new ExcludeList();
 
     // EmptyList should be passed if there are no nodes excluded.

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestWritableECContainerProvider.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestWritableECContainerProvider.java
@@ -36,7 +36,7 @@ import org.apache.hadoop.hdds.scm.ha.SCMHAManager;
 import org.apache.hadoop.hdds.scm.ha.SCMHAManagerStub;
 import org.apache.hadoop.hdds.scm.metadata.SCMDBDefinition;
 import org.apache.hadoop.hdds.scm.pipeline.WritableECContainerProvider.WritableECContainerProviderConfig;
-import org.apache.hadoop.hdds.scm.pipeline.choose.algorithms.HealthyPipelineChoosePolicy;
+import org.apache.hadoop.hdds.scm.pipeline.choose.algorithms.RandomPipelineChoosePolicy;
 import org.apache.hadoop.hdds.utils.db.DBStore;
 import org.apache.hadoop.hdds.utils.db.DBStoreBuilder;
 import org.apache.ozone.test.GenericTestUtils;
@@ -77,7 +77,7 @@ public class TestWritableECContainerProvider {
   private final ContainerManager containerManager
       = Mockito.mock(ContainerManager.class);
   private final PipelineChoosePolicy pipelineChoosingPolicy
-      = new HealthyPipelineChoosePolicy();
+      = new RandomPipelineChoosePolicy();
 
   private OzoneConfiguration conf;
   private DBStore dbStore;

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/choose/algorithms/TestPipelineChoosePolicyFactory.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/choose/algorithms/TestPipelineChoosePolicyFactory.java
@@ -71,6 +71,12 @@ public class TestPipelineChoosePolicyFactory {
         PipelineRequestInformation pri) {
       return null;
     }
+
+    @Override
+    public int choosePipelineIndex(List<Pipeline> pipelineList,
+        PipelineRequestInformation pri) {
+      return -1;
+    }
   }
 
   @Test


### PR DESCRIPTION
## What changes were proposed in this pull request?

When iterating over the pipeline list, if a pipeline is not valid for selection, we call Array.remove(element) to remove it from the list before selecting another random element.

If the pipeline selection policy could return the array index of the selected pipeline rather than the actual pipeline, then we can use the more efficient Array.remove(index). Even this is still O(n) as the array has to shuffle the elements down the internal array, but it is better than Array.remove(element) as it avoids searching for the element.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-8682

## How was this patch tested?

Existing tests should cover this.