### PR TITLE
HDDS-9373. Optimize listKeysLight API further by efficient server-side proto field population

### DIFF
--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/OzoneKey.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/OzoneKey.java
@@ -32,6 +32,9 @@ import java.util.HashMap;
  */
 public class OzoneKey {
 
+  public static final long DEFAULT_CREATION_TIME_VALUE = Long.MIN_VALUE;
+  public static final long DEFAULT_MODIFICATION_TIME_VALUE = Long.MIN_VALUE;
+
   /**
    * Name of the Volume the Key belongs to.
    */
@@ -140,12 +143,27 @@ public class OzoneKey {
     return creationTime;
   }
 
+  public Instant getCreationTime(Instant bucketCreationTime) {
+    if (creationTime == Instant.ofEpochMilli(DEFAULT_CREATION_TIME_VALUE)) {
+      return bucketCreationTime;
+    }
+    return creationTime;
+  }
+
   /**
    * Returns the modification time of the key.
    *
    * @return modification time
    */
   public Instant getModificationTime() {
+    return modificationTime;
+  }
+
+  public Instant getModificationTime(Instant bucketModificationTime) {
+    if (modificationTime ==
+        Instant.ofEpochMilli(DEFAULT_MODIFICATION_TIME_VALUE)) {
+      return bucketModificationTime;
+    }
     return modificationTime;
   }
 
@@ -157,25 +175,27 @@ public class OzoneKey {
     this.metadata.putAll(metadata);
   }
 
-  /**
-   * Returns the replication type of the key.
-   *
-   * @return replicationType
-   */
   @Deprecated
   @JsonIgnore
-  public ReplicationType getReplicationType() {
+  public ReplicationType getReplicationType(
+      ReplicationConfig bucketReplicationConfig) {
+    if (replicationConfig == null) {
+      return ReplicationType
+          .fromProto(bucketReplicationConfig.getReplicationType());
+    }
     return ReplicationType
-            .fromProto(replicationConfig.getReplicationType());
-  }
-
-  @Deprecated
-  @JsonIgnore
-  public int getReplicationFactor() {
-    return replicationConfig.getRequiredNodes();
+        .fromProto(replicationConfig.getReplicationType());
   }
 
   public ReplicationConfig getReplicationConfig() {
+    return replicationConfig;
+  }
+
+  public ReplicationConfig getReplicationConfig(
+      ReplicationConfig bucketReplicationConfig) {
+    if (replicationConfig == null) {
+      return bucketReplicationConfig;
+    }
     return replicationConfig;
   }
 

--- a/hadoop-ozone/client/src/test/java/org/apache/hadoop/ozone/client/TestOzoneClient.java
+++ b/hadoop-ozone/client/src/test/java/org/apache/hadoop/ozone/client/TestOzoneClient.java
@@ -168,8 +168,10 @@ public class TestOzoneClient {
       Assert.assertEquals(value.length(), is.read(fileContent));
       is.close();
       Assert.assertEquals(value, new String(fileContent, UTF_8));
-      Assert.assertFalse(key.getCreationTime().isBefore(testStartTime));
-      Assert.assertFalse(key.getModificationTime().isBefore(testStartTime));
+      Assert.assertFalse(key.getCreationTime(bucket.getCreationTime())
+          .isBefore(testStartTime));
+      Assert.assertFalse(key.getModificationTime(bucket.getModificationTime())
+          .isBefore(testStartTime));
     }
   }
 

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFileSystem.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFileSystem.java
@@ -1576,7 +1576,8 @@ public class TestOzoneFileSystem {
       throws IOException {
     o3FS.createFile(keyPath).build().close();
     Assert.assertEquals(expectedType.name(),
-        bucket.getKey(o3FS.pathToKey(keyPath)).getReplicationConfig()
+        bucket.getKey(o3FS.pathToKey(keyPath))
+            .getReplicationConfig(bucket.getReplicationConfig())
             .getReplicationType().name());
   }
 

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestRootedOzoneFileSystem.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestRootedOzoneFileSystem.java
@@ -2244,8 +2244,8 @@ public class TestRootedOzoneFileSystem {
     OFSPath ofsPath = new OFSPath(vol + "/" + buck + "/test", conf);
     final OzoneBucket bucket = adapter.getBucket(ofsPath, false);
     final OzoneKeyDetails key = bucket.getKey(ofsPath.getKeyName());
-    Assert.assertEquals(key.getReplicationConfig().getReplicationType().name(),
-        ReplicationType.RATIS.name());
+    Assert.assertEquals(key.getReplicationConfig(bucket.getReplicationConfig())
+        .getReplicationType().name(), ReplicationType.RATIS.name());
   }
 
   @Test
@@ -2275,7 +2275,8 @@ public class TestRootedOzoneFileSystem {
     final OzoneBucket bucket = adapter.getBucket(ofsPath, false);
     final OzoneKeyDetails key = bucket.getKey(ofsPath.getKeyName());
     Assert.assertEquals(ReplicationType.EC.name(),
-        key.getReplicationConfig().getReplicationType().name());
+        key.getReplicationConfig(bucket.getReplicationConfig())
+            .getReplicationType().name());
   }
 
   @Test

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestECKeyOutputStream.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestECKeyOutputStream.java
@@ -239,7 +239,8 @@ public class TestECKeyOutputStream {
       }
     }
     OzoneKeyDetails key = bucket.getKey(keyName);
-    Assert.assertEquals(replicationConfig, key.getReplicationConfig());
+    Assert.assertEquals(replicationConfig,
+        key.getReplicationConfig(bucket.getReplicationConfig()));
   }
 
   @Test

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestOzoneAtRestEncryption.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestOzoneAtRestEncryption.java
@@ -275,8 +275,10 @@ class TestOzoneAtRestEncryption {
         bucket.getName(), keyName, RATIS,
         ONE));
     assertEquals(value, new String(fileContent, StandardCharsets.UTF_8));
-    assertFalse(key.getCreationTime().isBefore(testStartTime));
-    assertFalse(key.getModificationTime().isBefore(testStartTime));
+    assertFalse(
+        key.getCreationTime(bucket.getCreationTime()).isBefore(testStartTime));
+    assertFalse(key.getModificationTime(bucket.getModificationTime())
+        .isBefore(testStartTime));
   }
 
   private OzoneBucket createVolumeAndBucket(String volumeName,
@@ -357,8 +359,10 @@ class TestOzoneAtRestEncryption {
         keyName, RATIS,
         ONE));
     assertEquals(value, new String(fileContent, StandardCharsets.UTF_8));
-    assertFalse(key.getCreationTime().isBefore(testStartTime));
-    assertFalse(key.getModificationTime().isBefore(testStartTime));
+    assertFalse(
+        key.getCreationTime(bucket.getCreationTime()).isBefore(testStartTime));
+    assertFalse(key.getModificationTime(bucket.getModificationTime())
+        .isBefore(testStartTime));
     assertEquals("true", key.getMetadata().get(OzoneConsts.GDPR_FLAG));
     //As TDE is enabled, the TDE encryption details should not be null.
     assertNotNull(key.getFileEncryptionInfo());

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestOzoneRpcClientAbstract.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestOzoneRpcClientAbstract.java
@@ -981,8 +981,10 @@ public abstract class TestOzoneRpcClientAbstract {
             RatisReplicationConfig.getInstance(
                 HddsProtos.ReplicationFactor.ONE));
         assertEquals(value, new String(fileContent, UTF_8));
-        assertFalse(key.getCreationTime().isBefore(testStartTime));
-        assertFalse(key.getModificationTime().isBefore(testStartTime));
+        assertFalse(key.getCreationTime(bucket.getCreationTime())
+            .isBefore(testStartTime));
+        assertFalse(key.getModificationTime(bucket.getModificationTime())
+            .isBefore(testStartTime));
       }
     }
   }
@@ -1542,8 +1544,10 @@ public abstract class TestOzoneRpcClientAbstract {
             RatisReplicationConfig.getInstance(
                 HddsProtos.ReplicationFactor.ONE));
         assertEquals(value, new String(fileContent, UTF_8));
-        assertFalse(key.getCreationTime().isBefore(testStartTime));
-        assertFalse(key.getModificationTime().isBefore(testStartTime));
+        assertFalse(key.getCreationTime(bucket.getCreationTime())
+            .isBefore(testStartTime));
+        assertFalse(key.getModificationTime(bucket.getModificationTime())
+            .isBefore(testStartTime));
       }
     }
   }
@@ -1577,8 +1581,10 @@ public abstract class TestOzoneRpcClientAbstract {
             RatisReplicationConfig.getInstance(
                 HddsProtos.ReplicationFactor.THREE));
         assertEquals(value, new String(fileContent, UTF_8));
-        assertFalse(key.getCreationTime().isBefore(testStartTime));
-        assertFalse(key.getModificationTime().isBefore(testStartTime));
+        assertFalse(key.getCreationTime(bucket.getCreationTime())
+            .isBefore(testStartTime));
+        assertFalse(key.getModificationTime(bucket.getModificationTime())
+            .isBefore(testStartTime));
       }
     }
   }
@@ -1619,8 +1625,10 @@ public abstract class TestOzoneRpcClientAbstract {
                     HddsProtos.ReplicationFactor.THREE));
             assertEquals(data, new String(fileContent, UTF_8));
           }
-          assertFalse(key.getCreationTime().isBefore(testStartTime));
-          assertFalse(key.getModificationTime().isBefore(testStartTime));
+          assertFalse(key.getCreationTime(bucket.getCreationTime())
+              .isBefore(testStartTime));
+          assertFalse(key.getModificationTime(bucket.getModificationTime())
+              .isBefore(testStartTime));
         }
         latch.countDown();
       } catch (IOException ex) {
@@ -4024,9 +4032,11 @@ public abstract class TestOzoneRpcClientAbstract {
     assertEquals(bucketName, key.getBucketName());
     assertEquals(keyName, key.getName());
     assertEquals(replicationConfig.getReplicationType(),
-        key.getReplicationConfig().getReplicationType());
+        key.getReplicationConfig(bucket.getReplicationConfig())
+            .getReplicationType());
     assertEquals(replicationConfig.getRequiredNodes(),
-        key.getReplicationConfig().getRequiredNodes());
+        key.getReplicationConfig(bucket.getReplicationConfig())
+            .getRequiredNodes());
     assertEquals(value.getBytes(UTF_8).length, key.getDataSize());
 
     try {

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestSecureOzoneRpcClient.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestSecureOzoneRpcClient.java
@@ -227,8 +227,10 @@ public class TestSecureOzoneRpcClient extends TestOzoneRpcClient {
           keyName, ReplicationType.RATIS,
           ReplicationFactor.ONE));
       assertEquals(value, new String(fileContent, UTF_8));
-      assertFalse(key.getCreationTime().isBefore(testStartTime));
-      assertFalse(key.getModificationTime().isBefore(testStartTime));
+      assertFalse(key.getCreationTime(bucket.getCreationTime())
+          .isBefore(testStartTime));
+      assertFalse(key.getModificationTime(bucket.getModificationTime())
+          .isBefore(testStartTime));
     }
   }
 

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestListKeys.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestListKeys.java
@@ -295,7 +295,8 @@ public class TestListKeys {
     List <String> keyLists = new ArrayList<>();
     while (ozoneKeyIterator.hasNext()) {
       OzoneKey ozoneKey = ozoneKeyIterator.next();
-      Assert.assertEquals(expectedReplication, ozoneKey.getReplicationConfig());
+      Assert.assertEquals(expectedReplication,
+          ozoneKey.getReplicationConfig(bucket.getReplicationConfig()));
       keyLists.add(ozoneKey.getName());
     }
     LinkedList outputKeysList = new LinkedList(keyLists);

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestListKeysWithFSO.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestListKeysWithFSO.java
@@ -507,7 +507,8 @@ public class TestListKeysWithFSO {
     List <String> keyLists = new ArrayList<>();
     while (ozoneKeyIterator.hasNext()) {
       OzoneKey ozoneKey = ozoneKeyIterator.next();
-      Assert.assertEquals(expectedReplication, ozoneKey.getReplicationConfig());
+      Assert.assertEquals(expectedReplication,
+          ozoneKey.getReplicationConfig(fsoBucket.getReplicationConfig()));
       keyLists.add(ozoneKey.getName());
     }
     LinkedList outputKeysList = new LinkedList(keyLists);

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerRestart.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerRestart.java
@@ -231,8 +231,9 @@ public class TestOzoneManagerRestart {
     // Get newKey1.
     OzoneKey ozoneKey = ozoneBucket.getKey(newKey1);
     Assert.assertTrue(ozoneKey.getName().equals(newKey1));
-    Assert.assertTrue(ozoneKey.getReplicationType().equals(
-        ReplicationType.RATIS));
+    Assert.assertTrue(
+        ozoneKey.getReplicationType(ozoneBucket.getReplicationConfig())
+            .equals(ReplicationType.RATIS));
 
     // Get newKey2, it should not exist
     try {

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/scm/TestStorageContainerManagerHA.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/scm/TestStorageContainerManagerHA.java
@@ -193,8 +193,11 @@ public class TestStorageContainerManagerHA {
       byte[] fileContent = new byte[value.getBytes(UTF_8).length];
       is.read(fileContent);
       Assertions.assertEquals(value, new String(fileContent, UTF_8));
-      Assertions.assertFalse(key.getCreationTime().isBefore(testStartTime));
-      Assertions.assertFalse(key.getModificationTime().isBefore(testStartTime));
+      Assertions.assertFalse(key.getCreationTime(bucket.getCreationTime())
+          .isBefore(testStartTime));
+      Assertions.assertFalse(
+          key.getModificationTime(bucket.getModificationTime())
+              .isBefore(testStartTime));
       is.close();
       final OmKeyArgs keyArgs = new OmKeyArgs.Builder()
           .setVolumeName(volumeName)

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/shell/TestOzoneShellHA.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/shell/TestOzoneShellHA.java
@@ -1246,8 +1246,9 @@ public class TestOzoneShellHA {
     OzoneKeyDetails key =
         client.getObjectStore().getVolume(volumeName)
             .getBucket(bucketName).getKey(keyName);
-    assertEquals(HddsProtos.ReplicationType.EC,
-        key.getReplicationConfig().getReplicationType());
+    assertEquals(HddsProtos.ReplicationType.EC, key.getReplicationConfig(
+        client.getObjectStore().getVolume(volumeName).getBucket(bucketName)
+            .getReplicationConfig()).getReplicationType());
   }
 
   @Test

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/BucketEndpoint.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/BucketEndpoint.java
@@ -694,19 +694,23 @@ public class BucketEndpoint extends EndpointBase {
     return ozoneAclList;
   }
 
-  private void addKey(ListObjectResponse response, OzoneKey next) {
+  private void addKey(ListObjectResponse response, OzoneKey next)
+      throws OS3Exception, IOException {
     KeyMetadata keyMetadata = new KeyMetadata();
     keyMetadata.setKey(EncodingTypeObject.createNullable(next.getName(),
         response.getEncodingType()));
     keyMetadata.setSize(next.getDataSize());
-    keyMetadata.setETag("" + next.getModificationTime());
-    if (next.getReplicationType().toString().equals(ReplicationType
-        .STAND_ALONE.toString())) {
+    keyMetadata.setETag("" + next.getModificationTime(
+        getBucket(next.getBucketName()).getModificationTime()));
+    if (next.getReplicationType(
+            getBucket(next.getBucketName()).getReplicationConfig()).toString()
+        .equals(ReplicationType.STAND_ALONE.toString())) {
       keyMetadata.setStorageClass(S3StorageType.REDUCED_REDUNDANCY.toString());
     } else {
       keyMetadata.setStorageClass(S3StorageType.STANDARD.toString());
     }
-    keyMetadata.setLastModified(next.getModificationTime());
+    keyMetadata.setLastModified(next.getModificationTime(
+        getBucket(next.getBucketName()).getModificationTime()));
     response.addKey(keyMetadata);
   }
 

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/ObjectEndpoint.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/ObjectEndpoint.java
@@ -535,7 +535,8 @@ public class ObjectEndpoint extends EndpointBase {
     }
 
     ResponseBuilder response = Response.ok().status(HttpStatus.SC_OK)
-        .header("ETag", "" + key.getModificationTime())
+        .header("ETag", "" + key.getModificationTime(
+            getBucket(key.getBucketName()).getModificationTime()))
         .header("Content-Length", key.getDataSize())
         .header("Content-Type", "binary/octet-stream");
     addLastModifiedDate(response, key);
@@ -854,8 +855,9 @@ public class ObjectEndpoint extends EndpointBase {
 
           OzoneKeyDetails sourceKeyDetails = getClientProtocol().getKeyDetails(
               volume.getName(), sourceBucket, sourceKey);
-          Long sourceKeyModificationTime = sourceKeyDetails
-              .getModificationTime().toEpochMilli();
+          Long sourceKeyModificationTime = sourceKeyDetails.getModificationTime(
+                  getBucket(sourceKeyDetails.getBucketName()).
+                      getModificationTime()).toEpochMilli();
           String copySourceIfModifiedSince =
               headers.getHeaderString(COPY_SOURCE_IF_MODIFIED_SINCE);
           String copySourceIfUnmodifiedSince =
@@ -1083,7 +1085,8 @@ public class ObjectEndpoint extends EndpointBase {
       getMetrics().updateCopyObjectSuccessStats(startNanos);
       CopyObjectResponse copyObjectResponse = new CopyObjectResponse();
       copyObjectResponse.setETag(OzoneUtils.getRequestID());
-      copyObjectResponse.setLastModified(destKeyDetails.getModificationTime());
+      copyObjectResponse.setLastModified(destKeyDetails.getModificationTime(
+          getBucket(destKeyDetails.getBucketName()).getModificationTime()));
       return copyObjectResponse;
     } catch (OMException ex) {
       if (ex.getResult() == ResultCodes.KEY_NOT_FOUND) {

--- a/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestMultipartUploadWithCopy.java
+++ b/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestMultipartUploadWithCopy.java
@@ -100,7 +100,9 @@ public class TestMultipartUploadWithCopy {
     sourceKeyLastModificationTime = CLIENT.getObjectStore()
         .getS3Bucket(OzoneConsts.S3_BUCKET)
         .getKey(EXISTING_KEY)
-        .getModificationTime().toEpochMilli();
+        .getModificationTime(
+            CLIENT.getObjectStore().getS3Bucket(OzoneConsts.S3_BUCKET)
+                .getModificationTime()).toEpochMilli();
     beforeSourceKeyModificationTimeStr =
         OzoneUtils.formatTime(sourceKeyLastModificationTime - 1000);
     afterSourceKeyModificationTimeStr =

--- a/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestObjectPut.java
+++ b/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestObjectPut.java
@@ -129,7 +129,9 @@ public class TestObjectPut {
 
     Assert.assertEquals(ecReplicationConfig,
         clientStub.getObjectStore().getS3Bucket(bucketName).getKey(keyName)
-            .getReplicationConfig());
+            .getReplicationConfig(
+                clientStub.getObjectStore().getS3Bucket(bucketName)
+                    .getReplicationConfig()));
     OzoneInputStream ozoneInputStream =
         clientStub.getObjectStore().getS3Bucket(bucketName)
             .readKey(keyName);
@@ -297,7 +299,9 @@ public class TestObjectPut {
 
 
     //default type is set
-    Assert.assertEquals(ReplicationType.RATIS, key.getReplicationType());
+    Assert.assertEquals(ReplicationType.RATIS, key.getReplicationType(
+        clientStub.getObjectStore().getS3Bucket(bucketName)
+            .getReplicationConfig()));
   }
 
   @Test


### PR DESCRIPTION
## What changes were proposed in this pull request?

We have introduced a lightweight listKeys API as part of [HDDS-9079](https://issues.apache.org/jira/browse/HDDS-9079). Implement a lightweight listKeys API (PR [#5115](https://github.com/apache/ozone/pull/5115)), leveraging a trimmed `KeyInfo` (`BasicKeyInfo`) proto object to exclude less relevant fields, such as `KeyLocations`, which have limited utility on the client side. This implementation utilizes newer server-side Ozone key encapsulations and proto objects as part of HDDS-9079.

```
message BasicKeyInfo {
    optional string keyName = 1;
    optional uint64 dataSize = 2;
    optional uint64 creationTime = 3;
    optional uint64 modificationTime = 4;
    optional hadoop.hdds.ReplicationType type = 5;
    optional hadoop.hdds.ReplicationFactor factor = 6;
    optional hadoop.hdds.ECReplicationConfig ecReplicationConfig = 7;
}
```

The primary goal of this enhancement is to skip the deserialization of metadata specific to block information, etc. thus reducing the performance overhead when listing keys. Additionally, we aim to further improve performance by selectively populating the   below fields server-side only when the key's configuration differs from that of its associated bucket:

> ```
>     optional uint64 modificationTime = 4;
>     optional hadoop.hdds.ReplicationType type = 5;
>     optional hadoop.hdds.ReplicationFactor factor = 6;
>     optional hadoop.hdds.ECReplicationConfig ecReplicationConfig = 7;
> ```

This optimization should lead to reduced payload and server-side processing unless the key is replicated in a configuration distinct from the bucket's default settings. Addressing the [review comment](https://github.com/apache/ozone/pull/5115#discussion_r1298020212) as part of this PR.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-9373

## How was this patch tested?

Existing test cases should cover the code changes
