### PR TITLE
HDDS-9513. Fix gRPC queue time metrics

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/grpc/metrics/GrpcMetrics.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/grpc/metrics/GrpcMetrics.java
@@ -71,7 +71,7 @@ public class GrpcMetrics implements MetricsSource {
           new MutableQuantiles[intervals.length];
       for (int i = 0; i < intervals.length; i++) {
         int interval = intervals[i];
-        grpcProcessingTimeMillisQuantiles[i] = registry
+        grpcQueueTimeMillisQuantiles[i] = registry
             .newQuantiles("grpcQueueTime" + interval
                     + "s", "grpc queue time in millisecond", "ops",
                 "latency", interval);
@@ -104,18 +104,9 @@ public class GrpcMetrics implements MetricsSource {
 
   @Override
   public synchronized void getMetrics(MetricsCollector collector, boolean all) {
+    registry.snapshot(collector.addRecord(registry.info()), all);
     MetricsRecordBuilder recordBuilder = collector.addRecord(SOURCE_NAME);
-
     recordBuilder.tag(LATEST_REQUEST_TYPE, requestType);
-
-    sentBytes.snapshot(recordBuilder, all);
-    receivedBytes.snapshot(recordBuilder, all);
-    unknownMessagesSent.snapshot(recordBuilder, all);
-    unknownMessagesReceived.snapshot(recordBuilder, all);
-    grpcQueueTime.snapshot(recordBuilder, all);
-    grpcProcessingTime.snapshot(recordBuilder, all);
-    numOpenClientConnections.snapshot(recordBuilder, all);
-    recordBuilder.endRecord();
   }
 
   @Metric("Number of sent bytes")


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fix some bugs about quantiles in GrpcMetrics.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-9513

## How was this patch tested?

Test locally.
When config is like:

```
<property>   
  <name>ozone.grpc.metrics.percentiles.intervals</name>
  <value>57</value>
</property

```
The result will be:

<img width="529" alt="grpc" src="https://github.com/apache/ozone/assets/48795318/47da3474-8447-4ff0-8441-5b67fd178eee">

