### PR TITLE
HDDS-9340. ReplicationManager: Handle all UNHEALTHY replicas of a CLOSING Ratis container

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/health/ClosingContainerHandler.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/health/ClosingContainerHandler.java
@@ -87,14 +87,17 @@ public class ClosingContainerHandler extends AbstractCheck {
 
     // Moving a RATIS container that has only unhealthy replicas to QUASI_CLOSED
     // so the unhealthy replicas will be replicated if needed.
-    if (allUnhealthy && !request.getContainerReplicas().isEmpty()
-        && containerInfo.getReplicationConfig().getReplicationType()
-        == ReplicationType.RATIS) {
-      LOG.debug("Container {} has only unhealthy replicas and is closing, so "
-          + "moving it to quasi-closed.", containerInfo);
+    if (allUnhealthy && !request.getContainerReplicas().isEmpty()) {
+      LifeCycleEvent event = LifeCycleEvent.QUASI_CLOSE;
+      if (containerInfo.getReplicationConfig().getReplicationType()
+          == ReplicationType.EC) {
+        event = LifeCycleEvent.CLOSE;
+      }
 
+      LOG.debug("Container {} has only unhealthy replicas and is closing, so "
+          + "executing the {} event.", containerInfo, event);
       replicationManager.updateContainerState(
-          containerInfo.containerID(), LifeCycleEvent.QUASI_CLOSE);
+          containerInfo.containerID(), event);
     }
 
     /*

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/health/TestClosingContainerHandler.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/health/TestClosingContainerHandler.java
@@ -48,6 +48,7 @@ import java.util.Set;
 import java.util.stream.Stream;
 
 import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.LifeCycleEvent.CLOSE;
+import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.LifeCycleEvent.QUASI_CLOSE;
 import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.LifeCycleState.CLOSED;
 import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.LifeCycleState.CLOSING;
 import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationType.EC;
@@ -260,6 +261,40 @@ public class TestClosingContainerHandler {
     assertAndVerify(request, true, 0);
     Mockito.verify(replicationManager, Mockito.times(1))
         .updateContainerState(containerInfo.containerID(), CLOSE);
+  }
+
+  @Test
+  public void testClosingRatisWithUnhealthyReplicas() {
+    ContainerInfo containerInfo = ReplicationTestUtil.createContainerInfo(
+        RATIS_REPLICATION_CONFIG, 1, CLOSING);
+    Set<ContainerReplica> containerReplicas = ReplicationTestUtil
+        .createReplicas(containerInfo.containerID(),
+            ContainerReplicaProto.State.UNHEALTHY, 0, 0, 0);
+
+    ReplicationManagerReport report = new ReplicationManagerReport();
+
+    ContainerCheckRequest request = new ContainerCheckRequest.Builder()
+        .setPendingOps(Collections.emptyList())
+        .setReport(report)
+        .setContainerInfo(containerInfo)
+        .setContainerReplicas(containerReplicas)
+        .build();
+    subject.handle(request);
+
+    Mockito.verify(replicationManager, Mockito.times(1))
+        .updateContainerState(containerInfo.containerID(), QUASI_CLOSE);
+
+    Mockito.clearInvocations(replicationManager);
+
+    // Now add an open container. This time, the container should not move to
+    // quasi-closed, and a close should be sent for the open replica.
+    containerReplicas.addAll(ReplicationTestUtil
+        .createReplicas(containerInfo.containerID(),
+            ContainerReplicaProto.State.OPEN, 0));
+
+    assertAndVerify(request, true, 1);
+    Mockito.verify(replicationManager, Mockito.times(0))
+        .updateContainerState(containerInfo.containerID(), QUASI_CLOSE);
   }
 
   /**


### PR DESCRIPTION
## What changes were proposed in this pull request?

Replication Manager currently doesn't handle a CLOSING container when all its replicas are UNHEALTHY. RM needs to make decisions for such a container so it can move to one of the terminal states and be eligible for replication. This PR moves such a container to the QUASI_CLOSED state.

This is the equivalent of #5348 for the new replication manager.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-9340

## How was this patch tested?

New unit test added