### PR TITLE
HDDS-6634. Incorrect datanode state drop after lose connection to SCM server

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/states/endpoint/HeartbeatEndpointTask.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/states/endpoint/HeartbeatEndpointTask.java
@@ -452,7 +452,7 @@ public class HeartbeatEndpointTask
         LOG.debug("Received SCM notification to register."
             + " Interrupt HEARTBEAT and transit to REGISTER state.");
       }
-      rpcEndpoint.setState(EndPointStates.REGISTER);
+      rpcEndpoint.setState(EndPointStates.GETVERSION);
     } else {
       if (LOG.isDebugEnabled()) {
         LOG.debug("Illegal state {} found, expecting {}.",

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/states/endpoint/HeartbeatEndpointTask.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/states/endpoint/HeartbeatEndpointTask.java
@@ -86,7 +86,7 @@ import static org.apache.hadoop.ozone.container.upgrade.UpgradeUtils.toLayoutVer
  */
 public class HeartbeatEndpointTask
     implements Callable<EndpointStateMachine.EndPointStates> {
-  static final Logger LOG =
+  public static final Logger LOG =
       LoggerFactory.getLogger(HeartbeatEndpointTask.class);
   private final EndpointStateMachine rpcEndpoint;
   private final ConfigurationSource conf;
@@ -450,7 +450,7 @@ public class HeartbeatEndpointTask
     if (rpcEndpoint.getState() == EndPointStates.HEARTBEAT) {
       if (LOG.isDebugEnabled()) {
         LOG.debug("Received SCM notification to register."
-            + " Interrupt HEARTBEAT and transit to REGISTER state.");
+            + " Interrupt HEARTBEAT and transit to GETVERSION state.");
       }
       rpcEndpoint.setState(EndPointStates.GETVERSION);
     } else {

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMDatanodeHeartbeatDispatcher.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMDatanodeHeartbeatDispatcher.java
@@ -72,7 +72,7 @@ import static org.apache.hadoop.ozone.container.upgrade.UpgradeUtils.toLayoutVer
  */
 public final class SCMDatanodeHeartbeatDispatcher {
 
-  private static final Logger LOG =
+  public static final Logger LOG =
       LoggerFactory.getLogger(SCMDatanodeHeartbeatDispatcher.class);
 
   private final NodeManager nodeManager;

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/scm/TestStorageContainerManager.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/scm/TestStorageContainerManager.java
@@ -78,6 +78,10 @@ import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.hadoop.ozone.OzoneTestUtils;
 import org.apache.hadoop.ozone.container.ContainerTestHelper;
 import org.apache.hadoop.ozone.container.common.SCMTestUtils;
+import org.apache.hadoop.ozone.HddsDatanodeService;
+import org.apache.hadoop.ozone.container.common.statemachine.DatanodeStateMachine;
+import org.apache.hadoop.ozone.container.common.statemachine.EndpointStateMachine;
+import org.apache.hadoop.ozone.container.common.states.endpoint.VersionEndpointTask;
 import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
 import org.apache.hadoop.ozone.om.helpers.OmKeyLocationInfo;
 import org.apache.hadoop.ozone.protocol.commands.CloseContainerCommand;
@@ -87,6 +91,7 @@ import org.apache.hadoop.ozone.protocol.commands.SCMCommand;
 import org.apache.hadoop.ozone.upgrade.LayoutVersionManager;
 import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.hadoop.security.authentication.client.AuthenticationException;
+import org.apache.hadoop.util.ExitUtil;
 import org.apache.hadoop.util.Time;
 import org.apache.ozone.test.GenericTestUtils;
 import org.apache.ratis.conf.RaftProperties;
@@ -365,6 +370,78 @@ public class TestStorageContainerManager {
           return false;
         }
       }, 1000, 20000);
+    } finally {
+      cluster.shutdown();
+    }
+  }
+
+  @Test
+  public void testOldDNRegistersToReInitialisedSCM() throws Exception {
+    OzoneConfiguration conf = new OzoneConfiguration();
+    MiniOzoneCluster cluster =
+        MiniOzoneCluster.newBuilder(conf).setHbInterval(1000)
+            .setHbProcessorInterval(3000).setNumDatanodes(1)
+            .setClusterId(UUID.randomUUID().toString()).build();
+    cluster.waitForClusterToBeReady();
+
+    try {
+      HddsDatanodeService datanode = cluster.getHddsDatanodes().get(0);
+      StorageContainerManager scm = cluster.getStorageContainerManager();
+      scm.stop();
+
+      // re-initialise SCM with new clusterID
+
+      GenericTestUtils.deleteDirectory(
+          new File(scm.getScmStorageConfig().getStorageDir()));
+      String newClusterId = UUID.randomUUID().toString();
+      StorageContainerManager.scmInit(scm.getConfiguration(), newClusterId);
+      scm = HddsTestUtils.getScmSimple(scm.getConfiguration());
+
+      DatanodeStateMachine dsm = datanode.getDatanodeStateMachine();
+      Assert.assertEquals(DatanodeStateMachine.DatanodeStates.RUNNING,
+          dsm.getContext().getState());
+      // DN Endpoint State has already gone through GetVersion and Register,
+      // so it will be in HEARTBEAT state.
+      for (EndpointStateMachine endpoint : dsm.getConnectionManager()
+          .getValues()) {
+        Assert.assertEquals(EndpointStateMachine.EndPointStates.HEARTBEAT,
+            endpoint.getState());
+      }
+      GenericTestUtils.LogCapturer scmDnHBDispatcherLog =
+          GenericTestUtils.LogCapturer.captureLogs(
+              SCMDatanodeHeartbeatDispatcher.LOG);
+      GenericTestUtils.LogCapturer versionEndPointTaskLog =
+          GenericTestUtils.LogCapturer.captureLogs(VersionEndpointTask.LOG);
+      // Initially empty
+      Assert.assertTrue(scmDnHBDispatcherLog.getOutput().isEmpty());
+      Assert.assertTrue(versionEndPointTaskLog.getOutput().isEmpty());
+      // start the new SCM
+      scm.start();
+      // Initially DatanodeStateMachine will be in Running state
+      Assert.assertEquals(DatanodeStateMachine.DatanodeStates.RUNNING,
+          dsm.getContext().getState());
+      // DN heartbeats to new SCM, SCM doesn't recognize the node, sends the
+      // command to DN to re-register. Wait for SCM to send re-register command
+      String expectedLog = String.format(
+          "SCM received heartbeat from an unregistered datanode %s. "
+              + "Asking datanode to re-register.",
+          datanode.getDatanodeDetails());
+      GenericTestUtils.waitFor(
+          () -> scmDnHBDispatcherLog.getOutput().contains(expectedLog), 100,
+          3000);
+      ExitUtil.disableSystemExit();
+      // As part of processing response for re-register, DN EndpointStateMachine
+      // goes to GET-VERSION state which checks if there is already existing
+      // version file on the DN & if the clusterID matches with that of the SCM
+      // In this case, it won't match and gets InconsistentStorageStateException
+      // and DN shuts down.
+      GenericTestUtils.waitFor(() -> dsm.getContext().getShutdownOnError(), 100,
+          5000);
+      Assert.assertEquals(DatanodeStateMachine.DatanodeStates.SHUTDOWN,
+          dsm.getContext().getState());
+      Assert.assertTrue(versionEndPointTaskLog.getOutput().contains(
+          "org.apache.hadoop.ozone.common" +
+              ".InconsistentStorageStateException: Mismatched ClusterIDs"));
     } finally {
       cluster.shutdown();
     }


### PR DESCRIPTION
## What changes were proposed in this pull request?
Change endpoint state to GetVersion in case of Re-Register to prevent cases where older version with older cluster ID of datanode registers back.

To add more context : 
Datanode has an EndpointStateMachine which undergoes various states in sequence - {GETVERSION,REGISTER,HEARTBEAT,SHUTDOWN}
When DN is started it first gets version from SCM and creates its storage dirs (adds version files etc) and then registers with SCM. Now that it is registered, it will keep sending HeartBeats and EndpointState = HEARTBEAT. If during this time, SCM is re-initialised i.e all prev storage dirs are deleted and SCM is inited with new cluster ID then DN still keeps sending Heartbeats and re-registers . In this case if version is not checked an old DN can register to  a new SCM and cause issues which is why the PR adds a check to validate clusterID's in case of Re-Register.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-6634

## How was this patch tested?
Unit test
