### PR TITLE
HDDS-9142. EC write fails when there are only 5 DNs up with rs-3-2-1024k policy

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/WritableECContainerProvider.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/WritableECContainerProvider.java
@@ -116,8 +116,7 @@ public class WritableECContainerProvider
       }
     }
     List<Pipeline> existingPipelines = pipelineManager.getPipelines(
-        repConfig, Pipeline.PipelineState.OPEN,
-        excludeList.getDatanodes(), excludeList.getPipelineIds());
+        repConfig, Pipeline.PipelineState.OPEN);
     final int pipelineCount = existingPipelines.size();
     LOG.debug("Checking existing pipelines: {}", existingPipelines);
 
@@ -143,7 +142,7 @@ public class WritableECContainerProvider
             pipelineManager.closePipeline(pipeline, true);
             openPipelineCount--;
           } else {
-            if (containerIsExcluded(containerInfo, excludeList)) {
+            if (pipelineIsExcluded(pipeline, containerInfo, excludeList)) {
               existingPipelines.remove(pipelineIndex);
             } else {
               containerInfo.updateLastUsedTime();
@@ -213,9 +212,32 @@ public class WritableECContainerProvider
     return container;
   }
 
-  private boolean containerIsExcluded(ContainerInfo container,
+  /**
+   * Checks if the specified pipeline is excluded. It's excluded if the
+   * specified excludeList contains the specified container associated with
+   * this pipeline, or if it contains this pipeline, or if it contains any
+   * Datanode that is a part of this pipeline.
+   * @param pipeline Pipeline to check
+   * @param container Container associated with this pipeline
+   * @param excludeList Objects to exclude
+   * @return true if excluded, else false
+   */
+  private boolean pipelineIsExcluded(Pipeline pipeline, ContainerInfo container,
       ExcludeList excludeList) {
-    return excludeList.getContainerIds().contains(container.containerID());
+    if (excludeList.getContainerIds().contains(container.containerID())) {
+      return true;
+    }
+    if (excludeList.getPipelineIds().contains(pipeline.getId())) {
+      return true;
+    }
+
+    for (DatanodeDetails dn : pipeline.getNodes()) {
+      if (excludeList.getDatanodes().contains(dn)) {
+        return true;
+      }
+    }
+
+    return false;
   }
 
   private ContainerInfo getContainerFromPipeline(Pipeline pipeline)

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestWritableECContainerProvider.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestWritableECContainerProvider.java
@@ -474,7 +474,44 @@ public class TestWritableECContainerProvider {
     }
   }
 
+  /**
+   * Suppose there's a closed container but its pipeline is still open. This
+   * pipeline is also present in the excludeList. Such a pipeline should not
+   * be included in the count of open pipelines and should be closed.
+   * @see <a href="https://issues.apache.org/jira/browse/HDDS-9142">...</a>
+   */
   @ParameterizedTest
+  @MethodSource("policies")
+  public void testExcludedOpenPipelineWithClosedContainerIsClosed(
+      PipelineChoosePolicy policy) throws IOException {
+    int nodeCount = nodeManager.getNodeCount(
+        org.apache.hadoop.hdds.scm.node.NodeStatus.inServiceHealthy());
+    providerConf.setMinimumPipelines(nodeCount);
+    provider = createSubject(policy);
+    Set<ContainerInfo> allocated = assertDistinctContainers(nodeCount);
+    assertEquals(nodeCount, allocated.size());
+
+    ExcludeList excludeList = new ExcludeList();
+    // close all of these containers
+    for (ContainerInfo container : allocated) {
+      // Remove the container from the pipeline to simulate closing the
+      // container
+      pipelineManager.removeContainerFromPipeline(
+          container.getPipelineID(), container.containerID());
+      excludeList.addPipeline(container.getPipelineID());
+    }
+
+    // expecting a new container to be created
+    ContainerInfo containerInfo = provider.getContainer(1, repConfig, OWNER,
+        excludeList);
+    assertFalse(allocated.contains(containerInfo));
+    for (ContainerInfo c : allocated) {
+      Pipeline pipeline = pipelineManager.getPipeline(c.getPipelineID());
+      assertEquals(CLOSED, pipeline.getPipelineState());
+    }
+  }
+
+    @ParameterizedTest
   @MethodSource("policies")
   public void testExcludedNodesPassedToCreatePipelineIfProvided(
       PipelineChoosePolicy policy) throws IOException {


### PR DESCRIPTION
## What changes were proposed in this pull request?

Check the jira for the problem. The fix is made in `WritableECContainerProvider`:
1. First get all open pipelines from PipelineManager. Then,
2. Close pipelines with closed containers, excluding them and decreasing `openPipelineCount` as required.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-9142

## How was this patch tested?

Added a UT, tested it with and without this patch.