### PR TITLE
HDDS-9305. Make OM service ID optional for `ozone admin om roles` if only one is defined in config

### DIFF
--- a/hadoop-ozone/dist/src/main/smoketest/omha/om-roles.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/omha/om-roles.robot
@@ -20,36 +20,36 @@ Test Timeout        5 minutes
 Test Setup          Run Keyword if    '${SECURITY_ENABLED}' == 'true'    Kinit test user     testuser     testuser.keytab
 
 *** Keywords ***
-Parse non json output
+Assert Leader Present
      [Arguments]                     ${output}
-     Should Match Regexp             ${output}                  [om (: LEADER|)]
+     Should Match Regexp             ${output}                      [om (: LEADER|)]
 
-Parse json output
+Assert Leader Present in JSON
      [Arguments]                     ${output}
-     ${leader} =                     Execute                    echo '${output}' | jq '.[] | select(.[] | .serverRole == "LEADER")'
-                                     Should Not Be Equal        ${leader}       ${EMPTY}
+     ${leader} =                     Execute                        echo '${output}' | jq '.[] | select(.[] | .serverRole == "LEADER")'
+                                     Should Not Be Equal            ${leader}       ${EMPTY}
 
 *** Test Cases ***
 List om roles with OM service ID passed
-    ${output_with_id_passed} =      Execute                     ozone admin om roles --service-id=omservice
-                                    Parse non json output       ${output_with_id_passed}
-    ${output_with_id_passed} =      Execute                     ozone admin --set=ozone.om.service.ids=omservice,omservice2 om roles --service-id=omservice
-                                    Parse non json output       ${output_with_id_passed}
+    ${output_with_id_passed} =      Execute                         ozone admin om roles --service-id=omservice
+                                    Assert Leader Present           ${output_with_id_passed}
+    ${output_with_id_passed} =      Execute                         ozone admin --set=ozone.om.service.ids=omservice,omservice2 om roles --service-id=omservice
+                                    Assert Leader Present           ${output_with_id_passed}
 
 List om roles without OM service ID passed
-    ${output_without_id_passed} =   Execute                     ozone admin om roles
-                                    Parse non json output       ${output_without_id_passed}
-    ${output_without_id_passed} =   Execute And Ignore Error    ozone admin --set=ozone.om.service.ids=omservice,omservice2 om roles
-                                    Should Contain              ${output_without_id_passed}      Please specify the service ID to be finalized.
+    ${output_without_id_passed} =   Execute                         ozone admin om roles
+                                    Assert Leader Present           ${output_without_id_passed}
+    ${output_without_id_passed} =   Execute And Ignore Error        ozone admin --set=ozone.om.service.ids=omservice,omservice2 om roles
+                                    Should Contain                  ${output_without_id_passed}      no Ozone Manager service ID specified
 
 List om roles as JSON with OM service ID passed
-    ${output_with_id_passed} =      Execute                     ozone admin om roles --service-id=omservice --json
-                                    Parse json output           ${output_with_id_passed}
-    ${output_with_id_passed} =      Execute                     ozone admin --set=ozone.om.service.ids=omservice,omservice2 om roles --service-id=omservice --json
-                                    Parse json output           ${output_with_id_passed}
+    ${output_with_id_passed} =      Execute                         ozone admin om roles --service-id=omservice --json
+                                    Assert Leader Present in JSON   ${output_with_id_passed}
+    ${output_with_id_passed} =      Execute                         ozone admin --set=ozone.om.service.ids=omservice,omservice2 om roles --service-id=omservice --json
+                                    Parse json output               ${output_with_id_passed}
 
 List om roles as JSON without OM service ID passed
-    ${output_without_id_passed} =   Execute                     ozone admin om roles --json
-                                    Parse json output           ${output_without_id_passed}
-    ${output_without_id_passed} =   Execute And Ignore Error    ozone admin --set=ozone.om.service.ids=omservice,omservice2 om roles --json
-                                    Should Contain              ${output_without_id_passed}      Please specify the service ID to be finalized.
+    ${output_without_id_passed} =   Execute                         ozone admin om roles --json
+                                    Assert Leader Present in JSON   ${output_without_id_passed}
+    ${output_without_id_passed} =   Execute And Ignore Error        ozone admin --set=ozone.om.service.ids=omservice,omservice2 om roles --json
+                                    Should Contain                  ${output_without_id_passed}      no Ozone Manager service ID specified

--- a/hadoop-ozone/dist/src/main/smoketest/omha/om-roles.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/omha/om-roles.robot
@@ -21,10 +21,15 @@ Test Setup          Run Keyword if    '${SECURITY_ENABLED}' == 'true'    Kinit t
 
 *** Test Cases ***
 List om roles
-    ${output} =         Execute          ozone admin om roles --service-id=omservice
-                        Should Match Regexp   ${output}  [om (: LEADER|)]
+    ${output_with_id_passed} =      Execute          ozone admin om roles --service-id=omservice
+                                    Should Match Regexp   ${output_with_id_passed}  [om (: LEADER|)]
+    ${output_without_id_passed} =   Execute          ozone admin om roles
+                                    Should Match Regexp   ${output_without_id_passed}  [om (: LEADER|)]
 
 List om roles as JSON
-    ${output} =         Execute          ozone admin om roles --service-id=omservice --json
-    ${leader} =         Execute          echo '${output}' | jq -r '.[] | select(.serverRole == "LEADER")'
-                        Should Not Be Equal       ${leader}       ${EMPTY}
+    ${output_with_id_passed} =      Execute          ozone admin om roles --service-id=omservice --json
+    ${leader} =                     Execute          echo '${output_with_id_passed}' | jq -r '.[] | select(.serverRole == "LEADER")'
+                                    Should Not Be Equal       ${leader}       ${EMPTY}
+    ${output_without_id_passed} =   Execute          ozone admin om roles
+    ${leader} =                     Execute          echo '${output_without_id_passed}' | jq -r '.[] | select(.serverRole == "LEADER")'
+                                    Should Not Be Equal       ${leader}       ${EMPTY}

--- a/hadoop-ozone/dist/src/main/smoketest/omha/om-roles.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/omha/om-roles.robot
@@ -21,15 +21,15 @@ Test Setup          Run Keyword if    '${SECURITY_ENABLED}' == 'true'    Kinit t
 
 *** Test Cases ***
 List om roles
-    ${output_with_id_passed} =      Execute          ozone admin om roles --service-id=omservice
-                                    Should Match Regexp   ${output_with_id_passed}  [om (: LEADER|)]
-    ${output_without_id_passed} =   Execute          ozone admin om roles
-                                    Should Match Regexp   ${output_without_id_passed}  [om (: LEADER|)]
+    ${output_with_id_passed} =      Execute                 ozone admin om roles --service-id=omservice
+                                    Should Match Regexp     ${output_with_id_passed}  [om (: LEADER|)]
+    ${output_without_id_passed} =   Execute                 ozone admin om roles
+                                    Should Match Regexp     ${output_without_id_passed}  [om (: LEADER|)]
 
 List om roles as JSON
-    ${output_with_id_passed} =      Execute          ozone admin om roles --service-id=omservice --json
-    ${leader} =                     Execute          echo '${output_with_id_passed}' | jq -r '.[] | select(.serverRole == "LEADER")'
-                                    Should Not Be Equal       ${leader}       ${EMPTY}
-    ${output_without_id_passed} =   Execute          ozone admin om roles
-    ${leader} =                     Execute          echo '${output_without_id_passed}' | jq -r '.[] | select(.serverRole == "LEADER")'
-                                    Should Not Be Equal       ${leader}       ${EMPTY}
+    ${output_with_id_passed} =      Execute                 ozone admin om roles --service-id=omservice --json
+    ${leader} =                     Execute                 echo '${output_with_id_passed}' | jq '.[] | select(.[] | .serverRole == "LEADER")'
+                                    Should Not Be Equal     ${leader}       ${EMPTY}
+    ${output_without_id_passed} =   Execute                 ozone admin om roles --json
+    ${leader} =                     Execute                 echo '${output_without_id_passed}' | jq '.[] | select(.[] | .serverRole == "LEADER")'
+                                    Should Not Be Equal     ${leader}       ${EMPTY}

--- a/hadoop-ozone/dist/src/main/smoketest/omha/om-roles.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/omha/om-roles.robot
@@ -22,26 +22,34 @@ Test Setup          Run Keyword if    '${SECURITY_ENABLED}' == 'true'    Kinit t
 *** Keywords ***
 Parse non json output
      [Arguments]                     ${output}
-     Should Match Regexp             ${output}  [om (: LEADER|)]
+     Should Match Regexp             ${output}                  [om (: LEADER|)]
 
 Parse json output
      [Arguments]                     ${output}
-     ${leader} =                     Execute                 echo '${output}' | jq '.[] | select(.[] | .serverRole == "LEADER")'
-                                     Should Not Be Equal     ${leader}       ${EMPTY}
+     ${leader} =                     Execute                    echo '${output}' | jq '.[] | select(.[] | .serverRole == "LEADER")'
+                                     Should Not Be Equal        ${leader}       ${EMPTY}
 
 *** Test Cases ***
 List om roles with OM service ID passed
-    ${output_with_id_passed} =      Execute                 ozone admin om roles --service-id=omservice
-                                    Parse non json output   ${output_with_id_passed}
+    ${output_with_id_passed} =      Execute                     ozone admin om roles --service-id=omservice
+                                    Parse non json output       ${output_with_id_passed}
+    ${output_with_id_passed} =      Execute                     ozone admin --set=ozone.om.service.ids=omservice,omservice2 om roles --service-id=omservice
+                                    Parse non json output       ${output_with_id_passed}
 
 List om roles without OM service ID passed
-    ${output_without_id_passed} =   Execute                 ozone admin om roles
-                                    Parse non json output   ${output_without_id_passed}
+    ${output_without_id_passed} =   Execute                     ozone admin om roles
+                                    Parse non json output       ${output_without_id_passed}
+    ${output_without_id_passed} =   Execute And Ignore Error    ozone admin --set=ozone.om.service.ids=omservice,omservice2 om roles
+                                    Should Contain              ${output_without_id_passed}      Please specify the service ID to be finalized.
 
 List om roles as JSON with OM service ID passed
-    ${output_with_id_passed} =      Execute                 ozone admin om roles --service-id=omservice --json
-                                    Parse json output       ${output_with_id_passed}
+    ${output_with_id_passed} =      Execute                     ozone admin om roles --service-id=omservice --json
+                                    Parse json output           ${output_with_id_passed}
+    ${output_with_id_passed} =      Execute                     ozone admin --set=ozone.om.service.ids=omservice,omservice2 om roles --service-id=omservice --json
+                                    Parse json output           ${output_with_id_passed}
 
 List om roles as JSON without OM service ID passed
-    ${output_without_id_passed} =   Execute                 ozone admin om roles --json
-                                    Parse json output       ${output_without_id_passed}
+    ${output_without_id_passed} =   Execute                     ozone admin om roles --json
+                                    Parse json output           ${output_without_id_passed}
+    ${output_without_id_passed} =   Execute And Ignore Error    ozone admin --set=ozone.om.service.ids=omservice,omservice2 om roles --json
+                                    Should Contain              ${output_without_id_passed}      Please specify the service ID to be finalized.

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/admin/om/GetServiceRolesSubcommand.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/admin/om/GetServiceRolesSubcommand.java
@@ -49,7 +49,7 @@ public class GetServiceRolesSubcommand implements Callable<Void> {
 
   @CommandLine.Option(names = {"-id", "--service-id"},
       description = "OM Service ID",
-      required = true)
+      required = false)
   private String omServiceId;
 
   @CommandLine.Option(names = { "--json" },

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/admin/om/OMAdmin.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/admin/om/OMAdmin.java
@@ -133,8 +133,8 @@ public class OMAdmin extends GenericCli implements SubcommandWithParent {
   private String getTheOnlyConfiguredOmServiceIdOrThrow() {
     if (getConfiguredServiceIds().size() != 1) {
       throw new IllegalArgumentException("There is no Ozone Manager service ID "
-          + "specified, but there are either zero, or more than one service "
-          + "configured. Please specify the service ID to be finalized.");
+          + "specified, but there are either zero, or more than one service ID"
+          + "configured.");
     }
     return getConfiguredServiceIds().iterator().next();
   }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Currently, for ozone admin om roles command, we need to specify the om service ID as its a mandatory parameter.

```
bash-4.2$ ozone admin om roles
Missing required option: '--service-id=<omServiceId>'
Usage: ozone admin om roles [-hV] [--json] -id=<omServiceId>
List all OMs and their respective Ratis server roles
  -h, --help      Show this help message and exit.
      -id, --service-id=<omServiceId>
                  OM Service ID
      --json      Format output as JSON
  -V, --version   Print version information and exit.
```

Even if the omServiceId is null, its handled properly [here](https://github.com/apache/ozone/blob/4b43f158b8b5f9e0d1a58ffe81d3411729337c66/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/admin/om/OMAdmin.java#L113) 

## What is the link to the Apache JIRA

[HDDS-9305](https://issues.apache.org/jira/browse/HDDS-9305)

## How was this patch tested?

Modified already present Robot tests.
