### PR TITLE
HDDS-9096. Add OM performance metrics for listKeys operation

### DIFF
--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OMPerformanceMetrics.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OMPerformanceMetrics.java
@@ -150,7 +150,7 @@ public class OMPerformanceMetrics {
     checkAccessLatencyNs.add(latencyInNs);
   }
 
-  public MutableRate getListKeysLatencyNs() {
-    return listKeysLatencyNs;
+  public void addListKeysLatencyNs(long latencyInNs) {
+    listKeysLatencyNs.add(latencyInNs);
   }
 }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OMPerformanceMetrics.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OMPerformanceMetrics.java
@@ -86,6 +86,9 @@ public class OMPerformanceMetrics {
   @Metric(about = "checkAccess latency in nanoseconds")
   private MutableRate checkAccessLatencyNs;
 
+  @Metric(about = "listKeys latency in nanoseconds")
+  private MutableRate listKeysLatencyNs;
+
   public void addLookupLatency(long latencyInNs) {
     lookupLatencyNs.add(latencyInNs);
   }
@@ -145,5 +148,9 @@ public class OMPerformanceMetrics {
 
   public void setCheckAccessLatencyNs(long latencyInNs) {
     checkAccessLatencyNs.add(latencyInNs);
+  }
+
+  public MutableRate getListKeysLatencyNs() {
+    return listKeysLatencyNs;
   }
 }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmMetadataReader.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmMetadataReader.java
@@ -323,8 +323,11 @@ public class OmMetadataReader implements IOmMetadataReader, Auditor {
             bucket.realVolume(), bucket.realBucket(), keyPrefix);
       }
       metrics.incNumKeyLists();
-      return keyManager.listKeys(bucket.realVolume(), bucket.realBucket(),
-          startKey, keyPrefix, maxKeys);
+      List<OmKeyInfo> omKeyInfoList =
+          captureLatencyNs(perfMetrics.getListKeysLatencyNs(),
+              () -> keyManager.listKeys(bucket.realVolume(),
+                  bucket.realBucket(), startKey, keyPrefix, maxKeys));
+      return omKeyInfoList;
     } catch (IOException ex) {
       metrics.incNumKeyListFails();
       auditSuccess = false;


### PR DESCRIPTION
## What changes were proposed in this pull request?

Introduce a new OM performance metric for capturing the latency of the listKeys operation. 
This metric should help in benchmarking the listKeys performance and in identifying performance bottlenecks (if any).

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-9096

## How was this patch tested?

The patch has been tested over a cluster that has Ozone services running to see what the metric looks like. 
A sample screenshot of the Prometheus UI has been attached (for reference) capturing `om_performance_metrics_list_keys_latency_ns_avg_time` (in nanoseconds):

![listKeys_latency](https://github.com/apache/ozone/assets/46785609/e599e6e1-bba2-42e1-8bbb-70168f2395ee)
