### PR TITLE
HDDS-9098. Exclude the cleanup of incomplete MPU open keys in getExpiredOpenKeys

### DIFF
--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmMetadataManagerImpl.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmMetadataManagerImpl.java
@@ -82,6 +82,7 @@ import org.apache.hadoop.ozone.om.lock.OmReadOnlyLock;
 import org.apache.hadoop.ozone.om.lock.OzoneManagerLock;
 import org.apache.hadoop.hdds.utils.TransactionInfo;
 import org.apache.hadoop.ozone.om.protocolPB.OzoneManagerProtocolClientSideTranslatorPB;
+import org.apache.hadoop.ozone.om.request.util.OMMultipartUploadUtils;
 import org.apache.hadoop.ozone.om.snapshot.ReferenceCounted;
 import org.apache.hadoop.ozone.om.snapshot.SnapshotCache;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.KeyArgs;
@@ -1684,6 +1685,44 @@ public class OmMetadataManagerImpl implements OMMetadataManager,
     return rcOmSnapshot.orElse(null);
   }
 
+  /**
+   * Decide whether the open key is a multipart upload related key.
+   * @param openKeyInfo open key related to multipart upload
+   * @param openDbKey db key of open key related to multipart upload, which
+   *                  might have different format depending on the bucket
+   *                  layout
+   * @return true open key is a multipart upload related key.
+   *         false otherwise.
+   */
+  private boolean isOpenMultipartKey(OmKeyInfo openKeyInfo, String openDbKey)
+      throws IOException {
+    if (OMMultipartUploadUtils.isMultipartKeySet(openKeyInfo)) {
+      return true;
+    }
+
+    String multipartUploadId =
+        OMMultipartUploadUtils.getUploadIdFromDbKey(openDbKey);
+
+    if (StringUtils.isEmpty(multipartUploadId)) {
+      return false;
+    }
+
+    String multipartInfoDbKey = getMultipartKey(openKeyInfo.getVolumeName(),
+        openKeyInfo.getBucketName(), openKeyInfo.getKeyName(),
+        multipartUploadId);
+
+    // In addition to checking isMultipartKey flag in the open key info,
+    // multipartInfoTable needs to be checked to handle multipart upload
+    // open keys that already set isMultipartKey = false prior to HDDS-9017.
+    // These open keys should not be deleted since doing so will result in
+    // orphan MPUs (i.e. multipart upload exists in multipartInfoTable, but
+    // does not exist in the openKeyTable/openFileTable). These orphan MPUs
+    // will not be able to be aborted / completed by the user
+    // since the MPU abort and complete requests require the open MPU keys
+    // to exist in the open key/file table.
+    return getMultipartInfoTable().isExist(multipartInfoDbKey);
+  }
+
   @Override
   public ExpiredOpenKeys getExpiredOpenKeys(Duration expireThreshold,
       int count, BucketLayout bucketLayout) throws IOException {
@@ -1708,6 +1747,10 @@ public class OmMetadataManagerImpl implements OMMetadataManager,
         final int lastPrefix = dbOpenKeyName.lastIndexOf(OM_KEY_PREFIX);
         final String dbKeyName = dbOpenKeyName.substring(0, lastPrefix);
         OmKeyInfo openKeyInfo = openKeyValue.getValue();
+
+        if (isOpenMultipartKey(openKeyInfo, dbOpenKeyName)) {
+          continue;
+        }
 
         if (openKeyInfo.getCreationTime() <= expiredCreationTimestamp) {
           final String clientIdString

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3InitiateMultipartUploadRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3InitiateMultipartUploadRequest.java
@@ -33,6 +33,7 @@ import org.apache.hadoop.ozone.om.helpers.OmMultipartKeyInfo;
 import org.apache.hadoop.ozone.om.ratis.utils.OzoneManagerDoubleBufferHelper;
 import org.apache.hadoop.ozone.om.request.file.OMFileRequest;
 import org.apache.hadoop.ozone.om.request.key.OMKeyRequest;
+import org.apache.hadoop.ozone.om.request.util.OMMultipartUploadUtils;
 import org.apache.hadoop.ozone.om.request.util.OmResponseUtil;
 import org.apache.hadoop.ozone.om.request.validation.RequestFeatureValidator;
 import org.apache.hadoop.ozone.om.request.validation.RequestProcessingPhase;
@@ -51,7 +52,6 @@ import org.apache.hadoop.ozone.protocolPB.OMPBHelper;
 import org.apache.hadoop.ozone.security.acl.IAccessAuthorizer;
 import org.apache.hadoop.ozone.security.acl.OzoneObj;
 import org.apache.hadoop.util.Time;
-import org.apache.hadoop.hdds.utils.UniqueId;
 import org.apache.hadoop.hdds.utils.db.cache.CacheKey;
 import org.apache.hadoop.hdds.utils.db.cache.CacheValue;
 import org.slf4j.Logger;
@@ -62,7 +62,6 @@ import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Map;
-import java.util.UUID;
 
 import static org.apache.hadoop.ozone.om.lock.OzoneManagerLock.Resource.BUCKET_LOCK;
 
@@ -92,8 +91,9 @@ public class S3InitiateMultipartUploadRequest extends OMKeyRequest {
         keyPath, getBucketLayout());
 
     KeyArgs.Builder newKeyArgs = keyArgs.toBuilder()
-            .setMultipartUploadID(UUID.randomUUID().toString() + "-" +
-                UniqueId.next()).setModificationTime(Time.now())
+            .setMultipartUploadID(
+                OMMultipartUploadUtils.getMultipartUploadId())
+            .setModificationTime(Time.now())
             .setKeyName(keyPath);
 
     generateRequiredEncryptionInfo(keyArgs, newKeyArgs, ozoneManager);

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/util/OMMultipartUploadUtils.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/util/OMMultipartUploadUtils.java
@@ -1,0 +1,92 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.ozone.om.request.util;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.hadoop.hdds.utils.UniqueId;
+import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
+
+import java.util.UUID;
+
+import static org.apache.hadoop.ozone.OzoneConsts.OM_KEY_PREFIX;
+
+/**
+ * Utility class related to OM Multipart Upload.
+ */
+public final class OMMultipartUploadUtils {
+
+
+  private OMMultipartUploadUtils() {
+  }
+
+  /**
+   * Generate a unique Multipart Upload ID.
+   * @return multipart upload ID
+   */
+  public static String getMultipartUploadId() {
+    return UUID.randomUUID() + "-" + UniqueId.next();
+  }
+
+  /**
+   * Get multipart upload ID from the DB key of multipart upload
+   * form openKeyTable/openFileTable.
+   *
+   * The DB keys of openKeyTable and openFileTable are different:
+   *   openKeyTable: /{volumeName}/{bucketName}/{keyName}/{uploadId}
+   *   openFileTable: /{volumeId}/{bucketId}/{parentId}/{fileName}/{uploadId}
+   *
+   *
+   * Despite the difference, both have the uploadId as the suffix of the DB
+   * key, we can extract this suffix to get the upload ID from the DB key.
+   *
+   * Upload ID format: uploadId = UUIDv4 + "-" + UniqueId#next
+   *
+   * @param key DB key
+   * @return upload ID if uploadId can be extracted from openDBKey
+   *         otherwise null
+   */
+  public static String getUploadIdFromDbKey(String key) {
+    String[] split = key.split(OM_KEY_PREFIX);
+    if (split.length < 5) {
+      return null;
+    }
+
+    String uploadId = split[split.length - 1];
+
+    // Similar to the logic of UUID#fromString, but use 6 since there is
+    // another "-" between the UUID and the UniqueId
+    if (StringUtils.isEmpty(uploadId) ||
+        uploadId.split("-").length != 6) {
+      return null;
+    }
+
+    return uploadId;
+  }
+
+
+  /**
+   * Check whether key's isMultipartKey flag is set.
+   * @param openKeyInfo open key
+   * @return true if flag is set, false otherwise.
+   */
+  public static boolean isMultipartKeySet(OmKeyInfo openKeyInfo) {
+    return openKeyInfo.getLatestVersionLocations() != null
+        && openKeyInfo.getLatestVersionLocations().isMultipartKey();
+  }
+}

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/service/TestOpenKeyCleanupService.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/service/TestOpenKeyCleanupService.java
@@ -36,6 +36,7 @@ import org.apache.hadoop.ozone.om.OzoneManager;
 import org.apache.hadoop.ozone.om.helpers.BucketLayout;
 import org.apache.hadoop.ozone.om.helpers.OmBucketInfo;
 import org.apache.hadoop.ozone.om.helpers.OmKeyArgs;
+import org.apache.hadoop.ozone.om.helpers.OmMultipartInfo;
 import org.apache.hadoop.ozone.om.helpers.OmVolumeArgs;
 import org.apache.hadoop.ozone.om.helpers.OpenKeySession;
 import org.apache.hadoop.ozone.om.protocol.OzoneManagerProtocol;
@@ -189,6 +190,69 @@ public class TestOpenKeyCleanupService {
     }
   }
 
+  /**
+   * In this test, we create a bunch of incomplete MPU keys and try to run
+   * openKeyCleanupService on it. We make sure that none of these incomplete
+   * MPU keys are actually deleted.
+   *
+   * @throws IOException - on Failure.
+   */
+  @ParameterizedTest
+  @CsvSource({
+      "9, 0",
+      "0, 8",
+      "6, 7",
+  })
+  public void testExcludeMPUOpenKeys(
+      int numDEFKeys, int numFSOKeys) throws Exception {
+    LOG.info("numDEFMpuKeys={}, numFSOMpuKeys={}",
+        numDEFKeys, numFSOKeys);
+
+    OpenKeyCleanupService openKeyCleanupService =
+        (OpenKeyCleanupService) keyManager.getOpenKeyCleanupService();
+
+    openKeyCleanupService.suspend();
+    // wait for submitted tasks to complete
+    Thread.sleep(SERVICE_INTERVAL.toMillis());
+    final long oldkeyCount = openKeyCleanupService.getSubmittedOpenKeyCount();
+    final long oldrunCount = openKeyCleanupService.getRunCount();
+    LOG.info("oldMpuKeyCount={}, oldMpuRunCount={}", oldkeyCount, oldrunCount);
+    assertEquals(0, oldkeyCount);
+
+    final OMMetrics metrics = om.getMetrics();
+    assertEquals(0, metrics.getNumKeyHSyncs());
+    assertEquals(0, metrics.getNumOpenKeysCleaned());
+    assertEquals(0, metrics.getNumOpenKeysHSyncCleaned());
+    createIncompleteMPUKeys(numDEFKeys, BucketLayout.DEFAULT);
+    createIncompleteMPUKeys(numFSOKeys, BucketLayout.FILE_SYSTEM_OPTIMIZED);
+
+    // wait for open keys to expire
+    Thread.sleep(EXPIRE_THRESHOLD.toMillis());
+
+    // All MPU open keys should be skipped
+    assertExpiredOpenKeys(true, false, BucketLayout.DEFAULT);
+    assertExpiredOpenKeys(true, false,
+        BucketLayout.FILE_SYSTEM_OPTIMIZED);
+
+    openKeyCleanupService.resume();
+
+    GenericTestUtils.waitFor(() -> openKeyCleanupService
+            .getRunCount() > oldrunCount,
+        (int) SERVICE_INTERVAL.toMillis(),
+        5 * (int) SERVICE_INTERVAL.toMillis());
+
+    // wait for requests to complete
+    Thread.sleep(SERVICE_INTERVAL.toMillis());
+
+    // No expired open keys fetched
+    assertEquals(openKeyCleanupService.getSubmittedOpenKeyCount(), oldkeyCount);
+    assertExpiredOpenKeys(true, false, BucketLayout.DEFAULT);
+    assertExpiredOpenKeys(true, false,
+        BucketLayout.FILE_SYSTEM_OPTIMIZED);
+
+    assertEquals(0, metrics.getNumOpenKeysCleaned());
+  }
+
   void assertExpiredOpenKeys(boolean expectedToEmpty, boolean hsync,
       BucketLayout layout) throws IOException {
     final ExpiredOpenKeys expired = keyManager.getExpiredOpenKeys(
@@ -260,5 +324,87 @@ public class TestOpenKeyCleanupService {
     if (hsync) {
       writeClient.hsyncKey(keyArg, session.getId());
     }
+  }
+
+  private void createIncompleteMPUKeys(int mpuKeyCount,
+       BucketLayout bucketLayout) throws IOException {
+    String volume = UUID.randomUUID().toString();
+    String bucket = UUID.randomUUID().toString();
+    for (int x = 0; x < mpuKeyCount; x++) {
+      if (RandomUtils.nextBoolean()) {
+        bucket = UUID.randomUUID().toString();
+        if (RandomUtils.nextBoolean()) {
+          volume = UUID.randomUUID().toString();
+        }
+      }
+      String key = UUID.randomUUID().toString();
+      createVolumeAndBucket(volume, bucket, bucketLayout);
+
+      final int numParts = RandomUtils.nextInt(0, 5);
+      // Create the MPU key
+      createIncompleteMPUKey(volume, bucket, key, numParts);
+    }
+  }
+
+  /**
+   * Create inflight multipart upload that are not completed / aborted yet.
+   * @param volumeName
+   * @param bucketName
+   * @param keyName
+   * @throws IOException
+   */
+  private void createIncompleteMPUKey(String volumeName, String bucketName,
+      String keyName, int numParts) throws IOException {
+    // Initiate MPU
+    OmKeyArgs keyArgs =
+        new OmKeyArgs.Builder()
+            .setVolumeName(volumeName)
+            .setBucketName(bucketName)
+            .setKeyName(keyName)
+            .setAcls(Collections.emptyList())
+            .setReplicationConfig(StandaloneReplicationConfig.getInstance(
+                HddsProtos.ReplicationFactor.ONE))
+            .setLocationInfoList(new ArrayList<>())
+            .build();
+
+    OmMultipartInfo omMultipartInfo = writeClient.
+        initiateMultipartUpload(keyArgs);
+
+    // Commit MPU parts
+    for (int i = 1; i <= numParts; i++) {
+      OmKeyArgs partKeyArgs =
+          new OmKeyArgs.Builder()
+              .setVolumeName(volumeName)
+              .setBucketName(bucketName)
+              .setKeyName(keyName)
+              .setIsMultipartKey(true)
+              .setMultipartUploadID(omMultipartInfo.getUploadID())
+              .setMultipartUploadPartNumber(i)
+              .setAcls(Collections.emptyList())
+              .setReplicationConfig(StandaloneReplicationConfig.getInstance(
+                  HddsProtos.ReplicationFactor.ONE))
+              .build();
+
+      OpenKeySession openKey = writeClient.openKey(partKeyArgs);
+
+      OmKeyArgs commitPartKeyArgs =
+          new OmKeyArgs.Builder()
+              .setVolumeName(volumeName)
+              .setBucketName(bucketName)
+              .setKeyName(keyName)
+              .setIsMultipartKey(true)
+              .setMultipartUploadID(omMultipartInfo.getUploadID())
+              .setMultipartUploadPartNumber(i)
+              .setAcls(Collections.emptyList())
+              .setReplicationConfig(StandaloneReplicationConfig.getInstance(
+                  HddsProtos.ReplicationFactor.ONE))
+              .setLocationInfoList(Collections.emptyList())
+              .build();
+
+      writeClient.commitMultipartUploadPart(commitPartKeyArgs, openKey.getId());
+    }
+
+    // MPU key is not completed / aborted, so it's still in the
+    // multipartInfoTable
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Currently OpenKeyCleanupService deletes all the open keys in the openKeyTable regardless whether the open keys are MPU-related or not. This might cause orphan MPU in MultipartInfoTable, since to abort the MultipartInfo, we need to check openKeyTable for MPU-related open keys, which will fail if the open keys are already deleted. 

We need to exclude the incomplete MPU open keys in getExpiredOpenKeys so they are not deleted. We can use `isMultipartKey` flag set in the incomplete MPU open key info and exclude them from being deleted. However, prior to HDDS-9017, `isMultipartKey` flag is always set to false, so we need to handle this case. Here are the cases considered:

1. For MPU open keys with `isMultipartKey` flag set to true
    - We can skip it straight, without further checks
2. For MPU open keys with `isMultipartKey` flag set to false (prior to HDDS-9017)
    - Step 1 (fast check): extract `uploadId` from the MPU open key's db key and validate its structure, returning false if `uploadId `does not conform to the correct structure. Most non-MPU open keys will return false in this check, with possibility for false positives which will be handled in step 2.
    - Step 2 (MPU table check): from the `uploadId` we build the MPU db key and check the `multipartInfoTable` for such key. If it exists in the `multipartInfoTable`, it means that it is an incomplete MPU keys, which should be excluded from `getExpiredOpenKeys`

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-9098

## How was this patch tested?

Unit tests.
