### PR TITLE
HDDS-9272. Performance improvement for OM's sort datanodes

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/protocol/StorageContainerLocationProtocol.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/protocol/StorageContainerLocationProtocol.java
@@ -100,6 +100,18 @@ public interface StorageContainerLocationProtocol extends Closeable {
       throws IOException;
 
   /**
+   * getContainerWithPipeline with an optional sortDatanodes in container
+   * pipelines.
+   *
+   * @param containerID - ID of the container.
+   * @param shouldSortDatanodes - true to sort datanodes in container pipelines.
+   * @return ContainerWithPipeline - the container info with the pipeline.
+   * @throws IOException
+   */
+  ContainerWithPipeline getContainerPipeline(long containerID,
+      boolean shouldSortDatanodes) throws IOException;
+
+  /**
    * Gets the list of ReplicaInfo known by SCM for a given container.
    * @param containerId ID of the container
    * @return List of ReplicaInfo for the container or an empty list if none.
@@ -119,6 +131,20 @@ public interface StorageContainerLocationProtocol extends Closeable {
    */
   List<ContainerWithPipeline> getContainerWithPipelineBatch(
       Iterable<? extends Long> containerIDs) throws IOException;
+
+  /**
+   * getContainerWithPipelineBatch with an optional sortDatanodes in container
+   * pipelines.
+   *
+   * @param containerIDs - IDs of a batch of containers.
+   * @param shouldSortDatanodes - true to sort datanodes in container pipelines.
+   * @return List of ContainerWithPipeline
+   * - the container info with the pipeline.
+   * @throws IOException
+   */
+  List<ContainerWithPipeline> getContainerPipelineBatch(
+      Iterable<? extends Long> containerIDs, boolean shouldSortDatanodes)
+      throws IOException;
 
   /**
    * Ask SCM which containers of the given list exist.

--- a/hadoop-hdds/interface-admin/src/main/proto/ScmAdminProtocol.proto
+++ b/hadoop-hdds/interface-admin/src/main/proto/ScmAdminProtocol.proto
@@ -81,6 +81,8 @@ message ScmContainerLocationRequest {
   optional TransferLeadershipRequestProto  transferScmLeadershipRequest = 42;
   optional GetFailedDeletedBlocksTxnRequestProto getFailedDeletedBlocksTxnRequest = 43;
   optional DecommissionScmRequestProto decommissionScmRequest = 44;
+  optional GetContainerPipelineRequestProto getContainerPipelineRequest = 45;
+  optional GetContainerPipelineBatchRequestProto getContainerPipelineBatchRequest = 46;
 }
 
 message ScmContainerLocationResponse {
@@ -184,6 +186,8 @@ enum Type {
   TransferLeadership = 38;
   GetFailedDeletedBlocksTransaction = 39;
   DecommissionScm = 40;
+  GetContainerPipeline = 41;
+  GetContainerPipelineBatch = 42;
 }
 
 /**
@@ -228,6 +232,12 @@ message GetContainerWithPipelineRequestProto {
 
 }
 
+message GetContainerPipelineRequestProto {
+  required int64 containerID = 1;
+  optional string traceID = 2;
+  optional bool sortDatanodes = 3 [default = true];
+}
+
 message GetContainerWithPipelineResponseProto {
   required ContainerWithPipeline containerWithPipeline = 1;
 }
@@ -244,6 +254,12 @@ message GetContainerReplicasResponseProto {
 message GetContainerWithPipelineBatchRequestProto {
   repeated int64 containerIDs = 1;
   optional string traceID = 2;
+}
+
+message GetContainerPipelineBatchRequestProto {
+  repeated int64 containerIDs = 1;
+  optional string traceID = 2;
+  optional bool sortDatanodes = 3 [default = true];
 }
 
 message GetExistContainerWithPipelinesInBatchRequestProto {

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/KeyManagerImpl.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/KeyManagerImpl.java
@@ -1953,11 +1953,6 @@ public class KeyManagerImpl implements KeyManager {
       captureLatencyNs(metrics.getGetKeyInfoRefreshLocationLatencyNs(),
           () -> refreshPipelineFromCache(value,
               args.isForceUpdateContainerCacheFromSCM()));
-
-      if (args.getSortDatanodes()) {
-        captureLatencyNs(metrics.getGetKeyInfoSortDatanodesLatencyNs(),
-            () -> sortDatanodes(clientAddress, value));
-      }
     }
     return value;
   }
@@ -1973,7 +1968,7 @@ public class KeyManagerImpl implements KeyManager {
     // location is outdated, it'll call getKeyInfo with cacheRefresh=true
     // to request cache refresh on individual container.
     Map<Long, Pipeline> containerLocations =
-        scmClient.getContainerLocations(containerIds, false);
+        scmClient.getContainerLocations(containerIds, false, true);
 
     for (OmKeyInfo keyInfo : keyInfos) {
       setUpdatedContainerLocation(keyInfo, containerLocations);
@@ -1988,7 +1983,7 @@ public class KeyManagerImpl implements KeyManager {
 
     metrics.setForceContainerCacheRefresh(forceRefresh);
     Map<Long, Pipeline> containerLocations =
-        scmClient.getContainerLocations(containerIds, forceRefresh);
+        scmClient.getContainerLocations(containerIds, forceRefresh, true);
 
     setUpdatedContainerLocation(keyInfo, containerLocations);
   }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/PipelineCacheKey.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/PipelineCacheKey.java
@@ -1,0 +1,60 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package org.apache.hadoop.ozone.om;
+
+import java.util.Objects;
+
+/**
+ * Cache key used by {@link org.apache.hadoop.ozone.om.ScmClient}.
+ */
+public class PipelineCacheKey {
+  private final Long containerId;
+  private final boolean datanodeSorted;
+
+  public PipelineCacheKey(Long containerId, boolean datanodeSorted) {
+    this.containerId = containerId;
+    this.datanodeSorted = datanodeSorted;
+  }
+
+  public Long getContainerId() {
+    return containerId;
+  }
+
+  public boolean isDatanodeSorted() {
+    return datanodeSorted;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    PipelineCacheKey that = (PipelineCacheKey) o;
+    return containerId == that.containerId &&
+        datanodeSorted == that.datanodeSorted;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(containerId, datanodeSorted);
+  }
+}

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestScmClient.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestScmClient.java
@@ -117,7 +117,7 @@ public class TestScmClient {
         .getContainerWithPipelineBatch(eq(prepopulatedIds)))
         .thenReturn(new ArrayList<>(actualLocations.values()));
     Map<Long, Pipeline> locations =
-        scmClient.getContainerLocations(prepopulatedIds, false);
+        scmClient.getContainerLocations(prepopulatedIds, false, false);
     locations.forEach((id, pipeline) -> {
       Assertions.assertEquals(actualLocations.get(id).getPipeline(), pipeline);
     });
@@ -136,7 +136,8 @@ public class TestScmClient {
           eq(expectedScmCallIds))).thenReturn(scmLocations);
     }
 
-    locations = scmClient.getContainerLocations(testContainerIds, forceRefresh);
+    locations =
+        scmClient.getContainerLocations(testContainerIds, forceRefresh, false);
     locations.forEach((id, pipeline) -> {
       Assertions.assertEquals(actualLocations.get(id).getPipeline(), pipeline);
     });
@@ -154,7 +155,7 @@ public class TestScmClient {
         .getContainerWithPipelineBatch(newHashSet(1L)))
         .thenThrow(ioException);
     IOException actual = Assertions.assertThrows(IOException.class,
-        () -> scmClient.getContainerLocations(newHashSet(1L), false));
+        () -> scmClient.getContainerLocations(newHashSet(1L), false, false));
     Assertions.assertEquals(ioException, actual);
 
     RuntimeException runtimeException = new IllegalStateException("Test");
@@ -162,7 +163,7 @@ public class TestScmClient {
         .getContainerWithPipelineBatch(newHashSet(2L)))
         .thenThrow(runtimeException);
     RuntimeException actualRt = Assertions.assertThrows(RuntimeException.class,
-        () -> scmClient.getContainerLocations(newHashSet(2L), false));
+        () -> scmClient.getContainerLocations(newHashSet(2L), false, false));
     Assertions.assertEquals(runtimeException, actualRt.getCause());
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

After the implementation of [HDDS-8300](https://issues.apache.org/jira/browse/HDDS-8300), get key metadata API in OM sorts datanodes to allow clients to optimize data I/O based on locality. However, as of today, this requires OM to make additional calls to SCM for sorting the datanodes. 

The get key metadata API makes 2 separate calls to SCM: one to retrieve the container pipelines and the second responsible for sorting the datanodes in the container pipelines, as illustrated in the code snippet [KeyManagerImpl#getKeyInfo](https://github.com/apache/ozone/blob/master/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/KeyManagerImpl.java#L1946-L1959): 
```
if (!args.isHeadOp()) {
...
      // get container pipeline info from cache.
      captureLatencyNs(metrics.getGetKeyInfoRefreshLocationLatencyNs(),
          () -> refreshPipelineFromCache(value,
              args.isForceUpdateContainerCacheFromSCM()));

      if (args.getSortDatanodes()) {
        sortDatanodes(clientAddress, value);
      }
```

For performance enhancement, these two calls can be combined into one allowing the result to be cached in the existing `containerLocationCache` in `ScmClient`. More details on the analysis and implementation can be found [here](https://issues.apache.org/jira/browse/HDDS-9272).

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-9272

## How was this patch tested?

The existing tests should cover the changes.
