### PR TITLE
HDDS-8981. TestRootedOzoneFileSystem runs out of disk space

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestRootedOzoneFileSystem.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestRootedOzoneFileSystem.java
@@ -30,8 +30,6 @@ import org.apache.hadoop.fs.InvalidPathException;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.PathIsNotEmptyDirectoryException;
 import org.apache.hadoop.fs.RemoteIterator;
-import org.apache.hadoop.fs.SafeMode;
-import org.apache.hadoop.fs.SafeModeAction;
 import org.apache.hadoop.fs.StreamCapabilities;
 import org.apache.hadoop.fs.Trash;
 import org.apache.hadoop.fs.TrashPolicy;
@@ -79,7 +77,6 @@ import org.junit.After;
 import org.junit.Assert;
 import org.junit.Assume;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.Timeout;
@@ -2549,19 +2546,4 @@ public class TestRootedOzoneFileSystem {
     Assert.assertEquals(mtime, fileStatus.getModificationTime());
   }
 
-  @Test
-  @Ignore("HDDS-8981")
-  public void testSafeMode() throws Exception {
-    SafeMode safeModeFS = (SafeMode) fs;
-    // safe mode is off
-    assertFalse(safeModeFS.setSafeMode(SafeModeAction.GET));
-    // shutdown datanodes and restart SCM
-    cluster.shutdownHddsDatanodes();
-    cluster.restartStorageContainerManager(false);
-    // SCM should be in safe mode
-    assertTrue(safeModeFS.setSafeMode(SafeModeAction.GET));
-    // force exit safe mode and verify that it's out of safe mode.
-    safeModeFS.setSafeMode(SafeModeAction.FORCE_EXIT);
-    assertFalse(safeModeFS.setSafeMode(SafeModeAction.GET));
-  }
 }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestSafeMode.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestSafeMode.java
@@ -1,0 +1,132 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.fs.ozone;
+
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.SafeMode;
+import org.apache.hadoop.fs.SafeModeAction;
+import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import org.apache.hadoop.hdds.utils.IOUtils;
+import org.apache.hadoop.ozone.MiniOzoneCluster;
+import org.apache.hadoop.ozone.MiniOzoneClusterProvider;
+import org.apache.hadoop.ozone.client.OzoneClient;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.net.URI;
+import java.util.function.Function;
+
+import static org.apache.hadoop.ozone.OzoneConsts.OZONE_OFS_URI_SCHEME;
+import static org.apache.hadoop.ozone.OzoneConsts.OZONE_URI_SCHEME;
+import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_ADDRESS_KEY;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class TestSafeMode {
+
+  private static final String VOLUME = "vol";
+  private static final String BUCKET = "bucket";
+  private static MiniOzoneClusterProvider clusterProvider;
+
+  private MiniOzoneCluster cluster;
+
+  @BeforeAll
+  static void setup() {
+    OzoneConfiguration conf = new OzoneConfiguration();
+    clusterProvider = new MiniOzoneClusterProvider(
+        conf, MiniOzoneCluster.newBuilder(conf), 2);
+  }
+
+  @BeforeEach
+  void createCluster() throws Exception {
+    cluster = clusterProvider.provide();
+    cluster.waitForClusterToBeReady();
+    try (OzoneClient client = cluster.newClient()) {
+      client.getObjectStore().createVolume(VOLUME);
+      client.getObjectStore().getVolume(VOLUME).createBucket(BUCKET);
+    }
+  }
+
+  @AfterEach
+  void shutdownCluster() {
+    if (cluster != null) {
+      cluster.shutdown();
+    }
+  }
+
+  @AfterAll
+  static void shutdown() throws Exception {
+    clusterProvider.shutdown();
+  }
+
+  @Test
+  void ofs() throws Exception {
+    testSafeMode(TestSafeMode::getOFSRoot);
+  }
+
+  @Test
+  void o3fs() throws Exception {
+    testSafeMode(TestSafeMode::getO3FSRoot);
+  }
+
+  private void testSafeMode(Function<OzoneConfiguration, String> fsRoot)
+      throws Exception {
+    FileSystem fs = createFS(fsRoot);
+    try {
+      SafeMode subject = assertInstanceOf(SafeMode.class, fs);
+
+      assertFalse(subject.setSafeMode(SafeModeAction.GET));
+
+      cluster.shutdownHddsDatanodes();
+      cluster.restartStorageContainerManager(false);
+
+      // SCM should be in safe mode
+      assertTrue(subject.setSafeMode(SafeModeAction.GET));
+
+      // force exit safe mode and verify that it's out of safe mode.
+      subject.setSafeMode(SafeModeAction.FORCE_EXIT);
+      assertFalse(subject.setSafeMode(SafeModeAction.GET));
+    } finally {
+      IOUtils.closeQuietly(fs);
+    }
+  }
+
+  private FileSystem createFS(Function<OzoneConfiguration, String> fsRoot)
+      throws IOException {
+    OzoneConfiguration conf = cluster.getConf();
+    URI uri = URI.create(fsRoot.apply(conf));
+    return FileSystem.get(uri, conf);
+  }
+
+  private static String getOFSRoot(OzoneConfiguration conf) {
+    return String.format("%s://%s/",
+        OZONE_OFS_URI_SCHEME,
+        conf.get(OZONE_OM_ADDRESS_KEY));
+  }
+
+  private static String getO3FSRoot(OzoneConfiguration conf) {
+    return String.format("%s://%s.%s.%s/",
+        OZONE_URI_SCHEME, BUCKET, VOLUME, conf.get(OZONE_OM_ADDRESS_KEY));
+  }
+
+}


### PR DESCRIPTION
## What changes were proposed in this pull request?

`TestRootedOzoneFileSystem#testSafeMode` (introduced for HDDS-8436) stops datanodes, restarts SCM and forces it to exit safe mode.  This leaves the cluster in a bad state, breaking other test cases.  Log is flooded due to an "infinite" loop trying to allocate block without datanodes.  (It's not really infinite, exits after at most 5 minutes, but by that time tests are aborted due to disk out of space error.)

This PR extracts `testSafeMode` to a separate class, where the final state of the cluster is not a problem for other test cases.

The same test is run for both OFS and O3FS.

https://issues.apache.org/jira/browse/HDDS-8981

## How was this patch tested?

```
$ mvn -am -pl :ozone-integration-test -Dtest='TestRootedOzoneFileSystem,TestSafeMode' clean test
...
[WARNING] Tests run: 250, Failures: 0, Errors: 0, Skipped: 9, Time elapsed: 332.357 s - in org.apache.hadoop.fs.ozone.TestRootedOzoneFileSystem
[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 41.188 s - in org.apache.hadoop.fs.ozone.TestSafeMode
...
[INFO] BUILD SUCCESS
```

CI:
https://github.com/adoroszlai/hadoop-ozone/actions/runs/5475617964