### PR TITLE
HDDS-9230. Add CLI command for checking native libs

### DIFF
--- a/hadoop-hdds/docs/content/feature/ErasureCoding.md
+++ b/hadoop-hdds/docs/content/feature/ErasureCoding.md
@@ -210,3 +210,25 @@ ozone sh key put <Ozone Key Object Path> <Local File> --type EC --replication rs
 
 In the case bucket already has default EC Replication Config, there is no need of passing EC Replication Config while creating key.
 
+### Enable Intel ISA-L
+
+Intel Intelligent Storage Acceleration Library (ISA-L) is an open-source collection of optimized low-level functions used for
+storage applications. Enabling ISA-L allows significantly improve EC performance.
+
+#### Prerequisites
+
+To enable ISA-L you will also require Hadoop native libraries (libhadoop.so). 
+
+#### Installation
+Both libraries should be placed to the directory specified by the java.library.path property or set by  `LD_LIBRARY_PATH` environment variable.
+The default value of java.library.path depends on the OS and Java version. For example, on Linux with OpenJDK 8 it is `/usr/java/packages/lib/amd64:/usr/lib64:/lib64:/lib:/usr/lib`.
+
+#### Verification
+
+You can check if ISA-L is accessible to Ozone by running the following command:
+
+```shell
+ozone checknative
+```
+
+

--- a/hadoop-ozone/dist/src/shell/ozone/ozone
+++ b/hadoop-ozone/dist/src/shell/ozone/ozone
@@ -59,6 +59,7 @@ function ozone_usage
   ozone_add_subcommand "dtutil" client "operations related to delegation tokens"
   ozone_add_subcommand "admin" client "Ozone admin tool"
   ozone_add_subcommand "debug" client "Ozone debug tool"
+  ozone_add_subcommand "checknative" client "checks if native libraries are loaded"
 
   ozone_generate_usage "${OZONE_SHELL_EXECNAME}" false
 }
@@ -229,6 +230,10 @@ function ozonecmd_case
     debug)
       OZONE_CLASSNAME=org.apache.hadoop.ozone.debug.OzoneDebug
       OZONE_RUN_ARTIFACT_NAME="ozone-tools"
+    ;;
+    checknative)
+        OZONE_CLASSNAME=org.apache.hadoop.ozone.shell.checknative.CheckNative
+        OZONE_RUN_ARTIFACT_NAME="ozone-tools"
     ;;
     *)
       OZONE_CLASSNAME="${subcmd}"

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/checknative/CheckNative.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/checknative/CheckNative.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.apache.hadoop.ozone.shell.checknative;
+
+import org.apache.hadoop.hdds.cli.GenericCli;
+import org.apache.hadoop.io.erasurecode.ErasureCodeNative;
+import org.apache.hadoop.util.NativeCodeLoader;
+import picocli.CommandLine;
+
+/**
+ * CLI command to check if native libraries are loaded.
+ */
+@CommandLine.Command(name = "ozone checknative",
+    description = "Checks if native libraries are loaded")
+public class CheckNative extends GenericCli {
+
+  public static void main(String[] argv) {
+    new CheckNative().run(argv);
+  }
+
+  @Override
+  public Void call() throws Exception {
+    boolean nativeHadoopLoaded = NativeCodeLoader.isNativeCodeLoaded();
+    String hadoopLibraryName = "";
+    String isalDetail = "";
+    boolean isalLoaded = false;
+    if (nativeHadoopLoaded) {
+      hadoopLibraryName = NativeCodeLoader.getLibraryName();
+
+      isalDetail = ErasureCodeNative.getLoadingFailureReason();
+      if (isalDetail != null) {
+        isalLoaded = false;
+      } else {
+        isalDetail = ErasureCodeNative.getLibraryName();
+        isalLoaded = true;
+      }
+
+    }
+    System.out.println("Native library checking:");
+    System.out.printf("hadoop:  %b %s%n", nativeHadoopLoaded,
+        hadoopLibraryName);
+    System.out.printf("ISA-L:   %b %s%n", isalLoaded, isalDetail);
+    return null;
+  }
+}

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/checknative/package-info.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/checknative/package-info.java
@@ -1,0 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+/**
+ * Package for commands related to checking native libraries.
+ */
+package org.apache.hadoop.ozone.shell.checknative;

--- a/hadoop-ozone/tools/src/test/java/org/apache/hadoop/ozone/checknative/TestCheckNative.java
+++ b/hadoop-ozone/tools/src/test/java/org/apache/hadoop/ozone/checknative/TestCheckNative.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.apache.hadoop.ozone.checknative;
+
+import org.apache.hadoop.ozone.shell.checknative.CheckNative;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.io.UnsupportedEncodingException;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Tests for {@link CheckNative}.
+ */
+public class TestCheckNative {
+
+  private static PrintStream psBackup;
+  private static ByteArrayOutputStream outputStream;
+
+  private static final String DEFAULT_ENCODING = UTF_8.name();
+
+  @BeforeClass
+  public static void init() throws UnsupportedEncodingException {
+    psBackup = System.out;
+    outputStream = new ByteArrayOutputStream();
+    PrintStream psOut = new PrintStream(outputStream, false, DEFAULT_ENCODING);
+    System.setOut(psOut);
+  }
+
+  @Test
+  public void testCheckNativeNotLoaded() throws UnsupportedEncodingException {
+    outputStream.reset();
+    new CheckNative()
+        .run(new String[] {});
+    // trims multiple spaces
+    String stdOut = outputStream.toString(DEFAULT_ENCODING)
+        .replaceAll(" +", " ");
+    assertTrue(stdOut.contains("Native library checking:"));
+    assertTrue(stdOut.contains("hadoop: false"));
+    assertTrue(stdOut.contains("ISA-L: false"));
+  }
+
+  @After
+  public void setUp() {
+    outputStream.reset();
+  }
+
+  @AfterClass
+  public static void tearDown() {
+    System.setOut(psBackup);
+  }
+}


### PR DESCRIPTION
## What changes were proposed in this pull request?

Added CLI command for checking if native libraries (libhadoop and isa-l) are accessible

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-9230

## How was this patch tested?

added a unit test for a case where native libs are not provided. Other cases are tricky to mock so I did manual testing:

Native libs not provided:
```
$ ozone checknative
Native library checking:
hadoop:  false
ISA-L:   false
```
Only hadooplib is provided:
```
$ ozone checknative
Native library checking:
hadoop:  true /root/lib/libhadoop.so
ISA-L:   false Loading ISA-L failed: Failed to load libisal.so.2 (libisal.so.2: cannot open shared object file: No such file or directory)
```

Hadooplib and isa-l are provided:
```
$ ozone checknative
Native library checking:
hadoop:  true /root/lib/libhadoop.so
ISA-L:   true /lib64/libisal.so.2
```