### PR TITLE
HDDS-9224. Recon HeatMap UI issues

### DIFF
--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/views/heatMap/heatMapConfiguration.tsx
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/views/heatMap/heatMapConfiguration.tsx
@@ -40,7 +40,6 @@ interface IHeatmapConfigurationProps {
   data: ITreeResponse[];
   onClick: Function;
   colorScheme: string[];
-  childEntityType: string;
 }
 
 export default class HeatMapConfiguration extends React.Component<IHeatmapConfigurationProps> {
@@ -127,9 +126,9 @@ export default class HeatMapConfiguration extends React.Component<IHeatmapConfig
     `;}
     if (params.datum.label !== "") {
       tooltipContent += `<br/>
-          ${this.props.childEntityType.charAt(0).toUpperCase() + this.props.childEntityType.slice(1)} Name:
-          ${params.datum.label ? params.datum.label.split("/").slice(-1) : ""}
-        `;
+        Entity Name:
+        ${params.datum.label ? params.datum.label.split("/").slice(-1) : ""}
+      `;
     }
     tooltipContent += '</span>';
     return tooltipContent;

--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/views/heatMap/heatMapConfiguration.tsx
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/views/heatMap/heatMapConfiguration.tsx
@@ -40,6 +40,7 @@ interface IHeatmapConfigurationProps {
   data: ITreeResponse[];
   onClick: Function;
   colorScheme: string[];
+  childEntityType: string;
 }
 
 export default class HeatMapConfiguration extends React.Component<IHeatmapConfigurationProps> {
@@ -126,7 +127,7 @@ export default class HeatMapConfiguration extends React.Component<IHeatmapConfig
     `;}
     if (params.datum.label !== "") {
       tooltipContent += `<br/>
-          File Name:
+          ${this.props.childEntityType.charAt(0).toUpperCase() + this.props.childEntityType.slice(1)} Name:
           ${params.datum.label ? params.datum.label.split("/").slice(-1) : ""}
         `;
     }

--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/views/heatMap/heatmap.tsx
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/views/heatMap/heatmap.tsx
@@ -133,8 +133,8 @@ export class Heatmap extends React.Component<Record<string, object>, ITreeState>
     const value = e.target.value;
     let inputValid = "";
     let helpMessage = ""
-    // Only allow letters, numbers,underscores and forward slashes
-    const regex = /^[a-zA-Z0-9_/]*$/;
+    // Only allow letters, numbers,underscores and forward slashes and hyphen
+    const regex = /^[a-zA-Z0-9_/-]*$/;
     if (!regex.test(value)) {
       helpMessage = "Please enter valid path"
       inputValid = "error"
@@ -392,7 +392,7 @@ export class Heatmap extends React.Component<Record<string, object>, ITreeState>
                       </div>
                     </div>
                     <div id="heatmap-chart-container">
-                      <HeatMapConfiguration data={treeResponse} colorScheme={colourScheme["amber_alert"]} onClick={this.updateTreemapParent}></HeatMapConfiguration>
+                      <HeatMapConfiguration data={treeResponse} colorScheme={colourScheme["amber_alert"]} onClick={this.updateTreemapParent} childEntityType={this.state.entityType}></HeatMapConfiguration>
                     </div>
                   </div>
                   :

--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/views/heatMap/heatmap.tsx
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/views/heatMap/heatmap.tsx
@@ -392,7 +392,7 @@ export class Heatmap extends React.Component<Record<string, object>, ITreeState>
                       </div>
                     </div>
                     <div id="heatmap-chart-container">
-                      <HeatMapConfiguration data={treeResponse} colorScheme={colourScheme["amber_alert"]} onClick={this.updateTreemapParent} childEntityType={this.state.entityType}></HeatMapConfiguration>
+                      <HeatMapConfiguration data={treeResponse} colorScheme={colourScheme["amber_alert"]} onClick={this.updateTreemapParent}></HeatMapConfiguration>
                     </div>
                   </div>
                   :


### PR DESCRIPTION
## What changes were proposed in this pull request?
Few HeatMap issues:
1) Not able to enter "/s3v/cloudera-health-monitoring-ozone-basic-canary-bucket/cloudera-health-monitoring-ozone-basic-canary-key" in path box.
2) Tooltip always show FileName label irrespective of entity type selected. It should display label as Key Name, if selected bucket entity type, tool tip should have label Bucket Name and if volume, the should be Volume Name.

**Yes it will need backend Changes also as not able to differentiate between Volume,Bucket, Directories, Sub Directories and keys byseeing name only. Currently did changes as Entity Name so it will be consistent across all levels**.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-9224


## How was this patch tested?
Manually
![image](https://github.com/apache/ozone/assets/112169209/2cc260f7-014e-416b-8811-0092856f5858)


Regular Expression for - working
![image](https://github.com/apache/ozone/assets/112169209/9c21bfe7-3b14-4f93-b889-41afe49323fc)

