### PR TITLE
HDDS-8776. ReplicationManager: Log overloaded commands at debug rather than error level

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/UnhealthyReplicationProcessor.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/UnhealthyReplicationProcessor.java
@@ -112,19 +112,18 @@ public abstract class UnhealthyReplicationProcessor<HealthResult extends
         processContainer(healthResult);
         processed++;
         healthStateCntMap.compute(healthResult.getHealthState(),
-                (healthState, cnt) -> cnt == null ? 1 : (cnt + 1));
+            (healthState, cnt) -> cnt == null ? 1 : (cnt + 1));
+      } catch (CommandTargetOverloadedException e) {
+        LOG.debug("All targets overloaded when processing Health result of " +
+            "class: {} for container {}", healthResult.getClass(),
+            healthResult.getContainerInfo());
+        overloaded++;
+        failedOnes.add(healthResult);
       } catch (Exception e) {
-        if (e instanceof CommandTargetOverloadedException) {
-          LOG.debug("All targets overloaded when processing Health result of " +
-                  "class: {} for container {}", healthResult.getClass(),
-                  healthResult.getContainerInfo(), e);
-          overloaded++;
-        } else {
-          LOG.error("Error processing Health result of class: {} for " +
-              "container {}", healthResult.getClass(),
-              healthResult.getContainerInfo(), e);
-          failed++;
-        }
+        LOG.error("Error processing Health result of class: {} for " +
+                "container {}", healthResult.getClass(),
+            healthResult.getContainerInfo(), e);
+        failed++;
         failedOnes.add(healthResult);
       }
     }


### PR DESCRIPTION
## What changes were proposed in this pull request?

When processing the unhealthy container queues, we would expect quite a large number of containers to have processing deferred due to load on the datanodes. At the moment, these are logged at ERROR level, which is probably too verbose and also the messages are expected, so ERROR will likely worry administrators.

This change moves that to debug level, and also adds a counter so we can print a summary of how many containers were deferred due to load after each iteration.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-8776

## How was this patch tested?

No tests added or changed. This is just a logging change.