### PR TITLE
HDDS-8726. Let run.sh start more than 3 datanodes

### DIFF
--- a/hadoop-ozone/dist/src/main/compose/ozone/README.md
+++ b/hadoop-ozone/dist/src/main/compose/ozone/README.md
@@ -29,10 +29,11 @@ TL;DR:
    ```
    ./run.sh -d
    ```
-2. three datanodes for replication:
+2. multiple datanodes for replication:
    ```
-   export OZONE_REPLICATION_FACTOR=3
-   ./run.sh -d
+   OZONE_DATANODES=3 ./run.sh -d
+   # or
+   OZONE_DATANODES=5 ./run.sh -d
    ```
 
 ### Basics
@@ -43,7 +44,7 @@ You can change the number of datanodes to start using the `--scale` option.  Eg.
 
 The cluster's replication factor (1 or 3) can be controlled by setting the `OZONE_REPLICATION_FACTOR` environment variable.  It defaults to 1 to match the number of datanodes started by default, without the `--scale` option.
 
-For convenience the `run.sh` script can be used to make sure the replication factor and the number of datanodes match.  It also passes any additional arguments provided on the command-line (eg. `-d`) to `docker-compose`.
+For convenience the `run.sh` script can be used to start multiple datanodes (by setting the `OZONE_DATANODES` variable), while making sure the replication factor and the number of datanodes are compatible.  It also passes any additional arguments provided on the command-line (eg. `-d`) to `docker-compose`.
 
 ### Add-ons
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

`run.sh` uses `$OZONE_REPLICATION_FACTOR` both to set the default replication factor and to decide how many datanodes to start.  This limits the number of datanodes to 1 or 3.  While datanodes can be scaled afterwards, it would be nice to be able to start the cluster with e.g. 5 datanodes in the first place.

https://issues.apache.org/jira/browse/HDDS-8726

## How was this patch tested?

Old usage (still works):

```
$ ./run.sh -d
$ OZONE_REPLICATION_FACTOR=3 ./run.sh -d
```

New usage:

```
$ OZONE_DATANODES=5 ./run.sh -d
```

(Also tested various combinations of the two parameters.)