### PR TITLE
HDDS-9481. A reformatted datanode node cannot be decommissioned

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/NodeDecommissionManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/NodeDecommissionManager.java
@@ -187,7 +187,7 @@ public class NodeDecommissionManager {
     return results;
   }
 
-  public boolean allPortsMatch(List<DatanodeDetails> dns) {
+  private boolean allPortsMatch(List<DatanodeDetails> dns) {
     if (dns.size() < 2) {
       return true;
     }
@@ -201,7 +201,7 @@ public class NodeDecommissionManager {
     return true;
   }
 
-  public DatanodeDetails findDnWithMostRecentHeartbeat(
+  private DatanodeDetails findDnWithMostRecentHeartbeat(
       List<DatanodeDetails> dns) {
     if (dns.size() < 2) {
       return dns.isEmpty() ? null : dns.get(0);

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/NodeDecommissionManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/NodeDecommissionManager.java
@@ -197,6 +197,9 @@ public class NodeDecommissionManager {
 
   public DatanodeDetails findDnWithMostRecentHeartbeat(
       List<DatanodeDetails> dns) {
+    if (dns.size() < 2) {
+      return dns.isEmpty() ? null : dns.get(0);
+    }
     List<Pair<DatanodeDetails, Long>> dnsWithHeartbeat = dns.stream()
         .map(dn -> Pair.of(dn, nodeManager.getLastHeartbeat(dn)))
         .sorted(Comparator.comparingLong(Pair::getRight))

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/NodeDecommissionManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/NodeDecommissionManager.java
@@ -18,6 +18,7 @@ package org.apache.hadoop.hdds.scm.node;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
+import org.apache.commons.lang3.tuple.Pair;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos.NodeOperationalState;
@@ -37,11 +38,13 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.UnknownHostException;
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
 
 /**
  * Class used to manage datanodes scheduled for maintenance or decommission.
@@ -125,7 +128,7 @@ public class NodeDecommissionManager {
         dnsName = addr.getHostAddress();
       }
       List<DatanodeDetails> found = nodeManager.getNodesByAddress(dnsName);
-      if (found.size() == 0) {
+      if (found.isEmpty()) {
         throw new InvalidHostStringException("Host " + host.getRawHostname()
             + " (" + dnsName + ") is not running any datanodes registered"
             + " with SCM."
@@ -139,24 +142,75 @@ public class NodeDecommissionManager {
               + " Please check the port number.");
         }
         results.add(found.get(0));
-      } else if (found.size() > 1) {
-        DatanodeDetails match = null;
-        for (DatanodeDetails dn : found) {
-          if (validateDNPortMatch(host.getPort(), dn)) {
-            match = dn;
-            break;
+      } else {
+        // Here we either have multiple DNs on the same host / IP, and they
+        // should have different ports. Or, we have a case where a DN was
+        // registered from a host, then stopped and formatted, changing its
+        // UUID and registered again. In that case, the ports of all hosts
+        // should be the same, and we should just use the one with the most
+        // recent heartbeat.
+        if (allPortsMatch(found)) {
+          // All ports match, so just use the most recent heartbeat as it is
+          // not possible for a host to have 2 DNs coming from the same port.
+          DatanodeDetails mostRecent = findDnWithMostRecentHeartbeat(found);
+          if (mostRecent == null) {
+            throw new InvalidHostStringException("Host " + host.getRawHostname()
+                + " has multiple datanodes registered with SCM."
+                + " All have identical ports, but none have a newest"
+                + " heartbeat.");
           }
+          results.add(mostRecent);
+        } else {
+          DatanodeDetails match = null;
+          for (DatanodeDetails dn : found) {
+            if (validateDNPortMatch(host.getPort(), dn)) {
+              match = dn;
+              break;
+            }
+          }
+          if (match == null) {
+            throw new InvalidHostStringException("Host " + host.getRawHostname()
+                + " is running multiple datanodes registered with SCM,"
+                + " but no port numbers match."
+                + " Please check the port number.");
+          }
+          results.add(match);
         }
-        if (match == null) {
-          throw new InvalidHostStringException("Host " + host.getRawHostname()
-              + " is running multiple datanodes registered with SCM,"
-              + " but no port numbers match."
-              + " Please check the port number.");
-        }
-        results.add(match);
       }
     }
     return results;
+  }
+
+  public boolean allPortsMatch(List<DatanodeDetails> dns) {
+    if (dns.size() < 2) {
+      return true;
+    }
+    int port = dns.get(0).getPort(DatanodeDetails.Port.Name.RATIS).getValue();
+    for (int i = 1; i < dns.size(); i++) {
+      if (dns.get(i).getPort(DatanodeDetails.Port.Name.RATIS).getValue()
+          != port) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  public DatanodeDetails findDnWithMostRecentHeartbeat(
+      List<DatanodeDetails> dns) {
+    List<Pair<DatanodeDetails, Long>> dnsWithHeartbeat = dns.stream()
+        .map(dn -> Pair.of(dn, nodeManager.getLastHeartbeat(dn)))
+        .sorted(Comparator.comparingLong(Pair::getRight))
+        .collect(Collectors.toList());
+    // The last element should have the largest (newest) heartbeat. But also
+    // check it is not identical to the last but 1 element, as then we cannot
+    // determine which node to decommission.
+    Pair<DatanodeDetails, Long> last = dnsWithHeartbeat.get(
+        dnsWithHeartbeat.size() - 1);
+    if (last.getRight() > dnsWithHeartbeat.get(
+        dnsWithHeartbeat.size() - 2).getRight()) {
+      return last.getLeft();
+    }
+    return null;
   }
 
   /**

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/NodeManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/NodeManager.java
@@ -381,6 +381,14 @@ public interface NodeManager extends StorageContainerNodeProtocol,
   List<DatanodeDetails> getNodesByAddress(String address);
 
   /**
+   * For the given node, retried the last heartbeat time.
+   * @param datanodeDetails DatanodeDetails of the node.
+   * @return The last heartbeat time in milliseconds or -1 if the node does not
+   *         existing in the nodeManager.
+   */
+  long getLastHeartbeat(DatanodeDetails datanodeDetails);
+
+  /**
    * Get cluster map as in network topology for this node manager.
    * @return cluster map
    */

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/SCMNodeManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/SCMNodeManager.java
@@ -1393,6 +1393,22 @@ public class SCMNodeManager implements NodeManager {
     return clusterMap;
   }
 
+  /**
+   * For the given node, retried the last heartbeat time.
+   * @param datanodeDetails DatanodeDetails of the node.
+   * @return The last heartbeat time in milliseconds or -1 if the node does not
+   *         exist.
+   */
+  @Override
+  public long getLastHeartbeat(DatanodeDetails datanodeDetails) {
+    try {
+      DatanodeInfo node = nodeStateManager.getNode(datanodeDetails);
+      return node.getLastHeartbeatTime();
+    } catch (NodeNotFoundException e) {
+      return -1;
+    }
+  }
+
   private String nodeResolve(String hostname) {
     List<String> hosts = new ArrayList<>(1);
     hosts.add(hostname);

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/MockNodeManager.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/MockNodeManager.java
@@ -922,6 +922,11 @@ public class MockNodeManager implements NodeManager {
     return numPipelinePerDatanode;
   }
 
+  @Override
+  public long getLastHeartbeat(DatanodeDetails datanodeDetails) {
+    return -1;
+  }
+
   public void setNumPipelinePerDatanode(int value) {
     numPipelinePerDatanode = value;
   }

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/SimpleMockNodeManager.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/SimpleMockNodeManager.java
@@ -382,6 +382,11 @@ public class SimpleMockNodeManager implements NodeManager {
   }
 
   @Override
+  public long getLastHeartbeat(DatanodeDetails datanodeDetails) {
+    return -1;
+  }
+
+  @Override
   public void close() throws IOException {
 
   }

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/ozone/container/testutils/ReplicationNodeManagerMock.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/ozone/container/testutils/ReplicationNodeManagerMock.java
@@ -534,4 +534,9 @@ public class ReplicationNodeManagerMock implements NodeManager {
   public int minPipelineLimit(List<DatanodeDetails> dn) {
     return 0;
   }
+
+  @Override
+  public long getLastHeartbeat(DatanodeDetails datanodeDetails) {
+    return -1;
+  }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

If a datanode is registered to SCM on the cluster, and then it is stopped and the data disks cleared and then it is restarted, it will reconnect to SCM as a new node with a new UUID.

When this happens, the old datanode details are kept in SCM as a dead node and the mapping table which maps DNs running on a host to their UUIDs will contain two entries, leaving the decommission command unable to decide which entry is to be decommissioned, giving this error:

```
2023-10-03 08:05:50,279 ERROR [IPC Server handler 25 on 9860]-org.apache.hadoop.hdds.scm.server.SCMClientProtocolServer: Failed to decommission nodes
org.apache.hadoop.hdds.scm.node.InvalidHostStringException: Host host1.acme.org is running multiple datanodes registered with SCM, but no port numbers match. Please check the port number.
        at org.apache.hadoop.hdds.scm.node.NodeDecommissionManager.mapHostnamesToDatanodes(NodeDecommissionManager.java:151)
        at org.apache.hadoop.hdds.scm.node.NodeDecommissionManager.decommissionNodes(NodeDecommissionManager.java:228)
        at org.apache.hadoop.hdds.scm.server.SCMClientProtocolServer.decommissionNodes(SCMClientProtocolServer.java:624)
        at org.apache.hadoop.hdds.scm.protocol.StorageContainerLocationProtocolServerSideTranslatorPB.decommissionNodes(StorageContainerLocationProtocolServerSideTranslatorPB.java:1114)
        at org.apache.hadoop.hdds.scm.protocol.StorageContainerLocationProtocolServerSideTranslatorPB.processRequest(StorageContainerLocationProtocolServerSideTranslatorPB.java:602)
        at org.apache.hadoop.hdds.server.OzoneProtocolMessageDispatcher.processRequest(OzoneProtocolMessageDispatcher.java:87)
        at org.apache.hadoop.hdds.scm.protocol.StorageContainerLocationProtocolServerSideTranslatorPB.submitRequest(StorageContainerLocationProtocolServerSideTranslatorPB.java:221)
        at org.apache.hadoop.hdds.protocol.proto.StorageContainerLocationProtocolProtos$StorageContainerLocationProtocolService$2.callBlockingMethod(StorageContainerLocationProtocolProtos.java)
        at org.apache.hadoop.ipc.ProtobufRpcEngine$Server$ProtoBufRpcInvoker.call(ProtobufRpcEngine.java:533)
        at org.apache.hadoop.ipc.RPC$Server.call(RPC.java:1070)
        at org.apache.hadoop.ipc.Server$RpcCall.run(Server.java:994)
        at org.apache.hadoop.ipc.Server$RpcCall.run(Server.java:922)
        at java.base/java.security.AccessController.doPrivileged(Native Method)
        at java.base/javax.security.auth.Subject.doAs(Subject.java:423)
        at org.apache.hadoop.security.UserGroupInformation.doAs(UserGroupInformation.java:1899)
        at org.apache.hadoop.ipc.Server$Handler.run(Server.java:2899)
```

It is valid for multiple DNs to be on the same host, especially on test clusters or mini-clusters. However it is not possible for a DN to be heartbeating from the same host with the same ports.

In this case, where we try to decommission a host, and it has multiple entries from the same host and all the ports are the same for all entries, we can safely decommission the one with the newest heartbeat.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-9481

## How was this patch tested?

New unit test added to reproduce and validate the fix.
