### PR TITLE
HDDS-8557 Cannot reuse MiniOzoneCluster dir due to RocksDBCheckpointDiffer instance cache

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestOzoneRpcClientAbstract.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestOzoneRpcClientAbstract.java
@@ -190,7 +190,7 @@ public abstract class TestOzoneRpcClientAbstract {
       remoteGroupName, READ, ACCESS);
 
   private static String scmId = UUID.randomUUID().toString();
-  private static String clusterId = UUID.randomUUID().toString();
+  private static String clusterId;
 
 
   /**
@@ -201,6 +201,7 @@ public abstract class TestOzoneRpcClientAbstract {
   static void startCluster(OzoneConfiguration conf) throws Exception {
     // Reduce long wait time in MiniOzoneClusterImpl#waitForHddsDatanodesStop
     //  for testZReadKeyWithUnhealthyContainerReplica.
+    clusterId = UUID.randomUUID().toString()
     conf.set("ozone.scm.stale.node.interval", "10s");
     cluster = MiniOzoneCluster.newBuilder(conf)
         .setNumDatanodes(14)


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fix issue in : HDDS-8557 Cannot reuse MiniOzoneCluster dir due to RocksDBCheckpointDiffer instance cache

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-8557

## How was this patch tested?
multiple rounds of CI compatibility test
