### PR TITLE
HDDS-9299. Mark TestOmSnapshot#testDayWeekMonthSnapshotCreationAndExpiration as slow

### DIFF
--- a/hadoop-hdds/test-utils/src/main/java/org/apache/ozone/test/SlowTest.java
+++ b/hadoop-hdds/test-utils/src/main/java/org/apache/ozone/test/SlowTest.java
@@ -1,0 +1,26 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.ozone.test;
+
+/**
+ * Interface to mark test classes or methods that take too much time.
+ * These are excluded from CI runs for each commit and run periodically.
+ */
+public interface SlowTest {
+  // category marker
+}

--- a/hadoop-hdds/test-utils/src/main/java/org/apache/ozone/test/SlowTest.java
+++ b/hadoop-hdds/test-utils/src/main/java/org/apache/ozone/test/SlowTest.java
@@ -18,8 +18,11 @@
 package org.apache.ozone.test;
 
 /**
- * Interface to mark test classes or methods that take too much time.
- * These are excluded from CI runs for each commit and run periodically.
+ * Interface to mark JUnit4 test classes or methods that take too much time.
+ * These are excluded from CI runs for each commit, but can be run manually or
+ * in scheduled runs.
+ *
+ * Usage: <code>@Category(SlowTest.class) @Slow("HDDS-123")</code>
  */
 public interface SlowTest {
   // category marker

--- a/hadoop-hdds/test-utils/src/main/java/org/apache/ozone/test/UnhealthyTest.java
+++ b/hadoop-hdds/test-utils/src/main/java/org/apache/ozone/test/UnhealthyTest.java
@@ -18,8 +18,12 @@
 package org.apache.ozone.test;
 
 /**
- * Interface to mark test classes or methods that are unhealthy which
+ * Interface to mark JUnit4 test classes or methods that are unhealthy, which
  * means either they are unstable or inconsistent to run.
+ * These are excluded from CI runs for each commit, but can be run manually or
+ * in scheduled runs.
+ *
+ * Usage: <code>@Category(UnhealthyTest.class) @Unhealthy("HDDS-123")</code>
  */
 public interface UnhealthyTest {
   // category marker

--- a/hadoop-hdds/test-utils/src/main/java/org/apache/ozone/test/tag/Flaky.java
+++ b/hadoop-hdds/test-utils/src/main/java/org/apache/ozone/test/tag/Flaky.java
@@ -25,9 +25,10 @@ import java.lang.annotation.Target;
 import org.junit.jupiter.api.Tag;
 
 /**
- * Annotation to mark test classes or methods with some intermittent failures.
- * These are handled separately from the normal tests.  (Not required to pass,
- * may be repeated automatically, etc.)
+ * Annotation to mark JUnit5 test classes or methods that exhibit intermittent
+ * issues.  These are run separately from the normal tests in CI.  In case of
+ * failure they may be repeated a few times.
+ * Usage: <code>@Flaky("HDDS-123")</code>
  */
 @Target({ ElementType.TYPE, ElementType.METHOD })
 @Retention(RetentionPolicy.RUNTIME)

--- a/hadoop-hdds/test-utils/src/main/java/org/apache/ozone/test/tag/Native.java
+++ b/hadoop-hdds/test-utils/src/main/java/org/apache/ozone/test/tag/Native.java
@@ -25,7 +25,7 @@ import java.lang.annotation.Target;
 import org.junit.jupiter.api.Tag;
 
 /**
- * Annotation to mark test classes that require native libraries.
+ * Annotation to mark JUnit5 test classes that require native libraries.
  */
 @Target({ ElementType.TYPE, ElementType.METHOD })
 @Retention(RetentionPolicy.RUNTIME)

--- a/hadoop-hdds/test-utils/src/main/java/org/apache/ozone/test/tag/Slow.java
+++ b/hadoop-hdds/test-utils/src/main/java/org/apache/ozone/test/tag/Slow.java
@@ -25,8 +25,10 @@ import java.lang.annotation.Target;
 import org.junit.jupiter.api.Tag;
 
 /**
- * Annotation to mark test classes or methods that take too much time.
- * These are excluded from CI runs for each commit and run periodically.
+ * Annotation to mark JUnit5 test classes or methods that take too much time.
+ * These are excluded from CI runs for each commit, but can be run manually or
+ * in scheduled runs.
+ * Usage: <code>@Slow("HDDS-123")</code>
  */
 @Target({ ElementType.TYPE, ElementType.METHOD })
 @Retention(RetentionPolicy.RUNTIME)

--- a/hadoop-hdds/test-utils/src/main/java/org/apache/ozone/test/tag/Unhealthy.java
+++ b/hadoop-hdds/test-utils/src/main/java/org/apache/ozone/test/tag/Unhealthy.java
@@ -25,10 +25,11 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * Annotation to mark test classes or methods that are unhealthy which
+ * Annotation to mark JUnit5 test classes or methods that are unhealthy which
  * means either they are unstable or inconsistent to run.
- * These are excluded from CI runs for each commit and should run only
- * during nightly or other scheduled runs.
+ * These are excluded from CI runs for each commit, but can be run manually or
+ * in scheduled runs.
+ * Usage: <code>@Unhealthy("HDDS-123")</code>
  */
 @Target({ ElementType.TYPE, ElementType.METHOD })
 @Retention(RetentionPolicy.RUNTIME)

--- a/hadoop-hdds/test-utils/src/main/java/org/apache/ozone/test/tag/package-info.java
+++ b/hadoop-hdds/test-utils/src/main/java/org/apache/ozone/test/tag/package-info.java
@@ -19,4 +19,4 @@
 /**
  * Tags are annotations for grouping tests.
  */
-package org.apache.ozone.test;
+package org.apache.ozone.test.tag;

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOmSnapshot.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOmSnapshot.java
@@ -74,7 +74,9 @@ import org.apache.hadoop.ozone.upgrade.UpgradeFinalizer;
 import org.apache.log4j.Level;
 import org.apache.log4j.Logger;
 import org.apache.ozone.test.GenericTestUtils;
+import org.apache.ozone.test.SlowTest;
 import org.apache.ozone.test.UnhealthyTest;
+import org.apache.ozone.test.tag.Slow;
 import org.apache.ozone.test.tag.Unhealthy;
 import org.jetbrains.annotations.NotNull;
 import org.junit.Assert;
@@ -2122,6 +2124,7 @@ public class TestOmSnapshot {
   }
 
   @Test
+  @Category(SlowTest.class) @Slow("HDDS-9299")
   public void testDayWeekMonthSnapshotCreationAndExpiration() throws Exception {
     String volumeA = "vol-a-" + RandomStringUtils.randomNumeric(5);
     String bucketA = "buc-a-" + RandomStringUtils.randomNumeric(5);

--- a/pom.xml
+++ b/pom.xml
@@ -2208,7 +2208,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
               <includes>
                 <include>org.apache.hadoop.ozone.client.**</include>
               </includes>
-              <excludedGroups>flaky | slow | unhealthy | org.apache.ozone.test.UnhealthyTest</excludedGroups>
+              <excludedGroups>flaky | slow | org.apache.ozone.test.SlowTest | unhealthy | org.apache.ozone.test.UnhealthyTest</excludedGroups>
             </configuration>
           </plugin>
         </plugins>
@@ -2225,7 +2225,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
               <includes>
                 <include>org.apache.hadoop.ozone.om.**</include>
               </includes>
-              <excludedGroups>flaky | slow | unhealthy | org.apache.ozone.test.UnhealthyTest</excludedGroups>
+              <excludedGroups>flaky | slow | org.apache.ozone.test.SlowTest | unhealthy | org.apache.ozone.test.UnhealthyTest</excludedGroups>
             </configuration>
           </plugin>
         </plugins>
@@ -2242,7 +2242,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
               <includes>
                 <include>org.apache.hadoop.ozone.scm.**</include>
               </includes>
-              <excludedGroups>flaky | slow | unhealthy | org.apache.ozone.test.UnhealthyTest</excludedGroups>
+              <excludedGroups>flaky | slow | org.apache.ozone.test.SlowTest | unhealthy | org.apache.ozone.test.UnhealthyTest</excludedGroups>
             </configuration>
           </plugin>
         </plugins>
@@ -2259,7 +2259,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
               <includes>
                 <include>org.apache.hadoop.fs.ozone.contract.**</include>
               </includes>
-              <excludedGroups>flaky | slow | unhealthy | org.apache.ozone.test.UnhealthyTest</excludedGroups>
+              <excludedGroups>flaky | slow | org.apache.ozone.test.SlowTest | unhealthy | org.apache.ozone.test.UnhealthyTest</excludedGroups>
             </configuration>
           </plugin>
         </plugins>
@@ -2279,7 +2279,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
               <excludes>
                 <exclude>org.apache.hadoop.fs.ozone.contract.**</exclude>
               </excludes>
-              <excludedGroups>flaky | slow | unhealthy | org.apache.ozone.test.UnhealthyTest</excludedGroups>
+              <excludedGroups>flaky | slow | org.apache.ozone.test.SlowTest | unhealthy | org.apache.ozone.test.UnhealthyTest</excludedGroups>
             </configuration>
           </plugin>
         </plugins>
@@ -2296,7 +2296,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
               <includes>
                 <include>org.apache.hadoop.hdds.**</include>
               </includes>
-              <excludedGroups>flaky | slow | unhealthy | org.apache.ozone.test.UnhealthyTest</excludedGroups>
+              <excludedGroups>flaky | slow | org.apache.ozone.test.SlowTest | unhealthy | org.apache.ozone.test.UnhealthyTest</excludedGroups>
             </configuration>
           </plugin>
         </plugins>
@@ -2321,7 +2321,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
                 <exclude>org.apache.hadoop.ozone.scm.**</exclude>
                 <exclude>org.apache.hadoop.ozone.shell.**</exclude>
               </excludes>
-              <excludedGroups>flaky | slow | unhealthy | org.apache.ozone.test.UnhealthyTest</excludedGroups>
+              <excludedGroups>flaky | slow | org.apache.ozone.test.SlowTest | unhealthy | org.apache.ozone.test.UnhealthyTest</excludedGroups>
             </configuration>
           </plugin>
         </plugins>
@@ -2340,7 +2340,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
                 <include>org.apache.hadoop.ozone.freon.**</include>
                 <include>org.apache.hadoop.ozone.shell.**</include>
               </includes>
-              <excludedGroups>flaky | slow | unhealthy | org.apache.ozone.test.UnhealthyTest</excludedGroups>
+              <excludedGroups>flaky | slow | org.apache.ozone.test.SlowTest | unhealthy | org.apache.ozone.test.UnhealthyTest</excludedGroups>
             </configuration>
           </plugin>
         </plugins>
@@ -2354,7 +2354,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-surefire-plugin</artifactId>
             <configuration>
-              <excludedGroups>flaky | slow | unhealthy | org.apache.ozone.test.UnhealthyTest</excludedGroups>
+              <excludedGroups>flaky | slow | org.apache.ozone.test.SlowTest | unhealthy | org.apache.ozone.test.UnhealthyTest</excludedGroups>
             </configuration>
           </plugin>
         </plugins>
@@ -2369,7 +2369,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
             <artifactId>maven-surefire-plugin</artifactId>
             <configuration>
               <groups>flaky</groups>
-              <excludedGroups>slow | unhealthy | org.apache.ozone.test.UnhealthyTest</excludedGroups>
+              <excludedGroups>slow | org.apache.ozone.test.SlowTest | unhealthy | org.apache.ozone.test.UnhealthyTest</excludedGroups>
             </configuration>
           </plugin>
         </plugins>


### PR DESCRIPTION
## What changes were proposed in this pull request?

`TestOmSnapshot` requires 1000-1200 seconds in CI.  Single slowest test case is testDayWeekMonthSnapshotCreationAndExpiration (added in HDDS-8378), takes 130s in each 4 parameterized runs.  I propose marking `testDayWeekMonthSnapshotCreationAndExpiration` as slow.  Slow tests are skipped in regular CI, but still can be executed manually or in scheduled runs.

`@Slow` only applies to JUnit5 tests, so this PR also adds a matching `@Category` for JUnit4.

Also:
 * improve javadoc comments on these tags/categories to clarify how they can be used
 * fix package name mismatch in `package-info.java`

https://issues.apache.org/jira/browse/HDDS-9299

## How was this patch tested?

Before:

```
Tests run: 160, Failures: 0, Errors: 0, Skipped: 5, Time elapsed: 1,066.519 s - in org.apache.hadoop.ozone.om.TestOmSnapshot
```

After:

```
Tests run: 156, Failures: 0, Errors: 0, Skipped: 5, Time elapsed: 575.976 s - in org.apache.hadoop.ozone.om.TestOmSnapshot
```

CI:
https://github.com/adoroszlai/hadoop-ozone/actions/runs/6504785239