### PR TITLE
HDDS-7978. Using shell command name as root span name instead of main

### DIFF
--- a/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/cli/OzoneAdmin.java
+++ b/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/cli/OzoneAdmin.java
@@ -87,7 +87,8 @@ public class OzoneAdmin extends GenericCli {
   @Override
   public int execute(String[] argv) {
     TracingUtil.initTracing("shell", createOzoneConfiguration());
-    return TracingUtil.executeInNewSpan("main",
+    String spanName = "ozone admin " + String.join(" ", argv);
+    return TracingUtil.executeInNewSpan(spanName,
         () -> super.execute(argv));
   }
 }

--- a/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/OzoneFsShell.java
+++ b/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/OzoneFsShell.java
@@ -81,7 +81,8 @@ public class OzoneFsShell extends FsShell {
     TracingUtil.initTracing("FsShell", conf);
     conf.setQuietMode(false);
     shell.setConf(conf);
-    int res = TracingUtil.executeInNewSpan("main",
+    String spanName = "ozone fs " + String.join(" ", argv);
+    int res = TracingUtil.executeInNewSpan(spanName,
         () -> shell.execute(argv));
     System.exit(res);
   }

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/OzoneShell.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/OzoneShell.java
@@ -47,7 +47,8 @@ public class OzoneShell extends Shell {
   @Override
   public int execute(String[] argv) {
     TracingUtil.initTracing("shell", createOzoneConfiguration());
-    return TracingUtil.executeInNewSpan("main",
+    String spanName = "ozone sh " + String.join(" ", argv);
+    return TracingUtil.executeInNewSpan(spanName,
         () -> super.execute(argv));
   }
 

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/s3/S3Shell.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/s3/S3Shell.java
@@ -37,7 +37,8 @@ public class S3Shell extends Shell {
   @Override
   public int execute(String[] argv) {
     TracingUtil.initTracing("s3shell", createOzoneConfiguration());
-    return TracingUtil.executeInNewSpan("s3shell",
+    String spanName = "ozone s3 " + String.join(" ", argv);
+    return TracingUtil.executeInNewSpan(spanName,
         () -> super.execute(argv));
   }
 

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/tenant/TenantShell.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/tenant/TenantShell.java
@@ -38,7 +38,8 @@ public class TenantShell extends Shell {
   @Override
   public int execute(String[] argv) {
     TracingUtil.initTracing("tenant-shell", createOzoneConfiguration());
-    return TracingUtil.executeInNewSpan("tenant-shell",
+    String spanName = "ozone tenant " + String.join(" ", argv);
+    return TracingUtil.executeInNewSpan(spanName,
         () -> super.execute(argv));
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Using the entire shell command as root span instead of main

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-7978 

## How was this patch tested?

docker-compose env with jaegar tracing enabled.
<img width="495" alt="image" src="https://github.com/apache/ozone/assets/30603028/365bab19-29d4-4e5a-bc0c-4edf170f2d4a">
<img width="461" alt="image" src="https://github.com/apache/ozone/assets/30603028/e9d36694-b230-47eb-91ea-2bb44cffe5f6">
<img width="320" alt="image" src="https://github.com/apache/ozone/assets/30603028/cb709684-fa5f-4526-aaab-819530fee8fc">
<img width="476" alt="image" src="https://github.com/apache/ozone/assets/30603028/0b6b315c-d1e7-47b1-bf83-db0c7b73f9d7">

