### PR TITLE
HDDS-8910. Replace LockManager with striped lock in ContainerStateManager

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/ScmConfigKeys.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/ScmConfigKeys.java
@@ -346,6 +346,10 @@ public final class ScmConfigKeys {
       "ozone.scm.container.size";
   public static final String OZONE_SCM_CONTAINER_SIZE_DEFAULT = "5GB";
 
+  public static final String OZONE_SCM_CONTAINER_LOCK_STRIPE_SIZE =
+      "ozone.scm.container.lock.stripes";
+  public static final int OZONE_SCM_CONTAINER_LOCK_STRIPE_SIZE_DEFAULT = 512;
+
   public static final String OZONE_SCM_CONTAINER_PLACEMENT_IMPL_KEY =
       "ozone.scm.container.placement.impl";
   public static final String OZONE_SCM_PIPELINE_PLACEMENT_IMPL_KEY =

--- a/hadoop-hdds/common/src/main/resources/ozone-default.xml
+++ b/hadoop-hdds/common/src/main/resources/ozone-default.xml
@@ -1013,6 +1013,14 @@
     </description>
   </property>
   <property>
+    <name>ozone.scm.container.lock.stripes</name>
+    <value>512</value>
+    <tag>OZONE, SCM, PERFORMANCE, MANAGEMENT</tag>
+    <description>
+      The number of stripes created for the container state manager lock.
+    </description>
+  </property>
+  <property>
     <name>ozone.scm.datanode.address</name>
     <value/>
     <tag>OZONE, MANAGEMENT</tag>


### PR DESCRIPTION
## What changes were proposed in this pull request?

`ContainerStateManagerImpl` uses `LockManager` for maintaining a set of locks to be used per container ID.  Similar to HDDS-8765, it should be replaced with `Striped` locks.

https://issues.apache.org/jira/browse/HDDS-8910

## How was this patch tested?

CI:
https://github.com/adoroszlai/hadoop-ozone/actions/runs/5346927967