### PR TITLE
HDDS-9092. Recon Legend Text Alignment in Disk Usage

### DIFF
--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/api/db.json
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/api/db.json
@@ -1346,7 +1346,7 @@
     "subPathCount": 5,
     "subPaths": [
       {
-        "path": "/vol1",
+        "path": "/vol1cloudera-health-monitoring-ozone-basic-canary-volume",
         "size": 50000,
         "sizeWithReplica": 150000
       },

--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/api/db.json
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/api/db.json
@@ -1346,7 +1346,7 @@
     "subPathCount": 5,
     "subPaths": [
       {
-        "path": "/vol1cloudera-health-monitoring-ozone-basic-canary-volume",
+        "path": "/vol1",
         "size": 50000,
         "sizeWithReplica": 150000
       },

--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/components/rightDrawer/rightDrawer.tsx
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/components/rightDrawer/rightDrawer.tsx
@@ -55,7 +55,7 @@ export class DetailPanel extends React.Component<IRightDrawerProps> {
           title={`Metadata Summary for ${path}`}
           placement='right'
           width='40%'
-          closable={false}
+          closable={true}
           visible={visible}
           getContainer={false}
           style={{position: 'absolute'}}

--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/views/diskUsage/diskUsage.less
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/views/diskUsage/diskUsage.less
@@ -80,3 +80,15 @@
 .ant-drawer-open .ant-drawer-mask {
   opacity: 0 !important;
 }
+
+div.svg-container {
+  width: 1400px !important;
+}
+
+svg.main-svg {
+  width: 1400px !important;
+}
+
+g.legend {
+  transform: translate(650px, 100px) !important;
+}

--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/views/diskUsage/diskUsage.tsx
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/views/diskUsage/diskUsage.tsx
@@ -202,7 +202,7 @@ export class DiskUsage extends React.Component<Record<string, object>, IDUState>
           labels: pathLabels,
           text: sizeStr,
           textinfo: 'label',
-          hovertemplate: 'Percentage: %{customdata}%<br>Total Data Size: %{text}<extra></extra>'
+          hovertemplate: 'Percentage: %{customdata}%<br>Total Data Size: %{text}<br> Name: %{label} <extra></extra>'
         }]
       });
     }).catch(error => {


### PR DESCRIPTION
## What changes were proposed in this pull request?
1) Recon legend alignment issue in CSS.
2) Closing option for Metadata Summary Information Drawer.


## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-9092

## How was this patch tested?
Manually
Previous  Issue
![image](https://github.com/apache/ozone/assets/112169209/f7efba04-c5cf-42b9-8620-174d5f34a025)

New Changes with this PR
![image](https://github.com/apache/ozone/assets/112169209/68302a18-333f-47c7-85c3-a69e3148e7f2)

Testing with Responsive Web
![image](https://github.com/apache/ozone/assets/112169209/b8f88fba-4858-4e65-b939-68e06efd185d)

Testing with Big Screen Size
Dimension 2500 * 1000
![image](https://github.com/apache/ozone/assets/112169209/166d1601-d677-4cfc-96ac-791819dd8cce)

Testing with Small Screen Size
![image](https://github.com/apache/ozone/assets/112169209/49bd0424-f03e-4135-984b-8235f7ee14bb)

Closing Option Enabled for Metadata Summary Drawer
![image](https://github.com/apache/ozone/assets/112169209/317cb50b-5562-4f33-8ad7-f9af05b8c721)
