### PR TITLE
HDDS-8957. Move info level log messages for create / open pipelines outside of locks

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/BackgroundPipelineCreator.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/BackgroundPipelineCreator.java
@@ -229,7 +229,8 @@ public class BackgroundPipelineCreator implements SCMService {
           (ReplicationConfig) it.next();
 
       try {
-        pipelineManager.createPipeline(replicationConfig);
+        Pipeline pipeline = pipelineManager.createPipeline(replicationConfig);
+        LOG.info("Created new pipeline {}", pipeline);
       } catch (IOException ioe) {
         it.remove();
       } catch (Throwable t) {

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/PipelineManagerImpl.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/PipelineManagerImpl.java
@@ -296,7 +296,6 @@ public class PipelineManagerImpl implements PipelineManager {
     } finally {
       releaseWriteLock();
     }
-    LOG.info("Added pipeline {}.", pipeline);
     recordMetricsForPipeline(pipeline);
   }
 
@@ -422,7 +421,6 @@ public class PipelineManagerImpl implements PipelineManager {
     HddsProtos.PipelineID pipelineIdProtobuf = pipelineId.getProtobuf();
     acquireWriteLock();
     final Pipeline pipeline;
-    boolean opened = false;
     try {
       pipeline = stateManager.getPipeline(pipelineId);
       if (pipeline.isClosed()) {
@@ -431,14 +429,9 @@ public class PipelineManagerImpl implements PipelineManager {
       if (pipeline.getPipelineState() == Pipeline.PipelineState.ALLOCATED) {
         stateManager.updatePipelineState(pipelineIdProtobuf,
             HddsProtos.PipelineState.PIPELINE_OPEN);
-        opened = true;
       }
     } finally {
       releaseWriteLock();
-    }
-
-    if (opened) {
-      LOG.info("Pipeline {} moved to OPEN state", pipeline);
     }
     metrics.incNumPipelineCreated();
     metrics.createPerPipelineMetrics(pipeline);

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/PipelineReportHandler.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/PipelineReportHandler.java
@@ -133,6 +133,7 @@ public class PipelineReportHandler implements
       }
       if (pipeline.isHealthy()) {
         pipelineManager.openPipeline(pipelineID);
+        LOGGER.info("Opened pipeline {}", pipelineID);
       }
     }
     if (pipeline.isHealthy()) {

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/WritableECContainerProvider.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/WritableECContainerProvider.java
@@ -191,6 +191,7 @@ public class WritableECContainerProvider
     ContainerInfo container =
         containerManager.getMatchingContainer(size, owner, newPipeline);
     pipelineManager.openPipeline(newPipeline.getId());
+    LOG.info("Created and opened new pipeline {}", newPipeline);
     return container;
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Move the logging of create / open pipelines to the caller so the log message is not performed under a lock. Flame charts show logging to be a significant factor when creating EC pipelines under a synchronized block.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-8957

## How was this patch tested?

Logging only change to existing tests should cover.
