### PR TITLE
HDDS-9269. [snapshot] Add unit-testcase for Snapshot Quota handling

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOmSnapshot.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOmSnapshot.java
@@ -1801,33 +1801,28 @@ public class TestOmSnapshot {
     String key1 = "key-1-";
     createFileKeyWithPrefix(bucket1, key1);
 
-    long volNameQuotaBefore = volume1.getQuotaInNamespace();
-    long volSpaceQuotaBefore = volume1.getQuotaInBytes();
-    long buckNameQuotaBefore = bucket1.getQuotaInNamespace();
-    long buckSpaceQuotaBefore = bucket1.getQuotaInBytes();
+    long volNameQuotaBefore = volume1.getUsedNamespace();
+    long buckNameQuotaBefore = bucket1.getUsedNamespace();
+    long buckSpaceQuotaBefore = bucket1.getUsedBytes();
 
     String snap1 = "snap" + counter.incrementAndGet();
     createSnapshot(volume, bucket, snap1);
 
-    long volNameQuotaAfter = volume1.getQuotaInNamespace();
-    long volSpaceQuotaAfter = volume1.getQuotaInBytes();
-    long buckNameQuotaAfter = bucket1.getQuotaInNamespace();
-    long buckSpaceQuotaAfter = bucket1.getQuotaInBytes();
+    long volNameQuotaAfter = volume1.getUsedNamespace();
+    long buckNameQuotaAfter = bucket1.getUsedNamespace();
+    long buckSpaceQuotaAfter = bucket1.getUsedBytes();
 
     assertEquals(volNameQuotaBefore, volNameQuotaAfter);
-    assertEquals(volSpaceQuotaBefore, volSpaceQuotaAfter);
     assertEquals(buckNameQuotaBefore, buckNameQuotaAfter);
     assertEquals(buckSpaceQuotaBefore, buckSpaceQuotaAfter);
 
     store.deleteSnapshot(volume, bucket, snap1);
 
-    long volNameQuotaFinal = volume1.getQuotaInNamespace();
-    long volSpaceQuotaFinal = volume1.getQuotaInBytes();
-    long buckNameQuotaFinal = bucket1.getQuotaInNamespace();
-    long buckSpaceQuotaFinal = bucket1.getQuotaInBytes();
+    long volNameQuotaFinal = volume1.getUsedNamespace();
+    long buckNameQuotaFinal = bucket1.getUsedNamespace();
+    long buckSpaceQuotaFinal = bucket1.getUsedBytes();
 
     assertEquals(volNameQuotaBefore, volNameQuotaFinal);
-    assertEquals(volSpaceQuotaBefore, volSpaceQuotaFinal);
     assertEquals(buckNameQuotaBefore, buckNameQuotaFinal);
     assertEquals(buckSpaceQuotaBefore, buckSpaceQuotaFinal);
   }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOmSnapshot.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOmSnapshot.java
@@ -1818,6 +1818,18 @@ public class TestOmSnapshot {
     assertEquals(volSpaceQuotaBefore, volSpaceQuotaAfter);
     assertEquals(buckNameQuotaBefore, buckNameQuotaAfter);
     assertEquals(buckSpaceQuotaBefore, buckSpaceQuotaAfter);
+
+    store.deleteSnapshot(volume, bucket, snap1);
+
+    long volNameQuotaFinal = volume1.getQuotaInNamespace();
+    long volSpaceQuotaFinal = volume1.getQuotaInBytes();
+    long buckNameQuotaFinal = bucket1.getQuotaInNamespace();
+    long buckSpaceQuotaFinal = bucket1.getQuotaInBytes();
+
+    assertEquals(volNameQuotaBefore, volNameQuotaFinal);
+    assertEquals(volSpaceQuotaBefore, volSpaceQuotaFinal);
+    assertEquals(buckNameQuotaBefore, buckNameQuotaFinal);
+    assertEquals(buckSpaceQuotaBefore, buckSpaceQuotaFinal);
   }
 
   @NotNull

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOmSnapshot.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOmSnapshot.java
@@ -1797,34 +1797,44 @@ public class TestOmSnapshot {
     OzoneBucket bucket1 = volume1.getBucket(bucket);
     bucket1.setQuota(OzoneQuota.parseQuota("102400000", "500"));
     volume1.setQuota(OzoneQuota.parseQuota("204800000", "1000"));
-    // Create Key1 and take snapshot
-    String key1 = "key-1-";
-    createFileKeyWithPrefix(bucket1, key1);
 
-    long volNameQuotaBefore = volume1.getUsedNamespace();
-    long buckNameQuotaBefore = bucket1.getUsedNamespace();
-    long buckSpaceQuotaBefore = bucket1.getUsedBytes();
+    long volUsedNamespaceInitial = volume1.getUsedNamespace();
+    long buckUsedNamspaceInitial = bucket1.getUsedNamespace();
+    long buckUsedBytesIntial = bucket1.getUsedBytes();
+
+    String key1 = "key-1-";
+    key1 = createFileKeyWithPrefix(bucket1, key1);
+
+    long volUsedNamespaceBefore = volume1.getUsedNamespace();
+    long buckUsedNamspaceBefore = bucket1.getUsedNamespace();
+    long buckUsedBytesBefore = bucket1.getUsedBytes();
 
     String snap1 = "snap" + counter.incrementAndGet();
     createSnapshot(volume, bucket, snap1);
 
-    long volNameQuotaAfter = volume1.getUsedNamespace();
-    long buckNameQuotaAfter = bucket1.getUsedNamespace();
-    long buckSpaceQuotaAfter = bucket1.getUsedBytes();
+    long volUsedNamespaceAfter = volume1.getUsedNamespace();
+    long buckUsedNamespaceAfter = bucket1.getUsedNamespace();
+    long buckUsedBytesAfter = bucket1.getUsedBytes();
 
-    assertEquals(volNameQuotaBefore, volNameQuotaAfter);
-    assertEquals(buckNameQuotaBefore, buckNameQuotaAfter);
-    assertEquals(buckSpaceQuotaBefore, buckSpaceQuotaAfter);
+    assertEquals(volUsedNamespaceBefore, volUsedNamespaceAfter);
+    assertEquals(buckUsedNamspaceBefore, buckUsedNamespaceAfter);
+    assertEquals(buckUsedBytesBefore, buckUsedBytesAfter);
 
     store.deleteSnapshot(volume, bucket, snap1);
 
-    long volNameQuotaFinal = volume1.getUsedNamespace();
-    long buckNameQuotaFinal = bucket1.getUsedNamespace();
-    long buckSpaceQuotaFinal = bucket1.getUsedBytes();
+    long volUsedNamespaceFinal = volume1.getUsedNamespace();
+    long buckUsedNamespaceFinal = bucket1.getUsedNamespace();
+    long buckUsedBytesFinal = bucket1.getUsedBytes();
 
-    assertEquals(volNameQuotaBefore, volNameQuotaFinal);
-    assertEquals(buckNameQuotaBefore, buckNameQuotaFinal);
-    assertEquals(buckSpaceQuotaBefore, buckSpaceQuotaFinal);
+    assertEquals(volUsedNamespaceBefore, volUsedNamespaceFinal);
+    assertEquals(buckUsedNamspaceBefore, buckUsedNamespaceFinal);
+    assertEquals(buckUsedBytesBefore, buckUsedBytesFinal);
+
+    bucket1.deleteKey(key1);
+
+    assertEquals(volUsedNamespaceInitial, volume1.getUsedNamespace());
+    assertEquals(buckUsedNamspaceInitial, bucket1.getUsedNamespace());
+    assertEquals(buckUsedBytesIntial, bucket1.getUsedBytes());
   }
 
   @NotNull


### PR DESCRIPTION
## What changes were proposed in this pull request?

Added unit-testcase for Snapshot Quota handling - `TestOmSnapshot#testSnapshotQuotaHandling
`
## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-9269

## How was this patch tested?

Testcase file - `hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOmSnapshot.java`
```
 mvn -l testlog.out -Dtest=TestOmSnapshot#testSnapshotQuotaHandling test
[INFO] -------------------------------------------------------
[INFO]  T E S T S
[INFO] -------------------------------------------------------
[INFO] Running org.apache.hadoop.ozone.om.TestOmSnapshot
[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 493.689 s - in org.apache.hadoop.ozone.om.TestOmSnapshot
[INFO]
[INFO] Results:
[INFO]
[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0
[INFO]
```
