### PR TITLE
HDDS-9003. Remove curator-framework version from HttpFS gateway pom.xml

### DIFF
--- a/hadoop-ozone/httpfsgateway/pom.xml
+++ b/hadoop-ozone/httpfsgateway/pom.xml
@@ -115,7 +115,6 @@
       <groupId>org.apache.curator</groupId>
       <artifactId>curator-framework</artifactId>
       <scope>runtime</scope>
-      <version>4.2.0</version>
       <!-- These were excluded as non of them is used in the HttpFS module, but all of them would be a new unnecessary
        dependency to the Ozone project, we would also need to update the jar-report.txt with that. -->
       <exclusions>


### PR DESCRIPTION
## What changes were proposed in this pull request?

In this change I removed the `curator-framework` dependency's fixed version from the `ozone-httpfsgateway`'s `pom.xml` and let it inherit the root `pom.xml`'s version. 

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-9003

## How was this patch tested?

successful CI on my fork: https://github.com/dombizita/ozone/actions/runs/5533274810/jobs/10096568833
