### PR TITLE
HDDS-9050. Ozone fails to start because certificate is missing.

### DIFF
--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/security/x509/certificate/authority/DefaultApprover.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/security/x509/certificate/authority/DefaultApprover.java
@@ -146,9 +146,11 @@ public class DefaultApprover extends BaseApprover {
 
     Extensions exts = getPkcs9Extensions(certificationRequest);
     for (ASN1ObjectIdentifier extId : getProfile().getSupportedExtensions()) {
-      Extension ext = exts.getExtension(extId);
-      if (ext != null) {
-        certificateGenerator.addExtension(ext);
+      if (null != extId) {
+        Extension ext = exts.getExtension(extId);
+        if (ext != null) {
+          certificateGenerator.addExtension(ext);
+        }
       }
     }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Ozone fails to start because certificate is missing
```
INFO org.apache.hadoop.hdds.security.x509.certificate.client.SCMCertificateClient: Certificate client init case: 6
INFO org.apache.hadoop.hdds.security.x509.certificate.client.SCMCertificateClient: Found private and public key but certificate is missing.
INFO org.apache.hadoop.hdds.scm.ha.HASecurityUtils: Init response: RECOVER
ERROR org.apache.hadoop.hdds.scm.ha.HASecurityUtils: SCM security initialization failed. SCM certificate is missing.
```
When analysed SCM logs further, below exception NPE being thrown, so to fix NPE while signing certificate, this patch is raised.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-9050

## How was this patch tested?

Tested using existing Junit test cases.
