### PR TITLE
HDDS-9381. Remove `@Flaky` annotations from now-stable test cases.

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFileSystem.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFileSystem.java
@@ -61,7 +61,6 @@ import org.apache.hadoop.ozone.om.protocol.OzoneManagerProtocol;
 import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.ozone.test.GenericTestUtils;
 import org.apache.ozone.test.TestClock;
-import org.apache.ozone.test.tag.Flaky;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Assert;
@@ -1635,7 +1634,6 @@ public class TestOzoneFileSystem {
    * 2.Verify that the key gets deleted by the trash emptier.
    */
   @Test
-  @Flaky("HDDS-6645")
   public void testTrash() throws Exception {
     String testKeyName = "testKey2";
     Path path = new Path(OZONE_URI_DELIMITER, testKeyName);

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/TestMiniOzoneCluster.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/TestMiniOzoneCluster.java
@@ -34,7 +34,6 @@ import org.apache.hadoop.ozone.container.common.statemachine.DatanodeStateMachin
 import org.apache.hadoop.ozone.container.common.statemachine.EndpointStateMachine;
 import org.apache.hadoop.ozone.container.common.volume.StorageVolume;
 import org.apache.ozone.test.GenericTestUtils;
-import org.apache.ozone.test.tag.Flaky;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -81,7 +80,6 @@ public class TestMiniOzoneCluster {
   }
 
   @Test
-  @Flaky("HDDS-6112")
   public void testStartMultipleDatanodes() throws Exception {
     final int numberOfNodes = 3;
     cluster = MiniOzoneCluster.newBuilder(conf)
@@ -210,7 +208,6 @@ public class TestMiniOzoneCluster {
    * @throws Exception
    */
   @Test @Timeout(100)
-  @Flaky("HDDS-6111")
   public void testDNstartAfterSCM() throws Exception {
     // Start a cluster with 3 DN
     cluster = MiniOzoneCluster.newBuilder(conf)

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestBlockOutputStreamWithFailures.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestBlockOutputStreamWithFailures.java
@@ -48,7 +48,6 @@ import org.apache.hadoop.ozone.client.io.KeyOutputStream;
 import org.apache.hadoop.ozone.client.io.OzoneOutputStream;
 import org.apache.hadoop.ozone.container.ContainerTestHelper;
 import org.apache.hadoop.ozone.container.TestHelper;
-import org.apache.ozone.test.tag.Flaky;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_DEADNODE_INTERVAL;
@@ -66,7 +65,6 @@ import org.junit.jupiter.api.Timeout;
  * Tests failure detection and handling in BlockOutputStream Class.
  */
 @Timeout(300)
-@Flaky("HDDS-1967")
 public class TestBlockOutputStreamWithFailures {
 
   private MiniOzoneCluster cluster;

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestContainerStateMachineFailureOnRead.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestContainerStateMachineFailureOnRead.java
@@ -47,7 +47,6 @@ import org.apache.hadoop.ozone.client.io.OzoneOutputStream;
 import org.apache.hadoop.ozone.container.ozoneimpl.TestOzoneContainer;
 import org.apache.hadoop.ozone.om.helpers.OmKeyLocationInfo;
 import org.apache.ozone.test.GenericTestUtils;
-import org.apache.ozone.test.tag.Flaky;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_COMMAND_STATUS_REPORT_INTERVAL;
@@ -68,7 +67,6 @@ import org.junit.jupiter.api.Timeout;
 /**
  * Test to verify pipeline is closed on readStateMachine failure.
  */
-@Flaky("see HDDS-3294")
 public class TestContainerStateMachineFailureOnRead {
   private MiniOzoneCluster cluster;
   private ObjectStore objectStore;

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestFailureHandlingByClient.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestFailureHandlingByClient.java
@@ -67,7 +67,6 @@ import static org.apache.hadoop.fs.CommonConfigurationKeysPublic.NET_TOPOLOGY_NO
 import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationFactor.THREE;
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_STALENODE_INTERVAL;
 
-import org.apache.ozone.test.tag.Flaky;
 import org.junit.Assert;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
@@ -165,7 +164,6 @@ public class TestFailureHandlingByClient {
   }
 
   @Test
-  @Flaky("HDDS-7877")
   public void testBlockWritesWithDnFailures() throws Exception {
     startCluster();
     String keyName = UUID.randomUUID().toString();
@@ -355,7 +353,6 @@ public class TestFailureHandlingByClient {
 
 
   @Test
-  @Flaky("HDDS-7878")
   public void testContainerExclusionWithClosedContainerException()
       throws Exception {
     startCluster();
@@ -416,7 +413,6 @@ public class TestFailureHandlingByClient {
   }
 
   @Test
-  @Flaky("HDDS-3298")
   public void testDatanodeExclusionWithMajorityCommit() throws Exception {
     startCluster();
     String keyName = UUID.randomUUID().toString();

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/TestCloseContainerByPipeline.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/TestCloseContainerByPipeline.java
@@ -47,7 +47,6 @@ import org.apache.ozone.test.tag.Unhealthy;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.Assert;
 import org.junit.jupiter.api.BeforeAll;
-import org.apache.ozone.test.tag.Flaky;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
@@ -64,7 +63,6 @@ import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_DATANODE_PIPELINE_L
 /**
  * Test container closing.
  */
-@Flaky("HDDS-3263")
 public class TestCloseContainerByPipeline {
 
   private static MiniOzoneCluster cluster;

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/freon/TestRandomKeyGenerator.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/freon/TestRandomKeyGenerator.java
@@ -24,7 +24,6 @@ import org.apache.hadoop.hdds.conf.DatanodeRatisServerConfig;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.ratis.conf.RatisClientConfig;
 import org.apache.hadoop.ozone.MiniOzoneCluster;
-import org.apache.ozone.test.tag.Flaky;
 
 import org.junit.Assert;
 import org.junit.jupiter.api.AfterAll;
@@ -218,7 +217,6 @@ public class TestRandomKeyGenerator {
   }
 
   @Test
-  @Flaky("HDDS-5993")
   void cleanObjectsTest() {
     RandomKeyGenerator randomKeyGenerator =
         new RandomKeyGenerator(cluster.getConf());

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerHAMetadataOnly.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerHAMetadataOnly.java
@@ -40,7 +40,6 @@ import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.VolumeI
 import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.ozone.test.GenericTestUtils;
 import org.apache.log4j.Logger;
-import org.apache.ozone.test.tag.Flaky;
 import org.apache.ratis.protocol.ClientId;
 import org.apache.ratis.protocol.Message;
 import org.apache.ratis.protocol.RaftClientReply;
@@ -332,7 +331,6 @@ public class TestOzoneManagerHAMetadataOnly extends TestOzoneManagerHA {
   }
 
   @Test
-  @Flaky("HDDS-6644")
   public void testReadRequest() throws Exception {
     String volumeName = "volume" + RandomStringUtils.randomNumeric(5);
     ObjectStore objectStore = getObjectStore();
@@ -370,7 +368,6 @@ public class TestOzoneManagerHAMetadataOnly extends TestOzoneManagerHA {
   }
 
   @Test
-  @Flaky("HDDS-6642")
   public void testListVolumes() throws Exception {
     String userName = UserGroupInformation.getCurrentUser().getUserName();
     ObjectStore objectStore = getObjectStore();

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestRecursiveAclWithFSO.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestRecursiveAclWithFSO.java
@@ -35,7 +35,6 @@ import org.apache.hadoop.ozone.om.request.OMRequestTestUtils;
 import org.apache.hadoop.ozone.security.acl.OzoneObj;
 import org.apache.hadoop.ozone.security.acl.OzoneObjInfo;
 import org.apache.hadoop.security.UserGroupInformation;
-import org.apache.ozone.test.tag.Flaky;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -82,7 +81,6 @@ public class TestRecursiveAclWithFSO {
   }
 
   @Test
-  @Flaky("HDDS-8092")
   public void testKeyDeleteAndRenameWithoutPermission() throws Exception {
     /* r = READ, w = WRITE, c = CREATE, d = DELETE
        l = LIST, a = ALL, n = NONE, x = READ_ACL, y = WRITE_ACL */

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/scm/TestSCMContainerPlacementPolicyMetrics.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/scm/TestSCMContainerPlacementPolicyMetrics.java
@@ -42,7 +42,6 @@ import org.apache.hadoop.ozone.client.OzoneClientFactory;
 import org.apache.hadoop.ozone.client.OzoneVolume;
 import org.apache.hadoop.ozone.client.io.OzoneOutputStream;
 import org.apache.hadoop.ozone.om.OMConfigKeys;
-import org.apache.ozone.test.tag.Flaky;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.Assert;
 import org.junit.jupiter.api.BeforeEach;
@@ -68,7 +67,6 @@ import static org.apache.hadoop.test.MetricsAsserts.getMetrics;
 /**
  * Test cases to verify the metrics exposed by SCMPipelineManager.
  */
-@Flaky("HDDS-2961")
 public class TestSCMContainerPlacementPolicyMetrics {
 
   private MiniOzoneCluster cluster;


### PR DESCRIPTION
## What changes were proposed in this pull request?

Remove the `@Flaky` annotations from the test cases that have been successfully fixed and are no longer experiencing flakiness.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-9381
## How was this patch tested?
I ran the Test class 300 times for each test class and ensured that there were no intermittent failures.


Class Name | CI Runs
-- | -- 
TestSCMContainerPlacementPolicyMetrics HDDS-2961 | https://github.com/ArafatKhan2198/ozone/actions/runs/6398416895 https://github.com/ArafatKhan2198/ozone/actions/runs/6398418026 https://github.com/ArafatKhan2198/ozone/actions/runs/6398419702
TestOzoneManagerHAMetadataOnly HDDS-6644 |  https://github.com/ArafatKhan2198/ozone/actions/runs/6235727447 https://github.com/ArafatKhan2198/ozone/actions/runs/6235729232 
TestOzoneManagerHAMetadataOnly HDDS-6642 | https://github.com/ArafatKhan2198/ozone/actions/runs/6235727447 https://github.com/ArafatKhan2198/ozone/actions/runs/6235729232   
TestBlockOutputStreamWithFailures HDDS-1967 | https://github.com/ArafatKhan2198/ozone/actions/runs/6398347226 https://github.com/ArafatKhan2198/ozone/actions/runs/6398357035 https://github.com/ArafatKhan2198/ozone/actions/runs/6398360165
TestCloseContainerByPipeline HDDS-3263 | https://github.com/ArafatKhan2198/ozone/actions/runs/6377459304 https://github.com/ArafatKhan2198/ozone/actions/runs/6377460878 https://github.com/ArafatKhan2198/ozone/actions/runs/6377461812      
TestRandomKeyGenerator HDDS-5993 | https://github.com/ArafatKhan2198/ozone/actions/runs/6025312941 https://github.com/ArafatKhan2198/ozone/actions/runs/6028746303 https://github.com/ArafatKhan2198/ozone/actions/runs/6028751338 
TestRecursiveAclWithFSO HDDS-8092 | https://github.com/ArafatKhan2198/ozone/actions/runs/6402939616 https://github.com/ArafatKhan2198/ozone/actions/runs/6402940691 https://github.com/ArafatKhan2198/ozone/actions/runs/6402942430
TestOzoneFileSystem HDDS-6645 | https://github.com/ArafatKhan2198/ozone/actions/runs/6403238608 https://github.com/ArafatKhan2198/ozone/actions/runs/6403241618 https://github.com/ArafatKhan2198/ozone/actions/runs/6403245347
TestFailureHandlingByClient HDDS-7878, HDDS-7877, HDDS-3298 | https://github.com/ArafatKhan2198/ozone/actions/runs/6406992420 https://github.com/ArafatKhan2198/ozone/actions/runs/6406994448 https://github.com/ArafatKhan2198/ozone/actions/runs/6406995766 https://github.com/ArafatKhan2198/ozone/actions/runs/6398395587 https://github.com/ArafatKhan2198/ozone/actions/runs/6398397760 https://github.com/ArafatKhan2198/ozone/actions/runs/6398399722
TestMiniOzoneCluster HDDS-6112 | https://github.com/ArafatKhan2198/ozone/actions/runs/6415665976 https://github.com/ArafatKhan2198/ozone/actions/runs/6415667287 https://github.com/ArafatKhan2198/ozone/actions/runs/6415667828
TestContainerStateMachineFailureOnRead HDDS-3294 | https://github.com/ArafatKhan2198/ozone/actions/runs/6407771968 https://github.com/ArafatKhan2198/ozone/actions/runs/6407770619 https://github.com/ArafatKhan2198/ozone/actions/runs/6407768429