### PR TITLE
HDDS-8746. Add metrics to ReplicationSupervisor for task count and max streams

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/replication/ReplicationSupervisor.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/replication/ReplicationSupervisor.java
@@ -21,6 +21,7 @@ import java.time.Clock;
 import java.time.Instant;
 import java.time.ZoneId;
 import java.util.Comparator;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
 import java.util.OptionalLong;
@@ -268,6 +269,14 @@ public final class ReplicationSupervisor {
     return counter == null ? 0 : counter.get();
   }
 
+  public Map<String, Integer> getInFlightReplicationSummary() {
+    Map<String, Integer> result = new HashMap<>();
+    for (Map.Entry<Class<?>, AtomicInteger> entry : taskCounter.entrySet()) {
+      result.put(entry.getKey().getSimpleName(), entry.getValue().get());
+    }
+    return result;
+  }
+
   /**
    * Returns a count of all inflight replication tasks across all task types.
    * Note that `getInFlightReplications(Class taskClass) allows for the .count
@@ -411,6 +420,14 @@ public final class ReplicationSupervisor {
       return ((ThreadPoolExecutor)executor).getQueue().size();
     } else {
       return 0;
+    }
+  }
+
+  public long getMaxReplicationStreams() {
+    if (executor instanceof ThreadPoolExecutor) {
+      return ((ThreadPoolExecutor) executor).getMaximumPoolSize();
+    } else {
+      return 1;
     }
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

To give added visibility into the Replication Queue on a datanode, this Jira adds some extra metrics to give visibility into the count of "normal priority" Replication and Reconstruction tasks, along with the current maxStreams setting, which is automatically adjusted when the node moves into decommission.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-8746

## How was this patch tested?

This was tested manually in Docker compose by sampling the JMX output. Sample output:

```
    "name" : "Hadoop:service=HddsDatanode,name=ReplicationSupervisorMetrics",
    "modelerType" : "ReplicationSupervisorMetrics",
    "tag.Hostname" : "b297306fcf0f",
    "numInFlightReplications" : 5,
    "numQueuedReplications" : 4,
    "numRequestedReplications" : 1,
    "numTimeoutReplications" : 0,
    "numSkippedReplications" : 0,
    "maxReplicationStreams" : 1, ** newly added
    "numInflightECReconstructionCoordinatorTask" : 5 ** newly added


    "name" : "Hadoop:service=HddsDatanode,name=ReplicationSupervisorMetrics",
    "modelerType" : "ReplicationSupervisorMetrics",
    "tag.Hostname" : "b297306fcf0f",
    "numInFlightReplications" : 1,
    "numQueuedReplications" : 0,
    "numRequestedReplications" : 6,
    "numTimeoutReplications" : 0,
    "numSkippedReplications" : 0,
    "maxReplicationStreams" : 1,      ** newly added
    "numInflightReplicationTask" : 1,  ** newly added
    "numInflightECReconstructionCoordinatorTask" : 0 ** newly added
```
