### PR TITLE
HDDS-8994. [Multi-Tenant] Add CLI option to allow tenant creation on top of existing volumes

### DIFF
--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/TenantArgs.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/TenantArgs.java
@@ -31,15 +31,27 @@ public final class TenantArgs {
   private final String volumeName;
 
   /**
-   * Private constructor, constructed via builder.
-   * @param volumeName Volume name.
+   * Force tenant creation when volume exists.
    */
-  private TenantArgs(String volumeName) {
+  private final boolean forceCreationWhenVolumeExists;
+
+  /**
+   * Private constructor, constructed via builder.
+   *
+   * @param volumeName                    Volume name.
+   * @param forceCreationWhenVolumeExists Force creation when volume exists.
+   */
+  private TenantArgs(String volumeName, boolean forceCreationWhenVolumeExists) {
     this.volumeName = volumeName;
+    this.forceCreationWhenVolumeExists = forceCreationWhenVolumeExists;
   }
 
   public String getVolumeName() {
     return volumeName;
+  }
+
+  public boolean getForceCreationWhenVolumeExists() {
+    return forceCreationWhenVolumeExists;
   }
 
   /**
@@ -57,6 +69,7 @@ public final class TenantArgs {
   @SuppressWarnings("checkstyle:hiddenfield")
   public static class Builder {
     private String volumeName;
+    private boolean forceCreationWhenVolumeExists;
 
     /**
      * Constructs a builder.
@@ -69,13 +82,19 @@ public final class TenantArgs {
       return this;
     }
 
+    public TenantArgs.Builder setForceCreationWhenVolumeExists(
+        boolean forceCreationWhenVolumeExists) {
+      this.forceCreationWhenVolumeExists = forceCreationWhenVolumeExists;
+      return this;
+    }
+
     /**
      * Constructs a TenantArgs.
      * @return TenantArgs.
      */
     public TenantArgs build() {
       Preconditions.checkNotNull(volumeName);
-      return new TenantArgs(volumeName);
+      return new TenantArgs(volumeName, forceCreationWhenVolumeExists);
     }
   }
 

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/rpc/RpcClient.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/rpc/RpcClient.java
@@ -885,14 +885,21 @@ public class RpcClient implements ClientProtocol {
     final String volumeName = tenantArgs.getVolumeName();
     verifyVolumeName(volumeName);
 
+    final boolean forceCreationWhenVolumeExists =
+        tenantArgs.getForceCreationWhenVolumeExists();
+
     OmTenantArgs.Builder builder = OmTenantArgs.newBuilder();
     builder.setTenantId(tenantId);
     builder.setVolumeName(volumeName);
-    // TODO: Add more fields
-    // TODO: Include OmVolumeArgs in (Om)TenantArgs as well for volume creation?
+    builder.setForceCreationWhenVolumeExists(
+        tenantArgs.getForceCreationWhenVolumeExists());
 
-    LOG.info("Creating Tenant: '{}', with new volume: '{}'",
-        tenantId, volumeName);
+    // TODO: Add more fields. e.g. include OmVolumeArgs in (Om)TenantArgs
+    //  as well for customized volume creation.
+
+    LOG.info("Creating Tenant: '{}', with volume: '{}', "
+            + "forceCreationWhenVolumeExists: {}",
+        tenantId, volumeName, forceCreationWhenVolumeExists);
 
     ozoneManagerClient.createTenant(builder.build());
   }

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmTenantArgs.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmTenantArgs.java
@@ -36,6 +36,11 @@ public class OmTenantArgs {
    */
   private final String volumeName;
 
+  /**
+   * Force tenant creation when volume exists.
+   */
+  private boolean forceCreationWhenVolumeExists;
+
   public OmTenantArgs(String tenantId) {
     this.tenantId = tenantId;
     this.volumeName = this.tenantId;
@@ -46,12 +51,23 @@ public class OmTenantArgs {
     this.volumeName = volumeName;
   }
 
+  public OmTenantArgs(String tenantId, String volumeName,
+      boolean forceCreationWhenVolumeExists) {
+    this.tenantId = tenantId;
+    this.volumeName = volumeName;
+    this.forceCreationWhenVolumeExists = forceCreationWhenVolumeExists;
+  }
+
   public String getTenantId() {
     return tenantId;
   }
 
   public String getVolumeName() {
     return volumeName;
+  }
+
+  public boolean getForceCreationWhenVolumeExists() {
+    return forceCreationWhenVolumeExists;
   }
 
   public static OmTenantArgs.Builder newBuilder() {
@@ -65,6 +81,7 @@ public class OmTenantArgs {
   public static class Builder {
     private String tenantId;
     private String volumeName;
+    private boolean forceCreationWhenVolumeExists;
 
     /**
      * Constructs a builder.
@@ -82,10 +99,17 @@ public class OmTenantArgs {
       return this;
     }
 
+    public Builder setForceCreationWhenVolumeExists(
+        boolean forceCreationWhenVolumeExists) {
+      this.forceCreationWhenVolumeExists = forceCreationWhenVolumeExists;
+      return this;
+    }
+
     public OmTenantArgs build() {
       Preconditions.checkNotNull(tenantId);
       Preconditions.checkNotNull(volumeName);
-      return new OmTenantArgs(tenantId, volumeName);
+      return new OmTenantArgs(tenantId, volumeName,
+          forceCreationWhenVolumeExists);
     }
   }
 

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocolPB/OzoneManagerProtocolClientSideTranslatorPB.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocolPB/OzoneManagerProtocolClientSideTranslatorPB.java
@@ -1074,7 +1074,9 @@ public final class OzoneManagerProtocolClientSideTranslatorPB
     final CreateTenantRequest.Builder requestBuilder =
         CreateTenantRequest.newBuilder()
             .setTenantId(omTenantArgs.getTenantId())
-            .setVolumeName(omTenantArgs.getVolumeName());
+            .setVolumeName(omTenantArgs.getVolumeName())
+            .setForceCreationWhenVolumeExists(
+                omTenantArgs.getForceCreationWhenVolumeExists());
             // Can add more args (like policy names) later if needed
     final OMRequest omRequest = createOMRequest(Type.CreateTenant)
         .setCreateTenantRequest(requestBuilder)

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/shell/TestOzoneTenantShell.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/shell/TestOzoneTenantShell.java
@@ -1077,7 +1077,7 @@ public class TestOzoneTenantShell {
   }
 
   @Test
-  public void testCreateTenantOnExistingVolumeShouldFail() throws IOException {
+  public void testCreateTenantOnExistingVolume() throws IOException {
     final String testVolume = "existing-volume-1";
     int exitC = execute(ozoneSh, new String[] {"volume", "create", testVolume});
     // Volume create should succeed
@@ -1085,12 +1085,26 @@ public class TestOzoneTenantShell {
     checkOutput(out, "", true);
     checkOutput(err, "", true);
 
-    // Try to create tenant on the same volume, should fail
+    // Try to create tenant on the same volume, should fail by default
     executeHA(tenantShell, new String[] {"create", testVolume});
     checkOutput(out, "", true);
     checkOutput(err, "Volume already exists\n", true);
 
+    // Try to create tenant on the same volume with --force, should work
+    executeHA(tenantShell, new String[] {"create", testVolume, "--force"});
+    checkOutput(out, "", true);
+    checkOutput(err, "", true);
+
+    // Try to create the same tenant one more time, should fail even
+    // with --force because the tenant already exists.
+    executeHA(tenantShell, new String[] {"create", testVolume, "--force"});
+    checkOutput(out, "", true);
+    checkOutput(err, "Tenant '" + testVolume + "' already exists\n", true);
+
     // Clean up
+    executeHA(tenantShell, new String[] {"delete", testVolume});
+    checkOutput(out, "", true);
+    checkOutput(err, "Deleted tenant '" + testVolume + "'.\n", false);
     deleteVolume(testVolume);
   }
 }

--- a/hadoop-ozone/interface-client/src/main/proto/OmClientProtocol.proto
+++ b/hadoop-ozone/interface-client/src/main/proto/OmClientProtocol.proto
@@ -1724,6 +1724,7 @@ message CreateTenantRequest {
     optional string volumeName = 2;
     optional string userRoleName = 3;
     optional string adminRoleName = 4;
+    optional bool forceCreationWhenVolumeExists = 5;
 }
 
 message SetRangerServiceVersionRequest {

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/tenant/OMTenantCreateRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/tenant/OMTenantCreateRequest.java
@@ -147,9 +147,16 @@ public class OMTenantCreateRequest extends OMVolumeRequest {
     final String dbVolumeKey = ozoneManager.getMetadataManager()
         .getVolumeKey(volumeName);
 
+    // Backwards compatibility with older Ozone clients that don't have this
+    // field. Defaults to false.
+    boolean forceCreationWhenVolumeExists =
+        request.hasForceCreationWhenVolumeExists()
+            && request.getForceCreationWhenVolumeExists();
+
     // Check volume existence
-    if (ozoneManager.getMetadataManager().getVolumeTable()
-        .isExist(dbVolumeKey)) {
+    if (!forceCreationWhenVolumeExists &&
+        ozoneManager.getMetadataManager().getVolumeTable().isExist(
+            dbVolumeKey)) {
       LOG.debug("volume: '{}' already exists", volumeName);
       throw new OMException("Volume already exists", VOLUME_ALREADY_EXISTS);
     }
@@ -186,12 +193,6 @@ public class OMTenantCreateRequest extends OMVolumeRequest {
       throw e;
     }
 
-    // Backwards compatibility with older Ozone clients that don't have this
-    // field. Defaults to false.
-    boolean forceCreationWhenVolumeExists =
-        request.hasForceCreationWhenVolumeExists()
-            && request.getForceCreationWhenVolumeExists();
-
     final OMRequest.Builder omRequestBuilder = omRequest.toBuilder()
         .setCreateTenantRequest(
             CreateTenantRequest.newBuilder()
@@ -224,7 +225,7 @@ public class OMTenantCreateRequest extends OMVolumeRequest {
     OMClientResponse omClientResponse = null;
     final OMResponse.Builder omResponse =
         OmResponseUtil.getOMResponseBuilder(getOmRequest());
-    OmVolumeArgs omVolumeArgs;
+    OmVolumeArgs omVolumeArgs = null;
     boolean acquiredVolumeLock = false;
     boolean acquiredUserLock = false;
     final String owner = getOmRequest().getUserInfo().getUserName();
@@ -259,46 +260,51 @@ public class OMTenantCreateRequest extends OMVolumeRequest {
       acquiredVolumeLock = omMetadataManager.getLock().acquireWriteLock(
           VOLUME_LOCK, volumeName);
 
+      boolean skipVolumeCreation = false;
       // Check volume existence
       if (omMetadataManager.getVolumeTable().isExist(dbVolumeKey)) {
         LOG.debug("volume: '{}' already exists", volumeName);
         if (forceCreationWhenVolumeExists) {
-          LOG.warn("But forceCreationWhenVolumeExists is set to true. Resuming "
+          LOG.warn("forceCreationWhenVolumeExists = true. Resuming "
               + "tenant creation despite volume '{}' existence", volumeName);
+          skipVolumeCreation = true;
         } else {
           // forceCreationWhenVolumeExists is false, throw
           throw new OMException("Volume already exists", VOLUME_ALREADY_EXISTS);
         }
       }
 
-      // Create volume
-      acquiredUserLock = omMetadataManager.getLock().acquireWriteLock(USER_LOCK,
-          owner);
+      PersistedUserVolumeInfo volumeList = null;
+      if (!skipVolumeCreation) {
+        // Create volume
+        acquiredUserLock = omMetadataManager.getLock().acquireWriteLock(
+            USER_LOCK, owner);
 
-      // TODO: dedup OMVolumeCreateRequest
-      omVolumeArgs = OmVolumeArgs.getFromProtobuf(volumeInfo);
-      omVolumeArgs.setQuotaInBytes(OzoneConsts.QUOTA_RESET);
-      omVolumeArgs.setQuotaInNamespace(OzoneConsts.QUOTA_RESET);
-      omVolumeArgs.setObjectID(
-          ozoneManager.getObjectIdFromTxId(transactionLogIndex));
-      omVolumeArgs.setUpdateID(transactionLogIndex,
-          ozoneManager.isRatisEnabled());
-      // Set volume reference count to 1
-      omVolumeArgs.incRefCount();
-      Preconditions.checkState(omVolumeArgs.getRefCount() == 1,
-          "refCount should have been set to 1");
-      // Audit
-      auditMap = omVolumeArgs.toAuditMap();
+        // TODO: dedup OMVolumeCreateRequest
+        omVolumeArgs = OmVolumeArgs.getFromProtobuf(volumeInfo);
+        omVolumeArgs.setQuotaInBytes(OzoneConsts.QUOTA_RESET);
+        omVolumeArgs.setQuotaInNamespace(OzoneConsts.QUOTA_RESET);
+        omVolumeArgs.setObjectID(
+            ozoneManager.getObjectIdFromTxId(transactionLogIndex));
+        omVolumeArgs.setUpdateID(transactionLogIndex,
+            ozoneManager.isRatisEnabled());
+        // Set volume reference count to 1
+        omVolumeArgs.incRefCount();
+        Preconditions.checkState(omVolumeArgs.getRefCount() == 1,
+            "refCount should have been set to 1");
+        // Audit
+        auditMap = omVolumeArgs.toAuditMap();
 
-      PersistedUserVolumeInfo volumeList;
-      final String dbUserKey = omMetadataManager.getUserKey(owner);
-      volumeList = omMetadataManager.getUserTable().get(dbUserKey);
-      volumeList = addVolumeToOwnerList(volumeList, volumeName, owner,
-          ozoneManager.getMaxUserVolumeCount(), transactionLogIndex);
-      createVolume(omMetadataManager, omVolumeArgs, volumeList, dbVolumeKey,
-          dbUserKey, transactionLogIndex);
-      LOG.debug("volume: '{}' successfully created", dbVolumeKey);
-
+        final String dbUserKey = omMetadataManager.getUserKey(owner);
+        volumeList = omMetadataManager.getUserTable().get(dbUserKey);
+        volumeList = addVolumeToOwnerList(volumeList, volumeName, owner,
+            ozoneManager.getMaxUserVolumeCount(), transactionLogIndex);
+        createVolume(omMetadataManager, omVolumeArgs, volumeList, dbVolumeKey,
+            dbUserKey, transactionLogIndex);
+        LOG.debug("volume: '{}' successfully created", dbVolumeKey);
+      } else {
+        LOG.info("Skipped volume '{}' creation", volumeName);
+      }
 
       // Check tenant existence in tenantStateTable
       if (omMetadataManager.getTenantStateTable().isExist(tenantId)) {

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/s3/tenant/OMTenantCreateResponse.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/s3/tenant/OMTenantCreateResponse.java
@@ -26,7 +26,7 @@ import org.apache.hadoop.ozone.om.helpers.OmVolumeArgs;
 import org.apache.hadoop.ozone.om.response.CleanupTableInfo;
 import org.apache.hadoop.ozone.om.response.OMClientResponse;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMResponse;
-import org.apache.hadoop.ozone.storage.proto.OzoneManagerStorageProtos;
+import org.apache.hadoop.ozone.storage.proto.OzoneManagerStorageProtos.PersistedUserVolumeInfo;
 
 import javax.annotation.Nonnull;
 import java.io.IOException;
@@ -43,13 +43,13 @@ import static org.apache.hadoop.ozone.om.OmMetadataManagerImpl.VOLUME_TABLE;
 })
 public class OMTenantCreateResponse extends OMClientResponse {
 
-  private OzoneManagerStorageProtos.PersistedUserVolumeInfo userVolumeInfo;
+  private PersistedUserVolumeInfo userVolumeInfo;
   private OmVolumeArgs omVolumeArgs;
   private OmDBTenantState omTenantState;
 
   public OMTenantCreateResponse(@Nonnull OMResponse omResponse,
-      @Nonnull OmVolumeArgs omVolumeArgs,
-      @Nonnull OzoneManagerStorageProtos.PersistedUserVolumeInfo userVolumeInfo,
+      OmVolumeArgs omVolumeArgs,
+      PersistedUserVolumeInfo userVolumeInfo,
       @Nonnull OmDBTenantState omTenantState
   ) {
     super(omResponse);
@@ -75,16 +75,19 @@ public class OMTenantCreateResponse extends OMClientResponse {
     omMetadataManager.getTenantStateTable().putWithBatch(
         batchOperation, tenantId, omTenantState);
 
-    // From OMVolumeCreateResponse
-    String dbVolumeKey =
-        omMetadataManager.getVolumeKey(omVolumeArgs.getVolume());
-    String dbUserKey =
-        omMetadataManager.getUserKey(omVolumeArgs.getOwnerName());
+    // omVolumeArgs and userVolumeInfo can be null when skipped volume creation
+    if (omVolumeArgs != null && userVolumeInfo != null) {
+      // From OMVolumeCreateResponse
+      String dbVolumeKey =
+          omMetadataManager.getVolumeKey(omVolumeArgs.getVolume());
+      String dbUserKey =
+          omMetadataManager.getUserKey(omVolumeArgs.getOwnerName());
 
-    omMetadataManager.getVolumeTable().putWithBatch(batchOperation,
-        dbVolumeKey, omVolumeArgs);
-    omMetadataManager.getUserTable().putWithBatch(batchOperation, dbUserKey,
-        userVolumeInfo);
+      omMetadataManager.getVolumeTable().putWithBatch(batchOperation,
+          dbVolumeKey, omVolumeArgs);
+      omMetadataManager.getUserTable().putWithBatch(batchOperation, dbUserKey,
+          userVolumeInfo);
+    }
   }
 
   @VisibleForTesting

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/s3/tenant/OMTenantCreateResponse.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/s3/tenant/OMTenantCreateResponse.java
@@ -48,7 +48,7 @@ public class OMTenantCreateResponse extends OMClientResponse {
   private OmDBTenantState omTenantState;
 
   public OMTenantCreateResponse(@Nonnull OMResponse omResponse,
-      OmVolumeArgs omVolumeArgs,
+      @Nonnull OmVolumeArgs omVolumeArgs,
       PersistedUserVolumeInfo userVolumeInfo,
       @Nonnull OmDBTenantState omTenantState
   ) {
@@ -75,16 +75,16 @@ public class OMTenantCreateResponse extends OMClientResponse {
     omMetadataManager.getTenantStateTable().putWithBatch(
         batchOperation, tenantId, omTenantState);
 
-    // omVolumeArgs and userVolumeInfo can be null when skipped volume creation
-    if (omVolumeArgs != null && userVolumeInfo != null) {
-      // From OMVolumeCreateResponse
-      String dbVolumeKey =
-          omMetadataManager.getVolumeKey(omVolumeArgs.getVolume());
+    // From OMVolumeCreateResponse
+    String dbVolumeKey =
+        omMetadataManager.getVolumeKey(omVolumeArgs.getVolume());
+    omMetadataManager.getVolumeTable().putWithBatch(batchOperation,
+        dbVolumeKey, omVolumeArgs);
+
+    // userVolumeInfo can be null when skipped volume creation
+    if (userVolumeInfo != null) {
       String dbUserKey =
           omMetadataManager.getUserKey(omVolumeArgs.getOwnerName());
-
-      omMetadataManager.getVolumeTable().putWithBatch(batchOperation,
-          dbVolumeKey, omVolumeArgs);
       omMetadataManager.getUserTable().putWithBatch(batchOperation, dbUserKey,
           userVolumeInfo);
     }

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestOMMultiTenantManager.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestOMMultiTenantManager.java
@@ -139,7 +139,7 @@ public class TestOMMultiTenantManager {
 
     // Check that Multi-Tenancy write requests are blocked when not enabled
     expectWriteRequestToFail(ozoneManager,
-        OMRequestTestUtils.createTenantRequest(tenantId));
+        OMRequestTestUtils.createTenantRequest(tenantId, false));
     expectWriteRequestToFail(ozoneManager,
         OMRequestTestUtils.deleteTenantRequest(tenantId));
     expectWriteRequestToFail(ozoneManager,

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestOMTenantCreateRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestOMTenantCreateRequest.java
@@ -135,7 +135,7 @@ public class TestOMTenantCreateRequest {
 
   @Test
   public void testValidateAndUpdateCacheWhenVolumeExists() throws Exception {
-    // Check that forceCreationWhenVolumeExists flag is effective
+    // Check that forceCreationWhenVolumeExists flag behaves as expected
 
     final String tenantId = UUID.randomUUID().toString();
     final String ownerName = "username";
@@ -144,7 +144,7 @@ public class TestOMTenantCreateRequest {
     //  the volume already exists.
     OMRequestTestUtils.addVolumeToDB(tenantId, ownerName, omMetadataManager);
 
-    // forceCreationWhenVolumeExists = false
+    // First with forceCreationWhenVolumeExists = false
     OMRequest originalRequest =
         OMRequestTestUtils.createTenantRequest(tenantId, false);
     OMTenantCreateRequest omTenantCreateRequest1 =
@@ -155,7 +155,7 @@ public class TestOMTenantCreateRequest {
     LambdaTestUtils.intercept(OMException.class, "VOLUME_ALREADY_EXISTS",
         () -> omTenantCreateRequest1.preExecute(ozoneManager));
 
-    // forceCreationWhenVolumeExists = true
+    // Now with forceCreationWhenVolumeExists = true
     originalRequest =
         OMRequestTestUtils.createTenantRequest(tenantId, true);
     OMTenantCreateRequest omTenantCreateRequest2 =
@@ -168,19 +168,19 @@ public class TestOMTenantCreateRequest {
 
     // Craft a request that sets forceCreationWhenVolumeExists to false to test
     //  validateAndUpdateCache.
-    CreateTenantRequest transformedRequest =
+    CreateTenantRequest reqPostPreExecute =
         omTenantCreateRequest2.getOmRequest().getCreateTenantRequest();
-    OMRequest modRequest =
+    OMRequest modReqPostPreExecute =
         omTenantCreateRequest2.getOmRequest().toBuilder()
             .setCreateTenantRequest(
                 CreateTenantRequest.newBuilder()
                     .setTenantId(tenantId)
-                    .setVolumeName(transformedRequest.getVolumeName())
-                    .setUserRoleName(transformedRequest.getUserRoleName())
-                    .setAdminRoleName(transformedRequest.getAdminRoleName())
+                    .setVolumeName(reqPostPreExecute.getVolumeName())
+                    .setUserRoleName(reqPostPreExecute.getUserRoleName())
+                    .setAdminRoleName(reqPostPreExecute.getAdminRoleName())
                     .setForceCreationWhenVolumeExists(false)).build();
     OMTenantCreateRequest modTenantCreateRequest =
-        new OMTenantCreateRequest(modRequest);
+        new OMTenantCreateRequest(modReqPostPreExecute);
     // OMResponse should have status VOLUME_ALREADY_EXISTS in this crafted case
     OMClientResponse modOMClientResponse =
         modTenantCreateRequest.validateAndUpdateCache(ozoneManager, 2L,

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestOMTenantCreateRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestOMTenantCreateRequest.java
@@ -28,8 +28,10 @@ import org.apache.hadoop.ozone.om.request.OMRequestTestUtils;
 import org.apache.hadoop.ozone.om.request.s3.tenant.OMTenantCreateRequest;
 import org.apache.hadoop.ozone.om.response.OMClientResponse;
 import org.apache.hadoop.ozone.om.upgrade.OMLayoutVersionManager;
-import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos;
+import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.CreateTenantRequest;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMRequest;
+import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMResponse;
+import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.Status;
 import org.apache.ozone.test.LambdaTestUtils;
 import org.junit.After;
 import org.junit.Assert;
@@ -39,6 +41,7 @@ import org.junit.rules.TemporaryFolder;
 import org.junit.Test;
 import org.mockito.Mockito;
 
+import java.io.IOException;
 import java.util.UUID;
 
 import static org.mockito.ArgumentMatchers.any;
@@ -102,6 +105,102 @@ public class TestOMTenantCreateRequest {
     Mockito.framework().clearInlineMocks();
   }
 
+  @Test
+  public void testValidateAndUpdateCache() throws IOException {
+    // Happy path
+
+    final String tenantId = UUID.randomUUID().toString();
+
+    OMRequest originalRequest =
+        OMRequestTestUtils.createTenantRequest(tenantId, false);
+    OMTenantCreateRequest omTenantCreateRequest =
+        Mockito.spy(new OMTenantCreateRequest(originalRequest));
+    Mockito.doReturn("username").when(omTenantCreateRequest).getUserName();
+
+    // First creation should be successful
+    OMRequest modifiedRequest = omTenantCreateRequest.preExecute(ozoneManager);
+    omTenantCreateRequest = new OMTenantCreateRequest(modifiedRequest);
+
+    long txLogIndex = 1L;
+    OMClientResponse omClientResponse =
+        omTenantCreateRequest.validateAndUpdateCache(ozoneManager, txLogIndex,
+            ozoneManagerDoubleBufferHelper);
+    OMResponse omResponse = omClientResponse.getOMResponse();
+
+    Assert.assertNotNull(omResponse.getCreateTenantResponse());
+    Assert.assertEquals(Status.OK, omResponse.getStatus());
+    Assert.assertNotNull(omMetadataManager.getVolumeTable().get(
+        omMetadataManager.getVolumeKey(tenantId)));
+  }
+
+  @Test
+  public void testValidateAndUpdateCacheWhenVolumeExists() throws Exception {
+    // Check that forceCreationWhenVolumeExists flag is effective
+
+    final String tenantId = UUID.randomUUID().toString();
+    final String ownerName = "username";
+
+    // Deliberately put volume entry in VolumeTable, to simulate the case where
+    //  the volume already exists.
+    OMRequestTestUtils.addVolumeToDB(tenantId, ownerName, omMetadataManager);
+
+    // forceCreationWhenVolumeExists = false
+    OMRequest originalRequest =
+        OMRequestTestUtils.createTenantRequest(tenantId, false);
+    OMTenantCreateRequest omTenantCreateRequest1 =
+        Mockito.spy(new OMTenantCreateRequest(originalRequest));
+    Mockito.doReturn(ownerName).when(omTenantCreateRequest1).getUserName();
+
+    // Should throw in preExecute
+    LambdaTestUtils.intercept(OMException.class, "VOLUME_ALREADY_EXISTS",
+        () -> omTenantCreateRequest1.preExecute(ozoneManager));
+
+    // forceCreationWhenVolumeExists = true
+    originalRequest =
+        OMRequestTestUtils.createTenantRequest(tenantId, true);
+    OMTenantCreateRequest omTenantCreateRequest2 =
+        Mockito.spy(new OMTenantCreateRequest(originalRequest));
+    Mockito.doReturn(ownerName).when(omTenantCreateRequest2).getUserName();
+
+    // Should not throw now that forceCreationWhenVolumeExists = true
+    OMRequest modifiedRequest = omTenantCreateRequest2.preExecute(ozoneManager);
+    omTenantCreateRequest2 = new OMTenantCreateRequest(modifiedRequest);
+
+    // Craft a request that sets forceCreationWhenVolumeExists to false to test
+    //  validateAndUpdateCache.
+    CreateTenantRequest transformedRequest =
+        omTenantCreateRequest2.getOmRequest().getCreateTenantRequest();
+    OMRequest modRequest =
+        omTenantCreateRequest2.getOmRequest().toBuilder()
+            .setCreateTenantRequest(
+                CreateTenantRequest.newBuilder()
+                    .setTenantId(tenantId)
+                    .setVolumeName(transformedRequest.getVolumeName())
+                    .setUserRoleName(transformedRequest.getUserRoleName())
+                    .setAdminRoleName(transformedRequest.getAdminRoleName())
+                    .setForceCreationWhenVolumeExists(false)).build();
+    OMTenantCreateRequest modTenantCreateRequest =
+        new OMTenantCreateRequest(modRequest);
+    // OMResponse should have status VOLUME_ALREADY_EXISTS in this crafted case
+    OMClientResponse modOMClientResponse =
+        modTenantCreateRequest.validateAndUpdateCache(ozoneManager, 2L,
+            ozoneManagerDoubleBufferHelper);
+    Assert.assertEquals(Status.VOLUME_ALREADY_EXISTS,
+        modOMClientResponse.getOMResponse().getStatus());
+    Assert.assertEquals("Volume already exists",
+        modOMClientResponse.getOMResponse().getMessage());
+
+    // validateAndUpdateCache with forceCreationWhenVolumeExists = true
+    OMClientResponse omClientResponse =
+        omTenantCreateRequest2.validateAndUpdateCache(ozoneManager, 2L,
+            ozoneManagerDoubleBufferHelper);
+    OMResponse omResponse = omClientResponse.getOMResponse();
+
+    Assert.assertNotNull(omResponse.getCreateTenantResponse());
+    Assert.assertEquals(Status.OK, omResponse.getStatus());
+    Assert.assertNotNull(omMetadataManager.getVolumeTable().get(
+        omMetadataManager.getVolumeKey(tenantId)));
+  }
 
   @Test
   public void
@@ -140,7 +239,7 @@ public class TestOMTenantCreateRequest {
   private void acceptTenantIdCreationHelper(String tenantId)
       throws Exception {
     OMRequest originalRequest =
-        OMRequestTestUtils.createTenantRequest(tenantId);
+        OMRequestTestUtils.createTenantRequest(tenantId, false);
     OMTenantCreateRequest omTenantCreateRequest =
         Mockito.spy(new OMTenantCreateRequest(originalRequest));
     Mockito.doReturn("username").when(omTenantCreateRequest).getUserName();
@@ -151,12 +250,10 @@ public class TestOMTenantCreateRequest {
     OMClientResponse omClientResponse =
         omTenantCreateRequest.validateAndUpdateCache(ozoneManager, txLogIndex,
             ozoneManagerDoubleBufferHelper);
-    OzoneManagerProtocolProtos.OMResponse omResponse =
-        omClientResponse.getOMResponse();
+    OMResponse omResponse = omClientResponse.getOMResponse();
 
     Assert.assertNotNull(omResponse.getCreateTenantResponse());
-    Assert.assertEquals(OzoneManagerProtocolProtos.Status.OK,
-        omResponse.getStatus());
+    Assert.assertEquals(Status.OK, omResponse.getStatus());
     Assert.assertNotNull(omMetadataManager.getVolumeTable().get(
         omMetadataManager.getVolumeKey(tenantId)));
   }
@@ -171,7 +268,7 @@ public class TestOMTenantCreateRequest {
 
   private void doPreExecute(String tenantId) throws Exception {
     OMRequest originalRequest =
-        OMRequestTestUtils.createTenantRequest(tenantId);
+        OMRequestTestUtils.createTenantRequest(tenantId, false);
 
     OMTenantCreateRequest omTenantCreateRequest =
         Mockito.spy(new OMTenantCreateRequest(originalRequest));

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/OMRequestTestUtils.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/OMRequestTestUtils.java
@@ -971,12 +971,14 @@ public final class OMRequestTestUtils {
         .setClientId(UUID.randomUUID().toString()).build();
   }
 
-  public static OMRequest createTenantRequest(String tenantId) {
+  public static OMRequest createTenantRequest(String tenantId,
+      boolean forceCreationWhenVolumeExists) {
 
     final CreateTenantRequest.Builder requestBuilder =
         CreateTenantRequest.newBuilder()
             .setTenantId(tenantId)
-            .setVolumeName(tenantId);
+            .setVolumeName(tenantId)
+            .setForceCreationWhenVolumeExists(forceCreationWhenVolumeExists);
 
     return OMRequest.newBuilder()
         .setCreateTenantRequest(requestBuilder)

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/tenant/TenantCreateHandler.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/tenant/TenantCreateHandler.java
@@ -21,6 +21,7 @@ import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.JsonObject;
 import org.apache.hadoop.ozone.client.OzoneClient;
+import org.apache.hadoop.ozone.client.TenantArgs;
 import org.apache.hadoop.ozone.shell.OzoneAddress;
 import picocli.CommandLine;
 
@@ -37,11 +38,23 @@ public class TenantCreateHandler extends TenantHandler {
   @CommandLine.Parameters(description = "Tenant name", arity = "1..1")
   private String tenantId;
 
+  @CommandLine.Option(names = {"-f", "--force"},
+      description = "(Optional) Force tenant creation even when volume exists. "
+          + "This does NOT override other errors like Ranger failure.",
+      hidden = true)
+  // This option is intentionally hidden to avoid abuse.
+  private boolean forceCreationWhenVolumeExists;
+
   @Override
   protected void execute(OzoneClient client, OzoneAddress address)
       throws IOException {
 
-    client.getObjectStore().createTenant(tenantId);
+    final TenantArgs tenantArgs = TenantArgs.newBuilder()
+        .setVolumeName(tenantId)
+        .setForceCreationWhenVolumeExists(forceCreationWhenVolumeExists)
+        .build();
+
+    client.getObjectStore().createTenant(tenantId, tenantArgs);
     // RpcClient#createTenant prints INFO level log of tenant and volume name
 
     if (isVerbose()) {


### PR DESCRIPTION
## What changes were proposed in this pull request?

Add `--force` option to tenant create CLI that allows a tenant to be created even when the volume exists. Note this option does NOT override any other failures, e.g. Ranger failures

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-8994

## How was this patch tested?

- [x] Added Ratis Tx UT.
- [x] Added CLI integration test case.