### PR TITLE
HDDS-9260. Optimize OmDbInsight API to avoid redundant recursive size calculations for deleted directories during data retrieval.

### DIFF
--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/api/OMDBInsightEndpoint.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/api/OMDBInsightEndpoint.java
@@ -580,10 +580,22 @@ public class OMDBInsightEndpoint {
     if (nsSummary == null) {
       return 0L;
     }
+    // Check if the deleted dir size is already computed and set previously.
+    if (nsSummary.getIsSizeOfDeletedDirectoryComputed()) {
+      return nsSummary.getSizeOfFiles();
+    }
+
+    // Initialize the total size
     long totalSize = nsSummary.getSizeOfFiles();
+
+    // Compute the size recursively
     for (long childId : nsSummary.getChildDir()) {
       totalSize += fetchSizeForDeletedDirectory(childId);
     }
+    // Update the size in the NSSummary and set sizeOfFilesSet to true to avoid
+    // re-computation the next time.
+    nsSummary.setSizeOfFiles(totalSize);
+    nsSummary.setIsSizeOfDeletedDirectoryComputed();
     return totalSize;
   }
 

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/api/OMDBInsightEndpoint.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/api/OMDBInsightEndpoint.java
@@ -585,17 +585,18 @@ public class OMDBInsightEndpoint {
       return nsSummary.getSizeOfFiles();
     }
 
-    // Initialize the total size
+    // Initialize the total size.
     long totalSize = nsSummary.getSizeOfFiles();
 
-    // Compute the size recursively
+    // Compute the size recursively.
     for (long childId : nsSummary.getChildDir()) {
       totalSize += fetchSizeForDeletedDirectory(childId);
     }
     // Update the size in the NSSummary and set sizeOfFilesSet to true to avoid
     // re-computation the next time.
     nsSummary.setSizeOfFiles(totalSize);
-    nsSummary.setIsSizeOfDeletedDirectoryComputed();
+    nsSummary.setIsSizeOfDeletedDirectoryComputed(true);
+    reconNamespaceSummaryManager.storeNSSummary(objectId, nsSummary);
     return totalSize;
   }
 

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/api/types/NSSummary.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/api/types/NSSummary.java
@@ -36,10 +36,13 @@ public class NSSummary {
   private int[] fileSizeBucket;
   private Set<Long> childDir;
   private String dirName;
+  private boolean isSizeOfDeletedDirectoryComputed;
 
   public NSSummary() {
     this(0, 0L, new int[ReconConstants.NUM_OF_FILE_SIZE_BINS],
          new HashSet<>(), "");
+    // Prevents redundant size computation for deleted directories.
+    isSizeOfDeletedDirectoryComputed = false;
   }
 
   public NSSummary(int numOfFiles,
@@ -80,6 +83,14 @@ public class NSSummary {
 
   public void setSizeOfFiles(long sizeOfFiles) {
     this.sizeOfFiles = sizeOfFiles;
+  }
+
+  public boolean getIsSizeOfDeletedDirectoryComputed() {
+    return isSizeOfDeletedDirectoryComputed;
+  }
+
+  public void setIsSizeOfDeletedDirectoryComputed() {
+    this.isSizeOfDeletedDirectoryComputed = true;
   }
 
   public void setFileSizeBucket(int[] fileSizeBucket) {

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/api/types/NSSummary.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/api/types/NSSummary.java
@@ -90,7 +90,7 @@ public class NSSummary {
   }
 
   public void setIsSizeOfDeletedDirectoryComputed(
-      Boolean isSizeOfDeletedDirComputed) {
+      boolean isSizeOfDeletedDirComputed) {
     this.isSizeOfDeletedDirectoryComputed = isSizeOfDeletedDirComputed;
   }
 

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/api/types/NSSummary.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/api/types/NSSummary.java
@@ -41,7 +41,7 @@ public class NSSummary {
   public NSSummary() {
     this(0, 0L, new int[ReconConstants.NUM_OF_FILE_SIZE_BINS],
          new HashSet<>(), "");
-    // Prevents redundant size computation for deleted directories.
+  // Avoids recalculating size for deleted directories, as it remains constant.
     isSizeOfDeletedDirectoryComputed = false;
   }
 
@@ -89,8 +89,9 @@ public class NSSummary {
     return isSizeOfDeletedDirectoryComputed;
   }
 
-  public void setIsSizeOfDeletedDirectoryComputed() {
-    this.isSizeOfDeletedDirectoryComputed = true;
+  public void setIsSizeOfDeletedDirectoryComputed(
+      Boolean isSizeOfDeletedDirComputed) {
+    this.isSizeOfDeletedDirectoryComputed = isSizeOfDeletedDirComputed;
   }
 
   public void setFileSizeBucket(int[] fileSizeBucket) {


### PR DESCRIPTION
## What changes were proposed in this pull request?

In the current implementation of `omdbInsights`, the calculation of sizes for `deleted directories` occurs dynamically when needed. The respective NSSummary object associated with a deleted directory does not retain the directory's size information. Consequently, we must repeatedly traverse the directory structure recursively to calculate its size whenever the omdbInsights endpoint is invoked.

To eliminate the redundancy, we can store the calculated size within the corresponding NSSummary objects. This means that the next time we need to determine the size of a specific deleted directory, we can retrieve the stored size value directly, avoiding the need for recomputation.

It's important to note that this approach is effective for **deleted directories**, as their size remains constant once they are deleted. Unlike normal directories, where size can change dynamically as files are added or removed, the size of deleted directories remains constant, making it a suitable candidate for this optimization.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-9260

## How was this patch tested?
Integration Tests
