### PR TITLE
HDDS-3131. Enable TestMiniChaosOzoneCluster

### DIFF
--- a/hadoop-ozone/fault-injection-test/mini-chaos-tests/src/test/java/org/apache/hadoop/ozone/TestMiniChaosOzoneCluster.java
+++ b/hadoop-ozone/fault-injection-test/mini-chaos-tests/src/test/java/org/apache/hadoop/ozone/TestMiniChaosOzoneCluster.java
@@ -30,11 +30,9 @@ import org.apache.hadoop.ozone.failure.Failures;
 import org.apache.hadoop.ozone.freon.FreonReplicationOptions;
 import org.apache.hadoop.ozone.loadgenerators.LoadGenerator;
 import org.apache.hadoop.ozone.om.helpers.BucketLayout;
-import org.apache.ozone.test.UnhealthyTest;
 import org.junit.BeforeClass;
 import org.junit.AfterClass;
 import org.junit.Test;
-import org.junit.experimental.categories.Category;
 import picocli.CommandLine;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Option;
@@ -46,7 +44,6 @@ import java.util.concurrent.TimeUnit;
 /**
  * Test Read Write with Mini Ozone Chaos Cluster.
  */
-@Category(UnhealthyTest.class)
 @Command(description = "Starts IO with MiniOzoneChaosCluster",
     name = "chaos", mixinStandardHelpOptions = true)
 public class TestMiniChaosOzoneCluster extends GenericCli {


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR removes the `UnhealthyTest` category annotation from `TestMiniChaosOzoneCluster`, as it no longer times out.
  
## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-3131

## How was this patch tested?

This patch is tested using flaky-test-check workflow [CI run](https://github.com/devmadhuu/ozone/actions/runs/6559767946/job/17817681781) and no failures or timeout in 200 iterations.