### PR TITLE
HDDS-9352. LegacyReplicationManager: Ignore any Datanodes that are not in-service and healthy when finding unique origins

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/LegacyReplicationManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/LegacyReplicationManager.java
@@ -2229,6 +2229,19 @@ public class LegacyReplicationManager {
     // deletion.
     Set<UUID> existingOriginNodeIDs = allReplicas.stream()
         .filter(r -> !deleteCandidates.contains(r))
+        .filter(
+            r -> {
+              try {
+                return nodeManager.getNodeStatus(r.getDatanodeDetails())
+                    .isHealthy();
+              } catch (NodeNotFoundException e) {
+                LOG.warn("Exception when checking replica {} for container {}" +
+                    " while deleting excess UNHEALTHY.", r, container, e);
+                return false;
+              }
+            })
+        .filter(r -> r.getDatanodeDetails().getPersistedOpState()
+            .equals(IN_SERVICE))
         .map(ContainerReplica::getOriginDatanodeId)
         .collect(Collectors.toSet());
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

LRM needs to save UNHEALTHY replicas that have unique Origin IDs when deleting excess UNHEALTHY replicas of a QUASI_CLOSED container. This is because replicas with unique origins are used to decide whether such a container can be closed. If we can close UNHEALTHY replicas in the future, these replicas can be used to make this decision.

Currently, LRM considers all replicas in the algorithm for finding out which replicas need to be saved and which should be deleted:
```
    // Gather the origin node IDs of replicas which are not candidates for
    // deletion.
    Set<UUID> existingOriginNodeIDs = allReplicas.stream()
        .filter(r -> !deleteCandidates.contains(r))
        .map(ContainerReplica::getOriginDatanodeId)
        .collect(Collectors.toSet());
```
We need to remove any DNs that are not in-service and healthy because it's likely we've already lost them or will lose them in the future.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-9352

## How was this patch tested?

Modified an existing unit test.
Draft only while waiting for CI to pass in my fork.