### PR TITLE
HDDS-9075. QUASI_CLOSED Replica with incorrect sequenceID should be deleted by SCM.

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/RatisOverReplicationHandler.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/RatisOverReplicationHandler.java
@@ -83,8 +83,8 @@ public class RatisOverReplicationHandler
 
     // We are going to check for over replication, so we should filter out any
     // replicas that are not in a HEALTHY state. This is because a replica can
-    // be healthy, stale or dead. If it is dead is will be quickly removed from
-    // scm. If it is state, there is a good chance the DN is offline and the
+    // be healthy, stale or dead. If it is dead it will be quickly removed from
+    // scm. If it is stale, there is a good chance the DN is offline and the
     // replica will go away soon. So, if we have a container that is over
     // replicated with a HEALTHY and STALE replica, and we decide to delete the
     // HEALTHY one, and then the STALE ones goes away, we will lose them both.

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/RatisUnderReplicationHandler.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/RatisUnderReplicationHandler.java
@@ -215,12 +215,13 @@ public class RatisUnderReplicationHandler
       }
     }
 
-    Predicate<ContainerReplica> predicate;
+    Predicate<ContainerReplica> predicate =
+        replica -> replica.getState() == State.CLOSED ||
+        replica.getState() == State.QUASI_CLOSED;
+
     if (replicaCount.getHealthyReplicaCount() == 0) {
-      predicate = replica -> replica.getState() == State.UNHEALTHY;
-    } else {
-      predicate = replica -> replica.getState() == State.CLOSED ||
-          replica.getState() == State.QUASI_CLOSED;
+      predicate = predicate.or(
+          replica -> replica.getState() == State.UNHEALTHY);
     }
 
     /*

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/ReplicationTestUtil.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/ReplicationTestUtil.java
@@ -199,6 +199,17 @@ public final class ReplicationTestUtil {
 
   public static ContainerInfo createContainerInfo(
       ReplicationConfig replicationConfig, long containerID,
+      HddsProtos.LifeCycleState containerState, long sequenceID) {
+    return TestContainerInfo.newBuilderForTest()
+        .setContainerID(containerID)
+        .setReplicationConfig(replicationConfig)
+        .setState(containerState)
+        .setSequenceId(sequenceID)
+        .build();
+  }
+
+  public static ContainerInfo createContainerInfo(
+      ReplicationConfig replicationConfig, long containerID,
       HddsProtos.LifeCycleState containerState, long keyCount, long bytesUsed) {
     return TestContainerInfo.newBuilderForTest()
         .setContainerID(containerID)


### PR DESCRIPTION
## What changes were proposed in this pull request?

When a Container is in CLOSED state with one of its replicas in QUASI_CLOSED state and has incorrect sequenceID, that replica should be deleted by SCM as it's inconsistent replica.

## What is the link to the Apache JIRA
[HDDS-9075](https://issues.apache.org/jira/browse/HDDS-9075)

## How was this patch tested?
Added unit test to verify if SCM is re-replicating the container when there is an inconsistent quasi_closed container and then deleting the inconsistent replica when the container is in CLOSED state.
