### PR TITLE
HDDS-9605. Upgrade coverage check to Java 17

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -501,11 +501,11 @@ jobs:
           tar xzvf target/artifacts/ozone-bin/ozone*.tar.gz -C hadoop-ozone/dist/target
       - name: Calculate combined coverage
         run: ./hadoop-ozone/dev-support/checks/coverage.sh
-      - name: Setup java 11
+      - name: Setup java 17
         uses: actions/setup-java@v3
         with:
           distribution: 'temurin'
-          java-version: 11
+          java-version: 17
       - name: Upload coverage to Sonar
         run: ./hadoop-ozone/dev-support/checks/sonar.sh
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -482,6 +482,8 @@ jobs:
     steps:
       - name: Checkout project
         uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
       - name: Cache for maven dependencies
         uses: actions/cache@v3
         with:


### PR DESCRIPTION
## What changes were proposed in this pull request?

SonarCloud will no longer accept scans created with Java 11 ([announcement](https://community.sonarsource.com/t/java-11-is-deprecated-as-a-runtime-env-to-scan-your-projects/96597)), so we should upgrade _coverage_ check to Java 17.

Also: checkout the project with history, to eliminate a [warning](https://github.com/apache/ozone/actions/runs/6712269060/job/18244181507#step:8:5788) printed for each source file.

https://issues.apache.org/jira/browse/HDDS-9605

## How was this patch tested?

CI (in `apache/ozone` instead of my fork, because forks and PRs skip coverage check):
https://github.com/apache/ozone/actions/runs/6724730333

Verified that analysis was uploaded to SonarCloud:
https://sonarcloud.io/summary/overall?id=hadoop-ozone&branch=HDDS-9605