### PR TITLE
HDDS-8857. [snapshot] UnsupportedOperationException for snapshot distcp operation.

### DIFF
--- a/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/OzonePathCapabilities.java
+++ b/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/OzonePathCapabilities.java
@@ -43,6 +43,7 @@ public final class OzonePathCapabilities {
     switch (validatePathCapabilityArgs(path, capability)) {
     case CommonPathCapabilities.FS_ACLS:
     case CommonPathCapabilities.FS_CHECKSUMS:
+    case CommonPathCapabilities.FS_SNAPSHOTS:
       return true;
     default:
       return false;


### PR DESCRIPTION
## What changes were proposed in this pull request?
Add Path capability for FS snapshots to prevent this exception.

https://issues.apache.org/jira/browse/HDDS-8857


## How was this patch tested?
Manually tested.
