### PR TITLE
HDDS-9179. Datanode Command Count Updated related DEBUG logging is too frequent

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/DatanodeCommandCountUpdatedHandler.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/DatanodeCommandCountUpdatedHandler.java
@@ -41,7 +41,7 @@ public class DatanodeCommandCountUpdatedHandler implements
   @Override
   public void onMessage(DatanodeDetails datanodeDetails,
       EventPublisher publisher) {
-    LOG.debug("DatanodeCommandCountUpdatedHandler called with datanode {}",
+    LOG.trace("DatanodeCommandCountUpdatedHandler called with datanode {}",
         datanodeDetails);
     replicationManager.datanodeCommandCountUpdated(datanodeDetails);
   }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ReplicationManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ReplicationManager.java
@@ -805,7 +805,7 @@ public class ReplicationManager implements SCMService {
    * @param datanode The datanode for which the commands have been updated.
    */
   public void datanodeCommandCountUpdated(DatanodeDetails datanode) {
-    LOG.debug("Received a notification that the DN command count " +
+    LOG.trace("Received a notification that the DN command count " +
         "has been updated for {}", datanode);
     // If there is an existing mapping, we may need to remove it
     excludedNodes.computeIfPresent(datanode, (dn, v) -> {


### PR DESCRIPTION
## What changes were proposed in this pull request?

Whenever a `DATANODE_COMMAND_COUNT_UPDATED` event is processed in the SCM, these log messages are printed in DEBUG mode:

```
LOG.debug("DatanodeCommandCountUpdatedHandler called with datanode {}",
        datanodeDetails);
```
and 
```
    LOG.debug("Received a notification that the DN command count " +
        "has been updated for {}", datanode);

```

In a busy cluster this can happen quite frequently. This PR moves them to TRACE level.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-9179

## How was this patch tested?

Existing tests.