### PR TITLE
HDDS-9117. Source bucket replication type is ignored for links

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestOzoneRpcClientAbstract.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestOzoneRpcClientAbstract.java
@@ -898,6 +898,45 @@ public abstract class TestOzoneRpcClientAbstract {
     );
   }
 
+  @Test
+  public void testDeleteLinkedBucket()
+      throws Exception {
+    String volumeName = UUID.randomUUID().toString();
+    String bucketName = UUID.randomUUID().toString();
+    String linkedBucketName = UUID.randomUUID().toString();
+
+    store.createVolume(volumeName);
+    OzoneVolume volume = store.getVolume(volumeName);
+
+    volume.createBucket(bucketName);
+    OzoneBucket bucket = volume.getBucket(bucketName);
+    assertNotNull(bucket);
+
+    volume.createBucket(linkedBucketName,
+        BucketArgs.newBuilder()
+            .setSourceBucket(bucketName)
+            .setSourceVolume(volumeName)
+            .build());
+    OzoneBucket linkedBucket = volume.getBucket(linkedBucketName);
+    assertNotNull(linkedBucket);
+
+    volume.deleteBucket(bucketName);
+    //now linkedBucketName has become a dangling one
+    //should still be possible to get its info
+    OzoneBucket danglingLinkedBucket = volume.getBucket(linkedBucketName);
+    assertNotNull(danglingLinkedBucket);
+
+    //now delete the dangling linked bucket
+    volume.deleteBucket(linkedBucketName);
+
+    OzoneTestUtils.expectOmException(ResultCodes.BUCKET_NOT_FOUND,
+        () -> volume.getBucket(bucketName)
+    );
+    OzoneTestUtils.expectOmException(ResultCodes.BUCKET_NOT_FOUND,
+        () -> volume.getBucket(linkedBucketName)
+    );
+  }
+
   private void verifyReplication(String volumeName, String bucketName,
       String keyName, ReplicationConfig replication)
       throws IOException {

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestOzoneRpcClientAbstract.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestOzoneRpcClientAbstract.java
@@ -921,6 +921,10 @@ public abstract class TestOzoneRpcClientAbstract {
     assertNotNull(linkedBucket);
 
     volume.deleteBucket(bucketName);
+
+    OzoneTestUtils.expectOmException(ResultCodes.BUCKET_NOT_FOUND,
+        () -> volume.getBucket(bucketName)
+    );
     //now linkedBucketName has become a dangling one
     //should still be possible to get its info
     OzoneBucket danglingLinkedBucket = volume.getBucket(linkedBucketName);
@@ -930,11 +934,10 @@ public abstract class TestOzoneRpcClientAbstract {
     volume.deleteBucket(linkedBucketName);
 
     OzoneTestUtils.expectOmException(ResultCodes.BUCKET_NOT_FOUND,
-        () -> volume.getBucket(bucketName)
-    );
-    OzoneTestUtils.expectOmException(ResultCodes.BUCKET_NOT_FOUND,
         () -> volume.getBucket(linkedBucketName)
     );
+
+    store.deleteVolume(volumeName);
   }
 
   private void verifyReplication(String volumeName, String bucketName,

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/BucketManagerImpl.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/BucketManagerImpl.java
@@ -66,7 +66,7 @@ public class BucketManagerImpl implements BucketManager {
    *
    * @param volumeName - Name of the Volume.
    * @param bucketName - Name of the Bucket.
-   * @return
+   * @return Bucket Information.
    * @throws IOException
    */
   @Override

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/BucketManagerImpl.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/BucketManagerImpl.java
@@ -17,7 +17,6 @@
 package org.apache.hadoop.ozone.om;
 
 import java.io.IOException;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
 
@@ -36,7 +35,6 @@ import org.slf4j.LoggerFactory;
 
 import static org.apache.hadoop.ozone.om.exceptions.OMException.ResultCodes.BUCKET_NOT_FOUND;
 import static org.apache.hadoop.ozone.om.exceptions.OMException.ResultCodes.INTERNAL_ERROR;
-import static org.apache.hadoop.ozone.om.exceptions.OMException.ResultCodes.VOLUME_NOT_FOUND;
 import static org.apache.hadoop.ozone.om.lock.OzoneManagerLock.Resource.BUCKET_LOCK;
 
 /**
@@ -61,6 +59,16 @@ public class BucketManagerImpl implements BucketManager {
     this.metadataManager = metadataManager;
   }
 
+  /**
+   * Retrieve bucket info.
+   * This method does not follow the bucket link and returns only
+   * this bucket properties.
+   *
+   * @param volumeName - Name of the Volume.
+   * @param bucketName - Name of the Bucket.
+   * @return
+   * @throws IOException
+   */
   @Override
   public OmBucketInfo getBucketInfo(String volumeName, String bucketName)
       throws IOException {
@@ -69,27 +77,8 @@ public class BucketManagerImpl implements BucketManager {
     metadataManager.getLock().acquireReadLock(BUCKET_LOCK, volumeName,
         bucketName);
     try {
-      String bucketKey = metadataManager.getBucketKey(volumeName, bucketName);
-      OmBucketInfo value = metadataManager.getBucketTable().get(bucketKey);
-      if (value == null) {
-        LOG.debug("bucket: {} not found in volume: {}.", bucketName,
-            volumeName);
-        // Check parent volume existence
-        final String dbVolumeKey = metadataManager.getVolumeKey(volumeName);
-        if (metadataManager.getVolumeTable().get(dbVolumeKey) == null) {
-          // Parent volume doesn't exist, throw VOLUME_NOT_FOUND
-          throw new OMException("Volume not found when getting bucket info",
-              VOLUME_NOT_FOUND);
-        } else {
-          // Parent volume exists, throw BUCKET_NOT_FOUND
-          throw new OMException("Bucket not found", BUCKET_NOT_FOUND);
-        }
-      }
-
-      value = OzoneManagerUtils.resolveLinkBucketLayout(value, metadataManager,
-          new HashSet<>());
-
-      return value;
+      return OzoneManagerUtils.getBucketInfo(metadataManager,
+          volumeName, bucketName);
     } catch (IOException ex) {
       if (!(ex instanceof OMException)) {
         LOG.error("Exception while getting bucket info for bucket: {}",

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
@@ -2792,7 +2792,32 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
             bucket, null);
       }
       metrics.incNumBucketInfos();
-      return bucketManager.getBucketInfo(volume, bucket);
+
+      ResolvedBucket resolvedBucket =
+          resolveBucketLink(Pair.of(volume, bucket), true);
+      OmBucketInfo bucketInfo = bucketManager.getBucketInfo(volume, bucket);
+
+      // If it is a dangling link it means no real bucket exists.
+      if (!resolvedBucket.isDangling() && resolvedBucket.isLink()) {
+        OmBucketInfo realBucket =
+            bucketManager.getBucketInfo(
+                resolvedBucket.realVolume(),
+                resolvedBucket.realBucket());
+        // Pass the real bucket metadata in the link bucket info.
+        return bucketInfo.toBuilder()
+            .setDefaultReplicationConfig(
+                realBucket.getDefaultReplicationConfig())
+            .setIsVersionEnabled(realBucket.getIsVersionEnabled())
+            .setStorageType(realBucket.getStorageType())
+            .setQuotaInBytes(realBucket.getQuotaInBytes())
+            .setQuotaInNamespace(realBucket.getQuotaInNamespace())
+            .setUsedBytes(realBucket.getUsedBytes())
+            .setUsedNamespace(realBucket.getUsedNamespace())
+            .addAllMetadata(realBucket.getMetadata())
+            .setBucketLayout(realBucket.getBucketLayout())
+            .build();
+      }
+      return bucketInfo;
     } catch (Exception ex) {
       metrics.incNumBucketInfoFails();
       auditSuccess = false;
@@ -4126,10 +4151,15 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
         Pair.of(args.getVolumeName(), args.getBucketName()), omClientRequest);
   }
 
+  public ResolvedBucket resolveBucketLink(Pair<String, String> requested)
+      throws IOException {
+    return resolveBucketLink(requested, false);
+  }
+
   public ResolvedBucket resolveBucketLink(OmKeyArgs args)
       throws IOException {
     return resolveBucketLink(
-        Pair.of(args.getVolumeName(), args.getBucketName()));
+        Pair.of(args.getVolumeName(), args.getBucketName()), false);
   }
 
   public ResolvedBucket resolveBucketLink(Pair<String, String> requested,
@@ -4140,15 +4170,17 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
       resolved = resolveBucketLink(requested, new HashSet<>(),
               omClientRequest.createUGIForApi(),
               omClientRequest.getRemoteAddress(),
-              omClientRequest.getHostName());
+              omClientRequest.getHostName(),
+              false);
     } else {
       resolved = resolveBucketLink(requested, new HashSet<>(),
-          null, null, null);
+          null, null, null, false);
     }
     return new ResolvedBucket(requested, resolved);
   }
 
-  public ResolvedBucket resolveBucketLink(Pair<String, String> requested)
+  public ResolvedBucket resolveBucketLink(Pair<String, String> requested,
+                                          boolean allowDanglingBuckets)
       throws IOException {
     Pair<String, String> resolved;
     if (isAclEnabled) {
@@ -4162,10 +4194,10 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
           ugi,
           remoteIp != null ? remoteIp : omRpcAddress.getAddress(),
           remoteIp != null ? remoteIp.getHostName() :
-              omRpcAddress.getHostName());
+              omRpcAddress.getHostName(), allowDanglingBuckets);
     } else {
       resolved = resolveBucketLink(requested, new HashSet<>(),
-          null, null, null);
+          null, null, null, allowDanglingBuckets);
     }
     return new ResolvedBucket(requested, resolved);
   }
@@ -4186,11 +4218,21 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
       Set<Pair<String, String>> visited,
       UserGroupInformation userGroupInformation,
       InetAddress remoteAddress,
-      String hostName) throws IOException {
+      String hostName,
+      boolean allowDanglingBuckets) throws IOException {
 
     String volumeName = volumeAndBucket.getLeft();
     String bucketName = volumeAndBucket.getRight();
-    OmBucketInfo info = bucketManager.getBucketInfo(volumeName, bucketName);
+    OmBucketInfo info;
+    try {
+      info = bucketManager.getBucketInfo(volumeName, bucketName);
+    } catch (OMException e) {
+      LOG.warn("Bucket {} not found in volume {}", bucketName, volumeName);
+      if (allowDanglingBuckets) {
+        return null;
+      }
+      throw e;
+    }
     if (!info.isLink()) {
       return volumeAndBucket;
     }
@@ -4210,7 +4252,8 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
 
     return resolveBucketLink(
         Pair.of(info.getSourceVolume(), info.getSourceBucket()),
-        visited, userGroupInformation, remoteAddress, hostName);
+        visited, userGroupInformation, remoteAddress, hostName,
+        allowDanglingBuckets);
   }
 
   @VisibleForTesting

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ResolvedBucket.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ResolvedBucket.java
@@ -89,6 +89,11 @@ public class ResolvedBucket {
     return !Objects.equals(requested, resolved);
   }
 
+  public boolean isDangling() {
+    return resolved == null;
+  }
+
+
   public Map<String, String> audit() {
     return audit(new LinkedHashMap<>());
   }

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/PrefixParser.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/PrefixParser.java
@@ -21,7 +21,6 @@ package org.apache.hadoop.ozone.debug;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Paths;
-import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.concurrent.Callable;
@@ -36,6 +35,7 @@ import org.apache.hadoop.hdds.utils.db.Table.KeyValue;
 import org.apache.hadoop.ozone.om.OMConfigKeys;
 import org.apache.hadoop.ozone.om.OmMetadataManagerImpl;
 import org.apache.hadoop.ozone.om.OzoneManagerUtils;
+import org.apache.hadoop.ozone.om.exceptions.OMException;
 import org.apache.hadoop.ozone.om.helpers.BucketLayout;
 import org.apache.hadoop.ozone.om.helpers.OmBucketInfo;
 import org.apache.hadoop.ozone.om.helpers.WithParentObjectId;
@@ -147,17 +147,16 @@ public class PrefixParser implements Callable<Void>, SubcommandWithParent {
 
     parserStats[Types.VOLUME.ordinal()]++;
     // First get the info about the bucket
-    String bucketKey = metadataManager.getBucketKey(vol, buck);
-    OmBucketInfo info = metadataManager.getBucketTable().get(bucketKey);
-    if (info == null) {
+    OmBucketInfo info;
+    try {
+      info = OzoneManagerUtils
+          .getResolvedBucketInfo(metadataManager, vol, buck);
+    } catch (OMException e) {
       System.out.println("Invalid Bucket:" + buck);
       metadataManager.stop();
       return;
     }
-
-    BucketLayout bucketLayout =
-        OzoneManagerUtils.resolveLinkBucketLayout(info, metadataManager,
-            new HashSet<>()).getBucketLayout();
+    BucketLayout bucketLayout = info.getBucketLayout();
 
     if (!bucketLayout.isFileSystemOptimized()) {
       System.out.println("Prefix tool only works for FileSystem Optimized" +
@@ -171,7 +170,8 @@ public class PrefixParser implements Callable<Void>, SubcommandWithParent {
     long lastObjectId = info.getObjectID();
     WithParentObjectId objectBucketId = new WithParentObjectId();
     objectBucketId.setObjectID(lastObjectId);
-    dumpInfo(Types.BUCKET, effectivePath, objectBucketId, bucketKey);
+    dumpInfo(Types.BUCKET, effectivePath, objectBucketId,
+        metadataManager.getBucketKey(vol, buck));
 
     Iterator<Path> pathIterator =  p.iterator();
     while (pathIterator.hasNext()) {


### PR DESCRIPTION
## What changes were proposed in this pull request?

Before these changes single and multipart uploads via S3G to an EC bucket resulted in keys created with RATIS/3 replication. 
Now linked buckets inherit the original bucket's replication type

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-9117

## How was this patch tested?

Unit tests, manual tests
