### PR TITLE
HDDS-8822. [S3G] Improve list performance in LEGACY/OBS bucket

### DIFF
--- a/hadoop-hdds/common/src/main/resources/ozone-default.xml
+++ b/hadoop-hdds/common/src/main/resources/ozone-default.xml
@@ -1788,6 +1788,16 @@
   </property>
 
   <property>
+    <name>ozone.s3g.list-keys.shallow.enabled</name>
+    <value>true</value>
+    <tag>OZONE, S3GATEWAY</tag>
+    <description>If this is true, there will be efficiency optimization effects
+      when calling s3g list interface with delimiter '/' parameter, especially
+      when there are a large number of keys.
+    </description>
+  </property>
+
+  <property>
     <name>ozone.om.save.metrics.interval</name>
     <value>5m</value>
     <tag>OZONE, OM</tag>

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/OzoneBucket.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/OzoneBucket.java
@@ -563,6 +563,9 @@ public class OzoneBucket extends WithMetadata {
   /**
    * Returns Iterator to iterate over all keys after prevKey in the bucket.
    * If shallow is true, iterator will only contain immediate children.
+   * This applies to the aws s3 list with delimiter '/' scenario.
+   * Note: When shallow is true, whether keyPrefix ends with slash or not
+   * will affect the results, see {@code getNextShallowListOfKeys}.
    *
    * @param keyPrefix Bucket prefix to match
    * @param prevKey Keys will be listed after this key name
@@ -1173,11 +1176,14 @@ public class OzoneBucket extends WithMetadata {
      *      a/b3/e2/
      *      a/b3/e3/
      *
-     * Example 1: keyPrefix="a/b2/", prevKey=""
+     * When keyPrefix ends without slash (/), the result as Example 1:
+     * Example 1: keyPrefix="a/b2", prevKey=""
+     *            result: [a/b2/]
+     * Example 2: keyPrefix="a/b2/", prevKey=""
      *            result: [a/b2/d1/, a/b2/d2/, a/b2/d3/]
-     * Example 2: keyPrefix="a/b2/", prevKey="a/b2/d2/d21.txt"
+     * Example 3: keyPrefix="a/b2/", prevKey="a/b2/d2/d21.txt"
      *            result: [a/b2/d2/, a/b2/d3/]
-     * Example 3: keyPrefix="a/b2/", prevKey="a/b2/d2/d22.txt"
+     * Example 4: keyPrefix="a/b2/", prevKey="a/b2/d2/d22.txt"
      *            result: [a/b2/d3/]
      * Say, keyPrefix="a/b" and prevKey="", the results will be
      * [a/b1/, a/b2/, a/b3/]

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/OzoneBucket.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/OzoneBucket.java
@@ -1168,14 +1168,20 @@ public class OzoneBucket extends WithMetadata {
      *      a/b2/d1/
      *      a/b2/d2/
      *      a/b2/d2/d21.txt
+     *      a/b2/d2/d22.txt
      *      a/b2/d3/
-     *      a/b2/d3/d22.txt
      *      a/b3/
      *      a/b3/e1/
+     *      a/b3/e1/e11.txt
      *      a/b3/e2/
      *      a/b3/e3/
-     *      a/b3/e3/e11.txt
      *
+     * Example 1: keyPrefix="a/b2/", prevKey=""
+     *            result: [a/b2/d1/, a/b2/d2/, a/b2/d3/]
+     * Example 2: keyPrefix="a/b2/", prevKey="a/b2/d2/d21.txt"
+     *            result: [a/b2/d2/, a/b2/d3/]
+     * Example 3: keyPrefix="a/b2/", prevKey="a/b2/d2/d22.txt"
+     *            result: [a/b2/d3/]
      * Say, keyPrefix="a/b" and prevKey="", the results will be
      * [a/b1/, a/b2/, a/b3/]
      * In implementation, the keyPrefix "a/b" can be identified in listKeys,

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestListKeys.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestListKeys.java
@@ -1,0 +1,339 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with this
+ * work for additional information regarding copyright ownership.  The ASF
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.hadoop.ozone.om;
+
+import org.apache.hadoop.hdds.client.ReplicationConfig;
+import org.apache.hadoop.hdds.utils.IOUtils;
+import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import org.apache.hadoop.ozone.MiniOzoneCluster;
+import org.apache.hadoop.ozone.TestDataUtil;
+import org.apache.hadoop.ozone.client.OzoneBucket;
+import org.apache.hadoop.ozone.client.OzoneClient;
+import org.apache.hadoop.ozone.client.OzoneKey;
+import org.apache.hadoop.ozone.client.io.OzoneInputStream;
+import org.apache.hadoop.ozone.client.io.OzoneOutputStream;
+import org.apache.hadoop.ozone.om.helpers.BucketLayout;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.rules.Timeout;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.ArrayList;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.stream.Stream;
+
+import static com.google.common.collect.Lists.newLinkedList;
+import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_CLIENT_LIST_CACHE_SIZE;
+import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_FS_ITERATE_BATCH_SIZE;
+import static org.junit.jupiter.params.provider.Arguments.of;
+
+/**
+ * Test covers listKeys(keyPrefix, startKey, shallow) combinations
+ * in a legacy/OBS bucket layout type.
+ */
+public class TestListKeys {
+
+  private static MiniOzoneCluster cluster = null;
+
+  private static OzoneConfiguration conf;
+  private static String clusterId;
+  private static String scmId;
+  private static String omId;
+
+  private static OzoneBucket legacyOzoneBucket;
+  private static OzoneClient client;
+
+  @Rule
+  public Timeout timeout = new Timeout(1200000);
+
+  /**
+   * Create a MiniDFSCluster for testing.
+   * <p>
+   *
+   * @throws IOException
+   */
+  @BeforeAll
+  public static void init() throws Exception {
+    conf = new OzoneConfiguration();
+    conf.setBoolean(OMConfigKeys.OZONE_OM_ENABLE_FILESYSTEM_PATHS, true);
+    clusterId = UUID.randomUUID().toString();
+    scmId = UUID.randomUUID().toString();
+    omId = UUID.randomUUID().toString();
+    // Set the number of keys to be processed during batch operate.
+    conf.setInt(OZONE_FS_ITERATE_BATCH_SIZE, 3);
+    conf.setInt(OZONE_CLIENT_LIST_CACHE_SIZE, 3);
+    cluster = MiniOzoneCluster.newBuilder(conf).setClusterId(clusterId)
+        .setScmId(scmId).setOmId(omId).build();
+    cluster.waitForClusterToBeReady();
+    client = cluster.newClient();
+
+    // create a volume and a LEGACY bucket
+    legacyOzoneBucket = TestDataUtil
+        .createVolumeAndBucket(client, BucketLayout.LEGACY);
+
+    initFSNameSpace();
+  }
+
+  @AfterAll
+  public static void teardownClass() {
+    IOUtils.closeQuietly(client);
+    if (cluster != null) {
+      cluster.shutdown();
+    }
+  }
+
+  private static void initFSNameSpace() throws Exception {
+    buildNameSpaceTree(legacyOzoneBucket);
+  }
+
+  /**
+   * Verify listKeys at different levels.
+   *
+   *                  buck-1
+   *                    |
+   *                    a1
+   *                    |
+   *      -----------------------------------
+   *     |              |                       |
+   *     b1             b2                      b3
+   *    -------         ---------              -----------
+   *   |      |        |    |   |             |    |     |
+   *  c1     c2       d1   d2  d3             e1   e2   e3
+   *  |      |        |    |   |              |    |    |
+   * c1.tx  c2.tx  d11.tx  | d31.tx           |    |    e31.tx
+   *                      ---------           |   e21.tx
+   *                     |        |           |
+   *                    d21.tx   d22.tx      e11.tx
+   *
+   * Above is the key namespace tree structure.
+   */
+  private static void buildNameSpaceTree(OzoneBucket ozoneBucket)
+      throws Exception {
+    LinkedList<String> keys = new LinkedList<>();
+    keys.add("/a1/b1/c1111.tx");
+    keys.add("/a1/b1/c1222.tx");
+    keys.add("/a1/b1/c1333.tx");
+    keys.add("/a1/b1/c1444.tx");
+    keys.add("/a1/b1/c1555.tx");
+    keys.add("/a1/b1/c1/c1.tx");
+    keys.add("/a1/b1/c12/c2.tx");
+    keys.add("/a1/b1/c12/c3.tx");
+
+    keys.add("/a1/b2/d1/d11.tx");
+    keys.add("/a1/b2/d2/d21.tx");
+    keys.add("/a1/b2/d2/d22.tx");
+    keys.add("/a1/b2/d3/d31.tx");
+
+    keys.add("/a1/b3/e1/e11.tx");
+    keys.add("/a1/b3/e2/e21.tx");
+    keys.add("/a1/b3/e3/e31.tx");
+
+    createKeys(ozoneBucket, keys);
+  }
+
+  private static Stream<Arguments> shallowListDataWithTrailingSlash() {
+    return Stream.of(
+
+        // Case-1: StartKey is less than prefixKey, return emptyList.
+        of("a1/b2/", "a1", newLinkedList(Collections.emptyList())),
+
+        // Case-2: StartKey is empty, return all immediate node.
+        of("a1/b2/", "", newLinkedList(Arrays.asList(
+            "a1/b2/d1/",
+            "a1/b2/d2/",
+            "a1/b2/d3/"
+        ))),
+
+        // Case-3: StartKey is same as prefixKey, return all immediate nodes.
+        of("a1/b2/", "a1/b2", newLinkedList(Arrays.asList(
+            "a1/b2/d1/",
+            "a1/b2/d2/",
+            "a1/b2/d3/"
+        ))),
+
+        // Case-4: StartKey is greater than prefixKey
+        of("a1/b2/", "a1/b2/d2/d21.tx", newLinkedList(Arrays.asList(
+            "a1/b2/d2/",
+            "a1/b2/d3/"
+        ))),
+
+        // Case-5: StartKey reaches last element, return emptyList
+        of("a1/b2/", "a1/b2/d3/d31.tx", newLinkedList(
+            Collections.emptyList()
+        )),
+
+        // Case-6: Mix result
+        of("a1/b1/", "a1/b1/c12", newLinkedList(Arrays.asList(
+            "a1/b1/c12/",
+            "a1/b1/c1222.tx",
+            "a1/b1/c1333.tx",
+            "a1/b1/c1444.tx",
+            "a1/b1/c1555.tx"
+        )))
+    );
+  }
+
+  private static Stream<Arguments> shallowListDataWithoutTrailingSlash() {
+    return Stream.of(
+
+        // Case-1: StartKey is less than prefixKey, return emptyList.
+        of("a1/b2", "a1", newLinkedList(Collections.emptyList())),
+
+        // Case-2: StartKey is empty, return all immediate node.
+        of("a1/b2", "", newLinkedList(Arrays.asList(
+            "a1/b2/"
+        ))),
+
+        // Case-3: StartKey is same as prefixKey.
+        of("a1/b2", "a1/b2", newLinkedList(Arrays.asList(
+            "a1/b2/"
+        ))),
+
+        // Case-4: StartKey is greater than prefixKey, return immediate
+        // nodes which after startKey.
+        of("a1/b2", "a1/b2/d2/d21.tx", newLinkedList(Arrays.asList(
+            "a1/b2/"
+        ))),
+
+        // Case-5: StartKey reaches last element, return emptyList
+        of("a1/b2", "a1/b2/d3/d31.tx", newLinkedList(
+            Collections.emptyList()
+        )),
+
+        // Case-6: StartKey is invalid (less than last element)
+        of("a1/b1/c1", "a1/b1/c1/c0invalid", newLinkedList(Arrays.asList(
+            "a1/b1/c1/",
+            "a1/b1/c1111.tx",
+            "a1/b1/c12/",
+            "a1/b1/c1222.tx",
+            "a1/b1/c1333.tx",
+            "a1/b1/c1444.tx",
+            "a1/b1/c1555.tx"
+        ))),
+
+        // Case-7: StartKey reaches last element
+        of("a1/b1/c1", "a1/b1/c1/c2.tx", newLinkedList(Arrays.asList(
+            "a1/b1/c1111.tx",
+            "a1/b1/c12/",
+            "a1/b1/c1222.tx",
+            "a1/b1/c1333.tx",
+            "a1/b1/c1444.tx",
+            "a1/b1/c1555.tx"
+        ))),
+
+        // Case-8: StartKey is invalid (greater than last element)
+        of("a1/b1/c1", "a1/b1/c1/c2invalid", newLinkedList(Arrays.asList(
+            "a1/b1/c1111.tx",
+            "a1/b1/c12/",
+            "a1/b1/c1222.tx",
+            "a1/b1/c1333.tx",
+            "a1/b1/c1444.tx",
+            "a1/b1/c1555.tx"
+        ))),
+
+        // Case-9:
+        of("a1/b1/c12", "", newLinkedList(Arrays.asList(
+            "a1/b1/c12/",
+            "a1/b1/c1222.tx"
+        )))
+
+    );
+  }
+
+  @ParameterizedTest
+  @MethodSource("shallowListDataWithTrailingSlash")
+  public void testShallowListKeysWithPrefixTrailingSlash(String keyPrefix,
+      String startKey, List<String> expectedKeys) throws Exception {
+    checkKeyShallowList(keyPrefix, startKey, expectedKeys, legacyOzoneBucket);
+  }
+
+  @ParameterizedTest
+  @MethodSource("shallowListDataWithoutTrailingSlash")
+  public void testShallowListKeysWithoutPrefixTrailingSlash(String keyPrefix,
+      String startKey, List<String> expectedKeys) throws Exception {
+    checkKeyShallowList(keyPrefix, startKey, expectedKeys, legacyOzoneBucket);
+  }
+
+  private void checkKeyShallowList(String keyPrefix, String startKey,
+      List<String> keys, OzoneBucket bucket)
+      throws Exception {
+
+    Iterator<? extends OzoneKey> ozoneKeyIterator =
+        bucket.listKeys(keyPrefix, startKey, true);
+    ReplicationConfig expectedReplication =
+        Optional.ofNullable(bucket.getReplicationConfig())
+            .orElse(cluster.getOzoneManager().getDefaultReplicationConfig());
+
+    List <String> keyLists = new ArrayList<>();
+    while (ozoneKeyIterator.hasNext()) {
+      OzoneKey ozoneKey = ozoneKeyIterator.next();
+      Assert.assertEquals(expectedReplication, ozoneKey.getReplicationConfig());
+      keyLists.add(ozoneKey.getName());
+    }
+    LinkedList outputKeysList = new LinkedList(keyLists);
+    System.out.println("BEGIN:::keyPrefix---> " + keyPrefix + ":::---> " +
+        startKey);
+    for (String key : keys) {
+      System.out.println(" " + key);
+    }
+    System.out.println("END:::keyPrefix---> " + keyPrefix + ":::---> " +
+        startKey);
+    Assert.assertEquals(keys, outputKeysList);
+  }
+
+  private static void createKeys(OzoneBucket ozoneBucket, List<String> keys)
+      throws Exception {
+    int length = 10;
+    byte[] input = new byte[length];
+    Arrays.fill(input, (byte) 96);
+    for (String key : keys) {
+      createKey(ozoneBucket, key, 10, input);
+    }
+  }
+
+  private static void createKey(OzoneBucket ozoneBucket, String key, int length,
+      byte[] input) throws Exception {
+
+    OzoneOutputStream ozoneOutputStream =
+        ozoneBucket.createKey(key, length);
+
+    ozoneOutputStream.write(input);
+    ozoneOutputStream.write(input, 0, 10);
+    ozoneOutputStream.close();
+
+    // Read the key with given key name.
+    OzoneInputStream ozoneInputStream = ozoneBucket.readKey(key);
+    byte[] read = new byte[length];
+    ozoneInputStream.read(read, 0, length);
+    ozoneInputStream.close();
+
+    Assert.assertEquals(new String(input, StandardCharsets.UTF_8),
+        new String(read, StandardCharsets.UTF_8));
+  }
+}

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestListKeys.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestListKeys.java
@@ -165,6 +165,7 @@ public class TestListKeys {
 
         // Case-2: StartKey is empty, return all immediate node.
         of("a1/b2/", "", newLinkedList(Arrays.asList(
+            "a1/b2/",
             "a1/b2/d1/",
             "a1/b2/d2/",
             "a1/b2/d3/"
@@ -172,6 +173,7 @@ public class TestListKeys {
 
         // Case-3: StartKey is same as prefixKey, return all immediate nodes.
         of("a1/b2/", "a1/b2", newLinkedList(Arrays.asList(
+            "a1/b2/",
             "a1/b2/d1/",
             "a1/b2/d2/",
             "a1/b2/d3/"

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/S3GatewayConfigKeys.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/S3GatewayConfigKeys.java
@@ -73,6 +73,15 @@ public final class S3GatewayConfigKeys {
       true;
 
   /**
+   * Configuration key that enables shallow listing of Keys when results
+   * with delimiter by '/'.
+   */
+  public static final String OZONE_S3G_LIST_KEYS_SHALLOW_ENABLED =
+      "ozone.s3g.list-keys.shallow.enabled";
+  public static final boolean OZONE_S3G_LIST_KEYS_SHALLOW_ENABLED_DEFAULT =
+      true;
+
+  /**
    * Never constructed.
    */
   private S3GatewayConfigKeys() {

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/BucketEndpoint.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/BucketEndpoint.java
@@ -20,6 +20,7 @@ package org.apache.hadoop.ozone.s3.endpoint;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.hadoop.hdds.client.ReplicationType;
+import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.ozone.OzoneAcl;
 import org.apache.hadoop.ozone.audit.S3GAction;
 import org.apache.hadoop.ozone.client.OzoneBucket;
@@ -45,6 +46,7 @@ import org.apache.http.HttpStatus;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.inject.Inject;
 import javax.ws.rs.DELETE;
 import javax.ws.rs.DefaultValue;
 import javax.ws.rs.GET;
@@ -70,6 +72,8 @@ import java.util.Set;
 
 import static org.apache.hadoop.ozone.OzoneAcl.AclScope.ACCESS;
 import static org.apache.hadoop.ozone.OzoneConsts.OZONE_URI_DELIMITER;
+import static org.apache.hadoop.ozone.s3.S3GatewayConfigKeys.OZONE_S3G_LIST_KEYS_SHALLOW_ENABLED;
+import static org.apache.hadoop.ozone.s3.S3GatewayConfigKeys.OZONE_S3G_LIST_KEYS_SHALLOW_ENABLED_DEFAULT;
 import static org.apache.hadoop.ozone.s3.exception.S3ErrorTable.NOT_IMPLEMENTED;
 import static org.apache.hadoop.ozone.s3.exception.S3ErrorTable.newError;
 import static org.apache.hadoop.ozone.s3.util.S3Consts.ENCODING_TYPE;
@@ -82,6 +86,11 @@ public class BucketEndpoint extends EndpointBase {
 
   private static final Logger LOG =
       LoggerFactory.getLogger(BucketEndpoint.class);
+
+  private boolean listKeysShallowEnabled;
+
+  @Inject
+  private OzoneConfiguration ozoneConfiguration;
 
   /**
    * Rest endpoint to list objects in a specific bucket.
@@ -141,7 +150,8 @@ public class BucketEndpoint extends EndpointBase {
 
       // If shallow is true, only list immediate children
       // delimited by OZONE_URI_DELIMITER
-      boolean shallow = OZONE_URI_DELIMITER.equals(delimiter);
+      boolean shallow = listKeysShallowEnabled
+          && OZONE_URI_DELIMITER.equals(delimiter);
 
       OzoneBucket bucket = getBucket(bucketName);
       ozoneKeyIterator = bucket.listKeys(prefix, prevKey, shallow);
@@ -702,6 +712,8 @@ public class BucketEndpoint extends EndpointBase {
 
   @Override
   public void init() {
-
+    listKeysShallowEnabled = ozoneConfiguration.getBoolean(
+        OZONE_S3G_LIST_KEYS_SHALLOW_ENABLED,
+        OZONE_S3G_LIST_KEYS_SHALLOW_ENABLED_DEFAULT);
   }
 }

--- a/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/client/OzoneBucketStub.java
+++ b/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/client/OzoneBucketStub.java
@@ -368,7 +368,7 @@ public class OzoneBucketStub extends OzoneBucket {
               key.getDataSize(),
               key.getCreationTime().getEpochSecond() * 1000,
               key.getModificationTime().getEpochSecond() * 1000,
-              key.getReplicationConfig());
+              key.getReplicationConfig(), key.isFile());
         }).collect(Collectors.toList());
 
     if (prevKey != null) {

--- a/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/client/OzoneBucketStub.java
+++ b/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/client/OzoneBucketStub.java
@@ -52,6 +52,8 @@ import org.apache.hadoop.ozone.om.helpers.OmMultipartInfo;
 import org.apache.hadoop.ozone.om.helpers.OmMultipartUploadCompleteInfo;
 import org.apache.hadoop.util.Time;
 
+import static org.apache.hadoop.ozone.OzoneConsts.OZONE_URI_DELIMITER;
+
 /**
  * In-memory ozone bucket for testing.
  */
@@ -337,6 +339,45 @@ public class OzoneBucketStub extends OzoneBucket {
         .filter(key -> key.getName().startsWith(keyPrefix))
         .collect(Collectors.toList())
         .iterator();
+  }
+
+  public Iterator<? extends OzoneKey> listKeys(String keyPrefix,
+      String prevKey, boolean shallow) throws IOException {
+    if (!shallow) {
+      return prevKey == null ? listKeys(keyPrefix)
+          : listKeys(keyPrefix, prevKey);
+    }
+
+    Map<String, OzoneKey> sortedKey = new TreeMap<>(keyDetails);
+    List<OzoneKey> ozoneKeys = sortedKey.values()
+        .stream()
+        .filter(key -> key.getName().startsWith(keyPrefix))
+        .map(key -> {
+          String[] res = key.getName().split(OZONE_URI_DELIMITER);
+          String newKeyName;
+          if (res.length < 2) {
+            newKeyName = key.getName();
+          } else if (res.length == 2) {
+            newKeyName = res[0] + OZONE_URI_DELIMITER + res[1];
+          } else {
+            newKeyName =
+                res[0] + OZONE_URI_DELIMITER + res[1] + OZONE_URI_DELIMITER;
+          }
+          return new OzoneKey(key.getVolumeName(),
+              key.getBucketName(), newKeyName,
+              key.getDataSize(),
+              key.getCreationTime().getEpochSecond() * 1000,
+              key.getModificationTime().getEpochSecond() * 1000,
+              key.getReplicationConfig());
+        }).collect(Collectors.toList());
+
+    if (prevKey != null) {
+      return ozoneKeys.stream()
+          .filter(key -> key.getName().compareTo(prevKey) > 0)
+          .collect(Collectors.toList())
+          .iterator();
+    }
+    return ozoneKeys.iterator();
   }
 
   @Override

--- a/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestBucketList.java
+++ b/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestBucketList.java
@@ -36,6 +36,8 @@ import org.junit.Test;
 
 /**
  * Testing basic object list browsing.
+ * Note: delimiter with '/' will call shallow list logic,
+ * just list immediate subdir of prefix.
  */
 public class TestBucketList {
 

--- a/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestPermissionCheck.java
+++ b/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestPermissionCheck.java
@@ -45,6 +45,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.when;
 
@@ -168,7 +169,8 @@ public class TestPermissionCheck {
   public void testListKey() throws IOException {
     Mockito.when(objectStore.getVolume(anyString())).thenReturn(volume);
     Mockito.when(objectStore.getS3Bucket(anyString())).thenReturn(bucket);
-    doThrow(exception).when(bucket).listKeys(anyString());
+    doThrow(exception).when(bucket).listKeys(anyString(), isNull(),
+        anyBoolean());
     BucketEndpoint bucketEndpoint = new BucketEndpoint();
     bucketEndpoint.setClient(client);
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

[S3G] Improve list performance in LEGACY/OBS bucket when listing delimited by '/'

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-8822


## How was this patch tested?

- Manual test

### (1) LEGACY bucket list optimization
keys info:
```bash
hadoop fs -count ofs://om/s3v/buk-lg/*
           6        54712             109424 ofs://om/s3v/buk-lg/s3put
           1            1                238 ofs://om/s3v/buk-lg/test1
          61        30489              30489 ofs://om/s3v/buk-lg/test2
          21       100000             100000 ofs://om/s3v/buk-lg/test3

hadoop fs -count ofs://om/s3v/buk-lg/test3/*
           1         5000               5000 ofs://om/s3v/buk-lg/test3/dir0_47640
           1         5000               5000 ofs://om/s3v/buk-lg/test3/dir10_19047
           1         5000               5000 ofs://om/s3v/buk-lg/test3/dir11_99507
           1         5000               5000 ofs://om/s3v/buk-lg/test3/dir12_43926
           1         5000               5000 ofs://om/s3v/buk-lg/test3/dir13_98700
           1         5000               5000 ofs://om/s3v/buk-lg/test3/dir14_30007
           1         5000               5000 ofs://om/s3v/buk-lg/test3/dir15_32065
           1         5000               5000 ofs://om/s3v/buk-lg/test3/dir16_42162
           1         5000               5000 ofs://om/s3v/buk-lg/test3/dir17_71071
           1         5000               5000 ofs://om/s3v/buk-lg/test3/dir18_46050
           1         5000               5000 ofs://om/s3v/buk-lg/test3/dir19_86567
           1         5000               5000 ofs://om/s3v/buk-lg/test3/dir1_78108
           1         5000               5000 ofs://om/s3v/buk-lg/test3/dir2_53468
           1         5000               5000 ofs://om/s3v/buk-lg/test3/dir3_60271
           1         5000               5000 ofs://om/s3v/buk-lg/test3/dir4_41931
           1         5000               5000 ofs://om/s3v/buk-lg/test3/dir5_92207
           1         5000               5000 ofs://om/s3v/buk-lg/test3/dir6_93526
           1         5000               5000 ofs://om/s3v/buk-lg/test3/dir7_98836
           1         5000               5000 ofs://om/s3v/buk-lg/test3/dir8_71060
           1         5000               5000 ofs://om/s3v/buk-lg/test3/dir9_11147
```
time before and after optimization:
```bash
$ time aws s3api --endpoint http://<old-s3g-ip>:9878 list-objects-v2 --bucket buk-lg --prefix 't' --delimiter '/'
{
    "CommonPrefixes": [
        {
            "Prefix": "test1/"
        },
        {
            "Prefix": "test2/"
        },
        {
            "Prefix": "test3/"
        }
    ]
}

real	0m13.022s
user	0m0.952s
sys	0m0.161s

$ time aws s3api --endpoint http://<new-s3g-ip>:9878 list-objects-v2 --bucket buk-lg --prefix 't' --delimiter '/'
{
    "CommonPrefixes": [
        {
            "Prefix": "test1/"
        },
        {
            "Prefix": "test2/"
        },
        {
            "Prefix": "test3/"
        }
    ]
}

real	0m3.210s
user	0m0.969s
sys	0m0.169s
```
Detail data are shown in the following table:

 time with prefix     | t | test3/   | '' 
-------- | ----- | --- | -- 
before optimization  |  13.022s | 10.381s | 16.430s
after optimization  | 3.210s | 3.134s | 3.132s

### (2) OBS bucket list optimization
keys info:
```
aws s3api --endpoint http://<s3g-ip>:9878 list-objects-v2 --bucket buk-obs --prefix 'obs1/obs2/obs3/' --max-keys 100000 | grep Key | wc -l
9986
aws s3api --endpoint http://<s3g-ip>:9878 list-objects-v2 --bucket buk-obs --prefix 'obs1/obs2/obs31/' --max-keys 100000 | grep Key | wc -l
10002
aws s3api --endpoint http://<s3g-ip>:9878 list-objects-v2 --bucket buk-obs --prefix 'obs1/obs2/obs311/' --max-keys 100000 | grep Key | wc -l
57549
```
time before and after optimization:
```bash
$ time aws s3 --endpoint http://<old-s3g-ip>:9878 ls buk-obs/obs1/obs2/obs3
                           PRE obs3/
                           PRE obs31/
                           PRE obs311/

real	0m9.165s
user	0m0.919s
sys	0m0.114s
```
```bash
$ time aws s3 --endpoint http://<new-s3g-ip>:9878 ls buk-obs/obs1/obs2/obs3
                           PRE obs3/
                           PRE obs31/
                           PRE obs311/

real	0m3.124s
user	0m0.927s
sys	0m0.159s
```

Detail data are shown in the following table:

 time with prefix     | obs1/obs2/obs3 | obs1/obs2/   | '' 
-------- | ----- | --- | -- 
before optimization  |  9.165s | 9.112s | 9.045s
after optimization  | 3.124s | 3.067s | 3.014s 

Note：reduce `ozone.client.list.cache` to simulate multiple calls to iterators
