### PR TITLE
HDDS-9555. Decommission should not wait on deleting containers

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/DatanodeAdminMonitorImpl.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/DatanodeAdminMonitorImpl.java
@@ -336,6 +336,7 @@ public class DatanodeAdminMonitorImpl implements DatanodeAdminMonitor {
   private boolean checkContainersReplicatedOnNode(DatanodeDetails dn)
       throws NodeNotFoundException {
     int sufficientlyReplicated = 0;
+    int deleting = 0;
     int underReplicated = 0;
     int unhealthy = 0;
     List<ContainerID> underReplicatedIDs = new ArrayList<>();
@@ -346,6 +347,17 @@ public class DatanodeAdminMonitorImpl implements DatanodeAdminMonitor {
       try {
         ContainerReplicaCount replicaSet =
             replicationManager.getContainerReplicaCount(cid);
+
+        // If a container is deleted or deleting, and we have a replica on this
+        // datanode, just ignore it. It should not block decommission.
+        HddsProtos.LifeCycleState containerState
+            = replicaSet.getContainer().getState();
+        if (containerState == HddsProtos.LifeCycleState.DELETED
+            || containerState == HddsProtos.LifeCycleState.DELETING) {
+          deleting++;
+          continue;
+        }
+
         if (replicaSet.isSufficientlyReplicatedForOffline(dn, nodeManager)) {
           sufficientlyReplicated++;
         } else {
@@ -389,9 +401,9 @@ public class DatanodeAdminMonitorImpl implements DatanodeAdminMonitor {
             "in containerManager", cid, dn);
       }
     }
-    LOG.info("{} has {} sufficientlyReplicated, {} underReplicated and {} " +
-        "unhealthy containers",
-        dn, sufficientlyReplicated, underReplicated, unhealthy);
+    LOG.info("{} has {} sufficientlyReplicated, {} deleting, {} " +
+            "underReplicated and {} unhealthy containers",
+        dn, sufficientlyReplicated, deleting, underReplicated, unhealthy);
     containerStateByHost.put(dn.getHostName(),
         new ContainerStateInWorkflow(dn.getHostName(),
             sufficientlyReplicated,


### PR DESCRIPTION
## What changes were proposed in this pull request?

When decommissioning a node, if there are replicas for a container which are marked as deleting in SCM, decommission should not wait on them, as they are going to be removed anyway.

We have also seen some cases where the container is deleting and has some unhealthy replicas which can cause decommission to hang unnecessarily.

This change will have decommission check for deleting containers and ignore them for the purposes of allowing decommission to complete.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-9555

## How was this patch tested?

New unit test added.