### PR TITLE
HDDS-9321. LegacyReplicationManager: Save UNHEALTHY replicas with highest BCSID for a QUASI_CLOSED container

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/LegacyReplicationManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/LegacyReplicationManager.java
@@ -527,8 +527,7 @@ public class LegacyReplicationManager {
         List<ContainerReplica> vulnerableUnhealthy =
             replicaSet.getVulnerableUnhealthyReplicas(nodeManager);
         if (!vulnerableUnhealthy.isEmpty()) {
-          handleVulnerableUnhealthyReplicas(replicaSet, vulnerableUnhealthy,
-              placementStatus);
+          handleVulnerableUnhealthyReplicas(replicaSet, vulnerableUnhealthy);
           return;
         }
 
@@ -568,12 +567,10 @@ public class LegacyReplicationManager {
    * @param replicaCount RatisContainerReplicaCount for this container
    * @param vulnerableUnhealthy List of UNHEALTHY replicas that need to be
    * replicated
-   * @param placementStatus placement status
    */
   private void handleVulnerableUnhealthyReplicas(
       RatisContainerReplicaCount replicaCount,
-      List<ContainerReplica> vulnerableUnhealthy,
-      ContainerPlacementStatus placementStatus) {
+      List<ContainerReplica> vulnerableUnhealthy) {
     ContainerInfo container = replicaCount.getContainer();
     LOG.debug("Handling vulnerable UNHEALTHY replicas {} for container {}.",
         vulnerableUnhealthy, container);

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/LegacyReplicationManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/LegacyReplicationManager.java
@@ -527,6 +527,8 @@ public class LegacyReplicationManager {
         List<ContainerReplica> vulnerableUnhealthy =
             replicaSet.getVulnerableUnhealthyReplicas(nodeManager);
         if (!vulnerableUnhealthy.isEmpty()) {
+          report.incrementAndSample(HealthState.UNDER_REPLICATED,
+              container.containerID());
           handleVulnerableUnhealthyReplicas(replicaSet, vulnerableUnhealthy);
           return;
         }
@@ -2280,8 +2282,8 @@ public class LegacyReplicationManager {
                 return nodeManager.getNodeStatus(r.getDatanodeDetails())
                     .isHealthy();
               } catch (NodeNotFoundException e) {
-                LOG.warn("Exception when checking node {} for deleting " +
-                    "excess replicas.", r, e);
+                LOG.warn("Exception when checking replica {} for container {}" +
+                    " while deleting excess UNHEALTHY.", r, container, e);
                 return false;
               }
             })

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/RatisContainerReplicaCount.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/RatisContainerReplicaCount.java
@@ -24,18 +24,23 @@ import org.apache.hadoop.hdds.scm.container.ContainerInfo;
 import org.apache.hadoop.hdds.scm.container.ContainerReplica;
 import org.apache.hadoop.hdds.scm.container.replication.ContainerHealthResult.OverReplicatedHealthResult;
 import org.apache.hadoop.hdds.scm.container.replication.ContainerHealthResult.UnderReplicatedHealthResult;
+import org.apache.hadoop.hdds.scm.node.NodeManager;
+import org.apache.hadoop.hdds.scm.node.states.NodeNotFoundException;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.UUID;
 import java.util.stream.Collectors;
 
 import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.NodeOperationalState.DECOMMISSIONED;
 import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.NodeOperationalState.DECOMMISSIONING;
 import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.NodeOperationalState.ENTERING_MAINTENANCE;
 import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.NodeOperationalState.IN_MAINTENANCE;
+import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.NodeOperationalState.IN_SERVICE;
 import static org.apache.hadoop.hdds.scm.container.replication.ReplicationManager.compareState;
 
 /**
@@ -414,6 +419,84 @@ public class RatisContainerReplicaCount implements ContainerReplicaCount {
   @Override
   public boolean isSufficientlyReplicatedForOffline(DatanodeDetails datanode) {
     return isSufficientlyReplicated();
+  }
+
+  /**
+   * QUASI_CLOSED containers that have a mix of healthy and UNHEALTHY
+   * replicas require special treatment. If the healthy replicas don't have
+   * the same BCSID as the container, but the UNHEALTHY ones do, then we need
+   * to save at least one copy of each such UNHEALTHY replica. This method
+   * finds such UNHEALTHY replicas.
+   *
+   * @param nodeManager an instance of NodeManager
+   * @return List of UNHEALTHY replicas with the greatest Sequence ID that
+   * need to be replicated to other nodes. Empty list if this container is not
+   * QUASI_CLOSED, doesn't have a mix of healthy and UNHEALTHY replicas, or
+   * if there are no replicas that need to be saved.
+   */
+  List<ContainerReplica> getVulnerableUnhealthyReplicas(
+      NodeManager nodeManager) {
+    if (container.getState() != HddsProtos.LifeCycleState.QUASI_CLOSED) {
+      // this method is only relevant for QUASI_CLOSED containers
+      return Collections.emptyList();
+    }
+
+    boolean foundHealthy = false;
+    List<ContainerReplica> unhealthyReplicas = new ArrayList<>();
+    for (ContainerReplica replica : replicas) {
+      if (replica.getState() != ContainerReplicaProto.State.UNHEALTHY) {
+        foundHealthy = true;
+      }
+
+      if (replica.getSequenceId() == container.getSequenceId()) {
+        if (replica.getState() == ContainerReplicaProto.State.UNHEALTHY) {
+          unhealthyReplicas.add(replica);
+        } else if (replica.getState() ==
+            ContainerReplicaProto.State.QUASI_CLOSED) {
+          // don't need to save UNHEALTHY replicas if there's a QUASI_CLOSED
+          // replica with the greatest Sequence ID.
+          return Collections.emptyList();
+        }
+      }
+    }
+    if (!foundHealthy) {
+      // this method is only relevant when there's a mix of healthy and
+      // unhealthy replicas
+      return Collections.emptyList();
+    }
+
+    unhealthyReplicas.removeIf(
+        replica -> {
+          try {
+            return !nodeManager.getNodeStatus(replica.getDatanodeDetails())
+                .isHealthy();
+          } catch (NodeNotFoundException e) {
+            return true;
+          }
+        });
+    /*
+    At this point, the list of unhealthyReplicas contains all UNHEALTHY
+    replicas with the greatest Sequence ID that are on healthy Datanodes.
+    Note that this also includes multiple copies of the same UNHEALTHY
+    replica, that is, replicas with the same Origin ID. We need to consider
+    the fact that replicas can be uniquely unhealthy. That is, 2 UNHEALTHY
+    replicas will difference Origin ID need not be exact copies of each other.
+
+    Replicas that don't have at least one instance (multiple instances of a
+    replica will have the same Origin ID) on an IN_SERVICE node are
+    vulnerable and need to be saved.
+     */
+    // TODO should we also consider pending deletes?
+    Set<UUID> originsOfInServiceReplicas = new HashSet<>();
+    for (ContainerReplica replica : unhealthyReplicas) {
+      if (replica.getDatanodeDetails().getPersistedOpState()
+          .equals(IN_SERVICE)) {
+        originsOfInServiceReplicas.add(replica.getOriginDatanodeId());
+      }
+    }
+    unhealthyReplicas.removeIf(replica -> originsOfInServiceReplicas.contains(
+        replica.getOriginDatanodeId()));
+    return unhealthyReplicas;
   }
 
   /**


### PR DESCRIPTION
## What changes were proposed in this pull request?

QUASI_CLOSED containers may have some UNHEALTHY replicas that have the highest sequence ID while all healthy replicas have a smaller sequence ID. In such cases, RM should try to keep one copy of such UNHEALTHY replicas.

Changes:
1. RatisContainerReplicaCount: A new API to get UNHEALTHY replicas that need to be replicated to other DNs. These replicas will be on decommissioning or maintenance nodes.
2. LegacyReplicationManager: Uses the above API to get UNHEALTHY replicas and sends replicate commands for them.

Additionally, this PR already contains the changes from #5365. We should get that one merged first.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-9321

## How was this patch tested?

Added unit tests.
Green CI in my fork: https://github.com/siddhantsangwan/ozone/actions/runs/6317121316/job/17153215650.