### PR TITLE
HDDS-9402. Increase timeout of unit check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -226,7 +226,7 @@ jobs:
       - build-info
       - basic
     runs-on: ubuntu-20.04
-    timeout-minutes: 90
+    timeout-minutes: 150
     if: needs.build-info.outputs.needs-unit-check == 'true'
     strategy:
       matrix:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,7 +73,7 @@ jobs:
     needs:
       - build-info
     runs-on: ubuntu-20.04
-    timeout-minutes: 45
+    timeout-minutes: 60
     if: needs.build-info.outputs.needs-build == 'true'
     strategy:
       matrix:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -172,7 +172,7 @@ jobs:
     needs:
       - build-info
     runs-on: ubuntu-20.04
-    timeout-minutes: 90
+    timeout-minutes: 30
     if: needs.build-info.outputs.needs-basic-check == 'true'
     strategy:
       matrix:


### PR DESCRIPTION
## What changes were proposed in this pull request?

_unit_ check runtime varies around 70-85 minutes, but occasionally times out after 90 minutes (e.g. [here](https://github.com/apache/ozone/actions/runs/6421657632/job/17436882342#step:5:3145)).  I think we should increase the timeout to avoid unnecessarily failed CI runs.  While we should strive to reduce test runtime, the set of tests is also incrementally growing.

Also:
 * _basic_ check timeout can be reduced after HDDS-6618 (long running parts were extracted to separate check)
 * increase timeout of _build_, which occasionally times out in forks due to cache miss

https://issues.apache.org/jira/browse/HDDS-9402

## How was this patch tested?

https://github.com/adoroszlai/hadoop-ozone/actions/runs/6429432639