### PR TITLE
HDDS-8706. Remove ContainerSet.getContainerIterator().

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/impl/ContainerSet.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/impl/ContainerSet.java
@@ -196,14 +196,6 @@ public class ContainerSet implements Iterable<Container<?>> {
     });
   }
 
-  /**
-   * Return an container Iterator over {@link ContainerSet#containerMap}.
-   * @return {@literal Iterator<Container<?>>}
-   */
-  public Iterator<Container<?>> getContainerIterator() {
-    return iterator();
-  }
-
   @Override
   public Iterator<Container<?>> iterator() {
     return containerMap.values().iterator();

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/transport/server/ratis/XceiverServerRatis.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/transport/server/ratis/XceiverServerRatis.java
@@ -24,7 +24,6 @@ import java.net.InetSocketAddress;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -65,6 +64,7 @@ import org.apache.hadoop.hdds.utils.HddsServerUtil;
 import org.apache.hadoop.ozone.OzoneConfigKeys;
 import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.hadoop.ozone.container.common.impl.ContainerData;
+import org.apache.hadoop.ozone.container.common.interfaces.Container;
 import org.apache.hadoop.ozone.container.common.interfaces.ContainerDispatcher;
 import org.apache.hadoop.ozone.container.common.statemachine.StateContext;
 import org.apache.hadoop.ozone.container.common.transport.server.XceiverServerSpi;
@@ -729,10 +729,8 @@ public final class XceiverServerRatis implements XceiverServerSpi {
 
   private long calculatePipelineBytesWritten(HddsProtos.PipelineID pipelineID) {
     long bytesWritten = 0;
-    Iterator<org.apache.hadoop.ozone.container.common.interfaces.Container<?>>
-        containerIt = containerController.getContainers();
-    while (containerIt.hasNext()) {
-      ContainerData containerData = containerIt.next().getContainerData();
+    for (Container<?> container : containerController.getContainers()) {
+      ContainerData containerData = container.getContainerData();
       if (containerData.getOriginPipelineId()
           .compareTo(pipelineID.getId()) == 0) {
         bytesWritten += containerData.getWriteBytes();

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/ozoneimpl/BackgroundContainerMetadataScanner.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/ozoneimpl/BackgroundContainerMetadataScanner.java
@@ -50,7 +50,7 @@ public class BackgroundContainerMetadataScanner extends
 
   @Override
   public Iterator<Container<?>> getContainerIterator() {
-    return controller.getContainers();
+    return controller.getContainers().iterator();
   }
 
   @VisibleForTesting

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/ozoneimpl/ContainerController.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/ozoneimpl/ContainerController.java
@@ -192,11 +192,7 @@ public class ContainerController {
     return handlers.get(container.getContainerType());
   }
 
-  public Iterator<Container<?>> getContainers() {
-    return containerSet.getContainerIterator();
-  }
-
-  public Iterable<Container<?>> getContainerSet() {
+  public Iterable<Container<?>> getContainers() {
     return containerSet;
   }
 

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/upgrade/DataNodeUpgradeFinalizer.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/upgrade/DataNodeUpgradeFinalizer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -23,7 +23,6 @@ import static org.apache.hadoop.ozone.upgrade.UpgradeFinalizer.Status.FINALIZATI
 import static org.apache.hadoop.ozone.upgrade.UpgradeFinalizer.Status.FINALIZATION_REQUIRED;
 
 import java.io.IOException;
-import java.util.Iterator;
 
 import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos;
 import org.apache.hadoop.hdds.upgrade.HDDSLayoutFeature;
@@ -63,10 +62,8 @@ public class DataNodeUpgradeFinalizer extends
     // Lets be sure that we do not have any open container before we return
     // from here. This function should be called in its own finalizer thread
     // context.
-    Iterator<Container<?>> containerIt =
-        dsm.getContainer().getController().getContainers();
-    while (containerIt.hasNext()) {
-      Container ctr = containerIt.next();
+    for (Container<?> ctr :
+        dsm.getContainer().getController().getContainers()) {
       ContainerProtos.ContainerDataProto.State state = ctr.getContainerState();
       long id = ctr.getContainerData().getContainerID();
       switch (state) {
@@ -76,7 +73,6 @@ public class DataNodeUpgradeFinalizer extends
             + "state is: {}", id, state);
         return false;
       default:
-        continue;
       }
     }
     return true;

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/TestBlockDeletingService.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/TestBlockDeletingService.java
@@ -830,7 +830,7 @@ public class TestBlockDeletingService {
 
     // get container meta data
     KeyValueContainer container =
-        (KeyValueContainer) containerSet.getContainerIterator().next();
+        (KeyValueContainer) containerSet.iterator().next();
     KeyValueContainerData data = container.getContainerData();
     try (DBHandle meta = BlockUtils.getDB(data, conf)) {
       LogCapturer newLog = LogCapturer.captureLogs(BackgroundService.LOG);

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/TestStaleRecoveringContainerScrubbingService.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/TestStaleRecoveringContainerScrubbingService.java
@@ -52,7 +52,6 @@ import java.time.Instant;
 import java.time.ZoneOffset;
 import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -178,10 +177,8 @@ public class TestStaleRecoveringContainerScrubbingService {
     testClock.fastForward(1000L);
     srcss.runPeriodicalTaskNow();
     //recovering container should be scrubbed since recovering timeout
-    Assert.assertTrue(containerSet.containerCount() == 10);
-    Iterator<Container<?>> it = containerSet.getContainerIterator();
-    while (it.hasNext()) {
-      Container<?> entry = it.next();
+    Assert.assertEquals(10, containerSet.containerCount());
+    for (Container<?> entry : containerSet) {
       Assert.assertEquals(entry.getContainerState(),
               containerStateMap.get(entry.getContainerData().getContainerID()));
     }
@@ -194,10 +191,8 @@ public class TestStaleRecoveringContainerScrubbingService {
     testClock.fastForward(1000L);
     srcss.runPeriodicalTaskNow();
     //recovering container should not be scrubbed
-    Assert.assertTrue(containerSet.containerCount() == 15);
-    it = containerSet.getContainerIterator();
-    while (it.hasNext()) {
-      Container<?> entry = it.next();
+    Assert.assertEquals(15, containerSet.containerCount());
+    for (Container<?> entry : containerSet) {
       Assert.assertEquals(entry.getContainerState(),
               containerStateMap.get(entry.getContainerData().getContainerID()));
     }

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/impl/TestContainerSet.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/impl/TestContainerSet.java
@@ -119,11 +119,8 @@ public class TestContainerSet {
 
     assertEquals(10, containerSet.containerCount());
 
-    Iterator<Container<?>> iterator = containerSet.getContainerIterator();
-
     int count = 0;
-    while (iterator.hasNext()) {
-      Container kv = iterator.next();
+    for (Container<?> kv : containerSet) {
       ContainerData containerData = kv.getContainerData();
       long containerId = containerData.getContainerID();
       if (containerId % 2 == 0) {

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/ozoneimpl/TestContainerScannersAbstract.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/ozoneimpl/TestContainerScannersAbstract.java
@@ -148,7 +148,7 @@ public abstract class TestContainerScannersAbstract {
         healthy, corruptData, openCorruptMetadata);
     ContainerController mock = mock(ContainerController.class);
     when(mock.getContainers(vol)).thenReturn(containers.iterator());
-    when(mock.getContainers()).thenReturn(containers.iterator());
+    when(mock.getContainers()).thenReturn(containers);
 
     return mock;
   }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/upgrade/TestHddsUpgradeUtils.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/upgrade/TestHddsUpgradeUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -40,7 +40,6 @@ import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.util.Arrays;
-import java.util.Iterator;
 import java.util.List;
 import java.util.concurrent.TimeoutException;
 
@@ -121,14 +120,9 @@ public final class TestHddsUpgradeUtils {
     // pipeline to use.
     PipelineManager scmPipelineManager = scm.getPipelineManager();
     try {
-      GenericTestUtils.waitFor(() -> {
-        int pipelineCount = scmPipelineManager.getPipelines(RATIS_THREE, OPEN)
-            .size();
-        if (pipelineCount >= 1) {
-          return true;
-        }
-        return false;
-      }, 500, 60000);
+      GenericTestUtils.waitFor(
+          () -> scmPipelineManager.getPipelines(RATIS_THREE, OPEN).size() >= 1,
+          500, 60000);
     } catch (TimeoutException | InterruptedException e) {
       Assert.fail("Timeout waiting for Upgrade to complete on SCM.");
     }
@@ -169,9 +163,8 @@ public final class TestHddsUpgradeUtils {
     for (HddsDatanodeService dataNode : datanodes) {
       DatanodeStateMachine dsm = dataNode.getDatanodeStateMachine();
       // Also verify that all the existing containers are open.
-      for (Iterator<Container<?>> it =
-           dsm.getContainer().getController().getContainers(); it.hasNext();) {
-        Container container = it.next();
+      for (Container<?> container :
+          dsm.getContainer().getController().getContainers()) {
         Assert.assertSame(container.getContainerState(),
             ContainerProtos.ContainerDataProto.State.OPEN);
         countContainers++;
@@ -224,9 +217,8 @@ public final class TestHddsUpgradeUtils {
       Assert.assertTrue(dnVersionManager.getMetadataLayoutVersion() >= 1);
 
       // Also verify that all the existing containers are closed.
-      for (Iterator<Container<?>> it =
-           dsm.getContainer().getController().getContainers(); it.hasNext();) {
-        Container<?> container = it.next();
+      for (Container<?> container :
+           dsm.getContainer().getController().getContainers()) {
         Assert.assertTrue("Container had unexpected state " +
                 container.getContainerState(),
             closeStates.stream().anyMatch(

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/container/InspectSubcommand.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/container/InspectSubcommand.java
@@ -52,7 +52,7 @@ public class InspectSubcommand implements Callable<Void> {
     final KeyValueContainerMetadataInspector inspector
         = new KeyValueContainerMetadataInspector(
             KeyValueContainerMetadataInspector.Mode.INSPECT);
-    for (Container<?> container : parent.getController().getContainerSet()) {
+    for (Container<?> container : parent.getController().getContainers()) {
       final ContainerData data = container.getContainerData();
       if (!(data instanceof KeyValueContainerData)) {
         continue;

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/container/ListSubcommand.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/container/ListSubcommand.java
@@ -22,7 +22,6 @@ import org.apache.hadoop.ozone.container.common.interfaces.Container;
 import picocli.CommandLine;
 import picocli.CommandLine.Command;
 
-import java.util.Iterator;
 import java.util.concurrent.Callable;
 
 import static org.apache.hadoop.ozone.debug.container.ContainerCommands.outputContainer;
@@ -42,9 +41,7 @@ public class ListSubcommand implements Callable<Void> {
   public Void call() throws Exception {
     parent.loadContainersFromVolumes();
 
-    Iterator<Container<?>> containerIt = parent.getController().getContainers();
-    while (containerIt.hasNext()) {
-      Container container = containerIt.next();
+    for (Container<?> container : parent.getController().getContainers()) {
       outputContainer(container.getContainerData());
     }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Use the iterator() method (and the Iterable interface) instead.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-8706

## How was this patch tested?

Modifying existing tests.