### PR TITLE
HDDS-7750. Incorrect WRITE ACL check

### DIFF
--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/KeyManagerImpl.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/KeyManagerImpl.java
@@ -934,32 +934,25 @@ public class KeyManagerImpl implements KeyManager {
       OMFileRequest.validateBucket(metadataManager, volume, bucket);
       OmKeyInfo keyInfo;
 
-      // For Acl Type "WRITE", the key can only be found in
-      // OpenKeyTable since appends to existing keys are not supported.
-      if (context.getAclRights() == IAccessAuthorizer.ACLType.WRITE) {
-        keyInfo =
-            metadataManager.getOpenKeyTable(bucketLayout).get(objectKey);
-      } else {
-        // Recursive check is done only for ACL_TYPE DELETE
-        // Rename and delete operations will send ACL_TYPE DELETE
-        if (context.isRecursiveAccessCheck()
-            && context.getAclRights() == IAccessAuthorizer.ACLType.DELETE) {
-          return checkChildrenAcls(ozObject, context);
-        }
-        try {
-          OzoneFileStatus fileStatus = getFileStatus(args);
-          keyInfo = fileStatus.getKeyInfo();
-        } catch (IOException e) {
-          // OzoneFS will check whether the key exists when write a new key.
-          // For Acl Type "READ", when the key is not exist return true.
-          // To Avoid KEY_NOT_FOUND Exception.
-          if (context.getAclRights() == IAccessAuthorizer.ACLType.READ) {
-            return true;
-          } else {
-            throw new OMException(
-                "Key not found, checkAccess failed. Key:" + objectKey,
-                KEY_NOT_FOUND);
-          }
+      // Recursive check is done only for ACL_TYPE DELETE
+      // Rename and delete operations will send ACL_TYPE DELETE
+      if (context.isRecursiveAccessCheck()
+          && context.getAclRights() == IAccessAuthorizer.ACLType.DELETE) {
+        return checkChildrenAcls(ozObject, context);
+      }
+      try {
+        OzoneFileStatus fileStatus = getFileStatus(args);
+        keyInfo = fileStatus.getKeyInfo();
+      } catch (IOException e) {
+        // OzoneFS will check whether the key exists when write a new key.
+        // For Acl Type "READ", when the key is not exist return true.
+        // To Avoid KEY_NOT_FOUND Exception.
+        if (context.getAclRights() == IAccessAuthorizer.ACLType.READ) {
+          return true;
+        } else {
+          throw new OMException(
+              "Key not found, checkAccess failed. Key:" + objectKey,
+              KEY_NOT_FOUND);
         }
       }
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3MultipartUploadCommitPartRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3MultipartUploadCommitPartRequest.java
@@ -133,9 +133,11 @@ public class S3MultipartUploadCommitPartRequest extends OMKeyRequest {
       volumeName = keyArgs.getVolumeName();
       bucketName = keyArgs.getBucketName();
 
+      long clientID = multipartCommitUploadPartRequest.getClientID();
+
       // check acl
-      checkKeyAcls(ozoneManager, volumeName, bucketName, keyName,
-          IAccessAuthorizer.ACLType.WRITE, OzoneObj.ResourceType.KEY);
+      checkKeyAclsInOpenKeyTable(ozoneManager, volumeName, bucketName, keyName,
+          IAccessAuthorizer.ACLType.WRITE, clientID);
 
       acquiredLock = omMetadataManager.getLock().acquireWriteLock(BUCKET_LOCK,
           volumeName, bucketName);
@@ -148,8 +150,6 @@ public class S3MultipartUploadCommitPartRequest extends OMKeyRequest {
 
       multipartKeyInfo = omMetadataManager.getMultipartInfoTable()
           .get(multipartKey);
-
-      long clientID = multipartCommitUploadPartRequest.getClientID();
 
       openKey = getOpenKey(volumeName, bucketName, keyName, omMetadataManager,
               clientID);

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3MultipartUploadCommitPartRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3MultipartUploadCommitPartRequest.java
@@ -53,7 +53,6 @@ import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos
     .OMResponse;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.Type;
 import org.apache.hadoop.ozone.security.acl.IAccessAuthorizer;
-import org.apache.hadoop.ozone.security.acl.OzoneObj;
 import org.apache.hadoop.util.Time;
 import org.apache.hadoop.hdds.utils.db.cache.CacheKey;
 import org.apache.hadoop.hdds.utils.db.cache.CacheValue;

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/s3/multipart/TestS3MultipartRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/s3/multipart/TestS3MultipartRequest.java
@@ -38,6 +38,7 @@ import org.apache.hadoop.ozone.audit.AuditLogger;
 import org.apache.hadoop.ozone.audit.AuditMessage;
 import org.apache.hadoop.ozone.om.OMConfigKeys;
 import org.apache.hadoop.ozone.om.OMMetadataManager;
+import org.apache.hadoop.ozone.om.OmMetadataReader;
 import org.apache.hadoop.ozone.om.OMMetrics;
 import org.apache.hadoop.ozone.om.OmMetadataManagerImpl;
 import org.apache.hadoop.ozone.om.OzoneManager;
@@ -83,6 +84,8 @@ public class TestS3MultipartRequest {
     when(ozoneManager.getMetrics()).thenReturn(omMetrics);
     when(ozoneManager.getMetadataManager()).thenReturn(omMetadataManager);
     auditLogger = Mockito.mock(AuditLogger.class);
+    OmMetadataReader omMetadataReader = Mockito.mock(OmMetadataReader.class);
+    when(ozoneManager.getOmMetadataReader()).thenReturn(omMetadataReader);
     when(ozoneManager.getAuditLogger()).thenReturn(auditLogger);
     when(ozoneManager.getDefaultReplicationConfig()).thenReturn(
         ReplicationConfig.getDefault(ozoneConfiguration));


### PR DESCRIPTION
## What changes were proposed in this pull request?

Changing checkKeyAcls() to checkKeyAclsInOpenKeyTable() in S3MultipartUploadCommitPartRequest as for Acl type "WRITE", the key can only be found in OpenKeyTable.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-7750

## How was this patch tested?

Tested Manually