### PR TITLE
HDDS-9498. Migrate tests with TemporaryFolder in ozone-recon to JUnit5

### DIFF
--- a/hadoop-ozone/recon/pom.xml
+++ b/hadoop-ozone/recon/pom.xml
@@ -306,6 +306,11 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-params</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
       <scope>test</scope>

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/api/TestBlocksEndPoint.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/api/TestBlocksEndPoint.java
@@ -37,14 +37,15 @@ import org.apache.hadoop.ozone.recon.scm.ReconStorageContainerManagerFacade;
 import org.apache.hadoop.ozone.recon.spi.StorageContainerServiceProvider;
 import org.apache.hadoop.ozone.recon.spi.impl.OzoneManagerServiceProviderImpl;
 import org.apache.hadoop.ozone.recon.spi.impl.StorageContainerServiceProviderImpl;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Assertions;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.io.TempDir;
 
 import javax.ws.rs.core.Response;
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -62,8 +63,8 @@ import static org.mockito.Mockito.mock;
  */
 public class TestBlocksEndPoint {
 
-  @Rule
-  public TemporaryFolder temporaryFolder = new TemporaryFolder();
+  @TempDir
+  public Path temporaryFolder;
 
   private ReconStorageContainerManagerFacade reconStorageContainerManager;
   private ReconContainerManager reconContainerManager;
@@ -75,11 +76,12 @@ public class TestBlocksEndPoint {
 
   private void initializeInjector() throws Exception {
     reconOMMetadataManager = getTestReconOmMetadataManager(
-        initializeNewOmMetadataManager(temporaryFolder.newFolder()),
-        temporaryFolder.newFolder());
+        initializeNewOmMetadataManager(Files.createDirectory(
+            temporaryFolder.resolve("JunitOmDBDir")).toFile()),
+        Files.createDirectory(temporaryFolder.resolve("NewDir")).toFile());
 
     ReconTestInjector reconTestInjector =
-        new ReconTestInjector.Builder(temporaryFolder)
+        new ReconTestInjector.Builder(temporaryFolder.toFile())
             .withReconSqlDb()
             .withReconOm(reconOMMetadataManager)
             .withOmServiceProvider(mock(OzoneManagerServiceProviderImpl.class))
@@ -105,7 +107,7 @@ public class TestBlocksEndPoint {
     scmDBStore = reconStorageContainerManager.getScmDBStore();
   }
 
-  @Before
+  @BeforeEach
   public void setUp() throws Exception {
     // The following setup runs only once
     if (!isSetupDone) {

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/api/TestBlocksEndPoint.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/api/TestBlocksEndPoint.java
@@ -64,7 +64,7 @@ import static org.mockito.Mockito.mock;
 public class TestBlocksEndPoint {
 
   @TempDir
-  public Path temporaryFolder;
+  private Path temporaryFolder;
 
   private ReconStorageContainerManagerFacade reconStorageContainerManager;
   private ReconContainerManager reconContainerManager;

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/api/TestContainerEndpoint.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/api/TestContainerEndpoint.java
@@ -115,7 +115,7 @@ import static org.mockito.Mockito.when;
 public class TestContainerEndpoint {
 
   @TempDir
-  public Path temporaryFolder;
+  private Path temporaryFolder;
 
   private static final Logger LOG =
       LoggerFactory.getLogger(TestContainerEndpoint.class);

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/api/TestContainerEndpoint.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/api/TestContainerEndpoint.java
@@ -68,18 +68,18 @@ import org.apache.hadoop.ozone.recon.spi.impl.StorageContainerServiceProviderImp
 import org.apache.hadoop.ozone.recon.tasks.ContainerKeyMapperTask;
 import org.hadoop.ozone.recon.schema.ContainerSchemaDefinition.UnHealthyContainerStates;
 import org.hadoop.ozone.recon.schema.tables.pojos.UnhealthyContainers;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.api.Assertions;
-import org.junit.rules.TemporaryFolder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.Response;
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -100,12 +100,12 @@ import static org.apache.hadoop.ozone.recon.OMMetadataManagerTestUtils.getTestRe
 import static org.apache.hadoop.ozone.recon.OMMetadataManagerTestUtils.initializeNewOmMetadataManager;
 import static org.apache.hadoop.ozone.recon.OMMetadataManagerTestUtils.writeDataToOm;
 import static org.apache.hadoop.ozone.recon.OMMetadataManagerTestUtils.writeKeyToOm;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
-import static org.junit.Assert.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -114,8 +114,8 @@ import static org.mockito.Mockito.when;
  */
 public class TestContainerEndpoint {
 
-  @Rule
-  public TemporaryFolder temporaryFolder = new TemporaryFolder();
+  @TempDir
+  public Path temporaryFolder;
 
   private static final Logger LOG =
       LoggerFactory.getLogger(TestContainerEndpoint.class);
@@ -167,11 +167,12 @@ public class TestContainerEndpoint {
 
   private void initializeInjector() throws Exception {
     reconOMMetadataManager = getTestReconOmMetadataManager(
-        initializeNewOmMetadataManager(temporaryFolder.newFolder()),
-        temporaryFolder.newFolder());
+        initializeNewOmMetadataManager(Files.createDirectory(
+            temporaryFolder.resolve("JunitOmDBDir")).toFile()),
+        Files.createDirectory(temporaryFolder.resolve("NewDir")).toFile());
 
     ReconTestInjector reconTestInjector =
-        new ReconTestInjector.Builder(temporaryFolder)
+        new ReconTestInjector.Builder(temporaryFolder.toFile())
             .withReconSqlDb()
             .withReconOm(reconOMMetadataManager)
             .withOmServiceProvider(mock(OzoneManagerServiceProviderImpl.class))
@@ -205,7 +206,7 @@ public class TestContainerEndpoint {
         .getContainerStateManager();
   }
 
-  @Before
+  @BeforeEach
   public void setUp() throws Exception {
     // The following setup runs only once
     if (!isSetupDone) {
@@ -759,7 +760,7 @@ public class TestContainerEndpoint {
         new HashSet<>(Arrays.asList("host2", "host3", "host4")));
     List<ContainerHistory> containerReplicas = container.getReplicas();
     containerReplicas.forEach(history -> {
-      Assert.assertTrue(datanodes.contains(history.getDatanodeHost()));
+      Assertions.assertTrue(datanodes.contains(history.getDatanodeHost()));
     });
   }
 
@@ -838,7 +839,7 @@ public class TestContainerEndpoint {
         new HashSet<>(Arrays.asList("host2", "host3", "host4")));
     List<ContainerHistory> containerReplicas = missing.get(0).getReplicas();
     containerReplicas.forEach(history -> {
-      Assert.assertTrue(datanodes.contains(history.getDatanodeHost()));
+      assertTrue(datanodes.contains(history.getDatanodeHost()));
     });
 
     List<UnhealthyContainerMetadata> overRep = records
@@ -997,23 +998,23 @@ public class TestContainerEndpoint {
     Set<String> datanodes = Collections.unmodifiableSet(
         new HashSet<>(Arrays.asList(
             u1.toString(), u2.toString(), u3.toString(), u4.toString())));
-    Assert.assertEquals(4, histories.size());
+    assertEquals(4, histories.size());
     histories.forEach(history -> {
-      Assert.assertTrue(datanodes.contains(history.getDatanodeUuid()));
+      assertTrue(datanodes.contains(history.getDatanodeUuid()));
       if (history.getDatanodeUuid().equals(u1.toString())) {
-        Assert.assertEquals("host1", history.getDatanodeHost());
-        Assert.assertEquals(1L, history.getFirstSeenTime());
-        Assert.assertEquals(5L, history.getLastSeenTime());
+        assertEquals("host1", history.getDatanodeHost());
+        assertEquals(1L, history.getFirstSeenTime());
+        assertEquals(5L, history.getLastSeenTime());
       }
     });
 
     // Check getLatestContainerHistory
     List<ContainerHistory> hist1 = reconContainerManager
         .getLatestContainerHistory(1L, 10);
-    Assert.assertTrue(hist1.size() <= 10);
+    assertTrue(hist1.size() <= 10);
     // Descending order by last report timestamp
     for (int i = 0; i < hist1.size() - 1; i++) {
-      Assert.assertTrue(hist1.get(i).getLastSeenTime()
+      assertTrue(hist1.get(i).getLastSeenTime()
           >= hist1.get(i + 1).getLastSeenTime());
     }
   }
@@ -1513,14 +1514,14 @@ public class TestContainerEndpoint {
             HddsProtos.LifeCycleEvent.DELETE);
     Set<ContainerID> containerIDs = containerStateManager
         .getContainerIDs(HddsProtos.LifeCycleState.DELETING);
-    Assert.assertEquals(1, containerIDs.size());
+    assertEquals(1, containerIDs.size());
 
     reconContainerManager
         .updateContainerState(ContainerID.valueOf(1),
             HddsProtos.LifeCycleEvent.CLEANUP);
     containerIDs = containerStateManager
         .getContainerIDs(HddsProtos.LifeCycleState.DELETED);
-    Assert.assertEquals(1, containerIDs.size());
+    assertEquals(1, containerIDs.size());
 
     List<ContainerInfo> deletedSCMContainers =
         reconContainerManager.getContainers(HddsProtos.LifeCycleState.DELETED);
@@ -1562,7 +1563,7 @@ public class TestContainerEndpoint {
 
     Set<ContainerID> containerIDs = containerStateManager
         .getContainerIDs(HddsProtos.LifeCycleState.DELETED);
-    Assert.assertEquals(1, containerIDs.size());
+    assertEquals(1, containerIDs.size());
 
     List<ContainerInfo> deletedSCMContainers =
         reconContainerManager.getContainers(HddsProtos.LifeCycleState.DELETED);
@@ -1606,7 +1607,7 @@ public class TestContainerEndpoint {
 
     Set<ContainerID> containerIDs = containerStateManager
         .getContainerIDs(HddsProtos.LifeCycleState.DELETED);
-    Assert.assertEquals(2, containerIDs.size());
+    assertEquals(2, containerIDs.size());
 
     List<ContainerInfo> deletedSCMContainers =
         reconContainerManager.getContainers(HddsProtos.LifeCycleState.DELETED);

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/api/TestContainerEndpoint.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/api/TestContainerEndpoint.java
@@ -71,7 +71,6 @@ import org.hadoop.ozone.recon.schema.tables.pojos.UnhealthyContainers;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
-import org.junit.jupiter.api.Assertions;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -760,7 +759,7 @@ public class TestContainerEndpoint {
         new HashSet<>(Arrays.asList("host2", "host3", "host4")));
     List<ContainerHistory> containerReplicas = container.getReplicas();
     containerReplicas.forEach(history -> {
-      Assertions.assertTrue(datanodes.contains(history.getDatanodeHost()));
+      assertTrue(datanodes.contains(history.getDatanodeHost()));
     });
   }
 
@@ -1117,7 +1116,7 @@ public class TestContainerEndpoint {
             HddsProtos.LifeCycleEvent.CLEANUP);
     Set<ContainerID> containerIDs = containerStateManager
         .getContainerIDs(HddsProtos.LifeCycleState.DELETED);
-    Assertions.assertEquals(1, containerIDs.size());
+    assertEquals(1, containerIDs.size());
 
     reconContainerManager.updateContainerState(ContainerID.valueOf(103L),
         HddsProtos.LifeCycleEvent.FINALIZE);
@@ -1133,23 +1132,21 @@ public class TestContainerEndpoint {
             HddsProtos.LifeCycleEvent.CLEANUP);
     containerIDs = containerStateManager
         .getContainerIDs(HddsProtos.LifeCycleState.DELETED);
-    Assertions.assertEquals(2, containerIDs.size());
+    assertEquals(2, containerIDs.size());
 
     Response scmDeletedContainers =
         containerEndpoint.getSCMDeletedContainers(2, 0);
     List<DeletedContainerInfo> deletedContainerInfoList =
         (List<DeletedContainerInfo>) scmDeletedContainers.getEntity();
-    Assertions.assertEquals(2, deletedContainerInfoList.size());
+    assertEquals(2, deletedContainerInfoList.size());
 
     DeletedContainerInfo deletedContainerInfo = deletedContainerInfoList.get(0);
-    Assertions.assertEquals(102, deletedContainerInfo.getContainerID());
-    Assertions.assertEquals("DELETED",
-        deletedContainerInfo.getContainerState());
+    assertEquals(102, deletedContainerInfo.getContainerID());
+    assertEquals("DELETED", deletedContainerInfo.getContainerState());
 
     deletedContainerInfo = deletedContainerInfoList.get(1);
-    Assertions.assertEquals(103, deletedContainerInfo.getContainerID());
-    Assertions.assertEquals("DELETED",
-        deletedContainerInfo.getContainerState());
+    assertEquals(103, deletedContainerInfo.getContainerID());
+    assertEquals("DELETED", deletedContainerInfo.getContainerState());
   }
 
   @Test
@@ -1170,7 +1167,7 @@ public class TestContainerEndpoint {
             HddsProtos.LifeCycleEvent.CLEANUP);
     Set<ContainerID> containerIDs = containerStateManager
         .getContainerIDs(HddsProtos.LifeCycleState.DELETED);
-    Assertions.assertEquals(1, containerIDs.size());
+    assertEquals(1, containerIDs.size());
 
     reconContainerManager.updateContainerState(ContainerID.valueOf(105L),
         HddsProtos.LifeCycleEvent.FINALIZE);
@@ -1184,18 +1181,17 @@ public class TestContainerEndpoint {
             HddsProtos.LifeCycleEvent.CLEANUP);
     containerIDs = containerStateManager
         .getContainerIDs(HddsProtos.LifeCycleState.DELETED);
-    Assertions.assertEquals(2, containerIDs.size());
+    assertEquals(2, containerIDs.size());
 
     Response scmDeletedContainers =
         containerEndpoint.getSCMDeletedContainers(1, 0);
     List<DeletedContainerInfo> deletedContainerInfoList =
         (List<DeletedContainerInfo>) scmDeletedContainers.getEntity();
-    Assertions.assertEquals(1, deletedContainerInfoList.size());
+    assertEquals(1, deletedContainerInfoList.size());
 
     DeletedContainerInfo deletedContainerInfo = deletedContainerInfoList.get(0);
-    Assertions.assertEquals(104, deletedContainerInfo.getContainerID());
-    Assertions.assertEquals("DELETED",
-        deletedContainerInfo.getContainerState());
+    assertEquals(104, deletedContainerInfo.getContainerID());
+    assertEquals("DELETED", deletedContainerInfo.getContainerState());
   }
 
   @Test
@@ -1217,7 +1213,7 @@ public class TestContainerEndpoint {
             HddsProtos.LifeCycleEvent.CLEANUP);
     Set<ContainerID> containerIDs = containerStateManager
         .getContainerIDs(HddsProtos.LifeCycleState.DELETED);
-    Assertions.assertEquals(1, containerIDs.size());
+    assertEquals(1, containerIDs.size());
 
     reconContainerManager.updateContainerState(ContainerID.valueOf(107L),
         HddsProtos.LifeCycleEvent.FINALIZE);
@@ -1231,18 +1227,17 @@ public class TestContainerEndpoint {
             HddsProtos.LifeCycleEvent.CLEANUP);
     containerIDs = containerStateManager
         .getContainerIDs(HddsProtos.LifeCycleState.DELETED);
-    Assertions.assertEquals(2, containerIDs.size());
+    assertEquals(2, containerIDs.size());
 
     Response scmDeletedContainers =
         containerEndpoint.getSCMDeletedContainers(2, 106L);
     List<DeletedContainerInfo> deletedContainerInfoList =
         (List<DeletedContainerInfo>) scmDeletedContainers.getEntity();
-    Assertions.assertEquals(1, deletedContainerInfoList.size());
+    assertEquals(1, deletedContainerInfoList.size());
 
     DeletedContainerInfo deletedContainerInfo = deletedContainerInfoList.get(0);
-    Assertions.assertEquals(107, deletedContainerInfo.getContainerID());
-    Assertions.assertEquals("DELETED",
-        deletedContainerInfo.getContainerState());
+    assertEquals(107, deletedContainerInfo.getContainerID());
+    assertEquals("DELETED", deletedContainerInfo.getContainerState());
   }
 
   private void updateContainerStateToDeleted(long containerId)

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/api/TestContainerStateCounts.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/api/TestContainerStateCounts.java
@@ -44,6 +44,7 @@ import org.junit.jupiter.api.Test;
 
 import javax.ws.rs.core.Response;
 import java.io.IOException;
+import java.nio.file.Files;
 import java.util.concurrent.TimeoutException;
 
 import static org.apache.hadoop.ozone.recon.OMMetadataManagerTestUtils.getRandomPipeline;
@@ -74,10 +75,11 @@ public class TestContainerStateCounts extends AbstractReconSqlDBTest {
   @BeforeEach
   public void setUp() throws Exception {
     reconOMMetadataManager = getTestReconOmMetadataManager(
-        initializeNewOmMetadataManager(temporaryFolder.newFolder()),
-        temporaryFolder.newFolder());
+        initializeNewOmMetadataManager(Files.createDirectory(
+            temporaryFolder.resolve("JunitOmDBDir")).toFile()),
+        Files.createDirectory(temporaryFolder.resolve("NewDir")).toFile());
     ReconTestInjector reconTestInjector =
-        new ReconTestInjector.Builder(temporaryFolder)
+        new ReconTestInjector.Builder(temporaryFolder.toFile())
             .withReconSqlDb()
             .withReconOm(reconOMMetadataManager)
             .withOmServiceProvider(mock(OzoneManagerServiceProviderImpl.class))

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/api/TestContainerStateCounts.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/api/TestContainerStateCounts.java
@@ -41,10 +41,12 @@ import org.hadoop.ozone.recon.schema.tables.daos.GlobalStatsDao;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 import javax.ws.rs.core.Response;
 import java.io.IOException;
 import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.concurrent.TimeoutException;
 
 import static org.apache.hadoop.ozone.recon.OMMetadataManagerTestUtils.getRandomPipeline;
@@ -56,7 +58,8 @@ import static org.mockito.Mockito.mock;
  * Unit test for ClusterStateEndpoint ContainerStateCounts.
  */
 public class TestContainerStateCounts extends AbstractReconSqlDBTest {
-
+  @TempDir
+  private Path temporaryFolder;
   private OzoneStorageContainerManager ozoneStorageContainerManager;
   private ContainerHealthSchemaManager containerHealthSchemaManager;
   private ClusterStateEndpoint clusterStateEndpoint;

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/api/TestEndpoints.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/api/TestEndpoints.java
@@ -122,6 +122,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.net.HttpURLConnection;
 import java.net.URI;
+import java.nio.file.Files;
 import java.util.Arrays;
 import java.util.ArrayList;
 import java.util.LinkedList;
@@ -168,8 +169,9 @@ public class TestEndpoints extends AbstractReconSqlDBTest {
 
   private void initializeInjector() throws Exception {
     reconOMMetadataManager = getTestReconOmMetadataManager(
-        initializeNewOmMetadataManager(temporaryFolder.newFolder()),
-        temporaryFolder.newFolder());
+        initializeNewOmMetadataManager(Files.createDirectory(
+            temporaryFolder.resolve("JunitOmDBDir")).toFile()),
+        Files.createDirectory(temporaryFolder.resolve("NewDir")).toFile());
     datanodeDetails = randomDatanodeDetails();
     datanodeDetails2 = randomDatanodeDetails();
     datanodeDetails.setHostName(HOST1);
@@ -222,7 +224,7 @@ public class TestEndpoints extends AbstractReconSqlDBTest {
         any(OzoneConfiguration.class))).thenReturn(
         commonUtils.getReconNodeDetails());
     ReconTestInjector reconTestInjector =
-        new ReconTestInjector.Builder(temporaryFolder)
+        new ReconTestInjector.Builder(temporaryFolder.toFile())
             .withReconSqlDb()
             .withReconOm(reconOMMetadataManager)
             .withOmServiceProvider(mock(OzoneManagerServiceProviderImpl.class))

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/api/TestEndpoints.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/api/TestEndpoints.java
@@ -100,6 +100,7 @@ import org.jooq.DSLContext;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 import static org.apache.hadoop.hdds.protocol.MockDatanodeDetails.randomDatanodeDetails;
 import static org.apache.hadoop.ozone.container.upgrade.UpgradeUtils.defaultLayoutVersionProto;
@@ -134,6 +135,7 @@ import java.io.InputStream;
 import java.net.HttpURLConnection;
 import java.net.URI;
 import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.ArrayList;
 import java.util.LinkedList;
@@ -146,6 +148,8 @@ import java.util.concurrent.atomic.AtomicInteger;
  * Test for Recon API endpoints.
  */
 public class TestEndpoints extends AbstractReconSqlDBTest {
+  @TempDir
+  private Path temporaryFolder;
   private NodeEndpoint nodeEndpoint;
   private PipelineEndpoint pipelineEndpoint;
   private ClusterStateEndpoint clusterStateEndpoint;

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/api/TestFeaturesEndPoint.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/api/TestFeaturesEndPoint.java
@@ -27,14 +27,14 @@ import org.apache.hadoop.ozone.recon.scm.ReconStorageContainerManagerFacade;
 import org.apache.hadoop.ozone.recon.spi.StorageContainerServiceProvider;
 import org.apache.hadoop.ozone.recon.spi.impl.OzoneManagerServiceProviderImpl;
 import org.apache.hadoop.ozone.recon.spi.impl.StorageContainerServiceProviderImpl;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Assertions;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.io.TempDir;
 
 import javax.ws.rs.core.Response;
-
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.List;
 
 import static org.apache.hadoop.hdds.recon.ReconConfigKeys.OZONE_RECON_HEATMAP_ENABLE_KEY;
@@ -48,8 +48,8 @@ import static org.mockito.Mockito.mock;
  */
 public class TestFeaturesEndPoint {
 
-  @Rule
-  public TemporaryFolder temporaryFolder = new TemporaryFolder();
+  @TempDir
+  public Path temporaryFolder;
   private FeaturesEndpoint featuresEndPoint;
   private boolean isSetupDone = false;
   private ReconOMMetadataManager reconOMMetadataManager;
@@ -58,11 +58,12 @@ public class TestFeaturesEndPoint {
   private void initializeInjector() throws Exception {
     ozoneConfiguration = new OzoneConfiguration();
     reconOMMetadataManager = getTestReconOmMetadataManager(
-        initializeNewOmMetadataManager(temporaryFolder.newFolder()),
-        temporaryFolder.newFolder());
+        initializeNewOmMetadataManager(Files.createDirectory(
+            temporaryFolder.resolve("JunitOmDBDir")).toFile()),
+        Files.createDirectory(temporaryFolder.resolve("NewDir")).toFile());
 
     ReconTestInjector reconTestInjector =
-        new ReconTestInjector.Builder(temporaryFolder)
+        new ReconTestInjector.Builder(temporaryFolder.toFile())
             .withReconSqlDb()
             .withReconOm(reconOMMetadataManager)
             .withOmServiceProvider(mock(OzoneManagerServiceProviderImpl.class))
@@ -80,7 +81,7 @@ public class TestFeaturesEndPoint {
         FeaturesEndpoint.class);
   }
 
-  @Before
+  @BeforeEach
   public void setUp() throws Exception {
     // The following setup runs only once
     if (!isSetupDone) {

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/api/TestFeaturesEndPoint.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/api/TestFeaturesEndPoint.java
@@ -49,7 +49,7 @@ import static org.mockito.Mockito.mock;
 public class TestFeaturesEndPoint {
 
   @TempDir
-  public Path temporaryFolder;
+  private Path temporaryFolder;
   private FeaturesEndpoint featuresEndPoint;
   private boolean isSetupDone = false;
   private ReconOMMetadataManager reconOMMetadataManager;

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/api/TestNSSummaryEndpointWithFSO.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/api/TestNSSummaryEndpointWithFSO.java
@@ -57,16 +57,18 @@ import org.apache.hadoop.ozone.recon.spi.StorageContainerServiceProvider;
 import org.apache.hadoop.ozone.recon.spi.impl.OzoneManagerServiceProviderImpl;
 import org.apache.hadoop.ozone.recon.spi.impl.StorageContainerServiceProviderImpl;
 import org.apache.hadoop.ozone.recon.tasks.NSSummaryTaskWithFSO;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 
 import javax.ws.rs.core.Response;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
@@ -108,8 +110,8 @@ import static org.mockito.Mockito.when;
  * so there is no need to test process() on DB's updates
  */
 public class TestNSSummaryEndpointWithFSO {
-  @Rule
-  public TemporaryFolder temporaryFolder = new TemporaryFolder();
+  @TempDir
+  public Path temporaryFolder;
 
   private ReconOMMetadataManager reconOMMetadataManager;
   private NSSummaryEndpoint nsSummaryEndpoint;
@@ -348,20 +350,20 @@ public class TestNSSummaryEndpointWithFSO {
   private static final long DIR_ONE_DATA_SIZE = KEY_TWO_SIZE +
           KEY_THREE_SIZE + KEY_SIX_SIZE;
 
-  @Before
+  @BeforeEach
   public void setUp() throws Exception {
     ozoneConfiguration = new OzoneConfiguration();
     ozoneConfiguration.setLong(OZONE_RECON_NSSUMMARY_FLUSH_TO_DB_MAX_THRESHOLD,
         10);
     OMMetadataManager omMetadataManager = initializeNewOmMetadataManager(
-        temporaryFolder.newFolder());
+        Files.createDirectory(temporaryFolder.resolve("JunitOmDBDir")).toFile());
     OzoneManagerServiceProviderImpl ozoneManagerServiceProvider =
         getMockOzoneManagerServiceProviderWithFSO();
     reconOMMetadataManager = getTestReconOmMetadataManager(omMetadataManager,
-            temporaryFolder.newFolder());
+        Files.createDirectory(temporaryFolder.resolve("OmMetataDir")).toFile());
 
     ReconTestInjector reconTestInjector =
-            new ReconTestInjector.Builder(temporaryFolder)
+            new ReconTestInjector.Builder(temporaryFolder.toFile())
                     .withReconOm(reconOMMetadataManager)
                     .withOmServiceProvider(ozoneManagerServiceProvider)
                     .withReconSqlDb()
@@ -388,11 +390,11 @@ public class TestNSSummaryEndpointWithFSO {
   @Test
   public void testUtility() {
     String[] names = EntityHandler.parseRequestPath(TEST_PATH_UTILITY);
-    Assert.assertArrayEquals(TEST_NAMES, names);
+    assertArrayEquals(TEST_NAMES, names);
     String keyName = BucketHandler.getKeyName(names);
-    Assert.assertEquals(TEST_KEY_NAMES, keyName);
+    assertEquals(TEST_KEY_NAMES, keyName);
     String subpath = BucketHandler.buildSubpath(PARENT_DIR, "file1.txt");
-    Assert.assertEquals(TEST_PATH_UTILITY, subpath);
+    assertEquals(TEST_PATH_UTILITY, subpath);
   }
 
   @Test
@@ -448,17 +450,17 @@ public class TestNSSummaryEndpointWithFSO {
     Response rootResponse = nsSummaryEndpoint.getDiskUsage(ROOT_PATH,
         false, false);
     DUResponse duRootRes = (DUResponse) rootResponse.getEntity();
-    Assert.assertEquals(2, duRootRes.getCount());
+    assertEquals(2, duRootRes.getCount());
     List<DUResponse.DiskUsage> duRootData = duRootRes.getDuData();
     // sort based on subpath
     Collections.sort(duRootData,
         Comparator.comparing(DUResponse.DiskUsage::getSubpath));
     DUResponse.DiskUsage duVol1 = duRootData.get(0);
     DUResponse.DiskUsage duVol2 = duRootData.get(1);
-    Assert.assertEquals(VOL_PATH, duVol1.getSubpath());
-    Assert.assertEquals(VOL_TWO_PATH, duVol2.getSubpath());
-    Assert.assertEquals(VOL_DATA_SIZE, duVol1.getSize());
-    Assert.assertEquals(VOL_TWO_DATA_SIZE, duVol2.getSize());
+    assertEquals(VOL_PATH, duVol1.getSubpath());
+    assertEquals(VOL_TWO_PATH, duVol2.getSubpath());
+    assertEquals(VOL_DATA_SIZE, duVol1.getSize());
+    assertEquals(VOL_TWO_DATA_SIZE, duVol2.getSize());
   }
   @Test
   public void testDiskUsageVolume() throws Exception {
@@ -466,17 +468,17 @@ public class TestNSSummaryEndpointWithFSO {
     Response volResponse = nsSummaryEndpoint.getDiskUsage(VOL_PATH,
             false, false);
     DUResponse duVolRes = (DUResponse) volResponse.getEntity();
-    Assert.assertEquals(2, duVolRes.getCount());
+    assertEquals(2, duVolRes.getCount());
     List<DUResponse.DiskUsage> duData = duVolRes.getDuData();
     // sort based on subpath
     Collections.sort(duData,
             Comparator.comparing(DUResponse.DiskUsage::getSubpath));
     DUResponse.DiskUsage duBucket1 = duData.get(0);
     DUResponse.DiskUsage duBucket2 = duData.get(1);
-    Assert.assertEquals(BUCKET_ONE_PATH, duBucket1.getSubpath());
-    Assert.assertEquals(BUCKET_TWO_PATH, duBucket2.getSubpath());
-    Assert.assertEquals(BUCKET_ONE_DATA_SIZE, duBucket1.getSize());
-    Assert.assertEquals(BUCKET_TWO_DATA_SIZE, duBucket2.getSize());
+    assertEquals(BUCKET_ONE_PATH, duBucket1.getSubpath());
+    assertEquals(BUCKET_TWO_PATH, duBucket2.getSubpath());
+    assertEquals(BUCKET_ONE_DATA_SIZE, duBucket1.getSize());
+    assertEquals(BUCKET_TWO_DATA_SIZE, duBucket2.getSize());
 
   }
   @Test
@@ -485,10 +487,10 @@ public class TestNSSummaryEndpointWithFSO {
     Response bucketResponse = nsSummaryEndpoint.getDiskUsage(BUCKET_ONE_PATH,
             false, false);
     DUResponse duBucketResponse = (DUResponse) bucketResponse.getEntity();
-    Assert.assertEquals(1, duBucketResponse.getCount());
+    assertEquals(1, duBucketResponse.getCount());
     DUResponse.DiskUsage duDir1 = duBucketResponse.getDuData().get(0);
-    Assert.assertEquals(DIR_ONE_PATH, duDir1.getSubpath());
-    Assert.assertEquals(DIR_ONE_DATA_SIZE, duDir1.getSize());
+    assertEquals(DIR_ONE_PATH, duDir1.getSubpath());
+    assertEquals(DIR_ONE_DATA_SIZE, duDir1.getSize());
 
   }
   @Test
@@ -497,21 +499,21 @@ public class TestNSSummaryEndpointWithFSO {
     Response dirResponse = nsSummaryEndpoint.getDiskUsage(DIR_ONE_PATH,
             false, false);
     DUResponse duDirReponse = (DUResponse) dirResponse.getEntity();
-    Assert.assertEquals(3, duDirReponse.getCount());
+    assertEquals(3, duDirReponse.getCount());
     List<DUResponse.DiskUsage> duSubDir = duDirReponse.getDuData();
     Collections.sort(duSubDir,
             Comparator.comparing(DUResponse.DiskUsage::getSubpath));
     DUResponse.DiskUsage duDir2 = duSubDir.get(0);
     DUResponse.DiskUsage duDir3 = duSubDir.get(1);
     DUResponse.DiskUsage duDir4 = duSubDir.get(2);
-    Assert.assertEquals(DIR_TWO_PATH, duDir2.getSubpath());
-    Assert.assertEquals(KEY_TWO_SIZE, duDir2.getSize());
+    assertEquals(DIR_TWO_PATH, duDir2.getSubpath());
+    assertEquals(KEY_TWO_SIZE, duDir2.getSize());
 
-    Assert.assertEquals(DIR_THREE_PATH, duDir3.getSubpath());
-    Assert.assertEquals(KEY_THREE_SIZE, duDir3.getSize());
+    assertEquals(DIR_THREE_PATH, duDir3.getSubpath());
+    assertEquals(KEY_THREE_SIZE, duDir3.getSize());
 
-    Assert.assertEquals(DIR_FOUR_PATH, duDir4.getSubpath());
-    Assert.assertEquals(KEY_SIX_SIZE, duDir4.getSize());
+    assertEquals(DIR_FOUR_PATH, duDir4.getSubpath());
+    assertEquals(KEY_SIX_SIZE, duDir4.getSize());
 
   }
   @Test
@@ -520,8 +522,8 @@ public class TestNSSummaryEndpointWithFSO {
     Response keyResponse = nsSummaryEndpoint.getDiskUsage(KEY_PATH,
             false, false);
     DUResponse keyObj = (DUResponse) keyResponse.getEntity();
-    Assert.assertEquals(0, keyObj.getCount());
-    Assert.assertEquals(KEY_FOUR_SIZE, keyObj.getSize());
+    assertEquals(0, keyObj.getCount());
+    assertEquals(KEY_FOUR_SIZE, keyObj.getSize());
 
   }
   @Test
@@ -530,7 +532,7 @@ public class TestNSSummaryEndpointWithFSO {
     Response invalidResponse = nsSummaryEndpoint.getDiskUsage(INVALID_PATH,
             false, false);
     DUResponse invalidObj = (DUResponse) invalidResponse.getEntity();
-    Assert.assertEquals(ResponseStatus.PATH_NOT_FOUND,
+    assertEquals(ResponseStatus.PATH_NOT_FOUND,
             invalidObj.getStatus());
   }
 
@@ -540,8 +542,8 @@ public class TestNSSummaryEndpointWithFSO {
     Response keyResponse = nsSummaryEndpoint.getDiskUsage(MULTI_BLOCK_KEY_PATH,
             false, true);
     DUResponse replicaDUResponse = (DUResponse) keyResponse.getEntity();
-    Assert.assertEquals(ResponseStatus.OK, replicaDUResponse.getStatus());
-    Assert.assertEquals(MULTI_BLOCK_KEY_SIZE_WITH_REPLICA,
+    assertEquals(ResponseStatus.OK, replicaDUResponse.getStatus());
+    assertEquals(MULTI_BLOCK_KEY_SIZE_WITH_REPLICA,
             replicaDUResponse.getSizeWithReplica());
   }
 
@@ -552,10 +554,10 @@ public class TestNSSummaryEndpointWithFSO {
     Response rootResponse = nsSummaryEndpoint.getDiskUsage(ROOT_PATH,
         false, true);
     DUResponse replicaDUResponse = (DUResponse) rootResponse.getEntity();
-    Assert.assertEquals(ResponseStatus.OK, replicaDUResponse.getStatus());
-    Assert.assertEquals(MULTI_BLOCK_TOTAL_SIZE_WITH_REPLICA_UNDER_ROOT,
+    assertEquals(ResponseStatus.OK, replicaDUResponse.getStatus());
+    assertEquals(MULTI_BLOCK_TOTAL_SIZE_WITH_REPLICA_UNDER_ROOT,
         replicaDUResponse.getSizeWithReplica());
-    Assert.assertEquals(MULTI_BLOCK_TOTAL_SIZE_WITH_REPLICA_UNDER_VOL,
+    assertEquals(MULTI_BLOCK_TOTAL_SIZE_WITH_REPLICA_UNDER_VOL,
         replicaDUResponse.getDuData().get(0).getSizeWithReplica());
 
   }
@@ -566,10 +568,10 @@ public class TestNSSummaryEndpointWithFSO {
     Response volResponse = nsSummaryEndpoint.getDiskUsage(VOL_PATH,
         false, true);
     DUResponse replicaDUResponse = (DUResponse) volResponse.getEntity();
-    Assert.assertEquals(ResponseStatus.OK, replicaDUResponse.getStatus());
-    Assert.assertEquals(MULTI_BLOCK_TOTAL_SIZE_WITH_REPLICA_UNDER_VOL,
+    assertEquals(ResponseStatus.OK, replicaDUResponse.getStatus());
+    assertEquals(MULTI_BLOCK_TOTAL_SIZE_WITH_REPLICA_UNDER_VOL,
         replicaDUResponse.getSizeWithReplica());
-    Assert.assertEquals(MULTI_BLOCK_TOTAL_SIZE_WITH_REPLICA_UNDER_BUCKET1,
+    assertEquals(MULTI_BLOCK_TOTAL_SIZE_WITH_REPLICA_UNDER_BUCKET1,
         replicaDUResponse.getDuData().get(0).getSizeWithReplica());
   }
 
@@ -579,10 +581,10 @@ public class TestNSSummaryEndpointWithFSO {
     Response bucketResponse = nsSummaryEndpoint.getDiskUsage(BUCKET_ONE_PATH,
         false, true);
     DUResponse replicaDUResponse = (DUResponse) bucketResponse.getEntity();
-    Assert.assertEquals(ResponseStatus.OK, replicaDUResponse.getStatus());
-    Assert.assertEquals(MULTI_BLOCK_TOTAL_SIZE_WITH_REPLICA_UNDER_BUCKET1,
+    assertEquals(ResponseStatus.OK, replicaDUResponse.getStatus());
+    assertEquals(MULTI_BLOCK_TOTAL_SIZE_WITH_REPLICA_UNDER_BUCKET1,
         replicaDUResponse.getSizeWithReplica());
-    Assert.assertEquals(MULTI_BLOCK_TOTAL_SIZE_WITH_REPLICA_UNDER_DIR1,
+    assertEquals(MULTI_BLOCK_TOTAL_SIZE_WITH_REPLICA_UNDER_DIR1,
         replicaDUResponse.getDuData().get(0).getSizeWithReplica());
   }
 
@@ -598,10 +600,10 @@ public class TestNSSummaryEndpointWithFSO {
     Response dir1Response = nsSummaryEndpoint.getDiskUsage(DIR_ONE_PATH,
         false, true);
     DUResponse replicaDUResponse = (DUResponse) dir1Response.getEntity();
-    Assert.assertEquals(ResponseStatus.OK, replicaDUResponse.getStatus());
-    Assert.assertEquals(MULTI_BLOCK_TOTAL_SIZE_WITH_REPLICA_UNDER_DIR1,
+    assertEquals(ResponseStatus.OK, replicaDUResponse.getStatus());
+    assertEquals(MULTI_BLOCK_TOTAL_SIZE_WITH_REPLICA_UNDER_DIR1,
         replicaDUResponse.getSizeWithReplica());
-    Assert.assertEquals(MULTI_BLOCK_TOTAL_SIZE_WITH_REPLICA_UNDER_DIR2,
+    assertEquals(MULTI_BLOCK_TOTAL_SIZE_WITH_REPLICA_UNDER_DIR2,
         replicaDUResponse.getDuData().get(0).getSizeWithReplica());
   }
 
@@ -611,8 +613,8 @@ public class TestNSSummaryEndpointWithFSO {
     Response keyResponse = nsSummaryEndpoint.getDiskUsage(KEY_PATH,
         false, true);
     DUResponse replicaDUResponse = (DUResponse) keyResponse.getEntity();
-    Assert.assertEquals(ResponseStatus.OK, replicaDUResponse.getStatus());
-    Assert.assertEquals(MULTI_BLOCK_TOTAL_SIZE_WITH_REPLICA_UNDER_KEY,
+    assertEquals(ResponseStatus.OK, replicaDUResponse.getStatus());
+    assertEquals(MULTI_BLOCK_TOTAL_SIZE_WITH_REPLICA_UNDER_KEY,
         replicaDUResponse.getSizeWithReplica());
   }
 
@@ -622,45 +624,45 @@ public class TestNSSummaryEndpointWithFSO {
     Response rootResponse = nsSummaryEndpoint.getQuotaUsage(ROOT_PATH);
     QuotaUsageResponse quRootRes =
         (QuotaUsageResponse) rootResponse.getEntity();
-    Assert.assertEquals(ROOT_QUOTA, quRootRes.getQuota());
-    Assert.assertEquals(ROOT_DATA_SIZE, quRootRes.getQuotaUsed());
+    assertEquals(ROOT_QUOTA, quRootRes.getQuota());
+    assertEquals(ROOT_DATA_SIZE, quRootRes.getQuotaUsed());
 
     // volume level quota usage
     Response volResponse = nsSummaryEndpoint.getQuotaUsage(VOL_PATH);
     QuotaUsageResponse quVolRes = (QuotaUsageResponse) volResponse.getEntity();
-    Assert.assertEquals(VOL_QUOTA, quVolRes.getQuota());
-    Assert.assertEquals(VOL_DATA_SIZE, quVolRes.getQuotaUsed());
+    assertEquals(VOL_QUOTA, quVolRes.getQuota());
+    assertEquals(VOL_DATA_SIZE, quVolRes.getQuotaUsed());
 
     // bucket level quota usage
     Response bucketRes = nsSummaryEndpoint.getQuotaUsage(BUCKET_ONE_PATH);
     QuotaUsageResponse quBucketRes = (QuotaUsageResponse) bucketRes.getEntity();
-    Assert.assertEquals(BUCKET_ONE_QUOTA, quBucketRes.getQuota());
-    Assert.assertEquals(BUCKET_ONE_DATA_SIZE, quBucketRes.getQuotaUsed());
+    assertEquals(BUCKET_ONE_QUOTA, quBucketRes.getQuota());
+    assertEquals(BUCKET_ONE_DATA_SIZE, quBucketRes.getQuotaUsed());
 
     Response bucketRes2 = nsSummaryEndpoint.getQuotaUsage(BUCKET_TWO_PATH);
     QuotaUsageResponse quBucketRes2 =
             (QuotaUsageResponse) bucketRes2.getEntity();
-    Assert.assertEquals(BUCKET_TWO_QUOTA, quBucketRes2.getQuota());
-    Assert.assertEquals(BUCKET_TWO_DATA_SIZE, quBucketRes2.getQuotaUsed());
+    assertEquals(BUCKET_TWO_QUOTA, quBucketRes2.getQuota());
+    assertEquals(BUCKET_TWO_DATA_SIZE, quBucketRes2.getQuotaUsed());
 
     // other level not applicable
     Response naResponse1 = nsSummaryEndpoint.getQuotaUsage(DIR_ONE_PATH);
     QuotaUsageResponse quotaUsageResponse1 =
             (QuotaUsageResponse) naResponse1.getEntity();
-    Assert.assertEquals(ResponseStatus.TYPE_NOT_APPLICABLE,
+    assertEquals(ResponseStatus.TYPE_NOT_APPLICABLE,
             quotaUsageResponse1.getResponseCode());
 
     Response naResponse2 = nsSummaryEndpoint.getQuotaUsage(KEY_PATH);
     QuotaUsageResponse quotaUsageResponse2 =
             (QuotaUsageResponse) naResponse2.getEntity();
-    Assert.assertEquals(ResponseStatus.TYPE_NOT_APPLICABLE,
+    assertEquals(ResponseStatus.TYPE_NOT_APPLICABLE,
             quotaUsageResponse2.getResponseCode());
 
     // invalid path request
     Response invalidRes = nsSummaryEndpoint.getQuotaUsage(INVALID_PATH);
     QuotaUsageResponse invalidResObj =
             (QuotaUsageResponse) invalidRes.getEntity();
-    Assert.assertEquals(ResponseStatus.PATH_NOT_FOUND,
+    assertEquals(ResponseStatus.PATH_NOT_FOUND,
             invalidResObj.getResponseCode());
   }
 
@@ -679,12 +681,12 @@ public class TestNSSummaryEndpointWithFSO {
     FileSizeDistributionResponse fileSizeDistResObj =
             (FileSizeDistributionResponse) res.getEntity();
     int[] fileSizeDist = fileSizeDistResObj.getFileSizeDist();
-    Assert.assertEquals(bin0, fileSizeDist[0]);
-    Assert.assertEquals(bin1, fileSizeDist[1]);
-    Assert.assertEquals(bin2, fileSizeDist[2]);
-    Assert.assertEquals(bin3, fileSizeDist[3]);
+    assertEquals(bin0, fileSizeDist[0]);
+    assertEquals(bin1, fileSizeDist[1]);
+    assertEquals(bin2, fileSizeDist[2]);
+    assertEquals(bin3, fileSizeDist[3]);
     for (int i = 4; i < ReconConstants.NUM_OF_FILE_SIZE_BINS; ++i) {
-      Assert.assertEquals(0, fileSizeDist[i]);
+      assertEquals(0, fileSizeDist[i]);
     }
   }
 

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/api/TestNSSummaryEndpointWithFSO.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/api/TestNSSummaryEndpointWithFSO.java
@@ -60,8 +60,6 @@ import org.apache.hadoop.ozone.recon.tasks.NSSummaryTaskWithFSO;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 
 import javax.ws.rs.core.Response;
 
@@ -76,6 +74,8 @@ import java.util.ArrayList;
 import java.util.Set;
 import java.util.HashSet;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.apache.hadoop.hdds.protocol.MockDatanodeDetails.randomDatanodeDetails;
 import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_DB_DIRS;
 import static org.apache.hadoop.ozone.recon.OMMetadataManagerTestUtils.writeDirToOm;

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/api/TestNSSummaryEndpointWithFSO.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/api/TestNSSummaryEndpointWithFSO.java
@@ -111,7 +111,7 @@ import static org.mockito.Mockito.when;
  */
 public class TestNSSummaryEndpointWithFSO {
   @TempDir
-  public Path temporaryFolder;
+  private Path temporaryFolder;
 
   private ReconOMMetadataManager reconOMMetadataManager;
   private NSSummaryEndpoint nsSummaryEndpoint;
@@ -356,7 +356,8 @@ public class TestNSSummaryEndpointWithFSO {
     ozoneConfiguration.setLong(OZONE_RECON_NSSUMMARY_FLUSH_TO_DB_MAX_THRESHOLD,
         10);
     OMMetadataManager omMetadataManager = initializeNewOmMetadataManager(
-        Files.createDirectory(temporaryFolder.resolve("JunitOmDBDir")).toFile());
+        Files.createDirectory(temporaryFolder.resolve("JunitOmDBDir"))
+            .toFile());
     OzoneManagerServiceProviderImpl ozoneManagerServiceProvider =
         getMockOzoneManagerServiceProviderWithFSO();
     reconOMMetadataManager = getTestReconOmMetadataManager(omMetadataManager,

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/api/TestNSSummaryEndpointWithLegacy.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/api/TestNSSummaryEndpointWithLegacy.java
@@ -61,9 +61,6 @@ import org.apache.hadoop.ozone.recon.tasks.NSSummaryTaskWithLegacy;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertArrayEquals;
-
 import javax.ws.rs.core.Response;
 
 import java.io.File;
@@ -77,6 +74,8 @@ import java.util.ArrayList;
 import java.util.Set;
 import java.util.HashSet;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.apache.hadoop.hdds.protocol.MockDatanodeDetails.randomDatanodeDetails;
 import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_DB_DIRS;
 import static org.apache.hadoop.ozone.OzoneConsts.OM_KEY_PREFIX;

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/api/TestNSSummaryEndpointWithLegacy.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/api/TestNSSummaryEndpointWithLegacy.java
@@ -112,7 +112,7 @@ import static org.mockito.Mockito.when;
  */
 public class TestNSSummaryEndpointWithLegacy {
   @TempDir
-  public Path temporaryFolder;
+  private Path temporaryFolder;
 
   private ReconOMMetadataManager reconOMMetadataManager;
   private NSSummaryEndpoint nsSummaryEndpoint;

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/api/TestNSSummaryEndpointWithLegacy.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/api/TestNSSummaryEndpointWithLegacy.java
@@ -58,16 +58,18 @@ import org.apache.hadoop.ozone.recon.spi.StorageContainerServiceProvider;
 import org.apache.hadoop.ozone.recon.spi.impl.OzoneManagerServiceProviderImpl;
 import org.apache.hadoop.ozone.recon.spi.impl.StorageContainerServiceProviderImpl;
 import org.apache.hadoop.ozone.recon.tasks.NSSummaryTaskWithLegacy;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 
 import javax.ws.rs.core.Response;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
@@ -109,8 +111,8 @@ import static org.mockito.Mockito.when;
  * so there is no need to test process() on DB's updates
  */
 public class TestNSSummaryEndpointWithLegacy {
-  @Rule
-  public TemporaryFolder temporaryFolder = new TemporaryFolder();
+  @TempDir
+  public Path temporaryFolder;
 
   private ReconOMMetadataManager reconOMMetadataManager;
   private NSSummaryEndpoint nsSummaryEndpoint;
@@ -351,18 +353,20 @@ public class TestNSSummaryEndpointWithLegacy {
   private static final long DIR_ONE_DATA_SIZE = KEY_TWO_SIZE +
       KEY_THREE_SIZE + KEY_SIX_SIZE;
 
-  @Before
+  @BeforeEach
   public void setUp() throws Exception {
     conf = new OzoneConfiguration();
     OMMetadataManager omMetadataManager = initializeNewOmMetadataManager(
-        temporaryFolder.newFolder(), conf);
+        Files.createDirectory(temporaryFolder.resolve(
+            "JunitOmDBDir")).toFile(), conf);
     OzoneManagerServiceProviderImpl ozoneManagerServiceProvider =
         getMockOzoneManagerServiceProvider();
-    reconOMMetadataManager = getTestReconOmMetadataManager(omMetadataManager, 
-        temporaryFolder.newFolder());
+    reconOMMetadataManager = getTestReconOmMetadataManager(omMetadataManager,
+        Files.createDirectory(temporaryFolder.resolve(
+            "omMetadatDir")).toFile());
 
     ReconTestInjector reconTestInjector =
-        new ReconTestInjector.Builder(temporaryFolder)
+        new ReconTestInjector.Builder(temporaryFolder.toFile())
             .withReconOm(reconOMMetadataManager)
             .withOmServiceProvider(ozoneManagerServiceProvider)
             .withReconSqlDb()
@@ -389,11 +393,11 @@ public class TestNSSummaryEndpointWithLegacy {
   @Test
   public void testUtility() {
     String[] names = EntityHandler.parseRequestPath(TEST_PATH_UTILITY);
-    Assert.assertArrayEquals(TEST_NAMES, names);
+    assertArrayEquals(TEST_NAMES, names);
     String keyName = BucketHandler.getKeyName(names);
-    Assert.assertEquals(TEST_KEY_NAMES, keyName);
+    assertEquals(TEST_KEY_NAMES, keyName);
     String subpath = BucketHandler.buildSubpath(PARENT_DIR, "file1.txt");
-    Assert.assertEquals(TEST_PATH_UTILITY, subpath);
+    assertEquals(TEST_PATH_UTILITY, subpath);
   }
 
   @Test
@@ -448,17 +452,17 @@ public class TestNSSummaryEndpointWithLegacy {
     Response rootResponse = nsSummaryEndpoint.getDiskUsage(ROOT_PATH,
         false, false);
     DUResponse duRootRes = (DUResponse) rootResponse.getEntity();
-    Assert.assertEquals(2, duRootRes.getCount());
+    assertEquals(2, duRootRes.getCount());
     List<DUResponse.DiskUsage> duRootData = duRootRes.getDuData();
     // sort based on subpath
     Collections.sort(duRootData,
         Comparator.comparing(DUResponse.DiskUsage::getSubpath));
     DUResponse.DiskUsage duVol1 = duRootData.get(0);
     DUResponse.DiskUsage duVol2 = duRootData.get(1);
-    Assert.assertEquals(VOL_PATH, duVol1.getSubpath());
-    Assert.assertEquals(VOL_TWO_PATH, duVol2.getSubpath());
-    Assert.assertEquals(VOL_DATA_SIZE, duVol1.getSize());
-    Assert.assertEquals(VOL_TWO_DATA_SIZE, duVol2.getSize());
+    assertEquals(VOL_PATH, duVol1.getSubpath());
+    assertEquals(VOL_TWO_PATH, duVol2.getSubpath());
+    assertEquals(VOL_DATA_SIZE, duVol1.getSize());
+    assertEquals(VOL_TWO_DATA_SIZE, duVol2.getSize());
   }
 
   @Test
@@ -467,17 +471,17 @@ public class TestNSSummaryEndpointWithLegacy {
     Response volResponse = nsSummaryEndpoint.getDiskUsage(VOL_PATH,
         false, false);
     DUResponse duVolRes = (DUResponse) volResponse.getEntity();
-    Assert.assertEquals(2, duVolRes.getCount());
+    assertEquals(2, duVolRes.getCount());
     List<DUResponse.DiskUsage> duData = duVolRes.getDuData();
     // sort based on subpath
     Collections.sort(duData,
         Comparator.comparing(DUResponse.DiskUsage::getSubpath));
     DUResponse.DiskUsage duBucket1 = duData.get(0);
     DUResponse.DiskUsage duBucket2 = duData.get(1);
-    Assert.assertEquals(BUCKET_ONE_PATH, duBucket1.getSubpath());
-    Assert.assertEquals(BUCKET_TWO_PATH, duBucket2.getSubpath());
-    Assert.assertEquals(BUCKET_ONE_DATA_SIZE, duBucket1.getSize());
-    Assert.assertEquals(BUCKET_TWO_DATA_SIZE, duBucket2.getSize());
+    assertEquals(BUCKET_ONE_PATH, duBucket1.getSubpath());
+    assertEquals(BUCKET_TWO_PATH, duBucket2.getSubpath());
+    assertEquals(BUCKET_ONE_DATA_SIZE, duBucket1.getSize());
+    assertEquals(BUCKET_TWO_DATA_SIZE, duBucket2.getSize());
   }
 
   @Test
@@ -486,10 +490,10 @@ public class TestNSSummaryEndpointWithLegacy {
     Response bucketResponse = nsSummaryEndpoint.getDiskUsage(BUCKET_ONE_PATH,
         false, false);
     DUResponse duBucketResponse = (DUResponse) bucketResponse.getEntity();
-    Assert.assertEquals(1, duBucketResponse.getCount());
+    assertEquals(1, duBucketResponse.getCount());
     DUResponse.DiskUsage duDir1 = duBucketResponse.getDuData().get(0);
-    Assert.assertEquals(DIR_ONE_PATH, duDir1.getSubpath());
-    Assert.assertEquals(DIR_ONE_DATA_SIZE, duDir1.getSize());
+    assertEquals(DIR_ONE_PATH, duDir1.getSubpath());
+    assertEquals(DIR_ONE_DATA_SIZE, duDir1.getSize());
   }
 
   @Test
@@ -498,21 +502,21 @@ public class TestNSSummaryEndpointWithLegacy {
     Response dirResponse = nsSummaryEndpoint.getDiskUsage(DIR_ONE_PATH,
         false, false);
     DUResponse duDirReponse = (DUResponse) dirResponse.getEntity();
-    Assert.assertEquals(3, duDirReponse.getCount());
+    assertEquals(3, duDirReponse.getCount());
     List<DUResponse.DiskUsage> duSubDir = duDirReponse.getDuData();
     Collections.sort(duSubDir,
         Comparator.comparing(DUResponse.DiskUsage::getSubpath));
     DUResponse.DiskUsage duDir2 = duSubDir.get(0);
     DUResponse.DiskUsage duDir3 = duSubDir.get(1);
     DUResponse.DiskUsage duDir4 = duSubDir.get(2);
-    Assert.assertEquals(DIR_TWO_PATH, duDir2.getSubpath());
-    Assert.assertEquals(KEY_TWO_SIZE, duDir2.getSize());
+    assertEquals(DIR_TWO_PATH, duDir2.getSubpath());
+    assertEquals(KEY_TWO_SIZE, duDir2.getSize());
 
-    Assert.assertEquals(DIR_THREE_PATH, duDir3.getSubpath());
-    Assert.assertEquals(KEY_THREE_SIZE, duDir3.getSize());
+    assertEquals(DIR_THREE_PATH, duDir3.getSubpath());
+    assertEquals(KEY_THREE_SIZE, duDir3.getSize());
 
-    Assert.assertEquals(DIR_FOUR_PATH, duDir4.getSubpath());
-    Assert.assertEquals(KEY_SIX_SIZE, duDir4.getSize());
+    assertEquals(DIR_FOUR_PATH, duDir4.getSubpath());
+    assertEquals(KEY_SIX_SIZE, duDir4.getSize());
   }
 
   @Test
@@ -521,8 +525,8 @@ public class TestNSSummaryEndpointWithLegacy {
     Response keyResponse = nsSummaryEndpoint.getDiskUsage(KEY_PATH,
         false, false);
     DUResponse keyObj = (DUResponse) keyResponse.getEntity();
-    Assert.assertEquals(0, keyObj.getCount());
-    Assert.assertEquals(KEY_FOUR_SIZE, keyObj.getSize());
+    assertEquals(0, keyObj.getCount());
+    assertEquals(KEY_FOUR_SIZE, keyObj.getSize());
   }
 
   @Test
@@ -531,7 +535,7 @@ public class TestNSSummaryEndpointWithLegacy {
     Response invalidResponse = nsSummaryEndpoint.getDiskUsage(INVALID_PATH,
         false, false);
     DUResponse invalidObj = (DUResponse) invalidResponse.getEntity();
-    Assert.assertEquals(ResponseStatus.PATH_NOT_FOUND,
+    assertEquals(ResponseStatus.PATH_NOT_FOUND,
         invalidObj.getStatus());
   }
 
@@ -541,8 +545,8 @@ public class TestNSSummaryEndpointWithLegacy {
     Response keyResponse = nsSummaryEndpoint.getDiskUsage(MULTI_BLOCK_KEY_PATH,
         false, true);
     DUResponse replicaDUResponse = (DUResponse) keyResponse.getEntity();
-    Assert.assertEquals(ResponseStatus.OK, replicaDUResponse.getStatus());
-    Assert.assertEquals(MULTI_BLOCK_KEY_SIZE_WITH_REPLICA,
+    assertEquals(ResponseStatus.OK, replicaDUResponse.getStatus());
+    assertEquals(MULTI_BLOCK_KEY_SIZE_WITH_REPLICA,
         replicaDUResponse.getSizeWithReplica());
   }
 
@@ -553,10 +557,10 @@ public class TestNSSummaryEndpointWithLegacy {
     Response rootResponse = nsSummaryEndpoint.getDiskUsage(ROOT_PATH,
         false, true);
     DUResponse replicaDUResponse = (DUResponse) rootResponse.getEntity();
-    Assert.assertEquals(ResponseStatus.OK, replicaDUResponse.getStatus());
-    Assert.assertEquals(MULTI_BLOCK_TOTAL_SIZE_WITH_REPLICA_UNDER_ROOT,
+    assertEquals(ResponseStatus.OK, replicaDUResponse.getStatus());
+    assertEquals(MULTI_BLOCK_TOTAL_SIZE_WITH_REPLICA_UNDER_ROOT,
         replicaDUResponse.getSizeWithReplica());
-    Assert.assertEquals(MULTI_BLOCK_TOTAL_SIZE_WITH_REPLICA_UNDER_VOL,
+    assertEquals(MULTI_BLOCK_TOTAL_SIZE_WITH_REPLICA_UNDER_VOL,
         replicaDUResponse.getDuData().get(0).getSizeWithReplica());
 
   }
@@ -567,10 +571,10 @@ public class TestNSSummaryEndpointWithLegacy {
     Response volResponse = nsSummaryEndpoint.getDiskUsage(VOL_PATH,
         false, true);
     DUResponse replicaDUResponse = (DUResponse) volResponse.getEntity();
-    Assert.assertEquals(ResponseStatus.OK, replicaDUResponse.getStatus());
-    Assert.assertEquals(MULTI_BLOCK_TOTAL_SIZE_WITH_REPLICA_UNDER_VOL,
+    assertEquals(ResponseStatus.OK, replicaDUResponse.getStatus());
+    assertEquals(MULTI_BLOCK_TOTAL_SIZE_WITH_REPLICA_UNDER_VOL,
         replicaDUResponse.getSizeWithReplica());
-    Assert.assertEquals(MULTI_BLOCK_TOTAL_SIZE_WITH_REPLICA_UNDER_BUCKET1,
+    assertEquals(MULTI_BLOCK_TOTAL_SIZE_WITH_REPLICA_UNDER_BUCKET1,
         replicaDUResponse.getDuData().get(0).getSizeWithReplica());
   }
 
@@ -580,10 +584,10 @@ public class TestNSSummaryEndpointWithLegacy {
     Response bucketResponse = nsSummaryEndpoint.getDiskUsage(BUCKET_ONE_PATH,
         false, true);
     DUResponse replicaDUResponse = (DUResponse) bucketResponse.getEntity();
-    Assert.assertEquals(ResponseStatus.OK, replicaDUResponse.getStatus());
-    Assert.assertEquals(MULTI_BLOCK_TOTAL_SIZE_WITH_REPLICA_UNDER_BUCKET1,
+    assertEquals(ResponseStatus.OK, replicaDUResponse.getStatus());
+    assertEquals(MULTI_BLOCK_TOTAL_SIZE_WITH_REPLICA_UNDER_BUCKET1,
         replicaDUResponse.getSizeWithReplica());
-    Assert.assertEquals(MULTI_BLOCK_TOTAL_SIZE_WITH_REPLICA_UNDER_DIR1,
+    assertEquals(MULTI_BLOCK_TOTAL_SIZE_WITH_REPLICA_UNDER_DIR1,
         replicaDUResponse.getDuData().get(0).getSizeWithReplica());
   }
 
@@ -599,10 +603,10 @@ public class TestNSSummaryEndpointWithLegacy {
     Response dir1Response = nsSummaryEndpoint.getDiskUsage(DIR_ONE_PATH,
         false, true);
     DUResponse replicaDUResponse = (DUResponse) dir1Response.getEntity();
-    Assert.assertEquals(ResponseStatus.OK, replicaDUResponse.getStatus());
-    Assert.assertEquals(MULTI_BLOCK_TOTAL_SIZE_WITH_REPLICA_UNDER_DIR1,
+    assertEquals(ResponseStatus.OK, replicaDUResponse.getStatus());
+    assertEquals(MULTI_BLOCK_TOTAL_SIZE_WITH_REPLICA_UNDER_DIR1,
         replicaDUResponse.getSizeWithReplica());
-    Assert.assertEquals(MULTI_BLOCK_TOTAL_SIZE_WITH_REPLICA_UNDER_DIR2,
+    assertEquals(MULTI_BLOCK_TOTAL_SIZE_WITH_REPLICA_UNDER_DIR2,
         replicaDUResponse.getDuData().get(0).getSizeWithReplica());
   }
 
@@ -612,8 +616,8 @@ public class TestNSSummaryEndpointWithLegacy {
     Response keyResponse = nsSummaryEndpoint.getDiskUsage(KEY_PATH,
         false, true);
     DUResponse replicaDUResponse = (DUResponse) keyResponse.getEntity();
-    Assert.assertEquals(ResponseStatus.OK, replicaDUResponse.getStatus());
-    Assert.assertEquals(MULTI_BLOCK_TOTAL_SIZE_WITH_REPLICA_UNDER_KEY,
+    assertEquals(ResponseStatus.OK, replicaDUResponse.getStatus());
+    assertEquals(MULTI_BLOCK_TOTAL_SIZE_WITH_REPLICA_UNDER_KEY,
         replicaDUResponse.getSizeWithReplica());
   }
 
@@ -623,45 +627,45 @@ public class TestNSSummaryEndpointWithLegacy {
     Response rootResponse = nsSummaryEndpoint.getQuotaUsage(ROOT_PATH);
     QuotaUsageResponse quRootRes =
         (QuotaUsageResponse) rootResponse.getEntity();
-    Assert.assertEquals(ROOT_QUOTA, quRootRes.getQuota());
-    Assert.assertEquals(ROOT_DATA_SIZE, quRootRes.getQuotaUsed());
+    assertEquals(ROOT_QUOTA, quRootRes.getQuota());
+    assertEquals(ROOT_DATA_SIZE, quRootRes.getQuotaUsed());
 
     // volume level quota usage
     Response volResponse = nsSummaryEndpoint.getQuotaUsage(VOL_PATH);
     QuotaUsageResponse quVolRes = (QuotaUsageResponse) volResponse.getEntity();
-    Assert.assertEquals(VOL_QUOTA, quVolRes.getQuota());
-    Assert.assertEquals(VOL_DATA_SIZE, quVolRes.getQuotaUsed());
+    assertEquals(VOL_QUOTA, quVolRes.getQuota());
+    assertEquals(VOL_DATA_SIZE, quVolRes.getQuotaUsed());
 
     // bucket level quota usage
     Response bucketRes = nsSummaryEndpoint.getQuotaUsage(BUCKET_ONE_PATH);
     QuotaUsageResponse quBucketRes = (QuotaUsageResponse) bucketRes.getEntity();
-    Assert.assertEquals(BUCKET_ONE_QUOTA, quBucketRes.getQuota());
-    Assert.assertEquals(BUCKET_ONE_DATA_SIZE, quBucketRes.getQuotaUsed());
+    assertEquals(BUCKET_ONE_QUOTA, quBucketRes.getQuota());
+    assertEquals(BUCKET_ONE_DATA_SIZE, quBucketRes.getQuotaUsed());
 
     Response bucketRes2 = nsSummaryEndpoint.getQuotaUsage(BUCKET_TWO_PATH);
     QuotaUsageResponse quBucketRes2 =
         (QuotaUsageResponse) bucketRes2.getEntity();
-    Assert.assertEquals(BUCKET_TWO_QUOTA, quBucketRes2.getQuota());
-    Assert.assertEquals(BUCKET_TWO_DATA_SIZE, quBucketRes2.getQuotaUsed());
+    assertEquals(BUCKET_TWO_QUOTA, quBucketRes2.getQuota());
+    assertEquals(BUCKET_TWO_DATA_SIZE, quBucketRes2.getQuotaUsed());
 
     // other level not applicable
     Response naResponse1 = nsSummaryEndpoint.getQuotaUsage(DIR_ONE_PATH);
     QuotaUsageResponse quotaUsageResponse1 =
         (QuotaUsageResponse) naResponse1.getEntity();
-    Assert.assertEquals(ResponseStatus.TYPE_NOT_APPLICABLE,
+    assertEquals(ResponseStatus.TYPE_NOT_APPLICABLE,
         quotaUsageResponse1.getResponseCode());
 
     Response naResponse2 = nsSummaryEndpoint.getQuotaUsage(KEY_PATH);
     QuotaUsageResponse quotaUsageResponse2 =
         (QuotaUsageResponse) naResponse2.getEntity();
-    Assert.assertEquals(ResponseStatus.TYPE_NOT_APPLICABLE,
+    assertEquals(ResponseStatus.TYPE_NOT_APPLICABLE,
         quotaUsageResponse2.getResponseCode());
 
     // invalid path request
     Response invalidRes = nsSummaryEndpoint.getQuotaUsage(INVALID_PATH);
     QuotaUsageResponse invalidResObj =
         (QuotaUsageResponse) invalidRes.getEntity();
-    Assert.assertEquals(ResponseStatus.PATH_NOT_FOUND,
+    assertEquals(ResponseStatus.PATH_NOT_FOUND,
         invalidResObj.getResponseCode());
   }
 
@@ -680,12 +684,12 @@ public class TestNSSummaryEndpointWithLegacy {
     FileSizeDistributionResponse fileSizeDistResObj =
             (FileSizeDistributionResponse) res.getEntity();
     int[] fileSizeDist = fileSizeDistResObj.getFileSizeDist();
-    Assert.assertEquals(bin0, fileSizeDist[0]);
-    Assert.assertEquals(bin1, fileSizeDist[1]);
-    Assert.assertEquals(bin2, fileSizeDist[2]);
-    Assert.assertEquals(bin3, fileSizeDist[3]);
+    assertEquals(bin0, fileSizeDist[0]);
+    assertEquals(bin1, fileSizeDist[1]);
+    assertEquals(bin2, fileSizeDist[2]);
+    assertEquals(bin3, fileSizeDist[3]);
     for (int i = 4; i < ReconConstants.NUM_OF_FILE_SIZE_BINS; ++i) {
-      Assert.assertEquals(0, fileSizeDist[i]);
+      assertEquals(0, fileSizeDist[i]);
     }
   }
 

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/api/TestOmDBInsightEndPoint.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/api/TestOmDBInsightEndPoint.java
@@ -49,9 +49,11 @@ import org.hadoop.ozone.recon.schema.tables.pojos.GlobalStats;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.io.TempDir;
 
 import javax.ws.rs.core.Response;
 import java.nio.file.Files;
+import java.nio.file.Path;
 import java.sql.Timestamp;
 import java.util.List;
 import java.util.ArrayList;
@@ -75,7 +77,8 @@ import static org.mockito.Mockito.when;
  * Unit test for OmDBInsightEndPoint.
  */
 public class TestOmDBInsightEndPoint extends AbstractReconSqlDBTest {
-
+  @TempDir
+  private Path temporaryFolder;
   private OzoneStorageContainerManager ozoneStorageContainerManager;
   private ReconContainerMetadataManager reconContainerMetadataManager;
   private OMMetadataManager omMetadataManager;

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/api/TestOmDBInsightEndPoint.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/api/TestOmDBInsightEndPoint.java
@@ -46,11 +46,12 @@ import org.apache.hadoop.ozone.recon.spi.impl.StorageContainerServiceProviderImp
 import org.apache.hadoop.ozone.recon.tasks.ContainerKeyMapperTask;
 import org.hadoop.ozone.recon.schema.tables.daos.GlobalStatsDao;
 import org.hadoop.ozone.recon.schema.tables.pojos.GlobalStats;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Assertions;
 
 import javax.ws.rs.core.Response;
+import java.nio.file.Files;
 import java.sql.Timestamp;
 import java.util.List;
 import java.util.ArrayList;
@@ -96,14 +97,16 @@ public class TestOmDBInsightEndPoint extends AbstractReconSqlDBTest {
     return newValue;
   }
 
-  @Before
+  @BeforeEach
   public void setUp() throws Exception {
     omMetadataManager = initializeNewOmMetadataManager(
-        temporaryFolder.newFolder());
+        Files.createDirectory(temporaryFolder.resolve(
+            "JunitOmMetadata")).toFile());
     reconOMMetadataManager = getTestReconOmMetadataManager(omMetadataManager,
-        temporaryFolder.newFolder());
+        Files.createDirectory(temporaryFolder.resolve(
+            "JunitOmMetadataTest")).toFile());
     ReconTestInjector reconTestInjector =
-        new ReconTestInjector.Builder(temporaryFolder)
+        new ReconTestInjector.Builder(temporaryFolder.toFile())
             .withReconSqlDb()
             .withReconOm(reconOMMetadataManager)
             .withOmServiceProvider(mock(OzoneManagerServiceProviderImpl.class))

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/api/TestOpenContainerCount.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/api/TestOpenContainerCount.java
@@ -57,11 +57,10 @@ import org.apache.hadoop.ozone.recon.spi.impl.OzoneManagerServiceProviderImpl;
 import org.apache.hadoop.ozone.recon.spi.impl.StorageContainerServiceProviderImpl;
 import org.apache.ozone.test.GenericTestUtils;
 import org.apache.ozone.test.LambdaTestUtils;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 import static org.apache.hadoop.hdds.protocol.MockDatanodeDetails.randomDatanodeDetails;
 import static org.apache.hadoop.ozone.container.upgrade.UpgradeUtils.defaultLayoutVersionProto;
@@ -79,6 +78,8 @@ import javax.ws.rs.core.Response;
 
 import java.io.IOException;
 import java.net.HttpURLConnection;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.UUID;
@@ -88,8 +89,8 @@ import java.util.concurrent.Callable;
  * Test for Open Container count per Datanode.
  */
 public class TestOpenContainerCount {
-  @Rule
-  public TemporaryFolder temporaryFolder = new TemporaryFolder();
+  @TempDir
+  public Path temporaryFolder;
 
   private NodeEndpoint nodeEndpoint;
   private ReconOMMetadataManager reconOMMetadataManager;
@@ -118,8 +119,9 @@ public class TestOpenContainerCount {
 
   private void initializeInjector() throws Exception {
     reconOMMetadataManager = getTestReconOmMetadataManager(
-            initializeNewOmMetadataManager(temporaryFolder.newFolder()),
-            temporaryFolder.newFolder());
+            initializeNewOmMetadataManager(Files.createDirectory(
+                temporaryFolder.resolve("JunitOmDBDir")).toFile()),
+        Files.createDirectory(temporaryFolder.resolve("NewDir")).toFile());
     datanodeDetails = randomDatanodeDetails();
     datanodeDetails.setHostName(HOST1);
     datanodeDetails.setIpAddress(IP1);
@@ -196,7 +198,7 @@ public class TestOpenContainerCount {
         commonUtils.getReconNodeDetails());
 
     ReconTestInjector reconTestInjector =
-            new ReconTestInjector.Builder(temporaryFolder)
+            new ReconTestInjector.Builder(temporaryFolder.toFile())
                     .withReconSqlDb()
                     .withReconOm(reconOMMetadataManager)
                     .withOmServiceProvider(
@@ -219,7 +221,7 @@ public class TestOpenContainerCount {
             reconTestInjector.getInstance(OzoneStorageContainerManager.class);
   }
 
-  @Before
+  @BeforeEach
   public void setUp() throws Exception {
     // The following setup runs only once
     if (!isSetupDone) {
@@ -327,7 +329,7 @@ public class TestOpenContainerCount {
       // Process all events in the event queue
       reconScm.getEventQueue().processAll(1000);
     } catch (Exception ex) {
-      Assert.fail(ex.getMessage());
+      Assertions.fail(ex.getMessage());
     }
   }
 
@@ -350,7 +352,7 @@ public class TestOpenContainerCount {
       --expectedCnt;
       closeContainer(id);
       DatanodeMetadata metadata = getDatanodeMetadata();
-      Assert.assertEquals(expectedCnt, metadata.getOpenContainers());
+      Assertions.assertEquals(expectedCnt, metadata.getOpenContainers());
     }
   }
 
@@ -419,7 +421,7 @@ public class TestOpenContainerCount {
       // Process all events in the event queue
       reconScm.getEventQueue().processAll(1000);
     } catch (Exception ex) {
-      Assert.fail(ex.getMessage());
+      Assertions.fail(ex.getMessage());
     }
   }
 

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/api/TestOpenContainerCount.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/api/TestOpenContainerCount.java
@@ -90,7 +90,7 @@ import java.util.concurrent.Callable;
  */
 public class TestOpenContainerCount {
   @TempDir
-  public Path temporaryFolder;
+  private Path temporaryFolder;
 
   private NodeEndpoint nodeEndpoint;
   private ReconOMMetadataManager reconOMMetadataManager;

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/api/TestTriggerDBSyncEndpoint.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/api/TestTriggerDBSyncEndpoint.java
@@ -71,7 +71,7 @@ import static org.mockito.Mockito.when;
 public class TestTriggerDBSyncEndpoint {
 
   @TempDir
-  public Path temporaryFolder;
+  private Path temporaryFolder;
   private ReconTestInjector reconTestInjector;
   private CommonUtils commonUtils;
 

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/api/TestTriggerDBSyncEndpoint.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/api/TestTriggerDBSyncEndpoint.java
@@ -39,11 +39,10 @@ import org.apache.hadoop.ozone.recon.spi.impl.StorageContainerServiceProviderImp
 import org.apache.hadoop.ozone.recon.tasks.ReconTaskController;
 import org.apache.hadoop.security.authentication.client.AuthenticationException;
 import org.hadoop.ozone.recon.schema.tables.daos.ReconTaskStatusDao;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Assertions;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.io.TempDir;
 
 import javax.ws.rs.core.Response;
 import java.io.File;
@@ -51,6 +50,8 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.HttpURLConnection;
+import java.nio.file.Files;
+import java.nio.file.Path;
 
 import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_ADDRESS_KEY;
 import static org.apache.hadoop.ozone.recon.OMMetadataManagerTestUtils.getTestReconOmMetadataManager;
@@ -69,18 +70,20 @@ import static org.mockito.Mockito.when;
  */
 public class TestTriggerDBSyncEndpoint {
 
-  @Rule
-  public TemporaryFolder temporaryFolder = new TemporaryFolder();
+  @TempDir
+  public Path temporaryFolder;
   private ReconTestInjector reconTestInjector;
   private CommonUtils commonUtils;
 
-  @Before
+  @BeforeEach
   public void setUp() throws IOException, AuthenticationException {
     OzoneConfiguration configuration = new OzoneConfiguration();
     configuration.set(OZONE_RECON_OM_SNAPSHOT_DB_DIR,
-        temporaryFolder.newFolder().getAbsolutePath());
+        Files.createDirectory(temporaryFolder.resolve("OmSnapshotDB"))
+            .toFile().getAbsolutePath());
     configuration.set(OZONE_RECON_DB_DIR,
-        temporaryFolder.newFolder().getAbsolutePath());
+        Files.createDirectory(temporaryFolder.resolve("ReconDb"))
+            .toFile().getAbsolutePath());
     configuration.set(OZONE_OM_ADDRESS_KEY, "localhost:9862");
     commonUtils = new CommonUtils();
     OzoneManagerProtocol ozoneManagerProtocol
@@ -89,10 +92,12 @@ public class TestTriggerDBSyncEndpoint {
         .DBUpdatesRequest.class))).thenReturn(new DBUpdates());
 
     OMMetadataManager omMetadataManager =
-        initializeNewOmMetadataManager(temporaryFolder.newFolder());
+        initializeNewOmMetadataManager(Files.createDirectory(
+            temporaryFolder.resolve("OnMetadata")).toFile());
     ReconOMMetadataManager reconOMMetadataManager
         = getTestReconOmMetadataManager(omMetadataManager,
-        temporaryFolder.newFolder());
+        Files.createDirectory(
+            temporaryFolder.resolve("OmMetadataTest")).toFile());
 
 
     ReconUtils reconUtilsMock = mock(ReconUtils.class);
@@ -120,7 +125,7 @@ public class TestTriggerDBSyncEndpoint {
     ozoneManagerServiceProvider.start();
 
     reconTestInjector =
-        new ReconTestInjector.Builder(temporaryFolder)
+        new ReconTestInjector.Builder(temporaryFolder.toFile())
             .withReconSqlDb()
             .withReconOm(reconOMMetadataManager)
             .withOmServiceProvider(ozoneManagerServiceProvider)

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/heatmap/TestHeatMapInfo.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/heatmap/TestHeatMapInfo.java
@@ -32,13 +32,14 @@ import org.apache.hadoop.ozone.recon.scm.ReconStorageContainerManagerFacade;
 import org.apache.hadoop.ozone.recon.spi.StorageContainerServiceProvider;
 import org.apache.hadoop.ozone.recon.spi.impl.OzoneManagerServiceProviderImpl;
 import org.apache.hadoop.ozone.recon.spi.impl.StorageContainerServiceProviderImpl;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.api.Assertions;
-import org.junit.rules.TemporaryFolder;
 
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -53,8 +54,8 @@ import static org.mockito.Mockito.mock;
  */
 public class TestHeatMapInfo {
 
-  @Rule
-  public TemporaryFolder temporaryFolder = new TemporaryFolder();
+  @TempDir
+  private Path temporaryFolder;
 
   private boolean isSetupDone = false;
   private ReconOMMetadataManager reconOMMetadataManager;
@@ -64,11 +65,12 @@ public class TestHeatMapInfo {
   @SuppressWarnings("checkstyle:methodlength")
   private void initializeInjector() throws Exception {
     reconOMMetadataManager = getTestReconOmMetadataManager(
-        initializeNewOmMetadataManager(temporaryFolder.newFolder()),
-        temporaryFolder.newFolder());
+        initializeNewOmMetadataManager(Files.createDirectory(
+            temporaryFolder.resolve("JunitOmDBDir")).toFile()),
+        Files.createDirectory(temporaryFolder.resolve("NewDir")).toFile());
 
     ReconTestInjector reconTestInjector =
-        new ReconTestInjector.Builder(temporaryFolder)
+        new ReconTestInjector.Builder(temporaryFolder.toFile())
             .withReconSqlDb()
             .withReconOm(reconOMMetadataManager)
             .withOmServiceProvider(mock(OzoneManagerServiceProviderImpl.class))
@@ -728,7 +730,7 @@ public class TestHeatMapInfo {
         "}";
   }
 
-  @Before
+  @BeforeEach
   public void setUp() throws Exception {
     // The following setup runs only once
     if (!isSetupDone) {

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/persistence/AbstractReconSqlDBTest.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/persistence/AbstractReconSqlDBTest.java
@@ -46,6 +46,7 @@ import com.google.inject.Guice;
 import com.google.inject.Injector;
 import com.google.inject.Module;
 import com.google.inject.Provider;
+import org.junit.jupiter.api.io.TempDir;
 
 /**
  * Class that provides a Recon SQL DB with all the tables created, and APIs
@@ -53,7 +54,8 @@ import com.google.inject.Provider;
  */
 public class AbstractReconSqlDBTest {
 
-  private Path temporaryFolder;
+  @TempDir
+  protected Path temporaryFolder;
 
   private Injector injector;
   private DSLContext dslContext;

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/persistence/AbstractReconSqlDBTest.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/persistence/AbstractReconSqlDBTest.java
@@ -40,7 +40,6 @@ import org.jooq.impl.DSL;
 import org.jooq.impl.DefaultConfiguration;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.io.TempDir;
 
 import com.google.inject.AbstractModule;
 import com.google.inject.Guice;
@@ -54,7 +53,7 @@ import com.google.inject.Provider;
  */
 public class AbstractReconSqlDBTest {
 
-  public Path temporaryFolder;
+  private Path temporaryFolder;
 
   private Injector injector;
   private DSLContext dslContext;
@@ -62,10 +61,10 @@ public class AbstractReconSqlDBTest {
 
   public AbstractReconSqlDBTest() {
     try {
-      temporaryFolder = Files.createTempDirectory("JunitConfig");//System.getProperty("java.io.tmpdir"));
-      //temporaryFolder.create();
+      temporaryFolder = Files.createTempDirectory("JunitConfig");
       configurationProvider =
-          new DerbyDataSourceConfigurationProvider(Files.createDirectory(temporaryFolder.resolve("Config")).toFile());
+          new DerbyDataSourceConfigurationProvider(Files.createDirectory(
+              temporaryFolder.resolve("Config")).toFile());
     } catch (IOException e) {
       Assertions.fail();
     }
@@ -73,7 +72,7 @@ public class AbstractReconSqlDBTest {
 
   protected AbstractReconSqlDBTest(Provider<DataSourceConfiguration> provider) {
     try {
-      temporaryFolder = Files.createTempDirectory("JunitConfig");//System.getProperty("java.io.tmpdir"));
+      temporaryFolder = Files.createTempDirectory("JunitConfig");
       Files.createDirectory(temporaryFolder.resolve("ConfigProvider"));
       configurationProvider = provider;
     } catch (IOException e) {

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/persistence/AbstractReconSqlDBTest.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/persistence/AbstractReconSqlDBTest.java
@@ -70,7 +70,7 @@ public class AbstractReconSqlDBTest {
   }
 
   protected AbstractReconSqlDBTest(Provider<DataSourceConfiguration> provider) {
-      configurationProvider = provider;
+    configurationProvider = provider;
   }
 
   @BeforeEach

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/persistence/AbstractReconSqlDBTest.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/persistence/AbstractReconSqlDBTest.java
@@ -55,7 +55,7 @@ import org.junit.jupiter.api.io.TempDir;
 public class AbstractReconSqlDBTest {
 
   @TempDir
-  protected Path temporaryFolder;
+  private Path temporaryFolder;
 
   private Injector injector;
   private DSLContext dslContext;

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/persistence/AbstractReconSqlDBTest.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/persistence/AbstractReconSqlDBTest.java
@@ -46,15 +46,12 @@ import com.google.inject.Guice;
 import com.google.inject.Injector;
 import com.google.inject.Module;
 import com.google.inject.Provider;
-import org.junit.jupiter.api.io.TempDir;
 
 /**
  * Class that provides a Recon SQL DB with all the tables created, and APIs
  * to access the DAOs easily.
  */
 public class AbstractReconSqlDBTest {
-
-  @TempDir
   private Path temporaryFolder;
 
   private Injector injector;
@@ -73,13 +70,7 @@ public class AbstractReconSqlDBTest {
   }
 
   protected AbstractReconSqlDBTest(Provider<DataSourceConfiguration> provider) {
-    try {
-      temporaryFolder = Files.createTempDirectory("JunitConfig");
-      Files.createDirectory(temporaryFolder.resolve("ConfigProvider"));
       configurationProvider = provider;
-    } catch (IOException e) {
-      Assertions.fail();
-    }
   }
 
   @BeforeEach

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/persistence/AbstractReconSqlDBTest.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/persistence/AbstractReconSqlDBTest.java
@@ -21,6 +21,8 @@ import static org.hadoop.ozone.recon.codegen.SqlDbUtils.DERBY_DRIVER_CLASS;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.sql.Connection;
 import java.sql.SQLException;
 import java.util.ArrayList;
@@ -36,11 +38,9 @@ import org.jooq.DSLContext;
 import org.jooq.SQLDialect;
 import org.jooq.impl.DSL;
 import org.jooq.impl.DefaultConfiguration;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Rule;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.io.TempDir;
 
 import com.google.inject.AbstractModule;
 import com.google.inject.Guice;
@@ -54,8 +54,7 @@ import com.google.inject.Provider;
  */
 public class AbstractReconSqlDBTest {
 
-  @Rule
-  public TemporaryFolder temporaryFolder = new TemporaryFolder();
+  public Path temporaryFolder;
 
   private Injector injector;
   private DSLContext dslContext;
@@ -63,25 +62,26 @@ public class AbstractReconSqlDBTest {
 
   public AbstractReconSqlDBTest() {
     try {
-      temporaryFolder.create();
+      temporaryFolder = Files.createTempDirectory("JunitConfig");//System.getProperty("java.io.tmpdir"));
+      //temporaryFolder.create();
       configurationProvider =
-          new DerbyDataSourceConfigurationProvider(temporaryFolder.newFolder());
+          new DerbyDataSourceConfigurationProvider(Files.createDirectory(temporaryFolder.resolve("Config")).toFile());
     } catch (IOException e) {
-      Assert.fail();
+      Assertions.fail();
     }
   }
 
   protected AbstractReconSqlDBTest(Provider<DataSourceConfiguration> provider) {
     try {
-      temporaryFolder.create();
+      temporaryFolder = Files.createTempDirectory("JunitConfig");//System.getProperty("java.io.tmpdir"));
+      Files.createDirectory(temporaryFolder.resolve("ConfigProvider"));
       configurationProvider = provider;
     } catch (IOException e) {
-      Assert.fail();
+      Assertions.fail();
     }
   }
 
   @BeforeEach
-  @Before
   public void createReconSchemaForTest() throws IOException {
     injector = Guice.createInjector(getReconSqlDBModules());
     dslContext = DSL.using(new DefaultConfiguration().set(

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/persistence/TestReconWithDifferentSqlDBs.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/persistence/TestReconWithDifferentSqlDBs.java
@@ -17,7 +17,6 @@
 
 package org.apache.hadoop.ozone.recon.persistence;
 
-import static java.util.stream.Collectors.toList;
 import static org.apache.hadoop.ozone.recon.ReconControllerModule.ReconDaoBindingModule.RECON_DAO_LIST;
 import static org.hadoop.ozone.recon.codegen.SqlDbUtils.SQLITE_DRIVER_CLASS;
 import static org.hadoop.ozone.recon.schema.Tables.RECON_TASK_STATUS;
@@ -26,59 +25,58 @@ import static org.junit.Assert.assertNotNull;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.sql.SQLException;
 import java.util.stream.Stream;
 
 import org.hadoop.ozone.recon.schema.tables.daos.ReconTaskStatusDao;
 import org.hadoop.ozone.recon.schema.tables.pojos.ReconTaskStatus;
 import org.jooq.SQLDialect;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import com.google.inject.Provider;
 
 /**
  * Test Recon schema with different DBs.
  */
-@RunWith(Parameterized.class)
-public class TestReconWithDifferentSqlDBs extends AbstractReconSqlDBTest {
-
-  public TestReconWithDifferentSqlDBs(
-      Provider<DataSourceConfiguration> provider) {
-    super(provider);
-  }
-
-  @Parameterized.Parameters(name = "{0}")
-  public static Iterable<Object[]> parameters() throws IOException {
-    TemporaryFolder temporaryFolder = new TemporaryFolder();
-    temporaryFolder.create();
+public class TestReconWithDifferentSqlDBs {
+  @TempDir
+  private static Path temporaryFolder;
+  public static Stream<Object> parametersSource() throws IOException {
     return Stream.of(
-        new DerbyDataSourceConfigurationProvider(temporaryFolder.newFolder()),
-        new SqliteDataSourceConfigurationProvider(temporaryFolder.newFolder()))
-        .map(each -> new Object[] {each})
-        .collect(toList());
+        new AbstractReconSqlDBTest.DerbyDataSourceConfigurationProvider(
+            Files.createDirectory(temporaryFolder.resolve("JunitDerbyDB"))
+                .toFile()),
+        new SqliteDataSourceConfigurationProvider(Files.createDirectory(
+            temporaryFolder.resolve("JunitSQLDS")).toFile()));
   }
 
   /**
    * Make sure schema was created correctly.
    * @throws SQLException
    */
-  @Test
-  public void testSchemaSetup() throws SQLException {
-    assertNotNull(getInjector());
-    assertNotNull(getConfiguration());
-    assertNotNull(getDslContext());
-    assertNotNull(getConnection());
+  @ParameterizedTest
+  @MethodSource("parametersSource")
+  public void testSchemaSetup(Provider<DataSourceConfiguration> provider)
+      throws SQLException, IOException {
+    AbstractReconSqlDBTest reconSqlDB = new AbstractReconSqlDBTest(provider);
+    reconSqlDB.createReconSchemaForTest();
+    assertNotNull(reconSqlDB.getInjector());
+    assertNotNull(reconSqlDB.getConfiguration());
+    assertNotNull(reconSqlDB.getDslContext());
+    assertNotNull(reconSqlDB.getConnection());
     RECON_DAO_LIST.forEach(dao -> {
-      assertNotNull(getDao(dao));
+      assertNotNull(reconSqlDB.getDao(dao));
     });
-    ReconTaskStatusDao dao = getDao(ReconTaskStatusDao.class);
+    ReconTaskStatusDao dao = reconSqlDB.getDao(ReconTaskStatusDao.class);
     dao.insert(new ReconTaskStatus("TestTask", 1L, 2L));
     assertEquals(1, dao.findAll().size());
 
-    int numRows = getDslContext().delete(RECON_TASK_STATUS).execute();
+    int numRows = reconSqlDB.getDslContext().
+        delete(RECON_TASK_STATUS).execute();
     assertEquals(1, numRows);
     assertEquals(0, dao.findAll().size());
   }

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/recovery/TestReconOmMetadataManagerImpl.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/recovery/TestReconOmMetadataManagerImpl.java
@@ -23,6 +23,8 @@ import static org.apache.hadoop.ozone.recon.ReconServerConfigKeys.OZONE_RECON_OM
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 
 import org.apache.commons.io.FileUtils;
 import org.apache.hadoop.hdds.client.StandaloneReplicationConfig;
@@ -37,18 +39,20 @@ import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
 import org.apache.hadoop.ozone.om.helpers.OmVolumeArgs;
 import org.apache.hadoop.hdds.utils.db.DBCheckpoint;
 import org.apache.hadoop.ozone.recon.ReconUtils;
-import org.junit.Assert;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Test Recon OM Metadata Manager implementation.
  */
 public class TestReconOmMetadataManagerImpl {
 
-  @Rule
-  public TemporaryFolder temporaryFolder = new TemporaryFolder();
+  @TempDir
+  private Path temporaryFolder;
 
   @Test
   public void testStart() throws Exception {
@@ -64,7 +68,8 @@ public class TestReconOmMetadataManagerImpl {
     checkpoint.getCheckpointLocation().toFile().renameTo(snapshotFile);
 
     //Create new Recon OM Metadata manager instance.
-    File reconOmDbDir = temporaryFolder.newFolder();
+    File reconOmDbDir = Files.createDirectory(
+        temporaryFolder.resolve("NewDir")).toFile();
     OzoneConfiguration configuration = new OzoneConfiguration();
     configuration.set(OZONE_RECON_OM_SNAPSHOT_DB_DIR, reconOmDbDir
         .getAbsolutePath());
@@ -74,14 +79,14 @@ public class TestReconOmMetadataManagerImpl {
         new ReconOmMetadataManagerImpl(configuration, new ReconUtils());
     reconOMMetadataManager.start(configuration);
 
-    Assert.assertNotNull(reconOMMetadataManager.getBucketTable());
-    Assert.assertNotNull(reconOMMetadataManager.getVolumeTable()
+    assertNotNull(reconOMMetadataManager.getBucketTable());
+    assertNotNull(reconOMMetadataManager.getVolumeTable()
         .get("/sampleVol"));
-    Assert.assertNotNull(reconOMMetadataManager.getBucketTable()
+    assertNotNull(reconOMMetadataManager.getBucketTable()
         .get("/sampleVol/bucketOne"));
-    Assert.assertNotNull(reconOMMetadataManager.getKeyTable(getBucketLayout())
+    assertNotNull(reconOMMetadataManager.getKeyTable(getBucketLayout())
         .get("/sampleVol/bucketOne/key_one"));
-    Assert.assertNotNull(reconOMMetadataManager.getKeyTable(getBucketLayout())
+    assertNotNull(reconOMMetadataManager.getKeyTable(getBucketLayout())
         .get("/sampleVol/bucketOne/key_two"));
   }
 
@@ -90,18 +95,19 @@ public class TestReconOmMetadataManagerImpl {
 
     OMMetadataManager omMetadataManager = getOMMetadataManager();
     //Make sure OM Metadata reflects the keys that were inserted.
-    Assert.assertNotNull(omMetadataManager.getKeyTable(getBucketLayout())
+    assertNotNull(omMetadataManager.getKeyTable(getBucketLayout())
         .get("/sampleVol/bucketOne/key_one"));
-    Assert.assertNotNull(omMetadataManager.getKeyTable(getBucketLayout())
+    assertNotNull(omMetadataManager.getKeyTable(getBucketLayout())
         .get("/sampleVol/bucketOne/key_two"));
 
     //Take checkpoint of OM DB.
     DBCheckpoint checkpoint = omMetadataManager.getStore()
         .getCheckpoint(true);
-    Assert.assertNotNull(checkpoint.getCheckpointLocation());
+    assertNotNull(checkpoint.getCheckpointLocation());
 
     //Create new Recon OM Metadata manager instance.
-    File reconOmDbDir = temporaryFolder.newFolder();
+    File reconOmDbDir = Files.createDirectory(
+        temporaryFolder.resolve("reconOmDbDir")).toFile();
     OzoneConfiguration configuration = new OzoneConfiguration();
     configuration.set(OZONE_RECON_OM_SNAPSHOT_DB_DIR, reconOmDbDir
         .getAbsolutePath());
@@ -110,37 +116,37 @@ public class TestReconOmMetadataManagerImpl {
     reconOMMetadataManager.start(configuration);
 
     //Before accepting a snapshot, the metadata should have null tables.
-    Assert.assertNull(reconOMMetadataManager.getBucketTable());
+    assertNull(reconOMMetadataManager.getBucketTable());
 
     //Update Recon OM DB with the OM DB checkpoint location.
     reconOMMetadataManager.updateOmDB(
         checkpoint.getCheckpointLocation().toFile());
 
     //Now, the tables should have been initialized.
-    Assert.assertNotNull(reconOMMetadataManager.getBucketTable());
+    assertNotNull(reconOMMetadataManager.getBucketTable());
 
     // Check volume and bucket entries.
-    Assert.assertNotNull(reconOMMetadataManager.getVolumeTable()
+    assertNotNull(reconOMMetadataManager.getVolumeTable()
         .get("/sampleVol"));
-    Assert.assertNotNull(reconOMMetadataManager.getBucketTable()
+    assertNotNull(reconOMMetadataManager.getBucketTable()
         .get("/sampleVol/bucketOne"));
 
     //Verify Keys inserted in OM DB are available in Recon OM DB.
-    Assert.assertNotNull(reconOMMetadataManager.getKeyTable(getBucketLayout())
+    assertNotNull(reconOMMetadataManager.getKeyTable(getBucketLayout())
         .get("/sampleVol/bucketOne/key_one"));
-    Assert.assertNotNull(reconOMMetadataManager.getKeyTable(getBucketLayout())
+    assertNotNull(reconOMMetadataManager.getKeyTable(getBucketLayout())
         .get("/sampleVol/bucketOne/key_two"));
 
     //Take a new checkpoint of OM DB.
     DBCheckpoint newCheckpoint = omMetadataManager.getStore()
         .getCheckpoint(true);
-    Assert.assertNotNull(newCheckpoint.getCheckpointLocation());
+    assertNotNull(newCheckpoint.getCheckpointLocation());
     // Update again with an existing OM DB.
     DBStore current = reconOMMetadataManager.getStore();
     reconOMMetadataManager.updateOmDB(
         newCheckpoint.getCheckpointLocation().toFile());
     // Verify that the existing DB instance is closed.
-    Assert.assertTrue(current.isClosed());
+    assertTrue(current.isClosed());
   }
 
   /**
@@ -150,7 +156,8 @@ public class TestReconOmMetadataManagerImpl {
    */
   private OMMetadataManager getOMMetadataManager() throws IOException {
     //Create a new OM Metadata Manager instance + DB.
-    File omDbDir = temporaryFolder.newFolder();
+    File omDbDir = Files.createDirectory(
+        temporaryFolder.resolve("OmMetadataDir")).toFile();
     OzoneConfiguration omConfiguration = new OzoneConfiguration();
     omConfiguration.set(OZONE_OM_DB_DIRS,
         omDbDir.getAbsolutePath());

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/scm/TestReconNodeManager.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/scm/TestReconNodeManager.java
@@ -33,6 +33,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import java.io.IOException;
+import java.nio.file.Path;
 import java.util.List;
 import java.util.UUID;
 
@@ -52,30 +53,28 @@ import org.apache.hadoop.ozone.protocol.commands.ReregisterCommand;
 import org.apache.hadoop.ozone.protocol.commands.SCMCommand;
 import org.apache.hadoop.ozone.protocol.commands.SetNodeOperationalStateCommand;
 import org.apache.hadoop.ozone.recon.ReconUtils;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 /**
  * Tests for Recon Node Manager.
  */
 public class TestReconNodeManager {
 
-  @Rule
-  public TemporaryFolder temporaryFolder = new TemporaryFolder();
+  @TempDir
+  private Path temporaryFolder;
 
   private OzoneConfiguration conf;
   private DBStore store;
   private ReconStorageConfig reconStorageConfig;
   private HDDSLayoutVersionManager versionManager;
 
-  @Before
+  @BeforeEach
   public void setUp() throws Exception {
     conf = new OzoneConfiguration();
-    conf.set(OZONE_METADATA_DIRS,
-        temporaryFolder.newFolder().getAbsolutePath());
+    conf.set(OZONE_METADATA_DIRS, temporaryFolder.toAbsolutePath().toString());
     conf.set(OZONE_SCM_NAMES, "localhost");
     reconStorageConfig = new ReconStorageConfig(conf, new ReconUtils());
     versionManager = new HDDSLayoutVersionManager(
@@ -83,7 +82,7 @@ public class TestReconNodeManager {
     store = DBStoreBuilder.createDBStore(conf, new ReconSCMDBDefinition());
   }
 
-  @After
+  @AfterEach
   public void tearDown() throws Exception {
     store.close();
   }

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/scm/TestReconPipelineManager.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/scm/TestReconPipelineManager.java
@@ -19,6 +19,7 @@
 package org.apache.hadoop.ozone.recon.scm;
 
 import java.io.IOException;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -55,14 +56,14 @@ import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_NAMES;
 import static org.apache.hadoop.hdds.upgrade.HDDSLayoutVersionManager.maxLayoutVersion;
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_METADATA_DIRS;
 import static org.apache.hadoop.ozone.recon.OMMetadataManagerTestUtils.getRandomPipeline;
-import org.junit.After;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 import org.mockito.Mockito;
 
 import static org.mockito.Mockito.mock;
@@ -72,8 +73,8 @@ import static org.mockito.Mockito.mock;
  */
 public class TestReconPipelineManager {
 
-  @Rule
-  public TemporaryFolder temporaryFolder = new TemporaryFolder();
+  @TempDir
+  private Path temporaryFolder;
 
   private OzoneConfiguration conf;
   private SCMStorageConfig scmStorageConfig;
@@ -82,11 +83,11 @@ public class TestReconPipelineManager {
   private SCMHAManager scmhaManager;
   private SCMContext scmContext;
 
-  @Before
+  @BeforeEach
   public void setup() throws IOException {
     conf = new OzoneConfiguration();
     conf.set(OZONE_METADATA_DIRS,
-        temporaryFolder.newFolder().getAbsolutePath());
+        temporaryFolder.toAbsolutePath().toString());
     conf.set(OZONE_SCM_NAMES, "localhost");
     scmStorageConfig = new ReconStorageConfig(conf, new ReconUtils());
     store = DBStoreBuilder.createDBStore(conf, new ReconSCMDBDefinition());
@@ -95,7 +96,7 @@ public class TestReconPipelineManager {
     scmContext = SCMContext.emptyContext();
   }
 
-  @After
+  @AfterEach
   public void tearDown() throws Exception {
     store.close();
   }

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/scm/TestReconPipelineManager.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/scm/TestReconPipelineManager.java
@@ -56,6 +56,7 @@ import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_NAMES;
 import static org.apache.hadoop.hdds.upgrade.HDDSLayoutVersionManager.maxLayoutVersion;
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_METADATA_DIRS;
 import static org.apache.hadoop.ozone.recon.OMMetadataManagerTestUtils.getRandomPipeline;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/spi/impl/TestReconContainerMetadataManagerImpl.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/spi/impl/TestReconContainerMetadataManagerImpl.java
@@ -25,6 +25,8 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -35,20 +37,18 @@ import org.apache.hadoop.ozone.recon.api.types.ContainerMetadata;
 import org.apache.hadoop.ozone.recon.api.types.KeyPrefixContainer;
 import org.apache.hadoop.ozone.recon.recovery.ReconOMMetadataManager;
 import org.apache.hadoop.ozone.recon.spi.ReconContainerMetadataManager;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.ClassRule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 /**
  * Unit Tests for ContainerDBServiceProviderImpl.
  */
 public class TestReconContainerMetadataManagerImpl {
 
-  @ClassRule
-  public static final TemporaryFolder TEMP_FOLDER = new TemporaryFolder();
+  @TempDir()
+  private static Path TEMP_FOLDER;
   private static ReconContainerMetadataManager reconContainerMetadataManager;
   private static ReconOMMetadataManager reconOMMetadataManager;
 
@@ -56,13 +56,14 @@ public class TestReconContainerMetadataManagerImpl {
   private String keyPrefix2 = "V3/B1/K2";
   private String keyPrefix3 = "V3/B2/K1";
 
-  @BeforeClass
+  @BeforeAll
   public static void setupOnce() throws Exception {
     reconOMMetadataManager = getTestReconOmMetadataManager(
-        initializeNewOmMetadataManager(TEMP_FOLDER.newFolder()),
-        TEMP_FOLDER.newFolder());
+        initializeNewOmMetadataManager(Files.createDirectory(
+            TEMP_FOLDER.resolve("JunitOmDBDir")).toFile()),
+        Files.createDirectory(TEMP_FOLDER.resolve("NewDir")).toFile());
     ReconTestInjector reconTestInjector =
-        new ReconTestInjector.Builder(TEMP_FOLDER)
+        new ReconTestInjector.Builder(TEMP_FOLDER.toFile())
             .withReconSqlDb()
             .withContainerDB()
             .withReconOm(reconOMMetadataManager)
@@ -71,7 +72,7 @@ public class TestReconContainerMetadataManagerImpl {
         reconTestInjector.getInstance(ReconContainerMetadataManager.class);
   }
 
-  @Before
+  @BeforeEach
   public void setUp() throws Exception {
     // Reset containerDB before running each test
     reconContainerMetadataManager.reinitWithNewContainerDataFromOm(null);
@@ -174,15 +175,15 @@ public class TestReconContainerMetadataManagerImpl {
     }
     reconContainerMetadataManager.commitBatchOperation(rdbBatchOperation);
 
-    Assert.assertEquals(1,
+    assertEquals(1,
         reconContainerMetadataManager.getCountForContainerKeyPrefix(
             ContainerKeyPrefix.get(containerId, keyPrefix1,
                 0)).longValue());
-    Assert.assertEquals(2,
+    assertEquals(2,
         reconContainerMetadataManager.getCountForContainerKeyPrefix(
             ContainerKeyPrefix.get(containerId, keyPrefix2,
                 0)).longValue());
-    Assert.assertEquals(3,
+    assertEquals(3,
         reconContainerMetadataManager.getCountForContainerKeyPrefix(
             ContainerKeyPrefix.get(containerId, keyPrefix3,
                 0)).longValue());

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/spi/impl/TestReconContainerMetadataManagerImpl.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/spi/impl/TestReconContainerMetadataManagerImpl.java
@@ -20,10 +20,10 @@ package org.apache.hadoop.ozone.recon.spi.impl;
 
 import static org.apache.hadoop.ozone.recon.OMMetadataManagerTestUtils.getTestReconOmMetadataManager;
 import static org.apache.hadoop.ozone.recon.OMMetadataManagerTestUtils.initializeNewOmMetadataManager;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.nio.file.Files;
 import java.nio.file.Path;

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/spi/impl/TestReconContainerMetadataManagerImpl.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/spi/impl/TestReconContainerMetadataManagerImpl.java
@@ -48,7 +48,7 @@ import org.junit.jupiter.api.io.TempDir;
 public class TestReconContainerMetadataManagerImpl {
 
   @TempDir()
-  private static Path TEMP_FOLDER;
+  private static Path temporaryFolder;
   private static ReconContainerMetadataManager reconContainerMetadataManager;
   private static ReconOMMetadataManager reconOMMetadataManager;
 
@@ -60,10 +60,10 @@ public class TestReconContainerMetadataManagerImpl {
   public static void setupOnce() throws Exception {
     reconOMMetadataManager = getTestReconOmMetadataManager(
         initializeNewOmMetadataManager(Files.createDirectory(
-            TEMP_FOLDER.resolve("JunitOmDBDir")).toFile()),
-        Files.createDirectory(TEMP_FOLDER.resolve("NewDir")).toFile());
+            temporaryFolder.resolve("JunitOmDBDir")).toFile()),
+        Files.createDirectory(temporaryFolder.resolve("NewDir")).toFile());
     ReconTestInjector reconTestInjector =
-        new ReconTestInjector.Builder(TEMP_FOLDER.toFile())
+        new ReconTestInjector.Builder(temporaryFolder.toFile())
             .withReconSqlDb()
             .withContainerDB()
             .withReconOm(reconOMMetadataManager)

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/spi/impl/TestReconDBProvider.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/spi/impl/TestReconDBProvider.java
@@ -48,7 +48,6 @@ public class TestReconDBProvider {
 
   @BeforeEach
   public void setUp() throws IOException {
-    //tempFolder.create();
     injector = Guice.createInjector(new AbstractModule() {
       @Override
       protected void configure() {

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/spi/impl/TestReconDBProvider.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/spi/impl/TestReconDBProvider.java
@@ -23,12 +23,12 @@ import static org.junit.Assert.assertNotNull;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Path;
 
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.io.TempDir;
 
 import com.google.inject.AbstractModule;
 import com.google.inject.Guice;
@@ -41,18 +41,18 @@ import com.google.inject.Singleton;
  */
 public class TestReconDBProvider {
 
-  @Rule
-  public TemporaryFolder tempFolder = new TemporaryFolder();
+  @TempDir
+  private Path temporaryFolder;
 
   private Injector injector;
 
-  @Before
+  @BeforeEach
   public void setUp() throws IOException {
-    tempFolder.create();
+    //tempFolder.create();
     injector = Guice.createInjector(new AbstractModule() {
       @Override
       protected void configure() {
-        File dbDir = tempFolder.getRoot();
+        File dbDir = temporaryFolder.toFile();
         OzoneConfiguration configuration = new OzoneConfiguration();
         configuration.set(OZONE_RECON_DB_DIR, dbDir.getAbsolutePath());
         bind(OzoneConfiguration.class).toInstance(configuration);

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/spi/impl/TestReconNamespaceSummaryManagerImpl.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/spi/impl/TestReconNamespaceSummaryManagerImpl.java
@@ -45,7 +45,7 @@ import static org.apache.hadoop.ozone.recon.OMMetadataManagerTestUtils.initializ
  */
 public class TestReconNamespaceSummaryManagerImpl {
   @TempDir()
-  private static Path TEMP_FOLDER;
+  private static Path temporaryFolder;
   private static ReconNamespaceSummaryManagerImpl reconNamespaceSummaryManager;
   private static ReconOMMetadataManager reconOMMetadataManager;
   private static int[] testBucket;
@@ -56,10 +56,10 @@ public class TestReconNamespaceSummaryManagerImpl {
   public static void setupOnce() throws Exception {
     reconOMMetadataManager = getTestReconOmMetadataManager(
         initializeNewOmMetadataManager(Files.createDirectory(
-            TEMP_FOLDER.resolve("JunitOmDBDir")).toFile()),
-        Files.createDirectory(TEMP_FOLDER.resolve("NewDir")).toFile());
+            temporaryFolder.resolve("JunitOmDBDir")).toFile()),
+        Files.createDirectory(temporaryFolder.resolve("NewDir")).toFile());
     ReconTestInjector reconTestInjector =
-            new ReconTestInjector.Builder(TEMP_FOLDER.toFile())
+            new ReconTestInjector.Builder(temporaryFolder.toFile())
                     .withReconSqlDb()
                     .withReconOm(reconOMMetadataManager)
                     .withContainerDB()

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/spi/impl/TestReconNamespaceSummaryManagerImpl.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/spi/impl/TestReconNamespaceSummaryManagerImpl.java
@@ -22,14 +22,15 @@ import org.apache.hadoop.hdds.utils.db.RDBBatchOperation;
 import org.apache.hadoop.ozone.recon.ReconTestInjector;
 import org.apache.hadoop.ozone.recon.api.types.NSSummary;
 import org.apache.hadoop.ozone.recon.recovery.ReconOMMetadataManager;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.ClassRule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -43,21 +44,22 @@ import static org.apache.hadoop.ozone.recon.OMMetadataManagerTestUtils.initializ
  * Test for NSSummary manager.
  */
 public class TestReconNamespaceSummaryManagerImpl {
-  @ClassRule
-  public static final TemporaryFolder TEMP_FOLDER = new TemporaryFolder();
+  @TempDir()
+  private static Path TEMP_FOLDER;
   private static ReconNamespaceSummaryManagerImpl reconNamespaceSummaryManager;
   private static ReconOMMetadataManager reconOMMetadataManager;
   private static int[] testBucket;
   private static final Set<Long> TEST_CHILD_DIR =
           new HashSet<>(Arrays.asList(new Long[]{1L, 2L, 3L}));
 
-  @BeforeClass
+  @BeforeAll
   public static void setupOnce() throws Exception {
     reconOMMetadataManager = getTestReconOmMetadataManager(
-        initializeNewOmMetadataManager(TEMP_FOLDER.newFolder()),
-        TEMP_FOLDER.newFolder());
+        initializeNewOmMetadataManager(Files.createDirectory(
+            TEMP_FOLDER.resolve("JunitOmDBDir")).toFile()),
+        Files.createDirectory(TEMP_FOLDER.resolve("NewDir")).toFile());
     ReconTestInjector reconTestInjector =
-            new ReconTestInjector.Builder(TEMP_FOLDER)
+            new ReconTestInjector.Builder(TEMP_FOLDER.toFile())
                     .withReconSqlDb()
                     .withReconOm(reconOMMetadataManager)
                     .withContainerDB()
@@ -70,7 +72,7 @@ public class TestReconNamespaceSummaryManagerImpl {
     }
   }
 
-  @Before
+  @BeforeEach
   public void setUp() throws Exception {
     // Clear namespace table before running each test
     reconNamespaceSummaryManager.clearNSSummaryTable();
@@ -82,30 +84,30 @@ public class TestReconNamespaceSummaryManagerImpl {
     NSSummary summary = reconNamespaceSummaryManager.getNSSummary(1L);
     NSSummary summary2 = reconNamespaceSummaryManager.getNSSummary(2L);
     NSSummary summary3 = reconNamespaceSummaryManager.getNSSummary(3L);
-    Assert.assertEquals(1, summary.getNumOfFiles());
-    Assert.assertEquals(2, summary.getSizeOfFiles());
-    Assert.assertEquals(3, summary2.getNumOfFiles());
-    Assert.assertEquals(4, summary2.getSizeOfFiles());
-    Assert.assertEquals(5, summary3.getNumOfFiles());
-    Assert.assertEquals(6, summary3.getSizeOfFiles());
+    Assertions.assertEquals(1, summary.getNumOfFiles());
+    Assertions.assertEquals(2, summary.getSizeOfFiles());
+    Assertions.assertEquals(3, summary2.getNumOfFiles());
+    Assertions.assertEquals(4, summary2.getSizeOfFiles());
+    Assertions.assertEquals(5, summary3.getNumOfFiles());
+    Assertions.assertEquals(6, summary3.getSizeOfFiles());
 
-    Assert.assertEquals("dir1", summary.getDirName());
-    Assert.assertEquals("dir2", summary2.getDirName());
-    Assert.assertEquals("dir3", summary3.getDirName());
+    Assertions.assertEquals("dir1", summary.getDirName());
+    Assertions.assertEquals("dir2", summary2.getDirName());
+    Assertions.assertEquals("dir3", summary3.getDirName());
 
     // test child dir is written
-    Assert.assertEquals(3, summary.getChildDir().size());
+    Assertions.assertEquals(3, summary.getChildDir().size());
     // non-existent key
-    Assert.assertNull(reconNamespaceSummaryManager.getNSSummary(0L));
+    Assertions.assertNull(reconNamespaceSummaryManager.getNSSummary(0L));
   }
 
   @Test
   public void testInitNSSummaryTable() throws IOException {
     putThreeNSMetadata();
-    Assert.assertFalse(
+    Assertions.assertFalse(
             reconNamespaceSummaryManager.getNSSummaryTable().isEmpty());
     reconNamespaceSummaryManager.clearNSSummaryTable();
-    Assert.assertTrue(
+    Assertions.assertTrue(
             reconNamespaceSummaryManager.getNSSummaryTable().isEmpty());
   }
 

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/tasks/TestContainerKeyMapperTask.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/tasks/TestContainerKeyMapperTask.java
@@ -25,10 +25,12 @@ import static org.apache.hadoop.ozone.recon.OMMetadataManagerTestUtils.getRandom
 import static org.apache.hadoop.ozone.recon.OMMetadataManagerTestUtils.getTestReconOmMetadataManager;
 import static org.apache.hadoop.ozone.recon.OMMetadataManagerTestUtils.initializeNewOmMetadataManager;
 import static org.apache.hadoop.ozone.recon.OMMetadataManagerTestUtils.writeDataToOm;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
+import java.nio.file.Path;
 import java.util.Iterator;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -50,18 +52,17 @@ import org.apache.hadoop.ozone.recon.api.types.ContainerKeyPrefix;
 import org.apache.hadoop.ozone.recon.recovery.ReconOMMetadataManager;
 import org.apache.hadoop.ozone.recon.spi.ReconContainerMetadataManager;
 import org.apache.hadoop.ozone.recon.spi.impl.OzoneManagerServiceProviderImpl;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 /**
  * Unit test for Container Key mapper task.
  */
 public class TestContainerKeyMapperTask {
 
-  @Rule
-  public TemporaryFolder temporaryFolder = new TemporaryFolder();
+  @TempDir
+  private Path temporaryFolder;
 
   private ReconContainerMetadataManager reconContainerMetadataManager;
   private OMMetadataManager omMetadataManager;
@@ -80,17 +81,17 @@ public class TestContainerKeyMapperTask {
   private static final long VOL_OBJECT_ID = 0L;
   private static final long KEY_ONE_SIZE = 500L; // 500 bytes
 
-  @Before
+  @BeforeEach
   public void setUp() throws Exception {
     omMetadataManager = initializeNewOmMetadataManager(
-        temporaryFolder.newFolder());
+        temporaryFolder.resolve("JunitOmDBDir").toFile());
     ozoneManagerServiceProvider = getMockOzoneManagerServiceProvider();
     reconOMMetadataManager = getTestReconOmMetadataManager(omMetadataManager,
-        temporaryFolder.newFolder());
+        temporaryFolder.resolve("JunitOmMetadataDir").toFile());
     omConfiguration = new OzoneConfiguration();
 
     ReconTestInjector reconTestInjector =
-        new ReconTestInjector.Builder(temporaryFolder)
+        new ReconTestInjector.Builder(temporaryFolder.toFile())
             .withReconSqlDb()
             .withReconOm(reconOMMetadataManager)
             .withOmServiceProvider(ozoneManagerServiceProvider)

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/tasks/TestOMDBUpdatesHandler.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/tasks/TestOMDBUpdatesHandler.java
@@ -69,7 +69,8 @@ public class TestOMDBUpdatesHandler {
   private OMDBDefinition omdbDefinition = new OMDBDefinition();
   private Random random = new Random();
 
-  private OzoneConfiguration createNewTestPath(String folderName) throws IOException {
+  private OzoneConfiguration createNewTestPath(String folderName)
+      throws IOException {
     OzoneConfiguration configuration = new OzoneConfiguration();
     Path tempDirPath =
         Files.createDirectory(temporaryFolder.resolve(folderName));

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/tasks/TestOMDBUpdatesHandler.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/tasks/TestOMDBUpdatesHandler.java
@@ -21,13 +21,13 @@ package org.apache.hadoop.ozone.recon.tasks;
 import static org.apache.hadoop.ozone.recon.tasks.OMDBUpdateEvent.OMDBUpdateAction.PUT;
 import static org.apache.hadoop.ozone.recon.tasks.OMDBUpdateEvent.OMDBUpdateAction.UPDATE;
 import static org.apache.hadoop.ozone.recon.tasks.OMDBUpdateEvent.OMDBUpdateAction.DELETE;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
-import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Random;
@@ -49,10 +49,9 @@ import org.apache.hadoop.ozone.om.helpers.OmVolumeArgs;
 import org.apache.hadoop.hdds.utils.db.RDBStore;
 import org.apache.hadoop.ozone.security.OzoneTokenIdentifier;
 import org.jetbrains.annotations.NotNull;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 import org.rocksdb.RocksDBException;
 import org.rocksdb.TransactionLogIterator;
 import org.rocksdb.WriteBatch;
@@ -62,30 +61,28 @@ import org.rocksdb.WriteBatch;
  */
 public class TestOMDBUpdatesHandler {
 
-  @Rule
-  public TemporaryFolder folder = new TemporaryFolder();
+  @TempDir
+  private Path temporaryFolder;
 
   private OMMetadataManager omMetadataManager;
   private OMMetadataManager reconOmMetadataManager;
   private OMDBDefinition omdbDefinition = new OMDBDefinition();
   private Random random = new Random();
 
-  private OzoneConfiguration createNewTestPath() throws IOException {
+  private OzoneConfiguration createNewTestPath(String folderName) throws IOException {
     OzoneConfiguration configuration = new OzoneConfiguration();
-    File newFolder = folder.newFolder();
-    if (!newFolder.exists()) {
-      assertTrue(newFolder.mkdirs());
-    }
-    ServerUtils.setOzoneMetaDirPath(configuration, newFolder.toString());
+    Path tempDirPath =
+        Files.createDirectory(temporaryFolder.resolve(folderName));
+    ServerUtils.setOzoneMetaDirPath(configuration, tempDirPath.toString());
     return configuration;
   }
 
-  @Before
+  @BeforeEach
   public void setUp() throws Exception {
-    OzoneConfiguration configuration = createNewTestPath();
+    OzoneConfiguration configuration = createNewTestPath("config");
     omMetadataManager = new OmMetadataManagerImpl(configuration, null);
 
-    OzoneConfiguration reconConfiguration = createNewTestPath();
+    OzoneConfiguration reconConfiguration = createNewTestPath("reconConfig");
     reconOmMetadataManager = new OmMetadataManagerImpl(reconConfiguration,
         null);
   }

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/tasks/TestOmTableInsightTask.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/tasks/TestOmTableInsightTask.java
@@ -35,9 +35,11 @@ import org.hadoop.ozone.recon.schema.tables.daos.GlobalStatsDao;
 import org.jooq.DSLContext;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 import java.io.IOException;
 import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -67,7 +69,8 @@ import static org.mockito.Mockito.when;
  * Unit test for Object Count Task.
  */
 public class TestOmTableInsightTask extends AbstractReconSqlDBTest {
-
+  @TempDir
+  private Path temporaryFolder;
   private GlobalStatsDao globalStatsDao;
   private OmTableInsightTask omTableInsightTask;
   private DSLContext dslContext;

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/tasks/TestOmTableInsightTask.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/tasks/TestOmTableInsightTask.java
@@ -37,6 +37,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
+import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -75,8 +76,9 @@ public class TestOmTableInsightTask extends AbstractReconSqlDBTest {
 
   private void initializeInjector() throws IOException {
     reconOMMetadataManager = getTestReconOmMetadataManager(
-        initializeNewOmMetadataManager(temporaryFolder.newFolder()),
-        temporaryFolder.newFolder());
+        initializeNewOmMetadataManager(Files.createDirectory(
+            temporaryFolder.resolve("JunitOmDBDir")).toFile()),
+        Files.createDirectory(temporaryFolder.resolve("NewDir")).toFile());
     globalStatsDao = getDao(GlobalStatsDao.class);
     omTableInsightTask = new OmTableInsightTask(
         globalStatsDao, getConfiguration(), reconOMMetadataManager);

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/tasks/TestOmUpdateEventValidator.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/tasks/TestOmUpdateEventValidator.java
@@ -26,21 +26,21 @@ import org.apache.hadoop.ozone.om.helpers.RepeatedOmKeyInfo;
 import org.apache.hadoop.ozone.om.helpers.OmPrefixInfo;
 import org.apache.hadoop.ozone.om.helpers.SnapshotInfo;
 import org.apache.hadoop.ozone.om.helpers.BucketLayout;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 import org.slf4j.Logger;
 
 import java.io.IOException;
+import java.nio.file.Path;
 import java.util.List;
 
 import static org.apache.hadoop.ozone.recon.OMMetadataManagerTestUtils.initializeNewOmMetadataManager;
 import static org.apache.hadoop.ozone.recon.tasks.OMDBUpdateEvent.OMDBUpdateAction.PUT;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.times;
@@ -54,13 +54,13 @@ public class TestOmUpdateEventValidator {
   private OMDBDefinition omdbDefinition;
   private OMMetadataManager omMetadataManager;
   private Logger logger;
-  @Rule
-  public TemporaryFolder temporaryFolder = new TemporaryFolder();
+  @TempDir
+  private Path temporaryFolder;
 
-  @Before
+  @BeforeEach
   public void setUp() throws IOException {
     omMetadataManager = initializeNewOmMetadataManager(
-        temporaryFolder.newFolder());
+        temporaryFolder.toFile());
     omdbDefinition = new OMDBDefinition();
     eventValidator = new OmUpdateEventValidator(omdbDefinition);
     // Create a mock logger
@@ -138,7 +138,7 @@ public class TestOmUpdateEventValidator {
     // Assert that the captured log messages are not empty
     List<String> logMessages = captor.getAllValues();
     for (String logMessage : logMessages) {
-      assertFalse("Warning message is empty", logMessage.isEmpty());
+      assertFalse(logMessage.isEmpty(), "Warning message is empty");
     }
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?
Migrate the following test classes to JUnit5.

Please describe your PR in detail:
Migrate the following test classes to JUnit5. See parent task for details.
- As a first batch modified following files.
hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/TestReconUtils.java
hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/api/TestBlocksEndPoint.java
hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/api/TestContainerEndpoint.java
hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/api/TestFeaturesEndPoint.java
hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/api/TestNSSummaryEndpointWithFSO.java
hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/api/TestNSSummaryEndpointWithLegacy.java
hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/api/TestOmDBInsightEndPoint.java
hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/api/TestOpenContainerCount.java
hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/api/TestTriggerDBSyncEndpoint.java
hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/heatmap/TestHeatMapInfo.java
hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/recovery/TestReconOmMetadataManagerImpl.java
hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/scm/TestReconNodeManager.java
hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/scm/TestReconPipelineManager.java
hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/spi/impl/TestOzoneManagerServiceProviderImpl.java
hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/spi/impl/TestReconContainerMetadataManagerImpl.java
hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/spi/impl/TestReconDBProvider.java
hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/spi/impl/TestReconNamespaceSummaryManagerImpl.java
hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/tasks/TestContainerKeyMapperTask.java
hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/tasks/TestOMDBUpdatesHandler.java
hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/tasks/TestOmUpdateEventValidator.java
hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/api/TestOmDBInsightEndPoint.java


- When making the changes for `TestContainerStateCounts` which extends `AbstractReconSqlDBTest`. so covered some sub-clasess as well.
hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/api/TestContainerStateCounts.java
hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/api/TestEndpoints.java
hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/tasks/TestOmTableInsightTask.java 
-Once these are reviewed will cover the rest of classes in second batch in another PR.

- In AbstractReconSqlDBTest I modified the access modifier to protected instead of public earlier.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-9498 

## How was this patch tested?
Tested this patch by manual tests
