### PR TITLE
HDDS-9136. Throw exception when rename fails during moveToTrash.

### DIFF
--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/TrashPolicyOzone.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/TrashPolicyOzone.java
@@ -207,7 +207,7 @@ public class TrashPolicyOzone extends TrashPolicyDefault {
           // move to current trash
           boolean renamed = fs.rename(path, trashPath);
           if (!renamed) {
-            LOG.error("Failed to move to trash: {}",  trashPath);
+            LOG.error("Failed to move to trash: {}", path);
             throw new IOException("Failed to move to trash: " + path);
           }
           LOG.info("Moved: '" + path + "' to trash at: " + trashPath);

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/TrashPolicyOzone.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/TrashPolicyOzone.java
@@ -205,7 +205,11 @@ public class TrashPolicyOzone extends TrashPolicyDefault {
           }
 
           // move to current trash
-          fs.rename(path, trashPath);
+          boolean renamed = fs.rename(path, trashPath);
+          if (!renamed) {
+            LOG.error("Failed to move to trash: {}",  trashPath);
+            throw new IOException("Failed to move to trash: " + path);
+          }
           LOG.info("Moved: '" + path + "' to trash at: " + trashPath);
           return true;
         } catch (IOException e) {

--- a/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicOzoneFileSystem.java
+++ b/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicOzoneFileSystem.java
@@ -350,7 +350,19 @@ public class BasicOzoneFileSystem extends FileSystem {
       // TODO RenameKey needs to be changed to batch operation
       for (String key : keyList) {
         String newKeyName = dstKey.concat(key.substring(srcKey.length()));
-        adapter.renameKey(key, newKeyName);
+        try {
+          adapter.renameKey(key, newKeyName);
+        } catch (OMException ome) {
+          LOG.error("rename key failed: {}. source:{}, destin:{}",
+              ome.getMessage(), key, newKeyName);
+          if (OMException.ResultCodes.KEY_ALREADY_EXISTS == ome.getResult() ||
+              OMException.ResultCodes.KEY_RENAME_ERROR  == ome.getResult() ||
+              OMException.ResultCodes.KEY_NOT_FOUND == ome.getResult()) {
+            return false;
+          } else {
+            throw ome;
+          }
+        }
       }
       return true;
     }

--- a/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicOzoneFileSystem.java
+++ b/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicOzoneFileSystem.java
@@ -353,8 +353,8 @@ public class BasicOzoneFileSystem extends FileSystem {
         try {
           adapter.renameKey(key, newKeyName);
         } catch (OMException ome) {
-          LOG.error("rename key failed: {}. source:{}, destin:{}",
-              ome.getMessage(), key, newKeyName);
+          LOG.error("Key rename failed for source key: {} to " +
+              "destination key: {}.", key, newKeyName, ome);
           if (OMException.ResultCodes.KEY_ALREADY_EXISTS == ome.getResult() ||
               OMException.ResultCodes.KEY_RENAME_ERROR  == ome.getResult() ||
               OMException.ResultCodes.KEY_NOT_FOUND == ome.getResult()) {

--- a/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicRootedOzoneFileSystem.java
+++ b/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicRootedOzoneFileSystem.java
@@ -338,7 +338,19 @@ public class BasicRootedOzoneFileSystem extends FileSystem {
     boolean processKeyPath(List<String> keyPathList) throws IOException {
       for (String keyPath : keyPathList) {
         String newPath = dstPath.concat(keyPath.substring(srcPath.length()));
-        adapterImpl.rename(this.bucket, keyPath, newPath);
+        try {
+          adapterImpl.rename(this.bucket, keyPath, newPath);
+        } catch (OMException ome) {
+          LOG.error("rename key failed: {}. source:{}, destin:{}",
+              ome.getMessage(), keyPath, newPath);
+          if (OMException.ResultCodes.KEY_ALREADY_EXISTS == ome.getResult() ||
+              OMException.ResultCodes.KEY_RENAME_ERROR  == ome.getResult() ||
+              OMException.ResultCodes.KEY_NOT_FOUND == ome.getResult()) {
+            return false;
+          } else {
+            throw ome;
+          }
+        }
       }
       return true;
     }

--- a/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicRootedOzoneFileSystem.java
+++ b/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicRootedOzoneFileSystem.java
@@ -341,8 +341,8 @@ public class BasicRootedOzoneFileSystem extends FileSystem {
         try {
           adapterImpl.rename(this.bucket, keyPath, newPath);
         } catch (OMException ome) {
-          LOG.error("rename key failed: {}. source:{}, destin:{}",
-              ome.getMessage(), keyPath, newPath);
+          LOG.error("Key rename failed for source key: {} to " +
+              "destination key: {}.", keyPath, newPath, ome);
           if (OMException.ResultCodes.KEY_ALREADY_EXISTS == ome.getResult() ||
               OMException.ResultCodes.KEY_RENAME_ERROR  == ome.getResult() ||
               OMException.ResultCodes.KEY_NOT_FOUND == ome.getResult()) {


### PR DESCRIPTION
## What changes were proposed in this pull request?

moveToTrash is not checking for return value of rename API. When rename fails due to various reasons, still moveToTrash assume it as success. This leads to inconsistent behaviour, one which is mentioned in Jira description(HDDS-9136).
In this PR, If there is failure in rename operation, we are throwing exception to know moveToTrash has failed. 

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-9136

## How was this patch tested?

Manually tested.