### PR TITLE
HDDS-8919. Allow EC pipelines to be created and then added to PipelineManager in two steps

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/PipelineManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/PipelineManager.java
@@ -45,12 +45,12 @@ public interface PipelineManager extends Closeable, PipelineManagerMXBean {
                           List<DatanodeDetails> favoredNodes)
       throws IOException, TimeoutException;
 
-  Pipeline buildPipeline(ReplicationConfig replicationConfig,
-                         List<DatanodeDetails> excludedNodes,
-                         List<DatanodeDetails> favoredNodes)
+  Pipeline buildECPipeline(ReplicationConfig replicationConfig,
+                           List<DatanodeDetails> excludedNodes,
+                           List<DatanodeDetails> favoredNodes)
       throws IOException, TimeoutException;
 
-  void addPipeline(Pipeline pipeline) throws IOException, TimeoutException;
+  void addEcPipeline(Pipeline pipeline) throws IOException, TimeoutException;
 
 
   Pipeline createPipeline(

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/PipelineManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/PipelineManager.java
@@ -45,6 +45,13 @@ public interface PipelineManager extends Closeable, PipelineManagerMXBean {
                           List<DatanodeDetails> favoredNodes)
       throws IOException, TimeoutException;
 
+  Pipeline buildPipeline(ReplicationConfig replicationConfig,
+                         List<DatanodeDetails> excludedNodes,
+                         List<DatanodeDetails> favoredNodes)
+      throws IOException, TimeoutException;
+
+  void addPipeline(Pipeline pipeline) throws IOException, TimeoutException;
+
 
   Pipeline createPipeline(
       ReplicationConfig replicationConfig,

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/MockPipelineManager.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/MockPipelineManager.java
@@ -71,7 +71,7 @@ public class MockPipelineManager implements PipelineManager {
   public Pipeline createPipeline(ReplicationConfig replicationConfig,
       List<DatanodeDetails> excludedNodes, List<DatanodeDetails> favoredNodes)
       throws IOException, TimeoutException {
-    Pipeline pipeline = buildPipeline(replicationConfig, excludedNodes,
+    Pipeline pipeline = buildECPipeline(replicationConfig, excludedNodes,
         favoredNodes);
 
     stateManager.addPipeline(pipeline.getProtobufMessage(
@@ -80,7 +80,7 @@ public class MockPipelineManager implements PipelineManager {
   }
 
   @Override
-  public Pipeline buildPipeline(ReplicationConfig replicationConfig,
+  public Pipeline buildECPipeline(ReplicationConfig replicationConfig,
       List<DatanodeDetails> excludedNodes, List<DatanodeDetails> favoredNodes)
       throws IOException, TimeoutException {
     final List<DatanodeDetails> nodes = Stream.generate(
@@ -97,7 +97,7 @@ public class MockPipelineManager implements PipelineManager {
   }
 
   @Override
-  public void addPipeline(Pipeline pipeline)
+  public void addEcPipeline(Pipeline pipeline)
       throws IOException, TimeoutException {
     stateManager.addPipeline(pipeline.getProtobufMessage(
         ClientVersion.CURRENT_VERSION));

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/MockPipelineManager.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/MockPipelineManager.java
@@ -71,8 +71,20 @@ public class MockPipelineManager implements PipelineManager {
   public Pipeline createPipeline(ReplicationConfig replicationConfig,
       List<DatanodeDetails> excludedNodes, List<DatanodeDetails> favoredNodes)
       throws IOException, TimeoutException {
+    Pipeline pipeline = buildPipeline(replicationConfig, excludedNodes,
+        favoredNodes);
+
+    stateManager.addPipeline(pipeline.getProtobufMessage(
+        ClientVersion.CURRENT_VERSION));
+    return pipeline;
+  }
+
+  @Override
+  public Pipeline buildPipeline(ReplicationConfig replicationConfig,
+      List<DatanodeDetails> excludedNodes, List<DatanodeDetails> favoredNodes)
+      throws IOException, TimeoutException {
     final List<DatanodeDetails> nodes = Stream.generate(
-        MockDatanodeDetails::randomDatanodeDetails)
+            MockDatanodeDetails::randomDatanodeDetails)
         .limit(replicationConfig.getRequiredNodes())
         .collect(Collectors.toList());
     final Pipeline pipeline = Pipeline.newBuilder()
@@ -81,10 +93,14 @@ public class MockPipelineManager implements PipelineManager {
         .setNodes(nodes)
         .setState(Pipeline.PipelineState.OPEN)
         .build();
+    return pipeline;
+  }
 
+  @Override
+  public void addPipeline(Pipeline pipeline)
+      throws IOException, TimeoutException {
     stateManager.addPipeline(pipeline.getProtobufMessage(
         ClientVersion.CURRENT_VERSION));
-    return pipeline;
   }
 
   @Override

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestPipelineManagerImpl.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestPipelineManagerImpl.java
@@ -196,10 +196,10 @@ public class TestPipelineManagerImpl {
     Assertions.assertEquals(2, pipelineManager.getPipelines().size());
     Assertions.assertTrue(pipelineManager.containsPipeline(pipeline2.getId()));
 
-    Pipeline builtPipeline = pipelineManager.buildPipeline(
+    Pipeline builtPipeline = pipelineManager.buildECPipeline(
         RatisReplicationConfig.getInstance(ReplicationFactor.THREE),
         Collections.emptyList(), Collections.emptyList());
-    pipelineManager.addPipeline(builtPipeline);
+    pipelineManager.addEcPipeline(builtPipeline);
 
     Assertions.assertEquals(3, pipelineManager.getPipelines().size());
     Assertions.assertTrue(pipelineManager.containsPipeline(

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestPipelineManagerImpl.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestPipelineManagerImpl.java
@@ -72,6 +72,7 @@ import java.time.Instant;
 import java.time.ZoneOffset;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -194,6 +195,16 @@ public class TestPipelineManagerImpl {
         RatisReplicationConfig.getInstance(ReplicationFactor.ONE));
     Assertions.assertEquals(2, pipelineManager.getPipelines().size());
     Assertions.assertTrue(pipelineManager.containsPipeline(pipeline2.getId()));
+
+    Pipeline builtPipeline = pipelineManager.buildPipeline(
+        RatisReplicationConfig.getInstance(ReplicationFactor.THREE),
+        Collections.emptyList(), Collections.emptyList());
+    pipelineManager.addPipeline(builtPipeline);
+
+    Assertions.assertEquals(3, pipelineManager.getPipelines().size());
+    Assertions.assertTrue(pipelineManager.containsPipeline(
+        builtPipeline.getId()));
+
     buffer1.close();
     pipelineManager.close();
 
@@ -203,11 +214,11 @@ public class TestPipelineManagerImpl {
         createPipelineManager(true, buffer2);
     // Should be able to load previous pipelines.
     Assertions.assertFalse(pipelineManager2.getPipelines().isEmpty());
-    Assertions.assertEquals(2, pipelineManager.getPipelines().size());
+    Assertions.assertEquals(3, pipelineManager.getPipelines().size());
     Pipeline pipeline3 = pipelineManager2.createPipeline(
         RatisReplicationConfig.getInstance(ReplicationFactor.THREE));
     buffer2.close();
-    Assertions.assertEquals(3, pipelineManager2.getPipelines().size());
+    Assertions.assertEquals(4, pipelineManager2.getPipelines().size());
     Assertions.assertTrue(pipelineManager2.containsPipeline(pipeline3.getId()));
 
     pipelineManager2.close();

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestPipelineManagerImpl.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestPipelineManagerImpl.java
@@ -197,7 +197,7 @@ public class TestPipelineManagerImpl {
     Assertions.assertTrue(pipelineManager.containsPipeline(pipeline2.getId()));
 
     Pipeline builtPipeline = pipelineManager.buildECPipeline(
-        RatisReplicationConfig.getInstance(ReplicationFactor.THREE),
+        new ECReplicationConfig(3, 2),
         Collections.emptyList(), Collections.emptyList());
     pipelineManager.addEcPipeline(builtPipeline);
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

As it stands, the method:

```
 PipelineManager.createPipeline(ReplicationConfig replicationConfig,
      List<DatanodeDetails> excludedNodes, List<DatanodeDetails> favoredNodes)
```
Is used to create a new pipeline and add it to the Pipeline manager. This creation and adding is all performed under a single lock The somewhat expensive node selection process from the placement policy is performed under the lock.

For Ratis pipelines, this could be important, as pipelines are created and limited based on the number of existing pipelines on the nodes.

EC pipelines do not have such a limitation, and they also need to be created much more frequently due to their short lived nature.

This PR changes the pipeline manager to have a buildPipeline Method, which calls the placement policy and creates the new pipeline object without any locks.

Then there is an addPipeline method to add the created pipeline to the pipelineManager under the lock.

This will allow for the WritableECPipelineProvider to build pipelines without blocking other threads and then add them to the manager under a lock, reducing the amount of work performed under a lock. This change would need to be made in another PR.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-8919

## How was this patch tested?

Modified one test to call the new methods
