### PR TITLE
HDDS-9315. Fix comparison logic for SCMContainerPlacementCapacity.

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/placement/metrics/SCMNodeMetric.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/placement/metrics/SCMNodeMetric.java
@@ -51,7 +51,7 @@ public class SCMNodeMetric  implements DatanodeMetric<SCMNodeStat, Long> {
   /**
    *
    * @param o - Other Object
-   * @return - True if *this* object is greater than argument.
+   * @return - True if *this* object used space weight is greater than argument.
    */
   @Override
   public boolean isGreater(SCMNodeStat o) {
@@ -74,15 +74,15 @@ public class SCMNodeMetric  implements DatanodeMetric<SCMNodeStat, Long> {
       return thisNodeWeight > oNodeWeight;
     }
     // if these nodes are have similar weight then return the node with more
-    // free space as the greater node.
-    return stat.getRemaining().isGreater(o.getRemaining().get());
+    // used space as the greater node.
+    return stat.getScmUsed().isGreater(o.getScmUsed().get());
   }
 
   /**
    * Inverse of isGreater.
    *
    * @param o - other object.
-   * @return True if *this* object is Lesser than argument.
+   * @return True if *this* object used space weight is Lesser than argument.
    */
   @Override
   public boolean isLess(SCMNodeStat o) {
@@ -105,8 +105,8 @@ public class SCMNodeMetric  implements DatanodeMetric<SCMNodeStat, Long> {
     }
 
     // if these nodes are have similar weight then return the node with less
-    // free space as the lesser node.
-    return stat.getRemaining().isLess(o.getRemaining().get());
+    // used space as the lesser node.
+    return stat.getScmUsed().isLess(o.getScmUsed().get());
   }
 
   /**

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/placement/metrics/SCMNodeMetric.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/placement/metrics/SCMNodeMetric.java
@@ -73,7 +73,7 @@ public class SCMNodeMetric  implements DatanodeMetric<SCMNodeStat, Long> {
     if (Math.abs(thisNodeWeight - oNodeWeight) > 0.000001) {
       return thisNodeWeight > oNodeWeight;
     }
-    // if these nodes are have similar weight then return the node with more
+    // if these nodes have similar weight then return the node with more
     // used space as the greater node.
     return stat.getScmUsed().isGreater(o.getScmUsed().get());
   }

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/ozone/container/placement/TestDatanodeMetrics.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/ozone/container/placement/TestDatanodeMetrics.java
@@ -52,5 +52,9 @@ public class TestDatanodeMetrics {
     // Assert we can handle zero capacity.
     assertTrue(metric.isGreater(zeroMetric.get()));
 
+    // Another case when nodes have similar weight
+    SCMNodeStat stat1 = new SCMNodeStat(10000000L, 50L, 9999950L);
+    SCMNodeStat stat2 = new SCMNodeStat(10000000L, 51L, 9999949L);
+    assertTrue(new SCMNodeMetric(stat2).isGreater(stat1));
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

`SCMContainerPlacementCapacity#chooseNode` select less used space node through the following code:
```java
datanodeDetails = ! firstNodeMetric.isGreater(secondNodeMetric.get()) ? firstNodeDetails : secondNodeDetails; 
```
More used node should be return in `SCMNodeMetric#isGreater`, rather than more remaining  node.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-9315

## How was this patch tested?

TestDatanodeMetrics passed
