### PR TITLE
HDDS-9251. EC-recovery acceptance test is failling randomly

### DIFF
--- a/hadoop-ozone/dist/src/main/compose/ozone/docker-config
+++ b/hadoop-ozone/dist/src/main/compose/ozone/docker-config
@@ -46,6 +46,10 @@ OZONE-SITE.XML_ozone.scm.stale.node.interval=30s
 OZONE-SITE.XML_ozone.scm.dead.node.interval=45s
 OZONE-SITE.XML_hdds.heartbeat.interval=5s
 OZONE-SITE.XML_ozone.scm.close.container.wait.duration=5s
+OZONE-SITE.XML_hdds.scm.replication.thread.interval=15s
+OZONE-SITE.XML_hdds.scm.replication.under.replicated.interval=5s
+OZONE-SITE.XML_hdds.scm.replication.over.replicated.interval=5s
+OZONE-SITE.XML_hdds.scm.wait.time.after.safemode.exit=30s
 
 OZONE-SITE.XML_dfs.container.ratis.datastream.enabled=true
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Test case of EC offline reconstruction is intermittently timing out.  To fix that, this PR reduces the delay of Replication Manager's start after safe mode exit, and increases the frequency of replication tasks.

https://issues.apache.org/jira/browse/HDDS-9251

## How was this patch tested?

Ran EC acceptance test locally.

CI:
https://github.com/adoroszlai/hadoop-ozone/actions/runs/6120159439/job/16612475120