### PR TITLE
HDDS-9546. Fix possible deadlock during shutdown in OzoneDelegationTokenSecretManager

### DIFF
--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/security/OzoneDelegationTokenSecretManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/security/OzoneDelegationTokenSecretManager.java
@@ -71,8 +71,7 @@ public class OzoneDelegationTokenSecretManager
   private final S3SecretManager s3SecretManager;
   private Thread tokenRemoverThread;
   private final long tokenRemoverScanInterval;
-  private String omCertificateSerialId;
-  private String omServiceId;
+  private final String omServiceId;
   private final OzoneManager ozoneManager;
 
   /**
@@ -81,7 +80,7 @@ public class OzoneDelegationTokenSecretManager
    */
   private final Object noInterruptsLock = new Object();
 
-  private boolean isRatisEnabled;
+  private final boolean isRatisEnabled;
 
   /**
    * Create a secret manager with a builder object.
@@ -187,10 +186,6 @@ public class OzoneDelegationTokenSecretManager
   /**
    * Returns {@link Token} for given identifier.
    *
-   * @param owner
-   * @param renewer
-   * @param realUser
-   * @return Token
    * @throws IOException to allow future exceptions to be added without breaking
    * compatibility
    */
@@ -221,8 +216,6 @@ public class OzoneDelegationTokenSecretManager
 
   /**
    * Add delegation token in to in-memory map of tokens.
-   * @param token
-   * @param ozoneTokenIdentifier
    * @return renewTime - If updated successfully, return renewTime.
    */
   public long updateToken(Token<OzoneTokenIdentifier> token,
@@ -236,10 +229,6 @@ public class OzoneDelegationTokenSecretManager
 
   /**
    * Stores given identifier in token store.
-   *
-   * @param identifier
-   * @param password
-   * @throws IOException
    */
   private void addToTokenStore(OzoneTokenIdentifier identifier,
       byte[] password, long renewTime)
@@ -393,8 +382,6 @@ public class OzoneDelegationTokenSecretManager
 
   /**
    * Remove the expired token from in-memory map.
-   * @param ozoneTokenIdentifier
-   * @throws IOException
    */
   public void removeToken(OzoneTokenIdentifier ozoneTokenIdentifier) {
     currentTokens.remove(ozoneTokenIdentifier);
@@ -446,13 +433,10 @@ public class OzoneDelegationTokenSecretManager
 
   /**
    * Validates if given hash is valid.
-   *
-   * @param identifier
-   * @param password
    */
   public boolean verifySignature(OzoneTokenIdentifier identifier,
       byte[] password) {
-    X509Certificate signerCert = null;
+    X509Certificate signerCert;
     try {
       signerCert = getCertClient().getCertificate(
           identifier.getOmCertSerialId());
@@ -592,8 +576,6 @@ public class OzoneDelegationTokenSecretManager
 
   /**
    * Stops the OzoneDelegationTokenSecretManager.
-   *
-   * @throws IOException
    */
   @Override
   public void stop() throws IOException {

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/security/OzoneDelegationTokenSecretManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/security/OzoneDelegationTokenSecretManager.java
@@ -79,7 +79,7 @@ public class OzoneDelegationTokenSecretManager
    * If the delegation token update thread holds this lock, it will not get
    * interrupted.
    */
-  private Object noInterruptsLock = new Object();
+  private final Object noInterruptsLock = new Object();
 
   private boolean isRatisEnabled;
 
@@ -609,7 +609,7 @@ public class OzoneDelegationTokenSecretManager
    */
   private void removeExpiredToken() {
     long now = Time.now();
-    synchronized (this) {
+    synchronized (noInterruptsLock) {
       Iterator<Map.Entry<OzoneTokenIdentifier,
           TokenInfo>> i = currentTokens.entrySet().iterator();
       while (i.hasNext()) {


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fix deadlock during shutdown in `OzoneDelegationTokenSecretManager`:

```
"nullExpiredTokenRemover" 
   java.lang.Thread.State: BLOCKED
        at org.apache.hadoop.ozone.security.OzoneDelegationTokenSecretManager.removeExpiredToken(OzoneDelegationTokenSecretManager.java:612)
        at org.apache.hadoop.ozone.security.OzoneDelegationTokenSecretManager.access$4(OzoneDelegationTokenSecretManager.java:610)
        at org.apache.hadoop.ozone.security.OzoneDelegationTokenSecretManager$ExpiredTokenRemover.run(OzoneDelegationTokenSecretManager.java:647)
        at java.lang.Thread.run(Thread.java:750)

"main" 
   java.lang.Thread.State: WAITING
        at java.lang.Object.wait(Native Method)
        at java.lang.Thread.join(Thread.java:1257)
        at java.lang.Thread.join(Thread.java:1331)
        at org.apache.hadoop.ozone.security.OzoneDelegationTokenSecretManager.stopThreads(OzoneDelegationTokenSecretManager.java:584)
        at org.apache.hadoop.ozone.security.OzoneDelegationTokenSecretManager.stop(OzoneDelegationTokenSecretManager.java:601)
        at org.apache.hadoop.ozone.security.TestOzoneDelegationTokenSecretManager.tearDown(TestOzoneDelegationTokenSecretManager.java:179)
```

According to the comment on `noInterruptsLock`, the expired token remover task should be syncing on that instead of the `OzoneDelegationTokenSecretManager` instance.

https://issues.apache.org/jira/browse/HDDS-9546

## How was this patch tested?

Ran `TestOzoneDelegationTokenSecretManager` 100x successfully:
https://github.com/adoroszlai/hadoop-ozone/actions/runs/6652845828

Regular CI:
https://github.com/adoroszlai/hadoop-ozone/actions/runs/6652628509