### PR TITLE
HDDS-9090. NullPointerException thrown by ReplicationManagerMetrics because of the order of initialization

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ReplicationManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ReplicationManager.java
@@ -243,6 +243,7 @@ public class ReplicationManager implements SCMService {
     this.ratisReplicationCheckHandler =
         new RatisReplicationCheckHandler(ratisContainerPlacement);
     this.nodeManager = nodeManager;
+    this.metrics = ReplicationManagerMetrics.create(this);
 
     ecUnderReplicationHandler = new ECUnderReplicationHandler(
         ecContainerPlacement, conf, this);
@@ -285,7 +286,6 @@ public class ReplicationManager implements SCMService {
     if (!isRunning()) {
       LOG.info("Starting Replication Monitor Thread.");
       running = true;
-      metrics = ReplicationManagerMetrics.create(this);
       if (rmConf.isLegacyEnabled()) {
         legacyReplicationManager.setMetrics(metrics);
       }


### PR DESCRIPTION
## What changes were proposed in this pull request?

`ECUnderReplicationHandler` is initialized before initializing `ReplicationManagerMetrics`, So whenever any ReplicationManagerMetrics is used, it throws NPE. The behavior is same for all these other classes and will throw NPEs,
`ECOverReplicationHandler, ECMisReplicationHandler, RatisUnderReplicationHandler, RatisMisReplicationHandler`

```
  ECUnderReplicationHandler(final PlacementPolicy containerPlacement,
      final ConfigurationSource conf, ReplicationManager replicationManager) {
    this.containerPlacement = containerPlacement;
    this.currentContainerSize = (long) conf
        .getStorageSize(ScmConfigKeys.OZONE_SCM_CONTAINER_SIZE,
            ScmConfigKeys.OZONE_SCM_CONTAINER_SIZE_DEFAULT, StorageUnit.BYTES);
    this.replicationManager = replicationManager;
    this.metrics = replicationManager.getMetrics(); --> still null because replication manager metrics is not initialized yet.
 }
```

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-9090

## How was this patch tested?

Manually tested by adding a line and verified it threw NPE.
```
  ECUnderReplicationHandler(final PlacementPolicy containerPlacement,
      final ConfigurationSource conf, ReplicationManager replicationManager) {
    this.containerPlacement = containerPlacement;
    this.currentContainerSize = (long) conf
        .getStorageSize(ScmConfigKeys.OZONE_SCM_CONTAINER_SIZE,
            ScmConfigKeys.OZONE_SCM_CONTAINER_SIZE_DEFAULT, StorageUnit.BYTES);
    this.replicationManager = replicationManager;
    this.metrics = replicationManager.getMetrics();
    this.metrics.getEcPartialReconstructionNoneOverloadedTotal(); ---> Added line manually just to check NPE
}
java.lang.NullPointerException
	at org.apache.hadoop.hdds.scm.container.replication.ECUnderReplicationHandler.<init>(ECUnderReplicationHandler.java:78)
	at org.apache.hadoop.hdds.scm.container.replication.ReplicationManager.<init>(ReplicationManager.java:247)
	at org.apache.hadoop.hdds.scm.container.replication.TestReplicationManager$1.<init>(TestReplicationManager.java:177)
	at 
```
<img width="754" alt="Screen Shot 2023-07-27 at 10 58 57 AM" src="https://github.com/apache/ozone/assets/28673916/e032a999-c01c-4bb9-9904-d6cc15619853">

Even after metrics is initialized, the metrics inside other classes are null
