### PR TITLE
HDDS-8896. Remove -skipTrash option from sh key delete command.

### DIFF
--- a/hadoop-ozone/dist/src/main/smoketest/basic/links.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/basic/links.robot
@@ -114,9 +114,12 @@ Key list passthrough
                         Should Contain              ${source_list}    key2
 
 Key delete passthrough
-                        Execute                     ozone sh key delete --skipTrash ${target}/link1/key2
-    ${source_list} =    Execute                     ozone sh key list ${source}/bucket1 | jq -r '.[].name'
-                        Should Not Contain          ${source_list}    key2
+                        Execute                     ozone sh key delete ${target}/link1/key2
+    ${source_list} =    Execute                     ozone sh key list ${source}/bucket1 | jq -r '.[] | select(.name | startswith(".Trash")) | .name'
+                        Should Contain Any          ${source_list}     .Trash/hadoop    .Trash/testuser    .Trash/root
+                        Should contain              ${source_list}    key2
+    ${result} =         Execute                     ozone sh key list ${source}/bucket1 | jq -r '.[] | select(.name | startswith(".Trash") | not) | .name'
+                        Should Not contain          ${result}         key2
 
 Bucket list contains links
     ${result} =         Execute                     ozone sh bucket list ${target}

--- a/hadoop-ozone/dist/src/main/smoketest/basic/ozone-shell-lib.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/basic/ozone-shell-lib.robot
@@ -72,7 +72,7 @@ Test ozone shell
                     Execute             ozone sh bucket clrquota --namespace-quota ${protocol}${server}/${volume}/bb1
     ${result} =     Execute             ozone sh bucket info ${protocol}${server}/${volume}/bb1 | jq -r '. | select(.name=="bb1") | .quotaInNamespace'
                     Should Be Equal     ${result}       -1
-                    Execute             ozone sh bucket delete ${protocol}${server}/${volume}/bb1
+                    Execute             ozone sh bucket delete -r --yes ${protocol}${server}/${volume}/bb1
                     Execute             ozone sh volume delete ${protocol}${server}/${volume}
                     Execute             ozone sh volume create ${protocol}${server}/${volume}
                     Execute             ozone sh volume info ${protocol}${server}/${volume} > volume.json
@@ -153,13 +153,13 @@ Test key handling
                     Execute             diff -q /opt/hadoop/NOTICE.txt /tmp/key1_RATIS
     ${result} =     Execute             ozone sh key info ${protocol}${server}/${volume}/bb1/key1_RATIS | jq -r '. | select(.name=="key1_RATIS")'
                     Should contain      ${result}       RATIS
-                    Execute             ozone sh key delete --skipTrash ${protocol}${server}/${volume}/bb1/key1_RATIS
+                    Execute             ozone sh key delete ${protocol}${server}/${volume}/bb1/key1_RATIS
 
                     Execute             ozone sh key cp ${protocol}${server}/${volume}/bb1 key1 key1-copy
                     Execute             rm -f /tmp/key1-copy
                     Execute             ozone sh key get ${protocol}${server}/${volume}/bb1/key1-copy /tmp/key1-copy
                     Execute             diff -q /opt/hadoop/NOTICE.txt /tmp/key1-copy
-                    Execute             ozone sh key delete --skipTrash ${protocol}${server}/${volume}/bb1/key1-copy
+                    Execute             ozone sh key delete ${protocol}${server}/${volume}/bb1/key1-copy
 
     ${result} =     Execute And Ignore Error    ozone sh key get ${protocol}${server}/${volume}/bb1/key1 /tmp/NOTICE.txt.1
                     Should Contain      ${result}       NOTICE.txt.1 exists
@@ -170,9 +170,9 @@ Test key handling
     ${result} =     Execute             ozone sh key list ${protocol}${server}/${volume}/bb1 | jq -r '.[] | select(.name=="key1") | .name'
                     Should Be Equal     ${result}       key1
                     Execute             ozone sh key rename ${protocol}${server}/${volume}/bb1 key1 key2
-    ${result} =     Execute             ozone sh key list ${protocol}${server}/${volume}/bb1 | jq -r '.[].name'
+    ${result} =     Execute             ozone sh key list ${protocol}${server}/${volume}/bb1 | jq -r '.[] | select(.name=="key2") | .name'
                     Should Be Equal     ${result}       key2
-                    Execute             ozone sh key delete --skipTrash ${protocol}${server}/${volume}/bb1/key2
+                    Execute             ozone sh key delete ${protocol}${server}/${volume}/bb1/key2
 
 Test key Acls
     [arguments]     ${protocol}         ${server}       ${volume}
@@ -245,21 +245,19 @@ Test native authorizer
     Execute         kdestroy
     Run Keyword     Kinit test user     testuser    testuser.keytab
 
-Test Delete key with and without Trash
+Test Delete key with Trash
     [arguments]    ${protocol}         ${server}       ${volume}
                    Execute               ozone sh volume create ${protocol}${server}/${volume}
                    Execute               ozone sh bucket create ${protocol}${server}/${volume}/bfso --layout FILE_SYSTEM_OPTIMIZED
-                   Execute               ozone sh key put -t RATIS ${protocol}${server}/${volume}/bfso/key1 /opt/hadoop/NOTICE.txt
-                   Execute               ozone sh key delete --skipTrash ${protocol}${server}/${volume}/bfso/key1
-    ${result} =    Execute               ozone sh key list ${protocol}${server}/${volume}/bfso
-                   Should not contain    ${result}     key1
+                   Execute               ozone sh key put -t RATIS ${protocol}${server}/${volume}/bfso/key3 /opt/hadoop/NOTICE.txt
+                   Execute               ozone sh key delete ${protocol}${server}/${volume}/bfso/key3
+    ${result} =    Execute               ozone sh key list ${protocol}${server}/${volume}/bfso | jq -r '.[] | select(.name | startswith(".Trash")) | .name'
+                   Should Contain Any    ${result}    .Trash/hadoop    .Trash/testuser    .Trash/root
+                   Should contain        ${result}    key3
+    ${result} =    Execute               ozone sh key list ${protocol}${server}/${volume}/bfso | jq -r '.[] | select(.name | startswith(".Trash") | not) | .name'
+                   Should Not contain    ${result}    key3
                    Execute               ozone sh bucket create ${protocol}${server}/${volume}/obsbkt --layout OBJECT_STORE
                    Execute               ozone sh key put -t RATIS ${protocol}${server}/${volume}/obsbkt/key2 /opt/hadoop/NOTICE.txt
                    Execute               ozone sh key delete ${protocol}${server}/${volume}/obsbkt/key2
     ${result} =    Execute               ozone sh key list ${protocol}${server}/${volume}/obsbkt
-                   Should not contain    ${result}     key2
-                   Execute               ozone sh key put -t RATIS ${protocol}${server}/${volume}/bfso/key3 /opt/hadoop/NOTICE.txt
-                   Execute               ozone sh key delete ${protocol}${server}/${volume}/bfso/key3
-    ${result} =    Execute               ozone sh key list ${protocol}${server}/${volume}/bfso
-                   Should Contain Any    ${result}     .Trash/hadoop    .Trash/testuser    .Trash/root
-                   Should contain        ${result}     key3
+                   Should not contain    ${result}    key2

--- a/hadoop-ozone/dist/src/main/smoketest/basic/ozone-shell.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/basic/ozone-shell.robot
@@ -49,4 +49,4 @@ RpcClient without host
     Test ozone shell      o3://            ${EMPTY}    ${prefix}-without-host
 
 RpcClient Delete key
-   Test Delete key with and without Trash       o3://            om:9862      ${prefix}-with-del
+   Test Delete key with Trash       o3://            om:9862      ${prefix}-with-del

--- a/hadoop-ozone/dist/src/main/smoketest/security/ozone-secure-fs.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/security/ozone-secure-fs.robot
@@ -70,9 +70,9 @@ Create bucket with non-admin owner(testuser2)
                   Should not contain  ${result}       PERMISSION_DENIED
     ${result} =   Execute     ozone sh key list ${volume4}/bucket1
                   Should not contain  ${result}       PERMISSION_DENIED
-    ${result} =   Execute     ozone sh key delete --skipTrash ${volume4}/bucket1/key1
+    ${result} =   Execute     ozone sh key delete ${volume4}/bucket1/key1
                   Should not contain  ${result}       PERMISSION_DENIED
-    ${result} =   Execute     ozone sh bucket delete ${volume4}/bucket1
+    ${result} =   Execute     ozone sh bucket delete -r --yes ${volume4}/bucket1
                   Should not contain  ${result}       PERMISSION_DENIED
 
 Create volume bucket with credentials

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/shell/TestOzoneShellHA.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/shell/TestOzoneShellHA.java
@@ -1160,6 +1160,10 @@ public class TestOzoneShellHA {
     // One key should be present in .Trash
     Assert.assertEquals(1, getNumOfKeys());
 
+    args = new String[] {trashConfKey, "key", "delete",
+        "/volumefso1/bucket1/key5"};
+    execute(ozoneShell, args);
+
     args = new String[] {"key", "list", "o3://" + omServiceId +
           "/volumefso1/bucket1/", "-l ", "110"};
     out.reset();
@@ -1168,26 +1172,13 @@ public class TestOzoneShellHA {
     // Total number of keys still 100.
     Assert.assertEquals(100, getNumOfKeys());
 
-    // Skip Trash
-    args = new String[] {trashConfKey, "key", "delete",
-        "/volumefso1/bucket1/key5", "--skipTrash"};
-    execute(ozoneShell, args);
-
-    // .Trash should still contain 1 key
+    // .Trash should contain 2 keys
     prefixKey = "--prefix=.Trash";
     args = new String[] {"key", "list", prefixKey, "o3://" +
           omServiceId + "/volumefso1/bucket1/"};
     out.reset();
     execute(ozoneShell, args);
-    Assert.assertEquals(1, getNumOfKeys());
-
-    args = new String[] {"key", "list", "o3://" + omServiceId +
-          "/volumefso1/bucket1/", "-l ", "110"};
-    out.reset();
-    execute(ozoneShell, args);
-    // Total number of keys now will be 99 as
-    // 1 key deleted without trash
-    Assert.assertEquals(99, getNumOfKeys());
+    Assert.assertEquals(2, getNumOfKeys());
 
     final String username =
         UserGroupInformation.getCurrentUser().getShortUserName();
@@ -1209,25 +1200,10 @@ public class TestOzoneShellHA {
     out.reset();
     execute(ozoneShell, args);
 
-    // Total number of keys still remain 99 as
-    // delete from trash not allowed without --skipTrash
-    Assert.assertEquals(99, getNumOfKeys());
+    // Total number of keys still remain 100 as
+    // delete from trash not allowed using sh command
+    Assert.assertEquals(100, getNumOfKeys());
 
-    // Now try to delete from trash path with --skipTrash option
-    args = new String[] {trashConfKey, "key", "delete",
-        "/volumefso1/bucket1/" + userTrashCurrent.toUri().getPath()
-          + "/key4", "--skipTrash"};
-    out.reset();
-    execute(ozoneShell, args);
-
-    args = new String[] {"key", "list", "o3://" + omServiceId +
-          "/volumefso1/bucket1/", "-l ", "110"};
-    out.reset();
-    execute(ozoneShell, args);
-
-    // Total number of keys now will be 98 as
-    // 1 key deleted without trash and 1 from the trash path
-    Assert.assertEquals(98, getNumOfKeys());
   }
 
   @Test

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/keys/DeleteKeyHandler.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/keys/DeleteKeyHandler.java
@@ -30,7 +30,6 @@ import org.apache.hadoop.ozone.om.OMConfigKeys;
 import org.apache.hadoop.ozone.om.helpers.OzoneFSUtils;
 import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.hadoop.util.Time;
-import picocli.CommandLine;
 import picocli.CommandLine.Command;
 
 import java.io.IOException;
@@ -47,10 +46,6 @@ import static org.apache.hadoop.ozone.OzoneConsts.OZONE_URI_DELIMITER;
 @Command(name = "delete",
     description = "deletes an existing key")
 public class DeleteKeyHandler extends KeyHandler {
-
-  @CommandLine.Option(names = "--skipTrash",
-      description = "Specify whether to skip Trash ")
-  private boolean skipTrash = false;
 
   private static final Path CURRENT = new Path("Current");
 
@@ -83,7 +78,7 @@ public class DeleteKeyHandler extends KeyHandler {
 
     // If Bucket layout is FSO and Trash is enabled
     // In this case during delete operation move key to trash
-    if (trashInterval > 0 && !skipTrash &&
+    if (trashInterval > 0 &&
         !keyName.contains(TRASH_PREFIX)) {
       keyName = OzoneFSUtils.removeTrailingSlashIfNeeded(keyName);
         // Check if key exists in Ozone
@@ -135,10 +130,10 @@ public class DeleteKeyHandler extends KeyHandler {
       // Rename key to move inside trash folder
       bucket.renameKey(keyName, toKeyName);
       out().printf("Key moved inside Trash: %s %n", toKeyName);
-    } else if (trashInterval > 0 && !skipTrash &&
+    } else if (trashInterval > 0 &&
         keyName.contains(TRASH_PREFIX)) {
-      // Delete from trash not possible when user didn't do skipTrash
-      out().printf("Use --skipTrash to delete key from Trash %n");
+      // Delete from trash not possible use fs to delete
+      out().printf("Use fs command to delete key from Trash %n");
     } else {
       bucket.deleteKey(keyName);
     }


### PR DESCRIPTION
## What changes were proposed in this pull request?

ozone sh command is applicable for all bucket layout types. But skipTrash is applicable only for FSO. If user wants to delete key without trash, user can do so by using ozone fs commands which supports FSO specific bucket features.
If skipTrash option is provided in sh command, user may wrongly interpret OBS buckets also supports trash which actually doesn't support. So to avoid confusion skipTrash which is bucket specific option is removed in this PR.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-8896

## How was this patch tested?

Updated existing tests to verify
