### PR TITLE
HDDS-8755. Cleanup loadAllCertificates code in DefaultCertificateClient.

### DIFF
--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/security/x509/certificate/client/CertificateClient.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/security/x509/certificate/client/CertificateClient.java
@@ -99,14 +99,6 @@ public interface CertificateClient extends Closeable {
   X509Certificate getCACertificate();
 
   /**
-   * Returns the full certificate path for the CA certificate known to the
-   * client.
-   *
-   * @return latest ca certificate path known to the client
-   */
-  CertPath getCACertPath();
-
-  /**
    * Return all certificates in this component's trust chain,
    * the last one is the root CA certificate.
    */

--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/security/x509/certificate/client/CertificateClientTestImpl.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/security/x509/certificate/client/CertificateClientTestImpl.java
@@ -204,11 +204,6 @@ public class CertificateClientTestImpl implements CertificateClient {
   }
 
   @Override
-  public CertPath getCACertPath() {
-    return null;
-  }
-
-  @Override
   public List<X509Certificate> getTrustChain() {
     List<X509Certificate> list = new ArrayList<>();
     list.add(x509Certificate);


### PR DESCRIPTION
## What changes were proposed in this pull request?

Reorganize the loadAllCertificates code in the DefaultCertificateClient, to make it more easy to understand what is actually happening.
Reduce visibility of getCACertPath method which is used only within the DefaultCertificateClient.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-8755

## How was this patch tested?

Existing JUnit tests.
