### PR TITLE
HDDS-8722. Improve thread names in Datanode.

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/protocol/DatanodeDetails.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/protocol/DatanodeDetails.java
@@ -116,11 +116,13 @@ public class DatanodeDetails extends NodeImpl implements
    */
   @SuppressWarnings("parameternumber")
   private DatanodeDetails(UUID uuid, String ipAddress, String hostName,
-      String networkLocation, List<Port> ports, String certSerialId,
-      String version, long setupTime, String revision, String buildDate,
-      HddsProtos.NodeOperationalState persistedOpState,
-      long persistedOpStateExpiryEpochSec,
-      int initialVersion, int currentVersion) {
+                          String networkLocation, List<Port> ports,
+                          String certSerialId,
+                          String version, long setupTime, String revision,
+                          String buildDate,
+                          HddsProtos.NodeOperationalState persistedOpState,
+                          long persistedOpStateExpiryEpochSec,
+                          int initialVersion, int currentVersion) {
     super(hostName, networkLocation, NetConstants.NODE_COST_DEFAULT);
     this.uuid = uuid;
     this.uuidString = uuid.toString();

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/protocol/DatanodeDetails.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/protocol/DatanodeDetails.java
@@ -116,13 +116,11 @@ public class DatanodeDetails extends NodeImpl implements
    */
   @SuppressWarnings("parameternumber")
   private DatanodeDetails(UUID uuid, String ipAddress, String hostName,
-                          String networkLocation, List<Port> ports,
-                          String certSerialId,
-                          String version, long setupTime, String revision,
-                          String buildDate,
-                          HddsProtos.NodeOperationalState persistedOpState,
-                          long persistedOpStateExpiryEpochSec,
-                          int initialVersion, int currentVersion) {
+      String networkLocation, List<Port> ports, String certSerialId,
+      String version, long setupTime, String revision, String buildDate,
+      HddsProtos.NodeOperationalState persistedOpState,
+      long persistedOpStateExpiryEpochSec,
+      int initialVersion, int currentVersion) {
     super(hostName, networkLocation, NetConstants.NODE_COST_DEFAULT);
     this.uuid = uuid;
     this.uuidString = uuid.toString();

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/report/ReportManager.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/report/ReportManager.java
@@ -49,17 +49,18 @@ public final class ReportManager {
    * Construction of {@link ReportManager} should be done via
    * {@link ReportManager.Builder}.
    *
-   * @param context StateContext which holds the report
+   * @param context    StateContext which holds the report
    * @param publishers List of publishers which generates report
    */
-  private ReportManager(StateContext context,
-                        List<ReportPublisher> publishers) {
+  private ReportManager(StateContext context, List<ReportPublisher> publishers,
+      String threadNamePrefix) {
     this.context = context;
     this.publishers = publishers;
     this.executorService = HadoopExecutors.newScheduledThreadPool(
         publishers.size(),
         new ThreadFactoryBuilder().setDaemon(true)
-            .setNameFormat("Datanode ReportManager Thread - %d").build());
+            .setNameFormat(threadNamePrefix +
+                "DatanodeReportManager-%d").build());
   }
 
   /**
@@ -103,6 +104,7 @@ public final class ReportManager {
     private StateContext stateContext;
     private List<ReportPublisher> reportPublishers;
     private ReportPublisherFactory publisherFactory;
+    private String threadNamePrefix = "";
 
 
     private Builder(ConfigurationSource conf) {
@@ -146,6 +148,11 @@ public final class ReportManager {
       return this;
     }
 
+    public Builder addThreadNamePrefix(String threadPrefix) {
+      this.threadNamePrefix = threadPrefix;
+      return this;
+    }
+
     /**
      * Build and returns ReportManager.
      *
@@ -153,7 +160,8 @@ public final class ReportManager {
      */
     public ReportManager build() {
       Preconditions.checkNotNull(stateContext);
-      return new ReportManager(stateContext, reportPublishers);
+      return new ReportManager(
+          stateContext, reportPublishers, threadNamePrefix);
     }
 
   }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/DatanodeStateMachine.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/DatanodeStateMachine.java
@@ -169,8 +169,9 @@ public class DatanodeStateMachine implements Closeable {
     this.dnCRLStore = crlStore;
     executorService = Executors.newFixedThreadPool(
         getEndPointTaskThreadPoolSize(),
-        new ThreadFactoryBuilder()
-            .setNameFormat("Datanode State Machine Task Thread - %d").build());
+        new ThreadFactoryBuilder().setNameFormat(
+            datanodeDetails.threadNamePrefix() +
+                "Datanode State Machine Task Thread - %d").build());
     connectionManager = new SCMConnectionManager(conf);
     context = new StateContext(this.conf, DatanodeStates.getInitState(), this);
     // OzoneContainer instance is used in a non-thread safe way by the context
@@ -225,8 +226,8 @@ public class DatanodeStateMachine implements Closeable {
         ecReconstructionCoordinator);
 
     pipelineCommandExecutorService = Executors
-        .newSingleThreadExecutor(new ThreadFactoryBuilder()
-            .setNameFormat("PipelineCommandHandlerThread-%d").build());
+        .newSingleThreadExecutor(new ThreadFactoryBuilder().setNameFormat(
+            datanodeDetails + "PipelineCommandHandlerThread-%d").build());
 
     // When we add new handlers just adding a new handler here should do the
     // trick.
@@ -551,7 +552,8 @@ public class DatanodeStateMachine implements Closeable {
     };
     stateMachineThread =  new ThreadFactoryBuilder()
         .setDaemon(true)
-        .setNameFormat("Datanode State Machine Daemon Thread")
+        .setNameFormat(datanodeDetails.threadNamePrefix() +
+            "Datanode State Machine Daemon Thread")
         .setUncaughtExceptionHandler((Thread t, Throwable ex) -> {
           String message = "Terminate Datanode, encounter uncaught exception"
               + " in Datanode State Machine Thread";
@@ -689,7 +691,8 @@ public class DatanodeStateMachine implements Closeable {
   private Thread getCommandHandlerThread(Runnable processCommandQueue) {
     Thread handlerThread = new Thread(processCommandQueue);
     handlerThread.setDaemon(true);
-    handlerThread.setName("Command processor thread");
+    handlerThread.setName(
+        datanodeDetails.threadNamePrefix() + "Command processor thread");
     handlerThread.setUncaughtExceptionHandler((Thread t, Throwable e) -> {
       // Let us just restart this thread after logging a critical error.
       // if this thread is not running we cannot handle commands from SCM.

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/DatanodeStateMachine.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/DatanodeStateMachine.java
@@ -171,7 +171,7 @@ public class DatanodeStateMachine implements Closeable {
         getEndPointTaskThreadPoolSize(),
         new ThreadFactoryBuilder().setNameFormat(
             datanodeDetails.threadNamePrefix() +
-                "Datanode State Machine Task Thread - %d").build());
+                "DatanodeStateMachineTaskThread-%d").build());
     connectionManager = new SCMConnectionManager(conf);
     context = new StateContext(this.conf, DatanodeStates.getInitState(), this);
     // OzoneContainer instance is used in a non-thread safe way by the context
@@ -553,7 +553,7 @@ public class DatanodeStateMachine implements Closeable {
     stateMachineThread =  new ThreadFactoryBuilder()
         .setDaemon(true)
         .setNameFormat(datanodeDetails.threadNamePrefix() +
-            "Datanode State Machine Daemon Thread")
+            "DatanodeStateMachineDaemonThread")
         .setUncaughtExceptionHandler((Thread t, Throwable ex) -> {
           String message = "Terminate Datanode, encounter uncaught exception"
               + " in Datanode State Machine Thread";

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/DatanodeStateMachine.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/DatanodeStateMachine.java
@@ -176,7 +176,8 @@ public class DatanodeStateMachine implements Closeable {
                 "DatanodeStateMachineTaskThread-%d")
             .build());
     connectionManager = new SCMConnectionManager(conf);
-    context = new StateContext(this.conf, DatanodeStates.getInitState(), this);
+    context = new StateContext(this.conf, DatanodeStates.getInitState(), this,
+        threadNamePrefix);
     // OzoneContainer instance is used in a non-thread safe way by the context
     // past to its constructor, so we much synchronize its access. See
     // HDDS-3116 for more details.
@@ -699,7 +700,7 @@ public class DatanodeStateMachine implements Closeable {
     Thread handlerThread = new Thread(processCommandQueue);
     handlerThread.setDaemon(true);
     handlerThread.setName(
-        datanodeDetails.threadNamePrefix() + "Command processor thread");
+        datanodeDetails.threadNamePrefix() + "CommandProcessorThread");
     handlerThread.setUncaughtExceptionHandler((Thread t, Throwable e) -> {
       // Let us just restart this thread after logging a critical error.
       // if this thread is not running we cannot handle commands from SCM.

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/EndpointStateMachine.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/EndpointStateMachine.java
@@ -68,7 +68,7 @@ public class EndpointStateMachine
    */
   public EndpointStateMachine(InetSocketAddress address,
       StorageContainerDatanodeProtocolClientSideTranslatorPB endPoint,
-      ConfigurationSource conf) {
+      ConfigurationSource conf, String threadNamePrefix) {
     this.endPoint = endPoint;
     this.missedCount = new AtomicLong(0);
     this.address = address;
@@ -77,8 +77,8 @@ public class EndpointStateMachine
     this.conf = conf;
     executorService = Executors.newSingleThreadExecutor(
         new ThreadFactoryBuilder()
-            .setNameFormat("EndpointStateMachine task thread for "
-                + this.address + " - %d ")
+            .setNameFormat(threadNamePrefix + "EndpointStateMachineTaskThread-"
+                + this.address + "-%d ")
             .build());
   }
 

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/EndpointStateMachine.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/EndpointStateMachine.java
@@ -56,7 +56,6 @@ public class EndpointStateMachine
   private ZonedDateTime lastSuccessfulHeartbeat;
   private boolean isPassive;
   private final ExecutorService executorService;
-  private final String threadNamePrefix;
 
   private static final String RECON_TYPE = "Recon";
 
@@ -69,7 +68,7 @@ public class EndpointStateMachine
    */
   public EndpointStateMachine(InetSocketAddress address,
       StorageContainerDatanodeProtocolClientSideTranslatorPB endPoint,
-      ConfigurationSource conf, String threadNamePrefix) {
+      ConfigurationSource conf) {
     this.endPoint = endPoint;
     this.missedCount = new AtomicLong(0);
     this.address = address;
@@ -78,8 +77,8 @@ public class EndpointStateMachine
     this.conf = conf;
     executorService = Executors.newSingleThreadExecutor(
         new ThreadFactoryBuilder()
-            .setNameFormat(threadNamePrefix + "EndpointStateMachine-"
-                + this.address + "-%d ")
+            .setNameFormat("EndpointStateMachine task thread for "
+                + this.address + " - %d ")
             .build());
   }
 

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/EndpointStateMachine.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/EndpointStateMachine.java
@@ -56,6 +56,7 @@ public class EndpointStateMachine
   private ZonedDateTime lastSuccessfulHeartbeat;
   private boolean isPassive;
   private final ExecutorService executorService;
+  private final String threadNamePrefix;
 
   private static final String RECON_TYPE = "Recon";
 
@@ -68,7 +69,7 @@ public class EndpointStateMachine
    */
   public EndpointStateMachine(InetSocketAddress address,
       StorageContainerDatanodeProtocolClientSideTranslatorPB endPoint,
-      ConfigurationSource conf) {
+      ConfigurationSource conf, String threadNamePrefix) {
     this.endPoint = endPoint;
     this.missedCount = new AtomicLong(0);
     this.address = address;
@@ -77,8 +78,8 @@ public class EndpointStateMachine
     this.conf = conf;
     executorService = Executors.newSingleThreadExecutor(
         new ThreadFactoryBuilder()
-            .setNameFormat("EndpointStateMachine task thread for "
-                + this.address + " - %d ")
+            .setNameFormat(threadNamePrefix + "EndpointStateMachine-"
+                + this.address + "-%d ")
             .build());
   }
 

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/SCMConnectionManager.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/SCMConnectionManager.java
@@ -132,7 +132,8 @@ public class SCMConnectionManager
    * @param address - Address of the SCM machine to send heartbeat to.
    * @throws IOException
    */
-  public void addSCMServer(InetSocketAddress address) throws IOException {
+  public void addSCMServer(InetSocketAddress address,
+      String threadNamePrefix) throws IOException {
     writeLock();
     try {
       if (scmMachines.containsKey(address)) {
@@ -163,10 +164,10 @@ public class SCMConnectionManager
 
       StorageContainerDatanodeProtocolClientSideTranslatorPB rpcClient =
           new StorageContainerDatanodeProtocolClientSideTranslatorPB(
-          rpcProxy);
+              rpcProxy);
 
-      EndpointStateMachine endPoint =
-          new EndpointStateMachine(address, rpcClient, this.conf);
+      EndpointStateMachine endPoint = new EndpointStateMachine(address,
+          rpcClient, this.conf, threadNamePrefix);
       endPoint.setPassive(false);
       scmMachines.put(address, endPoint);
     } finally {
@@ -176,10 +177,12 @@ public class SCMConnectionManager
 
   /**
    * Adds a new Recon server to the set of endpoints.
+   *
    * @param address Recon address.
    * @throws IOException
    */
-  public void addReconServer(InetSocketAddress address) throws IOException {
+  public void addReconServer(InetSocketAddress address,
+      String threadNamePrefix) throws IOException {
     LOG.info("Adding Recon Server : {}", address.toString());
     writeLock();
     try {
@@ -209,7 +212,7 @@ public class SCMConnectionManager
           new StorageContainerDatanodeProtocolClientSideTranslatorPB(rpcProxy);
 
       EndpointStateMachine endPoint =
-          new EndpointStateMachine(address, rpcClient, conf);
+          new EndpointStateMachine(address, rpcClient, conf, threadNamePrefix);
       endPoint.setPassive(true);
       scmMachines.put(address, endPoint);
     } finally {

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/StateContext.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/StateContext.java
@@ -152,8 +152,11 @@ public class StateContext {
   private final AtomicLong heartbeatFrequency = new AtomicLong(2000);
 
   private final AtomicLong reconHeartbeatFrequency = new AtomicLong(2000);
-  
+
   private final int maxCommandQueueLimit;
+
+  private final String threadNamePrefix;
+
   /**
    * Constructs a StateContext.
    *
@@ -163,7 +166,7 @@ public class StateContext {
    */
   public StateContext(ConfigurationSource conf,
       DatanodeStateMachine.DatanodeStates
-          state, DatanodeStateMachine parent) {
+          state, DatanodeStateMachine parent, String threadNamePrefix) {
     this.conf = conf;
     DatanodeConfiguration dnConf =
         conf.getObject(DatanodeConfiguration.class);
@@ -187,6 +190,7 @@ public class StateContext {
     isFullReportReadyToBeSent = new HashMap<>();
     fullReportTypeList = new ArrayList<>();
     type2Reports = new HashMap<>();
+    this.threadNamePrefix = threadNamePrefix;
     initReportTypeCollection();
   }
 
@@ -967,5 +971,9 @@ public class StateContext {
 
   public DatanodeQueueMetrics getQueueMetrics() {
     return parentDatanodeStateMachine.getQueueMetrics();
+  }
+
+  public String getThreadNamePrefix() {
+    return threadNamePrefix;
   }
 }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/CloseContainerCommandHandler.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/CloseContainerCommandHandler.java
@@ -65,13 +65,14 @@ public class CloseContainerCommandHandler implements CommandHandler {
    * Constructs a ContainerReport handler.
    */
   public CloseContainerCommandHandler(
-      int threadPoolSize, int queueSize) {
+      int threadPoolSize, int queueSize, String threadNamePrefix) {
     executor = new ThreadPoolExecutor(
-            threadPoolSize, threadPoolSize,
-            0L, TimeUnit.MILLISECONDS,
-            new LinkedBlockingQueue<>(queueSize),
-            new ThreadFactoryBuilder()
-                .setNameFormat("CloseContainerThread-%d").build());
+        threadPoolSize, threadPoolSize,
+        0L, TimeUnit.MILLISECONDS,
+        new LinkedBlockingQueue<>(queueSize),
+        new ThreadFactoryBuilder()
+            .setNameFormat(threadNamePrefix + "CloseContainerThread-%d")
+            .build());
   }
 
   /**

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/DeleteContainerCommandHandler.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/DeleteContainerCommandHandler.java
@@ -58,13 +58,14 @@ public class DeleteContainerCommandHandler implements CommandHandler {
   private int maxQueueSize;
 
   public DeleteContainerCommandHandler(
-      int threadPoolSize, Clock clock, int queueSize) {
+      int threadPoolSize, Clock clock, int queueSize, String threadNamePrefix) {
     this(clock, new ThreadPoolExecutor(
-        threadPoolSize, threadPoolSize,
-        0L, TimeUnit.MILLISECONDS,
-        new LinkedBlockingQueue<>(queueSize),
-        new ThreadFactoryBuilder()
-            .setNameFormat("DeleteContainerThread-%d").build()),
+            threadPoolSize, threadPoolSize,
+            0L, TimeUnit.MILLISECONDS,
+            new LinkedBlockingQueue<>(queueSize),
+            new ThreadFactoryBuilder()
+                .setNameFormat(threadNamePrefix + "DeleteContainerThread-%d")
+                .build()),
         queueSize);
   }
 

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/states/datanode/InitDatanodeState.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/states/datanode/InitDatanodeState.java
@@ -101,12 +101,13 @@ public class InitDatanodeState implements DatanodeState,
         }
       }
       for (InetSocketAddress addr : addresses) {
-        connectionManager.addSCMServer(addr);
+        connectionManager.addSCMServer(addr, context.getThreadNamePrefix());
         this.context.addEndpoint(addr);
       }
       InetSocketAddress reconAddress = getReconAddresses(conf);
       if (reconAddress != null) {
-        connectionManager.addReconServer(reconAddress);
+        connectionManager.addReconServer(reconAddress,
+            context.getThreadNamePrefix());
         this.context.addEndpoint(reconAddress);
       }
     }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/transport/server/XceiverServerGrpc.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/transport/server/XceiverServerGrpc.java
@@ -114,11 +114,13 @@ public final class XceiverServerGrpc implements XceiverServerSpi {
         60, TimeUnit.SECONDS,
         new LinkedBlockingQueue<>(),
         new ThreadFactoryBuilder().setDaemon(true)
-            .setNameFormat("ChunkReader-%d")
+            .setNameFormat(datanodeDetails.threadNamePrefix() +
+                "ChunkReader-%d")
             .build());
 
     ThreadFactory factory = new ThreadFactoryBuilder().setDaemon(true)
-        .setNameFormat("ChunkReader-ELG-%d")
+        .setNameFormat(datanodeDetails.threadNamePrefix() +
+            "ChunkReader-ELG-%d")
         .build();
 
     if (Epoll.isAvailable()) {

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/transport/server/XceiverServerGrpc.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/transport/server/XceiverServerGrpc.java
@@ -118,7 +118,8 @@ public final class XceiverServerGrpc implements XceiverServerSpi {
                 "ChunkReader-%d")
             .build());
 
-    ThreadFactory factory = new ThreadFactoryBuilder().setDaemon(true)
+    ThreadFactory factory = new ThreadFactoryBuilder()
+        .setDaemon(true)
         .setNameFormat(datanodeDetails.threadNamePrefix() +
             "ChunkReader-ELG-%d")
         .build();

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/transport/server/ratis/XceiverServerRatis.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/transport/server/ratis/XceiverServerRatis.java
@@ -167,13 +167,14 @@ public final class XceiverServerRatis implements XceiverServerSpi {
     this.dispatcher = dispatcher;
     this.containerController = containerController;
     this.raftPeerId = RatisHelper.toRaftPeerId(dd);
-    chunkExecutors = createChunkExecutors(conf);
+    String threadNamePrefix = datanodeDetails.threadNamePrefix();
+    chunkExecutors = createChunkExecutors(conf, threadNamePrefix);
     nodeFailureTimeoutMs =
-            conf.getObject(DatanodeRatisServerConfig.class)
-                    .getFollowerSlownessTimeout();
+        conf.getObject(DatanodeRatisServerConfig.class)
+            .getFollowerSlownessTimeout();
     shouldDeleteRatisLogDirectory =
-            conf.getObject(DatanodeRatisServerConfig.class)
-                    .shouldDeleteRatisLogDirectory();
+        conf.getObject(DatanodeRatisServerConfig.class)
+            .shouldDeleteRatisLogDirectory();
 
     RaftServer.Builder builder =
         RaftServer.newBuilder().setServerId(raftPeerId)
@@ -215,7 +216,7 @@ public final class XceiverServerRatis implements XceiverServerSpi {
 
   private ContainerStateMachine getStateMachine(RaftGroupId gid) {
     return new ContainerStateMachine(gid, dispatcher, containerController,
-        chunkExecutors, this, conf);
+        chunkExecutors, this, conf, datanodeDetails.threadNamePrefix());
   }
 
   private void setUpRatisStream(RaftProperties properties) {
@@ -920,7 +921,7 @@ public final class XceiverServerRatis implements XceiverServerSpi {
   }
 
   private static List<ThreadPoolExecutor> createChunkExecutors(
-      ConfigurationSource conf) {
+      ConfigurationSource conf, String threadNamePrefix) {
     // TODO create single pool with N threads if using non-incremental chunks
     final int threadCountPerDisk = conf.getInt(
         OzoneConfigKeys
@@ -936,7 +937,7 @@ public final class XceiverServerRatis implements XceiverServerSpi {
     for (int i = 0; i < executors.length; i++) {
       ThreadFactory threadFactory = new ThreadFactoryBuilder()
           .setDaemon(true)
-          .setNameFormat("ChunkWriter-" + i + "-%d")
+          .setNameFormat(threadNamePrefix + "ChunkWriter-" + i + "-%d")
           .build();
       BlockingQueue<Runnable> workQueue = new LinkedBlockingDeque<>();
       executors[i] = new ThreadPoolExecutor(1, 1,

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/ec/reconstruction/ECReconstructionCoordinator.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/ec/reconstruction/ECReconstructionCoordinator.java
@@ -69,6 +69,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.SynchronousQueue;
+import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
@@ -114,17 +115,23 @@ public class ECReconstructionCoordinator implements Closeable {
   public ECReconstructionCoordinator(
       ConfigurationSource conf, CertificateClient certificateClient,
       SecretKeySignerClient secretKeyClient, StateContext context,
-      ECReconstructionMetrics metrics) throws IOException {
+      ECReconstructionMetrics metrics,
+      String threadNamePrefix) throws IOException {
     this.context = context;
     this.containerOperationClient = new ECContainerOperationClient(conf,
         certificateClient);
     this.byteBufferPool = new ElasticByteBufferPool();
+    ThreadFactory threadFactory = new ThreadFactoryBuilder()
+        .setNameFormat(threadNamePrefix + "ec-reconstruct-reader-TID-%d")
+        .build();
     this.ecReconstructExecutor =
         new ThreadPoolExecutor(EC_RECONSTRUCT_STRIPE_READ_POOL_MIN_SIZE,
             conf.getObject(OzoneClientConfig.class)
-                .getEcReconstructStripeReadPoolLimit(), 60, TimeUnit.SECONDS,
-            new SynchronousQueue<>(), new ThreadFactoryBuilder()
-            .setNameFormat("ec-reconstruct-reader-TID-%d").build(),
+                .getEcReconstructStripeReadPoolLimit(),
+            60,
+            TimeUnit.SECONDS,
+            new SynchronousQueue<>(),
+            threadFactory,
             new ThreadPoolExecutor.CallerRunsPolicy());
     this.blockInputStreamFactory = BlockInputStreamFactoryImpl
         .getInstance(byteBufferPool, () -> ecReconstructExecutor);

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/ozoneimpl/OzoneContainer.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/ozoneimpl/OzoneContainer.java
@@ -296,8 +296,10 @@ public class OzoneContainer {
     ContainerInspectorUtil.load();
     while (volumeSetIterator.hasNext()) {
       StorageVolume volume = volumeSetIterator.next();
-      Thread thread = new Thread(new ContainerReader(volumeSet,
-          (HddsVolume) volume, containerSet, config, true));
+      ContainerReader containerReader = new ContainerReader(volumeSet,
+          (HddsVolume) volume, containerSet, config, true);
+      Thread thread = new Thread(containerReader,
+          datanodeDetails.threadNamePrefix());
       thread.start();
       volumeThreads.add(thread);
     }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/ozoneimpl/OzoneContainer.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/ozoneimpl/OzoneContainer.java
@@ -141,7 +141,8 @@ public class OzoneContainer {
     config = conf;
     this.datanodeDetails = datanodeDetails;
     this.context = context;
-    this.volumeChecker = new StorageVolumeChecker(conf, new Timer());
+    this.volumeChecker = new StorageVolumeChecker(conf, new Timer(),
+        datanodeDetails.threadNamePrefix());
 
     volumeSet = new MutableVolumeSet(datanodeDetails.getUuidString(), conf,
         context, VolumeType.DATA_VOLUME, volumeChecker);
@@ -211,7 +212,8 @@ public class OzoneContainer {
         secConf,
         certClient,
         new ContainerImporter(conf, containerSet, controller,
-            volumeSet));
+            volumeSet),
+        datanodeDetails.threadNamePrefix());
 
     readChannel = new XceiverServerGrpc(
         datanodeDetails, config, hddsDispatcher, certClient);

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/replication/ReplicationServer.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/replication/ReplicationServer.java
@@ -19,6 +19,7 @@ package org.apache.hadoop.ozone.container.replication;
 
 import java.io.IOException;
 import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 
@@ -69,7 +70,8 @@ public class ReplicationServer {
 
   public ReplicationServer(ContainerController controller,
       ReplicationConfig replicationConfig, SecurityConfig secConf,
-      CertificateClient caClient, ContainerImporter importer) {
+      CertificateClient caClient, ContainerImporter importer,
+      String threadNamePrefix) {
     this.secConf = secConf;
     this.caClient = caClient;
     this.controller = controller;
@@ -81,17 +83,20 @@ public class ReplicationServer {
     int replicationQueueLimit =
         replicationConfig.getReplicationQueueLimit();
     LOG.info("Initializing replication server with thread count = {}"
-        + " queue length = {}",
+            + " queue length = {}",
         replicationConfig.getReplicationMaxStreams(),
         replicationConfig.getReplicationQueueLimit());
-    this.executor =
-        new ThreadPoolExecutor(replicationServerWorkers,
-            replicationServerWorkers,
-            60, TimeUnit.SECONDS,
-            new LinkedBlockingQueue<>(replicationQueueLimit),
-            new ThreadFactoryBuilder().setDaemon(true)
-                .setNameFormat("ReplicationContainerReader-%d")
-                .build());
+    ThreadFactory threadFactory = new ThreadFactoryBuilder().setDaemon(true)
+        .setNameFormat(threadNamePrefix + "ReplicationContainerReader" +
+            "-%d")
+        .build();
+    this.executor = new ThreadPoolExecutor(
+        replicationServerWorkers,
+        replicationServerWorkers,
+        60,
+        TimeUnit.SECONDS,
+        new LinkedBlockingQueue<>(replicationQueueLimit),
+        threadFactory);
 
     init();
   }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/replication/ReplicationServer.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/replication/ReplicationServer.java
@@ -86,9 +86,9 @@ public class ReplicationServer {
             + " queue length = {}",
         replicationConfig.getReplicationMaxStreams(),
         replicationConfig.getReplicationQueueLimit());
-    ThreadFactory threadFactory = new ThreadFactoryBuilder().setDaemon(true)
-        .setNameFormat(threadNamePrefix + "ReplicationContainerReader" +
-            "-%d")
+    ThreadFactory threadFactory = new ThreadFactoryBuilder()
+        .setDaemon(true)
+        .setNameFormat(threadNamePrefix + "ReplicationContainerReader-%d")
         .build();
     this.executor = new ThreadPoolExecutor(
         replicationServerWorkers,

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/ContainerTestUtils.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/ContainerTestUtils.java
@@ -110,7 +110,7 @@ public final class ContainerTestUtils {
     StorageContainerDatanodeProtocolClientSideTranslatorPB rpcClient =
         new StorageContainerDatanodeProtocolClientSideTranslatorPB(rpcProxy);
     return new EndpointStateMachine(address, rpcClient,
-        new LegacyHadoopConfigurationSource(conf));
+        new LegacyHadoopConfigurationSource(conf), "");
   }
 
   public static OzoneContainer getOzoneContainer(

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/TestDatanodeStateMachine.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/TestDatanodeStateMachine.java
@@ -120,7 +120,7 @@ public class TestDatanodeStateMachine {
     conf.set(ScmConfigKeys.OZONE_SCM_DATANODE_ID_DIR, path);
     executorService = HadoopExecutors.newCachedThreadPool(
         new ThreadFactoryBuilder().setDaemon(true)
-            .setNameFormat("Test Data Node State Machine Thread - %d").build());
+            .setNameFormat("TestDataNodeStateMachineThread-%d").build());
   }
 
   @AfterEach

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/report/TestReportPublisher.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/report/TestReportPublisher.java
@@ -109,7 +109,7 @@ public class TestReportPublisher {
     ScheduledExecutorService executorService = HadoopExecutors
         .newScheduledThreadPool(1,
             new ThreadFactoryBuilder().setDaemon(true)
-                .setNameFormat("Unit test ReportManager Thread - %d").build());
+                .setNameFormat("TestReportManagerThread-%d").build());
     publisher.init(dummyContext, executorService);
     Thread.sleep(150);
     Assertions.assertEquals(1,
@@ -131,7 +131,7 @@ public class TestReportPublisher {
     ScheduledExecutorService executorService = HadoopExecutors
         .newScheduledThreadPool(1,
             new ThreadFactoryBuilder().setDaemon(true)
-                .setNameFormat("Unit test ReportManager Thread - %d").build());
+                .setNameFormat("TestReportManagerThread-%d").build());
     publisher.init(dummyContext, executorService);
     Thread.sleep(150);
     executorService.shutdown();
@@ -155,7 +155,7 @@ public class TestReportPublisher {
     ScheduledExecutorService executorService = HadoopExecutors
         .newScheduledThreadPool(1,
             new ThreadFactoryBuilder().setDaemon(true)
-                .setNameFormat("Unit test ReportManager Thread - %d").build());
+                .setNameFormat("TestReportManagerThread-%d").build());
     publisher.init(dummyContext, executorService);
     Assertions.assertNull(
         ((CommandStatusReportPublisher) publisher).getReport());
@@ -200,7 +200,7 @@ public class TestReportPublisher {
     ScheduledExecutorService executorService = HadoopExecutors
         .newScheduledThreadPool(1,
             new ThreadFactoryBuilder().setDaemon(true)
-                .setNameFormat("Unit test ReportManager Thread - %d").build());
+                .setNameFormat("TestReportManagerThread-%d").build());
     publisher.init(dummyContext, executorService);
     Message report =
         ((CRLStatusReportPublisher) publisher).getReport();

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/statemachine/TestStateContext.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/statemachine/TestStateContext.java
@@ -85,7 +85,7 @@ public class TestStateContext {
         mock(DatanodeStateMachine.class);
 
     StateContext ctx = new StateContext(conf, DatanodeStates.getInitState(),
-        datanodeStateMachineMock);
+        datanodeStateMachineMock, "");
     InetSocketAddress scm1 = new InetSocketAddress("scm1", 9001);
     ctx.addEndpoint(scm1);
     InetSocketAddress scm2 = new InetSocketAddress("scm2", 9001);
@@ -300,7 +300,7 @@ public class TestStateContext {
   private StateContext newStateContext(OzoneConfiguration conf,
       DatanodeStateMachine datanodeStateMachineMock) {
     StateContext stateContext = new StateContext(conf,
-        DatanodeStates.getInitState(), datanodeStateMachineMock);
+        DatanodeStates.getInitState(), datanodeStateMachineMock, "");
     InetSocketAddress scm1 = new InetSocketAddress("scm1", 9001);
     stateContext.addEndpoint(scm1);
     InetSocketAddress scm2 = new InetSocketAddress("scm2", 9001);
@@ -328,7 +328,7 @@ public class TestStateContext {
     DatanodeStateMachine datanodeStateMachineMock =
         mock(DatanodeStateMachine.class);
     StateContext stateContext = new StateContext(conf,
-        DatanodeStates.getInitState(), datanodeStateMachineMock);
+        DatanodeStates.getInitState(), datanodeStateMachineMock, "");
 
     InetSocketAddress scm1 = new InetSocketAddress("scm1", 9001);
     InetSocketAddress scm2 = new InetSocketAddress("scm2", 9001);
@@ -365,7 +365,7 @@ public class TestStateContext {
     DatanodeStateMachine datanodeStateMachineMock =
         mock(DatanodeStateMachine.class);
     StateContext stateContext = new StateContext(conf,
-        DatanodeStates.getInitState(), datanodeStateMachineMock);
+        DatanodeStates.getInitState(), datanodeStateMachineMock, "");
 
     InetSocketAddress scm1 = new InetSocketAddress("scm1", 9001);
     InetSocketAddress scm2 = new InetSocketAddress("scm2", 9001);
@@ -429,7 +429,7 @@ public class TestStateContext {
     final AtomicBoolean taskExecuted = new AtomicBoolean();
 
     StateContext subject = new StateContext(new OzoneConfiguration(),
-        DatanodeStates.getInitState(), mock(DatanodeStateMachine.class)) {
+        DatanodeStates.getInitState(), mock(DatanodeStateMachine.class), "") {
       @Override
       public DatanodeState<DatanodeStates> getTask() {
         // this task waits until {@code subject} is shutdown
@@ -478,7 +478,7 @@ public class TestStateContext {
   @Test
   public void testIsThreadPoolAvailable() throws Exception {
     StateContext stateContext = new StateContext(
-        new OzoneConfiguration(), null, null);
+        new OzoneConfiguration(), null, null, "");
 
     int threadPoolSize = 2;
     ExecutorService executorService = Executors.newFixedThreadPool(
@@ -514,7 +514,7 @@ public class TestStateContext {
     executorService.submit((Callable<String>) future::get);
 
     StateContext subject = new StateContext(new OzoneConfiguration(),
-        DatanodeStates.INIT, mock(DatanodeStateMachine.class)) {
+        DatanodeStates.INIT, mock(DatanodeStateMachine.class), "") {
       @Override
       public DatanodeState<DatanodeStates> getTask() {
         // this task counts the number of execute() and await() calls
@@ -564,7 +564,7 @@ public class TestStateContext {
         mock(DatanodeStateMachine.class);
 
     StateContext ctx = new StateContext(conf, DatanodeStates.getInitState(),
-        datanodeStateMachineMock);
+        datanodeStateMachineMock, "");
     InetSocketAddress scm1 = new InetSocketAddress("scm1", 9001);
     ctx.addEndpoint(scm1);
     InetSocketAddress scm2 = new InetSocketAddress("scm2", 9001);
@@ -678,7 +678,7 @@ public class TestStateContext {
             StorageContainerDatanodeProtocolProtos
                 .ContainerReportsProto.getDefaultInstance());
     return new StateContext(conf, DatanodeStates.getInitState(),
-        datanodeStateMachineMock);
+        datanodeStateMachineMock, "");
   }
 
   private static SCMCommand<?> someCommand() {

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/TestCloseContainerCommandHandler.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/TestCloseContainerCommandHandler.java
@@ -70,7 +70,7 @@ public class TestCloseContainerCommandHandler {
   private ContainerController controller;
   private ContainerSet containerSet;
   private CloseContainerCommandHandler subject =
-      new CloseContainerCommandHandler(1, 1000);
+      new CloseContainerCommandHandler(1, 1000, "");
 
   private final ContainerLayoutVersion layout;
 

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/TestDeleteBlocksCommandHandler.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/TestDeleteBlocksCommandHandler.java
@@ -124,7 +124,7 @@ public class TestDeleteBlocksCommandHandler {
         conf.getObject(DatanodeConfiguration.class);
 
     handler = spy(new DeleteBlocksCommandHandler(
-        ozoneContainer, conf, dnConf));
+        ozoneContainer, conf, dnConf, ""));
     blockDeleteMetrics = handler.getBlockDeleteMetrics();
     TestSchemaHandler testSchemaHandler1 = Mockito.spy(new TestSchemaHandler());
     TestSchemaHandler testSchemaHandler2 = Mockito.spy(new TestSchemaHandler());

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/TestDeleteContainerCommandHandler.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/TestDeleteContainerCommandHandler.java
@@ -168,7 +168,7 @@ public class TestDeleteContainerCommandHandler {
 
   private static DeleteContainerCommandHandler createSubjectWithPoolSize(
       TestClock clock, int queueSize) {
-    return new DeleteContainerCommandHandler(1, clock, queueSize);
+    return new DeleteContainerCommandHandler(1, clock, queueSize, "");
   }
 
 }

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/states/datanode/TestRunningDatanodeState.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/states/datanode/TestRunningDatanodeState.java
@@ -57,7 +57,7 @@ public class TestRunningDatanodeState {
     state.setExecutorCompletionService(ecs);
 
     for (int i = 0; i < threadPoolSize; i++) {
-      stateMachines.add(new EndpointStateMachine(null, null, null));
+      stateMachines.add(new EndpointStateMachine(null, null, null, ""));
     }
 
     CompletableFuture<EndpointStateMachine.EndPointStates> futureOne =

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/states/endpoint/TestHeartbeatEndpointTask.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/states/endpoint/TestHeartbeatEndpointTask.java
@@ -95,7 +95,7 @@ public class TestHeartbeatEndpointTask {
     DatanodeStateMachine datanodeStateMachine =
         Mockito.mock(DatanodeStateMachine.class);
     StateContext context = new StateContext(conf, DatanodeStates.RUNNING,
-        datanodeStateMachine);
+        datanodeStateMachine, "");
 
     // WHEN
     HeartbeatEndpointTask task = getHeartbeatEndpointTask(conf, context, scm);
@@ -125,7 +125,7 @@ public class TestHeartbeatEndpointTask {
 
     OzoneConfiguration conf = new OzoneConfiguration();
     StateContext context = new StateContext(conf, DatanodeStates.RUNNING,
-        Mockito.mock(DatanodeStateMachine.class));
+        Mockito.mock(DatanodeStateMachine.class), "");
     context.setTermOfLeaderSCM(1);
     HeartbeatEndpointTask endpointTask = getHeartbeatEndpointTask(
         conf, context, scm);
@@ -145,7 +145,7 @@ public class TestHeartbeatEndpointTask {
   public void testheartbeatWithNodeReports() throws Exception {
     OzoneConfiguration conf = new OzoneConfiguration();
     StateContext context = new StateContext(conf, DatanodeStates.RUNNING,
-        Mockito.mock(DatanodeStateMachine.class));
+        Mockito.mock(DatanodeStateMachine.class), "");
 
     StorageContainerDatanodeProtocolClientSideTranslatorPB scm =
         Mockito.mock(
@@ -177,7 +177,7 @@ public class TestHeartbeatEndpointTask {
   public void testheartbeatWithContainerReports() throws Exception {
     OzoneConfiguration conf = new OzoneConfiguration();
     StateContext context = new StateContext(conf, DatanodeStates.RUNNING,
-        Mockito.mock(DatanodeStateMachine.class));
+        Mockito.mock(DatanodeStateMachine.class), "");
 
     StorageContainerDatanodeProtocolClientSideTranslatorPB scm =
         Mockito.mock(
@@ -209,7 +209,7 @@ public class TestHeartbeatEndpointTask {
   public void testheartbeatWithCommandStatusReports() throws Exception {
     OzoneConfiguration conf = new OzoneConfiguration();
     StateContext context = new StateContext(conf, DatanodeStates.RUNNING,
-        Mockito.mock(DatanodeStateMachine.class));
+        Mockito.mock(DatanodeStateMachine.class), "");
 
     StorageContainerDatanodeProtocolClientSideTranslatorPB scm =
         Mockito.mock(
@@ -242,7 +242,7 @@ public class TestHeartbeatEndpointTask {
   public void testheartbeatWithContainerActions() throws Exception {
     OzoneConfiguration conf = new OzoneConfiguration();
     StateContext context = new StateContext(conf, DatanodeStates.RUNNING,
-        Mockito.mock(DatanodeStateMachine.class));
+        Mockito.mock(DatanodeStateMachine.class), "");
 
     StorageContainerDatanodeProtocolClientSideTranslatorPB scm =
         Mockito.mock(
@@ -276,7 +276,7 @@ public class TestHeartbeatEndpointTask {
     DatanodeStateMachine datanodeStateMachine =
         Mockito.mock(DatanodeStateMachine.class);
     StateContext context = new StateContext(conf, DatanodeStates.RUNNING,
-        datanodeStateMachine);
+        datanodeStateMachine, "");
 
     // Return a Map of command counts when the heartbeat logic requests it
     final Map<SCMCommandProto.Type, Integer> commands = new HashMap<>();

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/volume/TestPeriodicVolumeChecker.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/volume/TestPeriodicVolumeChecker.java
@@ -89,7 +89,8 @@ public class TestPeriodicVolumeChecker {
 
     FakeTimer timer = new FakeTimer();
 
-    StorageVolumeChecker volumeChecker = new StorageVolumeChecker(conf, timer);
+    StorageVolumeChecker volumeChecker = new StorageVolumeChecker(conf, timer,
+        "");
 
     try {
       volumeChecker.registerVolumeSet(new ImmutableVolumeSet(makeVolumes(

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/volume/TestStorageVolumeChecker.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/volume/TestStorageVolumeChecker.java
@@ -156,7 +156,7 @@ public class TestStorageVolumeChecker {
     LOG.info("Executing {}", testName.getMethodName());
     final HddsVolume volume = makeVolumes(1, expectedVolumeHealth).get(0);
     final StorageVolumeChecker checker =
-        new StorageVolumeChecker(new OzoneConfiguration(), new FakeTimer());
+        new StorageVolumeChecker(new OzoneConfiguration(), new FakeTimer(), "");
     checker.setDelegateChecker(new DummyChecker());
     final AtomicLong numCallbackInvocations = new AtomicLong(0);
 
@@ -200,7 +200,7 @@ public class TestStorageVolumeChecker {
     final List<HddsVolume> volumes = makeVolumes(
         NUM_VOLUMES, expectedVolumeHealth);
     final StorageVolumeChecker checker =
-        new StorageVolumeChecker(new OzoneConfiguration(), new FakeTimer());
+        new StorageVolumeChecker(new OzoneConfiguration(), new FakeTimer(), "");
     checker.setDelegateChecker(new DummyChecker());
 
     Set<? extends StorageVolume> failedVolumes =

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/volume/TestVolumeSetDiskChecks.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/volume/TestVolumeSetDiskChecks.java
@@ -373,7 +373,7 @@ public class TestVolumeSetDiskChecks {
 
     DummyChecker(ConfigurationSource conf, Timer timer, int numBadVolumes)
         throws DiskErrorException {
-      super(conf, timer);
+      super(conf, timer, "");
       this.numBadVolumes = numBadVolumes;
     }
 

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/volume/TestVolumeSetDiskChecks.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/volume/TestVolumeSetDiskChecks.java
@@ -325,7 +325,7 @@ public class TestVolumeSetDiskChecks {
     StateContext stateContext = new StateContext(
         new OzoneConfiguration(), DatanodeStateMachine
         .DatanodeStates.getInitState(),
-        datanodeStateMachineMock);
+        datanodeStateMachineMock, "");
     InetSocketAddress scm1 = new InetSocketAddress("scm1", 9001);
     stateContext.addEndpoint(scm1);
     when(datanodeStateMachineMock.getContainer()).thenReturn(ozoneContainer);

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/replication/TestReplicationSupervisor.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/replication/TestReplicationSupervisor.java
@@ -131,7 +131,7 @@ public class TestReplicationSupervisor {
     context = new StateContext(
         new OzoneConfiguration(),
         DatanodeStateMachine.DatanodeStates.getInitState(),
-        stateMachine);
+        stateMachine, "");
     context.setTermOfLeaderSCM(CURRENT_TERM);
     datanode = MockDatanodeDetails.randomDatanodeDetails();
     Mockito.when(stateMachine.getDatanodeDetails()).thenReturn(datanode);

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/ozone/container/common/TestEndPoint.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/ozone/container/common/TestEndPoint.java
@@ -575,7 +575,7 @@ public class TestEndPoint {
 
       final StateContext stateContext =
           new StateContext(conf, DatanodeStateMachine.DatanodeStates.RUNNING,
-              stateMachine);
+              stateMachine, "");
 
       HeartbeatEndpointTask endpointTask =
           new HeartbeatEndpointTask(rpcEndPoint, conf, stateContext,

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/storage/TestContainerCommandsEC.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/storage/TestContainerCommandsEC.java
@@ -266,15 +266,10 @@ public class TestContainerCommandsEC {
     scm.getPipelineManager().closePipeline(orphanPipeline, false);
 
     // Find the datanode hosting Replica index = 2
-    DatanodeDetails dn2 = null;
     HddsDatanodeService dn2Service = null;
     List<DatanodeDetails> pipelineNodes = orphanPipeline.getNodes();
-    for (DatanodeDetails node : pipelineNodes) {
-      if (orphanPipeline.getReplicaIndex(node) == 2) {
-        dn2 = node;
-        break;
-      }
-    }
+    DatanodeDetails dn2 = findDatanodeWithIndex(
+        orphanPipeline, pipelineNodes, 2);
     // Find the Cluster node corresponding to the datanode hosting index = 2
     for (HddsDatanodeService dn : cluster.getHddsDatanodes()) {
       if (dn.getDatanodeDetails().equals(dn2)) {
@@ -363,8 +358,9 @@ public class TestContainerCommandsEC {
     }
 
     try (ECReconstructionCoordinator coordinator =
-        new ECReconstructionCoordinator(config, certClient, secretKeyClient,
-            null, ECReconstructionMetrics.create())) {
+             new ECReconstructionCoordinator(config, certClient,
+                 secretKeyClient, null,
+                 ECReconstructionMetrics.create(), "")) {
 
       // Attempt to reconstruct the container.
       coordinator.reconstructECContainerGroup(orphanContainerID,
@@ -388,6 +384,16 @@ public class TestContainerCommandsEC {
       Assert.assertEquals(0L, count);
       Assert.assertEquals(0, response.getBlockDataList().size());
     }
+  }
+
+  private DatanodeDetails findDatanodeWithIndex(Pipeline orphanPipeline,
+      List<DatanodeDetails> pipelineNodes, int index) {
+    for (DatanodeDetails node : pipelineNodes) {
+      if (orphanPipeline.getReplicaIndex(node) == index) {
+        return node;
+      }
+    }
+    return null;
   }
 
   @Test
@@ -581,7 +587,7 @@ public class TestContainerCommandsEC {
             new XceiverClientManager(config);
         ECReconstructionCoordinator coordinator =
             new ECReconstructionCoordinator(config, certClient, secretKeyClient,
-                 null, ECReconstructionMetrics.create())) {
+                null, ECReconstructionMetrics.create(), "2")) {
 
       ECReconstructionMetrics metrics =
           coordinator.getECReconstructionMetrics();
@@ -776,8 +782,9 @@ public class TestContainerCommandsEC {
 
     Assert.assertThrows(IOException.class, () -> {
       try (ECReconstructionCoordinator coordinator =
-          new ECReconstructionCoordinator(config, certClient,  secretKeyClient,
-              null, ECReconstructionMetrics.create())) {
+               new ECReconstructionCoordinator(config, certClient,
+                   secretKeyClient,
+                   null, ECReconstructionMetrics.create(), "")) {
         coordinator.reconstructECContainerGroup(conID,
             (ECReplicationConfig) containerPipeline.getReplicationConfig(),
             sourceNodeMap, targetNodeMap);


### PR DESCRIPTION
## What changes were proposed in this pull request?

MiniOzoneCluster test logs are hard to follow because earlier they didn't contain the thread names. This change fixes it for the Datanode side by adding a prefix that identifies it.

This is a smaller task under a series of tasks [improve thread names](https://issues.apache.org/jira/browse/HDDS-8719)
 
## How was this patch tested?
Run existing unit/integration test through github: https://github.com/Galsza/ozone/actions/runs/6639296207
Run docker based tests and observed logs. 