### PR TITLE
HDDS-8593. Add RootCARotationPoller to CertClient

### DIFF
--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/TestHddsSecureDatanodeInit.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/TestHddsSecureDatanodeInit.java
@@ -327,7 +327,7 @@ public class TestHddsSecureDatanodeInit {
         client.getCertificate().getSerialNumber().toString()));
 
     // start monitor task to renew key and cert
-    client.startCertificateMonitor();
+    client.startCertificateRenewerService();
 
     // check after renew, client will have the new cert ID
     GenericTestUtils.waitFor(() -> {
@@ -402,7 +402,7 @@ public class TestHddsSecureDatanodeInit {
         client.getCertificate().getSerialNumber().toString()));
 
     // start monitor task to renew key and cert
-    client.startCertificateMonitor();
+    client.startCertificateRenewerService();
 
     // certificate failed to renew, client still hold the old expired cert.
     Thread.sleep(CERT_LIFETIME * 1000);

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/security/x509/certificate/client/DefaultCertificateClient.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/security/x509/certificate/client/DefaultCertificateClient.java
@@ -1379,10 +1379,11 @@ public abstract class DefaultCertificateClient implements CertificateClient {
         }
         String newCertId;
         try {
-          getLogger().info("Current certificate {} has entered the expiry" +
-                  " grace period {}. Starting renew key and certs.",
+          getLogger().info("Current certificate {} needs to be renewed " +
+                  "remaining grace period {}. Forced renewal due to root ca " +
+                  "rotation: {}.",
               currentCert.getSerialNumber().toString(),
-              timeLeft, securityConfig.getRenewalGracePeriod());
+              timeLeft, forceRenewal);
           newCertId = renewAndStoreKeyAndCertificate(forceRenewal);
         } catch (CertificateException e) {
           if (e.errorCode() ==

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/security/x509/certificate/client/DefaultCertificateClient.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/security/x509/certificate/client/DefaultCertificateClient.java
@@ -171,19 +171,19 @@ public abstract class DefaultCertificateClient implements CertificateClient {
       return;
     }
 
-    if (shouldStartCertificateMonitorService()) {
+    if (shouldStartCertificateRenewerService()) {
       startRootCaRotationPoller();
       if (certPath != null && executorService == null) {
-        startCertificateMonitor();
+        startCertificateRenewerService();
       } else {
         if (executorService != null) {
-          getLogger().debug("CertificateLifetimeMonitor is already started.");
+          getLogger().debug("CertificateRenewerService is already started.");
         } else {
           getLogger().warn("Component certificate was not loaded.");
         }
       }
     } else {
-      getLogger().info("CertificateLifetimeMonitor and root ca rotation " +
+      getLogger().info("CertificateRenewerService and root ca rotation " +
           "polling is disabled for {}", component);
     }
   }
@@ -1312,7 +1312,7 @@ public abstract class DefaultCertificateClient implements CertificateClient {
     return scmSecurityClient;
   }
 
-  protected boolean shouldStartCertificateMonitorService() {
+  protected boolean shouldStartCertificateRenewerService() {
     return true;
   }
 
@@ -1326,7 +1326,7 @@ public abstract class DefaultCertificateClient implements CertificateClient {
     return CompletableFuture.runAsync(renewerService, executorService);
   }
 
-  public synchronized void startCertificateMonitor() {
+  public synchronized void startCertificateRenewerService() {
     Preconditions.checkNotNull(getCertificate(),
         "Component certificate should not be empty");
     // Schedule task to refresh certificate before it expires
@@ -1340,13 +1340,13 @@ public abstract class DefaultCertificateClient implements CertificateClient {
     if (executorService == null) {
       executorService = Executors.newScheduledThreadPool(1,
           new ThreadFactoryBuilder().setNameFormat(
-                  getComponentName() + "-CertificateLifetimeMonitor")
+                  getComponentName() + "-CertificateRenewerService")
               .setDaemon(true).build());
     }
     this.executorService.scheduleAtFixedRate(
         new CertificateRenewerService(false),
         timeBeforeGracePeriod, interval, TimeUnit.MILLISECONDS);
-    getLogger().info("CertificateLifetimeMonitor for {} is started with " +
+    getLogger().info("CertificateRenewerService for {} is started with " +
             "first delay {} ms and interval {} ms.", component,
         timeBeforeGracePeriod, interval);
   }

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/security/x509/certificate/client/DefaultCertificateClient.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/security/x509/certificate/client/DefaultCertificateClient.java
@@ -171,7 +171,8 @@ public abstract class DefaultCertificateClient implements CertificateClient {
       return;
     }
 
-    if (shouldStartCertificateMonitor()) {
+    if (shouldStartCertificateMonitorService()) {
+      startRootCaRotationPoller();
       if (certPath != null && executorService == null) {
         startCertificateMonitor();
       } else {
@@ -182,19 +183,21 @@ public abstract class DefaultCertificateClient implements CertificateClient {
         }
       }
     } else {
-      getLogger().info("CertificateLifetimeMonitor is disabled for {}",
-          component);
+      getLogger().info("CertificateLifetimeMonitor and root ca rotation " +
+          "polling is disabled for {}", component);
     }
-    startRootCaRotationPoller();
   }
 
-  protected void startRootCaRotationPoller() {
+  private void startRootCaRotationPoller() {
     if (rootCaRotationPoller == null) {
       rootCaRotationPoller = new RootCaRotationPoller(securityConfig,
           rootCaCertificates, scmSecurityClient);
       rootCaRotationPoller.addRootCARotationProcessor(
           this::getRootCaRotationListener);
       rootCaRotationPoller.run();
+    } else {
+      getLogger().debug("Root CA certificate rotation poller is already " +
+          "started.");
     }
   }
 
@@ -1309,7 +1312,7 @@ public abstract class DefaultCertificateClient implements CertificateClient {
     return scmSecurityClient;
   }
 
-  protected boolean shouldStartCertificateMonitor() {
+  protected boolean shouldStartCertificateMonitorService() {
     return true;
   }
 

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/security/x509/certificate/client/SCMCertificateClient.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/security/x509/certificate/client/SCMCertificateClient.java
@@ -173,7 +173,7 @@ public class SCMCertificateClient extends DefaultCertificateClient {
   }
 
   @Override
-  protected boolean shouldStartCertificateMonitorService() {
+  protected boolean shouldStartCertificateRenewerService() {
     return false;
   }
 

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/security/x509/certificate/client/SCMCertificateClient.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/security/x509/certificate/client/SCMCertificateClient.java
@@ -231,4 +231,9 @@ public class SCMCertificateClient extends DefaultCertificateClient {
       throw new RuntimeException(e);
     }
   }
+
+  @Override
+  protected void startRootCaRotationPoller() {
+    //SCM root CA rotation is handled separately from polling
+  }
 }

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/security/x509/certificate/client/SCMCertificateClient.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/security/x509/certificate/client/SCMCertificateClient.java
@@ -173,7 +173,7 @@ public class SCMCertificateClient extends DefaultCertificateClient {
   }
 
   @Override
-  protected boolean shouldStartCertificateMonitor() {
+  protected boolean shouldStartCertificateMonitorService() {
     return false;
   }
 
@@ -230,10 +230,5 @@ public class SCMCertificateClient extends DefaultCertificateClient {
       LOG.error("Error while fetching/storing SCM signed certificate.", e);
       throw new RuntimeException(e);
     }
-  }
-
-  @Override
-  protected void startRootCaRotationPoller() {
-    //SCM root CA rotation is handled separately from polling
   }
 }

--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/security/x509/certificate/client/CertificateClientTestImpl.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/security/x509/certificate/client/CertificateClientTestImpl.java
@@ -166,7 +166,7 @@ public class CertificateClientTestImpl implements CertificateClient {
           Duration.between(currentTime, gracePeriodStart);
 
       executorService = Executors.newScheduledThreadPool(1,
-          new ThreadFactoryBuilder().setNameFormat("CertificateLifetimeMonitor")
+          new ThreadFactoryBuilder().setNameFormat("CertificateRenewerService")
               .setDaemon(true).build());
       this.executorService.schedule(new RenewCertTask(),
           delay.toMillis(), TimeUnit.MILLISECONDS);

--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/security/x509/certificate/client/TestDefaultCertificateClient.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/security/x509/certificate/client/TestDefaultCertificateClient.java
@@ -656,7 +656,7 @@ public class TestDefaultCertificateClient {
     Thread.enumerate(threads);
     Predicate<Thread> monitorFilterPredicate =
         t -> t != null
-            && t.getName().equals(compName + "-CertificateLifetimeMonitor");
+            && t.getName().equals(compName + "-CertificateRenewerService");
     long monitorThreadCount = Arrays.stream(threads)
         .filter(monitorFilterPredicate)
         .count();

--- a/hadoop-ozone/dist/src/main/compose/ozonesecure/root-ca-rotation.yaml
+++ b/hadoop-ozone/dist/src/main/compose/ozonesecure/root-ca-rotation.yaml
@@ -25,6 +25,7 @@ x-root-cert-rotation-config:
     - OZONE-SITE.XML_hdds.x509.renew.grace.duration=PT45S
     - OZONE-SITE.XML_hdds.x509.ca.rotation.check.interval=PT1S
     - OZONE-SITE.XML_hdds.x509.ca.rotation.ack.timeout=PT20S
+    - OZONE-SITE.XML_hdds.x509.rootca.certificate.polling.interval=PT10s
     - OZONE-SITE.XML_hdds.block.token.expiry.time=15s
     - OZONE-SITE.XML_ozone.manager.delegation.token.max-lifetime=15s
     - OZONE-SITE.XML_ozone.manager.delegation.token.renew-interval=15s

--- a/hadoop-ozone/dist/src/main/compose/ozonesecure/test-root-ca-rotation.sh
+++ b/hadoop-ozone/dist/src/main/compose/ozonesecure/test-root-ca-rotation.sh
@@ -40,6 +40,7 @@ wait_for_execute_command scm 30 "jps | grep StorageContainerManagerStarter |  se
 
 # wait and verify root CA is rotated
 wait_for_execute_command scm 180 "ozone admin cert info 2"
+wait_for_execute_command datanode 30 "find /data/metadata/dn/certs/ROOTCA-2.crt"
 
 # verify om operations and data operations
 execute_commands_in_container scm "ozone sh volume create /r-v1 && ozone sh bucket create /r-v1/r-b1"


### PR DESCRIPTION
## What changes were proposed in this pull request?

After all preparation has been made for the root ca rotation poller, it can be started in DefaultCertificateClient. SCMCertificateClient should be ommited from this since SCM will get Root CA rotation done separately.

Note: these are the same changes created in https://github.com/apache/ozone/pull/5001 but due to the rebasing complexity I found it easier to recreate the pull request from scratch

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-8593

## How was this patch tested?
https://github.com/Galsza/ozone/actions/runs/5478158390
unit/integration tests, more extended docker based testing will be created in a separate jira
