### PR TITLE
HDDS-8737. Organize Ozone admin related Methods into Class OzoneAdmin

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/HddsDatanodeService.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/HddsDatanodeService.java
@@ -662,7 +662,7 @@ public class HddsDatanodeService extends GenericCli implements ServicePlugin {
    */
   public void checkAdminUserPrivilege(UserGroupInformation ugi)
       throws IOException {
-    admins.isAdmin(ugi);
+    admins.checkAdminUserPrivilege(ugi);
   }
 
   public String reconfigurePropertyImpl(String property, String newVal)

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/HddsDatanodeService.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/HddsDatanodeService.java
@@ -65,7 +65,6 @@ import org.apache.hadoop.ozone.container.common.volume.StorageVolume;
 import org.apache.hadoop.ozone.container.keyvalue.helpers.KeyValueContainerUtil;
 import org.apache.hadoop.ozone.util.OzoneNetUtils;
 import org.apache.hadoop.ozone.util.ShutdownHookManager;
-import org.apache.hadoop.security.AccessControlException;
 import org.apache.hadoop.security.SecurityUtil;
 import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.hadoop.security.authentication.client.AuthenticationException;
@@ -78,8 +77,6 @@ import com.google.common.base.Preconditions;
 import static org.apache.hadoop.hdds.protocol.DatanodeDetails.Port.Name.HTTP;
 import static org.apache.hadoop.hdds.protocol.DatanodeDetails.Port.Name.HTTPS;
 import static org.apache.hadoop.ozone.OzoneConfigKeys.HDDS_DATANODE_PLUGINS_KEY;
-import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_ADMINISTRATORS;
-import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_ADMINISTRATORS_GROUPS;
 import static org.apache.hadoop.ozone.conf.OzoneServiceConfig.DEFAULT_SHUTDOWN_HOOK_PRIORITY;
 import static org.apache.hadoop.ozone.common.Storage.StorageState.INITIALIZED;
 import static org.apache.hadoop.util.ExitUtil.terminate;
@@ -330,12 +327,8 @@ public class HddsDatanodeService extends GenericCli implements ServicePlugin {
       // Get admin list
       String starterUser =
           UserGroupInformation.getCurrentUser().getShortUserName();
-      Collection<String> adminUserNames =
-          getOzoneAdminsFromConfig(conf, starterUser);
-      Collection<String> adminGroupNames =
-          getOzoneAdminsGroupsFromConfig(conf);
-      LOG.info("Datanode start with admins: {}", adminUserNames);
-      admins = new OzoneAdmins(adminUserNames, adminGroupNames);
+      admins = OzoneAdmins.getOzoneAdmins(starterUser, conf);
+      LOG.info("Datanode start with admins: {}", admins.getAdminUsernames());
 
       clientProtocolServer.start();
       startPlugins();
@@ -669,18 +662,7 @@ public class HddsDatanodeService extends GenericCli implements ServicePlugin {
    */
   public void checkAdminUserPrivilege(UserGroupInformation ugi)
       throws IOException {
-    if (ugi != null && !isAdmin(ugi)) {
-      throw new AccessControlException("Access denied for user "
-          + ugi.getUserName() + ". Superuser privilege is required.");
-    }
-  }
-
-  /**
-   * Return true if a UserGroupInformation is admin, false otherwise.
-   * @param callerUgi Caller UserGroupInformation
-   */
-  public boolean isAdmin(UserGroupInformation callerUgi) {
-    return callerUgi != null && admins.isAdmin(callerUgi);
+    admins.isAdmin(ugi);
   }
 
   public String reconfigurePropertyImpl(String property, String newVal)
@@ -690,26 +672,6 @@ public class HddsDatanodeService extends GenericCli implements ServicePlugin {
 
   public Collection<String> getReconfigurableProperties() {
     return reconfigurableProperties;
-  }
-
-  /**
-   * Return list of OzoneAdministrators from config.
-   * The service startup user will default to an admin.
-   */
-  private Collection<String> getOzoneAdminsFromConfig(
-      OzoneConfiguration configuration, String starterUser) {
-    Collection<String> ozAdmins = configuration.getTrimmedStringCollection(
-        OZONE_ADMINISTRATORS);
-    if (!ozAdmins.contains(starterUser)) {
-      ozAdmins.add(starterUser);
-    }
-    return ozAdmins;
-  }
-
-  Collection<String> getOzoneAdminsGroupsFromConfig(
-      OzoneConfiguration configuration) {
-    return configuration.getTrimmedStringCollection(
-        OZONE_ADMINISTRATORS_GROUPS);
   }
 
 }

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/server/OzoneAdmins.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/server/OzoneAdmins.java
@@ -72,7 +72,7 @@ public class OzoneAdmins {
    * @return a configured OzoneAdmins instance.
    */
   public static OzoneAdmins getOzoneAdmins(String starterUser,
-                                           OzoneConfiguration configuration) {
+      OzoneConfiguration configuration) {
     Collection<String> adminUserNames =
         getOzoneAdminsFromConfig(configuration, starterUser);
     Collection<String> adminGroupNames =

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/server/OzoneAdmins.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/server/OzoneAdmins.java
@@ -81,6 +81,23 @@ public class OzoneAdmins {
   }
 
   /**
+   * Creates and returns a read-only admin object. This object includes the
+   * read-only admin users and user groups obtained from the Ozone
+   * configuration.
+   *
+   * @param configuration the configuration settings to apply.
+   * @return a configured OzoneAdmins instance.
+   */
+  public static OzoneAdmins getReadonlyAdmins(
+      OzoneConfiguration configuration) {
+    Collection<String> omReadOnlyAdmins =
+        getOzoneReadOnlyAdminsFromConfig(configuration);
+    Collection<String> omReadOnlyAdminsGroups =
+        getOzoneReadOnlyAdminsGroupsFromConfig(configuration);
+    return new OzoneAdmins(omReadOnlyAdmins, omReadOnlyAdminsGroups);
+  }
+
+  /**
    * Check ozone admin privilege, throws exception if not admin.
    */
   public void checkAdminUserPrivilege(UserGroupInformation ugi)
@@ -126,7 +143,9 @@ public class OzoneAdmins {
 
   /**
    * Return list of administrators from config.
-   * The service startup user will default to an admin.
+   * The starterUser user will default to an admin.
+   * @param conf the configuration settings to apply.
+   * @param starterUser initial user to consider in admin list.
    */
   public static Collection<String> getOzoneAdminsFromConfig(
       OzoneConfiguration conf, String starterUser) {
@@ -139,20 +158,29 @@ public class OzoneAdmins {
   }
 
   /**
+   * Return list of administrators Groups from config.
+   * The service startup user will default to an admin.
+   * @param configuration the configuration settings to apply.
+   */
+  public static Collection<String> getOzoneAdminsGroupsFromConfig(
+      OzoneConfiguration configuration) {
+    return configuration.getTrimmedStringCollection(
+        OZONE_ADMINISTRATORS_GROUPS);
+  }
+
+  /**
    * Return list of Ozone Read only admin Usernames from config.
+   * @param conf the configuration settings to apply.
    */
   public static Collection<String> getOzoneReadOnlyAdminsFromConfig(
       OzoneConfiguration conf) {
     return conf.getTrimmedStringCollection(OZONE_READONLY_ADMINISTRATORS);
   }
 
-  private static Collection<String> getOzoneAdminsGroupsFromConfig(
-      OzoneConfiguration configuration) {
-    return configuration.getTrimmedStringCollection(
-        OZONE_ADMINISTRATORS_GROUPS);
-  }
-
-
+  /**
+   * Return list of Ozone Read only admin Groups from config.
+   * @param conf the configuration settings to apply.
+   */
   public static Collection<String> getOzoneReadOnlyAdminsGroupsFromConfig(
       OzoneConfiguration conf) {
     return conf.getTrimmedStringCollection(

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneConfigUtil.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneConfigUtil.java
@@ -33,8 +33,6 @@ import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_ADMINISTRATORS;
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_ADMINISTRATORS_GROUPS;
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_S3_ADMINISTRATORS;
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_S3_ADMINISTRATORS_GROUPS;
-import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_READONLY_ADMINISTRATORS;
-import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_READONLY_ADMINISTRATORS_GROUPS;
 
 /**
  * Utility class for ozone configurations.

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneConfigUtil.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneConfigUtil.java
@@ -46,20 +46,6 @@ public final class OzoneConfigUtil {
   }
 
   /**
-   * Return list of OzoneAdministrators from config.
-   * The service startup user will default to an admin.
-   */
-  static Collection<String> getOzoneAdminsFromConfig(OzoneConfiguration conf,
-      String starterUser) {
-    Collection<String> ozAdmins = conf.getTrimmedStringCollection(
-        OZONE_ADMINISTRATORS);
-    if (!ozAdmins.contains(starterUser)) {
-      ozAdmins.add(starterUser);
-    }
-    return ozAdmins;
-  }
-
-  /**
    * Return list of s3 administrators prop from config.
    *
    * If ozone.s3.administrators value is empty string or unset,
@@ -79,19 +65,6 @@ public final class OzoneConfigUtil {
     return ozAdmins;
   }
 
-  /**
-   * Return list of Ozone Read only admin Usernames from config.
-   */
-  static Collection<String> getOzoneReadOnlyAdminsFromConfig(
-      OzoneConfiguration conf) {
-    return conf.getTrimmedStringCollection(OZONE_READONLY_ADMINISTRATORS);
-  }
-
-  static Collection<String> getOzoneAdminsGroupsFromConfig(
-      OzoneConfiguration conf) {
-    return conf.getTrimmedStringCollection(OZONE_ADMINISTRATORS_GROUPS);
-  }
-
   static Collection<String> getS3AdminsGroupsFromConfig(
       OzoneConfiguration conf) {
     Collection<String> s3AdminsGroup =
@@ -102,12 +75,6 @@ public final class OzoneConfigUtil {
               .getTrimmedStringCollection(OZONE_ADMINISTRATORS_GROUPS);
     }
     return s3AdminsGroup;
-  }
-
-  static Collection<String> getOzoneReadOnlyAdminsGroupsFromConfig(
-      OzoneConfiguration conf) {
-    return conf.getTrimmedStringCollection(
-        OZONE_READONLY_ADMINISTRATORS_GROUPS);
   }
 
   public static ReplicationConfig resolveReplicationConfigPreference(

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
@@ -646,15 +646,7 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
     LOG.info("OM start with adminUsers: {}", omAdmins.getAdminUsernames());
 
     // Get read only admin list
-    Collection<String> omReadOnlyAdmins =
-        OzoneAdmins.getOzoneReadOnlyAdminsFromConfig(
-            configuration);
-    Collection<String> omReadOnlyAdminsGroups =
-        OzoneAdmins.getOzoneReadOnlyAdminsGroupsFromConfig(
-            configuration);
-
-    readOnlyAdmins = new OzoneAdmins(omReadOnlyAdmins,
-        omReadOnlyAdminsGroups);
+    readOnlyAdmins = OzoneAdmins.getReadonlyAdmins(conf);
 
     Collection<String> s3AdminUsernames =
             OzoneConfigUtil.getS3AdminsFromConfig(configuration);

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
@@ -642,19 +642,15 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
     perfMetrics = OMPerformanceMetrics.register();
     // Get admin list
     omStarterUser = UserGroupInformation.getCurrentUser().getShortUserName();
-    Collection<String> omAdminUsernames =
-        OzoneConfigUtil.getOzoneAdminsFromConfig(configuration, omStarterUser);
-    Collection<String> omAdminGroups =
-        OzoneConfigUtil.getOzoneAdminsGroupsFromConfig(configuration);
-    LOG.info("OM start with adminUsers: {}", omAdminUsernames);
-    omAdmins = new OzoneAdmins(omAdminUsernames, omAdminGroups);
+    omAdmins = OzoneAdmins.getOzoneAdmins(omStarterUser, conf);
+    LOG.info("OM start with adminUsers: {}", omAdmins.getAdminUsernames());
 
     // Get read only admin list
     Collection<String> omReadOnlyAdmins =
-        OzoneConfigUtil.getOzoneReadOnlyAdminsFromConfig(
+        OzoneAdmins.getOzoneReadOnlyAdminsFromConfig(
             configuration);
     Collection<String> omReadOnlyAdminsGroups =
-        OzoneConfigUtil.getOzoneReadOnlyAdminsGroupsFromConfig(
+        OzoneAdmins.getOzoneReadOnlyAdminsGroupsFromConfig(
             configuration);
 
     readOnlyAdmins = new OzoneAdmins(omReadOnlyAdmins,
@@ -4654,7 +4650,7 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
   private String reconfOzoneAdmins(String newVal) {
     getConfiguration().set(OZONE_ADMINISTRATORS, newVal);
     Collection<String> admins =
-        OzoneConfigUtil.getOzoneAdminsFromConfig(getConfiguration(),
+        OzoneAdmins.getOzoneAdminsFromConfig(getConfiguration(),
             omStarterUser);
     omAdmins.setAdminUsernames(admins);
     LOG.info("Load conf {} : {}, and now admins are: {}", OZONE_ADMINISTRATORS,
@@ -4665,7 +4661,7 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
   private String reconfOzoneReadOnlyAdmins(String newVal) {
     getConfiguration().set(OZONE_READONLY_ADMINISTRATORS, newVal);
     Collection<String> pReadOnlyAdmins =
-        OzoneConfigUtil.getOzoneReadOnlyAdminsFromConfig(getConfiguration());
+        OzoneAdmins.getOzoneReadOnlyAdminsFromConfig(getConfiguration());
     readOnlyAdmins.setAdminUsernames(pReadOnlyAdmins);
     LOG.info("Load conf {} : {}, and now readOnly admins are: {}",
         OZONE_READONLY_ADMINISTRATORS, newVal, pReadOnlyAdmins);


### PR DESCRIPTION
## What changes were proposed in this pull request?
There have some duplicate Method, such as `getOzoneAdminsFromConfig` , `getOzoneAdminsGroupsFromConfig` and `isAdmin` etc, This PR will move them to the class `OzoneAdmin`


## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-8737

Please replace this section with the link to the Apache JIRA)

## How was this patch tested?
The Existing tests
