### PR TITLE
HDDS-9101. Recon - Overview Page shows incorrect count of keys and buckets.

### DIFF
--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/tasks/OmTableInsightTask.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/tasks/OmTableInsightTask.java
@@ -489,7 +489,7 @@ public class OmTableInsightTask implements ReconOmTask {
   }
 
   public static String getTableCountKeyFromTable(String tableName) {
-    return tableName + "TableCount";
+    return tableName + "Count";
   }
 
   public static String getReplicatedSizeKeyFromTable(String tableName) {

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/api/TestOmDBInsightEndPoint.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/api/TestOmDBInsightEndPoint.java
@@ -238,6 +238,8 @@ public class TestOmDBInsightEndPoint extends AbstractReconSqlDBTest {
     Map<String, Long> summary = keyInsightInfoResp.getKeysSummary();
     // Assert that the key prefix format is accepted in the global stats
     Assertions.assertEquals(6L, summary.get("totalOpenKeys"));
+    Assertions.assertEquals(300L, summary.get("totalReplicatedDataSize"));
+    Assertions.assertEquals(100L, summary.get("totalUnreplicatedDataSize"));
 
     // Delete the previous records and Update the new value for valid key prefix
     statsDao.deleteById("openKeyTable" + "Count",

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/api/TestOmDBInsightEndPoint.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/api/TestOmDBInsightEndPoint.java
@@ -217,8 +217,18 @@ public class TestOmDBInsightEndPoint extends AbstractReconSqlDBTest {
     GlobalStatsDao statsDao = omdbInsightEndpoint.getDao();
 
     // Insert valid key count with valid key prefix
-    insertGlobalStatsRecords(statsDao, now, "openKeyTable" + "Count", 3L);
-    insertGlobalStatsRecords(statsDao, now, "openFileTable" + "Count", 3L);
+    insertGlobalStatsRecords(statsDao, now,
+        "openKeyTable" + "Count", 3L);
+    insertGlobalStatsRecords(statsDao, now,
+        "openFileTable" + "Count", 3L);
+    insertGlobalStatsRecords(statsDao, now,
+        "openKeyTable" + "ReplicatedDataSize", 150L);
+    insertGlobalStatsRecords(statsDao, now,
+        "openFileTable" + "ReplicatedDataSize", 150L);
+    insertGlobalStatsRecords(statsDao, now,
+        "openKeyTable" + "UnReplicatedDataSize", 50L);
+    insertGlobalStatsRecords(statsDao, now,
+        "openFileTable" + "UnReplicatedDataSize", 50L);
 
     Response openKeyInfoResp =
         omdbInsightEndpoint.getOpenKeyInfo(-1, "", true, true);
@@ -229,15 +239,19 @@ public class TestOmDBInsightEndPoint extends AbstractReconSqlDBTest {
     // Assert that the key prefix format is accepted in the global stats
     Assertions.assertEquals(6L, summary.get("totalOpenKeys"));
 
-    // Delete the previous records and Update the new value for valid key count prefix
-    statsDao.deleteById(
-        "openKeyTable" + "Count",
-        "openFileTable" + "Count"
-    );
+    // Delete the previous records and Update the new value for valid key prefix
+    statsDao.deleteById("openKeyTable" + "Count",
+        "openFileTable" + "Count",
+        "openKeyTable" + "ReplicatedDataSize",
+        "openFileTable" + "ReplicatedDataSize",
+        "openKeyTable" + "UnReplicatedDataSize",
+        "openFileTable" + "UnReplicatedDataSize");
 
     // Insert new record for a key with invalid prefix
-    insertGlobalStatsRecords(statsDao, now, "openKeyTable" + "InvalidPrefix", 3L);
-    insertGlobalStatsRecords(statsDao, now, "openFileTable" + "InvalidPrefix", 3L);
+    insertGlobalStatsRecords(statsDao, now, "openKeyTable" + "InvalidPrefix",
+        3L);
+    insertGlobalStatsRecords(statsDao, now, "openFileTable" + "InvalidPrefix",
+        3L);
 
     openKeyInfoResp =
         omdbInsightEndpoint.getOpenKeyInfo(-1, "", true, true);
@@ -247,6 +261,8 @@ public class TestOmDBInsightEndPoint extends AbstractReconSqlDBTest {
     summary = keyInsightInfoResp.getKeysSummary();
     // Assert that the key format is not accepted in the global stats
     Assertions.assertEquals(0L, summary.get("totalOpenKeys"));
+    Assertions.assertEquals(0L, summary.get("totalReplicatedDataSize"));
+    Assertions.assertEquals(0L, summary.get("totalUnreplicatedDataSize"));
   }
 
   @Test
@@ -295,7 +311,9 @@ public class TestOmDBInsightEndPoint extends AbstractReconSqlDBTest {
     Assertions.assertEquals(3L, summary.get("totalDeletedKeys"));
   }
 
-  private void insertGlobalStatsRecords(GlobalStatsDao statsDao, Timestamp timestamp, String key, long value) {
+  private void insertGlobalStatsRecords(GlobalStatsDao statsDao,
+                                        Timestamp timestamp, String key,
+                                        long value) {
     GlobalStats newRecord = new GlobalStats(key, value, timestamp);
     statsDao.insert(newRecord);
   }


### PR DESCRIPTION
## What changes were proposed in this pull request?

After upgrading Ozone to a newer version, Recon faces compatibility issues while reading data from the `GlobalStats` table, that keeps a count of total records in every OM table and Size related metrics for certain OM tables. 
The problem lies in the transformation of data values stored in the GlobalStats table between the old and new versions. The previous data format used a suffix "**Count**" for key strings, while the current format employs the suffix "**TableCount**." As a result, Recon is unable to interpret the data properly.
A simple fix for this would be to either add a handler that gets triggered upon recon starting, or just change the prefix back to "Count".

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-9101?filter=-1
## How was this patch tested?

Ran Existing UT's and also added new ones
