### PR TITLE
HDDS-9295. Avoid overriding finalize() in CodecBuffer.

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/utils/db/CodecBuffer.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/utils/db/CodecBuffer.java
@@ -71,7 +71,7 @@ public class CodecBuffer implements AutoCloseable {
       return new CodecBuffer(buf) {
         @Override
         protected void finalize() {
-          finalizeImpl();
+          detectLeaks();
         }
       };
     }
@@ -189,10 +189,15 @@ public class CodecBuffer implements AutoCloseable {
   }
 
   /**
-   * Provide an implementation of the {@link #finalize()} method.
+   * Detect buffer leak by asserting that the underlying buffer is released
+   * when this object is garbage collected.
+   * This method may be invoked inside the {@link #finalize()} method
+   * or using a {@link java.lang.ref.ReferenceQueue}.
    * For performance reason, this class does not override {@link #finalize()}.
+   *
+   * @see #enableLeakDetection()
    */
-  void finalizeImpl() {
+  void detectLeaks() {
     // leak detection
     final int capacity = buf.capacity();
     if (!released.isDone() && capacity > 0) {

--- a/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/utils/db/CodecTestUtil.java
+++ b/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/utils/db/CodecTestUtil.java
@@ -36,7 +36,7 @@ public final class CodecTestUtil {
   /**
    * Force gc to check leakage.
    */
-  static void gc() throws InterruptedException {
+  public static void gc() throws InterruptedException {
     // use WeakReference to detect gc
     Object obj = new Object();
     final WeakReference<Object> weakRef = new WeakReference<>(obj);

--- a/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/utils/db/TestLeakDetector.java
+++ b/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/utils/db/TestLeakDetector.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hdds.utils.db;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test {@link CodecBuffer.LeakDetector}.
+ */
+public final class TestLeakDetector {
+  @Test
+  public void test() throws Exception {
+    CodecBuffer.enableLeakDetection();
+    // allocate a buffer and then release it.
+    CodecBuffer.allocateHeap(2).release();
+    // no leak at this point.
+    CodecTestUtil.gc();
+
+    // allocate a buffer but NOT release it.
+    CodecBuffer.allocateHeap(3);
+    // It should detect a buffer leak.
+    final AssertionError e = Assertions.assertThrows(AssertionError.class, CodecTestUtil::gc);
+    e.printStackTrace(System.out);
+    Assertions.assertTrue(e.getMessage().startsWith("Found 1 leak"));
+  }
+}

--- a/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/utils/db/TestLeakDetector.java
+++ b/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/utils/db/TestLeakDetector.java
@@ -35,7 +35,8 @@ public final class TestLeakDetector {
     // allocate a buffer but NOT release it.
     CodecBuffer.allocateHeap(3);
     // It should detect a buffer leak.
-    final AssertionError e = Assertions.assertThrows(AssertionError.class, CodecTestUtil::gc);
+    final AssertionError e = Assertions.assertThrows(
+        AssertionError.class, CodecTestUtil::gc);
     e.printStackTrace(System.out);
     Assertions.assertTrue(e.getMessage().startsWith("Found 1 leak"));
   }

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/TestBlockDeletingService.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/TestBlockDeletingService.java
@@ -143,6 +143,8 @@ public class TestBlockDeletingService {
 
   @Before
   public void init() throws IOException {
+    CodecBuffer.enableLeakDetection();
+
     testRoot = GenericTestUtils
         .getTestDir(TestBlockDeletingService.class.getSimpleName());
     if (testRoot.exists()) {

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/TestKeyValueContainer.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/TestKeyValueContainer.java
@@ -138,6 +138,8 @@ public class TestKeyValueContainer {
 
   @Before
   public void setUp() throws Exception {
+    CodecBuffer.enableLeakDetection();
+
     DatanodeConfiguration dc = CONF.getObject(DatanodeConfiguration.class);
     dc.setAutoCompactionSmallSstFileNum(100);
     dc.setRocksdbDeleteObsoleteFilesPeriod(5000);

--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/utils/TestRDBSnapshotProvider.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/utils/TestRDBSnapshotProvider.java
@@ -88,6 +88,8 @@ public class TestRDBSnapshotProvider {
 
   @BeforeEach
   public void init(@TempDir File tempDir) throws Exception {
+    CodecBuffer.enableLeakDetection();
+
     options = getNewDBOptions();
     configSet = new HashSet<>();
     for (String name : families) {

--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/utils/db/TestCodec.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/utils/db/TestCodec.java
@@ -43,6 +43,10 @@ public final class TestCodec {
   static final Logger LOG = LoggerFactory.getLogger(TestCodec.class);
   static final int NUM_LOOPS = 10;
 
+  static {
+    CodecBuffer.enableLeakDetection();
+  }
+
   @Test
   public void testShortCodec() throws Exception {
     runTestShortCodec((short)0);

--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/utils/db/TestRDBStore.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/utils/db/TestRDBStore.java
@@ -75,6 +75,8 @@ public class TestRDBStore {
 
   @BeforeEach
   public void setUp(@TempDir File tempDir) throws Exception {
+    CodecBuffer.enableLeakDetection();
+
     options = new ManagedDBOptions();
     options.setCreateIfMissing(true);
     options.setCreateMissingColumnFamilies(true);

--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/utils/db/TestRDBStoreCodecBufferIterator.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/utils/db/TestRDBStoreCodecBufferIterator.java
@@ -62,6 +62,7 @@ public class TestRDBStoreCodecBufferIterator {
 
   @BeforeEach
   public void setup() {
+    CodecBuffer.enableLeakDetection();
     rocksIteratorMock = mock(RocksIterator.class);
     managedRocksIterator = newManagedRocksIterator();
     rdbTableMock = mock(RDBTable.class);

--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/utils/db/TestTypedRDBTableStore.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/utils/db/TestTypedRDBTableStore.java
@@ -65,6 +65,8 @@ public class TestTypedRDBTableStore {
 
   @BeforeEach
   public void setUp(@TempDir File tempDir) throws Exception {
+    CodecBuffer.enableLeakDetection();
+
     options = new ManagedDBOptions();
     options.setCreateIfMissing(true);
     options.setCreateMissingColumnFamilies(true);

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/MiniOzoneClusterImpl.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/MiniOzoneClusterImpl.java
@@ -66,6 +66,7 @@ import org.apache.hadoop.hdds.security.symmetric.SecretKeyClient;
 import org.apache.hadoop.hdds.security.x509.certificate.client.CertificateClient;
 import org.apache.hadoop.hdds.utils.IOUtils;
 import org.apache.hadoop.hdds.utils.db.CodecBuffer;
+import org.apache.hadoop.hdds.utils.db.CodecTestUtil;
 import org.apache.hadoop.hdds.utils.db.managed.ManagedRocksObjectMetrics;
 import org.apache.hadoop.metrics2.lib.DefaultMetricsSystem;
 import org.apache.hadoop.ozone.client.OzoneClient;
@@ -119,6 +120,10 @@ public class MiniOzoneClusterImpl implements MiniOzoneCluster {
 
   private static final Logger LOG =
       LoggerFactory.getLogger(MiniOzoneClusterImpl.class);
+
+  static {
+    CodecBuffer.enableLeakDetection();
+  }
 
   private OzoneConfiguration conf;
   private final SCMConfigurator scmConfigurator;
@@ -449,8 +454,8 @@ public class MiniOzoneClusterImpl implements MiniOzoneCluster {
       DefaultMetricsSystem.shutdown();
 
       ManagedRocksObjectMetrics.INSTANCE.assertNoLeaks();
-      CodecBuffer.assertNoLeaks();
-    } catch (IOException e) {
+      CodecTestUtil.gc();
+    } catch (Exception e) {
       LOG.error("Exception while shutting down the cluster.", e);
     }
   }


### PR DESCRIPTION
## What changes were proposed in this pull request?

CodecBuffer overrides the finalize() method for leak detection. It turns out causing a much longer GC time. (Thanks
@duongkame for finding it out.)

This JIRA is to change CodecBuffer not to override finalize(). In the test, we will create a subclass to override CodecBuffer for leak detection.

## What is the link to the Apache JIRA

HDDS-9295

## How was this patch tested?

Added a new test.