### PR TITLE
HDDS-7531. Intermittent error while removing docker network

### DIFF
--- a/hadoop-ozone/dist/src/main/compose/testlib.sh
+++ b/hadoop-ozone/dist/src/main/compose/testlib.sh
@@ -338,26 +338,16 @@ stop_docker_env(){
   save_container_logs
   if [ "${KEEP_RUNNING:-false}" = false ]; then
     down_repeats=3
-    result=0
     for i in $(seq 1 $down_repeats)
     do
-      docker-compose --ansi never down
-      result=$?
-      if [[ $result -eq 0 ]]
-      then
-        echo "Docker-compose down successful"
-        break
-      else
-        echo "Error while trying to shut down docker containers"
-        sleep 5
+      if docker-compose --ansi never down; then
+        return
       fi
+      sleep 5
     done
-
-    if [[ $result -ne 0 ]]
-    then
-      echo "Couldn't remove all docker containers after $down_repeats repeats."
-    fi
   fi
+  echo "Failed to remove all docker containers in $down_repeats attempts."
+  return 1
 }
 
 ## @description  Removes the given docker images if configured not to keep them (via KEEP_IMAGE=false)

--- a/hadoop-ozone/dist/src/main/compose/testlib.sh
+++ b/hadoop-ozone/dist/src/main/compose/testlib.sh
@@ -337,7 +337,26 @@ stop_docker_env(){
   copy_daemon_logs
   save_container_logs
   if [ "${KEEP_RUNNING:-false}" = false ]; then
-     docker-compose --ansi never down
+    down_repeats=3
+    result=0
+    for i in $(seq 1 $down_repeats)
+    do
+      docker-compose --ansi never down
+      result=$?
+      if [[ $result -eq 0 ]]
+      then
+        echo "Docker-compose down successful"
+        break
+      else
+        echo "Error while trying to shut down docker containers"
+        sleep 5
+      fi
+    done
+
+    if [[ $result -ne 0 ]]
+    then
+      echo "Couldn't remove all docker containers after $down_repeats repeats."
+    fi
   fi
 }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

In rare occasions there is a race condition between closing a docker container and that container leaving the network. When the container is still connected to the network but the network is being shut down it will cause an error that makes the acceptance tests fail.

This pr adds a retry mechanism for docker-compose down as well as ignoring the possible error coming from it, since it's irrelevant to the result of the test itself.

## What is the link to the Apache JIRA

[HDDS-7531](https://issues.apache.org/jira/browse/HDDS-7531)

## How was this patch tested?

The error is hard to reproduce directly. I observed that the CI still runs. Locally I've also changed the docker-comose.yaml while running an acceptance test thus creating an orphan container that can't be removed. When the test shut down it was retried and the test was still successful in result.

Green CI run: https://github.com/Galsza/ozone/actions/runs/6265723643