### PR TITLE
HDDS-8294. mvn clean should remove frontend build artifacts stored in Recon src

### DIFF
--- a/hadoop-ozone/recon/pom.xml
+++ b/hadoop-ozone/recon/pom.xml
@@ -136,6 +136,28 @@
         </executions>
       </plugin>
       <plugin>
+        <artifactId>maven-clean-plugin</artifactId>
+        <version>${maven-clean-plugin.version}</version>
+        <configuration>
+          <filesets>
+            <fileset>
+              <directory>${basedir}/src/main/resources/webapps/recon/ozone-recon-web/build</directory>
+              <includes>
+                <include>**</include>
+              </includes>
+              <followSymlinks>false</followSymlinks>
+            </fileset>
+            <fileset>
+              <directory>${basedir}/src/main/resources/webapps/recon/ozone-recon-web/node_modules</directory>
+              <includes>
+                <include>**</include>
+              </includes>
+              <followSymlinks>false</followSymlinks>
+            </fileset>
+          </filesets>
+        </configuration>
+      </plugin>
+      <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-resources-plugin</artifactId>
         <executions>


### PR DESCRIPTION
## What changes were proposed in this pull request?

It is noticed that because the pnpm build during Recon compilation doesn't put the files under `./target`, they are not removed by `mvn clean` by default. This PR aims to address that.

Note this will slightly increase build time for devs who regularly uses `mvn clean install` when building Ozone, since now Recon build and node_modules dirs would first be deleted in `clean` phase. If Recon is not the component you currently work on, consider appending `-DskipRecon` to your maven build command.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-8294

## How was this patch tested?

- [x] Tested locally that `mvn clean` removes the two directories recursively, including the dirs themselves.