### PR TITLE
HDDS-9231. Recon: Heatmap Page can be directly accessed even after disable config

### DIFF
--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/components/navBar/navBar.tsx
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/components/navBar/navBar.tsx
@@ -22,8 +22,6 @@ import {Layout, Menu, Icon} from 'antd';
 import './navBar.less';
 import {withRouter, Link} from 'react-router-dom';
 import {RouteComponentProps} from 'react-router';
-import axios from 'axios';
-import {showDataFetchError} from 'utils/common';
 
 const {Sider} = Layout;
 
@@ -38,47 +36,17 @@ class NavBar extends React.Component<INavBarProps> {
   constructor(props = {}) {
     super(props);
     this.state = {
-      isHeatmapAvailable: false,
       isLoading: false
     };
   }
 
-  componentDidMount(): void {
-    this.setState({
-      isLoading: true
-    });
-    this.fetchDisableFeatures();
-  }
-  
-  fetchDisableFeatures = () => {
-    this.setState({
-      isLoading: true
-    });
-
-    const disabledfeaturesEndpoint = `/api/v1/features/disabledFeatures`;
-    axios.get(disabledfeaturesEndpoint).then(response => {
-      const disabledFeaturesFlag = response.data && response.data.includes('HEATMAP');
-      // If disabledFeaturesFlag is true then disable Heatmap Feature in Ozone Recon
-      this.setState({
-        isLoading: false,
-        isHeatmapAvailable: !disabledFeaturesFlag
-      });
-    }).catch(error => {
-      this.setState({
-        isLoading: false
-      });
-      showDataFetchError(error.toString());
-    });
-  };
-
   refresh = () => {
-    console.log("refresh");
     this.props.history.push('/Heatmap');
     window.location.reload();
-    }
+  }
 
   render() {
-    const {location} = this.props;
+    const {location, isHeatmapAvailable } = this.props;
     return (
       <Sider
         collapsible
@@ -140,7 +108,7 @@ class NavBar extends React.Component<INavBarProps> {
             <Link to='/DiskUsage'/>
           </Menu.Item>
           {
-            this.state.isHeatmapAvailable ?
+            isHeatmapAvailable ?
               <Menu.Item key='/Heatmap'>
                 <Icon type='bar-chart' />
                 <span>Heatmap</span>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Steps to repro:
Disable the config "ozone.recon.heatmap.enable"
Wait for CM to show up restart icon.
Deploy and restart the Ozone service.
Try refresh the same HeatMap URL "https://deveshsingh-3.deveshsingh.root.hwx.site:9889/?inputPath=#/Heatmap".
HeatMap page still accessible.
Heatmap is accessible after we disable heatmap

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-9231

## How was this patch tested?
Manually

HEATMAP Feature is disabled.

![image](https://github.com/apache/ozone/assets/112169209/4204db84-c8df-46b9-bfc3-f66463809f7c)

![image](https://github.com/apache/ozone/assets/112169209/0c165d2a-11e4-4237-82bd-8f4deb2d5df9)


