### PR TITLE
HDDS-9630. Add missing javadoc description for ECReplicationConfig constructor param

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/client/ECReplicationConfig.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/client/ECReplicationConfig.java
@@ -89,7 +89,8 @@ public class ECReplicationConfig implements ReplicationConfig {
    *     XOR-10-4-4096K
    * IllegalArgumentException will be thrown if the passed string does not
    * match the defined pattern.
-   * @param string
+   * @param string Parameters used to create ECReplicationConfig instances.
+   *       Format: &lt;codec&gt;-&lt;data&gt;-&lt;parity&gt;-&lt;chunksize&gt;
    */
   public ECReplicationConfig(String string) {
     final Matcher matcher = STRING_FORMAT.matcher(string);


### PR DESCRIPTION
## What changes were proposed in this pull request?
There is some missing documentation and comments in ECReplicationConfig, the purpose of this PR is to improve here.
Details: HDDS-9630

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-9630

## How was this patch tested?
This PR is mainly related to documentation and does not require too much testing.