### PR TITLE
HDDS-9370. Avoid copying ByteString in ByteStringCodec.

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/utils/db/BooleanCodec.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/utils/db/BooleanCodec.java
@@ -18,7 +18,6 @@
 package org.apache.hadoop.hdds.utils.db;
 
 import javax.annotation.Nonnull;
-import java.util.function.IntFunction;
 
 /**
  * Codec to serialize/deserialize {@link Boolean}.
@@ -44,7 +43,7 @@ public final class BooleanCodec implements Codec<Boolean> {
 
   @Override
   public CodecBuffer toCodecBuffer(Boolean object,
-      IntFunction<CodecBuffer> allocator) {
+      CodecBuffer.Allocator allocator) {
     return allocator.apply(1).put(TRUE);
   }
 

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/utils/db/Codec.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/utils/db/Codec.java
@@ -19,7 +19,6 @@ package org.apache.hadoop.hdds.utils.db;
 
 import javax.annotation.Nonnull;
 import java.io.IOException;
-import java.util.function.IntFunction;
 
 /**
  * Codec interface to serialize/deserialize objects to/from bytes.
@@ -34,7 +33,7 @@ public interface Codec<T> {
   /**
    * Does this {@link Codec} support the {@link CodecBuffer} methods?
    * If this method returns true, this class must implement both
-   * {@link #toCodecBuffer(Object, IntFunction)} and
+   * {@link #toCodecBuffer(Object, CodecBuffer.Allocator)} and
    * {@link #fromCodecBuffer(CodecBuffer)}.
    *
    * @return ture iff this class supports the {@link CodecBuffer} methods.
@@ -59,7 +58,7 @@ public interface Codec<T> {
    * @return a buffer storing the serialized bytes.
    */
   default CodecBuffer toCodecBuffer(@Nonnull T object,
-      IntFunction<CodecBuffer> allocator) throws IOException {
+      CodecBuffer.Allocator allocator) throws IOException {
     throw new UnsupportedOperationException();
   }
 
@@ -71,7 +70,7 @@ public interface Codec<T> {
    */
   default CodecBuffer toDirectCodecBuffer(@Nonnull T object)
       throws IOException {
-    return toCodecBuffer(object, CodecBuffer::allocateDirect);
+    return toCodecBuffer(object, CodecBuffer.Allocator.getDirect());
   }
 
   /**
@@ -82,7 +81,7 @@ public interface Codec<T> {
    */
   default CodecBuffer toHeapCodecBuffer(@Nonnull T object)
       throws IOException {
-    return toCodecBuffer(object, CodecBuffer::allocateHeap);
+    return toCodecBuffer(object, CodecBuffer.Allocator.getHeap());
   }
 
   /**

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/utils/db/CodecBuffer.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/utils/db/CodecBuffer.java
@@ -56,7 +56,7 @@ public class CodecBuffer implements AutoCloseable {
   private static class Factory {
     private static volatile BiFunction<ByteBuf, Object, CodecBuffer> constructor
         = CodecBuffer::new;
-    static void set(BiFunction<ByteBuf, Object, CodecBuffer>f) {
+    static void set(BiFunction<ByteBuf, Object, CodecBuffer> f) {
       constructor = f;
       LOG.info("Successfully set constructor to " + f);
     }

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/utils/db/CodecBuffer.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/utils/db/CodecBuffer.java
@@ -139,6 +139,7 @@ public class CodecBuffer implements AutoCloseable {
     return EMPTY_BUFFER;
   }
 
+  /** To allocate {@link CodecBuffer} objects. */
   public interface Allocator extends IntFunction<CodecBuffer> {
     Allocator DIRECT = new Allocator() {
       @Override
@@ -172,6 +173,7 @@ public class CodecBuffer implements AutoCloseable {
       return HEAP;
     }
 
+    /** Does this object allocate direct buffers? */
     boolean isDirect();
   }
 

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/utils/db/DelegatedCodec.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/utils/db/DelegatedCodec.java
@@ -21,7 +21,6 @@ import org.apache.ratis.util.function.CheckedFunction;
 
 import javax.annotation.Nonnull;
 import java.io.IOException;
-import java.util.function.IntFunction;
 
 /**
  * A {@link Codec} to serialize/deserialize objects by delegation.
@@ -82,7 +81,7 @@ public class DelegatedCodec<T, DELEGATE> implements Codec<T> {
 
   @Override
   public final CodecBuffer toCodecBuffer(@Nonnull T message,
-      IntFunction<CodecBuffer> allocator) throws IOException {
+      CodecBuffer.Allocator allocator) throws IOException {
     return delegate.toCodecBuffer(backward.apply(message), allocator);
   }
 

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/utils/db/IntegerCodec.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/utils/db/IntegerCodec.java
@@ -20,7 +20,6 @@ package org.apache.hadoop.hdds.utils.db;
 
 import javax.annotation.Nonnull;
 import java.nio.ByteBuffer;
-import java.util.function.IntFunction;
 
 /**
  * Codec to serialize/deserialize {@link Integer}.
@@ -44,7 +43,7 @@ public final class IntegerCodec implements Codec<Integer> {
 
   @Override
   public CodecBuffer toCodecBuffer(@Nonnull Integer object,
-      IntFunction<CodecBuffer> allocator) {
+      CodecBuffer.Allocator allocator) {
     return allocator.apply(Integer.BYTES).putInt(object);
   }
 

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/utils/db/LongCodec.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/utils/db/LongCodec.java
@@ -20,7 +20,6 @@ package org.apache.hadoop.hdds.utils.db;
 
 import javax.annotation.Nonnull;
 import java.nio.ByteBuffer;
-import java.util.function.IntFunction;
 
 /**
  * Codec to serialize/deserialize {@link Long}.
@@ -41,7 +40,7 @@ public final class LongCodec implements Codec<Long> {
 
   @Override
   public CodecBuffer toCodecBuffer(@Nonnull Long object,
-      IntFunction<CodecBuffer> allocator) {
+      CodecBuffer.Allocator allocator) {
     return allocator.apply(Long.BYTES).putLong(object);
   }
 

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/utils/db/Proto2Codec.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/utils/db/Proto2Codec.java
@@ -28,7 +28,6 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
-import java.util.function.IntFunction;
 
 /**
  * Codecs to serialize/deserialize Protobuf v2 messages.
@@ -70,7 +69,7 @@ public final class Proto2Codec<M extends MessageLite>
 
   @Override
   public CodecBuffer toCodecBuffer(@Nonnull M message,
-      IntFunction<CodecBuffer> allocator) throws IOException {
+      CodecBuffer.Allocator allocator) throws IOException {
     final int size = message.getSerializedSize();
     return allocator.apply(size).put(writeTo(message, size));
   }

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/utils/db/Proto3Codec.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/utils/db/Proto3Codec.java
@@ -27,7 +27,6 @@ import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
-import java.util.function.IntFunction;
 import java.util.function.ToIntFunction;
 
 /**
@@ -82,7 +81,7 @@ public final class Proto3Codec<M extends MessageLite>
 
   @Override
   public CodecBuffer toCodecBuffer(@Nonnull M message,
-      IntFunction<CodecBuffer> allocator) {
+      CodecBuffer.Allocator allocator) {
     final int size = message.getSerializedSize();
     return allocator.apply(size).put(writeTo(message, size));
   }

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/utils/db/ShortCodec.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/utils/db/ShortCodec.java
@@ -19,7 +19,6 @@
 package org.apache.hadoop.hdds.utils.db;
 
 import java.nio.ByteBuffer;
-import java.util.function.IntFunction;
 
 import javax.annotation.Nonnull;
 
@@ -45,7 +44,7 @@ public final class ShortCodec implements Codec<Short> {
 
   @Override
   public CodecBuffer toCodecBuffer(@Nonnull Short object,
-      IntFunction<CodecBuffer> allocator) {
+      CodecBuffer.Allocator allocator) {
     return allocator.apply(Short.BYTES).putShort(object);
   }
 

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/utils/db/StringCodecBase.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/utils/db/StringCodecBase.java
@@ -34,7 +34,6 @@ import java.nio.charset.CoderResult;
 import java.nio.charset.CodingErrorAction;
 import java.util.Objects;
 import java.util.function.Function;
-import java.util.function.IntFunction;
 
 /**
  * An abstract {@link Codec} to serialize/deserialize {@link String}
@@ -169,7 +168,7 @@ abstract class StringCodecBase implements Codec<String> {
 
   @Override
   public CodecBuffer toCodecBuffer(@Nonnull String object,
-      IntFunction<CodecBuffer> allocator) throws IOException {
+      CodecBuffer.Allocator allocator) throws IOException {
     // allocate a larger buffer to avoid encoding twice.
     final int upperBound = getSerializedSizeUpperBound(object);
     final CodecBuffer buffer = allocator.apply(upperBound);

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/utils/db/UuidCodec.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/utils/db/UuidCodec.java
@@ -21,7 +21,6 @@ package org.apache.hadoop.hdds.utils.db;
 import javax.annotation.Nonnull;
 import java.nio.ByteBuffer;
 import java.util.UUID;
-import java.util.function.IntFunction;
 
 /**
  * Codec to serialize/deserialize {@link UUID}.
@@ -48,7 +47,7 @@ public final class UuidCodec implements Codec<UUID> {
 
   @Override
   public CodecBuffer toCodecBuffer(@Nonnull UUID id,
-      IntFunction<CodecBuffer> allocator) {
+      CodecBuffer.Allocator allocator) {
     return allocator.apply(SERIALIZED_SIZE)
         .putLong(id.getMostSignificantBits())
         .putLong(id.getLeastSignificantBits());

--- a/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/utils/db/CodecTestUtil.java
+++ b/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/utils/db/CodecTestUtil.java
@@ -71,7 +71,7 @@ public final class CodecTestUtil {
 
     // serialize to CodecBuffer
     final CodecBuffer codecBuffer = codec.toCodecBuffer(
-        original, CodecBuffer::allocateHeap);
+        original, CodecBuffer.Allocator.getHeap());
     Assertions.assertEquals(array.length, codecBuffer.readableBytes());
     final ByteBuffer byteBuffer = codecBuffer.asReadOnlyByteBuffer();
     Assertions.assertEquals(array.length, byteBuffer.remaining());

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/ByteStringCodec.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/ByteStringCodec.java
@@ -21,7 +21,6 @@ package org.apache.hadoop.hdds.utils.db;
 import com.google.protobuf.ByteString;
 
 import javax.annotation.Nonnull;
-import java.util.function.IntFunction;
 
 /**
  * Codec to serialize/deserialize a {@link ByteString}.
@@ -42,7 +41,11 @@ public final class ByteStringCodec implements Codec<ByteString> {
 
   @Override
   public CodecBuffer toCodecBuffer(@Nonnull ByteString object,
-      IntFunction<CodecBuffer> allocator) {
+      CodecBuffer.Allocator allocator) {
+    if (allocator.isDirect() && !object.asReadOnlyByteBuffer().isDirect()) {
+      // require direct but the existing buffer is not.
+      return allocator.apply(object.size()).put(object.asReadOnlyByteBuffer());
+    }
     return CodecBuffer.wrap(object);
   }
 

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/ByteStringCodec.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/ByteStringCodec.java
@@ -49,7 +49,7 @@ public final class ByteStringCodec implements Codec<ByteString> {
   @Override
   public ByteString fromCodecBuffer(@Nonnull CodecBuffer buffer) {
     final Object wrapped = buffer.getWrapped();
-    return wrapped instanceof ByteString? (ByteString) wrapped
+    return wrapped instanceof ByteString ? (ByteString) wrapped
         : ByteString.copyFrom(buffer.asReadOnlyByteBuffer());
   }
 

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/ByteStringCodec.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/ByteStringCodec.java
@@ -29,7 +29,7 @@ import java.util.function.IntFunction;
 public final class ByteStringCodec implements Codec<ByteString> {
   private static final ByteStringCodec INSTANCE = new ByteStringCodec();
 
-  public static ByteStringCodec getInstance() {
+  public static ByteStringCodec get() {
     return INSTANCE;
   }
 
@@ -43,12 +43,14 @@ public final class ByteStringCodec implements Codec<ByteString> {
   @Override
   public CodecBuffer toCodecBuffer(@Nonnull ByteString object,
       IntFunction<CodecBuffer> allocator) {
-    return allocator.apply(object.size()).put(object.asReadOnlyByteBuffer());
+    return CodecBuffer.wrap(object);
   }
 
   @Override
   public ByteString fromCodecBuffer(@Nonnull CodecBuffer buffer) {
-    return ByteString.copyFrom(buffer.asReadOnlyByteBuffer());
+    final Object wrapped = buffer.getWrapped();
+    return wrapped instanceof ByteString? (ByteString) wrapped
+        : ByteString.copyFrom(buffer.asReadOnlyByteBuffer());
   }
 
   /**

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/TypedTable.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/TypedTable.java
@@ -192,7 +192,7 @@ public class TypedTable<KEY, VALUE> implements Table<KEY, VALUE> {
       // keyCodec.supportCodecBuffer() is enough since value is not needed.
       try (CodecBuffer inKey = keyCodec.toDirectCodecBuffer(key)) {
         // Use zero capacity buffer since value is not needed.
-        try (CodecBuffer outValue = CodecBuffer.allocateDirect(0)) {
+        try (CodecBuffer outValue = CodecBuffer.getEmptyBuffer()) {
           return getFromTableIfExist(inKey, outValue) != null;
         }
       }

--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/utils/db/TestCodec.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/utils/db/TestCodec.java
@@ -20,6 +20,7 @@ package org.apache.hadoop.hdds.utils.db;
 import com.google.common.primitives.Ints;
 import com.google.common.primitives.Longs;
 import com.google.common.primitives.Shorts;
+import com.google.protobuf.ByteString;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.function.Executable;
@@ -203,6 +204,44 @@ public final class TestCodec {
         tryCatch(() -> FixedLengthStringCodec.string2Bytes(multiByteChars)));
 
     gc();
+  }
+
+  @Test
+  public void testByteStringCodec() throws Exception {
+    runTestByteStringCodec(ByteString.EMPTY);
+
+    for (int i = 0; i < NUM_LOOPS; i++) {
+      final String original = "test" + ThreadLocalRandom.current().nextLong();
+      runTestByteStringCodec(ByteString.copyFromUtf8(original));
+    }
+
+    final String alphabets = "AbcdEfghIjklmnOpqrstUvwxyz";
+    for (int i = 0; i < NUM_LOOPS; i++) {
+      final String original = i == 0 ? alphabets : alphabets.substring(0, i);
+      runTestByteStringCodec(ByteString.copyFromUtf8(original));
+    }
+
+    final String[] docs = {
+        "Ozone 是 Hadoop 的分布式对象存储系统，具有易扩展和冗余存储的特点。",
+        "Ozone 不仅能存储数十亿个不同大小的对象，还支持在容器化环境（比如 Kubernetes）中运行。",
+        "Apache Spark、Hive 和 YARN 等应用无需任何修改即可使用 Ozone。"
+    };
+    for (String original : docs) {
+      runTestByteStringCodec(ByteString.copyFromUtf8(original));
+    }
+
+    final String multiByteChars = "官方发行包包括了源代码包和二进制代码包";
+    for (int i = 0; i < NUM_LOOPS; i++) {
+      final String original = i == 0 ? multiByteChars
+          : multiByteChars.substring(0, i);
+      runTestByteStringCodec(ByteString.copyFromUtf8(original));
+    }
+
+    gc();
+  }
+
+  static void runTestByteStringCodec(ByteString original) throws Exception {
+    runTest(ByteStringCodec.get(), original, original.size());
   }
 
   static Executable tryCatch(Executable executable) {

--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/utils/db/TestCodec.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/utils/db/TestCodec.java
@@ -208,7 +208,7 @@ public final class TestCodec {
 
   @Test
   public void testByteStringCodec() throws Exception {
-    for(int i = 0; i < 2; i++) {
+    for (int i = 0; i < 2; i++) {
       try (CodecBuffer empty = CodecBuffer.getEmptyBuffer()) {
         Assertions.assertTrue(empty.isDirect());
       }

--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/utils/db/TestCodec.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/utils/db/TestCodec.java
@@ -208,6 +208,12 @@ public final class TestCodec {
 
   @Test
   public void testByteStringCodec() throws Exception {
+    for(int i = 0; i < 2; i++) {
+      try (CodecBuffer empty = CodecBuffer.getEmptyBuffer()) {
+        Assertions.assertTrue(empty.isDirect());
+      }
+    }
+
     runTestByteStringCodec(ByteString.EMPTY);
 
     for (int i = 0; i < NUM_LOOPS; i++) {
@@ -288,7 +294,7 @@ public final class TestCodec {
     final Bytes fromArray = new Bytes(array);
 
     try (CodecBuffer buffer = codec.toCodecBuffer(object,
-        CodecBuffer::allocateHeap)) {
+        CodecBuffer.Allocator.HEAP)) {
       final Bytes fromBuffer = new Bytes(buffer);
 
       Assertions.assertEquals(fromArray.hashCode(), fromBuffer.hashCode());

--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/utils/db/TestCodecRegistry.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/utils/db/TestCodecRegistry.java
@@ -30,7 +30,7 @@ public final class TestCodecRegistry {
   static final Logger LOG = LoggerFactory.getLogger(TestCodecRegistry.class);
 
   private final CodecRegistry registry = CodecRegistry.newBuilder()
-      .addCodec(ByteString.class, ByteStringCodec.getInstance())
+      .addCodec(ByteString.class, ByteStringCodec.get())
       .build();
 
   <T> void assertGetCodec(Class<?> expectedCodecClass, T object) {

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMHAManagerStub.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMHAManagerStub.java
@@ -232,8 +232,8 @@ public final class SCMHAManagerStub implements SCMHAManager {
       } catch (NoSuchMethodException | SecurityException ex) {
         throw new InvalidProtocolBufferException(ex.getMessage());
       } catch (InvocationTargetException e) {
-        final Exception targetEx = (Exception) e.getTargetException();
-        throw targetEx != null ? targetEx : e;
+        final Throwable targetEx = e.getTargetException();
+        throw targetEx instanceof Exception? (Exception) targetEx : e;
       }
     }
 

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMHAManagerStub.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMHAManagerStub.java
@@ -232,8 +232,8 @@ public final class SCMHAManagerStub implements SCMHAManager {
       } catch (NoSuchMethodException | SecurityException ex) {
         throw new InvalidProtocolBufferException(ex.getMessage());
       } catch (InvocationTargetException e) {
-        final Throwable targetEx = e.getTargetException();
-        throw targetEx instanceof Exception? (Exception) targetEx : e;
+        final Throwable target = e.getTargetException();
+        throw target instanceof Exception ? (Exception) target : e;
       }
     }
 

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/metadata/SCMDBDefinition.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/metadata/SCMDBDefinition.java
@@ -182,7 +182,7 @@ public class SCMDBDefinition extends DBDefinition.WithMap {
           String.class,
           StringCodec.get(),
           ByteString.class,
-          ByteStringCodec.getInstance());
+          ByteStringCodec.get());
 
   private static final Map<String, DBColumnFamilyDefinition<?, ?>>
       COLUMN_FAMILIES = DBColumnFamilyDefinition.newUnmodifiableMap(

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/metadata/X509CertificateCodec.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/metadata/X509CertificateCodec.java
@@ -24,7 +24,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.security.cert.X509Certificate;
-import java.util.function.IntFunction;
 
 import org.apache.hadoop.hdds.security.exception.SCMSecurityException;
 import org.apache.hadoop.hdds.security.x509.certificate.utils.CertificateCodec;
@@ -65,7 +64,7 @@ public final class X509CertificateCodec implements Codec<X509Certificate> {
 
   @Override
   public CodecBuffer toCodecBuffer(@Nonnull X509Certificate object,
-      IntFunction<CodecBuffer> allocator) throws IOException {
+      CodecBuffer.Allocator allocator) throws IOException {
     return allocator.apply(-INITIAL_CAPACITY).put(writeTo(object));
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

In `ByteStringCodec`, we may wrap the ByteString instead of copying it in the `toCodecBuffer(..)` method.

## What is the link to the Apache JIRA

HDDS-9370

## How was this patch tested?

Added new tests.