### PR TITLE
HDDS-9337. Tmp files are not deleted after OM bootstrapping

### DIFF
--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OMDBCheckpointServlet.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OMDBCheckpointServlet.java
@@ -600,10 +600,13 @@ public class OMDBCheckpointServlet extends DBCheckpointServlet {
           includeFile(hardLinkFile.toFile(), OmSnapshotManager.OM_HARDLINK_FILE,
               archiveOutputStream);
         } finally {
-          try {
-            Files.delete(Objects.requireNonNull(hardLinkFile));
-          } catch (Exception e) {
-            LOG.error("Exception during tmp hard link file deletion" + e);
+          if (Objects.nonNull(hardLinkFile)) {
+            try {
+              Files.delete(Objects.requireNonNull(hardLinkFile));
+            } catch (Exception e) {
+              LOG.error("Exception during hard link file: {} deletion",
+                  hardLinkFile, e);
+            }
           }
         }
       }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OMDBCheckpointServlet.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OMDBCheckpointServlet.java
@@ -602,7 +602,7 @@ public class OMDBCheckpointServlet extends DBCheckpointServlet {
         } finally {
           if (Objects.nonNull(hardLinkFile)) {
             try {
-              Files.delete(Objects.requireNonNull(hardLinkFile));
+              Files.delete(hardLinkFile);
             } catch (Exception e) {
               LOG.error("Exception during hard link file: {} deletion",
                   hardLinkFile, e);

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OMDBCheckpointServlet.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OMDBCheckpointServlet.java
@@ -594,13 +594,17 @@ public class OMDBCheckpointServlet extends DBCheckpointServlet {
     if (completed) {
       // Only create the hard link list for the last tarball.
       if (!hardLinkFiles.isEmpty()) {
-        Path hardLinkFile = createHardLinkList(truncateLength, hardLinkFiles);
-        includeFile(hardLinkFile.toFile(), OmSnapshotManager.OM_HARDLINK_FILE,
-            archiveOutputStream);
+        Path hardLinkFile = null;
         try {
-          Files.delete(hardLinkFile);
-        } catch (Exception e) {
-          LOG.error("Exception during hard link file deletion" + e);
+          hardLinkFile = createHardLinkList(truncateLength, hardLinkFiles);
+          includeFile(hardLinkFile.toFile(), OmSnapshotManager.OM_HARDLINK_FILE,
+              archiveOutputStream);
+        } finally {
+          try {
+            Files.delete(Objects.requireNonNull(hardLinkFile));
+          } catch (Exception e) {
+            LOG.error("Exception during tmp hard link file deletion" + e);
+          }
         }
       }
       // Mark tarball completed.

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OMDBCheckpointServlet.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OMDBCheckpointServlet.java
@@ -597,6 +597,11 @@ public class OMDBCheckpointServlet extends DBCheckpointServlet {
         Path hardLinkFile = createHardLinkList(truncateLength, hardLinkFiles);
         includeFile(hardLinkFile.toFile(), OmSnapshotManager.OM_HARDLINK_FILE,
             archiveOutputStream);
+        try {
+          Files.delete(hardLinkFile);
+        } catch (Exception e) {
+          LOG.error("Exception during hard link file deletion" + e);
+        }
       }
       // Mark tarball completed.
       includeRatisSnapshotCompleteFlag(archiveOutputStream);

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/snapshot/OmSnapshotUtils.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/snapshot/OmSnapshotUtils.java
@@ -40,6 +40,9 @@ import static org.apache.hadoop.ozone.OzoneConsts.OM_CHECKPOINT_DIR;
  */
 public final class OmSnapshotUtils {
 
+  public static final String DATA_PREFIX = "data";
+  public static final String DATA_SUFFIX = "txt";
+
   private OmSnapshotUtils() { }
 
   /**
@@ -80,7 +83,7 @@ public final class OmSnapshotUtils {
   public static Path createHardLinkList(int truncateLength,
                                         Map<Path, Path> hardLinkFiles)
       throws IOException {
-    Path data = Files.createTempFile("data", "txt");
+    Path data = Files.createTempFile(DATA_PREFIX, DATA_SUFFIX);
     StringBuilder sb = new StringBuilder();
     for (Map.Entry<Path, Path> entry : hardLinkFiles.entrySet()) {
       String fixedFile = truncateFileName(truncateLength, entry.getValue());


### PR DESCRIPTION
## What changes were proposed in this pull request?
When OM bootstrap process generates last snapshot checkpoint it creates tmp file that contains hard links data and adds it to the tarball. Currently, created tmp file is not deleted after it is used. Idea of the this PR is to delete that tmp file when it is no longer needed.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-9337

## How was this patch tested?
Modified existing OM integration test to check whether tmp file is deleted.
