### PR TITLE
HDDS-9359. Parameter for fail-fast behavior in flaky-test-check

### DIFF
--- a/.github/workflows/intermittent-test-check.yml
+++ b/.github/workflows/intermittent-test-check.yml
@@ -36,11 +36,16 @@ on:
         description: Number of splits
         default: 2
         required: true
+      fail-fast:
+        description: Stop after first failure
+        default: false
+        required: true
 env:
   MAVEN_OPTS: -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.http.retryHandler.class=standard -Dmaven.wagon.http.retryHandler.count=3
   TEST_CLASS: ${{ github.event.inputs.test-class}}
   TEST_METHOD: ${{ github.event.inputs.test-name }}
   ITERATIONS: ${{ github.event.inputs.iterations }}
+  FAIL_FAST: ${{ github.event.inputs.fail-fast }}
 jobs:
   prepare-job:
     runs-on: ubuntu-20.04
@@ -93,6 +98,7 @@ jobs:
     strategy:
       matrix:
         split: ${{fromJson(needs.prepare-job.outputs.matrix)}}  # Define  splits
+      fail-fast: ${{ fromJson(github.event.inputs.fail-fast) }}
     steps:
       - uses: actions/checkout@v3
         with:


### PR DESCRIPTION
## What changes were proposed in this pull request?

HDDS-9357 introduced a new workflow to easily run some intermittent test in multiple iterations.  Currently it has the default `fail-fast: true` behavior for the matrix check, but `FAIL_FAST=false` for iterations within a split.  This PR adds a new parameter to the workflow to ensure these two are consistent.  This will allow running all splits to completion, which helps estimate the rate of failure.

https://issues.apache.org/jira/browse/HDDS-9359

## How was this patch tested?

fail-fast=true:
https://github.com/adoroszlai/hadoop-ozone/actions/runs/6336826095

fail-fast=false:
https://github.com/adoroszlai/hadoop-ozone/actions/runs/6336793682