### PR TITLE
HDDS-9286. Migrate TestSecureOzoneCluster to JUnit5

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/TestSecureOzoneCluster.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/TestSecureOzoneCluster.java
@@ -401,7 +401,7 @@ final class TestSecureOzoneCluster {
         IOException ioException = assertThrows(IOException.class,
             securityClient::getCACertificate);
         assertTrue(ioException.getMessage().contains(cannotAuthMessage));
-        assertThrows(IOException.class,
+        ioException = assertThrows(IOException.class,
             () -> securityClient.getCertificate("1"));
         assertTrue(ioException.getMessage().contains(cannotAuthMessage));
       }


### PR DESCRIPTION
## What changes were proposed in this pull request?

 * Upgrade `TestSecureOzoneCluster` to JUnit5.
 * Mark `testDelegationTokenRenewCrossCertificateRenew` as flaky.

https://issues.apache.org/jira/browse/HDDS-9286

## How was this patch tested?

https://github.com/adoroszlai/hadoop-ozone/actions/runs/6186500594/job/16794302198#step:5:3790
https://github.com/adoroszlai/hadoop-ozone/actions/runs/6186500594/job/16794304438#step:6:3780