### PR TITLE
HDDS-9306. Default reads/lists to 0 (freon ockrw)

### DIFF
--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/OzoneClientKeyReadWriteListOps.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/OzoneClientKeyReadWriteListOps.java
@@ -99,15 +99,17 @@ public class OzoneClientKeyReadWriteListOps extends BaseFreonGenerator
   @CommandLine.Option(names = {"--percentage-read"},
           description = "Percentage of read tasks in mix workload."
           + " The remainder of the percentage will be divided between write"
-          + " and list tasks.",
-          required = true)
+          + " and list tasks. By default this is 0%, to populate a range.",
+          required = false,
+          defaultValue = "0")
   private int percentageRead;
 
   @CommandLine.Option(names = {"--percentage-list"},
           description = "Percentage of list tasks in mix workload."
           + " The remainder of the percentage will be divided between write"
           + " and read tasks.",
-          required = true)
+          required = false,
+          defaultValue = "0")
   private int percentageList;
 
   @CommandLine.Option(names = {"--max-list-result"},


### PR DESCRIPTION
## What changes were proposed in this pull request?

This command requires specifying the percentage of reads and list operations. This makes the CLI invocation long when one wants to create a few keys. This issue is to track making the reads and list to default to 0 and the command to run a pure create workload unless specified to do reads and or list keys.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-9306

## How was this patch tested?
Existing robot tests
