### PR TITLE
HDDS-9097. Add openFileTable in CleanupTableInfo of OMOpenKeysDeleteResponse

### DIFF
--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/key/OMOpenKeysDeleteResponse.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/key/OMOpenKeysDeleteResponse.java
@@ -31,13 +31,15 @@ import java.util.Map;
 
 import static org.apache.hadoop.ozone.om.OmMetadataManagerImpl.BUCKET_TABLE;
 import static org.apache.hadoop.ozone.om.OmMetadataManagerImpl.DELETED_TABLE;
+import static org.apache.hadoop.ozone.om.OmMetadataManagerImpl.OPEN_FILE_TABLE;
 import static org.apache.hadoop.ozone.om.OmMetadataManagerImpl.OPEN_KEY_TABLE;
 
 /**
  * Handles responses to move open keys from the open key table to the delete
  * table. Modifies the open key table and delete table databases.
  */
-@CleanupTableInfo(cleanupTables = {OPEN_KEY_TABLE, DELETED_TABLE, BUCKET_TABLE})
+@CleanupTableInfo(cleanupTables = {OPEN_KEY_TABLE, OPEN_FILE_TABLE,
+    DELETED_TABLE, BUCKET_TABLE})
 public class OMOpenKeysDeleteResponse extends AbstractOMKeyDeleteResponse {
 
   private Map<String, OmKeyInfo> keysToDelete;


### PR DESCRIPTION
## What changes were proposed in this pull request?

OMOpenKeysDeleteResponse deletes both from openKeyTable and openFileTable depending on the bucketLayout. This patch adds openFileTable as the list of cleanupTables.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-9097

## How was this patch tested?

Existing CI.