### PR TITLE
HDDS-9025. Upgrade acceptance test cannot be run with docker-compose v1

### DIFF
--- a/hadoop-ozone/dist/src/main/compose/upgrade/testlib.sh
+++ b/hadoop-ozone/dist/src/main/compose/upgrade/testlib.sh
@@ -119,7 +119,7 @@ run_test() {
 
   # The container to run test commands from. Use one of the SCM containers,
   # but SCM HA may or may not be used.
-  export SCM="$(docker compose --project-directory="$compose_dir" config --services | grep --max-count=1 scm)"
+  export SCM="$(docker-compose --project-directory="$compose_dir" config --services | grep --max-count=1 scm)"
 
   if ! run_test_script "$test_dir" ./driver.sh; then
     RESULT=1


### PR DESCRIPTION
## What changes were proposed in this pull request?

Upgrade acceptance test uses v2 `docker compose` to determine SCM node, cannot be run with v1.

```
Using docker cluster defined in compose/ha/docker-compose.yaml
unknown flag: --project-directory
See 'docker --help'.
```

https://issues.apache.org/jira/browse/HDDS-9025

## How was this patch tested?

Ran `upgrade` acceptance test locally.

```
$ docker-compose --version
docker-compose version 1.29.2, build unknown
$ cd hadoop-ozone/dist/target/ozone-1.4.0-SNAPSHOT/compose/upgrade
$ ./test.sh
...
```

CI:
https://github.com/adoroszlai/hadoop-ozone/actions/runs/5566833396