### PR TITLE
HDDS-8728. Incorrect expectedNodes passed to InsufficientNodesException

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ECUnderReplicationHandler.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ECUnderReplicationHandler.java
@@ -342,7 +342,7 @@ public class ECUnderReplicationHandler implements UnhealthyReplicationHandler {
             " to fully reconstruct container {}. Requested {} received {}",
             container.getContainerID(), expectedTargets,
             selectedDatanodes.size());
-        throw new InsufficientDatanodesException(missingIndexes.size(),
+        throw new InsufficientDatanodesException(expectedTargets,
             selectedDatanodes.size());
       }
     } else {


### PR DESCRIPTION
## What changes were proposed in this pull request?

When forming the InsufficientNodesException, we pass missingIndexes.size() as the expected node count. However if there are insufficient nodes, the expected list gets trimmed, so this count is incorrect. We should pass expectedNodes instead, which is the original list length.

```
2023-05-30 07:17:30,597 [Under Replicated Processor] ERROR org.apache.hadoop.hdds.scm.container.replication.UnhealthyReplicationProcessor: Error processing Health result of class: class org.apache.hadoop.hdds.scm.container.replication.ContainerHealthResult$UnderReplicatedHealthResult for container ContainerInfo{id=#54, state=CLOSED, pipelineID=PipelineID=d795e5a1-5eb9-4833-9c03-2b1342683b99, stateEnterTime=2023-05-30T06:50:10.331Z, owner=om1}
org.apache.hadoop.hdds.scm.pipeline.InsufficientDatanodesException: Not enough datanodes, requested: 1, found: 1
        at org.apache.hadoop.hdds.scm.container.replication.ECUnderReplicationHandler.processMissingIndexes(ECUnderReplicationHandler.java:335)
        at org.apache.hadoop.hdds.scm.container.replication.ECUnderReplicationHandler.processAndSendCommands(ECUnderReplicationHandler.java:160)
        at org.apache.hadoop.hdds.scm.container.replication.ReplicationManager.processUnderReplicatedContainer(ReplicationManager.java:776)
        at org.apache.hadoop.hdds.scm.container.replication.UnderReplicatedProcessor.sendDatanodeCommands(UnderReplicatedProcessor.java:58)
        at org.apache.hadoop.hdds.scm.container.replication.UnderReplicatedProcessor.sendDatanodeCommands(UnderReplicatedProcessor.java:27)
        at org.apache.hadoop.hdds.scm.container.replication.UnhealthyReplicationProcessor.processContainer(UnhealthyReplicationProcessor.java:148)
        at org.apache.hadoop.hdds.scm.container.replication.UnhealthyReplicationProcessor.processAll(UnhealthyReplicationProcessor.java:115)
        at org.apache.hadoop.hdds.scm.container.replication.UnhealthyReplicationProcessor.run(UnhealthyReplicationProcessor.java:157)
        at java.base/java.lang.Thread.run(Thread.java:834)
```

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-8728

## How was this patch tested?

Simple log message change