### PR TITLE
HDDS-9511. Handle DataNode decommissioning error for hoststring and port.

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/NodeDecommissionManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/NodeDecommissionManager.java
@@ -190,6 +190,7 @@ public class NodeDecommissionManager {
                 + " has multiple datanodes registered with SCM."
                 + " All have identical ports, but none have a newest"
                 + " heartbeat.";
+            LOG.warn(msg);
             errors.add(new DatanodeAdminError(host.getRawHostname(), msg));
             continue;
           }
@@ -201,6 +202,7 @@ public class NodeDecommissionManager {
               + " is running multiple datanodes registered with SCM,"
               + " but no port numbers match."
               + " Please check the port number.";
+          LOG.warn(msg);
           errors.add(new DatanodeAdminError(host.getRawHostname(), msg));
         }
       }


### PR DESCRIPTION
## What changes were proposed in this pull request?

When decommission command is executed and if port or hostname is wrong and doesn't present in SCM, in that case command retries for 300 times which is unnecessary. 
In this PR we are fixing below:
If hoststring or port is wrong, instead of throwing exception we are returning DataNodeAdmin error which will avoid retry and will be normal exit.
If there are multiple hosts passed in the command, hosts which are invalid we add into error list and continue decommissioning for the proper host.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-9511

## How was this patch tested?

Update existing tests and verify
