### PR TITLE
HDDS-9445. Improve flaky-test-check job name.

### DIFF
--- a/.github/workflows/intermittent-test-check.yml
+++ b/.github/workflows/intermittent-test-check.yml
@@ -46,6 +46,7 @@ env:
   TEST_METHOD: ${{ github.event.inputs.test-name }}
   ITERATIONS: ${{ github.event.inputs.iterations }}
   FAIL_FAST: ${{ github.event.inputs.fail-fast }}
+run-name: ${{ github.event_name == 'workflow_dispatch' && format('{0}#{1}[{2}]', inputs.test-class, inputs.test-name, inputs.ref) || '' }}
 jobs:
   prepare-job:
     runs-on: ubuntu-20.04


### PR DESCRIPTION
## What changes were proposed in this pull request?
Improve flaky-test-check job name to include input arguments for better usability and identification of the run.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-9445

## How was this patch tested?
Sample Run : https://github.com/sadanand48/hadoop-ozone/actions/runs/6486056047
