### PR TITLE
HDDS-8536. ReplicationManager: Unhealthy replicas could block Ratis containers being replicated

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/RatisUnderReplicationHandler.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/RatisUnderReplicationHandler.java
@@ -154,7 +154,14 @@ public class RatisUnderReplicationHandler
       Set<ContainerReplica> replicas, List<ContainerReplicaOp> pendingOps)
       throws NotLeaderException {
     ContainerReplica deleteCandidate = ReplicationManagerUtil
-        .selectUnhealthyReplicaForDelete(containerInfo, replicas, pendingOps);
+        .selectUnhealthyReplicaForDelete(containerInfo, replicas, pendingOps,
+            (dnd) -> {
+              try {
+                return replicationManager.getNodeStatus(dnd);
+              } catch (NodeNotFoundException e) {
+                return null;
+              }
+            });
 
     if (deleteCandidate != null) {
       replicationManager.sendDeleteCommand(containerInfo,

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestRatisUnderReplicationHandler.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestRatisUnderReplicationHandler.java
@@ -357,14 +357,12 @@ public class TestRatisUnderReplicationHandler {
 
     // This quasi closed is newer than the other one below, so it should not
     // be removed.
-    replicas.add(createContainerReplica(container.containerID(), 0,
-        IN_SERVICE, State.QUASI_CLOSED, sequenceID - 1));
-    // Unhealthy should not be removed when there are quasi closed replicas
     replicas.add(createContainerReplica(
-        container.containerID(), 0, IN_SERVICE, State.UNHEALTHY));
-    ContainerReplica shouldDelete = createContainerReplica(
         container.containerID(), 0, IN_SERVICE, State.QUASI_CLOSED,
-        sequenceID - 2);
+        sequenceID - 2));
+    // Unhealthy should be removed over the quasi-closed ones.
+    ContainerReplica shouldDelete = createContainerReplica(
+        container.containerID(), 0, IN_SERVICE, State.UNHEALTHY);
     replicas.add(shouldDelete);
 
     Assert.assertThrows(IOException.class,

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestRatisUnderReplicationHandler.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestRatisUnderReplicationHandler.java
@@ -25,6 +25,7 @@ import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
 import org.apache.hadoop.hdds.protocol.MockDatanodeDetails;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
+import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.ContainerReplicaProto.State;
 import org.apache.hadoop.hdds.scm.PlacementPolicy;
 import org.apache.hadoop.hdds.scm.container.ContainerInfo;
@@ -57,6 +58,7 @@ import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.NodeOperationalSt
 import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.NodeOperationalState.ENTERING_MAINTENANCE;
 import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.NodeOperationalState.IN_MAINTENANCE;
 import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.NodeOperationalState.IN_SERVICE;
+import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationFactor.THREE;
 import static org.apache.hadoop.hdds.scm.container.replication.ReplicationTestUtil.createContainerInfo;
 import static org.apache.hadoop.hdds.scm.container.replication.ReplicationTestUtil.createContainerReplica;
 import static org.apache.hadoop.hdds.scm.container.replication.ReplicationTestUtil.createReplicas;
@@ -73,7 +75,7 @@ public class TestRatisUnderReplicationHandler {
   private NodeManager nodeManager;
   private OzoneConfiguration conf;
   private static final RatisReplicationConfig RATIS_REPLICATION_CONFIG =
-      RatisReplicationConfig.getInstance(HddsProtos.ReplicationFactor.THREE);
+      RatisReplicationConfig.getInstance(THREE);
   private PlacementPolicy policy;
   private ReplicationManager replicationManager;
   private Set<Pair<DatanodeDetails, SCMCommand<?>>> commandsSent;
@@ -114,6 +116,8 @@ public class TestRatisUnderReplicationHandler {
     ReplicationTestUtil.mockRMSendThrottleReplicateCommand(
         replicationManager, commandsSent, new AtomicBoolean(false));
     ReplicationTestUtil.mockRMSendDatanodeCommand(replicationManager,
+        commandsSent);
+    ReplicationTestUtil.mockRMSendDeleteCommand(replicationManager,
         commandsSent);
   }
 
@@ -224,6 +228,7 @@ public class TestRatisUnderReplicationHandler {
     Assert.assertThrows(IOException.class,
         () -> handler.processAndSendCommands(replicas,
             Collections.emptyList(), getUnderReplicatedHealthResult(), 2));
+    Assert.assertEquals(0, commandsSent.size());
     Assert.assertEquals(0, metrics.getPartialReplicationTotal());
   }
 
@@ -245,6 +250,131 @@ public class TestRatisUnderReplicationHandler {
     // fine one node rather than two.
     Assert.assertEquals(1, commandsSent.size());
     Assert.assertEquals(1, metrics.getPartialReplicationTotal());
+  }
+
+  @Test
+  public void testNoTargetsFoundBecauseOfPlacementPolicyRemoveNone() {
+    policy = ReplicationTestUtil.getNoNodesTestPlacementPolicy(nodeManager,
+        conf);
+    RatisUnderReplicationHandler handler =
+        new RatisUnderReplicationHandler(policy, conf, replicationManager);
+
+    Set<ContainerReplica> replicas
+        = createReplicas(container.containerID(), State.CLOSED, 0);
+
+    ContainerReplica shouldDelete = createContainerReplica(
+        container.containerID(), 0, IN_SERVICE, State.UNHEALTHY);
+    replicas.add(shouldDelete);
+
+    Assert.assertThrows(IOException.class,
+        () -> handler.processAndSendCommands(replicas,
+            Collections.emptyList(), getUnderReplicatedHealthResult(), 2));
+    // No commands send, as there are only 2 replicas available.
+    Assert.assertEquals(0, commandsSent.size());
+  }
+
+  @Test
+  public void testNoTargetsFoundBecauseOfPlacementPolicyNoneHealthy() {
+    policy = ReplicationTestUtil.getNoNodesTestPlacementPolicy(nodeManager,
+        conf);
+    RatisUnderReplicationHandler handler =
+        new RatisUnderReplicationHandler(policy, conf, replicationManager);
+
+    // All replicas UNHEALTHY so we do nothing.
+    Set<ContainerReplica> replicas
+        = createReplicas(container.containerID(), State.UNHEALTHY, 0, 0);
+
+    Assert.assertThrows(IOException.class,
+        () -> handler.processAndSendCommands(replicas,
+            Collections.emptyList(), getUnderReplicatedHealthResult(), 2));
+    // No commands send, as no CLOSED replicas available.
+    Assert.assertEquals(0, commandsSent.size());
+  }
+
+  @Test
+  public void testNoTargetsFoundBecauseOfPlacementPolicyRemoveUnhealthy() {
+    policy = ReplicationTestUtil.getNoNodesTestPlacementPolicy(nodeManager,
+        conf);
+    RatisUnderReplicationHandler handler =
+        new RatisUnderReplicationHandler(policy, conf, replicationManager);
+
+    Set<ContainerReplica> replicas
+        = createReplicas(container.containerID(), State.CLOSED, 0, 0);
+
+    ContainerReplica shouldDelete = createContainerReplica(
+        container.containerID(), 0, IN_SERVICE, State.UNHEALTHY);
+    replicas.add(shouldDelete);
+
+    Assert.assertThrows(IOException.class,
+        () -> handler.processAndSendCommands(replicas,
+            Collections.emptyList(), getUnderReplicatedHealthResult(), 2));
+    Assert.assertEquals(1, commandsSent.size());
+    Pair<DatanodeDetails, SCMCommand<?>> cmd = commandsSent.iterator().next();
+    Assert.assertEquals(shouldDelete.getDatanodeDetails(), cmd.getKey());
+    Assert.assertEquals(StorageContainerDatanodeProtocolProtos.SCMCommandProto
+        .Type.deleteContainerCommand, cmd.getValue().getType());
+  }
+
+  @Test
+  public void testNoTargetsFoundBecauseOfPlacementPolicyPendingDelete() {
+    policy = ReplicationTestUtil.getNoNodesTestPlacementPolicy(nodeManager,
+        conf);
+    RatisUnderReplicationHandler handler =
+        new RatisUnderReplicationHandler(policy, conf, replicationManager);
+
+    Set<ContainerReplica> replicas
+        = createReplicas(container.containerID(), State.CLOSED, 0, 0);
+
+    ContainerReplica shouldDelete = createContainerReplica(
+        container.containerID(), 0, IN_SERVICE, State.UNHEALTHY);
+    replicas.add(shouldDelete);
+
+    List<ContainerReplicaOp> pending = Collections.singletonList(
+        ContainerReplicaOp.create(ContainerReplicaOp.PendingOpType.DELETE,
+        shouldDelete.getDatanodeDetails(), 0));
+
+    Assert.assertThrows(IOException.class,
+        () -> handler.processAndSendCommands(replicas,
+            pending, getUnderReplicatedHealthResult(), 2));
+    // No commands sent as we have a pending delete.
+    Assert.assertEquals(0, commandsSent.size());
+  }
+
+  @Test
+  public void testNoTargetsFoundRemoveQuasiClosedWithLowestSeq() {
+    policy = ReplicationTestUtil.getNoNodesTestPlacementPolicy(nodeManager,
+        conf);
+    RatisUnderReplicationHandler handler =
+        new RatisUnderReplicationHandler(policy, conf, replicationManager);
+
+    long sequenceID = 10;
+    container = ReplicationTestUtil.createContainerInfo(
+        RatisReplicationConfig.getInstance(THREE),
+        1, HddsProtos.LifeCycleState.CLOSED, sequenceID);
+
+    Set<ContainerReplica> replicas
+        = createReplicas(container.containerID(), State.CLOSED, 0, 0);
+
+    // This quasi closed is newer than the other one below, so it should not
+    // be removed.
+    replicas.add(createContainerReplica(container.containerID(), 0,
+        IN_SERVICE, State.QUASI_CLOSED, sequenceID - 1));
+    // Unhealthy should not be removed when there are quasi closed replicas
+    replicas.add(createContainerReplica(
+        container.containerID(), 0, IN_SERVICE, State.UNHEALTHY));
+    ContainerReplica shouldDelete = createContainerReplica(
+        container.containerID(), 0, IN_SERVICE, State.QUASI_CLOSED,
+        sequenceID - 2);
+    replicas.add(shouldDelete);
+
+    Assert.assertThrows(IOException.class,
+        () -> handler.processAndSendCommands(replicas,
+            Collections.emptyList(), getUnderReplicatedHealthResult(), 2));
+    Assert.assertEquals(1, commandsSent.size());
+    Pair<DatanodeDetails, SCMCommand<?>> cmd = commandsSent.iterator().next();
+    Assert.assertEquals(shouldDelete.getDatanodeDetails(), cmd.getKey());
+    Assert.assertEquals(StorageContainerDatanodeProtocolProtos.SCMCommandProto
+        .Type.deleteContainerCommand, cmd.getValue().getType());
   }
 
   @Test


### PR DESCRIPTION
## What changes were proposed in this pull request?


This PR changes the flow so that if RM cannot find a spare node to replicate to, it will check look for quasi_closed or unhealthy replicas.

Provided there are at least 3 replicas available AND there are no pending deletes on the container AND there is at least one CLOSED replica it will:

1. Try to delete a single quasi_closed replica. If there is more than 1, it will delete the one with the lowest seqID.
2. If there are no quasi-closed, it will delete an unhealthy one
3. If there are no unhealthy or quasi-closed, it will do nothing (same functionality as before).

The container will then be requeued to be processed again later when the delete has hopefully completed OK.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-8536

## How was this patch tested?

New unit tests added to test the new flow and all scenarios.
