### PR TITLE
HDDS-9446. Set HadoopRPC as the default transport between S3 and Ozone.

### DIFF
--- a/hadoop-hdds/common/src/main/resources/ozone-default.xml
+++ b/hadoop-hdds/common/src/main/resources/ozone-default.xml
@@ -2859,11 +2859,21 @@
   </property>
   <property>
     <name>ozone.om.transport.class</name>
-    <value>org.apache.hadoop.ozone.om.protocolPB.GrpcOmTransportFactory</value>
+    <value>org.apache.hadoop.ozone.om.protocolPB.Hadoop3OmTransportFactory</value>
     <tag>OM, MANAGEMENT</tag>
     <description>
-      Enable Ozone Manager S3G Grpc channel.
+      Property to determine the transport protocol for the client to Ozone Manager channel.
+      If GRPC (Hadoop3OmTransportFactory) is used, please make sure ozone.om.s3.grpc.server_enabled is enabled
+      in Ozone Manager.
     </description>
+  </property>
+  <property>
+    <name>ozone.om.s3.grpc.server_enabled</name>
+    <value>false</value>
+    <description>
+      Determine if GRPC should be supported by Ozone Manager as a client transport protocol.
+    </description>
+    <tag>OM, MANAGEMENT</tag>
   </property>
   <property>
     <name>ozone.recon.http.enabled</name>

--- a/hadoop-hdds/common/src/main/resources/ozone-default.xml
+++ b/hadoop-hdds/common/src/main/resources/ozone-default.xml
@@ -2863,17 +2863,7 @@
     <tag>OM, MANAGEMENT</tag>
     <description>
       Property to determine the transport protocol for the client to Ozone Manager channel.
-      If GRPC (Hadoop3OmTransportFactory) is used, please make sure ozone.om.s3.grpc.server_enabled is enabled
-      in Ozone Manager.
     </description>
-  </property>
-  <property>
-    <name>ozone.om.s3.grpc.server_enabled</name>
-    <value>false</value>
-    <description>
-      Determine if GRPC should be supported by Ozone Manager as a client transport protocol.
-    </description>
-    <tag>OM, MANAGEMENT</tag>
   </property>
   <property>
     <name>ozone.recon.http.enabled</name>

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/OMConfigKeys.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/OMConfigKeys.java
@@ -422,7 +422,7 @@ public final class OMConfigKeys {
   public static final String OZONE_OM_S3_GPRC_SERVER_ENABLED =
       "ozone.om.s3.grpc.server_enabled";
   public static final boolean OZONE_OM_S3_GRPC_SERVER_ENABLED_DEFAULT =
-      true;
+      false;
 
   public static final String OZONE_OM_NAMESPACE_STRICT_S3 =
       "ozone.om.namespace.s3.strict";

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/OMConfigKeys.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/OMConfigKeys.java
@@ -422,7 +422,7 @@ public final class OMConfigKeys {
   public static final String OZONE_OM_S3_GPRC_SERVER_ENABLED =
       "ozone.om.s3.grpc.server_enabled";
   public static final boolean OZONE_OM_S3_GRPC_SERVER_ENABLED_DEFAULT =
-      false;
+      true;
 
   public static final String OZONE_OM_NAMESPACE_STRICT_S3 =
       "ozone.om.namespace.s3.strict";


### PR DESCRIPTION
## What changes were proposed in this pull request?

Set HadoopRPC as the default transport between S3 and Ozone. Details in JIRA.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-9446

## How was this patch tested?

Tested locally to verify HadoopRPC is used for the traffic S3->OM. 