### PR TITLE
HDDS-9004. [Snapshot] Pause the compaction log append if tarball creation is in progress

### DIFF
--- a/hadoop-hdds/rocksdb-checkpoint-differ/src/main/java/org/apache/ozone/rocksdiff/RocksDBCheckpointDiffer.java
+++ b/hadoop-hdds/rocksdb-checkpoint-differ/src/main/java/org/apache/ozone/rocksdiff/RocksDBCheckpointDiffer.java
@@ -1524,6 +1524,11 @@ public class RocksDBCheckpointDiffer implements AutoCloseable,
   }
 
   @VisibleForTesting
+  public int getTarballRequestCount() {
+    return tarballRequestCount.get();
+  }
+
+  @VisibleForTesting
   public boolean debugEnabled(Integer level) {
     return DEBUG_LEVEL.contains(level);
   }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOMDbCheckpointServlet.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOMDbCheckpointServlet.java
@@ -87,6 +87,7 @@ import static org.apache.hadoop.ozone.OzoneConsts.OZONE_DB_CHECKPOINT_REQUEST_TO
 import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_HTTP_AUTH_TYPE;
 
 
+import org.apache.ozone.rocksdiff.RocksDBCheckpointDiffer;
 import org.apache.ozone.test.GenericTestUtils;
 
 import org.junit.Assert;
@@ -397,6 +398,10 @@ public class TestOMDbCheckpointServlet {
     // Get the tarball.
     when(responseMock.getOutputStream()).thenReturn(servletOutputStream);
     omDbCheckpointServletMock.doGet(requestMock, responseMock);
+
+    // Verify that tarball request count reaches to zero once doGet completes.
+    Assertions.assertEquals(0,
+        dbStore.getRocksDBCheckpointDiffer().getTarballRequestCount());
     dbCheckpoint = realCheckpoint.get();
 
     // Untar the file into a temp folder to be examined.

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOMDbCheckpointServlet.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOMDbCheckpointServlet.java
@@ -86,8 +86,6 @@ import static org.apache.hadoop.ozone.OzoneConsts.OZONE_DB_CHECKPOINT_REQUEST_FL
 import static org.apache.hadoop.ozone.OzoneConsts.OZONE_DB_CHECKPOINT_REQUEST_TO_EXCLUDE_SST;
 import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_HTTP_AUTH_TYPE;
 
-
-import org.apache.ozone.rocksdiff.RocksDBCheckpointDiffer;
 import org.apache.ozone.test.GenericTestUtils;
 
 import org.junit.Assert;


### PR DESCRIPTION
## What changes were proposed in this pull request?
Currently it is possible that RocksDB compaction adds the newer log entry to the compaction log while tarball creation is in progress because it is unaware of tarball creation. This lead to the situation when compaction log has new log entries after checkpoint was created for the follower. And when follower construct the DAG based on the compaction log, new entries nodes will become dangling nodes and will never be reached by snap diff or removed from the DAG unless OM is restarted or another bootstrap kicks in.

In this change, it is proposed to wait for tarball completion before appending new log entries to the compaction log. This way follower will never get new entries. Whenever OM gets tarball request, it increases the tarball request count in the `RocksDBCheckpointDiffer` and once request finishes it decreases the request count and notify all the thread. `CompactionCompletedListener` waits till all the tarball requests finish and request count reaches to zero.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-9004

## How was this patch tested?
* Existing unit and integration tests for now. New integration test will be added as a separate PR because it would be tricky to start the compaction at the same time tarball creation kicks in. 
