### PR TITLE
HDDS-9393. Introduce data unit support for objects creation in freon

### DIFF
--- a/hadoop-ozone/tools/pom.xml
+++ b/hadoop-ozone/tools/pom.xml
@@ -126,6 +126,12 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
       <artifactId>junit-jupiter-params</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-core</artifactId>
+      <version>5.3.27</version>
+      <scope>compile</scope>
+    </dependency>
   </dependencies>
   <build>
     <plugins>

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/AbstractOmBucketReadWriteOps.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/AbstractOmBucketReadWriteOps.java
@@ -22,6 +22,7 @@ import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.ozone.OzoneConsts;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.util.unit.DataSize;
 import picocli.CommandLine.Option;
 
 import java.io.IOException;
@@ -46,10 +47,12 @@ public abstract class AbstractOmBucketReadWriteOps extends BaseFreonGenerator
       LoggerFactory.getLogger(AbstractOmBucketReadWriteOps.class);
 
   @Option(names = {"-g", "--size"},
-      description = "Generated data size (in bytes) of each key/file to be " +
-          "written.",
-      defaultValue = "256")
-  private long sizeInBytes;
+      description = "Generated data size of each key/file to be written. " +
+          "You can specify the size using data units like 'GB', 'MB', 'KB', " +
+          "etc.",
+      defaultValue = "256B",
+      converter = DataSizeConverter.class)
+  private DataSize size;
 
   @Option(names = {"--buffer"},
       description = "Size of buffer used for generating the key/file content.",
@@ -103,7 +106,7 @@ public abstract class AbstractOmBucketReadWriteOps extends BaseFreonGenerator
     writeThreadCount = totalThreadCount - readThreadCount;
 
     display();
-    print("SizeInBytes: " + sizeInBytes);
+    print("SizeInBytes: " + size.toBytes());
     print("bufferSize: " + bufferSize);
     print("totalThreadCount: " + totalThreadCount);
     print("readThreadPercentage: " + readThreadPercentage);
@@ -114,7 +117,7 @@ public abstract class AbstractOmBucketReadWriteOps extends BaseFreonGenerator
     print("numOfWriteOperations: " + numOfWriteOperations);
 
     ozoneConfiguration = createOzoneConfiguration();
-    contentGenerator = new ContentGenerator(sizeInBytes, bufferSize);
+    contentGenerator = new ContentGenerator(size.toBytes(), bufferSize);
     timer = getMetrics().timer("om-bucket-read-write-ops");
 
     initialize(ozoneConfiguration);
@@ -223,6 +226,6 @@ public abstract class AbstractOmBucketReadWriteOps extends BaseFreonGenerator
   protected abstract OutputStream create(String pathName) throws IOException;
 
   protected long getSizeInBytes() {
-    return sizeInBytes;
+    return size.toBytes();
   }
 }

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/DataSizeConverter.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/DataSizeConverter.java
@@ -1,0 +1,37 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with this
+ * work for additional information regarding copyright ownership.  The ASF
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.hadoop.ozone.freon;
+
+import org.springframework.util.unit.DataSize;
+import org.springframework.util.unit.DataUnit;
+import picocli.CommandLine.ITypeConverter;
+
+/**
+ * A Picocli custom converter for parsing command line string values into
+ * DataSize objects.
+ */
+
+public class DataSizeConverter implements ITypeConverter<DataSize> {
+  @Override
+  public DataSize convert(String value) throws Exception {
+    try {
+      return DataSize.parse(value, DataUnit.BYTES);
+    } catch (IllegalArgumentException e) {
+      throw new Exception("Invalid data size format: " + value);
+    }
+  }
+}

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/HadoopDirTreeGenerator.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/HadoopDirTreeGenerator.java
@@ -25,6 +25,7 @@ import org.apache.hadoop.hdds.cli.HddsVersionProvider;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.util.unit.DataSize;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Option;
 
@@ -67,11 +68,13 @@ public class HadoopDirTreeGenerator extends BaseFreonGenerator
   private int fileCount;
 
   @Option(names = {"-g", "--file-size", "--fileSize"},
-      description = "Generated data size(in bytes) of each file to be " +
-          "written in each directory. Full name --fileSize will be removed " +
-          "in later versions.",
-      defaultValue = "4096")
-  private long fileSizeInBytes;
+      description = "Generated data size of each file to be " +
+          "written in each directory. You can specify the size using data " +
+          "units like 'GB', 'MB', 'KB', etc. Full name --fileSize will be " +
+          "removed in later versions.",
+      defaultValue = "4KB",
+      converter = DataSizeConverter.class)
+  private DataSize fileSize;
 
   @Option(names = {"-b", "--buffer"},
           description = "Size of buffer used to generated the file content.",
@@ -113,7 +116,7 @@ public class HadoopDirTreeGenerator extends BaseFreonGenerator
       OzoneConfiguration configuration = createOzoneConfiguration();
       fileSystem = FileSystem.get(URI.create(rootPath), configuration);
 
-      contentGenerator = new ContentGenerator(fileSizeInBytes, bufferSize);
+      contentGenerator = new ContentGenerator(fileSize.toBytes(), bufferSize);
       timer = getMetrics().timer("file-create");
 
       runTests(this::createDir);

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/HadoopFsGenerator.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/HadoopFsGenerator.java
@@ -28,6 +28,7 @@ import org.apache.hadoop.hdds.cli.HddsVersionProvider;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 
 import com.codahale.metrics.Timer;
+import org.springframework.util.unit.DataSize;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Option;
 
@@ -49,9 +50,11 @@ public class HadoopFsGenerator extends BaseFreonGenerator
   private String rootPath;
 
   @Option(names = {"-s", "--size"},
-      description = "Size of the generated files (in bytes)",
-      defaultValue = "10240")
-  private long fileSize;
+      description = "Size of the generated files. You can specify the size " +
+          "using data units like 'GB', 'MB', 'KB', etc.",
+      defaultValue = "10KB",
+      converter = DataSizeConverter.class)
+  private DataSize fileSize;
 
   @Option(names = {"--buffer"},
       description = "Size of buffer used store the generated key content",
@@ -95,7 +98,8 @@ public class HadoopFsGenerator extends BaseFreonGenerator
     }
 
     contentGenerator =
-        new ContentGenerator(fileSize, bufferSize, copyBufferSize, flushOrSync);
+        new ContentGenerator(fileSize.toBytes(), bufferSize, copyBufferSize,
+            flushOrSync);
 
     timer = getMetrics().timer("file-create");
 

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/StreamingGenerator.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/StreamingGenerator.java
@@ -25,6 +25,7 @@ import org.apache.hadoop.ozone.container.stream.StreamingClient;
 import org.apache.hadoop.ozone.container.stream.StreamingServer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.util.unit.DataSize;
 import picocli.CommandLine;
 
 import java.io.FileOutputStream;
@@ -61,9 +62,11 @@ public class StreamingGenerator extends BaseFreonGenerator
   private int numberOfFiles;
 
   @CommandLine.Option(names = {"--size"},
-      description = "Size of the generated files.",
-      defaultValue = "104857600")
-  private long fileSize;
+      description = "Size of the generated files. You can specify the size " +
+          "using data units like 'GB', 'MB', 'KB', etc.",
+      defaultValue = "100MB",
+      converter = DataSizeConverter.class)
+  private DataSize fileSize;
 
   private static final String SUB_DIR_NAME = "dir1";
 
@@ -91,8 +94,8 @@ public class StreamingGenerator extends BaseFreonGenerator
       }
       Path subDir = sourceDir.resolve(SUB_DIR_NAME);
       Files.createDirectories(subDir);
-      ContentGenerator contentGenerator = new ContentGenerator(fileSize,
-          1024);
+      ContentGenerator contentGenerator =
+          new ContentGenerator(fileSize.toBytes(), 1024);
 
       for (int i = 0; i < numberOfFiles; i++) {
         try (FileOutputStream out = new FileOutputStream(


### PR DESCRIPTION
## What changes were proposed in this pull request?

Address a [suggestion](https://github.com/apache/ozone/pull/5386#pullrequestreview-1658397256) shared on [HDDS-9374](https://issues.apache.org/jira/browse/HDDS-9374). RangeKeysGenerator freon tool should support objects creation >2GB.

The key improvement proposed is the introduction of data units support for the '--size' parameter to be specified while using most ozone freon tools. Currently, users are required to specify sizes in bytes, which can be cumbersome. With this change, users will have the convenience of specifying object sizes using data units like `GB`, `MB`, `KB`, etc.

For example, the current use case for creating an object with the size of `4GB` [`4294967296` bytes] would look like this (if no unit is specified, the default unit is bytes):

```
$ ozone freon ork -n 1 -t 1 --size 4294967296 -v voltest -b buckettest -p test
```

With the proposed enhancement, the same use case can be expressed more intuitively, like this:
```
$ ozone freon ork -n 1 -t 1 --size 4GB -v voltest -b buckettest -p test
```

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-9393

## How was this patch tested?

Existing test cases should cover the change.
