### PR TITLE
HDDS-9609. Recon doesn't display 'Last Heartbeat' for datanodes

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/protocol/StorageContainerNodeProtocol.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/protocol/StorageContainerNodeProtocol.java
@@ -67,6 +67,10 @@ public interface StorageContainerNodeProtocol {
 
   /**
    * Send heartbeat to indicate the datanode is alive and doing well.
+   *
+   * This method is currently used only in tests.
+   * TODO: Cleanup and update tests, HDDS-9642.
+   *
    * @param datanodeDetails - Datanode ID.
    * @param layoutVersionInfo - Layout Version Proto.
    * @return Commands to be sent to the datanode.

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/scm/ReconNodeManager.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/scm/ReconNodeManager.java
@@ -29,6 +29,7 @@ import java.util.UUID;
 import com.google.common.annotations.VisibleForTesting;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
+import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.CommandQueueReportProto;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.LayoutVersionProto;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.NodeReportProto;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.PipelineReportsProto;
@@ -224,7 +225,7 @@ public class ReconNodeManager extends SCMNodeManager {
    */
   @Override
   public List<SCMCommand> processHeartbeat(DatanodeDetails datanodeDetails,
-                                           LayoutVersionProto layoutInfo) {
+      LayoutVersionProto layoutInfo, CommandQueueReportProto queueReport) {
     List<SCMCommand> cmds = new ArrayList<>();
     long currentTime = Time.now();
     if (needUpdate(datanodeDetails, currentTime)) {
@@ -236,7 +237,8 @@ public class ReconNodeManager extends SCMNodeManager {
     }
     // Update heartbeat map with current time
     datanodeHeartbeatMap.put(datanodeDetails.getUuid(), Time.now());
-    cmds.addAll(super.processHeartbeat(datanodeDetails, layoutInfo));
+    cmds.addAll(super.processHeartbeat(datanodeDetails,
+        layoutInfo, queueReport));
     return cmds.stream()
         .filter(c -> ALLOWED_COMMANDS.contains(c.getType()))
         .collect(toList());


### PR DESCRIPTION
## What changes were proposed in this pull request?

`Last Heartbeat` in the Datanodes section in Recon's UI, is always showing NA because the `datanodeHeartbeatMap` in `ReconNodeManager` doesn't get updated. 

PR #4341, modified the `processHeartbeat()` method to also process the queue report as part of the heartbeat, by adding a `CommandQueueReport` parameter.

[SCMDatanodeHeartbeatDispatcher.dispatch()](https://github.com/apache/ozone/blob/master/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMDatanodeHeartbeatDispatcher.java#L133-L134) is the only place where `processHeartbeat()` is used but it's only calling the overloaded method with the 3 parameters. Recon overrides the 2 parameter method and as a result, Recon's `processHeartbeat()` never gets called. 

The 2 parameter method is only used in tests and for that reason it has been cleaned up as part of this patch. This change is made as a second commit so that it can be easily reverted.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-9609

## How was this patch tested?

All existing tests were updated and are still passing. 

Green CIs on my fork: 
- https://github.com/xBis7/ozone/actions/runs/6769734433
- https://github.com/xBis7/ozone/actions/runs/6770026351

This patch was also tested manually and values are updating as expected. Check attached screenshots.

<img width="2041" alt="Screenshot 2023-11-06 at 16 32 13" src="https://github.com/apache/ozone/assets/74301312/149e2163-0006-4605-a27e-5ee3bf0e719f">

<img width="2044" alt="Screenshot 2023-11-06 at 16 33 34" src="https://github.com/apache/ozone/assets/74301312/8bf80a9a-edf0-4dce-8dcb-dd899cf0bead">