### PR TITLE
HDDS-8641. Removed numSnapshotReclaimed metric and added missing getter for snapshot metrics.

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOmMetrics.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOmMetrics.java
@@ -424,7 +424,6 @@ public class TestOmMetrics {
     assertCounter("NumSnapshotLists", 0L, omMetrics);
     assertCounter("NumSnapshotActive", 1L, omMetrics);
     assertCounter("NumSnapshotDeleted", 0L, omMetrics);
-    assertCounter("NumSnapshotReclaimed", 0L, omMetrics);
 
     // Create second key
     OmKeyArgs keyArgs2 = createKeyArgs(volumeName, bucketName,

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OMMetrics.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OMMetrics.java
@@ -72,6 +72,7 @@ public class OMMetrics implements OmMetadataReaderMetrics {
   private @Metric MutableCounterLong numSnapshotCreates;
   private @Metric MutableCounterLong numSnapshotDeletes;
   private @Metric MutableCounterLong numSnapshotLists;
+  private @Metric MutableCounterLong numSnapshotDiffJobs;
 
   private @Metric MutableCounterLong numGetFileStatus;
   private @Metric MutableCounterLong numCreateDirectory;
@@ -126,6 +127,8 @@ public class OMMetrics implements OmMetadataReaderMetrics {
   private @Metric MutableCounterLong numSnapshotCreateFails;
   private @Metric MutableCounterLong numSnapshotDeleteFails;
   private @Metric MutableCounterLong numSnapshotListFails;
+  private @Metric MutableCounterLong numSnapshotDiffJobFails;
+
   private @Metric MutableCounterLong numSnapshotActive;
   private @Metric MutableCounterLong numSnapshotDeleted;
 
@@ -464,8 +467,16 @@ public class OMMetrics implements OmMetadataReaderMetrics {
     numSnapshotLists.incr();
   }
 
+  public void incNumSnapshotDiffJobs() {
+    numSnapshotDiffJobs.incr();
+  }
+
   public void incNumSnapshotListFails() {
     numSnapshotListFails.incr();
+  }
+
+  public void incNumSnapshotDiffJobFails() {
+    numSnapshotDiffJobFails.incr();
   }
 
   public void setNumSnapshotActive(long num) {
@@ -1215,6 +1226,10 @@ public class OMMetrics implements OmMetadataReaderMetrics {
     return numSnapshotLists.value();
   }
 
+  public long getNumSnapshotDiffJobs() {
+    return numSnapshotDiffJobs.value();
+  }
+
   public long getNumSnapshotCreateFails() {
     return numSnapshotCreateFails.value();
   }
@@ -1225,6 +1240,10 @@ public class OMMetrics implements OmMetadataReaderMetrics {
 
   public long getNumSnapshotListFails() {
     return numSnapshotListFails.value();
+  }
+
+  public long getNumSnapshotDiffJobFails() {
+    return numSnapshotDiffJobFails.value();
   }
 
   public long getNumSnapshotActive() {

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OMMetrics.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OMMetrics.java
@@ -128,7 +128,6 @@ public class OMMetrics implements OmMetadataReaderMetrics {
   private @Metric MutableCounterLong numSnapshotListFails;
   private @Metric MutableCounterLong numSnapshotActive;
   private @Metric MutableCounterLong numSnapshotDeleted;
-  private @Metric MutableCounterLong numSnapshotReclaimed;
 
   // Number of tenant operations attempted
   private @Metric MutableCounterLong numTenantOps;
@@ -493,19 +492,6 @@ public class OMMetrics implements OmMetadataReaderMetrics {
 
   public void decNumSnapshotDeleted() {
     numSnapshotDeleted.incr(-1);
-  }
-
-  public void setNumSnapshotReclaimed(long num) {
-    long currVal = numSnapshotReclaimed.value();
-    numSnapshotReclaimed.incr(num - currVal);
-  }
-
-  public void incNumSnapshotReclaimed() {
-    numSnapshotReclaimed.incr();
-  }
-
-  public void decNumSnapshotReclaimed() {
-    numSnapshotReclaimed.incr(-1);
   }
 
   public void incNumCompleteMultipartUploadFails() {
@@ -1221,12 +1207,20 @@ public class OMMetrics implements OmMetadataReaderMetrics {
     return numSnapshotCreates.value();
   }
 
+  public long getNumSnapshotDeletes() {
+    return numSnapshotDeletes.value();
+  }
+
   public long getNumSnapshotLists() {
     return numSnapshotLists.value();
   }
 
   public long getNumSnapshotCreateFails() {
     return numSnapshotCreateFails.value();
+  }
+
+  public long getNumSnapshotDeleteFails() {
+    return numSnapshotDeleteFails.value();
   }
 
   public long getNumSnapshotListFails() {
@@ -1239,10 +1233,6 @@ public class OMMetrics implements OmMetadataReaderMetrics {
 
   public long getNumSnapshotDeleted() {
     return numSnapshotDeleted.value();
-  }
-
-  public long getNumSnapshotReclaimed() {
-    return numSnapshotReclaimed.value();
   }
 
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
@@ -1785,7 +1785,6 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
 
     long activeGauge = 0;
     long deletedGauge = 0;
-    long reclaimedGauge = 0;
 
     try (TableIterator<String, ? extends
         KeyValue<String, SnapshotInfo>> keyIter =
@@ -1802,20 +1801,16 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
         } else if (snapshotStatus ==
             SnapshotInfo.SnapshotStatus.SNAPSHOT_DELETED) {
           deletedGauge++;
-        } else if (snapshotStatus ==
-            SnapshotInfo.SnapshotStatus.SNAPSHOT_RECLAIMED) {
-          reclaimedGauge++;
         }
       }
     }
 
     metrics.setNumSnapshotActive(activeGauge);
     metrics.setNumSnapshotDeleted(deletedGauge);
-    metrics.setNumSnapshotReclaimed(reclaimedGauge);
   }
 
   private void checkConfigBeforeBootstrap() throws IOException {
-    List<OMNodeDetails> omsWihtoutNewConfig = new ArrayList<>();
+    List<OMNodeDetails> omsWithoutNewConfig = new ArrayList<>();
     for (Map.Entry<String, OMNodeDetails> entry : peerNodesMap.entrySet()) {
       String remoteNodeId = entry.getKey();
       OMNodeDetails remoteNodeDetails = entry.getValue();
@@ -1828,11 +1823,11 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
         checkRemoteOMConfig(remoteNodeId, remoteOMConfiguration);
       } catch (IOException ioe) {
         LOG.error("Remote OM config check failed on OM {}", remoteNodeId, ioe);
-        omsWihtoutNewConfig.add(remoteNodeDetails);
+        omsWithoutNewConfig.add(remoteNodeDetails);
       }
     }
-    if (!omsWihtoutNewConfig.isEmpty()) {
-      String errorMsg = OmUtils.getOMAddressListPrintString(omsWihtoutNewConfig)
+    if (!omsWithoutNewConfig.isEmpty()) {
+      String errorMsg = OmUtils.getOMAddressListPrintString(omsWithoutNewConfig)
           + " do not have or have incorrect information of the bootstrapping " +
           "OM. Update their ozone-site.xml before proceeding.";
       exitManager.exitSystem(1, errorMsg, LOG);

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/snapshot/SnapshotDiffManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/snapshot/SnapshotDiffManager.java
@@ -835,6 +835,7 @@ public class SnapshotDiffManager implements AutoCloseable {
     LOG.info("Started snap diff report generation for volume: '{}', " +
             "bucket: '{}', fromSnapshot: '{}', toSnapshot: '{}'",
         volumeName, bucketName, fromSnapshotName, toSnapshotName);
+    ozoneManager.getMetrics().incNumSnapshotDiffJobs();
 
     ColumnFamilyHandle fromSnapshotColumnFamily = null;
     ColumnFamilyHandle toSnapshotColumnFamily = null;
@@ -1016,6 +1017,7 @@ public class SnapshotDiffManager implements AutoCloseable {
       }
     } catch (IOException | RocksDBException exception) {
       updateJobStatusToFailed(jobKey, exception.getMessage());
+      ozoneManager.getMetrics().incNumSnapshotDiffJobFails();
       LOG.error("Caught checked exception during diff report generation for " +
               "volume: {} bucket: {}, fromSnapshot: {} and toSnapshot: {}",
           volumeName, bucketName, fromSnapshotName, toSnapshotName, exception);
@@ -1024,6 +1026,7 @@ public class SnapshotDiffManager implements AutoCloseable {
       throw new RuntimeException(exception);
     } catch (Exception exception) {
       updateJobStatusToFailed(jobKey, exception.getMessage());
+      ozoneManager.getMetrics().incNumSnapshotDiffJobFails();
       LOG.error("Caught unchecked exception during diff report generation " +
               "for volume: {} bucket: {}, fromSnapshot: {} and toSnapshot: {}",
           volumeName, bucketName, fromSnapshotName, toSnapshotName, exception);

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/snapshot/SnapshotDiffManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/snapshot/SnapshotDiffManager.java
@@ -1017,7 +1017,6 @@ public class SnapshotDiffManager implements AutoCloseable {
       }
     } catch (IOException | RocksDBException exception) {
       updateJobStatusToFailed(jobKey, exception.getMessage());
-      ozoneManager.getMetrics().incNumSnapshotDiffJobFails();
       LOG.error("Caught checked exception during diff report generation for " +
               "volume: {} bucket: {}, fromSnapshot: {} and toSnapshot: {}",
           volumeName, bucketName, fromSnapshotName, toSnapshotName, exception);
@@ -1026,7 +1025,6 @@ public class SnapshotDiffManager implements AutoCloseable {
       throw new RuntimeException(exception);
     } catch (Exception exception) {
       updateJobStatusToFailed(jobKey, exception.getMessage());
-      ozoneManager.getMetrics().incNumSnapshotDiffJobFails();
       LOG.error("Caught unchecked exception during diff report generation " +
               "for volume: {} bucket: {}, fromSnapshot: {} and toSnapshot: {}",
           volumeName, bucketName, fromSnapshotName, toSnapshotName, exception);
@@ -1604,6 +1602,7 @@ public class SnapshotDiffManager implements AutoCloseable {
       // TODO: [Snapshot] Revisit this when we have proper exception handling.
       snapshotDiffJob.setReason("Job failed due to unknown reason.");
     }
+    ozoneManager.getMetrics().incNumSnapshotDiffJobFails();
     snapDiffJobTable.put(jobKey, snapshotDiffJob);
   }
 

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/snapshot/TestOMSnapshotDeleteRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/snapshot/TestOMSnapshotDeleteRequest.java
@@ -217,10 +217,11 @@ public class TestOMSnapshotDeleteRequest {
     snapshotInfo = omMetadataManager.getSnapshotInfoTable().get(key);
     assertNotNull(snapshotInfo);
     assertEquals(SNAPSHOT_DELETED, snapshotInfo.getSnapshotStatus());
-    // Expected -1 because no snapshot was created before.
     assertEquals(0, omMetrics.getNumSnapshotCreates());
+    // Expected -1 because no snapshot was created before.
     assertEquals(-1, omMetrics.getNumSnapshotActive());
     assertEquals(1, omMetrics.getNumSnapshotDeleted());
+    assertEquals(0, omMetrics.getNumSnapshotDeleteFails());
   }
 
   /**
@@ -246,6 +247,8 @@ public class TestOMSnapshotDeleteRequest {
     assertNotNull(omResponse.getDeleteSnapshotResponse());
     assertEquals(Status.FILE_NOT_FOUND, omResponse.getStatus());
     assertEquals(0, omMetrics.getNumSnapshotActive());
+    assertEquals(0, omMetrics.getNumSnapshotDeleted());
+    assertEquals(1, omMetrics.getNumSnapshotDeleteFails());
   }
 
   /**
@@ -312,6 +315,7 @@ public class TestOMSnapshotDeleteRequest {
     assertNotNull(snapshotInfo);
     assertEquals(SNAPSHOT_DELETED, snapshotInfo.getSnapshotStatus());
     assertEquals(0, omMetrics.getNumSnapshotActive());
+    assertEquals(1, omMetrics.getNumSnapshotDeleteFails());
   }
 
   private OMSnapshotDeleteRequest doPreExecute(

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/snapshot/TestSnapshotDiffManager.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/snapshot/TestSnapshotDiffManager.java
@@ -43,6 +43,7 @@ import org.apache.hadoop.hdfs.protocol.SnapshotDiffReport;
 import org.apache.hadoop.hdfs.protocol.SnapshotDiffReport.DiffReportEntry;
 import org.apache.hadoop.ozone.om.IOmMetadataReader;
 import org.apache.hadoop.ozone.om.OMMetadataManager;
+import org.apache.hadoop.ozone.om.OMMetrics;
 import org.apache.hadoop.ozone.om.OmMetadataManagerImpl;
 import org.apache.hadoop.ozone.om.OmSnapshot;
 import org.apache.hadoop.ozone.om.OmSnapshotManager;
@@ -200,6 +201,7 @@ public class TestSnapshotDiffManager {
   private final List<String> snapshotNames = new ArrayList<>();
   private final List<SnapshotInfo> snapshotInfoList = new ArrayList<>();
   private final List<SnapshotDiffJob> snapDiffJobs = new ArrayList<>();
+  private final OMMetrics omMetrics = OMMetrics.create();
   @TempDir
   private File dbDir;
   @Mock
@@ -368,6 +370,7 @@ public class TestSnapshotDiffManager {
     when(omMetadataManager.getBucketKey(VOLUME_NAME, BUCKET_NAME))
         .thenReturn(bucketTableKey);
     when(omMetadataManager.getKeyTable(LEGACY)).thenReturn(keyInfoTable);
+    when(ozoneManager.getMetrics()).thenReturn(omMetrics);
     when(ozoneManager.getConfiguration()).thenReturn(configuration);
     when(ozoneManager.getMetadataManager()).thenReturn(omMetadataManager);
 


### PR DESCRIPTION
## What changes were proposed in this pull request?
In this change, 
1. Metric `numSnapshotReclaimed` metric counter is removed because *Reclaimed* is not a used snapshot status and will be removed completely as part of [HDDS-9214](https://issues.apache.org/jira/browse/HDDS-9214). 
2. Added missing getter for some metrics.
3. Added snapshotDiffJob count and failure metrics.
4. Updated existing tests to validate metrics are getting populated properly. 

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-8641

## How was this patch tested?
Updated unit tests.
