### PR TITLE
HDDS-8675. Fix expectation in testUnderRepSentToOverRepHandlerIfNoNewNodes

### DIFF
--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestECUnderReplicationHandler.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestECUnderReplicationHandler.java
@@ -466,29 +466,16 @@ public class TestECUnderReplicationHandler {
           () -> ecURH.processAndSendCommands(availableReplicas,
               Collections.emptyList(), underRep, 2));
 
-      // Now adjust replicas so it is also over replicated. This time rather
-      // than throwing it should call the OverRepHandler and return whatever it
+      // Now adjust replicas so it is also over replicated. This time before
+      // throwing it should call the OverRepHandler and return whatever it
       // returns, which in this case is a delete command for replica index 4.
       availableReplicas.add(overRepReplica);
 
-      Set<Pair<DatanodeDetails, SCMCommand<?>>> expectedDelete =
-          new HashSet<>();
-      expectedDelete.add(Pair.of(overRepReplica.getDatanodeDetails(),
-          createDeleteContainerCommand(container,
-              overRepReplica.getReplicaIndex())));
-
-      Mockito.when(replicationManager.processOverReplicatedContainer(
-          underRep)).thenAnswer(invocationOnMock -> {
-            commandsSent.addAll(expectedDelete);
-            return expectedDelete.size();
-          });
-      commandsSent.clear();
       assertThrows(SCMException.class,
           () -> ecURH.processAndSendCommands(availableReplicas,
               Collections.emptyList(), underRep, 2));
       Mockito.verify(replicationManager, times(1))
           .processOverReplicatedContainer(underRep);
-      Assertions.assertEquals(true, expectedDelete.equals(commandsSent));
     }
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Looks like we are writing the expected result into the actual result of `commandsSent` and comparing them:

```
      Set<Pair<DatanodeDetails, SCMCommand<?>>> expectedDelete =
          new HashSet<>();
      expectedDelete.add(Pair.of(overRepReplica.getDatanodeDetails(),
          createDeleteContainerCommand(container,
              overRepReplica.getReplicaIndex())));

      Mockito.when(replicationManager.processOverReplicatedContainer(
          underRep)).thenAnswer(invocationOnMock -> {
            commandsSent.addAll(expectedDelete);
            return expectedDelete.size();
          });
      commandsSent.clear();
      assertThrows(SCMException.class,
          () -> ecURH.processAndSendCommands(availableReplicas,
              Collections.emptyList(), underRep, 2));
      Mockito.verify(replicationManager, times(1))
          .processOverReplicatedContainer(underRep);
      Assertions.assertEquals(true, expectedDelete.equals(commandsSent));
```

Ideally, `commandsSent` should be populated with the actual command that was sent. However, since this is a unit test, it's better to not run the code in `ECOverReplicationHandler` and simply verify that `replicationManager.processOverReplicatedContainer` was called once. So I've removed the assertion `Assertions.assertEquals(true, expectedDelete.equals(commandsSent))`.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-8675

## How was this patch tested?

No new tests.