### PR TITLE
HDDS-9294. Avoid creating Managed objects per getKeyInfo request.

### DIFF
--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/RocksDatabase.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/RocksDatabase.java
@@ -80,6 +80,8 @@ public final class RocksDatabase implements Closeable {
   static final Logger LOG = LoggerFactory.getLogger(RocksDatabase.class);
 
   public static final String ESTIMATE_NUM_KEYS = "rocksdb.estimate-num-keys";
+  private static final ManagedReadOptions DEFAULT_READ_OPTION =
+      new ManagedReadOptions();
 
   private static Map<String, List<ColumnFamilyHandle>> dbNameToCfHandleMap =
       new HashMap<>();
@@ -738,9 +740,10 @@ public final class RocksDatabase implements Closeable {
   Integer get(ColumnFamily family, ByteBuffer key, ByteBuffer outValue)
       throws IOException {
     assertClose();
-    try (ManagedReadOptions options = new ManagedReadOptions()) {
+    try {
       counter.incrementAndGet();
-      final int size = db.get().get(family.getHandle(), options, key, outValue);
+      final int size = db.get().get(family.getHandle(),
+          DEFAULT_READ_OPTION, key, outValue);
       LOG.debug("get: size={}, remaining={}",
           size, outValue.asReadOnlyBuffer().remaining());
       return size == ManagedRocksDB.NOT_FOUND ? null : size;


### PR DESCRIPTION
## What changes were proposed in this pull request?

Avoid creating Managed objects per getKeyInfo request to avoid the finalizer cost. 

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-9294

## How was this patch tested?

Standard CI. 