### PR TITLE
HDDS-8731. Standardize JVM pause monitor

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/ratis/RatisHelper.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/ratis/RatisHelper.java
@@ -63,6 +63,7 @@ import org.apache.ratis.rpc.RpcType;
 import org.apache.ratis.rpc.SupportedRpcType;
 import org.apache.ratis.thirdparty.com.google.protobuf.ByteString;
 import org.apache.ratis.thirdparty.io.netty.buffer.ByteBuf;
+import org.apache.ratis.util.JvmPauseMonitor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -88,6 +89,10 @@ public final class RatisHelper {
       Collections.emptyList());
 
   private RatisHelper() {
+  }
+
+  public static JvmPauseMonitor newJvmPauseMonitor(String name) {
+    return new JvmPauseMonitor(name, extraSleep -> { });
   }
 
   private static String toRaftPeerIdString(DatanodeDetails id) {
@@ -320,8 +325,6 @@ public final class RatisHelper {
    * Set all client properties matching with regex
    * {@link RatisHelper#HDDS_DATANODE_RATIS_PREFIX_KEY} in
    * ozone configuration object and configure it to RaftProperties.
-   * @param ozoneConf
-   * @param raftProperties
    */
   public static void createRaftClientProperties(ConfigurationSource ozoneConf,
       RaftProperties raftProperties) {
@@ -360,8 +363,6 @@ public final class RatisHelper {
    * Set all server properties matching with prefix
    * {@link RatisHelper#HDDS_DATANODE_RATIS_PREFIX_KEY} in
    * ozone configuration object and configure it to RaftProperties.
-   * @param ozoneConf
-   * @param raftProperties
    */
   public static void createRaftServerProperties(ConfigurationSource ozoneConf,
        RaftProperties raftProperties) {
@@ -447,7 +448,7 @@ public final class RatisHelper {
         }
       } catch (IOException e) {
         LOG.error("Can not get FirstNode from the pipeline: {} with " +
-            "exception: {}", pipeline.toString(), e.getLocalizedMessage());
+            "exception: {}", pipeline, e.getLocalizedMessage());
         return null;
       }
       raftPeers.add(raftPeerId);
@@ -498,7 +499,6 @@ public final class RatisHelper {
    *
    * @param raftGroup     the Raft group
    * @param targetPeerId  the target expected leader
-   * @throws IOException
    */
   public static void transferRatisLeadership(ConfigurationSource conf,
       RaftGroup raftGroup, RaftPeerId targetPeerId, GrpcTlsConfig tlsConfig)

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/DatanodeStateMachine.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/DatanodeStateMachine.java
@@ -318,7 +318,6 @@ public class DatanodeStateMachine implements Closeable {
 
     upgradeFinalizer.runPrefinalizeStateActions(layoutStorage, this);
 
-    // Start jvm monitor
     while (context.getState() != DatanodeStates.SHUTDOWN) {
       try {
         LOG.debug("Executing cycle Number : {}", context.getExecutionCount());

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/DatanodeStateMachine.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/DatanodeStateMachine.java
@@ -41,7 +41,6 @@ import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolPro
 import org.apache.hadoop.hdds.security.x509.certificate.client.CertificateClient;
 import org.apache.hadoop.hdds.upgrade.HDDSLayoutVersionManager;
 import org.apache.hadoop.hdds.utils.IOUtils;
-import org.apache.hadoop.hdds.utils.LegacyHadoopConfigurationSource;
 import org.apache.hadoop.ozone.HddsDatanodeStopService;
 import org.apache.hadoop.ozone.container.common.DatanodeLayoutStorage;
 import org.apache.hadoop.ozone.container.common.report.ReportManager;
@@ -75,7 +74,6 @@ import org.apache.hadoop.ozone.container.upgrade.VersionedDatanodeFeatures;
 import org.apache.hadoop.ozone.protocol.commands.SCMCommand;
 import org.apache.hadoop.ozone.upgrade.UpgradeFinalizer;
 import org.apache.hadoop.ozone.upgrade.UpgradeFinalizer.StatusAndMessages;
-import org.apache.hadoop.util.JvmPauseMonitor;
 import org.apache.hadoop.util.Time;
 
 import com.google.common.annotations.VisibleForTesting;
@@ -108,13 +106,11 @@ public class DatanodeStateMachine implements Closeable {
   private Thread cmdProcessThread = null;
   private final ReplicationSupervisor supervisor;
 
-  private JvmPauseMonitor jvmPauseMonitor;
-  private CertificateClient dnCertClient;
   private final HddsDatanodeStopService hddsDatanodeStopService;
 
-  private HDDSLayoutVersionManager layoutVersionManager;
-  private DatanodeLayoutStorage layoutStorage;
-  private DataNodeUpgradeFinalizer upgradeFinalizer;
+  private final HDDSLayoutVersionManager layoutVersionManager;
+  private final DatanodeLayoutStorage layoutStorage;
+  private final DataNodeUpgradeFinalizer upgradeFinalizer;
 
   /**
    * Used to synchronize to the OzoneContainer object created in the
@@ -126,6 +122,7 @@ public class DatanodeStateMachine implements Closeable {
   private final ReplicationSupervisorMetrics replicationSupervisorMetrics;
   private final ECReconstructionMetrics ecReconstructionMetrics;
   // This is an instance variable as mockito needs to access it in a test
+  @SuppressWarnings("FieldCanBeLocal")
   private final ReconstructECContainersCommandHandler
       reconstructECContainersCommandHandler;
 
@@ -176,7 +173,6 @@ public class DatanodeStateMachine implements Closeable {
     } finally {
       constructionLock.writeLock().unlock();
     }
-    dnCertClient = certClient;
     nextHB = new AtomicLong(Time.monotonicNow());
 
     ContainerImporter importer = new ContainerImporter(conf,
@@ -186,10 +182,10 @@ public class DatanodeStateMachine implements Closeable {
     ContainerReplicator pullReplicator = new DownloadAndImportReplicator(
         conf, container.getContainerSet(),
         importer,
-        new SimpleContainerDownloader(conf, dnCertClient));
+        new SimpleContainerDownloader(conf, certClient));
     ContainerReplicator pushReplicator = new PushReplicator(conf,
         new OnDemandContainerReplicationSource(container.getController()),
-        new GrpcContainerUploader(conf, dnCertClient)
+        new GrpcContainerUploader(conf, certClient)
     );
 
     pullReplicatorWithMetrics = new MeasuredReplicator(pullReplicator, "pull");
@@ -315,7 +311,7 @@ public class DatanodeStateMachine implements Closeable {
    * Runs the state machine at a fixed frequency.
    */
   private void startStateMachineThread() throws IOException {
-    long now = 0;
+    long now;
 
     reportManager.init();
     initCommandHandlerThread(conf);
@@ -323,11 +319,6 @@ public class DatanodeStateMachine implements Closeable {
     upgradeFinalizer.runPrefinalizeStateActions(layoutStorage, this);
 
     // Start jvm monitor
-    jvmPauseMonitor = new JvmPauseMonitor();
-    jvmPauseMonitor
-        .init(LegacyHadoopConfigurationSource.asHadoopConfiguration(conf));
-    jvmPauseMonitor.start();
-
     while (context.getState() != DatanodeStates.SHUTDOWN) {
       try {
         LOG.debug("Executing cycle Number : {}", context.getExecutionCount());
@@ -427,10 +418,6 @@ public class DatanodeStateMachine implements Closeable {
 
     if (container != null) {
       container.stop();
-    }
-
-    if (jvmPauseMonitor != null) {
-      jvmPauseMonitor.stop();
     }
 
     if (commandDispatcher != null) {
@@ -565,8 +552,6 @@ public class DatanodeStateMachine implements Closeable {
 
   /**
    * Waits for DatanodeStateMachine to exit.
-   *
-   * @throws InterruptedException
    */
   public void join() throws InterruptedException {
     if (stateMachineThread != null) {
@@ -643,12 +628,10 @@ public class DatanodeStateMachine implements Closeable {
 
   /**
    * Create a command handler thread.
-   *
-   * @param config
    */
   private void initCommandHandlerThread(ConfigurationSource config) {
 
-    /**
+    /*
      * Task that periodically checks if we have any outstanding commands.
      * It is assumed that commands can be processed slowly and in order.
      * This assumption might change in future. Right now due to this assumption
@@ -657,7 +640,7 @@ public class DatanodeStateMachine implements Closeable {
     Runnable processCommandQueue = () -> {
       long now;
       while (getContext().getState() != DatanodeStates.SHUTDOWN) {
-        SCMCommand command = getContext().getNextCommand();
+        SCMCommand<?> command = getContext().getNextCommand();
         if (command != null) {
           commandDispatcher.handle(command);
           commandsHandled++;

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/StorageContainerManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/StorageContainerManager.java
@@ -158,9 +158,9 @@ import org.apache.hadoop.security.SecurityUtil;
 import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.hadoop.security.UserGroupInformation.AuthenticationMethod;
 import org.apache.hadoop.security.authentication.client.AuthenticationException;
-import org.apache.hadoop.util.JvmPauseMonitor;
 import org.apache.ratis.protocol.RaftPeerId;
 import org.apache.ratis.util.ExitUtils;
+import org.apache.ratis.util.JvmPauseMonitor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.apache.hadoop.hdds.scm.server.SCMDatanodeHeartbeatDispatcher.ContainerReport;
@@ -188,6 +188,7 @@ import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 
 import static org.apache.hadoop.hdds.HddsUtils.preserveThreadName;
+import static org.apache.hadoop.hdds.ratis.RatisHelper.newJvmPauseMonitor;
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_EVENT_REPORT_EXEC_WAIT_THRESHOLD_DEFAULT;
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_EVENT_REPORT_QUEUE_WAIT_THRESHOLD_DEFAULT;
 import static org.apache.hadoop.hdds.security.x509.certificate.authority.CertificateStore.CertType.VALID_CERTS;
@@ -272,7 +273,7 @@ public final class StorageContainerManager extends ServiceRuntimeInfoImpl
   private CertificateClient scmCertificateClient;
   private ContainerTokenSecretManager containerTokenMgr;
 
-  private JvmPauseMonitor jvmPauseMonitor;
+  private final JvmPauseMonitor jvmPauseMonitor;
   private final OzoneConfiguration configuration;
   private SCMContainerMetrics scmContainerMetrics;
   private SCMContainerPlacementMetrics placementMetrics;
@@ -283,7 +284,7 @@ public final class StorageContainerManager extends ServiceRuntimeInfoImpl
   private final Map<String, RatisDropwizardExports> ratisMetricsMap =
       new ConcurrentHashMap<>();
   private List<RatisDropwizardExports.MetricReporter> ratisReporterList = null;
-  private String primaryScmNodeId;
+  private final String primaryScmNodeId;
 
   /**
    *  Network topology Map.
@@ -294,7 +295,7 @@ public final class StorageContainerManager extends ServiceRuntimeInfoImpl
 
   private final SCMHANodeDetails scmHANodeDetails;
 
-  private ContainerBalancer containerBalancer;
+  private final ContainerBalancer containerBalancer;
   // MoveManager is used by ContainerBalancer to schedule container moves
   private final MoveManager moveManager;
   private StatefulServiceStateManager statefulServiceStateManager;
@@ -342,22 +343,20 @@ public final class StorageContainerManager extends ServiceRuntimeInfoImpl
 
     Objects.requireNonNull(configurator, "configurator cannot not be null");
     Objects.requireNonNull(conf, "configuration cannot not be null");
-    /**
-     * It is assumed the scm --init command creates the SCM Storage Config.
-     */
+    // It is assumed the scm --init command creates the SCM Storage Config.
     scmStorageConfig = new SCMStorageConfig(conf);
 
     scmHANodeDetails = SCMHANodeDetails.loadSCMHAConfig(conf, scmStorageConfig);
     configuration = conf;
     initMetrics();
 
+    boolean ratisEnabled = SCMHAUtils.isSCMHAEnabled(conf);
     if (scmStorageConfig.getState() != StorageState.INITIALIZED) {
-      String errMsg = "Please make sure you have run \'ozone scm --init\' " +
+      String errMsg = "Please make sure you have run 'ozone scm --init' " +
           "command to generate all the required metadata to " +
           scmStorageConfig.getStorageDir();
-      if (SCMHAUtils.isSCMHAEnabled(conf) && !scmStorageConfig
-          .isSCMHAEnabled()) {
-        errMsg += " or make sure you have run \'ozone scm --bootstrap\' cmd to "
+      if (ratisEnabled && !scmStorageConfig.isSCMHAEnabled()) {
+        errMsg += " or make sure you have run 'ozone scm --bootstrap' cmd to "
             + "add the SCM to existing SCM HA group";
       }
       LOG.error(errMsg + ".");
@@ -368,7 +367,9 @@ public final class StorageContainerManager extends ServiceRuntimeInfoImpl
     primaryScmNodeId = scmStorageConfig.getPrimaryScmNodeId();
     initializeCertificateClient();
 
-    /**
+    jvmPauseMonitor = !ratisEnabled ? newJvmPauseMonitor(getScmId()) : null;
+
+    /*
      * Important : This initialization sequence is assumed by some of our tests.
      * The testSecureOzoneCluster assumes that security checks have to be
      * passed before any artifacts like SCM DB is created. So please don't
@@ -619,7 +620,7 @@ public final class StorageContainerManager extends ServiceRuntimeInfoImpl
     }
     // This needs to be done before initializing Ratis.
     ratisReporterList = RatisDropwizardExports
-        .registerRatisMetricReporters(ratisMetricsMap, () -> isStopped.get());
+        .registerRatisMetricReporters(ratisMetricsMap, isStopped::get);
     if (configurator.getSCMHAManager() != null) {
       scmHAManager = configurator.getSCMHAManager();
     } else {
@@ -808,7 +809,6 @@ public final class StorageContainerManager extends ServiceRuntimeInfoImpl
    * @param conf - Config
    * @param configurator - configurator
    * @throws IOException - on Failure
-   * @throws AuthenticationException - on Failure
    */
   private void initializeCAnSecurityProtocol(OzoneConfiguration conf,
       SCMConfigurator configurator) throws IOException {
@@ -885,9 +885,8 @@ public final class StorageContainerManager extends ServiceRuntimeInfoImpl
     }
   }
 
-  /** Persist primary SCM root ca cert and sub-ca certs to DB.
-   *
-   * @throws IOException
+  /**
+   * Persist primary SCM root ca cert and sub-ca certs to DB.
    */
   private void persistPrimarySCMCerts() throws IOException {
     BigInteger certSerial =
@@ -1000,8 +999,6 @@ public final class StorageContainerManager extends ServiceRuntimeInfoImpl
 
   /**
    * Login as the configured user for SCM.
-   *
-   * @param conf
    */
   private static void loginAsSCMUserIfSecurityEnabled(
       SCMHANodeDetails scmhaNodeDetails, ConfigurationSource conf)
@@ -1057,7 +1054,7 @@ public final class StorageContainerManager extends ServiceRuntimeInfoImpl
   public static String buildRpcServerStartMessage(String description,
                                                   InetSocketAddress addr) {
     return addr != null
-        ? String.format("%s is listening at %s", description, addr.toString())
+        ? String.format("%s is listening at %s", description, addr)
         : String.format("%s not started", description);
   }
 
@@ -1199,10 +1196,6 @@ public final class StorageContainerManager extends ServiceRuntimeInfoImpl
   /**
    * Initialize security If Ozone security is enabled and
    * ScmStorageConfig does not have certificate serial id.
-   * @param conf
-   * @param scmhaNodeDetails
-   * @param scmStorageConfig
-   * @throws IOException
    */
   private static void initializeSecurityIfNeeded(
       OzoneConfiguration conf, SCMHANodeDetails scmhaNodeDetails,
@@ -1507,9 +1500,9 @@ public final class StorageContainerManager extends ServiceRuntimeInfoImpl
     leaseManager.start();
 
     // Start jvm monitor
-    jvmPauseMonitor = new JvmPauseMonitor();
-    jvmPauseMonitor.init(configuration);
-    jvmPauseMonitor.start();
+    if (jvmPauseMonitor != null) {
+      jvmPauseMonitor.start();
+    }
 
     try {
       httpServer = new StorageContainerManagerHttpServer(configuration, this);
@@ -1525,9 +1518,8 @@ public final class StorageContainerManager extends ServiceRuntimeInfoImpl
     scmHAMetricsUpdate(null);
   }
 
-  /** Persist SCM certs to DB on bootstrap scm nodes.
-   *
-   * @throws IOException
+  /**
+   * Persist SCM certs to DB on bootstrap scm nodes.
    */
   private void persistSCMCertificates() throws IOException {
     // Fetch all CA's and persist during startup on bootstrap nodes. This

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/StorageContainerManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/StorageContainerManager.java
@@ -1499,7 +1499,6 @@ public final class StorageContainerManager extends ServiceRuntimeInfoImpl
     scmBlockManager.start();
     leaseManager.start();
 
-    // Start jvm monitor
     if (jvmPauseMonitor != null) {
       jvmPauseMonitor.start();
     }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
@@ -82,6 +82,7 @@ import org.apache.hadoop.hdds.ratis.RatisHelper;
 import org.apache.hadoop.hdds.scm.ScmInfo;
 import org.apache.hadoop.hdds.scm.client.HddsClientUtils;
 import org.apache.hadoop.hdds.server.OzoneAdmins;
+import org.apache.hadoop.hdds.utils.IOUtils;
 import org.apache.hadoop.hdds.utils.db.Table;
 import org.apache.hadoop.hdds.utils.db.Table.KeyValue;
 import org.apache.hadoop.hdds.utils.db.TableIterator;
@@ -209,9 +210,7 @@ import org.apache.hadoop.security.SecurityUtil;
 import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.hadoop.security.UserGroupInformation.AuthenticationMethod;
 import org.apache.hadoop.security.authentication.client.AuthenticationException;
-import org.apache.hadoop.security.token.SecretManager.InvalidToken;
 import org.apache.hadoop.security.token.Token;
-import org.apache.hadoop.util.JvmPauseMonitor;
 import org.apache.hadoop.util.KMSUtil;
 import org.apache.hadoop.util.Time;
 
@@ -231,12 +230,11 @@ import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_BLOCK_TOKEN_ENABLED;
 import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_BLOCK_TOKEN_ENABLED_DEFAULT;
 import static org.apache.hadoop.hdds.HddsUtils.getScmAddressForClients;
 import static org.apache.hadoop.hdds.HddsUtils.preserveThreadName;
+import static org.apache.hadoop.hdds.ratis.RatisHelper.newJvmPauseMonitor;
 import static org.apache.hadoop.hdds.server.ServerUtils.updateRPCListenAddress;
 import static org.apache.hadoop.hdds.utils.HAUtils.getScmInfo;
 import static org.apache.hadoop.ozone.OmUtils.MAX_TRXN_ID;
 import static org.apache.hadoop.ozone.OzoneAcl.AclScope.ACCESS;
-import static org.apache.hadoop.ozone.OzoneConfigKeys.DFS_CONTAINER_RATIS_ENABLED_DEFAULT;
-import static org.apache.hadoop.ozone.OzoneConfigKeys.DFS_CONTAINER_RATIS_ENABLED_KEY;
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_ACL_ENABLED;
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_ACL_ENABLED_DEFAULT;
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_ADMINISTRATORS;
@@ -309,6 +307,7 @@ import org.apache.ratis.server.RaftServer;
 import org.apache.ratis.server.protocol.TermIndex;
 import org.apache.ratis.util.ExitUtils;
 import org.apache.ratis.util.FileUtils;
+import org.apache.ratis.util.JvmPauseMonitor;
 import org.apache.ratis.util.LifeCycle;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -343,8 +342,8 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
   private OzoneConfiguration configuration;
   private RPC.Server omRpcServer;
   private GrpcOzoneManagerServer omS3gGrpcServer;
-  private InetSocketAddress omRpcAddress;
-  private String omId;
+  private final InetSocketAddress omRpcAddress;
+  private final String omId;
 
   private OMMetadataManager metadataManager;
   private OMMultiTenantManager multiTenantManager;
@@ -352,7 +351,7 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
   private BucketManager bucketManager;
   private KeyManager keyManager;
   private PrefixManagerImpl prefixManager;
-  private UpgradeFinalizer<OzoneManager> upgradeFinalizer;
+  private final UpgradeFinalizer<OzoneManager> upgradeFinalizer;
 
   /**
    * OM super user / admin list.
@@ -378,11 +377,10 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
   private static final ObjectReader READER =
       new ObjectMapper().readerFor(OmMetricsInfo.class);
   private static final int SHUTDOWN_HOOK_PRIORITY = 30;
-  private final Runnable shutdownHook;
   private final File omMetaDir;
   private boolean isAclEnabled;
   private final boolean isSpnegoEnabled;
-  private JvmPauseMonitor jvmPauseMonitor;
+  private final JvmPauseMonitor jvmPauseMonitor;
   private final SecurityConfig secConfig;
   private S3SecretManager s3SecretManager;
   private final boolean isOmGrpcServerEnabled;
@@ -391,28 +389,26 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
   private String omComponent;
   private OzoneManagerProtocolServerSideTranslatorPB omServerProtocol;
 
-  private boolean isRatisEnabled;
+  private final boolean isRatisEnabled;
   private OzoneManagerRatisServer omRatisServer;
   private OmRatisSnapshotProvider omRatisSnapshotProvider;
   private OMNodeDetails omNodeDetails;
-  private Map<String, OMNodeDetails> peerNodesMap;
+  private final Map<String, OMNodeDetails> peerNodesMap;
   private File omRatisSnapshotDir;
   private final RatisSnapshotInfo omRatisSnapshotInfo;
   private final Map<String, RatisDropwizardExports> ratisMetricsMap =
       new ConcurrentHashMap<>();
   private List<RatisDropwizardExports.MetricReporter> ratisReporterList = null;
 
-  private KeyProviderCryptoExtension kmsProvider = null;
-  private static String keyProviderUriKeyName =
-      CommonConfigurationKeysPublic.HADOOP_SECURITY_KEY_PROVIDER_PATH;
-  private OMLayoutVersionManager versionManager;
+  private KeyProviderCryptoExtension kmsProvider;
+  private final OMLayoutVersionManager versionManager;
 
   private final ReplicationConfigValidator replicationConfigValidator;
 
   private boolean allowListAllVolumes;
   // Adding parameters needed for VolumeRequests here, so that during request
   // execution, we can get from ozoneManager.
-  private long maxUserVolumeCount;
+  private final long maxUserVolumeCount;
 
   private int minMultipartUploadPartSize = OzoneConsts.OM_MULTIPART_MIN_SIZE;
 
@@ -420,12 +416,11 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
   private final long scmBlockSize;
   private final int preallocateBlocksMax;
   private final boolean grpcBlockTokenEnabled;
-  private final boolean useRatisForReplication;
   private final BucketLayout defaultBucketLayout;
-  private ReplicationConfig defaultReplicationConfig;
+  private final ReplicationConfig defaultReplicationConfig;
 
-  private boolean isS3MultiTenancyEnabled;
-  private boolean isStrictS3;
+  private final boolean isS3MultiTenancyEnabled;
+  private final boolean isStrictS3;
   private ExitManager exitManager;
 
   private OzoneManagerPrepareState prepareState;
@@ -439,9 +434,9 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
   private static UserGroupInformation testUgi;
 
   private final OzoneLockProvider ozoneLockProvider;
-  private OMPerformanceMetrics perfMetrics;
+  private final OMPerformanceMetrics perfMetrics;
 
-  private boolean fsSnapshotEnabled;
+  private final boolean fsSnapshotEnabled;
 
   /**
    * OM Startup mode.
@@ -541,8 +536,6 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
         OZONE_KEY_PREALLOCATION_BLOCKS_MAX_DEFAULT);
     this.grpcBlockTokenEnabled = conf.getBoolean(HDDS_BLOCK_TOKEN_ENABLED,
         HDDS_BLOCK_TOKEN_ENABLED_DEFAULT);
-    this.useRatisForReplication = conf.getBoolean(
-        DFS_CONTAINER_RATIS_ENABLED_KEY, DFS_CONTAINER_RATIS_ENABLED_DEFAULT);
     this.isStrictS3 = conf.getBoolean(
         OZONE_OM_NAMESPACE_STRICT_S3,
         OZONE_OM_NAMESPACE_STRICT_S3_DEFAULT);
@@ -553,6 +546,9 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
     isRatisEnabled = configuration.getBoolean(
         OMConfigKeys.OZONE_OM_RATIS_ENABLE_KEY,
         OMConfigKeys.OZONE_OM_RATIS_ENABLE_DEFAULT);
+
+    // Ratis server comes with JvmPauseMonitor, no need to start another
+    jvmPauseMonitor = !isRatisEnabled ? newJvmPauseMonitor(omId) : null;
 
     fsSnapshotEnabled = configuration.getBoolean(
         OMConfigKeys.OZONE_FILESYSTEM_SNAPSHOT_ENABLED_KEY,
@@ -694,10 +690,7 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
     if (isOmGrpcServerEnabled) {
       omS3gGrpcServer = getOmS3gGrpcServer(configuration);
     }
-    shutdownHook = () -> {
-      saveOmMetrics();
-    };
-    ShutdownHookManager.get().addShutdownHook(shutdownHook,
+    ShutdownHookManager.get().addShutdownHook(this::saveOmMetrics,
         SHUTDOWN_HOOK_PRIORITY);
 
     if (isBootstrapping || isForcedBootstrapping) {
@@ -760,7 +753,7 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
 
   private void logVersionMismatch(OzoneConfiguration conf, ScmInfo scmInfo) {
     List<SCMNodeInfo> scmNodeInfoList = SCMNodeInfo.buildNodeInfo(conf);
-    StringBuilder scmBlockAddressBuilder = new StringBuilder("");
+    StringBuilder scmBlockAddressBuilder = new StringBuilder();
     for (SCMNodeInfo scmNodeInfo : scmNodeInfoList) {
       scmBlockAddressBuilder.append(scmNodeInfo.getBlockClientAddress())
           .append(",");
@@ -864,14 +857,6 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
   }
 
   /**
-   * Return configuration value of
-   * {@link OzoneConfigKeys#DFS_CONTAINER_RATIS_ENABLED_KEY}.
-   */
-  public boolean shouldUseRatis() {
-    return useRatisForReplication;
-  }
-
-  /**
    * Return scmClient.
    */
   public ScmClient getScmClient() {
@@ -946,13 +931,12 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
   private KeyProviderCryptoExtension createKeyProviderExt(
       OzoneConfiguration conf) throws IOException {
     KeyProvider keyProvider = KMSUtil.createKeyProvider(conf,
-        keyProviderUriKeyName);
+        CommonConfigurationKeysPublic.HADOOP_SECURITY_KEY_PROVIDER_PATH);
     if (keyProvider == null) {
       return null;
     }
-    KeyProviderCryptoExtension cryptoProvider = KeyProviderCryptoExtension
+    return KeyProviderCryptoExtension
         .createKeyProviderCryptoExtension(keyProvider);
-    return cryptoProvider;
   }
 
   @Override
@@ -972,7 +956,6 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
 
   private void saveOmMetrics() {
     try {
-      boolean success;
       File parent = getTempMetricsStorageFile().getParentFile();
       if (!parent.exists()) {
         Files.createDirectories(parent.toPath());
@@ -983,14 +966,11 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
         OmMetricsInfo metricsInfo = new OmMetricsInfo();
         metricsInfo.setNumKeys(metrics.getNumKeys());
         WRITER.writeValue(writer, metricsInfo);
-        success = true;
       }
 
-      if (success) {
-        Files.move(getTempMetricsStorageFile().toPath(),
-            getMetricsStorageFile().toPath(), StandardCopyOption
-                .ATOMIC_MOVE, StandardCopyOption.REPLACE_EXISTING);
-      }
+      Files.move(getTempMetricsStorageFile().toPath(),
+          getMetricsStorageFile().toPath(), StandardCopyOption
+              .ATOMIC_MOVE, StandardCopyOption.REPLACE_EXISTING);
     } catch (IOException ex) {
       LOG.error("Unable to write the om Metrics file", ex);
     }
@@ -1139,9 +1119,6 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
 
   /**
    * Login OM service user if security and Kerberos are enabled.
-   *
-   * @param conf
-   * @throws IOException, AuthenticationException
    */
   private static void loginOMUser(OzoneConfiguration conf)
       throws IOException, AuthenticationException {
@@ -1172,10 +1149,9 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
    * Create a scm block client, used by putKey() and getKey().
    *
    * @return {@link ScmBlockLocationProtocol}
-   * @throws IOException
    */
   private static ScmBlockLocationProtocol getScmBlockClient(
-      OzoneConfiguration conf) throws IOException {
+      OzoneConfiguration conf) {
     return HAUtils.getScmBlockClient(conf);
   }
 
@@ -1299,8 +1275,7 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
    * @return gRPC server
    * @throws IOException if there is an I/O error while creating RPC server
    */
-  private GrpcOzoneManagerServer startGrpcServer(OzoneConfiguration conf)
-          throws IOException {
+  private GrpcOzoneManagerServer startGrpcServer(OzoneConfiguration conf) {
     return new GrpcOzoneManagerServer(conf,
             this.omServerProtocol,
             this.delegationTokenMgr,
@@ -1341,7 +1316,7 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
     loginOMUserIfSecurityEnabled(conf);
     OMStorage omStorage = new OMStorage(conf);
     StorageState state = omStorage.getState();
-    String scmId = null;
+    String scmId;
     try {
       ScmInfo scmInfo = getScmInfo(conf);
       scmId = scmInfo.getScmId();
@@ -1398,6 +1373,7 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
       LOG.info("Re-initialize certificate client.");
       omStore.unsetOmCertSerialId();
       omStore.persistCurrentState();
+      IOUtils.close(LOG, certClient);
       certClient = new OMCertificateClient(
           new SecurityConfig(conf), omStore, scmId, null, null);
       response = certClient.init();
@@ -1496,9 +1472,9 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
    */
   private static String buildRpcServerStartMessage(String description,
       InetSocketAddress addr) {
-    return addr != null ? String.format("%s is listening at %s",
-        description, addr.toString()) :
-        String.format("%s not started", description);
+    return addr != null
+        ? String.format("%s is listening at %s", description, addr)
+        : String.format("%s not started", description);
   }
 
   @VisibleForTesting
@@ -1910,14 +1886,12 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
 
     // NodeIds present in new node list and not in current peer list are the
     // bootstapped OMs and should be added to the peer list
-    List<String> bootstrappedOMs = new ArrayList<>();
-    bootstrappedOMs.addAll(newPeers);
+    List<String> bootstrappedOMs = new ArrayList<>(newPeers);
     bootstrappedOMs.removeAll(currentPeers);
 
     // NodeIds present in current peer list but not in new node list are the
     // decommissioned OMs and should be removed from the peer list
-    List<String> decommissionedOMs = new ArrayList<>();
-    decommissionedOMs.addAll(currentPeers);
+    List<String> decommissionedOMs = new ArrayList<>(currentPeers);
     decommissionedOMs.removeAll(newPeers);
 
     // Add bootstrapped OMs to peer list
@@ -2082,8 +2056,6 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
   /**
    * Starts a Trash Emptier thread that does an fs.trashRoots and performs
    * checkpointing & deletion.
-   * @param conf
-   * @throws IOException
    */
   private void startTrashEmptier(Configuration conf) throws IOException {
     if (emptier == null) {
@@ -2105,12 +2077,8 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
 
       OzoneManager i = this;
       FileSystem fs = SecurityUtil.doAsLoginUser(
-          new PrivilegedExceptionAction<FileSystem>() {
-            @Override
-            public FileSystem run() throws IOException {
-              return new TrashOzoneFileSystem(i);
-            }
-          });
+          (PrivilegedExceptionAction<FileSystem>)
+              () -> new TrashOzoneFileSystem(i));
       this.emptier = new Thread(new OzoneTrash(fs, conf, this).
           getEmptier(), "Trash Emptier");
       this.emptier.setDaemon(true);
@@ -2123,8 +2091,7 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
    * for serving s3g OmRequests.  If an earlier instance is already running
    * then returns the same.
    */
-  private GrpcOzoneManagerServer getOmS3gGrpcServer(OzoneConfiguration conf)
-      throws IOException {
+  private GrpcOzoneManagerServer getOmS3gGrpcServer(OzoneConfiguration conf) {
     if (isOmGrpcServerRunning) {
       return omS3gGrpcServer;
     }
@@ -2133,13 +2100,9 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
 
   /**
    * Creates an instance of ratis server.
-   */
-  /**
-   * Creates an instance of ratis server.
    * @param shouldBootstrap If OM is started in Bootstrap mode, then Ratis
    *                        server will be initialized without adding self to
    *                        Ratis group
-   * @throws IOException
    */
   private void initializeRatisServer(boolean shouldBootstrap)
       throws IOException {
@@ -2147,7 +2110,7 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
       if (omRatisServer == null) {
         // This needs to be done before initializing Ratis.
         ratisReporterList = RatisDropwizardExports.
-            registerRatisMetricReporters(ratisMetricsMap, () -> isStopped());
+            registerRatisMetricReporters(ratisMetricsMap, this::isStopped);
         omRatisServer = OzoneManagerRatisServer.newOMRatisServer(
             configuration, this, omNodeDetails, peerNodesMap,
             secConfig, certClient, shouldBootstrap);
@@ -2314,20 +2277,16 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
    */
   private boolean isAllowedDelegationTokenOp() throws IOException {
     AuthenticationMethod authMethod = getConnectionAuthenticationMethod();
-    if (UserGroupInformation.isSecurityEnabled()
-        && (authMethod != AuthenticationMethod.KERBEROS)
-        && (authMethod != AuthenticationMethod.KERBEROS_SSL)
-        && (authMethod != AuthenticationMethod.CERTIFICATE)) {
-      return false;
-    }
-    return true;
+    return !UserGroupInformation.isSecurityEnabled()
+        || (authMethod == AuthenticationMethod.KERBEROS)
+        || (authMethod == AuthenticationMethod.KERBEROS_SSL)
+        || (authMethod == AuthenticationMethod.CERTIFICATE);
   }
 
   /**
    * Returns authentication method used to establish the connection.
    *
    * @return AuthenticationMethod used to establish connection
-   * @throws IOException
    */
   private AuthenticationMethod getConnectionAuthenticationMethod()
       throws IOException {
@@ -2351,12 +2310,10 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
    *
    * @param renewer Renewer information
    * @return delegationToken DelegationToken signed by OzoneManager
-   * @throws IOException on error
    */
   @Override
   public Token<OzoneTokenIdentifier> getDelegationToken(Text renewer)
       throws OMException {
-    Token<OzoneTokenIdentifier> token;
     try {
       if (!isAllowedDelegationTokenOp()) {
         throw new OMException("Delegation Token can be issued only with "
@@ -2391,8 +2348,6 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
    *
    * @param token token to renew
    * @return new expiryTime of the token
-   * @throws InvalidToken if {@code token} is invalid
-   * @throws IOException  on other errors
    */
   @Override
   public long renewDelegationToken(Token<OzoneTokenIdentifier> token)
@@ -2415,7 +2370,7 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
       OzoneTokenIdentifier id = null;
       try {
         id = OzoneTokenIdentifier.readProtoBuf(token.getIdentifier());
-      } catch (IOException exe) {
+      } catch (IOException ignored) {
       }
       LOG.error("Delegation token renewal failed for dt id: {}, cause: {}",
           id, ex.getMessage());
@@ -2429,7 +2384,6 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
    * Cancels a delegation token.
    *
    * @param token token to cancel
-   * @throws IOException on error
    */
   @Override
   public void cancelDelegationToken(Token<OzoneTokenIdentifier> token)
@@ -2453,11 +2407,8 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
     if (ownerName == null) {
       return false;
     }
-    if (callerUgi.getUserName().equals(ownerName) ||
-            callerUgi.getShortUserName().equals(ownerName)) {
-      return true;
-    }
-    return false;
+    return callerUgi.getUserName().equals(ownerName) ||
+        callerUgi.getShortUserName().equals(ownerName);
   }
 
   /**
@@ -2493,7 +2444,7 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
     Boolean lockAcquired = metadataManager.getLock().acquireReadLock(
         VOLUME_LOCK, volume);
     String dbVolumeKey = metadataManager.getVolumeKey(volume);
-    OmVolumeArgs volumeArgs = null;
+    OmVolumeArgs volumeArgs;
     try {
       volumeArgs = metadataManager.getVolumeTable().get(dbVolumeKey);
     } catch (IOException ioe) {
@@ -2533,7 +2484,7 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
 
   private String getBucketOwner(String volume, String bucket)
       throws OMException {
-    OmBucketInfo bucketInfo = null;
+    OmBucketInfo bucketInfo;
 
     boolean lockAcquired = metadataManager.getLock().acquireReadLock(
             BUCKET_LOCK, volume, bucket);
@@ -2624,7 +2575,6 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
    *
    * @param volume - Volume name.
    * @return VolumeArgs or exception is thrown.
-   * @throws IOException
    */
   @Override
   public OmVolumeArgs getVolumeInfo(String volume) throws IOException {
@@ -2661,7 +2611,6 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
    *                 prevkey
    * @param maxKeys  - Max number of keys to return.
    * @return List of Volumes.
-   * @throws IOException
    */
   @Override
   public List<OmVolumeArgs> listVolumeByUser(String userName, String prefix,
@@ -2729,7 +2678,6 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
    *                prevkey
    * @param maxKeys - Max number of keys to return.
    * @return List of Volumes.
-   * @throws IOException
    */
   @Override
   public List<OmVolumeArgs> listAllVolumes(String prefix, String prevKey, int
@@ -2810,7 +2758,6 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
    * @param volume - Volume name.
    * @param bucket - Bucket name.
    * @return OmBucketInfo or exception is thrown.
-   * @throws IOException
    */
   @Override
   public OmBucketInfo getBucketInfo(String volume, String bucket)
@@ -2825,9 +2772,7 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
             bucket, null);
       }
       metrics.incNumBucketInfos();
-      final OmBucketInfo bucketInfo =
-          bucketManager.getBucketInfo(volume, bucket);
-      return bucketInfo;
+      return bucketManager.getBucketInfo(volume, bucket);
     } catch (Exception ex) {
       metrics.incNumBucketInfoFails();
       auditSuccess = false;
@@ -2847,7 +2792,6 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
    *
    * @param args - attributes of the key.
    * @return OmKeyInfo - the info about the requested key.
-   * @throws IOException
    */
   @Override
   public OmKeyInfo lookupKey(OmKeyArgs args) throws IOException {
@@ -2973,7 +2917,7 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
 
   @Override
   public String getRatisRoles() {
-    List<ServiceInfo> serviceList = null;
+    List<ServiceInfo> serviceList;
     int port = omNodeDetails.getRatisPort();
     RaftPeer leaderId;
     if (isRatisEnabled) {
@@ -2986,7 +2930,7 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
         serviceList = getServiceList();
       } catch (IOException e) {
         LOG.error("IO-Exception Occurred", e);
-        return "Exception: " + e.toString();
+        return "Exception: " + e;
       }
       return OmUtils.format(serviceList, port, leaderId.getId().toString());
     } else {
@@ -3799,7 +3743,6 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
    * @param lastAppliedIndex the last applied index in the current OM DB.
    * @param checkpointPath   path to the new DB checkpoint
    * @return location of backup of the original DB
-   * @throws Exception
    */
   File replaceOMDBWithCheckpoint(long lastAppliedIndex, File oldDB,
       Path checkpointPath) throws IOException {
@@ -4000,19 +3943,16 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
    * process the requests.
    *
    * If ratis is not enabled, then it always returns true.
-   * @return
    */
   public boolean isLeaderReady() {
-    return isRatisEnabled ?
-        omRatisServer.checkLeaderStatus() == LEADER_AND_READY : true;
+    return !isRatisEnabled
+        || omRatisServer.checkLeaderStatus() == LEADER_AND_READY;
   }
 
   /**
-   * Check the leader status.
-   *
-   * @return null                       leader is ready
-   *         OMLeaderNotReadyException  leader is not ready
-   *         OMNotLeaderException       not leader
+   * Checks the leader status.  Does nothing if this OM is leader and is ready.
+   * @throws OMLeaderNotReadyException  if leader, but not ready
+   * @throws OMNotLeaderException       if not leader
    */
   public void checkLeaderStatus() throws OMNotLeaderException,
       OMLeaderNotReadyException {
@@ -4039,8 +3979,6 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
 
   /**
    * Return if Ratis is enabled or not.
-   *
-   * @return
    */
   public boolean isRatisEnabled() {
     return isRatisEnabled;
@@ -4136,10 +4074,9 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
   }
 
   private void startJVMPauseMonitor() {
-    // Start jvm monitor
-    jvmPauseMonitor = new JvmPauseMonitor();
-    jvmPauseMonitor.init(configuration);
-    jvmPauseMonitor.start();
+    if (jvmPauseMonitor != null) {
+      jvmPauseMonitor.start();
+    }
   }
 
   public ResolvedBucket resolveBucketLink(KeyArgs args,
@@ -4197,9 +4134,6 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
    * @param volumeAndBucket the bucket to be resolved (if it is a link)
    * @param visited collects link buckets visited during the resolution to
    *   avoid infinite loops
-   * @param {@link UserGroupInformation}
-   * @param remoteAddress
-   * @param hostName
    * @return bucket location possibly updated with its actual volume and bucket
    *   after following bucket links
    * @throws IOException (most likely OMException) if ACL check fails, bucket is
@@ -4277,7 +4211,6 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
 
   /**
    * Create volume which is required for S3Gateway operations.
-   * @throws IOException
    */
   private void addS3GVolumeToDB() throws IOException {
     String s3VolumeName = HddsClientUtils.getDefaultS3VolumeName(configuration);
@@ -4361,7 +4294,7 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
     List<String> userGroups = Arrays.asList(UserGroupInformation
         .createRemoteUser(userName).getGroupNames());
 
-    userGroups.stream().forEach((group) -> listOfAcls.add(
+    userGroups.forEach((group) -> listOfAcls.add(
         new OzoneAcl(ACLIdentityType.GROUP, group, ACLType.ALL, ACCESS)));
 
     // Add ACLs
@@ -4488,14 +4421,13 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
 
   @Override
   public EchoRPCResponse echoRPCReq(byte[] payloadReq,
-                                    int payloadSizeResp)
-          throws IOException {
+                                    int payloadSizeResp) {
     return null;
   }
 
   @Override
   public boolean recoverLease(String volumeName, String bucketName,
-                              String keyName) throws IOException {
+                              String keyName) {
     return false;
   }
 
@@ -4607,7 +4539,7 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
   }
 
   @Override // ReconfigureProtocol
-  public String getServerName() throws IOException {
+  public String getServerName() {
     return "OM";
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

 * Replace Hadoop's `JvmPauseMonitor` with the one from Ratis in OM and SCM for non-HA.  (With HA, Ratis automatically starts `JvmPauseMonitor`.)
 * Remove Hadoop's `JvmPauseMonitor` from datanode (which also has the one from Ratis).
 * Add `JvmPauseMonitor` in Recon and S3 Gateway.
 * HttpFS is unchanged, as it uses `JvmPauseMonitor` with the Hadoop metrics.

https://issues.apache.org/jira/browse/HDDS-8731

## How was this patch tested?

Temporarily changed config in `ozone` compose environment to disable Ratis in OM and SCM:

```
OZONE-SITE.XML_ozone.scm.ratis.enable=false
OZONE-SITE.XML_ozone.om.ratis.enable=false
```

Checked logs for `JvmPauseMonitor` output:

```
scm_1       | 2023-06-01 07:08:27,260 [JvmPauseMonitor0] INFO util.JvmPauseMonitor: JvmPauseMonitor-53e975e9-f056-4c13-9ed0-1fd833e12de6: Started
om_1        | 2023-06-01 07:08:30,457 [JvmPauseMonitor0] INFO util.JvmPauseMonitor: JvmPauseMonitor-c730746b-bff5-4eea-957d-89884f969a83: Started
```

Also checked CI logs:

```
datanode1_1  | 2023-05-31 22:22:14,358 [JvmPauseMonitor0] INFO util.JvmPauseMonitor: JvmPauseMonitor-dc62510b-f2bc-4027-bd54-e7557a46c04a: Started
datanode2_1  | 2023-05-31 22:22:14,304 [JvmPauseMonitor0] INFO util.JvmPauseMonitor: JvmPauseMonitor-5cb115c7-a534-4766-9c3c-8510d546970e: Started
datanode3_1  | 2023-05-31 22:22:15,788 [JvmPauseMonitor0] INFO util.JvmPauseMonitor: JvmPauseMonitor-176213ad-6890-4137-9d56-17155c09848f: Started
om1_1        | 2023-05-31 22:22:46,857 [JvmPauseMonitor0] INFO util.JvmPauseMonitor: JvmPauseMonitor-om1: Started
om2_1        | 2023-05-31 22:22:50,709 [JvmPauseMonitor0] INFO util.JvmPauseMonitor: JvmPauseMonitor-om2: Started
om3_1        | 2023-05-31 22:22:48,214 [JvmPauseMonitor0] INFO util.JvmPauseMonitor: JvmPauseMonitor-om3: Started
recon_1      | 2023-05-31 22:24:14,844 [JvmPauseMonitor0] INFO util.JvmPauseMonitor: JvmPauseMonitor-Recon: Started
s3g_1        | 2023-05-31 22:19:53,994 [JvmPauseMonitor0] INFO util.JvmPauseMonitor: JvmPauseMonitor-S3G: Started
scm1.org_1   | 2023-05-31 22:20:17,957 [JvmPauseMonitor0] INFO util.JvmPauseMonitor: JvmPauseMonitor-a7441ac5-6d0b-4791-9e02-202ed584e3d8: Started
scm2.org_1   | 2023-05-31 22:20:43,301 [JvmPauseMonitor0] INFO util.JvmPauseMonitor: JvmPauseMonitor-cb18fbfd-00b6-40c5-968d-4c8c6c3a5f5d: Started
scm3.org_1   | 2023-05-31 22:21:04,495 [JvmPauseMonitor0] INFO util.JvmPauseMonitor: JvmPauseMonitor-ba411f21-f2be-4770-b0a7-a86d665290e3: Started
```

And logs of an HA integration test:

```
[JvmPauseMonitor0] INFO  util.JvmPauseMonitor (JvmPauseMonitor.java:run(103)) - JvmPauseMonitor-2cfafcb0-6fb7-4429-af27-d12c9cdc3486: Started
[JvmPauseMonitor0] INFO  util.JvmPauseMonitor (JvmPauseMonitor.java:run(109)) - JvmPauseMonitor-2cfafcb0-6fb7-4429-af27-d12c9cdc3486: Stopped
[JvmPauseMonitor1] INFO  util.JvmPauseMonitor (JvmPauseMonitor.java:run(103)) - JvmPauseMonitor-2cfafcb0-6fb7-4429-af27-d12c9cdc3486: Started
[JvmPauseMonitor2] INFO  util.JvmPauseMonitor (JvmPauseMonitor.java:run(103)) - JvmPauseMonitor-b8291a7d-1d53-46e7-80d1-9121a46e1600: Started
[JvmPauseMonitor3] INFO  util.JvmPauseMonitor (JvmPauseMonitor.java:run(103)) - JvmPauseMonitor-80f6a8ef-98cf-4f0b-b878-538ca6967471: Started
[JvmPauseMonitor4] INFO  util.JvmPauseMonitor (JvmPauseMonitor.java:run(103)) - JvmPauseMonitor-omNode-1: Started
[JvmPauseMonitor5] INFO  util.JvmPauseMonitor (JvmPauseMonitor.java:run(103)) - JvmPauseMonitor-omNode-2: Started
[JvmPauseMonitor6] INFO  util.JvmPauseMonitor (JvmPauseMonitor.java:run(103)) - JvmPauseMonitor-omNode-3: Started
[JvmPauseMonitor7] INFO  util.JvmPauseMonitor (JvmPauseMonitor.java:run(103)) - JvmPauseMonitor-2ecd1af4-338e-44cb-927e-9eb5b664ac82: Started
[JvmPauseMonitor8] INFO  util.JvmPauseMonitor (JvmPauseMonitor.java:run(103)) - JvmPauseMonitor-075e4d60-eed2-4150-bea0-bb71654ce811: Started
[JvmPauseMonitor9] INFO  util.JvmPauseMonitor (JvmPauseMonitor.java:run(103)) - JvmPauseMonitor-d2a35d79-ca96-4007-8985-041b914415db: Started
[JvmPauseMonitor6] INFO  util.JvmPauseMonitor (JvmPauseMonitor.java:run(109)) - JvmPauseMonitor-omNode-3: Stopped
[JvmPauseMonitor4] INFO  util.JvmPauseMonitor (JvmPauseMonitor.java:run(109)) - JvmPauseMonitor-omNode-1: Stopped
[JvmPauseMonitor5] INFO  util.JvmPauseMonitor (JvmPauseMonitor.java:run(109)) - JvmPauseMonitor-omNode-2: Stopped
[JvmPauseMonitor2] INFO  util.JvmPauseMonitor (JvmPauseMonitor.java:run(109)) - JvmPauseMonitor-b8291a7d-1d53-46e7-80d1-9121a46e1600: Stopped
[JvmPauseMonitor3] INFO  util.JvmPauseMonitor (JvmPauseMonitor.java:run(109)) - JvmPauseMonitor-80f6a8ef-98cf-4f0b-b878-538ca6967471: Stopped
[JvmPauseMonitor1] INFO  util.JvmPauseMonitor (JvmPauseMonitor.java:run(109)) - JvmPauseMonitor-2cfafcb0-6fb7-4429-af27-d12c9cdc3486: Stopped
[JvmPauseMonitor9] INFO  util.JvmPauseMonitor (JvmPauseMonitor.java:run(109)) - JvmPauseMonitor-d2a35d79-ca96-4007-8985-041b914415db: Stopped
[JvmPauseMonitor7] INFO  util.JvmPauseMonitor (JvmPauseMonitor.java:run(109)) - JvmPauseMonitor-2ecd1af4-338e-44cb-927e-9eb5b664ac82: Stopped
[JvmPauseMonitor8] INFO  util.JvmPauseMonitor (JvmPauseMonitor.java:run(109)) - JvmPauseMonitor-075e4d60-eed2-4150-bea0-bb71654ce811: Stopped
```