### PR TITLE
HDDS-9436. Intermittent failure in TestOzoneSnapshotRestore#testUnorderedDeletion

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/snapshot/TestOzoneSnapshotRestore.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/snapshot/TestOzoneSnapshotRestore.java
@@ -225,12 +225,11 @@ public class TestOzoneSnapshotRestore {
 
     String snapshotKeyPrefix = createSnapshot(volume, bucket, snapshotName);
 
-    int volBucketKeyCount = keyCount(buck, snapshotKeyPrefix + keyPrefix);
-    Assertions.assertEquals(5, volBucketKeyCount);
+    assertDoesNotThrow(() -> waitForKeyCount(buck, snapshotKeyPrefix + keyPrefix,
+        5));
 
     deleteKeys(buck);
-    int delKeyCount = keyCount(buck, keyPrefix);
-    Assertions.assertEquals(0, delKeyCount);
+    assertDoesNotThrow(() -> waitForKeyCount(buck, keyPrefix, 0));
 
     String sourcePath = OM_KEY_PREFIX + volume + OM_KEY_PREFIX + bucket
         + OM_KEY_PREFIX + snapshotKeyPrefix;
@@ -269,8 +268,9 @@ public class TestOzoneSnapshotRestore {
 
     String snapshotKeyPrefix = createSnapshot(volume, bucket, snapshotName);
 
-    int volBucketKeyCount = keyCount(buck, snapshotKeyPrefix + keyPrefix);
-    Assertions.assertEquals(5, volBucketKeyCount);
+    assertDoesNotThrow(() -> waitForKeyCount(buck, snapshotKeyPrefix + keyPrefix,
+        5));
+
 
     // Delete keys from the source bucket.
     // This is temporary fix to make sure that test passes all the time.
@@ -328,8 +328,8 @@ public class TestOzoneSnapshotRestore {
 
     String snapshotKeyPrefix = createSnapshot(volume, bucket, snapshotName);
 
-    int volBucketKeyCount = keyCount(buck, snapshotKeyPrefix + keyPrefix);
-    Assertions.assertEquals(5, volBucketKeyCount);
+    assertDoesNotThrow(() -> waitForKeyCount(buck, snapshotKeyPrefix + keyPrefix,
+        5));
 
     String sourcePath = OM_KEY_PREFIX + volume + OM_KEY_PREFIX + bucket
         + OM_KEY_PREFIX + snapshotKeyPrefix;
@@ -345,7 +345,6 @@ public class TestOzoneSnapshotRestore {
 
   @ParameterizedTest
   @MethodSource("bucketTypes")
-  @Flaky("HDDS-9436")
   public void testUnorderedDeletion(BucketLayout bucketLayoutTest)
           throws Exception {
     String volume = "vol-" + counter.incrementAndGet();
@@ -377,8 +376,7 @@ public class TestOzoneSnapshotRestore {
 
     // delete all keys in bucket before restoring from snapshot
     deleteKeys(buck);
-    int keyCountAfterDelete = keyCount(buck, "key-");
-    Assertions.assertEquals(0, keyCountAfterDelete);
+    assertDoesNotThrow(() -> waitForKeyCount(buck, "key-", 0));
 
     String sourcePath = OM_KEY_PREFIX + volume + OM_KEY_PREFIX + bucket
             + OM_KEY_PREFIX + snapshotKeyPrefix[9];

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/snapshot/TestOzoneSnapshotRestore.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/snapshot/TestOzoneSnapshotRestore.java
@@ -42,7 +42,6 @@ import org.apache.hadoop.ozone.om.helpers.BucketLayout;
 import org.apache.hadoop.ozone.om.helpers.SnapshotInfo;
 import org.apache.hadoop.util.ToolRunner;
 import org.apache.ozone.test.GenericTestUtils;
-import org.apache.ozone.test.tag.Flaky;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
@@ -225,8 +224,8 @@ public class TestOzoneSnapshotRestore {
 
     String snapshotKeyPrefix = createSnapshot(volume, bucket, snapshotName);
 
-    assertDoesNotThrow(() -> waitForKeyCount(buck, snapshotKeyPrefix + keyPrefix,
-        5));
+    assertDoesNotThrow(() -> waitForKeyCount(buck,
+        snapshotKeyPrefix + keyPrefix, 5));
 
     deleteKeys(buck);
     assertDoesNotThrow(() -> waitForKeyCount(buck, keyPrefix, 0));
@@ -268,8 +267,8 @@ public class TestOzoneSnapshotRestore {
 
     String snapshotKeyPrefix = createSnapshot(volume, bucket, snapshotName);
 
-    assertDoesNotThrow(() -> waitForKeyCount(buck, snapshotKeyPrefix + keyPrefix,
-        5));
+    assertDoesNotThrow(() -> waitForKeyCount(buck,
+        snapshotKeyPrefix + keyPrefix, 5));
 
 
     // Delete keys from the source bucket.
@@ -328,8 +327,8 @@ public class TestOzoneSnapshotRestore {
 
     String snapshotKeyPrefix = createSnapshot(volume, bucket, snapshotName);
 
-    assertDoesNotThrow(() -> waitForKeyCount(buck, snapshotKeyPrefix + keyPrefix,
-        5));
+    assertDoesNotThrow(() -> waitForKeyCount(buck,
+        snapshotKeyPrefix + keyPrefix, 5));
 
     String sourcePath = OM_KEY_PREFIX + volume + OM_KEY_PREFIX + bucket
         + OM_KEY_PREFIX + snapshotKeyPrefix;


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fix intermittent failure in the test by waiting so that create/delete operations are finished properly before key count is done

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-9436

## How was this patch tested?

Ran test multiple times
```
[INFO] -------------------------------------------------------
[INFO]  T E S T S
[INFO] -------------------------------------------------------
[INFO] Running org.apache.hadoop.ozone.om.snapshot.TestOzoneSnapshotRestore
[INFO] Tests run: 8, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 62.567 s - in org.apache.hadoop.ozone.om.snapshot.TestOzoneSnapshotRestore
[INFO]
[INFO] Results:
[INFO]
[INFO] Tests run: 8, Failures: 0, Errors: 0, Skipped: 0
```
