### PR TITLE
HDDS-9313. Make OM service ID optional for `ozone admin om fetch-key` if only one is defined in config

### DIFF
--- a/hadoop-ozone/dist/src/main/compose/ozonesecure-ha/test.sh
+++ b/hadoop-ozone/dist/src/main/compose/ozonesecure-ha/test.sh
@@ -50,6 +50,8 @@ done
 
 execute_robot_test s3g admincli
 
+execute_robot_test s3g omha/om-fetch-key.robot
+
 execute_robot_test s3g omha/om-leader-transfer.robot
 
 execute_robot_test s3g httpfs

--- a/hadoop-ozone/dist/src/main/smoketest/omha/om-fetch-key.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/omha/om-fetch-key.robot
@@ -28,18 +28,26 @@ Test Setup          Run Keyword if    '${SECURITY_ENABLED}' == 'true'    Kinit t
 
 
 *** Test Cases ***
-Test OM Fetch-Key with OM Service ID
+Fetch Key with Valid ServiceID Specified
     ${result} =              Execute                        ozone admin om fetch-key --service-id=omservice
     Should Contain           ${result}                      Current Secret Key ID
+
+Fetch Key with Multiple ServiceIDs, Valid ServiceID Specified
     ${result} =              Execute                        ozone admin --set=ozone.om.service.ids=omservice,omservice2 om fetch-key --service-id=omservice
     Should Contain           ${result}                      Current Secret Key ID
+
+Fetch Key with Multiple ServiceIDs, Unconfigured ServiceID Specified
     ${result} =              Execute And Ignore Error       ozone admin --set=ozone.om.service.ids=omservice,omservice2 om fetch-key --service-id=omservice3
     Should Contain           ${result}                      Service ID specified does not match
+
+Fetch Key with Multiple ServiceIDs, Invalid ServiceID Specified
     ${result} =              Execute And Ignore Error       ozone admin --set=ozone.om.service.ids=omservice,omservice2 om fetch-key --service-id=omservice2
     Should Contain           ${result}                      Could not find any configured addresses for OM.
 
-Test OM Fetch-Key without OM Service ID
+Fetch Key without OM Service ID
     ${result} =              Execute                        ozone admin om fetch-key
     Should Contain           ${result}                      Current Secret Key ID
+
+Fetch Key with Multiple ServiceIDs, No ServiceID Specified
     ${result} =              Execute And Ignore Error       ozone admin --set=ozone.om.service.ids=omservice,ozone1 om fetch-key
     Should Contain           ${result}                      no Ozone Manager service ID specified

--- a/hadoop-ozone/dist/src/main/smoketest/omha/om-fetch-key.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/omha/om-fetch-key.robot
@@ -1,0 +1,45 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+*** Settings ***
+Documentation       Smoke test for om fetch-key
+Library             OperatingSystem
+Resource            ../commonlib.robot
+Test Timeout        5 minute
+Test Setup          Run Keyword if    '${SECURITY_ENABLED}' == 'true'    Kinit test user     testuser     testuser.keytab
+
+
+*** Variables ***
+
+
+*** Keywords ***
+
+
+*** Test Cases ***
+Test OM Fetch-Key with OM Service ID
+    ${result} =              Execute                        ozone admin om fetch-key --service-id=omservice
+    Should Contain           ${result}                      Current Secret Key ID
+    ${result} =              Execute                        ozone admin --set=ozone.om.service.ids=omservice,omservice2 om fetch-key --service-id=omservice
+    Should Contain           ${result}                      Current Secret Key ID
+    ${result} =              Execute And Ignore Error       ozone admin --set=ozone.om.service.ids=omservice,omservice2 om fetch-key --service-id=omservice3
+    Should Contain           ${result}                      Service ID specified does not match
+    ${result} =              Execute And Ignore Error       ozone admin --set=ozone.om.service.ids=omservice,omservice2 om fetch-key --service-id=omservice2
+    Should Contain           ${result}                      Could not find any configured addresses for OM.
+
+Test OM Fetch-Key without OM Service ID
+    ${result} =              Execute                        ozone admin om fetch-key
+    Should Contain           ${result}                      Current Secret Key ID
+    ${result} =              Execute And Ignore Error       ozone admin --set=ozone.om.service.ids=omservice,ozone1 om fetch-key
+    Should Contain           ${result}                      no Ozone Manager service ID specified

--- a/hadoop-ozone/dist/src/main/smoketest/omha/om-fetch-key.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/omha/om-fetch-key.robot
@@ -18,7 +18,7 @@ Documentation       Smoke test for om fetch-key
 Library             OperatingSystem
 Resource            ../commonlib.robot
 Test Timeout        5 minute
-Test Setup          Run Keyword if    '${SECURITY_ENABLED}' == 'true'    Kinit test user     testuser     testuser.keytab
+Suite Setup         Run Keyword if    '${SECURITY_ENABLED}' == 'true'    Kinit test user     testuser     testuser.keytab
 
 
 *** Variables ***

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/admin/om/FetchKeySubCommand.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/admin/om/FetchKeySubCommand.java
@@ -40,7 +40,7 @@ public class FetchKeySubCommand implements Callable<Void> {
   @CommandLine.Option(
       names = {"-id", "--service-id"},
       description = "Ozone Manager Service ID",
-      required = true
+      required = false
   )
   private String omServiceId;
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Currently, for ozone admin om fetch-key command, we need to specify the om service ID as its a mandatory parameter.

```
ozone admin om fetch-key
Missing required option: '--service-id=<omServiceId>'
Usage: ozone admin om fetch-key [-hV] -id=<omServiceId>
CLI command to force OM to fetch the latest secret key from SCM.
  -h, --help      Show this help message and exit.
      -id, --service-id=<omServiceId>
                  Ozone Manager Service ID
  -V, --version   Print version information and exit. 
```
Even if the omServiceId is null, its handled properly [here](https://github.com/apache/ozone/blob/4b43f158b8b5f9e0d1a58ffe81d3411729337c66/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/admin/om/OMAdmin.java#L113)

## What is the link to the Apache JIRA

[HDDS-9313](https://issues.apache.org/jira/browse/HDDS-9313)

## How was this patch tested?

Manually tested + Added Robot Test.
