### PR TITLE
HDDS-9547. Rename tests to follow ozone conventions.

### DIFF
--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/security/symmetric/TestLocalKeyStore.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/security/symmetric/TestLocalKeyStore.java
@@ -53,7 +53,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 /**
  * Test cases for {@link LocalSecretKeyStore}.
  */
-public class LocalSecretKeyStoreTest {
+public class TestLocalKeyStore {
   private SecretKeyStore secretKeyStore;
   private Path testSecretFile;
 

--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/security/symmetric/TestManagedSecretKey.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/security/symmetric/TestManagedSecretKey.java
@@ -34,7 +34,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 /**
  * Simple test cases for {@link ManagedSecretKey}.
  */
-public class ManagedSecretKeyTest {
+public class TestManagedSecretKey {
 
   @Test
   public void testSignAndVerifySuccess() throws Exception {

--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/security/symmetric/TestSecretKeyManager.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/security/symmetric/TestSecretKeyManager.java
@@ -46,7 +46,7 @@ import static org.mockito.Mockito.when;
 /**
  * Tests cases for {@link SecretKeyManager} implementation.
  */
-public class SecretKeyManagerTest {
+public class TestSecretKeyManager {
   private static final Duration VALIDITY_DURATION = Duration.ofDays(3);
   private static final Duration ROTATION_DURATION = Duration.ofDays(1);
   private static final String ALGORITHM = "HmacSHA256";

--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/server/http/TestHttpServer2Metrics.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/server/http/TestHttpServer2Metrics.java
@@ -42,7 +42,7 @@ import java.util.Random;
 /**
  * Testing HttpServer2Metrics.
  */
-public class TestHttpServer2MetricsTest {
+public class TestHttpServer2Metrics {
 
   private QueuedThreadPool threadPool;
   private MetricsCollector metricsCollector;

--- a/hadoop-ozone/s3-secret-store/src/test/java/org/apache/hadoop/ozone/s3/remote/vault/TestVaultS3SecretStore.java
+++ b/hadoop-ozone/s3-secret-store/src/test/java/org/apache/hadoop/ozone/s3/remote/vault/TestVaultS3SecretStore.java
@@ -44,7 +44,7 @@ import static org.mockito.Mockito.when;
 /**
  * Test suite for {@link VaultS3SecretStore}.
  */
-public class VaultS3SecretStoreTest {
+public class TestVaultS3SecretStore {
   private static final String TOKEN = "token";
   private static final AtomicInteger AUTH_OPERATION_PROVIDER
       = new AtomicInteger(0);


### PR DESCRIPTION
## What changes were proposed in this pull request?
Some tests don't follow the naming convention of starting a test name with Test...
Here I'm fixing the name of these tests.

This is also useful for ci scripting and running mvn test easier.

[HDDS-9547](https://issues.apache.org/jira/browse/HDDS-9547)

## How was this patch tested?

Run each changed test locally without failure, also there is CI run on my fork here:
https://github.com/Galsza/ozone/actions/runs/6655462537

To ensure there are no other tests like this:
```
find . -name "*Test.java"                      
./hadoop-hdds/test-utils/src/main/java/org/apache/ozone/test/UnhealthyTest.java
./hadoop-hdds/test-utils/src/main/java/org/apache/ozone/test/SlowTest.java
./hadoop-hdds/test-utils/src/main/java/org/apache/ozone/test/FlakyTest.java
./hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/replication/GrpcOutputStreamTest.java
./hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/persistence/AbstractReconSqlDBTest.java
./hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/scm/AbstractReconContainerManagerTest.java
```
Unhealthy/Slow/Flaky test are helper interfaces, and GrpcOutputStreamTest and the other two are abstract classes.
