### PR TITLE
HDDS-8788. Robot test for finalized upgrade duplicates non-upgrade test

### DIFF
--- a/hadoop-ozone/dist/src/main/compose/upgrade/upgrades/non-rolling-upgrade/callbacks/1.4.0/callback.sh
+++ b/hadoop-ozone/dist/src/main/compose/upgrade/upgrades/non-rolling-upgrade/callbacks/1.4.0/callback.sh
@@ -27,6 +27,6 @@ with_this_version_pre_finalized() {
 
 with_this_version_finalized() {
   execute_robot_test "$SCM" --include finalized upgrade/check-finalization.robot
-  execute_robot_test "$SCM" --include finalized-snapshot-tests snapshot/upgrade-snapshot-check.robot
+  execute_robot_test "$SCM" snapshot/snapshot-sh.robot
 }
 

--- a/hadoop-ozone/dist/src/main/smoketest/snapshot/snapshot-sh.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/snapshot/snapshot-sh.robot
@@ -57,3 +57,11 @@ Read Snapshot
     Key Should Match Local File         /${VOLUME}/${BUCKET}/${SNAPSHOT_INDICATOR}/${SNAPSHOT_ONE}/${KEY_ONE}       /etc/hosts
     Key Should Match Local File         /${VOLUME}/${BUCKET}/${SNAPSHOT_INDICATOR}/${SNAPSHOT_TWO}/${KEY_TWO}       /etc/passwd
     Key Should Match Local File         /${VOLUME}/${BUCKET}/${SNAPSHOT_INDICATOR}/${SNAPSHOT_TWO}/${KEY_THREE}     /etc/group
+
+Delete snapshot
+    ${output} =         Execute           ozone sh snapshot delete /${VOLUME}/${BUCKET} ${SNAPSHOT_ONE}
+                        Should not contain      ${output}       Failed
+
+    ${output} =         Execute            ozone sh snapshot ls /${VOLUME}/${BUCKET} | jq '[.[] | select(.name == "${SNAPSHOT_ONE}") | .snapshotStatus] | if length > 0 then .[] else "SNAPSHOT_DELETED" end'
+                        Should contain   ${output}   SNAPSHOT_DELETED
+

--- a/hadoop-ozone/dist/src/main/smoketest/snapshot/upgrade-snapshot-check.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/snapshot/upgrade-snapshot-check.robot
@@ -18,26 +18,14 @@ Documentation       Smoketest ozone cluster snapshot feature
 Library             OperatingSystem
 Library             BuiltIn
 Resource            ../commonlib.robot
+Default Tags        pre-finalized-snapshot-tests
 Test Timeout        5 minutes
 
 *** Variables ***
 
 
 *** Test Cases ***
-Create snapshots
-    [Tags]     finalized-snapshot-tests
-    ${output} =         Execute                ozone sh volume create snapvolume-1
-                        Should not contain     ${output}       Failed
-    ${output} =         Execute                ozone sh bucket create /snapvolume-1/snapbucket-1
-                        Should not contain     ${output}       Failed
-    ${output} =         Execute                ozone sh snapshot create /snapvolume-1/snapbucket-1 snapshot1
-                        Should not contain     ${output}       Failed
-                        Execute and checkrc    echo "key created using Ozone Shell" > /tmp/sourcekey    0
-                        Execute                ozone sh key put /snapvolume-1/snapbucket-1/key1 /tmp/sourcekey
-                        Execute                ozone sh snapshot create /snapvolume-1/snapbucket-1 snapshot2
-
 Attempt to create snapshot when snapshot feature is disabled
-    [Tags]     pre-finalized-snapshot-tests
     ${output} =         Execute And Ignore Error    ozone sh volume create snapvolume-2     
                         Should not contain     ${output}       Failed
     ${output} =         Execute And Ignore Error    ozone sh bucket create /snapvolume-2/snapbucket-1     
@@ -45,44 +33,14 @@ Attempt to create snapshot when snapshot feature is disabled
     ${output} =         Execute and checkrc         ozone sh snapshot create /snapvolume-2/snapbucket-1 snapshot1    255
                         Should contain    ${output}   NOT_SUPPORTED_OPERATION
 
-List snapshots
-    [Tags]     finalized-snapshot-tests
-    ${output} =         Execute           ozone sh snapshot ls /snapvolume-1/snapbucket-1
-                        Should contain    ${output}       snapshot1
-                        Should contain    ${output}       snapshot2
-                        Should contain    ${output}       SNAPSHOT_ACTIVE
-
 Attempt to list snapshot when snapshot feature is disabled
-    [Tags]     pre-finalized-snapshot-tests
     ${output} =         Execute and checkrc         ozone sh snapshot ls /snapvolume-2/snapbucket-1    255
                         Should contain    ${output}   NOT_SUPPORTED_OPERATION
 
-Snapshot Diff
-    [Tags]     finalized-snapshot-tests
-    WHILE   True
-        ${output} =       Execute      ozone sh snapshot snapshotDiff /snapvolume-1/snapbucket-1 snapshot1 snapshot2
-        IF                "Snapshot diff job is IN_PROGRESS" in """${output}"""
-                          Sleep   10s
-        ELSE
-                          BREAK
-        END
-    END
-    Should contain    ${output}       +    key1
-
 Attempt to snapshotDiff when snapshot feature is disabled
-    [Tags]     pre-finalized-snapshot-tests
     ${output} =         Execute and checkrc         ozone sh snapshot snapshotDiff /snapvolume-2/snapbucket-1 snapshot1 snapshot2    255
                         Should contain    ${output}   NOT_SUPPORTED_OPERATION
 
-Delete snapshot
-    [Tags]     finalized-snapshot-tests
-    ${output} =         Execute           ozone sh snapshot delete /snapvolume-1/snapbucket-1 snapshot1
-                        Should not contain      ${output}       Failed
-
-    ${output} =         Execute            ozone sh snapshot ls /snapvolume-1/snapbucket-1 | jq '[.[] | select(.name == "snapshot1") | .snapshotStatus] | if length > 0 then .[] else "SNAPSHOT_DELETED" end'
-                        Should contain   ${output}   SNAPSHOT_DELETED
-
 Attempt to delete when snapshot feature is disabled
-    [Tags]     pre-finalized-snapshot-tests
     ${output} =         Execute and checkrc         ozone sh snapshot delete /snapvolume-2/snapbucket-1 snapshot1    255
                         Should contain    ${output}   NOT_SUPPORTED_OPERATION


### PR DESCRIPTION
## What changes were proposed in this pull request?

Test cases in `upgrade-snapshot-check.robot` that cover finalized state duplicate some regular robot tests from `snapshot-sh.robot`.

Problems:
 * for upgrade test it causes code duplication
 * for non-upgrade test it performs similar steps twice, leading to longer test execution time

This PR removes the duplicated test cases and executes `snapshot-sh.robot` after the upgrade.

https://issues.apache.org/jira/browse/HDDS-8788

## How was this patch tested?

Verified that acceptance test runs regular snapshot robot tests after upgrade is finalized:
https://github.com/adoroszlai/hadoop-ozone/actions/runs/5230058676/jobs/9443669110#step:5:884