### PR TITLE
HDDS-8880. Intermittent fork timeout in TestOMRatisSnapshots

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOMRatisSnapshots.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOMRatisSnapshots.java
@@ -50,12 +50,11 @@ import org.apache.ozone.test.GenericTestUtils;
 import org.apache.ozone.test.tag.Flaky;
 import org.apache.ratis.server.protocol.TermIndex;
 import org.assertj.core.api.Fail;
-import org.junit.Ignore;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
 import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -96,8 +95,6 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
  * Tests the Ratis snapshots feature in OM.
  */
 @Timeout(5000)
-@Flaky("HDDS-8876")
-@Disabled("HDDS-8880")
 public class TestOMRatisSnapshots {
 
   private MiniOzoneHAClusterImpl cluster = null;
@@ -127,7 +124,7 @@ public class TestOMRatisSnapshots {
    * @throws IOException
    */
   @BeforeEach
-  public void init() throws Exception {
+  public void init(TestInfo testInfo) throws Exception {
     conf = new OzoneConfiguration();
     clusterId = UUID.randomUUID().toString();
     scmId = UUID.randomUUID().toString();
@@ -137,9 +134,16 @@ public class TestOMRatisSnapshots {
         StorageUnit.KB);
     conf.setStorageSize(OMConfigKeys.
         OZONE_OM_RATIS_SEGMENT_PREALLOCATED_SIZE_KEY, 16, StorageUnit.KB);
+    long snapshotThreshold = SNAPSHOT_THRESHOLD;
+    // TODO: refactor tests to run under a new class with different configs.
+    if (testInfo.getTestMethod().isPresent() &&
+        testInfo.getTestMethod().get().getName()
+            .equals("testInstallSnapshot")) {
+      snapshotThreshold = SNAPSHOT_THRESHOLD * 10;
+    }
     conf.setLong(
         OMConfigKeys.OZONE_OM_RATIS_SNAPSHOT_AUTO_TRIGGER_THRESHOLD_KEY,
-        SNAPSHOT_THRESHOLD);
+        snapshotThreshold);
     cluster = (MiniOzoneHAClusterImpl) MiniOzoneCluster.newOMHABuilder(conf)
         .setClusterId(clusterId)
         .setScmId(scmId)
@@ -444,9 +448,15 @@ public class TestOMRatisSnapshots {
     // Read & Write after snapshot installed.
     List<String> newKeys = writeKeys(1);
     readKeys(newKeys);
-    assertNotNull(followerOMMetaMngr.getKeyTable(
-        TEST_BUCKET_LAYOUT).get(followerOMMetaMngr.getOzoneKey(
-        volumeName, bucketName, newKeys.get(0))));
+    GenericTestUtils.waitFor(() -> {
+      try {
+        return followerOMMetaMngr.getKeyTable(TEST_BUCKET_LAYOUT)
+            .get(followerOMMetaMngr.getOzoneKey(
+                volumeName, bucketName, newKeys.get(0))) != null;
+      } catch (IOException e) {
+        throw new RuntimeException(e);
+      }
+    }, 100, 10000);
 
     // Verify follower candidate directory get cleaned
     String[] filesInCandidate = followerOM.getOmSnapshotProvider().
@@ -550,6 +560,7 @@ public class TestOMRatisSnapshots {
 
   @Test
   @Timeout(300)
+  @Flaky("HDDS-8876")
   public void testInstallIncrementalSnapshotWithFailure() throws Exception {
     // Get the leader OM
     String leaderOMNodeId = OmFailoverProxyUtil
@@ -649,6 +660,11 @@ public class TestOMRatisSnapshots {
           .get(followerOMMetaMngr.getOzoneKey(volumeName, bucketName, key)));
     }
 
+    // There is a chance we end up checking the DBCheckpointMetrics
+    // before the follower sends another request to the leader
+    // to generate a checkpoint.
+    // TODO: Add wait check here, to avoid flakiness.
+
     // Verify the metrics
     DBCheckpointMetrics dbMetrics = leaderOM.getMetrics().
         getDBCheckpointMetrics();
@@ -664,9 +680,15 @@ public class TestOMRatisSnapshots {
     // Read & Write after snapshot installed.
     List<String> newKeys = writeKeys(1);
     readKeys(newKeys);
-    assertNotNull(followerOMMetaMngr.getKeyTable(
-        TEST_BUCKET_LAYOUT).get(followerOMMetaMngr.getOzoneKey(
-        volumeName, bucketName, newKeys.get(0))));
+    GenericTestUtils.waitFor(() -> {
+      try {
+        return followerOMMetaMngr.getKeyTable(TEST_BUCKET_LAYOUT)
+            .get(followerOMMetaMngr.getOzoneKey(
+                volumeName, bucketName, newKeys.get(0))) != null;
+      } catch (IOException e) {
+        throw new RuntimeException(e);
+      }
+    }, 100, 10000);
 
     // Verify follower candidate directory get cleaned
     String[] filesInCandidate = followerOM.getOmSnapshotProvider().
@@ -675,7 +697,7 @@ public class TestOMRatisSnapshots {
     assertEquals(0, filesInCandidate.length);
   }
 
-  @Ignore("Enable this unit test after RATIS-1481 used")
+  @Test
   public void testInstallSnapshotWithClientWrite() throws Exception {
     // Get the leader OM
     String leaderOMNodeId = OmFailoverProxyUtil


### PR DESCRIPTION
## What changes were proposed in this pull request?

This patch fixes issues with three methods running under `TestOMRatisSnapshots`. This class was 30% of the time resulting in a timeout due to the configuration setup.

The issue comes from the config key `ozone.om.ratis.snapshot.auto.trigger.threshold` which is referring to the number of unappended logs before triggering a snapshot installation. All tests under this class depend on frequent Ratis snapshot installations. 

#4770 Increased the number of writes performed by `testInstallSnapshot()` which in combination with the frequent Ratis snapshot installations led 30% of runs to a system freeze that caused a timeout. To fix the issue, only `testInstallSnapshot()` runs configured with a higher threshold number.

Furthermore, `testInstallIncrementalSnapshot` and `testInstallIncrementalSnapshotWithFailure` are installing a Ratis snapshot on the follower and then checking that the follower's key table has the keys from the Ratis snapshot. Sometimes this check is taking place sooner than expected making the methods flaky. By adding a wait check on reading the key table, the issue is fixed.

There is an existing issue with `testInstallIncrementalSnapshotWithFailure`, that hasn't been fixed. At some point we are expecting that there is a new checkpoint generated in the leader OM and we check the metrics to see if they are updated accordingly. Rarely, this doesn't happen and there is a failure. I added the `@Flaky` annotation above the method until I address the issue in [HDDS-8876](https://issues.apache.org/jira/browse/HDDS-8876).

This class is still flaky but I'm creating this PR to remove the `@Disabled` annotation and get this test class running along with the rest of the CI.

Should we add 
```
@Flaky("HDDS-8876")
```
above the class as well?

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-8880

https://issues.apache.org/jira/browse/HDDS-8952

## How was this patch tested?

CI on my fork: https://github.com/xBis7/ozone/actions/runs/5452838798

CI running `TestOMRatisSnapshot` in 100 iterations

https://github.com/xBis7/ozone/actions/runs/5447212761

https://github.com/xBis7/ozone/actions/runs/5447866879

https://github.com/xBis7/ozone/actions/runs/5447868491

We are getting a fork timeout in 1/100 or 2/100 runs.

https://github.com/xBis7/ozone/actions/runs/5447868491/jobs/9910384871#step:5:4472