### PR TITLE
HDDS-9377. MutableStat.add in a seperate executor service

### DIFF
--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/XceiverClientMetrics.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/XceiverClientMetrics.java
@@ -96,8 +96,8 @@ public class XceiverClientMetrics {
 
   public void addContainerOpsLatency(ContainerProtos.Type type,
       long latencyMillis) {
-    MetricUtil.executeMetricsUpdateAction(() ->
-            containerOpsLatency[type.ordinal()].add(latencyMillis));
+    MetricUtil.executeStatAddAction(containerOpsLatency[type.ordinal()]::add,
+        latencyMillis);
   }
 
   public long getPendingContainerOpCountMetrics(ContainerProtos.Type type) {

--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/XceiverClientMetrics.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/XceiverClientMetrics.java
@@ -27,6 +27,7 @@ import org.apache.hadoop.metrics2.lib.DefaultMetricsSystem;
 import org.apache.hadoop.metrics2.lib.MetricsRegistry;
 import org.apache.hadoop.metrics2.lib.MutableCounterLong;
 import org.apache.hadoop.metrics2.lib.MutableRate;
+import org.apache.hadoop.util.MetricUtil;
 
 /**
  * The client metrics for the Storage Container protocol.
@@ -95,7 +96,8 @@ public class XceiverClientMetrics {
 
   public void addContainerOpsLatency(ContainerProtos.Type type,
       long latencyMillis) {
-    containerOpsLatency[type.ordinal()].add(latencyMillis);
+    MetricUtil.executeMetricsUpdateAction(() ->
+            containerOpsLatency[type.ordinal()].add(latencyMillis));
   }
 
   public long getPendingContainerOpCountMetrics(ContainerProtos.Type type) {

--- a/hadoop-hdds/common/dev-support/findbugsExcludeFile.xml
+++ b/hadoop-hdds/common/dev-support/findbugsExcludeFile.xml
@@ -31,9 +31,6 @@
     <Method name="update" />
     <Bug pattern="SF_SWITCH_FALLTHROUGH,SF_SWITCH_NO_DEFAULT" />
   </Match>
-  <Match>
-    <Class name="org.apache.hadoop.hdds.utils.db.CodecBuffer"></Class>
-  </Match>
 
   <!-- Test -->
   <Match>

--- a/hadoop-hdds/common/dev-support/findbugsExcludeFile.xml
+++ b/hadoop-hdds/common/dev-support/findbugsExcludeFile.xml
@@ -31,6 +31,9 @@
     <Method name="update" />
     <Bug pattern="SF_SWITCH_FALLTHROUGH,SF_SWITCH_NO_DEFAULT" />
   </Match>
+  <Match>
+    <Class name="org.apache.hadoop.hdds.utils.db.CodecBuffer"></Class>
+  </Match>
 
   <!-- Test -->
   <Match>

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/grpc/metrics/GrpcMetrics.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/grpc/metrics/GrpcMetrics.java
@@ -33,6 +33,7 @@ import org.apache.hadoop.metrics2.lib.DefaultMetricsSystem;
 import org.apache.hadoop.metrics2.lib.MutableRate;
 import org.apache.hadoop.ozone.OzoneConfigKeys;
 import org.apache.hadoop.ozone.OzoneConsts;
+import org.apache.hadoop.util.MetricUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -155,25 +156,29 @@ public class GrpcMetrics implements MetricsSource {
   }
 
   public void addGrpcQueueTime(int queueTime) {
-    grpcQueueTime.add(queueTime);
-    if (grpcQuantileEnable) {
-      for (MutableQuantiles q : grpcQueueTimeMillisQuantiles) {
-        if (q != null) {
-          q.add(queueTime);
+    MetricUtil.executeMetricsUpdateAction(() -> {
+      grpcQueueTime.add(queueTime);
+      if (grpcQuantileEnable) {
+        for (MutableQuantiles q : grpcQueueTimeMillisQuantiles) {
+          if (q != null) {
+            q.add(queueTime);
+          }
         }
       }
-    }
+    });
   }
 
   public void addGrpcProcessingTime(int processingTime) {
-    grpcProcessingTime.add(processingTime);
-    if (grpcQuantileEnable) {
-      for (MutableQuantiles q : grpcProcessingTimeMillisQuantiles) {
-        if (q != null) {
-          q.add(processingTime);
+    MetricUtil.executeMetricsUpdateAction(() -> {
+      grpcProcessingTime.add(processingTime);
+      if (grpcQuantileEnable) {
+        for (MutableQuantiles q : grpcProcessingTimeMillisQuantiles) {
+          if (q != null) {
+            q.add(processingTime);
+          }
         }
       }
-    }
+    });
   }
 
   public void inrcNumOpenClientConnections() {

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/grpc/metrics/GrpcMetrics.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/grpc/metrics/GrpcMetrics.java
@@ -156,29 +156,25 @@ public class GrpcMetrics implements MetricsSource {
   }
 
   public void addGrpcQueueTime(int queueTime) {
-    MetricUtil.executeMetricsUpdateAction(() -> {
-      grpcQueueTime.add(queueTime);
-      if (grpcQuantileEnable) {
-        for (MutableQuantiles q : grpcQueueTimeMillisQuantiles) {
-          if (q != null) {
-            q.add(queueTime);
-          }
+    MetricUtil.executeStatAddAction(grpcQueueTime::add, queueTime);
+    if (grpcQuantileEnable) {
+      for (MutableQuantiles q : grpcQueueTimeMillisQuantiles) {
+        if (q != null) {
+          MetricUtil.executeStatAddAction(q::add, queueTime);
         }
       }
-    });
+    }
   }
 
   public void addGrpcProcessingTime(int processingTime) {
-    MetricUtil.executeMetricsUpdateAction(() -> {
-      grpcProcessingTime.add(processingTime);
-      if (grpcQuantileEnable) {
-        for (MutableQuantiles q : grpcProcessingTimeMillisQuantiles) {
-          if (q != null) {
-            q.add(processingTime);
-          }
+    MetricUtil.executeStatAddAction(grpcProcessingTime::add, processingTime);
+    if (grpcQuantileEnable) {
+      for (MutableQuantiles q : grpcProcessingTimeMillisQuantiles) {
+        if (q != null) {
+          MetricUtil.executeStatAddAction(q::add, processingTime);
         }
       }
-    });
+    }
   }
 
   public void inrcNumOpenClientConnections() {

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/util/MetricUtil.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/util/MetricUtil.java
@@ -17,6 +17,7 @@
  */
 package org.apache.hadoop.util;
 
+import com.google.common.annotations.VisibleForTesting;
 import org.apache.hadoop.metrics2.lib.MutableRate;
 import org.apache.hadoop.thirdparty.com.google.common.util.concurrent.ThreadFactoryBuilder;
 import org.apache.ratis.util.function.CheckedRunnable;
@@ -82,6 +83,14 @@ public final class MetricUtil {
   public static void executeStatAddAction(Consumer<Long> metric,
                                           long statValue) {
     EXECUTOR.submit(() -> metric.accept(statValue));
+  }
+
+  @VisibleForTesting
+  public static void awaitExecutionOfStatsUpdateMethods()
+      throws InterruptedException {
+    while (((ThreadPoolExecutor)EXECUTOR).getActiveCount() > 0) {
+      Thread.sleep(500);
+    }
   }
 
 }

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/util/MetricUtil.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/util/MetricUtil.java
@@ -17,8 +17,8 @@
  */
 package org.apache.hadoop.util;
 
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import org.apache.hadoop.metrics2.lib.MutableRate;
-import org.apache.hadoop.thirdparty.com.google.common.util.concurrent.ThreadFactoryBuilder;
 import org.apache.ratis.util.function.CheckedRunnable;
 import org.apache.ratis.util.function.CheckedSupplier;
 

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/util/MetricUtil.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/util/MetricUtil.java
@@ -17,7 +17,6 @@
  */
 package org.apache.hadoop.util;
 
-import com.google.common.annotations.VisibleForTesting;
 import org.apache.hadoop.metrics2.lib.MutableRate;
 import org.apache.hadoop.thirdparty.com.google.common.util.concurrent.ThreadFactoryBuilder;
 import org.apache.ratis.util.function.CheckedRunnable;
@@ -83,14 +82,6 @@ public final class MetricUtil {
   public static void executeStatAddAction(Consumer<Long> metric,
                                           long statValue) {
     EXECUTOR.submit(() -> metric.accept(statValue));
-  }
-
-  @VisibleForTesting
-  public static void awaitExecutionOfStatsUpdateMethods()
-      throws InterruptedException {
-    while (((ThreadPoolExecutor)EXECUTOR).getActiveCount() > 0) {
-      Thread.sleep(500);
-    }
   }
 
 }

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/util/MetricUtil.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/util/MetricUtil.java
@@ -36,7 +36,7 @@ public final class MetricUtil {
 
   private static final ExecutorService EXECUTOR =
       new ThreadPoolExecutor(1, 10, 100, TimeUnit.MILLISECONDS,
-          new LinkedBlockingQueue<>(),
+          new LinkedBlockingQueue<>(500_000),
           new ThreadFactoryBuilder()
               .setDaemon(true)
               .setNameFormat("metric-mutable-rate-handler-%d")

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/helpers/ContainerMetrics.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/helpers/ContainerMetrics.java
@@ -30,6 +30,7 @@ import org.apache.hadoop.metrics2.lib.MetricsRegistry;
 import org.apache.hadoop.metrics2.lib.MutableCounterLong;
 import org.apache.hadoop.metrics2.lib.MutableQuantiles;
 import org.apache.hadoop.metrics2.lib.MutableRate;
+import org.apache.hadoop.util.MetricUtil;
 
 /**
  *
@@ -116,10 +117,12 @@ public class ContainerMetrics {
 
   public void incContainerOpsLatencies(ContainerProtos.Type type,
                                        long latencyMillis) {
-    opsLatency[type.ordinal()].add(latencyMillis);
-    for (MutableQuantiles q: opsLatQuantiles[type.ordinal()]) {
-      q.add(latencyMillis);
-    }
+    MetricUtil.executeMetricsUpdateAction(() -> {
+      opsLatency[type.ordinal()].add(latencyMillis);
+      for (MutableQuantiles q: opsLatQuantiles[type.ordinal()]) {
+        q.add(latencyMillis);
+      }
+    });
   }
 
   public void incContainerBytesStats(ContainerProtos.Type type, long bytes) {

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/helpers/ContainerMetrics.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/helpers/ContainerMetrics.java
@@ -117,12 +117,11 @@ public class ContainerMetrics {
 
   public void incContainerOpsLatencies(ContainerProtos.Type type,
                                        long latencyMillis) {
-    MetricUtil.executeMetricsUpdateAction(() -> {
-      opsLatency[type.ordinal()].add(latencyMillis);
-      for (MutableQuantiles q: opsLatQuantiles[type.ordinal()]) {
-        q.add(latencyMillis);
-      }
-    });
+    MetricUtil.executeStatAddAction(opsLatency[type.ordinal()]::add,
+        latencyMillis);
+    for (MutableQuantiles q: opsLatQuantiles[type.ordinal()]) {
+      MetricUtil.executeStatAddAction(q::add, latencyMillis);
+    }
   }
 
   public void incContainerBytesStats(ContainerProtos.Type type, long bytes) {

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/transport/server/ratis/CSMMetrics.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/transport/server/ratis/CSMMetrics.java
@@ -27,6 +27,7 @@ import org.apache.hadoop.metrics2.lib.DefaultMetricsSystem;
 import org.apache.hadoop.metrics2.lib.MutableCounterLong;
 import org.apache.hadoop.metrics2.lib.MutableRate;
 import org.apache.hadoop.metrics2.lib.MetricsRegistry;
+import org.apache.hadoop.util.MetricUtil;
 import org.apache.ratis.protocol.RaftGroupId;
 
 /**
@@ -198,8 +199,10 @@ public class CSMMetrics {
 
   public void incPipelineLatencyMs(ContainerProtos.Type type,
       long latencyMillis) {
-    opsLatencyMs[type.ordinal()].add(latencyMillis);
-    transactionLatencyMs.add(latencyMillis);
+    MetricUtil.executeMetricsUpdateAction(() -> {
+      opsLatencyMs[type.ordinal()].add(latencyMillis);
+      transactionLatencyMs.add(latencyMillis);
+    });
   }
 
   public void incNumStartTransactionVerifyFailures() {
@@ -211,11 +214,13 @@ public class CSMMetrics {
   }
 
   public void recordApplyTransactionCompletionNs(long latencyNanos) {
-    applyTransactionNs.add(latencyNanos);
+    MetricUtil.executeMetricsUpdateAction(() ->
+            applyTransactionNs.add(latencyNanos));
   }
 
   public void recordWriteStateMachineCompletionNs(long latencyNanos) {
-    writeStateMachineDataNs.add(latencyNanos);
+    MetricUtil.executeMetricsUpdateAction(() ->
+            writeStateMachineDataNs.add(latencyNanos));
   }
 
   public void incNumDataCacheMiss() {

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/transport/server/ratis/CSMMetrics.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/transport/server/ratis/CSMMetrics.java
@@ -199,10 +199,9 @@ public class CSMMetrics {
 
   public void incPipelineLatencyMs(ContainerProtos.Type type,
       long latencyMillis) {
-    MetricUtil.executeMetricsUpdateAction(() -> {
-      opsLatencyMs[type.ordinal()].add(latencyMillis);
-      transactionLatencyMs.add(latencyMillis);
-    });
+    MetricUtil.executeStatAddAction(opsLatencyMs[type.ordinal()]::add,
+        latencyMillis);
+    MetricUtil.executeStatAddAction(transactionLatencyMs::add, latencyMillis);
   }
 
   public void incNumStartTransactionVerifyFailures() {
@@ -214,13 +213,11 @@ public class CSMMetrics {
   }
 
   public void recordApplyTransactionCompletionNs(long latencyNanos) {
-    MetricUtil.executeMetricsUpdateAction(() ->
-            applyTransactionNs.add(latencyNanos));
+    MetricUtil.executeStatAddAction(applyTransactionNs::add, latencyNanos);
   }
 
   public void recordWriteStateMachineCompletionNs(long latencyNanos) {
-    MetricUtil.executeMetricsUpdateAction(() ->
-            writeStateMachineDataNs.add(latencyNanos));
+    MetricUtil.executeStatAddAction(writeStateMachineDataNs::add, latencyNanos);
   }
 
   public void incNumDataCacheMiss() {

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/utils/ContainerCacheMetrics.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/utils/ContainerCacheMetrics.java
@@ -22,6 +22,7 @@ import org.apache.hadoop.metrics2.annotation.Metric;
 import org.apache.hadoop.metrics2.lib.DefaultMetricsSystem;
 import org.apache.hadoop.metrics2.lib.MutableCounterLong;
 import org.apache.hadoop.metrics2.lib.MutableRate;
+import org.apache.hadoop.util.MetricUtil;
 
 /**
  * Metrics for the usage of ContainerDB.
@@ -85,11 +86,11 @@ public final class ContainerCacheMetrics {
   }
 
   public void incDbCloseLatency(long millis) {
-    dbCloseLatency.add(millis);
+    MetricUtil.executeMetricsUpdateAction(() -> dbCloseLatency.add(millis));
   }
 
   public void incDbOpenLatency(long millis) {
-    dbOpenLatency.add(millis);
+    MetricUtil.executeMetricsUpdateAction(() -> dbOpenLatency.add(millis));
   }
 
   public long getNumDbGetOps() {

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/utils/ContainerCacheMetrics.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/utils/ContainerCacheMetrics.java
@@ -86,11 +86,11 @@ public final class ContainerCacheMetrics {
   }
 
   public void incDbCloseLatency(long millis) {
-    MetricUtil.executeMetricsUpdateAction(() -> dbCloseLatency.add(millis));
+    MetricUtil.executeStatAddAction(dbCloseLatency::add, millis);
   }
 
   public void incDbOpenLatency(long millis) {
-    MetricUtil.executeMetricsUpdateAction(() -> dbOpenLatency.add(millis));
+    MetricUtil.executeStatAddAction(dbOpenLatency::add, millis);
   }
 
   public long getNumDbGetOps() {

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/ozoneimpl/ContainerDataScannerMetrics.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/ozoneimpl/ContainerDataScannerMetrics.java
@@ -51,7 +51,7 @@ public final class ContainerDataScannerMetrics
   }
 
   public void incNumBytesScanned(long bytes) {
-    MetricUtil.executeMetricsUpdateAction(() -> numBytesScanned.add(bytes));
+    MetricUtil.executeStatAddAction(numBytesScanned::add, bytes);
   }
 
   private ContainerDataScannerMetrics(String name, MetricsSystem ms) {

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/ozoneimpl/ContainerDataScannerMetrics.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/ozoneimpl/ContainerDataScannerMetrics.java
@@ -23,6 +23,7 @@ import org.apache.hadoop.metrics2.annotation.Metric;
 import org.apache.hadoop.metrics2.annotation.Metrics;
 import org.apache.hadoop.metrics2.lib.DefaultMetricsSystem;
 import org.apache.hadoop.metrics2.lib.MutableRate;
+import org.apache.hadoop.util.MetricUtil;
 
 import java.util.concurrent.ThreadLocalRandom;
 
@@ -50,7 +51,7 @@ public final class ContainerDataScannerMetrics
   }
 
   public void incNumBytesScanned(long bytes) {
-    numBytesScanned.add(bytes);
+    MetricUtil.executeMetricsUpdateAction(() -> numBytesScanned.add(bytes));
   }
 
   private ContainerDataScannerMetrics(String name, MetricsSystem ms) {

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/server/events/EventWatcherMetrics.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/server/events/EventWatcherMetrics.java
@@ -22,6 +22,7 @@ import org.apache.hadoop.metrics2.lib.MutableCounterLong;
 import org.apache.hadoop.metrics2.lib.MutableRate;
 
 import com.google.common.annotations.VisibleForTesting;
+import org.apache.hadoop.util.MetricUtil;
 
 /**
  * Metrics for any event watcher.
@@ -53,7 +54,7 @@ public class EventWatcherMetrics {
   }
 
   public void updateFinishingTime(long duration) {
-    completionTime.add(duration);
+    MetricUtil.executeMetricsUpdateAction(() -> completionTime.add(duration));
   }
 
   @VisibleForTesting

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/server/events/EventWatcherMetrics.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/server/events/EventWatcherMetrics.java
@@ -54,7 +54,7 @@ public class EventWatcherMetrics {
   }
 
   public void updateFinishingTime(long duration) {
-    MetricUtil.executeMetricsUpdateAction(() -> completionTime.add(duration));
+    MetricUtil.executeStatAddAction(completionTime::add, duration);
   }
 
   @VisibleForTesting

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ReplicationManagerMetrics.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ReplicationManagerMetrics.java
@@ -39,6 +39,7 @@ import java.util.Map;
 
 import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.LifeCycleState;
 import org.apache.hadoop.hdds.scm.container.ReplicationManagerReport.HealthState;
+import org.apache.hadoop.util.MetricUtil;
 
 /**
  * Class contains metrics related to ReplicationManager.
@@ -359,11 +360,12 @@ public final class ReplicationManagerMetrics implements MetricsSource {
   }
 
   public void addReplicationTime(long millis) {
-    this.replicationTime.add(millis);
+    MetricUtil.executeMetricsUpdateAction(() ->
+            this.replicationTime.add(millis));
   }
 
   public void addDeletionTime(long millis) {
-    this.deletionTime.add(millis);
+    MetricUtil.executeMetricsUpdateAction(() -> this.deletionTime.add(millis));
   }
 
   public void incrInflightSkipped(InflightType type) {

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ReplicationManagerMetrics.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ReplicationManagerMetrics.java
@@ -360,12 +360,11 @@ public final class ReplicationManagerMetrics implements MetricsSource {
   }
 
   public void addReplicationTime(long millis) {
-    MetricUtil.executeMetricsUpdateAction(() ->
-            this.replicationTime.add(millis));
+    MetricUtil.executeStatAddAction(this.replicationTime::add, millis);
   }
 
   public void addDeletionTime(long millis) {
-    MetricUtil.executeMetricsUpdateAction(() -> this.deletionTime.add(millis));
+    MetricUtil.executeStatAddAction(this.deletionTime::add, millis);
   }
 
   public void incrInflightSkipped(InflightType type) {

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/StorageContainerManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/StorageContainerManager.java
@@ -1721,7 +1721,6 @@ public final class StorageContainerManager extends ServiceRuntimeInfoImpl
         LOG.error("Closing certificate client failed", ioe);
       }
     }
-
     try {
       LOG.info("Stopping SCM MetadataStore.");
       scmMetadataStore.stop();

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/lock/OMLockMetrics.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/lock/OMLockMetrics.java
@@ -85,8 +85,8 @@ public final class OMLockMetrics implements MetricsSource {
    * @param readLockWaitingTimeMs read lock waiting time (ms)
    */
   public void setReadLockWaitingTimeMsStat(long readLockWaitingTimeMs) {
-    MetricUtil.executeMetricsUpdateAction(() ->
-            this.readLockWaitingTimeMsStat.add(readLockWaitingTimeMs));
+    MetricUtil.executeStatAddAction(this.readLockWaitingTimeMsStat::add,
+        readLockWaitingTimeMs);
   }
 
   /**
@@ -95,8 +95,8 @@ public final class OMLockMetrics implements MetricsSource {
    * @param readLockHeldTimeMs read lock held time (ms)
    */
   public void setReadLockHeldTimeMsStat(long readLockHeldTimeMs) {
-    MetricUtil.executeMetricsUpdateAction(() ->
-            this.readLockHeldTimeMsStat.add(readLockHeldTimeMs));
+    MetricUtil.executeStatAddAction(this.readLockHeldTimeMsStat::add,
+        readLockHeldTimeMs);
   }
 
   /**
@@ -105,8 +105,8 @@ public final class OMLockMetrics implements MetricsSource {
    * @param writeLockWaitingTimeMs write lock waiting time (ms)
    */
   public void setWriteLockWaitingTimeMsStat(long writeLockWaitingTimeMs) {
-    MetricUtil.executeMetricsUpdateAction(() ->
-            this.writeLockWaitingTimeMsStat.add(writeLockWaitingTimeMs));
+    MetricUtil.executeStatAddAction(this.writeLockWaitingTimeMsStat::add,
+        writeLockWaitingTimeMs);
   }
 
   /**
@@ -115,8 +115,8 @@ public final class OMLockMetrics implements MetricsSource {
    * @param writeLockHeldTimeMs write lock held time (ms)
    */
   public void setWriteLockHeldTimeMsStat(long writeLockHeldTimeMs) {
-    MetricUtil.executeMetricsUpdateAction(() ->
-            this.writeLockHeldTimeMsStat.add(writeLockHeldTimeMs));
+    MetricUtil.executeStatAddAction(this.writeLockHeldTimeMsStat::add,
+        writeLockHeldTimeMs);
   }
 
   /**

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/lock/OMLockMetrics.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/lock/OMLockMetrics.java
@@ -27,6 +27,7 @@ import org.apache.hadoop.metrics2.lib.DefaultMetricsSystem;
 import org.apache.hadoop.metrics2.lib.MetricsRegistry;
 import org.apache.hadoop.metrics2.lib.MutableStat;
 import org.apache.hadoop.ozone.OzoneConsts;
+import org.apache.hadoop.util.MetricUtil;
 
 /**
  * This class is for maintaining the various Ozone Manager Lock Metrics.
@@ -84,7 +85,8 @@ public final class OMLockMetrics implements MetricsSource {
    * @param readLockWaitingTimeMs read lock waiting time (ms)
    */
   public void setReadLockWaitingTimeMsStat(long readLockWaitingTimeMs) {
-    this.readLockWaitingTimeMsStat.add(readLockWaitingTimeMs);
+    MetricUtil.executeMetricsUpdateAction(() ->
+            this.readLockWaitingTimeMsStat.add(readLockWaitingTimeMs));
   }
 
   /**
@@ -93,7 +95,8 @@ public final class OMLockMetrics implements MetricsSource {
    * @param readLockHeldTimeMs read lock held time (ms)
    */
   public void setReadLockHeldTimeMsStat(long readLockHeldTimeMs) {
-    this.readLockHeldTimeMsStat.add(readLockHeldTimeMs);
+    MetricUtil.executeMetricsUpdateAction(() ->
+            this.readLockHeldTimeMsStat.add(readLockHeldTimeMs));
   }
 
   /**
@@ -102,7 +105,8 @@ public final class OMLockMetrics implements MetricsSource {
    * @param writeLockWaitingTimeMs write lock waiting time (ms)
    */
   public void setWriteLockWaitingTimeMsStat(long writeLockWaitingTimeMs) {
-    this.writeLockWaitingTimeMsStat.add(writeLockWaitingTimeMs);
+    MetricUtil.executeMetricsUpdateAction(() ->
+            this.writeLockWaitingTimeMsStat.add(writeLockWaitingTimeMs));
   }
 
   /**
@@ -111,7 +115,8 @@ public final class OMLockMetrics implements MetricsSource {
    * @param writeLockHeldTimeMs write lock held time (ms)
    */
   public void setWriteLockHeldTimeMsStat(long writeLockHeldTimeMs) {
-    this.writeLockHeldTimeMsStat.add(writeLockHeldTimeMs);
+    MetricUtil.executeMetricsUpdateAction(() ->
+            this.writeLockHeldTimeMsStat.add(writeLockHeldTimeMs));
   }
 
   /**

--- a/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/om/lock/TestOzoneManagerLock.java
+++ b/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/om/lock/TestOzoneManagerLock.java
@@ -41,7 +41,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyLong;
 
 /**
  * Class tests OzoneManagerLock.
@@ -427,7 +426,7 @@ public class TestOzoneManagerLock {
                  Mockito.mockStatic(MetricUtil.class)) {
           metricUtilMock.when(() ->
                   MetricUtil.executeStatAddAction(any(Consumer.class),
-                      anyLong()))
+                      any()))
               .thenAnswer((invocation) -> {
                 ((Consumer) invocation.getArguments()[0])
                     .accept(invocation.getArguments()[1]);
@@ -474,7 +473,7 @@ public class TestOzoneManagerLock {
                  Mockito.mockStatic(MetricUtil.class)) {
           metricUtilMock.when(() ->
                   MetricUtil.executeStatAddAction(any(Consumer.class),
-                      anyLong()))
+                      any()))
               .thenAnswer((invocation) -> {
                 ((Consumer) invocation.getArguments()[0])
                     .accept(invocation.getArguments()[1]);
@@ -521,7 +520,7 @@ public class TestOzoneManagerLock {
         try (MockedStatic<MetricUtil> metricUtilMock =
                  Mockito.mockStatic(MetricUtil.class)) {
           metricUtilMock.when(() -> MetricUtil.executeStatAddAction(
-              any(Consumer.class), anyLong())).thenAnswer((invocation) -> {
+              any(Consumer.class), any())).thenAnswer((invocation) -> {
                 ((Consumer) invocation.getArguments()[0])
                     .accept(invocation.getArguments()[1]);
                 return null;

--- a/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/om/lock/TestOzoneManagerLock.java
+++ b/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/om/lock/TestOzoneManagerLock.java
@@ -30,6 +30,7 @@ import java.util.List;
 import java.util.Stack;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Consumer;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -40,6 +41,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
 
 /**
  * Class tests OzoneManagerLock.
@@ -424,9 +426,11 @@ public class TestOzoneManagerLock {
         try (MockedStatic<MetricUtil> metricUtilMock =
                  Mockito.mockStatic(MetricUtil.class)) {
           metricUtilMock.when(() ->
-                  MetricUtil.executeMetricsUpdateAction(any(Runnable.class)))
+                  MetricUtil.executeStatAddAction(any(Consumer.class),
+                      anyLong()))
               .thenAnswer((invocation) -> {
-                ((Runnable) invocation.getArguments()[0]).run();
+                ((Consumer) invocation.getArguments()[0])
+                    .accept(invocation.getArguments()[1]);
                 return null;
               });
           lock.acquireReadLock(resource, resourceName);
@@ -469,9 +473,11 @@ public class TestOzoneManagerLock {
         try (MockedStatic<MetricUtil> metricUtilMock =
                  Mockito.mockStatic(MetricUtil.class)) {
           metricUtilMock.when(() ->
-                  MetricUtil.executeMetricsUpdateAction(any(Runnable.class)))
+                  MetricUtil.executeStatAddAction(any(Consumer.class),
+                      anyLong()))
               .thenAnswer((invocation) -> {
-                ((Runnable) invocation.getArguments()[0]).run();
+                ((Consumer) invocation.getArguments()[0])
+                    .accept(invocation.getArguments()[1]);
                 return null;
               });
           lock.acquireWriteLock(resource, resourceName);
@@ -514,10 +520,10 @@ public class TestOzoneManagerLock {
       readThreads[i] = new Thread(() -> {
         try (MockedStatic<MetricUtil> metricUtilMock =
                  Mockito.mockStatic(MetricUtil.class)) {
-          metricUtilMock.when(() ->
-                  MetricUtil.executeMetricsUpdateAction(any(Runnable.class)))
-              .thenAnswer((invocation) -> {
-                ((Runnable) invocation.getArguments()[0]).run();
+          metricUtilMock.when(() -> MetricUtil.executeStatAddAction(
+              any(Consumer.class), anyLong())).thenAnswer((invocation) -> {
+                ((Consumer) invocation.getArguments()[0])
+                    .accept(invocation.getArguments()[1]);
                 return null;
               });
           lock.acquireReadLock(resource, resourceName);

--- a/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/om/lock/TestOzoneManagerLock.java
+++ b/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/om/lock/TestOzoneManagerLock.java
@@ -18,23 +18,28 @@
 
 package org.apache.hadoop.ozone.om.lock;
 
+import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import org.apache.hadoop.metrics2.impl.MetricsCollectorImpl;
+import org.apache.hadoop.ozone.om.lock.OzoneManagerLock.Resource;
+import org.apache.hadoop.util.MetricUtil;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Stack;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicBoolean;
 
-import org.apache.hadoop.metrics2.impl.MetricsCollectorImpl;
-import org.apache.hadoop.ozone.om.lock.OzoneManagerLock.Resource;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 
-import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.fail;
+import static org.mockito.ArgumentMatchers.any;
 
 /**
  * Class tests OzoneManagerLock.
@@ -416,13 +421,22 @@ public class TestOzoneManagerLock {
 
     for (int i = 0; i < threads.length; i++) {
       threads[i] = new Thread(() -> {
-        lock.acquireReadLock(resource, resourceName);
-        try {
-          Thread.sleep(500);
-        } catch (InterruptedException e) {
-          e.printStackTrace();
+        try (MockedStatic<MetricUtil> metricUtilMock =
+                 Mockito.mockStatic(MetricUtil.class)) {
+          metricUtilMock.when(() ->
+                  MetricUtil.executeMetricsUpdateAction(any(Runnable.class)))
+              .thenAnswer((invocation) -> {
+                ((Runnable) invocation.getArguments()[0]).run();
+                return null;
+              });
+          lock.acquireReadLock(resource, resourceName);
+          try {
+            Thread.sleep(500);
+          } catch (InterruptedException e) {
+            e.printStackTrace();
+          }
+          lock.releaseReadLock(resource, resourceName);
         }
-        lock.releaseReadLock(resource, resourceName);
       });
       threads[i].start();
     }
@@ -452,13 +466,22 @@ public class TestOzoneManagerLock {
 
     for (int i = 0; i < threads.length; i++) {
       threads[i] = new Thread(() -> {
-        lock.acquireWriteLock(resource, resourceName);
-        try {
-          Thread.sleep(100);
-        } catch (InterruptedException e) {
-          e.printStackTrace();
+        try (MockedStatic<MetricUtil> metricUtilMock =
+                 Mockito.mockStatic(MetricUtil.class)) {
+          metricUtilMock.when(() ->
+                  MetricUtil.executeMetricsUpdateAction(any(Runnable.class)))
+              .thenAnswer((invocation) -> {
+                ((Runnable) invocation.getArguments()[0]).run();
+                return null;
+              });
+          lock.acquireWriteLock(resource, resourceName);
+          try {
+            Thread.sleep(100);
+          } catch (InterruptedException e) {
+            e.printStackTrace();
+          }
+          lock.releaseWriteLock(resource, resourceName);
         }
-        lock.releaseWriteLock(resource, resourceName);
       });
       threads[i].start();
     }
@@ -489,13 +512,22 @@ public class TestOzoneManagerLock {
 
     for (int i = 0; i < readThreads.length; i++) {
       readThreads[i] = new Thread(() -> {
-        lock.acquireReadLock(resource, resourceName);
-        try {
-          Thread.sleep(500);
-        } catch (InterruptedException e) {
-          e.printStackTrace();
+        try (MockedStatic<MetricUtil> metricUtilMock =
+                 Mockito.mockStatic(MetricUtil.class)) {
+          metricUtilMock.when(() ->
+                  MetricUtil.executeMetricsUpdateAction(any(Runnable.class)))
+              .thenAnswer((invocation) -> {
+                ((Runnable) invocation.getArguments()[0]).run();
+                return null;
+              });
+          lock.acquireReadLock(resource, resourceName);
+          try {
+            Thread.sleep(500);
+          } catch (InterruptedException e) {
+            e.printStackTrace();
+          }
+          lock.releaseReadLock(resource, resourceName);
         }
-        lock.releaseReadLock(resource, resourceName);
       });
       readThreads[i].setName("ReadLockThread-" + i);
       readThreads[i].start();

--- a/hadoop-ozone/dist/src/main/smoketest/ozonefs/hadoopo3fs.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/ozonefs/hadoopo3fs.robot
@@ -33,8 +33,11 @@ Test hadoop dfs
     ${dir} =          Format FS URL         ${SCHEME}     ${volume}    ${bucket}
     ${random} =        Generate Random String  5  [NUMBERS]
     ${result} =        Execute                    hdfs dfs -put /opt/hadoop/NOTICE.txt ${dir}/${PREFIX}-${random}
+                       Log to console             ${result}
                        Should Not Contain         ${result}           multiple SLF4J bindings
     ${result} =        Execute                    hdfs dfs -ls ${dir}
+                       Log to console             ${result}
                        Should contain             ${result}   ${PREFIX}-${random}
     ${result} =        Execute                    hdfs dfs -cat ${dir}/${PREFIX}-${random}
+                       Log to console             ${result}
                        Should contain             ${result}   This product includes software developed

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OMPerformanceMetrics.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OMPerformanceMetrics.java
@@ -20,6 +20,7 @@ import org.apache.hadoop.metrics2.MetricsSystem;
 import org.apache.hadoop.metrics2.annotation.Metric;
 import org.apache.hadoop.metrics2.lib.DefaultMetricsSystem;
 import org.apache.hadoop.metrics2.lib.MutableRate;
+import org.apache.hadoop.util.MetricUtil;
 
 /**
  * Including OM performance related metrics.
@@ -115,7 +116,8 @@ public class OMPerformanceMetrics {
 
 
   public void addLookupLatency(long latencyInNs) {
-    lookupLatencyNs.add(latencyInNs);
+    MetricUtil.executeMetricsUpdateAction(() ->
+            lookupLatencyNs.add(latencyInNs));
   }
 
   public MutableRate getLookupRefreshLocationLatencyNs() {
@@ -136,7 +138,8 @@ public class OMPerformanceMetrics {
   }
 
   public void addS3VolumeContextLatencyNs(long latencyInNs) {
-    s3VolumeContextLatencyNs.add(latencyInNs);
+    MetricUtil.executeMetricsUpdateAction(() ->
+            s3VolumeContextLatencyNs.add(latencyInNs));
   }
 
   public MutableRate getLookupResolveBucketLatencyNs() {
@@ -144,7 +147,8 @@ public class OMPerformanceMetrics {
   }
 
   public void addGetKeyInfoLatencyNs(long value) {
-    getKeyInfoLatencyNs.add(value);
+    MetricUtil.executeMetricsUpdateAction(() ->
+            getKeyInfoLatencyNs.add(value));
   }
 
   public MutableRate getGetKeyInfoAclCheckLatencyNs() {
@@ -172,15 +176,18 @@ public class OMPerformanceMetrics {
   }
 
   public void setForceContainerCacheRefresh(boolean value) {
-    forceContainerCacheRefresh.add(value ? 1L : 0L);
+    MetricUtil.executeMetricsUpdateAction(() ->
+            forceContainerCacheRefresh.add(value ? 1L : 0L));
   }
 
   public void setCheckAccessLatencyNs(long latencyInNs) {
-    checkAccessLatencyNs.add(latencyInNs);
+    MetricUtil.executeMetricsUpdateAction(() ->
+            checkAccessLatencyNs.add(latencyInNs));
   }
 
   public void addListKeysLatencyNs(long latencyInNs) {
-    listKeysLatencyNs.add(latencyInNs);
+    MetricUtil.executeMetricsUpdateAction(() ->
+            listKeysLatencyNs.add(latencyInNs));
   }
 
   public MutableRate getValidateRequestLatencyNs() {

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OMPerformanceMetrics.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OMPerformanceMetrics.java
@@ -116,8 +116,7 @@ public class OMPerformanceMetrics {
 
 
   public void addLookupLatency(long latencyInNs) {
-    MetricUtil.executeMetricsUpdateAction(() ->
-            lookupLatencyNs.add(latencyInNs));
+    MetricUtil.executeStatAddAction(lookupLatencyNs::add, latencyInNs);
   }
 
   public MutableRate getLookupRefreshLocationLatencyNs() {
@@ -138,8 +137,7 @@ public class OMPerformanceMetrics {
   }
 
   public void addS3VolumeContextLatencyNs(long latencyInNs) {
-    MetricUtil.executeMetricsUpdateAction(() ->
-            s3VolumeContextLatencyNs.add(latencyInNs));
+    MetricUtil.executeStatAddAction(s3VolumeContextLatencyNs::add, latencyInNs);
   }
 
   public MutableRate getLookupResolveBucketLatencyNs() {
@@ -147,8 +145,7 @@ public class OMPerformanceMetrics {
   }
 
   public void addGetKeyInfoLatencyNs(long value) {
-    MetricUtil.executeMetricsUpdateAction(() ->
-            getKeyInfoLatencyNs.add(value));
+    MetricUtil.executeStatAddAction(getKeyInfoLatencyNs::add, value);
   }
 
   public MutableRate getGetKeyInfoAclCheckLatencyNs() {
@@ -176,18 +173,16 @@ public class OMPerformanceMetrics {
   }
 
   public void setForceContainerCacheRefresh(boolean value) {
-    MetricUtil.executeMetricsUpdateAction(() ->
-            forceContainerCacheRefresh.add(value ? 1L : 0L));
+    MetricUtil.executeStatAddAction(forceContainerCacheRefresh::add,
+        value ? 1L : 0L);
   }
 
   public void setCheckAccessLatencyNs(long latencyInNs) {
-    MetricUtil.executeMetricsUpdateAction(() ->
-            checkAccessLatencyNs.add(latencyInNs));
+    MetricUtil.executeStatAddAction(checkAccessLatencyNs::add, latencyInNs);
   }
 
   public void addListKeysLatencyNs(long latencyInNs) {
-    MetricUtil.executeMetricsUpdateAction(() ->
-            listKeysLatencyNs.add(latencyInNs));
+    MetricUtil.executeStatAddAction(listKeysLatencyNs::add, latencyInNs);
   }
 
   public MutableRate getValidateRequestLatencyNs() {

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/metrics/OzoneManagerDoubleBufferMetrics.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/metrics/OzoneManagerDoubleBufferMetrics.java
@@ -27,6 +27,7 @@ import org.apache.hadoop.metrics2.lib.MutableCounterLong;
 import org.apache.hadoop.metrics2.lib.MutableGaugeFloat;
 import org.apache.hadoop.metrics2.lib.MutableRate;
 import org.apache.hadoop.metrics2.lib.MutableStat;
+import org.apache.hadoop.util.MetricUtil;
 
 /**
  * Class which maintains metrics related to OzoneManager DoubleBuffer.
@@ -107,7 +108,7 @@ public class OzoneManagerDoubleBufferMetrics {
   }
 
   public void updateFlushTime(long time) {
-    flushTime.add(time);
+    MetricUtil.executeMetricsUpdateAction(() -> flushTime.add(time));
   }
 
   @VisibleForTesting
@@ -124,7 +125,7 @@ public class OzoneManagerDoubleBufferMetrics {
   }
 
   public void updateQueueSize(long size) {
-    queueSize.add(size);
+    MetricUtil.executeMetricsUpdateAction(() -> queueSize.add(size));
   }
 
   @VisibleForTesting

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/metrics/OzoneManagerDoubleBufferMetrics.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/metrics/OzoneManagerDoubleBufferMetrics.java
@@ -108,7 +108,7 @@ public class OzoneManagerDoubleBufferMetrics {
   }
 
   public void updateFlushTime(long time) {
-    MetricUtil.executeMetricsUpdateAction(() -> flushTime.add(time));
+    MetricUtil.executeStatAddAction(flushTime::add, time);
   }
 
   @VisibleForTesting
@@ -125,7 +125,7 @@ public class OzoneManagerDoubleBufferMetrics {
   }
 
   public void updateQueueSize(long size) {
-    MetricUtil.executeMetricsUpdateAction(() -> queueSize.add(size));
+    MetricUtil.executeStatAddAction(queueSize::add, size);
   }
 
   @VisibleForTesting

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/metrics/S3GatewayMetrics.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/metrics/S3GatewayMetrics.java
@@ -29,6 +29,7 @@ import org.apache.hadoop.metrics2.lib.MetricsRegistry;
 import org.apache.hadoop.metrics2.lib.MutableCounterLong;
 import org.apache.hadoop.metrics2.lib.MutableRate;
 import org.apache.hadoop.ozone.OzoneConsts;
+import org.apache.hadoop.util.MetricUtil;
 import org.apache.hadoop.util.Time;
 
 /**
@@ -364,57 +365,79 @@ public final class S3GatewayMetrics implements MetricsSource {
 
   public void updateGetBucketSuccessStats(long startNanos) {
     getBucketSuccess.incr();
-    getBucketSuccessLatencyNs.add(Time.monotonicNowNanos() - startNanos);
+    MetricUtil.executeMetricsUpdateAction(() ->
+            getBucketSuccessLatencyNs
+                    .add(Time.monotonicNowNanos() - startNanos));
   }
 
   public void updateGetBucketFailureStats(long startNanos) {
     getBucketFailure.incr();
-    getBucketFailureLatencyNs.add(Time.monotonicNowNanos() - startNanos);
+    MetricUtil.executeMetricsUpdateAction(() ->
+            getBucketFailureLatencyNs
+                    .add(Time.monotonicNowNanos() - startNanos));
   }
 
   public void updateCreateBucketSuccessStats(long startNanos) {
     createBucketSuccess.incr();
-    createBucketSuccessLatencyNs.add(Time.monotonicNowNanos() - startNanos);
+    MetricUtil.executeMetricsUpdateAction(() ->
+            createBucketSuccessLatencyNs
+                    .add(Time.monotonicNowNanos() - startNanos));
   }
 
   public void updateCreateBucketFailureStats(long startNanos) {
     createBucketFailure.incr();
-    createBucketFailureLatencyNs.add(Time.monotonicNowNanos() - startNanos);
+    MetricUtil.executeMetricsUpdateAction(() ->
+            createBucketFailureLatencyNs
+                    .add(Time.monotonicNowNanos() - startNanos));
   }
 
   public void updateHeadBucketSuccessStats(long startNanos) {
     headBucketSuccess.incr();
-    headBucketSuccessLatencyNs.add(Time.monotonicNowNanos() - startNanos);
+    MetricUtil.executeMetricsUpdateAction(() ->
+            headBucketSuccessLatencyNs
+                    .add(Time.monotonicNowNanos() - startNanos));
   }
 
   public void updateDeleteBucketSuccessStats(long startNanos) {
     deleteBucketSuccess.incr();
-    deleteBucketSuccessLatencyNs.add(Time.monotonicNowNanos() - startNanos);
+    MetricUtil.executeMetricsUpdateAction(() ->
+            deleteBucketSuccessLatencyNs
+                    .add(Time.monotonicNowNanos() - startNanos));
   }
 
   public void updateDeleteBucketFailureStats(long startNanos) {
     deleteBucketFailure.incr();
-    deleteBucketFailureLatencyNs.add(Time.monotonicNowNanos() - startNanos);
+    MetricUtil.executeMetricsUpdateAction(() ->
+            deleteBucketFailureLatencyNs
+                    .add(Time.monotonicNowNanos() - startNanos));
   }
 
   public void updateGetAclSuccessStats(long startNanos) {
     getAclSuccess.incr();
-    getAclSuccessLatencyNs.add(Time.monotonicNowNanos() - startNanos);
+    MetricUtil.executeMetricsUpdateAction(() ->
+            getAclSuccessLatencyNs
+                    .add(Time.monotonicNowNanos() - startNanos));
   }
 
   public void updateGetAclFailureStats(long startNanos) {
     getAclFailure.incr();
-    getAclFailureLatencyNs.add(Time.monotonicNowNanos() - startNanos);
+    MetricUtil.executeMetricsUpdateAction(() ->
+            getAclFailureLatencyNs
+                    .add(Time.monotonicNowNanos() - startNanos));
   }
 
   public void updatePutAclSuccessStats(long startNanos) {
     putAclSuccess.incr();
-    putAclSuccessLatencyNs.add(Time.monotonicNowNanos() - startNanos);
+    MetricUtil.executeMetricsUpdateAction(() ->
+            putAclSuccessLatencyNs
+                    .add(Time.monotonicNowNanos() - startNanos));
   }
 
   public void updatePutAclFailureStats(long startNanos) {
     putAclFailure.incr();
-    putAclFailureLatencyNs.add(Time.monotonicNowNanos() - startNanos);
+    MetricUtil.executeMetricsUpdateAction(() ->
+            putAclFailureLatencyNs
+                    .add(Time.monotonicNowNanos() - startNanos));
   }
 
   public void incListKeyCount(int count) {
@@ -423,148 +446,186 @@ public final class S3GatewayMetrics implements MetricsSource {
 
   public void updateListMultipartUploadsSuccessStats(long startNanos) {
     listMultipartUploadsSuccess.incr();
-    listMultipartUploadsSuccessLatencyNs.add(
-        Time.monotonicNowNanos() - startNanos);
+    MetricUtil.executeMetricsUpdateAction(() ->
+            listMultipartUploadsSuccessLatencyNs
+                    .add(Time.monotonicNowNanos() - startNanos));
   }
 
   public void updateListMultipartUploadsFailureStats(long startNanos) {
     listMultipartUploadsFailure.incr();
-    listMultipartUploadsFailureLatencyNs.add(
-        Time.monotonicNowNanos() - startNanos);
+    MetricUtil.executeMetricsUpdateAction(() ->
+            listMultipartUploadsFailureLatencyNs
+                    .add(Time.monotonicNowNanos() - startNanos));
   }
 
   // RootEndpoint
 
   public void updateListS3BucketsSuccessStats(long startNanos) {
     listS3BucketsSuccess.incr();
-    listS3BucketsSuccessLatencyNs.add(Time.monotonicNowNanos() - startNanos);
+    MetricUtil.executeMetricsUpdateAction(() ->
+            listS3BucketsSuccessLatencyNs
+                    .add(Time.monotonicNowNanos() - startNanos));
   }
 
   public void updateListS3BucketsFailureStats(long startNanos) {
     listS3BucketsFailure.incr();
-    listS3BucketsFailureLatencyNs.add(Time.monotonicNowNanos() - startNanos);
+    MetricUtil.executeMetricsUpdateAction(() ->
+            listS3BucketsFailureLatencyNs
+                    .add(Time.monotonicNowNanos() - startNanos));
   }
 
   // ObjectEndpoint
 
   public void updateCreateMultipartKeySuccessStats(long startNanos) {
     createMultipartKeySuccess.incr();
-    createMultipartKeySuccessLatencyNs.add(
-        Time.monotonicNowNanos() - startNanos);
+    MetricUtil.executeMetricsUpdateAction(() ->
+            createMultipartKeySuccessLatencyNs
+                    .add(Time.monotonicNowNanos() - startNanos));
   }
 
   public void updateCreateMultipartKeyFailureStats(long startNanos) {
     createMultipartKeyFailure.incr();
-    createMultipartKeyFailureLatencyNs.add(
-        Time.monotonicNowNanos() - startNanos);
+    MetricUtil.executeMetricsUpdateAction(() ->
+            createMultipartKeyFailureLatencyNs
+                    .add(Time.monotonicNowNanos() - startNanos));
   }
 
   public void updateCopyObjectSuccessStats(long startNanos) {
     copyObjectSuccess.incr();
-    copyObjectSuccessLatencyNs.add(Time.monotonicNowNanos() - startNanos);
+    MetricUtil.executeMetricsUpdateAction(() ->
+            copyObjectSuccessLatencyNs
+                    .add(Time.monotonicNowNanos() - startNanos));
   }
 
   public void updateCopyObjectFailureStats(long startNanos) {
     copyObjectFailure.incr();
-    copyObjectFailureLatencyNs.add(Time.monotonicNowNanos() - startNanos);
+    MetricUtil.executeMetricsUpdateAction(() ->
+            copyObjectFailureLatencyNs
+                    .add(Time.monotonicNowNanos() - startNanos));
   }
 
   public void updateCreateKeySuccessStats(long startNanos) {
     createKeySuccess.incr();
-    createKeySuccessLatencyNs.add(Time.monotonicNowNanos() - startNanos);
+    MetricUtil.executeMetricsUpdateAction(() ->
+            createKeySuccessLatencyNs
+                    .add(Time.monotonicNowNanos() - startNanos));
   }
 
   public void updateCreateKeyFailureStats(long startNanos) {
     createKeyFailure.incr();
-    createKeyFailureLatencyNs.add(Time.monotonicNowNanos() - startNanos);
+    MetricUtil.executeMetricsUpdateAction(() ->
+            createKeyFailureLatencyNs
+                    .add(Time.monotonicNowNanos() - startNanos));
   }
 
   public void updateListPartsSuccessStats(long startNanos) {
     listPartsSuccess.incr();
-    listPartsSuccessLatencyNs.add(Time.monotonicNowNanos() - startNanos);
+    MetricUtil.executeMetricsUpdateAction(() ->
+            listPartsSuccessLatencyNs
+                    .add(Time.monotonicNowNanos() - startNanos));
   }
 
   public void updateListPartsFailureStats(long startNanos) {
     listPartsFailure.incr();
-    listPartsFailureLatencyNs.add(Time.monotonicNowNanos() - startNanos);
+    MetricUtil.executeMetricsUpdateAction(() ->
+            listPartsFailureLatencyNs
+                    .add(Time.monotonicNowNanos() - startNanos));
   }
 
   public void updateGetKeySuccessStats(long startNanos) {
     getKeySuccess.incr();
-    getKeySuccessLatencyNs.add(Time.monotonicNowNanos() - startNanos);
+    MetricUtil.executeMetricsUpdateAction(() ->
+            getKeySuccessLatencyNs.add(Time.monotonicNowNanos() - startNanos));
   }
 
   public void updateGetKeyFailureStats(long startNanos) {
     getKeyFailure.incr();
-    getKeyFailureLatencyNs.add(Time.monotonicNowNanos() - startNanos);
+    MetricUtil.executeMetricsUpdateAction(() ->
+            getKeyFailureLatencyNs.add(Time.monotonicNowNanos() - startNanos));
   }
 
   public void updateHeadKeySuccessStats(long startNanos) {
     headKeySuccess.incr();
-    headKeySuccessLatencyNs.add(Time.monotonicNowNanos() - startNanos);
+    MetricUtil.executeMetricsUpdateAction(() ->
+            headKeySuccessLatencyNs.add(Time.monotonicNowNanos() - startNanos));
   }
 
   public void updateHeadKeyFailureStats(long startNanos) {
     headKeyFailure.incr();
-    headKeyFailureLatencyNs.add(Time.monotonicNowNanos() - startNanos);
+    MetricUtil.executeMetricsUpdateAction(() ->
+            headKeyFailureLatencyNs.add(Time.monotonicNowNanos() - startNanos));
   }
 
   public void updateInitMultipartUploadSuccessStats(long startNanos) {
     initMultipartUploadSuccess.incr();
-    initMultipartUploadSuccessLatencyNs.add(
-        Time.monotonicNowNanos() - startNanos);
+    MetricUtil.executeMetricsUpdateAction(() ->
+            initMultipartUploadSuccessLatencyNs
+                    .add(Time.monotonicNowNanos() - startNanos));
   }
 
   public void updateInitMultipartUploadFailureStats(long startNanos) {
     initMultipartUploadFailure.incr();
-    initMultipartUploadFailureLatencyNs.add(
-        Time.monotonicNowNanos() - startNanos);
+    MetricUtil.executeMetricsUpdateAction(() ->
+            initMultipartUploadFailureLatencyNs
+                    .add(Time.monotonicNowNanos() - startNanos));
   }
 
   public void updateCompleteMultipartUploadSuccessStats(long startNanos) {
     completeMultipartUploadSuccess.incr();
-    completeMultipartUploadSuccessLatencyNs.add(
-        Time.monotonicNowNanos() - startNanos);
+    MetricUtil.executeMetricsUpdateAction(() ->
+            completeMultipartUploadSuccessLatencyNs
+                    .add(Time.monotonicNowNanos() - startNanos));
   }
 
   public void updateCompleteMultipartUploadFailureStats(long startNanos) {
     completeMultipartUploadFailure.incr();
-    completeMultipartUploadFailureLatencyNs.add(
-        Time.monotonicNowNanos() - startNanos);
+    MetricUtil.executeMetricsUpdateAction(() ->
+            completeMultipartUploadFailureLatencyNs
+                    .add(Time.monotonicNowNanos() - startNanos));
   }
 
   public void updateAbortMultipartUploadSuccessStats(long startNanos) {
     abortMultipartUploadSuccess.incr();
-    abortMultipartUploadSuccessLatencyNs.add(
-        Time.monotonicNowNanos() - startNanos);
+    MetricUtil.executeMetricsUpdateAction(() ->
+            abortMultipartUploadSuccessLatencyNs
+                    .add(Time.monotonicNowNanos() - startNanos));
   }
 
   public void updateAbortMultipartUploadFailureStats(long startNanos) {
     abortMultipartUploadFailure.incr();
-    abortMultipartUploadFailureLatencyNs.add(
-        Time.monotonicNowNanos() - startNanos);
+    MetricUtil.executeMetricsUpdateAction(() ->
+            abortMultipartUploadFailureLatencyNs
+                    .add(Time.monotonicNowNanos() - startNanos));
   }
 
   public void updateDeleteKeySuccessStats(long startNanos) {
     deleteKeySuccess.incr();
-    deleteKeySuccessLatencyNs.add(Time.monotonicNowNanos() - startNanos);
+    MetricUtil.executeMetricsUpdateAction(() ->
+            deleteKeySuccessLatencyNs
+                    .add(Time.monotonicNowNanos() - startNanos));
   }
 
   public void updateDeleteKeyFailureStats(long startNanos) {
     deleteKeyFailure.incr();
-    deleteKeyFailureLatencyNs.add(Time.monotonicNowNanos() - startNanos);
+    MetricUtil.executeMetricsUpdateAction(() ->
+            deleteKeyFailureLatencyNs
+                    .add(Time.monotonicNowNanos() - startNanos));
   }
 
   public void updateGetKeyMetadataStats(long startNanos) {
-    getKeyMetadataLatencyNs.add(Time.monotonicNowNanos() - startNanos);
+    MetricUtil.executeMetricsUpdateAction(() ->
+            getKeyMetadataLatencyNs.add(Time.monotonicNowNanos() - startNanos));
   }
 
   public void updateCopyKeyMetadataStats(long startNanos) {
-    copyKeyMetadataLatencyNs.add(Time.monotonicNowNanos() - startNanos);
+    MetricUtil.executeMetricsUpdateAction(() ->
+            copyKeyMetadataLatencyNs
+                    .add(Time.monotonicNowNanos() - startNanos));
   }
 
   public void updatePutKeyMetadataStats(long startNanos) {
-    putKeyMetadataLatencyNs.add(Time.monotonicNowNanos() - startNanos);
+    MetricUtil.executeMetricsUpdateAction(() ->
+            putKeyMetadataLatencyNs.add(Time.monotonicNowNanos() - startNanos));
   }
 
   public void incCopyObjectSuccessLength(long bytes) {

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/metrics/S3GatewayMetrics.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/metrics/S3GatewayMetrics.java
@@ -365,79 +365,68 @@ public final class S3GatewayMetrics implements MetricsSource {
 
   public void updateGetBucketSuccessStats(long startNanos) {
     getBucketSuccess.incr();
-    MetricUtil.executeMetricsUpdateAction(() ->
-            getBucketSuccessLatencyNs
-                    .add(Time.monotonicNowNanos() - startNanos));
+    MetricUtil.executeStatAddAction(getBucketSuccessLatencyNs::add,
+        Time.monotonicNowNanos() - startNanos);
   }
 
   public void updateGetBucketFailureStats(long startNanos) {
     getBucketFailure.incr();
-    MetricUtil.executeMetricsUpdateAction(() ->
-            getBucketFailureLatencyNs
-                    .add(Time.monotonicNowNanos() - startNanos));
+    MetricUtil.executeStatAddAction(getBucketFailureLatencyNs::add,
+        Time.monotonicNowNanos() - startNanos);
   }
 
   public void updateCreateBucketSuccessStats(long startNanos) {
     createBucketSuccess.incr();
-    MetricUtil.executeMetricsUpdateAction(() ->
-            createBucketSuccessLatencyNs
-                    .add(Time.monotonicNowNanos() - startNanos));
+    MetricUtil.executeStatAddAction(createBucketSuccessLatencyNs::add,
+        Time.monotonicNowNanos() - startNanos);
   }
 
   public void updateCreateBucketFailureStats(long startNanos) {
     createBucketFailure.incr();
-    MetricUtil.executeMetricsUpdateAction(() ->
-            createBucketFailureLatencyNs
-                    .add(Time.monotonicNowNanos() - startNanos));
+    MetricUtil.executeStatAddAction(createBucketFailureLatencyNs::add,
+        Time.monotonicNowNanos() - startNanos);
   }
 
   public void updateHeadBucketSuccessStats(long startNanos) {
     headBucketSuccess.incr();
-    MetricUtil.executeMetricsUpdateAction(() ->
-            headBucketSuccessLatencyNs
-                    .add(Time.monotonicNowNanos() - startNanos));
+    MetricUtil.executeStatAddAction(headBucketSuccessLatencyNs::add,
+        Time.monotonicNowNanos() - startNanos);
   }
 
   public void updateDeleteBucketSuccessStats(long startNanos) {
     deleteBucketSuccess.incr();
-    MetricUtil.executeMetricsUpdateAction(() ->
-            deleteBucketSuccessLatencyNs
-                    .add(Time.monotonicNowNanos() - startNanos));
+    MetricUtil.executeStatAddAction(deleteBucketSuccessLatencyNs::add,
+        Time.monotonicNowNanos() - startNanos);
   }
 
   public void updateDeleteBucketFailureStats(long startNanos) {
     deleteBucketFailure.incr();
-    MetricUtil.executeMetricsUpdateAction(() ->
-            deleteBucketFailureLatencyNs
-                    .add(Time.monotonicNowNanos() - startNanos));
+    MetricUtil.executeStatAddAction(deleteBucketFailureLatencyNs::add,
+        Time.monotonicNowNanos() - startNanos);
   }
 
   public void updateGetAclSuccessStats(long startNanos) {
     getAclSuccess.incr();
-    MetricUtil.executeMetricsUpdateAction(() ->
-            getAclSuccessLatencyNs
-                    .add(Time.monotonicNowNanos() - startNanos));
+    MetricUtil.executeStatAddAction(getAclSuccessLatencyNs::add,
+        Time.monotonicNowNanos() - startNanos);
   }
 
   public void updateGetAclFailureStats(long startNanos) {
     getAclFailure.incr();
-    MetricUtil.executeMetricsUpdateAction(() ->
-            getAclFailureLatencyNs
-                    .add(Time.monotonicNowNanos() - startNanos));
+    MetricUtil.executeStatAddAction(getAclFailureLatencyNs::add,
+        Time.monotonicNowNanos() - startNanos);
   }
 
   public void updatePutAclSuccessStats(long startNanos) {
     putAclSuccess.incr();
-    MetricUtil.executeMetricsUpdateAction(() ->
-            putAclSuccessLatencyNs
-                    .add(Time.monotonicNowNanos() - startNanos));
+    MetricUtil.executeStatAddAction(putAclSuccessLatencyNs::add,
+        Time.monotonicNowNanos() - startNanos);
   }
 
   public void updatePutAclFailureStats(long startNanos) {
     putAclFailure.incr();
-    MetricUtil.executeMetricsUpdateAction(() ->
-            putAclFailureLatencyNs
-                    .add(Time.monotonicNowNanos() - startNanos));
+    MetricUtil.executeStatAddAction(putAclFailureLatencyNs::add,
+        Time.monotonicNowNanos() - startNanos);
   }
 
   public void incListKeyCount(int count) {
@@ -446,186 +435,167 @@ public final class S3GatewayMetrics implements MetricsSource {
 
   public void updateListMultipartUploadsSuccessStats(long startNanos) {
     listMultipartUploadsSuccess.incr();
-    MetricUtil.executeMetricsUpdateAction(() ->
-            listMultipartUploadsSuccessLatencyNs
-                    .add(Time.monotonicNowNanos() - startNanos));
+    MetricUtil.executeStatAddAction(listMultipartUploadsSuccessLatencyNs::add,
+        Time.monotonicNowNanos() - startNanos);
   }
 
   public void updateListMultipartUploadsFailureStats(long startNanos) {
     listMultipartUploadsFailure.incr();
-    MetricUtil.executeMetricsUpdateAction(() ->
-            listMultipartUploadsFailureLatencyNs
-                    .add(Time.monotonicNowNanos() - startNanos));
+    MetricUtil.executeStatAddAction(listMultipartUploadsFailureLatencyNs::add,
+        Time.monotonicNowNanos() - startNanos);
   }
 
   // RootEndpoint
 
   public void updateListS3BucketsSuccessStats(long startNanos) {
     listS3BucketsSuccess.incr();
-    MetricUtil.executeMetricsUpdateAction(() ->
-            listS3BucketsSuccessLatencyNs
-                    .add(Time.monotonicNowNanos() - startNanos));
+    MetricUtil.executeStatAddAction(listS3BucketsSuccessLatencyNs::add,
+        Time.monotonicNowNanos() - startNanos);
   }
 
   public void updateListS3BucketsFailureStats(long startNanos) {
     listS3BucketsFailure.incr();
-    MetricUtil.executeMetricsUpdateAction(() ->
-            listS3BucketsFailureLatencyNs
-                    .add(Time.monotonicNowNanos() - startNanos));
+    MetricUtil.executeStatAddAction(listS3BucketsFailureLatencyNs::add,
+        Time.monotonicNowNanos());
   }
 
   // ObjectEndpoint
 
   public void updateCreateMultipartKeySuccessStats(long startNanos) {
     createMultipartKeySuccess.incr();
-    MetricUtil.executeMetricsUpdateAction(() ->
-            createMultipartKeySuccessLatencyNs
-                    .add(Time.monotonicNowNanos() - startNanos));
+    MetricUtil.executeStatAddAction(createMultipartKeySuccessLatencyNs::add,
+        Time.monotonicNowNanos() - startNanos);
   }
 
   public void updateCreateMultipartKeyFailureStats(long startNanos) {
     createMultipartKeyFailure.incr();
-    MetricUtil.executeMetricsUpdateAction(() ->
-            createMultipartKeyFailureLatencyNs
-                    .add(Time.monotonicNowNanos() - startNanos));
+    MetricUtil.executeStatAddAction(createMultipartKeyFailureLatencyNs::add,
+        Time.monotonicNowNanos() - startNanos);
   }
 
   public void updateCopyObjectSuccessStats(long startNanos) {
     copyObjectSuccess.incr();
-    MetricUtil.executeMetricsUpdateAction(() ->
-            copyObjectSuccessLatencyNs
-                    .add(Time.monotonicNowNanos() - startNanos));
+    MetricUtil.executeStatAddAction(copyObjectSuccessLatencyNs::add,
+        Time.monotonicNowNanos() - startNanos);
   }
 
   public void updateCopyObjectFailureStats(long startNanos) {
     copyObjectFailure.incr();
-    MetricUtil.executeMetricsUpdateAction(() ->
-            copyObjectFailureLatencyNs
-                    .add(Time.monotonicNowNanos() - startNanos));
+    MetricUtil.executeStatAddAction(copyObjectFailureLatencyNs::add,
+        Time.monotonicNowNanos() - startNanos);
   }
 
   public void updateCreateKeySuccessStats(long startNanos) {
     createKeySuccess.incr();
-    MetricUtil.executeMetricsUpdateAction(() ->
-            createKeySuccessLatencyNs
-                    .add(Time.monotonicNowNanos() - startNanos));
+    MetricUtil.executeStatAddAction(createKeySuccessLatencyNs::add,
+        Time.monotonicNowNanos() - startNanos);
   }
 
   public void updateCreateKeyFailureStats(long startNanos) {
     createKeyFailure.incr();
-    MetricUtil.executeMetricsUpdateAction(() ->
-            createKeyFailureLatencyNs
-                    .add(Time.monotonicNowNanos() - startNanos));
+    MetricUtil.executeStatAddAction(createKeyFailureLatencyNs::add,
+        Time.monotonicNowNanos() - startNanos);
   }
 
   public void updateListPartsSuccessStats(long startNanos) {
     listPartsSuccess.incr();
-    MetricUtil.executeMetricsUpdateAction(() ->
-            listPartsSuccessLatencyNs
-                    .add(Time.monotonicNowNanos() - startNanos));
+    MetricUtil.executeStatAddAction(listPartsSuccessLatencyNs::add,
+        Time.monotonicNowNanos() - startNanos);
   }
 
   public void updateListPartsFailureStats(long startNanos) {
     listPartsFailure.incr();
-    MetricUtil.executeMetricsUpdateAction(() ->
-            listPartsFailureLatencyNs
-                    .add(Time.monotonicNowNanos() - startNanos));
+    MetricUtil.executeStatAddAction(listPartsFailureLatencyNs::add,
+        Time.monotonicNowNanos() - startNanos);
   }
 
   public void updateGetKeySuccessStats(long startNanos) {
     getKeySuccess.incr();
-    MetricUtil.executeMetricsUpdateAction(() ->
-            getKeySuccessLatencyNs.add(Time.monotonicNowNanos() - startNanos));
+    MetricUtil.executeStatAddAction(getKeySuccessLatencyNs::add,
+        Time.monotonicNowNanos() - startNanos);
   }
 
   public void updateGetKeyFailureStats(long startNanos) {
     getKeyFailure.incr();
-    MetricUtil.executeMetricsUpdateAction(() ->
-            getKeyFailureLatencyNs.add(Time.monotonicNowNanos() - startNanos));
+    MetricUtil.executeStatAddAction(getKeyFailureLatencyNs::add,
+        Time.monotonicNowNanos() - startNanos);
   }
 
   public void updateHeadKeySuccessStats(long startNanos) {
     headKeySuccess.incr();
-    MetricUtil.executeMetricsUpdateAction(() ->
-            headKeySuccessLatencyNs.add(Time.monotonicNowNanos() - startNanos));
+    MetricUtil.executeStatAddAction(headKeySuccessLatencyNs::add,
+        Time.monotonicNowNanos() - startNanos);
   }
 
   public void updateHeadKeyFailureStats(long startNanos) {
     headKeyFailure.incr();
-    MetricUtil.executeMetricsUpdateAction(() ->
-            headKeyFailureLatencyNs.add(Time.monotonicNowNanos() - startNanos));
+    MetricUtil.executeStatAddAction(headKeyFailureLatencyNs::add,
+        Time.monotonicNowNanos() - startNanos);
   }
 
   public void updateInitMultipartUploadSuccessStats(long startNanos) {
     initMultipartUploadSuccess.incr();
-    MetricUtil.executeMetricsUpdateAction(() ->
-            initMultipartUploadSuccessLatencyNs
-                    .add(Time.monotonicNowNanos() - startNanos));
+    MetricUtil.executeStatAddAction(initMultipartUploadSuccessLatencyNs::add,
+        Time.monotonicNowNanos() - startNanos);
   }
 
   public void updateInitMultipartUploadFailureStats(long startNanos) {
     initMultipartUploadFailure.incr();
-    MetricUtil.executeMetricsUpdateAction(() ->
-            initMultipartUploadFailureLatencyNs
-                    .add(Time.monotonicNowNanos() - startNanos));
+    MetricUtil.executeStatAddAction(initMultipartUploadFailureLatencyNs::add,
+        Time.monotonicNowNanos() - startNanos);
   }
 
   public void updateCompleteMultipartUploadSuccessStats(long startNanos) {
     completeMultipartUploadSuccess.incr();
-    MetricUtil.executeMetricsUpdateAction(() ->
-            completeMultipartUploadSuccessLatencyNs
-                    .add(Time.monotonicNowNanos() - startNanos));
+    MetricUtil.executeStatAddAction(
+        completeMultipartUploadSuccessLatencyNs::add,
+        Time.monotonicNowNanos() - startNanos);
   }
 
   public void updateCompleteMultipartUploadFailureStats(long startNanos) {
     completeMultipartUploadFailure.incr();
-    MetricUtil.executeMetricsUpdateAction(() ->
-            completeMultipartUploadFailureLatencyNs
-                    .add(Time.monotonicNowNanos() - startNanos));
+    MetricUtil.executeStatAddAction(
+        completeMultipartUploadFailureLatencyNs::add,
+        Time.monotonicNowNanos() - startNanos);
   }
 
   public void updateAbortMultipartUploadSuccessStats(long startNanos) {
     abortMultipartUploadSuccess.incr();
-    MetricUtil.executeMetricsUpdateAction(() ->
-            abortMultipartUploadSuccessLatencyNs
-                    .add(Time.monotonicNowNanos() - startNanos));
+    MetricUtil.executeStatAddAction(abortMultipartUploadSuccessLatencyNs::add,
+        Time.monotonicNowNanos() - startNanos);
   }
 
   public void updateAbortMultipartUploadFailureStats(long startNanos) {
     abortMultipartUploadFailure.incr();
-    MetricUtil.executeMetricsUpdateAction(() ->
-            abortMultipartUploadFailureLatencyNs
-                    .add(Time.monotonicNowNanos() - startNanos));
+    MetricUtil.executeStatAddAction(abortMultipartUploadFailureLatencyNs::add,
+        Time.monotonicNowNanos() - startNanos);
   }
 
   public void updateDeleteKeySuccessStats(long startNanos) {
     deleteKeySuccess.incr();
-    MetricUtil.executeMetricsUpdateAction(() ->
-            deleteKeySuccessLatencyNs
-                    .add(Time.monotonicNowNanos() - startNanos));
+    MetricUtil.executeStatAddAction(deleteKeySuccessLatencyNs::add,
+        Time.monotonicNowNanos() - startNanos);
   }
 
   public void updateDeleteKeyFailureStats(long startNanos) {
     deleteKeyFailure.incr();
-    MetricUtil.executeMetricsUpdateAction(() ->
-            deleteKeyFailureLatencyNs
-                    .add(Time.monotonicNowNanos() - startNanos));
+    MetricUtil.executeStatAddAction(deleteKeyFailureLatencyNs::add,
+        Time.monotonicNowNanos() - startNanos);
   }
 
   public void updateGetKeyMetadataStats(long startNanos) {
-    MetricUtil.executeMetricsUpdateAction(() ->
-            getKeyMetadataLatencyNs.add(Time.monotonicNowNanos() - startNanos));
+    MetricUtil.executeStatAddAction(getKeyMetadataLatencyNs::add,
+        Time.monotonicNowNanos() - startNanos);
   }
 
   public void updateCopyKeyMetadataStats(long startNanos) {
-    MetricUtil.executeMetricsUpdateAction(() ->
-            copyKeyMetadataLatencyNs
-                    .add(Time.monotonicNowNanos() - startNanos));
+    MetricUtil.executeStatAddAction(copyKeyMetadataLatencyNs::add,
+        Time.monotonicNowNanos() - startNanos);
   }
 
   public void updatePutKeyMetadataStats(long startNanos) {
-    MetricUtil.executeMetricsUpdateAction(() ->
-            putKeyMetadataLatencyNs.add(Time.monotonicNowNanos() - startNanos));
+    MetricUtil.executeStatAddAction(putKeyMetadataLatencyNs::add,
+        Time.monotonicNowNanos() - startNanos);
   }
 
   public void incCopyObjectSuccessLength(long bytes) {


### PR DESCRIPTION
## What changes were proposed in this pull request?

Move MutableStat.add(long stat) method call to the separate thread pool executor (in order to get rid of high lock contention on reading keys)

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-9377

## How was this patch tested?

Manual high-load test of reading of 15mln 1KiB files (3 clients in 100 thread - 300 threads in total)
