### PR TITLE
HDDS-8854. Avoid unnecessary DatanodeDetails creation for NodeStateManager lookup

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/NodeStateManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/NodeStateManager.java
@@ -374,7 +374,12 @@ public class NodeStateManager implements Runnable, Closeable {
    */
   public DatanodeInfo getNode(DatanodeDetails datanodeDetails)
       throws NodeNotFoundException {
-    return nodeStateMap.getNodeInfo(datanodeDetails.getUuid());
+    return getNode(datanodeDetails.getUuid());
+  }
+
+  public DatanodeInfo getNode(UUID uuid)
+      throws NodeNotFoundException {
+    return nodeStateMap.getNodeInfo(uuid);
   }
 
   /**


### PR DESCRIPTION
## What changes were proposed in this pull request?

Add `getNode(UUID)` in `NodeStateManager` so that callers with only `UUID` can avoid creation of temporary `DatanodeDetails`.

Change `dnsToUuidMap` in `SCMNodeManager` to store `UUID` instead of `String`.

https://issues.apache.org/jira/browse/HDDS-8854

## How was this patch tested?

CI:
https://github.com/adoroszlai/hadoop-ozone/actions/runs/5298453058