### PR TITLE
HDDS-9599. Recon : Highlight the search icon on the containers page of Recon UI

### DIFF
--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/utils/columnSearch.tsx
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/utils/columnSearch.tsx
@@ -67,7 +67,7 @@ class ColumnSearch extends React.PureComponent {
       </div>
     ),
     filterIcon: (filtered: boolean) => (
-      <Icon type='search' style={{color: filtered ? '#1890ff' : undefined}}/>
+      <Icon type='search' style={{color: filtered ? '#1890ff' : '#000000'}}/>
     ),
     onFilter: (value: string, record: any) => {
       if (record[dataIndex] !== undefined || record[dataIndex] !== null) {


### PR DESCRIPTION
## What changes were proposed in this pull request?
Need to Highlight Search Functionality Icon across all pages so it will be helpful in debugging.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-9599

## How was this patch tested?
Manually
Before this PR
![image](https://github.com/apache/ozone/assets/112169209/c4bd8a59-3c0c-4cbd-855d-d1c3fe187ef2)


After this PR Change
![image](https://github.com/apache/ozone/assets/112169209/581f7b99-1144-45c8-b266-cb50a9a4e4fe)
