### PR TITLE
HDDS-8831. UnsupportedOperationException when there are more replication tasks than limit

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ECUnderReplicationHandler.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ECUnderReplicationHandler.java
@@ -291,7 +291,7 @@ public class ECUnderReplicationHandler implements UnhealthyReplicationHandler {
           replicationManager.getExcludedNodes();
       final boolean hasOverloaded = !excludedDueToLoad.isEmpty();
       final List<DatanodeDetails> excludedOrOverloadedNodes = hasOverloaded
-          ? ImmutableList.copyOf(ImmutableSet.<DatanodeDetails>builder()
+          ? new ArrayList<>(ImmutableSet.<DatanodeDetails>builder()
               .addAll(excludedNodes)
               .addAll(excludedDueToLoad)
               .build())


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fix `UnsupportedOperationException` thrown by `SCMCommonPlacementPolicy` due to trying to modify an `ImmutableList` passed from `ECUnderReplicationHandler`.

```
java.lang.UnsupportedOperationException
    at com.google.common.collect.ImmutableList.set(ImmutableList.java:528)
    at org.apache.hadoop.hdds.scm.SCMCommonPlacementPolicy.validateDatanodes(SCMCommonPlacementPolicy.java:162)
    at org.apache.hadoop.hdds.scm.SCMCommonPlacementPolicy.chooseDatanodes(SCMCommonPlacementPolicy.java:208)
    at org.apache.hadoop.hdds.scm.container.replication.ReplicationManagerUtil.getTargetDatanodes(ReplicationManagerUtil.java:83)
    at org.apache.hadoop.hdds.scm.container.replication.ECUnderReplicationHandler.getTargetDatanodes(ECUnderReplicationHandler.java:396)
    at org.apache.hadoop.hdds.scm.container.replication.ECUnderReplicationHandler.processMissingIndexes(ECUnderReplicationHandler.java:307)
```

https://issues.apache.org/jira/browse/HDDS-8831

## How was this patch tested?

Trivial fix.