### PR TITLE
HDDS-8820. Compatibility test fails due to Jacoco not being available

### DIFF
--- a/hadoop-ozone/dist/src/main/compose/xcompat/clients.yaml
+++ b/hadoop-ozone/dist/src/main/compose/xcompat/clients.yaml
@@ -23,8 +23,6 @@ services:
       - docker-config
     volumes:
       - ../..:/opt/ozone
-    environment:
-      HADOOP_OPTS:
     command: ["sleep","1000000"]
   old_client_1_1_0:
     image: apache/ozone:1.1.0
@@ -32,8 +30,6 @@ services:
       - docker-config
     volumes:
       - ../..:/opt/ozone
-    environment:
-      HADOOP_OPTS:
     command: ["sleep","1000000"]
   old_client_1_2_1:
     image: apache/ozone:1.2.1
@@ -41,8 +37,6 @@ services:
       - docker-config
     volumes:
       - ../..:/opt/ozone
-    environment:
-      HADOOP_OPTS:
     command: ["sleep","1000000"]
   old_client_1_3_0:
     image: apache/ozone:1.3.0
@@ -50,8 +44,6 @@ services:
       - docker-config
     volumes:
       - ../..:/opt/ozone
-    environment:
-      OZONE_OPTS:
     command: ["sleep","1000000"]
   new_client:
     image: ${OZONE_RUNNER_IMAGE}:${OZONE_RUNNER_VERSION}


### PR DESCRIPTION
## What changes were proposed in this pull request?

Coverage is collected for commits in `apache/ozone` repo, but not for PRs, nor in forks:

https://github.com/apache/ozone/blob/b4ea2fb100e7edd7246dc2645dc8723746a68907/.github/workflows/ci.yml#L21

by Java agent defined in `OZONE_OPTS`:

https://github.com/apache/ozone/blob/b4ea2fb100e7edd7246dc2645dc8723746a68907/hadoop-ozone/dist/src/main/compose/test-all.sh#L32-L35

The problem is that `share/coverage/jacoco-agent.jar` is only available for tests running binaries built from source, but is not part of the official release, thus also not present in the `apache/ozone` images used for testing cross-compatibility.  HDDS-8768 added test for 1.3.0, which is now failing:

```
xcompat-cluster-1.4.0-client-1.3.0-write :: Write Compatibility               
==============================================================================
Key Can Be Written                                                    | FAIL |
1 != 0
------------------------------------------------------------------------------
Dir Can Be Created                                                    | FAIL |
1 != 0
------------------------------------------------------------------------------
File Can Be Put                                                       | FAIL |
1 != 0
------------------------------------------------------------------------------
xcompat-cluster-1.4.0-client-1.3.0-write :: Write Compatibility       | FAIL |
3 tests, 0 passed, 3 failed
```

due to:

```
Error opening zip file or JAR manifest missing : share/coverage/jacoco-agent.jar
Error occurred during initialization of VM
agent library failed to init: instrument
```

This PR removes the docker-compose definition that propagates `OZONE_OPTS` to 1.3.0 client.  The problem does not affect 1.2.1 and earlier clients, because only `HADOOP_OPTS` is passed to them.  For consistency, `HADOOP_OPTS` is also removed for these, though.

In the future we may improve this by using the jar mounted from "current" version.

https://issues.apache.org/jira/browse/HDDS-8820

## How was this patch tested?

```
mvn -Pcoverage -DskipTests clean package
export OZONE_TEST_SELECTOR=xcompat
export OZONE_WITH_COVERAGE=true
./hadoop-ozone/dev-support/checks/acceptance.sh
```

```
xcompat-cluster-1.4.0-client-1.3.0-write :: Write Compatibility               
==============================================================================
Key Can Be Written                                                    | PASS |
------------------------------------------------------------------------------
Dir Can Be Created                                                    | PASS |
------------------------------------------------------------------------------
File Can Be Put                                                       | PASS |
------------------------------------------------------------------------------
xcompat-cluster-1.4.0-client-1.3.0-write :: Write Compatibility       | PASS |
3 tests, 3 passed, 0 failed
```