### PR TITLE
HDDS-8983. Intermittent failure in test-root-ca-rotation.sh due to null certId

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/security/RootCARotationManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/security/RootCARotationManager.java
@@ -587,6 +587,7 @@ public class RootCARotationManager implements SCMService {
       String newSubCACertId) {
     // Send ack to rotationPrepare request
     try {
+      handler.setSubCACertId(newSubCACertId);
       handler.rotationPrepareAck(newRootCACertId, newSubCACertId,
           scm.getScmId());
       LOG.info("SubCARotationPrepareTask[rootCertId = {}] - " +
@@ -598,8 +599,6 @@ public class RootCARotationManager implements SCMService {
           e.getMessage() + ") when sending out rotationPrepare ack";
       scm.shutDown(message);
     }
-
-    handler.setSubCACertId(newSubCACertId);
   }
 
   /**


### PR DESCRIPTION
https://issues.apache.org/jira/browse/HDDS-8983