### PR TITLE
HDDS-9036. Create separate acceptance split for cert rotation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -256,6 +256,7 @@ jobs:
           - HA-unsecure
           - MR
           - misc
+          - cert-rotation
       fail-fast: false
     steps:
       - name: Checkout project

--- a/hadoop-ozone/dist/src/main/compose/ozonesecure-ha/test-root-ca-rotation.sh
+++ b/hadoop-ozone/dist/src/main/compose/ozonesecure-ha/test-root-ca-rotation.sh
@@ -15,7 +15,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-#suite:HA-secure
+#suite:cert-rotation
 
 COMPOSE_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 export COMPOSE_DIR

--- a/hadoop-ozone/dist/src/main/compose/ozonesecure/test-certificate-rotation.sh
+++ b/hadoop-ozone/dist/src/main/compose/ozonesecure/test-certificate-rotation.sh
@@ -15,7 +15,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-#suite:secure
+#suite:cert-rotation
 
 COMPOSE_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 export COMPOSE_DIR

--- a/hadoop-ozone/dist/src/main/compose/ozonesecure/test-root-ca-rotation.sh
+++ b/hadoop-ozone/dist/src/main/compose/ozonesecure/test-root-ca-rotation.sh
@@ -15,7 +15,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-#suite:secure
+#suite:cert-rotation
 
 COMPOSE_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 export COMPOSE_DIR


### PR DESCRIPTION
## What changes were proposed in this pull request?

`Test execution of ozonesecure-ha/test-root-ca-rotation.sh` failed 23 times recently (on `master`, not counting PRs).  Also, `acceptance (HA-secure)` now takes ~1.5 hours.  Both problems could be less severe if we executed cert. rotation in its own split.

https://issues.apache.org/jira/browse/HDDS-9036

## How was this patch tested?

CI:
https://github.com/adoroszlai/hadoop-ozone/actions/runs/5589130892