### PR TITLE
HDDS-8913. ContainerManagerImpl: reduce processing while locked

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/container/ContainerID.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/container/ContainerID.java
@@ -39,6 +39,8 @@ public final class ContainerID implements Comparable<ContainerID> {
       LongCodec.get(), ContainerID::valueOf, c -> c.id,
       DelegatedCodec.CopyType.SHALLOW);
 
+  public static final ContainerID MIN = ContainerID.valueOf(0);
+
   public static Codec<ContainerID> getCodec() {
     return CODEC;
   }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/ContainerManagerImpl.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/ContainerManagerImpl.java
@@ -19,19 +19,18 @@ package org.apache.hadoop.hdds.scm.container;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.NavigableSet;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.Random;
 import java.util.Set;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
-import java.util.stream.Collectors;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
@@ -144,34 +143,14 @@ public class ContainerManagerImpl implements ContainerManager {
   public List<ContainerInfo> getContainers(final ContainerID startID,
                                            final int count) {
     scmContainerManagerMetrics.incNumListContainersOps();
-    final List<ContainerID> containersIds =
-        new ArrayList<>(containerStateManager.getContainerIDs());
-    Collections.sort(containersIds);
-    List<ContainerInfo> containers;
-    lock.lock();
-    try {
-      containers = containersIds.stream()
-          .filter(id -> id.compareTo(startID) >= 0).limit(count)
-          .map(containerStateManager::getContainer)
-          .collect(Collectors.toList());
-    } finally {
-      lock.unlock();
-    }
-    return containers;
+    return toContainers(filterSortAndLimit(startID, count,
+        containerStateManager.getContainerIDs()));
   }
 
   @Override
   public List<ContainerInfo> getContainers(final LifeCycleState state) {
-    List<ContainerInfo> containers;
-    lock.lock();
-    try {
-      containers = containerStateManager.getContainerIDs(state).stream()
-          .map(containerStateManager::getContainer)
-          .filter(Objects::nonNull).collect(Collectors.toList());
-    } finally {
-      lock.unlock();
-    }
-    return containers;
+    scmContainerManagerMetrics.incNumListContainersOps();
+    return toContainers(containerStateManager.getContainerIDs(state));
   }
 
   @Override
@@ -179,20 +158,8 @@ public class ContainerManagerImpl implements ContainerManager {
                                            final int count,
                                            final LifeCycleState state) {
     scmContainerManagerMetrics.incNumListContainersOps();
-    final List<ContainerID> containersIds =
-        new ArrayList<>(containerStateManager.getContainerIDs(state));
-    Collections.sort(containersIds);
-    List<ContainerInfo> containers;
-    lock.lock();
-    try {
-      containers = containersIds.stream()
-          .filter(id -> id.compareTo(startID) >= 0).limit(count)
-          .map(containerStateManager::getContainer)
-          .collect(Collectors.toList());
-    } finally {
-      lock.unlock();
-    }
-    return containers;
+    return toContainers(filterSortAndLimit(startID, count,
+        containerStateManager.getContainerIDs(state)));
   }
 
   @Override
@@ -431,17 +398,23 @@ public class ContainerManagerImpl implements ContainerManager {
   public void deleteContainer(final ContainerID cid)
       throws IOException, TimeoutException {
     HddsProtos.ContainerID protoId = cid.getProtobuf();
+
+    final boolean found;
     lock.lock();
     try {
-      if (containerExist(cid)) {
+      found = containerExist(cid);
+      if (found) {
         containerStateManager.removeContainer(protoId);
-        scmContainerManagerMetrics.incNumSuccessfulDeleteContainers();
-      } else {
-        scmContainerManagerMetrics.incNumFailureDeleteContainers();
-        throwContainerNotFoundException(cid);
       }
     } finally {
       lock.unlock();
+    }
+
+    if (found) {
+      scmContainerManagerMetrics.incNumSuccessfulDeleteContainers();
+    } else {
+      scmContainerManagerMetrics.incNumFailureDeleteContainers();
+      throwContainerNotFoundException(cid);
     }
   }
 
@@ -470,5 +443,38 @@ public class ContainerManagerImpl implements ContainerManager {
   @VisibleForTesting
   public SCMHAManager getSCMHAManager() {
     return haManager;
+  }
+
+  private static List<ContainerID> filterSortAndLimit(
+      ContainerID startID, int count, Set<ContainerID> set) {
+
+    List<ContainerID> ids = new ArrayList<>(set);
+
+    // only filter if startID is not the minimum one
+    if (!startID.equals(ContainerID.MIN)) {
+      ids.removeIf(id -> id.compareTo(startID) < 0);
+    }
+
+    // sort after removing unnecessary items
+    Collections.sort(ids);
+
+    // limit
+    return ids.subList(0, Math.min(ids.size(), count));
+  }
+
+  /**
+   * Returns a list of all containers identified by {@code ids}.
+   */
+  private List<ContainerInfo> toContainers(Collection<ContainerID> ids) {
+    List<ContainerInfo> containers = new ArrayList<>(ids.size());
+
+    for (ContainerID id : ids) {
+      ContainerInfo container = containerStateManager.getContainer(id);
+      if (container != null) {
+        containers.add(container);
+      }
+    }
+
+    return containers;
   }
 }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/states/ContainerAttribute.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/states/ContainerAttribute.java
@@ -18,6 +18,7 @@
 package org.apache.hadoop.hdds.scm.container.states;
 
 import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableSortedSet;
 import org.apache.hadoop.hdds.scm.container.ContainerID;
 import org.apache.hadoop.hdds.scm.exceptions.SCMException;
 import org.slf4j.Logger;
@@ -189,7 +190,7 @@ public class ContainerAttribute<T> {
     Preconditions.checkNotNull(key);
 
     if (this.attributeMap.containsKey(key)) {
-      return Collections.unmodifiableNavigableSet(this.attributeMap.get(key));
+      return ImmutableSortedSet.copyOf(this.attributeMap.get(key));
     }
     if (LOG.isDebugEnabled()) {
       LOG.debug("No such Key. Key {}", key);

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/states/ContainerStateMap.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/states/ContainerStateMap.java
@@ -28,6 +28,7 @@ import java.util.concurrent.ConcurrentHashMap;
 
 import com.google.common.base.Preconditions;
 
+import com.google.common.collect.ImmutableSet;
 import org.apache.hadoop.hdds.client.ReplicationConfig;
 import org.apache.hadoop.hdds.scm.container.ContainerID;
 import org.apache.hadoop.hdds.scm.container.ContainerReplica;
@@ -295,7 +296,7 @@ public class ContainerStateMap {
   }
 
   public Set<ContainerID> getAllContainerIDs() {
-    return Collections.unmodifiableSet(containerMap.keySet());
+    return ImmutableSet.copyOf(containerMap.keySet());
   }
 
   /**


### PR DESCRIPTION
## What changes were proposed in this pull request?

1. `ContainerManagerImpl` lock is intended only for write operations (see [comment](https://github.com/apache/ozone/blob/3211547ed21b7683720ca57282e13a4edb9fdce2/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/ContainerManagerImpl.java#L68-L71) on `lock`).  `ContainerStateManagerImpl` has its own read/write lock.  Earlier `ConcurrentModificationException` (HDDS-6314) happened because `ContainerStateManagerImpl` returns an unmodifiable view of its internal sets.  These are not thread-safe, only protect against changing the set.  Replaced these with `ImmutableSet.copyOf`.
2. Replace stream with iteration.
3. Remove ineligible items from the list being sorted before sorting it.
4. Only filter items if request is not for all items (as indicated by the smallest possible `ContainerID`: 0.
5. Increment metric for `getContainers(LifeCycleState)`, was missing previously.
6. Move metrics calls out of locked block in `deleteContainer`.

Further improvement is possible, as some of the container sets are already sorted (to be done separately in HDDS-6315).

https://issues.apache.org/jira/browse/HDDS-8913

## How was this patch tested?

CI:
https://github.com/adoroszlai/hadoop-ozone/actions/runs/5356645847