### PR TITLE
HDDS-8668. Allow reconfiguration of annotated config object

### DIFF
--- a/hadoop-hdds/config/pom.xml
+++ b/hadoop-hdds/config/pom.xml
@@ -38,6 +38,16 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
       <artifactId>slf4j-api</artifactId>
     </dependency>
     <dependency>
+      <groupId>ch.qos.reload4j</groupId>
+      <artifactId>reload4j</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-reload4j</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.apache.ozone</groupId>
       <artifactId>hdds-test-utils</artifactId>
       <scope>test</scope>

--- a/hadoop-hdds/config/pom.xml
+++ b/hadoop-hdds/config/pom.xml
@@ -49,6 +49,10 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
       <scope>test</scope>
     </dependency>
 
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-params</artifactId>
+    </dependency>
   </dependencies>
 
 </project>

--- a/hadoop-hdds/config/src/main/java/org/apache/hadoop/hdds/conf/Config.java
+++ b/hadoop-hdds/config/src/main/java/org/apache/hadoop/hdds/conf/Config.java
@@ -61,4 +61,9 @@ public @interface Config {
   StorageUnit sizeUnit() default StorageUnit.BYTES;
 
   ConfigTag[] tags();
+
+  /**
+   * Indicates whether this property can be dynamically reconfigured at runtime.
+   */
+  boolean reconfigurable() default false;
 }

--- a/hadoop-hdds/config/src/main/java/org/apache/hadoop/hdds/conf/ConfigType.java
+++ b/hadoop-hdds/config/src/main/java/org/apache/hadoop/hdds/conf/ConfigType.java
@@ -17,6 +17,8 @@
  */
 package org.apache.hadoop.hdds.conf;
 
+import static org.apache.hadoop.hdds.conf.TimeDurationUtil.getTimeDurationHelper;
+
 /**
  * Possible type of injected configuration.
  * <p>
@@ -24,13 +26,76 @@ package org.apache.hadoop.hdds.conf;
  * the configuration field.
  */
 public enum ConfigType {
-  AUTO,
-  STRING,
-  BOOLEAN,
-  INT,
-  LONG,
-  TIME,
-  SIZE,
-  CLASS,
-  DOUBLE
+  AUTO {
+    @Override
+    Object parse(String value, Config config, Class<?> type, String key) {
+      throw new UnsupportedOperationException();
+    }
+
+  },
+  STRING {
+    @Override
+    String parse(String value, Config config, Class<?> type, String key) {
+      return value;
+    }
+
+  },
+  BOOLEAN {
+    @Override
+    Boolean parse(String value, Config config, Class<?> type, String key) {
+      return Boolean.parseBoolean(value);
+    }
+
+  },
+  INT {
+    @Override
+    Integer parse(String value, Config config, Class<?> type, String key) {
+      return Integer.parseInt(value);
+    }
+
+  },
+  LONG {
+    @Override
+    Long parse(String value, Config config, Class<?> type, String key) {
+      return Long.parseLong(value);
+    }
+
+  },
+  TIME {
+    @Override
+    Long parse(String value, Config config, Class<?> type, String key) {
+      return getTimeDurationHelper(key, value, config.timeUnit());
+    }
+
+  },
+  SIZE {
+    @Override
+    Object parse(String value, Config config, Class<?> type, String key) {
+      StorageSize measure = StorageSize.parse(value);
+      long val = Math.round(measure.getUnit().toBytes(measure.getValue()));
+      if (type == int.class) {
+        return (int) val;
+      }
+      return val;
+    }
+
+  },
+  CLASS {
+    @Override
+    Class<?> parse(String value, Config config, Class<?> type, String key)
+        throws ClassNotFoundException {
+      return Class.forName(value);
+    }
+
+  },
+  DOUBLE {
+    @Override
+    Double parse(String value, Config config, Class<?> type, String key) {
+      return Double.parseDouble(value);
+    }
+
+  };
+
+  abstract Object parse(String value, Config config, Class<?> type, String key)
+      throws Exception;
 }

--- a/hadoop-hdds/config/src/main/java/org/apache/hadoop/hdds/conf/ConfigurationReflectionUtil.java
+++ b/hadoop-hdds/config/src/main/java/org/apache/hadoop/hdds/conf/ConfigurationReflectionUtil.java
@@ -22,7 +22,9 @@ import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.util.Deque;
+import java.util.HashMap;
 import java.util.LinkedList;
+import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Stream;
 
@@ -34,99 +36,101 @@ public final class ConfigurationReflectionUtil {
   private ConfigurationReflectionUtil() {
   }
 
+  public static <T> Map<String, Field> mapReconfigurableProperties(
+      Class<T> configurationClass) {
+    Optional<String> prefix = getPrefix(configurationClass);
+    Map<String, Field> props =
+        mapReconfigurableProperties(configurationClass, prefix);
+    Class<? super T> superClass = configurationClass.getSuperclass();
+    while (superClass != null) {
+      props.putAll(mapReconfigurableProperties(superClass, prefix));
+      superClass = superClass.getSuperclass();
+    }
+    return props;
+  }
+
+  private static <T> Map<String, Field> mapReconfigurableProperties(
+      Class<T> configurationClass, Optional<String> prefix) {
+    Map<String, Field> props = new HashMap<>();
+    for (Field field : configurationClass.getDeclaredFields()) {
+      if (field.isAnnotationPresent(Config.class)) {
+        Config configAnnotation = field.getAnnotation(Config.class);
+
+        if (configAnnotation.reconfigurable()) {
+          checkNotFinal(configurationClass, field);
+          props.put(getFullKey(prefix, configAnnotation), field);
+        }
+      }
+    }
+    return props;
+  }
+
   public static <T> void injectConfiguration(
       ConfigurationSource configuration,
       Class<T> configurationClass,
-      T configObject, String prefix) {
+      T configObject, String prefix, boolean reconfiguration) {
     injectConfigurationToObject(configuration, configurationClass, configObject,
-        prefix);
+        prefix, reconfiguration);
     Class<? super T> superClass = configurationClass.getSuperclass();
     while (superClass != null) {
       injectConfigurationToObject(configuration, superClass, configObject,
-          prefix);
+          prefix, reconfiguration);
       superClass = superClass.getSuperclass();
     }
   }
 
-  public static <T> void injectConfigurationToObject(ConfigurationSource from,
+  private static <T> void injectConfigurationToObject(ConfigurationSource from,
       Class<T> configurationClass,
       T configuration,
-      String prefix) {
+      String prefix,
+      boolean reconfiguration
+  ) {
     for (Field field : configurationClass.getDeclaredFields()) {
       if (field.isAnnotationPresent(Config.class)) {
-        if ((field.getModifiers() & Modifier.FINAL) != 0) {
-          throw new ConfigurationException(String.format(
-              "Trying to set final field %s#%s, probably indicates misplaced " +
-                  "@Config annotation",
-              configurationClass.getSimpleName(), field.getName()));
-        }
-
-        String fieldLocation =
-            configurationClass + "." + field.getName();
+        checkNotFinal(configurationClass, field);
 
         Config configAnnotation = field.getAnnotation(Config.class);
 
+        if (reconfiguration && !configAnnotation.reconfigurable()) {
+          continue;
+        }
+
         String key = prefix + "." + configAnnotation.key();
-
         String defaultValue = configAnnotation.defaultValue();
+        String value = from.get(key, defaultValue);
 
-        ConfigType type = configAnnotation.type();
-
-        if (type == ConfigType.AUTO) {
-          type = detectConfigType(field.getType(), fieldLocation);
-        }
-
-        try {
-          switch (type) {
-          case STRING:
-            forcedFieldSet(field, configuration, from.get(key, defaultValue));
-            break;
-          case INT:
-            forcedFieldSet(field, configuration,
-                from.getInt(key, Integer.parseInt(defaultValue)));
-            break;
-          case BOOLEAN:
-            forcedFieldSet(field, configuration,
-                from.getBoolean(key, Boolean.parseBoolean(defaultValue)));
-            break;
-          case LONG:
-            forcedFieldSet(field, configuration,
-                from.getLong(key, Long.parseLong(defaultValue)));
-            break;
-          case DOUBLE:
-            forcedFieldSet(field, configuration,
-                from.getDouble(key, Double.parseDouble(defaultValue)));
-            break;
-          case TIME:
-            forcedFieldSet(field, configuration,
-                from.getTimeDuration(key, defaultValue,
-                    configAnnotation.timeUnit()));
-            break;
-          case SIZE:
-            final long value =
-                Math.round(from.getStorageSize(key,
-                    defaultValue, StorageUnit.BYTES));
-            if (field.getType() == int.class) {
-              forcedFieldSet(field, configuration, (int) value);
-            } else {
-              forcedFieldSet(field, configuration, value);
-
-            }
-            break;
-          case CLASS:
-            forcedFieldSet(field, configuration,
-                from.getClass(key, Class.forName(defaultValue)));
-            break;
-          default:
-            throw new ConfigurationException(
-                "Unsupported ConfigType " + type + " on " + fieldLocation);
-          }
-        } catch (IllegalAccessException | ClassNotFoundException e) {
-          throw new ConfigurationException(
-              "Can't inject configuration to " + fieldLocation, e);
-        }
-
+        setField(configurationClass, configuration, field, configAnnotation,
+            key, value);
       }
+    }
+  }
+
+  public static <T> void reconfigureProperty(T configuration, Field field,
+      String key, String value) {
+    if (!field.isAnnotationPresent(Config.class)) {
+      throw new ConfigurationException("Not configurable field: "
+          + field.getDeclaringClass() + "." + field.getName());
+    }
+    Config configAnnotation = field.getAnnotation(Config.class);
+
+    setField(field.getDeclaringClass(), configuration, field, configAnnotation,
+        key, value);
+  }
+
+  private static <T> void setField(
+      Class<?> configurationClass, T configuration, Field field,
+      Config configAnnotation, String key, String value) {
+    ConfigType type = configAnnotation.type();
+    if (type == ConfigType.AUTO) {
+      type = detectConfigType(field);
+    }
+
+    try {
+      Object parsed = type.parse(value, configAnnotation, field.getType(), key);
+      forcedFieldSet(field, configuration, parsed);
+    } catch (Exception e) {
+      throw new ConfigurationException("Failed to inject configuration to "
+          + configurationClass.getSimpleName() + "." + field.getName(), e);
     }
   }
 
@@ -146,9 +150,9 @@ public final class ConfigurationReflectionUtil {
     }
   }
 
-  private static ConfigType detectConfigType(Class<?> parameterType,
-      String methodLocation) {
+  private static ConfigType detectConfigType(Field field) {
     ConfigType type;
+    Class<?> parameterType = field.getType();
     if (parameterType == String.class) {
       type = ConfigType.STRING;
     } else if (parameterType == Integer.class || parameterType == int.class) {
@@ -163,9 +167,9 @@ public final class ConfigurationReflectionUtil {
     } else if (parameterType == Class.class) {
       type = ConfigType.CLASS;
     } else {
-      throw new ConfigurationException(
-          "Unsupported configuration type " + parameterType + " in "
-              + methodLocation);
+      throw new ConfigurationException("Unsupported configuration type "
+          + parameterType + " in "
+          + field.getDeclaringClass() + "." + field.getName());
     }
     return type;
   }
@@ -223,7 +227,7 @@ public final class ConfigurationReflectionUtil {
         ConfigType type = configAnnotation.type();
 
         if (type == ConfigType.AUTO) {
-          type = detectConfigType(field.getType(), fieldLocation);
+          type = detectConfigType(field);
         }
 
         //Note: default value is handled by ozone-default.xml. Here we can
@@ -291,13 +295,10 @@ public final class ConfigurationReflectionUtil {
 
   public static Optional<String> getKey(Class<?> configClass,
       String fieldName) {
-    ConfigGroup configGroup =
-        configClass.getAnnotation(ConfigGroup.class);
+    Optional<String> prefix = getPrefix(configClass);
 
-    return findFieldConfigAnnotationByName(configClass,
-        fieldName).map(
-            config -> configGroup == null ? config.key()
-                : configGroup.prefix() + "." + config.key());
+    return findFieldConfigAnnotationByName(configClass, fieldName)
+        .map(config -> getFullKey(prefix, config));
   }
 
   public static Optional<ConfigType> getType(Class<?> configClass,
@@ -326,4 +327,32 @@ public final class ConfigurationReflectionUtil {
     }
     return Optional.empty();
   }
+
+  private static <T> void checkNotFinal(
+      Class<T> configurationClass, Field field) {
+
+    if ((field.getModifiers() & Modifier.FINAL) != 0) {
+      throw new ConfigurationException(String.format(
+          "Trying to set final field %s#%s, probably indicates misplaced " +
+              "@Config annotation",
+          configurationClass.getSimpleName(), field.getName()));
+    }
+  }
+
+  private static <T> Optional<String> getPrefix(Class<T> configurationClass) {
+    ConfigGroup configGroup =
+        configurationClass.getAnnotation(ConfigGroup.class);
+    return configGroup != null
+        ? Optional.of(configGroup.prefix())
+        : Optional.empty();
+  }
+
+  private static String getFullKey(
+      Optional<String> optionalPrefix, Config configAnnotation) {
+    String key = configAnnotation.key();
+    return optionalPrefix
+        .map(prefix -> prefix + "." + key)
+        .orElse(key);
+  }
+
 }

--- a/hadoop-hdds/config/src/main/java/org/apache/hadoop/hdds/conf/ConfigurationSource.java
+++ b/hadoop-hdds/config/src/main/java/org/apache/hadoop/hdds/conf/ConfigurationSource.java
@@ -175,13 +175,23 @@ public interface ConfigurationSource {
 
     ConfigurationReflectionUtil
         .injectConfiguration(this, configurationClass, configObject,
-            prefix);
+            prefix, false);
 
     ConfigurationReflectionUtil
         .callPostConstruct(configurationClass, configObject);
 
     return configObject;
 
+  }
+
+  /**
+   * Update {@code object}'s reconfigurable properties from this configuration.
+   */
+  default <T> void reconfigure(Class<T> configClass, T object) {
+    ConfigGroup configGroup = configClass.getAnnotation(ConfigGroup.class);
+    String prefix = configGroup.prefix();
+    ConfigurationReflectionUtil.injectConfiguration(
+        this, configClass, object, prefix, true);
   }
 
   /**

--- a/hadoop-hdds/config/src/main/java/org/apache/hadoop/hdds/conf/ReconfigurableConfig.java
+++ b/hadoop-hdds/config/src/main/java/org/apache/hadoop/hdds/conf/ReconfigurableConfig.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -17,24 +17,27 @@
  */
 package org.apache.hadoop.hdds.conf;
 
+import java.lang.reflect.Field;
+import java.util.Map;
+import java.util.Set;
+
 /**
- * Example configuration to test inherited configuration injection.
+ * Base class for config with reconfigurable properties.
  */
-public class ConfigurationExampleGrandParent extends ReconfigurableConfig {
+public abstract class ReconfigurableConfig {
 
-  @Config(key = "number", defaultValue = "2", description = "Example numeric "
-      + "configuration", tags = ConfigTag.MANAGEMENT)
-  private int number = 1;
+  private final Map<String, Field> reconfigurableProperties =
+      ConfigurationReflectionUtil.mapReconfigurableProperties(getClass());
 
-  @Config(key = "grandpa.dyna", reconfigurable = true, defaultValue = "x",
-      description = "Test inherited dynamic property", tags = {})
-  private String grandpaDynamic;
-
-  public int getNumber() {
-    return number;
+  public void reconfigureProperty(String property, String newValue) {
+    Field field = reconfigurableProperties.get(property);
+    if (field != null) {
+      ConfigurationReflectionUtil.reconfigureProperty(this,
+          field, property, newValue);
+    }
   }
 
-  public void setNumber(int number) {
-    this.number = number;
+  public Set<String> reconfigurableProperties() {
+    return reconfigurableProperties.keySet();
   }
 }

--- a/hadoop-hdds/config/src/test/java/org/apache/hadoop/hdds/conf/ConfigurationExample.java
+++ b/hadoop-hdds/config/src/test/java/org/apache/hadoop/hdds/conf/ConfigurationExample.java
@@ -47,10 +47,24 @@ public class ConfigurationExample extends ConfigurationExampleParent {
       + "test TIME config type)", tags = ConfigTag.MANAGEMENT)
   private long waitTime = 1;
 
+  @Config(key = "size.small", type = ConfigType.SIZE, defaultValue = "42MB",
+      tags = {},
+      description = "Testing SIZE with int field")
+  private int smallSize;
+
+  @Config(key = "size.large", type = ConfigType.SIZE,
+      defaultValue = "5GB", tags = {},
+      description = "Testing SIZE with long field")
+  private long largeSize;
+
   @Config(key = "threshold", type = ConfigType.DOUBLE, defaultValue = "10",
       description = "Threshold (To test DOUBLE config type)",
       tags = ConfigTag.MANAGEMENT)
   private double threshold = 10;
+
+  @Config(key = "dynamic", reconfigurable = true, defaultValue = "original",
+      description = "Test dynamic property", tags = {})
+  private String dynamic;
 
   public void setClientAddress(String clientAddress) {
     this.clientAddress = clientAddress;
@@ -98,5 +112,9 @@ public class ConfigurationExample extends ConfigurationExampleParent {
 
   public double getThreshold() {
     return threshold;
+  }
+
+  public String getDynamic() {
+    return dynamic;
   }
 }

--- a/hadoop-hdds/config/src/test/java/org/apache/hadoop/hdds/conf/TestConfigurationReflectionUtil.java
+++ b/hadoop-hdds/config/src/test/java/org/apache/hadoop/hdds/conf/TestConfigurationReflectionUtil.java
@@ -35,51 +35,48 @@ class TestConfigurationReflectionUtil {
   static Stream<Arguments> data() {
     return Stream.of(
         arguments(ConfigurationExample.class, "waitTime",
-            ConfigType.TIME, true,
-            "ozone.scm.client.wait", true,
-            "30m", true),
+            Optional.of(ConfigType.TIME),
+            Optional.of("ozone.scm.client.wait"),
+            Optional.of("30m")),
         arguments(ConfigurationExampleGrandParent.class, "number",
-            ConfigType.AUTO, true,
-            "number", true,
-            "2", true),
+            Optional.of(ConfigType.AUTO),
+            Optional.of("number"),
+            Optional.of("2")),
         arguments(ConfigurationExample.class, "secure",
-            ConfigType.AUTO, true,
-            "ozone.scm.client.secure", true,
-            "true", true),
+            Optional.of(ConfigType.AUTO),
+            Optional.of("ozone.scm.client.secure"),
+            Optional.of("true")),
         arguments(ConfigurationExample.class, "no-such-field",
-            null, false,
-            "", false,
-            "", false),
+            Optional.empty(),
+            Optional.empty(),
+            Optional.empty()),
         arguments(ConfigFileAppender.class, "document",
-            null, false,
-            "", false,
-            "", false),
+            Optional.empty(),
+            Optional.empty(),
+            Optional.empty()),
         arguments(ConfigurationExample.class, "threshold",
-            ConfigType.DOUBLE, true,
-            "ozone.scm.client.threshold", true,
-            "10", true)
+            Optional.of(ConfigType.DOUBLE),
+            Optional.of("ozone.scm.client.threshold"),
+            Optional.of("10"))
     );
   }
 
   @ParameterizedTest
   @MethodSource("data")
   void testForGivenClasses(Class<?> testClass, String fieldName,
-      ConfigType expectedType, boolean typePresent,
-      String expectedKey, boolean keyPresent,
-      String expectedDefault, boolean defaultValuePresent) {
+      Optional<ConfigType> expectedType,
+      Optional<String> expectedKey,
+      Optional<String> expectedDefault) {
     Optional<ConfigType> type = ConfigurationReflectionUtil.getType(
         testClass, fieldName);
-    assertEquals(typePresent, type.isPresent());
-    type.ifPresent(actual -> assertEquals(expectedType, actual));
+    assertEquals(expectedType, type);
 
     Optional<String> key = ConfigurationReflectionUtil.getKey(
         testClass, fieldName);
-    assertEquals(keyPresent, key.isPresent());
-    key.ifPresent(actual -> assertEquals(expectedKey, actual));
+    assertEquals(expectedKey, key);
 
     Optional<String> defaultValue = ConfigurationReflectionUtil.getDefaultValue(
         testClass, fieldName);
-    assertEquals(defaultValuePresent, defaultValue.isPresent());
-    defaultValue.ifPresent(actual -> assertEquals(expectedDefault, actual));
+    assertEquals(expectedDefault, defaultValue);
   }
 }

--- a/hadoop-hdds/config/src/test/java/org/apache/hadoop/hdds/conf/TestConfigurationReflectionUtil.java
+++ b/hadoop-hdds/config/src/test/java/org/apache/hadoop/hdds/conf/TestConfigurationReflectionUtil.java
@@ -17,11 +17,14 @@
  */
 package org.apache.hadoop.hdds.conf;
 
+import com.google.common.collect.ImmutableSet;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
 import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -78,5 +81,18 @@ class TestConfigurationReflectionUtil {
     Optional<String> defaultValue = ConfigurationReflectionUtil.getDefaultValue(
         testClass, fieldName);
     assertEquals(expectedDefault, defaultValue);
+  }
+
+  @Test
+  void listReconfigurableProperties() {
+    Set<String> props =
+        ConfigurationReflectionUtil.mapReconfigurableProperties(
+            ConfigurationExample.class).keySet();
+
+    String prefix = "ozone.scm.client";
+    assertEquals(ImmutableSet.of(
+        prefix + ".dynamic",
+        prefix + ".grandpa.dyna"
+    ), props);
   }
 }

--- a/hadoop-hdds/config/src/test/java/org/apache/hadoop/hdds/conf/TestConfigurationSource.java
+++ b/hadoop-hdds/config/src/test/java/org/apache/hadoop/hdds/conf/TestConfigurationSource.java
@@ -18,10 +18,10 @@
 
 package org.apache.hadoop.hdds.conf;
 
-import org.junit.Assert;
+import com.google.common.collect.ImmutableMap;
 import org.junit.jupiter.api.Test;
 
-import java.util.Map;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 class TestConfigurationSource {
 
@@ -29,22 +29,17 @@ class TestConfigurationSource {
   void getPropsMatchPrefixAndTrimPrefix() {
     MutableConfigurationSource c = new InMemoryConfiguration();
     c.set("somePrefix.key", "value");
-    ConfigurationSource config = c;
-    Map<String, String> entry =
-        config.getPropsMatchPrefixAndTrimPrefix("somePrefix.");
-    Assert.assertEquals("key", entry.keySet().toArray()[0]);
-    Assert.assertEquals("value", entry.values().toArray()[0]);
+
+    assertEquals(ImmutableMap.of("key", "value"),
+        c.getPropsMatchPrefixAndTrimPrefix("somePrefix."));
   }
 
   @Test
   void getPropsMatchPrefix() {
     MutableConfigurationSource c = new InMemoryConfiguration();
     c.set("somePrefix.key", "value");
-    ConfigurationSource config = c;
-    Map<String, String> entry =
-        config.getPropsMatchPrefix("somePrefix.");
-    Assert.assertEquals("somePrefix.key",
-        entry.keySet().toArray()[0]);
-    Assert.assertEquals("value", entry.values().toArray()[0]);
+
+    assertEquals(ImmutableMap.of("somePrefix.key", "value"),
+        c.getPropsMatchPrefix("somePrefix."));
   }
 }

--- a/hadoop-hdds/config/src/test/java/org/apache/hadoop/hdds/conf/TestReconfigurableConfig.java
+++ b/hadoop-hdds/config/src/test/java/org/apache/hadoop/hdds/conf/TestReconfigurableConfig.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -17,24 +17,22 @@
  */
 package org.apache.hadoop.hdds.conf;
 
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
 /**
- * Example configuration to test inherited configuration injection.
+ * Test for {@link ReconfigurableConfig}.
  */
-public class ConfigurationExampleGrandParent extends ReconfigurableConfig {
+class TestReconfigurableConfig {
 
-  @Config(key = "number", defaultValue = "2", description = "Example numeric "
-      + "configuration", tags = ConfigTag.MANAGEMENT)
-  private int number = 1;
+  @Test
+  void testReconfigureProperty() {
+    ConfigurationExample subject = new InMemoryConfiguration()
+        .getObject(ConfigurationExample.class);
 
-  @Config(key = "grandpa.dyna", reconfigurable = true, defaultValue = "x",
-      description = "Test inherited dynamic property", tags = {})
-  private String grandpaDynamic;
+    subject.reconfigureProperty("ozone.scm.client.dynamic", "updated");
 
-  public int getNumber() {
-    return number;
-  }
-
-  public void setNumber(int number) {
-    this.number = number;
+    assertEquals("updated", subject.getDynamic());
   }
 }

--- a/hadoop-hdds/config/src/test/resources/log4j.properties
+++ b/hadoop-hdds/config/src/test/resources/log4j.properties
@@ -1,0 +1,23 @@
+#
+#   Licensed to the Apache Software Foundation (ASF) under one or more
+#   contributor license agreements.  See the NOTICE file distributed with
+#   this work for additional information regarding copyright ownership.
+#   The ASF licenses this file to You under the Apache License, Version 2.0
+#   (the "License"); you may not use this file except in compliance with
+#   the License.  You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+# log4j configuration used during build and unit tests
+
+log4j.rootLogger=INFO,stdout
+log4j.threshold=ALL
+log4j.appender.stdout=org.apache.log4j.ConsoleAppender
+log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
+log4j.appender.stdout.layout.ConversionPattern=%d{ISO8601} [%t] %-5p %c{2} (%F:%M(%L)) - %m%n


### PR DESCRIPTION
## What changes were proposed in this pull request?

 * allow `@Config` properties to be marked as `reconfigurable`
 * implement reconfiguration of annotated config object from `ConfigurationSource`
 * create base class `ReconfigurableConfig` to help with keeping track of reconfigurable properties and handling updates

This is not tied into reconfiguration handling in OM/SCM/etc., will be done in follow-up.

https://issues.apache.org/jira/browse/HDDS-8668

## How was this patch tested?

Added unit tests.

CI:
https://github.com/adoroszlai/hadoop-ozone/actions/runs/5073256233