### PR TITLE
HDDS-8698. EC: Avoid unbounded pipeline creation if all existing pipelines don't meet criteria

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/WritableECContainerProvider.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/WritableECContainerProvider.java
@@ -94,12 +94,12 @@ public class WritableECContainerProvider
   public ContainerInfo getContainer(final long size,
       ECReplicationConfig repConfig, String owner, ExcludeList excludeList)
       throws IOException, TimeoutException {
-    int minimumPipelines = getMinimumPipelines(repConfig);
+    int maximumPipelines = getMaximumPipelines(repConfig);
     int openPipelineCount = 0;
     synchronized (this) {
       openPipelineCount = pipelineManager.getPipelineCount(repConfig,
           Pipeline.PipelineState.OPEN);
-      if (openPipelineCount < minimumPipelines) {
+      if (openPipelineCount < maximumPipelines) {
         try {
           return allocateContainer(repConfig, size, owner, excludeList);
         } catch (IOException e) {
@@ -153,7 +153,7 @@ public class WritableECContainerProvider
     // allocate a new one.
     try {
       synchronized (this) {
-        if (openPipelineCount < minimumPipelines) {
+        if (openPipelineCount < maximumPipelines) {
           return allocateContainer(repConfig, size, owner, excludeList);
         }
         throw new IOException("Unable to allocate a pipeline for "
@@ -167,7 +167,7 @@ public class WritableECContainerProvider
     }
   }
 
-  private int getMinimumPipelines(ECReplicationConfig repConfig) {
+  private int getMaximumPipelines(ECReplicationConfig repConfig) {
     final double factor = providerConfig.getPipelinePerVolumeFactor();
     int volumeBasedCount = 0;
     if (factor > 0) {


### PR DESCRIPTION

## What changes were proposed in this pull request?

Currently, if the pipeline limit is not reached, when a new block is requested, a new pipeline is allocated and returned to the client.

If the pipeline limit is reached, we attempt to return a pipeline from the existing set.

If none of those pipelines meet the criteria, then we fall back to creating another pipeline. This could result in unbounded pipeline growth if a client is having problems.

We should therefore limit the pipelines that can be created via this exceptional case.

For example, if we close some pipelines when searching the existing list (due to them being full), we know we have freed up some capacity to create a new pipeline.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-8698

## How was this patch tested?

Modified existing tests
