### PR TITLE
HDDS-9526. Two S3G instances writing the same key may cause data loss in case of an exception.

### DIFF
--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/io/BlockDataStreamOutputEntryPool.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/io/BlockDataStreamOutputEntryPool.java
@@ -287,4 +287,8 @@ public class BlockDataStreamOutputEntryPool {
     }
     return totalDataLen;
   }
+
+  public long getDataSize() {
+    return keyArgs.getDataSize();
+  }
 }

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/io/BlockOutputStreamEntryPool.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/io/BlockOutputStreamEntryPool.java
@@ -428,4 +428,8 @@ public class BlockOutputStreamEntryPool {
   boolean isEmpty() {
     return streamEntries.isEmpty();
   }
+
+  long getDataSize() {
+    return keyArgs.getDataSize();
+  }
 }

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/io/KeyDataStreamOutput.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/io/KeyDataStreamOutput.java
@@ -399,11 +399,9 @@ public class KeyDataStreamOutput extends AbstractDataStreamOutput
       }
       if (atomicKeyCreation) {
         long expectedSize = blockDataStreamOutputEntryPool.getDataSize();
-        if (expectedSize != offset) {
-          LOG.info(String.format("Expected %d and actual %d write" +
-                  " sizes do not match, skip key COMMIT for atomic key",
-              expectedSize, offset));
-        }
+        Preconditions.checkArgument(expectedSize == offset,
+            String.format("Expected: %d and actual %d write sizes do not match",
+                expectedSize, offset));
       }
       blockDataStreamOutputEntryPool.commitKey(offset);
     } finally {

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/io/KeyDataStreamOutput.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/io/KeyDataStreamOutput.java
@@ -399,9 +399,11 @@ public class KeyDataStreamOutput extends AbstractDataStreamOutput
       }
       if (atomicKeyCreation) {
         long expectedSize = blockDataStreamOutputEntryPool.getDataSize();
-        Preconditions.checkArgument(expectedSize == offset,
-            String.format("Expected: %d and actual %d write sizes do not match",
-                expectedSize, offset));
+        if (expectedSize != offset) {
+          LOG.info(String.format("Expected %d and actual %d write" +
+                  " sizes do not match, skip key COMMIT for atomic key",
+              expectedSize, offset));
+        }
       }
       blockDataStreamOutputEntryPool.commitKey(offset);
     } finally {

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/io/KeyDataStreamOutput.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/io/KeyDataStreamOutput.java
@@ -87,7 +87,7 @@ public class KeyDataStreamOutput extends AbstractDataStreamOutput
    * A mismatch will prevent the commit from succeeding.
    * This is essential for operations like S3 put to ensure atomicity.
    */
-  private boolean requiresAtomicWrite;
+  private boolean atomicKeyCreation;
 
   @VisibleForTesting
   public List<BlockDataStreamOutputEntry> getStreamEntries() {
@@ -118,7 +118,7 @@ public class KeyDataStreamOutput extends AbstractDataStreamOutput
       String requestId, ReplicationConfig replicationConfig,
       String uploadID, int partNumber, boolean isMultipart,
       boolean unsafeByteBufferConversion,
-      boolean requiresAtomicWrite
+      boolean atomicKeyCreation
   ) {
     super(HddsClientUtils.getRetryPolicyByException(
         config.getMaxRetryCount(), config.getRetryInterval()));
@@ -139,7 +139,7 @@ public class KeyDataStreamOutput extends AbstractDataStreamOutput
     // encrypted bucket.
     this.writeOffset = 0;
     this.clientID = handler.getId();
-    this.requiresAtomicWrite = requiresAtomicWrite;
+    this.atomicKeyCreation = atomicKeyCreation;
   }
 
   /**
@@ -397,7 +397,7 @@ public class KeyDataStreamOutput extends AbstractDataStreamOutput
       if (!isException()) {
         Preconditions.checkArgument(writeOffset == offset);
       }
-      if (requiresAtomicWrite) {
+      if (atomicKeyCreation) {
         long expectedSize = blockDataStreamOutputEntryPool.getDataSize();
         Preconditions.checkArgument(expectedSize == offset,
             String.format("Expected: %d and actual %d write sizes do not match",
@@ -438,7 +438,7 @@ public class KeyDataStreamOutput extends AbstractDataStreamOutput
     private boolean unsafeByteBufferConversion;
     private OzoneClientConfig clientConfig;
     private ReplicationConfig replicationConfig;
-    private boolean requiresAtomicWrite = false;
+    private boolean atomicKeyCreation = false;
 
     public Builder setMultipartUploadID(String uploadID) {
       this.multipartUploadID = uploadID;
@@ -491,8 +491,8 @@ public class KeyDataStreamOutput extends AbstractDataStreamOutput
       return this;
     }
 
-    public Builder setRequiresAtomicWrite(boolean atomicWrite) {
-      this.requiresAtomicWrite = atomicWrite;
+    public Builder setAtomicKeyCreation(boolean atomicKey) {
+      this.atomicKeyCreation = atomicKey;
       return this;
     }
 
@@ -509,7 +509,7 @@ public class KeyDataStreamOutput extends AbstractDataStreamOutput
           multipartNumber,
           isMultipartKey,
           unsafeByteBufferConversion,
-          requiresAtomicWrite);
+          atomicKeyCreation);
     }
 
   }

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/io/KeyOutputStream.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/io/KeyOutputStream.java
@@ -101,7 +101,7 @@ public class KeyOutputStream extends OutputStream
    * A mismatch will prevent the commit from succeeding.
    * This is essential for operations like S3 put to ensure atomicity.
    */
-  private boolean requiresAtomicWrite;
+  private boolean atomicKeyCreation;
 
   public KeyOutputStream(ReplicationConfig replicationConfig,
       ContainerClientMetrics clientMetrics) {
@@ -151,7 +151,7 @@ public class KeyOutputStream extends OutputStream
       String uploadID, int partNumber, boolean isMultipart,
       boolean unsafeByteBufferConversion,
       ContainerClientMetrics clientMetrics,
-      boolean requiresAtomicWrite
+      boolean atomicKeyCreation
   ) {
     this.config = config;
     this.replication = replicationConfig;
@@ -172,7 +172,7 @@ public class KeyOutputStream extends OutputStream
     this.isException = false;
     this.writeOffset = 0;
     this.clientID = handler.getId();
-    this.requiresAtomicWrite = requiresAtomicWrite;
+    this.atomicKeyCreation = atomicKeyCreation;
   }
 
   /**
@@ -565,7 +565,7 @@ public class KeyOutputStream extends OutputStream
       if (!isException) {
         Preconditions.checkArgument(writeOffset == offset);
       }
-      if (requiresAtomicWrite) {
+      if (atomicKeyCreation) {
         long expectedSize = blockOutputStreamEntryPool.getDataSize();
         Preconditions.checkArgument(expectedSize == offset,
             String.format("Expected: %d and actual %d write sizes do not match",
@@ -607,7 +607,7 @@ public class KeyOutputStream extends OutputStream
     private OzoneClientConfig clientConfig;
     private ReplicationConfig replicationConfig;
     private ContainerClientMetrics clientMetrics;
-    private boolean requiresAtomicWrite = false;
+    private boolean atomicKeyCreation = false;
 
     public String getMultipartUploadID() {
       return multipartUploadID;
@@ -694,8 +694,8 @@ public class KeyOutputStream extends OutputStream
       return this;
     }
 
-    public Builder setRequiresAtomicWrite(boolean atomicWrite) {
-      this.requiresAtomicWrite = atomicWrite;
+    public Builder setAtomicKeyCreation(boolean atomicKey) {
+      this.atomicKeyCreation = atomicKey;
       return this;
     }
 
@@ -721,7 +721,7 @@ public class KeyOutputStream extends OutputStream
           isMultipartKey,
           unsafeByteBufferConversion,
           clientMetrics,
-          requiresAtomicWrite);
+          atomicKeyCreation);
     }
 
   }

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/io/KeyOutputStream.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/io/KeyOutputStream.java
@@ -708,6 +708,10 @@ public class KeyOutputStream extends OutputStream
       return clientMetrics;
     }
 
+    public boolean getAtomicKeyCreation() {
+      return atomicKeyCreation;
+    }
+
     public KeyOutputStream build() {
       return new KeyOutputStream(
           clientConfig,

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/io/KeyOutputStream.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/io/KeyOutputStream.java
@@ -567,7 +567,7 @@ public class KeyOutputStream extends OutputStream
       }
       if (atomicKeyCreation) {
         long expectedSize = blockOutputStreamEntryPool.getDataSize();
-        Preconditions.checkArgument(expectedSize == offset,
+        Preconditions.checkState(expectedSize == offset,
             String.format("Expected: %d and actual %d write sizes do not match",
                 expectedSize, offset));
       }

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/io/OzoneDataStreamOutput.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/io/OzoneDataStreamOutput.java
@@ -59,30 +59,35 @@ public class OzoneDataStreamOutput extends ByteBufferOutputStream
   }
 
   public OmMultipartCommitUploadPartInfo getCommitUploadPartInfo() {
+    KeyDataStreamOutput keyDataStreamOutput = getKeyDataStreamOutput();
+    if (keyDataStreamOutput != null) {
+      return keyDataStreamOutput.getCommitUploadPartInfo();
+    }
+    // Otherwise return null.
+    return null;
+  }
+
+  public KeyDataStreamOutput getKeyDataStreamOutput() {
     if (byteBufferStreamOutput instanceof OzoneOutputStream) {
       OutputStream outputStream =
           ((OzoneOutputStream) byteBufferStreamOutput).getOutputStream();
       if (outputStream instanceof KeyDataStreamOutput) {
-        return ((KeyDataStreamOutput)
-            outputStream).getCommitUploadPartInfo();
+        return ((KeyDataStreamOutput) outputStream);
       } else if (outputStream instanceof CryptoOutputStream) {
         OutputStream wrappedStream =
             ((CryptoOutputStream) outputStream).getWrappedStream();
         if (wrappedStream instanceof KeyDataStreamOutput) {
-          return ((KeyDataStreamOutput) wrappedStream)
-              .getCommitUploadPartInfo();
+          return ((KeyDataStreamOutput) wrappedStream);
         }
       } else if (outputStream instanceof CipherOutputStreamOzone) {
         OutputStream wrappedStream =
             ((CipherOutputStreamOzone) outputStream).getWrappedStream();
         if (wrappedStream instanceof KeyDataStreamOutput) {
-          return ((KeyDataStreamOutput) wrappedStream)
-              .getCommitUploadPartInfo();
+          return ((KeyDataStreamOutput) wrappedStream);
         }
       }
     } else if (byteBufferStreamOutput instanceof KeyDataStreamOutput) {
-      return ((KeyDataStreamOutput)
-          byteBufferStreamOutput).getCommitUploadPartInfo();
+      return ((KeyDataStreamOutput) byteBufferStreamOutput);
     }
     // Otherwise return null.
     return null;

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/io/OzoneOutputStream.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/io/OzoneOutputStream.java
@@ -123,20 +123,9 @@ public class OzoneOutputStream extends ByteArrayStreamOutput
   }
 
   public OmMultipartCommitUploadPartInfo getCommitUploadPartInfo() {
-    if (outputStream instanceof KeyOutputStream) {
-      return ((KeyOutputStream) outputStream).getCommitUploadPartInfo();
-    } else  if (outputStream instanceof CryptoOutputStream) {
-      OutputStream wrappedStream =
-          ((CryptoOutputStream) outputStream).getWrappedStream();
-      if (wrappedStream instanceof KeyOutputStream) {
-        return ((KeyOutputStream) wrappedStream).getCommitUploadPartInfo();
-      }
-    } else if (outputStream instanceof CipherOutputStreamOzone) {
-      OutputStream wrappedStream =
-          ((CipherOutputStreamOzone) outputStream).getWrappedStream();
-      if (wrappedStream instanceof KeyOutputStream) {
-        return ((KeyOutputStream)wrappedStream).getCommitUploadPartInfo();
-      }
+    KeyOutputStream keyOutputStream = getKeyOutputStream();
+    if (keyOutputStream != null) {
+      return keyOutputStream.getCommitUploadPartInfo();
     }
     // Otherwise return null.
     return null;
@@ -144,6 +133,26 @@ public class OzoneOutputStream extends ByteArrayStreamOutput
 
   public OutputStream getOutputStream() {
     return outputStream;
+  }
+
+  public KeyOutputStream getKeyOutputStream() {
+    if (outputStream instanceof KeyOutputStream) {
+      return ((KeyOutputStream) outputStream);
+    } else  if (outputStream instanceof CryptoOutputStream) {
+      OutputStream wrappedStream =
+          ((CryptoOutputStream) outputStream).getWrappedStream();
+      if (wrappedStream instanceof KeyOutputStream) {
+        return ((KeyOutputStream) wrappedStream);
+      }
+    } else if (outputStream instanceof CipherOutputStreamOzone) {
+      OutputStream wrappedStream =
+          ((CipherOutputStreamOzone) outputStream).getWrappedStream();
+      if (wrappedStream instanceof KeyOutputStream) {
+        return ((KeyOutputStream)wrappedStream);
+      }
+    }
+    // Otherwise return null.
+    return null;
   }
 
   @Override

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/protocol/ClientProtocol.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/protocol/ClientProtocol.java
@@ -1008,6 +1008,9 @@ public interface ClientProtocol {
    */
   void setThreadLocalS3Auth(S3Auth s3Auth);
 
+
+  void setIsS3Request(boolean isS3Request);
+
   /**
    * Gets the S3 Authentication information that is attached to the thread.
    * @return S3 Authentication information.

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/rpc/RpcClient.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/rpc/RpcClient.java
@@ -1789,7 +1789,7 @@ public class RpcClient implements ClientProtocol {
         .setMultipartNumber(partNumber)
         .setMultipartUploadID(uploadID)
         .setIsMultipartKey(true)
-        .setRequiresAtomicWrite(isS3GRequest.get())
+        .setAtomicKeyCreation(isS3GRequest.get())
         .build();
     return createOutputStream(openKey, keyOutputStream);
   }
@@ -1806,7 +1806,7 @@ public class RpcClient implements ClientProtocol {
     final OpenKeySession openKey = newMultipartOpenKey(
         volumeName, bucketName, keyName, size, partNumber, uploadID);
     // Amazon S3 never adds partial objects, So for S3 requests we need to
-    // set RequiresAtomicWrite to true
+    // set atomicKeyCreation to true
     // refer: https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutObject.html
     KeyDataStreamOutput keyOutputStream =
         new KeyDataStreamOutput.Builder()
@@ -1819,7 +1819,7 @@ public class RpcClient implements ClientProtocol {
             .setIsMultipartKey(true)
             .enableUnsafeByteBufferConversion(unsafeByteBufferConversion)
             .setConfig(conf.getObject(OzoneClientConfig.class))
-            .setRequiresAtomicWrite(isS3GRequest.get())
+            .setAtomicKeyCreation(isS3GRequest.get())
             .build();
     keyOutputStream
         .addPreallocateBlocks(
@@ -2223,7 +2223,7 @@ public class RpcClient implements ClientProtocol {
     final ReplicationConfig replicationConfig
         = openKey.getKeyInfo().getReplicationConfig();
     // Amazon S3 never adds partial objects, So for S3 requests we need to
-    // set RequiresAtomicWrite to true
+    // set atomicKeyCreation to true
     // refer: https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutObject.html
     KeyDataStreamOutput keyOutputStream =
         new KeyDataStreamOutput.Builder()
@@ -2233,7 +2233,7 @@ public class RpcClient implements ClientProtocol {
             .setReplicationConfig(replicationConfig)
             .enableUnsafeByteBufferConversion(unsafeByteBufferConversion)
             .setConfig(conf.getObject(OzoneClientConfig.class))
-            .setRequiresAtomicWrite(isS3GRequest.get())
+            .setAtomicKeyCreation(isS3GRequest.get())
             .build();
     keyOutputStream
         .addPreallocateBlocks(openKey.getKeyInfo().getLatestVersionLocations(),
@@ -2315,7 +2315,7 @@ public class RpcClient implements ClientProtocol {
         .setOmClient(ozoneManagerClient)
         .enableUnsafeByteBufferConversion(unsafeByteBufferConversion)
         .setConfig(conf.getObject(OzoneClientConfig.class))
-        .setRequiresAtomicWrite(isS3GRequest.get())
+        .setAtomicKeyCreation(isS3GRequest.get())
         .setClientMetrics(clientMetrics);
   }
 

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/rpc/RpcClient.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/rpc/RpcClient.java
@@ -1348,6 +1348,10 @@ public class RpcClient implements ClientProtocol {
         .setLatestVersionLocation(getLatestVersionLocation);
 
     OpenKeySession openKey = ozoneManagerClient.openKey(builder.build());
+    // For bucket with layout OBJECT_STORE, when create an empty file (size=0),
+    // OM will set DataSize to OzoneConfigKeys#OZONE_SCM_BLOCK_SIZE,
+    // which will cause S3G's atomic write length check to fail,
+    // so reset size to 0 here.
     if (isS3GRequest.get() && size == 0) {
       openKey.getKeyInfo().setDataSize(size);
     }

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/rpc/RpcClient.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/rpc/RpcClient.java
@@ -42,6 +42,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.SynchronousQueue;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
@@ -214,6 +215,7 @@ public class RpcClient implements ClientProtocol {
   private final OzoneManagerVersion omVersion;
   private volatile ExecutorService ecReconstructExecutor;
   private final ContainerClientMetrics clientMetrics;
+  private final AtomicBoolean isS3GRequest = new AtomicBoolean(false);
 
   /**
    * Creates RpcClient instance with the given configuration.
@@ -689,7 +691,7 @@ public class RpcClient implements ClientProtocol {
         : "with server-side default bucket layout";
     LOG.info("Creating Bucket: {}/{}, {}, {} as owner, Versioning {}, " +
             "Storage Type set to {} and Encryption set to {}, " +
-            "Replication Type set to {}, Namespace Quota set to {}, " + 
+            "Replication Type set to {}, Namespace Quota set to {}, " +
             "Space Quota set to {} ",
         volumeName, bucketName, layoutMsg, owner, isVersionEnabled,
         storageType, bek != null, replicationType,
@@ -1789,6 +1791,7 @@ public class RpcClient implements ClientProtocol {
         .setMultipartNumber(partNumber)
         .setMultipartUploadID(uploadID)
         .setIsMultipartKey(true)
+        .setRequiresAtomicWrite(isS3GRequest.get())
         .build();
     return createOutputStream(openKey, keyOutputStream);
   }
@@ -1804,7 +1807,9 @@ public class RpcClient implements ClientProtocol {
       throws IOException {
     final OpenKeySession openKey = newMultipartOpenKey(
         volumeName, bucketName, keyName, size, partNumber, uploadID);
-
+    // Amazon S3 never adds partial objects, So for S3 requests we need to
+    // set RequiresAtomicWrite to true
+    // refer: https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutObject.html
     KeyDataStreamOutput keyOutputStream =
         new KeyDataStreamOutput.Builder()
             .setHandler(openKey)
@@ -1816,6 +1821,7 @@ public class RpcClient implements ClientProtocol {
             .setIsMultipartKey(true)
             .enableUnsafeByteBufferConversion(unsafeByteBufferConversion)
             .setConfig(conf.getObject(OzoneClientConfig.class))
+            .setRequiresAtomicWrite(isS3GRequest.get())
             .build();
     keyOutputStream
         .addPreallocateBlocks(
@@ -2218,6 +2224,9 @@ public class RpcClient implements ClientProtocol {
       throws IOException {
     final ReplicationConfig replicationConfig
         = openKey.getKeyInfo().getReplicationConfig();
+    // Amazon S3 never adds partial objects, So for S3 requests we need to
+    // set RequiresAtomicWrite to true
+    // refer: https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutObject.html
     KeyDataStreamOutput keyOutputStream =
         new KeyDataStreamOutput.Builder()
             .setHandler(openKey)
@@ -2226,6 +2235,7 @@ public class RpcClient implements ClientProtocol {
             .setReplicationConfig(replicationConfig)
             .enableUnsafeByteBufferConversion(unsafeByteBufferConversion)
             .setConfig(conf.getObject(OzoneClientConfig.class))
+            .setRequiresAtomicWrite(isS3GRequest.get())
             .build();
     keyOutputStream
         .addPreallocateBlocks(openKey.getKeyInfo().getLatestVersionLocations(),
@@ -2307,6 +2317,7 @@ public class RpcClient implements ClientProtocol {
         .setOmClient(ozoneManagerClient)
         .enableUnsafeByteBufferConversion(unsafeByteBufferConversion)
         .setConfig(conf.getObject(OzoneClientConfig.class))
+        .setRequiresAtomicWrite(isS3GRequest.get())
         .setClientMetrics(clientMetrics);
   }
 
@@ -2383,6 +2394,11 @@ public class RpcClient implements ClientProtocol {
   public void setThreadLocalS3Auth(
       S3Auth ozoneSharedSecretAuth) {
     ozoneManagerClient.setThreadLocalS3Auth(ozoneSharedSecretAuth);
+  }
+
+  @Override
+  public void setIsS3Request(boolean s3Request) {
+    this.isS3GRequest.set(s3Request);
   }
 
   @Override

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/rpc/RpcClient.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/rpc/RpcClient.java
@@ -1348,6 +1348,9 @@ public class RpcClient implements ClientProtocol {
         .setLatestVersionLocation(getLatestVersionLocation);
 
     OpenKeySession openKey = ozoneManagerClient.openKey(builder.build());
+    if (isS3GRequest.get() && size == 0) {
+      openKey.getKeyInfo().setDataSize(size);
+    }
     return createOutputStream(openKey);
   }
 

--- a/hadoop-ozone/client/src/test/java/org/apache/hadoop/ozone/client/TestOzoneClient.java
+++ b/hadoop-ozone/client/src/test/java/org/apache/hadoop/ozone/client/TestOzoneClient.java
@@ -224,6 +224,40 @@ public class TestOzoneClient {
     }
   }
 
+  /**
+   * This test validates that for S3G,
+   * the key upload process needs to be atomic.
+   * It simulates two mismatch scenarios where the actual write data size does
+   * not match the expected size.
+   */
+  @Test
+  public void testPutKeySizeMismatch() throws IOException {
+    String value = new String(new byte[1024], UTF_8);
+    OzoneBucket bucket = getOzoneBucket();
+    String keyName = UUID.randomUUID().toString();
+    try {
+      // Simulating first mismatch: Write less data than expected
+      client.getProxy().setIsS3Request(true);
+      OzoneOutputStream out1 = bucket.createKey(keyName,
+          value.getBytes(UTF_8).length, ReplicationType.RATIS, ONE,
+          new HashMap<>());
+      out1.write(value.substring(0, value.length() - 1).getBytes(UTF_8));
+      Assertions.assertThrows(IllegalArgumentException.class, out1::close,
+          "Expected IllegalArgumentException due to size mismatch.");
+
+      // Simulating second mismatch: Write more data than expected
+      OzoneOutputStream out2 = bucket.createKey(keyName,
+          value.getBytes(UTF_8).length, ReplicationType.RATIS, ONE,
+          new HashMap<>());
+      value += "1";
+      out2.write(value.getBytes(UTF_8));
+      Assertions.assertThrows(IllegalArgumentException.class, out2::close,
+          "Expected IllegalArgumentException due to size mismatch.");
+    } finally {
+      client.getProxy().setIsS3Request(false);
+    }
+  }
+
   private OzoneBucket getOzoneBucket() throws IOException {
     String volumeName = UUID.randomUUID().toString();
     String bucketName = UUID.randomUUID().toString();

--- a/hadoop-ozone/client/src/test/java/org/apache/hadoop/ozone/client/TestOzoneClient.java
+++ b/hadoop-ozone/client/src/test/java/org/apache/hadoop/ozone/client/TestOzoneClient.java
@@ -242,7 +242,7 @@ public class TestOzoneClient {
           value.getBytes(UTF_8).length, ReplicationType.RATIS, ONE,
           new HashMap<>());
       out1.write(value.substring(0, value.length() - 1).getBytes(UTF_8));
-      Assertions.assertThrows(IllegalArgumentException.class, out1::close,
+      Assertions.assertThrows(IllegalStateException.class, out1::close,
           "Expected IllegalArgumentException due to size mismatch.");
 
       // Simulating second mismatch: Write more data than expected
@@ -251,7 +251,7 @@ public class TestOzoneClient {
           new HashMap<>());
       value += "1";
       out2.write(value.getBytes(UTF_8));
-      Assertions.assertThrows(IllegalArgumentException.class, out2::close,
+      Assertions.assertThrows(IllegalStateException.class, out2::close,
           "Expected IllegalArgumentException due to size mismatch.");
     } finally {
       client.getProxy().setIsS3Request(false);

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/EndpointBase.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/EndpointBase.java
@@ -123,9 +123,10 @@ public abstract class EndpointBase implements Auditor {
         signatureInfo.getSignature(),
         signatureInfo.getAwsAccessId(), signatureInfo.getAwsAccessId());
     LOG.debug("S3 access id: {}", s3Auth.getAccessID());
-    getClient().getObjectStore()
-        .getClientProxy()
-        .setThreadLocalS3Auth(s3Auth);
+    ClientProtocol clientProtocol =
+        getClient().getObjectStore().getClientProxy();
+    clientProtocol.setThreadLocalS3Auth(s3Auth);
+    clientProtocol.setIsS3Request(true);
     init();
   }
 

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/ObjectEndpoint.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/ObjectEndpoint.java
@@ -357,7 +357,14 @@ public class ObjectEndpoint extends EndpointBase {
       throw ex;
     } finally {
       if (output != null) {
-        output.close();
+        try {
+          output.close();
+        } catch (IllegalStateException ex) {
+          LOG.error(String.format(
+              "Data read has a different length than the expected," +
+                  " bucket %s, key %s", bucketName, keyPath), ex);
+          auditWriteFailure(s3GAction, ex);
+        }
       }
       if (auditSuccess) {
         AUDIT.logWriteSuccess(

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/ObjectEndpoint.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/ObjectEndpoint.java
@@ -206,6 +206,7 @@ public class ObjectEndpoint extends EndpointBase {
    * See: https://docs.aws.amazon.com/AmazonS3/latest/API/RESTObjectPUT.html for
    * more details.
    */
+  @SuppressWarnings("checkstyle:MethodLength")
   @PUT
   public Response put(
       @PathParam("bucket") String bucketName,

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/ObjectEndpoint.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/ObjectEndpoint.java
@@ -289,8 +289,7 @@ public class ObjectEndpoint extends EndpointBase {
           .equals(headers.getHeaderString("x-amz-content-sha256"))) {
         body = new DigestInputStream(new SignedChunksInputStream(body),
             E_TAG_PROVIDER.get());
-        length = Long.parseLong(
-            headers.getHeaderString(DECODED_CONTENT_LENGTH_HEADER));
+        length = Long.parseLong(amzDecodedLength);
       } else {
         body = new DigestInputStream(body, E_TAG_PROVIDER.get());
       }
@@ -894,9 +893,9 @@ public class ObjectEndpoint extends EndpointBase {
             volume.getName(), sourceBucket, sourceKey);
         String range =
             headers.getHeaderString(COPY_SOURCE_HEADER_RANGE);
+        RangeHeader rangeHeader = null;
         if (range != null) {
-          RangeHeader rangeHeader =
-              RangeHeaderParserUtil.parseRangeHeader(range, 0);
+          rangeHeader = RangeHeaderParserUtil.parseRangeHeader(range, 0);
           // When copy Range, the size of the target key is the
           // length specified by COPY_SOURCE_HEADER_RANGE.
           length = rangeHeader.getEndOffset() -
@@ -918,8 +917,6 @@ public class ObjectEndpoint extends EndpointBase {
         try (OzoneInputStream sourceObject = sourceKeyDetails.getContent()) {
           long copyLength;
           if (range != null) {
-            RangeHeader rangeHeader =
-                RangeHeaderParserUtil.parseRangeHeader(range, 0);
             final long skipped =
                 sourceObject.skip(rangeHeader.getStartOffset());
             if (skipped != rangeHeader.getStartOffset()) {

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/ObjectEndpoint.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/ObjectEndpoint.java
@@ -883,6 +883,10 @@ public class ObjectEndpoint extends EndpointBase {
             .createMultipartKey(ozoneBucket, key, length, partNumber,
                 uploadID, chunkSize, (DigestInputStream) body);
       }
+      // OmMultipartCommitUploadPartInfo can only be gotten after the
+      // OzoneOutputStream is closed, so we need to save the KeyOutputStream
+      // in the OzoneOutputStream and use it to get the
+      // OmMultipartCommitUploadPartInfo after OzoneOutputStream is closed.
       KeyOutputStream keyOutputStream = null;
       if (copyHeader != null) {
         Pair<String, String> result = parseSourceHeader(copyHeader);

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/ObjectEndpointStreaming.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/ObjectEndpointStreaming.java
@@ -22,9 +22,11 @@ import javax.xml.bind.DatatypeConverter;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.hadoop.hdds.client.ReplicationConfig;
 import org.apache.hadoop.ozone.client.OzoneBucket;
+import org.apache.hadoop.ozone.client.io.KeyDataStreamOutput;
 import org.apache.hadoop.ozone.client.io.KeyMetadataAware;
 import org.apache.hadoop.ozone.client.io.OzoneDataStreamOutput;
 import org.apache.hadoop.ozone.om.exceptions.OMException;
+import org.apache.hadoop.ozone.om.helpers.OmMultipartCommitUploadPartInfo;
 import org.apache.hadoop.ozone.s3.exception.OS3Exception;
 import org.apache.hadoop.ozone.s3.exception.S3ErrorTable;
 import org.apache.hadoop.ozone.s3.metrics.S3GatewayMetrics;
@@ -146,16 +148,17 @@ final class ObjectEndpointStreaming {
       throws IOException, OS3Exception {
     String eTag;
     S3GatewayMetrics metrics = S3GatewayMetrics.create();
+    KeyDataStreamOutput keyDataStreamOutput = null;
     try {
       try (OzoneDataStreamOutput streamOutput = ozoneBucket
           .createMultipartStreamKey(key, length, partNumber, uploadID)) {
         long putLength =
             writeToStreamOutput(streamOutput, body, chunkSize, length);
+        eTag = DatatypeConverter.printHexBinary(
+            body.getMessageDigest().digest()).toLowerCase();
+        ((KeyMetadataAware)streamOutput).getMetadata().put("ETag", eTag);
         metrics.incPutKeySuccessLength(putLength);
-        ((KeyMetadataAware)streamOutput).getMetadata().put("ETag",
-            DatatypeConverter.printHexBinary(
-            body.getMessageDigest().digest()).toLowerCase());
-        eTag = streamOutput.getCommitUploadPartInfo().getPartName();
+        keyDataStreamOutput = streamOutput.getKeyDataStreamOutput();
       }
     } catch (OMException ex) {
       if (ex.getResult() ==
@@ -167,6 +170,12 @@ final class ObjectEndpointStreaming {
             ozoneBucket.getName() + "/" + key);
       }
       throw ex;
+    } finally {
+      if (keyDataStreamOutput != null) {
+        OmMultipartCommitUploadPartInfo commitUploadPartInfo =
+            keyDataStreamOutput.getCommitUploadPartInfo();
+        eTag = commitUploadPartInfo.getPartName();
+      }
     }
     return Response.ok().header("ETag", eTag).build();
   }

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/ObjectEndpointStreaming.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/ObjectEndpointStreaming.java
@@ -148,6 +148,10 @@ final class ObjectEndpointStreaming {
       throws IOException, OS3Exception {
     String eTag;
     S3GatewayMetrics metrics = S3GatewayMetrics.create();
+    // OmMultipartCommitUploadPartInfo can only be gotten after the
+    // OzoneDataStreamOutput is closed, so we need to save the
+    // KeyDataStreamOutput in the OzoneDataStreamOutput and use it to get the
+    // OmMultipartCommitUploadPartInfo after OzoneDataStreamOutput is closed.
     KeyDataStreamOutput keyDataStreamOutput = null;
     try {
       try (OzoneDataStreamOutput streamOutput = ozoneBucket

--- a/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/client/ClientProtocolStub.java
+++ b/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/client/ClientProtocolStub.java
@@ -578,6 +578,11 @@ public class ClientProtocolStub implements ClientProtocol {
   }
 
   @Override
+  public void setIsS3Request(boolean isS3Request) {
+
+  }
+
+  @Override
   public S3Auth getThreadLocalS3Auth() {
     return null;
   }

--- a/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/client/OzoneBucketStub.java
+++ b/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/client/OzoneBucketStub.java
@@ -513,7 +513,7 @@ public class OzoneBucketStub extends OzoneBucket {
         if (partEntry.getKey() > partNumberMarker) {
           PartInfo partInfo = new PartInfo(partEntry.getKey(),
               partEntry.getValue().getPartName(),
-              partEntry.getValue().getContent().length, Time.now());
+              Time.now(), partEntry.getValue().getContent().length);
           partInfoList.add(partInfo);
           count++;
         }

--- a/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/client/OzoneOutputStreamStub.java
+++ b/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/client/OzoneOutputStreamStub.java
@@ -20,6 +20,9 @@
 
 package org.apache.hadoop.ozone.client;
 
+import org.apache.hadoop.hdds.client.ReplicationConfig;
+import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import org.apache.hadoop.ozone.client.io.KeyOutputStream;
 import org.apache.hadoop.ozone.client.io.OzoneOutputStream;
 import org.apache.hadoop.ozone.om.helpers.OmMultipartCommitUploadPartInfo;
 
@@ -67,6 +70,18 @@ public class OzoneOutputStreamStub extends OzoneOutputStream {
       getOutputStream().close();
       closed = true;
     }
+  }
+
+  @Override
+  public KeyOutputStream getKeyOutputStream() {
+    return new KeyOutputStream(
+        ReplicationConfig.getDefault(new OzoneConfiguration()), null) {
+      @Override
+      public synchronized OmMultipartCommitUploadPartInfo
+          getCommitUploadPartInfo() {
+        return OzoneOutputStreamStub.this.getCommitUploadPartInfo();
+      }
+    };
   }
 
   @Override

--- a/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestObjectPut.java
+++ b/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestObjectPut.java
@@ -49,6 +49,7 @@ import org.junit.jupiter.api.Assertions;
 import org.mockito.Mockito;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.apache.hadoop.ozone.s3.util.S3Consts.DECODED_CONTENT_LENGTH_HEADER;
 import static org.apache.hadoop.ozone.s3.util.S3Consts.COPY_SOURCE_HEADER;
 import static org.apache.hadoop.ozone.s3.util.S3Consts.STORAGE_CLASS_HEADER;
 import static org.apache.hadoop.ozone.s3.util.S3Utils.urlEncode;
@@ -141,6 +142,47 @@ public class TestObjectPut {
   }
 
   @Test
+  public void testPutObjectContentLength() throws IOException, OS3Exception {
+    // The contentLength specified when creating the Key should be the same as
+    // the Content-Length, the key Commit will compare the Content-Length with
+    // the actual length of the data written.
+    HttpHeaders headers = Mockito.mock(HttpHeaders.class);
+    ByteArrayInputStream body =
+        new ByteArrayInputStream(CONTENT.getBytes(UTF_8));
+    objectEndpoint.setHeaders(headers);
+    long dataSize = CONTENT.length() + 1;
+
+    objectEndpoint.put(bucketName, keyName, dataSize, 0, null, body);
+    Assert.assertEquals(dataSize + 1, getKeyDataSize(keyName));
+  }
+
+  @Test
+  public void testPutObjectContentLengthForStreaming()
+      throws IOException, OS3Exception {
+    HttpHeaders headers = Mockito.mock(HttpHeaders.class);
+    objectEndpoint.setHeaders(headers);
+
+    String chunkedContent = "0a;chunk-signature=signature\r\n"
+        + "1234567890\r\n"
+        + "05;chunk-signature=signature\r\n"
+        + "abcde\r\n";
+
+    when(headers.getHeaderString("x-amz-content-sha256"))
+        .thenReturn("STREAMING-AWS4-HMAC-SHA256-PAYLOAD");
+
+    when(headers.getHeaderString(DECODED_CONTENT_LENGTH_HEADER))
+        .thenReturn("15");
+    objectEndpoint.put(bucketName, keyName, chunkedContent.length(), 0, null,
+        new ByteArrayInputStream(chunkedContent.getBytes(UTF_8)));
+    Assert.assertEquals(15, getKeyDataSize(keyName));
+  }
+
+  private long getKeyDataSize(String key) throws IOException {
+    return clientStub.getObjectStore().getS3Bucket(bucketName)
+        .getKey(key).getDataSize();
+  }
+
+  @Test
   public void testPutObjectWithSignedChunks() throws IOException, OS3Exception {
     //GIVEN
     HttpHeaders headers = Mockito.mock(HttpHeaders.class);
@@ -153,6 +195,8 @@ public class TestObjectPut {
 
     when(headers.getHeaderString("x-amz-content-sha256"))
         .thenReturn("STREAMING-AWS4-HMAC-SHA256-PAYLOAD");
+    when(headers.getHeaderString(DECODED_CONTENT_LENGTH_HEADER))
+        .thenReturn("15");
 
     //WHEN
     Response response = objectEndpoint.put(bucketName, keyName,

--- a/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestObjectPut.java
+++ b/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestObjectPut.java
@@ -150,10 +150,10 @@ public class TestObjectPut {
     ByteArrayInputStream body =
         new ByteArrayInputStream(CONTENT.getBytes(UTF_8));
     objectEndpoint.setHeaders(headers);
-    long dataSize = CONTENT.length() + 1;
+    long dataSize = CONTENT.length();
 
     objectEndpoint.put(bucketName, keyName, dataSize, 0, null, body);
-    Assert.assertEquals(dataSize + 1, getKeyDataSize(keyName));
+    Assert.assertEquals(dataSize, getKeyDataSize(keyName));
   }
 
   @Test

--- a/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestPartUpload.java
+++ b/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestPartUpload.java
@@ -150,7 +150,6 @@ public class TestPartUpload {
     objectEndpoint.setHeaders(headers);
     objectEndpoint.setClient(client);
     objectEndpoint.setOzoneConfiguration(new OzoneConfiguration());
-    objectEndpoint.setHeaders(headers);
     String keyName = UUID.randomUUID().toString();
 
     String chunkedContent = "0a;chunk-signature=signature\r\n"

--- a/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestPartUpload.java
+++ b/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestPartUpload.java
@@ -171,7 +171,7 @@ public class TestPartUpload {
     long contentLength = chunkedContent.length();
 
     objectEndpoint.put(OzoneConsts.S3_BUCKET, keyName, contentLength, 1,
-        uploadID, new ByteArrayInputStream(chunkedContent.getBytes()));
+        uploadID, new ByteArrayInputStream(chunkedContent.getBytes(UTF_8)));
     assertContentLength(uploadID, keyName, 15);
   }
 

--- a/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestPartUpload.java
+++ b/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestPartUpload.java
@@ -24,7 +24,9 @@ import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.hadoop.ozone.client.OzoneClient;
 import org.apache.hadoop.ozone.client.OzoneClientStub;
+import org.apache.hadoop.ozone.client.OzoneMultipartUploadPartListParts;
 import org.apache.hadoop.ozone.s3.exception.OS3Exception;
+import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.mockito.Mockito;
@@ -33,9 +35,11 @@ import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.Response;
 
 import java.io.ByteArrayInputStream;
+import java.io.IOException;
 
 import static java.net.HttpURLConnection.HTTP_NOT_FOUND;
 import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.apache.hadoop.ozone.s3.util.S3Consts.DECODED_CONTENT_LENGTH_HEADER;
 import static org.apache.hadoop.ozone.s3.util.S3Consts.STORAGE_CLASS_HEADER;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
@@ -49,11 +53,12 @@ import static org.mockito.Mockito.when;
 public class TestPartUpload {
 
   private static final ObjectEndpoint REST = new ObjectEndpoint();
+  private static OzoneClient client;
 
   @BeforeClass
   public static void setUp() throws Exception {
 
-    OzoneClient client = new OzoneClientStub();
+    client = new OzoneClientStub();
     client.getObjectStore().createS3Bucket(OzoneConsts.S3_BUCKET);
 
 
@@ -87,6 +92,70 @@ public class TestPartUpload {
 
     assertNotNull(response.getHeaderString("ETag"));
 
+  }
+
+  @Test
+  public void testPartUploadStreamContentLength()
+      throws IOException, OS3Exception {
+    HttpHeaders headers = Mockito.mock(HttpHeaders.class);
+    REST.setHeaders(headers);
+
+    String chunkedContent = "0a;chunk-signature=signature\r\n"
+        + "1234567890\r\n"
+        + "05;chunk-signature=signature\r\n"
+        + "abcde\r\n";
+    when(headers.getHeaderString("x-amz-content-sha256"))
+        .thenReturn("STREAMING-AWS4-HMAC-SHA256-PAYLOAD");
+    when(headers.getHeaderString(DECODED_CONTENT_LENGTH_HEADER))
+        .thenReturn("15");
+
+    Response response = REST.initializeMultipartUpload(OzoneConsts.S3_BUCKET,
+        OzoneConsts.KEY);
+    MultipartUploadInitiateResponse multipartUploadInitiateResponse =
+        (MultipartUploadInitiateResponse) response.getEntity();
+    assertNotNull(multipartUploadInitiateResponse.getUploadID());
+    String uploadID = multipartUploadInitiateResponse.getUploadID();
+    String content = "Multipart Upload";
+    long contentLength = chunkedContent.length();
+
+    ByteArrayInputStream body =
+        new ByteArrayInputStream(content.getBytes(UTF_8));
+    REST.put(OzoneConsts.S3_BUCKET, OzoneConsts.KEY,
+        contentLength, 1, uploadID,
+        new ByteArrayInputStream(chunkedContent.getBytes(UTF_8)));
+    assertContentLength(uploadID, OzoneConsts.KEY, 15);
+  }
+
+  @Test
+  public void testPartUploadContentLength() throws IOException, OS3Exception {
+    // The contentLength specified when creating the Key should be the same as
+    // the Content-Length, the key Commit will compare the Content-Length with
+    // the actual length of the data written.
+
+    Response response = REST.initializeMultipartUpload(OzoneConsts.S3_BUCKET,
+        OzoneConsts.KEY);
+    MultipartUploadInitiateResponse multipartUploadInitiateResponse =
+        (MultipartUploadInitiateResponse) response.getEntity();
+    assertNotNull(multipartUploadInitiateResponse.getUploadID());
+    String uploadID = multipartUploadInitiateResponse.getUploadID();
+    String content = "Multipart Upload";
+    long contentLength = content.length() + 1;
+
+    ByteArrayInputStream body =
+        new ByteArrayInputStream(content.getBytes(UTF_8));
+    REST.put(OzoneConsts.S3_BUCKET, OzoneConsts.KEY,
+        contentLength, 1, uploadID, body);
+    assertContentLength(uploadID, OzoneConsts.KEY, content.length());
+  }
+
+  private void assertContentLength(String uploadID, String key,
+      long contentLength) throws IOException {
+    OzoneMultipartUploadPartListParts parts =
+        client.getObjectStore().getS3Bucket(OzoneConsts.S3_BUCKET)
+            .listParts(key, uploadID, 0, 100);
+    Assert.assertEquals(1, parts.getPartInfoList().size());
+    Assert.assertEquals(contentLength,
+        parts.getPartInfoList().get(0).getSize());
   }
 
   @Test


### PR DESCRIPTION
## What changes were proposed in this pull request?
To fix the problem of abnormal dirty data overwriting normal data when S3G writes data. Make Ozone S3 puts atomic writes, all successes total or failures
The main implementation is to check whether the data of the key is complete or not when committing, if the data written by the key is different from the expected size, the key is considered incomplete, and the commit operation is not executed.

```java
  @Override
  public synchronized void close() throws IOException {
//...
    try {
//...
      if (requiresAtomicWrite) {
        long expectedSize = blockOutputStreamEntryPool.getDataSize();
        Preconditions.checkArgument(expectedSize == offset,
            String.format("Expected: %d and actual %d write sizes do not match",
                expectedSize, offset));
      }
      blockOutputStreamEntryPool.commitKey(offset);
    } finally {
      blockOutputStreamEntryPool.cleanup();
    }
  }
```
- The `requiresAtomicWrite` is only `enable` in S3G, it will be set in `EndpointBase#initialization` , just like the `s3Auth`
- The `blockOutputStreamEntryPool.getDataSize()` is the `dataSize` that was passed in when the S3G created the key (including the MPU key). 
- The dataSize is the 
  - `Content-Length`: normal put key
  - `x-amz-decoded-content-length`: Stream mode uploaded key.
  - `x-amz-copy-source-range`: The length specified in the MPU copy `Range` (Ozone does not currently support Copy Ranges for non-MPU keys.).
  - Key length of source key: copy request without `Range`

PS:
refer to AWS put doc https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutObject.html
> Amazon S3 never adds partial objects; if you receive a success response, Amazon S3 added the entire object to the bucket.



## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-9526

## How was this patch tested?
unit test, manually test.
manually test.
```bash
[root@VM-8-3-centos ~]$ aws configure set default.s3.multipart_threshold 1GB
[root@VM-8-3-centos ~]$ aws s3 --endpoint-url http://localhost:9878 cp ~/500M.img s3://bucket1/500M.img
^Ccancelled: ctrl-c received 
[root@VM-8-3-centos /tmp]$ aws s3 ls s3://bucket1/ --endpoint-url http://localhost:9878
// A key that has not been completely written should not be visible.
```

