### PR TITLE
HDDS-6154. Update NodeManagerInsight with the correct node metrics

### DIFF
--- a/hadoop-ozone/insight/src/main/java/org/apache/hadoop/ozone/insight/scm/NodeManagerInsight.java
+++ b/hadoop-ozone/insight/src/main/java/org/apache/hadoop/ozone/insight/scm/NodeManagerInsight.java
@@ -50,11 +50,39 @@ public class NodeManagerInsight extends BaseInsightPoint {
     MetricGroupDisplay nodes =
         new MetricGroupDisplay(Type.SCM, "Node counters");
 
-    nodes.addMetrics(
-        new MetricDisplay("Healthy Nodes", "scm_node_manager_healthy_nodes"));
-    nodes.addMetrics(
-        new MetricDisplay("Dead Nodes", "scm_node_manager_dead_nodes"));
-
+    nodes.addMetrics(new MetricDisplay("In-Service Healthy Nodes",
+        "scm_node_manager_in_service_healthy_nodes"));
+    nodes.addMetrics(new MetricDisplay("In-Service Dead Nodes",
+        "scm_node_manager_in_service_dead_nodes"));
+    nodes.addMetrics(new MetricDisplay("In-Service Stale Nodes",
+        "scm_node_manager_in_service_stale_nodes"));
+    nodes.addMetrics(new MetricDisplay("Decommissioning Healthy Nodes",
+        "scm_node_manager_decommissioning_healthy_nodes"));
+    nodes.addMetrics(new MetricDisplay("Decommissioning Dead Nodes",
+        "scm_node_manager_decommissioning_dead_nodes"));
+    nodes.addMetrics(new MetricDisplay("Decommissioning Stale Nodes",
+        "scm_node_manager_decommissioning_stale_nodes"));
+    nodes.addMetrics(new MetricDisplay("Decommissioned Healthy Nodes",
+        "scm_node_manager_decommissioned_healthy_nodes"));
+    nodes.addMetrics(new MetricDisplay("Decommissioned Dead Nodes",
+        "scm_node_manager_decommissioned_dead_nodes"));
+    nodes.addMetrics(new MetricDisplay("Decommissioned Stale Nodes",
+        "scm_node_manager_decommissioned_stale_nodes"));
+    nodes.addMetrics(new MetricDisplay("In-maintenance Healthy Nodes",
+        "scm_node_manager_in_maintenance_healthy_nodes"));
+    nodes.addMetrics(new MetricDisplay("In-maintenance Dead Nodes",
+        "scm_node_manager_in_maintenance_dead_nodes"));
+    nodes.addMetrics(new MetricDisplay("In-maintenance Stale Nodes",
+        "scm_node_manager_in_maintenance_stale_nodes"));
+    nodes.addMetrics(new MetricDisplay(
+        "Entering-maintenance Healthy Nodes",
+        "scm_node_manager_entering_maintenance_healthy_nodes"));
+    nodes.addMetrics(new MetricDisplay(
+        "Entering-maintenance Dead Nodes",
+        "scm_node_manager_entering_maintenance_dead_nodes"));
+    nodes.addMetrics(new MetricDisplay(
+        "Entering-maintenance Stale Nodes",
+        "scm_node_manager_entering_maintenance_dead_nodes"));
     display.add(nodes);
 
     MetricGroupDisplay hb =

--- a/hadoop-ozone/insight/src/main/java/org/apache/hadoop/ozone/insight/scm/NodeManagerInsight.java
+++ b/hadoop-ozone/insight/src/main/java/org/apache/hadoop/ozone/insight/scm/NodeManagerInsight.java
@@ -18,7 +18,6 @@
 package org.apache.hadoop.ozone.insight.scm;
 
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -28,6 +27,8 @@ import org.apache.hadoop.ozone.insight.Component.Type;
 import org.apache.hadoop.ozone.insight.LoggerSource;
 import org.apache.hadoop.ozone.insight.MetricDisplay;
 import org.apache.hadoop.ozone.insight.MetricGroupDisplay;
+import org.apache.hadoop.hdds.protocol.proto.HddsProtos.NodeOperationalState;
+import org.apache.hadoop.hdds.protocol.proto.HddsProtos.NodeState;
 
 /**
  * Insight definition to check node manager / node report events.
@@ -51,16 +52,12 @@ public class NodeManagerInsight extends BaseInsightPoint {
     MetricGroupDisplay nodes =
         new MetricGroupDisplay(Type.SCM, "Node counters");
 
-    String[] operationalState = {"in_service", "decommissioning",
-        "decommissioned", "entering_maintenance", "in_maintenance"};
-    String[] healthState = {"healthy", "stale", "dead"};
-
-    for(int i=0; i < operationalState.length; i++){
-      for(int j=0; j < healthState.length; j++){
+    for (NodeOperationalState opState : NodeOperationalState.values()) {
+      for (NodeState healthState : NodeState.values()) {
         String metricId = String.format("scm_node_manager_%s_%s_nodes",
-            operationalState[i], healthState[j]);
+            opState, healthState).toLowerCase();
         String metricDescription = String.format("%s %s Nodes",
-            operationalState[i], healthState[j]);
+            opState, healthState);
         nodes.addMetrics(new MetricDisplay(metricDescription, metricId));
       }
     }

--- a/hadoop-ozone/insight/src/main/java/org/apache/hadoop/ozone/insight/scm/NodeManagerInsight.java
+++ b/hadoop-ozone/insight/src/main/java/org/apache/hadoop/ozone/insight/scm/NodeManagerInsight.java
@@ -18,6 +18,7 @@
 package org.apache.hadoop.ozone.insight.scm;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -50,39 +51,19 @@ public class NodeManagerInsight extends BaseInsightPoint {
     MetricGroupDisplay nodes =
         new MetricGroupDisplay(Type.SCM, "Node counters");
 
-    nodes.addMetrics(new MetricDisplay("In-Service Healthy Nodes",
-        "scm_node_manager_in_service_healthy_nodes"));
-    nodes.addMetrics(new MetricDisplay("In-Service Dead Nodes",
-        "scm_node_manager_in_service_dead_nodes"));
-    nodes.addMetrics(new MetricDisplay("In-Service Stale Nodes",
-        "scm_node_manager_in_service_stale_nodes"));
-    nodes.addMetrics(new MetricDisplay("Decommissioning Healthy Nodes",
-        "scm_node_manager_decommissioning_healthy_nodes"));
-    nodes.addMetrics(new MetricDisplay("Decommissioning Dead Nodes",
-        "scm_node_manager_decommissioning_dead_nodes"));
-    nodes.addMetrics(new MetricDisplay("Decommissioning Stale Nodes",
-        "scm_node_manager_decommissioning_stale_nodes"));
-    nodes.addMetrics(new MetricDisplay("Decommissioned Healthy Nodes",
-        "scm_node_manager_decommissioned_healthy_nodes"));
-    nodes.addMetrics(new MetricDisplay("Decommissioned Dead Nodes",
-        "scm_node_manager_decommissioned_dead_nodes"));
-    nodes.addMetrics(new MetricDisplay("Decommissioned Stale Nodes",
-        "scm_node_manager_decommissioned_stale_nodes"));
-    nodes.addMetrics(new MetricDisplay("In-maintenance Healthy Nodes",
-        "scm_node_manager_in_maintenance_healthy_nodes"));
-    nodes.addMetrics(new MetricDisplay("In-maintenance Dead Nodes",
-        "scm_node_manager_in_maintenance_dead_nodes"));
-    nodes.addMetrics(new MetricDisplay("In-maintenance Stale Nodes",
-        "scm_node_manager_in_maintenance_stale_nodes"));
-    nodes.addMetrics(new MetricDisplay(
-        "Entering-maintenance Healthy Nodes",
-        "scm_node_manager_entering_maintenance_healthy_nodes"));
-    nodes.addMetrics(new MetricDisplay(
-        "Entering-maintenance Dead Nodes",
-        "scm_node_manager_entering_maintenance_dead_nodes"));
-    nodes.addMetrics(new MetricDisplay(
-        "Entering-maintenance Stale Nodes",
-        "scm_node_manager_entering_maintenance_dead_nodes"));
+    String[] operationalState = {"in_service", "decommissioning",
+        "decommissioned", "entering_maintenance", "in_maintenance"};
+    String[] healthState = {"healthy", "stale", "dead"};
+
+    for(int i=0; i < operationalState.length; i++){
+      for(int j=0; j < healthState.length; j++){
+        String metricId = String.format("scm_node_manager_%s_%s_nodes",
+            operationalState[i], healthState[j]);
+        String metricDescription = String.format("%s %s Nodes",
+            operationalState[i], healthState[j]);
+        nodes.addMetrics(new MetricDisplay(metricDescription, metricId));
+      }
+    }
     display.add(nodes);
 
     MetricGroupDisplay hb =


### PR DESCRIPTION
## What changes were proposed in this pull request?

Updating the NodeManagerInsight to reflect the correct node metrics

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-6154

## How was this patch tested?

Docker-compose environment with command ozone insight metrics scm.node-manager
`sh-4.2$ ozone insight metrics scm.node-manager
Metrics for `scm.node-manager` (SCM Datanode management related information.)

Node counters

  in_service healthy Nodes: 3
  in_service stale Nodes: 0
  in_service dead Nodes: 0
  decommissioning healthy Nodes: 0
  decommissioning stale Nodes: 0
  decommissioning dead Nodes: 0
  decommissioned healthy Nodes: 0
  decommissioned stale Nodes: 0
  decommissioned dead Nodes: 0
  entering_maintenance healthy Nodes: 0
  entering_maintenance stale Nodes: 0
  entering_maintenance dead Nodes: 0
  in_maintenance healthy Nodes: 0
  in_maintenance stale Nodes: 0
  in_maintenance dead Nodes: 0


HB processing stats

  HB processed: 26
  HB processing failed: 0`
