### PR TITLE
HDDS-9465. Recon UI - Disk Usage page should reflect the information it displays

### DIFF
--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/views/diskUsage/diskUsage.tsx
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/views/diskUsage/diskUsage.tsx
@@ -18,7 +18,7 @@
 
 import React from 'react';
 import Plot from 'react-plotly.js';
-import {Row, Col, Icon, Button, Input, Menu, Dropdown} from 'antd';
+import {Row, Col, Icon, Button, Input, Menu, Dropdown,Tooltip} from 'antd';
 import {DetailPanel} from 'components/rightDrawer/rightDrawer';
 import * as Plotly from 'plotly.js';
 import {showDataFetchError} from 'utils/common';
@@ -539,7 +539,10 @@ export class DiskUsage extends React.Component<Record<string, object>, IDUState>
     return (
       <div className='du-container'>
         <div className='page-header'>
-          Disk Usage
+          Disk Usage&nbsp;&nbsp;
+          <Tooltip placement="rightTop" title="Shows Disk Usage Info for FSO buckets Only">
+            <Icon type='info-circle' />
+          </Tooltip>
         </div>
         <div className='content-div'>
           {isLoading ? <span><Icon type='loading'/> Loading...</span> : (


### PR DESCRIPTION

## What changes were proposed in this pull request?
Recon UI - Disk Usage page should reflect the information it displays like currently it shows storage stats only for FSO buckets/paths. As of now currently it doesn't support OBS and LEGACY buckets. For supporting OBS and LEGACY buckets, work is in progress tracked by [HDDS-7810](https://issues.apache.org/jira/browse/HDDS-7810) . Till then page should show that it displays storage stats only for FSO buckets/paths.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-9465

## How was this patch tested?
Manually
![image](https://github.com/apache/ozone/assets/112169209/f0c710a2-d6b4-469f-b4b1-0529c4904ab1)

