### PR TITLE
HDDS-8448. Send FCR to SCM on volume failure.

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/impl/ContainerSet.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/impl/ContainerSet.java
@@ -21,10 +21,12 @@ package org.apache.hadoop.ozone.container.common.impl;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableMap;
+import com.google.protobuf.Message;
 import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.ContainerReportsProto;
 import org.apache.hadoop.hdds.scm.container.common.helpers.StorageContainerException;
 import org.apache.hadoop.ozone.container.common.interfaces.Container;
+import org.apache.hadoop.ozone.container.common.statemachine.StateContext;
 import org.apache.hadoop.ozone.container.common.volume.HddsVolume;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -41,6 +43,7 @@ import java.util.Set;
 import java.util.concurrent.ConcurrentNavigableMap;
 import java.util.concurrent.ConcurrentSkipListMap;
 import java.util.concurrent.ConcurrentSkipListSet;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import static org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.ContainerDataProto.State.RECOVERING;
 
@@ -179,21 +182,35 @@ public class ContainerSet implements Iterable<Container<?>> {
     return containerMap.size();
   }
 
-  public void handleVolumeFailures() {
+  /**
+   * Remove all containers belonging to failed volume.
+   * Send FCR which will not contain removed containers.
+   *
+   * @param  context StateContext
+   * @return
+   */
+  public void handleVolumeFailures(StateContext context) {
+    AtomicBoolean failedVolume = new AtomicBoolean(false);
     containerMap.values().forEach(c -> {
       if (c.getContainerData().getVolume().isFailed()) {
-        try {
-          c.markContainerUnhealthy();
-          LOG.info("Marking Container {} UNHEALTHY as the Volume {} " +
+        removeContainer(c.getContainerData().getContainerID());
+        LOG.info("Removing Container {} as the Volume {} " +
               "has failed", c.getContainerData().getContainerID(),
-              c.getContainerData().getVolume());
-        } catch (StorageContainerException e) {
-          LOG.error("Failed to move container {} to UNHEALTHY state in "
-                  + "volume {}", c.getContainerData().getContainerID(),
-              c.getContainerData().getVolume(), e);
-        }
+            c.getContainerData().getVolume());
+        failedVolume.set(true);
       }
     });
+
+    if (failedVolume.get()) {
+      try {
+        // There are some failed volume(container), send FCR to SCM
+        Message report = context.getFullContainerReportDiscardPendingICR();
+        context.refreshFullReport(report);
+        context.getParent().triggerHeartbeat();
+      } catch (Exception e) {
+        LOG.error("Failed to send FCR in Volume failure", e);
+      }
+    }
   }
 
   /**

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/ozoneimpl/OzoneContainer.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/ozoneimpl/OzoneContainer.java
@@ -436,7 +436,7 @@ public class OzoneContainer {
 
   public void handleVolumeFailures() {
     if (containerSet != null) {
-      containerSet.handleVolumeFailures();
+      containerSet.handleVolumeFailures(context);
     }
   }
 

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/volume/TestStorageVolumeChecker.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/volume/TestStorageVolumeChecker.java
@@ -273,13 +273,8 @@ public class TestStorageVolumeChecker {
     Assert.assertEquals(1, volumeSet.getVolumesList().size());
     Assert.assertEquals(1, volumeSet.getFailedVolumesList().size());
 
-    i = 0;
-    for (ContainerDataProto.State state : ContainerDataProto.State.values()) {
-      if (!state.equals(ContainerDataProto.State.INVALID)) {
-        Assert.assertEquals(ContainerDataProto.State.UNHEALTHY,
-            containerSet.getContainer(++i).getContainerState());
-      }
-    }
+    // All containers should be removed from containerSet
+    Assert.assertEquals(0, containerSet.getContainerMap().size());
 
     ozoneContainer.stop();
   }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Currently when volume fail happens, DN just marks container UNHEALTHY and later when SCM receives this information, SCM tries to delete those containers , but since the volume has failed, delete container fails in DN.
In this change when there is volume fail, In DN we can remove those containers from container set and immediately send FCR to SCM.
SCM will get information about container is missing in particular DN so that SCM will replicate to other place.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-8448

## How was this patch tested?

Added test case.
