### PR TITLE
HDDS-9270. Create a script to list all acceptance test splits

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,7 @@ jobs:
     env:
       GITHUB_CONTEXT: ${{ toJson(github) }}
     outputs:
+      acceptance-suites: ${{ steps.acceptance-suites.outputs.suites }}
       basic-checks: ${{ steps.selective-checks.outputs.basic-checks }}
       needs-basic-checks: ${{ steps.selective-checks.outputs.needs-basic-checks }}
       needs-build: ${{ steps.selective-checks.outputs.needs-build }}
@@ -58,6 +59,9 @@ jobs:
             # Run all checks
             dev-support/ci/selective_ci_checks.sh
           fi
+      - name: Acceptance suites
+        id: acceptance-suites
+        run: dev-support/ci/acceptance_suites.sh
   build:
     needs:
       - build-info
@@ -247,16 +251,7 @@ jobs:
     if: needs.build-info.outputs.needs-compose-tests == 'true'
     strategy:
       matrix:
-        suite:
-          - secure
-          - unsecure
-          - compat
-          - EC
-          - HA-secure
-          - HA-unsecure
-          - MR
-          - misc
-          - cert-rotation
+        suite: ${{ fromJson(needs.build-info.outputs.acceptance-suites) }}
       fail-fast: false
     steps:
       - name: Checkout project

--- a/dev-support/ci/acceptance_suites.sh
+++ b/dev-support/ci/acceptance_suites.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# shellcheck source=dev-support/ci/lib/_script_init.sh
+. dev-support/ci/lib/_script_init.sh
+
+SUITES=$(grep --no-filename -r '^#suite:' hadoop-ozone/dist/src/main/compose \
+  | sort -u | cut -f2 -d':' | grep -v 'failing')
+
+initialization::ga_output suites \
+    "$(initialization::parameters_to_json ${SUITES})"


### PR DESCRIPTION
## What changes were proposed in this pull request?

When adding a new acceptance test split, we need to make two changes:

* set `suite` in some test script(s)
* add the new `suite` in `ci.yml`

To simplify this and avoid possible typos, this PR makes `ci.yml` execute a script to find all existing suites.

https://issues.apache.org/jira/browse/HDDS-9270

## How was this patch tested?

```
$ dev-support/ci/acceptance_suites.sh                   
suites=["cert-rotation","compat","EC","HA-secure","HA-unsecure","misc","MR","secure","unsecure"]
```

CI (same suites as on `master`):
https://github.com/adoroszlai/hadoop-ozone/actions/runs/6161699404