### PR TITLE
HDDS-8828. Adapt TestBlockTokens to build with Hadoop 3.3

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/TestBlockTokens.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/TestBlockTokens.java
@@ -240,7 +240,10 @@ public final class TestBlockTokens {
         Token<OzoneBlockTokenIdentifier> token = l.getToken();
         OzoneBlockTokenIdentifier tokenId = token.decodeIdentifier();
         tokenId.setSecretKeyId(UUID.randomUUID());
-        token.setID(tokenId.getBytes());
+        Token<OzoneBlockTokenIdentifier> override = new Token<>(
+            tokenId.getBytes(), token.getPassword(),
+            token.getKind(), token.getService());
+        l.setToken(override);
       }
     }
 
@@ -259,7 +262,11 @@ public final class TestBlockTokens {
     for (OmKeyLocationInfoGroup v : keyInfo.getKeyLocationVersions()) {
       for (OmKeyLocationInfo l : v.getLocationList()) {
         Token<OzoneBlockTokenIdentifier> token = l.getToken();
-        token.setPassword(RandomUtils.nextBytes(100));
+        byte[] randomPassword = RandomUtils.nextBytes(100);
+        Token<OzoneBlockTokenIdentifier> override = new Token<>(
+            token.getIdentifier(), randomPassword,
+            token.getKind(), token.getService());
+        l.setToken(override);
       }
     }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

TestBlockTokens uses methods that are removed in Hadoop 3.3. This prevents ozone to build with later versions of Hadoop. 

```
INFO    : [ERROR] /grid/0/jenkins/workspace/workspaceSOURCES/ozone/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/TestBlockTokens.java:[243,14] cannot find symbol
INFO    :   symbol:   method setID(byte[])
INFO    :   location: variable token of type org.apache.hadoop.security.token.Token<org.apache.hadoop.hdds.security.token.OzoneBlockTokenIdentifier>
INFO    : [ERROR] /grid/0/jenkins/workspace/workspace/SOURCES/ozone/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/TestBlockTokens.java:[262,14] cannot find symbol
INFO    :   symbol:   method setPassword(byte[])
INFO    :   location: variable token of type org.apache.hadoop.security.token.Token<org.apache.hadoop.hdds.security.token.OzoneBlockTokenIdentifier>
```
 
## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-8828

## How was this patch tested?

Standard CI. 