### PR TITLE
HDDS-9471. Speed up TestOzoneSnapshotRestore

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/snapshot/TestOzoneSnapshotRestore.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/snapshot/TestOzoneSnapshotRestore.java
@@ -43,9 +43,10 @@ import org.apache.hadoop.ozone.om.helpers.SnapshotInfo;
 import org.apache.hadoop.util.ToolRunner;
 import org.apache.ozone.test.GenericTestUtils;
 import org.apache.ozone.test.tag.Flaky;
-import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -69,6 +70,7 @@ import static org.junit.jupiter.params.provider.Arguments.arguments;
 /**
  * Tests Snapshot Restore function.
  */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
 @Timeout(value = 300)
 public class TestOzoneSnapshotRestore {
   private static final String OM_SERVICE_ID = "om-service-test-1";
@@ -97,7 +99,7 @@ public class TestOzoneSnapshotRestore {
     counter = new AtomicInteger();
   }
 
-  @BeforeEach
+  @BeforeAll
   public void init() throws Exception {
     OzoneConfiguration conf = new OzoneConfiguration();
     // Enable filesystem snapshot feature for the test regardless of the default
@@ -134,7 +136,7 @@ public class TestOzoneSnapshotRestore {
 
   }
 
-  @AfterEach
+  @AfterAll
   public void tearDown() throws Exception {
     IOUtils.closeQuietly(client);
     if (cluster != null) {


### PR DESCRIPTION
## What changes were proposed in this pull request?

Launch a single cluster for all tests in `TestOzoneSnapshotRestore` instead of one per test.

https://issues.apache.org/jira/browse/HDDS-9471

## How was this patch tested?

Before:

```
[INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 154.597 s - in org.apache.hadoop.ozone.om.snapshot.TestOzoneSnapshotRestore
```

After:

```
[INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 41.952 s - in org.apache.hadoop.ozone.om.snapshot.TestOzoneSnapshotRestore
```

https://github.com/adoroszlai/hadoop-ozone/actions/runs/6537079445