### PR TITLE
HDDS-9332. Handle empty unit check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,9 +26,10 @@ jobs:
       GITHUB_CONTEXT: ${{ toJson(github) }}
     outputs:
       acceptance-suites: ${{ steps.acceptance-suites.outputs.suites }}
-      needs-basic-checks: ${{ steps.selective-checks.outputs.needs-basic-checks }}
+      needs-basic-check: ${{ steps.categorize-basic-checks.outputs.needs-basic-check }}
+      needs-unit-check: ${{ steps.categorize-basic-checks.outputs.needs-unit-check }}
       basic-checks: ${{ steps.categorize-basic-checks.outputs.basic-checks }}
-      basic-unit: ${{ steps.categorize-basic-checks.outputs.basic-unit }}
+      unit-checks: ${{ steps.categorize-basic-checks.outputs.unit-checks }}
       needs-build: ${{ steps.selective-checks.outputs.needs-build }}
       needs-compile: ${{ steps.selective-checks.outputs.needs-compile }}
       needs-compose-tests: ${{ steps.selective-checks.outputs.needs-compose-tests }}
@@ -172,7 +173,7 @@ jobs:
       - build-info
     runs-on: ubuntu-20.04
     timeout-minutes: 90
-    if: needs.build-info.outputs.needs-basic-checks == 'true'
+    if: needs.build-info.outputs.needs-basic-check == 'true'
     strategy:
       matrix:
         check: ${{ fromJson(needs.build-info.outputs.basic-checks) }}
@@ -225,10 +226,10 @@ jobs:
       - basic
     runs-on: ubuntu-20.04
     timeout-minutes: 90
-    if: needs.build-info.outputs.needs-basic-checks == 'true'
+    if: needs.build-info.outputs.needs-unit-check == 'true'
     strategy:
       matrix:
-        check: ${{ fromJson(needs.build-info.outputs.basic-unit) }}
+        check: ${{ fromJson(needs.build-info.outputs.unit-checks) }}
       fail-fast: false
     steps:
       - name: Checkout project

--- a/dev-support/ci/categorize_basic_checks.sh
+++ b/dev-support/ci/categorize_basic_checks.sh
@@ -36,20 +36,28 @@ UNIT_CHECKS=$(grep -lr '^#checks:unit' hadoop-ozone/dev-support/checks \
 
 if [[ -n "${SPACE_DELIMITED_ALL_CHECKS}" ]]; then
     SPACE_DELIMITED_ALL_CHECKS=" ${SPACE_DELIMITED_ALL_CHECKS[*]} "     # add framing blanks
+    basic=()
     for item in ${BASIC_CHECKS[@]}; do
       if [[ $SPACE_DELIMITED_ALL_CHECKS =~ " $item " ]] ; then          # use $item as regexp
         basic+=($item)
       fi
     done
+    if [[ -n "${basic[@]}" ]]; then
+        initialization::ga_output needs-basic-check "true"
+    fi
     initialization::ga_output basic-checks \
         "$(initialization::parameters_to_json ${basic[@]})"
 
+    unit=()
     for item in ${UNIT_CHECKS[@]}; do
       if [[ $SPACE_DELIMITED_ALL_CHECKS =~ " $item " ]] ; then    # use $item as regexp
         unit+=($item)
       fi
     done
-    initialization::ga_output basic-unit \
+    if [[ -n "${unit[@]}" ]]; then
+        initialization::ga_output needs-unit-check "true"
+    fi
+    initialization::ga_output unit-checks \
         "$(initialization::parameters_to_json ${unit[@]})"
 fi
 

--- a/dev-support/ci/selective_ci_checks.sh
+++ b/dev-support/ci/selective_ci_checks.sh
@@ -551,9 +551,6 @@ function calculate_test_types_to_run() {
 function set_outputs() {
     # print results outside the group to increase visibility
 
-    if [[ -n "${BASIC_CHECKS}" ]]; then
-        initialization::ga_output needs-basic-checks "true"
-    fi
     initialization::ga_output basic-checks \
         "$(initialization::parameters_to_json ${BASIC_CHECKS})"
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

If neither unit, nor native check is required, PR check is successful, but email notification says "PR run failed", which is confusing.  [PR run](https://github.com/apache/ozone/actions/runs/6249526071) is annotated with:

```
Error when evaluating 'strategy' for job 'unit'. apache/ozone/.github/workflows/ci.yml@d74a8a98c243d5b0a9a82f5b3c21525cfea89933 (Line: 231, Col: 16): Matrix vector 'check' does not contain any values
```

https://issues.apache.org/jira/browse/HDDS-9332

## How was this patch tested?

Tested the case when no unit check is required:
https://github.com/adoroszlai/hadoop-ozone/actions/runs/6251667755

Full CI:
https://github.com/adoroszlai/hadoop-ozone/actions/runs/6251652835