### PR TITLE
HDDS-8872. New bootstrapped OM shouldn’t shutdown if ratis applies previous transactions

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestAddRemoveOzoneManager.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestAddRemoveOzoneManager.java
@@ -264,7 +264,6 @@ public class TestAddRemoveOzoneManager {
     newNodeId = "omNode-bootstrap-2";
     try {
       cluster.bootstrapOzoneManager(newNodeId, false, true);
-      Assert.fail();
     } catch (IOException e) {
       Assert.assertTrue(omLog.getOutput().contains("Couldn't add OM " +
           newNodeId + " to peer list."));

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
@@ -1813,7 +1813,7 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
     }
 
     if (remoteOMConfig.getCurrentPeerList().contains(this.getOMNodeId())) {
-      throw new IOException("Remote OM " + remoteNodeId + " already contains " +
+      LOG.warn("Remote OM " + remoteNodeId + " already contains " +
           "bootstrapping OM(" + getOMNodeId() + ") as part of its Raft group " +
           "peers.");
     }
@@ -1958,7 +1958,9 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
 
         if (newOMNodeDetails == null) {
           // If new node information is not present in the newly loaded
-          // configuration also, throw an exception
+          // configuration also, throw an exception.
+          // This case can also come when we have decommissioned a node and
+          // ratis will apply previous transactions to add that node back.
           throw new IOException("There is no OM configuration for node ID "
               + newOMNodeId + " in ozone-site.xml.");
         }
@@ -1966,7 +1968,7 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
     } catch (IOException e) {
       LOG.error("{}: Couldn't add OM {} to peer list.", getOMNodeId(),
           newOMNodeId);
-      exitManager.exitSystem(1, e.getLocalizedMessage(), e, LOG);
+      return;
     }
 
     if (omRatisSnapshotProvider == null) {

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
@@ -1813,9 +1813,10 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
     }
 
     if (remoteOMConfig.getCurrentPeerList().contains(this.getOMNodeId())) {
-      LOG.warn("Remote OM " + remoteNodeId + " already contains " +
-          "bootstrapping OM(" + getOMNodeId() + ") as part of its Raft group " +
-          "peers.");
+      LOG.warn(
+          "Remote OM {} already contains bootstrapping OM({}) as part of "
+              + "its Raft group peers.",
+          remoteNodeId, getOMNodeId());
     }
 
     OMNodeDetails omNodeDetailsInRemoteConfig = remoteOMConfig

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
@@ -1962,14 +1962,15 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
           // configuration also, throw an exception.
           // This case can also come when we have decommissioned a node and
           // ratis will apply previous transactions to add that node back.
-          throw new IOException("There is no OM configuration for node ID "
-              + newOMNodeId + " in ozone-site.xml.");
+          LOG.error(
+              "There is no OM configuration for node ID {} in ozone-site.xml.",
+              newOMNodeId);
+          return;
         }
       }
     } catch (IOException e) {
       LOG.error("{}: Couldn't add OM {} to peer list.", getOMNodeId(),
           newOMNodeId);
-      return;
     }
 
     if (omRatisSnapshotProvider == null) {


### PR DESCRIPTION
## What changes were proposed in this pull request?

When we decommission an OM node and then try to bootstrap a new OM node then ratis try to apply previous transactions and the call goes to "addOMNodeToPeers()" of OzoneManager.java which results in throwing off an exception as it's not able to find the details of the decommissioned node in the conf which is correct as node doesn’t exist as an OM now. So, we are changing the exception to a warning message so that process flow shouldn't stop and newly bootstrapped OM doesn’t get shut down.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-8872

## How was this patch tested?

Tested Manually.
