### PR TITLE
HDDS-7553. Ozone OM stopped with iIllegalStateException.

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMHAUtils.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMHAUtils.java
@@ -144,6 +144,15 @@ public final class SCMHAUtils {
     return scmRatisDirectory;
   }
 
+  public static String getRatisStorageDir(final ConfigurationSource conf) {
+    String storageDir = conf.get(ScmConfigKeys.OZONE_SCM_HA_RATIS_STORAGE_DIR);
+    if (Strings.isNullOrEmpty(storageDir)) {
+      File metaDirPath = ServerUtils.getOzoneMetaDirPath(conf);
+      storageDir = (new File(metaDirPath, "scm-ha")).getPath();
+    }
+    return storageDir;
+  }
+
   public static String getSCMRatisSnapshotDirectory(ConfigurationSource conf) {
     String snapshotDir =
             conf.get(ScmConfigKeys.OZONE_SCM_HA_RATIS_SNAPSHOT_DIR);

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/RatisUtil.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/RatisUtil.java
@@ -18,7 +18,6 @@
 package org.apache.hadoop.hdds.scm.ha;
 
 import com.google.common.base.Preconditions;
-import com.google.common.base.Strings;
 import com.google.protobuf.ServiceException;
 import org.apache.hadoop.hdds.conf.ConfigurationSource;
 import org.apache.hadoop.hdds.conf.StorageUnit;
@@ -26,7 +25,6 @@ import org.apache.hadoop.hdds.ratis.RatisHelper;
 import org.apache.hadoop.hdds.ratis.ServerNotLeaderException;
 import org.apache.hadoop.hdds.scm.ScmConfigKeys;
 import org.apache.hadoop.hdds.security.exception.SCMSecurityException;
-import org.apache.hadoop.hdds.server.ServerUtils;
 import org.apache.ratis.conf.RaftProperties;
 import org.apache.ratis.grpc.GrpcConfigKeys;
 import org.apache.ratis.protocol.exceptions.NotLeaderException;

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/RatisUtil.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/RatisUtil.java
@@ -85,19 +85,11 @@ public final class RatisUtil {
    * @param conf ConfigurationSource
    */
   public static void setRaftStorageDir(final RaftProperties properties,
-                                       final ConfigurationSource conf) {
-    RaftServerConfigKeys.setStorageDir(properties,
-        Collections.singletonList(new File(getRatisStorageDir(conf))));
+      final ConfigurationSource conf) {
+    RaftServerConfigKeys.setStorageDir(properties, Collections
+        .singletonList(new File(SCMHAUtils.getRatisStorageDir(conf))));
   }
 
-  public static String getRatisStorageDir(final ConfigurationSource conf) {
-    String storageDir = conf.get(ScmConfigKeys.OZONE_SCM_HA_RATIS_STORAGE_DIR);
-    if (Strings.isNullOrEmpty(storageDir)) {
-      File metaDirPath = ServerUtils.getOzoneMetaDirPath(conf);
-      storageDir = (new File(metaDirPath, "scm-ha")).getPath();
-    }
-    return storageDir;
-  }
   /**
    * Set properties related to Raft RPC.
    *

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/parser/TestOzoneHARatisLogParser.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/parser/TestOzoneHARatisLogParser.java
@@ -19,7 +19,7 @@ package org.apache.hadoop.ozone.parser;
 
 import com.google.common.base.Preconditions;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
-import org.apache.hadoop.hdds.scm.ha.RatisUtil;
+import org.apache.hadoop.hdds.scm.ha.SCMHAUtils;
 import org.apache.hadoop.hdds.scm.ha.SCMRatisRequest;
 import org.apache.hadoop.hdds.scm.server.StorageContainerManager;
 import org.apache.hadoop.hdds.utils.IOUtils;
@@ -141,7 +141,7 @@ class TestOzoneHARatisLogParser {
 
     // Now check for SCM.
     File scmMetadataDir =
-        new File(RatisUtil.getRatisStorageDir(leaderSCMConfig));
+        new File(SCMHAUtils.getRatisStorageDir(leaderSCMConfig));
     Assertions.assertTrue(scmMetadataDir.isDirectory());
 
     ratisDirs = scmMetadataDir.list();

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
@@ -81,6 +81,7 @@ import org.apache.hadoop.hdds.ratis.RatisHelper;
 import org.apache.hadoop.hdds.scm.ScmConfigKeys;
 import org.apache.hadoop.hdds.scm.ScmInfo;
 import org.apache.hadoop.hdds.scm.client.HddsClientUtils;
+import org.apache.hadoop.hdds.scm.ha.SCMHAUtils;
 import org.apache.hadoop.hdds.server.OzoneAdmins;
 import org.apache.hadoop.hdds.utils.db.Table;
 import org.apache.hadoop.hdds.utils.db.Table.KeyValue;
@@ -1431,11 +1432,9 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
       }
       OmUtils.createOMDir(omRatisDirectory);
 
-      String omStorageDir = conf.get(OMConfigKeys.OZONE_OM_RATIS_STORAGE_DIR);
-      String scmStorageDir =
-          conf.get(ScmConfigKeys.OZONE_SCM_HA_RATIS_STORAGE_DIR);
-      if (!Strings.isNullOrEmpty(omStorageDir) && !Strings
-          .isNullOrEmpty(scmStorageDir) && omStorageDir.equals(scmStorageDir)) {
+      String scmStorageDir = SCMHAUtils.getSCMRatisDirectory(conf);
+      if (!Strings.isNullOrEmpty(omRatisDirectory) && !Strings
+          .isNullOrEmpty(scmStorageDir) && omRatisDirectory.equals(scmStorageDir)) {
         throw new IOException(
             "Path of " + OMConfigKeys.OZONE_OM_RATIS_STORAGE_DIR + " and "
                 + ScmConfigKeys.OZONE_SCM_HA_RATIS_STORAGE_DIR

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
@@ -51,6 +51,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
 import com.google.common.base.Optional;
+import com.google.common.base.Strings;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.conf.StorageUnit;
 import org.apache.hadoop.crypto.key.KeyProvider;
@@ -1433,7 +1434,8 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
       String omStorageDir = conf.get(OMConfigKeys.OZONE_OM_RATIS_STORAGE_DIR);
       String scmStorageDir =
           conf.get(ScmConfigKeys.OZONE_SCM_HA_RATIS_STORAGE_DIR);
-      if (omStorageDir.equals(scmStorageDir)) {
+      if (!Strings.isNullOrEmpty(omStorageDir) && !Strings
+          .isNullOrEmpty(scmStorageDir) && omStorageDir.equals(scmStorageDir)) {
         throw new IOException(
             "Path of " + OMConfigKeys.OZONE_OM_RATIS_STORAGE_DIR + " and "
                 + ScmConfigKeys.OZONE_SCM_HA_RATIS_STORAGE_DIR

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
@@ -1432,7 +1432,7 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
       }
       OmUtils.createOMDir(omRatisDirectory);
 
-      String scmStorageDir = SCMHAUtils.getSCMRatisDirectory(conf);
+      String scmStorageDir = SCMHAUtils.getRatisStorageDir(conf);
       if (!Strings.isNullOrEmpty(omRatisDirectory) && !Strings
           .isNullOrEmpty(scmStorageDir) && omRatisDirectory
           .equals(scmStorageDir)) {

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
@@ -1434,7 +1434,8 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
 
       String scmStorageDir = SCMHAUtils.getSCMRatisDirectory(conf);
       if (!Strings.isNullOrEmpty(omRatisDirectory) && !Strings
-          .isNullOrEmpty(scmStorageDir) && omRatisDirectory.equals(scmStorageDir)) {
+          .isNullOrEmpty(scmStorageDir) && omRatisDirectory
+          .equals(scmStorageDir)) {
         throw new IOException(
             "Path of " + OMConfigKeys.OZONE_OM_RATIS_STORAGE_DIR + " and "
                 + ScmConfigKeys.OZONE_SCM_HA_RATIS_STORAGE_DIR


### PR DESCRIPTION
## What changes were proposed in this pull request?

Currently, we don't support om service id change but if someone changes om service id then we throw a warning message which results in the creation of a new raft group directory with respect to the new om service id and finally leads to iIllegalStateException. This PR aims to prevent the om service id change by throwing an exception, with this PR we also prevent the existence of SCM and OM ratis storage directory at the same path.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-7553

## How was this patch tested?

Tested Manually.
