### PR TITLE
HDDS-9341. om-roles.robot is not part of any test runs

### DIFF
--- a/hadoop-ozone/dist/src/main/compose/ozone-ha/test.sh
+++ b/hadoop-ozone/dist/src/main/compose/ozone-ha/test.sh
@@ -45,3 +45,5 @@ done
 
 execute_robot_test ${SCM} freon
 execute_robot_test ${SCM} -v USERNAME:httpfs httpfs
+
+execute_robot_test ${SCM} omha/om-roles.robot

--- a/hadoop-ozone/dist/src/main/compose/ozonesecure-ha/test.sh
+++ b/hadoop-ozone/dist/src/main/compose/ozonesecure-ha/test.sh
@@ -54,6 +54,8 @@ execute_robot_test s3g admincli
 
 execute_robot_test s3g omha/om-fetch-key.robot
 
+execute_robot_test s3g omha/om-roles.robot
+
 execute_robot_test s3g omha/om-leader-transfer.robot
 
 execute_robot_test s3g httpfs

--- a/hadoop-ozone/dist/src/main/smoketest/omha/om-roles.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/omha/om-roles.robot
@@ -46,7 +46,7 @@ List om roles as JSON with OM service ID passed
     ${output_with_id_passed} =      Execute                         ozone admin om roles --service-id=omservice --json
                                     Assert Leader Present in JSON   ${output_with_id_passed}
     ${output_with_id_passed} =      Execute                         ozone admin --set=ozone.om.service.ids=omservice,omservice2 om roles --service-id=omservice --json
-                                    Parse json output               ${output_with_id_passed}
+                                    Assert Leader Present in JSON   ${output_with_id_passed}
 
 List om roles as JSON without OM service ID passed
     ${output_without_id_passed} =   Execute                         ozone admin om roles --json


### PR DESCRIPTION
## What changes were proposed in this pull request?

The om-roles.robot test added in [HDDS-9305](https://issues.apache.org/jira/browse/HDDS-9305) is not executed in any of the acceptance test. Aim is to add it in ozone-ha and ozonesecure-ha environments.

## What is the link to the Apache JIRA
[HDDS-9341](https://issues.apache.org/jira/browse/HDDS-9341)

## How was this patch tested?

Acceptance test CI, passing in local fork.
ha-secure: https://github.com/LZD-PratyushBhatt/ozone/actions/runs/6277586606/job/17050342303

```
Om-Roles :: Smoke test for listing om roles.                                  
==============================================================================
List om roles with OM service ID passed                               | PASS |
------------------------------------------------------------------------------
List om roles without OM service ID passed                            | PASS |
------------------------------------------------------------------------------
List om roles as JSON with OM service ID passed                       | PASS |
------------------------------------------------------------------------------
List om roles as JSON without OM service ID passed                    | PASS |
------------------------------------------------------------------------------
Om-Roles :: Smoke test for listing om roles.                          | PASS |
4 tests, 4 passed, 0 failed
```

ha-unsecure: https://github.com/LZD-PratyushBhatt/ozone/actions/runs/6277586606/job/17050342650 
```
Om-Roles :: Smoke test for listing om roles.                                  
==============================================================================
List om roles with OM service ID passed                               | PASS |
------------------------------------------------------------------------------
List om roles without OM service ID passed                            | PASS |
------------------------------------------------------------------------------
List om roles as JSON with OM service ID passed                       | PASS |
------------------------------------------------------------------------------
List om roles as JSON without OM service ID passed                    | PASS |
------------------------------------------------------------------------------
Om-Roles :: Smoke test for listing om roles.                          | PASS |
4 tests, 4 passed, 0 failed
==============================================================================
Output:  /tmp/smoketest/ozone-ha/result/robot-7.xml
```
