### PR TITLE
HDDS-8993. Pin maven-antrun-plugin version to 3.1.0

### DIFF
--- a/hadoop-hdds/interface-client/pom.xml
+++ b/hadoop-hdds/interface-client/pom.xml
@@ -132,11 +132,12 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
       </plugin>
       <plugin>
         <artifactId>maven-antrun-plugin</artifactId>
+        <version>${maven-antrun-plugin.version}</version>
         <executions>
           <execution>
             <phase>generate-sources</phase>
             <configuration>
-              <tasks>
+              <target>
                 <replace token="com.google.protobuf"
                          value="org.apache.ratis.thirdparty.com.google.protobuf"
                          dir="target/generated-sources/java/org/apache/hadoop/hdds/protocol/datanode/proto">
@@ -161,7 +162,7 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
                       tofile="target/generated-sources/java/proto3/org/apache/hadoop/hdds/protocol/proto3"/>
                 <move file="target/generated-sources/java/proto3"
                       tofile="target/generated-sources/java"/>
-              </tasks>
+              </target>
             </configuration>
             <goals>
               <goal>run</goal>

--- a/hadoop-hdds/interface-server/pom.xml
+++ b/hadoop-hdds/interface-server/pom.xml
@@ -101,11 +101,12 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
       </plugin>
       <plugin>
         <artifactId>maven-antrun-plugin</artifactId>
+        <version>${maven-antrun-plugin.version}</version>
         <executions>
           <execution>
             <phase>generate-sources</phase>
             <configuration>
-              <tasks>
+              <target>
                 <replace token="com.google.protobuf"
                          value="org.apache.ratis.thirdparty.com.google.protobuf"
                          dir="target/generated-sources/java/org/apache/hadoop/hdds/protocol/scm/proto">
@@ -118,7 +119,7 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
                          value="org.apache.ratis.thirdparty.com.google.common"
                          dir="target/generated-sources/java/org/apache/hadoop/hdds/protocol/scm/proto">
                 </replace>
-              </tasks>
+              </target>
             </configuration>
             <goals>
               <goal>run</goal>

--- a/hadoop-hdds/rocks-native/pom.xml
+++ b/hadoop-hdds/rocks-native/pom.xml
@@ -192,19 +192,20 @@
                     </plugin>
                     <plugin>
                         <artifactId>maven-antrun-plugin</artifactId>
+                        <version>${maven-antrun-plugin.version}</version>
                         <executions>
                             <execution>
                                 <id>unzip-artifact</id>
                                 <phase>generate-sources</phase>
                                 <configuration>
-                                    <tasks>
+                                    <target>
                                         <untar src="${project.build.directory}/rocksdb/rocksdb-v${rocksdb.version}.tar.gz" compression="gzip" dest="${project.build.directory}/rocksdb/" />
                                         <untar src="${project.build.directory}/zlib/zlib-${zlib.version}.tar.gz" compression="gzip" dest="${project.build.directory}/zlib/" />
                                         <untar src="${project.build.directory}/bzip2/bzip2-v${bzip2.version}.tar.gz" compression="gzip" dest="${project.build.directory}/bzip2/" />
                                         <untar src="${project.build.directory}/lz4/lz4-v${lz4.version}.tar.gz" compression="gzip" dest="${project.build.directory}/lz4/" />
                                         <untar src="${project.build.directory}/snappy/snappy-v${snappy.version}.tar.gz" compression="gzip" dest="${project.build.directory}/snappy/" />
                                         <untar src="${project.build.directory}/zstd/zstd-v${zstd.version}.tar.gz" compression="gzip" dest="${project.build.directory}/zstd/" />
-                                    </tasks>
+                                    </target>
                                 </configuration>
                                 <goals>
                                     <goal>run</goal>

--- a/hadoop-hdds/rocks-native/pom.xml
+++ b/hadoop-hdds/rocks-native/pom.xml
@@ -215,14 +215,14 @@
                                 <id>build-zlib</id>
                                 <phase>process-sources</phase>
                                 <configuration>
-                                    <tasks>
+                                    <target>
                                         <chmod file="${project.build.directory}/zlib/zlib-${zlib.version}/configure" perm="775" />
                                         <exec executable="./configure" dir="${project.build.directory}/zlib/zlib-${zlib.version}" failonerror="true">
                                             <arg line="--static"/>
                                             <env key="CFLAGS" value="-fPIC"/>
                                         </exec>
                                         <exec executable="make" dir="${project.build.directory}/zlib/zlib-${zlib.version}" failonerror="true"/>
-                                    </tasks>
+                                    </target>
                                 </configuration>
                                 <goals>
                                     <goal>run</goal>
@@ -232,11 +232,11 @@
                                 <id>build-bzip2</id>
                                 <phase>process-sources</phase>
                                 <configuration>
-                                    <tasks>
+                                    <target>
                                         <exec executable="make" dir="${project.build.directory}/bzip2/bzip2-${bzip2.version}" failonerror="true">
                                             <arg line="CFLAGS='-fPIC'"/>
                                         </exec>
-                                    </tasks>
+                                    </target>
                                 </configuration>
                                 <goals>
                                     <goal>run</goal>
@@ -246,11 +246,11 @@
                                 <id>build-lz4</id>
                                 <phase>process-sources</phase>
                                 <configuration>
-                                    <tasks>
+                                    <target>
                                         <exec executable="make" dir="${project.build.directory}/lz4/lz4-${lz4.version}" failonerror="true">
                                             <arg line="CFLAGS='-fPIC'"/>
                                         </exec>
-                                    </tasks>
+                                    </target>
                                 </configuration>
                                 <goals>
                                     <goal>run</goal>
@@ -260,11 +260,11 @@
                                 <id>build-zstd</id>
                                 <phase>process-sources</phase>
                                 <configuration>
-                                    <tasks>
+                                    <target>
                                         <exec executable="make" dir="${project.build.directory}/zstd/zstd-${zstd.version}" failonerror="true">
                                             <arg line="CFLAGS='-fPIC'"/>
                                         </exec>
-                                    </tasks>
+                                    </target>
                                 </configuration>
                                 <goals>
                                     <goal>run</goal>
@@ -274,7 +274,7 @@
                                 <id>build-snappy</id>
                                 <phase>process-sources</phase>
                                 <configuration>
-                                    <tasks>
+                                    <target>
                                         <mkdir dir="${project.build.directory}/snappy/lib"/>
                                         <exec executable="cmake" failonerror="true" dir="${project.build.directory}/snappy/lib">
                                             <arg line="${project.build.directory}/snappy/snappy-${snappy.version}"/>
@@ -282,7 +282,7 @@
                                             <env key="CXXFLAGS" value="-fPIC"/>
                                         </exec>
                                         <exec executable="make" dir="${project.build.directory}/snappy/lib" failonerror="true"/>
-                                    </tasks>
+                                    </target>
                                 </configuration>
                                 <goals>
                                     <goal>run</goal>
@@ -292,7 +292,7 @@
                                 <id>build-rocksjava</id>
                                 <phase>generate-resources</phase>
                                 <configuration>
-                                    <tasks>
+                                    <target>
                                         <exec executable="chmod" failonerror="true">
                                             <arg line="-R"/>
                                             <arg line="775"/>
@@ -305,7 +305,7 @@
                                             <arg line="-j${system.numCores}"/>
                                             <arg line="tools"/>
                                         </exec>
-                                    </tasks>
+                                    </target>
                                 </configuration>
                                 <goals>
                                     <goal>run</goal>
@@ -315,7 +315,7 @@
                                 <id>build-rocks-tools</id>
                                 <phase>process-classes</phase>
                                 <configuration>
-                                    <tasks>
+                                    <target>
                                         <mkdir dir="${project.build.directory}/native/rocksdb"/>
                                         <exec executable="cmake" failonerror="true" dir="${project.build.directory}/native/rocksdb">
                                             <env key="CFLAGS" value="-fPIC"/>
@@ -334,7 +334,7 @@
                                             <arg line="-DZSTD_LIB=${project.build.directory}/zstd/zstd-${zstd.version}/lib"/>
                                         </exec>
                                         <exec executable="make" dir="${project.build.directory}/native/rocksdb" failonerror="true"/>
-                                    </tasks>
+                                    </target>
                                 </configuration>
                                 <goals>
                                     <goal>run</goal>
@@ -344,11 +344,11 @@
                                 <id>copy-lib-file</id>
                                 <phase>process-classes</phase>
                                 <configuration>
-                                    <tasks>
+                                    <target>
                                         <copy toDir="${project.build.outputDirectory}">
                                             <fileset dir="${project.build.directory}/native/rocksdb" includes="**/lib*.*" />
                                         </copy>
-                                    </tasks>
+                                    </target>
                                 </configuration>
                                 <goals>
                                     <goal>run</goal>

--- a/hadoop-ozone/httpfsgateway/pom.xml
+++ b/hadoop-ozone/httpfsgateway/pom.xml
@@ -250,7 +250,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-antrun-plugin</artifactId>
-        <version>1.8</version>
+        <version>${maven-antrun-plugin.version}</version>
         <executions>
           <execution>
             <id>create-web-xmls</id>

--- a/hadoop-ozone/interface-client/pom.xml
+++ b/hadoop-ozone/interface-client/pom.xml
@@ -110,11 +110,12 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
       </plugin>
       <plugin>
         <artifactId>maven-antrun-plugin</artifactId>
+        <version>${maven-antrun-plugin.version}</version>
         <executions>
           <execution>
             <phase>generate-sources</phase>
             <configuration>
-              <tasks>
+              <target>
                 <replace token="com.google.protobuf"
                          value="org.apache.hadoop.thirdparty.protobuf"
                          dir="target/generated-sources/protobuf/java/proto3/org/apache/hadoop/ozone/protocol/proto">
@@ -145,7 +146,7 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
                       tofile="target/generated-sources/protobuf/java/proto3/org/apache/hadoop/ozone/security/proto3"/>
                 <move file="target/generated-sources/protobuf/java/proto3"
                       tofile="target/generated-sources/protobuf/java/"/>
-              </tasks>
+              </target>
             </configuration>
             <goals>
               <goal>run</goal>

--- a/pom.xml
+++ b/pom.xml
@@ -283,6 +283,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
     <native-maven-plugin.version>1.0-alpha-8</native-maven-plugin.version>
     <maven-checkstyle-plugin.version>3.1.2</maven-checkstyle-plugin.version>
     <maven-site-plugin.version>3.9.1</maven-site-plugin.version>
+    <maven-antrun-plugin.version>3.1.0</maven-antrun-plugin.version>
     <checkstyle.version>9.3</checkstyle.version>
     <surefire.fork.timeout>1200</surefire.fork.timeout>
     <aws-java-sdk.version>1.12.261</aws-java-sdk.version>
@@ -1875,6 +1876,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-antrun-plugin</artifactId>
+        <version>${maven-antrun-plugin.version}</version>
         <executions>
           <execution>
             <id>create-testdirs</id>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Hitting this error during maven build on my end with the latest master branch:

```
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-antrun-plugin:3.1.0:run (default) on project hdds-interface-client: You are using 'tasks' which has been removed from the maven-antrun-plugin. Please use 'target' and refer to the >>Major Version Upgrade to version 3.0.0<< on the plugin site. -> [Help 1]
org.apache.maven.lifecycle.LifecycleExecutionException: Failed to execute goal org.apache.maven.plugins:maven-antrun-plugin:3.1.0:run (default) on project hdds-interface-client: You are using 'tasks' which has been removed from the maven-antrun-plugin. Please use 'target' and refer to the >>Major Version Upgrade to version 3.0.0<< on the plugin site.
```

Then I realized `maven-antrun-plugin` version wasn't actually pinned in most places.

1. Pin maven-antrun-plugin version to 3.1.0
2. Replace `<tasks>` tags with `<target>` because the former is removed in maven-antrun-plugin 3.0.0, according to https://maven.apache.org/plugins/maven-antrun-plugin/

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-8993

## How was this patch tested?

- [x] maven build passed locally
```
mvn clean install -DskipTests -e -Dmaven.javadoc.skip=true -DskipShade
```
- [x] CI build passed, along with all CI tests