### PR TITLE
HDDS-9492. Ban import of JUnit4 classes in modules already migrated to JUnit5

### DIFF
--- a/hadoop-hdds/erasurecode/pom.xml
+++ b/hadoop-hdds/erasurecode/pom.xml
@@ -29,6 +29,10 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <name>Apache Ozone HDDS Erasurecode</name>
   <packaging>jar</packaging>
 
+  <properties>
+    <allow.junit4>false</allow.junit4>
+  </properties>
+
   <dependencies>
 
     <dependency>

--- a/hadoop-hdds/rocks-native/pom.xml
+++ b/hadoop-hdds/rocks-native/pom.xml
@@ -64,6 +64,8 @@
         </dependency>
     </dependencies>
     <properties>
+        <allow.junit4>false</allow.junit4>
+
         <maven.compiler.source>8</maven.compiler.source>
         <maven.compiler.target>8</maven.compiler.target>
     </properties>

--- a/hadoop-hdds/rocksdb-checkpoint-differ/pom.xml
+++ b/hadoop-hdds/rocksdb-checkpoint-differ/pom.xml
@@ -29,6 +29,10 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <name>RocksDB Checkpoint Differ</name>
   <packaging>jar</packaging>
 
+  <properties>
+    <allow.junit4>false</allow.junit4>
+  </properties>
+
   <dependencies>
     <dependency>
       <groupId>org.rocksdb</groupId>

--- a/hadoop-ozone/common/pom.xml
+++ b/hadoop-ozone/common/pom.xml
@@ -28,6 +28,10 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <name>Apache Ozone Common</name>
   <packaging>jar</packaging>
 
+  <properties>
+    <allow.junit4>false</allow.junit4>
+  </properties>
+
   <dependencies>
 
     <dependency>

--- a/hadoop-ozone/s3-secret-store/pom.xml
+++ b/hadoop-ozone/s3-secret-store/pom.xml
@@ -28,6 +28,7 @@
   <properties>
     <file.encoding>UTF-8</file.encoding>
     <downloadSources>true</downloadSources>
+    <allow.junit4>false</allow.junit4>
   </properties>
 
   <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -1846,16 +1846,8 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
                     <includeTestCode>true</includeTestCode>
                     <reason>Use JUnit5</reason>
                     <bannedImports>
-                      <bannedImport>org.junit.After</bannedImport>
-                      <bannedImport>org.junit.AfterClass</bannedImport>
-                      <bannedImport>org.junit.Assert</bannedImport>
-                      <bannedImport>org.junit.Assume</bannedImport>
-                      <bannedImport>org.junit.Before</bannedImport>
-                      <bannedImport>org.junit.BeforeClass</bannedImport>
-                      <bannedImport>org.junit.ClassRule</bannedImport>
-                      <bannedImport>org.junit.ExpectedException</bannedImport>
-                      <bannedImport>org.junit.Rule</bannedImport>
-                      <bannedImport>org.junit.Test</bannedImport>
+                      <bannedImport>org.junit.*</bannedImport>
+                      <bannedImport>static org.junit.*.*</bannedImport>
                     </bannedImports>
                   </restrictImports>
                 </rules>

--- a/pom.xml
+++ b/pom.xml
@@ -252,6 +252,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
     -->
     <enforced.java.version>[${javac.version},)</enforced.java.version>
     <enforced.maven.version>[3.3.0,)</enforced.maven.version>
+    <allow.junit4>true</allow.junit4>
 
     <!-- Plugin versions and config -->
     <maven-surefire-plugin.argLine>-Xmx4096m -XX:+HeapDumpOnOutOfMemoryError</maven-surefire-plugin.argLine>
@@ -1827,6 +1828,34 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
                     <bannedImports>
                       <bannedImport>org.junit.Ignore</bannedImport>
                       <bannedImport>org.junit.jupiter.api.Disabled</bannedImport>
+                    </bannedImports>
+                  </restrictImports>
+                </rules>
+              </configuration>
+            </execution>
+            <execution>
+              <id>ban-junit4-imports</id>
+              <phase>process-sources</phase>
+              <goals>
+                <goal>enforce</goal>
+              </goals>
+              <configuration>
+                <skip>${allow.junit4}</skip>
+                <rules>
+                  <restrictImports>
+                    <includeTestCode>true</includeTestCode>
+                    <reason>Use JUnit5</reason>
+                    <bannedImports>
+                      <bannedImport>org.junit.After</bannedImport>
+                      <bannedImport>org.junit.AfterClass</bannedImport>
+                      <bannedImport>org.junit.Assert</bannedImport>
+                      <bannedImport>org.junit.Assume</bannedImport>
+                      <bannedImport>org.junit.Before</bannedImport>
+                      <bannedImport>org.junit.BeforeClass</bannedImport>
+                      <bannedImport>org.junit.ClassRule</bannedImport>
+                      <bannedImport>org.junit.ExpectedException</bannedImport>
+                      <bannedImport>org.junit.Rule</bannedImport>
+                      <bannedImport>org.junit.Test</bannedImport>
                     </bannedImports>
                   </restrictImports>
                 </rules>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Some modules had been completely migrated to JUnit5.  Ideally we should remove JUnit4 dependency, but it is also coming transitively from test utils.  Until the dependency can be completely removed, we should ban import of JUnit4 classes in such modules to avoid JUnit4 tests creeping back.

The goal of this change is to introduce the ban in modules that are currently completely on JUnit5.  Test migration tasks should then also add the rule to modules being cleaned up.

https://issues.apache.org/jira/browse/HDDS-9492

## How was this patch tested?

Added import of JUnit4 classes in some tests, tried to build locally:

```
$ mvn clean package
...

[ERROR] Banned imports detected in TEST code:
[ERROR] 
[ERROR] Reason: Use JUnit5
[ERROR] 	in file: org/apache/ozone/erasurecode/TestCoderBase.java
[ERROR] 		static org.junit.Assert.assertTrue 	(Line: 27, Matched by: static org.junit.*.*)

...

[ERROR] 	in file: org/apache/hadoop/ozone/TestOmUtils.java
[ERROR] 		org.junit.Test 	(Line: 23, Matched by: org.junit.*)
```

Regular CI:
https://github.com/adoroszlai/hadoop-ozone/actions/runs/6675278717/job/18143101681