### PR TITLE
HDDS-8864. Remove redundant checkAcls() when caller is volume owner during key or prefix access

### DIFF
--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneAclUtils.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneAclUtils.java
@@ -100,24 +100,26 @@ public final class OzoneAclUtils {
     // volume owner if current ugi user is volume owner else we need check
     //{OWNER} equals bucket owner for bucket/key/prefix.
     case PREFIX:
-      //OzoneNativeAuthorizer differs from Ranger Authorizer as Ranger requires
-      // only READ access on parent level access. OzoneNativeAuthorizer has
-      // different parent level access based on the child level access type
-      IAccessAuthorizer.ACLType parentAclRight = IAccessAuthorizer.ACLType.READ;
-      if (omMetadataReader.isNativeAuthorizerEnabled() && resType == BUCKET) {
-        parentAclRight = getParentNativeAcl(aclType, resType);
-      }
-      
-      omMetadataReader.checkAcls(OzoneObj.ResourceType.VOLUME, storeType,
-          parentAclRight, vol, bucket, key, user,
-          remoteAddress, hostName, true,
-          volOwner);
       if (isVolOwner) {
         omMetadataReader.checkAcls(resType, storeType,
             aclType, vol, bucket, key,
             user, remoteAddress, hostName, true,
             volOwner);
       } else {
+        IAccessAuthorizer.ACLType parentAclRight =
+            IAccessAuthorizer.ACLType.READ;
+        // OzoneNativeAuthorizer differs from Ranger Authorizer as Ranger
+        // requires only READ access on parent level access.
+        // OzoneNativeAuthorizer has different parent level access based on the
+        // child level access type.
+        if (omMetadataReader.isNativeAuthorizerEnabled() && resType == BUCKET) {
+          parentAclRight = getParentNativeAcl(aclType, resType);
+        }
+
+        omMetadataReader.checkAcls(OzoneObj.ResourceType.VOLUME, storeType,
+            parentAclRight, vol, bucket, key, user,
+            remoteAddress, hostName, true,
+            volOwner);
         omMetadataReader.checkAcls(resType, storeType,
             aclType, vol, bucket, key,
             user, remoteAddress, hostName, true,


### PR DESCRIPTION
## What changes were proposed in this pull request?

It is unnecessary to call `checkAcls()` twice when caller is volume owner in `OzoneAclUtils#checkAllAcls`.

Because the reason we had to split that into two calls in [HDDS-5903](https://issues.apache.org/jira/browse/HDDS-5903) is because Ranger only has one `{OWNER}` tag, and that we want `{OWNER}` tag used in bucket/key level policies to be filled in with the **bucket** owner during ACL check **when the caller is NOT the volume owner**.

In the case where the caller is the Ozone volume owner, this hierarchical check is already enforced by the authorizer (`OzoneNativeAuthorizer` or `RangerOzoneAuthorizer`) internally. Thus it is unnecessary.

Note: This has the potential side effect of having different number of audit log entries in different cases. i.e. There will be 1 audit log entry when bucket owner is volume owner with this PR. But there will still be 2 audit log entries if bucket owner is NOT the same as volume owner. Admittedly the goal should be that we should always emit only one entry for one operation.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-8864

## How was this patch tested?

- All existing tests should pass.