### PR TITLE
HDDS-3429. Remove testKeyOpFailureWithoutBlockToken from TestSecureOzoneRpcClient

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestSecureOzoneRpcClient.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestSecureOzoneRpcClient.java
@@ -64,7 +64,6 @@ import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.Status;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.VolumeInfo;
 import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.ozone.test.GenericTestUtils;
-import org.apache.ozone.test.tag.Unhealthy;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -81,7 +80,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
@@ -240,46 +238,6 @@ public class TestSecureOzoneRpcClient extends TestOzoneRpcClient {
                     keyLocationInfo -> assertNull(keyLocationInfo
                         .getToken())));
   }
-
-  /**
-   * Tests failure in following operations when grpc block token is
-   * not present.
-   * 1. getKey
-   * 2. writeChunk
-   * */
-  @Test
-  @Unhealthy("Needs to be moved out of this class as  client setup is static")
-  public void testKeyOpFailureWithoutBlockToken() throws Exception {
-    String volumeName = UUID.randomUUID().toString();
-    String bucketName = UUID.randomUUID().toString();
-    String value = "sample value";
-    store.createVolume(volumeName);
-    OzoneVolume volume = store.getVolume(volumeName);
-    volume.createBucket(bucketName);
-    OzoneBucket bucket = volume.getBucket(bucketName);
-
-    for (int i = 0; i < 10; i++) {
-      String keyName = UUID.randomUUID().toString();
-
-      try (OzoneOutputStream out = bucket.createKey(keyName,
-          value.getBytes(UTF_8).length, ReplicationType.RATIS,
-          ReplicationFactor.ONE, new HashMap<>())) {
-        IOException ioException = assertThrows(IOException.class,
-            () -> out.write(value.getBytes(UTF_8)));
-        assertTrue(ioException.getMessage()
-            .contains("UNAUTHENTICATED: Fail to find any token "));
-      }
-
-      OzoneKey key = bucket.getKey(keyName);
-      assertEquals(keyName, key.getName());
-      IOException ioException = assertThrows(IOException.class,
-          () -> bucket.readKey(keyName));
-      assertTrue(ioException.getMessage()
-          .contains("Failed to authenticate with GRPC XceiverServer with " +
-              "Ozone block token."));
-    }
-  }
-
 
   @Test
   public void testS3Auth() throws Exception {


### PR DESCRIPTION
## What changes were proposed in this pull request?

Remove the test case `testKeyOpFailureWithoutBlockToken` from `TestSecureOzoneRpcClient`.  It was disabled in HDDS-1119, and has never worked.  The same functionality is being tested in `TestBlockTokens` and `TestSecureOzoneContainer`.

https://issues.apache.org/jira/browse/HDDS-3429

## How was this patch tested?

CI:
https://github.com/adoroszlai/hadoop-ozone/actions/runs/6523940629