### PR TITLE
HDDS-7380. Remove expired certificates from SCM DB

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/HddsConfigKeys.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/HddsConfigKeys.java
@@ -230,6 +230,11 @@ public final class HddsConfigKeys {
       "hdds.x509.ca.rotation.enabled";
   public static final boolean HDDS_X509_CA_ROTATION_ENABLED_DEFAULT = false;
 
+  public static final String HDDS_X509_EXPIRED_CERTIFICATE_REMOVAL_INTERVAL =
+      "hdds.x509.expired.certificate.removal.interval";
+  public static final String
+      HDDS_X509_EXPIRED_CERTIFICATE_REMOVAL_INTERVAL_DEFAULT = "P1D";
+
   public static final String HDDS_CONTAINER_REPLICATION_COMPRESSION =
       "hdds.container.replication.compression";
   public static final String HDDS_X509_ROOTCA_CERTIFICATE_FILE =

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/HddsConfigKeys.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/HddsConfigKeys.java
@@ -230,10 +230,10 @@ public final class HddsConfigKeys {
       "hdds.x509.ca.rotation.enabled";
   public static final boolean HDDS_X509_CA_ROTATION_ENABLED_DEFAULT = false;
 
-  public static final String HDDS_X509_EXPIRED_CERTIFICATE_REMOVAL_INTERVAL =
-      "hdds.x509.expired.certificate.removal.interval";
+  public static final String HDDS_X509_EXPIRED_CERTIFICATE_CHECK_INTERVAL =
+      "hdds.x509.expired.certificate.check.interval";
   public static final String
-      HDDS_X509_EXPIRED_CERTIFICATE_REMOVAL_INTERVAL_DEFAULT = "P1D";
+      HDDS_X509_EXPIRED_CERTIFICATE_CHECK_INTERVAL_DEFAULT = "P1D";
 
   public static final String HDDS_CONTAINER_REPLICATION_COMPRESSION =
       "hdds.container.replication.compression";

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/security/SecurityConfig.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/security/SecurityConfig.java
@@ -52,8 +52,8 @@ import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_X509_CA_ROTATION_ENABLE
 import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_X509_CA_ROTATION_ENABLED_DEFAULT;
 import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_X509_CA_ROTATION_TIME_OF_DAY;
 import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_X509_CA_ROTATION_TIME_OF_DAY_DEFAULT;
-import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_X509_EXPIRED_CERTIFICATE_REMOVAL_INTERVAL;
-import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_X509_EXPIRED_CERTIFICATE_REMOVAL_INTERVAL_DEFAULT;
+import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_X509_EXPIRED_CERTIFICATE_CHECK_INTERVAL;
+import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_X509_EXPIRED_CERTIFICATE_CHECK_INTERVAL_DEFAULT;
 import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_X509_ROOTCA_CERTIFICATE_FILE;
 import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_X509_ROOTCA_CERTIFICATE_FILE_DEFAULT;
 import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_X509_ROOTCA_CERTIFICATE_POLLING_INTERVAL;
@@ -139,7 +139,7 @@ public class SecurityConfig {
   private final SslProvider grpcSSLProvider;
   private final Duration rootCaCertificatePollingInterval;
   private final boolean autoCARotationEnabled;
-  private final Duration expiredCertificateRemovalInterval;
+  private final Duration expiredCertificateCheckInterval;
 
   /**
    * Constructs a SecurityConfig.
@@ -246,12 +246,12 @@ public class SecurityConfig {
     this.rootCaCertificatePollingInterval =
         Duration.parse(rootCaCertificatePollingIntervalString);
 
-    String expiredCertificateRemovalIntervalString = configuration.get(
-        HDDS_X509_EXPIRED_CERTIFICATE_REMOVAL_INTERVAL,
-        HDDS_X509_EXPIRED_CERTIFICATE_REMOVAL_INTERVAL_DEFAULT);
+    String expiredCertificateCheckIntervalString = configuration.get(
+        HDDS_X509_EXPIRED_CERTIFICATE_CHECK_INTERVAL,
+        HDDS_X509_EXPIRED_CERTIFICATE_CHECK_INTERVAL_DEFAULT);
 
-    this.expiredCertificateRemovalInterval =
-        Duration.parse(expiredCertificateRemovalIntervalString);
+    this.expiredCertificateCheckInterval =
+        Duration.parse(expiredCertificateCheckIntervalString);
 
     this.externalRootCaCert = configuration.get(
         HDDS_X509_ROOTCA_CERTIFICATE_FILE,
@@ -585,8 +585,8 @@ public class SecurityConfig {
     return autoCARotationEnabled;
   }
 
-  public Duration getExpiredCertificateRemovalInterval() {
-    return expiredCertificateRemovalInterval;
+  public Duration getExpiredCertificateCheckInterval() {
+    return expiredCertificateCheckInterval;
   }
 
   /**

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/security/SecurityConfig.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/security/SecurityConfig.java
@@ -52,6 +52,8 @@ import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_X509_CA_ROTATION_ENABLE
 import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_X509_CA_ROTATION_ENABLED_DEFAULT;
 import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_X509_CA_ROTATION_TIME_OF_DAY;
 import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_X509_CA_ROTATION_TIME_OF_DAY_DEFAULT;
+import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_X509_EXPIRED_CERTIFICATE_REMOVAL_INTERVAL;
+import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_X509_EXPIRED_CERTIFICATE_REMOVAL_INTERVAL_DEFAULT;
 import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_X509_ROOTCA_CERTIFICATE_FILE;
 import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_X509_ROOTCA_CERTIFICATE_FILE_DEFAULT;
 import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_X509_ROOTCA_CERTIFICATE_POLLING_INTERVAL;
@@ -137,6 +139,7 @@ public class SecurityConfig {
   private final SslProvider grpcSSLProvider;
   private final Duration rootCaCertificatePollingInterval;
   private final boolean autoCARotationEnabled;
+  private final Duration expiredCertificateRemovalInterval;
 
   /**
    * Constructs a SecurityConfig.
@@ -242,6 +245,13 @@ public class SecurityConfig {
 
     this.rootCaCertificatePollingInterval =
         Duration.parse(rootCaCertificatePollingIntervalString);
+
+    String expiredCertificateRemovalIntervalString = configuration.get(
+        HDDS_X509_EXPIRED_CERTIFICATE_REMOVAL_INTERVAL,
+        HDDS_X509_EXPIRED_CERTIFICATE_REMOVAL_INTERVAL_DEFAULT);
+
+    this.expiredCertificateRemovalInterval =
+        Duration.parse(expiredCertificateRemovalIntervalString);
 
     this.externalRootCaCert = configuration.get(
         HDDS_X509_ROOTCA_CERTIFICATE_FILE,
@@ -573,6 +583,10 @@ public class SecurityConfig {
 
   public boolean isAutoCARotationEnabled() {
     return autoCARotationEnabled;
+  }
+
+  public Duration getExpiredCertificateRemovalInterval() {
+    return expiredCertificateRemovalInterval;
   }
 
   /**

--- a/hadoop-hdds/common/src/main/resources/ozone-default.xml
+++ b/hadoop-hdds/common/src/main/resources/ozone-default.xml
@@ -2295,7 +2295,7 @@
     </description>
   </property>
   <property>
-    <name>hdds.x509.expired.certificate.removal.interval</name>
+    <name>hdds.x509.expired.certificate.check.interval</name>
     <value>P1D</value>
     <description>Interval to use for removing expired certificates. A background
       task to remove expired certificates from the scm metadata store is

--- a/hadoop-hdds/common/src/main/resources/ozone-default.xml
+++ b/hadoop-hdds/common/src/main/resources/ozone-default.xml
@@ -2295,6 +2295,14 @@
     </description>
   </property>
   <property>
+    <name>hdds.x509.expired.certificate.removal.interval</name>
+    <value>P1D</value>
+    <description>Interval to use for removing expired certificates. A background
+      task to remove expired certificates from the scm metadata store is
+      scheduled to run at the rate this configuration option specifies.
+    </description>
+  </property>
+  <property>
     <name>ozone.scm.security.handler.count.key</name>
     <value>2</value>
     <tag>OZONE, HDDS, SECURITY</tag>

--- a/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/security/x509/CertificateTestUtils.java
+++ b/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/security/x509/CertificateTestUtils.java
@@ -107,6 +107,26 @@ public final class CertificateTestUtils {
    */
   public static X509Certificate createSelfSignedCert(KeyPair keys,
       String commonName, Duration expiresIn) throws Exception {
+    return createSelfSignedCert(keys, commonName, expiresIn,
+        BigInteger.valueOf(keys.getPublic().hashCode()));
+  }
+
+  /**
+   * Creates a self-signed certificate and returns it as an X509Certificate.
+   * The given keys and common name are being used in the certificate.
+   * The certificate will expire after the specified duration and its id
+   * will be the specified id.
+   *
+   * @param keys       the keypair to use for the certificate
+   * @param commonName the common name used in the certificate
+   * @param expiresIn  the lifespan of the certificate
+   * @param certId     the id of the generated certificate
+   * @return the X509Certificate representing a self-signed certificate
+   * @throws Exception in case any error occurs during the certificate creation
+   */
+  public static X509Certificate createSelfSignedCert(KeyPair keys,
+      String commonName, Duration expiresIn, BigInteger certId)
+      throws Exception {
     final Instant now = Instant.now();
     final Date notBefore = Date.from(now);
     final Date notAfter = Date.from(now.plus(expiresIn));
@@ -121,7 +141,7 @@ public final class CertificateTestUtils {
     final X509v3CertificateBuilder certificateBuilder =
         new JcaX509v3CertificateBuilder(
             x500Name,
-            BigInteger.valueOf(keys.getPublic().hashCode()),
+            certId,
             notBefore,
             notAfter,
             x500Name,

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/security/x509/certificate/authority/CertificateStore.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/security/x509/certificate/authority/CertificateStore.java
@@ -109,9 +109,10 @@ public interface CertificateStore {
   /**
    * Deletes all non-revoked expired certificates from the store.
    *
-   * @throws IOException
+   * @throws IOException - on failure
    */
-  void removeAllExpiredCertificates();
+  @Replicate
+  void removeAllExpiredCertificates() throws IOException;
 
   /**
    * Retrieves a Certificate based on the Serial number of that certificate.

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/security/x509/certificate/authority/CertificateStore.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/security/x509/certificate/authority/CertificateStore.java
@@ -107,6 +107,13 @@ public interface CertificateStore {
   void removeExpiredCertificate(BigInteger serialID) throws IOException;
 
   /**
+   * Deletes all non-revoked expired certificates from the store.
+   *
+   * @throws IOException
+   */
+  void removeAllExpiredCertificates();
+
+  /**
    * Retrieves a Certificate based on the Serial number of that certificate.
    * @param serialID - ID of the certificate.
    * @param certType - Whether its Valid or Revoked certificate.

--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/security/x509/certificate/authority/MockCAStore.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/security/x509/certificate/authority/MockCAStore.java
@@ -72,6 +72,10 @@ public class MockCAStore implements CertificateStore {
   }
 
   @Override
+  public void removeAllExpiredCertificates() {
+  }
+
+  @Override
   public X509Certificate getCertificateByID(BigInteger serialID,
                                             CertType certType)
       throws IOException {

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/security/RootCARotationManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/security/RootCARotationManager.java
@@ -219,6 +219,17 @@ public class RootCARotationManager implements SCMService {
     LOG.info("Monitor task for root certificate {} is started with " +
         "interval {}.", scmCertClient.getCACertificate().getSerialNumber(),
         checkInterval);
+    executorService.scheduleAtFixedRate(this::removeExpiredCertTask, 0,
+        secConf.getExpiredCertificateRemovalInterval().toMillis(),
+        TimeUnit.MILLISECONDS);
+    LOG.info("Scheduling expired certificate removal with interval {}s",
+        secConf.getExpiredCertificateRemovalInterval().getSeconds());
+  }
+
+  private void removeExpiredCertTask() {
+    if (scm.getCertificateStore() != null) {
+      scm.getCertificateStore().removeAllExpiredCertificates();
+    }
   }
 
   public boolean isRunning() {

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/security/RootCARotationManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/security/RootCARotationManager.java
@@ -220,15 +220,22 @@ public class RootCARotationManager implements SCMService {
         "interval {}.", scmCertClient.getCACertificate().getSerialNumber(),
         checkInterval);
     executorService.scheduleAtFixedRate(this::removeExpiredCertTask, 0,
-        secConf.getExpiredCertificateRemovalInterval().toMillis(),
+        secConf.getExpiredCertificateCheckInterval().toMillis(),
         TimeUnit.MILLISECONDS);
     LOG.info("Scheduling expired certificate removal with interval {}s",
-        secConf.getExpiredCertificateRemovalInterval().getSeconds());
+        secConf.getExpiredCertificateCheckInterval().getSeconds());
   }
 
   private void removeExpiredCertTask() {
+    if (!isRunning.get()) {
+      return;
+    }
     if (scm.getCertificateStore() != null) {
-      scm.getCertificateStore().removeAllExpiredCertificates();
+      try {
+        scm.getCertificateStore().removeAllExpiredCertificates();
+      } catch (IOException e) {
+        LOG.error("Failed to remove some expired certificates", e);
+      }
     }
   }
 

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/security/TestRootCARotationManager.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/security/TestRootCARotationManager.java
@@ -58,7 +58,7 @@ import java.util.concurrent.TimeoutException;
 import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_X509_CA_ROTATION_ACK_TIMEOUT;
 import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_X509_CA_ROTATION_CHECK_INTERNAL;
 import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_X509_CA_ROTATION_TIME_OF_DAY;
-import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_X509_EXPIRED_CERTIFICATE_REMOVAL_INTERVAL;
+import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_X509_EXPIRED_CERTIFICATE_CHECK_INTERVAL;
 import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_X509_GRACE_DURATION_TOKEN_CHECKS_ENABLED;
 import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_X509_RENEW_GRACE_DURATION;
 import static org.junit.Assert.assertEquals;
@@ -186,7 +186,7 @@ public class TestRootCARotationManager {
     ozoneConfig.set(HDDS_X509_CA_ROTATION_CHECK_INTERNAL, "PT2S");
     ozoneConfig.set(HDDS_X509_RENEW_GRACE_DURATION, "PT15S");
     ozoneConfig.set(HDDS_X509_CA_ROTATION_ACK_TIMEOUT, "PT2S");
-    ozoneConfig.set(HDDS_X509_EXPIRED_CERTIFICATE_REMOVAL_INTERVAL, "PT15S");
+    ozoneConfig.set(HDDS_X509_EXPIRED_CERTIFICATE_CHECK_INTERVAL, "PT15S");
     Date date = Calendar.getInstance().getTime();
     date.setSeconds(date.getSeconds() + 10);
     ozoneConfig.set(HDDS_X509_CA_ROTATION_TIME_OF_DAY,

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/security/TestRootCARotationManager.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/security/TestRootCARotationManager.java
@@ -58,6 +58,7 @@ import java.util.concurrent.TimeoutException;
 import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_X509_CA_ROTATION_ACK_TIMEOUT;
 import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_X509_CA_ROTATION_CHECK_INTERNAL;
 import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_X509_CA_ROTATION_TIME_OF_DAY;
+import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_X509_EXPIRED_CERTIFICATE_REMOVAL_INTERVAL;
 import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_X509_GRACE_DURATION_TOKEN_CHECKS_ENABLED;
 import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_X509_RENEW_GRACE_DURATION;
 import static org.junit.Assert.assertEquals;
@@ -185,6 +186,7 @@ public class TestRootCARotationManager {
     ozoneConfig.set(HDDS_X509_CA_ROTATION_CHECK_INTERNAL, "PT2S");
     ozoneConfig.set(HDDS_X509_RENEW_GRACE_DURATION, "PT15S");
     ozoneConfig.set(HDDS_X509_CA_ROTATION_ACK_TIMEOUT, "PT2S");
+    ozoneConfig.set(HDDS_X509_EXPIRED_CERTIFICATE_REMOVAL_INTERVAL, "PT15S");
     Date date = Calendar.getInstance().getTime();
     date.setSeconds(date.getSeconds() + 10);
     ozoneConfig.set(HDDS_X509_CA_ROTATION_TIME_OF_DAY,

--- a/hadoop-ozone/dist/src/main/compose/ozonesecure/root-ca-rotation.yaml
+++ b/hadoop-ozone/dist/src/main/compose/ozonesecure/root-ca-rotation.yaml
@@ -36,7 +36,7 @@ x-root-cert-rotation-config:
     - OZONE-SITE.XML_ozone.scm.ha.ratis.request.timeout=2s
     - OZONE-SITE.XML_ozone.http.filter.initializers=org.apache.hadoop.security.HttpCrossOriginFilterInitializer
     - OZONE-SITE.XML_hdds.x509.ca.rotation.enabled=true
-    - OZONE-SITE.XML_hdds.x509.expired.certificate.removal.interval=PT15s
+    - OZONE-SITE.XML_hdds.x509.expired.certificate.check.interval=PT15s
 services:
   datanode:
     <<: *root-cert-rotation-config

--- a/hadoop-ozone/dist/src/main/compose/ozonesecure/root-ca-rotation.yaml
+++ b/hadoop-ozone/dist/src/main/compose/ozonesecure/root-ca-rotation.yaml
@@ -36,6 +36,7 @@ x-root-cert-rotation-config:
     - OZONE-SITE.XML_ozone.scm.ha.ratis.request.timeout=2s
     - OZONE-SITE.XML_ozone.http.filter.initializers=org.apache.hadoop.security.HttpCrossOriginFilterInitializer
     - OZONE-SITE.XML_hdds.x509.ca.rotation.enabled=true
+    - OZONE-SITE.XML_hdds.x509.expired.certificate.removal.interval=PT15s
 services:
   datanode:
     <<: *root-cert-rotation-config

--- a/hadoop-ozone/dist/src/main/compose/ozonesecure/test-root-ca-rotation.sh
+++ b/hadoop-ozone/dist/src/main/compose/ozonesecure/test-root-ca-rotation.sh
@@ -54,6 +54,7 @@ execute_commands_in_container scm "ozone sh volume create /r-v1 && ozone sh buck
 # wait for second root CA rotation
 wait_for_execute_command scm 180 "ozone admin cert info 3"
 wait_for_execute_command om 30 "find /data/metadata/om/certs/ROOTCA-3.crt"
+wait_for_execute_command scm 60 "! ozone admin cert info 1"
 execute_robot_test scm -v PREFIX:"rootca2" certrotation/root-ca-rotation-client-checks.robot
 # check the metrics
 execute_robot_test scm scmha/root-ca-rotation.robot

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/TestSecureOzoneCluster.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/TestSecureOzoneCluster.java
@@ -1214,7 +1214,6 @@ public final class TestSecureOzoneCluster {
    * Test functionality to get SCM signed certificate for OM.
    */
   @Test
-  @Ignore("HDDS-8764")
   public void testOMGrpcServerCertificateRenew() throws Exception {
     initSCM();
     try {

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/TestSecureOzoneCluster.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/TestSecureOzoneCluster.java
@@ -1214,6 +1214,7 @@ public final class TestSecureOzoneCluster {
    * Test functionality to get SCM signed certificate for OM.
    */
   @Test
+  @Ignore("HDDS-8764")
   public void testOMGrpcServerCertificateRenew() throws Exception {
     initSCM();
     try {


### PR DESCRIPTION
## What changes were proposed in this pull request?

Periodically remove expired certificates from scm rocksdb just as housekeeping

[HDDS-7380](https://issues.apache.org/jira/browse/HDDS-7380)

## How was this patch tested?

Added unit test and robot test and also observed it in a local cluster