### PR TITLE
HDDS-8858. Do not mix JSON output with hints.

### DIFF
--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/bucket/ListBucketHandler.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/bucket/ListBucketHandler.java
@@ -72,7 +72,7 @@ public class ListBucketHandler extends VolumeHandler {
     }
     printAsJsonArray(bucketList.iterator(), listOptions.getLimit());
     if (isVerbose()) {
-      out().printf("Found : %d buckets for volume : %s ", counter, volumeName);
+      err().printf("Found : %d buckets for volume : %s ", counter, volumeName);
     }
   }
 

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/keys/ListKeyHandler.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/keys/ListKeyHandler.java
@@ -85,7 +85,7 @@ public class ListKeyHandler extends VolumeBucketHandler {
 
     // More keys were returned notify about max length
     if (keyIterator.hasNext()) {
-      out().println("Listing first " + maxKeyLimit + " entries of the " +
+      err().println("Listing first " + maxKeyLimit + " entries of the " +
           "result. Use --length (-l) to override max returned keys.");
     } else if (isVerbose()) {
       if (!Strings.isNullOrEmpty(snapshotNameWithIndicator)) {
@@ -93,11 +93,11 @@ public class ListKeyHandler extends VolumeBucketHandler {
         // snapshotValues[1] = snapshot name
         String[] snapshotValues = snapshotNameWithIndicator.split("/");
 
-        out().printf("Found : %d keys for snapshot %s " +
+        err().printf("Found : %d keys for snapshot %s " +
                 "under bucket %s in volume : %s ",
             counter, snapshotValues[1], bucketName, volumeName);
       } else {
-        out().printf("Found : %d keys for bucket %s in volume : %s ",
+        err().printf("Found : %d keys for bucket %s in volume : %s ",
             counter, bucketName, volumeName);
       }
     }
@@ -129,13 +129,13 @@ public class ListKeyHandler extends VolumeBucketHandler {
       // More keys were returned notify about max length
       if (keyIterator.hasNext() || (bucketIterator.hasNext()
           && maxKeyLimit <= 0)) {
-        out().println("Listing first " + totalKeys + " entries of the " +
+        err().println("Listing first " + totalKeys + " entries of the " +
             "result. Use --length (-l) to override max returned keys.");
         return;
       }
     }
     if (isVerbose()) {
-      out().printf("Found : %d keys in volume : %s %n",
+      err().printf("Found : %d keys in volume : %s %n",
           totalKeys, volumeName);
     }
   }

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/snapshot/ListSnapshotHandler.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/snapshot/ListSnapshotHandler.java
@@ -54,7 +54,7 @@ public class ListSnapshotHandler extends Handler {
         .listSnapshot(volumeName, bucketName, null, null);
     int counter = printAsJsonArray(snapshotInfos, Integer.MAX_VALUE);
     if (isVerbose()) {
-      out().printf("Found : %d snapshots for o3://%s/ %s ", counter,
+      err().printf("Found : %d snapshots for o3://%s/ %s ", counter,
           volumeName, bucketName);
     }
   }

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/volume/ListVolumeHandler.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/volume/ListVolumeHandler.java
@@ -87,7 +87,7 @@ public class ListVolumeHandler extends Handler {
     int counter = printAsJsonArray(volumeIterator, listOptions.getLimit());
 
     if (isVerbose()) {
-      out().printf("Found : %d volumes for user : %s ", counter, userName);
+      err().printf("Found : %d volumes for user : %s ", counter, userName);
     }
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

We should avoid mixing JSON output with hints, which can lead to jq parse failure.
In this PR, In code where hints are printed with stdout is replaced by stderr.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-8858

## How was this patch tested?

Verified in local cluster to see json/err redirection

`$$ozone sh key list -l 1 o3://localhost:9862/vol11/ > a.txt`
`Listing first 1 entries of the result. Use --length (-l) to override max returned keys.`

```
$$cat a.txt 
[ {
  "volumeName" : "vol11",
  "bucketName" : "bucket1",
  "name" : "key1",
  "dataSize" : 0,
  "creationTime" : "2023-06-19T11:04:46.584Z",
  "modificationTime" : "2023-06-19T11:04:46.640Z",
  "replicationConfig" : {
    "replicationFactor" : "THREE",
    "requiredNodes" : 3,
    "replicationType" : "RATIS"
  },
  "metadata" : { }
} ]
```

