### PR TITLE
HDDS-9540. Inconsistent API definitions in BlockManager

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/impl/BlockManagerImpl.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/impl/BlockManagerImpl.java
@@ -75,28 +75,11 @@ public class BlockManagerImpl implements BlockManager {
         StorageUnit.BYTES);
   }
 
-  /**
-   * Puts or overwrites a block.
-   *
-   * @param container - Container for which block need to be added.
-   * @param data - BlockData.
-   * @return length of the block.
-   * @throws IOException
-   */
   @Override
   public long putBlock(Container container, BlockData data) throws IOException {
     return putBlock(container, data, true);
   }
-  /**
-   * Puts or overwrites a block.
-   *
-   * @param container - Container for which block need to be added.
-   * @param data - BlockData.
-   * @param endOfBlock - The last putBlock call for this block (when
-   *                     all the chunks are written and stream is closed)
-   * @return length of the block.
-   * @throws IOException
-   */
+
   @Override
   public long putBlock(Container container, BlockData data,
       boolean endOfBlock) throws IOException {
@@ -222,14 +205,6 @@ public class BlockManagerImpl implements BlockManager {
     }
   }
 
-  /**
-   * Gets an existing block.
-   *
-   * @param container - Container from which block needs to be fetched.
-   * @param blockID - BlockID of the block.
-   * @return Block Data.
-   * @throws IOException
-   */
   @Override
   public BlockData getBlock(Container container, BlockID blockID)
       throws IOException {
@@ -264,14 +239,6 @@ public class BlockManagerImpl implements BlockManager {
     }
   }
 
-  /**
-   * Returns the last committed length of the block.
-   *
-   * @param container - Container from which block need to be fetched.
-   * @param blockID - BlockID of the block.
-   * @return length of the block.
-   * @throws IOException in case, the block key does not exist in db.
-   */
   @Override
   public long getCommittedBlockLength(Container container, BlockID blockID)
       throws IOException {
@@ -291,13 +258,6 @@ public class BlockManagerImpl implements BlockManager {
     return defaultReadBufferCapacity;
   }
 
-  /**
-   * Deletes an existing block.
-   *
-   * @param container - Container from which block need to be deleted.
-   * @param blockID - ID of the block.
-   * @throws StorageContainerException
-   */
   @Override
   public void deleteBlock(Container container, BlockID blockID) throws
       IOException {
@@ -307,14 +267,6 @@ public class BlockManagerImpl implements BlockManager {
     throw new UnsupportedOperationException();
   }
 
-  /**
-   * List blocks in a container.
-   *
-   * @param container - Container from which blocks need to be listed.
-   * @param startLocalID  - Key to start from, 0 to begin.
-   * @param count - Number of blocks to return.
-   * @return List of Blocks that match the criteria.
-   */
   @Override
   public List<BlockData> listBlock(Container container, long startLocalID, int
       count) throws IOException {

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/impl/BlockManagerImpl.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/impl/BlockManagerImpl.java
@@ -79,7 +79,7 @@ public class BlockManagerImpl implements BlockManager {
    * Puts or overwrites a block.
    *
    * @param container - Container for which block need to be added.
-   * @param data     - BlockData.
+   * @param data - BlockData.
    * @return length of the block.
    * @throws IOException
    */
@@ -93,7 +93,7 @@ public class BlockManagerImpl implements BlockManager {
    * @param container - Container for which block need to be added.
    * @param data - BlockData.
    * @param endOfBlock - The last putBlock call for this block (when
-   *                   all the chunks are written and stream is closed)
+   *                     all the chunks are written and stream is closed)
    * @return length of the block.
    * @throws IOException
    */
@@ -225,9 +225,9 @@ public class BlockManagerImpl implements BlockManager {
   /**
    * Gets an existing block.
    *
-   * @param container - Container from which block need to be fetched.
+   * @param container - Container from which block needs to be fetched.
    * @param blockID - BlockID of the block.
-   * @return Key Data.
+   * @return Block Data.
    * @throws IOException
    */
   @Override
@@ -265,7 +265,7 @@ public class BlockManagerImpl implements BlockManager {
   }
 
   /**
-   * Returns the length of the committed block.
+   * Returns the last committed length of the block.
    *
    * @param container - Container from which block need to be fetched.
    * @param blockID - BlockID of the block.
@@ -293,6 +293,10 @@ public class BlockManagerImpl implements BlockManager {
 
   /**
    * Deletes an existing block.
+   *
+   * @param container - Container from which block need to be deleted.
+   * @param blockID - ID of the block.
+   * @throws StorageContainerException
    */
   @Override
   public void deleteBlock(Container container, BlockID blockID) throws
@@ -308,7 +312,7 @@ public class BlockManagerImpl implements BlockManager {
    *
    * @param container - Container from which blocks need to be listed.
    * @param startLocalID  - Key to start from, 0 to begin.
-   * @param count    - Number of blocks to return.
+   * @param count - Number of blocks to return.
    * @return List of Blocks that match the criteria.
    */
   @Override

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/impl/BlockManagerImpl.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/impl/BlockManagerImpl.java
@@ -258,6 +258,14 @@ public class BlockManagerImpl implements BlockManager {
     return defaultReadBufferCapacity;
   }
 
+  /**
+   * Deletes an existing block.
+   * As Deletion is handled by BlockDeletingService,
+   * UnsupportedOperationException is thrown always
+   *
+   * @param container - Container from which block need to be deleted.
+   * @param blockID - ID of the block.
+   */
   @Override
   public void deleteBlock(Container container, BlockID blockID) throws
       IOException {

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/interfaces/BlockManager.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/interfaces/BlockManager.java
@@ -34,7 +34,7 @@ public interface BlockManager {
    * Puts or overwrites a block.
    *
    * @param container - Container for which block need to be added.
-   * @param data     - Block Data.
+   * @param data - Block Data.
    * @return length of the Block.
    * @throws IOException
    */
@@ -44,18 +44,19 @@ public interface BlockManager {
    * Puts or overwrites a block.
    *
    * @param container - Container for which block need to be added.
-   * @param data     - Block Data.
-   * @param incrKeyCount - Whether to increase container key count.
+   * @param data - Block Data.
+   * @param endOfBlock - The last putBlock call for this block (when
+   *                     all the chunks are written and stream is closed)
    * @return length of the Block.
    * @throws IOException
    */
-  long putBlock(Container container, BlockData data, boolean incrKeyCount)
+  long putBlock(Container container, BlockData data, boolean endOfBlock)
       throws IOException;
 
   /**
    * Gets an existing block.
    *
-   * @param container - Container from which block need to be get.
+   * @param container - Container from which block needs to be fetched.
    * @param blockID - BlockID of the Block.
    * @return Block Data.
    * @throws IOException
@@ -77,15 +78,19 @@ public interface BlockManager {
    *
    * @param container - Container from which blocks need to be listed.
    * @param startLocalID  - Block to start from, 0 to begin.
-   * @param count    - Number of blocks to return.
+   * @param count - Number of blocks to return.
    * @return List of Blocks that match the criteria.
    */
   List<BlockData> listBlock(Container container, long startLocalID, int count)
       throws IOException;
 
   /**
-   * Returns the last committed block length for the block.
-   * @param blockID blockId
+   * Returns last committed length of the block.
+   *
+   * @param container - Container from which block need to be fetched.
+   * @param blockID - BlockID of the block.
+   * @return length of the block.
+   * @throws IOException in case, the block key does not exist in db.
    */
   long getCommittedBlockLength(Container container, BlockID blockID)
       throws IOException;

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/interfaces/BlockManager.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/interfaces/BlockManager.java
@@ -57,7 +57,7 @@ public interface BlockManager {
    * @param container - Container from which block needs to be fetched.
    * @param blockID - BlockID of the Block.
    * @return Block Data.
-   * @throws StorageContainerException when BcsId is unknown or mismatched
+   * @throws IOException when BcsId is unknown or mismatched
    */
   BlockData getBlock(Container container, BlockID blockID)
       throws IOException;
@@ -67,7 +67,6 @@ public interface BlockManager {
    *
    * @param container - Container from which block need to be deleted.
    * @param blockID - ID of the block.
-   * @throws UnsupportedOperationException
    */
   void deleteBlock(Container container, BlockID blockID) throws IOException;
 

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/interfaces/BlockManager.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/interfaces/BlockManager.java
@@ -18,7 +18,6 @@
 package org.apache.hadoop.ozone.container.keyvalue.interfaces;
 
 import org.apache.hadoop.hdds.client.BlockID;
-import org.apache.hadoop.hdds.scm.container.common.helpers.StorageContainerException;
 import org.apache.hadoop.ozone.container.common.helpers.BlockData;
 import org.apache.hadoop.ozone.container.common.interfaces.Container;
 

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/interfaces/BlockManager.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/interfaces/BlockManager.java
@@ -36,7 +36,6 @@ public interface BlockManager {
    * @param container - Container for which block need to be added.
    * @param data - Block Data.
    * @return length of the Block.
-   * @throws IOException
    */
   long putBlock(Container container, BlockData data) throws IOException;
 
@@ -48,7 +47,6 @@ public interface BlockManager {
    * @param endOfBlock - The last putBlock call for this block (when
    *                     all the chunks are written and stream is closed)
    * @return length of the Block.
-   * @throws IOException
    */
   long putBlock(Container container, BlockData data, boolean endOfBlock)
       throws IOException;
@@ -59,7 +57,7 @@ public interface BlockManager {
    * @param container - Container from which block needs to be fetched.
    * @param blockID - BlockID of the Block.
    * @return Block Data.
-   * @throws IOException
+   * @throws StorageContainerException when BcsId is unknown or mismatched
    */
   BlockData getBlock(Container container, BlockID blockID)
       throws IOException;
@@ -69,7 +67,7 @@ public interface BlockManager {
    *
    * @param container - Container from which block need to be deleted.
    * @param blockID - ID of the block.
-   * @throws StorageContainerException
+   * @throws UnsupportedOperationException
    */
   void deleteBlock(Container container, BlockID blockID) throws IOException;
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

There were some inconsistent API definitions in BlockManager and BlockManagerImpl for putBlock(), getBlock(), getCommittedBlockLength(), deleteBlock() and listBlock().
This PR makes all the definitions consistent between the BlockManager interface and BlockManagerImpl class. 

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-9540

## How was this patch tested?

As it is only a JavaDoc change, No tests were performed
