### PR TITLE
HDDS-9038. Enable dynamic reconfiguration of EC container provider properties

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/WritableContainerFactory.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/WritableContainerFactory.java
@@ -50,13 +50,17 @@ public class WritableContainerFactory {
         scm.getContainerManager(), scm.getPipelineChoosePolicy());
     this.standaloneProvider = ratisProvider;
 
+    WritableECContainerProviderConfig ecProviderConfig =
+        conf.getObject(WritableECContainerProviderConfig.class);
     this.ecProvider = new WritableECContainerProvider(
-        conf.getObject(WritableECContainerProviderConfig.class),
+        ecProviderConfig,
         getConfiguredContainerSize(conf),
         scm.getScmNodeManager(),
         scm.getPipelineManager(),
         scm.getContainerManager(),
         scm.getEcPipelineChoosePolicy());
+
+    scm.getReconfigurationHandler().register(ecProviderConfig);
   }
 
   public ContainerInfo getContainer(final long size,

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/WritableECContainerProvider.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/WritableECContainerProvider.java
@@ -25,6 +25,7 @@ import org.apache.hadoop.hdds.conf.ConfigGroup;
 import org.apache.hadoop.hdds.conf.ConfigTag;
 import org.apache.hadoop.hdds.conf.ConfigType;
 import org.apache.hadoop.hdds.conf.PostConstruct;
+import org.apache.hadoop.hdds.conf.ReconfigurableConfig;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
 import org.apache.hadoop.hdds.scm.PipelineChoosePolicy;
 import org.apache.hadoop.hdds.scm.PipelineRequestInformation;
@@ -235,12 +236,14 @@ public class WritableECContainerProvider
    * Class to hold configuration for WriteableECContainerProvider.
    */
   @ConfigGroup(prefix = WritableECContainerProviderConfig.PREFIX)
-  public static class WritableECContainerProviderConfig {
+  public static class WritableECContainerProviderConfig
+      extends ReconfigurableConfig {
 
     private static final String PREFIX = "ozone.scm.ec";
 
     @Config(key = "pipeline.minimum",
         defaultValue = "5",
+        reconfigurable = true,
         type = ConfigType.INT,
         description = "The minimum number of pipelines to have open for each " +
             "Erasure Coding configuration",
@@ -265,6 +268,7 @@ public class WritableECContainerProvider
     @Config(key = PIPELINE_PER_VOLUME_FACTOR_KEY,
         type = ConfigType.DOUBLE,
         defaultValue = PIPELINE_PER_VOLUME_FACTOR_DEFAULT_VALUE,
+        reconfigurable = true,
         tags = {SCM},
         description = "TODO"
     )

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/StorageContainerManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/StorageContainerManager.java
@@ -2180,7 +2180,6 @@ public final class StorageContainerManager extends ServiceRuntimeInfoImpl
     scmHAMetrics = SCMHAMetrics.create(getScmId(), leaderId);
   }
 
-  @VisibleForTesting
   public ReconfigurationHandler getReconfigurationHandler() {
     return reconfigurationHandler;
   }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/reconfig/TestScmReconfiguration.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/reconfig/TestScmReconfiguration.java
@@ -22,6 +22,7 @@ import com.google.common.collect.ImmutableSet;
 import org.apache.hadoop.conf.ReconfigurationException;
 import org.apache.hadoop.hdds.conf.ReconfigurationHandler;
 import org.apache.hadoop.hdds.scm.container.replication.ReplicationManager.ReplicationManagerConfiguration;
+import org.apache.hadoop.hdds.scm.pipeline.WritableECContainerProvider.WritableECContainerProviderConfig;
 import org.junit.jupiter.api.Test;
 
 import java.time.Duration;
@@ -49,6 +50,8 @@ class TestScmReconfiguration extends ReconfigurationTestBase {
         .add(OZONE_ADMINISTRATORS)
         .add(OZONE_READONLY_ADMINISTRATORS)
         .addAll(new ReplicationManagerConfiguration()
+            .reconfigurableProperties())
+        .addAll(new WritableECContainerProviderConfig()
             .reconfigurableProperties())
         .build();
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Allow dynamic reconfiguration of `WritableECContainerProvider` config.

https://issues.apache.org/jira/browse/HDDS-9038

## How was this patch tested?

Updated integration test.

Tested in `ozone` compose example:

```
$ ozone freon ockg -n10 -t10 --type EC --replication rs-3-2-1024k
...
$ ozone admin container list | jq -r '.containerID' | wc -l
5
# edit /etc/hadoop/ozone-site.xml, add ozone.scm.ec.pipeline.minimum=10
$ ozone admin reconfig --address scm:9860 start
SCM: Started reconfiguration task on node [scm:9860].
$ ozone admin reconfig --address scm:9860 status
SCM: Reconfiguring status for node [scm:9860]: started at Tue Jul 18 19:28:06 UTC 2023 and finished at Tue Jul 18 19:28:06 UTC 2023.
SUCCESS: Changed property ozone.scm.ec.pipeline.minimum
	From: "5"
	To: "10"
$ ozone freon ockg -n10 -t10 --type EC --replication rs-3-2-1024k
...
$ ozone admin container list | jq -r '.containerID' | wc -l
10
```

CI:
https://github.com/adoroszlai/hadoop-ozone/actions/runs/5591531483