### PR TITLE
HDDS-9010. Fix RootCaRotationPoller not toggling rotation if previous rotation failed

### DIFF
--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/security/x509/certificate/client/DefaultCertificateClient.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/security/x509/certificate/client/DefaultCertificateClient.java
@@ -1333,7 +1333,8 @@ public abstract class DefaultCertificateClient implements CertificateClient {
       return CompletableFuture.completedFuture(null);
     }
     CertificateRenewerService renewerService =
-        new CertificateRenewerService(true);
+        new CertificateRenewerService(
+            true, rootCaRotationPoller::setCertificateRenewalError);
     return CompletableFuture.runAsync(renewerService, executorService);
   }
 
@@ -1355,7 +1356,8 @@ public abstract class DefaultCertificateClient implements CertificateClient {
               .setDaemon(true).build());
     }
     this.executorService.scheduleAtFixedRate(
-        new CertificateRenewerService(false),
+        new CertificateRenewerService(false, () -> {
+        }),
         timeBeforeGracePeriod, interval, TimeUnit.MILLISECONDS);
     getLogger().info("CertificateRenewerService for {} is started with " +
             "first delay {} ms and interval {} ms.", component,
@@ -1367,9 +1369,12 @@ public abstract class DefaultCertificateClient implements CertificateClient {
    */
   public class CertificateRenewerService implements Runnable {
     private boolean forceRenewal;
+    private Runnable rotationErrorCallback;
 
-    public CertificateRenewerService(boolean forceRenewal) {
+    public CertificateRenewerService(boolean forceRenewal,
+        Runnable rotationErrorCallback) {
       this.forceRenewal = forceRenewal;
+      this.rotationErrorCallback = rotationErrorCallback;
     }
 
     @Override
@@ -1397,6 +1402,7 @@ public abstract class DefaultCertificateClient implements CertificateClient {
               timeLeft, forceRenewal);
           newCertId = renewAndStoreKeyAndCertificate(forceRenewal);
         } catch (CertificateException e) {
+          rotationErrorCallback.run();
           if (e.errorCode() ==
               CertificateException.ErrorCode.ROLLBACK_ERROR) {
             if (shutdownCallback != null) {

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/security/x509/certificate/client/DefaultCertificateClient.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/security/x509/certificate/client/DefaultCertificateClient.java
@@ -205,7 +205,7 @@ public abstract class DefaultCertificateClient implements CertificateClient {
   }
 
   @Override
-  public void registerRootCARotationListener(
+  public synchronized void registerRootCARotationListener(
       Function<List<X509Certificate>, CompletableFuture<Void>> listener) {
     if (securityConfig.isAutoCARotationEnabled()) {
       rootCaRotationPoller.addRootCARotationProcessor(listener);

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/security/x509/certificate/client/RootCaRotationPoller.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/security/x509/certificate/client/RootCaRotationPoller.java
@@ -99,6 +99,13 @@ public class RootCaRotationPoller implements Runnable, Closeable {
         if (throwable == null && !certificateRenewalError.get()) {
           knownRootCerts = new HashSet<>(rootCAsFromSCM);
           certificateRenewalError.set(false);
+        } else {
+          LOG.info("Certificate consumption was unsuccesfull. " +
+              (certificateRenewalError.get() ?
+                  "There was a caught exception when trying to sign the " +
+                      "certificate" :
+                  "There was an unexpected error during cert rotation" +
+                      throwable));
         }
       });
     } catch (IOException e) {

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/security/x509/certificate/client/RootCaRotationPoller.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/security/x509/certificate/client/RootCaRotationPoller.java
@@ -89,7 +89,7 @@ public class RootCaRotationPoller implements Runnable, Closeable {
           getPrintableCertIds(knownRootCerts) + ". Root CA Cert ids from " +
           "SCM not known by the client: " +
           getPrintableCertIds(scmCertsWithoutKnownCerts));
-
+      certificateRenewalError.set(false);
       CompletableFuture<Void> allRootCAProcessorFutures =
           CompletableFuture.allOf(rootCARotationProcessors.stream()
               .map(c -> c.apply(rootCAsFromSCM))
@@ -98,7 +98,6 @@ public class RootCaRotationPoller implements Runnable, Closeable {
       allRootCAProcessorFutures.whenComplete((unused, throwable) -> {
         if (throwable == null && !certificateRenewalError.get()) {
           knownRootCerts = new HashSet<>(rootCAsFromSCM);
-          certificateRenewalError.set(false);
         } else {
           LOG.info("Certificate consumption was unsuccesfull. " +
               (certificateRenewalError.get() ?

--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/security/x509/certificate/utils/TestRootCaRotationPoller.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/security/x509/certificate/utils/TestRootCaRotationPoller.java
@@ -42,6 +42,7 @@ import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_X509_ROOTCA_CERTIFICATE_POLLING_INTERVAL;
 
@@ -138,9 +139,12 @@ public class TestRootCaRotationPoller {
     AtomicBoolean atomicBoolean = new AtomicBoolean();
     atomicBoolean.set(false);
     //Set that the first certificate renewal encountered an error
-    poller.setCertificateRenewalError();
+    AtomicInteger runNumber = new AtomicInteger(1);
     poller.addRootCARotationProcessor(
         certificates -> CompletableFuture.supplyAsync(() -> {
+          if (runNumber.getAndIncrement() < 2) {
+            poller.setCertificateRenewalError();
+          }
           atomicBoolean.set(true);
           Assertions.assertEquals(certificates.size(), 2);
           return null;

--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/security/x509/certificate/utils/TestRootCaRotationPoller.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/security/x509/certificate/utils/TestRootCaRotationPoller.java
@@ -149,7 +149,7 @@ public class TestRootCaRotationPoller {
     GenericTestUtils.waitFor(atomicBoolean::get, 50, 5000);
     //And that we see the error in the logs
     Assertions.assertTrue(logCapturer.getOutput().contains(
-        "There was an error when trying to sign the certificate"));
+        "There was a caught exception when trying to sign the certificate"));
   }
 
   private X509Certificate generateX509Cert(

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/TestSecureOzoneCluster.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/TestSecureOzoneCluster.java
@@ -1214,7 +1214,6 @@ public final class TestSecureOzoneCluster {
    * Test functionality to get SCM signed certificate for OM.
    */
   @Test
-  @Ignore("HDDS-8764")
   public void testOMGrpcServerCertificateRenew() throws Exception {
     initSCM();
     try {

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/TestSecureOzoneCluster.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/TestSecureOzoneCluster.java
@@ -1214,6 +1214,7 @@ public final class TestSecureOzoneCluster {
    * Test functionality to get SCM signed certificate for OM.
    */
   @Test
+  @Ignore("HDDS-8764")
   public void testOMGrpcServerCertificateRenew() throws Exception {
     initSCM();
     try {


### PR DESCRIPTION
## What changes were proposed in this pull request?
Polling when a new root ca certificate is available doesn't pick up if the certificate sign request (or anything during certificate rotation) went wrong and never tries again even if the client didn't store its certs successfully.

## What is the link to the Apache JIRA
[HDDS-9010](https://issues.apache.org/jira/browse/HDDS-9010)
