### PR TITLE
HDDS-9049. Use OM service ID from Ozone address for recursive delete

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/shell/TestOzoneShellHA.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/shell/TestOzoneShellHA.java
@@ -1662,8 +1662,7 @@ public class TestOzoneShellHA {
 
     // Delete volume1(containing OBS, FSO and Legacy buckets) recursively
     args =
-        new String[] {"volume", "delete", volume1, "-r", "--yes",
-            "-id", omServiceId};
+        new String[] {"volume", "delete", volume1, "-r", "--yes"};
 
     execute(ozoneShell, args);
     out.reset();

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/OzoneAddress.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/OzoneAddress.java
@@ -23,6 +23,7 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.Collection;
 
+import com.google.common.base.Strings;
 import org.apache.hadoop.hdds.conf.ConfigurationSource;
 import org.apache.hadoop.hdds.conf.MutableConfigurationSource;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
@@ -37,6 +38,7 @@ import com.google.common.annotations.VisibleForTesting;
 
 import static org.apache.hadoop.ozone.OzoneConsts.OZONE_HTTP_SCHEME;
 import static org.apache.hadoop.ozone.OzoneConsts.OZONE_RPC_SCHEME;
+import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_ADDRESS_KEY;
 import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_SERVICE_IDS_KEY;
 import org.apache.http.client.utils.URIBuilder;
 
@@ -299,6 +301,22 @@ public class OzoneAddress {
 
   public String getOmHost() {
     return ozoneURI.getHost();
+  }
+
+  public String getOmServiceId(ConfigurationSource conf) {
+    if (!Strings.isNullOrEmpty(getOmHost())) {
+      return getOmHost();
+    } else {
+      Collection<String> serviceIds = conf.getTrimmedStringCollection(
+          OZONE_OM_SERVICE_IDS_KEY);
+      if (serviceIds.size() == 1) {
+        // Only one OM service ID configured, we can use that
+        // If more than 1, it will fail in createClient step itself
+        return serviceIds.iterator().next();
+      } else {
+        return conf.get(OZONE_OM_ADDRESS_KEY);
+      }
+    }
   }
 
   public String getSnapshotNameWithIndicator() {

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/bucket/DeleteBucketHandler.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/bucket/DeleteBucketHandler.java
@@ -18,7 +18,6 @@
 
 package org.apache.hadoop.ozone.shell.bucket;
 
-import com.google.common.base.Strings;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
@@ -35,15 +34,12 @@ import java.io.IOException;
 import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.Iterator;
 import java.util.Scanner;
 
 import static org.apache.hadoop.fs.FileSystem.FS_DEFAULT_NAME_KEY;
 import static org.apache.hadoop.hdds.scm.net.NetConstants.PATH_SEPARATOR_STR;
 import static org.apache.hadoop.ozone.OzoneConsts.OZONE_OFS_URI_SCHEME;
-import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_ADDRESS_KEY;
-import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_SERVICE_IDS_KEY;
 import static org.apache.hadoop.ozone.om.helpers.BucketLayout.OBJECT_STORE;
 
 /**
@@ -71,21 +67,9 @@ public class DeleteBucketHandler extends BucketHandler {
     String volumeName = address.getVolumeName();
     String bucketName = address.getBucketName();
     OzoneVolume vol = client.getObjectStore().getVolume(volumeName);
+    omServiceId = address.getOmServiceId(getConf());
 
     if (bRecursive) {
-      if (!Strings.isNullOrEmpty(address.getOmHost())) {
-        omServiceId = address.getOmHost();
-      } else {
-        Collection<String> serviceIds = getConf().getTrimmedStringCollection(
-            OZONE_OM_SERVICE_IDS_KEY);
-        if (serviceIds.size() == 1) {
-          // Only one OM service ID configured, we can use that
-          // If more than 1, it will fail in createClient step itself
-          omServiceId = serviceIds.iterator().next();
-        } else {
-          omServiceId = getConf().get(OZONE_OM_ADDRESS_KEY);
-        }
-      }
       if (!yes) {
         // Ask for user confirmation
         out().print("This command will delete bucket recursively." +

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/volume/DeleteVolumeHandler.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/volume/DeleteVolumeHandler.java
@@ -18,7 +18,6 @@
 
 package org.apache.hadoop.ozone.shell.volume;
 
-import com.google.common.base.Strings;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
@@ -35,7 +34,6 @@ import java.io.IOException;
 import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Scanner;
@@ -47,8 +45,6 @@ import java.util.concurrent.atomic.AtomicInteger;
 import static org.apache.hadoop.fs.FileSystem.FS_DEFAULT_NAME_KEY;
 import static org.apache.hadoop.hdds.scm.net.NetConstants.PATH_SEPARATOR_STR;
 import static org.apache.hadoop.ozone.OzoneConsts.OZONE_OFS_URI_SCHEME;
-import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_ADDRESS_KEY;
-import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_SERVICE_IDS_KEY;
 
 /**
  * Executes deleteVolume call for the shell.
@@ -83,21 +79,9 @@ public class DeleteVolumeHandler extends VolumeHandler {
       throws IOException {
 
     String volumeName = address.getVolumeName();
+    omServiceId = address.getOmServiceId(getConf());
     try {
       if (bRecursive) {
-        if (!Strings.isNullOrEmpty(address.getOmHost())) {
-          omServiceId = address.getOmHost();
-        } else {
-          Collection<String> serviceIds = getConf().getTrimmedStringCollection(
-              OZONE_OM_SERVICE_IDS_KEY);
-          if (serviceIds.size() == 1) {
-            // Only one OM service ID configured, we can use that
-            // If more than 1, it will fail in createClient step itself
-            omServiceId = serviceIds.iterator().next();
-          } else {
-            omServiceId = getConf().get(OZONE_OM_ADDRESS_KEY);
-          }
-        }
         if (!yes) {
           // Ask for user confirmation
           out().print("This command will delete volume recursively." +


### PR DESCRIPTION
## What changes were proposed in this pull request?

OM ServiceId can be fetched from address and can be used to form Ozone address for fs URI. This can avoid giving service ID explicitly in option while running recursive delete volume command. Already this has been done for delete bucket command handler. Refactored getting serviceId from common place. 

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-9049

## How was this patch tested?

Update existing integration test and verify.
