### PR TITLE
HDDS-9364. Upload artifacts of unit/native check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -255,6 +255,19 @@ jobs:
       - name: Summary of failures
         run: hadoop-ozone/dev-support/checks/_summary.sh target/${{ matrix.check }}/summary.txt
         if: ${{ !cancelled() }}
+      - name: Archive build results
+        uses: actions/upload-artifact@v3
+        if: ${{ !cancelled() }}
+        with:
+          name: ${{ matrix.check }}
+          path: target/${{ matrix.check }}
+        continue-on-error: true
+      - name: Delete temporary build artifacts before caching
+        run: |
+          #Never cache local artifacts
+          rm -rf ~/.m2/repository/org/apache/ozone/hdds*
+          rm -rf ~/.m2/repository/org/apache/ozone/ozone*
+        if: always()
   dependency:
     needs:
       - build-info


### PR DESCRIPTION
## What changes were proposed in this pull request?

HDDS-6618 extracted a new `unit` check from `basic`.  Artifacts for this new check are missing, because `upload` step was not copied.  This PR adds it.

https://issues.apache.org/jira/browse/HDDS-9364

## How was this patch tested?

Regular CI:

```
Artifact has been finalized. All files have been successfully uploaded!
```

https://github.com/adoroszlai/hadoop-ozone/actions/runs/6342725953/job/17229534601#step:7:20