### PR TITLE
HDDS-9641. Parallel loading datanode volume db store

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/utils/HddsVolumeUtil.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/utils/HddsVolumeUtil.java
@@ -29,9 +29,11 @@ import org.slf4j.Logger;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.CompletableFuture;
 
 import static org.apache.hadoop.ozone.container.common.utils.StorageVolumeUtil.onFailure;
 
@@ -86,17 +88,29 @@ public final class HddsVolumeUtil {
     // between each HddsVolume -> DbVolume.
     mapDbVolumesToDataVolumesIfNeeded(hddsVolumeSet, dbVolumeSet);
 
-    for (HddsVolume volume : StorageVolumeUtil.getHddsVolumesList(
-        hddsVolumeSet.getVolumesList())) {
-      try {
-        volume.loadDbStore(readOnly);
-      } catch (IOException e) {
-        onFailure(volume);
-        if (logger != null) {
-          logger.error("Load db store for HddsVolume {} failed",
-              volume.getStorageDir().getAbsolutePath(), e);
+    List<CompletableFuture<Void>> futures = new ArrayList<>();
+    List<HddsVolume> hddsVolumes = StorageVolumeUtil.getHddsVolumesList(
+        hddsVolumeSet.getVolumesList());
+    long start = System.currentTimeMillis();
+    for (HddsVolume volume : hddsVolumes) {
+      futures.add(CompletableFuture.runAsync(() -> {
+        try {
+          volume.loadDbStore(readOnly);
+        } catch (IOException e) {
+          onFailure(volume);
+          if (logger != null) {
+            logger.error("Load db store for HddsVolume {} failed",
+                volume.getStorageDir().getAbsolutePath(), e);
+          }
         }
-      }
+      }));
+    }
+    for (CompletableFuture<Void> future : futures) {
+      future.join();
+    }
+    if (logger != null) {
+      logger.info("Load {} volumes DbStore cost: {}ms", hddsVolumes.size(),
+          System.currentTimeMillis() - start);
     }
   }
 

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/utils/HddsVolumeUtil.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/utils/HddsVolumeUtil.java
@@ -93,17 +93,8 @@ public final class HddsVolumeUtil {
         hddsVolumeSet.getVolumesList());
     long start = System.currentTimeMillis();
     for (HddsVolume volume : hddsVolumes) {
-      futures.add(CompletableFuture.runAsync(() -> {
-        try {
-          volume.loadDbStore(readOnly);
-        } catch (IOException e) {
-          onFailure(volume);
-          if (logger != null) {
-            logger.error("Load db store for HddsVolume {} failed",
-                volume.getStorageDir().getAbsolutePath(), e);
-          }
-        }
-      }));
+      futures.add(CompletableFuture.runAsync(
+          () -> loadVolume(volume, readOnly, logger)));
     }
     for (CompletableFuture<Void> future : futures) {
       future.join();
@@ -111,6 +102,19 @@ public final class HddsVolumeUtil {
     if (logger != null) {
       logger.info("Load {} volumes DbStore cost: {}ms", hddsVolumes.size(),
           System.currentTimeMillis() - start);
+    }
+  }
+
+  private static void loadVolume(HddsVolume volume, boolean readOnly,
+      Logger logger) {
+    try {
+      volume.loadDbStore(readOnly);
+    } catch (IOException e) {
+      onFailure(volume);
+      if (logger != null) {
+        logger.error("Load db store for HddsVolume {} failed",
+            volume.getStorageDir().getAbsolutePath(), e);
+      }
     }
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Currently the rocksdb that loads schema v3 uses sequential loading and is slow to load, the purpose of this PR is to speed up the loading of the rocksdb using parallel loading.

This is my test data:
1. datanode 35 disks * 8TB Wrote about 50% of the capacity
2. after restarting the datanode, it took 5 minutes to load the checksdb.

After using this feature:

```
2023-11-07 16:25:06,699 [main] INFO org.apache.hadoop.ozone.container.ozoneimpl.OzoneContainer: Load 35 volumes DbStore cost: 1532ms 
```



## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-9641
