### PR TITLE
HDDS-8839. Intermittent failure in TestSecretKeySnapshot.testInstallSnapshot

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/scm/TestSecretKeySnapshot.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/scm/TestSecretKeySnapshot.java
@@ -262,9 +262,12 @@ public final class TestSecretKeySnapshot {
             !leaderSecretKeyManager.getCurrentSecretKey()
                 .equals(currentKeyPostSnapshot),
         ROTATE_CHECK_DURATION_MS, ROTATE_DURATION_MS);
-    assertEquals(leaderSecretKeyManager.getSortedKeys(),
-        followerSecretKeyManager.getSortedKeys());
-
+    List<ManagedSecretKey> latestLeaderKeys =
+        leaderSecretKeyManager.getSortedKeys();
+    GenericTestUtils.waitFor(() ->
+            latestLeaderKeys.equals(
+            followerSecretKeyManager.getSortedKeys()),
+        ROTATE_CHECK_DURATION_MS, ROTATE_DURATION_MS);
   }
 
   private List<ContainerInfo> writeToIncreaseLogIndex(


### PR DESCRIPTION
## What changes were proposed in this pull request?

Intermittent happens because it may take time for secret keys to be replicated to followers. 


## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-8839

## How was this patch tested?

Standard CI: https://github.com/duongkame/ozone/actions/runs/5340376630
