### PR TITLE
HDDS-8789. Simplify snapshot diff command name

### DIFF
--- a/hadoop-ozone/dist/src/main/smoketest/snapshot/snapshot-sh.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/snapshot/snapshot-sh.robot
@@ -47,9 +47,9 @@ Snapshot Diff
     Set Suite Variable      ${KEY_THREE}        ${key_three}
     ${snapshot_two} =       Create snapshot     ${VOLUME}       ${BUCKET}
     Set Suite Variable      ${SNAPSHOT_TWO}     ${snapshot_two}
-    ${result} =     Execute             ozone sh snapshot snapshotDiff /${VOLUME}/${BUCKET} ${SNAPSHOT_ONE} ${SNAPSHOT_TWO}
+    ${result} =     Execute             ozone sh snapshot diff /${VOLUME}/${BUCKET} ${SNAPSHOT_ONE} ${SNAPSHOT_TWO}
                     Should contain      ${result}       Snapshot diff job is IN_PROGRESS
-    ${result} =     Execute             ozone sh snapshot snapshotDiff /${VOLUME}/${BUCKET} ${SNAPSHOT_ONE} ${SNAPSHOT_TWO}
+    ${result} =     Execute             ozone sh snapshot diff /${VOLUME}/${BUCKET} ${SNAPSHOT_ONE} ${SNAPSHOT_TWO}
                     Should contain      ${result}       +    ${KEY_TWO}
                     Should contain      ${result}       +    ${KEY_THREE}
 

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/snapshot/SnapshotDiffHandler.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/snapshot/SnapshotDiffHandler.java
@@ -28,9 +28,9 @@ import java.io.IOException;
 import java.io.PrintStream;
 
 /**
- * ozone snapshot create.
+ * ozone snapshot diff.
  */
-@CommandLine.Command(name = "snapshotDiff",
+@CommandLine.Command(name = "diff", aliases = "snapshotDiff",
     description = "Get the differences between two snapshots")
 public class SnapshotDiffHandler extends Handler {
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

`ozone sh snapshot snapshotDiff` would be more user-friendly simply as `ozone sh snapshot diff`.  Hierarchical sub-commands help establish context, no need for repeating "snapshot".

https://issues.apache.org/jira/browse/HDDS-8789

## How was this patch tested?

Updated acceptance test.

https://github.com/adoroszlai/hadoop-ozone/actions/runs/5230130623/jobs/9444144097#step:5:953