### PR TITLE
HDDS-8966. Replace test-specific unknown value with real one

### DIFF
--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/OmUtils.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/OmUtils.java
@@ -319,6 +319,7 @@ public final class OmUtils {
     case SnapshotPurge:
     case RecoverLease:
     case SetTimes:
+    case UnknownCommand:
       return false;
     default:
       LOG.error("CmdType {} is not categorized as readOnly or not.", cmdType);

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/ratis/TestOzoneManagerRatisRequest.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/ratis/TestOzoneManagerRatisRequest.java
@@ -103,7 +103,7 @@ public class TestOzoneManagerRatisRequest {
     // Create an instance of OMRequest with an unknown command type.
     OzoneManagerProtocolProtos.OMRequest omRequest =
         OzoneManagerProtocolProtos.OMRequest.newBuilder()
-            .setCmdType(OzoneManagerProtocolProtos.Type.TestUnknownCommand)
+            .setCmdType(OzoneManagerProtocolProtos.Type.UnknownCommand)
             .setClientId("test-client-id")
             .build();
 

--- a/hadoop-ozone/interface-client/src/main/proto/OmClientProtocol.proto
+++ b/hadoop-ozone/interface-client/src/main/proto/OmClientProtocol.proto
@@ -39,6 +39,7 @@ import "hdds.proto";
 import "Security.proto";
 
 enum Type {
+  UnknownCommand = 0;
   CreateVolume = 11;
   SetVolumeProperty = 12;
   CheckVolumeAccess = 13;
@@ -138,7 +139,6 @@ enum Type {
   RefetchSecretKey = 121;
   ListSnapshotDiffJobs = 122;
   CancelSnapshotDiff = 123;
-  TestUnknownCommand = 124;
 }
 
 message OMRequest {

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/ratis/TestOzoneManagerRatisServer.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/ratis/TestOzoneManagerRatisServer.java
@@ -200,11 +200,6 @@ public class TestOzoneManagerRatisServer {
         OzoneManagerProtocolProtos.Type.values();
 
     for (OzoneManagerProtocolProtos.Type cmdtype : cmdTypes) {
-      if (cmdtype == OzoneManagerProtocolProtos.Type.TestUnknownCommand) {
-        // Skip OzoneManagerProtocolProtos.Type.TestUnknownCommand, since this
-        // cmdType is reserved for testing purposes only.
-        continue;
-      }
       OMRequest request = OMRequest.newBuilder()
           .setCmdType(cmdtype)
           .setClientId(clientId)


### PR DESCRIPTION
## What changes were proposed in this pull request?

Replace `TestUnknownCommand` with a real catch-all type: `UnknownCommand = 0`.

Protobuf guide [recommends](https://protobuf.dev/programming-guides/dos-donts/#do-include-an-unspecified-value-in-an-enum):

> Enums should include a default FOO_UNSPECIFIED value as the first value in the declaration.

Rationale:

> When new values are added to a proto2 enum, old clients will see the field as unset and the getter will return the default value or the first-declared value if no default exists.

https://issues.apache.org/jira/browse/HDDS-8966

## How was this patch tested?

CI:
https://github.com/adoroszlai/hadoop-ozone/actions/runs/5421634940