### PR TITLE
HDDS-9327. LegacyReplicationManager: Handle all UNHEALTHY replicas of a CLOSING container

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/protocol/commands/CloseContainerCommand.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/protocol/commands/CloseContainerCommand.java
@@ -82,6 +82,10 @@ public class CloseContainerCommand
     return pipelineID;
   }
 
+  public boolean isForce() {
+    return force;
+  }
+
   @Override
   public String toString() {
     StringBuilder sb = new StringBuilder();

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/LegacyReplicationManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/LegacyReplicationManager.java
@@ -403,7 +403,8 @@ public class LegacyReplicationManager {
             return;
           }
 
-          if (!foundHealthy) {
+          if (!foundHealthy && container.getReplicationType().equals(
+              HddsProtos.ReplicationType.RATIS)) {
             /* If we get here, then this container has replicas and all are
             UNHEALTHY. Move it from CLOSING to QUASI_CLOSED so RM can then try
             to maintain replication factor number of replicas.

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/LegacyReplicationManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/LegacyReplicationManager.java
@@ -403,8 +403,7 @@ public class LegacyReplicationManager {
             return;
           }
 
-          if (!foundHealthy && container.getReplicationType().equals(
-              HddsProtos.ReplicationType.RATIS)) {
+          if (!foundHealthy) {
             /* If we get here, then this container has replicas and all are
             UNHEALTHY. Move it from CLOSING to QUASI_CLOSED so RM can then try
             to maintain replication factor number of replicas.

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/LegacyReplicationManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/LegacyReplicationManager.java
@@ -381,8 +381,10 @@ public class LegacyReplicationManager {
          */
         if (state == LifeCycleState.CLOSING) {
           setHealthStateForClosing(replicas, container, report);
+          boolean foundHealthy = false;
           for (ContainerReplica replica: replicas) {
             if (replica.getState() != State.UNHEALTHY) {
+              foundHealthy = true;
               sendCloseCommand(
                   container, replica.getDatanodeDetails(), false);
             }
@@ -398,7 +400,20 @@ public class LegacyReplicationManager {
            */
           if (replicas.isEmpty() && (container.getNumberOfKeys() == 0)) {
             closeEmptyContainer(container);
+            return;
           }
+
+          if (!foundHealthy) {
+            /* If we get here, then this container has replicas and all are
+            UNHEALTHY. Move it from CLOSING to QUASI_CLOSED so RM can then try
+            to maintain replication factor number of replicas.
+            */
+            containerManager.updateContainerState(container.containerID(),
+                HddsProtos.LifeCycleEvent.QUASI_CLOSE);
+            LOG.debug("Moved container {} to QUASI_CLOSED because it has only" +
+                " UNHEALTHY replicas: {}.", container, replicas);
+          }
+
           return;
         }
 

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/LegacyReplicationManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/LegacyReplicationManager.java
@@ -410,8 +410,9 @@ public class LegacyReplicationManager {
             */
             containerManager.updateContainerState(container.containerID(),
                 HddsProtos.LifeCycleEvent.QUASI_CLOSE);
-            LOG.debug("Moved container {} to QUASI_CLOSED because it has only" +
-                " UNHEALTHY replicas: {}.", container, replicas);
+            LOG.debug("Moved container {} from CLOSING to QUASI_CLOSED " +
+                "because it has only UNHEALTHY replicas: {}.", container,
+                replicas);
           }
 
           return;

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestLegacyReplicationManager.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestLegacyReplicationManager.java
@@ -65,6 +65,7 @@ import org.apache.hadoop.hdds.utils.db.DBStoreBuilder;
 import org.apache.hadoop.hdds.utils.db.LongCodec;
 import org.apache.hadoop.ozone.common.statemachine.InvalidStateTransitionException;
 import org.apache.hadoop.ozone.container.common.SCMTestUtils;
+import org.apache.hadoop.ozone.protocol.commands.CloseContainerCommand;
 import org.apache.hadoop.ozone.protocol.commands.CommandForDatanode;
 import org.apache.hadoop.ozone.protocol.commands.ReplicateContainerCommand;
 import org.apache.hadoop.ozone.protocol.commands.SCMCommand;
@@ -383,69 +384,6 @@ public class TestLegacyReplicationManager {
     }
 
     /**
-     * A CLOSING container which has only UNHEALTHY replicas should be moved
-     * to QUASI_CLOSED state so that RM can then maintain replication factor
-     * number of replicas.
-     */
-    @Test
-    public void testClosingContainerWithOnlyUnhealthyReplicas()
-        throws IOException, InvalidStateTransitionException {
-      final ContainerInfo container = getContainer(LifeCycleState.CLOSING);
-      final ContainerID id = container.containerID();
-      containerStateManager.addContainer(container.getProtobuf());
-
-      // all replicas are UNHEALTHY
-      final Set<ContainerReplica> replicas = getReplicas(id, UNHEALTHY,
-          randomDatanodeDetails(), randomDatanodeDetails(),
-          randomDatanodeDetails());
-      for (ContainerReplica replica : replicas) {
-        containerStateManager.updateContainerReplica(id, replica);
-      }
-
-      replicationManager.processAll();
-      Mockito.verify(containerManager, times(1))
-          .updateContainerState(container.containerID(),
-              LifeCycleEvent.QUASI_CLOSE);
-
-      containerStateManager.updateContainerState(
-          container.containerID().getProtobuf(), LifeCycleEvent.QUASI_CLOSE);
-
-      replicationManager.processAll();
-      Assertions.assertEquals(1,
-          replicationManager.getContainerReport().getStat(
-              ReplicationManagerReport.HealthState.QUASI_CLOSED_STUCK));
-    }
-
-    @Test
-    public void testClosingContainerWithSomeUnhealthyReplicas()
-        throws IOException, InvalidStateTransitionException {
-      final ContainerInfo container = getContainer(LifeCycleState.CLOSING);
-      final ContainerID id = container.containerID();
-      containerStateManager.addContainer(container.getProtobuf());
-
-      // 2 UNHEALTHY, 1 OPEN
-      final Set<ContainerReplica> replicas = getReplicas(id, UNHEALTHY,
-          randomDatanodeDetails(), randomDatanodeDetails());
-      final DatanodeDetails datanode = randomDatanodeDetails();
-      replicas.addAll(getReplicas(id, State.OPEN, datanode));
-      for (ContainerReplica replica : replicas) {
-        containerStateManager.updateContainerReplica(id, replica);
-      }
-
-      final int currentCloseCommandCount = datanodeCommandHandler
-          .getInvocationCount(SCMCommandProto.Type.closeContainerCommand);
-      replicationManager.processAll();
-      eventQueue.processAll(1000);
-
-      Mockito.verify(containerManager, times(0))
-          .updateContainerState(container.containerID(),
-              LifeCycleEvent.QUASI_CLOSE);
-      Assertions.assertEquals(currentCloseCommandCount + 1,
-          datanodeCommandHandler.getInvocationCount(
-              SCMCommandProto.Type.closeContainerCommand));
-    }
-
-    /**
      * Create closing container with 1 replica.
      * Expectation: Missing containers 0.
      * Remove the only replica.
@@ -650,6 +588,83 @@ public class TestLegacyReplicationManager {
    */
   @Nested
   class UnstableReplicas {
+
+    /**
+     * A CLOSING container which has only UNHEALTHY replicas should be moved
+     * to QUASI_CLOSED state so that RM can then maintain replication factor
+     * number of replicas.
+     */
+    @Test
+    public void testClosingContainerWithOnlyUnhealthyReplicas()
+        throws IOException, InvalidStateTransitionException {
+      final ContainerInfo container = getContainer(LifeCycleState.CLOSING);
+      final ContainerID id = container.containerID();
+      containerStateManager.addContainer(container.getProtobuf());
+
+      // all replicas are UNHEALTHY
+      final Set<ContainerReplica> replicas = getReplicas(id, UNHEALTHY,
+          randomDatanodeDetails(), randomDatanodeDetails(),
+          randomDatanodeDetails());
+      for (ContainerReplica replica : replicas) {
+        containerStateManager.updateContainerReplica(id, replica);
+      }
+
+      replicationManager.processAll();
+      Mockito.verify(containerManager, times(1))
+          .updateContainerState(container.containerID(),
+              LifeCycleEvent.QUASI_CLOSE);
+
+      containerStateManager.updateContainerState(
+          container.containerID().getProtobuf(), LifeCycleEvent.QUASI_CLOSE);
+
+      replicationManager.processAll();
+      Assertions.assertEquals(1,
+          replicationManager.getContainerReport().getStat(
+              ReplicationManagerReport.HealthState.QUASI_CLOSED_STUCK));
+    }
+
+    /**
+     * Close command should be sent to the healthy replicas. The container
+     * should not be moved to quasi-closed immediately.
+     */
+    @Test
+    public void testClosingContainerWithSomeUnhealthyReplicas()
+        throws IOException, InvalidStateTransitionException {
+      final ContainerInfo container = getContainer(LifeCycleState.CLOSING);
+      final ContainerID id = container.containerID();
+      containerStateManager.addContainer(container.getProtobuf());
+
+      // 2 UNHEALTHY, 1 OPEN
+      final Set<ContainerReplica> replicas = getReplicas(id, UNHEALTHY,
+          randomDatanodeDetails(), randomDatanodeDetails());
+      final DatanodeDetails datanode = randomDatanodeDetails();
+      replicas.addAll(getReplicas(id, State.OPEN, datanode));
+      for (ContainerReplica replica : replicas) {
+        containerStateManager.updateContainerReplica(id, replica);
+      }
+
+      final int currentCloseCommandCount = datanodeCommandHandler
+          .getInvocationCount(SCMCommandProto.Type.closeContainerCommand);
+      replicationManager.processAll();
+      eventQueue.processAll(1000);
+
+      Mockito.verify(containerManager, times(0))
+          .updateContainerState(container.containerID(),
+              LifeCycleEvent.QUASI_CLOSE);
+      Assertions.assertEquals(currentCloseCommandCount + 1,
+          datanodeCommandHandler.getInvocationCount(
+              SCMCommandProto.Type.closeContainerCommand));
+      Assertions.assertEquals(1,
+          datanodeCommandHandler.getReceivedCommands().size());
+      SCMCommand command =
+          datanodeCommandHandler.getReceivedCommands().iterator().next()
+              .getCommand();
+      Assertions.assertSame(SCMCommandProto.Type.closeContainerCommand,
+          command.getType());
+      CloseContainerCommand closeCommand = (CloseContainerCommand) command;
+      Assertions.assertFalse(closeCommand.isForce());
+    }
+
     /**
      * 2 open replicas
      * 1 quasi-closed replica


### PR DESCRIPTION
## What changes were proposed in this pull request?

Legacy Replication Manager currently doesn't handle a CLOSING container when all its replicas are UNHEALTHY. RM needs to make decisions for such a container so it can move to one of the terminal states and be eligible for replication. This PR moves such a container to the QUASI_CLOSED state. This jira will fix the LegacyReplicationManager only.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-9327

## How was this patch tested?

Added unit tests.