### PR TITLE
HDDS-9197. EC: Mark EC containers unhealthy when not missing but unrecoverable

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ContainerHealthResult.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ContainerHealthResult.java
@@ -108,6 +108,7 @@ public class ContainerHealthResult {
     private final boolean dueToOutOfService;
     private final boolean sufficientlyReplicatedAfterPending;
     private final boolean unrecoverable;
+    private boolean isMissing = false;
     private boolean hasHealthyReplicas;
     private boolean hasUnReplicatedOfflineIndexes = false;
     private int requeueCount = 0;
@@ -200,8 +201,8 @@ public class ContainerHealthResult {
 
     /**
      * Indicates whether a container has enough replicas to be read. For Ratis
-     * at least one replia must be available. For EC, at least dataNum replicas
-     * are needed.
+     * at least one healthy replia must be available. For EC, at least
+     * dataNum healthy replicas are needed.
      * @return True if the container has insufficient replicas available to be
      *         read, false otherwise
      */
@@ -238,6 +239,14 @@ public class ContainerHealthResult {
       this.hasHealthyReplicas = hasHealthyReplicas;
     }
 
+    public void setIsMissing(boolean isMissing) {
+      this.isMissing = isMissing;
+    }
+
+    public boolean isMissing() {
+      return isMissing;
+    }
+
     @Override
     public String toString() {
       StringBuilder sb = new StringBuilder("UnderReplicatedHealthResult{")
@@ -252,6 +261,9 @@ public class ContainerHealthResult {
       }
       if (unrecoverable) {
         sb.append(" +unrecoverable");
+      }
+      if (isMissing) {
+        sb.append(" +missing");
       }
       if (hasHealthyReplicas) {
         sb.append(" +hasHealthyReplicas");

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ECContainerReplicaCount.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ECContainerReplicaCount.java
@@ -128,7 +128,7 @@ public class ECContainerReplicaCount implements ContainerReplicaCount {
       3 is not considered over replicated because its second copy is unhealthy.
       */
       if (replica.getState() == ContainerReplicaProto.State.UNHEALTHY) {
-        int val = decommissionIndexes
+        int val = unHealthyIndexes
             .getOrDefault(replica.getReplicaIndex(), 0);
         unHealthyIndexes.put(replica.getReplicaIndex(), val + 1);
         continue;

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ECContainerReplicaCount.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ECContainerReplicaCount.java
@@ -75,6 +75,7 @@ public class ECContainerReplicaCount implements ContainerReplicaCount {
   private final List<Integer> pendingDelete;
   private final int remainingMaintenanceRedundancy;
   private final Map<Integer, Integer> healthyIndexes = new HashMap<>();
+  private final Map<Integer, Integer> unHealthyIndexes = new HashMap<>();
   private final Map<Integer, Integer> decommissionIndexes = new HashMap<>();
   private final Map<Integer, Integer> maintenanceIndexes = new HashMap<>();
   private final Set<DatanodeDetails> unhealthyReplicaDNs;
@@ -127,6 +128,9 @@ public class ECContainerReplicaCount implements ContainerReplicaCount {
       3 is not considered over replicated because its second copy is unhealthy.
       */
       if (replica.getState() == ContainerReplicaProto.State.UNHEALTHY) {
+        int val = decommissionIndexes
+            .getOrDefault(replica.getReplicaIndex(), 0);
+        unHealthyIndexes.put(replica.getReplicaIndex(), val + 1);
         continue;
       }
       HddsProtos.NodeOperationalState state =
@@ -304,13 +308,28 @@ public class ECContainerReplicaCount implements ContainerReplicaCount {
    */
   @Override
   public boolean isUnrecoverable() {
+    Set<Integer> distinct = healthyReplicas();
+    return distinct.size() < repConfig.getData();
+  }
+
+  /**
+   * Return true if there are insufficient replicas to recover this container
+   * when unhealthy replicas are included.
+   * @return True if the container is missing, false otherwise.
+   */
+  public boolean isMissing() {
+    Set<Integer> distinct = healthyReplicas();
+    distinct.addAll(unHealthyIndexes.keySet());
+    return distinct.size() < repConfig.getData();
+  }
+
+  private Set<Integer> healthyReplicas() {
     Set<Integer> distinct = new HashSet<>();
     distinct.addAll(healthyIndexes.keySet());
     distinct.addAll(decommissionIndexes.keySet());
     distinct.addAll(maintenanceIndexes.keySet());
-    return distinct.size() < repConfig.getData();
+    return distinct;
   }
-
   /**
    * Returns an unsorted list of indexes which need additional copies to
    * ensure the container is sufficiently replicated. These missing indexes will

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/health/ClosedWithUnhealthyReplicasHandler.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/health/ClosedWithUnhealthyReplicasHandler.java
@@ -105,11 +105,11 @@ public class ClosedWithUnhealthyReplicasHandler extends AbstractCheck {
       }
     }
 
-    // some unhealthy replicas were found so mark UNHEALTHY (note that
-    // UNHEALTHY is currently not a LifeCycleState for a Container)
+    // some unhealthy replicas were found so the container must be over
+    // over replicated due to unhealthy replicas.
     if (foundUnhealthy) {
       request.getReport().incrementAndSample(
-          ReplicationManagerReport.HealthState.UNHEALTHY,
+          ReplicationManagerReport.HealthState.OVER_REPLICATED,
           containerInfo.containerID());
     }
     LOG.debug("Returning {} for container {}", foundUnhealthy, containerInfo);

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/health/ClosedWithUnhealthyReplicasHandler.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/health/ClosedWithUnhealthyReplicasHandler.java
@@ -61,8 +61,9 @@ public class ClosedWithUnhealthyReplicasHandler extends AbstractCheck {
    * Replica Index 4: Closed
    * Replica Index 5: Closed
    *
-   * In this case, the unhealthy replica of index 3 should be deleted. This
-   * is not over replication because that unhealthy replica is not available.
+   * In this case, the unhealthy replica of index 3 should be deleted. The
+   * container will be marked over replicated as the unhealthy replicas need
+   * to be removed.
    * </p>
    * @param request ContainerCheckRequest object representing the container
    * @return true if this is a closed EC container with unhealthy replicas,

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/health/RatisUnhealthyReplicationCheckHandler.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/health/RatisUnhealthyReplicationCheckHandler.java
@@ -37,8 +37,10 @@ import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationType.R
  *   factor number of replicas and queue them for under/over replication if
  *   needed.
  *   </li>
- *   <li>If there is perfect replication of healthy replicas, remove any
- *   excess unhealthy replicas.
+ *   <li>If there is a mixture of unhealthy and healthy containers this
+ *   handler will only be called if there is no under or over replication after
+ *   excluding the empty containers. If there is under or over replication the
+ *   ECReplicationCheckHandler will take care of it first.
  *   </li>
  * </ul>
  */
@@ -77,6 +79,9 @@ public class RatisUnhealthyReplicationCheckHandler extends AbstractCheck {
           container.containerID());
     }
 
+    // At this point, we know there are only unhealthy replicas, so the
+    // container in UNHEALTHY, but it can also be over or under replicated with
+    // unhealthy replicas.
     ContainerHealthResult health = checkReplication(replicaCount);
     if (health.getHealthState()
         == ContainerHealthResult.HealthState.UNDER_REPLICATED) {

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestECContainerReplicaCount.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestECContainerReplicaCount.java
@@ -548,7 +548,7 @@ public class TestECContainerReplicaCount {
   }
 
   @Test
-  public void testMissing() {
+  public void testUnRecoverable() {
     ECContainerReplicaCount rcnt =
         new ECContainerReplicaCount(container, new HashSet<>(),
             Collections.emptyList(), 1);
@@ -557,6 +557,10 @@ public class TestECContainerReplicaCount {
 
     Set<ContainerReplica> replica = ReplicationTestUtil
         .createReplicas(Pair.of(IN_SERVICE, 1), Pair.of(IN_MAINTENANCE, 2));
+    // The unhealthy replica does not help with recovery even though we now
+    // have 3 replicas.
+    replica.addAll(ReplicationTestUtil.createReplicas(
+        UNHEALTHY, Pair.of(IN_SERVICE, 3)));
     rcnt = new ECContainerReplicaCount(container, replica,
         Collections.emptyList(), 1);
     Assertions.assertTrue(rcnt.isUnrecoverable());
@@ -572,6 +576,74 @@ public class TestECContainerReplicaCount {
     // Not missing as the decommission replicas are still online
     Assertions.assertFalse(rcnt.isUnrecoverable());
     Assertions.assertEquals(0, rcnt.unavailableIndexes(true).size());
+
+    // All unhealthy replicas is still un-recoverable.
+    replica = ReplicationTestUtil.createReplicas(
+        UNHEALTHY, Pair.of(IN_SERVICE, 1),
+        Pair.of(IN_SERVICE, 2), Pair.of(IN_SERVICE, 3),
+        Pair.of(IN_SERVICE, 4), Pair.of(IN_SERVICE, 5));
+    rcnt = new ECContainerReplicaCount(container, replica,
+        Collections.emptyList(), 1);
+    // Not missing as the decommission replicas are still online
+    Assertions.assertTrue(rcnt.isUnrecoverable());
+  }
+
+  @Test
+  public void testIsMissingAndUnhealthy() {
+    // No Replicas
+    ECContainerReplicaCount rcnt =
+        new ECContainerReplicaCount(container, new HashSet<>(),
+            Collections.emptyList(), 1);
+    Assertions.assertTrue(rcnt.isMissing());
+    Assertions.assertTrue(rcnt.isUnrecoverable());
+
+    // 1 unhealthy
+    Set<ContainerReplica> replica = ReplicationTestUtil
+        .createReplicas(UNHEALTHY, Pair.of(IN_SERVICE, 1));
+    rcnt = new ECContainerReplicaCount(container, replica,
+        Collections.emptyList(), 1);
+    Assertions.assertTrue(rcnt.isMissing());
+    Assertions.assertTrue(rcnt.isUnrecoverable());
+
+    // 2 unhealthy
+    replica = ReplicationTestUtil
+        .createReplicas(UNHEALTHY, Pair.of(IN_SERVICE, 1),
+            Pair.of(IN_SERVICE, 2));
+    rcnt = new ECContainerReplicaCount(container, replica,
+        Collections.emptyList(), 1);
+    Assertions.assertTrue(rcnt.isMissing());
+    Assertions.assertTrue(rcnt.isUnrecoverable());
+
+    // 3 unhealthy
+    replica = ReplicationTestUtil
+        .createReplicas(UNHEALTHY, Pair.of(IN_SERVICE, 1),
+            Pair.of(IN_SERVICE, 2), Pair.of(IN_SERVICE, 3));
+    rcnt = new ECContainerReplicaCount(container, replica,
+        Collections.emptyList(), 1);
+    Assertions.assertFalse(rcnt.isMissing());
+    Assertions.assertTrue(rcnt.isUnrecoverable());
+
+
+    // 3 replicas, with 1 unhealthy
+    replica = ReplicationTestUtil
+        .createReplicas(Pair.of(IN_SERVICE, 1), Pair.of(IN_SERVICE, 2));
+    replica.addAll(ReplicationTestUtil.createReplicas(
+        UNHEALTHY, Pair.of(IN_SERVICE, 3)));
+    rcnt = new ECContainerReplicaCount(container, replica,
+        Collections.emptyList(), 1);
+    Assertions.assertFalse(rcnt.isMissing());
+    Assertions.assertTrue(rcnt.isUnrecoverable());
+
+    // 4 replicas, with 1 unhealthy
+    replica = ReplicationTestUtil
+        .createReplicas(Pair.of(IN_SERVICE, 1), Pair.of(IN_SERVICE, 2),
+            Pair.of(IN_SERVICE, 3));
+    replica.addAll(ReplicationTestUtil.createReplicas(
+        UNHEALTHY, Pair.of(IN_SERVICE, 4)));
+    rcnt = new ECContainerReplicaCount(container, replica,
+        Collections.emptyList(), 1);
+    Assertions.assertFalse(rcnt.isMissing());
+    Assertions.assertFalse(rcnt.isUnrecoverable());
   }
 
   @Test

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/health/TestClosedWithUnhealthyReplicasHandler.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/health/TestClosedWithUnhealthyReplicasHandler.java
@@ -139,7 +139,7 @@ public class TestClosedWithUnhealthyReplicasHandler {
 
     assertTrue(handler.handle(request));
     assertEquals(1, request.getReport().getStat(
-        ReplicationManagerReport.HealthState.UNHEALTHY));
+        ReplicationManagerReport.HealthState.OVER_REPLICATED));
 
     ArgumentCaptor<Integer> replicaIndexCaptor =
         ArgumentCaptor.forClass(Integer.class);


### PR DESCRIPTION
## What changes were proposed in this pull request?



An EC container should only be marked as unhealthy if:

1) Is not missing (has at least dataNum replica indexs online)

2) Has at least dataNum Healthy indexes online.

For a 3-2 container, this means that:

Healthy, Healthy -> This is missing

Unhealthy, Unhealthy -> This is missing as it doesn't matter that the replicas are unhealthy, as we could not read it anyway as we need at least 3 replicas.

Healthy, Healthy, Unhealthy (indexes 1, 2, 3) -> This is unhealthy as technically much of the data can still be read, but it is the unhealthy container which is causing the problem and making it unrecoverable.

Healthy, Healthy, Healthy, Unhealthy -> This is under replicated, as we can recover using the 3 healthy.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-9197

## How was this patch tested?

Some tests modified and new tests added.
