### PR TITLE
HDDS-9508. Rebalance acceptance tests

### DIFF
--- a/hadoop-ozone/dist/src/main/compose/ozonesecure-ha/test-leadership.sh
+++ b/hadoop-ozone/dist/src/main/compose/ozonesecure-ha/test-leadership.sh
@@ -15,7 +15,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-#suite:misc
+#suite:leadership
 
 COMPOSE_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 export COMPOSE_DIR
@@ -23,12 +23,20 @@ export COMPOSE_DIR
 export SECURITY_ENABLED=true
 export OM_SERVICE_ID="omservice"
 export SCM=scm1.org
-export COMPOSE_FILE=docker-compose.yaml:s3g-virtual-host.yaml
 
 # shellcheck source=/dev/null
 source "$COMPOSE_DIR/../testlib.sh"
 
 start_docker_env
 
-## Run virtual host test cases
-execute_robot_test s3g -N s3-virtual-host s3/awss3virtualhost.robot
+execute_robot_test s3g kinit.robot
+
+execute_robot_test s3g admincli
+
+execute_robot_test s3g omha/om-fetch-key.robot
+
+execute_robot_test s3g omha/om-roles.robot
+
+execute_robot_test s3g omha/om-leader-transfer.robot
+
+execute_robot_test s3g scmha/scm-leader-transfer.robot

--- a/hadoop-ozone/dist/src/main/compose/ozonesecure-ha/test-scm-decommission.sh
+++ b/hadoop-ozone/dist/src/main/compose/ozonesecure-ha/test-scm-decommission.sh
@@ -15,7 +15,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-#suite:HA-secure
+#suite:leadership
 
 COMPOSE_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 export COMPOSE_DIR

--- a/hadoop-ozone/dist/src/main/compose/ozonesecure-ha/test.sh
+++ b/hadoop-ozone/dist/src/main/compose/ozonesecure-ha/test.sh
@@ -49,18 +49,3 @@ for bucket in encrypted link; do
   ## Exclude virtual-host.robot
   exclude="--exclude virtual-host --exclude no-bucket-type"
 done
-
-execute_robot_test s3g admincli
-
-execute_robot_test s3g omha/om-fetch-key.robot
-
-execute_robot_test s3g omha/om-roles.robot
-
-execute_robot_test s3g omha/om-leader-transfer.robot
-
-execute_robot_test s3g scmha/scm-leader-transfer.robot
-
-execute_robot_test s3g httpfs
-
-export SCM=scm2.org
-execute_robot_test s3g admincli

--- a/hadoop-ozone/dist/src/main/compose/ozonesecure/test-vault.sh
+++ b/hadoop-ozone/dist/src/main/compose/ozonesecure/test-vault.sh
@@ -15,7 +15,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-#suite:secure
+#suite:misc
 
 COMPOSE_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 export COMPOSE_DIR


### PR DESCRIPTION
## What changes were proposed in this pull request?

_acceptance (HA-secure)_ and _acceptance (secure)_ take quite a bit longer than all other checks.  This PR proposes to rebalance the tests in order to reduce wall-clock time for the complete CI run.

1. Create a new acceptance test split (`leadership`) to cover admin CLI, SCM/OM leader transfer, decomissioning.
2. Move some tests to `misc` split
3. Drop second run of `admincli` (with SCM=scm2.org) -- it affects only very few test cases since we have moved execution from `${SCM}` to `s3g`
4. Drop execution of `httpfs` tests in secure HA environment

https://issues.apache.org/jira/browse/HDDS-9508

## How was this patch tested?

CI:
https://github.com/adoroszlai/hadoop-ozone/actions/runs/6576844317

Total CI duration is now closer to 1.5 hours, and all acceptance check splits are within 1 hour.