### PR TITLE
HDDS-9424. Add a metric to indicate how many concurrent requests an RPC Server (OM, SCM) is handling

### DIFF
--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/server/OzoneProtocolMessageDispatcher.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/server/OzoneProtocolMessageDispatcher.java
@@ -83,11 +83,15 @@ public class OzoneProtocolMessageDispatcher<REQUEST, RESPONSE, TYPE> {
       }
 
       long startTime = System.currentTimeMillis();
-
-      RESPONSE response = methodCall.apply(request);
-
-      protocolMessageMetrics.increment(type,
-          System.currentTimeMillis() - startTime);
+      protocolMessageMetrics.increaseConcurrency();
+      RESPONSE response;
+      try {
+        response = methodCall.apply(request);
+      } finally {
+        protocolMessageMetrics.increment(type,
+            System.currentTimeMillis() - startTime);
+        protocolMessageMetrics.decreaseConcurrency();
+      }
 
       if (logger.isTraceEnabled()) {
         logger.trace(

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/ProtocolMessageMetrics.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/ProtocolMessageMetrics.java
@@ -78,14 +78,6 @@ public class ProtocolMessageMetrics<KEY> implements MetricsSource {
     };
   }
 
-  public void increaseConcurrency() {
-    concurrency.incrementAndGet();
-  }
-
-  public void decreaseConcurrency() {
-    concurrency.decrementAndGet();
-  }
-
   public void register() {
     DefaultMetricsSystem.instance()
         .register(name, description, this);

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/ProtocolMessageMetrics.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/ProtocolMessageMetrics.java
@@ -100,8 +100,8 @@ public class ProtocolMessageMetrics<KEY> implements MetricsSource {
 
     });
     MetricsRecordBuilder builder = collector.addRecord(name);
-    builder.addCounter(new MetricName("concurrency", "Number of requests processed concurrently"),
-        concurrency.get());
+    builder.addCounter(new MetricName("concurrency",
+            "Number of requests processed concurrently"), concurrency.get());
   }
 
   /**


### PR DESCRIPTION
This metric shows how many threads are really working in an RPC server. 

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-9424

## How was this patch tested?

Tested locally. 