### PR TITLE
HDDS-6814. ozone s3 getsecret default --om-service-id

### DIFF
--- a/hadoop-ozone/dist/src/main/smoketest/s3/s3_getsecret.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/s3/s3_getsecret.robot
@@ -14,29 +14,24 @@
 # limitations under the License.
 
 *** Settings ***
-Documentation       S3 gateway test with aws cli
-Library             OperatingSystem
-Library             String
-Library             BuiltIn
+Documentation       Test ozone s3 getsecret command
 Resource            ../commonlib.robot
-Resource            ./commonawslib.robot
 Test Timeout        2 minutes
-Suite Setup         Setup v4 headers
 
 *** Keywords ***
-Get-secret without om-service-id
-    ${output}=             Execute             ozone s3 getsecret -u testuser2
-    Should contain         ${output}           awsAccessKey
-    Should contain         ${output}           awsSecret
-
-Get-secret with om-service-id
-    ${output}=             Execute             ozone s3 getsecret -u testuser2 ${OM_HA_PARAM}
+Verify output
+    [arguments]    ${output}
     Should contain         ${output}           awsAccessKey
     Should contain         ${output}           awsSecret
 
 *** Test Cases ***
-S3 without om-service-id
-    Run Keyword if    '${SECURITY_ENABLED}' == 'true'    Get-secret without om-service-id
+Without OM service ID
+    Pass Execution If      '${SECURITY_ENABLED}' == 'false'    N/A
+    ${output} =            Execute             ozone s3 getsecret -u testuser2
+    Verify output          ${output}
 
-S3 with om-service-id
-    Run Keyword if    '${SECURITY_ENABLED}' == 'true'    Get-secret with om-service-id
+With OM service ID
+    Pass Execution If      '${OM_HA_PARAM}' == '${EMPTY}'          duplicate test in non-HA env.
+    Pass Execution If      '${SECURITY_ENABLED}' == 'false'    N/A
+    ${output} =            Execute             ozone s3 getsecret -u testuser2 ${OM_HA_PARAM}
+    Verify output          ${output}

--- a/hadoop-ozone/dist/src/main/smoketest/s3/s3_serviceId.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/s3/s3_serviceId.robot
@@ -1,0 +1,36 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+*** Settings ***
+Documentation       S3 gateway test with aws cli
+Library             OperatingSystem
+Library             String
+Resource            ../commonlib.robot
+Resource            commonawslib.robot
+Test Timeout        5 minutes
+Suite Setup         Setup s3 tests
+
+*** Test Cases ***
+Get-secret without om-service-id
+    Run Keyword   Kinit test user     testuser     testuser.keytab
+    ${output}=             Execute             ozone s3 getsecret -u testuser
+    Should contain         ${output}           awsAccessKey
+    Should contain         ${output}           awsSecret
+
+Get-secret with om-service-id
+    Run Keyword   Kinit test user     testuser     testuser.keytab
+    ${output}=             Execute             ozone s3 getsecret -u testuser ${OM_HA_PARAM}
+    Should contain         ${output}           awsAccessKey
+    Should contain         ${output}           awsSecret

--- a/hadoop-ozone/dist/src/main/smoketest/s3/s3_serviceId.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/s3/s3_serviceId.robot
@@ -17,20 +17,26 @@
 Documentation       S3 gateway test with aws cli
 Library             OperatingSystem
 Library             String
+Library             BuiltIn
 Resource            ../commonlib.robot
-Resource            commonawslib.robot
-Test Timeout        5 minutes
-Suite Setup         Setup s3 tests
+Resource            ./commonawslib.robot
+Test Timeout        2 minutes
+Suite Setup         Setup v4 headers
 
-*** Test Cases ***
+*** Keywords ***
 Get-secret without om-service-id
-    Run Keyword   Kinit test user     testuser     testuser.keytab
-    ${output}=             Execute             ozone s3 getsecret -u testuser
+    ${output}=             Execute             ozone s3 getsecret -u testuser2
     Should contain         ${output}           awsAccessKey
     Should contain         ${output}           awsSecret
 
 Get-secret with om-service-id
-    Run Keyword   Kinit test user     testuser     testuser.keytab
-    ${output}=             Execute             ozone s3 getsecret -u testuser ${OM_HA_PARAM}
+    ${output}=             Execute             ozone s3 getsecret -u testuser2 ${OM_HA_PARAM}
     Should contain         ${output}           awsAccessKey
     Should contain         ${output}           awsSecret
+
+*** Test Cases ***
+S3 without om-service-id
+    Run Keyword if    '${SECURITY_ENABLED}' == 'true'    Get-secret without om-service-id
+
+S3 with om-service-id
+    Run Keyword if    '${SECURITY_ENABLED}' == 'true'    Get-secret with om-service-id

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/OzoneAddress.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/OzoneAddress.java
@@ -204,16 +204,11 @@ public class OzoneAddress {
       // But before that check if serviceId is defined. If it is defined
       // and has length = 1, then take that ID as default.
       // otherwise throw an error "om service ID needs to be specified."
-      if (OmUtils.isServiceIdsDefined(conf)) {
-        if (serviceIds.size() == 1) {
-          return OzoneClientFactory.getRpcClient(serviceIds.iterator().next(),
-              conf);
-        } else {
+      if (serviceIds.size() == 1) {
           throw new OzoneClientException("Service ID must not"
               + " be omitted when cluster has multiple OM Services." +
               "  Configured " + OZONE_OM_SERVICE_IDS_KEY + " are "
               + serviceIds);
-        }
       }
       return OzoneClientFactory.getRpcClient(conf);
     }

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/OzoneAddress.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/OzoneAddress.java
@@ -187,6 +187,8 @@ public class OzoneAddress {
       String omServiceID
   )
       throws IOException, OzoneClientException {
+    Collection<String> serviceIds = conf.
+        getTrimmedStringCollection(OZONE_OM_SERVICE_IDS_KEY);
     if (omServiceID != null) {
       // OM HA cluster
       if (OmUtils.isOmHAServiceId(conf, omServiceID)) {
@@ -195,27 +197,23 @@ public class OzoneAddress {
         throw new OzoneClientException("Service ID specified does not match" +
             " with " + OZONE_OM_SERVICE_IDS_KEY + " defined in the " +
             "configuration. Configured " + OZONE_OM_SERVICE_IDS_KEY + " are" +
-            conf.getTrimmedStringCollection(OZONE_OM_SERVICE_IDS_KEY));
+            serviceIds);
       }
     } else {
       // If om service id is not specified, consider it as a non-HA cluster.
       // But before that check if serviceId is defined. If it is defined
       // and has length = 1, then take that ID as default.
-      // otherwise throw an error om service ID needs to be specified.
+      // otherwise throw an error "om service ID needs to be specified."
       if (OmUtils.isServiceIdsDefined(conf)) {
-        Collection<String> serviceIds=conf.
-            getTrimmedStringCollection(OZONE_OM_SERVICE_IDS_KEY);
         if (serviceIds.size() == 1) {
           return OzoneClientFactory.getRpcClient(serviceIds.iterator().next(),
               conf);
-        }
-        else {
+        } else {
           throw new OzoneClientException("Service ID must not"
-              + " be omitted when " + OZONE_OM_SERVICE_IDS_KEY + " is defined."
-              + " Configured " + OZONE_OM_SERVICE_IDS_KEY + " are " +
-              conf.getTrimmedStringCollection(OZONE_OM_SERVICE_IDS_KEY));
+              + " be omitted when cluster has multiple OM Services." +
+              "  Configured " + OZONE_OM_SERVICE_IDS_KEY + " are "
+              + serviceIds);
         }
-
       }
       return OzoneClientFactory.getRpcClient(conf);
     }

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/OzoneAddress.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/OzoneAddress.java
@@ -200,12 +200,22 @@ public class OzoneAddress {
     } else {
       // If om service id is not specified, consider it as a non-HA cluster.
       // But before that check if serviceId is defined. If it is defined
-      // throw an error om service ID needs to be specified.
+      // and has length = 1, then take that ID as default.
+      // otherwise throw an error om service ID needs to be specified.
       if (OmUtils.isServiceIdsDefined(conf)) {
-        throw new OzoneClientException("Service ID must not"
-            + " be omitted when " + OZONE_OM_SERVICE_IDS_KEY + " is defined. " +
-            "Configured " + OZONE_OM_SERVICE_IDS_KEY + " are " +
-            conf.getTrimmedStringCollection(OZONE_OM_SERVICE_IDS_KEY));
+        Collection<String> serviceIds=conf.
+            getTrimmedStringCollection(OZONE_OM_SERVICE_IDS_KEY);
+        if (serviceIds.size() == 1) {
+          return OzoneClientFactory.getRpcClient(serviceIds.iterator().next(),
+              conf);
+        }
+        else {
+          throw new OzoneClientException("Service ID must not"
+              + " be omitted when " + OZONE_OM_SERVICE_IDS_KEY + " is defined."
+              + " Configured " + OZONE_OM_SERVICE_IDS_KEY + " are " +
+              conf.getTrimmedStringCollection(OZONE_OM_SERVICE_IDS_KEY));
+        }
+
       }
       return OzoneClientFactory.getRpcClient(conf);
     }

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/OzoneAddress.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/OzoneAddress.java
@@ -204,11 +204,11 @@ public class OzoneAddress {
       // But before that check if serviceId is defined. If it is defined
       // and has length = 1, then take that ID as default.
       // otherwise throw an error "om service ID needs to be specified."
-      if (serviceIds.size() == 1) {
-          throw new OzoneClientException("Service ID must not"
-              + " be omitted when cluster has multiple OM Services." +
-              "  Configured " + OZONE_OM_SERVICE_IDS_KEY + " are "
-              + serviceIds);
+      if (serviceIds.size() > 1) {
+        throw new OzoneClientException("Service ID must not"
+            + " be omitted when cluster has multiple OM Services." +
+            "  Configured " + OZONE_OM_SERVICE_IDS_KEY + " are "
+            + serviceIds);
       }
       return OzoneClientFactory.getRpcClient(conf);
     }

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/OzoneAddress.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/OzoneAddress.java
@@ -200,15 +200,15 @@ public class OzoneAddress {
             serviceIds);
       }
     } else if (serviceIds.size() > 1) {
-      // If om service id is not specified, consider it as a non-HA cluster.
-      // But before that check if serviceId is defined. If it is defined
-      // and has length = 1, then take that ID as default.
-      // otherwise throw an error "om service ID needs to be specified."
+      // If multiple om service ids are there,
+      // throw an error "om service ID must not be omitted"
       throw new OzoneClientException("Service ID must not"
           + " be omitted when cluster has multiple OM Services." +
           "  Configured " + OZONE_OM_SERVICE_IDS_KEY + " are "
           + serviceIds);
-      }
+    }
+    // for non-HA cluster and HA cluster with only 1 service ID
+    // get service ID from configurations
     return OzoneClientFactory.getRpcClient(conf);
   }
 

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/OzoneAddress.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/OzoneAddress.java
@@ -199,19 +199,17 @@ public class OzoneAddress {
             "configuration. Configured " + OZONE_OM_SERVICE_IDS_KEY + " are" +
             serviceIds);
       }
-    } else {
+    } else if (serviceIds.size() > 1) {
       // If om service id is not specified, consider it as a non-HA cluster.
       // But before that check if serviceId is defined. If it is defined
       // and has length = 1, then take that ID as default.
       // otherwise throw an error "om service ID needs to be specified."
-      if (serviceIds.size() > 1) {
-        throw new OzoneClientException("Service ID must not"
-            + " be omitted when cluster has multiple OM Services." +
-            "  Configured " + OZONE_OM_SERVICE_IDS_KEY + " are "
-            + serviceIds);
+      throw new OzoneClientException("Service ID must not"
+          + " be omitted when cluster has multiple OM Services." +
+          "  Configured " + OZONE_OM_SERVICE_IDS_KEY + " are "
+          + serviceIds);
       }
-      return OzoneClientFactory.getRpcClient(conf);
-    }
+    return OzoneClientFactory.getRpcClient(conf);
   }
 
   /**

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/s3/S3Handler.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/s3/S3Handler.java
@@ -35,7 +35,7 @@ public abstract class S3Handler extends Handler {
   @CommandLine.Option(names = {"--om-service-id"},
       required = false,
       description = "OM Service ID for OM HA, " +
-          "required when cluster has are multiple OM services")
+          "required when cluster has multiple OM services")
   private String omServiceID;
 
   public String getOmServiceID() {

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/s3/S3Handler.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/s3/S3Handler.java
@@ -34,8 +34,8 @@ public abstract class S3Handler extends Handler {
 
   @CommandLine.Option(names = {"--om-service-id"},
       required = false,
-      description = "OM Service ID is required to be specified for OM HA" +
-          " cluster")
+      description = "OM Service ID is preferred to be specified for OM HA" +
+          " cluster when there are multiple service IDs")
   private String omServiceID;
 
   public String getOmServiceID() {

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/s3/S3Handler.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/s3/S3Handler.java
@@ -34,8 +34,8 @@ public abstract class S3Handler extends Handler {
 
   @CommandLine.Option(names = {"--om-service-id"},
       required = false,
-      description = "OM Service ID is preferred to be specified for OM HA" +
-          " cluster when there are multiple service IDs")
+      description = "OM Service ID for OM HA, " +
+          "required when cluster has are multiple OM services")
   private String omServiceID;
 
   public String getOmServiceID() {


### PR DESCRIPTION
## What changes were proposed in this pull request?

For ozone S3 commands, instead of having --om-service-id as a mandatory option, use the serviceID from the config file as the default if there is only one. Otherwise, Make the option a compulsory one.

The usage for non-HA clusters and HA clusters with one service ID:
`ozone s3 getsecret`
And usage for HA clusters with multiple service IDs:
`ozone s3 getsecret --om-service-id=<omServiceID>`

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-6814

## How was this patch tested?

Added a Robot test for the change.
