### PR TITLE
HDDS-9323. Better datanode exclude list handling for long-lived clients

### DIFF
--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/OzoneClientConfig.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/OzoneClientConfig.java
@@ -184,7 +184,7 @@ public class OzoneClientConfig {
   @Config(key = "exclude.nodes.expiry.time",
       defaultValue = "600000",
       description = "Time after which an excluded node is reconsidered for" +
-          " writes in EC. If the value is zero, the node is excluded for the" +
+          " writes. If the value is zero, the node is excluded for the" +
           " life of the client",
       tags = ConfigTag.CLIENT)
   private long excludeNodesExpiryTime = 10 * 60 * 1000;
@@ -348,6 +348,10 @@ public class OzoneClientConfig {
 
   public long getExcludeNodesExpiryTime() {
     return excludeNodesExpiryTime;
+  }
+
+  public void setExcludeNodesExpiryTime(long expiryTime) {
+    excludeNodesExpiryTime = expiryTime;
   }
 
   public int getBufferIncrement() {

--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/storage/BlockOutputStream.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/storage/BlockOutputStream.java
@@ -546,6 +546,7 @@ public class BlockOutputStream extends OutputStream {
     try {
       handleFlushInternal(close);
     } catch (ExecutionException e) {
+      failedServers.addAll(getPipeline().getNodes());
       handleExecutionException(e);
     } catch (InterruptedException ex) {
       Thread.currentThread().interrupt();

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/container/common/helpers/ExcludeList.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/container/common/helpers/ExcludeList.java
@@ -64,13 +64,13 @@ public class ExcludeList {
 
   public Set<DatanodeDetails> getDatanodes() {
     Set<DatanodeDetails> dns = new HashSet<>();
-    if (expiryTime > 0) {
+    if (getExpiryTime() > 0) {
       Iterator<Map.Entry<DatanodeDetails, Long>> iterator =
           datanodes.entrySet().iterator();
       while (iterator.hasNext()) {
         Map.Entry<DatanodeDetails, Long> entry = iterator.next();
         Long storedExpiryTime = entry.getValue();
-        if (clock.millis() > storedExpiryTime) {
+        if (isExpired(storedExpiryTime)) {
           iterator.remove(); // removing
         } else {
           dns.add(entry.getKey());
@@ -149,6 +149,14 @@ public class ExcludeList {
         ", containerIds = " + containerIds +
         ", pipelineIds = " + pipelineIds +
         '}';
+  }
+
+  public boolean isExpired(Long storedExpiryTime) {
+    return clock.millis() > storedExpiryTime;
+  }
+
+  public long getExpiryTime() {
+    return expiryTime;
   }
 
 }

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/io/BlockOutputStreamEntryPool.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/io/BlockOutputStreamEntryPool.java
@@ -79,7 +79,7 @@ public class BlockOutputStreamEntryPool {
   private final BufferPool bufferPool;
   private OmMultipartCommitUploadPartInfo commitUploadPartInfo;
   private final long openID;
-  private final ExcludeList excludeList;
+  private ExcludeList excludeList;
   private final ContainerClientMetrics clientMetrics;
 
   @SuppressWarnings({"parameternumber", "squid:S00107"})
@@ -105,7 +105,7 @@ public class BlockOutputStreamEntryPool {
         .setMultipartUploadPartNumber(partNumber).build();
     this.requestID = requestId;
     this.openID = openID;
-    this.excludeList = createExcludeList();
+    setExcludeList(createExcludeList());
 
     this.bufferPool =
         new BufferPool(config.getStreamBufferSize(),
@@ -425,6 +425,9 @@ public class BlockOutputStreamEntryPool {
     return excludeList;
   }
 
+  public void setExcludeList(ExcludeList excludeList) {
+    this.excludeList = excludeList;
+  }
   boolean isEmpty() {
     return streamEntries.isEmpty();
   }

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/io/KeyOutputStream.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/io/KeyOutputStream.java
@@ -90,7 +90,7 @@ public class KeyOutputStream extends OutputStream implements Syncable {
   // whether an exception is encountered while write and whole write could
   // not succeed
   private boolean isException;
-  private final BlockOutputStreamEntryPool blockOutputStreamEntryPool;
+  private BlockOutputStreamEntryPool blockOutputStreamEntryPool;
 
   private long clientID;
 
@@ -270,7 +270,7 @@ public class KeyOutputStream extends OutputStream implements Syncable {
       // the buffers
       Preconditions.checkState(!retry || len <= config
           .getStreamBufferMaxSize());
-      int dataWritten = (int) (current.getWrittenDataLength() - currentPos);
+      int dataWritten = getDataWritten(current, currentPos);
       writeLen = retry ? (int) len : dataWritten;
       // In retry path, the data written is already accounted in offset.
       if (!retry) {
@@ -709,4 +709,21 @@ public class KeyOutputStream extends OutputStream implements Syncable {
               + blockOutputStreamEntryPool.getKeyName());
     }
   }
+
+  protected BlockOutputStreamEntryPool getBlockOutputStreamEntryPool() {
+    return blockOutputStreamEntryPool;
+  }
+
+  protected void setBlockOutputStreamEntryPool(BlockOutputStreamEntryPool streamEntryPool) {
+    blockOutputStreamEntryPool = streamEntryPool;
+  }
+
+  public void setExcludeList(ExcludeList excludeList) {
+    blockOutputStreamEntryPool.setExcludeList(excludeList);
+  }
+
+  protected int getDataWritten(BlockOutputStreamEntry current, long currentPos) {
+    return (int) (current.getWrittenDataLength() - currentPos);
+  }
+
 }

--- a/hadoop-ozone/client/src/test/java/org/apache/hadoop/ozone/client/io/TestKeyOutputStream.java
+++ b/hadoop-ozone/client/src/test/java/org/apache/hadoop/ozone/client/io/TestKeyOutputStream.java
@@ -1,0 +1,119 @@
+package org.apache.hadoop.ozone.client.io;
+
+
+import org.apache.hadoop.hdds.client.*;
+import org.apache.hadoop.hdds.protocol.DatanodeDetails;
+import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
+import org.apache.hadoop.hdds.scm.OzoneClientConfig;
+import org.apache.hadoop.hdds.scm.XceiverClientFactory;
+import org.apache.hadoop.hdds.scm.container.common.helpers.ExcludeList;
+import org.apache.hadoop.hdds.scm.pipeline.Pipeline;
+import org.apache.hadoop.hdds.scm.pipeline.PipelineID;
+import org.apache.hadoop.ozone.om.helpers.*;
+import org.apache.hadoop.ozone.om.protocolPB.OzoneManagerClientProtocol;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationFactor.THREE;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+
+public class TestKeyOutputStream {
+
+private static String testKeyString = "test";
+  @Test
+  public void testRATISKeyOutputStreamExpiryTime() throws Exception {
+    KeyOutputStream keyOutputStream =
+        createRATISKeyOutputStream();
+    byte[] data = testKeyString.getBytes(UTF_8);
+    keyOutputStream.write(data);
+
+    Assert.assertEquals(3,
+        keyOutputStream.getExcludeList().getDatanodes().size());
+
+    ExcludeList excludeList = spy(keyOutputStream.getExcludeList());
+    doReturn(300 * 1000L).when(excludeList).getExpiryTime();
+    doReturn(true).when(excludeList).isExpired(anyLong());// mock DN in exclude list expire
+    keyOutputStream.setExcludeList(excludeList);
+    Assert.assertEquals(0,
+        keyOutputStream.getExcludeList().getDatanodes().size());
+  }
+
+  private KeyOutputStream createRATISKeyOutputStream() throws Exception {
+    OpenKeySession openKeySession = mock(OpenKeySession.class);
+    doReturn(1L).when(openKeySession).getId();
+    OmKeyInfo omKeyInfo =  new OmKeyInfo.Builder()
+        .setVolumeName("testvolume")
+        .setBucketName("testbucket")
+        .setKeyName("testKey")
+        .build();
+    doReturn(omKeyInfo).when(openKeySession).getKeyInfo();
+
+    XceiverClientFactory xceiverClientManager = mock(XceiverClientFactory.class);
+
+    OzoneManagerClientProtocol ozoneManagerClientProtocol = mock(OzoneManagerClientProtocol.class);
+
+    OzoneClientConfig clientConfig = mock(OzoneClientConfig.class);
+    doReturn(1).when(clientConfig).getStreamBufferSize();
+    doReturn(300 * 1000L).when(clientConfig).getExcludeNodesExpiryTime();
+
+    KeyOutputStream.Builder builder;
+
+    ReplicationConfig repConfig =
+        RatisReplicationConfig.getInstance(HddsProtos.ReplicationFactor.THREE);
+    builder = new KeyOutputStream.Builder()
+        .setReplicationConfig(repConfig);
+
+    KeyOutputStream keyOutputStream =
+        spy(builder.setHandler(openKeySession)
+            .setXceiverClientManager(xceiverClientManager)
+            .setOmClient(ozoneManagerClientProtocol)
+            .setConfig(clientConfig)
+            .build());
+
+    BlockOutputStreamEntryPool blockOutputStreamEntryPool = spy(keyOutputStream.getBlockOutputStreamEntryPool());
+    BlockOutputStreamEntry blockOutputStreamEntry = mock(BlockOutputStreamEntry.class);
+    Pipeline pipeline = new Pipeline.Builder()
+        .setState(Pipeline.PipelineState.OPEN)
+        .setReplicationConfig(RatisReplicationConfig.getInstance(THREE))
+        .setId(PipelineID.randomId())
+        .setNodes(new ArrayList<>())
+        .build();
+
+    doThrow(IOException.class).when(blockOutputStreamEntry).write(any(byte[].class),anyInt(),anyInt());
+    doReturn(pipeline).when(blockOutputStreamEntry).getPipeline();
+    doReturn(new BlockID(1,1)).when(blockOutputStreamEntry).getBlockID();
+
+    // mock the datanodes for getFailedServers()
+    List<DatanodeDetails> datanodeDetails = new ArrayList<>(3);
+    for (int i = 0; i < 3; i++) {
+      datanodeDetails.add(
+          DatanodeDetails.getFromProtoBuf(HddsProtos.DatanodeDetailsProto.newBuilder().setUuid128(
+                  HddsProtos.UUID.newBuilder().setLeastSigBits(i).setMostSigBits(i)
+                      .build()).setHostName("localhost").setIpAddress("0.0.0.0")
+              .addPorts(HddsProtos.Port.newBuilder().setName("test").setValue(i)
+                  .build()).build())
+      );
+    }
+
+    doReturn(datanodeDetails).when(blockOutputStreamEntry).getFailedServers();
+    doReturn(blockOutputStreamEntry).when(blockOutputStreamEntryPool).allocateBlockIfNeeded();
+    doReturn(Long.valueOf(testKeyString.length())).when(blockOutputStreamEntryPool).getKeyLength();
+    keyOutputStream.setBlockOutputStreamEntryPool(blockOutputStreamEntryPool);
+    doReturn(testKeyString.length())
+        .when(keyOutputStream)
+        .getDataWritten(any(BlockOutputStreamEntry.class),anyLong());
+    return keyOutputStream;
+  }
+
+}


### PR DESCRIPTION
## What changes were proposed in this pull request?
Currently it is possible that a long lived client can add most or all nodes of a small cluster to its exclude list, and further writes using that client instance will fail. This PR add a timeout for RATIS key to remove datanodes from the exclude list so that they can be retried later. 
(For EC key, this mechanism exists and is configured to 10 minutes by default.)

This improvement is especially relevant for S3 gateway, which uses a persistent Ozone client to connect to the cluster.

And there is another part of improvement that allows the write to fall back to datanodes in the exclude list if that is all available. This would be implemented as a retry from the client based on the server's initial error response.

This part of work is separated into another PR:  https://github.com/apache/ozone/pull/5514

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-9323

## How was this patch tested?
unit test
