### PR TITLE
HDDS-7457. Intermittent failure in TestContainerPersistence

### DIFF
--- a/hadoop-hdds/common/src/test/java/org/apache/hadoop/ozone/container/ContainerTestHelper.java
+++ b/hadoop-hdds/common/src/test/java/org/apache/hadoop/ozone/container/ContainerTestHelper.java
@@ -27,7 +27,6 @@ import java.util.UUID;
 import java.util.concurrent.ThreadLocalRandom;
 
 import org.apache.hadoop.conf.StorageUnit;
-import org.apache.hadoop.hdds.HddsUtils;
 import org.apache.hadoop.hdds.client.BlockID;
 import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos;
 import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.ChecksumType;
@@ -38,6 +37,7 @@ import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.DatanodeBl
 import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.KeyValue;
 import org.apache.hadoop.hdds.scm.pipeline.MockPipeline;
 import org.apache.hadoop.hdds.scm.pipeline.Pipeline;
+import org.apache.hadoop.hdds.utils.UniqueId;
 import org.apache.hadoop.ozone.common.Checksum;
 import org.apache.hadoop.ozone.common.ChunkBuffer;
 import org.apache.hadoop.ozone.common.OzoneChecksumException;
@@ -542,14 +542,11 @@ public final class ContainerTestHelper {
   }
 
   public static BlockID getTestBlockID(long containerID) {
-    // Add 2ms delay so that localID based on UtcTime
-    // won't collide.
-    sleep(2);
-    return new BlockID(containerID, HddsUtils.getTime());
+    return new BlockID(containerID, UniqueId.next());
   }
 
   public static long getTestContainerID() {
-    return HddsUtils.getTime();
+    return UniqueId.next();
   }
 
   public static String getFixedLengthString(String string, int length) {

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/ContainerTestUtils.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/ContainerTestUtils.java
@@ -19,7 +19,6 @@ package org.apache.hadoop.ozone.container.common;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.conf.StorageUnit;
-import org.apache.hadoop.hdds.HddsUtils;
 import org.apache.hadoop.hdds.conf.ConfigurationSource;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
@@ -196,7 +195,7 @@ public final class ContainerTestUtils {
       throws IOException {
     VolumeChoosingPolicy volumeChoosingPolicy =
         new RoundRobinVolumeChoosingPolicy();
-    long containerId = HddsUtils.getTime();
+    long containerId = ContainerTestHelper.getTestContainerID();
     ContainerLayoutVersion layout = ContainerLayoutVersion.FILE_PER_BLOCK;
 
     KeyValueContainerData keyValueContainerData = new KeyValueContainerData(


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fix intermittent failure in `TestContainerPersistence`:

```
StorageContainerException: Container creation failed because ContainerFile already exists
	at org.apache.hadoop.ozone.container.keyvalue.KeyValueContainer.create(KeyValueContainer.java:191)
	at org.apache.hadoop.ozone.container.common.impl.TestContainerPersistence.addContainer(TestContainerPersistence.java:200)
	at org.apache.hadoop.ozone.container.common.impl.TestContainerPersistence.testGetContainerReports(TestContainerPersistence.java:311)
```

Since "test container ID" was simply current time, next container could have the same ID.

https://issues.apache.org/jira/browse/HDDS-7457

## How was this patch tested?

10x100 repetitions:
https://github.com/adoroszlai/hadoop-ozone/actions/runs/5097065042

Regular CI:
https://github.com/adoroszlai/hadoop-ozone/actions/runs/5097300579