### PR TITLE
HDDS-9011. EC: Unhealthy replica not replaced with a healthy replica in a rack-scatter environment

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/placement/algorithms/SCMContainerPlacementRackScatter.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/placement/algorithms/SCMContainerPlacementRackScatter.java
@@ -347,10 +347,11 @@ public final class SCMContainerPlacementRackScatter
 
     So, in both cases, we want to ask for nodesRequired number of nodes.
     */
+    int maxOuterLoopIterations = Math.min(nodesRequired, maxReplicasPerRack);
     Set<DatanodeDetails> chosenNodes = new LinkedHashSet<>(
         chooseNodesFromRacks(racks, unavailableNodes,
             mutableFavoredNodes, nodesRequired, metadataSizeRequired,
-            dataSizeRequired, maxReplicasPerRack, usedRacksCntMap,
+            dataSizeRequired, maxOuterLoopIterations, usedRacksCntMap,
             maxReplicasPerRack));
 
     if (chosenNodes.size() < additionalRacksRequired) {

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/placement/algorithms/SCMContainerPlacementRackScatter.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/placement/algorithms/SCMContainerPlacementRackScatter.java
@@ -347,11 +347,10 @@ public final class SCMContainerPlacementRackScatter
 
     So, in both cases, we want to ask for nodesRequired number of nodes.
     */
-    int maxOuterLoopIterations = Math.min(nodesRequired, maxReplicasPerRack);
     Set<DatanodeDetails> chosenNodes = new LinkedHashSet<>(
         chooseNodesFromRacks(racks, unavailableNodes,
             mutableFavoredNodes, nodesRequired, metadataSizeRequired,
-            dataSizeRequired, maxOuterLoopIterations, usedRacksCntMap,
+            dataSizeRequired, maxReplicasPerRack, usedRacksCntMap,
             maxReplicasPerRack));
 
     if (chosenNodes.size() < additionalRacksRequired) {
@@ -386,10 +385,9 @@ public final class SCMContainerPlacementRackScatter
       LOG.debug("Available racks considering racks with used and exclude " +
               "nodes: {}.", racks);
       chosenNodes.addAll(chooseNodesFromRacks(racks, unavailableNodes,
-              mutableFavoredNodes, nodesRequired - chosenNodes.size(),
-              metadataSizeRequired, dataSizeRequired,
-              nodesRequired - chosenNodes.size(),
-              usedRacksCntMap, maxReplicasPerRack));
+          mutableFavoredNodes, nodesRequired - chosenNodes.size(),
+          metadataSizeRequired, dataSizeRequired, Integer.MAX_VALUE,
+          usedRacksCntMap, maxReplicasPerRack));
     }
     List<DatanodeDetails> result = new ArrayList<>(chosenNodes);
     if (nodesRequired != chosenNodes.size()) {

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/placement/algorithms/SCMContainerPlacementRackScatter.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/placement/algorithms/SCMContainerPlacementRackScatter.java
@@ -350,7 +350,7 @@ public final class SCMContainerPlacementRackScatter
     Set<DatanodeDetails> chosenNodes = new LinkedHashSet<>(
         chooseNodesFromRacks(racks, unavailableNodes,
             mutableFavoredNodes, nodesRequired, metadataSizeRequired,
-            dataSizeRequired, nodesRequired, usedRacksCntMap,
+            dataSizeRequired, maxReplicasPerRack, usedRacksCntMap,
             maxReplicasPerRack));
 
     if (chosenNodes.size() < additionalRacksRequired) {
@@ -363,7 +363,7 @@ public final class SCMContainerPlacementRackScatter
               reason, racks.size(), excludedNodesCount, usedNodesCount);
 
       /*
-      Couldn't choose enough nodes to satisfy the rack scatter policy. If
+      Couldn't choose enough racks to satisfy the rack scatter policy. If
       fallback is not allowed, then throw an exception.
       */
       if (!fallback) {

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/placement/algorithms/TestSCMContainerPlacementRackScatter.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/placement/algorithms/TestSCMContainerPlacementRackScatter.java
@@ -48,6 +48,7 @@ import org.mockito.Mockito;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -107,7 +108,41 @@ public class TestSCMContainerPlacementRackScatter {
     setup(datanodeCount, NODE_PER_RACK);
   }
 
-  private void setup(int datanodeCount, int nodesPerRack) {
+  /**
+   * Sets up cluster in a way such that there's one datanode per rack, except
+   * the last rack, which has datanodesInLastRackCount number of datanodes.
+   * @param rackCount number of racks this cluster should have, including the
+   * last rack
+   * @param datanodesInLastRackCount number of datanodes that should be in
+   * the last rack
+   */
+  private void setupOneDatanodePerRackWithExtraInLastRack(int rackCount,
+      int datanodesInLastRackCount) {
+    setupConfiguration();
+
+    String rack = "/rack";
+    String hostname = "node";
+    // add a datanode per rack to each rack except the last one
+    for (int i = 0; i < rackCount - 1; i++) {
+      DatanodeDetails datanodeDetails =
+          MockDatanodeDetails.createDatanodeDetails(
+              hostname + i, rack + i);
+      setupDatanode(datanodeDetails);
+    }
+
+    // add datanodesInLastRackCount number of datanodes to the last rack
+    for (int i = 0; i < datanodesInLastRackCount; i++) {
+      DatanodeDetails datanodeDetails =
+          MockDatanodeDetails.createDatanodeDetails(
+              hostname + (rackCount - 1 + i), rack + (rackCount - 1));
+      setupDatanode(datanodeDetails);
+    }
+
+    createMocksAndUpdateStorageReports(
+        rackCount - 1 + datanodesInLastRackCount);
+  }
+
+  private void setupConfiguration() {
     //initialize network topology instance
     conf = new OzoneConfiguration();
     // We are using small units here
@@ -117,7 +152,10 @@ public class TestSCMContainerPlacementRackScatter {
         {ROOT_SCHEMA, RACK_SCHEMA, LEAF_SCHEMA};
     NodeSchemaManager.getInstance().init(schemas, true);
     cluster = new NetworkTopologyImpl(NodeSchemaManager.getInstance());
+  }
 
+    private void setup(int datanodeCount, int nodesPerRack) {
+    setupConfiguration();
     // build datanodes, and network topology
     String rack = "/rack";
     String hostname = "node";
@@ -125,28 +163,40 @@ public class TestSCMContainerPlacementRackScatter {
       // Totally 6 racks, each has 5 datanodes
       DatanodeDetails datanodeDetails =
           MockDatanodeDetails.createDatanodeDetails(
-          hostname + i, rack + (i / nodesPerRack));
-
-      datanodes.add(datanodeDetails);
-      cluster.add(datanodeDetails);
-      DatanodeInfo datanodeInfo = new DatanodeInfo(
-          datanodeDetails, NodeStatus.inServiceHealthy(),
-          UpgradeUtils.defaultLayoutVersionProto());
-
-      StorageReportProto storage1 = HddsTestUtils.createStorageReport(
-          datanodeInfo.getUuid(), "/data1-" + datanodeInfo.getUuidString(),
-          STORAGE_CAPACITY, 0, 100L, null);
-      MetadataStorageReportProto metaStorage1 =
-          HddsTestUtils.createMetadataStorageReport(
-          "/metadata1-" + datanodeInfo.getUuidString(),
-          STORAGE_CAPACITY, 0, 100L, null);
-      datanodeInfo.updateStorageReports(
-          new ArrayList<>(Arrays.asList(storage1)));
-      datanodeInfo.updateMetaDataStorageReports(
-          new ArrayList<>(Arrays.asList(metaStorage1)));
-      dnInfos.add(datanodeInfo);
+              hostname + i, rack + (i / nodesPerRack));
+      setupDatanode(datanodeDetails);
     }
 
+    createMocksAndUpdateStorageReports(datanodeCount);
+  }
+
+  /**
+   * Adds the datanode to class level data structures and Network Topology.
+   * Creates a DatanodeInfo object and storage reports for it.
+   * @param datanodeDetails the datanode to setup
+   */
+  private void setupDatanode(DatanodeDetails datanodeDetails) {
+    datanodes.add(datanodeDetails);
+    cluster.add(datanodeDetails);
+    DatanodeInfo datanodeInfo = new DatanodeInfo(
+        datanodeDetails, NodeStatus.inServiceHealthy(),
+        UpgradeUtils.defaultLayoutVersionProto());
+
+    StorageReportProto storage1 = HddsTestUtils.createStorageReport(
+        datanodeInfo.getUuid(), "/data1-" + datanodeInfo.getUuidString(),
+        STORAGE_CAPACITY, 0, 100L, null);
+    MetadataStorageReportProto metaStorage1 =
+        HddsTestUtils.createMetadataStorageReport(
+            "/metadata1-" + datanodeInfo.getUuidString(),
+            STORAGE_CAPACITY, 0, 100L, null);
+    datanodeInfo.updateStorageReports(
+        new ArrayList<>(Collections.singletonList(storage1)));
+    datanodeInfo.updateMetaDataStorageReports(
+        new ArrayList<>(Collections.singletonList(metaStorage1)));
+    dnInfos.add(datanodeInfo);
+  }
+
+  private void createMocksAndUpdateStorageReports(int datanodeCount) {
     if (datanodeCount > 4) {
       StorageReportProto storage2 = HddsTestUtils.createStorageReport(
           dnInfos.get(2).getUuid(),
@@ -250,10 +300,18 @@ public class TestSCMContainerPlacementRackScatter {
     if (datanodeCount > nodeNum) {
       assumeTrue(datanodeCount >= NODE_PER_RACK);
       if (datanodeCount == 6) {
+        policy.setFallback(false);
         int finalNodeNum = nodeNum;
         SCMException e = assertThrows(SCMException.class,
                 () -> policy.chooseDatanodes(null, null, finalNodeNum, 0, 15));
         assertEquals(FAILED_TO_FIND_HEALTHY_NODES, e.getResult());
+
+        // allow fallback, expecting 5 nodes across both racks to get selected
+        policy.setFallback(true);
+        List<DatanodeDetails> chosenNodes =
+            policy.chooseDatanodes(null, null, finalNodeNum, 0, 15);
+        Assertions.assertEquals(5, chosenNodes.size());
+        Assertions.assertTrue(chosenNodes.contains(datanodes.get(5)));
       } else {
         datanodeDetails = policy.chooseDatanodes(null, null, nodeNum, 0, 15);
         Assertions.assertEquals(nodeNum, datanodeDetails.size());
@@ -267,10 +325,18 @@ public class TestSCMContainerPlacementRackScatter {
     if (datanodeCount > nodeNum) {
       assumeTrue(datanodeCount > 2 * NODE_PER_RACK);
       if (datanodeCount == 11) {
+        policy.setFallback(false);
         int finalNodeNum = nodeNum;
         SCMException e = assertThrows(SCMException.class,
                 () -> policy.chooseDatanodes(null, null, finalNodeNum, 0, 15));
         assertEquals(FAILED_TO_FIND_HEALTHY_NODES, e.getResult());
+
+        // allow fallback, expecting 10 nodes across both racks to be selected
+        policy.setFallback(true);
+        List<DatanodeDetails> chosenNodes =
+            policy.chooseDatanodes(null, null, finalNodeNum, 0, 15);
+        Assertions.assertEquals(10, chosenNodes.size());
+        Assertions.assertTrue(chosenNodes.contains(datanodes.get(10)));
       } else {
         datanodeDetails = policy.chooseDatanodes(null, null, nodeNum, 0, 15);
         Assertions.assertEquals(nodeNum, datanodeDetails.size());
@@ -333,11 +399,19 @@ public class TestSCMContainerPlacementRackScatter {
     excludedNodes.clear();
     excludedNodes.add(datanodes.get(0));
     if (datanodeCount == 6) {
+      policy.setFallback(false);
       int finalNodeNum = nodeNum;
       SCMException e = assertThrows(SCMException.class,
               () -> policy.chooseDatanodes(excludedNodes, null,
                       finalNodeNum, 0, 15));
       assertEquals(FAILED_TO_FIND_HEALTHY_NODES, e.getResult());
+
+      // allow fallback, expecting 4 nodes to get selected now
+      policy.setFallback(true);
+      List<DatanodeDetails> chosenNodes =
+          policy.chooseDatanodes(excludedNodes, null, finalNodeNum, 0, 15);
+      Assertions.assertEquals(4, chosenNodes.size());
+      Assertions.assertTrue(chosenNodes.contains(datanodes.get(5)));
     } else {
       datanodeDetails = policy.chooseDatanodes(
               excludedNodes, null, nodeNum, 0, 15);
@@ -368,12 +442,26 @@ public class TestSCMContainerPlacementRackScatter {
       *  met since there are two racks exist, but only one
       * of them is chosen
       * */
+      policy.setFallback(false);
       SCMException e = assertThrows(SCMException.class,
           () -> policy.chooseDatanodes(excludedNodes, null, 3, 0, 15));
       String message = e.getMessage();
-      assertTrue(message.contains("Chosen nodes size from Unique Racks: 1," +
-              " but required nodes to choose from Unique Racks: " +
-              "2 do not match."));
+      assertTrue(message.contains("Chosen nodes size: 2, but required nodes " +
+          "to choose: 3 do not match."));
+
+      /*
+      Now, allow fallback. The expectation is that 3 nodes from the first
+      rack should be chosen.
+       */
+      policy.setFallback(true);
+      List<DatanodeDetails> chosenNodes =
+          policy.chooseDatanodes(excludedNodes, null, 3, 0, 15);
+      Assertions.assertEquals(3, chosenNodes.size());
+      for (DatanodeDetails dn : chosenNodes) {
+        Assertions.assertTrue(
+            dn.equals(datanodes.get(1)) || dn.equals(datanodes.get(2)) ||
+                dn.equals(datanodes.get(3)) || dn.equals(datanodes.get(4)));
+      }
     } else {
       datanodeDetails = policy.chooseDatanodes(
           excludedNodes, null, nodeNum, 0, 15);
@@ -610,8 +698,10 @@ public class TestSCMContainerPlacementRackScatter {
   }
 
   @Test
-  public void testChooseNodesWithUsedNodesWithInsufficientRequiredNodeCount() {
+  public void testChooseNodesWithUsedNodesWithInsufficientRequiredNodeCount()
+      throws SCMException {
     setup(5, 2);
+    policy.setFallback(false);
     List<DatanodeDetails> usedDns = getDatanodes(Lists.newArrayList(0, 1));
     List<DatanodeDetails> excludedDns = getDatanodes(Lists.newArrayList(2));
     SCMException exception = Assertions.assertThrows(SCMException.class, () ->
@@ -621,6 +711,92 @@ public class TestSCMContainerPlacementRackScatter {
             "required number of racks to choose: 2.", exception.getMessage());
     assertEquals(SCMException.ResultCodes.FAILED_TO_FIND_SUITABLE_NODE,
             exception.getResult());
+
+    /*
+     Now, allow fallback. The expectation is that one datanode should be
+     chosen, even though the placement policy requires two more racks.
+     */
+    policy.setFallback(true);
+    List<DatanodeDetails> chosenNodes =
+        policy.chooseDatanodes(usedDns, excludedDns,
+            null, 1, 0, 5);
+    Assertions.assertEquals(1, chosenNodes.size());
+    /*
+    The chosen node should be node4 from the third rack because we prefer to
+    choose from racks that don't have used or excluded nodes.
+     */
+    Assertions.assertEquals(datanodes.get(4), chosenNodes.get(0));
+  }
+
+  /**
+   * Scenario:
+   * rack0 -> node0
+   * rack1 -> node1
+   * rack2 -> node2
+   * rack3 -> node3
+   * rack4 -> node4, node5
+   * <p>
+   * node0, node1, node2, node4 are used nodes. node3 is excluded node.
+   * Expectation is that node5 should be chosen if fallback is allowed.
+   * Else, an SCMException should be thrown because placement policy cannot
+   * be satisfied.
+   */
+  @Test
+  public void shouldChooseRackWithUsedNodeWhenOnlyThatRackIsAvailable()
+      throws SCMException {
+    setupOneDatanodePerRackWithExtraInLastRack(5, 2);
+    policy.setFallback(false);
+    List<DatanodeDetails> usedDns = getDatanodes(Lists.newArrayList(0, 1, 2,
+        4));
+    List<DatanodeDetails> excludedDns = getDatanodes(Lists.newArrayList(3));
+    Assertions.assertThrows(SCMException.class,
+        () -> policy.chooseDatanodes(usedDns, excludedDns,
+            null, 1, 0, 5));
+
+    // now, allow fallback
+    policy.setFallback(true);
+    List<DatanodeDetails> chosenNode =
+        policy.chooseDatanodes(usedDns, excludedDns,
+            null, 1, 0, 5);
+    Assertions.assertEquals(1, chosenNode.size());
+    Assertions.assertEquals(datanodes.get(5), chosenNode.get(0));
+  }
+
+  /**
+   * Scenario:
+   * rack0 -> node0
+   * rack1 -> node1
+   * rack2 -> node2
+   * rack3 -> node3
+   * rack4 -> node4
+   * rack5 -> node5, node6
+   * <p>
+   * node0, node1, node5, node6 are used nodes. node2 is excluded. We are
+   * asking the placement policy for one more node. Expectation is that an
+   * SCMException should be thrown if fallback is false because we're asking
+   * for one more node while placement policy requires two more racks. Else,
+   * either node3 or node4 should be returned.
+   */
+  @Test
+  public void shouldChooseNodeWhenOneNodeRequiredAndTwoRacksRequired()
+      throws SCMException {
+    setupOneDatanodePerRackWithExtraInLastRack(6, 2);
+    policy.setFallback(false);
+    List<DatanodeDetails> usedDns = getDatanodes(Lists.newArrayList(0, 1, 5,
+        5));
+    List<DatanodeDetails> excludedDns = getDatanodes(Lists.newArrayList(2));
+    Assertions.assertThrows(SCMException.class,
+        () -> policy.chooseDatanodes(usedDns, excludedDns,
+            null, 1, 0, 5));
+
+    // now, allow fallback
+    policy.setFallback(true);
+    List<DatanodeDetails> chosenNode =
+        policy.chooseDatanodes(usedDns, excludedDns,
+            null, 1, 0, 5);
+    Assertions.assertEquals(1, chosenNode.size());
+    Assertions.assertTrue(chosenNode.get(0).equals(datanodes.get(3)) ||
+        chosenNode.get(0).equals(datanodes.get(4)));
   }
 
   @Test
@@ -637,20 +813,29 @@ public class TestSCMContainerPlacementRackScatter {
         exception.getResult());
   }
 
+  /**
+   * Simulate a scenario with three racks and two datanodes per rack.
+   * Two new nodes are required and the only available ones are on the same
+   * rack. The expectation is that both these nodes on the same rack should be
+   * chosen, since max replicas allowed per rack in this situation is 2.
+   */
   @Test
-  public void testInValidChooseNodesWithUsedNodesWithInsufficientRacks() {
+  public void chooseNodesOnTheSameRackWhenInSufficientRacks()
+      throws SCMException {
     setup(6, 2);
+    policy.setFallback(false);
     List<DatanodeDetails> usedDns = getDatanodes(Lists.newArrayList(0, 1));
     updateStorageInDatanode(4, 99, 1);
     List<DatanodeDetails> excludedDns = getDatanodes(Lists.newArrayList(5));
-    SCMException exception = Assertions.assertThrows(SCMException.class, () ->
-            policy.chooseDatanodes(usedDns, excludedDns,
-                    null, 2, 0, 5));
-    assertEquals("Chosen nodes size from Unique Racks: 1, but required " +
-            "nodes to choose from Unique Racks: 2 do not match.",
-            exception.getMessage());
-    assertEquals(FAILED_TO_FIND_HEALTHY_NODES,
-            exception.getResult());
+
+    List<DatanodeDetails> chosenDatanodes =
+        policy.chooseDatanodes(usedDns, excludedDns, null, 2, 0, 5);
+
+    Assertions.assertEquals(2, chosenDatanodes.size());
+    for (DatanodeDetails dn : chosenDatanodes) {
+      Assertions.assertTrue(
+          dn.equals(datanodes.get(2)) || dn.equals(datanodes.get(3)));
+    }
   }
 
   @Test

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/placement/algorithms/TestSCMContainerPlacementRackScatter.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/placement/algorithms/TestSCMContainerPlacementRackScatter.java
@@ -154,7 +154,7 @@ public class TestSCMContainerPlacementRackScatter {
     cluster = new NetworkTopologyImpl(NodeSchemaManager.getInstance());
   }
 
-    private void setup(int datanodeCount, int nodesPerRack) {
+  private void setup(int datanodeCount, int nodesPerRack) {
     setupConfiguration();
     // build datanodes, and network topology
     String rack = "/rack";

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/placement/algorithms/TestSCMContainerPlacementRackScatter.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/placement/algorithms/TestSCMContainerPlacementRackScatter.java
@@ -36,7 +36,6 @@ import org.apache.hadoop.hdds.scm.node.DatanodeInfo;
 import org.apache.hadoop.hdds.scm.node.NodeManager;
 import org.apache.hadoop.hdds.scm.node.NodeStatus;
 import org.apache.hadoop.ozone.container.upgrade.UpgradeUtils;
-import org.apache.ozone.test.GenericTestUtils;
 import org.assertj.core.util.Lists;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
@@ -46,7 +45,6 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.Mockito;
-import org.slf4j.event.Level;
 
 import java.util.ArrayList;
 import java.util.Arrays;


### PR DESCRIPTION
## What changes were proposed in this pull request?

Simply put, the problem here is that EC under replication handling is blocked in cases where the Rack Scatter policy cannot return new Datanodes because they don't satisfy the policy.

Please check the jira for one such scenario, and this [document](https://docs.google.com/document/d/1ebuSwJZkw4wMWWCHinDvRCfNbeFD4kcHMyIN6Q6wD9g/edit?usp=sharing) for a detailed (but roughly documented) reproduction of some cases.

Changes proposed: Allow the rack scatter policy to fallback and return the required number of datanodes even if the policy can't be satisfied. But still try to follow the policy as well as possible. Because `fallback` is true by default, the policy will now try to return nodes if possible in situations it'd throw an `SCMException` previously. The invariant that this policy tries to return the asked number of nodes and fails if it can't is still true.

The normal definition of "maximum replicas a rack can host" (called `maxReplicasPerRack` in the code) in rack scatter policy is:
```
    return numReplicas / numberOfRacks
            + Math.min(numReplicas % numberOfRacks, 1);
```

When falling back, the definition of `maxReplicasPerRack` in `chooseDatanodesInternal` is changed to "replication factor number of replicas", so that one rack can host all replicas of this container if needed. It'll still try to spread the replicas across as many racks as possible - this is done by the existing algorithm in `chooseNodesFromRacks`. The algorithm iterates over reach rack and just chooses one node per rack in one iteration, so the chosen nodes are spread across as many racks as possible:

```
      for (Node rack : toChooseRacks) {
        if (rack == null) {
          // TODO: need to recheck why null coming here.
          continue;
        }
        Node node = chooseNode(rack.getNetworkFullPath(), unavailableNodes,
                metadataSizeRequired, dataSizeRequired);
        if (node != null) {
          chosenNodes.add((DatanodeDetails) node);
          rackCntMap.merge(rack, 1, Math::addExact);
          mutableFavoredNodes.remove(node);
          unavailableNodes.add(node);
          nodesRequired--;
          if (nodesRequired == 0) {
            break;
          }
        } else {
          // Store the skipped racks to check them first in next outer loop
          skippedRacks.add(rack);
        }
      }
```
The number of times this algo runs, or the number of times we will consider a rack for choosing a node, is controlled by the argument `maxOuterLoopIterations`. Previously, this argument was `1` in one case and `Integer.MAX_VALUE` in another case - now it's `maxReplicasPerRack` for the first call and still `Integer.MAX_VALUE` for the second call (see discussion under [this](https://github.com/apache/ozone/pull/5097#pullrequestreview-1539478356) comment).

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-9011

## How was this patch tested?

Changed some unit tests and added some new ones.
Draft while waiting for CI and doing some manual testing in a cluster.