### PR TITLE
HDDS-8972. Bump ozone-runner to 20230615-1

### DIFF
--- a/hadoop-ozone/dist/pom.xml
+++ b/hadoop-ozone/dist/pom.xml
@@ -28,7 +28,7 @@
   <properties>
     <file.encoding>UTF-8</file.encoding>
     <downloadSources>true</downloadSources>
-    <docker.ozone-runner.version>20230503-1</docker.ozone-runner.version>
+    <docker.ozone-runner.version>20230615-1</docker.ozone-runner.version>
     <docker.ozone-testkr5b.image>apache/ozone-testkrb5:20230318-1</docker.ozone-testkr5b.image>
     <maven.test.skip>true</maven.test.skip> <!-- no tests in this module so far -->
   </properties>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Upgrade `ozone-runner` to latest `20230615-1`, contains changes for HDDS-8628 and HDDS-8843.

https://issues.apache.org/jira/browse/HDDS-8972

## How was this patch tested?

```
20230615-1: Pulling from apache/ozone-runner
Digest: sha256:46c59e4f69c94a8f886d621c9f1898fda8cc4d5de59059c6c74175ffa4718474
Status: Downloaded newer image for apache/ozone-runner:20230615-1
```

CI:
https://github.com/adoroszlai/hadoop-ozone/actions/runs/5438295046