### PR TITLE
HDDS-8850. ReplicationManager: Add metrics for partial replication / reconstruction and cluster limit

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ECUnderReplicationHandler.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ECUnderReplicationHandler.java
@@ -462,6 +462,7 @@ public class ECUnderReplicationHandler implements UnhealthyReplicationHandler {
             " to fully replicate the decommission indexes for container {}." +
             " Requested {} received {}", container.getContainerID(),
             decomIndexes.size(), selectedDatanodes.size());
+        metrics.incrEcPartialReplicationForOutOfServiceReplicasTotal();
         throw new InsufficientDatanodesException(decomIndexes.size(),
             selectedDatanodes.size());
       }
@@ -546,6 +547,7 @@ public class ECUnderReplicationHandler implements UnhealthyReplicationHandler {
               " to fully replicate the maintenance indexes for container {}." +
               " Requested {} received {}", container.getContainerID(),
           maintIndexes.size(), targets.size());
+      metrics.incrEcPartialReplicationForOutOfServiceReplicasTotal();
       throw new InsufficientDatanodesException(maintIndexes.size(),
           targets.size());
     }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ECUnderReplicationHandler.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ECUnderReplicationHandler.java
@@ -64,6 +64,7 @@ public class ECUnderReplicationHandler implements UnhealthyReplicationHandler {
   private final PlacementPolicy containerPlacement;
   private final long currentContainerSize;
   private final ReplicationManager replicationManager;
+  private final ReplicationManagerMetrics metrics;
 
   ECUnderReplicationHandler(final PlacementPolicy containerPlacement,
       final ConfigurationSource conf, ReplicationManager replicationManager) {
@@ -72,6 +73,7 @@ public class ECUnderReplicationHandler implements UnhealthyReplicationHandler {
         .getStorageSize(ScmConfigKeys.OZONE_SCM_CONTAINER_SIZE,
             ScmConfigKeys.OZONE_SCM_CONTAINER_SIZE_DEFAULT, StorageUnit.BYTES);
     this.replicationManager = replicationManager;
+    this.metrics = replicationManager.getMetrics();
   }
 
   private boolean validatePlacement(List<DatanodeDetails> replicaNodes,
@@ -281,6 +283,7 @@ public class ECUnderReplicationHandler implements UnhealthyReplicationHandler {
         (ECReplicationConfig)container.getReplicationConfig();
     List<Integer> missingIndexes = replicaCount.unavailableIndexes(true);
     final int expectedTargetCount = missingIndexes.size();
+    boolean recoveryIsCritical = expectedTargetCount == repConfig.getParity();
     if (expectedTargetCount == 0) {
       return 0;
     }
@@ -307,7 +310,7 @@ public class ECUnderReplicationHandler implements UnhealthyReplicationHandler {
           // selection allows partial recovery
           0 < targetCount && targetCount < expectedTargetCount &&
           // recovery is not yet critical
-          expectedTargetCount < repConfig.getParity()) {
+          !recoveryIsCritical) {
 
         // check if placement exists when overloaded nodes are not excluded
         final List<DatanodeDetails> targetsMaybeOverloaded = getTargetDatanodes(
@@ -319,7 +322,7 @@ public class ECUnderReplicationHandler implements UnhealthyReplicationHandler {
                   + " target nodes to be fully reconstructed, but {} selected"
                   + " nodes are currently overloaded.",
               container.getContainerID(), expectedTargetCount, overloadedCount);
-
+          metrics.incrECPartialReconstructionSkippedTotal();
           throw new InsufficientDatanodesException(expectedTargetCount,
               targetCount);
         }
@@ -369,6 +372,11 @@ public class ECUnderReplicationHandler implements UnhealthyReplicationHandler {
         LOG.debug("Insufficient nodes were returned from the placement policy" +
             " to fully reconstruct container {}. Requested {} received {}",
             container.getContainerID(), expectedTargetCount, targetCount);
+        if (hasOverloaded && recoveryIsCritical) {
+          metrics.incrECPartialReconstructionCriticalTotal();
+        } else {
+          metrics.incrEcPartialReconstructionNoneOverloadedTotal();
+        }
         throw new InsufficientDatanodesException(expectedTargetCount,
             targetCount);
       }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/MisReplicationHandler.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/MisReplicationHandler.java
@@ -56,6 +56,7 @@ public abstract class MisReplicationHandler implements
   private final PlacementPolicy containerPlacement;
   private final long currentContainerSize;
   private final ReplicationManager replicationManager;
+  private final ReplicationManagerMetrics metrics;
 
   public MisReplicationHandler(
       final PlacementPolicy containerPlacement,
@@ -65,6 +66,7 @@ public abstract class MisReplicationHandler implements
             ScmConfigKeys.OZONE_SCM_CONTAINER_SIZE,
             ScmConfigKeys.OZONE_SCM_CONTAINER_SIZE_DEFAULT, StorageUnit.BYTES);
     this.replicationManager = replicationManager;
+    this.metrics = replicationManager.getMetrics();
   }
 
   protected ReplicationManager getReplicationManager() {
@@ -164,6 +166,11 @@ public abstract class MisReplicationHandler implements
 
     int found = targetDatanodes.size();
     if (found < requiredNodes) {
+      if (container.getReplicationType() == HddsProtos.ReplicationType.EC) {
+        metrics.incrEcPartialReplicationForMisReplicationTotal();
+      } else {
+        metrics.incrPartialReplicationForMisReplicationTotal();
+      }
       LOG.warn("Placement Policy {} found only {} nodes for Container: {}," +
           " number of required nodes: {}, usedNodes : {}",
           containerPlacement.getClass(), found,

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/RatisUnderReplicationHandler.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/RatisUnderReplicationHandler.java
@@ -55,6 +55,7 @@ public class RatisUnderReplicationHandler
   private final PlacementPolicy placementPolicy;
   private final long currentContainerSize;
   private final ReplicationManager replicationManager;
+  private final ReplicationManagerMetrics metrics;
 
   public RatisUnderReplicationHandler(final PlacementPolicy placementPolicy,
       final ConfigurationSource conf,
@@ -64,6 +65,7 @@ public class RatisUnderReplicationHandler
         .getStorageSize(ScmConfigKeys.OZONE_SCM_CONTAINER_SIZE,
             ScmConfigKeys.OZONE_SCM_CONTAINER_SIZE_DEFAULT, StorageUnit.BYTES);
     this.replicationManager = replicationManager;
+    this.metrics = replicationManager.getMetrics();
   }
 
   /**
@@ -128,6 +130,7 @@ public class RatisUnderReplicationHandler
           "additional replicas needed: {}",
           containerInfo, targetDatanodes.size(),
           replicaCount.additionalReplicaNeeded());
+      metrics.incrPartialReplicationTotal();
       throw new InsufficientDatanodesException(
           replicaCount.additionalReplicaNeeded(), targetDatanodes.size());
     }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ReplicationManagerMetrics.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ReplicationManagerMetrics.java
@@ -207,6 +207,14 @@ public final class ReplicationManagerMetrics implements MetricsSource {
       "insufficient nodes available.")
   private MutableCounterLong partialReplicationTotal;
 
+  @Metric("Number of times partial replication occurred to fix a " +
+      "mis-replicated ratis container due to insufficient nodes available.")
+  private MutableCounterLong partialReplicationForMisReplicationTotal;
+
+  @Metric("Number of times partial replication occurred to fix a " +
+      "mis-replicated EC container due to insufficient nodes available.")
+  private MutableCounterLong ecPartialReplicationForMisReplicationTotal;
+
   @Metric("NUmber of Reconstruct EC Container commands that could not be sent "
       + "due to the pending commands on the target datanode")
   private MutableCounterLong ecReconstructionCmdsDeferredTotal;
@@ -302,6 +310,8 @@ public final class ReplicationManagerMetrics implements MetricsSource {
     ecPartialReconstructionNoneOverloadedTotal.snapshot(builder, all);
     ecPartialReplicationForOutOfServiceReplicasTotal.snapshot(builder, all);
     partialReplicationTotal.snapshot(builder, all);
+    ecPartialReplicationForMisReplicationTotal.snapshot(builder, all);
+    partialReplicationForMisReplicationTotal.snapshot(builder, all);
   }
 
   public void unRegister() {
@@ -581,6 +591,22 @@ public final class ReplicationManagerMetrics implements MetricsSource {
 
   public void incrPartialReplicationTotal() {
     this.partialReplicationTotal.incr();
+  }
+
+  public void incrEcPartialReplicationForMisReplicationTotal() {
+    this.ecPartialReplicationForMisReplicationTotal.incr();
+  }
+
+  public long getEcPartialReplicationForMisReplicationTotal() {
+    return this.ecPartialReplicationForMisReplicationTotal.value();
+  }
+
+  public void incrPartialReplicationForMisReplicationTotal() {
+    this.partialReplicationForMisReplicationTotal.incr();
+  }
+
+  public long getPartialReplicationForMisReplicationTotal() {
+    return this.partialReplicationForMisReplicationTotal.value();
   }
 
 }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ReplicationManagerMetrics.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ReplicationManagerMetrics.java
@@ -203,6 +203,10 @@ public final class ReplicationManagerMetrics implements MetricsSource {
       "replicas were not all replicated due to insufficient nodes available.")
   private MutableCounterLong ecPartialReplicationForOutOfServiceReplicasTotal;
 
+  @Metric("Number of times partial Ratis replication occurred due to " +
+      "insufficient nodes available.")
+  private MutableCounterLong partialReplicationTotal;
+
   @Metric("NUmber of Reconstruct EC Container commands that could not be sent "
       + "due to the pending commands on the target datanode")
   private MutableCounterLong ecReconstructionCmdsDeferredTotal;
@@ -297,6 +301,7 @@ public final class ReplicationManagerMetrics implements MetricsSource {
     ecPartialReconstructionCriticalTotal.snapshot(builder, all);
     ecPartialReconstructionNoneOverloadedTotal.snapshot(builder, all);
     ecPartialReplicationForOutOfServiceReplicasTotal.snapshot(builder, all);
+    partialReplicationTotal.snapshot(builder, all);
   }
 
   public void unRegister() {
@@ -568,6 +573,14 @@ public final class ReplicationManagerMetrics implements MetricsSource {
 
   public void incrEcPartialReplicationForOutOfServiceReplicasTotal() {
     this.ecPartialReplicationForOutOfServiceReplicasTotal.incr();
+  }
+
+  public long getPartialReplicationTotal() {
+    return partialReplicationTotal.value();
+  }
+
+  public void incrPartialReplicationTotal() {
+    this.partialReplicationTotal.incr();
   }
 
 }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ReplicationManagerMetrics.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ReplicationManagerMetrics.java
@@ -155,6 +155,10 @@ public final class ReplicationManagerMetrics implements MetricsSource {
       " due to the configured limit.")
   private MutableCounterLong inflightDeletionSkippedTotal;
 
+  @Metric("Number of times under replication processing has paused due to" +
+      " reaching the cluster inflight replication limit.")
+  private MutableCounterLong pendingReplicationLimitReachedTotal;
+
   private MetricsRegistry registry;
 
   private final ReplicationManager replicationManager;
@@ -272,6 +276,7 @@ public final class ReplicationManagerMetrics implements MetricsSource {
     ecReconstructionCmdsDeferredTotal.snapshot(builder, all);
     deleteContainerCmdsDeferredTotal.snapshot(builder, all);
     replicateContainerCmdsDeferredTotal.snapshot(builder, all);
+    pendingReplicationLimitReachedTotal.snapshot(builder, all);
   }
 
   public void unRegister() {
@@ -503,6 +508,14 @@ public final class ReplicationManagerMetrics implements MetricsSource {
 
   public long getReplicateContainerCmdsDeferredTotal() {
     return replicateContainerCmdsDeferredTotal.value();
+  }
+
+  public void incrPendingReplicationLimitReachedTotal() {
+    this.pendingReplicationLimitReachedTotal.incr();
+  }
+
+  public long getPendingReplicationLimitReachedTotal() {
+    return pendingReplicationLimitReachedTotal.value();
   }
 
 }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ReplicationManagerMetrics.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ReplicationManagerMetrics.java
@@ -187,6 +187,18 @@ public final class ReplicationManagerMetrics implements MetricsSource {
   @Metric("Number of EC replicas scheduled for delete which timed out.")
   private MutableCounterLong ecReplicaDeleteTimeoutTotal;
 
+  @Metric("Number of times partial EC reconstruction was needed due to " +
+      "overloaded nodes, but skipped as there was still sufficient redundancy.")
+  private MutableCounterLong ecPartialReconstructionSkippedTotal;
+
+  @Metric("Number of times partial EC reconstruction was used due to " +
+      "insufficient nodes available and reconstruction was critical.")
+  private MutableCounterLong ecPartialReconstructionCriticalTotal;
+
+  @Metric("Number of time partial EC reconstruction was used due to " +
+      "insufficient nodes available and with no overloaded nodes.")
+  private MutableCounterLong ecPartialReconstructionNoneOverloadedTotal;
+
   @Metric("NUmber of Reconstruct EC Container commands that could not be sent "
       + "due to the pending commands on the target datanode")
   private MutableCounterLong ecReconstructionCmdsDeferredTotal;
@@ -277,6 +289,9 @@ public final class ReplicationManagerMetrics implements MetricsSource {
     deleteContainerCmdsDeferredTotal.snapshot(builder, all);
     replicateContainerCmdsDeferredTotal.snapshot(builder, all);
     pendingReplicationLimitReachedTotal.snapshot(builder, all);
+    ecPartialReconstructionSkippedTotal.snapshot(builder, all);
+    ecPartialReconstructionCriticalTotal.snapshot(builder, all);
+    ecPartialReconstructionNoneOverloadedTotal.snapshot(builder, all);
   }
 
   public void unRegister() {
@@ -516,6 +531,30 @@ public final class ReplicationManagerMetrics implements MetricsSource {
 
   public long getPendingReplicationLimitReachedTotal() {
     return pendingReplicationLimitReachedTotal.value();
+  }
+
+  public long getECPartialReconstructionSkippedTotal() {
+    return ecPartialReconstructionSkippedTotal.value();
+  }
+
+  public void incrECPartialReconstructionSkippedTotal() {
+    this.ecPartialReconstructionSkippedTotal.incr();
+  }
+
+  public long getECPartialReconstructionCriticalTotal() {
+    return ecPartialReconstructionCriticalTotal.value();
+  }
+
+  public void incrECPartialReconstructionCriticalTotal() {
+    this.ecPartialReconstructionCriticalTotal.incr();
+  }
+
+  public long getEcPartialReconstructionNoneOverloadedTotal() {
+    return ecPartialReconstructionNoneOverloadedTotal.value();
+  }
+
+  public void incrEcPartialReconstructionNoneOverloadedTotal() {
+    this.ecPartialReconstructionNoneOverloadedTotal.incr();
   }
 
 }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ReplicationManagerMetrics.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ReplicationManagerMetrics.java
@@ -195,9 +195,13 @@ public final class ReplicationManagerMetrics implements MetricsSource {
       "insufficient nodes available and reconstruction was critical.")
   private MutableCounterLong ecPartialReconstructionCriticalTotal;
 
-  @Metric("Number of time partial EC reconstruction was used due to " +
+  @Metric("Number of times partial EC reconstruction was used due to " +
       "insufficient nodes available and with no overloaded nodes.")
   private MutableCounterLong ecPartialReconstructionNoneOverloadedTotal;
+
+  @Metric("Number of times EC decommissioning or entering maintenance mode " +
+      "replicas were not all replicated due to insufficient nodes available.")
+  private MutableCounterLong ecPartialReplicationForOutOfServiceReplicasTotal;
 
   @Metric("NUmber of Reconstruct EC Container commands that could not be sent "
       + "due to the pending commands on the target datanode")
@@ -292,6 +296,7 @@ public final class ReplicationManagerMetrics implements MetricsSource {
     ecPartialReconstructionSkippedTotal.snapshot(builder, all);
     ecPartialReconstructionCriticalTotal.snapshot(builder, all);
     ecPartialReconstructionNoneOverloadedTotal.snapshot(builder, all);
+    ecPartialReplicationForOutOfServiceReplicasTotal.snapshot(builder, all);
   }
 
   public void unRegister() {
@@ -555,6 +560,14 @@ public final class ReplicationManagerMetrics implements MetricsSource {
 
   public void incrEcPartialReconstructionNoneOverloadedTotal() {
     this.ecPartialReconstructionNoneOverloadedTotal.incr();
+  }
+
+  public long getEcPartialReplicationForOutOfServiceReplicasTotal() {
+    return ecPartialReplicationForOutOfServiceReplicasTotal.value();
+  }
+
+  public void incrEcPartialReplicationForOutOfServiceReplicasTotal() {
+    this.ecPartialReplicationForOutOfServiceReplicasTotal.incr();
   }
 
 }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/UnhealthyReplicationProcessor.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/UnhealthyReplicationProcessor.java
@@ -103,6 +103,8 @@ public abstract class UnhealthyReplicationProcessor<HealthResult extends
           inflightOperationLimitReached(replicationManager, inflightLimit)) {
         LOG.info("The maximum number of pending replicas ({}) are scheduled. " +
             "Ending the iteration.", inflightLimit);
+        replicationManager
+            .getMetrics().incrPendingReplicationLimitReachedTotal();
         break;
       }
       HealthResult healthResult =

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestECMisReplicationHandler.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestECMisReplicationHandler.java
@@ -45,6 +45,7 @@ import java.util.Set;
 import static java.util.Collections.singletonList;
 import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.NodeOperationalState.IN_MAINTENANCE;
 import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.NodeOperationalState.IN_SERVICE;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
@@ -216,6 +217,8 @@ public class TestECMisReplicationHandler extends TestMisReplicationHandler {
     assertThrows(InsufficientDatanodesException.class,
         () -> testMisReplication(availableReplicas, Collections.emptyList(),
             0, 2, 1));
+    assertEquals(1,
+        getMetrics().getEcPartialReplicationForMisReplicationTotal());
   }
 
   @Override

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestECUnderReplicationHandler.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestECUnderReplicationHandler.java
@@ -765,6 +765,8 @@ public class TestECUnderReplicationHandler {
     SCMCommand<?> cmd = commandsSent.iterator().next().getValue();
     assertEquals(
         SCMCommandProto.Type.replicateContainerCommand, cmd.getType());
+    assertEquals(1,
+        metrics.getEcPartialReplicationForOutOfServiceReplicasTotal());
   }
 
   @Test
@@ -788,6 +790,11 @@ public class TestECUnderReplicationHandler {
     SCMCommand<?> cmd = commandsSent.iterator().next().getValue();
     assertEquals(
         SCMCommandProto.Type.replicateContainerCommand, cmd.getType());
+    // The partial recovery here is due to overloaded nodes, not insufficient
+    // nodes. The "deferred" metric should be updated when all sources are
+    // overloaded.
+    assertEquals(0,
+        metrics.getEcPartialReplicationForOutOfServiceReplicasTotal());
   }
 
   @Test
@@ -813,6 +820,8 @@ public class TestECUnderReplicationHandler {
     SCMCommand<?> cmd = commandsSent.iterator().next().getValue();
     assertEquals(
         SCMCommandProto.Type.replicateContainerCommand, cmd.getType());
+    assertEquals(1,
+        metrics.getEcPartialReplicationForOutOfServiceReplicasTotal());
   }
 
   @Test
@@ -837,6 +846,11 @@ public class TestECUnderReplicationHandler {
     SCMCommand<?> cmd = commandsSent.iterator().next().getValue();
     assertEquals(
         SCMCommandProto.Type.replicateContainerCommand, cmd.getType());
+    // The partial recovery here is due to overloaded nodes, not insufficient
+    // nodes. The "deferred" metric should be updated when all sources are
+    // overloaded.
+    assertEquals(0,
+        metrics.getEcPartialReplicationForOutOfServiceReplicasTotal());
   }
 
   @Test

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestECUnderReplicationHandler.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestECUnderReplicationHandler.java
@@ -110,6 +110,7 @@ public class TestECUnderReplicationHandler {
   private ContainerInfo container;
   private NodeManager nodeManager;
   private ReplicationManager replicationManager;
+  private ReplicationManagerMetrics metrics;
   private OzoneConfiguration conf;
   private PlacementPolicy policy;
   private static final int DATA = 3;
@@ -137,6 +138,8 @@ public class TestECUnderReplicationHandler {
         new ReplicationManager.ReplicationManagerConfiguration();
     when(replicationManager.getConfig())
         .thenReturn(rmConf);
+    metrics = ReplicationManagerMetrics.create(replicationManager);
+    when(replicationManager.getMetrics()).thenReturn(metrics);
 
     when(replicationManager.getNodeStatus(any(DatanodeDetails.class)))
         .thenAnswer(invocation -> {
@@ -200,6 +203,7 @@ public class TestECUnderReplicationHandler {
     assertEquals(e.getRequiredNodes() - excluded.size(), e.getAvailableNodes());
     verify(replicationManager, never())
         .sendThrottledReconstructionCommand(any(), any());
+    assertEquals(1, metrics.getECPartialReconstructionSkippedTotal());
   }
 
   private static UnderReplicatedHealthResult mockUnderReplicated(
@@ -258,6 +262,7 @@ public class TestECUnderReplicationHandler {
     assertEquals(e.getRequiredNodes() - excluded.size(), e.getAvailableNodes());
     verify(replicationManager, times(1))
         .sendThrottledReconstructionCommand(any(), any());
+    assertEquals(1, metrics.getECPartialReconstructionCriticalTotal());
   }
 
   @Test
@@ -711,6 +716,7 @@ public class TestECUnderReplicationHandler {
     ReconstructECContainersCommand cmd = (ReconstructECContainersCommand)
         commandsSent.iterator().next().getValue();
     assertEquals(1, cmd.getTargetDatanodes().size());
+    assertEquals(1, metrics.getEcPartialReconstructionNoneOverloadedTotal());
   }
 
   @Test

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestMisReplicationHandler.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestMisReplicationHandler.java
@@ -72,6 +72,7 @@ public abstract class TestMisReplicationHandler {
   private Set<Pair<DatanodeDetails, SCMCommand<?>>> commandsSent;
   private final AtomicBoolean throwThrottledException =
       new AtomicBoolean(false);
+  private ReplicationManagerMetrics metrics;
 
   protected void setup(ReplicationConfig repConfig)
       throws NodeNotFoundException, CommandTargetOverloadedException,
@@ -89,6 +90,8 @@ public abstract class TestMisReplicationHandler {
         conf.getObject(ReplicationManagerConfiguration.class);
     Mockito.when(replicationManager.getConfig())
         .thenReturn(rmConf);
+    metrics = ReplicationManagerMetrics.create(replicationManager);
+    Mockito.when(replicationManager.getMetrics()).thenReturn(metrics);
 
     commandsSent = new HashSet<>();
     ReplicationTestUtil.mockRMSendDatanodeCommand(
@@ -105,6 +108,10 @@ public abstract class TestMisReplicationHandler {
 
   protected ReplicationManager getReplicationManager() {
     return replicationManager;
+  }
+
+  protected ReplicationManagerMetrics getMetrics() {
+    return metrics;
   }
 
   protected void setThrowThrottledException(boolean showThrow) {

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestRatisUnderReplicationHandler.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestRatisUnderReplicationHandler.java
@@ -76,6 +76,7 @@ public class TestRatisUnderReplicationHandler {
   private PlacementPolicy policy;
   private ReplicationManager replicationManager;
   private Set<Pair<DatanodeDetails, SCMCommand<?>>> commandsSent;
+  private ReplicationManagerMetrics metrics;
 
   @Before
   public void setup() throws NodeNotFoundException,
@@ -93,6 +94,8 @@ public class TestRatisUnderReplicationHandler {
     Mockito.when(replicationManager.getConfig())
         .thenReturn(ozoneConfiguration.getObject(
             ReplicationManagerConfiguration.class));
+    metrics = ReplicationManagerMetrics.create(replicationManager);
+    Mockito.when(replicationManager.getMetrics()).thenReturn(metrics);
 
     /*
       Return NodeStatus with NodeOperationalState as specified in
@@ -220,6 +223,7 @@ public class TestRatisUnderReplicationHandler {
     Assert.assertThrows(IOException.class,
         () -> handler.processAndSendCommands(replicas,
             Collections.emptyList(), getUnderReplicatedHealthResult(), 2));
+    Assert.assertEquals(0, metrics.getPartialReplicationTotal());
   }
 
   @Test
@@ -239,6 +243,7 @@ public class TestRatisUnderReplicationHandler {
     // One command should be sent to the replication manager as we could only
     // fine one node rather than two.
     Assert.assertEquals(1, commandsSent.size());
+    Assert.assertEquals(1, metrics.getPartialReplicationTotal());
   }
 
   @Test

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestUnderReplicatedProcessor.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestUnderReplicatedProcessor.java
@@ -44,6 +44,7 @@ public class TestUnderReplicatedProcessor {
   private ECReplicationConfig repConfig;
   private UnderReplicatedProcessor underReplicatedProcessor;
   private ReplicationQueue queue;
+  private ReplicationManagerMetrics rmMetrics;
 
   @Before
   public void setup() {
@@ -57,8 +58,7 @@ public class TestUnderReplicatedProcessor {
     repConfig = new ECReplicationConfig(3, 2);
     Mockito.when(replicationManager.shouldRun()).thenReturn(true);
     Mockito.when(replicationManager.getConfig()).thenReturn(rmConf);
-    ReplicationManagerMetrics rmMetrics =
-        ReplicationManagerMetrics.create(replicationManager);
+    rmMetrics = ReplicationManagerMetrics.create(replicationManager);
     Mockito.when(replicationManager.getMetrics())
         .thenReturn(rmMetrics);
     Mockito.when(replicationManager.getReplicationInFlightLimit())
@@ -132,6 +132,7 @@ public class TestUnderReplicatedProcessor {
     // We should have processed the message now
     Mockito.verify(replicationManager, Mockito.times(1))
         .processUnderReplicatedContainer(any());
+    assertEquals(1, rmMetrics.getPendingReplicationLimitReachedTotal());
   }
 
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Add additional metrics to ReplicationManagerMetrics:

  * PendingReplicationClusterLimitReached - incremented if the cluster wide limit has been reached.
  * Partial Reconstruction metrics to indicate when EC reconstruction is not able to recover all the indexes, only some of them.
  * Partial replication metrics for EC decommission / maintenance replicas and Ratis replication.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-8850

## How was this patch tested?

Tests modified to check the new metrics.
