### PR TITLE
HDDS-9147. Removed await from LambdaTestUtils and replaced it with Awaitility#await 

### DIFF
--- a/hadoop-hdds/common/pom.xml
+++ b/hadoop-hdds/common/pom.xml
@@ -194,6 +194,11 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.awaitility</groupId>
+      <artifactId>awaitility</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>io.jaegertracing</groupId>
       <artifactId>jaeger-client</artifactId>
     </dependency>

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/upgrade/TestDatanodeUpgradeToScmHA.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/upgrade/TestDatanodeUpgradeToScmHA.java
@@ -42,7 +42,6 @@ import org.apache.hadoop.ozone.container.keyvalue.KeyValueContainerData;
 import org.apache.hadoop.ozone.container.replication.ContainerImporter;
 import org.apache.hadoop.ozone.container.replication.ContainerReplicationSource;
 import org.apache.hadoop.ozone.container.replication.OnDemandContainerReplicationSource;
-import org.apache.ozone.test.LambdaTestUtils;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -58,6 +57,7 @@ import java.net.InetSocketAddress;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -70,6 +70,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 
 import static org.apache.hadoop.ozone.container.replication.CopyContainerCompression.NO_COMPRESSION;
+import static org.awaitility.Awaitility.await;
 
 /**
  * Tests upgrading a single datanode from pre-SCM HA volume format that used
@@ -264,9 +265,11 @@ public class TestDatanodeUpgradeToScmHA {
         .getContainer(containerID).getContainerState();
     Assert.assertEquals(State.UNHEALTHY, containerState);
     dsm.finalizeUpgrade();
-    LambdaTestUtils.await(2000, 500,
-        () -> dsm.getLayoutVersionManager()
-            .isAllowed(HDDSLayoutFeature.SCM_HA));
+
+    await().atMost(Duration.ofMillis(2000))
+        .pollInterval(Duration.ofMillis(500))
+        .until(() ->
+            dsm.getLayoutVersionManager().isAllowed(HDDSLayoutFeature.SCM_HA));
 
     /// FINALIZED: Volume marked failed but gets restored on disk ///
 
@@ -371,9 +374,10 @@ public class TestDatanodeUpgradeToScmHA {
 
     closeContainer(containerID, pipeline);
     dsm.finalizeUpgrade();
-    LambdaTestUtils.await(2000, 500,
-        () -> dsm.getLayoutVersionManager()
-            .isAllowed(HDDSLayoutFeature.SCM_HA));
+    await().atMost(Duration.ofMillis(2000))
+        .pollInterval(Duration.ofMillis(500))
+        .until(() ->
+            dsm.getLayoutVersionManager().isAllowed(HDDSLayoutFeature.SCM_HA));
 
     /// FINALIZED: Add a new volume and check its formatting ///
 

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/placement/algorithms/TestSCMContainerPlacementRackScatter.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/placement/algorithms/TestSCMContainerPlacementRackScatter.java
@@ -65,7 +65,7 @@ import static org.apache.hadoop.hdds.scm.net.NetConstants.LEAF_SCHEMA;
 import static org.apache.hadoop.hdds.scm.net.NetConstants.RACK_SCHEMA;
 import static org.apache.hadoop.hdds.scm.net.NetConstants.ROOT_SCHEMA;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.matchesPattern;
+import static org.hamcrest.text.MatchesPattern.matchesPattern;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;

--- a/hadoop-ozone/common/pom.xml
+++ b/hadoop-ozone/common/pom.xml
@@ -94,6 +94,11 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.awaitility</groupId>
+      <artifactId>awaitility</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.apache.ozone</groupId>
       <artifactId>hdds-hadoop-dependency-test</artifactId>
       <scope>test</scope>

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestMultiRaftSetup.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestMultiRaftSetup.java
@@ -29,16 +29,18 @@ import org.apache.hadoop.hdds.scm.node.NodeManager;
 import org.apache.hadoop.hdds.scm.server.StorageContainerManager;
 import org.apache.hadoop.ozone.MiniOzoneCluster;
 
-import org.apache.ozone.test.LambdaTestUtils;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
+import java.time.Duration;
 import java.util.List;
 import java.util.Collection;
 import java.util.ArrayList;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
+
+import static org.awaitility.Awaitility.await;
 
 /**
  * Tests for MultiRaft set up.
@@ -158,12 +160,9 @@ public class  TestMultiRaftSetup {
     });
   }
 
-  private void waitForPipelineCreated(int num) throws Exception {
-    LambdaTestUtils.await(10000, 500, () -> {
-      List<Pipeline> pipelines =
-          pipelineManager.getPipelines(RATIS_THREE);
-      return pipelines.size() == num;
-    });
+  private void waitForPipelineCreated(int num) {
+    await().atMost(Duration.ofSeconds(10))
+        .pollInterval(Duration.ofMillis(500))
+        .until(() -> pipelineManager.getPipelines(RATIS_THREE).size() == num);
   }
-
 }

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/api/TestEndpoints.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/api/TestEndpoints.java
@@ -24,15 +24,13 @@ import org.apache.hadoop.hdds.client.RatisReplicationConfig;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
-import org.apache.hadoop.hdds.protocol.proto.HddsProtos
-    .ExtendedDatanodeDetailsProto;
+import org.apache.hadoop.hdds.protocol.proto.HddsProtos.ExtendedDatanodeDetailsProto;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos.NodeOperationalState;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos.NodeState;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos.LifeCycleState;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos.PipelineID;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationFactor;
-import org.apache.hadoop.hdds.protocol.proto
-    .StorageContainerDatanodeProtocolProtos.LayoutVersionProto;
+import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.LayoutVersionProto;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.ContainerReplicaProto;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.PipelineReport;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.SCMHeartbeatRequestProto;
@@ -78,7 +76,6 @@ import org.apache.hadoop.ozone.recon.tasks.ContainerSizeCountTask;
 import org.apache.hadoop.ozone.recon.tasks.FileSizeCountTask;
 import org.apache.hadoop.ozone.recon.tasks.OmTableInsightTask;
 import org.apache.ozone.test.GenericTestUtils;
-import org.apache.ozone.test.LambdaTestUtils;
 import org.hadoop.ozone.recon.schema.UtilizationSchemaDefinition;
 import org.hadoop.ozone.recon.schema.tables.daos.ContainerCountBySizeDao;
 import org.hadoop.ozone.recon.schema.tables.daos.FileCountBySizeDao;
@@ -100,6 +97,7 @@ import static org.apache.hadoop.ozone.recon.OMMetadataManagerTestUtils.initializ
 import static org.apache.hadoop.ozone.recon.OMMetadataManagerTestUtils.writeDataToOm;
 import static org.apache.hadoop.ozone.recon.OMMetadataManagerTestUtils.writeDeletedKeysToOm;
 import static org.apache.hadoop.ozone.recon.spi.impl.PrometheusServiceProviderImpl.PROMETHEUS_INSTANT_QUERY_API;
+import static org.awaitility.Awaitility.await;
 import static org.hadoop.ozone.recon.schema.tables.GlobalStatsTable.GLOBAL_STATS;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -121,6 +119,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.net.HttpURLConnection;
 import java.net.URI;
+import java.time.Duration;
 import java.util.Arrays;
 import java.util.ArrayList;
 import java.util.LinkedList;
@@ -828,7 +827,9 @@ public class TestEndpoints extends AbstractReconSqlDBTest {
             .setDataNodeLayoutVersion(defaultLayoutVersionProto())
             .build();
     reconScm.getDatanodeProtocolServer().sendHeartbeat(heartbeatRequestProto);
-    LambdaTestUtils.await(30000, 1000, check);
+    await().atMost(Duration.ofSeconds(30))
+        .pollInterval(Duration.ofSeconds(1))
+        .until(check);
   }
 
   private BucketLayout getBucketLayout() {

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/api/TestOpenContainerCount.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/api/TestOpenContainerCount.java
@@ -22,8 +22,7 @@ import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.hadoop.hdds.client.RatisReplicationConfig;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
-import org.apache.hadoop.hdds.protocol.proto.HddsProtos
-        .ExtendedDatanodeDetailsProto;
+import org.apache.hadoop.hdds.protocol.proto.HddsProtos.ExtendedDatanodeDetailsProto;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos.LifeCycleState;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos.PipelineID;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationFactor;
@@ -55,7 +54,6 @@ import org.apache.hadoop.ozone.recon.spi.StorageContainerServiceProvider;
 import org.apache.hadoop.ozone.recon.spi.impl.OzoneManagerServiceProviderImpl;
 import org.apache.hadoop.ozone.recon.spi.impl.StorageContainerServiceProviderImpl;
 import org.apache.ozone.test.GenericTestUtils;
-import org.apache.ozone.test.LambdaTestUtils;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
@@ -67,6 +65,7 @@ import static org.apache.hadoop.ozone.container.upgrade.UpgradeUtils.defaultLayo
 import static org.apache.hadoop.ozone.recon.OMMetadataManagerTestUtils.getRandomPipeline;
 import static org.apache.hadoop.ozone.recon.OMMetadataManagerTestUtils.getTestReconOmMetadataManager;
 import static org.apache.hadoop.ozone.recon.OMMetadataManagerTestUtils.initializeNewOmMetadataManager;
+import static org.awaitility.Awaitility.await;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -78,6 +77,7 @@ import javax.ws.rs.core.Response;
 
 import java.io.IOException;
 import java.net.HttpURLConnection;
+import java.time.Duration;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.UUID;
@@ -116,8 +116,8 @@ public class TestOpenContainerCount {
 
   private void initializeInjector() throws Exception {
     reconOMMetadataManager = getTestReconOmMetadataManager(
-            initializeNewOmMetadataManager(temporaryFolder.newFolder()),
-            temporaryFolder.newFolder());
+        initializeNewOmMetadataManager(temporaryFolder.newFolder()),
+        temporaryFolder.newFolder());
     datanodeDetails = randomDatanodeDetails();
     datanodeDetails.setHostName(HOST1);
     datanodeDetails.setIpAddress(IP1);
@@ -128,31 +128,31 @@ public class TestOpenContainerCount {
     pipelineId2 = pipeline2.getId().getId().toString();
 
     StorageContainerLocationProtocol mockScmClient = mock(
-            StorageContainerLocationProtocol.class);
+        StorageContainerLocationProtocol.class);
     mockScmServiceProvider = mock(
-            StorageContainerServiceProviderImpl.class);
+        StorageContainerServiceProviderImpl.class);
 
     when(mockScmServiceProvider.getPipeline(
-            pipeline.getId().getProtobuf())).thenReturn(pipeline);
+        pipeline.getId().getProtobuf())).thenReturn(pipeline);
     when(mockScmServiceProvider.getPipeline(
-            pipeline2.getId().getProtobuf())).thenReturn(pipeline2);
+        pipeline2.getId().getProtobuf())).thenReturn(pipeline2);
 
     // Open 5 containers on pipeline 1
     containerIDs = new LinkedList<>();
     cpw = new LinkedList<>();
     for (long i = 1L; i <= 5L; ++i) {
       ContainerInfo containerInfo = new ContainerInfo.Builder()
-              .setContainerID(i)
-              .setReplicationConfig(
-                      RatisReplicationConfig.getInstance(ReplicationFactor.ONE))
-              .setState(LifeCycleState.OPEN)
-              .setOwner("test")
-              .setPipelineID(pipeline.getId())
-              .build();
+          .setContainerID(i)
+          .setReplicationConfig(
+              RatisReplicationConfig.getInstance(ReplicationFactor.ONE))
+          .setState(LifeCycleState.OPEN)
+          .setOwner("test")
+          .setPipelineID(pipeline.getId())
+          .build();
       ContainerWithPipeline containerWithPipeline =
-              new ContainerWithPipeline(containerInfo, pipeline);
+          new ContainerWithPipeline(containerInfo, pipeline);
       when(mockScmServiceProvider.getContainerWithPipeline(i))
-              .thenReturn(containerWithPipeline);
+          .thenReturn(containerWithPipeline);
       containerIDs.add(i);
       cpw.add(containerWithPipeline);
     }
@@ -160,56 +160,56 @@ public class TestOpenContainerCount {
     // Open 5 containers on pipeline 2
     for (long i = 6L; i <= 10L; ++i) {
       ContainerInfo containerInfo = new ContainerInfo.Builder()
-              .setContainerID(i)
-              .setReplicationConfig(
-                      RatisReplicationConfig.getInstance(ReplicationFactor.ONE))
-              .setState(LifeCycleState.OPEN)
-              .setOwner("test")
-              .setPipelineID(pipeline2.getId())
-              .build();
+          .setContainerID(i)
+          .setReplicationConfig(
+              RatisReplicationConfig.getInstance(ReplicationFactor.ONE))
+          .setState(LifeCycleState.OPEN)
+          .setOwner("test")
+          .setPipelineID(pipeline2.getId())
+          .build();
       ContainerWithPipeline containerWithPipeline =
-              new ContainerWithPipeline(containerInfo, pipeline2);
+          new ContainerWithPipeline(containerInfo, pipeline2);
       when(mockScmServiceProvider.getContainerWithPipeline(i))
-              .thenReturn(containerWithPipeline);
+          .thenReturn(containerWithPipeline);
       containerIDs.add(i);
       cpw.add(containerWithPipeline);
     }
 
     when(mockScmServiceProvider
-            .getExistContainerWithPipelinesInBatch(containerIDs))
-            .thenReturn(cpw);
+        .getExistContainerWithPipelinesInBatch(containerIDs))
+        .thenReturn(cpw);
 
     reconUtilsMock = mock(ReconUtils.class);
     HttpURLConnection urlConnectionMock = mock(HttpURLConnection.class);
     when(urlConnectionMock.getResponseCode())
-            .thenReturn(HttpServletResponse.SC_OK);
+        .thenReturn(HttpServletResponse.SC_OK);
     when(reconUtilsMock.makeHttpCall(any(URLConnectionFactory.class),
-            anyString(), anyBoolean())).thenReturn(urlConnectionMock);
+        anyString(), anyBoolean())).thenReturn(urlConnectionMock);
     when(reconUtilsMock.getReconDbDir(any(OzoneConfiguration.class),
         anyString())).thenReturn(GenericTestUtils.getRandomizedTestDir());
 
     ReconTestInjector reconTestInjector =
-            new ReconTestInjector.Builder(temporaryFolder)
-                    .withReconSqlDb()
-                    .withReconOm(reconOMMetadataManager)
-                    .withOmServiceProvider(
-                            mock(OzoneManagerServiceProviderImpl.class))
-                    .addBinding(StorageContainerServiceProvider.class,
-                            mockScmServiceProvider)
-                    .addBinding(OzoneStorageContainerManager.class,
-                            ReconStorageContainerManagerFacade.class)
-                    .withContainerDB()
-                    .addBinding(NodeEndpoint.class)
-                    .addBinding(MetricsServiceProviderFactory.class)
-                    .addBinding(ContainerHealthSchemaManager.class)
-                    .addBinding(ReconUtils.class, reconUtilsMock)
-                    .addBinding(StorageContainerLocationProtocol.class,
-                            mockScmClient)
-                    .build();
+        new ReconTestInjector.Builder(temporaryFolder)
+            .withReconSqlDb()
+            .withReconOm(reconOMMetadataManager)
+            .withOmServiceProvider(
+                mock(OzoneManagerServiceProviderImpl.class))
+            .addBinding(StorageContainerServiceProvider.class,
+                mockScmServiceProvider)
+            .addBinding(OzoneStorageContainerManager.class,
+                ReconStorageContainerManagerFacade.class)
+            .withContainerDB()
+            .addBinding(NodeEndpoint.class)
+            .addBinding(MetricsServiceProviderFactory.class)
+            .addBinding(ContainerHealthSchemaManager.class)
+            .addBinding(ReconUtils.class, reconUtilsMock)
+            .addBinding(StorageContainerLocationProtocol.class,
+                mockScmClient)
+            .build();
 
     nodeEndpoint = reconTestInjector.getInstance(NodeEndpoint.class);
     reconScm = (ReconStorageContainerManagerFacade)
-            reconTestInjector.getInstance(OzoneStorageContainerManager.class);
+        reconTestInjector.getInstance(OzoneStorageContainerManager.class);
   }
 
   @Before
@@ -225,98 +225,95 @@ public class TestOpenContainerCount {
     builder = ContainerReportsProto.newBuilder();
     for (long i = 1L; i <= 10L; i++) {
       builder.addReports(
-              ContainerReplicaProto.newBuilder()
-                      .setContainerID(i)
-                      .setState(ContainerReplicaProto.State.OPEN)
-                      .setOriginNodeId(datanodeId)
-                      .build()
+          ContainerReplicaProto.newBuilder()
+              .setContainerID(i)
+              .setState(ContainerReplicaProto.State.OPEN)
+              .setOriginNodeId(datanodeId)
+              .build()
       );
     }
     containerReportsProto = builder.build();
 
     UUID pipelineUuid = UUID.fromString(pipelineId);
     HddsProtos.UUID uuid128 = HddsProtos.UUID.newBuilder()
-            .setMostSigBits(pipelineUuid.getMostSignificantBits())
-            .setLeastSigBits(pipelineUuid.getLeastSignificantBits())
-            .build();
+        .setMostSigBits(pipelineUuid.getMostSignificantBits())
+        .setLeastSigBits(pipelineUuid.getLeastSignificantBits())
+        .build();
 
     UUID pipelineUuid2 = UUID.fromString(pipelineId2);
     HddsProtos.UUID uuid1282 = HddsProtos.UUID.newBuilder()
-            .setMostSigBits(pipelineUuid2.getMostSignificantBits())
-            .setLeastSigBits(pipelineUuid2.getLeastSignificantBits())
-            .build();
+        .setMostSigBits(pipelineUuid2.getMostSignificantBits())
+        .setLeastSigBits(pipelineUuid2.getLeastSignificantBits())
+        .build();
 
     PipelineReport pipelineReport = PipelineReport.newBuilder()
-            .setPipelineID(
-                    PipelineID.newBuilder()
-                            .setId(pipelineId)
-                            .setUuid128(uuid128)
-                            .build())
-            .setIsLeader(true)
-            .build();
+        .setPipelineID(
+            PipelineID.newBuilder()
+                .setId(pipelineId)
+                .setUuid128(uuid128)
+                .build())
+        .setIsLeader(true)
+        .build();
 
     PipelineReport pipelineReport2 = PipelineReport.newBuilder()
-            .setPipelineID(
-                    PipelineID
-                            .newBuilder()
-                            .setId(pipelineId2)
-                            .setUuid128(uuid1282)
-                            .build())
-            .setIsLeader(false)
-            .build();
+        .setPipelineID(
+            PipelineID
+                .newBuilder()
+                .setId(pipelineId2)
+                .setUuid128(uuid1282)
+                .build())
+        .setIsLeader(false)
+        .build();
 
     pipelineReportsProto =
-            PipelineReportsProto.newBuilder()
-                    .addPipelineReport(pipelineReport)
-                    .addPipelineReport(pipelineReport2)
-                    .build();
+        PipelineReportsProto.newBuilder()
+            .addPipelineReport(pipelineReport)
+            .addPipelineReport(pipelineReport2)
+            .build();
 
     DatanodeDetailsProto datanodeDetailsProto =
-            DatanodeDetailsProto.newBuilder()
-                    .setHostName(HOST1)
-                    .setUuid(datanodeId)
-                    .setIpAddress(IP1)
-                    .build();
+        DatanodeDetailsProto.newBuilder()
+            .setHostName(HOST1)
+            .setUuid(datanodeId)
+            .setIpAddress(IP1)
+            .build();
 
     extendedDatanodeDetailsProto =
-            HddsProtos.ExtendedDatanodeDetailsProto.newBuilder()
-                    .setDatanodeDetails(datanodeDetailsProto)
-                    .setVersion("0.6.0")
-                    .setSetupTime(1596347628802L)
-                    .setBuildDate("2020-08-01T08:50Z")
-                    .setRevision("3346f493fa1690358add7bb9f3e5b52545993f36")
-                    .build();
+        HddsProtos.ExtendedDatanodeDetailsProto.newBuilder()
+            .setDatanodeDetails(datanodeDetailsProto)
+            .setVersion("0.6.0")
+            .setSetupTime(1596347628802L)
+            .setBuildDate("2020-08-01T08:50Z")
+            .setRevision("3346f493fa1690358add7bb9f3e5b52545993f36")
+            .build();
 
-    StorageReportProto storageReportProto1 =
-            StorageReportProto.newBuilder()
-                    .setStorageType(StorageTypeProto.DISK)
-                    .setStorageLocation("/disk1")
-                    .setScmUsed(10 * OzoneConsts.GB)
-                    .setRemaining(90 * OzoneConsts.GB)
-                    .setCapacity(100 * OzoneConsts.GB)
-                    .setStorageUuid(UUID.randomUUID().toString())
-                    .setFailed(false).build();
+    StorageReportProto storageReportProto1 = StorageReportProto.newBuilder()
+        .setStorageType(StorageTypeProto.DISK)
+        .setStorageLocation("/disk1")
+        .setScmUsed(10 * OzoneConsts.GB)
+        .setRemaining(90 * OzoneConsts.GB)
+        .setCapacity(100 * OzoneConsts.GB)
+        .setStorageUuid(UUID.randomUUID().toString())
+        .setFailed(false).build();
 
-    StorageReportProto storageReportProto2 =
-            StorageReportProto.newBuilder()
-                    .setStorageType(StorageTypeProto.DISK)
-                    .setStorageLocation("/disk2")
-                    .setScmUsed(10 * OzoneConsts.GB)
-                    .setRemaining(90 * OzoneConsts.GB)
-                    .setCapacity(100 * OzoneConsts.GB)
-                    .setStorageUuid(UUID.randomUUID().toString())
-                    .setFailed(false).build();
+    StorageReportProto storageReportProto2 = StorageReportProto.newBuilder()
+        .setStorageType(StorageTypeProto.DISK)
+        .setStorageLocation("/disk2")
+        .setScmUsed(10 * OzoneConsts.GB)
+        .setRemaining(90 * OzoneConsts.GB)
+        .setCapacity(100 * OzoneConsts.GB)
+        .setStorageUuid(UUID.randomUUID().toString())
+        .setFailed(false).build();
 
-    nodeReportProto =
-            NodeReportProto.newBuilder()
-                    .addStorageReport(storageReportProto1)
-                    .addStorageReport(storageReportProto2).build();
+    nodeReportProto = NodeReportProto.newBuilder()
+        .addStorageReport(storageReportProto1)
+        .addStorageReport(storageReportProto2).build();
 
     try {
       reconScm.getDatanodeProtocolServer()
-              .register(extendedDatanodeDetailsProto, nodeReportProto,
-                      containerReportsProto, pipelineReportsProto,
-                  defaultLayoutVersionProto());
+          .register(extendedDatanodeDetailsProto, nodeReportProto,
+              containerReportsProto, pipelineReportsProto,
+              defaultLayoutVersionProto());
       // Process all events in the event queue
       reconScm.getEventQueue().processAll(1000);
     } catch (Exception ex) {
@@ -328,10 +325,9 @@ public class TestOpenContainerCount {
   public void testOpenContainerCount() throws Exception {
     // In case of pipeline doesn't exist
     waitAndCheckConditionAfterHeartbeat(() -> {
-
       DatanodeMetadata datanodeMetadata1 = getDatanodeMetadata();
       return datanodeMetadata1.getContainers() == 10
-              && datanodeMetadata1.getPipelines().size() == 2;
+          && datanodeMetadata1.getPipelines().size() == 2;
     });
 
     DatanodeMetadata datanodeMetadata = getDatanodeMetadata();
@@ -350,12 +346,13 @@ public class TestOpenContainerCount {
   private DatanodeMetadata getDatanodeMetadata() {
     Response response = nodeEndpoint.getDatanodes();
     DatanodesResponse datanodesResponse =
-            (DatanodesResponse) response.getEntity();
+        (DatanodesResponse) response.getEntity();
 
-    DatanodeMetadata datanodeMetadata =
-            datanodesResponse.getDatanodes().stream().filter(metadata ->
-                    metadata.getHostname().equals("host1.datanode"))
-                    .findFirst().orElse(null);
+    DatanodeMetadata datanodeMetadata = datanodesResponse.getDatanodes()
+        .stream()
+        .filter(metadata -> metadata.getHostname().equals("host1.datanode"))
+        .findFirst()
+        .orElse(null);
     return datanodeMetadata;
   }
 
@@ -363,52 +360,52 @@ public class TestOpenContainerCount {
 
     if (containerID >= 1L && containerID <= 5L) {
       ContainerInfo closedContainer = new ContainerInfo.Builder()
-              .setContainerID(containerID)
-              .setReplicationConfig(
-                      RatisReplicationConfig.getInstance(ReplicationFactor.ONE))
-              .setState(LifeCycleState.CLOSED)
-              .setOwner("test")
-              .setPipelineID(pipeline.getId())
-              .build();
+          .setContainerID(containerID)
+          .setReplicationConfig(
+              RatisReplicationConfig.getInstance(ReplicationFactor.ONE))
+          .setState(LifeCycleState.CLOSED)
+          .setOwner("test")
+          .setPipelineID(pipeline.getId())
+          .build();
       ContainerWithPipeline containerWithPipeline =
-              new ContainerWithPipeline(closedContainer, pipeline);
+          new ContainerWithPipeline(closedContainer, pipeline);
       when(mockScmServiceProvider.getContainerWithPipeline(containerID))
-              .thenReturn(containerWithPipeline);
+          .thenReturn(containerWithPipeline);
       cpw.set((int) containerID - 1, containerWithPipeline);
     } else if (containerID >= 6L && containerID <= 10L) {
       ContainerInfo closedContainer = new ContainerInfo.Builder()
-              .setContainerID(containerID)
-              .setReplicationConfig(
-                      RatisReplicationConfig.getInstance(ReplicationFactor.ONE))
-              .setState(LifeCycleState.CLOSED)
-              .setOwner("test")
-              .setPipelineID(pipeline2.getId())
-              .build();
+          .setContainerID(containerID)
+          .setReplicationConfig(
+              RatisReplicationConfig.getInstance(ReplicationFactor.ONE))
+          .setState(LifeCycleState.CLOSED)
+          .setOwner("test")
+          .setPipelineID(pipeline2.getId())
+          .build();
       ContainerWithPipeline containerWithPipeline =
-              new ContainerWithPipeline(closedContainer, pipeline2);
+          new ContainerWithPipeline(closedContainer, pipeline2);
       when(mockScmServiceProvider.getContainerWithPipeline(containerID))
-              .thenReturn(containerWithPipeline);
+          .thenReturn(containerWithPipeline);
       cpw.set((int) containerID - 1, containerWithPipeline);
     }
     when(mockScmServiceProvider
-            .getExistContainerWithPipelinesInBatch(containerIDs))
-            .thenReturn(cpw);
+        .getExistContainerWithPipelinesInBatch(containerIDs))
+        .thenReturn(cpw);
     updateContainerReport(containerID);
   }
 
   private void updateContainerReport(long containerId) {
     containerReportsProto = builder.setReports((int) containerId - 1,
             ContainerReplicaProto.newBuilder()
-                    .setContainerID(containerId)
-                    .setState(ContainerReplicaProto.State.CLOSED)
-                    .setOriginNodeId(datanodeId)
-                    .build())
-            .build();
+                .setContainerID(containerId)
+                .setState(ContainerReplicaProto.State.CLOSED)
+                .setOriginNodeId(datanodeId)
+                .build())
+        .build();
     try {
       reconScm.getDatanodeProtocolServer()
-              .register(extendedDatanodeDetailsProto, nodeReportProto,
-                      containerReportsProto, pipelineReportsProto,
-                  defaultLayoutVersionProto());
+          .register(extendedDatanodeDetailsProto, nodeReportProto,
+              containerReportsProto, pipelineReportsProto,
+              defaultLayoutVersionProto());
       // Process all events in the event queue
       reconScm.getEventQueue().processAll(1000);
     } catch (Exception ex) {
@@ -417,17 +414,18 @@ public class TestOpenContainerCount {
   }
 
   private void waitAndCheckConditionAfterHeartbeat(Callable<Boolean> check)
-          throws Exception {
+      throws Exception {
     // if container report is processed first, and pipeline does not exist
     // then container is not added until the next container report is processed
-    SCMHeartbeatRequestProto heartbeatRequestProto =
-            SCMHeartbeatRequestProto.newBuilder()
-                    .setContainerReport(containerReportsProto)
-                    .setDatanodeDetails(extendedDatanodeDetailsProto
-                            .getDatanodeDetails())
-                    .build();
+    SCMHeartbeatRequestProto heartbeatRequestProto = SCMHeartbeatRequestProto
+        .newBuilder()
+        .setContainerReport(containerReportsProto)
+        .setDatanodeDetails(extendedDatanodeDetailsProto.getDatanodeDetails())
+        .build();
 
     reconScm.getDatanodeProtocolServer().sendHeartbeat(heartbeatRequestProto);
-    LambdaTestUtils.await(30000, 1000, check);
+    await().atMost(Duration.ofSeconds(30))
+        .pollInterval(Duration.ofSeconds(1))
+        .until(check);
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?
This change is to replace [LambdaTestUtils#await](https://github.com/apache/ozone/blob/387c53781aae03f944906a0add58f51250d36687/hadoop-hdds/test-utils/src/main/java/org/apache/ozone/test/LambdaTestUtils.java#L111) with [Awaitility#await](https://github.com/awaitility/awaitility). Awaitility provides the same functionality as LambdaTestUtils with more granular configuration.

This is part 1 of [HDDS-9147](https://issues.apache.org/jira/browse/HDDS-9147).

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-9147

## How was this patch tested?
No functional or logical change so just run the CI/CD on fork couple of time.
* https://github.com/hemantk-12/ozone/actions/runs/5844454571
* https://github.com/hemantk-12/ozone/actions/runs/5844965636