### PR TITLE
HDDS-9515. Capture build scans on ge.apache.org to benefit from deep build insights

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,6 +106,8 @@ jobs:
           java-version: ${{ matrix.java }}
       - name: Run a full build
         run: hadoop-ozone/dev-support/checks/build.sh -Pdist -Psrc
+        env:
+          GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GE_ACCESS_TOKEN }}
       - name: Store binaries for tests
         uses: actions/upload-artifact@v3
         with:
@@ -169,6 +171,7 @@ jobs:
         run: hadoop-ozone/dev-support/checks/build.sh -Dskip.npx -Dskip.installnpx -Djavac.version=${{ matrix.java }}
         env:
           OZONE_WITH_COVERAGE: false
+          GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GE_ACCESS_TOKEN }}
       - name: Delete temporary build artifacts before caching
         run: |
           #Never cache local artifacts
@@ -212,6 +215,8 @@ jobs:
       - name: Execute tests
         run: hadoop-ozone/dev-support/checks/${{ matrix.check }}.sh
         continue-on-error: true
+        env:
+          GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GE_ACCESS_TOKEN }}
       - name: Summary of failures
         run: hadoop-ozone/dev-support/checks/_summary.sh target/${{ matrix.check }}/summary.txt
         if: ${{ !cancelled() }}
@@ -259,6 +264,8 @@ jobs:
       - name: Execute tests
         run: hadoop-ozone/dev-support/checks/${{ matrix.check }}.sh
         continue-on-error: true
+        env:
+          GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GE_ACCESS_TOKEN }}
       - name: Summary of failures
         run: hadoop-ozone/dev-support/checks/_summary.sh target/${{ matrix.check }}/summary.txt
         if: ${{ !cancelled() }}
@@ -445,7 +452,8 @@ jobs:
           fi
 
           hadoop-ozone/dev-support/checks/integration.sh -P${{ matrix.profile }} ${args}
-
+        env:
+          GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GE_ACCESS_TOKEN }}
       - name: Summary of failures
         run: hadoop-ozone/dev-support/checks/_summary.sh target/${{ github.job }}/summary.txt
         if: ${{ !cancelled() }}
@@ -502,6 +510,7 @@ jobs:
         env:
           SONAR_TOKEN: ${{ secrets.SONARCLOUD_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GE_ACCESS_TOKEN }}
       - name: Archive build results
         uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/intermittent-test-check.yml
+++ b/.github/workflows/intermittent-test-check.yml
@@ -135,6 +135,7 @@ jobs:
         continue-on-error: true
         env:
           CHECK: ${{ needs.prepare-job.outputs.test_type }}
+          GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GE_ACCESS_TOKEN }}
       - name: Summary of failures
         run: hadoop-ozone/dev-support/checks/_summary.sh target/${{ needs.prepare-job.outputs.test_type }}/summary.txt
         if: always()

--- a/.gitignore
+++ b/.gitignore
@@ -65,10 +65,10 @@ hadoop-hdds/docs/public
 hadoop-hdds/docs/.hugo_build.lock
 hadoop-ozone/recon/node_modules
 
-.mvn
-
 .dev-tools
 dev-support/ci/bats-assert
 dev-support/ci/bats-support
 
 hadoop-ozone/dist/src/main/license/current.txt
+
+.mvn/.gradle-enterprise/

--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<extensions xmlns="http://maven.apache.org/EXTENSIONS/1.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+            xsi:schemaLocation="http://maven.apache.org/EXTENSIONS/1.0.0 http://maven.apache.org/xsd/core-extensions-1.0.0.xsd">
+  <extension>
+    <groupId>com.gradle</groupId>
+    <artifactId>gradle-enterprise-maven-extension</artifactId>
+    <version>1.19.2</version>
+  </extension>
+  <extension>
+    <groupId>com.gradle</groupId>
+    <artifactId>common-custom-user-data-maven-extension</artifactId>
+    <version>1.12.4</version>
+  </extension>
+</extensions>

--- a/.mvn/gradle-enterprise.xml
+++ b/.mvn/gradle-enterprise.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes" ?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<gradleEnterprise
+        xmlns="https://www.gradle.com/gradle-enterprise-maven" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="https://www.gradle.com/gradle-enterprise-maven https://www.gradle.com/schema/gradle-enterprise-maven.xsd">
+  <server>
+    <url>https://ge.apache.org</url>
+    <allowUntrusted>false</allowUntrusted>
+  </server>
+  <buildScan>
+    <capture>
+      <goalInputFiles>true</goalInputFiles>
+      <buildLogging>true</buildLogging>
+      <testLogging>true</testLogging>
+    </capture>
+    <backgroundBuildScanUpload>#{isFalse(env['GITHUB_ACTIONS'])}</backgroundBuildScanUpload>
+    <publish>ALWAYS</publish>
+    <publishIfAuthenticated>true</publishIfAuthenticated>
+    <obfuscation>
+      <ipAddresses>#{{'0.0.0.0'}}</ipAddresses>
+    </obfuscation>
+  </buildScan>
+  <buildCache>
+    <local>
+      <enabled>#{isFalse(env['GITHUB_ACTIONS'])}</enabled>
+    </local>
+    <remote>
+      <enabled>false</enabled>
+    </remote>
+  </buildCache>
+</gradleEnterprise>


### PR DESCRIPTION
## What changes were proposed in this pull request?

It was nice meeting some of you at the Gradle booth last week at Community over Code. We discussed Develocity with some of you, and this would be the PR that enables it.

This PR publishes a build scan for every CI build and for every local build from an authenticated Apache committer. The build will not fail if publishing fails.

The build scans of the Apache Ozone project are published to the Develocity instance at [ge.apache.org](https://ge.apache.org/), hosted by the Apache Software Foundation and run in partnership between the ASF and Gradle. This Develocity instance has all features and extensions enabled and is freely available for use by the Apache Ozone project and all other Apache projects.

On this Develocity instance, Apache Ozone will have access not only to all of the published build scans but other aggregate data features such as:

* Dashboards to view all historical build scans, along with performance trends over time
* Build failure analytics for enhanced investigation and diagnosis of build failures
* Test failure analytics to better understand trends and causes around slow, failing, and flaky tests
Please let me know if there are any questions about the value of Develocity or the changes in this pull request and I’d be happy to address them.

## What is the link to the Apache JIRA

[HDDS-9515](https://issues.apache.org/jira/browse/HDDS-9515)

## How was this patch tested?

This PR was tested by running the `build-branch` workflow from my fork and publishing build scans to a [different Develocity instance](https://ge.solutions-team.gradle.com/scans?search.rootProjectNames=*ozone*&search.timeZoneId=America%2FChicago). When merged, this PR will correctly publish build scans to https://ge.apache.org.