### PR TITLE
HDDS-9074. Ozone Manager terminated in CreateKey request due to bucket not found

### DIFF
--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/OzoneManagerStateMachine.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/OzoneManagerStateMachine.java
@@ -41,6 +41,7 @@ import org.apache.hadoop.ozone.om.OzoneManager;
 import org.apache.hadoop.ozone.om.OzoneManagerPrepareState;
 import org.apache.hadoop.ozone.om.exceptions.OMException;
 import org.apache.hadoop.ozone.om.helpers.OMRatisHelper;
+import org.apache.hadoop.ozone.om.ratis.utils.OzoneManagerRatisUtils;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos
     .OMRequest;
@@ -566,12 +567,28 @@ public class OzoneManagerStateMachine extends BaseStateMachine {
     try {
       return handler.handleWriteRequest(request,
           trxLogIndex).getOMResponse();
+    } catch (IOException e) {
+      LOG.warn("Failed to write, Exception occurred ", e);
+      return createErrorResponse(request, e);
     } catch (Throwable e) {
       // For any Runtime exceptions, terminate OM.
       String errorMessage = "Request " + request + " failed with exception";
       ExitUtils.terminate(1, errorMessage, e, LOG);
     }
     return null;
+  }
+
+  private OMResponse createErrorResponse(
+      OMRequest omRequest, IOException exception) {
+    OMResponse.Builder omResponse = OMResponse.newBuilder()
+        .setStatus(OzoneManagerRatisUtils.exceptionToResponseStatus(exception))
+        .setCmdType(omRequest.getCmdType())
+        .setTraceID(omRequest.getTraceID())
+        .setSuccess(false);
+    if (exception.getMessage() != null) {
+      omResponse.setMessage(exception.getMessage());
+    }
+    return omResponse.build();
   }
 
   /**


### PR DESCRIPTION
## What changes were proposed in this pull request?

Currently in case of IOException also OzoneManager terminates and not able to recover. In this PR handling IOException in runCommand in OzoneManagerStateMachine so that ozone manager runs normally. 
Detail mentioned in below "patch tested" step when this can happen.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-9074

## How was this patch tested?
Verified locally using below steps:

1. Create bucket bucket1
2. Delete bucket bucket1 (Before Apply transaction) 
3. Create key key1 inside bucket1 (Pre execute) 
4. Delete bucket bucket1 (Apply transaction)
5. Key1 create(During apply transaction)
Calls `OzoneManagerRatisUtils.createClientRequest` which uses [getBucketLayout](https://github.com/apache/ozone/blob/e374aae82db1f39e666325d47fcd09a0392d0b70/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/BucketLayoutAwareOMKeyRequestFactory.java#L230)
Since bucket is already deleted, it throws [Bucket Not Found](https://github.com/apache/ozone/blob/e374aae82db1f39e666325d47fcd09a0392d0b70/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManagerUtils.java#L143)
Ozone manager [terminates](https://github.com/apache/ozone/blob/e374aae82db1f39e666325d47fcd09a0392d0b70/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/OzoneManagerStateMachine.java#L572) as it doesn't handle OMException.

After fix It fails normally and ozone manager doesn't stop, And returns error message to client.
