### PR TITLE
HDDS-9112. Make snapshot dir wait poll max timeout configurable

### DIFF
--- a/hadoop-hdds/common/src/main/resources/ozone-default.xml
+++ b/hadoop-hdds/common/src/main/resources/ozone-default.xml
@@ -3369,10 +3369,12 @@
     </description>
   </property>
   <property>
-    <name>ozone.snapshot.dir.check.poll.timeout</name>
-    <value>5s</value>
+    <name>ozone.om.snapshot.checkpoint.dir.creation.poll.timeout</name>
+    <value>20s</value>
     <tag>OZONE, PERFORMANCE, OM</tag>
-    <description>Max poll timeout for snapshot dir exists check performed before loading a snapshot in cache.
+    <description>
+      Max poll timeout for snapshot dir exists check performed before loading a snapshot in cache.
+      Unit defaults to millisecond if a unit is not specified.
     </description>
   </property>
   <property>

--- a/hadoop-hdds/common/src/main/resources/ozone-default.xml
+++ b/hadoop-hdds/common/src/main/resources/ozone-default.xml
@@ -3369,6 +3369,13 @@
     </description>
   </property>
   <property>
+    <name>ozone.snapshot.dir.check.poll.timeout</name>
+    <value>5s</value>
+    <tag>OZONE, PERFORMANCE, OM</tag>
+    <description>Max poll timeout for snapshot dir exists check performed before loading a snapshot in cache.
+    </description>
+  </property>
+  <property>
     <name>ozone.sst.filtering.service.timeout</name>
     <value>300000ms</value>
     <tag>OZONE, PERFORMANCE,OM</tag>

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/RDBCheckpointUtils.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/RDBCheckpointUtils.java
@@ -45,13 +45,14 @@ public final class RDBCheckpointUtils {
    * Wait for checkpoint directory to be created for 5 secs with 100 millis
    * poll interval.
    * @param file Checkpoint directory.
+   * @param pollMaxDuration max duration for polling
    * @return true if found.
    */
-  public static boolean waitForCheckpointDirectoryExist(File file)
-      throws IOException {
+  public static boolean waitForCheckpointDirectoryExist(File file,
+         Duration pollMaxDuration) {
     Instant start = Instant.now();
     try {
-      with().atMost(POLL_MAX_DURATION)
+      with().atMost(pollMaxDuration)
           .pollDelay(POLL_DELAY_DURATION)
           .pollInterval(POLL_INTERVAL_DURATION)
           .await()
@@ -66,5 +67,16 @@ public final class RDBCheckpointUtils {
           file.getAbsolutePath());
       return false;
     }
+  }
+
+  /**
+   * Wait for checkpoint directory to be created for 5 secs with 100 millis
+   * poll interval.
+   * @param file Checkpoint directory.
+   * @return true if found.
+   */
+  public static boolean waitForCheckpointDirectoryExist(File file)
+      throws IOException {
+    return waitForCheckpointDirectoryExist(file, POLL_MAX_DURATION);
   }
 }

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/RDBCheckpointUtils.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/RDBCheckpointUtils.java
@@ -42,21 +42,17 @@ public final class RDBCheckpointUtils {
   private RDBCheckpointUtils() { }
 
   /**
-   * Wait for checkpoint directory to be created for the given duration with 100 millis
-   * poll interval.
+   * Wait for checkpoint directory to be created for the given duration with
+   * 100 millis poll interval.
    * @param file Checkpoint directory.
-   * @param maxWaitTimeout wait at most before request timeout and returns false.
-   * @return true if found within given timeout.
-   * poll interval.
-   * @param file Checkpoint directory.
-   * @param pollMaxDuration max duration for polling
-   * @return true if found.
+   * @param maxWaitTimeout wait at most before request timeout.
+   * @return true if found within given timeout else false.
    */
   public static boolean waitForCheckpointDirectoryExist(File file,
-      Duration pollMaxDuration) {
+      Duration maxWaitTimeout) {
     Instant start = Instant.now();
     try {
-      with().atMost(pollMaxDuration)
+      with().atMost(maxWaitTimeout)
           .pollDelay(POLL_DELAY_DURATION)
           .pollInterval(POLL_INTERVAL_DURATION)
           .await()
@@ -68,7 +64,7 @@ public final class RDBCheckpointUtils {
       return true;
     } catch (ConditionTimeoutException exception) {
       LOG.info("Checkpoint directory: {} didn't get created in {} secs.",
-          pollMaxDuration.getSeconds(), file.getAbsolutePath());
+          maxWaitTimeout.getSeconds(), file.getAbsolutePath());
       return false;
     }
   }

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/RDBCheckpointUtils.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/RDBCheckpointUtils.java
@@ -42,14 +42,14 @@ public final class RDBCheckpointUtils {
   private RDBCheckpointUtils() { }
 
   /**
-   * Wait for checkpoint directory to be created for 5 secs with 100 millis
+   * Wait for checkpoint directory to be created with 100 millis
    * poll interval.
    * @param file Checkpoint directory.
    * @param pollMaxDuration max duration for polling
    * @return true if found.
    */
   public static boolean waitForCheckpointDirectoryExist(File file,
-         Duration pollMaxDuration) {
+      Duration pollMaxDuration) {
     Instant start = Instant.now();
     try {
       with().atMost(pollMaxDuration)
@@ -63,8 +63,8 @@ public final class RDBCheckpointUtils {
           file.getAbsoluteFile());
       return true;
     } catch (ConditionTimeoutException exception) {
-      LOG.info("Checkpoint directory: {} didn't get created in 5 secs.",
-          file.getAbsolutePath());
+      LOG.info("Checkpoint directory: {} didn't get created in {} secs.",
+          pollMaxDuration.getSeconds(), file.getAbsolutePath());
       return false;
     }
   }

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/RDBCheckpointUtils.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/RDBCheckpointUtils.java
@@ -37,7 +37,7 @@ public final class RDBCheckpointUtils {
       LoggerFactory.getLogger(RDBCheckpointUtils.class);
   private static final Duration POLL_DELAY_DURATION = Duration.ZERO;
   private static final Duration POLL_INTERVAL_DURATION = Duration.ofMillis(100);
-  private static final Duration POLL_MAX_DURATION = Duration.ofSeconds(5);
+  private static final Duration POLL_MAX_DURATION = Duration.ofSeconds(20);
 
   private RDBCheckpointUtils() { }
 

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/RDBCheckpointUtils.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/RDBCheckpointUtils.java
@@ -42,7 +42,11 @@ public final class RDBCheckpointUtils {
   private RDBCheckpointUtils() { }
 
   /**
-   * Wait for checkpoint directory to be created with 100 millis
+   * Wait for checkpoint directory to be created for the given duration with 100 millis
+   * poll interval.
+   * @param file Checkpoint directory.
+   * @param maxWaitTimeout wait at most before request timeout and returns false.
+   * @return true if found within given timeout.
    * poll interval.
    * @param file Checkpoint directory.
    * @param pollMaxDuration max duration for polling

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/OMConfigKeys.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/OMConfigKeys.java
@@ -383,11 +383,12 @@ public final class OMConfigKeys {
   public static final String
       OZONE_SNAPSHOT_SST_FILTERING_SERVICE_INTERVAL_DEFAULT = "60s";
 
-  public static final String OZONE_SNAPSHOT_DIR_CHECK_POLL_TIMEOUT =
-      "ozone.snapshot.dir.check.poll.timeout";
+  public static final String
+      OZONE_SNAPSHOT_CHECKPOINT_DIR_CREATION_POLL_TIMEOUT =
+      "ozone.om.snapshot.checkpoint.dir.creation.poll.timeout";
 
-  public static final String OZONE_SNAPSHOT_DIR_CHECK_POLL_TIMEOUT_DEFAULT =
-      "5s";
+  public static final String
+      OZONE_SNAPSHOT_CHECKPOINT_DIR_CREATION_POLL_TIMEOUT_DEFAULT = "20s";
 
   public static final String OZONE_OM_GRPC_MAXIMUM_RESPONSE_LENGTH =
       "ozone.om.grpc.maximum.response.length";

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/OMConfigKeys.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/OMConfigKeys.java
@@ -383,6 +383,11 @@ public final class OMConfigKeys {
   public static final String
       OZONE_SNAPSHOT_SST_FILTERING_SERVICE_INTERVAL_DEFAULT = "60s";
 
+  public static final String OZONE_SNAPSHOT_DIR_CHECK_POLL_TIMEOUT =
+      "ozone.snapshot.dir.check.poll.timeout";
+
+  public static final String OZONE_SNAPSHOT_DIR_CHECK_POLL_TIMEOUT_DEFAULT =
+      "5s";
 
   public static final String OZONE_OM_GRPC_MAXIMUM_RESPONSE_LENGTH =
       "ozone.om.grpc.maximum.response.length";

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmMetadataManagerImpl.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmMetadataManagerImpl.java
@@ -33,6 +33,7 @@ import java.util.Set;
 import java.util.TreeMap;
 import java.util.TreeSet;
 import java.util.UUID;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -97,6 +98,8 @@ import static org.apache.hadoop.ozone.OzoneConsts.OM_DB_NAME;
 import static org.apache.hadoop.ozone.OzoneConsts.OM_KEY_PREFIX;
 import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_FS_SNAPSHOT_MAX_LIMIT;
 import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_FS_SNAPSHOT_MAX_LIMIT_DEFAULT;
+import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_SNAPSHOT_DIR_CHECK_POLL_TIMEOUT;
+import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_SNAPSHOT_DIR_CHECK_POLL_TIMEOUT_DEFAULT;
 import static org.apache.hadoop.ozone.om.OmSnapshotManager.getSnapshotPrefix;
 import static org.apache.hadoop.ozone.om.exceptions.OMException.ResultCodes.BUCKET_NOT_FOUND;
 import static org.apache.hadoop.ozone.om.exceptions.OMException.ResultCodes.VOLUME_NOT_FOUND;
@@ -377,13 +380,19 @@ public class OmMetadataManagerImpl implements OMMetadataManager,
           OM_KEY_PREFIX + OM_SNAPSHOT_CHECKPOINT_DIR;
       File metaDir = new File(snapshotDir);
       String dbName = OM_DB_NAME + snapshotDirName;
+      Duration maxPollDuration =
+          Duration.ofMillis(conf.getTimeDuration(
+              OZONE_SNAPSHOT_DIR_CHECK_POLL_TIMEOUT,
+              OZONE_SNAPSHOT_DIR_CHECK_POLL_TIMEOUT_DEFAULT,
+              TimeUnit.MILLISECONDS));
       // The check is only to prevent every snapshot read to perform a disk IO
       // and check if a checkpoint dir exists. If entry is present in cache,
       // it is most likely DB entries will get flushed in this wait time.
       if (isSnapshotInCache) {
         File checkpoint =
             Paths.get(metaDir.toPath().toString(), dbName).toFile();
-        RDBCheckpointUtils.waitForCheckpointDirectoryExist(checkpoint);
+        RDBCheckpointUtils.waitForCheckpointDirectoryExist(checkpoint,
+            maxPollDuration);
         // Check if the snapshot directory exists.
         checkSnapshotDirExist(checkpoint);
       }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmMetadataManagerImpl.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmMetadataManagerImpl.java
@@ -98,8 +98,8 @@ import static org.apache.hadoop.ozone.OzoneConsts.OM_DB_NAME;
 import static org.apache.hadoop.ozone.OzoneConsts.OM_KEY_PREFIX;
 import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_FS_SNAPSHOT_MAX_LIMIT;
 import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_FS_SNAPSHOT_MAX_LIMIT_DEFAULT;
-import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_SNAPSHOT_DIR_CHECK_POLL_TIMEOUT;
-import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_SNAPSHOT_DIR_CHECK_POLL_TIMEOUT_DEFAULT;
+import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_SNAPSHOT_CHECKPOINT_DIR_CREATION_POLL_TIMEOUT;
+import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_SNAPSHOT_CHECKPOINT_DIR_CREATION_POLL_TIMEOUT_DEFAULT;
 import static org.apache.hadoop.ozone.om.OmSnapshotManager.getSnapshotPrefix;
 import static org.apache.hadoop.ozone.om.exceptions.OMException.ResultCodes.BUCKET_NOT_FOUND;
 import static org.apache.hadoop.ozone.om.exceptions.OMException.ResultCodes.VOLUME_NOT_FOUND;
@@ -382,8 +382,8 @@ public class OmMetadataManagerImpl implements OMMetadataManager,
       String dbName = OM_DB_NAME + snapshotDirName;
       Duration maxPollDuration =
           Duration.ofMillis(conf.getTimeDuration(
-              OZONE_SNAPSHOT_DIR_CHECK_POLL_TIMEOUT,
-              OZONE_SNAPSHOT_DIR_CHECK_POLL_TIMEOUT_DEFAULT,
+              OZONE_SNAPSHOT_CHECKPOINT_DIR_CREATION_POLL_TIMEOUT,
+              OZONE_SNAPSHOT_CHECKPOINT_DIR_CREATION_POLL_TIMEOUT_DEFAULT,
               TimeUnit.MILLISECONDS));
       // The check is only to prevent every snapshot read to perform a disk IO
       // and check if a checkpoint dir exists. If entry is present in cache,

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/snapshot/SnapshotUtils.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/snapshot/SnapshotUtils.java
@@ -102,8 +102,8 @@ public final class SnapshotUtils {
     if (!checkpoint.exists()) {
       throw new OMException("Unable to load snapshot. " +
           "Snapshot checkpoint directory '" + checkpoint.getAbsolutePath() +
-          "' does not exist yet. Please wait a few more seconds before retrying",
-          TIMEOUT);
+          "' does not exist yet. Please wait a few more seconds before " +
+          "retrying", TIMEOUT);
     }
   }
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/snapshot/SnapshotUtils.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/snapshot/SnapshotUtils.java
@@ -36,6 +36,7 @@ import java.util.UUID;
 
 import static org.apache.hadoop.ozone.om.exceptions.OMException.ResultCodes.FILE_NOT_FOUND;
 import static org.apache.hadoop.ozone.om.exceptions.OMException.ResultCodes.KEY_NOT_FOUND;
+import static org.apache.hadoop.ozone.om.exceptions.OMException.ResultCodes.TIMEOUT;
 
 /**
  * Util class for snapshot diff APIs.
@@ -101,7 +102,7 @@ public final class SnapshotUtils {
     if (!checkpoint.exists()) {
       throw new OMException("Unable to load snapshot. " +
           "Snapshot checkpoint directory '" + checkpoint.getAbsolutePath() +
-          "' does not exists.", FILE_NOT_FOUND);
+          "' does not exists.", TIMEOUT);
     }
   }
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/snapshot/SnapshotUtils.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/snapshot/SnapshotUtils.java
@@ -102,7 +102,7 @@ public final class SnapshotUtils {
     if (!checkpoint.exists()) {
       throw new OMException("Unable to load snapshot. " +
           "Snapshot checkpoint directory '" + checkpoint.getAbsolutePath() +
-          "' does not exists. Please wait a few more seconds before retrying",
+          "' does not exist yet. Please wait a few more seconds before retrying",
           TIMEOUT);
     }
   }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/snapshot/SnapshotUtils.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/snapshot/SnapshotUtils.java
@@ -94,7 +94,7 @@ public final class SnapshotUtils {
   }
 
   /**
-   * Throws OMException FILE_NOT_FOUND if snapshot directory does not exist.
+   * Throws OMException TIMEOUT if snapshot directory does not exist.
    * @param checkpoint Snapshot checkpoint directory
    */
   public static void checkSnapshotDirExist(File checkpoint)
@@ -102,7 +102,8 @@ public final class SnapshotUtils {
     if (!checkpoint.exists()) {
       throw new OMException("Unable to load snapshot. " +
           "Snapshot checkpoint directory '" + checkpoint.getAbsolutePath() +
-          "' does not exists.", TIMEOUT);
+          "' does not exists. Please wait a few more seconds before retrying",
+          TIMEOUT);
     }
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Currently snapshot dir wait poll max timeout value is a constant value. Adding a config for the same.
Snapshot listing currently throws FileNotFound exception if the directory exists check times out. This should throw a timeout error code instead of file not found.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-9112

## How was this patch tested?
Adding a configuration. No testing required.
