### PR TITLE
HDDS-8701. Recon - Improve Mismatched container info API (containers/v1/mismatch).

### DIFF
--- a/hadoop-ozone/ozone-manager/null/snapDiff/_README.txt
+++ b/hadoop-ozone/ozone-manager/null/snapDiff/_README.txt
@@ -1,0 +1,2 @@
+This directory is used to store SST files needed to generate snap diff report for a particular job.
+ DO NOT add, change or delete any files in this directory unless you know what you are doing.

--- a/hadoop-ozone/ozone-manager/null/snapDiff/_README.txt
+++ b/hadoop-ozone/ozone-manager/null/snapDiff/_README.txt
@@ -1,2 +1,0 @@
-This directory is used to store SST files needed to generate snap diff report for a particular job.
- DO NOT add, change or delete any files in this directory unless you know what you are doing.

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/ReconConstants.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/ReconConstants.java
@@ -49,7 +49,7 @@ public final class ReconConstants {
   public static final String PREV_DELETED_BLOCKS_TRANSACTION_ID_DEFAULT_VALUE =
       "0";
   // Only include containers that are missing in OM by default
-  public static final String DEFAULT_FILTER_FOR_MISSING_CONTAINERS = "OM";
+  public static final String DEFAULT_FILTER_FOR_MISSING_CONTAINERS = "SCM";
   public static final String RECON_QUERY_LIMIT = "limit";
   public static final String RECON_QUERY_VOLUME = "volume";
   public static final String RECON_QUERY_BUCKET = "bucket";

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/ReconConstants.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/ReconConstants.java
@@ -44,9 +44,12 @@ public final class ReconConstants {
   public static final String RECON_QUERY_PREVKEY = "prevKey";
   public static final String RECON_OPEN_KEY_INCLUDE_NON_FSO = "includeNonFso";
   public static final String RECON_OPEN_KEY_INCLUDE_FSO = "includeFso";
+  public static final String RECON_QUERY_FILTER = "missingIn";
   public static final String PREV_CONTAINER_ID_DEFAULT_VALUE = "0";
   public static final String PREV_DELETED_BLOCKS_TRANSACTION_ID_DEFAULT_VALUE =
       "0";
+  // Only include containers that are missing in OM by default
+  public static final String DEFAULT_FILTER_FOR_MISSING_CONTAINERS = "OM";
   public static final String RECON_QUERY_LIMIT = "limit";
   public static final String RECON_QUERY_VOLUME = "volume";
   public static final String RECON_QUERY_BUCKET = "bucket";

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/api/ContainerEndpoint.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/api/ContainerEndpoint.java
@@ -677,9 +677,14 @@ public class ContainerEndpoint {
           Response.Status.INTERNAL_SERVER_ERROR);
     }
     Map<String, Object> response = new HashMap<>();
-    response.put("prevKey", containerDiscrepancyInfoList.get(
-        containerDiscrepancyInfoList.size() - 1).getContainerID());
+    if (!containerDiscrepancyInfoList.isEmpty()) {
+      response.put("prevKey", containerDiscrepancyInfoList.get(
+          containerDiscrepancyInfoList.size() - 1).getContainerID());
+    } else {
+      response.put("prevKey", null);
+    }
     response.put("containerDiscrepancyInfo", containerDiscrepancyInfoList);
+
 
     return Response.ok(response).build();
   }

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/api/ContainerEndpoint.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/api/ContainerEndpoint.java
@@ -640,27 +640,27 @@ public class ContainerEndpoint {
 
         List<Pipeline> pipelines = new ArrayList<>();
         nonOMContainers.forEach(nonOMContainerId -> {
-            boolean containerExistsInScm = true;
-            ContainerDiscrepancyInfo containerDiscrepancyInfo =
-                new ContainerDiscrepancyInfo();
-            containerDiscrepancyInfo.setContainerID(nonOMContainerId);
-            containerDiscrepancyInfo.setNumberOfKeys(0);
-            PipelineID pipelineID = null;
-            try {
-              pipelineID = containerManager.getContainer(
-                  ContainerID.valueOf(nonOMContainerId)).getPipelineID();
-              if (pipelineID != null) {
-                pipelines.add(pipelineManager.getPipeline(pipelineID));
-              }
-            } catch (ContainerNotFoundException e) {
-              containerExistsInScm = false;
-              LOG.warn("Container {} not found in SCM: {}", nonOMContainerId,
-                  e);
-            } catch (PipelineNotFoundException e) {
-              LOG.debug(
-                  "Pipeline not found for container: {} and pipelineId: {}",
-                  nonOMContainerId, pipelineID, e);
+          boolean containerExistsInScm = true;
+          ContainerDiscrepancyInfo containerDiscrepancyInfo =
+              new ContainerDiscrepancyInfo();
+          containerDiscrepancyInfo.setContainerID(nonOMContainerId);
+          containerDiscrepancyInfo.setNumberOfKeys(0);
+          PipelineID pipelineID = null;
+          try {
+            pipelineID = containerManager.getContainer(
+                ContainerID.valueOf(nonOMContainerId)).getPipelineID();
+            if (pipelineID != null) {
+              pipelines.add(pipelineManager.getPipeline(pipelineID));
             }
+          } catch (ContainerNotFoundException e) {
+            containerExistsInScm = false;
+            LOG.warn("Container {} not found in SCM: {}", nonOMContainerId,
+                e);
+          } catch (PipelineNotFoundException e) {
+            LOG.debug(
+                "Pipeline not found for container: {} and pipelineId: {}",
+                nonOMContainerId, pipelineID, e);
+          }
           // The container might have been deleted in SCM after the call to
           // get the list of containers
           if (containerExistsInScm) {

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/api/ContainerEndpoint.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/api/ContainerEndpoint.java
@@ -506,7 +506,7 @@ public class ContainerEndpoint {
    * Retrieves the container mismatch insights.
    *
    * This method returns a list of ContainerDiscrepancyInfo objects representing
-   * the containers that are missing in either the Object Manager (OM) or the
+   * the containers that are missing in either the Ozone Manager (OM) or the
    * Storage Container Manager (SCM), based on the provided filter parameter.
    * The returned list is paginated based on the provided limit and prevKey
    * parameters.

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/api/ContainerEndpoint.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/api/ContainerEndpoint.java
@@ -641,8 +641,9 @@ public class ContainerEndpoint {
           Response.Status.INTERNAL_SERVER_ERROR);
     }
     Map<String, Object> response = new HashMap<>();
-    response.put("prevKey", prevKey);
-    response.put("missingContainerList", containerDiscrepancyInfoList);
+    response.put("prevKey", containerDiscrepancyInfoList.get(
+        containerDiscrepancyInfoList.size() - 1).getContainerID());
+    response.put("containerDiscrepancyInfo", containerDiscrepancyInfoList);
 
     return Response.ok(response).build();
   }

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/api/ContainerEndpoint.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/api/ContainerEndpoint.java
@@ -759,6 +759,14 @@ public class ContainerEndpoint {
       throw new WebApplicationException(ex,
           Response.Status.INTERNAL_SERVER_ERROR);
     }
-    return Response.ok(containerDiscrepancyInfoList).build();
+    Map<String, Object> response = new HashMap<>();
+    if (!containerDiscrepancyInfoList.isEmpty()) {
+      response.put("prevKey", containerDiscrepancyInfoList.get(
+          containerDiscrepancyInfoList.size() - 1).getContainerID());
+    } else {
+      response.put("prevKey", null);
+    }
+    response.put("containerDiscrepancyInfo", containerDiscrepancyInfoList);
+    return Response.ok(response).build();
   }
 }

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/api/ContainerEndpoint.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/api/ContainerEndpoint.java
@@ -67,7 +67,12 @@ import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import java.io.IOException;
 import java.time.Instant;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.Collections;
 import java.util.stream.Collectors;
 
 import static org.apache.hadoop.ozone.recon.ReconConstants.DEFAULT_BATCH_NUMBER;

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/api/ContainerEndpoint.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/api/ContainerEndpoint.java
@@ -678,10 +678,10 @@ public class ContainerEndpoint {
     }
     Map<String, Object> response = new HashMap<>();
     if (!containerDiscrepancyInfoList.isEmpty()) {
-      response.put("prevKey", containerDiscrepancyInfoList.get(
+      response.put("lastKey", containerDiscrepancyInfoList.get(
           containerDiscrepancyInfoList.size() - 1).getContainerID());
     } else {
-      response.put("prevKey", null);
+      response.put("lastKey", null);
     }
     response.put("containerDiscrepancyInfo", containerDiscrepancyInfoList);
 
@@ -761,10 +761,10 @@ public class ContainerEndpoint {
     }
     Map<String, Object> response = new HashMap<>();
     if (!containerDiscrepancyInfoList.isEmpty()) {
-      response.put("prevKey", containerDiscrepancyInfoList.get(
+      response.put("lastKey", containerDiscrepancyInfoList.get(
           containerDiscrepancyInfoList.size() - 1).getContainerID());
     } else {
-      response.put("prevKey", null);
+      response.put("lastKey", null);
     }
     response.put("containerDiscrepancyInfo", containerDiscrepancyInfoList);
     return Response.ok(response).build();

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/api/TestContainerEndpoint.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/api/TestContainerEndpoint.java
@@ -1278,7 +1278,7 @@ public class TestContainerEndpoint {
             "containerDiscrepancyInfo");
 
     // Check the prevKey is set correct in the response
-    long responsePrevKey = (long) response.get("prevKey");
+    long responsePrevKey = (long) response.get("lastKey");
     assertEquals(containerDiscrepancyInfoList.get(
             containerDiscrepancyInfoList.size() - 1).getContainerID(),
         responsePrevKey);
@@ -1334,7 +1334,7 @@ public class TestContainerEndpoint {
           containerEndpoint.getContainerMisMatchInsights(limit, prevKey, "SCM");
       Map<String, Object> response =
           (Map<String, Object>) containerInsights.getEntity();
-      long responsePrevKey = (long) response.get("prevKey");
+      long responsePrevKey = (long) response.get("lastKey");
       List<ContainerDiscrepancyInfo> containerDiscrepancyInfoList =
           (List<ContainerDiscrepancyInfo>) response.get(
               "containerDiscrepancyInfo");
@@ -1380,7 +1380,7 @@ public class TestContainerEndpoint {
             "containerDiscrepancyInfo");
 
     // Check the prevKey is set correct in the response
-    long responsePrevKey = (long) response.get("prevKey");
+    long responsePrevKey = (long) response.get("lastKey");
     assertEquals(containerDiscrepancyInfoList.get(
             containerDiscrepancyInfoList.size() - 1).getContainerID(),
         responsePrevKey);
@@ -1422,7 +1422,7 @@ public class TestContainerEndpoint {
             "containerDiscrepancyInfo");
 
     // Check the prevKey is set correct in the response
-    long responsePrevKey = (long) response.get("prevKey");
+    long responsePrevKey = (long) response.get("lastKey");
     assertEquals(containerDiscrepancyInfoList.get(
             containerDiscrepancyInfoList.size() - 1).getContainerID(),
         responsePrevKey);
@@ -1539,7 +1539,7 @@ public class TestContainerEndpoint {
             "containerDiscrepancyInfo");
 
     // Check the prevKey is set correct in the response
-    long responsePrevKey = (long) responseMap.get("prevKey");
+    long responsePrevKey = (long) responseMap.get("lastKey");
     assertEquals(containerDiscrepancyInfoList.get(
             containerDiscrepancyInfoList.size() - 1).getContainerID(),
         responsePrevKey);
@@ -1581,7 +1581,7 @@ public class TestContainerEndpoint {
             "containerDiscrepancyInfo");
 
     // Check the prevKey is set correct in the response
-    long responsePrevKey = (long) responseMap.get("prevKey");
+    long responsePrevKey = (long) responseMap.get("lastKey");
     assertEquals(containerDiscrepancyInfoList.get(
             containerDiscrepancyInfoList.size() - 1).getContainerID(),
         responsePrevKey);
@@ -1625,7 +1625,7 @@ public class TestContainerEndpoint {
             "containerDiscrepancyInfo");
 
     // Check the prevKey is set correct in the response
-    long responsePrevKey = (long) responseMap.get("prevKey");
+    long responsePrevKey = (long) responseMap.get("lastKey");
     assertEquals(containerDiscrepancyInfoList.get(
             containerDiscrepancyInfoList.size() - 1).getContainerID(),
         responsePrevKey);

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/api/TestContainerEndpoint.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/api/TestContainerEndpoint.java
@@ -1273,10 +1273,10 @@ public class TestContainerEndpoint {
     Map<String, Object> response =
         (Map<String, Object>) containerInsights.getEntity();
     long prevKey = (long) response.get("prevKey");
-    assertEquals(0, prevKey);
+    assertEquals(1, prevKey);
     List<ContainerDiscrepancyInfo> containerDiscrepancyInfoList =
         (List<ContainerDiscrepancyInfo>) response.get(
-            "missingContainerList");
+            "containerDiscrepancyInfo");
     ContainerDiscrepancyInfo containerDiscrepancyInfo =
         containerDiscrepancyInfoList.get(0);
     assertEquals(1, containerDiscrepancyInfo.getContainerID());
@@ -1325,7 +1325,7 @@ public class TestContainerEndpoint {
         (Map<String, Object>) containerInsights.getEntity();
     long responsePrevKey = (long) response.get("prevKey");
     List<ContainerDiscrepancyInfo> containerDiscrepancyInfoList =
-        (List<ContainerDiscrepancyInfo>) response.get("missingContainerList");
+        (List<ContainerDiscrepancyInfo>) response.get("containerDiscrepancyInfo");
 
     // Check the first ContainerDiscrepancyInfo object in the response
     assertEquals(3, containerDiscrepancyInfoList.size());
@@ -1334,7 +1334,7 @@ public class TestContainerEndpoint {
         containerDiscrepancyInfoList.get(0);
     assertEquals(3, containerDiscrepancyInfo.getContainerID());
     assertEquals("OM", containerDiscrepancyInfo.getExistsAt());
-    assertEquals(prevKey, responsePrevKey);
+    assertEquals(5, responsePrevKey);
   }
 
   @Test
@@ -1359,7 +1359,7 @@ public class TestContainerEndpoint {
     Map<String, Object> response =
         (Map<String, Object>) containerInsights.getEntity();
     List<ContainerDiscrepancyInfo> containerDiscrepancyInfoList =
-        (List<ContainerDiscrepancyInfo>) response.get("missingContainerList");
+        (List<ContainerDiscrepancyInfo>) response.get("containerDiscrepancyInfo");
     ContainerDiscrepancyInfo containerDiscrepancyInfo =
         containerDiscrepancyInfoList.get(0);
     assertEquals(2, containerDiscrepancyInfo.getContainerID());
@@ -1393,7 +1393,7 @@ public class TestContainerEndpoint {
     Map<String, Object> response =
         (Map<String, Object>) containerInsights.getEntity();
     List<ContainerDiscrepancyInfo> containerDiscrepancyInfoList =
-        (List<ContainerDiscrepancyInfo>) response.get("missingContainerList");
+        (List<ContainerDiscrepancyInfo>) response.get("containerDiscrepancyInfo");
 
     // Check the first two ContainerDiscrepancyInfo objects in the response
     assertEquals(3, containerDiscrepancyInfoList.size());
@@ -1432,7 +1432,7 @@ public class TestContainerEndpoint {
         (Map<String, Object>) responseOM.getEntity();
     List<ContainerDiscrepancyInfo> containerDiscrepancyInfoListOM =
         (List<ContainerDiscrepancyInfo>)
-            responseMapOM.get("missingContainerList");
+            responseMapOM.get("containerDiscrepancyInfo");
     assertEquals(3, containerDiscrepancyInfoListOM.size());
 
     // Set the filter to "SCM" to get missing containers in SCM
@@ -1442,7 +1442,7 @@ public class TestContainerEndpoint {
         (Map<String, Object>) responseSCM.getEntity();
     List<ContainerDiscrepancyInfo> containerDiscrepancyInfoListSCM =
         (List<ContainerDiscrepancyInfo>)
-            responseMapSCM.get("missingContainerList");
+            responseMapSCM.get("containerDiscrepancyInfo");
     assertEquals(2, containerDiscrepancyInfoListSCM.size());
 
     List<Long> missingContainerIdsOM = containerDiscrepancyInfoListOM.stream()

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/api/TestContainerEndpoint.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/api/TestContainerEndpoint.java
@@ -100,7 +100,12 @@ import static org.apache.hadoop.ozone.recon.OMMetadataManagerTestUtils.getTestRe
 import static org.apache.hadoop.ozone.recon.OMMetadataManagerTestUtils.initializeNewOmMetadataManager;
 import static org.apache.hadoop.ozone.recon.OMMetadataManagerTestUtils.writeDataToOm;
 import static org.apache.hadoop.ozone.recon.OMMetadataManagerTestUtils.writeKeyToOm;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import static org.junit.Assert.assertNotEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/api/TestContainerEndpoint.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/api/TestContainerEndpoint.java
@@ -1529,9 +1529,21 @@ public class TestContainerEndpoint {
     Response omContainersDeletedInSCMResponse =
         containerEndpoint.getOmContainersDeletedInSCM(-1, 0);
     assertNotNull(omContainersDeletedInSCMResponse);
+
+    Map<String, Object> responseMap =
+        (Map<String, Object>) omContainersDeletedInSCMResponse.getEntity();
+
+    // Fetch the ContainerDiscrepancyInfo list from the response
     List<ContainerDiscrepancyInfo> containerDiscrepancyInfoList =
-        (List<ContainerDiscrepancyInfo>)
-            omContainersDeletedInSCMResponse.getEntity();
+        (List<ContainerDiscrepancyInfo>) responseMap.get(
+            "containerDiscrepancyInfo");
+
+    // Check the prevKey is set correct in the response
+    long responsePrevKey = (long) responseMap.get("prevKey");
+    assertEquals(containerDiscrepancyInfoList.get(
+            containerDiscrepancyInfoList.size() - 1).getContainerID(),
+        responsePrevKey);
+
     assertEquals(3, containerDiscrepancyInfoList.get(0)
         .getNumberOfKeys());
     assertEquals(1, containerDiscrepancyInfoList.size());
@@ -1559,9 +1571,21 @@ public class TestContainerEndpoint {
     Response omContainersDeletedInSCMResponse =
         containerEndpoint.getOmContainersDeletedInSCM(1, 0);
     assertNotNull(omContainersDeletedInSCMResponse);
+
+    Map<String, Object> responseMap =
+        (Map<String, Object>) omContainersDeletedInSCMResponse.getEntity();
+
+    // Fetch the ContainerDiscrepancyInfo list from the response
     List<ContainerDiscrepancyInfo> containerDiscrepancyInfoList =
-        (List<ContainerDiscrepancyInfo>)
-            omContainersDeletedInSCMResponse.getEntity();
+        (List<ContainerDiscrepancyInfo>) responseMap.get(
+            "containerDiscrepancyInfo");
+
+    // Check the prevKey is set correct in the response
+    long responsePrevKey = (long) responseMap.get("prevKey");
+    assertEquals(containerDiscrepancyInfoList.get(
+            containerDiscrepancyInfoList.size() - 1).getContainerID(),
+        responsePrevKey);
+
     assertEquals(3, containerDiscrepancyInfoList.get(0)
         .getNumberOfKeys());
     assertEquals(1, containerDiscrepancyInfoList.size());
@@ -1591,10 +1615,21 @@ public class TestContainerEndpoint {
     Response omContainersDeletedInSCMResponse =
         containerEndpoint.getOmContainersDeletedInSCM(2,
             1);
-    assertNotNull(omContainersDeletedInSCMResponse);
+
+    Map<String, Object> responseMap =
+        (Map<String, Object>) omContainersDeletedInSCMResponse.getEntity();
+
+    // Fetch the ContainerDiscrepancyInfo list from the response
     List<ContainerDiscrepancyInfo> containerDiscrepancyInfoList =
-        (List<ContainerDiscrepancyInfo>)
-            omContainersDeletedInSCMResponse.getEntity();
+        (List<ContainerDiscrepancyInfo>) responseMap.get(
+            "containerDiscrepancyInfo");
+
+    // Check the prevKey is set correct in the response
+    long responsePrevKey = (long) responseMap.get("prevKey");
+    assertEquals(containerDiscrepancyInfoList.get(
+            containerDiscrepancyInfoList.size() - 1).getContainerID(),
+        responsePrevKey);
+
     assertEquals(2, containerDiscrepancyInfoList.get(0)
         .getNumberOfKeys());
     assertEquals(1, containerDiscrepancyInfoList.size());

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/api/TestContainerEndpoint.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/api/TestContainerEndpoint.java
@@ -724,20 +724,20 @@ public class TestContainerEndpoint {
 
     Response responseWithLimit = containerEndpoint.getMissingContainers(3);
     MissingContainersResponse responseWithLimitObject
-            = (MissingContainersResponse) responseWithLimit.getEntity();
+        = (MissingContainersResponse) responseWithLimit.getEntity();
     assertEquals(3, responseWithLimitObject.getTotalCount());
     MissingContainerMetadata containerWithLimit =
-            responseWithLimitObject.getContainers().stream().findFirst()
-                    .orElse(null);
+        responseWithLimitObject.getContainers().stream().findFirst()
+            .orElse(null);
     assertNotNull(containerWithLimit);
     assertTrue(containerWithLimit.getReplicas().stream()
         .map(ContainerHistory::getState)
         .allMatch(s -> s.equals("UNHEALTHY")));
 
     Collection<MissingContainerMetadata> recordsWithLimit
-            = responseWithLimitObject.getContainers();
+        = responseWithLimitObject.getContainers();
     List<MissingContainerMetadata> missingWithLimit
-            = new ArrayList<>(recordsWithLimit);
+        = new ArrayList<>(recordsWithLimit);
     assertEquals(3, missingWithLimit.size());
     assertEquals(1L, missingWithLimit.get(0).getContainerID());
     assertEquals(2L, missingWithLimit.get(1).getContainerID());
@@ -919,7 +919,7 @@ public class TestContainerEndpoint {
     assertTrue(records.stream()
         .flatMap(containerMetadata -> containerMetadata.getReplicas().stream()
             .map(ContainerHistory::getState))
-            .allMatch(s -> s.equals("UNHEALTHY")));
+        .allMatch(s -> s.equals("UNHEALTHY")));
     // There should only be 5 missing containers and no others as we asked for
     // only missing.
     assertEquals(5, records.size());
@@ -1272,11 +1272,17 @@ public class TestContainerEndpoint {
         containerEndpoint.getContainerMisMatchInsights(10, 0, "SCM");
     Map<String, Object> response =
         (Map<String, Object>) containerInsights.getEntity();
-    long prevKey = (long) response.get("prevKey");
-    assertEquals(1, prevKey);
+
     List<ContainerDiscrepancyInfo> containerDiscrepancyInfoList =
         (List<ContainerDiscrepancyInfo>) response.get(
             "containerDiscrepancyInfo");
+
+    // Check the prevKey is set correct in the response
+    long responsePrevKey = (long) response.get("prevKey");
+    assertEquals(containerDiscrepancyInfoList.get(
+            containerDiscrepancyInfoList.size() - 1).getContainerID(),
+        responsePrevKey);
+
     ContainerDiscrepancyInfo containerDiscrepancyInfo =
         containerDiscrepancyInfoList.get(0);
     assertEquals(1, containerDiscrepancyInfo.getContainerID());
@@ -1372,6 +1378,13 @@ public class TestContainerEndpoint {
     List<ContainerDiscrepancyInfo> containerDiscrepancyInfoList =
         (List<ContainerDiscrepancyInfo>) response.get(
             "containerDiscrepancyInfo");
+
+    // Check the prevKey is set correct in the response
+    long responsePrevKey = (long) response.get("prevKey");
+    assertEquals(containerDiscrepancyInfoList.get(
+            containerDiscrepancyInfoList.size() - 1).getContainerID(),
+        responsePrevKey);
+
     ContainerDiscrepancyInfo containerDiscrepancyInfo =
         containerDiscrepancyInfoList.get(0);
     assertEquals(2, containerDiscrepancyInfo.getContainerID());
@@ -1407,6 +1420,12 @@ public class TestContainerEndpoint {
     List<ContainerDiscrepancyInfo> containerDiscrepancyInfoList =
         (List<ContainerDiscrepancyInfo>) response.get(
             "containerDiscrepancyInfo");
+
+    // Check the prevKey is set correct in the response
+    long responsePrevKey = (long) response.get("prevKey");
+    assertEquals(containerDiscrepancyInfoList.get(
+            containerDiscrepancyInfoList.size() - 1).getContainerID(),
+        responsePrevKey);
 
     // Check the first two ContainerDiscrepancyInfo objects in the response
     assertEquals(3, containerDiscrepancyInfoList.size());


### PR DESCRIPTION
## What changes were proposed in this pull request?

In the modified code, the pagination and filtering logic is applied to : `getContainerMisMatchInsights()`

**For the notSCMContainers list (OM containers not in SCM):**
- If prevKey is greater than 0, the method finds the index of the next container after prevKey and retrieves the sublist from that index up to the specified limit.
- If prevKey is negative, we return `NOT_ACCEPTABLE`

**For the nonOMContainers list (SCM containers not in OM):**
- Similar to the previous section, the pagination logic is applied to retrieve the sublist of containers based on the prevKey and limit.

**Filter Parameter:** 
- The `missingIn` filter parameter is used in the `getContainerMisMatchInsights` method to specify whether the returned container discrepancies should be based on containers missing in the **Ozone Manager (OM)** or the **Storage Container Manager (SCM)**.

**Response Type:**
- The return type of the method has been changed to Response containing a map. The map includes two entries: `prevKey` and `missingContainerList`.

**Final Response** 
```
{
  "lastKey": <containerID>,
  "containerDiscrepancyInfo": [
    {
      "containerId": <containerID>,
      "numberOfKeys": <numberOfKeys>,
      "pipelines": [
        {
          // Pipeline details
        },
        ...
      ],
      "existsAt": "<existsAt>"
    },
    ...
  ]
}

```

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-8701
## How was this patch tested?
Manual Testing and Unit Testing