### PR TITLE
HDDS-8725. Support keyMayExist with ByteBuffer.

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/utils/db/CodecBuffer.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/utils/db/CodecBuffer.java
@@ -239,8 +239,7 @@ public final class CodecBuffer implements AutoCloseable {
     final ByteBuffer buffer = buf.nioBuffer(i, writable);
     final Integer size = source.apply(buffer);
     if (size != null) {
-      Preconditions.assertTrue(size >= 0, () -> "size = " + size + " < 0");
-      if (size <= writable) {
+      if (size > 0 && size <= writable) {
         buf.setIndex(buf.readerIndex(), i + size);
       }
     }

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/utils/db/CodecBuffer.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/utils/db/CodecBuffer.java
@@ -46,9 +46,13 @@ public final class CodecBuffer implements AutoCloseable {
   private static final ByteBufAllocator POOL
       = PooledByteBufAllocator.DEFAULT;
 
+  private static final CodecBuffer EMPTY_DIRECT_BUFFER
+      = new CodecBuffer(POOL.directBuffer(0, 0));
+
   /** Allocate a direct buffer. */
   public static CodecBuffer allocateDirect(int exactSize) {
-    return new CodecBuffer(POOL.directBuffer(exactSize, exactSize));
+    return exactSize == 0? EMPTY_DIRECT_BUFFER
+        : new CodecBuffer(POOL.directBuffer(exactSize, exactSize));
   }
 
   /** Allocate a heap buffer. */
@@ -239,6 +243,7 @@ public final class CodecBuffer implements AutoCloseable {
     final ByteBuffer buffer = buf.nioBuffer(i, writable);
     final Integer size = source.apply(buffer);
     if (size != null) {
+      Preconditions.assertTrue(size >= 0, () -> "size = " + size + " < 0");
       if (size > 0 && size <= writable) {
         buf.setIndex(buf.readerIndex(), i + size);
       }

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/utils/db/CodecBuffer.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/utils/db/CodecBuffer.java
@@ -46,13 +46,9 @@ public final class CodecBuffer implements AutoCloseable {
   private static final ByteBufAllocator POOL
       = PooledByteBufAllocator.DEFAULT;
 
-  private static final CodecBuffer EMPTY_DIRECT_BUFFER
-      = new CodecBuffer(POOL.directBuffer(0, 0));
-
   /** Allocate a direct buffer. */
   public static CodecBuffer allocateDirect(int exactSize) {
-    return exactSize == 0? EMPTY_DIRECT_BUFFER
-        : new CodecBuffer(POOL.directBuffer(exactSize, exactSize));
+    return new CodecBuffer(POOL.directBuffer(exactSize, exactSize));
   }
 
   /** Allocate a heap buffer. */

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/RDBTable.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/RDBTable.java
@@ -30,7 +30,6 @@ import java.util.function.Supplier;
 import org.apache.hadoop.hdds.annotation.InterfaceAudience;
 import org.apache.hadoop.hdds.utils.db.RocksDatabase.ColumnFamily;
 import org.apache.hadoop.hdds.utils.MetadataKeyFilters;
-import org.apache.ratis.util.Preconditions;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -176,9 +175,13 @@ class RDBTable implements Table<byte[], byte[]> {
       return null; // definitely not exists
     }
     if (value.get() != null) {
-      return value.get(); // definitely exists
+      // definitely exists, return value size.
+      return value.get();
     }
-    Preconditions.assertSame(remaining, outValue.remaining(), "remaining");
+    if (outValue.remaining() < remaining) {
+      // definitely exists but value size is unknown.
+      return outValue.remaining() - remaining;
+    }
 
     // inconclusive: the key may or may not exist
     rdbMetrics.incNumDBKeyGetIfExistGets();

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/RDBTable.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/RDBTable.java
@@ -169,18 +169,14 @@ class RDBTable implements Table<byte[], byte[]> {
 
   Integer getIfExist(ByteBuffer key, ByteBuffer outValue) throws IOException {
     rdbMetrics.incNumDBKeyGetIfExistChecks();
-    final int remaining = outValue.remaining();
-    final Supplier<Integer> value = db.keyMayExist(family, key, outValue);
+    final Supplier<Integer> value = db.keyMayExist(
+        family, key, outValue.duplicate());
     if (value == null) {
       return null; // definitely not exists
     }
     if (value.get() != null) {
       // definitely exists, return value size.
       return value.get();
-    }
-    if (outValue.remaining() < remaining) {
-      // definitely exists but value size is unknown.
-      return outValue.remaining() - remaining;
     }
 
     // inconclusive: the key may or may not exist

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/RocksDatabase.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/RocksDatabase.java
@@ -672,20 +672,20 @@ public final class RocksDatabase implements Closeable {
     }
   }
 
-  Supplier<Integer> keyMayExist(ColumnFamily family, ByteBuffer key, ByteBuffer out)
-      throws IOException {
+  Supplier<Integer> keyMayExist(ColumnFamily family,
+      ByteBuffer key, ByteBuffer out) throws IOException {
     assertClose();
     try {
       counter.incrementAndGet();
       final KeyMayExist result = db.get().keyMayExist(
           family.getHandle(), key, out);
       switch (result.exists) {
-        case kNotExist: return null;
-        case kExistsWithValue: return () -> result.valueLength;
-        case kExistsWithoutValue: return () -> null;
-        default:
-          throw new IllegalStateException(
-              "Unexpected KeyMayExistEnum case " + result.exists);
+      case kNotExist: return null;
+      case kExistsWithValue: return () -> result.valueLength;
+      case kExistsWithoutValue: return () -> null;
+      default:
+        throw new IllegalStateException(
+            "Unexpected KeyMayExistEnum case " + result.exists);
       }
     } finally {
       counter.decrementAndGet();

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/RocksDatabase.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/RocksDatabase.java
@@ -37,6 +37,7 @@ import org.apache.hadoop.hdds.utils.db.managed.ManagedWriteOptions;
 import org.rocksdb.ColumnFamilyDescriptor;
 import org.rocksdb.ColumnFamilyHandle;
 import org.rocksdb.Holder;
+import org.rocksdb.KeyMayExist;
 import org.rocksdb.LiveFileMetaData;
 import org.rocksdb.RocksDBException;
 import org.slf4j.Logger;
@@ -666,6 +667,26 @@ public final class RocksDatabase implements Closeable {
       final Holder<byte[]> out = new Holder<>();
       return db.get().keyMayExist(family.getHandle(), key, out) ?
           out::getValue : null;
+    } finally {
+      counter.decrementAndGet();
+    }
+  }
+
+  Supplier<Integer> keyMayExist(ColumnFamily family, ByteBuffer key, ByteBuffer out)
+      throws IOException {
+    assertClose();
+    try {
+      counter.incrementAndGet();
+      final KeyMayExist result = db.get().keyMayExist(
+          family.getHandle(), key, out);
+      switch (result.exists) {
+        case kNotExist: return null;
+        case kExistsWithValue: return () -> result.valueLength;
+        case kExistsWithoutValue: return () -> null;
+        default:
+          throw new IllegalStateException(
+              "Unexpected KeyMayExistEnum case " + result.exists);
+      }
     } finally {
       counter.decrementAndGet();
     }

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/TypedTable.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/TypedTable.java
@@ -190,8 +190,8 @@ public class TypedTable<KEY, VALUE> implements Table<KEY, VALUE> {
     } else if (keyCodec.supportCodecBuffer()) {
       // keyCodec.supportCodecBuffer() is enough since value is not needed.
       try (CodecBuffer inKey = keyCodec.toDirectCodecBuffer(key)) {
-        // Only allocate 2 bytes since value is not needed.
-        try (CodecBuffer outValue = CodecBuffer.allocateDirect(2)) {
+        // Use zero capacity buffer since value is not needed.
+        try (CodecBuffer outValue = CodecBuffer.allocateDirect(0)) {
           return getFromTableIfExist(inKey, outValue) != null;
         }
       }

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/TypedTable.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/TypedTable.java
@@ -357,12 +357,12 @@ public class TypedTable<KEY, VALUE> implements Table<KEY, VALUE> {
           if (required == null) {
             // key not found
             return null;
-          } else if (required <= allocated) {
+          } else if (required >= 0 && required <= allocated) {
             // buffer size is big enough
             return valueCodec.fromCodecBuffer(outValue);
           }
           // buffer size too small, retry
-          increaseBufferSize(required);
+          increaseBufferSize(Math.max(required, allocated));
         }
       }
     }

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/TypedTable.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/TypedTable.java
@@ -362,7 +362,7 @@ public class TypedTable<KEY, VALUE> implements Table<KEY, VALUE> {
             return valueCodec.fromCodecBuffer(outValue);
           }
           // buffer size too small, retry
-          increaseBufferSize(Math.max(required, allocated));
+          increaseBufferSize(required);
         }
       }
     }

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/TypedTable.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/TypedTable.java
@@ -192,7 +192,7 @@ public class TypedTable<KEY, VALUE> implements Table<KEY, VALUE> {
       try (CodecBuffer inKey = keyCodec.toDirectCodecBuffer(key)) {
         // Only allocate 2 bytes since value is not needed.
         try (CodecBuffer outValue = CodecBuffer.allocateDirect(2)) {
-          return getFromTableIfExistCodecBuffer(inKey, outValue) != null;
+          return getFromTableIfExist(inKey, outValue) != null;
         }
       }
     } else {
@@ -342,7 +342,7 @@ public class TypedTable<KEY, VALUE> implements Table<KEY, VALUE> {
     }
   }
 
-  private Integer getFromTableIfExistCodecBuffer(CodecBuffer key,
+  private Integer getFromTableIfExist(CodecBuffer key,
       CodecBuffer outValue) throws IOException {
     return outValue.putFromSource(
         buffer -> rawTable.getIfExist(key.asReadOnlyByteBuffer(), buffer));
@@ -353,7 +353,7 @@ public class TypedTable<KEY, VALUE> implements Table<KEY, VALUE> {
       for (; ;) {
         final int allocated = bufferSize.get();
         try (CodecBuffer outValue = CodecBuffer.allocateDirect(allocated)) {
-          final Integer required = getFromTableIfExistCodecBuffer(inKey, outValue);
+          final Integer required = getFromTableIfExist(inKey, outValue);
           if (required == null) {
             // key not found
             return null;
@@ -373,7 +373,7 @@ public class TypedTable<KEY, VALUE> implements Table<KEY, VALUE> {
       return getFromTableIfExistCodecBuffer(key);
     } else {
       final byte[] keyBytes = encodeKey(key);
-      byte[] valueBytes = rawTable.getIfExist(keyBytes);
+      final byte[] valueBytes = rawTable.getIfExist(keyBytes);
       return decodeValue(valueBytes);
     }
   }

--- a/pom.xml
+++ b/pom.xml
@@ -1765,6 +1765,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
                       <!-- Allow non-RocksObject classes. -->
                       <allowedImport>org.rocksdb.ColumnFamilyDescriptor</allowedImport>
                       <allowedImport>org.rocksdb.CompactionStyle</allowedImport>
+                      <allowedImport>org.rocksdb.KeyMayExist</allowedImport>
                       <allowedImport>org.rocksdb.HistogramData</allowedImport>
                       <allowedImport>org.rocksdb.HistogramType</allowedImport>
                       <allowedImport>org.rocksdb.Holder</allowedImport>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Use RocksDB ByteBuffer API: 
https://javadoc.io/static/org.rocksdb/rocksdbjni/7.7.3/org/rocksdb/RocksDB.html#keyMayExist-org.rocksdb.ColumnFamilyHandle-java.nio.ByteBuffer-java.nio.ByteBuffer-

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-8725

## How was this patch tested?

Existing tests.