### PR TITLE
HDDS-9363. Updated pull request template to remove PR title confusion

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,12 +1,12 @@
 ## What changes were proposed in this pull request?
+(Provide a one-liner summary of the changes in the **PR Title** field above.)
 
 (Please fill in changes proposed in this fix
-1. **Title:** Title should provide a one sentence overview of the purpose of the PR.
-2. **Description:**
+1. **Description:**
    * What changes are proposed in the PR? and Why? It would be better if it is written from third person's perspective not just for the reviewer. 
    * Provide as much context and rationale for the pull request as possible. It could be copy-paste from the Jira's description if the jira is well defined.
    * If it is complex code, describe the approach used to solve the issue. If possible attach design doc, issue investigation, github discussion, etc.
-3. **PR examples:** [PR#3980](https://github.com/apache/ozone/pull/3980), [PR#5265](https://github.com/apache/ozone/pull/5265), [PR#4701](https://github.com/apache/ozone/pull/4701), [PR#5283](https://github.com/apache/ozone/pull/5283), [PR#5300](https://github.com/apache/ozone/pull/5300))
+2. **PR examples:** [PR#3980](https://github.com/apache/ozone/pull/3980), [PR#5265](https://github.com/apache/ozone/pull/5265), [PR#4701](https://github.com/apache/ozone/pull/4701), [PR#5283](https://github.com/apache/ozone/pull/5283), [PR#5300](https://github.com/apache/ozone/pull/5300))
 
 ## What is the link to the Apache JIRA
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,18 +1,26 @@
 ## What changes were proposed in this pull request?
-(Provide a one-liner summary of the changes in the **PR Title** field above.)
+Provide a one-liner summary of the changes in the PR **Title** field above.
+It should be in the form of `HDDS-1234. Short summary of the change`.
 
-(Please fill in changes proposed in this fix
-1. **Description:**
-   * What changes are proposed in the PR? and Why? It would be better if it is written from third person's perspective not just for the reviewer. 
-   * Provide as much context and rationale for the pull request as possible. It could be copy-paste from the Jira's description if the jira is well defined.
-   * If it is complex code, describe the approach used to solve the issue. If possible attach design doc, issue investigation, github discussion, etc.
-2. **PR examples:** [PR#3980](https://github.com/apache/ozone/pull/3980), [PR#5265](https://github.com/apache/ozone/pull/5265), [PR#4701](https://github.com/apache/ozone/pull/4701), [PR#5283](https://github.com/apache/ozone/pull/5283), [PR#5300](https://github.com/apache/ozone/pull/5300))
+Please describe your PR in detail:
+* What changes are proposed in the PR? and Why? It would be better if it is written from third person's
+perspective not just for the reviewer.
+* Provide as much context and rationale for the pull request as possible. It could be copy-paste from
+the Jira's description if the jira is well defined.
+* If it is complex code, describe the approach used to solve the issue. If possible attach design doc,
+issue investigation, github discussion, etc.
+
+Examples of well-written pull requests:
+* [#3980](https://github.com/apache/ozone/pull/3980)
+* [#5265](https://github.com/apache/ozone/pull/5265)
+* [#4701](https://github.com/apache/ozone/pull/4701)
+* [#5283](https://github.com/apache/ozone/pull/5283)
+* [#5300](https://github.com/apache/ozone/pull/5300)
 
 ## What is the link to the Apache JIRA
 
-(Please create an issue in ASF JIRA before opening a pull request,
-and you need to set the title of the pull request which starts with
-the corresponding JIRA issue number. (e.g. HDDS-XXXX. Fix a typo in YYY.)
+Please create an issue in ASF JIRA before opening a pull request, and you need to set the title of the pull
+request which starts with the corresponding JIRA issue number. (e.g. HDDS-XXXX. Fix a typo in YYY.)
 
 (Please replace this section with the link to the Apache JIRA)
 


### PR DESCRIPTION
## What changes were proposed in this pull request?
In PR https://github.com/apache/ozone/pull/5372, pull request template was updated to provide more context in PRs description. But it created confusion and title is duplicated in PR description as well.
This change is to update the template so that title is not duplicated in description and only added to the PR title field.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-9363

## How was this patch tested?
No testing. Just documentation change.
