### PR TITLE
HDDS-9363. Added jira guideline and updated Pull request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,6 +1,12 @@
 ## What changes were proposed in this pull request?
 
-(Please fill in changes proposed in this fix)
+(Please fill in changes proposed in this fix
+1. **Title:** Title should provide a one sentence overview of the purpose of the PR.
+2. **Description:**
+   * What changes are proposed in the PR? and Why? It would be better if it is written from third person's perspective not just for the reviewer. 
+   * Provide as much context and rationale for the pull request as possible. It could be copy-paste from the Jira's description if the jira is well defined.
+   * If it is complex code, describe the approach used to solve the issue. If possible attach design doc, issue investigation, github discussion, etc.
+3. **PR examples:** [PR#3980](https://github.com/apache/ozone/pull/3980), [PR#5265](https://github.com/apache/ozone/pull/5265), [PR#4701](https://github.com/apache/ozone/pull/4701), [PR#5283](https://github.com/apache/ozone/pull/5283), [PR#5300](https://github.com/apache/ozone/pull/5300))
 
 ## What is the link to the Apache JIRA
 
@@ -8,9 +14,9 @@
 and you need to set the title of the pull request which starts with
 the corresponding JIRA issue number. (e.g. HDDS-XXXX. Fix a typo in YYY.)
 
-Please replace this section with the link to the Apache JIRA)
+(Please replace this section with the link to the Apache JIRA)
 
 ## How was this patch tested?
 
-(Please explain how this patch was tested. Ex: unit tests, manual tests)
-(If this patch involves UI changes, please attach a screen-shot; otherwise, remove this)
+(Please explain how this patch was tested. Ex: unit tests, manual tests, workflow run on the fork git repo.)
+(If this patch involves UI changes, please attach a screenshot; otherwise, remove this.)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -77,6 +77,19 @@ OZONE_REPLICATION_FACTOR=3 ./run.sh -d
 
 See more details in the [README](https://github.com/apache/ozone/blob/master/hadoop-ozone/dist/src/main/compose/ozone/README.md) and in the [docs](https://ozone.apache.org/docs/current/start.html).
 
+## Jira guideline
+
+When creating a new jira for any kind of new feature, improvement or bug, please follow below guideline: 
+
+  1. **Title:** Title should be a one-liner stating the problem.
+  2. **Description:**
+     * What is the problem? Is it a feature, improvement or bug? Add as many details as possible and related design doc and discussion.
+     * For new features, add as many details as possible. If it is part of the big feature, attach parent jira.
+     * For improvement, add the value it will bring. Is it an optimization, code simplification or something else?
+     * For bugs, add steps to reproduce it. Where the root cause is unknown and needs investigation, it would be great to update the jira description or add the summary once the root cause is identified.
+     * If it is follow up of another issue, please link the previous jira to it so that context is preserve.
+  3. **Jira examples:** [HDDS-9272](https://issues.apache.org/jira/browse/HDDS-9272), [HDDS-9322](https://issues.apache.org/jira/browse/HDDS-9322), [HDDS-9291](https://issues.apache.org/jira/browse/HDDS-9291), [HDDS-8940](https://issues.apache.org/jira/browse/HDDS-8940), [HDDS-9282](https://issues.apache.org/jira/browse/HDDS-9282)
+
 ## Contribute your modifications
 
 We use GitHub pull requests for contributing changes to the repository. The main workflow is as follows:
@@ -101,7 +114,6 @@ We use GitHub pull requests for contributing changes to the repository. The main
       * In general, please try to avoid force-push when updating the PR.  Here are some great articles that explain why:
         * https://developers.mattermost.com/blog/submitting-great-prs/#4-avoid-force-pushing
         * https://www.freecodecamp.org/news/optimize-pull-requests-for-reviewer-happiness#request-a-review
-    
 ## Code convention and tests
 
 Basic code conventions followed by Ozone:


### PR DESCRIPTION
## What changes were proposed in this pull request?
In the part, we have been in a situation when there is not much context provided behind the change. Also Jira doesn't have proper description as well other than a one-liner. This change is to add jira creation guideline and update PR template to preserve the context behind the change.

For more details, check [Ozone_Jira_and_PR_guidelines.pdf](https://issues.apache.org/jira/secure/attachment/13063247/13063247_Ozone_Jira_and_PR_guidelines.pdf) discussion.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-9363

## How was this patch tested?
No testing. Just documentation change.
