### PR TITLE
HDDS-7743. [Snapshot] Implement snapshot disk usage.

### DIFF
--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/OmUtils.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/OmUtils.java
@@ -321,6 +321,7 @@ public final class OmUtils {
     case SnapshotPurge:
     case RecoverLease:
     case SetTimes:
+    case SnapshotUpdateSize:
     case UnknownCommand:
       return false;
     default:

--- a/hadoop-ozone/interface-client/src/main/proto/OmClientProtocol.proto
+++ b/hadoop-ozone/interface-client/src/main/proto/OmClientProtocol.proto
@@ -141,6 +141,7 @@ enum Type {
   CancelSnapshotDiff = 123;
   SetSafeMode = 124;
   PrintCompactionLogDag = 125;
+  SnapshotUpdateSize = 126;
 }
 
 enum SafeMode {
@@ -272,6 +273,7 @@ message OMRequest {
   optional CancelSnapshotDiffRequest        CancelSnapshotDiffRequest      = 123;
   optional SetSafeModeRequest               SetSafeModeRequest             = 124;
   optional PrintCompactionLogDagRequest     PrintCompactionLogDagRequest   = 125;
+  optional SnapshotUpdateSizeRequest        SnapshotUpdateSizeRequest      = 126;
 }
 
 message OMResponse {
@@ -388,6 +390,7 @@ message OMResponse {
   optional CancelSnapshotDiffResponse        cancelSnapshotDiffResponse    = 123;
   optional SetSafeModeResponse               SetSafeModeResponse           = 124;
   optional PrintCompactionLogDagResponse     PrintCompactionLogDagResponse = 125;
+  optional SnapshotUpdateSizeResponse        SnapshotUpdateSizeResponse    = 126;
 }
 
 enum Status {
@@ -1815,6 +1818,16 @@ message SnapshotPurgeRequest {
   repeated string updatedSnapshotDBKey = 2;
 }
 
+message SnapshotUpdateSizeRequest {
+  repeated SnapshotSize snapshotSize = 1;
+}
+
+message SnapshotSize {
+  optional string snapshotKey = 1;
+  optional uint64 exclusiveSize = 2;
+  optional uint64 exclusiveReplicatedSize = 3;
+}
+
 message DeleteTenantRequest {
     optional string tenantId = 1;
 }
@@ -1897,6 +1910,10 @@ message SnapshotMoveDeletedKeysResponse {
 }
 
 message SnapshotPurgeResponse {
+
+}
+
+message SnapshotUpdateSizeResponse {
 
 }
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/utils/OzoneManagerRatisUtils.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/utils/OzoneManagerRatisUtils.java
@@ -77,6 +77,7 @@ import org.apache.hadoop.ozone.om.request.snapshot.OMSnapshotCreateRequest;
 import org.apache.hadoop.ozone.om.request.snapshot.OMSnapshotDeleteRequest;
 import org.apache.hadoop.ozone.om.request.snapshot.OMSnapshotMoveDeletedKeysRequest;
 import org.apache.hadoop.ozone.om.request.snapshot.OMSnapshotPurgeRequest;
+import org.apache.hadoop.ozone.om.request.snapshot.OMSnapshotUpdateSizeRequest;
 import org.apache.hadoop.ozone.om.request.upgrade.OMCancelPrepareRequest;
 import org.apache.hadoop.ozone.om.request.upgrade.OMFinalizeUpgradeRequest;
 import org.apache.hadoop.ozone.om.request.upgrade.OMPrepareRequest;
@@ -224,6 +225,8 @@ public final class OzoneManagerRatisUtils {
       return new OMSnapshotMoveDeletedKeysRequest(omRequest);
     case SnapshotPurge:
       return new OMSnapshotPurgeRequest(omRequest);
+    case SnapshotUpdateSize:
+      return new OMSnapshotUpdateSizeRequest(omRequest);
     case DeleteOpenKeys:
       BucketLayout bktLayout = BucketLayout.DEFAULT;
       if (omRequest.getDeleteOpenKeysRequest().hasBucketLayout()) {

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/snapshot/OMSnapshotUpdateSizeRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/snapshot/OMSnapshotUpdateSizeRequest.java
@@ -1,0 +1,98 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.ozone.om.request.snapshot;
+
+import org.apache.hadoop.hdds.utils.db.cache.CacheKey;
+import org.apache.hadoop.hdds.utils.db.cache.CacheValue;
+import org.apache.hadoop.ozone.om.OMMetadataManager;
+import org.apache.hadoop.ozone.om.OzoneManager;
+import org.apache.hadoop.ozone.om.helpers.SnapshotInfo;
+import org.apache.hadoop.ozone.om.ratis.utils.OzoneManagerDoubleBufferHelper;
+import org.apache.hadoop.ozone.om.request.OMClientRequest;
+import org.apache.hadoop.ozone.om.request.util.OmResponseUtil;
+import org.apache.hadoop.ozone.om.response.OMClientResponse;
+import org.apache.hadoop.ozone.om.response.snapshot.OMSnapshotUpdateSizeResponse;
+import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos;
+import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMRequest;
+import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.SnapshotSize;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Updates the exclusive size of the snapshot.
+ */
+public class OMSnapshotUpdateSizeRequest extends OMClientRequest {
+
+  public OMSnapshotUpdateSizeRequest(OMRequest omRequest) {
+    super(omRequest);
+  }
+
+  @Override
+  public OMClientResponse validateAndUpdateCache(OzoneManager ozoneManager,
+      long trxnLogIndex, OzoneManagerDoubleBufferHelper omDoubleBufferHelper) {
+
+    OMClientResponse omClientResponse = null;
+    OMMetadataManager metadataManager = ozoneManager.getMetadataManager();
+
+    OzoneManagerProtocolProtos.OMResponse.Builder omResponse =
+        OmResponseUtil.getOMResponseBuilder(getOmRequest());
+    OzoneManagerProtocolProtos.SnapshotUpdateSizeRequest
+        snapshotUpdateSizeRequest = getOmRequest()
+        .getSnapshotUpdateSizeRequest();
+
+    List<SnapshotSize> snapshotSizeList = snapshotUpdateSizeRequest
+        .getSnapshotSizeList();
+    Map<String, SnapshotInfo> updatedSnapInfos = new HashMap<>();
+
+    try {
+      for (SnapshotSize snapshotSize: snapshotSizeList) {
+        String snapshotKey = snapshotSize.getSnapshotKey();
+        long exclusiveSize = snapshotSize.getExclusiveSize();
+        long exclusiveReplicatedSize = snapshotSize
+            .getExclusiveReplicatedSize();
+        SnapshotInfo snapshotInfo = metadataManager
+            .getSnapshotInfoTable().get(snapshotKey);
+
+        if (snapshotInfo == null) {
+          continue;
+        }
+
+        // Set Exclusive size.
+        snapshotInfo.setExclusiveSize(exclusiveSize);
+        snapshotInfo.setExclusiveReplicatedSize(exclusiveReplicatedSize);
+        // Update Table Cache
+        metadataManager.getSnapshotInfoTable().addCacheEntry(
+            new CacheKey<>(snapshotKey),
+            CacheValue.get(trxnLogIndex, snapshotInfo));
+        updatedSnapInfos.put(snapshotKey, snapshotInfo);
+      }
+      omClientResponse = new OMSnapshotUpdateSizeResponse(
+          omResponse.build(), updatedSnapInfos);
+    } catch (IOException ex) {
+      omClientResponse = new OMSnapshotUpdateSizeResponse(
+          createErrorOMResponse(omResponse, ex));
+    } finally {
+      addResponseToDoubleBuffer(trxnLogIndex, omClientResponse,
+          omDoubleBufferHelper);
+    }
+    return omClientResponse;
+  }
+}

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/snapshot/OMSnapshotUpdateSizeResponse.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/snapshot/OMSnapshotUpdateSizeResponse.java
@@ -1,0 +1,67 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.ozone.om.response.snapshot;
+
+import org.apache.hadoop.hdds.utils.db.BatchOperation;
+import org.apache.hadoop.ozone.om.OMMetadataManager;
+import org.apache.hadoop.ozone.om.OmMetadataManagerImpl;
+import org.apache.hadoop.ozone.om.helpers.SnapshotInfo;
+import org.apache.hadoop.ozone.om.response.CleanupTableInfo;
+import org.apache.hadoop.ozone.om.response.OMClientResponse;
+import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMResponse;
+
+
+import javax.annotation.Nonnull;
+import java.io.IOException;
+import java.util.Map;
+
+import static org.apache.hadoop.ozone.om.OmMetadataManagerImpl.SNAPSHOT_INFO_TABLE;
+
+/**
+ * Response for OMSnapshotUpdateSizeRequest.
+ */
+@CleanupTableInfo(cleanupTables = {SNAPSHOT_INFO_TABLE})
+public class OMSnapshotUpdateSizeResponse extends OMClientResponse {
+  private final Map<String, SnapshotInfo> updatedSnapInfos;
+
+  public OMSnapshotUpdateSizeResponse(
+      @Nonnull OMResponse omResponse,
+      Map<String, SnapshotInfo> updatedSnapInfos) {
+    super(omResponse);
+    this.updatedSnapInfos = updatedSnapInfos;
+  }
+
+  public OMSnapshotUpdateSizeResponse(@Nonnull OMResponse omResponse) {
+    super(omResponse);
+    checkStatusNotOK();
+    this.updatedSnapInfos = null;
+  }
+
+  @Override
+  protected void addToDBBatch(OMMetadataManager omMetadataManager,
+                              BatchOperation batchOperation)
+      throws IOException {
+    OmMetadataManagerImpl metadataManager = (OmMetadataManagerImpl)
+        omMetadataManager;
+    for (Map.Entry<String, SnapshotInfo> entry : updatedSnapInfos.entrySet()) {
+      metadataManager.getSnapshotInfoTable().putWithBatch(batchOperation,
+          entry.getKey(), entry.getValue());
+    }
+  }
+}

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/snapshot/TestOMSnapshotSizeRequestAndResponse.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/snapshot/TestOMSnapshotSizeRequestAndResponse.java
@@ -1,0 +1,185 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package org.apache.hadoop.ozone.om.request.snapshot;
+
+import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import org.apache.hadoop.hdds.utils.db.BatchOperation;
+import org.apache.hadoop.hdds.utils.db.Table;
+import org.apache.hadoop.hdds.utils.db.TableIterator;
+import org.apache.hadoop.hdds.utils.db.cache.CacheKey;
+import org.apache.hadoop.hdds.utils.db.cache.CacheValue;
+import org.apache.hadoop.ozone.OzoneConfigKeys;
+import org.apache.hadoop.ozone.om.OMConfigKeys;
+import org.apache.hadoop.ozone.om.OMMetadataManager;
+import org.apache.hadoop.ozone.om.OmMetadataManagerImpl;
+import org.apache.hadoop.ozone.om.OzoneManager;
+import org.apache.hadoop.ozone.om.helpers.SnapshotInfo;
+import org.apache.hadoop.ozone.om.ratis.utils.OzoneManagerDoubleBufferHelper;
+import org.apache.hadoop.ozone.om.request.OMRequestTestUtils;
+
+import org.apache.hadoop.ozone.om.response.snapshot.OMSnapshotUpdateSizeResponse;
+import org.apache.hadoop.ozone.om.upgrade.OMLayoutVersionManager;
+import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos;
+import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMRequest;
+import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.SnapshotSize;
+import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.SnapshotUpdateSizeRequest;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.io.TempDir;
+import org.mockito.Mockito;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Tests TestOMSnapshotSizeRequest TestOMSnapshotSizeResponse class.
+ */
+public class TestOMSnapshotSizeRequestAndResponse {
+  private BatchOperation batchOperation;
+  private OzoneManager ozoneManager;
+  private OMMetadataManager omMetadataManager;
+
+  private String volumeName;
+  private String bucketName;
+  private String snapName;
+  private long exclusiveSize;
+  private long exclusiveSizeAfterRepl;
+
+  // Just setting ozoneManagerDoubleBuffer which does nothing.
+  private static final OzoneManagerDoubleBufferHelper
+      DOUBLE_BUFFER_HELPER = ((response, transactionIndex) -> null);
+
+  @BeforeEach
+  void setup(@TempDir File testDir) throws Exception {
+    ozoneManager = Mockito.mock(OzoneManager.class);
+    OMLayoutVersionManager lvm = mock(OMLayoutVersionManager.class);
+    when(lvm.isAllowed(anyString())).thenReturn(true);
+    when(ozoneManager.getVersionManager()).thenReturn(lvm);
+    when(ozoneManager.isRatisEnabled()).thenReturn(true);
+    OzoneConfiguration ozoneConfiguration = new OzoneConfiguration();
+    ozoneConfiguration.set(OMConfigKeys.OZONE_OM_DB_DIRS,
+        testDir.getAbsolutePath());
+    ozoneConfiguration.set(OzoneConfigKeys.OZONE_METADATA_DIRS,
+        testDir.getAbsolutePath());
+    omMetadataManager = new OmMetadataManagerImpl(ozoneConfiguration,
+        ozoneManager);
+    when(ozoneManager.getMetadataManager()).thenReturn(omMetadataManager);
+
+    volumeName = UUID.randomUUID().toString();
+    bucketName = UUID.randomUUID().toString();
+    snapName = UUID.randomUUID().toString();
+    exclusiveSize = 2000L;
+    exclusiveSizeAfterRepl = 6000L;
+  }
+
+  @Test
+  public void testValidateAndUpdateCache() throws IOException {
+    createSnapshotDataForTest();
+    assertFalse(omMetadataManager.getSnapshotInfoTable().isEmpty());
+    OzoneManagerProtocolProtos.OMRequest snapshotUpdateSizeRequest =
+        createSnapshotUpdateSizeRequest();
+
+    // Pre-Execute
+    OMSnapshotUpdateSizeRequest omSnapshotUpdateSizeRequest = new
+        OMSnapshotUpdateSizeRequest(snapshotUpdateSizeRequest);
+    OMRequest modifiedOmRequest = omSnapshotUpdateSizeRequest
+        .preExecute(ozoneManager);
+    omSnapshotUpdateSizeRequest = new
+        OMSnapshotUpdateSizeRequest(modifiedOmRequest);
+
+    // Validate and Update Cache
+    OMSnapshotUpdateSizeResponse omSnapshotUpdateSizeResponse =
+        (OMSnapshotUpdateSizeResponse) omSnapshotUpdateSizeRequest
+            .validateAndUpdateCache(ozoneManager, 200L,
+            DOUBLE_BUFFER_HELPER);
+
+    // Commit to DB.
+    batchOperation = omMetadataManager.getStore().initBatchOperation();
+    omSnapshotUpdateSizeResponse.checkAndUpdateDB(omMetadataManager,
+        batchOperation);
+    omMetadataManager.getStore().commitBatchOperation(batchOperation);
+
+    // Check if the exclusive size is set.
+    try (TableIterator<String, ? extends Table.KeyValue<String, SnapshotInfo>>
+             iterator = omMetadataManager.getSnapshotInfoTable().iterator()) {
+      while (iterator.hasNext()) {
+        Table.KeyValue<String, SnapshotInfo> snapshotEntry = iterator.next();
+        assertCacheValues(snapshotEntry.getKey());
+        assertEquals(exclusiveSize, snapshotEntry.getValue().
+            getExclusiveSize());
+        assertEquals(exclusiveSizeAfterRepl, snapshotEntry.getValue()
+            .getExclusiveReplicatedSize());
+      }
+    }
+  }
+
+  private void assertCacheValues(String dbKey) {
+    CacheValue<SnapshotInfo> cacheValue = omMetadataManager
+        .getSnapshotInfoTable()
+        .getCacheValue(new CacheKey<>(dbKey));
+    assertEquals(exclusiveSize, cacheValue.getCacheValue().getExclusiveSize());
+    assertEquals(exclusiveSizeAfterRepl, cacheValue.getCacheValue()
+        .getExclusiveReplicatedSize());
+  }
+
+  private OMRequest createSnapshotUpdateSizeRequest() throws IOException {
+    List<SnapshotSize> snapshotSizeList = new ArrayList<>();
+    try (TableIterator<String, ? extends Table.KeyValue<String, SnapshotInfo>>
+             iterator = omMetadataManager.getSnapshotInfoTable().iterator()) {
+      while (iterator.hasNext()) {
+        String snapDbKey = iterator.next().getKey();
+        SnapshotSize snapshotSize = SnapshotSize.newBuilder()
+            .setSnapshotKey(snapDbKey)
+            .setExclusiveSize(exclusiveSize)
+            .setExclusiveReplicatedSize(exclusiveSizeAfterRepl)
+            .build();
+        snapshotSizeList.add(snapshotSize);
+      }
+    }
+    SnapshotUpdateSizeRequest snapshotUpdateSizeRequest =
+        SnapshotUpdateSizeRequest.newBuilder()
+            .addAllSnapshotSize(snapshotSizeList)
+            .build();
+
+    OMRequest omRequest = OMRequest.newBuilder()
+        .setCmdType(OzoneManagerProtocolProtos.Type.SnapshotUpdateSize)
+        .setSnapshotUpdateSizeRequest(snapshotUpdateSizeRequest)
+        .setClientId(UUID.randomUUID().toString())
+        .build();
+
+    return omRequest;
+  }
+
+  private void createSnapshotDataForTest() throws IOException {
+    // Create 10 Snapshots
+    for (int i = 0; i < 10; i++) {
+      OMRequestTestUtils.addSnapshotToTableCache(volumeName, bucketName,
+          snapName + i, omMetadataManager);
+    }
+  }
+}

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/service/TestKeyDeletingService.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/service/TestKeyDeletingService.java
@@ -24,12 +24,15 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.stream.Collectors;
 
+import org.apache.hadoop.hdds.client.RatisReplicationConfig;
 import org.apache.hadoop.hdds.utils.db.Table;
 import org.apache.hadoop.hdds.utils.db.TableIterator;
 import org.apache.hadoop.ozone.om.IOmMetadataReader;
@@ -71,6 +74,7 @@ import org.apache.hadoop.hdds.utils.db.DBConfigFromFile;
 
 import org.apache.commons.lang3.RandomStringUtils;
 import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_CONTAINER_REPORT_INTERVAL;
+import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationFactor.THREE;
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_BLOCK_DELETING_SERVICE_INTERVAL;
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_SNAPSHOT_DELETING_SERVICE_INTERVAL;
 import static org.apache.hadoop.ozone.om.OmSnapshotManager.getSnapshotPrefix;
@@ -550,15 +554,126 @@ t
 
       // 5 keys can be deep cleaned as it was stuck previously
       assertTableRowCount(snap3deletedTable, 10, metadataManager);
-      checkSnapDeepCleanStatus(snapshotInfoTable, false);
 
       writeClient.deleteSnapshot(volumeName, bucketName, "snap2");
       assertTableRowCount(snapshotInfoTable, 2, metadataManager);
 
       assertTableRowCount(snap3deletedTable, 0, metadataManager);
       assertTableRowCount(deletedTable, 0, metadataManager);
+      checkSnapDeepCleanStatus(snapshotInfoTable, false);
     }
 
+  }
+
+  @Test
+  public void testSnapshotExclusiveSize() throws Exception {
+    OzoneConfiguration conf = createConfAndInitValues();
+    OmTestManagers omTestManagers
+        = new OmTestManagers(conf);
+    KeyManager keyManager = omTestManagers.getKeyManager();
+    writeClient = omTestManagers.getWriteClient();
+    om = omTestManagers.getOzoneManager();
+    OMMetadataManager metadataManager = omTestManagers.getMetadataManager();
+    Table<String, SnapshotInfo> snapshotInfoTable =
+        om.getMetadataManager().getSnapshotInfoTable();
+    Table<String, RepeatedOmKeyInfo> deletedTable =
+        om.getMetadataManager().getDeletedTable();
+    Table<String, String> renamedTable =
+        om.getMetadataManager().getSnapshotRenamedTable();
+    Table<String, OmKeyInfo> keyTable =
+        om.getMetadataManager().getKeyTable(BucketLayout.DEFAULT);
+
+    KeyDeletingService keyDeletingService = keyManager.getDeletingService();
+    // Supspend KDS
+    keyDeletingService.suspend();
+
+    String volumeName = "volume1";
+    String bucketName = "bucket1";
+    String keyName = "key";
+
+    // Create Volume and Buckets
+    createVolumeAndBucket(keyManager, volumeName, bucketName, false);
+
+    // Create 3 keys
+    for (int i = 1; i <= 3; i++) {
+      createAndCommitKey(keyManager, volumeName, bucketName, keyName + i, 3);
+    }
+    assertTableRowCount(keyTable, 3, metadataManager);
+
+    // Create Snapshot1
+    writeClient.createSnapshot(volumeName, bucketName, "snap1");
+    assertTableRowCount(snapshotInfoTable, 1, metadataManager);
+    assertTableRowCount(deletedTable, 0, metadataManager);
+
+    // Create 2 keys
+    for (int i = 4; i <= 5; i++) {
+      createAndCommitKey(keyManager, volumeName, bucketName, keyName + i, 3);
+    }
+    // Delete a key, rename 2 keys. We will be using this to test
+    // how we handle renamed key for exclusive size calculation.
+    renameKey(volumeName, bucketName, keyName + 1, "renamedKey1");
+    renameKey(volumeName, bucketName, keyName + 2, "renamedKey2");
+    deleteKey(volumeName, bucketName, keyName + 3);
+    assertTableRowCount(deletedTable, 1, metadataManager);
+    assertTableRowCount(renamedTable, 2, metadataManager);
+
+    // Create Snapshot2
+    writeClient.createSnapshot(volumeName, bucketName, "snap2");
+    assertTableRowCount(snapshotInfoTable, 2, metadataManager);
+    assertTableRowCount(deletedTable, 0, metadataManager);
+
+    // Create 2 keys
+    for (int i = 6; i <= 7; i++) {
+      createAndCommitKey(keyManager, volumeName, bucketName, keyName + i, 3);
+    }
+
+    deleteKey(volumeName, bucketName, "renamedKey1");
+    deleteKey(volumeName, bucketName, "key4");
+    // Do a second rename of already renamedKey2
+    renameKey(volumeName, bucketName, "renamedKey2", "renamedKey22");
+    assertTableRowCount(deletedTable, 2, metadataManager);
+    assertTableRowCount(renamedTable, 1, metadataManager);
+
+    // Create Snapshot3
+    writeClient.createSnapshot(volumeName, bucketName, "snap3");
+    // Delete 4 keys
+    deleteKey(volumeName, bucketName, "renamedKey22");
+    for (int i = 5; i <= 7; i++) {
+      deleteKey(volumeName, bucketName, keyName + i);
+    }
+
+    // Create Snapshot4
+    writeClient.createSnapshot(volumeName, bucketName, "snap4");
+    createAndCommitKey(keyManager, volumeName, bucketName, "key8", 3);
+    keyDeletingService.resume();
+
+    Map<String, Long> expectedSize = new HashMap<String, Long>() {{
+        put("snap1", 1000L);
+        put("snap2", 1000L);
+        put("snap3", 2000L);
+        put("snap4", 0L);
+      }};
+
+    long prevKdsRunCount = keyDeletingService.getRunCount().get();
+
+    // Let KeyDeletingService to run for some iterations
+    GenericTestUtils.waitFor(
+        () -> (keyDeletingService.getRunCount().get() > prevKdsRunCount + 5),
+        100, 10000);
+
+    // Check if the exclusive size is set.
+    try (TableIterator<String, ? extends Table.KeyValue<String, SnapshotInfo>>
+             iterator = snapshotInfoTable.iterator()) {
+      while (iterator.hasNext()) {
+        Table.KeyValue<String, SnapshotInfo> snapshotEntry = iterator.next();
+        String snapshotName = snapshotEntry.getValue().getName();
+        assertEquals(expectedSize.get(snapshotName), snapshotEntry.getValue().
+            getExclusiveSize());
+        // Since for the test we are using RATIS/THREE
+        assertEquals(expectedSize.get(snapshotName) * 3,
+            snapshotEntry.getValue().getExclusiveReplicatedSize());
+      }
+    }
   }
 
   private void checkSnapDeepCleanStatus(Table<String, SnapshotInfo>
@@ -613,6 +728,37 @@ t
             .build());
   }
 
+  private void deleteKey(String volumeName,
+                         String bucketName,
+                         String keyName) throws IOException {
+    OmKeyArgs keyArg =
+        new OmKeyArgs.Builder()
+            .setVolumeName(volumeName)
+            .setBucketName(bucketName)
+            .setKeyName(keyName)
+            .setAcls(Collections.emptyList())
+            .setReplicationConfig(StandaloneReplicationConfig.getInstance(
+                HddsProtos.ReplicationFactor.THREE))
+            .build();
+    writeClient.deleteKey(keyArg);
+  }
+
+  private void renameKey(String volumeName,
+                         String bucketName,
+                         String keyName,
+                         String toKeyName) throws IOException {
+    OmKeyArgs keyArg =
+        new OmKeyArgs.Builder()
+            .setVolumeName(volumeName)
+            .setBucketName(bucketName)
+            .setKeyName(keyName)
+            .setAcls(Collections.emptyList())
+            .setReplicationConfig(StandaloneReplicationConfig.getInstance(
+                HddsProtos.ReplicationFactor.THREE))
+            .build();
+    writeClient.renameKey(keyArg, toKeyName);
+  }
+
   private OmKeyArgs createAndCommitKey(KeyManager keyManager, String volumeName,
       String bucketName, String keyName, int numBlocks) throws IOException {
     return createAndCommitKey(keyManager, volumeName, bucketName, keyName,
@@ -630,8 +776,8 @@ t
             .setBucketName(bucketName)
             .setKeyName(keyName)
             .setAcls(Collections.emptyList())
-            .setReplicationConfig(StandaloneReplicationConfig.getInstance(
-                HddsProtos.ReplicationFactor.ONE))
+            .setReplicationConfig(RatisReplicationConfig.getInstance(THREE))
+            .setDataSize(1000L)
             .setLocationInfoList(new ArrayList<>())
             .build();
     //Open and Commit the Key in the Key Manager.


### PR DESCRIPTION
## What changes were proposed in this pull request?

The change proposes to add exclusive size for a snapshot. PR #5175 address Reference Size calculation for each Snapshot. I have linked a PDF in the JIRA explaining the design. I have summarized it below for future reference. A Snapshot has 4 size, 

- Reference Size, it is explained here #5175 
- Total Size - Refers to the sum of shared size and exclusive size of the snapshot. This is nothing but the bucket size during snapshot. 
- Shared Size - Refers to data shared between snapshots. Hence this size can’t be quantified as data held by one snapshot but shared between 2 or more snapshots.
- Exclusive Size - Refers to the data held only by that snapshot.

### Calculations: 
### Total Size
We can get `Total Size` from the bucketInfo `omBucketInfo.getUsedBytes()`  in the Snapshot. This gives the total size used by the snapshot. 

**Note:** This give the size of the bucket **after** replication.
### Shared Size
Once we get the Total Size and Exclusive Size we can calculate Shared Size.
`Shared Size = Total Size - Exclusive Size`
### Exclusive Size
To calculate `Exclusive Size` for current snapshot, Check the next snapshot `deletedTable` if the deleted key is **referenced** in current snapshot and **not referenced** in the previous snapshot then that key is exclusive to the current snapshot.

## Things to do in follow-up PRs

- Expand `deletedDirTable` for all the snapshot.
- Update the code to accommodate files moved to `deleteTable` and calculate Exclusive size. 

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-7743

## How was this patch tested?

Added New Unit Test and Integration test. 
