### PR TITLE
HDDS-9234. OM should shutdown immediately if certificate durations are invalid

### DIFF
--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
@@ -1332,6 +1332,9 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
       AuthenticationException {
     OMHANodeDetails omhaNodeDetails = OMHANodeDetails.loadOMHAConfig(conf);
     String nodeId = omhaNodeDetails.getLocalNodeDetails().getNodeId();
+    // Checking certificate duration validity by using
+    // validateCertificateValidityConfig() in SecurityConfig constructor.
+    new SecurityConfig(conf);
     loginOMUserIfSecurityEnabled(conf);
     OMStorage omStorage = new OMStorage(conf);
     StorageState state = omStorage.getState();

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
@@ -1315,6 +1315,9 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
       throws IOException, AuthenticationException {
     securityEnabled = OzoneSecurityUtil.isSecurityEnabled(conf);
     if (securityEnabled && testUgi == null) {
+      // Checking certificate duration validity by using
+      // validateCertificateValidityConfig() in SecurityConfig constructor.
+      new SecurityConfig(conf);
       loginOMUser(conf);
     }
   }
@@ -1332,9 +1335,6 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
       AuthenticationException {
     OMHANodeDetails omhaNodeDetails = OMHANodeDetails.loadOMHAConfig(conf);
     String nodeId = omhaNodeDetails.getLocalNodeDetails().getNodeId();
-    // Checking certificate duration validity by using
-    // validateCertificateValidityConfig() in SecurityConfig constructor.
-    new SecurityConfig(conf);
     loginOMUserIfSecurityEnabled(conf);
     OMStorage omStorage = new OMStorage(conf);
     StorageState state = omStorage.getState();


### PR DESCRIPTION
## What changes were proposed in this pull request?

As of now if certificate durations are invalid for example, if "hdds.x509.max.duration" is set with a negative value then OM goes into a retry mode as OM tries to communicate with SCM which is already down so in this case after 600 seconds(by default) OM shuts down. In this jira, we will try to check the validity of the certificate duration in the init process and shut down the OM immediately if the durations are invalid.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-9234

## How was this patch tested?

Tested Manually.
