### PR TITLE
HDDS-8676. Speed up TestContainerBalancer

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/balancer/ContainerBalancerTask.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/balancer/ContainerBalancerTask.java
@@ -228,7 +228,7 @@ public class ContainerBalancerTask implements Runnable {
           long sleepTime = 3 * nodeReportInterval;
           LOG.info("ContainerBalancer will sleep for {} ms while waiting " +
               "for updated usage information from Datanodes.", sleepTime);
-          Thread.sleep(nodeReportInterval);
+          Thread.sleep(sleepTime);
         } catch (InterruptedException e) {
           LOG.info("Container Balancer was interrupted while waiting for" +
               "datanodes refreshing volume usage info");

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/balancer/TestContainerBalancer.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/balancer/TestContainerBalancer.java
@@ -37,17 +37,21 @@ import org.apache.ozone.test.GenericTestUtils;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.mockito.Mockito;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.slf4j.event.Level;
 
+import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_NODE_REPORT_INTERVAL;
+import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_SCM_WAIT_TIME_AFTER_SAFE_MODE_EXIT;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 /**
  * Tests for {@link ContainerBalancer}.
  */
+@Timeout(60)
 public class TestContainerBalancer {
   private static final Logger LOG =
       LoggerFactory.getLogger(TestContainerBalancer.class);
@@ -66,6 +70,9 @@ public class TestContainerBalancer {
   public void setup() throws IOException, NodeNotFoundException,
       TimeoutException {
     conf = new OzoneConfiguration();
+    conf.setTimeDuration(HDDS_SCM_WAIT_TIME_AFTER_SAFE_MODE_EXIT,
+        5, TimeUnit.SECONDS);
+    conf.setTimeDuration(HDDS_NODE_REPORT_INTERVAL, 2, TimeUnit.SECONDS);
     scm = Mockito.mock(StorageContainerManager.class);
     serviceStateManager = Mockito.mock(StatefulServiceStateManagerImpl.class);
     balancerConfiguration =
@@ -73,7 +80,7 @@ public class TestContainerBalancer {
     balancerConfiguration.setThreshold(10);
     balancerConfiguration.setIterations(10);
     // Note: this will make container balancer task to wait for running
-    // for 60 sec as default and ensure below test case have sufficient
+    // for 6 sec as default and ensure below test case have sufficient
     // time to verify, and interrupt when stop.
     balancerConfiguration.setTriggerDuEnable(true);
     conf.setFromObject(balancerConfiguration);
@@ -230,9 +237,8 @@ public class TestContainerBalancer {
       throws IllegalContainerBalancerStateException, IOException,
       InvalidContainerBalancerConfigurationException, TimeoutException,
       InterruptedException {
-    long delayDuration = 10;
-    conf.setTimeDuration("hdds.scm.wait.time.after.safemode.exit",
-        delayDuration, TimeUnit.SECONDS);
+    long delayDuration = conf.getTimeDuration(
+        HDDS_SCM_WAIT_TIME_AFTER_SAFE_MODE_EXIT, 10, TimeUnit.SECONDS);
     balancerConfiguration =
         conf.getObject(ContainerBalancerConfiguration.class);
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Container balancer may fail to interrupt the current balancing thread.  We've seen various test execution times from 1 second to 10 minutes.

This change is a workaround to reduce test execution time.

1. Reduce node report interval from 1 minute to 2 seconds, safe mode wait time from 5 minutes to 5 seconds.
2. Fix mismatch between sleep time being logged and actual sleep duration.
3. Add a unique ID to balancer thread name so we can distinguish between runs.

https://issues.apache.org/jira/browse/HDDS-8676

## How was this patch tested?

1000x runs passed in CI, each batch of 100 runs in ~1 hour.
https://github.com/adoroszlai/hadoop-ozone/actions/runs/5077320448

Regular CI:
https://github.com/adoroszlai/hadoop-ozone/actions/runs/5079590645