### PR TITLE
HDDS-9047. Ozone not to disable netty resource leak detector in datanode

### DIFF
--- a/hadoop-ozone/dist/src/shell/ozone/ozone
+++ b/hadoop-ozone/dist/src/shell/ozone/ozone
@@ -80,7 +80,6 @@ function ozonecmd_case
   # TODO: Fix the problem related to netty resource leak detector throwing
   # exception as mentioned in HDDS-3812
   RATIS_OPTS="-Dorg.apache.ratis.thirdparty.io.netty.allocator.useCacheForAllThreads=false ${RATIS_OPTS}"
-  RATIS_OPTS="-Dorg.apache.ratis.thirdparty.io.netty.leakDetection.level=disabled ${RATIS_OPTS}"
   # Add JVM parameter for Java 17
   OZONE_MODULE_ACCESS_ARGS=""
 

--- a/hadoop-ozone/dist/src/shell/ozone/ozone
+++ b/hadoop-ozone/dist/src/shell/ozone/ozone
@@ -77,8 +77,6 @@ function ozonecmd_case
   # for disabling netty PooledByteBufAllocator thread caches for non-netty threads.
   # This parameter significantly reduces GC pressure for Datanode.
   # Corresponding Ratis issue https://issues.apache.org/jira/browse/RATIS-534.
-  # TODO: Fix the problem related to netty resource leak detector throwing
-  # exception as mentioned in HDDS-3812
   RATIS_OPTS="-Dorg.apache.ratis.thirdparty.io.netty.allocator.useCacheForAllThreads=false ${RATIS_OPTS}"
   # Add JVM parameter for Java 17
   OZONE_MODULE_ACCESS_ARGS=""


### PR DESCRIPTION
## What changes were proposed in this pull request?
Revert [HDDS-3812](https://issues.apache.org/jira/browse/HDDS-3812).

Forcing datanode to disable the Netty leak detector is premature optimization. This prevents efforts to debug memory leaks in Ozone.

The default netty leak detection level is SIMPLE, meaning it doesn't create any stacktrace and hurt performance. Ref: https://netty.io/wiki/reference-counted-objects.html#wiki-h3-11

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-9047

## How was this patch tested?

