### PR TITLE
HDDS-8256. ozone admin cert list should provide JSON output option

### DIFF
--- a/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/cert/ListSubcommand.java
+++ b/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/cert/ListSubcommand.java
@@ -173,10 +173,10 @@ public class ListSubcommand extends ScmCertSubcommand {
 
     }
 
-    private void parseDnInfo(String DnName, boolean isSubject) {
-      String[] dnNameComponents = DnName.split(",");
+    private void parseDnInfo(String dnName, boolean isSubject) {
+      String[] dnNameComponents = dnName.split(",");
       if (dnNameComponents.length == 0) {
-        err.println("Invalid format of name: " + DnName);
+        err.println("Invalid format of name: " + dnName);
       } else {
         for (String elem : dnNameComponents) {
           String[] components = elem.split("=");
@@ -184,7 +184,7 @@ public class ListSubcommand extends ScmCertSubcommand {
             (isSubject ? subjectDN : issuerDN)
                 .put(components[0], components[1]);
           } else {
-            err.println("Invalid format of name: " + DnName);
+            err.println("Invalid format of name: " + dnName);
           }
         }
       }

--- a/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/cert/ListSubcommand.java
+++ b/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/cert/ListSubcommand.java
@@ -22,7 +22,7 @@ import java.math.BigInteger;
 import java.security.cert.CertificateException;
 import java.security.cert.X509Certificate;
 import java.util.ArrayList;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -157,38 +157,34 @@ public class ListSubcommand extends ScmCertSubcommand {
     private BigInteger serialNumber;
     private String validFrom;
     private String expiry;
-    private Map<String, String> subjectDN = new HashMap<>();
-    private Map<String, String> issuerDN = new HashMap<>();;
+    private Map<String, String> subjectDN = new LinkedHashMap<>();
+    private Map<String, String> issuerDN = new LinkedHashMap<>();;
 
     Certificate(X509Certificate cert) {
       serialNumber = cert.getSerialNumber();
       validFrom = cert.getNotBefore().toString();
       expiry = cert.getNotAfter().toString();
 
-      String[] subject = cert.getSubjectDN().getName().split(",");
-      if(subject.length == 0) {
-        err.println("Invalid format of subjectDN name");
-      } else {
-        for(String elem : subject) {
-          String[] subjectComponents = elem.split("=");
-          if(subjectComponents.length == 2) {
-            subjectDN.put(subjectComponents[0], subjectComponents[1]);
-          } else {
-            err.println("Invalid format of subjectDN name");
-          }
-        }
-      }
+      String subject = cert.getSubjectDN().getName();
+      parseDnInfo(subject, true);
 
-      String[] issuer = cert.getIssuerDN().getName().split(",");
-      if(issuer.length == 0) {
-        err.println("Invalid format of issuerDN name");
+      String issuer = cert.getIssuerDN().getName();
+      parseDnInfo(issuer, false);
+
+    }
+
+    private void parseDnInfo(String DnName, boolean isSubject) {
+      String[] dnNameComponents = DnName.split(",");
+      if (dnNameComponents.length == 0) {
+        err.println("Invalid format of name: " + DnName);
       } else {
-        for(String elem : issuer) {
-          String[] issuerComponents = elem.split("=");
-          if(issuerComponents.length == 2) {
-            issuerDN.put(issuerComponents[0], issuerComponents[1]);
+        for (String elem : dnNameComponents) {
+          String[] components = elem.split("=");
+          if (components.length == 2) {
+            (isSubject ? subjectDN : issuerDN)
+                .put(components[0], components[1]);
           } else {
-            err.println("Invalid format of issueDN name");
+            err.println("Invalid format of name: " + DnName);
           }
         }
       }

--- a/hadoop-ozone/dist/src/main/smoketest/admincli/cert.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/admincli/cert.robot
@@ -14,22 +14,24 @@
 # limitations under the License.
 
 *** Settings ***
-Documentation       Smoketest ozone cluster startup
-Library             OperatingSystem
-Library             BuiltIn
+Documentation       Test ozone admin cert command
 Resource            ../commonlib.robot
 Test Timeout        5 minutes
 
-*** Variables ***
+*** Keywords ***
+Setup Test
+    Run Keyword if    '${SECURITY_ENABLED}' == 'true'    Kinit test user     testuser     testuser.keytab
 
 *** Test Cases ***
 Run cert list
-    ${output} =         Execute          ozone admin cert list
-    Should Contain      ${output}        Certificate list:(Type=
+    Pass Execution If       '${SECURITY_ENABLED}' == 'false'    N/A
+    ${output} =             Execute          ozone admin cert list
+    Should Contain          ${output}        Certificate list:(Type=
 
 cert list as JSON
-    ${output} =         Execute             ozone admin cert list --json 2>> certInfo
-    ${errOutput} =      Execute             cat certInfo
-                        Execute             echo '${output}' | jq -r '.'
-    Should Contain      ${errOutput}        Certificate list:(Type=
-                        Execute             rm certInfo
+    Pass Execution If      '${SECURITY_ENABLED}' == 'false'    N/A
+    ${output} =             Execute             ozone admin cert list --json 2>> certInfo
+    ${errOutput} =          Execute             cat certInfo
+                            Execute             echo '${output}' | jq -r '.'
+    Should Contain          ${errOutput}        Certificate list:(Type=
+                            Execute             rm certInfo

--- a/hadoop-ozone/dist/src/main/smoketest/admincli/cert.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/admincli/cert.robot
@@ -1,0 +1,32 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+*** Settings ***
+Documentation       Smoketest ozone cluster startup
+Library             OperatingSystem
+Library             BuiltIn
+Resource            ../commonlib.robot
+Test Timeout        5 minutes
+
+*** Variables ***
+
+*** Test Cases ***
+Run cert list
+    ${output} =         Execute          ozone admin cert list
+    Should Contain      ${output}       Certificate list:(Type=
+
+cert list as JSON
+    ${output} =         Execute          ozone admin cert list --json
+                        Execute          echo '${output}' | jq -r '.'

--- a/hadoop-ozone/dist/src/main/smoketest/admincli/cert.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/admincli/cert.robot
@@ -23,12 +23,12 @@ Setup Test
     Run Keyword if    '${SECURITY_ENABLED}' == 'true'    Kinit test user     testuser     testuser.keytab
 
 *** Test Cases ***
-Run cert list
+List certificates
     Pass Execution If       '${SECURITY_ENABLED}' == 'false'    N/A
     ${output} =             Execute          ozone admin cert list
     Should Contain          ${output}        Certificate list:(Type=
 
-cert list as JSON
+List certificates as JSON
     Pass Execution If      '${SECURITY_ENABLED}' == 'false'    N/A
     Execute                 ozone admin cert list --json 1>> outStream 2>> errStream
     ${output}               Execute             cat outStream | jq -r '.[0] | keys'

--- a/hadoop-ozone/dist/src/main/smoketest/admincli/cert.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/admincli/cert.robot
@@ -25,8 +25,11 @@ Test Timeout        5 minutes
 *** Test Cases ***
 Run cert list
     ${output} =         Execute          ozone admin cert list
-    Should Contain      ${output}       Certificate list:(Type=
+    Should Contain      ${output}        Certificate list:(Type=
 
 cert list as JSON
-    ${output} =         Execute          ozone admin cert list --json
-                        Execute          echo '${output}' | jq -r '.'
+    ${output} =         Execute             ozone admin cert list --json 2>> certInfo
+    ${errOutput} =      Execute             cat certInfo
+                        Execute             echo '${output}' | jq -r '.'
+    Should Contain      ${errOutput}        Certificate list:(Type=
+                        Execute             rm certInfo

--- a/hadoop-ozone/dist/src/main/smoketest/admincli/cert.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/admincli/cert.robot
@@ -30,8 +30,10 @@ Run cert list
 
 cert list as JSON
     Pass Execution If      '${SECURITY_ENABLED}' == 'false'    N/A
-    ${output} =             Execute             ozone admin cert list --json 2>> certInfo
-    ${errOutput} =          Execute             cat certInfo
-                            Execute             echo '${output}' | jq -r '.'
-    Should Contain          ${errOutput}        Certificate list:(Type=
-                            Execute             rm certInfo
+    Execute                 ozone admin cert list --json 1>> outStream 2>> errStream
+    ${output}               Execute             cat outStream | jq -r '.[0] | keys'
+                            Should Contain          ${output}           serialNumber
+    ${errOutput} =          Execute                 cat errStream
+                            Should Contain          ${errOutput}        Certificate list:(Type=
+    Execute                 rm outStream
+    Execute                 rm errStream


### PR DESCRIPTION
## What changes were proposed in this pull request?

Add the option for the command `ozone admin cert list` to output as JSON

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-8256

## How was this patch tested?

Added new Robot test. Also verified the JSON out using a docker-compose cluster:
```
bash-4.2$ ozone admin cert list --json | more
Certificate list:(Type=VALID, BatchSize=20, CertCount=8)
[ {
  "serialNumber" : 554359750626,
  "validFrom" : "Thu Jul 13 07:32:58 UTC 2023",
  "expiry" : "Sun Aug 20 07:32:58 UTC 2028",
  "subjectDN" : {
    "CN" : "scm-sub-554314287126@scm",
    "OU" : "899b84a5-3c9a-4245-a2c4-f3b74158c512",
    "O" : "CID-94fd40c6-5fe3-466c-8b72-06e8f93b6e55"
  },
  "issuerDN" : {
    "CN" : "scm-1@scm",
    "OU" : "899b84a5-3c9a-4245-a2c4-f3b74158c512",
    "O" : "CID-94fd40c6-5fe3-466c-8b72-06e8f93b6e55"
  }
}, {
  "serialNumber" : 571775840717,
--More--
```
