### PR TITLE
HDDS-8940. Fix for missing SST files on optimized snapDiff code path

### DIFF
--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/RocksDatabase.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/RocksDatabase.java
@@ -18,9 +18,7 @@
 package org.apache.hadoop.hdds.utils.db;
 
 import com.google.common.annotations.VisibleForTesting;
-import org.apache.commons.lang3.tuple.Pair;
 import org.apache.hadoop.hdds.StringUtils;
-import org.apache.hadoop.hdds.utils.BooleanTriFunction;
 import org.apache.hadoop.hdds.utils.HddsServerUtil;
 import org.apache.hadoop.hdds.utils.db.managed.ManagedCheckpoint;
 import org.apache.hadoop.hdds.utils.db.managed.ManagedColumnFamilyOptions;
@@ -36,6 +34,7 @@ import org.apache.hadoop.hdds.utils.db.managed.ManagedRocksObjectUtils;
 import org.apache.hadoop.hdds.utils.db.managed.ManagedTransactionLogIterator;
 import org.apache.hadoop.hdds.utils.db.managed.ManagedWriteBatch;
 import org.apache.hadoop.hdds.utils.db.managed.ManagedWriteOptions;
+import org.apache.ozone.rocksdiff.RocksDiffUtils;
 import org.rocksdb.ColumnFamilyDescriptor;
 import org.rocksdb.ColumnFamilyHandle;
 import org.rocksdb.Holder;
@@ -49,7 +48,6 @@ import java.io.Closeable;
 import java.io.File;
 import java.io.IOException;
 import java.nio.ByteBuffer;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -66,6 +64,7 @@ import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.apache.hadoop.hdds.StringUtils.bytes2String;
 import static org.apache.hadoop.hdds.utils.db.managed.ManagedColumnFamilyOptions.closeDeeply;
 import static org.apache.hadoop.hdds.utils.db.managed.ManagedRocksIterator.managed;
@@ -616,7 +615,7 @@ public final class RocksDatabase implements Closeable {
     assertClose();
     for (ColumnFamilyHandle cf : getCfHandleMap().get(db.get().getName())) {
       try {
-        String table = new String(cf.getName(), StandardCharsets.UTF_8);
+        String table = new String(cf.getName(), UTF_8);
         if (cfName.equals(table)) {
           return cf;
         }
@@ -955,46 +954,45 @@ public final class RocksDatabase implements Closeable {
   /**
    * Deletes sst files which do not correspond to prefix
    * for given table.
-   * @param prefixPairs, a list of pair (TableName,prefixUsed).
+   * @param prefixPairs, a map of TableName to prefixUsed.
    */
-  public void deleteFilesNotMatchingPrefix(
-      List<Pair<String, String>> prefixPairs,
-      BooleanTriFunction<String, String, String, Boolean> filterFunction)
+  public void deleteFilesNotMatchingPrefix(Map<String, String> prefixPairs)
       throws IOException, RocksDBException {
     assertClose();
     for (LiveFileMetaData liveFileMetaData : getSstFileList()) {
       String sstFileColumnFamily =
-          new String(liveFileMetaData.columnFamilyName(),
-              StandardCharsets.UTF_8);
+          new String(liveFileMetaData.columnFamilyName(), UTF_8);
       int lastLevel = getLastLevel();
-      for (Pair<String, String> prefixPair : prefixPairs) {
-        String columnFamily = prefixPair.getKey();
-        String prefixForColumnFamily = prefixPair.getValue();
-        if (!sstFileColumnFamily.equals(columnFamily)) {
-          continue;
-        }
-        // RocksDB #deleteFile API allows only to delete the last level of
-        // SST Files. Any level < last level won't get deleted and
-        // only last file of level 0 can be deleted
-        // and will throw warning in the rocksdb manifest.
-        // Instead, perform the level check here
-        // itself to avoid failed delete attempts for lower level files.
-        if (liveFileMetaData.level() != lastLevel || lastLevel == 0) {
-          continue;
-        }
-        String firstDbKey =
-            new String(liveFileMetaData.smallestKey(), StandardCharsets.UTF_8);
-        String lastDbKey =
-            new String(liveFileMetaData.largestKey(), StandardCharsets.UTF_8);
-        boolean isKeyWithPrefixPresent =
-            filterFunction.apply(firstDbKey, lastDbKey, prefixForColumnFamily);
-        if (!isKeyWithPrefixPresent) {
-          LOG.info("Deleting sst file {} corresponding to column family"
-                  + " {} from db: {}", liveFileMetaData.fileName(),
-              StringUtils.bytes2String(liveFileMetaData.columnFamilyName()),
-              db.get().getName());
-          db.deleteFile(liveFileMetaData);
-        }
+
+      if (!prefixPairs.containsKey(sstFileColumnFamily)) {
+        continue;
+      }
+
+      // RocksDB #deleteFile API allows only to delete the last level of
+      // SST Files. Any level < last level won't get deleted and
+      // only last file of level 0 can be deleted
+      // and will throw warning in the rocksdb manifest.
+      // Instead, perform the level check here
+      // itself to avoid failed delete attempts for lower level files.
+      if (liveFileMetaData.level() != lastLevel || lastLevel == 0) {
+        continue;
+      }
+
+      String prefixForColumnFamily = prefixPairs.get(sstFileColumnFamily);
+      String firstDbKey = new String(liveFileMetaData.smallestKey(), UTF_8);
+      String lastDbKey = new String(liveFileMetaData.largestKey(), UTF_8);
+      boolean isKeyWithPrefixPresent = RocksDiffUtils.isKeyWithPrefixPresent(
+          prefixForColumnFamily, firstDbKey, lastDbKey);
+      if (!isKeyWithPrefixPresent) {
+        LOG.info("Deleting sst file: {} with start key: {} and end key: {} " +
+                "corresponding to column family {} from db: {}. " +
+                "Prefix for the column family: {}.",
+            liveFileMetaData.fileName(),
+            firstDbKey, lastDbKey,
+            StringUtils.bytes2String(liveFileMetaData.columnFamilyName()),
+            db.get().getName(),
+            prefixForColumnFamily);
+        db.deleteFile(liveFileMetaData);
       }
     }
   }

--- a/hadoop-hdds/rocksdb-checkpoint-differ/src/main/java/org/apache/ozone/compaction/log/CompactionFileInfo.java
+++ b/hadoop-hdds/rocksdb-checkpoint-differ/src/main/java/org/apache/ozone/compaction/log/CompactionFileInfo.java
@@ -18,6 +18,7 @@
 
 package org.apache.ozone.compaction.log;
 
+import com.google.common.annotations.VisibleForTesting;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.util.Preconditions;
 
@@ -32,10 +33,11 @@ public final class CompactionFileInfo {
   private final String endKey;
   private final String columnFamily;
 
-  private CompactionFileInfo(String fileName,
-                             String startRange,
-                             String endRange,
-                             String columnFamily) {
+  @VisibleForTesting
+  public CompactionFileInfo(String fileName,
+                            String startRange,
+                            String endRange,
+                            String columnFamily) {
     this.fileName = fileName;
     this.startKey = startRange;
     this.endKey = endRange;

--- a/hadoop-hdds/rocksdb-checkpoint-differ/src/main/java/org/apache/ozone/compaction/log/CompactionLogEntry.java
+++ b/hadoop-hdds/rocksdb-checkpoint-differ/src/main/java/org/apache/ozone/compaction/log/CompactionLogEntry.java
@@ -18,6 +18,7 @@
 
 package org.apache.ozone.compaction.log;
 
+import com.google.common.annotations.VisibleForTesting;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos.CompactionLogEntryProto;
 import org.apache.hadoop.hdds.utils.db.Codec;
 import org.apache.hadoop.hdds.utils.db.CopyObject;
@@ -49,7 +50,8 @@ public final class CompactionLogEntry implements
   private final List<CompactionFileInfo> outputFileInfoList;
   private final String compactionReason;
 
-  private CompactionLogEntry(long dbSequenceNumber,
+  @VisibleForTesting
+  public CompactionLogEntry(long dbSequenceNumber,
                             long compactionTime,
                             List<CompactionFileInfo> inputFileInfoList,
                             List<CompactionFileInfo> outputFileInfoList,

--- a/hadoop-hdds/rocksdb-checkpoint-differ/src/main/java/org/apache/ozone/rocksdiff/CompactionNode.java
+++ b/hadoop-hdds/rocksdb-checkpoint-differ/src/main/java/org/apache/ozone/rocksdiff/CompactionNode.java
@@ -28,6 +28,9 @@ public class CompactionNode {
   private final long snapshotGeneration;
   private final long totalNumberOfKeys;
   private long cumulativeKeysReverseTraversal;
+  private final String startKey;
+  private final String endKey;
+  private final String columnFamily;
 
   /**
    * CompactionNode constructor.
@@ -36,12 +39,16 @@ public class CompactionNode {
    * @param numKeys Number of keys in the SST
    * @param seqNum Snapshot generation (sequence number)
    */
-  public CompactionNode(String file, String ssId, long numKeys, long seqNum) {
+  public CompactionNode(String file, String ssId, long numKeys, long seqNum,
+                        String startKey, String endKey, String columnFamily) {
     fileName = file;
     snapshotId = ssId;
     totalNumberOfKeys = numKeys;
     snapshotGeneration = seqNum;
     cumulativeKeysReverseTraversal = 0L;
+    this.startKey = startKey;
+    this.endKey = endKey;
+    this.columnFamily = columnFamily;
   }
 
   @Override
@@ -67,6 +74,18 @@ public class CompactionNode {
 
   public long getCumulativeKeysReverseTraversal() {
     return cumulativeKeysReverseTraversal;
+  }
+
+  public String getStartKey() {
+    return startKey;
+  }
+
+  public String getEndKey() {
+    return endKey;
+  }
+
+  public String getColumnFamily() {
+    return columnFamily;
   }
 
   public void setCumulativeKeysReverseTraversal(

--- a/hadoop-hdds/rocksdb-checkpoint-differ/src/main/java/org/apache/ozone/rocksdiff/RocksDBCheckpointDiffer.java
+++ b/hadoop-hdds/rocksdb-checkpoint-differ/src/main/java/org/apache/ozone/rocksdiff/RocksDBCheckpointDiffer.java
@@ -1580,8 +1580,9 @@ public class RocksDBCheckpointDiffer implements AutoCloseable,
     return response;
   }
 
-  private boolean shouldSkipNode(CompactionNode node,
-                                 Map<String, String> columnFamilyToPrefixMap) {
+  @VisibleForTesting
+  boolean shouldSkipNode(CompactionNode node,
+                         Map<String, String> columnFamilyToPrefixMap) {
     // This is for backward compatibility. Before the compaction log table
     // migration, startKey, endKey and columnFamily information is not persisted
     // in compaction log files.
@@ -1600,14 +1601,14 @@ public class RocksDBCheckpointDiffer implements AutoCloseable,
     }
 
     if (!columnFamilyToPrefixMap.containsKey(node.getColumnFamily())) {
-      LOG.debug("SstFile: {} is for columnFamily: {} while filter map " +
+      LOG.debug("SstFile node: {} is for columnFamily: {} while filter map " +
               "contains columnFamilies: {}.", node.getFileName(),
           node.getColumnFamily(), columnFamilyToPrefixMap.keySet());
-      return false;
+      return true;
     }
 
     String keyPrefix = columnFamilyToPrefixMap.get(node.getColumnFamily());
-    return RocksDiffUtils.isKeyWithPrefixPresent(keyPrefix, node.getStartKey(),
+    return !RocksDiffUtils.isKeyWithPrefixPresent(keyPrefix, node.getStartKey(),
         node.getEndKey());
   }
 }

--- a/hadoop-hdds/rocksdb-checkpoint-differ/src/main/java/org/apache/ozone/rocksdiff/RocksDiffUtils.java
+++ b/hadoop-hdds/rocksdb-checkpoint-differ/src/main/java/org/apache/ozone/rocksdiff/RocksDiffUtils.java
@@ -48,9 +48,12 @@ public final class RocksDiffUtils {
   }
 
   public static boolean isKeyWithPrefixPresent(String prefixForColumnFamily,
-      String firstDbKey, String lastDbKey) {
-    return firstDbKey.compareTo(prefixForColumnFamily) <= 0
-        && prefixForColumnFamily.compareTo(lastDbKey) <= 0;
+                                               String firstDbKey,
+                                               String lastDbKey) {
+    String firstKeyPrefix = constructBucketKey(firstDbKey);
+    String endKeyPrefix = constructBucketKey(lastDbKey);
+    return firstKeyPrefix.compareTo(prefixForColumnFamily) <= 0
+        && prefixForColumnFamily.compareTo(endKeyPrefix) <= 0;
   }
 
   public static String constructBucketKey(String keyName) {

--- a/hadoop-hdds/rocksdb-checkpoint-differ/src/test/java/org/apache/ozone/rocksdiff/TestRocksDBCheckpointDiffer.java
+++ b/hadoop-hdds/rocksdb-checkpoint-differ/src/test/java/org/apache/ozone/rocksdiff/TestRocksDBCheckpointDiffer.java
@@ -471,9 +471,9 @@ public class TestRocksDBCheckpointDiffer {
           destSnapshot,
           srcSnapshotSstFiles,
           destSnapshotSstFiles,
-          rocksDBCheckpointDiffer.getForwardCompactionDAG(),
           actualSameSstFiles,
-          actualDiffSstFiles);
+          actualDiffSstFiles,
+          Collections.emptyMap());
     } catch (RuntimeException rtEx) {
       if (!expectingException) {
         fail("Unexpected exception thrown in test.");
@@ -569,7 +569,8 @@ public class TestRocksDBCheckpointDiffer {
     int index = 0;
     for (DifferSnapshotInfo snap : snapshots) {
       // Returns a list of SST files to be fed into RocksDiff
-      List<String> sstDiffList = differ.getSSTDiffList(src, snap);
+      List<String> sstDiffList = differ.getSSTDiffList(src, snap,
+          Collections.emptyMap());
       LOG.info("SST diff list from '{}' to '{}': {}",
           src.getDbPath(), snap.getDbPath(), sstDiffList);
 
@@ -850,7 +851,8 @@ public class TestRocksDBCheckpointDiffer {
                       sstFile -> new CompactionNode(sstFile,
                           UUID.randomUUID().toString(),
                           1000L,
-                          Long.parseLong(sstFile.substring(0, 6))
+                          Long.parseLong(sstFile.substring(0, 6)),
+                          null, null, null
                       ))
                   .collect(Collectors.toList()))
           .collect(Collectors.toList());

--- a/hadoop-hdds/rocksdb-checkpoint-differ/src/test/java/org/apache/ozone/rocksdiff/TestRocksDBCheckpointDiffer.java
+++ b/hadoop-hdds/rocksdb-checkpoint-differ/src/test/java/org/apache/ozone/rocksdiff/TestRocksDBCheckpointDiffer.java
@@ -33,8 +33,11 @@ import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
@@ -1519,5 +1522,305 @@ public class TestRocksDBCheckpointDiffer {
     try (FileOutputStream fileOutputStream = new FileOutputStream(fileName)) {
       fileOutputStream.write(context.getBytes(UTF_8));
     }
+  }
+
+  private final List<CompactionLogEntry> compactionLogEntryList = Arrays.asList(
+      new CompactionLogEntry(101, System.currentTimeMillis(),
+          Arrays.asList(
+              new CompactionFileInfo("000068", "/volume/bucket2",
+                  "/volume/bucket2", "bucketTable"),
+              new CompactionFileInfo("000057", "/volume/bucket1",
+                  "/volume/bucket1", "bucketTable")),
+          Collections.singletonList(
+              new CompactionFileInfo("000086", "/volume/bucket1",
+                  "/volume/bucket2", "bucketTable")),
+          null),
+      new CompactionLogEntry(178, System.currentTimeMillis(),
+          Arrays.asList(new CompactionFileInfo("000078",
+                  "/volume/bucket1/key-0000001411",
+                  "/volume/bucket2/key-0000099649",
+                  "keyTable"),
+              new CompactionFileInfo("000075",
+                  "/volume/bucket1/key-0000016536",
+                  "/volume/bucket2/key-0000098897",
+                  "keyTable"),
+              new CompactionFileInfo("000073",
+                  "/volume/bucket1/key-0000000730",
+                  "/volume/bucket2/key-0000097010",
+                  "keyTable"),
+              new CompactionFileInfo("000071",
+                  "/volume/bucket1/key-0000001820",
+                  "/volume/bucket2/key-0000097895",
+                  "keyTable"),
+              new CompactionFileInfo("000063",
+                  "/volume/bucket1/key-0000001016",
+                  "/volume/bucket1/key-0000099930",
+                  "keyTable")),
+          Collections.singletonList(new CompactionFileInfo("000081",
+              "/volume/bucket1/key-0000000730",
+              "/volume/bucket2/key-0000099649",
+              "keyTable")),
+          null
+      ),
+      new CompactionLogEntry(233, System.currentTimeMillis(),
+          Arrays.asList(
+              new CompactionFileInfo("000086", "/volume/bucket1",
+                  "/volume/bucket2", "bucketTable"),
+              new CompactionFileInfo("000088", "/volume/bucket3",
+                  "/volume/bucket3", "bucketTable")),
+          Collections.singletonList(
+              new CompactionFileInfo("000110", "/volume/bucket1",
+                  "/volume/bucket3", "bucketTable")
+          ),
+          null),
+      new CompactionLogEntry(256, System.currentTimeMillis(),
+          Arrays.asList(new CompactionFileInfo("000081",
+                  "/volume/bucket1/key-0000000730",
+                  "/volume/bucket2/key-0000099649",
+                  "keyTable"),
+              new CompactionFileInfo("000103",
+                  "/volume/bucket1/key-0000017460",
+                  "/volume/bucket3/key-0000097450",
+                  "keyTable"),
+              new CompactionFileInfo("000099",
+                  "/volume/bucket1/key-0000002310",
+                  "/volume/bucket3/key-0000098286",
+                  "keyTable"),
+              new CompactionFileInfo("000097",
+                  "/volume/bucket1/key-0000005965",
+                  "/volume/bucket3/key-0000099136",
+                  "keyTable"),
+              new CompactionFileInfo("000095",
+                  "/volume/bucket1/key-0000012424",
+                  "/volume/bucket3/key-0000083904",
+                  "keyTable")),
+          Collections.singletonList(new CompactionFileInfo("000106",
+              "/volume/bucket1/key-0000000730",
+              "/volume/bucket3/key-0000099136",
+              "keyTable")),
+          null),
+      new CompactionLogEntry(397, now(),
+          Arrays.asList(new CompactionFileInfo("000106",
+                  "/volume/bucket1/key-0000000730",
+                  "/volume/bucket3/key-0000099136",
+                  "keyTable"),
+              new CompactionFileInfo("000128",
+                  "/volume/bucket2/key-0000005031",
+                  "/volume/bucket3/key-0000084385",
+                  "keyTable"),
+              new CompactionFileInfo("000125",
+                  "/volume/bucket2/key-0000003491",
+                  "/volume/bucket3/key-0000088414",
+                  "keyTable"),
+              new CompactionFileInfo("000123",
+                  "/volume/bucket2/key-0000007390",
+                  "/volume/bucket3/key-0000094627",
+                  "keyTable"),
+              new CompactionFileInfo("000121",
+                  "/volume/bucket2/key-0000003232",
+                  "/volume/bucket3/key-0000094246",
+                  "keyTable")),
+          Collections.singletonList(new CompactionFileInfo("000131",
+              "/volume/bucket1/key-0000000730",
+              "/volume/bucket3/key-0000099136",
+              "keyTable")),
+          null
+      )
+  );
+
+  private static Map<String, String> columnFamilyToPrefixMap1 =
+      new HashMap<String, String>() {
+        {
+          put("keyTable", "/volume/bucket1/");
+          // Simply using bucketName instead of ID for the test.
+          put("directoryTable", "/volume/bucket1/");
+          put("fileTable", "/volume/bucket1/");
+        }
+      };
+
+  private static Map<String, String> columnFamilyToPrefixMap2 =
+      new HashMap<String, String>() {
+        {
+          put("keyTable", "/volume/bucket2/");
+          // Simply using bucketName instead of ID for the test.
+          put("directoryTable", "/volume/bucket2/");
+          put("fileTable", "/volume/bucket2/");
+        }
+      };
+
+  private static Map<String, String> columnFamilyToPrefixMap3 =
+      new HashMap<String, String>() {
+        {
+          put("keyTable", "/volume/bucket3/");
+          // Simply using bucketName instead of ID for the test.
+          put("directoryTable", "/volume/bucket3/");
+          put("fileTable", "/volume/bucket3/");
+        }
+      };
+
+  /**
+   * Test cases for testGetSSTDiffListWithoutDB.
+   */
+  private static Stream<Arguments> casesGetSSTDiffListWithoutDB2() {
+    return Stream.of(
+        Arguments.of("Test case 1.",
+            ImmutableSet.of("000081"),
+            ImmutableSet.of("000063"),
+            ImmutableSet.of("000063"),
+            ImmutableSet.of("000078", "000071", "000075", "000073"),
+            columnFamilyToPrefixMap1),
+        Arguments.of("Test case 2.",
+            ImmutableSet.of("000106"),
+            ImmutableSet.of("000081"),
+            ImmutableSet.of("000081"),
+            ImmutableSet.of("000099", "000103", "000097", "000095"),
+            columnFamilyToPrefixMap1),
+        Arguments.of("Test case 3.",
+            ImmutableSet.of("000106"),
+            ImmutableSet.of("000063"),
+            ImmutableSet.of("000063"),
+            ImmutableSet.of("000078", "000071", "000075", "000073", "000103",
+                "000099", "000097", "000095"),
+            columnFamilyToPrefixMap1),
+        Arguments.of("Test case 4.",
+            ImmutableSet.of("000131"),
+            ImmutableSet.of("000106"),
+            ImmutableSet.of("000106"),
+            ImmutableSet.of("000123", "000121", "000128", "000125"),
+            columnFamilyToPrefixMap2),
+        Arguments.of("Test case 5.",
+            ImmutableSet.of("000131"),
+            ImmutableSet.of("000081"),
+            ImmutableSet.of("000081"),
+            ImmutableSet.of("000123", "000121", "000128", "000125", "000103",
+                "000099", "000097", "000095"),
+            columnFamilyToPrefixMap2),
+        Arguments.of("Test case 6.",
+            ImmutableSet.of("000147", "000131", "000141"),
+            ImmutableSet.of("000131"),
+            ImmutableSet.of("000131"),
+            ImmutableSet.of("000147", "000141"),
+            columnFamilyToPrefixMap3),
+        Arguments.of("Test case 7.",
+            ImmutableSet.of("000147", "000131", "000141"),
+            ImmutableSet.of("000106"),
+            ImmutableSet.of("000106"),
+            ImmutableSet.of("000123", "000121", "000128", "000125", "000147",
+                "000141"),
+            columnFamilyToPrefixMap3)
+    );
+  }
+
+  /**
+   * Tests core SST diff list logic. Does not involve DB.
+   * Focuses on testing edge cases in internalGetSSTDiffList().
+   */
+  @ParameterizedTest(name = "{0}")
+  @MethodSource("casesGetSSTDiffListWithoutDB2")
+  public void testGetSSTDiffListWithoutDB2(
+      String description,
+      Set<String> srcSnapshotSstFiles,
+      Set<String> destSnapshotSstFiles,
+      Set<String> expectedSameSstFiles,
+      Set<String> expectedDiffSstFiles,
+      Map<String, String> columnFamilyToPrefixMap
+  ) {
+    compactionLogEntryList.forEach(entry ->
+        rocksDBCheckpointDiffer.addToCompactionLogTable(entry));
+
+    rocksDBCheckpointDiffer.loadAllCompactionLogs();
+
+    // Snapshot is used for logging purpose and short-circuiting traversal.
+    // Using gen 0 for this test.
+    DifferSnapshotInfo mockedSourceSnapshot = new DifferSnapshotInfo(
+        "/path/to/dbcp1", UUID.randomUUID(), 0L, null, null);
+    DifferSnapshotInfo mockedDestinationSnapshot = new DifferSnapshotInfo(
+        "/path/to/dbcp2", UUID.randomUUID(), 0L, null, null);
+
+    Set<String> actualSameSstFiles = new HashSet<>();
+    Set<String> actualDiffSstFiles = new HashSet<>();
+
+    rocksDBCheckpointDiffer.internalGetSSTDiffList(
+        mockedSourceSnapshot,
+        mockedDestinationSnapshot,
+        srcSnapshotSstFiles,
+        destSnapshotSstFiles,
+        actualSameSstFiles,
+        actualDiffSstFiles,
+        columnFamilyToPrefixMap);
+
+    // Check same and different SST files result
+    Assertions.assertEquals(expectedSameSstFiles, actualSameSstFiles);
+    Assertions.assertEquals(expectedDiffSstFiles, actualDiffSstFiles);
+  }
+
+  private static Stream<Arguments> shouldSkipNodeCases() {
+    List<Boolean> expectedResponse1 = Arrays.asList(true, false, true, false,
+        false, false, false, false, true, true, false, false, false, false,
+        false, true, true, true, true, true, false);
+    List<Boolean> expectedResponse2 = Arrays.asList(true, true, true, false,
+        false, false, false, false, true, true, false, false, false, false,
+        false, true, false, false, false, false, false);
+    List<Boolean> expectedResponse3 = Arrays.asList(true, true, true, true,
+        true, true, true, true, true, true, false, false, false, false, false,
+        true, false, false, false, false, false);
+    return Stream.of(
+        Arguments.of(columnFamilyToPrefixMap1, expectedResponse1),
+        Arguments.of(columnFamilyToPrefixMap2, expectedResponse2),
+        Arguments.of(columnFamilyToPrefixMap3, expectedResponse3));
+  }
+
+  @ParameterizedTest()
+  @MethodSource("shouldSkipNodeCases")
+  public void testShouldSkipNode(Map<String, String> columnFamilyToPrefixMap,
+                                 List<Boolean> expectedResponse) {
+    compactionLogEntryList.forEach(entry ->
+        rocksDBCheckpointDiffer.addToCompactionLogTable(entry));
+
+    rocksDBCheckpointDiffer.loadAllCompactionLogs();
+
+    List<Boolean> actualResponse = rocksDBCheckpointDiffer
+        .getCompactionNodeMap().values().stream()
+        .sorted(Comparator.comparing(CompactionNode::getFileName))
+        .map(node ->
+            rocksDBCheckpointDiffer.shouldSkipNode(node,
+                columnFamilyToPrefixMap))
+        .collect(Collectors.toList());
+
+    assertEquals(expectedResponse, actualResponse);
+  }
+
+  private static Stream<Arguments> shouldSkipNodeEdgeCases() {
+    CompactionNode node = new CompactionNode("fileName",
+        "snapshotId", 100, 100, "startKey", "endKey", "columnFamily");
+    CompactionNode nullColumnFamilyNode = new CompactionNode("fileName",
+        "snapshotId", 100, 100, "startKey", "endKey", null);
+    CompactionNode nullStartKeyNode = new CompactionNode("fileName",
+        "snapshotId", 100, 100, null, "endKey", "columnFamily");
+    CompactionNode nullEndKeyNode = new CompactionNode("fileName",
+        "snapshotId", 100, 100, "startKey", null, "columnFamily");
+
+    return Stream.of(
+        Arguments.of(node, Collections.emptyMap(), false),
+        Arguments.of(node, columnFamilyToPrefixMap1, true),
+        Arguments.of(nullColumnFamilyNode, columnFamilyToPrefixMap1, false),
+        Arguments.of(nullStartKeyNode, columnFamilyToPrefixMap1, false),
+        Arguments.of(nullEndKeyNode, columnFamilyToPrefixMap1, false));
+  }
+
+  @ParameterizedTest()
+  @MethodSource("shouldSkipNodeEdgeCases")
+  public void testShouldSkipNodeEdgeCase(
+      CompactionNode node,
+      Map<String, String> columnFamilyToPrefixMap,
+      boolean expectedResponse
+  ) {
+    compactionLogEntryList.forEach(entry ->
+        rocksDBCheckpointDiffer.addToCompactionLogTable(entry));
+
+    rocksDBCheckpointDiffer.loadAllCompactionLogs();
+
+    assertEquals(expectedResponse, rocksDBCheckpointDiffer.shouldSkipNode(node,
+        columnFamilyToPrefixMap));
   }
 }

--- a/hadoop-hdds/rocksdb-checkpoint-differ/src/test/java/org/apache/ozone/rocksdiff/TestRocksDBCheckpointDiffer.java
+++ b/hadoop-hdds/rocksdb-checkpoint-differ/src/test/java/org/apache/ozone/rocksdiff/TestRocksDBCheckpointDiffer.java
@@ -475,8 +475,7 @@ public class TestRocksDBCheckpointDiffer {
           srcSnapshotSstFiles,
           destSnapshotSstFiles,
           actualSameSstFiles,
-          actualDiffSstFiles,
-          Collections.emptyMap());
+          actualDiffSstFiles);
     } catch (RuntimeException rtEx) {
       if (!expectingException) {
         fail("Unexpected exception thrown in test.");
@@ -572,8 +571,7 @@ public class TestRocksDBCheckpointDiffer {
     int index = 0;
     for (DifferSnapshotInfo snap : snapshots) {
       // Returns a list of SST files to be fed into RocksDiff
-      List<String> sstDiffList = differ.getSSTDiffList(src, snap,
-          Collections.emptyMap());
+      List<String> sstDiffList = differ.getSSTDiffList(src, snap);
       LOG.info("SST diff list from '{}' to '{}': {}",
           src.getDbPath(), snap.getDbPath(), sstDiffList);
 
@@ -1733,9 +1731,9 @@ public class TestRocksDBCheckpointDiffer {
     // Snapshot is used for logging purpose and short-circuiting traversal.
     // Using gen 0 for this test.
     DifferSnapshotInfo mockedSourceSnapshot = new DifferSnapshotInfo(
-        "/path/to/dbcp1", UUID.randomUUID(), 0L, null, null);
+        "/path/to/dbcp1", UUID.randomUUID(), 0L, columnFamilyToPrefixMap, null);
     DifferSnapshotInfo mockedDestinationSnapshot = new DifferSnapshotInfo(
-        "/path/to/dbcp2", UUID.randomUUID(), 0L, null, null);
+        "/path/to/dbcp2", UUID.randomUUID(), 0L, columnFamilyToPrefixMap, null);
 
     Set<String> actualSameSstFiles = new HashSet<>();
     Set<String> actualDiffSstFiles = new HashSet<>();
@@ -1746,8 +1744,7 @@ public class TestRocksDBCheckpointDiffer {
         srcSnapshotSstFiles,
         destSnapshotSstFiles,
         actualSameSstFiles,
-        actualDiffSstFiles,
-        columnFamilyToPrefixMap);
+        actualDiffSstFiles);
 
     // Check same and different SST files result
     Assertions.assertEquals(expectedSameSstFiles, actualSameSstFiles);

--- a/hadoop-hdds/rocksdb-checkpoint-differ/src/test/java/org/apache/ozone/rocksdiff/TestRocksDiffUtils.java
+++ b/hadoop-hdds/rocksdb-checkpoint-differ/src/test/java/org/apache/ozone/rocksdiff/TestRocksDiffUtils.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ozone.rocksdiff;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Class to test RocksDiffUtils.
+ */
+public class TestRocksDiffUtils {
+  @Test
+  public void testFilterFunction() {
+    assertTrue(RocksDiffUtils.isKeyWithPrefixPresent(
+        "/vol1/bucket1/",
+        "/vol1/bucket1/key1",
+        "/vol1/bucket1/key1"));
+    assertTrue(RocksDiffUtils.isKeyWithPrefixPresent(
+        "/vol1/bucket3/",
+        "/vol1/bucket1/key1",
+        "/vol1/bucket5/key1"));
+    assertFalse(RocksDiffUtils.isKeyWithPrefixPresent(
+        "/vol1/bucket5/",
+        "/vol1/bucket1/key1",
+        "/vol1/bucket4/key9"));
+    assertFalse(RocksDiffUtils.isKeyWithPrefixPresent(
+        "/vol1/bucket2/",
+        "/vol1/bucket1/key1",
+        "/vol1/bucket1/key1"));
+    assertFalse(RocksDiffUtils.isKeyWithPrefixPresent(
+        "/vol1/bucket/",
+        "/vol1/bucket1/key1",
+        "/vol1/bucket1/key1"));
+    assertTrue(RocksDiffUtils.isKeyWithPrefixPresent(
+        "/volume/bucket/",
+        "/volume/bucket/key-1",
+        "/volume/bucket2/key-97"));
+  }
+}

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/freon/TestOMSnapshotDAG.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/freon/TestOMSnapshotDAG.java
@@ -60,6 +60,7 @@ import java.io.IOException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.time.Duration;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -252,7 +253,8 @@ public class TestOMSnapshotDAG {
     final File checkpointSnap2 = new File(snap2.getDbPath());
     GenericTestUtils.waitFor(checkpointSnap2::exists, 2000, 20000);
 
-    List<String> sstDiffList21 = differ.getSSTDiffList(snap2, snap1);
+    List<String> sstDiffList21 = differ.getSSTDiffList(snap2, snap1,
+        Collections.emptyMap());
     LOG.debug("Got diff list: {}", sstDiffList21);
 
     // Delete 1000 keys, take a 3rd snapshot, and do another diff
@@ -273,13 +275,16 @@ public class TestOMSnapshotDAG {
     final File checkpointSnap3 = new File(snap3.getDbPath());
     GenericTestUtils.waitFor(checkpointSnap3::exists, 2000, 20000);
 
-    List<String> sstDiffList32 = differ.getSSTDiffList(snap3, snap2);
+    List<String> sstDiffList32 = differ.getSSTDiffList(snap3, snap2,
+        Collections.emptyMap());
 
     // snap3-snap1 diff result is a combination of snap3-snap2 and snap2-snap1
-    List<String> sstDiffList31 = differ.getSSTDiffList(snap3, snap1);
+    List<String> sstDiffList31 = differ.getSSTDiffList(snap3, snap1,
+        Collections.emptyMap());
 
     // Same snapshot. Result should be empty list
-    List<String> sstDiffList22 = differ.getSSTDiffList(snap2, snap2);
+    List<String> sstDiffList22 = differ.getSSTDiffList(snap2, snap2,
+        Collections.emptyMap());
     Assertions.assertTrue(sstDiffList22.isEmpty());
     snapDB1.close();
     snapDB2.close();
@@ -308,13 +313,16 @@ public class TestOMSnapshotDAG {
         volumeName, bucketName, "snap3",
         ((RDBStore)((OmSnapshot)snapDB3.get())
             .getMetadataManager().getStore()).getDb().getManagedRocksDb());
-    List<String> sstDiffList21Run2 = differ.getSSTDiffList(snap2, snap1);
+    List<String> sstDiffList21Run2 = differ.getSSTDiffList(snap2, snap1,
+        Collections.emptyMap());
     Assertions.assertEquals(sstDiffList21, sstDiffList21Run2);
 
-    List<String> sstDiffList32Run2 = differ.getSSTDiffList(snap3, snap2);
+    List<String> sstDiffList32Run2 = differ.getSSTDiffList(snap3, snap2,
+        Collections.emptyMap());
     Assertions.assertEquals(sstDiffList32, sstDiffList32Run2);
 
-    List<String> sstDiffList31Run2 = differ.getSSTDiffList(snap3, snap1);
+    List<String> sstDiffList31Run2 = differ.getSSTDiffList(snap3, snap1,
+        Collections.emptyMap());
     Assertions.assertEquals(sstDiffList31, sstDiffList31Run2);
     snapDB1.close();
     snapDB2.close();

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmSnapshotManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmSnapshotManager.java
@@ -97,6 +97,7 @@ import static org.apache.hadoop.ozone.om.exceptions.OMException.ResultCodes.INVA
 import static org.apache.hadoop.ozone.om.snapshot.SnapshotDiffManager.getSnapshotRootPath;
 import static org.apache.hadoop.ozone.om.snapshot.SnapshotUtils.checkSnapshotActive;
 import static org.apache.hadoop.ozone.om.snapshot.SnapshotUtils.dropColumnFamilyHandle;
+import static org.apache.hadoop.ozone.om.snapshot.SnapshotUtils.getOzonePathKeyForFso;
 import static org.apache.hadoop.ozone.snapshot.SnapshotDiffResponse.JobStatus.DONE;
 
 /**
@@ -478,8 +479,8 @@ public final class OmSnapshotManager implements AutoCloseable {
       String bucketName) throws IOException {
 
     // Range delete start key (inclusive)
-    final String keyPrefix = getOzonePathKeyWithVolumeBucketNames(
-        omMetadataManager, volumeName, bucketName);
+    final String keyPrefix = getOzonePathKeyForFso(omMetadataManager,
+        volumeName, bucketName);
 
     try (TableIterator<String, ? extends Table.KeyValue<String, OmKeyInfo>>
          iter = omMetadataManager.getDeletedDirTable().iterator(keyPrefix)) {
@@ -492,32 +493,6 @@ public final class OmSnapshotManager implements AutoCloseable {
             return null;
           });
     }
-  }
-
-  /**
-   * Helper method to generate /volumeId/bucketId/ DB key prefix from given
-   * volume name and bucket name as a prefix in FSO deletedDirectoryTable.
-   * Follows:
-   * {@link OmMetadataManagerImpl#getOzonePathKey(long, long, long, String)}.
-   * <p>
-   * Note: Currently, this is only intended to be a special use case in
-   * {@link OmSnapshotManager}. If this is used elsewhere, consider moving this
-   * to {@link OMMetadataManager}.
-   *
-   * @param volumeName volume name
-   * @param bucketName bucket name
-   * @return /volumeId/bucketId/
-   *    e.g. /-9223372036854772480/-9223372036854771968/
-   */
-  @VisibleForTesting
-  public static String getOzonePathKeyWithVolumeBucketNames(
-      OMMetadataManager omMetadataManager,
-      String volumeName,
-      String bucketName) throws IOException {
-
-    final long volumeId = omMetadataManager.getVolumeId(volumeName);
-    final long bucketId = omMetadataManager.getBucketId(volumeName, bucketName);
-    return OM_KEY_PREFIX + volumeId + OM_KEY_PREFIX + bucketId + OM_KEY_PREFIX;
   }
 
   @VisibleForTesting

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/SstFilteringService.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/SstFilteringService.java
@@ -18,15 +18,12 @@
  */
 package org.apache.hadoop.ozone.om;
 
-
 import com.google.common.annotations.VisibleForTesting;
-import org.apache.commons.lang3.tuple.Pair;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.utils.BackgroundService;
 import org.apache.hadoop.hdds.utils.BackgroundTask;
 import org.apache.hadoop.hdds.utils.BackgroundTaskQueue;
 import org.apache.hadoop.hdds.utils.BackgroundTaskResult;
-import org.apache.hadoop.hdds.utils.BooleanTriFunction;
 import org.apache.hadoop.hdds.utils.db.RDBStore;
 import org.apache.hadoop.hdds.utils.db.RocksDatabase;
 import org.apache.hadoop.hdds.utils.db.Table;
@@ -36,23 +33,21 @@ import org.apache.hadoop.ozone.om.exceptions.OMException;
 import org.apache.hadoop.ozone.om.helpers.SnapshotInfo;
 import org.apache.hadoop.ozone.om.snapshot.ReferenceCounted;
 import org.apache.hadoop.ozone.om.snapshot.SnapshotCache;
-import org.apache.ozone.rocksdiff.RocksDiffUtils;
 import org.rocksdb.RocksDBException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 
-import static org.apache.hadoop.ozone.OzoneConsts.OM_KEY_PREFIX;
 import static org.apache.hadoop.ozone.om.OMConfigKeys.SNAPSHOT_SST_DELETING_LIMIT_PER_TASK;
 import static org.apache.hadoop.ozone.om.OMConfigKeys.SNAPSHOT_SST_DELETING_LIMIT_PER_TASK_DEFAULT;
 import static org.apache.hadoop.ozone.om.lock.OzoneManagerLock.Resource.SNAPSHOT_LOCK;
+import static org.apache.hadoop.ozone.om.snapshot.SnapshotUtils.getColumnFamilyToPrefixMap;
 
 /**
  * When snapshots are taken, an entire snapshot of the
@@ -82,18 +77,6 @@ public class SstFilteringService extends BackgroundService
   private AtomicLong snapshotFilteredCount;
 
   private AtomicBoolean running;
-
-  // Note: This filter only works till snapshots are readable only.
-  // In the future, if snapshots are changed to writable as well,
-  // this will need to be revisited.
-  static final BooleanTriFunction<String, String, String, Boolean>
-      FILTER_FUNCTION =
-          (first, last, prefix) -> {
-            String firstBucketKey = RocksDiffUtils.constructBucketKey(first);
-            String lastBucketKey = RocksDiffUtils.constructBucketKey(last);
-            return RocksDiffUtils
-                .isKeyWithPrefixPresent(prefix, firstBucketKey, lastBucketKey);
-          };
 
   public SstFilteringService(long interval, TimeUnit unit, long serviceTimeout,
       OzoneManager ozoneManager, OzoneConfiguration configuration) {
@@ -192,8 +175,10 @@ public class SstFilteringService extends BackgroundService
             LOG.debug("Processing snapshot {} to filter relevant SST Files",
                 snapShotTableKey);
 
-            List<Pair<String, String>> prefixPairs = constructPrefixPairs(
-                snapshotInfo);
+            Map<String, String> columnFamilyNameToPrefixMap =
+                getColumnFamilyToPrefixMap(ozoneManager.getMetadataManager(),
+                    snapshotInfo.getVolumeName(),
+                    snapshotInfo.getBucketName());
 
             try (
                 ReferenceCounted<IOmMetadataReader, SnapshotCache>
@@ -205,7 +190,7 @@ public class SstFilteringService extends BackgroundService
               RocksDatabase db = rdbStore.getDb();
               try (BootstrapStateHandler.Lock lock = getBootstrapStateLock()
                   .lock()) {
-                db.deleteFilesNotMatchingPrefix(prefixPairs, FILTER_FUNCTION);
+                db.deleteFilesNotMatchingPrefix(columnFamilyNameToPrefixMap);
               }
             } catch (OMException ome) {
               // FILE_NOT_FOUND is obtained when the snapshot is deleted
@@ -238,42 +223,7 @@ public class SstFilteringService extends BackgroundService
       // nothing to return here
       return BackgroundTaskResult.EmptyTaskResult.newResult();
     }
-
-    /**
-     * @param snapshotInfo
-     * @return a list of pairs (tableName,keyPrefix).
-     * @throws IOException
-     */
-    private List<Pair<String, String>> constructPrefixPairs(
-        SnapshotInfo snapshotInfo) throws IOException {
-      String volumeName = snapshotInfo.getVolumeName();
-      String bucketName = snapshotInfo.getBucketName();
-
-      long volumeId = ozoneManager.getMetadataManager().getVolumeId(volumeName);
-      // TODO : HDDS-6984  buckets can be deleted via ofs
-      //  handle deletion of bucket case.
-      long bucketId =
-          ozoneManager.getMetadataManager().getBucketId(volumeName, bucketName);
-
-      String filterPrefix =
-          OM_KEY_PREFIX + volumeName + OM_KEY_PREFIX + bucketName
-              + OM_KEY_PREFIX;
-
-      String filterPrefixFSO =
-          OM_KEY_PREFIX + volumeId + OM_KEY_PREFIX + bucketId
-              + OM_KEY_PREFIX;
-
-      List<Pair<String, String>> prefixPairs = new ArrayList<>();
-      prefixPairs
-          .add(Pair.of(OmMetadataManagerImpl.KEY_TABLE, filterPrefix));
-      prefixPairs.add(
-          Pair.of(OmMetadataManagerImpl.DIRECTORY_TABLE, filterPrefixFSO));
-      prefixPairs
-          .add(Pair.of(OmMetadataManagerImpl.FILE_TABLE, filterPrefixFSO));
-      return prefixPairs;
-    }
   }
-
 
   @Override
   public BackgroundTaskQueue getTasks() {

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/SstFilteringService.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/SstFilteringService.java
@@ -47,7 +47,7 @@ import java.util.concurrent.atomic.AtomicLong;
 import static org.apache.hadoop.ozone.om.OMConfigKeys.SNAPSHOT_SST_DELETING_LIMIT_PER_TASK;
 import static org.apache.hadoop.ozone.om.OMConfigKeys.SNAPSHOT_SST_DELETING_LIMIT_PER_TASK_DEFAULT;
 import static org.apache.hadoop.ozone.om.lock.OzoneManagerLock.Resource.SNAPSHOT_LOCK;
-import static org.apache.hadoop.ozone.om.snapshot.SnapshotUtils.getColumnFamilyToPrefixMap;
+import static org.apache.hadoop.ozone.om.snapshot.SnapshotUtils.getColumnFamilyToKeyPrefixMap;
 
 /**
  * When snapshots are taken, an entire snapshot of the
@@ -176,7 +176,7 @@ public class SstFilteringService extends BackgroundService
                 snapShotTableKey);
 
             Map<String, String> columnFamilyNameToPrefixMap =
-                getColumnFamilyToPrefixMap(ozoneManager.getMetadataManager(),
+                getColumnFamilyToKeyPrefixMap(ozoneManager.getMetadataManager(),
                     snapshotInfo.getVolumeName(),
                     snapshotInfo.getBucketName());
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/snapshot/SnapshotDiffManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/snapshot/SnapshotDiffManager.java
@@ -121,6 +121,7 @@ import static org.apache.hadoop.ozone.om.OmSnapshotManager.DELIMITER;
 import static org.apache.hadoop.ozone.om.helpers.SnapshotInfo.getTableKey;
 import static org.apache.hadoop.ozone.om.snapshot.SnapshotUtils.checkSnapshotActive;
 import static org.apache.hadoop.ozone.om.snapshot.SnapshotUtils.dropColumnFamilyHandle;
+import static org.apache.hadoop.ozone.om.snapshot.SnapshotUtils.getColumnFamilyToPrefixMap;
 import static org.apache.hadoop.ozone.om.snapshot.SnapshotUtils.getSnapshotInfo;
 import static org.apache.hadoop.ozone.snapshot.CancelSnapshotDiffResponse.CancelMessage.CANCEL_FAILED;
 import static org.apache.hadoop.ozone.snapshot.CancelSnapshotDiffResponse.CancelMessage.CANCEL_ALREADY_CANCELLED_JOB;
@@ -1215,8 +1216,11 @@ public class SnapshotDiffManager implements AutoCloseable {
 
       LOG.debug("Calling RocksDBCheckpointDiffer");
       try {
-        List<String> sstDiffList =
-            differ.getSSTDiffListWithFullPath(toDSI, fromDSI, diffDir);
+        Map<String, String> columnFamilyToPrefixMap =
+            getColumnFamilyToPrefixMap(ozoneManager.getMetadataManager(),
+                volume, bucket);
+        List<String> sstDiffList = differ.getSSTDiffListWithFullPath(toDSI,
+            fromDSI, diffDir, columnFamilyToPrefixMap);
         deltaFiles.addAll(sstDiffList);
       } catch (Exception exception) {
         LOG.warn("Failed to get SST diff file using RocksDBCheckpointDiffer. " +

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/snapshot/SnapshotDiffManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/snapshot/SnapshotDiffManager.java
@@ -79,7 +79,6 @@ import java.nio.file.StandardOpenOption;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -115,13 +114,11 @@ import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_SNAPSHOT_FORCE_FU
 import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_SNAPSHOT_DIFF_DISABLE_NATIVE_LIBS;
 import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_SNAPSHOT_DIFF_DISABLE_NATIVE_LIBS_DEFAULT;
 import static org.apache.hadoop.ozone.om.OmMetadataManagerImpl.DIRECTORY_TABLE;
-import static org.apache.hadoop.ozone.om.OmMetadataManagerImpl.FILE_TABLE;
-import static org.apache.hadoop.ozone.om.OmMetadataManagerImpl.KEY_TABLE;
 import static org.apache.hadoop.ozone.om.OmSnapshotManager.DELIMITER;
 import static org.apache.hadoop.ozone.om.helpers.SnapshotInfo.getTableKey;
 import static org.apache.hadoop.ozone.om.snapshot.SnapshotUtils.checkSnapshotActive;
 import static org.apache.hadoop.ozone.om.snapshot.SnapshotUtils.dropColumnFamilyHandle;
-import static org.apache.hadoop.ozone.om.snapshot.SnapshotUtils.getColumnFamilyToPrefixMap;
+import static org.apache.hadoop.ozone.om.snapshot.SnapshotUtils.getColumnFamilyToKeyPrefixMap;
 import static org.apache.hadoop.ozone.om.snapshot.SnapshotUtils.getSnapshotInfo;
 import static org.apache.hadoop.ozone.snapshot.CancelSnapshotDiffResponse.CancelMessage.CANCEL_FAILED;
 import static org.apache.hadoop.ozone.snapshot.CancelSnapshotDiffResponse.CancelMessage.CANCEL_ALREADY_CANCELLED_JOB;
@@ -368,24 +365,6 @@ public class SnapshotDiffManager implements AutoCloseable {
     }
   }
 
-  private Map<String, String> getTablePrefixes(
-      OMMetadataManager omMetadataManager,
-      String volumeName, String bucketName) throws IOException {
-    // Copied straight from TestOMSnapshotDAG. TODO: Dedup. Move this to util.
-    Map<String, String> tablePrefixes = new HashMap<>();
-    String volumeId = String.valueOf(omMetadataManager.getVolumeId(volumeName));
-    String bucketId = String.valueOf(
-        omMetadataManager.getBucketId(volumeName, bucketName));
-    tablePrefixes.put(KEY_TABLE,
-        OM_KEY_PREFIX + volumeName + OM_KEY_PREFIX + bucketName +
-            OM_KEY_PREFIX);
-    tablePrefixes.put(FILE_TABLE,
-        OM_KEY_PREFIX + volumeId + OM_KEY_PREFIX + bucketId + OM_KEY_PREFIX);
-    tablePrefixes.put(DIRECTORY_TABLE,
-        OM_KEY_PREFIX + volumeId + OM_KEY_PREFIX + bucketId + OM_KEY_PREFIX);
-    return tablePrefixes;
-  }
-
   /**
    * Convert from SnapshotInfo to DifferSnapshotInfo.
    */
@@ -403,7 +382,7 @@ public class SnapshotDiffManager implements AutoCloseable {
         checkpointPath,
         snapshotId,
         dbTxSequenceNumber,
-        getTablePrefixes(snapshotOMMM, volumeName, bucketName),
+        getColumnFamilyToKeyPrefixMap(snapshotOMMM, volumeName, bucketName),
         ((RDBStore)snapshotOMMM.getStore()).getDb().getManagedRocksDb());
   }
 
@@ -905,8 +884,8 @@ public class SnapshotDiffManager implements AutoCloseable {
       final BucketLayout bucketLayout = getBucketLayout(volumeName, bucketName,
           fromSnapshot.getMetadataManager());
       Map<String, String> tablePrefixes =
-          getTablePrefixes(toSnapshot.getMetadataManager(), volumeName,
-              bucketName);
+          getColumnFamilyToKeyPrefixMap(toSnapshot.getMetadataManager(),
+              volumeName, bucketName);
 
       boolean useFullDiff = snapshotForceFullDiff || forceFullDiff;
       boolean performNonNativeDiff = diffDisableNativeLibs || disableNativeDiff;
@@ -1216,11 +1195,8 @@ public class SnapshotDiffManager implements AutoCloseable {
 
       LOG.debug("Calling RocksDBCheckpointDiffer");
       try {
-        Map<String, String> columnFamilyToPrefixMap =
-            getColumnFamilyToPrefixMap(ozoneManager.getMetadataManager(),
-                volume, bucket);
         List<String> sstDiffList = differ.getSSTDiffListWithFullPath(toDSI,
-            fromDSI, diffDir, columnFamilyToPrefixMap);
+            fromDSI, diffDir);
         deltaFiles.addAll(sstDiffList);
       } catch (Exception exception) {
         LOG.warn("Failed to get SST diff file using RocksDBCheckpointDiffer. " +

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/snapshot/SnapshotUtils.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/snapshot/SnapshotUtils.java
@@ -201,7 +201,8 @@ public final class SnapshotUtils {
    */
   public static String getOzonePathKey(String volumeName,
                                        String bucketName) throws IOException {
-    return OM_KEY_PREFIX + volumeName + bucketName;
+    return OM_KEY_PREFIX + volumeName + OM_KEY_PREFIX + bucketName +
+        OM_KEY_PREFIX;
   }
 
   /**

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/snapshot/SnapshotUtils.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/snapshot/SnapshotUtils.java
@@ -182,10 +182,10 @@ public final class SnapshotUtils {
     String keyPrefixFso = OM_KEY_PREFIX + volumeId + OM_KEY_PREFIX +
         bucketId + OM_KEY_PREFIX;
 
-    Map<String, String> comlumnFamilyToPrefixMap = new HashMap<>();
-    comlumnFamilyToPrefixMap.put(KEY_TABLE, keyPrefix);
-    comlumnFamilyToPrefixMap.put(DIRECTORY_TABLE, keyPrefixFso);
-    comlumnFamilyToPrefixMap.put(FILE_TABLE, keyPrefixFso);
-    return comlumnFamilyToPrefixMap;
+    Map<String, String> columnFamilyToPrefixMap = new HashMap<>();
+    columnFamilyToPrefixMap.put(KEY_TABLE, keyPrefix);
+    columnFamilyToPrefixMap.put(DIRECTORY_TABLE, keyPrefixFso);
+    columnFamilyToPrefixMap.put(FILE_TABLE, keyPrefixFso);
+    return columnFamilyToPrefixMap;
   }
 }

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestSstFilteringService.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestSstFilteringService.java
@@ -372,30 +372,6 @@ public class TestSstFilteringService {
     managerProtocol.commitKey(keyArg, session.getId());
   }
 
-  @Test
-  public void testFilterFunction() {
-    assertTrue(SstFilteringService.FILTER_FUNCTION.apply(
-        "/vol1/bucket1/key1",
-        "/vol1/bucket1/key1",
-        "/vol1/bucket1/"));
-    assertTrue(SstFilteringService.FILTER_FUNCTION.apply(
-        "/vol1/bucket1/key1",
-        "/vol1/bucket5/key1",
-        "/vol1/bucket3/"));
-    assertFalse(SstFilteringService.FILTER_FUNCTION.apply(
-        "/vol1/bucket1/key1",
-        "/vol1/bucket4/key9",
-        "/vol1/bucket5/"));
-    assertFalse(SstFilteringService.FILTER_FUNCTION.apply(
-        "/vol1/bucket1/key1",
-        "/vol1/bucket1/key1",
-        "/vol1/bucket2/"));
-    assertFalse(SstFilteringService.FILTER_FUNCTION.apply(
-        "/vol1/bucket1/key1",
-        "/vol1/bucket1/key1",
-        "/vol1/bucket/"));
-  }
-
   /**
    * Test to verify the data integrity after SST filtering service runs.
    * This test creates 150 keys randomly in one of the three buckets. It also

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/snapshot/TestOMSnapshotCreateResponse.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/snapshot/TestOMSnapshotCreateResponse.java
@@ -29,10 +29,10 @@ import java.util.UUID;
 import org.apache.hadoop.hdds.client.StandaloneReplicationConfig;
 import org.apache.hadoop.hdds.utils.db.Table;
 import org.apache.hadoop.hdds.utils.db.TableIterator;
-import org.apache.hadoop.ozone.om.OmSnapshotManager;
 import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
 import org.apache.hadoop.ozone.om.helpers.RepeatedOmKeyInfo;
 import org.apache.hadoop.ozone.om.helpers.SnapshotInfo;
+import org.apache.hadoop.ozone.om.snapshot.SnapshotUtils;
 import org.apache.hadoop.util.Time;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
@@ -214,8 +214,7 @@ public class TestOMSnapshotCreateResponse {
     // Add deletedDirectoryTable key entries that "surround" the snapshot scope
     Set<String> sentinelKeys = new HashSet<>();
 
-    final String dbKeyPfx =
-        OmSnapshotManager.getOzonePathKeyWithVolumeBucketNames(
+    final String dbKeyPfx = SnapshotUtils.getOzonePathKeyForFso(
             omMetadataManager, volumeName, bucketName);
 
     // Calculate offset to bucketId's last character in dbKeyPfx.

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/snapshot/TestSnapshotDiffManager.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/snapshot/TestSnapshotDiffManager.java
@@ -436,8 +436,7 @@ public class TestSnapshotDiffManager {
     when(differ.getSSTDiffListWithFullPath(
         any(DifferSnapshotInfo.class),
         any(DifferSnapshotInfo.class),
-        eq(diffDir),
-        anyMap())
+        eq(diffDir))
     ).thenReturn(Lists.newArrayList(randomStrings));
 
     ReferenceCounted<IOmMetadataReader, SnapshotCache> rcFromSnapshot =
@@ -502,8 +501,7 @@ public class TestSnapshotDiffManager {
         when(differ.getSSTDiffListWithFullPath(
             any(DifferSnapshotInfo.class),
             any(DifferSnapshotInfo.class),
-            anyString(),
-            anyMap()))
+            anyString()))
             .thenReturn(Collections.emptyList());
       }
 
@@ -570,8 +568,7 @@ public class TestSnapshotDiffManager {
           .getSSTDiffListWithFullPath(
               any(DifferSnapshotInfo.class),
               any(DifferSnapshotInfo.class),
-              anyString(),
-              anyMap());
+              anyString());
 
       ReferenceCounted<IOmMetadataReader, SnapshotCache> rcFromSnapshot =
           snapshotCache.get(snap1.toString());

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/snapshot/TestSnapshotDiffManager.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/snapshot/TestSnapshotDiffManager.java
@@ -436,7 +436,8 @@ public class TestSnapshotDiffManager {
     when(differ.getSSTDiffListWithFullPath(
         any(DifferSnapshotInfo.class),
         any(DifferSnapshotInfo.class),
-        eq(diffDir))
+        eq(diffDir),
+        anyMap())
     ).thenReturn(Lists.newArrayList(randomStrings));
 
     ReferenceCounted<IOmMetadataReader, SnapshotCache> rcFromSnapshot =
@@ -501,7 +502,8 @@ public class TestSnapshotDiffManager {
         when(differ.getSSTDiffListWithFullPath(
             any(DifferSnapshotInfo.class),
             any(DifferSnapshotInfo.class),
-            anyString()))
+            anyString(),
+            anyMap()))
             .thenReturn(Collections.emptyList());
       }
 
@@ -568,7 +570,8 @@ public class TestSnapshotDiffManager {
           .getSSTDiffListWithFullPath(
               any(DifferSnapshotInfo.class),
               any(DifferSnapshotInfo.class),
-              anyString());
+              anyString(),
+              anyMap());
 
       ReferenceCounted<IOmMetadataReader, SnapshotCache> rcFromSnapshot =
           snapshotCache.get(snap1.toString());


### PR DESCRIPTION
## What changes were proposed in this pull request?
**Problem**:
The problem is that [SSTFilteringService](https://github.com/apache/ozone/blob/master/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/SstFilteringService.java) and [SST pruning service](https://github.com/apache/ozone/blob/master/hadoop-hdds/rocksdb-checkpoint-differ/src/main/java/org/apache/ozone/rocksdiff/RocksDBCheckpointDiffer.java#L1483) work independently and try to optimize the space by deleting unnecessary SST files. SSTFilteringService deletes some files which don't belongs to the snapshotted bucket and SST prune service deletes the file which are not required for diff calculations. On the other hand compaction DAG is global at Ozone level and is kind a not aware of the above two clean ups. Problem arises when calculating the delta files for two snapshots and traversal reaches to this [condition](https://github.com/apache/ozone/blob/c801c02455982d3488cb099942f86912a492dc89/hadoop-hdds/rocksdb-checkpoint-differ/src/main/java/org/apache/ozone/rocksdiff/RocksDBCheckpointDiffer.java#L1049). Graph traversal adds a node because it is not present in the toSnapshot (because it might be deleted by SSTFilteringService) and later gets added to diff file because of this [condition](https://github.com/apache/ozone/blob/c801c02455982d3488cb099942f86912a492dc89/hadoop-hdds/rocksdb-checkpoint-differ/src/main/java/org/apache/ozone/rocksdiff/RocksDBCheckpointDiffer.java#L1024).
Before [returning delta files to SnapshotDiffManager](https://github.com/apache/ozone/blob/c801c02455982d3488cb099942f86912a492dc89/hadoop-hdds/rocksdb-checkpoint-differ/src/main/java/org/apache/ozone/rocksdiff/RocksDBCheckpointDiffer.java#L877), we look for the files in either [active DB dir and SST backup dir](https://github.com/apache/ozone/blob/c801c02455982d3488cb099942f86912a492dc89/hadoop-hdds/rocksdb-checkpoint-differ/src/main/java/org/apache/ozone/rocksdiff/RocksDBCheckpointDiffer.java#L832). Active DB dir doesn't have these files because they were compacted and SST backup dir doesn't have because of SST pruning service.

Detailed [explanation](https://issues.apache.org/jira/browse/HDDS-8940?focusedCommentId=17755663&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-17755663) and [example](https://issues.apache.org/jira/browse/HDDS-8940?focusedCommentId=17755668&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-17755668).

**Fix**:
In this PR, it is proposed to keep key range in the DAG node and use that to early return while traversing.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-8940

## How was this patch tested?
* Existing unit tests.
* New tests are in progress.
