### PR TITLE
HDDS-8790. Split EC acceptance tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -254,6 +254,7 @@ jobs:
           - secure
           - unsecure
           - compat
+          - EC
           - HA-secure
           - HA-unsecure
           - MR


### PR DESCRIPTION
## What changes were proposed in this pull request?

Extract EC-related tests into a separate acceptance check split.

Add unique name for the two repeated `read.robot` executions.

https://issues.apache.org/jira/browse/HDDS-8790

## How was this patch tested?

Ran `test-ec.sh` locally.

CI:
https://github.com/adoroszlai/hadoop-ozone/actions/runs/5209512124/jobs/9399896144