### PR TITLE
HDDS-8955. Add JAXB runtime to HttpFS classpath

### DIFF
--- a/hadoop-ozone/httpfsgateway/pom.xml
+++ b/hadoop-ozone/httpfsgateway/pom.xml
@@ -153,7 +153,10 @@
     <dependency>
       <groupId>javax.xml.bind</groupId>
       <artifactId>jaxb-api</artifactId>
-      <version>2.3.0</version>
+    </dependency>
+    <dependency>
+      <groupId>org.glassfish.jaxb</groupId>
+      <artifactId>jaxb-runtime</artifactId>
     </dependency>
   </dependencies>
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Get rid of:

```
httpfs_1    | SEVERE: Implementation of JAXB-API has not been found on module path or classpath.
httpfs_1    | javax.xml.bind.JAXBException: Implementation of JAXB-API has not been found on module path or classpath.
httpfs_1    |  - with linked exception:
httpfs_1    | [java.lang.ClassNotFoundException: com.sun.xml.internal.bind.v2.ContextFactory]
...
httpfs_1    | 	at org.apache.hadoop.http.HttpServer2.start(HttpServer2.java:1301)
```

https://issues.apache.org/jira/browse/HDDS-8955

## How was this patch tested?

Ran `httpfs` acceptance tests locally, verified exception is gone.

CI:
https://github.com/adoroszlai/hadoop-ozone/actions/runs/5411417691