### PR TITLE
HDDS-9283. ManagedReadOptions/ManagedSlice not closed properly in DBScanner

### DIFF
--- a/hadoop-hdds/managed-rocksdb/src/main/java/org/apache/hadoop/hdds/utils/db/managed/ManagedReadOptions.java
+++ b/hadoop-hdds/managed-rocksdb/src/main/java/org/apache/hadoop/hdds/utils/db/managed/ManagedReadOptions.java
@@ -20,17 +20,26 @@ package org.apache.hadoop.hdds.utils.db.managed;
 
 import org.rocksdb.ReadOptions;
 
+import static org.apache.hadoop.hdds.utils.db.managed.ManagedRocksObjectUtils.formatStackTrace;
+
 /**
  * Managed WriteBatch.
  */
 public class ManagedReadOptions extends ReadOptions {
+
+  private final StackTraceElement[] elements;
+
   public ManagedReadOptions() {
-    super();
+    this.elements = ManagedRocksObjectUtils.getStackTrace();
   }
 
   @Override
   protected void finalize() throws Throwable {
-    ManagedRocksObjectUtils.assertClosed(this);
+    ManagedRocksObjectUtils.assertClosed(this, getStackTrace());
     super.finalize();
+  }
+
+  private String getStackTrace() {
+    return formatStackTrace(elements);
   }
 }

--- a/hadoop-hdds/managed-rocksdb/src/main/java/org/apache/hadoop/hdds/utils/db/managed/ManagedRocksObjectUtils.java
+++ b/hadoop-hdds/managed-rocksdb/src/main/java/org/apache/hadoop/hdds/utils/db/managed/ManagedRocksObjectUtils.java
@@ -26,6 +26,7 @@ import org.rocksdb.RocksObject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.annotation.Nullable;
 import java.io.File;
 import java.io.IOException;
 import java.time.Duration;
@@ -54,19 +55,23 @@ public final class ManagedRocksObjectUtils {
   static void assertClosed(RocksObject rocksObject, String stackTrace) {
     ManagedRocksObjectMetrics.INSTANCE.increaseManagedObject();
     if (rocksObject.isOwningHandle()) {
-      ManagedRocksObjectMetrics.INSTANCE.increaseLeakObject();
-      String warning = String.format("%s is not closed properly",
-          rocksObject.getClass().getSimpleName());
-      if (stackTrace != null && LOG.isDebugEnabled()) {
-        String debugMessage = String
-            .format("%nStackTrace for unclosed instance: %s", stackTrace);
-        warning = warning.concat(debugMessage);
-      }
-      LOG.warn(warning);
+      reportLeak(rocksObject, stackTrace);
     }
   }
 
-  static StackTraceElement[] getStackTrace() {
+  static void reportLeak(Object object, String stackTrace) {
+    ManagedRocksObjectMetrics.INSTANCE.increaseLeakObject();
+    String warning = String.format("%s is not closed properly",
+        object.getClass().getSimpleName());
+    if (stackTrace != null && LOG.isDebugEnabled()) {
+      String debugMessage = String
+          .format("%nStackTrace for unclosed instance: %s", stackTrace);
+      warning = warning.concat(debugMessage);
+    }
+    LOG.warn(warning);
+  }
+
+  static @Nullable StackTraceElement[] getStackTrace() {
     return HddsUtils.getStackTrace(LOG);
   }
 

--- a/hadoop-hdds/managed-rocksdb/src/main/java/org/apache/hadoop/hdds/utils/db/managed/ManagedSlice.java
+++ b/hadoop-hdds/managed-rocksdb/src/main/java/org/apache/hadoop/hdds/utils/db/managed/ManagedSlice.java
@@ -20,13 +20,18 @@ package org.apache.hadoop.hdds.utils.db.managed;
 
 import org.rocksdb.Slice;
 
+import static org.apache.hadoop.hdds.utils.db.managed.ManagedRocksObjectUtils.formatStackTrace;
+
 /**
  * Managed Slice.
  */
 public class ManagedSlice extends Slice {
 
+  private final StackTraceElement[] elements;
+
   public ManagedSlice(byte[] var1) {
     super(var1);
+    this.elements = ManagedRocksObjectUtils.getStackTrace();
   }
 
   @Override
@@ -37,11 +42,13 @@ public class ManagedSlice extends Slice {
   @Override
   protected void finalize() throws Throwable {
     ManagedRocksObjectMetrics.INSTANCE.increaseManagedObject();
-    if (this.isOwningHandle()) {
-      ManagedRocksObjectMetrics.INSTANCE.increaseLeakObject();
-      ManagedRocksObjectUtils.LOG.warn("{} is not closed properly",
-          this.getClass().getSimpleName());
+    if (isOwningHandle()) {
+      ManagedRocksObjectUtils.reportLeak(this, getStackTrace());
     }
     super.finalize();
+  }
+
+  private String getStackTrace() {
+    return formatStackTrace(elements);
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

`TestLDBCli` intermittently fails due to:

```
2023-09-14 01:01:32,542 [Finalizer] WARN  managed.ManagedRocksObjectUtils (ManagedRocksObjectUtils.java:assertClosed(64)) - ManagedReadOptions is not closed properly
2023-09-14 01:01:32,542 [Finalizer] WARN  managed.ManagedRocksObjectUtils (ManagedSlice.java:finalize(42)) - ManagedSlice is not closed properly
```

This change attempts to fix it by closing `ManagedReadOptions` and `ManagedSlice` instance in `DBScanner`.

Also, add allocation stack trace to `ManagedReadOptions` and `ManagedSlice` to help debug any further leak.

https://issues.apache.org/jira/browse/HDDS-9283

## How was this patch tested?

`TestLDBCli` passed:
https://github.com/adoroszlai/hadoop-ozone/actions/runs/6678993900/job/18157010772#step:6:113

(Even without the fix I could not intentionally reproduce the bug in repeated execution with the stack trace added, so I did not try repeated run with the fix.)

CI:
https://github.com/adoroszlai/hadoop-ozone/actions/runs/6678993900