### PR TITLE
HDDS-9214. Remove Reclaimed snapshot status type

### DIFF
--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/SnapshotInfo.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/SnapshotInfo.java
@@ -64,13 +64,11 @@ public final class SnapshotInfo implements Auditable, CopyObject<SnapshotInfo> {
   }
 
   /**
-   * SnapshotStatus enum composed of
-   * active, deleted and reclaimed statues.
+   * SnapshotStatus enum composed of active and deleted statuses.
    */
   public enum SnapshotStatus {
     SNAPSHOT_ACTIVE,
-    SNAPSHOT_DELETED,
-    SNAPSHOT_RECLAIMED;
+    SNAPSHOT_DELETED;
 
     public static final SnapshotStatus DEFAULT = SNAPSHOT_ACTIVE;
 
@@ -80,8 +78,6 @@ public final class SnapshotInfo implements Auditable, CopyObject<SnapshotInfo> {
         return SnapshotStatusProto.SNAPSHOT_ACTIVE;
       case SNAPSHOT_DELETED:
         return SnapshotStatusProto.SNAPSHOT_DELETED;
-      case SNAPSHOT_RECLAIMED:
-        return SnapshotStatusProto.SNAPSHOT_RECLAIMED;
       default:
         throw new IllegalStateException(
             "BUG: missing valid SnapshotStatus, found status=" + this);
@@ -94,8 +90,6 @@ public final class SnapshotInfo implements Auditable, CopyObject<SnapshotInfo> {
         return SNAPSHOT_ACTIVE;
       case SNAPSHOT_DELETED:
         return SNAPSHOT_DELETED;
-      case SNAPSHOT_RECLAIMED:
-        return SNAPSHOT_RECLAIMED;
       default:
         throw new IllegalStateException(
             "BUG: missing valid SnapshotStatus, found status=" + status);
@@ -135,8 +129,7 @@ public final class SnapshotInfo implements Auditable, CopyObject<SnapshotInfo> {
    * @param name - snapshot name.
    * @param volumeName - volume name.
    * @param bucketName - bucket name.
-   * @param snapshotStatus - status: SNAPSHOT_ACTIVE, SNAPSHOT_DELETED,
-   *                      SNAPSHOT_RECLAIMED
+   * @param snapshotStatus - status: SNAPSHOT_ACTIVE, SNAPSHOT_DELETED
    * @param creationTime - Snapshot creation time.
    * @param deletionTime - Snapshot deletion time.
    * @param pathPreviousSnapshotId - Snapshot path previous snapshot id.

--- a/hadoop-ozone/interface-client/src/main/proto/OmClientProtocol.proto
+++ b/hadoop-ozone/interface-client/src/main/proto/OmClientProtocol.proto
@@ -811,12 +811,11 @@ message PrefixInfo {
 
 /**
  * SnapshotStatus - snapshot states.
- * Snapshot in one of : active, deleted, or reclaimed state
+ * Snapshot in one of : active or deleted state
  */
 enum SnapshotStatusProto {
   SNAPSHOT_ACTIVE = 1;
   SNAPSHOT_DELETED = 2;
-  SNAPSHOT_RECLAIMED = 3;
 }
 
 /**

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/snapshot/OMSnapshotDeleteRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/snapshot/OMSnapshotDeleteRequest.java
@@ -161,14 +161,11 @@ public class OMSnapshotDeleteRequest extends OMClientRequest {
       if (!snapshotInfo.getSnapshotStatus().equals(
           SnapshotInfo.SnapshotStatus.SNAPSHOT_ACTIVE)) {
         // If the snapshot is not in active state, throw exception as well
-        switch (snapshotInfo.getSnapshotStatus()) {
-        case SNAPSHOT_DELETED:
+        if (snapshotInfo.getSnapshotStatus().equals(
+                SnapshotInfo.SnapshotStatus.SNAPSHOT_DELETED)) {
           throw new OMException("Snapshot is already deleted. "
-              + "Pending reclamation.", FILE_NOT_FOUND);
-        case SNAPSHOT_RECLAIMED:
-          throw new OMException("Snapshot is already deleted and reclaimed.",
-              FILE_NOT_FOUND);
-        default:
+                  + "Pending reclamation.", FILE_NOT_FOUND);
+        } else {
           // Unknown snapshot non-active state
           throw new OMException("Snapshot exists but no longer in active state",
               FILE_NOT_FOUND);


### PR DESCRIPTION
## What changes were proposed in this pull request?
This PR removes the Reclaimed Snapshot Status Type. The Reclaimed snapshot status is not used what it was intended to use for. Since garbage collection simply deletes the entry after snapshot purge, it's not needed.

This change removes `SnaphostStatus.SNAPSHOT_RECLAIMED`, its corresponding proto `SnapshotStatusProto.SNAPSHOT_RECLAIMED` and all their usages. 

## What is the link to the Apache JIRA
[https://issues.apache.org/jira/browse/HDDS-9214](https://issues.apache.org/jira/browse/HDDS-9214)

## How was this patch tested?

The patch was tested by running unit test cases from the corresponding test class `TestOmSnapshotInfo` 