### PR TITLE
HDDS-9412. NPE in TestOzoneManagerHAKeyDeletion#testKeyDeletion

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOmSnapshot.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOmSnapshot.java
@@ -162,7 +162,6 @@ public class TestOmSnapshot {
   private static boolean disableNativeDiff;
   private static ObjectStore store;
   private static OzoneManager ozoneManager;
-  private static RDBStore rdbStore;
   private static OzoneBucket ozoneBucket;
   private static final Duration POLL_INTERVAL_DURATION = Duration.ofMillis(500);
   private static final Duration POLL_MAX_DURATION = Duration.ofSeconds(10);
@@ -257,21 +256,26 @@ public class TestOmSnapshot {
     volumeName = ozoneBucket.getVolumeName();
     bucketName = ozoneBucket.getName();
     ozoneManager = cluster.getOzoneManager();
-    rdbStore = (RDBStore) ozoneManager.getMetadataManager().getStore();
 
     store = client.getObjectStore();
     writeClient = store.getClientProxy().getOzoneManagerClient();
 
-    KeyManagerImpl keyManager = (KeyManagerImpl) HddsWhiteboxTestUtils
-        .getInternalState(ozoneManager, "keyManager");
-    counter = new AtomicInteger(0);
-    // stop the deletion services so that keys can still be read
-    keyManager.stop();
+    stopKeyManager();
 //    preFinalizationChecks();
     finalizeOMUpgrade();
     counter = new AtomicInteger();
   }
 
+  private static void stopKeyManager() throws IOException {
+    KeyManagerImpl keyManager = (KeyManagerImpl) HddsWhiteboxTestUtils
+        .getInternalState(ozoneManager, "keyManager");
+    // stop the deletion services so that keys can still be read
+    keyManager.stop();
+  }
+
+  private static RDBStore getRdbStore() {
+    return (RDBStore) ozoneManager.getMetadataManager().getStore();
+  }
 
   private static void preFinalizationChecks() throws Exception {
     // None of the snapshot APIs is usable before the upgrade finalization step
@@ -1887,20 +1891,20 @@ public class TestOmSnapshot {
   private static List<LiveFileMetaData> getKeyTableSstFiles()
       throws IOException {
     if (!bucketLayout.isFileSystemOptimized()) {
-      return rdbStore.getDb().getSstFileList().stream().filter(
+      return getRdbStore().getDb().getSstFileList().stream().filter(
           x -> new String(x.columnFamilyName(), UTF_8).equals(
               OmMetadataManagerImpl.KEY_TABLE)).collect(Collectors.toList());
     }
-    return rdbStore.getDb().getSstFileList().stream().filter(
+    return getRdbStore().getDb().getSstFileList().stream().filter(
         x -> new String(x.columnFamilyName(), UTF_8).equals(
             OmMetadataManagerImpl.FILE_TABLE)).collect(Collectors.toList());
   }
 
   private static void flushKeyTable() throws IOException {
     if (!bucketLayout.isFileSystemOptimized()) {
-      rdbStore.getDb().flush(OmMetadataManagerImpl.KEY_TABLE);
+      getRdbStore().getDb().flush(OmMetadataManagerImpl.KEY_TABLE);
     } else {
-      rdbStore.getDb().flush(OmMetadataManagerImpl.FILE_TABLE);
+      getRdbStore().getDb().flush(OmMetadataManagerImpl.FILE_TABLE);
     }
   }
 
@@ -2008,6 +2012,7 @@ public class TestOmSnapshot {
     // Restart the OM and wait for sometime to make sure that previous snapDiff
     // job finishes.
     cluster.restartOzoneManager();
+    stopKeyManager();
     await().atMost(Duration.ofSeconds(120)).
         until(() -> cluster.getOzoneManager().isRunning());
 
@@ -2052,6 +2057,7 @@ public class TestOmSnapshot {
     // Restart the OM and no need to wait because snapDiff job finished before
     // the restart.
     cluster.restartOzoneManager();
+    stopKeyManager();
     await().atMost(Duration.ofSeconds(120)).
         until(() -> cluster.getOzoneManager().isRunning());
 
@@ -2099,8 +2105,7 @@ public class TestOmSnapshot {
   public void testCompactionDagDisableForSnapshotMetadata() throws Exception {
     String snapshotName = createSnapshot(volumeName, bucketName);
 
-    RDBStore activeDbStore =
-        (RDBStore) cluster.getOzoneManager().getMetadataManager().getStore();
+    RDBStore activeDbStore = getRdbStore();
     // RocksDBCheckpointDiffer should be not null for active DB store.
     assertNotNull(activeDbStore.getRocksDBCheckpointDiffer());
     assertEquals(2,  activeDbStore.getDbOptions().listeners().size());

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
@@ -1722,6 +1722,8 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
 
     instantiateServices(false);
 
+    metadataManager.start(configuration);
+    keyManager.start(configuration);
     startSecretManagerIfNecessary();
 
     // Set metrics and start metrics back ground thread


### PR DESCRIPTION
## What changes were proposed in this pull request?

HDDS-9232 added a new test case in `TestOzoneManagerHAKeyDeletion`, now the only other test case started failing.

```
org.apache.hadoop.ozone.om.TestOzoneManagerHAKeyDeletion.testKeyDeletion  Time elapsed: 5.575 s  <<< ERROR!
java.lang.NullPointerException
	at org.apache.hadoop.ozone.om.TestOzoneManagerHAKeyDeletion.lambda$testKeyDeletion$0(TestOzoneManagerHAKeyDeletion.java:84)
	at org.apache.ozone.test.GenericTestUtils.waitFor(GenericTestUtils.java:221)
	at org.apache.hadoop.ozone.om.TestOzoneManagerHAKeyDeletion.testKeyDeletion(TestOzoneManagerHAKeyDeletion.java:83)
```

The root cause is that `TestOzoneManagerHA` restarts OMs after each test, but `restart()` does not start `KeyManager`.  The latter creates `KeyDeletingService` only upon start.

Also fix `TestOmSnapshot`, which stops `KeyManager` after cluster startup.  Since it restarts OM in a few test cases, we need to stop `KeyManager` at those points.  This was not required previously due to the bug above.

https://issues.apache.org/jira/browse/HDDS-9412

## How was this patch tested?

Verified `TestOzoneManagerHAKeyDeletion` passes:

```
[INFO] Running org.apache.hadoop.ozone.om.TestOzoneManagerHAKeyDeletion
[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 48.612 s - in org.apache.hadoop.ozone.om.TestOzoneManagerHAKeyDeletion
[INFO] org.apache.hadoop.ozone.om.TestOzoneManagerHAKeyDeletion.testConf  Time elapsed: 3.352 s
[INFO] org.apache.hadoop.ozone.om.TestOzoneManagerHAKeyDeletion.testKeyDeletion  Time elapsed: 23.016 s
```

CI:
https://github.com/adoroszlai/hadoop-ozone/actions/runs/6442224627