### PR TITLE
HDDS-9470. Improve thread names in Recon.

### DIFF
--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/ReconUtils.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/ReconUtils.java
@@ -34,6 +34,9 @@ import com.google.inject.Singleton;
 import org.apache.hadoop.hdds.HddsConfigKeys;
 import org.apache.hadoop.hdds.HddsUtils;
 import org.apache.hadoop.hdds.conf.ConfigurationSource;
+import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import org.apache.hadoop.hdds.scm.ha.SCMNodeDetails;
+import org.apache.hadoop.hdds.utils.HddsServerUtil;
 import org.apache.hadoop.hdfs.web.URLConnectionFactory;
 import org.apache.hadoop.io.IOUtils;
 
@@ -341,5 +344,13 @@ public class ReconUtils {
       index += 1;
     }
     return index;
+  }
+
+  public SCMNodeDetails getReconNodeDetails(OzoneConfiguration conf) {
+    SCMNodeDetails.Builder builder = new SCMNodeDetails.Builder();
+    builder.setSCMNodeId("Recon");
+    builder.setDatanodeProtocolServerAddress(
+        HddsServerUtil.getReconDataNodeBindAddress(conf));
+    return builder.build();
   }
 }

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/tasks/ReconTaskControllerImpl.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/tasks/ReconTaskControllerImpl.java
@@ -34,6 +34,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.ozone.om.OMMetadataManager;
@@ -219,7 +220,9 @@ public class ReconTaskControllerImpl implements ReconTaskController {
   @Override
   public synchronized void start() {
     LOG.info("Starting Recon Task Controller.");
-    executorService = Executors.newFixedThreadPool(threadCount);
+    executorService = Executors.newFixedThreadPool(threadCount,
+        new ThreadFactoryBuilder().setNameFormat("Recon Task Thread - %d")
+            .build());
   }
 
   @Override


### PR DESCRIPTION
## What changes were proposed in this pull request?

1. **Title:**  - Improve thread names in Recon.
2. **Description:**
   * [HDDS-9334](https://issues.apache.org/jira/browse/HDDS-9334) added the ability to specify a prefix for threads created in common/framework code (EventQueue, BackgroundService, etc.). These are used by multiple components (SCM, OM, DN, Recon).

Goals of this task:

1. pass "Recon" as thread name prefix in Recon
2. ensure all other threads created in Recon code also include "Recon" in their name.
   
## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-9470

## How was this patch tested?

This patch was tested by running docker based ozone cluster with Recon. Recon logs reflect the thread names with respective prefixes.