### PR TITLE
HDDS-9149. [Ozone-Streaming] Add Streaming Write Chunk Metrics to datanode

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/impl/StreamDataChannelBase.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/impl/StreamDataChannelBase.java
@@ -139,6 +139,10 @@ abstract class StreamDataChannelBase
     }
   }
 
+  public ContainerMetrics getMetrics() {
+    return metrics;
+  }
+
   @Override
   public String toString() {
     return getClass().getSimpleName() + "{" +


### PR DESCRIPTION


## What changes were proposed in this pull request?

We are not currently recording the metrics of write chunks on the datanode using stream.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-9149