### PR TITLE
HDDS-8871. Intermittent failure in TestOpenKeyCleanupService

### DIFF
--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/service/TestOpenKeyCleanupService.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/service/TestOpenKeyCleanupService.java
@@ -107,7 +107,9 @@ class TestOpenKeyCleanupService {
 
   @AfterEach
   public void cleanup() throws Exception {
-    om.stop();
+    if (om.stop()) {
+      om.join();
+    }
   }
 
   /**

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/service/TestOpenKeyCleanupService.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/service/TestOpenKeyCleanupService.java
@@ -166,7 +166,6 @@ class TestOpenKeyCleanupService {
         SERVICE_INTERVAL, WAIT_TIME);
     assertAtLeast(oldrunCount + 2, openKeyCleanupService.getRunCount());
 
-    final int n = hsync ? numDEFKeys + numFSOKeys : 1;
     waitForOpenKeyCleanup(false, BucketLayout.DEFAULT);
     waitForOpenKeyCleanup(hsync, BucketLayout.FILE_SYSTEM_OPTIMIZED);
 

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/service/TestOpenKeyCleanupService.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/service/TestOpenKeyCleanupService.java
@@ -67,16 +67,7 @@ import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_OPEN_KEY_EXPIRE_T
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-/**
- * Test Key Deleting Service.
- * <p>
- * This test does the following things.
- * <p>
- * 1. Creates a bunch of keys. 2. Then executes delete key directly using
- * Metadata Manager. 3. Waits for a while for the KeyDeleting Service to pick up
- * and call into SCM. 4. Confirms that calls have been successful.
- */
-public class TestOpenKeyCleanupService {
+class TestOpenKeyCleanupService {
   private OzoneManagerProtocol writeClient;
   private OzoneManager om;
   private static final Logger LOG =

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/service/TestOpenKeyCleanupService.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/service/TestOpenKeyCleanupService.java
@@ -172,7 +172,7 @@ public class TestOpenKeyCleanupService {
             oldkeyCount + keyCount,
         (int) SERVICE_INTERVAL.toMillis(),
         5 * (int) SERVICE_INTERVAL.toMillis());
-    assertAtLeast(oldrunCount + 1, openKeyCleanupService.getRunCount());
+    assertAtLeast(oldrunCount + 2, openKeyCleanupService.getRunCount());
 
     final int n = hsync ? numDEFKeys + numFSOKeys : 1;
     waitForOpenKeyCleanup(false, BucketLayout.DEFAULT, n);
@@ -310,7 +310,7 @@ public class TestOpenKeyCleanupService {
             oldkeyCount + numExpiredParts,
         (int) SERVICE_INTERVAL.toMillis(),
         5 * (int) SERVICE_INTERVAL.toMillis());
-    assertAtLeast(oldrunCount + 1, openKeyCleanupService.getRunCount());
+    assertAtLeast(oldrunCount + 2, openKeyCleanupService.getRunCount());
 
     // No expired MPU parts fetched
     waitForOpenKeyCleanup(false, BucketLayout.DEFAULT, 1);
@@ -345,7 +345,7 @@ public class TestOpenKeyCleanupService {
       throws Exception {
     GenericTestUtils.waitFor(() -> 0 == getExpiredOpenKeys(hsync, layout),
         (int) SERVICE_INTERVAL.toMillis(),
-        n * (int) SERVICE_INTERVAL.toMillis());
+        (int) Math.max(n * SERVICE_INTERVAL.toMillis(), EXPIRE_THRESHOLD.toMillis()));
   }
 
   private void createOpenKeys(int keyCount, boolean hsync,

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/service/TestOpenKeyCleanupService.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/service/TestOpenKeyCleanupService.java
@@ -166,7 +166,9 @@ class TestOpenKeyCleanupService {
     GenericTestUtils.waitFor(
         () -> openKeyCleanupService.getSubmittedOpenKeyCount() >= keyCount,
         SERVICE_INTERVAL, WAIT_TIME);
-    assertAtLeast(oldrunCount + 2, openKeyCleanupService.getRunCount());
+    GenericTestUtils.waitFor(
+        () -> openKeyCleanupService.getRunCount() >= oldrunCount + 2,
+        SERVICE_INTERVAL, WAIT_TIME);
 
     waitForOpenKeyCleanup(false, BucketLayout.DEFAULT);
     waitForOpenKeyCleanup(hsync, BucketLayout.FILE_SYSTEM_OPTIMIZED);
@@ -231,7 +233,7 @@ class TestOpenKeyCleanupService {
     openKeyCleanupService.resume();
 
     GenericTestUtils.waitFor(
-        () -> openKeyCleanupService.getRunCount() > oldrunCount + 1,
+        () -> openKeyCleanupService.getRunCount() >= oldrunCount + 2,
         SERVICE_INTERVAL, WAIT_TIME);
 
     // wait for requests to complete
@@ -300,7 +302,9 @@ class TestOpenKeyCleanupService {
     GenericTestUtils.waitFor(
         () -> openKeyCleanupService.getSubmittedOpenKeyCount() >= partCount,
         SERVICE_INTERVAL, WAIT_TIME);
-    assertAtLeast(oldrunCount + 2, openKeyCleanupService.getRunCount());
+    GenericTestUtils.waitFor(
+        () -> openKeyCleanupService.getRunCount() >= oldrunCount + 2,
+        SERVICE_INTERVAL, WAIT_TIME);
 
     // No expired MPU parts fetched
     waitForOpenKeyCleanup(false, BucketLayout.DEFAULT);

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/service/TestOpenKeyCleanupService.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/service/TestOpenKeyCleanupService.java
@@ -20,7 +20,7 @@
 package org.apache.hadoop.ozone.om.service;
 
 import org.apache.commons.lang3.RandomUtils;
-import org.apache.hadoop.hdds.client.StandaloneReplicationConfig;
+import org.apache.hadoop.hdds.client.RatisReplicationConfig;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.hdds.scm.container.common.helpers.ExcludeList;
@@ -394,7 +394,7 @@ public class TestOpenKeyCleanupService {
             .setBucketName(bucketName)
             .setKeyName(keyName)
             .setAcls(Collections.emptyList())
-            .setReplicationConfig(StandaloneReplicationConfig.getInstance(
+            .setReplicationConfig(RatisReplicationConfig.getInstance(
                 HddsProtos.ReplicationFactor.ONE))
             .setLocationInfoList(new ArrayList<>())
             .build();
@@ -447,7 +447,7 @@ public class TestOpenKeyCleanupService {
             .setBucketName(bucketName)
             .setKeyName(keyName)
             .setAcls(Collections.emptyList())
-            .setReplicationConfig(StandaloneReplicationConfig.getInstance(
+            .setReplicationConfig(RatisReplicationConfig.getInstance(
                 HddsProtos.ReplicationFactor.ONE))
             .setLocationInfoList(new ArrayList<>())
             .build();
@@ -466,7 +466,7 @@ public class TestOpenKeyCleanupService {
               .setMultipartUploadID(omMultipartInfo.getUploadID())
               .setMultipartUploadPartNumber(i)
               .setAcls(Collections.emptyList())
-              .setReplicationConfig(StandaloneReplicationConfig.getInstance(
+              .setReplicationConfig(RatisReplicationConfig.getInstance(
                   HddsProtos.ReplicationFactor.ONE))
               .build();
 
@@ -482,7 +482,7 @@ public class TestOpenKeyCleanupService {
                 .setMultipartUploadID(omMultipartInfo.getUploadID())
                 .setMultipartUploadPartNumber(i)
                 .setAcls(Collections.emptyList())
-                .setReplicationConfig(StandaloneReplicationConfig.getInstance(
+                .setReplicationConfig(RatisReplicationConfig.getInstance(
                     HddsProtos.ReplicationFactor.ONE))
                 .setLocationInfoList(Collections.emptyList())
                 .build();

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/service/TestOpenKeyCleanupService.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/service/TestOpenKeyCleanupService.java
@@ -171,8 +171,7 @@ public class TestOpenKeyCleanupService {
     openKeyCleanupService.resume();
 
     GenericTestUtils.waitFor(
-        () -> openKeyCleanupService.getSubmittedOpenKeyCount() >=
-            oldkeyCount + keyCount,
+        () -> openKeyCleanupService.getSubmittedOpenKeyCount() >= keyCount,
         SERVICE_INTERVAL, WAIT_TIME);
     assertAtLeast(oldrunCount + 2, openKeyCleanupService.getRunCount());
 
@@ -289,7 +288,7 @@ public class TestOpenKeyCleanupService {
     assertEquals(0, metrics.getNumOpenKeysCleaned());
     assertEquals(0, metrics.getNumOpenKeysHSyncCleaned());
     final int keyCount = numDEFKeys + numFSOKeys;
-    int numExpiredParts = NUM_MPU_PARTS * keyCount;
+    final int partCount = NUM_MPU_PARTS * keyCount;
     createIncompleteMPUKeys(numDEFKeys, BucketLayout.DEFAULT, NUM_MPU_PARTS,
         false);
     createIncompleteMPUKeys(numFSOKeys, BucketLayout.FILE_SYSTEM_OPTIMIZED,
@@ -307,15 +306,14 @@ public class TestOpenKeyCleanupService {
     openKeyCleanupService.resume();
 
     GenericTestUtils.waitFor(
-        () -> openKeyCleanupService.getSubmittedOpenKeyCount() >=
-            oldkeyCount + numExpiredParts,
+        () -> openKeyCleanupService.getSubmittedOpenKeyCount() >= partCount,
         SERVICE_INTERVAL, WAIT_TIME);
     assertAtLeast(oldrunCount + 2, openKeyCleanupService.getRunCount());
 
     // No expired MPU parts fetched
     waitForOpenKeyCleanup(false, BucketLayout.DEFAULT);
     waitForOpenKeyCleanup(false, BucketLayout.FILE_SYSTEM_OPTIMIZED);
-    assertAtLeast(numExpiredParts, metrics.getNumOpenKeysCleaned());
+    assertAtLeast(partCount, metrics.getNumOpenKeysCleaned());
   }
 
   private static void assertAtLeast(long expectedMinimum, long actual) {

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/service/TestOpenKeyCleanupService.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/service/TestOpenKeyCleanupService.java
@@ -288,9 +288,9 @@ class TestOpenKeyCleanupService {
 
     // Each MPU keys create 1 MPU open key and some MPU open part keys
     // only the MPU open part keys will be deleted
-    assertExpiredOpenKeys((numDEFKeys * NUM_MPU_PARTS) == 0, false,
+    assertExpiredOpenKeys(numDEFKeys == 0, false,
         BucketLayout.DEFAULT);
-    assertExpiredOpenKeys((numFSOKeys * NUM_MPU_PARTS) == 0, false,
+    assertExpiredOpenKeys(numFSOKeys == 0, false,
         BucketLayout.FILE_SYSTEM_OPTIMIZED);
 
     openKeyCleanupService.resume();

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/service/TestOpenKeyCleanupService.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/service/TestOpenKeyCleanupService.java
@@ -172,8 +172,9 @@ public class TestOpenKeyCleanupService {
         (int) SERVICE_INTERVAL.toMillis(),
         5 * (int) SERVICE_INTERVAL.toMillis());
 
-    waitForOpenKeyCleanup(false, BucketLayout.DEFAULT);
-    waitForOpenKeyCleanup(hsync, BucketLayout.FILE_SYSTEM_OPTIMIZED);
+    final int n = hsync ? numDEFKeys + numFSOKeys : 1;
+    waitForOpenKeyCleanup(false, BucketLayout.DEFAULT, n);
+    waitForOpenKeyCleanup(hsync, BucketLayout.FILE_SYSTEM_OPTIMIZED, n);
     assertTrue(openKeyCleanupService.getSubmittedOpenKeyCount() >=
         oldkeyCount + keyCount);
 
@@ -310,8 +311,8 @@ public class TestOpenKeyCleanupService {
 
     // No expired MPU parts fetched
     int numExpiredParts = NUM_MPU_PARTS * keyCount;
-    waitForOpenKeyCleanup(false, BucketLayout.DEFAULT);
-    waitForOpenKeyCleanup(false, BucketLayout.FILE_SYSTEM_OPTIMIZED);
+    waitForOpenKeyCleanup(false, BucketLayout.DEFAULT, 1);
+    waitForOpenKeyCleanup(false, BucketLayout.FILE_SYSTEM_OPTIMIZED, 1);
     assertTrue(openKeyCleanupService.getSubmittedOpenKeyCount() >=
         (oldkeyCount + numExpiredParts));
     assertAtLeast(numExpiredParts, metrics.getNumOpenKeysCleaned());
@@ -340,11 +341,11 @@ public class TestOpenKeyCleanupService {
     }
   }
 
-  void waitForOpenKeyCleanup(boolean hsync,
-      BucketLayout layout) throws Exception {
+  void waitForOpenKeyCleanup(boolean hsync, BucketLayout layout, int n)
+      throws Exception {
     GenericTestUtils.waitFor(() -> 0 == getExpiredOpenKeys(hsync, layout),
         (int) SERVICE_INTERVAL.toMillis(),
-        2 * (int) EXPIRE_THRESHOLD.toMillis());
+        n * (int) SERVICE_INTERVAL.toMillis());
   }
 
   private void createOpenKeys(int keyCount, boolean hsync,

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/service/TestOpenKeyCleanupService.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/service/TestOpenKeyCleanupService.java
@@ -175,12 +175,12 @@ public class TestOpenKeyCleanupService {
     final int n = hsync ? numDEFKeys + numFSOKeys : 1;
     waitForOpenKeyCleanup(false, BucketLayout.DEFAULT, n);
     waitForOpenKeyCleanup(hsync, BucketLayout.FILE_SYSTEM_OPTIMIZED, n);
-    assertTrue(openKeyCleanupService.getSubmittedOpenKeyCount() >=
-        oldkeyCount + keyCount);
+    assertAtLeast(oldkeyCount + keyCount,
+        openKeyCleanupService.getSubmittedOpenKeyCount());
 
     if (hsync) {
       assertAtLeast(numDEFKeys, metrics.getNumOpenKeysCleaned());
-      assertTrue(metrics.getNumOpenKeysHSyncCleaned() >= numFSOKeys);
+      assertAtLeast(numFSOKeys, metrics.getNumOpenKeysHSyncCleaned());
       assertEquals(numFSOKeys, metrics.getNumKeyHSyncs());
     } else {
       assertAtLeast(keyCount, metrics.getNumOpenKeysCleaned());
@@ -313,8 +313,8 @@ public class TestOpenKeyCleanupService {
     int numExpiredParts = NUM_MPU_PARTS * keyCount;
     waitForOpenKeyCleanup(false, BucketLayout.DEFAULT, 1);
     waitForOpenKeyCleanup(false, BucketLayout.FILE_SYSTEM_OPTIMIZED, 1);
-    assertTrue(openKeyCleanupService.getSubmittedOpenKeyCount() >=
-        (oldkeyCount + numExpiredParts));
+    assertAtLeast(oldkeyCount + numExpiredParts,
+        openKeyCleanupService.getSubmittedOpenKeyCount());
     assertAtLeast(numExpiredParts, metrics.getNumOpenKeysCleaned());
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fix intermittent failure in `TestOpenKeyCleanupService`.

There were several small items that contributed to the failures:

1. The test waited until `runCount` was incremented, then made some assertions.  However, `runCount` is incremented at the start of the cleanup task, so the other changes may have not been done when the test checked.  It needs to wait for `submittedKeyCount` to reach the expected value, since this counter is increased as the last step of the task.
2. `OpenKeyCleanupService` performs two tasks per run (processes different bucket layouts separately).  Tests use a combination of keys in the two layouts, hence it needs to wait until `runCount` is increased by both tasks.
3. OM is stopped after each test case.  We need to wait (`join()`) for it to finish stopping.
4. Instead of fixed amount of `sleep`, use `waitFor` in more places.  Use longer max. wait time to avoid intermittent timeouts.

Additional changes:

* replace repeated `(int) SERVICE_INTERVAL.toMillis()` with constant value
* remove unrelated class comment (leftover from `TestKeyDeletingService`)
* add assertion message for `assertTrue(... >= ...)` to get actual values in case of failure
* replace `STAND_ALONE` replication with `RATIS`, to avoid warnings from `QuotaUtil` in the log

https://issues.apache.org/jira/browse/HDDS-8871

## How was this patch tested?

Executed the test 500 times twice:
https://github.com/adoroszlai/hadoop-ozone/actions/runs/6638564445
https://github.com/adoroszlai/hadoop-ozone/actions/runs/6640547634

Regular CI:
https://github.com/adoroszlai/hadoop-ozone/actions/runs/6641074083