### PR TITLE
HDDS-8925. BaseFreonGenerator may not complete if last attempts fail

### DIFF
--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/BaseFreonGenerator.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/BaseFreonGenerator.java
@@ -97,7 +97,7 @@ public class BaseFreonGenerator {
   @Option(names = {"-t", "--threads", "--thread"},
       description = "Number of threads used to execute",
       defaultValue = "10")
-  private int threadNo;
+  private int threadNo = 10;
 
   @Option(names = {"--duration"},
       description = "Duration to run the test. "
@@ -273,6 +273,10 @@ public class BaseFreonGenerator {
    * Initialize internal counters, and variables. Call it before runTests.
    */
   public void init() {
+    // run outside of picocli, e.g. unit tests
+    if (freonCommand == null) {
+      freonCommand = new Freon();
+    }
 
     freonCommand.startHttpServer();
 
@@ -557,8 +561,20 @@ public class BaseFreonGenerator {
     void executeNextTask(long step) throws Exception;
   }
 
-  public AtomicLong getAttemptCounter() {
-    return attemptCounter;
+  public long getAttemptCount() {
+    return attemptCounter.get();
+  }
+
+  public long getSuccessCount() {
+    return successCounter.get();
+  }
+
+  public long getFailureCount() {
+    return failureCounter.get();
+  }
+
+  public boolean isCompleted() {
+    return completed.get();
   }
 
   public int getThreadNo() {

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/BaseFreonGenerator.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/BaseFreonGenerator.java
@@ -245,7 +245,7 @@ public class BaseFreonGenerator {
   }
 
   private void shutdown() {
-    if (failureCounter.get() > 0) {
+    if (!failAtEnd) {
       progressBar.terminate();
     } else {
       progressBar.shutdown();
@@ -329,7 +329,7 @@ public class BaseFreonGenerator {
           Instant.ofEpochMilli(startTime), Instant.now()).getSeconds();
     } else {
       maxValue = testNo;
-      supplier = successCounter::get;
+      supplier = () -> successCounter.get() + failureCounter.get();
     }
     progressBar = new ProgressBar(System.out, maxValue, supplier,
         freonCommand.isInteractive(), realTimeStatusSupplier());

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/FollowerAppendLogEntryGenerator.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/FollowerAppendLogEntryGenerator.java
@@ -363,7 +363,7 @@ public class FollowerAppendLogEntryGenerator extends BaseAppendLogGenerator
     }
     long lastCommit = reply.getFollowerCommit();
     if (lastCommit % 1000 == 0) {
-      long currentIndex = getAttemptCounter().get();
+      long currentIndex = getAttemptCount();
       if (currentIndex - lastCommit > batching * 3) {
         LOG.warn(
             "Last committed index ({}) is behind the current index ({}) on "


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fix edge case in `BaseFreonGenerator` which happens if there are tasks in progress when `ProgressBar` shutdown/termination is initiated AND one or more of these in-progress tasks fail.

Repro:

```
$ docker-compose exec -T s3g ozone freon s3kg -n 1 -t 10 -b no-such-bucket
...
2023-06-25 13:30:46,493 [main] INFO freon.BaseFreonGenerator: Executing test with prefix p0l2uvfgg7 and number-of-tests 1
2023-06-25 13:30:46,507 [Thread-3] INFO freon.ProgressBar: Progress: 0.00 % (0 out of 1)
2023-06-25 13:30:46,792 [pool-2-thread-1] ERROR freon.BaseFreonGenerator: Error on executing task 0
com.amazonaws.SdkClientException: Unable to load AWS credentials from environment variables (AWS_ACCESS_KEY_ID (or AWS_ACCESS_KEY) and AWS_SECRET_KEY (or AWS_SECRET_ACCESS_KEY))
	at com.amazonaws.auth.EnvironmentVariableCredentialsProvider.getCredentials(EnvironmentVariableCredentialsProvider.java:50)
	...
	at org.apache.hadoop.ozone.freon.S3KeyGenerator.createKey(S3KeyGenerator.java:111)
	at org.apache.hadoop.ozone.freon.BaseFreonGenerator.tryNextTask(BaseFreonGenerator.java:220)
	at org.apache.hadoop.ozone.freon.BaseFreonGenerator.taskLoop(BaseFreonGenerator.java:200)
	at org.apache.hadoop.ozone.freon.BaseFreonGenerator.lambda$startTaskRunners$0(BaseFreonGenerator.java:174)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
	at java.base/java.lang.Thread.run(Thread.java:829)
2023-06-25 13:30:47,509 [Thread-3] INFO freon.ProgressBar: Progress: 0.00 % (0 out of 1)
2023-06-25 13:30:48,510 [Thread-3] INFO freon.ProgressBar: Progress: 0.00 % (0 out of 1)
2023-06-25 13:30:49,511 [Thread-3] INFO freon.ProgressBar: Progress: 0.00 % (0 out of 1)
2023-06-25 13:30:50,513 [Thread-3] INFO freon.ProgressBar: Progress: 0.00 % (0 out of 1)
2023-06-25 13:30:51,514 [Thread-3] INFO freon.ProgressBar: Progress: 0.00 % (0 out of 1)
2023-06-25 13:30:52,515 [Thread-3] INFO freon.ProgressBar: Progress: 0.00 % (0 out of 1)
2023-06-25 13:30:53,517 [Thread-3] INFO freon.ProgressBar: Progress: 0.00 % (0 out of 1)
2023-06-25 13:30:54,518 [Thread-3] INFO freon.ProgressBar: Progress: 0.00 % (0 out of 1)
2023-06-25 13:30:55,519 [Thread-3] INFO freon.ProgressBar: Progress: 0.00 % (0 out of 1)
2023-06-25 13:30:56,520 [Thread-3] INFO freon.ProgressBar: Progress: 0.00 % (0 out of 1)
...
```

https://issues.apache.org/jira/browse/HDDS-8925

## How was this patch tested?

Added integration test.

Also tested manually:

```
$ docker-compose exec -T s3g ozone freon s3kg -n 1 -t 10 -b no-such-bucket
...
2023-06-25 16:08:04,029 [main] INFO freon.BaseFreonGenerator: Executing test with prefix x423upnr6h and number-of-tests 1
2023-06-25 16:08:04,044 [Thread-3] INFO freon.ProgressBar: Progress: 0.00 % (0 out of 1)
2023-06-25 16:08:04,338 [pool-2-thread-1] ERROR freon.BaseFreonGenerator: Error on executing task 0
com.amazonaws.SdkClientException: Unable to load AWS credentials from environment variables (AWS_ACCESS_KEY_ID (or AWS_ACCESS_KEY) and AWS_SECRET_KEY (or AWS_SECRET_ACCESS_KEY))
	at com.amazonaws.auth.EnvironmentVariableCredentialsProvider.getCredentials(EnvironmentVariableCredentialsProvider.java:50)
	...
	at org.apache.hadoop.ozone.freon.S3KeyGenerator.lambda$createKey$0(S3KeyGenerator.java:145)
	at com.codahale.metrics.Timer.time(Timer.java:101)
	at org.apache.hadoop.ozone.freon.S3KeyGenerator.createKey(S3KeyGenerator.java:111)
	at org.apache.hadoop.ozone.freon.BaseFreonGenerator.tryNextTask(BaseFreonGenerator.java:220)
	at org.apache.hadoop.ozone.freon.BaseFreonGenerator.taskLoop(BaseFreonGenerator.java:200)
	at org.apache.hadoop.ozone.freon.BaseFreonGenerator.lambda$startTaskRunners$0(BaseFreonGenerator.java:174)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
	at java.base/java.lang.Thread.run(Thread.java:829)
2023-06-25 16:08:05,045 [Thread-3] INFO freon.ProgressBar: Progress: 100.00 % (1 out of 1)
One ore more freon test is failed.
2023-06-25 16:08:05,062 [shutdown-hook-0] INFO metrics: type=TIMER, name=key-create, count=1, min=13.293068, max=13.293068, mean=13.293068, stddev=0.0, median=13.293068, p75=13.293068, p95=13.293068, p98=13.293068, p99=13.293068, p999=13.293068, mean_rate=1.3469914857611078, m1=0.0, m5=0.0, m15=0.0, rate_unit=events/second, duration_unit=milliseconds
2023-06-25 16:08:05,063 [shutdown-hook-0] INFO freon.BaseFreonGenerator: Total execution time (sec): 1
2023-06-25 16:08:05,063 [shutdown-hook-0] INFO freon.BaseFreonGenerator: Failures: 1
2023-06-25 16:08:05,063 [shutdown-hook-0] INFO freon.BaseFreonGenerator: Successful executions: 0
2023-06-25 16:08:05,063 [shutdown-hook-0] INFO freon.BaseFreonGenerator: Expected 1 --number-of-tests objects!, successfully executed 0
```

CI:
https://github.com/adoroszlai/hadoop-ozone/actions/runs/5370663046