### PR TITLE
HDDS-9275. LegacyReplicationManager: Delete excess unhealthy with force=true

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/LegacyReplicationManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/LegacyReplicationManager.java
@@ -1188,7 +1188,7 @@ public class LegacyReplicationManager {
               "under replication handling for container {} with replicas {}.",
           container, replicas);
     } else {
-      sendDeleteCommand(container, replica.getDatanodeDetails(), false);
+      sendDeleteCommand(container, replica.getDatanodeDetails(), true);
     }
   }
 

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestLegacyReplicationManager.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestLegacyReplicationManager.java
@@ -66,6 +66,7 @@ import org.apache.hadoop.hdds.utils.db.LongCodec;
 import org.apache.hadoop.ozone.common.statemachine.InvalidStateTransitionException;
 import org.apache.hadoop.ozone.container.common.SCMTestUtils;
 import org.apache.hadoop.ozone.protocol.commands.CommandForDatanode;
+import org.apache.hadoop.ozone.protocol.commands.DeleteContainerCommand;
 import org.apache.hadoop.ozone.protocol.commands.ReplicateContainerCommand;
 import org.apache.ozone.test.GenericTestUtils;
 import org.apache.ozone.test.TestClock;
@@ -1083,6 +1084,14 @@ public class TestLegacyReplicationManager {
       Assertions.assertTrue(datanodeCommandHandler.received(
           SCMCommandProto.Type.deleteContainerCommand,
           unhealthy.getDatanodeDetails()));
+
+      List<CommandForDatanode> commands = datanodeCommandHandler
+          .getReceivedCommands();
+      Assertions.assertEquals(1, commands.size());
+      DeleteContainerCommand deleteContainerCommand =
+          (DeleteContainerCommand) commands.get(0).getCommand();
+      Assertions.assertTrue(deleteContainerCommand.isForce());
+
       assertUnderReplicatedCount(1);
       // Update RM with the result of delete command
       containerStateManager.removeContainerReplica(


### PR DESCRIPTION
## What changes were proposed in this pull request?

In [HDDS-9257](https://issues.apache.org/jira/browse/HDDS-9257) we added logic to remove an excess unhealthy replica if a spare node could not be found to fix under replication. The delete command sent to the datanode needs to have force=true to allow it to delete a non-empty containers.

This change is to send the delete command with force = true.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-9275

## How was this patch tested?

Modified a unit test to ensure the force flag is true.
