### PR TITLE
HDDS-8503. Exclude nodes are not well considered in SCMContainerPlacementRackAware#chooseNodes

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/placement/algorithms/SCMContainerPlacementRackAware.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/placement/algorithms/SCMContainerPlacementRackAware.java
@@ -561,7 +561,7 @@ public final class SCMContainerPlacementRackAware
       DatanodeDetails favoredNode = favoredNodeNum > favorIndex ?
           favoredNodes.get(favorIndex) : null;
       DatanodeDetails chosenNode;
-      if (favoredNode != null && networkTopology.isSameParent(
+      if (favoredNode != null && !networkTopology.isSameParent(
           excludedNodeList.get(excludedNodeList.size() - 1), favoredNode)) {
         chosenNode = favoredNode;
         favorIndex++;

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/placement/algorithms/TestSCMContainerPlacementRackAware.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/placement/algorithms/TestSCMContainerPlacementRackAware.java
@@ -818,9 +818,9 @@ public class TestSCMContainerPlacementRackAware {
 
     Assertions.assertEquals(nodeNum, datanodeDetails.size());
     // Favoured node should not be returned,
-    // as favoured node is in the same rack as both used nodes.
-    Assertions.assertFalse(favouredNodes.get(0).getUuid() ==
-        datanodeDetails.get(0).getUuid());
+    // Returned node should be on the different rack than the favoured node.
+    Assertions.assertFalse(cluster.isSameParent(
+        favouredNodes.get(0), datanodeDetails.get(0)));
 
     favouredNodes.clear();
     // 1 favoured node

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/placement/algorithms/TestSCMContainerPlacementRackAware.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/placement/algorithms/TestSCMContainerPlacementRackAware.java
@@ -797,4 +797,44 @@ public class TestSCMContainerPlacementRackAware {
     Assertions.assertTrue(tryCount >= 1, "Not enough try count");
     Assertions.assertEquals(0, compromiseCount);
   }
+
+  @Test
+  public void chooseNodeWithUsedAndFavouredNodesMultipleRack()
+      throws SCMException {
+    int datanodeCount = 12;
+    setup(datanodeCount);
+    int nodeNum = 1;
+    List<DatanodeDetails> usedNodes = new ArrayList<>();
+    List<DatanodeDetails> favouredNodes = new ArrayList<>();
+
+    // 2 replica
+    usedNodes.add(datanodes.get(0));
+    usedNodes.add(datanodes.get(1));
+    // 1 favoured node
+    favouredNodes.add(datanodes.get(2));
+
+    List<DatanodeDetails> datanodeDetails = policy.chooseDatanodes(usedNodes,
+        null, favouredNodes, nodeNum, 0, 5);
+
+    Assertions.assertEquals(nodeNum, datanodeDetails.size());
+    // Favoured node should not be returned,
+    // as favoured node is in the same rack as both used nodes.
+    Assertions.assertFalse(favouredNodes.get(0).getUuid() ==
+        datanodeDetails.get(0).getUuid());
+
+    favouredNodes.clear();
+    // 1 favoured node
+    favouredNodes.add(datanodes.get(6));
+
+    datanodeDetails = policy.chooseDatanodes(usedNodes,
+        null, favouredNodes, nodeNum, 0, 5);
+
+    Assertions.assertEquals(nodeNum, datanodeDetails.size());
+
+    // Favoured node should be returned,
+    // as favoured node is in the different rack as used nodes.
+    Assertions.assertTrue(favouredNodes.get(0).getUuid() ==
+        datanodeDetails.get(0).getUuid());
+
+  }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

When used and favoured nodes are on same rack then there is possibility that all replicas will place into one rack. 
In this PR we are ensuring that if multiple racks are available then replicas will be placed in at least two racks, even though favoured node is on same rack as used node.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-8503

## How was this patch tested?

New Unit test.
