### PR TITLE
HDDS-9466. Introduce FlakyTest category for flaky JUnit4 tests

### DIFF
--- a/hadoop-hdds/test-utils/src/main/java/org/apache/ozone/test/FlakyTest.java
+++ b/hadoop-hdds/test-utils/src/main/java/org/apache/ozone/test/FlakyTest.java
@@ -1,0 +1,28 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.ozone.test;
+
+/**
+ * Interface to mark JUnit4 test classes or methods that exhibit intermittent
+ * issues.  These are run separately from the normal tests in CI.  In case of
+ * failure they may be repeated a few times.
+ * Usage: <code>@Category(FlakyTest.class) @Flaky("HDDS-123")</code>
+ */
+public interface FlakyTest {
+  // category marker
+}

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/scm/TestStorageContainerManager.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/scm/TestStorageContainerManager.java
@@ -96,8 +96,10 @@ import org.apache.hadoop.util.ExitUtil;
 import org.apache.hadoop.util.Time;
 import org.apache.log4j.Level;
 import org.apache.log4j.LogManager;
+import org.apache.ozone.test.FlakyTest;
 import org.apache.ozone.test.GenericTestUtils;
 import org.apache.ozone.test.JUnit5AwareTimeout;
+import org.apache.ozone.test.tag.Flaky;
 import org.apache.ratis.conf.RaftProperties;
 import org.apache.ratis.protocol.RaftGroupId;
 import org.apache.ratis.server.RaftServerConfigKeys;
@@ -107,6 +109,7 @@ import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.rules.ExpectedException;
 import org.junit.rules.TestRule;
 import org.junit.rules.Timeout;
@@ -986,6 +989,7 @@ public class TestStorageContainerManager {
   }
 
   @Test
+  @Category(FlakyTest.class) @Flaky("HDDS-8470")
   public void testContainerReportQueueTakingMoreTime() throws Exception {
     EventQueue eventQueue = new EventQueue();
     List<BlockingQueue<SCMDatanodeHeartbeatDispatcher.ContainerReport>>

--- a/pom.xml
+++ b/pom.xml
@@ -2216,7 +2216,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
               <includes>
                 <include>org.apache.hadoop.ozone.client.**</include>
               </includes>
-              <excludedGroups>flaky | slow | org.apache.ozone.test.SlowTest | unhealthy | org.apache.ozone.test.UnhealthyTest</excludedGroups>
+              <excludedGroups>flaky | org.apache.ozone.test.FlakyTest | slow | org.apache.ozone.test.SlowTest | unhealthy | org.apache.ozone.test.UnhealthyTest</excludedGroups>
             </configuration>
           </plugin>
         </plugins>
@@ -2233,7 +2233,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
               <includes>
                 <include>org.apache.hadoop.ozone.om.**</include>
               </includes>
-              <excludedGroups>flaky | slow | org.apache.ozone.test.SlowTest | unhealthy | org.apache.ozone.test.UnhealthyTest</excludedGroups>
+              <excludedGroups>flaky | org.apache.ozone.test.FlakyTest | slow | org.apache.ozone.test.SlowTest | unhealthy | org.apache.ozone.test.UnhealthyTest</excludedGroups>
             </configuration>
           </plugin>
         </plugins>
@@ -2250,7 +2250,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
               <includes>
                 <include>org.apache.hadoop.ozone.scm.**</include>
               </includes>
-              <excludedGroups>flaky | slow | org.apache.ozone.test.SlowTest | unhealthy | org.apache.ozone.test.UnhealthyTest</excludedGroups>
+              <excludedGroups>flaky | org.apache.ozone.test.FlakyTest | slow | org.apache.ozone.test.SlowTest | unhealthy | org.apache.ozone.test.UnhealthyTest</excludedGroups>
             </configuration>
           </plugin>
         </plugins>
@@ -2267,7 +2267,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
               <includes>
                 <include>org.apache.hadoop.fs.ozone.contract.**</include>
               </includes>
-              <excludedGroups>flaky | slow | org.apache.ozone.test.SlowTest | unhealthy | org.apache.ozone.test.UnhealthyTest</excludedGroups>
+              <excludedGroups>flaky | org.apache.ozone.test.FlakyTest | slow | org.apache.ozone.test.SlowTest | unhealthy | org.apache.ozone.test.UnhealthyTest</excludedGroups>
             </configuration>
           </plugin>
         </plugins>
@@ -2287,7 +2287,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
               <excludes>
                 <exclude>org.apache.hadoop.fs.ozone.contract.**</exclude>
               </excludes>
-              <excludedGroups>flaky | slow | org.apache.ozone.test.SlowTest | unhealthy | org.apache.ozone.test.UnhealthyTest</excludedGroups>
+              <excludedGroups>flaky | org.apache.ozone.test.FlakyTest | slow | org.apache.ozone.test.SlowTest | unhealthy | org.apache.ozone.test.UnhealthyTest</excludedGroups>
             </configuration>
           </plugin>
         </plugins>
@@ -2304,7 +2304,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
               <includes>
                 <include>org.apache.hadoop.hdds.**</include>
               </includes>
-              <excludedGroups>flaky | slow | org.apache.ozone.test.SlowTest | unhealthy | org.apache.ozone.test.UnhealthyTest</excludedGroups>
+              <excludedGroups>flaky | org.apache.ozone.test.FlakyTest | slow | org.apache.ozone.test.SlowTest | unhealthy | org.apache.ozone.test.UnhealthyTest</excludedGroups>
             </configuration>
           </plugin>
         </plugins>
@@ -2329,7 +2329,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
                 <exclude>org.apache.hadoop.ozone.scm.**</exclude>
                 <exclude>org.apache.hadoop.ozone.shell.**</exclude>
               </excludes>
-              <excludedGroups>flaky | slow | org.apache.ozone.test.SlowTest | unhealthy | org.apache.ozone.test.UnhealthyTest</excludedGroups>
+              <excludedGroups>flaky | org.apache.ozone.test.FlakyTest | slow | org.apache.ozone.test.SlowTest | unhealthy | org.apache.ozone.test.UnhealthyTest</excludedGroups>
             </configuration>
           </plugin>
         </plugins>
@@ -2348,7 +2348,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
                 <include>org.apache.hadoop.ozone.freon.**</include>
                 <include>org.apache.hadoop.ozone.shell.**</include>
               </includes>
-              <excludedGroups>flaky | slow | org.apache.ozone.test.SlowTest | unhealthy | org.apache.ozone.test.UnhealthyTest</excludedGroups>
+              <excludedGroups>flaky | org.apache.ozone.test.FlakyTest | slow | org.apache.ozone.test.SlowTest | unhealthy | org.apache.ozone.test.UnhealthyTest</excludedGroups>
             </configuration>
           </plugin>
         </plugins>
@@ -2362,7 +2362,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-surefire-plugin</artifactId>
             <configuration>
-              <excludedGroups>flaky | slow | org.apache.ozone.test.SlowTest | unhealthy | org.apache.ozone.test.UnhealthyTest</excludedGroups>
+              <excludedGroups>flaky | org.apache.ozone.test.FlakyTest | slow | org.apache.ozone.test.SlowTest | unhealthy | org.apache.ozone.test.UnhealthyTest</excludedGroups>
             </configuration>
           </plugin>
         </plugins>
@@ -2376,7 +2376,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-surefire-plugin</artifactId>
             <configuration>
-              <groups>flaky</groups>
+              <groups>flaky | org.apache.ozone.test.FlakyTest</groups>
               <excludedGroups>slow | org.apache.ozone.test.SlowTest | unhealthy | org.apache.ozone.test.UnhealthyTest</excludedGroups>
             </configuration>
           </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -255,6 +255,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
 
     <!-- Plugin versions and config -->
     <maven-surefire-plugin.argLine>-Xmx4096m -XX:+HeapDumpOnOutOfMemoryError</maven-surefire-plugin.argLine>
+    <unstable-test-groups>flaky | org.apache.ozone.test.FlakyTest | slow | org.apache.ozone.test.SlowTest | unhealthy | org.apache.ozone.test.UnhealthyTest</unstable-test-groups>
     <maven-surefire-plugin.version>3.0.0-M5</maven-surefire-plugin.version>
     <maven-surefire-report-plugin.version>${maven-surefire-plugin.version}</maven-surefire-report-plugin.version>
     <maven-failsafe-plugin.version>${maven-surefire-plugin.version}</maven-failsafe-plugin.version>
@@ -2216,7 +2217,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
               <includes>
                 <include>org.apache.hadoop.ozone.client.**</include>
               </includes>
-              <excludedGroups>flaky | org.apache.ozone.test.FlakyTest | slow | org.apache.ozone.test.SlowTest | unhealthy | org.apache.ozone.test.UnhealthyTest</excludedGroups>
+              <excludedGroups>${unstable-test-groups}</excludedGroups>
             </configuration>
           </plugin>
         </plugins>
@@ -2233,7 +2234,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
               <includes>
                 <include>org.apache.hadoop.ozone.om.**</include>
               </includes>
-              <excludedGroups>flaky | org.apache.ozone.test.FlakyTest | slow | org.apache.ozone.test.SlowTest | unhealthy | org.apache.ozone.test.UnhealthyTest</excludedGroups>
+              <excludedGroups>${unstable-test-groups}</excludedGroups>
             </configuration>
           </plugin>
         </plugins>
@@ -2250,7 +2251,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
               <includes>
                 <include>org.apache.hadoop.ozone.scm.**</include>
               </includes>
-              <excludedGroups>flaky | org.apache.ozone.test.FlakyTest | slow | org.apache.ozone.test.SlowTest | unhealthy | org.apache.ozone.test.UnhealthyTest</excludedGroups>
+              <excludedGroups>${unstable-test-groups}</excludedGroups>
             </configuration>
           </plugin>
         </plugins>
@@ -2267,7 +2268,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
               <includes>
                 <include>org.apache.hadoop.fs.ozone.contract.**</include>
               </includes>
-              <excludedGroups>flaky | org.apache.ozone.test.FlakyTest | slow | org.apache.ozone.test.SlowTest | unhealthy | org.apache.ozone.test.UnhealthyTest</excludedGroups>
+              <excludedGroups>${unstable-test-groups}</excludedGroups>
             </configuration>
           </plugin>
         </plugins>
@@ -2287,7 +2288,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
               <excludes>
                 <exclude>org.apache.hadoop.fs.ozone.contract.**</exclude>
               </excludes>
-              <excludedGroups>flaky | org.apache.ozone.test.FlakyTest | slow | org.apache.ozone.test.SlowTest | unhealthy | org.apache.ozone.test.UnhealthyTest</excludedGroups>
+              <excludedGroups>${unstable-test-groups}</excludedGroups>
             </configuration>
           </plugin>
         </plugins>
@@ -2304,7 +2305,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
               <includes>
                 <include>org.apache.hadoop.hdds.**</include>
               </includes>
-              <excludedGroups>flaky | org.apache.ozone.test.FlakyTest | slow | org.apache.ozone.test.SlowTest | unhealthy | org.apache.ozone.test.UnhealthyTest</excludedGroups>
+              <excludedGroups>${unstable-test-groups}</excludedGroups>
             </configuration>
           </plugin>
         </plugins>
@@ -2329,7 +2330,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
                 <exclude>org.apache.hadoop.ozone.scm.**</exclude>
                 <exclude>org.apache.hadoop.ozone.shell.**</exclude>
               </excludes>
-              <excludedGroups>flaky | org.apache.ozone.test.FlakyTest | slow | org.apache.ozone.test.SlowTest | unhealthy | org.apache.ozone.test.UnhealthyTest</excludedGroups>
+              <excludedGroups>${unstable-test-groups}</excludedGroups>
             </configuration>
           </plugin>
         </plugins>
@@ -2348,7 +2349,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
                 <include>org.apache.hadoop.ozone.freon.**</include>
                 <include>org.apache.hadoop.ozone.shell.**</include>
               </includes>
-              <excludedGroups>flaky | org.apache.ozone.test.FlakyTest | slow | org.apache.ozone.test.SlowTest | unhealthy | org.apache.ozone.test.UnhealthyTest</excludedGroups>
+              <excludedGroups>${unstable-test-groups}</excludedGroups>
             </configuration>
           </plugin>
         </plugins>
@@ -2362,7 +2363,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-surefire-plugin</artifactId>
             <configuration>
-              <excludedGroups>flaky | org.apache.ozone.test.FlakyTest | slow | org.apache.ozone.test.SlowTest | unhealthy | org.apache.ozone.test.UnhealthyTest</excludedGroups>
+              <excludedGroups>${unstable-test-groups}</excludedGroups>
             </configuration>
           </plugin>
         </plugins>


### PR DESCRIPTION
## What changes were proposed in this pull request?

`@Flaky` tag only applies to JUnit5 tests.  This change implements a similar feature for JUnit4 tests.  Now JUnit4 tests can be annotated with `@Category(FlakyTest.class)` to execute them in _integration (flaky)_ (with few repetitions if necessary) instead of their regular _integration_ split.

Also mark `TestStorageContainerManager#testContainerReportQueueTakingMoreTime` as flaky (see HDDS-8470).

https://issues.apache.org/jira/browse/HDDS-9466

## How was this patch tested?

Test marked as `@Category(FlakyTest.class)` was executed in _integration (flaky)_:

```
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 4.737 s - in org.apache.hadoop.ozone.scm.TestStorageContainerManager
```

https://github.com/adoroszlai/hadoop-ozone/actions/runs/6544313982/job/17771626430#step:6:3824

Other tests in same class were executed in _integration (scm)_:

```
[INFO] Tests run: 13, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 236.343 s - in org.apache.hadoop.ozone.scm.TestStorageContainerManager
```

https://github.com/adoroszlai/hadoop-ozone/actions/runs/6544313982/job/17771625577#step:5:3848