### PR TITLE
HDDS-9550. Container report shows missing containers when they actually appear empty

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/health/EmptyContainerHandler.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/health/EmptyContainerHandler.java
@@ -69,6 +69,20 @@ public class EmptyContainerHandler extends AbstractCheck {
       replicationManager.updateContainerState(
           containerInfo.containerID(), HddsProtos.LifeCycleEvent.DELETE);
       return true;
+    } else if (containerInfo.getNumberOfKeys() == 0 && replicas.isEmpty()) {
+      // If the container is empty and has no replicas, it is possible it was
+      // a container which stuck in the closing state which never got any
+      // replicas created on the datanodes. In this case, we don't have enough
+      // information to delete the container, so we just log it as EMPTY,
+      // leaving it as CLOSED and return true, otherwise, it will end up marked
+      // as missing in the replication check handlers.
+      request.getReport()
+          .incrementAndSample(ReplicationManagerReport.HealthState.EMPTY,
+              containerInfo.containerID());
+      LOG.debug("Container {} appears empty and is closed, but cannot be " +
+              "deleted because it has no replicas. Marking as EMPTY.",
+          containerInfo);
+      return true;
     }
 
     return false;

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/health/EmptyContainerHandler.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/health/EmptyContainerHandler.java
@@ -69,7 +69,8 @@ public class EmptyContainerHandler extends AbstractCheck {
       replicationManager.updateContainerState(
           containerInfo.containerID(), HddsProtos.LifeCycleEvent.DELETE);
       return true;
-    } else if (containerInfo.getNumberOfKeys() == 0 && replicas.isEmpty()) {
+    } else if (containerInfo.getState() == HddsProtos.LifeCycleState.CLOSED
+        && containerInfo.getNumberOfKeys() == 0 && replicas.isEmpty()) {
       // If the container is empty and has no replicas, it is possible it was
       // a container which stuck in the closing state which never got any
       // replicas created on the datanodes. In this case, we don't have enough

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/health/TestEmptyContainerHandler.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/health/TestEmptyContainerHandler.java
@@ -169,6 +169,28 @@ public class TestEmptyContainerHandler {
   }
 
   /**
+   * This test exists to verify that the definition of an empty container is
+   * 0 key count. Number of used bytes are not considered.
+   */
+  @Test
+  public void testEmptyContainerWithNoReplicas()
+      throws IOException {
+    long keyCount = 0L;
+    long bytesUsed = 0L;
+    ContainerInfo containerInfo = ReplicationTestUtil.createContainerInfo(
+        ratisReplicationConfig, 1, CLOSED, keyCount, bytesUsed);
+
+    ContainerCheckRequest request = new ContainerCheckRequest.Builder()
+        .setPendingOps(Collections.emptyList())
+        .setReport(new ReplicationManagerReport())
+        .setContainerInfo(containerInfo)
+        .setContainerReplicas(Collections.emptySet())
+        .build();
+
+    assertAndVerify(request, true, 0, 1);
+  }
+
+  /**
    * Handler should return false when there is a non-empty replica.
    */
   @Test


### PR DESCRIPTION
## What changes were proposed in this pull request?

If a container appears empty to SCM (ie key count is zero in the containerInfo) and there are no replicas, it could be a container which failed to be created on the datanodes, and no replicas will ever be reported.

However there isn't enough information to know if the container can be safely deleted or not, as the DN could have gone offline or missed some heartbeats etc.

As things stand, such as container will appear as missing in the container report. In this PR, we change that to leave the container as CLOSED but count it as EMPTY without triggering the delete process.

That means if replicas later appear, it will be OK. 

However if the replicas never appear, the container will be stuck in this state forever. Additionally, if there **should** be replicas, as the client successfully wrote to the DNs and updated OM, there is no way to know this on SCM and the container should really be missing despite it being logged as empty, hiding the problem.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-9550

## How was this patch tested?

New unit test added