### PR TITLE
HDDS-9239. Ozone cli command to get container info should deal with empty values for --json

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/pipeline/Pipeline.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/pipeline/Pipeline.java
@@ -33,6 +33,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
@@ -191,6 +192,7 @@ public final class Pipeline {
    *
    * @return Set of DatanodeDetails
    */
+  @JsonIgnore
   public Set<DatanodeDetails> getNodeSet() {
     return Collections.unmodifiableSet(nodeStatus.keySet());
   }
@@ -282,10 +284,12 @@ public final class Pipeline {
         "All nodes are excluded: Pipeline=%s, excluded=%s", id, excluded));
   }
 
+  @JsonIgnore
   public boolean isClosed() {
     return state == PipelineState.CLOSED;
   }
 
+  @JsonIgnore
   public boolean isOpen() {
     return state == PipelineState.OPEN;
   }
@@ -317,7 +321,7 @@ public final class Pipeline {
 
   public boolean isHealthy() {
     // EC pipelines are not reported by the DN and do not have a leader. If a
-    // node goes stale or dead, EC pipelines will by closed like RATIS pipelines
+    // node goes stale or dead, EC pipelines will be closed like RATIS pipelines
     // but at the current time there are not other health metrics for EC.
     if (replicationConfig.getReplicationType() == ReplicationType.EC) {
       return true;

--- a/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/container/InfoSubcommand.java
+++ b/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/container/InfoSubcommand.java
@@ -20,11 +20,17 @@ package org.apache.hadoop.hdds.scm.cli.container;
 import java.io.IOException;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Map;
+import java.util.HashMap;
+import java.util.ArrayList;
+import java.time.Instant;
 import java.util.stream.Collectors;
 
 import org.apache.hadoop.hdds.cli.GenericParentCommand;
 import org.apache.hadoop.hdds.cli.HddsVersionProvider;
+import org.apache.hadoop.hdds.client.ReplicationConfig;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
+import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.hdds.scm.cli.ScmSubcommand;
 import org.apache.hadoop.hdds.scm.client.ScmClient;
 import org.apache.hadoop.hdds.scm.container.ContainerInfo;
@@ -34,6 +40,7 @@ import org.apache.hadoop.hdds.scm.container.common.helpers
 
 import com.google.common.base.Preconditions;
 import org.apache.hadoop.hdds.scm.pipeline.Pipeline;
+import org.apache.hadoop.hdds.scm.pipeline.PipelineID;
 import org.apache.hadoop.hdds.server.JsonUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -80,10 +87,17 @@ public class InfoSubcommand extends ScmSubcommand {
     }
 
     if (json) {
-      ContainerWithPipelineAndReplicas wrapper =
-          new ContainerWithPipelineAndReplicas(container.getContainerInfo(),
-              container.getPipeline(), replicas);
-      LOG.info(JsonUtils.toJsonStringWithDefaultPrettyPrinter(wrapper));
+      if(container.getPipeline().size() != 0) {
+        ContainerWithPipelineAndReplicas wrapper =
+            new ContainerWithPipelineAndReplicas(container.getContainerInfo(),
+                container.getPipeline(), replicas);
+        LOG.info(JsonUtils.toJsonStringWithDefaultPrettyPrinter(wrapper));
+      } else {
+        ContainerWithoutDatanodes wrapper =
+            new ContainerWithoutDatanodes(container.getContainerInfo(),
+                container.getPipeline(), replicas);
+        LOG.info(JsonUtils.toJsonStringWithDefaultPrettyPrinter(wrapper));
+      }
     } else {
       // Print container report info.
       LOG.info("Container id: {}", containerID);
@@ -153,6 +167,85 @@ public class InfoSubcommand extends ScmSubcommand {
 
     public List<ContainerReplicaInfo> getReplicas() {
       return replicas;
+    }
+  }
+
+  private static class ContainerWithoutDatanodes {
+
+    private ContainerInfo containerInfo;
+    private PipelineWithoutDatanodes pipeline;
+    private List<ContainerReplicaInfo> replicas;
+
+    ContainerWithoutDatanodes(ContainerInfo container, Pipeline pipeline,
+                                     List<ContainerReplicaInfo> replicas) {
+      this.containerInfo = container;
+      this.pipeline = new PipelineWithoutDatanodes(pipeline);
+      this.replicas = replicas;
+    }
+
+    public ContainerInfo getContainerInfo() {
+      return containerInfo;
+    }
+
+    public PipelineWithoutDatanodes getPipeline() {
+      return pipeline;
+    }
+
+    public List<ContainerReplicaInfo> getReplicas() {
+      return replicas;
+    }
+  }
+
+  // All Pipeline information except the ones dependent on datanodes
+  private static class PipelineWithoutDatanodes {
+    private final PipelineID id;
+    private final ReplicationConfig replicationConfig;
+    private final Pipeline.PipelineState state;
+    private Instant creationTimestamp;
+    private Map<DatanodeDetails, Long> nodeStatus;
+
+    private PipelineWithoutDatanodes(Pipeline pipeline) {
+      this.id = pipeline.getId();
+      this.replicationConfig = pipeline.getReplicationConfig();
+      this.state = pipeline.getPipelineState();
+      this.creationTimestamp = pipeline.getCreationTimestamp();
+      this.nodeStatus = new HashMap<>(); // All DNs down
+    }
+
+    public PipelineID getId() {
+      return id;
+    }
+
+    public ReplicationConfig getReplicationConfig() {
+      return replicationConfig;
+    }
+
+    public Pipeline.PipelineState getPipelineState() {
+      return state;
+    }
+
+    public Instant getCreationTimestamp() {
+      return creationTimestamp;
+    }
+
+    public HddsProtos.ReplicationType getType() {
+      return replicationConfig.getReplicationType();
+    }
+
+    public boolean isEmpty() {
+      return nodeStatus.isEmpty();
+    }
+
+    public List<DatanodeDetails> getNodes() {
+      return new ArrayList<>(nodeStatus.keySet());
+    }
+
+    public boolean isAllocationTimeout() {
+      return false;
+    }
+
+    public boolean isHealthy() {
+      return false; // leaderId is always null, So pipeline is unhealthy
     }
   }
 }

--- a/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/container/InfoSubcommand.java
+++ b/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/container/InfoSubcommand.java
@@ -87,7 +87,7 @@ public class InfoSubcommand extends ScmSubcommand {
     }
 
     if (json) {
-      if(container.getPipeline().size() != 0) {
+      if (container.getPipeline().size() != 0) {
         ContainerWithPipelineAndReplicas wrapper =
             new ContainerWithPipelineAndReplicas(container.getContainerInfo(),
                 container.getPipeline(), replicas);
@@ -197,7 +197,7 @@ public class InfoSubcommand extends ScmSubcommand {
   }
 
   // All Pipeline information except the ones dependent on datanodes
-  private static class PipelineWithoutDatanodes {
+  private static final class PipelineWithoutDatanodes {
     private final PipelineID id;
     private final ReplicationConfig replicationConfig;
     private final Pipeline.PipelineState state;


### PR DESCRIPTION
## What changes were proposed in this pull request?

In case of all datanodes being down, various methods in Pipeline.java were throwing an IOException. This was causing `ozone admin container info <id> --json` to fail. The fix proposed is to create another class in InfoSubcommand.java to store all pipeline information not dependent on the existence of datanodes in case there are no datanodes up..

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-9239

## How was this patch tested?

Manually tested using docker
```
sh-4.2$ ozone admin container info 4
Container id: 4
Pipeline id: ac51ee38-c755-4f66-a2c2-16806f7a5974
Container State: CLOSING
Datanodes: []
Replicas: []
sh-4.2$ ozone admin container info 4 --json
{
"containerInfo" : {
"state" : "CLOSING",
"stateEnterTime" : "2023-09-27T04:44:27.592Z",
"replicationConfig" : {
"replicationFactor" : "THREE",
"requiredNodes" : 3,
"replicationType" : "RATIS"
},
"usedBytes" : 3,
"numberOfKeys" : 1,
"lastUsed" : "2023-09-27T04:45:10.814623Z",
"owner" : "om1",
"containerID" : 4,
"deleteTransactionId" : 0,
"sequenceId" : 2,
"open" : true,
"deleted" : false
},
"pipeline" : {
"id" : {
"id" : "f687b301-026c-45de-8779-5de88b3a4af5"
},
"replicationConfig" : {
"replicationFactor" : "THREE",
"requiredNodes" : 3,
"replicationType" : "RATIS"
},
"creationTimestamp" : "2023-09-27T04:45:10.772Z",
"empty" : true,
"open" : false,
"type" : "RATIS",
"closed" : false,
"nodes" : [ ],
"pipelineState" : "ALLOCATED",
"nodeSet" : [ ],
"allocationTimeout" : false,
"healthy" : false
},
"replicas" : [ ]
}
```