### PR TITLE
HDDS-9125. Decommissioning blocked because of under replicated EC containers

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/SCMCommonPlacementPolicy.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/SCMCommonPlacementPolicy.java
@@ -392,9 +392,12 @@ public abstract class SCMCommonPlacementPolicy implements
    * should have
    *
    * @param numReplicas - The desired replica counts
+   * @param excludedRackCount - The number of racks excluded due to containing
+   *                          only excluded nodes. The total racks on the
+   *                          cluster will be reduced by this number.
    * @return The number of racks containers should span to meet the policy
    */
-  protected int getRequiredRackCount(int numReplicas) {
+  protected int getRequiredRackCount(int numReplicas, int excludedRackCount) {
     return 1;
   }
 
@@ -432,7 +435,7 @@ public abstract class SCMCommonPlacementPolicy implements
       List<DatanodeDetails> dns, int replicas) {
     NetworkTopology topology = nodeManager.getClusterNetworkTopologyMap();
     // We have a network topology so calculate if it is satisfied or not.
-    int requiredRacks = getRequiredRackCount(replicas);
+    int requiredRacks = getRequiredRackCount(replicas, 0);
     if (topology == null || replicas == 1 || requiredRacks == 1) {
       if (dns.size() > 0) {
         // placement is always satisfied if there is at least one DN.
@@ -520,7 +523,7 @@ public abstract class SCMCommonPlacementPolicy implements
 
     int totalNumberOfReplicas = replicas.size();
     int requiredNumberOfPlacementGroups =
-            getRequiredRackCount(totalNumberOfReplicas);
+            getRequiredRackCount(totalNumberOfReplicas, 0);
     Set<ContainerReplica> copyReplicaSet = Sets.newHashSet();
     List<List<ContainerReplica>> replicaSet = placementGroupReplicaIdMap
             .values().stream()

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/placement/algorithms/SCMContainerPlacementRackAware.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/placement/algorithms/SCMContainerPlacementRackAware.java
@@ -591,9 +591,10 @@ public final class SCMContainerPlacementRackAware
   }
 
   @Override
-  protected int getRequiredRackCount(int numReplicas) {
+  protected int getRequiredRackCount(int numReplicas, int excludedRackCount) {
     int racks = networkTopology != null
         ? networkTopology.getNumOfNodes(networkTopology.getMaxLevel() - 1)
+            - excludedRackCount
         : 1;
     return Math.min(REQUIRED_RACKS, racks);
   }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/placement/algorithms/SCMContainerPlacementRackScatter.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/placement/algorithms/SCMContainerPlacementRackScatter.java
@@ -391,18 +391,15 @@ public final class SCMContainerPlacementRackScatter
     for (Node node : excludedNodes) {
       Node rack = networkTopology.getAncestor(node, RACK_LEVEL);
       if (rack != null && !usedRacksCntMap.containsKey(rack)) {
-        // Rack for an excluded node and no used nodes on this rack.
+        // Dead nodes are removed from the topology, so the node may have a null
+        // rack, hence the not null check.
+        // Anything that reaches here is the rack for an excluded node and no
+        // used nodes on are on the rack.
         excludedNodeRacks.add(rack);
       }
     }
     Set<Node> exc = new HashSet<>(excludedNodes);
     for (Node rack : excludedNodeRacks) {
-      // Dead nodes are removed from the topology, so the node may have a null
-      // rack, or the topology may not know about it, depending on the timing
-      // of when it got removed / excluded.
-      if (rack == null) {
-        continue;
-      }
       // If a node is removed from the cluster (eg goes dead), but the client
       // already added it to the exclude list, then the rack may not be in the
       // topology any longer. See test

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/placement/algorithms/SCMContainerPlacementRackScatter.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/placement/algorithms/SCMContainerPlacementRackScatter.java
@@ -265,8 +265,16 @@ public final class SCMContainerPlacementRackScatter
         usedRacksCntMap.merge(rack, 1, Math::addExact);
       }
     }
+
+    List<Node> unavailableRacks = findRacksWithOnlyExcludedNodes(excludedNodes,
+        usedRacksCntMap);
+    for (Node rack : unavailableRacks) {
+      racks.remove(rack);
+    }
+
     int requiredReplicationFactor = usedNodes.size() + nodesRequired;
-    int numberOfRacksRequired = getRequiredRackCount(requiredReplicationFactor);
+    int numberOfRacksRequired = getRequiredRackCount(requiredReplicationFactor,
+        unavailableRacks.size());
     int additionalRacksRequired =
         Math.min(nodesRequired, numberOfRacksRequired - usedRacksCntMap.size());
     LOG.debug("Additional nodes required: {}. Additional racks required: {}.",
@@ -364,6 +372,57 @@ public final class SCMContainerPlacementRackScatter
     return result;
   }
 
+  /**
+   * Given a list of excluded nodes, check if the rack for each excluded node is
+   * empty after removing the excluded nodes. If it is empty, then the rack
+   * contains only excluded nodes, and we return a list of these racks.
+   * @param excludedNodes List of excluded nodes
+   * @param usedRacksCntMap Map of used racks and their used node count
+   * @return List of racks that contain only excluded nodes or an empty list
+   */
+  private List<Node> findRacksWithOnlyExcludedNodes(
+      List<DatanodeDetails> excludedNodes, Map<Node, Integer> usedRacksCntMap) {
+    if (excludedNodes == null || excludedNodes.isEmpty()) {
+      return Collections.emptyList();
+    }
+
+    List<Node> unavailableRacks = new ArrayList<>();
+    Set<Node> excludedNodeRacks = new HashSet<>();
+    for (Node node : excludedNodes) {
+      Node rack = networkTopology.getAncestor(node, RACK_LEVEL);
+      if (rack != null && !usedRacksCntMap.containsKey(rack)) {
+        // Rack for an excluded node and no used nodes on this rack.
+        excludedNodeRacks.add(rack);
+      }
+    }
+    Set<Node> exc = new HashSet<>(excludedNodes);
+    for (Node rack : excludedNodeRacks) {
+      // Dead nodes are removed from the topology, so the node may have a null
+      // rack, or the topology may not know about it, depending on the timing
+      // of when it got removed / excluded.
+      if (rack == null) {
+        continue;
+      }
+      // If a node is removed from the cluster (eg goes dead), but the client
+      // already added it to the exclude list, then the rack may not be in the
+      // topology any longer. See test
+      // testExcludedNodesOverlapsOutOfServiceNodes
+      String rackPath = rack.getNetworkFullPath();
+      if (networkTopology.getNode(rackPath) == null) {
+        continue;
+      }
+
+      Node node = networkTopology.chooseRandom(rack.getNetworkFullPath(), exc);
+      if (node == null) {
+        // This implies we have a rack with all nodes excluded, so it is as if
+        // that rack does not exist. We also know there are no used nodes on
+        // this rack, so it means we need to reduce the rack count by 1
+        unavailableRacks.add(rack);
+      }
+    }
+    return unavailableRacks;
+  }
+
   @Override
   public DatanodeDetails chooseNode(List<DatanodeDetails> healthyNodes) {
     return null;
@@ -430,15 +489,19 @@ public final class SCMContainerPlacementRackScatter
    * For EC placement policy, desired rack count would be equal to the num of
    * Replicas.
    * @param numReplicas - num of Replicas.
+   * @param excludedRackCount - The number of racks excluded due to containing
+   *                          only excluded nodes. The total racks on the
+   *                          cluster will be reduced by this number.
    * @return required rack count.
    */
   @Override
-  protected int getRequiredRackCount(int numReplicas) {
+  protected int getRequiredRackCount(int numReplicas, int excludedRackCount) {
     if (networkTopology == null) {
       return 1;
     }
     int maxLevel = networkTopology.getMaxLevel();
-    int numRacks = networkTopology.getNumOfNodes(maxLevel - 1);
+    int numRacks = networkTopology.getNumOfNodes(maxLevel - 1)
+        - excludedRackCount;
     // Return the num of Rack if numRack less than numReplicas
     return Math.min(numRacks, numReplicas);
   }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/PipelinePlacementPolicy.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/PipelinePlacementPolicy.java
@@ -573,7 +573,7 @@ public final class PipelinePlacementPolicy extends SCMCommonPlacementPolicy {
   }
 
   @Override
-  protected int getRequiredRackCount(int numReplicas) {
+  protected int getRequiredRackCount(int numReplicas, int excludedRackCount) {
     return REQUIRED_RACKS;
   }
 

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/TestSCMCommonPlacementPolicy.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/TestSCMCommonPlacementPolicy.java
@@ -506,7 +506,7 @@ public class TestSCMCommonPlacementPolicy {
     }
 
     @Override
-    protected int getRequiredRackCount(int numReplicas) {
+    protected int getRequiredRackCount(int numReplicas, int excludedRackCount) {
       return Math.min(numReplicas, rackCnt);
     }
   }

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/placement/algorithms/TestSCMContainerPlacementRackScatter.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/placement/algorithms/TestSCMContainerPlacementRackScatter.java
@@ -403,33 +403,11 @@ public class TestSCMContainerPlacementRackScatter {
     excludedNodes.clear();
     excludedNodes.add(datanodes.get(0));
     excludedNodes.add(datanodes.get(5));
-    if (datanodeCount == 6) {
-      /*
-      * when datanodeCount is 6, the clusterMap will be
-      * /rack0/node0
-      * /rack0/node1
-      * /rack0/node2
-      * /rack0/node3
-      * /rack0/node4
-      * /rack1/node5
-      * if we select node0 and node5 as the excluded datanode,
-      * only datanode in rack0 will be chosen when calling
-      * `policy.chooseDatanodes` and the placement will not be
-      *  met since there are two racks exist, but only one
-      * of them is chosen
-      * */
-      SCMException e = assertThrows(SCMException.class,
-          () -> policy.chooseDatanodes(excludedNodes, null, 3, 0, 15));
-      String message = e.getMessage();
-      assertTrue(message.contains("Chosen nodes size: 2, but required nodes " +
-          "to choose: 3 do not match."));
-    } else {
-      datanodeDetails = policy.chooseDatanodes(
-          excludedNodes, null, nodeNum, 0, 15);
-      Assertions.assertEquals(nodeNum, datanodeDetails.size());
-      Assertions.assertEquals(getRackSize(datanodeDetails, excludedNodes),
-          Math.min(totalNum, rackNum));
-    }
+    datanodeDetails = policy.chooseDatanodes(
+        excludedNodes, null, nodeNum, 0, 15);
+    Assertions.assertEquals(nodeNum, datanodeDetails.size());
+    Assertions.assertEquals(getRackSize(datanodeDetails, excludedNodes),
+        Math.min(totalNum, rackNum));
   }
 
   @ParameterizedTest
@@ -803,6 +781,56 @@ public class TestSCMContainerPlacementRackScatter {
         excludedNodes, null, nodeNum, 0, 5);
     Assertions.assertEquals(nodeNum, datanodeDetails.size());
   }
+
+  @Test
+  public void testAllNodesOnRackExcludedReducesRackCount()
+      throws SCMException {
+    setup(10, 2);
+    // Here we have the following nodes / racks. Note that rack 4 is all
+    // excluded, so this test ensures we still get a node returned on the
+    // reduced set of racks.
+    // /rack0/node0 - used
+    // /rack0/node1 - free
+    // /rack1/node2 - used
+    // /rack1/node3 - free
+    // /rack2/node4 - used
+    // /rack2/node5 - free
+    // /rack3/node6 - used
+    // /rack3/node7 - free
+    // /rack4/node8 - excluded
+    // /rack4/node9 - excluded
+
+    List<DatanodeDetails> usedDns =
+        getDatanodes(Lists.newArrayList(0, 2, 4, 6));
+    List<DatanodeDetails> excludedDns = getDatanodes(Lists.newArrayList(8, 9));
+
+    List<DatanodeDetails> chosenNodes =
+        policy.chooseDatanodes(usedDns, excludedDns,
+            null, 1, 0, 5);
+    Assertions.assertEquals(1, chosenNodes.size());
+  }
+
+  @Test
+  public void testAllNodesOnRackExcludedReducesRackCount2()
+      throws SCMException {
+    setup(5, 2);
+    // Here we have a setup like this, which is like a Ratis container with a
+    // decommissioning node on rack 2. This makes rack 2 excluded, so we should
+    // get a node returned on rack 0 or 1 instead.
+    // /rack0/node0 - used
+    // /rack0/node1 - free
+    // /rack1/node2 - used
+    // /rack1/node3 - free
+    // /rack2/node4 - excluded (eg decommissioning)
+    List<DatanodeDetails> usedDns = getDatanodes(Lists.newArrayList(0, 2));
+    List<DatanodeDetails> excludedDns = getDatanodes(Lists.newArrayList(4));
+
+    List<DatanodeDetails> chosenNodes =
+        policy.chooseDatanodes(usedDns, excludedDns,
+            null, 1, 0, 5);
+    Assertions.assertEquals(1, chosenNodes.size());
+  }
+
 
   private int getRackSize(List<DatanodeDetails>... datanodeDetails) {
     Set<Node> racks = new HashSet<>();


### PR DESCRIPTION
## What changes were proposed in this pull request?

The situation is well documented under the heading 'Situation 4' in https://docs.google.com/document/d/1ebuSwJZkw4wMWWCHinDvRCfNbeFD4kcHMyIN6Q6wD9g/edit?usp=sharing. This happens because of limitations in rack scatter policy + replication manager flow. 

An example (summary) of this situation:
Suppose there are 5 racks and 6 DNs, such that any one rack will have 2 DNs. 5 replicas of an EC container are scattered across each of the 5 racks (so that there's only 1 replica on each rack). Now, if any of the Datanodes from any rack where there's only 1 DN on that rack is decommissioned, under replication handling will be blocked.

In this PR, if a rack has only excluded nodes, we reduce the cluster rack count by 1 for each rack in this case. So if we have a 5 rack clusters, and have replicas like:

```
/rack1/dn1 - replica
/rack1/dn2 - free
/rack2/dn3 - replica
/rack2/dn4 - free
/rack3/dn5 - replica
/rack3/dn6 - free
/rack4/dn7 - replica
/rack4/dn8 - free
/rack5/dn9 - replica decommissioning.
```

When this is passed to the placement policy, DNs 1, 3, 5 and 7 will be listed as used. 9 will be excluded. Before this PR, the placement policy will fail to find a new node, as it needs to place them over 5 racks and it cannot. After this PR, the new logic will reduce the required racks by 1, and the new replica will be placed on one of the other free nodes.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-9125

## How was this patch tested?

Unit tests added to reproduce the issue and test the change.