### PR TITLE
HDDS-9432. Perform individual delete key instead of delete range function

### DIFF
--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/ThrowableFunction.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/ThrowableFunction.java
@@ -17,9 +17,10 @@
  */
 package org.apache.hadoop.hdds.utils;
 
+
 /**
  * Utility interface for function which throws exceptions.
- * Similar to java.util.Function.
+ * Similar to {@link java.util.function.Function}.
  */
 public interface ThrowableFunction<T, R, E extends Throwable> {
   R apply(T t) throws E;

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/ThrowableFunction.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/ThrowableFunction.java
@@ -17,8 +17,10 @@
  */
 package org.apache.hadoop.hdds.utils;
 
-import java.util.function.Function;
-
+/**
+ * Utility interface for function which throws exceptions.
+ * Similar to java.util.Function.
+ */
 public interface ThrowableFunction<T, R, E extends Throwable> {
   R apply(T t) throws E;
 }

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/ThrowableFunction.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/ThrowableFunction.java
@@ -1,0 +1,24 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hdds.utils;
+
+import java.util.function.Function;
+
+public interface ThrowableFunction<T, R, E extends Throwable> {
+  R apply(T t) throws E;
+}

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmSnapshotManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmSnapshotManager.java
@@ -531,7 +531,7 @@ public final class OmSnapshotManager implements AutoCloseable {
   }
 
   /**
-   * Helper method to perform operation on keys with a given iterator
+   * Helper method to perform operation on keys with a given iterator.
    * @param keyIter TableIterator
    * @param operationFunction operation to be performed for each key.
    * @return endKey String, or null if no keys with such prefix is found

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmSnapshotManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmSnapshotManager.java
@@ -563,6 +563,8 @@ public final class OmSnapshotManager implements AutoCloseable {
 
   /**
    * Helper method to do deleteRange on a table, including endKey.
+   * TODO: Do remove this method, it is not used anywhere. Need to check if
+   *       deleteRange causes RocksDB corruption.
    * TODO: Move this into {@link Table} ?
    * @param table Table
    * @param beginKey begin key

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmSnapshotManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmSnapshotManager.java
@@ -483,7 +483,7 @@ public final class OmSnapshotManager implements AutoCloseable {
         omMetadataManager, volumeName, bucketName);
 
     try (TableIterator<String, ? extends Table.KeyValue<String, OmKeyInfo>>
-         iter = omMetadataManager.getDeletedDirTable().iterator()) {
+         iter = omMetadataManager.getDeletedDirTable().iterator(beginKey)) {
       performOperationGivenPrefix(iter, beginKey,
           entry -> {
             if (LOG.isDebugEnabled()) {
@@ -606,7 +606,7 @@ public final class OmSnapshotManager implements AutoCloseable {
 
     try (TableIterator<String,
         ? extends Table.KeyValue<String, RepeatedOmKeyInfo>>
-             iter = omMetadataManager.getDeletedTable().iterator()) {
+             iter = omMetadataManager.getDeletedTable().iterator(beginKey)) {
       performOperationGivenPrefix(iter, beginKey, entry -> {
         if (LOG.isDebugEnabled()) {
           LOG.debug("Removing key {} from DeletedTable", entry.getKey());

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmSnapshotManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmSnapshotManager.java
@@ -534,7 +534,6 @@ public final class OmSnapshotManager implements AutoCloseable {
    * Helper method to perform operation on keys with a given iterator.
    * @param keyIter TableIterator
    * @param operationFunction operation to be performed for each key.
-   * @return endKey String, or null if no keys with such prefix is found
    */
   private static void performOperationOnKeys(
       TableIterator<String, ? extends Table.KeyValue<String, ?>> keyIter,
@@ -543,8 +542,6 @@ public final class OmSnapshotManager implements AutoCloseable {
     // Continue only when there are entries of snapshot (bucket) scope
     // in deletedTable in the first place
     // Loop until prefix matches.
-    // TODO: [SNAPSHOT] Try to seek to next predicted bucket name instead of
-    //  the while-loop for a potential speed up?
     // Start performance tracking timer
     long startTime = System.nanoTime();
     while (keyIter.hasNext()) {

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmSnapshotManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmSnapshotManager.java
@@ -34,7 +34,6 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
-import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import com.google.common.cache.RemovalListener;

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/snapshot/TestOMSnapshotCreateResponse.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/snapshot/TestOMSnapshotCreateResponse.java
@@ -34,14 +34,12 @@ import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
 import org.apache.hadoop.ozone.om.helpers.RepeatedOmKeyInfo;
 import org.apache.hadoop.ozone.om.helpers.SnapshotInfo;
 import org.apache.hadoop.util.Time;
-import org.junit.Rule;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
-import org.junit.rules.TemporaryFolder;
 
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.ozone.om.OMConfigKeys;
@@ -62,8 +60,8 @@ import static org.apache.hadoop.ozone.om.OmSnapshotManager.getSnapshotPath;
  */
 public class TestOMSnapshotCreateResponse {
 
-  @Rule
-  public TemporaryFolder folder = new TemporaryFolder();
+  @TempDir
+  private File folder;
 
   private OMMetadataManager omMetadataManager;
   private BatchOperation batchOperation;
@@ -72,7 +70,7 @@ public class TestOMSnapshotCreateResponse {
   @BeforeEach
   public void setup() throws Exception {
     ozoneConfiguration = new OzoneConfiguration();
-    String fsPath = folder.newFolder().getAbsolutePath();
+    String fsPath = folder.getAbsolutePath();
     ozoneConfiguration.set(OMConfigKeys.OZONE_OM_DB_DIRS,
         fsPath);
     omMetadataManager = new OmMetadataManagerImpl(ozoneConfiguration, null);
@@ -199,8 +197,10 @@ public class TestOMSnapshotCreateResponse {
    * @param bucketName bucket name
    * @return A set of DB keys
    */
-  private Set<String> addTestKeysToDeletedDirTable(
-      String volumeName, String bucketName, int numberOfKeys) throws IOException {
+  private Set<String> addTestKeysToDeletedDirTable(String volumeName,
+                                                   String bucketName,
+                                                   int numberOfKeys)
+      throws IOException {
 
     OMSnapshotResponseTestUtil.addVolumeBucketInfoToTable(
         omMetadataManager, volumeName, bucketName);

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/snapshot/TestOMSnapshotCreateResponse.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/snapshot/TestOMSnapshotCreateResponse.java
@@ -34,11 +34,13 @@ import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
 import org.apache.hadoop.ozone.om.helpers.RepeatedOmKeyInfo;
 import org.apache.hadoop.ozone.om.helpers.SnapshotInfo;
 import org.apache.hadoop.util.Time;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
 import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.junit.rules.TemporaryFolder;
 
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
@@ -62,12 +64,12 @@ public class TestOMSnapshotCreateResponse {
 
   @Rule
   public TemporaryFolder folder = new TemporaryFolder();
-  
+
   private OMMetadataManager omMetadataManager;
   private BatchOperation batchOperation;
   private OzoneConfiguration ozoneConfiguration;
 
-  @Before
+  @BeforeEach
   public void setup() throws Exception {
     ozoneConfiguration = new OzoneConfiguration();
     String fsPath = folder.newFolder().getAbsolutePath();
@@ -77,15 +79,16 @@ public class TestOMSnapshotCreateResponse {
     batchOperation = omMetadataManager.getStore().initBatchOperation();
   }
 
-  @After
+  @AfterEach
   public void tearDown() {
     if (batchOperation != null) {
       batchOperation.close();
     }
   }
 
-  @Test
-  public void testAddToDBBatch() throws Exception {
+  @ParameterizedTest
+  @ValueSource(ints = {0, 1, 5, 10, 25})
+  public void testAddToDBBatch(int numberOfKeys) throws Exception {
     String volumeName = UUID.randomUUID().toString();
     String bucketName = UUID.randomUUID().toString();
     String snapshotName = UUID.randomUUID().toString();
@@ -97,15 +100,15 @@ public class TestOMSnapshotCreateResponse {
         Time.now());
 
     // confirm table is empty
-    Assert.assertEquals(0,
+    Assertions.assertEquals(0,
         omMetadataManager
-        .countRowsInTable(omMetadataManager.getSnapshotInfoTable()));
+            .countRowsInTable(omMetadataManager.getSnapshotInfoTable()));
 
     // Populate deletedTable and deletedDirectoryTable
     Set<String> dtSentinelKeys =
-        addTestKeysToDeletedTable(volumeName, bucketName);
+        addTestKeysToDeletedTable(volumeName, bucketName, numberOfKeys);
     Set<String> ddtSentinelKeys =
-        addTestKeysToDeletedDirTable(volumeName, bucketName);
+        addTestKeysToDeletedDirTable(volumeName, bucketName, numberOfKeys);
 
     // commit to table
     OMSnapshotCreateResponse omSnapshotCreateResponse =
@@ -114,17 +117,17 @@ public class TestOMSnapshotCreateResponse {
             .setStatus(OzoneManagerProtocolProtos.Status.OK)
             .setCreateSnapshotResponse(
                 CreateSnapshotResponse.newBuilder()
-                .setSnapshotInfo(snapshotInfo.getProtobuf())
-                .build()).build(), snapshotInfo);
+                    .setSnapshotInfo(snapshotInfo.getProtobuf())
+                    .build()).build(), snapshotInfo);
     omSnapshotCreateResponse.addToDBBatch(omMetadataManager, batchOperation);
     omMetadataManager.getStore().commitBatchOperation(batchOperation);
 
     // Confirm snapshot directory was created
     String snapshotDir = getSnapshotPath(ozoneConfiguration, snapshotInfo);
-    Assert.assertTrue((new File(snapshotDir)).exists());
+    Assertions.assertTrue((new File(snapshotDir)).exists());
 
     // Confirm table has 1 entry
-    Assert.assertEquals(1, omMetadataManager
+    Assertions.assertEquals(1, omMetadataManager
         .countRowsInTable(omMetadataManager.getSnapshotInfoTable()));
 
     // Check contents of entry
@@ -133,17 +136,19 @@ public class TestOMSnapshotCreateResponse {
              it = omMetadataManager.getSnapshotInfoTable().iterator()) {
       Table.KeyValue<String, SnapshotInfo> keyValue = it.next();
       storedInfo = keyValue.getValue();
-      Assert.assertEquals(snapshotInfo.getTableKey(), keyValue.getKey());
+      Assertions.assertEquals(snapshotInfo.getTableKey(), keyValue.getKey());
     }
-    Assert.assertEquals(snapshotInfo, storedInfo);
+    Assertions.assertEquals(snapshotInfo, storedInfo);
 
     // Check deletedTable and deletedDirectoryTable clean up work as expected
     verifyEntriesLeftInDeletedTable(dtSentinelKeys);
     verifyEntriesLeftInDeletedDirTable(ddtSentinelKeys);
   }
 
-  private Set<String> addTestKeysToDeletedTable(
-      String volumeName, String bucketName) throws IOException {
+  private Set<String> addTestKeysToDeletedTable(String volumeName,
+                                                String bucketName,
+                                                int numberOfKeys)
+      throws IOException {
 
     RepeatedOmKeyInfo dummyRepeatedKeyInfo = new RepeatedOmKeyInfo.Builder()
         .setOmKeyInfos(new ArrayList<>()).build();
@@ -176,7 +181,7 @@ public class TestOMSnapshotCreateResponse {
     }
 
     // Add deletedTable key entries in the snapshot (bucket) scope
-    for (int i = 0; i < 10; i++) {
+    for (int i = 0; i < numberOfKeys; i++) {
       String dtKey = omMetadataManager.getOzoneKey(volumeName, bucketName,
           "dtkey" + i);
       omMetadataManager.getDeletedTable().put(dtKey, dummyRepeatedKeyInfo);
@@ -189,12 +194,13 @@ public class TestOMSnapshotCreateResponse {
 
   /**
    * Populates deletedDirectoryTable for the test.
+   *
    * @param volumeName volume name
    * @param bucketName bucket name
    * @return A set of DB keys
    */
   private Set<String> addTestKeysToDeletedDirTable(
-      String volumeName, String bucketName) throws IOException {
+      String volumeName, String bucketName, int numberOfKeys) throws IOException {
 
     OMSnapshotResponseTestUtil.addVolumeBucketInfoToTable(
         omMetadataManager, volumeName, bucketName);
@@ -218,7 +224,7 @@ public class TestOMSnapshotCreateResponse {
 
     char bucketIdLastChar = dbKeyPfx.charAt(offset);
 
-    String dbKeyPfxBefore =  dbKeyPfx.substring(0, offset) +
+    String dbKeyPfxBefore = dbKeyPfx.substring(0, offset) +
         (char) (bucketIdLastChar - 1) + dbKeyPfx.substring(offset);
     for (int i = 0; i < 3; i++) {
       String dtKey = dbKeyPfxBefore + "dir" + i;
@@ -226,7 +232,7 @@ public class TestOMSnapshotCreateResponse {
       sentinelKeys.add(dtKey);
     }
 
-    String dbKeyPfxAfter =  dbKeyPfx.substring(0, offset) +
+    String dbKeyPfxAfter = dbKeyPfx.substring(0, offset) +
         (char) (bucketIdLastChar + 1) + dbKeyPfx.substring(offset);
     for (int i = 0; i < 3; i++) {
       String dtKey = dbKeyPfxAfter + "dir" + i;
@@ -235,7 +241,7 @@ public class TestOMSnapshotCreateResponse {
     }
 
     // Add key entries in the snapshot (bucket) scope
-    for (int i = 0; i < 10; i++) {
+    for (int i = 0; i < numberOfKeys; i++) {
       String dtKey = dbKeyPfx + "dir" + i;
       omMetadataManager.getDeletedDirTable().put(dtKey, dummyOmKeyInfo);
       // These are the keys that should be deleted.
@@ -261,18 +267,18 @@ public class TestOMSnapshotCreateResponse {
       Table<String, ?> table, Set<String> expectedKeys) throws IOException {
 
     try (TableIterator<String, ? extends Table.KeyValue<String, ?>>
-        keyIter = table.iterator()) {
+             keyIter = table.iterator()) {
       keyIter.seekToFirst();
       while (keyIter.hasNext()) {
         Table.KeyValue<String, ?> entry = keyIter.next();
         String dbKey = entry.getKey();
-        Assert.assertTrue(table.getName() + " should contain key",
-            expectedKeys.contains(dbKey));
+        Assertions.assertTrue(expectedKeys.contains(dbKey),
+            table.getName() + " should contain key");
         expectedKeys.remove(dbKey);
       }
     }
 
-    Assert.assertTrue(table.getName() + " is missing keys that should be there",
-        expectedKeys.isEmpty());
+    Assertions.assertTrue(expectedKeys.isEmpty(),
+        table.getName() + " is missing keys that should be there");
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?
Currently rocksDb sst file becomes corrupt in case of delete range function while creating snapshot. Speculating the corruption could be because of delete range function. When a snapshot for a bucket is created, all keys corresponding to the bucket in the deletedTable & deletedDirTable are removed from active object store after creating the rocksdb checkpoint.

## What is the link to the Apache JIRA:
https://issues.apache.org/jira/browse/HDDS-9432

## How was this patch tested?
Existing unit tests. Issue is not reproducible