### PR TITLE
HDDS-9425. Breakdown metrics for OM writes

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/util/MetricUtil.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/util/MetricUtil.java
@@ -31,7 +31,7 @@ public final class MetricUtil {
   private MetricUtil() {
   }
 
-  public static <T, E extends IOException> T captureLatencyNs(
+  public static <T, E extends Exception> T captureLatencyNs(
       MutableRate metric,
       CheckedSupplier<T, E> block) throws E {
     long start = Time.monotonicNowNanos();

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OMPerformanceMetrics.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OMPerformanceMetrics.java
@@ -92,6 +92,28 @@ public class OMPerformanceMetrics {
   @Metric(about = "listKeys latency in nanoseconds")
   private MutableRate listKeysLatencyNs;
 
+  @Metric(about = "Validate request latency in nano seconds")
+  private MutableRate validateRequestLatencyNs;
+
+  @Metric(about = "Validate response latency in nano seconds")
+  private MutableRate validateResponseLatencyNs;
+
+  @Metric(about = "PreExecute latency in nano seconds")
+  private MutableRate preExecuteLatencyNs;
+
+  @Metric(about = "Ratis latency in nano seconds")
+  private MutableRate ratisLatencyNs;
+
+  @Metric(about = "Convert om request to ratis request nano seconds")
+  private MutableRate convertRatisRequestLatencyNs;
+
+  @Metric(about = "Convert ratis response to om response nano seconds")
+  private MutableRate convertRatisResponseLatencyNs;
+
+  @Metric(about = "Ratis local command execution latency in nano seconds")
+  private MutableRate ratisLocalExecutionLatencyNs;
+
+
   public void addLookupLatency(long latencyInNs) {
     lookupLatencyNs.add(latencyInNs);
   }
@@ -159,5 +181,33 @@ public class OMPerformanceMetrics {
 
   public void addListKeysLatencyNs(long latencyInNs) {
     listKeysLatencyNs.add(latencyInNs);
+  }
+
+  public MutableRate getValidateRequestLatencyNs() {
+    return validateRequestLatencyNs;
+  }
+
+  public MutableRate getValidateResponseLatencyNs() {
+    return validateResponseLatencyNs;
+  }
+
+  public MutableRate getPreExecuteLatencyNs() {
+    return preExecuteLatencyNs;
+  }
+
+  public MutableRate getRatisLatencyNs() {
+    return ratisLatencyNs;
+  }
+
+  public MutableRate getConvertRatisRequestLatencyNs() {
+    return convertRatisRequestLatencyNs;
+  }
+
+  public MutableRate getConvertRatisResponseLatencyNs() {
+    return convertRatisResponseLatencyNs;
+  }
+
+  public MutableRate getRatisLocalExecutionLatencyNs() {
+    return ratisLocalExecutionLatencyNs;
   }
 }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OMPerformanceMetrics.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OMPerformanceMetrics.java
@@ -102,13 +102,13 @@ public class OMPerformanceMetrics {
   private MutableRate preExecuteLatencyNs;
 
   @Metric(about = "Ratis latency in nano seconds")
-  private MutableRate ratisLatencyNs;
+  private MutableRate submitToRatisLatencyNs;
 
   @Metric(about = "Convert om request to ratis request nano seconds")
-  private MutableRate convertRatisRequestLatencyNs;
+  private MutableRate createRatisRequestLatencyNs;
 
   @Metric(about = "Convert ratis response to om response nano seconds")
-  private MutableRate convertRatisResponseLatencyNs;
+  private MutableRate createOmResoonseLatencyNs;
 
   @Metric(about = "Ratis local command execution latency in nano seconds")
   private MutableRate ratisLocalExecutionLatencyNs;
@@ -195,16 +195,16 @@ public class OMPerformanceMetrics {
     return preExecuteLatencyNs;
   }
 
-  public MutableRate getRatisLatencyNs() {
-    return ratisLatencyNs;
+  public MutableRate getSubmitToRatisLatencyNs() {
+    return submitToRatisLatencyNs;
   }
 
-  public MutableRate getConvertRatisRequestLatencyNs() {
-    return convertRatisRequestLatencyNs;
+  public MutableRate getCreateRatisRequestLatencyNs() {
+    return createRatisRequestLatencyNs;
   }
 
-  public MutableRate getConvertRatisResponseLatencyNs() {
-    return convertRatisResponseLatencyNs;
+  public MutableRate getCreateOmResponseLatencyNs() {
+    return createOmResoonseLatencyNs;
   }
 
   public MutableRate getRatisLocalExecutionLatencyNs() {

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OMPerformanceMetrics.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OMPerformanceMetrics.java
@@ -111,7 +111,7 @@ public class OMPerformanceMetrics {
   private MutableRate createOmResoonseLatencyNs;
 
   @Metric(about = "Ratis local command execution latency in nano seconds")
-  private MutableRate ratisLocalExecutionLatencyNs;
+  private MutableRate validateAndUpdateCacneLatencyNs;
 
 
   public void addLookupLatency(long latencyInNs) {
@@ -207,7 +207,7 @@ public class OMPerformanceMetrics {
     return createOmResoonseLatencyNs;
   }
 
-  public MutableRate getRatisLocalExecutionLatencyNs() {
-    return ratisLocalExecutionLatencyNs;
+  public MutableRate getValidateAndUpdateCacneLatencyNs() {
+    return validateAndUpdateCacneLatencyNs;
   }
 }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/OzoneManagerRatisServer.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/OzoneManagerRatisServer.java
@@ -454,8 +454,8 @@ public final class OzoneManagerRatisServer {
    * @return OMResponse - response which is returned to client.
    * @throws ServiceException
    */
-  private OMResponse createOmResponse(OMRequest omRequest, RaftClientReply reply)
-      throws ServiceException {
+  private OMResponse createOmResponse(OMRequest omRequest,
+      RaftClientReply reply) throws ServiceException {
     // NotLeader exception is thrown only when the raft server to which the
     // request is submitted is not the leader. This can happen first time
     // when client is submitting request to OM.

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/OzoneManagerRatisServer.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/OzoneManagerRatisServer.java
@@ -302,7 +302,7 @@ public final class OzoneManagerRatisServer {
   public OMResponse submitRequest(OMRequest omRequest,
       RaftClientRequest raftClientRequest) throws ServiceException {
     RaftClientReply raftClientReply =
-        submitRequestToRatisImpl(raftClientRequest);
+        submitRequestToRatis(raftClientRequest);
     return createOmResponse(omRequest, raftClientReply);
   }
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/OzoneManagerRatisServer.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/OzoneManagerRatisServer.java
@@ -301,8 +301,9 @@ public final class OzoneManagerRatisServer {
    */
   public OMResponse submitRequest(OMRequest omRequest,
       RaftClientRequest raftClientRequest) throws ServiceException {
-    RaftClientReply raftClientReply = submitRequestToRatisImpl(raftClientRequest);
-    return createOmResponseImpl(omRequest, raftClientReply);
+    RaftClientReply raftClientReply =
+        submitRequestToRatisImpl(raftClientRequest);
+    return createOmResponse(omRequest, raftClientReply);
   }
 
   private RaftClientReply submitRequestToRatisImpl(

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/protocolPB/OzoneManagerProtocolServerSideTranslatorPB.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/protocolPB/OzoneManagerProtocolServerSideTranslatorPB.java
@@ -197,8 +197,7 @@ public class OzoneManagerProtocolServerSideTranslatorPB implements
         //  Added the assertion.
         assert (omClientRequest != null);
         OMClientRequest finalOmClientRequest = omClientRequest;
-        requestToSubmit = captureLatencyNs(perfMetrics.getPreExecuteLatencyNs(),
-            () -> finalOmClientRequest.preExecute(ozoneManager));
+        requestToSubmit = preExecute(finalOmClientRequest);
       } catch (IOException ex) {
         if (omClientRequest != null) {
           omClientRequest.handleRequestFailure(ozoneManager);
@@ -214,6 +213,12 @@ public class OzoneManagerProtocolServerSideTranslatorPB implements
     } finally {
       OzoneManager.setS3Auth(null);
     }
+  }
+
+  private OMRequest preExecute(OMClientRequest finalOmClientRequest)
+      throws IOException {
+    return captureLatencyNs(perfMetrics.getPreExecuteLatencyNs(),
+        () -> finalOmClientRequest.preExecute(ozoneManager));
   }
 
   /**

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/protocolPB/OzoneManagerProtocolServerSideTranslatorPB.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/protocolPB/OzoneManagerProtocolServerSideTranslatorPB.java
@@ -20,6 +20,7 @@ import static org.apache.hadoop.ozone.om.ratis.OzoneManagerRatisServer.RaftServe
 import static org.apache.hadoop.ozone.om.ratis.OzoneManagerRatisServer.RaftServerStatus.NOT_LEADER;
 import static org.apache.hadoop.ozone.om.ratis.utils.OzoneManagerRatisUtils.createClientRequest;
 import static org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.Type.PrepareStatus;
+import static org.apache.hadoop.util.MetricUtil.captureLatencyNs;
 
 import java.io.IOException;
 import java.util.concurrent.ExecutionException;
@@ -30,6 +31,7 @@ import org.apache.hadoop.hdds.server.OzoneProtocolMessageDispatcher;
 import org.apache.hadoop.hdds.tracing.TracingUtil;
 import org.apache.hadoop.hdds.utils.ProtocolMessageMetrics;
 import org.apache.hadoop.ozone.OmUtils;
+import org.apache.hadoop.ozone.om.OMPerformanceMetrics;
 import org.apache.hadoop.ozone.om.OzoneManager;
 import org.apache.hadoop.ozone.om.exceptions.OMException;
 import org.apache.hadoop.ozone.om.exceptions.OMLeaderNotReadyException;
@@ -76,6 +78,7 @@ public class OzoneManagerProtocolServerSideTranslatorPB implements
   private final OzoneProtocolMessageDispatcher<OMRequest, OMResponse,
       ProtocolMessageEnum> dispatcher;
   private final RequestValidations requestValidations;
+  private final OMPerformanceMetrics perfMetrics;
 
   /**
    * Constructs an instance of the server handler.
@@ -89,6 +92,7 @@ public class OzoneManagerProtocolServerSideTranslatorPB implements
       boolean enableRatis,
       long lastTransactionIndexForNonRatis) {
     this.ozoneManager = impl;
+    this.perfMetrics = impl.getPerfMetrics();
     this.isRatisEnabled = enableRatis;
     // Update the transactionIndex with the last TransactionIndex read from DB.
     // New requests should have transactionIndex incremented from this index
@@ -137,7 +141,9 @@ public class OzoneManagerProtocolServerSideTranslatorPB implements
       OMRequest request) throws ServiceException {
     OMRequest validatedRequest;
     try {
-      validatedRequest = requestValidations.validateRequest(request);
+      validatedRequest = captureLatencyNs(
+          perfMetrics.getValidateRequestLatencyNs(),
+          () -> requestValidations.validateRequest(request));
     } catch (Exception e) {
       if (e instanceof OMException) {
         return createErrorResponse(request, (OMException) e);
@@ -146,16 +152,14 @@ public class OzoneManagerProtocolServerSideTranslatorPB implements
     }
 
     OMResponse response = dispatcher.processRequest(validatedRequest,
-        this::processRequest,
-        request.getCmdType(),
-        request.getTraceID());
+        this::processRequest, request.getCmdType(), request.getTraceID());
 
-    return requestValidations.validateResponse(request, response);
+    return captureLatencyNs(perfMetrics.getValidateResponseLatencyNs(),
+        () -> requestValidations.validateResponse(request, response));
   }
 
   @VisibleForTesting
   public OMResponse processRequest(OMRequest request) throws ServiceException {
-    OMClientRequest omClientRequest = null;
     boolean s3Auth = false;
 
     try {
@@ -184,13 +188,17 @@ public class OzoneManagerProtocolServerSideTranslatorPB implements
       if (!s3Auth) {
         OzoneManagerRatisUtils.checkLeaderStatus(ozoneManager);
       }
+      OMClientRequest omClientRequest = null;
+      OMRequest requestToSubmit;
       try {
         omClientRequest = createClientRequest(request, ozoneManager);
         // TODO: Note: Due to HDDS-6055, createClientRequest() could now
         //  return null, which triggered the findbugs warning.
         //  Added the assertion.
         assert (omClientRequest != null);
-        request = omClientRequest.preExecute(ozoneManager);
+        OMClientRequest finalOmClientRequest = omClientRequest;
+        requestToSubmit = captureLatencyNs(perfMetrics.getPreExecuteLatencyNs(),
+            () -> finalOmClientRequest.preExecute(ozoneManager));
       } catch (IOException ex) {
         if (omClientRequest != null) {
           omClientRequest.handleRequestFailure(ozoneManager);
@@ -198,7 +206,7 @@ public class OzoneManagerProtocolServerSideTranslatorPB implements
         return createErrorResponse(request, ex);
       }
 
-      OMResponse response = submitRequestToRatis(request);
+      OMResponse response = submitRequestToRatis(requestToSubmit);
       if (!response.getSuccess()) {
         omClientRequest.handleRequestFailure(ozoneManager);
       }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/protocolPB/OzoneManagerRequestHandler.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/protocolPB/OzoneManagerRequestHandler.java
@@ -378,7 +378,7 @@ public class OzoneManagerRequestHandler implements RequestHandler {
     OMClientRequest omClientRequest =
         OzoneManagerRatisUtils.createClientRequest(omRequest, impl);
     return captureLatencyNs(
-        impl.getPerfMetrics().getRatisLocalExecutionLatencyNs(),
+        impl.getPerfMetrics().getValidateAndUpdateCacneLatencyNs(),
         () -> omClientRequest.validateAndUpdateCache(getOzoneManager(),
             transactionLogIndex, ozoneManagerDoubleBuffer::add));
   }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/protocolPB/OzoneManagerRequestHandler.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/protocolPB/OzoneManagerRequestHandler.java
@@ -151,6 +151,7 @@ import static org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.
 import static org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.MultipartUploadInfo;
 import static org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OzoneAclInfo;
 import static org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.PartInfo;
+import static org.apache.hadoop.util.MetricUtil.captureLatencyNs;
 
 import org.apache.hadoop.ozone.upgrade.UpgradeFinalizer.StatusAndMessages;
 import org.apache.hadoop.util.ProtobufUtils;
@@ -374,14 +375,12 @@ public class OzoneManagerRequestHandler implements RequestHandler {
   @Override
   public OMClientResponse handleWriteRequest(OMRequest omRequest,
       long transactionLogIndex) throws IOException {
-    OMClientRequest omClientRequest = null;
-    OMClientResponse omClientResponse = null;
-    omClientRequest =
+    OMClientRequest omClientRequest =
         OzoneManagerRatisUtils.createClientRequest(omRequest, impl);
-    omClientResponse = omClientRequest
-        .validateAndUpdateCache(getOzoneManager(), transactionLogIndex,
-            ozoneManagerDoubleBuffer::add);
-    return omClientResponse;
+    return captureLatencyNs(
+        impl.getPerfMetrics().getRatisLocalExecutionLatencyNs(),
+        () -> omClientRequest.validateAndUpdateCache(getOzoneManager(),
+            transactionLogIndex, ozoneManagerDoubleBuffer::add));
   }
 
   @Override


### PR DESCRIPTION
## What changes were proposed in this pull request?

These added metrics expose the details of where write operators spend time one.

- On RPC server:
  - Request validation
  - PreExecute
  - Convert OM request to Ratis format
  - Ratis invocation
  - Convert ratis response to OM response.
- On ratis execution:
  - applyTransaction local latency.  


## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-9425

## How was this patch tested?

Local test.