### PR TITLE
HDDS-8943. [Snapshot] Limit the total size of sst files in bootstrapping tarball.

### DIFF
--- a/hadoop-hdds/common/src/main/resources/ozone-default.xml
+++ b/hadoop-hdds/common/src/main/resources/ozone-default.xml
@@ -2022,6 +2022,14 @@
     </description>
   </property>
   <property>
+    <name>ozone.om.ratis.snapshot.max.total.sst.size</name>
+    <value>100000000</value>
+    <tag>OZONE, OM, RATIS</tag>
+    <description>
+      Max size of SST files in OM Ratis Snapshot tarball.
+    </description>
+  </property>
+  <property>
     <name>ozone.om.snapshot.provider.socket.timeout</name>
     <value>5000s</value>
     <tag>OZONE, OM, HA, MANAGEMENT</tag>

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/HddsServerUtil.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/HddsServerUtil.java
@@ -109,7 +109,7 @@ public final class HddsServerUtil {
   private HddsServerUtil() {
   }
 
-  static final String OZONE_RATIS_SNAPSHOT_COMPLETE_FLAG_NAME =
+  public static final String OZONE_RATIS_SNAPSHOT_COMPLETE_FLAG_NAME =
       "OzoneRatisSnapshotCompleteFlag";
 
   private static final Logger LOG = LoggerFactory.getLogger(

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/HddsServerUtil.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/HddsServerUtil.java
@@ -109,6 +109,9 @@ public final class HddsServerUtil {
   private HddsServerUtil() {
   }
 
+  static final String OZONE_RATIS_SNAPSHOT_COMPLETE_FLAG_NAME =
+      "OzoneRatisSnapshotCompleteFlag";
+
   private static final Logger LOG = LoggerFactory.getLogger(
       HddsServerUtil.class);
 
@@ -590,6 +593,7 @@ public final class HddsServerUtil {
           }
         }
       }
+      includeRatisSnapshotCompleteFlag(archiveOutputStream);
     }
   }
 
@@ -603,6 +607,20 @@ public final class HddsServerUtil {
       IOUtils.copy(fis, archiveOutputStream);
     }
     archiveOutputStream.closeArchiveEntry();
+  }
+
+  // Mark tarball completed.
+  public static void includeRatisSnapshotCompleteFlag(
+      ArchiveOutputStream archiveOutput) throws IOException {
+    File file = File.createTempFile(
+        OZONE_RATIS_SNAPSHOT_COMPLETE_FLAG_NAME, "");
+    String entryName = OZONE_RATIS_SNAPSHOT_COMPLETE_FLAG_NAME;
+    includeFile(file, entryName, archiveOutput);
+  }
+
+  static boolean ratisSnapshotComplete(Path dir) {
+    return new File(dir.toString(),
+        OZONE_RATIS_SNAPSHOT_COMPLETE_FLAG_NAME).exists();
   }
 
   // optimize ugi lookup for RPC operations to avoid a trip through

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/HddsServerUtil.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/HddsServerUtil.java
@@ -110,7 +110,7 @@ public final class HddsServerUtil {
   }
 
   public static final String OZONE_RATIS_SNAPSHOT_COMPLETE_FLAG_NAME =
-      "OzoneRatisSnapshotCompleteFlag";
+      "OZONE_RATIS_SNAPSHOT_COMPLETE";
 
   private static final Logger LOG = LoggerFactory.getLogger(
       HddsServerUtil.class);

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/RDBSnapshotProvider.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/RDBSnapshotProvider.java
@@ -123,11 +123,12 @@ public abstract class RDBSnapshotProvider implements Closeable {
 
       RocksDBCheckpoint checkpoint = getCheckpointFromSnapshotFile(targetFile,
           candidateDir, true);
-      File hardLinkFile = new File(checkpoint.getCheckpointLocation().toString(), "hardLinkFile");
+      File hardLinkFile = new File(
+          checkpoint.getCheckpointLocation().toString(), "hardLinkFile");
       // If the hardlink file exists we have gotten the last tar file.
       if (hardLinkFile.exists()) {
-        LOG.info("Successfully untar the downloaded snapshot {} at {}.", targetFile,
-            checkpoint.getCheckpointLocation());
+        LOG.info("Successfully untar the downloaded snapshot {} at {}.",
+            targetFile, checkpoint.getCheckpointLocation());
         return checkpoint;
       }
     }

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/RDBSnapshotProvider.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/RDBSnapshotProvider.java
@@ -127,7 +127,7 @@ public abstract class RDBSnapshotProvider implements Closeable {
       if (!incompleteFlag.exists()) {
         LOG.info("Successfully untar the downloaded snapshot {} at {}.", targetFile,
             checkpoint.getCheckpointLocation());
-        //        return checkpoint;
+        return checkpoint;
       } else {
         incompleteFlag.delete();
       }

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/RDBSnapshotProvider.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/RDBSnapshotProvider.java
@@ -123,13 +123,11 @@ public abstract class RDBSnapshotProvider implements Closeable {
 
       RocksDBCheckpoint checkpoint = getCheckpointFromSnapshotFile(targetFile,
           candidateDir, true);
-      File incompleteFlag = new File(checkpoint.getCheckpointLocation().toString(), "incompleteFlag.txt");
-      if (!incompleteFlag.exists()) {
+      File hardLinkFile = new File(checkpoint.getCheckpointLocation().toString(), "hardLinkFile");
+      if (hardLinkFile.exists()) {
         LOG.info("Successfully untar the downloaded snapshot {} at {}.", targetFile,
             checkpoint.getCheckpointLocation());
         return checkpoint;
-      } else {
-        incompleteFlag.delete();
       }
     }
   }

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/RDBSnapshotProvider.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/RDBSnapshotProvider.java
@@ -124,9 +124,10 @@ public abstract class RDBSnapshotProvider implements Closeable {
 
       RocksDBCheckpoint checkpoint = getCheckpointFromSnapshotFile(targetFile,
           candidateDir, true);
+      LOG.info("Successfully untar the downloaded snapshot {} at {}.",
+          targetFile, checkpoint.getCheckpointLocation());
       if (ratisSnapshotComplete(checkpoint.getCheckpointLocation())) {
-        LOG.info("Successfully untar the downloaded snapshot {} at {}.",
-            targetFile, checkpoint.getCheckpointLocation());
+        LOG.info("Ratis snapshot transfer is complete.");
         return checkpoint;
       }
     }

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/RDBSnapshotProvider.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/RDBSnapshotProvider.java
@@ -127,7 +127,7 @@ public abstract class RDBSnapshotProvider implements Closeable {
       if (!incompleteFlag.exists()) {
         LOG.info("Successfully untar the downloaded snapshot {} at {}.", targetFile,
             checkpoint.getCheckpointLocation());
-        return checkpoint;
+        //        return checkpoint;
       } else {
         incompleteFlag.delete();
       }

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/RDBSnapshotProvider.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/RDBSnapshotProvider.java
@@ -124,6 +124,7 @@ public abstract class RDBSnapshotProvider implements Closeable {
       RocksDBCheckpoint checkpoint = getCheckpointFromSnapshotFile(targetFile,
           candidateDir, true);
       File hardLinkFile = new File(checkpoint.getCheckpointLocation().toString(), "hardLinkFile");
+      // If the hardlink file exists we have gotten the last tar file.
       if (hardLinkFile.exists()) {
         LOG.info("Successfully untar the downloaded snapshot {} at {}.", targetFile,
             checkpoint.getCheckpointLocation());

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/RDBSnapshotProvider.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/RDBSnapshotProvider.java
@@ -34,6 +34,7 @@ import java.util.List;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 
+import static org.apache.hadoop.hdds.utils.HddsServerUtil.ratisSnapshotComplete;
 import static org.apache.hadoop.ozone.OzoneConsts.SNAPSHOT_CANDIDATE_DIR;
 
 /**
@@ -123,10 +124,7 @@ public abstract class RDBSnapshotProvider implements Closeable {
 
       RocksDBCheckpoint checkpoint = getCheckpointFromSnapshotFile(targetFile,
           candidateDir, true);
-      File hardLinkFile = new File(
-          checkpoint.getCheckpointLocation().toString(), "hardLinkFile");
-      // If the hardlink file exists we have gotten the last tar file.
-      if (hardLinkFile.exists()) {
+      if (ratisSnapshotComplete(checkpoint.getCheckpointLocation())) {
         LOG.info("Successfully untar the downloaded snapshot {} at {}.",
             targetFile, checkpoint.getCheckpointLocation());
         return checkpoint;

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/OMConfigKeys.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/OMConfigKeys.java
@@ -202,6 +202,11 @@ public final class OMConfigKeys {
   public static final long
       OZONE_OM_RATIS_SNAPSHOT_AUTO_TRIGGER_THRESHOLD_DEFAULT = 400000;
 
+  public static final String OZONE_OM_RATIS_SNAPSHOT_MAX_TOTAL_SST_SIZE_KEY
+      = "ozone.om.ratis.snapshot.max.total.sst.size";
+  public static final long
+      OZONE_OM_RATIS_SNAPSHOT_MAX_TOTAL_SST_SIZE_DEFAULT = 100_000_000;
+
   // OM Ratis server configurations
   public static final String OZONE_OM_RATIS_SERVER_REQUEST_TIMEOUT_KEY
       = "ozone.om.ratis.server.request.timeout";

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOMDbCheckpointServlet.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOMDbCheckpointServlet.java
@@ -71,6 +71,7 @@ import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.commons.io.FileUtils;
 
 import static org.apache.hadoop.hdds.recon.ReconConfig.ConfigStrings.OZONE_RECON_KERBEROS_PRINCIPAL_KEY;
+import static org.apache.hadoop.hdds.utils.HddsServerUtil.OZONE_RATIS_SNAPSHOT_COMPLETE_FLAG_NAME;
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_ACL_ENABLED;
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_ADMINISTRATORS;
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_ADMINISTRATORS_WILDCARD;
@@ -703,7 +704,9 @@ public class TestOMDbCheckpointServlet {
         if (file.toFile().isDirectory()) {
           getFiles(file, truncateLength, fileSet);
         }
-        if (!file.getFileName().toString().startsWith("fabricated")) {
+        String filename = file.getFileName().toString();
+        if (!filename.startsWith("fabricated") &&
+            !filename.startsWith(OZONE_RATIS_SNAPSHOT_COMPLETE_FLAG_NAME)) {
           fileSet.add(truncateFileName(truncateLength, file));
         }
       }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOMRatisSnapshots.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOMRatisSnapshots.java
@@ -188,7 +188,7 @@ public class TestOMRatisSnapshots {
   }
 
   @ParameterizedTest
-  @ValueSource(ints = {2})
+  @ValueSource(ints = {100})
   // tried up to 1000 snapshots and this test works, but some of the
   //  timeouts have to be increased.
   public void testInstallSnapshot(int numSnapshotsToCreate) throws Exception {
@@ -212,7 +212,6 @@ public class TestOMRatisSnapshots {
             followerOM.getOmSnapshotProvider().getSnapshotDir(),
             sstSetList);
     followerOM.getOmSnapshotProvider().setInjector(faultInjector);
-    //    faultInjector.resume();
 
     // Create some snapshots, each with new keys
     int keyIncrement = 10;
@@ -248,7 +247,7 @@ public class TestOMRatisSnapshots {
     GenericTestUtils.waitFor(() -> {
       return followerOM.getOmRatisServer().getLastAppliedTermIndex().getIndex()
           >= leaderOMSnapshotIndex - 1;
-    }, 100, 1000000);
+    }, 100, 1000*100);
 
     long followerOMLastAppliedIndex =
         followerOM.getOmRatisServer().getLastAppliedTermIndex().getIndex();
@@ -1196,7 +1195,7 @@ public class TestOMRatisSnapshots {
       if (count == 1) {
         assert tarball != null;
         om.getConfiguration().setLong("ozone.om.maxsize",
-            Files.size(tarball.toPath())/2);
+                                      (Files.size(tarball.toPath())*2)/3);
         createDummyTarball(tarball);
       } else {
         sstSetList.add(getSstFilenames(tarball));

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOMRatisSnapshots.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOMRatisSnapshots.java
@@ -97,7 +97,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
  */
 @Timeout(5000)
 @Flaky("HDDS-8876")
-@Disabled("HDDS-8880")
+//@Disabled("HDDS-8880")
 public class TestOMRatisSnapshots {
 
   private MiniOzoneHAClusterImpl cluster = null;

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOMRatisSnapshots.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOMRatisSnapshots.java
@@ -92,6 +92,7 @@ import java.util.stream.Stream;
 
 import static org.apache.hadoop.hdds.utils.HddsServerUtil.includeFile;
 import static org.apache.hadoop.ozone.OzoneConsts.OM_DB_NAME;
+import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_RATIS_SNAPSHOT_MAX_TOTAL_SST_SIZE_KEY;
 import static org.apache.hadoop.ozone.om.OmSnapshotManager.OM_HARDLINK_FILE;
 import static org.apache.hadoop.ozone.om.OmSnapshotManager.getSnapshotPath;
 import static org.apache.hadoop.ozone.om.TestOzoneManagerHAWithData.createKey;
@@ -1210,7 +1211,7 @@ public class TestOMRatisSnapshots {
         for (Path sstPath : sstPaths) {
           sstSize += Files.size(sstPath);
         }
-        om.getConfiguration().setLong("ozone.om.maxsize",
+        om.getConfiguration().setLong(OZONE_OM_RATIS_SNAPSHOT_MAX_TOTAL_SST_SIZE_KEY,
                                       sstSize/2);
         // Now empty the tarball to restart the download
         // process.

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOMRatisSnapshots.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOMRatisSnapshots.java
@@ -1223,6 +1223,7 @@ public class TestOMRatisSnapshots {
     private File getTarball(File dir) {
       assertNotNull(dir);
       File[] fileList = dir.listFiles();
+      assertNotNull(fileList);
        for (File f : fileList) {
         if (f != null) {
           if (f.getName().toLowerCase().endsWith(".tar")) {

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOMRatisSnapshots.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOMRatisSnapshots.java
@@ -1224,7 +1224,7 @@ public class TestOMRatisSnapshots {
       assertNotNull(dir);
       File[] fileList = dir.listFiles();
       assertNotNull(fileList);
-       for (File f : fileList) {
+      for (File f : fileList) {
         if (f != null) {
           if (f.getName().toLowerCase().endsWith(".tar")) {
             return f;

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOMRatisSnapshots.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOMRatisSnapshots.java
@@ -1221,14 +1221,11 @@ public class TestOMRatisSnapshots {
 
     // Find the tarball in the dir.
     private File getTarball(File dir) {
-      assertNotNull(dir);
       File[] fileList = dir.listFiles();
       assertNotNull(fileList);
       for (File f : fileList) {
-        if (f != null) {
-          if (f.getName().toLowerCase().endsWith(".tar")) {
-            return f;
-          }
+        if (f.getName().toLowerCase().endsWith(".tar")) {
+          return f;
         }
       }
       return null;

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOMRatisSnapshots.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOMRatisSnapshots.java
@@ -1205,13 +1205,14 @@ public class TestOMRatisSnapshots {
     private Set<String> getSstFilenames(File tarball)
         throws IOException {
       Set<String> sstFilenames = new HashSet<>();
-      TarArchiveInputStream tarInput =
-          new TarArchiveInputStream(new FileInputStream(tarball));
-      TarArchiveEntry entry;
-      while ((entry = tarInput.getNextTarEntry()) != null) {
-        String name = entry.getName();
-        if (name.toLowerCase().endsWith(".sst")) {
-          sstFilenames.add(entry.getName());
+      try (TarArchiveInputStream tarInput =
+           new TarArchiveInputStream(new FileInputStream(tarball))) {
+        TarArchiveEntry entry;
+        while ((entry = tarInput.getNextTarEntry()) != null) {
+          String name = entry.getName();
+          if (name.toLowerCase().endsWith(".sst")) {
+            sstFilenames.add(entry.getName());
+          }
         }
       }
       return sstFilenames;
@@ -1219,9 +1220,11 @@ public class TestOMRatisSnapshots {
 
     // Find the tarball in the dir.
     private File getTarball(File dir) {
-      for (File f : Objects.requireNonNull(dir.listFiles())) {
-        if (f.getName().toLowerCase().endsWith(".tar")) {
-          return f;
+      for (File f : dir.listFiles()) {
+        if (f != null) {
+          if (f.getName().toLowerCase().endsWith(".tar")) {
+            return f;
+          }
         }
       }
       return null;

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOMRatisSnapshots.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOMRatisSnapshots.java
@@ -154,7 +154,6 @@ public class TestOMRatisSnapshots {
         .setScmId(scmId)
         .setOMServiceId("om-service-test1")
         .setNumOfOzoneManagers(numOfOMs)
-//        .setNumDatanodes(1)
         .setNumOfActiveOMs(2)
         .build();
     cluster.waitForClusterToBeReady();
@@ -1196,8 +1195,8 @@ public class TestOMRatisSnapshots {
       File tarball = getTarball(snapshotDir);
       if (count == 1) {
         assert tarball != null;
-        om.getConfiguration().setLong("ozone.om.maxsize", 1);
-         //   Files.size(tarball.toPath())/2);
+        om.getConfiguration().setLong("ozone.om.maxsize",
+            Files.size(tarball.toPath())/2);
         createDummyTarball(tarball);
       } else {
         sstSetList.add(getSstFilenames(tarball));

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOMRatisSnapshots.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOMRatisSnapshots.java
@@ -105,7 +105,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
  */
 @Timeout(5000)
 @Flaky("HDDS-8876")
-//@Disabled("HDDS-8880")
+@Disabled("HDDS-8880")
 public class TestOMRatisSnapshots {
 
   private MiniOzoneHAClusterImpl cluster = null;
@@ -187,7 +187,7 @@ public class TestOMRatisSnapshots {
   }
 
   @ParameterizedTest
-  @ValueSource(ints = {100, 100, 100, 100, 100, 100, 100, 100, 100, 100, 100, 100, 100, 100, 100, 100, 100, 100})
+  @ValueSource(ints = {100})
   // tried up to 1000 snapshots and this test works, but some of the
   //  timeouts have to be increased.
   public void testInstallSnapshot(int numSnapshotsToCreate) throws Exception {
@@ -1193,14 +1193,12 @@ public class TestOMRatisSnapshots {
       return sstSize;
     }
 
-    @SuppressWarnings("checkstyle:EmptyBlock")
     private void createEmptyTarball(File dummyTarFile)
         throws IOException {
       FileOutputStream fileOutputStream = new FileOutputStream(dummyTarFile);
-      try (TarArchiveOutputStream archiveOutputStream =
-               new TarArchiveOutputStream(fileOutputStream)) {
-        ; // Don't add any files.
-      }
+      TarArchiveOutputStream archiveOutputStream =
+          new TarArchiveOutputStream(fileOutputStream);
+      archiveOutputStream.close();
     }
 
     // Return a list of sst files in tarball.

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOMRatisSnapshots.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOMRatisSnapshots.java
@@ -1137,7 +1137,7 @@ public class TestOMRatisSnapshots {
     }
   }
 
-  // Interupts the tarball download process to test creation of
+  // Interrupts the tarball download process to test creation of
   // multiple tarballs as needed when the tarball size exceeds the
   // max.
   private static class SnapshotMaxSizeInjector extends FaultInjector {

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OMDBCheckpointServlet.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OMDBCheckpointServlet.java
@@ -57,6 +57,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static org.apache.hadoop.hdds.utils.HddsServerUtil.includeFile;
+import static org.apache.hadoop.hdds.utils.HddsServerUtil.includeRatisSnapshotCompleteFlag;
 import static org.apache.hadoop.ozone.OzoneConsts.OM_CHECKPOINT_DIR;
 import static org.apache.hadoop.ozone.OzoneConsts.OM_SNAPSHOT_CHECKPOINT_DIR;
 import static org.apache.hadoop.ozone.OzoneConsts.OM_SNAPSHOT_DIR;
@@ -381,6 +382,8 @@ public class OMDBCheckpointServlet extends DBCheckpointServlet {
       Path hardLinkFile = createHardLinkList(truncateLength, hardLinkFiles);
       includeFile(hardLinkFile.toFile(), OmSnapshotManager.OM_HARDLINK_FILE,
           archiveOutputStream);
+      // Mark tarball completed.
+      includeRatisSnapshotCompleteFlag(archiveOutputStream);
     }
   }
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OMDBCheckpointServlet.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OMDBCheckpointServlet.java
@@ -379,9 +379,11 @@ public class OMDBCheckpointServlet extends DBCheckpointServlet {
 
     if (completed) {
       // Only create the hard link list for the last tarball.
-      Path hardLinkFile = createHardLinkList(truncateLength, hardLinkFiles);
-      includeFile(hardLinkFile.toFile(), OmSnapshotManager.OM_HARDLINK_FILE,
-          archiveOutputStream);
+      if (!hardLinkFiles.isEmpty()) {
+        Path hardLinkFile = createHardLinkList(truncateLength, hardLinkFiles);
+        includeFile(hardLinkFile.toFile(), OmSnapshotManager.OM_HARDLINK_FILE,
+            archiveOutputStream);
+      }
       // Mark tarball completed.
       includeRatisSnapshotCompleteFlag(archiveOutputStream);
     }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OMDBCheckpointServlet.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OMDBCheckpointServlet.java
@@ -87,7 +87,7 @@ public class OMDBCheckpointServlet extends DBCheckpointServlet {
       LoggerFactory.getLogger(OMDBCheckpointServlet.class);
   private static final long serialVersionUID = 1L;
   private transient BootstrapStateHandler.Lock lock;
-  private long max_total_sst_size = 0;
+  private long maxTotalSstSize = 0;
   @Override
   public void init() throws ServletException {
 
@@ -147,9 +147,11 @@ public class OMDBCheckpointServlet extends DBCheckpointServlet {
       Set<Path> toExcludeFiles = normalizeExcludeList(toExcludeList,
           checkpoint.getCheckpointLocation().toString(),
           ServerUtils.getOzoneMetaDirPath(getConf()).toString());
-      boolean completed = getFilesForArchive(checkpoint, copyFiles, hardLinkFiles, toExcludeFiles,
-          includeSnapshotData(request), excludedList);
-      writeFilesToArchive(copyFiles, hardLinkFiles, archiveOutputStream, completed);
+      boolean completed = getFilesForArchive(checkpoint, copyFiles,
+          hardLinkFiles, toExcludeFiles, includeSnapshotData(request),
+          excludedList);
+      writeFilesToArchive(copyFiles, hardLinkFiles, archiveOutputStream,
+          completed);
     } catch (Exception e) {
       LOG.error("got exception writing to archive " + e);
       throw e;
@@ -180,8 +182,9 @@ public class OMDBCheckpointServlet extends DBCheckpointServlet {
                                   List<String> excluded)
       throws IOException {
 
-    max_total_sst_size = getConf().getLong(OZONE_OM_RATIS_SNAPSHOT_MAX_TOTAL_SST_SIZE_KEY,
-                                      OZONE_OM_RATIS_SNAPSHOT_MAX_TOTAL_SST_SIZE_DEFAULT);
+    maxTotalSstSize = getConf().getLong(
+        OZONE_OM_RATIS_SNAPSHOT_MAX_TOTAL_SST_SIZE_KEY,
+        OZONE_OM_RATIS_SNAPSHOT_MAX_TOTAL_SST_SIZE_DEFAULT);
 
     AtomicLong copySize = new AtomicLong(0L);
     // Get the active fs files.
@@ -266,8 +269,9 @@ public class OMDBCheckpointServlet extends DBCheckpointServlet {
             return false;
           }
         } else {
-          long fileSize = processFile(file, copyFiles, hardLinkFiles, toExcludeFiles, excluded);
-          if (copySize.get() + fileSize > max_total_sst_size) {
+          long fileSize = processFile(file, copyFiles, hardLinkFiles,
+              toExcludeFiles, excluded);
+          if (copySize.get() + fileSize > maxTotalSstSize) {
             return false;
           } else {
             copySize.addAndGet(fileSize);
@@ -355,7 +359,7 @@ public class OMDBCheckpointServlet extends DBCheckpointServlet {
     int truncateLength = metaDirPath.toString().length() + 1;
 
     Set<Path> filteredCopyFiles = completed ? copyFiles :
-      copyFiles.stream().filter(path ->
+        copyFiles.stream().filter(path ->
           path.getFileName().toString().toLowerCase().endsWith(".sst")).
           collect(Collectors.toSet());
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OMDBCheckpointServlet.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OMDBCheckpointServlet.java
@@ -265,7 +265,7 @@ public class OMDBCheckpointServlet extends DBCheckpointServlet {
           }
         } else {
           copySize.addAndGet(processFile(file, copyFiles, hardLinkFiles, toExcludeFiles, excluded));
-          if (copySize.get() > max_copy_size) {
+          if ((copySize.get() > max_copy_size) && containsSstFile(copyFiles)) {
             return false;
           }
         }
@@ -318,6 +318,7 @@ public class OMDBCheckpointServlet extends DBCheckpointServlet {
       } else {
         // Not sst file.
         copyFiles.add(file);
+        fileSize = Files.size(file);
       }
     }
     return fileSize;
@@ -373,6 +374,11 @@ public class OMDBCheckpointServlet extends DBCheckpointServlet {
       Path incompleteFlag = Files.createTempFile("incompleteFlag", "txt");
       includeFile(incompleteFlag.toFile(), "incompleteFlag.txt", archiveOutputStream);
     }
+  }
+
+  private boolean containsSstFile(Set<Path> copyFiles) {
+    return copyFiles.stream().anyMatch(path ->
+        path.getFileName().toString().toLowerCase().endsWith(".sst"));
   }
 
   private OzoneConfiguration getConf() {

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OMDBCheckpointServlet.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OMDBCheckpointServlet.java
@@ -371,7 +371,7 @@ public class OMDBCheckpointServlet extends DBCheckpointServlet {
     }
 
     if (completed) {
-      // Create list of hard links.
+      // Only create the hard link list for the last tarball.
       Path hardLinkFile = createHardLinkList(truncateLength, hardLinkFiles);
       includeFile(hardLinkFile.toFile(), OmSnapshotManager.OM_HARDLINK_FILE,
           archiveOutputStream);

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/snapshot/OmSnapshotUtils.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/snapshot/OmSnapshotUtils.java
@@ -117,6 +117,10 @@ public final class OmSnapshotUtils {
           String to = l.split("\t")[0];
           Path fullFromPath = Paths.get(dbPath.toString(), from);
           Path fullToPath = Paths.get(dbPath.toString(), to);
+          File toParent = fullToPath.getParent().toFile();
+          if (!toParent.exists()) {
+            toParent.mkdirs();
+          }
           Files.createLink(fullToPath, fullFromPath);
         }
         if (!hardLinkFile.delete()) {

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/snapshot/OmSnapshotUtils.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/snapshot/OmSnapshotUtils.java
@@ -117,13 +117,12 @@ public final class OmSnapshotUtils {
           String to = l.split("\t")[0];
           Path fullFromPath = Paths.get(dbPath.toString(), from);
           Path fullToPath = Paths.get(dbPath.toString(), to);
+          // Make parent dir if it doesn't exist.
           Path parent = fullToPath.getParent();
-          if (parent != null) {
-            if (!parent.toFile().exists()) {
-              if (!toParent.mkdirs()) {
-                throw new IOException(
+          if ((parent != null) && (!parent.toFile().exists())) {
+            if (!parent.toFile().mkdirs()) {
+              throw new IOException(
                   "Failed to create directory: " + parent.toString());
-              }
             }
           }
           Files.createLink(fullToPath, fullFromPath);

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/snapshot/OmSnapshotUtils.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/snapshot/OmSnapshotUtils.java
@@ -117,9 +117,14 @@ public final class OmSnapshotUtils {
           String to = l.split("\t")[0];
           Path fullFromPath = Paths.get(dbPath.toString(), from);
           Path fullToPath = Paths.get(dbPath.toString(), to);
-          File toParent = fullToPath.getParent().toFile();
-          if (!toParent.exists()) {
-            toParent.mkdirs();
+          Path parent = fullToPath.getParent();
+          if (parent != null) {
+            if (!parent.toFile().exists()) {
+              if (!toParent.mkdirs()) {
+                throw new IOException(
+                  "Failed to create directory: " + parent.toString());
+              }
+            }
           }
           Files.createLink(fullToPath, fullFromPath);
         }

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestOmSnapshotManager.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestOmSnapshotManager.java
@@ -342,8 +342,8 @@ public class TestOmSnapshotManager {
    */
   @Test
   public void testProcessFile() throws IOException {
-    new File(testDir.toString(), "snap1").mkdirs();
-    new File(testDir.toString(), "snap2").mkdirs();
+    Assert.assertTrue(new File(testDir.toString(), "snap1").mkdirs());
+    Assert.assertTrue(new File(testDir.toString(), "snap2").mkdirs());
     Path copyFile = Paths.get(testDir.toString(),
         "snap1/copyfile.sst");
     Files.write(copyFile,

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestOmSnapshotManager.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestOmSnapshotManager.java
@@ -39,6 +39,7 @@ import org.junit.Test;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -340,19 +341,33 @@ public class TestOmSnapshotManager {
    * should be copied, linked, or excluded from the tarball entirely.
    */
   @Test
-  public void testProcessFile() {
+  public void testProcessFile() throws IOException {
+    new File(testDir.toString(), "snap1").mkdirs();
+    new File(testDir.toString(), "snap2").mkdirs();
     Path copyFile = Paths.get(testDir.toString(),
         "snap1/copyfile.sst");
+    Files.write(copyFile,
+        "dummyData".getBytes(StandardCharsets.UTF_8));
     Path excludeFile = Paths.get(testDir.toString(),
         "snap1/excludeFile.sst");
+    Files.write(excludeFile,
+        "dummyData".getBytes(StandardCharsets.UTF_8));
     Path linkToExcludedFile = Paths.get(testDir.toString(),
         "snap2/excludeFile.sst");
+    Files.write(linkToExcludedFile,
+        "dummyData".getBytes(StandardCharsets.UTF_8));
     Path linkToCopiedFile = Paths.get(testDir.toString(),
         "snap2/copyfile.sst");
+    Files.write(linkToCopiedFile,
+        "dummyData".getBytes(StandardCharsets.UTF_8));
     Path addToCopiedFiles = Paths.get(testDir.toString(),
         "snap1/copyfile2.sst");
+    Files.write(addToCopiedFiles,
+        "dummyData".getBytes(StandardCharsets.UTF_8));
     Path addNonSstToCopiedFiles = Paths.get(testDir.toString(),
         "snap1/nonSst");
+    Files.write(addNonSstToCopiedFiles,
+        "dummyData".getBytes(StandardCharsets.UTF_8));
 
     Set<Path> toExcludeFiles = new HashSet<>(
         Collections.singletonList(excludeFile));

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestOmSnapshotManager.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestOmSnapshotManager.java
@@ -378,8 +378,8 @@ public class TestOmSnapshotManager {
     long fileSize;
     // Confirm the exclude file gets added to the excluded list,
     //  (and thus is excluded.)
-    fileSize = processFile(excludeFile, copyFiles, hardLinkFiles, toExcludeFiles,
-        excluded);
+    fileSize = processFile(excludeFile, copyFiles, hardLinkFiles,
+        toExcludeFiles, excluded);
     Assert.assertEquals(excluded.size(), 1);
     Assert.assertEquals((excluded.get(0)), excludeFile.toString());
     Assert.assertEquals(copyFiles.size(), 1);
@@ -388,8 +388,8 @@ public class TestOmSnapshotManager {
     excluded = new ArrayList<>();
 
     // Confirm the linkToExcludedFile gets added as a link.
-    fileSize = processFile(linkToExcludedFile, copyFiles, hardLinkFiles, toExcludeFiles,
-        excluded);
+    fileSize = processFile(linkToExcludedFile, copyFiles, hardLinkFiles,
+        toExcludeFiles, excluded);
     Assert.assertEquals(excluded.size(), 0);
     Assert.assertEquals(copyFiles.size(), 1);
     Assert.assertEquals(hardLinkFiles.size(), 1);
@@ -398,8 +398,8 @@ public class TestOmSnapshotManager {
     hardLinkFiles = new HashMap<>();
 
     // Confirm the linkToCopiedFile gets added as a link.
-    fileSize = processFile(linkToCopiedFile, copyFiles, hardLinkFiles, toExcludeFiles,
-        excluded);
+    fileSize = processFile(linkToCopiedFile, copyFiles, hardLinkFiles,
+        toExcludeFiles, excluded);
     Assert.assertEquals(excluded.size(), 0);
     Assert.assertEquals(copyFiles.size(), 1);
     Assert.assertEquals(hardLinkFiles.size(), 1);
@@ -408,8 +408,8 @@ public class TestOmSnapshotManager {
     hardLinkFiles = new HashMap<>();
 
     // Confirm the addToCopiedFiles gets added to list of copied files
-    fileSize = processFile(addToCopiedFiles, copyFiles, hardLinkFiles, toExcludeFiles,
-        excluded);
+    fileSize = processFile(addToCopiedFiles, copyFiles, hardLinkFiles,
+        toExcludeFiles, excluded);
     Assert.assertEquals(excluded.size(), 0);
     Assert.assertEquals(copyFiles.size(), 2);
     Assert.assertTrue(copyFiles.contains(addToCopiedFiles));

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestOmSnapshotManager.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestOmSnapshotManager.java
@@ -348,6 +348,7 @@ public class TestOmSnapshotManager {
         "snap1/copyfile.sst");
     Files.write(copyFile,
         "dummyData".getBytes(StandardCharsets.UTF_8));
+    long expectedFileSize = Files.size(copyFile);
     Path excludeFile = Paths.get(testDir.toString(),
         "snap1/excludeFile.sst");
     Files.write(excludeFile,
@@ -374,48 +375,53 @@ public class TestOmSnapshotManager {
     Set<Path> copyFiles = new HashSet<>(Collections.singletonList(copyFile));
     List<String> excluded = new ArrayList<>();
     Map<Path, Path> hardLinkFiles = new HashMap<>();
-
+    long fileSize;
     // Confirm the exclude file gets added to the excluded list,
     //  (and thus is excluded.)
-    processFile(excludeFile, copyFiles, hardLinkFiles, toExcludeFiles,
+    fileSize = processFile(excludeFile, copyFiles, hardLinkFiles, toExcludeFiles,
         excluded);
     Assert.assertEquals(excluded.size(), 1);
     Assert.assertEquals((excluded.get(0)), excludeFile.toString());
     Assert.assertEquals(copyFiles.size(), 1);
     Assert.assertEquals(hardLinkFiles.size(), 0);
+    Assert.assertEquals(fileSize, 0);
     excluded = new ArrayList<>();
 
     // Confirm the linkToExcludedFile gets added as a link.
-    processFile(linkToExcludedFile, copyFiles, hardLinkFiles, toExcludeFiles,
+    fileSize = processFile(linkToExcludedFile, copyFiles, hardLinkFiles, toExcludeFiles,
         excluded);
     Assert.assertEquals(excluded.size(), 0);
     Assert.assertEquals(copyFiles.size(), 1);
     Assert.assertEquals(hardLinkFiles.size(), 1);
     Assert.assertEquals(hardLinkFiles.get(linkToExcludedFile), excludeFile);
+    Assert.assertEquals(fileSize, 0);
     hardLinkFiles = new HashMap<>();
 
     // Confirm the linkToCopiedFile gets added as a link.
-    processFile(linkToCopiedFile, copyFiles, hardLinkFiles, toExcludeFiles,
+    fileSize = processFile(linkToCopiedFile, copyFiles, hardLinkFiles, toExcludeFiles,
         excluded);
     Assert.assertEquals(excluded.size(), 0);
     Assert.assertEquals(copyFiles.size(), 1);
     Assert.assertEquals(hardLinkFiles.size(), 1);
     Assert.assertEquals(hardLinkFiles.get(linkToCopiedFile), copyFile);
+    Assert.assertEquals(fileSize, 0);
     hardLinkFiles = new HashMap<>();
 
     // Confirm the addToCopiedFiles gets added to list of copied files
-    processFile(addToCopiedFiles, copyFiles, hardLinkFiles, toExcludeFiles,
+    fileSize = processFile(addToCopiedFiles, copyFiles, hardLinkFiles, toExcludeFiles,
         excluded);
     Assert.assertEquals(excluded.size(), 0);
     Assert.assertEquals(copyFiles.size(), 2);
     Assert.assertTrue(copyFiles.contains(addToCopiedFiles));
+    Assert.assertEquals(fileSize, expectedFileSize);
     copyFiles = new HashSet<>(Collections.singletonList(copyFile));
 
     // Confirm the addNonSstToCopiedFiles gets added to list of copied files
-    processFile(addNonSstToCopiedFiles, copyFiles, hardLinkFiles,
+    fileSize = processFile(addNonSstToCopiedFiles, copyFiles, hardLinkFiles,
         toExcludeFiles, excluded);
     Assert.assertEquals(excluded.size(), 0);
     Assert.assertEquals(copyFiles.size(), 2);
+    Assert.assertEquals(fileSize, 0);
     Assert.assertTrue(copyFiles.contains(addNonSstToCopiedFiles));
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

The incremental checkpointing PR I created here: https://github.com/apache/ozone/pull/4770 allows multiple increments of data if the initial tarball took too long to download.

This is needed for om snapshots but is not completely sufficient, because the first increment can grow quite large, as it includes all sst files that exist at the time it is created.  (Each subsequent increment only includes the sst files created after the first tarball was created.)

This means there is no limit to the size of the initial tarball.  

In order to alleviate that, this PR adds the "max sst size" config flag: **OZONE_OM_RATIS_SNAPSHOT_MAX_TOTAL_SST_SIZE_KEY**.  

The tarball creation process  has been modified to close the tarball once it reaches that size of sst files.  If that leaves the tarball incomplete, the follower will know to request another, incremental one.

Note that with this design all the non sst files are in the final tarball; (because they are mutable and we want the latest version of each).

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-8943

## How was this patch tested?

Tests were updated accordingly.  However due to another bug, one of the test classes is entirely disabled: https://issues.apache.org/jira/browse/HDDS-8952

It will be reenabled once that ticket is addressed
