### PR TITLE
HDDS-8881. Add more BlockDeletingServiceMetrics to Monitor the Datanode

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/helpers/BlockDeletingServiceMetrics.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/helpers/BlockDeletingServiceMetrics.java
@@ -52,6 +52,28 @@ public final class BlockDeletingServiceMetrics {
   @Metric(about = "The total number of blocks pending for processing.")
   private MutableGaugeLong totalPendingBlockCount;
 
+  @Metric(about = "The total number of DeleteBlockTransaction received")
+  private MutableCounterLong receivedTransactionCount;
+
+  @Metric(about = "The total number of DeleteBlockTransaction" +
+      " that is a retry Transaction")
+  private MutableCounterLong receivedRetryTransactionCount;
+
+  @Metric(about = "The total number of Container received to be processed")
+  private MutableCounterLong receivedContainerCount;
+
+  @Metric(about = "The total number of blocks received to be processed.")
+  private MutableGaugeLong receivedBlockCount;
+
+  @Metric(about = "The total number of blocks marked count.")
+  private MutableGaugeLong markedBlockCount;
+
+  @Metric(about = "The total number of blocks chosen to be deleted.")
+  private MutableGaugeLong totalBlockChosenCount;
+
+  @Metric(about = "The total number of Container chosen to be deleted.")
+  private MutableGaugeLong totalContainerChosenCount;
+
   private BlockDeletingServiceMetrics() {
   }
 
@@ -86,6 +108,34 @@ public final class BlockDeletingServiceMetrics {
     this.failureCount.incr();
   }
 
+  public void incrReceiveTransactionCount(long count) {
+    receivedTransactionCount.incr(count);
+  }
+
+  public void incrReceiveRetryTransactionCount(long count) {
+    receivedRetryTransactionCount.incr(count);
+  }
+
+  public void incrContainerCount(long count) {
+    receivedContainerCount.incr(count);
+  }
+
+  public void incrTotalBlockChosenCount(long count) {
+    totalBlockChosenCount.incr(count);
+  }
+
+  public void incrTotalContainerChosenCount(long count) {
+    totalContainerChosenCount.incr(count);
+  }
+
+  public void incrReceivedBlockCount(long count) {
+    receivedBlockCount.incr(count);
+  }
+
+  public void incrMarkedBlockCount(long count) {
+    markedBlockCount.incr(count);
+  }
+
   public void setTotalPendingBlockCount(long count) {
     this.totalPendingBlockCount.set(count);
   }
@@ -114,6 +164,14 @@ public final class BlockDeletingServiceMetrics {
     return totalPendingBlockCount.value();
   }
 
+  public long getTotalBlockChosenCount() {
+    return totalBlockChosenCount.value();
+  }
+
+  public long getTotalContainerChosenCount() {
+    return totalContainerChosenCount.value();
+  }
+
   @Override
   public String toString() {
     StringBuffer buffer = new StringBuffer();
@@ -123,7 +181,21 @@ public final class BlockDeletingServiceMetrics {
         .append("outOfOrderDeleteBlockTransactionCount = "
             + outOfOrderDeleteBlockTransactionCount.value()).append("\t")
         .append("totalPendingBlockCount = "
-            + totalPendingBlockCount.value()).append("\t");
+            + totalPendingBlockCount.value()).append("\t")
+        .append("totalBlockChosenCount = "
+            + totalBlockChosenCount.value()).append("\t")
+        .append("totalContainerChosenCount = "
+            + totalContainerChosenCount.value()).append("\t")
+        .append("receivedTransactionCount = "
+            + receivedTransactionCount.value()).append("\t")
+        .append("receivedRetryTransactionCount = "
+            + receivedRetryTransactionCount.value()).append("\t")
+        .append("receivedContainerCount = "
+            + receivedContainerCount.value()).append("\t")
+        .append("receivedBlockCount = "
+            + receivedBlockCount.value()).append("\t")
+        .append("markedBlockCount = "
+            + markedBlockCount.value()).append("\t");
     return buffer.toString();
   }
 }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/helpers/BlockDeletingServiceMetrics.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/helpers/BlockDeletingServiceMetrics.java
@@ -108,15 +108,15 @@ public final class BlockDeletingServiceMetrics {
     this.failureCount.incr();
   }
 
-  public void incrReceiveTransactionCount(long count) {
+  public void incrReceivedTransactionCount(long count) {
     receivedTransactionCount.incr(count);
   }
 
-  public void incrReceiveRetryTransactionCount(long count) {
+  public void incrReceivedRetryTransactionCount(long count) {
     receivedRetryTransactionCount.incr(count);
   }
 
-  public void incrContainerCount(long count) {
+  public void incrReceivedContainerCount(long count) {
     receivedContainerCount.incr(count);
   }
 

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/helpers/DeletedContainerBlocksSummary.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/helpers/DeletedContainerBlocksSummary.java
@@ -51,7 +51,7 @@ public final class DeletedContainerBlocksSummary {
     blocks.forEach(entry -> {
       txSummary.put(entry.getTxID(), entry.getCount());
       if (entry.getCount() > 0) {
-        numOfRetryTxs += entry.getCount();
+        numOfRetryTxs++;
       }
       if (blockSummary.containsKey(entry.getContainerID())) {
         blockSummary.put(entry.getContainerID(),

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/helpers/DeletedContainerBlocksSummary.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/helpers/DeletedContainerBlocksSummary.java
@@ -34,6 +34,8 @@ public final class DeletedContainerBlocksSummary {
   // key : txID
   // value : times of this tx has been processed
   private final Map<Long, Integer> txSummary;
+  private final Map<Long, Integer> retryTxSummary;
+
   // key : container name
   // value : the number of blocks need to be deleted in this container
   // if the message contains multiple entries for same block,
@@ -46,8 +48,12 @@ public final class DeletedContainerBlocksSummary {
     this.blocks = blocks;
     txSummary = Maps.newHashMap();
     blockSummary = Maps.newHashMap();
+    retryTxSummary = Maps.newHashMap();
     blocks.forEach(entry -> {
       txSummary.put(entry.getTxID(), entry.getCount());
+      if (entry.getCount() > 0) {
+        retryTxSummary.put(entry.getTxID(), entry.getCount());
+      }
       if (blockSummary.containsKey(entry.getContainerID())) {
         blockSummary.put(entry.getContainerID(),
             blockSummary.get(entry.getContainerID())
@@ -66,6 +72,10 @@ public final class DeletedContainerBlocksSummary {
 
   public int getNumOfBlocks() {
     return numOfBlocks;
+  }
+
+  public int getNumOfRetryTxs() {
+    return retryTxSummary.size();
   }
 
   public int getNumOfContainers() {

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/helpers/DeletedContainerBlocksSummary.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/helpers/DeletedContainerBlocksSummary.java
@@ -34,7 +34,7 @@ public final class DeletedContainerBlocksSummary {
   // key : txID
   // value : times of this tx has been processed
   private final Map<Long, Integer> txSummary;
-  private final Map<Long, Integer> retryTxSummary;
+  private int numOfRetryTxs;
 
   // key : container name
   // value : the number of blocks need to be deleted in this container
@@ -48,11 +48,10 @@ public final class DeletedContainerBlocksSummary {
     this.blocks = blocks;
     txSummary = Maps.newHashMap();
     blockSummary = Maps.newHashMap();
-    retryTxSummary = Maps.newHashMap();
     blocks.forEach(entry -> {
       txSummary.put(entry.getTxID(), entry.getCount());
       if (entry.getCount() > 0) {
-        retryTxSummary.put(entry.getTxID(), entry.getCount());
+        numOfRetryTxs += entry.getCount();
       }
       if (blockSummary.containsKey(entry.getContainerID())) {
         blockSummary.put(entry.getContainerID(),
@@ -75,7 +74,7 @@ public final class DeletedContainerBlocksSummary {
   }
 
   public int getNumOfRetryTxs() {
-    return retryTxSummary.size();
+    return numOfRetryTxs;
   }
 
   public int getNumOfContainers() {

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/DeleteBlocksCommandHandler.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/DeleteBlocksCommandHandler.java
@@ -269,7 +269,7 @@ public class DeleteBlocksCommandHandler implements CommandHandler {
       // recycling thread.
       List<DeletedBlocksTransaction> containerBlocks =
           cmd.getCmd().blocksTobeDeleted();
-      blockDeleteMetrics.incrReceiveTransactionCount(containerBlocks.size());
+      blockDeleteMetrics.incrReceivedTransactionCount(containerBlocks.size());
 
       DeletedContainerBlocksSummary summary =
           DeletedContainerBlocksSummary.getFrom(containerBlocks);
@@ -278,8 +278,8 @@ public class DeleteBlocksCommandHandler implements CommandHandler {
           summary.getTxIDSummary(),
           summary.getNumOfContainers(),
           summary.getNumOfBlocks());
-      blockDeleteMetrics.incrContainerCount(summary.getNumOfContainers());
-      blockDeleteMetrics.incrReceiveRetryTransactionCount(
+      blockDeleteMetrics.incrReceivedContainerCount(summary.getNumOfContainers());
+      blockDeleteMetrics.incrReceivedRetryTransactionCount(
           summary.getNumOfRetryTxs());
       blockDeleteMetrics.incrReceivedBlockCount(summary.getNumOfBlocks());
 

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/DeleteBlocksCommandHandler.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/DeleteBlocksCommandHandler.java
@@ -278,7 +278,8 @@ public class DeleteBlocksCommandHandler implements CommandHandler {
           summary.getTxIDSummary(),
           summary.getNumOfContainers(),
           summary.getNumOfBlocks());
-      blockDeleteMetrics.incrReceivedContainerCount(summary.getNumOfContainers());
+      blockDeleteMetrics.incrReceivedContainerCount(
+          summary.getNumOfContainers());
       blockDeleteMetrics.incrReceivedRetryTransactionCount(
           summary.getNumOfRetryTxs());
       blockDeleteMetrics.incrReceivedBlockCount(summary.getNumOfBlocks());

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/DeleteBlocksCommandHandler.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/DeleteBlocksCommandHandler.java
@@ -269,6 +269,7 @@ public class DeleteBlocksCommandHandler implements CommandHandler {
       // recycling thread.
       List<DeletedBlocksTransaction> containerBlocks =
           cmd.getCmd().blocksTobeDeleted();
+      blockDeleteMetrics.incrReceiveTransactionCount(containerBlocks.size());
 
       DeletedContainerBlocksSummary summary =
           DeletedContainerBlocksSummary.getFrom(containerBlocks);
@@ -277,6 +278,10 @@ public class DeleteBlocksCommandHandler implements CommandHandler {
           summary.getTxIDSummary(),
           summary.getNumOfContainers(),
           summary.getNumOfBlocks());
+      blockDeleteMetrics.incrContainerCount(summary.getNumOfContainers());
+      blockDeleteMetrics.incrReceiveRetryTransactionCount(
+          summary.getNumOfRetryTxs());
+      blockDeleteMetrics.incrReceivedBlockCount(summary.getNumOfBlocks());
 
       ContainerBlocksDeletionACKProto.Builder resultBuilder =
           ContainerBlocksDeletionACKProto.newBuilder();
@@ -386,6 +391,7 @@ public class DeleteBlocksCommandHandler implements CommandHandler {
         containerDB.getStore().getBatchHandler().commitBatchOperation(batch);
       }
     }
+    blockDeleteMetrics.incrMarkedBlockCount(delTX.getLocalIDCount());
   }
 
   private void markBlocksForDeletionSchemaV1(
@@ -446,6 +452,7 @@ public class DeleteBlocksCommandHandler implements CommandHandler {
         throw new IOException(
             "Failed to delete blocks for TXID = " + delTX.getTxID(), e);
       }
+      blockDeleteMetrics.incrMarkedBlockCount(delTX.getLocalIDCount());
     }
   }
 

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/statemachine/background/BlockDeletingService.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/statemachine/background/BlockDeletingService.java
@@ -157,6 +157,8 @@ public class BlockDeletingService extends BackgroundService {
         queue.add(containerBlockInfos);
         totalBlocks += containerBlockInfo.numBlocksToDelete;
       }
+      metrics.incrTotalBlockChosenCount(totalBlocks);
+      metrics.incrTotalContainerChosenCount(containers.size());
       if (containers.size() > 0) {
         LOG.debug("Queued {} blocks from {} containers for deletion",
             totalBlocks, containers.size());

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/TestBlockDeletingService.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/TestBlockDeletingService.java
@@ -589,6 +589,10 @@ public class TestBlockDeletingService {
 
       long deleteSuccessCount =
           deletingServiceMetrics.getSuccessCount();
+      long totalBlockChosenCount =
+          deletingServiceMetrics.getTotalBlockChosenCount();
+      long totalContainerChosenCount =
+          deletingServiceMetrics.getTotalContainerChosenCount();
       Assert.assertEquals(0, transactionId);
 
       // Ensure there are 3 blocks under deletion and 0 deleted blocks
@@ -613,6 +617,12 @@ public class TestBlockDeletingService {
       Assert.assertEquals(2,
           deletingServiceMetrics.getSuccessCount()
               - deleteSuccessCount);
+      Assert.assertEquals(2,
+          deletingServiceMetrics.getTotalBlockChosenCount()
+              - totalBlockChosenCount);
+      Assert.assertEquals(1,
+          deletingServiceMetrics.getTotalContainerChosenCount()
+              - totalContainerChosenCount);
       // The value of the getTotalPendingBlockCount Metrics is obtained
       // before the deletion is processing
       // So the Pending Block count will be 3
@@ -636,6 +646,12 @@ public class TestBlockDeletingService {
       Assert.assertEquals(3,
           deletingServiceMetrics.getSuccessCount()
               - deleteSuccessCount);
+      Assert.assertEquals(3,
+          deletingServiceMetrics.getTotalBlockChosenCount()
+              - totalBlockChosenCount);
+      Assert.assertEquals(2,
+          deletingServiceMetrics.getTotalContainerChosenCount()
+              - totalContainerChosenCount);
 
       // check if blockData get deleted
       assertBlockDataTableRecordCount(0, meta, filter, data.getContainerID());


### PR DESCRIPTION

## What changes were proposed in this pull request?

Add more BlockDeletingServiceMetrics to Monitor the Datanode

## What is the link to the Apache JIRA

```bash
block_deleting_service_metrics_failure_count{context="dfs",hostname="VM-8-3-centos"} 0
block_deleting_service_metrics_marked_block_count{context="dfs",hostname="VM-8-3-centos"} 5210
block_deleting_service_metrics_out_of_order_delete_block_transaction_count{context="dfs",hostname="VM-8-3-centos"} 1
block_deleting_service_metrics_received_block_count{context="dfs",hostname="VM-8-3-centos"} 5210
block_deleting_service_metrics_received_container_count{context="dfs",hostname="VM-8-3-centos"} 20
block_deleting_service_metrics_received_retry_transaction_count{context="dfs",hostname="VM-8-3-centos"} 0
block_deleting_service_metrics_received_transaction_count{context="dfs",hostname="VM-8-3-centos"} 28
block_deleting_service_metrics_success_bytes{context="dfs",hostname="VM-8-3-centos"} 16498688
block_deleting_service_metrics_success_count{context="dfs",hostname="VM-8-3-centos"} 4028
block_deleting_service_metrics_total_block_chosen_count{context="dfs",hostname="VM-8-3-centos"} 4028
block_deleting_service_metrics_total_container_chosen_count{context="dfs",hostname="VM-8-3-centos"} 16
block_deleting_service_metrics_total_pending_block_count{context="dfs",hostname="VM-8-3-centos"} 0
```
new metrics

```bash
block_deleting_service_metrics_marked_block_count{context="dfs",hostname="VM-8-3-centos"} 5210
block_deleting_service_metrics_received_block_count{context="dfs",hostname="VM-8-3-centos"} 5210
block_deleting_service_metrics_received_container_count{context="dfs",hostname="VM-8-3-centos"} 20
block_deleting_service_metrics_received_retry_transaction_count{context="dfs",hostname="VM-8-3-centos"} 0
block_deleting_service_metrics_received_transaction_count{context="dfs",hostname="VM-8-3-centos"} 28
block_deleting_service_metrics_total_block_chosen_count{context="dfs",hostname="VM-8-3-centos"} 4028
block_deleting_service_metrics_total_container_chosen_count{context="dfs",hostname="VM-8-3-centos"} 16
```

## How was this patch tested?

manual test and some metrics have integration test
