### PR TITLE
HDDS-9118. Added an invalidateCacheEntry() in RocksDBCheckpointDifferHolder to close cached instance of RocksDBCheckpointDiffer

### DIFF
--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/RDBStore.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/RDBStore.java
@@ -42,6 +42,7 @@ import org.apache.hadoop.hdds.utils.db.managed.ManagedWriteOptions;
 import org.apache.ozone.rocksdiff.RocksDBCheckpointDiffer;
 
 import com.google.common.base.Preconditions;
+import org.apache.ozone.rocksdiff.RocksDBCheckpointDiffer.RocksDBCheckpointDifferHolder;
 import org.rocksdb.RocksDBException;
 
 import org.rocksdb.TransactionLogIterator.BatchResult;
@@ -97,7 +98,7 @@ public class RDBStore implements DBStore {
 
     try {
       if (enableCompactionDag) {
-        rocksDBCheckpointDiffer = new RocksDBCheckpointDiffer(
+        rocksDBCheckpointDiffer = RocksDBCheckpointDifferHolder.getInstance(
             getSnapshotMetadataDir(),
             DB_COMPACTION_SST_BACKUP_DIR,
             DB_COMPACTION_LOG_DIR,
@@ -218,7 +219,7 @@ public class RDBStore implements DBStore {
 
     RDBMetrics.unRegister();
     IOUtils.closeQuietly(checkPointManager);
-    IOUtils.closeQuietly(rocksDBCheckpointDiffer);
+    rocksDBCheckpointDiffer.stop();
     IOUtils.closeQuietly(db);
   }
 

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/RDBStore.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/RDBStore.java
@@ -42,7 +42,6 @@ import org.apache.hadoop.hdds.utils.db.managed.ManagedWriteOptions;
 import org.apache.ozone.rocksdiff.RocksDBCheckpointDiffer;
 
 import com.google.common.base.Preconditions;
-import org.apache.ozone.rocksdiff.RocksDBCheckpointDiffer.RocksDBCheckpointDifferHolder;
 import org.rocksdb.RocksDBException;
 
 import org.rocksdb.TransactionLogIterator.BatchResult;
@@ -98,10 +97,12 @@ public class RDBStore implements DBStore {
 
     try {
       if (enableCompactionDag) {
-        rocksDBCheckpointDiffer = RocksDBCheckpointDifferHolder.getInstance(
+        rocksDBCheckpointDiffer = new RocksDBCheckpointDiffer(
             getSnapshotMetadataDir(),
-            DB_COMPACTION_SST_BACKUP_DIR, DB_COMPACTION_LOG_DIR,
-            dbLocation.toString(), configuration);
+            DB_COMPACTION_SST_BACKUP_DIR,
+            DB_COMPACTION_LOG_DIR,
+            dbLocation.toString(),
+            configuration);
         rocksDBCheckpointDiffer.setRocksDBForCompactionTracking(dbOptions);
       } else {
         rocksDBCheckpointDiffer = null;

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/RDBStore.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/RDBStore.java
@@ -220,7 +220,8 @@ public class RDBStore implements DBStore {
     RDBMetrics.unRegister();
     IOUtils.closeQuietly(checkPointManager);
     if (rocksDBCheckpointDiffer != null) {
-      rocksDBCheckpointDiffer.stop();
+      RocksDBCheckpointDifferHolder
+          .invalidateCacheEntry(rocksDBCheckpointDiffer.getMetadataDir());
     }
     IOUtils.closeQuietly(db);
   }

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/RDBStore.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/RDBStore.java
@@ -219,7 +219,9 @@ public class RDBStore implements DBStore {
 
     RDBMetrics.unRegister();
     IOUtils.closeQuietly(checkPointManager);
-    rocksDBCheckpointDiffer.stop();
+    if (rocksDBCheckpointDiffer != null) {
+      rocksDBCheckpointDiffer.stop();
+    }
     IOUtils.closeQuietly(db);
   }
 

--- a/hadoop-hdds/rocksdb-checkpoint-differ/src/main/java/org/apache/ozone/rocksdiff/RocksDBCheckpointDiffer.java
+++ b/hadoop-hdds/rocksdb-checkpoint-differ/src/main/java/org/apache/ozone/rocksdiff/RocksDBCheckpointDiffer.java
@@ -175,7 +175,7 @@ public class RocksDBCheckpointDiffer implements BootstrapStateHandler {
   private String reconstructionLastSnapshotID;
 
   private final Scheduler scheduler;
-  private boolean closed = true;
+  private boolean closed = false;
   private final long maxAllowedTimeInDag;
   private final long pruneCompactionDagDaemonRunIntervalInMs;
   private final BootstrapStateHandler.Lock lock

--- a/hadoop-hdds/rocksdb-checkpoint-differ/src/main/java/org/apache/ozone/rocksdiff/RocksDBCheckpointDiffer.java
+++ b/hadoop-hdds/rocksdb-checkpoint-differ/src/main/java/org/apache/ozone/rocksdiff/RocksDBCheckpointDiffer.java
@@ -1516,32 +1516,6 @@ public class RocksDBCheckpointDiffer implements AutoCloseable,
     return compactionNodeMap;
   }
 
-  /**
-   * Holder for RocksDBCheckpointDiffer instance.
-   * This is to protect from creating more than one instance of
-   * RocksDBCheckpointDiffer per RocksDB dir and use the single instance per dir
-   * throughout the whole OM process.
-   */
-  public static class RocksDBCheckpointDifferHolder {
-    private static final ConcurrentMap<String, RocksDBCheckpointDiffer>
-        INSTANCE_MAP = new ConcurrentHashMap<>();
-
-    public static RocksDBCheckpointDiffer getInstance(
-        String metadataDirName,
-        String sstBackupDirName,
-        String compactionLogDirName,
-        String activeDBLocationName,
-        ConfigurationSource configuration
-    ) {
-      return INSTANCE_MAP.computeIfAbsent(metadataDirName, (key) ->
-          new RocksDBCheckpointDiffer(metadataDirName,
-              sstBackupDirName,
-              compactionLogDirName,
-              activeDBLocationName,
-              configuration));
-    }
-  }
-
   @Override
   public BootstrapStateHandler.Lock getBootstrapStateLock() {
     return lock;

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
@@ -3865,7 +3865,6 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
 
     // Restart required services
     metadataManager.start(configuration);
-    metadataManager.getStore().getRocksDBCheckpointDiffer().start();
     keyManager.start(configuration);
     startSecretManagerIfNecessary();
     startTrashEmptier(configuration);

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
@@ -3865,6 +3865,7 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
 
     // Restart required services
     metadataManager.start(configuration);
+    metadataManager.getStore().getRocksDBCheckpointDiffer().start();
     keyManager.start(configuration);
     startSecretManagerIfNecessary();
     startTrashEmptier(configuration);


### PR DESCRIPTION
## What changes were proposed in this pull request?
Compaction DAG pruning service/s are not getting started after bootstrapping. It is because `RocksDBCheckpointDiffer` is singleton class. On the metadataManager.stop() path we stop the executor and on restart we just used [the cached object](https://github.com/apache/ozone/blob/7a19afa71401e356cd86a99648e94278ea2850c8/hadoop-hdds/rocksdb-checkpoint-differ/src/main/java/org/apache/ozone/rocksdiff/RocksDBCheckpointDiffer.java#L1523) where executor is not running and don't restart Compaction DAG pruning service/s.

In this change, `invalidateCacheEntry()` is added in `RocksDBCheckpointDifferHolder` to close cached instance of `RocksDBCheckpointDiffer` and create new when `getInstance()` is called for the same metedata dir..

Note: Ideally there is no need to have [INSTANCE_MAP](https://github.com/apache/ozone/blob/ba891478468420f47f7d0702e70af4d00055a897/hadoop-hdds/rocksdb-checkpoint-differ/src/main/java/org/apache/ozone/rocksdiff/RocksDBCheckpointDiffer.java#L1538) but it was added so that tests don't interfere with each other.
For more details: https://github.com/apache/ozone/pull/4553#discussion_r1178510795


## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-9118

## How was this patch tested?
Un-commented [the test](https://github.com/apache/ozone/pull/5083/files#diff-376b2a5e5d22d59a4119790bb550dabdb074b78986a1fed7bf4d9160e36cd3ceR1165), (will be added as part of PR: https://github.com/apache/ozone/pull/5083) and ran it [on fork](https://github.com/hemantk-12/ozone/commit/3bd328bf43e93724dd048caca512ece828fae008#diff-1d5c6c892a2d24d85ca002dafcb9f39341192baaa7b5323d2325b5fc7a238c7f).

https://github.com/hemantk-12/ozone/actions/runs/5755269497/job/15602339618

Also the test locally.

![Screenshot 2023-08-03 at 1 44 55 PM](https://github.com/apache/ozone/assets/6820020/e417a537-9d74-4b53-ac79-5dcfc1272abf)


