### PR TITLE
HDDS-8990. Intermittent timeout waiting on datanode4 9856 to become available

### DIFF
--- a/hadoop-ozone/dist/src/main/compose/ozonesecure-ha/test-root-ca-rotation.sh
+++ b/hadoop-ozone/dist/src/main/compose/ozonesecure-ha/test-root-ca-rotation.sh
@@ -70,7 +70,7 @@ execute_robot_test scm4.org -v "TARGET_SCM:scm4.org" scmha/scm-leader-transfer.r
 
 # add new datanode4 and verify certificate
 docker-compose up -d datanode4
-wait_for_port datanode4 9856 60
+wait_for_port datanode4 9856 120
 wait_for_execute_command scm4.org 60 "ozone admin datanode list | grep datanode4"
 
 #transfer leader to scm3.org

--- a/hadoop-ozone/dist/src/main/compose/ozonesecure-ha/test.sh
+++ b/hadoop-ozone/dist/src/main/compose/ozonesecure-ha/test.sh
@@ -66,7 +66,7 @@ execute_robot_test scm4.org scmha/primordial-scm.robot
 
 # add new datanode4
 docker-compose up -d datanode4
-wait_for_port datanode4 9856 60
+wait_for_port datanode4 9856 120
 wait_for_execute_command scm4.org 60 "ozone admin datanode list | grep datanode4"
 
 # decommission primordial node scm1.org


### PR DESCRIPTION
## What changes were proposed in this pull request?

Increase time allowed for datanode4 to become available, to prevent frequent failure due to timeout.

https://issues.apache.org/jira/browse/HDDS-8990

## How was this patch tested?

CI:
https://github.com/adoroszlai/hadoop-ozone/actions/runs/5506570548