### PR TITLE
HDDS-8931. Allow EC PipelineChoosingPolicy to be defined separately from Ratis

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/ScmConfig.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/ScmConfig.java
@@ -71,11 +71,26 @@ public class ScmConfig {
           "The full name of class which implements "
           + "org.apache.hadoop.hdds.scm.PipelineChoosePolicy. "
           + "The class decides which pipeline will be used to find or "
-          + "allocate container. If not set, "
+          + "allocate Ratis containers. If not set, "
           + "org.apache.hadoop.hdds.scm.pipeline.choose.algorithms. "
           + "RandomPipelineChoosePolicy will be used as default value."
   )
   private String pipelineChoosePolicyName;
+
+  @Config(key = "ec.pipeline.choose.policy.impl",
+      type = ConfigType.STRING,
+      defaultValue = "org.apache.hadoop.hdds.scm.pipeline.choose.algorithms" +
+          ".RandomPipelineChoosePolicy",
+      tags = { ConfigTag.SCM, ConfigTag.PIPELINE },
+      description =
+          "The full name of class which implements "
+              + "org.apache.hadoop.hdds.scm.PipelineChoosePolicy. "
+              + "The class decides which pipeline will be used when "
+              + "selecting an EC Pipeline. If not set, "
+              + "org.apache.hadoop.hdds.scm.pipeline.choose.algorithms. "
+              + "RandomPipelineChoosePolicy will be used as default value."
+  )
+  private String ecPipelineChoosePolicyName;
 
   @Config(key = "block.deletion.per-interval.max",
       type = ConfigType.INT,
@@ -138,6 +153,10 @@ public class ScmConfig {
     this.pipelineChoosePolicyName = pipelineChoosePolicyName;
   }
 
+  public void setECPipelineChoosePolicyName(String policyName) {
+    this.ecPipelineChoosePolicyName = policyName;
+  }
+
   public void setBlockDeletionLimit(int blockDeletionLimit) {
     this.blockDeletionLimit = blockDeletionLimit;
   }
@@ -156,6 +175,10 @@ public class ScmConfig {
 
   public String getPipelineChoosePolicyName() {
     return pipelineChoosePolicyName;
+  }
+
+  public String getECPipelineChoosePolicyName() {
+    return ecPipelineChoosePolicyName;
   }
 
   public int getBlockDeletionLimit() {

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/WritableContainerFactory.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/WritableContainerFactory.java
@@ -57,7 +57,7 @@ public class WritableContainerFactory {
         scm.getScmNodeManager(),
         scm.getPipelineManager(),
         scm.getContainerManager(),
-        scm.getPipelineChoosePolicy());
+        scm.getEcPipelineChoosePolicy());
   }
 
   public ContainerInfo getContainer(final long size,

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/StorageContainerManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/StorageContainerManager.java
@@ -300,6 +300,7 @@ public final class StorageContainerManager extends ServiceRuntimeInfoImpl
    */
   private NetworkTopology clusterMap;
   private PipelineChoosePolicy pipelineChoosePolicy;
+  private PipelineChoosePolicy ecPipelineChoosePolicy;
   private SecurityConfig securityConfig;
 
   private final SCMHANodeDetails scmHANodeDetails;
@@ -764,7 +765,11 @@ public final class StorageContainerManager extends ServiceRuntimeInfoImpl
           containerReplicaPendingOps);
     }
 
-    pipelineChoosePolicy = PipelineChoosePolicyFactory.getPolicy(conf);
+    ScmConfig scmConfig = conf.getObject(ScmConfig.class);
+    pipelineChoosePolicy = PipelineChoosePolicyFactory
+        .getPolicy(scmConfig, false);
+    ecPipelineChoosePolicy = PipelineChoosePolicyFactory
+        .getPolicy(scmConfig, true);
     if (configurator.getWritableContainerFactory() != null) {
       writableContainerFactory = configurator.getWritableContainerFactory();
     } else {
@@ -2008,6 +2013,10 @@ public final class StorageContainerManager extends ServiceRuntimeInfoImpl
 
   public PipelineChoosePolicy getPipelineChoosePolicy() {
     return this.pipelineChoosePolicy;
+  }
+
+  public PipelineChoosePolicy getEcPipelineChoosePolicy() {
+    return this.ecPipelineChoosePolicy;
   }
 
   @Override


### PR DESCRIPTION
## What changes were proposed in this pull request?

A cluster may have set the PipelineChoosingPolicy to the HealthyPipelineChoosePolicy for Ratis, but it adds overhead and is not necessary for EC, as the EC pipeline is always healthy:

```
  public boolean isHealthy() {
    // EC pipelines are not reported by the DN and do not have a leader. If a
    // node goes stale or dead, EC pipelines will by closed like RATIS pipelines
    // but at the current time there are not other health metrics for EC.
    if (replicationConfig.getReplicationType() == ReplicationType.EC) {
      return true;
    }
    ...
```
To allow for flexibility, add a new config for the ECPipelineChoosingPolicy so it can be different from the Ratis policy.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-8931

## How was this patch tested?
Modified and added to the tests in the PipelinePolicyFactory.
