### PR TITLE
HDDS-9166. Fix OZONE_OM_UPGRADE_QUOTA_RECALCULATE_ENABLE default value

### DIFF
--- a/hadoop-hdds/common/src/main/resources/ozone-default.xml
+++ b/hadoop-hdds/common/src/main/resources/ozone-default.xml
@@ -4171,7 +4171,7 @@
   </property>
   <property>
     <name>ozone.om.upgrade.quota.recalculate.enabled</name>
-    <value>false</value>
+    <value>true</value>
     <tag>OZONE, OM</tag>
     <description>
       quota recalculation trigger when upgrade to the layout version QUOTA.

--- a/hadoop-hdds/common/src/main/resources/ozone-default.xml
+++ b/hadoop-hdds/common/src/main/resources/ozone-default.xml
@@ -4171,7 +4171,7 @@
   </property>
   <property>
     <name>ozone.om.upgrade.quota.recalculate.enabled</name>
-    <value>true</value>
+    <value>false</value>
     <tag>OZONE, OM</tag>
     <description>
       quota recalculation trigger when upgrade to the layout version QUOTA.

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/OMConfigKeys.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/OMConfigKeys.java
@@ -563,4 +563,7 @@ public final class OMConfigKeys {
 
   public static final String OZONE_OM_UPGRADE_QUOTA_RECALCULATE_ENABLE
       = "ozone.om.upgrade.quota.recalculate.enabled";
+
+  public static final boolean OZONE_OM_UPGRADE_QUOTA_RECALCULATE_ENABLE_DEFAULT
+      = false;
 }

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/OMConfigKeys.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/OMConfigKeys.java
@@ -565,5 +565,5 @@ public final class OMConfigKeys {
       = "ozone.om.upgrade.quota.recalculate.enabled";
 
   public static final boolean OZONE_OM_UPGRADE_QUOTA_RECALCULATE_ENABLE_DEFAULT
-      = false;
+      = true;
 }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/upgrade/QuotaRepairUpgradeAction.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/upgrade/QuotaRepairUpgradeAction.java
@@ -35,7 +35,8 @@ public class QuotaRepairUpgradeAction implements OmUpgradeAction {
   @Override
   public void execute(OzoneManager arg) throws Exception {
     boolean enabled = arg.getConfiguration().getBoolean(
-        OMConfigKeys.OZONE_OM_UPGRADE_QUOTA_RECALCULATE_ENABLE, false);
+        OMConfigKeys.OZONE_OM_UPGRADE_QUOTA_RECALCULATE_ENABLE,
+        OMConfigKeys.OZONE_OM_UPGRADE_QUOTA_RECALCULATE_ENABLE_DEFAULT);
     if (enabled) {
       QuotaRepairTask quotaRepairTask = new QuotaRepairTask(
           arg.getMetadataManager());


### PR DESCRIPTION
## What changes were proposed in this pull request?

The default value in `QuotaRepairUpgradeAction` class is not the same in `ozone-site.xml`, which is confusing. 
In fact, `QuotaRepairTask` will be very time consuming during upgrading om, the time taken is as follows:

```java
// test 1
2023-07-05 16:15:36,432 [pool-37-thread-1] INFO org.apache.hadoop.ozone.om.service.QuotaRepairTask: Recalculate Key usages completed, count 259337075 time 1873737ms
// test 2
2023-08-13 17:35:45,622 [pool-37-thread-2] INFO org.apache.hadoop.ozone.om.service.QuotaRepairTask: Recalculate File usages completed, count 19752234 time 440393ms
```

I prefer that `ozone.om.upgrade.quota.recalculate.enabled` default to false.


## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-9166

## How was this patch tested?


