### PR TITLE
HDDS-9212. HeatMap UI doesn't load On Disabling & Enable Recon HeatMap using Feature Flag.

### DIFF
--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/api/AccessHeatMapEndpoint.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/api/AccessHeatMapEndpoint.java
@@ -98,7 +98,7 @@ public class AccessHeatMapEndpoint {
     List<FeatureProvider.Feature> allDisabledFeatures =
         FeatureProvider.getAllDisabledFeatures();
     for (FeatureProvider.Feature feature : allDisabledFeatures) {
-      if (feature.getFeatureName().equals("HeatMap")) {
+      if ("HeatMap".equals(feature.getFeatureName())) {
         heatMapFeature = feature;
         break;
       }

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/api/AccessHeatMapEndpoint.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/api/AccessHeatMapEndpoint.java
@@ -19,6 +19,7 @@
 package org.apache.hadoop.ozone.recon.api;
 
 import org.apache.hadoop.ozone.recon.api.types.EntityReadAccessHeatMapResponse;
+import org.apache.hadoop.ozone.recon.api.types.FeatureProvider;
 import org.apache.hadoop.ozone.recon.heatmap.HeatMapServiceImpl;
 
 import javax.inject.Inject;
@@ -30,6 +31,8 @@ import javax.ws.rs.QueryParam;
 import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
+
+import java.util.List;
 
 import static org.apache.hadoop.ozone.recon.ReconConstants.RECON_ACCESS_METADATA_START_DATE;
 import static org.apache.hadoop.ozone.recon.ReconConstants.RECON_ENTITY_PATH;
@@ -78,6 +81,7 @@ public class AccessHeatMapEndpoint {
       @DefaultValue("key") @QueryParam(RECON_ENTITY_TYPE) String entityType,
       @DefaultValue("24H") @QueryParam(RECON_ACCESS_METADATA_START_DATE)
       String startDate) {
+    checkIfHeatMapFeatureIsEnabled();
     EntityReadAccessHeatMapResponse entityReadAccessHeatMapResponse = null;
     try {
       entityReadAccessHeatMapResponse =
@@ -87,5 +91,20 @@ public class AccessHeatMapEndpoint {
           Response.Status.INTERNAL_SERVER_ERROR);
     }
     return Response.ok(entityReadAccessHeatMapResponse).build();
+  }
+
+  private static void checkIfHeatMapFeatureIsEnabled() {
+    FeatureProvider.Feature heatMapFeature = null;
+    List<FeatureProvider.Feature> allDisabledFeatures =
+        FeatureProvider.getAllDisabledFeatures();
+    for (FeatureProvider.Feature feature : allDisabledFeatures) {
+      if (feature.getFeatureName().equals("HeatMap")) {
+        heatMapFeature = feature;
+        break;
+      }
+    }
+    if (null != heatMapFeature) {
+      throw new WebApplicationException(Response.Status.NOT_FOUND);
+    }
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR is to avoid calling heatmap API if client explicitly calls HeatMap UI page or API through postman.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-9212

## How was this patch tested?

This patch was tested using PostMan calling heatmap after disabling heatmap feature flag `ozone.recon.heatmap.enable`
