### PR TITLE
HDDS-8897. Avoid synchronization on WritableECContainerProvider

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/WritableECContainerProvider.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/WritableECContainerProvider.java
@@ -204,7 +204,9 @@ public class WritableECContainerProvider
           throw new IOException("interrupted", e);
         }
       } else {
-        LOG.info(msg, repConfig, current, pending, max);
+        if (finalAttempt || LOG.isTraceEnabled()) {
+          LOG.info(msg, repConfig, current, pending, max);
+        }
         return null;
       }
     } catch (IOException e) {

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/WritableECContainerProvider.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/WritableECContainerProvider.java
@@ -163,10 +163,14 @@ public class WritableECContainerProvider
       return container;
     }
 
-    throw new IOException("Unable to allocate a pipeline for " + repConfig + ":"
-        + " the maximum of " + maximumPipelines + " has been reached, and "
-        + " none of the " + openPipelineCount + " existing ones are suitable"
-    );
+    String msg = "Unable to allocate a pipeline for " + repConfig + ":"
+        + " the maximum of " + maximumPipelines + " has been reached";
+    if (openPipelineCount > 0) {
+      msg += ", and none of the " + openPipelineCount
+          + " existing ones are suitable";
+    }
+
+    throw new IOException(msg);
   }
 
   @Nullable

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/WritableECContainerProvider.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/WritableECContainerProvider.java
@@ -163,9 +163,10 @@ public class WritableECContainerProvider
       return container;
     }
 
-    throw new IOException("Unable to allocate a pipeline for "
-        + repConfig + " after trying all existing pipelines as the max "
-        + "limit has been reached and no pipelines where closed");
+    throw new IOException("Unable to allocate a pipeline for " + repConfig + ":"
+        + " the maximum of " + maximumPipelines + " has been reached, and "
+        + " none of the " + openPipelineCount + " existing ones are suitable"
+    );
   }
 
   @Nullable

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/freon/TestRandomKeyGenerator.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/freon/TestRandomKeyGenerator.java
@@ -23,7 +23,6 @@ import java.time.Duration;
 import org.apache.hadoop.hdds.conf.DatanodeRatisServerConfig;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.ratis.conf.RatisClientConfig;
-import org.apache.hadoop.hdds.scm.pipeline.WritableECContainerProvider.WritableECContainerProviderConfig;
 import org.apache.hadoop.ozone.MiniOzoneCluster;
 import org.apache.ozone.test.tag.Flaky;
 
@@ -61,11 +60,6 @@ public class TestRandomKeyGenerator {
     raftClientConfig.setRpcRequestTimeout(Duration.ofSeconds(3));
     raftClientConfig.setRpcWatchRequestTimeout(Duration.ofSeconds(3));
     conf.setFromObject(raftClientConfig);
-
-    WritableECContainerProviderConfig containerConfig =
-        conf.getObject(WritableECContainerProviderConfig.class);
-    containerConfig.setMinimumPipelines(10);
-    conf.setFromObject(containerConfig);
 
     cluster = MiniOzoneCluster.newBuilder(conf).setNumDatanodes(5).build();
     cluster.waitForClusterToBeReady();

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/freon/TestRandomKeyGenerator.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/freon/TestRandomKeyGenerator.java
@@ -23,6 +23,7 @@ import java.time.Duration;
 import org.apache.hadoop.hdds.conf.DatanodeRatisServerConfig;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.ratis.conf.RatisClientConfig;
+import org.apache.hadoop.hdds.scm.pipeline.WritableECContainerProvider.WritableECContainerProviderConfig;
 import org.apache.hadoop.ozone.MiniOzoneCluster;
 import org.apache.ozone.test.tag.Flaky;
 
@@ -60,6 +61,11 @@ public class TestRandomKeyGenerator {
     raftClientConfig.setRpcRequestTimeout(Duration.ofSeconds(3));
     raftClientConfig.setRpcWatchRequestTimeout(Duration.ofSeconds(3));
     conf.setFromObject(raftClientConfig);
+
+    WritableECContainerProviderConfig containerConfig =
+        conf.getObject(WritableECContainerProviderConfig.class);
+    containerConfig.setMinimumPipelines(10);
+    conf.setFromObject(containerConfig);
 
     cluster = MiniOzoneCluster.newBuilder(conf).setNumDatanodes(5).build();
     cluster.waitForClusterToBeReady();


### PR DESCRIPTION
## What changes were proposed in this pull request?

Keep track of pending EC pipeline allocations in `WritableECContainerProvider` to avoid the need for synchronization.  Only force wait for over-the-limit requests.

https://issues.apache.org/jira/browse/HDDS-8897

## How was this patch tested?

https://github.com/adoroszlai/hadoop-ozone/actions/runs/5342367241