### PR TITLE
HDDS-6645. Intermittent timeout in TestOzoneFileSystem#testTrash.

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFileSystem.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFileSystem.java
@@ -1655,7 +1655,7 @@ public class TestOzoneFileSystem {
     trash.moveToTrash(path);
 
     Assert.assertTrue(o3fs.exists(userTrash));
-    Assert.assertTrue(o3fs.exists(userTrashCurrent) || o3fs.listStatus(
+    Assert.assertTrue(o3fs.exists(trashPath) || o3fs.listStatus(
         o3fs.listStatus(userTrash)[0].getPath()).length > 0);
 
     // Wait until the TrashEmptier purges the key

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/TrashOzoneFileSystem.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/TrashOzoneFileSystem.java
@@ -448,7 +448,7 @@ public class TrashOzoneFileSystem extends FileSystem {
         String keyPrefix) throws IOException {
       OMMetadataManager metadataManager = ozoneManager.getMetadataManager();
       return metadataManager.listKeys(volumeName, bucketName, startKey,
-              keyPrefix, OZONE_MAX_LIST_KEYS_SIZE).stream()
+              keyPrefix, OZONE_MAX_LIST_KEYS_SIZE).getKeys().stream()
           .map(OmKeyInfo::getKeyName)
           .collect(Collectors.toList());
     }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/TrashOzoneFileSystem.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/TrashOzoneFileSystem.java
@@ -56,6 +56,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Iterator;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.stream.Collectors;
 
 import static org.apache.hadoop.ozone.OzoneConsts.OZONE_O3TRASH_URI_SCHEME;
 import static org.apache.hadoop.ozone.OzoneConsts.OZONE_URI_DELIMITER;
@@ -348,7 +349,7 @@ public class TrashOzoneFileSystem extends FileSystem {
     private final Path path;
     private final FileStatus status;
     private String pathKey;
-    private Iterator<OmKeyInfo> keyIterator;
+    private Iterator<String> keyIterator;
 
     OzoneListingIterator(Path path)
           throws IOException {
@@ -365,23 +366,18 @@ public class TrashOzoneFileSystem extends FileSystem {
               fsPath.getKeyName());
     }
 
-    private Iterator<OmKeyInfo> getKeyIterator(String volumeName,
+    private Iterator<String> getKeyIterator(String volumeName,
         String bucketName, String keyName) throws IOException {
-      OMMetadataManager metadataManager = ozoneManager.getMetadataManager();
-      List<OmKeyInfo> keys = new ArrayList<>(
-          metadataManager.listKeys(volumeName, bucketName, "", keyName,
-              OZONE_MAX_LIST_KEYS_SIZE));
-      String lastKey = keys.get(keys.size() - 1).getKeyName();
-      List<OmKeyInfo> nextBatchKeys =
-          metadataManager.listKeys(volumeName, bucketName, lastKey, keyName,
-              OZONE_MAX_LIST_KEYS_SIZE);
+      List<String> keys = new ArrayList<>(
+          listKeys(volumeName, bucketName, "", keyName));
+      String lastKey = keys.get(keys.size() - 1);
+      List<String> nextBatchKeys =
+          listKeys(volumeName, bucketName, lastKey, keyName);
 
       while (!nextBatchKeys.isEmpty()) {
         keys.addAll(nextBatchKeys);
-        lastKey = nextBatchKeys.get(nextBatchKeys.size() - 1).getKeyName();
-        nextBatchKeys =
-            metadataManager.listKeys(volumeName, bucketName, lastKey, keyName,
-                OZONE_MAX_LIST_KEYS_SIZE);
+        lastKey = nextBatchKeys.get(nextBatchKeys.size() - 1);
+        nextBatchKeys = listKeys(volumeName, bucketName, lastKey, keyName);
       }
       return keys.iterator();
     }
@@ -416,8 +412,8 @@ public class TrashOzoneFileSystem extends FileSystem {
         String ofsPathprefix =
             ofsPath.getNonKeyPathNoPrefixDelim() + OZONE_URI_DELIMITER;
         while (keyIterator.hasNext()) {
-          OmKeyInfo  kv = keyIterator.next();
-          String keyPath = ofsPathprefix + kv.getKeyName();
+          String keyName = keyIterator.next();
+          String keyPath = ofsPathprefix + keyName;
           LOG.trace("iterating key path: {}", keyPath);
           keyPathList.add(keyPath);
           if (keyPathList.size() >= OZONE_FS_ITERATE_BATCH_SIZE) {
@@ -443,6 +439,18 @@ public class TrashOzoneFileSystem extends FileSystem {
 
     FileStatus getStatus() {
       return status;
+    }
+
+    /**
+     * Return a listKeys output with only a list of keyNames.
+     */
+    List<String> listKeys(String volumeName, String bucketName, String startKey,
+        String keyPrefix) throws IOException {
+      OMMetadataManager metadataManager = ozoneManager.getMetadataManager();
+      return metadataManager.listKeys(volumeName, bucketName, startKey,
+              keyPrefix, OZONE_MAX_LIST_KEYS_SIZE).stream()
+          .map(OmKeyInfo::getKeyName)
+          .collect(Collectors.toList());
     }
   }
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/TrashPolicyOzone.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/TrashPolicyOzone.java
@@ -348,7 +348,7 @@ public class TrashPolicyOzone extends TrashPolicyDefault {
       }
     }
 
-    public Runnable getEmptierTask(Path trashRootPath, TrashPolicyOzone trash,
+    private Runnable getEmptierTask(Path trashRootPath, TrashPolicyOzone trash,
         boolean deleteImmediately) {
       Runnable task = () -> {
         try {

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/TrashPolicyOzone.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/TrashPolicyOzone.java
@@ -322,17 +322,8 @@ public class TrashPolicyOzone extends TrashPolicyDefault {
                 continue;
               }
               TrashPolicyOzone trash = new TrashPolicyOzone(fs, conf, om);
-              Runnable task = () -> {
-                try {
-                  om.getMetrics().incNumTrashRootsProcessed();
-                  trash.deleteCheckpoint(trashRoot.getPath(), false);
-                  trash.createCheckpoint(trashRoot.getPath(),
-                      new Date(Time.now()));
-                } catch (Exception e) {
-                  om.getMetrics().incNumTrashFails();
-                  LOG.error("Unable to checkpoint:" + trashRoot.getPath(), e);
-                }
-              };
+              Path trashRootPath = trashRoot.getPath();
+              Runnable task = getEmptierTask(trashRootPath, trash, false);
               om.getMetrics().incNumTrashRootsEnqueued();
               executor.submit(task);
             }
@@ -355,6 +346,21 @@ public class TrashPolicyOzone extends TrashPolicyDefault {
           Thread.currentThread().interrupt();
         }
       }
+    }
+
+    public Runnable getEmptierTask(Path trashRootPath, TrashPolicyOzone trash,
+        boolean deleteImmediately) {
+      Runnable task = () -> {
+        try {
+          om.getMetrics().incNumTrashRootsProcessed();
+          trash.deleteCheckpoint(trashRootPath, deleteImmediately);
+          trash.createCheckpoint(trashRootPath, new Date(Time.now()));
+        } catch (Exception e) {
+          om.getMetrics().incNumTrashFails();
+          LOG.error("Unable to checkpoint:" + trashRootPath, e);
+        }
+      };
+      return task;
     }
 
     private long ceiling(long time, long interval) {


### PR DESCRIPTION
## What changes were proposed in this pull request?

1. Modify the check in the test  after the key moves to trash to to assert that the key is either in the Current or the checkpoint directory as the checkpoint could immediately happen in some cases.
2. Make Trash FS Ozone Listing Iterator use omMetadataManager#listKeys instead of iterating the Raw key table directly as it won't account for keys in Cache. This solves cases where if Cache is not flushed after rename to trash  or delete from trash.
3. One of the main fixes for this is to fix createFakeDirIfShould to avoid race condition b/w cache flush and opening an older KeyTable Iterator reference solved by #5252 
## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-6645

## How was this patch tested?
Unit test
Ran the test successfully for 15x10 = 150 times here : https://github.com/sadanand48/hadoop-ozone/actions/runs/6304966964