### PR TITLE
HDDS-9072. Set isFile when creating OmKeyInfo for createFile code path

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerHA.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerHA.java
@@ -50,7 +50,6 @@ import java.io.IOException;
 import java.net.ConnectException;
 import java.time.Duration;
 import java.util.Iterator;
-import java.util.Objects;
 import java.util.UUID;
 import java.util.HashMap;
 
@@ -62,6 +61,7 @@ import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_ADMINISTRATORS_WILDC
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_BLOCK_DELETING_SERVICE_INTERVAL;
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_CLIENT_FAILOVER_MAX_ATTEMPTS_KEY;
 
+import static org.apache.hadoop.ozone.OzoneConsts.OM_KEY_PREFIX;
 import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_DEFAULT_BUCKET_LAYOUT;
 import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_KEY_DELETING_LIMIT_PER_TASK;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -402,9 +402,9 @@ public abstract class TestOzoneManagerHA {
     Iterator<? extends OzoneKey> iterator = ozoneBucket.listKeys("/");
     while (iterator.hasNext()) {
       OzoneKey ozoneKey = iterator.next();
-      if (Objects.equals(keyName, ozoneKey.getName())) {
+      if (!ozoneKey.getName().endsWith(OM_KEY_PREFIX)) {
         assertTrue(ozoneKey.isFile());
-      } else if (keyName.startsWith(ozoneKey.getName())) {
+      } else {
         assertFalse(ozoneKey.isFile());
       }
     }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerHA.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerHA.java
@@ -29,6 +29,7 @@ import org.apache.hadoop.ozone.client.BucketArgs;
 import org.apache.hadoop.ozone.client.ObjectStore;
 import org.apache.hadoop.ozone.client.OzoneBucket;
 import org.apache.hadoop.ozone.client.OzoneClient;
+import org.apache.hadoop.ozone.client.OzoneKey;
 import org.apache.hadoop.ozone.client.OzoneKeyDetails;
 import org.apache.hadoop.ozone.client.OzoneVolume;
 import org.apache.hadoop.ozone.client.VolumeArgs;
@@ -40,7 +41,6 @@ import org.apache.hadoop.ozone.client.rpc.RpcClient;
 import org.apache.hadoop.ozone.om.ha.HadoopRpcOMFailoverProxyProvider;
 import org.apache.hadoop.ozone.om.ratis.OzoneManagerRatisServerConfig;
 import org.apache.ozone.test.GenericTestUtils;
-import org.junit.Assert;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
@@ -49,6 +49,8 @@ import org.junit.jupiter.api.Timeout;
 import java.io.IOException;
 import java.net.ConnectException;
 import java.time.Duration;
+import java.util.Iterator;
+import java.util.Objects;
 import java.util.UUID;
 import java.util.HashMap;
 
@@ -62,7 +64,10 @@ import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_CLIENT_FAILOVER_MAX_
 
 import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_DEFAULT_BUCKET_LAYOUT;
 import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_KEY_DELETING_LIMIT_PER_TASK;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * Base class for Ozone Manager HA tests.
@@ -245,17 +250,17 @@ public abstract class TestOzoneManagerHA {
     objectStore.createVolume(volumeName, createVolumeArgs);
     OzoneVolume retVolumeinfo = objectStore.getVolume(volumeName);
 
-    Assert.assertTrue(retVolumeinfo.getName().equals(volumeName));
-    Assert.assertTrue(retVolumeinfo.getOwner().equals(userName));
-    Assert.assertTrue(retVolumeinfo.getAdmin().equals(adminName));
+    assertEquals(volumeName, retVolumeinfo.getName());
+    assertEquals(userName, retVolumeinfo.getOwner());
+    assertEquals(adminName, retVolumeinfo.getAdmin());
 
     String bucketName = UUID.randomUUID().toString();
     retVolumeinfo.createBucket(bucketName);
 
     OzoneBucket ozoneBucket = retVolumeinfo.getBucket(bucketName);
 
-    Assert.assertTrue(ozoneBucket.getName().equals(bucketName));
-    Assert.assertTrue(ozoneBucket.getVolumeName().equals(volumeName));
+    assertEquals(bucketName, ozoneBucket.getName());
+    assertEquals(volumeName, ozoneBucket.getVolumeName());
 
     return ozoneBucket;
   }
@@ -278,26 +283,24 @@ public abstract class TestOzoneManagerHA {
     objectStore.createVolume(linkedVolName, createVolumeArgs);
     OzoneVolume linkedVolumeInfo = objectStore.getVolume(linkedVolName);
 
-    Assert.assertTrue(linkedVolumeInfo.getName().equals(linkedVolName));
-    Assert.assertTrue(linkedVolumeInfo.getOwner().equals(userName));
-    Assert.assertTrue(linkedVolumeInfo.getAdmin().equals(adminName));
+    assertEquals(linkedVolName, linkedVolumeInfo.getName());
+    assertEquals(userName, linkedVolumeInfo.getOwner());
+    assertEquals(adminName, linkedVolumeInfo.getAdmin());
 
     String linkedBucketName = UUID.randomUUID().toString();
     linkedVolumeInfo.createBucket(linkedBucketName, createBucketArgs);
 
     OzoneBucket linkedBucket = linkedVolumeInfo.getBucket(linkedBucketName);
 
-    Assert.assertTrue(linkedBucket.getName().equals(linkedBucketName));
-    Assert.assertTrue(linkedBucket.getVolumeName().equals(linkedVolName));
-    Assert.assertTrue(linkedBucket.isLink());
+    assertEquals(linkedBucketName, linkedBucket.getName());
+    assertEquals(linkedVolName, linkedBucket.getVolumeName());
+    assertTrue(linkedBucket.isLink());
 
     return linkedBucket;
   }
 
   /**
    * Stop the current leader OM.
-   *
-   * @throws Exception
    */
   protected void stopLeaderOM() {
     //Stop the leader OM.
@@ -332,9 +335,9 @@ public abstract class TestOzoneManagerHA {
       OzoneVolume retVolumeinfo = objectStore.getVolume(volumeName);
 
       if (checkSuccess) {
-        Assert.assertTrue(retVolumeinfo.getName().equals(volumeName));
-        Assert.assertTrue(retVolumeinfo.getOwner().equals(userName));
-        Assert.assertTrue(retVolumeinfo.getAdmin().equals(adminName));
+        assertEquals(volumeName, retVolumeinfo.getName());
+        assertEquals(userName, retVolumeinfo.getOwner());
+        assertEquals(adminName, retVolumeinfo.getAdmin());
       } else {
         // Verify that the request failed
         fail("There is no quorum. Request should have failed");
@@ -383,16 +386,27 @@ public abstract class TestOzoneManagerHA {
 
     OzoneKeyDetails ozoneKeyDetails = ozoneBucket.getKey(keyName);
 
-    Assert.assertEquals(keyName, ozoneKeyDetails.getName());
-    Assert.assertEquals(ozoneBucket.getName(), ozoneKeyDetails.getBucketName());
-    Assert.assertEquals(ozoneBucket.getVolumeName(),
+    assertEquals(keyName, ozoneKeyDetails.getName());
+    assertEquals(ozoneBucket.getName(), ozoneKeyDetails.getBucketName());
+    assertEquals(ozoneBucket.getVolumeName(),
         ozoneKeyDetails.getVolumeName());
-    Assert.assertEquals(data.length(), ozoneKeyDetails.getDataSize());
+    assertEquals(data.length(), ozoneKeyDetails.getDataSize());
+    assertTrue(ozoneKeyDetails.isFile());
 
     try (OzoneInputStream ozoneInputStream = ozoneBucket.readKey(keyName)) {
       byte[] fileContent = new byte[data.getBytes(UTF_8).length];
       ozoneInputStream.read(fileContent);
-      Assert.assertEquals(data, new String(fileContent, UTF_8));
+      assertEquals(data, new String(fileContent, UTF_8));
+    }
+
+    Iterator<? extends OzoneKey> iterator = ozoneBucket.listKeys("/");
+    while (iterator.hasNext()) {
+      OzoneKey ozoneKey = iterator.next();
+      if (Objects.equals(keyName, ozoneKey.getName())) {
+        assertTrue(ozoneKey.isFile());
+      } else if (keyName.startsWith(ozoneKey.getName())) {
+        assertFalse(ozoneKey.isFile());
+      }
     }
   }
 
@@ -411,9 +425,9 @@ public abstract class TestOzoneManagerHA {
 
       OzoneVolume retVolumeinfo = getObjectStore().getVolume(volumeName);
 
-      Assert.assertTrue(retVolumeinfo.getName().equals(volumeName));
-      Assert.assertTrue(retVolumeinfo.getOwner().equals(userName));
-      Assert.assertTrue(retVolumeinfo.getAdmin().equals(adminName));
+      assertEquals(volumeName, retVolumeinfo.getName());
+      assertEquals(userName, retVolumeinfo.getOwner());
+      assertEquals(adminName, retVolumeinfo.getAdmin());
 
       String bucketName = UUID.randomUUID().toString();
       String keyName = UUID.randomUUID().toString();
@@ -421,8 +435,8 @@ public abstract class TestOzoneManagerHA {
 
       OzoneBucket ozoneBucket = retVolumeinfo.getBucket(bucketName);
 
-      Assert.assertTrue(ozoneBucket.getName().equals(bucketName));
-      Assert.assertTrue(ozoneBucket.getVolumeName().equals(volumeName));
+      assertEquals(bucketName, ozoneBucket.getName());
+      assertEquals(volumeName, ozoneBucket.getVolumeName());
 
       String value = "random data";
       OzoneOutputStream ozoneOutputStream = ozoneBucket.createKey(keyName,
@@ -434,7 +448,7 @@ public abstract class TestOzoneManagerHA {
       try (OzoneInputStream ozoneInputStream = ozoneBucket.readKey(keyName)) {
         byte[] fileContent = new byte[value.getBytes(UTF_8).length];
         ozoneInputStream.read(fileContent);
-        Assert.assertEquals(value, new String(fileContent, UTF_8));
+        assertEquals(value, new String(fileContent, UTF_8));
       }
 
     } catch (IOException e) {

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyRequest.java
@@ -686,7 +686,8 @@ public abstract class OMKeyRequest extends OMClientRequest {
    * @return OmKeyInfo
    */
   @SuppressWarnings("parameterNumber")
-  protected OmKeyInfo createFileInfo(@Nonnull KeyArgs keyArgs,
+  protected OmKeyInfo createFileInfo(
+      @Nonnull KeyArgs keyArgs,
       @Nonnull List<OmKeyLocationInfo> locations,
       @Nonnull ReplicationConfig replicationConfig,
       long size,
@@ -694,22 +695,24 @@ public abstract class OMKeyRequest extends OMClientRequest {
       @Nonnull PrefixManager prefixManager,
       @Nullable OmBucketInfo omBucketInfo,
       OMFileRequest.OMPathInfoWithFSO omPathInfo,
-      long transactionLogIndex, long objectID) {
+      long transactionLogIndex, long objectID
+  ) {
     OmKeyInfo.Builder builder = new OmKeyInfo.Builder();
     builder.setVolumeName(keyArgs.getVolumeName())
-            .setBucketName(keyArgs.getBucketName())
-            .setKeyName(keyArgs.getKeyName())
-            .setOmKeyLocationInfos(Collections.singletonList(
-                    new OmKeyLocationInfoGroup(0, locations)))
-            .setCreationTime(keyArgs.getModificationTime())
-            .setModificationTime(keyArgs.getModificationTime())
-            .setDataSize(size)
-            .setReplicationConfig(replicationConfig)
-            .setFileEncryptionInfo(encInfo)
-            .setAcls(getAclsForKey(keyArgs, omBucketInfo, prefixManager))
-            .addAllMetadata(KeyValueUtil.getFromProtobuf(
-                    keyArgs.getMetadataList()))
-            .setUpdateID(transactionLogIndex);
+        .setBucketName(keyArgs.getBucketName())
+        .setKeyName(keyArgs.getKeyName())
+        .setOmKeyLocationInfos(Collections.singletonList(
+            new OmKeyLocationInfoGroup(0, locations)))
+        .setCreationTime(keyArgs.getModificationTime())
+        .setModificationTime(keyArgs.getModificationTime())
+        .setDataSize(size)
+        .setReplicationConfig(replicationConfig)
+        .setFileEncryptionInfo(encInfo)
+        .setAcls(getAclsForKey(keyArgs, omBucketInfo, prefixManager))
+        .addAllMetadata(KeyValueUtil.getFromProtobuf(
+            keyArgs.getMetadataList()))
+        .setUpdateID(transactionLogIndex)
+        .setFile(true);
     if (omPathInfo != null) {
       // FileTable metadata format
       objectID = omPathInfo.getLeafNodeObjectId();


### PR DESCRIPTION
## What changes were proposed in this pull request?
As part of change #3912 and #4448, `isFile` parameter was added to `OmKeyInfo` and `OzoneKey` but it was not set when new create file gets created it doesn't exist [here](https://github.com/apache/ozone/blob/f2ef43b638e2df94af2a8e30fcef3849697195dc/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyRequest.java#L689).

This change is to set `isFile` on createFile code path so that it can properly identify if key is file or dir.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-9072

## How was this patch tested?
Updated unit tests.
