### PR TITLE
HDDS 9368

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -70,6 +70,8 @@ Additional requirements for running Ozone in pseudo cluster (including acceptanc
 
 After building Ozone locally, you can start your first pseudo cluster:
 
+Kindly ensure you have an updated version of bash to run the run.sh script. If you're on the default Mac terminal, Please update your bash.
+
 ```
 cd hadoop-ozone/dist/target/ozone-*-SNAPSHOT/compose/ozone
 OZONE_REPLICATION_FACTOR=3 ./run.sh -d

--- a/hadoop-ozone/dist/src/main/compose/ozone/bash_new.sh
+++ b/hadoop-ozone/dist/src/main/compose/ozone/bash_new.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+echo "Running bash_new script with the flags $@"
+
+declare -i OZONE_DATANODES OZONE_REPLICATION_FACTOR OZONE_SAFEMODE_MIN_DATANODES
+
+ORIG_DATANODES="${OZONE_DATANODES:-}"
+ORIG_REPLICATION_FACTOR="${OZONE_REPLICATION_FACTOR:-}"
+
+# only support replication factor of 1 or 3
+if [[ -n OZONE_REPLICATION_FACTOR ]] && [[ ${OZONE_REPLICATION_FACTOR} -ne 1 ]] && [[ ${OZONE_REPLICATION_FACTOR} -ne 3 ]]; then
+  # assume invalid replication factor was intended as "number of datanodes"
+  if [[ -z ${ORIG_DATANODES} ]]; then
+    OZONE_DATANODES=${OZONE_REPLICATION_FACTOR}
+  fi
+  unset OZONE_REPLICATION_FACTOR
+fi
+
+# at least 1 datanode
+if [[ -n OZONE_DATANODES ]] && [[ ${OZONE_DATANODES} -lt 1 ]]; then
+  unset OZONE_DATANODES
+fi
+
+if [[ -n OZONE_DATANODES ]] && [[ -n OZONE_REPLICATION_FACTOR ]]; then
+  # ensure enough datanodes for replication factor
+  if [[ ${OZONE_DATANODES} -lt ${OZONE_REPLICATION_FACTOR} ]]; then
+    OZONE_DATANODES=${OZONE_REPLICATION_FACTOR}
+  fi
+elif [[ -n OZONE_DATANODES ]]; then
+  if [[ ${OZONE_DATANODES} -ge 3 ]]; then
+    OZONE_REPLICATION_FACTOR=3
+  else
+    OZONE_REPLICATION_FACTOR=1
+  fi
+elif [[ -n OZONE_REPLICATION_FACTOR ]]; then
+  OZONE_DATANODES=${OZONE_REPLICATION_FACTOR}
+else
+  OZONE_DATANODES=1
+  OZONE_REPLICATION_FACTOR=1
+fi
+
+: ${OZONE_SAFEMODE_MIN_DATANODES:=${OZONE_REPLICATION_FACTOR}}
+
+export OZONE_DATANODES OZONE_REPLICATION_FACTOR OZONE_SAFEMODE_MIN_DATANODES
+
+#docker-compose up --scale datanode=${OZONE_DATANODES} --no-recreate "$@"
+echo "docker-compose up --scale datanode=${OZONE_DATANODES} --no-recreate \"$@\""

--- a/hadoop-ozone/dist/src/main/compose/ozone/bash_old.sh
+++ b/hadoop-ozone/dist/src/main/compose/ozone/bash_old.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+echo "Running bash_old script with the flags $@"
+# Here's the script content you provided
+declare -i OZONE_DATANODES OZONE_REPLICATION_FACTOR OZONE_SAFEMODE_MIN_DATANODES
+
+ORIG_DATANODES="${OZONE_DATANODES:-}"
+ORIG_REPLICATION_FACTOR="${OZONE_REPLICATION_FACTOR:-}"
+
+# only support replication factor of 1 or 3
+if [[ -n OZONE_REPLICATION_FACTOR ]] && [[ ${OZONE_REPLICATION_FACTOR} -ne 1 ]] && [[ ${OZONE_REPLICATION_FACTOR} -ne 3 ]]; then
+  # assume invalid replication factor was intended as "number of datanodes"
+  if [[ -z ${ORIG_DATANODES} ]]; then
+    OZONE_DATANODES=${OZONE_REPLICATION_FACTOR}
+  fi
+  unset OZONE_REPLICATION_FACTOR
+fi
+
+# at least 1 datanode
+if [[ -n OZONE_DATANODES ]] && [[ ${OZONE_DATANODES} -lt 1 ]]; then
+  unset OZONE_DATANODES
+fi
+
+if [[ -n OZONE_DATANODES ]] && [[ -n OZONE_REPLICATION_FACTOR ]]; then
+  # ensure enough datanodes for replication factor
+  if [[ ${OZONE_DATANODES} -lt ${OZONE_REPLICATION_FACTOR} ]]; then
+    OZONE_DATANODES=${OZONE_REPLICATION_FACTOR}
+  fi
+elif [[ -n OZONE_DATANODES ]]; then
+  if [[ ${OZONE_DATANODES} -ge 3 ]]; then
+    OZONE_REPLICATION_FACTOR=3
+  else
+    OZONE_REPLICATION_FACTOR=1
+  fi
+elif [[ -n OZONE_REPLICATION_FACTOR ]]; then
+  OZONE_DATANODES=${OZONE_REPLICATION_FACTOR}
+else
+  OZONE_DATANODES=1
+  OZONE_REPLICATION_FACTOR=1
+fi
+
+: ${OZONE_SAFEMODE_MIN_DATANODES:=${OZONE_REPLICATION_FACTOR}}
+
+export OZONE_DATANODES OZONE_REPLICATION_FACTOR OZONE_SAFEMODE_MIN_DATANODES
+
+#docker-compose up --scale datanode=${OZONE_DATANODES} --no-recreate "$@"
+echo "docker-compose up --scale datanode=${OZONE_DATANODES} --no-recreate \"$@\""

--- a/hadoop-ozone/dist/src/main/compose/ozone/run.sh
+++ b/hadoop-ozone/dist/src/main/compose/ozone/run.sh
@@ -22,7 +22,7 @@ minor_version=$(echo $bash_version | cut -d. -f2)
 
 # If bash version is below a certain minimum (4.2 in this case), exit the script
 if [[ "$major_version" -lt 4 ]] || [[ "$major_version" -eq 4 && "$minor_version" -lt 2 ]]; then
-    echo "Your bash version (${bash_version}) is incompatible with this script. Please update your Bash to a more recent version."
+    echo "Your bash version (${bash_version}) is too old to run this script. Please update your Bash to a more recent version."
     exit 1
 fi
 

--- a/hadoop-ozone/dist/src/main/compose/ozone/run.sh
+++ b/hadoop-ozone/dist/src/main/compose/ozone/run.sh
@@ -15,29 +15,56 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Get the version string of the bash
-bash_version_string=$(bash --version | head -n 1)
+# Get the version number and break it into major and minor parts
+bash_version=$(bash --version | grep -oE 'version [0-9]+\.[0-9]+' | grep -oE '[0-9]+\.[0-9]+')
+major_version=$(echo $bash_version | cut -d. -f1)
+minor_version=$(echo $bash_version | cut -d. -f2)
 
-# Extract the major, minor, and patch version numbers.
-BASH_VERSION_NUM=$(echo "$bash_version_string" | awk -F'[^0-9]*' '{print $2"."$3"."$4}')
-
-# Extract major and minor for the comparison logic
-BASH_MAJOR_VERSION=$(echo "$BASH_VERSION_NUM" | cut -d. -f1)
-BASH_MINOR_VERSION=$(echo "$BASH_VERSION_NUM" | cut -d. -f2)
-
-# Check bash version and call the appropriate script with appropriate flags
-if [[ $BASH_MAJOR_VERSION -lt 4 ]] || { [[ $BASH_MAJOR_VERSION -eq 4 ]] && [[ $BASH_MINOR_VERSION -lt 2 ]]; }; then
-    echo "+------------------------------------------------------------------------------------+"
-    echo "|                                                                                    |"
-    echo "|  WARNING: You are running Bash version $BASH_VERSION_NUM.                                     |"
-    echo "|  It is recommended to use Bash 4.2 or newer.                                       |"
-    echo "|  Bash 4.2 was released on February 13, 2011 and addresses vulnerabilities such as: |"
-    echo "|  CVE-2019-18276, CVE-2019-9924, CVE-2016-9401, and CVE-2016-7543.                  |"
-    echo "|                                                                                    |"
-    echo "|  Please consider updating your bash to a more recent version.                      |"
-    echo "|                                                                                    |"
-    echo "+------------------------------------------------------------------------------------+"
-    ./bash_old.sh -v
-else
-    ./bash_new.sh -v -z
+# If bash version is below a certain minimum (4.2 in this case), exit the script
+if [[ "$major_version" -lt 4 ]] || [[ "$major_version" -eq 4 && "$minor_version" -lt 2 ]]; then
+    echo "Your bash version (${bash_version}) is incompatible with this script. Please update your Bash to a more recent version."
+    exit 1
 fi
+
+declare -i OZONE_DATANODES OZONE_REPLICATION_FACTOR OZONE_SAFEMODE_MIN_DATANODES
+
+ORIG_DATANODES="${OZONE_DATANODES:-}"
+ORIG_REPLICATION_FACTOR="${OZONE_REPLICATION_FACTOR:-}"
+
+# only support replication factor of 1 or 3
+if [[ -v OZONE_REPLICATION_FACTOR ]] && [[ ${OZONE_REPLICATION_FACTOR} -ne 1 ]] && [[ ${OZONE_REPLICATION_FACTOR} -ne 3 ]]; then
+  # assume invalid replication factor was intended as "number of datanodes"
+  if [[ -z ${ORIG_DATANODES} ]]; then
+    OZONE_DATANODES=${OZONE_REPLICATION_FACTOR}
+  fi
+  unset OZONE_REPLICATION_FACTOR
+fi
+
+# at least 1 datanode
+if [[ -v OZONE_DATANODES ]] && [[ ${OZONE_DATANODES} -lt 1 ]]; then
+  unset OZONE_DATANODES
+fi
+
+if [[ -v OZONE_DATANODES ]] && [[ -v OZONE_REPLICATION_FACTOR ]]; then
+  # ensure enough datanodes for replication factor
+  if [[ ${OZONE_DATANODES} -lt ${OZONE_REPLICATION_FACTOR} ]]; then
+    OZONE_DATANODES=${OZONE_REPLICATION_FACTOR}
+  fi
+elif [[ -v OZONE_DATANODES ]]; then
+  if [[ ${OZONE_DATANODES} -ge 3 ]]; then
+    OZONE_REPLICATION_FACTOR=3
+  else
+    OZONE_REPLICATION_FACTOR=1
+  fi
+elif [[ -v OZONE_REPLICATION_FACTOR ]]; then
+  OZONE_DATANODES=${OZONE_REPLICATION_FACTOR}
+else
+  OZONE_DATANODES=1
+  OZONE_REPLICATION_FACTOR=1
+fi
+
+: ${OZONE_SAFEMODE_MIN_DATANODES:=${OZONE_REPLICATION_FACTOR}}
+
+export OZONE_DATANODES OZONE_REPLICATION_FACTOR OZONE_SAFEMODE_MIN_DATANODES
+
+docker-compose up --scale datanode=${OZONE_DATANODES} --no-recreate "$@"


### PR DESCRIPTION
## What changes were proposed in this pull request?

- The hadoop-ozone/dist/src/main/compose/ozone/run.sh file fails to execute if the bash version is lower than 4.2

- Added a condition to check the user's bash version and if it is lower than 4.2 then exit with a message that their bash version is too old and the user should update it.

- This happened when I tried in my mac's default terminal that had bash 3.2

- This issue happens because the flags -v and -z were introduced in bash 4.2 and they were not available in the bash version prior to that.

- Updated the CONTRIBUTING.md file to ask the user to check their bash version before running the run.sh file to run Ozone in Docker.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-9368

## How was this patch tested?

Tested by 

1. Replacing the 
`docker-compose up --scale datanode=${OZONE_DATANODES} --no-recreate "$@"`
 with an `echo "Success"` message. Then,
3. Set the bash_version variable to various values and tested it to see if it shows the error message.
4. The updated script exited with an error when the bash_version value is set to anything less then 4.2 and succeeded if the bash_version is above 4.2.
