### PR TITLE
HDDS-8571. Support get using RocksDB ByteBuffer APIs.

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/utils/db/Proto2Codec.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/utils/db/Proto2Codec.java
@@ -72,7 +72,7 @@ public final class Proto2Codec<M extends MessageLite>
   public CodecBuffer toCodecBuffer(@Nonnull M message,
       IntFunction<CodecBuffer> allocator) throws IOException {
     final int size = message.getSerializedSize();
-    return allocator.apply(size).put(writeTo(message, size));
+    return allocator.apply(size).putFromSource(writeTo(message, size));
   }
 
   private CheckedFunction<OutputStream, Integer, IOException> writeTo(

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/utils/db/Proto2Codec.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/utils/db/Proto2Codec.java
@@ -72,7 +72,7 @@ public final class Proto2Codec<M extends MessageLite>
   public CodecBuffer toCodecBuffer(@Nonnull M message,
       IntFunction<CodecBuffer> allocator) throws IOException {
     final int size = message.getSerializedSize();
-    return allocator.apply(size).putFromSource(writeTo(message, size));
+    return allocator.apply(size).put(writeTo(message, size));
   }
 
   private CheckedFunction<OutputStream, Integer, IOException> writeTo(

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/RDBTable.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/RDBTable.java
@@ -194,7 +194,7 @@ class RDBTable implements Table<byte[], byte[]> {
   }
 
   @Override
-  public String getName() throws IOException {
+  public String getName() {
     return family.getName();
   }
 

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/RDBTable.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/RDBTable.java
@@ -66,7 +66,7 @@ class RDBTable implements Table<byte[], byte[]> {
     return family;
   }
 
-  public void put(ByteBuffer key, ByteBuffer value) throws IOException {
+  void put(ByteBuffer key, ByteBuffer value) throws IOException {
     db.put(family, key, value);
   }
 
@@ -75,8 +75,8 @@ class RDBTable implements Table<byte[], byte[]> {
     db.put(family, key, value);
   }
 
-  public void putWithBatch(BatchOperation batch, CodecBuffer key,
-      CodecBuffer value) throws IOException {
+  void putWithBatch(BatchOperation batch, CodecBuffer key, CodecBuffer value)
+      throws IOException {
     if (batch instanceof RDBBatchOperation) {
       ((RDBBatchOperation) batch).put(family, key, value);
     } else {
@@ -123,6 +123,10 @@ class RDBTable implements Table<byte[], byte[]> {
   @Override
   public byte[] get(byte[] key) throws IOException {
     return db.get(family, key);
+  }
+
+  Integer get(ByteBuffer key, ByteBuffer outValue) throws IOException {
+    return db.get(family, key, outValue);
   }
 
   /**

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/RocksDatabase.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/RocksDatabase.java
@@ -38,8 +38,6 @@ import org.rocksdb.ColumnFamilyDescriptor;
 import org.rocksdb.ColumnFamilyHandle;
 import org.rocksdb.Holder;
 import org.rocksdb.LiveFileMetaData;
-import org.rocksdb.ReadOptions;
-import org.rocksdb.RocksDB;
 import org.rocksdb.RocksDBException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -715,10 +713,10 @@ public final class RocksDatabase implements Closeable {
   public Integer get(ColumnFamily family, ByteBuffer key, ByteBuffer outValue)
       throws IOException {
     assertClose();
-    try (ReadOptions options = new ReadOptions()) {
+    try (ManagedReadOptions options = new ManagedReadOptions()) {
       counter.incrementAndGet();
       final int size = db.get().get(family.getHandle(), options, key, outValue);
-      return size == RocksDB.NOT_FOUND ? null : size;
+      return size == ManagedRocksDB.NOT_FOUND ? null : size;
     } catch (RocksDBException e) {
       closeOnError(e, true);
       final String message = "get " + bytes2String(key) + " from " + family;

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/TypedTable.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/TypedTable.java
@@ -20,12 +20,12 @@ package org.apache.hadoop.hdds.utils.db;
 
 import java.io.File;
 import java.io.IOException;
-import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import com.google.common.annotations.VisibleForTesting;
 import org.apache.hadoop.hdds.utils.MetadataKeyFilters;
@@ -37,10 +37,13 @@ import org.apache.hadoop.hdds.utils.db.cache.FullTableCache;
 import org.apache.hadoop.hdds.utils.db.cache.PartialTableCache;
 import org.apache.hadoop.hdds.utils.db.cache.TableCache.CacheType;
 import org.apache.hadoop.hdds.utils.db.cache.TableCache;
-import org.apache.ratis.util.function.CheckedFunction;
+import org.apache.ratis.util.MemoizedSupplier;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import static org.apache.hadoop.hdds.utils.db.cache.CacheResult.CacheStatus.EXISTS;
 import static org.apache.hadoop.hdds.utils.db.cache.CacheResult.CacheStatus.NOT_EXIST;
+import static org.apache.ratis.util.JavaUtils.getClassSimpleName;
 /**
  * Strongly typed table implementation.
  * <p>
@@ -51,6 +54,10 @@ import static org.apache.hadoop.hdds.utils.db.cache.CacheResult.CacheStatus.NOT_
  * @param <VALUE> type of the values in the store.
  */
 public class TypedTable<KEY, VALUE> implements Table<KEY, VALUE> {
+  static final Logger LOG = LoggerFactory.getLogger(TypedTable.class);
+
+  private static final long EPOCH_DEFAULT = -1L;
+  static final int BUFFER_SIZE_DEFAULT = 4 << 10; // 4 KB
 
   private final RDBTable rawTable;
 
@@ -60,9 +67,9 @@ public class TypedTable<KEY, VALUE> implements Table<KEY, VALUE> {
   private final Codec<VALUE> valueCodec;
 
   private final boolean supportCodecBuffer;
+  private final AtomicInteger bufferSize
+      = new AtomicInteger(BUFFER_SIZE_DEFAULT);
   private final TableCache<CacheKey<KEY>, CacheValue<VALUE>> cache;
-
-  private static final long EPOCH_DEFAULT = -1L;
 
   /**
    * The same as this(rawTable, codecRegistry, keyType, valueType,
@@ -186,16 +193,15 @@ public class TypedTable<KEY, VALUE> implements Table<KEY, VALUE> {
   }
 
   /**
-   * Returns the value mapped to the given key in byte array or returns null
-   * if the key is not found.
-   *
+   * Get the value mapped to the given key.
+   * <p>
    * Caller's of this method should use synchronization mechanism, when
    * accessing. First it will check from cache, if it has entry return the
    * cloned cache value, otherwise get from the RocksDB table.
    *
    * @param key metadata key
-   * @return VALUE
-   * @throws IOException
+   * @return the mapped value; or null if the key is not found.
+   * @throws IOException when {@link #getFromTable(Object)} throw an exception.
    */
   @Override
   public VALUE get(KEY key) throws IOException {
@@ -229,15 +235,14 @@ public class TypedTable<KEY, VALUE> implements Table<KEY, VALUE> {
 
   /**
    * This method returns the value if it exists in cache, if it 
-   * does not, get the value from the underlying rockdb table. If it 
+   * does not, get the value from the underlying RockDB table. If it
    * exists in cache, it returns the same reference of the cached value.
-   * 
-   *
+   * <p>
    * Caller's of this method should use synchronization mechanism, when
    * accessing. First it will check from cache, if it has entry return the
    * cached value, otherwise get from the RocksDB table. It is caller
-   * responsibility to not to use the returned object outside the lock.
-   *
+   * responsibility not to use the returned object outside the lock.
+   * <p>
    * One example use case of this method is, when validating volume exists in
    * bucket requests and also where we need actual value of volume info. Once 
    * bucket response is added to the double buffer, only bucket info is 
@@ -245,7 +250,7 @@ public class TypedTable<KEY, VALUE> implements Table<KEY, VALUE> {
    * modifying the same cached object.
    * @param key metadata key
    * @return VALUE
-   * @throws IOException
+   * @throws IOException when {@link #getFromTable(Object)} throw an exception.
    */
   @Override
   public VALUE getReadCopy(KEY key) throws IOException {
@@ -281,18 +286,47 @@ public class TypedTable<KEY, VALUE> implements Table<KEY, VALUE> {
     }
   }
 
-  private CheckedFunction<ByteBuffer, Integer, IOException> getFromTable(
-      CodecBuffer key) {
-    return buffer -> rawTable.get(key.asReadOnlyByteBuffer(), buffer);
+  private static int nextBufferSize(int n) {
+    // round up to the next power of 2.
+    final long roundUp = Long.highestOneBit(n) << 1;
+    return roundUp > Integer.MAX_VALUE ? Integer.MAX_VALUE : (int) roundUp;
+  }
+
+  private void increaseBufferSize(int required) {
+    final MemoizedSupplier<Integer> newBufferSize = MemoizedSupplier.valueOf(
+        () -> nextBufferSize(required));
+    final int previous = bufferSize.getAndUpdate(
+        current -> required <= current ? current : newBufferSize.get());
+    if (newBufferSize.isInitialized()) {
+      LOG.info("{}: increaseBufferSize {} -> {}",
+          this, previous, newBufferSize.get());
+    }
+  }
+
+  private VALUE getFromTableCodecBuffer(KEY key) throws IOException {
+    try (CodecBuffer inKey = keyCodec.toDirectCodecBuffer(key)) {
+      for (; ;) {
+        final int allocated = bufferSize.get();
+        try (CodecBuffer outValue = CodecBuffer.allocateDirect(allocated)) {
+          final Integer required = outValue.putFromSource(
+              buffer -> rawTable.get(inKey.asReadOnlyByteBuffer(), buffer));
+          if (required == null) {
+            // key not found
+            return null;
+          } else if (required <= allocated) {
+            // buffer size is big enough
+            return valueCodec.fromCodecBuffer(outValue);
+          }
+          // buffer size too small, retry
+          increaseBufferSize(required);
+        }
+      }
+    }
   }
 
   private VALUE getFromTable(KEY key) throws IOException {
     if (supportCodecBuffer) {
-      try (CodecBuffer outValue = CodecBuffer.allocateDirect();
-           CodecBuffer inKey = keyCodec.toDirectCodecBuffer(key)) {
-        final CodecBuffer out = outValue.put(getFromTable(inKey));
-        return out == null ? null : valueCodec.fromCodecBuffer(out);
-      }
+      return getFromTableCodecBuffer(key);
     } else {
       final byte[] keyBytes = encodeKey(key);
       byte[] valueBytes = rawTable.get(keyBytes);
@@ -335,8 +369,15 @@ public class TypedTable<KEY, VALUE> implements Table<KEY, VALUE> {
   }
 
   @Override
-  public String getName() throws IOException {
+  public String getName() {
     return rawTable.getName();
+  }
+
+  @Override
+  public String toString() {
+    return getClassSimpleName(getClass()) + "-" + getName()
+        + "(" + getClassSimpleName(keyType)
+        + "->" + getClassSimpleName(valueType) + ")";
   }
 
   @Override
@@ -368,7 +409,7 @@ public class TypedTable<KEY, VALUE> implements Table<KEY, VALUE> {
   }
 
   @Override
-  public TableCacheMetrics createCacheMetrics() throws IOException {
+  public TableCacheMetrics createCacheMetrics() {
     return TableCacheMetrics.create(cache, getName());
   }
 
@@ -451,11 +492,6 @@ public class TypedTable<KEY, VALUE> implements Table<KEY, VALUE> {
       this.rawKeyValue = rawKeyValue;
     }
 
-    public TypedKeyValue(KeyValue<byte[], byte[]> rawKeyValue,
-        Class<KEY> keyType, Class<VALUE> valueType) {
-      this.rawKeyValue = rawKeyValue;
-    }
-
     @Override
     public KEY getKey() throws IOException {
       return decodeKey(rawKeyValue.getKey());
@@ -472,8 +508,7 @@ public class TypedTable<KEY, VALUE> implements Table<KEY, VALUE> {
    */
   public class TypedTableIterator implements TableIterator<KEY, TypedKeyValue> {
 
-    private TableIterator<byte[], KeyValue<byte[], byte[]>>
-        rawIterator;
+    private final TableIterator<byte[], KeyValue<byte[], byte[]>> rawIterator;
 
     public TypedTableIterator(
         TableIterator<byte[], KeyValue<byte[], byte[]>> rawIterator) {
@@ -512,8 +547,7 @@ public class TypedTable<KEY, VALUE> implements Table<KEY, VALUE> {
 
     @Override
     public TypedKeyValue next() {
-      return new TypedKeyValue(rawIterator.next(), keyType,
-          valueType);
+      return new TypedKeyValue(rawIterator.next());
     }
 
     @Override

--- a/hadoop-hdds/managed-rocksdb/src/main/java/org/apache/hadoop/hdds/utils/db/managed/ManagedRocksDB.java
+++ b/hadoop-hdds/managed-rocksdb/src/main/java/org/apache/hadoop/hdds/utils/db/managed/ManagedRocksDB.java
@@ -31,6 +31,7 @@ import java.util.List;
  */
 public class ManagedRocksDB extends ManagedObject<RocksDB> {
   public static final Class<RocksDB> ORIGINAL_CLASS = RocksDB.class;
+  public static final int NOT_FOUND = RocksDB.NOT_FOUND;
 
   ManagedRocksDB(RocksDB original) {
     super(original);


### PR DESCRIPTION
## What changes were proposed in this pull request?

Currently we use byte[] to get from RocksDB.  We should use RocksDB ByteBuffer APIs to reduce the number of buffer copying operations when the codec support `CodecBuffer`.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-8571

## How was this patch tested?

Added `testGetByteBuffer`.