### PR TITLE
HDDS-8948. Clarify Datanode upgrade error message (mention Recon, include endpoint address)

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/states/endpoint/RegisterEndpointTask.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/states/endpoint/RegisterEndpointTask.java
@@ -164,7 +164,8 @@ public final class RegisterEndpointTask implements
             "Invalid cluster ID in the response.");
         Preconditions.checkState(response.getErrorCode() == success,
             "DataNode has different Software Layout Version" +
-                " than SCM or RECON.");
+                " than SCM or RECON. EndPoint address is: " +
+                rpcEndPoint.getAddressString());
         if (response.hasHostname() && response.hasIpAddress()) {
           datanodeDetails.setHostName(response.getHostname());
           datanodeDetails.setIpAddress(response.getIpAddress());

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/states/endpoint/RegisterEndpointTask.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/states/endpoint/RegisterEndpointTask.java
@@ -163,7 +163,8 @@ public final class RegisterEndpointTask implements
         Preconditions.checkState(!StringUtils.isBlank(response.getClusterID()),
             "Invalid cluster ID in the response.");
         Preconditions.checkState(response.getErrorCode() == success,
-            "DataNode has different Software Layout Version than SCM or RECON.");
+            "DataNode has different Software Layout Version" +
+                " than SCM or RECON.");
         if (response.hasHostname() && response.hasIpAddress()) {
           datanodeDetails.setHostName(response.getHostname());
           datanodeDetails.setIpAddress(response.getIpAddress());

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/states/endpoint/RegisterEndpointTask.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/states/endpoint/RegisterEndpointTask.java
@@ -163,7 +163,7 @@ public final class RegisterEndpointTask implements
         Preconditions.checkState(!StringUtils.isBlank(response.getClusterID()),
             "Invalid cluster ID in the response.");
         Preconditions.checkState(response.getErrorCode() == success,
-            "DataNode has higher Software Layout Version than SCM.");
+            "DataNode has different Software Layout Version than SCM or RECON.");
         if (response.hasHostname() && response.hasIpAddress()) {
           datanodeDetails.setHostName(response.getHostname());
           datanodeDetails.setIpAddress(response.getIpAddress());


### PR DESCRIPTION
## What changes were proposed in this pull request?

During the upgrade process, the datanode has an error exception message.

datanode log:
```
java.util.concurrent.ExecutionException: java.util.concurrent.ExecutionException: java.lang.IllegalStateException: DataNode has higher Software Layout Version than SCM.
    at java.util.concurrent.FutureTask.report(FutureTask.java:122)
    at java.util.concurrent.FutureTask.get(FutureTask.java:192)
    at org.apache.hadoop.ozone.container.common.states.datanode.RunningDatanodeState.computeNextContainerState(RunningDatanodeState.java:199)
    at org.apache.hadoop.ozone.container.common.states.datanode.RunningDatanodeState.await(RunningDatanodeState.java:239)
    at org.apache.hadoop.ozone.container.common.states.datanode.RunningDatanodeState.await(RunningDatanodeState.java:50)
    at org.apache.hadoop.ozone.container.common.statemachine.StateContext.execute(StateContext.java:666)
    at org.apache.hadoop.ozone.container.common.statemachine.DatanodeStateMachine.startStateMachineThread(DatanodeStateMachine.java:334)
    at org.apache.hadoop.ozone.container.common.statemachine.DatanodeStateMachine.lambda$startDaemon$0(DatanodeStateMachine.java:532)
    at java.lang.Thread.run(Thread.java:745)
Caused by: java.util.concurrent.ExecutionException: java.lang.IllegalStateException: DataNode has higher Software Layout Version than SCM.
    at java.util.concurrent.FutureTask.report(FutureTask.java:122)
    at java.util.concurrent.FutureTask.get(FutureTask.java:206)
    at org.apache.hadoop.ozone.container.common.states.datanode.RunningDatanodeState.lambda$execute$0(RunningDatanodeState.java:157)
    at java.util.concurrent.FutureTask.run(FutureTask.java:266)
    at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
    at java.util.concurrent.FutureTask.run(FutureTask.java:266)
    at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
    at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
    ... 1 more
Caused by: java.lang.IllegalStateException: DataNode has higher Software Layout Version than SCM.
    at com.google.common.base.Preconditions.checkState(Preconditions.java:512)
    at org.apache.hadoop.ozone.container.common.states.endpoint.RegisterEndpointTask.call(RegisterEndpointTask.java:165)
    at org.apache.hadoop.ozone.container.common.states.endpoint.RegisterEndpointTask.call(RegisterEndpointTask.java:52)
    ... 4 more
```
 

 

Through positioning, it is found that when the datanode calls the register method to the recon, because the recon has not been updated to the new version, the layout of the recon is inconsistent with the layout of the datanode.

I think this exception message is misleading DataNode has higher Software Layout Version than SCM.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-8948

