### PR TITLE
HDDS-9419. java.lang.UnsatisfiedLinkError when trying to read RocksDB with ozone debug ldb

### DIFF
--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/RocksDatabase.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/RocksDatabase.java
@@ -32,6 +32,7 @@ import org.apache.hadoop.hdds.utils.db.managed.ManagedOptions;
 import org.apache.hadoop.hdds.utils.db.managed.ManagedReadOptions;
 import org.apache.hadoop.hdds.utils.db.managed.ManagedRocksDB;
 import org.apache.hadoop.hdds.utils.db.managed.ManagedRocksIterator;
+import org.apache.hadoop.hdds.utils.db.managed.ManagedRocksObjectUtils;
 import org.apache.hadoop.hdds.utils.db.managed.ManagedTransactionLogIterator;
 import org.apache.hadoop.hdds.utils.db.managed.ManagedWriteBatch;
 import org.apache.hadoop.hdds.utils.db.managed.ManagedWriteOptions;
@@ -80,9 +81,11 @@ public final class RocksDatabase implements Closeable {
   static final Logger LOG = LoggerFactory.getLogger(RocksDatabase.class);
 
   public static final String ESTIMATE_NUM_KEYS = "rocksdb.estimate-num-keys";
+  static {
+    ManagedRocksObjectUtils.loadRocksDBLibrary();
+  }
   private static final ManagedReadOptions DEFAULT_READ_OPTION =
       new ManagedReadOptions();
-
   private static Map<String, List<ColumnFamilyHandle>> dbNameToCfHandleMap =
       new HashMap<>();
 

--- a/hadoop-hdds/managed-rocksdb/src/main/java/org/apache/hadoop/hdds/utils/db/managed/ManagedRocksObjectUtils.java
+++ b/hadoop-hdds/managed-rocksdb/src/main/java/org/apache/hadoop/hdds/utils/db/managed/ManagedRocksObjectUtils.java
@@ -21,6 +21,7 @@ package org.apache.hadoop.hdds.utils.db.managed;
 import org.apache.hadoop.hdds.HddsUtils;
 import org.awaitility.Awaitility;
 import org.awaitility.core.ConditionTimeoutException;
+import org.rocksdb.RocksDB;
 import org.rocksdb.RocksObject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -112,5 +113,14 @@ public final class ManagedRocksObjectUtils {
       throws IOException {
     waitForFileDelete(file, maxDuration, POLL_INTERVAL_DURATION,
         POLL_DELAY_DURATION);
+  }
+
+  /**
+   * Ensures that the RocksDB native library is loaded.
+   * This method should be called before performing any operations
+   * that require the RocksDB native library.
+   */
+  public static void loadRocksDBLibrary() {
+    RocksDB.loadLibrary();
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?
Fix java.lang.UnsatisfiedLinkError: 'long org.rocksdb.ReadOptions.newReadOptions()' 
```bash
> docker exec -it ozone-om-1 bash
bash-4.2$ ozone debug ldb --db=/data/metadata/om.db ls
Exception in thread "main" java.lang.UnsatisfiedLinkError: 'long org.rocksdb.ReadOptions.newReadOptions()'
	at org.rocksdb.ReadOptions.newReadOptions(Native Method)
	at org.rocksdb.ReadOptions.<init>(ReadOptions.java:16)
	at org.apache.hadoop.hdds.utils.db.managed.ManagedReadOptions.<init>(ManagedReadOptions.java:28)
	at org.apache.hadoop.hdds.utils.db.RocksDatabase.<clinit>(RocksDatabase.java:83)
	at org.apache.hadoop.ozone.debug.ListTables.call(ListTables.java:47)
	at org.apache.hadoop.ozone.debug.ListTables.call(ListTables.java:34)
	at picocli.CommandLine.executeUserObject(CommandLine.java:1953)
	at picocli.CommandLine.access$1300(CommandLine.java:145)
	at picocli.CommandLine$RunLast.executeUserObjectOfLastSubcommandWithSameParent(CommandLine.java:2352)
	at picocli.CommandLine$RunLast.handle(CommandLine.java:2346)
	at picocli.CommandLine$RunLast.handle(CommandLine.java:2311)
	at picocli.CommandLine$AbstractParseResultHandler.execute(CommandLine.java:2179)
	at picocli.CommandLine.execute(CommandLine.java:2078)
	at org.apache.hadoop.hdds.cli.GenericCli.execute(GenericCli.java:100)
	at org.apache.hadoop.hdds.cli.GenericCli.run(GenericCli.java:91)
	at org.apache.hadoop.ozone.debug.OzoneDebug.main(OzoneDebug.java:64) 
```

The error `java.lang.UnsatisfiedLinkError: org.rocksdb.ReadOptions.newReadOptions()J` was caused because `ManagedReadOptions()` was statically loaded before the RocksDB native methods were loaded, as introduced in [PR#5304](https://github.com/apache/ozone/pull/5304). This PR adds the logic for static library loading to ensure RocksDB native methods are loaded before `ManagedReadOptions()` is invoked.
## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-9419

## How was this patch tested?
manually Test
