### PR TITLE
HDDS-9439. Refactor sortDatanodes to OM

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/net/NetworkTopologyImpl.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/net/NetworkTopologyImpl.java
@@ -70,6 +70,16 @@ public class NetworkTopologyImpl implements NetworkTopology {
         schemaManager.getCost(NetConstants.ROOT_LEVEL));
   }
 
+  public NetworkTopologyImpl(String schemaFile) {
+    schemaManager = NodeSchemaManager.getInstance();
+    schemaManager.init(schemaFile);
+    maxLevel = schemaManager.getMaxLevel();
+    factory = InnerNodeImpl.FACTORY;
+    clusterTree = factory.newInnerNode(ROOT, null, null,
+        NetConstants.ROOT_LEVEL,
+        schemaManager.getCost(NetConstants.ROOT_LEVEL));
+  }
+
   @VisibleForTesting
   public NetworkTopologyImpl(NodeSchemaManager manager) {
     schemaManager = manager;

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/net/NodeSchemaManager.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/net/NodeSchemaManager.java
@@ -76,6 +76,21 @@ public final class NodeSchemaManager {
     }
   }
 
+  public void init(String schemaFile) {
+    NodeSchemaLoadResult result;
+    try {
+      result = NodeSchemaLoader.getInstance().loadSchemaFromFile(schemaFile);
+      allSchema = result.getSchemaList();
+      enforcePrefix = result.isEnforePrefix();
+      maxLevel = allSchema.size();
+    } catch (Throwable e) {
+      String msg = "Failed to load schema file:" + schemaFile
+          + ", error: " + e.getMessage();
+      LOG.error(msg, e);
+      throw new RuntimeException(msg, e);
+    }
+  }
+
   @VisibleForTesting
   public void init(NodeSchema[] schemas, boolean enforce) {
     allSchema = new ArrayList<>();

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/OzoneConfigKeys.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/OzoneConfigKeys.java
@@ -662,6 +662,18 @@ public final class OzoneConfigKeys {
   public static final String OZONE_SCM_CLOSE_CONTAINER_WAIT_DURATION =
       "ozone.scm.close.container.wait.duration";
 
+  public static final String
+      OZONE_SCM_NETWORK_TOPOLOGY_SCHEMA_FILE_REFRESH_DURATION =
+      "ozone.scm.network.topology.schema.file.refresh.duration";
+  public static final String
+      OZONE_SCM_NETWORK_TOPOLOGY_SCHEMA_FILE_REFRESH_DURATION_DEFAULT = "3h";
+
+  public static final String
+      OZONE_SCM_NETWORK_TOPOLOGY_SCHEMA_FILE_CHECK_DURATION =
+      "ozone.scm.network.topology.schema.file.check.duration";
+  public static final String
+      OZONE_SCM_NETWORK_TOPOLOGY_SCHEMA_FILE_CHECK_DURATION_DEFAULT = "5m";
+
   /**
    * There is no need to instantiate this class.
    */

--- a/hadoop-hdds/common/src/main/resources/ozone-default.xml
+++ b/hadoop-hdds/common/src/main/resources/ozone-default.xml
@@ -3601,6 +3601,23 @@
       is send to DN.</description>
   </property>
   <property>
+    <name>ozone.scm.network.topology.schema.file.refresh.duration</name>
+    <value>3h</value>
+    <tag>SCM, OZONE</tag>
+    <description>The duration at which we periodically fetch the updated network topology schema file from SCM.
+    </description>
+  </property>
+  <property>
+    <name>ozone.scm.network.topology.schema.file.check.duration</name>
+    <value>5m</value>
+    <tag>SCM, OZONE, RECON</tag>
+    <description>The duration at which we periodically check if it is the time for fetching the updated network
+      topology schema file from SCM. Example: If ozone.scm.network.topology.schema.file.refresh.duration=3d and
+      ozone.scm.network.topology.schema.file.check.duration=10m, the actual refresh duration will occur for each
+      3h +/- 5m.
+    </description>
+  </property>
+  <property>
     <name>ozone.scm.ha.ratis.server.snapshot.creation.gap</name>
     <value>1024</value>
     <tag>SCM, OZONE</tag>

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/scm/client/ScmBlockLocationClient.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/scm/client/ScmBlockLocationClient.java
@@ -92,14 +92,14 @@ public class ScmBlockLocationClient {
   private void scheduleTopologyPoller(ConfigurationSource conf,
                                        Instant initialInvocation) {
     Duration refreshDuration = parseRefreshDuration(conf);
-    Instant nextRotate = initialInvocation.plus(refreshDuration);
+    Instant nextRefresh = initialInvocation.plus(refreshDuration);
     ThreadFactory threadFactory = new ThreadFactoryBuilder()
         .setNameFormat("NetworkTopologyPoller")
         .setDaemon(true)
         .build();
     executorService = Executors.newScheduledThreadPool(1, threadFactory);
     Duration interval = parseRefreshCheckDuration(conf);
-    Duration initialDelay = Duration.between(Instant.now(), nextRotate);
+    Duration initialDelay = Duration.between(Instant.now(), nextRefresh);
 
     LOG.info("Scheduling NetworkTopologyPoller with initial delay of {} " +
         "and interval of {}", initialDelay, interval);

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/scm/client/ScmBlockLocationClient.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/scm/client/ScmBlockLocationClient.java
@@ -1,0 +1,146 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hdds.scm.client;
+
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
+import org.apache.hadoop.hdds.conf.ConfigurationSource;
+import org.apache.hadoop.hdds.scm.protocol.ScmBlockLocationProtocol;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static java.util.Objects.requireNonNull;
+import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_SCM_NETWORK_TOPOLOGY_SCHEMA_FILE_REFRESH_DURATION;
+import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_SCM_NETWORK_TOPOLOGY_SCHEMA_FILE_REFRESH_DURATION_DEFAULT;
+import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_SCM_NETWORK_TOPOLOGY_SCHEMA_FILE_CHECK_DURATION;
+import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_SCM_NETWORK_TOPOLOGY_SCHEMA_FILE_CHECK_DURATION_DEFAULT;
+
+/**
+ * This client implements a background thread which periodically checks and
+ * gets the latest network topology schema file from SCM.
+ */
+public class ScmBlockLocationClient {
+  private static final Logger LOG =
+      LoggerFactory.getLogger(ScmBlockLocationClient.class);
+
+  private final ScmBlockLocationProtocol scmBlockLocationProtocol;
+  private final AtomicReference<String> cache = new AtomicReference<>();
+  private ScheduledExecutorService executorService;
+
+  public ScmBlockLocationClient(
+      ScmBlockLocationProtocol scmBlockLocationProtocol) {
+    this.scmBlockLocationProtocol = scmBlockLocationProtocol;
+  }
+
+  public String getTopologyInformation() {
+    return requireNonNull(cache.get(),
+        "ScmBlockLocationClient must have been initialized already.");
+  }
+
+  public void refetchTopologyInformation() {
+    checkAndRefresh(Duration.ZERO, Instant.now());
+  }
+
+  public void start(ConfigurationSource conf) throws IOException {
+    final String initialTopology =
+        scmBlockLocationProtocol.getTopologyInformation();
+    LOG.info("Initial topology information fetched from SCM: {}.",
+        initialTopology);
+    cache.set(initialTopology);
+    scheduleTopologyPoller(conf, Instant.now());
+  }
+
+  public void stop() {
+    if (executorService != null) {
+      executorService.shutdown();
+      try {
+        if (executorService.awaitTermination(1, TimeUnit.MINUTES)) {
+          executorService.shutdownNow();
+        }
+      } catch (InterruptedException e) {
+        LOG.error("Interrupted while shutting down executor service.", e);
+        Thread.currentThread().interrupt();
+      }
+    }
+  }
+
+  private void scheduleTopologyPoller(ConfigurationSource conf,
+                                       Instant initialInvocation) {
+    Duration refreshDuration = parseRefreshDuration(conf);
+    Instant nextRotate = initialInvocation.plus(refreshDuration);
+    ThreadFactory threadFactory = new ThreadFactoryBuilder()
+        .setNameFormat("NetworkTopologyPoller")
+        .setDaemon(true)
+        .build();
+    executorService = Executors.newScheduledThreadPool(1, threadFactory);
+    Duration interval = parseRefreshCheckDuration(conf);
+    Duration initialDelay = Duration.between(Instant.now(), nextRotate);
+
+    LOG.info("Scheduling NetworkTopologyPoller with initial delay of {} " +
+        "and interval of {}", initialDelay, interval);
+    executorService.scheduleAtFixedRate(
+        () -> checkAndRefresh(refreshDuration, initialInvocation),
+        initialDelay.toMillis(), interval.toMillis(),
+        TimeUnit.MILLISECONDS);
+  }
+
+  public static Duration parseRefreshDuration(ConfigurationSource conf) {
+    long refreshDurationInMs = conf.getTimeDuration(
+        OZONE_SCM_NETWORK_TOPOLOGY_SCHEMA_FILE_REFRESH_DURATION,
+        OZONE_SCM_NETWORK_TOPOLOGY_SCHEMA_FILE_REFRESH_DURATION_DEFAULT,
+        TimeUnit.MILLISECONDS);
+    return Duration.ofMillis(refreshDurationInMs);
+  }
+
+  public static Duration parseRefreshCheckDuration(ConfigurationSource conf) {
+    long refreshCheckInMs = conf.getTimeDuration(
+        OZONE_SCM_NETWORK_TOPOLOGY_SCHEMA_FILE_CHECK_DURATION,
+        OZONE_SCM_NETWORK_TOPOLOGY_SCHEMA_FILE_CHECK_DURATION_DEFAULT,
+        TimeUnit.MILLISECONDS);
+    return Duration.ofMillis(refreshCheckInMs);
+  }
+
+  private synchronized void checkAndRefresh(Duration refreshDuration,
+                                            Instant initialInvocation) {
+    String current = cache.get();
+    Instant nextRefresh = initialInvocation.plus(refreshDuration);
+    if (nextRefresh.isBefore(Instant.now())) {
+      try {
+        String newTopology = scmBlockLocationProtocol.getTopologyInformation();
+        if (!newTopology.equals(current)) {
+          cache.set(newTopology);
+          LOG.info("Updated network topology schema file fetched from " +
+              "SCM: {}.", newTopology);
+        }
+      } catch (IOException e) {
+        throw new UncheckedIOException(
+            "Error fetching updated network topology schema file from SCM", e);
+      }
+    }
+  }
+}

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/scm/client/package-info.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/scm/client/package-info.java
@@ -1,0 +1,24 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * <p>
+ * Freon related helper classes used for load testing.
+ */
+
+/**
+ * Contains SCM client related classes.
+ */
+package org.apache.hadoop.hdds.scm.client;

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/scm/protocol/ScmBlockLocationProtocol.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/scm/protocol/ScmBlockLocationProtocol.java
@@ -114,4 +114,6 @@ public interface ScmBlockLocationProtocol extends Closeable {
    */
   List<DatanodeDetails> sortDatanodes(List<String> nodes,
       String clientMachine) throws IOException;
+
+  String getTopologyInformation() throws IOException;
 }

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/scm/protocolPB/ScmBlockLocationProtocolClientSideTranslatorPB.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/scm/protocolPB/ScmBlockLocationProtocolClientSideTranslatorPB.java
@@ -38,6 +38,8 @@ import org.apache.hadoop.hdds.protocol.proto.ScmBlockLocationProtocolProtos.Allo
 import org.apache.hadoop.hdds.protocol.proto.ScmBlockLocationProtocolProtos.AllocateScmBlockResponseProto;
 import org.apache.hadoop.hdds.protocol.proto.ScmBlockLocationProtocolProtos.DeleteScmKeyBlocksRequestProto;
 import org.apache.hadoop.hdds.protocol.proto.ScmBlockLocationProtocolProtos.DeleteScmKeyBlocksResponseProto;
+import org.apache.hadoop.hdds.protocol.proto.ScmBlockLocationProtocolProtos.GetTopologyInformationRequestProto;
+import org.apache.hadoop.hdds.protocol.proto.ScmBlockLocationProtocolProtos.GetTopologyInformationResponseProto;
 import org.apache.hadoop.hdds.protocol.proto.ScmBlockLocationProtocolProtos.KeyBlocks;
 import org.apache.hadoop.hdds.protocol.proto.ScmBlockLocationProtocolProtos
     .SortDatanodesRequestProto;
@@ -318,6 +320,23 @@ public final class ScmBlockLocationProtocolClientSideTranslatorPB
         .map(node -> DatanodeDetails.getFromProtoBuf(node))
         .collect(Collectors.toList()));
     return results;
+  }
+
+  @Override
+  public String getTopologyInformation() throws IOException {
+    GetTopologyInformationRequestProto request =
+        GetTopologyInformationRequestProto.newBuilder().build();
+    SCMBlockLocationRequest wrapper =
+        createSCMBlockRequest(Type.GetTopologyInformation)
+            .setGetTopologyInformationRequest(request)
+            .build();
+
+    final SCMBlockLocationResponse wrappedResponse =
+        handleError(submitRequest(wrapper));
+    GetTopologyInformationResponseProto resp =
+        wrappedResponse.getGetTopologyInformationResponse();
+
+    return resp.getSchemaFile();
   }
 
   @Override

--- a/hadoop-hdds/interface-server/src/main/proto/ScmServerProtocol.proto
+++ b/hadoop-hdds/interface-server/src/main/proto/ScmServerProtocol.proto
@@ -39,6 +39,7 @@ enum Type {
   GetScmInfo         = 13;
   SortDatanodes      = 14;
   AddScm             = 15;
+  GetTopologyInformation = 16;
 }
 
 message SCMBlockLocationRequest {
@@ -56,6 +57,7 @@ message SCMBlockLocationRequest {
   optional hadoop.hdds.GetScmInfoRequestProto getScmInfoRequest         = 13;
   optional SortDatanodesRequestProto          sortDatanodesRequest      = 14;
   optional hadoop.hdds.AddScmRequestProto     addScmRequestProto       = 15;
+  optional GetTopologyInformationRequestProto getTopologyInformationRequest = 16;
 }
 
 message SCMBlockLocationResponse {
@@ -80,6 +82,7 @@ message SCMBlockLocationResponse {
   optional hadoop.hdds.GetScmInfoResponseProto getScmInfoResponse         = 13;
   optional SortDatanodesResponseProto          sortDatanodesResponse      = 14;
   optional hadoop.hdds.AddScmResponseProto     addScmResponse        = 15;
+  optional GetTopologyInformationResponseProto getTopologyInformationResponse = 16;
 }
 
 /**
@@ -224,6 +227,13 @@ message SortDatanodesRequestProto{
 
 message SortDatanodesResponseProto{
   repeated DatanodeDetailsProto node = 1;
+}
+
+message GetTopologyInformationRequestProto {
+}
+
+message GetTopologyInformationResponseProto {
+  required string schemaFile = 1;
 }
 
 /**

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/protocol/ScmBlockLocationProtocolServerSideTranslatorPB.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/protocol/ScmBlockLocationProtocolServerSideTranslatorPB.java
@@ -162,6 +162,7 @@ public final class ScmBlockLocationProtocolServerSideTranslatorPB
         break;
       case GetTopologyInformation:
         response.setGetTopologyInformationResponse(getTopologyInformation());
+        break;
       default:
         // Should never happen
         throw new IOException("Unknown Operation " + request.getCmdType() +

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/protocol/ScmBlockLocationProtocolServerSideTranslatorPB.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/protocol/ScmBlockLocationProtocolServerSideTranslatorPB.java
@@ -32,6 +32,7 @@ import org.apache.hadoop.hdds.protocol.proto.ScmBlockLocationProtocolProtos.Allo
 import org.apache.hadoop.hdds.protocol.proto.ScmBlockLocationProtocolProtos.DeleteKeyBlocksResultProto;
 import org.apache.hadoop.hdds.protocol.proto.ScmBlockLocationProtocolProtos.DeleteScmKeyBlocksRequestProto;
 import org.apache.hadoop.hdds.protocol.proto.ScmBlockLocationProtocolProtos.DeleteScmKeyBlocksResponseProto;
+import org.apache.hadoop.hdds.protocol.proto.ScmBlockLocationProtocolProtos.GetTopologyInformationResponseProto;
 import org.apache.hadoop.hdds.protocol.proto.ScmBlockLocationProtocolProtos.SCMBlockLocationRequest;
 import org.apache.hadoop.hdds.protocol.proto.ScmBlockLocationProtocolProtos.SCMBlockLocationResponse;
 import org.apache.hadoop.hdds.protocol.proto.ScmBlockLocationProtocolProtos.SortDatanodesRequestProto;
@@ -159,6 +160,8 @@ public final class ScmBlockLocationProtocolServerSideTranslatorPB
             request.getSortDatanodesRequest(), request.getVersion()
         ));
         break;
+      case GetTopologyInformation:
+        response.setGetTopologyInformationResponse(getTopologyInformation());
       default:
         // Should never happen
         throw new IOException("Unknown Operation " + request.getCmdType() +
@@ -274,5 +277,14 @@ public final class ScmBlockLocationProtocolServerSideTranslatorPB
     } catch (IOException ex) {
       throw new ServiceException(ex);
     }
+  }
+
+  public GetTopologyInformationResponseProto getTopologyInformation()
+      throws IOException {
+    GetTopologyInformationResponseProto.Builder resp =
+        GetTopologyInformationResponseProto.newBuilder();
+    String schemaFile = impl.getTopologyInformation();
+    resp.setSchemaFile(schemaFile);
+    return resp.build();
   }
 }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMBlockProtocolServer.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMBlockProtocolServer.java
@@ -35,6 +35,7 @@ import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
 import org.apache.hadoop.hdds.protocol.proto.ScmBlockLocationProtocolProtos;
 import org.apache.hadoop.hdds.scm.AddSCMRequest;
+import org.apache.hadoop.hdds.scm.ScmConfigKeys;
 import org.apache.hadoop.hdds.scm.ScmInfo;
 import org.apache.hadoop.hdds.scm.container.common.helpers.AllocatedBlock;
 import org.apache.hadoop.hdds.scm.container.common.helpers.DeleteBlockResult;
@@ -333,6 +334,14 @@ public class SCMBlockProtocolServer implements
         );
       }
     }
+  }
+
+  @Override
+  public String getTopologyInformation() {
+    String schemaFile = conf.get(
+        ScmConfigKeys.OZONE_SCM_NETWORK_TOPOLOGY_SCHEMA_FILE,
+        ScmConfigKeys.OZONE_SCM_NETWORK_TOPOLOGY_SCHEMA_FILE_DEFAULT);
+    return schemaFile;
   }
 
   @Override

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/server/TestSCMBlockProtocolServer.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/server/TestSCMBlockProtocolServer.java
@@ -22,6 +22,7 @@ import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
 import org.apache.hadoop.hdds.protocol.proto.ScmBlockLocationProtocolProtos;
 import org.apache.hadoop.hdds.scm.HddsTestUtils;
+import org.apache.hadoop.hdds.scm.ScmConfigKeys;
 import org.apache.hadoop.hdds.scm.ha.SCMHAManagerStub;
 import org.apache.hadoop.hdds.scm.ha.SCMContext;
 import org.apache.hadoop.hdds.scm.node.NodeManager;
@@ -81,6 +82,15 @@ public class TestSCMBlockProtocolServer {
       scm.stop();
       scm.join();
     }
+  }
+
+  @Test
+  public void testGetTopologyInformation() {
+    String schemaFile = server.getTopologyInformation();
+    Assertions.assertEquals(
+        config.get(ScmConfigKeys.OZONE_SCM_NETWORK_TOPOLOGY_SCHEMA_FILE,
+            ScmConfigKeys.OZONE_SCM_NETWORK_TOPOLOGY_SCHEMA_FILE_DEFAULT),
+        schemaFile);
   }
 
   @Test

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/server/TestSCMBlockProtocolServer.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/server/TestSCMBlockProtocolServer.java
@@ -85,15 +85,6 @@ public class TestSCMBlockProtocolServer {
   }
 
   @Test
-  public void testGetTopologyInformation() {
-    String schemaFile = server.getTopologyInformation();
-    Assertions.assertEquals(
-        config.get(ScmConfigKeys.OZONE_SCM_NETWORK_TOPOLOGY_SCHEMA_FILE,
-            ScmConfigKeys.OZONE_SCM_NETWORK_TOPOLOGY_SCHEMA_FILE_DEFAULT),
-        schemaFile);
-  }
-
-  @Test
   public void testSortDatanodes() throws Exception {
     List<String> nodes = new ArrayList();
     nodeManager.getAllNodes().stream().forEach(

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/server/TestSCMBlockProtocolServer.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/server/TestSCMBlockProtocolServer.java
@@ -22,7 +22,6 @@ import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
 import org.apache.hadoop.hdds.protocol.proto.ScmBlockLocationProtocolProtos;
 import org.apache.hadoop.hdds.scm.HddsTestUtils;
-import org.apache.hadoop.hdds.scm.ScmConfigKeys;
 import org.apache.hadoop.hdds.scm.ha.SCMHAManagerStub;
 import org.apache.hadoop.hdds.scm.ha.SCMContext;
 import org.apache.hadoop.hdds.scm.node.NodeManager;

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/OmUtils.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/OmUtils.java
@@ -259,6 +259,7 @@ public final class OmUtils {
     case TenantListUser:
     case ListSnapshot:
     case RefetchSecretKey:
+    case RefetchTopologyInformation:
     case RangerBGSync:
       // RangerBGSync is a read operation in the sense that it doesn't directly
       // write to OM DB. And therefore it doesn't need a OMClientRequest.

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocol/OzoneManagerProtocol.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocol/OzoneManagerProtocol.java
@@ -1072,6 +1072,14 @@ public interface OzoneManagerProtocol
       throws IOException;
 
   UUID refetchSecretKey() throws IOException;
+
+  /**
+   * Refetches the updated network topology schema file from SCM.
+   *
+   * @return true if the topology information is either not null and is not
+   * empty.
+   */
+  boolean refetchTopologyInformation() throws IOException;
   /**
    * Enter, leave, or get safe mode.
    *

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocol/OzoneManagerProtocol.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocol/OzoneManagerProtocol.java
@@ -1076,10 +1076,10 @@ public interface OzoneManagerProtocol
   /**
    * Refetches the updated network topology schema file from SCM.
    *
-   * @return true if the topology information is either not null and is not
-   * empty.
+   * @return the refetched network topology schema file from SCM.
+   * @throws IOException
    */
-  boolean refetchTopologyInformation() throws IOException;
+  String refetchTopologyInformation() throws IOException;
   /**
    * Enter, leave, or get safe mode.
    *

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocolPB/OzoneManagerProtocolClientSideTranslatorPB.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocolPB/OzoneManagerProtocolClientSideTranslatorPB.java
@@ -166,6 +166,8 @@ import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.Recover
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.RecoverTrashResponse;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.RefetchSecretKeyRequest;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.RefetchSecretKeyResponse;
+import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.RefetchTopologyInformationRequest;
+import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.RefetchTopologyInformationResponse;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.RemoveAclRequest;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.RemoveAclResponse;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.RenameKeysArgs;
@@ -1526,6 +1528,19 @@ public final class OzoneManagerProtocolClientSideTranslatorPB
     final RefetchSecretKeyResponse resp =
         handleError(omResponse).getRefetchSecretKeyResponse();
     return ProtobufUtils.fromProtobuf(resp.getId());
+  }
+
+  @Override
+  public boolean refetchTopologyInformation() throws IOException {
+    final RefetchTopologyInformationRequest.Builder requestBuilder =
+        RefetchTopologyInformationRequest.newBuilder();
+    final OMRequest omRequest = createOMRequest(Type.RefetchTopologyInformation)
+        .setRefetchTopologyInformationRequest(requestBuilder)
+        .build();
+    final OMResponse omResponse = submitRequest(omRequest);
+    final RefetchTopologyInformationResponse resp =
+        handleError(omResponse).getRefetchTopologyInformationResponse();
+    return resp.getStatus();
   }
 
   /**

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocolPB/OzoneManagerProtocolClientSideTranslatorPB.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocolPB/OzoneManagerProtocolClientSideTranslatorPB.java
@@ -1531,7 +1531,7 @@ public final class OzoneManagerProtocolClientSideTranslatorPB
   }
 
   @Override
-  public boolean refetchTopologyInformation() throws IOException {
+  public String refetchTopologyInformation() throws IOException {
     final RefetchTopologyInformationRequest.Builder requestBuilder =
         RefetchTopologyInformationRequest.newBuilder();
     final OMRequest omRequest = createOMRequest(Type.RefetchTopologyInformation)
@@ -1540,7 +1540,7 @@ public final class OzoneManagerProtocolClientSideTranslatorPB
     final OMResponse omResponse = submitRequest(omRequest);
     final RefetchTopologyInformationResponse resp =
         handleError(omResponse).getRefetchTopologyInformationResponse();
-    return resp.getStatus();
+    return resp.getUpdatedSchema();
   }
 
   /**

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/TestDelegationToken.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/TestDelegationToken.java
@@ -294,7 +294,7 @@ public final class TestDelegationToken {
       // Start OM
       om.setCertClient(new CertificateClientTestImpl(conf));
       om.setScmBlockLocationClient(new ScmBlockLocationClient(
-          new ScmBlockLocationTestingClient(null, null, 0)));
+          new ScmBlockLocationTestingClient(null, null, 0, conf)));
       om.start();
       UserGroupInformation ugi = UserGroupInformation.getCurrentUser();
       String username = ugi.getUserName();

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/TestDelegationToken.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/TestDelegationToken.java
@@ -29,6 +29,7 @@ import java.util.Properties;
 import org.apache.hadoop.hdds.annotation.InterfaceAudience;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.scm.ScmConfig;
+import org.apache.hadoop.hdds.scm.client.ScmBlockLocationClient;
 import org.apache.hadoop.hdds.scm.server.SCMHTTPServerConfig;
 import org.apache.hadoop.hdds.scm.server.StorageContainerManager;
 import org.apache.hadoop.hdds.security.SecurityConfig;
@@ -41,6 +42,7 @@ import org.apache.hadoop.metrics2.lib.DefaultMetricsSystem;
 import org.apache.hadoop.minikdc.MiniKdc;
 import org.apache.hadoop.ozone.om.OMStorage;
 import org.apache.hadoop.ozone.om.OzoneManager;
+import org.apache.hadoop.ozone.om.ScmBlockLocationTestingClient;
 import org.apache.hadoop.ozone.om.exceptions.OMException;
 import org.apache.hadoop.ozone.om.protocolPB.OmTransportFactory;
 import org.apache.hadoop.ozone.om.protocolPB.OzoneManagerProtocolClientSideTranslatorPB;
@@ -291,6 +293,8 @@ public final class TestDelegationToken {
     try {
       // Start OM
       om.setCertClient(new CertificateClientTestImpl(conf));
+      om.setScmBlockLocationClient(new ScmBlockLocationClient(
+          new ScmBlockLocationTestingClient(null, null, 0)));
       om.start();
       UserGroupInformation ugi = UserGroupInformation.getCurrentUser();
       String username = ugi.getUserName();

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/TestGetTopologyInformation.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/TestGetTopologyInformation.java
@@ -1,0 +1,106 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.ozone;
+
+import org.apache.hadoop.hdds.conf.DefaultConfigManager;
+import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import org.apache.hadoop.hdds.scm.ScmConfigKeys;
+import org.apache.hadoop.ozone.client.ObjectStore;
+import org.apache.hadoop.ozone.client.OzoneClient;
+import org.apache.hadoop.ozone.om.OzoneManager;
+import org.apache.hadoop.ozone.om.protocol.OzoneManagerProtocol;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+
+import java.io.IOException;
+import java.util.UUID;
+import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_SCM_NETWORK_TOPOLOGY_SCHEMA_FILE_CHECK_DURATION;
+import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_SCM_NETWORK_TOPOLOGY_SCHEMA_FILE_REFRESH_DURATION;
+
+/**
+ * Test fetching network topology information from SCM.
+ */
+public class TestGetTopologyInformation {
+  private static MiniOzoneCluster cluster = null;
+  private static OzoneConfiguration conf;
+  private static OzoneClient client;
+  private static ObjectStore store;
+  private static OzoneManagerProtocol writeClient;
+  private ClassLoader classLoader =
+      Thread.currentThread().getContextClassLoader();
+
+  @BeforeClass
+  public static void init() throws Exception {
+    conf = new OzoneConfiguration();
+    String clusterId = UUID.randomUUID().toString();
+    String scmId = UUID.randomUUID().toString();
+    String omId = UUID.randomUUID().toString();
+    conf.set(OZONE_SCM_NETWORK_TOPOLOGY_SCHEMA_FILE_REFRESH_DURATION, "15s");
+    conf.set(OZONE_SCM_NETWORK_TOPOLOGY_SCHEMA_FILE_CHECK_DURATION, "2s");
+    cluster = MiniOzoneCluster.newBuilder(conf)
+        .setClusterId(clusterId)
+        .setScmId(scmId)
+        .setOmId(omId)
+        .setNumOfOzoneManagers(3)
+        .setNumOfStorageContainerManagers(3)
+        .build();
+    cluster.waitForClusterToBeReady();
+    client = cluster.newClient();
+    store = client.getObjectStore();
+    writeClient = store.getClientProxy().getOzoneManagerClient();
+  }
+
+  @AfterClass
+  public static void stop() {
+    if (cluster != null) {
+      cluster.stop();
+    }
+    DefaultConfigManager.clearDefaultConfigs();
+  }
+
+  @Test
+  public void testGetTopologyInformation()
+      throws InterruptedException, IOException {
+    String expected =
+        conf.get(ScmConfigKeys.OZONE_SCM_NETWORK_TOPOLOGY_SCHEMA_FILE);
+    String actual = writeClient.refetchTopologyInformation();
+    Assertions.assertEquals(expected, actual);
+
+    testWithUpdatedTopologyInformation();
+  }
+
+  /**
+   * Modify the path to SCM's network topology schema file to test whether OM
+   * refetches the updated file within the specified refresh duration.
+   * @throws InterruptedException
+   */
+  public void testWithUpdatedTopologyInformation()
+      throws InterruptedException, IOException {
+    String filePath =
+        classLoader.getResource("./networkTopologyTestFiles/test-topology.xml")
+            .getPath();
+    conf.set(ScmConfigKeys.OZONE_SCM_NETWORK_TOPOLOGY_SCHEMA_FILE, filePath);
+    Thread.sleep(30000);
+    String expected =
+        conf.get(ScmConfigKeys.OZONE_SCM_NETWORK_TOPOLOGY_SCHEMA_FILE);
+    String actual = writeClient.refetchTopologyInformation();
+    Assertions.assertEquals(expected, actual);
+  }
+}

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/TestGetTopologyInformation.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/TestGetTopologyInformation.java
@@ -22,7 +22,6 @@ import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.scm.ScmConfigKeys;
 import org.apache.hadoop.ozone.client.ObjectStore;
 import org.apache.hadoop.ozone.client.OzoneClient;
-import org.apache.hadoop.ozone.om.OzoneManager;
 import org.apache.hadoop.ozone.om.protocol.OzoneManagerProtocol;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/TestSecureOzoneCluster.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/TestSecureOzoneCluster.java
@@ -263,7 +263,7 @@ final class TestSecureOzoneCluster {
       clusterId = UUID.randomUUID().toString();
       scmId = UUID.randomUUID().toString();
       omId = UUID.randomUUID().toString();
-      scmBlockClient = new ScmBlockLocationTestingClient(null, null, 0);
+      scmBlockClient = new ScmBlockLocationTestingClient(null, null, 0, conf);
 
       startMiniKdc();
       setSecureConfig();

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOmContainerLocationCache.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOmContainerLocationCache.java
@@ -101,6 +101,7 @@ import static com.google.common.collect.Sets.newHashSet;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.concurrent.CompletableFuture.completedFuture;
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_KEY_PREALLOCATION_BLOCKS_MAX;
+import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_NETWORK_TOPOLOGY_SCHEMA_FILE;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.argThat;
@@ -161,6 +162,8 @@ public class TestOmContainerLocationCache {
     mockScmBlockLocationProtocol = mock(ScmBlockLocationProtocol.class);
     mockScmContainerClient =
         Mockito.mock(StorageContainerLocationProtocol.class);
+    when(mockScmBlockLocationProtocol.getTopologyInformation()).thenReturn(
+        conf.get(OZONE_SCM_NETWORK_TOPOLOGY_SCHEMA_FILE));
 
     OmTestManagers omTestManagers = new OmTestManagers(conf,
         mockScmBlockLocationProtocol, mockScmContainerClient);

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerListVolumesSecure.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerListVolumesSecure.java
@@ -211,7 +211,7 @@ public class TestOzoneManagerListVolumesSecure {
 
     om = OzoneManager.createOm(conf);
     om.setScmBlockLocationClient(new ScmBlockLocationClient(
-        new ScmBlockLocationTestingClient(null, null, 0)));
+        new ScmBlockLocationTestingClient(null, null, 0, conf)));
     om.setCertClient(new CertificateClientTestImpl(conf));
     om.start();
 

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerListVolumesSecure.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerListVolumesSecure.java
@@ -45,6 +45,7 @@ import java.util.concurrent.Callable;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import org.apache.hadoop.hdds.scm.client.ScmBlockLocationClient;
 import org.apache.hadoop.hdds.security.x509.certificate.client.CertificateClientTestImpl;
 import org.apache.hadoop.minikdc.MiniKdc;
 import org.apache.hadoop.ozone.OzoneAcl;
@@ -209,6 +210,8 @@ public class TestOzoneManagerListVolumesSecure {
     OzoneManager.setTestSecureOmFlag(true);
 
     om = OzoneManager.createOm(conf);
+    om.setScmBlockLocationClient(new ScmBlockLocationClient(
+        new ScmBlockLocationTestingClient(null, null, 0)));
     om.setCertClient(new CertificateClientTestImpl(conf));
     om.start();
 

--- a/hadoop-ozone/integration-test/src/test/resources/networkTopologyTestFiles/test-topology.xml
+++ b/hadoop-ozone/integration-test/src/test/resources/networkTopologyTestFiles/test-topology.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0"?>
+<!--
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+<configuration>
+  <layoutversion>1</layoutversion>
+  <layers>
+    <layer id="datacenter">
+      <prefix></prefix>
+      <cost>1</cost>
+      <type>Root</type>
+    </layer>
+    <layer id="rack">
+      <prefix>rack</prefix>
+      <cost>1</cost>
+      <type>InnerNode</type>
+      <default>/default-rack</default>
+    </layer>
+    <layer id="nodegroup">
+      <prefix>nodegroup</prefix>
+      <cost>1</cost>
+      <type>InnerNode</type>
+      <default>/default-nodegroup</default>
+    </layer>
+    <layer id="node">
+      <prefix></prefix>
+      <cost>0</cost>
+      <type>Leaf</type>
+    </layer>
+  </layers>
+  <topology>
+    <path>/datacenter/rack/nodegroup/node</path>
+    <enforceprefix>true</enforceprefix>
+  </topology>
+</configuration>

--- a/hadoop-ozone/interface-client/src/main/proto/OmClientProtocol.proto
+++ b/hadoop-ozone/interface-client/src/main/proto/OmClientProtocol.proto
@@ -142,6 +142,7 @@ enum Type {
   SetSafeMode = 124;
   PrintCompactionLogDag = 125;
   ListKeysLight = 126;
+  RefetchTopologyInformation = 127;
 }
 
 enum SafeMode {
@@ -273,6 +274,7 @@ message OMRequest {
   optional CancelSnapshotDiffRequest        CancelSnapshotDiffRequest      = 123;
   optional SetSafeModeRequest               SetSafeModeRequest             = 124;
   optional PrintCompactionLogDagRequest     PrintCompactionLogDagRequest   = 125;
+  optional RefetchTopologyInformationRequest RefetchTopologyInformationRequest = 126;
 }
 
 message OMResponse {
@@ -390,6 +392,7 @@ message OMResponse {
   optional SetSafeModeResponse               SetSafeModeResponse           = 124;
   optional PrintCompactionLogDagResponse     PrintCompactionLogDagResponse = 125;
   optional ListKeysLightResponse             listKeysLightResponse         = 126;
+  optional RefetchTopologyInformationResponse RefetchTopologyInformationResponse = 127;
 }
 
 enum Status {
@@ -627,6 +630,14 @@ message RefetchSecretKeyRequest {
 
 message RefetchSecretKeyResponse {
     optional hdds.UUID id = 1;
+}
+
+message RefetchTopologyInformationRequest {
+
+}
+
+message RefetchTopologyInformationResponse {
+    optional bool status = 1;
 }
 
 /**

--- a/hadoop-ozone/interface-client/src/main/proto/OmClientProtocol.proto
+++ b/hadoop-ozone/interface-client/src/main/proto/OmClientProtocol.proto
@@ -644,7 +644,7 @@ message RefetchTopologyInformationRequest {
 }
 
 message RefetchTopologyInformationResponse {
-    optional bool status = 1;
+    optional string updatedSchema = 1;
 }
 
 /**

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/KeyManagerImpl.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/KeyManagerImpl.java
@@ -48,6 +48,7 @@ import org.apache.hadoop.hdds.client.ReplicationConfig;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
 import org.apache.hadoop.hdds.scm.container.common.helpers.ContainerWithPipeline;
+import org.apache.hadoop.hdds.scm.net.Node;
 import org.apache.hadoop.hdds.scm.pipeline.Pipeline;
 import org.apache.hadoop.hdds.scm.storage.BlockLocationInfo;
 import org.apache.hadoop.hdds.utils.BackgroundService;
@@ -1802,8 +1803,7 @@ public class KeyManagerImpl implements KeyManager {
               LOG.warn("No datanodes in pipeline {}", pipeline.getId());
               continue;
             }
-            sortedNodes = sortDatanodes(clientMachine, nodes, keyInfo,
-                uuidList);
+            sortedNodes = sortDatanodes(clientMachine, nodes);
             if (sortedNodes != null) {
               sortedPipelines.put(uuidSet, sortedNodes);
             }
@@ -1817,24 +1817,30 @@ public class KeyManagerImpl implements KeyManager {
     }
   }
 
-  private List<DatanodeDetails> sortDatanodes(String clientMachine,
-      List<DatanodeDetails> nodes, OmKeyInfo keyInfo, List<String> nodeList) {
-    List<DatanodeDetails> sortedNodes = null;
-    try {
-      sortedNodes = scmClient.getBlockClient()
-          .sortDatanodes(nodeList, clientMachine);
-      if (LOG.isDebugEnabled()) {
-        LOG.debug("Sorted datanodes {} for client {}, result: {}", nodes,
-            clientMachine, sortedNodes);
-      }
-    } catch (IOException e) {
-      LOG.warn("Unable to sort datanodes based on distance to client, "
-          + " volume={}, bucket={}, key={}, client={}, datanodes={}, "
-          + " exception={}",
-          keyInfo.getVolumeName(), keyInfo.getBucketName(),
-          keyInfo.getKeyName(), clientMachine, nodeList, e.getMessage());
+  public List<DatanodeDetails> sortDatanodes(String clientMachine,
+                                             List<DatanodeDetails> nodes) {
+    DatanodeDetails client = null;
+    List<DatanodeDetails> possibleClients =
+        getClientNodesByAddress(clientMachine, nodes);
+    if (possibleClients.size() > 0) {
+      client = possibleClients.get(0);
     }
-    return sortedNodes;
+    List<? extends Node> sortedNodeList = ozoneManager.getClusterMap()
+        .sortByDistanceCost(client, nodes, nodes.size());
+    List<DatanodeDetails> ret = new ArrayList<>();
+    sortedNodeList.stream().forEach(node -> ret.add((DatanodeDetails) node));
+    return ret;
+  }
+
+  private List<DatanodeDetails> getClientNodesByAddress(String clientMachine,
+      List<DatanodeDetails> nodes) {
+    List<DatanodeDetails> matchingNodes = new ArrayList<>();
+    for (DatanodeDetails node : nodes) {
+      if (node.getIpAddress().equals(clientMachine)) {
+        matchingNodes.add(node);
+      }
+    }
+    return matchingNodes;
   }
 
   private static List<String> toNodeUuid(Collection<DatanodeDetails> nodes) {

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
@@ -1138,6 +1138,16 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
   }
 
   /**
+   * For testing purpose only. This allows setting up ScmBlockLocationClient
+   * without having to fully setup a working cluster.
+   */
+  @VisibleForTesting
+  public void setScmBlockLocationClient(
+      ScmBlockLocationClient scmBlockLocationClient) {
+    this.scmBlockLocationClient = scmBlockLocationClient;
+  }
+
+  /**
    * For testing purpose only. This allows testing token in integration test
    * without fully setting up a working secure cluster.
    */

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
@@ -1089,10 +1089,9 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
     return secretKeyClient.getCurrentSecretKey().getId();
   }
 
-  public boolean refetchTopologyInformation() {
+  public String refetchTopologyInformation() {
     scmBlockLocationClient.refetchTopologyInformation();
-    String topologyInfo = scmBlockLocationClient.getTopologyInformation();
-    return topologyInfo != null && !topologyInfo.isEmpty();
+    return scmBlockLocationClient.getTopologyInformation();
   }
 
   @VisibleForTesting

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
@@ -83,6 +83,8 @@ import org.apache.hadoop.hdds.scm.ScmInfo;
 import org.apache.hadoop.hdds.scm.client.HddsClientUtils;
 import org.apache.hadoop.hdds.scm.client.ScmBlockLocationClient;
 import org.apache.hadoop.hdds.scm.ha.SCMHAUtils;
+import org.apache.hadoop.hdds.scm.net.NetworkTopology;
+import org.apache.hadoop.hdds.scm.net.NetworkTopologyImpl;
 import org.apache.hadoop.hdds.server.OzoneAdmins;
 import org.apache.hadoop.hdds.utils.db.Table;
 import org.apache.hadoop.hdds.utils.db.Table.KeyValue;
@@ -388,6 +390,7 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
   private final OMStorage omStorage;
   private final ScmBlockLocationProtocol scmBlockClient;
   private final StorageContainerLocationProtocol scmContainerClient;
+  private NetworkTopology clusterMap;
   private ObjectName omInfoBeanName;
   private Timer metricsTimer;
   private ScheduleOMMetricsWriteTask scheduleOMMetricsWriteTask;
@@ -1147,6 +1150,10 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
     this.scmBlockLocationClient = scmBlockLocationClient;
   }
 
+  public NetworkTopology getClusterMap() {
+    return clusterMap;
+  }
+
   /**
    * For testing purpose only. This allows testing token in integration test
    * without fully setting up a working secure cluster.
@@ -1706,6 +1713,9 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
       LOG.error("Unable to initialize network topology schema file. ", ex);
       throw new UncheckedIOException(ex);
     }
+
+    clusterMap = new NetworkTopologyImpl(
+        scmBlockLocationClient.getTopologyInformation());
 
     try {
       httpServer = new OzoneManagerHttpServer(configuration, this);

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/protocolPB/OzoneManagerRequestHandler.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/protocolPB/OzoneManagerRequestHandler.java
@@ -1024,7 +1024,7 @@ public class OzoneManagerRequestHandler implements RequestHandler {
   private RefetchTopologyInformationResponse refetchTopologyInformation() {
     RefetchTopologyInformationResponse response =
         RefetchTopologyInformationResponse.newBuilder()
-            .setStatus(impl.refetchTopologyInformation())
+            .setUpdatedSchema(impl.refetchTopologyInformation())
             .build();
     return response;
   }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/protocolPB/OzoneManagerRequestHandler.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/protocolPB/OzoneManagerRequestHandler.java
@@ -91,6 +91,7 @@ import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.GetKeyI
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.PrintCompactionLogDagRequest;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.PrintCompactionLogDagResponse;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.RefetchSecretKeyResponse;
+import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.RefetchTopologyInformationResponse;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.InfoBucketRequest;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.InfoBucketResponse;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.InfoVolumeRequest;
@@ -354,6 +355,10 @@ public class OzoneManagerRequestHandler implements RequestHandler {
             printCompactionLogDag(request.getPrintCompactionLogDagRequest());
         responseBuilder
             .setPrintCompactionLogDagResponse(printCompactionLogDagResponse);
+        break;
+      case RefetchTopologyInformation:
+        responseBuilder.setRefetchTopologyInformationResponse(
+            refetchTopologyInformation());
         break;
       default:
         responseBuilder.setSuccess(false);
@@ -1013,6 +1018,14 @@ public class OzoneManagerRequestHandler implements RequestHandler {
     RefetchSecretKeyResponse response =
         RefetchSecretKeyResponse.newBuilder()
             .setId(ProtobufUtils.toProtobuf(uuid)).build();
+    return response;
+  }
+
+  private RefetchTopologyInformationResponse refetchTopologyInformation() {
+    RefetchTopologyInformationResponse response =
+        RefetchTopologyInformationResponse.newBuilder()
+            .setStatus(impl.refetchTopologyInformation())
+            .build();
     return response;
   }
 

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/OmTestManagers.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/OmTestManagers.java
@@ -21,6 +21,7 @@ import org.apache.hadoop.crypto.key.KeyProviderCryptoExtension;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.scm.HddsWhiteboxTestUtils;
 import org.apache.hadoop.hdds.scm.ScmConfigKeys;
+import org.apache.hadoop.hdds.scm.client.ScmBlockLocationClient;
 import org.apache.hadoop.hdds.scm.protocol.ScmBlockLocationProtocol;
 import org.apache.hadoop.hdds.scm.protocol.StorageContainerLocationProtocol;
 import org.apache.hadoop.metrics2.lib.DefaultMetricsSystem;
@@ -102,12 +103,16 @@ public final class OmTestManagers {
     keyManager = (KeyManagerImpl) HddsWhiteboxTestUtils
         .getInternalState(om, "keyManager");
     ScmClient scmClient = new ScmClient(scmBlockClient, containerClient, conf);
+    ScmBlockLocationClient scmBlockLocationClient =
+        new ScmBlockLocationClient(scmBlockClient);
     HddsWhiteboxTestUtils.setInternalState(om,
         "scmClient", scmClient);
     HddsWhiteboxTestUtils.setInternalState(keyManager,
         "scmClient", scmClient);
     HddsWhiteboxTestUtils.setInternalState(keyManager,
         "secretManager", Mockito.mock(OzoneBlockTokenSecretManager.class));
+    HddsWhiteboxTestUtils.setInternalState(om,
+        "scmBlockLocationClient", scmBlockLocationClient);
 
     om.start();
     writeClient = OzoneClientFactory.getRpcClient(conf)

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/OmTestManagers.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/OmTestManagers.java
@@ -88,7 +88,7 @@ public final class OmTestManagers {
           Mockito.mock(StorageContainerLocationProtocol.class);
     }
     scmBlockClient = blockClient != null ? blockClient :
-        new ScmBlockLocationTestingClient(null, null, 0);
+        new ScmBlockLocationTestingClient(null, null, 0, conf);
 
     conf.set(ScmConfigKeys.OZONE_SCM_CLIENT_ADDRESS_KEY, "127.0.0.1:0");
     DefaultMetricsSystem.setMiniClusterMode(true);

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/ScmBlockLocationTestingClient.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/ScmBlockLocationTestingClient.java
@@ -199,6 +199,11 @@ public class ScmBlockLocationTestingClient implements ScmBlockLocationProtocol {
     return null;
   }
 
+  @Override
+  public String getTopologyInformation() throws IOException {
+    return null;
+  }
+
   /**
    * Return the number of blocks puesdo deleted by this testing client.
    */

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/ScmBlockLocationTestingClient.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/ScmBlockLocationTestingClient.java
@@ -24,9 +24,11 @@ import org.apache.hadoop.hdds.client.BlockID;
 import org.apache.hadoop.hdds.client.ContainerBlockID;
 import org.apache.hadoop.hdds.client.ReplicationConfig;
 import org.apache.hadoop.hdds.client.StandaloneReplicationConfig;
+import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationFactor;
 import org.apache.hadoop.hdds.scm.AddSCMRequest;
+import org.apache.hadoop.hdds.scm.ScmConfigKeys;
 import org.apache.hadoop.hdds.scm.ScmInfo;
 import org.apache.hadoop.hdds.scm.container.common.helpers.AllocatedBlock;
 import org.apache.hadoop.hdds.scm.container.common.helpers.DeleteBlockResult;
@@ -78,6 +80,7 @@ public class ScmBlockLocationTestingClient implements ScmBlockLocationProtocol {
 
   // The number of blocks deleted by this client
   private int numBlocksDeleted = 0;
+  private OzoneConfiguration conf;
 
   /**
    * If ClusterID or SCMID is blank a per instance ID is generated.
@@ -88,12 +91,13 @@ public class ScmBlockLocationTestingClient implements ScmBlockLocationProtocol {
    * a positive number for that frequency of failure.
    */
   public ScmBlockLocationTestingClient(String clusterID, String scmId,
-      int failCallsFrequency) {
+      int failCallsFrequency, OzoneConfiguration conf) {
     this.clusterID = StringUtils.isNotBlank(clusterID) ? clusterID :
         UUID.randomUUID().toString();
     this.scmId = StringUtils.isNotBlank(scmId) ? scmId :
         UUID.randomUUID().toString();
     this.failCallsFrequency = Math.abs(failCallsFrequency);
+    this.conf = conf;
     switch (this.failCallsFrequency) {
     case 0:
       LOG.debug("Set to no failure mode, all delete block calls will " +
@@ -200,8 +204,11 @@ public class ScmBlockLocationTestingClient implements ScmBlockLocationProtocol {
   }
 
   @Override
-  public String getTopologyInformation() throws IOException {
-    return null;
+  public String getTopologyInformation() {
+    String schemaFile = conf.get(
+        ScmConfigKeys.OZONE_SCM_NETWORK_TOPOLOGY_SCHEMA_FILE,
+        ScmConfigKeys.OZONE_SCM_NETWORK_TOPOLOGY_SCHEMA_FILE_DEFAULT);
+    return schemaFile;
   }
 
   /**

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestKeyManagerUnit.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestKeyManagerUnit.java
@@ -42,6 +42,7 @@ import org.apache.hadoop.hdds.protocol.DatanodeDetails;
 import org.apache.hadoop.hdds.protocol.MockDatanodeDetails;
 import org.apache.hadoop.hdds.protocol.StorageType;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationFactor;
+import org.apache.hadoop.hdds.scm.ScmConfigKeys;
 import org.apache.hadoop.hdds.scm.container.common.helpers.ContainerWithPipeline;
 import org.apache.hadoop.hdds.scm.container.ContainerInfo;
 import org.apache.hadoop.hdds.scm.pipeline.MockPipeline;
@@ -118,6 +119,9 @@ public class TestKeyManagerUnit {
         testDir.toString());
     containerClient = Mockito.mock(StorageContainerLocationProtocol.class);
     blockClient = Mockito.mock(ScmBlockLocationProtocol.class);
+    when(blockClient.getTopologyInformation()).thenReturn(
+        configuration.get(
+            ScmConfigKeys.OZONE_SCM_NETWORK_TOPOLOGY_SCHEMA_FILE));
 
     OmTestManagers omTestManagers
         = new OmTestManagers(configuration, blockClient, containerClient);

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/service/TestKeyDeletingService.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/service/TestKeyDeletingService.java
@@ -172,7 +172,7 @@ public class TestKeyDeletingService {
     OzoneConfiguration conf = createConfAndInitValues();
     ScmBlockLocationProtocol blockClient =
         //failCallsFrequency = 1 , means all calls fail.
-        new ScmBlockLocationTestingClient(null, null, 1);
+        new ScmBlockLocationTestingClient(null, null, 1, conf);
     OmTestManagers omTestManagers
         = new OmTestManagers(conf, blockClient, null);
     KeyManager keyManager = omTestManagers.getKeyManager();
@@ -217,7 +217,7 @@ public class TestKeyDeletingService {
     OzoneConfiguration conf = createConfAndInitValues();
     ScmBlockLocationProtocol blockClient =
         //failCallsFrequency = 1 , means all calls fail.
-        new ScmBlockLocationTestingClient(null, null, 1);
+        new ScmBlockLocationTestingClient(null, null, 1, conf);
     OmTestManagers omTestManagers
         = new OmTestManagers(conf, blockClient, null);
     KeyManager keyManager = omTestManagers.getKeyManager();
@@ -264,7 +264,7 @@ public class TestKeyDeletingService {
     OzoneConfiguration conf = createConfAndInitValues();
     ScmBlockLocationProtocol blockClient =
         //failCallsFrequency = 1 , means all calls fail.
-        new ScmBlockLocationTestingClient(null, null, 1);
+        new ScmBlockLocationTestingClient(null, null, 1, conf);
     OmTestManagers omTestManagers
         = new OmTestManagers(conf, blockClient, null);
     KeyManager keyManager = omTestManagers.getKeyManager();


### PR DESCRIPTION
## What changes were proposed in this pull request?

[To be merged post  PR #5391]

- The NetworkTopology calculation can be moved to OM by utilizing the network topology file fetched from SCM ([HDDS-9389](https://issues.apache.org/jira/browse/HDDS-9389). Introduce new API and cache refresh for serving network topology schema to OM)
- On top of the NetworkTopology object obtained, NetworkTopology#sortByDistanceCost would be called.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-9439

## How was this patch tested?

Existing test cases should cover the changes.
