### PR TITLE
HDDS-9500. Migrate simple tests in ozone-client to JUnit5

### DIFF
--- a/hadoop-ozone/client/src/test/java/org/apache/hadoop/ozone/client/TestHddsClientUtils.java
+++ b/hadoop-ozone/client/src/test/java/org/apache/hadoop/ozone/client/TestHddsClientUtils.java
@@ -51,7 +51,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-//import org.junit.Test;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 
@@ -60,7 +59,7 @@ import org.junit.jupiter.api.Timeout;
  * parsing logic is in
  * {@link org.apache.hadoop.hdds.scm.client.HddsClientUtils}.
  */
-@Timeout(3)
+@Timeout(300)
 public class TestHddsClientUtils {
 
   /**

--- a/hadoop-ozone/client/src/test/java/org/apache/hadoop/ozone/client/TestHddsClientUtils.java
+++ b/hadoop-ozone/client/src/test/java/org/apache/hadoop/ozone/client/TestHddsClientUtils.java
@@ -44,30 +44,24 @@ import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_CLIENT_ADDRESS_
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_CLIENT_PORT_DEFAULT;
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_CLIENT_PORT_KEY;
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_NAMES;
-import static org.hamcrest.core.Is.is;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.fail;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import org.junit.Assert;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
-import org.junit.rules.TestRule;
-import org.junit.rules.Timeout;
-import org.apache.ozone.test.JUnit5AwareTimeout;
+//import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 /**
  * This test class verifies the parsing of SCM endpoint config settings. The
  * parsing logic is in
  * {@link org.apache.hadoop.hdds.scm.client.HddsClientUtils}.
  */
+@Timeout(3)
 public class TestHddsClientUtils {
-  @Rule
-  public TestRule timeout = new JUnit5AwareTimeout(Timeout.seconds(300));
-
-  @Rule
-  public ExpectedException thrown = ExpectedException.none();
 
   /**
    * Verify client endpoint lookup failure if it is not configured.
@@ -75,8 +69,8 @@ public class TestHddsClientUtils {
   @Test
   public void testMissingScmClientAddress() {
     final OzoneConfiguration conf = new OzoneConfiguration();
-    thrown.expect(ConfigurationException.class);
-    HddsUtils.getScmAddressForClients(conf);
+    assertThrows(ConfigurationException.class,
+        () -> HddsUtils.getScmAddressForClients(conf));
   }
 
   /**
@@ -135,7 +129,7 @@ public class TestHddsClientUtils {
       int port) {
     Iterator<InetSocketAddress> scmAddrIterator =
         HddsUtils.getScmAddressForClients(conf).iterator();
-    Assert.assertTrue(scmAddrIterator.hasNext());
+    assertTrue(scmAddrIterator.hasNext());
     InetSocketAddress scmAddr = scmAddrIterator.next();
     assertThat(scmAddr.getHostString(), is(address));
     assertThat(scmAddr.getPort(), is(port));
@@ -188,7 +182,7 @@ public class TestHddsClientUtils {
     conf.set(OZONE_SCM_NAMES, scmHost);
     final Collection<InetSocketAddress> address =
         HddsUtils.getScmAddressForClients(conf);
-    Assert.assertTrue(address.iterator().hasNext());
+    assertTrue(address.iterator().hasNext());
     InetSocketAddress socketAddress = address.iterator().next();
     assertEquals(scmHost, socketAddress.getHostName());
     assertEquals(OZONE_SCM_CLIENT_PORT_DEFAULT, socketAddress.getPort());
@@ -207,7 +201,7 @@ public class TestHddsClientUtils {
     conf.set(OZONE_SCM_NAMES, scmHost);
     final Collection<InetSocketAddress> address =
         HddsUtils.getScmAddressForClients(conf);
-    Assert.assertTrue(address.iterator().hasNext());
+    assertTrue(address.iterator().hasNext());
     InetSocketAddress socketAddress = address.iterator().next();
     assertEquals(scmHost.split(":")[0],
         socketAddress.getHostName());

--- a/hadoop-ozone/client/src/test/java/org/apache/hadoop/ozone/client/TestOzoneClient.java
+++ b/hadoop-ozone/client/src/test/java/org/apache/hadoop/ozone/client/TestOzoneClient.java
@@ -35,10 +35,10 @@ import org.apache.hadoop.ozone.om.exceptions.OMException.ResultCodes;
 import org.apache.hadoop.ozone.om.protocolPB.OmTransport;
 import org.apache.ozone.test.LambdaTestUtils.VoidCallable;
 import org.jetbrains.annotations.NotNull;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.security.cert.X509Certificate;
@@ -66,13 +66,13 @@ public class TestOzoneClient {
       throws Exception {
     try {
       eval.call();
-      Assert.fail("OMException is expected");
+      Assertions.fail("OMException is expected");
     } catch (OMException ex) {
-      Assert.assertEquals(code, ex.getResult());
+      Assertions.assertEquals(code, ex.getResult());
     }
   }
 
-  @Before
+  @BeforeEach
   public void init() throws IOException {
     OzoneConfiguration config = new OzoneConfiguration();
     createNewClient(config, new SinglePipelineBlockAllocator(config));
@@ -99,7 +99,7 @@ public class TestOzoneClient {
     store = client.getObjectStore();
   }
 
-  @After
+  @AfterEach
   public void close() throws IOException {
     client.close();
   }
@@ -110,7 +110,7 @@ public class TestOzoneClient {
     String volumeName = UUID.randomUUID().toString();
     store.createVolume(volumeName);
     OzoneVolume volume = store.getVolume(volumeName);
-    Assert.assertNotNull(volume);
+    Assertions.assertNotNull(volume);
     store.deleteVolume(volumeName);
     expectOmException(ResultCodes.VOLUME_NOT_FOUND,
         () -> store.getVolume(volumeName));
@@ -126,10 +126,11 @@ public class TestOzoneClient {
         .build();
     store.createVolume(volumeName, volumeArgs);
     OzoneVolume volume = store.getVolume(volumeName);
-    Assert.assertEquals(OzoneConsts.QUOTA_RESET, volume.getQuotaInNamespace());
-    Assert.assertEquals(OzoneConsts.QUOTA_RESET, volume.getQuotaInBytes());
-    Assert.assertEquals("val1", volume.getMetadata().get("key1"));
-    Assert.assertEquals(volumeName, volume.getName());
+    Assertions.assertEquals(OzoneConsts.QUOTA_RESET,
+        volume.getQuotaInNamespace());
+    Assertions.assertEquals(OzoneConsts.QUOTA_RESET, volume.getQuotaInBytes());
+    Assertions.assertEquals("val1", volume.getMetadata().get("key1"));
+    Assertions.assertEquals(volumeName, volume.getName());
   }
 
   @Test
@@ -142,9 +143,9 @@ public class TestOzoneClient {
     OzoneVolume volume = store.getVolume(volumeName);
     volume.createBucket(bucketName);
     OzoneBucket bucket = volume.getBucket(bucketName);
-    Assert.assertEquals(bucketName, bucket.getName());
-    Assert.assertFalse(bucket.getCreationTime().isBefore(testStartTime));
-    Assert.assertFalse(volume.getCreationTime().isBefore(testStartTime));
+    Assertions.assertEquals(bucketName, bucket.getName());
+    Assertions.assertFalse(bucket.getCreationTime().isBefore(testStartTime));
+    Assertions.assertFalse(volume.getCreationTime().isBefore(testStartTime));
   }
 
   @Test
@@ -162,14 +163,14 @@ public class TestOzoneClient {
       out.write(value.getBytes(UTF_8));
       out.close();
       OzoneKey key = bucket.getKey(keyName);
-      Assert.assertEquals(keyName, key.getName());
+      Assertions.assertEquals(keyName, key.getName());
       OzoneInputStream is = bucket.readKey(keyName);
       byte[] fileContent = new byte[value.getBytes(UTF_8).length];
-      Assert.assertEquals(value.length(), is.read(fileContent));
+      Assertions.assertEquals(value.length(), is.read(fileContent));
       is.close();
-      Assert.assertEquals(value, new String(fileContent, UTF_8));
-      Assert.assertFalse(key.getCreationTime().isBefore(testStartTime));
-      Assert.assertFalse(key.getModificationTime().isBefore(testStartTime));
+      Assertions.assertEquals(value, new String(fileContent, UTF_8));
+      Assertions.assertFalse(key.getCreationTime().isBefore(testStartTime));
+      Assertions.assertFalse(key.getModificationTime().isBefore(testStartTime));
     }
   }
 
@@ -219,7 +220,7 @@ public class TestOzoneClient {
         out.write(value.getBytes(UTF_8));
       }
       OzoneKey key = bucket.getKey(keyName);
-      Assert.assertEquals(keyName, key.getName());
+      Assertions.assertEquals(keyName, key.getName());
     }
   }
 

--- a/hadoop-ozone/client/src/test/java/org/apache/hadoop/ozone/client/TestOzoneECClient.java
+++ b/hadoop-ozone/client/src/test/java/org/apache/hadoop/ozone/client/TestOzoneECClient.java
@@ -47,10 +47,10 @@ import org.apache.ozone.erasurecode.rawcoder.RSRawErasureCoderFactory;
 import org.apache.ozone.erasurecode.rawcoder.RawErasureEncoder;
 import org.apache.ozone.test.GenericTestUtils;
 import org.apache.ratis.thirdparty.com.google.protobuf.ByteString;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
@@ -93,7 +93,7 @@ public class TestOzoneECClient {
       new RSRawErasureCoderFactory().createEncoder(
           new ECReplicationConfig(dataBlocks, parityBlocks));
 
-  @Before
+  @BeforeEach
   public void init() throws IOException {
     createNewClient(conf, transportStub);
   }
@@ -138,7 +138,7 @@ public class TestOzoneECClient {
     return builder.toString().getBytes(UTF_8);
   }
 
-  @After
+  @AfterEach
   public void close() throws IOException {
     client.close();
   }
@@ -147,7 +147,7 @@ public class TestOzoneECClient {
   public void testPutECKeyAndCheckDNStoredData() throws IOException {
     OzoneBucket bucket = writeIntoECKey(inputChunks, keyName, null);
     OzoneKey key = bucket.getKey(keyName);
-    Assert.assertEquals(keyName, key.getName());
+    Assertions.assertEquals(keyName, key.getName());
     Map<DatanodeDetails, MockDatanodeStorage> storages =
         ((MockXceiverClientFactory) factoryStub).getStorages();
     DatanodeDetails[] dnDetails =
@@ -155,10 +155,10 @@ public class TestOzoneECClient {
     Arrays.sort(dnDetails);
     for (int i = 0; i < inputChunks.length; i++) {
       MockDatanodeStorage datanodeStorage = storages.get(dnDetails[i]);
-      Assert.assertEquals(1, datanodeStorage.getAllBlockData().size());
+      Assertions.assertEquals(1, datanodeStorage.getAllBlockData().size());
       ByteString content =
           datanodeStorage.getAllBlockData().values().iterator().next();
-      Assert.assertEquals(new String(inputChunks[i], UTF_8),
+      Assertions.assertEquals(new String(inputChunks[i], UTF_8),
           content.toStringUtf8());
     }
   }
@@ -176,7 +176,7 @@ public class TestOzoneECClient {
     }
     encoder.encode(dataBuffers, parityBuffers);
     OzoneKey key = bucket.getKey(keyName);
-    Assert.assertEquals(keyName, key.getName());
+    Assertions.assertEquals(keyName, key.getName());
     Map<DatanodeDetails, MockDatanodeStorage> storages =
         ((MockXceiverClientFactory) factoryStub).getStorages();
     DatanodeDetails[] dnDetails =
@@ -185,10 +185,10 @@ public class TestOzoneECClient {
 
     for (int i = dataBlocks; i < parityBlocks + dataBlocks; i++) {
       MockDatanodeStorage datanodeStorage = storages.get(dnDetails[i]);
-      Assert.assertEquals(1, datanodeStorage.getAllBlockData().size());
+      Assertions.assertEquals(1, datanodeStorage.getAllBlockData().size());
       ByteString content =
           datanodeStorage.getAllBlockData().values().iterator().next();
-      Assert.assertEquals(
+      Assertions.assertEquals(
           new String(parityBuffers[i - dataBlocks].array(), UTF_8),
           content.toStringUtf8());
     }
@@ -199,15 +199,15 @@ public class TestOzoneECClient {
   public void testPutECKeyAndReadContent() throws IOException {
     OzoneBucket bucket = writeIntoECKey(inputChunks, keyName, null);
     OzoneKey key = bucket.getKey(keyName);
-    Assert.assertEquals(keyName, key.getName());
+    Assertions.assertEquals(keyName, key.getName());
     try (OzoneInputStream is = bucket.readKey(keyName)) {
       byte[] fileContent = new byte[chunkSize];
       for (int i = 0; i < dataBlocks; i++) {
-        Assert.assertEquals(inputChunks[i].length, is.read(fileContent));
-        Assert.assertTrue(Arrays.equals(inputChunks[i], fileContent));
+        Assertions.assertEquals(inputChunks[i].length, is.read(fileContent));
+        Assertions.assertTrue(Arrays.equals(inputChunks[i], fileContent));
       }
       // A further read should give EOF
-      Assert.assertEquals(-1, is.read(fileContent));
+      Assertions.assertEquals(-1, is.read(fileContent));
     }
   }
 
@@ -222,7 +222,7 @@ public class TestOzoneECClient {
     // create key without mentioning replication config. Since we set EC
     // replication in bucket, key should be EC key.
     try (OzoneOutputStream out = bucket.createKey("mykey", inputSize)) {
-      Assert.assertTrue(out.getOutputStream() instanceof ECKeyOutputStream);
+      Assertions.assertTrue(out.getOutputStream() instanceof ECKeyOutputStream);
       for (int i = 0; i < inputChunks.length; i++) {
         out.write(inputChunks[i]);
       }
@@ -300,11 +300,11 @@ public class TestOzoneECClient {
   private void validateContent(int offset, int length, byte[] inputData,
                                OzoneBucket bucket,
       OzoneKey key) throws IOException {
-    Assert.assertEquals(keyName, key.getName());
+    Assertions.assertEquals(keyName, key.getName());
     try (OzoneInputStream is = bucket.readKey(keyName)) {
       byte[] fileContent = new byte[length];
-      Assert.assertEquals(length, is.read(fileContent));
-      Assert.assertEquals(new String(Arrays.copyOfRange(inputData, offset,
+      Assertions.assertEquals(length, is.read(fileContent));
+      Assertions.assertEquals(new String(Arrays.copyOfRange(inputData, offset,
                       offset + length),
                       UTF_8),
           new String(fileContent, UTF_8));
@@ -342,7 +342,8 @@ public class TestOzoneECClient {
         keyLocations.getBlockID().getContainerBlockID().getContainerID(),
         keyLocations.getBlockID().getContainerBlockID().getLocalID()));
 
-    Assert.assertArrayEquals(firstSmallChunk, firstBlockData.getBytes(UTF_8));
+    Assertions.assertArrayEquals(
+        firstSmallChunk, firstBlockData.getBytes(UTF_8));
 
     final ByteBuffer[] dataBuffers = new ByteBuffer[dataBlocks];
     dataBuffers[0] = ByteBuffer.wrap(firstSmallChunk);
@@ -365,8 +366,8 @@ public class TestOzoneECClient {
           keyLocations.getBlockID().getContainerBlockID().getLocalID()));
       String expected =
           new String(parityBuffers[i - dataBlocks].array(), UTF_8);
-      Assert.assertEquals(expected, parityBlockData);
-      Assert.assertEquals(expected.length(), parityBlockData.length());
+      Assertions.assertEquals(expected, parityBlockData);
+      Assertions.assertEquals(expected.length(), parityBlockData.length());
 
     }
   }
@@ -375,12 +376,12 @@ public class TestOzoneECClient {
   public void testPutBlockHasBlockGroupLen() throws IOException {
     OzoneBucket bucket = writeIntoECKey(inputChunks, keyName, null);
     OzoneKey key = bucket.getKey(keyName);
-    Assert.assertEquals(keyName, key.getName());
+    Assertions.assertEquals(keyName, key.getName());
     try (OzoneInputStream is = bucket.readKey(keyName)) {
       byte[] fileContent = new byte[chunkSize];
       for (int i = 0; i < dataBlocks; i++) {
-        Assert.assertEquals(inputChunks[i].length, is.read(fileContent));
-        Assert.assertTrue(Arrays.equals(inputChunks[i], fileContent));
+        Assertions.assertEquals(inputChunks[i].length, is.read(fileContent));
+        Assertions.assertTrue(Arrays.equals(inputChunks[i], fileContent));
       }
 
       Map<DatanodeDetails, MockDatanodeStorage> storages =
@@ -411,7 +412,7 @@ public class TestOzoneECClient {
                 .equals(OzoneConsts.BLOCK_GROUP_LEN_KEY_IN_PUT_BLOCK))
                 .collect(Collectors.toList());
 
-        Assert.assertEquals(3L * chunkSize,
+        Assertions.assertEquals(3L * chunkSize,
             Long.parseLong(metadataList.get(0).getValue()));
       }
     }
@@ -463,7 +464,7 @@ public class TestOzoneECClient {
     // create key without mentioning replication config. Since we set EC
     // replication in bucket, key should be EC key.
     try (OzoneOutputStream out = bucket.createKey("mykey", 6 * inputSize)) {
-      Assert.assertTrue(out.getOutputStream() instanceof ECKeyOutputStream);
+      Assertions.assertTrue(out.getOutputStream() instanceof ECKeyOutputStream);
       // Block Size is 2kb, so to create 3 blocks we need 6 iterations here
       for (int j = 0; j < 6; j++) {
         for (int i = 0; i < inputChunks.length; i++) {
@@ -475,20 +476,20 @@ public class TestOzoneECClient {
         transportStub.getKeys().get(volumeName).get(bucketName).get("mykey")
             .getKeyLocationListList().get(0);
 
-    Assert.assertEquals(3, blockList.getKeyLocationsCount());
+    Assertions.assertEquals(3, blockList.getKeyLocationsCount());
     // As the mock allocator allocates block with id's increasing sequentially
     // from 1. Therefore the block should be in the order with id starting 1, 2
     // and then 3.
     for (int i = 0; i < 3; i++) {
       long localId = blockList.getKeyLocationsList().get(i).getBlockID()
           .getContainerBlockID().getLocalID();
-      Assert.assertEquals(i + 1, localId);
+      Assertions.assertEquals(i + 1, localId);
     }
 
-    Assert.assertEquals(1,
+    Assertions.assertEquals(1,
         transportStub.getKeys().get(volumeName).get(bucketName).get("mykey")
             .getKeyLocationListCount());
-    Assert.assertEquals(inputChunks[0].length * 3 * 6,
+    Assertions.assertEquals(inputChunks[0].length * 3 * 6,
         transportStub.getKeys().get(volumeName).get(bucketName).get("mykey")
             .getDataSize());
   }
@@ -560,14 +561,14 @@ public class TestOzoneECClient {
     try (OzoneInputStream is = bucket.readKey(keyName)) {
       byte[] fileContent = new byte[chunkSize];
       for (int i = 0; i < 2; i++) {
-        Assert.assertEquals(inputChunks[i].length, is.read(fileContent));
-        Assert.assertTrue(Arrays.equals(inputChunks[i], fileContent));
+        Assertions.assertEquals(inputChunks[i].length, is.read(fileContent));
+        Assertions.assertTrue(Arrays.equals(inputChunks[i], fileContent));
       }
-      Assert.assertEquals(lastChunk.length, is.read(fileContent));
-      Assert.assertTrue(Arrays.equals(lastChunk,
+      Assertions.assertEquals(lastChunk.length, is.read(fileContent));
+      Assertions.assertTrue(Arrays.equals(lastChunk,
           Arrays.copyOf(fileContent, lastChunk.length)));
       // A further read should give EOF
-      Assert.assertEquals(-1, is.read(fileContent));
+      Assertions.assertEquals(-1, is.read(fileContent));
     }
   }
 
@@ -601,8 +602,8 @@ public class TestOzoneECClient {
 
     try (OzoneInputStream is = bucket.readKey(keyName)) {
       byte[] fileContent = new byte[chunkSize];
-      Assert.assertEquals(inSize, is.read(fileContent));
-      Assert.assertTrue(Arrays.equals(partialChunk,
+      Assertions.assertEquals(inSize, is.read(fileContent));
+      Assertions.assertTrue(Arrays.equals(partialChunk,
           Arrays.copyOf(fileContent, inSize)));
     }
   }
@@ -648,8 +649,8 @@ public class TestOzoneECClient {
         nodesIndexesToMarkFailure);
     // It should have used 3rd block group also. So, total initialized nodes
     // count should be clusterSize.
-    Assert.assertTrue(((MockXceiverClientFactory) factoryStub).getStorages()
-        .size() == clusterSize);
+    Assertions.assertTrue(((MockXceiverClientFactory) factoryStub)
+        .getStorages().size() == clusterSize);
   }
 
   @Test
@@ -669,13 +670,13 @@ public class TestOzoneECClient {
         nodesIndexesToMarkFailure);
     // It should have used 3rd block group also. So, total initialized nodes
     // count should be clusterSize.
-    Assert.assertTrue(((MockXceiverClientFactory) factoryStub).getStorages()
-        .size() == clusterSize);
+    Assertions.assertTrue(((MockXceiverClientFactory) factoryStub)
+        .getStorages().size() == clusterSize);
   }
 
   // The mocked impl throws IllegalStateException when there are not enough
   // nodes in allocateBlock request.
-  @Test(expected = IllegalStateException.class)
+  @Test
   public void testStripeWriteRetriesOnAllNodeFailures() throws Exception {
     OzoneConfiguration con = createConfiguration();
 
@@ -687,8 +688,9 @@ public class TestOzoneECClient {
     }
     // Mocked MultiNodePipelineBlockAllocator#allocateBlock implementation can
     // not pick new block group as all nodes in cluster marked as bad.
-    testStripeWriteRetriesOnFailures(con, clusterSize,
-        nodesIndexesToMarkFailure);
+    Assertions.assertThrows(IllegalStateException.class, () ->
+        testStripeWriteRetriesOnFailures(con, clusterSize,
+            nodesIndexesToMarkFailure));
   }
 
   @Test
@@ -711,11 +713,12 @@ public class TestOzoneECClient {
       // OZONE_CLIENT_MAX_EC_STRIPE_WRITE_RETRIES_ON_FAILURE(here it was
       // configured as 3). So, it should fail as we have marked 3 nodes as bad.
       testStripeWriteRetriesOnFailures(con, 20, nodesIndexesToMarkFailure);
-      Assert.fail(
+      Assertions.fail(
           "Expecting it to fail as retries should exceed the max allowed times:"
               + " " + 3);
     } catch (IOException e) {
-      Assert.assertEquals("Completed max allowed retries 3 on stripe failures.",
+      Assertions.assertEquals(
+          "Completed max allowed retries 3 on stripe failures.",
           e.getMessage());
     }
   }
@@ -740,7 +743,7 @@ public class TestOzoneECClient {
         out.write(inputChunks[i]);
       }
       waitForFlushingThreadToFinish((ECKeyOutputStream) out.getOutputStream());
-      Assert.assertTrue(
+      Assertions.assertTrue(
           ((MockXceiverClientFactory) factoryStub).getStorages().size() == 5);
       List<DatanodeDetails> failedDNs = new ArrayList<>();
       List<HddsProtos.DatanodeDetailsProto> dns = blkAllocator.getClusterDns();
@@ -763,20 +766,20 @@ public class TestOzoneECClient {
     // failures after first stripe, the second stripe data should have been
     // written into new blockgroup. So, we should have 2 block groups. That
     // means two keyLocations.
-    Assert.assertEquals(2, key.getOzoneKeyLocations().size());
+    Assertions.assertEquals(2, key.getOzoneKeyLocations().size());
     try (OzoneInputStream is = bucket.readKey(keyName)) {
       byte[] fileContent = new byte[chunkSize];
       for (int i = 0; i < dataBlocks; i++) {
-        Assert.assertEquals(inputChunks[i].length, is.read(fileContent));
-        Assert.assertTrue("Expected: " + new String(inputChunks[i],
-                UTF_8) + " \n " + "Actual: " + new String(fileContent, UTF_8),
-            Arrays.equals(inputChunks[i], fileContent));
+        Assertions.assertEquals(inputChunks[i].length, is.read(fileContent));
+        Assertions.assertTrue(Arrays.equals(inputChunks[i], fileContent),
+            "Expected: " + new String(inputChunks[i],
+                UTF_8) + " \n " + "Actual: " + new String(fileContent, UTF_8));
       }
       for (int i = 0; i < numChunksToWriteAfterFailure; i++) {
-        Assert.assertEquals(inputChunks[i].length, is.read(fileContent));
-        Assert.assertTrue("Expected: " + new String(inputChunks[i],
-                UTF_8) + " \n " + "Actual: " + new String(fileContent, UTF_8),
-            Arrays.equals(inputChunks[i], fileContent));
+        Assertions.assertEquals(inputChunks[i].length, is.read(fileContent));
+        Assertions.assertTrue(Arrays.equals(inputChunks[i], fileContent),
+            "Expected: " + new String(inputChunks[i],
+                UTF_8) + " \n " + "Actual: " + new String(fileContent, UTF_8));
       }
     }
   }
@@ -817,22 +820,23 @@ public class TestOzoneECClient {
     // failures after first stripe, the second stripe data should have been
     // written into new block group. So, we should have numExpectedBlockGrps.
     // That means two keyLocations.
-    Assert
+    Assertions
         .assertEquals(numExpectedBlockGrps, key.getOzoneKeyLocations().size());
     try (OzoneInputStream is = bucket.readKey(keyName)) {
       byte[] fileContent = new byte[chunkSize];
       for (int i = 0; i < dataBlocks; i++) {
-        Assert.assertEquals(inputChunks[i].length, is.read(fileContent));
-        Assert.assertTrue("Expected: " + new String(inputChunks[i],
-                UTF_8) + " \n " + "Actual: " + new String(fileContent, UTF_8),
-            Arrays.equals(inputChunks[i], fileContent));
+        Assertions.assertEquals(inputChunks[i].length, is.read(fileContent));
+        Assertions.assertTrue(Arrays.equals(inputChunks[i], fileContent),
+            "Expected: " + new String(inputChunks[i],
+                UTF_8) + " \n " + "Actual: " + new String(fileContent, UTF_8));
       }
       for (int i = 0; i < numChunksToWriteAfterFailure; i++) {
-        Assert.assertEquals(inputChunks[i % dataBlocks].length,
+        Assertions.assertEquals(inputChunks[i % dataBlocks].length,
             is.read(fileContent));
-        Assert.assertTrue("Expected: " + new String(inputChunks[i % dataBlocks],
-                UTF_8) + " \n " + "Actual: " + new String(fileContent, UTF_8),
-            Arrays.equals(inputChunks[i % dataBlocks], fileContent));
+        Assertions.assertTrue(
+            Arrays.equals(inputChunks[i % dataBlocks], fileContent),
+            "Expected: " + new String(inputChunks[i % dataBlocks],
+                UTF_8) + " \n " + "Actual: " + new String(fileContent, UTF_8));
       }
     }
   }
@@ -871,7 +875,7 @@ public class TestOzoneECClient {
     try (OzoneOutputStream out = bucket.createKey(keyName,
         2L * dataBlocks * chunkSize, repConfig, new HashMap<>())) {
 
-      Assert.assertTrue(out.getOutputStream() instanceof ECKeyOutputStream);
+      Assertions.assertTrue(out.getOutputStream() instanceof ECKeyOutputStream);
       ECKeyOutputStream ecKeyOut = (ECKeyOutputStream) out.getOutputStream();
 
       List<HddsProtos.DatanodeDetailsProto> dns = blkAllocator.getClusterDns();
@@ -900,7 +904,7 @@ public class TestOzoneECClient {
       waitForFlushingThreadToFinish((ECKeyOutputStream) out.getOutputStream());
 
       // Assert excludeList only includes failedDNs
-      Assert.assertArrayEquals(failedDNs.toArray(new DatanodeDetails[0]),
+      Assertions.assertArrayEquals(failedDNs.toArray(new DatanodeDetails[0]),
           ecKeyOut.getExcludeList().getDatanodes()
               .toArray(new DatanodeDetails[0]));
     }
@@ -964,25 +968,25 @@ public class TestOzoneECClient {
     // failures after first stripe, the second stripe data should have been
     // written into new block group. So, we should have numExpectedBlockGrps.
     // That means two keyLocations.
-    Assert
+    Assertions
         .assertEquals(numExpectedBlockGrps, key.getOzoneKeyLocations().size());
     try (OzoneInputStream is = bucket.readKey(keyName)) {
       byte[] fileContent = new byte[chunkSize];
       for (int i = 0; i < dataBlocks * numFullStripesBeforeFailure; i++) {
-        Assert.assertEquals(inputChunks[i % dataBlocks].length,
+        Assertions.assertEquals(inputChunks[i % dataBlocks].length,
             is.read(fileContent));
-        Assert.assertTrue(
+        Assertions.assertTrue(
+            Arrays.equals(inputChunks[i % dataBlocks], fileContent),
             "Expected: " + new String(inputChunks[i % dataBlocks], UTF_8)
-                + " \n " + "Actual: " + new String(fileContent, UTF_8),
-            Arrays.equals(inputChunks[i % dataBlocks], fileContent));
+                + " \n " + "Actual: " + new String(fileContent, UTF_8));
       }
       for (int i = 0; i < numChunksToWriteAfterFailure; i++) {
-        Assert.assertEquals(inputChunks[i % dataBlocks].length,
+        Assertions.assertEquals(inputChunks[i % dataBlocks].length,
             is.read(fileContent));
-        Assert.assertTrue(
+        Assertions.assertTrue(
+            Arrays.equals(inputChunks[i % dataBlocks], fileContent),
             "Expected: " + new String(inputChunks[i % dataBlocks],
-                UTF_8) + " \n " + "Actual: " + new String(fileContent, UTF_8),
-            Arrays.equals(inputChunks[i % dataBlocks], fileContent));
+                UTF_8) + " \n " + "Actual: " + new String(fileContent, UTF_8));
       }
     }
   }
@@ -1037,19 +1041,20 @@ public class TestOzoneECClient {
     try (OzoneInputStream is = bucket.readKey(keyName)) {
       byte[] fileContent = new byte[chunkSize];
       for (int i = 0; i < numFullChunks; i++) {
-        Assert.assertEquals(inputChunks[i % dataBlocks].length,
+        Assertions.assertEquals(inputChunks[i % dataBlocks].length,
             is.read(fileContent));
-        Assert.assertTrue("Expected: " + new String(inputChunks[i % dataBlocks],
-                UTF_8) + " \n " + "Actual: " + new String(fileContent, UTF_8),
-            Arrays.equals(inputChunks[i % dataBlocks], fileContent));
+        Assertions.assertTrue(
+            Arrays.equals(inputChunks[i % dataBlocks], fileContent),
+            "Expected: " + new String(inputChunks[i % dataBlocks],
+                UTF_8) + " \n " + "Actual: " + new String(fileContent, UTF_8));
       }
 
       byte[] partialChunkToRead = new byte[partialChunkSize];
-      Assert
+      Assertions
           .assertEquals(partialChunkToRead.length, is.read(partialChunkToRead));
-      Assert.assertTrue(Arrays.equals(partialChunk, partialChunkToRead));
+      Assertions.assertTrue(Arrays.equals(partialChunk, partialChunkToRead));
 
-      Assert.assertEquals(-1, is.read(partialChunkToRead));
+      Assertions.assertEquals(-1, is.read(partialChunkToRead));
     }
   }
 
@@ -1083,10 +1088,10 @@ public class TestOzoneECClient {
         new ECReplicationConfig(dataBlocks, parityBlocks,
             ECReplicationConfig.EcCodec.RS,
             chunkSize), new HashMap<>())) {
-      Assert.assertTrue(out.getOutputStream() instanceof ECKeyOutputStream);
+      Assertions.assertTrue(out.getOutputStream() instanceof ECKeyOutputStream);
       ECKeyOutputStream kos = (ECKeyOutputStream) out.getOutputStream();
       List<OmKeyLocationInfo> blockInfos = getAllLocationInfoList(kos);
-      Assert.assertEquals(1, blockInfos.size());
+      Assertions.assertEquals(1, blockInfos.size());
 
       // Mock some pre-allocated blocks to the key,
       // should be > maxRetries
@@ -1134,23 +1139,22 @@ public class TestOzoneECClient {
       } catch (IOException e) {
         // If we don't discard pre-allocated blocks,
         // retries should exceed the maxRetries and write will fail.
-        Assert.fail("Max retries exceeded");
+        Assertions.fail("Max retries exceeded");
       }
     }
 
     final OzoneKeyDetails key = bucket.getKey(keyName);
-    Assert.assertEquals(numExpectedBlockGrps,
+    Assertions.assertEquals(numExpectedBlockGrps,
         key.getOzoneKeyLocations().size());
 
     try (OzoneInputStream is = bucket.readKey(keyName)) {
       byte[] fileContent = new byte[chunkSize];
       for (int i = 0; i < dataBlocks * numStripesTotal; i++) {
-        Assert.assertEquals(inputChunks[i % dataBlocks].length,
+        Assertions.assertEquals(inputChunks[i % dataBlocks].length,
             is.read(fileContent));
-        Assert.assertArrayEquals(
+        Assertions.assertArrayEquals(inputChunks[i % dataBlocks], fileContent,
             "Expected: " + new String(inputChunks[i % dataBlocks], UTF_8)
-                + " \n " + "Actual: " + new String(fileContent, UTF_8),
-            inputChunks[i % dataBlocks], fileContent);
+                + " \n " + "Actual: " + new String(fileContent, UTF_8));
       }
     }
   }

--- a/hadoop-ozone/client/src/test/java/org/apache/hadoop/ozone/client/checksum/TestReplicatedBlockChecksumComputer.java
+++ b/hadoop-ozone/client/src/test/java/org/apache/hadoop/ozone/client/checksum/TestReplicatedBlockChecksumComputer.java
@@ -23,7 +23,7 @@ import org.apache.hadoop.util.CrcComposer;
 import org.apache.hadoop.util.CrcUtil;
 import org.apache.hadoop.util.DataChecksum;
 import org.apache.ratis.thirdparty.com.google.protobuf.ByteString;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
@@ -33,7 +33,7 @@ import java.util.Random;
 
 import static org.apache.hadoop.hdds.scm.OzoneClientConfig.ChecksumCombineMode.COMPOSITE_CRC;
 import static org.apache.hadoop.hdds.scm.OzoneClientConfig.ChecksumCombineMode.MD5MD5CRC;
-import static org.junit.Assert.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 
 /**
  * Unit tests for ReplicatedBlockChecksumComputer class.

--- a/hadoop-ozone/client/src/test/java/org/apache/hadoop/ozone/client/checksum/TestReplicatedFileChecksumHelper.java
+++ b/hadoop-ozone/client/src/test/java/org/apache/hadoop/ozone/client/checksum/TestReplicatedFileChecksumHelper.java
@@ -52,9 +52,9 @@ import org.apache.hadoop.util.DataChecksum;
 import org.apache.hadoop.util.Time;
 import org.apache.ratis.thirdparty.com.google.protobuf.ByteString;
 import org.jetbrains.annotations.NotNull;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentMatchers;
 import org.mockito.Mockito;
 
@@ -71,9 +71,9 @@ import java.util.concurrent.CompletableFuture;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.apache.hadoop.hdds.client.ReplicationFactor.ONE;
 import static org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.ChecksumType.CRC32;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.when;
 
 /**
@@ -85,7 +85,7 @@ public class TestReplicatedFileChecksumHelper {
   private OzoneVolume volume;
   private RpcClient rpcClient;
 
-  @Before
+  @BeforeEach
   public void init() throws IOException {
     ConfigurationSource config = new InMemoryConfiguration();
     OzoneClientConfig clientConfig = config.getObject(OzoneClientConfig.class);
@@ -116,7 +116,7 @@ public class TestReplicatedFileChecksumHelper {
     store = client.getObjectStore();
   }
 
-  @After
+  @AfterEach
   public void close() throws IOException {
     client.close();
   }

--- a/hadoop-ozone/client/src/test/java/org/apache/hadoop/ozone/client/io/TestECBlockOutputStreamEntry.java
+++ b/hadoop-ozone/client/src/test/java/org/apache/hadoop/ozone/client/io/TestECBlockOutputStreamEntry.java
@@ -25,7 +25,6 @@ import org.apache.hadoop.hdds.scm.XceiverClientManager;
 import org.apache.hadoop.hdds.scm.XceiverClientSpi;
 import org.apache.hadoop.hdds.scm.pipeline.Pipeline;
 import org.apache.hadoop.hdds.scm.pipeline.PipelineID;
-import org.junit.Test;
 
 import java.io.IOException;
 import java.util.Arrays;
@@ -33,7 +32,8 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.UUID;
 
-import static org.junit.Assert.assertEquals;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * {@link ECBlockOutputStreamEntry} tests.

--- a/hadoop-ozone/client/src/test/java/org/apache/hadoop/ozone/client/io/TestKeyInputStreamEC.java
+++ b/hadoop-ozone/client/src/test/java/org/apache/hadoop/ozone/client/io/TestKeyInputStreamEC.java
@@ -28,8 +28,8 @@ import org.apache.hadoop.hdds.scm.storage.BlockExtendedInputStream;
 import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
 import org.apache.hadoop.ozone.om.helpers.OmKeyLocationInfo;
 import org.apache.hadoop.ozone.om.helpers.OmKeyLocationInfoGroup;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
@@ -74,7 +74,7 @@ public class TestKeyInputStreamEC {
         null, true,  null, mockStreamFactory)) {
       byte[] buf = new byte[100];
       int readBytes = kis.read(buf, 0, 100);
-      Assert.assertEquals(100, readBytes);
+      Assertions.assertEquals(100, readBytes);
     }
   }
 

--- a/hadoop-ozone/client/src/test/java/org/apache/hadoop/ozone/client/rpc/TestOzoneKMSUtil.java
+++ b/hadoop-ozone/client/src/test/java/org/apache/hadoop/ozone/client/rpc/TestOzoneKMSUtil.java
@@ -19,13 +19,13 @@ package org.apache.hadoop.ozone.client.rpc;
 
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.ozone.OzoneConfigKeys;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  * Test class for {@link OzoneKMSUtil}.
@@ -33,7 +33,7 @@ import static org.junit.Assert.fail;
 public class TestOzoneKMSUtil {
   private OzoneConfiguration config;
 
-  @Before
+  @BeforeEach
   public void setUp() {
     config = new OzoneConfiguration();
     config.setBoolean(OzoneConfigKeys.OZONE_SECURITY_ENABLED_KEY, true);


### PR DESCRIPTION
## What changes were proposed in this pull request?
Migrate the few of test classes to JUnit5

Please describe your PR in detail:
Migrate the following test classes to JUnit5. See parent task for details.
- hadoop-ozone/client/src/test/java/org/apache/hadoop/ozone/client/TestHddsClientUtils.java
- hadoop-ozone/client/src/test/java/org/apache/hadoop/ozone/client/TestOzoneClient.java
- hadoop-ozone/client/src/test/java/org/apache/hadoop/ozone/client/TestOzoneECClient.java
- hadoop-ozone/client/src/test/java/org/apache/hadoop/ozone/client/checksum/TestReplicatedBlockChecksumComputer.java
- hadoop-ozone/client/src/test/java/org/apache/hadoop/ozone/client/checksum/TestReplicatedFileChecksumHelper.java
- hadoop-ozone/client/src/test/java/org/apache/hadoop/ozone/client/io/TestECBlockOutputStreamEntry.java
- hadoop-ozone/client/src/test/java/org/apache/hadoop/ozone/client/io/TestKeyInputStreamEC.java
- hadoop-ozone/client/src/test/java/org/apache/hadoop/ozone/client/rpc/TestOzoneKMSUtil.java

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-9500

## How was this patch tested?
The changes are tested in local system as well as all the tests are run as part of CI build.
