### PR TITLE
HDDS-8592. Fetch and save all root certificates during service's certificate rotation.

### DIFF
--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/TestHddsSecureDatanodeInit.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/TestHddsSecureDatanodeInit.java
@@ -25,6 +25,8 @@ import java.security.PublicKey;
 import java.security.cert.CertificateExpiredException;
 import java.time.Duration;
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.concurrent.Callable;
 
 import org.apache.hadoop.fs.FileUtil;
@@ -316,6 +318,9 @@ public class TestHddsSecureDatanodeInit {
     when(scmClient.getDataNodeCertificateChain(anyObject(), anyString()))
         .thenReturn(responseProto);
 
+    List<String> rootCaList = new ArrayList<>();
+    rootCaList.add(pemCert);
+    when(scmClient.getAllRootCaCertificates()).thenReturn(rootCaList);
     // check that new cert ID should not equal to current cert ID
     String certId = newCertHolder.getSerialNumber().toString();
     Assert.assertFalse(certId.equals(
@@ -338,6 +343,7 @@ public class TestHddsSecureDatanodeInit {
     // test the second time certificate rotation, generate a new cert
     newCertHolder = generateX509CertHolder(null, null,
         Duration.ofSeconds(CERT_LIFETIME));
+    rootCaList.remove(pemCert);
     pemCert = CertificateCodec.getPEMEncodedString(newCertHolder);
     responseProto = SCMSecurityProtocolProtos.SCMGetCertResponseProto
         .newBuilder().setResponseCode(SCMSecurityProtocolProtos
@@ -348,6 +354,8 @@ public class TestHddsSecureDatanodeInit {
         .build();
     when(scmClient.getDataNodeCertificateChain(anyObject(), anyString()))
         .thenReturn(responseProto);
+    rootCaList.add(pemCert);
+    when(scmClient.getAllRootCaCertificates()).thenReturn(rootCaList);
     String certId2 = newCertHolder.getSerialNumber().toString();
 
     // check after renew, client will have the new cert ID

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/security/x509/certificate/client/DefaultCertificateClient.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/security/x509/certificate/client/DefaultCertificateClient.java
@@ -21,6 +21,7 @@ package org.apache.hadoop.hdds.security.x509.certificate.client;
 
 import java.io.File;
 import java.io.IOException;
+import java.math.BigInteger;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -228,15 +229,17 @@ public abstract class DefaultCertificateClient implements CertificateClient {
   }
 
   private synchronized void updateCachedRootCAId(String s) {
+    BigInteger candidateNewId = new BigInteger(s);
     if (rootCaCertId == null
-        || Long.parseLong(s) > Long.parseLong(rootCaCertId)) {
+        || new BigInteger(rootCaCertId).compareTo(candidateNewId) < 0) {
       rootCaCertId = s;
     }
   }
 
   private synchronized void updateCachedSubCAId(String s) {
+    BigInteger candidateNewId = new BigInteger(s);
     if (caCertId == null
-        || Long.parseLong(s) > Long.parseLong(caCertId)) {
+        || new BigInteger(caCertId).compareTo(candidateNewId) < 0) {
       caCertId = s;
     }
   }

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/security/x509/certificate/client/DefaultCertificateClient.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/security/x509/certificate/client/DefaultCertificateClient.java
@@ -1258,9 +1258,8 @@ public abstract class DefaultCertificateClient implements CertificateClient {
 
         getAndStoreAllRootCAs(certCodec, renew);
         // Return the default certificate ID
-        return updateCertSerialId(CertificateCodec.getX509Certificate(pemEncodedCert)
-            .getSerialNumber()
-            .toString());
+        return updateCertSerialId(CertificateCodec
+            .getX509Certificate(pemEncodedCert).getSerialNumber().toString());
       } else {
         throw new CertificateException("Unable to retrieve " +
             "certificate chain.");

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/security/x509/certificate/client/DefaultCertificateClient.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/security/x509/certificate/client/DefaultCertificateClient.java
@@ -1268,7 +1268,7 @@ public abstract class DefaultCertificateClient implements CertificateClient {
               getComponentName() + "-CertificateLifetimeMonitor")
               .setDaemon(true).build());
     }
-    this.executorService.scheduleAtFixedRate(new CertificateLifetimeMonitor(),
+    this.executorService.scheduleAtFixedRate(new CertificateRenewerService(),
         timeBeforeGracePeriod, interval, TimeUnit.MILLISECONDS);
     getLogger().info("CertificateLifetimeMonitor for {} is started with " +
             "first delay {} ms and interval {} ms.", component,
@@ -1278,9 +1278,9 @@ public abstract class DefaultCertificateClient implements CertificateClient {
   /**
    *  Task to monitor certificate lifetime and renew the certificate if needed.
    */
-  public class CertificateLifetimeMonitor implements Runnable {
+  public class CertificateRenewerService implements Runnable {
 
-    public CertificateLifetimeMonitor() {
+    public CertificateRenewerService() {
     }
 
     @Override

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/security/x509/certificate/client/SCMCertificateClient.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/security/x509/certificate/client/SCMCertificateClient.java
@@ -18,10 +18,10 @@
 
 package org.apache.hadoop.hdds.security.x509.certificate.client;
 
+import org.apache.hadoop.hdds.protocol.proto.SCMSecurityProtocolProtos.SCMGetCertResponseProto;
 import org.apache.hadoop.hdds.protocolPB.SCMSecurityProtocolClientSideTranslatorPB;
 import org.apache.hadoop.hdds.security.SecurityConfig;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
-import org.apache.hadoop.hdds.protocol.proto.SCMSecurityProtocolProtos;
 import org.apache.hadoop.hdds.security.x509.certificate.authority.CAType;
 import org.apache.hadoop.hdds.security.x509.certificate.utils.CertificateCodec;
 import org.apache.hadoop.hdds.security.x509.certificate.utils.CertificateSignRequest;
@@ -183,6 +183,13 @@ public class SCMCertificateClient extends DefaultCertificateClient {
   }
 
   @Override
+  protected SCMGetCertResponseProto getCertificateSignResponse(
+      PKCS10CertificationRequest request) {
+    throw new UnsupportedOperationException("getCertSignResponse of " +
+        " SCMCertificateClient is not supported currently");
+  }
+
+  @Override
   public String signAndStoreCertificate(PKCS10CertificationRequest request,
       Path certPath, boolean renew) throws CertificateException {
     try {
@@ -193,7 +200,7 @@ public class SCMCertificateClient extends DefaultCertificateClient {
               .setScmNodeId(scmId).build();
 
       // Get SCM sub CA cert.
-      SCMSecurityProtocolProtos.SCMGetCertResponseProto response =
+      SCMGetCertResponseProto response =
           getScmSecureClient().getSCMCertChain(scmNodeDetailsProto,
               getEncodedString(request), true);
 

--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/security/x509/certificate/client/TestDefaultCertificateClient.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/security/x509/certificate/client/TestDefaultCertificateClient.java
@@ -20,7 +20,7 @@ package org.apache.hadoop.hdds.security.x509.certificate.client;
 
 import org.apache.hadoop.hdds.HddsConfigKeys;
 import org.apache.hadoop.hdds.protocol.MockDatanodeDetails;
-import org.apache.hadoop.hdds.protocol.proto.SCMSecurityProtocolProtos;
+import org.apache.hadoop.hdds.protocol.proto.SCMSecurityProtocolProtos.SCMGetCertResponseProto;
 import org.apache.hadoop.hdds.protocolPB.SCMSecurityProtocolClientSideTranslatorPB;
 import org.apache.hadoop.hdds.security.x509.certificate.authority.CAType;
 import org.apache.hadoop.hdds.security.x509.certificate.client.CertificateClient.InitResponse;
@@ -490,9 +490,15 @@ public class TestDefaultCertificateClient {
           }
 
           @Override
+          protected SCMGetCertResponseProto getCertificateSignResponse(
+              PKCS10CertificationRequest request) {
+            return null;
+          }
+
+          @Override
           public String signAndStoreCertificate(
               PKCS10CertificationRequest request, Path certificatePath,
-              boolean renew) throws CertificateException {
+              boolean renew) {
             return null;
           }
         }) {
@@ -536,10 +542,11 @@ public class TestDefaultCertificateClient {
 
     X509Certificate newCert = generateX509Cert(null);
     String pemCert = CertificateCodec.getPEMEncodedString(newCert);
-    SCMSecurityProtocolProtos.SCMGetCertResponseProto responseProto =
-        SCMSecurityProtocolProtos.SCMGetCertResponseProto
-            .newBuilder().setResponseCode(SCMSecurityProtocolProtos
-                .SCMGetCertResponseProto.ResponseCode.success)
+    SCMGetCertResponseProto responseProto =
+        SCMGetCertResponseProto
+            .newBuilder().setResponseCode(
+                SCMGetCertResponseProto
+                    .ResponseCode.success)
             .setX509Certificate(pemCert)
             .setX509CACertificate(pemCert)
             .build();
@@ -632,9 +639,15 @@ public class TestDefaultCertificateClient {
       }
 
       @Override
+      protected SCMGetCertResponseProto getCertificateSignResponse(
+          PKCS10CertificationRequest request) {
+        return null;
+      }
+
+      @Override
       protected String signAndStoreCertificate(
           PKCS10CertificationRequest request, Path certificatePath,
-          boolean renew) throws CertificateException {
+          boolean renew) {
         return null;
       }
     };


### PR DESCRIPTION
What changes were proposed in this pull request?

This is a redone version of an approved draft pr: https://github.com/apache/ozone/pull/5000 
The reason for the redo is to clean up the commit history and make sure that the rebase process was done cleanly.
Unfortunately I lost the original changes in that pull request due to a personal error and had to use changes saved in 
https://github.com/apache/ozone/pull/5001 
But during the process of taking commits from that pull request I realized that the conflicts and the number of commits makes it more complicated than rewriting it from scratch. Sorry for the inconvenience.

Orig description:
After the SCMs finished their part of root ca rotation the clients also need to get the new root CA certificate. This is done through a simple polling mechanism that asks the SCMs for the root CAs and once it observes a change it invokes a consumer from the clients to notify them. Integrating this change is going to be done in later items.

What is the link to the Apache JIRA

[HDDS-8592](https://issues.apache.org/jira/browse/HDDS-8592)

How was this patch tested?

Added unit tests. Functional change is not yet observed in this patch as the polling is not actually integrated into anything yet.
