### PR TITLE
HDDS-9380. Reduce the number of system calls when DN writes a key

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/impl/HddsDispatcher.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/impl/HddsDispatcher.java
@@ -78,6 +78,7 @@ import java.util.TreeMap;
 import static org.apache.hadoop.hdds.scm.protocolPB.ContainerCommandResponseBuilders.malformedRequest;
 import static org.apache.hadoop.hdds.scm.protocolPB.ContainerCommandResponseBuilders.unsupportedRequest;
 import static org.apache.hadoop.ozone.container.common.interfaces.Container.ScanResult;
+import static org.apache.hadoop.ozone.container.common.volume.VolumeUsage.PrecomputedVolumeSpace;
 
 /**
  * Ozone Container dispatcher takes a call from the netty server and routes it
@@ -580,10 +581,12 @@ public class HddsDispatcher implements ContainerDispatcher, Auditor {
         .orElse(Boolean.FALSE);
     if (isOpen) {
       HddsVolume volume = container.getContainerData().getVolume();
-      long volumeCapacity = volume.getCapacity();
+      PrecomputedVolumeSpace precomputedVolumeSpace =
+          volume.getPrecomputedVolumeSpace();
+      long volumeCapacity = precomputedVolumeSpace.getCapacity();
       long volumeFreeSpaceToSpare =
           VolumeUsage.getMinVolumeFreeSpace(conf, volumeCapacity);
-      long volumeFree = volume.getAvailable();
+      long volumeFree = volume.getAvailable(precomputedVolumeSpace);
       long volumeCommitted = volume.getCommittedBytes();
       long volumeAvailable = volumeFree - volumeCommitted;
       return (volumeAvailable <= volumeFreeSpaceToSpare);

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/volume/StorageVolume.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/volume/StorageVolume.java
@@ -50,6 +50,8 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Stream;
 
 import static org.apache.hadoop.ozone.container.common.HDDSVolumeLayoutVersion.getLatestVersion;
+import static org.apache.hadoop.ozone.container.common.volume.VolumeUsage.PrecomputedVolumeSpace;
+
 
 /**
  * StorageVolume represents a generic Volume in datanode, could be
@@ -452,6 +454,16 @@ public abstract class StorageVolume
   public long getAvailable() {
     return volumeInfo.map(VolumeInfo::getAvailable).orElse(0L);
 
+  }
+
+  public long getAvailable(PrecomputedVolumeSpace precomputedVolumeSpace) {
+    return volumeInfo.map(info -> info.getAvailable(precomputedVolumeSpace))
+        .orElse(0L);
+  }
+
+  public PrecomputedVolumeSpace getPrecomputedVolumeSpace() {
+    return volumeInfo.map(VolumeInfo::getPrecomputedVolumeSpace)
+        .orElse(new PrecomputedVolumeSpace(0L, 0L));
   }
 
   public long getUsedSpace() {

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/volume/VolumeInfo.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/volume/VolumeInfo.java
@@ -32,6 +32,7 @@ import com.google.common.annotations.VisibleForTesting;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import static org.apache.hadoop.ozone.container.common.volume.VolumeUsage.PrecomputedVolumeSpace;
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.HDDS_DATANODE_DIR_DU_RESERVED;
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.HDDS_DATANODE_DIR_DU_RESERVED_PERCENT;
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.HDDS_DATANODE_DIR_DU_RESERVED_PERCENT_DEFAULT;
@@ -237,6 +238,15 @@ public final class VolumeInfo {
   public long getAvailable() {
     long avail = getCapacity() - usage.getUsedSpace();
     return Math.max(Math.min(avail, usage.getAvailable()), 0);
+  }
+
+  public long getAvailable(PrecomputedVolumeSpace precomputedValues) {
+    long avail = precomputedValues.getCapacity() - usage.getUsedSpace();
+    return Math.max(Math.min(avail, usage.getAvailable(precomputedValues)), 0);
+  }
+
+  public PrecomputedVolumeSpace getPrecomputedVolumeSpace() {
+    return usage.getPrecomputedVolumeSpace();
   }
 
   public void incrementUsedSpace(long usedSpace) {

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/volume/VolumeUsage.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/volume/VolumeUsage.java
@@ -66,7 +66,7 @@ public class VolumeUsage implements SpaceUsageSource {
   }
 
   public long getAvailable(PrecomputedVolumeSpace precomputedVolumeSpace) {
-    long available = source.getAvailable();
+    long available = precomputedVolumeSpace.getAvailable();
     return available - getRemainingReserved(precomputedVolumeSpace);
   }
 
@@ -187,6 +187,7 @@ public class VolumeUsage implements SpaceUsageSource {
   }
 
   public PrecomputedVolumeSpace getPrecomputedVolumeSpace() {
-    return new PrecomputedVolumeSpace(getCapacity(), getAvailable());
+    return new PrecomputedVolumeSpace(source.getCapacity(),
+        source.getAvailable());
   }
 }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/volume/VolumeUsage.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/volume/VolumeUsage.java
@@ -65,6 +65,11 @@ public class VolumeUsage implements SpaceUsageSource {
     return source.getAvailable() - getRemainingReserved();
   }
 
+  public long getAvailable(PrecomputedVolumeSpace precomputedVolumeSpace) {
+    long available = source.getAvailable();
+    return available - getRemainingReserved(precomputedVolumeSpace);
+  }
+
   @Override
   public long getUsedSpace() {
     return source.getUsedSpace();
@@ -89,8 +94,19 @@ public class VolumeUsage implements SpaceUsageSource {
     return Math.max(totalUsed - source.getUsedSpace(), 0L);
   }
 
+  private long getOtherUsed(PrecomputedVolumeSpace precomputedVolumeSpace) {
+    long totalUsed = precomputedVolumeSpace.getCapacity() -
+        precomputedVolumeSpace.getAvailable();
+    return Math.max(totalUsed - source.getUsedSpace(), 0L);
+  }
+
   private long getRemainingReserved() {
     return Math.max(reservedInBytes - getOtherUsed(), 0L);
+  }
+
+  private long getRemainingReserved(
+      PrecomputedVolumeSpace precomputedVolumeSpace) {
+    return Math.max(reservedInBytes - getOtherUsed(precomputedVolumeSpace), 0L);
   }
 
   public synchronized void start() {
@@ -144,5 +160,33 @@ public class VolumeUsage implements SpaceUsageSource {
     return (long) conf.getStorageSize(HDDS_DATANODE_VOLUME_MIN_FREE_SPACE,
         HDDS_DATANODE_VOLUME_MIN_FREE_SPACE_DEFAULT, StorageUnit.BYTES);
 
+  }
+
+  /**
+   * Class representing precomputed space values of a volume.
+   * This class is intended to store precomputed values, such as capacity
+   * and available space of a volume, to avoid recalculating these
+   * values multiple times and to make method signatures simpler.
+   */
+  public static class PrecomputedVolumeSpace {
+    private final long capacity;
+    private final long available;
+
+    public PrecomputedVolumeSpace(long capacity, long available) {
+      this.capacity = capacity;
+      this.available = available;
+    }
+
+    public long getCapacity() {
+      return capacity;
+    }
+
+    public long getAvailable() {
+      return available;
+    }
+  }
+
+  public PrecomputedVolumeSpace getPrecomputedVolumeSpace() {
+    return new PrecomputedVolumeSpace(getCapacity(), getAvailable());
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?
Reduce the number of system calls when DN writes a key
To execute `HddsDispatcher.sendCloseContainerActionIfNeeded` once, need to call `getCapacity()` 3 times and `getAvailable()` 2 times.
The `getCapacity()` and `getAvailable()` are System call, we need reduce the System calls.
In this PR, reduces the number of `getCapacity()` and `getAvailable()` calls to once each.

![image](https://github.com/apache/ozone/assets/32928346/abad087d-3485-4664-b87d-4adea534b0f8)


After this PR
![image](https://github.com/apache/ozone/assets/32928346/232ec4d5-8a37-44c5-a858-b1ebd6f7210b)


## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-9380

## How was this patch tested?
Existing Test
