### PR TITLE
HDDS-9055. Datanode decommission Failed, Follower never received the command

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/protocol/DatanodeDetails.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/protocol/DatanodeDetails.java
@@ -90,8 +90,8 @@ public class DatanodeDetails extends NodeImpl implements
   private long setupTime;
   private String revision;
   private String buildDate;
-  private HddsProtos.NodeOperationalState persistedOpState;
-  private long persistedOpStateExpiryEpochSec = 0;
+  private volatile HddsProtos.NodeOperationalState persistedOpState;
+  private volatile long persistedOpStateExpiryEpochSec = 0;
   private int initialVersion;
   private int currentVersion;
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

- volatile keyword is added to fields persistedOpState and persistedOpStateExpiryEpochSec as its observed that DN on HB always sends IN_SERVICE state but SetNodeOperationalStateCommandHandler changes to DECOMMISSIONING. So seems after update also, this state is not returned.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-9055

## How was this patch tested?

- current Integration test cover impact test
- This is random failure, will be observed if occurs again
