### PR TITLE
HDDS-9443. Skip unhealthy tests in repeated runs workflow

### DIFF
--- a/.github/workflows/intermittent-test-check.yml
+++ b/.github/workflows/intermittent-test-check.yml
@@ -120,9 +120,9 @@ jobs:
       - name: Execute tests
         run: |
           test_type=${{ needs.prepare-job.outputs.test_type }}
-          args=""
+          args="-DexcludedGroups=unhealthy,org.apache.ozone.test.UnhealthyTest"
           if [ "$test_type" = "integration" ]; then
-              args="-pl :ozone-integration-test,:mini-chaos-tests"
+              args="$args -pl :ozone-integration-test,:mini-chaos-tests"
           fi
           if [ "$TEST_METHOD" = "ALL" ]; then
               echo "Running all tests from $TEST_CLASS"

--- a/hadoop-hdds/rocks-native/src/test/java/org/apache/hadoop/hdds/utils/db/managed/TestManagedSSTDumpIterator.java
+++ b/hadoop-hdds/rocks-native/src/test/java/org/apache/hadoop/hdds/utils/db/managed/TestManagedSSTDumpIterator.java
@@ -25,9 +25,9 @@ import org.apache.hadoop.hdds.utils.NativeLibraryLoader;
 import org.apache.hadoop.hdds.utils.NativeLibraryNotLoadedException;
 import org.apache.hadoop.hdds.utils.TestUtils;
 import org.apache.ozone.test.tag.Native;
+import org.apache.ozone.test.tag.Unhealthy;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Assumptions;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Named;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -177,7 +177,7 @@ class TestManagedSSTDumpIterator {
   @Native(ROCKS_TOOLS_NATIVE_LIBRARY_NAME)
   @ParameterizedTest
   @MethodSource("keyValueFormatArgs")
-  @Disabled("HDDS-9274")
+  @Unhealthy("HDDS-9274")
   public void testSSTDumpIteratorWithKeyFormat(String keyFormat,
                                                String valueFormat)
       throws Exception {

--- a/hadoop-hdds/rocksdb-checkpoint-differ/src/test/java/org/apache/ozone/rocksdb/util/TestManagedSstFileReader.java
+++ b/hadoop-hdds/rocksdb-checkpoint-differ/src/test/java/org/apache/ozone/rocksdb/util/TestManagedSstFileReader.java
@@ -28,9 +28,9 @@ import org.apache.hadoop.hdds.utils.db.managed.ManagedOptions;
 import org.apache.hadoop.hdds.utils.db.managed.ManagedSSTDumpTool;
 import org.apache.hadoop.hdds.utils.db.managed.ManagedSstFileWriter;
 import org.apache.ozone.test.tag.Native;
+import org.apache.ozone.test.tag.Unhealthy;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Assumptions;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.rocksdb.RocksDBException;
@@ -155,7 +155,7 @@ class TestManagedSstFileReader {
   @Native(ROCKS_TOOLS_NATIVE_LIBRARY_NAME)
   @ParameterizedTest
   @ValueSource(ints = {0, 1, 2, 3, 7, 10})
-  @Disabled("HDDS-9274")
+  @Unhealthy("HDDS-9274")
   public void testGetKeyStreamWithTombstone(int numberOfFiles)
       throws RocksDBException, IOException, NativeLibraryNotLoadedException {
     Assumptions.assumeTrue(NativeLibraryLoader.getInstance()

--- a/hadoop-ozone/dev-support/checks/native.sh
+++ b/hadoop-ozone/dev-support/checks/native.sh
@@ -19,4 +19,6 @@
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 CHECK=native
 
-source "${DIR}/junit.sh" -Pnative -Drocks_tools_native "$@"
+source "${DIR}/junit.sh" -Pnative -Drocks_tools_native \
+  -DexcludedGroups="unhealthy | org.apache.ozone.test.UnhealthyTest" \
+  "$@"

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFileInterfaces.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFileInterfaces.java
@@ -69,9 +69,12 @@ import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Assert;
 
+import static org.apache.hadoop.ozone.om.helpers.BucketLayout.FILE_SYSTEM_OPTIMIZED;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assume.assumeFalse;
+
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -222,6 +225,8 @@ public class TestOzoneFileInterfaces {
 
   @Test
   public void testFileSystemInit() throws IOException {
+    assumeFalse(FILE_SYSTEM_OPTIMIZED.equals(getBucketLayout()));
+
     if (setDefaultFs) {
       assertTrue(
           "The initialized file system is not OzoneFileSystem but " +
@@ -234,6 +239,8 @@ public class TestOzoneFileInterfaces {
 
   @Test
   public void testOzFsReadWrite() throws IOException {
+    assumeFalse(FILE_SYSTEM_OPTIMIZED.equals(getBucketLayout()));
+
     long currentTime = Time.now();
     int stringLen = 20;
     OMMetadataManager metadataManager = cluster.getOzoneManager()
@@ -320,6 +327,8 @@ public class TestOzoneFileInterfaces {
 
   @Test
   public void testReplication() throws IOException {
+    assumeFalse(FILE_SYSTEM_OPTIMIZED.equals(getBucketLayout()));
+
     int stringLen = 20;
     String data = RandomStringUtils.randomAlphanumeric(stringLen);
     String filePath = RandomStringUtils.randomAlphanumeric(5);
@@ -346,6 +355,8 @@ public class TestOzoneFileInterfaces {
 
   @Test
   public void testDirectory() throws IOException {
+    assumeFalse(FILE_SYSTEM_OPTIMIZED.equals(getBucketLayout()));
+
     String leafName = RandomStringUtils.randomAlphanumeric(5);
     OMMetadataManager metadataManager = cluster.getOzoneManager()
         .getMetadataManager();
@@ -538,6 +549,7 @@ public class TestOzoneFileInterfaces {
 
   @Test
   public void testPathToKey() throws Exception {
+    assumeFalse(FILE_SYSTEM_OPTIMIZED.equals(getBucketLayout()));
 
     assertEquals("a/b/1", o3fs.pathToKey(new Path("/a/b/1")));
 

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFileInterfacesWithFSO.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFileInterfacesWithFSO.java
@@ -19,12 +19,8 @@
 package org.apache.hadoop.fs.ozone;
 
 import org.apache.hadoop.ozone.om.helpers.BucketLayout;
-import org.junit.Ignore;
-import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
-
-import java.io.IOException;
 
 /**
  * Test OzoneFileSystem Interfaces - prefix layout.
@@ -39,41 +35,6 @@ public class TestOzoneFileInterfacesWithFSO extends TestOzoneFileInterfaces {
       boolean useAbsolutePath, boolean enabledFileSystemPaths)
       throws Exception {
     super(setDefaultFs, useAbsolutePath, enabledFileSystemPaths);
-  }
-
-  @Override
-  @Test
-  @Ignore("HDDS-2939")
-  public void testReplication() throws IOException {
-    // ignore as this is not relevant to PREFIX layout changes
-  }
-
-  @Override
-  @Test
-  @Ignore("HDDS-2939")
-  public void testPathToKey() throws Exception {
-    // ignore as this is not relevant to PREFIX layout changes
-  }
-
-  @Override
-  @Test
-  @Ignore("HDDS-2939")
-  public void testFileSystemInit() throws IOException {
-    // ignore as this is not relevant to PREFIX layout changes
-  }
-
-  @Override
-  @Test
-  @Ignore("TODO:HDDS-2939")
-  public void testDirectory() {
-
-  }
-
-  @Override
-  @Test
-  @Ignore("TODO:HDDS-2939")
-  public void testOzFsReadWrite() {
-
   }
 
   @Override

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFileSystem.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFileSystem.java
@@ -100,6 +100,7 @@ import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_ACL_ENABLED;
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_FS_ITERATE_BATCH_SIZE;
 import static org.apache.hadoop.ozone.OzoneConsts.OM_KEY_PREFIX;
 import static org.apache.hadoop.ozone.OzoneConsts.OZONE_URI_DELIMITER;
+import static org.apache.hadoop.ozone.om.helpers.BucketLayout.FILE_SYSTEM_OPTIMIZED;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
@@ -107,6 +108,7 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+import static org.junit.Assume.assumeFalse;
 
 /**
  * Ozone file system tests that are not covered by contract tests.
@@ -185,7 +187,7 @@ public class TestOzoneFileSystem {
     conf.setBoolean(OMConfigKeys.OZONE_OM_RATIS_ENABLE_KEY, omRatisEnabled);
     conf.setBoolean(OZONE_ACL_ENABLED, true);
     conf.setBoolean(OzoneConfigKeys.OZONE_FS_HSYNC_ENABLED, true);
-    if (!bucketLayout.equals(BucketLayout.FILE_SYSTEM_OPTIMIZED)) {
+    if (!bucketLayout.equals(FILE_SYSTEM_OPTIMIZED)) {
       conf.setBoolean(OMConfigKeys.OZONE_OM_ENABLE_FILESYSTEM_PATHS,
           enabledFileSystemPaths);
     }
@@ -378,6 +380,8 @@ public class TestOzoneFileSystem {
 
   @Test
   public void testCreateWithInvalidPaths() throws Exception {
+    assumeFalse(FILE_SYSTEM_OPTIMIZED.equals(getBucketLayout()));
+
     // Test for path with ..
     Path parent = new Path("../../../../../d1/d2/");
     Path file1 = new Path(parent, "key1");
@@ -401,6 +405,8 @@ public class TestOzoneFileSystem {
 
   @Test
   public void testOzoneFsServiceLoader() throws IOException {
+    assumeFalse(FILE_SYSTEM_OPTIMIZED.equals(getBucketLayout()));
+
     assertEquals(
         FileSystem.getFileSystemClass(OzoneConsts.OZONE_URI_SCHEME, null),
         OzoneFileSystem.class);
@@ -619,6 +625,8 @@ public class TestOzoneFileSystem {
 
   @Test
   public void testListStatusWithIntermediateDir() throws Exception {
+    assumeFalse(FILE_SYSTEM_OPTIMIZED.equals(getBucketLayout()));
+
     String keyName = "object-dir/object-name";
     OmKeyArgs keyArgs = new OmKeyArgs.Builder()
         .setVolumeName(volumeName)
@@ -720,6 +728,8 @@ public class TestOzoneFileSystem {
    */
   @Test
   public void testListStatusOnLargeDirectory() throws Exception {
+    assumeFalse(FILE_SYSTEM_OPTIMIZED.equals(getBucketLayout()));
+
     deleteRootDir(); // cleanup
     Set<String> paths = new TreeSet<>();
     int numDirs = LISTING_PAGE_SIZE + LISTING_PAGE_SIZE / 2;
@@ -1469,6 +1479,8 @@ public class TestOzoneFileSystem {
   @Test
   public void testGetDirectoryModificationTime()
       throws IOException, InterruptedException {
+    assumeFalse(FILE_SYSTEM_OPTIMIZED.equals(getBucketLayout()));
+
     Path mdir1 = new Path("/mdir1");
     Path mdir11 = new Path(mdir1, "mdir11");
     Path mdir111 = new Path(mdir11, "mdir111");

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFileSystemWithFSO.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFileSystemWithFSO.java
@@ -36,7 +36,6 @@ import org.apache.ozone.test.GenericTestUtils;
 import org.junit.Assert;
 import org.junit.After;
 import org.junit.BeforeClass;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -89,27 +88,6 @@ public class TestOzoneFileSystemWithFSO extends TestOzoneFileSystem {
 
   private static final Logger LOG =
       LoggerFactory.getLogger(TestOzoneFileSystemWithFSO.class);
-
-  @Override
-  @Test
-  @Ignore("HDDS-2939")
-  public void testGetDirectoryModificationTime() {
-    // ignore as this is not relevant to PREFIX layout changes
-  }
-
-  @Override
-  @Test
-  @Ignore("HDDS-2939")
-  public void testOzoneFsServiceLoader() {
-    // ignore as this is not relevant to PREFIX layout changes
-  }
-
-  @Override
-  @Test
-  @Ignore("HDDS-2939")
-  public void testCreateWithInvalidPaths() {
-    // ignore as this is not relevant to PREFIX layout changes
-  }
 
   @Test
   public void testListStatusWithoutRecursiveSearch() throws Exception {
@@ -447,18 +425,6 @@ public class TestOzoneFileSystemWithFSO extends TestOzoneFileSystem {
       assertEquals(bucketBeforeMTime, bucketAfterMTime);
     }
     assertEquals(fileBeforeMTime, fileAfterMTime);
-  }
-
-  @Override
-  @Test
-  @Ignore("TODO:HDDS-2939")
-  public void testListStatusWithIntermediateDir() throws Exception {
-  }
-
-  @Override
-  @Test
-  @Ignore("TODO:HDDS-5012")
-  public void testListStatusOnLargeDirectory() throws Exception {
   }
 
   @Test

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestRootedOzoneFileSystem.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestRootedOzoneFileSystem.java
@@ -135,6 +135,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+import static org.junit.Assume.assumeFalse;
 
 /**
  * Ozone file system tests that are not covered by contract tests.
@@ -305,6 +306,8 @@ public class TestRootedOzoneFileSystem {
 
   @Test
   public void testOzoneFsServiceLoader() throws IOException {
+    assumeFalse(isBucketFSOptimized);
+
     OzoneConfiguration confTestLoader = new OzoneConfiguration();
     // fs.ofs.impl should be loaded from META-INF, no need to explicitly set it
     Assert.assertEquals(FileSystem.getFileSystemClass(
@@ -783,6 +786,8 @@ public class TestRootedOzoneFileSystem {
    */
   @Test
   public void testMkdirNonExistentVolume() throws Exception {
+    assumeFalse(isBucketFSOptimized);
+
     String volumeNameLocal = getRandomNonExistVolumeName();
     Path newVolume = new Path("/" + volumeNameLocal);
     fs.mkdirs(newVolume);
@@ -1149,6 +1154,8 @@ public class TestRootedOzoneFileSystem {
    */
   @Test
   public void testListStatusRootAndVolumeRecursive() throws IOException {
+    assumeFalse(isBucketFSOptimized);
+
     Path bucketPath1 = createRandomVolumeBucketWithDirs();
     Path bucketPath2 = createRandomVolumeBucketWithDirs();
     // listStatus("/volume/bucket")
@@ -1362,6 +1369,8 @@ public class TestRootedOzoneFileSystem {
    */
   @Test
   public void testTempMount() throws IOException {
+    assumeFalse(isBucketFSOptimized);
+
     // Prep
     // Use ClientProtocol to pass in volume ACL, ObjectStore won't do it
     ClientProtocol proxy = objectStore.getClientProxy();
@@ -1462,6 +1471,8 @@ public class TestRootedOzoneFileSystem {
 
   @Test
   public void testDeleteEmptyVolume() throws IOException {
+    assumeFalse(isBucketFSOptimized);
+
     // Create volume
     String volumeStr1 = getRandomNonExistVolumeName();
     Path volumePath1 = new Path(OZONE_URI_DELIMITER + volumeStr1);
@@ -2050,6 +2061,8 @@ public class TestRootedOzoneFileSystem {
 
   @Test
   public void testCreateWithInvalidPaths() throws Exception {
+    assumeFalse(isBucketFSOptimized);
+
     // Test for path with ..
     Path parent = new Path("../../../../../d1/d2/");
     Path file1 = new Path(parent, "key1");

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestRootedOzoneFileSystemWithFSO.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestRootedOzoneFileSystemWithFSO.java
@@ -26,7 +26,6 @@ import org.apache.hadoop.ozone.om.exceptions.OMException;
 
 import org.junit.Assert;
 import org.junit.BeforeClass;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -71,49 +70,6 @@ public class TestRootedOzoneFileSystemWithFSO
   public static void init()
       throws IOException, InterruptedException, TimeoutException {
     setIsBucketFSOptimized(true);
-  }
-
-  @Override
-  @Test
-  @Ignore("HDDS-2939")
-  public void testTempMount() {
-    // ignore as this is not relevant to PREFIX layout changes
-  }
-
-  @Override
-  @Test
-  @Ignore("HDDS-2939")
-  public void testOzoneFsServiceLoader() {
-    // ignore as this is not relevant to PREFIX layout changes
-  }
-
-  @Override
-  @Test
-  @Ignore("HDDS-2939")
-  public void testCreateWithInvalidPaths() {
-    // ignore as this is not relevant to PREFIX layout changes
-  }
-
-  @Override
-  @Test
-  @Ignore("HDDS-2939")
-  public void testDeleteEmptyVolume() {
-    // ignore as this is not relevant to PREFIX layout changes
-  }
-
-  @Override
-  @Test
-  @Ignore("HDDS-2939")
-  public void testMkdirNonExistentVolume() {
-    // ignore as this is not relevant to PREFIX layout changes
-  }
-
-  /**
-   * OFS: Test recursive listStatus on root and volume.
-   */
-  @Override
-  @Ignore("TODO:HDDS-4360")
-  public void testListStatusRootAndVolumeRecursive() throws IOException {
   }
 
   /**

--- a/pom.xml
+++ b/pom.xml
@@ -1820,6 +1820,14 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
                       <bannedImport>org.apache.ratis.thirdparty.com.google.common.**</bannedImport>
                     </bannedImports>
                   </restrictImports>
+                  <restrictImports>
+                    <includeTestCode>true</includeTestCode>
+                    <reason>Disable with @Unhealthy or @Slow instead (see HDDS-9276)</reason>
+                    <bannedImports>
+                      <bannedImport>org.junit.Ignore</bannedImport>
+                      <bannedImport>org.junit.jupiter.api.Disabled</bannedImport>
+                    </bannedImports>
+                  </restrictImports>
                 </rules>
               </configuration>
             </execution>


### PR DESCRIPTION
## What changes were proposed in this pull request?

The new `flaky-test-check` workflow should skip `@Unhealthy` tests (these were `@Ignore` or `@Disabled` previously).

Also, convert a few leftover `@Disabled` instances to `@Unhealthy`.

https://issues.apache.org/jira/browse/HDDS-9443

## How was this patch tested?

Triggered run for `TestSecureOzoneCluster`, confirmed 2 unhealthy tests (of 16 total) were [excluded](https://github.com/adoroszlai/hadoop-ozone/actions/runs/6498802347):

```
[INFO] Tests run: 14, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 139.993 s - in org.apache.hadoop.ozone.TestSecureOzoneCluster
```

Regular CI:
https://github.com/adoroszlai/hadoop-ozone/actions/runs/6498802347