### PR TITLE
HDDS-9161. Recon Pipelines datanode columns search does not work

### DIFF
--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/utils/columnSearch.tsx
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/utils/columnSearch.tsx
@@ -70,8 +70,9 @@ class ColumnSearch extends React.PureComponent {
       <Icon type='search' style={{color: filtered ? '#1890ff' : undefined}}/>
     ),
     onFilter: (value: string, record: any) => {
-        if (record[dataIndex]) {
-          return typeof (record[dataIndex]) == 'object' ? Object.values(...record[dataIndex]).toString().toLowerCase().includes(value.toLowerCase())
+      if (record[dataIndex]) {
+          return typeof (record[dataIndex]) === typeof {}
+            ? Object.values(...record[dataIndex]).toString().toLowerCase().includes(value.toLowerCase())
             : record[dataIndex].toString().toLowerCase().includes(value.toLowerCase())
         }
         else {

--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/utils/columnSearch.tsx
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/utils/columnSearch.tsx
@@ -72,7 +72,7 @@ class ColumnSearch extends React.PureComponent {
     onFilter: (value: string, record: any) => {
       if (record[dataIndex] !== undefined || record[dataIndex] !== null) {
           return typeof (record[dataIndex]) === typeof {}
-            ? Boolean (record[dataIndex].find(item => Object.values(item).toString().toLowerCase().includes(value.toLowerCase())) ? true :false)
+            ? Boolean (record[dataIndex].find(item => Object.values(item).toString().toLowerCase().includes(value.toLowerCase())))
             : record[dataIndex].toString().toLowerCase().includes(value.toLowerCase())
         }
         else {

--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/utils/columnSearch.tsx
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/utils/columnSearch.tsx
@@ -69,8 +69,15 @@ class ColumnSearch extends React.PureComponent {
     filterIcon: (filtered: boolean) => (
       <Icon type='search' style={{color: filtered ? '#1890ff' : undefined}}/>
     ),
-    onFilter: (value: string, record: any) =>
-      record[dataIndex].toString().toLowerCase().includes(value.toLowerCase()),
+    onFilter: (value: string, record: any) => {
+        if (record[dataIndex]) {
+          return typeof (record[dataIndex]) == 'object' ? Object.values(...record[dataIndex]).toString().toLowerCase().includes(value.toLowerCase())
+            : record[dataIndex].toString().toLowerCase().includes(value.toLowerCase())
+        }
+        else {
+          return;
+        }
+    },
     onFilterDropdownVisibleChange: (visible: boolean) => {
       if (visible) {
         setTimeout(() => {

--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/utils/columnSearch.tsx
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/utils/columnSearch.tsx
@@ -72,7 +72,7 @@ class ColumnSearch extends React.PureComponent {
     onFilter: (value: string, record: any) => {
       if (record[dataIndex] !== undefined || record[dataIndex] !== null) {
           return typeof (record[dataIndex]) === typeof {}
-            ? record[dataIndex].find(item => Object.values(item).toString().toLowerCase().includes(value.toLowerCase())) ? true :false
+            ? Boolean (record[dataIndex].find(item => Object.values(item).toString().toLowerCase().includes(value.toLowerCase())) ? true :false)
             : record[dataIndex].toString().toLowerCase().includes(value.toLowerCase())
         }
         else {

--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/utils/columnSearch.tsx
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/utils/columnSearch.tsx
@@ -70,9 +70,9 @@ class ColumnSearch extends React.PureComponent {
       <Icon type='search' style={{color: filtered ? '#1890ff' : undefined}}/>
     ),
     onFilter: (value: string, record: any) => {
-      if (record[dataIndex]) {
+      if (record[dataIndex] !== undefined || record[dataIndex] !== null) {
           return typeof (record[dataIndex]) === typeof {}
-            ? Object.values(...record[dataIndex]).toString().toLowerCase().includes(value.toLowerCase())
+            ? record[dataIndex].find(item => Object.values(item).toString().toLowerCase().includes(value.toLowerCase())) ? true :false
             : record[dataIndex].toString().toLowerCase().includes(value.toLowerCase())
         }
         else {

--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/utils/columnSearch.tsx
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/utils/columnSearch.tsx
@@ -71,13 +71,13 @@ class ColumnSearch extends React.PureComponent {
     ),
     onFilter: (value: string, record: any) => {
       if (record[dataIndex] !== undefined || record[dataIndex] !== null) {
-          return typeof (record[dataIndex]) === typeof {}
-            ? Boolean (record[dataIndex].find(item => Object.values(item).toString().toLowerCase().includes(value.toLowerCase())))
-            : record[dataIndex].toString().toLowerCase().includes(value.toLowerCase())
-        }
-        else {
-          return;
-        }
+         return typeof (record[dataIndex]) === typeof {}
+           ? Boolean (record[dataIndex].find(item => Object.values(item).toString().toLowerCase().includes(value.toLowerCase())))
+           : record[dataIndex].toString().toLowerCase().includes(value.toLowerCase())
+       }
+       else {
+         return;
+       }
     },
     onFilterDropdownVisibleChange: (visible: boolean) => {
       if (visible) {

--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/utils/columnSearch.tsx
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/utils/columnSearch.tsx
@@ -71,13 +71,13 @@ class ColumnSearch extends React.PureComponent {
     ),
     onFilter: (value: string, record: any) => {
       if (record[dataIndex] !== undefined || record[dataIndex] !== null) {
-         return typeof (record[dataIndex]) === typeof {}
-           ? Boolean (record[dataIndex].find(item => Object.values(item).toString().toLowerCase().includes(value.toLowerCase())))
-           : record[dataIndex].toString().toLowerCase().includes(value.toLowerCase())
-       }
-       else {
-         return;
-       }
+        return typeof (record[dataIndex]) === typeof {}
+          ? Boolean (record[dataIndex].find(item => Object.values(item).toString().toLowerCase().includes(value.toLowerCase())))
+          : record[dataIndex].toString().toLowerCase().includes(value.toLowerCase())
+      }
+      else {
+        return;
+      }
     },
     onFilterDropdownVisibleChange: (visible: boolean) => {
       if (visible) {


### PR DESCRIPTION
## What changes were proposed in this pull request?
There are values present in the column, but the search does not filter them out. so Now search Functionality is working on Array and Objects

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-9161

## How was this patch tested?
Manually

[pieplines.webm](https://github.com/apache/ozone/assets/112169209/6c9923a3-83fe-4f23-b65d-8717e05290fc)



From UID Search
![image](https://github.com/apache/ozone/assets/112169209/746b935c-8b6f-43b2-9cb6-ce97a386eeb3)

![image](https://github.com/apache/ozone/assets/112169209/37cc7227-ef40-4b1a-8353-b8f57bfa10b9)



