### PR TITLE
HDDS-9427. Robot test for JSON output option in Pipeline list subcommand

### DIFF
--- a/hadoop-ozone/dist/src/main/smoketest/admincli/pipeline.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/admincli/pipeline.robot
@@ -41,7 +41,6 @@ List pipeline with json option
 
     Should be true      $output
 
-
 List pipelines with explicit host
     ${output} =         Execute          ozone admin pipeline list --scm ${SCM}
                         Should contain   ${output}   STANDALONE/ONE

--- a/hadoop-ozone/dist/src/main/smoketest/admincli/pipeline.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/admincli/pipeline.robot
@@ -36,9 +36,20 @@ List pipelines
     ${output} =         Execute          ozone admin pipeline list
                         Should contain   ${output}   STANDALONE/ONE
 
+List pipeline with json option
+    ${output} =         Execute          ozone admin pipeline list --json | jq 'map(.replicationConfig) | contains([{"replicationFactor": "ONE", "replicationType": "STANDALONE"}])'
+
+    Should be true      $output
+
+
 List pipelines with explicit host
     ${output} =         Execute          ozone admin pipeline list --scm ${SCM}
                         Should contain   ${output}   STANDALONE/ONE
+
+List pipelines with explicit host and json option
+    ${output} =         Execute   ozone admin pipeline list --scm ${SCM} --json | jq 'map(.replicationConfig) | contains([{"replicationFactor": "ONE", "replicationType": "STANDALONE"}])'
+
+    Should be true      $output
 
 Deactivate pipeline
                         Execute          ozone admin pipeline deactivate "${PIPELINE}"


### PR DESCRIPTION
## What changes were proposed in this pull request?

Add robot test for pipeline list subcommands json output i.e.
`ozone admin pipeline list --json `

## What is the link to the Apache JIRA
[HDDS-9427](https://issues.apache.org/jira/browse/HDDS-9427)

## How was this patch tested?
Added a robot test.

Result:

```
==============================================================================
Create pipeline                                                       | PASS |
------------------------------------------------------------------------------
List pipelines                                                        | PASS |
------------------------------------------------------------------------------
List pipeline with json option                                        | PASS |
------------------------------------------------------------------------------
List pipelines with explicit host                                     | PASS |
------------------------------------------------------------------------------
List pipelines with explicit host and json option                     | PASS |
------------------------------------------------------------------------------
Deactivate pipeline                                                   | PASS |
------------------------------------------------------------------------------
Activate pipeline                                                     | PASS |
------------------------------------------------------------------------------
Close pipeline                                                        | PASS |
------------------------------------------------------------------------------
Incomplete command                                                    | PASS |
------------------------------------------------------------------------------
Pipeline :: Test ozone admin pipeline command                         | PASS |
9 tests, 9 passed, 0 failed
==============================================================================
```

