### PR TITLE
HDDS-8373. Document that setquota doesn't accept decimals

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/client/OzoneQuota.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/client/OzoneQuota.java
@@ -192,7 +192,7 @@ public final class OzoneQuota {
     } catch (NumberFormatException e) {
       throw new IllegalArgumentException("Invalid values for quota, to ensure" +
           " that the Quota format is legal(supported values are B," +
-          " KB, MB, GB and TB). And the quota value cannot be greater than " +
+          " KB, MB, GB and TB with positive long values). And the quota value cannot be greater than " +
           "Long.MAX_VALUE BYTES");
     }
 

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/client/OzoneQuota.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/client/OzoneQuota.java
@@ -191,9 +191,10 @@ public final class OzoneQuota {
       nSize = Long.parseLong(size);
     } catch (NumberFormatException e) {
       throw new IllegalArgumentException("Invalid values for quota, to ensure" +
-          " that the Quota format is legal(supported values are B," +
-          " KB, MB, GB and TB with positive long values). And the quota value cannot be greater than " +
-          "Long.MAX_VALUE BYTES");
+              " that the Quota format is legal(supported values are B," +
+              " KB, MB, GB and TB with positive long values)." +
+              " And the quota value cannot be greater than " +
+              "Long.MAX_VALUE BYTES");
     }
 
     if (nSize <= 0) {

--- a/hadoop-hdds/docs/content/feature/Quota.md
+++ b/hadoop-hdds/docs/content/feature/Quota.md
@@ -72,7 +72,7 @@ Storage space level quotas allow the use of units B, KB, MB, GB and TB. Represen
 
 #### Note:
 
-- You cannot set the quota of volumes and buckets in decimals. For example, 1.5 TB.
+- Decimals are not supported while setting quota for volume and bucket. For example, 1.5 TB.
 
 - Ensure that the minimum storage quota is default block size * replication factor. If you set the value lesser than the default block size * replication factor, while writing the data (key put) operation, an operation error is displayed.
 

--- a/hadoop-hdds/docs/content/feature/Quota.md
+++ b/hadoop-hdds/docs/content/feature/Quota.md
@@ -70,6 +70,12 @@ f. If the cluster is upgraded from old version less than 1.1.0, use of quota on 
 ### Storage Space level quota
 Storage space level quotas allow the use of units B, KB, MB, GB and TB. Represents how much storage Spaces will be used.
 
+#### Note:
+
+- You cannot set the quota of volumes and buckets in decimals. For example, 1.5 TB.
+
+- Ensure that the minimum storage quota is default block size * replication factor. If you set the value lesser than the default block size * replication factor, while writing the data (key put) operation, an operation error is displayed.
+
 #### Volume Storage Space level quota
 ```shell
 bin/ozone sh volume create --space-quota 5MB /volume1

--- a/hadoop-hdds/docs/content/feature/Quota.zh.md
+++ b/hadoop-hdds/docs/content/feature/Quota.zh.md
@@ -67,6 +67,11 @@ menu:
 ## 客户端用法
 ### Storage space级别配额
 Storage space级别配额允许使用 B, KB ，MB ，GB ，TB 等单位。表示将使用多少个存储空间。
+
+#### 注意:
+- Volume 和 Bucket 不支持设置带小数点的配额值，例如 1.5 TB.
+- 最小的有效空间配额，是一个数据块需要的存储空间，即默认块大小 * 副本数. 请确保设置的空间配额不小于这个数值，不然对象/文件写入操作，会失败。
+
 #### Volume Space quota用法
 ```shell
 bin/ozone sh volume create --space-quota 5MB /volume1


### PR DESCRIPTION
## What changes were proposed in this pull request?

Added a note in quota documentation for below 2 conditions
- In setquota [Volume & Bucker level ] doesn't accepts decimals 
- Minimum Storage quota should be default block size * replication factor 

## What is the link to the Apache JIRA

[HDDS-8373](https://issues.apache.org/jira/browse/HDDS-8373)
[HDDS-8372](https://issues.apache.org/jira/browse/HDDS-8372)

Please replace this section with the link to the Apache JIRA)

## How was this patch tested?

UT
