### PR TITLE
HDDS-9213. Findbugs error in TestOMRatisSnapshots.

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOMRatisSnapshots.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOMRatisSnapshots.java
@@ -1241,8 +1241,9 @@ public class TestOMRatisSnapshots {
     SnapshotInfo snapshotInfoD = createOzoneSnapshot(newLeaderOM,
         snapshotNamePrefix + RandomStringUtils.randomNumeric(5));
 
-    File sstBackupDir = getSstBackupDir(newLeaderOM);
-    int numberOfSstFiles = sstBackupDir.listFiles().length;
+    // TODO: https://issues.apache.org/jira/browse/HDDS-9209
+    // File sstBackupDir = getSstBackupDir(newLeaderOM);
+    // int numberOfSstFiles = sstBackupDir.listFiles().length;
 
     // delete snapshot c
     client.getObjectStore()


### PR DESCRIPTION
## What changes were proposed in this pull request?
I accidentally merged this findbugs error into master:

M D DLS: Dead store to numberOfSstFiles in org.apache.hadoop.ozone.om.TestOMRatisSnapshots.testSnapshotBackgroundServices() At TestOMRatisSnapshots.java:[line 1245]


## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-9213

## How was this patch tested?

findbugs
