### PR TITLE
HDDS-9549. defaultReadBufferCapacity should be int instead of long

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/common/utils/BufferUtils.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/common/utils/BufferUtils.java
@@ -52,7 +52,7 @@ public final class BufferUtils {
     int buffersAllocated = 0;
     // For each ByteBuffer (except the last) allocate bufferLen of capacity
     for (int i = 0; i < numBuffers - 1; i++) {
-      dataBuffers[i] = ByteBuffer.allocate((bufferCapacity));
+      dataBuffers[i] = ByteBuffer.allocate(bufferCapacity);
       buffersAllocated += bufferCapacity;
     }
     // For the last ByteBuffer, allocate as much space as is needed to fit

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/common/utils/BufferUtils.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/common/utils/BufferUtils.java
@@ -39,8 +39,8 @@ public final class BufferUtils {
    * @param totalLen total length of all ByteBuffers
    * @param bufferCapacity max capacity of each ByteBuffer
    */
-  public static ByteBuffer[] assignByteBuffers(long totalLen,
-      long bufferCapacity) {
+  public static ByteBuffer[] assignByteBuffers(int totalLen,
+      int bufferCapacity) {
     Preconditions.checkArgument(totalLen > 0, "Buffer Length should be a " +
         "positive integer.");
     Preconditions.checkArgument(bufferCapacity > 0, "Buffer Capacity should " +
@@ -52,13 +52,13 @@ public final class BufferUtils {
     int buffersAllocated = 0;
     // For each ByteBuffer (except the last) allocate bufferLen of capacity
     for (int i = 0; i < numBuffers - 1; i++) {
-      dataBuffers[i] = ByteBuffer.allocate((int) bufferCapacity);
+      dataBuffers[i] = ByteBuffer.allocate((bufferCapacity));
       buffersAllocated += bufferCapacity;
     }
     // For the last ByteBuffer, allocate as much space as is needed to fit
     // remaining bytes
     dataBuffers[numBuffers - 1] = ByteBuffer.allocate(
-        (int) (totalLen - buffersAllocated));
+        (totalLen - buffersAllocated));
     return dataBuffers;
   }
 

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/impl/BlockManagerImpl.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/impl/BlockManagerImpl.java
@@ -59,7 +59,7 @@ public class BlockManagerImpl implements BlockManager {
       "Unable to find the block.";
 
   // Default Read Buffer capacity when Checksum is not present
-  private final long defaultReadBufferCapacity;
+  private final int defaultReadBufferCapacity;
 
   /**
    * Constructs a Block Manager.
@@ -69,7 +69,7 @@ public class BlockManagerImpl implements BlockManager {
   public BlockManagerImpl(ConfigurationSource conf) {
     Preconditions.checkNotNull(conf, "Config cannot be null");
     this.config = conf;
-    this.defaultReadBufferCapacity = (long) config.getStorageSize(
+    this.defaultReadBufferCapacity = (int) config.getStorageSize(
         ScmConfigKeys.OZONE_CHUNK_READ_BUFFER_DEFAULT_SIZE_KEY,
         ScmConfigKeys.OZONE_CHUNK_READ_BUFFER_DEFAULT_SIZE_DEFAULT,
         StorageUnit.BYTES);
@@ -287,7 +287,7 @@ public class BlockManagerImpl implements BlockManager {
   }
 
   @Override
-  public long getDefaultReadBufferCapacity() {
+  public int getDefaultReadBufferCapacity() {
     return defaultReadBufferCapacity;
   }
 

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/impl/FilePerBlockStrategy.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/impl/FilePerBlockStrategy.java
@@ -75,7 +75,7 @@ public class FilePerBlockStrategy implements ChunkManager {
 
   private final boolean doSyncWrite;
   private final OpenFiles files = new OpenFiles();
-  private final long defaultReadBufferCapacity;
+  private final int defaultReadBufferCapacity;
   private final VolumeSet volumeSet;
 
   public FilePerBlockStrategy(boolean sync, BlockManager manager,
@@ -191,7 +191,7 @@ public class FilePerBlockStrategy implements ChunkManager {
 
     int len = (int) info.getLen();
     long offset = info.getOffset();
-    long bufferCapacity =  ChunkManager.getBufferCapacityForChunkRead(info,
+    int bufferCapacity =  ChunkManager.getBufferCapacityForChunkRead(info,
         defaultReadBufferCapacity);
 
     ByteBuffer[] dataBuffers = BufferUtils.assignByteBuffers(len,

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/impl/FilePerChunkStrategy.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/impl/FilePerChunkStrategy.java
@@ -68,7 +68,7 @@ public class FilePerChunkStrategy implements ChunkManager {
 
   private final boolean doSyncWrite;
   private final BlockManager blockManager;
-  private final long defaultReadBufferCapacity;
+  private final int defaultReadBufferCapacity;
   private final VolumeSet volumeSet;
 
   public FilePerChunkStrategy(boolean sync, BlockManager manager,
@@ -229,8 +229,8 @@ public class FilePerChunkStrategy implements ChunkManager {
       possibleFiles.add(finalChunkFile);
     }
 
-    long len = info.getLen();
-    long bufferCapacity = ChunkManager.getBufferCapacityForChunkRead(info,
+    int len = (int) info.getLen();
+    int bufferCapacity = ChunkManager.getBufferCapacityForChunkRead(info,
         defaultReadBufferCapacity);
 
     ByteBuffer[] dataBuffers = BufferUtils.assignByteBuffers(len,

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/interfaces/BlockManager.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/interfaces/BlockManager.java
@@ -90,7 +90,7 @@ public interface BlockManager {
   long getCommittedBlockLength(Container container, BlockID blockID)
       throws IOException;
 
-  long getDefaultReadBufferCapacity();
+  int getDefaultReadBufferCapacity();
 
   /**
    * Shutdown ContainerManager.

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/interfaces/ChunkManager.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/interfaces/ChunkManager.java
@@ -117,12 +117,12 @@ public interface ChunkManager {
     return null;
   }
 
-  static long getBufferCapacityForChunkRead(ChunkInfo chunkInfo,
-      long defaultReadBufferCapacity) {
-    long bufferCapacity = 0;
+  static int getBufferCapacityForChunkRead(ChunkInfo chunkInfo,
+      int defaultReadBufferCapacity) {
+    int bufferCapacity = 0;
     if (chunkInfo.isReadDataIntoSingleBuffer()) {
       // Older client - read all chunk data into one single buffer.
-      bufferCapacity = chunkInfo.getLen();
+      bufferCapacity = (int) chunkInfo.getLen();
     } else {
       // Set buffer capacity to checksum boundary size so that each buffer
       // corresponds to one checksum. If checksum is NONE, then set buffer
@@ -140,7 +140,7 @@ public interface ChunkManager {
     }
     // If the buffer capacity is 0, set all the data into one ByteBuffer
     if (bufferCapacity == 0) {
-      bufferCapacity = chunkInfo.getLen();
+      bufferCapacity = (int) chunkInfo.getLen();
     }
 
     return bufferCapacity;

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/helpers/TestChunkUtils.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/helpers/TestChunkUtils.java
@@ -72,8 +72,8 @@ public class TestChunkUtils {
     ChunkBuffer data = ChunkBuffer.wrap(ByteBuffer.wrap(array));
     Path tempFile = Files.createTempFile(PREFIX, "concurrent");
     try {
-      long len = data.limit();
-      long offset = 0;
+      int len = data.limit();
+      int offset = 0;
       File file = tempFile.toFile();
       ChunkUtils.writeData(file, data, offset, len, null, true);
       int threads = 10;
@@ -168,8 +168,8 @@ public class TestChunkUtils {
     Path tempFile = Files.createTempFile(PREFIX, "serial");
     try {
       File file = tempFile.toFile();
-      long len = data.limit();
-      long offset = 0;
+      int len = data.limit();
+      int offset = 0;
       ChunkUtils.writeData(file, data, offset, len, null, true);
 
       ByteBuffer[] readBuffers = BufferUtils.assignByteBuffers(len, len);


### PR DESCRIPTION
## What changes were proposed in this pull request?

defaultReadBufferCapacity was changed from long to int in this PR. 
This change was made because although defaultReadBufferCapacity was long in BlockManagerImpl/FilePerBlockStrategy/FilePerChunkStrategy, it was casted to int when it is used as shown below.
```
//BufferUtils.assignByteBuffers
    for (int i = 0; i < numBuffers - 1; i++) {
      dataBuffers[i] = ByteBuffer.allocate((int) bufferCapacity);
      buffersAllocated += bufferCapacity;
    }
```
Using long as buffer capacity does NOT work for Java array, Java ByteBuffer, Protobuf ByteString and Netty ByteBuf. Moreover, if we set ozone.chunk.read.buffer.default.size to "2GB", `((int) bufferCapacity) == -2147483648 ` would throw an IllegalArgumentException from ByteBuffer.allocate(..).

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-9549

## How was this patch tested?

Existing tests in TestChunkUtils, TestFilePerBlockStrategy, TestFilePerChunkStrategy cover this change
