### PR TITLE
HDDS-9147. Replaced GenericTestUtils#wait with Awaitility#await in hadoop-ozone packages

### DIFF
--- a/hadoop-ozone/client/pom.xml
+++ b/hadoop-ozone/client/pom.xml
@@ -58,6 +58,11 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.awaitility</groupId>
+      <artifactId>awaitility</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>ch.qos.reload4j</groupId>
       <artifactId>reload4j</artifactId>
       <scope>test</scope>

--- a/hadoop-ozone/common/pom.xml
+++ b/hadoop-ozone/common/pom.xml
@@ -99,6 +99,11 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.awaitility</groupId>
+      <artifactId>awaitility</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>com.github.spotbugs</groupId>
       <artifactId>spotbugs-annotations</artifactId>
       <scope>provided</scope>

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFileSystem.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFileSystem.java
@@ -638,7 +638,14 @@ public class TestOzoneFileSystem {
     if (!enabledFileSystemPaths) {
       await().atMost(Duration.ofSeconds(120))
           .pollInterval(Duration.ofSeconds(1))
-          .until(() -> fs.listStatus(ROOT, EXCLUDE_TRASH).length != 0);
+          .until(() -> {
+            try {
+              return fs.listStatus(ROOT, EXCLUDE_TRASH).length != 0;
+            } catch (IOException e) {
+              Assert.fail("listStatus() failed.");
+              return false;
+            }
+          });
     }
 
     FileStatus[] fileStatuses = fs.listStatus(ROOT, EXCLUDE_TRASH);
@@ -662,11 +669,18 @@ public class TestOzoneFileSystem {
             .build();
     OpenKeySession session = writeClient.openKey(keyArgs);
     writeClient.commitKey(keyArgs, session.getId());
-    // Wait until the filestatus is updated
+    // Wait until the file status is updated
     if (!enabledFileSystemPaths) {
       await().atMost(Duration.ofSeconds(120))
           .pollInterval(Duration.ofSeconds(1))
-          .until(() -> fs.listStatus(ROOT, EXCLUDE_TRASH).length != 0);
+          .until(() -> {
+            try {
+              return fs.listStatus(ROOT, EXCLUDE_TRASH).length != 0;
+            } catch (IOException e) {
+              Assert.fail("listStatus() failed.");
+              return false;
+            }
+          });
     }
     FileStatus[] fileStatuses = fs.listStatus(ROOT, EXCLUDE_TRASH);
     // the number of immediate children of root is 1
@@ -1657,7 +1671,14 @@ public class TestOzoneFileSystem {
     // Wait until the TrashEmptier purges the key
     await().atMost(Duration.ofSeconds(120))
         .pollInterval(Duration.ofSeconds(1))
-        .until(() -> !o3fs.exists(trashPath));
+        .until(() -> {
+          try {
+            return !o3fs.exists(trashPath);
+          } catch (IOException e) {
+            Assert.fail("Delete from trash failed.");
+            return false;
+          }
+        });
 
     // userTrash path will contain the checkpoint folder
     FileStatus[] statusList = fs.listStatus(userTrash);
@@ -1666,7 +1687,14 @@ public class TestOzoneFileSystem {
     // wait for deletion of checkpoint dir
     await().atMost(Duration.ofSeconds(120))
         .pollInterval(Duration.ofSeconds(1))
-        .until(() -> o3fs.listStatus(userTrash).length == 0);
+        .until(() -> {
+          try {
+            return o3fs.listStatus(userTrash).length == 0;
+          } catch (IOException e) {
+            Assert.fail("Delete from trash failed.");
+            return false;
+          }
+        });
   }
 
   @Test

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFileSystemWithFSO.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFileSystemWithFSO.java
@@ -564,9 +564,14 @@ public class TestOzoneFileSystemWithFSO extends TestOzoneFileSystem {
     // wait for DB updates
     await().atMost(Duration.ofSeconds(120))
         .pollInterval(Duration.ofSeconds(1))
-        .ignoreException(IOException.class)
-        .untilAsserted(() -> Assert.assertTrue(
-            omMgr.getOpenKeyTable(getBucketLayout()).isEmpty()));
+        .until(() -> {
+          try {
+            return omMgr.getOpenKeyTable(getBucketLayout()).isEmpty();
+          } catch (IOException e) {
+            Assert.fail("DB failure.");
+            return false;
+          }
+        });
   }
 
   /**

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/TestRatisPipelineLeader.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/TestRatisPipelineLeader.java
@@ -56,8 +56,6 @@ import org.slf4j.event.Level;
 public class TestRatisPipelineLeader {
   private static MiniOzoneCluster cluster;
   private static OzoneConfiguration conf;
-  private static final Logger LOG =
-      LoggerFactory.getLogger(TestRatisPipelineLeader.class);
 
   @BeforeAll
   public static void setup() throws Exception {
@@ -78,7 +76,8 @@ public class TestRatisPipelineLeader {
     }
   }
 
-  @Test @Timeout(unit = TimeUnit.MILLISECONDS, value = 120000)
+  @Test
+  @Timeout(unit = TimeUnit.MILLISECONDS, value = 120000)
   public void testLeaderIdUsedOnFirstCall() throws Exception {
     List<Pipeline> pipelines = cluster.getStorageContainerManager()
         .getPipelineManager().getPipelines(RatisReplicationConfig.getInstance(
@@ -92,8 +91,14 @@ public class TestRatisPipelineLeader {
     // Verify correct leader info populated
     await().atMost(Duration.ofSeconds(20))
         .pollInterval(Duration.ofMillis(200))
-        .ignoreException(IOException.class)
-        .until(() -> verifyLeaderInfo(ratisPipeline));
+        .until(() -> {
+          try {
+            return verifyLeaderInfo(ratisPipeline);
+          } catch (IOException e) {
+            Assertions.fail("Failed verifying the leader info.");
+            return false;
+          }
+        });
 
     // Verify client connects to Leader without NotLeaderException
     final Logger log = LoggerFactory.getLogger(
@@ -137,8 +142,14 @@ public class TestRatisPipelineLeader {
 
     await().atMost(Duration.ofSeconds(20))
         .pollInterval(Duration.ofMillis(200))
-        .ignoreException(IOException.class)
-        .until(() -> verifyLeaderInfo(ratisPipeline));
+        .until(() -> {
+          try {
+            return verifyLeaderInfo(ratisPipeline);
+          } catch (IOException e) {
+            Assertions.fail("Failed getting leader info.");
+            return false;
+          }
+        });
   }
 
   private boolean verifyLeaderInfo(Pipeline ratisPipeline) throws IOException {

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestMultiRaftSetup.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestMultiRaftSetup.java
@@ -29,16 +29,18 @@ import org.apache.hadoop.hdds.scm.node.NodeManager;
 import org.apache.hadoop.hdds.scm.server.StorageContainerManager;
 import org.apache.hadoop.ozone.MiniOzoneCluster;
 
-import org.apache.ozone.test.LambdaTestUtils;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
+import java.time.Duration;
 import java.util.List;
 import java.util.Collection;
 import java.util.ArrayList;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
+
+import static org.awaitility.Awaitility.await;
 
 /**
  * Tests for MultiRaft set up.
@@ -158,12 +160,9 @@ public class  TestMultiRaftSetup {
     });
   }
 
-  private void waitForPipelineCreated(int num) throws Exception {
-    LambdaTestUtils.await(10000, 500, () -> {
-      List<Pipeline> pipelines =
-          pipelineManager.getPipelines(RATIS_THREE);
-      return pipelines.size() == num;
-    });
+  private void waitForPipelineCreated(int num) {
+    await().atMost(Duration.ofSeconds(10))
+        .pollInterval(Duration.ofMillis(500))
+        .until(() -> pipelineManager.getPipelines(RATIS_THREE).size() == num);
   }
-
 }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/TestBlockTokensCLI.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/TestBlockTokensCLI.java
@@ -54,7 +54,6 @@ import java.time.Instant;
 import java.util.Map;
 import java.util.Properties;
 import java.util.UUID;
-import java.util.concurrent.TimeoutException;
 
 import static java.time.Duration.between;
 import static org.apache.hadoop.fs.CommonConfigurationKeysPublic.HADOOP_SECURITY_AUTHENTICATION;
@@ -75,6 +74,7 @@ import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_HTTP_KERBEROS_PRI
 import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_KERBEROS_KEYTAB_FILE_KEY;
 import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_KERBEROS_PRINCIPAL_KEY;
 import static org.apache.hadoop.security.UserGroupInformation.AuthenticationMethod.KERBEROS;
+import static org.awaitility.Awaitility.await;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
@@ -238,9 +238,10 @@ public final class TestBlockTokensCLI {
   }
 
   @Test
-  public void testRotateKeySCMAdminCommandWithForceFlag()
-      throws InterruptedException, TimeoutException {
-    GenericTestUtils.waitFor(() -> cluster.getScmLeader() != null, 100, 1000);
+  public void testRotateKeySCMAdminCommandWithForceFlag() {
+    await().atMost(Duration.ofSeconds(1))
+        .pollInterval(Duration.ofMillis(100))
+        .until(() -> cluster.getScmLeader() != null);
     InetSocketAddress address = cluster.getScmLeader().getClientRpcAddress();
     String hostPort = address.getHostName() + ":" + address.getPort();
 
@@ -249,9 +250,10 @@ public final class TestBlockTokensCLI {
   }
 
   @Test
-  public void testRotateKeySCMAdminCommandWithoutForceFlag()
-      throws InterruptedException, TimeoutException {
-    GenericTestUtils.waitFor(() -> cluster.getScmLeader() != null, 100, 1000);
+  public void testRotateKeySCMAdminCommandWithoutForceFlag() {
+    await().atMost(Duration.ofSeconds(1))
+        .pollInterval(Duration.ofMillis(100))
+        .until(() -> cluster.getScmLeader() != null);
     InetSocketAddress address = cluster.getScmLeader().getClientRpcAddress();
     String hostPort = address.getHostName() + ":" + address.getPort();
 
@@ -274,8 +276,7 @@ public final class TestBlockTokensCLI {
     ozoneAdmin.execute(args);
 
     // Get the new secret key.
-    String newKey =
-        getScmSecretKeyManager().getCurrentSecretKey().toString();
+    String newKey = getScmSecretKeyManager().getCurrentSecretKey().toString();
 
     // Assert that the old key and new key are not the same after rotating if
     // either:
@@ -322,8 +323,7 @@ public final class TestBlockTokensCLI {
     return args;
   }
 
-  private static void startCluster()
-      throws IOException, TimeoutException, InterruptedException {
+  private static void startCluster() throws IOException {
     OzoneManager.setTestSecureOmFlag(true);
     MiniOzoneCluster.Builder builder = MiniOzoneCluster.newHABuilder(conf)
         .setClusterId(clusterId)

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestContainerReplicationEndToEnd.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestContainerReplicationEndToEnd.java
@@ -62,6 +62,7 @@ import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_CONTAINER_REPORT_INTERV
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_PIPELINE_DESTROY_TIMEOUT;
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_STALENODE_INTERVAL;
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_DATANODE_PIPELINE_LIMIT;
+import static org.awaitility.Awaitility.await;
 
 /**
  * Tests delete key operation with a slow follower in the datanode
@@ -222,10 +223,10 @@ public class TestContainerReplicationEndToEnd {
     Assert.assertNotNull(dnService);
     final HddsDatanodeService newReplicaNode = dnService;
     // wait for the container to get replicated
-    GenericTestUtils.waitFor(() -> {
-      return newReplicaNode.getDatanodeStateMachine().getContainer()
-          .getContainerSet().getContainer(containerID) != null;
-    }, 500, 100000);
+    await().atMost(Duration.ofSeconds(100))
+        .pollInterval(Duration.ofMillis(500))
+        .until(() -> newReplicaNode.getDatanodeStateMachine().getContainer()
+            .getContainerSet().getContainer(containerID) != null);
     Assert.assertTrue(newReplicaNode.getDatanodeStateMachine().getContainer()
         .getContainerSet().getContainer(containerID).getContainerData()
         .getBlockCommitSequenceId() > 0);

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestOzoneAtRestEncryption.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestOzoneAtRestEncryption.java
@@ -23,6 +23,7 @@ import java.net.URI;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.security.NoSuchAlgorithmException;
+import java.time.Duration;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -78,6 +79,7 @@ import org.apache.ozone.test.GenericTestUtils;
 import static org.apache.hadoop.hdds.HddsConfigKeys.OZONE_METADATA_DIRS;
 import static org.apache.hadoop.hdds.client.ReplicationFactor.ONE;
 import static org.apache.hadoop.hdds.client.ReplicationType.RATIS;
+import static org.awaitility.Awaitility.await;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -368,13 +370,11 @@ class TestOzoneAtRestEncryption {
 
     OMMetadataManager omMetadataManager = ozoneManager.getMetadataManager();
 
-    GenericTestUtils.waitFor(() -> {
-      try {
-        return getMatchedKeyInfo(keyName, omMetadataManager) != null;
-      } catch (IOException e) {
-        return false;
-      }
-    }, 500, 100000);
+    await().atMost(Duration.ofSeconds(100))
+        .pollInterval(Duration.ofMillis(500))
+        .ignoreException(IOException.class)
+        .until(() -> getMatchedKeyInfo(keyName, omMetadataManager) != null);
+
     RepeatedOmKeyInfo deletedKeys =
         getMatchedKeyInfo(keyName, omMetadataManager);
     assertNotNull(deletedKeys);

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestOzoneRpcClientAbstract.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestOzoneRpcClientAbstract.java
@@ -1960,8 +1960,14 @@ public abstract class TestOzoneRpcClientAbstract {
 
     await().atMost(Duration.ofSeconds(100))
         .pollInterval(Duration.ofSeconds(1))
-        .ignoreException(IOException.class)
-        .until(() -> scm.getContainerInfo(containerID).getState() == CLOSING);
+        .until(() -> {
+          try {
+            return scm.getContainerInfo(containerID).getState() == CLOSING;
+          } catch (IOException e) {
+            fail("Failed to get container info. " + e.getMessage());
+            return false;
+          }
+        });
 
     // Try reading keyName2
     try {

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestOzoneRpcClientForAclAuditLog.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestOzoneRpcClientForAclAuditLog.java
@@ -36,7 +36,6 @@ import org.apache.hadoop.ozone.security.acl.IAccessAuthorizer;
 import org.apache.hadoop.ozone.security.acl.OzoneObj;
 import org.apache.hadoop.ozone.security.acl.OzoneObjInfo;
 import org.apache.hadoop.security.UserGroupInformation;
-import org.apache.ozone.test.GenericTestUtils;
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
@@ -49,6 +48,7 @@ import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.io.IOException;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -62,6 +62,7 @@ import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_ADMINISTRATORS;
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_ADMINISTRATORS_WILDCARD;
 import static org.apache.hadoop.ozone.security.acl.OzoneObj.ResourceType.VOLUME;
 import static org.apache.hadoop.ozone.security.acl.OzoneObj.StoreType.OZONE;
+import static org.awaitility.Awaitility.await;
 import static org.junit.Assert.assertTrue;
 
 /**
@@ -279,7 +280,10 @@ public class TestOzoneRpcClientForAclAuditLog {
   private void verifyLog(String... expected) throws Exception {
     File file = new File("audit.log");
     final List<String> lines = FileUtils.readLines(file, (String)null);
-    GenericTestUtils.waitFor(() -> lines != null, 100, 60000);
+
+    await().atMost(Duration.ofSeconds(60))
+        .pollInterval(Duration.ofMillis(100))
+        .until(() -> lines != null);
 
     try {
       // When log entry is expected, the log file will contain one line and

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestSecureOzoneRpcClient.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestSecureOzoneRpcClient.java
@@ -71,12 +71,14 @@ import org.junit.jupiter.api.Test;
 
 import java.io.File;
 import java.io.IOException;
+import java.time.Duration;
 import java.time.Instant;
 import java.util.HashMap;
 import java.util.UUID;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.apache.hadoop.hdds.HddsConfigKeys.OZONE_METADATA_DIRS;
+import static org.awaitility.Awaitility.await;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -320,8 +322,10 @@ public class TestSecureOzoneRpcClient extends TestOzoneRpcClient {
             .setSignature(signature).setStringToSign(strToSign))
         .build();
 
-    GenericTestUtils.waitFor(() -> cluster.getOzoneManager().isLeaderReady(),
-        100, 120000);
+
+    await().atMost(Duration.ofSeconds(120))
+        .pollInterval(Duration.ofMillis(100))
+        .until(() -> cluster.getOzoneManager().isLeaderReady());
     OMResponse omResponse = cluster.getOzoneManager().getOmServerProtocol()
         .submitRequest(null, writeRequest);
 

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/read/TestKeyInputStream.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/read/TestKeyInputStream.java
@@ -24,17 +24,13 @@ import java.util.Arrays;
 
 import java.util.List;
 import java.util.Random;
-import java.util.concurrent.TimeoutException;
 
 import org.apache.hadoop.hdds.client.ECReplicationConfig;
 import org.apache.hadoop.hdds.client.RatisReplicationConfig;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
 import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos;
-import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.hdds.scm.XceiverClientManager;
 import org.apache.hadoop.hdds.scm.XceiverClientMetrics;
-import org.apache.hadoop.hdds.scm.node.NodeManager;
-import org.apache.hadoop.hdds.scm.node.states.NodeNotFoundException;
 import org.apache.hadoop.hdds.scm.storage.BlockExtendedInputStream;
 import org.apache.hadoop.hdds.scm.storage.BlockInputStream;
 import org.apache.hadoop.hdds.scm.storage.ChunkInputStream;
@@ -46,7 +42,6 @@ import org.apache.hadoop.ozone.om.helpers.OmKeyArgs;
 import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
 import org.apache.hadoop.ozone.om.helpers.OmKeyLocationInfo;
 import org.apache.hadoop.ozone.om.helpers.OmKeyLocationInfoGroup;
-import org.apache.ozone.test.GenericTestUtils;
 import org.junit.Assert;
 import org.junit.Assume;
 import org.junit.Test;
@@ -56,7 +51,6 @@ import org.slf4j.LoggerFactory;
 import static org.apache.hadoop.hdds.client.ECReplicationConfig.EcCodec.RS;
 import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationFactor.THREE;
 import static org.apache.hadoop.ozone.container.TestHelper.countReplicas;
-import static org.junit.Assert.fail;
 
 /**
  * Tests {@link KeyInputStream}.
@@ -449,27 +443,6 @@ public class TestKeyInputStream extends TestInputStreamBase {
       // check that we can still read it
       assertReadFullyUsingByteBuffer(data, keyInputStream, dataLength - 1, 1);
     }
-  }
-
-  private void waitForNodeToBecomeDead(
-      DatanodeDetails datanode) throws TimeoutException, InterruptedException {
-    GenericTestUtils.waitFor(() ->
-        HddsProtos.NodeState.DEAD == getNodeHealth(datanode),
-        100, 30000);
-    LOG.info("Node {} is {}", datanode.getUuidString(),
-        getNodeHealth(datanode));
-  }
-
-  private HddsProtos.NodeState getNodeHealth(DatanodeDetails dn) {
-    HddsProtos.NodeState health = null;
-    try {
-      NodeManager nodeManager =
-          getCluster().getStorageContainerManager().getScmNodeManager();
-      health = nodeManager.getNodeStatus(dn).getHealth();
-    } catch (NodeNotFoundException e) {
-      fail("Unexpected NodeNotFound exception");
-    }
-    return health;
   }
 
   private void assertReadFully(byte[] data, InputStream in,

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/TestDeleteContainerHandler.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/TestDeleteContainerHandler.java
@@ -78,6 +78,7 @@ import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationFactor
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_DATANODE_RATIS_VOLUME_FREE_SPACE_MIN;
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_CONTAINER_SIZE;
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_BLOCK_DELETING_SERVICE_INTERVAL;
+import static org.awaitility.Awaitility.await;
 
 /**
  * Tests DeleteContainerCommand Handler.
@@ -191,9 +192,10 @@ public class TestDeleteContainerHandler {
         hddsDatanodeService
             .getDatanodeStateMachine().getContainer().getMetrics();
     long beforeDeleteFailedCount = metrics.getContainerDeleteFailedNonEmpty();
-    GenericTestUtils.waitFor(() ->
-            isContainerClosed(hddsDatanodeService, containerId.getId()),
-        500, 5 * 1000);
+    await().atMost(Duration.ofSeconds(5))
+        .pollInterval(Duration.ofMillis(500))
+        .until(() ->
+            isContainerClosed(hddsDatanodeService, containerId.getId()));
 
     //double check if it's really closed (waitFor also throws an exception)
     Assert.assertTrue(isContainerClosed(hddsDatanodeService,
@@ -204,11 +206,11 @@ public class TestDeleteContainerHandler {
         .getBucket(bucketName).deleteKey(keyName);
 
     // Ensure isEmpty flag is true when key is deleted and container is empty
-    GenericTestUtils.waitFor(() -> getContainerfromDN(
-        hddsDatanodeService, containerId.getId())
-        .getContainerData().isEmpty(),
-        500,
-        5 * 2000);
+    await().atMost(Duration.ofSeconds(10))
+        .pollInterval(Duration.ofMillis(500))
+        .until(() ->
+            getContainerfromDN(hddsDatanodeService, containerId.getId())
+                .getContainerData().isEmpty());
 
     Container containerInternalObj =
         hddsDatanodeService.
@@ -245,11 +247,11 @@ public class TestDeleteContainerHandler {
     GenericTestUtils.LogCapturer logCapturer =
         GenericTestUtils.LogCapturer.captureLogs(
             LoggerFactory.getLogger(KeyValueHandler.class));
-    GenericTestUtils.waitFor(() ->
+    await().atMost(Duration.ofSeconds(10))
+        .pollInterval(Duration.ofMillis(500))
+        .until(() ->
             logCapturer.getOutput().
-                contains("Files still part of the container on delete"),
-        500,
-        5 * 2000);
+                contains("Files still part of the container on delete"));
     Assert.assertTrue(!isContainerDeleted(hddsDatanodeService,
         containerId.getId()));
     Assert.assertTrue(beforeDeleteFailedCount <
@@ -264,9 +266,10 @@ public class TestDeleteContainerHandler {
         cluster.getStorageContainerManager().getScmContext().getTermOfLeader());
     nodeManager.addDatanodeCommand(datanodeDetails.getUuid(), command);
 
-    GenericTestUtils.waitFor(() ->
-            isContainerDeleted(hddsDatanodeService, containerId.getId()),
-        500, 5 * 1000);
+    await().atMost(Duration.ofSeconds(5))
+        .pollInterval(Duration.ofMillis(500))
+        .until(() ->
+            isContainerDeleted(hddsDatanodeService, containerId.getId()));
     Assert.assertTrue(isContainerDeleted(hddsDatanodeService,
         containerId.getId()));
     Assert.assertTrue(beforeForceCount <
@@ -315,9 +318,10 @@ public class TestDeleteContainerHandler {
     OzoneTestUtils.closeAllContainers(cluster.getStorageContainerManager()
         .getEventQueue(), cluster.getStorageContainerManager());
 
-    GenericTestUtils.waitFor(() ->
-            isContainerClosed(hddsDatanodeService, containerId.getId()),
-        500, 5 * 1000);
+    await().atMost(Duration.ofSeconds(5))
+        .pollInterval(Duration.ofMillis(500))
+        .until(() ->
+            isContainerClosed(hddsDatanodeService, containerId.getId()));
 
     //double check if it's really closed (waitFor also throws an exception)
     Assert.assertTrue(isContainerClosed(hddsDatanodeService,
@@ -328,11 +332,11 @@ public class TestDeleteContainerHandler {
         .getBucket(bucketName).deleteKey(keyName);
 
     // Ensure isEmpty flag is true when key is deleted and container is empty
-    GenericTestUtils.waitFor(() -> getContainerfromDN(
-            hddsDatanodeService, containerId.getId())
-            .getContainerData().isEmpty(),
-        500,
-        5 * 2000);
+    await().atMost(Duration.ofSeconds(10))
+        .pollInterval(Duration.ofMillis(500))
+        .until(() ->
+            getContainerfromDN(hddsDatanodeService, containerId.getId())
+                .getContainerData().isEmpty());
 
     Container containerInternalObj =
         hddsDatanodeService.
@@ -361,9 +365,10 @@ public class TestDeleteContainerHandler {
         cluster.getStorageContainerManager().getScmContext().getTermOfLeader());
     nodeManager.addDatanodeCommand(datanodeDetails.getUuid(), command);
 
-    GenericTestUtils.waitFor(() ->
-            isContainerDeleted(hddsDatanodeService, containerId.getId()),
-        500, 5 * 1000);
+    await().atMost(Duration.ofSeconds(50))
+        .pollInterval(Duration.ofMillis(500))
+        .until(() ->
+            isContainerDeleted(hddsDatanodeService, containerId.getId()));
     Assert.assertTrue(isContainerDeleted(hddsDatanodeService,
         containerId.getId()));
   }
@@ -420,9 +425,10 @@ public class TestDeleteContainerHandler {
     ContainerMetrics metrics =
         hddsDatanodeService
             .getDatanodeStateMachine().getContainer().getMetrics();
-    GenericTestUtils.waitFor(() ->
-            isContainerClosed(hddsDatanodeService, containerId.getId()),
-        500, 5 * 1000);
+    await().atMost(Duration.ofSeconds(5))
+        .pollInterval(Duration.ofMillis(500))
+        .until(() ->
+            isContainerClosed(hddsDatanodeService, containerId.getId()));
 
     //double check if it's really closed (waitFor also throws an exception)
     Assert.assertTrue(isContainerClosed(hddsDatanodeService,
@@ -448,11 +454,11 @@ public class TestDeleteContainerHandler {
     GenericTestUtils.LogCapturer logCapturer =
         GenericTestUtils.LogCapturer.captureLogs(
             LoggerFactory.getLogger(KeyValueHandler.class));
-    GenericTestUtils.waitFor(() ->
+    await().atMost(Duration.ofSeconds(10))
+        .pollInterval(Duration.ofMillis(500))
+        .until(() ->
             logCapturer.getOutput().
-                contains("the container is not empty with blockCount"),
-        500,
-        5 * 2000);
+                contains("the container is not empty with blockCount"));
     Assert.assertTrue(!isContainerDeleted(hddsDatanodeService,
         containerId.getId()));
     Assert.assertTrue(containerDeleteFailedNonEmptyBlockDB <
@@ -486,10 +492,10 @@ public class TestDeleteContainerHandler {
     command.setTerm(
         cluster.getStorageContainerManager().getScmContext().getTermOfLeader());
     nodeManager.addDatanodeCommand(datanodeDetails.getUuid(), command);
-
-    GenericTestUtils.waitFor(() ->
-            isContainerDeleted(hddsDatanodeService, containerId.getId()),
-        500, 5 * 1000);
+    await().atMost(Duration.ofSeconds(5))
+        .pollInterval(Duration.ofMillis(500))
+        .until(() ->
+            isContainerDeleted(hddsDatanodeService, containerId.getId()));
     Assert.assertTrue(isContainerDeleted(hddsDatanodeService,
         containerId.getId()));
     Assert.assertTrue(beforeForceCount <
@@ -526,10 +532,10 @@ public class TestDeleteContainerHandler {
     command.setTerm(
         cluster.getStorageContainerManager().getScmContext().getTermOfLeader());
     nodeManager.addDatanodeCommand(datanodeDetails.getUuid(), command);
-
-    GenericTestUtils.waitFor(() ->
-            isContainerClosed(hddsDatanodeService, containerId.getId()),
-        500, 5 * 1000);
+    await().atMost(Duration.ofSeconds(5))
+        .pollInterval(Duration.ofMillis(500))
+        .until(() ->
+            isContainerClosed(hddsDatanodeService, containerId.getId()));
 
     //double check if it's really closed (waitFor also throws an exception)
     Assert.assertTrue(isContainerClosed(hddsDatanodeService,
@@ -565,14 +571,14 @@ public class TestDeleteContainerHandler {
         cluster.getStorageContainerManager().getScmContext().getTermOfLeader());
     nodeManager.addDatanodeCommand(datanodeDetails.getUuid(), command);
 
-    GenericTestUtils.waitFor(() ->
-            isContainerDeleted(hddsDatanodeService, containerId.getId()),
-        500, 5 * 1000);
+    await().atMost(Duration.ofSeconds(10))
+        .pollInterval(Duration.ofMillis(500))
+        .until(() ->
+            isContainerDeleted(hddsDatanodeService, containerId.getId()));
     Assert.assertTrue(isContainerDeleted(hddsDatanodeService,
         containerId.getId()));
 
   }
-
 
   private void clearBlocksTable(Container container) throws IOException {
     try (DBHandle dbHandle
@@ -632,9 +638,10 @@ public class TestDeleteContainerHandler {
     OzoneTestUtils.closeAllContainers(cluster.getStorageContainerManager()
         .getEventQueue(), cluster.getStorageContainerManager());
 
-    GenericTestUtils.waitFor(() ->
-            isContainerClosed(hddsDatanodeService, containerId.getId()),
-        500, 5 * 1000);
+    await().atMost(Duration.ofSeconds(5))
+        .pollInterval(Duration.ofMillis(500))
+        .until(() ->
+            isContainerClosed(hddsDatanodeService, containerId.getId()));
 
     //double check if it's really closed (waitFor also throws an exception)
     Assert.assertTrue(isContainerClosed(hddsDatanodeService,
@@ -657,9 +664,10 @@ public class TestDeleteContainerHandler {
     GenericTestUtils.LogCapturer logCapturer =
         GenericTestUtils.LogCapturer.captureLogs(
             LoggerFactory.getLogger(DeleteContainerCommandHandler.class));
-    GenericTestUtils.waitFor(() -> logCapturer.getOutput().contains("Non" +
-            "-force deletion of non-empty container is not allowed"), 500,
-        5 * 1000);
+    await().atMost(Duration.ofSeconds(5))
+        .pollInterval(Duration.ofMillis(500))
+        .until(() -> logCapturer.getOutput().contains("Non" +
+            "-force deletion of non-empty container is not allowed"));
     ContainerMetrics metrics =
         hddsDatanodeService
             .getDatanodeStateMachine().getContainer().getMetrics();
@@ -671,19 +679,21 @@ public class TestDeleteContainerHandler {
         .getBucket(bucketName).deleteKey(keyName);
 
     // Ensure isEmpty flag is true when key is deleted
-    GenericTestUtils.waitFor(() -> getContainerfromDN(
-            hddsDatanodeService, containerId.getId())
-            .getContainerData().isEmpty(),
-        500, 5 * 2000);
+    await().atMost(Duration.ofSeconds(10))
+        .pollInterval(Duration.ofMillis(500))
+        .until(() ->
+            getContainerfromDN(hddsDatanodeService, containerId.getId())
+                .getContainerData().isEmpty());
 
     // Send the delete command again. It should succeed this time.
     command.setTerm(
         cluster.getStorageContainerManager().getScmContext().getTermOfLeader());
     nodeManager.addDatanodeCommand(datanodeDetails.getUuid(), command);
 
-    GenericTestUtils.waitFor(() ->
-            isContainerDeleted(hddsDatanodeService, containerId.getId()),
-        500, 5 * 1000);
+    await().atMost(Duration.ofSeconds(5))
+        .pollInterval(Duration.ofMillis(500))
+        .until(() ->
+            isContainerDeleted(hddsDatanodeService, containerId.getId()));
 
     Assert.assertTrue(isContainerDeleted(hddsDatanodeService,
         containerId.getId()));
@@ -741,13 +751,13 @@ public class TestDeleteContainerHandler {
         cluster.getStorageContainerManager().getScmContext().getTermOfLeader());
     nodeManager.addDatanodeCommand(datanodeDetails.getUuid(), command);
 
-    GenericTestUtils.waitFor(() ->
-            isContainerDeleted(hddsDatanodeService, containerId.getId()),
-        500, 5 * 1000);
+    await().atMost(Duration.ofSeconds(5))
+        .pollInterval(Duration.ofMillis(500))
+        .until(() ->
+            isContainerDeleted(hddsDatanodeService, containerId.getId()));
 
     Assert.assertTrue(isContainerDeleted(hddsDatanodeService,
         containerId.getId()));
-
   }
 
   /**

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/ozoneimpl/TestOzoneContainerWithTLS.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/ozoneimpl/TestOzoneContainerWithTLS.java
@@ -83,6 +83,7 @@ import static org.apache.hadoop.hdds.HddsConfigKeys.OZONE_METADATA_DIRS;
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.HDDS_DATANODE_DIR_KEY;
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_SECURITY_ENABLED_KEY;
 import static org.apache.hadoop.ozone.container.replication.CopyContainerCompression.NO_COMPRESSION;
+import static org.awaitility.Awaitility.await;
 
 /**
  * Tests ozone containers via secure grpc/netty.
@@ -251,9 +252,10 @@ public class TestOzoneContainerWithTLS {
       containerIdList.add(containerId++);
 
       // Wait certificate to expire
-      GenericTestUtils.waitFor(() ->
-              caClient.getCertificate().getNotAfter().before(new Date()),
-          100, certLifetime);
+      await().atMost(Duration.ofMillis(certLifetime))
+          .pollInterval(Duration.ofMillis(100))
+          .until(() ->
+              caClient.getCertificate().getNotAfter().before(new Date()));
 
       List<DatanodeDetails> sourceDatanodes = new ArrayList<>();
       sourceDatanodes.add(dn);

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/dn/DatanodeTestUtils.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/dn/DatanodeTestUtils.java
@@ -22,10 +22,12 @@ package org.apache.hadoop.ozone.dn;
 import org.apache.hadoop.ozone.container.common.volume.HddsVolume;
 import org.apache.hadoop.ozone.container.common.volume.StorageVolume;
 import org.apache.hadoop.ozone.container.common.volume.MutableVolumeSet;
-import org.apache.ozone.test.GenericTestUtils;
 
 import java.io.File;
 import java.io.IOException;
+import java.time.Duration;
+
+import static org.awaitility.Awaitility.await;
 
 /**
  * Utility offers low-level access methods to datanode.
@@ -222,29 +224,24 @@ public final class DatanodeTestUtils {
 
   /**
    * Wait for detect volume failure.
-   *
-   * @param volSet
-   * @param numOfChecks target number of checks
-   * @throws Exception
    */
   public static void waitForCheckVolume(MutableVolumeSet volSet,
-                                        long numOfChecks) throws Exception {
-    GenericTestUtils.waitFor(
-        () -> numOfChecks == volSet.getVolumeChecker().getNumVolumeChecks(),
-        100, 10000);
+                                        long numOfChecks) {
+    await().atMost(Duration.ofSeconds(10))
+        .pollInterval(Duration.ofMillis(100))
+        .until(() ->
+                numOfChecks == volSet.getVolumeChecker().getNumVolumeChecks());
   }
 
   /**
    * Wait for failed volume to be handled.
-   * @param volSet
-   * @param numOfFailedVolumes
-   * @throws Exception
    */
-  public static void waitForHandleFailedVolume(
-      MutableVolumeSet volSet, int numOfFailedVolumes) throws Exception {
-    GenericTestUtils.waitFor(
-        () -> numOfFailedVolumes == volSet.getFailedVolumesList().size(),
-        100, 10000);
+  public static void waitForHandleFailedVolume(MutableVolumeSet volSet,
+                                               int numOfFailedVolumes) {
+    await().atMost(Duration.ofSeconds(10))
+        .pollInterval(Duration.ofMillis(100))
+        .until(() ->
+            numOfFailedVolumes == volSet.getFailedVolumesList().size());
   }
 
   public static File getHddsVolumeClusterDir(HddsVolume vol) {

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/dn/ratis/TestDnRatisLogParser.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/dn/ratis/TestDnRatisLogParser.java
@@ -21,6 +21,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.PrintStream;
 import java.nio.charset.StandardCharsets;
+import java.time.Duration;
 import java.util.UUID;
 
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
@@ -28,7 +29,6 @@ import org.apache.hadoop.ozone.MiniOzoneCluster;
 import org.apache.hadoop.ozone.OzoneConfigKeys;
 import org.apache.hadoop.ozone.segmentparser.DatanodeRatisLogParser;
 
-import org.apache.ozone.test.GenericTestUtils;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -37,6 +37,7 @@ import org.junit.Test;
 import org.junit.rules.Timeout;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.awaitility.Awaitility.await;
 
 /**
  * Test Datanode Ratis log parser.
@@ -83,7 +84,9 @@ public class TestDnRatisLogParser {
     File pipelineDir = new File(path, pid.toString());
     File currentDir = new File(pipelineDir, "current");
     File logFile = new File(currentDir, "log_inprogress_0");
-    GenericTestUtils.waitFor(logFile::exists, 100, 15000);
+    await().atMost(Duration.ofSeconds(15))
+        .pollInterval(Duration.ofMillis(100))
+        .until(logFile::exists);
     Assert.assertTrue(logFile.isFile());
 
     DatanodeRatisLogParser datanodeRatisLogParser =

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/freon/TestOMSnapshotDAG.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/freon/TestOMSnapshotDAG.java
@@ -72,6 +72,7 @@ import static org.apache.hadoop.ozone.OzoneConsts.DB_COMPACTION_LOG_DIR;
 import static org.apache.hadoop.ozone.OzoneConsts.DB_COMPACTION_SST_BACKUP_DIR;
 import static org.apache.hadoop.ozone.OzoneConsts.OM_KEY_PREFIX;
 import static org.apache.hadoop.ozone.OzoneConsts.OM_SNAPSHOT_DIFF_DIR;
+import static org.awaitility.Awaitility.await;
 
 /**
  * Tests Freon, with MiniOzoneCluster.
@@ -248,9 +249,14 @@ public class TestOMSnapshotDAG {
 
       // RocksDB does checkpointing in a separate thread, wait for it
     final File checkpointSnap1 = new File(snap1.getDbPath());
-    GenericTestUtils.waitFor(checkpointSnap1::exists, 2000, 20000);
+
+    await().atMost(Duration.ofSeconds(20))
+        .pollInterval(Duration.ofSeconds(2))
+        .until(checkpointSnap1::exists);
     final File checkpointSnap2 = new File(snap2.getDbPath());
-    GenericTestUtils.waitFor(checkpointSnap2::exists, 2000, 20000);
+    await().atMost(Duration.ofSeconds(20))
+        .pollInterval(Duration.ofSeconds(2))
+        .until(checkpointSnap2::exists);
 
     List<String> sstDiffList21 = differ.getSSTDiffList(snap2, snap1);
     LOG.debug("Got diff list: {}", sstDiffList21);
@@ -271,7 +277,9 @@ public class TestOMSnapshotDAG {
         ((RDBStore)((OmSnapshot)snapDB3.get())
             .getMetadataManager().getStore()).getDb().getManagedRocksDb());
     final File checkpointSnap3 = new File(snap3.getDbPath());
-    GenericTestUtils.waitFor(checkpointSnap3::exists, 2000, 20000);
+    await().atMost(Duration.ofSeconds(20))
+        .pollInterval(Duration.ofSeconds(2))
+        .until(checkpointSnap3::exists);
 
     List<String> sstDiffList32 = differ.getSSTDiffList(snap3, snap2);
 
@@ -366,5 +374,4 @@ public class TestOMSnapshotDAG {
     Assertions.assertNotNull(fileList);
     Assertions.assertEquals(0L, fileList.length);
   }
-
 }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/freon/TestRandomKeyGenerator.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/freon/TestRandomKeyGenerator.java
@@ -33,7 +33,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 import picocli.CommandLine;
 
-import static org.apache.ozone.test.GenericTestUtils.waitFor;
+import static org.awaitility.Awaitility.await;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -81,7 +81,9 @@ public class TestRandomKeyGenerator {
 
     assertThrows(RuntimeException.class, () -> subject.runTests(
         n -> {
-          waitFor(subject::isCompleted, 100, 3000);
+          await().atMost(Duration.ofSeconds(3))
+              .pollInterval(Duration.ofMillis(100))
+              .until(subject::isCompleted);
           throw new RuntimeException("fail");
         }
     ));

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestKeyPurging.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestKeyPurging.java
@@ -138,7 +138,9 @@ public class TestKeyPurging {
     await().atMost(Duration.ofSeconds(10))
         .pollInterval(Duration.ofSeconds(1))
         .untilAsserted(() -> Assert.assertTrue(
-            keyDeletingService.getRunCount().get() >= NUM_KEYS));
+            keyDeletingService.getDeletedKeyCount().get() >= NUM_KEYS));
+
+    Assert.assertTrue(keyDeletingService.getRunCount().get() > 1);
 
     await().atMost(Duration.ofSeconds(10))
         .pollInterval(Duration.ofSeconds(1))

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOMDbCheckpointServlet.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOMDbCheckpointServlet.java
@@ -35,6 +35,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.security.Principal;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -86,8 +87,6 @@ import static org.apache.hadoop.ozone.OzoneConsts.OZONE_DB_CHECKPOINT_REQUEST_FL
 import static org.apache.hadoop.ozone.OzoneConsts.OZONE_DB_CHECKPOINT_REQUEST_TO_EXCLUDE_SST;
 import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_HTTP_AUTH_TYPE;
 
-import org.apache.ozone.test.GenericTestUtils;
-
 import org.junit.Assert;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
@@ -104,6 +103,7 @@ import static org.apache.hadoop.ozone.om.OmSnapshotManager.OM_HARDLINK_FILE;
 import static org.apache.hadoop.ozone.om.snapshot.OmSnapshotUtils.truncateFileName;
 import static org.apache.hadoop.ozone.om.OmSnapshotManager.getSnapshotPath;
 import static org.apache.ozone.rocksdiff.RocksDBCheckpointDiffer.COMPACTION_LOG_FILE_NAME_SUFFIX;
+import static org.awaitility.Awaitility.await;
 import static org.junit.jupiter.params.provider.Arguments.arguments;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
@@ -750,8 +750,10 @@ public class TestOMDbCheckpointServlet {
         .get(SnapshotInfo.getTableKey(vname, bname, snapshotName));
     String snapshotPath = getSnapshotPath(conf, snapshotInfo)
         + OM_KEY_PREFIX;
-    GenericTestUtils.waitFor(() -> new File(snapshotPath).exists(),
-        100, 2000);
+
+    await().atMost(Duration.ofSeconds(2))
+        .pollInterval(Duration.ofMillis(100))
+        .until(() -> new File(snapshotPath).exists());
     return snapshotPath;
   }
 

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestObjectStoreWithFSO.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestObjectStoreWithFSO.java
@@ -822,8 +822,14 @@ public class TestObjectStoreWithFSO {
       // wait for DB updates
       await().atMost(Duration.ofSeconds(120))
           .pollInterval(Duration.ofSeconds(1))
-          .ignoreException(IOException.class)
-          .until(() -> openFileTable.get(dbOpenFileKey) == null);
+          .until(() -> {
+            try {
+              return openFileTable.get(dbOpenFileKey) == null;
+            } catch (IOException e) {
+              Assert.fail("DB failure.");
+              return false;
+            }
+          });
     } else {
       OmKeyInfo omKeyInfo = openFileTable.get(dbOpenFileKey);
       Assert.assertNotNull("Table is empty!", omKeyInfo);

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestObjectStoreWithLegacyFS.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestObjectStoreWithLegacyFS.java
@@ -42,7 +42,6 @@ import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
 import org.apache.hadoop.ozone.om.helpers.OmMultipartCommitUploadPartInfo;
 import org.apache.hadoop.ozone.om.helpers.OmMultipartUploadCompleteInfo;
 
-import org.apache.ozone.test.GenericTestUtils;
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.Before;
@@ -54,10 +53,13 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
+import java.time.Duration;
 import java.util.Arrays;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.UUID;
+
+import static org.awaitility.Awaitility.await;
 
 /**
  * Test verifies object store with OZONE_OM_ENABLE_FILESYSTEM_PATHS enabled.
@@ -135,15 +137,15 @@ public class TestObjectStoreWithLegacyFS {
     String dbKey = cluster.getOzoneManager().getMetadataManager()
         .getOzoneKey(volumeName, bucketName, seekKey);
 
-    GenericTestUtils
-        .waitFor(() -> assertKeyCount(keyTable, dbKey, 1, keyName), 500,
-            60000);
+    await().atMost(Duration.ofSeconds(60))
+        .pollInterval(Duration.ofMillis(500))
+        .until(() -> assertKeyCount(keyTable, dbKey, 1, keyName));
 
     ozoneBucket.renameKey(keyName, "dir1/NewKey-1");
 
-    GenericTestUtils
-        .waitFor(() -> assertKeyCount(keyTable, dbKey, 1, "dir1/NewKey-1"), 500,
-            60000);
+    await().atMost(Duration.ofSeconds(60))
+        .pollInterval(Duration.ofMillis(500))
+        .until(() -> assertKeyCount(keyTable, dbKey, 1, "dir1/NewKey-1"));
   }
 
   private boolean assertKeyCount(

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOmSnapshotFileSystem.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOmSnapshotFileSystem.java
@@ -494,8 +494,14 @@ public class TestOmSnapshotFileSystem {
     if (!enabledFileSystemPaths) {
       await().atMost(Duration.ofSeconds(120))
           .pollInterval(Duration.ofSeconds(1))
-          .ignoreException(IOException.class)
-          .until(() -> fs.listStatus(parent).length != 0);
+          .until(() -> {
+            try {
+              return fs.listStatus(parent).length != 0;
+            } catch (IOException e) {
+              Assert.fail("listStatus() failed.");
+              return false;
+            }
+          });
     }
 
     String snapshotKeyPrefix = createSnapshot();
@@ -518,8 +524,14 @@ public class TestOmSnapshotFileSystem {
     if (!enabledFileSystemPaths) {
       await().atMost(Duration.ofSeconds(120))
           .pollInterval(Duration.ofSeconds(1))
-          .ignoreException(IOException.class)
-          .until(() -> fs.listStatus(parent).length != 0);
+          .until(() -> {
+            try {
+              return fs.listStatus(parent).length != 0;
+            } catch (IOException e) {
+              Assert.fail("listStatus() failed.");
+              return false;
+            }
+          });
     }
 
     String snapshotKeyPrefix = createSnapshot();
@@ -547,8 +559,14 @@ public class TestOmSnapshotFileSystem {
     if (!enabledFileSystemPaths) {
       await().atMost(Duration.ofSeconds(120))
           .pollInterval(Duration.ofSeconds(1))
-          .ignoreException(IOException.class)
-          .until(() -> fs.listStatus(parent).length != 0);
+          .until(() -> {
+            try {
+              return fs.listStatus(parent).length != 0;
+            } catch (IOException e) {
+              Assert.fail("listStatus() failed.");
+              return false;
+            }
+          });
     }
 
     String snapshotKeyPrefix = createSnapshot();

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerHAMetrics.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerHAMetrics.java
@@ -17,15 +17,15 @@
 package org.apache.hadoop.ozone.om;
 
 import org.apache.hadoop.ozone.om.ha.OMHAMetrics;
-import org.apache.ozone.test.GenericTestUtils;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
+import java.time.Duration;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
 
 import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_RATIS_SERVER_FAILURE_TIMEOUT_DURATION_DEFAULT;
+import static org.awaitility.Awaitility.await;
 
 /**
  * Test Ozone Manager HA Metrics.
@@ -90,15 +90,13 @@ public class TestOzoneManagerHAMetrics extends TestOzoneManagerHA {
 
 
   /**
-   * After restarting OMs we need to wait
-   * for a leader to be elected and ready.
+   * After restarting OMs we need to wait for a leader to be elected and ready.
    */
-  private void waitForLeaderToBeReady()
-      throws InterruptedException, TimeoutException {
-    // Wait for Leader Election timeout
+  private void waitForLeaderToBeReady() {
     int timeout = OZONE_OM_RATIS_SERVER_FAILURE_TIMEOUT_DURATION_DEFAULT
         .toIntExact(TimeUnit.MILLISECONDS);
-    GenericTestUtils.waitFor(() ->
-        getCluster().getOMLeader() != null, 500, timeout);
+    await().atMost(Duration.ofMillis(timeout))
+        .pollInterval(Duration.ofMillis(500))
+        .until(() -> getCluster().getOMLeader() != null);
   }
 }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestScmSafeMode.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestScmSafeMode.java
@@ -206,10 +206,16 @@ public class TestScmSafeMode {
     // Test 3: SCM should be out of safe mode.
     await().atMost(Duration.ofSeconds(5))
         .pollInterval(Duration.ofMillis(100))
-        .ignoreException(IOException.class)
-        .until(() -> !cluster.getStorageContainerManager()
-            .getClientProtocolServer()
-            .inSafeMode());
+        .until(() -> {
+          try {
+            return !cluster.getStorageContainerManager()
+                .getClientProtocolServer()
+                .inSafeMode();
+          } catch (IOException e) {
+            Assert.fail("Cluster.");
+            return false;
+          }
+        });
   }
 
   @Test(timeout = 300_000)

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/multitenant/TestMultiTenantVolume.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/multitenant/TestMultiTenantVolume.java
@@ -155,10 +155,16 @@ public class TestMultiTenantVolume {
     await().atMost(Duration.ofSeconds(10))
         .pollInterval(Duration.ofMillis(500))
         .until(() -> {
-          final UpgradeFinalizer.StatusAndMessages progress =
-              omClient.queryUpgradeFinalizationProgress(
-                  upgradeClientID, false, false);
-          return isDone(progress.status());
+          try {
+            final UpgradeFinalizer.StatusAndMessages progress =
+                omClient.queryUpgradeFinalizationProgress(
+                    upgradeClientID, false, false);
+            return isDone(progress.status());
+          } catch (IOException e) {
+            Assert.fail("Unexpected exception while waiting for "
+                + "the OM upgrade to finalize. " + e.getMessage());
+            return false;
+          }
         });
   }
 

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/service/TestRangerBGSyncService.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/service/TestRangerBGSyncService.java
@@ -23,6 +23,7 @@ import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_RANGER_HTTPS_ADDRESS
 import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_RANGER_SERVICE;
 import static org.apache.hadoop.ozone.om.OMMultiTenantManager.OZONE_TENANT_RANGER_ROLE_DESCRIPTION;
 import static org.apache.hadoop.security.authentication.util.KerberosName.DEFAULT_MECHANISM;
+import static org.awaitility.Awaitility.await;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doNothing;
@@ -34,6 +35,7 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashSet;
@@ -480,8 +482,9 @@ public class TestRangerBGSyncService {
     bgSync.start();
     // Wait for sync to finish once.
     // The counter is incremented at the beginning of the run, hence the ">"
-    GenericTestUtils.waitFor(() -> bgSync.getRangerSyncRunCount() > 1L,
-        CHECK_SYNC_MILLIS, WAIT_SYNC_TIMEOUT_MILLIS);
+    await().atMost(Duration.ofMillis(WAIT_SYNC_TIMEOUT_MILLIS))
+        .pollInterval(Duration.ofMillis(CHECK_SYNC_MILLIS))
+        .until(() -> bgSync.getRangerSyncRunCount() > 1L);
     bgSync.shutdown();
     final long dbSvcVersionAfter = bgSync.getOMDBRangerServiceVersion();
     final long rangerSvcVersionAfter =
@@ -543,8 +546,9 @@ public class TestRangerBGSyncService {
     bgSync.start();
     // Wait for sync to finish once.
     // The counter is incremented at the beginning of the run, hence the ">"
-    GenericTestUtils.waitFor(() -> bgSync.getRangerSyncRunCount() > 1L,
-        CHECK_SYNC_MILLIS, WAIT_SYNC_TIMEOUT_MILLIS);
+    await().atMost(Duration.ofMillis(WAIT_SYNC_TIMEOUT_MILLIS))
+        .pollInterval(Duration.ofMillis(CHECK_SYNC_MILLIS))
+        .until(() -> bgSync.getRangerSyncRunCount() > 1L);
     bgSync.shutdown();
     final long dbSvcVersionAfter = bgSync.getOMDBRangerServiceVersion();
     final long rangerSvcVersionAfter =
@@ -615,9 +619,9 @@ public class TestRangerBGSyncService {
     bgSync.start();
     // Wait for sync to finish once.
     // The counter is incremented at the beginning of the run, hence the ">"
-    GenericTestUtils.waitFor(
-        () -> bgSync.getRangerSyncRunCount() > currRunCount + 1L,
-        CHECK_SYNC_MILLIS, WAIT_SYNC_TIMEOUT_MILLIS);
+    await().atMost(Duration.ofMillis(WAIT_SYNC_TIMEOUT_MILLIS))
+        .pollInterval(Duration.ofMillis(CHECK_SYNC_MILLIS))
+        .until(() -> bgSync.getRangerSyncRunCount() > currRunCount + 1L);
     bgSync.shutdown();
     final long dbSvcVersionAfter = bgSync.getOMDBRangerServiceVersion();
     final long rangerSvcVersionAfter =
@@ -673,8 +677,9 @@ public class TestRangerBGSyncService {
     bgSync.start();
     // Wait for sync to finish once.
     // The counter is incremented at the beginning of the run, hence the ">"
-    GenericTestUtils.waitFor(() -> bgSync.getRangerSyncRunCount() > 1L,
-        CHECK_SYNC_MILLIS, WAIT_SYNC_TIMEOUT_MILLIS);
+    await().atMost(Duration.ofMillis(WAIT_SYNC_TIMEOUT_MILLIS))
+        .pollInterval(Duration.ofMillis(CHECK_SYNC_MILLIS))
+        .until(() -> bgSync.getRangerSyncRunCount() > 1L);
     bgSync.shutdown();
     long dbSvcVersionAfter = bgSync.getOMDBRangerServiceVersion();
     final long rangerSvcVersionAfter =

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/parser/TestOzoneHARatisLogParser.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/parser/TestOzoneHARatisLogParser.java
@@ -31,7 +31,6 @@ import org.apache.hadoop.ozone.om.helpers.OMRatisHelper;
 import org.apache.hadoop.ozone.MiniOzoneCluster;
 import org.apache.hadoop.ozone.segmentparser.OMRatisLogParser;
 import org.apache.hadoop.ozone.segmentparser.SCMRatisLogParser;
-import org.apache.ozone.test.GenericTestUtils;
 import org.apache.ozone.test.tag.Flaky;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
@@ -42,10 +41,12 @@ import org.junit.jupiter.api.Timeout;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.PrintStream;
+import java.time.Duration;
 import java.util.UUID;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.apache.hadoop.hdds.HddsConfigKeys.OZONE_METADATA_DIRS;
+import static org.awaitility.Awaitility.await;
 
 /**
  * Test Ozone OM and SCM HA Ratis log parser.
@@ -125,13 +126,15 @@ class TestOzoneHARatisLogParser {
     Assertions.assertTrue(groupDir.isDirectory());
     File currentDir = new File(groupDir, "current");
     File logFile = new File(currentDir, "log_inprogress_0");
-    GenericTestUtils.waitFor(logFile::exists, 100, 15000);
+
+    await().atMost(Duration.ofSeconds(15))
+        .pollInterval(Duration.ofMillis(100))
+        .until(logFile::exists);
     Assertions.assertTrue(logFile.isFile());
 
     OMRatisLogParser omRatisLogParser = new OMRatisLogParser();
     omRatisLogParser.setSegmentFile(logFile);
     omRatisLogParser.parseRatisLogs(OMRatisHelper::smProtoToString);
-
 
     // Not checking total entry count, because of not sure of exact count of
     // metadata entry changes.
@@ -154,7 +157,10 @@ class TestOzoneHARatisLogParser {
     Assertions.assertTrue(groupDir.isDirectory());
     currentDir = new File(groupDir, "current");
     logFile = new File(currentDir, "log_inprogress_1");
-    GenericTestUtils.waitFor(logFile::exists, 100, 15000);
+
+    await().atMost(Duration.ofSeconds(15))
+        .pollInterval(Duration.ofMillis(100))
+        .until(logFile::exists);
     Assertions.assertTrue(logFile.isFile());
 
     SCMRatisLogParser scmRatisLogParser = new SCMRatisLogParser();

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/scm/TestCloseContainer.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/scm/TestCloseContainer.java
@@ -30,7 +30,6 @@ import org.apache.hadoop.ozone.OzoneTestUtils;
 import org.apache.hadoop.ozone.TestDataUtil;
 import org.apache.hadoop.ozone.client.OzoneBucket;
 import org.apache.hadoop.ozone.client.OzoneClient;
-import org.apache.ozone.test.GenericTestUtils;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -48,6 +47,7 @@ import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_PIPELINE_REPORT_INTERVA
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_DEADNODE_INTERVAL;
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_HEARTBEAT_PROCESS_INTERVAL;
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_STALENODE_INTERVAL;
+import static org.awaitility.Awaitility.await;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -129,8 +129,9 @@ public class TestCloseContainer {
     assertEquals(originalSeq, newContainer.getSequenceId());
 
     // Ensure 3 replicas are reported successfully as expected.
-    GenericTestUtils.waitFor(() ->
-            getContainerReplicas(newContainer).size() == 3, 200, 30000);
+    await().atMost(Duration.ofSeconds(20))
+        .pollInterval(Duration.ofMillis(200))
+        .until(() -> getContainerReplicas(newContainer).size() == 3);
   }
 
   /**
@@ -138,12 +139,10 @@ public class TestCloseContainer {
    * if the container cannot be found. This is a helper method to allow the
    * container replica count to be checked in a lambda expression.
    * @param c The container for which to retrieve replicas
-   * @return
    */
   private Set<ContainerReplica> getContainerReplicas(ContainerInfo c) {
     return assertDoesNotThrow(() -> cluster.getStorageContainerManager()
         .getContainerManager().getContainerReplicas(c.containerID()),
         "Unexpected exception while retrieving container replicas");
   }
-
 }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/scm/TestSCMInstallSnapshotWithHA.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/scm/TestSCMInstallSnapshotWithHA.java
@@ -19,6 +19,7 @@ package org.apache.hadoop.ozone.scm;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
@@ -48,6 +49,7 @@ import org.apache.ozone.test.GenericTestUtils;
 import org.apache.ozone.test.tag.Flaky;
 import org.apache.ratis.server.protocol.TermIndex;
 
+import static org.awaitility.Awaitility.await;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.assertFalse;
 
@@ -143,9 +145,10 @@ public class TestSCMInstallSnapshotWithHA {
     // Wait & retry for follower to update transactions to leader
     // snapshot index.
     // Timeout error if follower does not load update within 3s
-    GenericTestUtils.waitFor(() -> {
-      return followerSM.getLastAppliedTermIndex().getIndex() >= 200;
-    }, 100, 3000);
+
+    await().atMost(Duration.ofSeconds(3))
+        .pollInterval(Duration.ofMillis(100))
+        .until(() -> followerSM.getLastAppliedTermIndex().getIndex() >= 200);
     long followerLastAppliedIndex =
         followerSM.getLastAppliedTermIndex().getIndex();
     assertTrue(followerLastAppliedIndex >= 200);

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/shell/TestOzoneDebugShell.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/shell/TestOzoneDebugShell.java
@@ -39,7 +39,6 @@ import org.apache.hadoop.ozone.om.OMConfigKeys;
 import org.apache.hadoop.ozone.om.OMStorage;
 import org.apache.hadoop.ozone.om.helpers.OmKeyArgs;
 import org.apache.hadoop.ozone.om.helpers.OmKeyLocationInfo;
-import org.apache.ozone.test.GenericTestUtils;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
@@ -64,6 +63,7 @@ import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_HEARTBEAT_PROCE
 import static org.apache.hadoop.ozone.OzoneConsts.OM_KEY_PREFIX;
 import static org.apache.hadoop.ozone.OzoneConsts.OM_SNAPSHOT_CHECKPOINT_DIR;
 import static org.apache.hadoop.ozone.OzoneConsts.OM_DB_NAME;
+import static org.awaitility.Awaitility.await;
 
 /**
  * Test Ozone Debug shell.
@@ -151,8 +151,10 @@ public class TestOzoneDebugShell {
     Assertions.assertEquals(snapshotName, snapshot.getName());
     String dbPath = getSnapshotDBPath(snapshot.getCheckpointDir());
     String snapshotCurrent = dbPath + OM_KEY_PREFIX + "CURRENT";
-    GenericTestUtils
-        .waitFor(() -> new File(snapshotCurrent).exists(), 1000, 120000);
+
+    await().atMost(Duration.ofSeconds(120))
+        .pollInterval(Duration.ofSeconds(1))
+        .until(() ->  new File(snapshotCurrent).exists());
     String[] args =
         new String[] {"--db=" + dbPath, "scan", "--cf", "keyTable"};
     int exitCode = cmd.execute(args);

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/ratis/TestOzoneManagerDoubleBufferWithDummyResponse.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/ratis/TestOzoneManagerDoubleBufferWithDummyResponse.java
@@ -19,6 +19,7 @@
 package org.apache.hadoop.ozone.om.ratis;
 
 import java.io.IOException;
+import java.time.Duration;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicLong;
 
@@ -48,7 +49,7 @@ import org.apache.hadoop.hdds.utils.db.BatchOperation;
 import static org.apache.hadoop.hdds.HddsConfigKeys.OZONE_METADATA_DIRS;
 import static org.apache.hadoop.ozone.OzoneConsts.TRANSACTION_INFO_KEY;
 import static org.apache.hadoop.ozone.om.OmMetadataManagerImpl.BUCKET_TABLE;
-import static org.apache.ozone.test.GenericTestUtils.waitFor;
+import static org.awaitility.Awaitility.await;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
@@ -114,8 +115,10 @@ public class TestOzoneManagerDoubleBufferWithDummyResponse {
       doubleBuffer.add(createDummyBucketResponse(volumeName),
           trxId.incrementAndGet());
     }
-    waitFor(() -> metrics.getTotalNumOfFlushedTransactions() == bucketCount,
-        100, 60000);
+
+    await().atMost(Duration.ofSeconds(60))
+        .pollInterval(Duration.ofMillis(100))
+        .until(() -> metrics.getTotalNumOfFlushedTransactions() == bucketCount);
 
     assertTrue(metrics.getTotalNumOfFlushOperations() > 0);
     assertEquals(bucketCount, doubleBuffer.getFlushedTransactionCount());

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/service/TestOpenKeyCleanupService.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/service/TestOpenKeyCleanupService.java
@@ -40,7 +40,6 @@ import org.apache.hadoop.ozone.om.helpers.OmVolumeArgs;
 import org.apache.hadoop.ozone.om.helpers.OpenKeySession;
 import org.apache.hadoop.ozone.om.protocol.OzoneManagerProtocol;
 import org.apache.hadoop.ozone.om.request.OMRequestTestUtils;
-import org.apache.ozone.test.GenericTestUtils;
 import org.apache.ratis.util.ExitUtils;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
@@ -62,6 +61,7 @@ import java.util.concurrent.TimeUnit;
 
 import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_OPEN_KEY_CLEANUP_SERVICE_INTERVAL;
 import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_OPEN_KEY_EXPIRE_THRESHOLD;
+import static org.awaitility.Awaitility.await;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -164,10 +164,9 @@ public class TestOpenKeyCleanupService {
 
     openKeyCleanupService.resume();
 
-    GenericTestUtils.waitFor(() -> openKeyCleanupService
-            .getRunCount() > oldrunCount,
-        (int) SERVICE_INTERVAL.toMillis(),
-        5 * (int) SERVICE_INTERVAL.toMillis());
+    await().atMost(SERVICE_INTERVAL.multipliedBy(5))
+        .pollInterval(SERVICE_INTERVAL)
+        .until(() -> openKeyCleanupService.getRunCount() > oldrunCount);
 
     // wait for requests to complete
     final int n = hsync ? numDEFKeys + numFSOKeys : 1;


### PR DESCRIPTION
## What changes were proposed in this pull request?
This change is to replace [GenericTestUtils#wait](https://github.com/apache/ozone/blob/387c53781aae03f944906a0add58f51250d36687/hadoop-hdds/test-utils/src/main/java/org/apache/ozone/test/GenericTestUtils.java#L214) with [Awaitility#await](https://github.com/awaitility/awaitility) hadoop-ozone packages. Awaitility provides the same functionality as **GenericTestUtils** with more granular configuration.

This is part 3 of [HDDS-9147](https://issues.apache.org/jira/browse/HDDS-9147).

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-9147

## How was this patch tested?
No functional or logical change so just run the CI/CD on fork couple of time.
* https://github.com/hemantk-12/ozone/actions/runs/5843839777
* https://github.com/hemantk-12/ozone/actions/runs/5844969161
