### PR TITLE
HDDS-9415. ozone-debug-lease-recovery.robot not part of acceptance tests

### DIFF
--- a/hadoop-ozone/dist/src/main/compose/ozone/test.sh
+++ b/hadoop-ozone/dist/src/main/compose/ozone/test.sh
@@ -48,6 +48,8 @@ execute_robot_test scm freon
 execute_robot_test scm cli
 execute_robot_test scm admincli
 
+execute_robot_test scm debug/ozone-debug-lease-recovery.robot
+
 execute_robot_test scm -v USERNAME:httpfs httpfs
 execute_debug_tests
 

--- a/hadoop-ozone/dist/src/main/compose/testlib.sh
+++ b/hadoop-ozone/dist/src/main/compose/testlib.sh
@@ -503,6 +503,8 @@ execute_debug_tests() {
   local datafile="$(jq -r '.KeyLocations[0][0].Locations.files[0]' ${chunkinfo})"
   docker exec "${container}" sed -i -e '1s/^/a/' "${datafile}"
 
+  execute_robot_test ${SCM} debug/ozone-debug-lease-recovery.robot
+
   execute_robot_test ${SCM} -v "PREFIX:${prefix}" -v "CORRUPT_DATANODE:${host}" debug/ozone-debug-corrupt-block.robot
 
   docker stop "${container}"

--- a/hadoop-ozone/dist/src/main/compose/testlib.sh
+++ b/hadoop-ozone/dist/src/main/compose/testlib.sh
@@ -503,8 +503,6 @@ execute_debug_tests() {
   local datafile="$(jq -r '.KeyLocations[0][0].Locations.files[0]' ${chunkinfo})"
   docker exec "${container}" sed -i -e '1s/^/a/' "${datafile}"
 
-  execute_robot_test ${SCM} debug/ozone-debug-lease-recovery.robot
-
   execute_robot_test ${SCM} -v "PREFIX:${prefix}" -v "CORRUPT_DATANODE:${host}" debug/ozone-debug-corrupt-block.robot
 
   docker stop "${container}"


### PR DESCRIPTION
## What changes were proposed in this pull request?

[HDDS-9255](https://issues.apache.org/jira/browse/HDDS-9255) introduced robot tests for lease Recovery, but the tests were never executed.
Aim is to add these tests in atleast one test suite.

## What is the link to the Apache JIRA
[HDDS-9415](https://issues.apache.org/jira/browse/HDDS-9415)

## How was this patch tested?
CI: 
Working in fork CI : https://github.com/LZD-PratyushBhatt/ozone/actions/runs/6452398832/job/17514936342?pr=7
