### PR TITLE
HDDS-8922. Random EC pipeline ID causes XceiverClient cache churn

### DIFF
--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/ozone/client/io/ECBlockInputStream.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/ozone/client/io/ECBlockInputStream.java
@@ -181,12 +181,13 @@ public class ECBlockInputStream extends BlockExtendedInputStream {
       // single location for the block index we want to read. The EC blocks are
       // indexed from 1 to N, however the data locations are stored in the
       // dataLocations array indexed from zero.
+      DatanodeDetails dataLocation = dataLocations[locationIndex];
       Pipeline pipeline = Pipeline.newBuilder()
           .setReplicationConfig(StandaloneReplicationConfig.getInstance(
               HddsProtos.ReplicationFactor.ONE))
-          .setNodes(Arrays.asList(dataLocations[locationIndex]))
-          .setId(PipelineID.randomId()).setReplicaIndexes(
-              ImmutableMap.of(dataLocations[locationIndex], locationIndex + 1))
+          .setNodes(Arrays.asList(dataLocation))
+          .setId(PipelineID.valueOf(dataLocation.getUuid())).setReplicaIndexes(
+              ImmutableMap.of(dataLocation, locationIndex + 1))
           .setState(Pipeline.PipelineState.CLOSED)
           .build();
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

The XceiverClient cache is often expired when using ec reads

I am currently using ec for large concurrent reads and found that on the client side, a large number of XceiverClient cache remove logs .

Now each read builds a new pipeline, I think we can use the datanode id, as the pipeline id, so that we can take the client's XceiverClient cache.


## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-8922

## How was this patch tested?

Existing test
