### PR TITLE
HDDS-8750. In ContainerKeyPrefixCodec, toPersistedFormat(..) and fromPersistedFormat(..) are not consistent.

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/utils/db/CodecBuffer.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/utils/db/CodecBuffer.java
@@ -32,6 +32,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.IntFunction;
@@ -212,6 +213,30 @@ public final class CodecBuffer implements AutoCloseable {
   }
 
   /**
+   * Similar to {@link ByteBuffer#getLong()}.
+   * The read index of this buffer will be incremented by 8.
+   *
+   * @return the long stored at the current read index.
+   */
+  public long getLong() {
+    return buf.readLong();
+  }
+
+  /**
+   * Get a {@link StandardCharsets#UTF_8} string from this buffer.
+   * The read index of this buffer will be incremented by the given length.
+   *
+   * @param length the number of bytes to be read.
+   * @return the string stored at the current read index.
+   */
+  public String getUtf8(int length) {
+    final int r = buf.readerIndex();
+    final String s = buf.toString(r, length, StandardCharsets.UTF_8);
+    buf.setIndex(r + length, buf.writerIndex());
+    return s;
+  }
+
+  /**
    * Similar to {@link ByteBuffer#putShort(short)}.
    *
    * @return this object.
@@ -241,6 +266,17 @@ public final class CodecBuffer implements AutoCloseable {
   public CodecBuffer putLong(long n) {
     assertRefCnt(1);
     buf.writeLong(n);
+    return this;
+  }
+
+  /**
+   * Put the given string to this buffer using {@link StandardCharsets#UTF_8}.
+   *
+   * @return this object.
+   */
+  public CodecBuffer putUtf8(String s) {
+    assertRefCnt(1);
+    buf.writeCharSequence(s, StandardCharsets.UTF_8);
     return this;
   }
 
@@ -329,5 +365,14 @@ public final class CodecBuffer implements AutoCloseable {
       }
     }
     return size;
+  }
+
+  @Override
+  public String toString() {
+    return getClass().getSimpleName()
+        + "[" + buf.readerIndex()
+        + "<=" + buf.writerIndex()
+        + "<=" + buf.capacity()
+        + "]";
   }
 }

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/api/types/ContainerKeyPrefixImpl.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/api/types/ContainerKeyPrefixImpl.java
@@ -144,7 +144,6 @@ final class ContainerKeyPrefixImpl
     @Override
     public final int getSerializedSizeUpperBound(ContainerKeyPrefix object) {
       final String keyPrefix = object.getKeyPrefix();
-      // containerId
       return Long.BYTES // containerId
           + Delimiter.length()
           + StringCodec.get().getSerializedSizeUpperBound(keyPrefix)

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/api/types/KeyPrefixContainer.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/api/types/KeyPrefixContainer.java
@@ -69,10 +69,7 @@ public interface KeyPrefixContainer {
      * <p>
      * Deserialization:
      * (d1) Use {@link CodecImpl} to deserialize.
-     * (d2) Use {@link ContainerKeyPrefix#toKeyPrefixContainer()}.
-     *      Note that,
-     *      since the object was serialized from a {@link KeyPrefixContainer},
-     *      {@link ContainerKeyPrefix#getKeyPrefix()} is always non-empty.
+     * (d2) Cast the object to {@link KeyPrefixContainer}.
      */
     private static final Codec<KeyPrefixContainer> CODEC = new DelegatedCodec<>(
         new CodecImpl(),
@@ -81,6 +78,7 @@ public interface KeyPrefixContainer {
         DelegatedCodec.CopyType.SHALLOW);
 
     private CodecImpl() {
+      // singleton
     }
 
     @Override

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/api/types/KeyPrefixContainer.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/api/types/KeyPrefixContainer.java
@@ -18,6 +18,14 @@
 
 package org.apache.hadoop.ozone.recon.api.types;
 
+import org.apache.hadoop.hdds.utils.db.Codec;
+import org.apache.hadoop.hdds.utils.db.CodecBuffer;
+import org.apache.hadoop.hdds.utils.db.DelegatedCodec;
+
+import javax.annotation.Nonnull;
+import java.util.Objects;
+import java.util.function.IntFunction;
+
 /**
  * Class to encapsulate the Key information needed for the Recon container DB.
  * Currently, it is the whole key + key version and the containerId.
@@ -28,6 +36,7 @@ public interface KeyPrefixContainer {
 
   static KeyPrefixContainer get(String keyPrefix, long keyVersion,
       long containerId) {
+    Objects.requireNonNull(keyPrefix, "keyPrefix == null");
     return ContainerKeyPrefixImpl.get(containerId, keyPrefix, keyVersion);
   }
 
@@ -41,9 +50,58 @@ public interface KeyPrefixContainer {
 
   long getContainerId();
 
-  String getKeyPrefix();
+  @Nonnull String getKeyPrefix();
 
   long getKeyVersion();
 
   ContainerKeyPrefix toContainerKeyPrefix();
+
+  static Codec<KeyPrefixContainer> getCodec() {
+    return CodecImpl.CODEC;
+  }
+
+  /** Implementing {@link Codec} for {@link KeyPrefixContainer}. */
+  final class CodecImpl extends ContainerKeyPrefixImpl.CodecBase {
+    /**
+     * Serialization:
+     * (s1) Use {@link KeyPrefixContainer#toContainerKeyPrefix()}.
+     * (s2) Use {@link CodecImpl} to serialize.
+     * <p>
+     * Deserialization:
+     * (d1) Use {@link CodecImpl} to deserialize.
+     * (d2) Use {@link ContainerKeyPrefix#toKeyPrefixContainer()}.
+     *      Note that,
+     *      since the object was serialized from a {@link KeyPrefixContainer},
+     *      {@link ContainerKeyPrefix#getKeyPrefix()} is always non-empty.
+     */
+    private static final Codec<KeyPrefixContainer> CODEC = new DelegatedCodec<>(
+        new CodecImpl(),
+        KeyPrefixContainer.class::cast,
+        KeyPrefixContainer::toContainerKeyPrefix,
+        DelegatedCodec.CopyType.SHALLOW);
+
+    private CodecImpl() {
+    }
+
+    @Override
+    public ContainerKeyPrefix fromCodecBuffer(@Nonnull CodecBuffer buffer) {
+      final int keyPrefixLength = buffer.readableBytes()
+          - 2 * (Long.BYTES + Delimiter.length());
+      final String keyPrefix = buffer.getUtf8(keyPrefixLength);
+      final long keyVersion = Delimiter.skip(buffer).getLong();
+      final long containerId = Delimiter.skip(buffer).getLong();
+      return ContainerKeyPrefix.get(containerId, keyPrefix, keyVersion);
+    }
+
+    @Override
+    public CodecBuffer toCodecBuffer(@Nonnull ContainerKeyPrefix object,
+        IntFunction<CodecBuffer> allocator) {
+      return allocator.apply(getSerializedSizeUpperBound(object))
+          .putUtf8(object.getKeyPrefix())
+          .put(Delimiter.getBytes())
+          .putLong(object.getKeyVersion())
+          .put(Delimiter.getBytes())
+          .putLong(object.getContainerId());
+    }
+  }
 }

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/spi/impl/ReconDBDefinition.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/spi/impl/ReconDBDefinition.java
@@ -47,7 +47,7 @@ public class ReconDBDefinition extends DBDefinition.WithMap {
       new DBColumnFamilyDefinition<>(
           "containerKeyTable",
           ContainerKeyPrefix.class,
-          ContainerKeyPrefixCodec.get(),
+          ContainerKeyPrefix.getCodec(),
           Integer.class,
           IntegerCodec.get());
 
@@ -56,7 +56,7 @@ public class ReconDBDefinition extends DBDefinition.WithMap {
       new DBColumnFamilyDefinition<>(
           "keyContainerTable",
           KeyPrefixContainer.class,
-          KeyPrefixContainerCodec.get(),
+          KeyPrefixContainer.getCodec(),
           Integer.class,
           IntegerCodec.get());
 

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/TestReconCodecs.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/TestReconCodecs.java
@@ -19,29 +19,176 @@
 package org.apache.hadoop.ozone.recon;
 
 import java.io.IOException;
+import java.util.concurrent.ThreadLocalRandom;
 
+import org.apache.hadoop.hdds.utils.db.CodecTestUtil;
 import org.apache.hadoop.ozone.recon.api.types.ContainerKeyPrefix;
-import org.apache.hadoop.ozone.recon.spi.impl.ContainerKeyPrefixCodec;
 import org.apache.hadoop.hdds.utils.db.Codec;
 import org.apache.hadoop.hdds.utils.db.IntegerCodec;
+import org.apache.hadoop.ozone.recon.api.types.KeyPrefixContainer;
+import org.apache.hadoop.ozone.recon.spi.impl.OldContainerKeyPrefixCodecForTesting;
+import org.apache.hadoop.ozone.recon.spi.impl.OldKeyPrefixContainerCodecForTesting;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.opentest4j.AssertionFailedError;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Unit Tests for Codecs used in Recon.
  */
 public class TestReconCodecs {
+  public static final Logger LOG = LoggerFactory.getLogger(
+      TestReconCodecs.class);
+
+  static long nextPositiveLong() {
+    final long next = ThreadLocalRandom.current().nextLong(Long.MAX_VALUE) + 1;
+    Assertions.assertTrue(next > 0);
+    return next;
+  }
 
   @Test
-  public void testContainerKeyPrefixCodec() throws IOException {
-    ContainerKeyPrefix containerKeyPrefix = ContainerKeyPrefix.get(
-        System.currentTimeMillis(), "TestKeyPrefix", 0);
+  public void testContainerKeyPrefixCodec() throws Exception {
+    // consistent with old codecs
+    runTestContainerKeyPrefixCodec(
+        nextPositiveLong(), "TestKeyPrefix", 0, true, true);
+    final String key = "0123456789";
+    for (int i = 0; i < 10; i++) {
+      runTestContainerKeyPrefixCodec(
+          nextPositiveLong(), key.substring(i), nextPositiveLong(), true, true);
+    }
 
-    Codec<ContainerKeyPrefix> codec = ContainerKeyPrefixCodec.get();
+    // Both old codecs cannot handle keyVersion == -1.
+    runTestContainerKeyPrefixCodec(
+        nextPositiveLong(), "TestKeyPrefix", -1, false, false);
+
+    // Both old codecs can handle empty/null keyPrefix.
+    runTestContainerKeyPrefixCodec(
+        nextPositiveLong(), "", 0, true, null);
+    runTestContainerKeyPrefixCodec(
+        nextPositiveLong(), null, 0, true, null);
+
+    // Old ContainerKeyPrefixCodec can handle containerId == -1
+    // but old KeyPrefixContainerCodec cannot.
+    runTestContainerKeyPrefixCodec(
+        -1, "TestKeyPrefix", 0, true, false);
+  }
+
+  static void runTestContainerKeyPrefixCodec(
+      long containerId, String keyPrefix, long keyVersion,
+      boolean oldCKPCodecValid, Boolean oldKPCCodecValid) throws Exception {
+    ContainerKeyPrefix containerKeyPrefix = ContainerKeyPrefix.get(
+        containerId, keyPrefix, keyVersion);
+    runTestContainerKeyPrefixCodec(containerKeyPrefix, oldCKPCodecValid);
+
+    final KeyPrefixContainer keyPrefixContainer
+        = containerKeyPrefix.toKeyPrefixContainer();
+    if (keyPrefixContainer != null) {
+      runTestKeyPrefixContainerCodec(keyPrefixContainer, oldKPCCodecValid);
+    } else {
+      Assertions.assertNull(oldKPCCodecValid);
+    }
+  }
+
+  @Test
+  public void testKeyPrefixContainer() throws Exception {
+    // consistent with old codecs
+    runTestKeyPrefixContainer(
+        "TestKeyPrefix", 0, nextPositiveLong(), true, true);
+    final String key = "0123456789";
+    for (int i = 0; i < 10; i++) {
+      runTestKeyPrefixContainer(
+          key.substring(i), nextPositiveLong(), nextPositiveLong(), true, true);
+    }
+
+    // Both old codecs cannot handle keyVersion == -1.
+    runTestKeyPrefixContainer(
+        "TestKeyPrefix", -1, nextPositiveLong(), false, false);
+
+    // Both old codecs can handle empty non-null keyPrefix.
+    runTestKeyPrefixContainer(
+        "", 0, nextPositiveLong(), true, true);
+
+    // Old ContainerKeyPrefixCodec can handle containerId == -1
+    // but old KeyPrefixContainerCodec cannot.
+    runTestKeyPrefixContainer(
+        "TestKeyPrefix", 0, -1, true, false);
+  }
+
+  static void runTestKeyPrefixContainer(
+      String keyPrefix, long keyVersion, long containerId,
+      boolean oldCKPCodecValid, boolean oldKPCCodecValid) throws Exception {
+    final KeyPrefixContainer keyPrefixContainer = KeyPrefixContainer.get(
+        keyPrefix, keyVersion, containerId);
+    runTestKeyPrefixContainerCodec(keyPrefixContainer, oldKPCCodecValid);
+
+    final ContainerKeyPrefix containerKeyPrefix
+        = keyPrefixContainer.toContainerKeyPrefix();
+    runTestContainerKeyPrefixCodec(containerKeyPrefix, oldCKPCodecValid);
+  }
+
+  static void runTestContainerKeyPrefixCodec(
+      ContainerKeyPrefix containerKeyPrefix,
+      boolean oldCodecValid) throws Exception {
+    final Codec<ContainerKeyPrefix> newCodec = ContainerKeyPrefix.getCodec();
+    final Codec<ContainerKeyPrefix> oldCodec
+        = OldContainerKeyPrefixCodecForTesting.get();
+    runTestContainerKeyPrefixCodec(containerKeyPrefix, newCodec);
+    if (oldCodecValid) {
+      runTestContainerKeyPrefixCodec(containerKeyPrefix, oldCodec);
+    } else {
+      try {
+        runTestContainerKeyPrefixCodec(containerKeyPrefix, oldCodec);
+        throw new IllegalStateException(
+            "Unexpected: oldCodec did not fail for " + containerKeyPrefix);
+      } catch (AssertionFailedError e) {
+        LOG.info("Good!", e);
+      }
+    }
+    CodecTestUtil.runTest(newCodec, containerKeyPrefix, null,
+        oldCodecValid ? oldCodec : null);
+  }
+
+  static void runTestKeyPrefixContainerCodec(
+      KeyPrefixContainer keyPrefixContainer,
+      boolean oldCodecValid) throws Exception {
+    final Codec<KeyPrefixContainer> newCodec = KeyPrefixContainer.getCodec();
+    final Codec<KeyPrefixContainer> oldCodec
+        = OldKeyPrefixContainerCodecForTesting.get();
+    runTestKeyPrefixContainerCodec(keyPrefixContainer, newCodec);
+    if (oldCodecValid) {
+      runTestKeyPrefixContainerCodec(keyPrefixContainer, oldCodec);
+    } else {
+      try {
+        runTestKeyPrefixContainerCodec(keyPrefixContainer, oldCodec);
+        throw new IllegalStateException(
+            "Unexpected: oldCodec did not fail for " + keyPrefixContainer);
+      } catch (AssertionFailedError e) {
+        LOG.info("Good!", e);
+      }
+    }
+    CodecTestUtil.runTest(newCodec, keyPrefixContainer, null,
+        oldCodecValid ? oldCodec : null);
+  }
+
+  static void runTestContainerKeyPrefixCodec(
+      ContainerKeyPrefix containerKeyPrefix,
+      Codec<ContainerKeyPrefix> codec) throws Exception {
     byte[] persistedFormat = codec.toPersistedFormat(containerKeyPrefix);
-    Assertions.assertTrue(persistedFormat != null);
+    Assertions.assertNotNull(persistedFormat);
     ContainerKeyPrefix fromPersistedFormat =
         codec.fromPersistedFormat(persistedFormat);
+    Assertions.assertEquals(containerKeyPrefix, fromPersistedFormat);
+  }
+
+  static void runTestKeyPrefixContainerCodec(
+      KeyPrefixContainer containerKeyPrefix,
+      Codec<KeyPrefixContainer> codec) throws Exception {
+    byte[] persistedFormat = codec.toPersistedFormat(containerKeyPrefix);
+    Assertions.assertNotNull(persistedFormat);
+    KeyPrefixContainer fromPersistedFormat =
+        codec.fromPersistedFormat(persistedFormat);
+    LOG.info("fromPersistedFormat = " + fromPersistedFormat);
     Assertions.assertEquals(containerKeyPrefix, fromPersistedFormat);
   }
 

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/spi/impl/OldContainerKeyPrefixCodecForTesting.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/spi/impl/OldContainerKeyPrefixCodecForTesting.java
@@ -34,19 +34,19 @@ import com.google.common.primitives.Longs;
 /**
  * Codec to serialize/deserialize {@link ContainerKeyPrefix}.
  */
-public final class ContainerKeyPrefixCodec
+public final class OldContainerKeyPrefixCodecForTesting
     implements Codec<ContainerKeyPrefix> {
 
   private static final String KEY_DELIMITER = "_";
 
   private static final Codec<ContainerKeyPrefix> INSTANCE =
-      new ContainerKeyPrefixCodec();
+      new OldContainerKeyPrefixCodecForTesting();
 
   public static Codec<ContainerKeyPrefix> get() {
     return INSTANCE;
   }
 
-  private ContainerKeyPrefixCodec() {
+  private OldContainerKeyPrefixCodecForTesting() {
     // singleton
   }
 

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/spi/impl/OldKeyPrefixContainerCodecForTesting.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/spi/impl/OldKeyPrefixContainerCodecForTesting.java
@@ -32,17 +32,17 @@ import static org.apache.commons.compress.utils.CharsetNames.UTF_8;
 /**
  * Codec to serialize/deserialize {@link KeyPrefixContainer}.
  */
-public final class KeyPrefixContainerCodec
+public final class OldKeyPrefixContainerCodecForTesting
     implements Codec<KeyPrefixContainer> {
 
   private static final Codec<KeyPrefixContainer> INSTANCE =
-      new KeyPrefixContainerCodec();
+      new OldKeyPrefixContainerCodecForTesting();
 
   public static Codec<KeyPrefixContainer> get() {
     return INSTANCE;
   }
 
-  private KeyPrefixContainerCodec() {
+  private OldKeyPrefixContainerCodecForTesting() {
     // singleton
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

- Always encode negative values in order to maintain consistence.
- Support `CodecBuffer`.

## What is the link to the Apache JIRA

HDDS-8750

## How was this patch tested?

Added new tests.