### PR TITLE
HDDS-3420. Enable TestSCMSafeModeWithPipelineRules test cases

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/safemode/TestSCMSafeModeWithPipelineRules.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/safemode/TestSCMSafeModeWithPipelineRules.java
@@ -23,7 +23,9 @@ import org.apache.hadoop.hdds.client.RatisReplicationConfig;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationFactor;
+import org.apache.hadoop.hdds.scm.PlacementPolicy;
 import org.apache.hadoop.hdds.scm.ScmConfigKeys;
+import org.apache.hadoop.hdds.scm.container.placement.algorithms.SCMContainerPlacementCapacity;
 import org.apache.hadoop.hdds.scm.container.replication.ReplicationManager;
 import org.apache.hadoop.hdds.scm.pipeline.Pipeline;
 import org.apache.hadoop.hdds.scm.pipeline.PipelineManager;
@@ -32,45 +34,50 @@ import org.apache.hadoop.ozone.MiniOzoneCluster;
 import org.apache.ozone.test.GenericTestUtils;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.io.TempDir;
 
-import java.nio.file.Path;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_HEARTBEAT_INTERVAL;
+import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_PIPELINE_REPORT_INTERVAL;
+import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_COMMAND_STATUS_REPORT_INTERVAL;
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_DATANODE_PIPELINE_LIMIT;
+import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_HEARTBEAT_PROCESS_INTERVAL;
 import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  * This class tests SCM Safe mode with pipeline rules.
  */
 
-@Disabled
 public class TestSCMSafeModeWithPipelineRules {
 
   private MiniOzoneCluster cluster;
-  private OzoneConfiguration conf = new OzoneConfiguration();
+  private OzoneConfiguration conf;
   private PipelineManager pipelineManager;
-  private MiniOzoneCluster.Builder clusterBuilder;
 
-  public void setup(int numDatanodes, Path metadataDir) throws Exception {
-    conf.set(HddsConfigKeys.OZONE_METADATA_DIRS,
-        metadataDir.toAbsolutePath().toString());
+  public void setup(int numDatanodes) throws Exception {
+    conf = new OzoneConfiguration();
+    conf.setTimeDuration(OZONE_SCM_HEARTBEAT_PROCESS_INTERVAL,
+        100, TimeUnit.MILLISECONDS);
     conf.setBoolean(
         HddsConfigKeys.HDDS_SCM_SAFEMODE_PIPELINE_AVAILABILITY_CHECK,
         true);
     conf.set(HddsConfigKeys.HDDS_SCM_WAIT_TIME_AFTER_SAFE_MODE_EXIT, "10s");
     conf.set(ScmConfigKeys.OZONE_SCM_PIPELINE_CREATION_INTERVAL, "10s");
-    conf.setInt(OZONE_DATANODE_PIPELINE_LIMIT, 50);
+    conf.setInt(OZONE_DATANODE_PIPELINE_LIMIT, 1);
+    conf.setTimeDuration(HDDS_HEARTBEAT_INTERVAL, 1, SECONDS);
+    conf.setTimeDuration(HDDS_PIPELINE_REPORT_INTERVAL, 1, SECONDS);
+    conf.setTimeDuration(HDDS_COMMAND_STATUS_REPORT_INTERVAL, 1, SECONDS);
+    conf.setBoolean(ScmConfigKeys.OZONE_SCM_DATANODE_DISALLOW_SAME_PEERS, true);
+    conf.setClass(ScmConfigKeys.OZONE_SCM_CONTAINER_PLACEMENT_IMPL_KEY,
+        SCMContainerPlacementCapacity.class, PlacementPolicy.class);
 
-    clusterBuilder = MiniOzoneCluster.newBuilder(conf)
+    cluster = MiniOzoneCluster.newBuilder(conf)
         .setNumDatanodes(numDatanodes)
-        .setHbInterval(1000)
-        .setHbProcessorInterval(1000);
-
-    cluster = clusterBuilder.build();
+        .build();
     cluster.waitForClusterToBeReady();
     StorageContainerManager scm = cluster.getStorageContainerManager();
     pipelineManager = scm.getPipelineManager();
@@ -78,11 +85,9 @@ public class TestSCMSafeModeWithPipelineRules {
 
 
   @Test
-  public void testScmSafeMode(@TempDir Path tempDir) throws Exception {
-
+  public void testScmSafeMode() throws Exception {
     int datanodeCount = 6;
-    setup(datanodeCount, tempDir);
-
+    setup(datanodeCount);
     waitForRatis3NodePipelines(datanodeCount / 3);
     waitForRatis1NodePipelines(datanodeCount);
 
@@ -136,47 +141,34 @@ public class TestSCMSafeModeWithPipelineRules {
       fail("Datanode restart failed");
     }
 
-
     GenericTestUtils.waitFor(() ->
         scmSafeModeManager.getOneReplicaPipelineSafeModeRule()
             .validate(), 1000, 60000);
 
+    // All safeMode preChecks are now satisfied, SCM should be out of safe mode.
+
     GenericTestUtils.waitFor(() -> !scmSafeModeManager.getInSafeMode(), 1000,
         60000);
 
-    // As after safemode wait time is not completed, we should have total
+    // As after safeMode wait time is not completed, we should have total
     // pipeline's as original count 6(1 node pipelines) + 2 (3 node pipeline)
     Assertions.assertEquals(totalPipelineCount,
         pipelineManager.getPipelines().size());
+
+    // The below check calls pipelineManager.getPipelines()
+    // which is a call to the SCM to get the list of pipeline infos.
+    // This is independent of DN reports or whether any number of DataNodes are
+    // alive as the pipeline info is persisted to SCM upon creation and loaded
+    // back upon restart.
+
+    waitForRatis1NodePipelines(datanodeCount);
+    waitForRatis3NodePipelines(datanodeCount / 3);
 
     ReplicationManager replicationManager =
         cluster.getStorageContainerManager().getReplicationManager();
 
     GenericTestUtils.waitFor(() ->
         replicationManager.isRunning(), 1000, 60000);
-
-
-    // As 4 datanodes are reported, 4 single node pipeline and 1 3 node
-    // pipeline.
-
-    waitForRatis1NodePipelines(4);
-    waitForRatis3NodePipelines(1);
-
-    // Restart other datanodes in the pipeline, and after some time we should
-    // have same count as original.
-    pipelineList.get(1).getNodes().forEach(datanodeDetails -> {
-      try {
-        if (!restartedDatanode.equals(datanodeDetails)) {
-          cluster.restartHddsDatanode(datanodeDetails, false);
-        }
-      } catch (Exception ex) {
-        fail("Datanode restart failed");
-      }
-    });
-
-    waitForRatis1NodePipelines(datanodeCount);
-    waitForRatis3NodePipelines(datanodeCount / 3);
-
   }
 
   @AfterEach


### PR DESCRIPTION
## What changes were proposed in this pull request?
The changes that fix the test :
1. Setting `OZONE_DATANODE_PIPELINE_LIMIT` to 1 , earlier set to 50 . With Multi-Raft enabled by default, each DN was participating in multiple pipelines which caused failures in some assertions that asserted pipeline count. This test was written prior to multi raft. 
2.  Outdated waiting logic : When pipeline scrubber creates pipelines , SCM persists its info in its RocksDB. After a cluster/SCM restart, SCM loads back the persisted pipelines in its memory . pipelineManager.getPipelines() returns this info. 
This is independent of how many dataNodes are up or down as it is purely loading it from SCM DB. Removed such redundant checks.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-3420

## How was this patch tested?
Unit test fix

Ran the test for 100 iterations :  https://github.com/sadanand48/hadoop-ozone/actions/runs/6008530745
