### PR TITLE
HDDS-8928. SCM Decommissioning command should exit with non-zero code on failure.

### DIFF
--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/admin/scm/DecommissionScmSubcommand.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/admin/scm/DecommissionScmSubcommand.java
@@ -49,10 +49,13 @@ public class DecommissionScmSubcommand extends ScmSubcommand {
   public void execute(ScmClient scmClient) throws IOException {
     DecommissionScmResponseProto response = scmClient.decommissionScm(nodeId);
     if (!response.getSuccess()) {
-      System.out.println("Error decommissioning Scm " + nodeId);
+      String errorMsg = "Error decommissioning Scm " + nodeId;
       if (response.hasErrorMsg()) {
-        System.out.println(response.getErrorMsg());
+        errorMsg = errorMsg + ", " + response.getErrorMsg();
       }
+      System.err.println(errorMsg);
+      // Throwing exception to create non-zero exit code in case of failure.
+      throw new IOException(errorMsg);
     } else {
       System.out.println("Decommissioned Scm " + nodeId);
     }

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/admin/scm/DecommissionScmSubcommand.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/admin/scm/DecommissionScmSubcommand.java
@@ -53,7 +53,6 @@ public class DecommissionScmSubcommand extends ScmSubcommand {
       if (response.hasErrorMsg()) {
         errorMsg = errorMsg + ", " + response.getErrorMsg();
       }
-      System.err.println(errorMsg);
       // Throwing exception to create non-zero exit code in case of failure.
       throw new IOException(errorMsg);
     } else {

--- a/hadoop-ozone/tools/src/test/java/org/apache/hadoop/ozone/scm/TestDecommissionScmSubcommand.java
+++ b/hadoop-ozone/tools/src/test/java/org/apache/hadoop/ozone/scm/TestDecommissionScmSubcommand.java
@@ -23,11 +23,14 @@ import org.apache.hadoop.hdds.scm.client.ScmClient;
 import org.apache.hadoop.ozone.admin.scm.DecommissionScmSubcommand;
 import org.apache.ozone.test.GenericTestUtils;
 
+import java.io.IOException;
 import java.util.UUID;
 
 import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import org.mockito.Mockito;
+
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.mock;
 import picocli.CommandLine;
@@ -98,11 +101,9 @@ public class TestDecommissionScmSubcommand {
     try (GenericTestUtils.SystemOutCapturer capture =
              new GenericTestUtils.SystemOutCapturer()) {
       cmd.execute(client);
-      assertTrue(capture.getOutput().contains(
-          "remove current leader"));
+      fail();
+    } catch (IOException ex) {
+      assertTrue(ex.getMessage().contains("remove current leader"));
     }
   }
-
-  // TODO: test decommission revoke certificate
-
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?
SCM Decommissioning command currently prints the error message on failure, but the exit code is 0. The decommissioning command should exit with non-zero code on failure.

## What is the link to the Apache JIRA
[HDDS-8928](https://issues.apache.org/jira/browse/HDDS-8928)

## How was this patch tested?
Modified and verified the existing unit test
