### PR TITLE
HDDS-8821. Implement a task in Recon to gather insights from SCM tables at regular intervals.

### DIFF
--- a/hadoop-hdds/docs/content/concept/Recon.md
+++ b/hadoop-hdds/docs/content/concept/Recon.md
@@ -140,6 +140,8 @@ to the Prometheus endpoint like `ozone.recon.prometheus.http.endpoint=http://pro
      * UnhealthyContainers table
        * Keeps track of all the Unhealthy Containers (MISSING, UNDER_REPLICATED,
        OVER_REPLICATED, MIS_REPLICATED) in the cluster at any given time
+     * ScmTableCount table
+       * Keeps track of the number of records in each SCM table
  
 
 ## Notable configurations
@@ -154,6 +156,7 @@ ozone.recon.om.db.dir | none | Directory where the Recon Server stores its OM sn
 ozone.recon.om.snapshot<br>.task.interval.delay | 10m | Interval in MINUTES by Recon to request OM DB Snapshot / delta updates.
 ozone.recon.task<br>.missingcontainer.interval | 300s | Time interval of the periodic check for Unhealthy Containers in the cluster.
 ozone.recon.task<br>.safemode.wait.threshold | 300s | Max time for Recon to wait before it exit out of safe or warmup mode.
+ozone.recon.task<br>.scmtablecounttask.interval | 60s | Time interval of the periodic check for SCM table record counts.
 ozone.recon.sql.db.jooq.dialect | DERBY | Please refer to [SQL Dialect](https://www.jooq.org/javadoc/latest/org.jooq/org/jooq/SQLDialect.html) to specify a different dialect.
 ozone.recon.sql.db.jdbc.url | jdbc:derby:${ozone.recon.db.dir}<br>/ozone_recon_derby.db | Recon SQL database jdbc url.
 ozone.recon.sql.db.username | none | Recon SQL database username.

--- a/hadoop-ozone/recon-codegen/src/main/java/org/hadoop/ozone/recon/schema/UtilizationSchemaDefinition.java
+++ b/hadoop-ozone/recon-codegen/src/main/java/org/hadoop/ozone/recon/schema/UtilizationSchemaDefinition.java
@@ -53,7 +53,7 @@ public class UtilizationSchemaDefinition implements ReconSchemaDefinition {
       "FILE_COUNT_BY_SIZE";
   public static final String CONTAINER_COUNT_BY_SIZE_TABLE_NAME =
       "CONTAINER_COUNT_BY_SIZE";
-  public static final String SCM_TABLE_COUNT =
+  public static final String SCM_TABLE_COUNT_TABLE_NAME =
       "SCM_TABLE_COUNT";
 
   @Inject
@@ -75,13 +75,13 @@ public class UtilizationSchemaDefinition implements ReconSchemaDefinition {
     if (!TABLE_EXISTS_CHECK.test(conn, CONTAINER_COUNT_BY_SIZE_TABLE_NAME)) {
       createContainerSizeCountTable();
     }
-    if (!TABLE_EXISTS_CHECK.test(conn, SCM_TABLE_COUNT)) {
+    if (!TABLE_EXISTS_CHECK.test(conn, SCM_TABLE_COUNT_TABLE_NAME)) {
       createScmTableCountTable();
     }
   }
 
   private void createScmTableCountTable() {
-    dslContext.createTableIfNotExists(SCM_TABLE_COUNT)
+    dslContext.createTableIfNotExists(SCM_TABLE_COUNT_TABLE_NAME)
         .column("table_name", SQLDataType.VARCHAR(1024).nullable(false))
         .column("count", SQLDataType.BIGINT)
         .constraint(DSL.constraint("pk_table_name")

--- a/hadoop-ozone/recon-codegen/src/main/java/org/hadoop/ozone/recon/schema/UtilizationSchemaDefinition.java
+++ b/hadoop-ozone/recon-codegen/src/main/java/org/hadoop/ozone/recon/schema/UtilizationSchemaDefinition.java
@@ -53,6 +53,8 @@ public class UtilizationSchemaDefinition implements ReconSchemaDefinition {
       "FILE_COUNT_BY_SIZE";
   public static final String CONTAINER_COUNT_BY_SIZE_TABLE_NAME =
       "CONTAINER_COUNT_BY_SIZE";
+  public static final String SCM_TABLE_COUNT =
+      "SCM_TABLE_COUNT";
 
   @Inject
   UtilizationSchemaDefinition(DataSource dataSource) {
@@ -73,6 +75,18 @@ public class UtilizationSchemaDefinition implements ReconSchemaDefinition {
     if (!TABLE_EXISTS_CHECK.test(conn, CONTAINER_COUNT_BY_SIZE_TABLE_NAME)) {
       createContainerSizeCountTable();
     }
+    if (!TABLE_EXISTS_CHECK.test(conn, SCM_TABLE_COUNT)) {
+      createScmTableCountTable();
+    }
+  }
+
+  private void createScmTableCountTable() {
+    dslContext.createTableIfNotExists(SCM_TABLE_COUNT)
+        .column("table_name", SQLDataType.VARCHAR(1024).nullable(false))
+        .column("count", SQLDataType.BIGINT)
+        .constraint(DSL.constraint("pk_table_name")
+            .primaryKey("table_name"))
+        .execute();
   }
 
   private void createClusterGrowthTable() {

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/ReconControllerModule.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/ReconControllerModule.java
@@ -64,6 +64,7 @@ import org.hadoop.ozone.recon.schema.tables.daos.FileCountBySizeDao;
 import org.hadoop.ozone.recon.schema.tables.daos.GlobalStatsDao;
 import org.hadoop.ozone.recon.schema.tables.daos.ReconTaskStatusDao;
 import org.hadoop.ozone.recon.schema.tables.daos.UnhealthyContainersDao;
+import org.hadoop.ozone.recon.schema.tables.daos.ScmTableCountDao;
 import org.jooq.Configuration;
 import org.jooq.DAO;
 import org.slf4j.Logger;
@@ -144,7 +145,8 @@ public class ReconControllerModule extends AbstractModule {
             UnhealthyContainersDao.class,
             GlobalStatsDao.class,
             ClusterGrowthDailyDao.class,
-            ContainerCountBySizeDao.class
+            ContainerCountBySizeDao.class,
+            ScmTableCountDao.class
         );
 
     @Override

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/scm/ReconStorageContainerManagerFacade.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/scm/ReconStorageContainerManagerFacade.java
@@ -113,10 +113,12 @@ import org.apache.hadoop.hdds.scm.server.SCMDatanodeHeartbeatDispatcher.Containe
 import org.apache.hadoop.hdds.scm.server.SCMDatanodeHeartbeatDispatcher.ContainerReportFromDatanode;
 import org.apache.hadoop.hdds.scm.server.SCMDatanodeHeartbeatDispatcher.IncrementalContainerReportFromDatanode;
 
+import org.apache.hadoop.ozone.recon.tasks.ScmTableCountTask;
 import org.apache.ratis.util.ExitUtils;
 import org.hadoop.ozone.recon.schema.UtilizationSchemaDefinition;
 import org.hadoop.ozone.recon.schema.tables.daos.ContainerCountBySizeDao;
 import org.hadoop.ozone.recon.schema.tables.daos.ReconTaskStatusDao;
+import org.hadoop.ozone.recon.schema.tables.daos.ScmTableCountDao;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -156,6 +158,8 @@ public class ReconStorageContainerManagerFacade
   private ReconSafeModeMgrTask reconSafeModeMgrTask;
   private ContainerSizeCountTask containerSizeCountTask;
   private ContainerCountBySizeDao containerCountBySizeDao;
+  private ScmTableCountTask scmTableCountTask;
+  private ScmTableCountDao scmTableCountDao;
   private ScheduledExecutorService scheduler;
 
   private AtomicBoolean isSyncDataFromSCMRunning;
@@ -247,6 +251,13 @@ public class ReconStorageContainerManagerFacade
         reconTaskStatusDao,
         reconTaskConfig,
         containerCountBySizeDao,
+        utilizationSchemaDefinition);
+
+    this.scmTableCountTask = new ScmTableCountTask(
+        this,
+        reconTaskStatusDao,
+        reconTaskConfig,
+        scmTableCountDao,
         utilizationSchemaDefinition);
 
     StaleNodeHandler staleNodeHandler =

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/scm/ReconStorageContainerManagerFacade.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/scm/ReconStorageContainerManagerFacade.java
@@ -171,6 +171,7 @@ public class ReconStorageContainerManagerFacade
       StorageContainerServiceProvider scmServiceProvider,
       ReconTaskStatusDao reconTaskStatusDao,
       ContainerCountBySizeDao containerCountBySizeDao,
+      ScmTableCountDao scmTableCountDao,
       UtilizationSchemaDefinition utilizationSchemaDefinition,
       ContainerHealthSchemaManager containerHealthSchemaManager,
       ReconContainerMetadataManager reconContainerMetadataManager,
@@ -222,6 +223,7 @@ public class ReconStorageContainerManagerFacade
     this.scmServiceProvider = scmServiceProvider;
     this.isSyncDataFromSCMRunning = new AtomicBoolean();
     this.containerCountBySizeDao = containerCountBySizeDao;
+    this.scmTableCountDao = scmTableCountDao;
     NodeReportHandler nodeReportHandler =
         new NodeReportHandler(nodeManager);
 
@@ -334,6 +336,7 @@ public class ReconStorageContainerManagerFacade
     reconScmTasks.add(pipelineSyncTask);
     reconScmTasks.add(containerHealthTask);
     reconScmTasks.add(containerSizeCountTask);
+    reconScmTasks.add(scmTableCountTask);
     reconSafeModeMgrTask = new ReconSafeModeMgrTask(
         containerManager, nodeManager, safeModeManager,
         reconTaskConfig, ozoneConfiguration);

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/tasks/ReconTaskConfig.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/tasks/ReconTaskConfig.java
@@ -102,4 +102,22 @@ public class ReconTaskConfig {
     this.containerSizeCountTaskInterval = interval.toMillis();
   }
 
+  @Config(key = "scmtablecounttask.interval",
+      type = ConfigType.TIME,
+      defaultValue = "60s",
+      tags = { ConfigTag.RECON, ConfigTag.OZONE },
+      description = "The time interval to wait between each runs of " +
+          "SCM table count task."
+  )
+  private long scmTableCountTaskInterval =
+      Duration.ofMinutes(1).toMillis();
+
+  public Duration getScmTableCountTaskInterval() {
+    return Duration.ofMillis(scmTableCountTaskInterval);
+  }
+
+  public void setScmTableCountTaskInterval(Duration interval) {
+    this.scmTableCountTaskInterval = interval.toMillis();
+  }
+
 }

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/tasks/ReconTaskConfig.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/tasks/ReconTaskConfig.java
@@ -116,8 +116,4 @@ public class ReconTaskConfig {
     return Duration.ofMillis(scmTableCountTaskInterval);
   }
 
-  public void setScmTableCountTaskInterval(Duration interval) {
-    this.scmTableCountTaskInterval = interval.toMillis();
-  }
-
 }

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/tasks/ScmTableCountTask.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/tasks/ScmTableCountTask.java
@@ -194,7 +194,7 @@ public class ScmTableCountTask extends ReconScmTask {
    * @return the list of SCM tables to be processed by the task.
    * @throws IOException if an I/O error occurs.
    */
-  public List<String> getTaskTables() throws IOException {
+  public List<String> getTaskTables() {
     List<String> tables = new ArrayList<>();
 
     // Add the table names to the list

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/tasks/ScmTableCountTask.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/tasks/ScmTableCountTask.java
@@ -90,29 +90,25 @@ public class ScmTableCountTask extends ReconScmTask {
   }
 
   private void runTableCountProcess() {
-    try {
-      long startTime, endTime, duration, durationMilliseconds;
       try {
+        long startTime, endTime, duration, durationMilliseconds;
+
         int execute = dslContext.truncate(SCM_TABLE_COUNT_TABLE_NAME).execute();
         LOG.info("Deleted {} records from {}", execute,
             SCM_TABLE_COUNT_TABLE_NAME);
+
+        startTime = System.nanoTime();
+        processTableCount();
+        endTime = System.nanoTime();
+        duration = endTime - startTime;
+        durationMilliseconds = duration / NANOSECONDS_IN_MILLISECOND;
+        LOG.info(
+            "Elapsed Time in milliseconds for processTableCount() execution: {}",
+            durationMilliseconds);
       } catch (Exception e) {
-        LOG.error("An error occurred while truncating the table {}: {}",
-            SCM_TABLE_COUNT_TABLE_NAME, e.getMessage(), e);
-        return;
+        LOG.error("An error occurred while performing table count: {}", e);
       }
-      startTime = System.nanoTime();
-      processTableCount();
-      endTime = System.nanoTime();
-      duration = endTime - startTime;
-      durationMilliseconds = duration / NANOSECONDS_IN_MILLISECOND;
-      LOG.info(
-          "Elapsed Time in milliseconds for processTableCount() execution: {}",
-          durationMilliseconds);
-    } catch (Exception e) {
-      LOG.error("Error while performing table count: {}", e);
     }
-  }
 
   /**
    * Processes the table count by iterating over SCM tables and retrieving the

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/tasks/ScmTableCountTask.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/tasks/ScmTableCountTask.java
@@ -1,0 +1,207 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.ozone.recon.tasks;
+
+import org.apache.hadoop.hdds.utils.db.DBStore;
+import org.apache.hadoop.hdds.utils.db.Table;
+import org.apache.hadoop.hdds.utils.db.TableIterator;
+import org.apache.hadoop.ozone.recon.scm.ReconScmTask;
+import org.apache.hadoop.ozone.recon.scm.ReconStorageContainerManagerFacade;
+import org.hadoop.ozone.recon.schema.UtilizationSchemaDefinition;
+import org.hadoop.ozone.recon.schema.tables.daos.ReconTaskStatusDao;
+import org.hadoop.ozone.recon.schema.tables.daos.ScmTableCountDao;
+import org.hadoop.ozone.recon.schema.tables.pojos.ScmTableCount;
+import org.jooq.DSLContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+
+import java.util.HashMap;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Iterator;
+import java.util.Collection;
+import java.util.Map;
+import java.util.concurrent.locks.ReadWriteLock;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
+
+import static org.hadoop.ozone.recon.schema.UtilizationSchemaDefinition.SCM_TABLE_COUNT;
+
+
+/**
+ * Any background task that tracks SCM's table counts.
+ */
+public class ScmTableCountTask extends ReconScmTask {
+
+  private static final Logger LOG =
+      LoggerFactory.getLogger(ScmTableCountTask.class);
+
+  private final DBStore scmDBStore;
+  private final ScmTableCountDao scmTableCountDao;
+  private final DSLContext dslContext;
+  private final long interval;
+  private ReadWriteLock lock = new ReentrantReadWriteLock(true);
+
+  public ScmTableCountTask(ReconStorageContainerManagerFacade reconSCM,
+                           ReconTaskStatusDao reconTaskStatusDao,
+                           ReconTaskConfig reconTaskConfig,
+                           ScmTableCountDao scmTableCountDao,
+                           UtilizationSchemaDefinition schemaDefinition) {
+    super(reconTaskStatusDao);
+    this.scmDBStore = reconSCM.getScmDBStore();
+    this.scmTableCountDao = scmTableCountDao;
+    this.dslContext = schemaDefinition.getDSLContext();
+    this.interval = reconTaskConfig.getScmTableCountTaskInterval().toMillis();
+  }
+
+  @Override
+  protected void run() {
+    try {
+      while (canRun()) {
+        wait(interval);
+        long startTime, endTime, duration, durationMilliseconds;
+          try {
+            int execute =
+                dslContext.truncate(SCM_TABLE_COUNT).execute();
+            LOG.info("Deleted {} records from {}", execute,
+                SCM_TABLE_COUNT);
+          } catch (Exception e) {
+            LOG.error("An error occurred while truncating the table {}: {}",
+                SCM_TABLE_COUNT, e.getMessage(), e);
+            return;
+          }
+        startTime = System.nanoTime();
+        processTableCount();
+        endTime = System.nanoTime();
+        duration = endTime - startTime;
+        durationMilliseconds = duration / 1_000_000;
+        LOG.info("Elapsed Time in milliseconds for processTableCount() " +
+                "execution: {}", durationMilliseconds);
+      }
+    } catch (Throwable t) {
+      LOG.error("Error while running ScmTableCountTask: {}", t);
+      if (t instanceof InterruptedException) {
+        Thread.currentThread().interrupt();
+      }
+    }
+  }
+
+  /**
+   * Processes the table count by iterating over SCM tables and retrieving the
+   * counts of objects in each table. The counts are then stored in the Recon
+   * database.
+   *
+   * @throws IOException if an I/O error occurs during table count processing.
+   */
+  private void processTableCount() throws IOException {
+    // Acquire write lock
+    lock.writeLock().lock();
+    try {
+      // Initialize the object count map
+      HashMap<String, Long> objectCountMap = initializeCountMap();
+
+      // Iterate over SCM tables
+      for (String tableName : getTaskTables()) {
+        Table table = scmDBStore.getTable(tableName);
+
+        try (TableIterator keyIter = table.iterator()) {
+          // Retrieve the count of objects in the table
+          long count = getCount(keyIter);
+          objectCountMap.put(getRowKeyFromTable(tableName), count);
+        } catch (IOException ioEx) {
+          LOG.error("Unable to populate SCM Table Count in Recon DB.", ioEx);
+        }
+      }
+
+      // Write the counts to the Recon database
+      writeCountsToDB(objectCountMap);
+
+      objectCountMap.clear();
+      LOG.info("Completed writing SCM table counts to DB.");
+    } finally {
+      // Release write lock
+      lock.writeLock().unlock();
+    }
+  }
+
+
+  /**
+   * Writes the object counts from the object count map to the Recon database.
+   *
+   * @param objectCountMap a map containing table names as keys and their object
+   *                       counts as values.
+   */
+  private void writeCountsToDB(Map<String, Long> objectCountMap) {
+    List<ScmTableCount> insertToDb = new ArrayList<>();
+
+    // Iterate over the object count map
+    for (Map.Entry<String, Long> entry : objectCountMap.entrySet()) {
+      // Create a new ScmTableCount object
+      ScmTableCount scmTableCountRecord = new ScmTableCount();
+      scmTableCountRecord.setTableName(entry.getKey());
+      scmTableCountRecord.setCount(entry.getValue());
+
+      // Add the ScmTableCount object to the list
+      insertToDb.add(scmTableCountRecord);
+    }
+    // Insert the list of ScmTableCount objects into the Recon database
+    scmTableCountDao.insert(insertToDb);
+  }
+
+  /**
+   * Returns the count of items in the iterator.
+   *
+   * @param iterator the iterator to count the items from.
+   * @return the count of items in the iterator.
+   */
+  private long getCount(Iterator iterator) {
+    long count = 0L;
+    while (iterator.hasNext()) {
+      count++;
+      iterator.next();
+    }
+    return count;
+  }
+
+  private HashMap<String, Long> initializeCountMap() throws IOException {
+    Collection<String> tables = getTaskTables();
+    HashMap<String, Long> objectCountMap = new HashMap<>(tables.size());
+    for (String tableName: tables) {
+      String key = getRowKeyFromTable(tableName);
+      objectCountMap.put(key, 0L);
+    }
+    return objectCountMap;
+  }
+
+  public Collection<String> getTaskTables() throws IOException {
+    return new ArrayList<>(scmDBStore.getTableNames().values());
+  }
+
+  /**
+   * Each row in the table would correspond to tableName+Count
+   *  eg:- DeletedBlocksCount
+   * @param tableName the name of the table.
+   * @return the generated row key for the table count.
+   */
+  public static String getRowKeyFromTable(String tableName) {
+    return tableName + "Count";
+  }
+
+}

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/tasks/ScmTableCountTask.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/tasks/ScmTableCountTask.java
@@ -115,7 +115,7 @@ public class ScmTableCountTask extends ReconScmTask {
    *
    * @throws IOException if an I/O error occurs during table count processing.
    */
-  public void processTableCount() throws IOException {
+  public void processTableCount() {
     try {
       // Initialize the object count map
       Map<String, Long> objectCountMap = initializeCountMap();

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/tasks/ScmTableCountTask.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/tasks/ScmTableCountTask.java
@@ -81,9 +81,9 @@ public class ScmTableCountTask extends ReconScmTask {
         wait(interval);
         runTableCountProcess();
       }
-    } catch (Throwable t) {
-      LOG.error("Error while running ScmTableCountTask: {}", t);
-      if (t instanceof InterruptedException) {
+    } catch (Exception e) {
+      LOG.error("Error while running ScmTableCountTask: {}", e);
+      if (e instanceof InterruptedException) {
         Thread.currentThread().interrupt();
       }
     }
@@ -179,15 +179,14 @@ public class ScmTableCountTask extends ReconScmTask {
   }
 
   private Map<String, Long> initializeCountMap() throws IOException {
-    Collection<String> tables = getTaskTables();
+    List<String> tables = getTaskTables();
     Map<String, Long> objectCountMap = new HashMap<>(tables.size());
-    for (String tableName: tables) {
+    for (String tableName : tables) {
       String key = getRowKeyFromTable(tableName);
       objectCountMap.put(key, 0L);
     }
     return objectCountMap;
   }
-
 
   /**
    * Returns the list of SCM tables to be processed by the task.
@@ -195,10 +194,10 @@ public class ScmTableCountTask extends ReconScmTask {
    * @return the list of SCM tables to be processed by the task.
    * @throws IOException if an I/O error occurs.
    */
-  public Collection<String> getTaskTables() throws IOException {
-    Collection<String> tables = new ArrayList<>();
+  public List<String> getTaskTables() throws IOException {
+    List<String> tables = new ArrayList<>();
 
-    // Add the table names to the array list
+    // Add the table names to the list
     tables.add(DELETED_BLOCKS.getName());
 
     return tables;

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/tasks/ScmTableCountTask.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/tasks/ScmTableCountTask.java
@@ -43,7 +43,6 @@ import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 
 import static org.apache.hadoop.hdds.scm.metadata.SCMDBDefinition.DELETED_BLOCKS;
-import static org.apache.hadoop.ozone.recon.scm.ReconSCMDBDefinition.NODES;
 import static org.hadoop.ozone.recon.schema.UtilizationSchemaDefinition.SCM_TABLE_COUNT_TABLE_NAME;
 
 
@@ -79,23 +78,23 @@ public class ScmTableCountTask extends ReconScmTask {
       while (canRun()) {
         wait(interval);
         long startTime, endTime, duration, durationMilliseconds;
-          try {
-            int execute =
-                dslContext.truncate(SCM_TABLE_COUNT_TABLE_NAME).execute();
-            LOG.info("Deleted {} records from {}", execute,
-                SCM_TABLE_COUNT_TABLE_NAME);
-          } catch (Exception e) {
-            LOG.error("An error occurred while truncating the table {}: {}",
-                SCM_TABLE_COUNT_TABLE_NAME, e.getMessage(), e);
-            return;
-          }
+        try {
+          int execute =
+              dslContext.truncate(SCM_TABLE_COUNT_TABLE_NAME).execute();
+          LOG.info("Deleted {} records from {}", execute,
+              SCM_TABLE_COUNT_TABLE_NAME);
+        } catch (Exception e) {
+          LOG.error("An error occurred while truncating the table {}: {}",
+              SCM_TABLE_COUNT_TABLE_NAME, e.getMessage(), e);
+          return;
+        }
         startTime = System.nanoTime();
         processTableCount();
         endTime = System.nanoTime();
         duration = endTime - startTime;
         durationMilliseconds = duration / 1_000_000;
         LOG.info("Elapsed Time in milliseconds for processTableCount() " +
-                "execution: {}", durationMilliseconds);
+            "execution: {}", durationMilliseconds);
       }
     } catch (Throwable t) {
       LOG.error("Error while running ScmTableCountTask: {}", t);
@@ -208,7 +207,7 @@ public class ScmTableCountTask extends ReconScmTask {
   }
 
   /**
-   * Each row in the table would correspond to tableName+Count
+   * Each row in the table would correspond to tableName+Count.
    *  eg:- DeletedBlocksCount
    * @param tableName the name of the table.
    * @return the generated row key for the table count.

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/tasks/ScmTableCountTask.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/tasks/ScmTableCountTask.java
@@ -81,9 +81,9 @@ public class ScmTableCountTask extends ReconScmTask {
         wait(interval);
         runTableCountProcess();
       }
-    } catch (Exception e) {
-      LOG.error("Error while running ScmTableCountTask: {}", e);
-      if (e instanceof InterruptedException) {
+    } catch (Throwable t) {
+      LOG.error("Error while running ScmTableCountTask: {}", t);
+      if (t instanceof InterruptedException) {
         Thread.currentThread().interrupt();
       }
     }
@@ -109,8 +109,8 @@ public class ScmTableCountTask extends ReconScmTask {
       LOG.info(
           "Elapsed Time in milliseconds for processTableCount() execution: {}",
           durationMilliseconds);
-    } catch (Throwable t) {
-      LOG.error("Error while performing table count: {}", t);
+    } catch (Exception e) {
+      LOG.error("Error while performing table count: {}", e);
     }
   }
 

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/tasks/ScmTableCountTask.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/tasks/ScmTableCountTask.java
@@ -42,7 +42,7 @@ import java.util.Map;
 import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 
-import static org.hadoop.ozone.recon.schema.UtilizationSchemaDefinition.SCM_TABLE_COUNT;
+import static org.hadoop.ozone.recon.schema.UtilizationSchemaDefinition.SCM_TABLE_COUNT_TABLE_NAME;
 
 
 /**
@@ -79,12 +79,12 @@ public class ScmTableCountTask extends ReconScmTask {
         long startTime, endTime, duration, durationMilliseconds;
           try {
             int execute =
-                dslContext.truncate(SCM_TABLE_COUNT).execute();
+                dslContext.truncate(SCM_TABLE_COUNT_TABLE_NAME).execute();
             LOG.info("Deleted {} records from {}", execute,
-                SCM_TABLE_COUNT);
+                SCM_TABLE_COUNT_TABLE_NAME);
           } catch (Exception e) {
             LOG.error("An error occurred while truncating the table {}: {}",
-                SCM_TABLE_COUNT, e.getMessage(), e);
+                SCM_TABLE_COUNT_TABLE_NAME, e.getMessage(), e);
             return;
           }
         startTime = System.nanoTime();

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/tasks/TestScmTableCountTask.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/tasks/TestScmTableCountTask.java
@@ -164,7 +164,7 @@ public class TestScmTableCountTask extends AbstractReconSqlDBTest {
 
 
   private long getCountForTable(String tableName) {
-    String key = TableCountTask.getRowKeyFromTable(tableName);
+    String key = ScmTableCountTask.getRowKeyFromTable(tableName);
     return scmTableCountDao.findById(key).getCount();
   }
 

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/tasks/TestScmTableCountTask.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/tasks/TestScmTableCountTask.java
@@ -49,6 +49,9 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThrows;
 import static org.mockito.Mockito.mock;
 
+/**
+ * Test class to verify the ScmTableCountTask.
+ */
 public class TestScmTableCountTask extends AbstractReconSqlDBTest {
 
   private DBStore scmDBStore;
@@ -147,7 +150,8 @@ public class TestScmTableCountTask extends AbstractReconSqlDBTest {
 
     for (long i = 1; i <= totalRecords; i++) {
       StorageContainerDatanodeProtocolProtos.DeletedBlocksTransaction dtx =
-          StorageContainerDatanodeProtocolProtos.DeletedBlocksTransaction.newBuilder()
+          StorageContainerDatanodeProtocolProtos.DeletedBlocksTransaction
+              .newBuilder()
               .setTxID(i)
               .setContainerID(100L)
               .addAllLocalID(localIdList)

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/tasks/TestScmTableCountTask.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/tasks/TestScmTableCountTask.java
@@ -1,0 +1,168 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package org.apache.hadoop.ozone.recon.tasks;
+
+
+import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos;
+import org.apache.hadoop.hdds.scm.server.OzoneStorageContainerManager;
+import org.apache.hadoop.hdds.utils.db.DBStore;
+import org.apache.hadoop.ozone.recon.ReconTestInjector;
+import org.apache.hadoop.ozone.recon.persistence.AbstractReconSqlDBTest;
+import org.apache.hadoop.ozone.recon.recovery.ReconOMMetadataManager;
+import org.apache.hadoop.ozone.recon.scm.ReconStorageContainerManagerFacade;
+import org.apache.hadoop.ozone.recon.spi.StorageContainerServiceProvider;
+import org.apache.hadoop.ozone.recon.spi.impl.OzoneManagerServiceProviderImpl;
+import org.apache.hadoop.ozone.recon.spi.impl.StorageContainerServiceProviderImpl;
+import org.hadoop.ozone.recon.schema.UtilizationSchemaDefinition;
+import org.hadoop.ozone.recon.schema.tables.daos.ReconTaskStatusDao;
+import org.hadoop.ozone.recon.schema.tables.daos.ScmTableCountDao;
+import org.jooq.DSLContext;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.BeforeEach;
+
+import java.io.IOException;
+import java.time.Duration;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.apache.hadoop.hdds.scm.metadata.SCMDBDefinition.DELETED_BLOCKS;
+import static org.apache.hadoop.ozone.recon.OMMetadataManagerTestUtils.getTestReconOmMetadataManager;
+import static org.apache.hadoop.ozone.recon.OMMetadataManagerTestUtils.initializeNewOmMetadataManager;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
+import static org.mockito.Mockito.mock;
+
+public class TestScmTableCountTask extends AbstractReconSqlDBTest {
+
+  private DBStore scmDBStore;
+  private ScmTableCountDao scmTableCountDao;
+  private ScmTableCountTask scmTableCountTask;
+  private ReconTaskStatusDao reconTaskStatusDao;
+  private ReconTaskConfig reconTaskConfig;
+  private DSLContext dslContext;
+  private boolean isSetupDone = false;
+  private ReconOMMetadataManager reconOMMetadataManager;
+  private ReconStorageContainerManagerFacade reconStorageContainerManager;
+  private UtilizationSchemaDefinition utilizationSchemaDefinition;
+
+  private void initializeInjector() throws IOException {
+    this.reconOMMetadataManager = getTestReconOmMetadataManager(
+        initializeNewOmMetadataManager(temporaryFolder.newFolder()),
+        temporaryFolder.newFolder());
+
+    ReconTestInjector reconTestInjector =
+        new ReconTestInjector.Builder(temporaryFolder)
+            .withReconSqlDb()
+            .withReconOm(reconOMMetadataManager)
+            .withOmServiceProvider(mock(OzoneManagerServiceProviderImpl.class))
+            .addBinding(OzoneStorageContainerManager.class,
+                ReconStorageContainerManagerFacade.class)
+            .withContainerDB()
+            .addBinding(StorageContainerServiceProvider.class,
+                mock(StorageContainerServiceProviderImpl.class))
+            .build();
+
+    this.reconStorageContainerManager =
+        reconTestInjector.getInstance(ReconStorageContainerManagerFacade.class);
+    this.scmDBStore = reconStorageContainerManager.getScmDBStore();
+    this.scmTableCountDao = getDao(ScmTableCountDao.class);
+    this.reconTaskStatusDao = getDao(ReconTaskStatusDao.class);
+    this.dslContext = getDslContext();
+    this.reconTaskConfig = new ReconTaskConfig();
+    this.reconTaskConfig.setContainerSizeCountTaskInterval(
+        Duration.ofSeconds(1));
+    this.utilizationSchemaDefinition =
+        getSchemaDefinition(UtilizationSchemaDefinition.class);
+    this.dslContext = utilizationSchemaDefinition.getDSLContext();
+    this.scmTableCountTask =
+        new ScmTableCountTask(reconStorageContainerManager,
+            reconTaskStatusDao, reconTaskConfig,
+            scmTableCountDao, utilizationSchemaDefinition);
+  }
+
+  @BeforeEach
+  public void setUp() throws Exception {
+    // The following setup runs only once
+    if (!isSetupDone) {
+      initializeInjector();
+      isSetupDone = true;
+    }
+    // Truncate table before running each test
+    dslContext.truncate(DELETED_BLOCKS.getName());
+  }
+
+  /**
+   * Test method for {@link ScmTableCountTask#processTableCount()}.
+   *
+   * @throws IOException if an I/O error occurs during the test.
+   */
+  @Test
+  public void testProcessTableCount2() throws IOException {
+    addDeletedBlocksData(5);
+
+    // Attempt to fetch the record before running the task as
+    // the record does not exist
+    for (String tableName : scmTableCountTask.getTaskTables()) {
+      assertThrows(
+          NullPointerException.class,
+          () -> getCountForTable(tableName)
+      );
+    }
+
+    // Run the task
+    scmTableCountTask.processTableCount();
+
+    // Verify that the table counts are updated for each table returned by the
+    // getTaskTables
+    for (String tableName : scmTableCountTask.getTaskTables()) {
+      assertEquals(5, getCountForTable(tableName));
+    }
+  }
+
+
+  /**
+   * Adds dummy data to the DELETED_BLOCKS table.
+   *
+   * @throws IOException if an I/O error occurs while adding the data.
+   */
+  private void addDeletedBlocksData(int totalRecords) throws IOException {
+    List<Long> localIdList = Arrays.asList(10L, 20L, 30L, 40L, 50L);
+
+    for (long i = 1; i <= totalRecords; i++) {
+      StorageContainerDatanodeProtocolProtos.DeletedBlocksTransaction dtx =
+          StorageContainerDatanodeProtocolProtos.DeletedBlocksTransaction.newBuilder()
+              .setTxID(i)
+              .setContainerID(100L)
+              .addAllLocalID(localIdList)
+              .setCount(4)
+              .build();
+
+      DELETED_BLOCKS.getTable(this.scmDBStore).put(i, dtx);
+    }
+  }
+
+
+  private long getCountForTable(String tableName) {
+    String key = TableCountTask.getRowKeyFromTable(tableName);
+    return scmTableCountDao.findById(key).getCount();
+  }
+
+}
+


### PR DESCRIPTION
## What changes were proposed in this pull request?

- The **`ScmTableCountTask`** is a background task responsible for tracking the table counts in the Storage Container Manager (SCM) of a system. It iterates over the SCM tables and retrieves the counts of objects in each table. The counts are then stored in the Recon Derby database, under the table name `ScmTableCountTable` .
- Currently the **`ScmTableCountTask`** specifically tracks the table counts for the **`DELETED_BLOCKS`** table in the Storage Container Manager (SCM) of the system. The task retrieves the count of objects in the **`DELETED_BLOCKS`** table and stores the count in the Recon database. We can add in more table names into the `getTaskTables` list.
- When the task is run, it enters a loop and periodically waits for the specified interval. Since its an SCM task the task is the process is repeated after a given time interval of **60 sec** as specified by the `scmTableCountTaskInterval`
- The task ensures that the table counts in the Recon database are up-to-date with the SCM tables,
## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-8821

## How was this patch tested?

Manually Tested & Unit Testing 
