### PR TITLE
HDDS-9165. Exclude empty CLOSED containers in ContainerSafeModeRule.

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/safemode/ContainerSafeModeRule.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/safemode/ContainerSafeModeRule.java
@@ -78,7 +78,8 @@ public class ContainerSafeModeRule extends
 
       Optional.ofNullable(container.getState())
           .filter(state -> (state == HddsProtos.LifeCycleState.QUASI_CLOSED ||
-              state == HddsProtos.LifeCycleState.CLOSED))
+              state == HddsProtos.LifeCycleState.CLOSED)
+              && container.getNumberOfKeys() > 0)
           .ifPresent(s -> containerMap.put(container.getContainerID(),
               container));
     });
@@ -166,7 +167,8 @@ public class ContainerSafeModeRule extends
 
       Optional.ofNullable(container.getState())
           .filter(state -> (state == HddsProtos.LifeCycleState.QUASI_CLOSED ||
-              state == HddsProtos.LifeCycleState.CLOSED))
+              state == HddsProtos.LifeCycleState.CLOSED)
+              && container.getNumberOfKeys() > 0)
           .ifPresent(s -> containerMap.put(container.getContainerID(),
               container));
     });

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/safemode/TestSCMSafeModeManager.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/safemode/TestSCMSafeModeManager.java
@@ -501,12 +501,19 @@ public class TestSCMSafeModeManager {
     // Add 100 containers to the list of containers in SCM
     containers.addAll(HddsTestUtils.getContainerInfo(25 * 4));
     // Assign CLOSED state to first 25 containers and OPEN state to rest
-    // of the containers
+    // of the containers. Set container key count = 10 in each container.
     for (ContainerInfo container : containers.subList(0, 25)) {
       container.setState(HddsProtos.LifeCycleState.CLOSED);
+      container.setNumberOfKeys(10);
     }
     for (ContainerInfo container : containers.subList(25, 100)) {
       container.setState(HddsProtos.LifeCycleState.OPEN);
+      container.setNumberOfKeys(10);
+    }
+
+    // Set the last 5 closed containers to be empty
+    for (ContainerInfo container : containers.subList(20, 25)) {
+      container.setNumberOfKeys(0);
     }
 
     scmSafeModeManager = new SCMSafeModeManager(
@@ -515,14 +522,15 @@ public class TestSCMSafeModeManager {
     assertTrue(scmSafeModeManager.getInSafeMode());
 
     // When 10 CLOSED containers are reported by DNs, the computed container
-    // threshold should be 10/25 as there are only 25 CLOSED containers.
+    // threshold should be 10/20 as there are only 20 CLOSED NON-EMPTY
+    // containers.
     // Containers in OPEN state should not contribute towards list of
     // containers while calculating container threshold in SCMSafeNodeManager
-    testContainerThreshold(containers.subList(0, 10), 0.4);
+    testContainerThreshold(containers.subList(0, 10), 0.5);
     assertTrue(scmSafeModeManager.getInSafeMode());
 
-    // When remaining 15 OPEN containers are reported by DNs, the container
-    // threshold should be (10+15)/25.
+    // When remaining 10 CLOSED NON-EMPTY containers are reported by DNs,
+    // the container threshold should be (10+10)/20.
     testContainerThreshold(containers.subList(10, 25), 1.0);
 
     GenericTestUtils.waitFor(() -> !scmSafeModeManager.getInSafeMode(),


### PR DESCRIPTION
## What changes were proposed in this pull request?
The containers which are created in SCM and never got created on the datanodes (allocated block discarded by the client) and moved to CLOSING state during pipeline deletion and are marked as CLOSED by [HDDS-7882](https://issues.apache.org/jira/browse/HDDS-7882).
When SCM is restarted before those containers are deleted, we end up having CLOSED (empty) containers in SCM but no corresponding replicas on any of the datanodes. This is causing the SCM to be stuck in safemode. 
This change modifies safe mode rule to exclude closed empty containers.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-9165

## How was this patch tested?
Unit test
