### PR TITLE
HDDS-8902. Close open container immediately on ICR of unhealthy replica

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/AbstractContainerReportHandler.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/AbstractContainerReportHandler.java
@@ -257,10 +257,11 @@ public class AbstractContainerReportHandler {
        * any other state.
        */
       if (replica.getState() != State.OPEN) {
-        logger.warn("Container {} is in OPEN state, but the datanode {} " +
-            "reports an {} replica.", containerId,
-            datanode, replica.getState());
-        // Should we take some action?
+        logger.info("Moving OPEN container {} to CLOSING state, datanode {} " +
+                "reported {} replica with index {}.", containerId, datanode,
+            replica.getState(), replica.getReplicaIndex());
+        containerManager.updateContainerState(containerId,
+            LifeCycleEvent.FINALIZE);
       }
       break;
     case CLOSING:

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/MockPipelineManager.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/MockPipelineManager.java
@@ -17,6 +17,7 @@
 
 package org.apache.hadoop.hdds.scm.pipeline;
 
+import com.google.common.collect.ImmutableList;
 import org.apache.hadoop.hdds.client.ReplicationConfig;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
 import org.apache.hadoop.hdds.protocol.MockDatanodeDetails;
@@ -70,8 +71,17 @@ public class MockPipelineManager implements PipelineManager {
   public Pipeline createPipeline(ReplicationConfig replicationConfig,
       List<DatanodeDetails> excludedNodes, List<DatanodeDetails> favoredNodes)
       throws IOException {
-    Pipeline pipeline = buildECPipeline(replicationConfig, excludedNodes,
-        favoredNodes);
+    Pipeline pipeline;
+    if (replicationConfig.getReplicationType()
+        == HddsProtos.ReplicationType.EC) {
+      pipeline = buildECPipeline(
+          replicationConfig, excludedNodes, favoredNodes);
+    } else {
+      pipeline = createPipeline(replicationConfig,
+          ImmutableList.of(MockDatanodeDetails.randomDatanodeDetails(),
+              MockDatanodeDetails.randomDatanodeDetails(),
+              MockDatanodeDetails.randomDatanodeDetails()));
+    }
 
     stateManager.addPipeline(pipeline.getProtobufMessage(
         ClientVersion.CURRENT_VERSION));


### PR DESCRIPTION
## What changes were proposed in this pull request?

Currently when a datanode's replica moves from open to unhealthy, it will send an ICR to SCM. This is processed on the next run of the SCM replication manager, which could be up to 5 minutes by default. In the mean time, SCM will continue to send writes to this open container, which will fail at the datanode. 

The unhealthy replica could be handled quicker if the container is closed when the unhealthy ICR is processed in [AbstractContainerReportHandler#updateState](https://github.com/apache/ozone/blob/0fcfe212e18efc620260f733b14db43e63e2ea08/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/AbstractContainerReportHandler.java#L262)

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-8902

## How was this patch tested?

New unit test added.