### PR TITLE
HDDS-8758. Container replication to use DISK volumes

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/HddsConfigKeys.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/HddsConfigKeys.java
@@ -61,6 +61,8 @@ public final class HddsConfigKeys {
   // Configuration to allow volume choosing policy.
   public static final String HDDS_DATANODE_VOLUME_CHOOSING_POLICY =
       "hdds.datanode.volume.choosing.policy";
+  public static final String HDDS_DATANODE_VOLUME_REPLICA_CHOOSING_POLICY =
+      "hdds.datanode.volume.replica.choosing.policy";
 
   public static final String HDDS_DATANODE_VOLUME_MIN_FREE_SPACE =
       "hdds.datanode.volume.min.free.space";

--- a/hadoop-hdds/common/src/main/resources/ozone-default.xml
+++ b/hadoop-hdds/common/src/main/resources/ozone-default.xml
@@ -205,6 +205,16 @@
     </description>
   </property>
   <property>
+    <name>hdds.datanode.volume.replica.choosing.policy</name>
+    <value/>
+    <tag>OZONE, CONTAINER, STORAGE, MANAGEMENT</tag>
+    <description>
+      The class name of the policy for choosing volumes in the list of
+      directories for replicating closed containers.
+      If not set, hdds.datanode.volume.choosing.policy is used.
+    </description>
+  </property>
+  <property>
     <name>hdds.datanode.volume.min.free.space</name>
     <value>5GB</value>
     <tag>OZONE, CONTAINER, STORAGE, MANAGEMENT</tag>

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/volume/FilteredVolumeChoosingPolicy.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/volume/FilteredVolumeChoosingPolicy.java
@@ -1,0 +1,48 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with this
+ * work for additional information regarding copyright ownership.  The ASF
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package org.apache.hadoop.ozone.container.common.volume;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+import org.apache.hadoop.ozone.container.common.interfaces.VolumeChoosingPolicy;
+
+/**
+ * Refine the list of volumes before choosing one.
+ */
+public class FilteredVolumeChoosingPolicy implements VolumeChoosingPolicy {
+
+  private final VolumeChoosingPolicy delegate;
+  private final Predicate<HddsVolume> volumeFilter;
+
+  public FilteredVolumeChoosingPolicy(VolumeChoosingPolicy delegate,
+                                      Predicate<HddsVolume> volumeFilter) {
+    this.delegate = delegate;
+    this.volumeFilter = volumeFilter;
+  }
+
+  @Override
+  public HddsVolume chooseVolume(List<HddsVolume> volumes,
+                                 long maxContainerSize) throws IOException {
+    return delegate.chooseVolume(volumes.stream()
+                                     .filter(volumeFilter)
+                                     .collect(Collectors.toList()),
+                                 maxContainerSize);
+  }
+}

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/volume/HddVolumeChoosingPolicy.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/volume/HddVolumeChoosingPolicy.java
@@ -1,0 +1,31 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with this
+ * work for additional information regarding copyright ownership.  The ASF
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package org.apache.hadoop.ozone.container.common.volume;
+
+import org.apache.hadoop.fs.StorageType;
+
+/**
+ * Chose only DISK volumes with {@link RoundRobinVolumeChoosingPolicy} policy.
+ */
+public class HddVolumeChoosingPolicy extends FilteredVolumeChoosingPolicy {
+
+  public HddVolumeChoosingPolicy() {
+    super(new RoundRobinVolumeChoosingPolicy(),
+          volume -> volume.getStorageType() == StorageType.DISK);
+  }
+}

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/volume/SsdVolumeChoosingPolicy.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/volume/SsdVolumeChoosingPolicy.java
@@ -1,0 +1,31 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with this
+ * work for additional information regarding copyright ownership.  The ASF
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package org.apache.hadoop.ozone.container.common.volume;
+
+import org.apache.hadoop.fs.StorageType;
+
+/**
+ * Chose only SSD volumes with {@link RoundRobinVolumeChoosingPolicy} policy.
+ */
+public class SsdVolumeChoosingPolicy extends FilteredVolumeChoosingPolicy {
+
+  public SsdVolumeChoosingPolicy() {
+    super(new RoundRobinVolumeChoosingPolicy(),
+        volume -> volume.getStorageType() == StorageType.SSD);
+  }
+}

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/replication/ContainerImporter.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/replication/ContainerImporter.java
@@ -41,6 +41,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 
 import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_DATANODE_VOLUME_CHOOSING_POLICY;
+import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_DATANODE_VOLUME_REPLICA_CHOOSING_POLICY;
 
 /**
  * Imports container from tarball.
@@ -65,9 +66,17 @@ public class ContainerImporter {
     this.controller = controller;
     this.volumeSet = volumeSet;
     try {
-      volumeChoosingPolicy = conf.getClass(
-          HDDS_DATANODE_VOLUME_CHOOSING_POLICY, RoundRobinVolumeChoosingPolicy
-              .class, VolumeChoosingPolicy.class).newInstance();
+      //we want custom volume choosing policy for container replicating case
+      //if not set, the cluster-wide policy is used
+      String key =
+          conf.isConfigured(HDDS_DATANODE_VOLUME_REPLICA_CHOOSING_POLICY) ?
+              HDDS_DATANODE_VOLUME_REPLICA_CHOOSING_POLICY :
+              HDDS_DATANODE_VOLUME_CHOOSING_POLICY;
+      volumeChoosingPolicy =
+          conf.getClass(key,
+                        RoundRobinVolumeChoosingPolicy.class,
+                        VolumeChoosingPolicy.class)
+              .newInstance();
     } catch (Exception e) {
       throw new RuntimeException(e);
     }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/placement/algorithms/SCMContainerPlacementHDD.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/placement/algorithms/SCMContainerPlacementHDD.java
@@ -1,0 +1,64 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with this
+ * work for additional information regarding copyright ownership.  The ASF
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package org.apache.hadoop.hdds.scm.container.placement.algorithms;
+
+
+import org.apache.hadoop.hdds.conf.ConfigurationSource;
+import org.apache.hadoop.hdds.protocol.DatanodeDetails;
+import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.StorageTypeProto;
+import org.apache.hadoop.hdds.scm.net.NetworkTopology;
+import org.apache.hadoop.hdds.scm.node.NodeManager;
+
+/**
+ * Container placement policy that chooses datanodes with DISK storage.
+ *
+ * The datanode selection algorithm is {@link SCMContainerPlacementRandom}
+ * but only the datanodes with enough {@link StorageTypeProto#DISK} space
+ * for data are considered.
+ */
+public class SCMContainerPlacementHDD extends SCMContainerPlacementRandom {
+
+  /**
+   * Construct a random Block Placement policy.
+   *
+   * @param nodeManager     nodeManager
+   * @param conf            Config
+   * @param networkTopology
+   * @param fallback
+   * @param metrics
+   */
+  public SCMContainerPlacementHDD(NodeManager nodeManager,
+                                  ConfigurationSource conf,
+                                  NetworkTopology networkTopology,
+                                  boolean fallback,
+                                  SCMContainerPlacementMetrics metrics) {
+    super(nodeManager, conf, networkTopology, fallback, metrics);
+  }
+
+  @Override
+  protected boolean hasEnoughSpace(DatanodeDetails datanodeDetails,
+                                   long metadataSizeRequired,
+                                   long dataSizeRequired) {
+    return StorageUtils.hasEnoughSpace(datanodeDetails,
+                          data ->
+                              data.getStorageType() == StorageTypeProto.DISK,
+                          null,
+                          metadataSizeRequired,
+                          dataSizeRequired);
+  }
+}

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/placement/algorithms/SCMContainerPlacementRandom.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/placement/algorithms/SCMContainerPlacementRandom.java
@@ -39,7 +39,7 @@ import java.util.List;
  * Balancer will need to support containers as a feature before this class
  * can be practically used.
  */
-public final class SCMContainerPlacementRandom extends SCMCommonPlacementPolicy
+public class SCMContainerPlacementRandom extends SCMCommonPlacementPolicy
     implements PlacementPolicy {
   @VisibleForTesting
   public static final Logger LOG =

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/placement/algorithms/StorageUtils.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/placement/algorithms/StorageUtils.java
@@ -1,0 +1,92 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with this
+ * work for additional information regarding copyright ownership.  The ASF
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package org.apache.hadoop.hdds.scm.container.placement.algorithms;
+
+import com.google.common.base.Preconditions;
+
+import java.util.function.Predicate;
+
+import org.apache.hadoop.hdds.protocol.DatanodeDetails;
+import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.MetadataStorageReportProto;
+import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.StorageReportProto;
+import org.apache.hadoop.hdds.scm.node.DatanodeInfo;
+
+/**
+ * Datanode storage volumes related functions.
+ */
+public final class StorageUtils {
+  private StorageUtils() {
+  }
+
+  /**
+   * Returns true if this node has enough space to meet our requirement.
+   *
+   * @param datanodeDetails DatanodeDetails
+   * @return true if we have enough space.
+   */
+  public static boolean hasEnoughSpace(DatanodeDetails datanodeDetails,
+                                       long metadataSizeRequired,
+                                       long dataSizeRequired) {
+    return hasEnoughSpace(datanodeDetails, null, null,
+        metadataSizeRequired, dataSizeRequired);
+  }
+
+  public static boolean hasEnoughSpace(
+      DatanodeDetails datanodeDetails,
+      Predicate<StorageReportProto> dataFilter,
+      Predicate<MetadataStorageReportProto> metadataFilter,
+      long metadataSizeRequired, long dataSizeRequired) {
+    Preconditions.checkArgument(datanodeDetails instanceof DatanodeInfo);
+
+    boolean enoughForData = false;
+    boolean enoughForMeta = false;
+
+    DatanodeInfo datanodeInfo = (DatanodeInfo) datanodeDetails;
+
+    if (dataSizeRequired > 0) {
+      for (StorageReportProto reportProto : datanodeInfo.getStorageReports()) {
+        if (reportProto.getRemaining() > dataSizeRequired
+            && (dataFilter == null || dataFilter.test(reportProto))) {
+          enoughForData = true;
+          break;
+        }
+      }
+    } else {
+      enoughForData = true;
+    }
+
+    if (!enoughForData) {
+      return false;
+    }
+
+    if (metadataSizeRequired > 0) {
+      for (MetadataStorageReportProto reportProto
+          : datanodeInfo.getMetadataStorageReports()) {
+        if (reportProto.getRemaining() > metadataSizeRequired
+            && (metadataFilter == null || metadataFilter.test(reportProto))) {
+          enoughForMeta = true;
+          break;
+        }
+      }
+    } else {
+      enoughForMeta = true;
+    }
+
+    return enoughForData && enoughForMeta;
+  }
+}

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/PipelineProvider.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/PipelineProvider.java
@@ -26,8 +26,8 @@ import java.util.stream.Collectors;
 
 import org.apache.hadoop.hdds.client.ReplicationConfig;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
-import org.apache.hadoop.hdds.scm.SCMCommonPlacementPolicy;
 import org.apache.hadoop.hdds.scm.container.ContainerReplica;
+import org.apache.hadoop.hdds.scm.container.placement.algorithms.StorageUtils;
 import org.apache.hadoop.hdds.scm.exceptions.SCMException;
 import org.apache.hadoop.hdds.scm.node.NodeManager;
 import org.apache.hadoop.hdds.scm.node.NodeStatus;
@@ -89,7 +89,7 @@ public abstract class PipelineProvider<REPLICATION_CONFIG
     int nodesRequired = replicationConfig.getRequiredNodes();
     List<DatanodeDetails> healthyDNs = pickAllNodesNotUsed(replicationConfig);
     List<DatanodeDetails> healthyDNsWithSpace = healthyDNs.stream()
-        .filter(dn -> SCMCommonPlacementPolicy
+        .filter(dn -> StorageUtils
             .hasEnoughSpace(dn, metadataSizeRequired, dataSizeRequired))
         .limit(nodesRequired)
         .collect(Collectors.toList());

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/MockNodeManager.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/MockNodeManager.java
@@ -276,7 +276,7 @@ public class MockNodeManager implements NodeManager {
   public List<DatanodeDetails> getNodes(
       HddsProtos.NodeOperationalState opState, HddsProtos.NodeState nodestate) {
     if (nodestate == HEALTHY) {
-      // mock storage reports for SCMCommonPlacementPolicy.hasEnoughSpace()
+      // mock storage reports for VolumeUtils..hasEnoughSpace()
       List<DatanodeDetails> healthyNodesWithInfo = new ArrayList<>();
       for (DatanodeDetails dd : healthyNodes) {
         DatanodeInfo di = new DatanodeInfo(dd, NodeStatus.inServiceHealthy(),

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/placement/algorithms/TestSCMContainerPlacementHDD.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/placement/algorithms/TestSCMContainerPlacementHDD.java
@@ -1,0 +1,165 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with this
+ * work for additional information regarding copyright ownership.  The ASF
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.hadoop.hdds.scm.container.placement.algorithms;
+
+import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import org.apache.hadoop.hdds.conf.StorageUnit;
+import org.apache.hadoop.hdds.protocol.DatanodeDetails;
+import org.apache.hadoop.hdds.protocol.MockDatanodeDetails;
+import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.MetadataStorageReportProto;
+import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.StorageReportProto;
+import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.StorageTypeProto;
+import org.apache.hadoop.hdds.scm.HddsTestUtils;
+import org.apache.hadoop.hdds.scm.exceptions.SCMException;
+import org.apache.hadoop.hdds.scm.node.DatanodeInfo;
+import org.apache.hadoop.hdds.scm.node.NodeManager;
+import org.apache.hadoop.hdds.scm.node.NodeStatus;
+import org.apache.hadoop.ozone.container.upgrade.UpgradeUtils;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_DATANODE_RATIS_VOLUME_FREE_SPACE_MIN;
+import static org.mockito.Mockito.when;
+
+/**
+ * Test for the DISK-only volume container placement.
+ */
+public class TestSCMContainerPlacementHDD {
+
+  @Test
+  public void chooseDatanodes() throws SCMException {
+    //given
+    OzoneConfiguration conf = new OzoneConfiguration();
+    // We are using small units here
+    conf.setStorageSize(OZONE_DATANODE_RATIS_VOLUME_FREE_SPACE_MIN,
+        1, StorageUnit.BYTES);
+
+    List<DatanodeInfo> datanodes = new ArrayList<>();
+
+    DatanodeInfo datanodeInfo0 = new DatanodeInfo(
+        MockDatanodeDetails.randomDatanodeDetails(),
+        NodeStatus.inServiceHealthy(),
+        UpgradeUtils.defaultLayoutVersionProto());
+    StorageReportProto storage01 = HddsTestUtils.createStorageReport(
+        datanodeInfo0.getUuid(), "/data1-" + datanodeInfo0.getUuidString(),
+        100L, 0, 100L, null);
+    StorageReportProto storage02 = HddsTestUtils.createStorageReport(
+        datanodeInfo0.getUuid(), "/data2-" + datanodeInfo0.getUuidString(),
+        300L, 0, 300L, StorageTypeProto.SSD);
+    MetadataStorageReportProto metaStorage01 =
+        HddsTestUtils.createMetadataStorageReport(
+            "/metadata1-" + datanodeInfo0.getUuidString(),
+            100L, 0, 100L, null);
+    datanodeInfo0.updateStorageReports(
+        new ArrayList<>(Arrays.asList(storage01, storage02)));
+    datanodeInfo0.updateMetaDataStorageReports(
+        new ArrayList<>(Arrays.asList(metaStorage01)));
+    datanodes.add(datanodeInfo0);
+
+    DatanodeInfo datanodeInfo1 = new DatanodeInfo(
+        MockDatanodeDetails.randomDatanodeDetails(),
+        NodeStatus.inServiceHealthy(),
+        UpgradeUtils.defaultLayoutVersionProto());
+    StorageReportProto storage11 = HddsTestUtils.createStorageReport(
+        datanodeInfo1.getUuid(), "/data1-" + datanodeInfo1.getUuidString(),
+        100L, 0, 100L, StorageTypeProto.SSD);
+    StorageReportProto storage12 = HddsTestUtils.createStorageReport(
+        datanodeInfo1.getUuid(), "/data2-" + datanodeInfo1.getUuidString(),
+        300L, 0, 300L, null);
+    MetadataStorageReportProto metaStorage11 =
+        HddsTestUtils.createMetadataStorageReport(
+            "/metadata1-" + datanodeInfo1.getUuidString(),
+            100L, 0, 100L, null);
+    datanodeInfo1.updateStorageReports(
+        new ArrayList<>(Arrays.asList(storage11, storage12)));
+    datanodeInfo1.updateMetaDataStorageReports(
+        new ArrayList<>(Arrays.asList(metaStorage11)));
+    datanodes.add(datanodeInfo1);
+
+    DatanodeInfo datanodeInfo2 = new DatanodeInfo(
+        MockDatanodeDetails.randomDatanodeDetails(),
+        NodeStatus.inServiceHealthy(),
+        UpgradeUtils.defaultLayoutVersionProto());
+    StorageReportProto storage21 = HddsTestUtils.createStorageReport(
+        datanodeInfo2.getUuid(), "/data1-" + datanodeInfo2.getUuidString(),
+        100L, 0, 100L, StorageTypeProto.SSD);
+    StorageReportProto storage22 = HddsTestUtils.createStorageReport(
+        datanodeInfo2.getUuid(), "/data2-" + datanodeInfo2.getUuidString(),
+        300L, 0, 300L, StorageTypeProto.SSD);
+    MetadataStorageReportProto metaStorage21 =
+        HddsTestUtils.createMetadataStorageReport(
+            "/metadata1-" + datanodeInfo2.getUuidString(),
+            100L, 0, 100L, null);
+    datanodeInfo2.updateStorageReports(
+        new ArrayList<>(Arrays.asList(storage21, storage22)));
+    datanodeInfo2.updateMetaDataStorageReports(
+        new ArrayList<>(Arrays.asList(metaStorage21)));
+    datanodes.add(datanodeInfo2);
+
+    DatanodeInfo datanodeInfo3 = new DatanodeInfo(
+        MockDatanodeDetails.randomDatanodeDetails(),
+        NodeStatus.inServiceHealthy(),
+        UpgradeUtils.defaultLayoutVersionProto());
+    StorageReportProto storage31 = HddsTestUtils.createStorageReport(
+        datanodeInfo3.getUuid(), "/data1-" + datanodeInfo3.getUuidString(),
+        100L, 0, 100L, null);
+    StorageReportProto storage32 = HddsTestUtils.createStorageReport(
+        datanodeInfo3.getUuid(), "/data2-" + datanodeInfo3.getUuidString(),
+        300L, 0, 300L, null);
+    MetadataStorageReportProto metaStorage31 =
+        HddsTestUtils.createMetadataStorageReport(
+            "/metadata1-" + datanodeInfo3.getUuidString(),
+            100L, 0, 100L, StorageTypeProto.SSD);
+    datanodeInfo3.updateStorageReports(
+        new ArrayList<>(Arrays.asList(storage31, storage32)));
+    datanodeInfo3.updateMetaDataStorageReports(
+        new ArrayList<>(Arrays.asList(metaStorage31)));
+    datanodes.add(datanodeInfo3);
+
+    NodeManager mockNodeManager = Mockito.mock(NodeManager.class);
+    when(mockNodeManager.getNodes(NodeStatus.inServiceHealthy()))
+        .thenReturn(new ArrayList<>(datanodes));
+
+    SCMContainerPlacementHDD scmContainerPlacement =
+        new SCMContainerPlacementHDD(mockNodeManager, conf, null, true,
+            null);
+
+    for (int i = 0; i < 100; i++) {
+      //when
+      List<DatanodeDetails> datanodeDetails = scmContainerPlacement
+          .chooseDatanodes(null, null, 1, 15, 120);
+      //then
+      Assertions.assertEquals(1, datanodeDetails.size());
+      //this is either node1 or node3. The type of metadata storage
+      //is not taken into account while filtering volumes
+      DatanodeDetails datanode0Details = datanodeDetails.get(0);
+
+      Assertions.assertNotEquals(
+          datanodes.get(0), datanode0Details,
+          "Datanode 0 should not been selected: not available space on DISK");
+      Assertions.assertNotEquals(
+          datanodes.get(2), datanode0Details,
+          "Datanode 2 should not been selected: no DISK volumes");
+    }
+  }
+
+}

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/placement/algorithms/TestStorageUtils.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/placement/algorithms/TestStorageUtils.java
@@ -1,0 +1,266 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with this
+ * work for additional information regarding copyright ownership.  The ASF
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.hadoop.hdds.scm.container.placement.algorithms;
+
+import org.apache.hadoop.hdds.protocol.MockDatanodeDetails;
+import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.MetadataStorageReportProto;
+import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.StorageReportProto;
+import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.StorageTypeProto;
+import org.apache.hadoop.hdds.scm.HddsTestUtils;
+import org.apache.hadoop.hdds.scm.node.DatanodeInfo;
+import org.apache.hadoop.hdds.scm.node.NodeStatus;
+import org.apache.hadoop.ozone.container.upgrade.UpgradeUtils;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.UUID;
+
+import static java.util.Arrays.asList;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Test for StorageUtils.
+ */
+public class TestStorageUtils {
+
+  @Test
+  public void testNoFilters() {
+    DatanodeInfo datanodeInfo = new DatanodeInfo(
+        MockDatanodeDetails.randomDatanodeDetails(),
+        NodeStatus.inServiceHealthy(),
+        UpgradeUtils.defaultLayoutVersionProto());
+    StorageReportProto data0 =
+        HddsTestUtils.createStorageReport(UUID.randomUUID(),
+            "/" + UUID.randomUUID(), 2_000_000);
+    StorageReportProto data1 =
+        HddsTestUtils.createStorageReport(UUID.randomUUID(),
+            "/" + UUID.randomUUID(), 6_000_000, 0, 6_000_000,
+            StorageTypeProto.SSD);
+    datanodeInfo.
+        updateStorageReports(new ArrayList<>(asList(data0, data1)));
+
+    MetadataStorageReportProto meta0 =
+        HddsTestUtils.createMetadataStorageReport("/meta-" + UUID.randomUUID(),
+            2_000_000, 0, 2_000_000, StorageTypeProto.SSD);
+    datanodeInfo.
+        updateMetaDataStorageReports(
+            new ArrayList<>(Arrays.asList(meta0)));
+
+    long dataRequired = 5_000_000;
+    long metaRequired = 1_000_000;
+
+    boolean hasSpace =
+        StorageUtils.hasEnoughSpace(datanodeInfo, metaRequired, dataRequired);
+    //no filters, able to pick suitable volumes
+    assertTrue(hasSpace);
+  }
+
+  @Test
+  public void testFilterNoDataSpace() {
+    DatanodeInfo datanodeInfo = new DatanodeInfo(
+        MockDatanodeDetails.randomDatanodeDetails(),
+        NodeStatus.inServiceHealthy(),
+        UpgradeUtils.defaultLayoutVersionProto());
+
+    StorageReportProto data0 =
+        HddsTestUtils.createStorageReport(UUID.randomUUID(),
+            "/" + UUID.randomUUID(), 2_000_000);
+    StorageReportProto data1 =
+        HddsTestUtils.createStorageReport(UUID.randomUUID(),
+            "/" + UUID.randomUUID(), 6_000_000, 0, 6_000_000,
+            StorageTypeProto.SSD);
+    datanodeInfo.
+        updateStorageReports(new ArrayList<>(asList(data0, data1)));
+
+    MetadataStorageReportProto meta0 =
+        HddsTestUtils.createMetadataStorageReport("/meta-" + UUID.randomUUID(),
+            2_000_000, 0, 2_000_000, StorageTypeProto.SSD);
+    datanodeInfo.
+        updateMetaDataStorageReports(
+            new ArrayList<>(Arrays.asList(meta0)));
+
+    long dataRequired = 5_000_000;
+    long metaRequired = 1_000_000;
+
+    boolean hasSpace =
+        StorageUtils.hasEnoughSpace(datanodeInfo, data ->
+                data.getStorageType() == StorageTypeProto.DISK,
+            null,
+            metaRequired, dataRequired);
+    //no free DISK storage
+    assertFalse(hasSpace);
+  }
+
+  @Test
+  public void testHasSuitableDiskVolume() {
+    DatanodeInfo datanodeInfo = new DatanodeInfo(
+        MockDatanodeDetails.randomDatanodeDetails(),
+        NodeStatus.inServiceHealthy(),
+        UpgradeUtils.defaultLayoutVersionProto());
+
+    StorageReportProto data0 =
+        HddsTestUtils.createStorageReport(UUID.randomUUID(),
+            "/" + UUID.randomUUID(), 2_000_000);
+    StorageReportProto data1 =
+        HddsTestUtils.createStorageReport(UUID.randomUUID(),
+            "/" + UUID.randomUUID(), 6_000_000, 0, 6_000_000,
+            StorageTypeProto.SSD);
+    StorageReportProto data2 =
+        HddsTestUtils.createStorageReport(UUID.randomUUID(),
+            "/" + UUID.randomUUID(), 7_000_000);
+    datanodeInfo.
+        updateStorageReports(new ArrayList<>(asList(data0, data1, data2)));
+
+    MetadataStorageReportProto meta0 =
+        HddsTestUtils.createMetadataStorageReport("/meta-" + UUID.randomUUID(),
+            2_000_000, 0, 2_000_000, StorageTypeProto.SSD);
+    datanodeInfo.
+        updateMetaDataStorageReports(
+            new ArrayList<>(Arrays.asList(meta0)));
+
+    long dataRequired = 5_000_000;
+    long metaRequired = 1_000_000;
+
+    boolean hasSpace =
+        StorageUtils.hasEnoughSpace(datanodeInfo, data ->
+                data.getStorageType() == StorageTypeProto.DISK,
+            null,
+            metaRequired, dataRequired);
+    //found suitable volume after filtering
+    assertTrue(hasSpace);
+  }
+
+  @Test
+  public void testFilterNoMetaSpace() {
+    DatanodeInfo datanodeInfo = new DatanodeInfo(
+        MockDatanodeDetails.randomDatanodeDetails(),
+        NodeStatus.inServiceHealthy(),
+        UpgradeUtils.defaultLayoutVersionProto());
+
+    StorageReportProto data0 =
+        HddsTestUtils.createStorageReport(UUID.randomUUID(),
+            "/" + UUID.randomUUID(), 2_000_000);
+    StorageReportProto data1 =
+        HddsTestUtils.createStorageReport(UUID.randomUUID(),
+            "/" + UUID.randomUUID(), 6_000_000, 0, 6_000_000,
+            StorageTypeProto.SSD);
+    datanodeInfo.
+        updateStorageReports(new ArrayList<>(asList(data0, data1)));
+
+    MetadataStorageReportProto meta0 =
+        HddsTestUtils.createMetadataStorageReport("/meta-" + UUID.randomUUID(),
+            2_000_000, 0, 2_000_000, StorageTypeProto.SSD);
+    datanodeInfo.
+        updateMetaDataStorageReports(
+            new ArrayList<>(Arrays.asList(meta0)));
+
+    long dataRequired = 5_000_000;
+    long metaRequired = 1_000_000;
+
+    boolean hasSpace =
+        StorageUtils.hasEnoughSpace(datanodeInfo, null,
+            meta ->
+                meta.getStorageType() == StorageTypeProto.DISK,
+            metaRequired, dataRequired);
+    //no free metadata DISK storage
+    assertFalse(hasSpace);
+  }
+
+  @Test
+  public void testFilterHasMetaSpace() {
+    DatanodeInfo datanodeInfo = new DatanodeInfo(
+        MockDatanodeDetails.randomDatanodeDetails(),
+        NodeStatus.inServiceHealthy(),
+        UpgradeUtils.defaultLayoutVersionProto());
+
+    StorageReportProto data0 =
+        HddsTestUtils.createStorageReport(UUID.randomUUID(),
+            "/" + UUID.randomUUID(), 2_000_000);
+    StorageReportProto data1 =
+        HddsTestUtils.createStorageReport(UUID.randomUUID(),
+            "/" + UUID.randomUUID(), 6_000_000, 0, 6_000_000,
+            StorageTypeProto.SSD);
+    datanodeInfo.
+        updateStorageReports(new ArrayList<>(asList(data0, data1)));
+
+    MetadataStorageReportProto meta0 =
+        HddsTestUtils.createMetadataStorageReport("/meta-" + UUID.randomUUID(),
+            2_000_000, 0, 2_000_000, StorageTypeProto.SSD);
+    MetadataStorageReportProto meta1 =
+        HddsTestUtils.createMetadataStorageReport("/meta-" + UUID.randomUUID(),
+            2_000_000, 0, 2_000_000, StorageTypeProto.DISK);
+    datanodeInfo.
+        updateMetaDataStorageReports(
+            new ArrayList<>(Arrays.asList(meta0, meta1)));
+
+    long dataRequired = 5_000_000;
+    long metaRequired = 1_000_000;
+
+    boolean hasSpace =
+        StorageUtils.hasEnoughSpace(datanodeInfo, null,
+            meta ->
+                meta.getStorageType() == StorageTypeProto.DISK,
+            metaRequired, dataRequired);
+    //found suitable metadata DISK space
+    assertTrue(hasSpace);
+  }
+
+  @Test
+  public void testHasSuitableDiskAndMetaVolume() {
+    DatanodeInfo datanodeInfo = new DatanodeInfo(
+        MockDatanodeDetails.randomDatanodeDetails(),
+        NodeStatus.inServiceHealthy(),
+        UpgradeUtils.defaultLayoutVersionProto());
+
+    StorageReportProto data0 =
+        HddsTestUtils.createStorageReport(UUID.randomUUID(),
+            "/" + UUID.randomUUID(), 2_000_000);
+    StorageReportProto data1 =
+        HddsTestUtils.createStorageReport(UUID.randomUUID(),
+            "/" + UUID.randomUUID(), 6_000_000, 0, 6_000_000,
+            StorageTypeProto.SSD);
+    StorageReportProto data2 =
+        HddsTestUtils.createStorageReport(UUID.randomUUID(),
+            "/" + UUID.randomUUID(), 7_000_000);
+    datanodeInfo.
+        updateStorageReports(new ArrayList<>(asList(data0, data1, data2)));
+
+    MetadataStorageReportProto meta0 =
+        HddsTestUtils.createMetadataStorageReport("/meta-" + UUID.randomUUID(),
+            2_000_000, 0, 2_000_000, StorageTypeProto.SSD);
+    MetadataStorageReportProto meta1 =
+        HddsTestUtils.createMetadataStorageReport("/meta-" + UUID.randomUUID(),
+            2_000_000, 0, 2_000_000, StorageTypeProto.DISK);
+    datanodeInfo.
+        updateMetaDataStorageReports(
+            new ArrayList<>(Arrays.asList(meta0, meta1)));
+
+    long dataRequired = 5_000_000;
+    long metaRequired = 1_000_000;
+
+    boolean hasSpace =
+        StorageUtils.hasEnoughSpace(datanodeInfo, data ->
+                data.getStorageType() == StorageTypeProto.DISK,
+            meta ->
+                meta.getStorageType() == StorageTypeProto.DISK,
+            metaRequired, dataRequired);
+    //both filters applied, found space
+    assertTrue(hasSpace);
+  }
+}


### PR DESCRIPTION
## What changes were proposed in this pull request?

Now there is a way to define a volume choosing policy for replicating closed containers only. 
Also added a policy that selects nodes with enough space on DISK/SSD storage - to be able to replicated closed containers on nodes with HDD.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-8758

## How was this patch tested?
unit tests, manual tests
