### PR TITLE
HDDS-9195. TestOzoneFileSystem - Handle inconsistency in Create, Delete operations of same key before cache flush.

### DIFF
--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/KeyManagerImpl.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/KeyManagerImpl.java
@@ -1613,7 +1613,7 @@ public class KeyManagerImpl implements KeyManager {
             // for recursive list all the entries
 
             if (!isKeyDeleted(entryInDb, keyTable)) {
-              cacheKeyMap.put(entryInDb, new OzoneFileStatus(omKeyInfo,
+              cacheKeyMap.putIfAbsent(entryInDb, new OzoneFileStatus(omKeyInfo,
                   scmBlockSize, !OzoneFSUtils.isFile(entryKeyName)));
               countEntries++;
             }


### PR DESCRIPTION
## What changes were proposed in this pull request?

There could be possible issue of getting wrong key listStatus if a key is created, deleted and flushed to DB, but then again before cache gets  flushed, same key is created, current cache map get overwritten with DB.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-9195

## How was this patch tested?

This patch is tested by running existing test cases in multiple counts of Job runs.
