### PR TITLE
HDDS-9351. ManagedChannel not shutdown properly in TestRootedOzoneFileSystemWithFSO

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestLeaseRecovery.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestLeaseRecovery.java
@@ -30,6 +30,7 @@ import org.apache.hadoop.ozone.OzoneConfigKeys;
 import org.apache.hadoop.ozone.TestDataUtil;
 import org.apache.hadoop.ozone.client.OzoneBucket;
 import org.apache.hadoop.ozone.client.OzoneClient;
+import org.apache.hadoop.ozone.om.exceptions.OMException;
 import org.apache.hadoop.ozone.om.helpers.BucketLayout;
 import org.junit.After;
 import org.junit.Before;
@@ -38,6 +39,7 @@ import org.junit.Test;
 import org.junit.rules.Timeout;
 
 import java.io.IOException;
+import java.io.OutputStream;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeoutException;
 
@@ -65,6 +67,19 @@ public class TestLeaseRecovery {
 
   private OzoneClient client;
   private final OzoneConfiguration conf = new OzoneConfiguration();
+
+  /**
+   * Closing the output stream after lease recovery throws because the key
+   * is no longer open in OM.  This is currently expected (see HDDS-9358).
+   */
+  public static void closeIgnoringKeyNotFound(OutputStream stream)
+      throws IOException {
+    try {
+      stream.close();
+    } catch (OMException e) {
+      assertEquals(OMException.ResultCodes.KEY_NOT_FOUND, e.getResult());
+    }
+  }
 
   @Before
   public void init() throws IOException, InterruptedException,

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFileSystemWithFSO.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFileSystemWithFSO.java
@@ -578,15 +578,19 @@ public class TestOzoneFileSystemWithFSO extends TestOzoneFileSystem {
 
     LeaseRecoverable fs = (LeaseRecoverable)getFs();
     FSDataOutputStream stream = getFs().create(source);
-    // file not visible yet
-    assertThrows(OMException.class, () -> fs.isFileClosed(source));
-    stream.write(1);
-    stream.hsync();
-    // file is visible and open
-    assertFalse(fs.isFileClosed(source));
-    assertTrue(fs.recoverLease(source));
-    // file is closed after lease recovery
-    assertTrue(fs.isFileClosed(source));
+    try {
+      // file not visible yet
+      assertThrows(OMException.class, () -> fs.isFileClosed(source));
+      stream.write(1);
+      stream.hsync();
+      // file is visible and open
+      assertFalse(fs.isFileClosed(source));
+      assertTrue(fs.recoverLease(source));
+      // file is closed after lease recovery
+      assertTrue(fs.isFileClosed(source));
+    } finally {
+      TestLeaseRecovery.closeIgnoringKeyNotFound(stream);
+    }
   }
 
   @Test

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestRootedOzoneFileSystem.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestRootedOzoneFileSystem.java
@@ -182,7 +182,7 @@ public class TestRootedOzoneFileSystem {
     if (cluster != null) {
       cluster.shutdown();
     }
-    IOUtils.closeQuietly(fs);
+    IOUtils.closeQuietly(fs, userOfs);
   }
 
   @Before

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestRootedOzoneFileSystemWithFSO.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestRootedOzoneFileSystemWithFSO.java
@@ -39,6 +39,7 @@ import java.util.Collection;
 import java.util.concurrent.TimeoutException;
 
 import static org.apache.hadoop.ozone.OzoneConsts.OZONE_URI_DELIMITER;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
@@ -268,11 +269,10 @@ public class TestRootedOzoneFileSystemWithFSO
 
     FileStatus[] fileStatuses = getFs().listStatus(
         new Path(getBucketPath() + "/testListStatusFSO"));
-    Assert.assertEquals(valueGreaterBatchSize, fileStatuses.length);
+    assertEquals(valueGreaterBatchSize, fileStatuses.length);
   }
 
   @Test
-  @Ignore("HDDS-9358")
   public void testLeaseRecoverable() throws Exception {
     // Create a file
     final String dir = "dir1";
@@ -281,11 +281,16 @@ public class TestRootedOzoneFileSystemWithFSO
 
     LeaseRecoverable fs = (LeaseRecoverable)getFs();
     FSDataOutputStream stream = getFs().create(source);
-    assertThrows(OMException.class, () -> fs.isFileClosed(source));
-    stream.write(1);
-    stream.hsync();
-    assertFalse(fs.isFileClosed(source));
-    assertTrue(fs.recoverLease(source));
-    assertTrue(fs.isFileClosed(source));
+    try {
+      assertThrows(OMException.class, () -> fs.isFileClosed(source));
+      stream.write(1);
+      stream.hsync();
+      assertFalse(fs.isFileClosed(source));
+      assertTrue(fs.recoverLease(source));
+      assertTrue(fs.isFileClosed(source));
+    } finally {
+      TestLeaseRecovery.closeIgnoringKeyNotFound(stream);
+    }
   }
+
 }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestRootedOzoneFileSystemWithFSO.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestRootedOzoneFileSystemWithFSO.java
@@ -272,6 +272,7 @@ public class TestRootedOzoneFileSystemWithFSO
   }
 
   @Test
+  @Ignore("HDDS-9358")
   public void testLeaseRecoverable() throws Exception {
     // Create a file
     final String dir = "dir1";


### PR DESCRIPTION
## What changes were proposed in this pull request?

1. Add a missing `close` call for a `FileSystem` instance
2. Close output stream in `testLeaseRecoverable()`, ignoring `KEY_NOT_FOUND` (see HDDS-9358).  Also in two other test classes that had the same pattern (although I haven't yet seen `ManagedChannel` warning from those).

https://issues.apache.org/jira/browse/HDDS-9351

## How was this patch tested?

`TestRootedOzoneFileSystemWithFSO` had no `not shutdown properly` warnings in 10x10 runs:
https://github.com/adoroszlai/hadoop-ozone/actions/runs/6335324968

Regular CI:
https://github.com/adoroszlai/hadoop-ozone/actions/runs/6335857380