### PR TITLE
HDDS-9348. Improving parsing speed of DB Scanner

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/debug/TestLDBCli.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/debug/TestLDBCli.java
@@ -18,7 +18,7 @@ package org.apache.hadoop.ozone.debug;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.google.gson.Gson;
+import com.fasterxml.jackson.databind.ObjectWriter;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.hadoop.hdds.StringUtils;
 import org.apache.hadoop.hdds.client.BlockID;
@@ -322,9 +322,8 @@ public class TestLDBCli {
   }
 
   private static Map<String, Object> toMap(Object obj) throws IOException {
-    // Have to use the same serializer (Gson) as DBScanner does.
-    // JsonUtils (ObjectMapper) parses object differently.
-    String json = new Gson().toJson(obj);
+    ObjectWriter objectWriter = DBScanner.JsonSerializationHelper.getWriter();
+    String json = objectWriter.writeValueAsString(obj);
     return MAPPER.readValue(json, new TypeReference<Map<String, Object>>() { });
   }
 

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/DBScanner.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/DBScanner.java
@@ -51,6 +51,7 @@ import org.slf4j.LoggerFactory;
 import picocli.CommandLine;
 
 import java.io.BufferedWriter;
+import java.io.FileWriter;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.nio.file.Paths;
@@ -210,18 +211,15 @@ public class DBScanner implements Callable<Void>, SubcommandWithParent {
                                boolean schemaV3)
       throws IOException {
 
-    PrintWriter printWriter = null;
-    try {
-      if (fileName != null) {
-        printWriter = new PrintWriter(
-            new BufferedWriter(new PrintWriter(fileName, UTF_8.name())));
-      }
-      return displayTable(iterator, dbColumnFamilyDef, printWriter,
-          schemaV3);
-    } finally {
-      if (printWriter != null) {
-        printWriter.close();
-      }
+    if (fileName == null) {
+      // Print to stdout
+      return displayTable(iterator, dbColumnFamilyDef, out(), schemaV3);
+    }
+
+    // Write to file output
+    try (PrintWriter out = new PrintWriter(new BufferedWriter(
+        new PrintWriter(fileName, UTF_8.name())))) {
+      return displayTable(iterator, dbColumnFamilyDef, out, schemaV3);
     }
   }
 
@@ -229,9 +227,6 @@ public class DBScanner implements Callable<Void>, SubcommandWithParent {
                                DBColumnFamilyDefinition dbColumnFamilyDef,
                                PrintWriter printWriter, boolean schemaV3) {
     exception = false;
-    if (printWriter == null) {
-      printWriter = out();
-    }
     ThreadFactory factory = new ThreadFactoryBuilder()
         .setNameFormat("DBScanner-%d")
         .build();

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/DBScanner.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/DBScanner.java
@@ -51,7 +51,6 @@ import org.slf4j.LoggerFactory;
 import picocli.CommandLine;
 
 import java.io.BufferedWriter;
-import java.io.FileWriter;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.nio.file.Paths;

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/DBScanner.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/DBScanner.java
@@ -215,8 +215,6 @@ public class DBScanner implements Callable<Void>, SubcommandWithParent {
       if (fileName != null) {
         printWriter = new PrintWriter(
             new BufferedWriter(new PrintWriter(fileName, UTF_8.name())));
-      } else {
-        printWriter = out();
       }
       return displayTable(iterator, dbColumnFamilyDef, printWriter,
           schemaV3);
@@ -230,6 +228,9 @@ public class DBScanner implements Callable<Void>, SubcommandWithParent {
   private boolean displayTable(ManagedRocksIterator iterator,
                                DBColumnFamilyDefinition dbColumnFamilyDef,
                                PrintWriter printWriter, boolean schemaV3) {
+    if (printWriter == null) {
+      printWriter = out();
+    }
     ThreadFactory factory = new ThreadFactoryBuilder()
         .setNameFormat("DBScanner-%d")
         .build();
@@ -624,7 +625,9 @@ public class DBScanner implements Callable<Void>, SubcommandWithParent {
           LOG.error("Exception while output", e);
         } finally {
           stop = true;
-          drainRemainingMessages();
+          synchronized (lock) {
+            drainRemainingMessages();
+          }
         }
       }
     }

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/DBScanner.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/DBScanner.java
@@ -228,6 +228,7 @@ public class DBScanner implements Callable<Void>, SubcommandWithParent {
   private boolean displayTable(ManagedRocksIterator iterator,
                                DBColumnFamilyDefinition dbColumnFamilyDef,
                                PrintWriter printWriter, boolean schemaV3) {
+    exception = false;
     if (printWriter == null) {
       printWriter = out();
     }


### PR DESCRIPTION
## What changes were proposed in this pull request?
Improving parsing speed of DB Scanner

### Test
```bash
 ozone debug ldb --db=/tmp/metadata/om.db/ scan --column_family=keyTable -l 1000000 -o /dev/null
```
Before:
Take about 300s
After:
Take about 5s

**Performance improvement of about 50 ~ 60 times**

### Optimization method
- Multi-threaded Json parsing, separate thread to read RocksDB, separate thread for output
- Replacing the Json parsing tool from Gson to Jackson

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-9348

## How was this patch tested?
Existing Test
