### PR TITLE
HDDS-9625. Enable multipart upload cleanup service by default

### DIFF
--- a/hadoop-hdds/common/src/main/resources/ozone-default.xml
+++ b/hadoop-hdds/common/src/main/resources/ozone-default.xml
@@ -1430,7 +1430,7 @@
 
   <property>
     <name>ozone.om.open.mpu.parts.cleanup.limit.per.task</name>
-    <value>0</value>
+    <value>1000</value>
     <tag>OZONE, OM, PERFORMANCE</tag>
     <description>
       The maximum number of parts, rounded up to the nearest

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/OMConfigKeys.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/OMConfigKeys.java
@@ -160,7 +160,7 @@ public final class OMConfigKeys {
   public static final String OZONE_OM_MPU_PARTS_CLEANUP_LIMIT_PER_TASK =
       "ozone.om.open.mpu.parts.cleanup.limit.per.task";
   public static final int OZONE_OM_MPU_PARTS_CLEANUP_LIMIT_PER_TASK_DEFAULT =
-      0;
+      1000;
 
   public static final String OZONE_OM_METRICS_SAVE_INTERVAL =
       "ozone.om.save.metrics.interval";


### PR DESCRIPTION
## What changes were proposed in this pull request?

Enable multipart upload cleanup service by default by setting `ozone.om.open.mpu.parts.cleanup.limit.per.task` to 1000.

Set to the same value as open key clean up service. 

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-9625

## How was this patch tested?

Only configuration change. Unit tests already enable the clean up service.
