### PR TITLE
HDDS-9441. Support Recon om snapshot full update interval delay

### DIFF
--- a/hadoop-hdds/common/src/main/resources/ozone-default.xml
+++ b/hadoop-hdds/common/src/main/resources/ozone-default.xml
@@ -4228,4 +4228,20 @@
       to existing buckets till this operation is completed.
     </description>
   </property>
+  <property>
+    <name>recon.om.snapshot.full.update.interval.enable</name>
+    <value>false</value>
+    <tag>OZONE, RECON</tag>
+    <description>
+      Whether to enable recon to fetch ozone manager rocks DB from ozone manager regularly
+    </description>
+  </property>
+  <property>
+    <name>recon.om.snapshot.full.update.interval.delay</name>
+    <value>12h</value>
+    <tag>OZONE, RECON</tag>
+    <description>
+      Recon regularly fetches ozone manager rocks DB from ozone manager and updates recon rocks DB information
+    </description>
+  </property>
 </configuration>

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/ReconServerConfigKeys.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/ReconServerConfigKeys.java
@@ -168,6 +168,18 @@ public final class  ReconServerConfigKeys {
 
   public static final String
       OZONE_RECON_SCM_SNAPSHOT_TASK_INITIAL_DELAY_DEFAULT = "1m";
+
+  public static final String RECON_OM_SNAPSHOT_FULL_UPDATE_INTERVAL_ENABLE =
+          "recon.om.snapshot.full.update.interval.enable";
+
+  public static final boolean
+          RECON_OM_SNAPSHOT_FULL_UPDATE_INTERVAL_ENABLE_DEFAULT = false;
+
+  public static final String RECON_OM_SNAPSHOT_FULL_UPDATE_INTERVAL_DALAY =
+          "recon.om.snapshot.full.update.interval.delay";
+
+  public static final String
+          RECON_OM_SNAPSHOT_FULL_UPDATE_INTERVAL_DALAY_DEFAULT = "12h";
   /**
    * Private constructor for utility class.
    */


### PR DESCRIPTION
## Background

There are two methods for retrieving om roskDB snapshots from om: incremental update and full update. Incremental update may result in inaccurate update data due to cluster operations and other reasons, resulting in inaccurate record statistics. Therefore, it is necessary to add a timed full update function to update the om roskDB snapshot in a timely and full manner, ensuring the accuracy of recon statistical information. The following is the test report.

## Configuration

Enable zone recon to support the XML configuration items recon. om. snapshot. full. update. interval. enable and recon. om. snapshot. full. update. interval. delay. Set the time interval for recon to schedule and fully obtain om roskDB snapshots. The configuration is as follows:

```
<property>
 <name>recon.om.snapshot.full.update.interval.delay</name>
  <value>5m</value>
  <tag>OZONE, RECON</tag>
  <description>
    Recon regularly fetches ozone manager rocks DB from ozone manager and updates recon rocks DB information
  </description>
</property>

<property>
  <name>recon.om.snapshot.full.update.interval.enable</name>
  <value>true</value>
  <tag>OZONE, RECON</tag>
  <description>
    Whether to enable recon to fetch ozone manager rocks DB from ozone manager regularly
  </description>
</property>
```

## Test result
**2023-10-12 12:01:29,922**
```
org.apache.hadoop.ozone.recon.spi.impl.OzoneManagerServiceProviderImpl: Syncing data from Ozone Manager.
2023-10-12 12:01:29,922 [pool-27-thread-1] INFO org.apache.hadoop.ozone.recon.spi.impl.OzoneManagerServiceProviderImpl: Obtaining full snapshot from Ozone Manager
2023-10-12 12:01:33,729 [pool-27-thread-1] INFO org.apache.hadoop.ozone.recon.spi.impl.OzoneManagerServiceProviderImpl: Got new checkpoint from OM : /home/hadoop-addfullUpdateXML-03/ozonedata/omdbdir/om.snapshot.db_1697083289922
2023-10-12 12:01:33,734 [pool-27-thread-1] INFO org.apache.hadoop.ozone.om.helpers.OmKeyInfo: OmKeyInfo.getCodec ignorePipeline = true
2023-10-12 12:01:34,149 [pool-27-thread-1] INFO org.apache.hadoop.ozone.recon.recovery.ReconOmMetadataManagerImpl: Created OM DB handle from snapshot at /home/hadoop-addfullUpdateXML-03/ozonedata/omdbdir/om.snapshot.db_1697083289922.
```

**2023-10-12 12:06:35,387**
```
2023-10-12 12:06:35,386 [pool-27-thread-1] INFO org.apache.hadoop.ozone.recon.spi.impl.OzoneManagerServiceProviderImpl: Syncing data from Ozone Manager.
2023-10-12 12:06:35,387 [pool-27-thread-1] INFO org.apache.hadoop.ozone.recon.spi.impl.OzoneManagerServiceProviderImpl: Obtaining full snapshot from Ozone Manager
2023-10-12 12:06:35,449 [pool-27-thread-1] INFO org.apache.hadoop.ozone.recon.spi.impl.OzoneManagerServiceProviderImpl: Got new checkpoint from OM : /home/hadoop-addfullUpdateXML-03/ozonedata/omdbdir/om.snapshot.db_1697083595387
2023-10-12 12:06:35,450 [pool-27-thread-1] INFO org.apache.hadoop.ozone.recon.recovery.ReconOmMetadataManagerImpl: Cleaning up old OM snapshot db at /home/hadoop-addfullUpdateXML-03/ozonedata/omdbdir/om.snapshot.db_1697083289922.
```
