### PR TITLE
HDDS-8736. Add usedNodes to limit check and log messages in SCMContainerPlacementRackScatter

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/placement/algorithms/SCMContainerPlacementRackScatter.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/placement/algorithms/SCMContainerPlacementRackScatter.java
@@ -210,6 +210,7 @@ public final class SCMContainerPlacementRackScatter
    * @throws SCMException  SCMException
    */
   @Override
+  @SuppressWarnings("checkstyle:methodlength")
   protected List<DatanodeDetails> chooseDatanodesInternal(
           List<DatanodeDetails> usedNodes,
           final List<DatanodeDetails> excludedNodes,
@@ -226,18 +227,23 @@ public final class SCMContainerPlacementRackScatter
     }
     int nodesRequired = nodesRequiredToChoose;
     int excludedNodesCount = excludedNodes == null ? 0 : excludedNodes.size();
+    int usedNodesCount = usedNodes == null ? 0 : usedNodes.size();
     List<Node> availableNodes = networkTopology.getNodes(
         networkTopology.getMaxLevel());
     int totalNodesCount = availableNodes.size();
     if (excludedNodes != null) {
       availableNodes.removeAll(excludedNodes);
     }
+    if (usedNodes != null) {
+      availableNodes.removeAll(usedNodes);
+    }
     if (availableNodes.size() < nodesRequired) {
       throw new SCMException("No enough datanodes to choose. " +
-          "TotalNode = " + totalNodesCount +
-          " AvailableNode = " + availableNodes.size() +
-          " RequiredNode = " + nodesRequired +
-          " ExcludedNode = " + excludedNodesCount,
+          "TotalNodes = " + totalNodesCount +
+          " AvailableNodes = " + availableNodes.size() +
+          " RequiredNodes = " + nodesRequired +
+          " ExcludedNodes = " + excludedNodesCount +
+          " UsedNodes = " + usedNodesCount,
           FAILED_TO_FIND_SUITABLE_NODE);
     }
     List<DatanodeDetails> mutableFavoredNodes = new ArrayList<>();
@@ -316,8 +322,8 @@ public final class SCMContainerPlacementRackScatter
               + additionalRacksRequired + " do not match.";
       LOG.warn("Placement policy could not choose the enough nodes from " +
                       "available racks. {} Available racks count: {},"
-                      + " Excluded nodes count: {}",
-              reason, racks.size(), excludedNodesCount);
+                      + " Excluded nodes count: {}, UsedNodes count: {}",
+              reason, racks.size(), excludedNodesCount, usedNodesCount);
       throw new SCMException(reason,
               SCMException.ResultCodes.FAILED_TO_FIND_HEALTHY_NODES);
     }
@@ -337,8 +343,9 @@ public final class SCMContainerPlacementRackScatter
               .size() + ", but required nodes to choose: "
               + nodesRequiredToChoose + " do not match.";
       LOG.warn("Placement policy could not choose the enough nodes."
-               + " {} Available nodes count: {}, Excluded nodes count: {}",
-              reason, totalNodesCount, excludedNodesCount);
+               + " {} Available nodes count: {}, Excluded nodes count: {}, "
+               + " Used nodes count: {}",
+              reason, totalNodesCount, excludedNodesCount, usedNodesCount);
       throw new SCMException(reason,
               SCMException.ResultCodes.FAILED_TO_FIND_HEALTHY_NODES);
     }

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/placement/algorithms/TestSCMContainerPlacementRackScatter.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/placement/algorithms/TestSCMContainerPlacementRackScatter.java
@@ -63,6 +63,8 @@ import static org.apache.hadoop.hdds.scm.exceptions.SCMException.ResultCodes.FAI
 import static org.apache.hadoop.hdds.scm.net.NetConstants.LEAF_SCHEMA;
 import static org.apache.hadoop.hdds.scm.net.NetConstants.RACK_SCHEMA;
 import static org.apache.hadoop.hdds.scm.net.NetConstants.ROOT_SCHEMA;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.matchesPattern;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -619,6 +621,20 @@ public class TestSCMContainerPlacementRackScatter {
             "required number of racks to choose: 2.", exception.getMessage());
     assertEquals(SCMException.ResultCodes.FAILED_TO_FIND_SUITABLE_NODE,
             exception.getResult());
+  }
+
+  @Test
+  public void testChooseNodesWithInsufficientNodesAvailable() {
+    setup(5, 2);
+    List<DatanodeDetails> usedDns = getDatanodes(Lists.newArrayList(0, 1));
+    List<DatanodeDetails> excludedDns = getDatanodes(Lists.newArrayList(2));
+    SCMException exception = Assertions.assertThrows(SCMException.class, () ->
+        policy.chooseDatanodes(usedDns, excludedDns,
+            null, 3, 0, 5));
+    assertThat(exception.getMessage(),
+        matchesPattern("^No enough datanodes to choose.*"));
+    assertEquals(SCMException.ResultCodes.FAILED_TO_FIND_SUITABLE_NODE,
+        exception.getResult());
   }
 
   @Test


### PR DESCRIPTION
## What changes were proposed in this pull request?

The usedNode count is missing in some log messages in the SCMContainerPlacementRackScatter placement policy.

Also, it checks at the start to see if there are enough available nodes, and the usedNodes need to be removed from the available nodes for the check to work correctly.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-8736

## How was this patch tested?

Added a unit test to validate the limit check
