### PR TITLE
HDDS-8868. Support CommandHandler Metrics

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/helpers/CommandHandlerMetrics.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/helpers/CommandHandlerMetrics.java
@@ -1,0 +1,130 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.ozone.container.common.helpers;
+
+import org.apache.hadoop.hdds.annotation.InterfaceAudience;
+import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.SCMCommandProto.Type;
+import org.apache.hadoop.metrics2.MetricsCollector;
+import org.apache.hadoop.metrics2.MetricsInfo;
+import org.apache.hadoop.metrics2.MetricsRecordBuilder;
+import org.apache.hadoop.metrics2.MetricsSource;
+import org.apache.hadoop.metrics2.MetricsSystem;
+import org.apache.hadoop.metrics2.lib.DefaultMetricsSystem;
+import org.apache.hadoop.ozone.container.common.statemachine.commandhandler.CommandHandler;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.apache.hadoop.ozone.container.common.helpers.CommandHandlerMetrics.CommandMetricsMetricsInfo.TotalRunTimeMs;
+import static org.apache.hadoop.ozone.container.common.helpers.CommandHandlerMetrics.CommandMetricsMetricsInfo.QueueWaitingTaskCount;
+import static org.apache.hadoop.ozone.container.common.helpers.CommandHandlerMetrics.CommandMetricsMetricsInfo.InvocationCount;
+import static org.apache.hadoop.ozone.container.common.helpers.CommandHandlerMetrics.CommandMetricsMetricsInfo.ThreadPoolActivePoolSize;
+import static org.apache.hadoop.ozone.container.common.helpers.CommandHandlerMetrics.CommandMetricsMetricsInfo.ThreadPoolMaxPoolSize;
+import static org.apache.hadoop.ozone.container.common.helpers.CommandHandlerMetrics.CommandMetricsMetricsInfo.CommandReceivedCount;
+
+/**
+ * This class collects and exposes metrics for CommandHandlerMetrics.
+ */
+@InterfaceAudience.Private
+public final class CommandHandlerMetrics implements MetricsSource {
+  enum CommandMetricsMetricsInfo implements MetricsInfo {
+    Command("The type of the SCM command"),
+    TotalRunTimeMs("The total runtime of the command handler in milliseconds"),
+    QueueWaitingTaskCount("The number of queued tasks waiting for execution"),
+    InvocationCount("The number of times the command handler has been invoked"),
+    ThreadPoolActivePoolSize("The number of active threads in the thread pool"),
+    ThreadPoolMaxPoolSize("The maximum number of threads in the thread pool"),
+    CommandReceivedCount(
+        "The number of received SCM commands for each command type");
+
+    private final String desc;
+    CommandMetricsMetricsInfo(String desc) {
+      this.desc = desc;
+    }
+
+    @Override
+    public String description() {
+      return desc;
+    }
+  }
+
+  public static final String SOURCE_NAME =
+      CommandHandlerMetrics.class.getSimpleName();
+  private final Map<Type, CommandHandler> handlerMap;
+  private final Map<Type, AtomicInteger> commandCount;
+  private CommandHandlerMetrics(Map<Type, CommandHandler> handlerMap) {
+    this.handlerMap = handlerMap;
+    this.commandCount = new HashMap<>();
+    handlerMap.forEach((k, v) -> this.commandCount.put(k, new AtomicInteger()));
+  }
+
+  /**
+   * Creates a new instance of CommandHandlerMetrics and
+   * registers it to the DefaultMetricsSystem.
+   *
+   * @param handlerMap the map of command types to their
+   *                  corresponding command handlers
+   * @return the registered instance of CommandHandlerMetrics
+   */
+  public static CommandHandlerMetrics create(
+      Map<Type, CommandHandler> handlerMap) {
+    MetricsSystem ms = DefaultMetricsSystem.instance();
+    return ms.register(SOURCE_NAME, "CommandHandlerMetrics Metrics",
+        new CommandHandlerMetrics(handlerMap));
+  }
+
+  /**
+   * Increases the count of received commands for the specified command type.
+   *
+   * @param type the type of the command for which the count should be increased
+   */
+  public void increaseCommandCount(Type type) {
+    commandCount.get(type).addAndGet(1);
+  }
+
+  @Override
+  public void getMetrics(MetricsCollector collector, boolean all) {
+    for (Map.Entry<Type, CommandHandler> entry : handlerMap.entrySet()) {
+      CommandHandler commandHandler = entry.getValue();
+      MetricsRecordBuilder builder = collector.addRecord(SOURCE_NAME)
+          .setContext("CommandHandlerMetrics")
+          .tag(CommandMetricsMetricsInfo.Command,
+              commandHandler.getCommandType().name());
+
+      builder.addGauge(TotalRunTimeMs, commandHandler.getTotalRunTime());
+      builder.addGauge(QueueWaitingTaskCount, commandHandler.getQueuedCount());
+      builder.addGauge(InvocationCount, commandHandler.getInvocationCount());
+      int activePoolSize = commandHandler.getThreadPoolActivePoolSize();
+      if (activePoolSize >= 0) {
+        builder.addGauge(ThreadPoolActivePoolSize, activePoolSize);
+      }
+      int maxPoolSize = commandHandler.getThreadPoolMaxPoolSize();
+      if (maxPoolSize >= 0) {
+        builder.addGauge(ThreadPoolMaxPoolSize, maxPoolSize);
+      }
+      builder.addGauge(CommandReceivedCount,
+          commandCount.get(commandHandler.getCommandType()).get());
+    }
+  }
+
+  public void unRegister() {
+    MetricsSystem ms = DefaultMetricsSystem.instance();
+    ms.unregisterSource(SOURCE_NAME);
+  }
+}

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/CloseContainerCommandHandler.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/CloseContainerCommandHandler.java
@@ -188,6 +188,11 @@ public class CloseContainerCommandHandler implements CommandHandler {
   }
 
   @Override
+  public long getTotalRunTime() {
+    return totalTime;
+  }
+
+  @Override
   public int getQueuedCount() {
     return 0;
   }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/ClosePipelineCommandHandler.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/ClosePipelineCommandHandler.java
@@ -133,6 +133,11 @@ public class ClosePipelineCommandHandler implements CommandHandler {
   }
 
   @Override
+  public long getTotalRunTime() {
+    return totalTime;
+  }
+
+  @Override
   public int getQueuedCount() {
     return queuedCount.get();
   }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/CommandHandler.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/CommandHandler.java
@@ -63,6 +63,12 @@ public interface CommandHandler {
   long getAverageRunTime();
 
   /**
+   * Returns the total time this function takes to run.
+   * @return  long
+   */
+  long getTotalRunTime();
+
+  /**
    * Default implementation for updating command status.
    */
   default void updateCommandStatus(StateContext context, SCMCommand command,
@@ -86,4 +92,31 @@ public interface CommandHandler {
    * @return The number of queued commands inside this handler.
    */
   int getQueuedCount();
+
+  /**
+   * Returns the maximum number of threads allowed in the thread pool for this
+   * handler. If the subclass does not override this method, the default
+   * implementation will return -1, indicating that the maximum pool size is not
+   * applicable or not defined.
+   *
+   * @return The maximum number of threads allowed in the thread pool,
+   * or -1 if not applicable or not defined.
+   */
+  default int getThreadPoolMaxPoolSize() {
+    return -1;
+  }
+
+  /**
+   * Returns the number of threads currently executing tasks in the thread pool
+   * for this handler.If the subclass does not override this method,
+   * the default implementation will return -1, indicating that the number of
+   * active threads is not applicable or not defined.
+   *
+   * @return The number of threads currently executing tasks in the thread pool,
+   * or -1 if not applicable or not defined.
+   */
+  default int getThreadPoolActivePoolSize() {
+    return -1;
+  }
+
 }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/CreatePipelineCommandHandler.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/CreatePipelineCommandHandler.java
@@ -174,6 +174,11 @@ public class CreatePipelineCommandHandler implements CommandHandler {
   }
 
   @Override
+  public long getTotalRunTime() {
+    return totalTime;
+  }
+
+  @Override
   public int getQueuedCount() {
     return queuedCount.get();
   }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/DeleteBlocksCommandHandler.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/DeleteBlocksCommandHandler.java
@@ -65,6 +65,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 
@@ -134,6 +135,16 @@ public class DeleteBlocksCommandHandler implements CommandHandler {
   @Override
   public int getQueuedCount() {
     return deleteCommandQueues.size();
+  }
+
+  @Override
+  public int getThreadPoolMaxPoolSize() {
+    return ((ThreadPoolExecutor)executor).getMaximumPoolSize();
+  }
+
+  @Override
+  public int getThreadPoolActivePoolSize() {
+    return ((ThreadPoolExecutor)executor).getActiveCount();
   }
 
   /**
@@ -513,6 +524,11 @@ public class DeleteBlocksCommandHandler implements CommandHandler {
       return totalTime / invocationCount;
     }
     return 0;
+  }
+
+  @Override
+  public long getTotalRunTime() {
+    return totalTime;
   }
 
   @Override

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/DeleteContainerCommandHandler.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/DeleteContainerCommandHandler.java
@@ -155,6 +155,11 @@ public class DeleteContainerCommandHandler implements CommandHandler {
   }
 
   @Override
+  public long getTotalRunTime() {
+    return totalTime.get();
+  }
+
+  @Override
   public void stop() {
     try {
       executor.shutdown();

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/FinalizeNewLayoutVersionCommandHandler.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/FinalizeNewLayoutVersionCommandHandler.java
@@ -120,6 +120,11 @@ public class FinalizeNewLayoutVersionCommandHandler implements CommandHandler {
   }
 
   @Override
+  public long getTotalRunTime() {
+    return totalTime;
+  }
+
+  @Override
   public int getQueuedCount() {
     return 0;
   }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/ReconstructECContainersCommandHandler.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/ReconstructECContainersCommandHandler.java
@@ -72,6 +72,11 @@ public class ReconstructECContainersCommandHandler implements CommandHandler {
   }
 
   @Override
+  public long getTotalRunTime() {
+    return 0;
+  }
+
+  @Override
   public int getQueuedCount() {
     return supervisor
         .getInFlightReplications(ECReconstructionCoordinatorTask.class);

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/RefreshVolumeUsageCommandHandler.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/RefreshVolumeUsageCommandHandler.java
@@ -72,6 +72,11 @@ public class RefreshVolumeUsageCommandHandler implements CommandHandler {
   }
 
   @Override
+  public long getTotalRunTime() {
+    return totalTime.get();
+  }
+
+  @Override
   public int getQueuedCount() {
     return 0;
   }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/ReplicateContainerCommandHandler.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/ReplicateContainerCommandHandler.java
@@ -111,4 +111,9 @@ public class ReplicateContainerCommandHandler implements CommandHandler {
     }
     return 0;
   }
+
+  @Override
+  public long getTotalRunTime() {
+    return totalTime;
+  }
 }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/SetNodeOperationalStateCommandHandler.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/SetNodeOperationalStateCommandHandler.java
@@ -153,6 +153,11 @@ public class SetNodeOperationalStateCommandHandler implements CommandHandler {
   }
 
   @Override
+  public long getTotalRunTime() {
+    return totalTime.get();
+  }
+
+  @Override
   public int getQueuedCount() {
     return 0;
   }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Add CommandHandler Metrics

```
command_handler_metrics_command_received_count{context="CommandHandlerMetrics",command="closeContainerCommand",hostname="VM-8-3-centos"} 8
command_handler_metrics_command_received_count{context="CommandHandlerMetrics",command="closePipelineCommand",hostname="VM-8-3-centos"} 6
command_handler_metrics_command_received_count{context="CommandHandlerMetrics",command="createPipelineCommand",hostname="VM-8-3-centos"} 2
command_handler_metrics_command_received_count{context="CommandHandlerMetrics",command="deleteBlocksCommand",hostname="VM-8-3-centos"} 1
command_handler_metrics_command_received_count{context="CommandHandlerMetrics",command="deleteContainerCommand",hostname="VM-8-3-centos"} 0
command_handler_metrics_command_received_count{context="CommandHandlerMetrics",command="finalizeNewLayoutVersionCommand",hostname="VM-8-3-centos"} 0
command_handler_metrics_command_received_count{context="CommandHandlerMetrics",command="reconstructECContainersCommand",hostname="VM-8-3-centos"} 0
command_handler_metrics_command_received_count{context="CommandHandlerMetrics",command="refreshVolumeUsageInfo",hostname="VM-8-3-centos"} 0
command_handler_metrics_command_received_count{context="CommandHandlerMetrics",command="replicateContainerCommand",hostname="VM-8-3-centos"} 0
command_handler_metrics_command_received_count{context="CommandHandlerMetrics",command="setNodeOperationalStateCommand",hostname="VM-8-3-centos"} 0
command_handler_metrics_invocation_count{context="CommandHandlerMetrics",command="closeContainerCommand",hostname="VM-8-3-centos"} 8
command_handler_metrics_invocation_count{context="CommandHandlerMetrics",command="closePipelineCommand",hostname="VM-8-3-centos"} 6
command_handler_metrics_invocation_count{context="CommandHandlerMetrics",command="createPipelineCommand",hostname="VM-8-3-centos"} 2
command_handler_metrics_invocation_count{context="CommandHandlerMetrics",command="deleteBlocksCommand",hostname="VM-8-3-centos"} 1
command_handler_metrics_invocation_count{context="CommandHandlerMetrics",command="deleteContainerCommand",hostname="VM-8-3-centos"} 0
command_handler_metrics_invocation_count{context="CommandHandlerMetrics",command="finalizeNewLayoutVersionCommand",hostname="VM-8-3-centos"} 0
command_handler_metrics_invocation_count{context="CommandHandlerMetrics",command="reconstructECContainersCommand",hostname="VM-8-3-centos"} 0
command_handler_metrics_invocation_count{context="CommandHandlerMetrics",command="refreshVolumeUsageInfo",hostname="VM-8-3-centos"} 0
command_handler_metrics_invocation_count{context="CommandHandlerMetrics",command="replicateContainerCommand",hostname="VM-8-3-centos"} 0
command_handler_metrics_invocation_count{context="CommandHandlerMetrics",command="setNodeOperationalStateCommand",hostname="VM-8-3-centos"} 0
command_handler_metrics_queue_waiting_task_count{context="CommandHandlerMetrics",command="closeContainerCommand",hostname="VM-8-3-centos"} 0
command_handler_metrics_queue_waiting_task_count{context="CommandHandlerMetrics",command="closePipelineCommand",hostname="VM-8-3-centos"} 0
command_handler_metrics_queue_waiting_task_count{context="CommandHandlerMetrics",command="createPipelineCommand",hostname="VM-8-3-centos"} 0
command_handler_metrics_queue_waiting_task_count{context="CommandHandlerMetrics",command="deleteBlocksCommand",hostname="VM-8-3-centos"} 0
command_handler_metrics_queue_waiting_task_count{context="CommandHandlerMetrics",command="deleteContainerCommand",hostname="VM-8-3-centos"} 0
command_handler_metrics_queue_waiting_task_count{context="CommandHandlerMetrics",command="finalizeNewLayoutVersionCommand",hostname="VM-8-3-centos"} 0
command_handler_metrics_queue_waiting_task_count{context="CommandHandlerMetrics",command="reconstructECContainersCommand",hostname="VM-8-3-centos"} 0
command_handler_metrics_queue_waiting_task_count{context="CommandHandlerMetrics",command="refreshVolumeUsageInfo",hostname="VM-8-3-centos"} 0
command_handler_metrics_queue_waiting_task_count{context="CommandHandlerMetrics",command="replicateContainerCommand",hostname="VM-8-3-centos"} 0
command_handler_metrics_queue_waiting_task_count{context="CommandHandlerMetrics",command="setNodeOperationalStateCommand",hostname="VM-8-3-centos"} 0
command_handler_metrics_thread_pool_active_pool_size{context="CommandHandlerMetrics",command="deleteBlocksCommand",hostname="VM-8-3-centos"} 0
command_handler_metrics_thread_pool_max_pool_size{context="CommandHandlerMetrics",command="deleteBlocksCommand",hostname="VM-8-3-centos"} 5
command_handler_metrics_total_run_time_ms{context="CommandHandlerMetrics",command="closeContainerCommand",hostname="VM-8-3-centos"} 2
command_handler_metrics_total_run_time_ms{context="CommandHandlerMetrics",command="closePipelineCommand",hostname="VM-8-3-centos"} 1467
command_handler_metrics_total_run_time_ms{context="CommandHandlerMetrics",command="createPipelineCommand",hostname="VM-8-3-centos"} 0
command_handler_metrics_total_run_time_ms{context="CommandHandlerMetrics",command="deleteBlocksCommand",hostname="VM-8-3-centos"} 16
command_handler_metrics_total_run_time_ms{context="CommandHandlerMetrics",command="deleteContainerCommand",hostname="VM-8-3-centos"} 0
command_handler_metrics_total_run_time_ms{context="CommandHandlerMetrics",command="finalizeNewLayoutVersionCommand",hostname="VM-8-3-centos"} 0
command_handler_metrics_total_run_time_ms{context="CommandHandlerMetrics",command="reconstructECContainersCommand",hostname="VM-8-3-centos"} 0
command_handler_metrics_total_run_time_ms{context="CommandHandlerMetrics",command="refreshVolumeUsageInfo",hostname="VM-8-3-centos"} 0
command_handler_metrics_total_run_time_ms{context="CommandHandlerMetrics",command="replicateContainerCommand",hostname="VM-8-3-centos"} 0
command_handler_metrics_total_run_time_ms{context="CommandHandlerMetrics",command="setNodeOperationalStateCommand",hostname="VM-8-3-centos"} 0
```
## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-8868

## How was this patch tested?

manually test
