### PR TITLE
HDDS-9463. Speed up TestSecretKeysApi

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/scm/TestSecretKeysApi.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/scm/TestSecretKeysApi.java
@@ -246,6 +246,8 @@ public final class TestSecretKeysApi {
     ManagedSecretKey nonExisting = secretKeyProtocol.getSecretKey(
         UUID.randomUUID());
     assertNull(nonExisting);
+
+    testSecretKeyAuthorization();
   }
 
   /**
@@ -301,12 +303,7 @@ public final class TestSecretKeysApi {
     }
   }
 
-  @Test
-  public void testSecretKeyAuthorization() throws Exception {
-    enableBlockToken();
-    conf.setBoolean(HADOOP_SECURITY_AUTHORIZATION, true);
-    startCluster(1);
-
+  private void testSecretKeyAuthorization() throws Exception {
     // When HADOOP_SECURITY_AUTHORIZATION is enabled, SecretKey protocol
     // is only available for Datanode and OM, any other authenticated user
     // can't access the protocol.


### PR DESCRIPTION
## What changes were proposed in this pull request?

Merge two test cases in `TestSecretKeysApi` to save some cluster setup time.

https://issues.apache.org/jira/browse/HDDS-9463

## How was this patch tested?

Before:

```
[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 232.86 s - in org.apache.hadoop.ozone.scm.TestSecretKeysApi
```

After:

```
[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 196.522 s - in org.apache.hadoop.ozone.scm.TestSecretKeysApi
```