### PR TITLE
HDDS-8959. Add the ability to turn off automated CA rotation

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/HddsConfigKeys.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/HddsConfigKeys.java
@@ -226,6 +226,9 @@ public final class HddsConfigKeys {
       "hdds.x509.rootca.certificate.polling.interval";
   public static final String
       HDDS_X509_ROOTCA_CERTIFICATE_POLLING_INTERVAL_DEFAULT = "PT2h";
+  public static final String HDDS_X509_CA_ROTATION_ENABLED =
+      "hdds.x509.ca.rotation.enabled";
+  public static final boolean HDDS_X509_CA_ROTATION_ENABLED_DEFAULT = true;
 
   public static final String HDDS_CONTAINER_REPLICATION_COMPRESSION =
       "hdds.container.replication.compression";

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/HddsConfigKeys.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/HddsConfigKeys.java
@@ -228,7 +228,7 @@ public final class HddsConfigKeys {
       HDDS_X509_ROOTCA_CERTIFICATE_POLLING_INTERVAL_DEFAULT = "PT2h";
   public static final String HDDS_X509_CA_ROTATION_ENABLED =
       "hdds.x509.ca.rotation.enabled";
-  public static final boolean HDDS_X509_CA_ROTATION_ENABLED_DEFAULT = true;
+  public static final boolean HDDS_X509_CA_ROTATION_ENABLED_DEFAULT = false;
 
   public static final String HDDS_CONTAINER_REPLICATION_COMPRESSION =
       "hdds.container.replication.compression";

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/security/SecurityConfig.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/security/SecurityConfig.java
@@ -48,6 +48,8 @@ import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_X509_CA_ROTATION_ACK_TI
 import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_X509_CA_ROTATION_ACK_TIMEOUT_DEFAULT;
 import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_X509_CA_ROTATION_CHECK_INTERNAL;
 import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_X509_CA_ROTATION_CHECK_INTERNAL_DEFAULT;
+import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_X509_CA_ROTATION_ENABLED;
+import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_X509_CA_ROTATION_ENABLED_DEFAULT;
 import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_X509_CA_ROTATION_TIME_OF_DAY;
 import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_X509_CA_ROTATION_TIME_OF_DAY_DEFAULT;
 import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_X509_ROOTCA_CERTIFICATE_FILE;
@@ -134,6 +136,7 @@ public class SecurityConfig {
   private final Duration caAckTimeout;
   private final SslProvider grpcSSLProvider;
   private final Duration rootCaCertificatePollingInterval;
+  private final boolean autoCARotationEnabled;
 
   /**
    * Constructs a SecurityConfig.
@@ -228,6 +231,8 @@ public class SecurityConfig {
         HDDS_X509_CA_ROTATION_ACK_TIMEOUT,
         HDDS_X509_CA_ROTATION_ACK_TIMEOUT_DEFAULT);
     caAckTimeout = Duration.parse(ackTimeString);
+    autoCARotationEnabled = configuration.getBoolean(
+        HDDS_X509_CA_ROTATION_ENABLED, HDDS_X509_CA_ROTATION_ENABLED_DEFAULT);
 
     validateCertificateValidityConfig();
 
@@ -564,6 +569,10 @@ public class SecurityConfig {
 
   public Duration getRootCaCertificatePollingInterval() {
     return rootCaCertificatePollingInterval;
+  }
+
+  public boolean isAutoCARotationEnabled() {
+    return autoCARotationEnabled;
   }
 
   /**

--- a/hadoop-hdds/common/src/main/resources/ozone-default.xml
+++ b/hadoop-hdds/common/src/main/resources/ozone-default.xml
@@ -2270,9 +2270,9 @@
   </property>
   <property>
     <name>hdds.x509.ca.rotation.enabled</name>
-    <value>true</value>
+    <value>false</value>
     <tag>OZONE, HDDS, SECURITY</tag>
-    <description>Whether auto root CA and sub CA certificate rotation is enabled or not. Default is enabled.
+    <description>Whether auto root CA and sub CA certificate rotation is enabled or not. Default is disabled.
     </description>
   </property>
   <property>

--- a/hadoop-hdds/common/src/main/resources/ozone-default.xml
+++ b/hadoop-hdds/common/src/main/resources/ozone-default.xml
@@ -2269,6 +2269,13 @@
     </description>
   </property>
   <property>
+    <name>hdds.x509.ca.rotation.enabled</name>
+    <value>true</value>
+    <tag>OZONE, HDDS, SECURITY</tag>
+    <description>Whether auto root CA and sub CA certificate rotation is enabled or not. Default is enabled.
+    </description>
+  </property>
+  <property>
     <name>hdds.x509.rootca.certificate.polling.interval</name>
     <value>PT2h</value>
     <description>Interval to use for polling in certificate clients for a new

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/security/x509/certificate/client/DefaultCertificateClient.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/security/x509/certificate/client/DefaultCertificateClient.java
@@ -172,7 +172,9 @@ public abstract class DefaultCertificateClient implements CertificateClient {
     }
 
     if (shouldStartCertificateRenewerService()) {
-      startRootCaRotationPoller();
+      if (securityConfig.isAutoCARotationEnabled()) {
+        startRootCaRotationPoller();
+      }
       if (certPath != null && executorService == null) {
         startCertificateRenewerService();
       } else {

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMSecurityProtocolServer.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMSecurityProtocolServer.java
@@ -190,8 +190,9 @@ public class SCMSecurityProtocolServer implements SCMSecurityProtocol,
     LOGGER.info("Processing CSR for dn {}, UUID: {}", dnDetails.getHostName(),
         dnDetails.getUuid());
     Objects.requireNonNull(dnDetails);
-    if (storageContainerManager.getRootCARotationManager()
-        .isRotationInProgress()) {
+    if (storageContainerManager.getRootCARotationManager() != null &&
+        storageContainerManager.getRootCARotationManager()
+            .isRotationInProgress()) {
       throw new SCMException(("Root CA and Sub CA rotation is in-progress." +
           " Please try the operation later again."),
           SCMException.ResultCodes.CA_ROTATION_IN_PROGRESS);
@@ -207,8 +208,9 @@ public class SCMSecurityProtocolServer implements SCMSecurityProtocol,
         nodeDetails.getNodeType(), nodeDetails.getHostName(),
         nodeDetails.getUuid());
     Objects.requireNonNull(nodeDetails);
-    if (storageContainerManager.getRootCARotationManager()
-        .isRotationInProgress()) {
+    if (storageContainerManager.getRootCARotationManager() != null &&
+        storageContainerManager.getRootCARotationManager()
+            .isRotationInProgress()) {
       throw new SCMException(("Root CA and Sub CA rotation is in-progress." +
           " Please try the operation later again."),
           SCMException.ResultCodes.CA_ROTATION_IN_PROGRESS);
@@ -275,8 +277,9 @@ public class SCMSecurityProtocolServer implements SCMSecurityProtocol,
     LOGGER.info("Processing CSR for om {}, UUID: {}", omDetails.getHostName(),
         omDetails.getUuid());
     Objects.requireNonNull(omDetails);
-    if (storageContainerManager.getRootCARotationManager()
-        .isRotationInProgress()) {
+    if (storageContainerManager.getRootCARotationManager() != null &&
+        storageContainerManager.getRootCARotationManager()
+            .isRotationInProgress()) {
       throw new SCMException(("Root CA and Sub CA rotation is in-progress." +
           " Please try the operation later again."),
           SCMException.ResultCodes.CA_ROTATION_IN_PROGRESS);
@@ -317,8 +320,9 @@ public class SCMSecurityProtocolServer implements SCMSecurityProtocol,
           + storageContainerManager.getClusterId());
     }
 
-    if (storageContainerManager.getRootCARotationManager()
-        .isRotationInProgress() && !isRenew) {
+    if (storageContainerManager.getRootCARotationManager() != null &&
+        storageContainerManager.getRootCARotationManager()
+            .isRotationInProgress() && !isRenew) {
       throw new SCMException(("Root CA and Sub CA rotation is in-progress." +
           " Please try the operation later again."),
           SCMException.ResultCodes.CA_ROTATION_IN_PROGRESS);

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/StorageContainerManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/StorageContainerManager.java
@@ -910,7 +910,9 @@ public final class StorageContainerManager extends ServiceRuntimeInfoImpl
     if (securityConfig.isContainerTokenEnabled()) {
       containerTokenMgr = createContainerTokenSecretManager();
     }
-    rootCARotationManager = new RootCARotationManager(this);
+    if (securityConfig.isAutoCARotationEnabled()) {
+      rootCARotationManager = new RootCARotationManager(this);
+    }
   }
 
   /**

--- a/hadoop-ozone/dist/src/main/compose/ozonesecure-ha/root-ca-rotation.yaml
+++ b/hadoop-ozone/dist/src/main/compose/ozonesecure-ha/root-ca-rotation.yaml
@@ -34,6 +34,7 @@ x-root-cert-rotation-config:
     - OZONE-SITE.XML_ozone.scm.info.wait.duration=60s
     - OZONE-SITE.XML_ozone.scm.ha.ratis.request.timeout=2s
     - OZONE-SITE.XML_ozone.http.filter.initializers=org.apache.hadoop.security.HttpCrossOriginFilterInitializer
+    - OZONE-SITE.XML_hdds.x509.ca.rotation.enabled=true
 services:
   datanode1:
     <<: *root-cert-rotation-config

--- a/hadoop-ozone/dist/src/main/compose/ozonesecure/root-ca-rotation.yaml
+++ b/hadoop-ozone/dist/src/main/compose/ozonesecure/root-ca-rotation.yaml
@@ -35,6 +35,7 @@ x-root-cert-rotation-config:
     - OZONE-SITE.XML_ozone.scm.info.wait.duration=60s
     - OZONE-SITE.XML_ozone.scm.ha.ratis.request.timeout=2s
     - OZONE-SITE.XML_ozone.http.filter.initializers=org.apache.hadoop.security.HttpCrossOriginFilterInitializer
+    - OZONE-SITE.XML_hdds.x509.ca.rotation.enabled=true
 services:
   datanode:
     <<: *root-cert-rotation-config


### PR DESCRIPTION
https://issues.apache.org/jira/browse/HDDS-8959 


Manual test:
1. start a docker based cluster, remote ssh to one SCM,  verify 
```
   bash-4.2$ jstack 7 | grep RootCARotationManager
  "RootCARotationManager-Inactive" #381 daemon prio=5 os_prio=0 cpu=0.34ms elapsed=21.62s tid=0x0000ffff9a084800 nid=0x2d2 waiting on condition  [0x0000ffff3ade4000]
```

2. stop the cluster, add following configuration
OZONE-SITE.XML_hdds.x509.ca.rotation.enabled=false

4. start a docker based cluster again, run the same command, 
```
bash-4.2$ jstack 7 | grep RootCARotationManager
bash-4.2$ 
```
