### PR TITLE
HDDS-9277. [Quota] Add more negative unit-testcases coverage for volume/bucket quota

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/shell/TestOzoneShellHA.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/shell/TestOzoneShellHA.java
@@ -1045,7 +1045,7 @@ public class TestOzoneShellHA {
         .contains("Missing required parameter"));
     out.reset();
 
-    // Test set bucket quota to 0.
+    // Test set bucket quota to invalid values
     String[] bucketArgs1 = new String[]{"bucket", "setquota", "vol4/buck4",
         "--space-quota", "0GB"};
     eException = assertThrows(ExecutionException.class,

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/shell/TestOzoneShellHA.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/shell/TestOzoneShellHA.java
@@ -96,6 +96,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import picocli.CommandLine;
 import picocli.CommandLine.ExecutionException;
+import picocli.CommandLine.MissingParameterException;
 import picocli.CommandLine.IExceptionHandler2;
 import picocli.CommandLine.ParameterException;
 import picocli.CommandLine.ParseResult;
@@ -902,7 +903,7 @@ public class TestOzoneShellHA {
         "And the quota value cannot be greater than Long.MAX_VALUE BYTES");
     out.reset();
 
-    args = new String[]{"volume", "create", "vol5", "--space-quota", "1GB"};
+    args = new String[]{"volume", "create", "vol5", "--space-quota", "1.5GB"};
     executeWithError(ozoneShell, args, "Invalid values for quota, " +
         "to ensure that the Quota format is legal(supported values are " +
         "B, KB, MB, GB and TB with positive long values). " +
@@ -938,7 +939,7 @@ public class TestOzoneShellHA {
         "And the quota value cannot be greater than Long.MAX_VALUE BYTES");
     out.reset();
 
-    args = new String[]{"bucket", "create", "vol5/buck5", "--space-quota", "1GB"};
+    args = new String[]{"bucket", "create", "vol5/buck5", "--space-quota", "1.5GB"};
     executeWithError(ozoneShell, args, "Invalid values for quota, " +
         "to ensure that the Quota format is legal(supported values are " +
         "B, KB, MB, GB and TB with positive long values). " +
@@ -996,51 +997,51 @@ public class TestOzoneShellHA {
         .contains("Invalid values for space quota"));
     out.reset();
 
-    volumeArgs1 = new String[]{"volume", "setquota", "vol4",
+    String[] volumeArgs2 = new String[]{"volume", "setquota", "vol4",
         "--space-quota", "-1GB"};
     eException = assertThrows(ExecutionException.class,
-        () -> execute(ozoneShell, volumeArgs1));
+        () -> execute(ozoneShell, volumeArgs2));
     assertTrue(eException.getMessage()
         .contains("Invalid values for space quota"));
     out.reset();
 
-    volumeArgs1 = new String[]{"volume", "setquota", "vol4",
+    String[] volumeArgs3 = new String[]{"volume", "setquota", "vol4",
         "--space-quota", "test"};
     eException = assertThrows(ExecutionException.class,
-        () -> execute(ozoneShell, volumeArgs1));
+        () -> execute(ozoneShell, volumeArgs3));
     assertTrue(eException.getMessage()
         .contains("Invalid values for quota"));
     out.reset();
 
-    volumeArgs1 = new String[]{"volume", "setquota", "vol4",
+    String[] volumeArgs4 = new String[]{"volume", "setquota", "vol4",
         "--space-quota", "1.5GB"};
     eException = assertThrows(ExecutionException.class,
-        () -> execute(ozoneShell, volumeArgs1));
+        () -> execute(ozoneShell, volumeArgs4));
     assertTrue(eException.getMessage()
         .contains("Invalid values for quota"));
     out.reset();
 
-    volumeArgs1 = new String[]{"volume", "setquota", "vol4",
+    String[] volumeArgs5 = new String[]{"volume", "setquota", "vol4",
         "--space-quota"};
-    eException = assertThrows(ExecutionException.class,
-        () -> execute(ozoneShell, volumeArgs1));
-    assertTrue(eException.getMessage()
+    MissingParameterException mException = assertThrows(MissingParameterException.class,
+        () -> execute(ozoneShell, volumeArgs5));
+    assertTrue(mException.getMessage()
         .contains("Missing required parameter"));
     out.reset();
 
-    String[] volumeArgs2 = new String[]{"volume", "setquota", "vol4",
+    String[] volumeArgs6 = new String[]{"volume", "setquota", "vol4",
         "--namespace-quota", "0"};
     eException = assertThrows(ExecutionException.class,
-        () -> execute(ozoneShell, volumeArgs2));
+        () -> execute(ozoneShell, volumeArgs6));
     assertTrue(eException.getMessage()
         .contains("Invalid values for namespace quota"));
     out.reset();
 
-    volumeArgs2 = new String[]{"volume", "setquota", "vol4",
+    String[] volumeArgs7 = new String[]{"volume", "setquota", "vol4",
         "--namespace-quota"};
-    eException = assertThrows(ExecutionException.class,
-        () -> execute(ozoneShell, volumeArgs2));
-    assertTrue(eException.getMessage()
+    mException = assertThrows(MissingParameterException.class,
+        () -> execute(ozoneShell, volumeArgs7));
+    assertTrue(mException.getMessage()
         .contains("Missing required parameter"));
     out.reset();
 
@@ -1053,67 +1054,67 @@ public class TestOzoneShellHA {
         .contains("Invalid values for space quota"));
     out.reset();
 
-    bucketArgs1 = new String[]{"bucket", "setquota", "vol4/buck4",
+    String[] bucketArgs2 = new String[]{"bucket", "setquota", "vol4/buck4",
         "--space-quota", "-1GB"};
     eException = assertThrows(ExecutionException.class,
-        () -> execute(ozoneShell, bucketArgs1));
+        () -> execute(ozoneShell, bucketArgs2));
     assertTrue(eException.getMessage()
         .contains("Invalid values for space quota"));
     out.reset();
 
-    bucketArgs1 = new String[]{"bucket", "setquota", "vol4/buck4",
+    String[] bucketArgs3 = new String[]{"bucket", "setquota", "vol4/buck4",
         "--space-quota", "test"};
     eException = assertThrows(ExecutionException.class,
-        () -> execute(ozoneShell, bucketArgs1));
+        () -> execute(ozoneShell, bucketArgs3));
     assertTrue(eException.getMessage()
         .contains("Invalid values for quota"));
     out.reset();
 
-    bucketArgs1 = new String[]{"bucket", "setquota", "vol4/buck4",
+    String[] bucketArgs4 = new String[]{"bucket", "setquota", "vol4/buck4",
         "--space-quota", "1.5GB"};
     eException = assertThrows(ExecutionException.class,
-        () -> execute(ozoneShell, bucketArgs1));
+        () -> execute(ozoneShell, bucketArgs4));
     assertTrue(eException.getMessage()
         .contains("Invalid values for quota"));
     out.reset();
 
-    bucketArgs1 = new String[]{"bucket", "setquota", "vol4/buck4",
+    String[] bucketArgs5 = new String[]{"bucket", "setquota", "vol4/buck4",
         "--space-quota"};
-    eException = assertThrows(ExecutionException.class,
-        () -> execute(ozoneShell, bucketArgs1));
-    assertTrue(eException.getMessage()
+    mException = assertThrows(MissingParameterException.class,
+        () -> execute(ozoneShell, bucketArgs5));
+    assertTrue(mException.getMessage()
         .contains("Missing required parameter"));
     out.reset();
 
-    String[] bucketArgs2 = new String[]{"bucket", "setquota", "vol4/buck4",
+    String[] bucketArgs6 = new String[]{"bucket", "setquota", "vol4/buck4",
         "--namespace-quota", "0"};
     eException = assertThrows(ExecutionException.class,
-        () -> execute(ozoneShell, bucketArgs2));
+        () -> execute(ozoneShell, bucketArgs6));
     assertTrue(eException.getMessage()
         .contains("Invalid values for namespace quota"));
     out.reset();
 
-    bucketArgs2 = new String[]{"bucket", "setquota", "vol4/buck4",
+    String[] bucketArgs7 = new String[]{"bucket", "setquota", "vol4/buck4",
         "--namespace-quota"};
-    eException = assertThrows(ExecutionException.class,
-        () -> execute(ozoneShell, bucketArgs2));
-    assertTrue(eException.getMessage()
+    mException = assertThrows(MissingParameterException.class,
+        () -> execute(ozoneShell, bucketArgs7));
+    assertTrue(mException.getMessage()
         .contains("Missing required parameter"));
     out.reset();
 
     // Test set bucket spaceQuota or nameSpaceQuota to normal value.
-    String[] bucketArgs3 = new String[]{"bucket", "setquota", "vol4/buck4",
+    String[] bucketArgs8 = new String[]{"bucket", "setquota", "vol4/buck4",
         "--space-quota", "1000B"};
-    execute(ozoneShell, bucketArgs3);
+    execute(ozoneShell, bucketArgs8);
     out.reset();
     assertEquals(1000, objectStore.getVolume("vol4")
         .getBucket("buck4").getQuotaInBytes());
     assertEquals(-1, objectStore.getVolume("vol4")
         .getBucket("buck4").getQuotaInNamespace());
 
-    String[] bucketArgs4 = new String[]{"bucket", "setquota", "vol4/buck4",
+    String[] bucketArgs9 = new String[]{"bucket", "setquota", "vol4/buck4",
         "--namespace-quota", "100"};
-    execute(ozoneShell, bucketArgs4);
+    execute(ozoneShell, bucketArgs9);
     out.reset();
     assertEquals(1000, objectStore.getVolume("vol4")
         .getBucket("buck4").getQuotaInBytes());
@@ -1121,9 +1122,9 @@ public class TestOzoneShellHA {
         .getBucket("buck4").getQuotaInNamespace());
 
     // test whether supports default quota unit as bytes.
-    String[] bucketArgs5 = new String[]{"bucket", "setquota", "vol4/buck4",
+    String[] bucketArgs10 = new String[]{"bucket", "setquota", "vol4/buck4",
         "--space-quota", "500"};
-    execute(ozoneShell, bucketArgs5);
+    execute(ozoneShell, bucketArgs10);
     out.reset();
     assertEquals(500, objectStore.getVolume("vol4")
         .getBucket("buck4").getQuotaInBytes());
@@ -1131,31 +1132,31 @@ public class TestOzoneShellHA {
         .getBucket("buck4").getQuotaInNamespace());
 
     // Test set volume quota without quota flag
-    String[] bucketArgs6 = new String[]{"bucket", "setquota", "vol4/buck4"};
-    executeWithError(ozoneShell, bucketArgs6,
+    String[] bucketArgs11 = new String[]{"bucket", "setquota", "vol4/buck4"};
+    executeWithError(ozoneShell, bucketArgs11,
         "At least one of the quota set flag is required");
     out.reset();
 
     // Test set volume spaceQuota or nameSpaceQuota to normal value.
-    String[] volumeArgs3 = new String[]{"volume", "setquota", "vol4",
+    String[] volumeArgs8 = new String[]{"volume", "setquota", "vol4",
         "--space-quota", "1000B"};
-    execute(ozoneShell, volumeArgs3);
+    execute(ozoneShell, volumeArgs8);
     out.reset();
     assertEquals(1000, objectStore.getVolume("vol4").getQuotaInBytes());
     assertEquals(-1,
         objectStore.getVolume("vol4").getQuotaInNamespace());
 
-    String[] volumeArgs4 = new String[]{"volume", "setquota", "vol4",
+    String[] volumeArgs9 = new String[]{"volume", "setquota", "vol4",
         "--namespace-quota", "100"};
-    execute(ozoneShell, volumeArgs4);
+    execute(ozoneShell, volumeArgs9);
     out.reset();
     assertEquals(1000, objectStore.getVolume("vol4").getQuotaInBytes());
     assertEquals(100,
         objectStore.getVolume("vol4").getQuotaInNamespace());
 
     // Test set volume quota without quota flag
-    String[] volumeArgs5 = new String[]{"volume", "setquota", "vol4"};
-    executeWithError(ozoneShell, volumeArgs5,
+    String[] volumeArgs10 = new String[]{"volume", "setquota", "vol4"};
+    executeWithError(ozoneShell, volumeArgs10,
         "At least one of the quota set flag is required");
     out.reset();
     

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/shell/TestOzoneShellHA.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/shell/TestOzoneShellHA.java
@@ -884,6 +884,80 @@ public class TestOzoneShellHA {
         objectStore.getVolume("vol4").getBucket("buck4")
             .getQuotaInNamespace());
 
+
+    // Test negative scenarios for --space-quota and --namespace-quota option
+    args = new String[]{"volume", "create", "vol5", "--space-quota"};
+    executeWithError(ozoneShell, args, "Missing required parameter for option " +
+        "'--space-quota' (<quotaInBytes>)");
+    out.reset();
+
+    args = new String[]{"volume", "create", "vol5", "--space-quota", "-1"};
+    executeWithError(ozoneShell, args, "Invalid values for space quota: -1");
+    out.reset();
+
+    args = new String[]{"volume", "create", "vol5", "--space-quota", "test"};
+    executeWithError(ozoneShell, args, "Invalid values for quota, " +
+        "to ensure that the Quota format is legal(supported values are " +
+        "B, KB, MB, GB and TB with positive long values). " +
+        "And the quota value cannot be greater than Long.MAX_VALUE BYTES");
+    out.reset();
+
+    args = new String[]{"volume", "create", "vol5", "--space-quota", "1GB"};
+    executeWithError(ozoneShell, args, "Invalid values for quota, " +
+        "to ensure that the Quota format is legal(supported values are " +
+        "B, KB, MB, GB and TB with positive long values). " +
+        "And the quota value cannot be greater than Long.MAX_VALUE BYTES");
+    out.reset();
+
+    args = new String[]{"volume", "create", "vol5", "--namespace-quota"};
+    executeWithError(ozoneShell, args, "Missing required parameter for option " +
+        "'--namespace-quota' (<quotaInNamespace>)");
+    out.reset();
+
+    args = new String[]{"volume", "create", "vol5", "--namespace-quota", "-1"};
+    executeWithError(ozoneShell, args, "Invalid values for namespace quota: -1");
+    out.reset();
+
+    args = new String[]{"volume", "create", "vol5"};
+    execute(ozoneShell, args);
+    out.reset();
+
+    args = new String[]{"bucket", "create", "vol5/buck5", "--space-quota"};
+    executeWithError(ozoneShell, args, "Missing required parameter for option " +
+        "'--space-quota' (<quotaInBytes>)");
+    out.reset();
+
+    args = new String[]{"bucket", "create", "vol5/buck5", "--space-quota", "-1"};
+    executeWithError(ozoneShell, args, "Invalid values for space quota: -1");
+    out.reset();
+
+    args = new String[]{"bucket", "create", "vol5/buck5", "--space-quota", "test"};
+    executeWithError(ozoneShell, args, "Invalid values for quota, " +
+        "to ensure that the Quota format is legal(supported values are " +
+        "B, KB, MB, GB and TB with positive long values). " +
+        "And the quota value cannot be greater than Long.MAX_VALUE BYTES");
+    out.reset();
+
+    args = new String[]{"bucket", "create", "vol5/buck5", "--space-quota", "1GB"};
+    executeWithError(ozoneShell, args, "Invalid values for quota, " +
+        "to ensure that the Quota format is legal(supported values are " +
+        "B, KB, MB, GB and TB with positive long values). " +
+        "And the quota value cannot be greater than Long.MAX_VALUE BYTES");
+    out.reset();
+
+    args = new String[]{"bucket", "create", "vol5/buck5", "--namespace-quota"};
+    executeWithError(ozoneShell, args, "Missing required parameter for option " +
+        "'--namespace-quota' (<quotaInNamespace>)");
+    out.reset();
+
+    args = new String[]{"volume", "create", "vol5", "--namespace-quota", "-1"};
+    executeWithError(ozoneShell, args, "Invalid values for namespace quota: -1");
+    out.reset();
+
+    args = new String[]{"bucket", "create", "vol5/buck5"};
+    execute(ozoneShell, args);
+    out.reset();
+
     // Test clrquota option.
     args = new String[]{"volume", "clrquota", "vol4"};
     executeWithError(ozoneShell, args, "At least one of the quota clear" +
@@ -913,7 +987,7 @@ public class TestOzoneShellHA {
             .getQuotaInNamespace());
     out.reset();
 
-    // Test set volume quota to 0.
+    // Test set volume quota to invalid values.
     String[] volumeArgs1 = new String[]{"volume", "setquota", "vol4",
         "--space-quota", "0GB"};
     ExecutionException eException = assertThrows(ExecutionException.class,
@@ -922,12 +996,52 @@ public class TestOzoneShellHA {
         .contains("Invalid values for space quota"));
     out.reset();
 
+    volumeArgs1 = new String[]{"volume", "setquota", "vol4",
+        "--space-quota", "-1GB"};
+    eException = assertThrows(ExecutionException.class,
+        () -> execute(ozoneShell, volumeArgs1));
+    assertTrue(eException.getMessage()
+        .contains("Invalid values for space quota"));
+    out.reset();
+
+    volumeArgs1 = new String[]{"volume", "setquota", "vol4",
+        "--space-quota", "test"};
+    eException = assertThrows(ExecutionException.class,
+        () -> execute(ozoneShell, volumeArgs1));
+    assertTrue(eException.getMessage()
+        .contains("Invalid values for quota"));
+    out.reset();
+
+    volumeArgs1 = new String[]{"volume", "setquota", "vol4",
+        "--space-quota", "1.5GB"};
+    eException = assertThrows(ExecutionException.class,
+        () -> execute(ozoneShell, volumeArgs1));
+    assertTrue(eException.getMessage()
+        .contains("Invalid values for quota"));
+    out.reset();
+
+    volumeArgs1 = new String[]{"volume", "setquota", "vol4",
+        "--space-quota"};
+    eException = assertThrows(ExecutionException.class,
+        () -> execute(ozoneShell, volumeArgs1));
+    assertTrue(eException.getMessage()
+        .contains("Missing required parameter"));
+    out.reset();
+
     String[] volumeArgs2 = new String[]{"volume", "setquota", "vol4",
         "--namespace-quota", "0"};
     eException = assertThrows(ExecutionException.class,
         () -> execute(ozoneShell, volumeArgs2));
     assertTrue(eException.getMessage()
         .contains("Invalid values for namespace quota"));
+    out.reset();
+
+    volumeArgs2 = new String[]{"volume", "setquota", "vol4",
+        "--namespace-quota"};
+    eException = assertThrows(ExecutionException.class,
+        () -> execute(ozoneShell, volumeArgs2));
+    assertTrue(eException.getMessage()
+        .contains("Missing required parameter"));
     out.reset();
 
     // Test set bucket quota to 0.
@@ -939,12 +1053,52 @@ public class TestOzoneShellHA {
         .contains("Invalid values for space quota"));
     out.reset();
 
+    bucketArgs1 = new String[]{"bucket", "setquota", "vol4/buck4",
+        "--space-quota", "-1GB"};
+    eException = assertThrows(ExecutionException.class,
+        () -> execute(ozoneShell, bucketArgs1));
+    assertTrue(eException.getMessage()
+        .contains("Invalid values for space quota"));
+    out.reset();
+
+    bucketArgs1 = new String[]{"bucket", "setquota", "vol4/buck4",
+        "--space-quota", "test"};
+    eException = assertThrows(ExecutionException.class,
+        () -> execute(ozoneShell, bucketArgs1));
+    assertTrue(eException.getMessage()
+        .contains("Invalid values for quota"));
+    out.reset();
+
+    bucketArgs1 = new String[]{"bucket", "setquota", "vol4/buck4",
+        "--space-quota", "1.5GB"};
+    eException = assertThrows(ExecutionException.class,
+        () -> execute(ozoneShell, bucketArgs1));
+    assertTrue(eException.getMessage()
+        .contains("Invalid values for quota"));
+    out.reset();
+
+    bucketArgs1 = new String[]{"bucket", "setquota", "vol4/buck4",
+        "--space-quota"};
+    eException = assertThrows(ExecutionException.class,
+        () -> execute(ozoneShell, bucketArgs1));
+    assertTrue(eException.getMessage()
+        .contains("Missing required parameter"));
+    out.reset();
+
     String[] bucketArgs2 = new String[]{"bucket", "setquota", "vol4/buck4",
         "--namespace-quota", "0"};
     eException = assertThrows(ExecutionException.class,
         () -> execute(ozoneShell, bucketArgs2));
     assertTrue(eException.getMessage()
         .contains("Invalid values for namespace quota"));
+    out.reset();
+
+    bucketArgs2 = new String[]{"bucket", "setquota", "vol4/buck4",
+        "--namespace-quota"};
+    eException = assertThrows(ExecutionException.class,
+        () -> execute(ozoneShell, bucketArgs2));
+    assertTrue(eException.getMessage()
+        .contains("Missing required parameter"));
     out.reset();
 
     // Test set bucket spaceQuota or nameSpaceQuota to normal value.
@@ -1015,6 +1169,8 @@ public class TestOzoneShellHA {
     objectStore.deleteVolume("vol3");
     objectStore.getVolume("vol4").deleteBucket("buck4");
     objectStore.deleteVolume("vol4");
+    objectStore.getVolume("vol5").deleteBucket("buck5");
+    objectStore.deleteVolume("vol5");
   }
 
   @Test

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/shell/TestOzoneShellHA.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/shell/TestOzoneShellHA.java
@@ -888,7 +888,8 @@ public class TestOzoneShellHA {
 
     // Test negative scenarios for --space-quota and --namespace-quota option
     args = new String[]{"volume", "create", "vol5", "--space-quota"};
-    executeWithError(ozoneShell, args, "Missing required parameter for option " +
+    executeWithError(ozoneShell, args,
+        "Missing required parameter for option " +
         "'--space-quota' (<quotaInBytes>)");
     out.reset();
 
@@ -911,12 +912,14 @@ public class TestOzoneShellHA {
     out.reset();
 
     args = new String[]{"volume", "create", "vol5", "--namespace-quota"};
-    executeWithError(ozoneShell, args, "Missing required parameter for option " +
+    executeWithError(ozoneShell, args,
+        "Missing required parameter for option " +
         "'--namespace-quota' (<quotaInNamespace>)");
     out.reset();
 
     args = new String[]{"volume", "create", "vol5", "--namespace-quota", "-1"};
-    executeWithError(ozoneShell, args, "Invalid values for namespace quota: -1");
+    executeWithError(ozoneShell, args,
+        "Invalid values for namespace quota: -1");
     out.reset();
 
     args = new String[]{"volume", "create", "vol5"};
@@ -924,22 +927,27 @@ public class TestOzoneShellHA {
     out.reset();
 
     args = new String[]{"bucket", "create", "vol5/buck5", "--space-quota"};
-    executeWithError(ozoneShell, args, "Missing required parameter for option " +
+    executeWithError(ozoneShell, args,
+        "Missing required parameter for option " +
         "'--space-quota' (<quotaInBytes>)");
     out.reset();
 
-    args = new String[]{"bucket", "create", "vol5/buck5", "--space-quota", "-1"};
-    executeWithError(ozoneShell, args, "Invalid values for space quota: -1");
+    args = new String[]{"bucket", "create", "vol5/buck5",
+        "--space-quota", "-1"};
+    executeWithError(ozoneShell, args,
+        "Invalid values for space quota: -1");
     out.reset();
 
-    args = new String[]{"bucket", "create", "vol5/buck5", "--space-quota", "test"};
+    args = new String[]{"bucket", "create", "vol5/buck5",
+        "--space-quota", "test"};
     executeWithError(ozoneShell, args, "Invalid values for quota, " +
         "to ensure that the Quota format is legal(supported values are " +
         "B, KB, MB, GB and TB with positive long values). " +
         "And the quota value cannot be greater than Long.MAX_VALUE BYTES");
     out.reset();
 
-    args = new String[]{"bucket", "create", "vol5/buck5", "--space-quota", "1.5GB"};
+    args = new String[]{"bucket", "create", "vol5/buck5",
+        "--space-quota", "1.5GB"};
     executeWithError(ozoneShell, args, "Invalid values for quota, " +
         "to ensure that the Quota format is legal(supported values are " +
         "B, KB, MB, GB and TB with positive long values). " +
@@ -947,12 +955,14 @@ public class TestOzoneShellHA {
     out.reset();
 
     args = new String[]{"bucket", "create", "vol5/buck5", "--namespace-quota"};
-    executeWithError(ozoneShell, args, "Missing required parameter for option " +
+    executeWithError(ozoneShell, args,
+        "Missing required parameter for option " +
         "'--namespace-quota' (<quotaInNamespace>)");
     out.reset();
 
     args = new String[]{"volume", "create", "vol5", "--namespace-quota", "-1"};
-    executeWithError(ozoneShell, args, "Invalid values for namespace quota: -1");
+    executeWithError(ozoneShell, args,
+        "Invalid values for namespace quota: -1");
     out.reset();
 
     args = new String[]{"bucket", "create", "vol5/buck5"};
@@ -1023,7 +1033,8 @@ public class TestOzoneShellHA {
 
     String[] volumeArgs5 = new String[]{"volume", "setquota", "vol4",
         "--space-quota"};
-    MissingParameterException mException = assertThrows(MissingParameterException.class,
+    MissingParameterException mException = assertThrows(
+        MissingParameterException.class,
         () -> execute(ozoneShell, volumeArgs5));
     assertTrue(mException.getMessage()
         .contains("Missing required parameter"));


### PR DESCRIPTION
## What changes were proposed in this pull request?

Add more negative unit-testcases coverage for volume/bucket quota - `TestOzoneShellHA#testShQuota`
## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-9277

## How was this patch tested?

Testcase file - `hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/shell/TestOzoneShellHA.java`
```
mvn -l testlog.out -Dtest=TestOzoneShellHA#testShQuota test
[INFO] -------------------------------------------------------
[INFO]  T E S T S
[INFO] -------------------------------------------------------
[INFO] Running org.apache.hadoop.ozone.shell.TestOzoneShellHA
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 769.384 s - in org.apache.hadoop.ozone.shell.TestOzoneShellHA
[INFO]
[INFO] Results:
[INFO]
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0
```