### PR TITLE
HDDS-8984. Keep separate Robot XMLs if rebot fails to combine them

### DIFF
--- a/hadoop-ozone/dist/src/main/compose/testlib.sh
+++ b/hadoop-ozone/dist/src/main/compose/testlib.sh
@@ -409,8 +409,8 @@ copy_results() {
   fi
 
   if [[ -n "$(find "${result_dir}" -name "*.xml")" ]]; then
-    rebot --nostatusrc -N "${test_name}" -l NONE -r NONE -o "${all_result_dir}/${test_name}.xml" "${result_dir}"/*.xml
-    rm -fv "${result_dir}"/*.xml "${result_dir}"/log.html "${result_dir}"/report.html
+    rebot --nostatusrc -N "${test_name}" -l NONE -r NONE -o "${all_result_dir}/${test_name}.xml" "${result_dir}"/*.xml \
+      && rm -fv "${result_dir}"/*.xml "${result_dir}"/log.html "${result_dir}"/report.html
   fi
 
   mkdir -p "${target_dir}"


### PR DESCRIPTION
## What changes were proposed in this pull request?

Test results for `test-root-ca-rotation.sh` failure (see HDDS-8983) are missing, because `rebot` encountered error processing one of the files (hence no combined XML is available), but then the script deleted individual XMLs.

This PR changes the acceptance test lib to only delete separate Robot XMLs if combination (`rebot ...`) is successful.  This ensures we have some test output in both cases.

https://issues.apache.org/jira/browse/HDDS-8984

## How was this patch tested?

Not yet, need repro of HA-secure test failure.