### PR TITLE
HDDS-9229. Fix S3A compatibility - dfs -put for FSO bucket.

### DIFF
--- a/hadoop-ozone/dist/src/main/smoketest/s3/objectcopys3a.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/s3/objectcopys3a.robot
@@ -1,0 +1,49 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+*** Settings ***
+Documentation       S3 gateway test with aws cli
+Library             OperatingSystem
+Library             String
+Resource            ../commonlib.robot
+Resource            commonawslib.robot
+Test Timeout        5 minutes
+Suite Setup         Setup s3 tests
+
+*** Variables ***
+${ENDPOINT_URL}       http://s3g:9878
+${BUCKET}             generated
+
+*** Test Cases ***
+Put object s3a simulation
+                        Execute                    echo "Randomtext" > /tmp/testfile
+    ${result} =         Execute AWSS3APICli and checkrc    head-object --bucket ${BUCKET} --key ${PREFIX}/word.txt    255
+    ${result} =         Execute AWSS3ApiCli        list-objects --bucket ${BUCKET} --prefix ${PREFIX}/word.txt/
+                        Should Not contain         ${result}   word.txt
+
+    ${result} =         Execute AWSS3APICli and checkrc    head-object --bucket ${BUCKET} --key ${PREFIX}/word.txt._COPYING_    255
+    ${result} =         Execute AWSS3ApiCli        list-objects --bucket ${BUCKET} --prefix ${PREFIX}/word.txt._COPYING_/
+                        Should Not contain         ${result}  word.txt._COPYING_
+
+    ${result} =         Execute AWSS3ApiCli        put-object --bucket ${BUCKET} --key ${PREFIX}/word.txt._COPYING_ --body /tmp/testfile
+                        Execute AWSS3APICli and checkrc    head-object --bucket ${BUCKET} --key ${PREFIX}/word.txt._COPYING_    0
+                        Execute AWSS3APICli and checkrc    head-object --bucket ${BUCKET} --key ${PREFIX}/word.txt    255
+    ${result} =         Execute AWSS3ApiCli        list-objects --bucket ${BUCKET} --prefix ${PREFIX}/word.txt/
+                        Should Not contain         ${result}  word.txt._COPYING_
+
+    ${result} =         Execute AWSS3ApiCli        copy-object --bucket ${BUCKET} --key ${PREFIX}/word.txt --copy-source ${BUCKET}/${PREFIX}/word.txt._COPYING_
+                        Execute AWSS3APICli and checkrc    head-object --bucket ${BUCKET} --key ${PREFIX}/word.txt    0
+                        Execute AWSS3APICli        delete-object --bucket ${BUCKET} --key ${PREFIX}/word.txt._COPYING_
+                        Execute AWSS3APICli and checkrc    head-object --bucket ${BUCKET} --key ${PREFIX}/word.txt._COPYING_    255

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/BucketEndpoint.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/BucketEndpoint.java
@@ -209,7 +209,7 @@ public class BucketEndpoint extends EndpointBase {
       OzoneKey next = ozoneKeyIterator.next();
       if (bucket.getBucketLayout().isFileSystemOptimized() &&
           StringUtils.isNotEmpty(prefix) &&
-          !next.getName().contains(prefix)) {
+          !next.getName().startsWith(prefix)) {
         // prefix has delimiter but key don't have
         // example prefix: dir1/ key: dir123
         continue;

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/BucketEndpoint.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/BucketEndpoint.java
@@ -118,7 +118,7 @@ public class BucketEndpoint extends EndpointBase {
     Iterator<? extends OzoneKey> ozoneKeyIterator;
     ContinueToken decodedToken =
         ContinueToken.decodeFromString(continueToken);
-    OzoneBucket bucket = getBucket(bucketName);
+    OzoneBucket bucket;
 
     try {
       if (aclMarker != null) {
@@ -154,6 +154,7 @@ public class BucketEndpoint extends EndpointBase {
       boolean shallow = listKeysShallowEnabled
           && OZONE_URI_DELIMITER.equals(delimiter);
 
+      bucket = getBucket(bucketName);
       ozoneKeyIterator = bucket.listKeys(prefix, prevKey, shallow);
 
     } catch (OMException ex) {
@@ -207,6 +208,7 @@ public class BucketEndpoint extends EndpointBase {
     while (ozoneKeyIterator.hasNext()) {
       OzoneKey next = ozoneKeyIterator.next();
       if (bucket.getBucketLayout().isFileSystemOptimized() &&
+          StringUtils.isNotEmpty(prefix) &&
           !prefix.contains(next.getName())) {
         // prefix has delimiter but key don't have
         // example prefix: dir1/ key: dir123

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/BucketEndpoint.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/BucketEndpoint.java
@@ -209,7 +209,7 @@ public class BucketEndpoint extends EndpointBase {
       OzoneKey next = ozoneKeyIterator.next();
       if (bucket.getBucketLayout().isFileSystemOptimized() &&
           StringUtils.isNotEmpty(prefix) &&
-          !prefix.contains(next.getName())) {
+          !next.getName().contains(prefix)) {
         // prefix has delimiter but key don't have
         // example prefix: dir1/ key: dir123
         continue;


### PR DESCRIPTION
## What changes were proposed in this pull request?

`BucketEndPoint` returns keys without considering `"/" ` for FSO bucket, So it matches `dir1/` with `dir123` also, and return back the result. Because of this it leads to incorrect behaviour for FSO bucket keys.
 To fix this issue in this PR we are ensuring exact prefix match so that for FSO bucket result from `BucketEndPoint` is proper.


## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-9229

## How was this patch tested?

Manually tested using dfs s3a for FSO bucket.
