### PR TITLE
HDDS-9521. Increase recovering container default timeout for containers

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/OzoneConfigKeys.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/OzoneConfigKeys.java
@@ -301,7 +301,7 @@ public final class OzoneConfigKeys {
       OZONE_RECOVERING_CONTAINER_TIMEOUT =
       "ozone.recovering.container.timeout";
   public static final String
-      OZONE_RECOVERING_CONTAINER_TIMEOUT_DEFAULT = "30m";
+      OZONE_RECOVERING_CONTAINER_TIMEOUT_DEFAULT = "1d";
 
 
   public static final String OZONE_KEY_PREALLOCATION_BLOCKS_MAX =

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/OzoneConfigKeys.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/OzoneConfigKeys.java
@@ -301,7 +301,7 @@ public final class OzoneConfigKeys {
       OZONE_RECOVERING_CONTAINER_TIMEOUT =
       "ozone.recovering.container.timeout";
   public static final String
-      OZONE_RECOVERING_CONTAINER_TIMEOUT_DEFAULT = "20m";
+      OZONE_RECOVERING_CONTAINER_TIMEOUT_DEFAULT = "30m";
 
 
   public static final String OZONE_KEY_PREALLOCATION_BLOCKS_MAX =


### PR DESCRIPTION
## What changes were proposed in this pull request?
Increase recovering container default timeout for containers. This configuration is responsible for marking the container as unhealthy after the timeout value.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-9521

## How was this patch tested?
Default config change no testing required.