### PR TITLE
HDDS-8697 Recon - Expose API for total count for blocks pending for deletion.

### DIFF
--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/api/BlocksEndPoint.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/api/BlocksEndPoint.java
@@ -68,41 +68,66 @@ public class BlocksEndPoint {
   }
 
   /**
-   * This API returns list of blocks grouped by container state
+   * This API returns the total count of blocks pending deletion and a list of
+   * blocks grouped by container state
    * (OPEN/CLOSING/CLOSED).
+   *
+   * Example of response:
    * {
-   *   "OPEN": [
-   *     {
-   *       "containerId": 100,
-   *       "localIDList": [
-   *         1,
-   *         2,
-   *         3,
-   *         4
-   *       ],
-   *       "localIDCount": 4,
-   *       "txID": 1
-   *     }
-   *   ]
+   *   "totalCount": 1000,
+   *   "containerStateBlockInfoListMap": {
+   *     "OPEN": [
+   *       {
+   *         "containerId": 100,
+   *         "localIDList": [
+   *           1,
+   *           2,
+   *           3,
+   *           4
+   *         ],
+   *         "localIDCount": 4,
+   *         "txID": 1
+   *       }
+   *     ]
+   *   }
    * }
+   *
    * @param limit limits the number of records having list of blocks
    *              grouped by container state (OPEN/CLOSING/CLOSED)
    * @param prevKey deletedBlocks table key to skip records before prevKey
-   * @return list of blocks grouped by container state (OPEN/CLOSING/CLOSED)
+   * @return a Response object containing total count of blocks pending deletion
+   *         and list of blocks grouped by container state (OPEN/CLOSING/CLOSED)
    */
   @GET
   @Path("/deletePending")
   public Response getBlocksPendingDeletion(
       @DefaultValue(DEFAULT_FETCH_COUNT) @QueryParam(RECON_QUERY_LIMIT)
-      int limit,
+          int limit,
       @DefaultValue(PREV_DELETED_BLOCKS_TRANSACTION_ID_DEFAULT_VALUE)
       @QueryParam(RECON_QUERY_PREVKEY) long prevKey) {
     if (limit < 0 || prevKey < 0) {
       // Send back an empty response
       return Response.status(Response.Status.NOT_ACCEPTABLE).build();
     }
+
+    // Create a response map to hold totalCount and containerStateList
+    Map<String, Object> response = new HashMap<>();
+
     Map<String, List<ContainerBlocksInfoWrapper>>
         containerStateBlockInfoListMap = new HashMap<>();
+
+    try (
+        Table<Long,
+            StorageContainerDatanodeProtocolProtos.DeletedBlocksTransaction>
+            deletedBlocksTable = DELETED_BLOCKS.getTable(this.scmDBStore)) {
+      long totalCount = deletedBlocksTable.getEstimatedKeyCount();
+      response.put("totalCount",
+          totalCount); // Add totalCount to the response map
+    } catch (Exception e) {
+      throw new WebApplicationException(e,
+          Response.Status.INTERNAL_SERVER_ERROR);
+    }
+
     try (
         Table<Long,
             StorageContainerDatanodeProtocolProtos.DeletedBlocksTransaction>
@@ -169,6 +194,9 @@ public class BlocksEndPoint {
       throw new WebApplicationException(ex,
           Response.Status.INTERNAL_SERVER_ERROR);
     }
-    return Response.ok(containerStateBlockInfoListMap).build();
+    // At the end, add the containerStateBlockInfoListMap to the response map
+    response.put("containerStateList", containerStateBlockInfoListMap);
+
+    return Response.ok(response).build();
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?
Improvements have been made to the existing `BlocksEndpoint` API response. Now, the total count of blocks pending deletion is displayed in the API response. The updated response will appear as follows:
```
{
  "totalCount": 1000,
  "containerStateBlockInfoListMap": {
    "OPEN": [
      {
        "containerId": 100,
        "localIDList": [
          1,
          2,
          3,
          4
        ],
        "localIDCount": 4,
        "txID": 1
      }
    ]
  }
}

```
This new response includes the total count of **pending deletions blocks** and a **list of containers**, each with their state, container ID, list of local IDs, count of local IDs, and transaction ID.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-8697

## How was this patch tested?

Added new and made modifications to the existing UT's
