### PR TITLE
HDDS-9264. Execute EC acceptance test in secure environment

### DIFF
--- a/hadoop-ozone/dist/src/main/compose/ozonesecure/docker-config
+++ b/hadoop-ozone/dist/src/main/compose/ozonesecure/docker-config
@@ -75,6 +75,9 @@ OZONE-SITE.XML_ozone.httpfs.kerberos.keytab.file=/etc/security/keytabs/httpfs.ke
 OZONE-SITE.XML_ozone.httpfs.kerberos.principal=httpfs/httpfs@EXAMPLE.COM
 
 OZONE-SITE.XML_hdds.scm.replication.thread.interval=5s
+OZONE-SITE.XML_hdds.scm.replication.under.replicated.interval=5s
+OZONE-SITE.XML_hdds.scm.replication.over.replicated.interval=5s
+OZONE-SITE.XML_hdds.scm.wait.time.after.safemode.exit=30s
 OZONE-SITE.XML_ozone.scm.stale.node.interval=30s
 OZONE-SITE.XML_ozone.scm.dead.node.interval=45s
 OZONE-SITE.XML_hdds.container.report.interval=60s

--- a/hadoop-ozone/dist/src/main/compose/ozonesecure/test-ec.sh
+++ b/hadoop-ozone/dist/src/main/compose/ozonesecure/test-ec.sh
@@ -20,7 +20,7 @@
 COMPOSE_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 export COMPOSE_DIR
 
-export SECURITY_ENABLED=false
+export SECURITY_ENABLED=true
 export OZONE_REPLICATION_FACTOR=3
 
 # shellcheck source=/dev/null

--- a/hadoop-ozone/dist/src/main/smoketest/ec/lib.resource
+++ b/hadoop-ozone/dist/src/main/smoketest/ec/lib.resource
@@ -30,6 +30,7 @@ Prepare For Tests
     Execute             dd if=/dev/urandom of=/tmp/2mb bs=1048576 count=2
     Execute             dd if=/dev/urandom of=/tmp/3mb bs=1048576 count=3
     Execute             dd if=/dev/urandom of=/tmp/100mb bs=1048576 count=100
+    Run Keyword if      '${SECURITY_ENABLED}' == 'true'     Kinit test user    testuser    testuser.keytab
 
 # xcompat/test.sh creates unified test data files in /tmp for client containers
 Prepare Data For Xcompat Tests


### PR DESCRIPTION
## What changes were proposed in this pull request?

EC acceptance tests are executed only in unsecure environment.  They should be also run in secure environment (to catch bugs like HDDS-9196).

https://issues.apache.org/jira/browse/HDDS-9264

## How was this patch tested?

CI:
https://github.com/adoroszlai/hadoop-ozone/actions/runs/6157599390/job/16711249803#step:5:995