### PR TITLE
HDDS-9417. OM key delete use OzoneLockStrategy Acquisition Lock

### DIFF
--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyDeleteRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyDeleteRequest.java
@@ -57,7 +57,6 @@ import org.apache.hadoop.hdds.utils.db.cache.CacheKey;
 import org.apache.hadoop.hdds.utils.db.cache.CacheValue;
 
 import static org.apache.hadoop.ozone.om.exceptions.OMException.ResultCodes.KEY_NOT_FOUND;
-import static org.apache.hadoop.ozone.om.lock.OzoneManagerLock.Resource.BUCKET_LOCK;
 
 /**
  * Handles DeleteKey request.

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyDeleteRequestWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyDeleteRequestWithFSO.java
@@ -51,7 +51,6 @@ import java.util.Map;
 
 import static org.apache.hadoop.ozone.om.exceptions.OMException.ResultCodes.DIRECTORY_NOT_EMPTY;
 import static org.apache.hadoop.ozone.om.exceptions.OMException.ResultCodes.KEY_NOT_FOUND;
-import static org.apache.hadoop.ozone.om.lock.OzoneManagerLock.Resource.BUCKET_LOCK;
 
 /**
  * Handles DeleteKey request - prefix layout.

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMKeyRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMKeyRequest.java
@@ -38,6 +38,7 @@ import org.apache.hadoop.ozone.om.KeyManagerImpl;
 import org.apache.hadoop.ozone.om.helpers.OmBucketInfo;
 import org.apache.hadoop.ozone.om.helpers.BucketLayout;
 import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
+import org.apache.hadoop.ozone.om.lock.OzoneLockProvider;
 import org.apache.hadoop.ozone.om.ratis.utils.OzoneManagerDoubleBufferHelper;
 import org.apache.hadoop.ozone.om.request.OMClientRequest;
 import org.apache.hadoop.ozone.om.snapshot.ReferenceCounted;
@@ -76,6 +77,10 @@ import org.apache.hadoop.hdds.security.token.OzoneBlockTokenSecretManager;
 import org.apache.hadoop.util.Time;
 import org.slf4j.event.Level;
 
+import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_ENABLE_FILESYSTEM_PATHS;
+import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_ENABLE_FILESYSTEM_PATHS_DEFAULT;
+import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_KEY_PATH_LOCK_ENABLED;
+import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_KEY_PATH_LOCK_ENABLED_DEFAULT;
 import static org.apache.hadoop.ozone.om.request.OMRequestTestUtils.setupReplicationConfigValidation;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
@@ -233,6 +238,19 @@ public class TestOMKeyRequest {
     OmSnapshotManager omSnapshotManager = new OmSnapshotManager(ozoneManager);
     when(ozoneManager.getOmSnapshotManager())
         .thenReturn(omSnapshotManager);
+
+
+    final boolean keyPathLockEnabled =
+        ozoneConfiguration.getBoolean(OZONE_OM_ENABLE_FILESYSTEM_PATHS,
+            OZONE_OM_ENABLE_FILESYSTEM_PATHS_DEFAULT);
+    final boolean fileSystemPathsEnable =
+        ozoneConfiguration.getBoolean(OZONE_OM_KEY_PATH_LOCK_ENABLED,
+            OZONE_OM_KEY_PATH_LOCK_ENABLED_DEFAULT);
+
+    final OzoneLockProvider ozoneLockProvider =
+        new OzoneLockProvider(keyPathLockEnabled, fileSystemPathsEnable);
+    when(ozoneManager.getOzoneLockProvider())
+        .thenReturn(ozoneLockProvider);
 
     // Enable DEBUG level logging for relevant classes
     GenericTestUtils.setLogLevel(OMKeyRequest.LOG, Level.DEBUG);


### PR DESCRIPTION
## What changes were proposed in this pull request?

OM key delete use OzoneLockStrategy Acquisition Lock

The current use is to write locks to the bucket, this pr uses OzoneLockStrategy to use different locking strategies depending on the BucketLayout.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-9417

## How was this patch tested?

Add support for OzoneLockStrategy in TestOMKeyRequest and test it with TestOMKeyDeleteRequest 
