### PR TITLE
HDDS-9151. Close EC Pipeline when container transitions to closing

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/ContainerManagerImpl.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/ContainerManagerImpl.java
@@ -175,13 +175,13 @@ public class ContainerManagerImpl implements ContainerManager {
     List<Pipeline> pipelines;
     Pipeline pipeline;
     ContainerInfo containerInfo = null;
+    lock.lock();
     try {
-      lock.lock();
+      // Acquire pipeline manager lock, to avoid any updates to pipeline
+      // while allocate container happens. This is to avoid scenario like
+      // mentioned in HDDS-5655.
+      pipelineManager.acquireReadLock();
       try {
-        // Acquire pipeline manager lock, to avoid any updates to pipeline
-        // while allocate container happens. This is to avoid scenario like
-        // mentioned in HDDS-5655.
-        pipelineManager.acquireReadLock();
         pipelines = pipelineManager
             .getPipelines(replicationConfig, Pipeline.PipelineState.OPEN);
         if (!pipelines.isEmpty()) {
@@ -206,10 +206,10 @@ public class ContainerManagerImpl implements ContainerManager {
             + ", State:PipelineState.OPEN", e);
       }
 
+      lock.lock();
       try {
-        lock.lock();
+        pipelineManager.acquireReadLock();
         try {
-          pipelineManager.acquireReadLock();
           pipelines = pipelineManager
               .getPipelines(replicationConfig, Pipeline.PipelineState.OPEN);
           if (!pipelines.isEmpty()) {

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/PipelineManagerImpl.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/PipelineManagerImpl.java
@@ -415,6 +415,9 @@ public class PipelineManagerImpl implements PipelineManager {
         // pipeline to get created
         closePipeline(pipeline, true);
       }
+    } catch (PipelineNotFoundException e) {
+      LOG.warn("Pipeline {} not found when removing container {}",
+          pipelineID, containerID, e);
     } finally {
       releaseWriteLock();
     }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/PipelineManagerImpl.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/PipelineManagerImpl.java
@@ -400,8 +400,24 @@ public class PipelineManagerImpl implements PipelineManager {
   @Override
   public void removeContainerFromPipeline(
       PipelineID pipelineID, ContainerID containerID) throws IOException {
-    // should not lock here, since no ratis operation happens.
-    stateManager.removeContainerFromPipeline(pipelineID, containerID);
+    acquireWriteLock();
+    try {
+      Pipeline pipeline = stateManager.getPipeline(pipelineID);
+      stateManager.removeContainerFromPipeline(pipelineID, containerID);
+      if (pipeline.getReplicationConfig().getReplicationType()
+          == ReplicationType.EC) {
+        // For EC, a pipeline is used for only a single container. When that
+        // container is closed or removed from the pipeline, the pipeline should
+        // also be closed. For EC, if a pipeline had a container and then the
+        // container is removed via this method, the pipeline is no longer
+        // useful - nothing will allocate a new container on it. Therefore, we
+        // close the pipeline here to free up the pipeline slot for a new
+        // pipeline to get created
+        closePipeline(pipeline, true);
+      }
+    } finally {
+      releaseWriteLock();
+    }
   }
 
   @Override

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestPipelineManagerImpl.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestPipelineManagerImpl.java
@@ -390,7 +390,7 @@ public class TestPipelineManagerImpl {
       Assertions.assertEquals(1, pipelineManager
           .getContainersInPipeline(ratisPipeline.getId()).size());
       Assertions.assertEquals(1, pipelineManager
-          .getContainersInPipeline(ratisPipeline.getId()).size());
+          .getContainersInPipeline(ecPipeline.getId()).size());
 
       // Remove the container from the Ratis pipeline - this should leave the
       // pipeline in the OPEN state

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestPipelineManagerImpl.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestPipelineManagerImpl.java
@@ -87,6 +87,7 @@ import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_DATANODE_PIPELINE_L
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_DATANODE_PIPELINE_LIMIT_DEFAULT;
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_PIPELINE_ALLOCATED_TIMEOUT;
 import static org.apache.hadoop.hdds.scm.pipeline.Pipeline.PipelineState.ALLOCATED;
+import static org.apache.hadoop.hdds.scm.pipeline.Pipeline.PipelineState.CLOSED;
 import static org.apache.hadoop.hdds.scm.pipeline.Pipeline.PipelineState.OPEN;
 import static org.apache.hadoop.test.MetricsAsserts.getLongCounter;
 import static org.apache.hadoop.test.MetricsAsserts.getMetrics;
@@ -353,6 +354,60 @@ public class TestPipelineManagerImpl {
   }
 
   @Test
+  public void testRemoveContainerFromPipeline() throws Exception {
+    try (PipelineManagerImpl pipelineManager = createPipelineManager(true)) {
+      Pipeline ratisPipeline =  pipelineManager.createPipeline(
+          RatisReplicationConfig.getInstance(ReplicationFactor.THREE));
+      pipelineManager.openPipeline(ratisPipeline.getId());
+      ECReplicationConfig ecRepConfig = new ECReplicationConfig(3, 2);
+      Pipeline ecPipeline = pipelineManager.createPipeline(ecRepConfig);
+      pipelineManager.openPipeline(ecPipeline.getId());
+
+      ContainerInfo ratisContainerInfo = HddsTestUtils.
+          getContainer(HddsProtos.LifeCycleState.OPEN, ratisPipeline.getId());
+      ContainerInfo ecContainerInfo = HddsTestUtils.getECContainer(
+          HddsProtos.LifeCycleState.OPEN, ecPipeline.getId(), ecRepConfig);
+
+      pipelineManager.addContainerToPipeline(ratisPipeline.getId(),
+          ratisContainerInfo.containerID());
+      pipelineManager.addContainerToPipeline(ecPipeline.getId(),
+          ecContainerInfo.containerID());
+
+      List<Pipeline> ratisPipelines = pipelineManager.getPipelines(
+          RatisReplicationConfig.getInstance(ReplicationFactor.THREE),
+          Pipeline.PipelineState.OPEN);
+
+      List<Pipeline> ecPipelines = pipelineManager.getPipelines(
+          ecRepConfig, Pipeline.PipelineState.OPEN);
+
+      // Background pipeline creator could create additional Ratis pipelines,
+      // so an equals check may not work. EC pipelines are created on demand,
+      // so an equals check is fine.
+      Assertions.assertTrue(ratisPipelines.contains(ratisPipeline));
+      Assertions.assertEquals(1, ecPipelines.size());
+
+      // Ensure both pipelines have a single container
+      Assertions.assertEquals(1, pipelineManager
+          .getContainersInPipeline(ratisPipeline.getId()).size());
+      Assertions.assertEquals(1, pipelineManager
+          .getContainersInPipeline(ratisPipeline.getId()).size());
+
+      // Remove the container from the Ratis pipeline - this should leave the
+      // pipeline in the OPEN state
+      pipelineManager.removeContainerFromPipeline(ratisPipeline.getId(),
+          ratisContainerInfo.containerID());
+      Assertions.assertEquals(OPEN, pipelineManager
+          .getPipeline(ratisPipeline.getId()).getPipelineState());
+
+      // Removing from the EC pipeline should trigger the pipeline to close.
+      pipelineManager.removeContainerFromPipeline(ecPipeline.getId(),
+          ecContainerInfo.containerID());
+      Assertions.assertEquals(CLOSED, pipelineManager
+          .getPipeline(ecPipeline.getId()).getPipelineState());
+    }
+  }
+
+  @Test
   public void testClosePipelineShouldFailOnFollower() throws Exception {
     try (PipelineManagerImpl pipelineManager = createPipelineManager(true)) {
       Pipeline pipeline = assertAllocate(pipelineManager);
@@ -539,7 +594,7 @@ public class TestPipelineManagerImpl {
     Assertions.assertTrue(pipelineManager
         .getPipelines(RatisReplicationConfig
                 .getInstance(ReplicationFactor.THREE),
-            Pipeline.PipelineState.CLOSED).contains(closedPipeline));
+            CLOSED).contains(closedPipeline));
 
     // Set the clock to "now". All pipelines were created before this.
     testClock.set(Instant.now());
@@ -557,7 +612,7 @@ public class TestPipelineManagerImpl {
     Assertions.assertFalse(pipelineManager
         .getPipelines(RatisReplicationConfig
                 .getInstance(ReplicationFactor.THREE),
-            Pipeline.PipelineState.CLOSED).contains(closedPipeline));
+            CLOSED).contains(closedPipeline));
 
     testClock.fastForward((60000));
 
@@ -592,7 +647,7 @@ public class TestPipelineManagerImpl {
 
     pipelineManager.scrubPipelines();
     pipeline = pipelineManager.getPipeline(pipeline.getId());
-    Assertions.assertEquals(Pipeline.PipelineState.CLOSED,
+    Assertions.assertEquals(CLOSED,
         pipeline.getPipelineState());
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?
In testing we have found an issues in the ECWritableContainerProvider.

For EC a pipeline is used for only one container, when the container gets closed, the pipeline also gets closed. At the moment, the only place in the code which closes the EC piplines which no longer have an open container is inside the ECWritableContainerProvider. It first gets the list of open piplines and enforces the pipeline limit, then for all open pipelines, it tries top find one the client can use.

If the client has had problems writing to the pipelines (eg it was given a container/pipeline and then the write failed as the container was closed on the DN), the pipelines get added to the exclude list. Then we can get into a situation where many pipelines need to be closed on the write path, slowing down block allocation. 

Ideally, when a container transitions to CLOSING in SCM, if the container is an EC container, we should also close the associated pipeline to avoid it counting toward the limit and to avoid needing to close it during the write (block allocation) path.

This could be achieved relatively simply inside the PipelineManagerImpl.removeContainersFromPipeline() method which is called as soon as the container transitions to CLOSING via ContainerStateManagerImpl.updateContainerState() when it executes the containerStateChangeActions. Wrapping the container close and pipeline close in a lock inside PipelineManagerImpl ensure we have a consistent "ec container close" flow and it should avoid the ECWritableContainerProvider needing to close the pipelines internally. However we can leave that code in place in ECWritableContainerProvider incase some pipelines slip through somehow.


## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-9151

## How was this patch tested?

New unit test added to ensure EC pipelines get closed and Ratis do not.
