### PR TITLE
HDDS-8011. IllegalArgumentException logged for invalid user-defined metadata

### DIFF
--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/EndpointBase.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/EndpointBase.java
@@ -290,8 +290,7 @@ public abstract class EndpointBase implements Auditor {
 
         if (sizeInBytes >
                 OzoneConsts.S3_REQUEST_HEADER_METADATA_SIZE_LIMIT_KB * KB) {
-          throw new IllegalArgumentException("Illegal user defined metadata." +
-              " Combined size cannot exceed 2KB.");
+          throw newError(S3ErrorTable.METADATA_TOO_LARGE, key);
         }
         customMetadata.put(mapKey, value);
       }

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/EndpointBase.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/EndpointBase.java
@@ -290,7 +290,9 @@ public abstract class EndpointBase implements Auditor {
 
         if (sizeInBytes >
                 OzoneConsts.S3_REQUEST_HEADER_METADATA_SIZE_LIMIT_KB * KB) {
-          throw newError(S3ErrorTable.METADATA_TOO_LARGE, key);
+          OS3Exception os3Exception = newError(S3ErrorTable.METADATA_TOO_LARGE, key);
+          os3Exception.setErrorMessage("Illegal user defined metadata. Combined size cannot exceed the maximum allowed metadata size of 2KB.");
+          throw os3Exception;
         }
         customMetadata.put(mapKey, value);
       }

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/EndpointBase.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/EndpointBase.java
@@ -290,8 +290,11 @@ public abstract class EndpointBase implements Auditor {
 
         if (sizeInBytes >
                 OzoneConsts.S3_REQUEST_HEADER_METADATA_SIZE_LIMIT_KB * KB) {
-          OS3Exception os3Exception = newError(S3ErrorTable.METADATA_TOO_LARGE, key);
-          os3Exception.setErrorMessage("Illegal user defined metadata. Combined size cannot exceed the maximum allowed metadata size of 2KB.");
+          OS3Exception os3Exception = newError(S3ErrorTable.METADATA_TOO_LARGE,
+              key);
+          os3Exception.setErrorMessage("Illegal user defined metadata. " +
+              "Combined size cannot exceed the maximum allowed metadata size " +
+              "of 2KB.");
           throw os3Exception;
         }
         customMetadata.put(mapKey, value);

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/EndpointBase.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/EndpointBase.java
@@ -290,12 +290,7 @@ public abstract class EndpointBase implements Auditor {
 
         if (sizeInBytes >
                 OzoneConsts.S3_REQUEST_HEADER_METADATA_SIZE_LIMIT_KB * KB) {
-          OS3Exception os3Exception = newError(S3ErrorTable.METADATA_TOO_LARGE,
-              key);
-          os3Exception.setErrorMessage("Illegal user defined metadata. " +
-              "Combined size cannot exceed the maximum allowed metadata size " +
-              "of 2KB.");
-          throw os3Exception;
+          throw newError(S3ErrorTable.METADATA_TOO_LARGE, key);
         }
         customMetadata.put(mapKey, value);
       }

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/exception/S3ErrorTable.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/exception/S3ErrorTable.java
@@ -29,6 +29,7 @@ import static java.net.HttpURLConnection.HTTP_NOT_FOUND;
 import static java.net.HttpURLConnection.HTTP_PRECON_FAILED;
 import static java.net.HttpURLConnection.HTTP_NOT_IMPLEMENTED;
 import static java.net.HttpURLConnection.HTTP_INTERNAL_ERROR;
+import static org.apache.hadoop.ozone.OzoneConsts.S3_REQUEST_HEADER_METADATA_SIZE_LIMIT_KB;
 import static org.apache.hadoop.ozone.s3.util.S3Consts.RANGE_NOT_SATISFIABLE;
 
 /**
@@ -128,8 +129,8 @@ public final class S3ErrorTable {
 
   public static final OS3Exception METADATA_TOO_LARGE = new OS3Exception(
       "MetadataTooLarge", "Illegal user defined metadata. Combined size " +
-      "exceeds the maximum allowed metadata size of 2KB",
-      HTTP_BAD_REQUEST);
+      "exceeds the maximum allowed metadata size of " +
+      S3_REQUEST_HEADER_METADATA_SIZE_LIMIT_KB + "KB", HTTP_BAD_REQUEST);
 
   public static OS3Exception newError(OS3Exception e, String resource) {
     return newError(e, resource, null);

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/exception/S3ErrorTable.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/exception/S3ErrorTable.java
@@ -126,6 +126,10 @@ public final class S3ErrorTable {
   public static final OS3Exception NO_OVERWRITE = new OS3Exception(
       "Conflict", "Cannot overwrite file with directory", HTTP_CONFLICT);
 
+  public static final OS3Exception METADATA_TOO_LARGE = new OS3Exception(
+      "MetadataTooLarge", "Your metadata headers exceed the maximum allowed " +
+      "metadata size.", HTTP_BAD_REQUEST);
+
   public static OS3Exception newError(OS3Exception e, String resource) {
     return newError(e, resource, null);
   }

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/exception/S3ErrorTable.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/exception/S3ErrorTable.java
@@ -127,8 +127,9 @@ public final class S3ErrorTable {
       "Conflict", "Cannot overwrite file with directory", HTTP_CONFLICT);
 
   public static final OS3Exception METADATA_TOO_LARGE = new OS3Exception(
-      "MetadataTooLarge", "Your metadata headers exceed the maximum allowed " +
-      "metadata size.", HTTP_BAD_REQUEST);
+      "MetadataTooLarge", "Illegal user defined metadata. Combined size " +
+      "exceeds the maximum allowed metadata size of 2KB",
+      HTTP_BAD_REQUEST);
 
   public static OS3Exception newError(OS3Exception e, String resource) {
     return newError(e, resource, null);

--- a/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestEndpointBase.java
+++ b/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestEndpointBase.java
@@ -97,7 +97,8 @@ public class TestEndpointBase {
 
     try {
       endpointBase.getCustomMetadataFromHeaders(s3requestHeaders);
-      Assert.fail("getCustomMetadataFromHeaders should fail. Expected OS3Exception not thrown");
+      Assert.fail("getCustomMetadataFromHeaders should fail. " +
+          "Expected OS3Exception not thrown");
     } catch (OS3Exception ex) {
       Assert.assertTrue(ex.getCode().contains("MetadataTooLarge"));
     }

--- a/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestEndpointBase.java
+++ b/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestEndpointBase.java
@@ -97,6 +97,7 @@ public class TestEndpointBase {
 
     try {
       endpointBase.getCustomMetadataFromHeaders(s3requestHeaders);
+      Assert.fail("getCustomMetadataFromHeaders should fail. Expected OS3Exception not thrown");
     } catch (OS3Exception ex) {
       Assert.assertTrue(ex.getCode().contains("MetadataTooLarge"));
     }

--- a/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestEndpointBase.java
+++ b/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestEndpointBase.java
@@ -95,12 +95,11 @@ public class TestEndpointBase {
       public void init() { }
     };
 
-    Exception exception = Assertions.assertThrows(
-            IllegalArgumentException.class,
-            () -> endpointBase.getCustomMetadataFromHeaders(s3requestHeaders));
-    Assert.assertEquals(
-            "Illegal user defined metadata. Combined size cannot exceed 2KB.",
-            exception.getMessage());
+    try {
+      endpointBase.getCustomMetadataFromHeaders(s3requestHeaders);
+    } catch (OS3Exception ex) {
+      Assert.assertTrue(ex.getCode().contains("MetadataTooLarge"));
+    }
   }
 
 }

--- a/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestEndpointBase.java
+++ b/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestEndpointBase.java
@@ -26,7 +26,6 @@ import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.hadoop.ozone.s3.exception.OS3Exception;
 import org.junit.Assert;
 import org.junit.Test;
-import org.junit.jupiter.api.Assertions;
 
 import javax.ws.rs.core.MultivaluedHashMap;
 import javax.ws.rs.core.MultivaluedMap;


### PR DESCRIPTION
## What changes were proposed in this pull request?

Replacing the IllegalArgumentException thrown with a new OS3Exception for MetadataTooLarge.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-8011

## How was this patch tested?

Manually tested in Docker set-up using an API development tool to send a request to s3g.
cURL form of the request used to test: https://gist.github.com/Tejaskriya/7a8740cb2152ba7704030835ae8b85f1
Output seen:
```
<?xml version="1.0" encoding="UTF-8"?>
<Error>
  <Code>MetadataTooLarge</Code>
  <Message>Your metadata headers exceed the maximum allowed metadata size.</Message>
  <Resource>x-amz-meta-b</Resource>
  <RequestId>2f65ae49-bf28-4947-9504-dddca6fc0452</RequestId>
</Error>
```

Also tested using a test case in TestEndpointBase.java.