### PR TITLE
HDDS-7645. Kubernetes check should fail fast if cluster cannot start

### DIFF
--- a/hadoop-ozone/dist/src/main/k8s/examples/getting-started/test.sh
+++ b/hadoop-ozone/dist/src/main/k8s/examples/getting-started/test.sh
@@ -15,6 +15,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+set -eu -o pipefail
+
 export K8S_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 
 cd "$K8S_DIR"
@@ -22,18 +24,6 @@ cd "$K8S_DIR"
 # shellcheck source=/dev/null
 source "../testlib.sh"
 
-rm -rf result
-
-regenerate_resources
-
-start_k8s_env
+pre_run_setup
 
 execute_robot_test scm-0 smoketest/basic/basic.robot
-
-combine_reports
-
-get_logs
-
-stop_k8s_env
-
-revert_resources

--- a/hadoop-ozone/dist/src/main/k8s/examples/minikube/test.sh
+++ b/hadoop-ozone/dist/src/main/k8s/examples/minikube/test.sh
@@ -15,6 +15,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+set -eu -o pipefail
+
 export K8S_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 
 cd "$K8S_DIR"
@@ -22,18 +24,6 @@ cd "$K8S_DIR"
 # shellcheck source=/dev/null
 source "../testlib.sh"
 
-rm -rf result
-
-regenerate_resources
-
-start_k8s_env
+pre_run_setup
 
 execute_robot_test scm-0 smoketest/basic/basic.robot
-
-combine_reports
-
-get_logs
-
-stop_k8s_env
-
-revert_resources

--- a/hadoop-ozone/dist/src/main/k8s/examples/ozone-dev/test.sh
+++ b/hadoop-ozone/dist/src/main/k8s/examples/ozone-dev/test.sh
@@ -15,6 +15,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+set -eu -o pipefail
+
 export K8S_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 
 cd "$K8S_DIR"
@@ -22,18 +24,6 @@ cd "$K8S_DIR"
 # shellcheck source=/dev/null
 source "../testlib.sh"
 
-rm -rf result
-
-regenerate_resources
-
-start_k8s_env
+pre_run_setup
 
 execute_robot_test scm-0 smoketest/basic/basic.robot
-
-combine_reports
-
-get_logs
-
-stop_k8s_env
-
-revert_resources

--- a/hadoop-ozone/dist/src/main/k8s/examples/ozone/test.sh
+++ b/hadoop-ozone/dist/src/main/k8s/examples/ozone/test.sh
@@ -15,6 +15,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+set -eu -o pipefail
+
 export K8S_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 
 cd "$K8S_DIR"
@@ -22,11 +24,7 @@ cd "$K8S_DIR"
 # shellcheck source=/dev/null
 source "../testlib.sh"
 
-rm -rf result
-
-regenerate_resources
-
-start_k8s_env
+pre_run_setup
 
 export SCM=scm-0
 
@@ -41,11 +39,3 @@ wait_for_startup
 execute_robot_test ${SCM} -v PREFIX:pre smoketest/freon/validate.robot
 execute_robot_test ${SCM} -v PREFIX:post smoketest/freon/generate.robot
 execute_robot_test ${SCM} -v PREFIX:post smoketest/freon/validate.robot
-
-combine_reports
-
-get_logs
-
-stop_k8s_env
-
-revert_resources

--- a/hadoop-ozone/dist/src/main/k8s/examples/testlib.sh
+++ b/hadoop-ozone/dist/src/main/k8s/examples/testlib.sh
@@ -62,7 +62,15 @@ all_pods_are_running() {
    fi
 }
 
-start_k8s_env() {
+pre_run_setup() {
+  rm -fr logs result
+  regenerate_resources
+  reset_k8s_env
+  start_k8s_env
+  wait_for_startup
+}
+
+reset_k8s_env() {
    print_phase "Deleting existing k8s resources"
    #reset environment
    kubectl delete statefulset --all
@@ -73,13 +81,25 @@ start_k8s_env() {
    kubectl delete pod --all
    kubectl delete pvc --all
    kubectl delete pv --all
+}
 
+start_k8s_env() {
    print_phase "Applying k8s resources from $(basename $(pwd))"
    kubectl apply -k .
-   wait_for_startup
+   trap post_run EXIT HUP INT TERM
+}
+
+post_run() {
+  set +e
+  combine_reports
+  get_logs
+  stop_k8s_env
+  revert_resources
+  set -e
 }
 
 get_logs() {
+  print_phase "Collecting container logs"
   mkdir -p logs
   for pod in $(kubectl get pods -o custom-columns=NAME:.metadata.name | tail -n +2); do
     for initContainer in $(kubectl get pod -o jsonpath='{.spec.initContainers[*].name}' "${pod}"); do
@@ -90,7 +110,8 @@ get_logs() {
 }
 
 stop_k8s_env() {
-   if [ ! "$KEEP_RUNNING" ]; then
+   if [ "${KEEP_RUNNING:-false}" != "true" ]; then
+     print_phase "Deleting k8s resources"
      kubectl delete -k .
    fi
 }
@@ -144,8 +165,10 @@ execute_robot_test() {
 }
 
 combine_reports() {
-  rm result/output.xml || true
-  rebot -d result --nostatusrc -o output.xml -N $(basename "$(pwd)") result/*.xml
+  if [[ -d result ]]; then
+    rm -f result/output.xml
+    rebot -d result --nostatusrc -o output.xml -N $(basename "$(pwd)") result/*.xml
+  fi
 }
 
 print_phase() {

--- a/hadoop-ozone/dist/src/main/k8s/examples/testlib.sh
+++ b/hadoop-ozone/dist/src/main/k8s/examples/testlib.sh
@@ -16,15 +16,16 @@
 # limitations under the License.
 
 retry() {
-   n=0
-   until [ $n -ge 100 ]
+   local -i n=0
+   local -i attempts=${RETRY_ATTEMPTS:-100}
+   until [ $n -ge $attempts ]
    do
       "$@" && break
       n=$[$n+1]
       echo "$n '$@' is failed..."
       sleep ${RETRY_SLEEP:-3}
    done
-   if [ $n -eq 100 ]; then
+   if [ $n -eq $attempts ]; then
       return 255
    fi
 }

--- a/hadoop-ozone/dist/src/main/k8s/examples/testlib.sh
+++ b/hadoop-ozone/dist/src/main/k8s/examples/testlib.sh
@@ -54,7 +54,7 @@ all_pods_are_running() {
       echo "$running pods are running. Waiting for more."
       return 1
    elif [ "$running" -ne "$all" ]; then
-      echo "$running pods are running out from the $all"
+      echo "$running / $all pods are running"
       return 2
    else
       STARTED=true

--- a/hadoop-ozone/dist/src/main/k8s/examples/testlib.sh
+++ b/hadoop-ozone/dist/src/main/k8s/examples/testlib.sh
@@ -47,15 +47,13 @@ wait_for_startup(){
 }
 
 all_pods_are_running() {
-   RUNNING_COUNT=$(kubectl get pod --field-selector status.phase=Running | wc -l)
-   ALL_COUNT=$(kubectl get pod | wc -l)
-   RUNNING_COUNT=$((RUNNING_COUNT - 1))
-   ALL_COUNT=$((ALL_COUNT - 1))
-   if [ "$RUNNING_COUNT" -lt "3" ]; then
-      echo "$RUNNING_COUNT pods are running. Waiting for more."
+   local -i running=$(kubectl get pod --field-selector status.phase=Running | grep -v 'STATUS' | wc -l)
+   local -i all=$(kubectl get pod | grep -v 'STATUS' | wc -l)
+   if [ "$running" -lt "3" ]; then
+      echo "$running pods are running. Waiting for more."
       return 1
-   elif [ "$RUNNING_COUNT" -ne "$ALL_COUNT" ]; then
-      echo "$RUNNING_COUNT pods are running out from the $ALL_COUNT"
+   elif [ "$running" -ne "$all" ]; then
+      echo "$running pods are running out from the $all"
       return 2
    else
       STARTED=true


### PR DESCRIPTION
## What changes were proposed in this pull request?

Kubernetes check currently proceeds to execute tests even if cluster is not able to start up.  It should exit without trying to run the tests.

```
**** Waiting until the k8s cluster is running ****

...
4 pods are running out from the 5
100 'all_pods_are_running' is failed...

**** Executing robot tests scm-0 ****

Defaulted container "scm" out of: scm, init (init)
Unable to use a TTY - input is not a terminal or the right kind of file
error: unable to upgrade connection: container not found ("scm")
```

This change skips the tests if cluster fails to start up.

Also:
 * Fix `-1 pods are running` message (due to hard-coded subtraction intended to account for the header row of `kubectl get pod`'s output)
 * Allow custom number of retry attempts (for easier testing)
 * Reduce code duplication in test scripts

https://issues.apache.org/jira/browse/HDDS-7645

## How was this patch tested?

Triggered cluster startup "error" by setting low number of retry attempts.  Verified tests are not attempted, logs are collected, cluster is shut down:

```
$ RETRY_ATTEMPTS=5 OZONE_TEST_SELECTOR=getting-started ./hadoop-ozone/dev-support/checks/kubernetes.sh
...

**** Applying k8s resources from getting-started ****

...

**** Waiting until the k8s cluster is running ****

No resources found in default namespace.
0 pods are running. Waiting for more.
1 'all_pods_are_running' is failed...
3 pods are running out from the 5
2 'all_pods_are_running' is failed...
5 pods are running out from the 6
3 'all_pods_are_running' is failed...
1 'grep_log scm-0 SCM exiting safe mode.' is failed...
2 'grep_log scm-0 SCM exiting safe mode.' is failed...
3 'grep_log scm-0 SCM exiting safe mode.' is failed...
4 'grep_log scm-0 SCM exiting safe mode.' is failed...
5 'grep_log scm-0 SCM exiting safe mode.' is failed...

**** Collecting container logs ****


**** Deleting k8s resources ****

configmap "config" deleted
service "datanode" deleted
service "datanode-public" deleted
service "om" deleted
service "om-public" deleted
service "s3g" deleted
service "s3g-public" deleted
service "scm" deleted
service "scm-public" deleted
statefulset.apps "datanode" deleted
statefulset.apps "om" deleted
statefulset.apps "s3g" deleted
statefulset.apps "scm" deleted

$ ls -1 hadoop-ozone/dist/target/ozone-1.4.0-SNAPSHOT/kubernetes/examples/getting-started/logs
pod-datanode-0.log
pod-datanode-1.log
pod-datanode-2.log
pod-om-0.log
pod-s3g-0.log
pod-scm-0-init.log
pod-scm-0.log
```

With even fewer retries:

```
$ RETRY_ATTEMPTS=2 OZONE_TEST_SELECTOR=getting-started ./hadoop-ozone/dev-support/checks/kubernetes.sh  
...

**** Waiting until the k8s cluster is running ****

No resources found in default namespace.
0 pods are running. Waiting for more.
1 'all_pods_are_running' is failed...
3 pods are running out from the 5
2 'all_pods_are_running' is failed...

**** Collecting container logs ****

...
```

Regular CI:
https://github.com/adoroszlai/hadoop-ozone/actions/runs/5472252928