### PR TITLE
HDDS-9559. Synchronized OmSnapshotMetrics initialization

### DIFF
--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmSnapshotMetrics.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmSnapshotMetrics.java
@@ -17,6 +17,7 @@
  */
 package org.apache.hadoop.ozone.om;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.apache.hadoop.hdds.annotation.InterfaceAudience;
 import org.apache.hadoop.metrics2.MetricsSystem;
 import org.apache.hadoop.metrics2.annotation.Metric;
@@ -37,6 +38,8 @@ public final class OmSnapshotMetrics implements OmMetadataReaderMetrics {
   }
 
   private static OmSnapshotMetrics instance;
+
+  @SuppressFBWarnings("DC_DOUBLECHECK")
   public static OmSnapshotMetrics getInstance() {
     if (instance != null) {
       return instance;

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmSnapshotMetrics.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmSnapshotMetrics.java
@@ -41,10 +41,15 @@ public final class OmSnapshotMetrics implements OmMetadataReaderMetrics {
     if (instance != null) {
       return instance;
     }
-    MetricsSystem ms = DefaultMetricsSystem.instance();
-    instance = ms.register(SOURCE_NAME,
-        "Snapshot Manager Metrics",
-        new OmSnapshotMetrics());
+
+    synchronized (OmSnapshotMetrics.class) {
+      if (instance == null) {
+        MetricsSystem ms = DefaultMetricsSystem.instance();
+        instance = ms.register(SOURCE_NAME,
+            "Snapshot Manager Metrics",
+            new OmSnapshotMetrics());
+      }
+    }
     return instance;
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?
Snapshot's snap diff acceptance test failed with an exception `Metrics source OmSnapshotMetrics already exists!`. Based on exception and message looks like `OmSnapshotMetrics` is getting initialized more than once. Even though it is singleton class, it is not synchronized. So it is possible that two or more threads can try to register `OmSnapshotMetrics` metric at the same time and fail except the first one.

This change is to put `register` inside a `synchronized` block and added double check to make sure that it is registered only once.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-9559

## How was this patch tested?
Existing unit test.
