### PR TITLE
HDDS-8887. Support --all option in ListOptions.

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/shell/TestOzoneShellHA.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/shell/TestOzoneShellHA.java
@@ -1405,6 +1405,49 @@ public class TestOzoneShellHA {
   }
 
   @Test
+  public void testListAllKeys()
+      throws Exception {
+    String volumeName = "vollst";
+    // Create volume vollst
+    String[] args = new String[] {
+        "volume", "create", "o3://" + omServiceId +
+          OZONE_URI_DELIMITER + volumeName};
+    execute(ozoneShell, args);
+    out.reset();
+
+    // Create bucket bucket1
+    args = new String[]{"bucket", "create", "o3://" + omServiceId +
+          OZONE_URI_DELIMITER + volumeName + "/bucket1"};
+    execute(ozoneShell, args);
+    out.reset();
+
+    // Insert 120 keys into bucket1
+    String keyName = OZONE_URI_DELIMITER + volumeName + "/bucket1" +
+        OZONE_URI_DELIMITER + "key";
+    for (int i = 0; i < 120; i++) {
+      args = new String[]{
+          "key", "put", "o3://" + omServiceId + keyName + i,
+          testFile.getPath()};
+      execute(ozoneShell, args);
+    }
+
+    out.reset();
+    // Number of keys should return less than 120(100 by default)
+    args =
+        new String[]{"key", "list", volumeName};
+    execute(ozoneShell, args);
+    Assert.assertTrue(getNumOfKeys() < 120);
+
+    out.reset();
+    // Use --all option to get all the keys
+    args =
+        new String[]{"key", "list", "--all", volumeName};
+    execute(ozoneShell, args);
+    // Number of keys returned should be 120
+    Assert.assertEquals(120, getNumOfKeys());
+  }
+
+  @Test
   public void testVolumeListKeys()
       throws Exception {
     String volume1 = "volx";

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/ListOptions.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/ListOptions.java
@@ -24,11 +24,21 @@ import picocli.CommandLine;
  */
 public class ListOptions {
 
-  @CommandLine.Option(names = {"--length", "-l"},
-      description = "Maximum number of items to list",
-      defaultValue = "100",
-      showDefaultValue = CommandLine.Help.Visibility.ALWAYS)
-  private int limit;
+  @CommandLine.ArgGroup(exclusive = true)
+  private ExclusiveLimit exclusiveLimit = new ExclusiveLimit();
+  
+  static class ExclusiveLimit {
+    @CommandLine.Option(names = {"--length", "-l"},
+        description = "Maximum number of items to list",
+        defaultValue = "100",
+        showDefaultValue = CommandLine.Help.Visibility.ALWAYS)
+    private int limit;
+
+    @CommandLine.Option(names = {"--all", "-a"},
+        description = "List all results",
+        defaultValue = "false")
+    private boolean all;
+  }
 
   @CommandLine.Option(names = {"--start", "-s"},
       description = "The item to start the listing from.\n" +
@@ -39,20 +49,20 @@ public class ListOptions {
       description = "Prefix to filter the items")
   private String prefix;
 
-  @CommandLine.Option(names = {"--all", "-a"},
-      description = "List all results")
-  private boolean bListAll;
-
   public int getLimit() {
-    if (bListAll) {
+    if (exclusiveLimit.all) {
       return Integer.MAX_VALUE;
     }
-    if (limit < 1) {
+    if (exclusiveLimit.limit < 1) {
       throw new IllegalArgumentException(
           "List length should be a positive number");
     }
 
-    return limit;
+    return exclusiveLimit.limit;
+  }
+
+  public boolean isAll() {
+    return exclusiveLimit.all;
   }
 
   public String getStartItem() {

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/ListOptions.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/ListOptions.java
@@ -39,7 +39,14 @@ public class ListOptions {
       description = "Prefix to filter the items")
   private String prefix;
 
+  @CommandLine.Option(names = {"--all", "-a"},
+      description = "List all results")
+  private boolean bListAll;
+
   public int getLimit() {
+    if (bListAll) {
+      return Integer.MAX_VALUE;
+    }
     if (limit < 1) {
       throw new IllegalArgumentException(
           "List length should be a positive number");

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/volume/ListVolumeHandler.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/volume/ListVolumeHandler.java
@@ -56,10 +56,6 @@ public class ListVolumeHandler extends Handler {
           + " if list all volumes option is specified.")
   private String userName;
 
-  @Option(names = {"--all", "-a"},
-      description = "List all volumes.")
-  private boolean listAllVolumes;
-
   @Override
   protected OzoneAddress getAddress() throws OzoneClientException {
     OzoneAddress address = new OzoneAddress(uri);
@@ -76,7 +72,7 @@ public class ListVolumeHandler extends Handler {
     }
 
     Iterator<? extends OzoneVolume> volumeIterator;
-    if (userName != null && !listAllVolumes) {
+    if (userName != null && (Integer.MAX_VALUE != listOptions.getLimit())) {
       volumeIterator = client.getObjectStore().listVolumesByUser(userName,
           listOptions.getPrefix(), listOptions.getStartItem());
     } else {

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/volume/ListVolumeHandler.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/volume/ListVolumeHandler.java
@@ -72,7 +72,7 @@ public class ListVolumeHandler extends Handler {
     }
 
     Iterator<? extends OzoneVolume> volumeIterator;
-    if (userName != null && (Integer.MAX_VALUE != listOptions.getLimit())) {
+    if (userName != null && !listOptions.isAll()) {
       volumeIterator = client.getObjectStore().listVolumesByUser(userName,
           listOptions.getPrefix(), listOptions.getStartItem());
     } else {


### PR DESCRIPTION
## What changes were proposed in this pull request?

Currently ListOptions provide -l option to override number of results return. 
In this PR providing a way to return all results by providing --all option applicable for command which is using ListOptions like ListVolume, ListBucket, ListKeys.

- Using --all option for listKeys

`ozone sh key list --all o3://localhost:9862/vol11/bucket1
`
[ {
  "volumeName" : "vol11",
  "bucketName" : "bucket1",
  "name" : "key1",
  "dataSize" : 0,
  "creationTime" : "2023-06-19T11:04:46.584Z",
  "modificationTime" : "2023-06-19T11:04:46.640Z",
  "replicationConfig" : {
    "replicationFactor" : "THREE",
    "requiredNodes" : 3,
    "replicationType" : "RATIS"
  },
  "metadata" : { }
}, {
  "volumeName" : "vol11",
  "bucketName" : "bucket1",
  "name" : "key2",
  "dataSize" : 0,
  "creationTime" : "2023-06-19T11:04:50.748Z",
  "modificationTime" : "2023-06-19T11:04:50.779Z",
  "replicationConfig" : {
    "replicationFactor" : "THREE",
    "requiredNodes" : 3,
    "replicationType" : "RATIS"
  },
  "metadata" : { }
} ]

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-8887

## How was this patch tested?

Using integration test and also local test using docker cluster.
