### PR TITLE
HDDS-8923. Expose XceiverClient cache stats as metrics

### DIFF
--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/XceiverClientManager.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/XceiverClientManager.java
@@ -46,6 +46,8 @@ import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static org.apache.hadoop.hdds.conf.ConfigTag.OZONE;
 import static org.apache.hadoop.hdds.conf.ConfigTag.PERFORMANCE;
 import static org.apache.hadoop.hdds.scm.exceptions.SCMException.ResultCodes.NO_REPLICA_FOUND;
+
+import org.apache.hadoop.util.CacheMetrics;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -68,6 +70,7 @@ public class XceiverClientManager implements Closeable, XceiverClientFactory {
   private final ConfigurationSource conf;
   private final ScmClientConfig clientConfig;
   private final Cache<String, XceiverClientSpi> clientCache;
+  private final CacheMetrics cacheMetrics;
   private List<X509Certificate> caCerts;
 
   private static XceiverClientMetrics metrics;
@@ -99,6 +102,7 @@ public class XceiverClientManager implements Closeable, XceiverClientFactory {
     }
 
     this.clientCache = CacheBuilder.newBuilder()
+        .recordStats()
         .expireAfterAccess(staleThresholdMs, MILLISECONDS)
         .maximumSize(clientConf.getMaxSize())
         .removalListener(
@@ -117,6 +121,8 @@ public class XceiverClientManager implements Closeable, XceiverClientFactory {
     topologyAwareRead = conf.getBoolean(
         OzoneConfigKeys.OZONE_NETWORK_TOPOLOGY_AWARE_READ_KEY,
         OzoneConfigKeys.OZONE_NETWORK_TOPOLOGY_AWARE_READ_DEFAULT);
+
+    cacheMetrics = CacheMetrics.create(clientCache, "xceiverClientCache");
   }
 
   @VisibleForTesting
@@ -278,6 +284,10 @@ public class XceiverClientManager implements Closeable, XceiverClientFactory {
     //closing is done through RemovalListener
     clientCache.invalidateAll();
     clientCache.cleanUp();
+    if (LOG.isDebugEnabled()) {
+      LOG.debug("XceiverClient cache stats: {}", clientCache.stats());
+    }
+    cacheMetrics.unregister();
 
     if (metrics != null) {
       metrics.unRegister();

--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/XceiverClientManager.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/XceiverClientManager.java
@@ -122,7 +122,7 @@ public class XceiverClientManager implements Closeable, XceiverClientFactory {
         OzoneConfigKeys.OZONE_NETWORK_TOPOLOGY_AWARE_READ_KEY,
         OzoneConfigKeys.OZONE_NETWORK_TOPOLOGY_AWARE_READ_DEFAULT);
 
-    cacheMetrics = CacheMetrics.create(clientCache, "xceiverClientCache");
+    cacheMetrics = CacheMetrics.create(clientCache, this);
   }
 
   @VisibleForTesting

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/util/CacheMetrics.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/util/CacheMetrics.java
@@ -60,8 +60,6 @@ public final class CacheMetrics implements MetricsSource {
   public static final String SOURCE_NAME =
       CacheMetrics.class.getSimpleName();
 
-  public static final String NAME = CacheMetrics.class.getSimpleName();
-
   private final Cache<?, ?> cache;
   private final String name;
   private final String sourceName;
@@ -69,7 +67,7 @@ public final class CacheMetrics implements MetricsSource {
   private CacheMetrics(Cache<?, ?> cache, String name) {
     this.cache = cache;
     this.name = name;
-    sourceName = NAME + ":" + name;
+    sourceName = SOURCE_NAME + ":" + name;
   }
 
   public static CacheMetrics create(Cache<?, ?> cache, Object owner) {

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/util/CacheMetrics.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/util/CacheMetrics.java
@@ -67,7 +67,7 @@ public final class CacheMetrics implements MetricsSource {
   private CacheMetrics(Cache<?, ?> cache, String name) {
     this.cache = cache;
     this.name = name;
-    sourceName = SOURCE_NAME + ":" + name;
+    sourceName = SOURCE_NAME + "-" + name;
   }
 
   public static CacheMetrics create(Cache<?, ?> cache, Object owner) {

--- a/hadoop-ozone/client/src/test/java/org/apache/hadoop/ozone/client/io/TestECBlockOutputStreamEntry.java
+++ b/hadoop-ozone/client/src/test/java/org/apache/hadoop/ozone/client/io/TestECBlockOutputStreamEntry.java
@@ -60,21 +60,22 @@ public class TestECBlockOutputStreamEntry {
         .setState(Pipeline.PipelineState.OPEN)
         .setNodes(nodes)
         .build();
-    XceiverClientManager manager =
-        new XceiverClientManager(new OzoneConfiguration());
-    HashSet<XceiverClientSpi> clients = new HashSet<>();
-    ECBlockOutputStreamEntry entry = new ECBlockOutputStreamEntry.Builder()
-        .setXceiverClientManager(manager)
-        .setPipeline(anECPipeline)
-        .build();
-    for (int i = 0; i < nodes.size(); i++) {
-      clients.add(
-          manager.acquireClient(
-              entry.createSingleECBlockPipeline(
-                  anECPipeline, nodes.get(i), i
-              )));
+    try (XceiverClientManager manager =
+        new XceiverClientManager(new OzoneConfiguration())) {
+      HashSet<XceiverClientSpi> clients = new HashSet<>();
+      ECBlockOutputStreamEntry entry = new ECBlockOutputStreamEntry.Builder()
+          .setXceiverClientManager(manager)
+          .setPipeline(anECPipeline)
+          .build();
+      for (int i = 0; i < nodes.size(); i++) {
+        clients.add(
+            manager.acquireClient(
+                entry.createSingleECBlockPipeline(
+                    anECPipeline, nodes.get(i), i
+                )));
+      }
+      assertEquals(5, clients.size());
     }
-    assertEquals(5, clients.size());
   }
 
   @Test
@@ -97,23 +98,26 @@ public class TestECBlockOutputStreamEntry {
         .setState(Pipeline.PipelineState.OPEN)
         .setNodes(nodes)
         .build();
-    XceiverClientManager manager =
-        new XceiverClientManager(new OzoneConfiguration());
-    HashSet<XceiverClientSpi> clients = new HashSet<>();
-    ECBlockOutputStreamEntry entry = new ECBlockOutputStreamEntry.Builder()
-        .setXceiverClientManager(manager)
-        .setPipeline(anECPipeline)
-        .build();
-    for (int i = 0; i < nodes.size(); i++) {
-      clients.add(
-          manager.acquireClient(
-              entry.createSingleECBlockPipeline(
-                  anECPipeline, nodes.get(i), i
-              )));
+    try (XceiverClientManager manager =
+        new XceiverClientManager(new OzoneConfiguration())) {
+      HashSet<XceiverClientSpi> clients = new HashSet<>();
+      ECBlockOutputStreamEntry entry = new ECBlockOutputStreamEntry.Builder()
+          .setXceiverClientManager(manager)
+          .setPipeline(anECPipeline)
+          .build();
+      for (int i = 0; i < nodes.size(); i++) {
+        clients.add(
+            manager.acquireClient(
+                entry.createSingleECBlockPipeline(
+                    anECPipeline, nodes.get(i), i
+                )));
+      }
+      assertEquals(3, clients.size());
+      assertEquals(1,
+          clients.stream().filter(c -> c.getRefcount() == 3).count());
+      assertEquals(2,
+          clients.stream().filter(c -> c.getRefcount() == 1).count());
     }
-    assertEquals(3, clients.size());
-    assertEquals(1, clients.stream().filter(c -> c.getRefcount() == 3).count());
-    assertEquals(2, clients.stream().filter(c -> c.getRefcount() == 1).count());
   }
 
   private DatanodeDetails aNode(String ip, String hostName, int port) {


### PR DESCRIPTION
## What changes were proposed in this pull request?

Enable recording of statistics for `XceiverClientManager#clientCache`, and expose them as metrics.

https://issues.apache.org/jira/browse/HDDS-8923

## How was this patch tested?

Checked cache metrics in Prometheus after triggering EC reconstruction by scaling datanodes down and up.

CI:
https://github.com/adoroszlai/hadoop-ozone/actions/runs/5376304587