### PR TITLE
HDDS-9301. Fail checks in Summary step instead of Test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -203,8 +203,9 @@ jobs:
           java-version: 8
       - name: Execute tests
         run: hadoop-ozone/dev-support/checks/${{ matrix.check }}.sh
+        continue-on-error: true
       - name: Summary of failures
-        run: cat target/${{ matrix.check }}/summary.txt
+        run: hadoop-ozone/dev-support/checks/_summary.sh target/${{ matrix.check }}/summary.txt
         if: ${{ !cancelled() }}
       - name: Archive build results
         uses: actions/upload-artifact@v3
@@ -249,8 +250,9 @@ jobs:
           java-version: 8
       - name: Execute tests
         run: hadoop-ozone/dev-support/checks/${{ matrix.check }}.sh
+        continue-on-error: true
       - name: Summary of failures
-        run: cat target/${{ matrix.check }}/summary.txt
+        run: hadoop-ozone/dev-support/checks/_summary.sh target/${{ matrix.check }}/summary.txt
         if: ${{ !cancelled() }}
   dependency:
     needs:
@@ -315,8 +317,9 @@ jobs:
           KEEP_IMAGE: false
           OZONE_ACCEPTANCE_SUITE: ${{ matrix.suite }}
           OZONE_VOLUME_OWNER: 1000
+        continue-on-error: true
       - name: Summary of failures
-        run: cat target/${{ github.job }}/summary.txt
+        run: hadoop-ozone/dev-support/checks/_summary.sh target/${{ github.job }}/summary.txt
         if: ${{ !cancelled() }}
       - name: Archive build results
         uses: actions/upload-artifact@v3
@@ -350,8 +353,9 @@ jobs:
           sudo mkdir .aws && sudo chmod 777 .aws && sudo chown 1000 .aws
           popd
           ./hadoop-ozone/dev-support/checks/kubernetes.sh
+        continue-on-error: true
       - name: Summary of failures
-        run: cat target/${{ github.job }}/summary.txt
+        run: hadoop-ozone/dev-support/checks/_summary.sh target/${{ github.job }}/summary.txt
         if: ${{ !cancelled() }}
       - name: Archive build results
         uses: actions/upload-artifact@v3
@@ -401,11 +405,13 @@ jobs:
       - name: Execute tests
         run: hadoop-ozone/dev-support/checks/integration.sh -P${{ matrix.profile }}
         if: matrix.profile != 'flaky'
+        continue-on-error: true
       - name: Execute flaky tests
         run: hadoop-ozone/dev-support/checks/integration.sh -P${{ matrix.profile }} -Dsurefire.rerunFailingTestsCount=5 -Dsurefire.fork.timeout=3600
         if: matrix.profile == 'flaky'
+        continue-on-error: true
       - name: Summary of failures
-        run: cat target/${{ github.job }}/summary.txt
+        run: hadoop-ozone/dev-support/checks/_summary.sh target/${{ github.job }}/summary.txt
         if: ${{ !cancelled() }}
       - name: Archive build results
         uses: actions/upload-artifact@v3

--- a/hadoop-ozone/dev-support/checks/_summary.sh
+++ b/hadoop-ozone/dev-support/checks/_summary.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+REPORT_FILE="$1"
+
+rc=0
+
+if [[ ! -e "${REPORT_FILE}" ]]; then
+  echo "Report file missing, check logs for details"
+  rc=255
+fi
+
+if [[ -s "${REPORT_FILE}" ]]; then
+  cat "${REPORT_FILE}"
+  rc=1
+fi
+
+exit ${rc}

--- a/hadoop-ozone/dev-support/checks/_summary.sh
+++ b/hadoop-ozone/dev-support/checks/_summary.sh
@@ -16,14 +16,24 @@
 
 REPORT_FILE="$1"
 
+: ${ITERATIONS:="1"}
+
+declare -i ITERATIONS
+
 rc=0
 
 if [[ ! -e "${REPORT_FILE}" ]]; then
   echo "Report file missing, check logs for details"
   rc=255
-fi
 
-if [[ -s "${REPORT_FILE}" ]]; then
+elif [[ ${ITERATIONS} -gt 1 ]]; then
+  cat "${REPORT_FILE}"
+
+  if grep -q 'exit code: [^0]' "${REPORT_FILE}"; then
+    rc=1
+  fi
+
+elif [[ -s "${REPORT_FILE}" ]]; then
   cat "${REPORT_FILE}"
   rc=1
 fi


### PR DESCRIPTION
## What changes were proposed in this pull request?

Ozone's CI check scripts (`integration.sh`, etc.) have 2 main conventions:
 * exit with non-zero code if there are failed tests
 * list failures in `summary.txt` or similar

Most CI jobs have a _Summary of failures_ step, which provides a quick overview by showing the contents of `summary.txt`.

Github automatically expands the failed step, which according to these conventions is the main _Execute tests_ step.  The problem is that this can have very long output.

It would be better to exit with failure in the _Summary of failures_ step, thus focusing the developer's attention on the quick overview, keeping the long output collapsed by default.

https://issues.apache.org/jira/browse/HDDS-9301

## How was this patch tested?

Triggered failure in some checks.

checkstye:
https://github.com/adoroszlai/hadoop-ozone/actions/runs/6271727304/job/17031888295

unit:
https://github.com/adoroszlai/hadoop-ozone/actions/runs/6271731311/job/17031985797

Regular CI:
https://github.com/adoroszlai/hadoop-ozone/actions/runs/6265914701