### PR TITLE
HDDS-8848. Clean up datanode memory in case of an ozone stream write error

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/transport/server/ratis/ContainerStateMachine.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/transport/server/ratis/ContainerStateMachine.java
@@ -589,6 +589,9 @@ public class ContainerStateMachine extends BaseStateMachine {
     if (stream == null) {
       return JavaUtils.completeExceptionally(new IllegalStateException(
           "DataStream is null"));
+    } else if (!(stream instanceof LocalStream)) {
+      return JavaUtils.completeExceptionally(new IllegalStateException(
+          "Unexpected DataStream " + stream.getClass()));
     }
     final DataChannel dataChannel = stream.getDataChannel();
     if (dataChannel.isOpen()) {
@@ -596,16 +599,36 @@ public class ContainerStateMachine extends BaseStateMachine {
           "DataStream: " + stream + " is not closed properly"));
     }
 
-    final ContainerCommandRequestProto request;
     if (dataChannel instanceof KeyValueStreamDataChannel) {
-      request = ((KeyValueStreamDataChannel) dataChannel).getPutBlockRequest();
+      final KeyValueStreamDataChannel kvStreamDataChannel =
+          (KeyValueStreamDataChannel) dataChannel;
+
+      ContainerCommandRequestProto request =
+          kvStreamDataChannel.getPutBlockRequest();
+
+      return runCommandAsync(request, entry).whenComplete((response, e) -> {
+        if (e != null) {
+          LOG.warn("Failed to link logEntry {} for request {}",
+              TermIndex.valueOf(entry), request, e);
+        }
+        if (response != null) {
+          final ContainerProtos.Result result = response.getResult();
+          if (LOG.isDebugEnabled()) {
+            LOG.debug("{} to link logEntry {} for request {}, response: {}",
+                result, TermIndex.valueOf(entry), request, response);
+          }
+          if (result == ContainerProtos.Result.SUCCESS) {
+            kvStreamDataChannel.setLinked();
+            return;
+          }
+        }
+        // failed to link, cleanup
+        kvStreamDataChannel.cleanUp();
+      });
     } else {
       return JavaUtils.completeExceptionally(new IllegalStateException(
           "Unexpected DataChannel " + dataChannel.getClass()));
     }
-    return runCommandAsync(request, entry).whenComplete(
-        (res, e) -> LOG.debug("link {}, entry: {}, request: {}",
-            res.getResult(), entry, request));
   }
 
   private ExecutorService getChunkExecutor(WriteChunkRequestProto req) {

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/transport/server/ratis/LocalStream.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/transport/server/ratis/LocalStream.java
@@ -18,19 +18,18 @@
 
 package org.apache.hadoop.ozone.container.common.transport.server.ratis;
 
+import org.apache.hadoop.ozone.container.keyvalue.impl.StreamDataChannelBase;
 import org.apache.ratis.statemachine.StateMachine;
 
-import java.io.IOException;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.CompletionException;
 import java.util.concurrent.Executor;
 
 class LocalStream implements StateMachine.DataStream {
-  private final StateMachine.DataChannel dataChannel;
+  private final StreamDataChannelBase dataChannel;
   private final Executor executor;
 
   LocalStream(StateMachine.DataChannel dataChannel, Executor executor) {
-    this.dataChannel = dataChannel;
+    this.dataChannel = (StreamDataChannelBase) dataChannel;
     this.executor = executor;
   }
 
@@ -41,14 +40,7 @@ class LocalStream implements StateMachine.DataStream {
 
   @Override
   public CompletableFuture<?> cleanUp() {
-    return CompletableFuture.supplyAsync(() -> {
-      try {
-        dataChannel.close();
-        return true;
-      } catch (IOException e) {
-        throw new CompletionException("Failed to close data channel", e);
-      }
-    });
+    return CompletableFuture.supplyAsync(dataChannel::cleanUp, executor);
   }
 
   @Override

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/impl/KeyValueStreamDataChannel.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/impl/KeyValueStreamDataChannel.java
@@ -133,9 +133,8 @@ public class KeyValueStreamDataChannel extends StreamDataChannelBase {
     }
 
     void cleanUpAll() {
-      final int size = deque.size();
-      for (int i = 0; i < size; i++) {
-        Optional.ofNullable(poll()).ifPresent(ReferenceCountedObject::release);
+      while (!deque.isEmpty()) {
+        poll().release();
       }
     }
   }
@@ -216,7 +215,7 @@ public class KeyValueStreamDataChannel extends StreamDataChannelBase {
   @Override
   protected void cleanupInternal() throws IOException {
     buffers.cleanUpAll();
-    if (!closed.get()) {
+    if (closed.compareAndSet(false, true)) {
       super.close();
     }
   }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/impl/StreamDataChannelBase.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/impl/StreamDataChannelBase.java
@@ -23,6 +23,8 @@ import org.apache.hadoop.hdds.scm.container.common.helpers.StorageContainerExcep
 import org.apache.hadoop.ozone.container.common.helpers.ContainerMetrics;
 import org.apache.hadoop.ozone.container.common.impl.ContainerData;
 import org.apache.ratis.statemachine.StateMachine;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.io.FileNotFoundException;
@@ -30,16 +32,23 @@ import java.io.IOException;
 import java.io.RandomAccessFile;
 import java.nio.ByteBuffer;
 import java.nio.channels.FileChannel;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import static org.apache.hadoop.ozone.container.common.utils.StorageVolumeUtil.onFailure;
 
 /**
  * For write state machine data.
  */
-abstract class StreamDataChannelBase implements StateMachine.DataChannel {
+public abstract class StreamDataChannelBase
+    implements StateMachine.DataChannel {
+  static final Logger LOG = LoggerFactory.getLogger(
+      StreamDataChannelBase.class);
+
   private final RandomAccessFile randomAccessFile;
 
   private final File file;
+  private final AtomicBoolean linked = new AtomicBoolean();
+  private final AtomicBoolean cleaned = new AtomicBoolean();
 
   private final ContainerData containerData;
   private final ContainerMetrics metrics;
@@ -84,6 +93,29 @@ abstract class StreamDataChannelBase implements StateMachine.DataChannel {
   public final boolean isOpen() {
     return getChannel().isOpen();
   }
+
+  public void setLinked() {
+    linked.set(true);
+  }
+
+  /** @return true iff {@link StateMachine.DataChannel} is already linked. */
+  public boolean cleanUp() {
+    if (linked.get()) {
+      // already linked, nothing to do.
+      return true;
+    }
+    if (cleaned.compareAndSet(false, true)) {
+      // close and then delete the file.
+      try {
+        cleanupInternal();
+      } catch (IOException e) {
+        LOG.warn("Failed to close " + this, e);
+      }
+    }
+    return false;
+  }
+
+  protected abstract void cleanupInternal() throws IOException;
 
   @Override
   public void close() throws IOException {

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/impl/StreamDataChannelBase.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/impl/StreamDataChannelBase.java
@@ -39,7 +39,7 @@ import static org.apache.hadoop.ozone.container.common.utils.StorageVolumeUtil.o
 /**
  * For write state machine data.
  */
-public abstract class StreamDataChannelBase
+abstract class StreamDataChannelBase
     implements StateMachine.DataChannel {
   static final Logger LOG = LoggerFactory.getLogger(
       StreamDataChannelBase.class);


### PR DESCRIPTION
## What changes were proposed in this pull request?

Clean up datanode memory in case of an ozone stream write error

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-8848

## How was this patch tested?


