### PR TITLE
HDDS-8201. Migrated TestOmSnapshotFileSystem tests to JUnit5.

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/TestDataUtil.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/TestDataUtil.java
@@ -73,6 +73,15 @@ public final class TestDataUtil {
   public static OzoneBucket createVolumeAndBucket(OzoneClient client,
       String volumeName, String bucketName,
       BucketArgs omBucketArgs) throws IOException {
+
+    OzoneVolume volume = createVolume(client, volumeName);
+    volume.createBucket(bucketName, omBucketArgs);
+    return volume.getBucket(bucketName);
+
+  }
+
+  public static OzoneVolume createVolume(OzoneClient client,
+                                         String volumeName) throws IOException {
     String userName = "user" + RandomStringUtils.randomNumeric(5);
     String adminName = "admin" + RandomStringUtils.randomNumeric(5);
 
@@ -83,10 +92,7 @@ public final class TestDataUtil {
 
     objectStore.createVolume(volumeName, volumeArgs);
 
-    OzoneVolume volume = objectStore.getVolume(volumeName);
-
-    volume.createBucket(bucketName, omBucketArgs);
-    return volume.getBucket(bucketName);
+    return objectStore.getVolume(volumeName);
 
   }
 

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/TestDataUtil.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/TestDataUtil.java
@@ -71,9 +71,10 @@ public final class TestDataUtil {
   }
 
   public static OzoneBucket createVolumeAndBucket(OzoneClient client,
-      String volumeName, String bucketName,
-      BucketArgs omBucketArgs) throws IOException {
-
+                                                  String volumeName,
+                                                  String bucketName,
+                                                  BucketArgs omBucketArgs)
+      throws IOException {
     OzoneVolume volume = createVolume(client, volumeName);
     volume.createBucket(bucketName, omBucketArgs);
     return volume.getBucket(bucketName);
@@ -84,14 +85,13 @@ public final class TestDataUtil {
                                          String volumeName) throws IOException {
     String userName = "user" + RandomStringUtils.randomNumeric(5);
     String adminName = "admin" + RandomStringUtils.randomNumeric(5);
-
-    VolumeArgs volumeArgs =
-        VolumeArgs.newBuilder().setAdmin(adminName).setOwner(userName).build();
+    VolumeArgs volumeArgs = VolumeArgs.newBuilder()
+        .setAdmin(adminName)
+        .setOwner(userName)
+        .build();
 
     ObjectStore objectStore = client.getObjectStore();
-
     objectStore.createVolume(volumeName, volumeArgs);
-
     return objectStore.getVolume(volumeName);
 
   }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOmSnapshotFileSystem.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOmSnapshotFileSystem.java
@@ -99,8 +99,6 @@ public abstract class TestOmSnapshotFileSystem {
   private static OzoneClient client;
   private static ObjectStore objectStore;
   private static OzoneConfiguration conf;
-  private static FileSystem fs;
-  private static OzoneFileSystem o3fs;
   private static OzoneManagerProtocol writeClient;
   private static OzoneManager ozoneManager;
   private static String keyPrefix;
@@ -108,6 +106,8 @@ public abstract class TestOmSnapshotFileSystem {
   private static String bucketNameFso;
   private static String bucketNameLegacy;
   private final String bucketName;
+  private FileSystem fs;
+  private OzoneFileSystem o3fs;
 
   private static final Logger LOG =
       LoggerFactory.getLogger(TestOmSnapshot.class);


### PR DESCRIPTION
## What changes were proposed in this pull request?
This change is to migrate TestOmSnapshotFileSystem tests from JUnit-4 to JUnit-5. Changed the cluster setup to only once at class level as suggested in https://github.com/apache/ozone/pull/4740.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-8201

## How was this patch tested?
Ran the unit test locally and workflow run. Test run time after the change around 80 secs.
```
[INFO] Running org.apache.hadoop.ozone.om.TestOmSnapshotFileSystem
[INFO] Tests run: 16, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 80.806 s - in org.apache.hadoop.ozone.om.TestOmSnapshotFileSystem
```