### PR TITLE
HDDS-8861. Replace usage of log4j2 Strings class.

### DIFF
--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/security/x509/certificate/utils/CertificateSignRequest.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/security/x509/certificate/utils/CertificateSignRequest.java
@@ -27,6 +27,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
+import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.validator.routines.DomainValidator;
 import org.apache.hadoop.hdds.conf.ConfigurationSource;
 import org.apache.hadoop.hdds.security.exception.SCMSecurityException;
@@ -35,7 +36,6 @@ import org.apache.hadoop.hdds.security.x509.exception.CertificateException;
 
 import com.google.common.base.Preconditions;
 import org.apache.hadoop.ozone.OzoneSecurityUtil;
-import org.apache.logging.log4j.util.Strings;
 import org.bouncycastle.asn1.ASN1EncodableVector;
 import org.bouncycastle.asn1.ASN1Object;
 import org.bouncycastle.asn1.ASN1ObjectIdentifier;
@@ -401,7 +401,7 @@ public final class CertificateSignRequest {
 
     public PKCS10CertificationRequest build() throws SCMSecurityException {
       Preconditions.checkNotNull(key, "KeyPair cannot be null");
-      Preconditions.checkArgument(Strings.isNotBlank(subject), "Subject " +
+      Preconditions.checkArgument(StringUtils.isNotBlank(subject), "Subject " +
           "cannot be blank");
 
       try {

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/security/x509/certificate/utils/SelfSignedCertificate.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/security/x509/certificate/utils/SelfSignedCertificate.java
@@ -30,6 +30,7 @@ import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
 
+import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.validator.routines.DomainValidator;
 import org.apache.hadoop.hdds.conf.ConfigurationSource;
 import org.apache.hadoop.hdds.security.exception.SCMSecurityException;
@@ -40,7 +41,6 @@ import org.apache.hadoop.util.Time;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
-import org.apache.logging.log4j.util.Strings;
 import org.bouncycastle.asn1.ASN1EncodableVector;
 import org.bouncycastle.asn1.ASN1Object;
 import org.bouncycastle.asn1.ASN1ObjectIdentifier;
@@ -307,12 +307,12 @@ public final class SelfSignedCertificate {
     public X509CertificateHolder build()
         throws SCMSecurityException, IOException {
       Preconditions.checkNotNull(key, "Key cannot be null");
-      Preconditions.checkArgument(Strings.isNotBlank(subject), "Subject " +
-          "cannot be blank");
-      Preconditions.checkArgument(Strings.isNotBlank(clusterID), "Cluster ID " +
-          "cannot be blank");
-      Preconditions.checkArgument(Strings.isNotBlank(scmID), "SCM ID cannot " +
-          "be blank");
+      Preconditions.checkArgument(StringUtils.isNotBlank(subject),
+          "Subject " + "cannot be blank");
+      Preconditions.checkArgument(StringUtils.isNotBlank(clusterID),
+          "Cluster ID " + "cannot be blank");
+      Preconditions.checkArgument(StringUtils.isNotBlank(scmID),
+          "SCM ID cannot " + "be blank");
 
       Preconditions.checkArgument(beginDate.isBefore(endDate), "Certificate " +
           "begin date should be before end date");

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/server/http/RatisNameRewriteSampleBuilder.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/server/http/RatisNameRewriteSampleBuilder.java
@@ -25,7 +25,7 @@ import java.util.regex.Pattern;
 
 import io.prometheus.client.Collector.MetricFamilySamples.Sample;
 import io.prometheus.client.dropwizard.samplebuilder.DefaultSampleBuilder;
-import org.apache.logging.log4j.util.Strings;
+import org.apache.commons.lang3.StringUtils;
 import static org.apache.ratis.metrics.RatisMetrics.RATIS_APPLICATION_NAME_METRICS;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -107,7 +107,7 @@ public class RatisNameRewriteSampleBuilder extends DefaultSampleBuilder {
         }
       }
     }
-    return Strings.join(nameParts, '.');
+    return StringUtils.join(nameParts, '.');
   }
 
 }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMHANodeDetails.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMHANodeDetails.java
@@ -18,6 +18,7 @@
 package org.apache.hadoop.hdds.scm.ha;
 
 import com.google.common.base.Preconditions;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.hadoop.hdds.conf.ConfigurationException;
 import org.apache.hadoop.hdds.conf.DefaultConfigManager;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
@@ -29,7 +30,6 @@ import org.apache.hadoop.net.NetUtils;
 import org.apache.hadoop.ozone.common.Storage;
 import org.apache.hadoop.ozone.ha.ConfUtils;
 import org.apache.hadoop.ozone.util.OzoneNetUtils;
-import org.apache.logging.log4j.util.Strings;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -173,7 +173,8 @@ public class SCMHANodeDetails {
               : "SCM is running in Non-HA without Ratis")
               + " Ratis SCM -> Non Ratis SCM or " +
               "Non HA SCM -> HA SCM is not supported";
-      if (Strings.isNotEmpty(conf.get(ScmConfigKeys.OZONE_SCM_HA_ENABLE_KEY))) {
+      if (StringUtils.isNotEmpty(
+          conf.get(ScmConfigKeys.OZONE_SCM_HA_ENABLE_KEY))) {
         throw new ConfigurationException(String.format("Invalid Config %s " +
                 "Provided ConfigValue: %s, Expected Config Value: %s. %s",
             ScmConfigKeys.OZONE_SCM_HA_ENABLE_KEY, scmHAEnabled,

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/rpc/RpcClient.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/rpc/RpcClient.java
@@ -46,6 +46,7 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.hadoop.crypto.CryptoInputStream;
 import org.apache.hadoop.crypto.CryptoOutputStream;
 import org.apache.hadoop.crypto.key.KeyProvider;
@@ -170,7 +171,6 @@ import static org.apache.hadoop.ozone.OzoneConsts.OZONE_MAXIMUM_ACCESS_ID_LENGTH
 import static org.apache.hadoop.ozone.security.acl.IAccessAuthorizer.ACLType.READ;
 import static org.apache.hadoop.ozone.security.acl.IAccessAuthorizer.ACLType.WRITE;
 
-import org.apache.logging.log4j.util.Strings;
 import org.apache.ratis.protocol.ClientId;
 import org.jetbrains.annotations.NotNull;
 import org.slf4j.Logger;
@@ -818,7 +818,7 @@ public class RpcClient implements ClientProtocol {
    */
   @Override
   public S3SecretValue getS3Secret(String kerberosID) throws IOException {
-    Preconditions.checkArgument(Strings.isNotBlank(kerberosID),
+    Preconditions.checkArgument(StringUtils.isNotBlank(kerberosID),
         "kerberosID cannot be null or empty.");
 
     return ozoneManagerClient.getS3Secret(kerberosID);
@@ -833,7 +833,7 @@ public class RpcClient implements ClientProtocol {
   @Override
   public S3SecretValue getS3Secret(String kerberosID, boolean createIfNotExist)
           throws IOException {
-    Preconditions.checkArgument(Strings.isNotBlank(kerberosID),
+    Preconditions.checkArgument(StringUtils.isNotBlank(kerberosID),
             "kerberosID cannot be null or empty.");
     // No need to check createIfNotExist here which is a primitive
     return ozoneManagerClient.getS3Secret(kerberosID, createIfNotExist);
@@ -844,9 +844,9 @@ public class RpcClient implements ClientProtocol {
    */
   public S3SecretValue setS3Secret(String accessId, String secretKey)
           throws IOException {
-    Preconditions.checkArgument(Strings.isNotBlank(accessId),
+    Preconditions.checkArgument(StringUtils.isNotBlank(accessId),
             "accessId cannot be null or empty.");
-    Preconditions.checkArgument(Strings.isNotBlank(secretKey),
+    Preconditions.checkArgument(StringUtils.isNotBlank(secretKey),
             "secretKey cannot be null or empty.");
     return ozoneManagerClient.setS3Secret(accessId, secretKey);
   }
@@ -856,7 +856,7 @@ public class RpcClient implements ClientProtocol {
    */
   @Override
   public void revokeS3Secret(String kerberosID) throws IOException {
-    Preconditions.checkArgument(Strings.isNotBlank(kerberosID),
+    Preconditions.checkArgument(StringUtils.isNotBlank(kerberosID),
             "kerberosID cannot be null or empty.");
 
     ozoneManagerClient.revokeS3Secret(kerberosID);
@@ -877,7 +877,7 @@ public class RpcClient implements ClientProtocol {
   @Override
   public void createTenant(String tenantId, TenantArgs tenantArgs)
       throws IOException {
-    Preconditions.checkArgument(Strings.isNotBlank(tenantId),
+    Preconditions.checkArgument(StringUtils.isNotBlank(tenantId),
         "tenantId cannot be null or empty.");
     Preconditions.checkNotNull(tenantArgs);
 
@@ -901,7 +901,7 @@ public class RpcClient implements ClientProtocol {
    */
   @Override
   public DeleteTenantState deleteTenant(String tenantId) throws IOException {
-    Preconditions.checkArgument(Strings.isNotBlank(tenantId),
+    Preconditions.checkArgument(StringUtils.isNotBlank(tenantId),
         "tenantId cannot be null or empty.");
     return ozoneManagerClient.deleteTenant(tenantId);
   }
@@ -915,11 +915,11 @@ public class RpcClient implements ClientProtocol {
   @Override
   public S3SecretValue tenantAssignUserAccessId(
       String username, String tenantId, String accessId) throws IOException {
-    Preconditions.checkArgument(Strings.isNotBlank(username),
+    Preconditions.checkArgument(StringUtils.isNotBlank(username),
         "username can't be null or empty.");
-    Preconditions.checkArgument(Strings.isNotBlank(tenantId),
+    Preconditions.checkArgument(StringUtils.isNotBlank(tenantId),
         "tenantId can't be null or empty.");
-    Preconditions.checkArgument(Strings.isNotBlank(accessId),
+    Preconditions.checkArgument(StringUtils.isNotBlank(accessId),
         "accessId can't be null or empty.");
     Preconditions.checkArgument(
         accessId.length() <= OZONE_MAXIMUM_ACCESS_ID_LENGTH, "accessId length ("
@@ -936,7 +936,7 @@ public class RpcClient implements ClientProtocol {
    */
   @Override
   public void tenantRevokeUserAccessId(String accessId) throws IOException {
-    Preconditions.checkArgument(Strings.isNotBlank(accessId),
+    Preconditions.checkArgument(StringUtils.isNotBlank(accessId),
         "accessId can't be null or empty.");
     ozoneManagerClient.tenantRevokeUserAccessId(accessId);
   }
@@ -952,9 +952,9 @@ public class RpcClient implements ClientProtocol {
   @Override
   public String createSnapshot(String volumeName,
       String bucketName, String snapshotName) throws IOException {
-    Preconditions.checkArgument(Strings.isNotBlank(volumeName),
+    Preconditions.checkArgument(StringUtils.isNotBlank(volumeName),
         "volume can't be null or empty.");
-    Preconditions.checkArgument(Strings.isNotBlank(bucketName),
+    Preconditions.checkArgument(StringUtils.isNotBlank(bucketName),
         "bucket can't be null or empty.");
     return ozoneManagerClient.createSnapshot(volumeName,
         bucketName, snapshotName);
@@ -970,11 +970,11 @@ public class RpcClient implements ClientProtocol {
   @Override
   public void deleteSnapshot(String volumeName,
       String bucketName, String snapshotName) throws IOException {
-    Preconditions.checkArgument(Strings.isNotBlank(volumeName),
+    Preconditions.checkArgument(StringUtils.isNotBlank(volumeName),
         "volume can't be null or empty.");
-    Preconditions.checkArgument(Strings.isNotBlank(bucketName),
+    Preconditions.checkArgument(StringUtils.isNotBlank(bucketName),
         "bucket can't be null or empty.");
-    Preconditions.checkArgument(Strings.isNotBlank(snapshotName),
+    Preconditions.checkArgument(StringUtils.isNotBlank(snapshotName),
         "snapshot name can't be null or empty.");
     ozoneManagerClient.deleteSnapshot(volumeName, bucketName, snapshotName);
   }
@@ -988,9 +988,9 @@ public class RpcClient implements ClientProtocol {
                                            int pageSize,
                                            boolean forceFullDiff)
       throws IOException {
-    Preconditions.checkArgument(Strings.isNotBlank(volumeName),
+    Preconditions.checkArgument(StringUtils.isNotBlank(volumeName),
         "volume can't be null or empty.");
-    Preconditions.checkArgument(Strings.isNotBlank(bucketName),
+    Preconditions.checkArgument(StringUtils.isNotBlank(bucketName),
         "bucket can't be null or empty.");
     return ozoneManagerClient.snapshotDiff(volumeName, bucketName,
         fromSnapshot, toSnapshot, token, pageSize, forceFullDiff);
@@ -1010,9 +1010,9 @@ public class RpcClient implements ClientProtocol {
   public List<OzoneSnapshot> listSnapshot(
       String volumeName, String bucketName, String snapshotPrefix,
       String prevSnapshot, int maxListResult) throws IOException {
-    Preconditions.checkArgument(Strings.isNotBlank(volumeName),
+    Preconditions.checkArgument(StringUtils.isNotBlank(volumeName),
         "volume can't be null or empty.");
-    Preconditions.checkArgument(Strings.isNotBlank(bucketName),
+    Preconditions.checkArgument(StringUtils.isNotBlank(bucketName),
         "bucket can't be null or empty.");
     return ozoneManagerClient.listSnapshot(volumeName, bucketName,
             snapshotPrefix, prevSnapshot, maxListResult).stream()
@@ -1031,7 +1031,7 @@ public class RpcClient implements ClientProtocol {
   public void tenantAssignAdmin(String accessId, String tenantId,
       boolean delegated)
       throws IOException {
-    Preconditions.checkArgument(Strings.isNotBlank(accessId),
+    Preconditions.checkArgument(StringUtils.isNotBlank(accessId),
         "accessId can't be null or empty.");
     // tenantId can be empty
     ozoneManagerClient.tenantAssignAdmin(accessId, tenantId, delegated);
@@ -1046,7 +1046,7 @@ public class RpcClient implements ClientProtocol {
   @Override
   public void tenantRevokeAdmin(String accessId, String tenantId)
       throws IOException {
-    Preconditions.checkArgument(Strings.isNotBlank(accessId),
+    Preconditions.checkArgument(StringUtils.isNotBlank(accessId),
         "accessId can't be null or empty.");
     // tenantId can be empty
     ozoneManagerClient.tenantRevokeAdmin(accessId, tenantId);
@@ -1061,7 +1061,7 @@ public class RpcClient implements ClientProtocol {
   @Override
   public TenantUserInfoValue tenantGetUserInfo(String userPrincipal)
       throws IOException {
-    Preconditions.checkArgument(Strings.isNotBlank(userPrincipal),
+    Preconditions.checkArgument(StringUtils.isNotBlank(userPrincipal),
         "userPrincipal can't be null or empty.");
     return ozoneManagerClient.tenantGetUserInfo(userPrincipal);
   }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/MiniOzoneClusterImpl.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/MiniOzoneClusterImpl.java
@@ -35,6 +35,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
+import org.apache.commons.lang3.StringUtils;
 import org.apache.hadoop.conf.StorageUnit;
 import org.apache.hadoop.hdds.DFSConfigKeysLegacy;
 import org.apache.hadoop.hdds.HddsConfigKeys;
@@ -80,7 +81,6 @@ import org.apache.hadoop.ozone.om.OzoneManager;
 import org.apache.hadoop.ozone.recon.ConfigurationProvider;
 import org.apache.hadoop.ozone.recon.ReconServer;
 import org.apache.hadoop.security.authentication.client.AuthenticationException;
-import org.apache.logging.log4j.util.Strings;
 import org.apache.ozone.test.GenericTestUtils;
 
 import org.apache.commons.io.FileUtils;
@@ -768,7 +768,8 @@ public class MiniOzoneClusterImpl implements MiniOzoneCluster {
       //TODO: HDDS-6897
       //Disabling Ratis for only of MiniOzoneClusterImpl.
       //MiniOzoneClusterImpl doesn't work with Ratis enabled SCM
-      if (Strings.isNotEmpty(conf.get(ScmConfigKeys.OZONE_SCM_HA_ENABLE_KEY))
+      if (StringUtils.isNotEmpty(
+          conf.get(ScmConfigKeys.OZONE_SCM_HA_ENABLE_KEY))
               && SCMHAUtils.isSCMHAEnabled(conf)) {
         scmStore.setSCMHAFlag(true);
         scmStore.persistCurrentState();

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/S3SecretManagerImpl.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/S3SecretManagerImpl.java
@@ -19,9 +19,9 @@
 package org.apache.hadoop.ozone.om;
 
 import com.google.common.base.Preconditions;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.hadoop.hdds.security.OzoneSecurityException;
 import org.apache.hadoop.ozone.om.helpers.S3SecretValue;
-import org.apache.logging.log4j.util.Strings;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -52,7 +52,7 @@ public class S3SecretManagerImpl implements S3SecretManager {
 
   @Override
   public S3SecretValue getSecret(String kerberosID) throws IOException {
-    Preconditions.checkArgument(Strings.isNotBlank(kerberosID),
+    Preconditions.checkArgument(StringUtils.isNotBlank(kerberosID),
         "kerberosID cannot be null or empty.");
     S3SecretValue cacheValue = s3SecretCache.get(kerberosID);
     if (cacheValue != null) {
@@ -69,7 +69,7 @@ public class S3SecretManagerImpl implements S3SecretManager {
   @Override
   public String getSecretString(String awsAccessKey)
       throws IOException {
-    Preconditions.checkArgument(Strings.isNotBlank(awsAccessKey),
+    Preconditions.checkArgument(StringUtils.isNotBlank(awsAccessKey),
         "awsAccessKeyId cannot be null or empty.");
     LOG.trace("Get secret for awsAccessKey:{}", awsAccessKey);
 

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/admin/om/DecommissionOMSubcommand.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/admin/om/DecommissionOMSubcommand.java
@@ -23,6 +23,8 @@ import java.net.InetAddress;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+
+import org.apache.commons.lang3.StringUtils;
 import org.apache.hadoop.hdds.cli.HddsVersionProvider;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.ozone.OmUtils;
@@ -31,7 +33,6 @@ import org.apache.hadoop.ozone.om.helpers.OMNodeDetails;
 import org.apache.hadoop.ozone.om.protocol.OMConfiguration;
 import org.apache.hadoop.ozone.om.protocolPB.OMAdminProtocolClientSideImpl;
 import org.apache.hadoop.security.UserGroupInformation;
-import org.apache.logging.log4j.util.Strings;
 import picocli.CommandLine;
 
 import java.util.concurrent.Callable;
@@ -180,7 +181,7 @@ public class DecommissionOMSubcommand implements Callable<Void> {
       }
     }
     if (!staleOMConfigs.isEmpty()) {
-      throw new IOException("OM(s) " + Strings.join(staleOMConfigs, ',') +
+      throw new IOException("OM(s) " + StringUtils.join(staleOMConfigs, ',') +
           " have not been updated with decommissioned nodes list or their" +
           " address for the decommissioning node does not match");
     }


### PR DESCRIPTION
## What changes were proposed in this pull request?
Replace usage of org.apache.logging.log4j.util.Strings  with org.apache.commons.lang3.StringUtils

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-8861

## How was this patch tested?
Verified the logic of isBlank/isNotEmpty/join methods are same across both versions.
