### PR TITLE
HDDS-8453. [Snapshot] KeyDeleting service should not reclaim snapshot keys.

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestDirectoryDeletingServiceWithFSO.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestDirectoryDeletingServiceWithFSO.java
@@ -43,7 +43,6 @@ import org.apache.hadoop.ozone.om.helpers.OmDirectoryInfo;
 import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
 import org.apache.hadoop.ozone.om.helpers.RepeatedOmKeyInfo;
 import org.apache.ozone.test.GenericTestUtils;
-import org.apache.ozone.test.tag.Flaky;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
@@ -381,7 +380,6 @@ public class TestDirectoryDeletingServiceWithFSO {
   }
 
   @Test
-  @Flaky("HDDS-8453")
   public void testDirDeletedTableCleanUpForSnapshot() throws Exception {
     Table<String, OmKeyInfo> deletedDirTable =
         cluster.getOzoneManager().getMetadataManager().getDeletedDirTable();
@@ -449,6 +447,13 @@ public class TestDirectoryDeletingServiceWithFSO {
     // After delete. 5 more files left out under the root dir
     assertTableRowCount(keyTable, 5);
     assertTableRowCount(dirTable, 5);
+
+    long prevKdsRunCount = keyDeletingService.getRunCount().get();
+
+    // wait for at least 1 iteration of KeyDeletingService
+    GenericTestUtils.waitFor(
+        () -> (keyDeletingService.getRunCount().get() > prevKdsRunCount), 100,
+        10000);
 
     // KeyDeletingService and DirectoryDeletingService will not
     // clean up because the paths are part of a snapshot.

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmMetadataManagerImpl.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmMetadataManagerImpl.java
@@ -1567,7 +1567,7 @@ public class OmMetadataManagerImpl implements OMMetadataManager,
                   prevKeyTableDBKey = getOzonePathKey(volumeId,
                       bucketInfo.getObjectID(),
                       info.getParentObjectID(),
-                      info.getKeyName());
+                      info.getFileName());
                 } else if (prevKeyTableDBKey == null) {
                   prevKeyTableDBKey = getOzoneKey(info.getVolumeName(),
                       info.getBucketName(),

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/service/AbstractKeyDeletingService.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/service/AbstractKeyDeletingService.java
@@ -502,7 +502,7 @@ public abstract class AbstractKeyDeletingService extends BackgroundService
           volumeId,
           bucketInfo.getObjectID(),
           deletedKeyInfo.getParentObjectID(),
-          deletedKeyInfo.getKeyName());
+          deletedKeyInfo.getFileName());
     } else {
       dbKey = ozoneManager.getMetadataManager().getOzoneKey(
           deletedKeyInfo.getVolumeName(),


### PR DESCRIPTION
## What changes were proposed in this pull request?
KeyDeletingService currently processes deleted keys in FSO buckets that are present (held by) in snapshots which should not happen.
The fix here is to use getFileName() for FSO key instead of getKeyName(). For detailed explanation see [this](https://issues.apache.org/jira/browse/HDDS-8453?focusedCommentId=17763222&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-17763222)

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-8453

## How was this patch tested?
Unit test

Ran the test for 100 iterations here : https://github.com/sadanand48/hadoop-ozone/actions/runs/6144131795
