### PR TITLE
HDDS-8791. Create acceptance test for offline recovery

### DIFF
--- a/hadoop-ozone/dist/src/main/compose/ozone/test-ec.sh
+++ b/hadoop-ozone/dist/src/main/compose/ozone/test-ec.sh
@@ -37,6 +37,7 @@ execute_robot_test scm -v PREFIX:${prefix} -N read-4-datanodes ec/read.robot
 docker-compose up -d --no-recreate --scale datanode=3
 execute_robot_test scm -v PREFIX:${prefix} -N read-3-datanodes ec/read.robot
 docker-compose up -d --no-recreate --scale datanode=5
+execute_robot_test scm -v container:1 -v count:5 -N EC-recovery replication/wait.robot
 
 stop_docker_env
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Test EC container reconstruction, by waiting for replica count to reach 5 after 2 nodes were shutdown (for online reconstruction test) and restarted.

https://issues.apache.org/jira/browse/HDDS-8791

## How was this patch tested?

New test.  Also checked the logs:

```
datanode_4  | 2023-06-14 18:01:32,007 [ContainerReplicationThread-0] INFO reconstruction.ECReconstructionCoordinatorTask: IN_PROGRESS reconstructECContainersCommand: containerID=1, replication=rs-3-2-1024k, missingIndexes=[2, 3], sources={1=493f541b-c7f3-4b67-8f6d-8d341b56bf6c(ozone_datanode_1.ozone_default/172.18.0.8), 4=4a76fdb2-a7c7-4f03-93cc-59392b2b01fb(ozone_datanode_2.ozone_default/172.18.0.7), 5=957afea6-7c0d-4fbe-9f0c-4873208ae6f7(ozone_datanode_3.ozone_default/172.18.0.10)}, targets={2=fba614af-5325-4851-82e7-01fd06c6e8a4(ozone_datanode_4.ozone_default/172.18.0.9), 3=d2833a0e-e69b-4a83-8052-dbdeb429cade(ozone_datanode_5.ozone_default/172.18.0.11)}
datanode_4  | 2023-06-14 18:01:47,648 [ContainerReplicationThread-0] INFO reconstruction.ECReconstructionCoordinatorTask: DONE reconstructECContainersCommand: containerID=1, replication=rs-3-2-1024k, missingIndexes=[2, 3], sources={1=493f541b-c7f3-4b67-8f6d-8d341b56bf6c(ozone_datanode_1.ozone_default/172.18.0.8), 4=4a76fdb2-a7c7-4f03-93cc-59392b2b01fb(ozone_datanode_2.ozone_default/172.18.0.7), 5=957afea6-7c0d-4fbe-9f0c-4873208ae6f7(ozone_datanode_3.ozone_default/172.18.0.10)}, targets={2=fba614af-5325-4851-82e7-01fd06c6e8a4(ozone_datanode_4.ozone_default/172.18.0.9), 3=d2833a0e-e69b-4a83-8052-dbdeb429cade(ozone_datanode_5.ozone_default/172.18.0.11)} in 15641 ms
```