### PR TITLE
HDDS-9105. [Ozone-Streaming] Checks if the stream container command is read only or not

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/HddsUtils.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/HddsUtils.java
@@ -446,6 +446,8 @@ public final class HddsUtils {
     case DeleteBlock:
     case PutBlock:
     case PutSmallFile:
+    case StreamInit:
+    case StreamWrite:
     default:
       return false;
     }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Checks if the stream container command is read only or not.

Now there is no problem, because streamInit and streamWrite happen to be non-read-only (the default).But we'd better specify the value.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-9105
