### PR TITLE
HDDS-8946. Add dedicated log file for each service in docker test

### DIFF
--- a/hadoop-ozone/dist/src/main/compose/testlib.sh
+++ b/hadoop-ozone/dist/src/main/compose/testlib.sh
@@ -154,14 +154,15 @@ execute_robot_test(){
   unset 'ARGUMENTS[${#ARGUMENTS[@]}-1]' #Remove the last element, remainings are the custom parameters
   TEST_NAME=$(basename "$TEST")
   TEST_NAME="$(basename "$COMPOSE_DIR")-${TEST_NAME%.*}"
-  [[ -n "$OUTPUT_NAME" ]] || OUTPUT_NAME="$COMPOSE_ENV_NAME-$TEST_NAME-$CONTAINER"
+
+  local output_name=$(get_output_name)
 
   # find unique filename
   declare -i i=0
-  OUTPUT_FILE="robot-${OUTPUT_NAME}.xml"
+  OUTPUT_FILE="robot-${output_name}1.xml"
   while [[ -f $RESULT_DIR/$OUTPUT_FILE ]]; do
     let ++i
-    OUTPUT_FILE="robot-${OUTPUT_NAME}-${i}.xml"
+    OUTPUT_FILE="robot-${output_name}${i}.xml"
   done
 
   SMOKETEST_DIR_INSIDE="${OZONE_DIR:-/opt/hadoop}/smoketest"
@@ -267,10 +268,17 @@ create_containers() {
   docker-compose --ansi never up -d $@
 }
 
+get_output_name() {
+  if [[ -n "${OUTPUT_NAME}" ]]; then
+    echo "${OUTPUT_NAME}-"
+  fi
+}
+
 save_container_logs() {
+  local output_name=$(get_output_name)
   local c
   for c in $(docker-compose ps "$@" | cut -f1 -d' ' | tail -n +3); do
-    docker logs "${c}" &> "$RESULT_DIR/docker-${c}.log"
+    docker logs "${c}" &>> "$RESULT_DIR/docker-${output_name}${c}.log"
   done
 }
 

--- a/hadoop-ozone/dist/src/main/compose/testlib.sh
+++ b/hadoop-ozone/dist/src/main/compose/testlib.sh
@@ -269,7 +269,7 @@ create_containers() {
 
 save_container_logs() {
   local c
-  for c in $(docker-compose ps "$@" | cut -f1 -d' ' | grep $(basename $(pwd))); do
+  for c in $(docker-compose ps "$@" | cut -f1 -d' ' | tail -n +3); do
     docker logs "${c}" &> "$RESULT_DIR/docker-${c}.log"
   done
 }

--- a/hadoop-ozone/dist/src/main/compose/testlib.sh
+++ b/hadoop-ozone/dist/src/main/compose/testlib.sh
@@ -268,15 +268,10 @@ create_containers() {
 }
 
 save_container_logs() {
-  local output_name="${OUTPUT_NAME:-}"
-  if [[ -z "${output_name}" ]]; then
-    output_name="$COMPOSE_ENV_NAME"
-  fi
-  if [[ -z "${output_name}" ]]; then
-    output_name="$(basename $(pwd))"
-  fi
-
-  docker-compose --ansi never logs $@ >> "$RESULT_DIR/docker-${output_name}.log"
+  local c
+  for c in $(docker-compose ps "$@" | cut -f1 -d' ' | grep $(basename $(pwd))); do
+    docker logs "${c}" &> "$RESULT_DIR/docker-${c}.log"
+  done
 }
 
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Save docker container logs into separate files, instead of a single mixed file.

https://issues.apache.org/jira/browse/HDDS-8946

## How was this patch tested?

Verified content of some acceptance check bundles:

```
$ unzip -q acceptance-misc.zip
$ find * -type f -name 'docker*' | sort | xargs ls -1hs
 32K ozone-csi/docker-ozone-csi_csi_1.log
116K ozone-csi/docker-ozone-csi_datanode_1.log
120K ozone-csi/docker-ozone-csi_datanode_2.log
116K ozone-csi/docker-ozone-csi_datanode_3.log
 96K ozone-csi/docker-ozone-csi_om_1.log
140K ozone-csi/docker-ozone-csi_scm_1.log
116K ozone-om-prepare/docker-ozone-om-prepare_dn1_1.log
120K ozone-om-prepare/docker-ozone-om-prepare_dn2_1.log
120K ozone-om-prepare/docker-ozone-om-prepare_dn3_1.log
 76K ozone-om-prepare/docker-ozone-om-prepare_om1_1.log
 72K ozone-om-prepare/docker-ozone-om-prepare_om2_1.log
 72K ozone-om-prepare/docker-ozone-om-prepare_om3_1.log
 80K ozone-om-prepare/docker-ozone-om-prepare_scm_1.log
116K ozone/s3-haproxy/docker-ozone_datanode_1.log
124K ozone/s3-haproxy/docker-ozone_datanode_2.log
100K ozone/s3-haproxy/docker-ozone_datanode_3.log
 16K ozone/s3-haproxy/docker-ozone_httpfs_1.log
140K ozone/s3-haproxy/docker-ozone_om_1.log
160K ozone/s3-haproxy/docker-ozone_recon_1.log
104K ozone/s3-haproxy/docker-ozone_s3g1_1.log
4.0K ozone/s3-haproxy/docker-ozone_s3g_1.log
 80K ozone/s3-haproxy/docker-ozone_s3g2_1.log
 68K ozone/s3-haproxy/docker-ozone_s3g3_1.log
144K ozone/s3-haproxy/docker-ozone_scm_1.log
256K ozone-topology/docker-ozone-topology_datanode_1_1.log
264K ozone-topology/docker-ozone-topology_datanode_2_1.log
264K ozone-topology/docker-ozone-topology_datanode_3_1.log
176K ozone-topology/docker-ozone-topology_datanode_4_1.log
 80K ozone-topology/docker-ozone-topology_datanode_5_1.log
256K ozone-topology/docker-ozone-topology_datanode_6_1.log
104K ozone-topology/docker-ozone-topology_om_1.log
116K ozone-topology/docker-ozone-topology_recon_1.log
160K ozone-topology/docker-ozone-topology_scm_1.log
144K restart/docker-restart_dn1_1.log
140K restart/docker-restart_dn2_1.log
144K restart/docker-restart_dn3_1.log
 60K restart/docker-restart_om_1.log
 68K restart/docker-restart_recon_1.log
 36K restart/docker-restart_s3g_1.log
 80K restart/docker-restart_scm_1.log

$ unzip -q acceptance-HA-secure.zip
$ find * -type f -name 'docker*' | sort | xargs ls -1hs
212K ozonesecure-ha/docker-ozonesecure-ha_datanode1_1.log
208K ozonesecure-ha/docker-ozonesecure-ha_datanode2_1.log
212K ozonesecure-ha/docker-ozonesecure-ha_datanode3_1.log
132K ozonesecure-ha/docker-ozonesecure-ha_datanode4_1.log
 20K ozonesecure-ha/docker-ozonesecure-ha_httpfs_1.log
200K ozonesecure-ha/docker-ozonesecure-ha_kdc_1.log
4.0K ozonesecure-ha/docker-ozonesecure-ha_kms_1.log
484K ozonesecure-ha/docker-ozonesecure-ha_om1_1.log
324K ozonesecure-ha/docker-ozonesecure-ha_om2_1.log
336K ozonesecure-ha/docker-ozonesecure-ha_om3_1.log
912K ozonesecure-ha/docker-ozonesecure-ha_recon_1.log
448K ozonesecure-ha/docker-ozonesecure-ha_s3g_1.log
796K ozonesecure-ha/docker-ozonesecure-ha_scm1.org_1.log
872K ozonesecure-ha/docker-ozonesecure-ha_scm2.org_1.log
844K ozonesecure-ha/docker-ozonesecure-ha_scm3.org_1.log
232K ozonesecure-ha/docker-ozonesecure-ha_scm4.org_1.log
2.0M ozonesecure-ha/root-ca-rotation/docker-ozonesecure-ha_datanode1_1.log
2.2M ozonesecure-ha/root-ca-rotation/docker-ozonesecure-ha_datanode2_1.log
2.0M ozonesecure-ha/root-ca-rotation/docker-ozonesecure-ha_datanode3_1.log
564K ozonesecure-ha/root-ca-rotation/docker-ozonesecure-ha_datanode4_1.log
 16K ozonesecure-ha/root-ca-rotation/docker-ozonesecure-ha_httpfs_1.log
 36K ozonesecure-ha/root-ca-rotation/docker-ozonesecure-ha_kdc_1.log
4.0K ozonesecure-ha/root-ca-rotation/docker-ozonesecure-ha_kms_1.log
1.5M ozonesecure-ha/root-ca-rotation/docker-ozonesecure-ha_om1_1.log
1.4M ozonesecure-ha/root-ca-rotation/docker-ozonesecure-ha_om2_1.log
1.5M ozonesecure-ha/root-ca-rotation/docker-ozonesecure-ha_om3_1.log
1.9M ozonesecure-ha/root-ca-rotation/docker-ozonesecure-ha_recon_1.log
 40K ozonesecure-ha/root-ca-rotation/docker-ozonesecure-ha_s3g_1.log
1.2M ozonesecure-ha/root-ca-rotation/docker-ozonesecure-ha_scm1.org_1.log
1.3M ozonesecure-ha/root-ca-rotation/docker-ozonesecure-ha_scm2.org_1.log
1.1M ozonesecure-ha/root-ca-rotation/docker-ozonesecure-ha_scm3.org_1.log
392K ozonesecure-ha/root-ca-rotation/docker-ozonesecure-ha_scm4.org_1.log
```

CI:
https://github.com/adoroszlai/hadoop-ozone/actions/runs/5566812377