### PR TITLE
HDDS-9281. The DatanodeCommand sent in LegacyReplicationManager does not set the deadline

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/LegacyReplicationManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/LegacyReplicationManager.java
@@ -1625,6 +1625,7 @@ public class LegacyReplicationManager {
     }
     final CommandForDatanode<T> datanodeCommand =
         new CommandForDatanode<>(datanode.getUuid(), command);
+    command.setDeadline(clock.millis() + rmConf.getEventTimeout());
     eventPublisher.fireEvent(SCMEvents.DATANODE_COMMAND, datanodeCommand);
     return true;
   }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ReplicationManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ReplicationManager.java
@@ -651,7 +651,7 @@ public class ReplicationManager implements SCMService {
   public void sendDatanodeCommand(SCMCommand<?> command,
       ContainerInfo containerInfo, DatanodeDetails target)
       throws NotLeaderException {
-    long scmDeadline = clock.millis() + rmConf.eventTimeout;
+    long scmDeadline = clock.millis() + rmConf.getEventTimeout();
     sendDatanodeCommand(command, containerInfo, target, scmDeadline);
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

When a datanode is shutdown and the node deadline is exceeded, the state of the node is changed to DEAD, and the replication manager of the SCM schedules the replenishment of the replica of the container that the node is responsible for.

When the machine has more data and fewer nodes, other datanode nodes will receive too many replication tasks and queue them for execution. When the datanode is restarted during the execution process and reports the container it is responsible for to the SCM, these replication tasks will still be executed in the queue.

I know that each datanode command has a deadline, and I don't see it set in LegacyReplicationManager; it's set in ReplicationManager, and if LegacyReplicationManager is also set If LegacyReplicationManager also sets deadline, then the replication task on datanode will not be executed when it reaches deadline.

For a more detailed description see jira.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-9281

