### PR TITLE
HDDS-9584. Make native build thread count configurable

### DIFF
--- a/hadoop-hdds/rocks-native/pom.xml
+++ b/hadoop-hdds/rocks-native/pom.xml
@@ -72,16 +72,12 @@
 
     <profiles>
         <profile>
-            <id>rocks_tools_native</id>
+            <id>cpu-count</id>
             <activation>
                 <property>
-                    <name>rocks_tools_native</name>
+                    <name>!system.numCores</name>
                 </property>
             </activation>
-            <properties>
-                <cmake.standards>20</cmake.standards>
-                <sstDump.include>true</sstDump.include>
-            </properties>
             <build>
                 <plugins>
                     <plugin>
@@ -100,6 +96,22 @@
                             </execution>
                         </executions>
                     </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>rocks_tools_native</id>
+            <activation>
+                <property>
+                    <name>rocks_tools_native</name>
+                </property>
+            </activation>
+            <properties>
+                <cmake.standards>20</cmake.standards>
+                <sstDump.include>true</sstDump.include>
+            </properties>
+            <build>
+                <plugins>
                     <plugin>
                         <groupId>com.googlecode.maven-download-plugin</groupId>
                         <artifactId>download-maven-plugin</artifactId>


### PR DESCRIPTION
## What changes were proposed in this pull request?
Make native build thread count configurable. Build should set system.numCores property to the cpu count of the build machine if the property is not passed by the user during the maven build.
E.g. mvn -X clean install -DskipTests -pl :hdds-rocks-native -Drocks_tools_native -Dsystem.numCores=5

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-9584

## How was this patch tested?
Native build succeeded in local.
