### PR TITLE
HDDS-9429. Intermittent error in TestOzoneManagerHAMetadataOnly#testAllVolumeOperations

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/MiniOzoneClusterImpl.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/MiniOzoneClusterImpl.java
@@ -373,6 +373,7 @@ public class MiniOzoneClusterImpl implements MiniOzoneCluster {
   @Override
   public void restartOzoneManager() throws IOException {
     ozoneManager.stop();
+    ozoneManager.join();
     ozoneManager.restart();
   }
 

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/MiniOzoneClusterImpl.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/MiniOzoneClusterImpl.java
@@ -372,8 +372,7 @@ public class MiniOzoneClusterImpl implements MiniOzoneCluster {
 
   @Override
   public void restartOzoneManager() throws IOException {
-    ozoneManager.stop();
-    ozoneManager.join();
+    stopOM(ozoneManager);
     ozoneManager.restart();
   }
 
@@ -552,10 +551,8 @@ public class MiniOzoneClusterImpl implements MiniOzoneCluster {
     }
   }
 
-  private static void stopOM(OzoneManager om) {
-    if (om != null) {
-      LOG.info("Stopping the OzoneManager");
-      om.stop();
+  protected static void stopOM(OzoneManager om) {
+    if (om != null && om.stop()) {
       om.join();
     }
   }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/MiniOzoneHAClusterImpl.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/MiniOzoneHAClusterImpl.java
@@ -221,8 +221,12 @@ public class MiniOzoneHAClusterImpl extends MiniOzoneClusterImpl {
 
   @Override
   public void restartOzoneManager() throws IOException {
-    for (OzoneManager ozoneManager : this.omhaService.getServices()) {
+    for (OzoneManager ozoneManager : omhaService.getActiveServices()) {
       ozoneManager.stop();
+      ozoneManager.join();
+    }
+    omhaService.inactiveServices().forEachRemaining(omhaService::activate);
+    for (OzoneManager ozoneManager : omhaService.getServices()) {
       ozoneManager.restart();
     }
   }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/MiniOzoneHAClusterImpl.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/MiniOzoneHAClusterImpl.java
@@ -222,8 +222,7 @@ public class MiniOzoneHAClusterImpl extends MiniOzoneClusterImpl {
   @Override
   public void restartOzoneManager() throws IOException {
     for (OzoneManager ozoneManager : omhaService.getActiveServices()) {
-      ozoneManager.stop();
-      ozoneManager.join();
+      stopOM(ozoneManager);
     }
     omhaService.inactiveServices().forEachRemaining(omhaService::activate);
     for (OzoneManager ozoneManager : omhaService.getServices()) {
@@ -305,8 +304,7 @@ public class MiniOzoneHAClusterImpl extends MiniOzoneClusterImpl {
     for (OzoneManager ozoneManager : this.omhaService.getServices()) {
       if (ozoneManager != null) {
         LOG.info("Stopping the OzoneManager {}", ozoneManager.getOMNodeId());
-        ozoneManager.stop();
-        ozoneManager.join();
+        stopOM(ozoneManager);
       }
     }
 
@@ -321,17 +319,16 @@ public class MiniOzoneHAClusterImpl extends MiniOzoneClusterImpl {
   }
 
   public void stopOzoneManager(int index) {
-    OzoneManager om = omhaService.getServices().get(index);
-    om.stop();
-    om.join();
+    stopAndDeactivate(omhaService.getServices().get(index));
+  }
+
+  private void stopAndDeactivate(OzoneManager om) {
+    stopOM(om);
     omhaService.deactivate(om);
   }
 
   public void stopOzoneManager(String omNodeId) {
-    OzoneManager om = omhaService.getServiceById(omNodeId);
-    om.stop();
-    om.join();
-    omhaService.deactivate(om);
+    stopAndDeactivate(omhaService.getServiceById(omNodeId));
   }
 
   private static void configureOMPorts(ConfigurationTarget conf,
@@ -518,8 +515,7 @@ public class MiniOzoneHAClusterImpl extends MiniOzoneClusterImpl {
           break;
         } catch (BindException e) {
           for (OzoneManager om : omList) {
-            om.stop();
-            om.join();
+            stopOM(om);
             LOG.info("Stopping OzoneManager server at {}",
                 om.getOmRpcServerAddr());
           }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerHA.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerHA.java
@@ -203,6 +203,15 @@ public abstract class TestOzoneManagerHA {
   }
 
   /**
+   * After restarting OMs we need to wait
+   * for a leader to be elected and ready.
+   */
+  @BeforeEach
+  protected void setup() throws Exception {
+    waitForLeaderToBeReady();
+  }
+
+  /**
    * Reset cluster between tests.
    */
   @AfterEach
@@ -472,11 +481,6 @@ public abstract class TestOzoneManagerHA {
     }
   }
 
-  /**
-   * After restarting OMs we need to wait
-   * for a leader to be elected and ready.
-   */
-  @BeforeEach
   protected void waitForLeaderToBeReady()
       throws InterruptedException, TimeoutException {
     // Wait for Leader Election timeout

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerHA.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerHA.java
@@ -44,6 +44,7 @@ import org.apache.ozone.test.GenericTestUtils;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Timeout;
 
 import java.io.IOException;
@@ -52,6 +53,8 @@ import java.time.Duration;
 import java.util.Iterator;
 import java.util.UUID;
 import java.util.HashMap;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.apache.hadoop.fs.CommonConfigurationKeysPublic.IPC_CLIENT_CONNECT_MAX_RETRIES_KEY;
@@ -64,6 +67,7 @@ import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_CLIENT_FAILOVER_MAX_
 import static org.apache.hadoop.ozone.OzoneConsts.OM_KEY_PREFIX;
 import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_DEFAULT_BUCKET_LAYOUT;
 import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_KEY_DELETING_LIMIT_PER_TASK;
+import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_RATIS_SERVER_FAILURE_TIMEOUT_DURATION_DEFAULT;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
@@ -198,13 +202,11 @@ public abstract class TestOzoneManagerHA {
     objectStore = client.getObjectStore();
   }
 
-
   /**
    * Reset cluster between tests.
    */
   @AfterEach
-  public void resetCluster()
-      throws IOException {
+  public void resetCluster() throws Exception {
     if (cluster != null) {
       cluster.restartOzoneManager();
     }
@@ -470,4 +472,17 @@ public abstract class TestOzoneManagerHA {
     }
   }
 
+  /**
+   * After restarting OMs we need to wait
+   * for a leader to be elected and ready.
+   */
+  @BeforeEach
+  protected void waitForLeaderToBeReady()
+      throws InterruptedException, TimeoutException {
+    // Wait for Leader Election timeout
+    int timeout = OZONE_OM_RATIS_SERVER_FAILURE_TIMEOUT_DURATION_DEFAULT
+        .toIntExact(TimeUnit.MILLISECONDS);
+    GenericTestUtils.waitFor(() ->
+        getCluster().getOMLeader() != null, 500, timeout);
+  }
 }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerHAMetadataOnly.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerHAMetadataOnly.java
@@ -47,10 +47,7 @@ import org.apache.ratis.protocol.RaftClientRequest;
 import org.apache.ratis.server.RaftServer;
 import org.junit.Assert;
 import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.MethodOrderer;
-import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.TestMethodOrder;
 
 import javax.management.MBeanInfo;
 import javax.management.MBeanServer;
@@ -74,7 +71,6 @@ import static org.junit.Assert.fail;
 /**
  * Test Ozone Manager Metadata operation in distributed handler scenario.
  */
-@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 public class TestOzoneManagerHAMetadataOnly extends TestOzoneManagerHA {
 
   private OzoneVolume createAndCheckVolume(String volumeName)
@@ -189,7 +185,6 @@ public class TestOzoneManagerHAMetadataOnly extends TestOzoneManagerHA {
    * to OM client.
    */
   @Test
-  @Order(1)
   public void testOMProxyProviderFailoverOnConnectionFailure()
       throws Exception {
     ObjectStore objectStore = getObjectStore();
@@ -259,7 +254,6 @@ public class TestOzoneManagerHAMetadataOnly extends TestOzoneManagerHA {
   }
 
   @Test
-  @Order(2)
   public void testOMRetryProxy() throws Exception {
     int maxFailoverAttempts = getOzoneClientFailoverMaxAttempts();
     // Stop all the OMs.
@@ -372,7 +366,6 @@ public class TestOzoneManagerHAMetadataOnly extends TestOzoneManagerHA {
   }
 
   @Test
-  @Order(3)
   public void testListVolumes() throws Exception {
     String userName = UserGroupInformation.getCurrentUser().getUserName();
     ObjectStore objectStore = getObjectStore();

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerHAMetadataOnly.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerHAMetadataOnly.java
@@ -47,7 +47,10 @@ import org.apache.ratis.protocol.RaftClientRequest;
 import org.apache.ratis.server.RaftServer;
 import org.junit.Assert;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
 
 import javax.management.MBeanInfo;
 import javax.management.MBeanServer;
@@ -71,6 +74,7 @@ import static org.junit.Assert.fail;
 /**
  * Test Ozone Manager Metadata operation in distributed handler scenario.
  */
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 public class TestOzoneManagerHAMetadataOnly extends TestOzoneManagerHA {
 
   private OzoneVolume createAndCheckVolume(String volumeName)
@@ -96,7 +100,6 @@ public class TestOzoneManagerHAMetadataOnly extends TestOzoneManagerHA {
 
   @Test
   public void testAllVolumeOperations() throws Exception {
-
     String volumeName = "volume" + RandomStringUtils.randomNumeric(5);
 
     createAndCheckVolume(volumeName);
@@ -114,7 +117,6 @@ public class TestOzoneManagerHAMetadataOnly extends TestOzoneManagerHA {
 
   @Test
   public void testAllBucketOperations() throws Exception {
-
     String volumeName = "volume" + RandomStringUtils.randomNumeric(5);
     String bucketName = "volume" + RandomStringUtils.randomNumeric(5);
 
@@ -187,6 +189,7 @@ public class TestOzoneManagerHAMetadataOnly extends TestOzoneManagerHA {
    * to OM client.
    */
   @Test
+  @Order(1)
   public void testOMProxyProviderFailoverOnConnectionFailure()
       throws Exception {
     ObjectStore objectStore = getObjectStore();
@@ -256,6 +259,7 @@ public class TestOzoneManagerHAMetadataOnly extends TestOzoneManagerHA {
   }
 
   @Test
+  @Order(2)
   public void testOMRetryProxy() throws Exception {
     int maxFailoverAttempts = getOzoneClientFailoverMaxAttempts();
     // Stop all the OMs.
@@ -368,6 +372,7 @@ public class TestOzoneManagerHAMetadataOnly extends TestOzoneManagerHA {
   }
 
   @Test
+  @Order(3)
   public void testListVolumes() throws Exception {
     String userName = UserGroupInformation.getCurrentUser().getUserName();
     ObjectStore objectStore = getObjectStore();

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerHAMetrics.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerHAMetrics.java
@@ -17,15 +17,10 @@
 package org.apache.hadoop.ozone.om;
 
 import org.apache.hadoop.ozone.om.ha.OMHAMetrics;
-import org.apache.ozone.test.GenericTestUtils;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
-
-import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_RATIS_SERVER_FAILURE_TIMEOUT_DURATION_DEFAULT;
 
 /**
  * Test Ozone Manager HA Metrics.
@@ -34,8 +29,6 @@ public class TestOzoneManagerHAMetrics extends TestOzoneManagerHA {
 
   @Test
   public void testOMHAMetrics() throws Exception {
-    waitForLeaderToBeReady();
-
     // Get leader OM
     OzoneManager leaderOM = getCluster().getOMLeader();
     // Store current leader's node ID,
@@ -88,17 +81,4 @@ public class TestOzoneManagerHAMetrics extends TestOzoneManagerHA {
     }
   }
 
-
-  /**
-   * After restarting OMs we need to wait
-   * for a leader to be elected and ready.
-   */
-  private void waitForLeaderToBeReady()
-      throws InterruptedException, TimeoutException {
-    // Wait for Leader Election timeout
-    int timeout = OZONE_OM_RATIS_SERVER_FAILURE_TIMEOUT_DURATION_DEFAULT
-        .toIntExact(TimeUnit.MILLISECONDS);
-    GenericTestUtils.waitFor(() ->
-        getCluster().getOMLeader() != null, 500, timeout);
-  }
 }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerPrepare.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerPrepare.java
@@ -51,7 +51,6 @@ import org.apache.hadoop.ozone.container.TestHelper;
 import org.apache.hadoop.ozone.om.exceptions.OMException;
 import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.PrepareStatusResponse.PrepareStatus;
-import org.apache.ozone.test.GenericTestUtils;
 import org.apache.ozone.test.LambdaTestUtils;
 import org.apache.ozone.test.tag.Slow;
 import org.apache.ozone.test.tag.Unhealthy;
@@ -83,7 +82,7 @@ public class TestOzoneManagerPrepare extends TestOzoneManagerHA {
   private static final Logger LOG =
       LoggerFactory.getLogger(TestOzoneManagerPrepare.class);
 
-  public void setup() throws Exception {
+  private void initInstanceVariables() {
     cluster = getCluster();
     store = getObjectStore();
     clientProtocol = store.getClientProxy();
@@ -91,14 +90,14 @@ public class TestOzoneManagerPrepare extends TestOzoneManagerHA {
 
   /**
    * Make sure OM is out of Prepare state before executing individual tests.
-   * @throws Exception
    */
   @BeforeEach
-  public void initOM() throws Exception {
-    setup();
+  @Override
+  protected void setup() throws Exception {
+    initInstanceVariables();
+
     LOG.info("Waiting for OM leader election");
-    GenericTestUtils.waitFor(() -> cluster.getOMLeader() != null,
-        1000, 120_000);
+    waitForLeaderToBeReady();
     submitCancelPrepareRequest();
     assertClusterNotPrepared();
   }
@@ -202,7 +201,7 @@ public class TestOzoneManagerPrepare extends TestOzoneManagerHA {
     // modified cluster.
     shutdown();
     init();
-    setup();
+    initInstanceVariables();
 
     String volumeName = VOLUME + UUID.randomUUID().toString();
     writeKeysAndWaitForLogs(volumeName, 10);

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
@@ -2209,10 +2209,10 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
   /**
    * Stop service.
    */
-  public void stop() {
+  public boolean stop() {
     LOG.info("{}: Stopping Ozone Manager", omNodeDetails.getOMPrintInfo());
     if (isStopped()) {
-      return;
+      return false;
     }
     try {
       omState = State.STOPPED;
@@ -2270,9 +2270,11 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
       if (omhaMetrics != null) {
         OMHAMetrics.unRegister();
       }
+      return true;
     } catch (Exception e) {
       LOG.error("OzoneManager stop failed.", e);
     }
+    return false;
   }
 
   public void shutDown(String message) {

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManagerStarter.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManagerStarter.java
@@ -190,8 +190,9 @@ public class OzoneManagerStarter extends GenericCli {
       om.start();
       ShutdownHookManager.get().addShutdownHook(() -> {
         try {
-          om.stop();
-          om.join();
+          if (om.stop()) {
+            om.join();
+          }
         } catch (Exception e) {
           LOG.error("Error during stop OzoneManager.", e);
         }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fix intermittent error in `testAllVolumeOperations`: `OMNotLeaderException: OM:omNode-1 is not the leader. Suggested leader is OM:omNode-2[localhost/127.0.0.1].`

`TestOzoneManagerHA` subclasses use a single cluster for all tests, and all OM instances are restarted after each test case.

The patch makes 3 main changes:

1. add "wait for OM leader election" before each test case
2. mark all OMs as active when restarting them (HA mini cluster keeps track of active and inactive OMs.  OM stopped via `stopOzoneManager()` is marked as inactive.  Before this change `restartOzoneManager()` still starts all OMs, even inactive ones.  But `getLeaderOM()` only considers active ones, thus we may not find the actual leader if it is left as "inactive".)
3. wait for OM RPC server to really stop (call `join()`) when restarting OM.  Avoid calling `join()` if OM is already stopped, as that would wait for `notifyAll()` without anyone signalling.

https://issues.apache.org/jira/browse/HDDS-9429

## How was this patch tested?

`TestOzoneManagerHAMetadataOnly` passed in 300 runs:
https://github.com/adoroszlai/hadoop-ozone/actions/runs/6602838480

On `master` it failed in 17/300 runs:
https://github.com/adoroszlai/hadoop-ozone/actions/runs/6602302723/job/17935202601