### PR TITLE
HDDS-9550. Empty CLOSING containers should transition to DELETED rather than CLOSED

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/ContainerStateManagerImpl.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/ContainerStateManagerImpl.java
@@ -190,6 +190,7 @@ public final class ContainerStateManagerImpl
     containerLifecycleSM.addTransition(OPEN, CLOSING, FINALIZE);
     containerLifecycleSM.addTransition(CLOSING, QUASI_CLOSED, QUASI_CLOSE);
     containerLifecycleSM.addTransition(CLOSING, CLOSED, CLOSE);
+    containerLifecycleSM.addTransition(CLOSING, DELETED, CLEANUP);
     containerLifecycleSM.addTransition(QUASI_CLOSED, CLOSED, FORCE_CLOSE);
     containerLifecycleSM.addTransition(CLOSED, DELETING, DELETE);
     containerLifecycleSM.addTransition(DELETING, DELETED, CLEANUP);

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ReplicationManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ReplicationManager.java
@@ -376,17 +376,19 @@ public class ReplicationManager implements SCMService {
       if (!shouldRun()) {
         break;
       }
-      report.increment(c.getState());
       if (rmConf.isLegacyEnabled() && !isEC(c.getReplicationConfig())) {
         legacyReplicationManager.processContainer(c, report);
+        report.increment(c.getState());
         continue;
       }
       try {
         processContainer(c, newRepQueue, report);
-        // TODO - send any commands contained in the health result
       } catch (ContainerNotFoundException e) {
         LOG.error("Container {} not found", c.getContainerID(), e);
       }
+      // As the container state can be changed by processing, eg open to closing
+      // etc, we should increment the report state after processing.
+      report.increment(c.getState());
     }
     report.setComplete();
     replicationQueue.set(newRepQueue);

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/HddsTestUtils.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/HddsTestUtils.java
@@ -670,7 +670,6 @@ public final class HddsTestUtils {
       final HddsProtos.LifeCycleState state) {
     return getDefaultContainerInfoBuilder(state)
         .setPipelineID(randomPipelineID)
-        .setNumberOfKeys(10)
         .build();
   }
 

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/HddsTestUtils.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/HddsTestUtils.java
@@ -670,6 +670,7 @@ public final class HddsTestUtils {
       final HddsProtos.LifeCycleState state) {
     return getDefaultContainerInfoBuilder(state)
         .setPipelineID(randomPipelineID)
+        .setNumberOfKeys(10)
         .build();
   }
 

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/ReplicationTestUtil.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/ReplicationTestUtil.java
@@ -194,6 +194,7 @@ public final class ReplicationTestUtil {
         .setContainerID(containerID)
         .setReplicationConfig(replicationConfig)
         .setState(containerState)
+        .setNumberOfKeys(10)
         .build();
   }
 

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestLegacyReplicationManager.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestLegacyReplicationManager.java
@@ -393,6 +393,7 @@ public class TestLegacyReplicationManager {
     public void testClosingMissingContainer()
         throws IOException, InvalidStateTransitionException {
       final ContainerInfo container = getContainer(LifeCycleState.CLOSING);
+      container.setNumberOfKeys(10);
       final ContainerID id = container.containerID();
 
       containerStateManager.addContainer(container.getProtobuf());


### PR DESCRIPTION
## What changes were proposed in this pull request?

In [HDDS-7882](https://issues.apache.org/jira/browse/HDDS-7882) we handled a case where a container was stuck in closing state due to the containers never getting created on the datanodes. In that issue, we moved the container to CLOSED so that the deleting code path would take over and move the container to deleted. However, the deleting code path only works when there are empty replicas reported, so the container stayed CLOSED with no replicas and hence looks like it is MISSING (no replicas available).

This change adjusts [HDDS-7882](https://issues.apache.org/jira/browse/HDDS-7882) so that the container is moved directly to DELETED rather than going to CLOSED, as the original assumption was that it would be moved to deleted anyway.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-9550

## How was this patch tested?

Existing tests modified