### PR TITLE
HDDS-8774. Log allocation stack trace for leaked CodecBuffer

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/HddsUtils.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/HddsUtils.java
@@ -19,6 +19,9 @@
 package org.apache.hadoop.hdds;
 
 import com.google.protobuf.ServiceException;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import javax.management.ObjectName;
 import java.io.File;
 import java.io.IOException;
@@ -844,5 +847,27 @@ public final class HddsUtils {
         thread.setName(threadName);
       }
     }
+  }
+
+  /** Concatenate stack trace {@code elements} (one per line) starting at
+   * {@code startIndex}. */
+  public static @Nonnull String formatStackTrace(
+      @Nullable StackTraceElement[] elements, int startIndex) {
+    if (elements != null && elements.length > startIndex) {
+      final StringBuilder sb = new StringBuilder();
+      for (int line = startIndex; line < elements.length; line++) {
+        sb.append(elements[line]).append("\n");
+      }
+      return sb.toString();
+    }
+    return "";
+  }
+
+  /** @return current thread stack trace if {@code logger} has debug enabled */
+  public static @Nullable StackTraceElement[] getStackTrace(
+      @Nonnull Logger logger) {
+    return logger.isDebugEnabled()
+        ? Thread.currentThread().getStackTrace()
+        : null;
   }
 }

--- a/hadoop-hdds/managed-rocksdb/src/main/java/org/apache/hadoop/hdds/utils/db/managed/ManagedObject.java
+++ b/hadoop-hdds/managed-rocksdb/src/main/java/org/apache/hadoop/hdds/utils/db/managed/ManagedObject.java
@@ -20,6 +20,8 @@ package org.apache.hadoop.hdds.utils.db.managed;
 
 import org.rocksdb.RocksObject;
 
+import static org.apache.hadoop.hdds.utils.db.managed.ManagedRocksObjectUtils.formatStackTrace;
+
 /**
  * General template for a managed RocksObject.
  * @param <T>
@@ -31,11 +33,7 @@ class ManagedObject<T extends RocksObject> implements AutoCloseable {
 
   ManagedObject(T original) {
     this.original = original;
-    if (ManagedRocksObjectUtils.LOG.isDebugEnabled()) {
-      this.elements = Thread.currentThread().getStackTrace();
-    } else {
-      this.elements = null;
-    }
+    this.elements = ManagedRocksObjectUtils.getStackTrace();
   }
 
   public T get() {
@@ -54,15 +52,7 @@ class ManagedObject<T extends RocksObject> implements AutoCloseable {
   }
 
   public String getStackTrace() {
-    if (elements != null && elements.length > 0) {
-      StringBuilder sb = new StringBuilder();
-      for (int line = 1; line < elements.length; line++) {
-        sb.append(elements[line]);
-        sb.append("\n");
-      }
-      return sb.toString();
-    }
-    return "";
+    return formatStackTrace(elements);
   }
 
 }

--- a/hadoop-hdds/managed-rocksdb/src/main/java/org/apache/hadoop/hdds/utils/db/managed/ManagedRocksObjectUtils.java
+++ b/hadoop-hdds/managed-rocksdb/src/main/java/org/apache/hadoop/hdds/utils/db/managed/ManagedRocksObjectUtils.java
@@ -18,6 +18,7 @@
  */
 package org.apache.hadoop.hdds.utils.db.managed;
 
+import org.apache.hadoop.hdds.HddsUtils;
 import org.rocksdb.RocksObject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -48,10 +49,19 @@ public final class ManagedRocksObjectUtils {
           rocksObject.getClass().getSimpleName());
       if (stackTrace != null && LOG.isDebugEnabled()) {
         String debugMessage = String
-            .format("%n StackTrace for unclosed instance: %s", stackTrace);
+            .format("%nStackTrace for unclosed instance: %s", stackTrace);
         warning = warning.concat(debugMessage);
       }
       LOG.warn(warning);
     }
   }
+
+  static StackTraceElement[] getStackTrace() {
+    return HddsUtils.getStackTrace(LOG);
+  }
+
+  static String formatStackTrace(StackTraceElement[] elements) {
+    return HddsUtils.formatStackTrace(elements, 3);
+  }
+
 }

--- a/hadoop-ozone/integration-test/src/test/resources/log4j.properties
+++ b/hadoop-ozone/integration-test/src/test/resources/log4j.properties
@@ -20,3 +20,4 @@ log4j.appender.stdout.layout.ConversionPattern=%d{ISO8601} [%t] %-5p %c{2} (%F:%
 log4j.logger.org.apache.hadoop.security.ShellBasedUnixGroupsMapping=ERROR
 log4j.logger.org.apache.hadoop.util.NativeCodeLoader=ERROR
 log4j.logger.org.apache.hadoop.hdds.utils.db.managed=TRACE
+log4j.logger.org.apache.hadoop.hdds.utils.db.CodecBuffer=DEBUG


### PR DESCRIPTION
## What changes were proposed in this pull request?

Show stack trace of `CodecBuffer` allocation for leaked instances if log level is at least `DEBUG` (and set such log level for integration tests).

https://issues.apache.org/jira/browse/HDDS-8740

## How was this patch tested?

Introduced leak by randomly returning from `release()` without actually releasing the buffer.  Ran `TestOmMetrics`.  Verified log:

```
[Finalizer] WARN  db.CodecBuffer (CodecBuffer.java:finalize(129)) - LEAK 1: org.apache.hadoop.hdds.utils.db.CodecBuffer@26701f00, refCnt=1, capacity=24 allocation:
org.apache.hadoop.hdds.utils.db.CodecBuffer.allocate(CodecBuffer.java:74)
org.apache.hadoop.hdds.utils.db.CodecBuffer.allocateDirect(CodecBuffer.java:82)
org.apache.hadoop.hdds.utils.db.StringCodecBase.toCodecBuffer(StringCodecBase.java:175)
org.apache.hadoop.hdds.utils.db.StringCodec.toCodecBuffer(StringCodec.java:28)
org.apache.hadoop.hdds.utils.db.StringCodecBase.toCodecBuffer(StringCodecBase.java:43)
org.apache.hadoop.hdds.utils.db.Codec.toDirectCodecBuffer(Codec.java:75)
org.apache.hadoop.hdds.utils.db.TypedTable.getFromTable(TypedTable.java:358)
org.apache.hadoop.hdds.utils.db.TypedTable.getFromTable(TypedTable.java:337)
org.apache.hadoop.hdds.utils.db.TypedTable.get(TypedTable.java:230)
org.apache.hadoop.hdds.scm.ha.SequenceIdGenerator.upgradeToSequenceId(SequenceIdGenerator.java:353)
org.apache.hadoop.hdds.scm.server.StorageContainerManager.initializeSystemManagers(StorageContainerManager.java:654)
org.apache.hadoop.hdds.scm.server.StorageContainerManager.<init>(StorageContainerManager.java:389)
org.apache.hadoop.hdds.scm.server.StorageContainerManager.createSCM(StorageContainerManager.java:572)
org.apache.hadoop.hdds.scm.HddsTestUtils.getScmSimple(HddsTestUtils.java:598)
org.apache.hadoop.ozone.MiniOzoneClusterImpl$Builder.createSCM(MiniOzoneClusterImpl.java:735)
org.apache.hadoop.ozone.MiniOzoneClusterImpl$Builder.build(MiniOzoneClusterImpl.java:587)
org.apache.hadoop.ozone.om.TestOmMetrics.startCluster(TestOmMetrics.java:109)
org.apache.hadoop.ozone.om.TestOmMetrics.testBucketOps(TestOmMetrics.java:201)
```

Temporarily removed setting of log level, verified log has no stack trace:

```
[Finalizer] WARN  db.CodecBuffer (CodecBuffer.java:finalize(129)) - LEAK 1: org.apache.hadoop.hdds.utils.db.CodecBuffer@26701f00, refCnt=1, capacity=51
```