### PR TITLE
HDDS-9027. Error creating stack dump in S3 HA environment

### DIFF
--- a/hadoop-ozone/dist/src/main/compose/testlib.sh
+++ b/hadoop-ozone/dist/src/main/compose/testlib.sh
@@ -215,7 +215,7 @@ create_stack_dumps() {
     while read -r pid procname; do
       echo "jstack $pid > ${RESULT_DIR}/${c}_${procname}.stack"
       docker exec "${c}" bash -c "jstack $pid" > "${RESULT_DIR}/${c}_${procname}.stack"
-    done < <(docker exec "${c}" bash -c "jps | grep -v Jps")
+    done < <(docker exec "${c}" sh -c "jps | grep -v Jps" || true)
   done
 }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Creation of stack dump fails for `test-s3-haproxy.sh`, because `haproxy` image doesn't have `bash`.  Artifact upload then fails due to invalid character in filename.

```
2023-07-16T11:06:13.0454641Z jstack 6 > /home/runner/work/ozone/ozone/hadoop-ozone/dist/target/ozone-1.4.0-SNAPSHOT/compose/ozone/result/ozone_s3g1_1_Gateway.stack
2023-07-16T11:06:14.0932388Z jstack 7 > /home/runner/work/ozone/ozone/hadoop-ozone/dist/target/ozone-1.4.0-SNAPSHOT/compose/ozone/result/ozone_s3g2_1_Gateway.stack
2023-07-16T11:06:15.2248031Z jstack 6 > /home/runner/work/ozone/ozone/hadoop-ozone/dist/target/ozone-1.4.0-SNAPSHOT/compose/ozone/result/ozone_s3g3_1_Gateway.stack
2023-07-16T11:06:15.9927006Z jstack OCI > /home/runner/work/ozone/ozone/hadoop-ozone/dist/target/ozone-1.4.0-SNAPSHOT/compose/ozone/result/ozone_s3g_1_runtime exec failed: exec failed: unable to start container process: exec: "bash": executable file not found in $PATH: unknown
2023-07-16T11:06:15.9928158Z .stack

...

2023-07-16T11:06:36.5849554Z Starting artifact upload
2023-07-16T11:06:36.5850620Z For more detailed logs during the artifact upload process, enable step-debugging: https://docs.github.com/actions/monitoring-and-troubleshooting-workflows/enabling-debug-logging#enabling-step-debug-logging
2023-07-16T11:06:36.5854806Z Artifact name is valid!
2023-07-16T11:06:36.5903617Z ##[error]Artifact path is not valid: /ozone/s3-haproxy/ozone_s3g_1_runtime exec failed: exec failed: unable to start container process: exec: "bash": executable file not found in $PATH: unknown
.stack. Contains the following character:  Double quote "
          
Invalid characters include:  Double quote ", Colon :, Less than <, Greater than >, Vertical bar |, Asterisk *, Question mark ?, Carriage return \r, Line feed \n
          
The following characters are not allowed in files that are uploaded due to limitations with certain file systems such as NTFS. To maintain file system agnostic behavior, these characters are intentionally not allowed to prevent potential problems with downloads on different file systems.
```

This PR updates test lib to use `sh` instead of `bash` for stack dump, plus handles error in the command (stack dump for `haproxy` still cannot be created, due to non-existent `jps` command), to let artifact upload complete normally.

https://issues.apache.org/jira/browse/HDDS-9027

## How was this patch tested?

Verified that stack dump creation is successful for Ozone containers, failure in haproxy is not fatal.

```
$ cd hadoop-ozone/dist/target/ozone-1.4.0-SNAPSHOT/compose/ozone
$ cat <<"EOF" > verify.sh
#!/usr/bin/env bash

COMPOSE_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
export COMPOSE_DIR

export SECURITY_ENABLED=false
export COMPOSE_FILE=docker-compose.yaml:../common/s3-haproxy.yaml

source ../testlib.sh

start_docker_env
create_stack_dumps
EOF

$ chmod 700 verify.sh

$ ./verify.sh
...
jstack 7 > result/ozone_s3g1_1_Gateway.stack
jstack 7 > result/ozone_s3g2_1_Gateway.stack
jstack 7 > result/ozone_s3g3_1_Gateway.stack
sh: jps: not found
jstack 6 > result/ozone_scm_1_StorageContainerManagerStarter.stack
...
Stopping ozone_s3g_1      ... done
Stopping ozone_s3g3_1     ... done
Stopping ozone_s3g1_1     ... done
Stopping ozone_s3g2_1     ... done
...

$ echo $?
0

$ find result -type f | sort
result/dn-audit-1b550dec2d05.log
result/dn-audit-85415db6c5dd.log
result/dn-audit-c9994e1ca47a.log
result/docker-ozone.log
result/om-audit-dfa07964d2b8.log
result/ozone_datanode_1_HddsDatanodeService.stack
result/ozone_datanode_2_HddsDatanodeService.stack
result/ozone_datanode_3_HddsDatanodeService.stack
result/ozone_om_1_OzoneManagerStarter.stack
result/ozone_recon_1_ReconServer.stack
result/ozone_s3g1_1_Gateway.stack
result/ozone_s3g2_1_Gateway.stack
result/ozone_s3g3_1_Gateway.stack
result/ozone_scm_1_StorageContainerManagerStarter.stack
result/s3g-audit-1a8f6f2b7d3c.log
result/s3g-audit-a4719c50bfc5.log
result/s3g-audit-c59afa31cf7d.log
result/scm-audit-5c1e0f246b85.log
```

CI:
https://github.com/adoroszlai/hadoop-ozone/actions/runs/5567801491