### PR TITLE
HDDS-8979. error validating kustomization.yaml

### DIFF
--- a/hadoop-ozone/dist/src/main/k8s/examples/testlib.sh
+++ b/hadoop-ozone/dist/src/main/k8s/examples/testlib.sh
@@ -76,7 +76,7 @@ start_k8s_env() {
    kubectl delete pv --all
 
    print_phase "Applying k8s resources from $(basename $(pwd))"
-   kubectl apply -f .
+   kubectl apply -k .
    wait_for_startup
 }
 
@@ -92,7 +92,7 @@ get_logs() {
 
 stop_k8s_env() {
    if [ ! "$KEEP_RUNNING" ]; then
-     kubectl delete -f .
+     kubectl delete -k .
    fi
 }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Use `kubectl apply -k` instead of `-f` to get rid of error:

```
error: error validating "kustomization.yaml": error validating data: [apiVersion not set, kind not set]; if you choose to ignore these errors, turn validation off with --validate=false
```

(with `--validate=false` some other similar error is shown...)

https://github.com/apache/ozone/actions/runs/5463225307/jobs/9944167392#step:5:126

https://issues.apache.org/jira/browse/HDDS-8979

## How was this patch tested?

Verified output no longer shows this error:
https://github.com/adoroszlai/hadoop-ozone/actions/runs/5465403252/jobs/9949414579#step:5:111