### PR TITLE
HDDS-9262. Remove support for recursive volume list/delete using ozone fs command.

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestRootedDDSWithFSO.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestRootedDDSWithFSO.java
@@ -129,7 +129,7 @@ public class TestRootedDDSWithFSO {
       Path root = new Path("/");
       FileStatus[] fileStatuses = fs.listStatus(root);
       for (FileStatus fileStatus : fileStatuses) {
-        fs.delete(fileStatus.getPath(), true);
+        fs.delete(fileStatus.getPath(), false);
       }
     } catch (IOException ex) {
       fail("Failed to cleanup files.");
@@ -191,7 +191,8 @@ public class TestRootedDDSWithFSO {
 
     OMMetrics omMetrics = cluster.getOzoneManager().getMetrics();
     long prevDeletes = omMetrics.getNumKeyDeletes();
-    Assert.assertTrue(fs.delete(volumePath, true));
+    Assert.assertTrue(fs.delete(bucketPath, true));
+    Assert.assertTrue(fs.delete(volumePath, false));
     long deletes = omMetrics.getNumKeyDeletes();
     Assert.assertEquals(prevDeletes + 1, deletes);
 

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestRootedOzoneFileSystem.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestRootedOzoneFileSystem.java
@@ -198,7 +198,8 @@ public class TestRootedOzoneFileSystem {
 
   @After
   public void cleanup() throws IOException {
-    fs.delete(volumePath, true);
+    fs.delete(bucketPath, true);
+    fs.delete(volumePath, false);
   }
 
   public static FileSystem getFs() {
@@ -546,9 +547,9 @@ public class TestRootedOzoneFileSystem {
 
   @Test
   public void testListStatusIteratorWithPathNotFound() throws Exception {
-    Path root = new Path("/test");
+    Path path = new Path("/test/test1/test2");
     try {
-      ofs.listStatusIterator(root);
+      ofs.listStatusIterator(path);
       Assert.fail("Should have thrown OMException");
     } catch (OMException omEx) {
       Assert.assertEquals("Volume test is not found",
@@ -1514,14 +1515,6 @@ public class TestRootedOzoneFileSystem {
     Assert.assertTrue(fs.delete(volumePath3, false));
     // Verify the volume is deleted
     Assert.assertFalse(volumeExist(volumeStr3));
-
-    // Test recursively delete volume
-    // Create test volume, bucket and key
-    fs.mkdirs(dirPath3);
-    // Delete volume recursively
-    Assert.assertTrue(fs.delete(volumePath3, true));
-    // Verify the volume is deleted
-    Assert.assertFalse(volumeExist(volumeStr3));
   }
 
   private void createSymlinkSrcDestPaths(String srcVol,
@@ -1561,7 +1554,7 @@ public class TestRootedOzoneFileSystem {
       try (GenericTestUtils.SystemOutCapturer capture =
                new GenericTestUtils.SystemOutCapturer()) {
         String linkPathStr = rootPath + destVolume;
-        ToolRunner.run(shell, new String[]{"-ls", "-R", linkPathStr});
+        ToolRunner.run(shell, new String[]{"-ls", linkPathStr});
         Assert.assertTrue(capture.getOutput().contains("drwxrwxrwx"));
         Assert.assertTrue(capture.getOutput().contains(linkPathStr +
             OZONE_URI_DELIMITER + srcBucket));
@@ -1599,8 +1592,10 @@ public class TestRootedOzoneFileSystem {
       // due to bug - HDDS-7884
       fs.delete(new Path(OZONE_URI_DELIMITER + destVolume +
           OZONE_URI_DELIMITER + srcBucket));
-      fs.delete(new Path(OZONE_URI_DELIMITER + srcVolume), true);
-      fs.delete(new Path(OZONE_URI_DELIMITER + destVolume), true);
+      fs.delete(new Path(OZONE_URI_DELIMITER + srcVolume +
+          OZONE_URI_DELIMITER + srcBucket));
+      fs.delete(new Path(OZONE_URI_DELIMITER + srcVolume), false);
+      fs.delete(new Path(OZONE_URI_DELIMITER + destVolume), false);
     }
   }
 
@@ -1707,8 +1702,10 @@ public class TestRootedOzoneFileSystem {
       // due to bug - HDDS-7884
       fs.delete(new Path(OZONE_URI_DELIMITER + destVolume + OZONE_URI_DELIMITER
           + srcBucket));
-      fs.delete(new Path(OZONE_URI_DELIMITER + srcVolume), true);
-      fs.delete(new Path(OZONE_URI_DELIMITER + destVolume), true);
+      fs.delete(new Path(OZONE_URI_DELIMITER + srcVolume + OZONE_URI_DELIMITER
+          + srcBucket));
+      fs.delete(new Path(OZONE_URI_DELIMITER + srcVolume), false);
+      fs.delete(new Path(OZONE_URI_DELIMITER + destVolume), false);
     }
   }
 
@@ -1741,8 +1738,8 @@ public class TestRootedOzoneFileSystem {
     // confirm non recursive delete of volume with link fails
     deleteNonRecursivelyAndFail(linkVolumePath);
 
-    // confirm recursive delete of volume with link works
-    fs.delete(linkVolumePath, true);
+    fs.delete(linkPath, true);
+    fs.delete(linkVolumePath, false);
 
     // confirm vol1 data is unaffected
     Assert.assertTrue(dir1Status.equals(fs.getFileStatus(dirPath1)));
@@ -1753,7 +1750,8 @@ public class TestRootedOzoneFileSystem {
     assertTrue(exception.getMessage().contains("File not found."));
 
     // Cleanup
-    fs.delete(volumePath1, true);
+    fs.delete(bucketPath1, true);
+    fs.delete(volumePath1, false);
 
   }
 
@@ -2289,7 +2287,7 @@ public class TestRootedOzoneFileSystem {
     assertThrows(OMException.class,
         () -> ofs.getFileStatus(new Path(volume, bucketNameLocal)));
     // Cleanup
-    ofs.delete(volume, true);
+    ofs.delete(volume, false);
   }
 
   @Test

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestRootedOzoneFileSystemWithFSO.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestRootedOzoneFileSystemWithFSO.java
@@ -240,7 +240,8 @@ public class TestRootedOzoneFileSystemWithFSO
      */
 
     long prevDeletes = getOMMetrics().getNumKeyDeletes();
-    Assert.assertTrue(getFs().delete(volumePath1, true));
+    Assert.assertTrue(getFs().delete(bucketPath2, true));
+    Assert.assertTrue(getFs().delete(volumePath1, false));
     long deletes = getOMMetrics().getNumKeyDeletes();
     Assert.assertTrue(deletes == prevDeletes + 1);
   }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/contract/rooted/ITestRootedOzoneContractRootDir.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/contract/rooted/ITestRootedOzoneContractRootDir.java
@@ -57,4 +57,27 @@ public class ITestRootedOzoneContractRootDir extends
   public void testRmNonEmptyRootDirNonRecursive() {
     // OFS doesn't support creating files directly under root
   }
+
+  @Override
+  public void testRmEmptyRootDirNonRecursive() {
+    // Internally test deletes volume recursively
+    // Which is not supported
+  }
+
+  @Override
+  public void testListEmptyRootDirectory() {
+    // Internally test deletes volume recursively
+    // Which is not supported
+  }
+
+  @Override
+  public void testSimpleRootListing() {
+    // Recursive list is not supported
+  }
+
+  @Override
+  public void testMkDirDepth1() {
+    // Internally test deletes volume recursively
+    // Which is not supported
+  }
 }

--- a/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicRootedOzoneFileSystem.java
+++ b/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicRootedOzoneFileSystem.java
@@ -669,7 +669,14 @@ public class BasicRootedOzoneFileSystem extends FileSystem {
 
     // Handle delete volume
     if (ofsPath.isVolume()) {
-      return deleteVolume(f, recursive, ofsPath);
+      if (recursive) {
+        LOG.warn("Recursive volume delete using ofs is not supported");
+        throw new IOException("Recursive volume delete using " +
+            "ofs is not supported. " +
+            "Instead use 'ozone sh volume delete -r -skipTrash " +
+            "-id <OM_SERVICE_ID> <Volume_URI>' command");
+      }
+      return deleteVolume(f, ofsPath);
     }
 
     // delete bucket
@@ -781,7 +788,7 @@ public class BasicRootedOzoneFileSystem extends FileSystem {
     }
   }
 
-  private boolean deleteVolume(Path f, boolean recursive, OFSPath ofsPath)
+  private boolean deleteVolume(Path f, OFSPath ofsPath)
       throws IOException {
     // verify volume exist
     try {
@@ -792,18 +799,6 @@ public class BasicRootedOzoneFileSystem extends FileSystem {
     }
     
     String volumeName = ofsPath.getVolumeName();
-    if (recursive) {
-      // Delete all buckets first
-      OzoneVolume volume =
-          adapterImpl.getObjectStore().getVolume(volumeName);
-      Iterator<? extends OzoneBucket> it = volume.listBuckets("");
-      String prefixVolumePathStr = addTrailingSlashIfNeeded(f.toString());
-      while (it.hasNext()) {
-        OzoneBucket bucket = it.next();
-        String nextBucket = prefixVolumePathStr + bucket.getName();
-        delete(new Path(nextBucket), true);
-      }
-    }
     try {
       adapterImpl.getObjectStore().deleteVolume(volumeName);
       return true;
@@ -1127,6 +1122,15 @@ public class BasicRootedOzoneFileSystem extends FileSystem {
   @Override
   public RemoteIterator<FileStatus> listStatusIterator(Path f)
       throws IOException {
+    OFSPath ofsPath = new OFSPath(f,
+        OzoneConfiguration.of(getConfSource()));
+    if (ofsPath.isRoot() || ofsPath.isVolume()) {
+      LOG.warn("Recursive root/volume list using ofs is not supported");
+      throw new IOException("Recursive list root/volume " +
+          "using ofs is not supported. " +
+          "Instead use 'ozone sh key list " +
+          "<Volume_URI>' command");
+    }
     return new OzoneFileStatusIterator<>(f);
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Recursive volume list/delete doesn't work for OBS buckets using fs command which leads to abnormal behaviour. To handle this we are now already supporting both OBS and FSO bucket for list/delete using new sh command. Document for the change attached in [HDDS-6610](https://issues.apache.org/jira/browse/HDDS-6610).
In this Jira we are removing support for fs list/delete command.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-9262

## How was this patch tested?

Updated existing test.
