### PR TITLE
HDDS-8841. [Snapshot] Fix to return correct snapshotDiff when key is renamed and overridden.

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOmSnapshot.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOmSnapshot.java
@@ -318,10 +318,10 @@ public class TestOmSnapshot {
      */
     String keyBaseA = "key-a-";
     for (int i = 0; i < 10; i++) {
-      createFileKey(volAbucketA, keyBaseA + i + "-");
-      createFileKey(volAbucketB, keyBaseA + i + "-");
-      createFileKey(volBbucketA, keyBaseA + i + "-");
-      createFileKey(volBbucketB, keyBaseA + i + "-");
+      createFileKeyWithPrefix(volAbucketA, keyBaseA + i + "-");
+      createFileKeyWithPrefix(volAbucketB, keyBaseA + i + "-");
+      createFileKeyWithPrefix(volBbucketA, keyBaseA + i + "-");
+      createFileKeyWithPrefix(volBbucketB, keyBaseA + i + "-");
     }
     /*
     Create 10 keys in  vol-a-<random>/buc-a-<random>,
@@ -330,10 +330,10 @@ public class TestOmSnapshot {
      */
     String keyBaseB = "key-b-";
     for (int i = 0; i < 10; i++) {
-      createFileKey(volAbucketA, keyBaseB + i + "-");
-      createFileKey(volAbucketB, keyBaseB + i + "-");
-      createFileKey(volBbucketA, keyBaseB + i + "-");
-      createFileKey(volBbucketB, keyBaseB + i + "-");
+      createFileKeyWithPrefix(volAbucketA, keyBaseB + i + "-");
+      createFileKeyWithPrefix(volAbucketB, keyBaseB + i + "-");
+      createFileKeyWithPrefix(volBbucketA, keyBaseB + i + "-");
+      createFileKeyWithPrefix(volBbucketB, keyBaseB + i + "-");
     }
 
     String snapshotKeyPrefix = createSnapshot(volumeA, bucketA);
@@ -454,7 +454,7 @@ public class TestOmSnapshot {
     OzoneBucket volBucket = vol.getBucket(bucket);
 
     String key = "key-";
-    createFileKey(volBucket, key);
+    createFileKeyWithPrefix(volBucket, key);
     String snapshotKeyPrefix = createSnapshot(volume, bucket);
     deleteKeys(volBucket);
 
@@ -480,11 +480,11 @@ public class TestOmSnapshot {
     OzoneBucket bucket1 = vol.getBucket(bucket);
 
     String key1 = "key-1-";
-    createFileKey(bucket1, key1);
+    createFileKeyWithPrefix(bucket1, key1);
     String snapshotKeyPrefix1 = createSnapshot(volume, bucket);
 
     String key2 = "key-2-";
-    createFileKey(bucket1, key2);
+    createFileKeyWithPrefix(bucket1, key2);
     String snapshotKeyPrefix2 = createSnapshot(volume, bucket);
 
     int volBucketKeyCount = keyCount(bucket1, snapshotKeyPrefix1 + "key-");
@@ -530,7 +530,7 @@ public class TestOmSnapshot {
     OzoneBucket bucket1 = volume1.getBucket(bucket);
     // Create Key1 and take snapshot
     String key1 = "key-1-";
-    createFileKey(bucket1, key1);
+    createFileKeyWithPrefix(bucket1, key1);
     String snap1 = "snap" + counter.incrementAndGet();
     createSnapshot(volume, bucket, snap1);
 
@@ -555,8 +555,8 @@ public class TestOmSnapshot {
     OzoneBucket bucketWithSnapshot = volume.getBucket(bucket1);
     OzoneBucket bucketWithoutSnapshot = volume.getBucket(bucket2);
     String key = "key-";
-    createFileKey(bucketWithSnapshot, key);
-    createFileKey(bucketWithoutSnapshot, key);
+    createFileKeyWithPrefix(bucketWithSnapshot, key);
+    createFileKeyWithPrefix(bucketWithoutSnapshot, key);
     createSnapshot(volume1, bucket1);
     deleteKeys(bucketWithSnapshot);
     deleteKeys(bucketWithoutSnapshot);
@@ -578,7 +578,7 @@ public class TestOmSnapshot {
     OzoneBucket bucket1 = volume1.getBucket(bucket);
     // Create Key1 and take snapshot
     String key1 = "key-1-";
-    key1 = createFileKey(bucket1, key1);
+    key1 = createFileKeyWithPrefix(bucket1, key1);
     String snap1 = "snap" + counter.incrementAndGet();
     createSnapshot(volume, bucket, snap1);
     // Do nothing, take another snapshot
@@ -590,7 +590,7 @@ public class TestOmSnapshot {
     Assert.assertTrue(diff1.getDiffList().isEmpty());
     // Create Key2 and delete Key1, take snapshot
     String key2 = "key-2-";
-    key2 = createFileKey(bucket1, key2);
+    key2 = createFileKeyWithPrefix(bucket1, key2);
     bucket1.deleteKey(key1);
     String snap3 = "snap" + counter.incrementAndGet();
     createSnapshot(volume, bucket, snap3);
@@ -637,6 +637,28 @@ public class TestOmSnapshot {
         SnapshotDiffReportOzone.getDiffReportEntry(
             SnapshotDiffReportOzone.DiffType.CREATE, dir1)));
 
+    String key3 = createFileKeyWithPrefix(bucket1, "key-3-");
+    String snap6 = "snap" + counter.incrementAndGet();
+    createSnapshot(volume, bucket, snap6);
+    createFileKey(bucket1, key3);
+    String renamedKey3 = key3 + "_renamed";
+    bucket1.renameKey(key3, renamedKey3);
+
+    String snap7 = "snap" + counter.incrementAndGet();
+    createSnapshot(volume, bucket, snap7);
+    SnapshotDiffReportOzone
+        diff5 = getSnapDiffReport(volume, bucket, snap6, snap7);
+    assertEquals(2, diff5.getDiffList().size());
+    assertEquals(SnapshotDiffReportOzone.DiffType.RENAME,
+        diff5.getDiffList().get(0).getType());
+    assertEquals(key3, org.apache.hadoop.hdds.StringUtils.bytes2String(
+        diff5.getDiffList().get(0).getSourcePath()));
+    assertEquals(renamedKey3, org.apache.hadoop.hdds.StringUtils.bytes2String(
+        diff5.getDiffList().get(0).getTargetPath()));
+    assertEquals(SnapshotDiffReportOzone.DiffType.MODIFY,
+        diff5.getDiffList().get(1).getType());
+    assertEquals(key3, org.apache.hadoop.hdds.StringUtils.bytes2String(
+        diff5.getDiffList().get(1).getSourcePath()));
   }
 
   @Test
@@ -761,9 +783,9 @@ public class TestOmSnapshot {
   }
 
   private SnapshotDiffReportOzone getSnapDiffReport(String volume,
-                                               String bucket,
-                                               String fromSnapshot,
-                                               String toSnapshot)
+                                                    String bucket,
+                                                    String fromSnapshot,
+                                                    String toSnapshot)
       throws InterruptedException, IOException {
     SnapshotDiffResponse response;
     do {
@@ -785,7 +807,7 @@ public class TestOmSnapshot {
     OzoneBucket bucket1 = volume1.getBucket(bucket);
     // Create Key1 and take snapshot
     String key1 = "key-1-";
-    createFileKey(bucket1, key1);
+    createFileKeyWithPrefix(bucket1, key1);
     String snap1 = "snap" + counter.incrementAndGet();
     createSnapshot(volume, bucket, snap1);
     String snap2 = "snap" + counter.incrementAndGet();
@@ -815,7 +837,7 @@ public class TestOmSnapshot {
     OzoneBucket bucket1 = volume1.getBucket(bucketa);
     // Create Key1 and take 2 snapshots
     String key1 = "key-1-";
-    createFileKey(bucket1, key1);
+    createFileKeyWithPrefix(bucket1, key1);
     String snap1 = "snap" + counter.incrementAndGet();
     createSnapshot(volumea, bucketa, snap1);
     String snap2 = "snap" + counter.incrementAndGet();
@@ -847,7 +869,7 @@ public class TestOmSnapshot {
     OzoneBucket bucket1 = volume1.getBucket(bucket);
     // Create Key1 and take snapshot
     String key1 = "key-1-";
-    createFileKey(bucket1, key1);
+    createFileKeyWithPrefix(bucket1, key1);
     String snap1 = "snap" + counter.incrementAndGet();
     createSnapshot(volume, bucket, snap1);
     String snap2 = "snap" + counter.incrementAndGet();
@@ -886,13 +908,13 @@ public class TestOmSnapshot {
     OzoneBucket bucket2 = volume1.getBucket(bucketName2);
     // Create Key1 and take snapshot
     String key1 = "key-1-";
-    key1 = createFileKey(bucket1, key1);
+    key1 = createFileKeyWithPrefix(bucket1, key1);
     String snap1 = "snap" + counter.incrementAndGet();
     createSnapshot(volume, bucketName1, snap1);
     // Create key in bucket2 and bucket1 and calculate diff
     // Diff should not contain bucket2's key
-    createFileKey(bucket1, key1);
-    createFileKey(bucket2, key1);
+    createFileKeyWithPrefix(bucket1, key1);
+    createFileKeyWithPrefix(bucket2, key1);
     String snap2 = "snap" + counter.incrementAndGet();
     createSnapshot(volume, bucketName1, snap2);
     SnapshotDiffReportOzone diff1 =
@@ -922,23 +944,23 @@ public class TestOmSnapshot {
     OzoneBucket bucket2 = volume1.getBucket(bucketName2);
     String keyPrefix = "key-";
     // add file to bucket1 and take snapshot
-    createFileKey(bucket1, keyPrefix);
+    createFileKeyWithPrefix(bucket1, keyPrefix);
     String snap1 = "snap" + counter.incrementAndGet();
     createSnapshot(volumeName1, bucketName1, snap1); // 1.sst
     Assert.assertEquals(1, getKeyTableSstFiles().size());
     // add files to bucket2 and flush twice to create 2 sst files
     for (int i = 0; i < 5; i++) {
-      createFileKey(bucket2, keyPrefix);
+      createFileKeyWithPrefix(bucket2, keyPrefix);
     }
     flushKeyTable(); // 1.sst 2.sst
     Assert.assertEquals(2, getKeyTableSstFiles().size());
     for (int i = 0; i < 5; i++) {
-      createFileKey(bucket2, keyPrefix);
+      createFileKeyWithPrefix(bucket2, keyPrefix);
     }
     flushKeyTable(); // 1.sst 2.sst 3.sst
     Assert.assertEquals(3, getKeyTableSstFiles().size());
     // add a file to bucket1 and take second snapshot
-    createFileKey(bucket1, keyPrefix);
+    createFileKeyWithPrefix(bucket1, keyPrefix);
     String snap2 = "snap" + counter.incrementAndGet();
     createSnapshot(volumeName1, bucketName1, snap2); // 1.sst 2.sst 3.sst 4.sst
     Assert.assertEquals(4, getKeyTableSstFiles().size());
@@ -959,7 +981,7 @@ public class TestOmSnapshot {
     OzoneBucket bucket1 = volume1.getBucket(bucket);
     // Create Key1 and take snapshot
     String key1 = "key-1-";
-    createFileKey(bucket1, key1);
+    createFileKeyWithPrefix(bucket1, key1);
     String snap1 = "snap" + counter.incrementAndGet();
     createSnapshot(volume, bucket, snap1);
     store.deleteSnapshot(volume, bucket, snap1);
@@ -980,7 +1002,7 @@ public class TestOmSnapshot {
     OzoneBucket bucket1 = volume1.getBucket(bucket);
     // Create Key1 and take snapshot
     String key1 = "key-1-";
-    createFileKey(bucket1, key1);
+    createFileKeyWithPrefix(bucket1, key1);
     String snap1 = "snap" + counter.incrementAndGet();
     createSnapshot(volume, bucket, snap1);
 
@@ -1005,7 +1027,7 @@ public class TestOmSnapshot {
     OzoneBucket bucket1 = volume1.getBucket(bucket);
     // Create Key1 and take snapshot
     String key1 = "key-1-";
-    createFileKey(bucket1, key1);
+    createFileKeyWithPrefix(bucket1, key1);
     String snap1 = "snap" + counter.incrementAndGet();
     createSnapshot(volume, bucket, snap1);
     String nullstr = "";
@@ -1070,14 +1092,19 @@ public class TestOmSnapshot {
     }
   }
 
-  private String createFileKey(OzoneBucket bucket, String keyPrefix)
+  private String createFileKeyWithPrefix(OzoneBucket bucket, String keyPrefix)
+      throws IOException {
+    String key = keyPrefix + counter.incrementAndGet();
+    createFileKey(bucket, key);
+    return key;
+  }
+
+  private void createFileKey(OzoneBucket bucket, String key)
       throws IOException {
     byte[] value = RandomStringUtils.randomAscii(10240).getBytes(UTF_8);
-    String key = keyPrefix + counter.incrementAndGet();
     OzoneOutputStream fileKey = bucket.createKey(key, value.length);
     fileKey.write(value);
     fileKey.close();
-    return key;
   }
 
   @Test
@@ -1187,11 +1214,11 @@ public class TestOmSnapshot {
 
   private void createSnapshots(String snapshot1,
                                String snapshot2) throws IOException {
-    createFileKey(ozoneBucket, "key");
+    createFileKeyWithPrefix(ozoneBucket, "key");
     store.createSnapshot(volumeName, bucketName, snapshot1);
 
     for (int i = 0; i < 100; i++) {
-      createFileKey(ozoneBucket, "key-" + i);
+      createFileKeyWithPrefix(ozoneBucket, "key-" + i);
     }
 
     store.createSnapshot(volumeName, bucketName, snapshot2);

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmSnapshotManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmSnapshotManager.java
@@ -57,6 +57,7 @@ import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
 import org.apache.hadoop.ozone.om.helpers.RepeatedOmKeyInfo;
 import org.apache.hadoop.ozone.om.helpers.SnapshotInfo;
 import org.apache.hadoop.ozone.om.service.SnapshotDiffCleanupService;
+import org.apache.hadoop.ozone.om.snapshot.SnapshotDiffObject;
 import org.apache.hadoop.ozone.om.snapshot.SnapshotDiffJob;
 import org.apache.hadoop.ozone.om.snapshot.SnapshotDiffManager;
 import org.apache.hadoop.ozone.om.snapshot.SnapshotUtils;
@@ -354,6 +355,7 @@ public final class OmSnapshotManager implements AutoCloseable {
     registry.addCodec(SnapshotDiffReportOzone.DiffReportEntry.class,
         SnapshotDiffReportOzone.getDiffReportEntryCodec());
     registry.addCodec(SnapshotDiffJob.class, SnapshotDiffJob.getCodec());
+    registry.addCodec(SnapshotDiffObject.class, SnapshotDiffObject.getCodec());
     return registry.build();
   }
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/service/SnapshotDeletingService.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/service/SnapshotDeletingService.java
@@ -616,9 +616,19 @@ public class SnapshotDeletingService extends AbstractKeyDeletingService {
     }
   }
 
+  // TODO: Move this util class.
   public static boolean isBlockLocationInfoSame(OmKeyInfo prevKeyInfo,
                                                 OmKeyInfo deletedKeyInfo) {
 
+    if (prevKeyInfo == null && deletedKeyInfo == null) {
+      LOG.debug("Both prevKeyInfo and deletedKeyInfo are null.");
+      return true;
+    }
+    if (prevKeyInfo == null || deletedKeyInfo == null) {
+      LOG.debug("prevKeyInfo: '{}' or deletedKeyInfo: '{}' is null.",
+          prevKeyInfo, deletedKeyInfo);
+      return false;
+    }
     // For hsync, Though the blockLocationInfo of a key may not be same
     // at the time of snapshot and key deletion as blocks can be appended.
     // If the objectId is same then the key is same.

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/snapshot/RocksDbPersistentMap.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/snapshot/RocksDbPersistentMap.java
@@ -20,6 +20,8 @@ package org.apache.hadoop.ozone.om.snapshot;
 
 import java.io.IOException;
 import java.util.Map;
+import java.util.NoSuchElementException;
+
 import org.apache.hadoop.hdds.utils.db.CodecRegistry;
 import org.apache.hadoop.hdds.utils.db.managed.ManagedRocksDB;
 import org.apache.hadoop.hdds.utils.db.managed.ManagedRocksIterator;
@@ -98,6 +100,9 @@ public class RocksDbPersistentMap<K, V> implements PersistentMap<K, V> {
 
       @Override
       public Map.Entry<K, V> next() {
+        if (!hasNext()) {
+          throw new NoSuchElementException("No more elements in the map.");
+        }
         K key;
         V value;
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/snapshot/SnapshotDiffManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/snapshot/SnapshotDiffManager.java
@@ -71,6 +71,8 @@ import org.apache.hadoop.ozone.om.helpers.OmDirectoryInfo;
 import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
 import org.apache.hadoop.ozone.om.helpers.SnapshotInfo;
 import org.apache.hadoop.ozone.om.helpers.WithObjectID;
+import org.apache.hadoop.ozone.om.service.SnapshotDeletingService;
+import org.apache.hadoop.ozone.om.snapshot.SnapshotDiffObject.SnapshotDiffObjectBuilder;
 import org.apache.hadoop.ozone.snapshot.SnapshotDiffReportOzone;
 import org.apache.hadoop.util.ClosableIterator;
 import org.apache.hadoop.ozone.snapshot.SnapshotDiffResponse;
@@ -775,9 +777,9 @@ public class SnapshotDiffManager implements AutoCloseable {
           new RocksDbPersistentMap<>(db, toSnapshotColumnFamily, codecRegistry,
               byte[].class, byte[].class);
       // Set of unique objectId between fromSnapshot and toSnapshot.
-      final PersistentSet<byte[]> objectIDsToCheckMap =
-          new RocksDbPersistentSet<>(db, objectIDsColumnFamily, codecRegistry,
-              byte[].class);
+      final PersistentMap<byte[], SnapshotDiffObject> objectIdToDiffObject =
+          new RocksDbPersistentMap<>(db, objectIDsColumnFamily, codecRegistry,
+              byte[].class, SnapshotDiffObject.class);
 
       final BucketLayout bucketLayout = getBucketLayout(volumeName, bucketName,
           fromSnapshot.getMetadataManager());
@@ -804,7 +806,7 @@ public class SnapshotDiffManager implements AutoCloseable {
             getDeltaFilesAndDiffKeysToObjectIdToKeyMap(fsKeyTable, tsKeyTable,
                 fromSnapshot, toSnapshot, fsInfo, tsInfo, useFullDiff,
                 tablePrefixes, objectIdToKeyNameMapForFromSnapshot,
-                objectIdToKeyNameMapForToSnapshot, objectIDsToCheckMap,
+                objectIdToKeyNameMapForToSnapshot, objectIdToDiffObject,
                 path.toString());
             return null;
           },
@@ -818,14 +820,16 @@ public class SnapshotDiffManager implements AutoCloseable {
               getDeltaFilesAndDiffKeysToObjectIdToKeyMap(fsDirTable, tsDirTable,
                   fromSnapshot, toSnapshot, fsInfo, tsInfo, useFullDiff,
                   tablePrefixes, objectIdToKeyNameMapForFromSnapshot,
-                  objectIdToKeyNameMapForToSnapshot, objectIDsToCheckMap,
+                  objectIdToKeyNameMapForToSnapshot, objectIdToDiffObject,
                   path.toString());
             }
             return null;
           },
           () -> {
             long totalDiffEntries = generateDiffReport(jobId,
-                objectIDsToCheckMap,
+                fsKeyTable,
+                tsKeyTable,
+                objectIdToDiffObject,
                 objectIdToKeyNameMapForFromSnapshot,
                 objectIdToKeyNameMapForToSnapshot,
                 volumeName, bucketName,
@@ -884,7 +888,7 @@ public class SnapshotDiffManager implements AutoCloseable {
       final Map<String, String> tablePrefixes,
       final PersistentMap<byte[], byte[]> oldObjIdToKeyMap,
       final PersistentMap<byte[], byte[]> newObjIdToKeyMap,
-      final PersistentSet<byte[]> objectIDsToCheck,
+      final PersistentMap<byte[], SnapshotDiffObject> objectIdToDiffObject,
       final String diffDir
   ) throws IOException, RocksDBException {
 
@@ -908,7 +912,7 @@ public class SnapshotDiffManager implements AutoCloseable {
           sstDumpTool.isPresent(),
           oldObjIdToKeyMap,
           newObjIdToKeyMap,
-          objectIDsToCheck,
+          objectIdToDiffObject,
           tablePrefixes);
     } catch (NativeLibraryNotLoadedException e) {
       LOG.warn("SSTDumpTool load failure, retrying without it.", e);
@@ -924,7 +928,7 @@ public class SnapshotDiffManager implements AutoCloseable {
             false,
             oldObjIdToKeyMap,
             newObjIdToKeyMap,
-            objectIDsToCheck,
+            objectIdToDiffObject,
             tablePrefixes);
       } catch (NativeLibraryNotLoadedException ex) {
         throw new IllegalStateException(ex);
@@ -933,13 +937,15 @@ public class SnapshotDiffManager implements AutoCloseable {
   }
 
   @SuppressWarnings("checkstyle:ParameterNumber")
-  void addToObjectIdMap(Table<String, ? extends WithObjectID> fsTable,
-                        Table<String, ? extends WithObjectID> tsTable,
-                        Set<String> deltaFiles, boolean nativeRocksToolsLoaded,
-                        PersistentMap<byte[], byte[]> oldObjIdToKeyMap,
-                        PersistentMap<byte[], byte[]> newObjIdToKeyMap,
-                        PersistentSet<byte[]> objectIDsToCheck,
-                        Map<String, String> tablePrefixes) throws IOException,
+  void addToObjectIdMap(
+      final Table<String, ? extends WithObjectID> fsTable,
+      final Table<String, ? extends WithObjectID> tsTable,
+      final Set<String> deltaFiles, boolean nativeRocksToolsLoaded,
+      final PersistentMap<byte[], byte[]> oldObjIdToKeyMap,
+      final PersistentMap<byte[], byte[]> newObjIdToKeyMap,
+      final PersistentMap<byte[], SnapshotDiffObject> objectIdToDiffObject,
+      final Map<String, String> tablePrefixes
+  ) throws IOException,
       NativeLibraryNotLoadedException, RocksDBException {
     if (deltaFiles.isEmpty()) {
       return;
@@ -955,26 +961,33 @@ public class SnapshotDiffManager implements AutoCloseable {
                  : sstFileReader.getKeyStream()) {
       keysToCheck.forEach(key -> {
         try {
-          final WithObjectID oldKey = fsTable.get(key);
-          final WithObjectID newKey = tsTable.get(key);
-          if (areKeysEqual(oldKey, newKey) || !isKeyInBucket(key, tablePrefixes,
-              fsTable.getName())) {
+          final WithObjectID fromObjectId = fsTable.get(key);
+          final WithObjectID toObjectId = tsTable.get(key);
+          if (areKeysEqual(fromObjectId, toObjectId) || !isKeyInBucket(key,
+              tablePrefixes, fsTable.getName())) {
             // We don't have to do anything.
             return;
           }
-          if (oldKey != null) {
-            byte[] rawObjId = codecRegistry.asRawData(oldKey.getObjectID());
+          if (fromObjectId != null) {
+            byte[] rawObjId = codecRegistry.asRawData(
+                fromObjectId.getObjectID());
             byte[] rawValue = codecRegistry.asRawData(
-                getKeyOrDirectoryName(isDirectoryTable, oldKey));
+                getKeyOrDirectoryName(isDirectoryTable, fromObjectId));
             oldObjIdToKeyMap.put(rawObjId, rawValue);
-            objectIDsToCheck.add(rawObjId);
+            SnapshotDiffObject diffObject =
+                createDiffObjectWithOldName(fromObjectId.getObjectID(), key,
+                objectIdToDiffObject.get(rawObjId));
+            objectIdToDiffObject.put(rawObjId, diffObject);
           }
-          if (newKey != null) {
-            byte[] rawObjId = codecRegistry.asRawData(newKey.getObjectID());
+          if (toObjectId != null) {
+            byte[] rawObjId = codecRegistry.asRawData(toObjectId.getObjectID());
             byte[] rawValue = codecRegistry.asRawData(
-                getKeyOrDirectoryName(isDirectoryTable, newKey));
+                getKeyOrDirectoryName(isDirectoryTable, toObjectId));
             newObjIdToKeyMap.put(rawObjId, rawValue);
-            objectIDsToCheck.add(rawObjId);
+            SnapshotDiffObject diffObject =
+                createDiffObjectWithNewName(toObjectId.getObjectID(), key,
+                    objectIdToDiffObject.get(rawObjId));
+            objectIdToDiffObject.put(rawObjId, diffObject);
           }
         } catch (IOException e) {
           throw new RuntimeException(e);
@@ -985,6 +998,27 @@ public class SnapshotDiffManager implements AutoCloseable {
       //  e.g. when input files do not exist
       throw new RuntimeException(rocksDBException);
     }
+  }
+
+  private SnapshotDiffObject createDiffObjectWithOldName(
+      long objectId, String oldName, SnapshotDiffObject diffObject) {
+    SnapshotDiffObjectBuilder builder = new SnapshotDiffObjectBuilder(objectId)
+            .withOldKeyName(oldName);
+    if (diffObject != null) {
+      builder.withNewKeyName(diffObject.getNewKeyName());
+    }
+    return builder.build();
+  }
+
+  private SnapshotDiffObject createDiffObjectWithNewName(
+      long objectId, String newName, SnapshotDiffObject diffObject) {
+
+    SnapshotDiffObjectBuilder builder = new SnapshotDiffObjectBuilder(objectId)
+        .withNewKeyName(newName);
+    if (diffObject != null) {
+      builder.withOldKeyName(diffObject.getOldKeyName());
+    }
+    return builder.build();
   }
 
   private String getKeyOrDirectoryName(boolean isDirectory,
@@ -1064,17 +1098,19 @@ public class SnapshotDiffManager implements AutoCloseable {
     }
   }
 
-  @SuppressWarnings("checkstyle:ParameterNumber")
-  long generateDiffReport(final String jobId,
-                          final PersistentSet<byte[]> objectIDsToCheck,
-                          final PersistentMap<byte[], byte[]> oldObjIdToKeyMap,
-                          final PersistentMap<byte[], byte[]>
-                              newObjIdToKeyMap,
-                          final String volumeName,
-                          final String bucketName,
-                          final String fromSnapshotName,
-                          final String toSnapshotName) {
-    LOG.debug("Starting diff report generation for jobId: {}.", jobId);
+  @SuppressWarnings({"checkstyle:ParameterNumber", "checkstyle:MethodLength"})
+  long generateDiffReport(
+      final String jobId,
+      final Table<String, ? extends WithObjectID> fsTable,
+      final Table<String, ? extends WithObjectID> tsTable,
+      final PersistentMap<byte[], SnapshotDiffObject> objectIdToDiffObject,
+      final PersistentMap<byte[], byte[]> oldObjIdToKeyMap,
+      final PersistentMap<byte[], byte[]> newObjIdToKeyMap,
+      final String volumeName,
+      final String bucketName,
+      final String fromSnapshotName,
+      final String toSnapshotName) {
+    LOG.info("Starting diff report generation for jobId: {}.", jobId);
     ColumnFamilyHandle deleteDiffColumnFamily = null;
     ColumnFamilyHandle renameDiffColumnFamily = null;
     ColumnFamilyHandle createDiffColumnFamily = null;
@@ -1102,20 +1138,22 @@ public class SnapshotDiffManager implements AutoCloseable {
       final PersistentList<byte[]> modifyDiffs =
           createDiffReportPersistentList(modifyDiffColumnFamily);
 
-      try (ClosableIterator<byte[]>
-               objectIdsIterator = objectIDsToCheck.iterator()) {
+      try (ClosableIterator<Map.Entry<byte[], SnapshotDiffObject>>
+               iterator = objectIdToDiffObject.iterator()) {
         // This counter is used, so that we can check every 100 elements
         // if the job is cancelled and snapshots are still active.
         int counter = 0;
-
-        while (objectIdsIterator.hasNext()) {
+        while (iterator.hasNext()) {
           if (counter % 100 == 0 &&
               !areDiffJobAndSnapshotsActive(volumeName, bucketName,
                   fromSnapshotName, toSnapshotName)) {
             return -1L;
           }
 
-          byte[] id = objectIdsIterator.next();
+          Map.Entry<byte[], SnapshotDiffObject> nextEntry = iterator.next();
+          byte[] id = nextEntry.getKey();
+          SnapshotDiffObject snapshotDiffObject = nextEntry.getValue();
+
           /*
            * This key can be
            * -> Created after the old snapshot was taken, which means it will be
@@ -1129,7 +1167,6 @@ public class SnapshotDiffManager implements AutoCloseable {
            *    present in oldKeyTable and present in newKeyTable but with
            *    different name and same Object ID.
            */
-
           byte[] oldKeyName = oldObjIdToKeyMap.get(id);
           byte[] newKeyName = newObjIdToKeyMap.get(id);
 
@@ -1155,7 +1192,19 @@ public class SnapshotDiffManager implements AutoCloseable {
                 SnapshotDiffReportOzone.getDiffReportEntry(DiffType.MODIFY,
                     key);
             modifyDiffs.add(codecRegistry.asRawData(entry));
-          } else { // Key Renamed.
+          } else if (!isBlockLocationSame(snapshotDiffObject.getOldKeyName(),
+              snapshotDiffObject.getNewKeyName(), fsTable, tsTable)) {
+            String oldKey = codecRegistry.asObject(oldKeyName, String.class);
+            String newKey = codecRegistry.asObject(newKeyName, String.class);
+            renameDiffs.add(codecRegistry.asRawData(
+                SnapshotDiffReportOzone.getDiffReportEntry(DiffType.RENAME,
+                    oldKey, newKey)));
+            // Here, oldKey name is returned as modified. Modified key name is
+            // based on base snapshot (from snapshot).
+            renameDiffs.add(codecRegistry.asRawData(
+                SnapshotDiffReportOzone.getDiffReportEntry(DiffType.MODIFY,
+                    oldKey)));
+          } else {
             String oldKey = codecRegistry.asObject(oldKeyName, String.class);
             String newKey = codecRegistry.asObject(newKeyName, String.class);
             renameDiffs.add(codecRegistry.asRawData(
@@ -1217,6 +1266,50 @@ public class SnapshotDiffManager implements AutoCloseable {
       dropAndCloseColumnFamilyHandle(createDiffColumnFamily);
       dropAndCloseColumnFamilyHandle(modifyDiffColumnFamily);
     }
+  }
+
+  private boolean isBlockLocationSame(
+      String fromObjectName,
+      String toObjectName,
+      final Table<String, ? extends WithObjectID> fromSnapshotTable,
+      final Table<String, ? extends WithObjectID> toSnapshotTable
+  ) throws IOException {
+
+    if (fromObjectName == null && toObjectName == null) {
+      LOG.debug("fromObjectName and toObjectName are null.");
+      return true;
+    }
+
+    if (fromObjectName == null || toObjectName == null) {
+      LOG.debug("fromObjectName: '{}' or toObjectName: '{}' is null.",
+          fromObjectName, toObjectName);
+      return false;
+    }
+
+    final WithObjectID fromObject = fromSnapshotTable.get(fromObjectName);
+    final WithObjectID toObject = toSnapshotTable.get(toObjectName);
+
+    if (fromObject == null && toObject == null) {
+      LOG.debug("fromObject and toObject both are null.");
+      return true;
+    }
+
+    if (fromObject == null || toObject == null) {
+      LOG.debug("fromObject: '{}' or toObject: '{}' is null.",
+          fromObject, toObject);
+      return false;
+    }
+
+    if (!(fromObject instanceof OmKeyInfo) ||
+        !(toObject instanceof OmKeyInfo)) {
+      LOG.debug("fromObject is instance of '{}' and toObject is of '{}'.",
+          fromObject.getClass().getSimpleName(),
+          toObject.getClass().getSimpleName());
+      return false;
+    }
+
+    return SnapshotDeletingService.isBlockLocationInfoSame(
+        (OmKeyInfo) fromObject, (OmKeyInfo) toObject);
   }
 
   private PersistentList<byte[]> createDiffReportPersistentList(

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/snapshot/SnapshotDiffObject.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/snapshot/SnapshotDiffObject.java
@@ -1,0 +1,144 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.ozone.om.snapshot;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.hadoop.hdds.utils.db.Codec;
+
+import java.io.IOException;
+
+/**
+ * SnapshotDiffObject to keep objectId, key's oldName and newName.
+ */
+public class SnapshotDiffObject {
+
+  private static final Codec<SnapshotDiffObject> CODEC =
+      new SnapshotDiffObjectCodec();
+
+  public static Codec<SnapshotDiffObject> getCodec() {
+    return CODEC;
+  }
+
+  private long objectId;
+  private String oldKeyName;
+  private String newKeyName;
+
+  // Default constructor for Jackson Serializer.
+  public SnapshotDiffObject() {
+
+  }
+
+  public SnapshotDiffObject(long objectId,
+                            String oldKeyName,
+                            String newKeyName) {
+    this.objectId = objectId;
+    this.oldKeyName = oldKeyName;
+    this.newKeyName = newKeyName;
+  }
+
+  public long getObjectId() {
+    return objectId;
+  }
+
+  public String getOldKeyName() {
+    return oldKeyName;
+  }
+
+  public String getNewKeyName() {
+    return newKeyName;
+  }
+
+  // For Jackson Serializer.
+  public void setObjectId(long objectId) {
+    this.objectId = objectId;
+  }
+
+  // For Jackson Serializer.
+  public void setOldKeyName(String oldKeyName) {
+    this.oldKeyName = oldKeyName;
+  }
+
+  // For Jackson Serializer.
+  public void setNewKeyName(String newKeyName) {
+    this.newKeyName = newKeyName;
+  }
+
+  /**
+   * Builder for SnapshotDiffObject.
+   */
+  public static class SnapshotDiffObjectBuilder {
+    private final long objectId;
+    private String oldKeyName;
+    private String newKeyName;
+
+    public SnapshotDiffObjectBuilder(long objectID) {
+      this.objectId = objectID;
+    }
+
+    public static SnapshotDiffObjectBuilder newBuilder(long objectID) {
+      return new SnapshotDiffObjectBuilder(objectID);
+    }
+
+    public SnapshotDiffObjectBuilder withOldKeyName(String keyName) {
+      this.oldKeyName = keyName;
+      return this;
+    }
+
+    public SnapshotDiffObjectBuilder withNewKeyName(String keyName) {
+      this.newKeyName = keyName;
+      return this;
+    }
+
+    public SnapshotDiffObject build() {
+      return new SnapshotDiffObject(objectId, oldKeyName, newKeyName);
+    }
+  }
+
+
+  /**
+   * Codec to encode KeyObject as byte array.
+   */
+  private static final class SnapshotDiffObjectCodec
+      implements Codec<SnapshotDiffObject> {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper()
+        .setSerializationInclusion(JsonInclude.Include.NON_NULL)
+        .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+
+    @Override
+    public byte[] toPersistedFormat(SnapshotDiffObject object)
+        throws IOException {
+      return MAPPER.writeValueAsBytes(object);
+    }
+
+    @Override
+    public SnapshotDiffObject fromPersistedFormat(byte[] rawData)
+        throws IOException {
+      return MAPPER.readValue(rawData, SnapshotDiffObject.class);
+    }
+
+    @Override
+    public SnapshotDiffObject copyObject(SnapshotDiffObject object) {
+      // Note: Not really a "copy".
+      return object;
+    }
+  }
+}

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/snapshot/TestSnapshotDiffManager.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/snapshot/TestSnapshotDiffManager.java
@@ -48,11 +48,13 @@ import org.apache.hadoop.ozone.om.helpers.OmDirectoryInfo;
 import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
 import org.apache.hadoop.ozone.om.helpers.SnapshotInfo;
 import org.apache.hadoop.ozone.om.helpers.WithObjectID;
+import org.apache.hadoop.ozone.om.snapshot.SnapshotDiffObject.SnapshotDiffObjectBuilder;
 import org.apache.hadoop.ozone.snapshot.SnapshotDiffReportOzone;
 import org.apache.hadoop.ozone.snapshot.SnapshotDiffResponse;
 import org.apache.hadoop.ozone.snapshot.SnapshotDiffResponse.JobStatus;
 import org.apache.hadoop.ozone.snapshot.SnapshotDiffResponse.JobCancelResult;
 import org.apache.hadoop.security.UserGroupInformation;
+import org.apache.hadoop.util.ClosableIterator;
 import org.apache.ozone.rocksdb.util.ManagedSstFileReader;
 import org.apache.ozone.rocksdb.util.RdbUtil;
 import org.apache.ozone.rocksdiff.DifferSnapshotInfo;
@@ -92,6 +94,7 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.LinkedHashSet;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.ExecutionException;
@@ -101,6 +104,9 @@ import java.util.stream.LongStream;
 import java.util.stream.Stream;
 
 import static org.apache.hadoop.ozone.om.OmSnapshotManager.DELIMITER;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 /**
  * Test class for SnapshotDiffManager Class.
@@ -147,7 +153,7 @@ public class TestSnapshotDiffManager {
   }
 
   private DBStore getMockedDBStore(String dbStorePath) {
-    DBStore dbStore = Mockito.mock(DBStore.class);
+    DBStore dbStore = mock(DBStore.class);
     Mockito.when(dbStore.getDbLocation()).thenReturn(new File(dbStorePath));
     return dbStore;
   }
@@ -200,7 +206,7 @@ public class TestSnapshotDiffManager {
   }
 
   private SnapshotInfo getMockedSnapshotInfo(UUID snapshotId) {
-    SnapshotInfo snapshotInfo = Mockito.mock(SnapshotInfo.class);
+    SnapshotInfo snapshotInfo = mock(SnapshotInfo.class);
     Mockito.when(snapshotInfo.getSnapshotId()).thenReturn(snapshotId);
     return snapshotInfo;
   }
@@ -293,7 +299,7 @@ public class TestSnapshotDiffManager {
   private Table<String, ? extends WithObjectID> getMockedTable(
       Map<String, WithObjectID> map, String tableName)
       throws IOException {
-    Table<String, ? extends WithObjectID> mocked = Mockito.mock(Table.class);
+    Table<String, ? extends WithObjectID> mocked = mock(Table.class);
     Mockito.when(mocked.get(Matchers.any()))
         .thenAnswer(invocation -> map.get(invocation.getArgument(0)));
     Mockito.when(mocked.getName()).thenReturn(tableName);
@@ -391,18 +397,18 @@ public class TestSnapshotDiffManager {
           new SnapshotTestUtils.StubbedPersistentMap<>();
       PersistentMap<byte[], byte[]> newObjectIdKeyMap =
           new SnapshotTestUtils.StubbedPersistentMap<>();
-      PersistentSet<byte[]> objectIdsToCheck =
-          new SnapshotTestUtils.StubbedPersistentSet<>();
+      PersistentMap<byte[], SnapshotDiffObject> objectIdsToCheck =
+          new SnapshotTestUtils.StubbedPersistentMap<>();
       snapshotDiffManager.addToObjectIdMap(toSnapshotTable,
           fromSnapshotTable, Sets.newHashSet("dummy.sst"),
           nativeLibraryLoaded, oldObjectIdKeyMap, newObjectIdKeyMap,
           objectIdsToCheck, Maps.newHashMap());
 
-      Iterator<Map.Entry<byte[], byte[]>> oldObjectIdIter =
+      Iterator<Entry<byte[], byte[]>> oldObjectIdIter =
           oldObjectIdKeyMap.iterator();
       int oldObjectIdCnt = 0;
       while (oldObjectIdIter.hasNext()) {
-        Map.Entry<byte[], byte[]> v = oldObjectIdIter.next();
+        Entry<byte[], byte[]> v = oldObjectIdIter.next();
         long objectId = this.codecRegistry.asObject(v.getKey(), Long.class);
         Assertions.assertTrue(objectId % 2 == 0);
         Assertions.assertTrue(objectId >= 50);
@@ -410,11 +416,11 @@ public class TestSnapshotDiffManager {
         oldObjectIdCnt += 1;
       }
       Assertions.assertEquals(nativeLibraryLoaded ? 25 : 0, oldObjectIdCnt);
-      Iterator<Map.Entry<byte[], byte[]>> newObjectIdIter =
+      Iterator<Entry<byte[], byte[]>> newObjectIdIter =
           newObjectIdKeyMap.iterator();
       int newObjectIdCnt = 0;
       while (newObjectIdIter.hasNext()) {
-        Map.Entry<byte[], byte[]> v = newObjectIdIter.next();
+        Entry<byte[], byte[]> v = newObjectIdIter.next();
         long objectId = this.codecRegistry.asObject(v.getKey(), Long.class);
         Assertions.assertTrue(objectId % 2 == 0);
         Assertions.assertTrue(objectId >= 26);
@@ -423,10 +429,12 @@ public class TestSnapshotDiffManager {
       }
       Assertions.assertEquals(12, newObjectIdCnt);
 
-      Iterator<byte[]> objectIdsToCheckIter = objectIdsToCheck.iterator();
+      ClosableIterator<Entry<byte[], SnapshotDiffObject>> objectIdsToCheckIter =
+          objectIdsToCheck.iterator();
       int objectIdCnt = 0;
       while (objectIdsToCheckIter.hasNext()) {
-        byte[] v = objectIdsToCheckIter.next();
+        Entry<byte[], SnapshotDiffObject> entry = objectIdsToCheckIter.next();
+        byte[] v = entry.getKey();
         long objectId = this.codecRegistry.asObject(v, Long.class);
         Assertions.assertTrue(objectId % 2 == 0);
         Assertions.assertTrue(objectId >= 26);
@@ -476,27 +484,35 @@ public class TestSnapshotDiffManager {
           new SnapshotTestUtils.StubbedPersistentMap<>();
       PersistentMap<byte[], byte[]> newObjectIdKeyMap =
           new SnapshotTestUtils.StubbedPersistentMap<>();
-      PersistentSet<byte[]> objectIdsToCheck =
-          new SnapshotTestUtils.StubbedPersistentSet<>();
+      PersistentMap<byte[], SnapshotDiffObject> objectIdToDiffObject =
+          new SnapshotTestUtils.StubbedPersistentMap<>();
       Map<Long, SnapshotDiffReport.DiffType> diffMap = new HashMap<>();
       LongStream.range(0, 100).forEach(objectId -> {
         try {
+          SnapshotDiffObjectBuilder builder =
+              new SnapshotDiffObjectBuilder(objectId);
+          String key = "key" + objectId;
           byte[] objectIdVal = codecRegistry.asRawData(objectId);
-          byte[] key = codecRegistry.asRawData("key" + objectId);
+          byte[] keyBytes = codecRegistry.asRawData(key);
           if (objectId >= 0 && objectId <= 25 ||
               objectId >= 50 && objectId <= 100) {
-            oldObjectIdKeyMap.put(objectIdVal, key);
+            oldObjectIdKeyMap.put(objectIdVal, keyBytes);
+            builder.withOldKeyName(key);
           }
           if (objectId >= 0 && objectId <= 25 && objectId % 4 == 0 ||
               objectId > 25 && objectId < 50) {
-            newObjectIdKeyMap.put(objectIdVal, key);
+            newObjectIdKeyMap.put(objectIdVal, keyBytes);
+            builder.withNewKeyName(key);
           }
           if (objectId >= 0 && objectId <= 25 && objectId % 4 == 1) {
-            byte[] keyVal = codecRegistry.asRawData("renamed-key" + objectId);
-            newObjectIdKeyMap.put(objectIdVal, keyVal);
+            String renamedKey = "renamed-key" + objectId;
+            byte[] renamedKeyBytes = codecRegistry.asRawData(renamedKey);
+            newObjectIdKeyMap.put(objectIdVal, renamedKeyBytes);
             diffMap.put(objectId, SnapshotDiffReport.DiffType.RENAME);
+            builder.withOldKeyName(key);
+            builder.withNewKeyName(renamedKey);
           }
-          objectIdsToCheck.add(objectIdVal);
+          objectIdToDiffObject.put(objectIdVal, builder.build());
           if (objectId >= 50 && objectId <= 100 ||
               objectId >= 0 && objectId <= 25 && objectId % 4 > 1) {
             diffMap.put(objectId, SnapshotDiffReport.DiffType.DELETE);
@@ -518,6 +534,18 @@ public class TestSnapshotDiffManager {
       UUID fromSnapId = UUID.randomUUID();
       UUID toSnapId = UUID.randomUUID();
 
+      OmKeyInfo fromKeyInfo = mock(OmKeyInfo.class);
+      OmKeyInfo toKeyInfo = mock(OmKeyInfo.class);
+      // This is temporary to make sure that
+      // SnapshotDeletingService#isBlockLocationInfoSame always return true.
+      when(toKeyInfo.isHsync()).thenReturn(true);
+      when(fromKeyInfo.isHsync()).thenReturn(true);
+
+      Table<String, OmKeyInfo> fromSnapTable = mock(Table.class);
+      Table<String, OmKeyInfo> toSnapTable = mock(Table.class);
+      when(fromSnapTable.get(anyString())).thenReturn(fromKeyInfo);
+      when(toSnapTable.get(anyString())).thenReturn(toKeyInfo);
+
       SnapshotDiffManager snapshotDiffManager =
           getMockedSnapshotDiffManager(10);
 
@@ -533,17 +561,17 @@ public class TestSnapshotDiffManager {
 
       snapshotDiffManager.getSnapDiffJobTable().put(jobKey, snapshotDiffJob);
 
-      snapshotDiffManager.generateDiffReport("jobId",
-          objectIdsToCheck, oldObjectIdKeyMap, newObjectIdKeyMap,
-          volumeName, bucketName, fromSnapName, toSnapName);
+      snapshotDiffManager.generateDiffReport("jobId", fromSnapTable,
+          toSnapTable, objectIdToDiffObject, oldObjectIdKeyMap,
+          newObjectIdKeyMap, volumeName, bucketName, fromSnapName, toSnapName);
 
       snapshotDiffJob.setStatus(JobStatus.DONE);
       snapshotDiffManager.getSnapDiffJobTable().put(jobKey, snapshotDiffJob);
 
       SnapshotDiffReportOzone snapshotDiffReportOzone =
           snapshotDiffManager.createPageResponse(snapshotDiffJob, volumeName,
-          bucketName, fromSnapName, toSnapName,
-          0, Integer.MAX_VALUE);
+              bucketName, fromSnapName, toSnapName,
+              0, Integer.MAX_VALUE);
       Set<SnapshotDiffReport.DiffType> expectedOrder = new LinkedHashSet<>();
       expectedOrder.add(SnapshotDiffReport.DiffType.DELETE);
       expectedOrder.add(SnapshotDiffReport.DiffType.RENAME);


### PR DESCRIPTION
## What changes were proposed in this pull request?
This change is to return correct snapshot diff when key is renamed and overridden.
Currently it return rename diff entry only.
```
R    ./key -> ./key_renamed
```

After the change it would be rename and modify
```
R    ./key -> ./key_renamed
M    ./key
```
## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-8841

## How was this patch tested?
Updated integration tests.
