### PR TITLE
HDDS-9012. Log more information about failed EC block allocation

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/container/common/helpers/ExcludeList.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/container/common/helpers/ExcludeList.java
@@ -145,7 +145,7 @@ public class ExcludeList {
   @Override
   public String toString() {
     return "ExcludeList {" +
-        "datanodes = " + getDatanodes() +
+        "datanodes = " + datanodes.keySet() +
         ", containerIds = " + containerIds +
         ", pipelineIds = " + pipelineIds +
         '}';


### PR DESCRIPTION
## What changes were proposed in this pull request?

Log more information, including the exclude list, if EC block allocation fails due to max. open pipeline limit.

https://issues.apache.org/jira/browse/HDDS-9012

## How was this patch tested?

CI:
https://github.com/adoroszlai/hadoop-ozone/actions/runs/5547145701

Example output from unit test:

```
WARN  pipeline.WritableECContainerProvider (WritableECContainerProvider.java:getContainer(170)) - Unable to allocate a container after trying 5 existing ones; requested size=1, replication=EC{rs-3-2-1024k}, owner=SCM, ExcludeList {datanodes = [], containerIds = [#2381628560543191, #2381628561553557, #2381628561265675, #2381628560940851, #2381628561836869], pipelineIds = []}
java.io.IOException: Pipeline limit (5) reached (5), none closed
	at org.apache.hadoop.hdds.scm.pipeline.WritableECContainerProvider.getContainer(WritableECContainerProvider.java:166)
	at org.apache.hadoop.hdds.scm.pipeline.WritableECContainerProvider.getContainer(WritableECContainerProvider.java:51)
```

```
WARN  pipeline.WritableECContainerProvider (WritableECContainerProvider.java:getContainer(105)) - Unable to allocate a container with 0 existing ones; requested size=1, replication=EC{rs-3-2-1024k}, owner=SCM, ExcludeList {datanodes = [], containerIds = [], pipelineIds = []}
java.io.IOException: Cannot create pipelines
	at org.apache.hadoop.hdds.scm.pipeline.TestWritableECContainerProvider$2.createPipeline(TestWritableECContainerProvider.java:315)
	at org.apache.hadoop.hdds.scm.pipeline.MockPipelineManager.createPipeline(MockPipelineManager.java:65)
	at org.apache.hadoop.hdds.scm.pipeline.TestWritableECContainerProvider$2.createPipeline(TestWritableECContainerProvider.java:318)
	at org.apache.hadoop.hdds.scm.pipeline.WritableECContainerProvider.allocateContainer(WritableECContainerProvider.java:196)
	at org.apache.hadoop.hdds.scm.pipeline.WritableECContainerProvider.getContainer(WritableECContainerProvider.java:103)
	at org.apache.hadoop.hdds.scm.pipeline.WritableECContainerProvider.getContainer(WritableECContainerProvider.java:51)
```