### PR TITLE
HDDS-9314. create-bucket on an existing bucket should fail

### DIFF
--- a/hadoop-ozone/dist/src/main/smoketest/s3/bucketcreate.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/s3/bucketcreate.robot
@@ -33,13 +33,15 @@ Create new bucket
     Create bucket
 
 Create bucket which already exists
-    ${bucket} =                 Create bucket
-    Create bucket with name     ${bucket}
+    ${bucket} =         Create bucket
+    ${result} =         Execute AWSS3APICli and checkrc         create-bucket --bucket ${bucket}   255
+                        Should contain          ${result}           BucketAlreadyExists
 
 Create bucket with invalid bucket name
     ${randStr} =        Generate Ozone String
     ${result} =         Execute AWSS3APICli and checkrc         create-bucket --bucket invalid_bucket_${randStr}   255
-                        Should contain              ${result}         InvalidBucketName
+                        Should contain          ${result}           InvalidBucketName
+
 Create new bucket and check no group ACL
     ${bucket} =         Create bucket
     ${acl} =            Execute     ozone sh bucket getacl s3v/${bucket}

--- a/hadoop-ozone/dist/src/main/smoketest/upgrade/generate.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/upgrade/generate.robot
@@ -55,7 +55,8 @@ Setup credentials for S3
 
 Try to create a bucket using S3 API
     # Note: S3 API returns error if the bucket already exists
-    ${output} =         Create bucket with name    ${PREFIX}-bucket2
+    ${random} =         Generate Ozone String
+    ${output} =         Create bucket with name    ${PREFIX}-bucket-${random}
                         Should Be Equal    ${output}    ${None}
 
 Create key using S3 API

--- a/hadoop-ozone/dist/src/main/smoketest/upgrade/generate.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/upgrade/generate.robot
@@ -54,8 +54,8 @@ Setup credentials for S3
     Run Keyword         Setup dummy credentials for S3
 
 Try to create a bucket using S3 API
-    # Note: S3 API does not return error if the bucket already exists
-    ${output} =         Create bucket with name    ${PREFIX}-bucket
+    # Note: S3 API returns error if the bucket already exists
+    ${output} =         Create bucket with name    ${PREFIX}-bucket2
                         Should Be Equal    ${output}    ${None}
 
 Create key using S3 API

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/EndpointBase.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/EndpointBase.java
@@ -173,9 +173,9 @@ public abstract class EndpointBase implements Auditor {
       } else if (ex.getResult() == ResultCodes.TIMEOUT ||
           ex.getResult() == ResultCodes.INTERNAL_ERROR) {
         throw newError(S3ErrorTable.INTERNAL_ERROR, bucketName, ex);
-      } else if (ex.getResult() != ResultCodes.BUCKET_ALREADY_EXISTS) {
-        // S3 does not return error for bucket already exists, it just
-        // returns the location.
+      } else if (ex.getResult() == ResultCodes.BUCKET_ALREADY_EXISTS) {
+        throw newError(S3ErrorTable.BUCKET_ALREADY_EXISTS, bucketName, ex);
+      } else {
         throw ex;
       }
     }

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/exception/S3ErrorTable.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/exception/S3ErrorTable.java
@@ -132,6 +132,10 @@ public final class S3ErrorTable {
       "exceeds the maximum allowed metadata size of " +
       S3_REQUEST_HEADER_METADATA_SIZE_LIMIT_KB + "KB", HTTP_BAD_REQUEST);
 
+  public static final OS3Exception BUCKET_ALREADY_EXISTS = new OS3Exception(
+      "BucketAlreadyExists", "The requested bucket name is not available" +
+      " as it already exists.", HTTP_CONFLICT);
+
   public static OS3Exception newError(OS3Exception e, String resource) {
     return newError(e, resource, null);
   }

--- a/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestBucketPut.java
+++ b/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestBucketPut.java
@@ -28,7 +28,9 @@ import org.apache.hadoop.ozone.client.OzoneClient;
 import org.apache.hadoop.ozone.client.OzoneClientStub;
 import org.apache.hadoop.ozone.s3.exception.OS3Exception;
 
+import static java.net.HttpURLConnection.HTTP_CONFLICT;
 import static java.net.HttpURLConnection.HTTP_NOT_FOUND;
+import static org.apache.hadoop.ozone.s3.exception.S3ErrorTable.BUCKET_ALREADY_EXISTS;
 import static org.apache.hadoop.ozone.s3.exception.S3ErrorTable.MALFORMED_HEADER;
 import static org.apache.hadoop.ozone.s3.signature.SignatureProcessor.DATE_FORMATTER;
 import org.junit.Assert;
@@ -73,6 +75,13 @@ public class TestBucketPut {
     Response response = bucketEndpoint.put(bucketName, null, null, null);
     assertEquals(200, response.getStatus());
     assertNotNull(response.getLocation());
+    try {
+      // Create-bucket on an existing bucket fails
+      bucketEndpoint.put(bucketName, null, null, null);
+    } catch (OS3Exception ex) {
+      Assert.assertEquals(HTTP_CONFLICT, ex.getHttpCode());
+      Assert.assertEquals(BUCKET_ALREADY_EXISTS.getCode(), ex.getCode());
+    }
   }
 
   @Test


### PR DESCRIPTION
## What changes were proposed in this pull request?

AWS s3 returns with an exit code of 255 if a create-bucket on an existing bucket is done but ozone was returning the location of the bucket each time instead. In order to match the behaviours, S3G now throws a new error BUCKET_ALREADY_EXISTS if we try to create-bucket on an existing bucket.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-9314

## How was this patch tested?

Added test in TestBucketPut. Also tested manually using docker:
```
$ aws s3api --endpoint http://localhost:9878 create-bucket --bucket bucket1
{
    "Location": "http://localhost:9878/bucket1"
}

$ aws s3api --endpoint http://localhost:9878 create-bucket --bucket bucket1 

An error occurred (BucketAlreadyExists) when calling the CreateBucket operation: The requested bucket name is not available as it already exists.

```
