### PR TITLE
HDDS-8939. [Snapshot] isBlockLocationSame check should be skipped if object is not OmKeyInfo.

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOmSnapshot.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOmSnapshot.java
@@ -20,8 +20,6 @@ import java.time.Duration;
 import java.util.List;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.apache.commons.lang3.StringUtils;
-import org.apache.hadoop.fs.Path;
-import org.apache.hadoop.fs.permission.FsPermission;
 import org.apache.hadoop.hdds.utils.IOUtils;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.hadoop.hdds.client.StandaloneReplicationConfig;
@@ -590,8 +588,9 @@ public class TestOmSnapshot {
     createSnapshot(volume, bucket, snap2);
     SnapshotDiffReportOzone diff = getSnapDiffReport(volume, bucket,
         snap1, snap2);
-    Assertions.assertEquals(Arrays.asList(SnapshotDiffReportOzone.getDiffReportEntry(
-        SnapshotDiffReport.DiffType.RENAME, "/dir1", "/dir1_rename")),
+    Assertions.assertEquals(Arrays.asList(
+        SnapshotDiffReportOzone.getDiffReportEntry(
+            SnapshotDiffReport.DiffType.RENAME, "/dir1", "/dir1_rename")),
         diff.getDiffList());
   }
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/snapshot/SnapshotDiffManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/snapshot/SnapshotDiffManager.java
@@ -890,15 +890,21 @@ public class SnapshotDiffManager implements AutoCloseable {
           .getKeyTable(bucketLayout);
       Table<String, OmKeyInfo> tsKeyTable = toSnapshot.getMetadataManager()
           .getKeyTable(bucketLayout);
+      Table<String, OmDirectoryInfo> fsDirTable;
+      Table<String, OmDirectoryInfo> tsDirTable;
 
       final Optional<Set<Long>> oldParentIds;
       final Optional<Set<Long>> newParentIds;
       if (bucketLayout.isFileSystemOptimized()) {
         oldParentIds = Optional.of(new HashSet<>());
         newParentIds = Optional.of(new HashSet<>());
+        fsDirTable = fromSnapshot.getMetadataManager().getDirectoryTable();
+        tsDirTable = toSnapshot.getMetadataManager().getDirectoryTable();
       } else {
         oldParentIds = Optional.empty();
         newParentIds = Optional.empty();
+        fsDirTable = null;
+        tsDirTable = null;
       }
 
       final Optional<Map<Long, Path>> oldParentIdPathMap;
@@ -924,11 +930,6 @@ public class SnapshotDiffManager implements AutoCloseable {
           },
           () -> {
             if (bucketLayout.isFileSystemOptimized()) {
-              Table<String, OmDirectoryInfo> fsDirTable =
-                  fromSnapshot.getMetadataManager().getDirectoryTable();
-              Table<String, OmDirectoryInfo> tsDirTable =
-                  toSnapshot.getMetadataManager().getDirectoryTable();
-
               getDeltaFilesAndDiffKeysToObjectIdToKeyMap(fsDirTable, tsDirTable,
                   fromSnapshot, toSnapshot, fsInfo, tsInfo, useFullDiff,
                   tablePrefixes, objectIdToKeyNameMapForFromSnapshot,
@@ -959,6 +960,8 @@ public class SnapshotDiffManager implements AutoCloseable {
             long totalDiffEntries = generateDiffReport(jobId,
                 fsKeyTable,
                 tsKeyTable,
+                fsDirTable,
+                tsDirTable,
                 objectIdToDiffObject,
                 objectIdToKeyNameMapForFromSnapshot,
                 objectIdToKeyNameMapForToSnapshot,
@@ -1116,7 +1119,7 @@ public class SnapshotDiffManager implements AutoCloseable {
             oldObjIdToKeyMap.put(rawObjId, rawValue);
             SnapshotDiffObject diffObject =
                 createDiffObjectWithOldName(fromObjectId.getObjectID(), key,
-                    objectIdToDiffObject.get(rawObjId));
+                    objectIdToDiffObject.get(rawObjId), isDirectoryTable);
             objectIdToDiffObject.put(rawObjId, diffObject);
             oldParentIds.ifPresent(set -> set.add(
                 fromObjectId.getParentObjectID()));
@@ -1128,7 +1131,7 @@ public class SnapshotDiffManager implements AutoCloseable {
             newObjIdToKeyMap.put(rawObjId, rawValue);
             SnapshotDiffObject diffObject =
                 createDiffObjectWithNewName(toObjectId.getObjectID(), key,
-                    objectIdToDiffObject.get(rawObjId));
+                    objectIdToDiffObject.get(rawObjId), isDirectoryTable);
             objectIdToDiffObject.put(rawObjId, diffObject);
             newParentIds.ifPresent(set -> set.add(toObjectId
                 .getParentObjectID()));
@@ -1145,9 +1148,10 @@ public class SnapshotDiffManager implements AutoCloseable {
   }
 
   private SnapshotDiffObject createDiffObjectWithOldName(
-      long objectId, String oldName, SnapshotDiffObject diffObject) {
+      long objectId, String oldName, SnapshotDiffObject diffObject,
+      boolean isDirectory) {
     SnapshotDiffObjectBuilder builder = new SnapshotDiffObjectBuilder(objectId)
-        .withOldKeyName(oldName);
+        .withOldKeyName(oldName).isDirectory(isDirectory);
     if (diffObject != null) {
       builder.withNewKeyName(diffObject.getNewKeyName());
     }
@@ -1155,10 +1159,11 @@ public class SnapshotDiffManager implements AutoCloseable {
   }
 
   private SnapshotDiffObject createDiffObjectWithNewName(
-      long objectId, String newName, SnapshotDiffObject diffObject) {
+      long objectId, String newName, SnapshotDiffObject diffObject,
+      boolean isDirectory) {
 
     SnapshotDiffObjectBuilder builder = new SnapshotDiffObjectBuilder(objectId)
-        .withNewKeyName(newName);
+        .withNewKeyName(newName).isDirectory(isDirectory);
     if (diffObject != null) {
       builder.withOldKeyName(diffObject.getOldKeyName());
     }
@@ -1269,8 +1274,10 @@ public class SnapshotDiffManager implements AutoCloseable {
   @SuppressWarnings({"checkstyle:ParameterNumber", "checkstyle:MethodLength"})
   long generateDiffReport(
       final String jobId,
-      final Table<String, ? extends WithObjectID> fsTable,
-      final Table<String, ? extends WithObjectID> tsTable,
+      final Table<String, OmKeyInfo> fsTable,
+      final Table<String, OmKeyInfo> tsTable,
+      final Table<String, OmDirectoryInfo> fsDirTable,
+      final Table<String, OmDirectoryInfo> tsDirTable,
       final PersistentMap<byte[], SnapshotDiffObject> objectIdToDiffObject,
       final PersistentMap<byte[], byte[]> oldObjIdToKeyMap,
       final PersistentMap<byte[], byte[]> newObjIdToKeyMap,
@@ -1374,8 +1381,10 @@ public class SnapshotDiffManager implements AutoCloseable {
 
             // Check if block location is same or not. If it is not same,
             // key must have been overridden as well.
-            if (!isBlockLocationSame(snapshotDiffObject.getOldKeyName(),
-                snapshotDiffObject.getNewKeyName(), fsTable, tsTable)) {
+            if (isObjectModified(snapshotDiffObject.getOldKeyName(),
+                snapshotDiffObject.getNewKeyName(),
+                snapshotDiffObject.isDirectory() ? fsDirTable : fsTable,
+                snapshotDiffObject.isDirectory() ? tsDirTable : tsTable)) {
               // Here, oldKey name is returned as modified. Modified key name is
               // based on base snapshot (from snapshot).
               renameDiffs.add(codecRegistry.asRawData(
@@ -1437,6 +1446,34 @@ public class SnapshotDiffManager implements AutoCloseable {
       dropAndCloseColumnFamilyHandle(createDiffColumnFamily);
       dropAndCloseColumnFamilyHandle(modifyDiffColumnFamily);
     }
+  }
+
+  private boolean isObjectModified(String fromObjectName, String toObjectName,
+      final Table<String, ? extends WithObjectID> fromSnapshotTable,
+      final Table<String, ? extends WithObjectID> toSnapshotTable)
+      throws IOException {
+    Objects.requireNonNull(fromObjectName, "fromObjectName is null.");
+    Objects.requireNonNull(toObjectName, "toObjectName is null.");
+
+    final WithObjectID fromObject = fromSnapshotTable.get(fromObjectName);
+    final WithObjectID toObject = toSnapshotTable.get(toObjectName);
+    if ((fromObject instanceof OmKeyInfo) && (toObject instanceof OmKeyInfo)) {
+      return !SnapshotDeletingService.isBlockLocationInfoSame(
+          (OmKeyInfo) fromObject, (OmKeyInfo) toObject);
+    } else if ((fromObject instanceof OmDirectoryInfo)
+        && (toObject instanceof OmDirectoryInfo)) {
+      return !areAclsSame((OmDirectoryInfo) fromObject,
+          (OmDirectoryInfo) toObject);
+    } else {
+      throw new IllegalStateException("fromObject or toObject is not of " +
+          "the expected type. fromObject type : " +
+          fromObject.getClass().getName() + "toObject type: " +
+          toObject.getClass().getName());
+    }
+  }
+  private boolean areAclsSame(OmDirectoryInfo fromObject,
+                              OmDirectoryInfo toObject) {
+    return fromObject.getAcls().equals(toObject.getAcls());
   }
 
   private boolean isBlockLocationSame(

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/snapshot/SnapshotDiffManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/snapshot/SnapshotDiffManager.java
@@ -1151,7 +1151,7 @@ public class SnapshotDiffManager implements AutoCloseable {
       long objectId, String oldName, SnapshotDiffObject diffObject,
       boolean isDirectory) {
     SnapshotDiffObjectBuilder builder = new SnapshotDiffObjectBuilder(objectId)
-        .withOldKeyName(oldName).isDirectory(isDirectory);
+        .withOldKeyName(oldName).setIsDirectory(isDirectory);
     if (diffObject != null) {
       builder.withNewKeyName(diffObject.getNewKeyName());
     }
@@ -1163,7 +1163,7 @@ public class SnapshotDiffManager implements AutoCloseable {
       boolean isDirectory) {
 
     SnapshotDiffObjectBuilder builder = new SnapshotDiffObjectBuilder(objectId)
-        .withNewKeyName(newName).isDirectory(isDirectory);
+        .withNewKeyName(newName).setIsDirectory(isDirectory);
     if (diffObject != null) {
       builder.withOldKeyName(diffObject.getOldKeyName());
     }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/snapshot/SnapshotDiffObject.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/snapshot/SnapshotDiffObject.java
@@ -121,7 +121,7 @@ public class SnapshotDiffObject {
       return this;
     }
 
-    public SnapshotDiffObjectBuilder isDirectory(boolean directory) {
+    public SnapshotDiffObjectBuilder setIsDirectory(boolean directory) {
       isDirectory = directory;
       return this;
     }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/snapshot/SnapshotDiffObject.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/snapshot/SnapshotDiffObject.java
@@ -41,6 +41,8 @@ public class SnapshotDiffObject {
   private String oldKeyName;
   private String newKeyName;
 
+  private boolean isDirectory;
+
   // Default constructor for Jackson Serializer.
   public SnapshotDiffObject() {
 
@@ -48,10 +50,12 @@ public class SnapshotDiffObject {
 
   public SnapshotDiffObject(long objectId,
                             String oldKeyName,
-                            String newKeyName) {
+                            String newKeyName,
+                            boolean isDirectory) {
     this.objectId = objectId;
     this.oldKeyName = oldKeyName;
     this.newKeyName = newKeyName;
+    this.isDirectory = isDirectory;
   }
 
   public long getObjectId() {
@@ -81,6 +85,14 @@ public class SnapshotDiffObject {
     this.newKeyName = newKeyName;
   }
 
+  public void setDirectory(boolean directory) {
+    isDirectory = directory;
+  }
+
+  public boolean isDirectory() {
+    return isDirectory;
+  }
+
   /**
    * Builder for SnapshotDiffObject.
    */
@@ -88,6 +100,8 @@ public class SnapshotDiffObject {
     private final long objectId;
     private String oldKeyName;
     private String newKeyName;
+
+    private boolean isDirectory;
 
     public SnapshotDiffObjectBuilder(long objectID) {
       this.objectId = objectID;
@@ -107,8 +121,14 @@ public class SnapshotDiffObject {
       return this;
     }
 
+    public SnapshotDiffObjectBuilder isDirectory(boolean directory) {
+      isDirectory = directory;
+      return this;
+    }
+
     public SnapshotDiffObject build() {
-      return new SnapshotDiffObject(objectId, oldKeyName, newKeyName);
+      return new SnapshotDiffObject(objectId, oldKeyName, newKeyName,
+          isDirectory);
     }
   }
 

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/snapshot/TestSnapshotDiffManager.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/snapshot/TestSnapshotDiffManager.java
@@ -721,9 +721,10 @@ public class TestSnapshotDiffManager {
             toSnapName);
 
     long totalDiffEntries = spy.generateDiffReport("jobId",
-        fromSnapTable, toSnapTable, objectIdToDiffObject, oldObjectIdKeyMap,
-        newObjectIdKeyMap, volumeName, bucketName, fromSnapName, toSnapName,
-        false, Optional.empty(), Optional.empty());
+        fromSnapTable, toSnapTable, null, null,
+        objectIdToDiffObject, oldObjectIdKeyMap, newObjectIdKeyMap, volumeName,
+        bucketName, fromSnapName, toSnapName, false, Optional.empty(),
+        Optional.empty());
 
     assertEquals(100, totalDiffEntries);
     SnapshotDiffJob snapshotDiffJob = new SnapshotDiffJob(0, "jobId",
@@ -1101,6 +1102,8 @@ public class TestSnapshotDiffManager {
     long totalDiffEntries = snapshotDiffManager.generateDiffReport("jobId",
         keyInfoTable,
         keyInfoTable,
+        null,
+        null,
         objectIdToDiffObject,
         oldObjIdToKeyMap,
         newObjIdToKeyMap,
@@ -1140,6 +1143,8 @@ public class TestSnapshotDiffManager {
         () -> spy.generateDiffReport("jobId",
             keyInfoTable,
             keyInfoTable,
+            null,
+            null,
             objectIdToDiffObject,
             oldObjIdToKeyMap,
             newObjIdToKeyMap,
@@ -1411,8 +1416,9 @@ public class TestSnapshotDiffManager {
     doNothing().when(spy).checkReportsIntegrity(any(), anyInt(), anyInt());
 
     doReturn(10L).when(spy).generateDiffReport(anyString(),
-        any(), any(), any(), any(), any(), anyString(), anyString(),
-        anyString(), anyString(), anyBoolean(), any(), any());
+        any(), any(), any(), any(), any(), any(), any(),
+        anyString(), anyString(), anyString(), anyString(), anyBoolean(),
+        any(), any());
     doReturn(LEGACY).when(spy).getBucketLayout(VOLUME_NAME, BUCKET_NAME,
         omMetadataManager);
 


### PR DESCRIPTION

## What changes were proposed in this pull request?
As part of [HDDS-8841](https://issues.apache.org/jira/browse/HDDS-8841), we added a check if block location is same for key object. Somehow isBlockLocationSame function is getting called for non-OmKeyInfo object. We should skip this check is object are not OmKeyInfo. In the case it is a directory we should check if the directory acls are the same otherwise we should return a modify entry for the directory.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-8939

## How was this patch tested?
Unit Tests.