### PR TITLE
HDDS-8763. Support RocksDB iterator with ByteBuffer.

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/StringUtils.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/StringUtils.java
@@ -85,6 +85,10 @@ public final class StringUtils {
     return bytes2Hex(buffer, buffer.remaining());
   }
 
+  public static String bytes2Hex(byte[] array) {
+    return bytes2Hex(ByteBuffer.wrap(array));
+  }
+
   /**
    * Decode a specific range of bytes of the given byte array to a string
    * using UTF8.

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/utils/db/CodecBuffer.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/utils/db/CodecBuffer.java
@@ -51,7 +51,7 @@ public final class CodecBuffer implements AutoCloseable {
   public static final Logger LOG = LoggerFactory.getLogger(CodecBuffer.class);
 
   /** The size of a buffer. */
-  static class Capacity {
+  public static class Capacity {
     private final Object name;
     private final AtomicInteger value;
 

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/utils/db/CodecBuffer.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/utils/db/CodecBuffer.java
@@ -17,12 +17,14 @@
  */
 package org.apache.hadoop.hdds.utils.db;
 
+import org.apache.hadoop.hdds.StringUtils;
 import org.apache.ratis.thirdparty.io.netty.buffer.ByteBuf;
 import org.apache.ratis.thirdparty.io.netty.buffer.ByteBufAllocator;
 import org.apache.ratis.thirdparty.io.netty.buffer.ByteBufInputStream;
 import org.apache.ratis.thirdparty.io.netty.buffer.ByteBufOutputStream;
 import org.apache.ratis.thirdparty.io.netty.buffer.PooledByteBufAllocator;
 import org.apache.ratis.thirdparty.io.netty.buffer.Unpooled;
+import org.apache.ratis.util.MemoizedSupplier;
 import org.apache.ratis.util.Preconditions;
 import org.apache.ratis.util.function.CheckedFunction;
 import org.slf4j.Logger;
@@ -32,6 +34,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.nio.ByteBuffer;
+import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.IntFunction;
@@ -46,6 +49,38 @@ import static org.apache.hadoop.hdds.HddsUtils.getStackTrace;
  */
 public final class CodecBuffer implements AutoCloseable {
   public static final Logger LOG = LoggerFactory.getLogger(CodecBuffer.class);
+
+  /** The size of a buffer. */
+  static class Capacity {
+    private final Object name;
+    private final AtomicInteger value;
+
+    public Capacity(Object name, int initialCapacity) {
+      this.name = name;
+      this.value = new AtomicInteger(initialCapacity);
+    }
+
+    public int get() {
+      return value.get();
+    }
+
+    private static int nextValue(int n) {
+      // round up to the next power of 2.
+      final long roundUp = Long.highestOneBit(n) << 1;
+      return roundUp > Integer.MAX_VALUE ? Integer.MAX_VALUE : (int) roundUp;
+    }
+
+    /** Increase this size to accommodate the given required size. */
+    public void increase(int required) {
+      final MemoizedSupplier<Integer> newBufferSize = MemoizedSupplier.valueOf(
+          () -> nextValue(required));
+      final int previous = value.getAndUpdate(
+          current -> required <= current ? current : newBufferSize.get());
+      if (newBufferSize.isInitialized()) {
+        LOG.info("{}: increase {} -> {}", name, previous, newBufferSize.get());
+      }
+    }
+  }
 
   private static final ByteBufAllocator POOL
       = PooledByteBufAllocator.DEFAULT;
@@ -206,6 +241,16 @@ public final class CodecBuffer implements AutoCloseable {
     return array;
   }
 
+  /** Does the content of this buffer start with the given prefix? */
+  public boolean startsWith(CodecBuffer prefix) {
+    Objects.requireNonNull(prefix, "prefix == null");
+    final int length = prefix.readableBytes();
+    if (this.readableBytes() < length) {
+      return false;
+    }
+    return buf.slice(buf.readerIndex(), length).equals(prefix.buf);
+  }
+
   /** @return an {@link InputStream} reading from this buffer. */
   public InputStream getInputStream() {
     return new ByteBufInputStream(buf.duplicate());
@@ -316,7 +361,7 @@ public final class CodecBuffer implements AutoCloseable {
    * @throws E in case the source throws it.
    */
   <E extends Exception> Integer putFromSource(
-      CheckedFunction<ByteBuffer, Integer, E> source) throws E {
+      PutToByteBuffer<E> source) throws E {
     assertRefCnt(1);
     final int i = buf.writerIndex();
     final int writable = buf.writableBytes();
@@ -329,5 +374,16 @@ public final class CodecBuffer implements AutoCloseable {
       }
     }
     return size;
+  }
+
+  @Override
+  public String toString() {
+    return getClass().getSimpleName()
+        + "[" + buf.readerIndex()
+        + "<=" + buf.writerIndex()
+        + "<=" + buf.capacity()
+        + ": "
+        + StringUtils.bytes2Hex(asReadOnlyByteBuffer())
+        + "]";
   }
 }

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/utils/db/CodecBuffer.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/utils/db/CodecBuffer.java
@@ -383,7 +383,7 @@ public final class CodecBuffer implements AutoCloseable {
         + "<=" + buf.writerIndex()
         + "<=" + buf.capacity()
         + ": "
-        + StringUtils.bytes2Hex(asReadOnlyByteBuffer())
+        + StringUtils.bytes2Hex(asReadOnlyByteBuffer(), 10)
         + "]";
   }
 }

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/utils/db/PutToByteBuffer.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/utils/db/PutToByteBuffer.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hdds.utils.db;
+
+import org.apache.ratis.util.function.CheckedFunction;
+
+import java.nio.ByteBuffer;
+
+/**
+ * A function puts data from a source to the {@link ByteBuffer}
+ * specified in the parameter.
+ * The source may or may not be available.
+ * This function must return the required size (possibly 0)
+ * if the source is available; otherwise, return null.
+ * When the {@link ByteBuffer}'s capacity is smaller than the required size,
+ * partial data may be put to the {@link ByteBuffer}.
+ *
+ * @param <E> The exception type this function may throw.
+ */
+@FunctionalInterface
+interface PutToByteBuffer<E extends Exception>
+    extends CheckedFunction<ByteBuffer, Integer, E> {
+}

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/utils/db/StringCodecBase.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/utils/db/StringCodecBase.java
@@ -95,7 +95,7 @@ abstract class StringCodecBase implements Codec<String> {
     return maxBytesPerChar * s.length();
   }
 
-  private <E extends Exception> CheckedFunction<ByteBuffer, Integer, E> encode(
+  private <E extends Exception> PutToByteBuffer<E> encode(
       String string, Integer serializedSize, Function<String, E> newE) {
     return buffer -> {
       final CoderResult result = newEncoder().encode(
@@ -140,8 +140,7 @@ abstract class StringCodecBase implements Codec<String> {
       Function<String, E> newE) throws E {
     final int upperBound = getSerializedSizeUpperBound(string);
     final Integer serializedSize = isFixedLength() ? upperBound : null;
-    final CheckedFunction<ByteBuffer, Integer, E> encoder
-        = encode(string, serializedSize, newE);
+    final PutToByteBuffer<E> encoder = encode(string, serializedSize, newE);
 
     if (serializedSize != null) {
       // When the serialized size is known, create an array

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/utils/db/StringCodecBase.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/utils/db/StringCodecBase.java
@@ -20,7 +20,6 @@ package org.apache.hadoop.hdds.utils.db;
 
 import org.apache.hadoop.hdds.StringUtils;
 import org.apache.ratis.util.Preconditions;
-import org.apache.ratis.util.function.CheckedFunction;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/TestBlockDeletingService.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/TestBlockDeletingService.java
@@ -1059,12 +1059,13 @@ public class TestBlockDeletingService {
       DBHandle handle, KeyPrefixFilter filter, long containerID)
       throws IOException {
     long count = 0L;
-    BlockIterator<BlockData> iterator = handle.getStore().
-        getBlockIterator(containerID, filter);
-    iterator.seekToFirst();
-    while (iterator.hasNext()) {
-      iterator.nextBlock();
-      count += 1;
+    try (BlockIterator<BlockData> iterator = handle.getStore().
+        getBlockIterator(containerID, filter)) {
+      iterator.seekToFirst();
+      while (iterator.hasNext()) {
+        iterator.nextBlock();
+        count += 1;
+      }
     }
     Assert.assertEquals("Excepted: " + expectedCount
         + ", but actual: " + count + " in the blockData table of container: "

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/AutoCloseSupplier.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/AutoCloseSupplier.java
@@ -1,0 +1,29 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hdds.utils.db;
+
+import java.util.function.Supplier;
+
+/** An {@link AutoCloseable} {@link Supplier}. */
+@FunctionalInterface
+interface AutoCloseSupplier<RAW> extends AutoCloseable, Supplier<RAW> {
+  @Override
+  default void close() {
+    // no-op
+  }
+}

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/RDBStoreAbstractIterator.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/RDBStoreAbstractIterator.java
@@ -30,7 +30,7 @@ import org.slf4j.LoggerFactory;
  *
  * @param <RAW> the raw type.
  */
-public abstract class RDBStoreAbstractIterator<RAW>
+abstract class RDBStoreAbstractIterator<RAW>
     implements TableIterator<RAW, Table.KeyValue<RAW, RAW>> {
 
   private static final Logger LOG =
@@ -48,7 +48,6 @@ public abstract class RDBStoreAbstractIterator<RAW>
     this.rocksDBIterator = iterator;
     this.rocksDBTable = table;
     this.prefix = prefix;
-    seekToFirst();
   }
 
   /** @return the key for the current entry. */
@@ -150,7 +149,7 @@ public abstract class RDBStoreAbstractIterator<RAW>
   }
 
   @Override
-  public void close() throws IOException {
+  public void close() {
     rocksDBIterator.close();
   }
 }

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/RDBStoreByteArrayIterator.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/RDBStoreByteArrayIterator.java
@@ -25,17 +25,12 @@ import java.util.Arrays;
 /**
  * RocksDB store iterator using the byte[] API.
  */
-public class RDBStoreByteArrayIterator
-    extends RDBStoreAbstractIterator<byte[]> {
-  public RDBStoreByteArrayIterator(ManagedRocksIterator iterator,
-      RDBTable table) {
-    this(iterator, table, null);
-  }
-
-  public RDBStoreByteArrayIterator(ManagedRocksIterator iterator,
+class RDBStoreByteArrayIterator extends RDBStoreAbstractIterator<byte[]> {
+  RDBStoreByteArrayIterator(ManagedRocksIterator iterator,
       RDBTable table, byte[] prefix) {
     super(iterator, table,
         prefix == null ? null : Arrays.copyOf(prefix, prefix.length));
+    seekToFirst();
   }
 
   @Override

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/RDBStoreCodecBufferIterator.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/RDBStoreCodecBufferIterator.java
@@ -115,7 +115,8 @@ class RDBStoreCodecBufferIterator
 
   @Override
   Table.KeyValue<CodecBuffer, CodecBuffer> getKeyValue() {
-    return RawKeyValue.create(key(), valueBuffer.getFromDb());
+    assertOpen();
+    return Table.newKeyValue(key(), valueBuffer.getFromDb());
   }
 
   @Override

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/RDBStoreCodecBufferIterator.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/RDBStoreCodecBufferIterator.java
@@ -1,0 +1,158 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hdds.utils.db;
+
+import org.apache.hadoop.hdds.StringUtils;
+import org.apache.hadoop.hdds.utils.db.managed.ManagedRocksIterator;
+import org.apache.ratis.util.Preconditions;
+
+import java.io.IOException;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * Implement {@link RDBStoreAbstractIterator} using {@link CodecBuffer}.
+ */
+class RDBStoreCodecBufferIterator
+    extends RDBStoreAbstractIterator<CodecBuffer> {
+  static class Buffer {
+    private final CodecBuffer.Capacity initialCapacity;
+    private final PutToByteBuffer<RuntimeException> source;
+    private CodecBuffer buffer;
+
+    Buffer(CodecBuffer.Capacity initialCapacity,
+        PutToByteBuffer<RuntimeException> source) {
+      this.initialCapacity = initialCapacity;
+      this.source = source;
+    }
+
+    void release() {
+      if (buffer != null) {
+        buffer.release();
+      }
+    }
+
+    private void prepare() {
+      if (buffer == null) {
+        allocate();
+      } else {
+        buffer.clear();
+      }
+    }
+
+    private void allocate() {
+      if (buffer != null) {
+        buffer.release();
+      }
+      buffer = CodecBuffer.allocateDirect(-initialCapacity.get());
+    }
+
+    CodecBuffer getFromDb() {
+      for (prepare(); ; allocate()) {
+        final Integer required = buffer.putFromSource(source);
+        if (required == null) {
+          return null; // the source is unavailable
+        } else if (required == buffer.readableBytes()) {
+          return buffer; // buffer size is big enough
+        }
+        // buffer size too small, try increasing the capacity.
+        if (buffer.setCapacity(required)) {
+          buffer.clear();
+          // retry with the new capacity
+          final int retried = buffer.putFromSource(source);
+          Preconditions.assertSame(required.intValue(), retried, "required");
+          return buffer;
+        }
+
+        // failed to increase the capacity
+        // increase initial capacity and reallocate it
+        initialCapacity.increase(required);
+      }
+    }
+  }
+
+  private final Buffer keyBuffer;
+  private final Buffer valueBuffer;
+  private final AtomicBoolean closed = new AtomicBoolean();
+
+  RDBStoreCodecBufferIterator(ManagedRocksIterator iterator, RDBTable table,
+      CodecBuffer prefix) {
+    super(iterator, table, prefix);
+
+    final String name = table != null? table.getName(): null;
+    this.keyBuffer = new Buffer(
+        new CodecBuffer.Capacity(name + "-iterator-key", 1 << 10),
+        buffer -> getRocksDBIterator().get().key(buffer));
+    this.valueBuffer = new Buffer(
+        new CodecBuffer.Capacity(name + "-iterator-value", 4 << 10),
+        buffer -> getRocksDBIterator().get().value(buffer));
+    seekToFirst();
+  }
+
+  void assertOpen() {
+    Preconditions.assertTrue(!closed.get(), "Already closed");
+  }
+
+  @Override
+  CodecBuffer key() {
+    assertOpen();
+    return keyBuffer.getFromDb();
+  }
+
+  @Override
+  Table.KeyValue<CodecBuffer, CodecBuffer> getKeyValue() {
+    return RawKeyValue.create(key(), valueBuffer.getFromDb());
+  }
+
+  @Override
+  void seek0(CodecBuffer key) {
+    assertOpen();
+    getRocksDBIterator().get().seek(key.asReadOnlyByteBuffer());
+  }
+
+  @Override
+  void delete(CodecBuffer key) throws IOException {
+    assertOpen();
+    getRocksDBTable().delete(key.asReadOnlyByteBuffer());
+  }
+
+  @Override
+  boolean startsWithPrefix(CodecBuffer key) {
+    assertOpen();
+    final CodecBuffer prefix = getPrefix();
+    if (prefix == null) {
+      return true;
+    }
+    if (key == null) {
+      return false;
+    }
+    System.out.println("key " + StringUtils.bytes2Hex(key.asReadOnlyByteBuffer())
+        + " startsWithPrefix " + StringUtils.bytes2Hex(prefix.asReadOnlyByteBuffer()));
+    return key.startsWith(prefix);
+  }
+
+  @Override
+  public void close() {
+    if (closed.compareAndSet(false, true)) {
+      super.close();
+      Optional.ofNullable(getPrefix()).ifPresent(CodecBuffer::release);
+      keyBuffer.release();
+      valueBuffer.release();
+    }
+  }
+}

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/RDBStoreCodecBufferIterator.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/RDBStoreCodecBufferIterator.java
@@ -17,7 +17,6 @@
  */
 package org.apache.hadoop.hdds.utils.db;
 
-import org.apache.hadoop.hdds.StringUtils;
 import org.apache.hadoop.hdds.utils.db.managed.ManagedRocksIterator;
 import org.apache.ratis.util.Preconditions;
 
@@ -94,7 +93,7 @@ class RDBStoreCodecBufferIterator
       CodecBuffer prefix) {
     super(iterator, table, prefix);
 
-    final String name = table != null? table.getName(): null;
+    final String name = table != null ? table.getName() : null;
     this.keyBuffer = new Buffer(
         new CodecBuffer.Capacity(name + "-iterator-key", 1 << 10),
         buffer -> getRocksDBIterator().get().key(buffer));
@@ -141,8 +140,6 @@ class RDBStoreCodecBufferIterator
     if (key == null) {
       return false;
     }
-    System.out.println("key " + StringUtils.bytes2Hex(key.asReadOnlyByteBuffer())
-        + " startsWithPrefix " + StringUtils.bytes2Hex(prefix.asReadOnlyByteBuffer()));
     return key.startsWith(prefix);
   }
 

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/RDBTable.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/RDBTable.java
@@ -30,7 +30,6 @@ import java.util.function.Supplier;
 import org.apache.hadoop.hdds.annotation.InterfaceAudience;
 import org.apache.hadoop.hdds.utils.db.RocksDatabase.ColumnFamily;
 import org.apache.hadoop.hdds.utils.MetadataKeyFilters;
-import org.apache.hadoop.hdds.utils.db.managed.ManagedRocksIterator;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -230,8 +229,8 @@ class RDBTable implements Table<byte[], byte[]> {
 
   TableIterator<CodecBuffer, KeyValue<CodecBuffer, CodecBuffer>> iterator(
       CodecBuffer prefix) throws IOException {
-    final ManagedRocksIterator i = db.newIterator(family, false);
-    return new RDBStoreCodecBufferIterator(i, this, prefix);
+    return new RDBStoreCodecBufferIterator(db.newIterator(family, false),
+        this, prefix);
   }
 
   @Override

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/RDBTable.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/RDBTable.java
@@ -30,6 +30,7 @@ import java.util.function.Supplier;
 import org.apache.hadoop.hdds.annotation.InterfaceAudience;
 import org.apache.hadoop.hdds.utils.db.RocksDatabase.ColumnFamily;
 import org.apache.hadoop.hdds.utils.MetadataKeyFilters;
+import org.apache.hadoop.hdds.utils.db.managed.ManagedRocksIterator;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -217,7 +218,7 @@ class RDBTable implements Table<byte[], byte[]> {
   @Override
   public TableIterator<byte[], KeyValue<byte[], byte[]>> iterator()
       throws IOException {
-    return new RDBStoreByteArrayIterator(db.newIterator(family, false), this);
+    return iterator((byte[])null);
   }
 
   @Override
@@ -225,6 +226,12 @@ class RDBTable implements Table<byte[], byte[]> {
       throws IOException {
     return new RDBStoreByteArrayIterator(db.newIterator(family, false), this,
         prefix);
+  }
+
+  TableIterator<CodecBuffer, KeyValue<CodecBuffer, CodecBuffer>> iterator(
+      CodecBuffer prefix) throws IOException {
+    final ManagedRocksIterator i = db.newIterator(family, false);
+    return new RDBStoreCodecBufferIterator(i, this, prefix);
   }
 
   @Override

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/RawKeyValue.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/RawKeyValue.java
@@ -39,6 +39,26 @@ public abstract class RawKeyValue<RAW> implements KeyValue<RAW, RAW> {
     return new ByteArray(key, value);
   }
 
+  static <T> Table.KeyValue<T, T> create(
+      T key, T value) {
+    return new Table.KeyValue<T, T>() {
+      @Override
+      public T getKey() {
+        return key;
+      }
+
+      @Override
+      public T getValue() {
+        return value;
+      }
+
+      @Override
+      public String toString() {
+        return "(key=" + key + ", value=" + value + ")";
+      }
+    };
+  }
+
   /** Implement {@link RawKeyValue} with byte[]. */
   public static final class ByteArray extends RawKeyValue<byte[]> {
     static byte[] copy(byte[] bytes) {

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/RawKeyValue.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/RawKeyValue.java
@@ -39,26 +39,6 @@ public abstract class RawKeyValue<RAW> implements KeyValue<RAW, RAW> {
     return new ByteArray(key, value);
   }
 
-  static <T> Table.KeyValue<T, T> create(
-      T key, T value) {
-    return new Table.KeyValue<T, T>() {
-      @Override
-      public T getKey() {
-        return key;
-      }
-
-      @Override
-      public T getValue() {
-        return value;
-      }
-
-      @Override
-      public String toString() {
-        return "(key=" + key + ", value=" + value + ")";
-      }
-    };
-  }
-
   /** Implement {@link RawKeyValue} with byte[]. */
   public static final class ByteArray extends RawKeyValue<byte[]> {
     static byte[] copy(byte[] bytes) {

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/Table.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/Table.java
@@ -338,6 +338,25 @@ public interface Table<KEY, VALUE> extends AutoCloseable {
     VALUE getValue() throws IOException;
   }
 
+  static <K, V> KeyValue<K, V> newKeyValue(K key, V value) {
+    return new KeyValue<K, V>() {
+      @Override
+      public K getKey() {
+        return key;
+      }
+
+      @Override
+      public V getValue() {
+        return value;
+      }
+
+      @Override
+      public String toString() {
+        return "(key=" + key + ", value=" + value + ")";
+      }
+    };
+  }
+
   /** A {@link TableIterator} to iterate {@link KeyValue}s. */
   interface KeyValueIterator<KEY, VALUE>
       extends TableIterator<KEY, KeyValue<KEY, VALUE>> {

--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/utils/db/TestRDBStoreByteArrayIterator.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/utils/db/TestRDBStoreByteArrayIterator.java
@@ -23,7 +23,6 @@ import org.apache.hadoop.hdds.utils.db.managed.ManagedRocksIterator;
 import org.apache.hadoop.hdds.utils.db.managed.ManagedRocksObjectUtils;
 import org.apache.log4j.Level;
 import org.apache.log4j.Logger;
-import org.junit.Assert;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
@@ -39,7 +38,7 @@ import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.clearInvocations;
 import static org.mockito.Mockito.inOrder;
@@ -50,7 +49,8 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 /**
- * This test prescribe expected behaviour from the RDBStoreIterator which wraps
+ * This test prescribe expected behaviour
+ * from {@link RDBStoreByteArrayIterator} which wraps
  * RocksDB's own iterator. Ozone internally in TypedTableIterator uses, the
  * RDBStoreIterator to provide iteration over table elements in a typed manner.
  * The tests are to ensure we access RocksDB via the iterator properly.
@@ -70,7 +70,7 @@ public class TestRDBStoreByteArrayIterator {
   }
 
   RDBStoreByteArrayIterator newIterator() {
-    return new RDBStoreByteArrayIterator(managedRocksIterator, null);
+    return new RDBStoreByteArrayIterator(managedRocksIterator, null, null);
   }
 
   RDBStoreByteArrayIterator newIterator(byte[] prefix) {
@@ -234,8 +234,7 @@ public class TestRDBStoreByteArrayIterator {
     when(rocksDBIteratorMock.isValid()).thenReturn(true);
     when(rocksDBIteratorMock.key()).thenReturn(testKey);
 
-    RDBStoreByteArrayIterator iter =
-        new RDBStoreByteArrayIterator(managedRocksIterator, rocksTableMock);
+    RDBStoreByteArrayIterator iter = newIterator(null);
     iter.removeFromDB();
 
     InOrder verifier = inOrder(rocksDBIteratorMock, rocksTableMock);
@@ -329,6 +328,6 @@ public class TestRDBStoreByteArrayIterator {
     }
     String expectedTrace = sb.toString();
     String fromObjectInit = iterator.getStackTrace();
-    Assert.assertTrue(fromObjectInit.contains(expectedTrace));
+    assertTrue(fromObjectInit.contains(expectedTrace));
   }
 }

--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/utils/db/TestRDBStoreCodecBufferIterator.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/utils/db/TestRDBStoreCodecBufferIterator.java
@@ -14,7 +14,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
  */
 package org.apache.hadoop.hdds.utils.db;
 
@@ -83,14 +82,14 @@ public class TestRDBStoreCodecBufferIterator {
   }
 
   Answer<Integer> newAnswerInt(String name, int b) {
-    return newAnswer(name, (byte)b);
+    return newAnswer(name, (byte) b);
   }
 
   Answer<Integer> newAnswer(String name, byte... b) {
     return invocation -> {
       System.out.printf("answer %s: %s%n", name, StringUtils.bytes2Hex(b));
       Object[] args = invocation.getArguments();
-      final ByteBuffer buffer = (ByteBuffer)args[0];
+      final ByteBuffer buffer = (ByteBuffer) args[0];
       buffer.clear();
       buffer.put(b);
       buffer.flip();
@@ -99,7 +98,7 @@ public class TestRDBStoreCodecBufferIterator {
   }
 
   @Test
-  public void testForeachRemainingCallsConsumerWithAllElements() throws Exception {
+  public void testForEachRemaining() throws Exception {
     when(rocksIteratorMock.isValid())
         .thenReturn(true, true, true, true, true, true, true, false);
     when(rocksIteratorMock.key(any()))
@@ -118,7 +117,6 @@ public class TestRDBStoreCodecBufferIterator {
     List<Table.KeyValue<byte[], byte[]>> remaining = new ArrayList<>();
     try (RDBStoreCodecBufferIterator i = newIterator()) {
       i.forEachRemaining(kv -> {
-        System.out.println("add " + kv);
         try {
           remaining.add(RawKeyValue.create(
               kv.getKey().getArray(), kv.getValue().getArray()));
@@ -341,7 +339,8 @@ public class TestRDBStoreCodecBufferIterator {
   @Test
   public void testNormalPrefixedIterator() throws Exception {
     final byte[] prefixBytes = "sample".getBytes(StandardCharsets.UTF_8);
-    try(RDBStoreCodecBufferIterator i = newIterator(CodecBuffer.wrap(prefixBytes))) {
+    try (RDBStoreCodecBufferIterator i = newIterator(
+        CodecBuffer.wrap(prefixBytes))) {
       final ByteBuffer prefix = ByteBuffer.wrap(prefixBytes);
       verify(rocksIteratorMock, times(1)).seek(prefix);
       clearInvocations(rocksIteratorMock);
@@ -363,33 +362,6 @@ public class TestRDBStoreCodecBufferIterator {
       } catch (Exception e) {
         assertTrue(e instanceof UnsupportedOperationException);
       }
-    }
-
-    CodecTestUtil.gc();
-  }
-
-  @Test
-  public void testGetStackTrace() throws Exception {
-    try (ManagedRocksIterator iterator = mock(ManagedRocksIterator.class)) {
-      RocksIterator mock = mock(RocksIterator.class);
-      when(iterator.get()).thenReturn(mock);
-      when(mock.isOwningHandle()).thenReturn(true);
-      ManagedRocksObjectUtils.assertClosed(iterator);
-      verify(iterator, times(1)).getStackTrace();
-    }
-
-    try (ManagedRocksIterator iterator = newManagedRocksIterator()) {
-
-      // construct the expected trace.
-      StackTraceElement[] traces = Thread.currentThread().getStackTrace();
-      StringBuilder sb = new StringBuilder();
-      // first 2 lines will differ.
-      for (int i = 2; i < traces.length; i++) {
-        sb.append(traces[i]).append("\n");
-      }
-      String expectedTrace = sb.toString();
-      String fromObjectInit = iterator.getStackTrace();
-      assertTrue(fromObjectInit.contains(expectedTrace));
     }
 
     CodecTestUtil.gc();

--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/utils/db/TestRDBStoreCodecBufferIterator.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/utils/db/TestRDBStoreCodecBufferIterator.java
@@ -1,0 +1,397 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package org.apache.hadoop.hdds.utils.db;
+
+import org.apache.hadoop.hdds.StringUtils;
+import org.apache.hadoop.hdds.utils.db.managed.ManagedRocksIterator;
+import org.apache.hadoop.hdds.utils.db.managed.ManagedRocksObjectUtils;
+import org.apache.log4j.Level;
+import org.apache.log4j.Logger;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InOrder;
+import org.mockito.stubbing.Answer;
+import org.rocksdb.RocksIterator;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.NoSuchElementException;
+import java.util.concurrent.ThreadLocalRandom;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.clearInvocations;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * This test is similar to {@link TestRDBStoreByteArrayIterator}
+ * except that this test is for {@link RDBStoreCodecBufferIterator}.
+ */
+public class TestRDBStoreCodecBufferIterator {
+
+  private RocksIterator rocksIteratorMock;
+  private ManagedRocksIterator managedRocksIterator;
+  private RDBTable rdbTableMock;
+
+  @BeforeEach
+  public void setup() {
+    rocksIteratorMock = mock(RocksIterator.class);
+    managedRocksIterator = newManagedRocksIterator();
+    rdbTableMock = mock(RDBTable.class);
+    Logger.getLogger(ManagedRocksObjectUtils.class).setLevel(Level.DEBUG);
+  }
+
+  ManagedRocksIterator newManagedRocksIterator() {
+    return new ManagedRocksIterator(rocksIteratorMock);
+  }
+
+  RDBStoreCodecBufferIterator newIterator() {
+    return new RDBStoreCodecBufferIterator(managedRocksIterator, null, null);
+  }
+
+  RDBStoreCodecBufferIterator newIterator(CodecBuffer prefix) {
+    return new RDBStoreCodecBufferIterator(
+        managedRocksIterator, rdbTableMock, prefix);
+  }
+
+  Answer<Integer> newAnswerInt(String name, int b) {
+    return newAnswer(name, (byte)b);
+  }
+
+  Answer<Integer> newAnswer(String name, byte... b) {
+    return invocation -> {
+      System.out.printf("answer %s: %s%n", name, StringUtils.bytes2Hex(b));
+      Object[] args = invocation.getArguments();
+      final ByteBuffer buffer = (ByteBuffer)args[0];
+      buffer.clear();
+      buffer.put(b);
+      buffer.flip();
+      return b.length;
+    };
+  }
+
+  @Test
+  public void testForeachRemainingCallsConsumerWithAllElements() throws Exception {
+    when(rocksIteratorMock.isValid())
+        .thenReturn(true, true, true, true, true, true, true, false);
+    when(rocksIteratorMock.key(any()))
+        .then(newAnswerInt("key1", 0x00))
+        .then(newAnswerInt("key2", 0x00))
+        .then(newAnswerInt("key3", 0x01))
+        .then(newAnswerInt("key4", 0x02))
+        .thenThrow(new NoSuchElementException());
+    when(rocksIteratorMock.value(any()))
+        .then(newAnswerInt("val1", 0x7f))
+        .then(newAnswerInt("val2", 0x7f))
+        .then(newAnswerInt("val3", 0x7e))
+        .then(newAnswerInt("val4", 0x7d))
+        .thenThrow(new NoSuchElementException());
+
+    List<Table.KeyValue<byte[], byte[]>> remaining = new ArrayList<>();
+    try (RDBStoreCodecBufferIterator i = newIterator()) {
+      i.forEachRemaining(kv -> {
+        System.out.println("add " + kv);
+        try {
+          remaining.add(RawKeyValue.create(
+              kv.getKey().getArray(), kv.getValue().getArray()));
+        } catch (IOException e) {
+          throw new RuntimeException(e);
+        }
+      });
+
+      System.out.println("remaining: " + remaining);
+      assertArrayEquals(new byte[]{0x00}, remaining.get(0).getKey());
+      assertArrayEquals(new byte[]{0x7f}, remaining.get(0).getValue());
+      assertArrayEquals(new byte[]{0x01}, remaining.get(1).getKey());
+      assertArrayEquals(new byte[]{0x7e}, remaining.get(1).getValue());
+      assertArrayEquals(new byte[]{0x02}, remaining.get(2).getKey());
+      assertArrayEquals(new byte[]{0x7d}, remaining.get(2).getValue());
+    }
+
+    CodecTestUtil.gc();
+  }
+
+  @Test
+  public void testHasNextDependsOnIsvalid() throws Exception {
+    when(rocksIteratorMock.isValid()).thenReturn(true, true, false);
+
+    try (RDBStoreCodecBufferIterator i = newIterator()) {
+      assertTrue(i.hasNext());
+      assertFalse(i.hasNext());
+    }
+
+    CodecTestUtil.gc();
+  }
+
+  @Test
+  public void testNextCallsIsValidThenGetsTheValueAndStepsToNext()
+      throws Exception {
+    when(rocksIteratorMock.isValid()).thenReturn(true);
+    InOrder verifier = inOrder(rocksIteratorMock);
+    try (RDBStoreCodecBufferIterator i = newIterator()) {
+      i.next();
+    }
+
+    verifier.verify(rocksIteratorMock).isValid();
+    verifier.verify(rocksIteratorMock).key(any());
+    verifier.verify(rocksIteratorMock).value(any());
+    verifier.verify(rocksIteratorMock).next();
+
+    CodecTestUtil.gc();
+  }
+
+  @Test
+  public void testConstructorSeeksToFirstElement() throws Exception {
+    newIterator().close();
+
+    verify(rocksIteratorMock, times(1)).seekToFirst();
+
+    CodecTestUtil.gc();
+  }
+
+  @Test
+  public void testSeekToFirstSeeks() throws Exception {
+    try (RDBStoreCodecBufferIterator i = newIterator()) {
+      i.seekToFirst();
+    }
+    verify(rocksIteratorMock, times(2)).seekToFirst();
+
+    CodecTestUtil.gc();
+  }
+
+  @Test
+  public void testSeekToLastSeeks() throws Exception {
+    try (RDBStoreCodecBufferIterator i = newIterator()) {
+      i.seekToLast();
+    }
+
+    verify(rocksIteratorMock, times(1)).seekToLast();
+
+    CodecTestUtil.gc();
+  }
+
+  @Test
+  public void testSeekReturnsTheActualKey() throws Exception {
+    when(rocksIteratorMock.isValid()).thenReturn(true);
+    when(rocksIteratorMock.key(any()))
+        .then(newAnswerInt("key1", 0x00));
+    when(rocksIteratorMock.value(any()))
+        .then(newAnswerInt("val1", 0x7f));
+
+    try (RDBStoreCodecBufferIterator i = newIterator();
+         CodecBuffer target = CodecBuffer.wrap(new byte[]{0x55})) {
+      final Table.KeyValue<CodecBuffer, CodecBuffer> val = i.seek(target);
+
+      InOrder verifier = inOrder(rocksIteratorMock);
+
+      verify(rocksIteratorMock, times(1)).seekToFirst(); //at construct time
+      verify(rocksIteratorMock, never()).seekToLast();
+      verifier.verify(rocksIteratorMock, times(1))
+          .seek(any(ByteBuffer.class));
+      verifier.verify(rocksIteratorMock, times(1)).isValid();
+      verifier.verify(rocksIteratorMock, times(1)).key(any());
+      verifier.verify(rocksIteratorMock, times(1)).value(any());
+      assertArrayEquals(new byte[]{0x00}, val.getKey().getArray());
+      assertArrayEquals(new byte[]{0x7f}, val.getValue().getArray());
+    }
+
+    CodecTestUtil.gc();
+  }
+
+  @Test
+  public void testGettingTheKeyIfIteratorIsValid() throws Exception {
+    when(rocksIteratorMock.isValid()).thenReturn(true);
+    when(rocksIteratorMock.key(any()))
+        .then(newAnswerInt("key1", 0x00));
+
+    byte[] key = null;
+    try (RDBStoreCodecBufferIterator i = newIterator()) {
+      if (i.hasNext()) {
+        key = i.next().getKey().getArray();
+      }
+    }
+
+    InOrder verifier = inOrder(rocksIteratorMock);
+
+    verifier.verify(rocksIteratorMock, times(1)).isValid();
+    verifier.verify(rocksIteratorMock, times(1)).key(any());
+    assertArrayEquals(new byte[]{0x00}, key);
+
+    CodecTestUtil.gc();
+  }
+
+  @Test
+  public void testGettingTheValueIfIteratorIsValid() throws Exception {
+    when(rocksIteratorMock.isValid()).thenReturn(true);
+    when(rocksIteratorMock.key(any()))
+        .then(newAnswerInt("key1", 0x00));
+    when(rocksIteratorMock.value(any()))
+        .then(newAnswerInt("val1", 0x7f));
+
+    byte[] key = null;
+    byte[] value = null;
+    try (RDBStoreCodecBufferIterator i = newIterator()) {
+      if (i.hasNext()) {
+        Table.KeyValue<CodecBuffer, CodecBuffer> entry = i.next();
+        key = entry.getKey().getArray();
+        value = entry.getValue().getArray();
+      }
+    }
+
+    InOrder verifier = inOrder(rocksIteratorMock);
+
+    verifier.verify(rocksIteratorMock, times(1)).isValid();
+    verifier.verify(rocksIteratorMock, times(1)).key(any());
+    assertArrayEquals(new byte[]{0x00}, key);
+    assertArrayEquals(new byte[]{0x7f}, value);
+
+    CodecTestUtil.gc();
+  }
+
+  @Test
+  public void testRemovingFromDBActuallyDeletesFromTable() throws Exception {
+    final byte[] testKey = new byte[10];
+    ThreadLocalRandom.current().nextBytes(testKey);
+    when(rocksIteratorMock.isValid()).thenReturn(true);
+    when(rocksIteratorMock.key(any()))
+        .then(newAnswer("key1", testKey));
+
+    try (RDBStoreCodecBufferIterator i = newIterator(null)) {
+      i.removeFromDB();
+    }
+
+    InOrder verifier = inOrder(rocksIteratorMock, rdbTableMock);
+
+    verifier.verify(rocksIteratorMock, times(1)).isValid();
+    verifier.verify(rdbTableMock, times(1))
+        .delete(ByteBuffer.wrap(testKey));
+
+    CodecTestUtil.gc();
+  }
+
+  @Test
+  public void testRemoveFromDBWithoutDBTableSet() throws Exception {
+    try (RDBStoreCodecBufferIterator i = newIterator()) {
+      assertThrows(UnsupportedOperationException.class,
+          i::removeFromDB);
+    }
+
+    CodecTestUtil.gc();
+  }
+
+  @Test
+  public void testCloseCloses() throws Exception {
+    newIterator().close();
+
+    verify(rocksIteratorMock, times(1)).close();
+
+    CodecTestUtil.gc();
+  }
+
+  @Test
+  public void testNullPrefixedIterator() throws Exception {
+    try (RDBStoreCodecBufferIterator i = newIterator()) {
+      verify(rocksIteratorMock, times(1)).seekToFirst();
+      clearInvocations(rocksIteratorMock);
+
+      i.seekToFirst();
+      verify(rocksIteratorMock, times(1)).seekToFirst();
+      clearInvocations(rocksIteratorMock);
+
+      when(rocksIteratorMock.isValid()).thenReturn(true);
+      assertTrue(i.hasNext());
+      verify(rocksIteratorMock, times(1)).isValid();
+      verify(rocksIteratorMock, times(0)).key(any());
+
+      i.seekToLast();
+      verify(rocksIteratorMock, times(1)).seekToLast();
+    }
+
+    CodecTestUtil.gc();
+  }
+
+  @Test
+  public void testNormalPrefixedIterator() throws Exception {
+    final byte[] prefixBytes = "sample".getBytes(StandardCharsets.UTF_8);
+    try(RDBStoreCodecBufferIterator i = newIterator(CodecBuffer.wrap(prefixBytes))) {
+      final ByteBuffer prefix = ByteBuffer.wrap(prefixBytes);
+      verify(rocksIteratorMock, times(1)).seek(prefix);
+      clearInvocations(rocksIteratorMock);
+
+      i.seekToFirst();
+      verify(rocksIteratorMock, times(1)).seek(prefix);
+      clearInvocations(rocksIteratorMock);
+
+      when(rocksIteratorMock.isValid()).thenReturn(true);
+      when(rocksIteratorMock.key(any()))
+          .then(newAnswer("key1", prefixBytes));
+      assertTrue(i.hasNext());
+      verify(rocksIteratorMock, times(1)).isValid();
+      verify(rocksIteratorMock, times(1)).key(any());
+
+      try {
+        i.seekToLast();
+        fail("Prefixed iterator does not support seekToLast");
+      } catch (Exception e) {
+        assertTrue(e instanceof UnsupportedOperationException);
+      }
+    }
+
+    CodecTestUtil.gc();
+  }
+
+  @Test
+  public void testGetStackTrace() throws Exception {
+    try (ManagedRocksIterator iterator = mock(ManagedRocksIterator.class)) {
+      RocksIterator mock = mock(RocksIterator.class);
+      when(iterator.get()).thenReturn(mock);
+      when(mock.isOwningHandle()).thenReturn(true);
+      ManagedRocksObjectUtils.assertClosed(iterator);
+      verify(iterator, times(1)).getStackTrace();
+    }
+
+    try (ManagedRocksIterator iterator = newManagedRocksIterator()) {
+
+      // construct the expected trace.
+      StackTraceElement[] traces = Thread.currentThread().getStackTrace();
+      StringBuilder sb = new StringBuilder();
+      // first 2 lines will differ.
+      for (int i = 2; i < traces.length; i++) {
+        sb.append(traces[i]).append("\n");
+      }
+      String expectedTrace = sb.toString();
+      String fromObjectInit = iterator.getStackTrace();
+      assertTrue(fromObjectInit.contains(expectedTrace));
+    }
+
+    CodecTestUtil.gc();
+  }
+}


### PR DESCRIPTION
## What changes were proposed in this pull request?

Use RocksDB's ByteBuffer API to implement `Table.KeyValueIterator`.

## What is the link to the Apache JIRA

HDDS-8763

## How was this patch tested?

Added new tests.