### PR TITLE
HDDS-9107. Reduce the granularity of Container locks for BlockDeletingService

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/impl/BlockDeletingService.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/impl/BlockDeletingService.java
@@ -35,6 +35,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
+import java.time.Duration;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -62,6 +63,8 @@ public class BlockDeletingService extends BackgroundService {
   // Task priority is useful when a to-delete block has weight.
   private static final int TASK_PRIORITY_DEFAULT = 1;
 
+  private final Duration blockDeletingMaxLockHoldingTime;
+
   public BlockDeletingService(OzoneContainer ozoneContainer,
                               long serviceInterval, long serviceTimeout,
                               TimeUnit timeUnit, int workerSize,
@@ -80,6 +83,8 @@ public class BlockDeletingService extends BackgroundService {
     this.conf = conf;
     DatanodeConfiguration dnConf = conf.getObject(DatanodeConfiguration.class);
     this.blockLimitPerInterval = dnConf.getBlockDeletionLimit();
+    this.blockDeletingMaxLockHoldingTime =
+        dnConf.getBlockDeletingMaxLockHoldingTime();
     metrics = BlockDeletingServiceMetrics.create();
   }
 
@@ -247,6 +252,10 @@ public class BlockDeletingService extends BackgroundService {
 
   public BlockDeletingServiceMetrics getMetrics() {
     return metrics;
+  }
+
+  public Duration getBlockDeletingMaxLockHoldingTime() {
+    return blockDeletingMaxLockHoldingTime;
   }
 
   private static class BlockDeletingTaskBuilder {

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/DatanodeConfiguration.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/DatanodeConfiguration.java
@@ -231,6 +231,30 @@ public class DatanodeConfiguration {
     return blockLimitPerInterval;
   }
 
+  @Config(key = "block.deleting.max.lock.holding.time",
+      defaultValue = "1s",
+      type = ConfigType.TIME,
+      tags = { DATANODE, ConfigTag.DELETION },
+      description =
+          "This configuration controls the maximum time that the block "
+          + "deleting service can hold the lock during the deletion of blocks. "
+          + "Once this configured time period is reached, the service will "
+          + "release and re-acquire the lock. This is not a hard limit as the "
+          + "time check only occurs after the completion of each transaction, "
+          + "which means the actual execution time may exceed this limit. "
+          + "Unit could be defined with postfix (ns,ms,s,m,h,d). "
+  )
+  private long blockDeletingMaxLockHoldingTime =
+      Duration.ofSeconds(1).toMillis();
+
+  public Duration getBlockDeletingMaxLockHoldingTime() {
+    return Duration.ofMillis(blockDeletingMaxLockHoldingTime);
+  }
+
+  public void setBlockDeletingMaxLockHoldingTime(Duration maxLockHoldingTime) {
+    blockDeletingMaxLockHoldingTime = maxLockHoldingTime.toMillis();
+  }
+
   public void setBlockDeletionLimit(int limit) {
     this.blockLimitPerInterval = limit;
   }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/statemachine/background/BlockDeletingTask.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/statemachine/background/BlockDeletingTask.java
@@ -20,10 +20,13 @@ package org.apache.hadoop.ozone.container.keyvalue.statemachine.background;
 import java.io.File;
 import java.io.IOException;
 
+import java.time.Duration;
+import java.time.Instant;
 import java.util.LinkedList;
 import java.util.Objects;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import org.apache.hadoop.hdds.conf.ConfigurationSource;
 import org.apache.hadoop.hdds.utils.BackgroundTaskResult;
@@ -66,9 +69,10 @@ public class BlockDeletingTask implements BackgroundTask {
   private final BlockDeletingServiceMetrics metrics;
   private final int priority;
   private final KeyValueContainerData containerData;
-  private final long blocksToDelete;
+  private long blocksToDelete;
   private final OzoneContainer ozoneContainer;
   private final ConfigurationSource conf;
+  private Duration blockDeletingMaxLockHoldingTime;
 
   public BlockDeletingTask(
       BlockDeletingService blockDeletingService,
@@ -77,6 +81,8 @@ public class BlockDeletingTask implements BackgroundTask {
     this.ozoneContainer = blockDeletingService.getOzoneContainer();
     this.metrics = blockDeletingService.getMetrics();
     this.conf = blockDeletingService.getConf();
+    this.blockDeletingMaxLockHoldingTime =
+        blockDeletingService.getBlockDeletingMaxLockHoldingTime();
     this.priority = priority;
     this.containerData =
         (KeyValueContainerData) containerBlockInfo.getContainerData();
@@ -112,6 +118,25 @@ public class BlockDeletingTask implements BackgroundTask {
 
   @Override
   public BackgroundTaskResult call() throws Exception {
+    ContainerBackgroundTaskResult result =
+        new ContainerBackgroundTaskResult();
+    while (blocksToDelete > 0) {
+      ContainerBackgroundTaskResult crr = handleDeleteTask();
+      blocksToDelete -= crr.getSize();
+      result.addAll(crr.getDeletedBlocks());
+      if (blocksToDelete > 0 && crr.getSize() == 0) {
+        LOG.warn("Block deletion failed, remaining Blocks to be deleted {}," +
+                " but no Block be deleted. Container" +
+                " {}, pending block count {}",
+            blocksToDelete, containerData.getContainerID(),
+            containerData.getNumPendingDeletionBlocks());
+        break;
+      }
+    }
+    return result;
+  }
+
+  private ContainerBackgroundTaskResult handleDeleteTask() throws Exception {
     ContainerBackgroundTaskResult crr;
     final Container container = ozoneContainer.getContainerSet()
         .getContainer(containerData.getContainerID());
@@ -167,6 +192,7 @@ public class BlockDeletingTask implements BackgroundTask {
       if (toDeleteBlocks.isEmpty()) {
         LOG.debug("No under deletion block found in container : {}",
             containerData.getContainerID());
+        blocksToDelete = 0;
         return crr;
       }
 
@@ -321,6 +347,7 @@ public class BlockDeletingTask implements BackgroundTask {
         // actually no delete transactions for the container, so reset the
         // pending delete block count to the correct value of zero.
         containerData.resetPendingDeleteBlockCount(meta);
+        blocksToDelete = 0;
         return crr;
       }
 
@@ -335,12 +362,18 @@ public class BlockDeletingTask implements BackgroundTask {
       int deletedBlocksProcessed = deleteBlocksResult.getBlocksProcessed();
       int deletedBlocksCount = deleteBlocksResult.getBlocksDeleted();
       long releasedBytes = deleteBlocksResult.getBytesReleased();
+      List<DeletedBlocksTransaction> deletedBlocksTxs =
+          deleteBlocksResult.getDeletedBlockTransactions();
+      deleteBlocksResult.getDeletedBlockTransactions().forEach(
+          tx -> crr.addAll(tx.getLocalIDList().stream()
+              .map(String::valueOf).collect(Collectors.toList()))
+      );
 
       // Once blocks are deleted... remove the blockID from blockDataTable
       // and also remove the transactions from txnTable.
       try (BatchOperation batch = meta.getStore().getBatchHandler()
           .initBatchOperation()) {
-        for (DeletedBlocksTransaction delTx : delBlocks) {
+        for (DeletedBlocksTransaction delTx : deletedBlocksTxs) {
           deleter.apply(deleteTxns, batch, delTx.getTxID());
           for (Long blk : delTx.getLocalIDList()) {
             blockDataTable.deleteWithBatch(batch,
@@ -396,6 +429,9 @@ public class BlockDeletingTask implements BackgroundTask {
     int blocksProcessed = 0;
     int blocksDeleted = 0;
     long bytesReleased = 0;
+    List<DeletedBlocksTransaction> deletedBlocksTxs = new ArrayList<>();
+    Instant startTime = Instant.now();
+
     for (DeletedBlocksTransaction entry : delBlocks) {
       for (Long blkLong : entry.getLocalIDList()) {
         String blk = containerData.getBlockKey(blkLong);
@@ -439,14 +475,31 @@ public class BlockDeletingTask implements BackgroundTask {
           }
         }
       }
+      deletedBlocksTxs.add(entry);
+      Duration execTime = Duration.between(startTime, Instant.now());
+      if (deletedBlocksTxs.size() < delBlocks.size() &&
+          execTime.compareTo(getBlockDeletingMaxLockHoldingTime()) > 0) {
+        LOG.info("Max lock hold time ({} ms) reached after {} ms. " +
+                "Completed {} transactions, deleted {} blocks." +
+                "In container: {}." +
+                "Releasing lock and resuming deletion later.",
+            getBlockDeletingMaxLockHoldingTime().toMillis(),
+            execTime.toMillis(), deletedBlocksTxs.size(), blocksDeleted,
+            container.getContainerData().getContainerID());
+        break;
+      }
     }
     return new DeleteTransactionStats(blocksProcessed,
-        blocksDeleted, bytesReleased);
+        blocksDeleted, bytesReleased, deletedBlocksTxs);
   }
 
   @Override
   public int getPriority() {
     return priority;
+  }
+
+  public Duration getBlockDeletingMaxLockHoldingTime() {
+    return blockDeletingMaxLockHoldingTime;
   }
 
   private interface Deleter {
@@ -462,11 +515,14 @@ public class BlockDeletingTask implements BackgroundTask {
     private final int blocksProcessed;
     private final int blocksDeleted;
     private final long bytesReleased;
+    private final List<DeletedBlocksTransaction> delBlockTxs;
 
-    DeleteTransactionStats(int proceeded, int deleted, long released) {
+    DeleteTransactionStats(int proceeded, int deleted, long released,
+        List<DeletedBlocksTransaction> delBlocks) {
       blocksProcessed = proceeded;
       blocksDeleted = deleted;
       bytesReleased = released;
+      delBlockTxs = delBlocks;
     }
 
     public int getBlocksProcessed() {
@@ -479,6 +535,10 @@ public class BlockDeletingTask implements BackgroundTask {
 
     public long getBytesReleased() {
       return bytesReleased;
+    }
+
+    public List<DeletedBlocksTransaction> getDeletedBlockTransactions() {
+      return delBlockTxs;
     }
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Reduce the granularity of Container locks for BlockDeletingService, Reduces the amount of time the BlockDeletingService holds a `Container` lock to reduce affect to others threads who need acquire the `Container`  lock

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-9107

## How was this patch tested?

existing test
