### PR TITLE
HDDS-9297. getKeyInfo re-read bucket/volume info multiple times

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestOzoneRpcClientAbstract.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestOzoneRpcClientAbstract.java
@@ -3783,7 +3783,7 @@ public abstract class TestOzoneRpcClientAbstract {
         .setKeyName(keyName)
         .build();
     OmKeyInfo omKeyInfo = ozoneManager.getKeyManager().getKeyInfo(keyArgs,
-        UUID.randomUUID().toString());
+        BucketLayout.DEFAULT, UUID.randomUUID().toString());
 
     OmKeyLocationInfoGroup latestVersionLocations =
         omKeyInfo.getLatestVersionLocations();

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestOzoneRpcClientAbstract.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestOzoneRpcClientAbstract.java
@@ -3783,7 +3783,7 @@ public abstract class TestOzoneRpcClientAbstract {
         .setKeyName(keyName)
         .build();
     OmKeyInfo omKeyInfo = ozoneManager.getKeyManager().getKeyInfo(keyArgs,
-        BucketLayout.DEFAULT, UUID.randomUUID().toString());
+        bucket.getBucketLayout(), UUID.randomUUID().toString());
 
     OmKeyLocationInfoGroup latestVersionLocations =
         omKeyInfo.getLatestVersionLocations();

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestOzoneRpcClientAbstract.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestOzoneRpcClientAbstract.java
@@ -96,6 +96,7 @@ import org.apache.hadoop.ozone.om.OMConfigKeys;
 import org.apache.hadoop.ozone.om.OMMetadataManager;
 import org.apache.hadoop.ozone.om.OmFailoverProxyUtil;
 import org.apache.hadoop.ozone.om.OzoneManager;
+import org.apache.hadoop.ozone.om.ResolvedBucket;
 import org.apache.hadoop.ozone.om.exceptions.OMException;
 import org.apache.hadoop.ozone.om.exceptions.OMException.ResultCodes;
 import org.apache.hadoop.ozone.om.ha.HadoopRpcOMFailoverProxyProvider;
@@ -3782,8 +3783,12 @@ public abstract class TestOzoneRpcClientAbstract {
         .setBucketName(bucket.getName())
         .setKeyName(keyName)
         .build();
+    ResolvedBucket resolvedBucket = new ResolvedBucket(
+        bucket.getVolumeName(), bucket.getName(),
+        bucket.getVolumeName(), bucket.getName(),
+        "", bucket.getBucketLayout());
     OmKeyInfo omKeyInfo = ozoneManager.getKeyManager().getKeyInfo(keyArgs,
-        bucket.getBucketLayout(), UUID.randomUUID().toString());
+        resolvedBucket, UUID.randomUUID().toString());
 
     OmKeyLocationInfoGroup latestVersionLocations =
         omKeyInfo.getLatestVersionLocations();

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestKeyManagerImpl.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestKeyManagerImpl.java
@@ -829,17 +829,20 @@ public class TestKeyManagerImpl {
     assertNotEquals(follower1, follower2);
 
     // lookup key, leader as client
-    OmKeyInfo key1 = keyManager.lookupKey(keyArgs, BucketLayout.DEFAULT, leader.getIpAddress());
+    OmKeyInfo key1 = keyManager.lookupKey(keyArgs, BucketLayout.DEFAULT,
+        leader.getIpAddress());
     assertEquals(leader, key1.getLatestVersionLocations()
         .getLocationList().get(0).getPipeline().getClosestNode());
 
     // lookup key, follower1 as client
-    OmKeyInfo key2 = keyManager.lookupKey(keyArgs, BucketLayout.DEFAULT, follower1.getIpAddress());
+    OmKeyInfo key2 = keyManager.lookupKey(keyArgs, BucketLayout.DEFAULT,
+        follower1.getIpAddress());
     assertEquals(follower1, key2.getLatestVersionLocations()
         .getLocationList().get(0).getPipeline().getClosestNode());
 
     // lookup key, follower2 as client
-    OmKeyInfo key3 = keyManager.lookupKey(keyArgs, BucketLayout.DEFAULT, follower2.getIpAddress());
+    OmKeyInfo key3 = keyManager.lookupKey(keyArgs, BucketLayout.DEFAULT,
+        follower2.getIpAddress());
     assertEquals(follower2, key3.getLatestVersionLocations()
         .getLocationList().get(0).getPipeline().getClosestNode());
 
@@ -860,7 +863,7 @@ public class TestKeyManagerImpl {
 
     // lookup for a non-existent key
     try {
-      keyManager.lookupKey(keyArgs, BucketLayout.DEFAULT,null);
+      keyManager.lookupKey(keyArgs, BucketLayout.DEFAULT, null);
       fail("Lookup key should fail for non existent key");
     } catch (OMException ex) {
       if (ex.getResult() != OMException.ResultCodes.KEY_NOT_FOUND) {

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestKeyManagerImpl.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestKeyManagerImpl.java
@@ -115,6 +115,7 @@ import static org.apache.hadoop.ozone.om.exceptions.OMException.ResultCodes.SCM_
 import static org.apache.hadoop.ozone.security.acl.IAccessAuthorizer.ACLType.ALL;
 
 import org.apache.ratis.util.ExitUtils;
+import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
@@ -770,10 +771,9 @@ public class TestKeyManagerImpl {
         .setKeyName(keyName)
         .setSortDatanodesInPipeline(true)
         .build();
-
     // lookup for a non-existent key
     try {
-      keyManager.lookupKey(keyArgs, BucketLayout.DEFAULT, null);
+      keyManager.lookupKey(keyArgs, resolvedBucket(), null);
       fail("Lookup key should fail for non existent key");
     } catch (OMException ex) {
       if (ex.getResult() != OMException.ResultCodes.KEY_NOT_FOUND) {
@@ -815,7 +815,7 @@ public class TestKeyManagerImpl {
     when(mockScmContainerClient.getContainerWithPipelineBatch(
         Arrays.asList(containerID))).thenReturn(containerWithPipelines);
 
-    OmKeyInfo key = keyManager.lookupKey(keyArgs, BucketLayout.DEFAULT, null);
+    OmKeyInfo key = keyManager.lookupKey(keyArgs, resolvedBucket(), null);
     assertEquals(key.getKeyName(), keyName);
     List<OmKeyLocationInfo> keyLocations =
         key.getLatestVersionLocations().getLocationList();
@@ -829,28 +829,34 @@ public class TestKeyManagerImpl {
     assertNotEquals(follower1, follower2);
 
     // lookup key, leader as client
-    OmKeyInfo key1 = keyManager.lookupKey(keyArgs, BucketLayout.DEFAULT,
+    OmKeyInfo key1 = keyManager.lookupKey(keyArgs, resolvedBucket(),
         leader.getIpAddress());
     assertEquals(leader, key1.getLatestVersionLocations()
         .getLocationList().get(0).getPipeline().getClosestNode());
 
     // lookup key, follower1 as client
-    OmKeyInfo key2 = keyManager.lookupKey(keyArgs, BucketLayout.DEFAULT,
+    OmKeyInfo key2 = keyManager.lookupKey(keyArgs, resolvedBucket(),
         follower1.getIpAddress());
     assertEquals(follower1, key2.getLatestVersionLocations()
         .getLocationList().get(0).getPipeline().getClosestNode());
 
     // lookup key, follower2 as client
-    OmKeyInfo key3 = keyManager.lookupKey(keyArgs, BucketLayout.DEFAULT,
+    OmKeyInfo key3 = keyManager.lookupKey(keyArgs, resolvedBucket(),
         follower2.getIpAddress());
     assertEquals(follower2, key3.getLatestVersionLocations()
         .getLocationList().get(0).getPipeline().getClosestNode());
 
     // lookup key, random node as client
-    OmKeyInfo key4 = keyManager.lookupKey(keyArgs, BucketLayout.DEFAULT,
+    OmKeyInfo key4 = keyManager.lookupKey(keyArgs, resolvedBucket(),
         "/d=default-drack/127.0.0.1");
     assertEquals(leader, key4.getLatestVersionLocations()
         .getLocationList().get(0).getPipeline().getClosestNode());
+  }
+
+  @NotNull
+  private ResolvedBucket resolvedBucket() {
+    ResolvedBucket bucket = new ResolvedBucket(VOLUME_NAME, BUCKET_NAME, VOLUME_NAME, BUCKET_NAME, "", BucketLayout.DEFAULT);
+    return bucket;
   }
 
   @Test
@@ -863,7 +869,7 @@ public class TestKeyManagerImpl {
 
     // lookup for a non-existent key
     try {
-      keyManager.lookupKey(keyArgs, BucketLayout.DEFAULT, null);
+      keyManager.lookupKey(keyArgs, resolvedBucket(), null);
       fail("Lookup key should fail for non existent key");
     } catch (OMException ex) {
       if (ex.getResult() != OMException.ResultCodes.KEY_NOT_FOUND) {
@@ -905,14 +911,14 @@ public class TestKeyManagerImpl {
     when(mockScmContainerClient.getContainerWithPipelineBatch(
         Arrays.asList(1L))).thenReturn(containerWithPipelines);
 
-    OmKeyInfo key = keyManager.lookupKey(keyArgs, BucketLayout.DEFAULT, null);
+    OmKeyInfo key = keyManager.lookupKey(keyArgs, resolvedBucket(), null);
     assertEquals(key.getKeyLocationVersions().size(), 1);
 
     keySession = writeClient.createFile(keyArgs, true, true);
     writeClient.commitKey(keyArgs, keySession.getId());
 
     // Test lookupKey (latestLocationVersion == true)
-    key = keyManager.lookupKey(keyArgs, BucketLayout.DEFAULT, null);
+    key = keyManager.lookupKey(keyArgs, resolvedBucket(), null);
     assertEquals(key.getKeyLocationVersions().size(), 1);
 
     // Test ListStatus (latestLocationVersion == true)
@@ -937,7 +943,7 @@ public class TestKeyManagerImpl {
         .build();
 
     // Test lookupKey (latestLocationVersion == false)
-    key = keyManager.lookupKey(keyArgs, BucketLayout.DEFAULT, null);
+    key = keyManager.lookupKey(keyArgs, resolvedBucket(), null);
     assertEquals(key.getKeyLocationVersions().size(), 2);
 
     // Test ListStatus (latestLocationVersion == false)

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestKeyManagerImpl.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestKeyManagerImpl.java
@@ -773,7 +773,7 @@ public class TestKeyManagerImpl {
 
     // lookup for a non-existent key
     try {
-      keyManager.lookupKey(keyArgs, null);
+      keyManager.lookupKey(keyArgs, BucketLayout.DEFAULT, null);
       fail("Lookup key should fail for non existent key");
     } catch (OMException ex) {
       if (ex.getResult() != OMException.ResultCodes.KEY_NOT_FOUND) {
@@ -815,7 +815,7 @@ public class TestKeyManagerImpl {
     when(mockScmContainerClient.getContainerWithPipelineBatch(
         Arrays.asList(containerID))).thenReturn(containerWithPipelines);
 
-    OmKeyInfo key = keyManager.lookupKey(keyArgs, null);
+    OmKeyInfo key = keyManager.lookupKey(keyArgs, BucketLayout.DEFAULT, null);
     assertEquals(key.getKeyName(), keyName);
     List<OmKeyLocationInfo> keyLocations =
         key.getLatestVersionLocations().getLocationList();
@@ -829,22 +829,22 @@ public class TestKeyManagerImpl {
     assertNotEquals(follower1, follower2);
 
     // lookup key, leader as client
-    OmKeyInfo key1 = keyManager.lookupKey(keyArgs, leader.getIpAddress());
+    OmKeyInfo key1 = keyManager.lookupKey(keyArgs, BucketLayout.DEFAULT, leader.getIpAddress());
     assertEquals(leader, key1.getLatestVersionLocations()
         .getLocationList().get(0).getPipeline().getClosestNode());
 
     // lookup key, follower1 as client
-    OmKeyInfo key2 = keyManager.lookupKey(keyArgs, follower1.getIpAddress());
+    OmKeyInfo key2 = keyManager.lookupKey(keyArgs, BucketLayout.DEFAULT, follower1.getIpAddress());
     assertEquals(follower1, key2.getLatestVersionLocations()
         .getLocationList().get(0).getPipeline().getClosestNode());
 
     // lookup key, follower2 as client
-    OmKeyInfo key3 = keyManager.lookupKey(keyArgs, follower2.getIpAddress());
+    OmKeyInfo key3 = keyManager.lookupKey(keyArgs, BucketLayout.DEFAULT, follower2.getIpAddress());
     assertEquals(follower2, key3.getLatestVersionLocations()
         .getLocationList().get(0).getPipeline().getClosestNode());
 
     // lookup key, random node as client
-    OmKeyInfo key4 = keyManager.lookupKey(keyArgs,
+    OmKeyInfo key4 = keyManager.lookupKey(keyArgs, BucketLayout.DEFAULT,
         "/d=default-drack/127.0.0.1");
     assertEquals(leader, key4.getLatestVersionLocations()
         .getLocationList().get(0).getPipeline().getClosestNode());
@@ -860,7 +860,7 @@ public class TestKeyManagerImpl {
 
     // lookup for a non-existent key
     try {
-      keyManager.lookupKey(keyArgs, null);
+      keyManager.lookupKey(keyArgs, BucketLayout.DEFAULT,null);
       fail("Lookup key should fail for non existent key");
     } catch (OMException ex) {
       if (ex.getResult() != OMException.ResultCodes.KEY_NOT_FOUND) {
@@ -902,14 +902,14 @@ public class TestKeyManagerImpl {
     when(mockScmContainerClient.getContainerWithPipelineBatch(
         Arrays.asList(1L))).thenReturn(containerWithPipelines);
 
-    OmKeyInfo key = keyManager.lookupKey(keyArgs, null);
+    OmKeyInfo key = keyManager.lookupKey(keyArgs, BucketLayout.DEFAULT, null);
     assertEquals(key.getKeyLocationVersions().size(), 1);
 
     keySession = writeClient.createFile(keyArgs, true, true);
     writeClient.commitKey(keyArgs, keySession.getId());
 
     // Test lookupKey (latestLocationVersion == true)
-    key = keyManager.lookupKey(keyArgs, null);
+    key = keyManager.lookupKey(keyArgs, BucketLayout.DEFAULT, null);
     assertEquals(key.getKeyLocationVersions().size(), 1);
 
     // Test ListStatus (latestLocationVersion == true)
@@ -934,7 +934,7 @@ public class TestKeyManagerImpl {
         .build();
 
     // Test lookupKey (latestLocationVersion == false)
-    key = keyManager.lookupKey(keyArgs, null);
+    key = keyManager.lookupKey(keyArgs, BucketLayout.DEFAULT, null);
     assertEquals(key.getKeyLocationVersions().size(), 2);
 
     // Test ListStatus (latestLocationVersion == false)

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestKeyManagerImpl.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestKeyManagerImpl.java
@@ -855,7 +855,8 @@ public class TestKeyManagerImpl {
 
   @NotNull
   private ResolvedBucket resolvedBucket() {
-    ResolvedBucket bucket = new ResolvedBucket(VOLUME_NAME, BUCKET_NAME, VOLUME_NAME, BUCKET_NAME, "", BucketLayout.DEFAULT);
+    ResolvedBucket bucket = new ResolvedBucket(VOLUME_NAME, BUCKET_NAME,
+        VOLUME_NAME, BUCKET_NAME, "", BucketLayout.DEFAULT);
     return bucket;
   }
 

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOmMetrics.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOmMetrics.java
@@ -343,7 +343,7 @@ public class TestOmMetrics {
     assertCounter("NumBlockAllocationFails", 1L, omMetrics);
 
     // inject exception to test for Failure Metrics on the read path
-    Mockito.doThrow(exception).when(mockKm).lookupKey(any(), any());
+    Mockito.doThrow(exception).when(mockKm).lookupKey(any(), any(), any());
     Mockito.doThrow(exception).when(mockKm).listKeys(
         any(), any(), any(), any(), anyInt());
     Mockito.doThrow(exception).when(mockKm).listTrash(

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOmSnapshot.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOmSnapshot.java
@@ -640,7 +640,7 @@ public class TestOmSnapshot {
                                  String key) throws IOException {
     return cluster.getOzoneManager().getKeyManager()
             .getKeyInfo(new OmKeyArgs.Builder().setVolumeName(volume)
-            .setBucketName(bucket).setKeyName(key).build(), null);
+            .setBucketName(bucket).setKeyName(key).build(), BucketLayout.DEFAULT, null);
   }
 
   /**

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOmSnapshot.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOmSnapshot.java
@@ -639,8 +639,11 @@ public class TestOmSnapshot {
   private OmKeyInfo getOmKeyInfo(String volume, String bucket,
                                  String key) throws IOException {
     return cluster.getOzoneManager().getKeyManager()
-            .getKeyInfo(new OmKeyArgs.Builder().setVolumeName(volume)
-            .setBucketName(bucket).setKeyName(key).build(), BucketLayout.DEFAULT, null);
+            .getKeyInfo(new OmKeyArgs.Builder()
+                .setVolumeName(volume)
+                .setBucketName(bucket)
+                .setKeyName(key).build(),
+                BucketLayout.DEFAULT, null);
   }
 
   /**

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOmSnapshot.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOmSnapshot.java
@@ -638,12 +638,14 @@ public class TestOmSnapshot {
 
   private OmKeyInfo getOmKeyInfo(String volume, String bucket,
                                  String key) throws IOException {
+    ResolvedBucket resolvedBucket = new ResolvedBucket(volume, bucket,
+        volume, bucket, "", bucketLayout);
     return cluster.getOzoneManager().getKeyManager()
             .getKeyInfo(new OmKeyArgs.Builder()
                 .setVolumeName(volume)
                 .setBucketName(bucket)
                 .setKeyName(key).build(),
-                bucketLayout, null);
+                resolvedBucket, null);
   }
 
   /**

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOmSnapshot.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOmSnapshot.java
@@ -643,7 +643,7 @@ public class TestOmSnapshot {
                 .setVolumeName(volume)
                 .setBucketName(bucket)
                 .setKeyName(key).build(),
-                BucketLayout.DEFAULT, null);
+                bucketLayout, null);
   }
 
   /**

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/KeyManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/KeyManager.java
@@ -65,7 +65,7 @@ public interface KeyManager extends OzoneManagerFS, IOzoneAcl {
    * @return a OmKeyInfo instance client uses to talk to container.
    * @throws IOException
    */
-  OmKeyInfo lookupKey(OmKeyArgs args, BucketLayout bucketLayout,
+  OmKeyInfo lookupKey(OmKeyArgs args, ResolvedBucket bucketLayout,
       String clientAddress) throws IOException;
 
   /**

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/KeyManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/KeyManager.java
@@ -77,7 +77,7 @@ public interface KeyManager extends OzoneManagerFS, IOzoneAcl {
    * @return a OmKeyInfo instance client uses to talk to container.
    * @throws IOException
    */
-  OmKeyInfo getKeyInfo(OmKeyArgs args, BucketLayout bucketLayout,
+  OmKeyInfo getKeyInfo(OmKeyArgs args, ResolvedBucket buctket,
       String clientAddress) throws IOException;
 
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/KeyManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/KeyManager.java
@@ -65,7 +65,8 @@ public interface KeyManager extends OzoneManagerFS, IOzoneAcl {
    * @return a OmKeyInfo instance client uses to talk to container.
    * @throws IOException
    */
-  OmKeyInfo lookupKey(OmKeyArgs args, String clientAddress) throws IOException;
+  OmKeyInfo lookupKey(OmKeyArgs args, BucketLayout bucketLayout,
+      String clientAddress) throws IOException;
 
   /**
    * Return info of an existing key to client side to access to data on
@@ -76,7 +77,8 @@ public interface KeyManager extends OzoneManagerFS, IOzoneAcl {
    * @return a OmKeyInfo instance client uses to talk to container.
    * @throws IOException
    */
-  OmKeyInfo getKeyInfo(OmKeyArgs args, String clientAddress) throws IOException;
+  OmKeyInfo getKeyInfo(OmKeyArgs args, BucketLayout bucketLayout,
+      String clientAddress) throws IOException;
 
 
   /**

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/KeyManagerImpl.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/KeyManagerImpl.java
@@ -406,7 +406,8 @@ public class KeyManagerImpl implements KeyManager {
     return value;
   }
 
-  private OmKeyInfo readKeyInfo(OmKeyArgs args, BucketLayout bucketLayout) throws IOException {
+  private OmKeyInfo readKeyInfo(OmKeyArgs args, BucketLayout bucketLayout)
+      throws IOException {
     String volumeName = args.getVolumeName();
     String bucketName = args.getBucketName();
     String keyName = args.getKeyName();
@@ -1968,8 +1969,8 @@ public class KeyManagerImpl implements KeyManager {
   }
 
   @Override
-  public OmKeyInfo getKeyInfo(OmKeyArgs args, BucketLayout bucketLayout, String clientAddress)
-      throws IOException {
+  public OmKeyInfo getKeyInfo(OmKeyArgs args, BucketLayout bucketLayout,
+      String clientAddress) throws IOException {
     Preconditions.checkNotNull(args);
 
     OmKeyInfo value = captureLatencyNs(

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/KeyManagerImpl.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/KeyManagerImpl.java
@@ -1969,13 +1969,13 @@ public class KeyManagerImpl implements KeyManager {
   }
 
   @Override
-  public OmKeyInfo getKeyInfo(OmKeyArgs args, BucketLayout bucketLayout,
+  public OmKeyInfo getKeyInfo(OmKeyArgs args, ResolvedBucket bucket,
       String clientAddress) throws IOException {
     Preconditions.checkNotNull(args);
 
     OmKeyInfo value = captureLatencyNs(
         metrics.getGetKeyInfoReadKeyInfoLatencyNs(),
-        () -> readKeyInfo(args, bucketLayout));
+        () -> readKeyInfo(args, bucket.bucketLayout()));
 
     // If operation is head, do not perform any additional steps based on flags.
     // As head operation does not need any of those details.

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/KeyManagerImpl.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/KeyManagerImpl.java
@@ -377,12 +377,12 @@ public class KeyManagerImpl implements KeyManager {
     return edek;
   }
   @Override
-  public OmKeyInfo lookupKey(OmKeyArgs args, BucketLayout bucketLayout,
+  public OmKeyInfo lookupKey(OmKeyArgs args, ResolvedBucket bucket,
       String clientAddress) throws IOException {
     Preconditions.checkNotNull(args);
 
     OmKeyInfo value = captureLatencyNs(metrics.getLookupReadKeyInfoLatencyNs(),
-        () -> readKeyInfo(args, bucketLayout));
+        () -> readKeyInfo(args, bucket.bucketLayout()));
 
     // If operation is head, do not perform any additional steps based on flags.
     // As head operation does not need any of those details.

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmMetadataReader.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmMetadataReader.java
@@ -131,8 +131,7 @@ public class OmMetadataReader implements IOmMetadataReader, Auditor {
         );
       }
       metrics.incNumKeyLookups();
-      return keyManager.lookupKey(resolvedArgs, bucket.bucketLayout(),
-          getClientAddress());
+      return keyManager.lookupKey(resolvedArgs, bucket, getClientAddress());
     } catch (Exception ex) {
       metrics.incNumKeyLookupFails();
       auditSuccess = false;

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmMetadataReader.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmMetadataReader.java
@@ -185,8 +185,7 @@ public class OmMetadataReader implements IOmMetadataReader, Auditor {
       }
 
       metrics.incNumGetKeyInfo();
-      OmKeyInfo keyInfo =
-          keyManager.getKeyInfo(resolvedArgs, bucket.bucketLayout(),
+      OmKeyInfo keyInfo = keyManager.getKeyInfo(resolvedArgs, bucket,
               OmMetadataReader.getClientAddress());
       KeyInfoWithVolumeContext.Builder builder = KeyInfoWithVolumeContext
           .newBuilder()

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
@@ -4197,7 +4197,7 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
   public ResolvedBucket resolveBucketLink(Pair<String, String> requested,
       OMClientRequest omClientRequest)
       throws IOException {
-    Pair<String, String> resolved;
+    OmBucketInfo resolved;
     if (isAclEnabled) {
       resolved = resolveBucketLink(requested, new HashSet<>(),
               omClientRequest.createUGIForApi(),
@@ -4208,13 +4208,14 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
       resolved = resolveBucketLink(requested, new HashSet<>(),
           null, null, null, false);
     }
-    return new ResolvedBucket(requested, resolved);
+    return new ResolvedBucket(requested.getLeft(), requested.getRight(),
+        resolved);
   }
 
   public ResolvedBucket resolveBucketLink(Pair<String, String> requested,
                                           boolean allowDanglingBuckets)
       throws IOException {
-    Pair<String, String> resolved;
+    OmBucketInfo resolved;
     if (isAclEnabled) {
       UserGroupInformation ugi = getRemoteUser();
       if (getS3Auth() != null) {
@@ -4231,7 +4232,8 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
       resolved = resolveBucketLink(requested, new HashSet<>(),
           null, null, null, allowDanglingBuckets);
     }
-    return new ResolvedBucket(requested, resolved);
+    return new ResolvedBucket(requested.getLeft(), requested.getRight(),
+        resolved);
   }
 
   /**
@@ -4245,7 +4247,7 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
    * @throws IOException (most likely OMException) if ACL check fails, bucket is
    *   not found, loop is detected in the links, etc.
    */
-  private Pair<String, String> resolveBucketLink(
+  private OmBucketInfo resolveBucketLink(
       Pair<String, String> volumeAndBucket,
       Set<Pair<String, String>> visited,
       UserGroupInformation userGroupInformation,
@@ -4266,7 +4268,7 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
       throw e;
     }
     if (!info.isLink()) {
-      return volumeAndBucket;
+      return info;
     }
 
     if (!visited.add(volumeAndBucket)) {

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ResolvedBucket.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ResolvedBucket.java
@@ -19,6 +19,8 @@ package org.apache.hadoop.ozone.om;
 
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.hadoop.ozone.OzoneConsts;
+import org.apache.hadoop.ozone.om.helpers.BucketLayout;
+import org.apache.hadoop.ozone.om.helpers.OmBucketInfo;
 import org.apache.hadoop.ozone.om.helpers.OmKeyArgs;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.KeyArgs;
 
@@ -34,37 +36,59 @@ import java.util.Objects;
  */
 public class ResolvedBucket {
 
-  private final Pair<String, String> requested;
-  private final Pair<String, String> resolved;
+  private final String requestedVolume;
+  private final String requestedBucket;
+  private final String realVolume;
+  private final String realBucket;
+  private final String bucketOwner;
+  private final BucketLayout bucketLayout;
 
-  public ResolvedBucket(Pair<String, String> requested,
-      Pair<String, String> resolved) {
-    this.requested = requested;
-    this.resolved = resolved;
+  public ResolvedBucket(String requestedVolume, String requestedBucket,
+      OmBucketInfo resolved) {
+    this(requestedVolume, requestedBucket,
+        resolved.getVolumeName(), resolved.getBucketName(),
+        resolved.getOwner(), resolved.getBucketLayout());
   }
 
-  public Pair<String, String> requested() {
-    return requested;
+  public ResolvedBucket(String requestedVolume, String requestedBucket,
+      String realVolume, String realBucket, String bucketOwner,
+      BucketLayout bucketLayout) {
+    this.requestedVolume = requestedVolume;
+    this.requestedBucket = requestedBucket;
+    this.realVolume = realVolume;
+    this.realBucket = realBucket;
+    this.bucketOwner = bucketOwner;
+    this.bucketLayout = bucketLayout;
   }
 
-  public Pair<String, String> resolved() {
-    return resolved;
+  public ResolvedBucket(Pair<String, String> requested, Pair<String, String> real, String owner, BucketLayout bucketLayout) {
+    this(requested.getLeft(), requested.getRight(),
+        real.getLeft(), real.getRight(),
+        owner, bucketLayout);
   }
 
   public String requestedVolume() {
-    return requested.getLeft();
+    return requestedVolume;
   }
 
   public String requestedBucket() {
-    return requested.getRight();
+    return requestedBucket;
   }
 
   public String realVolume() {
-    return resolved.getLeft();
+    return realVolume;
   }
 
   public String realBucket() {
-    return resolved.getRight();
+    return realBucket;
+  }
+
+  public String bucketOwner() {
+    return bucketOwner;
+  }
+
+  public BucketLayout bucketLayout() {
+    return bucketLayout;
   }
 
   public OmKeyArgs update(OmKeyArgs args) {
@@ -86,7 +110,8 @@ public class ResolvedBucket {
   }
 
   public boolean isLink() {
-    return !Objects.equals(requested, resolved);
+    return !Objects.equals(requestedVolume, realVolume)
+        || !Objects.equals(requestedBucket, realBucket);
   }
 
   public boolean isDangling() {

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ResolvedBucket.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ResolvedBucket.java
@@ -45,9 +45,19 @@ public class ResolvedBucket {
 
   public ResolvedBucket(String requestedVolume, String requestedBucket,
       OmBucketInfo resolved) {
-    this(requestedVolume, requestedBucket,
-        resolved.getVolumeName(), resolved.getBucketName(),
-        resolved.getOwner(), resolved.getBucketLayout());
+    this.requestedVolume = requestedVolume;
+    this.requestedBucket = requestedBucket;
+    if (resolved != null) {
+      this.realVolume = resolved.getVolumeName();
+      this.realBucket = resolved.getBucketName();
+      this.bucketOwner = resolved.getOwner();
+      this.bucketLayout = resolved.getBucketLayout();
+    } else {
+      this.realVolume = null;
+      this.realBucket = null;
+      this.bucketOwner = null;
+      this.bucketLayout = null;
+    }
   }
 
   public ResolvedBucket(String requestedVolume, String requestedBucket,
@@ -61,7 +71,8 @@ public class ResolvedBucket {
     this.bucketLayout = bucketLayout;
   }
 
-  public ResolvedBucket(Pair<String, String> requested, Pair<String, String> real, String owner, BucketLayout bucketLayout) {
+  public ResolvedBucket(Pair<String, String> requested,
+      Pair<String, String> real, String owner, BucketLayout bucketLayout) {
     this(requested.getLeft(), requested.getRight(),
         real.getLeft(), real.getRight(),
         owner, bucketLayout);
@@ -115,7 +126,7 @@ public class ResolvedBucket {
   }
 
   public boolean isDangling() {
-    return resolved == null;
+    return realVolume == null || realBucket == null;
   }
 
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/file/OMFileRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/file/OMFileRequest.java
@@ -621,7 +621,7 @@ public final class OMFileRequest {
   }
 
   /**
-   * Gets OmKeyInfo if exists for the given key name in the DB.
+   * Gets OmKeyInfo if exists and validate bucket and volume.
    *
    * @param omMetadataMgr metadata manager
    * @param volumeName    volume name
@@ -637,8 +637,34 @@ public final class OMFileRequest {
       String volumeName, String bucketName, String keyName,
       long scmBlockSize, ReplicationConfig defaultReplication
   ) throws IOException {
+    return getOMKeyInfoIfExists(omMetadataMgr, volumeName, bucketName, keyName,
+        scmBlockSize, defaultReplication, true);
+  }
 
-    OMFileRequest.validateBucket(omMetadataMgr, volumeName, bucketName);
+
+  /**
+   * Gets OmKeyInfo if exists for the given key name in the DB.
+   *
+   * @param omMetadataMgr metadata manager
+   * @param volumeName    volume name
+   * @param bucketName    bucket name
+   * @param keyName       key name
+   * @param scmBlockSize  scm block size
+   * @param validateBucketAndVolume true if the volume/bucket needs validating.
+   * @return OzoneFileStatus
+   * @throws IOException DB failure
+   */
+  @Nullable
+  public static OzoneFileStatus getOMKeyInfoIfExists(
+      OMMetadataManager omMetadataMgr,
+      String volumeName, String bucketName, String keyName,
+      long scmBlockSize, ReplicationConfig defaultReplication,
+      boolean validateBucketAndVolume
+  ) throws IOException {
+
+    if (validateBucketAndVolume) {
+      OMFileRequest.validateBucket(omMetadataMgr, volumeName, bucketName);
+    }
 
     Path keyPath = Paths.get(keyName);
     Iterator<Path> elements = keyPath.iterator();

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestKeyManagerUnit.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestKeyManagerUnit.java
@@ -52,6 +52,7 @@ import org.apache.hadoop.hdds.utils.db.cache.CacheKey;
 import org.apache.hadoop.hdds.utils.db.cache.CacheValue;
 import org.apache.hadoop.hdds.scm.protocol.StorageContainerLocationProtocol;
 import org.apache.hadoop.ozone.OzoneConsts;
+import org.apache.hadoop.ozone.om.helpers.BucketLayout;
 import org.apache.hadoop.ozone.om.helpers.OmBucketInfo;
 import org.apache.hadoop.ozone.om.helpers.OmKeyArgs;
 import org.apache.hadoop.ozone.om.helpers.OmKeyArgs.Builder;
@@ -397,7 +398,8 @@ public class TestKeyManagerUnit {
         .setBucketName("bucketOne")
         .setKeyName("keyOne")
         .build();
-    OmKeyInfo keyInfo = keyManager.getKeyInfo(keyArgs, "test");
+    OmKeyInfo keyInfo = keyManager.getKeyInfo(keyArgs,
+        BucketLayout.DEFAULT, "test");
     final OmKeyLocationInfo blockLocation1 = keyInfo
         .getLatestVersionLocations().getBlocksLatestVersionOnly().get(0);
     Assert.assertEquals(blockID1, blockLocation1.getBlockID());
@@ -412,7 +414,8 @@ public class TestKeyManagerUnit {
         .setBucketName("bucketOne")
         .setKeyName("keyTwo")
         .build();
-    OmKeyInfo keyInfo2 = keyManager.getKeyInfo(keyArgs, "test");
+    OmKeyInfo keyInfo2 = keyManager.getKeyInfo(keyArgs,
+        BucketLayout.DEFAULT, "test");
     OmKeyLocationInfo blockLocation2 = keyInfo2
         .getLatestVersionLocations().getBlocksLatestVersionOnly().get(0);
     Assert.assertEquals(blockID2, blockLocation2.getBlockID());
@@ -428,7 +431,8 @@ public class TestKeyManagerUnit {
         .setKeyName("keyTwo")
         .setForceUpdateContainerCacheFromSCM(true)
         .build();
-    keyInfo2 = keyManager.getKeyInfo(keyArgs, "test");
+    keyInfo2 = keyManager.getKeyInfo(keyArgs,
+        BucketLayout.DEFAULT, "test");
     blockLocation2 = keyInfo2
         .getLatestVersionLocations().getBlocksLatestVersionOnly().get(0);
     Assert.assertEquals(blockID2, blockLocation2.getBlockID());

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestKeyManagerUnit.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestKeyManagerUnit.java
@@ -399,7 +399,7 @@ public class TestKeyManagerUnit {
         .setKeyName("keyOne")
         .build();
     OmKeyInfo keyInfo = keyManager.getKeyInfo(keyArgs,
-        BucketLayout.DEFAULT, "test");
+        resolveBucket(keyArgs), "test");
     final OmKeyLocationInfo blockLocation1 = keyInfo
         .getLatestVersionLocations().getBlocksLatestVersionOnly().get(0);
     Assert.assertEquals(blockID1, blockLocation1.getBlockID());
@@ -415,7 +415,7 @@ public class TestKeyManagerUnit {
         .setKeyName("keyTwo")
         .build();
     OmKeyInfo keyInfo2 = keyManager.getKeyInfo(keyArgs,
-        BucketLayout.DEFAULT, "test");
+        resolveBucket(keyArgs), "test");
     OmKeyLocationInfo blockLocation2 = keyInfo2
         .getLatestVersionLocations().getBlocksLatestVersionOnly().get(0);
     Assert.assertEquals(blockID2, blockLocation2.getBlockID());
@@ -432,7 +432,7 @@ public class TestKeyManagerUnit {
         .setForceUpdateContainerCacheFromSCM(true)
         .build();
     keyInfo2 = keyManager.getKeyInfo(keyArgs,
-        BucketLayout.DEFAULT, "test");
+        resolveBucket(keyArgs), "test");
     blockLocation2 = keyInfo2
         .getLatestVersionLocations().getBlocksLatestVersionOnly().get(0);
     Assert.assertEquals(blockID2, blockLocation2.getBlockID());
@@ -440,6 +440,12 @@ public class TestKeyManagerUnit {
     // Ensure SCM is called.
     verify(containerClient, times(2))
         .getContainerWithPipelineBatch(containerIDs);
+  }
+
+  private ResolvedBucket resolveBucket(OmKeyArgs keyArgs) {
+    return new ResolvedBucket(keyArgs.getVolumeName(), keyArgs.getBucketName(),
+        keyArgs.getVolumeName(), keyArgs.getBucketName(), "",
+        BucketLayout.DEFAULT);
   }
 
   @Test

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/bucket/TestBucketRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/bucket/TestBucketRequest.java
@@ -94,7 +94,8 @@ public class TestBucketRequest {
 
     when(ozoneManager.resolveBucketLink(any(Pair.class)))
         .thenAnswer(invocation -> new ResolvedBucket(
-            invocation.getArgument(0), invocation.getArgument(0)));
+            invocation.getArgument(0), invocation.getArgument(0),
+            "", BucketLayout.DEFAULT));
   }
 
   @After

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/file/TestOMDirectoryCreateRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/file/TestOMDirectoryCreateRequest.java
@@ -26,7 +26,6 @@ import java.util.UUID;
 import java.util.stream.Collectors;
 
 import org.apache.commons.lang3.RandomStringUtils;
-import org.apache.commons.lang3.tuple.Pair;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.ozone.OzoneAcl;
 import org.apache.hadoop.ozone.om.ResolvedBucket;

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/file/TestOMDirectoryCreateRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/file/TestOMDirectoryCreateRequest.java
@@ -102,7 +102,9 @@ public class TestOMDirectoryCreateRequest {
     Mockito.doNothing().when(auditLogger).logWrite(any(AuditMessage.class));
     when(ozoneManager.resolveBucketLink(any(KeyArgs.class),
         any(OMClientRequest.class)))
-        .thenReturn(new ResolvedBucket(Pair.of("", ""), Pair.of("", "")));
+        .thenReturn(new ResolvedBucket("", "",
+            "", "", "",
+            BucketLayout.DEFAULT));
   }
 
   @After

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/file/TestOMDirectoryCreateRequestWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/file/TestOMDirectoryCreateRequestWithFSO.java
@@ -19,7 +19,6 @@
 package org.apache.hadoop.ozone.om.request.file;
 
 import org.apache.commons.lang3.RandomStringUtils;
-import org.apache.commons.lang3.tuple.Pair;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.hdds.utils.db.cache.CacheKey;

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/file/TestOMDirectoryCreateRequestWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/file/TestOMDirectoryCreateRequestWithFSO.java
@@ -101,7 +101,9 @@ public class TestOMDirectoryCreateRequestWithFSO {
     Mockito.doNothing().when(auditLogger).logWrite(any(AuditMessage.class));
     when(ozoneManager.resolveBucketLink(any(KeyArgs.class),
             any(OMClientRequest.class)))
-            .thenReturn(new ResolvedBucket(Pair.of("", ""), Pair.of("", "")));
+            .thenReturn(new ResolvedBucket("", "",
+                    "", "", "",
+                    BucketLayout.DEFAULT));
   }
 
   @After

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMKeyRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMKeyRequest.java
@@ -221,15 +221,16 @@ public class TestOMKeyRequest {
     random = new Random();
     version = 0L;
 
-    Pair<String, String> volumeAndBucket = Pair.of(volumeName, bucketName);
+    ResolvedBucket bucket = new ResolvedBucket(volumeName, bucketName,
+        bucketName, volumeName, "owner", BucketLayout.OBJECT_STORE);
     when(ozoneManager.resolveBucketLink(any(KeyArgs.class),
         any(OMClientRequest.class)))
-        .thenReturn(new ResolvedBucket(volumeAndBucket, volumeAndBucket));
+        .thenReturn(bucket);
     when(ozoneManager.resolveBucketLink(any(Pair.class),
         any(OMClientRequest.class)))
-        .thenReturn(new ResolvedBucket(volumeAndBucket, volumeAndBucket));
+        .thenReturn(bucket);
     when(ozoneManager.resolveBucketLink(any(Pair.class)))
-        .thenReturn(new ResolvedBucket(volumeAndBucket, volumeAndBucket));
+        .thenReturn(bucket);
     OmSnapshotManager omSnapshotManager = new OmSnapshotManager(ozoneManager);
     when(ozoneManager.getOmSnapshotManager())
         .thenReturn(omSnapshotManager);

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMKeyRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMKeyRequest.java
@@ -222,7 +222,7 @@ public class TestOMKeyRequest {
     version = 0L;
 
     ResolvedBucket bucket = new ResolvedBucket(volumeName, bucketName,
-        bucketName, volumeName, "owner", BucketLayout.OBJECT_STORE);
+        volumeName, bucketName, "owner", BucketLayout.OBJECT_STORE);
     when(ozoneManager.resolveBucketLink(any(KeyArgs.class),
         any(OMClientRequest.class)))
         .thenReturn(bucket);

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/s3/multipart/TestS3MultipartRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/s3/multipart/TestS3MultipartRequest.java
@@ -34,7 +34,6 @@ import org.junit.Rule;
 import org.junit.rules.TemporaryFolder;
 import org.mockito.Mockito;
 
-import org.apache.commons.lang3.tuple.Pair;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.ozone.audit.AuditLogger;
 import org.apache.hadoop.ozone.audit.AuditMessage;

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/s3/multipart/TestS3MultipartRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/s3/multipart/TestS3MultipartRequest.java
@@ -109,8 +109,9 @@ public class TestS3MultipartRequest {
         .thenAnswer(inv -> {
           KeyArgs args = (KeyArgs) inv.getArguments()[0];
           return new ResolvedBucket(
-              Pair.of(args.getVolumeName(), args.getBucketName()),
-              Pair.of(args.getVolumeName(), args.getBucketName()));
+              args.getVolumeName(), args.getBucketName(),
+              args.getVolumeName(), args.getBucketName(),
+              "owner", BucketLayout.DEFAULT);
         });
     OMLayoutVersionManager lvm = mock(OMLayoutVersionManager.class);
     when(lvm.getMetadataLayoutVersion()).thenReturn(0);

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/TestCleanupTableInfo.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/TestCleanupTableInfo.java
@@ -129,7 +129,8 @@ public class TestCleanupTableInfo {
     when(om.getMetadataManager()).thenReturn(metaMgr);
     when(om.resolveBucketLink(any(KeyArgs.class), any(OMClientRequest.class)))
         .thenAnswer(
-            invocationOnMock -> new ResolvedBucket(TEST_VOLUME_NAME, TEST_BUCKET_NAME,
+            invocationOnMock -> new ResolvedBucket(
+                TEST_VOLUME_NAME, TEST_BUCKET_NAME,
                 TEST_VOLUME_NAME, TEST_BUCKET_NAME,
                 "owner", BucketLayout.DEFAULT)
         );

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/TestCleanupTableInfo.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/TestCleanupTableInfo.java
@@ -35,6 +35,7 @@ import org.apache.hadoop.ozone.om.OMMetrics;
 import org.apache.hadoop.ozone.om.OmMetadataManagerImpl;
 import org.apache.hadoop.ozone.om.OzoneManager;
 import org.apache.hadoop.ozone.om.ResolvedBucket;
+import org.apache.hadoop.ozone.om.helpers.BucketLayout;
 import org.apache.hadoop.ozone.om.helpers.OmBucketInfo;
 import org.apache.hadoop.ozone.om.helpers.OmVolumeArgs;
 import org.apache.hadoop.ozone.om.lock.OzoneLockProvider;
@@ -132,7 +133,9 @@ public class TestCleanupTableInfo {
             invocationOnMock -> {
               Pair<String, String> pair =
                   Pair.of(TEST_VOLUME_NAME, TEST_BUCKET_NAME);
-              return new ResolvedBucket(pair, pair);
+              return new ResolvedBucket(TEST_VOLUME_NAME, TEST_BUCKET_NAME,
+                  TEST_VOLUME_NAME, TEST_BUCKET_NAME,
+                  "owner", BucketLayout.DEFAULT);
             }
         );
     when(om.getAclsEnabled()).thenReturn(false);

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/TestCleanupTableInfo.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/TestCleanupTableInfo.java
@@ -18,7 +18,6 @@
 package org.apache.hadoop.ozone.om.response;
 
 import com.google.common.collect.Iterators;
-import org.apache.commons.lang3.tuple.Pair;
 import org.apache.hadoop.hdds.client.BlockID;
 import org.apache.hadoop.hdds.client.ReplicationConfig;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
@@ -130,13 +129,9 @@ public class TestCleanupTableInfo {
     when(om.getMetadataManager()).thenReturn(metaMgr);
     when(om.resolveBucketLink(any(KeyArgs.class), any(OMClientRequest.class)))
         .thenAnswer(
-            invocationOnMock -> {
-              Pair<String, String> pair =
-                  Pair.of(TEST_VOLUME_NAME, TEST_BUCKET_NAME);
-              return new ResolvedBucket(TEST_VOLUME_NAME, TEST_BUCKET_NAME,
-                  TEST_VOLUME_NAME, TEST_BUCKET_NAME,
-                  "owner", BucketLayout.DEFAULT);
-            }
+            invocationOnMock -> new ResolvedBucket(TEST_VOLUME_NAME, TEST_BUCKET_NAME,
+                TEST_VOLUME_NAME, TEST_BUCKET_NAME,
+                "owner", BucketLayout.DEFAULT)
         );
     when(om.getAclsEnabled()).thenReturn(false);
     when(om.getAuditLogger()).thenReturn(mock(AuditLogger.class));


### PR DESCRIPTION
## What changes were proposed in this pull request?

OM's getKeyInfo API internally does the following steps:
1. Resolve bucket link: confirms that bucket/volume exists, resolve the bucket's real name if the bucket param points to a soft link.
2. ACL check: check if the user has access to the requested resource.
3. Read key metadata from rocks db.
4. Get block container location cache/SCM.
5. Generate block token for read.

Although during (1), bucket/volume info is already retrieved from db/cache, step (2) and (3) still re-read the same information to extract different sub-attribute. e.g. (2) needs to read bucket/volume to get bucket/volume owner name, (3) needs to get bucket layout.

Those redundant reads unnecessarily add a significant cost to API, given that each read involves locking, encoding/decoding results...

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-9297

## How was this patch tested?

I did a quick load test in an internal cluster. This change helped the peak OPPS of OM pure reads (getKeyInfo) increase from **150K** to **190K**. 