### PR TITLE
HDDS-8998. Shared mutable state causes rootca poller to miss updates.

### DIFF
--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/security/x509/certificate/client/DefaultCertificateClient.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/security/x509/certificate/client/DefaultCertificateClient.java
@@ -191,7 +191,7 @@ public abstract class DefaultCertificateClient implements CertificateClient {
   private void startRootCaRotationPoller() {
     if (rootCaRotationPoller == null) {
       rootCaRotationPoller = new RootCaRotationPoller(securityConfig,
-          rootCaCertificates, scmSecurityClient);
+          new HashSet<>(rootCaCertificates), scmSecurityClient);
       rootCaRotationPoller.addRootCARotationProcessor(
           this::getRootCaRotationListener);
       rootCaRotationPoller.run();


### PR DESCRIPTION
## What changes were proposed in this pull request?

The PR proposes a change in how the RootCaRotationPoller is being instantiated, as the shared rootCaCertificates set from the DefaultCertificateClient is causing a problem.
The problem was found as part of the testing done for HDDS-8605, it is causing a problem in the case of the following events in order:
- rootCA certificates are being rotated
- OM certificate is being renewed with the new CA certs
- RootCaRotationPoller is running after the certificate renewal

The cause it the shared rootCaCertificates set, which is updated by the certificate renewal process within the DefaultCertificateClient, so that the poller once it gets to poll the new certificates, it does not recognize that there is an unkown certificate (as it already knows it via the change in the data structure during renewal), therefore it does not update its listeners about the rootCA change in this scenario.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-8998

## How was this patch tested?
In #5009 I am working on to add filesystem client calls towards the DataNodes that would rely on the ServiceInfoEx update in that patch. The ServiceInfoEx update happens within OM, once the poller sends a notification to the ServiceInfoProvider (again in that patch). This test bought up the problem, and with the proposed fix, that test also runs fine. I have not shared that test so far, I will push it up shortly to the PR so reviewers can see, once this gets merged I will rebase that PR again.