### PR TITLE
HDDS-8665. Implemented CopyObject for SnapshotInfo and moved out snapshot chain update form OMSnapshotPurgeResponse

### DIFF
--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/SnapshotInfo.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/SnapshotInfo.java
@@ -21,6 +21,7 @@ package org.apache.hadoop.ozone.om.helpers;
 import com.google.common.annotations.VisibleForTesting;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.hadoop.hdds.utils.db.Codec;
+import org.apache.hadoop.hdds.utils.db.CopyObject;
 import org.apache.hadoop.hdds.utils.db.DelegatedCodec;
 import org.apache.hadoop.hdds.utils.db.Proto2Codec;
 import org.apache.hadoop.ozone.OzoneConsts;
@@ -52,15 +53,11 @@ import static org.apache.hadoop.ozone.OzoneConsts.OM_KEY_PREFIX;
  * snapshot checkpoint directory, previous snapshotid
  * for the snapshot path & global amongst other necessary fields.
  */
-public final class SnapshotInfo implements Auditable {
+public final class SnapshotInfo implements Auditable, CopyObject<SnapshotInfo> {
   private static final Codec<SnapshotInfo> CODEC = new DelegatedCodec<>(
       Proto2Codec.get(OzoneManagerProtocolProtos.SnapshotInfo.class),
       SnapshotInfo::getFromProtobuf,
-      SnapshotInfo::getProtobuf,
-      // FIXME: HDDS-8665 Deep copy will cause failures
-      //        - TestOMSnapshotDeleteRequest           NullPointerException
-      //        - TestOMSnapshotPurgeRequestAndResponse AssertionFailedError
-      DelegatedCodec.CopyType.SHALLOW);
+      SnapshotInfo::getProtobuf);
 
   public static Codec<SnapshotInfo> getCodec() {
     return CODEC;
@@ -598,5 +595,28 @@ public final class SnapshotInfo implements Auditable {
         snapshotStatus,
         creationTime, deletionTime, pathPreviousSnapshotId,
         globalPreviousSnapshotId, snapshotPath, checkpointDir);
+  }
+
+  /**
+   * Return a new copy of the object.
+   */
+  @Override
+  public SnapshotInfo copyObject() {
+    return new Builder()
+        .setSnapshotId(snapshotId)
+        .setName(name)
+        .setVolumeName(volumeName)
+        .setBucketName(bucketName)
+        .setSnapshotStatus(snapshotStatus)
+        .setCreationTime(creationTime)
+        .setDeletionTime(deletionTime)
+        .setPathPreviousSnapshotId(pathPreviousSnapshotId)
+        .setGlobalPreviousSnapshotId(globalPreviousSnapshotId)
+        .setSnapshotPath(snapshotPath)
+        .setCheckpointDir(checkpointDir)
+        .setDbTxSequenceNumber(dbTxSequenceNumber)
+        .setDeepClean(deepClean)
+        .setSstFiltered(sstFiltered)
+        .build();
   }
 }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/SnapshotChainManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/SnapshotChainManager.java
@@ -16,6 +16,7 @@
  */
 package org.apache.hadoop.ozone.om;
 
+import com.google.common.annotations.VisibleForTesting;
 import org.apache.hadoop.hdds.utils.db.Table;
 import org.apache.hadoop.hdds.utils.db.TableIterator;
 import org.apache.hadoop.ozone.om.helpers.SnapshotInfo;
@@ -429,5 +430,16 @@ public class SnapshotChainManager {
   public LinkedHashMap<UUID, SnapshotChainInfo> getSnapshotChainPath(
       String path) {
     return snapshotChainByPath.get(path);
+  }
+
+  @VisibleForTesting
+  public Map<UUID, SnapshotChainInfo> getGlobalSnapshotChain() {
+    return globalSnapshotChain;
+  }
+
+  @VisibleForTesting
+  public Map<String,
+      LinkedHashMap<UUID, SnapshotChainInfo>> getSnapshotChainByPath() {
+    return snapshotChainByPath;
   }
 }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/snapshot/OMSnapshotPurgeRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/snapshot/OMSnapshotPurgeRequest.java
@@ -40,6 +40,8 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.NoSuchElementException;
+import java.util.UUID;
 
 /**
  * Handles OMSnapshotPurge Request.
@@ -73,6 +75,8 @@ public class OMSnapshotPurgeRequest extends OMClientRequest {
       List<String> snapInfosToUpdate = snapshotPurgeRequest
           .getUpdatedSnapshotDBKeyList();
       Map<String, SnapshotInfo> updatedSnapInfos = new HashMap<>();
+      Map<String, SnapshotInfo> updatedPathPreviousAndGlobalSnapshots =
+          new HashMap<>();
 
       // Snapshots that are already deepCleaned by the KeyDeletingService
       // can be marked as deepCleaned.
@@ -94,12 +98,16 @@ public class OMSnapshotPurgeRequest extends OMClientRequest {
         SnapshotInfo nextSnapshot = SnapshotUtils
             .getNextActiveSnapshot(fromSnapshot,
                 snapshotChainManager, omSnapshotManager);
+
         updateSnapshotInfoAndCache(nextSnapshot, omMetadataManager,
             trxnLogIndex, updatedSnapInfos, true);
+        updateSnapshotChainAndCache(omMetadataManager, fromSnapshot,
+            trxnLogIndex, updatedPathPreviousAndGlobalSnapshots);
       }
 
       omClientResponse = new OMSnapshotPurgeResponse(omResponse.build(),
-          snapshotDbKeys, updatedSnapInfos);
+          snapshotDbKeys, updatedSnapInfos,
+          updatedPathPreviousAndGlobalSnapshots);
     } catch (IOException ex) {
       omClientResponse = new OMSnapshotPurgeResponse(
           createErrorOMResponse(omResponse, ex));
@@ -123,5 +131,96 @@ public class OMSnapshotPurgeRequest extends OMClientRequest {
           CacheValue.get(trxnLogIndex, snapInfo));
       updatedSnapInfos.put(snapInfo.getTableKey(), snapInfo);
     }
+  }
+
+  /**
+   * Removes the snapshot from the chain and updates the next snapshot's
+   * previousPath and previousGlobal IDs in DB cache.
+   * It also returns the pair of updated next path and global snapshots to
+   * update in DB.
+   */
+  private void updateSnapshotChainAndCache(
+      OmMetadataManagerImpl metadataManager,
+      SnapshotInfo snapInfo,
+      long trxnLogIndex,
+      Map<String, SnapshotInfo> updatedPathPreviousAndGlobalSnapshots
+  ) throws IOException {
+    if (snapInfo == null) {
+      return;
+    }
+
+    SnapshotChainManager snapshotChainManager = metadataManager
+        .getSnapshotChainManager();
+    SnapshotInfo nextPathSnapInfo = null;
+
+    // If the snapshot is deleted in the previous run, then the in-memory
+    // SnapshotChainManager might throw NoSuchElementException as the snapshot
+    // is removed in-memory but OMDoubleBuffer has not flushed yet.
+    boolean hasNextPathSnapshot;
+    boolean hasNextGlobalSnapshot;
+    try {
+      hasNextPathSnapshot = snapshotChainManager.hasNextPathSnapshot(
+          snapInfo.getSnapshotPath(), snapInfo.getSnapshotId());
+      hasNextGlobalSnapshot = snapshotChainManager.hasNextGlobalSnapshot(
+          snapInfo.getSnapshotId());
+    } catch (NoSuchElementException ex) {
+      return;
+    }
+
+    // Updates next path snapshot's previous snapshot ID
+    if (hasNextPathSnapshot) {
+      UUID nextPathSnapshotId = snapshotChainManager.nextPathSnapshot(
+          snapInfo.getSnapshotPath(), snapInfo.getSnapshotId());
+
+      String snapshotTableKey = snapshotChainManager
+          .getTableKey(nextPathSnapshotId);
+      nextPathSnapInfo = metadataManager.getSnapshotInfoTable()
+          .get(snapshotTableKey);
+      if (nextPathSnapInfo != null) {
+        nextPathSnapInfo.setPathPreviousSnapshotId(
+            snapInfo.getPathPreviousSnapshotId());
+        metadataManager.getSnapshotInfoTable().addCacheEntry(
+            new CacheKey<>(nextPathSnapInfo.getTableKey()),
+            CacheValue.get(trxnLogIndex, nextPathSnapInfo));
+        updatedPathPreviousAndGlobalSnapshots
+            .put(nextPathSnapInfo.getTableKey(), nextPathSnapInfo);
+      }
+    }
+
+    // Updates next global snapshot's previous snapshot ID
+    if (hasNextGlobalSnapshot) {
+      UUID nextGlobalSnapshotId =
+          snapshotChainManager.nextGlobalSnapshot(snapInfo.getSnapshotId());
+
+      String snapshotTableKey = snapshotChainManager
+          .getTableKey(nextGlobalSnapshotId);
+
+      SnapshotInfo nextGlobalSnapInfo = metadataManager.getSnapshotInfoTable()
+          .get(snapshotTableKey);
+      // If both next global and path snapshot are same, it may overwrite
+      // nextPathSnapInfo.setPathPreviousSnapshotID(), adding this check
+      // will prevent it.
+      if (nextGlobalSnapInfo != null && nextPathSnapInfo != null &&
+          nextGlobalSnapInfo.getSnapshotId().equals(
+              nextPathSnapInfo.getSnapshotId())) {
+        nextPathSnapInfo.setGlobalPreviousSnapshotId(
+            snapInfo.getGlobalPreviousSnapshotId());
+        metadataManager.getSnapshotInfoTable().addCacheEntry(
+            new CacheKey<>(nextPathSnapInfo.getTableKey()),
+            CacheValue.get(trxnLogIndex, nextPathSnapInfo));
+        updatedPathPreviousAndGlobalSnapshots
+            .put(nextPathSnapInfo.getTableKey(), nextPathSnapInfo);
+      } else if (nextGlobalSnapInfo != null) {
+        nextGlobalSnapInfo.setGlobalPreviousSnapshotId(
+            snapInfo.getGlobalPreviousSnapshotId());
+        metadataManager.getSnapshotInfoTable().addCacheEntry(
+            new CacheKey<>(nextGlobalSnapInfo.getTableKey()),
+            CacheValue.get(trxnLogIndex, nextGlobalSnapInfo));
+        updatedPathPreviousAndGlobalSnapshots
+            .put(nextGlobalSnapInfo.getTableKey(), nextGlobalSnapInfo);
+      }
+    }
+
+    snapshotChainManager.deleteSnapshot(snapInfo);
   }
 }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/snapshot/OMSnapshotPurgeResponse.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/snapshot/OMSnapshotPurgeResponse.java
@@ -23,7 +23,6 @@ import org.apache.hadoop.hdds.utils.db.BatchOperation;
 import org.apache.hadoop.hdds.utils.db.RDBStore;
 import org.apache.hadoop.ozone.om.OMMetadataManager;
 import org.apache.hadoop.ozone.om.OmMetadataManagerImpl;
-import org.apache.hadoop.ozone.om.SnapshotChainManager;
 import org.apache.hadoop.ozone.om.helpers.SnapshotInfo;
 import org.apache.hadoop.ozone.om.response.CleanupTableInfo;
 import org.apache.hadoop.ozone.om.response.OMClientResponse;
@@ -37,8 +36,6 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.List;
 import java.util.Map;
-import java.util.NoSuchElementException;
-import java.util.UUID;
 
 import static org.apache.hadoop.ozone.om.OmMetadataManagerImpl.SNAPSHOT_INFO_TABLE;
 
@@ -51,13 +48,18 @@ public class OMSnapshotPurgeResponse extends OMClientResponse {
       LoggerFactory.getLogger(OMSnapshotPurgeResponse.class);
   private final List<String> snapshotDbKeys;
   private final Map<String, SnapshotInfo> updatedSnapInfos;
+  private final Map<String, SnapshotInfo> updatedPreviousAndGlobalSnapInfos;
 
-  public OMSnapshotPurgeResponse(@Nonnull OMResponse omResponse,
+  public OMSnapshotPurgeResponse(
+      @Nonnull OMResponse omResponse,
       @Nonnull List<String> snapshotDbKeys,
-      Map<String, SnapshotInfo> updatedSnapInfos) {
+      Map<String, SnapshotInfo> updatedSnapInfos,
+      Map<String, SnapshotInfo> updatedPreviousAndGlobalSnapInfos
+  ) {
     super(omResponse);
     this.snapshotDbKeys = snapshotDbKeys;
     this.updatedSnapInfos = updatedSnapInfos;
+    this.updatedPreviousAndGlobalSnapInfos = updatedPreviousAndGlobalSnapInfos;
   }
 
   /**
@@ -69,6 +71,7 @@ public class OMSnapshotPurgeResponse extends OMClientResponse {
     checkStatusNotOK();
     this.snapshotDbKeys = null;
     this.updatedSnapInfos = null;
+    this.updatedPreviousAndGlobalSnapInfos = null;
   }
 
   @Override
@@ -77,7 +80,9 @@ public class OMSnapshotPurgeResponse extends OMClientResponse {
 
     OmMetadataManagerImpl metadataManager = (OmMetadataManagerImpl)
         omMetadataManager;
-    updateSnapInfo(metadataManager, batchOperation);
+    updateSnapInfo(metadataManager, batchOperation, updatedSnapInfos);
+    updateSnapInfo(metadataManager, batchOperation,
+        updatedPreviousAndGlobalSnapInfos);
     for (String dbKey: snapshotDbKeys) {
       SnapshotInfo snapshotInfo = omMetadataManager
           .getSnapshotInfoTable().get(dbKey);
@@ -88,7 +93,7 @@ public class OMSnapshotPurgeResponse extends OMClientResponse {
       if (snapshotInfo == null) {
         continue;
       }
-      cleanupSnapshotChain(metadataManager, snapshotInfo, batchOperation);
+
       // Delete Snapshot checkpoint directory.
       deleteCheckpointDirectory(omMetadataManager, snapshotInfo);
       omMetadataManager.getSnapshotInfoTable().deleteWithBatch(batchOperation,
@@ -97,89 +102,13 @@ public class OMSnapshotPurgeResponse extends OMClientResponse {
   }
 
   private void updateSnapInfo(OmMetadataManagerImpl metadataManager,
-                              BatchOperation batchOp)
+                              BatchOperation batchOp,
+                              Map<String, SnapshotInfo> snapshotInfos)
       throws IOException {
-    for (Map.Entry<String, SnapshotInfo> entry : updatedSnapInfos.entrySet()) {
+    for (Map.Entry<String, SnapshotInfo> entry : snapshotInfos.entrySet()) {
       metadataManager.getSnapshotInfoTable().putWithBatch(batchOp,
           entry.getKey(), entry.getValue());
     }
-  }
-
-  /**
-   * Cleans up the snapshot chain and updates next snapshot's
-   * previousPath and previousGlobal IDs.
-   */
-  private void cleanupSnapshotChain(OmMetadataManagerImpl metadataManager,
-                                    SnapshotInfo snapInfo,
-                                    BatchOperation batchOperation)
-      throws IOException {
-    SnapshotChainManager snapshotChainManager = metadataManager
-        .getSnapshotChainManager();
-    SnapshotInfo nextPathSnapInfo = null;
-    SnapshotInfo nextGlobalSnapInfo;
-
-    // If the snapshot is deleted in the previous run, then the in-memory
-    // SnapshotChainManager might throw NoSuchElementException as the snapshot
-    // is removed in-memory but OMDoubleBuffer has not flushed yet.
-    boolean hasNextPathSnapshot;
-    boolean hasNextGlobalSnapshot;
-    try {
-      hasNextPathSnapshot = snapshotChainManager.hasNextPathSnapshot(
-          snapInfo.getSnapshotPath(), snapInfo.getSnapshotId());
-      hasNextGlobalSnapshot = snapshotChainManager.hasNextGlobalSnapshot(
-          snapInfo.getSnapshotId());
-    } catch (NoSuchElementException ex) {
-      LOG.warn("The Snapshot {} could have been deleted in the previous run.",
-          snapInfo.getSnapshotId(), ex);
-      return;
-    }
-
-    // Updates next path snapshot's previous snapshot ID
-    if (hasNextPathSnapshot) {
-      UUID nextPathSnapshotId = snapshotChainManager.nextPathSnapshot(
-          snapInfo.getSnapshotPath(), snapInfo.getSnapshotId());
-
-      String snapshotTableKey = snapshotChainManager
-          .getTableKey(nextPathSnapshotId);
-      nextPathSnapInfo = metadataManager.getSnapshotInfoTable()
-          .get(snapshotTableKey);
-      if (nextPathSnapInfo != null) {
-        nextPathSnapInfo.setPathPreviousSnapshotId(
-            snapInfo.getPathPreviousSnapshotId());
-        metadataManager.getSnapshotInfoTable().putWithBatch(batchOperation,
-            nextPathSnapInfo.getTableKey(), nextPathSnapInfo);
-      }
-    }
-
-    // Updates next global snapshot's previous snapshot ID
-    if (hasNextGlobalSnapshot) {
-      UUID nextGlobalSnapshotId =
-          snapshotChainManager.nextGlobalSnapshot(snapInfo.getSnapshotId());
-
-      String snapshotTableKey = snapshotChainManager
-          .getTableKey(nextGlobalSnapshotId);
-      nextGlobalSnapInfo = metadataManager.getSnapshotInfoTable()
-          .get(snapshotTableKey);
-      // If both next global and path snapshot are same, it may overwrite
-      // nextPathSnapInfo.setPathPreviousSnapshotID(), adding this check
-      // will prevent it.
-      if (nextGlobalSnapInfo != null && nextPathSnapInfo != null &&
-          nextGlobalSnapInfo.getSnapshotId().equals(
-              nextPathSnapInfo.getSnapshotId())) {
-        nextPathSnapInfo.setGlobalPreviousSnapshotId(
-            snapInfo.getGlobalPreviousSnapshotId());
-        metadataManager.getSnapshotInfoTable().putWithBatch(batchOperation,
-            nextPathSnapInfo.getTableKey(), nextPathSnapInfo);
-      } else if (nextGlobalSnapInfo != null) {
-        nextGlobalSnapInfo.setGlobalPreviousSnapshotId(
-            snapInfo.getGlobalPreviousSnapshotId());
-        metadataManager.getSnapshotInfoTable().putWithBatch(batchOperation,
-            nextGlobalSnapInfo.getTableKey(), nextGlobalSnapInfo);
-      }
-    }
-
-    // Removes current snapshot from the snapshot chain.
-    snapshotChainManager.deleteSnapshot(snapInfo);
   }
 
   /**


### PR DESCRIPTION
## What changes were proposed in this pull request?
Issue is that at final stage of snapshot purge we update the [snapshot chain and next global & path level snapshots in DB](https://github.com/apache/ozone/blob/master/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/snapshot/OMSnapshotPurgeResponse.java#L112). When we update next global and path level snapshots in DB, it doesn’t not [update the cache](https://github.com/apache/ozone/blob/master/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/snapshot/OMSnapshotPurgeResponse.java#L144). SnapshotInfo [read happens from the cache](https://github.com/apache/ozone/blob/master/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/snapshot/OMSnapshotPurgeResponse.java#L149). When causes that test failures mentioned in HDDS-8665.

This change contains two main change.
1. Snapshot Info to implement CopyObject.
2. Move out SnapshotChain update form `OMSnapshotPurgeResponse` to `OMSnapshotPurgeRequest`.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-8665

## How was this patch tested?
Existing unit tests.
