### PR TITLE
HDDS-9530. Recon - NPE in handling deleteKey event in NSSummaryFSO task.

### DIFF
--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/tasks/OMDBUpdatesHandler.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/tasks/OMDBUpdatesHandler.java
@@ -153,8 +153,18 @@ public class OMDBUpdatesHandler extends ManagedWriteBatch.Handler {
           }
         }
       } else if (action.equals(DELETE)) {
-        if (oldValue != null && !omUpdateEventValidator.isValidEvent(tableName,
-            oldValue, key, action)) {
+        if (null == oldValue) {
+          String keyStr = "";
+          if (key instanceof String) {
+            keyStr = (String) key;
+          }
+          LOG.info(
+              "WARNING !!!, Value of Key: {} in table: {} should not be null " +
+                  "for DELETE event ", keyStr, tableName);
+          return;
+        }
+        if (!omUpdateEventValidator.isValidEvent(tableName, oldValue, key,
+            action)) {
           return;
         }
         // When you delete a Key, we add the old value to the event so that

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/tasks/OMDBUpdatesHandler.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/tasks/OMDBUpdatesHandler.java
@@ -155,7 +155,15 @@ public class OMDBUpdatesHandler extends ManagedWriteBatch.Handler {
       } else if (action.equals(DELETE)) {
         if (null == oldValue) {
           String keyStr = (key instanceof String) ? key.toString() : "";
-          LOG.warn("Value of Key: {} in table: {} should not be null " +
+          if (keyStr.isEmpty()) {
+            LOG.warn(
+                "Only DTOKEN_TABLE table uses OzoneTokenIdentifier as key " +
+                    "instead of String. Event on any other table in this " +
+                    "condition may need to be investigated. This DELETE " +
+                    "event is on {} table which is not useful for Recon to " +
+                    "capture.", tableName);
+          }
+          LOG.warn("Old Value of Key: {} in table: {} should not be null " +
               "for DELETE event ", keyStr, tableName);
           return;
         }

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/tasks/OMDBUpdatesHandler.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/tasks/OMDBUpdatesHandler.java
@@ -154,13 +154,9 @@ public class OMDBUpdatesHandler extends ManagedWriteBatch.Handler {
         }
       } else if (action.equals(DELETE)) {
         if (null == oldValue) {
-          String keyStr = "";
-          if (key instanceof String) {
-            keyStr = (String) key;
-          }
-          LOG.info(
-              "WARNING !!!, Value of Key: {} in table: {} should not be null " +
-                  "for DELETE event ", keyStr, tableName);
+          String keyStr = (key instanceof String) ? key.toString() : "";
+          LOG.warn("Value of Key: {} in table: {} should not be null " +
+              "for DELETE event ", keyStr, tableName);
           return;
         }
         if (!omUpdateEventValidator.isValidEvent(tableName, oldValue, key,

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/tasks/OMDBUpdatesHandler.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/tasks/OMDBUpdatesHandler.java
@@ -116,7 +116,8 @@ public class OMDBUpdatesHandler extends ManagedWriteBatch.Handler {
       // - PUT with a new key: Insert the new value.
       // - PUT with an existing key: Update the existing value.
       // - DELETE with an existing key: Remove the value.
-      // - DELETE with a non-existing key: No action, log a warning if necessary.
+      // - DELETE with a non-existing key: No action, log a warning if
+      // necessary.
       Table table = omMetadataManager.getTable(tableName);
 
       OMDBUpdateEvent latestEvent = omdbLatestUpdateEvents.get(key);

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/tasks/OMDBUpdatesHandler.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/tasks/OMDBUpdatesHandler.java
@@ -81,12 +81,13 @@ public class OMDBUpdatesHandler extends ManagedWriteBatch.Handler {
   }
 
   /**
+   * Processes an OM DB update event based on the provided parameters.
    *
-   * @param cfIndex
-   * @param keyBytes
-   * @param valueBytes
-   * @param action
-   * @throws IOException
+   * @param cfIndex     Index of the column family.
+   * @param keyBytes    Serialized key bytes.
+   * @param valueBytes  Serialized value bytes.
+   * @param action      Type of the database action (e.g., PUT, DELETE).
+   * @throws IOException If an I/O error occurs.
    */
   private void processEvent(int cfIndex, byte[] keyBytes, byte[]
       valueBytes, OMDBUpdateEvent.OMDBUpdateAction action)
@@ -111,10 +112,11 @@ public class OMDBUpdatesHandler extends ManagedWriteBatch.Handler {
       final Object key = cf.getKeyCodec().fromPersistedFormat(keyBytes);
       builder.setKey(key);
 
-      // Put new
-      // Put existing --> Update
-      // Delete existing
-      // Delete non-existing
+      // Handle the event based on its type:
+      // - PUT with a new key: Insert the new value.
+      // - PUT with an existing key: Update the existing value.
+      // - DELETE with an existing key: Remove the value.
+      // - DELETE with a non-existing key: No action, log a warning if necessary.
       Table table = omMetadataManager.getTable(tableName);
 
       OMDBUpdateEvent latestEvent = omdbLatestUpdateEvents.get(key);
@@ -127,7 +129,7 @@ public class OMDBUpdatesHandler extends ManagedWriteBatch.Handler {
         oldValue = table.getSkipCache(key);
       }
 
-      if (action == PUT) {
+      if (action.equals(PUT)) {
         final Object value = cf.getValueCodec().fromPersistedFormat(valueBytes);
 
         // If the updated value is not valid for this event, we skip it.
@@ -137,8 +139,7 @@ public class OMDBUpdatesHandler extends ManagedWriteBatch.Handler {
         }
 
         builder.setValue(value);
-        // If a PUT operation happens on an existing Key, it is tagged
-        // as an "UPDATE" event.
+        // Tag PUT operations on existing keys as "UPDATE" events.
         if (oldValue != null) {
 
           // If the oldValue is not valid for this event, we skip it.
@@ -184,8 +185,7 @@ public class OMDBUpdatesHandler extends ManagedWriteBatch.Handler {
       omdbUpdateEvents.add(event);
       omdbLatestUpdateEvents.put(key, event);
     } else {
-      // key type or value type cannot be determined for this table.
-      // log a warn message and ignore the update.
+      // Log and ignore events if key or value types are undetermined.
       if (LOG.isWarnEnabled()) {
         LOG.warn(String.format("KeyType or ValueType could not be determined" +
             " for table %s. Ignoring the event.", tableName));

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/tasks/TestOMDBUpdatesHandler.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/tasks/TestOMDBUpdatesHandler.java
@@ -183,7 +183,7 @@ public class TestOMDBUpdatesHandler {
     OMDBUpdatesHandler omdbUpdatesHandler = captureEvents(writeBatches);
 
     List<OMDBUpdateEvent> events = omdbUpdatesHandler.getEvents();
-    assertEquals(4, events.size());
+    assertEquals(2, events.size());
 
     OMDBUpdateEvent keyEvent = events.get(0);
     assertEquals(OMDBUpdateEvent.OMDBUpdateAction.DELETE, keyEvent.getAction());
@@ -197,18 +197,8 @@ public class TestOMDBUpdatesHandler {
     OmVolumeArgs volumeInfo = (OmVolumeArgs) volEvent.getValue();
     assertEquals("sampleVol", volumeInfo.getVolume());
 
-    // Assert the values of non existent keys are set to null.
-    OMDBUpdateEvent nonExistKey = events.get(2);
-    assertEquals(OMDBUpdateEvent.OMDBUpdateAction.DELETE,
-        nonExistKey.getAction());
-    assertEquals("/sampleVol/bucketOne/key_two", nonExistKey.getKey());
-    assertNull(nonExistKey.getValue());
-
-    OMDBUpdateEvent nonExistVolume = events.get(3);
-    assertEquals(OMDBUpdateEvent.OMDBUpdateAction.DELETE,
-        nonExistVolume.getAction());
-    assertEquals(nonExistVolumeKey, nonExistVolume.getKey());
-    assertNull(nonExistVolume.getValue());
+    // Assert for non existent keys, no events will be captured and handled.
+    assertEquals(2, events.size());
   }
 
   @Test

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/tasks/TestOMDBUpdatesHandler.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/tasks/TestOMDBUpdatesHandler.java
@@ -152,8 +152,6 @@ public class TestOMDBUpdatesHandler {
   public void testDelete() throws Exception {
     // Write 1 volume, 1 key into source and target OM DBs.
     String volumeKey = omMetadataManager.getVolumeKey("sampleVol");
-    String nonExistVolumeKey = omMetadataManager
-        .getVolumeKey("nonExistingVolume");
     OmVolumeArgs args =
         OmVolumeArgs.newBuilder()
             .setVolume("sampleVol")

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/tasks/TestOMDBUpdatesHandler.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/tasks/TestOMDBUpdatesHandler.java
@@ -181,6 +181,8 @@ public class TestOMDBUpdatesHandler {
     OMDBUpdatesHandler omdbUpdatesHandler = captureEvents(writeBatches);
 
     List<OMDBUpdateEvent> events = omdbUpdatesHandler.getEvents();
+
+    // Assert for non existent keys, no events will be captured and handled.
     assertEquals(2, events.size());
 
     OMDBUpdateEvent keyEvent = events.get(0);
@@ -194,9 +196,6 @@ public class TestOMDBUpdatesHandler {
     assertNotNull(volEvent.getValue());
     OmVolumeArgs volumeInfo = (OmVolumeArgs) volEvent.getValue();
     assertEquals("sampleVol", volumeInfo.getVolume());
-
-    // Assert for non existent keys, no events will be captured and handled.
-    assertEquals(2, events.size());
   }
 
   @Test


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR fixes by omitting the event to be handled by Recon where a value in a table could be null for a key. Ideally this should not happen in Raft log sequence of events so this PR is trying to skip such event and log with WARNING and details of event like table, event key etc. This will address 2 issues along with update to javadoc for `processEvent` method code in`OMDBUpdatesHandler.java`

1. NPE will not be thrown while processing event (PUT, UPDATE, DELETE) in Recon task handler, if a event is having null value for a key.
2. Any inconsistency or issue identified later using above log message will be deeply analyzed why and on which table such key occurrence can happen on OM DB side.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-9530

## How was this patch tested?

This patch was tested using existing Junit tests as well by creating and deleting keys using freon tool and wait for Recon sync to happen with OM DB.
