### PR TITLE
HDDS-9059. NPE in SendContainerRequestHandler.deleteTarball

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/replication/SendContainerRequestHandler.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/replication/SendContainerRequestHandler.java
@@ -128,7 +128,9 @@ class SendContainerRequestHandler
 
   private void deleteTarball() {
     try {
-      Files.deleteIfExists(path);
+      if (null != path) {
+        Files.deleteIfExists(path);
+      }
     } catch (IOException e) {
       LOG.warn("Error removing {}", path);
     }


### PR DESCRIPTION
## What changes were proposed in this pull request?

This patch is to fix NullPointerException due to null path when trying to delete tar ball during container replication if any RuntimeException occurred.  Below is the exception trace:

`Jul 20, 2023 1:24:56 PM org.apache.ratis.thirdparty.io.grpc.internal.SerializingExecutor run SEVERE: Exception while executing runnable org.apache.ratis.thirdparty.io.grpc.internal.ServerImpl$JumpToApplicationThreadServerStreamListener$1Closed@60a1ee40 java.lang.NullPointerException at java.base/java.nio.file.Files.provider(Files.java:101) at java.base/java.nio.file.Files.deleteIfExists(Files.java:1181) at org.apache.hadoop.ozone.container.replication.SendContainerRequestHandler.deleteTarball(SendContainerRequestHandler`

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-9062

## How was this patch tested?

This patch was tested manually with existing tests.
