### PR TITLE
HDDS-8748. Reduce DN IO times when deleteChunk (FilePerBlockStrategy)

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/impl/FilePerBlockStrategy.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/impl/FilePerBlockStrategy.java
@@ -236,14 +236,6 @@ public class FilePerBlockStrategy implements ChunkManager {
 
     File file = getChunkFile(container, blockID, info);
 
-    // if the chunk file does not exist, it might have already been deleted.
-    // The call might be because of reapply of transactions on datanode
-    // restart.
-    if (!file.exists()) {
-      LOG.warn("Block file to be deleted does not exist: {}", file);
-      return;
-    }
-
     if (verifyLength) {
       Preconditions.checkNotNull(info, "Chunk info cannot be null for single " +
           "chunk delete");
@@ -263,6 +255,16 @@ public class FilePerBlockStrategy implements ChunkManager {
   private static void checkFullDelete(ChunkInfo info, File chunkFile)
       throws StorageContainerException {
     long fileLength = chunkFile.length();
+    if (fileLength == 0) {
+      // if the chunk file does not exist, it might have already been deleted.
+      // The call might be because of reapply of transactions on datanode
+      // restart.
+      if (!chunkFile.exists()) {
+        LOG.warn("Block file to be deleted does not exist: {}", chunkFile);
+        return;
+      }
+    }
+
     if ((info.getOffset() > 0) || (info.getLen() != fileLength)) {
       String msg = String.format(
           "Trying to delete partial chunk %s from file %s with length %s",


### PR DESCRIPTION
## What changes were proposed in this pull request?
When deleting a file, DN will check whether the Block file to be deleted exists or not in the `FilePerBlockStrategy#deleteChunk`.
This step of checking for the existence of a Block file can be omitted, and basically does not change the behavior of `FilePerBlockStrategy#deleteChunk`.
This can reduce the IO-times of `FilePerBlockStrategy#deleteChunk`
the `FilePerBlockStrategy#deleteChunk`

### `FilePerBlockStrategy#deleteChunk` Change
- For an existing file `FilePerBlockStrategy#deleteChunk` is no change in the result, just one less once IO with System.
- For non-existent files, the `FilePerBlockStrategy#deleteChunk' function behaves the same as before the change, the only difference is that it prints a log of successful deletions.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-8748

## How was this patch tested?
existing test

