### PR TITLE
HDDS-9328. Speed up testListStatusIteratorOnPageSize

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/OzoneFileSystemTests.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/OzoneFileSystemTests.java
@@ -1,0 +1,96 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.fs.ozone;
+
+import org.apache.hadoop.fs.FileStatus;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.fs.RemoteIterator;
+import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+
+import java.io.IOException;
+import java.util.Objects;
+import java.util.Set;
+import java.util.TreeSet;
+
+import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_FS_LISTING_PAGE_SIZE;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Common test cases for Ozone file systems.
+ */
+final class OzoneFileSystemTests {
+
+  private OzoneFileSystemTests() {
+    // no instances
+  }
+
+  /**
+   * Tests listStatusIterator operation on directory with different
+   * numbers of child directories.
+   */
+  public static void listStatusIteratorOnPageSize(OzoneConfiguration conf,
+      String rootPath) throws IOException {
+    final int pageSize = 32;
+    int[] dirCounts = {
+        1,
+        pageSize - 1,
+        pageSize,
+        pageSize + 1,
+        pageSize + pageSize / 2,
+        pageSize + pageSize
+    };
+    OzoneConfiguration config = new OzoneConfiguration(conf);
+    config.setInt(OZONE_FS_LISTING_PAGE_SIZE, pageSize);
+    FileSystem subject = FileSystem.get(config);
+    Path dir = new Path(Objects.requireNonNull(rootPath), "listStatusIterator");
+    try {
+      Set<String> paths = new TreeSet<>();
+      for (int dirCount : dirCounts) {
+        listStatusIterator(subject, dir, paths, dirCount);
+      }
+    } finally {
+      subject.delete(dir, true);
+    }
+  }
+
+  private static void listStatusIterator(FileSystem subject,
+      Path dir, Set<String> paths, int total) throws IOException {
+    for (int i = paths.size(); i < total; i++) {
+      Path p = new Path(dir, String.valueOf(i));
+      subject.mkdirs(p);
+      paths.add(p.getName());
+    }
+
+    RemoteIterator<FileStatus> iterator = subject.listStatusIterator(dir);
+    int iCount = 0;
+    if (iterator != null) {
+      while (iterator.hasNext()) {
+        FileStatus fileStatus = iterator.next();
+        iCount++;
+        String filename = fileStatus.getPath().getName();
+        assertTrue(filename + " not found", paths.contains(filename));
+      }
+    }
+
+    assertEquals(
+        "Total directories listed do not match the existing directories",
+        total, iCount);
+  }
+}

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFileSystem.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFileSystem.java
@@ -951,65 +951,10 @@ public class TestOzoneFileSystem {
     }
   }
 
-  /**
-   * Tests listStatusIterator operation on root directory with different
-   * numbers of numDir.
-   */
   @Test
   public void testListStatusIteratorOnPageSize() throws Exception {
-    int[] pageSize = {
-        1, LISTING_PAGE_SIZE, LISTING_PAGE_SIZE + 1,
-        LISTING_PAGE_SIZE - 1, LISTING_PAGE_SIZE + LISTING_PAGE_SIZE / 2,
-        LISTING_PAGE_SIZE + LISTING_PAGE_SIZE
-    };
-    for (int numDir : pageSize) {
-      int range = numDir / LISTING_PAGE_SIZE;
-      switch (range) {
-      case 0:
-        listStatusIterator(numDir);
-        break;
-      case 1:
-        listStatusIterator(numDir);
-        break;
-      case 2:
-        listStatusIterator(numDir);
-        break;
-      default:
-        listStatusIterator(numDir);
-      }
-    }
-  }
-
-  private void listStatusIterator(int numDirs) throws IOException {
-    Path root = new Path("/" + volumeName + "/" + bucketName);
-    Set<String> paths = new TreeSet<>();
-    try {
-      for (int i = 0; i < numDirs; i++) {
-        Path p = new Path(root, String.valueOf(i));
-        fs.mkdirs(p);
-        paths.add(p.getName());
-      }
-
-      RemoteIterator<FileStatus> iterator = o3fs.listStatusIterator(root);
-      int iCount = 0;
-      if (iterator != null) {
-        while (iterator.hasNext()) {
-          FileStatus fileStatus = iterator.next();
-          iCount++;
-          Assert.assertTrue(paths.contains(fileStatus.getPath().getName()));
-        }
-      }
-      Assert.assertEquals(
-          "Total directories listed do not match the existing directories",
-          numDirs, iCount);
-
-    } finally {
-      // Cleanup
-      for (int i = 0; i < numDirs; i++) {
-        Path p = new Path(root, String.valueOf(i));
-        fs.delete(p, true);
-      }
-    }
+    OzoneFileSystemTests.listStatusIteratorOnPageSize(cluster.getConf(),
+        "/" + volumeName + "/" + bucketName);
   }
 
   /**

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestRootedOzoneFileSystem.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestRootedOzoneFileSystem.java
@@ -563,59 +563,8 @@ public class TestRootedOzoneFileSystem {
    */
   @Test
   public void testListStatusIteratorOnPageSize() throws Exception {
-    int[] pageSize = {
-        1, LISTING_PAGE_SIZE, LISTING_PAGE_SIZE + 1,
-        LISTING_PAGE_SIZE - 1, LISTING_PAGE_SIZE + LISTING_PAGE_SIZE / 2,
-        LISTING_PAGE_SIZE + LISTING_PAGE_SIZE
-    };
-    for (int numDir : pageSize) {
-      int range = numDir / LISTING_PAGE_SIZE;
-      switch (range) {
-      case 0:
-        listStatusIterator(numDir);
-        break;
-      case 1:
-        listStatusIterator(numDir);
-        break;
-      case 2:
-        listStatusIterator(numDir);
-        break;
-      default:
-        listStatusIterator(numDir);
-      }
-    }
-  }
-
-  private void listStatusIterator(int numDirs) throws IOException {
-    Path root = new Path("/" + volumeName + "/" + bucketName);
-    Set<String> paths = new TreeSet<>();
-    try {
-      for (int i = 0; i < numDirs; i++) {
-        Path p = new Path(root, String.valueOf(i));
-        fs.mkdirs(p);
-        paths.add(p.getName());
-      }
-
-      RemoteIterator<FileStatus> iterator = ofs.listStatusIterator(root);
-      int iCount = 0;
-      if (iterator != null) {
-        while (iterator.hasNext()) {
-          FileStatus fileStatus = iterator.next();
-          iCount++;
-          Assert.assertTrue(paths.contains(fileStatus.getPath().getName()));
-        }
-      }
-      Assert.assertEquals(
-          "Total directories listed do not match the existing directories",
-          numDirs, iCount);
-
-    } finally {
-      // Cleanup
-      for (int i = 0; i < numDirs; i++) {
-        Path p = new Path(root, String.valueOf(i));
-        fs.delete(p, true);
-      }
-    }
+    OzoneFileSystemTests.listStatusIteratorOnPageSize(conf,
+        "/" + volumeName + "/" + bucketName);
   }
 
   /**


### PR DESCRIPTION
## What changes were proposed in this pull request?

Speed up `testListStatusIteratorOnPageSize` by:

* Reduce the number of directory entries created for testing iterator paging (set smaller page size in config).
* Keep entries from smaller batch to larger one, only create additional entries.  Delete only at the end.

Also reduce code duplication, extract method to common test class.

https://issues.apache.org/jira/browse/HDDS-9328

## How was this patch tested?

Before:

```
Tests run: 176, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 337.616 s - in org.apache.hadoop.fs.ozone.TestOzoneFileSystem
Tests run: 102, Failures: 0, Errors: 0, Skipped: 10, Time elapsed: 135.095 s - in org.apache.hadoop.fs.ozone.TestOzoneFileSystemWithFSO
Tests run: 250, Failures: 0, Errors: 0, Skipped: 9, Time elapsed: 547.686 s - in org.apache.hadoop.fs.ozone.TestRootedOzoneFileSystem
Tests run: 108, Failures: 0, Errors: 0, Skipped: 16, Time elapsed: 203.204 s - in org.apache.hadoop.fs.ozone.TestRootedOzoneFileSystemWithFSO
```

https://github.com/apache/ozone/actions/runs/6245661295/job/16955525758

After:

```
Tests run: 176, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 166.418 s - in org.apache.hadoop.fs.ozone.TestOzoneFileSystem
Tests run: 102, Failures: 0, Errors: 0, Skipped: 10, Time elapsed: 69.49 s - in org.apache.hadoop.fs.ozone.TestOzoneFileSystemWithFSO
Tests run: 250, Failures: 0, Errors: 0, Skipped: 9, Time elapsed: 250.157 s - in org.apache.hadoop.fs.ozone.TestRootedOzoneFileSystem
Tests run: 108, Failures: 0, Errors: 0, Skipped: 16, Time elapsed: 119.134 s - in org.apache.hadoop.fs.ozone.TestRootedOzoneFileSystemWithFSO
```

https://github.com/adoroszlai/hadoop-ozone/actions/runs/6248472464/job/16964041346