### PR TITLE
HDDS-7531. (addendum) Intermittent error while removing docker network

### DIFF
--- a/hadoop-ozone/dist/src/main/compose/testlib.sh
+++ b/hadoop-ozone/dist/src/main/compose/testlib.sh
@@ -345,9 +345,10 @@ stop_docker_env(){
       fi
       sleep 5
     done
+
+    echo "Failed to remove all docker containers in $down_repeats attempts."
+    return 1
   fi
-  echo "Failed to remove all docker containers in $down_repeats attempts."
-  return 1
 }
 
 ## @description  Removes the given docker images if configured not to keep them (via KEEP_IMAGE=false)


### PR DESCRIPTION
## What changes were proposed in this pull request?

Acceptance test scripts run locally with `KEEP_RUNNING=true` exit with an error at the end:

```
$ KEEP_RUNNING=true ./test.sh
...
Failed to remove all docker containers in  attempts.
$ echo $?
1
```

https://issues.apache.org/jira/browse/HDDS-7531

## How was this patch tested?

Ran (a shortened version of) `ozone/test.sh`:

```
$ cd hadoop-ozone/dist/target/ozone-1.4.0-SNAPSHOT/compose/ozone
$ KEEP_RUNNING=true ./test.sh
$ echo $?
0
```

Verified no error message is printed, and the script exits with success (0).