### PR TITLE
HDDS-9384. Update OpenTelemetry traces in the write path

### DIFF
--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/XceiverClientRatis.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/XceiverClientRatis.java
@@ -262,27 +262,20 @@ public final class XceiverClientRatis extends XceiverClientSpi {
       }
     }
     String fullSpanID = TracingUtil.exportCurrentSpan();
-    return TracingUtil.executeInNewSpan(
-        "XceiverClientRatis." + request.getCmdType().name() + "-async",
-        () -> {
-          final ContainerCommandRequestMessage message
-              = ContainerCommandRequestMessage.toMessage(
-              request, fullSpanID);
-          if (HddsUtils.isReadOnly(request)) {
-            if (LOG.isDebugEnabled()) {
-              LOG.debug("sendCommandAsync ReadOnly {}", message);
-            }
-            return getClient().async().sendReadOnly(message);
-          } else {
-            if (LOG.isDebugEnabled()) {
-              LOG.debug("sendCommandAsync {}", message);
-            }
-            return getClient().async().send(message);
-          }
-
+      final ContainerCommandRequestMessage message
+          = ContainerCommandRequestMessage.toMessage(
+          request, fullSpanID);
+      if (HddsUtils.isReadOnly(request)) {
+        if (LOG.isDebugEnabled()) {
+          LOG.debug("sendCommandAsync ReadOnly {}", message);
         }
-
-    );
+        return getClient().async().sendReadOnly(message);
+      } else {
+        if (LOG.isDebugEnabled()) {
+          LOG.debug("sendCommandAsync {}", message);
+        }
+        return getClient().async().send(message);
+      }
   }
 
   // gets the minimum log index replicated to all servers
@@ -376,7 +369,7 @@ public final class XceiverClientRatis extends XceiverClientSpi {
     long requestTime = System.currentTimeMillis();
 
     Span span = GlobalTracer.get()
-        .buildSpan("XceiverClientReply." + request.getCmdType()).start();
+        .buildSpan("XceiverClientRatis.sendCommandAsync(" + request.getCmdType() +")").start();
 
     CompletableFuture<RaftClientReply> raftClientReply =
         sendRequestAsync(request);

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/impl/BlockManagerImpl.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/impl/BlockManagerImpl.java
@@ -26,6 +26,7 @@ import org.apache.hadoop.hdds.client.BlockID;
 import org.apache.hadoop.hdds.conf.ConfigurationSource;
 import org.apache.hadoop.hdds.scm.ScmConfigKeys;
 import org.apache.hadoop.hdds.scm.container.common.helpers.StorageContainerException;
+import org.apache.hadoop.hdds.tracing.TracingUtil;
 import org.apache.hadoop.hdds.upgrade.HDDSLayoutFeature;
 import org.apache.hadoop.hdds.utils.db.BatchOperation;
 import org.apache.hadoop.hdds.utils.db.Table;
@@ -89,9 +90,11 @@ public class BlockManagerImpl implements BlockManager {
   @Override
   public long putBlock(Container container, BlockData data,
       boolean endOfBlock) throws IOException {
-    return persistPutBlock(
-        (KeyValueContainer) container,
-        data, endOfBlock);
+    return TracingUtil.executeInNewSpan("BlockManagerImpl.putBlock",
+        () -> persistPutBlock(
+            (KeyValueContainer) container,
+            data,
+            endOfBlock));
   }
 
   public long persistPutBlock(KeyValueContainer container,

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/impl/FilePerBlockStrategy.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/impl/FilePerBlockStrategy.java
@@ -27,6 +27,7 @@ import org.apache.hadoop.fs.FileUtil;
 import org.apache.hadoop.hdds.client.BlockID;
 import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos;
 import org.apache.hadoop.hdds.scm.container.common.helpers.StorageContainerException;
+import org.apache.hadoop.hdds.tracing.TracingUtil;
 import org.apache.hadoop.ozone.common.ChunkBuffer;
 import org.apache.hadoop.ozone.container.common.helpers.BlockData;
 import org.apache.hadoop.ozone.container.common.helpers.ChunkInfo;
@@ -114,6 +115,13 @@ public class FilePerBlockStrategy implements ChunkManager {
   public void writeChunk(Container container, BlockID blockID, ChunkInfo info,
       ChunkBuffer data, DispatcherContext dispatcherContext)
       throws StorageContainerException {
+    TracingUtil.executeInNewSpan("FilePerBlockStrategy.writeChunk",
+        () -> writeChunkInSpan(container, blockID, info, data, dispatcherContext));
+  }
+
+  private void writeChunkInSpan(Container container, BlockID blockID, ChunkInfo info,
+      ChunkBuffer data, DispatcherContext dispatcherContext)
+      throws StorageContainerException {
 
     checkLayoutVersion(container);
 
@@ -171,6 +179,13 @@ public class FilePerBlockStrategy implements ChunkManager {
 
   @Override
   public ChunkBuffer readChunk(Container container, BlockID blockID,
+      ChunkInfo info, DispatcherContext dispatcherContext)
+      throws StorageContainerException {
+    return TracingUtil.executeInNewSpan("FilePerBlockStrategy.readChunk",
+        () -> readChunkInSpan(container, blockID, info, dispatcherContext));
+  }
+
+  private ChunkBuffer readChunkInSpan(Container container, BlockID blockID,
       ChunkInfo info, DispatcherContext dispatcherContext)
       throws StorageContainerException {
 

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/server/OzoneProtocolMessageDispatcher.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/server/OzoneProtocolMessageDispatcher.java
@@ -17,6 +17,8 @@
  */
 package org.apache.hadoop.hdds.server;
 
+import io.opentracing.Scope;
+import io.opentracing.util.GlobalTracer;
 import org.apache.hadoop.hdds.tracing.TracingUtil;
 import org.apache.hadoop.hdds.utils.ProtocolMessageMetrics;
 
@@ -71,7 +73,7 @@ public class OzoneProtocolMessageDispatcher<REQUEST, RESPONSE, TYPE> {
       TYPE type,
       String traceId) throws ServiceException {
     Span span = TracingUtil.importAndCreateSpan(type.toString(), traceId);
-    try {
+    try (Scope scope = GlobalTracer.get().activateSpan(span)) {
       if (logger.isTraceEnabled()) {
         logger.trace(
             "[service={}] [type={}] request is received: <json>{}</json>",

--- a/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/OzoneFSOutputStream.java
+++ b/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/OzoneFSOutputStream.java
@@ -67,7 +67,8 @@ public class OzoneFSOutputStream extends OutputStream
 
   @Override
   public synchronized void close() throws IOException {
-    outputStream.close();
+    TracingUtil.executeInNewSpan("OzoneFSOutputStream.close",
+        outputStream::close);
   }
 
   @Override


### PR DESCRIPTION
## What changes were proposed in this pull request?
HDDS-9384. [hsync] Update OpenTelemetry traces in the write path

Please describe your PR in detail:

Traces for
   * Ratis callback function (ContainerStateMachine)
   * DataNode PutBlock/WriteChunk
   * Client BlockOutputStream WriteChunk

## What is the link to the Apache JIRA

[HDDS-9384](https://issues.apache.org/jira/browse/HDDS-9384)

## How was this patch tested?

Manual test. Screenshots