### PR TITLE
HDDS-8803. Release CodecBuffers when batch operation is closed

### DIFF
--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/RDBBatchOperation.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/RDBBatchOperation.java
@@ -166,17 +166,28 @@ public class RDBBatchOperation implements BatchOperation {
           }
         }
 
-        debug(() -> String.format("  %s %s, #put=%s, #del=%s", this,
-            batchSizeDiscardedString(), putCount, delCount));
+        debug(this::summary);
+      }
+
+      private String summary() {
+        return String.format("  %s %s, #put=%s, #del=%s", this,
+            batchSizeDiscardedString(), putCount, delCount);
       }
 
       void clear() {
+        final boolean warn = !isCommit && batchSize > 0;
+        String details = warn ? summary() : null;
+
         for (Object value : ops.values()) {
           if (value instanceof CodecBuffer) {
             ((CodecBuffer) value).release(); // the key will also be released
           }
         }
         ops.clear();
+
+        if (warn) {
+          LOG.warn("discarding changes {}", details);
+        }
       }
 
       void putOrDelete(Bytes key, int keyLen, Object val, int valLen) {
@@ -351,6 +362,7 @@ public class RDBBatchOperation implements BatchOperation {
   public void close() {
     debug(() -> String.format("%s: close", name));
     writeBatch.close();
+    opCache.clear();
   }
 
   public void delete(ColumnFamily family, byte[] key) throws IOException {


### PR DESCRIPTION
## What changes were proposed in this pull request?

`TestScmHAFinalization` intermittently reports `Found 2 leaked objects` (`CodecBuffer` instances).

```
2023-06-08 19:50:12,664 [Finalizer] WARN  db.CodecBuffer (CodecBuffer.java:finalize(129)) - LEAK 1: org.apache.hadoop.hdds.utils.db.CodecBuffer@292f4cc4, refCnt=1, capacity=3 allocation:
org.apache.hadoop.hdds.utils.db.CodecBuffer.allocate(CodecBuffer.java:74)
...
org.apache.hadoop.hdds.utils.db.TypedTable.putWithBatch(TypedTable.java:172)
```

`CodecBuffer`s created for batch operations are released on commit.  They are leaked if the batch is closed without commit.

https://github.com/apache/ozone/blob/b479a384e854b6eb62c429801ec3ce2acfa3c160/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/RDBBatchOperation.java#L333-L339

This PR fixes the leak by clearing the batch's cache in `close()`.  It does not commit the batch, which still must be done explicitly to persist the changes.

https://issues.apache.org/jira/browse/HDDS-8803

## How was this patch tested?

Ran `TestScmHAFinalization#testSnapshotFinalization`:

```
[664dc5c1-8c56-4847-89db-9e9428244ac1@group-B4112365FA6F-StateMachineUpdater] WARN  db.RDBBatchOperation (RDBBatchOperation.java:clear(189)) - discarding changes   Batch-4: meta batchSize=105 B, discarded: 6 (90 B), #put=7, #del=0
```

CI:
https://github.com/adoroszlai/hadoop-ozone/actions/runs/5230215922