### PR TITLE
HDDS-8813. Prepare for dynamic config in ReplicationManager

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/OverReplicatedProcessor.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/OverReplicatedProcessor.java
@@ -18,6 +18,8 @@
 package org.apache.hadoop.hdds.scm.container.replication;
 
 import java.io.IOException;
+import java.time.Duration;
+import java.util.function.Supplier;
 
 /**
  * Class used to pick messages from the ReplicationManager over replicated
@@ -28,8 +30,8 @@ public class OverReplicatedProcessor extends UnhealthyReplicationProcessor
         <ContainerHealthResult.OverReplicatedHealthResult> {
 
   public OverReplicatedProcessor(ReplicationManager replicationManager,
-      long intervalInMillis) {
-    super(replicationManager, intervalInMillis);
+      Supplier<Duration> interval) {
+    super(replicationManager, interval);
 
   }
 

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/UnderReplicatedProcessor.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/UnderReplicatedProcessor.java
@@ -18,6 +18,8 @@
 package org.apache.hadoop.hdds.scm.container.replication;
 
 import java.io.IOException;
+import java.time.Duration;
+import java.util.function.Supplier;
 
 /**
  * Class used to pick messages from the ReplicationManager under replicated
@@ -27,9 +29,9 @@ import java.io.IOException;
 public class UnderReplicatedProcessor extends UnhealthyReplicationProcessor
         <ContainerHealthResult.UnderReplicatedHealthResult> {
 
-  public UnderReplicatedProcessor(ReplicationManager replicationManager,
-                                  long intervalInMillis) {
-    super(replicationManager, intervalInMillis);
+  UnderReplicatedProcessor(ReplicationManager replicationManager,
+      Supplier<Duration> interval) {
+    super(replicationManager, interval);
   }
 
   @Override

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/UnhealthyReplicationProcessor.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/UnhealthyReplicationProcessor.java
@@ -25,9 +25,11 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
+import java.time.Duration;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Supplier;
 
 /**
  * Class used to pick messages from the respective ReplicationManager
@@ -41,12 +43,12 @@ public abstract class UnhealthyReplicationProcessor<HealthResult extends
           .getLogger(UnhealthyReplicationProcessor.class);
   private final ReplicationManager replicationManager;
   private volatile boolean runImmediately = false;
-  private final long intervalInMillis;
+  private final Supplier<Duration> interval;
 
   public UnhealthyReplicationProcessor(ReplicationManager replicationManager,
-                                       long intervalInMillis) {
+                                       Supplier<Duration> interval) {
     this.replicationManager = replicationManager;
-    this.intervalInMillis = intervalInMillis;
+    this.interval = interval;
   }
 
   /**
@@ -160,9 +162,14 @@ public abstract class UnhealthyReplicationProcessor<HealthResult extends
         if (replicationManager.shouldRun()) {
           processAll(replicationManager.getQueue());
         }
+
+        final Duration duration = interval.get();
+        if (!runImmediately && LOG.isDebugEnabled()) {
+          LOG.debug("May wait {} before next run", duration);
+        }
         synchronized (this) {
           if (!runImmediately) {
-            wait(intervalInMillis);
+            wait(duration.toMillis());
           }
           runImmediately = false;
         }

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestOverReplicatedProcessor.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestOverReplicatedProcessor.java
@@ -55,7 +55,7 @@ public class TestOverReplicatedProcessor {
     queue = new ReplicationQueue();
     repConfig = new ECReplicationConfig(3, 2);
     overReplicatedProcessor = new OverReplicatedProcessor(
-        replicationManager, rmConf.getOverReplicatedInterval());
+        replicationManager, rmConf::getOverReplicatedInterval);
     Mockito.when(replicationManager.shouldRun()).thenReturn(true);
 
     // Even through the limit has been exceeded, it should not stop over-rep

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestUnderReplicatedProcessor.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestUnderReplicatedProcessor.java
@@ -56,7 +56,7 @@ public class TestUnderReplicatedProcessor {
     queue = new ReplicationQueue();
     repConfig = new ECReplicationConfig(3, 2);
     underReplicatedProcessor = new UnderReplicatedProcessor(
-        replicationManager, rmConf.getUnderReplicatedInterval());
+        replicationManager, rmConf::getUnderReplicatedInterval);
     Mockito.when(replicationManager.shouldRun()).thenReturn(true);
     Mockito.when(replicationManager.getMetrics())
         .thenReturn(ReplicationManagerMetrics.create(replicationManager));


### PR DESCRIPTION
## What changes were proposed in this pull request?

Refactor `ReplicationManager` and related classes to prepare for dynamic reconfigurability.  Avoid storing config in member variables.

https://issues.apache.org/jira/browse/HDDS-8813

## How was this patch tested?

CI:
https://github.com/adoroszlai/hadoop-ozone/actions/runs/5235703783