### PR TITLE
HDDS-9237. Enable lock order fairness for striped locks.

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/utils/SimpleStriped.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/utils/SimpleStriped.java
@@ -1,0 +1,81 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.apache.hadoop.hdds.utils;
+
+import com.google.common.base.Supplier;
+import com.google.common.util.concurrent.Striped;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.concurrent.locks.ReadWriteLock;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
+
+/**
+ * A custom factory to force creation of {@link Striped}
+ * locks with fair order policy.
+ *
+ * The reason of this util is that today guava's {@link Striped} does not
+ * support creating locks with fair policy, either supports a mechanism for
+ * the client code to do that ({@link Striped#custom(int, Supplier)} is package
+ * private). Ref: https://github.com/google/guava/issues/2514
+ *
+ * So, we have to use reflection to forcibly support fair order policy with
+ * {@link Striped}. When the above issue is resolved, we can remove this util.
+ */
+public final class SimpleStriped<L> {
+
+  private SimpleStriped() {
+  }
+
+
+  /**
+   * Creates a {@code Striped<L>} with eagerly initialized, strongly referenced
+   * locks. Every lock is obtained from the passed supplier.
+   *
+   * @param stripes the minimum number of stripes (locks) required.
+   * @param supplier a {@code Supplier<L>} object to obtain locks from.
+   * @return a new {@code Striped<L>}.
+   */
+  @SuppressWarnings("unchecked")
+  public static <L> Striped<L> custom(int stripes, Supplier<L> supplier) {
+    try {
+      Method custom =
+          Striped.class.getDeclaredMethod("custom", int.class, Supplier.class);
+      custom.setAccessible(true);
+      return (Striped<L>) custom.invoke(null, stripes, supplier);
+    } catch (NoSuchMethodException | IllegalAccessException |
+             InvocationTargetException e) {
+      throw new IllegalStateException("Error creating custom Striped.", e);
+    }
+  }
+
+  /**
+   * Creates a {@code Striped<ReadWriteLock>} with eagerly initialized,
+   * strongly referenced read-write locks. Every lock is reentrant.
+   *
+   * @param stripes the minimum number of stripes (locks) required
+   * @return a new {@code Striped<ReadWriteLock>}
+   */
+  public static Striped<ReadWriteLock> readWriteLock(int stripes,
+      boolean fair) {
+    return custom(stripes, () -> new ReentrantReadWriteLock(fair));
+  }
+
+}

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/utils/SimpleStriped.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/utils/SimpleStriped.java
@@ -39,7 +39,7 @@ import java.util.concurrent.locks.ReentrantReadWriteLock;
  * So, we have to use reflection to forcibly support fair order policy with
  * {@link Striped}. When the above issue is resolved, we can remove this util.
  */
-public final class SimpleStriped<L> {
+public final class SimpleStriped {
 
   private SimpleStriped() {
   }

--- a/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/utils/SimpleStripedTest.java
+++ b/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/utils/SimpleStripedTest.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+package org.apache.hadoop.hdds.utils;
+
+import com.google.common.util.concurrent.Striped;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReadWriteLock;
+import java.util.concurrent.locks.ReentrantLock;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
+/**
+ * Test cases for {@link SimpleStriped}.
+ */
+public class SimpleStripedTest {
+  @Test
+  void testReadWriteLocks() {
+    testReadWriteLocks(true);
+    testReadWriteLocks(false);
+  }
+
+  private void testReadWriteLocks(boolean fair) {
+    Striped<ReadWriteLock> striped = SimpleStriped.readWriteLock(128,
+        fair);
+    assertEquals(128, striped.size());
+    ReadWriteLock lock = striped.get("key1");
+    assertEquals(fair, ((ReentrantReadWriteLock) lock).isFair());
+
+    // Ensure same key return same lock.
+    assertEquals(lock, striped.get("key1"));
+
+    // And different key (probably) return a different lock/
+    assertNotEquals(lock, striped.get("key2"));
+  }
+
+  @Test
+  void testCustomStripes() {
+    int size = 128;
+    Striped<Lock> striped = SimpleStriped.custom(size,
+        ReentrantLock::new);
+    assertEquals(128, striped.size());
+    Lock lock = striped.get("key1");
+    // Ensure same key return same lock.
+    assertEquals(lock, striped.get("key1"));
+    // And different key (probably) return a different lock/
+    assertNotEquals(lock, striped.get("key2"));
+  }
+}

--- a/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/utils/TestSimpleStriped.java
+++ b/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/utils/TestSimpleStriped.java
@@ -32,7 +32,7 @@ import static org.junit.jupiter.api.Assertions.assertNotEquals;
 /**
  * Test cases for {@link SimpleStriped}.
  */
-public class SimpleStripedTest {
+public class TestSimpleStriped {
   @Test
   void testReadWriteLocks() {
     testReadWriteLocks(true);


### PR DESCRIPTION
## What changes were proposed in this pull request?

[HDDS-8765](https://issues.apache.org/jira/browse/HDDS-8765) uses Guava's [Striped](https://guava.dev/releases/19.0/api/docs/com/google/common/util/concurrent/Striped.html) to implement striped locks in OM. For now, Striped doesn't allow creating striped locks with a custom fairness order. Details are in #4885.

There's a [open issue](https://github.com/google/guava/issues/2514) and a [PR](https://github.com/google/guava/pull/2515) in Guava to address that, but looks like they're not reviewed by Guava devs for a long time.

This PR implements a factory of `com.google.common.util.concurrent.Striped` which uses reflection to create Striped locks with fair order policy.



## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-9237

## How was this patch tested?

Unit-tested. 