### PR TITLE
HDDS-9557. Datanode should log Follower cannot close container at info level

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/CloseContainerCommandHandler.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/CloseContainerCommandHandler.java
@@ -150,7 +150,7 @@ public class CloseContainerCommandHandler implements CommandHandler {
           break;
         }
       } catch (NotLeaderException e) {
-        LOG.debug("Follower cannot close container #{}.", containerId);
+        LOG.info("Follower cannot close container #{}.", containerId);
       } catch (IOException e) {
         LOG.error("Can't close container #{}", containerId, e);
       } finally {


### PR DESCRIPTION
## What changes were proposed in this pull request?

When a datanode which is not the followed received a closed container command, if the pipeline is still active and the datanode is not the pipeline leader, the close fails with a NotLeaderException.

If the container is failing to close for some reason (eg [HDDS-3509](https://issues.apache.org/jira/browse/HDDS-3509)) then there are no clues in the DN log that it is failing to close the container.

We should log this at INFO level rather than debug.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-9557

## How was this patch tested?

Logging only change - no tests modified.