### PR TITLE
HDDS-9278. Return proper error message thrown when text/decimal is supplied as a parameter for namespace-quota

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/client/OzoneQuota.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/client/OzoneQuota.java
@@ -218,12 +218,17 @@ public final class OzoneQuota {
       throw new IllegalArgumentException(
           "Quota string cannot be null or empty.");
     }
-    long nameSpaceQuota = Long.parseLong(quotaInNamespace);
-    if (nameSpaceQuota <= 0) {
-      throw new IllegalArgumentException(
-          "Invalid values for namespace quota: " + nameSpaceQuota);
+    try {
+      long nameSpaceQuota = Long.parseLong(quotaInNamespace);
+      if (nameSpaceQuota <= 0) {
+        throw new IllegalArgumentException(
+            "Invalid values for namespace quota: " + nameSpaceQuota);
+      }
+      return new OzoneQuota(nameSpaceQuota, new RawQuotaInBytes(Units.B, -1));
+    } catch (NumberFormatException e) {
+      throw new IllegalArgumentException("Invalid values for quota, to ensure" +
+          " that the Quota format is legal(supported values are positive long values).");
     }
-    return new OzoneQuota(nameSpaceQuota, new RawQuotaInBytes(Units.B, -1));
   }
 
   /**

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/client/OzoneQuota.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/client/OzoneQuota.java
@@ -191,7 +191,7 @@ public final class OzoneQuota {
       nSize = Long.parseLong(size);
     } catch (NumberFormatException e) {
       throw new IllegalArgumentException(quotaInBytes + " is invalid. " +
-          "The quota value should be a positive integer between 1 and Long.MAX_VALUE" +
+          "The quota value should be a positive integer " +
           "with byte numeration(B, KB, MB, GB and TB)");
     }
 
@@ -225,7 +225,7 @@ public final class OzoneQuota {
       return new OzoneQuota(nameSpaceQuota, new RawQuotaInBytes(Units.B, -1));
     } catch (NumberFormatException e) {
       throw new IllegalArgumentException(quotaInNamespace + " is invalid. " +
-          "The quota value should be a positive integer between 1 and Long.MAX_VALUE");
+          "The quota value should be a positive integer");
     }
   }
 

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/client/OzoneQuota.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/client/OzoneQuota.java
@@ -190,7 +190,7 @@ public final class OzoneQuota {
       }
       nSize = Long.parseLong(size);
     } catch (NumberFormatException e) {
-      throw new IllegalArgumentException("Invalid values for quota, to ensure" +
+      throw new IllegalArgumentException("Invalid value for quota, to ensure" +
               " that the Quota format is legal(supported values are B," +
               " KB, MB, GB and TB with positive long values)." +
               " And the quota value cannot be greater than " +
@@ -198,7 +198,7 @@ public final class OzoneQuota {
     }
 
     if (nSize <= 0) {
-      throw new IllegalArgumentException("Invalid values for space quota: "
+      throw new IllegalArgumentException("Invalid value for space quota: "
           + nSize);
     }
 
@@ -222,12 +222,12 @@ public final class OzoneQuota {
       long nameSpaceQuota = Long.parseLong(quotaInNamespace);
       if (nameSpaceQuota <= 0) {
         throw new IllegalArgumentException(
-            "Invalid values for namespace quota: " + nameSpaceQuota);
+            "Invalid value for namespace quota: " + nameSpaceQuota);
       }
       return new OzoneQuota(nameSpaceQuota, new RawQuotaInBytes(Units.B, -1));
     } catch (NumberFormatException e) {
-      throw new IllegalArgumentException("Invalid values for quota, to ensure" +
-          " that the Quota format is legal(supported values are positive long values).");
+      throw new IllegalArgumentException(quotaInNamespace + " is invalid. " +
+          "The quota value should be a positive integer.");
     }
   }
 

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/client/OzoneQuota.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/client/OzoneQuota.java
@@ -190,11 +190,9 @@ public final class OzoneQuota {
       }
       nSize = Long.parseLong(size);
     } catch (NumberFormatException e) {
-      throw new IllegalArgumentException("Invalid value for quota, to ensure" +
-              " that the Quota format is legal(supported values are B," +
-              " KB, MB, GB and TB with positive long values)." +
-              " And the quota value cannot be greater than " +
-              "Long.MAX_VALUE BYTES");
+      throw new IllegalArgumentException(quotaInBytes + " is invalid. " +
+          "The quota value should be a positive integer between 1 and Long.MAX_VALUE" +
+          "with byte numeration(B, KB, MB, GB and TB)");
     }
 
     if (nSize <= 0) {
@@ -227,7 +225,7 @@ public final class OzoneQuota {
       return new OzoneQuota(nameSpaceQuota, new RawQuotaInBytes(Units.B, -1));
     } catch (NumberFormatException e) {
       throw new IllegalArgumentException(quotaInNamespace + " is invalid. " +
-          "The quota value should be a positive long.");
+          "The quota value should be a positive integer between 1 and Long.MAX_VALUE");
     }
   }
 

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/client/OzoneQuota.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/client/OzoneQuota.java
@@ -227,7 +227,7 @@ public final class OzoneQuota {
       return new OzoneQuota(nameSpaceQuota, new RawQuotaInBytes(Units.B, -1));
     } catch (NumberFormatException e) {
       throw new IllegalArgumentException(quotaInNamespace + " is invalid. " +
-          "The quota value should be a positive integer.");
+          "The quota value should be a positive long.");
     }
   }
 

--- a/hadoop-ozone/dist/src/main/smoketest/basic/ozone-shell-lib.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/basic/ozone-shell-lib.robot
@@ -92,7 +92,7 @@ Test ozone shell
 Test ozone shell errors
     [arguments]     ${protocol}         ${server}       ${volume}
     ${result} =     Execute and checkrc    ozone sh volume create ${protocol}${server}/${volume} --space-quota invalid      255
-                    Should contain      ${result}       Invalid
+                    Should contain      ${result}       invalid
                     Execute and checkrc    ozone sh volume create ${protocol}${server}/${volume}                            0
     ${result} =     Execute and checkrc    ozone sh bucket create ${protocol}${server}/${volume}/bucket_1                   255
                     Should contain      ${result}       INVALID_BUCKET_NAME

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestOzoneRpcClientAbstract.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestOzoneRpcClientAbstract.java
@@ -420,37 +420,37 @@ public abstract class TestOzoneRpcClientAbstract {
             () -> store.getVolume(volumeName).getBucket(bucketName)
                 .setQuota(OzoneQuota.parseQuota("0GB", "10")));
     assertTrue(exception.getMessage()
-        .startsWith("Invalid values for space quota"));
+        .startsWith("Invalid value for space quota"));
 
     exception = assertThrows(IllegalArgumentException.class,
         () -> store.getVolume(volumeName).getBucket(bucketName).setQuota(
             OzoneQuota.parseQuota("10GB", "0")));
     assertTrue(exception.getMessage()
-        .startsWith("Invalid values for namespace quota"));
+        .startsWith("Invalid value for namespace quota"));
 
     exception = assertThrows(IllegalArgumentException.class,
         () -> store.getVolume(volumeName).getBucket(bucketName).setQuota(
             OzoneQuota.parseQuota("1GB", "-100")));
     assertTrue(exception.getMessage()
-        .startsWith("Invalid values for namespace quota"));
+        .startsWith("Invalid value for namespace quota"));
 
     exception = assertThrows(IllegalArgumentException.class,
         () -> store.getVolume(volumeName).getBucket(bucketName).setQuota(
             OzoneQuota.parseQuota("1TEST", "100")));
     assertTrue(exception.getMessage()
-        .startsWith("Invalid values for quota"));
+        .startsWith("Invalid value for quota"));
 
     exception = assertThrows(IllegalArgumentException.class,
         () -> store.getVolume(volumeName).getBucket(bucketName).setQuota(
             OzoneQuota.parseQuota("9223372036854775808 BYTES", "100")));
     assertTrue(exception.getMessage()
-        .startsWith("Invalid values for quota"));
+        .startsWith("Invalid value for quota"));
 
     exception = assertThrows(IllegalArgumentException.class,
         () -> store.getVolume(volumeName).getBucket(bucketName).setQuota(
             OzoneQuota.parseQuota("-10GB", "100")));
     assertTrue(exception.getMessage()
-        .startsWith("Invalid values for space quota"));
+        .startsWith("Invalid value for space quota"));
 
   }
 
@@ -491,33 +491,33 @@ public abstract class TestOzoneRpcClientAbstract {
         () -> store.getVolume(volumeName).setQuota(OzoneQuota.parseQuota(
             "0GB", "10")));
     assertTrue(exception.getMessage()
-        .startsWith("Invalid values for space quota"));
+        .startsWith("Invalid value for space quota"));
     exception = assertThrows(IllegalArgumentException.class,
         () -> store.getVolume(volumeName).setQuota(OzoneQuota.parseQuota(
             "10GB", "0")));
     assertTrue(exception.getMessage()
-        .startsWith("Invalid values for namespace quota"));
+        .startsWith("Invalid value for namespace quota"));
 
     // The unit should be legal.
     exception = assertThrows(IllegalArgumentException.class,
         () -> store.getVolume(volumeName).setQuota(OzoneQuota.parseQuota(
             "1TEST", "1000")));
     assertTrue(exception.getMessage()
-        .startsWith("Invalid values for quota"));
+        .startsWith("Invalid value for quota"));
 
     // The setting value cannot be greater than LONG.MAX_VALUE BYTES.
     exception = assertThrows(IllegalArgumentException.class,
         () -> store.getVolume(volumeName).setQuota(OzoneQuota.parseQuota(
             "9223372036854775808 B", "1000")));
     assertTrue(exception.getMessage()
-        .startsWith("Invalid values for quota"));
+        .startsWith("Invalid value for quota"));
 
     // The value cannot be negative.
     exception = assertThrows(IllegalArgumentException.class,
         () -> store.getVolume(volumeName).setQuota(OzoneQuota.parseQuota(
             "-10GB", "1000")));
     assertTrue(exception.getMessage()
-        .startsWith("Invalid values for space quota"));
+        .startsWith("Invalid value for space quota"));
   }
 
   @Test

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestOzoneRpcClientAbstract.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestOzoneRpcClientAbstract.java
@@ -438,13 +438,13 @@ public abstract class TestOzoneRpcClientAbstract {
         () -> store.getVolume(volumeName).getBucket(bucketName).setQuota(
             OzoneQuota.parseQuota("1TEST", "100")));
     assertTrue(exception.getMessage()
-        .startsWith("Invalid value for quota"));
+        .startsWith("1TEST is invalid."));
 
     exception = assertThrows(IllegalArgumentException.class,
         () -> store.getVolume(volumeName).getBucket(bucketName).setQuota(
             OzoneQuota.parseQuota("9223372036854775808 BYTES", "100")));
     assertTrue(exception.getMessage()
-        .startsWith("Invalid value for quota"));
+        .startsWith("9223372036854775808 BYTES is invalid."));
 
     exception = assertThrows(IllegalArgumentException.class,
         () -> store.getVolume(volumeName).getBucket(bucketName).setQuota(
@@ -503,14 +503,14 @@ public abstract class TestOzoneRpcClientAbstract {
         () -> store.getVolume(volumeName).setQuota(OzoneQuota.parseQuota(
             "1TEST", "1000")));
     assertTrue(exception.getMessage()
-        .startsWith("Invalid value for quota"));
+        .startsWith("1TEST is invalid."));
 
     // The setting value cannot be greater than LONG.MAX_VALUE BYTES.
     exception = assertThrows(IllegalArgumentException.class,
         () -> store.getVolume(volumeName).setQuota(OzoneQuota.parseQuota(
             "9223372036854775808 B", "1000")));
     assertTrue(exception.getMessage()
-        .startsWith("Invalid value for quota"));
+        .startsWith("9223372036854775808 B is invalid."));
 
     // The value cannot be negative.
     exception = assertThrows(IllegalArgumentException.class,

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/shell/TestOzoneShellHA.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/shell/TestOzoneShellHA.java
@@ -919,13 +919,13 @@ public class TestOzoneShellHA {
 
     args = new String[]{"volume", "create", "vol5", "--space-quota", "test"};
     executeWithError(ozoneShell, args, "test is invalid. " +
-        "The quota value should be a positive integer between 1 and Long.MAX_VALUE" +
+        "The quota value should be a positive integer " +
         "with byte numeration(B, KB, MB, GB and TB)");
     out.reset();
 
     args = new String[]{"volume", "create", "vol5", "--space-quota", "1.5GB"};
     executeWithError(ozoneShell, args, "1.5GB is invalid. " +
-        "The quota value should be a positive integer between 1 and Long.MAX_VALUE" +
+        "The quota value should be a positive integer " +
         "with byte numeration(B, KB, MB, GB and TB)");
     out.reset();
 
@@ -959,14 +959,14 @@ public class TestOzoneShellHA {
     args = new String[]{"bucket", "create", "vol5/buck5",
         "--space-quota", "test"};
     executeWithError(ozoneShell, args, "test is invalid. " +
-        "The quota value should be a positive integer between 1 and Long.MAX_VALUE" +
+        "The quota value should be a positive integer " +
         "with byte numeration(B, KB, MB, GB and TB)");
     out.reset();
 
     args = new String[]{"bucket", "create", "vol5/buck5",
         "--space-quota", "1.5GB"};
     executeWithError(ozoneShell, args, "1.5GB is invalid. " +
-        "The quota value should be a positive integer between 1 and Long.MAX_VALUE" +
+        "The quota value should be a positive integer " +
         "with byte numeration(B, KB, MB, GB and TB)");
     out.reset();
 
@@ -1037,7 +1037,7 @@ public class TestOzoneShellHA {
         () -> execute(ozoneShell, volumeArgs3));
     assertTrue(eException.getMessage()
         .contains("test is invalid. " +
-            "The quota value should be a positive integer between 1 and Long.MAX_VALUE" +
+            "The quota value should be a positive integer " +
             "with byte numeration(B, KB, MB, GB and TB)"));
     out.reset();
 
@@ -1047,7 +1047,7 @@ public class TestOzoneShellHA {
         () -> execute(ozoneShell, volumeArgs4));
     assertTrue(eException.getMessage()
         .contains("1.5GB is invalid. " +
-            "The quota value should be a positive integer between 1 and Long.MAX_VALUE" +
+            "The quota value should be a positive integer " +
             "with byte numeration(B, KB, MB, GB and TB)"));
     out.reset();
 
@@ -1099,7 +1099,7 @@ public class TestOzoneShellHA {
         () -> execute(ozoneShell, bucketArgs3));
     assertTrue(eException.getMessage()
         .contains("test is invalid. " +
-            "The quota value should be a positive integer between 1 and Long.MAX_VALUE" +
+            "The quota value should be a positive integer " +
             "with byte numeration(B, KB, MB, GB and TB)"));
     out.reset();
 
@@ -1109,7 +1109,7 @@ public class TestOzoneShellHA {
         () -> execute(ozoneShell, bucketArgs4));
     assertTrue(eException.getMessage()
         .contains("1.5GB is invalid. " +
-            "The quota value should be a positive integer between 1 and Long.MAX_VALUE" +
+            "The quota value should be a positive integer " +
             "with byte numeration(B, KB, MB, GB and TB)"));
     out.reset();
 

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/shell/TestOzoneShellHA.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/shell/TestOzoneShellHA.java
@@ -918,17 +918,15 @@ public class TestOzoneShellHA {
     out.reset();
 
     args = new String[]{"volume", "create", "vol5", "--space-quota", "test"};
-    executeWithError(ozoneShell, args, "Invalid value for quota, " +
-        "to ensure that the Quota format is legal(supported values are " +
-        "B, KB, MB, GB and TB with positive long values). " +
-        "And the quota value cannot be greater than Long.MAX_VALUE BYTES");
+    executeWithError(ozoneShell, args, "test is invalid. " +
+        "The quota value should be a positive integer between 1 and Long.MAX_VALUE" +
+        "with byte numeration(B, KB, MB, GB and TB)");
     out.reset();
 
     args = new String[]{"volume", "create", "vol5", "--space-quota", "1.5GB"};
-    executeWithError(ozoneShell, args, "Invalid value for quota, " +
-        "to ensure that the Quota format is legal(supported values are " +
-        "B, KB, MB, GB and TB with positive long values). " +
-        "And the quota value cannot be greater than Long.MAX_VALUE BYTES");
+    executeWithError(ozoneShell, args, "1.5GB is invalid. " +
+        "The quota value should be a positive integer between 1 and Long.MAX_VALUE" +
+        "with byte numeration(B, KB, MB, GB and TB)");
     out.reset();
 
     args = new String[]{"volume", "create", "vol5", "--namespace-quota"};
@@ -960,18 +958,16 @@ public class TestOzoneShellHA {
 
     args = new String[]{"bucket", "create", "vol5/buck5",
         "--space-quota", "test"};
-    executeWithError(ozoneShell, args, "Invalid value for quota, " +
-        "to ensure that the Quota format is legal(supported values are " +
-        "B, KB, MB, GB and TB with positive long values). " +
-        "And the quota value cannot be greater than Long.MAX_VALUE BYTES");
+    executeWithError(ozoneShell, args, "test is invalid. " +
+        "The quota value should be a positive integer between 1 and Long.MAX_VALUE" +
+        "with byte numeration(B, KB, MB, GB and TB)");
     out.reset();
 
     args = new String[]{"bucket", "create", "vol5/buck5",
         "--space-quota", "1.5GB"};
-    executeWithError(ozoneShell, args, "Invalid value for quota, " +
-        "to ensure that the Quota format is legal(supported values are " +
-        "B, KB, MB, GB and TB with positive long values). " +
-        "And the quota value cannot be greater than Long.MAX_VALUE BYTES");
+    executeWithError(ozoneShell, args, "1.5GB is invalid. " +
+        "The quota value should be a positive integer between 1 and Long.MAX_VALUE" +
+        "with byte numeration(B, KB, MB, GB and TB)");
     out.reset();
 
     args = new String[]{"bucket", "create", "vol5/buck5", "--namespace-quota"};
@@ -1040,7 +1036,9 @@ public class TestOzoneShellHA {
     eException = assertThrows(ExecutionException.class,
         () -> execute(ozoneShell, volumeArgs3));
     assertTrue(eException.getMessage()
-        .contains("Invalid value for quota"));
+        .contains("test is invalid. " +
+            "The quota value should be a positive integer between 1 and Long.MAX_VALUE" +
+            "with byte numeration(B, KB, MB, GB and TB)"));
     out.reset();
 
     String[] volumeArgs4 = new String[]{"volume", "setquota", "vol4",
@@ -1048,7 +1046,9 @@ public class TestOzoneShellHA {
     eException = assertThrows(ExecutionException.class,
         () -> execute(ozoneShell, volumeArgs4));
     assertTrue(eException.getMessage()
-        .contains("Invalid value for quota"));
+        .contains("1.5GB is invalid. " +
+            "The quota value should be a positive integer between 1 and Long.MAX_VALUE" +
+            "with byte numeration(B, KB, MB, GB and TB)"));
     out.reset();
 
     String[] volumeArgs5 = new String[]{"volume", "setquota", "vol4",
@@ -1098,7 +1098,9 @@ public class TestOzoneShellHA {
     eException = assertThrows(ExecutionException.class,
         () -> execute(ozoneShell, bucketArgs3));
     assertTrue(eException.getMessage()
-        .contains("Invalid value for quota"));
+        .contains("test is invalid. " +
+            "The quota value should be a positive integer between 1 and Long.MAX_VALUE" +
+            "with byte numeration(B, KB, MB, GB and TB)"));
     out.reset();
 
     String[] bucketArgs4 = new String[]{"bucket", "setquota", "vol4/buck4",
@@ -1106,7 +1108,9 @@ public class TestOzoneShellHA {
     eException = assertThrows(ExecutionException.class,
         () -> execute(ozoneShell, bucketArgs4));
     assertTrue(eException.getMessage()
-        .contains("Invalid value for quota"));
+        .contains("1.5GB is invalid. " +
+            "The quota value should be a positive integer between 1 and Long.MAX_VALUE" +
+            "with byte numeration(B, KB, MB, GB and TB)"));
     out.reset();
 
     String[] bucketArgs5 = new String[]{"bucket", "setquota", "vol4/buck4",

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/shell/TestOzoneShellHA.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/shell/TestOzoneShellHA.java
@@ -919,7 +919,7 @@ public class TestOzoneShellHA {
     ExecutionException eException = assertThrows(ExecutionException.class,
         () -> execute(ozoneShell, volumeArgs1));
     assertTrue(eException.getMessage()
-        .contains("Invalid values for space quota"));
+        .contains("Invalid value for space quota"));
     out.reset();
 
     String[] volumeArgs2 = new String[]{"volume", "setquota", "vol4",
@@ -927,7 +927,7 @@ public class TestOzoneShellHA {
     eException = assertThrows(ExecutionException.class,
         () -> execute(ozoneShell, volumeArgs2));
     assertTrue(eException.getMessage()
-        .contains("Invalid values for namespace quota"));
+        .contains("Invalid value for namespace quota"));
     out.reset();
 
     // Test set bucket quota to 0.
@@ -936,7 +936,7 @@ public class TestOzoneShellHA {
     eException = assertThrows(ExecutionException.class,
         () -> execute(ozoneShell, bucketArgs1));
     assertTrue(eException.getMessage()
-        .contains("Invalid values for space quota"));
+        .contains("Invalid value for space quota"));
     out.reset();
 
     String[] bucketArgs2 = new String[]{"bucket", "setquota", "vol4/buck4",
@@ -944,7 +944,7 @@ public class TestOzoneShellHA {
     eException = assertThrows(ExecutionException.class,
         () -> execute(ozoneShell, bucketArgs2));
     assertTrue(eException.getMessage()
-        .contains("Invalid values for namespace quota"));
+        .contains("Invalid value for namespace quota"));
     out.reset();
 
     // Test set bucket spaceQuota or nameSpaceQuota to normal value.


### PR DESCRIPTION
## What changes were proposed in this pull request?

Return proper error message thrown when text/decimal is supplied as a parameter for namespace-quota

Issue observed -
```
# ozone sh bucket create vol1/buck5 --namespace-quota test
For input string: "test"
# ozone sh volume create vol2 --namespace-quota test
For input string: "test"
# ozone sh bucket setquota vol1/buck1 --namespace-quota test
For input string: "test"
# ozone sh volume setquota vol1 --namespace-quota test
For input string: "test" 
# ozone sh bucket create vol1/buck6 --namespace-quota 1.5
For input string: "1.5" 
```
Solution provided -
```
bash-4.2$ ozone sh volume create vol1 --namespace-quota test
test is invalid. The quota value should be a positive integer between 1 and Long.MAX_VALUE
bash-4.2$ ozone sh volume create vol1 --space-quota test
test is invalid. The quota value should be a positive integer between 1 and Long.MAX_VALUEwith byte numeration(B, KB, MB, GB and TB)
bash-4.2$ ozone sh volume create vol1 --space-quota 1.5GB
1.5GB is invalid. The quota value should be a positive integer between 1 and Long.MAX_VALUEwith byte numeration(B, KB, MB, GB and TB)
bash-4.2$ ozone sh volume create vol1 --namespace-quota 1.5
1.5 is invalid. The quota value should be a positive integer between 1 and Long.MAX_VALUE
```

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-9278

## How was this patch tested?

Tested manually on docker environment
