### PR TITLE
HDDS-7601. Added new columnFamily: compactionLogTable to store compaction entries

### DIFF
--- a/hadoop-hdds/interface-client/src/main/proto/hdds.proto
+++ b/hadoop-hdds/interface-client/src/main/proto/hdds.proto
@@ -480,3 +480,18 @@ message DeletedBlocksTransactionInfo {
     repeated int64 localID = 3;
     optional int32 count = 4;
 }
+
+message CompactionFileInfoProto {
+    required string fileName = 1;
+    optional string startKey = 2;
+    optional string endKey = 3;
+    optional string columnFamily = 4;
+}
+
+message CompactionLogEntryProto {
+    required uint64 dbSequenceNumber = 1;
+    required uint64 compactionTime = 2;
+    repeated CompactionFileInfoProto inputFileIntoList = 3;
+    repeated CompactionFileInfoProto outputFileIntoList = 4;
+    optional string compactionReason = 5;
+}

--- a/hadoop-hdds/interface-client/src/main/proto/hdds.proto
+++ b/hadoop-hdds/interface-client/src/main/proto/hdds.proto
@@ -482,15 +482,15 @@ message DeletedBlocksTransactionInfo {
 }
 
 message CompactionFileInfoProto {
-    required string fileName = 1;
+    optional string fileName = 1;
     optional string startKey = 2;
     optional string endKey = 3;
     optional string columnFamily = 4;
 }
 
 message CompactionLogEntryProto {
-    required uint64 dbSequenceNumber = 1;
-    required uint64 compactionTime = 2;
+    optional uint64 dbSequenceNumber = 1;
+    optional uint64 compactionTime = 2;
     repeated CompactionFileInfoProto inputFileIntoList = 3;
     repeated CompactionFileInfoProto outputFileIntoList = 4;
     optional string compactionReason = 5;

--- a/hadoop-hdds/rocksdb-checkpoint-differ/src/main/java/org/apache/ozone/compaction/log/CompactionFileInfo.java
+++ b/hadoop-hdds/rocksdb-checkpoint-differ/src/main/java/org/apache/ozone/compaction/log/CompactionFileInfo.java
@@ -21,6 +21,8 @@ package org.apache.ozone.compaction.log;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.util.Preconditions;
 
+import java.util.Objects;
+
 /**
  * Dao to keep SST file information in the compaction log.
  */
@@ -74,8 +76,19 @@ public final class CompactionFileInfo {
 
   public static CompactionFileInfo getFromProtobuf(
       HddsProtos.CompactionFileInfoProto proto) {
-    return new CompactionFileInfo(proto.getFileName(), proto.getStartKey(),
-        proto.getEndKey(), proto.getColumnFamily());
+    Builder builder = new Builder(proto.getFileName());
+
+    if (proto.hasStartKey()) {
+      builder.setStartRange(proto.getStartKey());
+    }
+    if (proto.hasEndKey()) {
+      builder.setEndRange(proto.getEndKey());
+    }
+    if (proto.hasColumnFamily()) {
+      builder.setColumnFamily(proto.getColumnFamily());
+    }
+
+    return builder.build();
   }
 
   @Override
@@ -126,5 +139,26 @@ public final class CompactionFileInfo {
       return new CompactionFileInfo(fileName, startRange, endRange,
           columnFamily);
     }
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof CompactionFileInfo)) {
+      return false;
+    }
+
+    CompactionFileInfo that = (CompactionFileInfo) o;
+    return Objects.equals(fileName, that.fileName) &&
+        Objects.equals(startKey, that.startKey) &&
+        Objects.equals(endKey, that.endKey) &&
+        Objects.equals(columnFamily, that.columnFamily);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(fileName, startKey, endKey, columnFamily);
   }
 }

--- a/hadoop-hdds/rocksdb-checkpoint-differ/src/main/java/org/apache/ozone/compaction/log/CompactionFileInfo.java
+++ b/hadoop-hdds/rocksdb-checkpoint-differ/src/main/java/org/apache/ozone/compaction/log/CompactionFileInfo.java
@@ -19,20 +19,21 @@
 package org.apache.ozone.compaction.log;
 
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
+import org.apache.hadoop.util.Preconditions;
 
 /**
  * Dao to keep SST file information in the compaction log.
  */
-public class CompactionFileInfo {
+public final class CompactionFileInfo {
   private final String fileName;
   private final String startKey;
   private final String endKey;
   private final String columnFamily;
 
-  public CompactionFileInfo(String fileName,
-                            String startRange,
-                            String endRange,
-                            String columnFamily) {
+  private CompactionFileInfo(String fileName,
+                             String startRange,
+                             String endRange,
+                             String columnFamily) {
     this.fileName = fileName;
     this.startKey = startRange;
     this.endKey = endRange;
@@ -81,5 +82,49 @@ public class CompactionFileInfo {
   public String toString() {
     return String.format("fileName: '%s', startKey: '%s', endKey: '%s'," +
         " columnFamily: '%s'", fileName, startKey, endKey, columnFamily);
+  }
+
+  /**
+   * Builder of CompactionFileInfo.
+   */
+  public static class Builder {
+    private final String fileName;
+    private String startRange;
+    private String endRange;
+    private String columnFamily;
+
+    public Builder(String fileName) {
+      Preconditions.checkNotNull(fileName, "FileName is required parameter.");
+      this.fileName = fileName;
+    }
+
+    public Builder setStartRange(String startRange) {
+      this.startRange = startRange;
+      return this;
+    }
+
+    public Builder setEndRange(String endRange) {
+      this.endRange = endRange;
+      return this;
+    }
+
+    public Builder setColumnFamily(String columnFamily) {
+      this.columnFamily = columnFamily;
+      return this;
+    }
+
+    public CompactionFileInfo build() {
+      if ((startRange != null || endRange != null || columnFamily != null) &&
+          (startRange == null || endRange == null || columnFamily == null)) {
+        throw new IllegalArgumentException(
+            String.format("Either all of startRange, endRange and " +
+                    "columnFamily should be non-null or null. " +
+                    "startRange: '%s', endRange: '%s', columnFamily: '%s'.",
+                startRange, endRange, columnFamily));
+      }
+
+      return new CompactionFileInfo(fileName, startRange, endRange,
+          columnFamily);
+    }
   }
 }

--- a/hadoop-hdds/rocksdb-checkpoint-differ/src/main/java/org/apache/ozone/compaction/log/CompactionFileInfo.java
+++ b/hadoop-hdds/rocksdb-checkpoint-differ/src/main/java/org/apache/ozone/compaction/log/CompactionFileInfo.java
@@ -64,10 +64,10 @@ public final class CompactionFileInfo {
       builder = builder.setStartKey(startKey);
     }
     if (endKey != null) {
-      builder = builder.setStartKey(endKey);
+      builder = builder.setEndKey(endKey);
     }
     if (columnFamily != null) {
-      builder = builder.setStartKey(columnFamily);
+      builder = builder.setColumnFamily(columnFamily);
     }
     return builder.build();
   }

--- a/hadoop-hdds/rocksdb-checkpoint-differ/src/main/java/org/apache/ozone/compaction/log/CompactionFileInfo.java
+++ b/hadoop-hdds/rocksdb-checkpoint-differ/src/main/java/org/apache/ozone/compaction/log/CompactionFileInfo.java
@@ -1,0 +1,85 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ozone.compaction.log;
+
+import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
+
+/**
+ * Dao to keep SST file information in the compaction log.
+ */
+public class CompactionFileInfo {
+  private final String fileName;
+  private final String startKey;
+  private final String endKey;
+  private final String columnFamily;
+
+  public CompactionFileInfo(String fileName,
+                            String startRange,
+                            String endRange,
+                            String columnFamily) {
+    this.fileName = fileName;
+    this.startKey = startRange;
+    this.endKey = endRange;
+    this.columnFamily = columnFamily;
+  }
+
+  public String getFileName() {
+    return fileName;
+  }
+
+  public String getStartKey() {
+    return startKey;
+  }
+
+  public String getEndKey() {
+    return endKey;
+  }
+
+  public String getColumnFamily() {
+    return columnFamily;
+  }
+
+  public HddsProtos.CompactionFileInfoProto getProtobuf() {
+    HddsProtos.CompactionFileInfoProto.Builder builder =
+        HddsProtos.CompactionFileInfoProto.newBuilder()
+            .setFileName(fileName);
+    if (startKey != null) {
+      builder = builder.setStartKey(startKey);
+    }
+    if (endKey != null) {
+      builder = builder.setStartKey(endKey);
+    }
+    if (columnFamily != null) {
+      builder = builder.setStartKey(columnFamily);
+    }
+    return builder.build();
+  }
+
+  public static CompactionFileInfo getFromProtobuf(
+      HddsProtos.CompactionFileInfoProto proto) {
+    return new CompactionFileInfo(proto.getFileName(), proto.getStartKey(),
+        proto.getEndKey(), proto.getColumnFamily());
+  }
+
+  @Override
+  public String toString() {
+    return String.format("fileName: '%s', startKey: '%s', endKey: '%s'," +
+        " columnFamily: '%s'", fileName, startKey, endKey, columnFamily);
+  }
+}

--- a/hadoop-hdds/rocksdb-checkpoint-differ/src/main/java/org/apache/ozone/compaction/log/CompactionLogEntry.java
+++ b/hadoop-hdds/rocksdb-checkpoint-differ/src/main/java/org/apache/ozone/compaction/log/CompactionLogEntry.java
@@ -138,24 +138,17 @@ public class CompactionLogEntry implements CopyObject<CompactionLogEntry> {
    * Builder of CompactionLogEntry.
    */
   public static class Builder {
-    private long dbSequenceNumber;
-    private long compactionTime;
+    private final long dbSequenceNumber;
+    private final long compactionTime;
     private List<String> inputFiles;
     private List<String> outputFiles;
     private String compactionReason;
 
-    public Builder() {
-    }
-
-    public Builder setDbSequenceNumber(long dbSequenceNumber) {
+    public Builder(long dbSequenceNumber, long compactionTime) {
       this.dbSequenceNumber = dbSequenceNumber;
-      return this;
+      this.compactionTime = compactionTime;
     }
 
-    public Builder setCompactionTime(long compactionTime) {
-      this.compactionTime = compactionTime;
-      return this;
-    }
     public Builder setInputFiles(List<String> inputFiles) {
       this.inputFiles = inputFiles;
       return this;

--- a/hadoop-hdds/rocksdb-checkpoint-differ/src/main/java/org/apache/ozone/compaction/log/CompactionLogEntry.java
+++ b/hadoop-hdds/rocksdb-checkpoint-differ/src/main/java/org/apache/ozone/compaction/log/CompactionLogEntry.java
@@ -207,8 +207,11 @@ public class CompactionLogEntry implements CopyObject<CompactionLogEntry> {
           iterator.seekToLast();
           String endKey = StringUtils.bytes2String(iterator.key());
 
-          CompactionFileInfo fileInfo =
-              new CompactionFileInfo(fileName, startKey, endKey, columnFamily);
+          CompactionFileInfo fileInfo = new CompactionFileInfo.Builder(fileName)
+              .setStartRange(startKey)
+              .setEndRange(endKey)
+              .setColumnFamily(columnFamily)
+              .build();
           response.add(fileInfo);
         } catch (RocksDBException rocksDBException) {
           throw new RuntimeException("Failed to read SST file: " + sstFile,

--- a/hadoop-hdds/rocksdb-checkpoint-differ/src/main/java/org/apache/ozone/compaction/log/CompactionLogEntry.java
+++ b/hadoop-hdds/rocksdb-checkpoint-differ/src/main/java/org/apache/ozone/compaction/log/CompactionLogEntry.java
@@ -1,0 +1,250 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ozone.compaction.log;
+
+import org.apache.commons.collections.CollectionUtils;
+import org.apache.hadoop.hdds.StringUtils;
+import org.apache.hadoop.hdds.protocol.proto.HddsProtos.CompactionLogEntryProto;
+import org.apache.hadoop.hdds.utils.db.Codec;
+import org.apache.hadoop.hdds.utils.db.CopyObject;
+import org.apache.hadoop.hdds.utils.db.DelegatedCodec;
+import org.apache.hadoop.hdds.utils.db.Proto2Codec;
+import org.apache.hadoop.hdds.utils.db.managed.ManagedOptions;
+import org.apache.hadoop.hdds.utils.db.managed.ManagedReadOptions;
+import org.rocksdb.RocksDBException;
+import org.rocksdb.SstFileReader;
+import org.rocksdb.SstFileReaderIterator;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+import static org.apache.ozone.rocksdiff.RocksDBCheckpointDiffer.SST_FILE_EXTENSION_LENGTH;
+
+/**
+ * Compaction log entry Dao to write to the compaction log file.
+ */
+public class CompactionLogEntry implements CopyObject<CompactionLogEntry> {
+  private static final Codec<CompactionLogEntry> CODEC = new DelegatedCodec<>(
+      Proto2Codec.get(CompactionLogEntryProto.class),
+      CompactionLogEntry::getFromProtobuf,
+      CompactionLogEntry::getProtobuf);
+
+  public static Codec<CompactionLogEntry> getCodec() {
+    return CODEC;
+  }
+
+  private final long dbSequenceNumber;
+  private final long compactionTime;
+  private final List<CompactionFileInfo> inputFileInfoList;
+  private final List<CompactionFileInfo> outputFileInfoList;
+  private final String compactionReason;
+
+  public CompactionLogEntry(long dbSequenceNumber,
+                            long compactionTime,
+                            List<CompactionFileInfo> inputFileInfoList,
+                            List<CompactionFileInfo> outputFileInfoList,
+                            String compactionReason) {
+    this.dbSequenceNumber = dbSequenceNumber;
+    this.compactionTime = compactionTime;
+    this.inputFileInfoList = inputFileInfoList;
+    this.outputFileInfoList = outputFileInfoList;
+    this.compactionReason = compactionReason;
+  }
+
+  public List<CompactionFileInfo> getInputFileInfoList() {
+    return inputFileInfoList;
+  }
+
+  public List<CompactionFileInfo> getOutputFileInfoList() {
+    return outputFileInfoList;
+  }
+
+  public long getDbSequenceNumber() {
+    return dbSequenceNumber;
+  }
+
+  public long getCompactionTime() {
+    return compactionTime;
+  }
+
+  public CompactionLogEntryProto getProtobuf() {
+    CompactionLogEntryProto.Builder builder = CompactionLogEntryProto
+        .newBuilder()
+        .setDbSequenceNumber(dbSequenceNumber)
+        .setCompactionTime(compactionTime);
+
+    if (compactionReason != null) {
+      builder.setCompactionReason(compactionReason);
+    }
+
+    if (inputFileInfoList != null) {
+      inputFileInfoList.forEach(fileInfo ->
+          builder.addInputFileIntoList(fileInfo.getProtobuf()));
+    }
+
+    if (outputFileInfoList != null) {
+      outputFileInfoList.forEach(fileInfo ->
+          builder.addOutputFileIntoList(fileInfo.getProtobuf()));
+    }
+
+    return builder.build();
+  }
+
+  public static CompactionLogEntry getFromProtobuf(
+      CompactionLogEntryProto proto) {
+    List<CompactionFileInfo> inputFileInfo = proto.getInputFileIntoListList()
+        .stream()
+        .map(CompactionFileInfo::getFromProtobuf)
+        .collect(Collectors.toList());
+
+    List<CompactionFileInfo> outputFileInfo = proto.getOutputFileIntoListList()
+        .stream()
+        .map(CompactionFileInfo::getFromProtobuf)
+        .collect(Collectors.toList());
+
+    return new CompactionLogEntry(proto.getDbSequenceNumber(),
+        proto.getCompactionTime(), inputFileInfo, outputFileInfo,
+        proto.getCompactionReason());
+  }
+
+  @Override
+  public String toString() {
+    return String.format("dbSequenceNumber: '%s', compactionTime: '%s', " +
+            "inputFileInfoList: '%s', outputFileInfoList: '%s', " +
+            "compactionReason: '%s'.", dbSequenceNumber, compactionTime,
+        inputFileInfoList, outputFileInfoList, compactionReason);
+  }
+
+  /**
+   * Builder of CompactionLogEntry.
+   */
+  public static class Builder {
+    private long dbSequenceNumber;
+    private long compactionTime;
+    private List<String> inputFiles;
+    private List<String> outputFiles;
+    private String compactionReason;
+
+    public Builder() {
+    }
+
+    public Builder setDbSequenceNumber(long dbSequenceNumber) {
+      this.dbSequenceNumber = dbSequenceNumber;
+      return this;
+    }
+
+    public Builder setCompactionTime(long compactionTime) {
+      this.compactionTime = compactionTime;
+      return this;
+    }
+    public Builder setInputFiles(List<String> inputFiles) {
+      this.inputFiles = inputFiles;
+      return this;
+    }
+
+    public Builder setOutputFiles(List<String> outputFiles) {
+      this.outputFiles = outputFiles;
+      return this;
+    }
+
+    public Builder setCompactionReason(String compactionReason) {
+      this.compactionReason = compactionReason;
+      return this;
+    }
+
+    public CompactionLogEntry build() {
+      try (ManagedOptions options = new ManagedOptions();
+           ManagedReadOptions readOptions = new ManagedReadOptions()) {
+        return new CompactionLogEntry(dbSequenceNumber, compactionTime,
+            toFileInfoList(inputFiles, options, readOptions),
+            toFileInfoList(outputFiles, options, readOptions),
+            compactionReason);
+      }
+    }
+
+    private List<CompactionFileInfo> toFileInfoList(
+        List<String> sstFiles,
+        ManagedOptions options,
+        ManagedReadOptions readOptions
+    ) {
+      if (CollectionUtils.isEmpty(sstFiles)) {
+        return Collections.emptyList();
+      }
+
+      final int fileNameOffset = sstFiles.get(0).lastIndexOf("/") + 1;
+      List<CompactionFileInfo> response = new ArrayList<>();
+
+      for (String sstFile : sstFiles) {
+        String fileName = sstFile.substring(fileNameOffset,
+            sstFile.length() - SST_FILE_EXTENSION_LENGTH);
+        SstFileReader fileReader = new SstFileReader(options);
+        try {
+          fileReader.open(sstFile);
+          String columnFamily = StringUtils.bytes2String(
+              fileReader.getTableProperties().getColumnFamilyName());
+          SstFileReaderIterator iterator = fileReader.newIterator(readOptions);
+          iterator.seekToFirst();
+          String startKey = StringUtils.bytes2String(iterator.key());
+          iterator.seekToLast();
+          String endKey = StringUtils.bytes2String(iterator.key());
+
+          CompactionFileInfo fileInfo =
+              new CompactionFileInfo(fileName, startKey, endKey, columnFamily);
+          response.add(fileInfo);
+        } catch (RocksDBException rocksDBException) {
+          throw new RuntimeException("Failed to read SST file: " + sstFile,
+              rocksDBException);
+        }
+      }
+      return response;
+    }
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof CompactionLogEntry)) {
+      return false;
+    }
+
+    CompactionLogEntry that = (CompactionLogEntry) o;
+    return dbSequenceNumber == that.dbSequenceNumber &&
+        compactionTime == that.compactionTime &&
+        Objects.equals(inputFileInfoList, that.inputFileInfoList) &&
+        Objects.equals(outputFileInfoList, that.outputFileInfoList) &&
+        Objects.equals(compactionReason, that.compactionReason);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(dbSequenceNumber, compactionTime, inputFileInfoList,
+        outputFileInfoList, compactionReason);
+  }
+
+  @Override
+  public CompactionLogEntry copyObject() {
+    return new CompactionLogEntry(dbSequenceNumber, compactionTime,
+        inputFileInfoList, outputFileInfoList, compactionReason);
+  }
+}

--- a/hadoop-hdds/rocksdb-checkpoint-differ/src/main/java/org/apache/ozone/compaction/log/package-info.java
+++ b/hadoop-hdds/rocksdb-checkpoint-differ/src/main/java/org/apache/ozone/compaction/log/package-info.java
@@ -1,0 +1,23 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ozone.compaction.log;
+
+/**
+ * This package contains POJO classes for Compaction information.
+ */

--- a/hadoop-hdds/rocksdb-checkpoint-differ/src/main/java/org/apache/ozone/rocksdiff/RocksDBCheckpointDiffer.java
+++ b/hadoop-hdds/rocksdb-checkpoint-differ/src/main/java/org/apache/ozone/rocksdiff/RocksDBCheckpointDiffer.java
@@ -165,7 +165,7 @@ public class RocksDBCheckpointDiffer implements AutoCloseable,
    * to save space.
    */
   static final String SST_FILE_EXTENSION = ".sst";
-  private static final int SST_FILE_EXTENSION_LENGTH =
+  public static final int SST_FILE_EXTENSION_LENGTH =
       SST_FILE_EXTENSION.length();
 
   private static final int LONG_MAX_STR_LEN =

--- a/hadoop-hdds/rocksdb-checkpoint-differ/src/test/java/org/apache/ozone/compaction/log/TestCompactionFileInfo.java
+++ b/hadoop-hdds/rocksdb-checkpoint-differ/src/test/java/org/apache/ozone/compaction/log/TestCompactionFileInfo.java
@@ -1,0 +1,154 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ozone.compaction.log;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Test class for CompactionFileInfo.
+ */
+public class TestCompactionFileInfo {
+
+  private static Stream<Arguments> compactionFileInfoValidScenarios() {
+    return Stream.of(
+        Arguments.of("All parameters are present.",
+            "fileName",
+            "startRange",
+            "endRange",
+            "columnFamily"
+        ),
+        Arguments.of("Only fileName is present.",
+            "fileName",
+            null,
+            null,
+            null
+        )
+    );
+  }
+
+
+  @ParameterizedTest(name = "{0}")
+  @MethodSource("compactionFileInfoValidScenarios")
+  public void testCompactionFileInfoValidScenario(String description,
+                                                  String fileName,
+                                                  String startRange,
+                                                  String endRange,
+                                                  String columnFamily) {
+
+    CompactionFileInfo compactionFileInfo =
+        new CompactionFileInfo.Builder(fileName).setStartRange(startRange)
+            .setEndRange(endRange).setColumnFamily(columnFamily).build();
+    Assertions.assertNotNull(compactionFileInfo);
+  }
+
+
+  private static Stream<Arguments> compactionFileInfoInvalidScenarios() {
+    return Stream.of(
+        Arguments.of("All parameters are null.",
+            null,
+            null,
+            null,
+            null,
+            "FileName is required parameter."
+        ),
+        Arguments.of("fileName is null.",
+            null,
+            "startRange",
+            "endRange",
+            "columnFamily",
+            "FileName is required parameter."
+        ),
+        Arguments.of("startRange is not present.",
+            "fileName",
+            null,
+            "endRange",
+            "columnFamily",
+            "Either all of startRange, endRange and columnFamily" +
+                " should be non-null or null. startRange: 'null', " +
+                "endRange: 'endRange', columnFamily: 'columnFamily'."
+        ),
+        Arguments.of("endRange is not present.",
+            "fileName",
+            "startRange",
+            null,
+            "columnFamily",
+            "Either all of startRange, endRange and columnFamily" +
+                " should be non-null or null. startRange: 'startRange', " +
+                "endRange: 'null', columnFamily: 'columnFamily'."
+        ),
+        Arguments.of("columnFamily is not present.",
+            "fileName",
+            "startRange",
+            "endRange",
+            null,
+            "Either all of startRange, endRange and columnFamily" +
+                " should be non-null or null. startRange: 'startRange', " +
+                "endRange: 'endRange', columnFamily: 'null'."
+        ),
+        Arguments.of("startRange and endRange are not present.",
+            "fileName",
+            null,
+            null,
+            "columnFamily",
+            "Either all of startRange, endRange and columnFamily" +
+                " should be non-null or null. startRange: 'null', " +
+                "endRange: 'null', columnFamily: 'columnFamily'."
+        ),
+        Arguments.of("endRange and columnFamily are not present.",
+            "fileName",
+            "startRange",
+            null,
+            null,
+            "Either all of startRange, endRange and columnFamily " +
+                "should be non-null or null. startRange: 'startRange', " +
+                "endRange: 'null', columnFamily: 'null'."
+        ),
+        Arguments.of("startRange and columnFamily are not present.",
+            "fileName",
+            null,
+            "endRange",
+            null,
+            "Either all of startRange, endRange and columnFamily" +
+                " should be non-null or null. startRange: 'null', " +
+                "endRange: 'endRange', columnFamily: 'null'."
+        )
+    );
+  }
+
+  @ParameterizedTest(name = "{0}")
+  @MethodSource("compactionFileInfoInvalidScenarios")
+  public void testCompactionFileInfoInvalidScenario(String description,
+                                                    String fileName,
+                                                    String startRange,
+                                                    String endRange,
+                                                    String columnFamily,
+                                                    String expectedMessage) {
+    RuntimeException exception = Assertions.assertThrows(RuntimeException.class,
+        () -> new CompactionFileInfo.Builder(fileName).setStartRange(startRange)
+            .setEndRange(endRange).setColumnFamily(columnFamily).build());
+    assertEquals(expectedMessage, exception.getMessage());
+  }
+}

--- a/hadoop-hdds/rocksdb-checkpoint-differ/src/test/java/org/apache/ozone/compaction/log/TestCompactionLogEntry.java
+++ b/hadoop-hdds/rocksdb-checkpoint-differ/src/test/java/org/apache/ozone/compaction/log/TestCompactionLogEntry.java
@@ -1,0 +1,146 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ozone.compaction.log;
+
+import org.apache.hadoop.hdds.protocol.proto.HddsProtos.CompactionLogEntryProto;
+import org.apache.hadoop.util.Time;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+/**
+ * Test class for CompactionLogEntry.
+ */
+public class TestCompactionLogEntry {
+
+  private static Stream<Arguments> compactionLogEntryValidScenarios() {
+    List<CompactionFileInfo> inputFiles = Arrays.asList(
+        new CompactionFileInfo.Builder("inputFileName1").setStartRange("key1")
+            .setEndRange("key5").setColumnFamily("columnFamily").build(),
+        new CompactionFileInfo.Builder("inputFileName2").setStartRange("key6")
+            .setEndRange("key11").setColumnFamily("columnFamily").build(),
+        new CompactionFileInfo.Builder("inputFileName3").setStartRange("key12")
+            .setEndRange("key19").setColumnFamily("columnFamily").build());
+    List<CompactionFileInfo> outputFiles = Arrays.asList(
+        new CompactionFileInfo.Builder("outputFileName1").setStartRange("key1")
+            .setEndRange("key8").setColumnFamily("columnFamily").build(),
+        new CompactionFileInfo.Builder("outputFileName2").setStartRange("key9")
+            .setEndRange("key19").setColumnFamily("columnFamily").build());
+
+    return Stream.of(
+        Arguments.of("With compaction reason.",
+            1000,
+            Time.now(),
+            inputFiles,
+            outputFiles,
+            "compactionReason"
+        ),
+        Arguments.of("Without compaction reason.",
+            2000,
+            Time.now(),
+            inputFiles,
+            outputFiles,
+            null
+        )
+    );
+  }
+
+  @ParameterizedTest(name = "{0}")
+  @MethodSource("compactionLogEntryValidScenarios")
+  public void testGetProtobuf(
+      String description,
+      long dbSequenceNumber,
+      long compactionTime,
+      List<CompactionFileInfo> inputFiles,
+      List<CompactionFileInfo> outputFiles,
+      String compactionReason) {
+    CompactionLogEntry.Builder builder = new CompactionLogEntry
+        .Builder(dbSequenceNumber, compactionTime, inputFiles, outputFiles);
+
+    if (compactionReason != null) {
+      builder.setCompactionReason(compactionReason);
+    }
+
+    CompactionLogEntry compactionLogEntry = builder.build();
+    assertNotNull(compactionLogEntry);
+    CompactionLogEntryProto protobuf =
+        compactionLogEntry.getProtobuf();
+    assertEquals(dbSequenceNumber, protobuf.getDbSequenceNumber());
+    assertEquals(compactionTime, protobuf.getCompactionTime());
+    assertEquals(inputFiles, protobuf.getInputFileIntoListList().stream()
+        .map(CompactionFileInfo::getFromProtobuf)
+        .collect(Collectors.toList()));
+    assertEquals(outputFiles, protobuf.getOutputFileIntoListList().stream()
+        .map(CompactionFileInfo::getFromProtobuf)
+        .collect(Collectors.toList()));
+    if (compactionReason != null) {
+      assertEquals(compactionReason, protobuf.getCompactionReason());
+    } else {
+      assertFalse(protobuf.hasCompactionReason());
+    }
+  }
+
+
+  @ParameterizedTest(name = "{0}")
+  @MethodSource("compactionLogEntryValidScenarios")
+  public void testFromProtobuf(
+      String description,
+      long dbSequenceNumber,
+      long compactionTime,
+      List<CompactionFileInfo> inputFiles,
+      List<CompactionFileInfo> outputFiles,
+      String compactionReason) {
+
+    CompactionLogEntryProto.Builder builder = CompactionLogEntryProto
+        .newBuilder()
+        .setDbSequenceNumber(dbSequenceNumber)
+        .setCompactionTime(compactionTime);
+
+    if (compactionReason != null) {
+      builder.setCompactionReason(compactionReason);
+    }
+
+    inputFiles.forEach(fileInfo ->
+        builder.addInputFileIntoList(fileInfo.getProtobuf()));
+
+    outputFiles.forEach(fileInfo ->
+        builder.addOutputFileIntoList(fileInfo.getProtobuf()));
+
+    CompactionLogEntryProto protobuf1 = builder.build();
+
+    CompactionLogEntry compactionLogEntry =
+        CompactionLogEntry.getFromProtobuf(protobuf1);
+
+    assertNotNull(compactionLogEntry);
+    assertEquals(dbSequenceNumber, compactionLogEntry.getDbSequenceNumber());
+    assertEquals(compactionTime, compactionLogEntry.getCompactionTime());
+    assertEquals(inputFiles, compactionLogEntry.getInputFileInfoList());
+    assertEquals(outputFiles, compactionLogEntry.getOutputFileInfoList());
+    assertEquals(compactionReason, compactionLogEntry.getCompactionReason());
+  }
+}

--- a/hadoop-ozone/interface-storage/src/main/java/org/apache/hadoop/ozone/om/OMMetadataManager.java
+++ b/hadoop-ozone/interface-storage/src/main/java/org/apache/hadoop/ozone/om/OMMetadataManager.java
@@ -51,6 +51,7 @@ import org.apache.hadoop.hdds.utils.db.DBStore;
 import org.apache.hadoop.hdds.utils.db.Table;
 
 import com.google.common.annotations.VisibleForTesting;
+import org.apache.ozone.compaction.log.CompactionLogEntry;
 
 /**
  * OM metadata manager interface.
@@ -378,6 +379,7 @@ public interface OMMetadataManager extends DBStoreHAManager {
 
   Table<String, String> getSnapshotRenamedTable();
 
+  Table<String, CompactionLogEntry> getCompactionLogTable();
   /**
    * Gets the OM Meta table.
    * @return meta table reference.

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmMetadataManagerImpl.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmMetadataManagerImpl.java
@@ -198,6 +198,8 @@ public class OmMetadataManagerImpl implements OMMetadataManager,
    * |                       |  2. /volumeId/bucketId/parentId/fileName        |
    * |                       |  3. /volumeName/bucketName/keyName              |
    * |-------------------------------------------------------------------------|
+   * | compactionLogTable    | dbTrxId-compactionTime -> compactionLogEntry    |
+   * |-------------------------------------------------------------------------|
    */
 
   public static final String USER_TABLE = "userTable";

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmMetadataManagerImpl.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmMetadataManagerImpl.java
@@ -753,7 +753,7 @@ public class OmMetadataManagerImpl implements OMMetadataManager,
     // TODO: [SNAPSHOT] Initialize table lock for snapshotRenamedTable.
 
     compactionLogTable = this.store.getTable(COMPACTION_LOG_TABLE,
-        String.class, String.class);
+        String.class, CompactionLogEntry.class);
     checkTableStatus(compactionLogTable, COMPACTION_LOG_TABLE,
         addCacheMetrics);
   }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmMetadataManagerImpl.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmMetadataManagerImpl.java
@@ -109,6 +109,7 @@ import static org.apache.hadoop.ozone.om.service.SnapshotDeletingService.isBlock
 import static org.apache.hadoop.ozone.om.snapshot.SnapshotUtils.checkSnapshotDirExist;
 
 import org.apache.hadoop.util.Time;
+import org.apache.ozone.compaction.log.CompactionLogEntry;
 import org.apache.ratis.util.ExitUtils;
 import org.eclipse.jetty.util.StringUtil;
 import org.slf4j.Logger;
@@ -225,6 +226,8 @@ public class OmMetadataManagerImpl implements OMMetadataManager,
   public static final String SNAPSHOT_INFO_TABLE = "snapshotInfoTable";
   public static final String SNAPSHOT_RENAMED_TABLE =
       "snapshotRenamedTable";
+  public static final String COMPACTION_LOG_TABLE =
+      "compactionLogTable";
 
   static final String[] ALL_TABLES = new String[] {
       USER_TABLE,
@@ -247,7 +250,8 @@ public class OmMetadataManagerImpl implements OMMetadataManager,
       PRINCIPAL_TO_ACCESS_IDS_TABLE,
       TENANT_STATE_TABLE,
       SNAPSHOT_INFO_TABLE,
-      SNAPSHOT_RENAMED_TABLE
+      SNAPSHOT_RENAMED_TABLE,
+      COMPACTION_LOG_TABLE
   };
 
   private DBStore store;
@@ -277,6 +281,7 @@ public class OmMetadataManagerImpl implements OMMetadataManager,
 
   private Table snapshotInfoTable;
   private Table snapshotRenamedTable;
+  private Table compactionLogTable;
 
   private boolean isRatisEnabled;
   private boolean ignorePipelineinKey;
@@ -615,6 +620,7 @@ public class OmMetadataManagerImpl implements OMMetadataManager,
         .addTable(TENANT_STATE_TABLE)
         .addTable(SNAPSHOT_INFO_TABLE)
         .addTable(SNAPSHOT_RENAMED_TABLE)
+        .addTable(COMPACTION_LOG_TABLE)
         .addCodec(OzoneTokenIdentifier.class, TokenIdentifierCodec.get())
         .addCodec(OmKeyInfo.class, OmKeyInfo.getCodec(true))
         .addCodec(RepeatedOmKeyInfo.class, RepeatedOmKeyInfo.getCodec(true))
@@ -629,7 +635,8 @@ public class OmMetadataManagerImpl implements OMMetadataManager,
         .addCodec(OmDBTenantState.class, OmDBTenantState.getCodec())
         .addCodec(OmDBAccessIdInfo.class, OmDBAccessIdInfo.getCodec())
         .addCodec(OmDBUserPrincipalInfo.class, OmDBUserPrincipalInfo.getCodec())
-        .addCodec(SnapshotInfo.class, SnapshotInfo.getCodec());
+        .addCodec(SnapshotInfo.class, SnapshotInfo.getCodec())
+        .addCodec(CompactionLogEntry.class, CompactionLogEntry.getCodec());
   }
 
   /**
@@ -742,6 +749,11 @@ public class OmMetadataManagerImpl implements OMMetadataManager,
     checkTableStatus(snapshotRenamedTable, SNAPSHOT_RENAMED_TABLE,
         addCacheMetrics);
     // TODO: [SNAPSHOT] Initialize table lock for snapshotRenamedTable.
+
+    compactionLogTable = this.store.getTable(COMPACTION_LOG_TABLE,
+        String.class, String.class);
+    checkTableStatus(compactionLogTable, COMPACTION_LOG_TABLE,
+        addCacheMetrics);
   }
 
   /**
@@ -1940,6 +1952,11 @@ public class OmMetadataManagerImpl implements OMMetadataManager,
   @Override
   public Table<String, String> getSnapshotRenamedTable() {
     return snapshotRenamedTable;
+  }
+
+  @Override
+  public Table<String, CompactionLogEntry> getCompactionLogTable() {
+    return compactionLogTable;
   }
 
   /**

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/codec/OMDBDefinition.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/codec/OMDBDefinition.java
@@ -236,7 +236,7 @@ public class OMDBDefinition extends DBDefinition.WithMap {
       COMPACTION_LOG_TABLE =
       new DBColumnFamilyDefinition<>(
           OmMetadataManagerImpl.COMPACTION_LOG_TABLE,
-          String.class,  // snapshot path
+          String.class,
           StringCodec.get(),
           CompactionLogEntry.class,
           CompactionLogEntry.getCodec());

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/codec/OMDBDefinition.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/codec/OMDBDefinition.java
@@ -43,6 +43,7 @@ import org.apache.hadoop.hdds.utils.TransactionInfo;
 import org.apache.hadoop.ozone.om.service.SnapshotDeletingService;
 import org.apache.hadoop.ozone.security.OzoneTokenIdentifier;
 import org.apache.hadoop.ozone.storage.proto.OzoneManagerStorageProtos.PersistedUserVolumeInfo;
+import org.apache.ozone.compaction.log.CompactionLogEntry;
 
 import java.util.Map;
 
@@ -231,6 +232,15 @@ public class OMDBDefinition extends DBDefinition.WithMap {
           SnapshotInfo.class,
           SnapshotInfo.getCodec());
 
+  public static final DBColumnFamilyDefinition<String, CompactionLogEntry>
+      COMPACTION_LOG_TABLE =
+      new DBColumnFamilyDefinition<>(
+          OmMetadataManagerImpl.COMPACTION_LOG_TABLE,
+          String.class,  // snapshot path
+          StringCodec.get(),
+          CompactionLogEntry.class,
+          CompactionLogEntry.getCodec());
+
   /**
    * SnapshotRenamedTable that complements the keyTable (or fileTable)
    * and dirTable entries of the immediately previous snapshot in the
@@ -268,6 +278,7 @@ public class OMDBDefinition extends DBDefinition.WithMap {
           S3_SECRET_TABLE,
           SNAPSHOT_INFO_TABLE,
           SNAPSHOT_RENAMED_TABLE,
+          COMPACTION_LOG_TABLE,
           TENANT_ACCESS_ID_TABLE,
           TENANT_STATE_TABLE,
           TRANSACTION_INFO_TABLE,


### PR DESCRIPTION
## What changes were proposed in this pull request?
In this change, a new columnFamily: `compactionLogTable` is added to keep the compaction log entries. Currently simple text file is used to keep compaction entries which has following problems:
* There is no proper way to serialize and deserialize the compaction entry. It is based on different token ` `,  `,` and `:`. Which makes it backward incompatible whenever a new parameter gets added to logs. e.g. 1). when dbSequence number was added to the log in [HDDS-8652](https://issues.apache.org/jira/browse/HDDS-8652), 2). when it is needed to add SST file details to fix [HDDS-8940](https://issues.apache.org/jira/browse/HDDS-8940). After migrating to column family, Protobuf's serialization will be used to store it in RocksDB column family. It will be easier to add new parameter with protobuf.
* There is no way to deal with potential (silent) corruption against the compaction log because it is a simple text file. Using RocksDB we can simply rely on RocksDB's built-in [per-key checksum](https://rocksdb.org/blog/2022/07/18/per-key-value-checksum.html) to deal with it rather than handling it ourselves.

Migrating compaction logs to RocksDB column family will solve the above problems.

Note: this is first patch to solve [HDDS-7601](https://issues.apache.org/jira/browse/HDDS-7601) and [HDDS-8940](https://issues.apache.org/jira/browse/HDDS-8940). Initially I raised single [PR-5236](https://github.com/apache/ozone/pull/5236) to fix both the issues. But over the time it is getting bigger and bigger. So I decided to create independent PRs to make it easier to review.

Follow up PR would be to migrate from compaction text file to new columnFamily: `compactionLogTable`.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-7601

## How was this patch tested?
Existing unit tests `TestOMDBDefinition#testDBDefinition` and `TestOmMetadataManager#testAllTablesAreProperInOMMetadataManagerImpl`.
