### PR TITLE
HDDS-8720. Improve thread names in SCM

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/balancer/ContainerBalancer.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/balancer/ContainerBalancer.java
@@ -271,10 +271,11 @@ public class ContainerBalancer extends StatefulService {
    */
   private void startBalancingThread(int nextIterationIndex,
       boolean delayStart) {
+    String prefix = scmContext.threadNamePrefix();
     task = new ContainerBalancerTask(scm, nextIterationIndex, this, metrics,
         config, delayStart);
     Thread thread = new Thread(task);
-    thread.setName("ContainerBalancerTask-" + ID.incrementAndGet());
+    thread.setName(prefix + "ContainerBalancerTask-" + ID.incrementAndGet());
     thread.setDaemon(true);
     thread.start();
     currentBalancingThread = thread;

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ReplicationManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ReplicationManager.java
@@ -340,18 +340,19 @@ public class ReplicationManager implements SCMService {
    */
   @VisibleForTesting
   protected void startSubServices() {
+    final String prefix = scmContext.threadNamePrefix();
     replicationMonitor = new Thread(this::run);
-    replicationMonitor.setName("ReplicationMonitor");
+    replicationMonitor.setName(prefix + "ReplicationMonitor");
     replicationMonitor.setDaemon(true);
     replicationMonitor.start();
 
     underReplicatedProcessorThread = new Thread(underReplicatedProcessor);
-    underReplicatedProcessorThread.setName("Under Replicated Processor");
+    underReplicatedProcessorThread.setName(prefix + "UnderReplicatedProcessor");
     underReplicatedProcessorThread.setDaemon(true);
     underReplicatedProcessorThread.start();
 
     overReplicatedProcessorThread = new Thread(overReplicatedProcessor);
-    overReplicatedProcessorThread.setName("Over Replicated Processor");
+    overReplicatedProcessorThread.setName(prefix + "OverReplicatedProcessor");
     overReplicatedProcessorThread.setDaemon(true);
     overReplicatedProcessorThread.start();
   }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/BackgroundSCMService.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/BackgroundSCMService.java
@@ -68,7 +68,7 @@ public final class BackgroundSCMService implements SCMService {
     log.info("Starting {} Service.", getServiceName());
 
     backgroundThread = new Thread(this::run);
-    backgroundThread.setName(serviceName + "Thread");
+    backgroundThread.setName(scmContext.threadNamePrefix() + serviceName);
     backgroundThread.setDaemon(true);
     backgroundThread.start();
   }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/NodeDecommissionManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/NodeDecommissionManager.java
@@ -187,8 +187,12 @@ public class NodeDecommissionManager {
     this.metrics = null;
 
     executor = Executors.newScheduledThreadPool(1,
-        new ThreadFactoryBuilder().setNameFormat("DatanodeAdminManager-%d")
-            .setDaemon(true).build());
+        new ThreadFactoryBuilder()
+            .setNameFormat(
+                scmContext.threadNamePrefix() + "DatanodeAdminManager-%d")
+            .setDaemon(true)
+            .build()
+    );
 
     useHostnames = conf.getBoolean(
         DFSConfigKeys.DFS_DATANODE_USE_DN_HOSTNAME,

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/NodeStateManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/NodeStateManager.java
@@ -196,8 +196,12 @@ public class NodeStateManager implements Runnable, Closeable {
         OZONE_SCM_STALENODE_INTERVAL + " should be less than" +
             OZONE_SCM_DEADNODE_INTERVAL);
     executorService = HadoopExecutors.newScheduledThreadPool(1,
-        new ThreadFactoryBuilder().setDaemon(true)
-            .setNameFormat("SCM Heartbeat Processing Thread - %d").build());
+        new ThreadFactoryBuilder()
+            .setDaemon(true)
+            .setNameFormat(
+                scmContext.threadNamePrefix() + "SCMHeartbeatProcessor-%d")
+            .build()
+    );
 
     skippedHealthChecks = 0;
     checkPaused = false; // accessed only from test functions

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/security/RootCARotationManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/security/RootCARotationManager.java
@@ -83,6 +83,9 @@ public class RootCARotationManager extends StatefulService {
   public static final Logger LOG =
       LoggerFactory.getLogger(RootCARotationManager.class);
 
+  private static final String SERVICE_NAME =
+      RootCARotationManager.class.getSimpleName();
+
   private final StorageContainerManager scm;
   private final OzoneConfiguration ozoneConf;
   private final SecurityConfig secConf;
@@ -99,7 +102,7 @@ public class RootCARotationManager extends StatefulService {
   private final AtomicReference<Long> processStartTime =
       new AtomicReference<>();
   private final AtomicBoolean isPostProcessing = new AtomicBoolean(false);
-  private final String threadName = this.getClass().getSimpleName();
+  private final String threadName;
   private final String newCAComponent = SCM_ROOT_CA_COMPONENT_NAME +
       HDDS_NEW_KEY_CERT_DIR_NAME_SUFFIX +
       HDDS_NEW_KEY_CERT_DIR_NAME_PROGRESS_SUFFIX;
@@ -150,6 +153,7 @@ public class RootCARotationManager extends StatefulService {
         .atZone(ZoneId.systemDefault()).toInstant());
     rootCertPollInterval = secConf.getRootCaCertificatePollingInterval();
 
+    threadName = scm.threadNamePrefix() + SERVICE_NAME;
     executorService = Executors.newScheduledThreadPool(1,
         new ThreadFactoryBuilder().setNameFormat(threadName)
             .setDaemon(true).build());

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/security/SecretKeyManagerService.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/security/SecretKeyManagerService.java
@@ -45,6 +45,9 @@ public class SecretKeyManagerService implements SCMService, Runnable {
   public static final Logger LOG =
       LoggerFactory.getLogger(SecretKeyManagerService.class);
 
+  private static final String SERVICE_NAME =
+      SecretKeyManagerService.class.getSimpleName();
+
   private final SCMContext scmContext;
   private final SecretKeyManager secretKeyManager;
   private final SecretKeyConfig secretKeyConfig;
@@ -77,7 +80,7 @@ public class SecretKeyManagerService implements SCMService, Runnable {
 
     scheduler = Executors.newScheduledThreadPool(1,
         new ThreadFactoryBuilder().setDaemon(true)
-            .setNameFormat(getServiceName())
+            .setNameFormat(scmContext.threadNamePrefix() + getServiceName())
             .build());
 
     start();
@@ -134,7 +137,7 @@ public class SecretKeyManagerService implements SCMService, Runnable {
 
   @Override
   public String getServiceName() {
-    return SecretKeyManagerService.class.getSimpleName();
+    return SERVICE_NAME;
   }
 
   @Override

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/upgrade/FinalizationManagerImpl.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/upgrade/FinalizationManagerImpl.java
@@ -20,6 +20,7 @@ package org.apache.hadoop.hdds.scm.server.upgrade;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.scm.ha.SCMContext;
 import org.apache.hadoop.hdds.scm.ha.SCMHAManager;
@@ -39,6 +40,7 @@ import org.slf4j.LoggerFactory;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.concurrent.Executors;
+import java.util.concurrent.ThreadFactory;
 
 /**
  * Class to initiate SCM finalization and query its progress.
@@ -53,6 +55,7 @@ public class FinalizationManagerImpl implements FinalizationManager {
   private OzoneConfiguration conf;
   private HDDSLayoutVersionManager versionManager;
   private final FinalizationStateManager finalizationStateManager;
+  private ThreadFactory threadFactory;
 
   /**
    * For test classes to inject their own state manager.
@@ -98,6 +101,11 @@ public class FinalizationManagerImpl implements FinalizationManager {
             .build();
 
     finalizationStateManager.setUpgradeContext(this.context);
+
+    String prefix = scmContext != null ? scmContext.threadNamePrefix() : "";
+    this.threadFactory = new ThreadFactoryBuilder()
+        .setNameFormat(prefix + "FinalizationManager-%d")
+        .build();
   }
 
   @Override
@@ -150,7 +158,7 @@ public class FinalizationManagerImpl implements FinalizationManager {
   @Override
   public void onLeaderReady() {
     // Launch a background thread to drive finalization.
-    Executors.newSingleThreadExecutor().submit(() -> {
+    Executors.newSingleThreadExecutor(threadFactory).submit(() -> {
       FinalizationCheckpoint currentCheckpoint = getCheckpoint();
       if (currentCheckpoint.hasCrossed(
           FinalizationCheckpoint.FINALIZATION_STARTED) &&


### PR DESCRIPTION
## What changes were proposed in this pull request?

Improve thread names in SCM by adding instance-specific prefix to make it easier to distinguish log messages from different instances.

https://issues.apache.org/jira/browse/HDDS-8720

## How was this patch tested?

Ran integration test with SCM HA (e.g. `TestSecretKeysApi`), checked thread names in log messages.

```
[scmNode-1-BackgroundPipelineScrubber]
[scmNode-1-ExpiredContainerReplicaOpScrubber]
[scmNode-1-ReplicationMonitor]
[scmNode-1-SCMHATransactionMonitor]
[scmNode-1-SecretKeyManagerService]
```

CI:
https://github.com/adoroszlai/hadoop-ozone/actions/runs/6532064840