### PR TITLE
HDDS-8878. When renaming a file with s3 presign url, special characters appear in garbled code

### DIFF
--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/ObjectEndpoint.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/ObjectEndpoint.java
@@ -44,6 +44,7 @@ import java.io.EOFException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.UnsupportedEncodingException;
+import java.net.URLEncoder;
 import java.text.ParseException;
 import java.time.Instant;
 import java.time.ZoneId;
@@ -400,7 +401,12 @@ public class ObjectEndpoint extends EndpointBase {
           headerValue = queryValue;
         }
         if (headerValue != null) {
-          responseBuilder.header(entry.getKey(), headerValue);
+          try {
+            responseBuilder.header(entry.getKey(),
+                URLEncoder.encode(headerValue, "UTF-8"));
+          } catch (UnsupportedEncodingException e) {
+            responseBuilder.header(entry.getKey(), headerValue);
+          }
         }
       }
       addLastModifiedDate(responseBuilder, keyDetails);

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/ObjectEndpoint.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/ObjectEndpoint.java
@@ -44,7 +44,6 @@ import java.io.EOFException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.UnsupportedEncodingException;
-import java.net.URLEncoder;
 import java.text.ParseException;
 import java.time.Instant;
 import java.time.ZoneId;
@@ -387,7 +386,7 @@ public class ObjectEndpoint extends EndpointBase {
       // http://localhost:9878/bucket/key?response-expires=1&response-expires=2
       // only response-expires=1 is valid
       MultivaluedMap<String, String> queryParams = context
-          .getUriInfo().getQueryParameters();
+          .getUriInfo().getQueryParameters(false);
 
       for (Map.Entry<String, String> entry :
           overrideQueryParameter.entrySet()) {
@@ -401,12 +400,7 @@ public class ObjectEndpoint extends EndpointBase {
           headerValue = queryValue;
         }
         if (headerValue != null) {
-          try {
-            responseBuilder.header(entry.getKey(),
-                URLEncoder.encode(headerValue, "UTF-8"));
-          } catch (UnsupportedEncodingException e) {
-            responseBuilder.header(entry.getKey(), headerValue);
-          }
+          responseBuilder.header(entry.getKey(), headerValue);
         }
       }
       addLastModifiedDate(responseBuilder, keyDetails);


### PR DESCRIPTION
## What changes were proposed in this pull request?

I generated the download link via s3 presign url and renamed it via response-content-disposition, if the target name has something like other non-English content, it appears garbled.

like this:
![image](https://github.com/apache/ozone/assets/5122636/d63d91cd-c5df-4955-8a80-365847cab222)


Presign url like this:
```
http://s3endpoint/bucketname/keyname?response-content-disposition=attachment%3B%20filename%20%3D%22%E6%95%B0%E6%8D%AE%E4%BA%91%E7%9B%98%E5%8A%9F%E8%83%BD%E8%A7%A3%E8%AF%BB.pdf%22&X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Date=20230616T093651Z&X-Amz-SignedHeaders=host&X-Amz-Expires=359999&X-Amz-Credential=ASU4JITCHORSVMEOQY9X%2F20230616%2Fozone-test%2Fs3%2Faws4_request&X-Amz-Signature=44962e707bf044e76379f445b03afefa3f31fdf72bd5d0dfd0f1c9cfd8e3ede7 
```



## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-8878


## How was this patch tested?


aws s3 java sdk generates presign url code similar to:
```
GeneratePresignedUrlRequest generatePresignedUrlRequest =
    new GeneratePresignedUrlRequest(bucketName, key);

generatePresignedUrlRequest
    .setExpiration(new Date(System.currentTimeMillis() + 3600 * 100000));

ResponseHeaderOverrides responseHeaderOverrides =
    new ResponseHeaderOverrides();
responseHeaderOverrides.setContentDisposition("attachment; filename =\"测试.pdf\"");


generatePresignedUrlRequest.setResponseHeaders(responseHeaderOverrides);

final URL url = s3.generatePresignedUrl(generatePresignedUrlRequest);

System.out.println("get url:" + url); 
```