### PR TITLE
HDDS-9628. Link in OzoneConfigKeys javadoc from DFS_CONTAINER_IPC_RANDOM_PORT to DFS_CONTAINER_IPC_PORT

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/OzoneConfigKeys.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/OzoneConfigKeys.java
@@ -55,8 +55,9 @@ public final class OzoneConfigKeys {
    * When set to true, allocate a random free port for ozone container,
    * so that a mini cluster is able to launch multiple containers on a node.
    *
-   * When set to false (default), container port is fixed as specified by
-   * DFS_CONTAINER_IPC_PORT_DEFAULT.
+   * When set to false (default), the container port will be specified as
+   * {@link #DFS_CONTAINER_IPC_PORT} and the default value will be specified
+   * as {@link #DFS_CONTAINER_IPC_PORT_DEFAULT}.
    */
   public static final String DFS_CONTAINER_IPC_RANDOM_PORT =
       "dfs.container.ipc.random.port";


### PR DESCRIPTION
## What changes were proposed in this pull request?
There are some irregular document descriptions in OzoneConfigKeys, one of which is the description of DFS_CONTAINER_IPC_PORT_DEFAULT. The purpose of this PR is to improve some documentation.
Also, there is one description here that needs to be updated.
When set to false (default), the container port will be specified as {@link #DFS_CONTAINER_IPC_PORT} and the default value will be specified as {@link #DFS_CONTAINER_IPC_PORT_DEFAULT}.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-9628

## How was this patch tested?
This PR is mainly related to documentation and does not require too much testing.
