### PR TITLE
HDDS-9449. Create pipeline consider datanode storage.

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/ScmConfigKeys.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/ScmConfigKeys.java
@@ -608,6 +608,19 @@ public final class ScmConfigKeys {
       "ozone.scm.ha.dbtransactionbuffer.flush.interval";
   public static final long
       OZONE_SCM_HA_DBTRANSACTIONBUFFER_FLUSH_INTERVAL_DEFAULT = 600 * 1000L;
+
+  public static final String OZONE_SCM_CREATE_PIPELINE_CONSIDER_DATANODE_STORAGE =
+      "ozone.scm.create.pipeline.consider.datanode.storage";
+
+  public static final boolean OZONE_SCM_CREATE_PIPELINE_CONSIDER_DATANODE_STORAGE_DEFAULT =
+      true;
+
+  public static final String OZONE_SCM_CREATE_PIPELINE_DATANODE_STORAGE_RATE =
+      "ozone.scm.create.pipeline.datanode.storage.rate";
+
+  public static final double OZONE_SCM_CREATE_PIPELINE_DATANODE_STORAGE_RATE_DEFAULT =
+      0.9;
+
   /**
    * Never constructed.
    */

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ScmUtils.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ScmUtils.java
@@ -56,6 +56,10 @@ import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_CLIENT_BIND_HOS
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_CLIENT_BIND_HOST_KEY;
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_CLIENT_PORT_DEFAULT;
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_CLIENT_PORT_KEY;
+import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_CREATE_PIPELINE_CONSIDER_DATANODE_STORAGE;
+import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_CREATE_PIPELINE_CONSIDER_DATANODE_STORAGE_DEFAULT;
+import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_CREATE_PIPELINE_DATANODE_STORAGE_RATE;
+import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_CREATE_PIPELINE_DATANODE_STORAGE_RATE_DEFAULT;
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_DATANODE_ADDRESS_KEY;
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_DATANODE_BIND_HOST_DEFAULT;
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_DATANODE_BIND_HOST_KEY;
@@ -247,5 +251,15 @@ public final class ScmUtils {
             SCMException.ResultCodes.CA_ROTATION_IN_POST_PROGRESS);
       }
     }
+  }
+
+  public static boolean shouldConsiderDatanodeStorage(ConfigurationSource conf) {
+    return conf.getBoolean(OZONE_SCM_CREATE_PIPELINE_CONSIDER_DATANODE_STORAGE,
+        OZONE_SCM_CREATE_PIPELINE_CONSIDER_DATANODE_STORAGE_DEFAULT);
+  }
+
+  public static double getDatanodeStorageRateLimit(ConfigurationSource conf) {
+    return conf.getDouble(OZONE_SCM_CREATE_PIPELINE_DATANODE_STORAGE_RATE,
+        OZONE_SCM_CREATE_PIPELINE_DATANODE_STORAGE_RATE_DEFAULT);
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Currently, for clusters with unbalanced, the storage of the dn machine needs to be considered when creating a new pipeline. should not select a dn with full storage, because exceptions such as the machine being filled up or writing failure may occur.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-9449