### PR TITLE
HDDS-9207. [Snapshot] Snapshot Bootstrap creates incorrect hard links.

### DIFF
--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OMDBCheckpointServlet.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OMDBCheckpointServlet.java
@@ -504,7 +504,7 @@ public class OMDBCheckpointServlet extends DBCheckpointServlet {
               OmSnapshotUtils.getINode(file))) {
             return destPath;
           } else {
-            LOG.info("gbjx2: found non matching sst files: {}, {}",
+            LOG.info("Found non matching sst files: {}, {}",
                 srcPath, file.toString());
           }
         }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OMDBCheckpointServlet.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OMDBCheckpointServlet.java
@@ -246,7 +246,7 @@ public class OMDBCheckpointServlet extends DBCheckpointServlet {
 
 
   // Convenience class for keeping track of the tmp dirs.
-  public static class DirectoryData {
+  static class DirectoryData {
     private final File originalDir;
     private final File tmpDir;
     DirectoryData(Path tmpdir, String dirStr) throws IOException {
@@ -499,11 +499,14 @@ public class OMDBCheckpointServlet extends DBCheckpointServlet {
       Path srcPath = entry.getKey();
       Path destPath = entry.getValue();
       if (srcPath.toString().endsWith(fileName)) {
-        if (srcPath.toFile().exists() && OmSnapshotUtils.getINode(srcPath).equals(
-            OmSnapshotUtils.getINode(file))) {
-          return destPath;
-        } else {
-          LOG.info("gbjx: found non matching sst files: {}, {}", srcPath.toString(), file.toString());
+        if (srcPath.toFile().exists()) {
+          if (OmSnapshotUtils.getINode(srcPath).equals(
+              OmSnapshotUtils.getINode(file))) {
+            return destPath;
+          } else {
+            LOG.info("gbjx2: found non matching sst files: {}, {}",
+                srcPath, file.toString());
+          }
         }
       }
     }
@@ -567,7 +570,7 @@ public class OMDBCheckpointServlet extends DBCheckpointServlet {
 
   @NotNull
   private static Path getMetaDirPath(Path checkpointLocation) {
-    // This check is done to take care of findbug else below getParent()
+    // This check is done to take care of find-bug else below getParent()
     // should not be null.
     Path locationParent = checkpointLocation.getParent();
     if (null == locationParent) {

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OMDBCheckpointServlet.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OMDBCheckpointServlet.java
@@ -250,7 +250,7 @@ public class OMDBCheckpointServlet extends DBCheckpointServlet {
 
 
   // Convenience class for keeping track of the tmp dirs.
-  private static class DirectoryData {
+  public static class DirectoryData {
     private final File originalDir;
     private final File tmpDir;
     DirectoryData(Path tmpdir, String dirStr) throws IOException {
@@ -506,6 +506,8 @@ public class OMDBCheckpointServlet extends DBCheckpointServlet {
         if (srcPath.toFile().exists() && OmSnapshotUtils.getINode(srcPath).equals(
             OmSnapshotUtils.getINode(file))) {
           return destPath;
+        } else {
+          LOG.info("gbjx: found non matching sst files: {}, {}", srcPath.toString(), file.toString());
         }
       }
     }

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestOmSnapshotManager.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestOmSnapshotManager.java
@@ -331,10 +331,13 @@ public class TestOmSnapshotManager {
     Assert.assertTrue(leaderSstBackupDir.mkdirs());
     File leaderTmpDir = new File(leaderDir.toString(), "tmp");
     Assert.assertTrue(leaderTmpDir.mkdirs());
-    OMDBCheckpointServlet.DirectoryData sstBackupDir = new OMDBCheckpointServlet.DirectoryData(leaderTmpDir.toPath(),
+    OMDBCheckpointServlet.DirectoryData sstBackupDir =
+        new OMDBCheckpointServlet.DirectoryData(leaderTmpDir.toPath(),
         leaderSstBackupDir.toString());
-    Path srcSstBackup = Paths.get(sstBackupDir.getTmpDir().toString(), "backup.sst");
-    Path destSstBackup = Paths.get(sstBackupDir.getOriginalDir().toString(), "backup.sst");
+    Path srcSstBackup = Paths.get(sstBackupDir.getTmpDir().toString(),
+        "backup.sst");
+    Path destSstBackup = Paths.get(sstBackupDir.getOriginalDir().toString(),
+        "backup.sst");
     truncateLength = leaderDir.toString().length() + 1;
     existingSstList.add(truncateFileName(truncateLength, destSstBackup));
     Map<Path, Path> normalizedMap =
@@ -541,7 +544,8 @@ public class TestOmSnapshotManager {
     Assert.assertEquals(excluded.size(), 0);
     Assert.assertEquals(copyFiles.size(), 2);
     Assert.assertEquals(hardLinkFiles.size(), 0);
-    Assert.assertEquals(copyFiles.get(sameNameAsExcludeFile), destSameNameAsExcludeFile);
+    Assert.assertEquals(copyFiles.get(sameNameAsExcludeFile),
+        destSameNameAsExcludeFile);
     Assert.assertEquals(fileSize, expectedFileSize);
     copyFiles = new HashMap<>();
     copyFiles.put(copyFile, destCopyFile);
@@ -553,7 +557,8 @@ public class TestOmSnapshotManager {
     Assert.assertEquals(excluded.size(), 0);
     Assert.assertEquals(copyFiles.size(), 2);
     Assert.assertEquals(hardLinkFiles.size(), 0);
-    Assert.assertEquals(copyFiles.get(sameNameAsCopyFile), destSameNameAsCopyFile);
+    Assert.assertEquals(copyFiles.get(sameNameAsCopyFile),
+        destSameNameAsCopyFile);
     Assert.assertEquals(fileSize, expectedFileSize);
     copyFiles = new HashMap<>();
     copyFiles.put(copyFile, destCopyFile);

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestOmSnapshotManager.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestOmSnapshotManager.java
@@ -309,7 +309,7 @@ public class TestOmSnapshotManager {
   /*
    * Test that exclude list is generated correctly.
    */
-  @Test
+  //@Test
   public void testExcludeUtilities() throws IOException {
     File noLinkFile = new File(followerSnapDir2, "noLink.sst");
 
@@ -340,7 +340,7 @@ public class TestOmSnapshotManager {
    * should be copied, linked, or excluded from the tarball entirely.
    * This test always passes in a null dest dir.
    */
-  @Test
+  //@Test
   public void testProcessFileWithNullDestDirParameter() throws IOException {
     Assert.assertTrue(new File(testDir.toString(), "snap1").mkdirs());
     Assert.assertTrue(new File(testDir.toString(), "snap2").mkdirs());
@@ -431,7 +431,7 @@ public class TestOmSnapshotManager {
    * should be copied, linked, or excluded from the tarball entirely.
    * This test always passes in a non-null dest dir.
    */
-  @Test
+  //@Test
   public void testProcessFileWithDestDirParameter() throws IOException {
     Assert.assertTrue(new File(testDir.toString(), "snap1").mkdirs());
     Assert.assertTrue(new File(testDir.toString(), "snap2").mkdirs());

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestOmSnapshotManager.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestOmSnapshotManager.java
@@ -309,7 +309,7 @@ public class TestOmSnapshotManager {
   /*
    * Test that exclude list is generated correctly.
    */
-  //@Test
+  @Test
   public void testExcludeUtilities() throws IOException {
     File noLinkFile = new File(followerSnapDir2, "noLink.sst");
 
@@ -325,14 +325,28 @@ public class TestOmSnapshotManager {
 
     // Confirm that the excluded list is normalized as expected.
     //  (Normalizing means matches the layout on the leader.)
-    Map<Path, Path> normalizedSet =
+    File leaderSstBackupDir = new File(leaderDir.toString(), "sstBackup");
+    Assert.assertTrue(leaderSstBackupDir.mkdirs());
+    File leaderCompactionLogDir = new File(leaderDir.toString(), "compactionLog");
+    Assert.assertTrue(leaderCompactionLogDir.mkdirs());
+    File leaderTmpDir = new File(leaderDir.toString(), "tmp");
+    Assert.assertTrue(leaderTmpDir.mkdirs());
+    OMDBCheckpointServlet.DirectoryData sstBackupDir = new OMDBCheckpointServlet.DirectoryData(leaderTmpDir.toPath(),
+        leaderSstBackupDir.toString());
+    OMDBCheckpointServlet.DirectoryData compactionLogDir = new OMDBCheckpointServlet.DirectoryData(leaderTmpDir.toPath(),
+        leaderCompactionLogDir.toString());
+
+    Map<Path, Path> normalizedMap =
         OMDBCheckpointServlet.normalizeExcludeList(existingSstList,
-            leaderCheckpointDir.toPath(), null, null);
-    Set<Path> expectedNormalizedSet = new HashSet<>(Arrays.asList(
-        Paths.get(leaderSnapDir1.toString(), "s1.sst"),
-        Paths.get(leaderSnapDir2.toString(), "noLink.sst"),
-        Paths.get(leaderCheckpointDir.toString(), "f1.sst")));
-    Assert.assertEquals(expectedNormalizedSet, normalizedSet);
+        leaderCheckpointDir.toPath(), sstBackupDir, compactionLogDir);
+    Map<Path, Path> expectedMap = new HashMap<>();
+    Path s1 = Paths.get(leaderSnapDir1.toString(), "s1.sst");
+    Path noLink = Paths.get(leaderSnapDir2.toString(), "noLink.sst");
+    Path f1 = Paths.get(leaderCheckpointDir.toString(), "f1.sst");
+    expectedMap.put(s1, s1);
+    expectedMap.put(noLink, noLink);
+    expectedMap.put(f1, f1);
+    Assert.assertEquals(expectedMap, normalizedMap);
   }
 
   /*
@@ -340,7 +354,7 @@ public class TestOmSnapshotManager {
    * should be copied, linked, or excluded from the tarball entirely.
    * This test always passes in a null dest dir.
    */
-  //@Test
+  @Test
   public void testProcessFileWithNullDestDirParameter() throws IOException {
     Assert.assertTrue(new File(testDir.toString(), "snap1").mkdirs());
     Assert.assertTrue(new File(testDir.toString(), "snap2").mkdirs());
@@ -369,7 +383,7 @@ public class TestOmSnapshotManager {
         "dummyData".getBytes(StandardCharsets.UTF_8));
 
     Map<Path, Path> toExcludeFiles = new HashMap<>();
-    //        Collections.singletonList(excludeFile));
+    toExcludeFiles.put(excludeFile, excludeFile);
     Map<Path, Path> copyFiles = new HashMap<>();
     copyFiles.put(copyFile, copyFile);
     List<String> excluded = new ArrayList<>();
@@ -431,7 +445,7 @@ public class TestOmSnapshotManager {
    * should be copied, linked, or excluded from the tarball entirely.
    * This test always passes in a non-null dest dir.
    */
-  //@Test
+  @Test
   public void testProcessFileWithDestDirParameter() throws IOException {
     Assert.assertTrue(new File(testDir.toString(), "snap1").mkdirs());
     Assert.assertTrue(new File(testDir.toString(), "snap2").mkdirs());
@@ -477,7 +491,7 @@ public class TestOmSnapshotManager {
 
     // Create test data structures.
     Map<Path, Path> toExcludeFiles = new HashMap<>();
-    //        Collections.singletonList(destExcludeFile));
+    toExcludeFiles.put(excludeFile, destExcludeFile);
     Map<Path, Path> copyFiles = new HashMap<>();
     copyFiles.put(copyFile, destCopyFile);
     List<String> excluded = new ArrayList<>();

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestOmSnapshotManager.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestOmSnapshotManager.java
@@ -356,12 +356,10 @@ public class TestOmSnapshotManager {
         "dummyData".getBytes(StandardCharsets.UTF_8));
     Path linkToExcludedFile = Paths.get(testDir.toString(),
         "snap2/excludeFile.sst");
-    Files.write(linkToExcludedFile,
-        "dummyData".getBytes(StandardCharsets.UTF_8));
+    Files.createLink(linkToExcludedFile, excludeFile);
     Path linkToCopiedFile = Paths.get(testDir.toString(),
         "snap2/copyfile.sst");
-    Files.write(linkToCopiedFile,
-        "dummyData".getBytes(StandardCharsets.UTF_8));
+    Files.createLink(linkToCopiedFile, copyFile);
     Path addToCopiedFiles = Paths.get(testDir.toString(),
         "snap1/copyfile2.sst");
     Files.write(addToCopiedFiles,
@@ -459,14 +457,12 @@ public class TestOmSnapshotManager {
         "snap2/excludeFile.sst");
     Path destLinkToExcludedFile = Paths.get(destDir.toString(),
         "snap2/excludeFile.sst");
-    Files.write(linkToExcludedFile,
-        "dummyData".getBytes(StandardCharsets.UTF_8));
+    Files.createLink(linkToExcludedFile, excludeFile);
     Path linkToCopiedFile = Paths.get(testDir.toString(),
         "snap2/copyfile.sst");
     Path destLinkToCopiedFile = Paths.get(destDir.toString(),
         "snap2/copyfile.sst");
-    Files.write(linkToCopiedFile,
-        "dummyData".getBytes(StandardCharsets.UTF_8));
+    Files.createLink(linkToCopiedFile, copyFile);
     Path addToCopiedFiles = Paths.get(testDir.toString(),
         "snap1/copyfile2.sst");
     Path destAddToCopiedFiles = Paths.get(destDir.toString(),

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestOmSnapshotManager.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestOmSnapshotManager.java
@@ -45,7 +45,6 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -326,9 +325,9 @@ public class TestOmSnapshotManager {
 
     // Confirm that the excluded list is normalized as expected.
     //  (Normalizing means matches the layout on the leader.)
-    Set<Path> normalizedSet =
+    Map<Path, Path> normalizedSet =
         OMDBCheckpointServlet.normalizeExcludeList(existingSstList,
-            leaderCheckpointDir.toPath());
+            leaderCheckpointDir.toPath(), null, null);
     Set<Path> expectedNormalizedSet = new HashSet<>(Arrays.asList(
         Paths.get(leaderSnapDir1.toString(), "s1.sst"),
         Paths.get(leaderSnapDir2.toString(), "noLink.sst"),
@@ -369,8 +368,8 @@ public class TestOmSnapshotManager {
     Files.write(addNonSstToCopiedFiles,
         "dummyData".getBytes(StandardCharsets.UTF_8));
 
-    Set<Path> toExcludeFiles = new HashSet<>(
-        Collections.singletonList(excludeFile));
+    Map<Path, Path> toExcludeFiles = new HashMap<>();
+    //        Collections.singletonList(excludeFile));
     Map<Path, Path> copyFiles = new HashMap<>();
     copyFiles.put(copyFile, copyFile);
     List<String> excluded = new ArrayList<>();
@@ -477,8 +476,8 @@ public class TestOmSnapshotManager {
         "dummyData".getBytes(StandardCharsets.UTF_8));
 
     // Create test data structures.
-    Set<Path> toExcludeFiles = new HashSet<>(
-        Collections.singletonList(destExcludeFile));
+    Map<Path, Path> toExcludeFiles = new HashMap<>();
+    //        Collections.singletonList(destExcludeFile));
     Map<Path, Path> copyFiles = new HashMap<>();
     copyFiles.put(copyFile, destCopyFile);
     List<String> excluded = new ArrayList<>();


### PR DESCRIPTION
## What changes were proposed in this pull request?
### Fix Incorrect hard links
The tarball creation code was incorrectly assuming that two sst files with the same name, (but different directories,) were hard linked to each other.

See the jira ticket for an example of when this isn't correct: https://issues.apache.org/jira/browse/HDDS-9207

To remedy this, the tarball creation process must check the INodes of each file to confirm they are equal before linking them together.  That is the purpose of this PR.

### Fix Incomplete exclude list
The exclude list is a list of sst files the follower generates and sends to the leader when requesting a tarball.  It includes all the sst files already received by the follower so that the leader doesn't need to resend them.

The leader also uses this list to decide what hard links to create.  Prior to adding the inode check described above, the filename was all that was required for this hard link determination.

Now that we need to check INodes, the excludeList needs to be modified to keep track of both the src and dest directories of the sst files.  (The src dir is where it is on the host, the dest is where it is on the client.)

Most of the changes in this PR deal with that data structure change.


## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-9207

## How was this patch tested?

Updated unit tests and tested on a real cluster with 10 million keys and 1000 snapshots.
