### PR TITLE
HDDS-9330. Optimize container lookup by owner during block allocation

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/ContainerManagerImpl.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/ContainerManagerImpl.java
@@ -21,7 +21,6 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.NavigableSet;

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/ContainerManagerImpl.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/ContainerManagerImpl.java
@@ -362,7 +362,6 @@ public class ContainerManagerImpl implements ContainerManager {
       Pipeline pipeline, String owner) throws IOException {
     NavigableSet<ContainerID> containerIDs =
         pipelineManager.getContainersInPipeline(pipeline.getId());
-    containerIDs = new TreeSet<>(containerIDs);
     final Set<ContainerID> containerIDsByOwner =
         containerStateManager.getContainerIDs(owner);
     containerIDs.retainAll(containerIDsByOwner);

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/ContainerManagerImpl.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/ContainerManagerImpl.java
@@ -28,6 +28,7 @@ import java.util.NavigableSet;
 import java.util.Optional;
 import java.util.Random;
 import java.util.Set;
+import java.util.TreeSet;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 
@@ -362,18 +363,10 @@ public class ContainerManagerImpl implements ContainerManager {
       Pipeline pipeline, String owner) throws IOException {
     NavigableSet<ContainerID> containerIDs =
         pipelineManager.getContainersInPipeline(pipeline.getId());
-    Iterator<ContainerID> containerIDIterator = containerIDs.iterator();
-    while (containerIDIterator.hasNext()) {
-      ContainerID cid = containerIDIterator.next();
-      try {
-        if (!getContainer(cid).getOwner().equals(owner)) {
-          containerIDIterator.remove();
-        }
-      } catch (ContainerNotFoundException e) {
-        LOG.error("Could not find container info for container {}", cid, e);
-        containerIDIterator.remove();
-      }
-    }
+    containerIDs = new TreeSet<>(containerIDs);
+    final Set<ContainerID> containerIDsByOwner =
+        containerStateManager.getContainerIDs(owner);
+    containerIDs.retainAll(containerIDsByOwner);
     return containerIDs;
   }
 

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/ContainerManagerImpl.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/ContainerManagerImpl.java
@@ -27,7 +27,6 @@ import java.util.NavigableSet;
 import java.util.Optional;
 import java.util.Random;
 import java.util.Set;
-import java.util.TreeSet;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/ContainerStateManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/ContainerStateManager.java
@@ -117,6 +117,11 @@ public interface ContainerStateManager {
   /**
    *
    */
+  Set<ContainerID> getContainerIDs(String ownerName);
+
+  /**
+   *
+   */
   ContainerInfo getContainer(ContainerID id);
 
   /**

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/ContainerStateManagerImpl.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/ContainerStateManagerImpl.java
@@ -291,6 +291,16 @@ public final class ContainerStateManagerImpl
   }
 
   @Override
+  public Set<ContainerID> getContainerIDs(final String owner) {
+    lock.readLock().lock();
+    try {
+      return containers.getContainerIDsByOwner(owner);
+    } finally {
+      lock.readLock().unlock();
+    }
+  }
+
+  @Override
   public ContainerInfo getContainer(final ContainerID id) {
     try (AutoCloseableLock ignored = readLock(id)) {
       return containers.getContainerInfo(id);

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/ContainerStateManagerImpl.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/ContainerStateManagerImpl.java
@@ -292,11 +292,8 @@ public final class ContainerStateManagerImpl
 
   @Override
   public Set<ContainerID> getContainerIDs(final String owner) {
-    lock.readLock().lock();
-    try {
+    try (AutoCloseableLock ignored = readLock()) {
       return containers.getContainerIDsByOwner(owner);
-    } finally {
-      lock.readLock().unlock();
     }
   }
 

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/states/ContainerAttribute.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/states/ContainerAttribute.java
@@ -189,8 +189,9 @@ public class ContainerAttribute<T> {
   public NavigableSet<ContainerID> getCollection(T key) {
     Preconditions.checkNotNull(key);
 
-    if (this.attributeMap.containsKey(key)) {
-      return ImmutableSortedSet.copyOf(this.attributeMap.get(key));
+    final NavigableSet<ContainerID> set = attributeMap.get(key);
+    if (set != null) {
+      return ImmutableSortedSet.copyOf(set);
     }
     if (LOG.isDebugEnabled()) {
       LOG.debug("No such Key. Key {}", key);

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/states/ContainerStateMap.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/states/ContainerStateMap.java
@@ -305,7 +305,7 @@ public class ContainerStateMap {
    * @param ownerName - Name of the NameService.
    * @return - NavigableSet of ContainerIDs.
    */
-  NavigableSet<ContainerID> getContainerIDsByOwner(final String ownerName) {
+  public NavigableSet<ContainerID> getContainerIDsByOwner(final String ownerName) {
     Preconditions.checkNotNull(ownerName);
     return ownerMap.getCollection(ownerName);
   }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/states/ContainerStateMap.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/states/ContainerStateMap.java
@@ -305,7 +305,8 @@ public class ContainerStateMap {
    * @param ownerName - Name of the NameService.
    * @return - NavigableSet of ContainerIDs.
    */
-  public NavigableSet<ContainerID> getContainerIDsByOwner(final String ownerName) {
+  public NavigableSet<ContainerID> getContainerIDsByOwner(
+      final String ownerName) {
     Preconditions.checkNotNull(ownerName);
     return ownerMap.getCollection(ownerName);
   }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Allocate ratis block latency optimization

When applying for blocks, if the number of containers under a pipeline is high, it will consume a lot of time in filtering the owner's part.

This pr optimizes the time consumed by filtering owners, and after testing in real scenarios.

See jira for performance details.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-9330

## How was this patch tested?

existing UT

ci see: https://github.com/guohao-rosicky/ozone/actions/runs/6248198048

