### PR TITLE
HDDS-8950. NPE in SCMCommonPlacementPolicy#validateContainerPlacement

### DIFF
--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestPipelinePlacementPolicy.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestPipelinePlacementPolicy.java
@@ -517,6 +517,12 @@ public class TestPipelinePlacementPolicy {
     subSet.add(dns.get(0));
     status = placementPolicy.validateContainerPlacement(subSet, 1);
     Assertions.assertTrue(status.isPolicySatisfied());
+
+    // three nodes, one dead, one rack
+    cluster.remove(dns.get(2));
+    status = placementPolicy.validateContainerPlacement(dns, 3);
+    Assertions.assertFalse(status.isPolicySatisfied());
+    Assertions.assertEquals(1, status.misReplicationCount());
   }
 
   @Test


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fix NPE in `validateContainerPlacement` which can happen when trying to get placement group for dead node.

Strictly speaking the fix is only this part:

```
-            .collect(Collectors.groupingBy(this::getPlacementGroup,
+        .map(this::getPlacementGroup)
+        .filter(Objects::nonNull)
+        .collect(Collectors.groupingBy(
+            Function.identity(),
```

https://issues.apache.org/jira/browse/HDDS-8950

## How was this patch tested?

Added unit test.

https://github.com/adoroszlai/hadoop-ozone/actions/runs/5400935177