### PR TITLE
HDDS-9060. [snapshot] Add unit-testcase for snapshot fs -deleteSnapshot

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFsSnapshot.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFsSnapshot.java
@@ -26,6 +26,7 @@ import java.util.stream.Stream;
 
 import com.google.common.base.Strings;
 
+import org.apache.commons.lang3.ObjectUtils;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.ozone.MiniOzoneCluster;
@@ -304,13 +305,44 @@ public class TestOzoneFsSnapshot {
         200, 10000);
   }
 
-  @Test
-  public void testSnapshotDeleteFailure() throws Exception {
-    // Delete snapshot that doesn't exist
-    String deleteSnapshotOut = execShellCommandAndGetOutput(1,
-        new String[]{"-deleteSnapshot", BUCKET_PATH, "testsnap"});
-    Assertions.assertTrue(deleteSnapshotOut
-        .contains("Snapshot does not exist"));
+  private static Stream<Arguments> deleteSnapshotFailureScenarios() {
+    String invalidBucketPath = "/invalid/uri";
+    return Stream.of(
+            Arguments.of("1st case: invalid snapshot name",
+                    BUCKET_PATH,
+                    "testsnap",
+                    "Snapshot does not exist",
+                    1),
+            Arguments.of("2nd case: invalid bucekt path",
+                    invalidBucketPath,
+                    "testsnap",
+                    "No such file or directory",
+                    1),
+            Arguments.of("3rd case: snapshot name not passed",
+                    BUCKET_PATH,
+                    "",
+                    "snapshot name can't be null or empty",
+                    -1),
+            Arguments.of("4th case: all parameters are missing",
+                    "",
+                    "",
+                    "Can not create a Path from an empty string",
+                    -1)
+    );
+  }
+
+  @ParameterizedTest(name = "{0}")
+  @MethodSource("deleteSnapshotFailureScenarios")
+  public void testSnapshotDeleteFailure(String description,
+                                        String paramBucketPath,
+                                        String snapshotName,
+                                        String expectedMessage,
+                                        int expectedResponse) throws Exception {
+    String errorMessage = execShellCommandAndGetOutput(expectedResponse,
+            new String[]{"-deleteSnapshot", paramBucketPath, snapshotName});
+
+    Assertions.assertTrue(errorMessage
+            .contains(expectedMessage), errorMessage);
   }
 
   /**

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFsSnapshot.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFsSnapshot.java
@@ -26,7 +26,6 @@ import java.util.stream.Stream;
 
 import com.google.common.base.Strings;
 
-import org.apache.commons.lang3.ObjectUtils;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.ozone.MiniOzoneCluster;


### PR DESCRIPTION
## What changes were proposed in this pull request?

Add UTs for fs deleteSnapshot - `TestOzoneFsSnapshot#testSnapshotDeleteFailure`

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-9060

## How was this patch tested?

Testcase file - `hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFsSnapshot.java`
```
mvn -l testlog.out -Dtest=TestOzoneFsSnapshot#testSnapshotDeleteFailure test
[INFO] -------------------------------------------------------
[INFO]  T E S T S
[INFO] -------------------------------------------------------
[INFO] Running org.apache.hadoop.fs.ozone.TestOzoneFsSnapshot
[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 21.999 s - in org.apache.hadoop.fs.ozone.TestOzoneFsSnapshot
[INFO]
[INFO] Results:
[INFO]
[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0
```
