### PR TITLE
HDDS-9493. Migrating tests in ozone-common to JUnit5

### DIFF
--- a/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/TestOmUtils.java
+++ b/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/TestOmUtils.java
@@ -18,14 +18,19 @@
 
 package org.apache.hadoop.ozone;
 
+import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.io.TempDir;
+
 import java.io.File;
 import java.io.IOException;
 import java.net.InetSocketAddress;
+import java.nio.file.Path;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-
-import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 
 import static org.apache.hadoop.ozone.OmUtils.getOmHostsFromConfig;
 import static org.apache.hadoop.ozone.OmUtils.getOzoneManagerServiceId;
@@ -33,35 +38,24 @@ import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_ADDRESS_KEY;
 import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_INTERNAL_SERVICE_ID;
 import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_NODES_KEY;
 import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_SERVICE_IDS_KEY;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assume.assumeTrue;
-
-import org.junit.Assert;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
-import org.junit.rules.TestRule;
-import org.junit.rules.Timeout;
-import org.apache.ozone.test.JUnit5AwareTimeout;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 /**
  * Unit tests for {@link OmUtils}.
  */
+@Timeout(60)
 public class TestOmUtils {
 
-  @Rule
-  public TemporaryFolder folder = new TemporaryFolder();
-
-  @Rule
-  public TestRule timeout = new JUnit5AwareTimeout(Timeout.seconds(60));
-
+  @TempDir
+  private Path folder;
 
   @Test
   public void createOMDirCreatesDirectoryIfNecessary() throws IOException {
-    File parent = folder.newFolder();
+    File parent = folder.toFile();
     File omDir = new File(new File(parent, "sub"), "dir");
     assertFalse(omDir.exists());
 
@@ -72,7 +66,7 @@ public class TestOmUtils {
 
   @Test
   public void createOMDirDoesNotThrowIfAlreadyExists() throws IOException {
-    File omDir = folder.newFolder();
+    File omDir = folder.toFile();
     assertTrue(omDir.exists());
 
     OmUtils.createOMDir(omDir.getAbsolutePath());
@@ -80,15 +74,16 @@ public class TestOmUtils {
     assertTrue(omDir.exists());
   }
 
-  @Test(expected = IllegalArgumentException.class)
-  public void createOMDirThrowsIfCannotCreate() throws IOException {
-    File parent = folder.newFolder();
-    File omDir = new File(new File(parent, "sub"), "dir");
-    assumeTrue(parent.setWritable(false, false));
+  @Test
+  public void createOMDirThrowsIfCannotCreate() {
+    Assertions.assertThrows(IllegalArgumentException.class, () -> {
+      File parent = folder.toFile();
+      File omDir = new File(new File(parent, "sub"), "dir");
+      assumeTrue(parent.setWritable(false, false));
 
-    OmUtils.createOMDir(omDir.getAbsolutePath());
-
-    // expecting exception
+      OmUtils.createOMDir(omDir.getAbsolutePath());
+      // expecting exception
+    });
   }
 
   @Test
@@ -129,7 +124,7 @@ public class TestOmUtils {
     configuration.set(OZONE_OM_SERVICE_IDS_KEY, "om2,om3");
     try {
       getOzoneManagerServiceId(configuration);
-      Assert.fail();
+      Assertions.fail();
     } catch (IOException ioEx) {
       assertTrue(ioEx.getMessage()
           .contains("Cannot find the internal service id om1 in [om2, om3]"));
@@ -147,7 +142,7 @@ public class TestOmUtils {
     configuration.set(OZONE_OM_SERVICE_IDS_KEY, "om2,om1");
     try {
       getOzoneManagerServiceId(configuration);
-      Assert.fail();
+      Assertions.fail();
     } catch (IOException ioEx) {
       assertTrue(ioEx.getMessage()
           .contains("More than 1 OzoneManager ServiceID (ozone.om.service" +
@@ -157,7 +152,7 @@ public class TestOmUtils {
 
   @Test
   public void checkMaxTransactionID() {
-    Assert.assertEquals((long) (Math.pow(2, 54) - 2), OmUtils.MAX_TRXN_ID);
+    Assertions.assertEquals((long) (Math.pow(2, 54) - 2), OmUtils.MAX_TRXN_ID);
   }
 
   @Test
@@ -175,16 +170,16 @@ public class TestOmUtils {
     conf.set(OZONE_OM_ADDRESS_KEY + "." + serviceId2 + ".om1", "om1-host");
 
     Set<String> hosts = getOmHostsFromConfig(conf, serviceId);
-    Assert.assertEquals(3, hosts.size());
-    Assert.assertTrue(hosts.contains("omA-host"));
-    Assert.assertTrue(hosts.contains("omB-host"));
-    Assert.assertTrue(hosts.contains("omC-host"));
+    Assertions.assertEquals(3, hosts.size());
+    Assertions.assertTrue(hosts.contains("omA-host"));
+    Assertions.assertTrue(hosts.contains("omB-host"));
+    Assertions.assertTrue(hosts.contains("omC-host"));
 
     hosts = getOmHostsFromConfig(conf, serviceId2);
-    Assert.assertEquals(1, hosts.size());
-    Assert.assertTrue(hosts.contains("om1-host"));
+    Assertions.assertEquals(1, hosts.size());
+    Assertions.assertTrue(hosts.contains("om1-host"));
 
-    Assert.assertTrue(getOmHostsFromConfig(conf, "newId").isEmpty());
+    Assertions.assertTrue(getOmHostsFromConfig(conf, "newId").isEmpty());
   }
 }
 

--- a/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/TestOzoneAcls.java
+++ b/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/TestOzoneAcls.java
@@ -19,9 +19,8 @@
 package org.apache.hadoop.ozone;
 
 import org.apache.hadoop.ozone.security.acl.IAccessAuthorizer.ACLIdentityType;
-
 import org.apache.hadoop.ozone.security.acl.IAccessAuthorizer.ACLType;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.HashMap;
 import java.util.List;
@@ -36,11 +35,11 @@ import static org.apache.hadoop.ozone.security.acl.IAccessAuthorizer.ACLType.REA
 import static org.apache.hadoop.ozone.security.acl.IAccessAuthorizer.ACLType.READ_ACL;
 import static org.apache.hadoop.ozone.security.acl.IAccessAuthorizer.ACLType.WRITE;
 import static org.apache.hadoop.ozone.security.acl.IAccessAuthorizer.ACLType.WRITE_ACL;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
  * This class is to test acl storage and retrieval in ozone store.
@@ -224,7 +223,7 @@ public class TestOzoneAcls {
     assertTrue(acl.getAclBitSet().get(READ_ACL.ordinal()));
     assertTrue(acl.getAclBitSet().get(WRITE_ACL.ordinal()));
     assertFalse(acl.getAclBitSet().get(ALL.ordinal()));
-    assertTrue(acl.getAclScope().equals(OzoneAcl.AclScope.DEFAULT));
+    assertEquals(acl.getAclScope(), OzoneAcl.AclScope.DEFAULT);
 
     acl = OzoneAcl.parseAcl("user:bilbo:rwdlncxy[ACCESS]");
     assertEquals(acl.getName(), "bilbo");
@@ -237,7 +236,7 @@ public class TestOzoneAcls {
     assertTrue(acl.getAclBitSet().get(READ_ACL.ordinal()));
     assertTrue(acl.getAclBitSet().get(WRITE_ACL.ordinal()));
     assertFalse(acl.getAclBitSet().get(ALL.ordinal()));
-    assertTrue(acl.getAclScope().equals(OzoneAcl.AclScope.ACCESS));
+    assertEquals(acl.getAclScope(), OzoneAcl.AclScope.ACCESS);
 
     acl = OzoneAcl.parseAcl("group:hadoop:rwdlncxy[ACCESS]");
     assertEquals(acl.getName(), "hadoop");
@@ -251,7 +250,7 @@ public class TestOzoneAcls {
     assertTrue(acl.getAclBitSet().get(WRITE_ACL.ordinal()));
     assertFalse(acl.getAclBitSet().get(ALL.ordinal()));
     assertEquals(ACLIdentityType.GROUP, acl.getType());
-    assertTrue(acl.getAclScope().equals(OzoneAcl.AclScope.ACCESS));
+    assertEquals(acl.getAclScope(), OzoneAcl.AclScope.ACCESS);
 
     acl = OzoneAcl.parseAcl("world::rwdlncxy[DEFAULT]");
     assertEquals(acl.getName(), "WORLD");

--- a/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/om/exceptions/TestResultCodes.java
+++ b/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/om/exceptions/TestResultCodes.java
@@ -20,8 +20,8 @@ package org.apache.hadoop.ozone.om.exceptions;
 import org.apache.hadoop.ozone.om.exceptions.OMException.ResultCodes;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.Status;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 /**
  * Test code mappping.
@@ -30,15 +30,16 @@ public class TestResultCodes {
 
   @Test
   public void codeMapping() {
-    Assert.assertEquals(ResultCodes.values().length, Status.values().length);
+    Assertions.assertEquals(ResultCodes.values().length,
+        Status.values().length);
     for (int i = 0; i < ResultCodes.values().length; i++) {
       ResultCodes codeValue = ResultCodes.values()[i];
       Status protoBufValue = Status.values()[i];
-      Assert.assertTrue(String
-          .format("Protobuf/Enum constant name mismatch %s %s", codeValue,
-              protoBufValue), sameName(codeValue.name(), protoBufValue.name()));
+      Assertions.assertTrue(sameName(codeValue.name(), protoBufValue.name()),
+          String.format("Protobuf/Enum constant name mismatch %s %s", codeValue,
+              protoBufValue));
       ResultCodes converted = ResultCodes.values()[protoBufValue.ordinal()];
-      Assert.assertEquals(codeValue, converted);
+      Assertions.assertEquals(codeValue, converted);
     }
   }
 

--- a/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/om/ha/TestOMFailoverProxyProvider.java
+++ b/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/om/ha/TestOMFailoverProxyProvider.java
@@ -27,9 +27,9 @@ import java.util.StringJoiner;
 import org.apache.hadoop.io.Text;
 import org.apache.hadoop.ozone.ha.ConfUtils;
 import org.apache.hadoop.ozone.om.protocolPB.OzoneManagerProtocolPB;
-import org.junit.Assert;
-import org.junit.Test;
-import org.junit.Before;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.BeforeEach;
 
 import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
@@ -53,7 +53,7 @@ public class TestOMFailoverProxyProvider {
   private int numNodes = 3;
   private OzoneConfiguration config;
 
-  @Before
+  @BeforeEach
   public void init() throws Exception {
     config = new OzoneConfiguration();
     waitBetweenRetries = config.getLong(
@@ -121,10 +121,10 @@ public class TestOMFailoverProxyProvider {
     Collection<String> allNodeIds = config.getTrimmedStringCollection(ConfUtils.
         addKeySuffixes(OZONE_OM_NODES_KEY, OM_SERVICE_ID));
     allNodeIds.remove(provider.getCurrentProxyOMNodeId());
-    Assert.assertTrue("This test needs at least 2 OMs",
-        allNodeIds.size() > 0);
+    Assertions.assertTrue(allNodeIds.size() > 0,
+        "This test needs at least 2 OMs");
     provider.setNextOmProxy(allNodeIds.iterator().next());
-    Assert.assertEquals(0, provider.getWaitTime());
+    Assertions.assertEquals(0, provider.getWaitTime());
   }
 
   /**
@@ -147,10 +147,10 @@ public class TestOMFailoverProxyProvider {
    * Failover to next node and wait time should be same as waitTimeAfter.
    */
   private void failoverToNextNode(int numNextNodeFailoverTimes,
-      long waitTimeAfter) {
+                                  long waitTimeAfter) {
     for (int attempt = 0; attempt < numNextNodeFailoverTimes; attempt++) {
       provider.selectNextOmProxy();
-      Assert.assertEquals(waitTimeAfter, provider.getWaitTime());
+      Assertions.assertEquals(waitTimeAfter, provider.getWaitTime());
       provider.performFailover(null);
     }
   }
@@ -162,7 +162,7 @@ public class TestOMFailoverProxyProvider {
     provider.performFailover(null);
     for (int attempt = 1; attempt <= numSameNodeFailoverTimes; attempt++) {
       provider.setNextOmProxy(provider.getCurrentProxyOMNodeId());
-      Assert.assertEquals(attempt * waitBetweenRetries,
+      Assertions.assertEquals(attempt * waitBetweenRetries,
           provider.getWaitTime());
     }
   }
@@ -175,29 +175,29 @@ public class TestOMFailoverProxyProvider {
     OzoneConfiguration ozoneConf = new OzoneConfiguration();
     ArrayList<String> nodeAddrs = new ArrayList<>(
         Arrays.asList("4.3.2.1:9862", "2.1.0.5:9862", "3.2.1.0:9862"));
-    Assert.assertEquals(numNodes, nodeAddrs.size());
+    Assertions.assertEquals(numNodes, nodeAddrs.size());
 
     StringJoiner allNodeIds = new StringJoiner(",");
     for (int i = 1; i <= numNodes; i++) {
       String nodeId = NODE_ID_BASE_STR + i;
       ozoneConf.set(
           ConfUtils.addKeySuffixes(OZONE_OM_ADDRESS_KEY, OM_SERVICE_ID,
-          nodeId), nodeAddrs.get(i - 1));
+              nodeId), nodeAddrs.get(i - 1));
       allNodeIds.add(nodeId);
     }
     ozoneConf.set(ConfUtils.addKeySuffixes(OZONE_OM_NODES_KEY, OM_SERVICE_ID),
         allNodeIds.toString());
     HadoopRpcOMFailoverProxyProvider prov =
-            new HadoopRpcOMFailoverProxyProvider(ozoneConf,
-                    UserGroupInformation.getCurrentUser(),
-                    OM_SERVICE_ID,
-                    OzoneManagerProtocolPB.class);
+        new HadoopRpcOMFailoverProxyProvider(ozoneConf,
+            UserGroupInformation.getCurrentUser(),
+            OM_SERVICE_ID,
+            OzoneManagerProtocolPB.class);
 
     Text dtService = prov.getCurrentProxyDelegationToken();
 
     Collections.sort(nodeAddrs);
     String expectedDtService = String.join(",", nodeAddrs);
-    Assert.assertEquals(expectedDtService, dtService.toString());
+    Assertions.assertEquals(expectedDtService, dtService.toString());
   }
 
 }

--- a/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/om/helpers/TestOmBucketArgs.java
+++ b/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/om/helpers/TestOmBucketArgs.java
@@ -20,8 +20,8 @@ package org.apache.hadoop.ozone.om.helpers;
 
 import org.apache.hadoop.hdds.client.DefaultReplicationConfig;
 import org.apache.hadoop.hdds.client.ECReplicationConfig;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import static org.apache.hadoop.hdds.client.ReplicationType.EC;
 
@@ -37,14 +37,14 @@ public class TestOmBucketArgs {
         .setVolumeName("volume")
         .build();
 
-    Assert.assertEquals(false, bucketArgs.hasQuotaInBytes());
-    Assert.assertEquals(false, bucketArgs.hasQuotaInNamespace());
+    Assertions.assertFalse(bucketArgs.hasQuotaInBytes());
+    Assertions.assertFalse(bucketArgs.hasQuotaInNamespace());
 
     OmBucketArgs argsFromProto = OmBucketArgs.getFromProtobuf(
         bucketArgs.getProtobuf());
 
-    Assert.assertEquals(false, argsFromProto.hasQuotaInBytes());
-    Assert.assertEquals(false, argsFromProto.hasQuotaInNamespace());
+    Assertions.assertFalse(argsFromProto.hasQuotaInBytes());
+    Assertions.assertFalse(argsFromProto.hasQuotaInNamespace());
 
     bucketArgs = OmBucketArgs.newBuilder()
         .setBucketName("bucket")
@@ -53,39 +53,39 @@ public class TestOmBucketArgs {
         .setQuotaInBytes(456)
         .build();
 
-    Assert.assertEquals(true, bucketArgs.hasQuotaInBytes());
-    Assert.assertEquals(true, bucketArgs.hasQuotaInNamespace());
+    Assertions.assertTrue(bucketArgs.hasQuotaInBytes());
+    Assertions.assertTrue(bucketArgs.hasQuotaInNamespace());
 
     argsFromProto = OmBucketArgs.getFromProtobuf(
         bucketArgs.getProtobuf());
 
-    Assert.assertEquals(true, argsFromProto.hasQuotaInBytes());
-    Assert.assertEquals(true, argsFromProto.hasQuotaInNamespace());
+    Assertions.assertTrue(argsFromProto.hasQuotaInBytes());
+    Assertions.assertTrue(argsFromProto.hasQuotaInNamespace());
   }
 
   @Test
   public void testDefaultReplicationConfigIsSetCorrectly() {
     OmBucketArgs bucketArgs = OmBucketArgs.newBuilder()
-            .setBucketName("bucket")
-            .setVolumeName("volume")
-            .build();
+        .setBucketName("bucket")
+        .setVolumeName("volume")
+        .build();
 
     OmBucketArgs argsFromProto = OmBucketArgs.getFromProtobuf(
-            bucketArgs.getProtobuf());
+        bucketArgs.getProtobuf());
 
-    Assert.assertEquals(null, argsFromProto.getDefaultReplicationConfig());
+    Assertions.assertNull(argsFromProto.getDefaultReplicationConfig());
 
     bucketArgs = OmBucketArgs.newBuilder()
-            .setBucketName("bucket")
-            .setVolumeName("volume")
-            .setDefaultReplicationConfig(new DefaultReplicationConfig(
-                    new ECReplicationConfig(3, 2)))
-            .build();
+        .setBucketName("bucket")
+        .setVolumeName("volume")
+        .setDefaultReplicationConfig(new DefaultReplicationConfig(
+            new ECReplicationConfig(3, 2)))
+        .build();
 
     argsFromProto = OmBucketArgs.getFromProtobuf(
-            bucketArgs.getProtobuf());
+        bucketArgs.getProtobuf());
 
-    Assert.assertEquals(EC,
-            argsFromProto.getDefaultReplicationConfig().getType());
+    Assertions.assertEquals(EC,
+        argsFromProto.getDefaultReplicationConfig().getType());
   }
 }

--- a/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/om/helpers/TestOmBucketInfo.java
+++ b/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/om/helpers/TestOmBucketInfo.java
@@ -26,8 +26,8 @@ import org.apache.hadoop.hdds.protocol.StorageType;
 import org.apache.hadoop.ozone.OzoneAcl;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos;
 import org.apache.hadoop.ozone.security.acl.IAccessAuthorizer;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 import org.apache.hadoop.util.Time;
 
 import java.util.Collections;
@@ -47,7 +47,7 @@ public class TestOmBucketInfo {
         .setStorageType(StorageType.ARCHIVE)
         .build();
 
-    Assert.assertEquals(bucket,
+    Assertions.assertEquals(bucket,
         OmBucketInfo.getFromProtobuf(bucket.getProtobuf()));
   }
 
@@ -60,7 +60,7 @@ public class TestOmBucketInfo {
         .setSourceBucket("someBucket")
         .build();
 
-    Assert.assertEquals(bucket,
+    Assertions.assertEquals(bucket,
         OmBucketInfo.getFromProtobuf(bucket.getProtobuf()));
   }
 
@@ -82,10 +82,10 @@ public class TestOmBucketInfo {
 
     /* Clone an omBucketInfo. */
     OmBucketInfo cloneBucketInfo = omBucketInfo.copyObject();
-    Assert.assertNotSame(omBucketInfo, cloneBucketInfo);
-    Assert.assertEquals("Expected " + omBucketInfo + " and " + cloneBucketInfo
-            + " to be equal",
-        omBucketInfo, cloneBucketInfo);
+    Assertions.assertNotSame(omBucketInfo, cloneBucketInfo);
+    Assertions.assertEquals(omBucketInfo, cloneBucketInfo,
+        "Expected " + omBucketInfo + " and " + cloneBucketInfo
+            + " to be equal");
 
     /* Reset acl & check not equal. */
     omBucketInfo.setAcls(Collections.singletonList(new OzoneAcl(
@@ -94,14 +94,14 @@ public class TestOmBucketInfo {
         IAccessAuthorizer.ACLType.WRITE_ACL,
         OzoneAcl.AclScope.ACCESS
     )));
-    Assert.assertNotEquals(
+    Assertions.assertNotEquals(
         omBucketInfo.getAcls().get(0),
         cloneBucketInfo.getAcls().get(0));
 
     /* Clone acl & check equal. */
     cloneBucketInfo = omBucketInfo.copyObject();
-    Assert.assertEquals(omBucketInfo, cloneBucketInfo);
-    Assert.assertEquals(
+    Assertions.assertEquals(omBucketInfo, cloneBucketInfo);
+    Assertions.assertEquals(
         omBucketInfo.getAcls().get(0),
         cloneBucketInfo.getAcls().get(0));
 
@@ -112,8 +112,8 @@ public class TestOmBucketInfo {
         IAccessAuthorizer.ACLType.WRITE_ACL,
         OzoneAcl.AclScope.ACCESS
     ));
-    Assert.assertEquals((int) 0, omBucketInfo.getAcls().size());
-    Assert.assertEquals((int) 1, cloneBucketInfo.getAcls().size());
+    Assertions.assertEquals(0, omBucketInfo.getAcls().size());
+    Assertions.assertEquals(1, cloneBucketInfo.getAcls().size());
 
   }
 
@@ -123,16 +123,17 @@ public class TestOmBucketInfo {
         OmBucketInfo.newBuilder().setBucketName("bucket").setVolumeName("vol1")
             .setCreationTime(Time.now()).setIsVersionEnabled(false)
             .setStorageType(StorageType.ARCHIVE).setAcls(Collections
-            .singletonList(new OzoneAcl(IAccessAuthorizer.ACLIdentityType.USER,
-                "defaultUser", IAccessAuthorizer.ACLType.WRITE_ACL,
-                OzoneAcl.AclScope.ACCESS))).build();
+                .singletonList(new OzoneAcl(
+                    IAccessAuthorizer.ACLIdentityType.USER,
+                    "defaultUser", IAccessAuthorizer.ACLType.WRITE_ACL,
+                    OzoneAcl.AclScope.ACCESS))).build();
     OzoneManagerProtocolProtos.BucketInfo protobuf = omBucketInfo.getProtobuf();
     // No EC Config
-    Assert.assertFalse(protobuf.hasDefaultReplicationConfig());
+    Assertions.assertFalse(protobuf.hasDefaultReplicationConfig());
 
     // Reconstruct object from Proto
     OmBucketInfo recovered = OmBucketInfo.getFromProtobuf(protobuf);
-    Assert.assertNull(recovered.getDefaultReplicationConfig());
+    Assertions.assertNull(recovered.getDefaultReplicationConfig());
 
     // EC Config
     omBucketInfo = OmBucketInfo.newBuilder()
@@ -150,20 +151,20 @@ public class TestOmBucketInfo {
                 new ECReplicationConfig(3, 2))).build();
     protobuf = omBucketInfo.getProtobuf();
 
-    Assert.assertTrue(protobuf.hasDefaultReplicationConfig());
-    Assert.assertEquals(3,
+    Assertions.assertTrue(protobuf.hasDefaultReplicationConfig());
+    Assertions.assertEquals(3,
         protobuf.getDefaultReplicationConfig().getEcReplicationConfig()
             .getData());
-    Assert.assertEquals(2,
+    Assertions.assertEquals(2,
         protobuf.getDefaultReplicationConfig().getEcReplicationConfig()
             .getParity());
 
     // Reconstruct object from Proto
     recovered = OmBucketInfo.getFromProtobuf(protobuf);
-    Assert.assertEquals(ReplicationType.EC,
+    Assertions.assertEquals(ReplicationType.EC,
         recovered.getDefaultReplicationConfig().getType());
     ReplicationConfig config =
         recovered.getDefaultReplicationConfig().getReplicationConfig();
-    Assert.assertEquals(new ECReplicationConfig(3, 2), config);
+    Assertions.assertEquals(new ECReplicationConfig(3, 2), config);
   }
 }

--- a/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/om/helpers/TestOmKeyInfo.java
+++ b/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/om/helpers/TestOmKeyInfo.java
@@ -32,8 +32,8 @@ import org.apache.hadoop.ozone.om.helpers.OmKeyInfo.Builder;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos;
 import org.apache.hadoop.ozone.security.acl.IAccessAuthorizer;
 import org.apache.hadoop.util.Time;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -59,11 +59,11 @@ public class TestOmKeyInfo {
     OmKeyInfo keyAfterSerialization = OmKeyInfo.getFromProtobuf(
         key.getProtobuf(ClientVersion.CURRENT_VERSION));
 
-    Assert.assertEquals(key, keyAfterSerialization);
+    Assertions.assertEquals(key, keyAfterSerialization);
 
-    Assert.assertFalse(key.isHsync());
+    Assertions.assertFalse(key.isHsync());
     key.getMetadata().put(OzoneConsts.HSYNC_CLIENT_ID, "clientid");
-    Assert.assertTrue(key.isHsync());
+    Assertions.assertTrue(key.isHsync());
   }
 
   @Test
@@ -74,37 +74,39 @@ public class TestOmKeyInfo {
         key.getProtobuf(ClientVersion.CURRENT_VERSION);
 
     // No EC Config
-    Assert.assertFalse(omKeyProto.hasEcReplicationConfig());
-    Assert.assertEquals(THREE, omKeyProto.getFactor());
-    Assert.assertEquals(RATIS, omKeyProto.getType());
+    Assertions.assertFalse(omKeyProto.hasEcReplicationConfig());
+    Assertions.assertEquals(THREE, omKeyProto.getFactor());
+    Assertions.assertEquals(RATIS, omKeyProto.getType());
 
     // Reconstruct object from Proto
     OmKeyInfo recovered = OmKeyInfo.getFromProtobuf(omKeyProto);
-    Assert.assertEquals(RATIS,
+    Assertions.assertEquals(RATIS,
         recovered.getReplicationConfig().getReplicationType());
-    Assert.assertTrue(
+    Assertions.assertTrue(
         recovered.getReplicationConfig() instanceof RatisReplicationConfig);
 
     // EC Config
     key = createOmKeyInfo(new ECReplicationConfig(3, 2));
-    Assert.assertFalse(key.isHsync());
+    Assertions.assertFalse(key.isHsync());
     omKeyProto = key.getProtobuf(ClientVersion.CURRENT_VERSION);
 
-    Assert.assertEquals(3, omKeyProto.getEcReplicationConfig().getData());
-    Assert.assertEquals(2, omKeyProto.getEcReplicationConfig().getParity());
-    Assert.assertFalse(omKeyProto.hasFactor());
-    Assert.assertEquals(EC, omKeyProto.getType());
+    Assertions.assertEquals(3,
+        omKeyProto.getEcReplicationConfig().getData());
+    Assertions.assertEquals(2,
+        omKeyProto.getEcReplicationConfig().getParity());
+    Assertions.assertFalse(omKeyProto.hasFactor());
+    Assertions.assertEquals(EC, omKeyProto.getType());
 
     // Reconstruct object from Proto
     recovered = OmKeyInfo.getFromProtobuf(omKeyProto);
-    Assert.assertEquals(EC,
+    Assertions.assertEquals(EC,
         recovered.getReplicationConfig().getReplicationType());
-    Assert.assertTrue(
+    Assertions.assertTrue(
         recovered.getReplicationConfig() instanceof ECReplicationConfig);
     ECReplicationConfig config =
         (ECReplicationConfig) recovered.getReplicationConfig();
-    Assert.assertEquals(3, config.getData());
-    Assert.assertEquals(2, config.getParity());
+    Assertions.assertEquals(3, config.getData());
+    Assertions.assertEquals(2, config.getParity());
   }
 
   private OmKeyInfo createOmKeyInfo(ReplicationConfig replicationConfig) {
@@ -151,10 +153,10 @@ public class TestOmKeyInfo {
 
     // OmKeyLocationInfoGroup has now implemented equals() method.
     // assertEquals should work now.
-    Assert.assertEquals(key, cloneKey);
+    Assertions.assertEquals(key, cloneKey);
 
     // Check each version content here.
-    Assert.assertEquals(key.getKeyLocationVersions().size(),
+    Assertions.assertEquals(key.getKeyLocationVersions().size(),
         cloneKey.getKeyLocationVersions().size());
 
     // Check blocks for each version.
@@ -162,16 +164,16 @@ public class TestOmKeyInfo {
       OmKeyLocationInfoGroup orig = key.getKeyLocationVersions().get(i);
       OmKeyLocationInfoGroup clone = key.getKeyLocationVersions().get(i);
 
-      Assert.assertEquals(orig.isMultipartKey(), clone.isMultipartKey());
-      Assert.assertEquals(orig.getVersion(), clone.getVersion());
+      Assertions.assertEquals(orig.isMultipartKey(), clone.isMultipartKey());
+      Assertions.assertEquals(orig.getVersion(), clone.getVersion());
 
-      Assert.assertEquals(orig.getLocationList().size(),
+      Assertions.assertEquals(orig.getLocationList().size(),
           clone.getLocationList().size());
 
       for (int j = 0; j < orig.getLocationList().size(); j++) {
         OmKeyLocationInfo origLocationInfo = orig.getLocationList().get(j);
         OmKeyLocationInfo cloneLocationInfo = clone.getLocationList().get(j);
-        Assert.assertEquals(origLocationInfo, cloneLocationInfo);
+        Assertions.assertEquals(origLocationInfo, cloneLocationInfo);
       }
     }
 
@@ -180,23 +182,23 @@ public class TestOmKeyInfo {
         IAccessAuthorizer.ACLType.WRITE, ACCESS)));
 
     // Change acls and check.
-    Assert.assertNotEquals(key, cloneKey);
+    Assertions.assertNotEquals(key, cloneKey);
 
-    Assert.assertNotEquals(key.getAcls(), cloneKey.getAcls());
+    Assertions.assertNotEquals(key.getAcls(), cloneKey.getAcls());
 
     // clone now again
     cloneKey = key.copyObject();
 
-    Assert.assertEquals(key.getAcls(), cloneKey.getAcls());
+    Assertions.assertEquals(key.getAcls(), cloneKey.getAcls());
   }
 
 
   private OmKeyLocationInfoGroup createOmKeyLocationInfoGroup(boolean isMPU) {
     List<OmKeyLocationInfo> omKeyLocationInfos = new ArrayList<>();
-    omKeyLocationInfos.add(getOmKeyLocationInfo(new BlockID(100L, 101L),
-        getPipeline()));
-    omKeyLocationInfos.add(getOmKeyLocationInfo(new BlockID(101L, 100L),
-        getPipeline()));
+    omKeyLocationInfos.add(getOmKeyLocationInfo(new BlockID(
+        100L, 101L), getPipeline()));
+    omKeyLocationInfos.add(getOmKeyLocationInfo(new BlockID(
+        101L, 100L), getPipeline()));
     return new OmKeyLocationInfoGroup(0, omKeyLocationInfos, isMPU);
 
   }
@@ -212,7 +214,7 @@ public class TestOmKeyInfo {
   }
 
   OmKeyLocationInfo getOmKeyLocationInfo(BlockID blockID,
-      Pipeline pipeline) {
+                                         Pipeline pipeline) {
     return new OmKeyLocationInfo.Builder()
         .setBlockID(blockID)
         .setPipeline(pipeline)

--- a/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/om/helpers/TestOmKeyLocationInfoGroup.java
+++ b/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/om/helpers/TestOmKeyLocationInfoGroup.java
@@ -16,8 +16,8 @@
  */
 package org.apache.hadoop.ozone.om.helpers;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -33,15 +33,16 @@ public class TestOmKeyLocationInfoGroup {
     OmKeyLocationInfoGroup testInstance = createTestInstance();
     List<OmKeyLocationInfo> latestList =
         testInstance.getBlocksLatestVersionOnly();
-    Assert.assertEquals(1, latestList.size());
-    Assert.assertEquals(2, latestList.get(0).getCreateVersion());
+    Assertions.assertEquals(1, latestList.size());
+    Assertions.assertEquals(2, latestList.get(0).getCreateVersion());
   }
 
   @Test
   public void testGettingPreviousVersions() {
     OmKeyLocationInfoGroup testInstance = createTestInstance();
-    Collection<OmKeyLocationInfo> list = testInstance.getLocationList(1L);
-    Assert.assertEquals(2, list.size());
+    Collection<OmKeyLocationInfo> list = testInstance.getLocationList(
+        1L);
+    Assertions.assertEquals(2, list.size());
   }
 
   @Test
@@ -50,9 +51,9 @@ public class TestOmKeyLocationInfoGroup {
     List<OmKeyLocationInfo> locationInfoList = createLocationList();
     OmKeyLocationInfoGroup newInstance =
         testInstance.generateNextVersion(locationInfoList);
-    Assert.assertEquals(1, newInstance.getLocationList().size());
+    Assertions.assertEquals(1, newInstance.getLocationList().size());
     // createTestInstance is of version 2, nextVersion should be 3
-    Assert.assertEquals(3, newInstance.getVersion());
+    Assertions.assertEquals(3, newInstance.getVersion());
 
   }
 

--- a/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/om/helpers/TestOmMultipartKeyInfo.java
+++ b/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/om/helpers/TestOmMultipartKeyInfo.java
@@ -27,14 +27,14 @@ import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.KeyInfo;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.PartKeyInfo;
 import org.apache.hadoop.util.Time;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.UUID;
 import java.util.stream.Stream;
 
 import static java.util.stream.Collectors.toList;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
 
 /**
  * Class to test OmMultipartKeyInfo.

--- a/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/om/helpers/TestOmMultipartUpload.java
+++ b/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/om/helpers/TestOmMultipartUpload.java
@@ -17,8 +17,8 @@
  */
 package org.apache.hadoop.ozone.om.helpers;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 /**
  * Test utilities inside OmMutipartUpload.
@@ -31,9 +31,9 @@ public class TestOmMultipartUpload {
         OmMultipartUpload.getDbKey("vol1", "bucket1", "dir1/key1", "uploadId");
     OmMultipartUpload info = OmMultipartUpload.from(key1);
 
-    Assert.assertEquals("vol1", info.getVolumeName());
-    Assert.assertEquals("bucket1", info.getBucketName());
-    Assert.assertEquals("dir1/key1", info.getKeyName());
-    Assert.assertEquals("uploadId", info.getUploadId());
+    Assertions.assertEquals("vol1", info.getVolumeName());
+    Assertions.assertEquals("bucket1", info.getBucketName());
+    Assertions.assertEquals("dir1/key1", info.getKeyName());
+    Assertions.assertEquals("uploadId", info.getUploadId());
   }
 }

--- a/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/om/helpers/TestOmSnapshotInfo.java
+++ b/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/om/helpers/TestOmSnapshotInfo.java
@@ -24,8 +24,8 @@ import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.SnapshotStatusProto;
 
 import org.apache.hadoop.util.Time;
-import org.junit.Test;
-import org.junit.Assert;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Assertions;
 
 import java.util.UUID;
 
@@ -102,7 +102,7 @@ public class TestOmSnapshotInfo {
   public void testSnapshotStatusProtoToObject() {
     OzoneManagerProtocolProtos.SnapshotInfo snapshotInfoEntry =
         createSnapshotInfoProto();
-    Assert.assertEquals(SNAPSHOT_STATUS,
+    Assertions.assertEquals(SNAPSHOT_STATUS,
         SnapshotStatus.valueOf(snapshotInfoEntry.getSnapshotStatus()));
   }
 
@@ -114,32 +114,34 @@ public class TestOmSnapshotInfo {
 
     OzoneManagerProtocolProtos.SnapshotInfo snapshotInfoEntryActual =
         snapshotInfo.getProtobuf();
-    Assert.assertEquals(snapshotInfoEntryExpected.getSnapshotID(),
+    Assertions.assertEquals(snapshotInfoEntryExpected.getSnapshotID(),
         snapshotInfoEntryActual.getSnapshotID());
-    Assert.assertEquals(snapshotInfoEntryExpected.getName(),
+    Assertions.assertEquals(snapshotInfoEntryExpected.getName(),
         snapshotInfoEntryActual.getName());
-    Assert.assertEquals(snapshotInfoEntryExpected.getVolumeName(),
+    Assertions.assertEquals(snapshotInfoEntryExpected.getVolumeName(),
         snapshotInfoEntryActual.getVolumeName());
-    Assert.assertEquals(snapshotInfoEntryExpected.getBucketName(),
+    Assertions.assertEquals(snapshotInfoEntryExpected.getBucketName(),
         snapshotInfoEntryActual.getBucketName());
-    Assert.assertEquals(snapshotInfoEntryExpected.getSnapshotStatus(),
+    Assertions.assertEquals(snapshotInfoEntryExpected.getSnapshotStatus(),
         snapshotInfoEntryActual.getSnapshotStatus());
-    Assert.assertEquals(snapshotInfoEntryExpected.getDbTxSequenceNumber(),
+    Assertions.assertEquals(snapshotInfoEntryExpected.getDbTxSequenceNumber(),
         snapshotInfoEntryActual.getDbTxSequenceNumber());
-    Assert.assertEquals(snapshotInfoEntryExpected.getDeepClean(),
+    Assertions.assertEquals(snapshotInfoEntryExpected.getDeepClean(),
         snapshotInfoEntryActual.getDeepClean());
-    Assert.assertEquals(snapshotInfoEntryExpected.getSstFiltered(),
+    Assertions.assertEquals(snapshotInfoEntryExpected.getSstFiltered(),
         snapshotInfoEntryActual.getSstFiltered());
-    Assert.assertEquals(snapshotInfoEntryExpected.getReferencedSize(),
+    Assertions.assertEquals(snapshotInfoEntryExpected.getReferencedSize(),
         snapshotInfoEntryActual.getReferencedSize());
-    Assert.assertEquals(snapshotInfoEntryExpected.getReferencedReplicatedSize(),
+    Assertions.assertEquals(
+        snapshotInfoEntryExpected.getReferencedReplicatedSize(),
         snapshotInfoEntryActual.getReferencedReplicatedSize());
-    Assert.assertEquals(snapshotInfoEntryExpected.getExclusiveSize(),
+    Assertions.assertEquals(snapshotInfoEntryExpected.getExclusiveSize(),
         snapshotInfoEntryActual.getExclusiveSize());
-    Assert.assertEquals(snapshotInfoEntryExpected.getExclusiveReplicatedSize(),
+    Assertions.assertEquals(
+        snapshotInfoEntryExpected.getExclusiveReplicatedSize(),
         snapshotInfoEntryActual.getExclusiveReplicatedSize());
 
-    Assert.assertEquals(snapshotInfoEntryExpected, snapshotInfoEntryActual);
+    Assertions.assertEquals(snapshotInfoEntryExpected, snapshotInfoEntryActual);
   }
 
   @Test
@@ -150,32 +152,32 @@ public class TestOmSnapshotInfo {
 
     SnapshotInfo snapshotInfoActual = SnapshotInfo
         .getFromProtobuf(snapshotInfoEntry);
-    Assert.assertEquals(snapshotInfoExpected.getSnapshotId(),
+    Assertions.assertEquals(snapshotInfoExpected.getSnapshotId(),
         snapshotInfoActual.getSnapshotId());
-    Assert.assertEquals(snapshotInfoExpected.getName(),
+    Assertions.assertEquals(snapshotInfoExpected.getName(),
         snapshotInfoActual.getName());
-    Assert.assertEquals(snapshotInfoExpected.getVolumeName(),
+    Assertions.assertEquals(snapshotInfoExpected.getVolumeName(),
         snapshotInfoActual.getVolumeName());
-    Assert.assertEquals(snapshotInfoExpected.getBucketName(),
+    Assertions.assertEquals(snapshotInfoExpected.getBucketName(),
         snapshotInfoActual.getBucketName());
-    Assert.assertEquals(snapshotInfoExpected.getSnapshotStatus(),
+    Assertions.assertEquals(snapshotInfoExpected.getSnapshotStatus(),
         snapshotInfoActual.getSnapshotStatus());
-    Assert.assertEquals(snapshotInfoExpected.getDbTxSequenceNumber(),
+    Assertions.assertEquals(snapshotInfoExpected.getDbTxSequenceNumber(),
         snapshotInfoActual.getDbTxSequenceNumber());
-    Assert.assertEquals(snapshotInfoExpected.getDeepClean(),
+    Assertions.assertEquals(snapshotInfoExpected.getDeepClean(),
         snapshotInfoActual.getDeepClean());
-    Assert.assertEquals(snapshotInfoExpected.isSstFiltered(),
+    Assertions.assertEquals(snapshotInfoExpected.isSstFiltered(),
         snapshotInfoActual.isSstFiltered());
-    Assert.assertEquals(snapshotInfoExpected.getReferencedSize(),
+    Assertions.assertEquals(snapshotInfoExpected.getReferencedSize(),
         snapshotInfoActual.getReferencedSize());
-    Assert.assertEquals(snapshotInfoExpected.getReferencedReplicatedSize(),
+    Assertions.assertEquals(snapshotInfoExpected.getReferencedReplicatedSize(),
         snapshotInfoActual.getReferencedReplicatedSize());
-    Assert.assertEquals(snapshotInfoExpected.getExclusiveSize(),
+    Assertions.assertEquals(snapshotInfoExpected.getExclusiveSize(),
         snapshotInfoActual.getExclusiveSize());
-    Assert.assertEquals(snapshotInfoExpected.getExclusiveReplicatedSize(),
+    Assertions.assertEquals(snapshotInfoExpected.getExclusiveReplicatedSize(),
         snapshotInfoActual.getExclusiveReplicatedSize());
 
-    Assert.assertEquals(snapshotInfoExpected, snapshotInfoActual);
+    Assertions.assertEquals(snapshotInfoExpected, snapshotInfoActual);
   }
 
   @Test
@@ -183,6 +185,6 @@ public class TestOmSnapshotInfo {
     // GMT: Sunday, July 10, 2022 7:56:55.001 PM
     long millis = 1657483015001L;
     String name = SnapshotInfo.generateName(millis);
-    Assert.assertEquals("s20220710-195655.001", name);
+    Assertions.assertEquals("s20220710-195655.001", name);
   }
 }

--- a/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/om/helpers/TestOmVolumeArgs.java
+++ b/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/om/helpers/TestOmVolumeArgs.java
@@ -24,8 +24,8 @@ import org.apache.hadoop.ozone.OzoneAcl;
 import org.apache.hadoop.ozone.security.acl.IAccessAuthorizer;
 import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.hadoop.util.Time;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import static org.apache.hadoop.ozone.OzoneAcl.AclScope.ACCESS;
 
@@ -49,7 +49,7 @@ public class TestOmVolumeArgs {
 
     OmVolumeArgs cloneVolumeArgs = omVolumeArgs.copyObject();
 
-    Assert.assertEquals(omVolumeArgs, cloneVolumeArgs);
+    Assertions.assertEquals(omVolumeArgs, cloneVolumeArgs);
 
     // add user acl to write.
     omVolumeArgs.addAcl(new OzoneAcl(
@@ -57,7 +57,7 @@ public class TestOmVolumeArgs {
         IAccessAuthorizer.ACLType.WRITE, ACCESS));
 
     // Now check clone acl
-    Assert.assertNotEquals(cloneVolumeArgs.getAcls().get(0),
+    Assertions.assertNotEquals(cloneVolumeArgs.getAcls().get(0),
         omVolumeArgs.getAcls().get(0));
 
     // Set user acl to Write_ACL.
@@ -65,14 +65,14 @@ public class TestOmVolumeArgs {
         IAccessAuthorizer.ACLIdentityType.USER, "user1",
         IAccessAuthorizer.ACLType.WRITE_ACL, ACCESS)));
 
-    Assert.assertNotEquals(cloneVolumeArgs.getAcls().get(0),
+    Assertions.assertNotEquals(cloneVolumeArgs.getAcls().get(0),
         omVolumeArgs.getAcls().get(0));
 
     // Now clone and check. It should have same as original acl.
     cloneVolumeArgs = (OmVolumeArgs) omVolumeArgs.copyObject();
 
-    Assert.assertEquals(omVolumeArgs, cloneVolumeArgs);
-    Assert.assertEquals(cloneVolumeArgs.getAcls().get(0),
+    Assertions.assertEquals(omVolumeArgs, cloneVolumeArgs);
+    Assertions.assertEquals(cloneVolumeArgs.getAcls().get(0),
         omVolumeArgs.getAcls().get(0));
 
     omVolumeArgs.removeAcl(new OzoneAcl(
@@ -80,8 +80,8 @@ public class TestOmVolumeArgs {
         IAccessAuthorizer.ACLType.WRITE_ACL, ACCESS));
 
     // Removing acl, in original omVolumeArgs it should have no acls.
-    Assert.assertEquals(0, omVolumeArgs.getAcls().size());
-    Assert.assertEquals(1, cloneVolumeArgs.getAcls().size());
+    Assertions.assertEquals(0, omVolumeArgs.getAcls().size());
+    Assertions.assertEquals(1, cloneVolumeArgs.getAcls().size());
 
   }
 }

--- a/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/om/helpers/TestOzoneAclUtil.java
+++ b/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/om/helpers/TestOzoneAclUtil.java
@@ -22,8 +22,8 @@ import org.apache.hadoop.ozone.security.acl.IAccessAuthorizer;
 import org.apache.hadoop.ozone.security.acl.IAccessAuthorizer.ACLType;
 import org.apache.hadoop.ozone.security.acl.OzoneAclConfig;
 import org.apache.hadoop.security.UserGroupInformation;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -36,8 +36,8 @@ import static org.apache.hadoop.ozone.OzoneAcl.AclScope.ACCESS;
 import static org.apache.hadoop.ozone.OzoneAcl.AclScope.DEFAULT;
 import static org.apache.hadoop.ozone.security.acl.IAccessAuthorizer.ACLIdentityType.GROUP;
 import static org.apache.hadoop.ozone.security.acl.IAccessAuthorizer.ACLIdentityType.USER;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Test for OzoneAcls utility class.
@@ -114,24 +114,25 @@ public class TestOzoneAclUtil {
   }
 
   private void addAndVerifyAcl(List<OzoneAcl> currentAcls, OzoneAcl addedAcl,
-      boolean expectedResult, int expectedSize) {
+                               boolean expectedResult, int expectedSize) {
     assertEquals(expectedResult, OzoneAclUtil.addAcl(currentAcls, addedAcl));
     if (currentAcls != null) {
       boolean verified = verifyAclAdded(currentAcls, addedAcl);
-      assertTrue("addedAcl: " + addedAcl + " should exist in the" +
-          " current acls: " + currentAcls, verified);
+      assertTrue(verified, "addedAcl: " + addedAcl + " should exist in the" +
+          " current acls: " + currentAcls);
       assertEquals(expectedSize, currentAcls.size());
     }
   }
 
   private void removeAndVerifyAcl(List<OzoneAcl> currentAcls,
-      OzoneAcl removedAcl, boolean expectedResult, int expectedSize) {
+                                  OzoneAcl removedAcl, boolean expectedResult,
+                                  int expectedSize) {
     assertEquals(expectedResult, OzoneAclUtil.removeAcl(currentAcls,
         removedAcl));
     if (currentAcls != null) {
       boolean verified = verifyAclRemoved(currentAcls, removedAcl);
-      assertTrue("removedAcl: " + removedAcl + " should not exist in the" +
-          " current acls: " + currentAcls, verified);
+      assertTrue(verified, "removedAcl: " + removedAcl + " should not exist " +
+          "in the current acls: " + currentAcls);
       assertEquals(expectedSize, currentAcls.size());
     }
   }
@@ -201,8 +202,8 @@ public class TestOzoneAclUtil {
         OzoneAcl.parseAcl("user:masstter:rw[DEFAULT]"));
 
     //[user:masstter:rwx[DEFAULT]]
-    Assert.assertEquals(1, ozoneAcls.size());
-    Assert.assertEquals(DEFAULT, ozoneAcls.get(0).getAclScope());
+    Assertions.assertEquals(1, ozoneAcls.size());
+    Assertions.assertEquals(DEFAULT, ozoneAcls.get(0).getAclScope());
 
     ozoneAcls = new ArrayList<>();
     OzoneAclUtil.addAcl(ozoneAcls,
@@ -211,8 +212,8 @@ public class TestOzoneAclUtil {
         OzoneAcl.parseAcl("user:masstter:rw[ACCESS]"));
 
     //[user:masstter:rwx[ACCESS]]
-    Assert.assertEquals(1, ozoneAcls.size());
-    Assert.assertEquals(ACCESS, ozoneAcls.get(0).getAclScope());
+    Assertions.assertEquals(1, ozoneAcls.size());
+    Assertions.assertEquals(ACCESS, ozoneAcls.get(0).getAclScope());
 
     ozoneAcls = new ArrayList<>();
     OzoneAclUtil.addAcl(ozoneAcls,
@@ -221,10 +222,10 @@ public class TestOzoneAclUtil {
         OzoneAcl.parseAcl("user:masstter:rwx[ACCESS]"));
 
     //[user:masstter:rwx[ACCESS], user:masstter:rwx[DEFAULT]]
-    Assert.assertEquals(2, ozoneAcls.size());
-    Assert.assertNotEquals(ozoneAcls.get(0).getAclScope(),
+    Assertions.assertEquals(2, ozoneAcls.size());
+    Assertions.assertNotEquals(ozoneAcls.get(0).getAclScope(),
         ozoneAcls.get(1).getAclScope());
-    Assert.assertEquals(ozoneAcls.get(0).getAclBitSet(),
+    Assertions.assertEquals(ozoneAcls.get(0).getAclBitSet(),
         ozoneAcls.get(1).getAclBitSet());
   }
 }

--- a/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/om/helpers/TestOzoneFsUtils.java
+++ b/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/om/helpers/TestOzoneFsUtils.java
@@ -18,8 +18,8 @@
 
 package org.apache.hadoop.ozone.om.helpers;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 /**
  * Test OzoneFsUtils.
@@ -28,12 +28,12 @@ public class TestOzoneFsUtils {
 
   @Test
   public void testPaths() {
-    Assert.assertTrue(OzoneFSUtils.isValidName("/a/b"));
-    Assert.assertFalse(OzoneFSUtils.isValidName("../../../a/b"));
-    Assert.assertFalse(OzoneFSUtils.isValidName("/./."));
-    Assert.assertFalse(OzoneFSUtils.isValidName("/:/"));
-    Assert.assertFalse(OzoneFSUtils.isValidName("a/b"));
-    Assert.assertFalse(OzoneFSUtils.isValidName("/a:/b"));
-    Assert.assertFalse(OzoneFSUtils.isValidName("/a//b"));
+    Assertions.assertTrue(OzoneFSUtils.isValidName("/a/b"));
+    Assertions.assertFalse(OzoneFSUtils.isValidName("../../../a/b"));
+    Assertions.assertFalse(OzoneFSUtils.isValidName("/./."));
+    Assertions.assertFalse(OzoneFSUtils.isValidName("/:/"));
+    Assertions.assertFalse(OzoneFSUtils.isValidName("a/b"));
+    Assertions.assertFalse(OzoneFSUtils.isValidName("/a:/b"));
+    Assertions.assertFalse(OzoneFSUtils.isValidName("/a//b"));
   }
 }

--- a/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/om/helpers/TestQuotaUtil.java
+++ b/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/om/helpers/TestQuotaUtil.java
@@ -20,8 +20,8 @@ package org.apache.hadoop.ozone.om.helpers;
 import org.apache.hadoop.hdds.client.ECReplicationConfig;
 import org.apache.hadoop.hdds.client.RatisReplicationConfig;
 import org.apache.hadoop.hdds.client.ReplicationConfig;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import static org.apache.hadoop.hdds.client.ECReplicationConfig.EcCodec.RS;
 import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationFactor.ONE;
@@ -39,7 +39,7 @@ public class TestQuotaUtil {
     ReplicationConfig repConfig = RatisReplicationConfig.getInstance(THREE);
     long replicatedSize =
         QuotaUtil.getReplicatedSize(123 * ONE_MB, repConfig);
-    Assert.assertEquals(123 * ONE_MB * 3, replicatedSize);
+    Assertions.assertEquals(123 * ONE_MB * 3, replicatedSize);
   }
 
   @Test
@@ -47,7 +47,7 @@ public class TestQuotaUtil {
     ReplicationConfig repConfig = RatisReplicationConfig.getInstance(ONE);
     long replicatedSize =
         QuotaUtil.getReplicatedSize(123 * ONE_MB, repConfig);
-    Assert.assertEquals(123 * ONE_MB, replicatedSize);
+    Assertions.assertEquals(123 * ONE_MB, replicatedSize);
   }
 
   @Test
@@ -55,7 +55,7 @@ public class TestQuotaUtil {
     ECReplicationConfig repConfig = new ECReplicationConfig(3, 2, RS, ONE_MB);
     long dataSize = ONE_MB * 3 * 123; // 123 full stripe
     long replicatedSize = QuotaUtil.getReplicatedSize(dataSize, repConfig);
-    Assert.assertEquals(dataSize + 123 * ONE_MB * 2, replicatedSize);
+    Assertions.assertEquals(dataSize + 123 * ONE_MB * 2, replicatedSize);
   }
 
   @Test
@@ -64,7 +64,8 @@ public class TestQuotaUtil {
     long dataSize = ONE_MB * 3 * 123 + 10; // 123 full stripes, plus 10 bytes
     long replicatedSize = QuotaUtil.getReplicatedSize(dataSize, repConfig);
     // Expected is 123 parity stripes, plus another 10 bytes in each parity
-    Assert.assertEquals(dataSize + 123 * ONE_MB * 2 + 10 * 2, replicatedSize);
+    Assertions.assertEquals(dataSize + 123 * ONE_MB * 2 + 10 * 2,
+        replicatedSize);
   }
 
   @Test
@@ -74,7 +75,7 @@ public class TestQuotaUtil {
     long dataSize = ONE_MB * 3 * 123 + ONE_MB + 10;
     long replicatedSize = QuotaUtil.getReplicatedSize(dataSize, repConfig);
     // Expected is 123 parity stripes, plus another 1MB in each parity
-    Assert.assertEquals(
+    Assertions.assertEquals(
         dataSize + 123 * ONE_MB * 2 + ONE_MB * 2, replicatedSize);
   }
 
@@ -84,7 +85,7 @@ public class TestQuotaUtil {
     long dataSize = 10;
     long replicatedSize = QuotaUtil.getReplicatedSize(dataSize, repConfig);
     // Expected is 123 parity stripes, plus another 1MB in each parity
-    Assert.assertEquals(dataSize + 10 * 2, replicatedSize);
+    Assertions.assertEquals(dataSize + 10 * 2, replicatedSize);
   }
 
   @Test
@@ -93,7 +94,7 @@ public class TestQuotaUtil {
     long dataSize = 2 * ONE_MB + 10;
     long replicatedSize = QuotaUtil.getReplicatedSize(dataSize, repConfig);
     // Expected is 123 parity stripes, plus another 1MB in each parity
-    Assert.assertEquals(dataSize + ONE_MB * 2, replicatedSize);
+    Assertions.assertEquals(dataSize + ONE_MB * 2, replicatedSize);
   }
 
 }

--- a/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/om/lock/TestKeyPathLock.java
+++ b/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/om/lock/TestKeyPathLock.java
@@ -20,8 +20,8 @@ package org.apache.hadoop.ozone.om.lock;
 
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.ozone.test.GenericTestUtils;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -30,7 +30,7 @@ import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.CountDownLatch;
 
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  * Tests OzoneManagerLock.Resource.KEY_PATH_LOCK.
@@ -104,14 +104,14 @@ public class TestKeyPathLock extends TestOzoneManagerLock {
 
     // For example, threadCount = 10, iterations = 100. The expected counter
     // value is 10 * 100
-    Assert.assertEquals(((long) threadCount) * iterations,
+    Assertions.assertEquals(((long) threadCount) * iterations,
         counter.getCount());
-    Assert.assertEquals(threadCount, listTokens.size());
+    Assertions.assertEquals(threadCount, listTokens.size());
 
     // Thread-1 -> 1 * 100,
     // Thread-2 -> 2 * 100 and so on.
     for (int i = 1; i <= listTokens.size(); i++) {
-      Assert.assertEquals(Integer.valueOf(i * iterations),
+      Assertions.assertEquals(Integer.valueOf(i * iterations),
           listTokens.get(i - 1));
     }
   }
@@ -134,7 +134,7 @@ public class TestKeyPathLock extends TestOzoneManagerLock {
     }
 
     // Now all threads have been instantiated.
-    Assert.assertEquals(0, countDownLatch.getCount());
+    Assertions.assertEquals(0, countDownLatch.getCount());
 
     lock.acquireWriteLock(resource, sampleResourceName);
     LOG.info("Write Lock Acquired by " + Thread.currentThread().getName());
@@ -201,7 +201,7 @@ public class TestKeyPathLock extends TestOzoneManagerLock {
       return true; // all threads have finished counting down.
     }, 3000, 120000); // 2 minutes
 
-    Assert.assertEquals(0, countDown.getCount());
+    Assertions.assertEquals(0, countDown.getCount());
 
     for (Thread t : threads) {
       t.join();
@@ -221,7 +221,7 @@ public class TestKeyPathLock extends TestOzoneManagerLock {
     // Waiting for all the threads to be instantiated/to reach
     // acquireWriteLock.
     countDown.countDown();
-    Assert.assertEquals(1, lock.getCurrentLocks().size());
+    Assertions.assertEquals(1, lock.getCurrentLocks().size());
 
     lock.releaseWriteLock(resource, sampleResourceName);
     LOG.info("Write Lock Released by " + Thread.currentThread().getName());
@@ -248,7 +248,7 @@ public class TestKeyPathLock extends TestOzoneManagerLock {
     } catch (RuntimeException ex) {
       String message = "cannot acquire " + higherResource.getName() + " lock " +
           "while holding [" + resource.getName() + "] lock(s).";
-      Assert.assertTrue(ex.getMessage(), ex.getMessage().contains(message));
+      Assertions.assertTrue(ex.getMessage().contains(message), ex.getMessage());
     }
   }
 
@@ -273,7 +273,7 @@ public class TestKeyPathLock extends TestOzoneManagerLock {
     } catch (RuntimeException ex) {
       String message = "cannot acquire " + higherResource.getName() + " lock " +
           "while holding [" + resource.getName() + "] lock(s).";
-      Assert.assertTrue(ex.getMessage(), ex.getMessage().contains(message));
+      Assertions.assertTrue(ex.getMessage().contains(message), ex.getMessage());
     }
   }
 
@@ -298,7 +298,7 @@ public class TestKeyPathLock extends TestOzoneManagerLock {
     } catch (RuntimeException ex) {
       String message = "cannot acquire " + higherResource.getName() + " lock " +
           "while holding [" + resource.getName() + "] lock(s).";
-      Assert.assertTrue(ex.getMessage(), ex.getMessage().contains(message));
+      Assertions.assertTrue(ex.getMessage().contains(message), ex.getMessage());
     }
   }
 
@@ -323,7 +323,7 @@ public class TestKeyPathLock extends TestOzoneManagerLock {
     } catch (RuntimeException ex) {
       String message = "cannot acquire " + higherResource.getName() + " lock " +
           "while holding [" + resource.getName() + "] lock(s).";
-      Assert.assertTrue(ex.getMessage(), ex.getMessage().contains(message));
+      Assertions.assertTrue(ex.getMessage().contains(message), ex.getMessage());
     }
   }
 }

--- a/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/om/lock/TestOzoneManagerLock.java
+++ b/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/om/lock/TestOzoneManagerLock.java
@@ -26,31 +26,21 @@ import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.apache.hadoop.metrics2.impl.MetricsCollectorImpl;
 import org.apache.hadoop.ozone.om.lock.OzoneManagerLock.Resource;
-import org.junit.Assert;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
-import org.junit.rules.TestRule;
-import org.junit.rules.Timeout;
-import org.apache.ozone.test.JUnit5AwareTimeout;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  * Class tests OzoneManagerLock.
  */
+@Timeout(300)
 public class TestOzoneManagerLock {
-
-  @Rule
-  public TestRule timeout = new JUnit5AwareTimeout(Timeout.seconds(300));
-
-  private static final Logger LOG =
-      LoggerFactory.getLogger(TestOzoneManagerLock.class);
 
   @Test
   public void acquireResourceLock() {
@@ -65,7 +55,7 @@ public class TestOzoneManagerLock {
     OzoneManagerLock lock = new OzoneManagerLock(new OzoneConfiguration());
     lock.acquireWriteLock(resource, resourceName);
     lock.releaseWriteLock(resource, resourceName);
-    Assert.assertTrue(true);
+    Assertions.assertTrue(true);
   }
 
   @Test
@@ -78,7 +68,7 @@ public class TestOzoneManagerLock {
   }
 
   private void testResourceReacquireLock(String[] resourceName,
-      Resource resource) {
+                                         Resource resource) {
     OzoneManagerLock lock = new OzoneManagerLock(new OzoneConfiguration());
 
     // Lock re-acquire not allowed by same thread.
@@ -92,16 +82,17 @@ public class TestOzoneManagerLock {
       } catch (RuntimeException ex) {
         String message = "cannot acquire " + resource.getName() + " lock " +
             "while holding [" + resource.getName() + "] lock(s).";
-        Assert.assertTrue(ex.getMessage(), ex.getMessage().contains(message));
+        Assertions.assertTrue(ex.getMessage().contains(message),
+            ex.getMessage());
       }
       lock.releaseWriteLock(resource, resourceName);
-      Assert.assertTrue(true);
+      Assertions.assertTrue(true);
     } else {
       lock.acquireWriteLock(resource, resourceName);
       lock.acquireWriteLock(resource, resourceName);
       lock.releaseWriteLock(resource, resourceName);
       lock.releaseWriteLock(resource, resourceName);
-      Assert.assertTrue(true);
+      Assertions.assertTrue(true);
     }
   }
 
@@ -132,7 +123,7 @@ public class TestOzoneManagerLock {
             resourceInfo.getLockName());
       }
     }
-    Assert.assertTrue(true);
+    Assertions.assertTrue(true);
   }
 
   @Test
@@ -149,8 +140,8 @@ public class TestOzoneManagerLock {
           } catch (RuntimeException ex) {
             String message = "cannot acquire " + resource.getName() + " lock " +
                 "while holding [" + higherResource.getName() + "] lock(s).";
-            Assert.assertTrue(ex.getMessage(),
-                ex.getMessage().contains(message));
+            Assertions.assertTrue(ex.getMessage().contains(message),
+                ex.getMessage());
           }
           lock.releaseWriteLock(higherResource, resourceName);
         }
@@ -181,9 +172,9 @@ public class TestOzoneManagerLock {
             lock.acquireWriteLock(resource, resourceName);
           } catch (RuntimeException ex) {
             String message = "cannot acquire " + resource.getName() + " lock " +
-                "while holding " + currentLocks.toString() + " lock(s).";
-            Assert.assertTrue(ex.getMessage(),
-                ex.getMessage().contains(message));
+                "while holding " + currentLocks + " lock(s).";
+            Assertions.assertTrue(ex.getMessage().contains(message),
+                ex.getMessage());
           }
         }
       }
@@ -245,7 +236,7 @@ public class TestOzoneManagerLock {
     OzoneManagerLock lock = new OzoneManagerLock(new OzoneConfiguration());
     lock.acquireMultiUserLock("user1", "user2");
     lock.releaseMultiUserLock("user1", "user2");
-    Assert.assertTrue(true);
+    Assertions.assertTrue(true);
   }
 
   @Test
@@ -258,7 +249,7 @@ public class TestOzoneManagerLock {
     } catch (RuntimeException ex) {
       String message = "cannot acquire USER_LOCK lock while holding " +
           "[USER_LOCK] lock(s).";
-      Assert.assertTrue(ex.getMessage(), ex.getMessage().contains(message));
+      Assertions.assertTrue(ex.getMessage().contains(message), ex.getMessage());
     }
     lock.releaseMultiUserLock("user1", "user2");
   }
@@ -273,7 +264,7 @@ public class TestOzoneManagerLock {
     } catch (RuntimeException ex) {
       String message = "cannot acquire USER_LOCK lock while holding " +
           "[USER_LOCK] lock(s).";
-      Assert.assertTrue(ex.getMessage(), ex.getMessage().contains(message));
+      Assertions.assertTrue(ex.getMessage().contains(message), ex.getMessage());
     }
     lock.releaseWriteLock(Resource.USER_LOCK, "user3");
   }
@@ -288,7 +279,7 @@ public class TestOzoneManagerLock {
     } catch (RuntimeException ex) {
       String message = "cannot acquire USER_LOCK lock while holding " +
           "[USER_LOCK] lock(s).";
-      Assert.assertTrue(ex.getMessage(), ex.getMessage().contains(message));
+      Assertions.assertTrue(ex.getMessage().contains(message), ex.getMessage());
     }
     lock.releaseMultiUserLock("user1", "user2");
   }
@@ -312,13 +303,13 @@ public class TestOzoneManagerLock {
       Thread.sleep(100);
       // Since the new thread is trying to get lock on same resource,
       // it will wait.
-      Assert.assertFalse(gotLock.get());
+      Assertions.assertFalse(gotLock.get());
       lock.releaseWriteLock(resource, resourceName);
       // Since we have released the lock, the new thread should have the lock
       // now.
       // Let's give some time for the new thread to run
       Thread.sleep(100);
-      Assert.assertTrue(gotLock.get());
+      Assertions.assertTrue(gotLock.get());
     }
 
   }
@@ -338,13 +329,13 @@ public class TestOzoneManagerLock {
     Thread.sleep(100);
     // Since the new thread is trying to get lock on same resource, it will
     // wait.
-    Assert.assertFalse(gotLock.get());
+    Assertions.assertFalse(gotLock.get());
     lock.releaseMultiUserLock("user2", "user1");
     // Since we have released the lock, the new thread should have the lock
     // now.
     // Let's give some time for the new thread to run
     Thread.sleep(100);
-    Assert.assertTrue(gotLock.get());
+    Assertions.assertTrue(gotLock.get());
   }
 
   @Test
@@ -379,26 +370,26 @@ public class TestOzoneManagerLock {
     lock.releaseReadLock(resource, resourceName);
     assertEquals(0, lock.getReadHoldCount(resource, resourceName));
 
-    Assert.assertFalse(
+    Assertions.assertFalse(
         lock.isWriteLockedByCurrentThread(resource, resourceName));
     assertEquals(0, lock.getWriteHoldCount(resource, resourceName));
     lock.acquireWriteLock(resource, resourceName);
-    Assert.assertTrue(
+    Assertions.assertTrue(
         lock.isWriteLockedByCurrentThread(resource, resourceName));
     assertEquals(1, lock.getWriteHoldCount(resource, resourceName));
 
     lock.acquireWriteLock(resource, resourceName);
-    Assert.assertTrue(
+    Assertions.assertTrue(
         lock.isWriteLockedByCurrentThread(resource, resourceName));
     assertEquals(2, lock.getWriteHoldCount(resource, resourceName));
 
     lock.releaseWriteLock(resource, resourceName);
-    Assert.assertTrue(
+    Assertions.assertTrue(
         lock.isWriteLockedByCurrentThread(resource, resourceName));
     assertEquals(1, lock.getWriteHoldCount(resource, resourceName));
 
     lock.releaseWriteLock(resource, resourceName);
-    Assert.assertFalse(
+    Assertions.assertFalse(
         lock.isWriteLockedByCurrentThread(resource, resourceName));
     assertEquals(0, lock.getWriteHoldCount(resource, resourceName));
   }
@@ -441,17 +432,15 @@ public class TestOzoneManagerLock {
     }
 
     String readHeldStat = lock.getOMLockMetrics().getReadLockHeldTimeMsStat();
-    Assert.assertTrue(
+    Assertions.assertTrue(readHeldStat.contains("Samples = " + threadCount),
         "Expected " + threadCount +
-            " samples in readLockHeldTimeMsStat: " + readHeldStat,
-        readHeldStat.contains("Samples = " + threadCount));
+            " samples in readLockHeldTimeMsStat: " + readHeldStat);
 
     String readWaitingStat =
         lock.getOMLockMetrics().getReadLockWaitingTimeMsStat();
-    Assert.assertTrue(
+    Assertions.assertTrue(readWaitingStat.contains("Samples = " + threadCount),
         "Expected " + threadCount +
-            " samples in readLockWaitingTimeMsStat: " + readWaitingStat,
-        readWaitingStat.contains("Samples = " + threadCount));
+            " samples in readLockWaitingTimeMsStat: " + readWaitingStat);
   }
 
   public void testWriteLockConcurrentStats(Resource resource,
@@ -479,17 +468,15 @@ public class TestOzoneManagerLock {
     }
 
     String writeHeldStat = lock.getOMLockMetrics().getWriteLockHeldTimeMsStat();
-    Assert.assertTrue(
+    Assertions.assertTrue(writeHeldStat.contains("Samples = " + threadCount),
         "Expected " + threadCount +
-            " samples in writeLockHeldTimeMsStat: " + writeHeldStat,
-        writeHeldStat.contains("Samples = " + threadCount));
+            " samples in writeLockHeldTimeMsStat: " + writeHeldStat);
 
     String writeWaitingStat =
         lock.getOMLockMetrics().getWriteLockWaitingTimeMsStat();
-    Assert.assertTrue(
+    Assertions.assertTrue(writeWaitingStat.contains("Samples = " + threadCount),
         "Expected " + threadCount +
-            " samples in writeLockWaitingTimeMsStat" + writeWaitingStat,
-        writeWaitingStat.contains("Samples = " + threadCount));
+            " samples in writeLockWaitingTimeMsStat" + writeWaitingStat);
   }
 
   public void testSyntheticReadWriteLockConcurrentStats(
@@ -537,30 +524,29 @@ public class TestOzoneManagerLock {
     }
 
     String readHeldStat = lock.getOMLockMetrics().getReadLockHeldTimeMsStat();
-    Assert.assertTrue(
+    Assertions.assertTrue(readHeldStat.contains("Samples = " + readThreadCount),
         "Expected " + readThreadCount +
-            " samples in readLockHeldTimeMsStat: " + readHeldStat,
-        readHeldStat.contains("Samples = " + readThreadCount));
+            " samples in readLockHeldTimeMsStat: " + readHeldStat);
 
     String readWaitingStat =
         lock.getOMLockMetrics().getReadLockWaitingTimeMsStat();
-    Assert.assertTrue(
+    Assertions.assertTrue(readWaitingStat.contains(
+            "Samples = " + readThreadCount),
         "Expected " + readThreadCount +
-            " samples in readLockWaitingTimeMsStat: " + readWaitingStat,
-        readWaitingStat.contains("Samples = " + readThreadCount));
+            " samples in readLockWaitingTimeMsStat: " + readWaitingStat);
 
     String writeHeldStat = lock.getOMLockMetrics().getWriteLockHeldTimeMsStat();
-    Assert.assertTrue(
+    Assertions.assertTrue(writeHeldStat.contains(
+            "Samples = " + writeThreadCount),
         "Expected " + writeThreadCount +
-            " samples in writeLockHeldTimeMsStat: " + writeHeldStat,
-        writeHeldStat.contains("Samples = " + writeThreadCount));
+            " samples in writeLockHeldTimeMsStat: " + writeHeldStat);
 
     String writeWaitingStat =
         lock.getOMLockMetrics().getWriteLockWaitingTimeMsStat();
-    Assert.assertTrue(
+    Assertions.assertTrue(writeWaitingStat.contains(
+            "Samples = " + writeThreadCount),
         "Expected " + writeThreadCount +
-            " samples in writeLockWaitingTimeMsStat" + writeWaitingStat,
-        writeWaitingStat.contains("Samples = " + writeThreadCount));
+            " samples in writeLockWaitingTimeMsStat" + writeWaitingStat);
   }
 
   @Test
@@ -569,17 +555,17 @@ public class TestOzoneManagerLock {
     try {
       MetricsCollectorImpl metricsCollector = new MetricsCollectorImpl();
       omLockMetrics.getMetrics(metricsCollector, true);
-      Assert.assertEquals(1, metricsCollector.getRecords().size());
+      Assertions.assertEquals(1, metricsCollector.getRecords().size());
 
       String omLockMetricsRecords = metricsCollector.getRecords().toString();
-      Assert.assertTrue(omLockMetricsRecords,
-          omLockMetricsRecords.contains("ReadLockWaitingTime"));
-      Assert.assertTrue(omLockMetricsRecords,
-          omLockMetricsRecords.contains("ReadLockHeldTime"));
-      Assert.assertTrue(omLockMetricsRecords,
-          omLockMetricsRecords.contains("WriteLockWaitingTime"));
-      Assert.assertTrue(omLockMetricsRecords,
-          omLockMetricsRecords.contains("WriteLockHeldTime"));
+      Assertions.assertTrue(omLockMetricsRecords.contains(
+          "ReadLockWaitingTime"), omLockMetricsRecords);
+      Assertions.assertTrue(omLockMetricsRecords.contains("ReadLockHeldTime"),
+          omLockMetricsRecords);
+      Assertions.assertTrue(omLockMetricsRecords.contains(
+          "WriteLockWaitingTime"), omLockMetricsRecords);
+      Assertions.assertTrue(omLockMetricsRecords.contains("WriteLockHeldTime"),
+          omLockMetricsRecords);
     } finally {
       omLockMetrics.unRegister();
     }

--- a/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/om/protocolPB/TestS3GrpcOmTransport.java
+++ b/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/om/protocolPB/TestS3GrpcOmTransport.java
@@ -37,10 +37,9 @@ import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMReque
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMResponse;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.ServiceListRequest;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.Type;
-import org.junit.Assert;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.Before;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.BeforeEach;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import java.io.IOException;
@@ -48,7 +47,7 @@ import java.io.IOException;
 import com.google.protobuf.ServiceException;
 import org.apache.ratis.protocol.RaftPeerId;
 
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.apache.hadoop.ozone.om.OMConfigKeys
     .OZONE_OM_GRPC_MAXIMUM_RESPONSE_LENGTH;
 
@@ -56,8 +55,7 @@ import static org.apache.hadoop.ozone.om.OMConfigKeys
  * Tests for GrpcOmTransport client.
  */
 public class TestS3GrpcOmTransport {
-  @Rule
-  public final GrpcCleanupRule grpcCleanup = new GrpcCleanupRule();
+  private final GrpcCleanupRule grpcCleanup = new GrpcCleanupRule();
 
   private static final Logger LOG =
       LoggerFactory.getLogger(TestS3GrpcOmTransport.class);
@@ -65,12 +63,12 @@ public class TestS3GrpcOmTransport {
   private final String leaderOMNodeId = "TestOM";
 
   private final OMResponse omResponse = OMResponse.newBuilder()
-                  .setSuccess(true)
-                  .setStatus(org.apache.hadoop.ozone.protocol
-                      .proto.OzoneManagerProtocolProtos.Status.OK)
-                  .setLeaderOMNodeId(leaderOMNodeId)
-                  .setCmdType(Type.AllocateBlock)
-                  .build();
+      .setSuccess(true)
+      .setStatus(org.apache.hadoop.ozone.protocol
+          .proto.OzoneManagerProtocolProtos.Status.OK)
+      .setLeaderOMNodeId(leaderOMNodeId)
+      .setCmdType(Type.AllocateBlock)
+      .build();
 
   private boolean doFailover = false;
 
@@ -96,8 +94,8 @@ public class TestS3GrpcOmTransport {
 
   private final OzoneManagerServiceGrpc.OzoneManagerServiceImplBase
       serviceImpl =
-        mock(OzoneManagerServiceGrpc.OzoneManagerServiceImplBase.class,
-            delegatesTo(
+      mock(OzoneManagerServiceGrpc.OzoneManagerServiceImplBase.class,
+          delegatesTo(
               new OzoneManagerServiceGrpc.OzoneManagerServiceImplBase() {
                 @Override
                 public void submitRequest(org.apache.hadoop.ozone.protocol.proto
@@ -107,7 +105,7 @@ public class TestS3GrpcOmTransport {
                                               .hadoop.ozone.protocol.proto
                                               .OzoneManagerProtocolProtos
                                               .OMResponse>
-                                          responseObserver) {
+                                              responseObserver) {
                   try {
                     if (doFailover) {
                       doFailover = false;
@@ -128,7 +126,7 @@ public class TestS3GrpcOmTransport {
 
   private GrpcOmTransport client;
 
-  @Before
+  @BeforeEach
   public void setUp() throws Exception {
     // Generate a unique in-process server name.
     serverName = InProcessServerBuilder.generateName();
@@ -167,9 +165,9 @@ public class TestS3GrpcOmTransport {
     client.startClient(channel);
 
     final OMResponse resp = client.submitRequest(omRequest);
-    Assert.assertEquals(resp.getStatus(), org.apache.hadoop.ozone.protocol
+    Assertions.assertEquals(resp.getStatus(), org.apache.hadoop.ozone.protocol
         .proto.OzoneManagerProtocolProtos.Status.OK);
-    Assert.assertEquals(resp.getLeaderOMNodeId(), leaderOMNodeId);
+    Assertions.assertEquals(resp.getLeaderOMNodeId(), leaderOMNodeId);
   }
 
   @Test
@@ -191,9 +189,9 @@ public class TestS3GrpcOmTransport {
     // failover is performed and request is internally retried
     // second invocation request to server succeeds
     final OMResponse resp = client.submitRequest(omRequest);
-    Assert.assertEquals(resp.getStatus(), org.apache.hadoop.ozone.protocol
+    Assertions.assertEquals(resp.getStatus(), org.apache.hadoop.ozone.protocol
         .proto.OzoneManagerProtocolProtos.Status.OK);
-    Assert.assertEquals(resp.getLeaderOMNodeId(), leaderOMNodeId);
+    Assertions.assertEquals(resp.getLeaderOMNodeId(), leaderOMNodeId);
   }
 
   @Test
@@ -221,7 +219,7 @@ public class TestS3GrpcOmTransport {
       final OMResponse resp = client.submitRequest(omRequest);
       fail();
     } catch (Exception e) {
-      Assert.assertTrue(true);
+      Assertions.assertTrue(true);
     }
   }
 
@@ -256,7 +254,7 @@ public class TestS3GrpcOmTransport {
       final OMResponse resp = client.submitRequest(omRequest);
       fail();
     } catch (Exception e) {
-      Assert.assertTrue(true);
+      Assertions.assertTrue(true);
     }
   }
 }

--- a/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/security/TestGDPRSymmetricKey.java
+++ b/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/security/TestGDPRSymmetricKey.java
@@ -18,8 +18,8 @@ package org.apache.hadoop.ozone.security;
 
 import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.hadoop.ozone.OzoneConsts;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.security.SecureRandom;
 
@@ -32,11 +32,11 @@ public class TestGDPRSymmetricKey {
   public void testKeyGenerationWithDefaults() throws Exception {
     GDPRSymmetricKey gkey = new GDPRSymmetricKey(new SecureRandom());
 
-    Assert.assertTrue(gkey.getCipher().getAlgorithm()
+    Assertions.assertTrue(gkey.getCipher().getAlgorithm()
         .equalsIgnoreCase(OzoneConsts.GDPR_ALGORITHM_NAME));
 
     gkey.acceptKeyDetails(
-        (k, v) -> Assert.assertTrue(v.length() > 0));
+        (k, v) -> Assertions.assertTrue(v.length() > 0));
   }
 
   @Test
@@ -45,11 +45,11 @@ public class TestGDPRSymmetricKey {
         RandomStringUtils.randomAlphabetic(16),
         OzoneConsts.GDPR_ALGORITHM_NAME);
 
-    Assert.assertTrue(gkey.getCipher().getAlgorithm()
+    Assertions.assertTrue(gkey.getCipher().getAlgorithm()
         .equalsIgnoreCase(OzoneConsts.GDPR_ALGORITHM_NAME));
 
     gkey.acceptKeyDetails(
-        (k, v) -> Assert.assertTrue(v.length() > 0));
+        (k, v) -> Assertions.assertTrue(v.length() > 0));
   }
 
   @Test
@@ -57,9 +57,9 @@ public class TestGDPRSymmetricKey {
     try {
       new GDPRSymmetricKey(RandomStringUtils.randomAlphabetic(5),
           OzoneConsts.GDPR_ALGORITHM_NAME);
-      Assert.fail("Expect length mismatched");
+      Assertions.fail("Expect length mismatched");
     } catch (IllegalArgumentException ex) {
-      Assert.assertTrue(ex.getMessage()
+      Assertions.assertTrue(ex.getMessage()
           .equalsIgnoreCase("Secret must be exactly 16 characters"));
     }
   }

--- a/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/security/TestOzoneDelegationTokenSelector.java
+++ b/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/security/TestOzoneDelegationTokenSelector.java
@@ -21,8 +21,8 @@ package org.apache.hadoop.ozone.security;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.hadoop.io.Text;
 import org.apache.hadoop.security.token.Token;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.nio.charset.StandardCharsets;
 import java.util.Collections;
@@ -59,7 +59,7 @@ public class TestOzoneDelegationTokenSelector {
             Collections.singletonList(tokenIdentifierToken));
 
 
-    Assert.assertNotNull(selectedToken);
+    Assertions.assertNotNull(selectedToken);
 
 
     tokenIdentifierToken.setService(new Text("om1:9863"));
@@ -67,14 +67,14 @@ public class TestOzoneDelegationTokenSelector {
         ozoneDelegationTokenSelector.selectToken(service,
             Collections.singletonList(tokenIdentifierToken));
 
-    Assert.assertNull(selectedToken);
+    Assertions.assertNull(selectedToken);
 
     service = new Text("om1:9863");
     selectedToken =
         ozoneDelegationTokenSelector.selectToken(service,
             Collections.singletonList(tokenIdentifierToken));
 
-    Assert.assertNotNull(selectedToken);
+    Assertions.assertNotNull(selectedToken);
 
   }
 

--- a/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/security/acl/TestOzoneObjInfo.java
+++ b/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/security/acl/TestOzoneObjInfo.java
@@ -17,11 +17,12 @@
 package org.apache.hadoop.ozone.security.acl;
 
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.apache.hadoop.ozone.OzoneConsts.OZONE_URI_DELIMITER;
 import static org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OzoneObj.ObjectType.KEY;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 import org.apache.hadoop.ozone.security.acl.OzoneObj.ResourceType;
 
@@ -46,15 +47,15 @@ public class TestOzoneObjInfo {
     assertEquals(objInfo.getVolumeName(), volume);
 
     objInfo = getBuilder(null, null, null).build();
-    assertEquals(objInfo.getVolumeName(), null);
+    assertNull(objInfo.getVolumeName());
 
     objInfo = getBuilder(volume, null, null).build();
     assertEquals(objInfo.getVolumeName(), volume);
   }
 
   private OzoneObjInfo.Builder getBuilder(String withVolume,
-      String withBucket,
-      String withKey) {
+                                          String withBucket,
+                                          String withKey) {
     return OzoneObjInfo.Builder.newBuilder()
         .setResType(ResourceType.VOLUME)
         .setStoreType(STORE)
@@ -69,7 +70,7 @@ public class TestOzoneObjInfo {
     assertEquals(objInfo.getBucketName(), bucket);
 
     objInfo = getBuilder(volume, null, null).build();
-    assertEquals(objInfo.getBucketName(), null);
+    assertNull(objInfo.getBucketName());
 
     objInfo = getBuilder(null, bucket, null).build();
     assertEquals(objInfo.getBucketName(), bucket);
@@ -81,10 +82,10 @@ public class TestOzoneObjInfo {
     assertEquals(objInfo.getKeyName(), key);
 
     objInfo = getBuilder(volume, null, null).build();
-    assertEquals(objInfo.getKeyName(), null);
+    assertNull(objInfo.getKeyName());
 
     objInfo = getBuilder(null, bucket, null).build();
-    assertEquals(objInfo.getKeyName(), null);
+    assertNull(objInfo.getKeyName());
 
     objInfo = getBuilder(null, null, key).build();
     assertEquals(objInfo.getKeyName(), key);
@@ -105,9 +106,9 @@ public class TestOzoneObjInfo {
     objInfo = OzoneObjInfo.fromProtobuf(protoObj);
     assertEquals(objInfo.getKeyName(), key);
     objInfo = getBuilder(volume, null, null).build();
-    assertEquals(objInfo.getKeyName(), null);
+    assertNull(objInfo.getKeyName());
     objInfo = getBuilder(null, bucket, null).build();
-    assertEquals(objInfo.getKeyName(), null);
+    assertNull(objInfo.getKeyName());
     objInfo = getBuilder(null, null, key).build();
     assertEquals(objInfo.getKeyName(), key);
 
@@ -124,9 +125,9 @@ public class TestOzoneObjInfo {
     objInfo = OzoneObjInfo.fromProtobuf(protoObj);
     assertEquals(objInfo.getKeyName(), key);
     objInfo = getBuilder(volume, null, null).build();
-    assertEquals(objInfo.getKeyName(), null);
+    assertNull(objInfo.getKeyName());
     objInfo = getBuilder(null, bucket, null).build();
-    assertEquals(objInfo.getKeyName(), null);
+    assertNull(objInfo.getKeyName());
     objInfo = getBuilder(null, null, key).build();
     assertEquals(objInfo.getKeyName(), key);
 
@@ -143,9 +144,9 @@ public class TestOzoneObjInfo {
     objInfo = OzoneObjInfo.fromProtobuf(protoObj);
     assertEquals(objInfo.getKeyName(), key);
     objInfo = getBuilder(volume, null, null).build();
-    assertEquals(objInfo.getKeyName(), null);
+    assertNull(objInfo.getKeyName());
     objInfo = getBuilder(null, bucket, null).build();
-    assertEquals(objInfo.getKeyName(), null);
+    assertNull(objInfo.getKeyName());
     objInfo = getBuilder(null, null, key).build();
     assertEquals(objInfo.getKeyName(), key);
   }

--- a/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/util/TestRadixTree.java
+++ b/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/util/TestRadixTree.java
@@ -18,12 +18,14 @@
 
 package org.apache.hadoop.ozone.util;
 
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 import java.util.List;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Test Ozone Radix tree operations.
@@ -32,10 +34,10 @@ public class TestRadixTree {
 
   static final RadixTree<Integer> ROOT = new RadixTree<>();
 
-  @BeforeClass
+  @BeforeAll
   public static void setupRadixTree() {
     // Test prefix paths with an empty tree
-    assertEquals(true, ROOT.isEmpty());
+    assertTrue(ROOT.isEmpty());
     assertEquals("/", ROOT.getLongestPrefix("/a/b/c"));
     assertEquals("/", RadixTree.radixPathToString(
         ROOT.getLongestPrefixPath("/a/g")));
@@ -99,7 +101,7 @@ public class TestRadixTree {
 
   @Test
   public void testGetLastNoeInPrefixPath() {
-    assertEquals(null, ROOT.getLastNodeInPrefixPath("/a/g"));
+    assertNull(ROOT.getLastNodeInPrefixPath("/a/g"));
     RadixNode<Integer> ln = ROOT.getLastNodeInPrefixPath("/a/b/e/dir1");
     assertEquals("dir1", ln.getName());
   }


### PR DESCRIPTION
## What changes were proposed in this pull request?
HDDS-9493. Migrating tests in ozone-common to JUnit5
Migrating all the tests under ozone-common to Junit5 and making sure that Junit4 is not used in any of the tests

Tested that using **grep -rlE "org.junit.[A-Z]" . --include '*.java'** command in hadoop-ozone/common folder

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-9493 

## How was this patch tested?

Full CI run- https://github.com/VarshaRaviCV/ozone/actions/runs/6663851768
