### PR TITLE
HDDS-8727. Defer non-critical partial EC reconstruction

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/InsufficientDatanodesException.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/InsufficientDatanodesException.java
@@ -23,21 +23,30 @@ import java.io.IOException;
 /**
  * Exception thrown when there are not enough Datanodes to create a pipeline.
  */
-public class InsufficientDatanodesException extends IOException {
+public final class InsufficientDatanodesException extends IOException {
 
+  private final int required;
+  private final int available;
 
-  public InsufficientDatanodesException() {
-    super();
-  }
-
-  public InsufficientDatanodesException(String message) {
+  public InsufficientDatanodesException(int required, int available,
+      String message) {
     super(message);
+    this.required = required;
+    this.available = available;
   }
 
   public InsufficientDatanodesException(int required, int available) {
-    super("Not enough datanodes" +
+    this(required, available, "Not enough datanodes" +
         ", requested: " + required +
         ", found: " + available
     );
+  }
+
+  public int getRequiredNodes() {
+    return required;
+  }
+
+  public int getAvailableNodes() {
+    return available;
   }
 }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/SimplePipelineProvider.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/SimplePipelineProvider.java
@@ -53,11 +53,13 @@ public class SimplePipelineProvider
       List<DatanodeDetails> excludedNodes, List<DatanodeDetails> favoredNodes)
       throws IOException {
     List<DatanodeDetails> dns = pickNodesNotUsed(replicationConfig);
-    if (dns.size() < replicationConfig.getRequiredNodes()) {
-      String e = String
-          .format("Cannot create pipeline of factor %d using %d nodes.",
-              replicationConfig.getRequiredNodes(), dns.size());
-      throw new InsufficientDatanodesException(e);
+    int available = dns.size();
+    int required = replicationConfig.getRequiredNodes();
+    if (available < required) {
+      String msg = String.format(
+          "Cannot create pipeline of factor %d using %d nodes.",
+          required, available);
+      throw new InsufficientDatanodesException(required, available, msg);
     }
 
     Collections.shuffle(dns);


### PR DESCRIPTION
## What changes were proposed in this pull request?

EC offline reconstruction has two properties that may be in conflict:
 * tries to exclude from targets any datanodes that are currently overloaded with replication commands
 * attempts partial reconstruction if full reconstruction is not possible due to lack of enough targets

This may result in multiple subsequent partial reconstructions, wasting resources.

This change lets SCM defer reconstruction if:
 * only partial reconstruction is currently possible AND
 * full reconstruction would be possible using overloaded nodes AND
 * at least one more replica may be lost before the container becomes unrecoverable (i.e. recovery is not yet critical)

The improvement applies to EC(6,3) and EC(10,4) only, because EC(3,2) can only have 1 or 2 replicas missing before becoming unrecoverable: with 1 missing replica recovery is not partial, with 2 missing replicas recovery is "critical".

https://issues.apache.org/jira/browse/HDDS-8727

## How was this patch tested?

Added unit test.

https://github.com/adoroszlai/hadoop-ozone/actions/runs/5134479384