### PR TITLE
HDDS-9379. thread local client ID generator for omRequest

### DIFF
--- a/hadoop-hdds/common/pom.xml
+++ b/hadoop-hdds/common/pom.xml
@@ -234,6 +234,10 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
       <version>${io.grpc.version}</version>
       <scope>compile</scope>
     </dependency>
+    <dependency>
+      <groupId>com.fasterxml.uuid</groupId>
+      <artifactId>java-uuid-generator</artifactId>
+    </dependency>
   </dependencies>
 
   <build>

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/util/UUIDUtil.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/util/UUIDUtil.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.util;
+
+import com.fasterxml.uuid.Generators;
+
+import java.security.SecureRandom;
+import java.util.UUID;
+
+/**
+ * Helper methods to deal with random UUIDs.
+ */
+public final class UUIDUtil {
+
+  private UUIDUtil() {
+
+  }
+
+  private static final ThreadLocal<SecureRandom> GENERATOR =
+      ThreadLocal.withInitial(SecureRandom::new);
+
+  public static UUID randomUUID() {
+    return Generators.randomBasedGenerator(GENERATOR.get()).generate();
+  }
+
+}

--- a/hadoop-ozone/dist/src/main/license/bin/LICENSE.txt
+++ b/hadoop-ozone/dist/src/main/license/bin/LICENSE.txt
@@ -448,6 +448,7 @@ Apache License 2.0
    org.yaml:snakeyaml
    software.amazon.ion:ion-java
    org.awaitility:awaitility
+   com.fasterxml.uuid:java-uuid-generator
 
 MIT
 =====================

--- a/hadoop-ozone/dist/src/main/license/jar-report.txt
+++ b/hadoop-ozone/dist/src/main/license/jar-report.txt
@@ -272,3 +272,4 @@ share/ozone/lib/woodstox-core.jar
 share/ozone/lib/zookeeper.jar
 share/ozone/lib/zookeeper-jute.jar
 share/ozone/lib/zstd-jni.jar
+share/ozone/lib/java-uuid-generator.jar

--- a/hadoop-ozone/ozone-manager/pom.xml
+++ b/hadoop-ozone/ozone-manager/pom.xml
@@ -262,6 +262,10 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
       <groupId>org.mockito</groupId>
       <artifactId>mockito-junit-jupiter</artifactId>
     </dependency>
+    <dependency>
+      <groupId>com.fasterxml.uuid</groupId>
+      <artifactId>java-uuid-generator</artifactId>
+    </dependency>
   </dependencies>
   <build>
     <plugins>

--- a/hadoop-ozone/ozone-manager/pom.xml
+++ b/hadoop-ozone/ozone-manager/pom.xml
@@ -262,10 +262,6 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
       <groupId>org.mockito</groupId>
       <artifactId>mockito-junit-jupiter</artifactId>
     </dependency>
-    <dependency>
-      <groupId>com.fasterxml.uuid</groupId>
-      <artifactId>java-uuid-generator</artifactId>
-    </dependency>
   </dependencies>
   <build>
     <plugins>

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManagerServiceGrpc.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManagerServiceGrpc.java
@@ -17,26 +17,23 @@
  */
 package org.apache.hadoop.ozone.om;
 
-import com.fasterxml.uuid.Generators;
-import io.grpc.Status;
 import com.google.protobuf.RpcController;
+import io.grpc.Status;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.security.SecurityConfig;
 import org.apache.hadoop.ipc.RPC;
 import org.apache.hadoop.ipc.Server;
+import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMRequest;
+import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMResponse;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerServiceGrpc.OzoneManagerServiceImplBase;
 import org.apache.hadoop.ozone.protocolPB.OzoneManagerProtocolServerSideTranslatorPB;
-import org.apache.hadoop.ozone.protocol.proto
-    .OzoneManagerProtocolProtos.OMRequest;
-import org.apache.hadoop.ozone.protocol.proto
-    .OzoneManagerProtocolProtos.OMResponse;
 import org.apache.hadoop.ozone.security.OzoneDelegationTokenSecretManager;
+import org.apache.hadoop.util.UUIDUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
-import java.security.SecureRandom;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -101,21 +98,11 @@ public class OzoneManagerServiceGrpc extends OzoneManagerServiceImplBase {
   }
 
   private static byte[] getClientId() {
-    UUID uuid = UUIDs.randomUUID();
+    UUID uuid = UUIDUtil.randomUUID();
     ByteBuffer buf = ByteBuffer.wrap(new byte[16]);
     buf.putLong(uuid.getMostSignificantBits());
     buf.putLong(uuid.getLeastSignificantBits());
     return buf.array();
-  }
-
-  private static class UUIDs {
-    private static final ThreadLocal<SecureRandom> GENERATOR =
-        ThreadLocal.withInitial(SecureRandom::new);
-
-    public static UUID randomUUID() {
-      return Generators.randomBasedGenerator(GENERATOR.get()).generate();
-    }
-
   }
 
 }

--- a/pom.xml
+++ b/pom.xml
@@ -309,7 +309,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
     <jgrapht.version>1.0.1</jgrapht.version>
 
     <vault.driver.version>5.1.0</vault.driver.version>
-    <java.uuid.generator.version>3.1.4</java.uuid.generator.version>
+    <java.uuid.generator.version>4.3.0</java.uuid.generator.version>
     <native.lib.tmp.dir></native.lib.tmp.dir>
   </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -309,6 +309,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
     <jgrapht.version>1.0.1</jgrapht.version>
 
     <vault.driver.version>5.1.0</vault.driver.version>
+    <java.uuid.generator.version>3.1.4</java.uuid.generator.version>
     <native.lib.tmp.dir></native.lib.tmp.dir>
   </properties>
 
@@ -1576,6 +1577,11 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
         <artifactId>mockito-inline</artifactId>
         <version>${mockito2.version}</version>
         <scope>test</scope>
+      </dependency>
+      <dependency>
+        <groupId>com.fasterxml.uuid</groupId>
+        <artifactId>java-uuid-generator</artifactId>
+        <version>${java.uuid.generator.version}</version>
       </dependency>
     </dependencies>
   </dependencyManagement>


### PR DESCRIPTION
## What changes were proposed in this pull request?

The OM's org.apache.hadoop.ozone.om.OzoneManagerServiceGrpc#submitRequest method uses UUID.randomUUID() (through org.apache.hadoop.ipc.ClientId#getClientId) to set the clientId for an omRequest. The latter has a synchronized block inside that leads to high lock contention in case of a big amount of tiny files (1K) read requests (we were testing a read of 15mln 1KiB files from 3 clients in 50 threads, 150 threads in total). Hence, the clientId generator should be thread-local

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-9379

## How was this patch tested?

Manual test of reading of 15mln 1KiB files
