### PR TITLE
HDDS-8729. Add metrics for count of pending Block on DN

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/helpers/BlockDeletingServiceMetrics.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/helpers/BlockDeletingServiceMetrics.java
@@ -23,6 +23,7 @@ import org.apache.hadoop.metrics2.annotation.Metric;
 import org.apache.hadoop.metrics2.annotation.Metrics;
 import org.apache.hadoop.metrics2.lib.DefaultMetricsSystem;
 import org.apache.hadoop.metrics2.lib.MutableCounterLong;
+import org.apache.hadoop.metrics2.lib.MutableGaugeLong;
 import org.apache.hadoop.ozone.container.keyvalue.statemachine.background.BlockDeletingService;
 
 /**
@@ -47,6 +48,9 @@ public final class BlockDeletingServiceMetrics {
 
   @Metric(about = "The number of out of order delete block transaction.")
   private MutableCounterLong outOfOrderDeleteBlockTransactionCount;
+
+  @Metric(about = "The total number of blocks pending for processing.")
+  private MutableGaugeLong totalPendingBlockCount;
 
   private BlockDeletingServiceMetrics() {
   }
@@ -82,6 +86,10 @@ public final class BlockDeletingServiceMetrics {
     this.failureCount.incr();
   }
 
+  public void setTotalPendingBlockCount(long count) {
+    this.totalPendingBlockCount.set(count);
+  }
+
   public long getSuccessCount() {
     return successCount.value();
   }
@@ -102,6 +110,10 @@ public final class BlockDeletingServiceMetrics {
     return outOfOrderDeleteBlockTransactionCount.value();
   }
 
+  public long getTotalPendingBlockCount() {
+    return totalPendingBlockCount.value();
+  }
+
   @Override
   public String toString() {
     StringBuffer buffer = new StringBuffer();
@@ -109,7 +121,9 @@ public final class BlockDeletingServiceMetrics {
         .append("successBytes = " + successBytes.value()).append("\t")
         .append("failureCount = " + failureCount.value()).append("\t")
         .append("outOfOrderDeleteBlockTransactionCount = "
-            + outOfOrderDeleteBlockTransactionCount.value()).append("\t");
+            + outOfOrderDeleteBlockTransactionCount.value()).append("\t")
+        .append("totalPendingBlockCount = "
+            + totalPendingBlockCount.value()).append("\t");
     return buffer.toString();
   }
 }

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/TestBlockDeletingService.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/TestBlockDeletingService.java
@@ -613,6 +613,11 @@ public class TestBlockDeletingService {
       Assert.assertEquals(2,
           deletingServiceMetrics.getSuccessCount()
               - deleteSuccessCount);
+      // The value of the getTotalPendingBlockCount Metrics is obtained
+      // before the deletion is processing
+      // So the Pending Block count will be 3
+      Assert.assertEquals(3,
+          deletingServiceMetrics.getTotalPendingBlockCount());
 
       deleteAndWait(svc, 2);
 
@@ -634,8 +639,12 @@ public class TestBlockDeletingService {
 
       // check if blockData get deleted
       assertBlockDataTableRecordCount(0, meta, filter, data.getContainerID());
+      // The value of the getTotalPendingBlockCount Metrics is obtained
+      // before the deletion is processing
+      // So the Pending Block count will be 1
+      Assert.assertEquals(1,
+          deletingServiceMetrics.getTotalPendingBlockCount());
     }
-
     svc.shutdown();
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Add a Metrics to monitor the `Pending Block` Count.
`block_deleting_service_metrics_total_pending_block_count{context="dfs",hostname="centos"} 0`

### Example:
```
[root@centos ~/root/ozone]$ curl -s http://127.0.0.1:9882/prom  | grep block_deleting_service_metrics | grep -v '#'
block_deleting_service_metrics_failure_count{context="dfs",hostname="centos"} 0
block_deleting_service_metrics_out_of_order_delete_block_transaction_count{context="dfs",hostname="centos"} 0
block_deleting_service_metrics_success_bytes{context="dfs",hostname="-centos"} 0
block_deleting_service_metrics_success_count{context="dfs",hostname="centos"} 0
block_deleting_service_metrics_total_pending_block_count{context="dfs",hostname="centos"} 0
[root@centos ~/root/ozone]$ 

```
## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-8729

## How was this patch tested?

manual test and unit test
