### PR TITLE
HDDS-9509. Count total number of failures in flaky-test-check

### DIFF
--- a/.github/workflows/intermittent-test-check.yml
+++ b/.github/workflows/intermittent-test-check.yml
@@ -137,7 +137,8 @@ jobs:
           CHECK: ${{ needs.prepare-job.outputs.test_type }}
       - name: Summary of failures
         run: hadoop-ozone/dev-support/checks/_summary.sh target/${{ needs.prepare-job.outputs.test_type }}/summary.txt
-        if: always()
+        if: ${{ !cancelled() }}
+        continue-on-error: true
       - name: Archive build results
         uses: actions/upload-artifact@v3
         if: always()
@@ -150,3 +151,20 @@ jobs:
           rm -rf ~/.m2/repository/org/apache/ozone/hdds*
           rm -rf ~/.m2/repository/org/apache/ozone/ozone*
         if: always()
+  count-failures:
+    needs: run-test
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Download build results
+        uses: actions/download-artifact@v3
+      - name: Count failures
+        run: |
+          failures=$(find . -name 'summary.txt' | grep -v 'iteration' | xargs grep -v 'exit code: 0' | wc -l)
+          echo "Total failures: $failures"
+          if [[ $failures -gt 0 ]]; then
+            echo ""
+            echo "Failed runs:"
+            grep 'exit code: 1' */summary.txt | grep -o 'split.*teration [0-9]*' | sed -e 's/.summary.txt:/ /' -e 's/-/ /' | sort -g -k2 -k4
+            echo ""
+            exit 1
+          fi

--- a/.github/workflows/intermittent-test-check.yml
+++ b/.github/workflows/intermittent-test-check.yml
@@ -46,7 +46,7 @@ env:
   TEST_METHOD: ${{ github.event.inputs.test-name }}
   ITERATIONS: ${{ github.event.inputs.iterations }}
   FAIL_FAST: ${{ github.event.inputs.fail-fast }}
-run-name: ${{ github.event_name == 'workflow_dispatch' && format('{0}#{1}[{2}]', inputs.test-class, inputs.test-name, inputs.ref) || '' }}
+run-name: ${{ github.event_name == 'workflow_dispatch' && format('{0}#{1}[{2}]-{3}x{4}', inputs.test-class, inputs.test-name, inputs.ref, inputs.splits, inputs.iterations) || '' }}
 jobs:
   prepare-job:
     runs-on: ubuntu-20.04

--- a/.github/workflows/intermittent-test-check.yml
+++ b/.github/workflows/intermittent-test-check.yml
@@ -138,7 +138,7 @@ jobs:
       - name: Summary of failures
         run: hadoop-ozone/dev-support/checks/_summary.sh target/${{ needs.prepare-job.outputs.test_type }}/summary.txt
         if: ${{ !cancelled() }}
-        continue-on-error: true
+        continue-on-error: ${{ github.event.inputs.fail-fast != 'true' }}
       - name: Archive build results
         uses: actions/upload-artifact@v3
         if: always()

--- a/.github/workflows/intermittent-test-check.yml
+++ b/.github/workflows/intermittent-test-check.yml
@@ -138,7 +138,6 @@ jobs:
       - name: Summary of failures
         run: hadoop-ozone/dev-support/checks/_summary.sh target/${{ needs.prepare-job.outputs.test_type }}/summary.txt
         if: ${{ !cancelled() }}
-        continue-on-error: ${{ github.event.inputs.fail-fast != 'true' }}
       - name: Archive build results
         uses: actions/upload-artifact@v3
         if: always()
@@ -152,6 +151,7 @@ jobs:
           rm -rf ~/.m2/repository/org/apache/ozone/ozone*
         if: always()
   count-failures:
+    if: ${{ always() }}
     needs: run-test
     runs-on: ubuntu-20.04
     steps:

--- a/hadoop-ozone/dev-support/checks/junit.sh
+++ b/hadoop-ozone/dev-support/checks/junit.sh
@@ -20,6 +20,7 @@ DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 cd "$DIR/../../.." || exit 1
 
 : ${CHECK:="unit"}
+: ${FAIL_FAST:="false"}
 : ${ITERATIONS:="1"}
 : ${OZONE_WITH_COVERAGE:="false"}
 : ${OZONE_REPO_CACHED:="false"}
@@ -36,7 +37,7 @@ if [[ "${OZONE_WITH_COVERAGE}" != "true" ]]; then
   MAVEN_OPTIONS="${MAVEN_OPTIONS} -Djacoco.skip"
 fi
 
-if [[ "${FAIL_FAST:-}" == "true" ]]; then
+if [[ "${FAIL_FAST}" == "true" ]]; then
   MAVEN_OPTIONS="${MAVEN_OPTIONS} --fail-fast -Dsurefire.skipAfterFailureCount=1"
 else
   MAVEN_OPTIONS="${MAVEN_OPTIONS} --fail-at-end"
@@ -76,6 +77,10 @@ for i in $(seq 1 ${ITERATIONS}); do
 
   if [[ ${rc} == 0 ]]; then
     rc=${irc}
+  fi
+
+  if [[ ${rc} != 0 ]] && [[ "${FAIL_FAST}" == "true" ]]; then
+    break
   fi
 done
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

 * Add a new job in `flaky-test-check` to sum up failures across all splits
 * Fix `junit.sh` to stop on first failure if `FAIL_FAST=true`
 * Improve _run name_ to include number of splits and iterations

https://issues.apache.org/jira/browse/HDDS-9509

## How was this patch tested?

Run with `Stop after first failure: false` (i.e. run all tests and collect results):
https://github.com/adoroszlai/hadoop-ozone/actions/runs/6595397183/job/17920692241

Run with `Stop after first failure: true`:
https://github.com/adoroszlai/hadoop-ozone/actions/runs/6589388300/job/17903770249