### PR TITLE
HDDS-9147. Replaced GenericTestUtils#wait with Awaitility#await in hadoop-hdds packages

### DIFF
--- a/hadoop-hdds/common/pom.xml
+++ b/hadoop-hdds/common/pom.xml
@@ -194,6 +194,11 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.awaitility</groupId>
+      <artifactId>awaitility</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>io.jaegertracing</groupId>
       <artifactId>jaeger-client</artifactId>
     </dependency>

--- a/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/fs/TestSaveSpaceUsageToFile.java
+++ b/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/fs/TestSaveSpaceUsageToFile.java
@@ -31,7 +31,7 @@ import java.time.Instant;
 import java.util.OptionalLong;
 
 import static org.apache.ozone.test.GenericTestUtils.getTestDir;
-import static org.apache.ozone.test.GenericTestUtils.waitFor;
+import static org.awaitility.Awaitility.await;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -94,7 +94,10 @@ public class TestSaveSpaceUsageToFile {
 
     subject.save(VALID_USAGE_SOURCE);
     Instant expired = Instant.now().plus(shortExpiry);
-    waitFor(() -> Instant.now().isAfter(expired), 10, 1000);
+
+    await().atMost(Duration.ofSeconds(1))
+        .pollInterval(Duration.ofMillis(10))
+        .until(() -> Instant.now().isAfter(expired));
     OptionalLong savedValue = subject.load();
 
     assertTrue(file.exists());

--- a/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/utils/TestResourceLimitCache.java
+++ b/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/utils/TestResourceLimitCache.java
@@ -16,17 +16,19 @@
  */
 package org.apache.hadoop.hdds.utils;
 
-import org.apache.ozone.test.GenericTestUtils;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 
+import java.time.Duration;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.function.Consumer;
+
+import static org.awaitility.Awaitility.await;
 
 /**
  * Test for ResourceLimitCache.
@@ -65,7 +67,10 @@ public class TestResourceLimitCache {
     // has acquired 6 permits out of 10
     resourceCache.remove(4);
 
-    GenericTestUtils.waitFor(future::isDone, 100, 1000);
+
+    await().atMost(Duration.ofSeconds(1))
+        .pollInterval(Duration.ofMillis(100))
+        .until(future::isDone);
     // map has the key 1
     Assertions.assertTrue(future.isDone());
     Assertions.assertFalse(future.isCompletedExceptionally());

--- a/hadoop-hdds/common/src/test/java/org/apache/hadoop/ozone/audit/AuditLogTestUtils.java
+++ b/hadoop-hdds/common/src/test/java/org/apache/hadoop/ozone/audit/AuditLogTestUtils.java
@@ -22,10 +22,10 @@ import org.apache.commons.io.FileUtils;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
-import java.util.concurrent.TimeoutException;
+import java.time.Duration;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
-import static org.apache.ozone.test.GenericTestUtils.waitFor;
+import static org.awaitility.Awaitility.await;
 
 /**
  * Utility class to read audit logs.
@@ -48,11 +48,11 @@ public final class AuditLogTestUtils {
    * Searches for the given action in the audit log file.
    */
   public static void verifyAuditLog(AuditAction action,
-      AuditEventStatus eventStatus)
-      throws InterruptedException, TimeoutException {
-    waitFor(
-        () -> auditLogContains(action.getAction(), eventStatus.getStatus()),
-        1000, 10000);
+                                    AuditEventStatus eventStatus) {
+    await().atMost(Duration.ofSeconds(10))
+        .pollInterval(Duration.ofSeconds(1))
+        .until(() ->
+            auditLogContains(action.getAction(), eventStatus.getStatus()));
   }
 
   public static boolean auditLogContains(String... strings) {

--- a/hadoop-hdds/common/src/test/java/org/apache/hadoop/ozone/lock/TestLockManager.java
+++ b/hadoop-hdds/common/src/test/java/org/apache/hadoop/ozone/lock/TestLockManager.java
@@ -18,14 +18,16 @@
 package org.apache.hadoop.ozone.lock;
 
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
-import org.apache.ozone.test.GenericTestUtils;
 import org.apache.hadoop.util.Daemon;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 
+import java.time.Duration;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.awaitility.Awaitility.await;
 
 /**
  * Test-cases to test LockManager.
@@ -177,7 +179,7 @@ public class TestLockManager {
   }
 
   @Test
-  public void testConcurrentWriteLockWithDifferentResource() throws Exception {
+  public void testConcurrentWriteLockWithDifferentResource() {
     OzoneConfiguration conf = new OzoneConfiguration();
     final int count = 100;
     final LockManager<Integer> manager = new LockManager<>(conf);
@@ -199,8 +201,9 @@ public class TestLockManager {
       d1.setName("Locker-" + i);
       d1.start();
     }
-    GenericTestUtils.waitFor(() -> done.get() == count, 100,
-        10 * count * sleep);
-    Assertions.assertEquals(count, done.get());
+
+    await().atMost(Duration.ofMillis(10 * count * sleep))
+        .pollInterval(Duration.ofMillis(100))
+        .untilAsserted(() -> Assertions.assertEquals(count, done.get()));
   }
 }

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/volume/TestStorageVolumeChecker.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/volume/TestStorageVolumeChecker.java
@@ -36,7 +36,6 @@ import org.apache.hadoop.ozone.container.common.interfaces.Container;
 import org.apache.hadoop.ozone.container.common.statemachine.DatanodeConfiguration;
 import org.apache.hadoop.ozone.container.keyvalue.KeyValueContainerData;
 import org.apache.hadoop.ozone.container.ozoneimpl.OzoneContainer;
-import org.apache.ozone.test.GenericTestUtils;
 import org.apache.hadoop.util.DiskChecker.DiskErrorException;
 import org.apache.hadoop.util.FakeTimer;
 import org.junit.Rule;
@@ -66,6 +65,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 
 import static org.apache.hadoop.hdfs.server.datanode.checker.VolumeCheckResult.FAILED;
+import static org.awaitility.Awaitility.await;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
@@ -76,7 +76,6 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-
 
 /**
  * Tests for {@link StorageVolumeChecker}.
@@ -174,7 +173,9 @@ public class TestStorageVolumeChecker {
           }
         });
 
-    GenericTestUtils.waitFor(() -> numCallbackInvocations.get() > 0, 5, 10000);
+    await().atMost(Duration.ofSeconds(10))
+        .pollInterval(Duration.ofMillis(5))
+        .until(() -> numCallbackInvocations.get() > 0);
 
     // Ensure that the check was invoked at least once.
     verify(volume, times(1)).check(anyObject());

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/helpers/TestChunkUtils.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/helpers/TestChunkUtils.java
@@ -24,6 +24,7 @@ import java.nio.channels.FileChannel;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
+import java.time.Duration;
 import java.util.Arrays;
 import java.util.LinkedList;
 import java.util.List;
@@ -38,7 +39,6 @@ import org.apache.hadoop.hdds.scm.container.common.helpers.StorageContainerExcep
 import org.apache.hadoop.ozone.common.ChunkBuffer;
 import org.apache.hadoop.ozone.common.utils.BufferUtils;
 import org.apache.hadoop.ozone.container.common.helpers.ChunkInfo;
-import org.apache.ozone.test.GenericTestUtils;
 
 import org.apache.commons.io.FileUtils;
 
@@ -46,6 +46,8 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.Result.UNABLE_TO_FIND_CHUNK;
 
 import org.junit.jupiter.api.Assertions;
+
+import static org.awaitility.Awaitility.await;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -106,8 +108,9 @@ public class TestChunkUtils {
         });
       }
       try {
-        GenericTestUtils.waitFor(() -> processed.get() == threads,
-            100, (int) TimeUnit.SECONDS.toMillis(5));
+        await().atMost(Duration.ofSeconds(5))
+            .pollInterval(Duration.ofMillis(100))
+            .untilAsserted(() -> assertEquals(threads, processed.get()));
       } finally {
         executor.shutdownNow();
       }
@@ -148,8 +151,9 @@ public class TestChunkUtils {
         });
       }
       try {
-        GenericTestUtils.waitFor(() -> processed.get() == threads,
-            100, maxTotalWait);
+        await().atMost(Duration.ofMillis(maxTotalWait))
+            .pollInterval(Duration.ofMillis(100))
+            .untilAsserted(() -> assertEquals(threads, processed.get()));
       } finally {
         executor.shutdownNow();
       }

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/ozoneimpl/TestBackgroundContainerDataScanner.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/ozoneimpl/TestBackgroundContainerDataScanner.java
@@ -25,7 +25,6 @@ import org.apache.hadoop.hdfs.util.DataTransferThrottler;
 import org.apache.hadoop.metrics2.lib.DefaultMetricsSystem;
 import org.apache.hadoop.ozone.container.common.interfaces.Container;
 import org.apache.hadoop.ozone.container.common.interfaces.Container.ScanResult;
-import org.apache.ozone.test.GenericTestUtils;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.BeforeEach;
 import org.mockito.Mockito;
@@ -39,6 +38,7 @@ import java.util.concurrent.TimeUnit;
 
 import static org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.ContainerDataProto.State.UNHEALTHY;
 import static org.apache.hadoop.ozone.container.common.ContainerTestUtils.getUnhealthyScanResult;
+import static org.awaitility.Awaitility.await;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -200,7 +200,9 @@ public class TestBackgroundContainerDataScanner extends
     // the first iteration because the volume is unhealthy.
     ContainerDataScannerMetrics metrics = scanner.getMetrics();
     scanner.start();
-    GenericTestUtils.waitFor(() -> !scanner.isAlive(), 1000, 5000);
+    await().atMost(Duration.ofSeconds(5))
+        .pollInterval(Duration.ofSeconds(1))
+        .until(() -> !scanner.isAlive());
 
     // Volume health should have been checked.
     Mockito.verify(vol, atLeastOnce()).isFailed();

--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/utils/db/TestTypedRDBTableStore.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/utils/db/TestTypedRDBTableStore.java
@@ -21,6 +21,7 @@ package org.apache.hadoop.hdds.utils.db;
 
 import java.io.File;
 import java.io.IOException;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashSet;
@@ -32,7 +33,6 @@ import java.util.Set;
 import org.apache.hadoop.hdds.StringUtils;
 import org.apache.hadoop.hdds.utils.db.managed.ManagedColumnFamilyOptions;
 import org.apache.hadoop.hdds.utils.db.managed.ManagedDBOptions;
-import org.apache.ozone.test.GenericTestUtils;
 import org.apache.hadoop.hdds.utils.db.Table.KeyValue;
 
 import org.apache.commons.lang3.RandomStringUtils;
@@ -46,6 +46,8 @@ import org.junit.jupiter.api.io.TempDir;
 import org.rocksdb.RocksDB;
 import org.rocksdb.Statistics;
 import org.rocksdb.StatsLevel;
+
+import static org.awaitility.Awaitility.await;
 
 /**
  * Tests for RocksDBTable Store.
@@ -299,11 +301,10 @@ public class TestTypedRDBTableStore {
         epochs.add(i);
       }
       testTable.cleanupCache(epochs);
-
-      GenericTestUtils.waitFor(() ->
-          ((TypedTable<String, String>) testTable).getCache().size() == 4,
-          100, 5000);
-
+      await().atMost(Duration.ofSeconds(5))
+          .pollInterval(Duration.ofMillis(100))
+          .until(() ->
+              ((TypedTable<String, String>) testTable).getCache().size() == 4);
 
       //Check remaining values
       for (int x = 6; x < iterCount; x++) {

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/block/TestBlockManager.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/block/TestBlockManager.java
@@ -513,7 +513,7 @@ public class TestBlockManager {
         .allocateBlock(DEFAULT_BLOCK_SIZE, replicationConfig, OzoneConsts.OZONE,
             new ExcludeList());
     // block should be allocated in different pipelines
-    await().atMost(Duration.ofSeconds(3))
+    await().atMost(Duration.ofSeconds(1))
         .pollInterval(Duration.ofMillis(100))
         .ignoreException(IOException.class)
         .until(() -> {

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/TestCloseContainerEventHandler.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/TestCloseContainerEventHandler.java
@@ -161,7 +161,7 @@ public class TestCloseContainerEventHandler {
     Mockito.verify(eventPublisher, never())
         .fireEvent(eq(DATANODE_COMMAND), commandCaptor.capture());
     // wait for event to happen
-    await().atMost(Duration.ofSeconds(timeoutInMs * 3))
+    await().atMost(Duration.ofMillis(timeoutInMs * 3))
         .pollInterval(Duration.ofMillis(1000))
         .ignoreExceptions()
         .until(() -> {

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/placement/algorithms/TestSCMContainerPlacementRackScatter.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/placement/algorithms/TestSCMContainerPlacementRackScatter.java
@@ -65,7 +65,7 @@ import static org.apache.hadoop.hdds.scm.net.NetConstants.LEAF_SCHEMA;
 import static org.apache.hadoop.hdds.scm.net.NetConstants.RACK_SCHEMA;
 import static org.apache.hadoop.hdds.scm.net.NetConstants.ROOT_SCHEMA;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.matchesPattern;
+import static org.hamcrest.text.MatchesPattern.matchesPattern;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestLegacyReplicationManager.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestLegacyReplicationManager.java
@@ -78,6 +78,7 @@ import org.mockito.Mockito;
 
 import java.io.IOException;
 import java.time.Clock;
+import java.time.Duration;
 import java.time.Instant;
 import java.time.ZoneId;
 import java.util.ArrayList;
@@ -114,6 +115,7 @@ import static org.apache.hadoop.hdds.scm.HddsTestUtils.CONTAINER_USED_BYTES_DEFA
 import static org.apache.hadoop.hdds.scm.HddsTestUtils.getContainer;
 import static org.apache.hadoop.hdds.scm.HddsTestUtils.getReplicas;
 import static org.apache.hadoop.hdds.protocol.MockDatanodeDetails.randomDatanodeDetails;
+import static org.awaitility.Awaitility.await;
 import static org.mockito.Mockito.when;
 
 /**
@@ -1391,11 +1393,12 @@ public class TestLegacyReplicationManager {
       // Run first iteraiton
 
       replicationManager.processAll();
-      GenericTestUtils.waitFor(
-          () -> (currentReplicateCommandCount + 2) == datanodeCommandHandler
-              .getInvocationCount(
-                  SCMCommandProto.Type.replicateContainerCommand),
-          50, 5000);
+
+      await().atMost(Duration.ofSeconds(5))
+          .pollInterval(Duration.ofMillis(50))
+          .until(() -> (currentReplicateCommandCount + 2) ==
+              datanodeCommandHandler.getInvocationCount(
+                  SCMCommandProto.Type.replicateContainerCommand));
 
       ReplicationManagerReport report = replicationManager.getContainerReport();
       Assertions.assertEquals(1,

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestPipelineManagerImpl.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestPipelineManagerImpl.java
@@ -70,6 +70,7 @@ import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.io.IOException;
+import java.time.Duration;
 import java.time.Instant;
 import java.time.ZoneOffset;
 import java.util.ArrayList;
@@ -91,6 +92,7 @@ import static org.apache.hadoop.hdds.scm.pipeline.Pipeline.PipelineState.OPEN;
 import static org.apache.hadoop.test.MetricsAsserts.getLongCounter;
 import static org.apache.hadoop.test.MetricsAsserts.getMetrics;
 import static org.apache.ratis.util.Preconditions.assertInstanceOf;
+import static org.awaitility.Awaitility.await;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
@@ -644,8 +646,11 @@ public class TestPipelineManagerImpl {
     // Simulate safemode check exiting.
     scmContext.updateSafeModeStatus(
         new SCMSafeModeManager.SafeModeStatus(true, true));
-    GenericTestUtils.waitFor(() -> pipelineManager.getPipelines().size() != 0,
-        100, 10000);
+
+    await().atMost(Duration.ofSeconds(10))
+        .pollInterval(Duration.ofMillis(100))
+        .untilAsserted(() -> Assertions.assertNotEquals(0,
+            pipelineManager.getPipelines().size()));
     pipelineManager.close();
   }
 

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/safemode/TestSCMSafeModeManager.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/safemode/TestSCMSafeModeManager.java
@@ -573,7 +573,7 @@ public class TestSCMSafeModeManager {
     queue.fireEvent(SCMEvents.NODE_REGISTRATION_CONT_REPORT,
         HddsTestUtils.createNodeRegistrationContainerReport(dnContainers));
 
-    await().atMost(Duration.ofSeconds(20))
+    await().atMost(Duration.ofSeconds(18))
         .pollInterval(Duration.ofMillis(100))
         .untilAsserted(() -> assertEquals(expectedThreshold,
             scmSafeModeManager.getCurrentContainerThreshold()));

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/update/server/TestSCMUpdateServiceGrpcServer.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/update/server/TestSCMUpdateServiceGrpcServer.java
@@ -272,7 +272,7 @@ public class TestSCMUpdateServiceGrpcServer {
 
       revokeCertNow(certIds.get(5));
       server.notifyCrlUpdate();
-      await().atMost(Duration.ofSeconds(2))
+      await().atMost(Duration.ofSeconds(5))
           .pollInterval(Duration.ofMillis(100))
           .untilAsserted(() ->
               Assertions.assertEquals(5, client.getUpdateCount()));

--- a/hadoop-hdds/test-utils/src/main/java/org/apache/ozone/test/GenericTestUtils.java
+++ b/hadoop-hdds/test-utils/src/main/java/org/apache/ozone/test/GenericTestUtils.java
@@ -148,13 +148,6 @@ public abstract class GenericTestUtils {
   }
 
   /**
-   * Assert that a given file exists.
-   */
-  public static void assertExists(File f) {
-    assertTrue("File " + f + " should exist", f.exists());
-  }
-
-  /**
    * Assert that a given dir can be created or it already exists.
    */
   public static void assertDirCreation(File f) {


### PR DESCRIPTION
## What changes were proposed in this pull request?
This change is to replace [GenericTestUtils#wait](https://github.com/apache/ozone/blob/387c53781aae03f944906a0add58f51250d36687/hadoop-hdds/test-utils/src/main/java/org/apache/ozone/test/GenericTestUtils.java#L214) with [Awaitility#await](https://github.com/awaitility/awaitility) in hadoop-hdds packages. Awaitility provides the same functionality as **GenericTestUtils** with more granular configuration.

This is part 2 of [HDDS-9147](https://issues.apache.org/jira/browse/HDDS-9147).

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-9147

## How was this patch tested?
No functional or logical change so just run the CI/CD on fork couple of time.
* https://github.com/hemantk-12/ozone/actions/runs/5844459561
* https://github.com/hemantk-12/ozone/actions/runs/5844967854