### PR TITLE
HDDS-9145. Use JUnit's assertThrow instead of LambdaTestUtils#intercept

### DIFF
--- a/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/TestHddsUtils.java
+++ b/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/TestHddsUtils.java
@@ -30,7 +30,6 @@ import java.util.Optional;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.scm.ScmConfigKeys;
 import org.apache.hadoop.ozone.ha.ConfUtils;
-import org.apache.ozone.test.LambdaTestUtils;
 import org.apache.hadoop.fs.CommonConfigurationKeysPublic;
 
 import static org.apache.hadoop.hdds.HddsUtils.getSCMAddressForDatanodes;
@@ -44,8 +43,8 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  * Testing HddsUtils.
@@ -70,7 +69,7 @@ public class TestHddsUtils {
   }
 
   @Test
-  public void validatePath() throws Exception {
+  public void validatePath() {
     HddsUtils.validatePath(Paths.get("/"), Paths.get("/"));
     HddsUtils.validatePath(Paths.get("/a"), Paths.get("/"));
     HddsUtils.validatePath(Paths.get("/a"), Paths.get("/a"));
@@ -78,13 +77,13 @@ public class TestHddsUtils {
     HddsUtils.validatePath(Paths.get("/a/b/c"), Paths.get("/a"));
     HddsUtils.validatePath(Paths.get("/a/../a/b"), Paths.get("/a"));
 
-    LambdaTestUtils.intercept(IllegalArgumentException.class,
+    assertThrows(IllegalArgumentException.class,
         () -> HddsUtils.validatePath(Paths.get("/b/c"), Paths.get("/a")));
-    LambdaTestUtils.intercept(IllegalArgumentException.class,
+    assertThrows(IllegalArgumentException.class,
         () -> HddsUtils.validatePath(Paths.get("/"), Paths.get("/a")));
-    LambdaTestUtils.intercept(IllegalArgumentException.class,
+    assertThrows(IllegalArgumentException.class,
         () -> HddsUtils.validatePath(Paths.get("/a/.."), Paths.get("/a")));
-    LambdaTestUtils.intercept(IllegalArgumentException.class,
+    assertThrows(IllegalArgumentException.class,
         () -> HddsUtils.validatePath(Paths.get("/a/../b"), Paths.get("/a")));
   }
 
@@ -154,39 +153,27 @@ public class TestHddsUtils {
 
     // Verify empty value
     conf.setStrings(ScmConfigKeys.OZONE_SCM_NAMES, "");
-    try {
-      getSCMAddressForDatanodes(conf);
-      fail("Empty value should cause an IllegalArgumentException");
-    } catch (Exception e) {
-      assertTrue(e instanceof IllegalArgumentException);
-    }
+    assertThrows(IllegalArgumentException.class,
+        () -> getSCMAddressForDatanodes(conf),
+        "Empty value should cause an IllegalArgumentException");
 
     // Verify invalid hostname
     conf.setStrings(ScmConfigKeys.OZONE_SCM_NAMES, "s..x..:1234");
-    try {
-      getSCMAddressForDatanodes(conf);
-      fail("An invalid hostname should cause an IllegalArgumentException");
-    } catch (Exception e) {
-      assertTrue(e instanceof IllegalArgumentException);
-    }
+    assertThrows(IllegalArgumentException.class,
+        () -> getSCMAddressForDatanodes(conf),
+        "An invalid hostname should cause an IllegalArgumentException");
 
     // Verify invalid port
     conf.setStrings(ScmConfigKeys.OZONE_SCM_NAMES, "scm:xyz");
-    try {
-      getSCMAddressForDatanodes(conf);
-      fail("An invalid port should cause an IllegalArgumentException");
-    } catch (Exception e) {
-      assertTrue(e instanceof IllegalArgumentException);
-    }
+    assertThrows(IllegalArgumentException.class,
+        () -> getSCMAddressForDatanodes(conf),
+        "An invalid port should cause an IllegalArgumentException");
 
     // Verify a mixed case (valid and invalid value both appears)
     conf.setStrings(ScmConfigKeys.OZONE_SCM_NAMES, "scm1:1234, scm:xyz");
-    try {
-      getSCMAddressForDatanodes(conf);
-      fail("An invalid value should cause an IllegalArgumentException");
-    } catch (Exception e) {
-      assertTrue(e instanceof IllegalArgumentException);
-    }
+    assertThrows(IllegalArgumentException.class,
+        () -> getSCMAddressForDatanodes(conf),
+        "An invalid value should cause an IllegalArgumentException");
   }
 
 

--- a/hadoop-hdds/common/src/test/java/org/apache/hadoop/ozone/upgrade/TestDefaultUpgradeFinalizationExecutor.java
+++ b/hadoop-hdds/common/src/test/java/org/apache/hadoop/ozone/upgrade/TestDefaultUpgradeFinalizationExecutor.java
@@ -18,13 +18,14 @@
 
 package org.apache.hadoop.ozone.upgrade;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import java.io.IOException;
 
 import org.apache.hadoop.ozone.common.Storage;
-import org.apache.ozone.test.LambdaTestUtils;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -33,7 +34,7 @@ import org.junit.jupiter.api.Test;
 public class TestDefaultUpgradeFinalizationExecutor {
 
   @Test
-  public void testPreFinalizeFailureThrowsException() throws Exception {
+  public void testPreFinalizeFailureThrowsException() {
     AbstractLayoutVersionManager mockLvm =
         mock(AbstractLayoutVersionManager.class);
     when(mockLvm.needsFinalization()).thenReturn(true);
@@ -60,8 +61,9 @@ public class TestDefaultUpgradeFinalizationExecutor {
 
     DefaultUpgradeFinalizationExecutor executor =
         new DefaultUpgradeFinalizationExecutor();
-    LambdaTestUtils.intercept(IOException.class,
-        "Failure!", () -> executor.execute(new Object(), uf));
+    IOException ioException = assertThrows(IOException.class,
+        () -> executor.execute(new Object(), uf));
+    assertEquals("Failure!", ioException.getMessage());
   }
 
   @Test

--- a/hadoop-hdds/common/src/test/java/org/apache/hadoop/ozone/upgrade/TestUpgradeFinalizerActions.java
+++ b/hadoop-hdds/common/src/test/java/org/apache/hadoop/ozone/upgrade/TestUpgradeFinalizerActions.java
@@ -23,6 +23,7 @@ import static org.apache.hadoop.ozone.upgrade.LayoutFeature.UpgradeActionType.ON
 import static org.apache.hadoop.ozone.upgrade.LayoutFeature.UpgradeActionType.VALIDATE_IN_PREFINALIZE;
 import static org.apache.hadoop.ozone.upgrade.TestUpgradeFinalizerActions.MockLayoutFeature.VERSION_2;
 import static org.apache.hadoop.ozone.upgrade.TestUpgradeFinalizerActions.MockLayoutFeature.VERSION_3;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
@@ -40,7 +41,6 @@ import org.apache.hadoop.hdds.upgrade.test.MockComponent;
 import org.apache.hadoop.hdds.upgrade.test.MockComponent.MockDnUpgradeAction;
 import org.apache.hadoop.hdds.upgrade.test.MockComponent.MockScmUpgradeAction;
 import org.apache.hadoop.ozone.common.Storage;
-import org.apache.ozone.test.LambdaTestUtils;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
@@ -97,12 +97,10 @@ public class TestUpgradeFinalizerActions {
     assertTrue(scmCurrent.mkdirs());
     Storage storage = newStorage(file);
 
-    LambdaTestUtils.intercept(UpgradeException.class,
-        "Exception while running pre finalize state validation",
-        () -> {
-          uF.runPrefinalizeStateActions(storage, mockObj);
-          return null;
-        });
+    UpgradeException upgradeException = assertThrows(UpgradeException.class,
+        () -> uF.runPrefinalizeStateActions(storage, mockObj));
+    assertTrue(upgradeException.getMessage()
+        .contains("Exception while running pre finalize state validation"));
   }
 
   private Storage newStorage(File f) throws IOException {

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/TestHddsSecureDatanodeInit.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/TestHddsSecureDatanodeInit.java
@@ -44,7 +44,6 @@ import org.apache.hadoop.hdds.security.x509.certificate.utils.SelfSignedCertific
 import org.apache.hadoop.hdds.security.x509.keys.KeyCodec;
 import org.apache.hadoop.security.ssl.KeyStoreTestUtil;
 import org.apache.ozone.test.GenericTestUtils;
-import org.apache.ozone.test.LambdaTestUtils;
 import org.apache.hadoop.util.ServicePlugin;
 
 import org.apache.commons.io.FileUtils;
@@ -168,11 +167,11 @@ public class TestHddsSecureDatanodeInit {
   }
 
   @Test
-  public void testSecureDnStartupCase0() throws Exception {
+  public void testSecureDnStartupCase0() {
 
     // Case 0: When keypair as well as certificate is missing. Initial keypair
     // boot-up. Get certificate will fail as no SCM is not running.
-    LambdaTestUtils.intercept(Exception.class, "",
+    Assertions.assertThrows(Exception.class,
         () -> service.initializeCertificateClient(client));
 
     Assertions.assertNotNull(client.getPrivateKey());
@@ -185,11 +184,12 @@ public class TestHddsSecureDatanodeInit {
   @Test
   public void testSecureDnStartupCase1() throws Exception {
     // Case 1: When only certificate is present.
-
     certCodec.writeCertificate(certHolder);
-    LambdaTestUtils.intercept(RuntimeException.class, "DN security" +
-            " initialization failed",
+    RuntimeException rteException = Assertions.assertThrows(
+        RuntimeException.class,
         () -> service.initializeCertificateClient(client));
+    Assertions.assertTrue(rteException.getMessage()
+        .contains("DN security initialization failed"));
     Assertions.assertNull(client.getPrivateKey());
     Assertions.assertNull(client.getPublicKey());
     Assertions.assertNotNull(client.getCertificate());
@@ -201,9 +201,11 @@ public class TestHddsSecureDatanodeInit {
   public void testSecureDnStartupCase2() throws Exception {
     // Case 2: When private key and certificate is missing.
     keyCodec.writePublicKey(publicKey);
-    LambdaTestUtils.intercept(RuntimeException.class, "DN security" +
-            " initialization failed",
+    RuntimeException rteException = Assertions.assertThrows(
+        RuntimeException.class,
         () -> service.initializeCertificateClient(client));
+    Assertions.assertTrue(rteException.getMessage()
+        .contains("DN security initialization failed"));
     Assertions.assertNull(client.getPrivateKey());
     Assertions.assertNotNull(client.getPublicKey());
     Assertions.assertNull(client.getCertificate());
@@ -216,9 +218,11 @@ public class TestHddsSecureDatanodeInit {
     // Case 3: When only public key and certificate is present.
     keyCodec.writePublicKey(publicKey);
     certCodec.writeCertificate(certHolder);
-    LambdaTestUtils.intercept(RuntimeException.class, "DN security" +
-            " initialization failed",
+    RuntimeException rteException = Assertions.assertThrows(
+        RuntimeException.class,
         () -> service.initializeCertificateClient(client));
+    Assertions.assertTrue(rteException.getMessage()
+        .contains("DN security initialization failed"));
     Assertions.assertNull(client.getPrivateKey());
     Assertions.assertNotNull(client.getPublicKey());
     Assertions.assertNotNull(client.getCertificate());
@@ -230,9 +234,11 @@ public class TestHddsSecureDatanodeInit {
   public void testSecureDnStartupCase4() throws Exception {
     // Case 4: When public key as well as certificate is missing.
     keyCodec.writePrivateKey(privateKey);
-    LambdaTestUtils.intercept(RuntimeException.class, " DN security" +
-            " initialization failed",
+    RuntimeException rteException = Assertions.assertThrows(
+        RuntimeException.class,
         () -> service.initializeCertificateClient(client));
+    Assertions.assertTrue(rteException.getMessage()
+        .contains("DN security initialization failed"));
     Assertions.assertNotNull(client.getPrivateKey());
     Assertions.assertNull(client.getPublicKey());
     Assertions.assertNull(client.getCertificate());
@@ -259,7 +265,7 @@ public class TestHddsSecureDatanodeInit {
     // Case 6: If key pair already exist than response should be GETCERT.
     keyCodec.writePublicKey(publicKey);
     keyCodec.writePrivateKey(privateKey);
-    LambdaTestUtils.intercept(Exception.class, "",
+    Assertions.assertThrows(Exception.class,
         () -> service.initializeCertificateClient(client));
     Assertions.assertNotNull(client.getPrivateKey());
     Assertions.assertNotNull(client.getPublicKey());

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/impl/TestHddsDispatcher.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/impl/TestHddsDispatcher.java
@@ -62,7 +62,6 @@ import org.apache.hadoop.ozone.container.keyvalue.KeyValueContainer;
 import org.apache.hadoop.ozone.container.keyvalue.KeyValueContainerData;
 import org.apache.ozone.test.GenericTestUtils;
 
-import org.apache.ozone.test.LambdaTestUtils;
 import org.apache.ratis.thirdparty.com.google.protobuf.ByteString;
 import org.junit.Assert;
 import org.junit.Test;
@@ -84,6 +83,8 @@ import static org.apache.hadoop.hdds.fs.MockSpaceUsagePersistence.inMemory;
 import static org.apache.hadoop.hdds.fs.MockSpaceUsageSource.fixed;
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.HDDS_DATANODE_DIR_KEY;
 import static org.apache.hadoop.hdds.scm.protocolPB.ContainerCommandResponseBuilders.getContainerCommandResponse;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -167,7 +168,6 @@ public class TestHddsDispatcher {
       ContainerMetrics.remove();
       FileUtils.deleteDirectory(new File(testDir));
     }
-
   }
 
   @Test
@@ -238,11 +238,12 @@ public class TestHddsDispatcher {
           50, UUID.randomUUID().toString(),
           dd.getUuidString());
       Container container2 = new KeyValueContainer(containerData2, conf);
-      LambdaTestUtils.intercept(StorageContainerException.class,
-          "Container creation failed, due to disk out of space",
-          () -> container2.create(volumeSet,
-              new RoundRobinVolumeChoosingPolicy(), scmId.toString()));
-
+      StorageContainerException scException =
+          assertThrows(StorageContainerException.class,
+              () -> container2.create(volumeSet,
+                  new RoundRobinVolumeChoosingPolicy(), scmId.toString()));
+      assertEquals("Container creation failed, due to disk out of space",
+          scException.getMessage());
     } finally {
       volumeSet.shutdown();
       ContainerMetrics.remove();

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/TestTarContainerPacker.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/TestTarContainerPacker.java
@@ -44,7 +44,6 @@ import org.apache.commons.compress.archivers.tar.TarArchiveInputStream;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
 import org.apache.hadoop.ozone.container.replication.CopyContainerCompression;
-import org.apache.ozone.test.LambdaTestUtils;
 import org.apache.ozone.test.SpyInputStream;
 import org.apache.ozone.test.SpyOutputStream;
 import org.junit.AfterClass;
@@ -58,6 +57,7 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.nio.file.Files.newInputStream;
 import static java.nio.file.Files.newOutputStream;
 import static org.apache.hadoop.ozone.container.keyvalue.TarContainerPacker.CONTAINER_FILE_NAME;
+import static org.junit.Assert.assertThrows;
 
 /**
  * Test the tar/untar for a given container.
@@ -307,7 +307,7 @@ public class TestTarContainerPacker {
 
     File containerFile = packContainerWithSingleFile(file, entryName);
 
-    LambdaTestUtils.intercept(IllegalArgumentException.class,
+    assertThrows(IllegalArgumentException.class,
         () -> unpackContainerData(containerFile));
   }
 
@@ -324,7 +324,7 @@ public class TestTarContainerPacker {
 
     File containerFile = packContainerWithSingleFile(file, entryName);
 
-    LambdaTestUtils.intercept(IllegalArgumentException.class,
+    assertThrows(IllegalArgumentException.class,
         () -> unpackContainerData(containerFile));
   }
 

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/helpers/TestChunkUtils.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/helpers/TestChunkUtils.java
@@ -45,11 +45,12 @@ import org.apache.commons.io.FileUtils;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.Result.UNABLE_TO_FIND_CHUNK;
 
-import org.apache.ozone.test.LambdaTestUtils;
 import org.junit.jupiter.api.Assertions;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -214,7 +215,7 @@ public class TestChunkUtils {
   }
 
   @Test
-  public void readMissingFile() throws Exception {
+  public void readMissingFile() {
     // given
     int len = 123;
     int offset = 0;
@@ -222,7 +223,7 @@ public class TestChunkUtils {
     ByteBuffer[] bufs = BufferUtils.assignByteBuffers(len, len);
 
     // when
-    StorageContainerException e = LambdaTestUtils.intercept(
+    StorageContainerException e = assertThrows(
         StorageContainerException.class,
         () -> ChunkUtils.readData(nonExistentFile, bufs, offset, len, null));
 

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/ozoneimpl/TestOzoneContainer.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/ozoneimpl/TestOzoneContainer.java
@@ -47,7 +47,6 @@ import org.apache.hadoop.ozone.container.keyvalue.ContainerTestVersionInfo;
 import org.apache.hadoop.ozone.container.keyvalue.KeyValueContainer;
 import org.apache.hadoop.ozone.container.keyvalue.KeyValueContainerData;
 import org.apache.hadoop.ozone.container.keyvalue.helpers.BlockUtils;
-import org.apache.ozone.test.LambdaTestUtils;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -70,6 +69,7 @@ import java.util.ArrayList;
 import static org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.Result.DISK_OUT_OF_SPACE;
 import static org.apache.hadoop.ozone.container.common.ContainerTestUtils.createDbInstancesForTestIfNeeded;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
 
 /**
  * This class is used to test OzoneContainer.
@@ -122,7 +122,7 @@ public class TestOzoneContainer {
   }
 
   @After
-  public void cleanUp() throws Exception {
+  public void cleanUp() {
     BlockUtils.shutdownCache(conf);
 
     if (volumeSet != null) {
@@ -263,15 +263,11 @@ public class TestOzoneContainer {
         UUID.randomUUID().toString(), datanodeDetails.getUuidString());
     keyValueContainer = new KeyValueContainer(keyValueContainerData, conf);
 
-    // we expect an out of space Exception
-    StorageContainerException e = LambdaTestUtils.intercept(
+    StorageContainerException e = assertThrows(
         StorageContainerException.class,
         () -> keyValueContainer.
             create(volumeSet, volumeChoosingPolicy, clusterId)
     );
-    if (!DISK_OUT_OF_SPACE.equals(e.getResult())) {
-      LOG.info("Unexpected error during container creation", e);
-    }
     assertEquals(DISK_OUT_OF_SPACE, e.getResult());
   }
 

--- a/hadoop-hdds/erasurecode/src/test/java/org/apache/ozone/erasurecode/rawcoder/TestRawCoderBase.java
+++ b/hadoop-hdds/erasurecode/src/test/java/org/apache/ozone/erasurecode/rawcoder/TestRawCoderBase.java
@@ -20,11 +20,13 @@ package org.apache.ozone.erasurecode.rawcoder;
 import org.apache.hadoop.hdds.client.ECReplicationConfig;
 import org.apache.ozone.erasurecode.ECChunk;
 import org.apache.ozone.erasurecode.TestCoderBase;
-import org.apache.ozone.test.LambdaTestUtils;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Raw coder test base with utilities.
@@ -127,14 +129,15 @@ public abstract class TestRawCoderBase extends TestCoderBase {
     encoder.release();
     final ECChunk[] data = prepareDataChunksForEncoding();
     final ECChunk[] parity = prepareParityChunksForEncoding();
-    LambdaTestUtils.intercept(IOException.class, "closed",
+    IOException ioException = assertThrows(IOException.class,
         () -> encoder.encode(data, parity));
-
+    assertTrue(ioException.getMessage().contains("closed"));
     decoder.release();
     final ECChunk[] in = prepareInputChunksForDecoding(data, parity);
     final ECChunk[] out = prepareOutputChunksForDecoding();
-    LambdaTestUtils.intercept(IOException.class, "closed",
+    ioException = assertThrows(IOException.class,
         () -> decoder.decode(in, getErasedIndexesForDecoding(), out));
+    assertTrue(ioException.getMessage().contains("closed"));
   }
 
   @Test

--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/security/x509/certificate/authority/TestDefaultCAServer.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/security/x509/certificate/authority/TestDefaultCAServer.java
@@ -35,7 +35,6 @@ import org.apache.hadoop.hdds.security.x509.certificate.utils.SelfSignedCertific
 import org.apache.hadoop.hdds.security.x509.keys.HDDSKeyGenerator;
 import org.apache.hadoop.hdds.security.x509.keys.KeyCodec;
 import org.apache.hadoop.security.ssl.KeyStoreTestUtil;
-import org.apache.ozone.test.LambdaTestUtils;
 
 import org.bouncycastle.asn1.x509.CRLReason;
 import org.bouncycastle.cert.X509CertificateHolder;
@@ -296,14 +295,15 @@ public class TestDefaultCAServer {
     assertTrue(revoked.isDone());
 
     // Revoking empty list of certificates should throw an error.
-    LambdaTestUtils.intercept(ExecutionException.class, "Certificates " +
-        "cannot be null",
+    ExecutionException execution = assertThrows(ExecutionException.class,
         () -> {
           Future<Optional<Long>> result =
               testCA.revokeCertificates(Collections.emptyList(),
               CRLReason.lookup(CRLReason.keyCompromise), now);
           result.get();
         });
+    assertTrue(execution.getCause().getMessage()
+        .contains("Certificates cannot be null"));
   }
 
   @Test
@@ -332,14 +332,15 @@ public class TestDefaultCAServer {
         Paths.get(SCM_CA_CERT_STORAGE_DIR, SCM_CA_PATH).toString());
     testCA.init(securityConfig, CAType.ROOT);
 
-    LambdaTestUtils.intercept(ExecutionException.class, "ScmId and " +
-            "ClusterId in CSR subject are incorrect",
+    ExecutionException execution = assertThrows(ExecutionException.class,
         () -> {
           Future<CertPath> holder =
               testCA.requestCertificate(csrString,
                   CertificateApprover.ApprovalType.TESTING_AUTOMATIC, OM);
           holder.get();
         });
+    assertTrue(execution.getCause().getMessage()
+        .contains("ScmId and ClusterId in CSR subject are incorrect"));
   }
 
   @Test

--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/security/x509/keys/TestKeyCodec.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/security/x509/keys/TestKeyCodec.java
@@ -20,6 +20,8 @@
 package org.apache.hadoop.hdds.security.x509.keys;
 
 import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_METADATA_DIR_NAME;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
@@ -41,7 +43,6 @@ import org.apache.commons.codec.binary.Base64;
 import org.apache.commons.io.FileUtils;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.security.SecurityConfig;
-import org.apache.ozone.test.LambdaTestUtils;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -178,15 +179,17 @@ public class TestKeyCodec {
     pemWriter.writeKey(kp);
 
     // Assert that rewriting of keys throws exception with valid messages.
-    LambdaTestUtils
-        .intercept(IOException.class, "Private Key file already exists.",
+    IOException ioException = assertThrows(IOException.class,
             () -> pemWriter.writeKey(kp));
+    assertTrue(ioException.getMessage()
+        .contains("Private Key file already exists."));
     FileUtils.deleteQuietly(Paths.get(
         secConfig.getKeyLocation(component).toString() + "/" + secConfig
             .getPrivateKeyFileName()).toFile());
-    LambdaTestUtils
-        .intercept(IOException.class, "Public Key file already exists.",
+    ioException = assertThrows(IOException.class,
             () -> pemWriter.writeKey(kp));
+    assertTrue(ioException.getMessage()
+        .contains("Public Key file already exists."));
     FileUtils.deleteQuietly(Paths.get(
         secConfig.getKeyLocation(component).toString() + "/" + secConfig
             .getPublicKeyFileName()).toFile());
@@ -200,8 +203,6 @@ public class TestKeyCodec {
 
   /**
    * Assert key rewrite fails in non Posix file system.
-   *
-   * @throws IOException - on I/O failure.
    */
   @Test
   public void testWriteKeyInNonPosixFS()
@@ -211,13 +212,14 @@ public class TestKeyCodec {
     pemWriter.setIsPosixFileSystem(() -> false);
 
     // Assert key rewrite fails in non Posix file system.
-    LambdaTestUtils
-        .intercept(IOException.class, "Unsupported File System for pem file.",
+    IOException ioException = assertThrows(IOException.class,
             () -> pemWriter.writeKey(kp));
+    assertTrue(ioException.getMessage()
+        .contains("Unsupported File System for pem file."));
   }
 
   @Test
-  public void testReadWritePublicKeywithoutArgs()
+  public void testReadWritePublicKeyWithoutArgs()
       throws NoSuchProviderException, NoSuchAlgorithmException, IOException,
       InvalidKeySpecException {
 
@@ -227,6 +229,5 @@ public class TestKeyCodec {
 
     PublicKey pubKey = keycodec.readPublicKey();
     Assertions.assertNotNull(pubKey);
-
   }
 }

--- a/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/TestOzoneAcls.java
+++ b/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/TestOzoneAcls.java
@@ -21,7 +21,6 @@ package org.apache.hadoop.ozone;
 import org.apache.hadoop.ozone.security.acl.IAccessAuthorizer.ACLIdentityType;
 
 import org.apache.hadoop.ozone.security.acl.IAccessAuthorizer.ACLType;
-import org.apache.ozone.test.LambdaTestUtils;
 import org.junit.Test;
 
 import java.util.HashMap;
@@ -39,6 +38,7 @@ import static org.apache.hadoop.ozone.security.acl.IAccessAuthorizer.ACLType.WRI
 import static org.apache.hadoop.ozone.security.acl.IAccessAuthorizer.ACLType.WRITE_ACL;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -265,13 +265,12 @@ public class TestOzoneAcls {
     assertTrue(acl.getAclBitSet().get(WRITE_ACL.ordinal()));
     assertFalse(acl.getAclBitSet().get(ALL.ordinal()));
     assertEquals(ACLIdentityType.WORLD, acl.getType());
-    assertTrue(acl.getAclScope().equals(OzoneAcl.AclScope.DEFAULT));
+    assertEquals(OzoneAcl.AclScope.DEFAULT, acl.getAclScope());
 
-
-
-    LambdaTestUtils.intercept(IllegalArgumentException.class, "ACL right" +
-            " is not", () -> OzoneAcl.parseAcl("world::rwdlncxncxdfsfgbny"
-    ));
+    IllegalArgumentException exception = assertThrows(
+        IllegalArgumentException.class,
+        () -> OzoneAcl.parseAcl("world::rwdlncxncxdfsfgbny"));
+    assertTrue(exception.getMessage().contains("ACL right is not"));
   }
 
   @Test
@@ -279,7 +278,7 @@ public class TestOzoneAcls {
     OzoneAcl acl = OzoneAcl.parseAcl("user:bilbo:rw");
 
     List<ACLType> rights = acl.getAclList();
-    assertTrue(rights.size() == 2);
+    assertEquals(2, rights.size());
     assertTrue(rights.contains(READ));
     assertTrue(rights.contains(WRITE));
     assertFalse(rights.contains(CREATE));
@@ -287,14 +286,14 @@ public class TestOzoneAcls {
     acl = OzoneAcl.parseAcl("user:bilbo:a");
 
     rights = acl.getAclList();
-    assertTrue(rights.size() == 1);
+    assertEquals(1, rights.size());
     assertTrue(rights.contains(ALL));
     assertFalse(rights.contains(WRITE));
     assertFalse(rights.contains(CREATE));
 
     acl = OzoneAcl.parseAcl("user:bilbo:cxy");
     rights = acl.getAclList();
-    assertTrue(rights.size() == 3);
+    assertEquals(3, rights.size());
     assertTrue(rights.contains(CREATE));
     assertTrue(rights.contains(READ_ACL));
     assertTrue(rights.contains(WRITE_ACL));
@@ -302,9 +301,9 @@ public class TestOzoneAcls {
     assertFalse(rights.contains(READ));
 
     List<OzoneAcl> acls = OzoneAcl.parseAcls("user:bilbo:cxy,group:hadoop:a");
-    assertTrue(acls.size() == 2);
+    assertEquals(2, acls.size());
     rights = acls.get(0).getAclList();
-    assertTrue(rights.size() == 3);
+    assertEquals(3, rights.size());
     assertTrue(rights.contains(CREATE));
     assertTrue(rights.contains(READ_ACL));
     assertTrue(rights.contains(WRITE_ACL));
@@ -315,9 +314,9 @@ public class TestOzoneAcls {
 
     acls = OzoneAcl.parseAcls("user:bilbo:cxy[ACCESS]," +
         "group:hadoop:a[DEFAULT],world::r[DEFAULT]");
-    assertTrue(acls.size() == 3);
+    assertEquals(3, acls.size());
     rights = acls.get(0).getAclList();
-    assertTrue(rights.size() == 3);
+    assertEquals(3, rights.size());
     assertTrue(rights.contains(CREATE));
     assertTrue(rights.contains(READ_ACL));
     assertTrue(rights.contains(WRITE_ACL));
@@ -326,12 +325,11 @@ public class TestOzoneAcls {
     rights = acls.get(1).getAclList();
     assertTrue(rights.contains(ALL));
 
-    assertTrue(acls.get(0).getName().equals("bilbo"));
-    assertTrue(acls.get(1).getName().equals("hadoop"));
-    assertTrue(acls.get(2).getName().equals("WORLD"));
-    assertTrue(acls.get(0).getAclScope().equals(OzoneAcl.AclScope.ACCESS));
-    assertTrue(acls.get(1).getAclScope().equals(OzoneAcl.AclScope.DEFAULT));
-    assertTrue(acls.get(2).getAclScope().equals(OzoneAcl.AclScope.DEFAULT));
+    assertEquals("bilbo", acls.get(0).getName());
+    assertEquals("hadoop", acls.get(1).getName());
+    assertEquals("WORLD", acls.get(2).getName());
+    assertEquals(OzoneAcl.AclScope.ACCESS, acls.get(0).getAclScope());
+    assertEquals(OzoneAcl.AclScope.DEFAULT, acls.get(1).getAclScope());
+    assertEquals(OzoneAcl.AclScope.DEFAULT, acls.get(2).getAclScope());
   }
-
 }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFileSystem.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFileSystem.java
@@ -58,7 +58,6 @@ import org.apache.hadoop.ozone.om.helpers.OzoneFileStatus;
 import org.apache.hadoop.ozone.om.protocol.OzoneManagerProtocol;
 import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.ozone.test.GenericTestUtils;
-import org.apache.ozone.test.LambdaTestUtils;
 import org.apache.ozone.test.TestClock;
 import org.apache.ozone.test.tag.Flaky;
 import org.junit.After;
@@ -102,6 +101,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -390,13 +390,11 @@ public class TestOzoneFileSystem {
     checkInvalidPath(file1);
   }
 
-  private void checkInvalidPath(Path path) throws Exception {
-    try {
-      LambdaTestUtils.intercept(InvalidPathException.class, "Invalid path Name",
-          () -> fs.create(path, false));
-    } catch (AssertionError e) {
-      fail("testCreateWithInvalidPaths failed for path" + path);
-    }
+  private void checkInvalidPath(Path path) {
+    InvalidPathException pathException = assertThrows(
+        InvalidPathException.class, () -> fs.create(path, false)
+    );
+    assertTrue(pathException.getMessage().contains("Invalid path Name"));
   }
 
   @Test
@@ -1440,8 +1438,10 @@ public class TestOzoneFileSystem {
         fs.exists(new Path(dest, "sub_dir1")));
 
     // Test if one path belongs to other FileSystem.
-    LambdaTestUtils.intercept(IllegalArgumentException.class, "Wrong FS",
+    IllegalArgumentException exception = assertThrows(
+        IllegalArgumentException.class,
         () -> fs.rename(new Path(fs.getUri().toString() + "fake" + dir), dest));
+    assertTrue(exception.getMessage().contains("Wrong FS"));
   }
 
   private OzoneKeyDetails getKey(Path keyPath, boolean isDirectory)

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFileSystemMissingParent.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFileSystemMissingParent.java
@@ -31,7 +31,6 @@ import org.apache.hadoop.ozone.client.OzoneBucket;
 import org.apache.hadoop.ozone.client.OzoneClient;
 import org.apache.hadoop.ozone.om.OMConfigKeys;
 import org.apache.hadoop.ozone.om.exceptions.OMException;
-import org.apache.ozone.test.LambdaTestUtils;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
@@ -40,6 +39,8 @@ import org.junit.Test;
 
 import static org.apache.hadoop.ozone.OzoneConsts.OZONE_URI_DELIMITER;
 import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_ADDRESS_KEY;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
 
 /**
  * Tests OFS behavior when filesystem paths are enabled and parent directory is
@@ -110,9 +111,9 @@ public class TestOzoneFileSystemMissingParent {
     fs.delete(parent, false);
 
     // Close should throw exception, Since parent doesn't exist.
-    LambdaTestUtils.intercept(OMException.class,
-        "Cannot create file : parent/file " + "as parent "
-            + "directory doesn't exist", () -> stream.close());
+    OMException omException = assertThrows(OMException.class, stream::close);
+    assertTrue(omException.getMessage().contains("Cannot create file : " +
+        "parent/file as parent directory doesn't exist"));
   }
 
   /**
@@ -131,11 +132,10 @@ public class TestOzoneFileSystemMissingParent {
     fs.rename(parent, renamedPath);
 
     // Close should throw exception, Since parent has been moved.
-    LambdaTestUtils.intercept(OMException.class,
-        "Cannot create file : parent/file " + "as parent "
-            + "directory doesn't exist", () -> stream.close());
+    OMException omException = assertThrows(OMException.class, stream::close);
+    assertTrue(omException.getMessage().contains("Cannot create file : " +
+        "parent/file as parent directory doesn't exist"));
 
-    // cleanup
     fs.delete(renamedPath, true);
   }
 }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestRootedOzoneFileSystem.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestRootedOzoneFileSystem.java
@@ -72,7 +72,6 @@ import org.apache.hadoop.ozone.security.acl.OzoneAclConfig;
 import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.hadoop.util.ToolRunner;
 import org.apache.ozone.test.GenericTestUtils;
-import org.apache.ozone.test.LambdaTestUtils;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Assume;
@@ -131,6 +130,7 @@ import static org.apache.hadoop.ozone.security.acl.IAccessAuthorizer.ACLType.DEL
 import static org.apache.hadoop.ozone.security.acl.IAccessAuthorizer.ACLType.LIST;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -1747,9 +1747,9 @@ public class TestRootedOzoneFileSystem {
     Assert.assertTrue(dir1Status.equals(fs.getFileStatus(dirPath1)));
 
     // confirm link is gone
-    LambdaTestUtils.intercept(FileNotFoundException.class,
-        "File not found.",
+    FileNotFoundException exception = assertThrows(FileNotFoundException.class,
         () -> fs.getFileStatus(dirPathLink));
+    assertTrue(exception.getMessage().contains("File not found."));
 
     // Cleanup
     fs.delete(volumePath1, true);
@@ -2063,9 +2063,10 @@ public class TestRootedOzoneFileSystem {
     checkInvalidPath(file1);
   }
 
-  private void checkInvalidPath(Path path) throws Exception {
-    LambdaTestUtils.intercept(InvalidPathException.class, "Invalid path Name",
+  private void checkInvalidPath(Path path) {
+    InvalidPathException exception = assertThrows(InvalidPathException.class,
         () -> fs.create(path, false));
+    assertTrue(exception.getMessage().contains("Invalid path Name"));
   }
 
 
@@ -2284,7 +2285,7 @@ public class TestRootedOzoneFileSystem {
     String bucketNameLocal = RandomStringUtils.randomNumeric(5);
     Path volume = new Path("/" + volumeNameLocal);
     ofs.mkdirs(volume);
-    LambdaTestUtils.intercept(OMException.class,
+    assertThrows(OMException.class,
         () -> ofs.getFileStatus(new Path(volume, bucketNameLocal)));
     // Cleanup
     ofs.delete(volume, true);
@@ -2519,9 +2520,11 @@ public class TestRootedOzoneFileSystem {
     String errorMsg = "Path is not a bucket";
     String finalFromSnap = fromSnap;
     String finalToSnap = toSnap;
-    LambdaTestUtils.intercept(IllegalArgumentException.class, errorMsg,
+    IllegalArgumentException exception = assertThrows(
+        IllegalArgumentException.class,
         () -> ofs.getSnapshotDiffReport(volumePath1, finalFromSnap,
             finalToSnap));
+    assertTrue(exception.getMessage().contains(errorMsg));
   }
 
   @Test

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/TestDelegationToken.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/TestDelegationToken.java
@@ -50,7 +50,6 @@ import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.hadoop.security.token.Token;
 import org.apache.ozone.test.GenericTestUtils;
 import org.apache.ozone.test.GenericTestUtils.LogCapturer;
-import org.apache.ozone.test.LambdaTestUtils;
 
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.RandomStringUtils;
@@ -86,6 +85,7 @@ import org.junit.After;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 import org.junit.Before;
 import org.junit.BeforeClass;
@@ -349,8 +349,7 @@ public final class TestDelegationToken {
       // initial connection via DT succeeded
       omLogs.clearOutput();
 
-      OMException ex = LambdaTestUtils.intercept(OMException.class,
-          "INVALID_AUTH_METHOD",
+      OMException ex = assertThrows(OMException.class,
           () -> omClient.renewDelegationToken(token));
       assertEquals(INVALID_AUTH_METHOD, ex.getResult());
       assertTrue(logs.getOutput().contains(
@@ -378,10 +377,10 @@ public final class TestDelegationToken {
       omClient = new OzoneManagerProtocolClientSideTranslatorPB(
           OmTransportFactory.create(conf, testUser, null),
           RandomStringUtils.randomAscii(5));
-      ex = LambdaTestUtils.intercept(OMException.class,
-          "Cancel delegation token failed",
+      ex = assertThrows(OMException.class,
           () -> omClient.cancelDelegationToken(token));
       assertEquals(TOKEN_ERROR_OTHER, ex.getResult());
+      assertTrue(ex.getMessage().contains("Cancel delegation token failed"));
       assertTrue(logs.getOutput().contains("Auth failed for"));
     } finally {
       om.stop();

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestOzoneRpcClientAbstract.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestOzoneRpcClientAbstract.java
@@ -118,7 +118,6 @@ import org.apache.hadoop.ozone.security.acl.OzoneObj;
 import org.apache.hadoop.ozone.security.acl.OzoneObjInfo;
 import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.ozone.test.GenericTestUtils;
-import org.apache.ozone.test.LambdaTestUtils;
 import org.apache.ozone.test.tag.Flaky;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
@@ -144,18 +143,18 @@ import static org.apache.hadoop.ozone.security.acl.IAccessAuthorizer.ACLIdentity
 import static org.apache.hadoop.ozone.security.acl.IAccessAuthorizer.ACLIdentityType.USER;
 import static org.apache.hadoop.ozone.security.acl.IAccessAuthorizer.ACLType.READ;
 
-import org.junit.Assert;
-
 import static org.apache.hadoop.ozone.security.acl.IAccessAuthorizer.ACLType.WRITE;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.slf4j.event.Level.DEBUG;
 
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.MethodOrderer;
 import org.junit.jupiter.api.Test;
@@ -280,11 +279,11 @@ public abstract class TestOzoneRpcClientAbstract {
     List<OMProxyInfo> omProxies = omFailoverProxyProvider.getOMProxyInfos();
 
     // For a non-HA OM service, there should be only one OM proxy.
-    Assert.assertEquals(1, omProxies.size());
+    assertEquals(1, omProxies.size());
     // The address in OMProxyInfo object, which client will connect to,
     // should match the OM's RPC address.
-    Assert.assertTrue(omProxies.get(0).getAddress().equals(
-        ozoneManager.getOmRpcServerAddr()));
+    assertEquals(omProxies.get(0).getAddress(),
+        ozoneManager.getOmRpcServerAddr());
   }
 
   @Test
@@ -292,7 +291,7 @@ public abstract class TestOzoneRpcClientAbstract {
     String s3VolumeName =
         HddsClientUtils.getDefaultS3VolumeName(cluster.getConf());
     OzoneVolume ozoneVolume = store.getVolume(s3VolumeName);
-    Assert.assertEquals(ozoneVolume.getName(), s3VolumeName);
+    assertEquals(ozoneVolume.getName(), s3VolumeName);
     OMMetadataManager omMetadataManager =
         cluster.getOzoneManager().getMetadataManager();
     long transactionID = MAX_TRXN_ID + 1;
@@ -301,8 +300,8 @@ public abstract class TestOzoneRpcClientAbstract {
     OmVolumeArgs omVolumeArgs =
         cluster.getOzoneManager().getMetadataManager().getVolumeTable().get(
             omMetadataManager.getVolumeKey(s3VolumeName));
-    Assert.assertEquals(objectID, omVolumeArgs.getObjectID());
-    Assert.assertEquals(DEFAULT_OM_UPDATE_ID, omVolumeArgs.getUpdateID());
+    assertEquals(objectID, omVolumeArgs.getObjectID());
+    assertEquals(DEFAULT_OM_UPDATE_ID, omVolumeArgs.getUpdateID());
   }
 
   @Test
@@ -352,59 +351,60 @@ public abstract class TestOzoneRpcClientAbstract {
 
     store.getVolume(volumeName).createBucket(bucketName);
     OzoneBucket bucket = store.getVolume(volumeName).getBucket(bucketName);
-    Assert.assertEquals(OzoneConsts.QUOTA_RESET, bucket.getQuotaInBytes());
-    Assert.assertEquals(OzoneConsts.QUOTA_RESET, bucket.getQuotaInNamespace());
+    assertEquals(OzoneConsts.QUOTA_RESET, bucket.getQuotaInBytes());
+    assertEquals(OzoneConsts.QUOTA_RESET, bucket.getQuotaInNamespace());
 
     store.getVolume(volumeName).getBucket(bucketName).setQuota(
         OzoneQuota.parseQuota("1GB", "1000"));
     OzoneBucket ozoneBucket = store.getVolume(volumeName).getBucket(bucketName);
-    Assert.assertEquals(1024 * 1024 * 1024,
+    assertEquals(1024 * 1024 * 1024,
         ozoneBucket.getQuotaInBytes());
-    Assert.assertEquals(1000L, ozoneBucket.getQuotaInNamespace());
+    assertEquals(1000L, ozoneBucket.getQuotaInNamespace());
 
     store.getVolume(volumeName).createBucket(bucketName2);
     store.getVolume(volumeName).getBucket(bucketName2).setQuota(
         OzoneQuota.parseQuota("1024", "1000"));
     OzoneBucket ozoneBucket2 =
         store.getVolume(volumeName).getBucket(bucketName2);
-    Assert.assertEquals(1024L, ozoneBucket2.getQuotaInBytes());
+    assertEquals(1024L, ozoneBucket2.getQuotaInBytes());
 
     store.getVolume(volumeName).setQuota(OzoneQuota.parseQuota(
         "10GB", "10000"));
     volume = store.getVolume(volumeName);
-    Assert.assertEquals(10 * GB, volume.getQuotaInBytes());
-    Assert.assertEquals(10000L, volume.getQuotaInNamespace());
+    assertEquals(10 * GB, volume.getQuotaInBytes());
+    assertEquals(10000L, volume.getQuotaInNamespace());
 
-    LambdaTestUtils.intercept(IOException.class, "Can not clear bucket" +
-        " spaceQuota because volume spaceQuota is not cleared.",
-        () -> ozoneBucket.clearSpaceQuota());
+    IOException ioException = assertThrows(IOException.class,
+        ozoneBucket::clearSpaceQuota);
+    assertEquals("Can not clear bucket spaceQuota because volume" +
+        " spaceQuota is not cleared.", ioException.getMessage());
 
     writeKey(bucket, UUID.randomUUID().toString(), ONE, value, valueLength);
-    Assert.assertEquals(1L,
+    assertEquals(1L,
         store.getVolume(volumeName).getBucket(bucketName).getUsedNamespace());
-    Assert.assertEquals(valueLength,
+    assertEquals(valueLength,
         store.getVolume(volumeName).getBucket(bucketName).getUsedBytes());
-    Assert.assertEquals(2L,
+    assertEquals(2L,
         store.getVolume(volumeName).getUsedNamespace());
 
     store.getVolume(volumeName).clearSpaceQuota();
     store.getVolume(volumeName).clearNamespaceQuota();
     OzoneVolume clrVolume = store.getVolume(volumeName);
-    Assert.assertEquals(OzoneConsts.QUOTA_RESET, clrVolume.getQuotaInBytes());
-    Assert.assertEquals(OzoneConsts.QUOTA_RESET,
+    assertEquals(OzoneConsts.QUOTA_RESET, clrVolume.getQuotaInBytes());
+    assertEquals(OzoneConsts.QUOTA_RESET,
         clrVolume.getQuotaInNamespace());
 
     ozoneBucket.clearSpaceQuota();
     ozoneBucket.clearNamespaceQuota();
     OzoneBucket clrBucket = store.getVolume(volumeName).getBucket(bucketName);
-    Assert.assertEquals(OzoneConsts.QUOTA_RESET, clrBucket.getQuotaInBytes());
-    Assert.assertEquals(OzoneConsts.QUOTA_RESET,
+    assertEquals(OzoneConsts.QUOTA_RESET, clrBucket.getQuotaInBytes());
+    assertEquals(OzoneConsts.QUOTA_RESET,
         clrBucket.getQuotaInNamespace());
-    Assert.assertEquals(1L,
+    assertEquals(1L,
         store.getVolume(volumeName).getBucket(bucketName).getUsedNamespace());
-    Assert.assertEquals(valueLength,
+    assertEquals(valueLength,
         store.getVolume(volumeName).getBucket(bucketName).getUsedBytes());
-    Assert.assertEquals(2L,
+    assertEquals(2L,
         store.getVolume(volumeName).getUsedNamespace());
   }
 
@@ -415,35 +415,42 @@ public abstract class TestOzoneRpcClientAbstract {
     store.createVolume(volumeName);
     store.getVolume(volumeName).createBucket(bucketName);
 
-    // test bucket set quota 0
-    LambdaTestUtils.intercept(IllegalArgumentException.class,
-        "Invalid values for space quota",
-        () -> store.getVolume(volumeName).getBucket(bucketName).setQuota(
-            OzoneQuota.parseQuota("0GB", "10")));
-    LambdaTestUtils.intercept(IllegalArgumentException.class,
-        "Invalid values for namespace quota",
+    IllegalArgumentException exception =
+        assertThrows(IllegalArgumentException.class,
+            () -> store.getVolume(volumeName).getBucket(bucketName)
+                .setQuota(OzoneQuota.parseQuota("0GB", "10")));
+    assertTrue(exception.getMessage()
+        .startsWith("Invalid values for space quota"));
+
+    exception = assertThrows(IllegalArgumentException.class,
         () -> store.getVolume(volumeName).getBucket(bucketName).setQuota(
             OzoneQuota.parseQuota("10GB", "0")));
+    assertTrue(exception.getMessage()
+        .startsWith("Invalid values for namespace quota"));
 
-    LambdaTestUtils.intercept(IllegalArgumentException.class,
-        "Invalid values for namespace quota",
+    exception = assertThrows(IllegalArgumentException.class,
         () -> store.getVolume(volumeName).getBucket(bucketName).setQuota(
             OzoneQuota.parseQuota("1GB", "-100")));
+    assertTrue(exception.getMessage()
+        .startsWith("Invalid values for namespace quota"));
 
-    LambdaTestUtils.intercept(IllegalArgumentException.class,
-        "Invalid values for quota",
+    exception = assertThrows(IllegalArgumentException.class,
         () -> store.getVolume(volumeName).getBucket(bucketName).setQuota(
             OzoneQuota.parseQuota("1TEST", "100")));
+    assertTrue(exception.getMessage()
+        .startsWith("Invalid values for quota"));
 
-    LambdaTestUtils.intercept(IllegalArgumentException.class,
-        "Invalid values for quota",
+    exception = assertThrows(IllegalArgumentException.class,
         () -> store.getVolume(volumeName).getBucket(bucketName).setQuota(
             OzoneQuota.parseQuota("9223372036854775808 BYTES", "100")));
+    assertTrue(exception.getMessage()
+        .startsWith("Invalid values for quota"));
 
-    LambdaTestUtils.intercept(IllegalArgumentException.class,
-        "Invalid values for space quota",
+    exception = assertThrows(IllegalArgumentException.class,
         () -> store.getVolume(volumeName).getBucket(bucketName).setQuota(
             OzoneQuota.parseQuota("-10GB", "100")));
+    assertTrue(exception.getMessage()
+        .startsWith("Invalid values for space quota"));
 
   }
 
@@ -451,15 +458,15 @@ public abstract class TestOzoneRpcClientAbstract {
   public void testSetVolumeQuota() throws IOException {
     String volumeName = UUID.randomUUID().toString();
     store.createVolume(volumeName);
-    Assert.assertEquals(OzoneConsts.QUOTA_RESET,
+    assertEquals(OzoneConsts.QUOTA_RESET,
         store.getVolume(volumeName).getQuotaInBytes());
-    Assert.assertEquals(OzoneConsts.QUOTA_RESET,
+    assertEquals(OzoneConsts.QUOTA_RESET,
         store.getVolume(volumeName).getQuotaInNamespace());
     store.getVolume(volumeName).setQuota(OzoneQuota.parseQuota("1GB", "1000"));
     OzoneVolume volume = store.getVolume(volumeName);
-    Assert.assertEquals(1024 * 1024 * 1024,
+    assertEquals(1024 * 1024 * 1024,
         volume.getQuotaInBytes());
-    Assert.assertEquals(1000L, volume.getQuotaInNamespace());
+    assertEquals(1000L, volume.getQuotaInNamespace());
   }
 
   @Test
@@ -471,39 +478,46 @@ public abstract class TestOzoneRpcClientAbstract {
         .setQuotaInNamespace(0)
         .setQuotaInBytes(0)
         .build();
-    LambdaTestUtils.intercept(IllegalArgumentException.class,
-        "Invalid values for quota",
+    IllegalArgumentException exception = assertThrows(
+        IllegalArgumentException.class,
         () -> store.createVolume(volumeName, volumeArgs));
+    assertTrue(exception.getMessage()
+        .startsWith("Invalid values for quota"));
 
     store.createVolume(volumeName);
 
     // test volume set quota 0
-    LambdaTestUtils.intercept(IllegalArgumentException.class,
-        "Invalid values for space quota",
+    exception = assertThrows(IllegalArgumentException.class,
         () -> store.getVolume(volumeName).setQuota(OzoneQuota.parseQuota(
             "0GB", "10")));
-    LambdaTestUtils.intercept(IllegalArgumentException.class,
-        "Invalid values for namespace quota",
+    assertTrue(exception.getMessage()
+        .startsWith("Invalid values for space quota"));
+    exception = assertThrows(IllegalArgumentException.class,
         () -> store.getVolume(volumeName).setQuota(OzoneQuota.parseQuota(
             "10GB", "0")));
+    assertTrue(exception.getMessage()
+        .startsWith("Invalid values for namespace quota"));
 
     // The unit should be legal.
-    LambdaTestUtils.intercept(IllegalArgumentException.class,
-        "Invalid values for quota",
+    exception = assertThrows(IllegalArgumentException.class,
         () -> store.getVolume(volumeName).setQuota(OzoneQuota.parseQuota(
             "1TEST", "1000")));
+    assertTrue(exception.getMessage()
+        .startsWith("Invalid values for quota"));
 
     // The setting value cannot be greater than LONG.MAX_VALUE BYTES.
-    LambdaTestUtils.intercept(IllegalArgumentException.class,
-        "Invalid values for quota",
+    exception = assertThrows(IllegalArgumentException.class,
         () -> store.getVolume(volumeName).setQuota(OzoneQuota.parseQuota(
             "9223372036854775808 B", "1000")));
+    assertTrue(exception.getMessage()
+        .startsWith("Invalid values for quota"));
 
     // The value cannot be negative.
-    LambdaTestUtils.intercept(IllegalArgumentException.class,
-        "Invalid values for space quota",
+    exception = assertThrows(IllegalArgumentException.class,
         () -> store.getVolume(volumeName).setQuota(OzoneQuota.parseQuota(
             "-10GB", "1000")));
+    assertTrue(exception.getMessage()
+        .startsWith("Invalid values for space quota"));
   }
 
   @Test
@@ -512,7 +526,7 @@ public abstract class TestOzoneRpcClientAbstract {
     String volumeName = UUID.randomUUID().toString();
     store.createVolume(volumeName);
     OzoneVolume volume = store.getVolume(volumeName);
-    Assert.assertNotNull(volume);
+    assertNotNull(volume);
     store.deleteVolume(volumeName);
     OzoneTestUtils.expectOmException(ResultCodes.VOLUME_NOT_FOUND,
         () -> store.getVolume(volumeName));
@@ -528,10 +542,10 @@ public abstract class TestOzoneRpcClientAbstract {
         .build();
     store.createVolume(volumeName, volumeArgs);
     OzoneVolume volume = store.getVolume(volumeName);
-    Assert.assertEquals(OzoneConsts.QUOTA_RESET, volume.getQuotaInNamespace());
-    Assert.assertEquals(OzoneConsts.QUOTA_RESET, volume.getQuotaInBytes());
-    Assert.assertEquals("val1", volume.getMetadata().get("key1"));
-    Assert.assertEquals(volumeName, volume.getName());
+    assertEquals(OzoneConsts.QUOTA_RESET, volume.getQuotaInNamespace());
+    assertEquals(OzoneConsts.QUOTA_RESET, volume.getQuotaInBytes());
+    assertEquals("val1", volume.getMetadata().get("key1"));
+    assertEquals(volumeName, volume.getName());
   }
 
   @Test
@@ -541,17 +555,17 @@ public abstract class TestOzoneRpcClientAbstract {
     String bucketName = UUID.randomUUID().toString();
     store.createVolume(volumeName);
     OzoneVolume volume = store.getVolume(volumeName);
-    Assert.assertEquals(OzoneConsts.QUOTA_RESET, volume.getQuotaInNamespace());
-    Assert.assertEquals(OzoneConsts.QUOTA_RESET, volume.getQuotaInBytes());
+    assertEquals(OzoneConsts.QUOTA_RESET, volume.getQuotaInNamespace());
+    assertEquals(OzoneConsts.QUOTA_RESET, volume.getQuotaInBytes());
     BucketArgs args = BucketArgs.newBuilder()
         .addMetadata("key1", "value1").build();
     volume.createBucket(bucketName, args);
     OzoneBucket bucket = volume.getBucket(bucketName);
-    Assert.assertEquals(bucketName, bucket.getName());
-    Assert.assertEquals(OzoneConsts.QUOTA_RESET, bucket.getQuotaInNamespace());
-    Assert.assertEquals(OzoneConsts.QUOTA_RESET, bucket.getQuotaInBytes());
-    Assert.assertNotNull(bucket.getMetadata());
-    Assert.assertEquals("value1", bucket.getMetadata().get("key1"));
+    assertEquals(bucketName, bucket.getName());
+    assertEquals(OzoneConsts.QUOTA_RESET, bucket.getQuotaInNamespace());
+    assertEquals(OzoneConsts.QUOTA_RESET, bucket.getQuotaInBytes());
+    assertNotNull(bucket.getMetadata());
+    assertEquals("value1", bucket.getMetadata().get("key1"));
 
   }
 
@@ -566,9 +580,9 @@ public abstract class TestOzoneRpcClientAbstract {
     OzoneVolume volume = store.getVolume(volumeName);
     volume.createBucket(bucketName);
     OzoneBucket bucket = volume.getBucket(bucketName);
-    Assert.assertEquals(bucketName, bucket.getName());
-    Assert.assertFalse(bucket.getCreationTime().isBefore(testStartTime));
-    Assert.assertFalse(volume.getCreationTime().isBefore(testStartTime));
+    assertEquals(bucketName, bucket.getName());
+    assertFalse(bucket.getCreationTime().isBefore(testStartTime));
+    assertFalse(volume.getCreationTime().isBefore(testStartTime));
   }
 
   @Test
@@ -578,9 +592,9 @@ public abstract class TestOzoneRpcClientAbstract {
     String bucketName = UUID.randomUUID().toString();
     store.createS3Bucket(bucketName);
     OzoneBucket bucket = store.getS3Bucket(bucketName);
-    Assert.assertEquals(bucketName, bucket.getName());
-    Assert.assertFalse(bucket.getCreationTime().isBefore(testStartTime));
-    Assert.assertEquals(BucketLayout.OBJECT_STORE, bucket.getBucketLayout());
+    assertEquals(bucketName, bucket.getName());
+    assertFalse(bucket.getCreationTime().isBefore(testStartTime));
+    assertEquals(BucketLayout.OBJECT_STORE, bucket.getBucketLayout());
   }
 
   @Test
@@ -590,8 +604,8 @@ public abstract class TestOzoneRpcClientAbstract {
     String bucketName = UUID.randomUUID().toString();
     store.createS3Bucket(bucketName);
     OzoneBucket bucket = store.getS3Bucket(bucketName);
-    Assert.assertEquals(bucketName, bucket.getName());
-    Assert.assertFalse(bucket.getCreationTime().isBefore(testStartTime));
+    assertEquals(bucketName, bucket.getName());
+    assertFalse(bucket.getCreationTime().isBefore(testStartTime));
     store.deleteS3Bucket(bucketName);
 
     OzoneTestUtils.expectOmException(ResultCodes.BUCKET_NOT_FOUND,
@@ -618,8 +632,8 @@ public abstract class TestOzoneRpcClientAbstract {
     builder.setVersioning(true);
     volume.createBucket(bucketName, builder.build());
     OzoneBucket bucket = volume.getBucket(bucketName);
-    Assert.assertEquals(bucketName, bucket.getName());
-    Assert.assertEquals(true, bucket.getVersioning());
+    assertEquals(bucketName, bucket.getName());
+    assertEquals(true, bucket.getVersioning());
   }
 
   @Test
@@ -633,8 +647,8 @@ public abstract class TestOzoneRpcClientAbstract {
     builder.setStorageType(StorageType.SSD);
     volume.createBucket(bucketName, builder.build());
     OzoneBucket bucket = volume.getBucket(bucketName);
-    Assert.assertEquals(bucketName, bucket.getName());
-    Assert.assertEquals(StorageType.SSD, bucket.getStorageType());
+    assertEquals(bucketName, bucket.getName());
+    assertEquals(StorageType.SSD, bucket.getStorageType());
   }
 
   @Test
@@ -652,8 +666,8 @@ public abstract class TestOzoneRpcClientAbstract {
     builder.setAcls(acls);
     volume.createBucket(bucketName, builder.build());
     OzoneBucket bucket = volume.getBucket(bucketName);
-    Assert.assertEquals(bucketName, bucket.getName());
-    Assert.assertTrue(bucket.getAcls().contains(userAcl));
+    assertEquals(bucketName, bucket.getName());
+    assertTrue(bucket.getAcls().contains(userAcl));
   }
 
   @Test
@@ -669,8 +683,8 @@ public abstract class TestOzoneRpcClientAbstract {
         .build();
     volume.createBucket(bucketName, bucketArgs);
     OzoneBucket bucket = volume.getBucket(bucketName);
-    Assert.assertEquals(bucketName, bucket.getName());
-    Assert.assertEquals(repConfig, bucket.getReplicationConfig());
+    assertEquals(bucketName, bucket.getName());
+    assertEquals(repConfig, bucket.getReplicationConfig());
   }
 
   @Test
@@ -692,23 +706,23 @@ public abstract class TestOzoneRpcClientAbstract {
         .setDefaultReplicationConfig(new DefaultReplicationConfig(repConfig));
     volume.createBucket(bucketName, builder.build());
     OzoneBucket bucket = volume.getBucket(bucketName);
-    Assert.assertEquals(bucketName, bucket.getName());
-    Assert.assertEquals(true, bucket.getVersioning());
-    Assert.assertEquals(StorageType.SSD, bucket.getStorageType());
-    Assert.assertTrue(bucket.getAcls().contains(userAcl));
-    Assert.assertEquals(repConfig, bucket.getReplicationConfig());
+    assertEquals(bucketName, bucket.getName());
+    assertEquals(true, bucket.getVersioning());
+    assertEquals(StorageType.SSD, bucket.getStorageType());
+    assertTrue(bucket.getAcls().contains(userAcl));
+    assertEquals(repConfig, bucket.getReplicationConfig());
   }
 
   @Test
   public void testInvalidBucketCreation() throws Exception {
-
     String volumeName = UUID.randomUUID().toString();
     String bucketName = "invalid#bucket";
     store.createVolume(volumeName);
     OzoneVolume volume = store.getVolume(volumeName);
-    LambdaTestUtils.intercept(OMException.class,
-        "Bucket or Volume name has an unsupported character : #",
+    OMException omException = assertThrows(OMException.class,
         () -> volume.createBucket(bucketName));
+    assertEquals("Bucket or Volume name has an unsupported character : #",
+        omException.getMessage());
   }
 
   @Test
@@ -726,8 +740,8 @@ public abstract class TestOzoneRpcClientAbstract {
       assertTrue(bucket.addAcl(acl));
     }
     OzoneBucket newBucket = volume.getBucket(bucketName);
-    Assert.assertEquals(bucketName, newBucket.getName());
-    Assert.assertTrue(bucket.getAcls().contains(acls.get(0)));
+    assertEquals(bucketName, newBucket.getName());
+    assertTrue(bucket.getAcls().contains(acls.get(0)));
   }
 
   @Test
@@ -749,8 +763,8 @@ public abstract class TestOzoneRpcClientAbstract {
       assertTrue(bucket.removeAcl(acl));
     }
     OzoneBucket newBucket = volume.getBucket(bucketName);
-    Assert.assertEquals(bucketName, newBucket.getName());
-    Assert.assertTrue(!bucket.getAcls().contains(acls.get(0)));
+    assertEquals(bucketName, newBucket.getName());
+    assertFalse(bucket.getAcls().contains(acls.get(0)));
   }
 
   @Test
@@ -777,12 +791,12 @@ public abstract class TestOzoneRpcClientAbstract {
 
     // Remove the 2nd acl added to the list.
     boolean remove = store.removeAcl(ozoneObj, acls.get(1));
-    Assert.assertTrue(remove);
-    Assert.assertFalse(store.getAcl(ozoneObj).contains(acls.get(1)));
+    assertTrue(remove);
+    assertFalse(store.getAcl(ozoneObj).contains(acls.get(1)));
 
     remove = store.removeAcl(ozoneObj, acls.get(0));
-    Assert.assertTrue(remove);
-    Assert.assertFalse(store.getAcl(ozoneObj).contains(acls.get(0)));
+    assertTrue(remove);
+    assertFalse(store.getAcl(ozoneObj).contains(acls.get(0)));
   }
 
   @Test
@@ -796,8 +810,8 @@ public abstract class TestOzoneRpcClientAbstract {
     OzoneBucket bucket = volume.getBucket(bucketName);
     bucket.setVersioning(true);
     OzoneBucket newBucket = volume.getBucket(bucketName);
-    Assert.assertEquals(bucketName, newBucket.getName());
-    Assert.assertEquals(true, newBucket.getVersioning());
+    assertEquals(bucketName, newBucket.getName());
+    assertEquals(true, newBucket.getVersioning());
   }
 
   @Test
@@ -814,11 +828,11 @@ public abstract class TestOzoneRpcClientAbstract {
     ozoneBucket.setVersioning(true);
 
     OzoneBucket newBucket = volume.getBucket(bucketName);
-    Assert.assertEquals(bucketName, newBucket.getName());
-    Assert.assertEquals(true, newBucket.getVersioning());
+    assertEquals(bucketName, newBucket.getName());
+    assertEquals(true, newBucket.getVersioning());
 
     List<OzoneAcl> aclsAfterSet = newBucket.getAcls();
-    Assert.assertEquals(currentAcls, aclsAfterSet);
+    assertEquals(currentAcls, aclsAfterSet);
 
   }
 
@@ -833,8 +847,8 @@ public abstract class TestOzoneRpcClientAbstract {
     OzoneBucket bucket = volume.getBucket(bucketName);
     bucket.setStorageType(StorageType.SSD);
     OzoneBucket newBucket = volume.getBucket(bucketName);
-    Assert.assertEquals(bucketName, newBucket.getName());
-    Assert.assertEquals(StorageType.SSD, newBucket.getStorageType());
+    assertEquals(bucketName, newBucket.getName());
+    assertEquals(StorageType.SSD, newBucket.getStorageType());
   }
 
   @ParameterizedTest
@@ -876,7 +890,7 @@ public abstract class TestOzoneRpcClientAbstract {
     OzoneVolume volume = store.getVolume(volumeName);
     volume.createBucket(bucketName);
     OzoneBucket bucket = volume.getBucket(bucketName);
-    Assert.assertNotNull(bucket);
+    assertNotNull(bucket);
     volume.deleteBucket(bucketName);
 
     OzoneTestUtils.expectOmException(ResultCodes.BUCKET_NOT_FOUND,
@@ -897,7 +911,7 @@ public abstract class TestOzoneRpcClientAbstract {
         keyInfo.getLatestVersionLocations().getLocationList()) {
       ContainerInfo container =
           storageContainerLocationClient.getContainer(info.getContainerID());
-      Assert.assertEquals(replication, container.getReplicationConfig());
+      assertEquals(replication, container.getReplicationConfig());
     }
   }
 
@@ -925,16 +939,16 @@ public abstract class TestOzoneRpcClientAbstract {
       out.write(value.getBytes(UTF_8));
       out.close();
       OzoneKey key = bucket.getKey(keyName);
-      Assert.assertEquals(keyName, key.getName());
+      assertEquals(keyName, key.getName());
       try (OzoneInputStream is = bucket.readKey(keyName)) {
         byte[] fileContent = new byte[value.getBytes(UTF_8).length];
         is.read(fileContent);
-        Assert.assertEquals(value, new String(fileContent, UTF_8));
+        assertEquals(value, new String(fileContent, UTF_8));
       }
     } else {
-      Assertions.assertThrows(IllegalArgumentException.class,
-              () -> bucket.createKey(keyName, "dummy".getBytes(UTF_8).length,
-                      replicationConfig, new HashMap<>()));
+      assertThrows(IllegalArgumentException.class,
+          () -> bucket.createKey(keyName, "dummy".getBytes(UTF_8).length,
+              replicationConfig, new HashMap<>()));
     }
   }
 
@@ -959,16 +973,16 @@ public abstract class TestOzoneRpcClientAbstract {
       out.write(value.getBytes(UTF_8));
       out.close();
       OzoneKey key = bucket.getKey(keyName);
-      Assert.assertEquals(keyName, key.getName());
+      assertEquals(keyName, key.getName());
       try (OzoneInputStream is = bucket.readKey(keyName)) {
         byte[] fileContent = new byte[value.getBytes(UTF_8).length];
         is.read(fileContent);
         verifyReplication(volumeName, bucketName, keyName,
             RatisReplicationConfig.getInstance(
                 HddsProtos.ReplicationFactor.ONE));
-        Assert.assertEquals(value, new String(fileContent, UTF_8));
-        Assert.assertFalse(key.getCreationTime().isBefore(testStartTime));
-        Assert.assertFalse(key.getModificationTime().isBefore(testStartTime));
+        assertEquals(value, new String(fileContent, UTF_8));
+        assertFalse(key.getCreationTime().isBefore(testStartTime));
+        assertFalse(key.getModificationTime().isBefore(testStartTime));
       }
     }
   }
@@ -1008,7 +1022,7 @@ public abstract class TestOzoneRpcClientAbstract {
       GenericTestUtils.assertExceptionContains("QUOTA_EXCEEDED", ex);
     }
     // Write failed, bucket usedBytes should be 0
-    Assert.assertEquals(0L,
+    assertEquals(0L,
         store.getVolume(volumeName).getBucket(bucketName).getUsedBytes());
 
     // Test bucket quota: write file.
@@ -1020,7 +1034,7 @@ public abstract class TestOzoneRpcClientAbstract {
       GenericTestUtils.assertExceptionContains("QUOTA_EXCEEDED", ex);
     }
     // Write failed, bucket usedBytes should be 0
-    Assert.assertEquals(0L,
+    assertEquals(0L,
         store.getVolume(volumeName).getBucket(bucketName).getUsedBytes());
 
     // Test bucket quota: write large key(with five blocks), the first four
@@ -1040,16 +1054,16 @@ public abstract class TestOzoneRpcClientAbstract {
       GenericTestUtils.assertExceptionContains("QUOTA_EXCEEDED", ex);
     }
     // AllocateBlock failed, bucket usedBytes should not update.
-    Assert.assertEquals(0L,
+    assertEquals(0L,
         store.getVolume(volumeName).getBucket(bucketName).getUsedBytes());
 
     // Reset bucket quota, the original usedBytes needs to remain the same
     bucket.setQuota(OzoneQuota.parseQuota(
         100 + " GB", "100"));
-    Assert.assertEquals(0,
+    assertEquals(0,
         store.getVolume(volumeName).getBucket(bucketName).getUsedBytes());
 
-    Assert.assertEquals(3, countException);
+    assertEquals(3, countException);
 
     // key with 0 bytes, usedBytes should not increase.
     bucket.setQuota(OzoneQuota.parseQuota(
@@ -1057,7 +1071,7 @@ public abstract class TestOzoneRpcClientAbstract {
     OzoneOutputStream out = bucket.createKey(UUID.randomUUID().toString(),
         valueLength, RATIS, ONE, new HashMap<>());
     out.close();
-    Assert.assertEquals(0,
+    assertEquals(0,
         store.getVolume(volumeName).getBucket(bucketName).getUsedBytes());
 
     // key write success,bucket usedBytes should update.
@@ -1067,7 +1081,7 @@ public abstract class TestOzoneRpcClientAbstract {
         valueLength, RATIS, ONE, new HashMap<>());
     out2.write(value.getBytes(UTF_8));
     out2.close();
-    Assert.assertEquals(valueLength,
+    assertEquals(valueLength,
         store.getVolume(volumeName).getBucket(bucketName).getUsedBytes());
   }
 
@@ -1099,21 +1113,21 @@ public abstract class TestOzoneRpcClientAbstract {
     String keyName = UUID.randomUUID().toString();
 
     writeKey(bucket, keyName, ONE, value, valueLength);
-    Assert.assertEquals(valueLength,
+    assertEquals(valueLength,
         store.getVolume(volumeName).getBucket(bucketName).getUsedBytes());
 
     writeKey(bucket, keyName, ONE, value, valueLength);
-    Assert.assertEquals(valueLength,
+    assertEquals(valueLength,
         store.getVolume(volumeName).getBucket(bucketName).getUsedBytes());
 
     // pre-allocate more blocks than needed
     int fakeValueLength = valueLength + blockSize;
     writeKey(bucket, keyName, ONE, value, fakeValueLength);
-    Assert.assertEquals(valueLength,
+    assertEquals(valueLength,
         store.getVolume(volumeName).getBucket(bucketName).getUsedBytes());
 
     bucket.deleteKey(keyName);
-    Assert.assertEquals(0L,
+    assertEquals(0L,
         store.getVolume(volumeName).getBucket(bucketName).getUsedBytes());
   }
 
@@ -1143,13 +1157,13 @@ public abstract class TestOzoneRpcClientAbstract {
     String keyName = UUID.randomUUID().toString();
 
     writeKey(bucket, keyName, ONE, value, valueLength);
-    Assert.assertEquals(valueLength,
+    assertEquals(valueLength,
         store.getVolume(volumeName).getBucket(bucketName).getUsedBytes());
 
     // Overwrite the same key, because this bucket setVersioning is true,
     // so the bucket usedBytes should increase.
     writeKey(bucket, keyName, ONE, value, valueLength);
-    Assert.assertEquals(valueLength * 2,
+    assertEquals(valueLength * 2,
         store.getVolume(volumeName).getBucket(bucketName).getUsedBytes());
   }
 
@@ -1187,27 +1201,27 @@ public abstract class TestOzoneRpcClientAbstract {
     OzoneOutputStream out = bucket.createKey(keyName, keyLength,
         repConfig, new HashMap<>());
     // Write a new key and do not update Bucket UsedBytes until commit.
-    Assert.assertEquals(0,
+    assertEquals(0,
         store.getVolume(volumeName).getBucket(bucketName).getUsedBytes());
     out.write(value);
     out.close();
     // After committing the new key, the Bucket UsedBytes must be updated to
     // keyQuota.
-    Assert.assertEquals(keyQuota,
+    assertEquals(keyQuota,
         store.getVolume(volumeName).getBucket(bucketName).getUsedBytes());
 
     out = bucket.createKey(keyName, keyLength, repConfig, new HashMap<>());
     // Overwrite an old key. The Bucket UsedBytes are not updated before the
     // commit. So the Bucket UsedBytes remain unchanged.
-    Assert.assertEquals(keyQuota,
+    assertEquals(keyQuota,
         store.getVolume(volumeName).getBucket(bucketName).getUsedBytes());
     out.write(value);
     out.close();
-    Assert.assertEquals(keyQuota,
+    assertEquals(keyQuota,
         store.getVolume(volumeName).getBucket(bucketName).getUsedBytes());
 
     bucket.deleteKey(keyName);
-    Assert.assertEquals(0L,
+    assertEquals(0L,
         store.getVolume(volumeName).getBucket(bucketName).getUsedBytes());
   }
 
@@ -1229,16 +1243,16 @@ public abstract class TestOzoneRpcClientAbstract {
     String keyName2 = UUID.randomUUID().toString();
 
     writeKey(bucket, keyName1, ONE, value, valueLength);
-    Assert.assertEquals(1L, getBucketUsedNamespace(volumeName, bucketName));
+    assertEquals(1L, getBucketUsedNamespace(volumeName, bucketName));
     // Test create a file twice will not increase usedNamespace twice
     writeKey(bucket, keyName1, ONE, value, valueLength);
-    Assert.assertEquals(1L, getBucketUsedNamespace(volumeName, bucketName));
+    assertEquals(1L, getBucketUsedNamespace(volumeName, bucketName));
     writeKey(bucket, keyName2, ONE, value, valueLength);
-    Assert.assertEquals(2L, getBucketUsedNamespace(volumeName, bucketName));
+    assertEquals(2L, getBucketUsedNamespace(volumeName, bucketName));
     bucket.deleteKey(keyName1);
-    Assert.assertEquals(1L, getBucketUsedNamespace(volumeName, bucketName));
+    assertEquals(1L, getBucketUsedNamespace(volumeName, bucketName));
     bucket.deleteKey(keyName2);
-    Assert.assertEquals(0L, getBucketUsedNamespace(volumeName, bucketName));
+    assertEquals(0L, getBucketUsedNamespace(volumeName, bucketName));
 
     RpcClient client = new RpcClient(cluster.getConf(), null);
     try {
@@ -1246,20 +1260,20 @@ public abstract class TestOzoneRpcClientAbstract {
       String directoryName2 = UUID.randomUUID().toString();
 
       client.createDirectory(volumeName, bucketName, directoryName1);
-      Assert.assertEquals(1L, getBucketUsedNamespace(volumeName, bucketName));
+      assertEquals(1L, getBucketUsedNamespace(volumeName, bucketName));
       // Test create a directory twice will not increase usedNamespace twice
       client.createDirectory(volumeName, bucketName, directoryName2);
-      Assert.assertEquals(2L, getBucketUsedNamespace(volumeName, bucketName));
+      assertEquals(2L, getBucketUsedNamespace(volumeName, bucketName));
       client.deleteKey(volumeName, bucketName,
           OzoneFSUtils.addTrailingSlashIfNeeded(directoryName1), false);
-      Assert.assertEquals(1L, getBucketUsedNamespace(volumeName, bucketName));
+      assertEquals(1L, getBucketUsedNamespace(volumeName, bucketName));
       client.deleteKey(volumeName, bucketName,
           OzoneFSUtils.addTrailingSlashIfNeeded(directoryName2), false);
-      Assert.assertEquals(0L, getBucketUsedNamespace(volumeName, bucketName));
+      assertEquals(0L, getBucketUsedNamespace(volumeName, bucketName));
 
       String multiComponentsDir = "dir1/dir2/dir3/dir4";
       client.createDirectory(volumeName, bucketName, multiComponentsDir);
-      Assert.assertEquals(OzoneFSUtils.getFileCount(multiComponentsDir),
+      assertEquals(OzoneFSUtils.getFileCount(multiComponentsDir),
           getBucketUsedNamespace(volumeName, bucketName));
     } finally {
       client.close();
@@ -1298,9 +1312,9 @@ public abstract class TestOzoneRpcClientAbstract {
     if (layout.equals(BucketLayout.OBJECT_STORE)) {
       // for OBJECT_STORE bucket, missing parent will not be
       // created automatically
-      Assert.assertEquals(1, getBucketUsedNamespace(volumeName, bucketName));
+      assertEquals(1, getBucketUsedNamespace(volumeName, bucketName));
     } else {
-      Assert.assertEquals(OzoneFSUtils.getFileCount(missingParentKeyName),
+      assertEquals(OzoneFSUtils.getFileCount(missingParentKeyName),
           getBucketUsedNamespace(volumeName, bucketName));
     }
   }
@@ -1322,11 +1336,11 @@ public abstract class TestOzoneRpcClientAbstract {
         VolumeArgs.newBuilder().setQuotaInNamespace(1L).build());
     volume = store.getVolume(volumeName);
     // The initial value should be 0
-    Assert.assertEquals(0L, volume.getUsedNamespace());
+    assertEquals(0L, volume.getUsedNamespace());
     volume.createBucket(bucketName);
     // Used namespace should be 1
     volume = store.getVolume(volumeName);
-    Assert.assertEquals(1L, volume.getUsedNamespace());
+    assertEquals(1L, volume.getUsedNamespace());
 
     try {
       volume.createBucket(bucketName2);
@@ -1347,18 +1361,18 @@ public abstract class TestOzoneRpcClientAbstract {
     volumeWithLinkedBucket.createBucket(targetBucketName, argsBuilder.build());
     // Used namespace should be 0 because linked bucket does not consume
     // namespace quota
-    Assert.assertEquals(0L, volumeWithLinkedBucket.getUsedNamespace());
+    assertEquals(0L, volumeWithLinkedBucket.getUsedNamespace());
 
     // Reset volume quota, the original usedNamespace needs to remain the same
     store.getVolume(volumeName).setQuota(OzoneQuota.parseNameSpaceQuota(
         "100"));
-    Assert.assertEquals(1L,
+    assertEquals(1L,
         store.getVolume(volumeName).getUsedNamespace());
 
     volume.deleteBucket(bucketName);
     // Used namespace should be 0
     volume = store.getVolume(volumeName);
-    Assert.assertEquals(0L, volume.getUsedNamespace());
+    assertEquals(0L, volume.getUsedNamespace());
   }
 
   @Test
@@ -1368,49 +1382,45 @@ public abstract class TestOzoneRpcClientAbstract {
     String key1 = UUID.randomUUID().toString();
     String key2 = UUID.randomUUID().toString();
     String key3 = UUID.randomUUID().toString();
-    OzoneVolume volume = null;
-    OzoneBucket bucket = null;
 
     String value = "sample value";
 
     store.createVolume(volumeName);
-    volume = store.getVolume(volumeName);
+    OzoneVolume volume = store.getVolume(volumeName);
     volume.createBucket(bucketName);
-    bucket = volume.getBucket(bucketName);
+    OzoneBucket bucket = volume.getBucket(bucketName);
     bucket.setQuota(OzoneQuota.parseQuota(Long.MAX_VALUE + " B", "2"));
 
     writeKey(bucket, key1, ONE, value, value.length());
-    Assert.assertEquals(1L,
+    assertEquals(1L,
         store.getVolume(volumeName).getBucket(bucketName).getUsedNamespace());
 
     writeKey(bucket, key2, ONE, value, value.length());
-    Assert.assertEquals(2L,
+    assertEquals(2L,
         store.getVolume(volumeName).getBucket(bucketName).getUsedNamespace());
 
-    try {
-      writeKey(bucket, key3, ONE, value, value.length());
-      Assert.fail("Write key should be failed");
-    } catch (IOException ex) {
-      GenericTestUtils.assertExceptionContains("QUOTA_EXCEEDED", ex);
-    }
+    IOException ioException = assertThrows(IOException.class,
+        () -> writeKey(bucket, key3, ONE, value, value.length()));
+    assertTrue(ioException.toString().contains("QUOTA_EXCEEDED"));
 
     // Write failed, bucket usedNamespace should remain as 2
-    Assert.assertEquals(2L,
+    assertEquals(2L,
         store.getVolume(volumeName).getBucket(bucketName).getUsedNamespace());
 
     // Reset bucket quota, the original usedNamespace needs to remain the same
     bucket.setQuota(
         OzoneQuota.parseQuota(Long.MAX_VALUE + " B", "100"));
-    Assert.assertEquals(2L,
+    assertEquals(2L,
         store.getVolume(volumeName).getBucket(bucketName).getUsedNamespace());
 
     bucket.deleteKeys(Arrays.asList(key1, key2));
-    Assert.assertEquals(0L,
+    assertEquals(0L,
         store.getVolume(volumeName).getBucket(bucketName).getUsedNamespace());
   }
 
   private void writeKey(OzoneBucket bucket, String keyName,
-      ReplicationFactor replication, String value, int valueLength)
+                        ReplicationFactor replication, String value,
+                        int valueLength)
       throws IOException {
     OzoneOutputStream out = bucket.createKey(keyName, valueLength, RATIS,
         replication, new HashMap<>());
@@ -1419,7 +1429,8 @@ public abstract class TestOzoneRpcClientAbstract {
   }
 
   private void writeFile(OzoneBucket bucket, String keyName,
-      ReplicationFactor replication, String value, int valueLength)
+                         ReplicationFactor replication, String value,
+                         int valueLength)
       throws IOException {
     OzoneOutputStream out = bucket.createFile(keyName, valueLength, RATIS,
         replication, true, true);
@@ -1449,9 +1460,9 @@ public abstract class TestOzoneRpcClientAbstract {
 
     assertNotNull(multipartInfo);
     String uploadID = multipartInfo.getUploadID();
-    Assert.assertEquals(volumeName, multipartInfo.getVolumeName());
-    Assert.assertEquals(bucketName, multipartInfo.getBucketName());
-    Assert.assertEquals(keyName, multipartInfo.getKeyName());
+    assertEquals(volumeName, multipartInfo.getVolumeName());
+    assertEquals(bucketName, multipartInfo.getBucketName());
+    assertEquals(keyName, multipartInfo.getKeyName());
     assertNotNull(multipartInfo.getUploadID());
 
     OzoneOutputStream ozoneOutputStream = bucket.createMultipartKey(keyName,
@@ -1460,12 +1471,12 @@ public abstract class TestOzoneRpcClientAbstract {
         sampleData.length());
     ozoneOutputStream.close();
 
-    Assert.assertEquals(valueLength, store.getVolume(volumeName)
+    assertEquals(valueLength, store.getVolume(volumeName)
         .getBucket(bucketName).getUsedBytes());
 
     // Abort uploaded partKey and the usedBytes of bucket should be 0.
     bucket.abortMultipartUpload(keyName, uploadID);
-    Assert.assertEquals(0, store.getVolume(volumeName)
+    assertEquals(0, store.getVolume(volumeName)
         .getBucket(bucketName).getUsedBytes());
   }
 
@@ -1494,12 +1505,12 @@ public abstract class TestOzoneRpcClientAbstract {
     List<OmKeyLocationInfo> locationInfoList =
         keyInfo.getLatestVersionLocations().getBlocksLatestVersionOnly();
     // LocationList should have only 1 block
-    Assert.assertEquals(1, locationInfoList.size());
+    assertEquals(1, locationInfoList.size());
     // make sure the data block size is updated
-    Assert.assertEquals(value.getBytes(UTF_8).length,
+    assertEquals(value.getBytes(UTF_8).length,
         locationInfoList.get(0).getLength());
     // make sure the total data size is set correctly
-    Assert.assertEquals(value.getBytes(UTF_8).length, keyInfo.getDataSize());
+    assertEquals(value.getBytes(UTF_8).length, keyInfo.getDataSize());
   }
 
   @Test
@@ -1523,16 +1534,16 @@ public abstract class TestOzoneRpcClientAbstract {
       out.write(value.getBytes(UTF_8));
       out.close();
       OzoneKey key = bucket.getKey(keyName);
-      Assert.assertEquals(keyName, key.getName());
+      assertEquals(keyName, key.getName());
       try (OzoneInputStream is = bucket.readKey(keyName)) {
         byte[] fileContent = new byte[value.getBytes(UTF_8).length];
         is.read(fileContent);
         verifyReplication(volumeName, bucketName, keyName,
             RatisReplicationConfig.getInstance(
                 HddsProtos.ReplicationFactor.ONE));
-        Assert.assertEquals(value, new String(fileContent, UTF_8));
-        Assert.assertFalse(key.getCreationTime().isBefore(testStartTime));
-        Assert.assertFalse(key.getModificationTime().isBefore(testStartTime));
+        assertEquals(value, new String(fileContent, UTF_8));
+        assertFalse(key.getCreationTime().isBefore(testStartTime));
+        assertFalse(key.getModificationTime().isBefore(testStartTime));
       }
     }
   }
@@ -1558,16 +1569,16 @@ public abstract class TestOzoneRpcClientAbstract {
       out.write(value.getBytes(UTF_8));
       out.close();
       OzoneKey key = bucket.getKey(keyName);
-      Assert.assertEquals(keyName, key.getName());
+      assertEquals(keyName, key.getName());
       try (OzoneInputStream is = bucket.readKey(keyName)) {
         byte[] fileContent = new byte[value.getBytes(UTF_8).length];
         is.read(fileContent);
         verifyReplication(volumeName, bucketName, keyName,
             RatisReplicationConfig.getInstance(
                 HddsProtos.ReplicationFactor.THREE));
-        Assert.assertEquals(value, new String(fileContent, UTF_8));
-        Assert.assertFalse(key.getCreationTime().isBefore(testStartTime));
-        Assert.assertFalse(key.getModificationTime().isBefore(testStartTime));
+        assertEquals(value, new String(fileContent, UTF_8));
+        assertFalse(key.getCreationTime().isBefore(testStartTime));
+        assertFalse(key.getModificationTime().isBefore(testStartTime));
       }
     }
   }
@@ -1599,17 +1610,17 @@ public abstract class TestOzoneRpcClientAbstract {
           out.write(data.getBytes(UTF_8));
           out.close();
           OzoneKey key = bucket.getKey(keyName);
-          Assert.assertEquals(keyName, key.getName());
+          assertEquals(keyName, key.getName());
           try (OzoneInputStream is = bucket.readKey(keyName)) {
             byte[] fileContent = new byte[data.getBytes(UTF_8).length];
             is.read(fileContent);
             verifyReplication(volumeName, bucketName, keyName,
                 RatisReplicationConfig.getInstance(
                     HddsProtos.ReplicationFactor.THREE));
-            Assert.assertEquals(data, new String(fileContent, UTF_8));
+            assertEquals(data, new String(fileContent, UTF_8));
           }
-          Assert.assertFalse(key.getCreationTime().isBefore(testStartTime));
-          Assert.assertFalse(key.getModificationTime().isBefore(testStartTime));
+          assertFalse(key.getCreationTime().isBefore(testStartTime));
+          assertFalse(key.getModificationTime().isBefore(testStartTime));
         }
         latch.countDown();
       } catch (IOException ex) {
@@ -1626,10 +1637,8 @@ public abstract class TestOzoneRpcClientAbstract {
 
     latch.await(600, TimeUnit.SECONDS);
 
-    if (failCount.get() > 0) {
-      fail("testPutKeyRatisThreeNodesParallel failed");
-    }
-
+    assertTrue(failCount.get() <= 0,
+        "testPutKeyRatisThreeNodesParallel failed");
   }
 
 
@@ -1693,7 +1702,7 @@ public abstract class TestOzoneRpcClientAbstract {
         break;
       }
     }
-    Assert.assertNotNull("Container not found", container);
+    assertNotNull(container, "Container not found");
     corruptData(container, key);
   }
 
@@ -1755,15 +1764,15 @@ public abstract class TestOzoneRpcClientAbstract {
     long containerID = keyInfo.getContainerID();
     long localID = keyInfo.getLocalID();
     OzoneKeyDetails keyDetails = (OzoneKeyDetails)bucket.getKey(keyName);
-    Assert.assertEquals(keyName, keyDetails.getName());
+    assertEquals(keyName, keyDetails.getName());
 
     List<OzoneKeyLocation> keyLocations = keyDetails.getOzoneKeyLocations();
-    Assert.assertEquals(1, keyLocations.size());
-    Assert.assertEquals(containerID, keyLocations.get(0).getContainerID());
-    Assert.assertEquals(localID, keyLocations.get(0).getLocalID());
+    assertEquals(1, keyLocations.size());
+    assertEquals(containerID, keyLocations.get(0).getContainerID());
+    assertEquals(localID, keyLocations.get(0).getLocalID());
 
     // Make sure that the data size matched.
-    Assert.assertEquals(keyValue.getBytes(UTF_8).length,
+    assertEquals(keyValue.getBytes(UTF_8).length,
         keyLocations.get(0).getLength());
 
     // Second, sum the data size from chunks in Container via containerID
@@ -1773,10 +1782,10 @@ public abstract class TestOzoneRpcClientAbstract {
     Pipeline pipeline = cluster.getStorageContainerManager()
         .getPipelineManager().getPipeline(container.getPipelineID());
     List<DatanodeDetails> datanodes = pipeline.getNodes();
-    Assert.assertEquals(datanodes.size(), 1);
+    assertEquals(datanodes.size(), 1);
 
     DatanodeDetails datanodeDetails = datanodes.get(0);
-    Assert.assertNotNull(datanodeDetails);
+    assertNotNull(datanodeDetails);
     HddsDatanodeService datanodeService = null;
     for (HddsDatanodeService datanodeServiceItr : cluster.getHddsDatanodes()) {
       if (datanodeDetails.equals(datanodeServiceItr.getDatanodeDetails())) {
@@ -1799,17 +1808,14 @@ public abstract class TestOzoneRpcClientAbstract {
           for (ContainerProtos.ChunkInfo chunk : chunks) {
             length += chunk.getLen();
           }
-          Assert.assertEquals(length, keyValue.getBytes(UTF_8).length);
+          assertEquals(length, keyValue.getBytes(UTF_8).length);
           break;
         }
       }
     }
 
-    OzoneInputStream inputStream = keyDetails.getContent();
-    try {
+    try (OzoneInputStream inputStream = keyDetails.getContent()) {
       assertInputStreamContent(keyValue, inputStream);
-    } finally {
-      inputStream.close();
     }
   }
 
@@ -1859,7 +1865,7 @@ public abstract class TestOzoneRpcClientAbstract {
         break;
       }
     }
-    Assert.assertNotNull("Container not found", container);
+    assertNotNull(container, "Container not found");
     corruptData(container, key);
 
     // Try reading the key. Since the chunk file is corrupted, it should
@@ -1966,7 +1972,7 @@ public abstract class TestOzoneRpcClientAbstract {
         byte[] content = new byte[100];
         is.read(content);
         String retValue = new String(content, UTF_8);
-        Assert.assertTrue(value.equals(retValue.trim()));
+        assertTrue(value.equals(retValue.trim()));
       }
     } catch (IOException e) {
       fail("Reading unhealthy replica should succeed.");
@@ -2002,7 +2008,7 @@ public abstract class TestOzoneRpcClientAbstract {
     OzoneKey key = bucket.getKey(keyName);
     List<OzoneKeyLocation> keyLocation =
         ((OzoneKeyDetails) key).getOzoneKeyLocations();
-    Assert.assertTrue("Key location not found in OM", !keyLocation.isEmpty());
+    assertFalse(keyLocation.isEmpty(), "Key location not found in OM");
     long containerID = ((OzoneKeyDetails) key).getOzoneKeyLocations().get(0)
         .getContainerID();
 
@@ -2019,14 +2025,14 @@ public abstract class TestOzoneRpcClientAbstract {
         }
       }
     }
-    Assert.assertTrue("Container not found", !containerList.isEmpty());
+    assertFalse(containerList.isEmpty(), "Container not found");
     corruptData(containerList.get(0), key);
     // Try reading the key. Read will fail on the first node and will eventually
     // failover to next replica
     try (OzoneInputStream is = bucket.readKey(keyName)) {
       byte[] b = new byte[data.length];
       is.read(b);
-      Assert.assertTrue(Arrays.equals(b, data));
+      assertArrayEquals(b, data);
     } catch (OzoneChecksumException e) {
       fail("Reading corrupted data should not fail.");
     }
@@ -2036,7 +2042,7 @@ public abstract class TestOzoneRpcClientAbstract {
     try (OzoneInputStream is = bucket.readKey(keyName)) {
       byte[] b = new byte[data.length];
       is.read(b);
-      Assert.assertTrue(Arrays.equals(b, data));
+      assertArrayEquals(b, data);
     } catch (OzoneChecksumException e) {
       fail("Reading corrupted data should not fail.");
     }
@@ -2073,7 +2079,7 @@ public abstract class TestOzoneRpcClientAbstract {
           break;
         }
       }
-      Assert.assertNotNull("Block not found", blockData);
+      assertNotNull(blockData, "Block not found");
 
       // Get the location of the chunk file
       String containreBaseDir =
@@ -2106,7 +2112,7 @@ public abstract class TestOzoneRpcClientAbstract {
     out.write(value.getBytes(UTF_8));
     out.close();
     OzoneKey key = bucket.getKey(keyName);
-    Assert.assertEquals(keyName, key.getName());
+    assertEquals(keyName, key.getName());
     bucket.deleteKey(keyName);
 
     OzoneTestUtils.expectOmException(KEY_NOT_FOUND,
@@ -2136,13 +2142,13 @@ public abstract class TestOzoneRpcClientAbstract {
       } catch (OMException e) {
         oe = e;
       }
-      Assert.assertEquals(ResultCodes.INVALID_KEY_NAME, oe.getResult());
+      assertEquals(ResultCodes.INVALID_KEY_NAME, oe.getResult());
     } else {
       // Rename to an empty key in FSO should be okay, as we are handling the
       // empty dest key on the server side and the source key name will be used
       bucket.renameKey(fromKeyName, toKeyName);
       OzoneKey emptyRenameKey = bucket.getKey(fromKeyName);
-      Assert.assertEquals(fromKeyName, emptyRenameKey.getName());
+      assertEquals(fromKeyName, emptyRenameKey.getName());
     }
 
     toKeyName = UUID.randomUUID().toString();
@@ -2154,10 +2160,10 @@ public abstract class TestOzoneRpcClientAbstract {
     } catch (OMException e) {
       oe = e;
     }
-    Assert.assertEquals(KEY_NOT_FOUND, oe.getResult());
+    assertEquals(KEY_NOT_FOUND, oe.getResult());
 
     OzoneKey key = bucket.getKey(toKeyName);
-    Assert.assertEquals(toKeyName, key.getName());
+    assertEquals(toKeyName, key.getName());
   }
 
   /**
@@ -2189,8 +2195,8 @@ public abstract class TestOzoneRpcClientAbstract {
     bucket.renameKeys(keyMap);
 
     // new key should exist
-    Assert.assertEquals(newKeyName1, bucket.getKey(newKeyName1).getName());
-    Assert.assertEquals(newKeyName2, bucket.getKey(newKeyName2).getName());
+    assertEquals(newKeyName1, bucket.getKey(newKeyName1).getName());
+    assertEquals(newKeyName2, bucket.getKey(newKeyName2).getName());
 
     // old key should not exist
     assertKeyRenamedEx(bucket, keyName1);
@@ -2228,11 +2234,11 @@ public abstract class TestOzoneRpcClientAbstract {
     try {
       bucket.renameKeys(keyMap);
     } catch (OMException ex) {
-      Assert.assertEquals(PARTIAL_RENAME, ex.getResult());
+      assertEquals(PARTIAL_RENAME, ex.getResult());
     }
 
     // newKeyName1 should exist
-    Assert.assertEquals(newKeyName1, bucket.getKey(newKeyName1).getName());
+    assertEquals(newKeyName1, bucket.getKey(newKeyName1).getName());
     // newKeyName2 should not exist
     assertKeyRenamedEx(bucket, keyName2);
   }
@@ -2258,25 +2264,25 @@ public abstract class TestOzoneRpcClientAbstract {
       volIterator.next();
       totalVolumeCount++;
     }
-    Assert.assertEquals(20, totalVolumeCount);
+    assertEquals(20, totalVolumeCount);
     Iterator<? extends OzoneVolume> volAIterator = store.listVolumes(
         volBaseNameA);
     for (int i = 0; i < 10; i++) {
-      Assert.assertTrue(volAIterator.next().getName()
+      assertTrue(volAIterator.next().getName()
           .startsWith(volBaseNameA + i + "-"));
     }
-    Assert.assertFalse(volAIterator.hasNext());
+    assertFalse(volAIterator.hasNext());
     Iterator<? extends OzoneVolume> volBIterator = store.listVolumes(
         volBaseNameB);
     for (int i = 0; i < 10; i++) {
-      Assert.assertTrue(volBIterator.next().getName()
+      assertTrue(volBIterator.next().getName()
           .startsWith(volBaseNameB + i + "-"));
     }
-    Assert.assertFalse(volBIterator.hasNext());
+    assertFalse(volBIterator.hasNext());
     Iterator<? extends OzoneVolume> iter = store.listVolumes(volBaseNameA +
         "1-");
-    Assert.assertTrue(iter.next().getName().startsWith(volBaseNameA + "1-"));
-    Assert.assertFalse(iter.hasNext());
+    assertTrue(iter.next().getName().startsWith(volBaseNameA + "1-"));
+    assertFalse(iter.hasNext());
   }
 
   @Test
@@ -2350,7 +2356,7 @@ public abstract class TestOzoneRpcClientAbstract {
     String bucketName = UUID.randomUUID().toString();
     volume.createBucket(bucketName);
     OzoneBucket bucket = volume.listBuckets(bucketName).next();
-    Assert.assertNull(bucket.getReplicationConfig());
+    assertNull(bucket.getReplicationConfig());
 
     // bucket-level replication config: EC/rs-3-2-1024k
     String ecBucketName = UUID.randomUUID().toString();
@@ -2361,7 +2367,7 @@ public abstract class TestOzoneRpcClientAbstract {
         .build();
     volume.createBucket(ecBucketName, ecBucketArgs);
     OzoneBucket ecBucket = volume.listBuckets(ecBucketName).next();
-    Assert.assertEquals(ecRepConfig, ecBucket.getReplicationConfig());
+    assertEquals(ecRepConfig, ecBucket.getReplicationConfig());
 
     // bucket-level replication config: RATIS/THREE
     String ratisBucketName = UUID.randomUUID().toString();
@@ -2373,7 +2379,7 @@ public abstract class TestOzoneRpcClientAbstract {
         .build();
     volume.createBucket(ratisBucketName, ratisBucketArgs);
     OzoneBucket ratisBucket = volume.listBuckets(ratisBucketName).next();
-    Assert.assertEquals(ratisRepConfig, ratisBucket.getReplicationConfig());
+    assertEquals(ratisRepConfig, ratisBucket.getReplicationConfig());
   }
 
   @Test
@@ -2469,7 +2475,7 @@ public abstract class TestOzoneRpcClientAbstract {
       volABucketAIter.next();
       volABucketAKeyCount++;
     }
-    Assert.assertEquals(20, volABucketAKeyCount);
+    assertEquals(20, volABucketAKeyCount);
     Iterator<? extends OzoneKey> volABucketBIter =
         volAbucketB.listKeys("key-");
     int volABucketBKeyCount = 0;
@@ -2477,7 +2483,7 @@ public abstract class TestOzoneRpcClientAbstract {
       volABucketBIter.next();
       volABucketBKeyCount++;
     }
-    Assert.assertEquals(20, volABucketBKeyCount);
+    assertEquals(20, volABucketBKeyCount);
     Iterator<? extends OzoneKey> volBBucketAIter =
         volBbucketA.listKeys("key-");
     int volBBucketAKeyCount = 0;
@@ -2485,7 +2491,7 @@ public abstract class TestOzoneRpcClientAbstract {
       volBBucketAIter.next();
       volBBucketAKeyCount++;
     }
-    Assert.assertEquals(20, volBBucketAKeyCount);
+    assertEquals(20, volBBucketAKeyCount);
     Iterator<? extends OzoneKey> volBBucketBIter =
         volBbucketB.listKeys("key-");
     int volBBucketBKeyCount = 0;
@@ -2493,7 +2499,7 @@ public abstract class TestOzoneRpcClientAbstract {
       volBBucketBIter.next();
       volBBucketBKeyCount++;
     }
-    Assert.assertEquals(20, volBBucketBKeyCount);
+    assertEquals(20, volBBucketBKeyCount);
     Iterator<? extends OzoneKey> volABucketAKeyAIter =
         volAbucketA.listKeys("key-a-");
     int volABucketAKeyACount = 0;
@@ -2501,14 +2507,14 @@ public abstract class TestOzoneRpcClientAbstract {
       volABucketAKeyAIter.next();
       volABucketAKeyACount++;
     }
-    Assert.assertEquals(10, volABucketAKeyACount);
+    assertEquals(10, volABucketAKeyACount);
     Iterator<? extends OzoneKey> volABucketAKeyBIter =
         volAbucketA.listKeys("key-b-");
     for (int i = 0; i < 10; i++) {
-      Assert.assertTrue(volABucketAKeyBIter.next().getName()
+      assertTrue(volABucketAKeyBIter.next().getName()
           .startsWith("key-b-" + i + "-"));
     }
-    Assert.assertFalse(volABucketBIter.hasNext());
+    assertFalse(volABucketBIter.hasNext());
   }
 
   @Test
@@ -2551,9 +2557,9 @@ public abstract class TestOzoneRpcClientAbstract {
 
     assertNotNull(multipartInfo);
     String uploadID = multipartInfo.getUploadID();
-    Assert.assertEquals(volumeName, multipartInfo.getVolumeName());
-    Assert.assertEquals(bucketName, multipartInfo.getBucketName());
-    Assert.assertEquals(keyName, multipartInfo.getKeyName());
+    assertEquals(volumeName, multipartInfo.getVolumeName());
+    assertEquals(bucketName, multipartInfo.getBucketName());
+    assertEquals(keyName, multipartInfo.getKeyName());
     assertNotNull(multipartInfo.getUploadID());
 
     // Call initiate multipart upload for the same key again, this should
@@ -2562,9 +2568,9 @@ public abstract class TestOzoneRpcClientAbstract {
         replicationConfig);
 
     assertNotNull(multipartInfo);
-    Assert.assertEquals(volumeName, multipartInfo.getVolumeName());
-    Assert.assertEquals(bucketName, multipartInfo.getBucketName());
-    Assert.assertEquals(keyName, multipartInfo.getKeyName());
+    assertEquals(volumeName, multipartInfo.getVolumeName());
+    assertEquals(bucketName, multipartInfo.getBucketName());
+    assertEquals(keyName, multipartInfo.getKeyName());
     assertNotEquals(multipartInfo.getUploadID(), uploadID);
     assertNotNull(multipartInfo.getUploadID());
   }
@@ -2585,9 +2591,9 @@ public abstract class TestOzoneRpcClientAbstract {
 
     assertNotNull(multipartInfo);
     String uploadID = multipartInfo.getUploadID();
-    Assert.assertEquals(volumeName, multipartInfo.getVolumeName());
-    Assert.assertEquals(bucketName, multipartInfo.getBucketName());
-    Assert.assertEquals(keyName, multipartInfo.getKeyName());
+    assertEquals(volumeName, multipartInfo.getVolumeName());
+    assertEquals(bucketName, multipartInfo.getBucketName());
+    assertEquals(keyName, multipartInfo.getKeyName());
     assertNotNull(multipartInfo.getUploadID());
 
     // Call initiate multipart upload for the same key again, this should
@@ -2595,9 +2601,9 @@ public abstract class TestOzoneRpcClientAbstract {
     multipartInfo = bucket.initiateMultipartUpload(keyName);
 
     assertNotNull(multipartInfo);
-    Assert.assertEquals(volumeName, multipartInfo.getVolumeName());
-    Assert.assertEquals(bucketName, multipartInfo.getBucketName());
-    Assert.assertEquals(keyName, multipartInfo.getKeyName());
+    assertEquals(volumeName, multipartInfo.getVolumeName());
+    assertEquals(bucketName, multipartInfo.getBucketName());
+    assertEquals(keyName, multipartInfo.getKeyName());
     assertNotEquals(multipartInfo.getUploadID(), uploadID);
     assertNotNull(multipartInfo.getUploadID());
   }
@@ -2620,9 +2626,9 @@ public abstract class TestOzoneRpcClientAbstract {
 
     assertNotNull(multipartInfo);
     String uploadID = multipartInfo.getUploadID();
-    Assert.assertEquals(volumeName, multipartInfo.getVolumeName());
-    Assert.assertEquals(bucketName, multipartInfo.getBucketName());
-    Assert.assertEquals(keyName, multipartInfo.getKeyName());
+    assertEquals(volumeName, multipartInfo.getVolumeName());
+    assertEquals(bucketName, multipartInfo.getBucketName());
+    assertEquals(keyName, multipartInfo.getKeyName());
     assertNotNull(multipartInfo.getUploadID());
 
     OzoneOutputStream ozoneOutputStream = bucket.createMultipartKey(keyName,
@@ -2657,9 +2663,9 @@ public abstract class TestOzoneRpcClientAbstract {
 
     assertNotNull(multipartInfo);
     String uploadID = multipartInfo.getUploadID();
-    Assert.assertEquals(volumeName, multipartInfo.getVolumeName());
-    Assert.assertEquals(bucketName, multipartInfo.getBucketName());
-    Assert.assertEquals(keyName, multipartInfo.getKeyName());
+    assertEquals(volumeName, multipartInfo.getVolumeName());
+    assertEquals(bucketName, multipartInfo.getBucketName());
+    assertEquals(keyName, multipartInfo.getKeyName());
     assertNotNull(multipartInfo.getUploadID());
 
     OzoneOutputStream ozoneOutputStream = bucket.createMultipartKey(keyName,
@@ -2695,8 +2701,8 @@ public abstract class TestOzoneRpcClientAbstract {
     // So, when a part is override partNames will still be same irrespective
     // of content in ozone s3. This will make S3 Mpu completeMPU pass when
     // comparing part names and large file uploads work using aws cp.
-    assertEquals("Part names should be same", partName,
-        commitUploadPartInfo.getPartName());
+    assertEquals(partName, commitUploadPartInfo.getPartName(),
+        "Part names should be same");
   }
 
   @Test
@@ -2752,15 +2758,15 @@ public abstract class TestOzoneRpcClientAbstract {
         .setStoreType(OzoneObj.StoreType.OZONE).build();
     List<OzoneAcl> aclList = store.getAcl(keyObj);
     // key should inherit bucket's DEFAULT type acl
-    Assert.assertTrue(aclList.stream().anyMatch(
+    assertTrue(aclList.stream().anyMatch(
         acl -> acl.getName().equals(acl1.getName())));
-    Assert.assertTrue(aclList.stream().anyMatch(
+    assertTrue(aclList.stream().anyMatch(
         acl -> acl.getName().equals(acl2.getName())));
 
     // kye should not inherit bucket's ACCESS type acl
-    Assert.assertFalse(aclList.stream().anyMatch(
+    assertFalse(aclList.stream().anyMatch(
         acl -> acl.getName().equals(acl3.getName())));
-    Assert.assertFalse(aclList.stream().anyMatch(
+    assertFalse(aclList.stream().anyMatch(
         acl -> acl.getName().equals(acl4.getName())));
 
     // User without permission should fail to upload the object
@@ -2995,7 +3001,7 @@ public abstract class TestOzoneRpcClientAbstract {
     OmMultipartInfo omMultipartInfo = bucket.initiateMultipartUpload(keyName,
         anyReplication());
 
-    Assert.assertNotNull(omMultipartInfo.getUploadID());
+    assertNotNull(omMultipartInfo.getUploadID());
 
     // Do not close output stream.
     byte[] data = "data".getBytes(UTF_8);
@@ -3030,7 +3036,7 @@ public abstract class TestOzoneRpcClientAbstract {
     OmMultipartInfo omMultipartInfo = bucket.initiateMultipartUpload(keyName,
         anyReplication());
 
-    Assert.assertNotNull(omMultipartInfo.getUploadID());
+    assertNotNull(omMultipartInfo.getUploadID());
 
     String uploadID = omMultipartInfo.getUploadID();
 
@@ -3056,7 +3062,7 @@ public abstract class TestOzoneRpcClientAbstract {
         bucket.completeMultipartUpload(keyName,
         uploadID, partsMap);
 
-    Assert.assertNotNull(omMultipartCommitUploadPartInfo);
+    assertNotNull(omMultipartCommitUploadPartInfo);
 
     byte[] fileContent = new byte[data.length];
     try (OzoneInputStream inputStream = bucket.readKey(keyName)) {
@@ -3067,7 +3073,7 @@ public abstract class TestOzoneRpcClientAbstract {
     // Combine all parts data, and check is it matching with get key data.
     String part1 = new String(data, UTF_8);
     sb.append(part1);
-    Assert.assertEquals(sb.toString(), new String(fileContent, UTF_8));
+    assertEquals(sb.toString(), new String(fileContent, UTF_8));
 
     try {
       ozoneOutputStream.close();
@@ -3143,24 +3149,24 @@ public abstract class TestOzoneRpcClientAbstract {
     OzoneMultipartUploadPartListParts ozoneMultipartUploadPartListParts =
         bucket.listParts(keyName, uploadID, 0, 3);
 
-    Assert.assertEquals(
+    assertEquals(
         replication,
         ozoneMultipartUploadPartListParts.getReplicationConfig());
 
-    Assert.assertEquals(partsMap.get(ozoneMultipartUploadPartListParts
+    assertEquals(partsMap.get(ozoneMultipartUploadPartListParts
             .getPartInfoList().get(0).getPartNumber()),
         ozoneMultipartUploadPartListParts.getPartInfoList().get(0)
             .getPartName());
-    Assert.assertEquals(partsMap.get(ozoneMultipartUploadPartListParts
+    assertEquals(partsMap.get(ozoneMultipartUploadPartListParts
             .getPartInfoList().get(1).getPartNumber()),
         ozoneMultipartUploadPartListParts.getPartInfoList().get(1)
             .getPartName());
-    Assert.assertEquals(partsMap.get(ozoneMultipartUploadPartListParts
+    assertEquals(partsMap.get(ozoneMultipartUploadPartListParts
             .getPartInfoList().get(2).getPartNumber()),
         ozoneMultipartUploadPartListParts.getPartInfoList().get(2)
             .getPartName());
 
-    Assert.assertFalse(ozoneMultipartUploadPartListParts.isTruncated());
+    assertFalse(ozoneMultipartUploadPartListParts.isTruncated());
   }
 
   @ParameterizedTest
@@ -3194,36 +3200,36 @@ public abstract class TestOzoneRpcClientAbstract {
     OzoneMultipartUploadPartListParts ozoneMultipartUploadPartListParts =
         bucket.listParts(keyName, uploadID, 0, 2);
 
-    Assert.assertEquals(replication,
+    assertEquals(replication,
         ozoneMultipartUploadPartListParts.getReplicationConfig());
 
-    Assert.assertEquals(2,
+    assertEquals(2,
         ozoneMultipartUploadPartListParts.getPartInfoList().size());
 
-    Assert.assertEquals(partsMap.get(ozoneMultipartUploadPartListParts
+    assertEquals(partsMap.get(ozoneMultipartUploadPartListParts
             .getPartInfoList().get(0).getPartNumber()),
         ozoneMultipartUploadPartListParts.getPartInfoList().get(0)
             .getPartName());
-    Assert.assertEquals(partsMap.get(ozoneMultipartUploadPartListParts
+    assertEquals(partsMap.get(ozoneMultipartUploadPartListParts
             .getPartInfoList().get(1).getPartNumber()),
         ozoneMultipartUploadPartListParts.getPartInfoList().get(1)
             .getPartName());
 
     // Get remaining
-    Assert.assertTrue(ozoneMultipartUploadPartListParts.isTruncated());
+    assertTrue(ozoneMultipartUploadPartListParts.isTruncated());
     ozoneMultipartUploadPartListParts = bucket.listParts(keyName, uploadID,
         ozoneMultipartUploadPartListParts.getNextPartNumberMarker(), 2);
 
-    Assert.assertEquals(1,
+    assertEquals(1,
         ozoneMultipartUploadPartListParts.getPartInfoList().size());
-    Assert.assertEquals(partsMap.get(ozoneMultipartUploadPartListParts
+    assertEquals(partsMap.get(ozoneMultipartUploadPartListParts
             .getPartInfoList().get(0).getPartNumber()),
         ozoneMultipartUploadPartListParts.getPartInfoList().get(0)
             .getPartName());
 
 
     // As we don't have any parts for this, we should get false here
-    Assert.assertFalse(ozoneMultipartUploadPartListParts.isTruncated());
+    assertFalse(ozoneMultipartUploadPartListParts.isTruncated());
 
   }
 
@@ -3293,12 +3299,12 @@ public abstract class TestOzoneRpcClientAbstract {
 
     // Should return empty
 
-    Assert.assertEquals(0,
+    assertEquals(0,
         ozoneMultipartUploadPartListParts.getPartInfoList().size());
 
     // As we don't have any parts with greater than partNumberMarker and list
     // is not truncated, so it should return false here.
-    Assert.assertFalse(ozoneMultipartUploadPartListParts.isTruncated());
+    assertFalse(ozoneMultipartUploadPartListParts.isTruncated());
 
   }
 
@@ -3342,7 +3348,7 @@ public abstract class TestOzoneRpcClientAbstract {
     OzoneVolume volume = store.getVolume(volumeName);
     volume.createBucket(bucketName);
     OzoneBucket bucket = volume.getBucket(bucketName);
-    assertNotNull("Bucket creation failed", bucket);
+    assertNotNull(bucket, "Bucket creation failed");
 
     OzoneObj ozObj = new OzoneObjInfo.Builder()
         .setVolumeName(volumeName)
@@ -3377,34 +3383,34 @@ public abstract class TestOzoneRpcClientAbstract {
       }
     }
     List<OzoneAcl> acls = store.getAcl(parentObj);
-    assertTrue("Current acls: " + StringUtils.join(",", acls) +
-            " inheritedUserAcl: " + inheritedUserAcl,
-        acls.contains(defaultUserAcl));
-    assertTrue("Current acls: " + StringUtils.join(",", acls) +
-            " inheritedGroupAcl: " + inheritedGroupAcl,
-        acls.contains(defaultGroupAcl));
+    assertTrue(acls.contains(defaultUserAcl),
+        "Current acls: " + StringUtils.join(",", acls) +
+            " inheritedUserAcl: " + inheritedUserAcl);
+    assertTrue(acls.contains(defaultGroupAcl),
+        "Current acls: " + StringUtils.join(",", acls) +
+            " inheritedGroupAcl: " + inheritedGroupAcl);
 
     acls = store.getAcl(childObj);
-    assertTrue("Current acls:" + StringUtils.join(",", acls) +
-            " inheritedUserAcl:" + inheritedUserAcl,
-        acls.contains(inheritedUserAcl));
-    assertTrue("Current acls:" + StringUtils.join(",", acls) +
-            " inheritedGroupAcl:" + inheritedGroupAcl,
-        acls.contains(inheritedGroupAcl));
+    assertTrue(acls.contains(inheritedUserAcl),
+        "Current acls:" + StringUtils.join(",", acls) +
+            " inheritedUserAcl:" + inheritedUserAcl);
+    assertTrue(acls.contains(inheritedGroupAcl),
+        "Current acls:" + StringUtils.join(",", acls) +
+            " inheritedGroupAcl:" + inheritedGroupAcl);
   }
 
   @Test
   public void testNativeAclsForKey() throws Exception {
     String volumeName = UUID.randomUUID().toString();
     String bucketName = UUID.randomUUID().toString();
-    String key1 = "dir1/dir2" + UUID.randomUUID().toString();
-    String key2 = "dir1/dir2" + UUID.randomUUID().toString();
+    String key1 = "dir1/dir2" + UUID.randomUUID();
+    String key2 = "dir1/dir2" + UUID.randomUUID();
 
     store.createVolume(volumeName);
     OzoneVolume volume = store.getVolume(volumeName);
     volume.createBucket(bucketName);
     OzoneBucket bucket = volume.getBucket(bucketName);
-    assertNotNull("Bucket creation failed", bucket);
+    assertNotNull(bucket, "Bucket creation failed");
 
     writeKey(key1, bucket);
     writeKey(key2, bucket);
@@ -3444,10 +3450,10 @@ public abstract class TestOzoneRpcClientAbstract {
     // Prefix should inherit DEFAULT acl from bucket.
 
     List<OzoneAcl> acls = store.getAcl(prefixObj);
-    assertTrue("Current acls:" + StringUtils.join(",", acls),
-        acls.contains(inheritedUserAcl));
-    assertTrue("Current acls:" + StringUtils.join(",", acls),
-        acls.contains(inheritedGroupAcl));
+    assertTrue(acls.contains(inheritedUserAcl),
+        "Current acls:" + StringUtils.join(",", acls));
+    assertTrue(acls.contains(inheritedGroupAcl),
+        "Current acls:" + StringUtils.join(",", acls));
     // Remove inherited acls from prefix.
     assertTrue(store.removeAcl(prefixObj, inheritedUserAcl));
     assertTrue(store.removeAcl(prefixObj, inheritedGroupAcl));
@@ -3470,7 +3476,7 @@ public abstract class TestOzoneRpcClientAbstract {
     OzoneVolume volume = store.getVolume(volumeName);
     volume.createBucket(bucketName);
     OzoneBucket bucket = volume.getBucket(bucketName);
-    assertNotNull("Bucket creation failed", bucket);
+    assertNotNull(bucket, "Bucket creation failed");
 
     writeKey(key1, bucket);
     writeKey(key2, bucket);
@@ -3500,13 +3506,13 @@ public abstract class TestOzoneRpcClientAbstract {
 
     // get acl
     List<OzoneAcl> aclsGet = store.getAcl(prefixObj);
-    Assert.assertEquals(1, aclsGet.size());
-    Assert.assertEquals(user1Acl, aclsGet.get(0));
+    assertEquals(1, aclsGet.size());
+    assertEquals(user1Acl, aclsGet.get(0));
 
     // remove acl
-    Assert.assertTrue(store.removeAcl(prefixObj, user1Acl));
+    assertTrue(store.removeAcl(prefixObj, user1Acl));
     aclsGet = store.getAcl(prefixObj);
-    Assert.assertEquals(0, aclsGet.size());
+    assertEquals(0, aclsGet.size());
 
     // set acl
     BitSet aclRights2 = new BitSet();
@@ -3516,11 +3522,11 @@ public abstract class TestOzoneRpcClientAbstract {
     List<OzoneAcl> acls = new ArrayList<>();
     acls.add(user1Acl);
     acls.add(group1Acl);
-    Assert.assertTrue(store.setAcl(prefixObj, acls));
+    assertTrue(store.setAcl(prefixObj, acls));
 
     // get acl
     aclsGet = store.getAcl(prefixObj);
-    Assert.assertEquals(2, aclsGet.size());
+    assertEquals(2, aclsGet.size());
 
     OzoneObj keyObj = new OzoneObjInfo.Builder()
         .setVolumeName(volumeName)
@@ -3582,10 +3588,9 @@ public abstract class TestOzoneRpcClientAbstract {
           .filter(acl -> acl.getName().equals(newAcl.getName())
               && acl.getType().equals(newAcl.getType()))
           .findFirst();
-      assertTrue("New acl expected but not found.", readAcl.isPresent());
-      assertTrue("READ_ACL should exist in current acls:"
-          + readAcl.get(),
-          readAcl.get().getAclList().contains(ACLType.READ_ACL));
+      assertTrue(readAcl.isPresent(), "New acl expected but not found.");
+      assertTrue(readAcl.get().getAclList().contains(ACLType.READ_ACL),
+          "READ_ACL should exist in current acls:" + readAcl.get());
 
 
       // Case:2 Remove newly added acl permission.
@@ -3596,10 +3601,9 @@ public abstract class TestOzoneRpcClientAbstract {
           .filter(acl -> acl.getName().equals(newAcl.getName())
               && acl.getType().equals(newAcl.getType()))
           .findFirst();
-      assertTrue("New acl expected but not found.", nonReadAcl.isPresent());
-      assertFalse("READ_ACL should not exist in current acls:"
-              + nonReadAcl.get(),
-          nonReadAcl.get().getAclList().contains(ACLType.READ_ACL));
+      assertTrue(nonReadAcl.isPresent(), "New acl expected but not found.");
+      assertFalse(nonReadAcl.get().getAclList().contains(ACLType.READ_ACL),
+          "READ_ACL should not exist in current acls:" + nonReadAcl.get());
     } else {
       fail("Default acl should not be empty.");
     }
@@ -3700,7 +3704,7 @@ public abstract class TestOzoneRpcClientAbstract {
     sb.append(part1);
     sb.append(part2);
     sb.append(part3);
-    Assertions.assertEquals(sb.toString(), new String(fileContent, UTF_8));
+    assertEquals(sb.toString(), new String(fileContent, UTF_8));
 
     OmKeyArgs keyArgs = new OmKeyArgs.Builder()
         .setVolumeName(bucket.getVolumeName())
@@ -3712,11 +3716,11 @@ public abstract class TestOzoneRpcClientAbstract {
 
     OmKeyLocationInfoGroup latestVersionLocations =
         omKeyInfo.getLatestVersionLocations();
-    Assertions.assertNotNull(latestVersionLocations);
-    Assertions.assertTrue(latestVersionLocations.isMultipartKey());
+    assertNotNull(latestVersionLocations);
+    assertTrue(latestVersionLocations.isMultipartKey());
     latestVersionLocations.getBlocksLatestVersionOnly()
         .forEach(omKeyLocationInfo ->
-            Assertions.assertTrue(omKeyLocationInfo.getPartNumber() != -1));
+            assertTrue(omKeyLocationInfo.getPartNumber() != -1));
   }
 
   private String initiateMultipartUpload(OzoneBucket bucket, String keyName,
@@ -3725,7 +3729,7 @@ public abstract class TestOzoneRpcClientAbstract {
         replicationConfig);
 
     String uploadID = multipartInfo.getUploadID();
-    Assert.assertNotNull(uploadID);
+    assertNotNull(uploadID);
     return uploadID;
   }
 
@@ -3740,8 +3744,8 @@ public abstract class TestOzoneRpcClientAbstract {
     OmMultipartCommitUploadPartInfo omMultipartCommitUploadPartInfo =
         ozoneOutputStream.getCommitUploadPartInfo();
 
-    Assert.assertNotNull(omMultipartCommitUploadPartInfo);
-    Assert.assertNotNull(omMultipartCommitUploadPartInfo.getPartName());
+    assertNotNull(omMultipartCommitUploadPartInfo);
+    assertNotNull(omMultipartCommitUploadPartInfo.getPartName());
     return omMultipartCommitUploadPartInfo.getPartName();
 
   }
@@ -3751,13 +3755,13 @@ public abstract class TestOzoneRpcClientAbstract {
     OmMultipartUploadCompleteInfo omMultipartUploadCompleteInfo = bucket
         .completeMultipartUpload(keyName, uploadID, partsMap);
 
-    Assert.assertNotNull(omMultipartUploadCompleteInfo);
-    Assert.assertEquals(omMultipartUploadCompleteInfo.getBucket(), bucket
+    assertNotNull(omMultipartUploadCompleteInfo);
+    assertEquals(omMultipartUploadCompleteInfo.getBucket(), bucket
         .getName());
-    Assert.assertEquals(omMultipartUploadCompleteInfo.getVolume(), bucket
+    assertEquals(omMultipartUploadCompleteInfo.getVolume(), bucket
         .getVolumeName());
-    Assert.assertEquals(omMultipartUploadCompleteInfo.getKey(), keyName);
-    Assert.assertNotNull(omMultipartUploadCompleteInfo.getHash());
+    assertEquals(omMultipartUploadCompleteInfo.getKey(), keyName);
+    assertNotNull(omMultipartUploadCompleteInfo.getHash());
   }
 
   private void createTestKey(OzoneBucket bucket, String keyName,
@@ -3768,7 +3772,7 @@ public abstract class TestOzoneRpcClientAbstract {
     out.write(keyValue.getBytes(UTF_8));
     out.close();
     OzoneKey key = bucket.getKey(keyName);
-    Assert.assertEquals(keyName, key.getName());
+    assertEquals(keyName, key.getName());
   }
 
   private void assertKeyRenamedEx(OzoneBucket bucket, String keyName)
@@ -3779,7 +3783,7 @@ public abstract class TestOzoneRpcClientAbstract {
     } catch (OMException e) {
       oe = e;
     }
-    Assert.assertEquals(KEY_NOT_FOUND, oe.getResult());
+    assertEquals(KEY_NOT_FOUND, oe.getResult());
   }
 
   /**
@@ -3815,9 +3819,9 @@ public abstract class TestOzoneRpcClientAbstract {
         .addMetadata(OzoneConsts.GDPR_FLAG, "true").build();
     volume.createBucket(bucketName, args);
     OzoneBucket bucket = volume.getBucket(bucketName);
-    Assert.assertEquals(bucketName, bucket.getName());
-    Assert.assertNotNull(bucket.getMetadata());
-    Assert.assertEquals("true",
+    assertEquals(bucketName, bucket.getName());
+    assertNotNull(bucket.getMetadata());
+    assertEquals("true",
         bucket.getMetadata().get(OzoneConsts.GDPR_FLAG));
 
     //Step 2
@@ -3828,16 +3832,16 @@ public abstract class TestOzoneRpcClientAbstract {
         text.getBytes(UTF_8).length, RATIS, ONE, keyMetadata);
     out.write(text.getBytes(UTF_8));
     out.close();
-    Assert.assertNull(keyMetadata.get(OzoneConsts.GDPR_SECRET));
+    assertNull(keyMetadata.get(OzoneConsts.GDPR_SECRET));
 
     //Step 3
     OzoneKeyDetails key = bucket.getKey(keyName);
 
-    Assert.assertEquals(keyName, key.getName());
-    Assert.assertEquals("true", key.getMetadata().get(OzoneConsts.GDPR_FLAG));
-    Assert.assertEquals("AES",
+    assertEquals(keyName, key.getName());
+    assertEquals("true", key.getMetadata().get(OzoneConsts.GDPR_FLAG));
+    assertEquals("AES",
         key.getMetadata().get(OzoneConsts.GDPR_ALGORITHM));
-    Assert.assertNotNull(key.getMetadata().get(OzoneConsts.GDPR_SECRET));
+    assertNotNull(key.getMetadata().get(OzoneConsts.GDPR_SECRET));
 
     try (OzoneInputStream is = bucket.readKey(keyName)) {
       assertInputStreamContent(text, is);
@@ -3858,15 +3862,15 @@ public abstract class TestOzoneRpcClientAbstract {
 
     //Step 5
     key = bucket.getKey(keyName);
-    Assert.assertEquals(keyName, key.getName());
-    Assert.assertNull(key.getMetadata().get(OzoneConsts.GDPR_FLAG));
+    assertEquals(keyName, key.getName());
+    assertNull(key.getMetadata().get(OzoneConsts.GDPR_FLAG));
 
     try (OzoneInputStream is = bucket.readKey(keyName)) {
       byte[] fileContent = new byte[text.getBytes(UTF_8).length];
       is.read(fileContent);
 
       //Step 6
-      Assert.assertNotEquals(text, new String(fileContent, UTF_8));
+      assertNotEquals(text, new String(fileContent, UTF_8));
     }
   }
 
@@ -3895,9 +3899,9 @@ public abstract class TestOzoneRpcClientAbstract {
         .addMetadata(OzoneConsts.GDPR_FLAG, "true").build();
     volume.createBucket(bucketName, args);
     OzoneBucket bucket = volume.getBucket(bucketName);
-    Assert.assertEquals(bucketName, bucket.getName());
-    Assert.assertNotNull(bucket.getMetadata());
-    Assert.assertEquals("true",
+    assertEquals(bucketName, bucket.getName());
+    assertNotNull(bucket.getMetadata());
+    assertEquals("true",
         bucket.getMetadata().get(OzoneConsts.GDPR_FLAG));
 
     //Step 2
@@ -3912,11 +3916,11 @@ public abstract class TestOzoneRpcClientAbstract {
     //Step 3
     OzoneKeyDetails key = bucket.getKey(keyName);
 
-    Assert.assertEquals(keyName, key.getName());
-    Assert.assertEquals("true", key.getMetadata().get(OzoneConsts.GDPR_FLAG));
-    Assert.assertEquals("AES",
+    assertEquals(keyName, key.getName());
+    assertEquals("true", key.getMetadata().get(OzoneConsts.GDPR_FLAG));
+    assertEquals("AES",
         key.getMetadata().get(OzoneConsts.GDPR_ALGORITHM));
-    Assert.assertTrue(key.getMetadata().get(OzoneConsts.GDPR_SECRET) != null);
+    assertTrue(key.getMetadata().get(OzoneConsts.GDPR_SECRET) != null);
 
     try (OzoneInputStream is = bucket.readKey(keyName)) {
       assertInputStreamContent(text, is);
@@ -3936,10 +3940,10 @@ public abstract class TestOzoneRpcClientAbstract {
     if (deletedKeys != null) {
       Map<String, String> deletedKeyMetadata =
           deletedKeys.getOmKeyInfoList().get(0).getMetadata();
-      Assert.assertFalse(deletedKeyMetadata.containsKey(OzoneConsts.GDPR_FLAG));
-      Assert.assertFalse(
+      assertFalse(deletedKeyMetadata.containsKey(OzoneConsts.GDPR_FLAG));
+      assertFalse(
           deletedKeyMetadata.containsKey(OzoneConsts.GDPR_SECRET));
-      Assert.assertFalse(
+      assertFalse(
           deletedKeyMetadata.containsKey(OzoneConsts.GDPR_ALGORITHM));
     }
   }
@@ -3957,11 +3961,11 @@ public abstract class TestOzoneRpcClientAbstract {
 
     boolean result = store.addAcl(s3vVolume, ozoneAcl);
 
-    Assert.assertTrue("SetAcl on default s3v failed", result);
+    assertTrue(result, "SetAcl on default s3v failed");
 
     List<OzoneAcl> ozoneAclList = store.getAcl(s3vVolume);
 
-    Assert.assertTrue(ozoneAclList.contains(ozoneAcl));
+    assertTrue(ozoneAclList.contains(ozoneAcl));
   }
 
   @Test
@@ -3987,19 +3991,19 @@ public abstract class TestOzoneRpcClientAbstract {
     out.close();
 
     OzoneKey key = bucket.headObject(keyName);
-    Assert.assertEquals(volumeName, key.getVolumeName());
-    Assert.assertEquals(bucketName, key.getBucketName());
-    Assert.assertEquals(keyName, key.getName());
-    Assert.assertEquals(replicationConfig.getReplicationType(),
+    assertEquals(volumeName, key.getVolumeName());
+    assertEquals(bucketName, key.getBucketName());
+    assertEquals(keyName, key.getName());
+    assertEquals(replicationConfig.getReplicationType(),
         key.getReplicationConfig().getReplicationType());
-    Assert.assertEquals(replicationConfig.getRequiredNodes(),
+    assertEquals(replicationConfig.getRequiredNodes(),
         key.getReplicationConfig().getRequiredNodes());
-    Assert.assertEquals(value.getBytes(UTF_8).length, key.getDataSize());
+    assertEquals(value.getBytes(UTF_8).length, key.getDataSize());
 
     try {
       bucket.headObject(UUID.randomUUID().toString());
     } catch (OMException ex) {
-      Assert.assertEquals(ResultCodes.KEY_NOT_FOUND, ex.getResult());
+      assertEquals(ResultCodes.KEY_NOT_FOUND, ex.getResult());
     }
 
   }
@@ -4045,8 +4049,8 @@ public abstract class TestOzoneRpcClientAbstract {
             cluster.getOzoneManager().getMetadataManager()
                 .getOzoneKey(volumeName, bucketName, keyName));
 
-    Assert.assertNotNull(omKeyInfo);
-    Assert.assertEquals(expectedCount,
+    assertNotNull(omKeyInfo);
+    assertEquals(expectedCount,
         omKeyInfo.getKeyLocationVersions().size());
 
     // ensure flush double buffer for deleted Table
@@ -4060,8 +4064,8 @@ public abstract class TestOzoneRpcClientAbstract {
               cluster.getOzoneManager().getMetadataManager()
               .getOzoneKey(volumeName, bucketName, keyName));
 
-      Assert.assertTrue(rangeKVs.size() > 0);
-      Assert.assertEquals(expectedCount,
+      assertTrue(rangeKVs.size() > 0);
+      assertEquals(expectedCount,
           rangeKVs.get(0).getValue().getOmKeyInfoList().size());
     } else {
       // If expectedCount is greater than 1 means versioning enabled,
@@ -4071,7 +4075,7 @@ public abstract class TestOzoneRpcClientAbstract {
           .getDeletedTable().get(cluster.getOzoneManager().getMetadataManager()
               .getOzoneKey(volumeName, bucketName, keyName));
 
-      Assert.assertNull(repeatedOmKeyInfo);
+      assertNull(repeatedOmKeyInfo);
     }
   }
 
@@ -4104,7 +4108,7 @@ public abstract class TestOzoneRpcClientAbstract {
     OzoneVolume volume = store.getVolume(volumeName);
     OzoneBucket bucket = getBucket(volume);
     ReplicationConfig currentReplicationConfig = bucket.getReplicationConfig();
-    Assert.assertEquals(
+    assertEquals(
         StandaloneReplicationConfig.getInstance(
             HddsProtos.ReplicationFactor.ONE),
         currentReplicationConfig);
@@ -4115,7 +4119,7 @@ public abstract class TestOzoneRpcClientAbstract {
     // Get the bucket and check the updated config.
     bucket = volume.getBucket(bucket.getName());
 
-    Assert.assertEquals(ecReplicationConfig, bucket.getReplicationConfig());
+    assertEquals(ecReplicationConfig, bucket.getReplicationConfig());
 
     RatisReplicationConfig ratisReplicationConfig =
         RatisReplicationConfig.getInstance(HddsProtos.ReplicationFactor.THREE);
@@ -4124,7 +4128,7 @@ public abstract class TestOzoneRpcClientAbstract {
     // Get the bucket and check the updated config.
     bucket = volume.getBucket(bucket.getName());
 
-    Assert.assertEquals(ratisReplicationConfig, bucket.getReplicationConfig());
+    assertEquals(ratisReplicationConfig, bucket.getReplicationConfig());
 
     //Reset replication config back.
     bucket.setReplicationConfig(currentReplicationConfig);
@@ -4154,11 +4158,11 @@ public abstract class TestOzoneRpcClientAbstract {
         volume.listBuckets(bucketPrefix, preBucket, hasSnapshot);
     int bucketCount = 0;
     while (bucketIterator.hasNext()) {
-      Assert.assertTrue(
+      assertTrue(
           bucketIterator.next().getName().startsWith(bucketPrefix));
       bucketCount++;
     }
-    Assert.assertEquals(expectedBucketCount, bucketCount);
+    assertEquals(expectedBucketCount, bucketCount);
   }
 
   @Test
@@ -4205,7 +4209,7 @@ public abstract class TestOzoneRpcClientAbstract {
       OzoneSnapshot snapshot = snapshotIter.next();
       volABucketASnapshotCount++;
     }
-    Assert.assertEquals(20, volABucketASnapshotCount);
+    assertEquals(20, volABucketASnapshotCount);
 
     snapshotIter = store.listSnapshot(volumeA, bucketB, null, null);
     int volABucketBSnapshotCount = 0;
@@ -4213,7 +4217,7 @@ public abstract class TestOzoneRpcClientAbstract {
       OzoneSnapshot snapshot = snapshotIter.next();
       volABucketBSnapshotCount++;
     }
-    Assert.assertEquals(20, volABucketASnapshotCount);
+    assertEquals(20, volABucketASnapshotCount);
 
     snapshotIter = store.listSnapshot(volumeB, bucketA, null, null);
     int volBBucketASnapshotCount = 0;
@@ -4221,7 +4225,7 @@ public abstract class TestOzoneRpcClientAbstract {
       OzoneSnapshot snapshot = snapshotIter.next();
       volBBucketASnapshotCount++;
     }
-    Assert.assertEquals(20, volABucketASnapshotCount);
+    assertEquals(20, volABucketASnapshotCount);
 
     snapshotIter = store.listSnapshot(volumeB, bucketB, null, null);
     int volBBucketBSnapshotCount = 0;
@@ -4229,17 +4233,17 @@ public abstract class TestOzoneRpcClientAbstract {
       OzoneSnapshot snapshot = snapshotIter.next();
       volBBucketBSnapshotCount++;
     }
-    Assert.assertEquals(20, volABucketASnapshotCount);
+    assertEquals(20, volABucketASnapshotCount);
 
     int volABucketASnapshotACount = 0;
     snapshotIter = store.listSnapshot(volumeA, bucketA, snapshotPrefixA, null);
     while (snapshotIter.hasNext()) {
       OzoneSnapshot snapshot = snapshotIter.next();
-      Assert.assertTrue(snapshot.getName().startsWith(snapshotPrefixA));
+      assertTrue(snapshot.getName().startsWith(snapshotPrefixA));
       volABucketASnapshotACount++;
     }
-    Assert.assertEquals(10, volABucketASnapshotACount);
-    Assert.assertFalse(snapshotIter.hasNext());
+    assertEquals(10, volABucketASnapshotACount);
+    assertFalse(snapshotIter.hasNext());
 
   }
 }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestSecureOzoneRpcClient.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestSecureOzoneRpcClient.java
@@ -64,9 +64,7 @@ import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.Status;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.VolumeInfo;
 import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.ozone.test.GenericTestUtils;
-import org.apache.ozone.test.LambdaTestUtils;
 import org.junit.jupiter.api.AfterAll;
-import org.junit.Assert;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
@@ -79,6 +77,12 @@ import java.util.UUID;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.apache.hadoop.hdds.HddsConfigKeys.OZONE_METADATA_DIRS;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * This class is to test all the public facing APIs of Ozone Client.
@@ -184,11 +188,11 @@ public class TestSecureOzoneRpcClient extends TestOzoneRpcClient {
         out.write(value.getBytes(UTF_8));
       }
 
-      Assert.assertEquals(committedBytes + value.getBytes(UTF_8).length,
-              ozoneManager.getMetrics().getDataCommittedBytes());
+      assertEquals(committedBytes + value.getBytes(UTF_8).length,
+          ozoneManager.getMetrics().getDataCommittedBytes());
 
       OzoneKey key = bucket.getKey(keyName);
-      Assert.assertEquals(keyName, key.getName());
+      assertEquals(keyName, key.getName());
       byte[] fileContent;
       try (OzoneInputStream is = bucket.readKey(keyName)) {
         fileContent = new byte[value.getBytes(UTF_8).length];
@@ -219,12 +223,12 @@ public class TestSecureOzoneRpcClient extends TestOzoneRpcClient {
       }
 
 
-      Assert.assertTrue(verifyRatisReplication(volumeName, bucketName,
+      assertTrue(verifyRatisReplication(volumeName, bucketName,
           keyName, ReplicationType.RATIS,
           ReplicationFactor.ONE));
-      Assert.assertEquals(value, new String(fileContent, UTF_8));
-      Assert.assertFalse(key.getCreationTime().isBefore(testStartTime));
-      Assert.assertFalse(key.getModificationTime().isBefore(testStartTime));
+      assertEquals(value, new String(fileContent, UTF_8));
+      assertFalse(key.getCreationTime().isBefore(testStartTime));
+      assertFalse(key.getModificationTime().isBefore(testStartTime));
     }
   }
 
@@ -233,7 +237,7 @@ public class TestSecureOzoneRpcClient extends TestOzoneRpcClient {
         .forEach(
             keyLocationInfoGroup -> keyLocationInfoGroup.getLocationList()
                 .forEach(
-                    keyLocationInfo -> Assert.assertNull(keyLocationInfo
+                    keyLocationInfo -> assertNull(keyLocationInfo
                         .getToken())));
   }
 
@@ -260,16 +264,19 @@ public class TestSecureOzoneRpcClient extends TestOzoneRpcClient {
       try (OzoneOutputStream out = bucket.createKey(keyName,
           value.getBytes(UTF_8).length, ReplicationType.RATIS,
           ReplicationFactor.ONE, new HashMap<>())) {
-        LambdaTestUtils.intercept(IOException.class, "UNAUTHENTICATED: Fail " +
-                "to find any token ",
+        IOException ioException = assertThrows(IOException.class,
             () -> out.write(value.getBytes(UTF_8)));
+        assertTrue(ioException.getMessage()
+            .contains("UNAUTHENTICATED: Fail to find any token "));
       }
 
       OzoneKey key = bucket.getKey(keyName);
-      Assert.assertEquals(keyName, key.getName());
-      LambdaTestUtils.intercept(IOException.class, "Failed to authenticate" +
-              " with GRPC XceiverServer with Ozone block token.",
+      assertEquals(keyName, key.getName());
+      IOException ioException = assertThrows(IOException.class,
           () -> bucket.readKey(keyName));
+      assertTrue(ioException.getMessage()
+          .contains("Failed to authenticate with GRPC XceiverServer with " +
+              "Ozone block token."));
     }
   }
 
@@ -319,7 +326,7 @@ public class TestSecureOzoneRpcClient extends TestOzoneRpcClient {
         .submitRequest(null, writeRequest);
 
     // Verify response.
-    Assert.assertTrue(omResponse.getStatus() == Status.OK);
+    assertEquals(Status.OK, omResponse.getStatus());
 
     // Read Request
     OMRequest readRequest = OMRequest.newBuilder()
@@ -337,13 +344,13 @@ public class TestSecureOzoneRpcClient extends TestOzoneRpcClient {
         .submitRequest(null, readRequest);
 
     // Verify response.
-    Assert.assertTrue(omResponse.getStatus() == Status.OK);
+    assertEquals(Status.OK, omResponse.getStatus());
 
     VolumeInfo volumeInfo = omResponse.getInfoVolumeResponse().getVolumeInfo();
-    Assert.assertNotNull(volumeInfo);
-    Assert.assertEquals(volumeName, volumeInfo.getVolume());
-    Assert.assertEquals(accessKey, volumeInfo.getAdminName());
-    Assert.assertEquals(accessKey, volumeInfo.getOwnerName());
+    assertNotNull(volumeInfo);
+    assertEquals(volumeName, volumeInfo.getVolume());
+    assertEquals(accessKey, volumeInfo.getAdminName());
+    assertEquals(accessKey, volumeInfo.getOwnerName());
 
     // Override secret to S3Secret store with some dummy value
     s3SecretManager
@@ -352,14 +359,12 @@ public class TestSecureOzoneRpcClient extends TestOzoneRpcClient {
     // Write request with invalid credentials.
     omResponse = cluster.getOzoneManager().getOmServerProtocol()
         .submitRequest(null, writeRequest);
-    Assert.assertTrue(omResponse.getStatus() == Status.INVALID_TOKEN);
+    assertEquals(Status.INVALID_TOKEN, omResponse.getStatus());
 
     // Read request with invalid credentials.
     omResponse = cluster.getOzoneManager().getOmServerProtocol()
         .submitRequest(null, readRequest);
-    Assert.assertTrue(omResponse.getStatus() == Status.INVALID_TOKEN);
-
-
+    assertEquals(Status.INVALID_TOKEN, omResponse.getStatus());
   }
 
   private boolean verifyRatisReplication(String volumeName, String bucketName,
@@ -411,5 +416,4 @@ public class TestSecureOzoneRpcClient extends TestOzoneRpcClient {
       cluster.shutdown();
     }
   }
-
 }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestKeyManagerImpl.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestKeyManagerImpl.java
@@ -95,7 +95,6 @@ import org.apache.hadoop.ozone.security.acl.OzoneObjInfo;
 import org.apache.hadoop.ozone.security.acl.RequestContext;
 import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.ozone.test.GenericTestUtils;
-import org.apache.ozone.test.LambdaTestUtils;
 import org.apache.hadoop.util.Time;
 
 import com.google.common.collect.Sets;
@@ -313,11 +312,11 @@ public class TestKeyManagerImpl {
     metadataManager.getOpenKeyTable(getDefaultBucketLayout()).put(
         metadataManager.getOpenKey(VOLUME_NAME, BUCKET_NAME, KEY_NAME, 1L),
         omKeyInfo);
-    LambdaTestUtils.intercept(OMException.class,
-        "SafeModePrecheck failed for allocateBlock", () -> {
-          writeClient
-              .allocateBlock(keyArgs, 1L, new ExcludeList());
-        });
+    OMException omException = assertThrows(OMException.class,
+         () ->
+             writeClient.allocateBlock(keyArgs, 1L, new ExcludeList()));
+    assertTrue(omException.getMessage()
+        .contains("SafeModePrecheck failed for allocateBlock"));
   }
 
   @Test
@@ -331,10 +330,10 @@ public class TestKeyManagerImpl {
         .setAcls(OzoneAclUtil.getAclList(ugi.getUserName(), ugi.getGroupNames(),
             ALL, ALL))
         .build();
-    LambdaTestUtils.intercept(OMException.class,
-        "SafeModePrecheck failed for allocateBlock", () -> {
-          writeClient.openKey(keyArgs);
-        });
+    OMException omException = assertThrows(OMException.class,
+        () -> writeClient.openKey(keyArgs));
+    assertTrue(omException.getMessage()
+        .contains("SafeModePrecheck failed for allocateBlock"));
   }
 
   @Test

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOmSnapshotDisabled.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOmSnapshotDisabled.java
@@ -28,8 +28,8 @@ import org.apache.hadoop.ozone.client.OzoneClient;
 import org.apache.hadoop.ozone.client.OzoneVolume;
 import org.apache.hadoop.ozone.om.exceptions.OMException;
 import org.apache.hadoop.ozone.om.helpers.BucketLayout;
-import org.apache.ozone.test.LambdaTestUtils;
 import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
@@ -37,6 +37,7 @@ import org.junit.jupiter.api.Timeout;
 import java.util.UUID;
 
 import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_DB_PROFILE;
+import static org.apache.hadoop.ozone.om.exceptions.OMException.ResultCodes.FEATURE_NOT_ENABLED;
 
 /**
  * Integration test to verify Ozone snapshot RPCs throw exception when called.
@@ -94,10 +95,12 @@ public class TestOmSnapshotDisabled {
     volume.createBucket(bucketName);
 
     // create snapshot should throw
-    LambdaTestUtils.intercept(OMException.class, "FEATURE_NOT_ENABLED",
+    OMException omException = Assertions.assertThrows(OMException.class,
         () -> store.createSnapshot(volumeName, bucketName, snapshotName));
+    Assertions.assertEquals(FEATURE_NOT_ENABLED, omException.getResult());
     // delete snapshot should throw
-    LambdaTestUtils.intercept(OMException.class, "FEATURE_NOT_ENABLED",
+    omException = Assertions.assertThrows(OMException.class,
         () -> store.deleteSnapshot(volumeName, bucketName, snapshotName));
+    Assertions.assertEquals(FEATURE_NOT_ENABLED, omException.getResult());
   }
 }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOmSnapshotDisabledRestart.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOmSnapshotDisabledRestart.java
@@ -25,7 +25,6 @@ import org.apache.hadoop.ozone.MiniOzoneHAClusterImpl;
 import org.apache.hadoop.ozone.client.ObjectStore;
 import org.apache.hadoop.ozone.client.OzoneClient;
 import org.apache.hadoop.ozone.client.OzoneVolume;
-import org.apache.ozone.test.LambdaTestUtils;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
@@ -101,8 +100,9 @@ public class TestOmSnapshotDisabledRestart {
         om.getConfiguration().setBoolean(
             OMConfigKeys.OZONE_FILESYSTEM_SNAPSHOT_ENABLED_KEY, false);
         // Restart OM, expect OM start up failure
-        LambdaTestUtils.intercept(RuntimeException.class, "snapshots remaining",
+        RuntimeException rte = Assertions.assertThrows(RuntimeException.class,
             () -> cluster.restartOzoneManager(om, true));
+        Assertions.assertTrue(rte.getMessage().contains("snapshots remaining"));
         // Enable snapshot feature again
         om.getConfiguration().setBoolean(
             OMConfigKeys.OZONE_FILESYSTEM_SNAPSHOT_ENABLED_KEY, true);

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOmSnapshotFileSystem.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOmSnapshotFileSystem.java
@@ -45,7 +45,6 @@ import org.apache.hadoop.ozone.om.helpers.OpenKeySession;
 import org.apache.hadoop.ozone.om.helpers.SnapshotInfo;
 import org.apache.hadoop.ozone.om.protocol.OzoneManagerProtocol;
 import org.apache.ozone.test.GenericTestUtils;
-import org.apache.ozone.test.LambdaTestUtils;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Rule;
@@ -84,6 +83,7 @@ import static org.apache.hadoop.ozone.OzoneConsts.OZONE_URI_SCHEME;
 import static org.apache.hadoop.ozone.om.OmSnapshotManager.getSnapshotPath;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 
 /**
@@ -193,9 +193,9 @@ public class TestOmSnapshotFileSystem {
   // based on TestObjectStoreWithFSO:testListKeysAtDifferentLevels
   public void testListKeysAtDifferentLevels() throws Exception {
     OzoneVolume ozoneVolume = objectStore.getVolume(volumeName);
-    Assert.assertTrue(ozoneVolume.getName().equals(volumeName));
+    assertEquals(ozoneVolume.getName(), volumeName);
     OzoneBucket ozoneBucket = ozoneVolume.getBucket(bucketName);
-    Assert.assertTrue(ozoneBucket.getName().equals(bucketName));
+    assertEquals(ozoneBucket.getName(), bucketName);
 
     String keyc1 = "/a/b1/c1/c1.tx";
     String keyc2 = "/a/b1/c2/c2.tx";
@@ -352,7 +352,7 @@ public class TestOmSnapshotFileSystem {
 
     // Read using filesystem.
     String rootPath = String.format("%s://%s.%s/", OZONE_URI_SCHEME,
-            bucketName, volumeName, StandardCharsets.UTF_8);
+            bucketName, volumeName);
     OzoneFileSystem o3fsNew = (OzoneFileSystem) FileSystem
         .get(new URI(rootPath), conf);
     FSDataInputStream fsDataInputStream = o3fsNew.open(new Path(key));
@@ -410,19 +410,31 @@ public class TestOmSnapshotFileSystem {
 
     // Can't access keys in snapshot anymore with FS API. Should throw exception
     final String errorMsg1 = "no longer active";
-    LambdaTestUtils.intercept(FileNotFoundException.class, errorMsg1,
-        () -> o3fs.listStatus(snapshotRoot));
-    LambdaTestUtils.intercept(FileNotFoundException.class, errorMsg1,
-        () -> o3fs.listStatus(snapshotParent));
+    FileNotFoundException exception = assertThrows(
+        FileNotFoundException.class,
+        () -> o3fs.listStatus(snapshotRoot)
+    );
+    assertTrue(exception.getMessage().contains(errorMsg1));
+    exception = assertThrows(
+        FileNotFoundException.class,
+        () -> o3fs.listStatus(snapshotParent)
+    );
+    assertTrue(exception.getMessage().contains(errorMsg1));
 
     // Note: Different error message due to inconsistent FNFE client-side
     //  handling in BasicOzoneClientAdapterImpl#getFileStatus
     // TODO: Reconciliation?
     final String errorMsg2 = "No such file or directory";
-    LambdaTestUtils.intercept(FileNotFoundException.class, errorMsg2,
-        () -> o3fs.getFileStatus(snapshotKey1));
-    LambdaTestUtils.intercept(FileNotFoundException.class, errorMsg2,
-        () -> o3fs.getFileStatus(snapshotKey2));
+    exception = assertThrows(
+        FileNotFoundException.class,
+        () -> o3fs.getFileStatus(snapshotKey1)
+    );
+    assertTrue(exception.getMessage().contains(errorMsg2));
+    exception = assertThrows(
+        FileNotFoundException.class,
+        () -> o3fs.getFileStatus(snapshotKey2)
+    );
+    assertTrue(exception.getMessage().contains(errorMsg2));
   }
 
   @Test

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestSecureOzoneManager.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestSecureOzoneManager.java
@@ -28,7 +28,6 @@ import org.apache.hadoop.hdds.security.x509.keys.KeyCodec;
 import org.apache.hadoop.ozone.MiniOzoneCluster;
 import org.apache.hadoop.ozone.security.OMCertificateClient;
 import org.apache.hadoop.security.ssl.KeyStoreTestUtil;
-import org.apache.ozone.test.LambdaTestUtils;
 import org.bouncycastle.cert.X509CertificateHolder;
 import org.junit.After;
 import org.junit.Assert;
@@ -224,9 +223,10 @@ public class TestSecureOzoneManager {
     omStorage.setClusterId(clusterId);
     omStorage.setOmId(omId);
     config.set(OZONE_OM_ADDRESS_KEY, "om-unknown");
-    LambdaTestUtils.intercept(RuntimeException.class, "Can't get SCM signed" +
-            " certificate",
+    RuntimeException rte = Assert.assertThrows(RuntimeException.class,
         () -> OzoneManager.initializeSecurity(config, omStorage, scmId));
+    Assert.assertEquals("Can't get SCM signed certificate. omRpcAdd:" +
+        " om-unknown:9862", rte.getMessage());
   }
 
 }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/multitenant/TestMultiTenantVolume.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/multitenant/TestMultiTenantVolume.java
@@ -37,7 +37,6 @@ import org.apache.hadoop.ozone.om.protocol.S3Auth;
 import org.apache.hadoop.ozone.om.upgrade.OMLayoutFeature;
 import org.apache.hadoop.ozone.upgrade.UpgradeFinalizer;
 import org.apache.ozone.test.GenericTestUtils;
-import org.apache.ozone.test.LambdaTestUtils;
 import org.apache.ozone.test.LambdaTestUtils.VoidCallable;
 import org.junit.AfterClass;
 import org.junit.Assert;
@@ -52,6 +51,7 @@ import static org.apache.hadoop.ozone.admin.scm.FinalizeUpgradeCommandUtil.isDon
 import static org.apache.hadoop.ozone.admin.scm.FinalizeUpgradeCommandUtil.isStarting;
 import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_MULTITENANCY_ENABLED;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Tests that S3 requests for a tenant are directed to that tenant's volume,
@@ -91,10 +91,10 @@ public class TestMultiTenantVolume {
     cluster.shutdown();
   }
 
-  private static void expectFailurePreFinalization(VoidCallable eval)
-      throws Exception {
-    LambdaTestUtils.intercept(OMException.class,
-        "cannot be invoked before finalization", eval);
+  private static void expectFailurePreFinalization(VoidCallable eval) {
+    OMException omException = assertThrows(OMException.class, eval::call);
+    assertTrue(omException.getMessage()
+        .contains("cannot be invoked before finalization"));
   }
 
   /**

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/recon/TestReconAsPassiveScm.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/recon/TestReconAsPassiveScm.java
@@ -53,6 +53,7 @@ import static org.apache.hadoop.ozone.container.ozoneimpl.TestOzoneContainer.run
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 
 /**
@@ -112,10 +113,12 @@ public class TestReconAsPassiveScm {
     });
 
     // Verify we can never create a pipeline in Recon.
-    LambdaTestUtils.intercept(UnsupportedOperationException.class,
-        "Trying to create pipeline in Recon, which is prohibited!",
+    UnsupportedOperationException exception = assertThrows(
+        UnsupportedOperationException.class,
         () -> reconPipelineManager
             .createPipeline(RatisReplicationConfig.getInstance(ONE)));
+    assertTrue(exception.getMessage()
+        .contains("Trying to create pipeline in Recon, which is prohibited!"));
 
     ContainerManager scmContainerManager = scm.getContainerManager();
     assertTrue(scmContainerManager.getContainers().isEmpty());

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/shell/TestOzoneShellHA.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/shell/TestOzoneShellHA.java
@@ -57,10 +57,8 @@ import org.apache.hadoop.ozone.om.OMConfigKeys;
 import org.apache.hadoop.ozone.om.OzoneManager;
 import org.apache.hadoop.ozone.om.exceptions.OMException;
 import org.apache.hadoop.ozone.om.helpers.BucketLayout;
-import org.apache.hadoop.ozone.shell.s3.S3Shell;
 import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.ozone.test.GenericTestUtils;
-import org.apache.ozone.test.LambdaTestUtils;
 import org.apache.hadoop.util.ToolRunner;
 import org.apache.hadoop.fs.TrashPolicy;
 import org.apache.hadoop.ozone.om.TrashPolicyOzone;
@@ -74,20 +72,25 @@ import static org.apache.hadoop.fs.CommonConfigurationKeysPublic.FS_TRASH_INTERV
 import static org.apache.hadoop.fs.FileSystem.FS_DEFAULT_NAME_KEY;
 import static org.apache.hadoop.fs.FileSystem.TRASH_PREFIX;
 import static org.apache.hadoop.ozone.OzoneConsts.OZONE_OFS_URI_SCHEME;
-import org.junit.After;
-import org.junit.AfterClass;
-import org.junit.Assert;
 
 import static org.apache.hadoop.ozone.OzoneConsts.OZONE_URI_DELIMITER;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.Timeout;
+import static org.apache.hadoop.ozone.om.exceptions.OMException.ResultCodes.BUCKET_NOT_EMPTY;
+import static org.apache.hadoop.ozone.om.exceptions.OMException.ResultCodes.BUCKET_NOT_FOUND;
+import static org.apache.hadoop.ozone.om.exceptions.OMException.ResultCodes.VOLUME_NOT_EMPTY;
+import static org.apache.hadoop.ozone.om.exceptions.OMException.ResultCodes.VOLUME_NOT_FOUND;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import picocli.CommandLine;
@@ -101,18 +104,13 @@ import picocli.CommandLine.RunLast;
  * This class tests Ozone sh shell command.
  * Inspired by TestS3Shell
  */
+@Timeout(300)
 public class TestOzoneShellHA {
 
   private static final Logger LOG =
       LoggerFactory.getLogger(TestOzoneShellHA.class);
 
   private static final String DEFAULT_ENCODING = UTF_8.name();
-
-  /**
-   * Set the timeout for every test.
-   */
-  @Rule
-  public Timeout testTimeout = Timeout.seconds(300);
 
   private static File baseDir;
   private static File testFile;
@@ -121,7 +119,6 @@ public class TestOzoneShellHA {
   private static OzoneClient client;
   private OzoneShell ozoneShell = null;
   private OzoneAdmin ozoneAdminShell = null;
-  private S3Shell s3Shell = null;
 
   private final ByteArrayOutputStream out = new ByteArrayOutputStream();
   private final ByteArrayOutputStream err = new ByteArrayOutputStream();
@@ -139,7 +136,7 @@ public class TestOzoneShellHA {
    *
    * @throws Exception
    */
-  @BeforeClass
+  @BeforeAll
   public static void init() throws Exception {
     OzoneConfiguration conf = new OzoneConfiguration();
     startCluster(conf);
@@ -176,7 +173,7 @@ public class TestOzoneShellHA {
   /**
    * shutdown MiniOzoneCluster.
    */
-  @AfterClass
+  @AfterAll
   public static void shutdown() {
     IOUtils.closeQuietly(client);
     if (cluster != null) {
@@ -188,16 +185,15 @@ public class TestOzoneShellHA {
     }
   }
 
-  @Before
+  @BeforeEach
   public void setup() throws UnsupportedEncodingException {
     ozoneShell = new OzoneShell();
     ozoneAdminShell = new OzoneAdmin();
-    s3Shell = new S3Shell();
     System.setOut(new PrintStream(out, false, DEFAULT_ENCODING));
     System.setErr(new PrintStream(err, false, DEFAULT_ENCODING));
   }
 
-  @After
+  @AfterEach
   public void reset() {
     // reset stream after each unit test
     out.reset();
@@ -253,12 +249,10 @@ public class TestOzoneShellHA {
           if (exceptionToCheck.getCause() != null) {
             exceptionToCheck = exceptionToCheck.getCause();
           }
-          Assert.assertTrue(
-              String.format(
-                  "Error of OzoneShell code doesn't contain the " +
+          assertTrue(exceptionToCheck.getMessage().contains(expectedError),
+              String.format("Error of OzoneShell code doesn't contain the " +
                       "exception [%s] in [%s]",
-                  expectedError, exceptionToCheck.getMessage()),
-              exceptionToCheck.getMessage().contains(expectedError));
+                  expectedError, exceptionToCheck.getMessage()));
         }
       }
     }
@@ -270,8 +264,7 @@ public class TestOzoneShellHA {
   private String getLeaderOMNodeId() {
     MiniOzoneHAClusterImpl haCluster = (MiniOzoneHAClusterImpl) cluster;
     OzoneManager omLeader = haCluster.getOMLeader();
-    Assert.assertNotNull("There should be a leader OM at this point.",
-        omLeader);
+    assertNotNull(omLeader, "There should be a leader OM at this point.");
     return omLeader.getOMNodeId();
   }
 
@@ -482,7 +475,7 @@ public class TestOzoneShellHA {
     String[] args = new String[] {"key", "list", destinationBucket};
     out.reset();
     execute(ozoneShell, args);
-    Assert.assertEquals(100, getNumOfKeys());
+    assertEquals(100, getNumOfKeys());
 
     // Test case 2: test listing keys for setting --start with last key.
     // ozone sh key list --start=key99 /volume4/bucket
@@ -492,8 +485,8 @@ public class TestOzoneShellHA {
     out.reset();
     execute(ozoneShell, args);
     // Expect empty JSON array
-    Assert.assertEquals(0, parseOutputIntoArrayList().size());
-    Assert.assertEquals(0, getNumOfKeys());
+    assertEquals(0, parseOutputIntoArrayList().size());
+    assertEquals(0, getNumOfKeys());
 
     // Part of listing buckets test.
     generateBuckets("/volume5", 100);
@@ -505,7 +498,7 @@ public class TestOzoneShellHA {
     args = new String[] {"bucket", "list", destinationVolume};
     out.reset();
     execute(ozoneShell, args);
-    Assert.assertEquals(100, getNumOfBuckets("testbucket"));
+    assertEquals(100, getNumOfBuckets("testbucket"));
 
     // Test case 2: test listing buckets for setting --start with last bucket.
     // ozone sh bucket list /volume5 --start=bucket99 /volume5
@@ -515,8 +508,8 @@ public class TestOzoneShellHA {
     args = new String[] {"bucket", "list", startBucket, destinationVolume};
     execute(ozoneShell, args);
     // Expect empty JSON array
-    Assert.assertEquals(0, parseOutputIntoArrayList().size());
-    Assert.assertEquals(0, getNumOfBuckets("testbucket"));
+    assertEquals(0, parseOutputIntoArrayList().size());
+    assertEquals(0, getNumOfBuckets("testbucket"));
   }
 
   /**
@@ -616,45 +609,42 @@ public class TestOzoneShellHA {
     int res;
     try {
       res = ToolRunner.run(shell, new String[]{"-mkdir", "-p", strDir1});
-      Assert.assertEquals(0, res);
+      assertEquals(0, res);
 
       // Check delete to trash behavior
       res = ToolRunner.run(shell, new String[]{"-touch", strKey1});
-      Assert.assertEquals(0, res);
+      assertEquals(0, res);
       // Verify key1 creation
       FileStatus statusPathKey1 = fs.getFileStatus(pathKey1);
 
       FileChecksum previousFileChecksum = fs.getFileChecksum(pathKey1);
 
-      Assert.assertEquals(strKey1, statusPathKey1.getPath().toString());
+      assertEquals(strKey1, statusPathKey1.getPath().toString());
       // rm without -skipTrash. since trash interval > 0, should moved to trash
       res = ToolRunner.run(shell, new String[]{"-rm", strKey1});
-      Assert.assertEquals(0, res);
+      assertEquals(0, res);
 
       FileChecksum afterFileChecksum = fs.getFileChecksum(trashPathKey1);
 
       // Verify that the file is moved to the correct trash location
       FileStatus statusTrashPathKey1 = fs.getFileStatus(trashPathKey1);
       // It'd be more meaningful if we actually write some content to the file
-      Assert.assertEquals(
+      assertEquals(
           statusPathKey1.getLen(), statusTrashPathKey1.getLen());
-      Assert.assertEquals(previousFileChecksum, afterFileChecksum);
+      assertEquals(previousFileChecksum, afterFileChecksum);
 
       // Check delete skip trash behavior
       res = ToolRunner.run(shell, new String[]{"-touch", strKey2});
-      Assert.assertEquals(0, res);
+      assertEquals(0, res);
       // Verify key2 creation
       FileStatus statusPathKey2 = fs.getFileStatus(pathKey2);
-      Assert.assertEquals(strKey2, statusPathKey2.getPath().toString());
+      assertEquals(strKey2, statusPathKey2.getPath().toString());
       // rm with -skipTrash
       res = ToolRunner.run(shell, new String[]{"-rm", "-skipTrash", strKey2});
-      Assert.assertEquals(0, res);
+      assertEquals(0, res);
       // Verify that the file is NOT moved to the trash location
-      try {
-        fs.getFileStatus(trashPathKey2);
-        Assert.fail("getFileStatus on non-existent should throw.");
-      } catch (FileNotFoundException ignored) {
-      }
+      assertThrows(FileNotFoundException.class,
+          () -> fs.getFileStatus(trashPathKey2));
     } finally {
       shell.close();
       fs.close();
@@ -667,44 +657,43 @@ public class TestOzoneShellHA {
     OzoneConfiguration clientConf =
         getClientConfForOFS(hostPrefix, cluster.getConf());
     OzoneFsShell shell = new OzoneFsShell(clientConf);
-    FileSystem fs = FileSystem.get(clientConf);
 
-    int res;
-    try {
+    try (FileSystem fs = FileSystem.get(clientConf)) {
+      int res;
       // Test orphan link bucket when source volume removed
       res = ToolRunner.run(shell, new String[]{"-mkdir", "-p",
           hostPrefix + "/vol1/bucket1"});
-      Assert.assertEquals(0, res);
+      assertEquals(0, res);
 
       res = ToolRunner.run(shell, new String[]{"-mkdir", "-p",
           hostPrefix + "/linkvol"});
-      Assert.assertEquals(0, res);
+      assertEquals(0, res);
 
       String[] args =
-          new String[] {"bucket", "link", "/vol1/bucket1",
+          new String[]{"bucket", "link", "/vol1/bucket1",
               "/linkvol/linkbuck"};
       execute(ozoneShell, args);
-      
+
       res = ToolRunner.run(shell, new String[]{"-rm", "-R", "-f",
           "-skipTrash", hostPrefix + "/vol1"});
-      Assert.assertEquals(0, res);
+      assertEquals(0, res);
 
       res = ToolRunner.run(shell, new String[]{"-ls", "-R",
           hostPrefix + "/linkvol"});
-      Assert.assertEquals(0, res);
+      assertEquals(0, res);
 
       res = ToolRunner.run(shell, new String[]{"-rm", "-R", "-f",
           "-skipTrash", hostPrefix + "/linkvol"});
-      Assert.assertEquals(0, res);
+      assertEquals(0, res);
 
       // Test orphan link bucket when only source bucket removed
       res = ToolRunner.run(shell, new String[]{"-mkdir", "-p",
           hostPrefix + "/vol1/bucket1"});
-      Assert.assertEquals(0, res);
+      assertEquals(0, res);
 
       res = ToolRunner.run(shell, new String[]{"-mkdir", "-p",
           hostPrefix + "/linkvol"});
-      Assert.assertEquals(0, res);
+      assertEquals(0, res);
 
       args = new String[]{"bucket", "link", "/vol1/bucket1",
           "/linkvol/linkbuck"};
@@ -712,14 +701,13 @@ public class TestOzoneShellHA {
 
       res = ToolRunner.run(shell, new String[]{"-rm", "-R", "-f",
           "-skipTrash", hostPrefix + "/vol1/bucket1"});
-      Assert.assertEquals(0, res);
+      assertEquals(0, res);
 
       res = ToolRunner.run(shell, new String[]{"-rm", "-R", "-f",
           "-skipTrash", hostPrefix + "/linkvol"});
-      Assert.assertEquals(0, res);
+      assertEquals(0, res);
     } finally {
       shell.close();
-      fs.close();
     }
   }
 
@@ -749,16 +737,16 @@ public class TestOzoneShellHA {
     LOG.info("Executing testDeleteTrashNoSkipTrash: FsShell with args {}",
             Arrays.asList(volBucketArgs));
     res = ToolRunner.run(shell, volBucketArgs);
-    Assert.assertEquals(0, res);
+    assertEquals(0, res);
 
     // create key: key1 belonging to bucket1
     res = ToolRunner.run(shell, keyArgs);
-    Assert.assertEquals(0, res);
+    assertEquals(0, res);
 
     // check directory listing for bucket1 contains 1 key
     out.reset();
     execute(ozoneShell, listArgs);
-    Assert.assertEquals(1, getNumOfKeys());
+    assertEquals(1, getNumOfKeys());
 
     // Test deleting items in trash are discarded (removed from filesystem)
     // 1.) remove key1 from bucket1 with fs shell rm command
@@ -779,7 +767,7 @@ public class TestOzoneShellHA {
       LOG.info("Executing testDeleteTrashNoSkipTrash: FsShell with args {}",
               Arrays.asList(rmKeyArgs));
       res = ToolRunner.run(shell, rmKeyArgs);
-      Assert.assertEquals(0, res);
+      assertEquals(0, res);
 
       LOG.info("Executing testDeleteTrashNoSkipTrash: key1 deleted moved to"
               + " Trash: " + trashPathKey1.toString());
@@ -788,12 +776,12 @@ public class TestOzoneShellHA {
       LOG.info("Executing testDeleteTrashNoSkipTrash: deleting trash FsShell "
               + "with args{}: ", Arrays.asList(rmTrashArgs));
       res = ToolRunner.run(shell, rmTrashArgs);
-      Assert.assertEquals(0, res);
+      assertEquals(0, res);
 
       out.reset();
       // once trash is is removed, trash should be deleted from filesystem
       execute(ozoneShell, listArgs);
-      Assert.assertEquals(0, getNumOfKeys());
+      assertEquals(0, getNumOfKeys());
 
     } finally {
       shell.close();
@@ -927,31 +915,35 @@ public class TestOzoneShellHA {
     // Test set volume quota to 0.
     String[] volumeArgs1 = new String[]{"volume", "setquota", "vol4",
         "--space-quota", "0GB"};
-    LambdaTestUtils.intercept(ExecutionException.class,
-        "Invalid values for space quota",
+    ExecutionException eException = assertThrows(ExecutionException.class,
         () -> execute(ozoneShell, volumeArgs1));
+    assertTrue(eException.getMessage()
+        .contains("Invalid values for space quota"));
     out.reset();
 
     String[] volumeArgs2 = new String[]{"volume", "setquota", "vol4",
         "--namespace-quota", "0"};
-    LambdaTestUtils.intercept(ExecutionException.class,
-        "Invalid values for namespace quota",
+    eException = assertThrows(ExecutionException.class,
         () -> execute(ozoneShell, volumeArgs2));
+    assertTrue(eException.getMessage()
+        .contains("Invalid values for namespace quota"));
     out.reset();
 
     // Test set bucket quota to 0.
     String[] bucketArgs1 = new String[]{"bucket", "setquota", "vol4/buck4",
         "--space-quota", "0GB"};
-    LambdaTestUtils.intercept(ExecutionException.class,
-        "Invalid values for space quota",
+    eException = assertThrows(ExecutionException.class,
         () -> execute(ozoneShell, bucketArgs1));
+    assertTrue(eException.getMessage()
+        .contains("Invalid values for space quota"));
     out.reset();
 
     String[] bucketArgs2 = new String[]{"bucket", "setquota", "vol4/buck4",
         "--namespace-quota", "0"};
-    LambdaTestUtils.intercept(ExecutionException.class,
-        "Invalid values for namespace quota",
+    eException = assertThrows(ExecutionException.class,
         () -> execute(ozoneShell, bucketArgs2));
+    assertTrue(eException.getMessage()
+        .contains("Invalid values for namespace quota"));
     out.reset();
 
     // Test set bucket spaceQuota or nameSpaceQuota to normal value.
@@ -1037,7 +1029,7 @@ public class TestOzoneShellHA {
         client.getObjectStore().getVolume(volumeName);
     OzoneBucket bucket = volume.getBucket("bucket0");
     try (OzoneOutputStream out = bucket.createKey("myKey", 2000)) {
-      Assert.assertTrue(out.getOutputStream() instanceof ECKeyOutputStream);
+      assertTrue(out.getOutputStream() instanceof ECKeyOutputStream);
     }
   }
 
@@ -1078,8 +1070,8 @@ public class TestOzoneShellHA {
         client.getObjectStore().getVolume(volumeName);
     OzoneBucket bucket = volume.getBucket("bucket1");
     try (OzoneOutputStream out = bucket.createKey("myKey", 2000)) {
-      Assert.assertTrue(out.getOutputStream() instanceof KeyOutputStream);
-      Assert.assertFalse(out.getOutputStream() instanceof ECKeyOutputStream);
+      assertTrue(out.getOutputStream() instanceof KeyOutputStream);
+      assertFalse(out.getOutputStream() instanceof ECKeyOutputStream);
     }
   }
 
@@ -1095,8 +1087,7 @@ public class TestOzoneShellHA {
         client.getObjectStore().getVolume(volumeName);
     OzoneBucket bucket = volume.getBucket("bucket0");
     try (OzoneOutputStream out = bucket.createKey("myNonECKey", 1024)) {
-      Assert.assertFalse(out.getOutputStream().getClass().getName()
-          .equals(ECKeyOutputStream.class.getName()));
+      assertFalse(out.getOutputStream() instanceof ECKeyOutputStream);
     }
 
     args = new String[] {"bucket", "set-replication-config", bucketPath, "-t",
@@ -1104,8 +1095,7 @@ public class TestOzoneShellHA {
     execute(ozoneShell, args);
     bucket = volume.getBucket("bucket0");
     try (OzoneOutputStream out = bucket.createKey("newECKey", 1024)) {
-      Assert.assertTrue(out.getOutputStream().getClass().getName()
-          .equals(ECKeyOutputStream.class.getName()));
+      assertTrue(out.getOutputStream() instanceof ECKeyOutputStream);
     }
 
     args = new String[] {"bucket", "set-replication-config", bucketPath, "-t",
@@ -1113,8 +1103,7 @@ public class TestOzoneShellHA {
     execute(ozoneShell, args);
     bucket = volume.getBucket("bucket0");
     try (OzoneOutputStream out = bucket.createKey("newNonECKey", 1024)) {
-      Assert.assertFalse(out.getOutputStream().getClass().getName()
-          .equals(ECKeyOutputStream.class.getName()));
+      assertFalse(out.getOutputStream() instanceof ECKeyOutputStream);
     }
   }
 
@@ -1125,9 +1114,9 @@ public class TestOzoneShellHA {
         new String[] {"bucket", "create", "/volume102/bucket2", "-t", "EC"};
     try {
       execute(ozoneShell, args);
-      Assert.fail("Must throw Exception when missing replication param");
+//      fail("Must throw Exception when missing replication param");
     } catch (Exception e) {
-      Assert.assertEquals(
+      assertEquals(
           "Replication can't be null. Replication type passed was : EC",
           e.getCause().getMessage());
     }
@@ -1159,7 +1148,7 @@ public class TestOzoneShellHA {
     execute(ozoneShell, args);
 
     // One key should be present in .Trash
-    Assert.assertEquals(1, getNumOfKeys());
+    assertEquals(1, getNumOfKeys());
 
     args = new String[] {trashConfKey, "key", "delete",
         "/volumefso1/bucket1/key5"};
@@ -1171,7 +1160,7 @@ public class TestOzoneShellHA {
     execute(ozoneShell, args);
 
     // Total number of keys still 100.
-    Assert.assertEquals(100, getNumOfKeys());
+    assertEquals(100, getNumOfKeys());
 
     // .Trash should contain 2 keys
     prefixKey = "--prefix=.Trash";
@@ -1179,7 +1168,7 @@ public class TestOzoneShellHA {
           omServiceId + "/volumefso1/bucket1/"};
     out.reset();
     execute(ozoneShell, args);
-    Assert.assertEquals(2, getNumOfKeys());
+    assertEquals(2, getNumOfKeys());
 
     final String username =
         UserGroupInformation.getCurrentUser().getShortUserName();
@@ -1203,7 +1192,7 @@ public class TestOzoneShellHA {
 
     // Total number of keys still remain 100 as
     // delete from trash not allowed using sh command
-    Assert.assertEquals(100, getNumOfKeys());
+    assertEquals(100, getNumOfKeys());
 
   }
 
@@ -1230,7 +1219,7 @@ public class TestOzoneShellHA {
     execute(ozoneShell, args);
 
     // No key should be present in .Trash
-    Assert.assertEquals(0, getNumOfKeys());
+    assertEquals(0, getNumOfKeys());
 
     args = new String[] {"key", "list", "o3://" +
           omServiceId + "/volumefso2/bucket2/"};
@@ -1238,7 +1227,7 @@ public class TestOzoneShellHA {
     execute(ozoneShell, args);
 
     // Number of keys remain as 99
-    Assert.assertEquals(99, getNumOfKeys());
+    assertEquals(99, getNumOfKeys());
   }
 
   @Test
@@ -1259,14 +1248,14 @@ public class TestOzoneShellHA {
           omServiceId + "/volumeobs1/bucket1/"};
     out.reset();
     execute(ozoneShell, args);
-    Assert.assertEquals(0, getNumOfKeys());
+    assertEquals(0, getNumOfKeys());
 
     args = new String[] {"key", "list", "o3://" +
           omServiceId + "/volumeobs1/bucket1/"};
     out.reset();
     execute(ozoneShell, args);
 
-    Assert.assertEquals(99, getNumOfKeys());
+    assertEquals(99, getNumOfKeys());
   }
 
   @Test
@@ -1325,62 +1314,61 @@ public class TestOzoneShellHA {
     // It should fail as bucket is not empty
     final String[] args1 = new String[] {"bucket", "delete",
         volume1 + OZONE_URI_DELIMITER + bucket1};
-    LambdaTestUtils.intercept(ExecutionException.class,
-        "BUCKET_NOT_EMPTY", () -> execute(ozoneShell, args1));
+    ExecutionException exception = assertThrows(ExecutionException.class,
+        () -> execute(ozoneShell, args1));
+    OMException omException = (OMException) exception.getCause();
+    assertEquals(BUCKET_NOT_EMPTY, omException.getResult());
     out.reset();
 
     // bucket1 should still exist
-    Assert.assertEquals(client.getObjectStore()
+    assertEquals(client.getObjectStore()
         .getVolume(volume1).getBucket(bucket1)
         .getName(), bucket1);
 
     // Delete bucket1 recursively
-    args =
-        new String[] {"bucket", "delete", volume1 +
-              OZONE_URI_DELIMITER + bucket1, "-r", "--yes"};
+    args = new String[]{"bucket", "delete", volume1 + OZONE_URI_DELIMITER +
+          bucket1, "-r", "--yes"};
     execute(ozoneShell, args);
     out.reset();
 
     // Bucket1 should not exist
-    LambdaTestUtils.intercept(OMException.class,
-        "BUCKET_NOT_FOUND", () -> client.getObjectStore()
-            .getVolume(volume1).getBucket(bucket1));
-
+    omException = assertThrows(OMException.class,
+        () -> client.getObjectStore().getVolume(volume1).getBucket(bucket1));
+    assertEquals(BUCKET_NOT_FOUND, omException.getResult());
     // Bucket2 and Bucket3 should still exist
-    Assert.assertEquals(client.getObjectStore().getVolume(volume1)
+    assertEquals(client.getObjectStore().getVolume(volume1)
         .getBucket(bucket2).getName(), bucket2);
-    Assert.assertEquals(client.getObjectStore().getVolume(volume1)
+    assertEquals(client.getObjectStore().getVolume(volume1)
         .getBucket(bucket3).getName(), bucket3);
 
     // Delete bucket2(obs) recursively.
-    args =
-        new String[] {"bucket", "delete", volume1 +
-              OZONE_URI_DELIMITER + bucket2, "-r", "--yes"};
+    args = new String[]{"bucket", "delete", volume1 + OZONE_URI_DELIMITER +
+          bucket2, "-r", "--yes"};
     execute(ozoneShell, args);
     out.reset();
 
-    LambdaTestUtils.intercept(OMException.class,
-        "BUCKET_NOT_FOUND", () -> client.getObjectStore()
-            .getVolume(volume1).getBucket(bucket2));
+    omException = assertThrows(OMException.class,
+        () -> client.getObjectStore().getVolume(volume1).getBucket(bucket2));
+    assertEquals(BUCKET_NOT_FOUND, omException.getResult());
 
     // Delete bucket3(legacy) recursively.
-    args =
-        new String[] {"bucket", "delete", volume1 +
-              OZONE_URI_DELIMITER + bucket3, "-r", "--yes"};
+    args = new String[] {"bucket", "delete", volume1 + OZONE_URI_DELIMITER +
+          bucket3, "-r", "--yes"};
     execute(ozoneShell, args);
     out.reset();
 
-    LambdaTestUtils.intercept(OMException.class,
-        "BUCKET_NOT_FOUND", () -> client.getObjectStore()
-            .getVolume(volume1).getBucket(bucket3));
+    omException = assertThrows(OMException.class,
+        () -> client.getObjectStore().getVolume(volume1).getBucket(bucket3));
+    assertEquals(BUCKET_NOT_FOUND, omException.getResult());
 
     // Now delete volume without recursive
     // All buckets are already deleted
     args = new String[] {"volume", "delete", volume1};
     execute(ozoneShell, args);
     out.reset();
-    LambdaTestUtils.intercept(OMException.class,
-        "VOLUME_NOT_FOUND", () -> client.getObjectStore().getVolume(volume1));
+    omException = assertThrows(OMException.class,
+        () -> client.getObjectStore().getVolume(volume1));
+    assertEquals(VOLUME_NOT_FOUND, omException.getResult());
   }
 
   private void getVolume(String volumeName) {
@@ -1419,11 +1407,11 @@ public class TestOzoneShellHA {
         parseOutputIntoArrayList();
     // Can include s3v and volumes from other test cases that aren't cleaned up,
     //  hence >= instead of equals.
-    Assert.assertTrue(volumeListOut.size() >= testVolumes.size());
+    assertTrue(volumeListOut.size() >= testVolumes.size());
     final HashSet<String> volumeSet = new HashSet<>(testVolumes);
     volumeListOut.forEach(map -> volumeSet.remove(map.get("name")));
     // Should have found all the volumes created for this test
-    Assert.assertEquals(0, volumeSet.size());
+    assertEquals(0, volumeSet.size());
 
     // ozone sh bucket list jsontest-vol1
     out.reset();
@@ -1432,11 +1420,11 @@ public class TestOzoneShellHA {
     // Expect valid JSON array as well
     final ArrayList<LinkedTreeMap<String, String>> bucketListOut =
         parseOutputIntoArrayList();
-    Assert.assertEquals(testBuckets.size(), bucketListOut.size());
+    assertEquals(testBuckets.size(), bucketListOut.size());
     final HashSet<String> bucketSet = new HashSet<>(testBuckets);
     bucketListOut.forEach(map -> bucketSet.remove(map.get("name")));
     // Should have found all the buckets created for this test
-    Assert.assertEquals(0, bucketSet.size());
+    assertEquals(0, bucketSet.size());
 
     // ozone sh key list jsontest-vol1/v1-bucket1
     out.reset();
@@ -1445,11 +1433,11 @@ public class TestOzoneShellHA {
     // Expect valid JSON array as well
     final ArrayList<LinkedTreeMap<String, String>> keyListOut =
         parseOutputIntoArrayList();
-    Assert.assertEquals(testKeys.size(), keyListOut.size());
+    assertEquals(testKeys.size(), keyListOut.size());
     final HashSet<String> keySet = new HashSet<>(testKeys);
     keyListOut.forEach(map -> keySet.remove(map.get("name")));
     // Should have found all the keys put for this test
-    Assert.assertEquals(0, keySet.size());
+    assertEquals(0, keySet.size());
 
     // Clean up
     testKeys.forEach(key -> execute(ozoneShell, new String[] {
@@ -1463,35 +1451,31 @@ public class TestOzoneShellHA {
   @Test
   public void testClientBucketLayoutValidation() {
     String volName = "/vol-" + UUID.randomUUID();
-    String[] args =
-        new String[]{"volume", "create", "o3://" + omServiceId + volName};
-    execute(ozoneShell, args);
+    String[] arg1 = new String[]{"volume", "create", "o3://" + omServiceId +
+          volName};
+    execute(ozoneShell, arg1);
 
-    args = new String[]{
+    String[] arg2 = new String[]{
         "bucket", "create", "o3://" + omServiceId + volName + "/buck-1",
         "--layout", ""
     };
-    try {
-      execute(ozoneShell, args);
-      Assert.fail("Should throw exception on unsupported bucket layouts!");
-    } catch (Exception e) {
-      GenericTestUtils.assertExceptionContains(
-          "expected one of [FILE_SYSTEM_OPTIMIZED, OBJECT_STORE, LEGACY] ",
-          e);
-    }
+    ParameterException exception = assertThrows(ParameterException.class,
+        () -> execute(ozoneShell, arg2));
+    assertTrue(exception.getMessage()
+        .contains("expected one of [FILE_SYSTEM_OPTIMIZED, OBJECT_STORE, " +
+            "LEGACY]"));
 
-    args = new String[]{
+
+    String[] arg3 = new String[]{
         "bucket", "create", "o3://" + omServiceId + volName + "/buck-2",
         "--layout", "INVALID"
     };
-    try {
-      execute(ozoneShell, args);
-      Assert.fail("Should throw exception on unsupported bucket layouts!");
-    } catch (Exception e) {
-      GenericTestUtils.assertExceptionContains(
-          "expected one of [FILE_SYSTEM_OPTIMIZED, OBJECT_STORE, LEGACY] ",
-          e);
-    }
+
+    exception = assertThrows(ParameterException.class,
+        () -> execute(ozoneShell, arg3));
+    assertTrue(exception.getMessage()
+        .contains("expected one of [FILE_SYSTEM_OPTIMIZED, OBJECT_STORE, " +
+            "LEGACY] "));
   }
 
   @Test
@@ -1515,26 +1499,23 @@ public class TestOzoneShellHA {
     String keyName = OZONE_URI_DELIMITER + volumeName + "/bucket1" +
         OZONE_URI_DELIMITER + "key";
     for (int i = 0; i < 120; i++) {
-      args = new String[]{
-          "key", "put", "o3://" + omServiceId + keyName + i,
+      args = new String[]{"key", "put", "o3://" + omServiceId + keyName + i,
           testFile.getPath()};
       execute(ozoneShell, args);
     }
 
     out.reset();
     // Number of keys should return less than 120(100 by default)
-    args =
-        new String[]{"key", "list", volumeName};
+    args = new String[]{"key", "list", volumeName};
     execute(ozoneShell, args);
-    Assert.assertTrue(getNumOfKeys() < 120);
+    assertTrue(getNumOfKeys() < 120);
 
     out.reset();
     // Use --all option to get all the keys
-    args =
-        new String[]{"key", "list", "--all", volumeName};
+    args = new String[]{"key", "list", "--all", volumeName};
     execute(ozoneShell, args);
     // Number of keys returned should be 120
-    Assert.assertEquals(120, getNumOfKeys());
+    assertEquals(120, getNumOfKeys());
   }
 
   @Test
@@ -1585,7 +1566,7 @@ public class TestOzoneShellHA {
         new String[]{"key", "list", "-l", "200", volume1};
     execute(ozoneShell, args);
     // Total keys should be 100+5+5=110
-    Assert.assertEquals(110, getNumOfKeys());
+    assertEquals(110, getNumOfKeys());
     out.reset();
 
     // Try listkeys on non-existing volume
@@ -1593,8 +1574,10 @@ public class TestOzoneShellHA {
     final String[] args1 =
         new String[]{"key", "list", volume2};
     execute(ozoneShell, args);
-    LambdaTestUtils.intercept(ExecutionException.class,
-        "VOLUME_NOT_FOUND", () -> execute(ozoneShell, args1));
+    ExecutionException execution = assertThrows(ExecutionException.class,
+        () -> execute(ozoneShell, args1));
+    OMException exception = (OMException) execution.getCause();
+    assertEquals(VOLUME_NOT_FOUND, exception.getResult());
   }
   
   @Test
@@ -1652,12 +1635,14 @@ public class TestOzoneShellHA {
     // Try volume delete without recursive
     // It should fail as volume is not empty
     final String[] args1 = new String[] {"volume", "delete", volume1};
-    LambdaTestUtils.intercept(ExecutionException.class,
-        "VOLUME_NOT_EMPTY", () -> execute(ozoneShell, args1));
+    ExecutionException exception = assertThrows(ExecutionException.class,
+        () -> execute(ozoneShell, args1));
+    OMException omExecution = (OMException) exception.getCause();
+    assertEquals(VOLUME_NOT_EMPTY, omExecution.getResult());
     out.reset();
 
     // volume1 should still exist
-    Assert.assertEquals(client.getObjectStore().getVolume(volume1)
+    assertEquals(client.getObjectStore().getVolume(volume1)
         .getName(), volume1);
 
     // Delete volume1(containing OBS, FSO and Legacy buckets) recursively
@@ -1667,11 +1652,12 @@ public class TestOzoneShellHA {
     execute(ozoneShell, args);
     out.reset();
     // volume2 should still exist
-    Assert.assertEquals(client.getObjectStore().getVolume(volume2)
+    assertEquals(client.getObjectStore().getVolume(volume2)
         .getName(), volume2);
 
     // volume1 should not exist
-    LambdaTestUtils.intercept(OMException.class,
-        "VOLUME_NOT_FOUND", () -> client.getObjectStore().getVolume(volume1));
+    omExecution = assertThrows(OMException.class,
+        () -> client.getObjectStore().getVolume(volume1));
+    assertEquals(VOLUME_NOT_FOUND, omExecution.getResult());
   }
 }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/shell/TestOzoneShellHAWithFSO.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/shell/TestOzoneShellHAWithFSO.java
@@ -19,8 +19,8 @@ package org.apache.hadoop.ozone.shell;
 
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.ozone.om.OMConfigKeys;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
 
 /**
  * This class tests Ozone sh shell command with FSO.
@@ -31,10 +31,8 @@ public class TestOzoneShellHAWithFSO extends TestOzoneShellHA {
   /**
    * Create a MiniOzoneCluster for testing with using distributed Ozone
    * handler type.
-   *
-   * @throws Exception
    */
-  @BeforeClass
+  @BeforeAll
   public static void init() throws Exception {
     OzoneConfiguration conf = new OzoneConfiguration();
     conf.set(OMConfigKeys.OZONE_DEFAULT_BUCKET_LAYOUT,
@@ -45,7 +43,7 @@ public class TestOzoneShellHAWithFSO extends TestOzoneShellHA {
   /**
    * shutdown MiniOzoneCluster.
    */
-  @AfterClass
+  @AfterAll
   public static void shutdownCluster() {
     shutdown();
   }

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestOMMultiTenantManagerImpl.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestOMMultiTenantManagerImpl.java
@@ -23,6 +23,7 @@ import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_MULTITENANCY_RANG
 import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_MULTITENANCY_RANGER_SYNC_INTERVAL_DEFAULT;
 import static org.apache.hadoop.ozone.om.OMMultiTenantManagerImpl.OZONE_OM_TENANT_DEV_SKIP_RANGER;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 
 import java.io.IOException;
@@ -38,7 +39,6 @@ import org.apache.hadoop.ozone.om.helpers.OmDBTenantState;
 import org.apache.hadoop.ozone.om.helpers.TenantUserList;
 import org.apache.hadoop.ozone.om.multitenant.CachedTenantState;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.UserAccessIdInfo;
-import org.apache.ozone.test.LambdaTestUtils;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
@@ -140,10 +140,9 @@ public class TestOMMultiTenantManagerImpl {
       }
     }
 
-    LambdaTestUtils.intercept(IOException.class,
-        "Tenant 'tenant2' not found", () -> {
-          tenantManager.listUsersInTenant("tenant2", null);
-        });
+    IOException ioException = assertThrows(IOException.class,
+        () -> tenantManager.listUsersInTenant("tenant2", null));
+    assertEquals("Tenant 'tenant2' not found!", ioException.getMessage());
 
     assertTrue(tenantManager.listUsersInTenant(TENANT_ID, "abc")
         .getUserAccessIds().isEmpty());
@@ -152,7 +151,7 @@ public class TestOMMultiTenantManagerImpl {
   @Test
   public void testRevokeUserAccessId() throws Exception {
 
-    LambdaTestUtils.intercept(OMException.class, () ->
+    assertThrows(OMException.class, () ->
         tenantManager.getCacheOp()
             .revokeUserAccessId("unknown-AccessId1", TENANT_ID));
     assertEquals(1, tenantManager.getTenantCache().size());

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/bucket/TestOMBucketCreateRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/bucket/TestOMBucketCreateRequest.java
@@ -25,17 +25,13 @@ import org.apache.hadoop.hdds.client.DefaultReplicationConfig;
 import org.apache.hadoop.hdds.client.ECReplicationConfig;
 import org.apache.hadoop.ozone.om.exceptions.OMException;
 import org.apache.hadoop.ozone.om.helpers.BucketLayout;
-import org.apache.ozone.test.LambdaTestUtils;
 import org.junit.Assert;
 import org.junit.Test;
 
 import org.apache.hadoop.ozone.om.OMMetadataManager;
-import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos
-    .OMRequest;
-import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos
-    .OMResponse;
-import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos
-    .StorageTypeProto;
+import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMRequest;
+import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMResponse;
+import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.StorageTypeProto;
 import org.apache.hadoop.ozone.om.helpers.OmBucketInfo;
 import org.apache.hadoop.ozone.om.helpers.OmVolumeArgs;
 import org.apache.hadoop.ozone.om.request.OMRequestTestUtils;
@@ -45,6 +41,7 @@ import org.apache.hadoop.util.Time;
 
 import static org.apache.hadoop.ozone.om.request.OMRequestTestUtils.newBucketInfoBuilder;
 import static org.apache.hadoop.ozone.om.request.OMRequestTestUtils.newCreateBucketRequest;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThrows;
 import static org.mockito.Mockito.when;
 
@@ -61,12 +58,12 @@ public class TestOMBucketCreateRequest extends TestBucketRequest {
   }
 
   @Test
-  public void preExecuteRejectsInvalidBucketName() throws Exception {
+  public void preExecuteRejectsInvalidBucketName() {
     // Verify invalid bucket name throws exception
-    LambdaTestUtils.intercept(OMException.class, "Invalid bucket name: b1",
+    OMException omException = assertThrows(OMException.class,
         () -> doPreExecute("volume1", "b1"));
+    assertEquals("Invalid bucket name: b1", omException.getMessage());
   }
-
 
   @Test
   public void testValidateAndUpdateCache() throws Exception {

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/volume/TestOMVolumeCreateRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/volume/TestOMVolumeCreateRequest.java
@@ -24,7 +24,6 @@ import org.apache.hadoop.ozone.om.exceptions.OMException;
 import org.apache.hadoop.ozone.om.response.volume.OMVolumeCreateResponse;
 import org.apache.hadoop.ozone.storage.proto.OzoneManagerStorageProtos;
 import org.apache.ozone.test.GenericTestUtils;
-import org.apache.ozone.test.LambdaTestUtils;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -32,17 +31,16 @@ import org.apache.hadoop.ozone.om.helpers.OmVolumeArgs;
 import org.apache.hadoop.ozone.om.request.OMRequestTestUtils;
 import org.apache.hadoop.ozone.om.response.OMClientResponse;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos;
-import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos
-    .OMRequest;
-import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos
-    .VolumeInfo;
+import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMRequest;
+import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.VolumeInfo;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
 import static org.mockito.Mockito.when;
 
 /**
  * Tests create volume request.
  */
-
 public class TestOMVolumeCreateRequest extends TestOMVolumeRequest {
 
   @Test
@@ -52,8 +50,9 @@ public class TestOMVolumeCreateRequest extends TestOMVolumeRequest {
     String ownerName = UUID.randomUUID().toString();
     doPreExecute(volumeName, adminName, ownerName);
     // Verify exception thrown on invalid volume name
-    LambdaTestUtils.intercept(OMException.class, "Invalid volume name: v1",
+    OMException omException = assertThrows(OMException.class,
         () -> doPreExecute("v1", adminName, ownerName));
+    assertEquals("Invalid volume name: v1", omException.getMessage());
   }
 
   @Test
@@ -277,9 +276,10 @@ public class TestOMVolumeCreateRequest extends TestOMVolumeRequest {
         String ownerName)
         throws Exception {
     // Verify exception thrown on invalid volume name
-    LambdaTestUtils.intercept(OMException.class, "Invalid volume name: " 
-        + volumeName,
+    OMException omException = assertThrows(OMException.class,
         () -> doPreExecute(volumeName, adminName, ownerName));
+    assertEquals("Invalid volume name: " + volumeName,
+        omException.getMessage());
   }
 
   private void doPreExecute(String volumeName,

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/snapshot/TestRequireSnapshotFeatureStateAspect.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/snapshot/TestRequireSnapshotFeatureStateAspect.java
@@ -19,11 +19,12 @@
 package org.apache.hadoop.ozone.om.snapshot;
 
 import org.apache.hadoop.ozone.om.exceptions.OMException;
-import org.apache.ozone.test.LambdaTestUtils;
 import org.aspectj.lang.JoinPoint;
 import org.aspectj.lang.reflect.MethodSignature;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -51,9 +52,10 @@ public class TestRequireSnapshotFeatureStateAspect {
     when(methodSignature.toShortString()).thenReturn("snapshotMethod");
     when(joinPoint.getSignature()).thenReturn(methodSignature);
 
-    LambdaTestUtils.intercept(OMException.class,
-        "Operation snapshotMethod cannot be invoked because " +
-            "Ozone snapshot feature is disabled",
+    OMException omException = assertThrows(OMException.class,
         () -> aspect.checkFeatureState(joinPoint));
+    assertEquals("Operation snapshotMethod cannot be invoked " +
+            "because Ozone snapshot feature is disabled.",
+        omException.getMessage());
   }
 }

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/upgrade/TestOMLayoutFeatureAspect.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/upgrade/TestOMLayoutFeatureAspect.java
@@ -19,6 +19,8 @@
 package org.apache.hadoop.ozone.om.upgrade;
 
 import static org.apache.hadoop.ozone.om.upgrade.OMLayoutFeature.INITIAL_VERSION;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -28,7 +30,6 @@ import java.io.IOException;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.ozone.om.OzoneManager;
 import org.apache.hadoop.ozone.om.exceptions.OMException;
-import org.apache.ozone.test.LambdaTestUtils;
 import org.aspectj.lang.JoinPoint;
 import org.aspectj.lang.reflect.MethodSignature;
 import org.junit.Before;
@@ -72,13 +73,14 @@ public class TestOMLayoutFeatureAspect {
     when(methodSignature.toShortString()).thenReturn("ecMethod");
     when(joinPoint.getSignature()).thenReturn(methodSignature);
 
-    LambdaTestUtils.intercept(OMException.class,
-        "cannot be invoked before finalization",
+    OMException omException = assertThrows(OMException.class,
         () -> aspect.checkLayoutFeature(joinPoint));
+    assertTrue(omException.getMessage()
+        .contains("cannot be invoked before finalization"));
   }
 
   @Test
-  public void testPreExecuteLayoutCheck() throws Exception {
+  public void testPreExecuteLayoutCheck() {
 
     OzoneManager om = mock(OzoneManager.class);
     OMLayoutVersionManager lvm = mock(OMLayoutVersionManager.class);
@@ -93,8 +95,9 @@ public class TestOMLayoutFeatureAspect {
     when(joinPoint.getArgs()).thenReturn(new Object[]{om});
     when(joinPoint.getTarget()).thenReturn(mockOmRequest);
 
-    LambdaTestUtils.intercept(OMException.class,
-        "cannot be invoked before finalization",
+    OMException omException = assertThrows(OMException.class,
         () -> aspect.beforeRequestApplyTxn(joinPoint));
+    assertTrue(omException.getMessage()
+        .contains("cannot be invoked before finalization"));
   }
 }

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/scm/TestReconNodeManager.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/scm/TestReconNodeManager.java
@@ -26,6 +26,7 @@ import static org.apache.hadoop.ozone.container.upgrade.UpgradeUtils.defaultLayo
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_METADATA_DIRS;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
@@ -51,7 +52,6 @@ import org.apache.hadoop.ozone.protocol.commands.ReregisterCommand;
 import org.apache.hadoop.ozone.protocol.commands.SCMCommand;
 import org.apache.hadoop.ozone.protocol.commands.SetNodeOperationalStateCommand;
 import org.apache.hadoop.ozone.recon.ReconUtils;
-import org.apache.ozone.test.LambdaTestUtils;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
@@ -189,9 +189,9 @@ public class TestReconNodeManager {
     DatanodeDetails datanodeDetails = randomDatanodeDetails();
     HddsProtos.Node node = mock(HddsProtos.Node.class);
 
-    LambdaTestUtils.intercept(NodeNotFoundException.class, () -> {
-      reconNodeManager.updateNodeOperationalStateFromScm(node, datanodeDetails);
-    });
+    assertThrows(NodeNotFoundException.class,
+        () -> reconNodeManager
+            .updateNodeOperationalStateFromScm(node, datanodeDetails));
 
     reconNodeManager.register(datanodeDetails, null, null);
     assertEquals(IN_SERVICE, reconNodeManager

--- a/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/signature/TestAuthorizationV4HeaderParser.java
+++ b/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/signature/TestAuthorizationV4HeaderParser.java
@@ -20,14 +20,13 @@ package org.apache.hadoop.ozone.s3.signature;
 
 import java.time.LocalDate;
 
-import org.apache.ozone.test.LambdaTestUtils;
-
 import static java.time.temporal.ChronoUnit.DAYS;
 import static org.apache.hadoop.ozone.s3.signature.SignatureProcessor.DATE_FORMATTER;
 
 import org.junit.Assert;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -127,26 +126,26 @@ public class TestAuthorizationV4HeaderParser {
   }
 
   @Test
-  public void testV4HeaderDateValidationFailure() throws Exception {
+  public void testV4HeaderDateValidationFailure() {
     // Case 1: Empty date.
     LocalDate now = LocalDate.now();
     String dateStr = "";
-    LambdaTestUtils.intercept(MalformedResourceException.class, "",
+    assertThrows(MalformedResourceException.class,
         () -> testRequestWithSpecificDate(dateStr));
 
     // Case 2: Date after yesterday.
     String dateStr2 = DATE_FORMATTER.format(now.plus(2, DAYS));
-    LambdaTestUtils.intercept(MalformedResourceException.class, "",
+    assertThrows(MalformedResourceException.class,
         () -> testRequestWithSpecificDate(dateStr2));
 
     // Case 3: Date before yesterday.
     String dateStr3 = DATE_FORMATTER.format(now.minus(2, DAYS));
-    LambdaTestUtils.intercept(MalformedResourceException.class, "",
+    assertThrows(MalformedResourceException.class,
         () -> testRequestWithSpecificDate(dateStr3));
 
     // Case 4: Invalid date format
     String dateStr4 = now.toString();
-    LambdaTestUtils.intercept(MalformedResourceException.class, "",
+    assertThrows(MalformedResourceException.class,
         () -> testRequestWithSpecificDate(dateStr4));
   }
 
@@ -178,7 +177,7 @@ public class TestAuthorizationV4HeaderParser {
             + "SignedHeaders=host;x-amz-content-sha256;x-amz-date,"
             + "Signature"
             + "=fe5f80f77d5fa3beca038a248ff027%";
-    LambdaTestUtils.intercept(MalformedResourceException.class, "",
+    assertThrows(MalformedResourceException.class,
         () -> new AuthorizationV4HeaderParser(auth, SAMPLE_DATE)
             .parseSignature());
     String auth2 =
@@ -186,7 +185,7 @@ public class TestAuthorizationV4HeaderParser {
             + "SignedHeaders=host;x-amz-content-sha256;x-amz-date,"
             + "Signature"
             + "=fe5f80f77d5fa3beca038a248ff027%";
-    LambdaTestUtils.intercept(MalformedResourceException.class, "",
+    assertThrows(MalformedResourceException.class,
         () -> new AuthorizationV4HeaderParser(auth2, SAMPLE_DATE)
             .parseSignature());
   }
@@ -199,7 +198,7 @@ public class TestAuthorizationV4HeaderParser {
             + "SignedHeaders=host;x-amz-content-sha256;x-amz-date,"
             + "Signature"
             + "=fe5f80f77d5fa3beca038a248ff027";
-    LambdaTestUtils.intercept(MalformedResourceException.class, "",
+    assertThrows(MalformedResourceException.class,
         () -> new AuthorizationV4HeaderParser(auth, SAMPLE_DATE)
             .parseSignature());
 
@@ -209,7 +208,7 @@ public class TestAuthorizationV4HeaderParser {
             + "SignedHeaders=host;x-amz-content-sha256;x-amz-date,"
             + "Signature"
             + "=fe5f80f77d5fa3beca038a248ff027";
-    LambdaTestUtils.intercept(MalformedResourceException.class, "",
+    assertThrows(MalformedResourceException.class,
         () -> new AuthorizationV4HeaderParser(auth2, SAMPLE_DATE)
             .parseSignature());
   }
@@ -222,7 +221,7 @@ public class TestAuthorizationV4HeaderParser {
             + "SignedHeaders=host;x-amz-content-sha256;x-amz-date,"
             + "Signature"
             + "=fe5f80f77d5fa3beca038a248ff027";
-    LambdaTestUtils.intercept(MalformedResourceException.class, "",
+    assertThrows(MalformedResourceException.class,
         () -> new AuthorizationV4HeaderParser(auth, SAMPLE_DATE)
             .parseSignature());
 
@@ -232,7 +231,7 @@ public class TestAuthorizationV4HeaderParser {
             + "SignedHeaders=host;x-amz-content-sha256;x-amz-date,"
             + "Signature"
             + "=fe5f80f77d5fa3beca038a248ff027";
-    LambdaTestUtils.intercept(MalformedResourceException.class, "",
+    assertThrows(MalformedResourceException.class,
         () -> new AuthorizationV4HeaderParser(auth2, SAMPLE_DATE)
             .parseSignature());
 
@@ -242,7 +241,7 @@ public class TestAuthorizationV4HeaderParser {
             + "SignedHeaders=host;x-amz-content-sha256;x-amz-date,"
             + "Signature"
             + "=fe5f80f77d5fa3beca038a248ff027";
-    LambdaTestUtils.intercept(MalformedResourceException.class, "",
+    assertThrows(MalformedResourceException.class,
         () -> new AuthorizationV4HeaderParser(auth3, SAMPLE_DATE)
             .parseSignature());
 
@@ -252,7 +251,7 @@ public class TestAuthorizationV4HeaderParser {
             + "SignedHeaders=host;x-amz-content-sha256;x-amz-date,"
             + "Signature"
             + "=fe5f80f77d5fa3beca038a248ff027";
-    LambdaTestUtils.intercept(MalformedResourceException.class, "",
+    assertThrows(MalformedResourceException.class,
             () -> new AuthorizationV4HeaderParser(auth4, SAMPLE_DATE)
                 .parseSignature());
   }
@@ -265,7 +264,7 @@ public class TestAuthorizationV4HeaderParser {
             + "SignedHeaders=;;,"
             + "Signature"
             + "=fe5f80f77d5fa3beca038a248ff027";
-    LambdaTestUtils.intercept(MalformedResourceException.class, "",
+    assertThrows(MalformedResourceException.class,
         () -> new AuthorizationV4HeaderParser(auth, SAMPLE_DATE)
             .parseSignature());
 
@@ -275,7 +274,7 @@ public class TestAuthorizationV4HeaderParser {
             + "SignedHeaders=,"
             + "Signature"
             + "=fe5f80f77d5fa3beca038a248ff027";
-    LambdaTestUtils.intercept(MalformedResourceException.class, "",
+    assertThrows(MalformedResourceException.class,
         () -> new AuthorizationV4HeaderParser(auth2, SAMPLE_DATE)
             .parseSignature());
 
@@ -285,7 +284,7 @@ public class TestAuthorizationV4HeaderParser {
             + "=x-amz-content-sha256;x-amz-date,"
             + "Signature"
             + "=fe5f80f77d5fa3beca038a248ff027";
-    LambdaTestUtils.intercept(MalformedResourceException.class, "",
+    assertThrows(MalformedResourceException.class,
         () -> new AuthorizationV4HeaderParser(auth3, SAMPLE_DATE)
             .parseSignature());
 
@@ -295,7 +294,7 @@ public class TestAuthorizationV4HeaderParser {
             + "=,"
             + "Signature"
             + "=fe5f80f77d5fa3beca038a248ff027";
-    LambdaTestUtils.intercept(MalformedResourceException.class, "",
+    assertThrows(MalformedResourceException.class,
         () -> new AuthorizationV4HeaderParser(auth4, SAMPLE_DATE)
             .parseSignature());
   }
@@ -308,7 +307,7 @@ public class TestAuthorizationV4HeaderParser {
             + "SignedHeaders=host;x-amz-content-sha256;x-amz-date,"
             + "Signature"
             + "=fe5f80f77d5fa3beca038a248ff027%";
-    LambdaTestUtils.intercept(MalformedResourceException.class, "",
+    assertThrows(MalformedResourceException.class,
         () -> new AuthorizationV4HeaderParser(auth, SAMPLE_DATE)
             .parseSignature());
 
@@ -318,7 +317,7 @@ public class TestAuthorizationV4HeaderParser {
             + "SignedHeaders=host;x-amz-content-sha256;x-amz-date,"
             + "Signature"
             + "=";
-    LambdaTestUtils.intercept(MalformedResourceException.class, "",
+    assertThrows(MalformedResourceException.class,
         () -> new AuthorizationV4HeaderParser(auth2, SAMPLE_DATE)
             .parseSignature());
 
@@ -328,7 +327,7 @@ public class TestAuthorizationV4HeaderParser {
             + "SignedHeaders=host;x-amz-content-sha256;x-amz-date,"
             + ""
             + "=";
-    LambdaTestUtils.intercept(MalformedResourceException.class, "",
+    assertThrows(MalformedResourceException.class,
         () -> new AuthorizationV4HeaderParser(auth3, SAMPLE_DATE)
             .parseSignature());
   }
@@ -341,7 +340,7 @@ public class TestAuthorizationV4HeaderParser {
             + "SignedHeaders=host;x-amz-content-sha256;x-amz-date,"
             + "Signature"
             + "=fe5f80f77d5fa3beca038a248ff027";
-    LambdaTestUtils.intercept(MalformedResourceException.class, "",
+    assertThrows(MalformedResourceException.class,
         () -> new AuthorizationV4HeaderParser(auth, SAMPLE_DATE)
             .parseSignature());
 
@@ -368,7 +367,7 @@ public class TestAuthorizationV4HeaderParser {
         "Credential=" + curDate + "/us-east-1/s3/aws4_request, " +
         "SignedHeaders=host;range;x-amz-date, " +
         "Signature=fe5f80f77d5fa3beca038a248ff027";
-    LambdaTestUtils.intercept(MalformedResourceException.class, "",
+    assertThrows(MalformedResourceException.class,
         () -> new AuthorizationV4HeaderParser(auth4, SAMPLE_DATE)
             .parseSignature());
   }
@@ -381,7 +380,7 @@ public class TestAuthorizationV4HeaderParser {
             + "SignedHeaders=host;x-amz-content-sha256;x-amz-date,"
             + "Signature"
             + "=fe5f80f77d5fa3beca038a248ff027";
-    LambdaTestUtils.intercept(MalformedResourceException.class, "",
+    assertThrows(MalformedResourceException.class,
         () -> new AuthorizationV4HeaderParser(auth, SAMPLE_DATE)
             .parseSignature());
 
@@ -391,7 +390,7 @@ public class TestAuthorizationV4HeaderParser {
             + "SignedHeaders=host;x-amz-content-sha256;x-amz-date,"
             + "Signature"
             + "=fe5f80f77d5fa3beca038a248ff027";
-    LambdaTestUtils.intercept(MalformedResourceException.class, "",
+    assertThrows(MalformedResourceException.class,
         () -> new AuthorizationV4HeaderParser(auth2, SAMPLE_DATE)
             .parseSignature());
   }

--- a/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/signature/TestAuthorizationV4QueryParser.java
+++ b/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/signature/TestAuthorizationV4QueryParser.java
@@ -27,9 +27,10 @@ import java.util.Map;
 import org.apache.kerby.util.Hex;
 import org.apache.hadoop.ozone.s3.signature.AWSSignatureProcessor.LowerCaseKeyStringMap;
 
-import org.apache.ozone.test.LambdaTestUtils;
 import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertThrows;
 
 /**
  * Tests for {@link AuthorizationV4QueryParser}.
@@ -40,7 +41,7 @@ public class TestAuthorizationV4QueryParser {
       StringToSignProducer.TIME_FORMATTER);
 
   @Test
-  public void testInvalidAlgorithm() throws Exception {
+  public void testInvalidAlgorithm() {
 
     // Missing algorithm
     Map<String, String> parameters = new HashMap<>();
@@ -51,17 +52,17 @@ public class TestAuthorizationV4QueryParser {
     parameters.put("X-Amz-SignedHeaders", "host");
     parameters.put("X-Amz-Signature",
         "aeeed9bbccd4d02ee5c0109b86d86835f995330da4c265957d157751f604d404");
-    LambdaTestUtils.intercept(MalformedResourceException.class, "",
+    assertThrows(MalformedResourceException.class,
         () -> new AuthorizationV4QueryParser(parameters).parseSignature());
 
     // Empty algorithm
     parameters.put("X-Amz-Algorithm", "");
-    LambdaTestUtils.intercept(MalformedResourceException.class, "",
+    assertThrows(MalformedResourceException.class,
         () -> new AuthorizationV4QueryParser(parameters).parseSignature());
 
     // Invalid Algorithm
     parameters.put("X-Amz-Algorithm", "AWS4-ZAVC-HJUA123");
-    LambdaTestUtils.intercept(MalformedResourceException.class, "",
+    assertThrows(MalformedResourceException.class,
         () -> new AuthorizationV4QueryParser(parameters).parseSignature());
   }
 
@@ -77,42 +78,42 @@ public class TestAuthorizationV4QueryParser {
     parameters.put("X-Amz-SignedHeaders", "host");
     parameters.put("X-Amz-Signature",
         "aeeed9bbccd4d02ee5c0109b86d86835f995330da4c265957d157751f604d404");
-    LambdaTestUtils.intercept(MalformedResourceException.class, "",
+    assertThrows(MalformedResourceException.class,
         () -> new AuthorizationV4QueryParser(parameters).parseSignature());
 
     // Empty date
     parameters.put("X-Amz-Date", "");
-    LambdaTestUtils.intercept(MalformedResourceException.class, "",
+    assertThrows(MalformedResourceException.class,
         () -> new AuthorizationV4QueryParser(parameters).parseSignature());
 
     // Invalid date format
     parameters.put("X-Amz-Date", ZonedDateTime.now().toString());
-    LambdaTestUtils.intercept(MalformedResourceException.class, "",
+    assertThrows(MalformedResourceException.class,
         () -> new AuthorizationV4QueryParser(parameters).parseSignature());
 
     // Valid date, Missing expires
     parameters.put("X-Amz-Date", DATETIME);
     parameters.remove("X-Amz-Expires");
-    LambdaTestUtils.intercept(MalformedResourceException.class, "",
+    assertThrows(MalformedResourceException.class,
         () -> new AuthorizationV4QueryParser(parameters).parseSignature());
 
     // Empty expires
     parameters.put("X-Amz-Expires", "");
-    LambdaTestUtils.intercept(MalformedResourceException.class, "",
+    assertThrows(MalformedResourceException.class,
         () -> new AuthorizationV4QueryParser(parameters).parseSignature());
 
     // Invalid expires
     parameters.put("X-Amz-Expires", "0");
-    LambdaTestUtils.intercept(MalformedResourceException.class, "",
+    assertThrows(MalformedResourceException.class,
         () -> new AuthorizationV4QueryParser(parameters).parseSignature());
     parameters.put("X-Amz-Expires", "604801");
-    LambdaTestUtils.intercept(MalformedResourceException.class, "",
+    assertThrows(MalformedResourceException.class,
         () -> new AuthorizationV4QueryParser(parameters).parseSignature());
 
     // Expired request
     parameters.put("X-Amz-Date", "20160801T083241Z");
     parameters.put("X-Amz-Expires", "10000");
-    LambdaTestUtils.intercept(MalformedResourceException.class, "",
+    assertThrows(MalformedResourceException.class,
         () -> new AuthorizationV4QueryParser(parameters).parseSignature());
 
   }
@@ -155,50 +156,50 @@ public class TestAuthorizationV4QueryParser {
     parameters.put("X-Amz-SignedHeaders", "host");
     parameters.put("X-Amz-Signature",
         "aeeed9bbccd4d02ee5c0109b86d86835f995330da4c265957d157751f604d404");
-    LambdaTestUtils.intercept(MalformedResourceException.class, "",
+    assertThrows(MalformedResourceException.class,
         () -> new AuthorizationV4QueryParser(parameters).parseSignature());
 
     // Empty AWS region
     parameters.put("X-Amz-Credential",
         "AKIAIOSFODNN7EXAMPLE%2F20130524%2F%2Fs3%2Faws4_request");
-    LambdaTestUtils.intercept(MalformedResourceException.class, "",
+    assertThrows(MalformedResourceException.class,
         () -> new AuthorizationV4QueryParser(parameters).parseSignature());
 
     // Empty AWS request
     parameters.put("X-Amz-Credential",
         "AKIAIOSFODNN7EXAMPLE%2F20130524%2Fus-east-1%2Fs3%2F");
-    LambdaTestUtils.intercept(MalformedResourceException.class, "",
+    assertThrows(MalformedResourceException.class,
         () -> new AuthorizationV4QueryParser(parameters).parseSignature());
 
     // Invalid aws request
     parameters.put("X-Amz-Credential",
         "AKIAIOSFODNN7EXAMPLE%2F20130524%2Fus-east-1%2Fs3%2Faws_request");
-    LambdaTestUtils.intercept(MalformedResourceException.class, "",
+    assertThrows(MalformedResourceException.class,
         () -> new AuthorizationV4QueryParser(parameters).parseSignature());
 
     // Empty aws service
     parameters.put("X-Amz-Credential",
         "AKIAIOSFODNN7EXAMPLE%2F20130524%2Fus-east-1%2F%2Faws4_request");
-    LambdaTestUtils.intercept(MalformedResourceException.class, "",
+    assertThrows(MalformedResourceException.class,
         () -> new AuthorizationV4QueryParser(parameters).parseSignature());
 
     // Empty date
     parameters.put("X-Amz-Credential",
         "AKIAIOSFODNN7EXAMPLE%2F%2Fus-east-1%2Fs3%2Faws4_request");
-    LambdaTestUtils.intercept(MalformedResourceException.class, "",
+    assertThrows(MalformedResourceException.class,
         () -> new AuthorizationV4QueryParser(parameters).parseSignature());
 
     // Invalid date format
     parameters.put("X-Amz-Credential",
         "AKIAIOSFODNN7EXAMPLE%2F2013-05-24%2F"
             + "us-east-1%2Fs3%2Faws4_request");
-    LambdaTestUtils.intercept(MalformedResourceException.class, "",
+    assertThrows(MalformedResourceException.class,
         () -> new AuthorizationV4QueryParser(parameters).parseSignature());
 
     // No URL encoding
     parameters.put("X-Amz-Credential",
         "AKIAIOSFODNN7EXAMPLE/20130524/us-east-1/s3/aws4_request");
-    LambdaTestUtils.intercept(MalformedResourceException.class, "",
+    assertThrows(MalformedResourceException.class,
         () -> new AuthorizationV4QueryParser(parameters).parseSignature());
   }
 
@@ -214,12 +215,12 @@ public class TestAuthorizationV4QueryParser {
     parameters.put("X-Amz-Expires", "10000");
     parameters.put("X-Amz-Signature",
         "aeeed9bbccd4d02ee5c0109b86d86835f995330da4c265957d157751f604d404");
-    LambdaTestUtils.intercept(MalformedResourceException.class, "",
+    assertThrows(MalformedResourceException.class,
         () -> new AuthorizationV4QueryParser(parameters).parseSignature());
 
     // Empty Signed Headers
     parameters.put("X-Amz-SignedHeaders", "");
-    LambdaTestUtils.intercept(MalformedResourceException.class, "",
+    assertThrows(MalformedResourceException.class,
         () -> new AuthorizationV4QueryParser(parameters).parseSignature());
   }
 
@@ -235,13 +236,13 @@ public class TestAuthorizationV4QueryParser {
     parameters.put("X-Amz-Expires", "10000");
     parameters.put("X-Amz-SignedHeaders", "host");
     parameters.put("X-Amz-Signature", "");
-    LambdaTestUtils.intercept(MalformedResourceException.class, "",
+    assertThrows(MalformedResourceException.class,
         () -> new AuthorizationV4QueryParser(parameters).parseSignature());
 
     // Invalid Signature
     parameters.put("X-Amz-Signature",
         "aeeed9bbccd4d02ee5c0109b86d86835f995330da4c265957d157751f604d404%");
-    LambdaTestUtils.intercept(MalformedResourceException.class, "",
+    assertThrows(MalformedResourceException.class,
         () -> new AuthorizationV4QueryParser(parameters).parseSignature());
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?
This change is use `JUnit`'s `assertThrow` to assert exception type and their messages and deprecate `LambdaTestUtils#intercept`. `JUnit#assertThrow` provides the same lambda functionality as `LambdaTestUtils#intercept`. `JUnit` is used for unit and integration tests so new dependency is getting added to Ozone.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-9145

## How was this patch tested?
No functional or logical change in source code or test  code. So existing tests to verify the change.
Ran workflow on fork branch few times:
* https://github.com/hemantk-12/ozone/actions/runs/5814451527
* https://github.com/hemantk-12/ozone/actions/runs/5813782303
* https://github.com/hemantk-12/ozone/actions/runs/5813825159