### PR TITLE
HDDS-8997. Fix RangerOzoneAuthorizer initialization issue.

### DIFF
--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmMetadataReader.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmMetadataReader.java
@@ -109,7 +109,8 @@ public class OmMetadataReader implements IOmMetadataReader, Auditor {
           OZONE_ACL_AUTHORIZER_CLASS, OzoneAccessAuthorizer.class,
           IAccessAuthorizer.class);
       if (bNeedAccessAuthInitialization ||
-          clazz.getSimpleName().equals("OzoneNativeAuthorizer")) {
+          clazz.getSimpleName().equals(
+              OzoneNativeAuthorizer.class.getSimpleName())) {
         // In case of NativeAuthorizer always re-initialize
         accessAuthorizer = getACLAuthorizerInstance(configuration, clazz);
         if (accessAuthorizer instanceof OzoneNativeAuthorizer) {

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmSnapshot.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmSnapshot.java
@@ -80,7 +80,7 @@ public class OmSnapshot implements IOmMetadataReader, Closeable {
                     String snapshotName) {
     omMetadataReader = new OmMetadataReader(keyManager, prefixManager,
         ozoneManager, LOG, AUDIT,
-        OmSnapshotMetrics.getInstance());
+        OmSnapshotMetrics.getInstance(), false);
     this.snapshotName = snapshotName;
     this.bucketName = bucketName;
     this.volumeName = volumeName;

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
@@ -826,7 +826,7 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
     keyManager = new KeyManagerImpl(this, scmClient, configuration,
         perfMetrics);
     omMetadataReader = new OmMetadataReader(keyManager, prefixManager,
-        this, LOG, AUDIT, metrics);
+        this, LOG, AUDIT, metrics, true);
     // Active DB's OmMetadataReader instance does not need to be reference
     // counted, but it still needs to be wrapped to be consistent.
     rcOmMetadataReader = new ReferenceCounted<>(omMetadataReader, true, null);


### PR DESCRIPTION
## What changes were proposed in this pull request?

External access authorizer can be shared in same service. In case of ranger we can see we initialize multiple times in same service which eventually does refresh policies internally inside ranger plugin. Any request at this point doesn't work as policy check returns null. Which can be avoided by initialize only once during OM startup. 

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-8997

## How was this patch tested?

Run existing tests.
