### PR TITLE
HDDS-878. Do the disk failure check before ContainerSet initialization.

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/ozoneimpl/OzoneContainer.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/ozoneimpl/OzoneContainer.java
@@ -290,8 +290,6 @@ public class OzoneContainer {
     // system properties set. These can inspect and possibly repair
     // containers as we iterate them here.
     ContainerInspectorUtil.load();
-    //TODO: diskchecker should be run before this, to see how disks are.
-    // And also handle disk failure tolerance need to be added
     while (volumeSetIterator.hasNext()) {
       StorageVolume volume = volumeSetIterator.next();
       Thread thread = new Thread(new ContainerReader(volumeSet,


### PR DESCRIPTION
## What changes were proposed in this pull request?

Remove the old todo mentioned in HDDS-878. The feature it describes is already implemented.

## What is the link to the Apache JIRA

HDDS-878

## How was this patch tested?

- Change in this PR is comments only, no testing required.
- An existing test verifies the functionality described in the jira is present: `TestDatanodeHddsVolumeFailureToleration#testDNCorrectlyHandlesVolumeFailureOnStartup`