### PR TITLE
HDDS-5161. Fix the regex for key name validation

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/OzoneConsts.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/OzoneConsts.java
@@ -427,12 +427,12 @@ public final class OzoneConsts {
    * contains illegal characters when creating/renaming key.
    *
    * Avoid the following characters in a key name:
-   * "\", "{", "}", "^", "<", ">", "#", "|", "%", "`", "[", "]", "~", "?"
+   * "\", "{", "}", "<", ">", "^", "?", "%", "~", "#", "|", "`", "[", "]"
    * and Non-printable ASCII characters (128–255 decimal characters).
-   * https://docs.aws.amazon.com/AmazonS3/latest/dev/UsingMetadata.html
+   * https://docs.aws.amazon.com/AmazonS3/latest/userguide/object-keys.html
    */
   public static final Pattern KEYNAME_ILLEGAL_CHARACTER_CHECK_REGEX  =
-          Pattern.compile("^[^^{}<>^?%~#`\\[\\]\\|\\\\(\\x80-\\xff)]+$");
+          Pattern.compile("^[^\\\\{}<>^?%~#|`\\[\\]\\x80-\\xff]+$");
 
   public static final String FS_FILE_COPYING_TEMP_SUFFIX = "._COPYING_";
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Changing the regex for KEYNAME_ILLEGAL_CHARACTER_CHECK_REGEX to allow "(" and ")"

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-5161

## How was this patch tested?

Tested manually using Docker after setting ozone.om.keyname.character.check.enabled to true in ozone_deafult.xml
```
bash-4.2$ ozone sh key put "s3v/buck1/k1(" k1
bash-4.2$ ozone sh key put "s3v/buck1/k1)" k1
bash-4.2$ ozone sh key list s3v/buck1
[ {
  "volumeName" : "s3v",
  "bucketName" : "buck1",
  "name" : "k1(",
  "dataSize" : 3,
  "creationTime" : "2023-08-18T07:17:31.837Z",
  "modificationTime" : "2023-08-18T07:53:49.334Z",
  "replicationConfig" : {
    "replicationFactor" : "THREE",
    "requiredNodes" : 3,
    "replicationType" : "RATIS"
  },
  "metadata" : { },
  "file" : true
}, {
  "volumeName" : "s3v",
  "bucketName" : "buck1",
  "name" : "k1)",
  "dataSize" : 3,
  "creationTime" : "2023-08-18T07:55:34.549Z",
  "modificationTime" : "2023-08-18T07:55:35.397Z",
  "replicationConfig" : {
    "replicationFactor" : "THREE",
    "requiredNodes" : 3,
    "replicationType" : "RATIS"
  },
  "metadata" : { },
  "file" : true
} ]
bash-4.2$ ozone sh key put "s3v/buck1/k1|" k1
Invalid key name: k1|
bash-4.2$ ozone sh key put "s3v/buck1/k1\\" k1
Invalid key name: k1\
bash-4.2$ ozone sh key put "s3v/buck1/k1^" k1
Invalid key name: k1^
```