### PR TITLE
HDDS-9356. Ozone debug chunkinfo shows incorrect block path for some nodes

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/storage/ContainerProtocolCalls.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/storage/ContainerProtocolCalls.java
@@ -724,4 +724,30 @@ public final class ContainerProtocolCalls  {
     }
     return datanodeToResponseMap;
   }
+
+  public static HashMap<DatanodeDetails, ReadContainerResponseProto>
+      readContainerFromAllNodes(XceiverClientSpi client, long containerID,
+      String encodedToken) throws IOException, InterruptedException {
+    String id = client.getPipeline().getFirstNode().getUuidString();
+    HashMap<DatanodeDetails, ReadContainerResponseProto> datanodeToResponseMap
+        = new HashMap<>();
+    ContainerCommandRequestProto.Builder request =
+        ContainerCommandRequestProto.newBuilder();
+    request.setCmdType(Type.ReadContainer);
+    request.setContainerID(containerID);
+    request.setReadContainer(ReadContainerRequestProto.getDefaultInstance());
+    request.setDatanodeUuid(id);
+    if (encodedToken != null) {
+      request.setEncodedToken(encodedToken);
+    }
+    Map<DatanodeDetails, ContainerCommandResponseProto> responses =
+        client.sendCommandOnAllNodes(request.build());
+    for (Map.Entry<DatanodeDetails, ContainerCommandResponseProto> entry :
+        responses.entrySet()) {
+      datanodeToResponseMap.put(entry.getKey(),
+          entry.getValue().getReadContainer());
+    }
+    return datanodeToResponseMap;
+  }
+
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

The block file path is incorrect for some nodes sometimes. All paths are the same (in the same data disks) in all the nodes, but in actuality, some of the nodes have the block path in different data disks. The problem is due to readContainer reading from the first node of the pipeline. If paths(storage dir) are different for different DN, then the tool needs to query every DN instead of just the first node similar to getBlockFromAllNodes.
So, we are querying every data node present in the pipeline to get the block information to display correct block paths.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-9356

## How was this patch tested?

Tested Manually.
