### PR TITLE
HDDS-8929. Avoid list allocation for pipeline search

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/pipeline/Pipeline.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/pipeline/Pipeline.java
@@ -468,7 +468,7 @@ public final class Pipeline {
     return new EqualsBuilder()
         .append(id, that.id)
         .append(replicationConfig, that.replicationConfig)
-        .append(getNodes(), that.getNodes())
+        .append(nodeStatus.keySet(), that.nodeStatus.keySet())
         .isEquals();
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

`Pipeline#equals` includes equality of `getNodes()`, which wraps the set of nodes in a new `ArrayList` (defensive "copy").  This is unnecessary, we can compare the underlying `Set`.

(see `HealthyPipelineChoosePolicy.choosePipelineIndex` in [flamegraph from HDDS-8897](https://issues.apache.org/jira/secure/attachment/13060838/profile-scm-60s-cpu.svg))

https://issues.apache.org/jira/browse/HDDS-8929

## How was this patch tested?

CI:
https://github.com/adoroszlai/hadoop-ozone/actions/runs/5376416993