### PR TITLE
HDDS-9063. OM - Recon unable to obtain Ozone Manager DB Snapshot

### DIFF
--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OMDBCheckpointServlet.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OMDBCheckpointServlet.java
@@ -19,7 +19,6 @@
 package org.apache.hadoop.ozone.om;
 
 import com.google.common.annotations.VisibleForTesting;
-import edu.umd.cs.findbugs.annotations.NonNull;
 import org.apache.commons.compress.archivers.ArchiveOutputStream;
 import org.apache.commons.compress.archivers.tar.TarArchiveOutputStream;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OMDBCheckpointServlet.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OMDBCheckpointServlet.java
@@ -356,7 +356,8 @@ public class OMDBCheckpointServlet extends DBCheckpointServlet {
       Set<Path> copyFiles,
       Map<Path, Path> hardLinkFiles,
       ArchiveOutputStream archiveOutputStream,
-      boolean completed, Path checkpointLocation)
+      boolean completed,
+      Path checkpointLocation)
       throws IOException {
     Path metaDirPath = getVerifiedCheckPointPath(checkpointLocation);
     int truncateLength = metaDirPath.toString().length() + 1;

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OMDBCheckpointServlet.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OMDBCheckpointServlet.java
@@ -23,7 +23,6 @@ import org.apache.commons.compress.archivers.ArchiveOutputStream;
 import org.apache.commons.compress.archivers.tar.TarArchiveOutputStream;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.recon.ReconConfig;
-import org.apache.hadoop.hdds.server.ServerUtils;
 import org.apache.hadoop.hdds.utils.DBCheckpointServlet;
 import org.apache.hadoop.hdds.utils.db.DBCheckpoint;
 import org.apache.hadoop.hdds.utils.db.RDBCheckpointUtils;
@@ -161,14 +160,16 @@ public class OMDBCheckpointServlet extends DBCheckpointServlet {
   // Format list from follower to match data on leader.
   @VisibleForTesting
   public static Set<Path> normalizeExcludeList(List<String> toExcludeList,
-      Path checkpointLocation) {
+                                               Path checkpointLocation) {
     Set<Path> paths = new HashSet<>();
-    for (String s: toExcludeList) {
+    for (String s : toExcludeList) {
       if (!s.startsWith(OM_SNAPSHOT_DIR)) {
         Path fixedPath = Paths.get(checkpointLocation.toString(), s);
         paths.add(fixedPath);
       } else {
-        paths.add(Paths.get(checkpointLocation.getParent().getParent().toString(), s));
+        paths.add(
+            Paths.get(checkpointLocation.getParent().getParent().toString(),
+                s));
       }
     }
     return paths;

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OMDBCheckpointServlet.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OMDBCheckpointServlet.java
@@ -397,15 +397,19 @@ public class OMDBCheckpointServlet extends DBCheckpointServlet {
 
   @NotNull
   private static Path getVerifiedCheckPointPath(Path checkpointLocation) {
-    Path metaDirPath = checkpointLocation;
     // This check is done to take care of findbug else below getParent()
     // should not be null.
     Path locationParent = checkpointLocation.getParent();
-    if (null != locationParent) {
-      Path parent = locationParent.getParent();
-      metaDirPath = parent != null ? parent : locationParent;
+    if (null == locationParent) {
+      throw new RuntimeException(
+          "checkpoint location's immediate parent is null.");
     }
-    return metaDirPath;
+    Path parent = locationParent.getParent();
+    if (null == parent) {
+      throw new RuntimeException(
+          "checkpoint location's path is invalid and could not be verified.");
+    }
+    return parent;
   }
 
   private OzoneConfiguration getConf() {

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestOmSnapshotManager.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestOmSnapshotManager.java
@@ -328,7 +328,7 @@ public class TestOmSnapshotManager {
     //  (Normalizing means matches the layout on the leader.)
     Set<Path> normalizedSet =
         OMDBCheckpointServlet.normalizeExcludeList(existingSstList,
-            leaderCheckpointDir.toString(), leaderDir.toString());
+            leaderCheckpointDir.toPath());
     Set<Path> expectedNormalizedSet = new HashSet<>(Arrays.asList(
         Paths.get(leaderSnapDir1.toString(), "s1.sst"),
         Paths.get(leaderSnapDir2.toString(), "noLink.sst"),


### PR DESCRIPTION
## What changes were proposed in this pull request?

Recon is unable to load data from the OM because the DB sync is failing due to path issues:
```
2023-07-20 23:44:50,686 ERROR [pool-27-thread-1]-org.apache.hadoop.ozone.recon.spi.impl.OzoneManagerServiceProviderImpl: Unable to obtain Ozone Manager DB Snapshot.
java.io.FileNotFoundException: /var/lib/hadoop-ozone/recon/om/data/om.snapshot.db_1689896689992/ints/om.db_checkpoint_1689896690655/000103.sst (No such file or directory)
        at java.io.FileOutputStream.open0(Native Method)
        at java.io.FileOutputStream.open(FileOutputStream.java:270)
        at java.io.FileOutputStream.<init>(FileOutputStream.java:213)
        at java.io.FileOutputStream.<init>(FileOutputStream.java:162)
        at org.apache.hadoop.ozone.recon.ReconUtils.untarCheckpointFile(ReconUtils.java:198)
```


## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-9063

## How was this patch tested?

This patch was tested using Junit test case as well after deploying patch in cluster.
