### PR TITLE
HDDS-9085. Recon Directories Pending for Deletion Inside OMDB Insight

### DIFF
--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/api/db.json
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/api/db.json
@@ -6697,7 +6697,7 @@
         "path": ".Trash/hadoop/231010153900",
         "inStateSince": 1696952297266,
         "size": 17289,
-        "replicatedSize": 0,
+        "replicatedSize": 100,
         "replicationInfo": {
           "replicationFactor": "THREE",
           "requiredNodes": 3,
@@ -6708,7 +6708,7 @@
         "key": "/-4611686018427388160/-9223372036854775552/-9223372036854775552/dir3/-9223372036854774015",
         "path": "dir1",
         "inStateSince": 1696954980154,
-        "size": 0,
+        "size": 1200,
         "replicatedSize": 0,
         "replicationInfo": {
           "replicationFactor": "THREE",

--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/api/db.json
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/api/db.json
@@ -6688,7 +6688,6 @@
     ]
   },
   "dirdeletePending": {
-    "lastKey": "dir11",
     "replicatedDataSize": 0,
     "unreplicatedDataSize": 0,
     "deletedDirInfo": [

--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/api/db.json
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/api/db.json
@@ -6686,5 +6686,73 @@
         ]
       }
     ]
+  },
+  "dirdeletePending": {
+    "lastKey": "dir11",
+    "replicatedDataSize": 0,
+    "unreplicatedDataSize": 0,
+    "deletedDirInfo": [
+      {
+        "key": "/-4611686018427388160/-9223372036854775552/-9223372036854764286/231010153900/-9223372036854760111",
+        "path": ".Trash/hadoop/231010153900",
+        "inStateSince": 1696952297266,
+        "size": 17289,
+        "replicatedSize": 0,
+        "replicationInfo": {
+          "replicationFactor": "THREE",
+          "requiredNodes": 3,
+          "replicationType": "RATIS"
+        }
+      },
+      {
+        "key": "/-4611686018427388160/-9223372036854775552/-9223372036854775552/dir3/-9223372036854774015",
+        "path": "dir1",
+        "inStateSince": 1696954980154,
+        "size": 0,
+        "replicatedSize": 0,
+        "replicationInfo": {
+          "replicationFactor": "THREE",
+          "requiredNodes": 3,
+          "replicationType": "RATIS"
+        }
+      },
+      {
+        "key": "/-4611686018427388160/-9223372036854775552/-9223372036854764286/231010153900/-9223372036854760191",
+        "path": ".Trash/hadoop/231010153900",
+        "inStateSince": 1696952297266,
+        "size": 17289,
+        "replicatedSize": 0,
+        "replicationInfo": {
+          "replicationFactor": "THREE",
+          "requiredNodes": 3,
+          "replicationType": "RATIS"
+        }
+      },
+      {
+        "key": "/-4611686018427388160/-9223372036854775552/-9223372036854775552/dir3/-9223372036854774112",
+        "path": "dir21",
+        "inStateSince": 1696954980154,
+        "size": 17289,
+        "replicatedSize": 0,
+        "replicationInfo": {
+          "replicationFactor": "THREE",
+          "requiredNodes": 3,
+          "replicationType": "RATIS"
+        }
+      },
+      {
+        "key": "/-4611686018427388160/-9223372036854775552/-9223372036854775552/dir3/-922337203685477303",
+        "path": "dir22",
+        "inStateSince": 1696954980900,
+        "size": 20289,
+        "replicatedSize": 0,
+        "replicationInfo": {
+          "replicationFactor": "THREE",
+          "requiredNodes": 3,
+          "replicationType": "RATIS"
+        }
+      }
+    ],
+    "status": "OK"
   }
 }

--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/api/routes.json
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/api/routes.json
@@ -48,5 +48,6 @@
 
   "/keys/deletePending?limit=*" : "/keydeletePending",
 
-  "/containers/mismatch/deleted?limit=*": "/deleted"
+  "/containers/mismatch/deleted?limit=*": "/deleted",
+  "/keys/deletePending/dirs?limit=*": "/dirdeletePending"
 }

--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/views/insights/om/om.tsx
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/views/insights/om/om.tsx
@@ -289,7 +289,7 @@ const PENDINGDIR_TAB_COLUMNS = [
     }
   },
   {
-    title: 'Key',
+    title: 'Path',
     dataIndex: 'key',
     key: 'key',
     isSearchable: true,

--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/views/insights/om/om.tsx
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/views/insights/om/om.tsx
@@ -274,6 +274,35 @@ const DELETED_TAB_COLUMNS = [
   }
 ];
 
+const PENDINGDIR_TAB_COLUMNS = [
+  {
+    title: 'Directory Name',
+    dataIndex: 'path',
+    key: 'path'
+  },
+  {
+    title: 'In state since',
+    dataIndex: 'inStateSince',
+    key: 'inStateSince',
+    render: (inStateSince: number) => {
+      return inStateSince > 0 ? moment(inStateSince).format('ll LTS') : 'NA';
+    }
+  },
+  {
+    title: 'Key',
+    dataIndex: 'key',
+    key: 'key',
+    isSearchable: true,
+    width: '450px'
+  },
+  {
+    title: 'Data Size',
+    dataIndex: 'size',
+    key: 'size',
+    render: (dataSize :any) => dataSize = byteToSize(dataSize,1)
+  }
+];
+
 interface IExpandedRow {
   [key: number]: IExpandedRowState;
 }
@@ -293,6 +322,7 @@ interface IOmdbInsightsState {
   expandedRowData: IExpandedRow;
   deletedContainerKeysDataSource: [];
   mismatchMissingState: any;
+  pendingDeleteDirDataSource: any[];
   activeTab: string;
   includeFso: boolean;
   includeNonFso: boolean;
@@ -313,6 +343,7 @@ let cancelOpenKeysSignal: AbortController;
 let cancelDeletePendingSignal: AbortController;
 let cancelDeletedKeysSignal: AbortController;
 let cancelRowExpandSignal: AbortController;
+let cancelDeletedPendingDirSignal: AbortController;
 
 export class Om extends React.Component<Record<string, object>, IOmdbInsightsState> {
 
@@ -326,6 +357,7 @@ export class Om extends React.Component<Record<string, object>, IOmdbInsightsSta
       openKeysDataSource: [],
       pendingDeleteKeyDataSource: [],
       deletedContainerKeysDataSource: [],
+      pendingDeleteDirDataSource:[],
       mismatchMissingState: 'SCM',
       expandedRowData: {},
       activeTab: props.location.state ? props.location.state.activeTab : '1',
@@ -448,6 +480,8 @@ export class Om extends React.Component<Record<string, object>, IOmdbInsightsSta
       this.fetchDeletePendingKeys();
     } else if (this.state.activeTab  === '4') {
       this.fetchDeletedKeys();
+    } else if (this.state.activeTab  === '5') {
+      this.fetchDeletePendingDir();
     }
   }
 
@@ -461,6 +495,7 @@ export class Om extends React.Component<Record<string, object>, IOmdbInsightsSta
     cancelDeletePendingSignal && cancelDeletePendingSignal.abort();
     cancelDeletedKeysSignal && cancelDeletedKeysSignal.abort();
     cancelRowExpandSignal && cancelRowExpandSignal.abort();
+    cancelDeletedPendingDirSignal && cancelDeletedPendingDirSignal.abort();
   }
 
   fetchMismatchContainers = (mismatchMissingState: any) => {
@@ -475,7 +510,8 @@ export class Om extends React.Component<Record<string, object>, IOmdbInsightsSta
       cancelOpenKeysSignal,
       cancelDeletePendingSignal,
       cancelDeletedKeysSignal,
-      cancelRowExpandSignal
+      cancelRowExpandSignal,
+      cancelDeletedPendingDirSignal
     ]);
 
     const mismatchEndpoint = `/api/v1/containers/mismatch?limit=${this.state.selectedLimit.value}&missingIn=${mismatchMissingState}`
@@ -510,7 +546,8 @@ export class Om extends React.Component<Record<string, object>, IOmdbInsightsSta
       cancelOpenKeysSignal,
       cancelDeletePendingSignal,
       cancelDeletedKeysSignal,
-      cancelRowExpandSignal
+      cancelRowExpandSignal,
+      cancelDeletedPendingDirSignal
     ]);
 
     let openKeysEndpoint = `/api/v1/keys/open?includeFso=${includeFso}&includeNonFso=${includeNonFso}&limit=${this.state.selectedLimit.value}`;
@@ -550,7 +587,8 @@ export class Om extends React.Component<Record<string, object>, IOmdbInsightsSta
       cancelOpenKeysSignal,
       cancelDeletePendingSignal,
       cancelDeletedKeysSignal,
-      cancelRowExpandSignal
+       cancelRowExpandSignal,
+       cancelDeletedPendingDirSignal
     ]);
 
     keysPendingExpanded =[];
@@ -651,7 +689,8 @@ export class Om extends React.Component<Record<string, object>, IOmdbInsightsSta
       cancelOpenKeysSignal,
       cancelDeletePendingSignal,
       cancelDeletedKeysSignal,
-      cancelRowExpandSignal
+      cancelRowExpandSignal,
+      cancelDeletedPendingDirSignal
     ]);
 
     const deletedKeysEndpoint = `/api/v1/containers/mismatch/deleted?limit=${this.state.selectedLimit.value}`;
@@ -671,6 +710,41 @@ export class Om extends React.Component<Record<string, object>, IOmdbInsightsSta
       showDataFetchError(error.toString());
     });
   };
+
+   // Pending Delete Directories
+   fetchDeletePendingDir = () => {
+    this.setState({
+      loading: true
+    });
+
+    //Cancel any previous pending request
+    cancelRequests([
+      cancelMismatchedEndpointSignal,
+      cancelOpenKeysSignal,
+      cancelDeletePendingSignal,
+      cancelDeletedKeysSignal,
+      cancelRowExpandSignal,
+      cancelDeletedPendingDirSignal
+    ]);
+    
+    const DELETE_PENDING_DIR_ENDPOINT = `/api/v1/keys/deletePending/dirs?limit=${this.state.selectedLimit.value}`;
+    const { request, controller } = AxiosGetHelper(DELETE_PENDING_DIR_ENDPOINT, cancelDeletedPendingDirSignal);
+    cancelDeletedPendingDirSignal = controller 
+     request.then(deletePendingDirResponse => {
+      let deletedDirInfo  = [];
+       deletedDirInfo = deletePendingDirResponse && deletePendingDirResponse.data && deletePendingDirResponse.data.deletedDirInfo;
+        this.setState({
+          loading: false,
+          pendingDeleteDirDataSource: deletedDirInfo
+        });
+    }).catch(error => {
+      this.setState({
+        loading: false,
+      });
+      showDataFetchError(error.toString());
+    });
+  };
+
 
   changeTab = (activeKey: any) => {
     this.setState({
@@ -692,6 +766,8 @@ export class Om extends React.Component<Record<string, object>, IOmdbInsightsSta
         this.fetchDeletePendingKeys();
       } else if (activeKey === '4') {
         this.fetchDeletedKeys();
+      } else if (activeKey === '5') {
+        this.fetchDeletePendingDir ();
       }
       else {
         this.fetchMismatchContainers(this.state.mismatchMissingState);
@@ -835,6 +911,21 @@ export class Om extends React.Component<Record<string, object>, IOmdbInsightsSta
     }, [])
   };
 
+  searchDirPendingColumn = () => {
+    return PENDINGDIR_TAB_COLUMNS.reduce<any[]>((filtered, column) => {
+      if (column.isSearchable) {
+        const newColumn = {
+          ...column,
+          ...new ColumnSearch(column).getColumnSearchProps(column.dataIndex)
+        };
+        filtered.push(newColumn);
+      } else {
+        filtered.push(column);
+      }
+      return filtered;
+    }, [])
+  };
+
   _handleLimitChange = (selected: ValueType<IOption>, _action: ActionMeta<IOption>) => {
     const selectedLimit = (selected as IOption)
     this.setState({
@@ -858,7 +949,7 @@ export class Om extends React.Component<Record<string, object>, IOmdbInsightsSta
   }
 
   render() {
-    const { mismatchDataSource, loading, openKeysDataSource, pendingDeleteKeyDataSource, deletedContainerKeysDataSource, selectedLimit } = this.state;
+    const { mismatchDataSource, loading, openKeysDataSource, pendingDeleteKeyDataSource, deletedContainerKeysDataSource, pendingDeleteDirDataSource, selectedLimit } = this.state;
 
     const paginationConfig: PaginationConfig = {
       showTotal: (total: number, range) => `${range[0]}-${range[1]} of ${total}`,
@@ -905,7 +996,15 @@ export class Om extends React.Component<Record<string, object>, IOmdbInsightsSta
       />
     }
 
-  
+    const generateDirPendingTable = (dataSource: any) => {
+      return <Table
+        expandRowByClick dataSource={dataSource}
+        columns={this.searchDirPendingColumn()}
+        loading={loading}
+        pagination={paginationConfig}
+        rowKey='key'
+        />
+    }
 
     return (
       <div>
@@ -958,6 +1057,15 @@ export class Om extends React.Component<Record<string, object>, IOmdbInsightsSta
               </label>
               }>
               {generateDeletedKeysTable(deletedContainerKeysDataSource)}
+            </TabPane>
+            <TabPane key='5'
+              tab={<label>Directories Pending for Deletion&nbsp;&nbsp;
+                <Tooltip placement='top' title="Directories that are pending for deletion.">
+                  <Icon type='info-circle' />
+                </Tooltip>
+              </label>
+              }>
+              {generateDirPendingTable(pendingDeleteDirDataSource)}
             </TabPane>
           </Tabs>
         </div>


### PR DESCRIPTION
## What changes were proposed in this pull request?
New Enhancement on Recon Directories Pending for Deletion Inside OMDB Insight to display the count of deletePending directories and the corresponding data size.

limit (optional)
Only returns the limited number of results. The default limit is 1000.

Returns
Returns set of directories pending for deletion.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-9085

## Response From This API  api/v1/keys/deletePending/dirs?limit=10

{
    "lastKey": "/-4611686018427388160/-9223372036854775552/-9223372036854767358/240122081700/-9223372036854767357",
    "replicatedDataSize": 0,
    "unreplicatedDataSize": 103734,
    "deletedDirInfo": [
        {
            "**key": "/-4611686018427388160/-9223372036854775552/-9223372036854767358/240122081700/-9223372036854767357"**,
            "**path": ".Trash/hadoop/240122081700**",
            "inStateSince": 1705911362730,
            "size": 103734,
            "replicatedSize": 0,
            "replicationInfo": {
                "replicationFactor": "THREE",
                "requiredNodes": 3,
                "replicationType": "RATIS"
            }
        }
    ],
    "status": "OK"
}

## How was this patch tested?
Manually


![image](https://github.com/apache/ozone/assets/112169209/eb7c16d3-1ecc-415a-bdee-532140ecac12)

![image](https://github.com/apache/ozone/assets/112169209/3fe9b7ee-3ecf-49cf-b351-2ffdea3f302c)









