### PR TITLE
HDDS-9008. Fix unchecked warnings in TableCache

### DIFF
--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/TypedTable.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/TypedTable.java
@@ -66,7 +66,7 @@ public class TypedTable<KEY, VALUE> implements Table<KEY, VALUE> {
   private final boolean supportCodecBuffer;
   private final CodecBuffer.Capacity bufferCapacity
       = new CodecBuffer.Capacity(this, BUFFER_SIZE_DEFAULT);
-  private final TableCache<CacheKey<KEY>, CacheValue<VALUE>> cache;
+  private final TableCache<KEY, VALUE> cache;
 
   /**
    * The same as this(rawTable, codecRegistry, keyType, valueType,
@@ -181,7 +181,7 @@ public class TypedTable<KEY, VALUE> implements Table<KEY, VALUE> {
   @Override
   public boolean isExist(KEY key) throws IOException {
 
-    CacheResult<CacheValue<VALUE>> cacheResult =
+    CacheResult<VALUE> cacheResult =
         cache.lookup(new CacheKey<>(key));
 
     if (cacheResult.getCacheStatus() == EXISTS) {
@@ -217,7 +217,7 @@ public class TypedTable<KEY, VALUE> implements Table<KEY, VALUE> {
     // Here the metadata lock will guarantee that cache is not updated for same
     // key during get key.
 
-    CacheResult<CacheValue<VALUE>> cacheResult =
+    CacheResult<VALUE> cacheResult =
         cache.lookup(new CacheKey<>(key));
 
     if (cacheResult.getCacheStatus() == EXISTS) {
@@ -266,7 +266,7 @@ public class TypedTable<KEY, VALUE> implements Table<KEY, VALUE> {
     // Here the metadata lock will guarantee that cache is not updated for same
     // key during get key.
 
-    CacheResult<CacheValue<VALUE>> cacheResult =
+    CacheResult<VALUE> cacheResult =
         cache.lookup(new CacheKey<>(key));
 
     if (cacheResult.getCacheStatus() == EXISTS) {
@@ -283,7 +283,7 @@ public class TypedTable<KEY, VALUE> implements Table<KEY, VALUE> {
     // Here the metadata lock will guarantee that cache is not updated for same
     // key during get key.
 
-    CacheResult<CacheValue<VALUE>> cacheResult =
+    CacheResult<VALUE> cacheResult =
         cache.lookup(new CacheKey<>(key));
 
     if (cacheResult.getCacheStatus() == EXISTS) {
@@ -530,7 +530,7 @@ public class TypedTable<KEY, VALUE> implements Table<KEY, VALUE> {
   }
 
   @VisibleForTesting
-  TableCache<CacheKey<KEY>, CacheValue<VALUE>> getCache() {
+  TableCache<KEY, VALUE> getCache() {
     return cache;
   }
 

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/cache/CacheKey.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/cache/CacheKey.java
@@ -24,7 +24,7 @@ import java.util.Objects;
  * CacheKey for the RocksDB table.
  * @param <KEY>
  */
-public class CacheKey<KEY> implements Comparable<KEY> {
+public class CacheKey<KEY> implements Comparable<CacheKey<KEY>> {
 
   private final KEY key;
 
@@ -55,11 +55,11 @@ public class CacheKey<KEY> implements Comparable<KEY> {
   }
 
   @Override
-  public int compareTo(Object o) {
-    if (Objects.equals(key, ((CacheKey<?>)o).key)) {
+  public int compareTo(CacheKey<KEY> other) {
+    if (Objects.equals(key, other.key)) {
       return 0;
     } else {
-      return key.toString().compareTo((((CacheKey<?>) o).key).toString());
+      return key.toString().compareTo(other.key.toString());
     }
   }
 }

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/cache/CacheResult.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/cache/CacheResult.java
@@ -22,24 +22,24 @@ import java.util.Objects;
 
 /**
  * CacheResult which is returned as response for Key exist in cache or not.
- * @param <CACHEVALUE>
+ * @param <VALUE>
  */
-public class CacheResult<CACHEVALUE extends CacheValue> {
+public class CacheResult<VALUE> {
 
-  private CacheStatus cacheStatus;
-  private CACHEVALUE cachevalue;
+  private final CacheStatus cacheStatus;
+  private final CacheValue<VALUE> cacheValue;
 
-  public CacheResult(CacheStatus cacheStatus, CACHEVALUE cachevalue) {
-    this.cacheStatus = cacheStatus;
-    this.cachevalue = cachevalue;
+  public CacheResult(CacheStatus status, CacheValue<VALUE> value) {
+    this.cacheStatus = status;
+    this.cacheValue = value;
   }
 
   public CacheStatus getCacheStatus() {
     return cacheStatus;
   }
 
-  public CACHEVALUE getValue() {
-    return cachevalue;
+  public CacheValue<VALUE> getValue() {
+    return cacheValue;
   }
 
   @Override
@@ -52,12 +52,12 @@ public class CacheResult<CACHEVALUE extends CacheValue> {
     }
     CacheResult< ? > that = (CacheResult< ? >) o;
     return cacheStatus == that.cacheStatus &&
-        Objects.equals(cachevalue, that.cachevalue);
+        Objects.equals(cacheValue, that.cacheValue);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(cacheStatus, cachevalue);
+    return Objects.hash(cacheStatus, cacheValue);
   }
 
   /**

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/cache/PartialTableCache.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/cache/PartialTableCache.java
@@ -42,18 +42,19 @@ import org.slf4j.LoggerFactory;
  * Cache implementation for the table. Partial Table cache, where the DB state
  * and cache state will not be same. Partial table cache holds entries until
  * flush to DB happens.
+ * @param <KEY>
+ * @param <VALUE>
  */
 @Private
 @Evolving
-public class PartialTableCache<CACHEKEY extends CacheKey,
-    CACHEVALUE extends CacheValue> implements TableCache<CACHEKEY, CACHEVALUE> {
+public class PartialTableCache<KEY, VALUE> implements TableCache<KEY, VALUE> {
 
   public static final Logger LOG =
       LoggerFactory.getLogger(PartialTableCache.class);
 
-  private final Map<CACHEKEY, CACHEVALUE> cache;
-  private final NavigableMap<Long, Set<CACHEKEY>> epochEntries;
-  private ExecutorService executorService;
+  private final Map<CacheKey<KEY>, CacheValue<VALUE>> cache;
+  private final NavigableMap<Long, Set<CacheKey<KEY>>> epochEntries;
+  private final ExecutorService executorService;
   private final CacheStatsRecorder statsRecorder;
 
 
@@ -84,19 +85,19 @@ public class PartialTableCache<CACHEKEY extends CacheKey,
   }
 
   @Override
-  public CACHEVALUE get(CACHEKEY cachekey) {
-    CACHEVALUE value = cache.get(cachekey);
+  public CacheValue<VALUE> get(CacheKey<KEY> cachekey) {
+    CacheValue<VALUE> value = cache.get(cachekey);
     statsRecorder.recordValue(value);
     return value;
   }
 
   @Override
-  public void loadInitial(CACHEKEY cacheKey, CACHEVALUE cacheValue) {
+  public void loadInitial(CacheKey<KEY> key, CacheValue<VALUE> value) {
     // Do nothing for partial table cache.
   }
 
   @Override
-  public void put(CACHEKEY cacheKey, CACHEVALUE value) {
+  public void put(CacheKey<KEY> cacheKey, CacheValue<VALUE> value) {
     cache.put(cacheKey, value);
     epochEntries.computeIfAbsent(value.getEpoch(), v -> new HashSet<>())
             .add(cacheKey);
@@ -113,7 +114,7 @@ public class PartialTableCache<CACHEKEY extends CacheKey,
   }
 
   @Override
-  public Iterator<Map.Entry<CACHEKEY, CACHEVALUE>> iterator() {
+  public Iterator<Map.Entry<CacheKey<KEY>, CacheValue<VALUE>>> iterator() {
     statsRecorder.recordIteration();
     return cache.entrySet().iterator();
   }
@@ -121,8 +122,8 @@ public class PartialTableCache<CACHEKEY extends CacheKey,
   @VisibleForTesting
   @Override
   public void evictCache(List<Long> epochs) {
-    Set<CACHEKEY> currentCacheKeys;
-    CACHEKEY cachekey;
+    Set<CacheKey<KEY>> currentCacheKeys;
+    CacheKey<KEY> cachekey;
     long lastEpoch = epochs.get(epochs.size() - 1);
     for (long currentEpoch : epochEntries.keySet()) {
       currentCacheKeys = epochEntries.get(currentEpoch);
@@ -135,7 +136,7 @@ public class PartialTableCache<CACHEKEY extends CacheKey,
       // As ConcurrentHashMap computeIfPresent is atomic, there is no race
       // condition between cache cleanup and requests updating same cache entry.
       if (epochs.contains(currentEpoch)) {
-        for (Iterator<CACHEKEY> iterator = currentCacheKeys.iterator();
+        for (Iterator<CacheKey<KEY>> iterator = currentCacheKeys.iterator();
              iterator.hasNext();) {
           cachekey = iterator.next();
           cache.computeIfPresent(cachekey, ((k, v) -> {
@@ -158,9 +159,9 @@ public class PartialTableCache<CACHEKEY extends CacheKey,
   }
 
   @Override
-  public CacheResult<CACHEVALUE> lookup(CACHEKEY cachekey) {
+  public CacheResult<VALUE> lookup(CacheKey<KEY> cachekey) {
 
-    CACHEVALUE cachevalue = cache.get(cachekey);
+    CacheValue<VALUE> cachevalue = cache.get(cachekey);
     statsRecorder.recordValue(cachevalue);
     if (cachevalue == null) {
       return new CacheResult<>(CacheResult.CacheStatus.MAY_EXIST,
@@ -177,7 +178,7 @@ public class PartialTableCache<CACHEKEY extends CacheKey,
 
   @VisibleForTesting
   @Override
-  public NavigableMap<Long, Set<CACHEKEY>> getEpochEntries() {
+  public NavigableMap<Long, Set<CacheKey<KEY>>> getEpochEntries() {
     return epochEntries;
   }
 

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/cache/TableCache.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/cache/TableCache.java
@@ -31,46 +31,37 @@ import java.util.Set;
 
 /**
  * Cache used for RocksDB tables.
- * @param <CACHEKEY>
- * @param <CACHEVALUE>
+ * @param <KEY>
+ * @param <VALUE>
  */
-
 @Private
 @Evolving
-public interface TableCache<CACHEKEY extends CacheKey,
-    CACHEVALUE extends CacheValue> {
+public interface TableCache<KEY, VALUE> {
 
   /**
    * Return the value for the key if it is present, otherwise return null.
-   * @param cacheKey
-   * @return CACHEVALUE
    */
-  CACHEVALUE get(CACHEKEY cacheKey);
+  CacheValue<VALUE> get(CacheKey<KEY> cacheKey);
 
   /**
    * This method should be called for tables with cache type full cache.
    * {@link TableCache.CacheType#FULL_CACHE} after system
    * restart to fill up the cache.
-   * @param cacheKey
-   * @param cacheValue
    */
-  void loadInitial(CACHEKEY cacheKey, CACHEVALUE cacheValue);
+  void loadInitial(CacheKey<KEY> cacheKey, CacheValue<VALUE> cacheValue);
 
   /**
    * Add an entry to the cache, if the key already exists it overrides.
-   * @param cacheKey
-   * @param value
    */
-  void put(CACHEKEY cacheKey, CACHEVALUE value);
+  void put(CacheKey<KEY> cacheKey, CacheValue<VALUE> value);
 
   /**
    * Removes all the entries from the cache which are matching with epoch
    * provided in the epoch list.
    *
    * If clean up policy is NEVER, this is a do nothing operation.
-   * If clean up policy is MANUAL, it is caller responsibility to cleanup the
+   * If clean up policy is MANUAL, it is caller responsibility to clean up the
    * cache before calling cleanup.
-   * @param epochs
    */
   void cleanup(List<Long> epochs);
 
@@ -87,7 +78,7 @@ public interface TableCache<CACHEKEY extends CacheKey,
    * Return an iterator for the cache.
    * @return iterator of the underlying cache for the table.
    */
-  Iterator<Map.Entry<CACHEKEY, CACHEVALUE>> iterator();
+  Iterator<Map.Entry<CacheKey<KEY>, CacheValue<VALUE>>> iterator();
 
   /**
    * Check key exist in cache or not.
@@ -102,18 +93,15 @@ public interface TableCache<CACHEKEY extends CacheKey,
    *
    *  If cache type is
    *  {@link TableCache.CacheType#PARTIAL_CACHE}.
-   *  It return's {@link CacheResult} with null and status as MAY_EXIST.
-   *
-   * @param cachekey
+   *  It returns {@link CacheResult} with null and status as MAY_EXIST.
    */
-  CacheResult<CACHEVALUE> lookup(CACHEKEY cachekey);
+  CacheResult<VALUE> lookup(CacheKey<KEY> cachekey);
 
   @VisibleForTesting
-  NavigableMap<Long, Set<CACHEKEY>> getEpochEntries();
+  NavigableMap<Long, Set<CacheKey<KEY>>> getEpochEntries();
 
   /**
    * Return the stat counters.
-   * @return
    */
   CacheStats getStats();
 

--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/utils/db/cache/TestTableCache.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/utils/db/cache/TestTableCache.java
@@ -36,7 +36,7 @@ import org.slf4j.event.Level;
  */
 public class TestTableCache {
 
-  private TableCache<CacheKey<String>, CacheValue<String>> tableCache;
+  private TableCache<String, String> tableCache;
 
   @BeforeAll
   public static void setLogLevel() {


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fix warnings in `TableCache` and related code caused by raw usage of `CacheKey` and `CacheValue`.

https://issues.apache.org/jira/browse/HDDS-9008

## How was this patch tested?

CI:
https://github.com/adoroszlai/hadoop-ozone/actions/runs/5540872425