### PR TITLE
HDDS-8980. RocksDB crash in RocksDBStoreMetrics.computeSstFileStat

### DIFF
--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/RocksDBStoreMetrics.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/RocksDBStoreMetrics.java
@@ -230,17 +230,22 @@ public class RocksDBStoreMetrics implements MetricsSource {
           cfPros[index][0], e);
     }
 
-    // Calculate number of files per level and size per level
-    Map<String, Map<Integer, Map<String, Long>>> data = computeSstFileStat();
+    try {
+      // Calculate number of files per level and size per level
+      Map<String, Map<Integer, Map<String, Long>>> data = computeSstFileStat();
 
-    // Export file number
-    exportSstFileStat(rb, data.get(NUM_FILES_AT_LEVEL), NUM_FILES_AT_LEVEL);
+      // Export file number
+      exportSstFileStat(rb, data.get(NUM_FILES_AT_LEVEL), NUM_FILES_AT_LEVEL);
 
-    // Export file total size
-    exportSstFileStat(rb, data.get(SIZE_AT_LEVEL), SIZE_AT_LEVEL);
+      // Export file total size
+      exportSstFileStat(rb, data.get(SIZE_AT_LEVEL), SIZE_AT_LEVEL);
+    } catch (IOException e) {
+      LOG.error("Failed to compute sst file stat", e);
+    }
   }
 
-  private Map<String, Map<Integer, Map<String, Long>>> computeSstFileStat() {
+  private Map<String, Map<Integer, Map<String, Long>>> computeSstFileStat()
+      throws IOException {
     // Calculate number of files per level and size per level
     List<LiveFileMetaData> liveFileMetaDataList =
         rocksDB.getLiveFilesMetaData();

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/RocksDBStoreMetrics.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/RocksDBStoreMetrics.java
@@ -297,7 +297,11 @@ public class RocksDBStoreMetrics implements MetricsSource {
   }
 
   private void getLatestSequenceNumber(MetricsRecordBuilder rb) {
-    rb.addCounter(Interns.info(LAST_SEQUENCE_NUMBER, "RocksDBStat"),
-        rocksDB.getLatestSequenceNumber());
+    try {
+      rb.addCounter(Interns.info(LAST_SEQUENCE_NUMBER, "RocksDBStat"),
+          rocksDB.getLatestSequenceNumber());
+    } catch (IOException e) {
+      LOG.error("Failed to get latest sequence number", e);
+    }
   }
 }

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/DBStore.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/DBStore.java
@@ -182,22 +182,15 @@ public interface DBStore extends Closeable, BatchOperationHandler {
 
   /**
    * Get data written to DB since a specific sequence number.
-   * @param sequenceNumber
-   * @return
-   * @throws SequenceNumberNotFoundException
    */
   DBUpdatesWrapper getUpdatesSince(long sequenceNumber)
-      throws SequenceNumberNotFoundException;
+      throws IOException;
 
   /**
    * Get limited data written to DB since a specific sequence number.
-   * @param sequenceNumber
-   * @param limitCount
-   * @return
-   * @throws SequenceNumberNotFoundException
    */
   DBUpdatesWrapper getUpdatesSince(long sequenceNumber, long limitCount)
-      throws SequenceNumberNotFoundException;
+      throws IOException;
 
   /**
    * Return if the underlying DB is closed. This call is thread safe.

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/RDBStore.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/RDBStore.java
@@ -413,6 +413,7 @@ public class RDBStore implements DBStore {
         }
         logIterator.get().next();
       }
+      dbUpdatesWrapper.setLatestSequenceNumber(db.getLatestSequenceNumber());
     } catch (SequenceNumberNotFoundException e) {
       LOG.warn("Unable to get delta updates since sequenceNumber {}. "
               + "This exception will be thrown to the client",
@@ -433,7 +434,6 @@ public class RDBStore implements DBStore {
             dbUpdatesWrapper.getCurrentSequenceNumber() - sequenceNumber);
       }
     }
-    dbUpdatesWrapper.setLatestSequenceNumber(db.getLatestSequenceNumber());
     return dbUpdatesWrapper;
   }
 

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/RDBStore.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/RDBStore.java
@@ -347,13 +347,13 @@ public class RDBStore implements DBStore {
 
   @Override
   public DBUpdatesWrapper getUpdatesSince(long sequenceNumber)
-      throws SequenceNumberNotFoundException {
+      throws IOException {
     return getUpdatesSince(sequenceNumber, Long.MAX_VALUE);
   }
 
   @Override
   public DBUpdatesWrapper getUpdatesSince(long sequenceNumber, long limitCount)
-      throws SequenceNumberNotFoundException {
+      throws IOException {
     if (limitCount <= 0) {
       throw new IllegalArgumentException("Illegal count for getUpdatesSince.");
     }

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/RocksDatabase.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/RocksDatabase.java
@@ -632,7 +632,8 @@ public final class RocksDatabase implements Closeable {
     }
   }
 
-  public List<LiveFileMetaData> getLiveFilesMetaData() {
+  public List<LiveFileMetaData> getLiveFilesMetaData() throws IOException {
+    assertClose();
     try {
       counter.incrementAndGet();
       return db.get().getLiveFilesMetaData();

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/RocksDatabase.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/RocksDatabase.java
@@ -243,7 +243,7 @@ public final class RocksDatabase implements Closeable {
       }
     }
 
-    public long getLatestSequenceNumber() {
+    public long getLatestSequenceNumber() throws IOException {
       return RocksDatabase.this.getLatestSequenceNumber();
     }
 
@@ -829,7 +829,8 @@ public final class RocksDatabase implements Closeable {
     }
   }
 
-  public long getLatestSequenceNumber() {
+  public long getLatestSequenceNumber() throws IOException {
+    assertClose();
     try {
       counter.incrementAndGet();
       return db.get().getLatestSequenceNumber();

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/RocksDatabase.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/RocksDatabase.java
@@ -508,9 +508,9 @@ public final class RocksDatabase implements Closeable {
 
   /**
    * @param cfName columnFamily on which flush will run.
-   * @throws IOException
    */
   public void flush(String cfName) throws IOException {
+    assertClose();
     ColumnFamilyHandle handle = getColumnFamilyHandle(cfName);
     try (ManagedFlushOptions options = new ManagedFlushOptions()) {
       options.setWaitForFlush(true);
@@ -555,6 +555,7 @@ public final class RocksDatabase implements Closeable {
 
   public void compactRangeDefault(final ManagedCompactRangeOptions options)
       throws IOException {
+    assertClose();
     try {
       counter.incrementAndGet();
       db.get().compactRange(null, null, null, options);
@@ -567,13 +568,15 @@ public final class RocksDatabase implements Closeable {
   }
 
   public void compactDB(ManagedCompactRangeOptions options) throws IOException {
+    assertClose();
     compactRangeDefault(options);
     for (RocksDatabase.ColumnFamily columnFamily : getExtraColumnFamilies()) {
       compactRange(columnFamily, null, null, options);
     }
   }
 
-  public int getLiveFilesMetaDataSize() {
+  public int getLiveFilesMetaDataSize() throws IOException {
+    assertClose();
     try {
       counter.incrementAndGet();
       return db.get().getLiveFilesMetaData().size();
@@ -584,9 +587,9 @@ public final class RocksDatabase implements Closeable {
 
   /**
    * @param cfName columnFamily on which compaction will run.
-   * @throws IOException
    */
   public void compactRange(String cfName) throws IOException {
+    assertClose();
     ColumnFamilyHandle handle = getColumnFamilyHandle(cfName);
     try {
       if (handle != null) {
@@ -604,6 +607,7 @@ public final class RocksDatabase implements Closeable {
 
   private ColumnFamilyHandle getColumnFamilyHandle(String cfName)
       throws IOException {
+    assertClose();
     for (ColumnFamilyHandle cf : getCfHandleMap().get(db.get().getName())) {
       try {
         String table = new String(cf.getName(), StandardCharsets.UTF_8);
@@ -621,6 +625,7 @@ public final class RocksDatabase implements Closeable {
   public void compactRange(ColumnFamily family, final byte[] begin,
       final byte[] end, final ManagedCompactRangeOptions options)
       throws IOException {
+    assertClose();
     try {
       counter.incrementAndGet();
       db.get().compactRange(family.getHandle(), begin, end, options);
@@ -925,7 +930,8 @@ public final class RocksDatabase implements Closeable {
   }
 
   @VisibleForTesting
-  public List<LiveFileMetaData> getSstFileList() {
+  public List<LiveFileMetaData> getSstFileList() throws IOException {
+    assertClose();
     return db.get().getLiveFilesMetaData();
   }
 
@@ -933,7 +939,7 @@ public final class RocksDatabase implements Closeable {
    * return the max compaction level of sst files in the db.
    * @return level
    */
-  private int getLastLevel() {
+  private int getLastLevel() throws IOException {
     return getSstFileList().stream()
         .max(Comparator.comparing(LiveFileMetaData::level)).get().level();
   }
@@ -942,12 +948,12 @@ public final class RocksDatabase implements Closeable {
    * Deletes sst files which do not correspond to prefix
    * for given table.
    * @param prefixPairs, a list of pair (TableName,prefixUsed).
-   * @throws RocksDBException
    */
   public void deleteFilesNotMatchingPrefix(
       List<Pair<String, String>> prefixPairs,
       BooleanTriFunction<String, String, String, Boolean> filterFunction)
-      throws RocksDBException {
+      throws IOException, RocksDBException {
+    assertClose();
     for (LiveFileMetaData liveFileMetaData : getSstFileList()) {
       String sstFileColumnFamily =
           new String(liveFileMetaData.columnFamilyName(),

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOmSnapshot.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOmSnapshot.java
@@ -1153,7 +1153,8 @@ public class TestOmSnapshot {
   }
 
   @NotNull
-  private static List<LiveFileMetaData> getKeyTableSstFiles() {
+  private static List<LiveFileMetaData> getKeyTableSstFiles()
+      throws IOException {
     if (!bucketLayout.isFileSystemOptimized()) {
       return rdbStore.getDb().getSstFileList().stream().filter(
           x -> new String(x.columnFamilyName(), UTF_8).equals(

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
@@ -4039,7 +4039,7 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
   @Override
   public DBUpdates getDBUpdates(
       DBUpdatesRequest dbUpdatesRequest)
-      throws SequenceNumberNotFoundException {
+      throws IOException {
     long limitCount = Long.MAX_VALUE;
     if (dbUpdatesRequest.hasLimitCount()) {
       limitCount = dbUpdatesRequest.getLimitCount();

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/protocolPB/OzoneManagerRequestHandler.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/protocolPB/OzoneManagerRequestHandler.java
@@ -37,7 +37,6 @@ import org.apache.hadoop.hdds.protocol.proto.HddsProtos.TransferLeadershipReques
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos.TransferLeadershipResponseProto;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos.UpgradeFinalizationStatus;
 import org.apache.hadoop.hdds.client.ReplicationConfig;
-import org.apache.hadoop.hdds.utils.db.SequenceNumberNotFoundException;
 import org.apache.hadoop.ozone.OzoneAcl;
 import org.apache.hadoop.ozone.om.OzoneManager;
 import org.apache.hadoop.ozone.om.OzoneManagerPrepareState;
@@ -376,7 +375,7 @@ public class OzoneManagerRequestHandler implements RequestHandler {
 
   private DBUpdatesResponse getOMDBUpdates(
       DBUpdatesRequest dbUpdatesRequest)
-      throws SequenceNumberNotFoundException {
+      throws IOException {
 
     DBUpdatesResponse.Builder builder = DBUpdatesResponse
         .newBuilder();

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/recovery/ReconOmMetadataManagerImpl.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/recovery/ReconOmMetadataManagerImpl.java
@@ -131,7 +131,11 @@ public class ReconOmMetadataManagerImpl extends OmMetadataManagerImpl
     if (null == rocksDBStore) {
       return 0;
     } else {
-      return rocksDBStore.getDb().getLatestSequenceNumber();
+      try {
+        return rocksDBStore.getDb().getLatestSequenceNumber();
+      } catch (IOException e) {
+        return 0;
+      }
     }
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

HDDS-7284 added a check in (almost) all methods of `RocksDatabase` to avoid operating on closed RocksDB.  This PR adds `assertClose()` calls in methods introduced without such check since then (in HDDS-6962, HDDS-7321, HDDS-7851).

https://issues.apache.org/jira/browse/HDDS-8980

## How was this patch tested?

CI:
https://github.com/adoroszlai/hadoop-ozone/actions/runs/5487024333