### PR TITLE
HDDS-9344. Allow multiple classpath items in OZONE_MANAGER_CLASSPATH

### DIFF
--- a/hadoop-ozone/dist/src/main/compose/ozonesecure/vault.yaml
+++ b/hadoop-ozone/dist/src/main/compose/ozonesecure/vault.yaml
@@ -21,7 +21,7 @@ services:
       - vault.conf
     environment:
       - OZONE_OPTS=-Dcom.sun.net.ssl.checkRevocation=false
-      - OZONE_CLASSPATH=/opt/hadoop/share/ozone/lib/ozone-s3-secret-store-@project.version@.jar:/opt/hadoop/share/ozone/lib/vault-java-driver-*.jar
+      - OZONE_CLASSPATH=/opt/hadoop/share/ozone/lib/ozone-s3-secret-store-@project.version@.jar:/opt/hadoop/share/ozone/lib/vault-java-driver-@vault.driver.version@.jar
   vault:
     image: hashicorp/vault:1.13.2
     hostname: vault

--- a/hadoop-ozone/dist/src/main/compose/ozonesecure/vault.yaml
+++ b/hadoop-ozone/dist/src/main/compose/ozonesecure/vault.yaml
@@ -21,7 +21,7 @@ services:
       - vault.conf
     environment:
       - OZONE_OPTS=-Dcom.sun.net.ssl.checkRevocation=false
-      - OZONE_CLASSPATH=/opt/hadoop/share/ozone/lib/ozone-s3-secret-store-@project.version@.jar:/opt/hadoop/share/ozone/lib/vault-java-driver-@vault.driver.version@.jar
+      - OZONE_MANAGER_CLASSPATH=/opt/hadoop/share/ozone/lib/ozone-s3-secret-store-@project.version@.jar:/opt/hadoop/share/ozone/lib/vault-java-driver-@vault.driver.version@.jar
   vault:
     image: hashicorp/vault:1.13.2
     hostname: vault

--- a/hadoop-ozone/dist/src/shell/ozone/ozone-functions.sh
+++ b/hadoop-ozone/dist/src/shell/ozone/ozone-functions.sh
@@ -1288,9 +1288,9 @@ function ozone_add_ldlibpath
 ## @replaceable  yes
 function ozone_add_to_classpath_userpath
 {
-  # Add the user-specified OZONE_CLASSPATH to the
-  # official CLASSPATH env var if OZONE_USE_CLIENT_CLASSLOADER
-  # is not set.
+  # Add the classpath definition from argument (or OZONE_CLASSPATH if no
+  # argument specified) to the official CLASSPATH env var if
+  # OZONE_USE_CLIENT_CLASSLOADER is not set.
   # Add it first or last depending on if user has
   # set env-var OZONE_USER_CLASSPATH_FIRST
   # we'll also dedupe it, because we're cool like that.
@@ -1300,10 +1300,11 @@ function ozone_add_to_classpath_userpath
   declare -i j
   declare -i i
   declare idx
+  local userpath="${1:-${OZONE_CLASSPATH}}"
 
-  if [[ -n "${OZONE_CLASSPATH}" ]]; then
+  if [[ -n "${userpath}" ]]; then
     # I wonder if Java runs on VMS.
-    for idx in $(echo "${OZONE_CLASSPATH}" | tr : '\n'); do
+    for idx in $(echo "${userpath}" | tr : '\n'); do
       array[${c}]=${idx}
       ((c=c+1))
     done

--- a/hadoop-ozone/dist/src/shell/shellprofile.d/hadoop-ozone-manager.sh
+++ b/hadoop-ozone/dist/src/shell/shellprofile.d/hadoop-ozone-manager.sh
@@ -23,6 +23,6 @@ _ozone_manager_hadoop_finalize() {
      [[ -n ${OZONE_MANAGER_CLASSPATH} ]];
   then
     echo "Ozone Manager classpath extended by ${OZONE_MANAGER_CLASSPATH}"
-    ozone_add_classpath "${OZONE_MANAGER_CLASSPATH}"
+    ozone_add_to_classpath_userpath "${OZONE_MANAGER_CLASSPATH}"
   fi
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

HDDS-2310 added support for OM-specific extra classpath. Currently it accepts only a single item (which can be a wildcard, though). However, it does not allow adding two or more specific jars given in a classpath-like string (e.g. `x.jar:y.jar:z.jar`).

This PR adds support for adding 2+ extra jars to OM classpath.

https://issues.apache.org/jira/browse/HDDS-9344

## How was this patch tested?

Change is verified by `test-vault.sh` in `ozonesecure` acceptance test, where two jars are added to OM classpath.

https://github.com/adoroszlai/hadoop-ozone/actions/runs/6285129998/job/17067585858