### PR TITLE
HDDS-9134. GRPC based replication can get stuck forever if the receiver is not available

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/replication/GrpcContainerUploader.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/replication/GrpcContainerUploader.java
@@ -160,8 +160,7 @@ public class GrpcContainerUploader implements ContainerUploader {
     @Override
     public boolean isReady() {
       if (responseObserver.isError()) {
-        observer.onError(responseObserver.getError());
-        return true;
+        throw new RuntimeException(responseObserver.getError());
       }
       return observer.isReady();
     }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/replication/GrpcContainerUploader.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/replication/GrpcContainerUploader.java
@@ -192,6 +192,11 @@ public class GrpcContainerUploader implements ContainerUploader {
 
     @Override
     public void onError(Throwable throwable) {
+      if (!responseObserver.isError()) {
+        // set up error to response observer, so that
+        // callback can be set with error in response observer
+        responseObserver.onError(throwable);
+      }
       observer.onError(throwable);
     }
 

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/replication/GrpcContainerUploader.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/replication/GrpcContainerUploader.java
@@ -33,6 +33,7 @@ import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.io.OutputStream;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.CompletableFuture;
 
 /**
@@ -60,10 +61,13 @@ public class GrpcContainerUploader implements ContainerUploader {
     try {
       // gRPC runtime always provides implementation of CallStreamObserver
       // that allows flow control.
+      SendContainerResponseStreamObserver responseObserver
+          = new SendContainerResponseStreamObserver(
+              containerId, target, callback);
       CallStreamObserver<SendContainerRequest> requestStream =
-          (CallStreamObserver<SendContainerRequest>) client.upload(
-              new SendContainerResponseStreamObserver(containerId, target,
-                  callback));
+          new WrappedRequestStreamObserver(
+              (CallStreamObserver<SendContainerRequest>) client.upload(
+              responseObserver), responseObserver);
       return new SendContainerOutputStream(requestStream, containerId,
           GrpcReplicationService.BUFFER_SIZE, compression) {
         @Override
@@ -94,11 +98,13 @@ public class GrpcContainerUploader implements ContainerUploader {
    * Observes gRPC response for SendContainer request, notifies callback on
    * completion/error.
    */
-  private static class SendContainerResponseStreamObserver
+  public static class SendContainerResponseStreamObserver
       implements StreamObserver<SendContainerResponse> {
     private final long containerId;
     private final DatanodeDetails target;
     private final CompletableFuture<Void> callback;
+    private AtomicBoolean error = new AtomicBoolean(false);
+    private volatile Throwable throwable = null;
 
     SendContainerResponseStreamObserver(long containerId,
         DatanodeDetails target, CompletableFuture<Void> callback) {
@@ -115,6 +121,9 @@ public class GrpcContainerUploader implements ContainerUploader {
     @Override
     public void onError(Throwable t) {
       LOG.warn("Failed to upload container {} to {}", containerId, target, t);
+
+      throwable = t;
+      error.set(true);
       callback.completeExceptionally(t);
     }
 
@@ -122,6 +131,74 @@ public class GrpcContainerUploader implements ContainerUploader {
     public void onCompleted() {
       LOG.info("Finished uploading container {} to {}", containerId, target);
       callback.complete(null);
+    }
+
+    public boolean isError() {
+      return error.get();
+    }
+
+    public Throwable getError() {
+      return throwable;
+    }
+  }
+
+  /**
+   * this class wrap the request stream observer and handle error
+   * reported by ratis to response handler.
+   */
+  public static class WrappedRequestStreamObserver<T>
+      extends CallStreamObserver<T> {
+    private final CallStreamObserver<T> observer;
+    private final SendContainerResponseStreamObserver responseObserver;
+
+    public WrappedRequestStreamObserver(
+        CallStreamObserver observer,
+        SendContainerResponseStreamObserver responseObserver) {
+      this.observer = observer;
+      this.responseObserver = responseObserver;
+    }
+    @Override
+    public boolean isReady() {
+      if (responseObserver.isError()) {
+        observer.onError(responseObserver.getError());
+        return true;
+      }
+      return observer.isReady();
+    }
+
+    @Override
+    public void setOnReadyHandler(Runnable runnable) {
+      observer.setOnReadyHandler(runnable);
+    }
+
+    @Override
+    public void disableAutoInboundFlowControl() {
+      observer.disableAutoInboundFlowControl();
+    }
+
+    @Override
+    public void request(int i) {
+      observer.request(i);
+    }
+
+    @Override
+    public void setMessageCompression(boolean b) {
+      observer.setMessageCompression(b);
+    }
+
+    @Override
+    public void onNext(T sendContainerResponse) {
+      observer.onNext(sendContainerResponse);
+    }
+
+    @Override
+    public void onError(Throwable throwable) {
+      observer.onError(throwable);
+    }
+
+    @Override
+    public void onCompleted() {
+      observer.onCompleted();
     }
   }
 }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/replication/GrpcOutputStream.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/replication/GrpcOutputStream.java
@@ -38,8 +38,8 @@ abstract class GrpcOutputStream<T> extends OutputStream {
   private static final Logger LOG =
       LoggerFactory.getLogger(GrpcOutputStream.class);
   public static final int READY_WAIT_TIME_IN_MS = 10;
-  // retry count 6000 for wait of 1 minute
-  public static final int READY_RETRY_COUNT = 6000;
+  // retry count 5 * 6000 for wait of 5 minute
+  public static final int READY_RETRY_COUNT = 30000;
 
   private final CallStreamObserver<T> streamObserver;
 
@@ -111,11 +111,14 @@ abstract class GrpcOutputStream<T> extends OutputStream {
   @Override
   public void close() throws IOException {
     if (!closed.getAndSet(true)) {
-      flushBuffer(true);
-      LOG.info("Sent {} bytes for container {}",
-          writtenBytes, containerId);
-      streamObserver.onCompleted();
-      buffer.close();
+      try {
+        flushBuffer(true);
+        LOG.info("Sent {} bytes for container {}",
+            writtenBytes, containerId);
+        streamObserver.onCompleted();
+      } finally {
+        buffer.close();
+      }
     }
   }
 
@@ -131,7 +134,7 @@ abstract class GrpcOutputStream<T> extends OutputStream {
     return streamObserver;
   }
 
-  private void flushBuffer(boolean eof) {
+  private void flushBuffer(boolean eof) throws IOException {
     waitUntilReady();
     int length = buffer.size();
     if (length > 0) {
@@ -148,18 +151,27 @@ abstract class GrpcOutputStream<T> extends OutputStream {
    * Handling back pressure of the stream, delay putting more messages to
    * the stream until it's ready.
    */
-  private void waitUntilReady() {
+  private void waitUntilReady() throws IOException {
     int count = 0;
-    while (!streamObserver.isReady() && count < READY_RETRY_COUNT) {
-      LOG.debug("Stream is not ready, backoff");
-      try {
-        Thread.sleep(READY_WAIT_TIME_IN_MS);
-        count++;
-      } catch (InterruptedException e) {
-        LOG.error("InterruptedException while waiting for channel ready", e);
-        Thread.currentThread().interrupt();
-        break;
+    try {
+      while (!streamObserver.isReady() && count < READY_RETRY_COUNT) {
+        LOG.debug("Stream is not ready, backoff");
+        try {
+          Thread.sleep(READY_WAIT_TIME_IN_MS);
+          count++;
+        } catch (InterruptedException e) {
+          LOG.error("InterruptedException while waiting for channel ready", e);
+          Thread.currentThread().interrupt();
+          break;
+        }
       }
+    } catch (Exception ex) {
+      throw new IOException(ex);
+    }
+
+    if (count >= READY_RETRY_COUNT) {
+      throw new IOException("Channel is not ready after "
+          + (count * READY_WAIT_TIME_IN_MS) + "ms");
     }
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

1. Wrapped Request Stream observer, with setting observer as error and returning isReady() true, so that it will fail while operating
2. timeout provided with 1 minute even if stream is not ready

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-9134

## How was this patch tested?

Test with debug to verify exit of replication at DN
