### PR TITLE
HDDS-8681. [SNAPSHOT] Intermittent failure in TestOMDbCheckpointServlet#testWriteDbDataToStream

### DIFF
--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/DBCheckpointServlet.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/DBCheckpointServlet.java
@@ -311,8 +311,10 @@ public class DBCheckpointServlet extends HttpServlet
     return lock;
   }
 
-  // This lock is a no-op but can overriden by child classes
-  static public class Lock extends BootstrapStateHandler.Lock {
+/**
+ * This lock is a no-op but can overriden by child classes.
+ */
+  public static class Lock extends BootstrapStateHandler.Lock {
     public Lock() {
     }
 

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/DBCheckpointServlet.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/DBCheckpointServlet.java
@@ -48,6 +48,7 @@ import static org.apache.hadoop.ozone.OzoneConsts.OZONE_DB_CHECKPOINT_REQUEST_FL
 import static org.apache.hadoop.ozone.OzoneConsts.OZONE_DB_CHECKPOINT_REQUEST_TO_EXCLUDE_SST;
 import static org.apache.hadoop.ozone.OzoneConsts.ROCKSDB_SST_SUFFIX;
 
+import org.apache.hadoop.ozone.lock.BootstrapStateHandler;
 import org.apache.hadoop.security.UserGroupInformation;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -55,7 +56,8 @@ import org.slf4j.LoggerFactory;
 /**
  * Provides the current checkpoint Snapshot of the OM/SCM DB. (tar)
  */
-public class DBCheckpointServlet extends HttpServlet {
+public class DBCheckpointServlet extends HttpServlet
+    implements BootstrapStateHandler {
 
   private static final String FIELD_NAME =
       OZONE_DB_CHECKPOINT_REQUEST_TO_EXCLUDE_SST + "[]";
@@ -69,6 +71,7 @@ public class DBCheckpointServlet extends HttpServlet {
   private boolean aclEnabled;
   private boolean isSpnegoEnabled;
   private transient OzoneAdmins admins;
+  private transient BootstrapStateHandler.Lock lock;
 
   public void initialize(DBStore store, DBCheckpointMetrics metrics,
                          boolean omAclEnabled,
@@ -87,6 +90,7 @@ public class DBCheckpointServlet extends HttpServlet {
     this.aclEnabled = omAclEnabled;
     this.admins = new OzoneAdmins(allowedAdminUsers, allowedAdminGroups);
     this.isSpnegoEnabled = isSpnegoAuthEnabled;
+    lock = new Lock();
   }
 
   private boolean hasPermission(UserGroupInformation user) {
@@ -145,7 +149,7 @@ public class DBCheckpointServlet extends HttpServlet {
     }
 
     DBCheckpoint checkpoint = null;
-    try {
+    try  (BootstrapStateHandler.Lock lock = getBootstrapStateLock().lock()) {
       boolean flush = false;
       String flushParam =
           request.getParameter(OZONE_DB_CHECKPOINT_REQUEST_FLUSH);
@@ -300,5 +304,26 @@ public class DBCheckpointServlet extends HttpServlet {
 
     writeDBCheckpointToStream(checkpoint, destination,
         toExcludeList, excludedList);
+  }
+
+  @Override
+  public BootstrapStateHandler.Lock getBootstrapStateLock() {
+    return lock;
+  }
+
+  // This lock is a no-op but can overriden by child classes
+  static public class Lock extends BootstrapStateHandler.Lock {
+    public Lock() {
+    }
+
+    @Override
+    public BootstrapStateHandler.Lock lock()
+        throws InterruptedException {
+      return this;
+    }
+
+    @Override
+    public void unlock() {
+    }
   }
 }

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/DBCheckpointServlet.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/DBCheckpointServlet.java
@@ -312,7 +312,10 @@ public class DBCheckpointServlet extends HttpServlet
     return lock;
   }
 
-/**
+  /**
+   * This lock is a no-op but can overridden by child classes.
+   */
+    public static class Lock extends BootstrapStateHandler.Lock {
  * This lock is a no-op but can overriden by child classes.
  */
   public static class Lock extends BootstrapStateHandler.Lock {

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/DBCheckpointServlet.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/DBCheckpointServlet.java
@@ -152,7 +152,7 @@ public class DBCheckpointServlet extends HttpServlet
 
     boolean flush = false;
     String flushParam =
-      request.getParameter(OZONE_DB_CHECKPOINT_REQUEST_FLUSH);
+        request.getParameter(OZONE_DB_CHECKPOINT_REQUEST_FLUSH);
     if (StringUtils.isNotEmpty(flushParam)) {
       flush = Boolean.parseBoolean(flushParam);
     }

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/DBCheckpointServlet.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/DBCheckpointServlet.java
@@ -171,7 +171,7 @@ public class DBCheckpointServlet extends HttpServlet
       LOG.info("Received excluding SST {}", receivedSstList);
     }
 
-    try  (BootstrapStateHandler.Lock lock = getBootstrapStateLock().lock()) {
+    try (BootstrapStateHandler.Lock lock = getBootstrapStateLock().lock()) {
       checkpoint = dbStore.getCheckpoint(flush);
       if (checkpoint == null || checkpoint.getCheckpointLocation() == null) {
         LOG.error("Unable to process metadata snapshot request. " +

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/DBCheckpointServlet.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/DBCheckpointServlet.java
@@ -315,9 +315,6 @@ public class DBCheckpointServlet extends HttpServlet
   /**
    * This lock is a no-op but can overridden by child classes.
    */
-    public static class Lock extends BootstrapStateHandler.Lock {
- * This lock is a no-op but can overriden by child classes.
- */
   public static class Lock extends BootstrapStateHandler.Lock {
     public Lock() {
     }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/TestSCMDbCheckpointServlet.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/TestSCMDbCheckpointServlet.java
@@ -40,6 +40,7 @@ import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.scm.container.placement.metrics.SCMMetrics;
 import org.apache.hadoop.hdds.scm.server.SCMDBCheckpointServlet;
 import org.apache.hadoop.hdds.scm.server.StorageContainerManager;
+import org.apache.hadoop.hdds.utils.DBCheckpointServlet;
 import org.apache.hadoop.ozone.MiniOzoneCluster;
 import org.apache.hadoop.ozone.OzoneConsts;
 
@@ -187,6 +188,8 @@ public class TestSCMDbCheckpointServlet {
             }
           });
 
+      when(scmDbCheckpointServletMock.getBootstrapStateLock()).thenReturn(
+          new DBCheckpointServlet.Lock());
       scmDbCheckpointServletMock.init();
       long initialCheckpointCount =
           scmMetrics.getDBCheckpointMetrics().getNumCheckpoints();

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOMDbCheckpointServlet.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOMDbCheckpointServlet.java
@@ -685,7 +685,7 @@ public class TestOMDbCheckpointServlet {
     String snapshotPath = getSnapshotPath(conf, snapshotInfo)
         + OM_KEY_PREFIX;
     GenericTestUtils.waitFor(() -> new File(snapshotPath).exists(),
-        100, 60000);
+        100, 2000);
     return snapshotPath;
   }
 

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOMDbCheckpointServlet.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOMDbCheckpointServlet.java
@@ -395,7 +395,13 @@ public class TestOMDbCheckpointServlet {
                                                                   any(),
 eq(false));
     // omDbCheckpointServletMock.init();
-    doInit(om, spyDbStore);
+    omDbCheckpointServletMock.initialize(
+                                         spyDbStore,
+        om.getMetrics().getDBCheckpointMetrics(),
+                                         false,
+        om.getOmAdminUsernames(),
+                                         om.getOmAdminGroups(), false);
+
     this.method = "GET";
     // Get the tarball.
     when(responseMock.getOutputStream()).thenReturn(servletOutputStream);
@@ -467,17 +473,6 @@ eq(false));
         "expected snapshot files not found");
   }
 
-  private void doInit(OzoneManager om, DBStore spyDbStore)
-      throws ServletException {
-    omDbCheckpointServletMock.initialize(
-                                         spyDbStore,
-        om.getMetrics().getDBCheckpointMetrics(),
-                                         false,
-        om.getOmAdminUsernames(),
-                                         om.getOmAdminGroups(), false);
-
-
-  }
   @Test
   public void testWriteDbDataWithoutOmSnapshot()
       throws Exception {

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOMDbCheckpointServlet.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOMDbCheckpointServlet.java
@@ -221,8 +221,8 @@ public class TestOMDbCheckpointServlet {
 
     doCallRealMethod().when(omDbCheckpointServletMock).doGet(requestMock,
         responseMock);
-    doCallRealMethod().when(omDbCheckpointServletMock).doPost(any(HttpServletRequest.class),
-        any(HttpServletResponse.class));
+    doCallRealMethod().when(omDbCheckpointServletMock).doPost(requestMock,
+        responseMock);
 
     doCallRealMethod().when(omDbCheckpointServletMock)
         .writeDbDataToStream(any(), any(), any(), any(), any());
@@ -394,11 +394,12 @@ public class TestOMDbCheckpointServlet {
                                                                   any(Collection.class),
                                                                   any(Collection.class),
 eq(false));
-    doInit(om, spyDbStore);
+    // omDbCheckpointServletMock.init();
+       doInit(om, spyDbStore);
     this.method = "GET";
     // Get the tarball.
     when(responseMock.getOutputStream()).thenReturn(servletOutputStream);
-    omDbCheckpointServletMock.doGet(requestMock, responseMock);
+    doEndpoint();
     dbCheckpoint = realCheckpoint.get();
 //    when(realCheckpoint.get().cleanupCheckpoint())
     // Untar the file into a temp folder to be examined.
@@ -466,10 +467,10 @@ eq(false));
         "expected snapshot files not found");
   }
 
-  private void doInit(OzoneManager om, DBStore spyDbstore)
+  private void doInit(OzoneManager om, DBStore spyDbStore)
       throws ServletException {
     omDbCheckpointServletMock.initialize(
-                                         spyDbstore,
+                                         spyDbStore,
         om.getMetrics().getDBCheckpointMetrics(),
                                          false,
         om.getOmAdminUsernames(),

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOMDbCheckpointServlet.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOMDbCheckpointServlet.java
@@ -388,14 +388,14 @@ public class TestOMDbCheckpointServlet {
       return checkpoint;
     });
     doCallRealMethod().when(omDbCheckpointServletMock).initialize(
-                                                                  any(DBStore.class),
-                                                                  any(DBCheckpointMetrics.class),
+                                                                  any(),
+                                                                  any(),
                                                                   eq(false),
-                                                                  any(Collection.class),
-                                                                  any(Collection.class),
+                                                                  any(),
+                                                                  any(),
 eq(false));
     // omDbCheckpointServletMock.init();
-       doInit(om, spyDbStore);
+    doInit(om, spyDbStore);
     this.method = "GET";
     // Get the tarball.
     when(responseMock.getOutputStream()).thenReturn(servletOutputStream);

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOMDbCheckpointServlet.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOMDbCheckpointServlet.java
@@ -384,6 +384,7 @@ public class TestOMDbCheckpointServlet {
     AtomicReference<DBCheckpoint> realCheckpoint = new AtomicReference<>();
     when(spyDbStore.getCheckpoint(true)).thenAnswer(b -> {
       DBCheckpoint checkpoint = spy(dbStore.getCheckpoint(true));
+      doNothing().when(checkpoint).cleanupCheckpoint();
       realCheckpoint.set(checkpoint);
       return checkpoint;
     });

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OMDBCheckpointServlet.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OMDBCheckpointServlet.java
@@ -78,8 +78,7 @@ import static org.apache.hadoop.ozone.om.snapshot.OmSnapshotUtils.truncateFileNa
  * If Kerberos is not enabled, simply append the login username to
  * `ozone.administrator`, e.g. `scm`
  */
-public class OMDBCheckpointServlet extends DBCheckpointServlet
-    implements BootstrapStateHandler {
+public class OMDBCheckpointServlet extends DBCheckpointServlet {
 
   private static final Logger LOG =
       LoggerFactory.getLogger(OMDBCheckpointServlet.class);
@@ -135,8 +134,7 @@ public class OMDBCheckpointServlet extends DBCheckpointServlet
     // Map of link to path.
     Map<Path, Path> hardLinkFiles = new HashMap<>();
 
-    try (BootstrapStateHandler.Lock lock = getBootstrapStateLock().lock();
-         TarArchiveOutputStream archiveOutputStream =
+    try (TarArchiveOutputStream archiveOutputStream =
              new TarArchiveOutputStream(destination)) {
       archiveOutputStream
           .setLongFileMode(TarArchiveOutputStream.LONGFILE_POSIX);

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/snapshot/OMSnapshotCreateResponse.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/snapshot/OMSnapshotCreateResponse.java
@@ -81,6 +81,13 @@ public class OMSnapshotCreateResponse extends OMClientResponse {
     OmSnapshotManager.createOmSnapshotCheckpoint(omMetadataManager,
         snapshotInfo);
 
+    try {
+      Thread.sleep(10000);
+    } catch (InterruptedException e) {
+      e.printStackTrace();
+    }
+
+
     // TODO: [SNAPSHOT] Move to createOmSnapshotCheckpoint and add table lock
     // Remove all entries from snapshotRenamedTable
     try (TableIterator<String, ? extends Table.KeyValue<String, String>>

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/snapshot/OMSnapshotCreateResponse.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/snapshot/OMSnapshotCreateResponse.java
@@ -81,14 +81,6 @@ public class OMSnapshotCreateResponse extends OMClientResponse {
     OmSnapshotManager.createOmSnapshotCheckpoint(omMetadataManager,
         snapshotInfo);
 
-    // try {
-    //   Thread.sleep(1000);
-    //   System.out.println("gbjnext");
-    // } catch (InterruptedException e) {
-    //   e.printStackTrace();
-    // }
-
-
     // TODO: [SNAPSHOT] Move to createOmSnapshotCheckpoint and add table lock
     // Remove all entries from snapshotRenamedTable
     try (TableIterator<String, ? extends Table.KeyValue<String, String>>

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/snapshot/OMSnapshotCreateResponse.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/snapshot/OMSnapshotCreateResponse.java
@@ -81,11 +81,12 @@ public class OMSnapshotCreateResponse extends OMClientResponse {
     OmSnapshotManager.createOmSnapshotCheckpoint(omMetadataManager,
         snapshotInfo);
 
-    try {
-      Thread.sleep(10000);
-    } catch (InterruptedException e) {
-      e.printStackTrace();
-    }
+    // try {
+    //   Thread.sleep(1000);
+    //   System.out.println("gbjnext");
+    // } catch (InterruptedException e) {
+    //   e.printStackTrace();
+    // }
 
 
     // TODO: [SNAPSHOT] Move to createOmSnapshotCheckpoint and add table lock


### PR DESCRIPTION
## What changes were proposed in this pull request?
This intermittent failure is caused by a race condition with the om double-buffer flush-thread.

the bootstrap lock here should have been preventing this problem from happening: https://github.com/apache/ozone/blob/2fbed633e87ba455e7635e75356df3ce2dd906ac/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OMDBCheckpointServlet.java#L395

The reason it wasn't was because I was taking the lock after the checkpoint was created instead before, so I moved it to before and that fixed the problem.


## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-8681

## How was this patch tested?

Without this fix, I can make this failure happen consistently by inserting a thread sleep in the double buffer thread here:  https://github.com/GeorgeJahad/ozone/blob/15d451742a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/snapshot/OMSnapshotCreateResponse.java#L84-L88


With the fix, it no longer fails even with the thread sleep.

