### PR TITLE
HDDS-9548. Intermittent failures in TestRootCaRotationPoller

### DIFF
--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/security/x509/certificate/client/RootCaRotationPoller.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/security/x509/certificate/client/RootCaRotationPoller.java
@@ -80,7 +80,7 @@ public class RootCaRotationPoller implements Runnable, Closeable {
    *
    * @return returns true if the SCM provided a new root ca certificate.
    */
-  boolean pollRootCas() {
+  void pollRootCas() {
     try {
       List<String> pemEncodedRootCaList =
           scmSecureClient.getAllRootCaCertificates();
@@ -90,7 +90,7 @@ public class RootCaRotationPoller implements Runnable, Closeable {
           = new ArrayList<>(rootCAsFromSCM);
       scmCertsWithoutKnownCerts.removeAll(knownRootCerts);
       if (scmCertsWithoutKnownCerts.isEmpty()) {
-        return false;
+        return;
       }
       LOG.info("Some root CAs are not known to the client out of the root " +
           "CAs known to the SCMs. Root CA Cert ids known to the client: " +
@@ -119,7 +119,6 @@ public class RootCaRotationPoller implements Runnable, Closeable {
     } catch (IOException e) {
       LOG.error("Error while trying to poll root ca certificate", e);
     }
-    return true;
   }
 
   public void addRootCARotationProcessor(

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/security/x509/certificate/client/RootCaRotationPoller.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/security/x509/certificate/client/RootCaRotationPoller.java
@@ -73,7 +73,14 @@ public class RootCaRotationPoller implements Runnable, Closeable {
     certificateRenewalError = new AtomicBoolean(false);
   }
 
-  private void pollRootCas() {
+  /**
+   * Polls the SCM for root ca certificates and compares them to the known
+   * set of root ca certificates. If there are new root ca certificates it
+   * invokes the necessary handlers provided in rootCaRotationProcessors.
+   *
+   * @return returns true if the SCM provided a new root ca certificate.
+   */
+  boolean pollRootCas() {
     try {
       List<String> pemEncodedRootCaList =
           scmSecureClient.getAllRootCaCertificates();
@@ -83,7 +90,7 @@ public class RootCaRotationPoller implements Runnable, Closeable {
           = new ArrayList<>(rootCAsFromSCM);
       scmCertsWithoutKnownCerts.removeAll(knownRootCerts);
       if (scmCertsWithoutKnownCerts.isEmpty()) {
-        return;
+        return false;
       }
       LOG.info("Some root CAs are not known to the client out of the root " +
           "CAs known to the SCMs. Root CA Cert ids known to the client: " +
@@ -99,8 +106,9 @@ public class RootCaRotationPoller implements Runnable, Closeable {
       allRootCAProcessorFutures.whenComplete((unused, throwable) -> {
         if (throwable == null && !certificateRenewalError.get()) {
           knownRootCerts = new HashSet<>(rootCAsFromSCM);
+          LOG.info("Certificate processing was successful.");
         } else {
-          LOG.info("Certificate consumption was unsuccesfull. " +
+          LOG.info("Certificate consumption was unsuccessful. " +
               (certificateRenewalError.get() ?
                   "There was a caught exception when trying to sign the " +
                       "certificate" :
@@ -111,6 +119,7 @@ public class RootCaRotationPoller implements Runnable, Closeable {
     } catch (IOException e) {
       LOG.error("Error while trying to poll root ca certificate", e);
     }
+    return true;
   }
 
   public void addRootCARotationProcessor(

--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/security/x509/certificate/client/TestRootCaRotationPoller.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/security/x509/certificate/client/TestRootCaRotationPoller.java
@@ -16,12 +16,14 @@
  * limitations under the License.
  *
  */
-package org.apache.hadoop.hdds.security.x509.certificate.utils;
+package org.apache.hadoop.hdds.security.x509.certificate.client;
 
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.protocolPB.SCMSecurityProtocolClientSideTranslatorPB;
 import org.apache.hadoop.hdds.security.SecurityConfig;
 import org.apache.hadoop.hdds.security.x509.certificate.client.RootCaRotationPoller;
+import org.apache.hadoop.hdds.security.x509.certificate.utils.CertificateCodec;
+import org.apache.hadoop.hdds.security.x509.certificate.utils.SelfSignedCertificate;
 import org.apache.hadoop.security.ssl.KeyStoreTestUtil;
 import org.apache.ozone.test.GenericTestUtils;
 import org.bouncycastle.cert.jcajce.JcaX509CertificateConverter;


### PR DESCRIPTION
## What changes were proposed in this pull request?
Fix the failure in TestRootCaRotationPoller arising from multi threaded execution

Please describe your PR in detail:
Sometimes the test cases were failing because `CompletableFuture.supplyAsync()` wasn't finishing before assertions were made for its results. Now 2 test cases avoid using the future at all, the third one is refactored so that it can wait for its result.

There is also a small refactor regarding pollRootCas, its visibility is changed so that it can be called directly from the test instead of relying on the run method that would introduce another point of possible sync issue via the executorService scheduling.

And finally pollRootCas now returns weather it found new certificates. Also added some logging in the success scenario.

The error `Exception in thread "RootCaRotationPoller" java.lang.OutOfMemoryError: GC overhead limit exceeded` mentioned in the Jira ticked was unrelated, its was caused by my local environment. (IntelliJ tried storing all test results on the heap)

## How was this patch tested?

Run each test locally 1000 times. I will add additional CI runs

Benchmark CI run on master finding at least 2 failures: https://github.com/Galsza/ozone/actions/runs/6847473750/job/18618436190
Run on the current branch without failures: 
https://github.com/Galsza/ozone/actions/runs/6849624033/job/18622199979
