### PR TITLE
HDDS-9454. TypedTable prefix iterator may leak CodecBuffer.

### DIFF
--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/RDBStore.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/RDBStore.java
@@ -287,7 +287,7 @@ public class RDBStore implements DBStore {
   }
 
   @Override
-  public <K, V> Table<K, V> getTable(String name,
+  public <K, V> TypedTable<K, V> getTable(String name,
       Class<K> keyType, Class<V> valueType) throws IOException {
     return new TypedTable<>(getTable(name), codecRegistry, keyType,
         valueType);

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/TypedTable.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/TypedTable.java
@@ -414,7 +414,12 @@ public class TypedTable<KEY, VALUE> implements Table<KEY, VALUE> {
       throws IOException {
     if (supportCodecBuffer) {
       final CodecBuffer prefixBuffer = encodeKeyCodecBuffer(prefix);
-      return newCodecBufferTableIterator(rawTable.iterator(prefixBuffer));
+      try {
+        return newCodecBufferTableIterator(rawTable.iterator(prefixBuffer));
+      } catch (Throwable t) {
+        prefixBuffer.release();
+        throw t;
+      }
     } else {
       final byte[] prefixBytes = encodeKey(prefix);
       return new TypedTableIterator(rawTable.iterator(prefixBytes));

--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/utils/db/TestRDBTableStore.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/utils/db/TestRDBTableStore.java
@@ -46,11 +46,16 @@ import org.junit.Rule;
 import org.rocksdb.RocksDB;
 import org.rocksdb.Statistics;
 import org.rocksdb.StatsLevel;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Tests for RocksDBTable Store.
  */
 public class TestRDBTableStore {
+  private static final Logger LOG = LoggerFactory.getLogger(
+      TestRDBTableStore.class);
+
   public static final int MAX_DB_UPDATES_SIZE_THRESHOLD = 80;
   private static int count = 0;
   private final List<String> families =
@@ -75,6 +80,7 @@ public class TestRDBTableStore {
 
   @BeforeAll
   public static void initConstants() {
+    CodecBuffer.enableLeakDetection();
     bytesOf = new byte[4][];
     for (int i = 1; i <= 3; i++) {
       bytesOf[i] = Integer.toString(i).getBytes(StandardCharsets.UTF_8);
@@ -123,6 +129,10 @@ public class TestRDBTableStore {
     if (rdbStore != null) {
       rdbStore.close();
     }
+    if (options != null) {
+      options.close();
+    }
+    CodecTestUtil.gc();
   }
 
   @Test
@@ -526,6 +536,7 @@ public class TestRDBTableStore {
     }
   }
 
+
   @Test
   public void testPrefixedIterator() throws Exception {
     int containerCount = 3;
@@ -564,6 +575,62 @@ public class TestRDBTableStore {
       }
     }
   }
+
+  @Test
+  public void testStringPrefixedIterator() throws Exception {
+    final int prefixCount = 3;
+    final int keyCount = 5;
+    final List<String> prefixes = generatePrefixes(prefixCount);
+    final List<Map<String, String>> data = generateKVs(prefixes, keyCount);
+
+    try (TypedTable<String, String> table = rdbStore.getTable(
+        "PrefixFirst", String.class, String.class)) {
+      populateTable(table, data);
+      for (String prefix : prefixes) {
+        assertIterator(keyCount, prefix, table);
+      }
+
+      final String nonExistingPrefix = RandomStringUtils.random(
+          PREFIX_LENGTH + 2, false, false);
+      assertIterator(0, nonExistingPrefix, table);
+    }
+  }
+
+  static void assertIterator(int expectedCount, String prefix,
+      TypedTable<String, String> table) throws Exception {
+    try (Table.KeyValueIterator<String, String> i = table.iterator(prefix)) {
+      int keyCount = 0;
+      for(; i.hasNext(); keyCount++) {
+        Assertions.assertEquals(prefix,
+            i.next().getKey().substring(0, PREFIX_LENGTH));
+      }
+      Assertions.assertEquals(expectedCount, keyCount);
+
+      // test seekToFirst
+      i.seekToFirst();
+      if (expectedCount > 0) {
+        // iterator should be able to seekToFirst
+        Assertions.assertTrue(i.hasNext());
+        Assertions.assertEquals(prefix,
+            i.next().getKey().substring(0, PREFIX_LENGTH));
+      }
+    }
+  }
+
+  @Test
+  public void testStringPrefixedIteratorCloseDb() throws Exception {
+    try (Table<String, String> testTable = rdbStore.getTable("PrefixFirst", String.class, String.class)) {
+      // iterator should seek to right pos in the middle
+      rdbStore.close();
+      try {
+        testTable.iterator("abc");
+        Assertions.fail();
+      } catch (IOException ioe) {
+        LOG.info("Great!", ioe);ioe.printStackTrace(System.out);
+      }
+    }
+  }
+
 
   @Test
   public void testPrefixedRangeKVs() throws Exception {
@@ -728,6 +795,16 @@ public class TestRDBTableStore {
       for (Map.Entry<String, String> entry : segment.entrySet()) {
         table.put(entry.getKey().getBytes(StandardCharsets.UTF_8),
             entry.getValue().getBytes(StandardCharsets.UTF_8));
+      }
+    }
+  }
+
+  private void populateTable(Table<String, String> table,
+      List<Map<String, String>> testData) throws IOException {
+    for (Map<String, String> segment : testData) {
+      for (Map.Entry<String, String> entry : segment.entrySet()) {
+        table.put(entry.getKey(), entry.getValue());
+        LOG.info("put {}", entry);
       }
     }
   }

--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/utils/db/TestRDBTableStore.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/utils/db/TestRDBTableStore.java
@@ -600,7 +600,7 @@ public class TestRDBTableStore {
       TypedTable<String, String> table) throws Exception {
     try (Table.KeyValueIterator<String, String> i = table.iterator(prefix)) {
       int keyCount = 0;
-      for(; i.hasNext(); keyCount++) {
+      for (; i.hasNext(); keyCount++) {
         Assertions.assertEquals(prefix,
             i.next().getKey().substring(0, PREFIX_LENGTH));
       }
@@ -619,14 +619,15 @@ public class TestRDBTableStore {
 
   @Test
   public void testStringPrefixedIteratorCloseDb() throws Exception {
-    try (Table<String, String> testTable = rdbStore.getTable("PrefixFirst", String.class, String.class)) {
+    try (Table<String, String> testTable = rdbStore.getTable(
+        "PrefixFirst", String.class, String.class)) {
       // iterator should seek to right pos in the middle
       rdbStore.close();
       try {
         testTable.iterator("abc");
         Assertions.fail();
       } catch (IOException ioe) {
-        LOG.info("Great!", ioe);ioe.printStackTrace(System.out);
+        LOG.info("Great!", ioe);
       }
     }
   }


### PR DESCRIPTION
## What changes were proposed in this pull request?

When the db is closed before calling `iterate(prefix)`, the `prefix` buffer is not released.

## What is the link to the Apache JIRA

HDDS-9454

## How was this patch tested?

New unit tests.