### PR TITLE
HDDS-9279. OM HA: support read from followers.

### DIFF
--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/OMConfigKeys.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/OMConfigKeys.java
@@ -22,6 +22,7 @@ import java.util.concurrent.TimeUnit;
 import org.apache.hadoop.hdds.client.ReplicationFactor;
 import org.apache.hadoop.hdds.client.ReplicationType;
 import org.apache.hadoop.ozone.om.helpers.BucketLayout;
+import org.apache.ratis.server.RaftServerConfigKeys.Read;
 import org.apache.ratis.util.TimeDuration;
 
 /**
@@ -235,6 +236,10 @@ public final class OMConfigKeys {
   public static final boolean
       OZONE_OM_RATIS_SERVER_ELECTION_PRE_VOTE_DEFAULT = true;
 
+  public static final String OZONE_OM_RATIS_SERVER_READ_OPTION
+      = "ozone.om.ratis.server.read.option";
+  public static final Read.Option OZONE_OM_RATIS_SERVER_READ_OPTION_DEFAULT
+      = Read.Option.LINEARIZABLE;
 
   // OM SnapshotProvider configurations
   public static final String OZONE_OM_RATIS_SNAPSHOT_DIR =

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/OzoneManagerRatisServer.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/OzoneManagerRatisServer.java
@@ -83,6 +83,7 @@ import org.apache.ratis.rpc.RpcType;
 import org.apache.ratis.rpc.SupportedRpcType;
 import org.apache.ratis.server.RaftServer;
 import org.apache.ratis.server.RaftServerConfigKeys;
+import org.apache.ratis.server.RaftServerConfigKeys.Read;
 import org.apache.ratis.server.protocol.TermIndex;
 import org.apache.ratis.thirdparty.com.google.protobuf.ByteString;
 import org.apache.ratis.util.LifeCycle;
@@ -118,6 +119,7 @@ public final class OzoneManagerRatisServer {
 
   private final ClientId clientId = ClientId.randomId();
   private static final AtomicLong CALL_ID_COUNTER = new AtomicLong();
+  private final Read.Option readOption;
 
   private static long nextCallId() {
     return CALL_ID_COUNTER.getAndIncrement() & Long.MAX_VALUE;
@@ -143,7 +145,6 @@ public final class OzoneManagerRatisServer {
     this.omRatisAddress = addr;
     this.port = addr.getPort();
     this.ratisStorageDir = OzoneManagerRatisUtils.getOMRatisDirectory(conf);
-    RaftProperties serverProperties = newRaftProperties(conf);
 
     this.raftPeerId = localRaftPeerId;
     this.raftGroupId = RaftGroupId.valueOf(
@@ -164,6 +165,9 @@ public final class OzoneManagerRatisServer {
           raftGroupIdStr, raftPeersStr.toString().substring(2));
     }
     this.omStateMachine = getStateMachine(conf);
+
+    final RaftProperties serverProperties = newRaftProperties(conf);
+    this.readOption = RaftServerConfigKeys.Read.option(serverProperties);
 
     Parameters parameters = createServerTlsParameters(secConfig, certClient);
     this.server = RaftServer.newBuilder()
@@ -532,6 +536,10 @@ public final class OzoneManagerRatisServer {
     return server;
   }
 
+  public boolean isLinearizableRead() {
+    return readOption == Read.Option.LINEARIZABLE;
+  }
+
   /**
    * Initializes and returns OzoneManager StateMachine.
    */
@@ -593,6 +601,10 @@ public final class OzoneManagerRatisServer {
     RaftServerConfigKeys.LeaderElection.setPreVote(properties,
         conf.getBoolean(OMConfigKeys.OZONE_OM_RATIS_SERVER_ELECTION_PRE_VOTE,
             OMConfigKeys.OZONE_OM_RATIS_SERVER_ELECTION_PRE_VOTE_DEFAULT));
+
+    RaftServerConfigKeys.Read.setOption(properties,
+        conf.getEnum(OMConfigKeys.OZONE_OM_RATIS_SERVER_READ_OPTION,
+            OMConfigKeys.OZONE_OM_RATIS_SERVER_READ_OPTION_DEFAULT));
 
     // Set RAFT segment size
     final long raftSegmentSize = (long) conf.getStorageSize(

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/protocolPB/OzoneManagerProtocolServerSideTranslatorPB.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/protocolPB/OzoneManagerProtocolServerSideTranslatorPB.java
@@ -218,6 +218,10 @@ public class OzoneManagerProtocolServerSideTranslatorPB implements
 
   private OMResponse submitReadRequestToOM(OMRequest request)
       throws ServiceException {
+    // Read from leader or followers using linearizable read
+    if (omRatisServer.isLinearizableRead()) {
+      return handler.handleReadRequest(request);
+    }
     // Check if this OM is the leader.
     RaftServerStatus raftServerStatus = omRatisServer.checkLeaderStatus();
     if (raftServerStatus == LEADER_AND_READY ||


### PR DESCRIPTION
## What changes were proposed in this pull request?

Ratis has a new Linearizable Read ([RATIS-1557](https://issues.apache.org/jira/browse/RATIS-1557)) feature, including reading from the followers. In this JIRA, we will change OM to serve read requests from any OM servers, including the follower OMs.

## What is the link to the Apache JIRA

HDDS-9279

## How was this patch tested?

(Please explain how this patch was tested. Ex: unit tests, manual tests)
(If this patch involves UI changes, please attach a screen-shot; otherwise, remove this)

Will add new tests.