### PR TITLE
HDDS-4113. Intermittent failure in TestSCMSafeModeManager#testPipelinesNotCreatedUntilPreCheckPasses.

### DIFF
--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/safemode/TestSCMSafeModeManager.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/safemode/TestSCMSafeModeManager.java
@@ -41,7 +41,6 @@ import org.apache.hadoop.hdds.scm.HddsTestUtils;
 import org.apache.hadoop.hdds.scm.container.ContainerInfo;
 import org.apache.hadoop.hdds.scm.container.MockNodeManager;
 import org.apache.hadoop.hdds.scm.events.SCMEvents;
-import org.apache.hadoop.hdds.scm.exceptions.SCMException;
 import org.apache.hadoop.hdds.scm.ha.SCMHAManagerStub;
 import org.apache.hadoop.hdds.scm.ha.SCMContext;
 import org.apache.hadoop.hdds.scm.ha.SCMServiceManager;
@@ -58,7 +57,6 @@ import org.apache.hadoop.hdds.server.events.EventPublisher;
 import org.apache.hadoop.hdds.server.events.EventQueue;
 import org.apache.ozone.test.GenericTestUtils;
 
-import org.apache.ozone.test.tag.Unhealthy;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -639,7 +637,6 @@ public class TestSCMSafeModeManager {
   }
 
   @Test
-  @Unhealthy("The test is failing, enable after fixing it")
   public void testPipelinesNotCreatedUntilPreCheckPasses()
       throws Exception {
     int numOfDns = 5;
@@ -682,6 +679,10 @@ public class TestSCMSafeModeManager {
     // Assert SCM is in Safe mode.
     assertTrue(scmSafeModeManager.getInSafeMode());
 
+    // stop background pipeline creator as we manually create
+    // pipeline below
+    pipelineManager.getBackgroundPipelineCreator().stop();
+
     // Register all DataNodes except last one and assert SCM is in safe mode.
     for (int i = 0; i < numOfDns - 1; i++) {
       queue.fireEvent(SCMEvents.NODE_REGISTRATION_CONT_REPORT,
@@ -700,20 +701,8 @@ public class TestSCMSafeModeManager {
     assertTrue(scmSafeModeManager.getPreCheckComplete());
     assertTrue(scmSafeModeManager.getInSafeMode());
 
-    /* There is a race condition where the background pipeline creation
-     * task creates the pipeline before the following create call.
-     * So wrapping it with try..catch.
-     */
-    Pipeline pipeline;
-    try {
-      pipeline = pipelineManager.createPipeline(
-          RatisReplicationConfig.getInstance(
-              ReplicationFactor.THREE));
-    } catch (SCMException ex) {
-      pipeline = pipelineManager.getPipelines(
-          RatisReplicationConfig.getInstance(
-              ReplicationFactor.THREE)).get(0);
-    }
+    Pipeline pipeline = pipelineManager.createPipeline(
+        RatisReplicationConfig.getInstance(ReplicationFactor.THREE));
 
     // Mark pipeline healthy
     pipeline = pipelineManager.getPipeline(pipeline.getId());


### PR DESCRIPTION
## What changes were proposed in this pull request?
The test already got fixed in HDDS-4133 with having a try-catch around createPipeline call. This test stops the background pipeline creator which is followed in another tests in this class. This way there won't be a race b/ w manual and bg process.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-4113

## How was this patch tested?
Test passed 100X10= 1000 times prior to this change itself  : https://github.com/sadanand48/hadoop-ozone/actions/runs/6296446016
