### PR TITLE
HDDS-9186. Use only cache to verify whether volume is empty or not.

### DIFF
--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmMetadataManagerImpl.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmMetadataManagerImpl.java
@@ -900,18 +900,9 @@ public class OmMetadataManagerImpl implements OMMetadataManager,
    * @return true if the volume is empty
    */
   @Override
-  public boolean isVolumeEmpty(String volume) throws IOException {
+  public boolean isVolumeEmpty(String volume) {
     String volumePrefix = getVolumeKey(volume + OM_KEY_PREFIX);
-
-    // First check in bucket table cache.
-    if (isKeyPresentInTableCache(volumePrefix, bucketTable)) {
-      return false;
-    }
-
-    if (isKeyPresentInTable(volumePrefix, bucketTable)) {
-      return false; // we found at least one key with this vol/
-    }
-    return true;
+    return !isKeyPresentInTableCache(volumePrefix, bucketTable);
   }
 
   /**


### PR DESCRIPTION
## What changes were proposed in this pull request?

BucketTable is cache CacheType.FULL_CACHE. To check whether volume is empty or not we can just use bycket table cache and avoid reading from rocksdb. This will enhance performance while checking volume empty. Suggestion given in [PR](https://github.com/apache/ozone/pull/5051#issuecomment-1633850262).

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-9186

## How was this patch tested?

Verified with new and existing integration test.
