### PR TITLE
HDDS-9014. Bump okio to 3.4.0

### DIFF
--- a/hadoop-ozone/dist/src/main/license/jar-report.txt
+++ b/hadoop-ozone/dist/src/main/license/jar-report.txt
@@ -162,6 +162,8 @@ share/ozone/lib/kerby-asn1.jar
 share/ozone/lib/kerby-pkix.jar
 share/ozone/lib/kerby-util.jar
 share/ozone/lib/kotlin-stdlib-common.jar
+share/ozone/lib/kotlin-stdlib-jdk7.jar
+share/ozone/lib/kotlin-stdlib-jdk8.jar
 share/ozone/lib/kotlin-stdlib.jar
 share/ozone/lib/libthrift.jar
 share/ozone/lib/listenablefuture-empty-to-avoid-conflict-with-guava.jar
@@ -191,6 +193,7 @@ share/ozone/lib/netty-transport-native-epoll.Final-linux-x86_64.jar
 share/ozone/lib/netty-transport-native-unix-common.Final.jar
 share/ozone/lib/nimbus-jose-jwt.jar
 share/ozone/lib/okhttp.jar
+share/ozone/lib/okio-jvm.jar
 share/ozone/lib/okio.jar
 share/ozone/lib/opentracing-api.jar
 share/ozone/lib/opentracing-noop.jar

--- a/pom.xml
+++ b/pom.xml
@@ -216,7 +216,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
 
     <objenesis.version>1.0</objenesis.version>
     <okhttp.version>2.7.5</okhttp.version>
-    <okio.version>2.8.0</okio.version>
+    <okio.version>3.4.0</okio.version>
     <mockito1-powermock.version>1.10.19</mockito1-powermock.version>
     <mockito2.version>3.5.9</mockito2.version>
     <hamcrest.version>1.3</hamcrest.version>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Bump okio from 2.8.0 to 3.4.0.

https://issues.apache.org/jira/browse/HDDS-9014

## How was this patch tested?

https://github.com/apache/ozone/actions/runs/5545884911?pr=5059