### PR TITLE
HDDS-9437. Intermittent failure in test-scm-decommission

### DIFF
--- a/hadoop-ozone/dist/src/main/compose/ozonesecure-ha/test-scm-decommission.sh
+++ b/hadoop-ozone/dist/src/main/compose/ozonesecure-ha/test-scm-decommission.sh
@@ -47,4 +47,4 @@ SCMID=$(execute_command_in_container scm4.org bash -c "ozone admin scm roles" | 
 docker-compose stop scm4.org
 execute_robot_test scm3.org kinit.robot
 wait_for_execute_command scm3.org 60 "ozone admin scm decommission --nodeid=${SCMID} | grep Decommissioned"
-execute_robot_test scm3.org scmha/scm-decommission.robot
+execute_robot_test s3g scmha/scm-decommission.robot

--- a/hadoop-ozone/dist/src/main/smoketest/scmha/scm-decommission.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/scmha/scm-decommission.robot
@@ -19,6 +19,7 @@ Library             OperatingSystem
 Library             BuiltIn
 Resource            ../commonlib.robot
 Test Timeout        5 minutes
+Suite Setup         Run Keyword if    '${SECURITY_ENABLED}' == 'true'    Kinit test user     testuser     testuser.keytab
 
 *** Variables ***
 ${VOLUME}           decom-volume


### PR DESCRIPTION
## What changes were proposed in this pull request?

The robot test currently was decommissioning the scm node that we were running the tests from. Hence the tests were abruptly stopping without any Pass/Fail message.
Changing the exec container to s3g to prevent this.

## What is the link to the Apache JIRA
[HDDS-9437](https://issues.apache.org/jira/browse/HDDS-9437)

## How was this patch tested?
Passed CI: https://github.com/LZD-PratyushBhatt/ozone/actions/runs/6505325429/job/17669363810?pr=8