### PR TITLE
HDDS-8559. Codec implementations should be singleton

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/hdds/datanode/metadata/CRLDBDefinition.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/hdds/datanode/metadata/CRLDBDefinition.java
@@ -52,7 +52,7 @@ public class CRLDBDefinition implements DBDefinition {
       new DBColumnFamilyDefinition<>(
           "crlSequenceId",
           String.class,
-          new StringCodec(),
+          StringCodec.get(),
           Long.class,
           LongCodec.get());
 

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/metadata/DatanodeSchemaOneDBDefinition.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/metadata/DatanodeSchemaOneDBDefinition.java
@@ -48,7 +48,7 @@ public class DatanodeSchemaOneDBDefinition
       new DBColumnFamilyDefinition<>(
           StringUtils.bytes2String(DEFAULT_COLUMN_FAMILY),
           String.class,
-          new SchemaOneKeyCodec(),
+          SchemaOneKeyCodec.get(),
           BlockData.class,
           BlockData.getCodec());
 
@@ -57,7 +57,7 @@ public class DatanodeSchemaOneDBDefinition
         new DBColumnFamilyDefinition<>(
             StringUtils.bytes2String(DEFAULT_COLUMN_FAMILY),
             String.class,
-            new SchemaOneKeyCodec(),
+            SchemaOneKeyCodec.get(),
             Long.class,
             LongCodec.get());
 
@@ -66,9 +66,9 @@ public class DatanodeSchemaOneDBDefinition
         new DBColumnFamilyDefinition<>(
             StringUtils.bytes2String(DEFAULT_COLUMN_FAMILY),
             String.class,
-            new SchemaOneKeyCodec(),
+            SchemaOneKeyCodec.get(),
             ChunkInfoList.class,
-            new SchemaOneChunkInfoListCodec());
+            SchemaOneChunkInfoListCodec.get());
 
   public DatanodeSchemaOneDBDefinition(String dbPath,
       ConfigurationSource config) {

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/metadata/DatanodeSchemaThreeDBDefinition.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/metadata/DatanodeSchemaThreeDBDefinition.java
@@ -58,7 +58,7 @@ public class DatanodeSchemaThreeDBDefinition
       new DBColumnFamilyDefinition<>(
           "block_data",
           String.class,
-          new FixedLengthStringCodec(),
+          FixedLengthStringCodec.get(),
           BlockData.class,
           BlockData.getCodec());
 
@@ -67,7 +67,7 @@ public class DatanodeSchemaThreeDBDefinition
       new DBColumnFamilyDefinition<>(
           "metadata",
           String.class,
-          new FixedLengthStringCodec(),
+          FixedLengthStringCodec.get(),
           Long.class,
           LongCodec.get());
 
@@ -76,7 +76,7 @@ public class DatanodeSchemaThreeDBDefinition
       new DBColumnFamilyDefinition<>(
           "deleted_blocks",
           String.class,
-          new FixedLengthStringCodec(),
+          FixedLengthStringCodec.get(),
           ChunkInfoList.class,
           ChunkInfoList.getCodec());
 
@@ -85,7 +85,7 @@ public class DatanodeSchemaThreeDBDefinition
       new DBColumnFamilyDefinition<>(
           "delete_txns",
           String.class,
-          new FixedLengthStringCodec(),
+          FixedLengthStringCodec.get(),
           DeletedBlocksTransaction.class,
           Proto2Codec.get(DeletedBlocksTransaction.class));
 

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/metadata/DatanodeSchemaTwoDBDefinition.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/metadata/DatanodeSchemaTwoDBDefinition.java
@@ -41,7 +41,7 @@ public class DatanodeSchemaTwoDBDefinition extends
           new DBColumnFamilyDefinition<>(
                   "block_data",
                   String.class,
-                  new StringCodec(),
+                  StringCodec.get(),
                   BlockData.class,
                   BlockData.getCodec());
 
@@ -50,7 +50,7 @@ public class DatanodeSchemaTwoDBDefinition extends
           new DBColumnFamilyDefinition<>(
           "metadata",
           String.class,
-          new StringCodec(),
+          StringCodec.get(),
           Long.class,
           LongCodec.get());
 
@@ -59,7 +59,7 @@ public class DatanodeSchemaTwoDBDefinition extends
           new DBColumnFamilyDefinition<>(
                   "deleted_blocks",
                   String.class,
-                  new StringCodec(),
+                  StringCodec.get(),
                   ChunkInfoList.class,
                   ChunkInfoList.getCodec());
 

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/metadata/SchemaOneChunkInfoListCodec.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/metadata/SchemaOneChunkInfoListCodec.java
@@ -43,7 +43,19 @@ import java.io.IOException;
  * future, callers should be aware that the associated chunk information may not
  * always be present.
  */
-public class SchemaOneChunkInfoListCodec implements Codec<ChunkInfoList> {
+public final class SchemaOneChunkInfoListCodec implements Codec<ChunkInfoList> {
+
+  private static final Codec<ChunkInfoList> INSTANCE =
+      new SchemaOneChunkInfoListCodec();
+
+  public static Codec<ChunkInfoList> get() {
+    return INSTANCE;
+  }
+
+  private SchemaOneChunkInfoListCodec() {
+    // singleton
+  }
+
   @Override
   public byte[] toPersistedFormat(ChunkInfoList chunkList) {
     return chunkList.getProtoBufMessage().toByteArray();

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/metadata/SchemaOneKeyCodec.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/metadata/SchemaOneKeyCodec.java
@@ -34,9 +34,19 @@ import org.slf4j.LoggerFactory;
  * prefixes in the data, and determining which format it should be
  * encoded/decoded to/from.
  */
-public class SchemaOneKeyCodec implements Codec<String> {
+public final class SchemaOneKeyCodec implements Codec<String> {
   private static final Logger LOG = LoggerFactory.getLogger(
       SchemaOneKeyCodec.class);
+
+  private static final Codec<String> INSTANCE = new SchemaOneKeyCodec();
+
+  public static Codec<String> get() {
+    return INSTANCE;
+  }
+
+  private SchemaOneKeyCodec() {
+    // singleton
+  }
 
   @Override
   public byte[] toPersistedFormat(String stringObject) {

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/ByteArrayCodec.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/ByteArrayCodec.java
@@ -19,9 +19,19 @@
 package org.apache.hadoop.hdds.utils.db;
 
 /**
- * Codec to convert byte array to/from byte array.
+ * No-op codec for byte arrays.
  */
 public final class ByteArrayCodec implements Codec<byte[]> {
+
+  private static final Codec<byte[]> INSTANCE = new ByteArrayCodec();
+
+  public static Codec<byte[]> get() {
+    return INSTANCE;
+  }
+
+  private ByteArrayCodec() {
+    // singleton
+  }
 
   @Override
   public byte[] toPersistedFormat(byte[] bytes) {

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/CodecRegistry.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/CodecRegistry.java
@@ -49,10 +49,10 @@ public final class CodecRegistry {
 
   public static Builder newBuilder() {
     return new Builder()
-        .addCodec(String.class, new StringCodec())
+        .addCodec(String.class, StringCodec.get())
         .addCodec(Long.class, LongCodec.get())
-        .addCodec(Integer.class, new IntegerCodec())
-        .addCodec(byte[].class, new ByteArrayCodec());
+        .addCodec(Integer.class, IntegerCodec.get())
+        .addCodec(byte[].class, ByteArrayCodec.get());
   }
 
   private static final class CodecMap {

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/FixedLengthStringCodec.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/FixedLengthStringCodec.java
@@ -24,7 +24,18 @@ import java.io.IOException;
  * Codec to convert a prefixed String to/from byte array.
  * The prefix has to be of fixed-length.
  */
-public class FixedLengthStringCodec implements Codec<String> {
+public final class FixedLengthStringCodec implements Codec<String> {
+
+  private static final Codec<String> INSTANCE = new FixedLengthStringCodec();
+
+  public static Codec<String> get() {
+    return INSTANCE;
+  }
+
+  private FixedLengthStringCodec() {
+    // singleton
+  }
+
   @Override
   public byte[] toPersistedFormat(String object) throws IOException {
     if (object != null) {

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/IntegerCodec.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/IntegerCodec.java
@@ -24,9 +24,20 @@ import javax.annotation.Nonnull;
 import java.util.function.IntFunction;
 
 /**
- * Codec to convert Integer to/from byte array.
+ * Codec to serialize/deserialize {@link Integer}.
  */
 public final class IntegerCodec implements Codec<Integer> {
+
+  private static final Codec<Integer> INSTANCE = new IntegerCodec();
+
+  public static Codec<Integer> get() {
+    return INSTANCE;
+  }
+
+  private IntegerCodec() {
+    // singleton
+  }
+
   @Override
   public boolean supportCodecBuffer() {
     return true;

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/RDBStore.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/RDBStore.java
@@ -333,7 +333,7 @@ public class RDBStore implements DBStore {
   @Override
   public Map<Integer, String> getTableNames() {
     Map<Integer, String> tableNames = new HashMap<>();
-    StringCodec stringCodec = new StringCodec();
+    StringCodec stringCodec = StringCodec.get();
 
     for (ColumnFamily columnFamily : getColumnFamilies()) {
       tableNames.put(columnFamily.getID(), columnFamily.getName(stringCodec));

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/ShortCodec.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/ShortCodec.java
@@ -22,9 +22,19 @@ import java.io.IOException;
 import com.google.common.primitives.Shorts;
 
 /**
- * Codec to convert Short to/from byte array.
+ * Codec to serialize/deserialize {@link Short}.
  */
-public class ShortCodec implements Codec<Short> {
+public final class ShortCodec implements Codec<Short> {
+
+  private static final Codec<Short> INSTANCE = new ShortCodec();
+
+  public static Codec<Short> get() {
+    return INSTANCE;
+  }
+
+  private ShortCodec() {
+    // singleton
+  }
 
   @Override
   public byte[] toPersistedFormat(Short object) throws IOException {

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/StringCodec.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/StringCodec.java
@@ -24,13 +24,17 @@ import javax.annotation.Nonnull;
 import org.apache.hadoop.hdds.StringUtils;
 
 /**
- * Codec to convert String to/from byte array.
+ * Codec to serialize/deserialize {@link String}.
  */
 public final class StringCodec implements Codec<String> {
   private static final StringCodec CODEC = new StringCodec();
 
   public static StringCodec get() {
     return CODEC;
+  }
+
+  private StringCodec() {
+    // singleton
   }
 
   @Override

--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/utils/db/TestCodec.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/utils/db/TestCodec.java
@@ -55,7 +55,7 @@ public final class TestCodec {
 
   @Test
   public void testIntegerCodec() throws Exception {
-    final IntegerCodec codec = new IntegerCodec();
+    final Codec<Integer> codec = IntegerCodec.get();
     runTest(codec, 0, Integer.BYTES);
     runTest(codec, 1, Integer.BYTES);
     runTest(codec, -1, Integer.BYTES);
@@ -87,7 +87,7 @@ public final class TestCodec {
 
   @Test
   public void testStringCodec() throws Exception {
-    final StringCodec codec = new StringCodec();
+    final StringCodec codec = StringCodec.get();
     runTest(codec, "", 0);
 
     for (int i = 0; i < NUM_LOOPS; i++) {

--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/utils/db/TestDBStoreBuilder.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/utils/db/TestDBStoreBuilder.java
@@ -176,7 +176,7 @@ public class TestDBStoreBuilder {
 
       private final DBColumnFamilyDefinition<String, Long> sampleTable =
           new DBColumnFamilyDefinition<>(sampleTableName,
-              String.class, new StringCodec(), Long.class, LongCodec.get());
+              String.class, StringCodec.get(), Long.class, LongCodec.get());
       {
         ManagedColumnFamilyOptions cfOptions = new ManagedColumnFamilyOptions();
         // reverse the default option for check
@@ -253,7 +253,7 @@ public class TestDBStoreBuilder {
 
       private final DBColumnFamilyDefinition<String, Long> sampleTable =
               new DBColumnFamilyDefinition<>(sampleTableName, String.class,
-                      new StringCodec(), Long.class, LongCodec.get());
+                      StringCodec.get(), Long.class, LongCodec.get());
 
 
       @Override

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/metadata/BigIntegerCodec.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/metadata/BigIntegerCodec.java
@@ -24,9 +24,20 @@ import java.math.BigInteger;
 import org.apache.hadoop.hdds.utils.db.Codec;
 
 /**
- * Encode and decode BigInteger.
+ * Codec to serialize/deserialize {@link BigInteger}.
  */
-public class BigIntegerCodec implements Codec<BigInteger> {
+public final class BigIntegerCodec implements Codec<BigInteger> {
+
+  private static final Codec<BigInteger> INSTANCE = new BigIntegerCodec();
+
+  public static Codec<BigInteger> get() {
+    return INSTANCE;
+  }
+
+  private BigIntegerCodec() {
+    // singleton
+  }
+
   @Override
   public byte[] toPersistedFormat(BigInteger object) throws IOException {
     return object.toByteArray();

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/metadata/SCMDBDefinition.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/metadata/SCMDBDefinition.java
@@ -57,18 +57,18 @@ public class SCMDBDefinition implements DBDefinition {
       new DBColumnFamilyDefinition<>(
           "validCerts",
           BigInteger.class,
-          new BigIntegerCodec(),
+          BigIntegerCodec.get(),
           X509Certificate.class,
-          new X509CertificateCodec());
+          X509CertificateCodec.get());
 
   public static final DBColumnFamilyDefinition<BigInteger, X509Certificate>
       VALID_SCM_CERTS =
       new DBColumnFamilyDefinition<>(
           "validSCMCerts",
           BigInteger.class,
-          new BigIntegerCodec(),
+          BigIntegerCodec.get(),
           X509Certificate.class,
-          new X509CertificateCodec());
+          X509CertificateCodec.get());
 
   /**
    * This column family is Deprecated in favor of REVOKED_CERTS_V2.
@@ -79,16 +79,16 @@ public class SCMDBDefinition implements DBDefinition {
       new DBColumnFamilyDefinition<>(
           "revokedCerts",
           BigInteger.class,
-          new BigIntegerCodec(),
+          BigIntegerCodec.get(),
           X509Certificate.class,
-          new X509CertificateCodec());
+          X509CertificateCodec.get());
 
   public static final DBColumnFamilyDefinition<BigInteger, CertInfo>
       REVOKED_CERTS_V2 =
       new DBColumnFamilyDefinition<>(
           "revokedCertsV2",
           BigInteger.class,
-          new BigIntegerCodec(),
+          BigIntegerCodec.get(),
           CertInfo.class,
           CertInfo.getCodec());
 
@@ -115,7 +115,7 @@ public class SCMDBDefinition implements DBDefinition {
       new DBColumnFamilyDefinition<>(
           "scmTransactionInfos",
           String.class,
-          new StringCodec(),
+          StringCodec.get(),
           TransactionInfo.class,
           TransactionInfo.getCodec());
 
@@ -132,7 +132,7 @@ public class SCMDBDefinition implements DBDefinition {
       new DBColumnFamilyDefinition<>(
           "crlSequenceId",
           String.class,
-          new StringCodec(),
+          StringCodec.get(),
           Long.class,
           LongCodec.get());
 
@@ -141,7 +141,7 @@ public class SCMDBDefinition implements DBDefinition {
       new DBColumnFamilyDefinition<>(
           "sequenceId",
           String.class,
-          new StringCodec(),
+          StringCodec.get(),
           Long.class,
           LongCodec.get());
 
@@ -163,16 +163,16 @@ public class SCMDBDefinition implements DBDefinition {
       META = new DBColumnFamilyDefinition<>(
           "meta",
           String.class,
-          new StringCodec(),
+          StringCodec.get(),
           String.class,
-          new StringCodec());
+          StringCodec.get());
 
   public static final DBColumnFamilyDefinition<String, ByteString>
       STATEFUL_SERVICE_CONFIG =
       new DBColumnFamilyDefinition<>(
           "statefulServiceConfig",
           String.class,
-          new StringCodec(),
+          StringCodec.get(),
           ByteString.class,
           ByteStringCodec.getInstance());
 

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/metadata/X509CertificateCodec.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/metadata/X509CertificateCodec.java
@@ -28,9 +28,21 @@ import org.apache.hadoop.hdds.security.x509.certificate.utils.CertificateCodec;
 import org.apache.hadoop.hdds.utils.db.Codec;
 
 /**
- * Encodes and Decodes X509Certificate Class.
+ * Codec to serialize/deserialize {@link X509Certificate}.
  */
-public class X509CertificateCodec implements Codec<X509Certificate> {
+public final class X509CertificateCodec implements Codec<X509Certificate> {
+
+  private static final Codec<X509Certificate> INSTANCE =
+      new X509CertificateCodec();
+
+  public static Codec<X509Certificate> get() {
+    return INSTANCE;
+  }
+
+  private X509CertificateCodec() {
+    // singleton
+  }
+
   @Override
   public byte[] toPersistedFormat(X509Certificate object) throws IOException {
     try {

--- a/hadoop-ozone/interface-storage/src/main/java/org/apache/hadoop/ozone/om/codec/TokenIdentifierCodec.java
+++ b/hadoop-ozone/interface-storage/src/main/java/org/apache/hadoop/ozone/om/codec/TokenIdentifierCodec.java
@@ -27,9 +27,20 @@ import java.io.IOException;
 import java.nio.BufferUnderflowException;
 
 /**
- * Codec to encode TokenIdentifierCodec as byte array.
+ * Codec to serialize/deserialize {@link OzoneTokenIdentifier}.
  */
-public class TokenIdentifierCodec implements Codec<OzoneTokenIdentifier> {
+public final class TokenIdentifierCodec implements Codec<OzoneTokenIdentifier> {
+
+  private static final Codec<OzoneTokenIdentifier> INSTANCE =
+      new TokenIdentifierCodec();
+
+  public static Codec<OzoneTokenIdentifier> get() {
+    return INSTANCE;
+  }
+
+  private TokenIdentifierCodec() {
+    // singleton
+  }
 
   @Override
   public byte[] toPersistedFormat(OzoneTokenIdentifier object) {

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmMetadataManagerImpl.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmMetadataManagerImpl.java
@@ -574,7 +574,7 @@ public class OmMetadataManagerImpl implements OMMetadataManager,
         .addTable(TENANT_STATE_TABLE)
         .addTable(SNAPSHOT_INFO_TABLE)
         .addTable(SNAPSHOT_RENAMED_TABLE)
-        .addCodec(OzoneTokenIdentifier.class, new TokenIdentifierCodec())
+        .addCodec(OzoneTokenIdentifier.class, TokenIdentifierCodec.get())
         .addCodec(OmKeyInfo.class, OmKeyInfo.getCodec(true))
         .addCodec(RepeatedOmKeyInfo.class, RepeatedOmKeyInfo.getCodec(true))
         .addCodec(OmBucketInfo.class, OmBucketInfo.getCodec())

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmSnapshotManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmSnapshotManager.java
@@ -353,8 +353,7 @@ public final class OmSnapshotManager implements AutoCloseable {
     // DiffReportEntry codec for Diff Report.
     registry.addCodec(SnapshotDiffReportOzone.DiffReportEntry.class,
         SnapshotDiffReportOzone.getDiffReportEntryCodec());
-    registry.addCodec(SnapshotDiffJob.class,
-        new SnapshotDiffJob.SnapshotDiffJobCodec());
+    registry.addCodec(SnapshotDiffJob.class, SnapshotDiffJob.getCodec());
     return registry.build();
   }
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/codec/OMDBDefinition.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/codec/OMDBDefinition.java
@@ -54,7 +54,7 @@ public class OMDBDefinition implements DBDefinition {
             new DBColumnFamilyDefinition<>(
                     OmMetadataManagerImpl.DELETED_TABLE,
                     String.class,
-                    new StringCodec(),
+                    StringCodec.get(),
                     RepeatedOmKeyInfo.class,
                     RepeatedOmKeyInfo.getCodec(true));
 
@@ -63,7 +63,7 @@ public class OMDBDefinition implements DBDefinition {
             new DBColumnFamilyDefinition<>(
                     OmMetadataManagerImpl.USER_TABLE,
                     String.class,
-                    new StringCodec(),
+                    StringCodec.get(),
                     PersistedUserVolumeInfo.class,
                     Proto2Codec.get(PersistedUserVolumeInfo.class));
 
@@ -72,7 +72,7 @@ public class OMDBDefinition implements DBDefinition {
             new DBColumnFamilyDefinition<>(
                     OmMetadataManagerImpl.VOLUME_TABLE,
                     String.class,
-                    new StringCodec(),
+                    StringCodec.get(),
                     OmVolumeArgs.class,
                     OmVolumeArgs.getCodec());
 
@@ -81,7 +81,7 @@ public class OMDBDefinition implements DBDefinition {
             new DBColumnFamilyDefinition<>(
                     OmMetadataManagerImpl.OPEN_KEY_TABLE,
                     String.class,
-                    new StringCodec(),
+                    StringCodec.get(),
                     OmKeyInfo.class,
                     OmKeyInfo.getCodec(true));
 
@@ -90,7 +90,7 @@ public class OMDBDefinition implements DBDefinition {
             new DBColumnFamilyDefinition<>(
                     OmMetadataManagerImpl.KEY_TABLE,
                     String.class,
-                    new StringCodec(),
+                    StringCodec.get(),
                     OmKeyInfo.class,
                     OmKeyInfo.getCodec(true));
 
@@ -99,7 +99,7 @@ public class OMDBDefinition implements DBDefinition {
             new DBColumnFamilyDefinition<>(
                     OmMetadataManagerImpl.BUCKET_TABLE,
                     String.class,
-                    new StringCodec(),
+                    StringCodec.get(),
                     OmBucketInfo.class,
                     OmBucketInfo.getCodec());
 
@@ -108,7 +108,7 @@ public class OMDBDefinition implements DBDefinition {
             new DBColumnFamilyDefinition<>(
                     OmMetadataManagerImpl.MULTIPARTINFO_TABLE,
                     String.class,
-                    new StringCodec(),
+                    StringCodec.get(),
                     OmMultipartKeyInfo.class,
                     OmMultipartKeyInfo.getCodec());
 
@@ -117,7 +117,7 @@ public class OMDBDefinition implements DBDefinition {
             new DBColumnFamilyDefinition<>(
                     OmMetadataManagerImpl.PREFIX_TABLE,
                     String.class,
-                    new StringCodec(),
+                    StringCodec.get(),
                     OmPrefixInfo.class,
                     OmPrefixInfo.getCodec());
 
@@ -126,7 +126,7 @@ public class OMDBDefinition implements DBDefinition {
             new DBColumnFamilyDefinition<>(
                     OmMetadataManagerImpl.DELEGATION_TOKEN_TABLE,
                     OzoneTokenIdentifier.class,
-                    new TokenIdentifierCodec(),
+                    TokenIdentifierCodec.get(),
                     Long.class,
                     LongCodec.get());
 
@@ -135,7 +135,7 @@ public class OMDBDefinition implements DBDefinition {
             new DBColumnFamilyDefinition<>(
                     OmMetadataManagerImpl.S3_SECRET_TABLE,
                     String.class,
-                    new StringCodec(),
+                    StringCodec.get(),
                     S3SecretValue.class,
                     S3SecretValue.getCodec());
 
@@ -144,7 +144,7 @@ public class OMDBDefinition implements DBDefinition {
             new DBColumnFamilyDefinition<>(
                     OmMetadataManagerImpl.TRANSACTION_INFO_TABLE,
                     String.class,
-                    new StringCodec(),
+                    StringCodec.get(),
                     TransactionInfo.class,
                     TransactionInfo.getCodec());
 
@@ -153,7 +153,7 @@ public class OMDBDefinition implements DBDefinition {
             new DBColumnFamilyDefinition<>(
                     OmMetadataManagerImpl.DIRECTORY_TABLE,
                     String.class,
-                    new StringCodec(),
+                    StringCodec.get(),
                     OmDirectoryInfo.class,
                     OmDirectoryInfo.getCodec());
 
@@ -162,7 +162,7 @@ public class OMDBDefinition implements DBDefinition {
             new DBColumnFamilyDefinition<>(
                     OmMetadataManagerImpl.FILE_TABLE,
                     String.class,
-                    new StringCodec(),
+                    StringCodec.get(),
                     OmKeyInfo.class,
                     OmKeyInfo.getCodec(true));
 
@@ -171,23 +171,23 @@ public class OMDBDefinition implements DBDefinition {
             new DBColumnFamilyDefinition<>(
                   OmMetadataManagerImpl.OPEN_FILE_TABLE,
                   String.class,
-                  new StringCodec(),
+                  StringCodec.get(),
                   OmKeyInfo.class,
                   OmKeyInfo.getCodec(true));
 
   public static final DBColumnFamilyDefinition<String, OmKeyInfo>
       DELETED_DIR_TABLE =
       new DBColumnFamilyDefinition<>(OmMetadataManagerImpl.DELETED_DIR_TABLE,
-          String.class, new StringCodec(), OmKeyInfo.class,
+          String.class, StringCodec.get(), OmKeyInfo.class,
           OmKeyInfo.getCodec(true));
 
   public static final DBColumnFamilyDefinition<String, String>
       META_TABLE = new DBColumnFamilyDefinition<>(
           OmMetadataManagerImpl.META_TABLE,
           String.class,
-          new StringCodec(),
+          StringCodec.get(),
           String.class,
-          new StringCodec());
+          StringCodec.get());
 
   // Tables for multi-tenancy
 
@@ -196,7 +196,7 @@ public class OMDBDefinition implements DBDefinition {
             new DBColumnFamilyDefinition<>(
                     OmMetadataManagerImpl.TENANT_ACCESS_ID_TABLE,
                     String.class,  // accessId
-                    new StringCodec(),
+                    StringCodec.get(),
                     OmDBAccessIdInfo.class,  // tenantId, secret, principal
                     OmDBAccessIdInfo.getCodec());
 
@@ -205,7 +205,7 @@ public class OMDBDefinition implements DBDefinition {
             new DBColumnFamilyDefinition<>(
                     OmMetadataManagerImpl.PRINCIPAL_TO_ACCESS_IDS_TABLE,
                     String.class,  // User principal
-                    new StringCodec(),
+                    StringCodec.get(),
                     OmDBUserPrincipalInfo.class,  // List of accessIds
                     OmDBUserPrincipalInfo.getCodec());
 
@@ -214,7 +214,7 @@ public class OMDBDefinition implements DBDefinition {
             new DBColumnFamilyDefinition<>(
                     OmMetadataManagerImpl.TENANT_STATE_TABLE,
                     String.class,  // tenantId (tenant name)
-                    new StringCodec(),
+                    StringCodec.get(),
                     OmDBTenantState.class,
                     OmDBTenantState.getCodec());
 
@@ -225,7 +225,7 @@ public class OMDBDefinition implements DBDefinition {
       new DBColumnFamilyDefinition<>(
           OmMetadataManagerImpl.SNAPSHOT_INFO_TABLE,
           String.class,  // snapshot path
-          new StringCodec(),
+          StringCodec.get(),
           SnapshotInfo.class,
           SnapshotInfo.getCodec());
 
@@ -244,9 +244,9 @@ public class OMDBDefinition implements DBDefinition {
       new DBColumnFamilyDefinition<>(
           OmMetadataManagerImpl.SNAPSHOT_RENAMED_TABLE,
           String.class,  // /volumeName/bucketName/objectID
-          new StringCodec(),
+          StringCodec.get(),
           String.class, // path to key in prev snapshot's key(file)/dir Table.
-          new StringCodec());
+          StringCodec.get());
 
   @Override
   public String getName() {

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/snapshot/SnapshotDiffJob.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/snapshot/SnapshotDiffJob.java
@@ -29,6 +29,14 @@ import org.apache.hadoop.ozone.snapshot.SnapshotDiffResponse.JobStatus;
  * POJO for Snapshot diff job.
  */
 public class SnapshotDiffJob {
+
+  private static final Codec<SnapshotDiffJob> CODEC =
+      new SnapshotDiffJobCodec();
+
+  public static Codec<SnapshotDiffJob> getCodec() {
+    return CODEC;
+  }
+
   private long creationTime;
   private String jobId;
   private JobStatus status;
@@ -180,7 +188,8 @@ public class SnapshotDiffJob {
   /**
    * Codec to encode SnapshotDiffJob as byte array.
    */
-  public static class SnapshotDiffJobCodec implements Codec<SnapshotDiffJob> {
+  private static final class SnapshotDiffJobCodec
+      implements Codec<SnapshotDiffJob> {
 
     private static final ObjectMapper MAPPER = new ObjectMapper()
         .setSerializationInclusion(JsonInclude.Include.NON_NULL)

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/service/TestSnapshotDiffCleanupService.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/service/TestSnapshotDiffCleanupService.java
@@ -171,8 +171,7 @@ public class TestSnapshotDiffCleanupService {
     // DiffReportEntry codec for Diff Report.
     b.addCodec(SnapshotDiffReportOzone.DiffReportEntry.class,
         SnapshotDiffReportOzone.getDiffReportEntryCodec());
-    b.addCodec(SnapshotDiffJob.class,
-        new SnapshotDiffJob.SnapshotDiffJobCodec());
+    b.addCodec(SnapshotDiffJob.class, SnapshotDiffJob.getCodec());
     codecRegistry = b.build();
     emptyReportEntry = codecRegistry.asRawData("{}");
 

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/security/TestOzoneTokenIdentifier.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/security/TestOzoneTokenIdentifier.java
@@ -46,6 +46,7 @@ import java.util.Map;
 import org.apache.hadoop.fs.FileUtil;
 import org.apache.hadoop.hdds.conf.ConfigurationSource;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import org.apache.hadoop.hdds.utils.db.Codec;
 import org.apache.hadoop.io.Text;
 import org.apache.hadoop.ozone.om.codec.TokenIdentifierCodec;
 import org.apache.hadoop.security.ssl.KeyStoreTestUtil;
@@ -335,7 +336,7 @@ public class TestOzoneTokenIdentifier {
     idWrite.setOmServiceId("defaultServiceId");
 
     byte[] oldIdBytes = idWrite.getBytes();
-    TokenIdentifierCodec idCodec = new TokenIdentifierCodec();
+    Codec<OzoneTokenIdentifier> idCodec = TokenIdentifierCodec.get();
 
     OzoneTokenIdentifier idRead = null;
     try {

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/codec/NSSummaryCodec.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/codec/NSSummaryCodec.java
@@ -35,18 +35,28 @@ import java.util.HashSet;
 import java.util.Set;
 
 /**
- * Codec for Namespace Summary.
+ * Codec to serialize/deserialize {@link NSSummary}.
  */
-public class NSSummaryCodec implements Codec<NSSummary> {
+public final class NSSummaryCodec implements Codec<NSSummary> {
 
-  private final Codec<Integer> integerCodec = new IntegerCodec();
-  private final Codec<Short> shortCodec = new ShortCodec();
+  private static final Codec<NSSummary> INSTANCE = new NSSummaryCodec();
+
+  public static Codec<NSSummary> get() {
+    return INSTANCE;
+  }
+
+  private final Codec<Integer> integerCodec = IntegerCodec.get();
+  private final Codec<Short> shortCodec = ShortCodec.get();
   private final Codec<Long> longCodec = LongCodec.get();
-  private final Codec<String> stringCodec = new StringCodec();
+  private final Codec<String> stringCodec = StringCodec.get();
   // 1 int fields + 41-length int array
   // + 2 dummy field to track list size/dirName length
   private static final int NUM_OF_INTS =
       3 + ReconConstants.NUM_OF_FILE_SIZE_BINS;
+
+  private NSSummaryCodec() {
+    // singleton
+  }
 
   @Override
   public byte[] toPersistedFormat(NSSummary object) throws IOException {

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/spi/impl/ContainerKeyPrefixCodec.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/spi/impl/ContainerKeyPrefixCodec.java
@@ -32,11 +32,23 @@ import com.google.common.base.Preconditions;
 import com.google.common.primitives.Longs;
 
 /**
- * Codec to encode ContainerKeyPrefix as byte array.
+ * Codec to serialize/deserialize {@link ContainerKeyPrefix}.
  */
-public class ContainerKeyPrefixCodec implements Codec<ContainerKeyPrefix> {
+public final class ContainerKeyPrefixCodec
+    implements Codec<ContainerKeyPrefix> {
 
   private static final String KEY_DELIMITER = "_";
+
+  private static final Codec<ContainerKeyPrefix> INSTANCE =
+      new ContainerKeyPrefixCodec();
+
+  public static Codec<ContainerKeyPrefix> get() {
+    return INSTANCE;
+  }
+
+  private ContainerKeyPrefixCodec() {
+    // singleton
+  }
 
   @Override
   public byte[] toPersistedFormat(ContainerKeyPrefix containerKeyPrefix)

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/spi/impl/KeyPrefixContainerCodec.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/spi/impl/KeyPrefixContainerCodec.java
@@ -30,9 +30,21 @@ import java.nio.ByteBuffer;
 import static org.apache.commons.compress.utils.CharsetNames.UTF_8;
 
 /**
- * Codec to encode KeyPrefixContainer as byte array.
+ * Codec to serialize/deserialize {@link KeyPrefixContainer}.
  */
-public class KeyPrefixContainerCodec implements Codec<KeyPrefixContainer> {
+public final class KeyPrefixContainerCodec
+    implements Codec<KeyPrefixContainer> {
+
+  private static final Codec<KeyPrefixContainer> INSTANCE =
+      new KeyPrefixContainerCodec();
+
+  public static Codec<KeyPrefixContainer> get() {
+    return INSTANCE;
+  }
+
+  private KeyPrefixContainerCodec() {
+    // singleton
+  }
 
   private static final String KEY_DELIMITER = "_";
 

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/spi/impl/ReconDBDefinition.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/spi/impl/ReconDBDefinition.java
@@ -44,18 +44,18 @@ public class ReconDBDefinition implements DBDefinition {
       new DBColumnFamilyDefinition<>(
           "containerKeyTable",
           ContainerKeyPrefix.class,
-          new ContainerKeyPrefixCodec(),
+          ContainerKeyPrefixCodec.get(),
           Integer.class,
-          new IntegerCodec());
+          IntegerCodec.get());
 
   public static final DBColumnFamilyDefinition<KeyPrefixContainer, Integer>
       KEY_CONTAINER =
       new DBColumnFamilyDefinition<>(
           "keyContainerTable",
           KeyPrefixContainer.class,
-          new KeyPrefixContainerCodec(),
+          KeyPrefixContainerCodec.get(),
           Integer.class,
-          new IntegerCodec());
+          IntegerCodec.get());
 
   public static final DBColumnFamilyDefinition<Long, Long>
       CONTAINER_KEY_COUNT =
@@ -81,7 +81,7 @@ public class ReconDBDefinition implements DBDefinition {
           Long.class,
           LongCodec.get(),
           NSSummary.class,
-          new NSSummaryCodec());
+          NSSummaryCodec.get());
 
   // Container Replica History with bcsId tracking.
   public static final DBColumnFamilyDefinition

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/TestReconCodecs.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/TestReconCodecs.java
@@ -37,7 +37,7 @@ public class TestReconCodecs {
     ContainerKeyPrefix containerKeyPrefix = new ContainerKeyPrefix(
         System.currentTimeMillis(), "TestKeyPrefix", 0);
 
-    Codec<ContainerKeyPrefix> codec = new ContainerKeyPrefixCodec();
+    Codec<ContainerKeyPrefix> codec = ContainerKeyPrefixCodec.get();
     byte[] persistedFormat = codec.toPersistedFormat(containerKeyPrefix);
     Assertions.assertTrue(persistedFormat != null);
     ContainerKeyPrefix fromPersistedFormat =
@@ -48,7 +48,7 @@ public class TestReconCodecs {
   @Test
   public void testIntegerCodec() throws IOException {
     Integer i = 1000;
-    Codec<Integer> codec = new IntegerCodec();
+    Codec<Integer> codec = IntegerCodec.get();
     byte[] persistedFormat = codec.toPersistedFormat(i);
     Assertions.assertTrue(persistedFormat != null);
     Integer fromPersistedFormat =


### PR DESCRIPTION
## What changes were proposed in this pull request?

DB codec implementations can be singletons, as they are stateless.  Some classes already are, this PR changes the rest.

https://issues.apache.org/jira/browse/HDDS-8559

## How was this patch tested?

Existing tests.

CI:
https://github.com/adoroszlai/hadoop-ozone/actions/runs/5078351190