### PR TITLE
HDDS-9093. Appended tailing slash while constructing the bucket key for SSTFilteringService

### DIFF
--- a/hadoop-hdds/rocksdb-checkpoint-differ/src/main/java/org/apache/ozone/rocksdiff/RocksDiffUtils.java
+++ b/hadoop-hdds/rocksdb-checkpoint-differ/src/main/java/org/apache/ozone/rocksdiff/RocksDiffUtils.java
@@ -66,6 +66,7 @@ public final class RocksDiffUtils {
     if (StringUtils.isNotBlank(bucket)) {
       builder.append(OM_KEY_PREFIX).append(bucket);
     }
+    builder.append(OM_KEY_PREFIX);
     return builder.toString();
   }
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/SstFilteringService.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/SstFilteringService.java
@@ -89,13 +89,14 @@ public class SstFilteringService extends BackgroundService
 
   private AtomicBoolean running;
 
-  private BooleanTriFunction<String, String, String, Boolean> filterFunction =
-      (first, last, prefix) -> {
-        String firstBucketKey = RocksDiffUtils.constructBucketKey(first);
-        String lastBucketKey = RocksDiffUtils.constructBucketKey(last);
-        return RocksDiffUtils
-            .isKeyWithPrefixPresent(prefix, firstBucketKey, lastBucketKey);
-      };
+  static final BooleanTriFunction<String, String, String, Boolean>
+      FILTER_FUNCTION =
+          (first, last, prefix) -> {
+            String firstBucketKey = RocksDiffUtils.constructBucketKey(first);
+            String lastBucketKey = RocksDiffUtils.constructBucketKey(last);
+            return RocksDiffUtils
+                .isKeyWithPrefixPresent(prefix, firstBucketKey, lastBucketKey);
+          };
 
   public SstFilteringService(long interval, TimeUnit unit, long serviceTimeout,
       OzoneManager ozoneManager, OzoneConfiguration configuration) {
@@ -178,7 +179,7 @@ public class SstFilteringService extends BackgroundService
             RocksDatabase db = rdbStore.getDb();
             try (BootstrapStateHandler.Lock lock =
                 getBootstrapStateLock().lock()) {
-              db.deleteFilesNotMatchingPrefix(prefixPairs, filterFunction);
+              db.deleteFilesNotMatchingPrefix(prefixPairs, FILTER_FUNCTION);
             }
           }
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/SstFilteringService.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/SstFilteringService.java
@@ -89,6 +89,9 @@ public class SstFilteringService extends BackgroundService
 
   private AtomicBoolean running;
 
+  // Note: This filter only works till snapshots are readable only.
+  // In the future, if snapshots are changed to writable as well,
+  // this will need to be revisited.
   static final BooleanTriFunction<String, String, String, Boolean>
       FILTER_FUNCTION =
           (first, last, prefix) -> {

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestSstFilteringService.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestSstFilteringService.java
@@ -317,12 +317,18 @@ public class TestSstFilteringService {
         "/vol1/bucket1/key1",
         "/vol1/bucket1/key1",
         "/vol1/bucket1/"));
-
+    Assert.assertTrue(SstFilteringService.FILTER_FUNCTION.apply(
+        "/vol1/bucket1/key1",
+        "/vol1/bucket5/key1",
+        "/vol1/bucket3/"));
+    Assert.assertFalse(SstFilteringService.FILTER_FUNCTION.apply(
+        "/vol1/bucket1/key1",
+        "/vol1/bucket4/key9",
+        "/vol1/bucket5/"));
     Assert.assertFalse(SstFilteringService.FILTER_FUNCTION.apply(
         "/vol1/bucket1/key1",
         "/vol1/bucket1/key1",
         "/vol1/bucket2/"));
-
     Assert.assertFalse(SstFilteringService.FILTER_FUNCTION.apply(
         "/vol1/bucket1/key1",
         "/vol1/bucket1/key1",

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestSstFilteringService.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestSstFilteringService.java
@@ -104,7 +104,9 @@ public class TestSstFilteringService {
 
   @After
   public void cleanup() throws Exception {
-    om.stop();
+    if (om != null) {
+      om.stop();
+    }
   }
 
   /**
@@ -309,4 +311,21 @@ public class TestSstFilteringService {
     return keyArg;
   }
 
+  @Test
+  public void testFilterFunction() {
+    Assert.assertTrue(SstFilteringService.FILTER_FUNCTION.apply(
+        "/vol1/bucket1/key1",
+        "/vol1/bucket1/key1",
+        "/vol1/bucket1/"));
+
+    Assert.assertFalse(SstFilteringService.FILTER_FUNCTION.apply(
+        "/vol1/bucket1/key1",
+        "/vol1/bucket1/key1",
+        "/vol1/bucket2/"));
+
+    Assert.assertFalse(SstFilteringService.FILTER_FUNCTION.apply(
+        "/vol1/bucket1/key1",
+        "/vol1/bucket1/key1",
+        "/vol1/bucket/"));
+  }
 }


### PR DESCRIPTION

## What changes were proposed in this pull request?
In [PR-5008](https://github.com/apache/ozone/pull/5008/files#diff-b9ad374a12f870c302a0cca808071a5da620f87b42595246e9e604633b228dacR221), tailing slash was appended in `filterPrefix` and `filterPrefixFSO` so that we don't delete wrong SST files.
For example, SST filtering service is running for a snapshot taken on vol1/bucket, if tailing slash is not appended, it might delete the SST files belongs to vol1/bucket1, vol1/bucket2 or anything with `bucket` prefix.
The above change caused a regression, because prefix had tailing `/` but [firstBucketKey](https://github.com/apache/ozone/blob/7a19afa71401e356cd86a99648e94278ea2850c8/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/SstFilteringService.java#L94) and [lastBucketKey](https://github.com/apache/ozone/blob/7a19afa71401e356cd86a99648e94278ea2850c8/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/SstFilteringService.java#L95) didn't have it.

This change is to append the tailing `/` on the `firstBucketKey` and `lastBucketKey`.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-9093

## How was this patch tested?
In the interest of time, just added a unit test which checks `FILTER_FUNCTION` is correct.

Will add end to end test while this is in review or as separate PR.