### PR TITLE
HDDS-8762. Support RocksDB delete with ByteBuffer.

### DIFF
--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/RDBTable.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/RDBTable.java
@@ -193,6 +193,11 @@ class RDBTable implements Table<byte[], byte[]> {
     db.delete(family, key);
   }
 
+  public void delete(ByteBuffer key) throws IOException {
+    db.delete(family, key);
+  }
+
+
   @Override
   public void deleteRange(byte[] beginKey, byte[] endKey) throws IOException {
     db.deleteRange(family, beginKey, endKey);

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/RocksDatabase.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/RocksDatabase.java
@@ -888,6 +888,20 @@ public final class RocksDatabase implements Closeable {
     }
   }
 
+  public void delete(ColumnFamily family, ByteBuffer key) throws IOException {
+    assertClose();
+    try {
+      counter.incrementAndGet();
+      db.get().delete(family.getHandle(), writeOptions, key);
+    } catch (RocksDBException e) {
+      closeOnError(e, true);
+      final String message = "delete " + bytes2String(key) + " from " + family;
+      throw toIOException(this, message, e);
+    } finally {
+      counter.decrementAndGet();
+    }
+  }
+
   public void deleteRange(ColumnFamily family, byte[] beginKey, byte[] endKey)
       throws IOException {
     assertClose();

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/TypedTable.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/TypedTable.java
@@ -403,7 +403,13 @@ public class TypedTable<KEY, VALUE> implements Table<KEY, VALUE> {
 
   @Override
   public void delete(KEY key) throws IOException {
-    rawTable.delete(encodeKey(key));
+    if (keyCodec.supportCodecBuffer()) {
+      try (CodecBuffer buffer = keyCodec.toDirectCodecBuffer(key)) {
+        rawTable.delete(buffer.asReadOnlyByteBuffer());
+      }
+    } else {
+      rawTable.delete(encodeKey(key));
+    }
   }
 
   @Override


### PR DESCRIPTION
## What changes were proposed in this pull request?

When the codec support CodecBuffer, use RocksDB ByteBuffer delete API.

## What is the link to the Apache JIRA

HDDS-8762

## How was this patch tested?

By existing tests.