### PR TITLE
HDDS-9180. Improve redirection operator in testlib.sh

### DIFF
--- a/hadoop-ozone/dist/src/main/compose/testlib.sh
+++ b/hadoop-ozone/dist/src/main/compose/testlib.sh
@@ -278,7 +278,7 @@ save_container_logs() {
   local output_name=$(get_output_name)
   local c
   for c in $(docker-compose ps "$@" | cut -f1 -d' ' | tail -n +3); do
-    docker logs "${c}" &>> "$RESULT_DIR/docker-${output_name}${c}.log"
+    docker logs "${c}" >> "$RESULT_DIR/docker-${output_name}${c}.log" 2>&1
   done
 }
 


### PR DESCRIPTION
Use cmd >> file 2>&1 instead of cmd &>> file for more portable shell script

https://issues.apache.org/jira/browse/HDDS-9180

## How was this patch tested?

Rebuilt the project and run the tests locally without error message. Container logs are still produced properly
