### PR TITLE
HDDS-9193. Updated the zlib download URL to stable URL

### DIFF
--- a/hadoop-hdds/rocks-native/pom.xml
+++ b/hadoop-hdds/rocks-native/pom.xml
@@ -116,7 +116,7 @@
                                     <goal>wget</goal>
                                 </goals>
                                 <configuration>
-                                    <url>https://zlib.net/zlib-${zlib.version}.tar.gz</url>
+                                    <url>https://zlib.net/fossils/zlib-${zlib.version}.tar.gz</url>
                                     <outputFileName>zlib-${zlib.version}.tar.gz</outputFileName>
                                     <outputDirectory>${project.build.directory}/zlib</outputDirectory>
                                 </configuration>


### PR DESCRIPTION
## What changes were proposed in this pull request?
Currently zlip url points to https://zlib.net/zlib-*.tar.gz which is not stable because older version get migrated to https://zlib.net/fossils/zlib-*.tar.gz. https://zlib.net/fossils/zlib-*.tar.gz is more stable URL to download zlib.
This change is to update the URL to https://zlib.net/fossils/zlib-*.tar.gz.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-9193

## How was this patch tested?
Built it on local machine and verified docker comes up properly.
