### PR TITLE
HDDS-8787. Reduce ozone sh calls in robot tests

### DIFF
--- a/hadoop-ozone/dist/src/main/smoketest/admincli/datanode.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/admincli/datanode.robot
@@ -21,12 +21,13 @@ Test Timeout        5 minutes
 
 *** Test Cases ***
 List datanodes
-    ${output} =         Execute          ozone admin datanode list
+                        Execute      ozone admin datanode list > datanode.list
+    ${output} =         Get File     datanode.list
                         Should contain   ${output}   Datanode:
                         Should contain   ${output}   Related pipelines:
 
 Filter list by UUID
-    ${uuid} =           Execute      ozone admin datanode list | grep '^Datanode:' | head -1 | awk '{ print \$2 }'
+    ${uuid} =           Execute      grep '^Datanode:' datanode.list | head -1 | awk '{ print \$2 }'
     ${output} =         Execute      ozone admin datanode list --id "${uuid}"
     Should contain      ${output}    Datanode: ${uuid}
     ${datanodes} =      Get Lines Containing String    ${output}    Datanode:
@@ -35,8 +36,8 @@ Filter list by UUID
     Should Be Equal As Integers    ${count}    1
 
 Filter list by NodeOperationalState
-    ${uuid} =           Execute      ozone admin datanode list | grep '^Datanode:' | head -1 | awk '{ print \$2 }'
-    ${expected} =       Execute      ozone admin datanode list | grep -c 'Operational State: IN_SERVICE'
+    ${uuid} =           Execute      grep '^Datanode:' datanode.list | head -1 | awk '{ print \$2 }'
+    ${expected} =       Execute      grep -c 'Operational State: IN_SERVICE' datanode.list
     ${output} =         Execute      ozone admin datanode list --operational-state IN_SERVICE
     Should contain      ${output}    Datanode: ${uuid}
     ${datanodes} =      Get Lines Containing String    ${output}    Datanode:
@@ -45,8 +46,8 @@ Filter list by NodeOperationalState
     Should Be Equal As Integers    ${count}    ${expected}
 
 Filter list by NodeState
-    ${uuid} =           Execute      ozone admin datanode list | grep '^Datanode:' | head -1 | awk '{ print \$2 }'
-    ${expected} =       Execute      ozone admin datanode list | grep -c 'Health State: HEALTHY'
+    ${uuid} =           Execute      grep '^Datanode:' datanode.list | head -1 | awk '{ print \$2 }'
+    ${expected} =       Execute      grep -c 'Health State: HEALTHY' datanode.list
     ${output} =         Execute      ozone admin datanode list --node-state HEALTHY
     Should contain      ${output}    Datanode: ${uuid}
     ${datanodes} =      Get Lines Containing String    ${output}    Datanode:

--- a/hadoop-ozone/dist/src/main/smoketest/basic/ozone-shell-lib.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/basic/ozone-shell-lib.robot
@@ -36,8 +36,6 @@ Test ozone shell
                     Should Be Empty     ${result}
     ${result} =     Execute             ozone sh volume list ${protocol}${server}/ | jq -r '.[] | select(.name=="${volume}")'
                     Should contain      ${result}       creationTime
-    ${result} =     Execute             ozone sh volume list | jq -r '.[] | select(.name=="${volume}")'
-                    Should contain      ${result}       creationTime
 # TODO: Disable updating the owner, acls should be used to give access to other user.
                     Execute             ozone sh volume setquota ${protocol}${server}/${volume} --space-quota 10TB --namespace-quota 100
 #    ${result} =     Execute             ozone sh volume info ${protocol}${server}/${volume} | jq -r '. | select(.volumeName=="${volume}") | .owner | .name'
@@ -46,16 +44,18 @@ Test ozone shell
                     Should Be Equal     ${result}       10995116277760
     ${result} =     Execute             ozone sh bucket create ${protocol}${server}/${volume}/bb1 --space-quota 10TB --namespace-quota 100
                     Should Be Empty     ${result}
-    ${result} =     Execute             ozone sh bucket info ${protocol}${server}/${volume}/bb1 | jq -r '. | select(.name=="bb1") | .storageType'
+                    Execute             ozone sh bucket info ${protocol}${server}/${volume}/bb1 > bb1.json
+    ${result} =     Execute             jq -r '. | select(.name=="bb1") | .storageType' bb1.json
                     Should Be Equal     ${result}       DISK
-    ${result} =     Execute             ozone sh bucket info ${protocol}${server}/${volume}/bb1 | jq -r '. | select(.name=="bb1") | .quotaInBytes'
+    ${result} =     Execute             jq -r '. | select(.name=="bb1") | .quotaInBytes' bb1.json
                     Should Be Equal     ${result}       10995116277760
-    ${result} =     Execute             ozone sh bucket info ${protocol}${server}/${volume}/bb1 | jq -r '. | select(.name=="bb1") | .quotaInNamespace'
+    ${result} =     Execute             jq -r '. | select(.name=="bb1") | .quotaInNamespace' bb1.json
                     Should Be Equal     ${result}       100
                     Execute             ozone sh bucket setquota ${protocol}${server}/${volume}/bb1 --space-quota 1TB --namespace-quota 1000
-    ${result} =     Execute             ozone sh bucket info ${protocol}${server}/${volume}/bb1 | jq -r '. | select(.name=="bb1") | .quotaInBytes'
+                    Execute             ozone sh bucket info ${protocol}${server}/${volume}/bb1 > bb1.json
+    ${result} =     Execute             jq -r '. | select(.name=="bb1") | .quotaInBytes' bb1.json
                     Should Be Equal     ${result}       1099511627776
-    ${result} =     Execute             ozone sh bucket info ${protocol}${server}/${volume}/bb1 | jq -r '. | select(.name=="bb1") | .quotaInNamespace'
+    ${result} =     Execute             jq -r '. | select(.name=="bb1") | .quotaInNamespace' bb1.json
                     Should Be Equal     ${result}       1000
     ${result} =     Execute             ozone sh bucket list ${protocol}${server}/${volume}/ | jq -r '.[] | select(.name=="bb1") | .volumeName'
                     Should Be Equal     ${result}       ${volume}
@@ -75,14 +75,16 @@ Test ozone shell
                     Execute             ozone sh bucket delete ${protocol}${server}/${volume}/bb1
                     Execute             ozone sh volume delete ${protocol}${server}/${volume}
                     Execute             ozone sh volume create ${protocol}${server}/${volume}
-    ${result} =     Execute             ozone sh volume info ${protocol}${server}/${volume} | jq -r '. | select(.name=="${volume}") | .quotaInBytes'
+                    Execute             ozone sh volume info ${protocol}${server}/${volume} > volume.json
+    ${result} =     Execute             jq -r '. | select(.name=="${volume}") | .quotaInBytes' volume.json
                     Should Be Equal     ${result}       -1
-    ${result} =     Execute             ozone sh volume info ${protocol}${server}/${volume} | jq -r '. | select(.name=="${volume}") | .quotaInNamespace'
+    ${result} =     Execute             jq -r '. | select(.name=="${volume}") | .quotaInNamespace' volume.json
                     Should Be Equal     ${result}       -1
                     Execute             ozone sh bucket create ${protocol}${server}/${volume}/bb1
-    ${result} =     Execute             ozone sh bucket info ${protocol}${server}/${volume}/bb1 | jq -r '. | select(.name=="bb1") | .quotaInBytes'
+                    Execute             ozone sh bucket info ${protocol}${server}/${volume}/bb1 > bb1.json
+    ${result} =     Execute             jq -r '. | select(.name=="bb1") | .quotaInBytes' bb1.json
                     Should Be Equal     ${result}       -1
-    ${result} =     Execute             ozone sh bucket info ${protocol}${server}/${volume}/bb1 | jq -r '. | select(.name=="bb1") | .quotaInNamespace'
+    ${result} =     Execute             jq -r '. | select(.name=="bb1") | .quotaInNamespace' bb1.json
                     Should Be Equal     ${result}       -1
                     Execute             ozone sh bucket delete ${protocol}${server}/${volume}/bb1
                     Execute             ozone sh volume delete ${protocol}${server}/${volume}


### PR DESCRIPTION
## What changes were proposed in this pull request?

Minor refactoring of some robot tests to reduce the number of identical `ozone sh` calls.

https://issues.apache.org/jira/browse/HDDS-8787

## How was this patch tested?

CI:
https://github.com/adoroszlai/hadoop-ozone/actions/runs/5208905246