### PR TITLE
HDDS-8766. Use empty BufferPool for EC reconstruction

### DIFF
--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/storage/BufferPool.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/storage/BufferPool.java
@@ -80,18 +80,16 @@ public class BufferPool {
    * chunk size.
    */
   public ChunkBuffer allocateBuffer(int increment) {
-    int nextBufferIndex = currentBufferIndex + 1;
+    final int nextBufferIndex = currentBufferIndex + 1;
+
     Preconditions.assertTrue(nextBufferIndex < capacity, () ->
         "next index: " + nextBufferIndex + " >= capacity: " + capacity);
 
-    currentBufferIndex++;
+    currentBufferIndex = nextBufferIndex;
 
-    int bufferCount = bufferList.size();
-    if (currentBufferIndex < bufferCount) {
+    if (currentBufferIndex < bufferList.size()) {
       return getBuffer(currentBufferIndex);
     } else {
-      Preconditions.assertTrue(bufferCount < capacity, () ->
-          "buffer count: " + bufferCount + " >= capacity: " + capacity);
       final ChunkBuffer newBuffer = ChunkBuffer.allocate(bufferSize, increment);
       bufferList.add(newBuffer);
       return newBuffer;
@@ -147,5 +145,9 @@ public class BufferPool {
 
   public int getCapacity() {
     return capacity;
+  }
+
+  public int getBufferSize() {
+    return bufferSize;
   }
 }

--- a/hadoop-hdds/client/src/test/java/org/apache/hadoop/hdds/scm/storage/TestBufferPool.java
+++ b/hadoop-hdds/client/src/test/java/org/apache/hadoop/hdds/scm/storage/TestBufferPool.java
@@ -20,27 +20,128 @@ package org.apache.hadoop.hdds.scm.storage;
 
 import org.apache.hadoop.ozone.common.ChunkBuffer;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+
+import java.util.Deque;
+import java.util.LinkedList;
+import java.util.concurrent.ThreadLocalRandom;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
- * Unit test for buffer pool.
+ * Test for {@link BufferPool}.
  */
-public class TestBufferPool {
+class TestBufferPool {
 
   @Test
-  public void releaseAndReallocate() {
-    BufferPool pool = new BufferPool(1024, 8);
-    ChunkBuffer cb1 = pool.allocateBuffer(0);
-    ChunkBuffer cb2 = pool.allocateBuffer(0);
-    ChunkBuffer cb3 = pool.allocateBuffer(0);
+  void testBufferPool() {
+    testBufferPool(BufferPool.empty());
+    testBufferPool(1, 1);
+    testBufferPool(3, 1 << 20);
+    testBufferPool(10, 1 << 10);
+  }
 
-    pool.releaseBuffer(cb1);
+  private static void testBufferPool(final int capacity, final int bufferSize) {
+    final BufferPool pool = new BufferPool(bufferSize, capacity);
+    assertEquals(capacity, pool.getCapacity());
+    assertEquals(bufferSize, pool.getBufferSize());
+    testBufferPool(pool);
+  }
 
-    //current state cb2, -> cb3, cb1
-    final ChunkBuffer allocated = pool.allocateBuffer(0);
-    Assert.assertEquals(3, pool.getSize());
-    Assert.assertEquals(cb1, allocated);
+  private static void testBufferPool(final BufferPool pool) {
+    assertEmpty(pool);
+    final Deque<ChunkBuffer> buffers = assertAllocate(pool);
+    assertFull(pool);
+    assertReallocate(pool, buffers);
+    assertRelease(pool, buffers);
+  }
+
+  private static void assertEmpty(BufferPool pool) {
+    assertEquals(0, pool.getNumberOfUsedBuffers());
+    assertEquals(0, pool.getSize());
+    assertEquals(-1, pool.getCurrentBufferIndex());
+  }
+
+  private static Deque<ChunkBuffer> assertAllocate(BufferPool pool) {
+    final int capacity = pool.getCapacity();
+    final int size = pool.getBufferSize();
+    final Deque<ChunkBuffer> buffers = new LinkedList<>();
+
+    for (int i = 0; i < capacity; i++) {
+      final int n = i;
+      assertEquals(n, pool.getSize());
+      assertEquals(n, pool.getNumberOfUsedBuffers());
+
+      final ChunkBuffer allocated = pool.allocateBuffer(0);
+      assertEmpty(allocated, size);
+      fill(allocated); // make buffer contents unique, for equals check
+
+      assertFalse(buffers.contains(allocated),
+          () -> "buffer " + n + ": " + allocated + " already in: " + buffers);
+      buffers.addLast(allocated);
+    }
+
+    return buffers;
+  }
+
+  private static void assertEmpty(ChunkBuffer buf, final int size) {
+    assertEquals(0, buf.position());
+    assertEquals(size, buf.limit());
+  }
+
+  private static void assertFull(BufferPool pool) {
+    final int capacity = pool.getCapacity();
+    assertEquals(capacity, pool.getSize());
+    assertEquals(capacity, pool.getNumberOfUsedBuffers());
+    assertThrows(IllegalStateException.class, () -> pool.allocateBuffer(0));
+  }
+
+  // buffers are released and reallocated FIFO
+  private static void assertReallocate(BufferPool pool,
+      Deque<ChunkBuffer> buffers) {
+    final int capacity = pool.getCapacity();
+    for (int i = 0; i < 3 * capacity; i++) {
+      if (capacity > 1) {
+        assertThrows(IllegalStateException.class,
+            () -> pool.releaseBuffer(buffers.getLast()));
+      }
+
+      final ChunkBuffer released = buffers.removeFirst();
+      pool.releaseBuffer(released);
+      assertEquals(0, released.position());
+      assertEquals(capacity - 1, pool.getNumberOfUsedBuffers());
+      assertEquals(capacity, pool.getSize());
+
+      final ChunkBuffer allocated = pool.allocateBuffer(0);
+      buffers.addLast(allocated);
+      assertSame(released, allocated);
+      assertEquals(capacity, pool.getNumberOfUsedBuffers());
+    }
+  }
+
+  private static void assertRelease(BufferPool pool,
+      Deque<ChunkBuffer> buffers) {
+    final int capacity = pool.getCapacity();
+    for (int i = capacity - 1; i >= 0; i--) {
+      final ChunkBuffer released = buffers.removeFirst();
+      pool.releaseBuffer(released);
+      assertEquals(i, pool.getNumberOfUsedBuffers());
+      assertThrows(IllegalStateException.class,
+          () -> pool.releaseBuffer(released));
+    }
+
+    pool.checkBufferPoolEmpty();
+  }
+
+  private static void fill(ChunkBuffer buf) {
+    buf.clear();
+    final byte[] bytes = new byte[buf.remaining()];
+    ThreadLocalRandom.current().nextBytes(bytes);
+    buf.put(bytes);
+    buf.rewind();
   }
 
 }

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/common/ChunkBufferImplWithByteBuffer.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/common/ChunkBufferImplWithByteBuffer.java
@@ -147,6 +147,7 @@ final class ChunkBufferImplWithByteBuffer implements ChunkBuffer {
 
   @Override
   public String toString() {
-    return getClass().getSimpleName() + ":limit=" + buffer.limit();
+    return getClass().getSimpleName() + ":limit=" + buffer.limit()
+        + "@" + Integer.toHexString(hashCode());
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Avoid unnecessary `BufferPool` creation for EC reconstruction flow:

```
// TODO: Let's avoid unnecessary bufferPool creation. This pool actually
//  not used in EC flows, but there are some dependencies on buffer pool.
```

Use an empty singleton `BufferPool` for that.

Also, convert some validation checks to real preconditions in `BufferPool` (i.e. perform the check before changing state, not afterwards).

https://issues.apache.org/jira/browse/HDDS-8766

## How was this patch tested?

Existing tests:
https://github.com/adoroszlai/hadoop-ozone/actions/runs/5186666728