### PR TITLE
HDDS-9128. Ozone freon tool extension for benchmarking listKeys operation

### DIFF
--- a/hadoop-ozone/dist/src/main/smoketest/freon/read-write-key.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/freon/read-write-key.robot
@@ -28,18 +28,18 @@ Pre-generate 100 keys of size 1 byte each to Ozone
 
 Read 10 keys from pre-generated keys
     ${keysCount} =     BuiltIn.Set Variable   10
-    ${result} =        Execute          ozone freon ockrw -n ${keysCount} -t 10 -r 100 -v voltest -b buckettest -p performanceTest
+    ${result} =        Execute          ozone freon ockrw -n ${keysCount} -t 10 -r 100 -v voltest -b buckettest -p performanceTest --percentage-read 100 --percentage-list 0
                        Should contain   ${result}   Successful executions: ${keysCount}
 
 Read 10 keys' metadata from pre-generated keys
     ${keysCount} =     BuiltIn.Set Variable   10
-    ${result} =        Execute          ozone freon ockrw -n ${keysCount} -t 10 -m -r 100 -v voltest -b buckettest -p performanceTest
+    ${result} =        Execute          ozone freon ockrw -n ${keysCount} -t 10 -m -r 100 -v voltest -b buckettest -p performanceTest --percentage-read 100 --percentage-list 0
                        Should contain   ${result}   Successful executions: ${keysCount}
 
 Write 10 keys of size 1 byte each from key index 0 to 99
     ${keysCount} =     BuiltIn.Set Variable   10
     ${size} =          BuiltIn.Set Variable   1
-    ${result} =        Execute          ozone freon ockrw -n ${keysCount} -t 10 --percentage-read 0 --size ${size} -r 100 -v voltest -b buckettest -p performanceTest
+    ${result} =        Execute          ozone freon ockrw -n ${keysCount} -t 10 --percentage-read 0 --percentage-list 0 --size ${size} -r 100 -v voltest -b buckettest -p performanceTest
                        Should contain   ${result}   Successful executions: ${keysCount}
     ${keyName} =       Execute          echo -n '1' | md5sum | head -c 7
     ${result} =        Execute          ozone sh key info /voltest/buckettest/performanceTest/${keyName}
@@ -48,6 +48,11 @@ Write 10 keys of size 1 byte each from key index 0 to 99
 
 Run 90 % of read-key tasks and 10 % of write-key tasks for 10 keys from pre-generated keys
     ${keysCount} =     BuiltIn.Set Variable   10
-    ${result} =        Execute          ozone freon ockrw -n ${keysCount} -t 10 --percentage-read 90 -r 100 -v voltest -b buckettest -p performanceTest
+    ${result} =        Execute          ozone freon ockrw -n ${keysCount} -t 10 --percentage-read 90 --percentage-list 0 -r 100 -v voltest -b buckettest -p performanceTest
+                       Should contain   ${result}   Successful executions: ${keysCount}
+
+Run 50 % of read-key tasks, 40 % list-key tasks and 10 % of write-key tasks for 10 keys from pre-generated keys
+    ${keysCount} =     BuiltIn.Set Variable   10
+    ${result} =        Execute          ozone freon ockrw -n ${keysCount} -t 10 --percentage-read 50 --percentage-list 40 -r 100 -v voltest -b buckettest -p performanceTest
                        Should contain   ${result}   Successful executions: ${keysCount}
 

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/Freon.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/Freon.java
@@ -68,7 +68,7 @@ import picocli.CommandLine.Option;
         OmBucketReadWriteFileOps.class,
         OmBucketReadWriteKeyOps.class,
         OmRPCLoadGenerator.class,
-        OzoneClientKeyReadWriteOps.class,
+        OzoneClientKeyReadWriteListOps.class,
         RangeKeysGenerator.class,
         DatanodeSimulator.class,
         OmMetadataGenerator.class

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/OzoneClientKeyReadWriteListOps.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/OzoneClientKeyReadWriteListOps.java
@@ -42,13 +42,13 @@ import static org.apache.hadoop.ozone.freon.KeyGeneratorUtil.FILE_DIR_SEPARATOR;
  */
 
 @CommandLine.Command(name = "ockrw",
-        aliases = "ozone-client-key-read-write-ops",
+        aliases = "ozone-client-key-read-write-list-ops",
         description = "Generate keys with a fixed name and ranges that can" 
-        + " be written and read as sub-ranges from multiple clients.",
+        + " be written, read and listed as sub-ranges from multiple clients.",
         versionProvider = HddsVersionProvider.class,
         mixinStandardHelpOptions = true,
         showDefaultValues = true)
-public class OzoneClientKeyReadWriteOps extends BaseFreonGenerator
+public class OzoneClientKeyReadWriteListOps extends BaseFreonGenerator
         implements Callable<Void> {
 
   @CommandLine.Option(names = {"-v", "--volume"},
@@ -98,10 +98,23 @@ public class OzoneClientKeyReadWriteOps extends BaseFreonGenerator
 
   @CommandLine.Option(names = {"--percentage-read"},
           description = "Percentage of read tasks in mix workload."
-          + " The remainder of the percentage will writes to keys."
-          + " Example --percentage-read 90 will result in 10% writes.",
-          defaultValue = "100")
+          + " The remainder of the percentage will be divided between write"
+          + " and list tasks.",
+          required = true)
   private int percentageRead;
+
+  @CommandLine.Option(names = {"--percentage-list"},
+          description = "Percentage of list tasks in mix workload."
+          + " The remainder of the percentage will be divided between write"
+          + " and read tasks.",
+          required = true)
+  private int percentageList;
+
+  @CommandLine.Option(names = {"--max-list-result"},
+      description = "Maximum number of keys to be fetched during the list task."
+          + " It ensures the size of the result will not exceed this limit.",
+      defaultValue = "1000")
+  private int maxListResult;
 
   @CommandLine.Option(
           names = "--om-service-id",
@@ -118,14 +131,15 @@ public class OzoneClientKeyReadWriteOps extends BaseFreonGenerator
   private byte[] keyContent;
 
   private static final Logger LOG =
-          LoggerFactory.getLogger(OzoneClientKeyReadWriteOps.class);
+          LoggerFactory.getLogger(OzoneClientKeyReadWriteListOps.class);
 
   /**
    * Task type of read task, or write task.
    */
   public enum TaskType {
     READ_TASK,
-    WRITE_TASK
+    WRITE_TASK,
+    LIST_TASK
   }
   private KeyGeneratorUtil kg;
 
@@ -142,14 +156,14 @@ public class OzoneClientKeyReadWriteOps extends BaseFreonGenerator
 
     ensureVolumeAndBucketExist(ozoneClients[0], volumeName, bucketName);
 
-    timer = getMetrics().timer("key-read-write");
+    timer = getMetrics().timer("key-read-write-list");
     if (objectSizeInBytes >= 0) {
       keyContent = RandomUtils.nextBytes(objectSizeInBytes);
     }
     if (kg == null) {
       kg = new KeyGeneratorUtil();
     }
-    runTests(this::readWriteKeys);
+    runTests(this::readWriteListKeys);
 
     for (int i = 0; i < clientCount; i++) {
       if (ozoneClients[i] != null) {
@@ -159,9 +173,10 @@ public class OzoneClientKeyReadWriteOps extends BaseFreonGenerator
     return null;
   }
 
-  public void readWriteKeys(long counter) throws RuntimeException, IOException {
+  public void readWriteListKeys(long counter) throws RuntimeException,
+      IOException {
     int clientIndex = (int)((counter) % clientCount);
-    TaskType taskType = decideReadOrWriteTask();
+    TaskType taskType = decideReadWriteOrListTask();
     String keyName = getKeyName();
 
     timer.time(() -> {
@@ -172,6 +187,9 @@ public class OzoneClientKeyReadWriteOps extends BaseFreonGenerator
           break;
         case WRITE_TASK:
           processWriteTasks(keyName, ozoneClients[clientIndex]);
+          break;
+        case LIST_TASK:
+          processListTasks(ozoneClients[clientIndex]);
           break;
         default:
           break;
@@ -212,16 +230,22 @@ public class OzoneClientKeyReadWriteOps extends BaseFreonGenerator
     }
   }
 
-  public TaskType decideReadOrWriteTask() {
-    if (percentageRead == 100) {
-      return TaskType.READ_TASK;
-    } else if (percentageRead == 0) {
-      return TaskType.WRITE_TASK;
+  public void processListTasks(OzoneClient ozoneClient)
+      throws RuntimeException, IOException {
+    try {
+      ozoneClient.getProxy()
+          .listKeys(volumeName, bucketName, getPrefix(), null, maxListResult);
+    } catch (Exception ex) {
+      throw ex;
     }
-    //mix workload
+  }
+
+  public TaskType decideReadWriteOrListTask() {
     int tmp = ThreadLocalRandom.current().nextInt(1, 101);
-    if (tmp  <= percentageRead) {
+    if (tmp <= percentageRead) {
       return TaskType.READ_TASK;
+    } else if (percentageRead < tmp && tmp <= percentageRead + percentageList) {
+      return TaskType.LIST_TASK;
     } else {
       return TaskType.WRITE_TASK;
     }

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/OzoneClientKeyReadWriteListOps.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/OzoneClientKeyReadWriteListOps.java
@@ -244,7 +244,7 @@ public class OzoneClientKeyReadWriteListOps extends BaseFreonGenerator
     int tmp = ThreadLocalRandom.current().nextInt(1, 101);
     if (tmp <= percentageRead) {
       return TaskType.READ_TASK;
-    } else if (percentageRead < tmp && tmp <= percentageRead + percentageList) {
+    } else if (tmp > percentageRead && tmp <= percentageRead + percentageList) {
       return TaskType.LIST_TASK;
     } else {
       return TaskType.WRITE_TASK;


### PR DESCRIPTION
## What changes were proposed in this pull request?

Enhance the read/write tool (ockrw) to include list operation support. Users can specify the percentage of read, write, and list tasks for generating the mixed workload. This should help in benchmarking the performance of the listKeys operation.
 
The below command runs 50% of read-key tasks, 40% list-key tasks and 10% of write-key tasks from pre-generated keys:
`ozone freon ockrw --percentage-read 50 --percentage-list 40 -r 100 -v voltest -b buckettest -p performanceTest`

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-9128

## How was this patch tested?

- Added robot tests.
- Green CI/CD: https://github.com/tanvipenumudy/ozone/actions/runs/5787028346/job/15698237642
- The updated freon tool has been tested over a cluster for capturing the metric: `om_performance_metrics_list_keys_latency_ns_avg_time` (in nanoseconds) - PR: #5131

![listKeys_latency](https://github.com/apache/ozone/assets/46785609/4cb8ec99-d5ba-408c-bf04-66af358dc537)

