### PR TITLE
HDDS-7953. [Snapshot] Print snapshot diff properly in shell when there is no diff

### DIFF
--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/snapshot/SnapshotDiffReportOzone.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/snapshot/SnapshotDiffReportOzone.java
@@ -18,6 +18,7 @@
 
 package org.apache.hadoop.ozone.snapshot;
 
+import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
@@ -101,6 +102,12 @@ public class SnapshotDiffReportOzone
         .append(" and snapshot: ")
         .append(getLaterSnapshotName())
         .append(LINE_SEPARATOR);
+
+    if (CollectionUtils.isEmpty(getDiffList())) {
+      str.append(LINE_SEPARATOR);
+      return str.toString();
+    }
+
     for (DiffReportEntry entry : getDiffList()) {
       str.append(entry.toString()).append(LINE_SEPARATOR);
     }


### PR DESCRIPTION
## What changes were proposed in this pull request?
This change is to print snapshot diff properly if there is no diff between two snapshots.
Current states:
```
sh-4.2$ ozone sh snapshot diff vol1/bucket1 snap2 snap3
Difference between snapshot: snap2 and snapshot: snap3
sh-4.2$ 
```
After the change:
```
sh-4.2$ ozone sh snapshot diff vol1/bucket1 snap2 snap3
Difference between snapshot: snap2 and snapshot: snap3

sh-4.2$ 
```

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-7953

## How was this patch tested?
Tested it locally using the docker and verified it.
