### PR TITLE
HDDS-9144. [Linked Buckets] No check on source volume/bucket while creating links.

### DIFF
--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/BucketManagerImpl.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/BucketManagerImpl.java
@@ -78,11 +78,13 @@ public class BucketManagerImpl implements BucketManager {
         final String dbVolumeKey = metadataManager.getVolumeKey(volumeName);
         if (metadataManager.getVolumeTable().get(dbVolumeKey) == null) {
           // Parent volume doesn't exist, throw VOLUME_NOT_FOUND
-          throw new OMException("Volume not found when getting bucket info",
+          throw new OMException(
+              "Volume " + volumeName + " not found when getting bucket info",
               VOLUME_NOT_FOUND);
         } else {
           // Parent volume exists, throw BUCKET_NOT_FOUND
-          throw new OMException("Bucket not found", BUCKET_NOT_FOUND);
+          throw new OMException("Bucket " + bucketName + " not found",
+              BUCKET_NOT_FOUND);
         }
       }
 

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/OzoneAddress.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/OzoneAddress.java
@@ -31,6 +31,8 @@ import org.apache.hadoop.ozone.OmUtils;
 import org.apache.hadoop.ozone.client.OzoneClient;
 import org.apache.hadoop.ozone.client.OzoneClientException;
 import org.apache.hadoop.ozone.client.OzoneClientFactory;
+import org.apache.hadoop.ozone.client.OzoneVolume;
+import org.apache.hadoop.ozone.om.exceptions.OMException;
 import org.apache.hadoop.ozone.security.acl.OzoneObj;
 import org.apache.hadoop.ozone.security.acl.OzoneObjInfo;
 
@@ -474,6 +476,36 @@ public class OzoneAddress {
       // Depending on operation is on volume or bucket
       throw new OzoneClientException(
             "Volume name is missing.");
+    }
+  }
+
+  /**
+   * Validate if volume and bucket exists.
+   * @param rpcClient the rpc client
+   * @throws IOException
+   */
+  public void ensureVolumeAndBucketExist(OzoneClient rpcClient)
+      throws IOException {
+    OzoneVolume volume;
+    ensureVolumeExists(rpcClient);
+    volume = rpcClient.getObjectStore().getVolume(volumeName);
+    try {
+      volume.getBucket(bucketName);
+    } catch (OMException ex) {
+      throw ex;
+    }
+  }
+
+  /**
+   * Validate if volume exists.
+   * @param rpcClient the rpc client
+   * @throws IOException
+   */
+  public void ensureVolumeExists(OzoneClient rpcClient) throws IOException {
+    try {
+      rpcClient.getObjectStore().getVolume(volumeName);
+    } catch (OMException ex) {
+      throw ex;
     }
   }
 }

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/bucket/LinkBucketHandler.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/bucket/LinkBucketHandler.java
@@ -65,6 +65,9 @@ public class LinkBucketHandler extends Handler {
         .setSourceVolume(source.getVolumeName())
         .setSourceBucket(source.getBucketName());
 
+    // Validate Source Volume and Source Bucket
+    address.ensureVolumeAndBucketExist(client);
+
     String volumeName = target.getVolumeName();
     String bucketName = target.getBucketName();
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

While creating a bucket link , there is no check to validate volume / bucket exist or path is valid .

But a dummy orphan link is getting created .

IMO its good to have a check on the source volume/bucket and path being passed in the command.

```
[root@quasar-rsyvvc-1 ~]# ozone sh bucket link --help
Usage: ozone sh bucket link [-hV] <source> <target>
creates a symlink to another bucket
      <source>    The bucket which the link should point to.
      <target>    Address of the link bucket
  -h, --help      Show this help message and exit.
  -V, --version   Print version information and exit.
[root@quasar-rsyvvc-1 ~]# ozone sh bucket link imaginaryvol1/imaginarybuck vol111111/bucketlink
23/08/09 19:41:22 INFO rpc.RpcClient: Creating Bucket: vol111111/bucketlink, with server-side default bucket layout, hdfs as owner, Versioning false, Storage Type set to DISK and Encryption set to false, Replication Type set to server-side default replication type, Namespace Quota set to -1, Space Quota set to -1 
[root@quasar-rsyvvc-1 ~]#  ozone sh volume info imaginaryvol1
VOLUME_NOT_FOUND Volume imaginaryvol1 is not found
[root@quasar-rsyvvc-1 ~]# ozone sh bucket list vol111111
[ {
  "metadata" : { },
  "volumeName" : "vol111111",
  "name" : "buck1111",
  "storageType" : "DISK",
  "versioning" : false,
  "usedBytes" : 3000000000,
  "usedNamespace" : 1,
  "creationTime" : "2023-08-09T17:23:11.534Z",
  "modificationTime" : "2023-08-09T17:23:35.523Z",
  "sourcePathExist" : true,
  "quotaInBytes" : 8053063680,
  "quotaInNamespace" : 2,
  "bucketLayout" : "FILE_SYSTEM_OPTIMIZED",
  "link" : false
}, {
  "volumeName" : "vol111111",
  "bucketName" : "bucketlink",
  "sourceVolume" : "imaginaryvol1",
  "sourceBucket" : "imaginarybuck",
  "creationTime" : "2023-08-09T19:41:22.350Z",
  "modificationTime" : "2023-08-09T19:41:22.350Z",
  "owner" : "hdfs"
}
```

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-9144

## How was this patch tested?

This patch was tested using Junit test case as well as tested manually on local docker cluster.
