### PR TITLE
HDDS-9406. Do not run all checks for draft PR touching CI files

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -130,6 +130,7 @@ jobs:
     needs:
       - build-info
       - build
+      - basic
     runs-on: ubuntu-20.04
     timeout-minutes: 30
     if: needs.build-info.outputs.needs-compile == 'true'

--- a/dev-support/ci/selective_ci_checks.bats
+++ b/dev-support/ci/selective_ci_checks.bats
@@ -297,6 +297,19 @@ load bats-assert/load.bash
   assert_output -p needs-kubernetes-tests=true
 }
 
+@test "draft CI workflow change" {
+  export PR_DRAFT=true
+  run dev-support/ci/selective_ci_checks.sh 90fd5f2adc
+
+  assert_output -p 'basic-checks=[]'
+  assert_output -p needs-build=false
+  assert_output -p needs-compile=false
+  assert_output -p needs-compose-tests=false
+  assert_output -p needs-dependency-check=false
+  assert_output -p needs-integration-tests=false
+  assert_output -p needs-kubernetes-tests=false
+}
+
 @test "CI workflow change (ci.yaml)" {
   run dev-support/ci/selective_ci_checks.sh 90fd5f2adc
 

--- a/dev-support/ci/selective_ci_checks.sh
+++ b/dev-support/ci/selective_ci_checks.sh
@@ -588,8 +588,8 @@ fi
 
 
 get_changed_files
-run_all_tests_if_environment_files_changed
 check_if_tests_are_needed_at_all
+run_all_tests_if_environment_files_changed
 
 get_count_all_files
 get_count_compose_files


### PR DESCRIPTION
## What changes were proposed in this pull request?

Draft PRs usually skip most checks.  However, if CI code is changed, all checks are run.  This is unnecessary, because marking the PR ready for review will trigger a new run anyway.

Also minor addendum for HDDS-6618: wait for successful _basic_ check before starting _compile_ check (which tests compilation with Java 11 and 17).

https://issues.apache.org/jira/browse/HDDS-9406

## How was this patch tested?

Added bats test case.  Also tested by creating this PR as draft.

Draft CI:
https://github.com/apache/ozone/actions/runs/6453841050?pr=5406

Regular CI:
https://github.com/apache/ozone/actions/runs/6453854455?pr=5406