### PR TITLE
HDDS-9081. Handling Netty back pressure when streaming containers for replication.

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/replication/CopyContainerResponseStream.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/replication/CopyContainerResponseStream.java
@@ -19,7 +19,7 @@ package org.apache.hadoop.ozone.container.replication;
 
 import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.CopyContainerResponseProto;
 import org.apache.ratis.thirdparty.com.google.protobuf.ByteString;
-import org.apache.ratis.thirdparty.io.grpc.stub.StreamObserver;
+import org.apache.ratis.thirdparty.io.grpc.stub.CallStreamObserver;
 
 /**
  * Output stream adapter for CopyContainerResponse.
@@ -28,7 +28,7 @@ class CopyContainerResponseStream
     extends GrpcOutputStream<CopyContainerResponseProto> {
 
   CopyContainerResponseStream(
-      StreamObserver<CopyContainerResponseProto> streamObserver,
+      CallStreamObserver<CopyContainerResponseProto> streamObserver,
       long containerId, int bufferSize) {
     super(streamObserver, containerId, bufferSize);
   }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/replication/GrpcContainerUploader.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/replication/GrpcContainerUploader.java
@@ -26,6 +26,7 @@ import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.SendContai
 import org.apache.hadoop.hdds.security.SecurityConfig;
 import org.apache.hadoop.hdds.security.x509.certificate.client.CertificateClient;
 import org.apache.hadoop.hdds.utils.IOUtils;
+import org.apache.ratis.thirdparty.io.grpc.stub.CallStreamObserver;
 import org.apache.ratis.thirdparty.io.grpc.stub.StreamObserver;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -60,8 +61,9 @@ public class GrpcContainerUploader implements ContainerUploader {
       StreamObserver<SendContainerRequest> requestStream = client.upload(
           new SendContainerResponseStreamObserver(containerId, target,
               callback));
-      return new SendContainerOutputStream(requestStream, containerId,
-          GrpcReplicationService.BUFFER_SIZE, compression) {
+      return new SendContainerOutputStream(
+          (CallStreamObserver<SendContainerRequest>) requestStream,
+          containerId, GrpcReplicationService.BUFFER_SIZE, compression) {
         @Override
         public void close() throws IOException {
           try {

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/replication/GrpcContainerUploader.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/replication/GrpcContainerUploader.java
@@ -58,12 +58,14 @@ public class GrpcContainerUploader implements ContainerUploader {
       throws IOException {
     GrpcReplicationClient client = createReplicationClient(target, compression);
     try {
-      StreamObserver<SendContainerRequest> requestStream = client.upload(
-          new SendContainerResponseStreamObserver(containerId, target,
-              callback));
-      return new SendContainerOutputStream(
-          (CallStreamObserver<SendContainerRequest>) requestStream,
-          containerId, GrpcReplicationService.BUFFER_SIZE, compression) {
+      // gRPC runtime always provides implementation of CallStreamObserver
+      // that allows flow control.
+      CallStreamObserver<SendContainerRequest> requestStream =
+          (CallStreamObserver<SendContainerRequest>) client.upload(
+              new SendContainerResponseStreamObserver(containerId, target,
+                  callback));
+      return new SendContainerOutputStream(requestStream, containerId,
+          GrpcReplicationService.BUFFER_SIZE, compression) {
         @Override
         public void close() throws IOException {
           try {

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/replication/GrpcReplicationService.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/replication/GrpcReplicationService.java
@@ -28,6 +28,7 @@ import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.SendContai
 import org.apache.hadoop.hdds.protocol.datanode.proto.IntraDatanodeProtocolServiceGrpc;
 
 import org.apache.hadoop.hdds.utils.IOUtils;
+import org.apache.ratis.thirdparty.io.grpc.stub.CallStreamObserver;
 import org.apache.ratis.thirdparty.io.grpc.stub.StreamObserver;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -64,7 +65,8 @@ public class GrpcReplicationService extends
     OutputStream outputStream = null;
     try {
       outputStream = new CopyContainerResponseStream(
-          responseObserver, containerID, BUFFER_SIZE);
+          (CallStreamObserver<CopyContainerResponseProto>) responseObserver,
+          containerID, BUFFER_SIZE);
       source.copyData(containerID, outputStream, compression);
     } catch (IOException e) {
       LOG.warn("Error streaming container {}", containerID, e);

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/replication/GrpcReplicationService.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/replication/GrpcReplicationService.java
@@ -65,6 +65,8 @@ public class GrpcReplicationService extends
     OutputStream outputStream = null;
     try {
       outputStream = new CopyContainerResponseStream(
+          // gRPC runtime always provides implementation of CallStreamObserver
+          // that allows flow control.
           (CallStreamObserver<CopyContainerResponseProto>) responseObserver,
           containerID, BUFFER_SIZE);
       source.copyData(containerID, outputStream, compression);

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/replication/ReplicationServer.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/replication/ReplicationServer.java
@@ -78,6 +78,8 @@ public class ReplicationServer {
 
     int replicationServerWorkers =
         replicationConfig.getReplicationMaxStreams();
+    LOG.info("Initializing replication server with thread count = {}",
+        replicationConfig.getReplicationMaxStreams());
     this.executor =
         new ThreadPoolExecutor(replicationServerWorkers,
             replicationServerWorkers,

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/replication/ReplicationSupervisor.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/replication/ReplicationSupervisor.java
@@ -152,6 +152,8 @@ public final class ReplicationSupervisor {
       }
 
       if (executor == null) {
+        LOG.info("Initializing replication supervisor with thread count = {}",
+            replicationConfig.getReplicationMaxStreams());
         ThreadPoolExecutor tpe = new ThreadPoolExecutor(
             replicationConfig.getReplicationMaxStreams(),
             replicationConfig.getReplicationMaxStreams(),

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/replication/SendContainerOutputStream.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/replication/SendContainerOutputStream.java
@@ -19,7 +19,7 @@ package org.apache.hadoop.ozone.container.replication;
 
 import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.SendContainerRequest;
 import org.apache.ratis.thirdparty.com.google.protobuf.ByteString;
-import org.apache.ratis.thirdparty.io.grpc.stub.StreamObserver;
+import org.apache.ratis.thirdparty.io.grpc.stub.CallStreamObserver;
 
 /**
  * Output stream adapter for SendContainerResponse.
@@ -29,7 +29,7 @@ class SendContainerOutputStream extends GrpcOutputStream<SendContainerRequest> {
   private final CopyContainerCompression compression;
 
   SendContainerOutputStream(
-      StreamObserver<SendContainerRequest> streamObserver,
+      CallStreamObserver<SendContainerRequest> streamObserver,
       long containerId, int bufferSize, CopyContainerCompression compression) {
     super(streamObserver, containerId, bufferSize);
     this.compression = compression;

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/replication/GrpcOutputStreamTest.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/replication/GrpcOutputStreamTest.java
@@ -18,7 +18,7 @@
 package org.apache.hadoop.ozone.container.replication;
 
 import org.apache.ratis.thirdparty.com.google.protobuf.ByteString;
-import org.apache.ratis.thirdparty.io.grpc.stub.StreamObserver;
+import org.apache.ratis.thirdparty.io.grpc.stub.CallStreamObserver;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -39,6 +39,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 /**
  * Tests for {@code GrpcOutputStream}.
@@ -53,7 +54,7 @@ abstract class GrpcOutputStreamTest<T> {
   private final Class<? extends T> clazz;
 
   @Mock
-  private StreamObserver<T> observer;
+  private CallStreamObserver<T> observer;
 
   private OutputStream subject;
 
@@ -64,6 +65,7 @@ abstract class GrpcOutputStreamTest<T> {
   @BeforeEach
   public void setUp() {
     subject = createSubject();
+    when(observer.isReady()).thenReturn(true);
   }
 
   protected abstract OutputStream createSubject();
@@ -228,7 +230,7 @@ abstract class GrpcOutputStreamTest<T> {
     return containerId;
   }
 
-  StreamObserver<T> getObserver() {
+  CallStreamObserver<T> getObserver() {
     return observer;
   }
 

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/replication/TestGrpcContainerUploader.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/replication/TestGrpcContainerUploader.java
@@ -23,6 +23,7 @@ import org.apache.hadoop.hdds.protocol.DatanodeDetails;
 import org.apache.hadoop.hdds.protocol.MockDatanodeDetails;
 import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.SendContainerRequest;
 import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.SendContainerResponse;
+import org.apache.ratis.thirdparty.io.grpc.stub.CallStreamObserver;
 import org.apache.ratis.thirdparty.io.grpc.stub.StreamObserver;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
@@ -136,7 +137,7 @@ class TestGrpcContainerUploader {
    * Empty implementation.
    */
   private static class NoopObserver
-      implements StreamObserver<SendContainerRequest> {
+      extends CallStreamObserver<SendContainerRequest> {
 
     @Override
     public void onNext(SendContainerRequest value) {
@@ -151,6 +152,27 @@ class TestGrpcContainerUploader {
     @Override
     public void onCompleted() {
       // override if needed
+    }
+
+    @Override
+    public boolean isReady() {
+      return true;
+    }
+
+    @Override
+    public void setOnReadyHandler(Runnable onReadyHandler) {
+    }
+
+    @Override
+    public void disableAutoInboundFlowControl() {
+    }
+
+    @Override
+    public void request(int count) {
+    }
+
+    @Override
+    public void setMessageCompression(boolean enable) {
     }
   }
 }

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/replication/TestGrpcReplicationService.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/replication/TestGrpcReplicationService.java
@@ -19,7 +19,7 @@ package org.apache.hadoop.ozone.container.replication;
 
 import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.CopyContainerRequestProto;
 import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.CopyContainerResponseProto;
-import org.apache.ratis.thirdparty.io.grpc.stub.StreamObserver;
+import org.apache.ratis.thirdparty.io.grpc.stub.CallStreamObserver;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
@@ -27,6 +27,7 @@ import java.io.OutputStream;
 
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 /**
  * Tests {@link GrpcReplicationService}.
@@ -57,8 +58,9 @@ class TestGrpcReplicationService {
         .setReadOffset(0)
         .setLen(123)
         .build();
-    StreamObserver<CopyContainerResponseProto> observer =
-        mock(StreamObserver.class);
+    CallStreamObserver<CopyContainerResponseProto> observer =
+        mock(CallStreamObserver.class);
+    when(observer.isReady()).thenReturn(true);
 
     // WHEN
     subject.download(request, observer);


### PR DESCRIPTION
## What changes were proposed in this pull request?
Replication sends messages faster than the network/receiver can consume. This results in many messages being queued by Netty and the amount allocated memory surges and results in OOME. 

The change in this PR eliminates messages backlog and memory surge for both pull and push, thus allowing multiple concurrent replications.

It can be optimized to fully utilize manual control to avoid unnecessary delay (or sleep), following these [examples](https://github.com/grpc/grpc-java/tree/v1.30.2/examples/src/main/java/io/grpc/examples/manualflowcontrol). I don't have data to say if it's worth it yet.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-9081

## How was this patch tested?

Tested locally and verified it eliminates direct memory surges during replication.
