### PR TITLE
HDDS-9080. om roles CLI should provide Json output option

### DIFF
--- a/hadoop-ozone/dist/src/main/smoketest/omha/om-roles.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/omha/om-roles.robot
@@ -1,0 +1,30 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+*** Settings ***
+Documentation       Smoke test for listing om roles.
+Resource            ../commonlib.robot
+Test Timeout        5 minutes
+Test Setup          Run Keyword if    '${SECURITY_ENABLED}' == 'true'    Kinit test user     testuser     testuser.keytab
+
+*** Test Cases ***
+List om roles
+    ${output} =         Execute          ozone admin om roles --service-id=omservice
+                        Should Match Regexp   ${output}  [om (: LEADER|)]
+
+List om roles as JSON
+    ${output} =         Execute          ozone admin om roles --service-id=omservice --json
+    ${leader} =         Execute          echo '${output}' | jq -r '.[] | select(.serverRole == "LEADER")'
+                        Should Not Be Equal       ${leader}       ${EMPTY}

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/admin/om/GetServiceRolesSubcommand.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/admin/om/GetServiceRolesSubcommand.java
@@ -20,13 +20,18 @@ package org.apache.hadoop.ozone.admin.om;
 
 import org.apache.hadoop.hdds.cli.HddsVersionProvider;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
+import org.apache.hadoop.hdds.server.JsonUtils;
 import org.apache.hadoop.ozone.client.OzoneClientException;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMRoleInfo;
 import org.apache.hadoop.ozone.om.protocol.OzoneManagerProtocol;
 import org.apache.hadoop.ozone.om.helpers.ServiceInfo;
 import picocli.CommandLine;
 
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.Callable;
 
 /**
@@ -47,13 +52,22 @@ public class GetServiceRolesSubcommand implements Callable<Void> {
       required = true)
   private String omServiceId;
 
+  @CommandLine.Option(names = { "--json" },
+      defaultValue = "false",
+      description = "Format output as JSON")
+  private boolean json;
+
   private OzoneManagerProtocol ozoneManagerClient;
 
   @Override
   public Void call() throws Exception {
     try {
       ozoneManagerClient =  parent.createOmClient(omServiceId);
-      getOmServerRoles(ozoneManagerClient.getServiceList());
+      if (json) {
+        getOmServerRolesAsJson(ozoneManagerClient.getServiceList());
+      } else {
+        getOmServerRoles(ozoneManagerClient.getServiceList());
+      }
     } catch (OzoneClientException ex) {
       System.out.printf("Error: %s", ex.getMessage());
     } finally {
@@ -75,5 +89,24 @@ public class GetServiceRolesSubcommand implements Callable<Void> {
                 serviceInfo.getHostname() + ")");
       }
     }
+  }
+
+  private void getOmServerRolesAsJson(List<ServiceInfo> serviceList)
+      throws IOException {
+    List<Map<String, String>> omServiceList = new ArrayList<>();
+    for (ServiceInfo serviceInfo : serviceList) {
+      OMRoleInfo omRoleInfo = serviceInfo.getOmRoleInfo();
+      if (omRoleInfo != null &&
+          serviceInfo.getNodeType() == HddsProtos.NodeType.OM) {
+        Map<String, String> omService = new HashMap<>();
+        omService.put("nodeId", serviceInfo.getOmRoleInfo().getNodeId());
+        omService.put("serverRole",
+            serviceInfo.getOmRoleInfo().getServerRole());
+        omService.put("hostname", serviceInfo.getHostname());
+        omServiceList.add(omService);
+      }
+    }
+    System.out.print(
+        JsonUtils.toJsonStringWithDefaultPrettyPrinter(omServiceList));
   }
 }

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/admin/om/GetServiceRolesSubcommand.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/admin/om/GetServiceRolesSubcommand.java
@@ -103,7 +103,7 @@ public class GetServiceRolesSubcommand implements Callable<Void> {
             new HashMap<String, String>() {{
               put("serverRole", serviceInfo.getOmRoleInfo().getServerRole());
               put("hostname", serviceInfo.getHostname());
-        }});
+            }});
         omServiceList.add(omService);
       }
     }

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/admin/om/GetServiceRolesSubcommand.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/admin/om/GetServiceRolesSubcommand.java
@@ -84,8 +84,8 @@ public class GetServiceRolesSubcommand implements Callable<Void> {
       if (omRoleInfo != null &&
           serviceInfo.getNodeType() == HddsProtos.NodeType.OM) {
         System.out.println(
-            serviceInfo.getOmRoleInfo().getNodeId() + " : " +
-                serviceInfo.getOmRoleInfo().getServerRole() + " (" +
+            omRoleInfo.getNodeId() + " : " +
+                omRoleInfo.getServerRole() + " (" +
                 serviceInfo.getHostname() + ")");
       }
     }
@@ -99,9 +99,9 @@ public class GetServiceRolesSubcommand implements Callable<Void> {
       if (omRoleInfo != null &&
           serviceInfo.getNodeType() == HddsProtos.NodeType.OM) {
         Map<String, Map<String, String>> omService = new HashMap<>();
-        omService.put(serviceInfo.getOmRoleInfo().getNodeId(),
+        omService.put(omRoleInfo.getNodeId(),
             new HashMap<String, String>() {{
-              put("serverRole", serviceInfo.getOmRoleInfo().getServerRole());
+              put("serverRole", omRoleInfo.getServerRole());
               put("hostname", serviceInfo.getHostname());
             }});
         omServiceList.add(omService);

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/admin/om/GetServiceRolesSubcommand.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/admin/om/GetServiceRolesSubcommand.java
@@ -93,16 +93,17 @@ public class GetServiceRolesSubcommand implements Callable<Void> {
 
   private void getOmServerRolesAsJson(List<ServiceInfo> serviceList)
       throws IOException {
-    List<Map<String, String>> omServiceList = new ArrayList<>();
+    List<Map<String, Map<String, String>>> omServiceList = new ArrayList<>();
     for (ServiceInfo serviceInfo : serviceList) {
       OMRoleInfo omRoleInfo = serviceInfo.getOmRoleInfo();
       if (omRoleInfo != null &&
           serviceInfo.getNodeType() == HddsProtos.NodeType.OM) {
-        Map<String, String> omService = new HashMap<>();
-        omService.put("nodeId", serviceInfo.getOmRoleInfo().getNodeId());
-        omService.put("serverRole",
-            serviceInfo.getOmRoleInfo().getServerRole());
-        omService.put("hostname", serviceInfo.getHostname());
+        Map<String, Map<String, String>> omService = new HashMap<>();
+        omService.put(serviceInfo.getOmRoleInfo().getNodeId(),
+            new HashMap<String, String>() {{
+              put("serverRole", serviceInfo.getOmRoleInfo().getServerRole());
+              put("hostname", serviceInfo.getHostname());
+        }});
         omServiceList.add(omService);
       }
     }

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/admin/om/GetServiceRolesSubcommand.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/admin/om/GetServiceRolesSubcommand.java
@@ -64,9 +64,9 @@ public class GetServiceRolesSubcommand implements Callable<Void> {
     try {
       ozoneManagerClient =  parent.createOmClient(omServiceId);
       if (json) {
-        getOmServerRolesAsJson(ozoneManagerClient.getServiceList());
+        printOmServerRolesAsJson(ozoneManagerClient.getServiceList());
       } else {
-        getOmServerRoles(ozoneManagerClient.getServiceList());
+        printOmServerRoles(ozoneManagerClient.getServiceList());
       }
     } catch (OzoneClientException ex) {
       System.out.printf("Error: %s", ex.getMessage());
@@ -78,7 +78,7 @@ public class GetServiceRolesSubcommand implements Callable<Void> {
     return null;
   }
 
-  private void getOmServerRoles(List<ServiceInfo> serviceList) {
+  private void printOmServerRoles(List<ServiceInfo> serviceList) {
     for (ServiceInfo serviceInfo : serviceList) {
       OMRoleInfo omRoleInfo = serviceInfo.getOmRoleInfo();
       if (omRoleInfo != null &&
@@ -91,7 +91,7 @@ public class GetServiceRolesSubcommand implements Callable<Void> {
     }
   }
 
-  private void getOmServerRolesAsJson(List<ServiceInfo> serviceList)
+  private void printOmServerRolesAsJson(List<ServiceInfo> serviceList)
       throws IOException {
     List<Map<String, Map<String, String>>> omServiceList = new ArrayList<>();
     for (ServiceInfo serviceInfo : serviceList) {


### PR DESCRIPTION
## What changes were proposed in this pull request?

Add the option for the command `ozone admin om roles` to output as JSON

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-9080

## How was this patch tested?

Added new Robot test. Also verified the JSON out using a docker-compose cluster:
```
ozone admin om roles --service-id=omservice --json
[ {
  "om1" : {
    "serverRole" : "FOLLOWER",
    "hostname" : "om1"
  }
}, {
  "om2" : {
    "serverRole" : "FOLLOWER",
    "hostname" : "om2"
  }
}, {
  "om3" : {
    "serverRole" : "LEADER",
    "hostname" : "om3"
  }
} ]
```