### PR TITLE
HDDS-9391. Change default bucket layout to FSO in standalone run using Intellij.

### DIFF
--- a/hadoop-ozone/dev-support/intellij/ozone-site.xml
+++ b/hadoop-ozone/dev-support/intellij/ozone-site.xml
@@ -17,7 +17,7 @@
 <configuration>
   <property>
     <name>ozone.default.bucket.layout</name>
-    <value>LEGACY</value>
+    <value>FILE_SYSTEM_OPTIMIZED</value>
   </property>
   <property>
     <name>hdds.profiler.endpoint.enabled</name>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Change default bucket layout to FILE_SYSTEM_OPTIMIZED for standalone run using Intellij.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-9391

## How was this patch tested?

Verified manually, Started ozone using Intellij and create volume/bucket.