### PR TITLE
HDDS-9263. Intermittent error in TestOzoneManagerHAMetadataOnly#testAllVolumeOperations.

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerHA.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerHA.java
@@ -205,7 +205,6 @@ public abstract class TestOzoneManagerHA {
   @AfterEach
   public void resetCluster()
       throws IOException {
-    IOUtils.closeQuietly(client);
     if (cluster != null) {
       cluster.restartOzoneManager();
     }
@@ -216,6 +215,7 @@ public abstract class TestOzoneManagerHA {
    */
   @AfterAll
   public static void shutdown() {
+    IOUtils.closeQuietly(client);
     if (cluster != null) {
       cluster.shutdown();
     }


### PR DESCRIPTION
## What changes were proposed in this pull request?

After having multiple runs we encountered the following error in `TestOzoneManagerHAMetadataOnly` `testAllVolumeOperations`
Looking at the logs we were able to see the error that the ozone client was not able to connect to any of the OM nodes.
```
--
2023-09-06 16:05:30,277 [main] ERROR ha.OMFailoverProxyProviderBase (OMFailoverProxyProviderBase.java:getRetryAction(224)) - Failed to connect to OMs: [omNode-1, omNode-2, omNode-3]. Attempted 5 failovers.
2023-09-06 16:05:30,280 [main] INFO  om.OzoneManager (OzoneManager.java:stop(2204)) - omNode-3[localhost:15012]: Stopping Ozone Manager
2023-09-06 16:05:30,280 [main] INFO  ipc.Server (Server.java:stop(3523)) - Stopping server on 15012
2023-09-06 16:05:30,282 [IPC Server listener on 15012] INFO  ipc.Server (Server.java:run(1434)) - Stopping IPC Server listener on 15012
2023-09-06 16:05:30,284 [IPC Server Responder] INFO  ipc.Server (Server.java:run(1567)) - Stopping IPC Server Responder
2023-09-06 16:05:30,287 [main] INFO  server.RaftServer (RaftServerProxy.java:lambda$close$6(416)) - omNode-3: close
2023-09-06 16:05:30,287 [main] INFO  server.GrpcService (GrpcService.java:closeImpl(311)) - omNode-3: shutdown server GrpcServerProtocolService now
2023-09-06 16:05:30,289 [omNode-3-impl-thread1] INFO  server.RaftServer$Division (RaftServerImpl.java:lambda$close$4(466)) - omNode-3@group-523986131536: shutdown
2023-09-06 16:05:30,290 [omNode-3-impl-thread1] INFO  util.JmxRegister (JmxRegister.java:unregister(73)) - Successfully un-registered JMX Bean with object name Ratis:service=RaftServer,group=group-523986131536,id=omNode-3
2023-09-06 16:05:30,290 [omNode-3-impl-thread1] INFO  impl.RoleInfo (RoleInfo.java:shutdownFollowerState(110)) - omNode-3: shutdown omNode-3@group-523986131536-FollowerState
2023-09-06 16:05:30,290 [omNode-3-impl-thread1] INFO  impl.StateMachineUpdater (StateMachineUpdater.java:stopAndJoin(155)) - omNode-3@group-523986131536-StateMachineUpdater: set stopIndex = 54
--
```
## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-9263

## How was this patch tested?

Ran the test a total of 200 times to check if the error shows up and the CI ran successfully. 
Test Runs :- 
1. https://github.com/ArafatKhan2198/ozone/actions/runs/6235727447
2. https://github.com/ArafatKhan2198/ozone/actions/runs/6235729232