### PR TITLE
HDDS-8961. [Snapshot] Added check to allow only Ozone admin user to call print compaction dag

### DIFF
--- a/hadoop-hdds/rocksdb-checkpoint-differ/src/main/java/org/apache/ozone/rocksdiff/RocksDBCheckpointDiffer.java
+++ b/hadoop-hdds/rocksdb-checkpoint-differ/src/main/java/org/apache/ozone/rocksdiff/RocksDBCheckpointDiffer.java
@@ -1547,17 +1547,16 @@ public class RocksDBCheckpointDiffer implements AutoCloseable,
     return lock;
   }
 
-  public String pngPrintMutableGraph(String fileName, GraphType graphType)
+  public void pngPrintMutableGraph(String filePath, GraphType graphType)
       throws IOException {
-    Objects.requireNonNull(fileName, "Image file name is required.");
+    Objects.requireNonNull(filePath, "Image file path is required.");
     Objects.requireNonNull(graphType, "Graph type is required.");
 
     PrintableGraph graph;
     synchronized (this) {
-      graph = new PrintableGraph(forwardCompactionDAG, graphType);
+      graph = new PrintableGraph(backwardCompactionDAG, graphType);
     }
 
-    graph.generateImage(fileName);
-    return fileName;
+    graph.generateImage(filePath);
   }
 }

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/ObjectStore.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/ObjectStore.java
@@ -595,14 +595,14 @@ public class ObjectStore {
 
   /**
    * Create an image of the current compaction log DAG in the OM.
-   * @param fileName     name of the image file.
-   * @param graphType    type of node name to use in the graph image.
-   * @return path of the image file.
-   * @throws IOException
+   * @param fileNamePrefix  file name prefix of the image file.
+   * @param graphType       type of node name to use in the graph image.
+   * @return message which tells the image name, parent dir and OM leader
+   * node information.
    */
-  public String printCompactionLogDag(String fileName,
+  public String printCompactionLogDag(String fileNamePrefix,
                                       String graphType) throws IOException {
-    return proxy.printCompactionLogDag(fileName, graphType);
+    return proxy.printCompactionLogDag(fileNamePrefix, graphType);
   }
 
   /**

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/protocol/ClientProtocol.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/protocol/ClientProtocol.java
@@ -1047,12 +1047,12 @@ public interface ClientProtocol {
 
   /**
    * Create an image of the current compaction log DAG in the OM.
-   * @param fileName     name of the image file.
-   * @param graphType    type of node name to use in the graph image.
-   * @return path of the image file.
-   * @throws IOException
+   * @param fileNamePrefix  file name prefix of the image file.
+   * @param graphType       type of node name to use in the graph image.
+   * @return message which tells the image name, parent dir and OM leader
+   * node information.
    */
-  String printCompactionLogDag(String fileName, String graphType)
+  String printCompactionLogDag(String fileNamePrefix, String graphType)
       throws IOException;
 
   /**

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/rpc/RpcClient.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/rpc/RpcClient.java
@@ -989,15 +989,15 @@ public class RpcClient implements ClientProtocol {
 
   /**
    * Create an image of the current compaction log DAG in the OM.
-   * @param fileName     name of the image file.
-   * @param graphType    type of node name to use in the graph image.
-   * @return path of the image file.
-   * @throws IOException
+   * @param fileNamePrefix  file name prefix of the image file.
+   * @param graphType       type of node name to use in the graph image.
+   * @return message which tells the image name, parent dir and OM leader
+   * node information.
    */
   @Override
-  public String printCompactionLogDag(String fileName,
+  public String printCompactionLogDag(String fileNamePrefix,
                                       String graphType) throws IOException {
-    return ozoneManagerClient.printCompactionLogDag(fileName, graphType);
+    return ozoneManagerClient.printCompactionLogDag(fileNamePrefix, graphType);
   }
 
   @Override

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocol/OzoneManagerProtocol.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocol/OzoneManagerProtocol.java
@@ -693,12 +693,12 @@ public interface OzoneManagerProtocol
 
   /**
    * Create an image of the current compaction log DAG in the OM.
-   * @param fileName     name of the image file.
-   * @param graphType    type of node name to use in the graph image.
-   * @return path of the image file.
-   * @throws IOException
+   * @param fileNamePrefix  file name prefix of the image file.
+   * @param graphType       type of node name to use in the graph image.
+   * @return message which tells the image name, parent dir and OM leader
+   * node information.
    */
-  default String printCompactionLogDag(String fileName, String graphType)
+  default String printCompactionLogDag(String fileNamePrefix, String graphType)
       throws IOException {
     throw new UnsupportedOperationException("OzoneManager does not require " +
         "this to be implemented");

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocolPB/OzoneManagerProtocolClientSideTranslatorPB.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocolPB/OzoneManagerProtocolClientSideTranslatorPB.java
@@ -1194,13 +1194,13 @@ public final class OzoneManagerProtocolClientSideTranslatorPB
    * {@inheritDoc}
    */
   @Override
-  public String printCompactionLogDag(String fileName, String graphType)
+  public String printCompactionLogDag(String fileNamePrefix, String graphType)
       throws IOException {
     final PrintCompactionLogDagRequest.Builder request =
         PrintCompactionLogDagRequest.newBuilder();
 
-    if (fileName != null) {
-      request.setFileName(fileName);
+    if (fileNamePrefix != null) {
+      request.setFileNamePrefix(fileNamePrefix);
     }
     if (graphType != null) {
       request.setGraphType(graphType);
@@ -1211,7 +1211,7 @@ public final class OzoneManagerProtocolClientSideTranslatorPB
         .build();
     final OMResponse omResponse = submitRequest(omRequest);
     handleError(omResponse);
-    return omResponse.getPrintCompactionLogDagResponse().getImagePath();
+    return omResponse.getPrintCompactionLogDagResponse().getMessage();
   }
 
   /**

--- a/hadoop-ozone/interface-client/src/main/proto/OmClientProtocol.proto
+++ b/hadoop-ozone/interface-client/src/main/proto/OmClientProtocol.proto
@@ -1783,7 +1783,7 @@ message DeleteSnapshotRequest {
 }
 
 message PrintCompactionLogDagRequest {
-  optional string fileName = 1;
+  optional string fileNamePrefix = 1;
   optional string graphType = 2;
 }
 
@@ -1879,7 +1879,7 @@ message DeleteSnapshotResponse {
 }
 
 message PrintCompactionLogDagResponse {
-  optional string imagePath = 1;
+  optional string message = 1;
 }
 
 message SnapshotMoveDeletedKeysResponse {

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
@@ -4676,8 +4676,8 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
         .getRocksDBCheckpointDiffer()
         .pngPrintMutableGraph(tempFile.getAbsolutePath(), type);
 
-    return String.format("File: '%s' was created in \\tmp dir of OM leader " +
-        "node: '%s'.", tempFile.getName(), getOMNodeId());
+    return String.format("Graph was generated at '\\tmp\\%s' on OM " +
+        "node '%s'.", tempFile.getName(), getOMNodeId());
   }
 
   private String reconfOzoneAdmins(String newVal) {

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/protocolPB/OzoneManagerRequestHandler.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/protocolPB/OzoneManagerRequestHandler.java
@@ -1335,11 +1335,11 @@ public class OzoneManagerRequestHandler implements RequestHandler {
   private PrintCompactionLogDagResponse printCompactionLogDag(
       PrintCompactionLogDagRequest printCompactionLogDagRequest)
       throws IOException {
-    String imagePath = impl.printCompactionLogDag(
-        printCompactionLogDagRequest.getFileName(),
+    String message = impl.printCompactionLogDag(
+        printCompactionLogDagRequest.getFileNamePrefix(),
         printCompactionLogDagRequest.getGraphType());
     return PrintCompactionLogDagResponse.newBuilder()
-        .setImagePath(imagePath)
+        .setMessage(message)
         .build();
   }
 

--- a/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/client/ClientProtocolStub.java
+++ b/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/client/ClientProtocolStub.java
@@ -631,7 +631,7 @@ public class ClientProtocolStub implements ClientProtocol {
 
   }
 
-  public String printCompactionLogDag(String fileName,
+  public String printCompactionLogDag(String fileNamePrefix,
                                       String graphType) throws IOException {
     return null;
   }

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/CompactionLogDagPrinter.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/CompactionLogDagPrinter.java
@@ -48,7 +48,7 @@ public class CompactionLogDagPrinter extends Handler
   @CommandLine.Option(names = {"-t", "--graph-type"},
       description = "Type of node name to use in the graph image. " +
           "(optional)\n Accepted values are: \n" +
-          "  file_name: to use file name as node name in DAG,\n" +
+          "  file_name (default) : to use file name as node name in DAG,\n" +
           "  key_size: to show the no. of keys in the file along with file " +
           "name in the DAG node name,\n" +
           "  cumulative_size: to show the cumulative size along with file " +

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/CompactionLogDagPrinter.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/CompactionLogDagPrinter.java
@@ -29,7 +29,7 @@ import picocli.CommandLine;
 import java.io.IOException;
 
 /**
- * Handler to generate image for current compaction DAG in the OM.
+ * Handler to generate image for current compaction DAG in the OM leader node.
  * ozone sh snapshot print-log-dag.
  */
 @CommandLine.Command(
@@ -40,14 +40,14 @@ import java.io.IOException;
 public class CompactionLogDagPrinter extends Handler
     implements SubcommandWithParent {
 
-  @CommandLine.Option(names = {"-f", "--file-name"},
-      description = "Name of the image file. (optional)")
-  private String fileName;
+  @CommandLine.Option(names = {"-f", "--file-name-prefix"},
+      description = "Prefix to be use in image file name. (optional)")
+  private String fileNamePrefix;
 
   // TODO: Change graphType to enum.
   @CommandLine.Option(names = {"-t", "--graph-type"},
-      description = "Type of node name to use in the graph image.\n" +
-          "Accepted values are: \n" +
+      description = "Type of node name to use in the graph image. " +
+          "(optional)\n Accepted values are: \n" +
           "  file_name: to use file name as node name in DAG,\n" +
           "  key_size: to show the no. of keys in the file along with file " +
           "name in the DAG node name,\n" +
@@ -64,8 +64,8 @@ public class CompactionLogDagPrinter extends Handler
   @Override
   protected void execute(OzoneClient client, OzoneAddress address)
       throws IOException, OzoneClientException {
-    String imagePath = client.getObjectStore()
-        .printCompactionLogDag(fileName, graphType);
-    System.out.println("DAG image is created on path: " + imagePath);
+    String message = client.getObjectStore()
+        .printCompactionLogDag(fileNamePrefix, graphType);
+    System.out.println(message);
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?
This change addresses few of the concerns raised in PR #5061. 
* Added check to allow only Ozone admin user to call print compaction dag API.
* Update the response message stating the file name, parent dir's absolute path and the OM leader node info.

Note: This PR doesn't addressed `Having a network call that generates a file on the server is strange.` because of following reason.
As we talked in [here](https://github.com/apache/ozone/pull/5061#issuecomment-1638972143), it is better to be have it as a OM request to get the in-memory picture of the DAG. It can be solved in following two ways.
1. Return graph POJO to client and generate the image on client side. But it comes with a problem of graph size and might need pagination.
2. Stream the generated image to the client. But we don't have existed interface to stream a file.
Both the solution will require more time and investigation. So for the interest of time, just addressed the security and debug message for now and create a jira: [HDDS-9040](https://issues.apache.org/jira/browse/HDDS-9040) for further enhancement.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-8961

## How was this patch tested?
Existed unit tests.
