### PR TITLE
HDDS-9485. Let integration check reuse Ozone jars from build check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -120,6 +120,13 @@ jobs:
           name: ozone-src
           path: hadoop-ozone/dist/target/ozone-*-src.tar.gz
           retention-days: 1
+      - name: Store Maven repo for tests
+        uses: actions/upload-artifact@v3
+        with:
+          name: ozone-repo
+          path: |
+            ~/.m2/repository/org/apache/ozone
+          retention-days: 1
       - name: Delete temporary build artifacts before caching
         run: |
           #Never cache local artifacts
@@ -412,19 +419,33 @@ jobs:
             maven-repo-${{ hashFiles('**/pom.xml') }}-8
             maven-repo-${{ hashFiles('**/pom.xml') }}
             maven-repo-
+      - name: Download Ozone repo
+        id: download-ozone-repo
+        uses: actions/download-artifact@v3
+        with:
+          name: ozone-repo
+          path: |
+            ~/.m2/repository/org/apache/ozone
+        continue-on-error: true
       - name: Setup java
         uses: actions/setup-java@v3
         with:
           distribution: 'temurin'
           java-version: 8
       - name: Execute tests
-        run: hadoop-ozone/dev-support/checks/integration.sh -P${{ matrix.profile }}
-        if: matrix.profile != 'flaky'
         continue-on-error: true
-      - name: Execute flaky tests
-        run: hadoop-ozone/dev-support/checks/integration.sh -P${{ matrix.profile }} -Dsurefire.rerunFailingTestsCount=5 -Dsurefire.fork.timeout=3600
-        if: matrix.profile == 'flaky'
-        continue-on-error: true
+        run: |
+          if [[ -e "${{ steps.download-ozone-repo.outputs.download-path }}" ]]; then
+            export OZONE_REPO_CACHED=true
+          fi
+
+          args=
+          if [[ "${{ matrix.profile }}" == "flaky" ]]; then
+            args="-Dsurefire.rerunFailingTestsCount=5 -Dsurefire.fork.timeout=3600"
+          fi
+
+          hadoop-ozone/dev-support/checks/integration.sh -P${{ matrix.profile }} ${args}
+
       - name: Summary of failures
         run: hadoop-ozone/dev-support/checks/_summary.sh target/${{ github.job }}/summary.txt
         if: ${{ !cancelled() }}

--- a/hadoop-ozone/dev-support/checks/junit.sh
+++ b/hadoop-ozone/dev-support/checks/junit.sh
@@ -22,6 +22,7 @@ cd "$DIR/../../.." || exit 1
 : ${CHECK:="unit"}
 : ${ITERATIONS:="1"}
 : ${OZONE_WITH_COVERAGE:="false"}
+: ${OZONE_REPO_CACHED:="false"}
 
 declare -i ITERATIONS
 if [[ ${ITERATIONS} -le 0 ]]; then
@@ -42,7 +43,9 @@ else
 fi
 
 if [[ "${CHECK}" == "integration" ]] || [[ ${ITERATIONS} -gt 1 ]]; then
-  mvn ${MAVEN_OPTIONS} -DskipTests clean install
+  if [[ ${OZONE_REPO_CACHED} == "false" ]]; then
+    mvn ${MAVEN_OPTIONS} -DskipTests clean install
+  fi
 fi
 
 REPORT_DIR=${OUTPUT_DIR:-"$DIR/../../../target/${CHECK}"}


### PR DESCRIPTION
## What changes were proposed in this pull request?

Let _integration_ check reuse Ozone jars created in _build_ check, instead of building everything from scratch.  These jars are not part of the cached Maven repo, so we need to upload/download them separately.

If there is a problem downloading the artifact (e.g. it has expired), `integration.sh` falls back to previous behavior.

To reduce code duplication, flaky/other executions are merged into the same code block.

https://issues.apache.org/jira/browse/HDDS-9485

## How was this patch tested?

Time for [_integration_ check's splits](https://github.com/adoroszlai/hadoop-ozone/actions/runs/6556786545) decreased by 10-20 minutes each compared to latest [run on `master`](https://github.com/apache/ozone/actions/runs/6556346778).