### PR TITLE
HDDS-9157. [Snapshot] Print correct snapshot path in `fs -createSnapshot`

### DIFF
--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OzoneFSUtils.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OzoneFSUtils.java
@@ -284,4 +284,12 @@ public final class OzoneFSUtils {
   public static String generateUniqueTempSnapshotName() {
     return "temp" + UUID.randomUUID() + SnapshotInfo.generateName(Time.now());
   }
+
+  public static Path trimPathToDepth(Path path, int maxDepth) {
+    Path res = path;
+    while (res.depth() > maxDepth) {
+      res = res.getParent();
+    }
+    return res;
+  }
 }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/snapshot/OMSnapshotCreateRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/snapshot/OMSnapshotCreateRequest.java
@@ -188,7 +188,7 @@ public class OMSnapshotCreateRequest extends OMClientRequest {
     // Performing audit logging outside the lock.
     auditLog(auditLogger, buildAuditMessage(OMAction.CREATE_SNAPSHOT,
         snapshotInfo.toAuditMap(), exception, userInfo));
-    
+
     if (exception == null) {
       LOG.info("Created snapshot: '{}' with snapshotId: '{}' under path '{}'",
           snapshotName, snapshotInfo.getSnapshotId(), snapshotPath);

--- a/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicOzoneFileSystem.java
+++ b/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicOzoneFileSystem.java
@@ -936,7 +936,8 @@ public class BasicOzoneFileSystem extends FileSystem {
   @Override
   public Path createSnapshot(Path path, String snapshotName)
           throws IOException {
-    String snapshot = adapter.createSnapshot(pathToKey(path), snapshotName);
+    String snapshot = getAdapter()
+        .createSnapshot(pathToKey(path), snapshotName);
     return new Path(OzoneFSUtils.trimPathToDepth(path, PATH_DEPTH_TO_BUCKET),
         OM_SNAPSHOT_INDICATOR + OZONE_URI_DELIMITER + snapshot);
   }

--- a/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicOzoneFileSystem.java
+++ b/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicOzoneFileSystem.java
@@ -128,6 +128,8 @@ public class BasicOzoneFileSystem extends FileSystem {
       "o3fs://bucket.volume.om-host.example.com:5678/key  OR " +
       "o3fs://bucket.volume.omServiceId/key";
 
+  private static final int PATH_DEPTH_TO_BUCKET = 0;
+
   @Override
   public void initialize(URI name, Configuration conf) throws IOException {
     super.initialize(name, conf);
@@ -935,7 +937,7 @@ public class BasicOzoneFileSystem extends FileSystem {
   public Path createSnapshot(Path path, String snapshotName)
           throws IOException {
     String snapshot = adapter.createSnapshot(pathToKey(path), snapshotName);
-    return new Path(path,
+    return new Path(OzoneFSUtils.trimPathToDepth(path, PATH_DEPTH_TO_BUCKET),
         OM_SNAPSHOT_INDICATOR + OZONE_URI_DELIMITER + snapshot);
   }
 

--- a/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicRootedOzoneFileSystem.java
+++ b/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicRootedOzoneFileSystem.java
@@ -511,7 +511,8 @@ public class BasicRootedOzoneFileSystem extends FileSystem {
   @Override
   public Path createSnapshot(Path path, String snapshotName)
           throws IOException {
-    String snapshot = adapter.createSnapshot(pathToKey(path), snapshotName);
+    String snapshot = getAdapter()
+        .createSnapshot(pathToKey(path), snapshotName);
     return new Path(OzoneFSUtils.trimPathToDepth(path, PATH_DEPTH_TO_BUCKET),
         OM_SNAPSHOT_INDICATOR + OZONE_URI_DELIMITER + snapshot);
   }

--- a/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicRootedOzoneFileSystem.java
+++ b/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicRootedOzoneFileSystem.java
@@ -127,6 +127,8 @@ public class BasicRootedOzoneFileSystem extends FileSystem {
       "ofs://om-host.example.com/path/to/key  OR " +
       "ofs://om-host.example.com:5678/path/to/key";
 
+  private static final int PATH_DEPTH_TO_BUCKET = 2;
+
   @Override
   public void initialize(URI name, Configuration conf) throws IOException {
     super.initialize(name, conf);
@@ -510,7 +512,7 @@ public class BasicRootedOzoneFileSystem extends FileSystem {
   public Path createSnapshot(Path path, String snapshotName)
           throws IOException {
     String snapshot = adapter.createSnapshot(pathToKey(path), snapshotName);
-    return new Path(path,
+    return new Path(OzoneFSUtils.trimPathToDepth(path, PATH_DEPTH_TO_BUCKET),
         OM_SNAPSHOT_INDICATOR + OZONE_URI_DELIMITER + snapshot);
   }
 

--- a/hadoop-ozone/ozonefs-common/src/test/java/org/apache/hadoop/fs/ozone/TestBasicOzoneFileSystems.java
+++ b/hadoop-ozone/ozonefs-common/src/test/java/org/apache/hadoop/fs/ozone/TestBasicOzoneFileSystems.java
@@ -26,13 +26,17 @@ import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
+import org.mockito.Mockito;
 
+import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collection;
 
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_SCM_BLOCK_SIZE;
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_SCM_BLOCK_SIZE_DEFAULT;
+import static org.apache.hadoop.ozone.OzoneConsts.OM_SNAPSHOT_INDICATOR;
 import static org.junit.Assert.assertEquals;
+import static org.mockito.Matchers.any;
 
 /**
  * Unit test for Basic*OzoneFileSystem.
@@ -76,10 +80,61 @@ public class TestBasicOzoneFileSystems {
   // test for filesystem pseduo-posix symlink support
   @Test
   public void testFileSystemPosixSymlinkSupport() {
-    if (subject.getClass() == BasicRootedOzoneFileSystem.class) {
+    if (subject instanceof BasicRootedOzoneFileSystem) {
       Assert.assertTrue(subject.supportsSymlinks());
-    } else {
+    } else if (subject instanceof BasicOzoneFileSystem) {
       Assert.assertFalse(subject.supportsSymlinks());
+    } else {
+      Assert.fail("Test case not implemented for FileSystem: " +
+          subject.getClass().getSimpleName());
+    }
+  }
+
+  @Test
+  public void testCreateSnapshotReturnPath() throws IOException {
+    final String snapshotName = "snap1";
+
+    if (subject instanceof BasicRootedOzoneFileSystem) {
+      BasicRootedOzoneClientAdapterImpl adapter =
+          Mockito.mock(BasicRootedOzoneClientAdapterImpl.class);
+      Mockito.doReturn(snapshotName).when(adapter).createSnapshot(any(), any());
+
+      BasicRootedOzoneFileSystem ofs =
+          Mockito.spy((BasicRootedOzoneFileSystem) subject);
+      Mockito.doReturn(adapter).when(ofs).getAdapter();
+
+      Path ofsBucketStr = new Path("ofs://om/vol1/buck1/");
+      Path ofsDir1 = new Path(ofsBucketStr, "dir1");
+      Path res = ofs.createSnapshot(new Path(ofsDir1, snapshotName));
+
+      Path expectedSnapshotRoot = new Path(ofsBucketStr, OM_SNAPSHOT_INDICATOR);
+      Path expectedSnapshotPath = new Path(expectedSnapshotRoot, snapshotName);
+
+      // Return value path should be "ofs://om/vol1/buck1/.snapshot/snap1"
+      // without the subdirectory "dir1" in the Path.
+      Assert.assertEquals(expectedSnapshotPath, res);
+    } else if (subject instanceof BasicOzoneFileSystem) {
+      BasicOzoneClientAdapterImpl adapter =
+          Mockito.mock(BasicOzoneClientAdapterImpl.class);
+      Mockito.doReturn(snapshotName).when(adapter).createSnapshot(any(), any());
+
+      BasicOzoneFileSystem o3fs = Mockito.spy((BasicOzoneFileSystem) subject);
+      Mockito.doReturn(adapter).when(o3fs).getAdapter();
+
+      Path o3fsBucketStr = new Path("o3fs://buck1.vol1.om/");
+      Path o3fsDir1 = new Path(o3fsBucketStr, "dir1");
+      Path res = o3fs.createSnapshot(new Path(o3fsDir1, snapshotName));
+
+      Path expectedSnapshotRoot =
+          new Path(o3fsBucketStr, OM_SNAPSHOT_INDICATOR);
+      Path expectedSnapshotPath = new Path(expectedSnapshotRoot, snapshotName);
+
+      // Return value path should be "o3fs://buck1.vol1.om/.snapshot/snap1"
+      // without the subdirectory "dir1" in the Path.
+      Assert.assertEquals(expectedSnapshotPath, res);
+    } else {
+      Assert.fail("Test case not implemented for FileSystem: " +
+          subject.getClass().getSimpleName());
     }
   }
 

--- a/hadoop-ozone/ozonefs-common/src/test/java/org/apache/hadoop/fs/ozone/TestBasicOzoneFileSystems.java
+++ b/hadoop-ozone/ozonefs-common/src/test/java/org/apache/hadoop/fs/ozone/TestBasicOzoneFileSystems.java
@@ -101,7 +101,7 @@ public class TestBasicOzoneFileSystems {
 
       BasicRootedOzoneFileSystem ofs =
           Mockito.spy((BasicRootedOzoneFileSystem) subject);
-      Mockito.doReturn(adapter).when(ofs).getAdapter();
+      Mockito.when(ofs.getAdapter()).thenReturn(adapter);
 
       Path ofsBucketStr = new Path("ofs://om/vol1/buck1/");
       Path ofsDir1 = new Path(ofsBucketStr, "dir1");
@@ -119,7 +119,7 @@ public class TestBasicOzoneFileSystems {
       Mockito.doReturn(snapshotName).when(adapter).createSnapshot(any(), any());
 
       BasicOzoneFileSystem o3fs = Mockito.spy((BasicOzoneFileSystem) subject);
-      Mockito.doReturn(adapter).when(o3fs).getAdapter();
+      Mockito.when(o3fs.getAdapter()).thenReturn(adapter);
 
       Path o3fsBucketStr = new Path("o3fs://buck1.vol1.om/");
       Path o3fsDir1 = new Path(o3fsBucketStr, "dir1");


### PR DESCRIPTION
## What changes were proposed in this pull request?

- Correctly print snapshot path when subdirectories are specified during snapshot creation with `fs -createSnapshot`.

cc @hemantk-12 

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-9157

## How was this patch tested?

- Added new test case in `TestOzoneFsSnapshot`.