### PR TITLE
HDDS-9123. Make S3G MPU invalid part Exception Reporting More detailed

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/OzoneConsts.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/OzoneConsts.java
@@ -377,6 +377,10 @@ public final class OzoneConsts {
   // For Multipart upload
   public static final int OM_MULTIPART_MIN_SIZE = 5 * 1024 * 1024;
 
+  // refer to :
+  // https://docs.aws.amazon.com/AmazonS3/latest/userguide/qfacts.html
+  public static final int MAXIMUM_NUMBER_OF_PARTS_PER_UPLOAD = 10000;
+
   // GRPC block token metadata header and context key
   public static final String OZONE_BLOCK_TOKEN = "blocktoken";
   public static final Context.Key<UserGroupInformation> UGI_CTX_KEY =

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/rpc/RpcClient.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/rpc/RpcClient.java
@@ -167,6 +167,7 @@ import static org.apache.hadoop.ozone.OzoneAcl.AclScope.ACCESS;
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_CLIENT_KEY_PROVIDER_CACHE_EXPIRY;
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_CLIENT_KEY_PROVIDER_CACHE_EXPIRY_DEFAULT;
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_CLIENT_REQUIRED_OM_VERSION_MIN_KEY;
+import static org.apache.hadoop.ozone.OzoneConsts.MAXIMUM_NUMBER_OF_PARTS_PER_UPLOAD;
 import static org.apache.hadoop.ozone.OzoneConsts.OLD_QUOTA_DEFAULT;
 import static org.apache.hadoop.ozone.OzoneConsts.OZONE_MAXIMUM_ACCESS_ID_LENGTH;
 import static org.apache.hadoop.ozone.security.acl.IAccessAuthorizer.ACLType.READ;
@@ -1738,8 +1739,11 @@ public class RpcClient implements ClientProtocol {
       HddsClientUtils.verifyKeyName(keyName);
     }
     HddsClientUtils.checkNotNull(keyName, uploadID);
-    Preconditions.checkArgument(partNumber > 0 && partNumber <= 10000, "Part " +
-        "number should be greater than zero and less than or equal to 10000");
+    if (partNumber <= 0 || partNumber > MAXIMUM_NUMBER_OF_PARTS_PER_UPLOAD) {
+      throw new OMException("Part number must be an integer between 1 and "
+          + MAXIMUM_NUMBER_OF_PARTS_PER_UPLOAD + ", inclusive",
+          OMException.ResultCodes.INVALID_PART);
+    }
     Preconditions.checkArgument(size >= 0, "size should be greater than or " +
         "equal to zero");
     OmKeyArgs keyArgs = new OmKeyArgs.Builder()

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestOzoneClientMultipartUploadWithFSO.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestOzoneClientMultipartUploadWithFSO.java
@@ -408,8 +408,6 @@ public class TestOzoneClientMultipartUploadWithFSO {
 
   @Test
   public void testMultipartPartNumberExceedingAllowedRange() throws Exception {
-    // https://docs.aws.amazon.com/AmazonS3/latest/userguide/qfacts.html
-    keyName = UUID.randomUUID().toString();
     String uploadID = initiateMultipartUpload(bucket, keyName,
         RATIS, ONE);
     byte[] data = "data".getBytes(UTF_8);

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestOzoneClientMultipartUploadWithFSO.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestOzoneClientMultipartUploadWithFSO.java
@@ -407,6 +407,28 @@ public class TestOzoneClientMultipartUploadWithFSO {
   }
 
   @Test
+  public void testMultipartPartNumberExceedingAllowedRange() throws Exception {
+    // https://docs.aws.amazon.com/AmazonS3/latest/userguide/qfacts.html
+    keyName = UUID.randomUUID().toString();
+    String uploadID = initiateMultipartUpload(bucket, keyName,
+        RATIS, ONE);
+    byte[] data = "data".getBytes(UTF_8);
+
+    // Multipart part number must be an integer between 1 and 10000. So the
+    // part number 1, 5000, 10000 will succeed,
+    // the part number 0, 10001 will fail.
+    bucket.createMultipartKey(keyName, data.length, 1, uploadID);
+    bucket.createMultipartKey(keyName, data.length, 5000, uploadID);
+    bucket.createMultipartKey(keyName, data.length, 10000, uploadID);
+    OzoneTestUtils.expectOmException(OMException.ResultCodes.INVALID_PART,
+        () -> bucket.createMultipartKey(
+            keyName, data.length, 0, uploadID));
+    OzoneTestUtils.expectOmException(OMException.ResultCodes.INVALID_PART,
+        () -> bucket.createMultipartKey(
+            keyName, data.length, 10001, uploadID));
+  }
+
+  @Test
   public void testCommitPartAfterCompleteUpload() throws Exception {
     String parentDir = "a/b/c/d/";
     keyName = parentDir + UUID.randomUUID().toString();

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestOzoneRpcClientAbstract.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestOzoneRpcClientAbstract.java
@@ -2968,7 +2968,6 @@ public abstract class TestOzoneRpcClientAbstract {
 
   @Test
   public void testMultipartPartNumberExceedingAllowedRange() throws Exception {
-    // https://docs.aws.amazon.com/AmazonS3/latest/userguide/qfacts.html
     String volumeName = UUID.randomUUID().toString();
     String bucketName = UUID.randomUUID().toString();
     String keyName = UUID.randomUUID().toString();

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestOzoneRpcClientAbstract.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestOzoneRpcClientAbstract.java
@@ -2967,6 +2967,36 @@ public abstract class TestOzoneRpcClientAbstract {
   }
 
   @Test
+  public void testMultipartPartNumberExceedingAllowedRange() throws Exception {
+    // https://docs.aws.amazon.com/AmazonS3/latest/userguide/qfacts.html
+    String volumeName = UUID.randomUUID().toString();
+    String bucketName = UUID.randomUUID().toString();
+    String keyName = UUID.randomUUID().toString();
+    String sampleData = "sample Value";
+
+    store.createVolume(volumeName);
+    OzoneVolume volume = store.getVolume(volumeName);
+    volume.createBucket(bucketName);
+    OzoneBucket bucket = volume.getBucket(bucketName);
+    OmMultipartInfo multipartInfo = bucket.initiateMultipartUpload(keyName);
+    assertNotNull(multipartInfo);
+    String uploadID = multipartInfo.getUploadID();
+
+    // Multipart part number must be an integer between 1 and 10000. So the
+    // part number 1, 5000, 10000 will succeed,
+    // the part number 0, 10001 will fail.
+    bucket.createMultipartKey(keyName, sampleData.length(), 1, uploadID);
+    bucket.createMultipartKey(keyName, sampleData.length(), 5000, uploadID);
+    bucket.createMultipartKey(keyName, sampleData.length(), 10000, uploadID);
+    OzoneTestUtils.expectOmException(ResultCodes.INVALID_PART, () ->
+        bucket.createMultipartKey(
+            keyName, sampleData.length(), 0, uploadID));
+    OzoneTestUtils.expectOmException(ResultCodes.INVALID_PART, () ->
+        bucket.createMultipartKey(
+            keyName, sampleData.length(), 10001, uploadID));
+  }
+
+  @Test
   public void testAbortUploadFail() throws Exception {
     String volumeName = UUID.randomUUID().toString();
     String bucketName = UUID.randomUUID().toString();

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/ObjectEndpoint.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/ObjectEndpoint.java
@@ -919,6 +919,11 @@ public class ObjectEndpoint extends EndpointBase {
         throw newError(NO_SUCH_UPLOAD, uploadID, ex);
       } else if (isAccessDenied(ex)) {
         throw newError(S3ErrorTable.ACCESS_DENIED, bucket + "/" + key, ex);
+      } else if ((ex.getResult() == ResultCodes.INVALID_PART)) {
+        OS3Exception os3Exception = S3ErrorTable.newError(
+            S3ErrorTable.INVALID_ARGUMENT, String.valueOf(partNumber), ex);
+        os3Exception.setErrorMessage(ex.getMessage());
+        throw os3Exception;
       }
       throw ex;
     }

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/ObjectEndpoint.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/ObjectEndpoint.java
@@ -919,7 +919,7 @@ public class ObjectEndpoint extends EndpointBase {
         throw newError(NO_SUCH_UPLOAD, uploadID, ex);
       } else if (isAccessDenied(ex)) {
         throw newError(S3ErrorTable.ACCESS_DENIED, bucket + "/" + key, ex);
-      } else if ((ex.getResult() == ResultCodes.INVALID_PART)) {
+      } else if (ex.getResult() == ResultCodes.INVALID_PART) {
         OS3Exception os3Exception = newError(
             S3ErrorTable.INVALID_ARGUMENT, String.valueOf(partNumber), ex);
         os3Exception.setErrorMessage(ex.getMessage());

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/ObjectEndpoint.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/ObjectEndpoint.java
@@ -920,7 +920,7 @@ public class ObjectEndpoint extends EndpointBase {
       } else if (isAccessDenied(ex)) {
         throw newError(S3ErrorTable.ACCESS_DENIED, bucket + "/" + key, ex);
       } else if ((ex.getResult() == ResultCodes.INVALID_PART)) {
-        OS3Exception os3Exception = S3ErrorTable.newError(
+        OS3Exception os3Exception = newError(
             S3ErrorTable.INVALID_ARGUMENT, String.valueOf(partNumber), ex);
         os3Exception.setErrorMessage(ex.getMessage());
         throw os3Exception;


### PR DESCRIPTION
## What changes were proposed in this pull request?
Make S3G MPU invalid part Exception Reporting More detailed, For MPU, the Part number must be an integer between 1 and 10000, refer to: https://docs.aws.amazon.com/AmazonS3/latest/userguide/qfacts.html

Before
```bash
[root@VM-8-3-centos ~]$ aws s3api upload-part --bucket pony-bucket1 --key my-large-file --part-number 0 --body /root/1M.img --upload-id adf5534e-a2c2-430c-b07d-e659f63adbdc-110831976767881217 --endpoint-url http://localhost:9878

An error occurred (500) when calling the UploadPart operation (reached max retries: 2): Internal Server Error
[root@VM-8-3-centos ~]$ aws s3api upload-part --bucket pony-bucket1 --key my-large-file --part-number 10001 --body /root/1M.img --upload-id adf5534e-a2c2-430c-b07d-e659f63adbdc-110831976767881217 --endpoint-url http://localhost:9878

An error occurred (500) when calling the UploadPart operation (reached max retries: 2): Internal Server Error
```

After this PR
```bash
[root@VM-8-3-centos ~]$ aws s3api upload-part --bucket pony-bucket1 --key my-large-file --part-number 0 --body /root/1M.img --upload-id adf5534e-a2c2-430c-b07d-e659f63adbdc-110831976767881217 --endpoint-url http://localhost:9878

An error occurred (InvalidArgument) when calling the UploadPart operation: Part number must be an integer between 1 and 10000, inclusive
[root@VM-8-3-centos ~]$ aws s3api upload-part --bucket pony-bucket1 --key my-large-file --part-number 10001 --body /root/1M.img --upload-id adf5534e-a2c2-430c-b07d-e659f63adbdc-110831976767881217 --endpoint-url http://localhost:9878

An error occurred (InvalidArgument) when calling the UploadPart operation: Part number must be an integer between 1 and 10000, inclusive
```

Refer to AWS 
```bash
[root@VM-8-3-centos ~]$ aws s3api upload-part --bucket pony-bucket1 --key my-large-file --part-number 10001 --body /root/1M.img --upload-id IxGus3j8XchCM0F2nSk3xaS.w8C6xZl6.hMYslFEiYD3xdIfqBPu0DcVWYRgx1wzIvvexUvr8dpoxQOxPv3SxaoyG2OOYkcendOyoZbMuhnbaEP84.ff3cf4Fq4R6AKPYrK9A7kRgED2k48P40Y7NA--

An error occurred (InvalidArgument) when calling the UploadPart operation: Part number must be an integer between 1 and 10000, inclusive
[root@VM-8-3-centos ~]$ aws s3api upload-part --bucket pony-bucket1 --key my-large-file --part-number 0 --body /root/1M.img --upload-id IxGus3j8XchCM0F2nSk3xaS.w8C6xZl6.hMYslFEiYD3xdIfqBPu0DcVWYRgx1wzIvvexUvr8dpoxQOxPv3SxaoyG2OOYkcendOyoZbMuhnbaEP84.ff3cf4Fq4R6AKPYrK9A7kRgED2k48P40Y7NA--

An error occurred (InvalidArgument) when calling the UploadPart operation: Part number must be an integer between 1 and 10000, inclusive
[root@VM-8-3-centos ~]$
```

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-9123

## How was this patch tested?

