### PR TITLE
HDDS-8892. OM Node Id from VERSION file should removed after the OM node has been decommissioned

### DIFF
--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OMStorage.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OMStorage.java
@@ -107,6 +107,14 @@ public class OMStorage extends Storage {
   }
 
   /**
+   * Removes the OM Node id from the VERSION file.
+   */
+  public void unsetOmNodeId() throws IOException {
+    getStorageInfo().unsetProperty(OM_NODE_ID);
+    persistCurrentState();
+  }
+
+  /**
    * Set's the Ozone Manager ID to be stored in the VERSION file representation.
    * Note that, to change the VERSION file itself,
    * {@link #persistCurrentState()} has to be called after this method.

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/admin/om/DecommissionOMSubcommand.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/admin/om/DecommissionOMSubcommand.java
@@ -29,6 +29,7 @@ import org.apache.hadoop.hdds.cli.HddsVersionProvider;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.ozone.OmUtils;
 import org.apache.hadoop.ozone.ha.ConfUtils;
+import org.apache.hadoop.ozone.om.OMStorage;
 import org.apache.hadoop.ozone.om.helpers.OMNodeDetails;
 import org.apache.hadoop.ozone.om.protocol.OMConfiguration;
 import org.apache.hadoop.ozone.om.protocolPB.OMAdminProtocolClientSideImpl;
@@ -115,6 +116,8 @@ public class DecommissionOMSubcommand implements Callable<Void> {
           .setHostAddress(hostInetAddress.getHostAddress())
           .build();
       omAdminProtocolClient.decommission(decommNodeDetails);
+      OMStorage omStorage = new OMStorage(ozoneConf);
+      omStorage.unsetOmNodeId();
 
       System.out.println("Successfully decommissioned OM " + decommNodeId);
     } catch (IOException e) {


### PR DESCRIPTION
## What changes were proposed in this pull request?

OM node id should be removed from the VERSION file after the OM node has been decommissioned to avoid OM node Id mismatch in case an ex-OM node is bootstrapped again. This can happen when an ex-OM node is bootstrapped, then it will be bootstrapped with a new OM node id and the existing VERSION file will contain the old OM node id which will cause an OM node id mismatch during the bootstrap, therefore we need to remove the OM node id from the VERSION file upon successful decommissioning. Also, when an OM is bootstrapped if the VERSION file doesn’t exist then it will be created and if it exists then a new entry of OM node id will be appended. 

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-8892

## How was this patch tested?

Tested Manually.