### PR TITLE
HDDS-9398. [snapshot] Prevent key writes with name .snapshot

### DIFF
--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/OmUtils.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/OmUtils.java
@@ -627,6 +627,11 @@ public final class OmUtils {
           "Cannot create key under path reserved for "
               + "snapshot: " + OM_SNAPSHOT_INDICATOR + OM_KEY_PREFIX,
               OMException.ResultCodes.INVALID_KEY_NAME);
+    } else if (keyName != null &&
+        keyName.equals(OM_SNAPSHOT_INDICATOR)) {
+      throw new OMException(
+          "Cannot create key with reserved name: " + OM_SNAPSHOT_INDICATOR,
+          OMException.ResultCodes.INVALID_KEY_NAME);
     }
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Prevent key writes with name .snapshot
```
bash-4.2$ ozone sh key put vol1/buck1/.snapshot/key1 NOTICE.txt
INVALID_KEY_NAME Cannot create key under path reserved for snapshot: .snapshot/
bash-4.2$ ozone sh key put vol1/buck1/.snapshot NOTICE.txt
INVALID_KEY_NAME Cannot create key with reserved name: .snapshot
```

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-9398

## How was this patch tested?

Tested manually on docker.
TODO - Add unit-testcases
