### PR TITLE
HDDS-8693. Generate linear keys for freon ockrw

### DIFF
--- a/hadoop-ozone/dist/src/main/smoketest/freon/read-write-key.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/freon/read-write-key.robot
@@ -31,15 +31,21 @@ Read 10 keys from pre-generated keys
     ${result} =        Execute          ozone freon ockrw -n ${keysCount} -t 10 -r 100 -v voltest -b buckettest -p performanceTest --percentage-read 100 --percentage-list 0
                        Should contain   ${result}   Successful executions: ${keysCount}
 
-Read 10 keys' metadata from pre-generated keys
+Read 10 keys metadata from pre-generated keys
     ${keysCount} =     BuiltIn.Set Variable   10
     ${result} =        Execute          ozone freon ockrw -n ${keysCount} -t 10 -m -r 100 -v voltest -b buckettest -p performanceTest --percentage-read 100 --percentage-list 0
+                       Should contain   ${result}   Successful executions: ${keysCount}
+
+Read 10 keys when generate in linear manner
+    ${keysCount} =     BuiltIn.Set Variable   10
+    ${result} =        Execute          ozone freon ockrw -n ${keysCount} -t 1 -r 100 --size 0 -v voltest -b buckettest -p performanceTest --linear --percentage-read=0 --percentage-list=0
+    ${result} =        Execute          ozone freon ockrw -n ${keysCount} -t 1 -m -r 100 -v voltest -b buckettest -p performanceTest --linear --percentage-read=100 --percentage-list=0
                        Should contain   ${result}   Successful executions: ${keysCount}
 
 Write 10 keys of size 1 byte each from key index 0 to 99
     ${keysCount} =     BuiltIn.Set Variable   10
     ${size} =          BuiltIn.Set Variable   1
-    ${result} =        Execute          ozone freon ockrw -n ${keysCount} -t 10 --percentage-read 0 --percentage-list 0 --size ${size} -r 100 -v voltest -b buckettest -p performanceTest
+    ${result} =        Execute          ozone freon ockrw -n ${keysCount} -t 10 --percentage-read 0 --percentage-list 0 --size ${size} -r 100 -v voltest -b buckettest -p performanceTest --linear
                        Should contain   ${result}   Successful executions: ${keysCount}
     ${keyName} =       Execute          echo -n '1' | md5sum | head -c 7
     ${result} =        Execute          ozone sh key info /voltest/buckettest/performanceTest/${keyName}

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/KeyGeneratorUtil.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/KeyGeneratorUtil.java
@@ -38,7 +38,7 @@ public class KeyGeneratorUtil {
     return number -> String.valueOf(number);
   }
 
-  public String generateMd5KeyName(int number) {
+  public String generateMd5KeyName(long number) {
     String encodedStr = DigestUtils.md5Hex(String.valueOf(number));
     return encodedStr.substring(0, 7);
   }


### PR DESCRIPTION
## What changes were proposed in this pull request?
ozone freon ockrw is a useful command to generate a fixed name key range and generate workload against a working set of keys. Currently the keys are generated only randomly. It would be useful to have a mode where the keys are generated .

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-8693

## How was this patch tested?

robot test added.