### PR TITLE
HDDS-9024. Update instructions in dependency check

### DIFF
--- a/hadoop-ozone/dist/src/main/license/update-jar-report.sh
+++ b/hadoop-ozone/dist/src/main/license/update-jar-report.sh
@@ -18,7 +18,7 @@
 set -euo pipefail
 
 SCRIPTDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
-REPORT_NAME=${1:-jar-report.txt}
+REPORT_NAME=${1:-current.txt}
 
 cd "$SCRIPTDIR/../../.." || exit 1
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Dependency check instructs developers to update `jar-report.txt` using `update-jar-report.sh`.  However, its output varies due to different `sort` implementations.  This can cause unnecessarily reordered lines, which makes it more difficult to see actual changes.  (This is similar to reordering imports unneccessarily in a PR.)

This change proposes updating the instructions: developers should edit `jar-report.txt` manually, based on the diff shown in the check's output.  License needs to be edited manually anyway, so it's only a minor change in the workflow.

Benefits:
 * simpler diffs of `jar-report.txt` in PRs
 * developers may build with `-DskipShade` locally and can still update `jar-report.txt`

https://issues.apache.org/jira/browse/HDDS-9024

## How was this patch tested?

```
$ ./hadoop-ozone/dev-support/checks/dependency.sh
Jar files under share/ozone/lib in the build have changed.

Please update:

 * hadoop-ozone/dist/src/main/license/bin/LICENSE.txt
   (add new dependencies with the appropriate license, delete any removed dependencies)

 * hadoop-ozone/dist/src/main/license/jar-report.txt
   (based on the diff shown below)

If you notice unexpected differences (can happen when the check is run in a
fork), please first update your branch from upstream master to get any other
recent dependency changes.

If you are running this locally after build with -DskipShade, please ignore any
ozone-filesystem jars reported to be missing.

Changes detected:

...
```