### PR TITLE
HDDS-8840. Add metrics to Container Balancer

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/balancer/ContainerBalancerMetrics.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/balancer/ContainerBalancerMetrics.java
@@ -81,6 +81,14 @@ public final class ContainerBalancerMetrics {
       "exceptionally in latest iteration of Container Balancer.")
   private MutableCounterLong numContainerMovesFailedInLatestIteration;
 
+  @Metric(about = "Number of container moves that were scheduled in the " +
+      "latest iteration of Container Balancer.")
+  private MutableCounterLong numContainerMovesScheduledInLatestIteration;
+
+  @Metric(about = "Total number of container moves that were scheduled across" +
+      " all iterations of Container Balancer.")
+  private MutableCounterLong numContainerMovesScheduled;
+
   /**
    * Create and register metrics named {@link ContainerBalancerMetrics#NAME}
    * for {@link ContainerBalancer}.
@@ -95,6 +103,32 @@ public final class ContainerBalancerMetrics {
 
   private ContainerBalancerMetrics(MetricsSystem ms) {
     this.ms = ms;
+  }
+
+  /**
+   * Gets the number of container moves scheduled across all iterations of
+   * Container Balancer.
+   * @return number of moves
+   */
+  public long getNumContainerMovesScheduled() {
+    return numContainerMovesScheduled.value();
+  }
+
+  void incrementNumContainerMovesScheduled(long valueToAdd) {
+    this.numContainerMovesScheduled.incr(valueToAdd);
+  }
+
+  /**
+   * Gets the number of container moves scheduled in the latest iteration of
+   * Container Balancer.
+   * @return number of moves
+   */
+  public long getNumContainerMovesScheduledInLatestIteration() {
+    return numContainerMovesScheduledInLatestIteration.value();
+  }
+
+  void incrementNumContainerMovesScheduledInLatestIteration(long valueToAdd) {
+    this.numContainerMovesScheduledInLatestIteration.incr(valueToAdd);
   }
 
   /**
@@ -158,6 +192,8 @@ public final class ContainerBalancerMetrics {
     case REPLICATION_NOT_HEALTHY_AFTER_MOVE:
     case FAIL_CONTAINER_ALREADY_BEING_MOVED:
     case FAIL_UNEXPECTED_ERROR:
+      incrementNumContainerMovesFailedInLatestIteration(valueToAdd);
+      break;
     default:
       break;
     }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/balancer/ContainerBalancerTask.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/balancer/ContainerBalancerTask.java
@@ -627,6 +627,8 @@ public class ContainerBalancerTask implements Runnable {
         selectedSources.size() + selectedTargets.size();
     metrics.incrementNumDatanodesInvolvedInLatestIteration(
         countDatanodesInvolvedPerIteration);
+    metrics.incrementNumContainerMovesScheduled(
+        metrics.getNumContainerMovesScheduledInLatestIteration());
     metrics.incrementNumContainerMovesCompleted(
         metrics.getNumContainerMovesCompletedInLatestIteration());
     metrics.incrementNumContainerMovesTimeout(
@@ -817,6 +819,7 @@ public class ContainerBalancerTask implements Runnable {
         future = moveManager.move(containerID, source,
             moveSelection.getTargetNode());
       }
+      metrics.incrementNumContainerMovesScheduledInLatestIteration(1);
 
       future = future.whenComplete((result, ex) -> {
         metrics.incrementCurrentIterationContainerMoveMetric(result, 1);


### PR DESCRIPTION
## What changes were proposed in this pull request?

Added metrics for number of moves that were scheduled in the latest iteration and in total. Included all `MoveResult` failure cases under existing metric for failures, `numContainerMovesFailed`. Except `REPLICATION_FAIL_TIME_OUT` and `DELETION_FAIL_TIME_OUT`, which are considered time outs and counted in `numContainerMovesTimeout`.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-8840

## How was this patch tested?

Added assertions to an existing unit test.