### PR TITLE
HDDS-9018. Refactor creation of IAccessAuthorizer

### DIFF
--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/security/acl/IAccessAuthorizer.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/security/acl/IAccessAuthorizer.java
@@ -43,6 +43,13 @@ public interface IAccessAuthorizer {
       throws OMException;
 
   /**
+   * @return true for Ozone-native authorizer
+   */
+  default boolean isNative() {
+    return false;
+  }
+
+  /**
    * ACL rights.
    */
   enum ACLType {

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/security/acl/OzoneAccessAuthorizer.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/security/acl/OzoneAccessAuthorizer.java
@@ -23,6 +23,13 @@ import org.apache.hadoop.ozone.om.exceptions.OMException;
  * */
 public class OzoneAccessAuthorizer implements IAccessAuthorizer {
 
+  private static final OzoneAccessAuthorizer INSTANCE =
+      new OzoneAccessAuthorizer();
+
+  public static OzoneAccessAuthorizer get() {
+    return INSTANCE;
+  }
+
   @Override
   public boolean checkAccess(IOzoneObj ozoneObject, RequestContext context)
       throws OMException {

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmSnapshot.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmSnapshot.java
@@ -29,6 +29,8 @@ import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
 import org.apache.hadoop.ozone.om.helpers.OmKeyLocationInfoGroup;
 import org.apache.hadoop.ozone.om.helpers.OzoneFileStatus;
 import org.apache.hadoop.ozone.om.helpers.SnapshotInfo;
+import org.apache.hadoop.ozone.security.acl.IAccessAuthorizer;
+import org.apache.hadoop.ozone.security.acl.OzoneAuthorizerFactory;
 import org.apache.hadoop.ozone.security.acl.OzoneObj;
 import org.apache.hadoop.ozone.security.acl.OzoneObjInfo;
 import org.apache.hadoop.util.Time;
@@ -78,9 +80,12 @@ public class OmSnapshot implements IOmMetadataReader, Closeable {
                     String volumeName,
                     String bucketName,
                     String snapshotName) {
+    IAccessAuthorizer accessAuthorizer =
+        OzoneAuthorizerFactory.forSnapshot(ozoneManager,
+            keyManager, prefixManager);
     omMetadataReader = new OmMetadataReader(keyManager, prefixManager,
         ozoneManager, LOG, AUDIT,
-        OmSnapshotMetrics.getInstance(), false);
+        OmSnapshotMetrics.getInstance(), accessAuthorizer);
     this.snapshotName = snapshotName;
     this.bucketName = bucketName;
     this.volumeName = volumeName;

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
@@ -98,6 +98,7 @@ import org.apache.hadoop.ozone.om.snapshot.OmSnapshotUtils;
 import org.apache.hadoop.ozone.om.snapshot.ReferenceCounted;
 import org.apache.hadoop.ozone.om.snapshot.SnapshotCache;
 import org.apache.hadoop.ozone.om.upgrade.OMLayoutFeature;
+import org.apache.hadoop.ozone.security.acl.OzoneAuthorizerFactory;
 import org.apache.hadoop.ozone.snapshot.CancelSnapshotDiffResponse;
 import org.apache.hadoop.ozone.snapshot.SnapshotDiffResponse;
 import org.apache.hadoop.ozone.util.OzoneNetUtils;
@@ -470,6 +471,7 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
 
   private final boolean isSecurityEnabled;
 
+  private IAccessAuthorizer accessAuthorizer;
   // This metadata reader points to the active filesystem
   private OmMetadataReader omMetadataReader;
   // Wrap active DB metadata reader in ReferenceCounted once to avoid
@@ -826,8 +828,9 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
     prefixManager = new PrefixManagerImpl(metadataManager, isRatisEnabled);
     keyManager = new KeyManagerImpl(this, scmClient, configuration,
         perfMetrics);
+    accessAuthorizer = OzoneAuthorizerFactory.forOM(this);
     omMetadataReader = new OmMetadataReader(keyManager, prefixManager,
-        this, LOG, AUDIT, metrics, true);
+        this, LOG, AUDIT, metrics, accessAuthorizer);
     // Active DB's OmMetadataReader instance does not need to be reference
     // counted, but it still needs to be wrapped to be consistent.
     rcOmMetadataReader = new ReferenceCounted<>(omMetadataReader, true, null);
@@ -866,6 +869,10 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
       // restart.
       instantiatePrepareStateOnStartup();
     }
+  }
+
+  private IAccessAuthorizer createAccessAuthorizer() {
+    return null;
   }
 
   /**
@@ -1549,7 +1556,7 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
   }
 
   public IAccessAuthorizer getAccessAuthorizer() {
-    return omMetadataReader.getAccessAuthorizer();
+    return accessAuthorizer;
   }
 
   /**

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
@@ -871,10 +871,6 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
     }
   }
 
-  private IAccessAuthorizer createAccessAuthorizer() {
-    return null;
-  }
-
   /**
    * Return scmClient.
    */

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/bucket/OMBucketSetPropertyRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/bucket/OMBucketSetPropertyRequest.java
@@ -26,8 +26,6 @@ import org.apache.hadoop.hdds.client.DefaultReplicationConfig;
 import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.hadoop.ozone.audit.AuditLogger;
 import org.apache.hadoop.ozone.audit.OMAction;
-import org.apache.hadoop.ozone.om.IOmMetadataReader;
-import org.apache.hadoop.ozone.om.OmMetadataReader;
 import org.apache.hadoop.ozone.om.helpers.OmVolumeArgs;
 import org.apache.hadoop.ozone.om.ratis.utils.OzoneManagerDoubleBufferHelper;
 import org.apache.hadoop.ozone.om.request.util.OmResponseUtil;
@@ -35,8 +33,6 @@ import org.apache.hadoop.ozone.om.request.validation.RequestFeatureValidator;
 import org.apache.hadoop.ozone.om.request.validation.RequestProcessingPhase;
 import org.apache.hadoop.ozone.om.request.validation.ValidationCondition;
 import org.apache.hadoop.ozone.om.request.validation.ValidationContext;
-import org.apache.hadoop.ozone.om.snapshot.ReferenceCounted;
-import org.apache.hadoop.ozone.om.snapshot.SnapshotCache;
 import org.apache.hadoop.ozone.om.upgrade.OMLayoutFeature;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.Type;
 import org.apache.hadoop.security.UserGroupInformation;
@@ -274,13 +270,7 @@ public class OMBucketSetPropertyRequest extends OMClientRequest {
   private void checkAclPermission(
       OzoneManager ozoneManager, String volumeName, String bucketName)
       throws IOException {
-    final boolean nativeAuthorizerEnabled;
-    try (ReferenceCounted<IOmMetadataReader, SnapshotCache> rcMetadataReader =
-        ozoneManager.getOmMetadataReader()) {
-      OmMetadataReader mdReader = (OmMetadataReader) rcMetadataReader.get();
-      nativeAuthorizerEnabled = mdReader.isNativeAuthorizerEnabled();
-    }
-    if (nativeAuthorizerEnabled) {
+    if (ozoneManager.getAccessAuthorizer().isNative()) {
       UserGroupInformation ugi = createUGI();
       String bucketOwner = ozoneManager.getBucketOwner(volumeName, bucketName,
           IAccessAuthorizer.ACLType.READ, OzoneObj.ResourceType.BUCKET);

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyRequest.java
@@ -39,9 +39,7 @@ import org.apache.hadoop.hdds.utils.db.cache.CacheValue;
 import org.apache.hadoop.ozone.OmUtils;
 import org.apache.hadoop.ozone.OzoneAcl;
 import org.apache.hadoop.ozone.OzoneConsts;
-import org.apache.hadoop.ozone.om.IOmMetadataReader;
 import org.apache.hadoop.ozone.om.OMMetrics;
-import org.apache.hadoop.ozone.om.OmMetadataReader;
 import org.apache.hadoop.ozone.om.PrefixManager;
 import org.apache.hadoop.ozone.om.ResolvedBucket;
 import org.apache.hadoop.ozone.om.helpers.BucketEncryptionKeyInfo;
@@ -59,8 +57,6 @@ import org.apache.hadoop.ozone.om.helpers.RepeatedOmKeyInfo;
 import org.apache.hadoop.ozone.om.lock.OzoneLockStrategy;
 import org.apache.hadoop.ozone.om.request.OMClientRequestUtils;
 import org.apache.hadoop.ozone.om.request.file.OMFileRequest;
-import org.apache.hadoop.ozone.om.snapshot.ReferenceCounted;
-import org.apache.hadoop.ozone.om.snapshot.SnapshotCache;
 import org.apache.hadoop.ozone.protocolPB.OMPBHelper;
 import org.apache.hadoop.ozone.security.acl.IAccessAuthorizer;
 import org.apache.hadoop.ozone.security.acl.OzoneObj;
@@ -385,18 +381,12 @@ public abstract class OMKeyRequest extends OMClientRequest {
   protected void checkKeyAclsInOpenKeyTable(OzoneManager ozoneManager,
       String volume, String bucket, String key,
       IAccessAuthorizer.ACLType aclType, long clientId) throws IOException {
-    final boolean nativeAuthorizerEnabled;
-    try (ReferenceCounted<IOmMetadataReader, SnapshotCache> rcMetadataReader =
-        ozoneManager.getOmMetadataReader()) {
-      OmMetadataReader mdReader = (OmMetadataReader) rcMetadataReader.get();
-      nativeAuthorizerEnabled = mdReader.isNativeAuthorizerEnabled();
-    }
 
     String keyNameForAclCheck = key;
     // Native authorizer requires client id as part of key name to check
     // write ACL on key. Add client id to key name if ozone native
     // authorizer is configured.
-    if (nativeAuthorizerEnabled) {
+    if (ozoneManager.getAccessAuthorizer().isNative()) {
       keyNameForAclCheck = key + "/" + clientId;
     }
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/security/acl/OzoneAuthorizerFactory.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/security/acl/OzoneAuthorizerFactory.java
@@ -1,0 +1,112 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.ozone.security.acl;
+
+import org.apache.hadoop.hdds.conf.ConfigurationSource;
+import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import org.apache.hadoop.ozone.om.KeyManager;
+import org.apache.hadoop.ozone.om.OmSnapshot;
+import org.apache.hadoop.ozone.om.OzoneManager;
+import org.apache.hadoop.ozone.om.PrefixManager;
+
+import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_ACL_AUTHORIZER_CLASS;
+import static org.apache.hadoop.util.ReflectionUtils.newInstance;
+
+/**
+ * Creates {@link IAccessAuthorizer} instances based on configuration.
+ */
+public final class OzoneAuthorizerFactory {
+
+  private OzoneAuthorizerFactory() {
+    // no instances
+  }
+
+  /**
+   * @return authorizer instance for {@link OzoneManager}
+   */
+  public static IAccessAuthorizer forOM(OzoneManager om) {
+    return create(om, om.getKeyManager(), om.getPrefixManager());
+  }
+
+  /**
+   * @return authorizer instance for {@link OmSnapshot}, may be new instance,
+   * or existing one, depending on configuration
+   */
+  public static IAccessAuthorizer forSnapshot(
+      OzoneManager om, KeyManager keyManager, PrefixManager prefixManager
+  ) {
+    return om.getAccessAuthorizer().isNative()
+        ? create(om, keyManager, prefixManager)
+        : om.getAccessAuthorizer();
+  }
+
+  /**
+   * Creates new instance (except for {@link OzoneAccessAuthorizer},
+   * which is a no-op authorizer.
+   */
+  private static IAccessAuthorizer create(
+      OzoneManager om, KeyManager km, PrefixManager pm
+  ) {
+    if (!om.getAclsEnabled()) {
+      return OzoneAccessAuthorizer.get();
+    }
+
+    final OzoneConfiguration conf = om.getConfiguration();
+    final Class<? extends IAccessAuthorizer> clazz = authorizerClass(conf);
+
+    if (OzoneAccessAuthorizer.class == clazz) {
+      return OzoneAccessAuthorizer.get();
+    }
+
+    if (OzoneNativeAuthorizer.class == clazz) {
+      final OzoneNativeAuthorizer authorizer = new OzoneNativeAuthorizer();
+      return configure(authorizer, om, km, pm);
+    }
+
+    final IAccessAuthorizer authorizer = newInstance(clazz, conf);
+    return authorizer instanceof OzoneNativeAuthorizer
+        ? configure((OzoneNativeAuthorizer) authorizer, om, km, pm)
+        : authorizer;
+  }
+
+  /**
+   * Configure {@link OzoneNativeAuthorizer}.
+   * @return same instance for convenience
+   */
+  private static IAccessAuthorizer configure(
+      OzoneNativeAuthorizer authorizer,
+      OzoneManager om, KeyManager km, PrefixManager pm
+  ) {
+    authorizer.setVolumeManager(om.getVolumeManager());
+    authorizer.setBucketManager(om.getBucketManager());
+    authorizer.setKeyManager(km);
+    authorizer.setPrefixManager(pm);
+    authorizer.setAdminCheck(om::isAdmin);
+    authorizer.setReadOnlyAdminCheck(om::isReadOnlyAdmin);
+    authorizer.setAllowListAllVolumes(om.getAllowListAllVolumes());
+    return authorizer;
+  }
+
+  private static Class<? extends IAccessAuthorizer> authorizerClass(
+      ConfigurationSource conf) {
+    return conf.getClass(OZONE_ACL_AUTHORIZER_CLASS,
+        OzoneAccessAuthorizer.class,
+        IAccessAuthorizer.class);
+  }
+
+}

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/security/acl/OzoneNativeAuthorizer.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/security/acl/OzoneNativeAuthorizer.java
@@ -37,8 +37,7 @@ import java.util.function.Predicate;
 import static org.apache.hadoop.ozone.om.exceptions.OMException.ResultCodes.INVALID_REQUEST;
 
 /**
- * Public API for Ozone ACLs. Security providers providing support for Ozone
- * ACLs should implement this.
+ * Native (internal) implementation of {@link IAccessAuthorizer}.
  */
 @InterfaceAudience.LimitedPrivate({"HDFS", "Yarn", "Ranger", "Hive", "HBase"})
 @InterfaceStability.Evolving
@@ -69,6 +68,11 @@ public class OzoneNativeAuthorizer implements IAccessAuthorizer {
     this.keyManager = keyManager;
     this.prefixManager = prefixManager;
     this.adminCheck = ozoneAdmins::isAdmin;
+  }
+
+  @Override
+  public boolean isNative() {
+    return true;
   }
 
   /**

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMKeyRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMKeyRequest.java
@@ -44,6 +44,7 @@ import org.apache.hadoop.ozone.om.snapshot.ReferenceCounted;
 import org.apache.hadoop.ozone.om.snapshot.SnapshotCache;
 import org.apache.hadoop.ozone.om.upgrade.OMLayoutVersionManager;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.KeyArgs;
+import org.apache.hadoop.ozone.security.acl.OzoneNativeAuthorizer;
 import org.apache.hadoop.security.UserGroupInformation;
 import org.jetbrains.annotations.NotNull;
 import org.junit.After;
@@ -168,6 +169,8 @@ public class TestOMKeyRequest {
     when(ozoneManager.getOMNodeId()).thenReturn(UUID.randomUUID().toString());
     when(scmClient.getBlockClient()).thenReturn(scmBlockLocationProtocol);
     when(ozoneManager.getKeyManager()).thenReturn(keyManager);
+    when(ozoneManager.getAccessAuthorizer())
+        .thenReturn(new OzoneNativeAuthorizer());
 
     ReferenceCounted<IOmMetadataReader, SnapshotCache> rcOmMetadataReader =
         mock(ReferenceCounted.class);

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/s3/multipart/TestS3MultipartRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/s3/multipart/TestS3MultipartRequest.java
@@ -25,6 +25,7 @@ import java.util.List;
 import org.apache.hadoop.hdds.client.ReplicationConfig;
 import org.apache.hadoop.ozone.om.helpers.BucketLayout;
 import org.apache.hadoop.ozone.om.request.OMClientRequest;
+import org.apache.hadoop.ozone.security.acl.OzoneNativeAuthorizer;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -95,6 +96,8 @@ public class TestS3MultipartRequest {
     OmMetadataReader omMetadataReader = Mockito.mock(OmMetadataReader.class);
     when(omMetadataReader.isNativeAuthorizerEnabled()).thenReturn(true);
     when(rcOmMetadataReader.get()).thenReturn(omMetadataReader);
+    when(ozoneManager.getAccessAuthorizer())
+        .thenReturn(new OzoneNativeAuthorizer());
     when(ozoneManager.getAuditLogger()).thenReturn(auditLogger);
     when(ozoneManager.getDefaultReplicationConfig()).thenReturn(
         ReplicationConfig.getDefault(ozoneConfiguration));

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/security/acl/TestOzoneAuthorizerFactory.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/security/acl/TestOzoneAuthorizerFactory.java
@@ -1,0 +1,177 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.ozone.security.acl;
+
+import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import org.apache.hadoop.ozone.om.OzoneManager;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import javax.annotation.Nonnull;
+
+import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_ACL_AUTHORIZER_CLASS;
+import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_ACL_ENABLED;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class TestOzoneAuthorizerFactory {
+
+  @Test
+  void aclsDisabled() {
+    // GIVEN
+    OzoneManager om = disableAcls();
+
+    // WHEN
+    IAccessAuthorizer omAuth =
+        OzoneAuthorizerFactory.forOM(om);
+
+    // THEN
+    assertSame(OzoneAccessAuthorizer.get(), omAuth);
+
+    assertSameInstanceForSnapshot(om, omAuth);
+  }
+
+  @ParameterizedTest
+  @ValueSource(classes = {
+      OzoneNativeAuthorizer.class,
+      MockNativeAuthorizer.class,
+  })
+  void nativeAuthorizer(Class<? extends IAccessAuthorizer> clazz) {
+    // GIVEN
+    OzoneManager om = enableAcls(clazz);
+
+    // WHEN
+    IAccessAuthorizer omAuth =
+        OzoneAuthorizerFactory.forOM(om);
+
+    // THEN
+    assertInstanceOf(clazz, omAuth);
+
+    assertNewInstanceForSnapshot(om, omAuth);
+  }
+
+  @Test
+  void customNativeAuthorizer() {
+    // GIVEN
+    OzoneManager om = enableAcls(MockNativeAuthorizer.class);
+
+    // WHEN
+    IAccessAuthorizer omAuth =
+        OzoneAuthorizerFactory.forOM(om);
+
+    // THEN
+    assertInstanceOf(MockNativeAuthorizer.class, omAuth);
+
+    assertNewInstanceForSnapshot(om, omAuth);
+  }
+
+  @Test
+  void thirdPartyAuthorizer() {
+    // GIVEN
+    OzoneManager om = enableAcls(MockThirdPartyAuthorizer.class);
+
+    // WHEN
+    IAccessAuthorizer omAuth =
+        OzoneAuthorizerFactory.forOM(om);
+
+    // THEN
+    assertInstanceOf(MockThirdPartyAuthorizer.class, omAuth);
+
+    assertSameInstanceForSnapshot(om, omAuth);
+  }
+
+  private static void assertSameInstanceForSnapshot(
+      OzoneManager om, IAccessAuthorizer omAuth) {
+    // GIVEN
+    when(om.getAccessAuthorizer()).thenReturn(omAuth);
+
+    // WHEN
+    IAccessAuthorizer snapshotAuth =
+        OzoneAuthorizerFactory.forSnapshot(om, null, null);
+
+    // THEN
+    assertSame(omAuth, snapshotAuth);
+  }
+
+  private static void assertNewInstanceForSnapshot(
+      OzoneManager om, IAccessAuthorizer omAuth) {
+    // GIVEN
+    when(om.getAccessAuthorizer()).thenReturn(omAuth);
+
+    // WHEN
+    IAccessAuthorizer snapshotAuth =
+        OzoneAuthorizerFactory.forSnapshot(om, null, null);
+
+    // THEN
+    assertEquals(omAuth.getClass(), snapshotAuth.getClass());
+    assertNotSame(omAuth, snapshotAuth);
+  }
+
+  @Nonnull
+  private static OzoneManager disableAcls() {
+    return configureOM(false, OzoneNativeAuthorizer.class);
+  }
+
+  @Nonnull
+  private static OzoneManager enableAcls(
+      Class<? extends IAccessAuthorizer> clazz) {
+    return configureOM(true, clazz);
+  }
+
+  @Nonnull
+  private static OzoneManager configureOM(boolean aclEnabled,
+      Class<? extends IAccessAuthorizer> clazz) {
+
+    OzoneConfiguration conf = new OzoneConfiguration();
+    conf.setBoolean(OZONE_ACL_ENABLED, aclEnabled);
+    conf.setClass(OZONE_ACL_AUTHORIZER_CLASS, clazz, IAccessAuthorizer.class);
+
+    OzoneManager om = mock(OzoneManager.class);
+    when(om.getConfiguration())
+        .thenReturn(conf);
+    when(om.getAclsEnabled())
+        .thenReturn(aclEnabled);
+
+    return om;
+  }
+
+  /**
+   * Non-native authorizer for tests.
+   */
+  public static class MockNativeAuthorizer extends OzoneNativeAuthorizer {
+    @Override
+    public boolean checkAccess(IOzoneObj ozoneObject, RequestContext context) {
+      return false;
+    }
+  }
+
+  /**
+   * Non-native authorizer for tests.
+   */
+  public static class MockThirdPartyAuthorizer implements IAccessAuthorizer {
+    @Override
+    public boolean checkAccess(IOzoneObj ozoneObject, RequestContext context) {
+      return false;
+    }
+  }
+}


### PR DESCRIPTION
## What changes were proposed in this pull request?

 * extract `IAccessAuthorizer` creation out of `OmMetadataReader` to a factory class
 * pass `IAccessAuthorizer` instance to `OmMetadataReader`
 * replace the `bNeedAccessAuthInitialization` flag with two separate methods in the factory class
 * use direct instantiation instead of reflection for known implementations (`OzoneAccessAuthorizer` and `OzoneNativeAuthorizer`)
 * eliminate cumbersome way of checking whether native authorizer is in use (in `OMBucketSetPropertyRequest` and `OMKeyRequest`)
 * make `OzoneAccessAuthorizer` (no-op implementation) a singleton (without strictly enforcing it for compatibility)
 * use `OzoneAccessAuthorizer`, instead of `null`, if ACL is disabled
 * add unit test for `IAccessAuthorizer` creation

https://issues.apache.org/jira/browse/HDDS-9018

## How was this patch tested?

CI:
https://github.com/adoroszlai/hadoop-ozone/actions/runs/5554283426