### PR TITLE
HDDS-9544. Incorrect pipeline ID and state for closed container.

### DIFF
--- a/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/container/InfoSubcommand.java
+++ b/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/container/InfoSubcommand.java
@@ -113,6 +113,14 @@ public class InfoSubcommand extends ScmSubcommand {
       }
       LOG.info("Write PipelineId: {}",
           container.getContainerInfo().getPipelineID().getId());
+      try {
+        String pipelineState = scmClient.getPipeline(
+                container.getContainerInfo().getPipelineID().getProtobuf())
+            .getPipelineState().toString();
+        LOG.info("Write Pipeline State: {}", pipelineState);
+      } catch (IOException ioe) {
+        LOG.info("Write Pipeline State: CLOSED");
+      }
       LOG.info("Container State: {}", container.getContainerInfo().getState());
 
       // Print pipeline of an existing container.

--- a/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/container/InfoSubcommand.java
+++ b/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/container/InfoSubcommand.java
@@ -120,6 +120,8 @@ public class InfoSubcommand extends ScmSubcommand {
         LOG.info("Pipeline id: {}",
             container.getContainerInfo().getPipelineID());
       }
+      LOG.info("Write PipelineId: {}",
+          container.getContainerInfo().getPipelineID().getId());
       LOG.info("Container State: {}", container.getContainerInfo().getState());
 
       // Print pipeline of an existing container.
@@ -181,6 +183,11 @@ public class InfoSubcommand extends ScmSubcommand {
     public List<ContainerReplicaInfo> getReplicas() {
       return replicas;
     }
+
+    public PipelineID getWritePipelineID() {
+      return writePipelineID;
+    }
+
   }
 
   private static class ContainerWithoutDatanodes {
@@ -208,6 +215,10 @@ public class InfoSubcommand extends ScmSubcommand {
 
     public List<ContainerReplicaInfo> getReplicas() {
       return replicas;
+    }
+
+    public PipelineID getWritePipelineId() {
+      return writePipelineId;
     }
   }
 

--- a/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/container/InfoSubcommand.java
+++ b/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/container/InfoSubcommand.java
@@ -41,7 +41,6 @@ import org.apache.hadoop.hdds.scm.container.common.helpers
 import com.google.common.base.Preconditions;
 import org.apache.hadoop.hdds.scm.pipeline.Pipeline;
 import org.apache.hadoop.hdds.scm.pipeline.PipelineID;
-import org.apache.hadoop.hdds.scm.pipeline.PipelineNotFoundException;
 import org.apache.hadoop.hdds.server.JsonUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -108,14 +107,7 @@ public class InfoSubcommand extends ScmSubcommand {
           && spec.root().userObject() instanceof GenericParentCommand
           && ((GenericParentCommand) spec.root().userObject()).isVerbose();
       if (verbose) {
-        Pipeline pipeline = null;
-        try {
-          pipeline = scmClient.getPipeline(
-              container.getContainerInfo().getPipelineID().getProtobuf());
-        } catch (PipelineNotFoundException pnfe) {
-          // Pipeline not found.
-        }
-        LOG.info("Pipeline Info: {}", pipeline == null ? "Pipeline Not Found" : pipeline.getId());
+        LOG.info("Pipeline Info: {}", container.getPipeline());
       } else {
         LOG.info("Pipeline id: {}",
             container.getContainerInfo().getPipelineID());

--- a/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/container/InfoSubcommand.java
+++ b/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/container/InfoSubcommand.java
@@ -109,8 +109,7 @@ public class InfoSubcommand extends ScmSubcommand {
       if (verbose) {
         LOG.info("Pipeline Info: {}", container.getPipeline());
       } else {
-        LOG.info("Pipeline id: {}",
-            container.getContainerInfo().getPipelineID());
+        LOG.info("Pipeline id: {}", container.getPipeline().getId().getId());
       }
       LOG.info("Write PipelineId: {}",
           container.getContainerInfo().getPipelineID().getId());

--- a/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/container/InfoSubcommand.java
+++ b/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/container/InfoSubcommand.java
@@ -39,8 +39,10 @@ import org.apache.hadoop.hdds.scm.container.common.helpers
     .ContainerWithPipeline;
 
 import com.google.common.base.Preconditions;
+import org.apache.hadoop.hdds.scm.ha.SCMHAUtils;
 import org.apache.hadoop.hdds.scm.pipeline.Pipeline;
 import org.apache.hadoop.hdds.scm.pipeline.PipelineID;
+import org.apache.hadoop.hdds.scm.pipeline.PipelineNotFoundException;
 import org.apache.hadoop.hdds.server.JsonUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -119,7 +121,12 @@ public class InfoSubcommand extends ScmSubcommand {
             .getPipelineState().toString();
         LOG.info("Write Pipeline State: {}", pipelineState);
       } catch (IOException ioe) {
-        LOG.info("Write Pipeline State: CLOSED");
+        if (SCMHAUtils.unwrapException(
+            ioe) instanceof PipelineNotFoundException) {
+          LOG.info("Write Pipeline State: CLOSED");
+        } else {
+          LOG.error("Failed to retrieve pipeline info");
+        }
       }
       LOG.info("Container State: {}", container.getContainerInfo().getState());
 

--- a/hadoop-hdds/tools/src/test/java/org/apache/hadoop/hdds/scm/cli/container/TestInfoSubCommand.java
+++ b/hadoop-hdds/tools/src/test/java/org/apache/hadoop/hdds/scm/cli/container/TestInfoSubCommand.java
@@ -27,6 +27,7 @@ import org.apache.hadoop.hdds.scm.container.ContainerReplicaInfo;
 import org.apache.hadoop.hdds.scm.container.common.helpers.ContainerWithPipeline;
 import org.apache.hadoop.hdds.scm.pipeline.Pipeline;
 import org.apache.hadoop.hdds.scm.pipeline.PipelineID;
+import org.apache.hadoop.hdds.scm.pipeline.PipelineNotFoundException;
 import org.apache.log4j.AppenderSkeleton;
 import org.apache.log4j.Level;
 import org.apache.log4j.Logger;
@@ -97,7 +98,7 @@ public class TestInfoSubCommand {
     Mockito.when(scmClient.getContainerReplicas(anyLong()))
         .thenReturn(getReplicas(includeIndex));
     Mockito.when(scmClient.getPipeline(any()))
-        .thenThrow(new IOException("Pipeline not found."));
+        .thenThrow(new PipelineNotFoundException("Pipeline not found."));
     cmd = new InfoSubcommand();
     CommandLine c = new CommandLine(cmd);
     c.parseArgs("1");
@@ -139,7 +140,7 @@ public class TestInfoSubCommand {
     Mockito.when(scmClient.getContainerReplicas(anyLong()))
         .thenThrow(new IOException("Error getting Replicas"));
     Mockito.when(scmClient.getPipeline(any()))
-        .thenThrow(new IOException("Pipeline not found."));
+        .thenThrow(new PipelineNotFoundException("Pipeline not found."));
     cmd = new InfoSubcommand();
     CommandLine c = new CommandLine(cmd);
     c.parseArgs("1");

--- a/hadoop-hdds/tools/src/test/java/org/apache/hadoop/hdds/scm/cli/container/TestInfoSubCommand.java
+++ b/hadoop-hdds/tools/src/test/java/org/apache/hadoop/hdds/scm/cli/container/TestInfoSubCommand.java
@@ -49,6 +49,7 @@ import java.util.stream.Collectors;
 import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.LifeCycleState.CLOSED;
 import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationFactor.THREE;
 import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 
 /**
@@ -95,6 +96,8 @@ public class TestInfoSubCommand {
       throws IOException {
     Mockito.when(scmClient.getContainerReplicas(anyLong()))
         .thenReturn(getReplicas(includeIndex));
+    Mockito.when(scmClient.getPipeline(any()))
+        .thenThrow(new IOException("Pipeline not found."));
     cmd = new InfoSubcommand();
     CommandLine c = new CommandLine(cmd);
     c.parseArgs("1");
@@ -135,6 +138,8 @@ public class TestInfoSubCommand {
   public void testReplicasNotOutputIfError() throws IOException {
     Mockito.when(scmClient.getContainerReplicas(anyLong()))
         .thenThrow(new IOException("Error getting Replicas"));
+    Mockito.when(scmClient.getPipeline(any()))
+        .thenThrow(new IOException("Pipeline not found."));
     cmd = new InfoSubcommand();
     CommandLine c = new CommandLine(cmd);
     c.parseArgs("1");


### PR DESCRIPTION
## What changes were proposed in this pull request?

For closed containers, the pipeline ID keeps on changing on every request, it's randomly generating everytime we execute the container info command. To address this issue we directly fetch the pipeline ID from scm client via container info and display it in the implementation of container info command instead of displaying the random pipeline ID assigned during the creation of pipeline when container are closed.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-9544

## How was this patch tested?

Tested Manually.
Output:
When the container is open,

``` bash
[root@ozone-ozone-1 ~]# ozone admin container info 2003
Container id: 2003
Pipeline id: 063c7d82-dba0-4cf6-95ed-b40fa84196fa
Write PipelineId: 063c7d82-dba0-4cf6-95ed-b40fa84196fa
Write Pipeline State: OPEN
Container State: OPEN
Datanodes: [d57cfdd8-a285-488b-a0ec-7f3477c6bc16/ozone-ozone-1.ozone-ozone.root.hwx.site,
e2da4dbf-fc09-4576-b86c-3bab72d1cfee/ozone-ozone-4.ozone-ozone.root.hwx.site,
dbb43785-b23d-4932-9667-4004bfb8fc2e/ozone-ozone-3.ozone-ozone.root.hwx.site]
Replicas: [State: OPEN; ReplicaIndex: 0; Origin: e2da4dbf-fc09-4576-b86c-3bab72d1cfee; Location: e2da4dbf-fc09-4576-b86c-3bab72d1cfee/ozone-ozone-4.ozone-ozone.root.hwx.site,
State: OPEN; ReplicaIndex: 0; Origin: dbb43785-b23d-4932-9667-4004bfb8fc2e; Location: dbb43785-b23d-4932-9667-4004bfb8fc2e/ozone-ozone-3.ozone-ozone.root.hwx.site,
State: OPEN; ReplicaIndex: 0; Origin: d57cfdd8-a285-488b-a0ec-7f3477c6bc16; Location: d57cfdd8-a285-488b-a0ec-7f3477c6bc16/ozone-ozone-1.ozone-ozone.root.hwx.site]
```

``` bash
[root@ozone-ozone-1 ~]# ozone admin container info 2003
Container id: 2003
Pipeline id: fcb22631-aa1d-4d0b-b15b-58ce6965ea48
Write PipelineId: 063c7d82-dba0-4cf6-95ed-b40fa84196fa
Write Pipeline State: CLOSED
Container State: CLOSING
Datanodes: [e2da4dbf-fc09-4576-b86c-3bab72d1cfee/ozone-ozone-4.ozone-ozone.root.hwx.site,
dbb43785-b23d-4932-9667-4004bfb8fc2e/ozone-ozone-3.ozone-ozone.root.hwx.site,
d57cfdd8-a285-488b-a0ec-7f3477c6bc16/ozone-ozone-1.ozone-ozone.root.hwx.site]
Replicas: [State: OPEN; ReplicaIndex: 0; Origin: e2da4dbf-fc09-4576-b86c-3bab72d1cfee; Location: e2da4dbf-fc09-4576-b86c-3bab72d1cfee/ozone-ozone-4.ozone-ozone.root.hwx.site,
State: OPEN; ReplicaIndex: 0; Origin: dbb43785-b23d-4932-9667-4004bfb8fc2e; Location: dbb43785-b23d-4932-9667-4004bfb8fc2e/ozone-ozone-3.ozone-ozone.root.hwx.site,
State: OPEN; ReplicaIndex: 0; Origin: d57cfdd8-a285-488b-a0ec-7f3477c6bc16; Location: d57cfdd8-a285-488b-a0ec-7f3477c6bc16/ozone-ozone-1.ozone-ozone.root.hwx.site]
```

