### PR TITLE
HDDS-7365. Integrate container and volume scanners.

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/impl/HddsDispatcher.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/impl/HddsDispatcher.java
@@ -359,6 +359,7 @@ public class HddsDispatcher implements ContainerDispatcher, Auditor {
                 || containerState == State.RECOVERING);
         // mark and persist the container state to be unhealthy
         try {
+          // TODO HDDS-7096: Use on demand scanning here instead.
           handler.markContainerUnhealthy(container);
           LOG.info("Marked Container UNHEALTHY, ContainerID: {}", containerID);
         } catch (IOException ioe) {

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/volume/StorageVolume.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/volume/StorageVolume.java
@@ -93,7 +93,7 @@ public abstract class StorageVolume
     NOT_INITIALIZED
   }
 
-  private VolumeState state;
+  private volatile VolumeState state;
 
   // VERSION file properties
   private String storageID;       // id of the file system

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/KeyValueHandler.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/KeyValueHandler.java
@@ -58,7 +58,6 @@ import org.apache.hadoop.ozone.OzoneConfigKeys;
 import org.apache.hadoop.ozone.common.Checksum;
 import org.apache.hadoop.ozone.common.ChunkBuffer;
 import org.apache.hadoop.ozone.common.OzoneChecksumException;
-import org.apache.hadoop.ozone.common.Storage;
 import org.apache.hadoop.ozone.common.utils.BufferUtils;
 import org.apache.hadoop.ozone.container.common.helpers.BlockData;
 import org.apache.hadoop.ozone.container.common.helpers.ChunkInfo;

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/ozoneimpl/BackgroundContainerDataScanner.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/ozoneimpl/BackgroundContainerDataScanner.java
@@ -70,6 +70,13 @@ public class BackgroundContainerDataScanner extends
 
   @Override
   public void scanContainer(Container<?> c) throws IOException {
+    // There is one background container data scanner per volume.
+    // If the volume fails, its scanning thread should terminate.
+    if (volume.isFailed()) {
+      shutdown();
+      return;
+    }
+
     if (!shouldScan(c)) {
       return;
     }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/ozoneimpl/BackgroundContainerDataScanner.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/ozoneimpl/BackgroundContainerDataScanner.java
@@ -122,9 +122,10 @@ public class BackgroundContainerDataScanner extends
   }
 
   private synchronized void shutdown(String reason) {
-    String cancelerMessage = String.format(NAME_FORMAT, volume) + " is " +
+    String shutdownMessage = String.format(NAME_FORMAT, volume) + " is " +
         "shutting down. " + reason;
-    this.canceler.cancel(cancelerMessage);
+    LOG.info(shutdownMessage);
+    this.canceler.cancel(shutdownMessage);
     super.shutdown();
   }
 

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/ozoneimpl/BackgroundContainerDataScanner.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/ozoneimpl/BackgroundContainerDataScanner.java
@@ -73,7 +73,7 @@ public class BackgroundContainerDataScanner extends
     // There is one background container data scanner per volume.
     // If the volume fails, its scanning thread should terminate.
     if (volume.isFailed()) {
-      shutdown();
+      shutdown("The volume has failed.");
       return;
     }
 
@@ -118,8 +118,13 @@ public class BackgroundContainerDataScanner extends
 
   @Override
   public synchronized void shutdown() {
-    this.canceler.cancel(
-        String.format(NAME_FORMAT, volume) + " is shutting down");
+    shutdown("");
+  }
+
+  private synchronized void shutdown(String reason) {
+    String cancelerMessage = String.format(NAME_FORMAT, volume) + " is " +
+        "shutting down. " + reason;
+    this.canceler.cancel(cancelerMessage);
     super.shutdown();
   }
 

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/ozoneimpl/BackgroundContainerMetadataScanner.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/ozoneimpl/BackgroundContainerMetadataScanner.java
@@ -19,6 +19,7 @@ package org.apache.hadoop.ozone.container.ozoneimpl;
 
 import com.google.common.annotations.VisibleForTesting;
 import org.apache.hadoop.ozone.container.common.helpers.ContainerUtils;
+import org.apache.hadoop.ozone.container.common.impl.ContainerData;
 import org.apache.hadoop.ozone.container.common.interfaces.Container;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -56,6 +57,16 @@ public class BackgroundContainerMetadataScanner extends
   @VisibleForTesting
   @Override
   public void scanContainer(Container<?> container) throws IOException {
+    // There is one background container metadata scanner per datanode.
+    // If this container's volume has failed, skip the container.
+    // The iterator returned by getContainerIterator may have stale results.
+    ContainerData data = container.getContainerData();
+    long containerID = data.getContainerID();
+    if (data.getVolume().isFailed()) {
+      LOG.debug("Skipping scan of container {}", containerID);
+      return;
+    }
+
     // Full data scan also does a metadata scan. If a full data scan was done
     // recently, we can skip this metadata scan.
     if (ContainerUtils.recentlyScanned(container, minScanGap, LOG)) {
@@ -66,8 +77,7 @@ public class BackgroundContainerMetadataScanner extends
     // not a full scan.
     if (!container.scanMetaData()) {
       metrics.incNumUnHealthyContainers();
-      controller.markContainerUnhealthy(
-          container.getContainerData().getContainerID());
+      controller.markContainerUnhealthy(containerID);
     }
     metrics.incNumContainersScanned();
   }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/ozoneimpl/BackgroundContainerMetadataScanner.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/ozoneimpl/BackgroundContainerMetadataScanner.java
@@ -21,6 +21,7 @@ import com.google.common.annotations.VisibleForTesting;
 import org.apache.hadoop.ozone.container.common.helpers.ContainerUtils;
 import org.apache.hadoop.ozone.container.common.impl.ContainerData;
 import org.apache.hadoop.ozone.container.common.interfaces.Container;
+import org.apache.hadoop.ozone.container.common.volume.HddsVolume;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -62,8 +63,10 @@ public class BackgroundContainerMetadataScanner extends
     // The iterator returned by getContainerIterator may have stale results.
     ContainerData data = container.getContainerData();
     long containerID = data.getContainerID();
-    if (data.getVolume().isFailed()) {
-      LOG.debug("Skipping scan of container {}", containerID);
+    HddsVolume containerVolume = data.getVolume();
+    if (containerVolume.isFailed()) {
+      LOG.debug("Skipping scan of container {}. Its volume {} has failed.",
+          containerID, containerVolume);
       return;
     }
 

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/ozoneimpl/OnDemandContainerDataScanner.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/ozoneimpl/OnDemandContainerDataScanner.java
@@ -23,6 +23,7 @@ import org.apache.hadoop.hdfs.util.DataTransferThrottler;
 import org.apache.hadoop.ozone.container.common.helpers.ContainerUtils;
 import org.apache.hadoop.ozone.container.common.impl.ContainerData;
 import org.apache.hadoop.ozone.container.common.interfaces.Container;
+import org.apache.hadoop.ozone.container.common.volume.HddsVolume;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -76,13 +77,21 @@ public final class OnDemandContainerDataScanner {
   }
 
   private static boolean shouldScan(Container<?> container) {
+    long containerID = container.getContainerData().getContainerID();
     if (instance == null) {
       LOG.debug("Skipping on demand scan for container {} since scanner was " +
-          "not initialized.", container.getContainerData().getContainerID());
+          "not initialized.", containerID);
+      return false;
     }
-    return instance != null &&
-        container.shouldScanData() &&
-        !ContainerUtils.recentlyScanned(container, instance.minScanGap, LOG);
+
+    HddsVolume containerVolume = container.getContainerData().getVolume();
+    if (containerVolume.isFailed()) {
+      LOG.debug("Skipping on demand scan for container {} since its volume {}" +
+          " has failed.", containerID, containerVolume);
+      return false;
+    }
+
+    return !ContainerUtils.recentlyScanned(container, instance.minScanGap, LOG);
   }
 
   public static Optional<Future<?>> scanContainer(Container<?> container) {

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/ozoneimpl/OnDemandContainerDataScanner.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/ozoneimpl/OnDemandContainerDataScanner.java
@@ -91,7 +91,8 @@ public final class OnDemandContainerDataScanner {
       return false;
     }
 
-    return !ContainerUtils.recentlyScanned(container, instance.minScanGap, LOG);
+    return !ContainerUtils.recentlyScanned(container, instance.minScanGap,
+        LOG) && container.shouldScanData();
   }
 
   public static Optional<Future<?>> scanContainer(Container<?> container) {

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/ozoneimpl/OnDemandContainerDataScanner.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/ozoneimpl/OnDemandContainerDataScanner.java
@@ -182,8 +182,10 @@ public final class OnDemandContainerDataScanner {
   private synchronized void shutdownScanner() {
     instance = null;
     metrics.unregister();
-    this.canceler.cancel("On-demand container" +
-        " scanner is shutting down.");
+    String shutdownMessage ="On-demand container" +
+        " scanner is shutting down.";
+    LOG.info(shutdownMessage);
+    this.canceler.cancel(shutdownMessage);
     if (!scanExecutor.isShutdown()) {
       scanExecutor.shutdown();
     }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/ozoneimpl/OnDemandContainerDataScanner.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/ozoneimpl/OnDemandContainerDataScanner.java
@@ -182,8 +182,7 @@ public final class OnDemandContainerDataScanner {
   private synchronized void shutdownScanner() {
     instance = null;
     metrics.unregister();
-    String shutdownMessage ="On-demand container" +
-        " scanner is shutting down.";
+    String shutdownMessage = "On-demand container scanner is shutting down.";
     LOG.info(shutdownMessage);
     this.canceler.cancel(shutdownMessage);
     if (!scanExecutor.isShutdown()) {

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/ContainerTestUtils.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/ContainerTestUtils.java
@@ -174,19 +174,13 @@ public final class ContainerTestUtils {
       Container<ContainerData> c, boolean shouldScanData,
       boolean scanMetaDataSuccess, boolean scanDataSuccess,
       AtomicLong containerIdSeq) {
-    setupMockContainer(c, shouldScanData, scanDataSuccess, containerIdSeq);
-    Mockito.lenient().when(c.scanMetaData()).thenReturn(scanMetaDataSuccess);
-  }
-
-  public static void setupMockContainer(
-      Container<ContainerData> c, boolean shouldScanData,
-      boolean scanDataSuccess, AtomicLong containerIdSeq) {
     ContainerData data = mock(ContainerData.class);
     when(data.getContainerID()).thenReturn(containerIdSeq.getAndIncrement());
     when(c.getContainerData()).thenReturn(data);
     when(c.shouldScanData()).thenReturn(shouldScanData);
     when(c.scanData(any(DataTransferThrottler.class), any(Canceler.class)))
         .thenReturn(scanDataSuccess);
+    Mockito.lenient().when(c.scanMetaData()).thenReturn(scanMetaDataSuccess);
   }
 
   public static KeyValueContainer setUpTestContainerUnderTmpDir(

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/ContainerTestUtils.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/ContainerTestUtils.java
@@ -173,7 +173,7 @@ public final class ContainerTestUtils {
   public static void setupMockContainer(
       Container<ContainerData> c, boolean shouldScanData,
       boolean scanMetaDataSuccess, boolean scanDataSuccess,
-      AtomicLong containerIdSeq) {
+      AtomicLong containerIdSeq, HddsVolume vol) {
     ContainerData data = mock(ContainerData.class);
     when(data.getContainerID()).thenReturn(containerIdSeq.getAndIncrement());
     when(c.getContainerData()).thenReturn(data);
@@ -181,6 +181,7 @@ public final class ContainerTestUtils {
     when(c.scanData(any(DataTransferThrottler.class), any(Canceler.class)))
         .thenReturn(scanDataSuccess);
     Mockito.lenient().when(c.scanMetaData()).thenReturn(scanMetaDataSuccess);
+    when(c.getContainerData().getVolume()).thenReturn(vol);
   }
 
   public static KeyValueContainer setUpTestContainerUnderTmpDir(

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/TestKeyValueHandlerWithUnhealthyContainer.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/TestKeyValueHandlerWithUnhealthyContainer.java
@@ -25,11 +25,16 @@ import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos;
 import org.apache.hadoop.hdds.scm.pipeline.MockPipeline;
 import org.apache.hadoop.ozone.container.common.helpers.ContainerMetrics;
 import org.apache.hadoop.ozone.container.common.impl.ContainerSet;
-import org.apache.hadoop.ozone.container.common.impl.TestHddsDispatcher;
+import org.apache.hadoop.ozone.container.common.interfaces.Container;
+import org.apache.hadoop.ozone.container.common.report.IncrementalReportSender;
 import org.apache.hadoop.ozone.container.common.statemachine.DatanodeStateMachine;
 
+import org.apache.hadoop.ozone.container.common.volume.HddsVolume;
 import org.apache.hadoop.ozone.container.common.volume.MutableVolumeSet;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.Mockito;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -56,8 +61,15 @@ public class TestKeyValueHandlerWithUnhealthyContainer {
   public static final Logger LOG = LoggerFactory.getLogger(
       TestKeyValueHandlerWithUnhealthyContainer.class);
 
+  public IncrementalReportSender<Container> mockIcrSender;
+
+  @BeforeEach
+  public void init() {
+    mockIcrSender = Mockito.mock(IncrementalReportSender.class);
+  }
+
   @Test
-  public void testRead() throws IOException {
+  public void testRead() {
     KeyValueContainer container = getMockUnhealthyContainer();
     KeyValueHandler handler = getDummyHandler();
 
@@ -69,7 +81,7 @@ public class TestKeyValueHandlerWithUnhealthyContainer {
   }
 
   @Test
-  public void testGetBlock() throws IOException {
+  public void testGetBlock() {
     KeyValueContainer container = getMockUnhealthyContainer();
     KeyValueHandler handler = getDummyHandler();
 
@@ -81,7 +93,7 @@ public class TestKeyValueHandlerWithUnhealthyContainer {
   }
 
   @Test
-  public void testGetCommittedBlockLength() throws IOException {
+  public void testGetCommittedBlockLength() {
     KeyValueContainer container = getMockUnhealthyContainer();
     KeyValueHandler handler = getDummyHandler();
 
@@ -94,7 +106,7 @@ public class TestKeyValueHandlerWithUnhealthyContainer {
   }
 
   @Test
-  public void testReadChunk() throws IOException {
+  public void testReadChunk() {
     KeyValueContainer container = getMockUnhealthyContainer();
     KeyValueHandler handler = getDummyHandler();
 
@@ -107,7 +119,7 @@ public class TestKeyValueHandlerWithUnhealthyContainer {
   }
 
   @Test
-  public void testGetSmallFile() throws IOException {
+  public void testGetSmallFile() {
     KeyValueContainer container = getMockUnhealthyContainer();
     KeyValueHandler handler = getDummyHandler();
 
@@ -137,9 +149,31 @@ public class TestKeyValueHandlerWithUnhealthyContainer {
     assertEquals(CONTAINER_INTERNAL_ERROR, response.getResult());
   }
 
+  @Test
+  public void testMarkContainerUnhealthyInFailedVolume() throws IOException {
+    KeyValueHandler handler = getDummyHandler();
+    KeyValueContainerData mockContainerData = mock(KeyValueContainerData.class);
+    HddsVolume mockVolume = mock(HddsVolume.class);
+    Mockito.when(mockContainerData.getVolume()).thenReturn(mockVolume);
+    KeyValueContainer container = new KeyValueContainer(
+        mockContainerData, new OzoneConfiguration());
+
+    // When volume is failed, the call to mark the container unhealthy should
+    // be ignored.
+    Mockito.when(mockVolume.isFailed()).thenReturn(true);
+    handler.markContainerUnhealthy(container);
+    Mockito.verify(mockIcrSender, Mockito.never()).send(Mockito.any());
+
+    // When volume is healthy, ICR should be sent when container is marked
+    // unhealthy.
+    Mockito.when(mockVolume.isFailed()).thenReturn(false);
+    handler.markContainerUnhealthy(container);
+    Mockito.verify(mockIcrSender, Mockito.atMostOnce()).send(Mockito.any());
+  }
+
   // -- Helper methods below.
 
-  private KeyValueHandler getDummyHandler() throws IOException {
+  private KeyValueHandler getDummyHandler() {
     DatanodeDetails dnDetails = DatanodeDetails.newBuilder()
         .setUuid(UUID.fromString(DATANODE_UUID))
         .setHostName("dummyHost")
@@ -153,7 +187,7 @@ public class TestKeyValueHandlerWithUnhealthyContainer {
         stateMachine.getDatanodeDetails().getUuidString(),
         mock(ContainerSet.class),
         mock(MutableVolumeSet.class),
-        mock(ContainerMetrics.class), TestHddsDispatcher.NO_OP_ICR_SENDER);
+        mock(ContainerMetrics.class), mockIcrSender);
   }
 
   private KeyValueContainer getMockUnhealthyContainer() {
@@ -165,5 +199,4 @@ public class TestKeyValueHandlerWithUnhealthyContainer {
         .ContainerDataProto.newBuilder().setContainerID(1).build());
     return new KeyValueContainer(containerData, new OzoneConfiguration());
   }
-
 }

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/TestKeyValueHandlerWithUnhealthyContainer.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/TestKeyValueHandlerWithUnhealthyContainer.java
@@ -33,7 +33,6 @@ import org.apache.hadoop.ozone.container.common.volume.HddsVolume;
 import org.apache.hadoop.ozone.container.common.volume.MutableVolumeSet;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -61,7 +60,7 @@ public class TestKeyValueHandlerWithUnhealthyContainer {
   public static final Logger LOG = LoggerFactory.getLogger(
       TestKeyValueHandlerWithUnhealthyContainer.class);
 
-  public IncrementalReportSender<Container> mockIcrSender;
+  private IncrementalReportSender<Container> mockIcrSender;
 
   @BeforeEach
   public void init() {

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/ozoneimpl/TestBackgroundContainerDataScanner.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/ozoneimpl/TestBackgroundContainerDataScanner.java
@@ -138,6 +138,7 @@ public class TestBackgroundContainerDataScanner extends
    * volume fails, the scanner thread should be terminated.
    */
   @Test
+  @Override
   public void testWithVolumeFailure() throws Exception {
     Mockito.when(vol.isFailed()).thenReturn(true);
     // Run the scanner thread in the background. It should be terminated on
@@ -150,6 +151,8 @@ public class TestBackgroundContainerDataScanner extends
     Mockito.verify(vol, atLeastOnce()).isFailed();
     // No iterations should have been run.
     assertEquals(0, metrics.getNumScanIterations());
+    assertEquals(0, metrics.getNumContainersScanned());
+    assertEquals(0, metrics.getNumUnHealthyContainers());
     // All containers were on the unhealthy volume, so they should not have
     // been scanned.
     Mockito.verify(healthy, never()).scanData(any(), any());

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/ozoneimpl/TestBackgroundContainerDataScanner.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/ozoneimpl/TestBackgroundContainerDataScanner.java
@@ -19,6 +19,7 @@
  */
 package org.apache.hadoop.ozone.container.ozoneimpl;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.apache.hadoop.metrics2.lib.DefaultMetricsSystem;
 import org.apache.ozone.test.GenericTestUtils;
 import org.junit.jupiter.api.Test;
@@ -139,6 +140,8 @@ public class TestBackgroundContainerDataScanner extends
    */
   @Test
   @Override
+  // Override findbugs warning about Mockito.verify
+  @SuppressFBWarnings("RV_RETURN_VALUE_IGNORED_NO_SIDE_EFFECT")
   public void testWithVolumeFailure() throws Exception {
     Mockito.when(vol.isFailed()).thenReturn(true);
     // Run the scanner thread in the background. It should be terminated on

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/ozoneimpl/TestBackgroundContainerMetadataScanner.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/ozoneimpl/TestBackgroundContainerMetadataScanner.java
@@ -20,6 +20,7 @@
 package org.apache.hadoop.ozone.container.ozoneimpl;
 
 import org.apache.hadoop.metrics2.lib.DefaultMetricsSystem;
+import org.apache.ozone.test.GenericTestUtils;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.BeforeEach;
 import org.mockito.Mockito;
@@ -31,6 +32,8 @@ import java.util.Optional;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.never;
 
@@ -110,5 +113,38 @@ public class TestBackgroundContainerMetadataScanner extends
     verifyContainerMarkedUnhealthy(corruptData, never());
     verifyContainerMarkedUnhealthy(openCorruptMetadata, atLeastOnce());
     verifyContainerMarkedUnhealthy(openContainer, never());
+  }
+
+  /**
+   * A datanode will have one metadata scanner thread for the whole process.
+   * When a volume fails, any the containers queued for scanning in that volume
+   * should be skipped but the thread will continue to run.
+   */
+  @Test
+  public void testWithVolumeFailure() throws Exception {
+    Mockito.when(vol.isFailed()).thenReturn(true);
+
+    ContainerMetadataScannerMetrics metrics = scanner.getMetrics();
+    // Start metadata scanner thread in the background.
+    scanner.start();
+    // Wait for at least one iteration to complete.
+    GenericTestUtils.waitFor(() -> metrics.getNumScanIterations() >= 1, 1000,
+        5000);
+    // Volume health should have been checked.
+    Mockito.verify(vol, atLeastOnce()).isFailed();
+    // Scanner should not have shutdown when it encountered the failed volume.
+    assertTrue(scanner.isAlive());
+
+    // Now explicitly shutdown the container.
+    scanner.shutdown();
+    // Wait for shutdown to finish
+    GenericTestUtils.waitFor(() -> !scanner.isAlive(), 1000, 5000);
+
+    // All containers were on the unhealthy volume, so they should not have
+    // been scanned.
+    Mockito.verify(healthy, never()).scanMetaData();
+    Mockito.verify(openContainer, never()).scanMetaData();
+    Mockito.verify(corruptData, never()).scanMetaData();
+    Mockito.verify(openCorruptMetadata, never()).scanMetaData();
   }
 }

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/ozoneimpl/TestBackgroundContainerMetadataScanner.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/ozoneimpl/TestBackgroundContainerMetadataScanner.java
@@ -33,7 +33,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.never;
 

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/ozoneimpl/TestBackgroundContainerMetadataScanner.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/ozoneimpl/TestBackgroundContainerMetadataScanner.java
@@ -121,6 +121,7 @@ public class TestBackgroundContainerMetadataScanner extends
    * should be skipped but the thread will continue to run.
    */
   @Test
+  @Override
   public void testWithVolumeFailure() throws Exception {
     Mockito.when(vol.isFailed()).thenReturn(true);
 
@@ -135,13 +136,15 @@ public class TestBackgroundContainerMetadataScanner extends
     // Scanner should not have shutdown when it encountered the failed volume.
     assertTrue(scanner.isAlive());
 
-    // Now explicitly shutdown the container.
+    // Now explicitly shutdown the scanner.
     scanner.shutdown();
-    // Wait for shutdown to finish
+    // Wait for shutdown to finish.
     GenericTestUtils.waitFor(() -> !scanner.isAlive(), 1000, 5000);
 
-    // All containers were on the unhealthy volume, so they should not have
+    // All containers were on the failed volume, so they should not have
     // been scanned.
+    assertEquals(0, metrics.getNumContainersScanned());
+    assertEquals(0, metrics.getNumUnHealthyContainers());
     Mockito.verify(healthy, never()).scanMetaData();
     Mockito.verify(openContainer, never()).scanMetaData();
     Mockito.verify(corruptData, never()).scanMetaData();

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/ozoneimpl/TestBackgroundContainerMetadataScanner.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/ozoneimpl/TestBackgroundContainerMetadataScanner.java
@@ -19,6 +19,7 @@
  */
 package org.apache.hadoop.ozone.container.ozoneimpl;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.apache.hadoop.metrics2.lib.DefaultMetricsSystem;
 import org.apache.ozone.test.GenericTestUtils;
 import org.junit.jupiter.api.Test;
@@ -121,6 +122,8 @@ public class TestBackgroundContainerMetadataScanner extends
    */
   @Test
   @Override
+  // Override findbugs warning about Mockito.verify
+  @SuppressFBWarnings("RV_RETURN_VALUE_IGNORED_NO_SIDE_EFFECT")
   public void testWithVolumeFailure() throws Exception {
     Mockito.when(vol.isFailed()).thenReturn(true);
 

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/ozoneimpl/TestContainerScannersAbstract.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/ozoneimpl/TestContainerScannersAbstract.java
@@ -129,20 +129,20 @@ public abstract class TestContainerScannersAbstract {
   private ContainerController mockContainerController() {
     // healthy container
     ContainerTestUtils.setupMockContainer(healthy,
-        true, true, true, CONTAINER_SEQ_ID);
+        true, true, true, CONTAINER_SEQ_ID, vol);
 
     // Open container (only metadata can be scanned)
     ContainerTestUtils.setupMockContainer(openContainer,
-        false, true, false, CONTAINER_SEQ_ID);
+        false, true, false, CONTAINER_SEQ_ID, vol);
 
     // unhealthy container (corrupt data)
     ContainerTestUtils.setupMockContainer(corruptData,
-        true, true, false, CONTAINER_SEQ_ID);
+        true, true, false, CONTAINER_SEQ_ID, vol);
 
     // unhealthy container (corrupt metadata). To simulate container still
     // being open while metadata is corrupted, shouldScanData will return false.
     ContainerTestUtils.setupMockContainer(openCorruptMetadata,
-        false, false, false, CONTAINER_SEQ_ID);
+        false, false, false, CONTAINER_SEQ_ID, vol);
 
     Collection<Container<?>> containers = Arrays.asList(
         healthy, corruptData, openCorruptMetadata);

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/ozoneimpl/TestContainerScannersAbstract.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/ozoneimpl/TestContainerScannersAbstract.java
@@ -97,6 +97,9 @@ public abstract class TestContainerScannersAbstract {
   @Test
   public abstract void testScannerMetricsUnregisters() throws Exception;
 
+  @Test
+  public abstract void testWithVolumeFailure() throws Exception;
+
   // HELPER METHODS
 
   protected void setScannedTimestampOld(Container<ContainerData> container) {

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/ozoneimpl/TestOnDemandContainerDataScanner.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/ozoneimpl/TestOnDemandContainerDataScanner.java
@@ -190,6 +190,34 @@ public class TestOnDemandContainerDataScanner extends
     verifyContainerMarkedUnhealthy(openContainer, never());
   }
 
+  /**
+   * A datanode will have one on-demand scanner thread for the whole process.
+   * When a volume fails, any the containers queued for scanning in that volume
+   * should be skipped but the thread will continue to run and accept new
+   * containers to scan.
+   */
+  @Test
+  @Override
+  public void testWithVolumeFailure() throws Exception {
+    Mockito.when(vol.isFailed()).thenReturn(true);
+
+    OnDemandContainerDataScanner.init(conf, controller);
+    OnDemandScannerMetrics metrics = OnDemandContainerDataScanner.getMetrics();
+
+    scanContainer(healthy);
+    verifyContainerMarkedUnhealthy(healthy, never());
+    scanContainer(corruptData);
+    verifyContainerMarkedUnhealthy(corruptData, never());
+    scanContainer(openCorruptMetadata);
+    verifyContainerMarkedUnhealthy(openCorruptMetadata, never());
+    scanContainer(openContainer);
+    verifyContainerMarkedUnhealthy(openContainer, never());
+
+    assertEquals(0, metrics.getNumContainersScanned());
+    assertEquals(0, metrics.getNumUnHealthyContainers());
+  }
+
+  @Test
   private void scanContainer(Container<ContainerData> container)
       throws Exception {
     OnDemandContainerDataScanner.init(conf, controller);

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/ozoneimpl/TestOnDemandContainerDataScanner.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/ozoneimpl/TestOnDemandContainerDataScanner.java
@@ -217,7 +217,6 @@ public class TestOnDemandContainerDataScanner extends
     assertEquals(0, metrics.getNumUnHealthyContainers());
   }
 
-  @Test
   private void scanContainer(Container<ContainerData> container)
       throws Exception {
     OnDemandContainerDataScanner.init(conf, controller);


### PR DESCRIPTION
## What changes were proposed in this pull request?

- Background container data scanner threads should terminate when their volume is marked unhealthy.
- When a container fails a scan, a volume scan should be done before marking it unhealthy to determine whether the problem is specific to the container or the volume.

## What is the link to the Apache JIRA

HDDS-7365

## How was this patch tested?

Unit tests added.
