### PR TITLE
HDDS-9558. Log reason for not using a node at info level in SCMCommonPlacementPolicy

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/SCMCommonPlacementPolicy.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/SCMCommonPlacementPolicy.java
@@ -500,7 +500,7 @@ public abstract class SCMCommonPlacementPolicy implements
           datanodeDetails, metadataSizeRequired, dataSizeRequired, nodeStatus);
       return true;
     }
-    LOG.debug("Datanode {} is not chosen. Required metadata size is {} and " +
+    LOG.info("Datanode {} is not chosen. Required metadata size is {} and " +
             "required data size is {} and NodeStatus is {}",
         datanodeDetails, metadataSizeRequired, dataSizeRequired, nodeStatus);
     return false;


### PR DESCRIPTION
## What changes were proposed in this pull request?

When we get placement policy problems, potentially caused by full or non-writable nodes, it is not possible to see why nodes were rejected without enabling debug logging.

This change adjusts the log added in [HDDS-9167](https://issues.apache.org/jira/browse/HDDS-9167) to be info level, as this should only be logged when nodes are not valid for space or non-writable reasons.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-9558

## How was this patch tested?

Log level change. No tests modified.
