### PR TITLE
HDDS-8483. Log failed temp snapshot deletes.

### DIFF
--- a/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicOzoneClientAdapterImpl.java
+++ b/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicOzoneClientAdapterImpl.java
@@ -707,24 +707,12 @@ public class BasicOzoneClientAdapterImpl implements OzoneClientAdapter {
       if (takeTemporaryToSnapshot || takeTemporaryFromSnapshot) {
         OFSPath snapPath = new OFSPath(snapshotDir.toString(), config);
         if (takeTemporaryToSnapshot) {
-          deleteSnapshot(toSnapshot, snapPath);
+          OzoneClientUtils.deleteSnapshot(objectStore, toSnapshot, snapPath);
         }
         if (takeTemporaryFromSnapshot) {
-          deleteSnapshot(fromSnapshot, snapPath);
+          OzoneClientUtils.deleteSnapshot(objectStore, fromSnapshot, snapPath);
         }
       }
-    }
-  }
-
-  private void deleteSnapshot(String snapshot, OFSPath snapPath) {
-    try {
-      objectStore.deleteSnapshot(snapPath.getVolumeName(),
-          snapPath.getBucketName(), snapshot);
-    } catch (IOException exception) {
-      LOG.warn("Failed to delete the temp snapshot with name {} in bucket"
-              + " {} and volume {} after snapDiff op. Exception : {}", snapshot,
-          snapPath.getBucketName(), snapPath.getVolumeName(),
-          exception.getMessage());
     }
   }
 

--- a/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicOzoneClientAdapterImpl.java
+++ b/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicOzoneClientAdapterImpl.java
@@ -722,8 +722,9 @@ public class BasicOzoneClientAdapterImpl implements OzoneClientAdapter {
           snapPath.getBucketName(), snapshot);
     } catch (IOException exception) {
       LOG.warn("Failed to delete the temp snapshot with name {} in bucket"
-              + " {} and volume {} after snapDiff op.", snapshot,
-          snapPath.getBucketName(), snapPath.getVolumeName());
+              + " {} and volume {} after snapDiff op. Exception : {}", snapshot,
+          snapPath.getBucketName(), snapPath.getVolumeName(),
+          exception.getMessage());
     }
   }
 

--- a/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicOzoneClientAdapterImpl.java
+++ b/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicOzoneClientAdapterImpl.java
@@ -707,14 +707,23 @@ public class BasicOzoneClientAdapterImpl implements OzoneClientAdapter {
       if (takeTemporaryToSnapshot || takeTemporaryFromSnapshot) {
         OFSPath snapPath = new OFSPath(snapshotDir.toString(), config);
         if (takeTemporaryToSnapshot) {
-          objectStore.deleteSnapshot(snapPath.getVolumeName(),
-              snapPath.getBucketName(), toSnapshot);
+          deleteSnapshot(toSnapshot, snapPath);
         }
         if (takeTemporaryFromSnapshot) {
-          objectStore.deleteSnapshot(snapPath.getVolumeName(),
-              snapPath.getBucketName(), fromSnapshot);
+          deleteSnapshot(fromSnapshot, snapPath);
         }
       }
+    }
+  }
+
+  private void deleteSnapshot(String snapshot, OFSPath snapPath) {
+    try {
+      objectStore.deleteSnapshot(snapPath.getVolumeName(),
+          snapPath.getBucketName(), snapshot);
+    } catch (IOException exception) {
+      LOG.warn("Failed to delete the temp snapshot with name {} in bucket"
+              + " {} and volume {} after snapDiff op.", snapshot,
+          snapPath.getBucketName(), snapPath.getVolumeName());
     }
   }
 

--- a/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicRootedOzoneClientAdapterImpl.java
+++ b/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicRootedOzoneClientAdapterImpl.java
@@ -1357,13 +1357,22 @@ public class BasicRootedOzoneClientAdapterImpl
     } finally {
       // delete the temp snapshot
       if (takeTemporaryToSnapshot) {
-        objectStore.deleteSnapshot(ofsPath.getVolumeName(),
-            ofsPath.getBucketName(), toSnapshot);
+        deleteSnapshot(toSnapshot, ofsPath);
       }
       if (takeTemporaryFromSnapshot) {
-        objectStore.deleteSnapshot(ofsPath.getVolumeName(),
-            ofsPath.getBucketName(), fromSnapshot);
+        deleteSnapshot(fromSnapshot, ofsPath);
       }
+    }
+  }
+
+  private void deleteSnapshot(String snapshot, OFSPath ofsPath) {
+    try {
+      objectStore.deleteSnapshot(ofsPath.getVolumeName(),
+          ofsPath.getBucketName(), snapshot);
+    } catch (IOException exception) {
+      LOG.warn("Failed to delete the temp snapshot with name {} in bucket"
+              + " {} and volume {} after snapDiff op.", snapshot,
+          ofsPath.getBucketName(), ofsPath.getVolumeName());
     }
   }
 

--- a/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicRootedOzoneClientAdapterImpl.java
+++ b/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicRootedOzoneClientAdapterImpl.java
@@ -1357,23 +1357,11 @@ public class BasicRootedOzoneClientAdapterImpl
     } finally {
       // delete the temp snapshot
       if (takeTemporaryToSnapshot) {
-        deleteSnapshot(toSnapshot, ofsPath);
+        OzoneClientUtils.deleteSnapshot(objectStore, toSnapshot, ofsPath);
       }
       if (takeTemporaryFromSnapshot) {
-        deleteSnapshot(fromSnapshot, ofsPath);
+        OzoneClientUtils.deleteSnapshot(objectStore, fromSnapshot, ofsPath);
       }
-    }
-  }
-
-  private void deleteSnapshot(String snapshot, OFSPath ofsPath) {
-    try {
-      objectStore.deleteSnapshot(ofsPath.getVolumeName(),
-          ofsPath.getBucketName(), snapshot);
-    } catch (IOException exception) {
-      LOG.warn("Failed to delete the temp snapshot with name {} in bucket"
-              + " {} and volume {} after snapDiff op. Exception : {}", snapshot,
-          ofsPath.getBucketName(), ofsPath.getVolumeName(),
-          exception.getMessage());
     }
   }
 

--- a/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicRootedOzoneClientAdapterImpl.java
+++ b/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicRootedOzoneClientAdapterImpl.java
@@ -1371,8 +1371,9 @@ public class BasicRootedOzoneClientAdapterImpl
           ofsPath.getBucketName(), snapshot);
     } catch (IOException exception) {
       LOG.warn("Failed to delete the temp snapshot with name {} in bucket"
-              + " {} and volume {} after snapDiff op.", snapshot,
-          ofsPath.getBucketName(), ofsPath.getVolumeName());
+              + " {} and volume {} after snapDiff op. Exception : {}", snapshot,
+          ofsPath.getBucketName(), ofsPath.getVolumeName(),
+          exception.getMessage());
     }
   }
 

--- a/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/OzoneClientUtils.java
+++ b/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/OzoneClientUtils.java
@@ -25,6 +25,7 @@ import org.apache.hadoop.hdds.conf.ConfigurationSource;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.fs.FileChecksum;
 import org.apache.hadoop.hdds.scm.OzoneClientConfig;
+import org.apache.hadoop.ozone.OFSPath;
 import org.apache.hadoop.ozone.client.checksum.BaseFileChecksumHelper;
 import org.apache.hadoop.ozone.client.ObjectStore;
 import org.apache.hadoop.ozone.client.OzoneBucket;
@@ -266,5 +267,18 @@ public final class OzoneClientUtils {
       limitVal = 2;
     }
     return limitVal;
+  }
+
+  public static void deleteSnapshot(ObjectStore objectStore,
+      String snapshot, OFSPath snapPath) {
+    try {
+      objectStore.deleteSnapshot(snapPath.getVolumeName(),
+          snapPath.getBucketName(), snapshot);
+    } catch (IOException exception) {
+      LOG.warn("Failed to delete the temp snapshot with name {} in bucket"
+              + " {} and volume {} after snapDiff op. Exception : {}", snapshot,
+          snapPath.getBucketName(), snapPath.getVolumeName(),
+          exception.getMessage());
+    }
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?
During snapshotDiff call, if toSnapshot or fromSnapshot is empty we take temporary snapshots to represent current state of Object store. These temp snapshots are later discarded after returning snapDiff. If there is a failure to delete these snapshots, they must be logged so that user can manually delete them later. Having a separate service to delete this doesn't make sense as failed deletes are not a common scenario.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-8483

