### PR TITLE
HDDS-9066. Remove the renew logic added by HDDS-7453.

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/security/x509/certificate/client/CertificateClient.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/security/x509/certificate/client/CertificateClient.java
@@ -263,7 +263,6 @@ public interface CertificateClient extends Closeable {
     SUCCESS,
     FAILURE,
     GETCERT,
-    RECOVER,
-    REINIT
+    RECOVER
   }
 }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/HddsDatanodeService.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/HddsDatanodeService.java
@@ -384,14 +384,6 @@ public class HddsDatanodeService extends GenericCli implements ServicePlugin {
       certClient = dnCertClient;
     }
     CertificateClient.InitResponse response = certClient.init();
-    if (response.equals(CertificateClient.InitResponse.REINIT)) {
-      certClient.close();
-      LOG.info("Re-initialize certificate client.");
-      certClient = new DNCertificateClient(secConf,
-          createScmSecurityClient(),
-          datanodeDetails, null, this::saveNewCertId, this::terminateDatanode);
-      response = certClient.init();
-    }
     LOG.info("Init response: {}", response);
     switch (response) {
     case SUCCESS:

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/security/x509/certificate/client/CommonCertificateClient.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/security/x509/certificate/client/CommonCertificateClient.java
@@ -28,7 +28,6 @@ import java.util.function.Consumer;
 import static org.apache.hadoop.hdds.security.x509.certificate.client.CertificateClient.InitResponse.FAILURE;
 import static org.apache.hadoop.hdds.security.x509.certificate.client.CertificateClient.InitResponse.GETCERT;
 import static org.apache.hadoop.hdds.security.x509.certificate.client.CertificateClient.InitResponse.RECOVER;
-import static org.apache.hadoop.hdds.security.x509.certificate.client.CertificateClient.InitResponse.REINIT;
 import static org.apache.hadoop.hdds.security.x509.certificate.client.CertificateClient.InitResponse.SUCCESS;
 
 /**
@@ -114,11 +113,6 @@ public abstract class CommonCertificateClient extends DefaultCertificateClient {
       } else {
         return FAILURE;
       }
-    case EXPIRED_CERT:
-      getLogger().info("Component certificate is about to expire. Initiating" +
-          "renewal.");
-      removeMaterial();
-      return REINIT;
     default:
       log.error("Unexpected case: {} (private/public/cert)",
           Integer.toBinaryString(init.ordinal()));

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/security/x509/certificate/client/SCMCertificateClient.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/security/x509/certificate/client/SCMCertificateClient.java
@@ -136,9 +136,6 @@ public class SCMCertificateClient extends DefaultCertificateClient {
       } else {
         return FAILURE;
       }
-    case EXPIRED_CERT:
-      LOG.warn("SCM CA certificate is about to be expire!");
-      return SUCCESS;
     default:
       LOG.error("Unexpected case: {} (private/public/cert)",
           Integer.toBinaryString(init.ordinal()));

--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/security/x509/certificate/client/TestDefaultCertificateClient.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/security/x509/certificate/client/TestDefaultCertificateClient.java
@@ -23,7 +23,6 @@ import org.apache.hadoop.hdds.protocol.MockDatanodeDetails;
 import org.apache.hadoop.hdds.protocol.proto.SCMSecurityProtocolProtos.SCMGetCertResponseProto;
 import org.apache.hadoop.hdds.protocolPB.SCMSecurityProtocolClientSideTranslatorPB;
 import org.apache.hadoop.hdds.security.x509.certificate.authority.CAType;
-import org.apache.hadoop.hdds.security.x509.certificate.client.CertificateClient.InitResponse;
 import org.apache.hadoop.hdds.security.x509.certificate.utils.CertificateCodec;
 import org.apache.hadoop.hdds.security.x509.exception.CertificateException;
 import org.apache.hadoop.hdds.security.x509.keys.KeyCodec;
@@ -68,7 +67,6 @@ import static org.apache.hadoop.fs.CommonConfigurationKeysPublic.IPC_CLIENT_CONN
 import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_METADATA_DIR_NAME;
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_NAMES;
 import static org.apache.hadoop.hdds.security.x509.certificate.client.CertificateClient.InitResponse.FAILURE;
-import static org.apache.hadoop.hdds.security.x509.certificate.client.CertificateClient.InitResponse.REINIT;
 import static org.apache.hadoop.hdds.security.x509.certificate.utils.CertificateCodec.getPEMEncodedString;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -444,69 +442,6 @@ public class TestDefaultCertificateClient {
     // Check for DN.
     assertEquals(FAILURE, dnCertClient.init());
     assertTrue(dnClientLog.getOutput().contains("Can't recover public key"));
-  }
-
-  @Test
-  public void testCertificateExpirationHandlingInInit() throws Exception {
-    String certId = "1L";
-    String compName = "TEST";
-
-    Logger mockLogger = mock(Logger.class);
-
-    SecurityConfig config = mock(SecurityConfig.class);
-    Path nonexistent = Paths.get("nonexistent");
-    when(config.getCertificateLocation(anyString())).thenReturn(nonexistent);
-    when(config.getKeyLocation(anyString())).thenReturn(nonexistent);
-    when(config.getRenewalGracePeriod()).thenReturn(Duration.ofDays(28));
-
-    Calendar cal = Calendar.getInstance();
-    cal.add(Calendar.DAY_OF_YEAR, 2);
-    Date expiration = cal.getTime();
-    X509Certificate mockCert = mock(X509Certificate.class);
-    when(mockCert.getNotAfter()).thenReturn(expiration);
-
-    try (DefaultCertificateClient client =
-        new DefaultCertificateClient(config, null, mockLogger, certId, compName,
-            null, null) {
-          @Override
-          public PrivateKey getPrivateKey() {
-            return mock(PrivateKey.class);
-          }
-
-          @Override
-          public PublicKey getPublicKey() {
-            return mock(PublicKey.class);
-          }
-
-          @Override
-          public X509Certificate getCertificate() {
-            return mockCert;
-          }
-
-          @Override
-          public String signAndStoreCertificate(
-              PKCS10CertificationRequest request, Path certificatePath) {
-            return null;
-          }
-
-          @Override
-          protected SCMGetCertResponseProto getCertificateSignResponse(
-              PKCS10CertificationRequest request) {
-            return null;
-          }
-
-          @Override
-          public String signAndStoreCertificate(
-              PKCS10CertificationRequest request, Path certificatePath,
-              boolean renew) {
-            return null;
-          }
-        }) {
-
-      InitResponse resp = client.init();
-      verify(mockLogger, atLeastOnce()).info(anyString());
-      assertEquals(resp, REINIT);
-    }
   }
 
   @Test

--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/security/x509/certificate/client/TestDefaultCertificateClient.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/security/x509/certificate/client/TestDefaultCertificateClient.java
@@ -44,8 +44,6 @@ import java.security.Signature;
 import java.security.cert.X509Certificate;
 import java.time.Duration;
 import java.util.Arrays;
-import java.util.Calendar;
-import java.util.Date;
 import java.util.UUID;
 import java.util.function.Predicate;
 
@@ -78,9 +76,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 /**

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
@@ -80,7 +80,6 @@ import org.apache.hadoop.hdds.ratis.RatisHelper;
 import org.apache.hadoop.hdds.scm.ScmInfo;
 import org.apache.hadoop.hdds.scm.client.HddsClientUtils;
 import org.apache.hadoop.hdds.server.OzoneAdmins;
-import org.apache.hadoop.hdds.utils.IOUtils;
 import org.apache.hadoop.hdds.utils.db.Table;
 import org.apache.hadoop.hdds.utils.db.Table.KeyValue;
 import org.apache.hadoop.hdds.utils.db.TableIterator;
@@ -1393,16 +1392,6 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
             new SecurityConfig(conf), scmSecurityClient, omStore, omInfo,
             "", scmId, null, null);
     CertificateClient.InitResponse response = certClient.init();
-    if (response.equals(CertificateClient.InitResponse.REINIT)) {
-      LOG.info("Re-initialize certificate client.");
-      omStore.unsetOmCertSerialId();
-      omStore.persistCurrentState();
-      IOUtils.close(LOG, certClient);
-      certClient = new OMCertificateClient(
-          new SecurityConfig(conf), scmSecurityClient, omStore, omInfo,
-          "", scmId, null, null);
-      response = certClient.init();
-    }
     LOG.info("Init response: {}", response);
     switch (response) {
     case SUCCESS:

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/ReconServer.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/ReconServer.java
@@ -185,15 +185,6 @@ public class ReconServer extends GenericCli {
         reconStorage, this::saveNewCertId, this::terminateRecon);
 
     CertificateClient.InitResponse response = certClient.init();
-    if (response.equals(CertificateClient.InitResponse.REINIT)) {
-      LOG.info("Re-initialize certificate client.");
-      certClient.close();
-      reconStorage.unsetReconCertSerialId();
-      reconStorage.persistCurrentState();
-      certClient = new ReconCertificateClient(secConf, scmSecurityClient,
-          reconStorage, this::saveNewCertId, this::terminateRecon);
-      response = certClient.init();
-    }
     LOG.info("Init response: {}", response);
     switch (response) {
     case SUCCESS:


### PR DESCRIPTION
## What changes were proposed in this pull request?

In this patch I propose to remove parts of HDDS-7453. Earlier we have added a check and some logic to renew the certificate of a service at startup. As we progressed with the development, there is a new background service thread that checks for the certificate's expiration date periodically, and also does the check at startup. This background service sufficiently replaces the previous functionality, and as it turned out during testing, in some cases these two solutions are competing in a race which leads to multiplying certificates, or sometimes miss the renewal.

The parts that are to be removed, are all related to the REINIT InitCase in DefaultCertificateClient together with the REINIT InitCase itself. The rest is related to configuration and other elements we still use in the code, so a simple revert would not do it, hence a specific patch.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-9066

## How was this patch tested?

As it is just removing code, the current CI should cover testing well.
