### PR TITLE
HDDS-9560. Improve NSSummaryTask thread name

### DIFF
--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/tasks/NSSummaryTask.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/tasks/NSSummaryTask.java
@@ -37,6 +37,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Callable;
 import java.util.concurrent.Future;
+import java.util.concurrent.ThreadFactory;
 
 /**
  * Task to query data from OMDB and write into Recon RocksDB.
@@ -123,10 +124,11 @@ public class NSSummaryTask implements ReconOmTask {
         .reprocessWithLegacy(reconOMMetadataManager));
 
     List<Future<Boolean>> results;
-    ExecutorService executorService = Executors
-        .newFixedThreadPool(2,
-            new ThreadFactoryBuilder().setNameFormat("NSSummaryTask - %d")
-                .build());
+    ThreadFactory threadFactory = new ThreadFactoryBuilder()
+        .setNameFormat("Recon-NSSummaryTask-%d")
+        .build();
+    ExecutorService executorService = Executors.newFixedThreadPool(2,
+        threadFactory);
     try {
       results = executorService.invokeAll(tasks);
       for (int i = 0; i < results.size(); i++) {


### PR DESCRIPTION
## What changes were proposed in this pull request?
This item's jira: [Improve NSSummaryTask thread name](https://issues.apache.org/jira/browse/HDDS-9560)
Change NSSummaryTask thread name missing from https://github.com/apache/ozone/pull/5456

Sometimes in tests it's hard to follow which thread was created where, adding these prefixes help clarifying these. More can be found in the parent jira: [Improve thread names](https://issues.apache.org/jira/browse/HDDS-8719).

## How was this patch tested?

Running the test locally and observing that the threadnames changed and starting a CI run on my fork: https://github.com/Galsza/ozone/actions/runs/6696071994
