### PR TITLE
HDDS-8526. Intermittent failure: Directory is not empty

### DIFF
--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmMetadataManagerImpl.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmMetadataManagerImpl.java
@@ -1017,23 +1017,15 @@ public class OmMetadataManagerImpl implements OMMetadataManager,
           // There is chance cache value flushed when
           // we iterate through the table.
           // Check in table whether it is deleted or still present.
-          if (table.getIfExist(kv.getKey()) == null) {
-            if (!keyIter.hasNext()) {
-              break;
-            }
-            kv = keyIter.next();
-            continue;
+          if (table.getIfExist(kv.getKey()) != null) {
+            // Still in table and no entry in cache
+            return true;
           }
-          // Still in table and no entry in cache
+        } else if (cacheValue.getCacheValue() != null) {
+          // Case 2a:
+          // We found a cache entry and cache value is not null.
           return true;
         }
-
-        // Case 2a:
-        // We found a cache entry and cache value is not null.
-        if (cacheValue.getCacheValue() != null) {
-          return true;
-        }
-
         // Case 2b:
         // Cache entry is present but cache value is null, hence this key is
         // marked for deletion.

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmMetadataManagerImpl.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmMetadataManagerImpl.java
@@ -1018,10 +1018,10 @@ public class OmMetadataManagerImpl implements OMMetadataManager,
           // we iterate through the table.
           // Check in table whether it is deleted or still present.
           if (table.getIfExist(kv.getKey()) == null) {
-            kv = keyIter.next();
             if (!keyIter.hasNext()) {
               break;
             }
+            kv = keyIter.next();
             continue;
           }
           // Still in table and no entry in cache

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmMetadataManagerImpl.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmMetadataManagerImpl.java
@@ -910,28 +910,49 @@ public class OmMetadataManagerImpl implements OMMetadataManager,
     }
 
     try (TableIterator<String, ? extends KeyValue<String, OmBucketInfo>>
-        bucketIter = bucketTable.iterator()) {
+             bucketIter = bucketTable.iterator()) {
       KeyValue<String, OmBucketInfo> kv = bucketIter.seek(volumePrefix);
-
-      if (kv != null) {
+      while (kv != null && kv.getKey().startsWith(volumePrefix)) {
         // Check the entry in db is not marked for delete. This can happen
         // while entry is marked for delete, but it is not flushed to DB.
         CacheValue<OmBucketInfo> cacheValue =
-            bucketTable.getCacheValue(new CacheKey(kv.getKey()));
-        if (cacheValue != null) {
-          if (kv.getKey().startsWith(volumePrefix)
-              && cacheValue.getCacheValue() != null) {
-            return false; // we found at least one bucket with this volume
-            // prefix.
-          }
-        } else {
-          if (kv.getKey().startsWith(volumePrefix)) {
-            return false; // we found at least one bucket with this volume
-            // prefix.
-          }
-        }
-      }
+            bucketTable.getCacheValue(new CacheKey<>(kv.getKey()));
 
+        // Case 1: We found an entry, but no cache entry.
+        if (cacheValue == null) {
+          // we found at least one key with this prefix.
+          // There is chance cache value flushed when
+          // we iterate through the table.
+          // Check in table whether it is deleted or still present.
+          if (bucketTable.getIfExist(kv.getKey()) == null) {
+            // already deleted from table also
+            kv = bucketIter.next();
+            if (!bucketIter.hasNext()) {
+              break;
+            }
+            continue;
+          }
+          // Still in table and no entry in cache
+          return false;
+        }
+
+        // Case 2a:
+        // We found a cache entry and cache value is not null.
+        if (cacheValue.getCacheValue() != null) {
+          return false;
+        }
+
+        // Case 2b:
+        // Cache entry is present but cache value is null, hence this key is
+        // marked for deletion.
+        // However, we still need to iterate through the rest of the prefix
+        // range to check for other keys with the same prefix that might still
+        // be present.
+        if (!bucketIter.hasNext()) {
+          break;
+        }
+        kv = bucketIter.next();
+      }
     }
     return true;
   }
@@ -1028,7 +1049,7 @@ public class OmMetadataManagerImpl implements OMMetadataManager,
    * @throws IOException
    */
   private <T> boolean isKeyPresentInTable(String keyPrefix,
-                                      Table<String, T> table)
+                                          Table<String, T> table)
       throws IOException {
     try (TableIterator<String, ? extends KeyValue<String, T>>
              keyIter = table.iterator()) {
@@ -1045,6 +1066,17 @@ public class OmMetadataManagerImpl implements OMMetadataManager,
         // Case 1: We found an entry, but no cache entry.
         if (cacheValue == null) {
           // we found at least one key with this prefix.
+          // There is chance cache value flushed when
+          // we iterate through the table.
+          // Check in table whether it is deleted or still present.
+          if (table.getIfExist(kv.getKey()) == null) {
+            kv = keyIter.next();
+            if (!keyIter.hasNext()) {
+              break;
+            }
+            continue;
+          }
+          // Still in table and no entry in cache
           return true;
         }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

When key is deleted, it firsts inserts into cache as deleted and later flush to db which deletes entry from db. In case of Bucket empty check we first check in cache and then check in table whether any entry exist for the prefix. But during this iteration there is chance that cache gets flushed into db and when we read cache it returns NULL and at this point we assume that table has entry but cache don't have. This shows that bucket is not empty at this point.
So to fix this in this case we should check in table whether really table entry is removed.

Similar problem is for Volume empty check. Making volume empty check also follow above criteria to ensure it is empty or not.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-8526

## How was this patch tested?
Before Fix: Test fails Intermittently in latest master for TestRootedOzoneFileSystemWithFSO.
https://github.com/ashishkumar50/ozone/actions/runs/5529154450

After Fix: Succeeded in all 10 * 10 run for TestRootedOzoneFileSystemWithFSO.
https://github.com/ashishkumar50/ozone/actions/runs/5531565163
