### PR TITLE
HDDS-9148. OM to reject hsync if ozone.fs.hsync.enabled is false

### DIFF
--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/io/KeyOutputStream.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/io/KeyOutputStream.java
@@ -93,7 +93,6 @@ public class KeyOutputStream extends OutputStream implements Syncable {
   private final BlockOutputStreamEntryPool blockOutputStreamEntryPool;
 
   private long clientID;
-  private boolean enableHsync;
 
   public KeyOutputStream(ReplicationConfig replicationConfig,
       ContainerClientMetrics clientMetrics) {
@@ -142,8 +141,7 @@ public class KeyOutputStream extends OutputStream implements Syncable {
       String requestId, ReplicationConfig replicationConfig,
       String uploadID, int partNumber, boolean isMultipart,
       boolean unsafeByteBufferConversion,
-      ContainerClientMetrics clientMetrics,
-      boolean enableHsync
+      ContainerClientMetrics clientMetrics
   ) {
     this.config = config;
     this.replication = replicationConfig;
@@ -164,7 +162,6 @@ public class KeyOutputStream extends OutputStream implements Syncable {
     this.isException = false;
     this.writeOffset = 0;
     this.clientID = handler.getId();
-    this.enableHsync = enableHsync;
   }
 
   /**
@@ -457,10 +454,6 @@ public class KeyOutputStream extends OutputStream implements Syncable {
 
   @Override
   public synchronized void hsync() throws IOException {
-    if (!enableHsync) {
-      throw new UnsupportedOperationException(
-          "Hsync is not enabled. To enable, set ozone.fs.hsync.enabled = true");
-    }
     if (replication.getReplicationType() != ReplicationType.RATIS) {
       throw new UnsupportedOperationException(
           "Replication type is not " + ReplicationType.RATIS);
@@ -592,7 +585,6 @@ public class KeyOutputStream extends OutputStream implements Syncable {
     private OzoneClientConfig clientConfig;
     private ReplicationConfig replicationConfig;
     private ContainerClientMetrics clientMetrics;
-    private boolean enableHsync;
 
     public String getMultipartUploadID() {
       return multipartUploadID;
@@ -684,11 +676,6 @@ public class KeyOutputStream extends OutputStream implements Syncable {
       return this;
     }
 
-    public Builder setEnableHsync(boolean enableHsync) {
-      this.enableHsync = enableHsync;
-      return this;
-    }
-
     public ContainerClientMetrics getClientMetrics() {
       return clientMetrics;
     }
@@ -705,8 +692,7 @@ public class KeyOutputStream extends OutputStream implements Syncable {
           multipartNumber,
           isMultipartKey,
           unsafeByteBufferConversion,
-          clientMetrics,
-          enableHsync);
+          clientMetrics);
     }
 
   }

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/io/OzoneOutputStream.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/io/OzoneOutputStream.java
@@ -115,7 +115,8 @@ public class OzoneOutputStream extends ByteArrayStreamOutput {
       }
       syncable.hsync();
     } else {
-      outputStream.flush();
+      throw new UnsupportedOperationException(outputStream.getClass()
+          + " is not " + Syncable.class.getSimpleName());
     }
   }
 

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/io/OzoneOutputStream.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/io/OzoneOutputStream.java
@@ -93,8 +93,7 @@ public class OzoneOutputStream extends ByteArrayStreamOutput {
       }
       syncable.hsync();
     } else {
-      throw new UnsupportedOperationException(outputStream.getClass()
-          + " is not " + Syncable.class.getSimpleName());
+      outputStream.flush();
     }
   }
 

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/io/OzoneOutputStream.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/io/OzoneOutputStream.java
@@ -39,6 +39,7 @@ public class OzoneOutputStream extends ByteArrayStreamOutput {
    * Constructs an instance with a {@link Syncable} {@link OutputStream}.
    *
    * @param outputStream an {@link OutputStream} which is {@link Syncable}.
+   * @param enableHsync if false, hsync() executes flush() instead.
    */
   public OzoneOutputStream(Syncable outputStream, boolean enableHsync) {
     this(Optional.of(Objects.requireNonNull(outputStream,
@@ -48,6 +49,18 @@ public class OzoneOutputStream extends ByteArrayStreamOutput {
         .orElseThrow(() -> new IllegalArgumentException(
             "The parameter syncable is not an OutputStream")),
         outputStream, enableHsync);
+  }
+
+  /**
+   * Constructs an instance with a (non-{@link Syncable}) {@link OutputStream}
+   * with an optional {@link Syncable} object.
+   *
+   * @param outputStream for writing data.
+   * @param syncable an optional parameter
+   *                 for accessing the {@link Syncable} feature.
+   */
+  public OzoneOutputStream(OutputStream outputStream, Syncable syncable) {
+    this(outputStream, syncable, false);
   }
 
   /**
@@ -91,6 +104,7 @@ public class OzoneOutputStream extends ByteArrayStreamOutput {
   }
 
   public void hsync() throws IOException {
+    // Disable the feature flag restores the prior behavior.
     if (!enableHsync) {
       outputStream.flush();
       return;

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/rpc/RpcClient.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/rpc/RpcClient.java
@@ -2260,12 +2260,17 @@ public class RpcClient implements ClientProtocol {
         .setReplicationConfig(replicationConfig);
     }
 
+    boolean enableHsync = conf.getBoolean(
+        OzoneConfigKeys.OZONE_FS_HSYNC_ENABLED,
+        OzoneConfigKeys.OZONE_FS_HSYNC_ENABLED_DEFAULT);
+
     return builder.setHandler(openKey)
         .setXceiverClientManager(xceiverClientManager)
         .setOmClient(ozoneManagerClient)
         .enableUnsafeByteBufferConversion(unsafeByteBufferConversion)
         .setConfig(conf.getObject(OzoneClientConfig.class))
-        .setClientMetrics(clientMetrics);
+        .setClientMetrics(clientMetrics)
+        .setEnableHsync(enableHsync);
   }
 
   @Override

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/rpc/RpcClient.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/rpc/RpcClient.java
@@ -2210,12 +2210,16 @@ public class RpcClient implements ClientProtocol {
   private OzoneOutputStream createOutputStream(OpenKeySession openKey,
       KeyOutputStream keyOutputStream)
       throws IOException {
+    boolean enableHsync = conf.getBoolean(
+        OzoneConfigKeys.OZONE_FS_HSYNC_ENABLED,
+        OzoneConfigKeys.OZONE_FS_HSYNC_ENABLED_DEFAULT);
     keyOutputStream
         .addPreallocateBlocks(openKey.getKeyInfo().getLatestVersionLocations(),
             openKey.getOpenVersion());
     final OzoneOutputStream out = createSecureOutputStream(
         openKey, keyOutputStream, keyOutputStream);
-    return out != null ? out : new OzoneOutputStream(keyOutputStream);
+    return out != null ? out : new OzoneOutputStream(
+        keyOutputStream, enableHsync);
   }
 
   private OzoneOutputStream createSecureOutputStream(OpenKeySession openKey,

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestHSync.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestHSync.java
@@ -436,6 +436,8 @@ public class TestHSync {
             () -> outputStream.hsync());
       }
     }
+    // re-enable the feature flag
+    CONF.setBoolean(OzoneConfigKeys.OZONE_FS_HSYNC_ENABLED, true);
   }
 
   private void testEncryptedStreamCapabilities(boolean isEC) throws IOException,

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestHSync.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestHSync.java
@@ -19,6 +19,7 @@
 package org.apache.hadoop.fs.ozone;
 
 import java.io.Closeable;
+import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.security.GeneralSecurityException;
 import java.security.PrivilegedExceptionAction;
@@ -53,7 +54,6 @@ import org.apache.hadoop.ozone.client.OzoneClient;
 import org.apache.hadoop.ozone.client.io.ECKeyOutputStream;
 import org.apache.hadoop.ozone.client.io.KeyOutputStream;
 import org.apache.hadoop.ozone.client.io.OzoneOutputStream;
-import org.apache.hadoop.ozone.om.exceptions.OMException;
 import org.apache.hadoop.ozone.om.helpers.BucketLayout;
 
 import org.apache.hadoop.security.UserGroupInformation;
@@ -434,7 +434,9 @@ public class TestHSync {
     try (FileSystem fs = FileSystem.get(CONF)) {
       final Path file = new Path(dir, "file");
       try (FSDataOutputStream outputStream = fs.create(file, true)) {
-        assertThrows(OMException.class, () -> outputStream.hsync());
+        outputStream.hsync();
+        assertThrows(FileNotFoundException.class,
+            () -> fs.getFileStatus(file));
       }
     } finally {
       // re-enable the feature flag

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestHSync.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestHSync.java
@@ -415,6 +415,29 @@ public class TestHSync {
     testEncryptedStreamCapabilities(true);
   }
 
+  @Test
+  public void testThrowUnsupportedException() throws Exception {
+    // Set the fs.defaultFS
+    final String rootPath = String.format("%s://%s/",
+        OZONE_OFS_URI_SCHEME, CONF.get(OZONE_OM_ADDRESS_KEY));
+    CONF.set(CommonConfigurationKeysPublic.FS_DEFAULT_NAME_KEY, rootPath);
+    CONF.setBoolean(OzoneConfigKeys.OZONE_FS_HSYNC_ENABLED, false);
+
+    final String dir = OZONE_ROOT + bucket.getVolumeName()
+        + OZONE_URI_DELIMITER + bucket.getName();
+
+    final byte[] data = new byte[1];
+    ThreadLocalRandom.current().nextBytes(data);
+
+    try (FileSystem fs = FileSystem.get(CONF)) {
+      final Path file = new Path(dir, "file");
+      try (FSDataOutputStream outputStream = fs.create(file, true)) {
+        assertThrows(UnsupportedOperationException.class,
+            () -> outputStream.hsync());
+      }
+    }
+  }
+
   private void testEncryptedStreamCapabilities(boolean isEC) throws IOException,
       GeneralSecurityException {
     KeyOutputStream kos;

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestHSync.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestHSync.java
@@ -432,7 +432,7 @@ public class TestHSync {
     ThreadLocalRandom.current().nextBytes(data);
 
     try (FileSystem fs = FileSystem.get(CONF)) {
-      final Path file = new Path(dir, "file");
+      final Path file = new Path(dir, "file_hsync_disable");
       try (FSDataOutputStream outputStream = fs.create(file, true)) {
         outputStream.hsync();
         assertThrows(FileNotFoundException.class,

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestHSync.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestHSync.java
@@ -457,7 +457,7 @@ public class TestHSync {
     when(codec.createEncryptor()).thenReturn(encryptor);
     CryptoOutputStream cos =
         new CryptoOutputStream(kos, codec, new byte[0], new byte[0]);
-    OzoneOutputStream oos = new OzoneOutputStream(cos);
+    OzoneOutputStream oos = new OzoneOutputStream(cos, true);
     OzoneFSOutputStream ofso = new OzoneFSOutputStream(oos);
 
     try (CapableOzoneFSOutputStream cofsos =

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestLeaseRecovery.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestLeaseRecovery.java
@@ -26,6 +26,7 @@ import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.utils.IOUtils;
 import org.apache.hadoop.ozone.MiniOzoneCluster;
+import org.apache.hadoop.ozone.OzoneConfigKeys;
 import org.apache.hadoop.ozone.TestDataUtil;
 import org.apache.hadoop.ozone.client.OzoneBucket;
 import org.apache.hadoop.ozone.client.OzoneClient;
@@ -75,6 +76,7 @@ public class TestLeaseRecovery {
     final BucketLayout layout = BucketLayout.FILE_SYSTEM_OPTIMIZED;
 
     conf.setBoolean(OZONE_OM_RATIS_ENABLE_KEY, false);
+    conf.setBoolean(OzoneConfigKeys.OZONE_FS_HSYNC_ENABLED, true);
     conf.set(OZONE_DEFAULT_BUCKET_LAYOUT, layout.name());
     cluster = MiniOzoneCluster.newBuilder(conf)
       .setNumDatanodes(5)

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFileSystem.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFileSystem.java
@@ -42,6 +42,7 @@ import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.hdds.utils.IOUtils;
 import org.apache.hadoop.ozone.MiniOzoneCluster;
+import org.apache.hadoop.ozone.OzoneConfigKeys;
 import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.hadoop.ozone.TestDataUtil;
 import org.apache.hadoop.ozone.client.OzoneBucket;
@@ -181,6 +182,7 @@ public class TestOzoneFileSystem {
 
     conf.setBoolean(OMConfigKeys.OZONE_OM_RATIS_ENABLE_KEY, omRatisEnabled);
     conf.setBoolean(OZONE_ACL_ENABLED, true);
+    conf.setBoolean(OzoneConfigKeys.OZONE_FS_HSYNC_ENABLED, true);
     if (!bucketLayout.equals(BucketLayout.FILE_SYSTEM_OPTIMIZED)) {
       conf.setBoolean(OMConfigKeys.OZONE_OM_ENABLE_FILESYSTEM_PATHS,
           enabledFileSystemPaths);

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestRootedOzoneFileSystem.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestRootedOzoneFileSystem.java
@@ -246,6 +246,7 @@ public class TestRootedOzoneFileSystem {
     conf.setFloat(FS_TRASH_INTERVAL_KEY, TRASH_INTERVAL);
     conf.setFloat(FS_TRASH_CHECKPOINT_INTERVAL_KEY, TRASH_INTERVAL / 2);
     conf.setBoolean(OMConfigKeys.OZONE_OM_RATIS_ENABLE_KEY, omRatisEnabled);
+    conf.setBoolean(OzoneConfigKeys.OZONE_FS_HSYNC_ENABLED, true);
     if (isBucketFSOptimized) {
       bucketLayout = BucketLayout.FILE_SYSTEM_OPTIMIZED;
       conf.set(OMConfigKeys.OZONE_DEFAULT_BUCKET_LAYOUT,

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/debug/TestLeaseRecoverer.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/debug/TestLeaseRecoverer.java
@@ -37,6 +37,7 @@ import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.utils.IOUtils;
 import org.apache.hadoop.ozone.MiniOzoneCluster;
+import org.apache.hadoop.ozone.OzoneConfigKeys;
 import org.apache.hadoop.ozone.TestDataUtil;
 import org.apache.hadoop.ozone.client.OzoneBucket;
 import org.apache.hadoop.ozone.client.OzoneClient;
@@ -70,6 +71,7 @@ public class TestLeaseRecoverer {
   @BeforeClass
   public static void init() throws Exception {
     conf = new OzoneConfiguration();
+    conf.setBoolean(OzoneConfigKeys.OZONE_FS_HSYNC_ENABLED, true);
     String clusterId = UUID.randomUUID().toString();
     String scmId = UUID.randomUUID().toString();
     String omId = UUID.randomUUID().toString();

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMKeyCommitRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMKeyCommitRequest.java
@@ -26,7 +26,10 @@ import java.util.Map;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
+import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import org.apache.hadoop.ozone.OzoneConfigKeys;
 import org.apache.hadoop.ozone.OzoneConsts;
+import org.apache.hadoop.ozone.om.exceptions.OMException;
 import org.apache.hadoop.ozone.om.helpers.BucketLayout;
 import org.apache.hadoop.ozone.om.helpers.OmBucketInfo;
 import org.apache.hadoop.ozone.om.helpers.OzoneFSUtils;
@@ -51,6 +54,8 @@ import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos
     .KeyLocation;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos
     .OMRequest;
+
+import static org.junit.Assert.assertThrows;
 
 /**
  * Class tests OMKeyCommitRequest class.
@@ -296,6 +301,24 @@ public class TestOMKeyCommitRequest extends TestOMKeyRequest {
         omKeyInfo.getLatestVersionLocations().getLocationList());
     Assert.assertEquals(3, intersection.size());
 
+  }
+
+  @Test
+  public void testRejectHsyncIfNotEnabled() throws Exception {
+    OzoneConfiguration conf = ozoneManager.getConfiguration();
+    conf.setBoolean(OzoneConfigKeys.OZONE_FS_HSYNC_ENABLED, false);
+    BucketLayout bucketLayout = getBucketLayout();
+    String bucketKey = omMetadataManager.getBucketKey(volumeName, bucketName);
+
+    OMRequestTestUtils.addVolumeAndBucketToDB(volumeName, bucketName,
+        omMetadataManager, bucketLayout);
+    List<KeyLocation> allocatedKeyLocationList = getKeyLocation(10);
+    OmBucketInfo bucketInfo = omMetadataManager.getBucketTable()
+        .get(bucketKey);
+
+    assertThrows(OMException.class, () ->
+        performHsyncCommit(allocatedKeyLocationList.subList(0, 5)));
+    conf.setBoolean(OzoneConfigKeys.OZONE_FS_HSYNC_ENABLED, true);
   }
 
   @Test

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMKeyCommitRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMKeyCommitRequest.java
@@ -308,7 +308,6 @@ public class TestOMKeyCommitRequest extends TestOMKeyRequest {
     OzoneConfiguration conf = ozoneManager.getConfiguration();
     conf.setBoolean(OzoneConfigKeys.OZONE_FS_HSYNC_ENABLED, false);
     BucketLayout bucketLayout = getBucketLayout();
-    String bucketKey = omMetadataManager.getBucketKey(volumeName, bucketName);
 
     OMRequestTestUtils.addVolumeAndBucketToDB(volumeName, bucketName,
         omMetadataManager, bucketLayout);

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMKeyCommitRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMKeyCommitRequest.java
@@ -313,8 +313,6 @@ public class TestOMKeyCommitRequest extends TestOMKeyRequest {
     OMRequestTestUtils.addVolumeAndBucketToDB(volumeName, bucketName,
         omMetadataManager, bucketLayout);
     List<KeyLocation> allocatedKeyLocationList = getKeyLocation(10);
-    OmBucketInfo bucketInfo = omMetadataManager.getBucketTable()
-        .get(bucketKey);
 
     assertThrows(OMException.class, () ->
         performHsyncCommit(allocatedKeyLocationList.subList(0, 5)));

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMKeyRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMKeyRequest.java
@@ -133,6 +133,7 @@ public class TestOMKeyRequest {
         folder.newFolder().getAbsolutePath());
     ozoneConfiguration.set(OzoneConfigKeys.OZONE_METADATA_DIRS,
         folder.newFolder().getAbsolutePath());
+    ozoneConfiguration.setBoolean(OzoneConfigKeys.OZONE_FS_HSYNC_ENABLED, true);
     omMetadataManager = new OmMetadataManagerImpl(ozoneConfiguration,
         ozoneManager);
     when(ozoneManager.getMetrics()).thenReturn(omMetrics);

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/service/TestOpenKeyCleanupService.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/service/TestOpenKeyCleanupService.java
@@ -26,6 +26,7 @@ import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.hdds.scm.container.common.helpers.ExcludeList;
 import org.apache.hadoop.hdds.server.ServerUtils;
 import org.apache.hadoop.hdds.utils.db.DBConfigFromFile;
+import org.apache.hadoop.ozone.OzoneConfigKeys;
 import org.apache.hadoop.ozone.om.ExpiredOpenKeys;
 import org.apache.hadoop.ozone.om.KeyManager;
 import org.apache.hadoop.ozone.om.OMMetadataManager;
@@ -98,6 +99,7 @@ public class TestOpenKeyCleanupService {
         SERVICE_INTERVAL.toMillis(), TimeUnit.MILLISECONDS);
     conf.setTimeDuration(OZONE_OM_OPEN_KEY_EXPIRE_THRESHOLD,
         EXPIRE_THRESHOLD.toMillis(), TimeUnit.MILLISECONDS);
+    conf.setBoolean(OzoneConfigKeys.OZONE_FS_HSYNC_ENABLED, true);
     conf.setQuietMode(false);
     OmTestManagers omTestManagers = new OmTestManagers(conf);
     keyManager = omTestManagers.getKeyManager();


### PR DESCRIPTION
## What changes were proposed in this pull request?

1. OM rejects hsync request if ozone.fs.hsync.enabled is false (which is the default value).
2. Client hsync() actually calls flush() if ozone.fs.hsync.enabled is false. This is the original behavior prior to the hsync implementation.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-9148

## How was this patch tested?

Unit tests in client and OM side.