### PR TITLE
HDDS-9602. Backport HDDS-9550 to legacy RM (missing containers which are empty)

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/LegacyReplicationManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/LegacyReplicationManager.java
@@ -499,6 +499,19 @@ public class LegacyReplicationManager {
           return;
         }
 
+        // If the container is empty and has no replicas, it is possible it was
+        // a container which stuck in the closing state which never got any
+        // replicas created on the datanodes. In this case, we don't have enough
+        // information to delete the container, so we just log it as EMPTY,
+        // leaving it as CLOSED and return true, otherwise, it will end up
+        // marked as missing by the under replication handling.
+        if (replicas.isEmpty()
+            && container.getState() == LifeCycleState.CLOSED
+            && container.getNumberOfKeys() == 0) {
+          report.incrementAndSample(HealthState.EMPTY, container.containerID());
+          return;
+        }
+
         /*
          * Check if the container is under replicated and take appropriate
          * action.

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/LegacyReplicationManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/LegacyReplicationManager.java
@@ -508,6 +508,9 @@ public class LegacyReplicationManager {
         if (replicas.isEmpty()
             && container.getState() == LifeCycleState.CLOSED
             && container.getNumberOfKeys() == 0) {
+          LOG.debug("Container {} appears empty and is closed, but cannot be " +
+              "deleted because it has no replicas. Marking as EMPTY.",
+              container);
           report.incrementAndSample(HealthState.EMPTY, container.containerID());
           return;
         }

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestLegacyReplicationManager.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestLegacyReplicationManager.java
@@ -514,6 +514,19 @@ public class TestLegacyReplicationManager {
     }
 
     @Test
+    public void testEmptyContainerWithNoReplicas() throws Exception {
+      final ContainerInfo container = createContainer(
+          LifeCycleState.CLOSED, 0, 0);
+      // No replicas
+      replicationManager.processAll();
+      eventQueue.processAll(1000);
+      ReplicationManagerReport report = replicationManager.getContainerReport();
+      Assertions.assertEquals(1,
+          report.getStat(ReplicationManagerReport.HealthState.EMPTY));
+      Assertions.assertEquals(LifeCycleState.CLOSED, container.getState());
+    }
+
+    @Test
     public void testDeletionLimit() throws Exception {
       runTestLimit(0, 2, 0, 1,
               () -> runTestDeleteEmptyContainer(2));


### PR DESCRIPTION
## What changes were proposed in this pull request?

This change mirrors #5523 for the legacy RM.

If a container appears empty to SCM (ie key count is zero in the containerInfo) and there are no replicas, it could be a container which failed to be created on the datanodes, and no replicas will ever be reported.

However there isn't enough information to know if the container can be safely deleted or not, as the DN could have gone offline or missed some heartbeats etc.

As things stand, such as container will appear as missing in the container report. In this PR, we change that to leave the container as CLOSED but count it as EMPTY without triggering the delete process.

That means if replicas later appear, it will be OK.

However if the replicas never appear, the container will be stuck in this state forever. Additionally, if there should be replicas, as the client successfully wrote to the DNs and updated OM, there is no way to know this on SCM and the container should really be missing despite it being logged as empty, hiding the problem.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-9602

## How was this patch tested?

New unit test added.