### PR TITLE
HDDS-8779. Recon - Expose flag for enable/disable of heatmap.

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/recon/ReconConfigKeys.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/recon/ReconConfigKeys.java
@@ -44,6 +44,9 @@ public final class ReconConfigKeys {
   // Fully qualified heatmap provider implementation class name key.
   public static final String OZONE_RECON_HEATMAP_PROVIDER_KEY =
       "ozone.recon.heatmap.provider";
+  public static final String OZONE_RECON_HEATMAP_ENABLE_KEY =
+      "ozone.recon.heatmap.enable";
+  public static final boolean OZONE_RECON_HEATMAP_ENABLE_DEFAULT = false;
   public static final String OZONE_RECON_ADDRESS_DEFAULT =
       "0.0.0.0:9891";
   public static final String OZONE_RECON_HTTP_ADDRESS_KEY =

--- a/hadoop-hdds/common/src/main/resources/ozone-default.xml
+++ b/hadoop-hdds/common/src/main/resources/ozone-default.xml
@@ -3736,6 +3736,17 @@
   </property>
 
   <property>
+    <name>ozone.recon.heatmap.enable</name>
+    <value>false</value>
+    <tag>OZONE, RECON</tag>
+    <description>
+      To enable/disable recon heatmap feature. Along with this config, user must also provide the implementation
+      of "org.apache.hadoop.ozone.recon.heatmap.IHeatMapProvider" interface and configure in
+      "ozone.recon.heatmap.provider" configuration.
+    </description>
+  </property>
+
+  <property>
     <name>ozone.fs.datastream.enabled</name>
     <value>false</value>
     <tag>OZONE, DATANODE</tag>

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/api/types/FeatureProvider.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/api/types/FeatureProvider.java
@@ -27,6 +27,8 @@ import java.util.EnumMap;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import static org.apache.hadoop.hdds.recon.ReconConfigKeys.OZONE_RECON_HEATMAP_ENABLE_DEFAULT;
+import static org.apache.hadoop.hdds.recon.ReconConfigKeys.OZONE_RECON_HEATMAP_ENABLE_KEY;
 import static org.apache.hadoop.hdds.recon.ReconConfigKeys.OZONE_RECON_HEATMAP_PROVIDER_KEY;
 
 /**
@@ -85,7 +87,9 @@ public final class FeatureProvider {
     resetInitOfFeatureSupport();
     String heatMapProviderCls = ozoneConfiguration.get(
         OZONE_RECON_HEATMAP_PROVIDER_KEY);
-    if (StringUtils.isEmpty(heatMapProviderCls)) {
+    boolean heatMapEnabled = ozoneConfiguration.getBoolean(
+        OZONE_RECON_HEATMAP_ENABLE_KEY, OZONE_RECON_HEATMAP_ENABLE_DEFAULT);
+    if (!heatMapEnabled || StringUtils.isEmpty(heatMapProviderCls)) {
       getFeatureSupportMap().put(Feature.HEATMAP, true);
     }
   }


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR is to expose a configuration to enable/disable heatmap feature in Recon.

`- ozone.recon.heatmap.enable`

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-8779

## How was this patch tested?

This patch is tested using Junit test cases :

1. Set "`ozone.recon.heatmap.enable`" as true and set "`ozone.recon.heatmap.provider`" as non-empty value and then verify heatmap feature should not come in disabled feature list by calling API "`api/v1/features/disabledFeatures`"
2. Set "`ozone.recon.heatmap.enable`" as false and set "`ozone.recon.heatmap.provider`" as non-empty value and then verify heatmap feature will be populated in disabled feature list by calling API "`api/v1/features/disabledFeatures`"
