### PR TITLE
HDDS-8826. Avoid String to UUID conversion in SCMNodeManager

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/SCMCommonPlacementPolicy.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/SCMCommonPlacementPolicy.java
@@ -157,7 +157,7 @@ public abstract class SCMCommonPlacementPolicy implements
     for (int i = 0; i < dns.size(); i++) {
       DatanodeDetails node = dns.get(i);
       DatanodeDetails datanodeDetails =
-          nodeManager.getNodeByUuid(node.getUuidString());
+          nodeManager.getNodeByUuid(node.getUuid());
       if (datanodeDetails != null) {
         dns.set(i, datanodeDetails);
       }
@@ -473,7 +473,7 @@ public abstract class SCMCommonPlacementPolicy implements
   public boolean isValidNode(DatanodeDetails datanodeDetails,
       long metadataSizeRequired, long dataSizeRequired) {
     DatanodeInfo datanodeInfo = (DatanodeInfo)getNodeManager()
-        .getNodeByUuid(datanodeDetails.getUuidString());
+        .getNodeByUuid(datanodeDetails.getUuid());
     if (datanodeInfo == null) {
       LOG.error("Failed to find the DatanodeInfo for datanode {}",
           datanodeDetails);

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/ContainerReportHandler.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/ContainerReportHandler.java
@@ -147,7 +147,7 @@ public class ContainerReportHandler extends AbstractContainerReportHandler
     final DatanodeDetails dnFromReport =
         reportFromDatanode.getDatanodeDetails();
     DatanodeDetails datanodeDetails =
-        nodeManager.getNodeByUuid(dnFromReport.getUuidString());
+        nodeManager.getNodeByUuid(dnFromReport.getUuid());
     if (datanodeDetails == null) {
       LOG.warn("Received container report from unknown datanode {}",
           dnFromReport);

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/IncrementalContainerReportHandler.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/IncrementalContainerReportHandler.java
@@ -66,7 +66,7 @@ public class IncrementalContainerReportHandler extends
           dnFromReport.getUuid());
     }
     DatanodeDetails dd =
-        nodeManager.getNodeByUuid(dnFromReport.getUuidString());
+        nodeManager.getNodeByUuid(dnFromReport.getUuid());
     if (dd == null) {
       LOG.warn("Received container report from unknown datanode {}",
           dnFromReport);

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/DeadNodeHandler.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/DeadNodeHandler.java
@@ -103,7 +103,7 @@ public class DeadNodeHandler implements EventHandler<DatanodeDetails> {
         //make sure after DN is removed from topology,
         //DatanodeDetails instance returned from nodeStateManager has no parent.
         Preconditions.checkState(
-            nodeManager.getNodeByUuid(datanodeDetails.getUuidString())
+            nodeManager.getNodeByUuid(datanodeDetails.getUuid())
                 .getParent() == null);
       }
     } catch (NodeNotFoundException ex) {

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/HealthyReadOnlyNodeHandler.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/HealthyReadOnlyNodeHandler.java
@@ -105,7 +105,7 @@ public class HealthyReadOnlyNodeHandler
       // make sure after DN is added back into topology, DatanodeDetails
       // instance returned from nodeStateManager has parent correctly set.
       Preconditions.checkNotNull(
-          nodeManager.getNodeByUuid(datanodeDetails.getUuidString())
+          nodeManager.getNodeByUuid(datanodeDetails.getUuid())
               .getParent());
     }
   }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/NodeManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/NodeManager.java
@@ -40,6 +40,7 @@ import org.apache.hadoop.ozone.protocol.commands.CommandForDatanode;
 import org.apache.hadoop.ozone.protocol.commands.RegisteredCommand;
 import org.apache.hadoop.ozone.protocol.commands.SCMCommand;
 
+import javax.annotation.Nullable;
 import java.io.Closeable;
 import java.util.List;
 import java.util.Map;
@@ -364,7 +365,11 @@ public interface NodeManager extends StorageContainerNodeProtocol,
    * @param uuid datanode uuid
    * @return the given datanode, or null if not found
    */
-  DatanodeDetails getNodeByUuid(String uuid);
+  @Nullable DatanodeDetails getNodeByUuid(@Nullable String uuid);
+
+  default @Nullable DatanodeDetails getNodeByUuid(@Nullable UUID uuid) {
+    return uuid != null ? getNodeByUuid(uuid.toString()) : null;
+  };
 
   /**
    * Given datanode address(Ipaddress or hostname), returns a list of

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/SCMNodeManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/SCMNodeManager.java
@@ -1348,14 +1348,16 @@ public class SCMNodeManager implements NodeManager {
    */
   @Override
   public DatanodeDetails getNodeByUuid(String uuid) {
-    if (Strings.isNullOrEmpty(uuid)) {
-      LOG.warn("uuid is null");
-      return null;
-    }
-    DatanodeDetails temp = DatanodeDetails.newBuilder()
-        .setUuid(UUID.fromString(uuid)).build();
+    return uuid != null && !uuid.isEmpty()
+        ? getNodeByUuid(UUID.fromString(uuid))
+        : null;
+  }
+
+  @Override
+  public DatanodeDetails getNodeByUuid(UUID uuid) {
     try {
-      return nodeStateManager.getNode(temp);
+      return nodeStateManager.getNode(
+          DatanodeDetails.newBuilder().setUuid(uuid).build());
     } catch (NodeNotFoundException e) {
       LOG.warn("Cannot find node for uuid {}", uuid);
       return null;

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/SCMNodeManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/SCMNodeManager.java
@@ -1355,6 +1355,10 @@ public class SCMNodeManager implements NodeManager {
 
   @Override
   public DatanodeDetails getNodeByUuid(UUID uuid) {
+    if (uuid == null) {
+      return null;
+    }
+
     try {
       return nodeStateManager.getNode(
           DatanodeDetails.newBuilder().setUuid(uuid).build());

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/PipelineManagerImpl.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/PipelineManagerImpl.java
@@ -548,7 +548,7 @@ public class PipelineManagerImpl implements PipelineManager {
       return false;
     }
     for (DatanodeDetails dn : pipeline.getNodes()) {
-      if (nodeManager.getNodeByUuid(dn.getUuidString()) == null) {
+      if (nodeManager.getNodeByUuid(dn.getUuid()) == null) {
         return true;
       }
     }

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/placement/algorithms/TestContainerPlacementFactory.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/placement/algorithms/TestContainerPlacementFactory.java
@@ -142,7 +142,7 @@ public class TestContainerPlacementFactory {
     when(nodeManager.getNodes(NodeStatus.inServiceHealthy()))
         .thenReturn(new ArrayList<>(datanodes));
     for (DatanodeInfo dn: dnInfos) {
-      when(nodeManager.getNodeByUuid(dn.getUuidString()))
+      when(nodeManager.getNodeByUuid(dn.getUuid()))
           .thenReturn(dn);
     }
 

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/placement/algorithms/TestSCMContainerPlacementCapacity.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/placement/algorithms/TestSCMContainerPlacementCapacity.java
@@ -21,6 +21,7 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.conf.StorageUnit;
@@ -40,8 +41,7 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_DATANODE_RATIS_VOLUME_FREE_SPACE_MIN;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Matchers.anyObject;
+import static org.mockito.ArgumentMatchers.any;
 import org.mockito.Mockito;
 import static org.mockito.Mockito.when;
 
@@ -102,7 +102,7 @@ public class TestSCMContainerPlacementCapacity {
     when(mockNodeManager.getNodes(NodeStatus.inServiceHealthy()))
         .thenReturn(new ArrayList<>(datanodes));
 
-    when(mockNodeManager.getNodeStat(anyObject()))
+    when(mockNodeManager.getNodeStat(any()))
         .thenReturn(new SCMNodeMetric(100L, 0L, 100L));
     when(mockNodeManager.getNodeStat(datanodes.get(2)))
         .thenReturn(new SCMNodeMetric(100L, 90L, 10L));
@@ -110,15 +110,11 @@ public class TestSCMContainerPlacementCapacity {
         .thenReturn(new SCMNodeMetric(100L, 80L, 20L));
     when(mockNodeManager.getNodeStat(datanodes.get(4)))
         .thenReturn(new SCMNodeMetric(100L, 70L, 30L));
-    when(mockNodeManager.getNodeByUuid(anyString())).thenAnswer(
-            invocation -> {
-              String uuid = invocation.getArgument(0);
-              return datanodes.stream().filter(
-                              datanode ->
-                                      datanode.getUuid().toString()
-                                              .equals(uuid)).findFirst()
-                      .orElse(null);
-            });
+    when(mockNodeManager.getNodeByUuid(any(UUID.class))).thenAnswer(
+            invocation -> datanodes.stream()
+                .filter(dn -> dn.getUuid().equals(invocation.getArgument(0)))
+                .findFirst()
+                .orElse(null));
 
     SCMContainerPlacementCapacity scmContainerPlacementRandom =
         new SCMContainerPlacementCapacity(mockNodeManager, conf, null, true,

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/placement/algorithms/TestSCMContainerPlacementRackAware.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/placement/algorithms/TestSCMContainerPlacementRackAware.java
@@ -173,7 +173,7 @@ public class TestSCMContainerPlacementRackAware {
     when(nodeManager.getNodes(NodeStatus.inServiceHealthy()))
         .thenReturn(new ArrayList<>(datanodes));
     for (DatanodeInfo dn: dnInfos) {
-      when(nodeManager.getNodeByUuid(dn.getUuidString()))
+      when(nodeManager.getNodeByUuid(dn.getUuid()))
           .thenReturn(dn);
     }
     when(nodeManager.getClusterNetworkTopologyMap())
@@ -475,7 +475,7 @@ public class TestSCMContainerPlacementRackAware {
     Assertions.assertEquals(dataList.size(), StringUtils.countMatches(
         clusterMap.toString(), NetConstants.DEFAULT_RACK));
     for (DatanodeInfo dn: dnInfoList) {
-      when(nodeManager.getNodeByUuid(dn.getUuidString()))
+      when(nodeManager.getNodeByUuid(dn.getUuid()))
           .thenReturn(dn);
     }
 

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/placement/algorithms/TestSCMContainerPlacementRackScatter.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/placement/algorithms/TestSCMContainerPlacementRackScatter.java
@@ -193,7 +193,7 @@ public class TestSCMContainerPlacementRackScatter {
     when(nodeManager.getNodes(NodeStatus.inServiceHealthy()))
         .thenReturn(new ArrayList<>(datanodes));
     for (DatanodeInfo dn: dnInfos) {
-      when(nodeManager.getNodeByUuid(dn.getUuidString()))
+      when(nodeManager.getNodeByUuid(dn.getUuid()))
           .thenReturn(dn);
     }
     when(nodeManager.getClusterNetworkTopologyMap())
@@ -488,7 +488,7 @@ public class TestSCMContainerPlacementRackScatter {
     Assertions.assertEquals(dataList.size(), StringUtils.countMatches(
         clusterMap.toString(), NetConstants.DEFAULT_RACK));
     for (DatanodeInfo dn: dnInfoList) {
-      when(nodeManager.getNodeByUuid(dn.getUuidString()))
+      when(nodeManager.getNodeByUuid(dn.getUuid()))
           .thenReturn(dn);
     }
 

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/placement/algorithms/TestSCMContainerPlacementRandom.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/placement/algorithms/TestSCMContainerPlacementRandom.java
@@ -204,11 +204,11 @@ public class TestSCMContainerPlacementRandom {
     NodeManager mockNodeManager = Mockito.mock(NodeManager.class);
     when(mockNodeManager.getNodes(NodeStatus.inServiceHealthy()))
         .thenReturn(new ArrayList<>(datanodes));
-    when(mockNodeManager.getNodeByUuid(datanodes.get(0).getUuidString()))
+    when(mockNodeManager.getNodeByUuid(datanodes.get(0).getUuid()))
         .thenReturn(datanodes.get(0));
-    when(mockNodeManager.getNodeByUuid(datanodes.get(1).getUuidString()))
+    when(mockNodeManager.getNodeByUuid(datanodes.get(1).getUuid()))
         .thenReturn(datanodes.get(1));
-    when(mockNodeManager.getNodeByUuid(datanodes.get(2).getUuidString()))
+    when(mockNodeManager.getNodeByUuid(datanodes.get(2).getUuid()))
         .thenReturn(datanodes.get(2));
 
     SCMContainerPlacementRandom scmContainerPlacementRandom =

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/scm/ReconIncrementalContainerReportHandler.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/scm/ReconIncrementalContainerReportHandler.java
@@ -60,7 +60,7 @@ public class ReconIncrementalContainerReportHandler
     }
 
     DatanodeDetails dd =
-        getNodeManager().getNodeByUuid(dnFromReport.getUuidString());
+        getNodeManager().getNodeByUuid(dnFromReport.getUuid());
     if (dd == null) {
       LOG.warn("Received container report from unknown datanode {}",
           dnFromReport);

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/scm/ReconNodeManager.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/scm/ReconNodeManager.java
@@ -293,7 +293,7 @@ public class ReconNodeManager extends SCMNodeManager {
           nodeStatus.getOperationalState());
 
       setNodeOperationalState(dnDetails, nodeOperationalStateFromScm);
-      DatanodeDetails scmDnd = getNodeByUuid(dnDetails.getUuidString());
+      DatanodeDetails scmDnd = getNodeByUuid(dnDetails.getUuid());
       scmDnd.setPersistedOpState(nodeOperationalStateFromScm);
     }
   }

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/scm/TestReconIncrementalContainerReportHandler.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/scm/TestReconIncrementalContainerReportHandler.java
@@ -132,7 +132,8 @@ public class TestReconIncrementalContainerReportHandler
       DatanodeDetails datanodeDetails =
           containerWithPipeline.getPipeline().getFirstNode();
       NodeManager nodeManagerMock = mock(NodeManager.class);
-      when(nodeManagerMock.getNodeByUuid(any())).thenReturn(datanodeDetails);
+      when(nodeManagerMock.getNodeByUuid(any(UUID.class)))
+          .thenReturn(datanodeDetails);
       IncrementalContainerReportFromDatanode reportMock =
           mock(IncrementalContainerReportFromDatanode.class);
       when(reportMock.getDatanodeDetails())


### PR DESCRIPTION
## What changes were proposed in this pull request?

Add `getNodeByUuid(UUID)` to avoid `UUID.fromString` conversion when looking up datanodes.

https://issues.apache.org/jira/browse/HDDS-8826

## How was this patch tested?

Updated unit tests.

CI:
https://github.com/adoroszlai/hadoop-ozone/actions/runs/5268395265