### PR TITLE
HDDS-8414. Recon: Heatmap Absolute Path in Response at end node level on HyperLink End Point Response.

### DIFF
--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/api/types/EntityReadAccessHeatMapResponse.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/api/types/EntityReadAccessHeatMapResponse.java
@@ -46,11 +46,13 @@ import java.util.Objects;
    *             }
  *            ],
  *           "size": 3072,
+ *           "path": "/hivevol1675429570/hivebuck1675429570",
  *           "minAccessCount": 3195,
  *           "maxAccessCount": 129977
  *         }
  *       ],
- *       "size": 6144
+ *       "size": 6144,
+ *       "path": "/hivevol1675429570"
  *     }
  */
 public class EntityReadAccessHeatMapResponse {

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/api/types/EntityReadAccessHeatMapResponse.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/api/types/EntityReadAccessHeatMapResponse.java
@@ -41,6 +41,8 @@ import java.util.Objects;
    *             {
    *               "label": "reg_path/hive_tpcds/store_sales/store_sales.dat",
    *               "size": 256,
+ *                 "path": "/hivevol1675429570/hivebuck1675429570/reg_path/
+ *                 hive_tpcds/store_sales/store_sales.dat",
    *               "accessCount": 129977,
    *               "color": 1
    *             }

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/api/types/EntityReadAccessHeatMapResponse.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/api/types/EntityReadAccessHeatMapResponse.java
@@ -55,8 +55,13 @@ import java.util.Objects;
  */
 public class EntityReadAccessHeatMapResponse {
 
+  /** Name of volume or bucket or full key name. */
   @JsonProperty("label")
   private String label;
+
+  /** Path at each node level. */
+  @JsonProperty("path")
+  private String path;
 
   /**
    * This property is a list of each Entity's
@@ -95,6 +100,14 @@ public class EntityReadAccessHeatMapResponse {
 
   public void setLabel(String label) {
     this.label = label;
+  }
+
+  public String getPath() {
+    return path;
+  }
+
+  public void setPath(String path) {
+    this.path = path;
   }
 
   public long getSize() {

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/heatmap/HeatMapServiceImpl.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/heatmap/HeatMapServiceImpl.java
@@ -142,6 +142,7 @@ public class HeatMapServiceImpl extends HeatMapService {
     EntityReadAccessHeatMapResponse volumeInfo =
         new EntityReadAccessHeatMapResponse();
     volumeInfo.setLabel(split[0]);
+    volumeInfo.setPath(split[0]);
     children.add(volumeInfo);
     addBucketAndPrefixPath(split, rootEntity, volumeInfo, readAccessCount,
         keySize);
@@ -202,6 +203,7 @@ public class HeatMapServiceImpl extends HeatMapService {
     EntityReadAccessHeatMapResponse bucket =
         new EntityReadAccessHeatMapResponse();
     bucket.setLabel(split[1]);
+    bucket.setPath(omMetadataManager.getBucketKey(split[0], split[1]));
     bucketEntities.add(bucket);
     bucket.setMinAccessCount(readAccessCount);
     addPrefixPathInfoToBucket(rootEntity, split, bucket, readAccessCount,
@@ -219,6 +221,7 @@ public class HeatMapServiceImpl extends HeatMapService {
     EntityReadAccessHeatMapResponse prefixPathInfo =
         new EntityReadAccessHeatMapResponse();
     prefixPathInfo.setLabel(path);
+    prefixPathInfo.setPath(bucket.getPath() + OM_KEY_PREFIX + path);
     prefixPathInfo.setAccessCount(readAccessCount);
     prefixPathInfo.setSize(keySize);
     prefixes.add(prefixPathInfo);
@@ -351,6 +354,7 @@ public class HeatMapServiceImpl extends HeatMapService {
     rootEntity.setMinAccessCount(
         entityMetaDataList.get(0).getReadAccessCount());
     rootEntity.setLabel("root");
+    rootEntity.setPath(OM_KEY_PREFIX);
     List<EntityReadAccessHeatMapResponse> children =
         rootEntity.getChildren();
     entityMetaDataList.forEach(entityMetaData -> {

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/heatmap/HeatMapServiceImpl.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/heatmap/HeatMapServiceImpl.java
@@ -293,6 +293,7 @@ public class HeatMapServiceImpl extends HeatMapService {
    *             }
    *           ],
    *           "size": 3584,
+   *           "path": "/hivevol1676574631/hiveencbuck1676574631",
    *           "minAccessCount": 2924,
    *           "maxAccessCount": 155074
    *         },
@@ -314,11 +315,13 @@ public class HeatMapServiceImpl extends HeatMapService {
    *             }
    *           ],
    *           "size": 3584,
+   *           "path": "/hivevol1676574631/hivebuck1676574631",
    *           "minAccessCount": 2924,
    *           "maxAccessCount": 155069
    *         }
    *       ],
-   *       "size": 7168
+   *       "size": 7168,
+   *       "path": "/hivevol1676574631"
    *     },
    *     {
    *       "label": "hivevol1675429570",
@@ -333,11 +336,13 @@ public class HeatMapServiceImpl extends HeatMapService {
    *               "color": 1
    *             }          ],
    *           "size": 3072,
+   *           "path": "/hivevol1675429570/hivebuck1675429570",
    *           "minAccessCount": 3195,
    *           "maxAccessCount": 129977
    *         }
    *       ],
-   *       "size": 6144
+   *       "size": 6144,
+   *       "path": "/hivevol1675429570"
    *     }
    *   ],
    *   "size": 25600,

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/heatmap/HeatMapServiceImpl.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/heatmap/HeatMapServiceImpl.java
@@ -281,6 +281,8 @@ public class HeatMapServiceImpl extends HeatMapService {
    *             {
    *               "label": "enc_path/hive_tpcds/store_sales/store_sales.dat",
    *               "size": 256,
+   *               "path": "/hivevol1676574631/hiveencbuck1676574631/enc_path/
+   *               hive_tpcds/store_sales/store_sales.dat",
    *               "accessCount": 155074,
    *               "color": 1
    *             },
@@ -288,6 +290,8 @@ public class HeatMapServiceImpl extends HeatMapService {
    *               "label": "enc_path/hive_tpcds/catalog_sales/
    *               catalog_sales.dat",
    *               "size": 256,
+   *               "path": "/hivevol1676574631/hiveencbuck1676574631/enc_path/
+   *               hive_tpcds/catalog_sales/catalog_sales.dat",
    *               "accessCount": 68567,
    *               "color": 0.442
    *             }
@@ -303,6 +307,8 @@ public class HeatMapServiceImpl extends HeatMapService {
    *             {
    *               "label": "reg_path/hive_tpcds/store_sales/store_sales.dat",
    *               "size": 256,
+   *               "path": "/hivevol1676574631/hivebuck1676574631/reg_path/
+   *               hive_tpcds/store_sales/store_sales.dat",
    *               "accessCount": 155069,
    *               "color": 1
    *             },
@@ -310,6 +316,8 @@ public class HeatMapServiceImpl extends HeatMapService {
    *               "label": "reg_path/hive_tpcds/catalog_sales/
    *               catalog_sales.dat",
    *               "size": 256,
+   *               "path": "/hivevol1676574631/hivebuck1676574631/reg_path/
+   *               hive_tpcds/catalog_sales/catalog_sales.dat",
    *               "accessCount": 68566,
    *               "color": 0.442
    *             }
@@ -332,6 +340,8 @@ public class HeatMapServiceImpl extends HeatMapService {
    *             {
    *               "label": "reg_path/hive_tpcds/store_sales/store_sales.dat",
    *               "size": 256,
+   *               "path": "/hivevol1675429570/hivebuck1675429570/reg_path/
+   *               hive_tpcds/store_sales/store_sales.dat",
    *               "accessCount": 129977,
    *               "color": 1
    *             }          ],

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/heatmap/TestHeatMapInfo.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/heatmap/TestHeatMapInfo.java
@@ -769,7 +769,11 @@ public class TestHeatMapInfo {
         getMaxAccessCount());
     Assertions.assertEquals("root", entityReadAccessHeatMapResponse.
         getLabel());
-
+    String path =
+        entityReadAccessHeatMapResponse.getChildren().get(1).getChildren()
+            .get(0).getChildren().get(0).getPath();
+    Assertions.assertEquals("/hivevol1675429570/hivebuck1675429570/" +
+        "reg_path/hive_tpcds/store_sales/store_sales.dat", path);
   }
 
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR is to add "path" attribute in "`api/v1/heatmap/readaccess`" API response at each node level including  bucket and volume.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-8414

## How was this patch tested?

This patch is tested functionally using Junit test case assertion as well as verifying response of API through POSTMAN client where a new attribute "`path`" being added:

```
{
  "label": "root",
  "children": [
    {
      "label": "hivevolTest1",
      "children": [
        {
          "label": "hivebucketTest1",
          "children": [
            {
              "label": "enc_path/hive_tpcds/store_sales/test1.dat",
              "size": 1026,
              "path": "/hivevolTest1/hivebucketTest1/enc_path/hive_tpcds/store_sales/test1.dat",
              "accessCount": 155074,
              "color": 1
            },
            {
              "label": "enc_path/hive_tpcds/catalog_sales/test2",
              "size": 20,
              "path": "/hivevolTest1/hivebucketTest1/enc_path/hive_tpcds/catalog_sales/test2",
              "accessCount": 68567,
              "color": 0.56
            },
            {
              "label": "enc_path/hive_tpcds/web_sales/test3",
              "size": 2000,
              "path": "/hivevolTest1/hivebucketTest1/enc_path/hive_tpcds/web_sales/test3",
              "accessCount": 36114,
              "color": 0.45
            },
            {
              "label": "enc_path/hive_tpcds/test4",
              "size": 800,
              "path": "/hivevolTest1/hivebucketTest1/enc_path/hive_tpcds/test4",
              "accessCount": 9047,
              "color": 0.62
            },
            {
              "label": "enc_path/hive_tpcds/date_dim/test5",
              "size": 256,
              "path": "/hivevolTest1/hivebucketTest1/enc_path/hive_tpcds/date_dim/test5",
              "accessCount": 9044,
              "color": 0.78
            },
            {
              "label": "enc_path/hive_tpcds/store_sales",
              "size": 256,
              "path": "/hivevolTest1/hivebucketTest1/enc_path/hive_tpcds/store_sales",
              "accessCount": 6463,
              "color": 0.88
            }
          ],
          "size": 3584,
          **"path": "/hivevolTest1/hivebucketTest1",**
          "minAccessCount": 2924,
          "maxAccessCount": 155074
        }
      ],
      "size": 7168,
      **"path": "/hivevolTest1"**
    }
  ],
  "size": 25600,
  "minAccessCount": 2924,
  "maxAccessCount": 155074
}
```

