### PR TITLE
HDDS-9300. Instruct admins to use `OZONE_MANAGER_CLASSPATH` for `RangerOzoneAuthorizer`

### DIFF
--- a/hadoop-hdds/docs/content/security/SecurityWithRanger.md
+++ b/hadoop-hdds/docs/content/security/SecurityWithRanger.md
@@ -48,7 +48,7 @@ ozone.acl.authorizer.class| org.apache.ranger.authorization.ozone.authorizer.Ran
 
 To use the RangerOzoneAuthorizer, you also need to add the following environment variables to ozone-env.sh:
 ```bash
-export OZONE_CLASSPATH="${OZONE_HOME}/share/ozone/lib/libext/*"
+export OZONE_MANAGER_CLASSPATH="${OZONE_HOME}/share/ozone/lib/libext/*"
 ```
 * The location of the ranger-ozone-plugin jars depends on where the Ranger Plugin is installed.
 * If the ranger-ozone-plugin jars is installed on another node, copy it to the Ozone installation directory.

--- a/hadoop-hdds/docs/content/security/SecurityWithRanger.zh.md
+++ b/hadoop-hdds/docs/content/security/SecurityWithRanger.zh.md
@@ -39,7 +39,7 @@ ozone.acl.authorizer.class| org.apache.ranger.authorization.ozone.authorizer.Ran
 
 为了使用 RangerOzoneAuthorizer，还需要在 ozone-env.sh 中增加下面环境变量：
 ```bash
-export OZONE_CLASSPATH="${OZONE_HOME}/share/ozone/lib/libext/*"
+export OZONE_MANAGER_CLASSPATH="${OZONE_HOME}/share/ozone/lib/libext/*"
 ```
 * ranger-ozone-plugin jars 具体路径取决于 Ranger Ozone plugin 安装配置。
 * 如果 ranger-ozone-plugin jars 安装在其他节点，需要拷贝到 Ozone 安装目录。


### PR DESCRIPTION
## What changes were proposed in this pull request?

The doc should ask admins to configure `RangerOzoneAuthorizer` classpath using `OZONE_MANAGER_CLASSPATH` instead of `OZONE_CLASSPATH` so as to narrow down the effective scope of it to OMs only.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-9300

## How was this patch tested?

- CDP is already using `OZONE_MANAGER_CLASSPATH`.