### PR TITLE
HDDS-9519. NPE in OM background services during restart

### DIFF
--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
@@ -4064,8 +4064,10 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
    * If ratis is not enabled, then it always returns true.
    */
   public boolean isLeaderReady() {
+    final OzoneManagerRatisServer ratisServer = omRatisServer;
     return !isRatisEnabled
-        || omRatisServer.checkLeaderStatus() == LEADER_AND_READY;
+        || (ratisServer != null &&
+            ratisServer.checkLeaderStatus() == LEADER_AND_READY);
   }
 
   /**

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/service/DirectoryDeletingService.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/service/DirectoryDeletingService.java
@@ -88,7 +88,7 @@ public class DirectoryDeletingService extends AbstractKeyDeletingService {
   public DirectoryDeletingService(long interval, TimeUnit unit,
       long serviceTimeout, OzoneManager ozoneManager,
       OzoneConfiguration configuration) {
-    super(KeyDeletingService.class.getSimpleName(), interval, unit,
+    super(DirectoryDeletingService.class.getSimpleName(), interval, unit,
         DIR_DELETING_CORE_POOL_SIZE, serviceTimeout, ozoneManager, null);
     this.pathLimitPerTask = configuration
         .getInt(OZONE_PATH_DELETING_LIMIT_PER_TASK,


### PR DESCRIPTION
## What changes were proposed in this pull request?

Various OM background services can encounter NPE after shutdown:

```
[omNode-3-KeyDeletingService#0] WARN  utils.BackgroundService (BackgroundService.java:lambda$run$0(145)) - Background task execution failed
java.lang.NullPointerException
	at org.apache.hadoop.ozone.om.OzoneManager.isLeaderReady(OzoneManager.java:4068)
	at org.apache.hadoop.ozone.om.service.DirectoryDeletingService.shouldRun(DirectoryDeletingService.java:110)
	at org.apache.hadoop.ozone.om.service.DirectoryDeletingService.access$0(DirectoryDeletingService.java:105)
	at org.apache.hadoop.ozone.om.service.DirectoryDeletingService$DirDeletingTask.call(DirectoryDeletingService.java:145)
	at org.apache.hadoop.hdds.utils.BackgroundService$PeriodicalTask.lambda$run$0(BackgroundService.java:140)
```

This happens mostly in integration tests that restart OM.  The problem is that these background services are stopped only after OM Ratis server is stopped and unset.

Instead of reordering steps of `stop()`, this PR proposes to fix this by treating unset OM Ratis server as "leader not ready".

Also fix mismatch of service name in `DirectoryDeletingService`.

https://issues.apache.org/jira/browse/HDDS-9519

## How was this patch tested?

Ran `TestOzoneManagerHAMetadataOnly`, verified NPE is no longer present in the logs.

CI:
https://github.com/adoroszlai/hadoop-ozone/actions/runs/6596116067