### PR TITLE
HDDS-6668. scm roles CLI should provide JSON output option

### DIFF
--- a/hadoop-ozone/dist/src/main/smoketest/admincli/scmrole.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/admincli/scmrole.robot
@@ -29,5 +29,4 @@ Run scm roles
 
 List scm roles as JSON
     ${output} =         Execute          ozone admin scm roles --json
-                        Should contain   ${output}    "raftPeerRole" :
-                        Should contain   ${output}    "ID" :
+                        Should contain   ${output}    "address" :

--- a/hadoop-ozone/dist/src/main/smoketest/admincli/scmrole.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/admincli/scmrole.robot
@@ -29,4 +29,5 @@ Run scm roles
 
 List scm roles as JSON
     ${output} =         Execute          ozone admin scm roles --json
-                        Should contain   ${output}    "address" :
+    ${leader} =         Execute          echo '${output}' | jq -r '.[] | select(.raftPeerRole == "LEADER")'
+                        Should Not Be Equal       ${leader}       ${EMPTY}

--- a/hadoop-ozone/dist/src/main/smoketest/admincli/scmrole.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/admincli/scmrole.robot
@@ -26,3 +26,8 @@ Test Timeout        5 minutes
 Run scm roles
     ${output} =         Execute          ozone admin scm roles
                         Should Match Regexp   ${output}  [scm:9894(:LEADER|)]
+
+List scm roles as JSON
+    ${output} =         Execute          ozone admin scm roles --json
+                        Should contain   ${output}    "raftPeerRole" :
+                        Should contain   ${output}    "ID" :

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/admin/scm/GetScmRatisRolesSubcommand.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/admin/scm/GetScmRatisRolesSubcommand.java
@@ -28,6 +28,8 @@ import org.apache.hadoop.hdds.scm.client.ScmClient;
 import org.apache.hadoop.hdds.server.JsonUtils;
 import picocli.CommandLine;
 
+import static java.lang.System.err;
+
 /**
  * Handler of scm status command.
  */
@@ -67,11 +69,15 @@ public class GetScmRatisRolesSubcommand extends ScmSubcommand {
     for (String role : ratisRoles) {
       Map<String, String> roleDetails = new HashMap<>();
       String[] roles = role.split(":");
-      roleDetails.put("address", roles[0].concat(roles[1]));
-      if(roles.length > 2) {
-        roleDetails.put("raftPeerRole", roles[2]);
-        roleDetails.put("ID", roles[3]);
-        roleDetails.put("InetAddress", roles[4]);
+      if (roles.length >= 2) {
+        roleDetails.put("address", roles[0].concat(roles[1]));
+        if (roles.length > 2) {
+          roleDetails.put("raftPeerRole", roles[2]);
+          roleDetails.put("ID", roles[3]);
+          roleDetails.put("InetAddress", roles[4]);
+        }
+      } else {
+        err.println("Invalid response received for ScmRatisRoles.");
       }
       allRoles.put(roles[0], roleDetails);
     }

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/admin/scm/GetScmRatisRolesSubcommand.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/admin/scm/GetScmRatisRolesSubcommand.java
@@ -64,7 +64,7 @@ public class GetScmRatisRolesSubcommand extends ScmSubcommand {
     }
   }
 
-  protected Map<String, Map<String, String>> parseScmRoles(
+  private Map<String, Map<String, String>> parseScmRoles(
       List<String> ratisRoles) {
     Map<String, Map<String, String>> allRoles = new HashMap<>();
     for (String role : ratisRoles) {
@@ -78,9 +78,9 @@ public class GetScmRatisRolesSubcommand extends ScmSubcommand {
       // This will just print the hostname with ratis port as the address
       roleDetails.put("address", roles[0].concat(":").concat(roles[1]));
       if (roles.length == 5) {
-          roleDetails.put("raftPeerRole", roles[2]);
-          roleDetails.put("ID", roles[3]);
-          roleDetails.put("InetAddress", roles[4]);
+        roleDetails.put("raftPeerRole", roles[2]);
+        roleDetails.put("ID", roles[3]);
+        roleDetails.put("InetAddress", roles[4]);
       }
       allRoles.put(roles[0], roleDetails);
     }

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/admin/scm/GetScmRatisRolesSubcommand.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/admin/scm/GetScmRatisRolesSubcommand.java
@@ -18,6 +18,7 @@
 package org.apache.hadoop.ozone.admin.scm;
 
 import java.io.IOException;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -69,15 +70,17 @@ public class GetScmRatisRolesSubcommand extends ScmSubcommand {
     for (String role : ratisRoles) {
       Map<String, String> roleDetails = new HashMap<>();
       String[] roles = role.split(":");
-      if (roles.length >= 2) {
-        roleDetails.put("address", roles[0].concat(roles[1]));
-        if (roles.length > 2) {
+      if (roles.length < 2) {
+        err.println("Invalid response received for ScmRatisRoles.");
+        return Collections.emptyMap();
+      }
+      // In case, there is no ratis, there is no ratis role.
+      // This will just print the hostname with ratis port as the address
+      roleDetails.put("address", roles[0].concat(":").concat(roles[1]));
+      if (roles.length == 5) {
           roleDetails.put("raftPeerRole", roles[2]);
           roleDetails.put("ID", roles[3]);
           roleDetails.put("InetAddress", roles[4]);
-        }
-      } else {
-        err.println("Invalid response received for ScmRatisRoles.");
       }
       allRoles.put(roles[0], roleDetails);
     }

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/admin/scm/GetScmRatisRolesSubcommand.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/admin/scm/GetScmRatisRolesSubcommand.java
@@ -53,7 +53,7 @@ public class GetScmRatisRolesSubcommand extends ScmSubcommand {
     if (json) {
       Map<String, Map<String, String>> scmRoles = parseScmRoles(ratisRoles);
       System.out.print(
-      JsonUtils.toJsonStringWithDefaultPrettyPrinter(scmRoles));
+          JsonUtils.toJsonStringWithDefaultPrettyPrinter(scmRoles));
     } else {
       for (String role: ratisRoles) {
         System.out.println(role);
@@ -67,11 +67,13 @@ public class GetScmRatisRolesSubcommand extends ScmSubcommand {
     for (String role : ratisRoles) {
       Map<String, String> roleDetails = new HashMap<>();
       String[] roles = role.split(":");
-      roleDetails.put("address",roles[1]);
-      roleDetails.put("raftPeerRole",roles[2]);
-      roleDetails.put("ID",roles[3]);
-      roleDetails.put("InetAddress",roles[4]);
-      allRoles.put(roles[0],roleDetails);
+      roleDetails.put("address", roles[0].concat(roles[1]));
+      if(roles.length > 2) {
+        roleDetails.put("raftPeerRole", roles[2]);
+        roleDetails.put("ID", roles[3]);
+        roleDetails.put("InetAddress", roles[4]);
+      }
+      allRoles.put(roles[0], roleDetails);
     }
     return allRoles;
   }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Add the option for the command `ozone admin scm roles` to output as JSON

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-6668

## How was this patch tested?

New robot test. Also verified the JSON out using a docker-compose cluster:
```
bash-4.2$ ozone admin scm roles --json
{
  "scm2" : {
    "address" : "scm2:9894",
    "raftPeerRole" : "FOLLOWER",
    "ID" : "3a52e9ff-77e2-488b-b1e8-539f5cf9a313",
    "InetAddress" : "172.18.0.6"
  },
  "scm1" : {
    "address" : "scm1:9894",
    "raftPeerRole" : "LEADER",
    "ID" : "808fae81-dcd4-4bcd-9a82-eab25b939530",
    "InetAddress" : "172.18.0.10"
  },
  "scm3" : {
    "address" : "scm3:9894",
    "raftPeerRole" : "FOLLOWER",
    "ID" : "07b07cf8-a1e5-4f70-b4bd-53feed2a4255",
    "InetAddress" : "172.18.0.4"
  }
}
```
