### PR TITLE
HDDS-8920. Ozone is supporting unicode volume and bucket names, unintentionally

### DIFF
--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/client/HddsClientUtils.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/client/HddsClientUtils.java
@@ -132,9 +132,8 @@ public final class HddsClientUtils {
     // ozone allows namespace to follow other volume/bucket naming convention,
     // for example, here supports '_',
     // which is a valid character in POSIX-compliant system, like HDFS.
-    return (c == '.' || c == '-' ||
-        Character.isLowerCase(c) || Character.isDigit(c)) ||
-        (c == '_' && !isStrictS3);
+    return (OzoneConsts.SUPPORTED_CHARACTER_CHECK_REGEX
+        .matcher(Character.toString(c)).matches()) || (c == '_' && !isStrictS3);
   }
 
   private static void doCharacterChecks(char currChar, char prev,

--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/client/HddsClientUtils.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/client/HddsClientUtils.java
@@ -132,8 +132,17 @@ public final class HddsClientUtils {
     // ozone allows namespace to follow other volume/bucket naming convention,
     // for example, here supports '_',
     // which is a valid character in POSIX-compliant system, like HDFS.
-    return (OzoneConsts.SUPPORTED_CHARACTER_CHECK_REGEX
-        .matcher(Character.toString(c)).matches()) || (c == '_' && !isStrictS3);
+    int code = c;
+    if (code >= 47 && code <= 57) { // 0 - 9
+      return true;
+    } else if (code >= 97 && code <= 122) {  // a-z
+      return true;
+    } else if (code == 45 || code == 46) { // "-" and "."
+      return true;
+    } else if (c == '_' && !isStrictS3) {
+      return true;
+    }
+    return false;
   }
 
   private static void doCharacterChecks(char currChar, char prev,

--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/client/HddsClientUtils.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/client/HddsClientUtils.java
@@ -132,12 +132,11 @@ public final class HddsClientUtils {
     // ozone allows namespace to follow other volume/bucket naming convention,
     // for example, here supports '_',
     // which is a valid character in POSIX-compliant system, like HDFS.
-    int code = c;
-    if (code >= 47 && code <= 57) { // 0 - 9
+    if (c >= '0' && c <= '9') {
       return true;
-    } else if (code >= 97 && code <= 122) {  // a-z
+    } else if (c >= 'a' && c <= 'z') {
       return true;
-    } else if (code == 45 || code == 46) { // "-" and "."
+    } else if (c == '-' || c == '.') {
       return true;
     } else if (c == '_' && !isStrictS3) {
       return true;

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/OzoneConsts.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/OzoneConsts.java
@@ -436,7 +436,7 @@ public final class OzoneConsts {
 
   // Supported characters for resource names when isStrictS3 is set as false
   public static final Pattern SUPPORTED_CHARACTER_CHECK_REGEX  =
-      Pattern.compile("[a-z0-9.-]]");
+      Pattern.compile("[a-z0-9.-]");
 
   public static final String FS_FILE_COPYING_TEMP_SUFFIX = "._COPYING_";
 

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/OzoneConsts.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/OzoneConsts.java
@@ -434,10 +434,6 @@ public final class OzoneConsts {
   public static final Pattern KEYNAME_ILLEGAL_CHARACTER_CHECK_REGEX  =
           Pattern.compile("^[^\\\\{}<>^%~#|`\\[\\]\"\\x80-\\xff]+$");
 
-  // Supported characters for resource names when isStrictS3 is set as false
-  public static final Pattern SUPPORTED_CHARACTER_CHECK_REGEX  =
-      Pattern.compile("[a-z0-9.-]");
-
   public static final String FS_FILE_COPYING_TEMP_SUFFIX = "._COPYING_";
 
   // Transaction Info

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/OzoneConsts.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/OzoneConsts.java
@@ -434,6 +434,10 @@ public final class OzoneConsts {
   public static final Pattern KEYNAME_ILLEGAL_CHARACTER_CHECK_REGEX  =
           Pattern.compile("^[^\\\\{}<>^%~#|`\\[\\]\"\\x80-\\xff]+$");
 
+  // Supported characters for resource names when isStrictS3 is set as false
+  public static final Pattern SUPPORTED_CHARACTER_CHECK_REGEX  =
+      Pattern.compile("[a-z0-9.-]]");
+
   public static final String FS_FILE_COPYING_TEMP_SUFFIX = "._COPYING_";
 
   // Transaction Info

--- a/hadoop-ozone/client/src/test/java/org/apache/hadoop/ozone/client/TestHddsClientUtils.java
+++ b/hadoop-ozone/client/src/test/java/org/apache/hadoop/ozone/client/TestHddsClientUtils.java
@@ -246,6 +246,7 @@ public class TestHddsClientUtils {
     final String upperCase = "notAname";
     final String endDot = "notaname.";
     final String startDot = ".notaname";
+    final String unicodeCharacters = "ｚｚｚ";
     final String tooShort = StringUtils.repeat("a",
         OzoneConsts.OZONE_MIN_BUCKET_NAME_LENGTH - 1);
 
@@ -257,6 +258,7 @@ public class TestHddsClientUtils {
     invalidNames.add(upperCase);
     invalidNames.add(endDot);
     invalidNames.add(startDot);
+    invalidNames.add(unicodeCharacters);
     invalidNames.add(tooShort);
 
     for (String name : invalidNames) {


### PR DESCRIPTION
## What changes were proposed in this pull request?

Ozone was unintentionally supporting Unicode non-ascii alphabetic characters (like Æ, ｚ, etc.) for volume and bucket names as Character.lowercase method is unicode aware. The check is now done using regex to avoid this behaviour.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-8920

## How was this patch tested?

Added a unit test in TestHddsClientUtils. Also tested manually in docker set-up:
```
bash-4.2$ LC_ALL="en_US.UTF-8" ozone sh volume create "ãñð"
INVALID_VOLUME_NAME Bucket or Volume name has an unsupported character : ã
bash-4.2$ LC_ALL="POSIX" ozone sh volume create Áaa
INVALID_VOLUME_NAME Bucket or Volume name has an unsupported character : ?
```
