### PR TITLE
HDDS-9171. Resolve dependabot build issues when updating npm packages

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,3 +1,17 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 version: 2
 updates:
   # Maintain dependencies for GitHub Actions

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,14 @@
+version: 2
+updates:
+  # Maintain dependencies for GitHub Actions
+  - package-ecosystem: "npm"
+    directory: "hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "[Recon] Dependabot Package Upgrade: "
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
+    pull-request-branch-name:
+      separator: "-"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -26,3 +26,12 @@ updates:
         update-types: ["version-update:semver-major"]
     pull-request-branch-name:
       separator: "-"
+
+  - package-ecosystem: maven
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "[Java] Dependabot Package Upgrade: "
+    pull-request-branch-name:
+      separator: "-"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,62 @@ env:
   MAVEN_OPTS: -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.http.retryHandler.class=standard -Dmaven.wagon.http.retryHandler.count=3
   OZONE_WITH_COVERAGE: ${{ github.repository == 'apache/ozone' && github.event_name != 'pull_request' }}
 jobs:
+  dependabot-check:
+    if: ${{ github.actor == 'dependabot[bot]' && github.event_name == 'pull_request'}}
+    runs-on: ubuntu-20.04
+    env:
+      CI_COMMIT_MESSAGE: Re-created lockfile using pnpm
+      CI_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      NODE_VERSION: 16.14.2
+      PNPM_VERSION: 7.33.6
+      cURL_LOC: /usr/bin/curl
+      cURL_ARGS: -fsSL
+      PNPM_URL: https://get.pnpm.io/install.sh
+    timeout-minutes: 15
+    steps:
+      - name: Extract branch name
+        shell: bash
+        run: echo "branch_name=${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}" >> $GITHUB_OUTPUT
+        id: get_branch_name
+      - name: Checkout dependabot branch
+        uses: actions/checkout@v4
+        with:
+          repository: apache/ozone
+          ref: ${{ github.event.pull_request.head.sha }}
+          path: ozone
+      - name: Delete the lockfile
+        working-directory: ozone
+        run: |
+          #Delete the lockfile created by dependabot
+          rm -rf hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/pnpm-lock.yaml
+      - name: Install NodeJS v16.14.2
+        uses: actions/setup-node@v3
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+      - name: Install pnpm v7.33.6 and recreate lockfile
+        working-directory: ozone
+        shell: bash
+        run: |
+          # Install PNPM and recreate lockfile
+          echo "Fetching pnpm from $PNPM_URL with version $PNPM_VERSION"
+          $cURL_LOC $cURL_ARGS $PNPM_URL | env PNPM_VERSION=$PNPM_VERSION SHELL="$(which sh)" ENV="$HOME/.shrc" sh -
+          source /home/runner/.shrc
+          PNPM_EXEC=$(which pnpm)
+          echo "pnpm is present at: $PNPM_EXEC"
+          $PNPM_EXEC config set store-dir ~/.pnpm-store
+          cd hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/
+          $PNPM_EXEC install --lockfile-only
+      - name: Commit generated lockfile
+        working-directory: ozone
+        run: |
+          OZONE_SHA=$(git -C ./ rev-parse HEAD)
+          cd hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/
+          git add ./pnpm-lock.yaml
+          git status
+          git config --global user.name 'Github Actions'
+          git config --global user.email 'noreply@github.com'
+          git commit -m "[auto] Generated pnpm-lock from actions for $OZONE_SHA" || true
+          git push origin HEAD:${{ steps.get_branch_name.outputs.branch_name }}
   build-info:
     runs-on: ubuntu-20.04
     env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,62 +20,6 @@ env:
   MAVEN_OPTS: -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.http.retryHandler.class=standard -Dmaven.wagon.http.retryHandler.count=3
   OZONE_WITH_COVERAGE: ${{ github.repository == 'apache/ozone' && github.event_name != 'pull_request' }}
 jobs:
-  dependabot-check:
-    if: ${{ github.actor == 'dependabot[bot]' && github.event_name == 'pull_request'}}
-    runs-on: ubuntu-20.04
-    env:
-      CI_COMMIT_MESSAGE: Re-created lockfile using pnpm
-      CI_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      NODE_VERSION: 16.14.2
-      PNPM_VERSION: 7.33.6
-      cURL_LOC: /usr/bin/curl
-      cURL_ARGS: -fsSL
-      PNPM_URL: https://get.pnpm.io/install.sh
-    timeout-minutes: 15
-    steps:
-      - name: Extract branch name
-        shell: bash
-        run: echo "branch_name=${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}" >> $GITHUB_OUTPUT
-        id: get_branch_name
-      - name: Checkout dependabot branch
-        uses: actions/checkout@v4
-        with:
-          repository: apache/ozone
-          ref: ${{ github.event.pull_request.head.sha }}
-          path: ozone
-      - name: Delete the lockfile
-        working-directory: ozone
-        run: |
-          #Delete the lockfile created by dependabot
-          rm -rf hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/pnpm-lock.yaml
-      - name: Install NodeJS v16.14.2
-        uses: actions/setup-node@v3
-        with:
-          node-version: ${{ env.NODE_VERSION }}
-      - name: Install pnpm v7.33.6 and recreate lockfile
-        working-directory: ozone
-        shell: bash
-        run: |
-          # Install PNPM and recreate lockfile
-          echo "Fetching pnpm from $PNPM_URL with version $PNPM_VERSION"
-          $cURL_LOC $cURL_ARGS $PNPM_URL | env PNPM_VERSION=$PNPM_VERSION SHELL="$(which sh)" ENV="$HOME/.shrc" sh -
-          source /home/runner/.shrc
-          PNPM_EXEC=$(which pnpm)
-          echo "pnpm is present at: $PNPM_EXEC"
-          $PNPM_EXEC config set store-dir ~/.pnpm-store
-          cd hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/
-          $PNPM_EXEC install --lockfile-only
-      - name: Commit generated lockfile
-        working-directory: ozone
-        run: |
-          OZONE_SHA=$(git -C ./ rev-parse HEAD)
-          cd hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/
-          git add ./pnpm-lock.yaml
-          git status
-          git config --global user.name 'Github Actions'
-          git config --global user.email 'noreply@github.com'
-          git commit -m "[auto] Generated pnpm-lock from actions for $OZONE_SHA" || true
-          git push origin HEAD:${{ steps.get_branch_name.outputs.branch_name }}
   build-info:
     runs-on: ubuntu-20.04
     env:

--- a/.github/workflows/dependabot-ci.yml
+++ b/.github/workflows/dependabot-ci.yml
@@ -1,0 +1,79 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+name: dependabot-ci
+on:
+  pull_request:
+    types: [opened, ready_for_review]
+concurrency:
+  group: dependabot-ci-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+jobs:
+  dependabot-check:
+    if: ${{ github.actor == 'dependabot[bot]' && github.event_name == 'pull_request'}}
+    runs-on: ubuntu-20.04
+    env:
+      CI_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      NODE_VERSION: 16.14.2
+      PNPM_VERSION: 7.33.6
+      cURL_LOC: /usr/bin/curl
+      cURL_ARGS: -fsSL
+      PNPM_URL: https://get.pnpm.io/install.sh
+    timeout-minutes: 15
+    permissions:
+      contents: write
+    steps:
+      - name: Extract branch name
+        shell: bash
+        run: echo "branch_name=${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}" >> $GITHUB_OUTPUT
+        id: get_branch_name
+      - name: Checkout dependabot branch
+        uses: actions/checkout@v4
+        with:
+          repository: apache/ozone
+          ref: ${{ github.event.pull_request.head.sha }}
+          path: ozone
+      - name: Delete the lockfile
+        working-directory: ozone
+        run: |
+          #Delete the lockfile created by dependabot
+          rm -rf hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/pnpm-lock.yaml
+      - name: Install NodeJS v16.14.2
+        uses: actions/setup-node@v3
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+      - name: Install pnpm v7.33.6 and recreate lockfile
+        working-directory: ozone
+        shell: bash
+        run: |
+          # Install PNPM and recreate lockfile
+          echo "Fetching pnpm from $PNPM_URL with version $PNPM_VERSION"
+          $cURL_LOC $cURL_ARGS $PNPM_URL | env PNPM_VERSION=$PNPM_VERSION SHELL="$(which sh)" ENV="$HOME/.shrc" sh -
+          source /home/runner/.shrc
+          PNPM_EXEC=$(which pnpm)
+          echo "pnpm is present at: $PNPM_EXEC"
+          $PNPM_EXEC config set store-dir ~/.pnpm-store
+          cd hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/
+          $PNPM_EXEC install --lockfile-only
+      - name: Commit generated lockfile
+        working-directory: ozone
+        run: |
+          OZONE_SHA=$(git -C ./ rev-parse HEAD)
+          cd hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/
+          git add ./pnpm-lock.yaml
+          git status
+          git config --global user.name 'Github Actions'
+          git config --global user.email 'noreply@github.com'
+          git commit -m "[auto] Generated pnpm-lock from actions for $OZONE_SHA" || true
+          git push origin HEAD:${{ steps.get_branch_name.outputs.branch_name }}

--- a/.github/workflows/dependabot-ci.yml
+++ b/.github/workflows/dependabot-ci.yml
@@ -41,7 +41,6 @@ jobs:
       - name: Checkout dependabot branch
         uses: actions/checkout@v4
         with:
-          repository: apache/ozone
           ref: ${{ github.event.pull_request.head.sha }}
           path: ozone
       - name: Delete the lockfile

--- a/.github/workflows/dependabot-ci.yml
+++ b/.github/workflows/dependabot-ci.yml
@@ -48,11 +48,11 @@ jobs:
         run: |
           #Delete the lockfile created by dependabot
           rm -rf hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/pnpm-lock.yaml
-      - name: Install NodeJS v16.14.2
+      - name: Install NodeJS v${{ env.NODE_VERSION }}
         uses: actions/setup-node@v3
         with:
           node-version: ${{ env.NODE_VERSION }}
-      - name: Install pnpm v7.33.6 and recreate lockfile
+      - name: Install pnpm v${{ env.PNPM_VERSION }} and recreate lockfile
         working-directory: ozone
         shell: bash
         run: |

--- a/.github/workflows/dependabot-ci.yml
+++ b/.github/workflows/dependabot-ci.yml
@@ -21,7 +21,7 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 jobs:
   dependabot-check:
-    if: ${{ github.actor == 'dependabot[bot]' && github.event_name == 'pull_request'}}
+    if: ${{ github.event_name == 'pull_request' && github.actor == 'dependabot[bot]' && startsWith(github.event.pull_request.title, '[Recon] Dependabot Package Upgrade') }}
     runs-on: ubuntu-20.04
     env:
       CI_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/dependabot-ci.yml
+++ b/.github/workflows/dependabot-ci.yml
@@ -15,7 +15,7 @@
 name: dependabot-ci
 on:
   pull_request:
-    types: [opened, ready_for_review]
+    types: [opened, synchronize]
 concurrency:
   group: dependabot-ci-${{ github.event.pull_request.number || github.sha }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}

--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/package.json
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/package.json
@@ -1,4 +1,5 @@
 {
+  "packageManager": "pnpm@7.33.6",
   "name": "ozone-recon",
   "version": "0.1.0",
   "private": true,


### PR DESCRIPTION
## What changes were proposed in this pull request?
HDDS-9171. Added a dependabot.yml file to control the PRs that are being raised by dependabot for auto-upgrade of versions.

Please describe your PR in detail:
* The Ozone upstream repo has dependabot upgrades enabled to maintain versions for JS libraries, however right now dependabot only updates the `pnpm-lock.yaml` file which is an incorrect behaviour and would cause build failures.
* This PR adds a dependabot.yml file to set the rules on which folders to scan for possible upgrades, defining the proper package manager to use, and setup general dependabot behaviour.
* This also adds a few github actions, which would be triggered on a dependabot raised PR.
  * Why the actions are required?
  Even after we properly define the dependabot behaviour, it would properly update the versions on the dependencies. But it would also create a pnpm-lock.yaml file automatically which might not be accurate. So the github actions delete this bot generated lockfile, re-creates this file using pnpm to ensure proper generation and re-commits this proper lockfile back into the PR, ensuring the generation is properly done and there are no build issues with such an upgrade.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-9171


## How was this patch tested?

This patch was tested manually.
Dummy PR was raised against the branch with the changes in the private forked repo, and then the validations were made.

| Screenshot | Description |
|------------|-------------|
|<img width="1728" alt="Screenshot 2023-11-03 at 16 28 52" src="https://github.com/apache/ozone/assets/43001336/3a9a4c42-b080-4b7e-9ee4-c411e3c85b60"> | PR created by dependabot, which includes the proper version bumps in the `package.json` file. |
|<img width="1728" alt="HDDS-9171-dependabot-check-action" src="https://github.com/apache/ozone/assets/43001336/29d52744-918b-4466-9348-dd63f8f64911"> | `dependabot-check` action ran on a dummy PR raised against the branch with the changes for testing. |
|<img width="1728" alt="HDDS-9171-dependabot-check-generated-lockfile" src="https://github.com/apache/ozone/assets/43001336/e1a08306-8e34-4461-adc1-a9c6837853ec"> | package-lock.yaml file that was created by the check action now included in the PR |

