### PR TITLE
HDDS-9518. Fix OM double buffer thread name.

### DIFF
--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/OzoneManagerStateMachine.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/OzoneManagerStateMachine.java
@@ -119,12 +119,12 @@ public class OzoneManagerStateMachine extends BaseStateMachine {
 
     this.snapshotInfo = ozoneManager.getSnapshotInfo();
     loadSnapshotInfoFromDB();
+    this.threadPrefix = ozoneManager.getThreadNamePrefix();
 
     this.ozoneManagerDoubleBuffer = buildDoubleBufferForRatis();
 
     this.handler = new OzoneManagerRequestHandler(ozoneManager,
         ozoneManagerDoubleBuffer);
-    this.threadPrefix = ozoneManager.getThreadNamePrefix();
 
     ThreadFactory build = new ThreadFactoryBuilder().setDaemon(true)
         .setNameFormat(threadPrefix +


### PR DESCRIPTION
## What changes were proposed in this pull request?
**Root Cause** - The Jira ticket suggests that the issue is related to the order of operations. It appears that the ozoneManagerDoubleBuffer is created before the threadPrefix is set, and this might be the reason why the thread name is being set incorrectly.

**Resolution** - Reordered the initialization of `threadPrefix` to precede the creation of the `ozoneManagerDoubleBuffer`

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-9518

## How was this patch tested?

I ran the `TestTrashService` class and verified the logs, which clearly display the `om node` prefix before the thread name `ozoneManagerDoubleBuffer`.

```
2023-10-23 11:58:21,931 [om1@group-C5BA1605619E-StateMachineUpdater] INFO  ratis.OzoneManagerDoubleBuffer (OzoneManagerDoubleBuffer.java:stopDaemon(559)) - Stopping OMDoubleBuffer flush thread
2023-10-23 11:58:21,931 [om1-OMDoubleBufferFlushThread] INFO  ratis.OzoneManagerDoubleBuffer (OzoneManagerDoubleBuffer.java:canFlush(646)) - OMDoubleBuffer flush thread om1-OMDoubleBufferFlushThread is interrupted and will exit.
```
