### PR TITLE
HDDS-8964. Create a separate endpoint for summary for various SCM Insights and OM Insights.

### DIFF
--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/api/OMDBInsightEndpoint.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/api/OMDBInsightEndpoint.java
@@ -105,11 +105,6 @@ public class OMDBInsightEndpoint {
    * @return the http json response wrapped in below format:
    *
    * {
-   *   "keysSummary": {
-   *     "totalUnreplicatedDataSize": 2147483648,
-   *     "totalReplicatedDataSize": 2147483648,
-   *     "totalOpenKeys": 8
-   *   },
    *   "lastKey": "/-4611686018427388160/-9223372036854775552/-922777620354",
    *   "replicatedTotal": 2147483648,
    *   "unreplicatedTotal": 2147483648,

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/api/OMDBInsightEndpoint.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/api/OMDBInsightEndpoint.java
@@ -174,8 +174,6 @@ public class OMDBInsightEndpoint {
     List<KeyEntityInfo> nonFSOKeyInfoList =
         openKeyInsightInfo.getNonFSOKeyInfoList();
 
-    // Create a HashMap for the keysSummary
-    Map<String, Long> keysSummary = new HashMap<>();
     boolean skipPrevKeyDone = false;
     boolean isLegacyBucketLayout = true;
     boolean recordsFetchedLimitReached = false;
@@ -255,13 +253,37 @@ public class OMDBInsightEndpoint {
         break;
       }
     }
-    // Populate the keysSummary map
-    createKeysSummaryForOpenKey(keysSummary);
-
-    openKeyInsightInfo.setKeysSummary(keysSummary);
 
     openKeyInsightInfo.setLastKey(lastKey);
     return Response.ok(openKeyInsightInfo).build();
+  }
+
+  /**
+   * Retrieves the summary of open keys.
+   *
+   * This method calculates and returns a summary of open keys.
+   *
+   * @return The HTTP  response body includes a map with the following entries:
+   * - "totalOpenKeys": the total number of open keys
+   * - "totalReplicatedDataSize": the total replicated size for open keys
+   * - "totalUnreplicatedDataSize": the total unreplicated size for open keys
+   *
+   *
+   * Example response:
+   *   {
+   *    "totalOpenKeys": 8,
+   *    "totalReplicatedDataSize": 90000,
+   *    "totalUnreplicatedDataSize": 30000
+   *   }
+   */
+  @GET
+  @Path("/open/summary")
+  public Response getOpenKeySummary() {
+    // Create a HashMap for the keysSummary
+    Map<String, Long> keysSummary = new HashMap<>();
+    // Create a keys summary for open keys
+    createKeysSummaryForOpenKey(keysSummary);
+    return Response.ok(keysSummary).build();
   }
 
   /**
@@ -310,8 +332,6 @@ public class OMDBInsightEndpoint {
         deletedKeyAndDirInsightInfo.getRepeatedOmKeyInfoList();
     Table<String, RepeatedOmKeyInfo> deletedTable =
         omMetadataManager.getDeletedTable();
-    // Create a HashMap for the keysSummary
-    Map<String, Long> keysSummary = new HashMap<>();
     try (
         TableIterator<String, ? extends Table.KeyValue<String,
             RepeatedOmKeyInfo>>
@@ -348,10 +368,6 @@ public class OMDBInsightEndpoint {
           break;
         }
       }
-      // Create the keysSummary for deleted keys
-      createKeysSummaryForDeletedKey(keysSummary);
-      // Set the keysSummary and lastKey in the response
-      deletedKeyAndDirInsightInfo.setKeysSummary(keysSummary);
       deletedKeyAndDirInsightInfo.setLastKey(lastKey);
     } catch (IOException ex) {
       throw new WebApplicationException(ex,
@@ -362,6 +378,33 @@ public class OMDBInsightEndpoint {
       throw new WebApplicationException(ex,
           Response.Status.INTERNAL_SERVER_ERROR);
     }
+  }
+
+  /** Retrieves the summary of deleted keys.
+   *
+   * This method calculates and returns a summary of deleted keys.
+   *
+   * @return The HTTP  response body includes a map with the following entries:
+   * - "totalDeletedKeys": the total number of deleted keys
+   * - "totalReplicatedDataSize": the total replicated size for deleted keys
+   * - "totalUnreplicatedDataSize": the total unreplicated size for deleted keys
+   *
+   *
+   * Example response:
+   *   {
+   *    "totalDeletedKeys": 8,
+   *    "totalReplicatedDataSize": 90000,
+   *    "totalUnreplicatedDataSize": 30000
+   *   }
+   */
+  @GET
+  @Path("/deletePending/summary")
+  public Response getDeletedKeySummary() {
+    // Create a HashMap for the keysSummary
+    Map<String, Long> keysSummary = new HashMap<>();
+    // Create a keys summary for deleted keys
+    createKeysSummaryForDeletedKey(keysSummary);
+    return Response.ok(keysSummary).build();
   }
 
   /**

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/api/types/KeyInsightInfoResponse.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/api/types/KeyInsightInfoResponse.java
@@ -23,18 +23,12 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import org.apache.hadoop.ozone.om.helpers.RepeatedOmKeyInfo;
 
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 
 /**
  * HTTP Response wrapped for keys insights.
  */
 public class KeyInsightInfoResponse {
-
-  /** Keys summary. Includes aggregated information about the keys. */
-  @JsonProperty("keysSummary")
-  private Map<String, Long> keysSummary;
 
   /** last key sent. */
   @JsonProperty("lastKey")
@@ -81,15 +75,6 @@ public class KeyInsightInfoResponse {
     fsoKeyInfoList = new ArrayList<>();
     repeatedOmKeyInfoList = new ArrayList<>();
     deletedDirInfoList = new ArrayList<>();
-    keysSummary = new HashMap<>();
-  }
-
-  public Map<String, Long> getKeysSummary() {
-    return keysSummary;
-  }
-
-  public void setKeysSummary(Map<String, Long> keysSummary) {
-    this.keysSummary = keysSummary;
   }
 
   public String getLastKey() {

--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/api/routes.json
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/api/routes.json
@@ -29,8 +29,8 @@
   "/heatmap/readaccess?startDate=*&path=*&entityType=key": "/keyHeatmap",
   "/heatmap/readaccess?startDate=*&path=*&entityType=volume": "/heatmap",
   "/features/disabledFeatures": "/disabledFeatures",
-  "/keys/open?limit=0": "/keysOpenSummary",
-  "/keys/deletePending?limit=1": "/keysdeletePendingSummary",
+  "/keys/open/summary": "/keysOpenSummary",
+  "/keys/deletePending/summary": "/keysdeletePendingSummary",
 
   "/containers/mismatch?limit=*&prevKey=11&missingIn=OM" : "/omMismatch1",
   "/containers/mismatch?limit=*&prevKey=21&missingIn=OM" : "/omMismatch2",

--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/views/overview/overview.tsx
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/views/overview/overview.tsx
@@ -114,8 +114,8 @@ export class Overview extends React.Component<Record<string, object>, IOverviewS
     axios.all([
       axios.get('/api/v1/clusterState'),
       axios.get('/api/v1/task/status'),
-      axios.get('/api/v1/keys/open?limit=0'),
-      axios.get('/api/v1/keys/deletePending?limit=1'),
+      axios.get('/api/v1/keys/open/summary'),
+      axios.get('/api/v1/keys/deletePending/summary'),
     ]).then(axios.spread((clusterStateResponse, taskstatusResponse, openResponse, deletePendingResponse) => {
       
       const clusterState: IClusterStateResponse = clusterStateResponse.data;
@@ -140,12 +140,12 @@ export class Overview extends React.Component<Record<string, object>, IOverviewS
         lastRefreshed: Number(moment()),
         lastUpdatedOMDBDelta: omDBDeltaObject && omDBDeltaObject.lastUpdatedTimestamp,
         lastUpdatedOMDBFull: omDBFullObject && omDBFullObject.lastUpdatedTimestamp,
-        openSummarytotalUnrepSize: openResponse.data && openResponse.data.keysSummary && openResponse.data.keysSummary.totalUnreplicatedDataSize,
-        openSummarytotalRepSize: openResponse.data && openResponse.data.keysSummary && openResponse.data.keysSummary.totalReplicatedDataSize,
-        openSummarytotalOpenKeys: openResponse.data && openResponse.data.keysSummary && openResponse.data.keysSummary.totalOpenKeys,
-        deletePendingSummarytotalUnrepSize: deletePendingResponse.data && deletePendingResponse.data.keysSummary && deletePendingResponse.data.keysSummary.totalUnreplicatedDataSize,
-        deletePendingSummarytotalRepSize: deletePendingResponse.data && deletePendingResponse.data.keysSummary && deletePendingResponse.data.keysSummary.totalReplicatedDataSize,
-        deletePendingSummarytotalDeletedKeys: deletePendingResponse.data && deletePendingResponse.data.keysSummary && deletePendingResponse.data.keysSummary.totalDeletedKeys
+        openSummarytotalUnrepSize: openResponse.data  && openResponse.data.totalUnreplicatedDataSize,
+        openSummarytotalRepSize: openResponse.data && openResponse.data.totalReplicatedDataSize,
+        openSummarytotalOpenKeys: openResponse.data && openResponse.data.totalOpenKeys,
+        deletePendingSummarytotalUnrepSize: deletePendingResponse.data && deletePendingResponse.data.totalUnreplicatedDataSize,
+        deletePendingSummarytotalRepSize: deletePendingResponse.data && deletePendingResponse.data.totalReplicatedDataSize,
+        deletePendingSummarytotalDeletedKeys: deletePendingResponse.data && deletePendingResponse.data.totalDeletedKeys
       });
     })).catch(error => {
       this.setState({

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/api/TestOmDBInsightEndPoint.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/api/TestOmDBInsightEndPoint.java
@@ -241,25 +241,33 @@ public class TestOmDBInsightEndPoint extends AbstractReconSqlDBTest {
 
     // Call the API of Open keys to get the response
     Response openKeyInfoResp =
-        omdbInsightEndpoint.getOpenKeyInfo(-1, "", true, true);
-    KeyInsightInfoResponse keyInsightInfoResp =
-        (KeyInsightInfoResponse) openKeyInfoResp.getEntity();
-    Assertions.assertNotNull(keyInsightInfoResp);
-    Map<String, Long> summary = keyInsightInfoResp.getKeysSummary();
-    Assertions.assertEquals(60L, summary.get("totalReplicatedDataSize"));
-    Assertions.assertEquals(20L, summary.get("totalUnreplicatedDataSize"));
-    Assertions.assertEquals(6L, summary.get("totalOpenKeys"));
+        omdbInsightEndpoint.getOpenKeySummary();
+    Assertions.assertNotNull(openKeyInfoResp);
+
+    Map<String, Long> openKeysSummary =
+        (Map<String, Long>) openKeyInfoResp.getEntity();
+
+    Assertions.assertEquals(60L,
+        openKeysSummary.get("totalReplicatedDataSize"));
+    Assertions.assertEquals(20L,
+        openKeysSummary.get("totalUnreplicatedDataSize"));
+    Assertions.assertEquals(6L,
+        openKeysSummary.get("totalOpenKeys"));
 
     // Call the API of Deleted keys to get the response
     Response deletedKeyInfoResp =
-        omdbInsightEndpoint.getDeletedKeyInfo(-1, "");
-    keyInsightInfoResp =
-        (KeyInsightInfoResponse) deletedKeyInfoResp.getEntity();
-    Assertions.assertNotNull(keyInsightInfoResp);
-    summary = keyInsightInfoResp.getKeysSummary();
-    Assertions.assertEquals(30L, summary.get("totalReplicatedDataSize"));
-    Assertions.assertEquals(10L, summary.get("totalUnreplicatedDataSize"));
-    Assertions.assertEquals(3L, summary.get("totalDeletedKeys"));
+        omdbInsightEndpoint.getDeletedKeySummary();
+    Assertions.assertNotNull(deletedKeyInfoResp);
+
+    Map<String, Long> deletedKeysSummary = (Map<String, Long>)
+        deletedKeyInfoResp.getEntity();
+
+    Assertions.assertEquals(30L,
+        deletedKeysSummary.get("totalReplicatedDataSize"));
+    Assertions.assertEquals(10L,
+        deletedKeysSummary.get("totalUnreplicatedDataSize"));
+    Assertions.assertEquals(3L,
+        deletedKeysSummary.get("totalDeletedKeys"));
   }
 
   @Test


### PR DESCRIPTION
## What changes were proposed in this pull request?
In summary, this patch introduces separate API endpoints for retrieving summarized information about open keys and deleted keys in Hadoop Ozone Recon. These summaries provide aggregated statistics and high-level information about the keys' status and data sizes.
Changes made :- 
- `OMDBInsightEndpoint.java` : This file adds two new API endpoints: `/open/summary` and `/deletePending/summary`. These endpoints retrieve summaries of open keys and deleted keys, providing aggregated information like total key count, replicated data size, and unreplicated data size.
- `KeyInsightInfoResponse.java` : This Response class no longer includes the `keysSummary` field, as the keys' summary information is now included directly in the response body of the API endpoints.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-8964

## How was this patch tested?

Ran the Existing UT's and also tested manually 

<img width="428" alt="image" src="https://github.com/apache/ozone/assets/98023601/80525c3d-38ae-4741-b0f0-32887ea4b4ad">
<img width="510" alt="image" src="https://github.com/apache/ozone/assets/98023601/4cd430d0-dbf0-4418-bff6-dce51797ffe3">
