### PR TITLE
HDDS-8836. Expose cpu load and available processors metrics

### DIFF
--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/CpuMetrics.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/CpuMetrics.java
@@ -1,0 +1,71 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.hdds.utils;
+
+import com.sun.management.OperatingSystemMXBean;
+import java.lang.management.ManagementFactory;
+import org.apache.hadoop.metrics2.MetricsCollector;
+import org.apache.hadoop.metrics2.MetricsRecordBuilder;
+import org.apache.hadoop.metrics2.MetricsSource;
+import org.apache.hadoop.metrics2.annotation.Metrics;
+import org.apache.hadoop.metrics2.lib.DefaultMetricsSystem;
+import org.apache.hadoop.metrics2.lib.Interns;
+import org.apache.hadoop.ozone.OzoneConsts;
+
+/**
+ * Expose the next JMX metrics.
+ *  <p>jvm_metrics_cpu_available_processors</p>
+ *  <p>jvm_metrics_cpu_system_load</p>
+ *  <p>jvm_metrics_cpu_jvm_load</p>
+ */
+@Metrics(about = "CPU Metrics", context = OzoneConsts.OZONE)
+public class CpuMetrics implements MetricsSource {
+
+  public static final String SOURCE = "JvmMetricsCpu";
+
+  private final OperatingSystemMXBean operatingSystemMXBean;
+
+  public CpuMetrics() {
+    operatingSystemMXBean =
+        (OperatingSystemMXBean) ManagementFactory.getOperatingSystemMXBean();
+  }
+
+  public static void create() {
+    if (DefaultMetricsSystem.instance().getSource(SOURCE) == null) {
+      DefaultMetricsSystem.instance().register(SOURCE,
+          "CPU Metrics",
+          new CpuMetrics());
+    }
+  }
+
+  @Override
+  public void getMetrics(MetricsCollector collector, boolean all) {
+    MetricsRecordBuilder builder = collector.addRecord(SOURCE);
+    builder.addGauge(Interns.info("jvmLoad",
+                "JVM CPU Load"),
+            operatingSystemMXBean.getProcessCpuLoad())
+        .addGauge(Interns.info("systemLoad",
+                "System CPU Load"),
+            operatingSystemMXBean.getSystemCpuLoad())
+        .addGauge(Interns.info("availableProcessors",
+                "Available processors"),
+            operatingSystemMXBean.getAvailableProcessors());
+  }
+
+}

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/HddsServerUtil.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/HddsServerUtil.java
@@ -576,6 +576,7 @@ public final class HddsServerUtil {
       JvmMetrics.create(serverName,
           configuration.get(DFSConfigKeysLegacy.DFS_METRICS_SESSION_ID_KEY),
           DefaultMetricsSystem.instance());
+      CpuMetrics.create();
     } catch (MetricsException e) {
       LOG.info("Metrics source JvmMetrics already added to DataNode.");
     }

--- a/hadoop-ozone/integration-test/dev-support/findbugsExcludeFile.xml
+++ b/hadoop-ozone/integration-test/dev-support/findbugsExcludeFile.xml
@@ -93,6 +93,11 @@
     <Bug pattern="NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE" />
   </Match>
   <Match>
+    <Class name="org.apache.hadoop.ozone.TestCpuMetrics"/>
+    <Method name="testCpuMetrics"/>
+    <Bug pattern="NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE" />
+  </Match>
+  <Match>
     <Class name="org.apache.hadoop.ozone.om.TestOzoneManagerHAWithData"/>
     <Bug pattern="DLS_DEAD_LOCAL_STORE" />
   </Match>

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/TestCpuMetrics.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/TestCpuMetrics.java
@@ -1,0 +1,81 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.ozone;
+
+import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_HTTP_ADDRESS_KEY;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.util.concurrent.TimeoutException;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.Response;
+import org.apache.hadoop.hdds.HddsUtils;
+import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test /prom http endpoint to test availability of the next metrics.
+ *  <p>jvm_metrics_cpu_available_processors</p>
+ *  <p>jvm_metrics_cpu_system_load</p>
+ *  <p>jvm_metrics_cpu_jvm_load</p>
+ */
+public class TestCpuMetrics {
+
+  private static MiniOzoneCluster cluster;
+  private final OkHttpClient httpClient = new OkHttpClient();
+
+  @BeforeAll
+  public static void setup() throws InterruptedException, TimeoutException,
+      IOException {
+    OzoneConfiguration conf = new OzoneConfiguration();
+    cluster = MiniOzoneCluster.newBuilder(conf)
+        .setNumDatanodes(1).build();
+    cluster.waitForClusterToBeReady();
+  }
+
+  @Test
+  public void testCpuMetrics() throws IOException {
+    // given
+    String scmHttpServerUrl = "http://localhost:" +
+        HddsUtils.getPortNumberFromConfigKeys(cluster.getConf(),
+                OZONE_SCM_HTTP_ADDRESS_KEY).getAsInt();
+    Request prometheusMetricsRequest = new Request.Builder()
+        .url(scmHttpServerUrl + "/prom")
+        .build();
+
+    // when
+    Response metricsResponse = httpClient.newCall(prometheusMetricsRequest)
+        .execute();
+    String metricsResponseBodyContent = metricsResponse.body().string();
+
+    // then
+    assertTrue(metricsResponseBodyContent
+        .contains("jvm_metrics_cpu_available_processors"),
+          metricsResponseBodyContent);
+    assertTrue(metricsResponseBodyContent
+        .contains("jvm_metrics_cpu_system_load"),
+          metricsResponseBodyContent);
+    assertTrue(metricsResponseBodyContent
+        .contains("jvm_metrics_cpu_jvm_load"),
+          metricsResponseBodyContent);
+  }
+
+}


### PR DESCRIPTION
## What changes were proposed in this pull request?
Expose CPU load (process & system) and available processors metrics to Prometheus

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-8836

## How was this patch tested?
new integration test that's located in  hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/TestCpuMetrics.java
