### PR TITLE
HDDS-9199. Snapshot chain corruption should not fail OM restart

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerHASnapshot.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerHASnapshot.java
@@ -50,6 +50,7 @@ import static org.apache.hadoop.ozone.snapshot.SnapshotDiffResponse.JobStatus.DO
 import static org.apache.hadoop.ozone.snapshot.SnapshotDiffResponse.JobStatus.IN_PROGRESS;
 import static org.awaitility.Awaitility.await;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -256,6 +257,10 @@ public class TestOzoneManagerHASnapshot {
     await().atMost(Duration.ofSeconds(180))
         .until(() -> cluster.getOMLeader() != null);
     assertNotNull(cluster.getOMLeader());
+    OmMetadataManagerImpl metadataManager = (OmMetadataManagerImpl) cluster
+        .getOMLeader().getMetadataManager();
+    assertFalse(metadataManager.getSnapshotChainManager()
+        .isSnapshotChainCorrupted());
   }
 
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/snapshot/OMSnapshotCreateRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/snapshot/OMSnapshotCreateRequest.java
@@ -298,7 +298,7 @@ public class OMSnapshotCreateRequest extends OMClientRequest {
   ) {
     try {
       snapshotChainManager.deleteSnapshot(info);
-    } catch (IOException exception) {
+    } catch (IllegalStateException exception) {
       LOG.error("Failed to remove snapshot: {} from SnapshotChainManager.",
           info, exception);
     }

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestSnapshotChain.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestSnapshotChain.java
@@ -21,7 +21,7 @@ import com.google.common.collect.ImmutableMap;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.utils.db.Table;
 import org.apache.hadoop.ozone.om.helpers.SnapshotInfo;
-import org.junit.jupiter.api.Assertions;
+import org.apache.hadoop.util.Time;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Named;
 import org.junit.jupiter.api.Test;
@@ -32,7 +32,6 @@ import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.ValueSource;
 
 import java.io.File;
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -93,7 +92,7 @@ public class TestSnapshotChain {
         .build();
   }
 
-  private void deleteSnapshot(UUID snapshotID) throws IOException {
+  private void deleteSnapshot(UUID snapshotID) {
     SnapshotInfo sinfo = null;
     final String snapshotPath = "vol1/bucket1";
     // reset the next snapshotInfo.globalPreviousSnapshotID
@@ -263,22 +262,23 @@ public class TestSnapshotChain {
     // add two snapshots to the snapshotInfo
     UUID snapshotID1 = UUID.randomUUID();
     UUID snapshotID2 = UUID.randomUUID();
-
-    ArrayList<UUID> snapshotIDs = new ArrayList<>();
+    List<UUID> snapshotIDs = new ArrayList<>();
     snapshotIDs.add(snapshotID1);
     snapshotIDs.add(snapshotID2);
+    List<SnapshotInfo> snapshotInfoList = new ArrayList<>();
 
     UUID prevSnapshotID = null;
     long time = System.currentTimeMillis();
-    // add 3 snapshots
     for (UUID snapshotID : snapshotIDs) {
-      snapshotInfo.put(snapshotID.toString(),
-          createSnapshotInfo(snapshotID, prevSnapshotID, prevSnapshotID,
-          increasingTIme ? time++ : time--));
+      SnapshotInfo snapInfo = createSnapshotInfo(snapshotID, prevSnapshotID,
+          prevSnapshotID, increasingTIme ? time++ : time--);
+      snapshotInfo.put(snapshotID.toString(), snapInfo);
       prevSnapshotID = snapshotID;
+      snapshotInfoList.add(snapInfo);
     }
 
     chainManager = new SnapshotChainManager(omMetadataManager);
+    assertFalse(chainManager.isSnapshotChainCorrupted());
     // check if snapshots loaded correctly from snapshotInfoTable
     assertEquals(snapshotID2, chainManager.getLatestGlobalSnapshotId());
     assertEquals(snapshotID2, chainManager.nextGlobalSnapshot(snapshotID1));
@@ -289,6 +289,16 @@ public class TestSnapshotChain {
     assertThrows(NoSuchElementException.class,
         () -> chainManager.previousPathSnapshot(String
             .join("/", "vol1", "bucket1"), snapshotID1));
+
+    UUID snapshotID3 = UUID.randomUUID();
+    SnapshotInfo snapshotInfo3 = createSnapshotInfo(snapshotID3, prevSnapshotID,
+        prevSnapshotID, Time.now());
+    // Add and delete snapshot to make sure snapshot chain is correct.
+    chainManager.addSnapshot(snapshotInfo3);
+    chainManager.deleteSnapshot(snapshotInfoList.get(0));
+    assertEquals(snapshotID3, chainManager.getLatestGlobalSnapshotId());
+    assertThrows(NoSuchElementException.class,
+        () -> chainManager.nextGlobalSnapshot(snapshotID1));
   }
 
   private static Stream<? extends Arguments> invalidSnapshotChain() {
@@ -334,12 +344,26 @@ public class TestSnapshotChain {
           createSnapshotInfo(snapshotID, snapshotChain.get(snapshotID),
               snapshotChain.get(snapshotID), System.currentTimeMillis()));
     }
-    IllegalStateException exception = Assertions.assertThrows(
-        IllegalStateException.class,
-        () -> new SnapshotChainManager(omMetadataManager));
-    Assertions.assertTrue(exception.getMessage()
-        .startsWith("Snapshot chain corruption. All snapshots have not been " +
-            "added to the snapshot chain."));
+    chainManager = new SnapshotChainManager(omMetadataManager);
+
+    assertTrue(chainManager.isSnapshotChainCorrupted());
+
+    SnapshotInfo snapInfo = createSnapshotInfo(UUID.randomUUID(),
+        UUID.randomUUID(),
+        UUID.randomUUID(),
+        System.currentTimeMillis());
+    IllegalStateException createException =
+        assertThrows(IllegalStateException.class,
+            () -> chainManager.addSnapshot(snapInfo));
+    assertEquals("Snapshot chain is corrupted.", createException.getMessage());
+    if (!snapshotIDs.isEmpty()) {
+      IllegalStateException deleteException =
+          assertThrows(IllegalStateException.class,
+              () -> chainManager.deleteSnapshot(
+                  snapshotInfo.get(snapshotIDs.get(0).toString())));
+      assertEquals("Snapshot chain is corrupted.",
+          deleteException.getMessage());
+    }
   }
 
   @ParameterizedTest
@@ -355,10 +379,24 @@ public class TestSnapshotChain {
               prevSnapshotId, System.currentTimeMillis()));
       prevSnapshotId = snapshotID;
     }
-    IllegalStateException exception = Assertions.assertThrows(
-        IllegalStateException.class,
-        () -> new SnapshotChainManager(omMetadataManager));
-    Assertions.assertTrue(exception.getMessage()
-        .startsWith("Path Snapshot chain corruption."));
+    chainManager = new SnapshotChainManager(omMetadataManager);
+    assertTrue(chainManager.isSnapshotChainCorrupted());
+
+    SnapshotInfo snapInfo = createSnapshotInfo(UUID.randomUUID(),
+        UUID.randomUUID(),
+        UUID.randomUUID(),
+        System.currentTimeMillis());
+    IllegalStateException createException =
+        assertThrows(IllegalStateException.class,
+            () -> chainManager.addSnapshot(snapInfo));
+    assertEquals("Snapshot chain is corrupted.", createException.getMessage());
+    if (!snapshotIDs.isEmpty()) {
+      IllegalStateException deleteException =
+          assertThrows(IllegalStateException.class,
+              () -> chainManager.deleteSnapshot(
+                  snapshotInfo.get(snapshotIDs.get(0).toString())));
+      assertEquals("Snapshot chain is corrupted.",
+          deleteException.getMessage());
+    }
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?
Currently, OM restart fails and leaves the OM in unstable (which can't be stabilized without manual effort) if there is any kind of failure in snapshot chain reconstruction. Previous issues ([HDDS-7689](https://issues.apache.org/jira/browse/HDDS-7689), [HDDS-8530](https://issues.apache.org/jira/browse/HDDS-8530), [HDDS-8832](https://issues.apache.org/jira/browse/HDDS-8832) and [HDDS-9073](https://issues.apache.org/jira/browse/HDDS-9073)) where OM restart failed and left it in unstable state.

In this change, it is proposed to keep the snapshot chain state and let the OM start without any snapshot/chain related issues. Snapshot chain corrupted state is used to block all the snapshot's write operations like create, delete and purge snapshot if snapshot chain is corrupted.

A new parameter, `snapshotChainCorrupted`, is added to `SnapshotChainManager` to keep the state if chain is loaded successfully or not. It is used in access methods `addSnapshot()` to chain, `deleteSnapshot()` from chain and others before returning response to the caller. In case of chain corruption, `addSnapshot()`, `deleteSnapshot()` will throw `IllegalStateException` and fail snapshot write operations.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-9199

## How was this patch tested?
Updated unit and integration tests.
