### PR TITLE
HDDS-8770. Cleanup of failed container delete may remove datanode RocksDB entries of active container

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/HddsDatanodeService.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/HddsDatanodeService.java
@@ -161,7 +161,7 @@ public class HddsDatanodeService extends GenericCli implements ServicePlugin {
           HddsVolume hddsVolume = (HddsVolume) volume;
           try {
             KeyValueContainerUtil.ContainerDeleteDirectory
-                .cleanTmpDir(hddsVolume);
+                .cleanTmpDir(hddsVolume, null);
           } catch (IOException ex) {
             LOG.error("Error while cleaning tmp delete directory " +
                 "under {}", hddsVolume.getWorkingDir(), ex);

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/interfaces/Container.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/interfaces/Container.java
@@ -102,6 +102,11 @@ public interface Container<CONTAINERDATA extends ContainerData> extends RwLock {
   void markContainerUnhealthy() throws StorageContainerException;
 
   /**
+   * Marks the container replica as deleted.
+   */
+  void markContainerForDelete() throws StorageContainerException;
+
+  /**
    * Quasi Closes a open container, if it is already closed or does not exist a
    * StorageContainerException is thrown.
    *

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/KeyValueContainer.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/KeyValueContainer.java
@@ -366,6 +366,22 @@ public class KeyValueContainer implements Container<KeyValueContainerData> {
   }
 
   @Override
+  public void markContainerForDelete() throws StorageContainerException {
+    writeLock();
+    ContainerDataProto.State prevState = containerData.getState();
+    try {
+      updateContainerData(() ->
+          containerData.setState(ContainerDataProto.State.DELETED));
+      clearPendingPutBlockCache();
+    } finally {
+      writeUnlock();
+    }
+    LOG.warn("Moving container {} to state {} from state:{}",
+        containerData.getContainerPath(), containerData.getState(),
+        prevState);
+  }
+
+  @Override
   public void quasiClose() throws StorageContainerException {
     closeAndFlushIfNeeded(containerData::quasiCloseContainer);
   }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/KeyValueHandler.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/KeyValueHandler.java
@@ -1324,6 +1324,7 @@ public class KeyValueHandler extends Handler {
         HddsVolume hddsVolume = keyValueContainerData.getVolume();
 
         // Rename container location
+        container.markContainerForDelete();
         boolean success = KeyValueContainerUtil.ContainerDeleteDirectory
             .moveToTmpDeleteDirectory(keyValueContainerData, hddsVolume);
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

- state DELETED is added in container file before container delete

current steps:
```
1. Move container directory to tmp deleted containers directory on the same file system (atomic).
2. Delete DB entries
3. Delete container from tmp directory.
```
new steps:
```
1. Mark container state as DELETED in container yaml file
2. Move container directory to tmp deleted containers directory on the same file system (atomic).
3. Delete DB entries
4. Delete container from tmp directory.

So during startup,
If any container in DELETED state, move to temp Directory
container present in active directory, and state is not deleted, no need delete from DB, else delete as part of cleanup
```

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-8770

## How was this patch tested?

- TODO UT after [HDDS-8771. Refactor volume level tmp directory for generic usage.](https://github.com/apache/ozone/pull/4838/files#top)
