### PR TITLE
HDDS-9204. Reduce log level of PipelinePlacementPolicy failed to create pipeline message

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/PipelinePlacementPolicy.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/PipelinePlacementPolicy.java
@@ -163,7 +163,7 @@ public final class PipelinePlacementPolicy extends SCMCommonPlacementPolicy {
       msg = String.format("Pipeline creation failed due to no sufficient" +
               " healthy datanodes. Required %d. Found %d. Excluded %d.",
           nodesRequired, initialHealthyNodesCount, excludedNodesSize);
-      LOG.warn(msg);
+      LOG.debug(msg);
       throw new SCMException(msg,
           SCMException.ResultCodes.FAILED_TO_FIND_SUITABLE_NODE);
     }
@@ -366,14 +366,14 @@ public final class PipelinePlacementPolicy extends SCMCommonPlacementPolicy {
             "pipeline allocation. healthyNodes size: %d, " +
             "excludeNodes size: %d", healthyNodes.size(),
             mutableExclude.size());
-        LOG.warn(msg);
+        LOG.debug(msg);
         throw new SCMException(msg,
             SCMException.ResultCodes.FAILED_TO_FIND_SUITABLE_NODE);
       }
     }
 
     if (results.size() < nodesRequired) {
-      LOG.warn("Unable to find the required number of " +
+      LOG.debug("Unable to find the required number of " +
               "healthy nodes that  meet the criteria. Required nodes: {}, " +
               "Found nodes: {}", nodesRequired, results.size());
       throw new SCMException("Unable to find required number of nodes.",
@@ -413,13 +413,11 @@ public final class PipelinePlacementPolicy extends SCMCommonPlacementPolicy {
         removePeers(anchor, healthyNodes);
         mutableExclude.add(anchor);
       } else {
-        LOG.warn("Unable to find healthy node for anchor(first) node.");
+        LOG.debug("Unable to find healthy node for anchor(first) node.");
         throw new SCMException("Unable to find anchor node.",
             SCMException.ResultCodes.FAILED_TO_FIND_SUITABLE_NODE);
       }
-      if (LOG.isDebugEnabled()) {
-        LOG.debug("First node chosen: {}", anchor);
-      }
+      LOG.debug("First node chosen: {}", anchor);
     } else if (usedNodes.size() == 1) {
       // Only 1 usedNode, consider it as anchor node.
       anchor = usedNodes.get(0);
@@ -457,9 +455,7 @@ public final class PipelinePlacementPolicy extends SCMCommonPlacementPolicy {
         results.add(nextNode);
         removePeers(nextNode, healthyNodes);
         mutableExclude.add(nextNode);
-        if (LOG.isDebugEnabled()) {
-          LOG.debug("Second node chosen: {}", nextNode);
-        }
+        LOG.debug("Second node chosen: {}", nextNode);
       } else {
         LOG.debug("Pipeline Placement: Unable to find 2nd node on different " +
             "rack based on rack awareness. anchor: {}", anchor);


### PR DESCRIPTION
## What changes were proposed in this pull request?

Under normal circumstances, a log like this is seen frequently in the SCM log:

```
2023-08-23 10:41:06,087 [main] WARN  pipeline.PipelinePlacementPolicy (PipelinePlacementPolicy.java:filterViableNodes(166)) - Pipeline creation failed due to no sufficient healthy datanodes. Required 3. Found 2. Excluded 14.
```

This happens regularly, as the background pipeline creator thread attempts to fill all datanodes with pipelines. When all the limits have been reached the above scenario legitimately happens and prints the warning to the logs.

We should move this message to debug along with a few others similar to it, as they are not warnings, but normal occurrences.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-9204

## How was this patch tested?

Logging only change. Ran the TestPipelineManagerImpl tests before and after and verified the message no longer appears.