### PR TITLE
HDDS-9126. [Snapshot] SstFilteringService throws Exception while processing deleted snapshots.

### DIFF
--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/KeyManagerImpl.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/KeyManagerImpl.java
@@ -646,7 +646,7 @@ public class KeyManagerImpl implements KeyManager {
         .getTimeDuration(OZONE_SNAPSHOT_SST_FILTERING_SERVICE_INTERVAL,
             OZONE_SNAPSHOT_SST_FILTERING_SERVICE_INTERVAL_DEFAULT,
             TimeUnit.MILLISECONDS);
-    return serviceInterval != KeyManagerImpl.DISABLE_VALUE;
+    return serviceInterval != DISABLE_VALUE;
   }
 
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/KeyManagerImpl.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/KeyManagerImpl.java
@@ -264,7 +264,7 @@ public class KeyManagerImpl implements KeyManager {
           OZONE_SNAPSHOT_SST_FILTERING_SERVICE_TIMEOUT,
           OZONE_SNAPSHOT_SST_FILTERING_SERVICE_TIMEOUT_DEFAULT,
           TimeUnit.MILLISECONDS);
-      if (serviceInterval != DISABLE_VALUE) {
+      if (isSstFilteringSvcEnabled()) {
         snapshotSstFilteringService =
             new SstFilteringService(serviceInterval, TimeUnit.MILLISECONDS,
                 serviceTimeout, ozoneManager, configuration);
@@ -640,6 +640,15 @@ public class KeyManagerImpl implements KeyManager {
   public SnapshotDeletingService getSnapshotDeletingService() {
     return snapshotDeletingService;
   }
+
+  public boolean isSstFilteringSvcEnabled() {
+    long serviceInterval = ozoneManager.getConfiguration()
+        .getTimeDuration(OZONE_SNAPSHOT_SST_FILTERING_SERVICE_INTERVAL,
+            OZONE_SNAPSHOT_SST_FILTERING_SERVICE_INTERVAL_DEFAULT,
+            TimeUnit.MILLISECONDS);
+    return serviceInterval != KeyManagerImpl.DISABLE_VALUE;
+  }
+
 
   @Override
   public OmMultipartUploadList listMultipartUploads(String volumeName,

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/SstFilteringService.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/SstFilteringService.java
@@ -37,6 +37,7 @@ import org.apache.hadoop.ozone.om.helpers.SnapshotInfo;
 import org.apache.hadoop.ozone.om.snapshot.ReferenceCounted;
 import org.apache.hadoop.ozone.om.snapshot.SnapshotCache;
 import org.apache.ozone.rocksdiff.RocksDiffUtils;
+import org.rocksdb.RocksDBException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -226,7 +227,7 @@ public class SstFilteringService extends BackgroundService
                 snapshotInfo.getBucketName(), snapshotInfo.getName());
             snapshotLimit--;
             snapshotFilteredCount.getAndIncrement();
-          } catch (Exception e) {
+          } catch (RocksDBException | IOException e) {
             LOG.error("Exception encountered while filtering a snapshot", e);
           }
         }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/SstFilteringService.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/SstFilteringService.java
@@ -198,7 +198,7 @@ public class SstFilteringService extends BackgroundService
             try (
                 ReferenceCounted<IOmMetadataReader, SnapshotCache>
                     snapshotMetadataReader = snapshotCache.get().get(
-                        snapshotInfo.getTableKey(),true)) {
+                    snapshotInfo.getTableKey(), true)) {
               OmSnapshot omSnapshot = (OmSnapshot) snapshotMetadataReader.get();
               RDBStore rdbStore =
                   (RDBStore) omSnapshot.getMetadataManager().getStore();

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/service/SnapshotDeletingService.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/service/SnapshotDeletingService.java
@@ -163,7 +163,7 @@ public class SnapshotDeletingService extends AbstractKeyDeletingService {
           // Only Iterate in deleted snapshot
           if (!snapshotStatus.equals(
               SnapshotInfo.SnapshotStatus.SNAPSHOT_DELETED) &&
-              (isSstFilteringSvcEnabled && snapInfo.isSstFiltered())) {
+              !(isSstFilteringSvcEnabled && snapInfo.isSstFiltered())) {
             continue;
           }
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/service/SnapshotDeletingService.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/service/SnapshotDeletingService.java
@@ -158,7 +158,7 @@ public class SnapshotDeletingService extends AbstractKeyDeletingService {
           // Only Iterate in deleted snapshot
           if (!snapshotStatus.equals(
               SnapshotInfo.SnapshotStatus.SNAPSHOT_DELETED) ||
-              (isSstFilteringServiceEnabled && snapInfo.isSstFiltered())) {
+              (isSstFilteringServiceEnabled && !snapInfo.isSstFiltered())) {
             continue;
           }
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/service/SnapshotDeletingService.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/service/SnapshotDeletingService.java
@@ -156,9 +156,8 @@ public class SnapshotDeletingService extends AbstractKeyDeletingService {
                   .isSstFilteringSvcEnabled();
 
           // Only Iterate in deleted snapshot
-          if (!snapshotStatus.equals(
-              SnapshotInfo.SnapshotStatus.SNAPSHOT_DELETED) ||
-              (isSstFilteringServiceEnabled && !snapInfo.isSstFiltered())) {
+          if (shouldIgnoreSnapshot(snapInfo, snapshotStatus,
+              isSstFilteringServiceEnabled)) {
             continue;
           }
 
@@ -568,6 +567,14 @@ public class SnapshotDeletingService extends AbstractKeyDeletingService {
             "Will retry at next run.", e);
       }
     }
+  }
+
+  public static boolean shouldIgnoreSnapshot(SnapshotInfo snapInfo,
+      SnapshotInfo.SnapshotStatus snapshotStatus,
+      boolean isSstFilteringServiceEnabled) {
+    return !snapshotStatus.equals(
+        SnapshotInfo.SnapshotStatus.SNAPSHOT_DELETED)
+        || (isSstFilteringServiceEnabled && !snapInfo.isSstFiltered());
   }
 
   // TODO: Move this util class.

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/service/SnapshotDeletingService.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/service/SnapshotDeletingService.java
@@ -156,8 +156,7 @@ public class SnapshotDeletingService extends AbstractKeyDeletingService {
                   .isSstFilteringSvcEnabled();
 
           // Only Iterate in deleted snapshot
-          if (shouldIgnoreSnapshot(snapInfo, snapshotStatus,
-              isSstFilteringServiceEnabled)) {
+          if (shouldIgnoreSnapshot(snapInfo, isSstFilteringServiceEnabled)) {
             continue;
           }
 
@@ -570,10 +569,9 @@ public class SnapshotDeletingService extends AbstractKeyDeletingService {
   }
 
   public static boolean shouldIgnoreSnapshot(SnapshotInfo snapInfo,
-      SnapshotInfo.SnapshotStatus snapshotStatus,
       boolean isSstFilteringServiceEnabled) {
-    return !snapshotStatus.equals(
-        SnapshotInfo.SnapshotStatus.SNAPSHOT_DELETED)
+    SnapshotInfo.SnapshotStatus snapshotStatus = snapInfo.getSnapshotStatus();
+    return !(snapshotStatus == SnapshotInfo.SnapshotStatus.SNAPSHOT_DELETED)
         || (isSstFilteringServiceEnabled && !snapInfo.isSstFiltered());
   }
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/service/SnapshotDeletingService.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/service/SnapshotDeletingService.java
@@ -148,9 +148,6 @@ public class SnapshotDeletingService extends AbstractKeyDeletingService {
 
         while (iterator.hasNext() && snapshotLimit > 0) {
           SnapshotInfo snapInfo = iterator.next().getValue();
-          SnapshotInfo.SnapshotStatus snapshotStatus =
-              snapInfo.getSnapshotStatus();
-
           boolean isSstFilteringServiceEnabled =
               ((KeyManagerImpl) ozoneManager.getKeyManager())
                   .isSstFilteringSvcEnabled();

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/service/SnapshotDeletingService.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/service/SnapshotDeletingService.java
@@ -162,8 +162,8 @@ public class SnapshotDeletingService extends AbstractKeyDeletingService {
 
           // Only Iterate in deleted snapshot
           if (!snapshotStatus.equals(
-              SnapshotInfo.SnapshotStatus.SNAPSHOT_DELETED) &&
-              !(isSstFilteringSvcEnabled && snapInfo.isSstFiltered())) {
+              SnapshotInfo.SnapshotStatus.SNAPSHOT_DELETED) ||
+              (isSstFilteringSvcEnabled && snapInfo.isSstFiltered()) ) {
             continue;
           }
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/service/SnapshotDeletingService.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/service/SnapshotDeletingService.java
@@ -163,7 +163,7 @@ public class SnapshotDeletingService extends AbstractKeyDeletingService {
           // Only Iterate in deleted snapshot
           if (!snapshotStatus.equals(
               SnapshotInfo.SnapshotStatus.SNAPSHOT_DELETED) ||
-              (isSstFilteringSvcEnabled && snapInfo.isSstFiltered()) ) {
+              (isSstFilteringSvcEnabled && snapInfo.isSstFiltered())) {
             continue;
           }
 

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestSstFilteringService.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestSstFilteringService.java
@@ -77,6 +77,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * Test SST Filtering Service.
  */
 public class TestSstFilteringService {
+  public static final String SST_FILE_EXTENSION = ".sst";
   @TempDir
   private File folder;
   private OzoneManagerProtocol writeClient;
@@ -256,6 +257,74 @@ public class TestSstFilteringService {
     Set<String> keysFromSnapshot2 =
         getKeysFromSnapshot(volumeName, bucketName2, snapshotName2);
     assertEquals(keysFromActiveDb2, keysFromSnapshot2);
+  }
+
+  @Test
+  public void testActiveSnapshotCleanup() throws IOException {
+    RDBStore activeDbStore = (RDBStore) om.getMetadataManager().getStore();
+    String volumeName = "volume1";
+    List<String> bucketNames = Arrays.asList("bucket1", "bucket2");
+
+    // Create 2 Buckets
+    for (String bucketName : bucketNames) {
+      createVolumeAndBucket(volumeName, bucketName);
+    }
+    // Write 25 keys in each bucket, 2 sst files would be generated each for
+    // keys in a single bucket
+    int keyCount = 25;
+    for (int bucketIdx = 0; bucketIdx < bucketNames.size(); bucketIdx++) {
+      for (int i = 1; i <= keyCount; i++) {
+        createKey(writeClient, volumeName, bucketNames.get(bucketIdx),
+            "key" + i);
+      }
+      activeDbStore.getDb().flush(OmMetadataManagerImpl.KEY_TABLE);
+      activeDbStore.getDb().compactRange(OmMetadataManagerImpl.KEY_TABLE);
+    }
+
+    SstFilteringService sstFilteringService =
+        keyManager.getSnapshotSstFilteringService();
+    sstFilteringService.pause();
+
+    writeClient.createSnapshot(volumeName, bucketNames.get(0), "snap1");
+    writeClient.createSnapshot(volumeName, bucketNames.get(0), "snap2");
+
+    SnapshotInfo snapshot1Info = om.getMetadataManager().getSnapshotInfoTable()
+        .get(SnapshotInfo.getTableKey(volumeName, bucketNames.get(0), "snap1"));
+    File snapshot1Dir =
+        new File(OmSnapshotManager.getSnapshotPath(conf, snapshot1Info));
+    SnapshotInfo snapshot2Info = om.getMetadataManager().getSnapshotInfoTable()
+        .get(SnapshotInfo.getTableKey(volumeName, bucketNames.get(0), "snap2"));
+    File snapshot2Dir =
+        new File(OmSnapshotManager.getSnapshotPath(conf, snapshot2Info));
+
+    File snap1Current = new File(snapshot1Dir, "CURRENT");
+    File snap2Current = new File(snapshot2Dir, "CURRENT");
+
+    // wait till both checkpoints are created
+    with().atMost(Duration.ofSeconds(10)).pollInterval(Duration.ofSeconds(1))
+        .await().until(() -> snap1Current.exists() && snap2Current.exists());
+
+    long snap1SstFileCountBeforeFilter = Arrays.stream(snapshot1Dir.listFiles())
+        .filter(f -> f.getName().endsWith(".sst")).count();
+    long snap2SstFileCountBeforeFilter = Arrays.stream(snapshot2Dir.listFiles())
+        .filter(f -> f.getName().endsWith(".sst")).count();
+
+    // delete snap1
+    writeClient.deleteSnapshot(volumeName, bucketNames.get(0), "snap1");
+    sstFilteringService.resume();
+    // Filtering service will only act on snap2 as it is an active snaphot
+    with().atMost(Duration.ofSeconds(10)).pollInterval(Duration.ofSeconds(1))
+        .await()
+        .until(() -> sstFilteringService.getSnapshotFilteredCount().get() >= 1);
+    long snap1SstFileCountAfterFilter = Arrays.stream(snapshot1Dir.listFiles())
+        .filter(f -> f.getName().endsWith(SST_FILE_EXTENSION)).count();
+    long snap2SstFileCountAfterFilter = Arrays.stream(snapshot2Dir.listFiles())
+        .filter(f -> f.getName().endsWith(SST_FILE_EXTENSION)).count();
+    assertEquals(1, sstFilteringService.getSnapshotFilteredCount().get());
+    assertEquals(snap1SstFileCountAfterFilter, snap1SstFileCountBeforeFilter);
+    // one sst will be filtered in the active (non-deleted) snapshot
+    assertEquals(snap2SstFileCountBeforeFilter - 1,
+        snap2SstFileCountAfterFilter);
   }
 
   private void createKeys(String volumeName,

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestSstFilteringService.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestSstFilteringService.java
@@ -313,10 +313,11 @@ public class TestSstFilteringService {
         .filter(f -> f.getName().endsWith(SST_FILE_EXTENSION)).count();
     long snap2SstFileCountAfterFilter = Arrays.stream(snapshot2Dir.listFiles())
         .filter(f -> f.getName().endsWith(SST_FILE_EXTENSION)).count();
+    // one sst will be filtered in both active but not in  deleted snapshot
+    // as sstFiltering svc won't run on already deleted snapshots but will mark
+    // it as filtered.
     assertEquals(2, sstFilteringService.getSnapshotFilteredCount().get());
-    // one sst will be filtered in both active & deleted snapshot
-    assertEquals(snap1SstFileCountBeforeFilter - 1,
-        snap1SstFileCountAfterFilter);
+    assertEquals(snap1SstFileCountBeforeFilter, snap1SstFileCountAfterFilter);
     assertEquals(snap2SstFileCountBeforeFilter - 1,
         snap2SstFileCountAfterFilter);
   }

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestSstFilteringService.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestSstFilteringService.java
@@ -253,7 +253,7 @@ public class TestSstFilteringService {
   }
 
   @Test
-  public void testActiveSnapshotCleanup() throws IOException {
+  public void testActiveAndDeletedSnapshotCleanup() throws IOException {
     RDBStore activeDbStore = (RDBStore) om.getMetadataManager().getStore();
     String volumeName = "volume1";
     List<String> bucketNames = Arrays.asList("bucket1", "bucket2");
@@ -308,14 +308,15 @@ public class TestSstFilteringService {
     // Filtering service will only act on snap2 as it is an active snaphot
     with().atMost(Duration.ofSeconds(10)).pollInterval(Duration.ofSeconds(1))
         .await()
-        .until(() -> sstFilteringService.getSnapshotFilteredCount().get() >= 1);
+        .until(() -> sstFilteringService.getSnapshotFilteredCount().get() >= 2);
     long snap1SstFileCountAfterFilter = Arrays.stream(snapshot1Dir.listFiles())
         .filter(f -> f.getName().endsWith(SST_FILE_EXTENSION)).count();
     long snap2SstFileCountAfterFilter = Arrays.stream(snapshot2Dir.listFiles())
         .filter(f -> f.getName().endsWith(SST_FILE_EXTENSION)).count();
-    assertEquals(1, sstFilteringService.getSnapshotFilteredCount().get());
-    assertEquals(snap1SstFileCountAfterFilter, snap1SstFileCountBeforeFilter);
-    // one sst will be filtered in the active (non-deleted) snapshot
+    assertEquals(2, sstFilteringService.getSnapshotFilteredCount().get());
+    // one sst will be filtered in both active & deleted snapshot
+    assertEquals(snap1SstFileCountBeforeFilter - 1,
+        snap1SstFileCountAfterFilter);
     assertEquals(snap2SstFileCountBeforeFilter - 1,
         snap2SstFileCountAfterFilter);
   }

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/snapshot/TestOmSnapshotUtils.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/snapshot/TestOmSnapshotUtils.java
@@ -18,15 +18,21 @@
 
 package org.apache.hadoop.ozone.om.snapshot;
 
+import org.apache.hadoop.ozone.om.helpers.SnapshotInfo;
+import org.apache.hadoop.ozone.om.service.SnapshotDeletingService;
 import org.apache.ozone.test.GenericTestUtils;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.io.File;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Set;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.apache.hadoop.ozone.om.snapshot.OmSnapshotUtils.getINode;
@@ -78,4 +84,41 @@ public class TestOmSnapshotUtils {
     assertEquals(tree1Files, tree2Files);
     GenericTestUtils.deleteDirectory(tempDir);
   }
+
+
+  private static Stream<Arguments> testCasesForIgnoreSnapshotGc() {
+    SnapshotInfo filteredSnapshot =
+        SnapshotInfo.newBuilder().setSstFiltered(true).setName("snap1").build();
+    SnapshotInfo unFilteredSnapshot =
+        SnapshotInfo.newBuilder().setSstFiltered(false).setName("snap1")
+            .build();
+    // {IsSnapshotFiltered,isSnapshotDeleted,IsSstServiceEnabled = ShouldIgnore}
+    return Stream.of(Arguments.of(filteredSnapshot,
+            SnapshotInfo.SnapshotStatus.SNAPSHOT_DELETED, true, false),
+        Arguments.of(filteredSnapshot,
+            SnapshotInfo.SnapshotStatus.SNAPSHOT_ACTIVE, true, true),
+        Arguments.of(unFilteredSnapshot,
+            SnapshotInfo.SnapshotStatus.SNAPSHOT_DELETED, true, true),
+        Arguments.of(unFilteredSnapshot,
+            SnapshotInfo.SnapshotStatus.SNAPSHOT_ACTIVE, true, true),
+        Arguments.of(filteredSnapshot,
+            SnapshotInfo.SnapshotStatus.SNAPSHOT_DELETED, false, false),
+        Arguments.of(unFilteredSnapshot,
+            SnapshotInfo.SnapshotStatus.SNAPSHOT_DELETED, false, false),
+        Arguments.of(unFilteredSnapshot,
+            SnapshotInfo.SnapshotStatus.SNAPSHOT_ACTIVE, false, true),
+        Arguments.of(filteredSnapshot,
+            SnapshotInfo.SnapshotStatus.SNAPSHOT_ACTIVE, false, true));
+  }
+
+  @ParameterizedTest
+  @MethodSource("testCasesForIgnoreSnapshotGc")
+  public void testProcessSnapshotLogicInSDS(SnapshotInfo snapshotInfo,
+      SnapshotInfo.SnapshotStatus status, boolean isSstFilteringSvcEnabled,
+      boolean expectedOutcome) {
+    assertEquals(expectedOutcome,
+        SnapshotDeletingService.shouldIgnoreSnapshot(snapshotInfo, status,
+            isSstFilteringSvcEnabled));
+  }
+
 }

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/snapshot/TestOmSnapshotUtils.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/snapshot/TestOmSnapshotUtils.java
@@ -117,7 +117,7 @@ public class TestOmSnapshotUtils {
       SnapshotInfo.SnapshotStatus status, boolean isSstFilteringSvcEnabled,
       boolean expectedOutcome) {
     assertEquals(expectedOutcome,
-        SnapshotDeletingService.shouldIgnoreSnapshot(snapshotInfo, status,
+        SnapshotDeletingService.shouldIgnoreSnapshot(snapshotInfo,
             isSstFilteringSvcEnabled));
   }
 

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/snapshot/TestOmSnapshotUtils.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/snapshot/TestOmSnapshotUtils.java
@@ -116,6 +116,7 @@ public class TestOmSnapshotUtils {
   public void testProcessSnapshotLogicInSDS(SnapshotInfo snapshotInfo,
       SnapshotInfo.SnapshotStatus status, boolean isSstFilteringSvcEnabled,
       boolean expectedOutcome) {
+    snapshotInfo.setSnapshotStatus(status);
     assertEquals(expectedOutcome,
         SnapshotDeletingService.shouldIgnoreSnapshot(snapshotInfo,
             isSstFilteringSvcEnabled));


### PR DESCRIPTION
## What changes were proposed in this pull request?
SstFilteringService throws Exception while processing deleted snapshots. 
1. The fix here is to catch the exception occurred while loading a deleted snapshot, check  if it is actually deleted and mark it as filtered.
2. Also added a condition in SnapshotDeletingService to perform gc only if the snapshots are filtering complete

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-9126


## How was this patch tested?
Unit tests
