### PR TITLE
HDDS-8587. Test that CertificateClient can store multiple rootCA certificates

### DIFF
--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/security/x509/certificate/client/TestDefaultCertificateClient.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/security/x509/certificate/client/TestDefaultCertificateClient.java
@@ -39,6 +39,8 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.security.KeyPair;
+import java.security.NoSuchAlgorithmException;
+import java.security.NoSuchProviderException;
 import java.security.PrivateKey;
 import java.security.PublicKey;
 import java.security.Signature;
@@ -333,6 +335,25 @@ public class TestDefaultCertificateClient {
     assertNotNull(dnCertClient.getCertificate(cert2.getSerialNumber()
         .toString()));
     assertNotNull(dnCertClient.getCertificate(cert3.getSerialNumber()
+        .toString()));
+  }
+
+  @Test
+  public void testStoreMultipleRootCACertificate() throws Exception {
+    KeyPair keyPair = keyGenerator.generateKey();
+    X509Certificate cert1 = generateX509Cert(keyPair);
+    X509Certificate cert2 = generateX509Cert(keyPair);
+    X509Certificate cert3 = generateX509Cert(keyPair);
+
+    dnCertClient.storeCertificate(getPEMEncodedString(cert1), CAType.ROOT);
+    dnCertClient.storeCertificate(getPEMEncodedString(cert2), CAType.ROOT);
+    dnCertClient.storeCertificate(getPEMEncodedString(cert3), CAType.ROOT);
+
+    assertEquals(cert1, dnCertClient.getCertificate(cert1.getSerialNumber()
+        .toString()));
+    assertEquals(cert2, dnCertClient.getCertificate(cert2.getSerialNumber()
+        .toString()));
+    assertEquals(cert3, dnCertClient.getCertificate(cert3.getSerialNumber()
         .toString()));
   }
 

--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/security/x509/certificate/client/TestDefaultCertificateClient.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/security/x509/certificate/client/TestDefaultCertificateClient.java
@@ -39,8 +39,6 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.security.KeyPair;
-import java.security.NoSuchAlgorithmException;
-import java.security.NoSuchProviderException;
 import java.security.PrivateKey;
 import java.security.PublicKey;
 import java.security.Signature;


### PR DESCRIPTION
## What changes were proposed in this pull request?

Pull request opened for master from feature branch PR, because the feature branch is going to be abandoned:
https://github.com/apache/ozone/pull/4717
For root CA cert rotation, it's necessary to enable the cert client to store multiple root CA certificates. This functionality already exists, here I'm just adding testing just to be sure. 

## What is the link to the Apache JIRA

[HDDS-8587](https://issues.apache.org/jira/browse/HDDS-8587)

## How was this patch tested?

CI runs on both my fork and on feature branch this was merged. Only testing functionality has been updated.