### PR TITLE
HDDS-9216. Update log in exception while processing ICR for container.

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/IncrementalContainerReportHandler.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/IncrementalContainerReportHandler.java
@@ -110,8 +110,8 @@ public class IncrementalContainerReportHandler extends
               replicaProto.getContainerID());
         } catch (SCMException ex) {
           if (ex.getResult() == SCMException.ResultCodes.SCM_NOT_LEADER) {
-            LOG.warn("Failed to process " + replicaProto.getState()
-                + " Container " + id + " due to " + ex);
+            LOG.warn("Failed to process {} container {}",
+                replicaProto.getState(), id, ex);
           } else {
             LOG.error("Exception while processing ICR for container {}",
                 replicaProto.getContainerID(), ex);

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/IncrementalContainerReportHandler.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/IncrementalContainerReportHandler.java
@@ -110,8 +110,8 @@ public class IncrementalContainerReportHandler extends
               replicaProto.getContainerID());
         } catch (SCMException ex) {
           if (ex.getResult() == SCMException.ResultCodes.SCM_NOT_LEADER) {
-            LOG.warn("Failed to process {} container {}",
-                replicaProto.getState(), id, ex);
+            LOG.warn("Failed to process {} container {}: {}",
+                replicaProto.getState(), id, ex.getMessage());
           } else {
             LOG.error("Exception while processing ICR for container {}",
                 replicaProto.getContainerID(), ex);

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/IncrementalContainerReportHandler.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/IncrementalContainerReportHandler.java
@@ -25,6 +25,7 @@ import org.apache.hadoop.hdds.protocol.DatanodeDetails;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos
     .ContainerReplicaProto;
 import org.apache.hadoop.hdds.scm.container.report.ContainerReportValidator;
+import org.apache.hadoop.hdds.scm.exceptions.SCMException;
 import org.apache.hadoop.hdds.scm.ha.SCMContext;
 import org.apache.hadoop.hdds.scm.node.NodeManager;
 import org.apache.hadoop.hdds.scm.node.states.NodeNotFoundException;
@@ -33,7 +34,6 @@ import org.apache.hadoop.hdds.scm.server.SCMDatanodeHeartbeatDispatcher
 import org.apache.hadoop.hdds.server.events.EventHandler;
 import org.apache.hadoop.hdds.server.events.EventPublisher;
 import org.apache.hadoop.ozone.common.statemachine.InvalidStateTransitionException;
-import org.apache.ratis.protocol.exceptions.NotLeaderException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -108,9 +108,14 @@ public class IncrementalContainerReportHandler extends
         } catch (ContainerReplicaNotFoundException e) {
           LOG.warn("Container {} replica not found!",
               replicaProto.getContainerID());
-        } catch (NotLeaderException nle) {
-          LOG.warn("Failed to process " + replicaProto.getState()
-              + " Container " + id + " due to " + nle);
+        } catch (SCMException ex) {
+          if (ex.getResult() == SCMException.ResultCodes.SCM_NOT_LEADER) {
+            LOG.warn("Failed to process " + replicaProto.getState()
+                + " Container " + id + " due to " + ex);
+          } else {
+            LOG.error("Exception while processing ICR for container {}",
+                replicaProto.getContainerID(), ex);
+          }
         } catch (IOException | InvalidStateTransitionException |
                  TimeoutException e) {
           LOG.error("Exception while processing ICR for container {}",


### PR DESCRIPTION
## What changes were proposed in this pull request?

Not leader log was changed in [HDDS-6241](https://issues.apache.org/jira/browse/HDDS-6241) when there is exception during ICR. But in [HDDS-8934](https://issues.apache.org/jira/browse/HDDS-8934) not leader exception is wrapped inside SCMException. Now it is not getting caught in `NotLeaderException`. In this PR updating the log for SCM_NOT_LEADER exception.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-9216

## How was this patch tested?

Just logging changed, no test impact.
