### PR TITLE
HDDS-9496. Migrate tests in ozone-manager to Junit5

### DIFF
--- a/hadoop-ozone/ozone-manager/pom.xml
+++ b/hadoop-ozone/ozone-manager/pom.xml
@@ -28,6 +28,10 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <name>Apache Ozone Manager Server</name>
   <packaging>jar</packaging>
 
+  <properties>
+    <allow.junit4>false</allow.junit4>
+  </properties>
+
   <dependencies>
 
     <dependency>

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestBucketManagerImpl.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestBucketManagerImpl.java
@@ -55,6 +55,9 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import static java.util.Collections.singletonMap;
 
+/**
+ * This class tests the Bucket Manager Implementation using Mockito.
+ */
 @ExtendWith(MockitoExtension.class)
 public class TestBucketManagerImpl {
 

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestBucketManagerImpl.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestBucketManagerImpl.java
@@ -188,7 +188,7 @@ public class TestBucketManagerImpl {
       BucketManager bucketManager = omTestManagers.getBucketManager();
       bucketManager.getBucketInfo("sample-vol", "bucket-one");
     });
-    Assertions.assertEquals("Bucket not found", exception.getMessage());
+    Assertions.assertTrue(exception.getMessage().contains("Bucket not found"));
     Assertions.assertEquals(ResultCodes.BUCKET_NOT_FOUND,
         exception.getResult());
   }
@@ -333,7 +333,7 @@ public class TestBucketManagerImpl {
     });
     Assertions.assertEquals(ResultCodes.BUCKET_NOT_FOUND,
           omEx.getResult());
-    Assertions.assertEquals("Bucket not found", omEx.getMessage());
+    Assertions.assertTrue(omEx.getMessage().contains("Bucket not found"));
   }
 
   @Test

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestBucketManagerImpl.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestBucketManagerImpl.java
@@ -18,6 +18,7 @@ package org.apache.hadoop.ozone.om;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collections;
 
@@ -43,44 +44,37 @@ import org.apache.hadoop.ozone.om.helpers.BucketLayout;
 import org.apache.hadoop.ozone.om.protocol.OzoneManagerProtocol;
 import org.apache.hadoop.ozone.om.request.OMRequestTestUtils;
 import org.apache.hadoop.security.authentication.client.AuthenticationException;
-import org.junit.Assert;
-import org.junit.After;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
-import org.junit.rules.TemporaryFolder;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
+
 import org.mockito.Mockito;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import static java.util.Collections.singletonMap;
 
-/**
- * Tests BucketManagerImpl, mocks OMMetadataManager for testing.
- */
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class TestBucketManagerImpl {
-  @Rule
-  public ExpectedException thrown = ExpectedException.none();
 
-  @Rule
-  public TemporaryFolder folder = new TemporaryFolder();
+  @TempDir
+  private Path folder;
 
   private OmTestManagers omTestManagers;
   private OzoneManagerProtocol writeClient;
-  private OzoneManager om;
 
-  @After
+  @AfterEach
   public void cleanup() throws Exception {
-    om = omTestManagers.getOzoneManager();
+    OzoneManager om = omTestManagers.getOzoneManager();
     om.stop();
   }
 
   private OzoneConfiguration createNewTestPath() throws IOException {
     OzoneConfiguration conf = new OzoneConfiguration();
-    File newFolder = folder.newFolder();
+    File newFolder = folder.toFile();
     if (!newFolder.exists()) {
-      Assert.assertTrue(newFolder.mkdirs());
+      Assertions.assertTrue(newFolder.mkdirs());
     }
     ServerUtils.setOzoneMetaDirPath(conf, newFolder.toString());
     return conf;
@@ -104,10 +98,9 @@ public class TestBucketManagerImpl {
 
   @Test
   public void testCreateBucketWithoutVolume() throws Exception {
-    thrown.expectMessage("Volume doesn't exist");
     OzoneConfiguration conf = createNewTestPath();
     omTestManagers = new OmTestManagers(conf);
-    try {
+    OMException omEx = Assertions.assertThrows(OMException.class, () -> {
       writeClient = omTestManagers.getWriteClient();
 
       OmBucketInfo bucketInfo = OmBucketInfo.newBuilder()
@@ -115,11 +108,10 @@ public class TestBucketManagerImpl {
           .setBucketName("bucket-one")
           .build();
       writeClient.createBucket(bucketInfo);
-    } catch (OMException omEx) {
-      Assert.assertEquals(ResultCodes.VOLUME_NOT_FOUND,
+    });
+    Assertions.assertEquals(ResultCodes.VOLUME_NOT_FOUND,
           omEx.getResult());
-      throw omEx;
-    }
+    Assertions.assertEquals("Volume doesn't exist", omEx.getMessage());
   }
 
   @Test
@@ -144,14 +136,14 @@ public class TestBucketManagerImpl {
             BucketEncryptionKeyInfo.Builder().setKeyName("key1").build())
         .build();
     writeClient.createBucket(bucketInfo);
-    Assert.assertNotNull(bucketManager.getBucketInfo("sample-vol",
+    Assertions.assertNotNull(bucketManager.getBucketInfo("sample-vol",
         "bucket-one"));
 
     OmBucketInfo bucketInfoRead =
         bucketManager.getBucketInfo("sample-vol", "bucket-one");
 
-    Assert.assertTrue(bucketInfoRead.getEncryptionKeyInfo().getKeyName()
-        .equals(bucketInfo.getEncryptionKeyInfo().getKeyName()));
+    Assertions.assertEquals(bucketInfoRead.getEncryptionKeyInfo().getKeyName(),
+        bucketInfo.getEncryptionKeyInfo().getKeyName());
   }
 
 
@@ -165,43 +157,37 @@ public class TestBucketManagerImpl {
         .setBucketName("bucket-one")
         .build();
     writeClient.createBucket(bucketInfo);
-    Assert.assertNotNull(bucketManager.getBucketInfo("sample-vol",
+    Assertions.assertNotNull(bucketManager.getBucketInfo("sample-vol",
         "bucket-one"));
   }
 
   @Test
   public void testCreateAlreadyExistingBucket() throws Exception {
-    thrown.expectMessage("Bucket already exist");
     createSampleVol();
 
-    try {
+    OMException omEx = Assertions.assertThrows(OMException.class, () -> {
       OmBucketInfo bucketInfo = OmBucketInfo.newBuilder()
           .setVolumeName("sample-vol")
           .setBucketName("bucket-one")
           .build();
       writeClient.createBucket(bucketInfo);
       writeClient.createBucket(bucketInfo);
-    } catch (OMException omEx) {
-      Assert.assertEquals(ResultCodes.BUCKET_ALREADY_EXISTS,
+    });
+    Assertions.assertEquals(ResultCodes.BUCKET_ALREADY_EXISTS,
           omEx.getResult());
-      throw omEx;
-    }
+    Assertions.assertEquals("Bucket already exist", omEx.getMessage());
   }
 
   @Test
   public void testGetBucketInfoForInvalidBucket() throws Exception {
-    thrown.expectMessage("Bucket not found");
-
     createSampleVol();
-    try {
-
+    OMException exception = Assertions.assertThrows(OMException.class, () -> {
       BucketManager bucketManager = omTestManagers.getBucketManager();
       bucketManager.getBucketInfo("sample-vol", "bucket-one");
-    } catch (OMException omEx) {
-      Assert.assertEquals(ResultCodes.BUCKET_NOT_FOUND,
-          omEx.getResult());
-      throw omEx;
-    }
+    });
+    Assertions.assertEquals("Bucket not found", exception.getMessage());
+    Assertions.assertEquals(ResultCodes.BUCKET_NOT_FOUND,
+        exception.getResult());
   }
 
   @Test
@@ -218,11 +204,11 @@ public class TestBucketManagerImpl {
     // Check exception thrown when volume does not exist
     try {
       bucketManager.getBucketInfo(volumeName, bucketName);
-      Assert.fail("Should have thrown OMException");
+      Assertions.fail("Should have thrown OMException");
     } catch (OMException omEx) {
-      Assert.assertEquals("getBucketInfo() should have thrown " +
-              "VOLUME_NOT_FOUND as the parent volume is not created!",
-          ResultCodes.VOLUME_NOT_FOUND, omEx.getResult());
+      Assertions.assertEquals(ResultCodes.VOLUME_NOT_FOUND, omEx.getResult(),
+          "getBucketInfo() should have thrown " +
+              "VOLUME_NOT_FOUND as the parent volume is not created!");
     }
     OmBucketInfo bucketInfo = OmBucketInfo.newBuilder()
         .setVolumeName(volumeName)
@@ -244,17 +230,18 @@ public class TestBucketManagerImpl {
     // Check exception thrown when bucket does not exist
     try {
       bucketManager.getBucketInfo(volumeName, "bucketNotExist");
-      Assert.fail("Should have thrown OMException");
+      Assertions.fail("Should have thrown OMException");
     } catch (OMException omEx) {
-      Assert.assertEquals("getBucketInfo() should have thrown " +
-              "BUCKET_NOT_FOUND as the parent volume exists but bucket " +
-              "doesn't!", ResultCodes.BUCKET_NOT_FOUND, omEx.getResult());
+      Assertions.assertEquals(
+          ResultCodes.BUCKET_NOT_FOUND, omEx.getResult(),
+          "getBucketInfo() should have thrown BUCKET_NOT_FOUND " +
+              "as the parent volume exists but bucket doesn't!");
     }
     OmBucketInfo result = bucketManager.getBucketInfo(volumeName, bucketName);
-    Assert.assertEquals(volumeName, result.getVolumeName());
-    Assert.assertEquals(bucketName, result.getBucketName());
-    Assert.assertEquals(StorageType.DISK, result.getStorageType());
-    Assert.assertFalse(result.getIsVersionEnabled());
+    Assertions.assertEquals(volumeName, result.getVolumeName());
+    Assertions.assertEquals(bucketName, result.getBucketName());
+    Assertions.assertEquals(StorageType.DISK, result.getStorageType());
+    Assertions.assertFalse(result.getIsVersionEnabled());
   }
 
   private void createBucket(OMMetadataManager metadataManager,
@@ -276,7 +263,7 @@ public class TestBucketManagerImpl {
     createBucket(metaMgr, bucketInfo);
     OmBucketInfo result = bucketManager.getBucketInfo(
         "sample-vol", "bucket-one");
-    Assert.assertEquals(StorageType.DISK,
+    Assertions.assertEquals(StorageType.DISK,
         result.getStorageType());
     OmBucketArgs bucketArgs = OmBucketArgs.newBuilder()
         .setVolumeName("sample-vol")
@@ -286,7 +273,7 @@ public class TestBucketManagerImpl {
     writeClient.setBucketProperty(bucketArgs);
     OmBucketInfo updatedResult = bucketManager.getBucketInfo(
         "sample-vol", "bucket-one");
-    Assert.assertEquals(StorageType.SSD,
+    Assertions.assertEquals(StorageType.SSD,
         updatedResult.getStorageType());
   }
 
@@ -303,7 +290,7 @@ public class TestBucketManagerImpl {
     writeClient.createBucket(bucketInfo);
     OmBucketInfo result = bucketManager.getBucketInfo(
         "sample-vol", "bucket-one");
-    Assert.assertFalse(result.getIsVersionEnabled());
+    Assertions.assertFalse(result.getIsVersionEnabled());
     OmBucketArgs bucketArgs = OmBucketArgs.newBuilder()
         .setVolumeName("sample-vol")
         .setBucketName("bucket-one")
@@ -312,12 +299,11 @@ public class TestBucketManagerImpl {
     writeClient.setBucketProperty(bucketArgs);
     OmBucketInfo updatedResult = bucketManager.getBucketInfo(
         "sample-vol", "bucket-one");
-    Assert.assertTrue(updatedResult.getIsVersionEnabled());
+    Assertions.assertTrue(updatedResult.getIsVersionEnabled());
   }
 
   @Test
   public void testDeleteBucket() throws Exception {
-    thrown.expectMessage("Bucket not found");
     createSampleVol();
     BucketManager bucketManager = omTestManagers.getBucketManager();
     for (int i = 0; i < 5; i++) {
@@ -328,29 +314,27 @@ public class TestBucketManagerImpl {
       writeClient.createBucket(bucketInfo);
     }
     for (int i = 0; i < 5; i++) {
-      Assert.assertEquals("bucket-" + i,
+      Assertions.assertEquals("bucket-" + i,
           bucketManager.getBucketInfo(
               "sample-vol", "bucket-" + i).getBucketName());
     }
     try {
       writeClient.deleteBucket("sample-vol", "bucket-1");
-      Assert.assertNotNull(bucketManager.getBucketInfo(
+      Assertions.assertNotNull(bucketManager.getBucketInfo(
           "sample-vol", "bucket-2"));
     } catch (IOException ex) {
-      Assert.fail(ex.getMessage());
+      Assertions.fail(ex.getMessage());
     }
-    try {
+    OMException omEx = Assertions.assertThrows(OMException.class, () -> {
       bucketManager.getBucketInfo("sample-vol", "bucket-1");
-    } catch (OMException omEx) {
-      Assert.assertEquals(ResultCodes.BUCKET_NOT_FOUND,
+    });
+    Assertions.assertEquals(ResultCodes.BUCKET_NOT_FOUND,
           omEx.getResult());
-      throw omEx;
-    }
+    Assertions.assertEquals("Bucket not found", omEx.getMessage());
   }
 
   @Test
   public void testDeleteNonEmptyBucket() throws Exception {
-    thrown.expectMessage("Bucket is not empty");
     createSampleVol();
     OmBucketInfo bucketInfo = OmBucketInfo.newBuilder()
         .setVolumeName("sample-vol")
@@ -383,13 +367,12 @@ public class TestBucketManagerImpl {
 
     OpenKeySession session2 = writeClient.openKey(args2);
     writeClient.commitKey(args2, session2.getId());
-    try {
+    OMException omEx = Assertions.assertThrows(OMException.class, () -> {
       writeClient.deleteBucket("sample-vol", "bucket-one");
-    } catch (OMException omEx) {
-      Assert.assertEquals(ResultCodes.BUCKET_NOT_EMPTY,
+    });
+    Assertions.assertEquals(ResultCodes.BUCKET_NOT_EMPTY,
           omEx.getResult());
-      throw omEx;
-    }
+    Assertions.assertEquals("Bucket is not empty", omEx.getMessage());
   }
 
   @Test
@@ -431,48 +414,48 @@ public class TestBucketManagerImpl {
 
     OmBucketInfo storedLinkBucket =
         writeClient.getBucketInfo("sample-vol", "link-two");
-    Assert.assertNotNull("Replication config is not set",
-                         storedLinkBucket.getDefaultReplicationConfig());
-    Assert.assertEquals(ecConfig,
+    Assertions.assertNotNull(storedLinkBucket.getDefaultReplicationConfig(),
+        "Replication config is not set");
+    Assertions.assertEquals(ecConfig,
                         storedLinkBucket
                             .getDefaultReplicationConfig()
                             .getReplicationConfig());
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         "link-two", storedLinkBucket.getBucketName());
-    Assert.assertEquals(
+    Assertions.assertEquals(
         "sample-vol", storedLinkBucket.getVolumeName());
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         "link-one", storedLinkBucket.getSourceBucket());
-    Assert.assertEquals(
+    Assertions.assertEquals(
         "sample-vol", storedLinkBucket.getSourceVolume());
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         bucketInfo.getBucketLayout(),
         storedLinkBucket.getBucketLayout());
-    Assert.assertEquals(
+    Assertions.assertEquals(
         bucketInfo.getQuotaInBytes(),
         storedLinkBucket.getQuotaInBytes());
-    Assert.assertEquals(
+    Assertions.assertEquals(
         bucketInfo.getQuotaInNamespace(),
         storedLinkBucket.getQuotaInNamespace());
-    Assert.assertEquals(
+    Assertions.assertEquals(
         bucketInfo.getUsedBytes(),
         storedLinkBucket.getUsedBytes());
-    Assert.assertEquals(
+    Assertions.assertEquals(
         bucketInfo.getUsedNamespace(),
         storedLinkBucket.getUsedNamespace());
-    Assert.assertEquals(
+    Assertions.assertEquals(
         bucketInfo.getDefaultReplicationConfig(),
         storedLinkBucket.getDefaultReplicationConfig());
-    Assert.assertEquals(
+    Assertions.assertEquals(
         bucketInfo.getMetadata(),
         storedLinkBucket.getMetadata());
-    Assert.assertEquals(
+    Assertions.assertEquals(
         bucketInfo.getStorageType(),
         storedLinkBucket.getStorageType());
-    Assert.assertEquals(
+    Assertions.assertEquals(
         bucketInfo.getIsVersionEnabled(),
         storedLinkBucket.getIsVersionEnabled());
   }

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestChunkStreams.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestChunkStreams.java
@@ -20,24 +20,19 @@ import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.hadoop.hdds.scm.storage.BlockInputStream;
 import org.apache.hadoop.ozone.client.io.KeyInputStream;
 import org.jetbrains.annotations.NotNull;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.Test;
 
 import java.io.ByteArrayInputStream;
 import java.util.ArrayList;
 import java.util.List;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * This class tests KeyInputStream and KeyOutputStream.
  */
 public class TestChunkStreams {
-
-  @Rule
-  public ExpectedException exception = ExpectedException.none();
 
   @Test
   public void testReadGroupInputStream() throws Exception {

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestGrpcOzoneManagerServer.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestGrpcOzoneManagerServer.java
@@ -18,11 +18,8 @@
 
 package org.apache.hadoop.ozone.om;
 
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TestRule;
-import org.junit.rules.Timeout;
-import org.apache.ozone.test.JUnit5AwareTimeout;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -33,15 +30,13 @@ import org.apache.hadoop.ozone.protocolPB.OzoneManagerProtocolServerSideTranslat
 /**
  * Tests for GrpcOzoneManagerServer.
  */
+@Timeout(30)
 public class TestGrpcOzoneManagerServer {
   private static final Logger LOG =
       LoggerFactory.getLogger(TestGrpcOzoneManagerServer.class);
   private OzoneManager ozoneManager;
   private OzoneManagerProtocolServerSideTranslatorPB omServerProtocol;
   private GrpcOzoneManagerServer server;
-
-  @Rule
-  public TestRule timeout = new JUnit5AwareTimeout(Timeout.seconds(30));
 
   @Test
   public void testStartStop() throws Exception {

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestKeyManagerUnit.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestKeyManagerUnit.java
@@ -71,11 +71,11 @@ import org.apache.ozone.test.GenericTestUtils;
 
 import org.apache.hadoop.util.Time;
 import org.apache.ratis.util.ExitUtils;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 import static com.google.common.collect.Sets.newHashSet;
@@ -105,12 +105,12 @@ public class TestKeyManagerUnit {
   private OzoneManagerProtocol writeClient;
   private OzoneManager om;
 
-  @BeforeClass
+  @BeforeAll
   public static void setup() {
     ExitUtils.disableSystemExit();
   }
   
-  @Before
+  @BeforeEach
   public void init() throws Exception {
     configuration = new OzoneConfiguration();
     testDir = GenericTestUtils.getRandomizedTestDir();
@@ -128,7 +128,7 @@ public class TestKeyManagerUnit {
     startDate = Instant.ofEpochMilli(Time.now());
   }
 
-  @After
+  @AfterEach
   public void cleanup() throws Exception {
     om.stop();
     FileUtils.deleteDirectory(testDir);
@@ -147,7 +147,7 @@ public class TestKeyManagerUnit {
         .listParts("vol1", "bucket1", "dir/key1", omMultipartInfo.getUploadID(),
             0, 10);
 
-    Assert.assertEquals(0,
+    Assertions.assertEquals(0,
         omMultipartUploadListParts.getPartInfoList().size());
   }
 
@@ -168,16 +168,16 @@ public class TestKeyManagerUnit {
 
     //THEN
     List<OmMultipartUpload> uploads = omMultipartUploadList.getUploads();
-    Assert.assertEquals(2, uploads.size());
-    Assert.assertEquals("dir/key1", uploads.get(0).getKeyName());
-    Assert.assertEquals("dir/key2", uploads.get(1).getKeyName());
+    Assertions.assertEquals(2, uploads.size());
+    Assertions.assertEquals("dir/key1", uploads.get(0).getKeyName());
+    Assertions.assertEquals("dir/key2", uploads.get(1).getKeyName());
 
-    Assert.assertNotNull(uploads.get(1));
+    Assertions.assertNotNull(uploads.get(1));
     Instant creationTime = uploads.get(1).getCreationTime();
-    Assert.assertNotNull(creationTime);
-    Assert.assertFalse("Creation date is too old: "
-            + creationTime + " < " + startDate,
-        creationTime.isBefore(startDate));
+    Assertions.assertNotNull(creationTime);
+    Assertions.assertFalse(creationTime.isBefore(startDate),
+        "Creation date is too old: "
+            + creationTime + " < " + startDate);
   }
 
   @Test
@@ -205,11 +205,11 @@ public class TestKeyManagerUnit {
 
     //THEN
     List<OmMultipartUpload> uploads = omMultipartUploadList.getUploads();
-    Assert.assertEquals(4, uploads.size());
-    Assert.assertEquals("dir/key1", uploads.get(0).getKeyName());
-    Assert.assertEquals("dir/key2", uploads.get(1).getKeyName());
-    Assert.assertEquals("dir/key3", uploads.get(2).getKeyName());
-    Assert.assertEquals("dir/key4", uploads.get(3).getKeyName());
+    Assertions.assertEquals(4, uploads.size());
+    Assertions.assertEquals("dir/key1", uploads.get(0).getKeyName());
+    Assertions.assertEquals("dir/key2", uploads.get(1).getKeyName());
+    Assertions.assertEquals("dir/key3", uploads.get(2).getKeyName());
+    Assertions.assertEquals("dir/key4", uploads.get(3).getKeyName());
 
     // Add few more to test prefix.
 
@@ -229,11 +229,11 @@ public class TestKeyManagerUnit {
 
     //THEN
     uploads = omMultipartUploadList.getUploads();
-    Assert.assertEquals(4, uploads.size());
-    Assert.assertEquals("dir/ozonekey1", uploads.get(0).getKeyName());
-    Assert.assertEquals("dir/ozonekey2", uploads.get(1).getKeyName());
-    Assert.assertEquals("dir/ozonekey3", uploads.get(2).getKeyName());
-    Assert.assertEquals("dir/ozonekey4", uploads.get(3).getKeyName());
+    Assertions.assertEquals(4, uploads.size());
+    Assertions.assertEquals("dir/ozonekey1", uploads.get(0).getKeyName());
+    Assertions.assertEquals("dir/ozonekey2", uploads.get(1).getKeyName());
+    Assertions.assertEquals("dir/ozonekey3", uploads.get(2).getKeyName());
+    Assertions.assertEquals("dir/ozonekey4", uploads.get(3).getKeyName());
 
     // Abort multipart upload for key in DB.
     abortMultipart(volume, bucket, "dir/ozonekey4",
@@ -245,10 +245,10 @@ public class TestKeyManagerUnit {
 
     //THEN
     uploads = omMultipartUploadList.getUploads();
-    Assert.assertEquals(3, uploads.size());
-    Assert.assertEquals("dir/ozonekey1", uploads.get(0).getKeyName());
-    Assert.assertEquals("dir/ozonekey2", uploads.get(1).getKeyName());
-    Assert.assertEquals("dir/ozonekey3", uploads.get(2).getKeyName());
+    Assertions.assertEquals(3, uploads.size());
+    Assertions.assertEquals("dir/ozonekey1", uploads.get(0).getKeyName());
+    Assertions.assertEquals("dir/ozonekey2", uploads.get(1).getKeyName());
+    Assertions.assertEquals("dir/ozonekey3", uploads.get(2).getKeyName());
 
     // abort multipart upload for key in cache.
     abortMultipart(volume, bucket, "dir/ozonekey3",
@@ -260,9 +260,9 @@ public class TestKeyManagerUnit {
 
     //THEN
     uploads = omMultipartUploadList.getUploads();
-    Assert.assertEquals(2, uploads.size());
-    Assert.assertEquals("dir/ozonekey1", uploads.get(0).getKeyName());
-    Assert.assertEquals("dir/ozonekey2", uploads.get(1).getKeyName());
+    Assertions.assertEquals(2, uploads.size());
+    Assertions.assertEquals("dir/ozonekey1", uploads.get(0).getKeyName());
+    Assertions.assertEquals("dir/ozonekey2", uploads.get(1).getKeyName());
 
   }
 
@@ -287,9 +287,9 @@ public class TestKeyManagerUnit {
 
     //THEN
     List<OmMultipartUpload> uploads = omMultipartUploadList.getUploads();
-    Assert.assertEquals(2, uploads.size());
-    Assert.assertEquals("dir/key1", uploads.get(0).getKeyName());
-    Assert.assertEquals("dir/key2", uploads.get(1).getKeyName());
+    Assertions.assertEquals(2, uploads.size());
+    Assertions.assertEquals("dir/key1", uploads.get(0).getKeyName());
+    Assertions.assertEquals("dir/key2", uploads.get(1).getKeyName());
   }
 
   private void createBucket(OMMetadataManager omMetadataManager,
@@ -400,8 +400,8 @@ public class TestKeyManagerUnit {
     OmKeyInfo keyInfo = keyManager.getKeyInfo(keyArgs, "test");
     final OmKeyLocationInfo blockLocation1 = keyInfo
         .getLatestVersionLocations().getBlocksLatestVersionOnly().get(0);
-    Assert.assertEquals(blockID1, blockLocation1.getBlockID());
-    Assert.assertEquals(pipeline1, blockLocation1.getPipeline());
+    Assertions.assertEquals(blockID1, blockLocation1.getBlockID());
+    Assertions.assertEquals(pipeline1, blockLocation1.getPipeline());
     // Ensure SCM is called.
     verify(containerClient, times(1))
         .getContainerWithPipelineBatch(containerIDs);
@@ -415,8 +415,8 @@ public class TestKeyManagerUnit {
     OmKeyInfo keyInfo2 = keyManager.getKeyInfo(keyArgs, "test");
     OmKeyLocationInfo blockLocation2 = keyInfo2
         .getLatestVersionLocations().getBlocksLatestVersionOnly().get(0);
-    Assert.assertEquals(blockID2, blockLocation2.getBlockID());
-    Assert.assertEquals(pipeline1, blockLocation2.getPipeline());
+    Assertions.assertEquals(blockID2, blockLocation2.getBlockID());
+    Assertions.assertEquals(pipeline1, blockLocation2.getPipeline());
     // Ensure SCM is not called.
     verify(containerClient, times(1))
         .getContainerWithPipelineBatch(containerIDs);
@@ -431,8 +431,8 @@ public class TestKeyManagerUnit {
     keyInfo2 = keyManager.getKeyInfo(keyArgs, "test");
     blockLocation2 = keyInfo2
         .getLatestVersionLocations().getBlocksLatestVersionOnly().get(0);
-    Assert.assertEquals(blockID2, blockLocation2.getBlockID());
-    Assert.assertEquals(pipeline2, blockLocation2.getPipeline());
+    Assertions.assertEquals(blockID2, blockLocation2.getBlockID());
+    Assertions.assertEquals(pipeline2, blockLocation2.getPipeline());
     // Ensure SCM is called.
     verify(containerClient, times(2))
         .getContainerWithPipelineBatch(containerIDs);
@@ -495,16 +495,16 @@ public class TestKeyManagerUnit {
     final OmKeyLocationInfo newBlockLocation = newKeyInfo
         .getLatestVersionLocations().getBlocksLatestVersionOnly().get(0);
 
-    Assert.assertEquals(1L, newBlockLocation.getContainerID());
-    Assert.assertEquals(1L, newBlockLocation
+    Assertions.assertEquals(1L, newBlockLocation.getContainerID());
+    Assertions.assertEquals(1L, newBlockLocation
         .getBlockID().getLocalID());
-    Assert.assertEquals(pipelineTwo.getId(),
+    Assertions.assertEquals(pipelineTwo.getId(),
         newBlockLocation.getPipeline().getId());
-    Assert.assertTrue(newBlockLocation.getPipeline()
+    Assertions.assertTrue(newBlockLocation.getPipeline()
         .getNodes().contains(dnFour));
-    Assert.assertTrue(newBlockLocation.getPipeline()
+    Assertions.assertTrue(newBlockLocation.getPipeline()
         .getNodes().contains(dnFive));
-    Assert.assertTrue(newBlockLocation.getPipeline()
+    Assertions.assertTrue(newBlockLocation.getPipeline()
         .getNodes().contains(dnSix));
   }
 
@@ -615,7 +615,7 @@ public class TestKeyManagerUnit {
         keyManager.listStatus(builder.build(), false,
             null, Long.MAX_VALUE, client);
 
-    Assert.assertEquals(10, fileStatusList.size());
+    Assertions.assertEquals(10, fileStatusList.size());
     verify(containerClient).getContainerWithPipelineBatch(containerIDs);
     verify(blockClient).sortDatanodes(nodes, client);
 
@@ -674,11 +674,11 @@ public class TestKeyManagerUnit {
     // verify all key info locations got updated
     for (OmKeyInfo keyInfo : keyInfos) {
       OmKeyLocationInfoGroup locations = keyInfo.getLatestVersionLocations();
-      Assert.assertNotNull(locations);
+      Assertions.assertNotNull(locations);
       for (OmKeyLocationInfo locationInfo : locations.getLocationList()) {
         Pipeline pipeline = locationInfo.getPipeline();
         List<DatanodeDetails> expectedOrder = expectedSortedNodes.get(pipeline);
-        Assert.assertEquals(expectedOrder, pipeline.getNodesInOrder());
+        Assertions.assertEquals(expectedOrder, pipeline.getNodesInOrder());
       }
     }
 

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestOMDBDefinition.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestOMDBDefinition.java
@@ -22,12 +22,12 @@ import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.utils.db.DBColumnFamilyDefinition;
 import org.apache.hadoop.hdds.utils.db.DBStore;
 import org.apache.hadoop.ozone.om.codec.OMDBDefinition;
-import org.junit.Assert;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 import java.io.File;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collection;
 
@@ -37,13 +37,13 @@ import java.util.Collection;
  */
 public class TestOMDBDefinition {
 
-  @Rule
-  public TemporaryFolder folder = new TemporaryFolder();
+  @TempDir
+  private Path folder;
 
   @Test
   public void testDBDefinition() throws Exception {
     OzoneConfiguration configuration = new OzoneConfiguration();
-    File metaDir = folder.getRoot();
+    File metaDir = folder.toFile();
     DBStore store = OmMetadataManagerImpl.loadDB(configuration, metaDir);
     OMDBDefinition dbDef = new OMDBDefinition();
 
@@ -65,10 +65,10 @@ public class TestOMDBDefinition {
       }
     }
 
-    Assert.assertEquals("Tables in OmMetadataManagerImpl are:"
-            + missingDBDefTables, 0, missingDBDefTables.size());
-    Assert.assertEquals("Tables missing in OMDBDefinition are:"
-        + missingOmDBTables, 0, missingOmDBTables.size());
-    Assert.assertEquals(countOmDBTables, countOmDefTables);
+    Assertions.assertEquals(0, missingDBDefTables.size(),
+        "Tables in OmMetadataManagerImpl are:" + missingDBDefTables);
+    Assertions.assertEquals(0, missingOmDBTables.size(),
+        "Tables missing in OMDBDefinition are:" + missingOmDBTables);
+    Assertions.assertEquals(countOmDBTables, countOmDefTables);
   }
 }

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestOMMultiTenantManager.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestOMMultiTenantManager.java
@@ -27,8 +27,8 @@ import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.Status;
 import org.apache.hadoop.ozone.protocolPB.OzoneManagerRequestHandler;
 import org.apache.hadoop.security.UserGroupInformation.AuthenticationMethod;
 import org.apache.hadoop.util.StringUtils;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 import java.io.IOException;
@@ -60,7 +60,7 @@ public class TestOMMultiTenantManager {
 
     // Case 1: ozone.om.multitenancy.enabled = false
     conf.setBoolean(OZONE_OM_MULTITENANCY_ENABLED, false);
-    Assert.assertFalse(
+    Assertions.assertFalse(
         OMMultiTenantManager.checkAndEnableMultiTenancy(ozoneManager, conf));
 
     // Case 2: ozone.om.multitenancy.enabled = true
@@ -94,7 +94,7 @@ public class TestOMMultiTenantManager {
     confKerbAuth.set(OZONE_OM_KERBEROS_PRINCIPAL_KEY, "om/_HOST@REALM");
     expectConfigCheckToFail(ozoneManager, confKerbAuth);
     confKerbAuth.set(OZONE_OM_KERBEROS_KEYTAB_FILE_KEY, "/path/to/om.keytab");
-    Assert.assertTrue(OMMultiTenantManager.checkAndEnableMultiTenancy(
+    Assertions.assertTrue(OMMultiTenantManager.checkAndEnableMultiTenancy(
         ozoneManager, confKerbAuth));
 
     // Try basic auth
@@ -103,7 +103,7 @@ public class TestOMMultiTenantManager {
     expectConfigCheckToFail(ozoneManager, confBasicAuth);
     confBasicAuth.set(OZONE_OM_RANGER_HTTPS_ADMIN_API_PASSWD, "Password1");
     // At this point the config check should pass. Method returns true
-    Assert.assertTrue(OMMultiTenantManager.checkAndEnableMultiTenancy(
+    Assertions.assertTrue(OMMultiTenantManager.checkAndEnableMultiTenancy(
         ozoneManager, confBasicAuth));
   }
 
@@ -114,9 +114,9 @@ public class TestOMMultiTenantManager {
       OzoneConfiguration conf) {
     try {
       OMMultiTenantManager.checkAndEnableMultiTenancy(ozoneManager, conf);
-      Assert.fail("Should have thrown RuntimeException");
+      Assertions.fail("Should have thrown RuntimeException");
     } catch (RuntimeException e) {
-      Assert.assertTrue(e.getMessage().contains("Failed to meet"));
+      Assertions.assertTrue(e.getMessage().contains("Failed to meet"));
     }
   }
 
@@ -174,9 +174,9 @@ public class TestOMMultiTenantManager {
       throws IOException {
     try {
       OzoneManagerRatisUtils.createClientRequest(omRequest, om);
-      Assert.fail("Should have thrown OMException");
+      Assertions.fail("Should have thrown OMException");
     } catch (OMException e) {
-      Assert.assertEquals(FEATURE_NOT_ENABLED, e.getResult());
+      Assertions.assertEquals(FEATURE_NOT_ENABLED, e.getResult());
     }
   }
 
@@ -188,9 +188,9 @@ public class TestOMMultiTenantManager {
 
     // handleReadRequest does not throw
     OMResponse omResponse = handler.handleReadRequest(omRequest);
-    Assert.assertFalse(omResponse.getSuccess());
-    Assert.assertEquals(Status.FEATURE_NOT_ENABLED, omResponse.getStatus());
-    Assert.assertTrue(omResponse.getMessage()
+    Assertions.assertFalse(omResponse.getSuccess());
+    Assertions.assertEquals(Status.FEATURE_NOT_ENABLED, omResponse.getStatus());
+    Assertions.assertTrue(omResponse.getMessage()
         .startsWith("S3 multi-tenancy feature is not enabled"));
   }
 

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestOMMultiTenantManagerImpl.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestOMMultiTenantManagerImpl.java
@@ -22,11 +22,12 @@ import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_DB_DIRS;
 import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_MULTITENANCY_RANGER_SYNC_INTERVAL;
 import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_MULTITENANCY_RANGER_SYNC_INTERVAL_DEFAULT;
 import static org.apache.hadoop.ozone.om.OMMultiTenantManagerImpl.OZONE_OM_TENANT_DEV_SKIP_RANGER;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
+import java.nio.file.Path;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
@@ -39,11 +40,10 @@ import org.apache.hadoop.ozone.om.helpers.OmDBTenantState;
 import org.apache.hadoop.ozone.om.helpers.TenantUserList;
 import org.apache.hadoop.ozone.om.multitenant.CachedTenantState;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.UserAccessIdInfo;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 import org.mockito.Mockito;
 
 /**
@@ -57,14 +57,13 @@ public class TestOMMultiTenantManagerImpl {
   private OzoneConfiguration conf;
   private OzoneManager ozoneManager;
 
-  @Rule
-  public TemporaryFolder folder = new TemporaryFolder();
+  @TempDir
+  private Path folder;
 
-  @Before
+  @BeforeEach
   public void setUp() throws IOException {
     conf = new OzoneConfiguration();
-    conf.set(OZONE_OM_DB_DIRS,
-        folder.newFolder().getAbsolutePath());
+    conf.set(OZONE_OM_DB_DIRS, folder.toAbsolutePath().toString());
     conf.set(OZONE_OM_TENANT_DEV_SKIP_RANGER, "true");
     omMetadataManager = new OmMetadataManagerImpl(conf, ozoneManager);
 
@@ -136,7 +135,7 @@ public class TestOMMultiTenantManagerImpl {
       } else if (user.equals("seed-user1")) {
         assertEquals("seed-accessId1", userAccessId.getAccessId());
       } else {
-        Assert.fail();
+        Assertions.fail();
       }
     }
 

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestOMTenantCreateRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestOMTenantCreateRequest.java
@@ -32,15 +32,15 @@ import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.CreateT
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMRequest;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMResponse;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.Status;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.rules.TemporaryFolder;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 import java.io.IOException;
+import java.nio.file.Path;
 import java.util.UUID;
 
 import static org.apache.hadoop.ozone.om.exceptions.OMException.ResultCodes.VOLUME_ALREADY_EXISTS;
@@ -53,8 +53,8 @@ import static org.mockito.Mockito.when;
  * Tests create tenant request.
  */
 public class TestOMTenantCreateRequest {
-  @Rule
-  public TemporaryFolder folder = new TemporaryFolder();
+  @TempDir
+  private Path folder;
   private OzoneManager ozoneManager;
   private OMMetrics omMetrics;
   private OMMetadataManager omMetadataManager;
@@ -65,13 +65,13 @@ public class TestOMTenantCreateRequest {
         return null;
       });
 
-  @Before
+  @BeforeEach
   public void setup() throws Exception {
     ozoneManager = mock(OzoneManager.class);
     omMetrics = OMMetrics.create();
     OzoneConfiguration ozoneConfiguration = new OzoneConfiguration();
     ozoneConfiguration.set(OMConfigKeys.OZONE_OM_DB_DIRS,
-        folder.newFolder().getAbsolutePath());
+        folder.toAbsolutePath().toString());
     omMetadataManager = new OmMetadataManagerImpl(ozoneConfiguration,
         ozoneManager);
     when(ozoneManager.getMetrics()).thenReturn(omMetrics);
@@ -99,7 +99,7 @@ public class TestOMTenantCreateRequest {
     when(ozoneManager.getMultiTenantManager()).thenReturn(multiTenantManager);
   }
 
-  @After
+  @AfterEach
   public void stop() {
     omMetrics.unRegister();
     Mockito.framework().clearInlineMocks();
@@ -127,9 +127,9 @@ public class TestOMTenantCreateRequest {
             ozoneManagerDoubleBufferHelper);
     OMResponse omResponse = omClientResponse.getOMResponse();
 
-    Assert.assertNotNull(omResponse.getCreateTenantResponse());
-    Assert.assertEquals(Status.OK, omResponse.getStatus());
-    Assert.assertNotNull(omMetadataManager.getVolumeTable().get(
+    Assertions.assertNotNull(omResponse.getCreateTenantResponse());
+    Assertions.assertEquals(Status.OK, omResponse.getStatus());
+    Assertions.assertNotNull(omMetadataManager.getVolumeTable().get(
         omMetadataManager.getVolumeKey(tenantId)));
   }
 
@@ -152,9 +152,9 @@ public class TestOMTenantCreateRequest {
     Mockito.doReturn(ownerName).when(omTenantCreateRequest1).getUserName();
 
     // Should throw in preExecute
-    OMException omException = Assert.assertThrows(OMException.class,
+    OMException omException = Assertions.assertThrows(OMException.class,
         () -> omTenantCreateRequest1.preExecute(ozoneManager));
-    Assert.assertEquals(VOLUME_ALREADY_EXISTS, omException.getResult());
+    Assertions.assertEquals(VOLUME_ALREADY_EXISTS, omException.getResult());
 
     // Now with forceCreationWhenVolumeExists = true
     originalRequest =
@@ -186,9 +186,9 @@ public class TestOMTenantCreateRequest {
     OMClientResponse modOMClientResponse =
         modTenantCreateRequest.validateAndUpdateCache(ozoneManager, 2L,
             ozoneManagerDoubleBufferHelper);
-    Assert.assertEquals(Status.VOLUME_ALREADY_EXISTS,
+    Assertions.assertEquals(Status.VOLUME_ALREADY_EXISTS,
         modOMClientResponse.getOMResponse().getStatus());
-    Assert.assertEquals("Volume already exists",
+    Assertions.assertEquals("Volume already exists",
         modOMClientResponse.getOMResponse().getMessage());
 
     // validateAndUpdateCache with forceCreationWhenVolumeExists = true
@@ -197,9 +197,9 @@ public class TestOMTenantCreateRequest {
             ozoneManagerDoubleBufferHelper);
     OMResponse omResponse = omClientResponse.getOMResponse();
 
-    Assert.assertNotNull(omResponse.getCreateTenantResponse());
-    Assert.assertEquals(Status.OK, omResponse.getStatus());
-    Assert.assertNotNull(omMetadataManager.getVolumeTable().get(
+    Assertions.assertNotNull(omResponse.getCreateTenantResponse());
+    Assertions.assertEquals(Status.OK, omResponse.getStatus());
+    Assertions.assertNotNull(omMetadataManager.getVolumeTable().get(
         omMetadataManager.getVolumeKey(tenantId)));
   }
 
@@ -222,9 +222,9 @@ public class TestOMTenantCreateRequest {
     when(ozoneManager.isStrictS3()).thenReturn(true);
     for (String tenantId : nonS3CompliantTenantId) {
 
-      OMException omException = Assert.assertThrows(OMException.class,
+      OMException omException = Assertions.assertThrows(OMException.class,
           () -> doPreExecute(tenantId));
-      Assert.assertEquals("Invalid volume name: " + tenantId,
+      Assertions.assertEquals("Invalid volume name: " + tenantId,
           omException.getMessage());
     }
   }
@@ -256,9 +256,9 @@ public class TestOMTenantCreateRequest {
             ozoneManagerDoubleBufferHelper);
     OMResponse omResponse = omClientResponse.getOMResponse();
 
-    Assert.assertNotNull(omResponse.getCreateTenantResponse());
-    Assert.assertEquals(Status.OK, omResponse.getStatus());
-    Assert.assertNotNull(omMetadataManager.getVolumeTable().get(
+    Assertions.assertNotNull(omResponse.getCreateTenantResponse());
+    Assertions.assertEquals(Status.OK, omResponse.getStatus());
+    Assertions.assertNotNull(omMetadataManager.getVolumeTable().get(
         omMetadataManager.getVolumeKey(tenantId)));
   }
 

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestOmSnapshotManager.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestOmSnapshotManager.java
@@ -32,10 +32,10 @@ import org.apache.hadoop.ozone.om.helpers.SnapshotInfo;
 import org.apache.hadoop.ozone.om.snapshot.OmSnapshotUtils;
 import org.apache.hadoop.util.Time;
 import org.apache.ozone.test.GenericTestUtils;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.io.File;
 import java.io.IOException;
@@ -92,7 +92,7 @@ public class TestOmSnapshotManager {
   private File s1File;
   private File f1File;
 
-  @Before
+  @BeforeEach
   public void init() throws Exception {
     OzoneConfiguration configuration = new OzoneConfiguration();
     testDir = GenericTestUtils.getRandomizedTestDir();
@@ -111,7 +111,7 @@ public class TestOmSnapshotManager {
     setupData();
   }
 
-  @After
+  @AfterEach
   public void cleanup() throws Exception {
     om.stop();
     FileUtils.deleteDirectory(testDir);
@@ -127,11 +127,11 @@ public class TestOmSnapshotManager {
         om.getMetadataManager(), SNAPSHOT_INFO_TABLE, snapshotInfoTable);
 
     when(snapshotInfoTable.isEmpty()).thenReturn(false);
-    Assert.assertFalse(om.getOmSnapshotManager()
+    Assertions.assertFalse(om.getOmSnapshotManager()
         .canDisableFsSnapshot(om.getMetadataManager()));
 
     when(snapshotInfoTable.isEmpty()).thenReturn(true);
-    Assert.assertTrue(om.getOmSnapshotManager()
+    Assertions.assertTrue(om.getOmSnapshotManager()
         .canDisableFsSnapshot(om.getMetadataManager()));
   }
 
@@ -232,15 +232,15 @@ public class TestOmSnapshotManager {
     // Create dummy leader files to calculate links.
     leaderDir = new File(testDir.toString(),
         "leader");
-    Assert.assertTrue(leaderDir.mkdirs());
+    Assertions.assertTrue(leaderDir.mkdirs());
     String pathSnap1 = OM_SNAPSHOT_CHECKPOINT_DIR + OM_KEY_PREFIX + "snap1";
     String pathSnap2 = OM_SNAPSHOT_CHECKPOINT_DIR + OM_KEY_PREFIX + "snap2";
     leaderSnapDir1 = new File(leaderDir.toString(), pathSnap1);
-    Assert.assertTrue(leaderSnapDir1.mkdirs());
+    Assertions.assertTrue(leaderSnapDir1.mkdirs());
     Files.write(Paths.get(leaderSnapDir1.toString(), "s1.sst"), dummyData);
 
     leaderSnapDir2 = new File(leaderDir.toString(), pathSnap2);
-    Assert.assertTrue(leaderSnapDir2.mkdirs());
+    Assertions.assertTrue(leaderSnapDir2.mkdirs());
     Files.write(Paths.get(leaderSnapDir2.toString(), "noLink.sst"), dummyData);
     Files.write(Paths.get(leaderSnapDir2.toString(), "nonSstFile"), dummyData);
 
@@ -254,13 +254,13 @@ public class TestOmSnapshotManager {
     Files.write(f1File.toPath(), dummyData);
     s1File = new File(followerSnapDir1, "s1.sst");
     // confirm s1 file got copied over.
-    Assert.assertTrue(s1File.exists());
+    Assertions.assertTrue(s1File.exists());
 
     // Finish creating leaders files that are not to be copied over, because
     //  f1.sst belongs in a different directory as explained above.
     leaderCheckpointDir = new File(leaderDir.toString(),
         OM_CHECKPOINT_DIR + OM_KEY_PREFIX + "checkpoint1");
-    Assert.assertTrue(leaderCheckpointDir.mkdirs());
+    Assertions.assertTrue(leaderCheckpointDir.mkdirs());
     Files.write(Paths.get(leaderCheckpointDir.toString(), "f1.sst"), dummyData);
   }
 
@@ -299,13 +299,13 @@ public class TestOmSnapshotManager {
     OmSnapshotUtils.createHardLinks(candidateDir.toPath());
 
     // Confirm expected follower links.
-    Assert.assertTrue(s1FileLink.exists());
-    Assert.assertEquals("link matches original file",
-        getINode(s1File.toPath()), getINode(s1FileLink.toPath()));
+    Assertions.assertTrue(s1FileLink.exists());
+    Assertions.assertEquals(getINode(s1File.toPath()),
+        getINode(s1FileLink.toPath()), "link matches original file");
 
-    Assert.assertTrue(f1FileLink.exists());
-    Assert.assertEquals("link matches original file",
-        getINode(f1File.toPath()), getINode(f1FileLink.toPath()));
+    Assertions.assertTrue(f1FileLink.exists());
+    Assertions.assertEquals(getINode(f1File.toPath()),
+        getINode(f1FileLink.toPath()), "link matches original file");
   }
 
   /*
@@ -323,14 +323,14 @@ public class TestOmSnapshotManager {
         s1File.toString().substring(truncateLength),
         noLinkFile.toString().substring(truncateLength),
         f1File.toString().substring(truncateLength)));
-    Assert.assertEquals(expectedSstFiles, existingSstFiles);
+    Assertions.assertEquals(expectedSstFiles, existingSstFiles);
 
     // Confirm that the excluded list is normalized as expected.
     //  (Normalizing means matches the layout on the leader.)
     File leaderSstBackupDir = new File(leaderDir.toString(), "sstBackup");
-    Assert.assertTrue(leaderSstBackupDir.mkdirs());
+    Assertions.assertTrue(leaderSstBackupDir.mkdirs());
     File leaderTmpDir = new File(leaderDir.toString(), "tmp");
-    Assert.assertTrue(leaderTmpDir.mkdirs());
+    Assertions.assertTrue(leaderTmpDir.mkdirs());
     OMDBCheckpointServlet.DirectoryData sstBackupDir =
         new OMDBCheckpointServlet.DirectoryData(leaderTmpDir.toPath(),
         leaderSstBackupDir.toString());
@@ -351,7 +351,7 @@ public class TestOmSnapshotManager {
     expectedMap.put(noLink, noLink);
     expectedMap.put(f1, f1);
     expectedMap.put(srcSstBackup, destSstBackup);
-    Assert.assertEquals(expectedMap, new TreeMap<>(normalizedMap));
+    Assertions.assertEquals(expectedMap, new TreeMap<>(normalizedMap));
   }
 
   /*
@@ -361,8 +361,8 @@ public class TestOmSnapshotManager {
    */
   @Test
   public void testProcessFileWithNullDestDirParameter() throws IOException {
-    Assert.assertTrue(new File(testDir.toString(), "snap1").mkdirs());
-    Assert.assertTrue(new File(testDir.toString(), "snap2").mkdirs());
+    Assertions.assertTrue(new File(testDir.toString(), "snap1").mkdirs());
+    Assertions.assertTrue(new File(testDir.toString(), "snap2").mkdirs());
     Path copyFile = Paths.get(testDir.toString(),
         "snap1/copyfile.sst");
     Files.write(copyFile,
@@ -398,50 +398,50 @@ public class TestOmSnapshotManager {
     //  (and thus is excluded.)
     fileSize = processFile(excludeFile, copyFiles, hardLinkFiles,
         toExcludeFiles, excluded, null);
-    Assert.assertEquals(excluded.size(), 1);
-    Assert.assertEquals((excluded.get(0)), excludeFile.toString());
-    Assert.assertEquals(copyFiles.size(), 1);
-    Assert.assertEquals(hardLinkFiles.size(), 0);
-    Assert.assertEquals(fileSize, 0);
+    Assertions.assertEquals(excluded.size(), 1);
+    Assertions.assertEquals((excluded.get(0)), excludeFile.toString());
+    Assertions.assertEquals(copyFiles.size(), 1);
+    Assertions.assertEquals(hardLinkFiles.size(), 0);
+    Assertions.assertEquals(fileSize, 0);
     excluded = new ArrayList<>();
 
     // Confirm the linkToExcludedFile gets added as a link.
     fileSize = processFile(linkToExcludedFile, copyFiles, hardLinkFiles,
         toExcludeFiles, excluded, null);
-    Assert.assertEquals(excluded.size(), 0);
-    Assert.assertEquals(copyFiles.size(), 1);
-    Assert.assertEquals(hardLinkFiles.size(), 1);
-    Assert.assertEquals(hardLinkFiles.get(linkToExcludedFile), excludeFile);
-    Assert.assertEquals(fileSize, 0);
+    Assertions.assertEquals(excluded.size(), 0);
+    Assertions.assertEquals(copyFiles.size(), 1);
+    Assertions.assertEquals(hardLinkFiles.size(), 1);
+    Assertions.assertEquals(hardLinkFiles.get(linkToExcludedFile), excludeFile);
+    Assertions.assertEquals(fileSize, 0);
     hardLinkFiles = new HashMap<>();
 
     // Confirm the linkToCopiedFile gets added as a link.
     fileSize = processFile(linkToCopiedFile, copyFiles, hardLinkFiles,
         toExcludeFiles, excluded, null);
-    Assert.assertEquals(excluded.size(), 0);
-    Assert.assertEquals(copyFiles.size(), 1);
-    Assert.assertEquals(hardLinkFiles.size(), 1);
-    Assert.assertEquals(hardLinkFiles.get(linkToCopiedFile), copyFile);
-    Assert.assertEquals(fileSize, 0);
+    Assertions.assertEquals(excluded.size(), 0);
+    Assertions.assertEquals(copyFiles.size(), 1);
+    Assertions.assertEquals(hardLinkFiles.size(), 1);
+    Assertions.assertEquals(hardLinkFiles.get(linkToCopiedFile), copyFile);
+    Assertions.assertEquals(fileSize, 0);
     hardLinkFiles = new HashMap<>();
 
     // Confirm the addToCopiedFiles gets added to list of copied files
     fileSize = processFile(addToCopiedFiles, copyFiles, hardLinkFiles,
         toExcludeFiles, excluded, null);
-    Assert.assertEquals(excluded.size(), 0);
-    Assert.assertEquals(copyFiles.size(), 2);
-    Assert.assertEquals(copyFiles.get(addToCopiedFiles), addToCopiedFiles);
-    Assert.assertEquals(fileSize, expectedFileSize);
+    Assertions.assertEquals(excluded.size(), 0);
+    Assertions.assertEquals(copyFiles.size(), 2);
+    Assertions.assertEquals(copyFiles.get(addToCopiedFiles), addToCopiedFiles);
+    Assertions.assertEquals(fileSize, expectedFileSize);
     copyFiles = new HashMap<>();
     copyFiles.put(copyFile, copyFile);
 
     // Confirm the addNonSstToCopiedFiles gets added to list of copied files
     fileSize = processFile(addNonSstToCopiedFiles, copyFiles, hardLinkFiles,
         toExcludeFiles, excluded, null);
-    Assert.assertEquals(excluded.size(), 0);
-    Assert.assertEquals(copyFiles.size(), 2);
-    Assert.assertEquals(fileSize, 0);
-    Assert.assertEquals(copyFiles.get(addNonSstToCopiedFiles),
+    Assertions.assertEquals(excluded.size(), 0);
+    Assertions.assertEquals(copyFiles.size(), 2);
+    Assertions.assertEquals(fileSize, 0);
+    Assertions.assertEquals(copyFiles.get(addNonSstToCopiedFiles),
         addNonSstToCopiedFiles);
   }
 
@@ -452,11 +452,11 @@ public class TestOmSnapshotManager {
    */
   @Test
   public void testProcessFileWithDestDirParameter() throws IOException {
-    Assert.assertTrue(new File(testDir.toString(), "snap1").mkdirs());
-    Assert.assertTrue(new File(testDir.toString(), "snap2").mkdirs());
-    Assert.assertTrue(new File(testDir.toString(), "snap3").mkdirs());
+    Assertions.assertTrue(new File(testDir.toString(), "snap1").mkdirs());
+    Assertions.assertTrue(new File(testDir.toString(), "snap2").mkdirs());
+    Assertions.assertTrue(new File(testDir.toString(), "snap3").mkdirs());
     Path destDir = Paths.get(testDir.toString(), "destDir");
-    Assert.assertTrue(new File(destDir.toString()).mkdirs());
+    Assertions.assertTrue(new File(destDir.toString()).mkdirs());
 
     // Create test files.
     Path copyFile = Paths.get(testDir.toString(),
@@ -520,33 +520,33 @@ public class TestOmSnapshotManager {
     //  (and thus is excluded.)
     fileSize = processFile(excludeFile, copyFiles, hardLinkFiles,
         toExcludeFiles, excluded, destExcludeFile.getParent());
-    Assert.assertEquals(excluded.size(), 1);
-    Assert.assertEquals((excluded.get(0)), destExcludeFile.toString());
-    Assert.assertEquals(copyFiles.size(), 1);
-    Assert.assertEquals(hardLinkFiles.size(), 0);
-    Assert.assertEquals(fileSize, 0);
+    Assertions.assertEquals(excluded.size(), 1);
+    Assertions.assertEquals((excluded.get(0)), destExcludeFile.toString());
+    Assertions.assertEquals(copyFiles.size(), 1);
+    Assertions.assertEquals(hardLinkFiles.size(), 0);
+    Assertions.assertEquals(fileSize, 0);
     excluded = new ArrayList<>();
 
     // Confirm the linkToExcludedFile gets added as a link.
     fileSize = processFile(linkToExcludedFile, copyFiles, hardLinkFiles,
         toExcludeFiles, excluded, destLinkToExcludedFile.getParent());
-    Assert.assertEquals(excluded.size(), 0);
-    Assert.assertEquals(copyFiles.size(), 1);
-    Assert.assertEquals(hardLinkFiles.size(), 1);
-    Assert.assertEquals(hardLinkFiles.get(destLinkToExcludedFile),
+    Assertions.assertEquals(excluded.size(), 0);
+    Assertions.assertEquals(copyFiles.size(), 1);
+    Assertions.assertEquals(hardLinkFiles.size(), 1);
+    Assertions.assertEquals(hardLinkFiles.get(destLinkToExcludedFile),
         destExcludeFile);
-    Assert.assertEquals(fileSize, 0);
+    Assertions.assertEquals(fileSize, 0);
     hardLinkFiles = new HashMap<>();
 
     // Confirm the file with same name as excluded file gets copied.
     fileSize = processFile(sameNameAsExcludeFile, copyFiles, hardLinkFiles,
         toExcludeFiles, excluded, destSameNameAsExcludeFile.getParent());
-    Assert.assertEquals(excluded.size(), 0);
-    Assert.assertEquals(copyFiles.size(), 2);
-    Assert.assertEquals(hardLinkFiles.size(), 0);
-    Assert.assertEquals(copyFiles.get(sameNameAsExcludeFile),
+    Assertions.assertEquals(excluded.size(), 0);
+    Assertions.assertEquals(copyFiles.size(), 2);
+    Assertions.assertEquals(hardLinkFiles.size(), 0);
+    Assertions.assertEquals(copyFiles.get(sameNameAsExcludeFile),
         destSameNameAsExcludeFile);
-    Assert.assertEquals(fileSize, expectedFileSize);
+    Assertions.assertEquals(fileSize, expectedFileSize);
     copyFiles = new HashMap<>();
     copyFiles.put(copyFile, destCopyFile);
 
@@ -554,12 +554,12 @@ public class TestOmSnapshotManager {
     // Confirm the file with same name as copy file gets copied.
     fileSize = processFile(sameNameAsCopyFile, copyFiles, hardLinkFiles,
         toExcludeFiles, excluded, destSameNameAsCopyFile.getParent());
-    Assert.assertEquals(excluded.size(), 0);
-    Assert.assertEquals(copyFiles.size(), 2);
-    Assert.assertEquals(hardLinkFiles.size(), 0);
-    Assert.assertEquals(copyFiles.get(sameNameAsCopyFile),
+    Assertions.assertEquals(excluded.size(), 0);
+    Assertions.assertEquals(copyFiles.size(), 2);
+    Assertions.assertEquals(hardLinkFiles.size(), 0);
+    Assertions.assertEquals(copyFiles.get(sameNameAsCopyFile),
         destSameNameAsCopyFile);
-    Assert.assertEquals(fileSize, expectedFileSize);
+    Assertions.assertEquals(fileSize, expectedFileSize);
     copyFiles = new HashMap<>();
     copyFiles.put(copyFile, destCopyFile);
 
@@ -567,30 +567,32 @@ public class TestOmSnapshotManager {
     // Confirm the linkToCopiedFile gets added as a link.
     fileSize = processFile(linkToCopiedFile, copyFiles, hardLinkFiles,
         toExcludeFiles, excluded, destLinkToCopiedFile.getParent());
-    Assert.assertEquals(excluded.size(), 0);
-    Assert.assertEquals(copyFiles.size(), 1);
-    Assert.assertEquals(hardLinkFiles.size(), 1);
-    Assert.assertEquals(hardLinkFiles.get(destLinkToCopiedFile), destCopyFile);
-    Assert.assertEquals(fileSize, 0);
+    Assertions.assertEquals(excluded.size(), 0);
+    Assertions.assertEquals(copyFiles.size(), 1);
+    Assertions.assertEquals(hardLinkFiles.size(), 1);
+    Assertions.assertEquals(hardLinkFiles.get(destLinkToCopiedFile),
+        destCopyFile);
+    Assertions.assertEquals(fileSize, 0);
     hardLinkFiles = new HashMap<>();
 
     // Confirm the addToCopiedFiles gets added to list of copied files
     fileSize = processFile(addToCopiedFiles, copyFiles, hardLinkFiles,
         toExcludeFiles, excluded, destAddToCopiedFiles.getParent());
-    Assert.assertEquals(excluded.size(), 0);
-    Assert.assertEquals(copyFiles.size(), 2);
-    Assert.assertEquals(copyFiles.get(addToCopiedFiles), destAddToCopiedFiles);
-    Assert.assertEquals(fileSize, expectedFileSize);
+    Assertions.assertEquals(excluded.size(), 0);
+    Assertions.assertEquals(copyFiles.size(), 2);
+    Assertions.assertEquals(copyFiles.get(addToCopiedFiles),
+        destAddToCopiedFiles);
+    Assertions.assertEquals(fileSize, expectedFileSize);
     copyFiles = new HashMap<>();
     copyFiles.put(copyFile, destCopyFile);
 
     // Confirm the addNonSstToCopiedFiles gets added to list of copied files
     fileSize = processFile(addNonSstToCopiedFiles, copyFiles, hardLinkFiles,
         toExcludeFiles, excluded, destAddNonSstToCopiedFiles.getParent());
-    Assert.assertEquals(excluded.size(), 0);
-    Assert.assertEquals(copyFiles.size(), 2);
-    Assert.assertEquals(fileSize, 0);
-    Assert.assertEquals(copyFiles.get(addNonSstToCopiedFiles),
+    Assertions.assertEquals(excluded.size(), 0);
+    Assertions.assertEquals(copyFiles.size(), 2);
+    Assertions.assertEquals(fileSize, 0);
+    Assertions.assertEquals(copyFiles.get(addNonSstToCopiedFiles),
         destAddNonSstToCopiedFiles);
   }
 
@@ -633,7 +635,7 @@ public class TestOmSnapshotManager {
     // Create first checkpoint for the snapshot checkpoint
     OmSnapshotManager.createOmSnapshotCheckpoint(om.getMetadataManager(),
         first);
-    Assert.assertFalse(logCapturer.getOutput().contains(
+    Assertions.assertFalse(logCapturer.getOutput().contains(
         "for snapshot " + first.getName() + " already exists."));
     logCapturer.clearOutput();
 
@@ -641,7 +643,7 @@ public class TestOmSnapshotManager {
     OmSnapshotManager.createOmSnapshotCheckpoint(om.getMetadataManager(),
         first);
 
-    Assert.assertTrue(logCapturer.getOutput().contains(
+    Assertions.assertTrue(logCapturer.getOutput().contains(
         "for snapshot " + first.getName() + " already exists."));
   }
 

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestOzoneConfigUtil.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestOzoneConfigUtil.java
@@ -23,9 +23,9 @@ import org.apache.hadoop.hdds.client.ReplicationConfig;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.ozone.OzoneConfigKeys;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.util.Arrays;
@@ -50,7 +50,7 @@ public class TestOzoneConfigUtil {
 
   private OzoneManager ozoneManager;
 
-  @Before
+  @BeforeEach
   public void setup() {
     ozoneManager = mock(OzoneManager.class);
     when(ozoneManager.getDefaultReplicationConfig())
@@ -66,7 +66,7 @@ public class TestOzoneConfigUtil {
         .resolveReplicationConfigPreference(noneType, zeroFactor,
             clientECReplicationConfig, bucketECConfig, ozoneManager);
     // Client has no preference, so we should bucket defaults as we passed.
-    Assert.assertEquals(bucketECConfig.getReplicationConfig(),
+    Assertions.assertEquals(bucketECConfig.getReplicationConfig(),
         replicationConfig);
   }
 
@@ -81,7 +81,7 @@ public class TestOzoneConfigUtil {
             clientECReplicationConfig, null, ozoneManager);
     // Client has no preference, no bucket defaults, so it should return server
     // defaults.
-    Assert.assertEquals(ratis3ReplicationConfig, replicationConfig);
+    Assertions.assertEquals(ratis3ReplicationConfig, replicationConfig);
   }
 
   /**
@@ -96,7 +96,7 @@ public class TestOzoneConfigUtil {
             ozoneManager);
     // Client has preference of type EC, no bucket defaults, so it should return
     // client preference.
-    Assert.assertEquals(new ECReplicationConfig("rs-3-2-1024K"),
+    Assertions.assertEquals(new ECReplicationConfig("rs-3-2-1024K"),
         replicationConfig);
   }
 
@@ -116,7 +116,7 @@ public class TestOzoneConfigUtil {
             ozoneManager);
     // Client has no preference of type and bucket has ratis defaults, so it
     // should return ratis.
-    Assert.assertEquals(ratisReplicationConfig, replicationConfig);
+    Assertions.assertEquals(ratisReplicationConfig, replicationConfig);
   }
 
   @Test
@@ -124,7 +124,7 @@ public class TestOzoneConfigUtil {
     OzoneConfiguration configuration = new OzoneConfiguration();
     configuration.set(OzoneConfigKeys.OZONE_S3_ADMINISTRATORS, "alice,bob");
 
-    Assert.assertTrue(OzoneConfigUtil.getS3AdminsFromConfig(configuration)
+    Assertions.assertTrue(OzoneConfigUtil.getS3AdminsFromConfig(configuration)
         .containsAll(Arrays.asList("alice", "bob")));
   }
 
@@ -133,7 +133,7 @@ public class TestOzoneConfigUtil {
     OzoneConfiguration configuration = new OzoneConfiguration();
     configuration.set(OzoneConfigKeys.OZONE_ADMINISTRATORS, "alice,bob");
 
-    Assert.assertTrue(OzoneConfigUtil.getS3AdminsFromConfig(configuration)
+    Assertions.assertTrue(OzoneConfigUtil.getS3AdminsFromConfig(configuration)
         .containsAll(Arrays.asList("alice", "bob")));
   }
 
@@ -143,8 +143,8 @@ public class TestOzoneConfigUtil {
     configuration.set(OzoneConfigKeys.OZONE_S3_ADMINISTRATORS_GROUPS,
         "test1, test2");
 
-    Assert.assertTrue(OzoneConfigUtil.getS3AdminsGroupsFromConfig(configuration)
-        .containsAll(Arrays.asList("test1", "test2")));
+    Assertions.assertTrue(OzoneConfigUtil.getS3AdminsGroupsFromConfig(
+        configuration).containsAll(Arrays.asList("test1", "test2")));
   }
 
   @Test
@@ -153,7 +153,7 @@ public class TestOzoneConfigUtil {
     configuration.set(OzoneConfigKeys.OZONE_ADMINISTRATORS_GROUPS,
         "test1, test2");
 
-    Assert.assertTrue(OzoneConfigUtil.getS3AdminsGroupsFromConfig(configuration)
-        .containsAll(Arrays.asList("test1", "test2")));
+    Assertions.assertTrue(OzoneConfigUtil.getS3AdminsGroupsFromConfig(
+        configuration).containsAll(Arrays.asList("test1", "test2")));
   }
 }

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerHttpServer.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerHttpServer.java
@@ -30,26 +30,22 @@ import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.server.http.BaseHttpServer;
 import org.apache.hadoop.hdfs.web.URLConnectionFactory;
 import org.apache.hadoop.http.HttpConfig;
-import org.apache.hadoop.http.HttpConfig.Policy;
 import org.apache.hadoop.metrics2.lib.DefaultMetricsSystem;
 import org.apache.hadoop.net.NetUtils;
 import org.apache.hadoop.ozone.OzoneConfigKeys;
 import org.apache.hadoop.security.ssl.KeyStoreTestUtil;
 import org.apache.ozone.test.GenericTestUtils;
 
-import org.junit.AfterClass;
-import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Assertions;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
-import org.junit.runners.Parameterized.Parameters;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 /**
  * Test http server of OM with various HTTP option.
  */
-@RunWith(value = Parameterized.class)
 public class TestOzoneManagerHttpServer {
   private static final String BASEDIR = GenericTestUtils
       .getTempPath(TestOzoneManagerHttpServer.class.getSimpleName());
@@ -58,8 +54,7 @@ public class TestOzoneManagerHttpServer {
   private static OzoneConfiguration conf;
   private static URLConnectionFactory connectionFactory;
   private static File ozoneMetadataDirectory;
-
-  @Parameters public static Collection<Object[]> policy() {
+  public static Collection<Object[]> policy() {
     Object[][] params = new Object[][] {
         {HttpConfig.Policy.HTTP_ONLY},
         {HttpConfig.Policy.HTTPS_ONLY},
@@ -67,14 +62,7 @@ public class TestOzoneManagerHttpServer {
     return Arrays.asList(params);
   }
 
-  private final HttpConfig.Policy policy;
-
-  public TestOzoneManagerHttpServer(Policy policy) {
-    super();
-    this.policy = policy;
-  }
-
-  @BeforeClass public static void setUp() throws Exception {
+  @BeforeAll public static void setUp() throws Exception {
     File base = new File(BASEDIR);
     FileUtil.fullyDelete(base);
 
@@ -104,13 +92,15 @@ public class TestOzoneManagerHttpServer {
     conf.set(OMConfigKeys.OZONE_OM_HTTPS_BIND_HOST_KEY, "localhost");
   }
 
-  @AfterClass public static void tearDown() throws Exception {
+  @AfterAll public static void tearDown() throws Exception {
     connectionFactory.destroy();
     FileUtil.fullyDelete(new File(BASEDIR));
     KeyStoreTestUtil.cleanupSSLConfig(keystoresDir, sslConfDir);
   }
 
-  @Test public void testHttpPolicy() throws Exception {
+  @ParameterizedTest
+  @MethodSource("policy")
+  public void testHttpPolicy(HttpConfig.Policy policy) throws Exception {
     conf.set(OzoneConfigKeys.OZONE_HTTP_POLICY_KEY, policy.name());
     OzoneManagerHttpServer server = null;
     try {
@@ -118,15 +108,15 @@ public class TestOzoneManagerHttpServer {
       DefaultMetricsSystem.initialize("TestOzoneManagerHttpServer");
       server.start();
 
-      Assert.assertTrue(implies(policy.isHttpEnabled(),
+      Assertions.assertTrue(implies(policy.isHttpEnabled(),
           canAccess("http", server.getHttpAddress())));
-      Assert.assertTrue(implies(policy.isHttpEnabled() &&
+      Assertions.assertTrue(implies(policy.isHttpEnabled() &&
               !policy.isHttpsEnabled(),
           !canAccess("https", server.getHttpsAddress())));
 
-      Assert.assertTrue(implies(policy.isHttpsEnabled(),
+      Assertions.assertTrue(implies(policy.isHttpsEnabled(),
           canAccess("https", server.getHttpsAddress())));
-      Assert.assertTrue(implies(policy.isHttpsEnabled(),
+      Assertions.assertTrue(implies(policy.isHttpsEnabled(),
           !canAccess("http", server.getHttpsAddress())));
     } finally {
       if (server != null) {
@@ -146,7 +136,7 @@ public class TestOzoneManagerHttpServer {
       // Checking if the /webserver directory does get created
       File webServerDir =
           new File(ozoneMetadataDirectory, BaseHttpServer.SERVER_DIR);
-      Assert.assertTrue(webServerDir.exists());
+      Assertions.assertTrue(webServerDir.exists());
       // Verify that the jetty directory is set correctly
       String expectedJettyDirLocation =
           ozoneMetadataDirectory.getAbsolutePath() + BaseHttpServer.SERVER_DIR;

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerStarter.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerStarter.java
@@ -19,9 +19,9 @@ package org.apache.hadoop.ozone.om;
 
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.security.authentication.client.AuthenticationException;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -32,9 +32,9 @@ import java.util.regex.Pattern;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.apache.hadoop.hdds.cli.GenericCli.EXECUTION_ERROR_EXIT_CODE;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static picocli.CommandLine.ExitCode.OK;
 import static picocli.CommandLine.ExitCode.USAGE;
 
@@ -54,14 +54,14 @@ public class TestOzoneManagerStarter {
 
   private MockOMStarter mock;
 
-  @Before
+  @BeforeEach
   public void setUpStreams() throws UnsupportedEncodingException {
     System.setOut(new PrintStream(outContent, false, DEFAULT_ENCODING));
     System.setErr(new PrintStream(errContent, false, DEFAULT_ENCODING));
     mock = new MockOMStarter();
   }
 
-  @After
+  @AfterEach
   public void restoreStreams() {
     System.setOut(originalOut);
     System.setErr(originalErr);

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestSnapshotInfo.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestSnapshotInfo.java
@@ -23,12 +23,12 @@ import org.apache.hadoop.hdds.utils.db.Table;
 import org.apache.hadoop.ozone.om.helpers.SnapshotInfo;
 import org.apache.hadoop.ozone.om.helpers.SnapshotInfo.SnapshotStatus;
 import org.apache.hadoop.util.Time;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
+import java.nio.file.Path;
 import java.util.UUID;
 
 import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_DB_DIRS;
@@ -43,14 +43,14 @@ public class TestSnapshotInfo {
   private static final UUID EXPECTED_SNAPSHOT_ID = UUID.randomUUID();
   private static final UUID EXPECTED_PREVIOUS_SNAPSHOT_ID = UUID.randomUUID();
 
-  @Rule
-  public TemporaryFolder folder = new TemporaryFolder();
+  @TempDir
+  private Path folder;
 
-  @Before
+  @BeforeEach
   public void setup() throws Exception {
     OzoneConfiguration conf = new OzoneConfiguration();
     conf.set(OZONE_OM_DB_DIRS,
-        folder.getRoot().getAbsolutePath());
+        folder.toAbsolutePath().toString());
     omMetadataManager = new OmMetadataManagerImpl(conf, null);
   }
 
@@ -74,7 +74,7 @@ public class TestSnapshotInfo {
   public void testTableExists() throws Exception {
     Table<String, SnapshotInfo> snapshotInfo =
         omMetadataManager.getSnapshotInfoTable();
-    Assert.assertTrue(snapshotInfo.isEmpty());
+    Assertions.assertTrue(snapshotInfo.isEmpty());
   }
 
   @Test
@@ -82,7 +82,7 @@ public class TestSnapshotInfo {
     Table<String, SnapshotInfo> snapshotInfo =
         omMetadataManager.getSnapshotInfoTable();
     snapshotInfo.put(EXPECTED_SNAPSHOT_KEY, createSnapshotInfo());
-    Assert.assertEquals(EXPECTED_SNAPSHOT_ID,
+    Assertions.assertEquals(EXPECTED_SNAPSHOT_ID,
         snapshotInfo.get(EXPECTED_SNAPSHOT_KEY).getSnapshotId());
   }
 
@@ -91,11 +91,11 @@ public class TestSnapshotInfo {
     Table<String, SnapshotInfo> snapshotInfo =
         omMetadataManager.getSnapshotInfoTable();
 
-    Assert.assertFalse(snapshotInfo.isExist(EXPECTED_SNAPSHOT_KEY));
+    Assertions.assertFalse(snapshotInfo.isExist(EXPECTED_SNAPSHOT_KEY));
     snapshotInfo.put(EXPECTED_SNAPSHOT_KEY, createSnapshotInfo());
-    Assert.assertTrue(snapshotInfo.isExist(EXPECTED_SNAPSHOT_KEY));
+    Assertions.assertTrue(snapshotInfo.isExist(EXPECTED_SNAPSHOT_KEY));
     snapshotInfo.delete(EXPECTED_SNAPSHOT_KEY);
-    Assert.assertFalse(snapshotInfo.isExist(EXPECTED_SNAPSHOT_KEY));
+    Assertions.assertFalse(snapshotInfo.isExist(EXPECTED_SNAPSHOT_KEY));
   }
 
   @Test
@@ -105,9 +105,11 @@ public class TestSnapshotInfo {
     SnapshotInfo info  = createSnapshotInfo();
     info.setSstFiltered(false);
     snapshotInfo.put(EXPECTED_SNAPSHOT_KEY, info);
-    Assert.assertFalse(snapshotInfo.get(EXPECTED_SNAPSHOT_KEY).isSstFiltered());
+    Assertions.assertFalse(snapshotInfo.get(EXPECTED_SNAPSHOT_KEY)
+        .isSstFiltered());
     info.setSstFiltered(true);
     snapshotInfo.put(EXPECTED_SNAPSHOT_KEY, info);
-    Assert.assertTrue(snapshotInfo.get(EXPECTED_SNAPSHOT_KEY).isSstFiltered());
+    Assertions.assertTrue(snapshotInfo.get(EXPECTED_SNAPSHOT_KEY)
+        .isSstFiltered());
   }
 }

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestTrashService.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestTrashService.java
@@ -33,15 +33,15 @@ import org.apache.hadoop.ozone.om.protocol.OzoneManagerProtocol;
 import org.apache.hadoop.ozone.om.request.OMRequestTestUtils;
 import org.apache.hadoop.security.authentication.client.AuthenticationException;
 import org.apache.ratis.util.ExitUtils;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collections;
 
@@ -56,8 +56,8 @@ import java.util.Collections;
  */
 public class TestTrashService {
 
-  @Rule
-  public TemporaryFolder tempFolder = new TemporaryFolder();
+  @TempDir
+  private Path tempFolder;
 
   private KeyManager keyManager;
   private OzoneManagerProtocol writeClient;
@@ -65,14 +65,14 @@ public class TestTrashService {
   private String volumeName;
   private String bucketName;
 
-  @Before
+  @BeforeEach
   public void setup() throws IOException, AuthenticationException {
     ExitUtils.disableSystemExit();
     OzoneConfiguration configuration = new OzoneConfiguration();
 
-    File folder = tempFolder.newFolder();
+    File folder = tempFolder.toFile();
     if (!folder.exists()) {
-      Assert.assertTrue(folder.mkdirs());
+      Assertions.assertTrue(folder.mkdirs());
     }
     System.setProperty(DBConfigFromFile.CONFIG_DIR, "/");
     ServerUtils.setOzoneMetaDirPath(configuration, folder.toString());
@@ -86,7 +86,7 @@ public class TestTrashService {
     bucketName = "bucket";
   }
 
-  @After
+  @AfterEach
   public void cleanup() throws Exception {
     om.stop();
   }
@@ -99,7 +99,7 @@ public class TestTrashService {
 
     boolean recoverOperation = keyManager.getMetadataManager()
         .recoverTrash(volumeName, bucketName, keyName, destinationBucket);
-    Assert.assertTrue(recoverOperation);
+    Assertions.assertTrue(recoverOperation);
   }
 
   private void createAndDeleteKey(String keyName) throws IOException {

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/failover/TestOMFailovers.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/failover/TestOMFailovers.java
@@ -38,8 +38,8 @@ import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMResponse;
 import org.apache.hadoop.security.AccessControlException;
 import org.apache.ozone.test.GenericTestUtils;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 import org.slf4j.event.Level;
 
 /**
@@ -70,22 +70,22 @@ public class TestOMFailovers {
 
     try {
       proxy.submitRequest(null, null);
-      Assert.fail("Request should fail with AccessControlException");
+      Assertions.fail("Request should fail with AccessControlException");
     } catch (Exception ex) {
-      Assert.assertTrue(ex instanceof ServiceException);
+      Assertions.assertTrue(ex instanceof ServiceException);
 
       // Request should try all OMs one be one and fail when the last OM also
       // throws AccessControlException.
       GenericTestUtils.assertExceptionContains("ServiceException of " +
           "type class org.apache.hadoop.security.AccessControlException for " +
           "om3", ex);
-      Assert.assertTrue(ex.getCause() instanceof AccessControlException);
+      Assertions.assertTrue(ex.getCause() instanceof AccessControlException);
 
-      Assert.assertTrue(
+      Assertions.assertTrue(
           logCapturer.getOutput().contains(getRetryProxyDebugMsg("om1")));
-      Assert.assertTrue(
+      Assertions.assertTrue(
           logCapturer.getOutput().contains(getRetryProxyDebugMsg("om2")));
-      Assert.assertTrue(
+      Assertions.assertTrue(
           logCapturer.getOutput().contains(getRetryProxyDebugMsg("om3")));
     }
   }

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/lock/TestOzoneLockProvider.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/lock/TestOzoneLockProvider.java
@@ -20,11 +20,10 @@ package org.apache.hadoop.ozone.om.lock;
 
 import org.apache.hadoop.ozone.om.OzoneManager;
 import org.apache.hadoop.ozone.om.helpers.BucketLayout;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.Mockito;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -37,7 +36,6 @@ import static org.mockito.Mockito.when;
 /**
  * Test for OzoneLockProvider.
  */
-@RunWith(Parameterized.class)
 public class TestOzoneLockProvider {
 
   private static final Logger LOG =
@@ -46,7 +44,6 @@ public class TestOzoneLockProvider {
   private OzoneManager ozoneManager;
   private OzoneLockStrategy ozoneLockStrategy;
 
-  @Parameterized.Parameters
   public static Collection<Object[]> data() {
     return Arrays.asList(
         new Object[]{true, true},
@@ -54,30 +51,20 @@ public class TestOzoneLockProvider {
         new Object[]{false, true},
         new Object[]{false, false});
   }
+  private boolean keyPathLockEnabled;
+  private boolean enableFileSystemPaths;
 
-  public TestOzoneLockProvider(boolean setKeyPathLock,
-                               boolean setFileSystemPaths) {
-    // Ignored. Actual init done in initParam().
-    // This empty constructor is still required to avoid argument exception.
-  }
-
-  @Parameterized.BeforeParam
-  public static void initParam(boolean setKeyPathLock,
-                               boolean setFileSystemPaths) {
-    keyPathLockEnabled = setKeyPathLock;
-    enableFileSystemPaths = setFileSystemPaths;
-  }
-
-  private static boolean keyPathLockEnabled;
-  private static boolean enableFileSystemPaths;
-
-  @Before
+  @BeforeEach
   public void setup() throws Exception {
     ozoneManager = Mockito.mock(OzoneManager.class);
   }
 
-  @Test
-  public void testOzoneLockProvider() {
+  @ParameterizedTest
+  @MethodSource("data")
+  public void testOzoneLockProvider(boolean setKeyPathLock,
+                                    boolean setFileSystemPaths) {
+    this.keyPathLockEnabled = setKeyPathLock;
+    this.enableFileSystemPaths = setFileSystemPaths;
     for (BucketLayout bucketLayout : BucketLayout.values()) {
       testOzoneLockProviderUtil(bucketLayout);
     }
@@ -96,13 +83,16 @@ public class TestOzoneLockProvider {
 
     if (keyPathLockEnabled) {
       if (bucketLayout == BucketLayout.OBJECT_STORE) {
-        Assert.assertTrue(ozoneLockStrategy instanceof OBSKeyPathLockStrategy);
+        Assertions.assertTrue(
+            ozoneLockStrategy instanceof OBSKeyPathLockStrategy);
       } else if (!enableFileSystemPaths &&
           bucketLayout == BucketLayout.LEGACY) {
-        Assert.assertTrue(ozoneLockStrategy instanceof OBSKeyPathLockStrategy);
+        Assertions.assertTrue(
+            ozoneLockStrategy instanceof OBSKeyPathLockStrategy);
       }
     } else {
-      Assert.assertTrue(ozoneLockStrategy instanceof RegularBucketLockStrategy);
+      Assertions.assertTrue(
+          ozoneLockStrategy instanceof RegularBucketLockStrategy);
     }
   }
 }

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/multitenant/TestMultiTenantAccessController.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/multitenant/TestMultiTenantAccessController.java
@@ -25,9 +25,9 @@ import org.apache.hadoop.ozone.security.acl.IAccessAuthorizer.ACLType;
 import org.apache.hadoop.security.authentication.util.KerberosName;
 import org.apache.ozone.test.GenericTestUtils;
 import org.apache.ranger.RangerClient;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.slf4j.LoggerFactory;
 import org.slf4j.event.Level;
 
@@ -53,7 +53,7 @@ public class TestMultiTenantAccessController {
   private MultiTenantAccessController controller;
   private List<String> users;
 
-  @Before
+  @BeforeEach
   public void setupUsers() {
     // If testing against a real cluster, users must already be added to Ranger.
     users = new ArrayList<>();
@@ -64,7 +64,7 @@ public class TestMultiTenantAccessController {
   /**
    * Use this setup to test against a simulated Ranger instance.
    */
-  @Before
+  @BeforeEach
   public void setupUnitTest() {
     controller = new InMemoryMultiTenantAccessController();
   }
@@ -72,7 +72,7 @@ public class TestMultiTenantAccessController {
   /**
    * Use this setup to test against a live Ranger instance.
    */
-//  @Before
+//  @BeforeEach
   public void setupClusterTest() throws Exception {
 
     // Set up truststore
@@ -148,23 +148,23 @@ public class TestMultiTenantAccessController {
     // get to check it's there with all attributes.
     MultiTenantAccessController.Policy retrievedPolicy =
         controller.getPolicy(policyName);
-    Assert.assertEquals(originalPolicy, retrievedPolicy);
+    Assertions.assertEquals(originalPolicy, retrievedPolicy);
 
     // Service policy version should have been bumped by 1 at this point
     long currPolicyVersion = controller.getRangerServicePolicyVersion();
-    Assert.assertEquals(prevPolicyVersion + 1L, currPolicyVersion);
+    Assertions.assertEquals(prevPolicyVersion + 1L, currPolicyVersion);
 
     // delete policy.
     controller.deletePolicy(policyName);
 
     // Service policy version should have been bumped again
     currPolicyVersion = controller.getRangerServicePolicyVersion();
-    Assert.assertEquals(prevPolicyVersion + 2L, currPolicyVersion);
+    Assertions.assertEquals(prevPolicyVersion + 2L, currPolicyVersion);
 
     // get to check it is deleted.
     try {
       controller.getPolicy(policyName);
-      Assert.fail("Expected exception for missing policy.");
+      Assertions.fail("Expected exception for missing policy.");
     } catch (Exception ex) {
        // Expected since policy is not there.
     }
@@ -181,7 +181,7 @@ public class TestMultiTenantAccessController {
             .build();
     // create in ranger.
     controller.createPolicy(originalPolicy);
-    Assert.assertEquals(originalPolicy, controller.getPolicy(policyName));
+    Assertions.assertEquals(originalPolicy, controller.getPolicy(policyName));
 
     // Create a policy with the same name but different resource.
     // Check for error.
@@ -192,7 +192,7 @@ public class TestMultiTenantAccessController {
             .build();
     try {
       controller.createPolicy(sameNamePolicy);
-      Assert.fail("Expected exception for duplicate policy.");
+      Assertions.fail("Expected exception for duplicate policy.");
     } catch (Exception ex) {
       // Expected since a policy with the same name should not be allowed.
     }
@@ -206,7 +206,7 @@ public class TestMultiTenantAccessController {
             .build();
     try {
       controller.createPolicy(sameResourcePolicy);
-      Assert.fail("Expected exception for duplicate policy.");
+      Assertions.fail("Expected exception for duplicate policy.");
     } catch (Exception ex) {
       // Expected since a policy with the same resource should not be allowed.
     }
@@ -245,16 +245,17 @@ public class TestMultiTenantAccessController {
     // Get should only return policies with the specified label.
     List<Policy> retrievedLabeledPolicies =
         controller.getLabeledPolicies(label);
-    Assert.assertEquals(labeledPolicies.size(),
+    Assertions.assertEquals(labeledPolicies.size(),
         retrievedLabeledPolicies.size());
-    Assert.assertTrue(retrievedLabeledPolicies.containsAll(labeledPolicies));
+    Assertions.assertTrue(retrievedLabeledPolicies.containsAll(
+        labeledPolicies));
 
     // Get of a specific policy should also succeed.
     Policy retrievedPolicy = controller.getPolicy(unlabeledPolicy.getName());
-    Assert.assertEquals(unlabeledPolicy, retrievedPolicy);
+    Assertions.assertEquals(unlabeledPolicy, retrievedPolicy);
 
     // Get of policies with nonexistent label should give an empty list.
-    Assert.assertTrue(controller.getLabeledPolicies(label + "1").isEmpty());
+    Assertions.assertTrue(controller.getLabeledPolicies(label + "1").isEmpty());
 
     // Cleanup
     for (Policy policy: labeledPolicies) {
@@ -276,7 +277,7 @@ public class TestMultiTenantAccessController {
             Collections.singletonList(Acl.allow(ACLType.READ_ACL)))
         .build();
     controller.createPolicy(originalPolicy);
-    Assert.assertEquals(originalPolicy,
+    Assertions.assertEquals(originalPolicy,
         controller.getPolicy(policyName));
 
     Policy updatedPolicy = new Policy.Builder()
@@ -289,7 +290,7 @@ public class TestMultiTenantAccessController {
             Collections.singletonList(Acl.allow(ACLType.READ_ACL)))
         .build();
     controller.updatePolicy(updatedPolicy);
-    Assert.assertEquals(updatedPolicy,
+    Assertions.assertEquals(updatedPolicy,
         controller.getPolicy(policyName));
 
     // Cleanup
@@ -313,17 +314,17 @@ public class TestMultiTenantAccessController {
     Policy retrievedPolicy = controller.getPolicy(policy.getName());
     Map<String, Collection<Acl>> retrievedRoleAcls =
         retrievedPolicy.getRoleAcls();
-    Assert.assertEquals(1, retrievedRoleAcls.size());
+    Assertions.assertEquals(1, retrievedRoleAcls.size());
     List<Acl> roleAcls = new ArrayList<>(retrievedRoleAcls.get(roleName));
-    Assert.assertEquals(1, roleAcls.size());
-    Assert.assertEquals(ACLType.ALL, roleAcls.get(0).getAclType());
-    Assert.assertTrue(roleAcls.get(0).isAllowed());
+    Assertions.assertEquals(1, roleAcls.size());
+    Assertions.assertEquals(ACLType.ALL, roleAcls.get(0).getAclType());
+    Assertions.assertTrue(roleAcls.get(0).isAllowed());
 
     // get one of the roles to check it is there but empty.
     Role retrievedRole = controller.getRole(roleName);
-    Assert.assertFalse(retrievedRole.getDescription().isPresent());
-    Assert.assertTrue(retrievedRole.getUsersMap().isEmpty());
-    Assert.assertTrue(retrievedRole.getId().isPresent());
+    Assertions.assertFalse(retrievedRole.getDescription().isPresent());
+    Assertions.assertTrue(retrievedRole.getUsersMap().isEmpty());
+    Assertions.assertTrue(retrievedRole.getId().isPresent());
 
     // Add a user to the role.
     retrievedRole.getUsersMap().put(users.get(0), false);
@@ -338,7 +339,7 @@ public class TestMultiTenantAccessController {
             Collections.singletonList(Acl.allow(ACLType.READ)))
         .build();
     controller.createPolicy(policy2);
-    Assert.assertEquals(controller.getRole(roleName), retrievedRole);
+    Assertions.assertEquals(controller.getRole(roleName), retrievedRole);
 
     controller.deletePolicy("policy1");
     controller.deletePolicy("policy2");
@@ -362,15 +363,15 @@ public class TestMultiTenantAccessController {
     // get to check it's there with all attributes.
     Role retrievedRole = controller.getRole(roleName);
     // Role ID should have been added by Ranger.
-    Assert.assertTrue(retrievedRole.getId().isPresent());
-    Assert.assertEquals(originalRole, retrievedRole);
+    Assertions.assertTrue(retrievedRole.getId().isPresent());
+    Assertions.assertEquals(originalRole, retrievedRole);
 
     // delete role.
     controller.deleteRole(roleName);
     // get to check it is deleted.
     try {
       controller.getRole(roleName);
-      Assert.fail("Expected exception for missing role.");
+      Assertions.fail("Expected exception for missing role.");
     } catch (Exception ex) {
       // Expected since policy is not there.
     }
@@ -385,7 +386,7 @@ public class TestMultiTenantAccessController {
             .build();
     // create in Ranger.
     controller.createRole(originalRole);
-    Assert.assertEquals(originalRole, controller.getRole(roleName));
+    Assertions.assertEquals(originalRole, controller.getRole(roleName));
 
     // Create a role with the same name and check for error.
     Role sameNameRole = new Role.Builder()
@@ -394,7 +395,7 @@ public class TestMultiTenantAccessController {
             .build();
     try {
       controller.createRole(sameNameRole);
-      Assert.fail("Expected exception for duplicate role.");
+      Assertions.fail("Expected exception for duplicate role.");
     } catch (Exception ex) {
       // Expected since a policy with the same name should not be allowed.
     }
@@ -415,18 +416,18 @@ public class TestMultiTenantAccessController {
     controller.createRole(originalRole);
 
     Role retrievedRole = controller.getRole(roleName);
-    Assert.assertEquals(originalRole, retrievedRole);
-    Assert.assertTrue(retrievedRole.getId().isPresent());
+    Assertions.assertEquals(originalRole, retrievedRole);
+    Assertions.assertTrue(retrievedRole.getId().isPresent());
     long roleId = retrievedRole.getId().get();
 
     // Remove a user from the role and update it.
     retrievedRole.getUsersMap().remove(users.get(0));
-    Assert.assertEquals(originalRole.getUsersMap().size() - 1,
+    Assertions.assertEquals(originalRole.getUsersMap().size() - 1,
         retrievedRole.getUsersMap().size());
     controller.updateRole(roleId, retrievedRole);
     Role retrievedUpdatedRole = controller.getRole(roleName);
-    Assert.assertEquals(retrievedRole, retrievedUpdatedRole);
-    Assert.assertEquals(originalRole.getUsersMap().size() - 1,
+    Assertions.assertEquals(retrievedRole, retrievedUpdatedRole);
+    Assertions.assertEquals(originalRole.getUsersMap().size() - 1,
         retrievedUpdatedRole.getUsersMap().size());
 
     // Cleanup.

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/ratis/TestOzoneManagerDoubleBuffer.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/ratis/TestOzoneManagerDoubleBuffer.java
@@ -51,7 +51,7 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.Mockito;
 
-import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/ratis/TestOzoneManagerDoubleBufferWithDummyResponse.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/ratis/TestOzoneManagerDoubleBufferWithDummyResponse.java
@@ -19,20 +19,18 @@
 package org.apache.hadoop.ozone.om.ratis;
 
 import java.io.IOException;
+import java.nio.file.Path;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicLong;
 
 import org.apache.hadoop.hdds.utils.TransactionInfo;
 import org.apache.hadoop.ozone.om.response.CleanupTableInfo;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
-import org.junit.rules.TestRule;
-import org.junit.rules.Timeout;
-import org.apache.ozone.test.JUnit5AwareTimeout;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos
@@ -52,10 +50,11 @@ import static org.apache.hadoop.hdds.HddsConfigKeys.OZONE_METADATA_DIRS;
 import static org.apache.hadoop.ozone.OzoneConsts.TRANSACTION_INFO_KEY;
 import static org.apache.hadoop.ozone.om.OmMetadataManagerImpl.BUCKET_TABLE;
 import static org.apache.ozone.test.GenericTestUtils.waitFor;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
+@Timeout(300)
 /**
  * This class tests OzoneManagerDoubleBuffer implementation with
  * dummy response class.
@@ -67,18 +66,14 @@ public class TestOzoneManagerDoubleBufferWithDummyResponse {
   private final AtomicLong trxId = new AtomicLong(0);
   private long lastAppliedIndex;
   private long term = 1L;
+  @TempDir
+  private Path folder;
 
-  @Rule
-  public TestRule timeout = new JUnit5AwareTimeout(Timeout.seconds(300));
-
-  @Rule
-  public TemporaryFolder folder = new TemporaryFolder();
-
-  @Before
+  @BeforeEach
   public void setup() throws IOException {
     OzoneConfiguration configuration = new OzoneConfiguration();
     configuration.set(OZONE_METADATA_DIRS,
-        folder.newFolder().getAbsolutePath());
+        folder.toAbsolutePath().toString());
     omMetadataManager =
         new OmMetadataManagerImpl(configuration, null);
     OzoneManagerRatisSnapshot ozoneManagerRatisSnapshot = index -> {
@@ -93,7 +88,7 @@ public class TestOzoneManagerDoubleBufferWithDummyResponse {
         .build();
   }
 
-  @After
+  @AfterEach
   public void stop() {
     doubleBuffer.stop();
   }
@@ -147,9 +142,9 @@ public class TestOzoneManagerDoubleBufferWithDummyResponse {
         omMetadataManager.getTransactionInfoTable().get(TRANSACTION_INFO_KEY);
     assertNotNull(transactionInfo);
 
-    Assert.assertEquals(lastAppliedIndex,
+    Assertions.assertEquals(lastAppliedIndex,
         transactionInfo.getTransactionIndex());
-    Assert.assertEquals(term, transactionInfo.getTerm());
+    Assertions.assertEquals(term, transactionInfo.getTerm());
   }
 
   /**

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/ratis/TestOzoneManagerDoubleBufferWithDummyResponse.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/ratis/TestOzoneManagerDoubleBufferWithDummyResponse.java
@@ -54,11 +54,11 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-@Timeout(300)
 /**
  * This class tests OzoneManagerDoubleBuffer implementation with
  * dummy response class.
  */
+@Timeout(300)
 public class TestOzoneManagerDoubleBufferWithDummyResponse {
 
   private OMMetadataManager omMetadataManager;

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/ratis/TestOzoneManagerRatisServer.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/ratis/TestOzoneManagerRatisServer.java
@@ -51,19 +51,18 @@ import org.apache.ratis.server.protocol.TermIndex;
 import org.apache.ratis.statemachine.SnapshotInfo;
 import org.apache.ratis.util.ExitUtils;
 import org.apache.ratis.util.LifeCycle;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 import org.mockito.Mockito;
 import org.slf4j.LoggerFactory;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.apache.hadoop.ozone.OzoneConsts.TRANSACTION_INFO_KEY;
-import static org.junit.Assert.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -73,8 +72,8 @@ import static org.mockito.Mockito.when;
 public class TestOzoneManagerRatisServer {
 
 
-  @Rule
-  public TemporaryFolder folder = new TemporaryFolder();
+  @TempDir
+  private Path folder;
 
   private OzoneConfiguration conf;
   private OzoneManagerRatisServer omRatisServer;
@@ -88,12 +87,12 @@ public class TestOzoneManagerRatisServer {
   private SecurityConfig secConfig;
   private OMCertificateClient certClient;
 
-  @BeforeClass
+  @BeforeAll
   public static void setup() {
     ExitUtils.disableSystemExit();
   }
   
-  @Before
+  @BeforeEach
   public void init() throws Exception {
     conf = new OzoneConfiguration();
     omID = UUID.randomUUID().toString();
@@ -121,7 +120,7 @@ public class TestOzoneManagerRatisServer {
     ozoneManager = Mockito.mock(OzoneManager.class);
     OzoneConfiguration ozoneConfiguration = new OzoneConfiguration();
     ozoneConfiguration.set(OMConfigKeys.OZONE_OM_DB_DIRS,
-        folder.newFolder().getAbsolutePath());
+        folder.toAbsolutePath().toString());
     omMetadataManager = new OmMetadataManagerImpl(ozoneConfiguration,
         ozoneManager);
     when(ozoneManager.getMetadataManager()).thenReturn(omMetadataManager);
@@ -140,7 +139,7 @@ public class TestOzoneManagerRatisServer {
     omRatisServer.start();
   }
 
-  @After
+  @AfterEach
   public void shutdown() throws IOException {
     if (omRatisServer != null) {
       omRatisServer.stop();
@@ -153,8 +152,9 @@ public class TestOzoneManagerRatisServer {
    */
   @Test
   public void testStartOMRatisServer() throws Exception {
-    Assert.assertEquals("Ratis Server should be in running state",
-        LifeCycle.State.RUNNING, omRatisServer.getServerState());
+    Assertions.assertEquals(LifeCycle.State.RUNNING,
+        omRatisServer.getServerState(),
+        "Ratis Server should be in running state");
   }
 
   @Test
@@ -182,9 +182,9 @@ public class TestOzoneManagerRatisServer {
     TermIndex lastAppliedTermIndex =
         omRatisServer.getLastAppliedTermIndex();
 
-    Assert.assertEquals(newSnapshotIndex.getIndex(),
+    Assertions.assertEquals(newSnapshotIndex.getIndex(),
         lastAppliedTermIndex.getIndex());
-    Assert.assertEquals(newSnapshotIndex.getTerm(),
+    Assertions.assertEquals(newSnapshotIndex.getTerm(),
         lastAppliedTermIndex.getTerm());
   }
 
@@ -205,10 +205,10 @@ public class TestOzoneManagerRatisServer {
           .setClientId(clientId)
           .build();
       OmUtils.isReadOnly(request);
-      assertFalse(cmdtype + " is not categorized in " +
-              "OmUtils#isReadyOnly",
+      assertFalse(
           logCapturer.getOutput().contains("CmdType " + cmdtype + " is not " +
-              "categorized as readOnly or not."));
+              "categorized as readOnly or not."),
+          cmdtype + " is not categorized in OmUtils#isReadyOnly");
       logCapturer.clearOutput();
     }
   }
@@ -219,8 +219,8 @@ public class TestOzoneManagerRatisServer {
     UUID uuid = UUID.nameUUIDFromBytes(OzoneConsts.OM_SERVICE_ID_DEFAULT
         .getBytes(UTF_8));
     RaftGroupId raftGroupId = omRatisServer.getRaftGroup().getGroupId();
-    Assert.assertEquals(uuid, raftGroupId.getUuid());
-    Assert.assertEquals(raftGroupId.toByteString().size(), 16);
+    Assertions.assertEquals(uuid, raftGroupId.getUuid());
+    Assertions.assertEquals(raftGroupId.toByteString().size(), 16);
   }
 
   @Test
@@ -252,8 +252,8 @@ public class TestOzoneManagerRatisServer {
 
     UUID uuid = UUID.nameUUIDFromBytes(customOmServiceId.getBytes(UTF_8));
     RaftGroupId raftGroupId = newOmRatisServer.getRaftGroup().getGroupId();
-    Assert.assertEquals(uuid, raftGroupId.getUuid());
-    Assert.assertEquals(raftGroupId.toByteString().size(), 16);
+    Assertions.assertEquals(uuid, raftGroupId.getUuid());
+    Assertions.assertEquals(raftGroupId.toByteString().size(), 16);
     newOmRatisServer.stop();
   }
 

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/ratis/TestOzoneManagerStateMachine.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/ratis/TestOzoneManagerStateMachine.java
@@ -37,13 +37,13 @@ import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.ratis.proto.RaftProtos;
 import org.apache.ratis.protocol.exceptions.StateMachineException;
 import org.apache.ratis.statemachine.TransactionContext;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 import org.mockito.Mockito;
 
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -55,13 +55,13 @@ import static org.mockito.Mockito.when;
  */
 public class TestOzoneManagerStateMachine {
 
-  @Rule
-  public TemporaryFolder tempDir = new TemporaryFolder();
+  @TempDir
+  private Path tempDir;
 
   private OzoneManagerStateMachine ozoneManagerStateMachine;
   private OzoneManagerPrepareState prepareState;
 
-  @Before
+  @BeforeEach
   public void setup() throws Exception {
     OzoneManagerRatisServer ozoneManagerRatisServer =
         Mockito.mock(OzoneManagerRatisServer.class);
@@ -72,7 +72,7 @@ public class TestOzoneManagerStateMachine {
 
     OzoneConfiguration conf = new OzoneConfiguration();
     conf.set(OMConfigKeys.OZONE_OM_DB_DIRS,
-        tempDir.newFolder().getAbsolutePath().toString());
+        tempDir.toAbsolutePath().toString());
 
     OMMetadataManager omMetadataManager = new OmMetadataManagerImpl(conf,
         ozoneManager);
@@ -98,9 +98,9 @@ public class TestOzoneManagerStateMachine {
 
     // Conf/metadata transaction.
     ozoneManagerStateMachine.notifyTermIndexUpdated(0, 1);
-    Assert.assertEquals(0,
+    Assertions.assertEquals(0,
         ozoneManagerStateMachine.getLastAppliedTermIndex().getTerm());
-    Assert.assertEquals(1,
+    Assertions.assertEquals(1,
         ozoneManagerStateMachine.getLastAppliedTermIndex().getIndex());
 
     List<Long> flushedEpochs = new ArrayList<>();
@@ -115,17 +115,17 @@ public class TestOzoneManagerStateMachine {
     // call update last applied index
     ozoneManagerStateMachine.updateLastAppliedIndex(flushedEpochs);
 
-    Assert.assertEquals(0,
+    Assertions.assertEquals(0,
         ozoneManagerStateMachine.getLastAppliedTermIndex().getTerm());
-    Assert.assertEquals(3,
+    Assertions.assertEquals(3,
         ozoneManagerStateMachine.getLastAppliedTermIndex().getIndex());
 
     // Conf/metadata transaction.
     ozoneManagerStateMachine.notifyTermIndexUpdated(0L, 4L);
 
-    Assert.assertEquals(0L,
+    Assertions.assertEquals(0L,
         ozoneManagerStateMachine.getLastAppliedTermIndex().getTerm());
-    Assert.assertEquals(4L,
+    Assertions.assertEquals(4L,
         ozoneManagerStateMachine.getLastAppliedTermIndex().getIndex());
 
     // Add some apply transactions.
@@ -137,9 +137,9 @@ public class TestOzoneManagerStateMachine {
     flushedEpochs.add(6L);
     ozoneManagerStateMachine.updateLastAppliedIndex(flushedEpochs);
 
-    Assert.assertEquals(0L,
+    Assertions.assertEquals(0L,
         ozoneManagerStateMachine.getLastAppliedTermIndex().getTerm());
-    Assert.assertEquals(6L,
+    Assertions.assertEquals(6L,
         ozoneManagerStateMachine.getLastAppliedTermIndex().getIndex());
 
 
@@ -156,9 +156,9 @@ public class TestOzoneManagerStateMachine {
 
     // Conf/metadata transaction.
     ozoneManagerStateMachine.notifyTermIndexUpdated(0, 1);
-    Assert.assertEquals(0,
+    Assertions.assertEquals(0,
         ozoneManagerStateMachine.getLastAppliedTermIndex().getTerm());
-    Assert.assertEquals(1,
+    Assertions.assertEquals(1,
         ozoneManagerStateMachine.getLastAppliedTermIndex().getIndex());
 
 
@@ -174,9 +174,9 @@ public class TestOzoneManagerStateMachine {
 
   // Still it should be zero, as for 2,3,4 updateLastAppliedIndex is not yet
     // called so the lastAppliedIndex will be at older value.
-    Assert.assertEquals(0L,
+    Assertions.assertEquals(0L,
         ozoneManagerStateMachine.getLastAppliedTermIndex().getTerm());
-    Assert.assertEquals(1L,
+    Assertions.assertEquals(1L,
         ozoneManagerStateMachine.getLastAppliedTermIndex().getIndex());
 
     List<Long> flushedEpochs = new ArrayList<>();
@@ -188,9 +188,9 @@ public class TestOzoneManagerStateMachine {
 
     ozoneManagerStateMachine.updateLastAppliedIndex(flushedEpochs);
 
-    Assert.assertEquals(0L,
+    Assertions.assertEquals(0L,
         ozoneManagerStateMachine.getLastAppliedTermIndex().getTerm());
-    Assert.assertEquals(5L,
+    Assertions.assertEquals(5L,
         ozoneManagerStateMachine.getLastAppliedTermIndex().getIndex());
 
   }
@@ -213,9 +213,9 @@ public class TestOzoneManagerStateMachine {
 
     ozoneManagerStateMachine.updateLastAppliedIndex(flushedEpochs);
 
-    Assert.assertEquals(0L,
+    Assertions.assertEquals(0L,
         ozoneManagerStateMachine.getLastAppliedTermIndex().getTerm());
-    Assert.assertEquals(2L,
+    Assertions.assertEquals(2L,
         ozoneManagerStateMachine.getLastAppliedTermIndex().getIndex());
 
 
@@ -233,9 +233,9 @@ public class TestOzoneManagerStateMachine {
 
     ozoneManagerStateMachine.updateLastAppliedIndex(flushedEpochs);
 
-    Assert.assertEquals(0L,
+    Assertions.assertEquals(0L,
         ozoneManagerStateMachine.getLastAppliedTermIndex().getTerm());
-    Assert.assertEquals(6L,
+    Assertions.assertEquals(6L,
         ozoneManagerStateMachine.getLastAppliedTermIndex().getIndex());
 
     // 3rd flush batch
@@ -252,9 +252,9 @@ public class TestOzoneManagerStateMachine {
 
     ozoneManagerStateMachine.updateLastAppliedIndex(flushedEpochs);
 
-    Assert.assertEquals(0L,
+    Assertions.assertEquals(0L,
         ozoneManagerStateMachine.getLastAppliedTermIndex().getTerm());
-    Assert.assertEquals(10L,
+    Assertions.assertEquals(10L,
         ozoneManagerStateMachine.getLastAppliedTermIndex().getIndex());
   }
 
@@ -281,9 +281,9 @@ public class TestOzoneManagerStateMachine {
     TransactionContext submittedTrx = mockTransactionContext(createKeyRequest);
     TransactionContext returnedTrx =
         ozoneManagerStateMachine.preAppendTransaction(submittedTrx);
-    Assert.assertSame(submittedTrx, returnedTrx);
+    Assertions.assertSame(submittedTrx, returnedTrx);
 
-    Assert.assertEquals(PrepareStatus.NOT_PREPARED,
+    Assertions.assertEquals(PrepareStatus.NOT_PREPARED,
         prepareState.getState().getStatus());
 
     // Submit prepare request.
@@ -302,33 +302,33 @@ public class TestOzoneManagerStateMachine {
 
     submittedTrx = mockTransactionContext(prepareRequest);
     returnedTrx = ozoneManagerStateMachine.preAppendTransaction(submittedTrx);
-    Assert.assertSame(submittedTrx, returnedTrx);
+    Assertions.assertSame(submittedTrx, returnedTrx);
 
     // Prepare should be started.
-    Assert.assertEquals(PrepareStatus.PREPARE_GATE_ENABLED,
+    Assertions.assertEquals(PrepareStatus.PREPARE_GATE_ENABLED,
         prepareState.getState().getStatus());
 
     // Submitting a write request should now fail.
     try {
       ozoneManagerStateMachine.preAppendTransaction(
           mockTransactionContext(createKeyRequest));
-      Assert.fail("Expected StateMachineException to be thrown when " +
+      Assertions.fail("Expected StateMachineException to be thrown when " +
           "submitting write request while prepared.");
     } catch (StateMachineException smEx) {
-      Assert.assertFalse(smEx.leaderShouldStepDown());
+      Assertions.assertFalse(smEx.leaderShouldStepDown());
 
       Throwable cause = smEx.getCause();
-      Assert.assertTrue(cause instanceof OMException);
-      Assert.assertEquals(((OMException) cause).getResult(),
+      Assertions.assertTrue(cause instanceof OMException);
+      Assertions.assertEquals(((OMException) cause).getResult(),
           OMException.ResultCodes.NOT_SUPPORTED_OPERATION_WHEN_PREPARED);
     }
 
     // Should be able to prepare again without issue.
     submittedTrx = mockTransactionContext(prepareRequest);
     returnedTrx = ozoneManagerStateMachine.preAppendTransaction(submittedTrx);
-    Assert.assertSame(submittedTrx, returnedTrx);
+    Assertions.assertSame(submittedTrx, returnedTrx);
 
-    Assert.assertEquals(PrepareStatus.PREPARE_GATE_ENABLED,
+    Assertions.assertEquals(PrepareStatus.PREPARE_GATE_ENABLED,
         prepareState.getState().getStatus());
 
     // Cancel prepare is handled in the cancel request apply txn step, not

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/TestBucketLayoutAwareOMKeyFactory.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/TestBucketLayoutAwareOMKeyFactory.java
@@ -22,8 +22,8 @@ import org.apache.hadoop.ozone.om.request.key.OMKeyRequest;
 import org.apache.hadoop.ozone.om.request.key.OMDirectoriesPurgeRequestWithFSO;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMRequest;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.Type;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -35,7 +35,7 @@ import static org.apache.hadoop.ozone.om.request.BucketLayoutAwareOMKeyRequestFa
 import static org.apache.hadoop.ozone.om.request.BucketLayoutAwareOMKeyRequestFactory.getRequestInstanceFromMap;
 import static org.apache.hadoop.ozone.om.request.BucketLayoutAwareOMKeyRequestFactory.OM_KEY_REQUEST_CLASSES;
 import static org.apache.hadoop.ozone.om.request.BucketLayoutAwareOMKeyRequestFactory.addRequestClass;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  * Validates functionality of {@link BucketLayoutAwareOMKeyRequestFactory}.
@@ -67,7 +67,7 @@ public class TestBucketLayoutAwareOMKeyFactory {
                       getDummyOMRequest(), k,
                       BucketLayout.FILE_SYSTEM_OPTIMIZED);
 
-              Assert.assertEquals(BucketLayout.FILE_SYSTEM_OPTIMIZED,
+              Assertions.assertEquals(BucketLayout.FILE_SYSTEM_OPTIMIZED,
                   omKeyRequest.getBucketLayout());
               omKeyReqsFSO.add(omKeyRequest);
             } catch (NoSuchMethodException e) {
@@ -85,7 +85,7 @@ public class TestBucketLayoutAwareOMKeyFactory {
                   getRequestInstanceFromMap(
                       getDummyOMRequest(), k, BucketLayout.LEGACY);
 
-              Assert.assertEquals(BucketLayout.LEGACY,
+              Assertions.assertEquals(BucketLayout.LEGACY,
                   omKeyRequest1.getBucketLayout());
               omKeyReqsLegacy.add(omKeyRequest1);
 
@@ -93,7 +93,7 @@ public class TestBucketLayoutAwareOMKeyFactory {
                   getRequestInstanceFromMap(
                       getDummyOMRequest(), k, BucketLayout.OBJECT_STORE);
 
-              Assert.assertEquals(BucketLayout.OBJECT_STORE,
+              Assertions.assertEquals(BucketLayout.OBJECT_STORE,
                   omKeyRequest2.getBucketLayout());
               omKeyReqsOBS.add(omKeyRequest2);
             } catch (NoSuchMethodException e) {
@@ -109,12 +109,12 @@ public class TestBucketLayoutAwareOMKeyFactory {
           LOG.info("Validated request class instantiation for cmdType " + k);
         });
 
-    Assert.assertEquals(13, omKeyReqsFSO.size());
-    Assert.assertEquals(14, omKeyReqsLegacy.size());
-    Assert.assertEquals(14, omKeyReqsOBS.size());
+    Assertions.assertEquals(13, omKeyReqsFSO.size());
+    Assertions.assertEquals(14, omKeyReqsLegacy.size());
+    Assertions.assertEquals(14, omKeyReqsOBS.size());
     // Check if the number of instantiated OMKeyRequest classes is equal to
     // the number of keys in the mapping.
-    Assert.assertEquals(
+    Assertions.assertEquals(
         OM_KEY_REQUEST_CLASSES.size(),
         omKeyReqsFSO.size() + omKeyReqsOBS.size());
   }

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/TestNormalizePaths.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/TestNormalizePaths.java
@@ -20,50 +20,44 @@
 package org.apache.hadoop.ozone.om.request;
 
 import org.apache.hadoop.ozone.om.exceptions.OMException;
-import org.junit.Assert;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import static org.apache.hadoop.ozone.om.request.OMClientRequest.validateAndNormalizeKey;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  * Class to test normalize paths.
  */
 public class TestNormalizePaths {
-
-  @Rule
-  public ExpectedException exceptionRule = ExpectedException.none();
-
   @Test
   public void testNormalizePathsEnabled() throws Exception {
 
-    Assert.assertEquals("a/b/c/d",
+    Assertions.assertEquals("a/b/c/d",
         validateAndNormalizeKey(true, "a/b/c/d"));
-    Assert.assertEquals("a/b/c/d",
+    Assertions.assertEquals("a/b/c/d",
         validateAndNormalizeKey(true, "/a/b/c/d"));
-    Assert.assertEquals("a/b/c/d",
+    Assertions.assertEquals("a/b/c/d",
         validateAndNormalizeKey(true, "////a/b/c/d"));
-    Assert.assertEquals("a/b/c/d",
+    Assertions.assertEquals("a/b/c/d",
         validateAndNormalizeKey(true, "////a/b/////c/d"));
-    Assert.assertEquals("a/b/c/...../d",
+    Assertions.assertEquals("a/b/c/...../d",
         validateAndNormalizeKey(true, "////a/b/////c/...../d"));
-    Assert.assertEquals("a/b/d",
+    Assertions.assertEquals("a/b/d",
         validateAndNormalizeKey(true, "/a/b/c/../d"));
-    Assert.assertEquals("a",
+    Assertions.assertEquals("a",
         validateAndNormalizeKey(true, "a"));
-    Assert.assertEquals("a/b",
+    Assertions.assertEquals("a/b",
         validateAndNormalizeKey(true, "/a/./b"));
-    Assert.assertEquals("a/b",
+    Assertions.assertEquals("a/b",
         validateAndNormalizeKey(true, ".//a/./b"));
-    Assert.assertEquals("a/",
+    Assertions.assertEquals("a/",
         validateAndNormalizeKey(true, "/a/."));
-    Assert.assertEquals("b/c",
+    Assertions.assertEquals("b/c",
         validateAndNormalizeKey(true, "//./b/c/"));
-    Assert.assertEquals("a/b/c/d",
+    Assertions.assertEquals("a/b/c/d",
         validateAndNormalizeKey(true, "a/b/c/d/"));
-    Assert.assertEquals("a/b/c/...../d",
+    Assertions.assertEquals("a/b/c/...../d",
         validateAndNormalizeKey(true, "////a/b/////c/...../d/"));
   }
 
@@ -84,7 +78,7 @@ public class TestNormalizePaths {
       validateAndNormalizeKey(true, keyName);
       fail("checkInvalidPath failed for path " + keyName);
     } catch (OMException ex) {
-      Assert.assertTrue(ex.getMessage().contains("Invalid KeyPath"));
+      Assertions.assertTrue(ex.getMessage().contains("Invalid KeyPath"));
     }
   }
 
@@ -93,17 +87,17 @@ public class TestNormalizePaths {
   @Test
   public void testNormalizePathsDisable() throws OMException {
 
-    Assert.assertEquals("/a/b/c/d",
+    Assertions.assertEquals("/a/b/c/d",
         validateAndNormalizeKey(false, "/a/b/c/d"));
-    Assert.assertEquals("////a/b/c/d",
+    Assertions.assertEquals("////a/b/c/d",
         validateAndNormalizeKey(false, "////a/b/c/d"));
-    Assert.assertEquals("////a/b/////c/d",
+    Assertions.assertEquals("////a/b/////c/d",
         validateAndNormalizeKey(false, "////a/b/////c/d"));
-    Assert.assertEquals("////a/b/////c/...../d",
+    Assertions.assertEquals("////a/b/////c/...../d",
         validateAndNormalizeKey(false, "////a/b/////c/...../d"));
-    Assert.assertEquals("/a/b/c/../d",
+    Assertions.assertEquals("/a/b/c/../d",
         validateAndNormalizeKey(false, "/a/b/c/../d"));
-    Assert.assertEquals("/a/b/c/../../d",
+    Assertions.assertEquals("/a/b/c/../../d",
         validateAndNormalizeKey(false, "/a/b/c/../../d"));
   }
 }

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/TestOMClientRequestWithUserInfo.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/TestOMClientRequestWithUserInfo.java
@@ -20,17 +20,17 @@
 package org.apache.hadoop.ozone.om.request;
 
 import java.net.InetAddress;
+import java.nio.file.Path;
 import java.util.UUID;
 
 import mockit.Mock;
 import mockit.MockUp;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.BucketInfo;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMRequest;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 import org.mockito.Mockito;
 
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
@@ -53,8 +53,8 @@ import static org.mockito.Mockito.when;
  */
 public class TestOMClientRequestWithUserInfo {
 
-  @Rule
-  public TemporaryFolder folder = new TemporaryFolder();
+  @TempDir
+  private Path folder;
 
   private OzoneManager ozoneManager;
   private OMMetrics omMetrics;
@@ -63,13 +63,13 @@ public class TestOMClientRequestWithUserInfo {
       UserGroupInformation.createRemoteUser("temp");
   private InetAddress inetAddress;
 
-  @Before
+  @BeforeEach
   public void setup() throws Exception {
     ozoneManager = Mockito.mock(OzoneManager.class);
     omMetrics = OMMetrics.create();
     OzoneConfiguration ozoneConfiguration = new OzoneConfiguration();
     ozoneConfiguration.set(OMConfigKeys.OZONE_OM_DB_DIRS,
-        folder.newFolder().getAbsolutePath());
+        folder.toAbsolutePath().toString());
     omMetadataManager = new OmMetadataManagerImpl(ozoneConfiguration,
         ozoneManager);
     when(ozoneManager.getMetrics()).thenReturn(omMetrics);
@@ -107,12 +107,12 @@ public class TestOMClientRequestWithUserInfo {
     OMBucketCreateRequest omBucketCreateRequest =
         new OMBucketCreateRequest(omRequest);
 
-    Assert.assertFalse(omRequest.hasUserInfo());
+    Assertions.assertFalse(omRequest.hasUserInfo());
 
     OMRequest modifiedRequest =
         omBucketCreateRequest.preExecute(ozoneManager);
 
-    Assert.assertTrue(modifiedRequest.hasUserInfo());
+    Assertions.assertTrue(modifiedRequest.hasUserInfo());
 
     // Now pass modified request to OMBucketCreateRequest and check ugi and
     // remote Address.
@@ -125,9 +125,10 @@ public class TestOMClientRequestWithUserInfo {
 
     // Now check we have original user info, remote address and hostname or not.
     // Here from OMRequest user info, converted to UGI, InetAddress and String.
-    Assert.assertEquals(inetAddress.getHostAddress(),
+    Assertions.assertEquals(inetAddress.getHostAddress(),
         remoteAddress.getHostAddress());
-    Assert.assertEquals(userGroupInformation.getUserName(), ugi.getUserName());
-    Assert.assertEquals(inetAddress.getHostName(), hostName);
+    Assertions.assertEquals(userGroupInformation.getUserName(),
+        ugi.getUserName());
+    Assertions.assertEquals(inetAddress.getHostName(), hostName);
   }
 }

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/bucket/TestBucketRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/bucket/TestBucketRequest.java
@@ -23,10 +23,9 @@ import org.apache.commons.lang3.tuple.Pair;
 import org.apache.hadoop.ozone.om.ResolvedBucket;
 import org.apache.hadoop.ozone.om.helpers.BucketLayout;
 import org.apache.hadoop.ozone.om.upgrade.OMLayoutVersionManager;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.io.TempDir;
 import org.mockito.Mockito;
 
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
@@ -40,6 +39,8 @@ import org.apache.hadoop.ozone.om.OzoneManager;
 import org.apache.hadoop.ozone.om.ratis.utils.OzoneManagerDoubleBufferHelper;
 
 
+import java.nio.file.Path;
+
 import static org.apache.hadoop.ozone.om.request.OMRequestTestUtils.setupReplicationConfigValidation;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
@@ -50,8 +51,8 @@ import static org.mockito.Mockito.when;
  */
 @SuppressWarnings("visibilityModifier")
 public class TestBucketRequest {
-  @Rule
-  public TemporaryFolder folder = new TemporaryFolder();
+  @TempDir
+  private Path folder;
 
   protected OzoneManager ozoneManager;
   protected OMMetrics omMetrics;
@@ -65,14 +66,14 @@ public class TestBucketRequest {
       });
 
 
-  @Before
+  @BeforeEach
   public void setup() throws Exception {
 
     ozoneManager = Mockito.mock(OzoneManager.class);
     omMetrics = OMMetrics.create();
     OzoneConfiguration ozoneConfiguration = new OzoneConfiguration();
     ozoneConfiguration.set(OMConfigKeys.OZONE_OM_DB_DIRS,
-        folder.newFolder().getAbsolutePath());
+        folder.toAbsolutePath().toString());
     when(ozoneManager.getConfiguration()).thenReturn(ozoneConfiguration);
     omMetadataManager = new OmMetadataManagerImpl(ozoneConfiguration,
         ozoneManager);
@@ -97,7 +98,7 @@ public class TestBucketRequest {
             invocation.getArgument(0), invocation.getArgument(0)));
   }
 
-  @After
+  @AfterEach
   public void stop() {
     omMetrics.unRegister();
     Mockito.framework().clearInlineMocks();

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/bucket/TestOMBucketCreateRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/bucket/TestOMBucketCreateRequest.java
@@ -25,8 +25,8 @@ import org.apache.hadoop.hdds.client.DefaultReplicationConfig;
 import org.apache.hadoop.hdds.client.ECReplicationConfig;
 import org.apache.hadoop.ozone.om.exceptions.OMException;
 import org.apache.hadoop.ozone.om.helpers.BucketLayout;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import org.apache.hadoop.ozone.om.OMMetadataManager;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMRequest;
@@ -41,8 +41,8 @@ import org.apache.hadoop.util.Time;
 
 import static org.apache.hadoop.ozone.om.request.OMRequestTestUtils.newBucketInfoBuilder;
 import static org.apache.hadoop.ozone.om.request.OMRequestTestUtils.newCreateBucketRequest;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.when;
 
 /**
@@ -95,19 +95,19 @@ public class TestOMBucketCreateRequest extends TestBucketRequest {
     // As we have not still called validateAndUpdateCache, get() should
     // return null.
 
-    Assert.assertNull(omMetadataManager.getBucketTable().get(bucketKey));
+    Assertions.assertNull(omMetadataManager.getBucketTable().get(bucketKey));
 
     OMClientResponse omClientResponse =
         omBucketCreateRequest.validateAndUpdateCache(ozoneManager, 1,
             ozoneManagerDoubleBufferHelper);
 
     OMResponse omResponse = omClientResponse.getOMResponse();
-    Assert.assertNotNull(omResponse.getCreateBucketResponse());
-    Assert.assertEquals(OzoneManagerProtocolProtos.Status.VOLUME_NOT_FOUND,
+    Assertions.assertNotNull(omResponse.getCreateBucketResponse());
+    Assertions.assertEquals(OzoneManagerProtocolProtos.Status.VOLUME_NOT_FOUND,
         omResponse.getStatus());
 
     // As request is invalid bucket table should not have entry.
-    Assert.assertNull(omMetadataManager.getBucketTable().get(bucketKey));
+    Assertions.assertNull(omMetadataManager.getBucketTable().get(bucketKey));
   }
 
   @Test
@@ -128,9 +128,9 @@ public class TestOMBucketCreateRequest extends TestBucketRequest {
             ozoneManagerDoubleBufferHelper);
 
     OMResponse omResponse = omClientResponse.getOMResponse();
-    Assert.assertNotNull(omResponse.getCreateBucketResponse());
-    Assert.assertEquals(OzoneManagerProtocolProtos.Status.BUCKET_ALREADY_EXISTS,
-        omResponse.getStatus());
+    Assertions.assertNotNull(omResponse.getCreateBucketResponse());
+    Assertions.assertEquals(OzoneManagerProtocolProtos.Status
+            .BUCKET_ALREADY_EXISTS, omResponse.getStatus());
   }
 
   @Test
@@ -148,7 +148,7 @@ public class TestOMBucketCreateRequest extends TestBucketRequest {
     OMException e = assertThrows(OMException.class,
         () -> doPreExecute(bucketInfo));
 
-    Assert.assertEquals(OMException.ResultCodes.INVALID_REQUEST,
+    Assertions.assertEquals(OMException.ResultCodes.INVALID_REQUEST,
         e.getResult());
   }
 
@@ -164,7 +164,7 @@ public class TestOMBucketCreateRequest extends TestBucketRequest {
     doValidateAndUpdateCache(volumeName, bucketName,
         omBucketCreateRequest.getOmRequest());
 
-    Assert.assertEquals(BucketLayout.FILE_SYSTEM_OPTIMIZED,
+    Assertions.assertEquals(BucketLayout.FILE_SYSTEM_OPTIMIZED,
         omMetadataManager.getBucketTable().get(bucketKey).getBucketLayout());
   }
 
@@ -210,7 +210,7 @@ public class TestOMBucketCreateRequest extends TestBucketRequest {
     OMClientResponse resp = testRequest.validateAndUpdateCache(
         ozoneManager, 1, ozoneManagerDoubleBufferHelper);
 
-    Assert.assertEquals(resp.getOMResponse().getStatus().toString(),
+    Assertions.assertEquals(resp.getOMResponse().getStatus().toString(),
         OMException.ResultCodes.QUOTA_EXCEEDED.toString());
   }
 
@@ -234,7 +234,7 @@ public class TestOMBucketCreateRequest extends TestBucketRequest {
     OMClientResponse resp = testRequest.validateAndUpdateCache(
         ozoneManager, 1, ozoneManagerDoubleBufferHelper);
 
-    Assert.assertEquals(resp.getOMResponse().getStatus().toString(),
+    Assertions.assertEquals(resp.getOMResponse().getStatus().toString(),
         OMException.ResultCodes.QUOTA_ERROR.toString());
   }
 
@@ -287,7 +287,8 @@ public class TestOMBucketCreateRequest extends TestBucketRequest {
         String bucketName) {
     Throwable e = assertThrows(OMException.class, () ->
         doPreExecute(volumeName, bucketName));
-    Assert.assertEquals(e.getMessage(), "Invalid bucket name: " + bucketName);
+    Assertions.assertEquals(e.getMessage(),
+        "Invalid bucket name: " + bucketName);
   }
 
   protected OMBucketCreateRequest doPreExecute(String volumeName,
@@ -318,7 +319,7 @@ public class TestOMBucketCreateRequest extends TestBucketRequest {
     // As we have not still called validateAndUpdateCache, get() should
     // return null.
 
-    Assert.assertNull(omMetadataManager.getBucketTable().get(bucketKey));
+    Assertions.assertNull(omMetadataManager.getBucketTable().get(bucketKey));
     OMBucketCreateRequest omBucketCreateRequest =
         new OMBucketCreateRequest(modifiedRequest);
 
@@ -331,25 +332,25 @@ public class TestOMBucketCreateRequest extends TestBucketRequest {
     // should return non null value.
     OmBucketInfo dbBucketInfo =
         omMetadataManager.getBucketTable().get(bucketKey);
-    Assert.assertNotNull(omMetadataManager.getBucketTable().get(bucketKey));
+    Assertions.assertNotNull(omMetadataManager.getBucketTable().get(bucketKey));
 
     // verify table data with actual request data.
     OmBucketInfo bucketInfoFromProto = OmBucketInfo.getFromProtobuf(
         modifiedRequest.getCreateBucketRequest().getBucketInfo());
 
-    Assert.assertEquals(bucketInfoFromProto.getCreationTime(),
+    Assertions.assertEquals(bucketInfoFromProto.getCreationTime(),
         dbBucketInfo.getCreationTime());
-    Assert.assertEquals(bucketInfoFromProto.getModificationTime(),
+    Assertions.assertEquals(bucketInfoFromProto.getModificationTime(),
         dbBucketInfo.getModificationTime());
-    Assert.assertEquals(bucketInfoFromProto.getAcls(),
+    Assertions.assertEquals(bucketInfoFromProto.getAcls(),
         dbBucketInfo.getAcls());
-    Assert.assertEquals(bucketInfoFromProto.getIsVersionEnabled(),
+    Assertions.assertEquals(bucketInfoFromProto.getIsVersionEnabled(),
         dbBucketInfo.getIsVersionEnabled());
-    Assert.assertEquals(bucketInfoFromProto.getStorageType(),
+    Assertions.assertEquals(bucketInfoFromProto.getStorageType(),
         dbBucketInfo.getStorageType());
-    Assert.assertEquals(bucketInfoFromProto.getMetadata(),
+    Assertions.assertEquals(bucketInfoFromProto.getMetadata(),
         dbBucketInfo.getMetadata());
-    Assert.assertEquals(bucketInfoFromProto.getEncryptionKeyInfo(),
+    Assertions.assertEquals(bucketInfoFromProto.getEncryptionKeyInfo(),
         dbBucketInfo.getEncryptionKeyInfo());
 
     // verify OMResponse.
@@ -364,21 +365,23 @@ public class TestOMBucketCreateRequest extends TestBucketRequest {
     OzoneManagerProtocolProtos.BucketInfo updated =
         modifiedOmRequest.getCreateBucketRequest().getBucketInfo();
 
-    Assert.assertEquals(original.getBucketName(), updated.getBucketName());
-    Assert.assertEquals(original.getVolumeName(), updated.getVolumeName());
-    Assert.assertEquals(original.getIsVersionEnabled(),
+    Assertions.assertEquals(original.getBucketName(), updated.getBucketName());
+    Assertions.assertEquals(original.getVolumeName(), updated.getVolumeName());
+    Assertions.assertEquals(original.getIsVersionEnabled(),
         updated.getIsVersionEnabled());
-    Assert.assertEquals(original.getStorageType(), updated.getStorageType());
-    Assert.assertEquals(original.getMetadataList(), updated.getMetadataList());
-    Assert.assertNotEquals(original.getCreationTime(),
+    Assertions.assertEquals(original.getStorageType(),
+        updated.getStorageType());
+    Assertions.assertEquals(original.getMetadataList(),
+        updated.getMetadataList());
+    Assertions.assertNotEquals(original.getCreationTime(),
         updated.getCreationTime());
   }
 
   public static void verifySuccessCreateBucketResponse(OMResponse omResponse) {
-    Assert.assertNotNull(omResponse.getCreateBucketResponse());
-    Assert.assertEquals(OzoneManagerProtocolProtos.Type.CreateBucket,
+    Assertions.assertNotNull(omResponse.getCreateBucketResponse());
+    Assertions.assertEquals(OzoneManagerProtocolProtos.Type.CreateBucket,
         omResponse.getCmdType());
-    Assert.assertEquals(OzoneManagerProtocolProtos.Status.OK,
+    Assertions.assertEquals(OzoneManagerProtocolProtos.Status.OK,
         omResponse.getStatus());
   }
 

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/bucket/TestOMBucketCreateRequestWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/bucket/TestOMBucketCreateRequestWithFSO.java
@@ -26,9 +26,9 @@ import org.apache.hadoop.ozone.om.request.OMRequestTestUtils;
 import org.apache.hadoop.ozone.om.response.OMClientResponse;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMRequest;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.UUID;
 
@@ -43,7 +43,7 @@ import static org.mockito.Mockito.when;
 public class TestOMBucketCreateRequestWithFSO
     extends TestOMBucketCreateRequest {
 
-  @Before
+  @BeforeEach
   public void setupWithFSO() {
     ozoneManager.getConfiguration()
         .set(OMConfigKeys.OZONE_DEFAULT_BUCKET_LAYOUT,
@@ -58,7 +58,7 @@ public class TestOMBucketCreateRequestWithFSO
     String bucketName = UUID.randomUUID().toString();
     String bucketKey = omMetadataManager.getBucketKey(volumeName, bucketName);
 
-    Assert.assertEquals(0, omMetrics.getNumFSOBucketCreates());
+    Assertions.assertEquals(0, omMetrics.getNumFSOBucketCreates());
 
     OMBucketCreateRequest omBucketCreateRequest = doPreExecute(volumeName,
         bucketName, true);
@@ -66,8 +66,8 @@ public class TestOMBucketCreateRequestWithFSO
     doValidateAndUpdateCache(volumeName, bucketName,
         omBucketCreateRequest.getOmRequest());
 
-    Assert.assertEquals(1, omMetrics.getNumFSOBucketCreates());
-    Assert.assertEquals(BucketLayout.FILE_SYSTEM_OPTIMIZED,
+    Assertions.assertEquals(1, omMetrics.getNumFSOBucketCreates());
+    Assertions.assertEquals(BucketLayout.FILE_SYSTEM_OPTIMIZED,
         omMetadataManager.getBucketTable().get(bucketKey).getBucketLayout());
   }
 
@@ -86,11 +86,12 @@ public class TestOMBucketCreateRequestWithFSO
     String bucketKey = omMetadataManager.getBucketKey(volumeName, bucketName);
 
     // Checking bucket layout from configuration
-    Assert.assertEquals(OMConfigKeys.OZONE_BUCKET_LAYOUT_FILE_SYSTEM_OPTIMIZED,
+    Assertions.assertEquals(
+        OMConfigKeys.OZONE_BUCKET_LAYOUT_FILE_SYSTEM_OPTIMIZED,
         ozoneManager.getConfiguration()
             .get(OMConfigKeys.OZONE_DEFAULT_BUCKET_LAYOUT));
 
-    Assert.assertEquals(0, omMetrics.getNumFSOBucketCreates());
+    Assertions.assertEquals(0, omMetrics.getNumFSOBucketCreates());
 
     // OzoneManager is mocked, the bucket layout will return null
     when(ozoneManager.getOMDefaultBucketLayout()).thenReturn(
@@ -102,8 +103,8 @@ public class TestOMBucketCreateRequestWithFSO
     doValidateAndUpdateCache(volumeName, bucketName,
         omBucketCreateRequest.getOmRequest());
 
-    Assert.assertEquals(1, omMetrics.getNumFSOBucketCreates());
-    Assert.assertEquals(BucketLayout.FILE_SYSTEM_OPTIMIZED,
+    Assertions.assertEquals(1, omMetrics.getNumFSOBucketCreates());
+    Assertions.assertEquals(BucketLayout.FILE_SYSTEM_OPTIMIZED,
         omMetadataManager.getBucketTable().get(bucketKey).getBucketLayout());
   }
 
@@ -137,7 +138,7 @@ public class TestOMBucketCreateRequestWithFSO
     // As we have not still called validateAndUpdateCache, get() should
     // return null.
 
-    Assert.assertNull(omMetadataManager.getBucketTable().get(bucketKey));
+    Assertions.assertNull(omMetadataManager.getBucketTable().get(bucketKey));
     OMBucketCreateRequest omBucketCreateRequest =
         new OMBucketCreateRequest(modifiedRequest);
 
@@ -150,7 +151,7 @@ public class TestOMBucketCreateRequestWithFSO
     // should return non null value.
     OmBucketInfo dbBucketInfo =
         omMetadataManager.getBucketTable().get(bucketKey);
-    Assert.assertNotNull(omMetadataManager.getBucketTable().get(bucketKey));
+    Assertions.assertNotNull(omMetadataManager.getBucketTable().get(bucketKey));
 
     BucketLayout bucketLayout = BucketLayout
         .fromString(ozoneManager.getConfiguration()
@@ -160,21 +161,21 @@ public class TestOMBucketCreateRequestWithFSO
     OmBucketInfo bucketInfoFromProto = OmBucketInfo.getFromProtobuf(
         modifiedRequest.getCreateBucketRequest().getBucketInfo(), bucketLayout);
 
-    Assert.assertEquals(bucketInfoFromProto.getCreationTime(),
+    Assertions.assertEquals(bucketInfoFromProto.getCreationTime(),
         dbBucketInfo.getCreationTime());
-    Assert.assertEquals(bucketInfoFromProto.getModificationTime(),
+    Assertions.assertEquals(bucketInfoFromProto.getModificationTime(),
         dbBucketInfo.getModificationTime());
-    Assert.assertEquals(bucketInfoFromProto.getAcls(),
+    Assertions.assertEquals(bucketInfoFromProto.getAcls(),
         dbBucketInfo.getAcls());
-    Assert.assertEquals(bucketInfoFromProto.getIsVersionEnabled(),
+    Assertions.assertEquals(bucketInfoFromProto.getIsVersionEnabled(),
         dbBucketInfo.getIsVersionEnabled());
-    Assert.assertEquals(bucketInfoFromProto.getStorageType(),
+    Assertions.assertEquals(bucketInfoFromProto.getStorageType(),
         dbBucketInfo.getStorageType());
-    Assert.assertEquals(bucketInfoFromProto.getMetadata(),
+    Assertions.assertEquals(bucketInfoFromProto.getMetadata(),
         dbBucketInfo.getMetadata());
-    Assert.assertEquals(bucketInfoFromProto.getEncryptionKeyInfo(),
+    Assertions.assertEquals(bucketInfoFromProto.getEncryptionKeyInfo(),
         dbBucketInfo.getEncryptionKeyInfo());
-    Assert.assertEquals(bucketInfoFromProto.getBucketLayout(),
+    Assertions.assertEquals(bucketInfoFromProto.getBucketLayout(),
         dbBucketInfo.getBucketLayout());
 
     // verify OMResponse.

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/bucket/TestOMBucketDeleteRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/bucket/TestOMBucketDeleteRequest.java
@@ -22,8 +22,8 @@ package org.apache.hadoop.ozone.om.request.bucket;
 import java.util.UUID;
 
 import org.apache.hadoop.ozone.om.request.OMRequestTestUtils;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 import org.apache.hadoop.ozone.om.response.OMClientResponse;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos
@@ -46,7 +46,7 @@ public class TestOMBucketDeleteRequest extends TestBucketRequest {
         new OMBucketDeleteRequest(omRequest);
 
     // As user info gets added.
-    Assert.assertNotEquals(omRequest,
+    Assertions.assertNotEquals(omRequest,
         omBucketDeleteRequest.preExecute(ozoneManager));
   }
 
@@ -67,7 +67,7 @@ public class TestOMBucketDeleteRequest extends TestBucketRequest {
     omBucketDeleteRequest.validateAndUpdateCache(ozoneManager, 1,
         ozoneManagerDoubleBufferHelper);
 
-    Assert.assertNull(omMetadataManager.getBucketTable().get(
+    Assertions.assertNull(omMetadataManager.getBucketTable().get(
         omMetadataManager.getBucketKey(volumeName, bucketName)));
   }
 
@@ -87,10 +87,10 @@ public class TestOMBucketDeleteRequest extends TestBucketRequest {
         omBucketDeleteRequest.validateAndUpdateCache(ozoneManager, 1,
             ozoneManagerDoubleBufferHelper);
 
-    Assert.assertNull(omMetadataManager.getBucketTable().get(
+    Assertions.assertNull(omMetadataManager.getBucketTable().get(
         omMetadataManager.getBucketKey(volumeName, bucketName)));
 
-    Assert.assertEquals(OzoneManagerProtocolProtos.Status.BUCKET_NOT_FOUND,
+    Assertions.assertEquals(OzoneManagerProtocolProtos.Status.BUCKET_NOT_FOUND,
         omClientResponse.getOMResponse().getStatus());
 
     OMRequestTestUtils.addVolumeAndBucketToDB(volumeName, bucketName,

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/bucket/TestOMBucketDeleteRequestWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/bucket/TestOMBucketDeleteRequestWithFSO.java
@@ -26,8 +26,8 @@ import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos
     .DeleteBucketRequest;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos
     .OMRequest;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.UUID;
 
@@ -42,7 +42,7 @@ public class TestOMBucketDeleteRequestWithFSO
     String volumeName = UUID.randomUUID().toString();
     String bucketName = UUID.randomUUID().toString();
 
-    Assert.assertEquals(0, omMetrics.getNumFSOBucketDeletes());
+    Assertions.assertEquals(0, omMetrics.getNumFSOBucketDeletes());
 
     OzoneManagerProtocolProtos.OMRequest omRequest =
         createDeleteBucketRequest(volumeName, bucketName);
@@ -57,10 +57,10 @@ public class TestOMBucketDeleteRequestWithFSO
     omBucketDeleteRequest.validateAndUpdateCache(ozoneManager, 1,
         ozoneManagerDoubleBufferHelper);
 
-    Assert.assertNull(omMetadataManager.getBucketTable().get(
+    Assertions.assertNull(omMetadataManager.getBucketTable().get(
         omMetadataManager.getBucketKey(volumeName, bucketName)));
 
-    Assert.assertEquals(1, omMetrics.getNumFSOBucketDeletes());
+    Assertions.assertEquals(1, omMetrics.getNumFSOBucketDeletes());
   }
 
   private OMRequest createDeleteBucketRequest(

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/bucket/TestOMBucketSetPropertyRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/bucket/TestOMBucketSetPropertyRequest.java
@@ -32,8 +32,8 @@ import org.apache.hadoop.ozone.om.helpers.OmBucketInfo;
 import org.apache.hadoop.ozone.om.request.OMRequestTestUtils;
 import org.apache.ozone.test.GenericTestUtils;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 import org.slf4j.LoggerFactory;
 
 import org.apache.hadoop.ozone.om.response.OMClientResponse;
@@ -75,10 +75,10 @@ public class TestOMBucketSetPropertyRequest extends TestBucketRequest {
         .getModificationTime();
     long newModTime = preExecuteRequest.getSetBucketPropertyRequest()
         .getModificationTime();
-    Assert.assertTrue(newModTime > originModTime);
+    Assertions.assertTrue(newModTime > originModTime);
 
     // As user info gets added.
-    Assert.assertNotEquals(omRequest,
+    Assertions.assertNotEquals(omRequest,
         omBucketSetPropertyRequest.preExecute(ozoneManager));
   }
 
@@ -102,12 +102,11 @@ public class TestOMBucketSetPropertyRequest extends TestBucketRequest {
         omBucketSetPropertyRequest.validateAndUpdateCache(ozoneManager, 1,
             ozoneManagerDoubleBufferHelper);
 
-    Assert.assertEquals(true,
-        omMetadataManager.getBucketTable().get(
+    Assertions.assertTrue(omMetadataManager.getBucketTable().get(
             omMetadataManager.getBucketKey(volumeName, bucketName))
-            .getIsVersionEnabled());
+        .getIsVersionEnabled());
 
-    Assert.assertEquals(OzoneManagerProtocolProtos.Status.OK,
+    Assertions.assertEquals(OzoneManagerProtocolProtos.Status.OK,
         omClientResponse.getOMResponse().getStatus());
   }
 
@@ -131,12 +130,12 @@ public class TestOMBucketSetPropertyRequest extends TestBucketRequest {
         omBucketSetPropertyRequest.validateAndUpdateCache(ozoneManager, 1,
             ozoneManagerDoubleBufferHelper);
 
-    Assert.assertEquals(BucketLayout.FILE_SYSTEM_OPTIMIZED,
+    Assertions.assertEquals(BucketLayout.FILE_SYSTEM_OPTIMIZED,
         omMetadataManager.getBucketTable().get(
             omMetadataManager.getBucketKey(volumeName, bucketName))
             .getBucketLayout());
 
-    Assert.assertEquals(OzoneManagerProtocolProtos.Status.OK,
+    Assertions.assertEquals(OzoneManagerProtocolProtos.Status.OK,
         omClientResponse.getOMResponse().getStatus());
   }
 
@@ -156,10 +155,10 @@ public class TestOMBucketSetPropertyRequest extends TestBucketRequest {
         omBucketSetPropertyRequest.validateAndUpdateCache(ozoneManager, 1,
             ozoneManagerDoubleBufferHelper);
 
-    Assert.assertEquals(OzoneManagerProtocolProtos.Status.BUCKET_NOT_FOUND,
+    Assertions.assertEquals(OzoneManagerProtocolProtos.Status.BUCKET_NOT_FOUND,
         omClientResponse.getOMResponse().getStatus());
 
-    Assert.assertNull(omMetadataManager.getBucketTable().get(
+    Assertions.assertNull(omMetadataManager.getBucketTable().get(
         omMetadataManager.getBucketKey(volumeName, bucketName)));
 
   }
@@ -203,13 +202,13 @@ public class TestOMBucketSetPropertyRequest extends TestBucketRequest {
             ozoneManagerDoubleBufferHelper);
 
     //capture the error log
-    Assert.assertTrue(logs.getOutput().contains(
+    Assertions.assertTrue(logs.getOutput().contains(
         "Setting bucket property failed for bucket"));
 
-    Assert.assertFalse(omClientResponse.getOMResponse().getSuccess());
-    Assert.assertEquals(omClientResponse.getOMResponse().getStatus(),
+    Assertions.assertFalse(omClientResponse.getOMResponse().getSuccess());
+    Assertions.assertEquals(omClientResponse.getOMResponse().getStatus(),
         OzoneManagerProtocolProtos.Status.QUOTA_EXCEEDED);
-    Assert.assertTrue(omClientResponse.getOMResponse().getMessage().
+    Assertions.assertTrue(omClientResponse.getOMResponse().getMessage().
         contains("Total buckets quota in this volume " +
             "should not be greater than volume quota"));
   }
@@ -241,12 +240,13 @@ public class TestOMBucketSetPropertyRequest extends TestBucketRequest {
             ozoneManagerDoubleBufferHelper);
 
     // THEN
-    Assert.assertFalse(omClientResponse.getOMResponse().getSuccess());
-    Assert.assertEquals(
+    Assertions.assertFalse(omClientResponse.getOMResponse().getSuccess());
+    Assertions.assertEquals(
         OzoneManagerProtocolProtos.Status.NOT_SUPPORTED_OPERATION,
         omClientResponse.getOMResponse().getStatus());
     String message = omClientResponse.getOMResponse().getMessage();
-    Assert.assertTrue(message, message.contains("Cannot set property on link"));
+    Assertions.assertTrue(message.contains("Cannot set property on link"),
+        message);
   }
 
   @Test
@@ -280,14 +280,14 @@ public class TestOMBucketSetPropertyRequest extends TestBucketRequest {
         .validateAndUpdateCache(ozoneManager, 1,
             ozoneManagerDoubleBufferHelper);
 
-    Assert.assertEquals(true, omClientResponse.getOMResponse().getSuccess());
+    Assertions.assertTrue(omClientResponse.getOMResponse().getSuccess());
 
     String bucketKey = omMetadataManager.getBucketKey(volumeName, bucketName);
     OmBucketInfo dbBucketInfo =
         omMetadataManager.getBucketTable().get(bucketKey);
 
-    Assert.assertEquals(8 * GB, dbBucketInfo.getQuotaInBytes());
-    Assert.assertEquals(EC,
+    Assertions.assertEquals(8 * GB, dbBucketInfo.getQuotaInBytes());
+    Assertions.assertEquals(EC,
         dbBucketInfo.getDefaultReplicationConfig().getType());
   }
 
@@ -328,15 +328,15 @@ public class TestOMBucketSetPropertyRequest extends TestBucketRequest {
             .validateAndUpdateCache(ozoneManager, 1,
                     ozoneManagerDoubleBufferHelper);
 
-    Assert.assertEquals(true, omClientResponse.getOMResponse().getSuccess());
+    Assertions.assertTrue(omClientResponse.getOMResponse().getSuccess());
 
     String bucketKey = omMetadataManager.getBucketKey(volumeName, bucketName);
     OmBucketInfo dbBucketInfo =
             omMetadataManager.getBucketTable().get(bucketKey);
 
-    Assert.assertEquals(TEST_KEY,
+    Assertions.assertEquals(TEST_KEY,
             dbBucketInfo.getEncryptionKeyInfo().getKeyName());
-    Assert.assertEquals(EC,
+    Assertions.assertEquals(EC,
             dbBucketInfo.getDefaultReplicationConfig().getType());
   }
 
@@ -367,19 +367,19 @@ public class TestOMBucketSetPropertyRequest extends TestBucketRequest {
             .validateAndUpdateCache(ozoneManager, 1,
                     ozoneManagerDoubleBufferHelper);
 
-    Assert.assertEquals(true, omClientResponse.getOMResponse().getSuccess());
+    Assertions.assertTrue(omClientResponse.getOMResponse().getSuccess());
 
     String bucketKey = omMetadataManager.getBucketKey(volumeName, bucketName);
     OmBucketInfo dbBucketInfo =
             omMetadataManager.getBucketTable().get(bucketKey);
 
-    Assert.assertEquals(TEST_KEY,
+    Assertions.assertEquals(TEST_KEY,
             dbBucketInfo.getEncryptionKeyInfo().getKeyName());
-    Assert.assertEquals(20 * GB,
+    Assertions.assertEquals(20 * GB,
             dbBucketInfo.getQuotaInBytes());
-    Assert.assertEquals(1000L,
+    Assertions.assertEquals(1000L,
             dbBucketInfo.getQuotaInNamespace());
-    Assert.assertEquals("testUser",
+    Assertions.assertEquals("testUser",
         dbBucketInfo.getOwner());
   }
 
@@ -398,7 +398,7 @@ public class TestOMBucketSetPropertyRequest extends TestBucketRequest {
     cacheValue.getCacheValue().incrUsedBytes(5 * GB);
     cacheValue.getCacheValue().incrUsedNamespace(10);
     OMRequest omRequest = createSetBucketPropertyRequest(volumeName,
-        bucketName, true, 1 * GB);
+        bucketName, true, GB);
 
     OMBucketSetPropertyRequest omBucketSetPropertyRequest =
         new OMBucketSetPropertyRequest(omRequest);
@@ -407,10 +407,10 @@ public class TestOMBucketSetPropertyRequest extends TestBucketRequest {
         .validateAndUpdateCache(ozoneManager, 1,
             ozoneManagerDoubleBufferHelper);
 
-    Assert.assertFalse(omClientResponse.getOMResponse().getSuccess());
-    Assert.assertEquals(omClientResponse.getOMResponse().getStatus(),
+    Assertions.assertFalse(omClientResponse.getOMResponse().getSuccess());
+    Assertions.assertEquals(omClientResponse.getOMResponse().getStatus(),
         OzoneManagerProtocolProtos.Status.QUOTA_ERROR);
-    Assert.assertTrue(omClientResponse.getOMResponse().getMessage().
+    Assertions.assertTrue(omClientResponse.getOMResponse().getMessage().
         contains("Cannot update bucket quota. Requested spaceQuota less than " +
             "used spaceQuota"));
   }
@@ -440,10 +440,10 @@ public class TestOMBucketSetPropertyRequest extends TestBucketRequest {
         .validateAndUpdateCache(ozoneManager, 1,
             ozoneManagerDoubleBufferHelper);
 
-    Assert.assertFalse(omClientResponse.getOMResponse().getSuccess());
-    Assert.assertEquals(omClientResponse.getOMResponse().getStatus(),
+    Assertions.assertFalse(omClientResponse.getOMResponse().getSuccess());
+    Assertions.assertEquals(omClientResponse.getOMResponse().getStatus(),
         OzoneManagerProtocolProtos.Status.QUOTA_ERROR);
-    Assert.assertTrue(omClientResponse.getOMResponse().getMessage().
+    Assertions.assertTrue(omClientResponse.getOMResponse().getMessage().
         contains("Cannot update bucket quota. NamespaceQuota requested " +
             "is less than used namespaceQuota"));
   }
@@ -476,19 +476,16 @@ public class TestOMBucketSetPropertyRequest extends TestBucketRequest {
             .validateAndUpdateCache(ozoneManager, 1,
                     ozoneManagerDoubleBufferHelper);
 
-    Assert.assertEquals(true, omClientResponse.getOMResponse().getSuccess());
+    Assertions.assertTrue(omClientResponse.getOMResponse().getSuccess());
 
     OmBucketInfo dbBucketInfoAfter =
             omMetadataManager.getBucketTable().get(bucketKey);
 
-    Assert.assertEquals(null,
-            dbBucketInfoAfter.getDefaultReplicationConfig());
-    Assert.assertEquals(
-            dbBucketInfoBefore.getDefaultReplicationConfig(),
-            dbBucketInfoAfter.getDefaultReplicationConfig());
-    Assert.assertEquals(20 * GB,
+    Assertions.assertNull(dbBucketInfoAfter.getDefaultReplicationConfig());
+    Assertions.assertNull(dbBucketInfoBefore.getDefaultReplicationConfig());
+    Assertions.assertEquals(20 * GB,
             dbBucketInfoAfter.getQuotaInBytes());
-    Assert.assertEquals(1000L,
+    Assertions.assertEquals(1000L,
             dbBucketInfoAfter.getQuotaInNamespace());
 
     /* Bucket with EC replication */
@@ -517,19 +514,19 @@ public class TestOMBucketSetPropertyRequest extends TestBucketRequest {
             .validateAndUpdateCache(ozoneManager, 1,
                     ozoneManagerDoubleBufferHelper);
 
-    Assert.assertEquals(true, omClientResponse.getOMResponse().getSuccess());
+    Assertions.assertTrue(omClientResponse.getOMResponse().getSuccess());
 
     dbBucketInfoAfter =
             omMetadataManager.getBucketTable().get(bucketKey);
 
-    Assert.assertEquals(EC,
+    Assertions.assertEquals(EC,
             dbBucketInfoAfter.getDefaultReplicationConfig().getType());
-    Assert.assertEquals(
+    Assertions.assertEquals(
             dbBucketInfoBefore.getDefaultReplicationConfig(),
             dbBucketInfoAfter.getDefaultReplicationConfig());
-    Assert.assertEquals(20 * GB,
+    Assertions.assertEquals(20 * GB,
             dbBucketInfoAfter.getQuotaInBytes());
-    Assert.assertEquals(1000L,
+    Assertions.assertEquals(1000L,
             dbBucketInfoAfter.getQuotaInNamespace());
   }
 }

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/bucket/acl/TestOMBucketAddAclRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/bucket/acl/TestOMBucketAddAclRequest.java
@@ -26,8 +26,8 @@ import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMRequest;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMResponse;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.List;
 import java.util.UUID;
@@ -51,13 +51,13 @@ public class TestOMBucketAddAclRequest extends TestBucketRequest {
         new OMBucketAddAclRequest(originalRequest);
     OMRequest preExecuteRequest = omBucketAddAclRequest
         .preExecute(ozoneManager);
-    Assert.assertNotEquals(originalRequest, preExecuteRequest);
+    Assertions.assertNotEquals(originalRequest, preExecuteRequest);
 
     long newModTime = preExecuteRequest.getAddAclRequest()
         .getModificationTime();
     // When preExecute() of adding acl,
     // the new modification time is greater than origin one.
-    Assert.assertTrue(newModTime > originModTime);
+    Assertions.assertTrue(newModTime > originModTime);
   }
 
   @Test
@@ -82,8 +82,8 @@ public class TestOMBucketAddAclRequest extends TestBucketRequest {
         .validateAndUpdateCache(ozoneManager, 1,
             ozoneManagerDoubleBufferHelper);
     OMResponse omResponse = omClientResponse.getOMResponse();
-    Assert.assertNotNull(omResponse.getAddAclResponse());
-    Assert.assertEquals(OzoneManagerProtocolProtos.Status.OK,
+    Assertions.assertNotNull(omResponse.getAddAclResponse());
+    Assertions.assertEquals(OzoneManagerProtocolProtos.Status.OK,
         omResponse.getStatus());
 
     String bucketKey = omMetadataManager.getBucketKey(volumeName, bucketName);
@@ -91,8 +91,8 @@ public class TestOMBucketAddAclRequest extends TestBucketRequest {
         .get(bucketKey).getAcls();
 
     // Acl is added.
-    Assert.assertEquals(1, bucketAcls.size());
-    Assert.assertEquals(acl, bucketAcls.get(0));
+    Assertions.assertEquals(1, bucketAcls.size());
+    Assertions.assertEquals(acl, bucketAcls.get(0));
   }
 
   @Test
@@ -111,9 +111,9 @@ public class TestOMBucketAddAclRequest extends TestBucketRequest {
         .validateAndUpdateCache(ozoneManager, 1,
             ozoneManagerDoubleBufferHelper);
     OMResponse omResponse = omClientResponse.getOMResponse();
-    Assert.assertNotNull(omResponse.getAddAclResponse());
+    Assertions.assertNotNull(omResponse.getAddAclResponse());
     // The bucket is not created.
-    Assert.assertEquals(OzoneManagerProtocolProtos.Status.BUCKET_NOT_FOUND,
+    Assertions.assertEquals(OzoneManagerProtocolProtos.Status.BUCKET_NOT_FOUND,
         omResponse.getStatus());
   }
 }

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/bucket/acl/TestOMBucketRemoveAclRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/bucket/acl/TestOMBucketRemoveAclRequest.java
@@ -25,8 +25,8 @@ import org.apache.hadoop.ozone.om.response.OMClientResponse;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMRequest;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMResponse;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.List;
 import java.util.UUID;
@@ -50,13 +50,13 @@ public class TestOMBucketRemoveAclRequest extends TestBucketRequest {
         new OMBucketRemoveAclRequest(originalRequest);
     OMRequest preExecuteRequest = omBucketRemoveAclRequest
         .preExecute(ozoneManager);
-    Assert.assertNotEquals(originalRequest, preExecuteRequest);
+    Assertions.assertNotEquals(originalRequest, preExecuteRequest);
 
     long newModTime = preExecuteRequest.getRemoveAclRequest()
         .getModificationTime();
     // When preExecute() of removing acl,
     // the new modification time is greater than origin one.
-    Assert.assertTrue(newModTime > originModTime);
+    Assertions.assertTrue(newModTime > originModTime);
   }
 
   @Test
@@ -81,16 +81,16 @@ public class TestOMBucketRemoveAclRequest extends TestBucketRequest {
         .validateAndUpdateCache(ozoneManager, 1,
             ozoneManagerDoubleBufferHelper);
     OMResponse omAddAclResponse = omClientAddAclResponse.getOMResponse();
-    Assert.assertNotNull(omAddAclResponse.getAddAclResponse());
-    Assert.assertEquals(OzoneManagerProtocolProtos.Status.OK,
+    Assertions.assertNotNull(omAddAclResponse.getAddAclResponse());
+    Assertions.assertEquals(OzoneManagerProtocolProtos.Status.OK,
         omAddAclResponse.getStatus());
 
     // Verify result of adding acl.
     String bucketKey = omMetadataManager.getBucketKey(volumeName, bucketName);
     List<OzoneAcl> bucketAcls = omMetadataManager.getBucketTable()
         .get(bucketKey).getAcls();
-    Assert.assertEquals(1, bucketAcls.size());
-    Assert.assertEquals(acl, bucketAcls.get(0));
+    Assertions.assertEquals(1, bucketAcls.size());
+    Assertions.assertEquals(acl, bucketAcls.get(0));
 
     // Remove acl.
     OMRequest removeAclRequest = OMRequestTestUtils
@@ -102,14 +102,14 @@ public class TestOMBucketRemoveAclRequest extends TestBucketRequest {
         .validateAndUpdateCache(ozoneManager, 2,
             ozoneManagerDoubleBufferHelper);
     OMResponse omRemoveAclResponse = omClientRemoveAclResponse.getOMResponse();
-    Assert.assertNotNull(omRemoveAclResponse.getRemoveAclResponse());
-    Assert.assertEquals(OzoneManagerProtocolProtos.Status.OK,
+    Assertions.assertNotNull(omRemoveAclResponse.getRemoveAclResponse());
+    Assertions.assertEquals(OzoneManagerProtocolProtos.Status.OK,
         omRemoveAclResponse.getStatus());
 
     // Verify result of removing acl.
     List<OzoneAcl> newAcls = omMetadataManager.getBucketTable()
         .get(bucketKey).getAcls();
-    Assert.assertEquals(0, newAcls.size());
+    Assertions.assertEquals(0, newAcls.size());
   }
 
   @Test
@@ -129,9 +129,9 @@ public class TestOMBucketRemoveAclRequest extends TestBucketRequest {
             ozoneManagerDoubleBufferHelper);
     OMResponse omResponse = omClientResponse.getOMResponse();
 
-    Assert.assertNotNull(omResponse.getRemoveAclResponse());
+    Assertions.assertNotNull(omResponse.getRemoveAclResponse());
     // The bucket is not created.
-    Assert.assertEquals(OzoneManagerProtocolProtos.Status.BUCKET_NOT_FOUND,
+    Assertions.assertEquals(OzoneManagerProtocolProtos.Status.BUCKET_NOT_FOUND,
         omResponse.getStatus());
   }
 }

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/bucket/acl/TestOMBucketSetAclRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/bucket/acl/TestOMBucketSetAclRequest.java
@@ -26,8 +26,8 @@ import org.apache.hadoop.ozone.om.response.OMClientResponse;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMRequest;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMResponse;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.List;
 import java.util.UUID;
@@ -52,13 +52,13 @@ public class TestOMBucketSetAclRequest extends TestBucketRequest {
         new OMBucketSetAclRequest(originalRequest);
     OMRequest preExecuteRequest = omBucketSetAclRequest
         .preExecute(ozoneManager);
-    Assert.assertNotEquals(originalRequest, preExecuteRequest);
+    Assertions.assertNotEquals(originalRequest, preExecuteRequest);
 
     long newModTime = preExecuteRequest.getSetAclRequest()
         .getModificationTime();
     // When preExecute() of setting acl,
     // the new modification time is greater than origin one.
-    Assert.assertTrue(newModTime > originModTime);
+    Assertions.assertTrue(newModTime > originModTime);
   }
 
   @Test
@@ -85,8 +85,8 @@ public class TestOMBucketSetAclRequest extends TestBucketRequest {
         .validateAndUpdateCache(ozoneManager, 1,
             ozoneManagerDoubleBufferHelper);
     OMResponse omResponse = omClientResponse.getOMResponse();
-    Assert.assertNotNull(omResponse.getSetAclResponse());
-    Assert.assertEquals(OzoneManagerProtocolProtos.Status.OK,
+    Assertions.assertNotNull(omResponse.getSetAclResponse());
+    Assertions.assertEquals(OzoneManagerProtocolProtos.Status.OK,
         omResponse.getStatus());
 
     String bucketKey = omMetadataManager.getBucketKey(volumeName, bucketName);
@@ -94,9 +94,9 @@ public class TestOMBucketSetAclRequest extends TestBucketRequest {
         .get(bucketKey).getAcls();
 
     // Acls are added to acl list.
-    Assert.assertEquals(acls.size(), bucketAclList.size());
-    Assert.assertEquals(userAcl, bucketAclList.get(0));
-    Assert.assertEquals(groupAcl, bucketAclList.get(1));
+    Assertions.assertEquals(acls.size(), bucketAclList.size());
+    Assertions.assertEquals(userAcl, bucketAclList.get(0));
+    Assertions.assertEquals(groupAcl, bucketAclList.get(1));
 
   }
 
@@ -117,9 +117,9 @@ public class TestOMBucketSetAclRequest extends TestBucketRequest {
         .validateAndUpdateCache(ozoneManager, 1,
             ozoneManagerDoubleBufferHelper);
     OMResponse omResponse = omClientResponse.getOMResponse();
-    Assert.assertNotNull(omResponse.getSetAclResponse());
+    Assertions.assertNotNull(omResponse.getSetAclResponse());
     // The bucket is not created.
-    Assert.assertEquals(OzoneManagerProtocolProtos.Status.BUCKET_NOT_FOUND,
+    Assertions.assertEquals(OzoneManagerProtocolProtos.Status.BUCKET_NOT_FOUND,
         omResponse.getStatus());
   }
 }

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/file/TestOMDirectoryCreateRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/file/TestOMDirectoryCreateRequest.java
@@ -160,11 +160,11 @@ public class TestOMDirectoryCreateRequest {
         omDirectoryCreateRequest.validateAndUpdateCache(ozoneManager, 100L,
             ozoneManagerDoubleBufferHelper);
 
-    Assertions.assertTrue(omClientResponse.getOMResponse().getStatus()
-        == OzoneManagerProtocolProtos.Status.OK);
-    Assertions.assertTrue(omMetadataManager.getKeyTable(getBucketLayout())
-        .get(omMetadataManager.getOzoneDirKey(volumeName, bucketName, keyName))
-        != null);
+    Assertions.assertSame(omClientResponse.getOMResponse().getStatus(),
+        OzoneManagerProtocolProtos.Status.OK);
+    Assertions.assertNotNull(omMetadataManager.getKeyTable(getBucketLayout())
+        .get(
+            omMetadataManager.getOzoneDirKey(volumeName, bucketName, keyName)));
 
     OmBucketInfo bucketInfo = omMetadataManager.getBucketTable()
         .get(omMetadataManager.getBucketKey(volumeName, bucketName));
@@ -199,9 +199,9 @@ public class TestOMDirectoryCreateRequest {
     OMClientResponse omClientResponse =
         omDirectoryCreateRequest.validateAndUpdateCache(ozoneManager, 100L,
             ozoneManagerDoubleBufferHelper);
-    
-    Assertions.assertTrue(omClientResponse.getOMResponse().getStatus()
-        == OzoneManagerProtocolProtos.Status.QUOTA_EXCEEDED);
+
+    Assertions.assertSame(omClientResponse.getOMResponse().getStatus(),
+        OzoneManagerProtocolProtos.Status.QUOTA_EXCEEDED);
   }
 
   @Test
@@ -256,13 +256,13 @@ public class TestOMDirectoryCreateRequest {
         omDirectoryCreateRequest.validateAndUpdateCache(ozoneManager, 100L,
             ozoneManagerDoubleBufferHelper);
 
-    Assertions.assertTrue(omClientResponse.getOMResponse().getStatus()
-        == OzoneManagerProtocolProtos.Status.BUCKET_NOT_FOUND);
+    Assertions.assertSame(omClientResponse.getOMResponse().getStatus(),
+        OzoneManagerProtocolProtos.Status.BUCKET_NOT_FOUND);
 
     // Key should not exist in DB
-    Assertions.assertTrue(omMetadataManager.getKeyTable(getBucketLayout())
-        .get(omMetadataManager.getOzoneDirKey(volumeName, bucketName, keyName))
-        == null);
+    Assertions.assertNull(omMetadataManager.getKeyTable(getBucketLayout())
+        .get(
+            omMetadataManager.getOzoneDirKey(volumeName, bucketName, keyName)));
   }
 
   @Test
@@ -294,17 +294,17 @@ public class TestOMDirectoryCreateRequest {
         omDirectoryCreateRequest.validateAndUpdateCache(ozoneManager, 100L,
             ozoneManagerDoubleBufferHelper);
 
-    Assertions.assertTrue(omClientResponse.getOMResponse().getStatus()
-        == OzoneManagerProtocolProtos.Status.OK);
+    Assertions.assertSame(omClientResponse.getOMResponse().getStatus(),
+        OzoneManagerProtocolProtos.Status.OK);
 
     // Key should exist in DB and cache.
-    Assertions.assertTrue(omMetadataManager.getKeyTable(getBucketLayout())
-        .get(omMetadataManager.getOzoneDirKey(volumeName, bucketName, keyName))
-        != null);
-    Assertions.assertTrue(omMetadataManager.getKeyTable(getBucketLayout())
+    Assertions.assertNotNull(omMetadataManager.getKeyTable(getBucketLayout())
+        .get(
+            omMetadataManager.getOzoneDirKey(volumeName, bucketName, keyName)));
+    Assertions.assertNotNull(omMetadataManager.getKeyTable(getBucketLayout())
         .getCacheValue(new CacheKey<>(
-            omMetadataManager.getOzoneDirKey(volumeName, bucketName, keyName)))
-        != null);
+            omMetadataManager.getOzoneDirKey(volumeName, bucketName,
+                keyName))));
 
   }
 
@@ -338,19 +338,19 @@ public class TestOMDirectoryCreateRequest {
         omDirectoryCreateRequest.validateAndUpdateCache(ozoneManager, 100L,
             ozoneManagerDoubleBufferHelper);
 
-    Assertions.assertTrue(omClientResponse.getOMResponse().getStatus()
-        == OzoneManagerProtocolProtos.Status.DIRECTORY_ALREADY_EXISTS);
+    Assertions.assertSame(omClientResponse.getOMResponse().getStatus(),
+        OzoneManagerProtocolProtos.Status.DIRECTORY_ALREADY_EXISTS);
 
     // Key should exist in DB
-    Assertions.assertTrue(omMetadataManager.getKeyTable(getBucketLayout())
-        .get(omMetadataManager.getOzoneDirKey(volumeName, bucketName, keyName))
-        != null);
+    Assertions.assertNotNull(omMetadataManager.getKeyTable(getBucketLayout())
+        .get(
+            omMetadataManager.getOzoneDirKey(volumeName, bucketName, keyName)));
 
     // As it already exists, it should not be in cache.
-    Assertions.assertTrue(omMetadataManager.getKeyTable(getBucketLayout())
+    Assertions.assertNull(omMetadataManager.getKeyTable(getBucketLayout())
         .getCacheValue(new CacheKey<>(
-            omMetadataManager.getOzoneDirKey(volumeName, bucketName, keyName)))
-        == null);
+            omMetadataManager.getOzoneDirKey(volumeName, bucketName,
+                keyName))));
 
   }
 
@@ -382,13 +382,13 @@ public class TestOMDirectoryCreateRequest {
         omDirectoryCreateRequest.validateAndUpdateCache(ozoneManager, 100L,
             ozoneManagerDoubleBufferHelper);
 
-    Assertions.assertTrue(omClientResponse.getOMResponse().getStatus()
-        == OzoneManagerProtocolProtos.Status.FILE_ALREADY_EXISTS);
+    Assertions.assertSame(omClientResponse.getOMResponse().getStatus(),
+        OzoneManagerProtocolProtos.Status.FILE_ALREADY_EXISTS);
 
     // Key should not exist in DB
-    Assertions.assertTrue(omMetadataManager.getKeyTable(getBucketLayout())
-        .get(omMetadataManager.getOzoneDirKey(volumeName, bucketName, keyName))
-        == null);
+    Assertions.assertNull(omMetadataManager.getKeyTable(getBucketLayout())
+        .get(
+            omMetadataManager.getOzoneDirKey(volumeName, bucketName, keyName)));
 
   }
 

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/file/TestOMDirectoryCreateRequestWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/file/TestOMDirectoryCreateRequestWithFSO.java
@@ -164,8 +164,8 @@ public class TestOMDirectoryCreateRequestWithFSO {
             omDirCreateRequestFSO.validateAndUpdateCache(ozoneManager, 100L,
                     ozoneManagerDoubleBufferHelper);
 
-    Assertions.assertTrue(omClientResponse.getOMResponse().getStatus()
-            == OzoneManagerProtocolProtos.Status.OK);
+    Assertions.assertSame(omClientResponse.getOMResponse().getStatus(),
+        OzoneManagerProtocolProtos.Status.OK);
     verifyDirectoriesInDB(dirs, volumeId, bucketId);
 
     OmBucketInfo bucketInfo = omMetadataManager.getBucketTable()
@@ -204,8 +204,8 @@ public class TestOMDirectoryCreateRequestWithFSO {
     OMClientResponse omClientResponse =
         omDirCreateRequestFSO.validateAndUpdateCache(ozoneManager, 100L,
             ozoneManagerDoubleBufferHelper);
-    Assertions.assertTrue(omClientResponse.getOMResponse().getStatus()
-        == OzoneManagerProtocolProtos.Status.QUOTA_EXCEEDED);
+    Assertions.assertSame(omClientResponse.getOMResponse().getStatus(),
+        OzoneManagerProtocolProtos.Status.QUOTA_EXCEEDED);
   }
 
   @Test
@@ -264,8 +264,8 @@ public class TestOMDirectoryCreateRequestWithFSO {
             omDirCreateReqFSO.validateAndUpdateCache(ozoneManager, 100L,
                     ozoneManagerDoubleBufferHelper);
 
-    Assertions.assertTrue(omClientResponse.getOMResponse().getStatus()
-            == OzoneManagerProtocolProtos.Status.BUCKET_NOT_FOUND);
+    Assertions.assertSame(omClientResponse.getOMResponse().getStatus(),
+        OzoneManagerProtocolProtos.Status.BUCKET_NOT_FOUND);
 
     // Key should not exist in DB
     Assertions.assertTrue(omMetadataManager.getDirectoryTable().isEmpty(),
@@ -372,8 +372,8 @@ public class TestOMDirectoryCreateRequestWithFSO {
             omDirCreateReqFSO.validateAndUpdateCache(ozoneManager, 100L,
                     ozoneManagerDoubleBufferHelper);
 
-    Assertions.assertTrue(omClientResponse.getOMResponse().getStatus()
-            == OzoneManagerProtocolProtos.Status.DIRECTORY_ALREADY_EXISTS);
+    Assertions.assertSame(omClientResponse.getOMResponse().getStatus(),
+        OzoneManagerProtocolProtos.Status.DIRECTORY_ALREADY_EXISTS);
 
     Assertions.assertEquals(0, ozoneManager.getMetrics().getNumKeys(),
         "Wrong OM numKeys metrics");
@@ -726,7 +726,7 @@ public class TestOMDirectoryCreateRequestWithFSO {
     // [user:newUser:rw[DEFAULT], group:newGroup:rwl[DEFAULT]]
     for (int indx = 0; indx < dirs.size(); indx++) {
       String dirName = dirs.get(indx);
-      String dbKey = "";
+      String dbKey;
       // for index=0, parentID is bucketID
       dbKey = omMetadataManager.getOzonePathKey(volumeId, bucketId,
           parentID, dirName);
@@ -765,7 +765,7 @@ public class TestOMDirectoryCreateRequestWithFSO {
     long parentID = bucketId;
     for (int indx = 0; indx < dirs.size(); indx++) {
       String dirName = dirs.get(indx);
-      String dbKey = "";
+      String dbKey;
       // for index=0, parentID is bucketID
       dbKey = omMetadataManager.getOzonePathKey(volumeId, bucketId,
               parentID, dirName);
@@ -787,7 +787,7 @@ public class TestOMDirectoryCreateRequestWithFSO {
     long parentID = bucketId;
     for (int indx = 0; indx < dirs.size(); indx++) {
       String dirName = dirs.get(indx);
-      String dbKey = "";
+      String dbKey;
       // for index=0, parentID is bucketID
       dbKey = omMetadataManager.getOzonePathKey(volumeId, bucketId,
               parentID, dirName);

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/file/TestOMFileCreateRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/file/TestOMFileCreateRequest.java
@@ -32,8 +32,8 @@ import org.apache.hadoop.ozone.om.helpers.OmBucketInfo;
 import org.apache.hadoop.ozone.om.helpers.OmDirectoryInfo;
 import org.apache.hadoop.ozone.om.request.OMRequestTestUtils;
 import org.jetbrains.annotations.NotNull;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
@@ -71,16 +71,16 @@ public class TestOMFileCreateRequest extends TestOMKeyRequest {
     OMFileCreateRequest omFileCreateRequest = getOMFileCreateRequest(omRequest);
 
     OMRequest modifiedOmRequest = omFileCreateRequest.preExecute(ozoneManager);
-    Assert.assertNotEquals(omRequest, modifiedOmRequest);
+    Assertions.assertNotEquals(omRequest, modifiedOmRequest);
 
     // Check clientID and modification time is set or not.
-    Assert.assertTrue(modifiedOmRequest.hasCreateFileRequest());
-    Assert.assertTrue(
+    Assertions.assertTrue(modifiedOmRequest.hasCreateFileRequest());
+    Assertions.assertTrue(
         modifiedOmRequest.getCreateFileRequest().getClientID() > 0);
 
     KeyArgs keyArgs = modifiedOmRequest.getCreateFileRequest().getKeyArgs();
-    Assert.assertNotNull(keyArgs);
-    Assert.assertTrue(keyArgs.getModificationTime() > 0);
+    Assertions.assertNotNull(keyArgs);
+    Assertions.assertTrue(keyArgs.getModificationTime() > 0);
 
     // As our data size is 100, and scmBlockSize is default to 1000, so we
     // shall have only one block.
@@ -88,18 +88,18 @@ public class TestOMFileCreateRequest extends TestOMKeyRequest {
         keyArgs.getKeyLocationsList();
 
     // KeyLocation should be set.
-    Assert.assertTrue(keyLocations.size() == 1);
-    Assert.assertEquals(CONTAINER_ID,
+    Assertions.assertTrue(keyLocations.size() == 1);
+    Assertions.assertEquals(CONTAINER_ID,
         keyLocations.get(0).getBlockID().getContainerBlockID()
             .getContainerID());
-    Assert.assertEquals(LOCAL_ID,
+    Assertions.assertEquals(LOCAL_ID,
         keyLocations.get(0).getBlockID().getContainerBlockID()
             .getLocalID());
-    Assert.assertTrue(keyLocations.get(0).hasPipeline());
+    Assertions.assertTrue(keyLocations.get(0).hasPipeline());
 
-    Assert.assertEquals(0, keyLocations.get(0).getOffset());
+    Assertions.assertEquals(0, keyLocations.get(0).getOffset());
 
-    Assert.assertEquals(scmBlockSize, keyLocations.get(0).getLength());
+    Assertions.assertEquals(scmBlockSize, keyLocations.get(0).getLength());
   }
 
   @Test
@@ -111,17 +111,17 @@ public class TestOMFileCreateRequest extends TestOMKeyRequest {
     OMFileCreateRequest omFileCreateRequest = getOMFileCreateRequest(omRequest);
 
     OMRequest modifiedOmRequest = omFileCreateRequest.preExecute(ozoneManager);
-    Assert.assertNotEquals(omRequest, modifiedOmRequest);
+    Assertions.assertNotEquals(omRequest, modifiedOmRequest);
 
     // When KeyName is root, nothing will be set.
-    Assert.assertTrue(modifiedOmRequest.hasCreateFileRequest());
-    Assert.assertFalse(
+    Assertions.assertTrue(modifiedOmRequest.hasCreateFileRequest());
+    Assertions.assertFalse(
         modifiedOmRequest.getCreateFileRequest().getClientID() > 0);
 
     KeyArgs keyArgs = modifiedOmRequest.getCreateFileRequest().getKeyArgs();
-    Assert.assertNotNull(keyArgs);
-    Assert.assertTrue(keyArgs.getModificationTime() == 0);
-    Assert.assertTrue(keyArgs.getKeyLocationsList().size() == 0);
+    Assertions.assertNotNull(keyArgs);
+    Assertions.assertTrue(keyArgs.getModificationTime() == 0);
+    Assertions.assertTrue(keyArgs.getKeyLocationsList().size() == 0);
   }
 
   @Test
@@ -140,7 +140,7 @@ public class TestOMFileCreateRequest extends TestOMKeyRequest {
 
     // Before calling
     OmKeyInfo omKeyInfo = verifyPathInOpenKeyTable(keyName, id, false);
-    Assert.assertNull(omKeyInfo);
+    Assertions.assertNull(omKeyInfo);
 
     omFileCreateRequest = getOMFileCreateRequest(modifiedOmRequest);
 
@@ -148,7 +148,7 @@ public class TestOMFileCreateRequest extends TestOMKeyRequest {
         omFileCreateRequest.validateAndUpdateCache(ozoneManager, 100L,
             ozoneManagerDoubleBufferHelper);
 
-    Assert.assertEquals(OzoneManagerProtocolProtos.Status.OK,
+    Assertions.assertEquals(OzoneManagerProtocolProtos.Status.OK,
         omFileCreateResponse.getOMResponse().getStatus());
 
     // Check open table whether key is added or not.
@@ -157,15 +157,15 @@ public class TestOMFileCreateRequest extends TestOMKeyRequest {
 
     List< OmKeyLocationInfo > omKeyLocationInfoList =
         omKeyInfo.getLatestVersionLocations().getLocationList();
-    Assert.assertTrue(omKeyLocationInfoList.size() == 1);
+    Assertions.assertTrue(omKeyLocationInfoList.size() == 1);
 
     OmKeyLocationInfo omKeyLocationInfo = omKeyLocationInfoList.get(0);
 
     // Check modification time
-    Assert.assertEquals(modifiedOmRequest.getCreateFileRequest()
+    Assertions.assertEquals(modifiedOmRequest.getCreateFileRequest()
         .getKeyArgs().getModificationTime(), omKeyInfo.getModificationTime());
 
-    Assert.assertEquals(omKeyInfo.getModificationTime(),
+    Assertions.assertEquals(omKeyInfo.getModificationTime(),
         omKeyInfo.getCreationTime());
 
     // Check data of the block
@@ -173,9 +173,9 @@ public class TestOMFileCreateRequest extends TestOMKeyRequest {
         modifiedOmRequest.getCreateFileRequest().getKeyArgs()
             .getKeyLocations(0);
 
-    Assert.assertEquals(keyLocation.getBlockID().getContainerBlockID()
+    Assertions.assertEquals(keyLocation.getBlockID().getContainerBlockID()
         .getContainerID(), omKeyLocationInfo.getContainerID());
-    Assert.assertEquals(keyLocation.getBlockID().getContainerBlockID()
+    Assertions.assertEquals(keyLocation.getBlockID().getContainerBlockID()
         .getLocalID(), omKeyLocationInfo.getLocalID());
   }
 
@@ -201,7 +201,7 @@ public class TestOMFileCreateRequest extends TestOMKeyRequest {
     OMClientResponse omFileCreateResponse =
         omFileCreateRequest.validateAndUpdateCache(ozoneManager, 100L,
             ozoneManagerDoubleBufferHelper);
-    Assert.assertTrue(omFileCreateResponse.getOMResponse().getStatus()
+    Assertions.assertTrue(omFileCreateResponse.getOMResponse().getStatus()
         == OzoneManagerProtocolProtos.Status.QUOTA_EXCEEDED);
   }
 
@@ -220,7 +220,7 @@ public class TestOMFileCreateRequest extends TestOMKeyRequest {
     OMClientResponse omFileCreateResponse =
         omFileCreateRequest.validateAndUpdateCache(ozoneManager, 100L,
             ozoneManagerDoubleBufferHelper);
-    Assert.assertEquals(VOLUME_NOT_FOUND,
+    Assertions.assertEquals(VOLUME_NOT_FOUND,
         omFileCreateResponse.getOMResponse().getStatus());
   }
 
@@ -240,7 +240,7 @@ public class TestOMFileCreateRequest extends TestOMKeyRequest {
     OMClientResponse omFileCreateResponse =
         omFileCreateRequest.validateAndUpdateCache(ozoneManager, 100L,
             ozoneManagerDoubleBufferHelper);
-    Assert.assertEquals(BUCKET_NOT_FOUND,
+    Assertions.assertEquals(BUCKET_NOT_FOUND,
         omFileCreateResponse.getOMResponse().getStatus());
   }
 
@@ -301,7 +301,7 @@ public class TestOMFileCreateRequest extends TestOMKeyRequest {
     testNonRecursivePath(key, false, true, false);
     
     // 3 parent directory created c/d/e
-    Assert.assertEquals(omMetadataManager.getBucketTable().get(
+    Assertions.assertEquals(omMetadataManager.getBucketTable().get(
             omMetadataManager.getBucketKey(volumeName, bucketName))
         .getUsedNamespace(), 3);
     
@@ -384,7 +384,7 @@ public class TestOMFileCreateRequest extends TestOMKeyRequest {
     String bucketKey = omMetadataManager.getBucketKey(volumeName, bucketName);
     bucketAclResults.addAll(omMetadataManager.getBucketTable()
         .get(bucketKey).getAcls());
-    Assert.assertEquals(acls, bucketAclResults);
+    Assertions.assertEquals(acls, bucketAclResults);
 
     // Recursive create file with acls inherited from bucket DEFAULT acls
     OMRequest omRequest = createFileRequest(volumeName, bucketName,
@@ -398,7 +398,7 @@ public class TestOMFileCreateRequest extends TestOMKeyRequest {
     OMClientResponse omFileCreateResponse =
         omFileCreateRequest.validateAndUpdateCache(ozoneManager, 100L,
             ozoneManagerDoubleBufferHelper);
-    Assert.assertEquals(OzoneManagerProtocolProtos.Status.OK,
+    Assertions.assertEquals(OzoneManagerProtocolProtos.Status.OK,
         omFileCreateResponse.getOMResponse().getStatus());
 
     long id = modifiedOmRequest.getCreateFileRequest().getClientID();
@@ -445,8 +445,8 @@ public class TestOMFileCreateRequest extends TestOMKeyRequest {
 
         System.out.println(
             "  subdir acls : " + omDirInfo + " ==> " + omDirAcls);
-        Assert.assertEquals("Failed to inherit parent DEFAULT acls!",
-            expectedInheritAcls, omDirAcls);
+        Assertions.assertEquals(expectedInheritAcls, omDirAcls,
+            "Failed to inherit parent DEFAULT acls!");
 
         parentID = omDirInfo.getObjectID();
         expectedInheritAcls = omDirAcls;
@@ -455,14 +455,14 @@ public class TestOMFileCreateRequest extends TestOMKeyRequest {
         // [user:newUser:rw[ACCESS], group:newGroup:rwl[ACCESS]]
         if (indx == dirs.size() - 1) {
           // verify file acls
-          Assert.assertEquals(omDirInfo.getObjectID(),
+          Assertions.assertEquals(omDirInfo.getObjectID(),
               omKeyInfo.getParentObjectID());
           List<OzoneAcl> fileAcls = omDirInfo.getAcls();
           System.out.println("  file acls : " + omKeyInfo + " ==> " + fileAcls);
-          Assert.assertEquals("Failed to inherit parent DEFAULT acls!",
-              expectedInheritAcls.stream()
+          Assertions.assertEquals(expectedInheritAcls.stream()
                   .map(acl -> acl.setAclScope(OzoneAcl.AclScope.ACCESS))
-                  .collect(Collectors.toList()), fileAcls);
+                  .collect(Collectors.toList()), fileAcls,
+              "Failed to inherit parent DEFAULT acls!");
         }
       }
     } else {
@@ -478,12 +478,12 @@ public class TestOMFileCreateRequest extends TestOMKeyRequest {
 
       // Should inherit parent DEFAULT acls
       // [user:newUser:rw[ACCESS], group:newGroup:rwl[ACCESS]]
-      Assert.assertEquals("Failed to inherit bucket DEFAULT acls!",
-          parentDefaultAcl.stream()
+      Assertions.assertEquals(parentDefaultAcl.stream()
               .map(acl -> acl.setAclScope(OzoneAcl.AclScope.ACCESS))
-              .collect(Collectors.toList()), keyAcls);
+              .collect(Collectors.toList()), keyAcls,
+          "Failed to inherit bucket DEFAULT acls!");
       // Should not inherit parent ACCESS acls
-      Assert.assertFalse(keyAcls.contains(parentAccessAcl));
+      Assertions.assertFalse(keyAcls.contains(parentAccessAcl));
     }
   }
 
@@ -516,10 +516,10 @@ public class TestOMFileCreateRequest extends TestOMKeyRequest {
       OMFileCreateRequest omFileCreateRequest =
           getOMFileCreateRequest(omRequest);
 
-      OMException ex = Assert.assertThrows(OMException.class,
+      OMException ex = Assertions.assertThrows(OMException.class,
           () -> omFileCreateRequest.preExecute(ozoneManager));
 
-      Assert.assertTrue(ex.getMessage().contains(expectedErrorMessage));
+      Assertions.assertTrue(ex.getMessage().contains(expectedErrorMessage));
     }
   }
 
@@ -544,11 +544,11 @@ public class TestOMFileCreateRequest extends TestOMKeyRequest {
     if (fail) {
       OzoneManagerProtocolProtos.Status respStatus =
           omFileCreateResponse.getOMResponse().getStatus();
-      Assert.assertTrue(respStatus == NOT_A_FILE
+      Assertions.assertTrue(respStatus == NOT_A_FILE
           || respStatus == FILE_ALREADY_EXISTS
           || respStatus == DIRECTORY_NOT_FOUND);
     } else {
-      Assert.assertTrue(omFileCreateResponse.getOMResponse().getSuccess());
+      Assertions.assertTrue(omFileCreateResponse.getOMResponse().getSuccess());
       long id = modifiedOmRequest.getCreateFileRequest().getClientID();
 
       verifyKeyNameInCreateFileResponse(key, omFileCreateResponse);
@@ -557,12 +557,12 @@ public class TestOMFileCreateRequest extends TestOMKeyRequest {
 
       List< OmKeyLocationInfo > omKeyLocationInfoList =
           omKeyInfo.getLatestVersionLocations().getLocationList();
-      Assert.assertTrue(omKeyLocationInfoList.size() == 1);
+      Assertions.assertTrue(omKeyLocationInfoList.size() == 1);
 
       OmKeyLocationInfo omKeyLocationInfo = omKeyLocationInfoList.get(0);
 
       // Check modification time
-      Assert.assertEquals(modifiedOmRequest.getCreateFileRequest()
+      Assertions.assertEquals(modifiedOmRequest.getCreateFileRequest()
           .getKeyArgs().getModificationTime(), omKeyInfo.getModificationTime());
 
       // Check data of the block
@@ -570,9 +570,9 @@ public class TestOMFileCreateRequest extends TestOMKeyRequest {
           modifiedOmRequest.getCreateFileRequest().getKeyArgs()
               .getKeyLocations(0);
 
-      Assert.assertEquals(keyLocation.getBlockID().getContainerBlockID()
+      Assertions.assertEquals(keyLocation.getBlockID().getContainerBlockID()
           .getContainerID(), omKeyLocationInfo.getContainerID());
-      Assert.assertEquals(keyLocation.getBlockID().getContainerBlockID()
+      Assertions.assertEquals(keyLocation.getBlockID().getContainerBlockID()
           .getLocalID(), omKeyLocationInfo.getLocalID());
     }
   }
@@ -582,7 +582,7 @@ public class TestOMFileCreateRequest extends TestOMKeyRequest {
     OzoneManagerProtocolProtos.CreateFileResponse createFileResponse =
             omFileCreateResponse.getOMResponse().getCreateFileResponse();
     String actualFileName = createFileResponse.getKeyInfo().getKeyName();
-    Assert.assertEquals("Incorrect keyName", key, actualFileName);
+    Assertions.assertEquals(key, actualFileName, "Incorrect keyName");
   }
 
   /**

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/file/TestOMFileCreateRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/file/TestOMFileCreateRequest.java
@@ -55,7 +55,6 @@ import static org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.
 import static org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.Status.FILE_ALREADY_EXISTS;
 import static org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.Status.NOT_A_FILE;
 import static org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.Status.DIRECTORY_NOT_FOUND;
-import static org.slf4j.MDC.put;
 
 /**
  * Tests OMFileCreateRequest.
@@ -88,7 +87,7 @@ public class TestOMFileCreateRequest extends TestOMKeyRequest {
         keyArgs.getKeyLocationsList();
 
     // KeyLocation should be set.
-    Assertions.assertTrue(keyLocations.size() == 1);
+    Assertions.assertEquals(1, keyLocations.size());
     Assertions.assertEquals(CONTAINER_ID,
         keyLocations.get(0).getBlockID().getContainerBlockID()
             .getContainerID());
@@ -120,8 +119,8 @@ public class TestOMFileCreateRequest extends TestOMKeyRequest {
 
     KeyArgs keyArgs = modifiedOmRequest.getCreateFileRequest().getKeyArgs();
     Assertions.assertNotNull(keyArgs);
-    Assertions.assertTrue(keyArgs.getModificationTime() == 0);
-    Assertions.assertTrue(keyArgs.getKeyLocationsList().size() == 0);
+    Assertions.assertEquals(0, keyArgs.getModificationTime());
+    Assertions.assertEquals(0, keyArgs.getKeyLocationsList().size());
   }
 
   @Test
@@ -157,7 +156,7 @@ public class TestOMFileCreateRequest extends TestOMKeyRequest {
 
     List< OmKeyLocationInfo > omKeyLocationInfoList =
         omKeyInfo.getLatestVersionLocations().getLocationList();
-    Assertions.assertTrue(omKeyLocationInfoList.size() == 1);
+    Assertions.assertEquals(1, omKeyLocationInfoList.size());
 
     OmKeyLocationInfo omKeyLocationInfo = omKeyLocationInfoList.get(0);
 
@@ -201,8 +200,8 @@ public class TestOMFileCreateRequest extends TestOMKeyRequest {
     OMClientResponse omFileCreateResponse =
         omFileCreateRequest.validateAndUpdateCache(ozoneManager, 100L,
             ozoneManagerDoubleBufferHelper);
-    Assertions.assertTrue(omFileCreateResponse.getOMResponse().getStatus()
-        == OzoneManagerProtocolProtos.Status.QUOTA_EXCEEDED);
+    Assertions.assertSame(omFileCreateResponse.getOMResponse().getStatus(),
+        OzoneManagerProtocolProtos.Status.QUOTA_EXCEEDED);
   }
 
   @Test
@@ -435,7 +434,7 @@ public class TestOMFileCreateRequest extends TestOMKeyRequest {
       // [user:newUser:rw[DEFAULT], group:newGroup:rwl[DEFAULT]]
       for (int indx = 0; indx < dirs.size(); indx++) {
         String dirName = dirs.get(indx);
-        String dbKey = "";
+        String dbKey;
         // for index=0, parentID is bucketID
         dbKey = omMetadataManager.getOzonePathKey(volumeId, bucketId,
             parentID, dirName);
@@ -557,7 +556,7 @@ public class TestOMFileCreateRequest extends TestOMKeyRequest {
 
       List< OmKeyLocationInfo > omKeyLocationInfoList =
           omKeyInfo.getLatestVersionLocations().getLocationList();
-      Assertions.assertTrue(omKeyLocationInfoList.size() == 1);
+      Assertions.assertEquals(1, omKeyLocationInfoList.size());
 
       OmKeyLocationInfo omKeyLocationInfo = omKeyLocationInfoList.get(0);
 

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/file/TestOMFileCreateRequestWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/file/TestOMFileCreateRequestWithFSO.java
@@ -94,8 +94,8 @@ public class TestOMFileCreateRequestWithFSO extends TestOMFileCreateRequest {
     OMClientResponse omFileCreateResponse =
         omFileCreateRequest.validateAndUpdateCache(ozoneManager, 100L,
             ozoneManagerDoubleBufferHelper);
-    Assertions.assertTrue(omFileCreateResponse.getOMResponse().getStatus()
-        == OzoneManagerProtocolProtos.Status.QUOTA_EXCEEDED);
+    Assertions.assertSame(omFileCreateResponse.getOMResponse().getStatus(),
+        OzoneManagerProtocolProtos.Status.QUOTA_EXCEEDED);
   }
 
   @Test

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/file/TestOMFileCreateRequestWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/file/TestOMFileCreateRequestWithFSO.java
@@ -29,8 +29,8 @@ import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMRequest;
 import org.apache.hadoop.util.StringUtils;
 import org.apache.hadoop.util.Time;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.UUID;
 
@@ -44,7 +44,8 @@ public class TestOMFileCreateRequestWithFSO extends TestOMFileCreateRequest {
   public void testValidateAndUpdateCacheWithNonRecursive() throws Exception {
     testNonRecursivePath(UUID.randomUUID().toString(), false, false, false);
     testNonRecursivePath("a/b", false, false, true);
-    Assert.assertEquals("Invalid metrics value", 0, omMetrics.getNumKeys());
+    Assertions.assertEquals(0, omMetrics.getNumKeys(),
+        "Invalid metrics value");
 
     // Create parent dirs for the path
     OMRequestTestUtils.addParentsToDirTable(volumeName, bucketName,
@@ -59,7 +60,7 @@ public class TestOMFileCreateRequestWithFSO extends TestOMFileCreateRequest {
 
     // Delete child key but retain path "a/b/ in the key table
     OmDirectoryInfo dirPathC = getDirInfo("a/b/c");
-    Assert.assertNotNull("Failed to find dir path: a/b/c", dirPathC);
+    Assertions.assertNotNull(dirPathC, "Failed to find dir path: a/b/c");
     final long volumeId = omMetadataManager.getVolumeId(volumeName);
     final long bucketId = omMetadataManager.getBucketId(volumeName,
             bucketName);
@@ -93,7 +94,7 @@ public class TestOMFileCreateRequestWithFSO extends TestOMFileCreateRequest {
     OMClientResponse omFileCreateResponse =
         omFileCreateRequest.validateAndUpdateCache(ozoneManager, 100L,
             ozoneManagerDoubleBufferHelper);
-    Assert.assertTrue(omFileCreateResponse.getOMResponse().getStatus()
+    Assertions.assertTrue(omFileCreateResponse.getOMResponse().getStatus()
         == OzoneManagerProtocolProtos.Status.QUOTA_EXCEEDED);
   }
 
@@ -103,8 +104,9 @@ public class TestOMFileCreateRequestWithFSO extends TestOMFileCreateRequest {
     String key = "c/d/e/f";
     // Should be able to create file even if parent directories does not exist
     testNonRecursivePath(key, false, true, false);
-    Assert.assertEquals("Invalid metrics value", 3, omMetrics.getNumKeys());
-    Assert.assertEquals(omMetadataManager.getBucketTable().get(
+    Assertions.assertEquals(3, omMetrics.getNumKeys(),
+        "Invalid metrics value");
+    Assertions.assertEquals(omMetadataManager.getBucketTable().get(
         omMetadataManager.getBucketKey(volumeName, bucketName))
         .getUsedNamespace(), omMetrics.getNumKeys());
 
@@ -194,7 +196,7 @@ public class TestOMFileCreateRequestWithFSO extends TestOMFileCreateRequest {
             omMetadataManager.getOpenKeyTable(getBucketLayout())
                 .get(dbOpenFileName);
         if (doAssert) {
-          Assert.assertNotNull("Invalid key!", omKeyInfo);
+          Assertions.assertNotNull(omKeyInfo, "Invalid key!");
         }
         return omKeyInfo;
       } else {
@@ -207,7 +209,7 @@ public class TestOMFileCreateRequestWithFSO extends TestOMFileCreateRequest {
       }
     }
     if (doAssert) {
-      Assert.fail("Invalid key!");
+      Assertions.fail("Invalid key!");
     }
     return null;
   }

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/file/TestOMRecoverLeaseRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/file/TestOMRecoverLeaseRequest.java
@@ -37,8 +37,8 @@ import org.apache.hadoop.ozone.security.acl.IAccessAuthorizer;
 import org.apache.hadoop.ozone.security.acl.OzoneObj;
 import org.apache.hadoop.util.Time;
 import org.jetbrains.annotations.NotNull;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.net.InetSocketAddress;
@@ -47,7 +47,7 @@ import java.util.List;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.when;
@@ -83,7 +83,7 @@ public class TestOMRecoverLeaseRequest extends TestOMKeyRequest {
 
     OMClientResponse omClientResponse = validateAndUpdateCache();
 
-    Assert.assertEquals(OzoneManagerProtocolProtos.Status.OK,
+    Assertions.assertEquals(OzoneManagerProtocolProtos.Status.OK,
         omClientResponse.getOMResponse().getStatus());
 
     verifyTables(true, true);
@@ -98,7 +98,7 @@ public class TestOMRecoverLeaseRequest extends TestOMKeyRequest {
 
     OMClientResponse omClientResponse = validateAndUpdateCache();
 
-    Assert.assertEquals(OzoneManagerProtocolProtos.Status.OK,
+    Assertions.assertEquals(OzoneManagerProtocolProtos.Status.OK,
         omClientResponse.getOMResponse().getStatus());
 
     verifyTables(true, false);
@@ -113,7 +113,7 @@ public class TestOMRecoverLeaseRequest extends TestOMKeyRequest {
 
     OMClientResponse omClientResponse = validateAndUpdateCache();
 
-    Assert.assertEquals(OzoneManagerProtocolProtos.Status.KEY_NOT_FOUND,
+    Assertions.assertEquals(OzoneManagerProtocolProtos.Status.KEY_NOT_FOUND,
         omClientResponse.getOMResponse().getStatus());
 
     verifyTables(false, true);
@@ -129,7 +129,7 @@ public class TestOMRecoverLeaseRequest extends TestOMKeyRequest {
 
     OMClientResponse omClientResponse = validateAndUpdateCache();
 
-    Assert.assertEquals(OzoneManagerProtocolProtos.Status.KEY_NOT_FOUND,
+    Assertions.assertEquals(OzoneManagerProtocolProtos.Status.KEY_NOT_FOUND,
         omClientResponse.getOMResponse().getStatus());
 
     verifyTables(false, false);
@@ -205,7 +205,7 @@ public class TestOMRecoverLeaseRequest extends TestOMKeyRequest {
     if (hasKey) {
       assertNotNull(omKeyInfo);
     } else {
-      Assert.assertNull(omKeyInfo);
+      Assertions.assertNull(omKeyInfo);
     }
     // Entry should be deleted from openKey Table.
     String openKey = getOpenFileName();
@@ -214,7 +214,7 @@ public class TestOMRecoverLeaseRequest extends TestOMKeyRequest {
     if (hasOpenKey) {
       assertNotNull(omKeyInfo);
     } else {
-      Assert.assertNull(omKeyInfo);
+      Assertions.assertNull(omKeyInfo);
     }
   }
 

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMAllocateBlockRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMAllocateBlockRequest.java
@@ -27,8 +27,8 @@ import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.hadoop.ozone.om.helpers.BucketLayout;
 import org.apache.hadoop.ozone.om.request.OMRequestTestUtils;
 import org.jetbrains.annotations.NotNull;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
 import org.apache.hadoop.ozone.om.helpers.OmKeyLocationInfo;
@@ -76,13 +76,13 @@ public class TestOMAllocateBlockRequest extends TestOMKeyRequest {
     List<OmKeyLocationInfo> omKeyLocationInfo =
         omKeyInfo.getLatestVersionLocations().getLocationList();
 
-    Assert.assertTrue(omKeyLocationInfo.size() == 0);
+    Assertions.assertTrue(omKeyLocationInfo.size() == 0);
 
     OMClientResponse omAllocateBlockResponse =
         omAllocateBlockRequest.validateAndUpdateCache(ozoneManager, 100L,
             ozoneManagerDoubleBufferHelper);
 
-    Assert.assertEquals(OzoneManagerProtocolProtos.Status.OK,
+    Assertions.assertEquals(OzoneManagerProtocolProtos.Status.OK,
         omAllocateBlockResponse.getOMResponse().getStatus());
 
     // Check open table whether new block is added or not.
@@ -91,13 +91,13 @@ public class TestOMAllocateBlockRequest extends TestOMKeyRequest {
             true);
 
     // Check modification time
-    Assert.assertEquals(modifiedOmRequest.getAllocateBlockRequest()
+    Assertions.assertEquals(modifiedOmRequest.getAllocateBlockRequest()
         .getKeyArgs().getModificationTime(), omKeyInfo.getModificationTime());
 
     // creationTime was assigned at OMRequestTestUtils.addKeyToTable
     // modificationTime was assigned at
     // doPreExecute(createAllocateBlockRequest())
-    Assert.assertTrue(
+    Assertions.assertTrue(
         omKeyInfo.getCreationTime() <= omKeyInfo.getModificationTime());
 
     // Check data of the block
@@ -107,12 +107,12 @@ public class TestOMAllocateBlockRequest extends TestOMKeyRequest {
     omKeyLocationInfo =
         omKeyInfo.getLatestVersionLocations().getLocationList();
 
-    Assert.assertTrue(omKeyLocationInfo.size() == 1);
+    Assertions.assertTrue(omKeyLocationInfo.size() == 1);
 
-    Assert.assertEquals(keyLocation.getBlockID().getContainerBlockID()
+    Assertions.assertEquals(keyLocation.getBlockID().getContainerBlockID()
         .getContainerID(), omKeyLocationInfo.get(0).getContainerID());
 
-    Assert.assertEquals(keyLocation.getBlockID().getContainerBlockID()
+    Assertions.assertEquals(keyLocation.getBlockID().getContainerBlockID()
             .getLocalID(), omKeyLocationInfo.get(0).getLocalID());
 
   }
@@ -137,7 +137,7 @@ public class TestOMAllocateBlockRequest extends TestOMKeyRequest {
         omAllocateBlockRequest.validateAndUpdateCache(ozoneManager, 100L,
             ozoneManagerDoubleBufferHelper);
 
-    Assert.assertTrue(omAllocateBlockResponse.getOMResponse().getStatus()
+    Assertions.assertTrue(omAllocateBlockResponse.getOMResponse().getStatus()
         == OzoneManagerProtocolProtos.Status.VOLUME_NOT_FOUND);
 
   }
@@ -160,7 +160,7 @@ public class TestOMAllocateBlockRequest extends TestOMKeyRequest {
         omAllocateBlockRequest.validateAndUpdateCache(ozoneManager, 100L,
             ozoneManagerDoubleBufferHelper);
 
-    Assert.assertTrue(omAllocateBlockResponse.getOMResponse().getStatus()
+    Assertions.assertTrue(omAllocateBlockResponse.getOMResponse().getStatus()
         == OzoneManagerProtocolProtos.Status.BUCKET_NOT_FOUND);
 
   }
@@ -183,7 +183,7 @@ public class TestOMAllocateBlockRequest extends TestOMKeyRequest {
         omAllocateBlockRequest.validateAndUpdateCache(ozoneManager, 100L,
             ozoneManagerDoubleBufferHelper);
 
-    Assert.assertTrue(omAllocateBlockResponse.getOMResponse().getStatus()
+    Assertions.assertTrue(omAllocateBlockResponse.getOMResponse().getStatus()
         == OzoneManagerProtocolProtos.Status.KEY_NOT_FOUND);
 
   }
@@ -204,29 +204,29 @@ public class TestOMAllocateBlockRequest extends TestOMKeyRequest {
         omAllocateBlockRequest.preExecute(ozoneManager);
 
 
-    Assert.assertEquals(originalOMRequest.getCmdType(),
+    Assertions.assertEquals(originalOMRequest.getCmdType(),
         modifiedOmRequest.getCmdType());
-    Assert.assertEquals(originalOMRequest.getClientId(),
+    Assertions.assertEquals(originalOMRequest.getClientId(),
         modifiedOmRequest.getClientId());
 
-    Assert.assertTrue(modifiedOmRequest.hasAllocateBlockRequest());
+    Assertions.assertTrue(modifiedOmRequest.hasAllocateBlockRequest());
     AllocateBlockRequest allocateBlockRequest =
         modifiedOmRequest.getAllocateBlockRequest();
     // Time should be set
-    Assert.assertTrue(allocateBlockRequest.getKeyArgs()
+    Assertions.assertTrue(allocateBlockRequest.getKeyArgs()
         .getModificationTime() > 0);
 
     // KeyLocation should be set.
-    Assert.assertTrue(allocateBlockRequest.hasKeyLocation());
-    Assert.assertEquals(CONTAINER_ID,
+    Assertions.assertTrue(allocateBlockRequest.hasKeyLocation());
+    Assertions.assertEquals(CONTAINER_ID,
         allocateBlockRequest.getKeyLocation().getBlockID()
             .getContainerBlockID().getContainerID());
-    Assert.assertEquals(LOCAL_ID,
+    Assertions.assertEquals(LOCAL_ID,
         allocateBlockRequest.getKeyLocation().getBlockID()
             .getContainerBlockID().getLocalID());
-    Assert.assertTrue(allocateBlockRequest.getKeyLocation().hasPipeline());
+    Assertions.assertTrue(allocateBlockRequest.getKeyLocation().hasPipeline());
 
-    Assert.assertEquals(allocateBlockRequest.getClientID(),
+    Assertions.assertEquals(allocateBlockRequest.getClientID(),
         allocateBlockRequest.getClientID());
 
     return modifiedOmRequest;

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMAllocateBlockRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMAllocateBlockRequest.java
@@ -76,7 +76,7 @@ public class TestOMAllocateBlockRequest extends TestOMKeyRequest {
     List<OmKeyLocationInfo> omKeyLocationInfo =
         omKeyInfo.getLatestVersionLocations().getLocationList();
 
-    Assertions.assertTrue(omKeyLocationInfo.size() == 0);
+    Assertions.assertEquals(0, omKeyLocationInfo.size());
 
     OMClientResponse omAllocateBlockResponse =
         omAllocateBlockRequest.validateAndUpdateCache(ozoneManager, 100L,
@@ -107,7 +107,7 @@ public class TestOMAllocateBlockRequest extends TestOMKeyRequest {
     omKeyLocationInfo =
         omKeyInfo.getLatestVersionLocations().getLocationList();
 
-    Assertions.assertTrue(omKeyLocationInfo.size() == 1);
+    Assertions.assertEquals(1, omKeyLocationInfo.size());
 
     Assertions.assertEquals(keyLocation.getBlockID().getContainerBlockID()
         .getContainerID(), omKeyLocationInfo.get(0).getContainerID());
@@ -137,8 +137,8 @@ public class TestOMAllocateBlockRequest extends TestOMKeyRequest {
         omAllocateBlockRequest.validateAndUpdateCache(ozoneManager, 100L,
             ozoneManagerDoubleBufferHelper);
 
-    Assertions.assertTrue(omAllocateBlockResponse.getOMResponse().getStatus()
-        == OzoneManagerProtocolProtos.Status.VOLUME_NOT_FOUND);
+    Assertions.assertSame(omAllocateBlockResponse.getOMResponse().getStatus(),
+        OzoneManagerProtocolProtos.Status.VOLUME_NOT_FOUND);
 
   }
 
@@ -160,8 +160,8 @@ public class TestOMAllocateBlockRequest extends TestOMKeyRequest {
         omAllocateBlockRequest.validateAndUpdateCache(ozoneManager, 100L,
             ozoneManagerDoubleBufferHelper);
 
-    Assertions.assertTrue(omAllocateBlockResponse.getOMResponse().getStatus()
-        == OzoneManagerProtocolProtos.Status.BUCKET_NOT_FOUND);
+    Assertions.assertSame(omAllocateBlockResponse.getOMResponse().getStatus(),
+        OzoneManagerProtocolProtos.Status.BUCKET_NOT_FOUND);
 
   }
 
@@ -183,8 +183,8 @@ public class TestOMAllocateBlockRequest extends TestOMKeyRequest {
         omAllocateBlockRequest.validateAndUpdateCache(ozoneManager, 100L,
             ozoneManagerDoubleBufferHelper);
 
-    Assertions.assertTrue(omAllocateBlockResponse.getOMResponse().getStatus()
-        == OzoneManagerProtocolProtos.Status.KEY_NOT_FOUND);
+    Assertions.assertSame(omAllocateBlockResponse.getOMResponse().getStatus(),
+        OzoneManagerProtocolProtos.Status.KEY_NOT_FOUND);
 
   }
 

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMAllocateBlockRequestWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMAllocateBlockRequestWithFSO.java
@@ -31,7 +31,7 @@ import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos;
 import org.apache.hadoop.util.StringUtils;
 import org.apache.hadoop.util.Time;
 import org.jetbrains.annotations.NotNull;
-import org.junit.Assert;
+import org.junit.jupiter.api.Assertions;
 
 /**
  * Tests OMAllocateBlockRequest class prefix layout.
@@ -111,7 +111,7 @@ public class TestOMAllocateBlockRequestWithFSO
             omMetadataManager.getOpenKeyTable(getBucketLayout())
                 .get(dbOpenFileName);
         if (doAssert) {
-          Assert.assertNotNull("Invalid key!", omKeyInfo);
+          Assertions.assertNotNull(omKeyInfo, "Invalid key!");
         }
         return omKeyInfo;
       } else {
@@ -124,7 +124,7 @@ public class TestOMAllocateBlockRequestWithFSO
       }
     }
     if (doAssert) {
-      Assert.fail("Invalid key!");
+      Assertions.fail("Invalid key!");
     }
     return  null;
   }

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMDirectoriesPurgeRequestAndResponse.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMDirectoriesPurgeRequestAndResponse.java
@@ -38,8 +38,8 @@ import org.apache.hadoop.ozone.om.response.key.OMKeyPurgeResponse;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMRequest;
 import org.jetbrains.annotations.NotNull;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 /**
  * Tests {@link OMKeyPurgeRequest} and {@link OMKeyPurgeResponse}.
@@ -170,7 +170,7 @@ public class TestOMDirectoriesPurgeRequestAndResponse extends TestOMKeyRequest {
     OMRequest modifiedOmRequest = omKeyPurgeRequest.preExecute(ozoneManager);
 
     // Will not be equal, as UserInfo will be set.
-    Assert.assertNotEquals(originalOmRequest, modifiedOmRequest);
+    Assertions.assertNotEquals(originalOmRequest, modifiedOmRequest);
 
     return modifiedOmRequest;
   }
@@ -192,7 +192,7 @@ public class TestOMDirectoriesPurgeRequestAndResponse extends TestOMKeyRequest {
     OMDirectoriesPurgeRequestWithFSO omKeyPurgeRequest =
         new OMDirectoriesPurgeRequestWithFSO(preExecutedRequest);
 
-    Assert.assertEquals(1000L * deletedKeyNames.size(),
+    Assertions.assertEquals(1000L * deletedKeyNames.size(),
         omBucketInfo.getUsedBytes());
     OMDirectoriesPurgeResponseWithFSO omClientResponse
         = (OMDirectoriesPurgeResponseWithFSO) omKeyPurgeRequest
@@ -200,7 +200,7 @@ public class TestOMDirectoriesPurgeRequestAndResponse extends TestOMKeyRequest {
         ozoneManagerDoubleBufferHelper);
     omBucketInfo = omMetadataManager.getBucketTable().get(
         bucketKey);
-    Assert.assertEquals(0L * deletedKeyNames.size(),
+    Assertions.assertEquals(0L * deletedKeyNames.size(),
         omBucketInfo.getUsedBytes());
 
     performBatchOperationCommit(omClientResponse);
@@ -244,7 +244,8 @@ public class TestOMDirectoriesPurgeRequestAndResponse extends TestOMKeyRequest {
     // prevalidate bucket
     omBucketInfo = omMetadataManager.getBucketTable().get(bucketKey);
     final long bucketExpectedUsedBytes = bucketInitialUsedBytes + 1000L;
-    Assert.assertEquals(bucketExpectedUsedBytes, omBucketInfo.getUsedBytes());
+    Assertions.assertEquals(bucketExpectedUsedBytes,
+        omBucketInfo.getUsedBytes());
     
     // perform delete
     OMDirectoriesPurgeResponseWithFSO omClientResponse
@@ -255,7 +256,8 @@ public class TestOMDirectoriesPurgeRequestAndResponse extends TestOMKeyRequest {
     // validate bucket info, no change expected
     omBucketInfo = omMetadataManager.getBucketTable().get(
         bucketKey);
-    Assert.assertEquals(bucketExpectedUsedBytes, omBucketInfo.getUsedBytes());
+    Assertions.assertEquals(bucketExpectedUsedBytes,
+        omBucketInfo.getUsedBytes());
 
     performBatchOperationCommit(omClientResponse);
 
@@ -282,7 +284,7 @@ public class TestOMDirectoriesPurgeRequestAndResponse extends TestOMKeyRequest {
     for (OmKeyInfo deletedKey : deletedKeyInfos) {
       String keyName = omMetadataManager.getOzoneKey(deletedKey.getVolumeName(),
           deletedKey.getBucketName(), deletedKey.getKeyName());
-      Assert.assertTrue(omMetadataManager.getDeletedTable().isExist(
+      Assertions.assertTrue(omMetadataManager.getDeletedTable().isExist(
           keyName));
       deletedKeyNames.add(keyName);
     }
@@ -292,7 +294,7 @@ public class TestOMDirectoriesPurgeRequestAndResponse extends TestOMKeyRequest {
   private void validateDeletedKeys(
       List<String> deletedKeyNames) throws IOException {
     for (String deletedKey : deletedKeyNames) {
-      Assert.assertTrue(omMetadataManager.getDeletedTable().isExist(
+      Assertions.assertTrue(omMetadataManager.getDeletedTable().isExist(
           deletedKey));
     }
   }

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMKeyAclRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMKeyAclRequest.java
@@ -35,8 +35,8 @@ import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMReque
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMResponse;
 import org.apache.hadoop.ozone.security.acl.OzoneObj;
 import org.apache.hadoop.ozone.security.acl.OzoneObjInfo;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 /**
  * Test Key ACL requests.
@@ -54,7 +54,7 @@ public class TestOMKeyAclRequest extends TestOMKeyRequest {
         omMetadataManager.getKeyTable(getBucketLayout()).get(ozoneKey);
 
     // As we added manually to key table.
-    Assert.assertNotNull(omKeyInfo);
+    Assertions.assertNotNull(omKeyInfo);
 
     OzoneAcl acl = OzoneAcl.parseAcl("user:bilbo:rwdlncxy[ACCESS]");
 
@@ -70,13 +70,13 @@ public class TestOMKeyAclRequest extends TestOMKeyRequest {
         .getModificationTime();
     long newModTime = preExecuteRequest.getAddAclRequest()
         .getModificationTime();
-    Assert.assertTrue(newModTime > originModTime);
+    Assertions.assertTrue(newModTime > originModTime);
 
     // Execute original request
     OMClientResponse omClientResponse = omKeyAddAclRequest
         .validateAndUpdateCache(ozoneManager, 100L,
             ozoneManagerDoubleBufferHelper);
-    Assert.assertEquals(OzoneManagerProtocolProtos.Status.OK,
+    Assertions.assertEquals(OzoneManagerProtocolProtos.Status.OK,
         omClientResponse.getOMResponse().getStatus());
 
   }
@@ -91,7 +91,7 @@ public class TestOMKeyAclRequest extends TestOMKeyRequest {
         omMetadataManager.getKeyTable(getBucketLayout()).get(ozoneKey);
 
     // As we added manually to key table.
-    Assert.assertNotNull(omKeyInfo);
+    Assertions.assertNotNull(omKeyInfo);
 
     OzoneAcl acl = OzoneAcl.parseAcl("user:bilbo:rwdlncxy[ACCESS]");
 
@@ -104,16 +104,16 @@ public class TestOMKeyAclRequest extends TestOMKeyRequest {
         .validateAndUpdateCache(ozoneManager, 100L,
             ozoneManagerDoubleBufferHelper);
     OMResponse omAddAclResponse = omClientAddAclResponse.getOMResponse();
-    Assert.assertNotNull(omAddAclResponse.getAddAclResponse());
-    Assert.assertEquals(OzoneManagerProtocolProtos.Status.OK,
+    Assertions.assertNotNull(omAddAclResponse.getAddAclResponse());
+    Assertions.assertEquals(OzoneManagerProtocolProtos.Status.OK,
         omAddAclResponse.getStatus());
 
     // Verify result of adding acl.
     List<OzoneAcl> keyAcls =
         omMetadataManager.getKeyTable(getBucketLayout()).get(ozoneKey)
             .getAcls();
-    Assert.assertEquals(1, keyAcls.size());
-    Assert.assertEquals(acl, keyAcls.get(0));
+    Assertions.assertEquals(1, keyAcls.size());
+    Assertions.assertEquals(acl, keyAcls.get(0));
 
     // Remove acl.
     OMRequest removeAclRequest = createRemoveAclKeyRequest(acl);
@@ -128,21 +128,21 @@ public class TestOMKeyAclRequest extends TestOMKeyRequest {
         .getModificationTime();
     long newModTime = preExecuteRequest.getRemoveAclRequest()
         .getModificationTime();
-    Assert.assertTrue(newModTime > originModTime);
+    Assertions.assertTrue(newModTime > originModTime);
 
     OMClientResponse omClientRemoveAclResponse = omKeyRemoveAclRequest
         .validateAndUpdateCache(ozoneManager, 100L,
             ozoneManagerDoubleBufferHelper);
     OMResponse omRemoveAclResponse = omClientRemoveAclResponse.getOMResponse();
-    Assert.assertNotNull(omRemoveAclResponse.getRemoveAclResponse());
-    Assert.assertEquals(OzoneManagerProtocolProtos.Status.OK,
+    Assertions.assertNotNull(omRemoveAclResponse.getRemoveAclResponse());
+    Assertions.assertEquals(OzoneManagerProtocolProtos.Status.OK,
         omRemoveAclResponse.getStatus());
 
     // Verify result of removing acl.
     List<OzoneAcl> newAcls =
         omMetadataManager.getKeyTable(getBucketLayout()).get(ozoneKey)
             .getAcls();
-    Assert.assertEquals(0, newAcls.size());
+    Assertions.assertEquals(0, newAcls.size());
   }
 
   @Test
@@ -155,7 +155,7 @@ public class TestOMKeyAclRequest extends TestOMKeyRequest {
         omMetadataManager.getKeyTable(getBucketLayout()).get(ozoneKey);
 
     // As we added manually to key table.
-    Assert.assertNotNull(omKeyInfo);
+    Assertions.assertNotNull(omKeyInfo);
 
     OzoneAcl acl = OzoneAcl.parseAcl("user:bilbo:rwdlncxy[ACCESS]");
 
@@ -170,21 +170,21 @@ public class TestOMKeyAclRequest extends TestOMKeyRequest {
         .getModificationTime();
     long newModTime = preExecuteRequest.getSetAclRequest()
         .getModificationTime();
-    Assert.assertTrue(newModTime > originModTime);
+    Assertions.assertTrue(newModTime > originModTime);
 
     OMClientResponse omClientResponse = omKeySetAclRequest
         .validateAndUpdateCache(ozoneManager, 100L,
             ozoneManagerDoubleBufferHelper);
     OMResponse omSetAclResponse = omClientResponse.getOMResponse();
-    Assert.assertNotNull(omSetAclResponse.getSetAclResponse());
-    Assert.assertEquals(OzoneManagerProtocolProtos.Status.OK,
+    Assertions.assertNotNull(omSetAclResponse.getSetAclResponse());
+    Assertions.assertEquals(OzoneManagerProtocolProtos.Status.OK,
         omSetAclResponse.getStatus());
 
     // Verify result of setting acl.
     List<OzoneAcl> newAcls =
         omMetadataManager.getKeyTable(getBucketLayout()).get(ozoneKey)
             .getAcls();
-    Assert.assertEquals(newAcls.get(0), acl);
+    Assertions.assertEquals(newAcls.get(0), acl);
   }
 
   /**

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMKeyCommitRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMKeyCommitRequest.java
@@ -38,8 +38,8 @@ import org.apache.hadoop.ozone.om.request.OMRequestTestUtils;
 import org.apache.hadoop.ozone.om.response.key.OMKeyCommitResponse;
 import org.apache.hadoop.util.Time;
 import org.jetbrains.annotations.NotNull;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
@@ -55,7 +55,7 @@ import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos
     .OMRequest;
 
-import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
  * Class tests OMKeyCommitRequest class.
@@ -92,7 +92,7 @@ public class TestOMKeyCommitRequest extends TestOMKeyRequest {
     OmKeyInfo omKeyInfo =
             omMetadataManager.getOpenKeyTable(
                     omKeyCommitRequest.getBucketLayout()).get(openKey);
-    Assert.assertNotNull(omKeyInfo);
+    Assertions.assertNotNull(omKeyInfo);
 
     // Key should not be there in key table, as validateAndUpdateCache is
     // still not called.
@@ -100,36 +100,36 @@ public class TestOMKeyCommitRequest extends TestOMKeyRequest {
         omMetadataManager.getKeyTable(omKeyCommitRequest.getBucketLayout())
             .get(ozoneKey);
 
-    Assert.assertNull(omKeyInfo);
+    Assertions.assertNull(omKeyInfo);
 
     OMClientResponse omClientResponse =
         omKeyCommitRequest.validateAndUpdateCache(ozoneManager,
             100L, ozoneManagerDoubleBufferHelper);
 
-    Assert.assertEquals(OzoneManagerProtocolProtos.Status.OK,
+    Assertions.assertEquals(OzoneManagerProtocolProtos.Status.OK,
         omClientResponse.getOMResponse().getStatus());
 
     // Entry should be deleted from openKey Table.
     omKeyInfo =
         omMetadataManager.getOpenKeyTable(omKeyCommitRequest.getBucketLayout())
             .get(openKey);
-    Assert.assertNull(omKeyInfo);
+    Assertions.assertNull(omKeyInfo);
 
     // Now entry should be created in key Table.
     omKeyInfo =
         omMetadataManager.getKeyTable(omKeyCommitRequest.getBucketLayout())
             .get(ozoneKey);
 
-    Assert.assertNotNull(omKeyInfo);
+    Assertions.assertNotNull(omKeyInfo);
 
     // Check modification time
 
     CommitKeyRequest commitKeyRequest = modifiedOmRequest.getCommitKeyRequest();
-    Assert.assertEquals(commitKeyRequest.getKeyArgs().getModificationTime(),
+    Assertions.assertEquals(commitKeyRequest.getKeyArgs().getModificationTime(),
         omKeyInfo.getModificationTime());
 
     // Check block location.
-    Assert.assertEquals(allocatedLocationList,
+    Assertions.assertEquals(allocatedLocationList,
         omKeyInfo.getLatestVersionLocations().getLocationList());
 
   }
@@ -160,7 +160,7 @@ public class TestOMKeyCommitRequest extends TestOMKeyRequest {
     OmKeyInfo omKeyInfo =
             omMetadataManager.getOpenKeyTable(
                     omKeyCommitRequest.getBucketLayout()).get(openKey);
-    Assert.assertNotNull(omKeyInfo);
+    Assertions.assertNotNull(omKeyInfo);
 
     // Key should not be there in key table, as validateAndUpdateCache is
     // still not called.
@@ -168,33 +168,33 @@ public class TestOMKeyCommitRequest extends TestOMKeyRequest {
         omMetadataManager.getKeyTable(omKeyCommitRequest.getBucketLayout())
             .get(ozoneKey);
 
-    Assert.assertNull(omKeyInfo);
+    Assertions.assertNull(omKeyInfo);
 
     OMClientResponse omClientResponse =
         omKeyCommitRequest.validateAndUpdateCache(ozoneManager,
         100L, ozoneManagerDoubleBufferHelper);
 
-    Assert.assertEquals(OzoneManagerProtocolProtos.Status.OK,
+    Assertions.assertEquals(OzoneManagerProtocolProtos.Status.OK,
         omClientResponse.getOMResponse().getStatus());
 
     // Entry should be deleted from openKey Table.
     omKeyInfo =
         omMetadataManager.getOpenKeyTable(omKeyCommitRequest.getBucketLayout())
             .get(openKey);
-    Assert.assertNull(omKeyInfo);
+    Assertions.assertNull(omKeyInfo);
 
     // Now entry should be created in key Table.
     omKeyInfo =
         omMetadataManager.getKeyTable(omKeyCommitRequest.getBucketLayout())
             .get(ozoneKey);
-    Assert.assertNotNull(omKeyInfo);
+    Assertions.assertNotNull(omKeyInfo);
     // DB keyInfo format
     verifyKeyName(omKeyInfo);
 
     // Check modification time
 
     CommitKeyRequest commitKeyRequest = modifiedOmRequest.getCommitKeyRequest();
-    Assert.assertEquals(commitKeyRequest.getKeyArgs().getModificationTime(),
+    Assertions.assertEquals(commitKeyRequest.getKeyArgs().getModificationTime(),
         omKeyInfo.getModificationTime());
 
     // Check block location.
@@ -203,9 +203,9 @@ public class TestOMKeyCommitRequest extends TestOMKeyRequest {
         .getKeyLocationsList().stream().map(OmKeyLocationInfo::getFromProtobuf)
         .collect(Collectors.toList());
 
-    Assert.assertEquals(locationInfoListFromCommitKeyRequest,
+    Assertions.assertEquals(locationInfoListFromCommitKeyRequest,
         omKeyInfo.getLatestVersionLocations().getLocationList());
-    Assert.assertEquals(allocatedLocationList,
+    Assertions.assertEquals(allocatedLocationList,
         omKeyInfo.getLatestVersionLocations().getLocationList());
   }
 
@@ -238,7 +238,7 @@ public class TestOMKeyCommitRequest extends TestOMKeyRequest {
     OmKeyInfo omKeyInfo =
             omMetadataManager.getOpenKeyTable(
                     omKeyCommitRequest.getBucketLayout()).get(openKey);
-    Assert.assertNotNull(omKeyInfo);
+    Assertions.assertNotNull(omKeyInfo);
 
     // Key should not be there in key table, as validateAndUpdateCache is
     // still not called.
@@ -246,13 +246,13 @@ public class TestOMKeyCommitRequest extends TestOMKeyRequest {
         omMetadataManager.getKeyTable(omKeyCommitRequest.getBucketLayout())
             .get(ozoneKey);
 
-    Assert.assertNull(omKeyInfo);
+    Assertions.assertNull(omKeyInfo);
 
     OMClientResponse omClientResponse =
         omKeyCommitRequest.validateAndUpdateCache(ozoneManager,
             100L, ozoneManagerDoubleBufferHelper);
 
-    Assert.assertEquals(OzoneManagerProtocolProtos.Status.OK,
+    Assertions.assertEquals(OzoneManagerProtocolProtos.Status.OK,
         omClientResponse.getOMResponse().getStatus());
 
     Map<String, RepeatedOmKeyInfo> toDeleteKeyList
@@ -260,30 +260,30 @@ public class TestOMKeyCommitRequest extends TestOMKeyRequest {
 
     // This is the first time to commit key, only the allocated but uncommitted
     // blocks should be deleted.
-    Assert.assertEquals(1, toDeleteKeyList.size());
-    Assert.assertEquals(2, toDeleteKeyList.values().stream().findFirst().get()
-        .cloneOmKeyInfoList().get(0).getKeyLocationVersions().get(0)
-        .getLocationList().size());
+    Assertions.assertEquals(1, toDeleteKeyList.size());
+    Assertions.assertEquals(2, toDeleteKeyList.values().stream()
+        .findFirst().get().cloneOmKeyInfoList().get(0).getKeyLocationVersions()
+        .get(0).getLocationList().size());
 
     // Entry should be deleted from openKey Table.
     omKeyInfo =
         omMetadataManager.getOpenKeyTable(omKeyCommitRequest.getBucketLayout())
             .get(openKey);
-    Assert.assertNull(omKeyInfo);
+    Assertions.assertNull(omKeyInfo);
 
     // Now entry should be created in key Table.
     omKeyInfo =
         omMetadataManager.getKeyTable(omKeyCommitRequest.getBucketLayout())
             .get(ozoneKey);
 
-    Assert.assertNotNull(omKeyInfo);
+    Assertions.assertNotNull(omKeyInfo);
 
     // DB keyInfo format
     verifyKeyName(omKeyInfo);
 
     // Check modification time
     CommitKeyRequest commitKeyRequest = modifiedOmRequest.getCommitKeyRequest();
-    Assert.assertEquals(commitKeyRequest.getKeyArgs().getModificationTime(),
+    Assertions.assertEquals(commitKeyRequest.getKeyArgs().getModificationTime(),
         omKeyInfo.getModificationTime());
 
     // Check block location.
@@ -297,9 +297,9 @@ public class TestOMKeyCommitRequest extends TestOMKeyRequest {
     intersection.retainAll(locationInfoListFromCommitKeyRequest);
 
     // Key table should have three blocks.
-    Assert.assertEquals(intersection,
+    Assertions.assertEquals(intersection,
         omKeyInfo.getLatestVersionLocations().getLocationList());
-    Assert.assertEquals(3, intersection.size());
+    Assertions.assertEquals(3, intersection.size());
 
   }
 
@@ -338,26 +338,26 @@ public class TestOMKeyCommitRequest extends TestOMKeyRequest {
     // 1st commit of 3 blocks, HSync = true
     Map<String, RepeatedOmKeyInfo> keyToDeleteMap =
         doKeyCommit(true, allocatedKeyLocationList.subList(0, 3));
-    Assert.assertNull(keyToDeleteMap);
+    Assertions.assertNull(keyToDeleteMap);
     bucketInfo = omMetadataManager.getBucketTable().get(bucketKey);
     long firstCommitUsedBytes = bucketInfo.getUsedBytes();
-    Assert.assertEquals(300, firstCommitUsedBytes - usedBytes);
+    Assertions.assertEquals(300, firstCommitUsedBytes - usedBytes);
 
     // 2nd commit of 6 blocks, HSync = true
     keyToDeleteMap = doKeyCommit(true, allocatedKeyLocationList.subList(0, 6));
-    Assert.assertNull(keyToDeleteMap);
+    Assertions.assertNull(keyToDeleteMap);
     bucketInfo = omMetadataManager.getBucketTable().get(bucketKey);
     long secondCommitUsedBytes = bucketInfo.getUsedBytes();
-    Assert.assertEquals(600, secondCommitUsedBytes - usedBytes);
+    Assertions.assertEquals(600, secondCommitUsedBytes - usedBytes);
 
     // 3rd and final commit of all 10 blocks, HSync = false
     keyToDeleteMap = doKeyCommit(false, allocatedKeyLocationList);
     // keyToDeleteMap should be null / empty because none of the previous blocks
     // should be deleted.
-    Assert.assertTrue(keyToDeleteMap == null || keyToDeleteMap.isEmpty());
+    Assertions.assertTrue(keyToDeleteMap == null || keyToDeleteMap.isEmpty());
     bucketInfo = omMetadataManager.getBucketTable().get(bucketKey);
     long thirdCommitUsedBytes = bucketInfo.getUsedBytes();
-    Assert.assertEquals(1000, thirdCommitUsedBytes - usedBytes);
+    Assertions.assertEquals(1000, thirdCommitUsedBytes - usedBytes);
   }
 
   private Map<String, RepeatedOmKeyInfo> doKeyCommit(boolean isHSync,
@@ -378,7 +378,7 @@ public class TestOMKeyCommitRequest extends TestOMKeyRequest {
     OMClientResponse omClientResponse =
         omKeyCommitRequest.validateAndUpdateCache(ozoneManager,
             100L, ozoneManagerDoubleBufferHelper);
-    Assert.assertEquals(OzoneManagerProtocolProtos.Status.OK,
+    Assertions.assertEquals(OzoneManagerProtocolProtos.Status.OK,
         omClientResponse.getOMResponse().getStatus());
 
     // Key should be present in both OpenKeyTable and KeyTable with HSync commit
@@ -386,15 +386,15 @@ public class TestOMKeyCommitRequest extends TestOMKeyRequest {
         omMetadataManager.getOpenKeyTable(
             omKeyCommitRequest.getBucketLayout()).get(openKey);
     if (isHSync) {
-      Assert.assertNotNull(omKeyInfo);
+      Assertions.assertNotNull(omKeyInfo);
     } else {
       // Key should not exist in OpenKeyTable anymore with non-HSync commit
-      Assert.assertNull(omKeyInfo);
+      Assertions.assertNull(omKeyInfo);
     }
     omKeyInfo =
         omMetadataManager.getKeyTable(omKeyCommitRequest.getBucketLayout())
             .get(ozoneKey);
-    Assert.assertNotNull(omKeyInfo);
+    Assertions.assertNotNull(omKeyInfo);
 
     return ((OMKeyCommitResponse) omClientResponse).getKeysToDelete();
   }
@@ -428,20 +428,20 @@ public class TestOMKeyCommitRequest extends TestOMKeyRequest {
         omMetadataManager.getKeyTable(omKeyCommitRequest.getBucketLayout())
             .get(ozoneKey);
 
-    Assert.assertNull(omKeyInfo);
+    Assertions.assertNull(omKeyInfo);
 
     OMClientResponse omClientResponse =
         omKeyCommitRequest.validateAndUpdateCache(ozoneManager,
             100L, ozoneManagerDoubleBufferHelper);
 
-    Assert.assertEquals(OzoneManagerProtocolProtos.Status.VOLUME_NOT_FOUND,
+    Assertions.assertEquals(OzoneManagerProtocolProtos.Status.VOLUME_NOT_FOUND,
         omClientResponse.getOMResponse().getStatus());
 
     omKeyInfo =
         omMetadataManager.getKeyTable(omKeyCommitRequest.getBucketLayout())
             .get(ozoneKey);
 
-    Assert.assertNull(omKeyInfo);
+    Assertions.assertNull(omKeyInfo);
   }
 
   @Test
@@ -463,20 +463,20 @@ public class TestOMKeyCommitRequest extends TestOMKeyRequest {
         omMetadataManager.getKeyTable(omKeyCommitRequest.getBucketLayout())
             .get(ozoneKey);
 
-    Assert.assertNull(omKeyInfo);
+    Assertions.assertNull(omKeyInfo);
 
     OMClientResponse omClientResponse =
         omKeyCommitRequest.validateAndUpdateCache(ozoneManager,
             100L, ozoneManagerDoubleBufferHelper);
 
-    Assert.assertEquals(OzoneManagerProtocolProtos.Status.BUCKET_NOT_FOUND,
+    Assertions.assertEquals(OzoneManagerProtocolProtos.Status.BUCKET_NOT_FOUND,
         omClientResponse.getOMResponse().getStatus());
 
     omKeyInfo =
         omMetadataManager.getKeyTable(omKeyCommitRequest.getBucketLayout())
             .get(ozoneKey);
 
-    Assert.assertNull(omKeyInfo);
+    Assertions.assertNull(omKeyInfo);
   }
 
   @Test
@@ -513,12 +513,12 @@ public class TestOMKeyCommitRequest extends TestOMKeyRequest {
         omKeyCommitRequest.validateAndUpdateCache(ozoneManager,
             100L, ozoneManagerDoubleBufferHelper);
 
-    Assert.assertEquals(OzoneManagerProtocolProtos.Status.QUOTA_EXCEEDED,
+    Assertions.assertEquals(OzoneManagerProtocolProtos.Status.QUOTA_EXCEEDED,
         omClientResponse.getOMResponse().getStatus());
 
     OmBucketInfo bucketInfo = omMetadataManager.getBucketTable()
         .get(omMetadataManager.getBucketKey(volumeName, bucketName));
-    Assert.assertEquals(0, bucketInfo.getUsedNamespace());
+    Assertions.assertEquals(0, bucketInfo.getUsedNamespace());
   }
 
   @Test
@@ -541,20 +541,20 @@ public class TestOMKeyCommitRequest extends TestOMKeyRequest {
         omMetadataManager.getKeyTable(omKeyCommitRequest.getBucketLayout())
             .get(ozoneKey);
 
-    Assert.assertNull(omKeyInfo);
+    Assertions.assertNull(omKeyInfo);
 
     OMClientResponse omClientResponse =
         omKeyCommitRequest.validateAndUpdateCache(ozoneManager,
             100L, ozoneManagerDoubleBufferHelper);
 
-    Assert.assertEquals(OzoneManagerProtocolProtos.Status.KEY_NOT_FOUND,
+    Assertions.assertEquals(OzoneManagerProtocolProtos.Status.KEY_NOT_FOUND,
         omClientResponse.getOMResponse().getStatus());
 
     omKeyInfo =
         omMetadataManager.getKeyTable(omKeyCommitRequest.getBucketLayout())
             .get(ozoneKey);
 
-    Assert.assertNull(omKeyInfo);
+    Assertions.assertNull(omKeyInfo);
   }
 
   @Test
@@ -578,9 +578,9 @@ public class TestOMKeyCommitRequest extends TestOMKeyRequest {
         omMetadataManager.getKeyTable(omKeyCommitRequest.getBucketLayout())
             .get(ozoneKey);
 
-    Assert.assertNotNull(omKeyInfo);
+    Assertions.assertNotNull(omKeyInfo);
     // Previously committed version
-    Assert.assertEquals(0L,
+    Assertions.assertEquals(0L,
             omKeyInfo.getLatestVersionLocations().getVersion());
 
     // Append new blocks
@@ -594,7 +594,7 @@ public class TestOMKeyCommitRequest extends TestOMKeyRequest {
             omKeyCommitRequest.validateAndUpdateCache(ozoneManager,
                     102L, ozoneManagerDoubleBufferHelper);
 
-    Assert.assertEquals(OzoneManagerProtocolProtos.Status.OK,
+    Assertions.assertEquals(OzoneManagerProtocolProtos.Status.OK,
             omClientResponse.getOMResponse().getStatus());
 
     // New entry should be created in key Table.
@@ -602,15 +602,15 @@ public class TestOMKeyCommitRequest extends TestOMKeyRequest {
         omMetadataManager.getKeyTable(omKeyCommitRequest.getBucketLayout())
             .get(ozoneKey);
 
-    Assert.assertNotNull(omKeyInfo);
-    Assert.assertEquals(version,
+    Assertions.assertNotNull(omKeyInfo);
+    Assertions.assertEquals(version,
             omKeyInfo.getLatestVersionLocations().getVersion());
     // DB keyInfo format
     verifyKeyName(omKeyInfo);
 
     // Check modification time
     CommitKeyRequest commitKeyRequest = modifiedOmRequest.getCommitKeyRequest();
-    Assert.assertEquals(commitKeyRequest.getKeyArgs().getModificationTime(),
+    Assertions.assertEquals(commitKeyRequest.getKeyArgs().getModificationTime(),
             omKeyInfo.getModificationTime());
 
     // Check block location.
@@ -619,11 +619,11 @@ public class TestOMKeyCommitRequest extends TestOMKeyRequest {
         .getKeyLocationsList().stream().map(OmKeyLocationInfo::getFromProtobuf)
         .collect(Collectors.toList());
 
-    Assert.assertEquals(locationInfoListFromCommitKeyRequest,
+    Assertions.assertEquals(locationInfoListFromCommitKeyRequest,
             omKeyInfo.getLatestVersionLocations().getLocationList());
-    Assert.assertEquals(allocatedLocationList,
+    Assertions.assertEquals(allocatedLocationList,
             omKeyInfo.getLatestVersionLocations().getLocationList());
-    Assert.assertEquals(1, omKeyInfo.getKeyLocationVersions().size());
+    Assertions.assertEquals(1, omKeyInfo.getKeyLocationVersions().size());
   }
 
   /**
@@ -639,7 +639,7 @@ public class TestOMKeyCommitRequest extends TestOMKeyRequest {
 
     OMRequest modifiedOmRequest = omKeyCommitRequest.preExecute(ozoneManager);
 
-    Assert.assertTrue(modifiedOmRequest.hasCommitKeyRequest());
+    Assertions.assertTrue(modifiedOmRequest.hasCommitKeyRequest());
     KeyArgs originalKeyArgs =
         originalOMRequest.getCommitKeyRequest().getKeyArgs();
     KeyArgs modifiedKeyArgs =
@@ -656,22 +656,22 @@ public class TestOMKeyCommitRequest extends TestOMKeyRequest {
   private void verifyKeyArgs(KeyArgs originalKeyArgs, KeyArgs modifiedKeyArgs) {
 
     // Check modification time is set or not.
-    Assert.assertTrue(modifiedKeyArgs.getModificationTime() > 0);
-    Assert.assertTrue(originalKeyArgs.getModificationTime() == 0);
+    Assertions.assertTrue(modifiedKeyArgs.getModificationTime() > 0);
+    Assertions.assertTrue(originalKeyArgs.getModificationTime() == 0);
 
-    Assert.assertEquals(originalKeyArgs.getVolumeName(),
+    Assertions.assertEquals(originalKeyArgs.getVolumeName(),
         modifiedKeyArgs.getVolumeName());
-    Assert.assertEquals(originalKeyArgs.getBucketName(),
+    Assertions.assertEquals(originalKeyArgs.getBucketName(),
         modifiedKeyArgs.getBucketName());
-    Assert.assertEquals(originalKeyArgs.getKeyName(),
+    Assertions.assertEquals(originalKeyArgs.getKeyName(),
         modifiedKeyArgs.getKeyName());
-    Assert.assertEquals(originalKeyArgs.getDataSize(),
+    Assertions.assertEquals(originalKeyArgs.getDataSize(),
         modifiedKeyArgs.getDataSize());
-    Assert.assertEquals(originalKeyArgs.getKeyLocationsList(),
+    Assertions.assertEquals(originalKeyArgs.getKeyLocationsList(),
         modifiedKeyArgs.getKeyLocationsList());
-    Assert.assertEquals(originalKeyArgs.getType(),
+    Assertions.assertEquals(originalKeyArgs.getType(),
         modifiedKeyArgs.getType());
-    Assert.assertEquals(originalKeyArgs.getFactor(),
+    Assertions.assertEquals(originalKeyArgs.getFactor(),
         modifiedKeyArgs.getFactor());
   }
 
@@ -749,10 +749,10 @@ public class TestOMKeyCommitRequest extends TestOMKeyRequest {
   }
 
   protected void verifyKeyName(OmKeyInfo omKeyInfo) {
-    Assert.assertEquals("Incorrect KeyName", keyName,
-            omKeyInfo.getKeyName());
+    Assertions.assertEquals(keyName, omKeyInfo.getKeyName(),
+        "Incorrect KeyName");
     String fileName = OzoneFSUtils.getFileName(keyName);
-    Assert.assertEquals("Incorrect FileName", fileName,
-            omKeyInfo.getFileName());
+    Assertions.assertEquals(fileName, omKeyInfo.getFileName(),
+        "Incorrect FileName");
   }
 }

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMKeyCommitRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMKeyCommitRequest.java
@@ -657,7 +657,7 @@ public class TestOMKeyCommitRequest extends TestOMKeyRequest {
 
     // Check modification time is set or not.
     Assertions.assertTrue(modifiedKeyArgs.getModificationTime() > 0);
-    Assertions.assertTrue(originalKeyArgs.getModificationTime() == 0);
+    Assertions.assertEquals(0, originalKeyArgs.getModificationTime());
 
     Assertions.assertEquals(originalKeyArgs.getVolumeName(),
         modifiedKeyArgs.getVolumeName());

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMKeyCommitRequestWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMKeyCommitRequestWithFSO.java
@@ -29,7 +29,7 @@ import org.apache.hadoop.ozone.om.request.OMRequestTestUtils;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMRequest;
 import org.apache.hadoop.util.Time;
 import org.jetbrains.annotations.NotNull;
-import org.junit.Assert;
+import org.junit.jupiter.api.Assertions;
 
 import java.io.IOException;
 import java.util.List;
@@ -104,9 +104,9 @@ public class TestOMKeyCommitRequestWithFSO extends TestOMKeyCommitRequest {
   protected void verifyKeyName(OmKeyInfo omKeyInfo) {
     // prefix layout format - stores fileName in the keyName DB field.
     String fileName = OzoneFSUtils.getFileName(keyName);
-    Assert.assertEquals("Incorrect FileName", fileName,
-            omKeyInfo.getFileName());
-    Assert.assertEquals("Incorrect KeyName", fileName,
-            omKeyInfo.getKeyName());
+    Assertions.assertEquals(fileName, omKeyInfo.getFileName(),
+        "Incorrect FileName");
+    Assertions.assertEquals(fileName, omKeyInfo.getKeyName(),
+        "Incorrect KeyName");
   }
 }

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMKeyCreateRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMKeyCreateRequest.java
@@ -87,6 +87,7 @@ public class TestOMKeyCreateRequest extends TestOMKeyRequest {
   private boolean keyPathLockEnabled;
   private boolean enableFileSystemPaths;
 
+  @org.junit.Test
   public void testPreExecuteWithNormalKey() throws Exception {
     ReplicationConfig ratis3Config =
         ReplicationConfig.fromProtoTypeAndFactor(RATIS, THREE);
@@ -242,8 +243,8 @@ public class TestOMKeyCreateRequest extends TestOMKeyRequest {
     OMClientResponse omKeyCreateResponse =
         omKeyCreateRequest.validateAndUpdateCache(ozoneManager, 100L,
             ozoneManagerDoubleBufferHelper);
-    Assertions.assertTrue(omKeyCreateResponse.getOMResponse().getStatus()
-        == OzoneManagerProtocolProtos.Status.QUOTA_EXCEEDED);
+    Assertions.assertSame(omKeyCreateResponse.getOMResponse().getStatus(),
+        OzoneManagerProtocolProtos.Status.QUOTA_EXCEEDED);
   }
 
   private void checkResponse(OMRequest modifiedOmRequest,

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMKeyCreateRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMKeyCreateRequest.java
@@ -57,6 +57,7 @@ import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos
     .KeyArgs;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos
     .OMRequest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationFactor.THREE;
 import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationType.EC;
@@ -84,9 +85,6 @@ public class TestOMKeyCreateRequest extends TestOMKeyRequest {
         new Object[]{false, false});
   }
 
-  private boolean keyPathLockEnabled;
-  private boolean enableFileSystemPaths;
-
   @Test
   public void testPreExecuteWithNormalKey() throws Exception {
     ReplicationConfig ratis3Config =
@@ -108,7 +106,7 @@ public class TestOMKeyCreateRequest extends TestOMKeyRequest {
   }
 
   private void preExecuteTest(boolean isMultipartKey, int partNumber,
-      ReplicationConfig repConfig) throws Exception {
+                              ReplicationConfig repConfig) throws Exception {
     long scmBlockSize = ozoneManager.getScmBlockSize();
     for (int i = 0; i <= repConfig.getRequiredNodes(); i++) {
       doPreExecute(createKeyRequest(isMultipartKey, partNumber,
@@ -132,10 +130,8 @@ public class TestOMKeyCreateRequest extends TestOMKeyRequest {
   @MethodSource("data")
   public void testValidateAndUpdateCache(
       boolean setKeyPathLock, boolean setFileSystemPaths) throws Exception {
-    this.keyPathLockEnabled = setKeyPathLock;
-    this.enableFileSystemPaths = setFileSystemPaths;
     when(ozoneManager.getOzoneLockProvider()).thenReturn(
-        new OzoneLockProvider(keyPathLockEnabled, enableFileSystemPaths));
+        new OzoneLockProvider(setKeyPathLock, setFileSystemPaths));
 
     OMRequest modifiedOmRequest =
         doPreExecute(createKeyRequest(false, 0));
@@ -222,10 +218,8 @@ public class TestOMKeyCreateRequest extends TestOMKeyRequest {
   @MethodSource("data")
   public void testValidateAndUpdateCacheWithNamespaceQuotaExceeded(
       boolean setKeyPathLock, boolean setFileSystemPaths)throws Exception {
-    this.keyPathLockEnabled = setKeyPathLock;
-    this.enableFileSystemPaths = setFileSystemPaths;
     when(ozoneManager.getOzoneLockProvider()).thenReturn(
-        new OzoneLockProvider(keyPathLockEnabled, enableFileSystemPaths));
+        new OzoneLockProvider(setKeyPathLock, setFileSystemPaths));
     OMRequest modifiedOmRequest =
         doPreExecute(createKeyRequest(false, 0, "test/" + keyName));
 
@@ -247,9 +241,9 @@ public class TestOMKeyCreateRequest extends TestOMKeyRequest {
         OzoneManagerProtocolProtos.Status.QUOTA_EXCEEDED);
   }
 
-  private void checkResponse(OMRequest modifiedOmRequest,
-      OMClientResponse omKeyCreateResponse, long id, boolean override,
-      BucketLayout bucketLayout) throws Exception {
+  private void checkResponse(
+      OMRequest modifiedOmRequest, OMClientResponse omKeyCreateResponse,
+      long id, boolean override, BucketLayout bucketLayout) throws Exception {
 
     Assertions.assertEquals(OK,
         omKeyCreateResponse.getOMResponse().getStatus());
@@ -298,16 +292,14 @@ public class TestOMKeyCreateRequest extends TestOMKeyRequest {
   @MethodSource("data")
   public void testValidateAndUpdateCacheWithNoSuchMultipartUploadError(
       boolean setKeyPathLock, boolean setFileSystemPaths) throws Exception {
-    this.keyPathLockEnabled = setKeyPathLock;
-    this.enableFileSystemPaths = setFileSystemPaths;
     when(ozoneManager.getOzoneLockProvider()).thenReturn(
-        new OzoneLockProvider(keyPathLockEnabled, enableFileSystemPaths));
+        new OzoneLockProvider(setKeyPathLock, setFileSystemPaths));
     int partNumber = 1;
     OMRequest modifiedOmRequest =
         doPreExecute(createKeyRequest(true, partNumber));
 
     OMKeyCreateRequest omKeyCreateRequest =
-            getOMKeyCreateRequest(modifiedOmRequest);
+        getOMKeyCreateRequest(modifiedOmRequest);
 
     // Add volume and bucket entries to DB.
     addVolumeAndBucketToDB(volumeName, bucketName,
@@ -346,15 +338,13 @@ public class TestOMKeyCreateRequest extends TestOMKeyRequest {
   @MethodSource("data")
   public void testValidateAndUpdateCacheWithVolumeNotFound(
       boolean setKeyPathLock, boolean setFileSystemPaths) throws Exception {
-    this.keyPathLockEnabled = setKeyPathLock;
-    this.enableFileSystemPaths = setFileSystemPaths;
     when(ozoneManager.getOzoneLockProvider()).thenReturn(
-        new OzoneLockProvider(keyPathLockEnabled, enableFileSystemPaths));
+        new OzoneLockProvider(setKeyPathLock, setFileSystemPaths));
     OMRequest modifiedOmRequest =
         doPreExecute(createKeyRequest(false, 0));
 
     OMKeyCreateRequest omKeyCreateRequest =
-            getOMKeyCreateRequest(modifiedOmRequest);
+        getOMKeyCreateRequest(modifiedOmRequest);
 
 
     long id = modifiedOmRequest.getCreateKeyRequest().getClientID();
@@ -390,16 +380,14 @@ public class TestOMKeyCreateRequest extends TestOMKeyRequest {
   @MethodSource("data")
   public void testValidateAndUpdateCacheWithBucketNotFound(
       boolean setKeyPathLock, boolean setFileSystemPaths) throws Exception {
-    this.keyPathLockEnabled = setKeyPathLock;
-    this.enableFileSystemPaths = setFileSystemPaths;
     when(ozoneManager.getOzoneLockProvider()).thenReturn(
-        new OzoneLockProvider(keyPathLockEnabled, enableFileSystemPaths));
+        new OzoneLockProvider(setKeyPathLock, setFileSystemPaths));
     OMRequest modifiedOmRequest =
         doPreExecute(createKeyRequest(
             false, 0));
 
     OMKeyCreateRequest omKeyCreateRequest =
-            getOMKeyCreateRequest(modifiedOmRequest);
+        getOMKeyCreateRequest(modifiedOmRequest);
 
 
     long id = modifiedOmRequest.getCreateKeyRequest().getClientID();
@@ -436,13 +424,11 @@ public class TestOMKeyCreateRequest extends TestOMKeyRequest {
   @MethodSource("data")
   public void testValidateAndUpdateCacheWithInvalidPath(
       boolean setKeyPathLock, boolean setFileSystemPaths) throws Exception {
-    this.keyPathLockEnabled = setKeyPathLock;
-    this.enableFileSystemPaths = setFileSystemPaths;
     PrefixManager prefixManager = new PrefixManagerImpl(
         ozoneManager.getMetadataManager(), true);
     when(ozoneManager.getPrefixManager()).thenReturn(prefixManager);
     when(ozoneManager.getOzoneLockProvider()).thenReturn(
-        new OzoneLockProvider(keyPathLockEnabled, enableFileSystemPaths));
+        new OzoneLockProvider(setKeyPathLock, setFileSystemPaths));
     OMRequest modifiedOmRequest =
         doPreExecute(createKeyRequest(
             false, 0, String.valueOf('\u0000')));
@@ -490,7 +476,7 @@ public class TestOMKeyCreateRequest extends TestOMKeyRequest {
   private OMRequest doPreExecute(OMRequest originalOMRequest) throws Exception {
 
     OMKeyCreateRequest omKeyCreateRequest =
-            getOMKeyCreateRequest(originalOMRequest);
+        getOMKeyCreateRequest(originalOMRequest);
 
     OMRequest modifiedOmRequest =
         omKeyCreateRequest.preExecute(ozoneManager);
@@ -561,7 +547,7 @@ public class TestOMKeyCreateRequest extends TestOMKeyRequest {
   }
 
   private OMRequest createKeyRequest(boolean isMultipartKey, int partNumber,
-      String keyName) {
+                                     String keyName) {
 
     KeyArgs.Builder keyArgs = KeyArgs.newBuilder()
         .setVolumeName(volumeName).setBucketName(bucketName)
@@ -582,8 +568,9 @@ public class TestOMKeyCreateRequest extends TestOMKeyRequest {
         .setCreateKeyRequest(createKeyRequest).build();
   }
 
-  private OMRequest createKeyRequest(boolean isMultipartKey, int partNumber,
-      long keyLength, ReplicationConfig repConfig) {
+  private OMRequest createKeyRequest(
+      boolean isMultipartKey, int partNumber, long keyLength,
+      ReplicationConfig repConfig) {
 
     KeyArgs.Builder keyArgs = KeyArgs.newBuilder()
         .setVolumeName(volumeName).setBucketName(bucketName)
@@ -613,17 +600,15 @@ public class TestOMKeyCreateRequest extends TestOMKeyRequest {
   }
 
   @ParameterizedTest
-  @MethodSource("data")
+  @ValueSource(booleans =  {true, false})
   public void testKeyCreateWithFileSystemPathsEnabled(
-      boolean setKeyPathLock, boolean setFileSystemPaths) throws Exception {
-    this.keyPathLockEnabled = setKeyPathLock;
-    this.enableFileSystemPaths = setFileSystemPaths;
+      boolean setKeyPathLock) throws Exception {
     OzoneConfiguration configuration = getOzoneConfiguration();
     configuration.setBoolean(OZONE_OM_ENABLE_FILESYSTEM_PATHS, true);
     when(ozoneManager.getConfiguration()).thenReturn(configuration);
     when(ozoneManager.getEnableFileSystemPaths()).thenReturn(true);
     when(ozoneManager.getOzoneLockProvider()).thenReturn(
-        new OzoneLockProvider(keyPathLockEnabled, true));
+        new OzoneLockProvider(setKeyPathLock, true));
 
     // Add volume and bucket entries to DB.
     addVolumeAndBucketToDB(volumeName, bucketName,
@@ -744,10 +729,8 @@ public class TestOMKeyCreateRequest extends TestOMKeyRequest {
   @MethodSource("data")
   public void testKeyCreateInheritParentDefaultAcls(
       boolean setKeyPathLock, boolean setFileSystemPaths) throws Exception {
-    this.keyPathLockEnabled = setKeyPathLock;
-    this.enableFileSystemPaths = setFileSystemPaths;
     when(ozoneManager.getOzoneLockProvider()).thenReturn(
-        new OzoneLockProvider(keyPathLockEnabled, enableFileSystemPaths));
+        new OzoneLockProvider(setKeyPathLock, setFileSystemPaths));
 
     List<OzoneAcl> acls = new ArrayList<>();
     acls.add(OzoneAcl.parseAcl("user:newUser:rw[DEFAULT]"));
@@ -795,7 +778,7 @@ public class TestOMKeyCreateRequest extends TestOMKeyRequest {
    * from parent DEFAULT acls.
    */
   private void verifyKeyInheritAcls(List<OzoneAcl> keyAcls,
-      List<OzoneAcl> bucketAcls) {
+                                    List<OzoneAcl> bucketAcls) {
 
     List<OzoneAcl> parentDefaultAcl = bucketAcls.stream()
         .filter(acl -> acl.getAclScope() == OzoneAcl.AclScope.DEFAULT)
@@ -873,8 +856,9 @@ public class TestOMKeyCreateRequest extends TestOMKeyRequest {
     checkCreatedPaths(omKeyCreateRequest, omRequest, keyName);
   }
 
-  protected void checkCreatedPaths(OMKeyCreateRequest omKeyCreateRequest,
-      OMRequest omRequest, String keyName) throws Exception {
+  protected void checkCreatedPaths(
+      OMKeyCreateRequest omKeyCreateRequest, OMRequest omRequest,
+      String keyName) throws Exception {
     keyName = omKeyCreateRequest.validateAndNormalizeKey(true, keyName);
     // Check intermediate directories created or not.
     Path keyPath = Paths.get(keyName);
@@ -903,7 +887,7 @@ public class TestOMKeyCreateRequest extends TestOMKeyRequest {
 
   protected String getOpenKey(long id) throws IOException {
     return omMetadataManager.getOpenKey(volumeName, bucketName,
-            keyName, id);
+        keyName, id);
   }
 
   protected String getOzoneKey() throws IOException {
@@ -919,11 +903,4 @@ public class TestOMKeyCreateRequest extends TestOMKeyRequest {
     return new OMKeyCreateRequest(omRequest, layout);
   }
 
-  protected boolean getKeyPathLockEnabled() {
-    return keyPathLockEnabled;
-  }
-
-  protected boolean getEnableFileSystemPaths() {
-    return enableFileSystemPaths;
-  }
 }

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMKeyCreateRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMKeyCreateRequest.java
@@ -87,7 +87,7 @@ public class TestOMKeyCreateRequest extends TestOMKeyRequest {
   private boolean keyPathLockEnabled;
   private boolean enableFileSystemPaths;
 
-  @org.junit.Test
+  @Test
   public void testPreExecuteWithNormalKey() throws Exception {
     ReplicationConfig ratis3Config =
         ReplicationConfig.fromProtoTypeAndFactor(RATIS, THREE);

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMKeyCreateRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMKeyCreateRequest.java
@@ -71,6 +71,9 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.Mockito.when;
 
+/**
+ * This class tests the OM Key Create Request.
+ */
 public class TestOMKeyCreateRequest extends TestOMKeyRequest {
 
   public static Collection<Object[]> data() {

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMKeyCreateRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMKeyCreateRequest.java
@@ -42,8 +42,10 @@ import org.apache.hadoop.ozone.om.helpers.BucketLayout;
 import org.apache.hadoop.ozone.om.helpers.OmBucketInfo;
 import org.apache.hadoop.ozone.om.lock.OzoneLockProvider;
 import org.apache.hadoop.ozone.om.request.OMRequestTestUtils;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
 import org.apache.hadoop.ozone.om.helpers.OmKeyLocationInfo;
@@ -55,8 +57,6 @@ import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos
     .KeyArgs;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos
     .OMRequest;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
 
 import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationFactor.THREE;
 import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationType.EC;
@@ -67,18 +67,12 @@ import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_ENABLE_FILESYSTEM
 import static org.apache.hadoop.ozone.om.request.OMRequestTestUtils.addVolumeAndBucketToDB;
 import static org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.Status.NOT_A_FILE;
 import static org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.Status.OK;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.Mockito.when;
-import static org.slf4j.MDC.put;
 
-/**
- * Tests OMCreateKeyRequest class.
- */
-@RunWith(Parameterized.class)
 public class TestOMKeyCreateRequest extends TestOMKeyRequest {
 
-  @Parameterized.Parameters
   public static Collection<Object[]> data() {
     return Arrays.asList(
         new Object[]{true, true},
@@ -87,23 +81,9 @@ public class TestOMKeyCreateRequest extends TestOMKeyRequest {
         new Object[]{false, false});
   }
 
-  public TestOMKeyCreateRequest(boolean setKeyPathLock,
-                                boolean setFileSystemPaths) {
-    // Ignored. Actual init done in initParam().
-    // This empty constructor is still required to avoid argument exception.
-  }
+  private boolean keyPathLockEnabled;
+  private boolean enableFileSystemPaths;
 
-  @Parameterized.BeforeParam
-  public static void initParam(boolean setKeyPathLock,
-                               boolean setFileSystemPaths) {
-    keyPathLockEnabled = setKeyPathLock;
-    enableFileSystemPaths = setFileSystemPaths;
-  }
-
-  private static boolean keyPathLockEnabled;
-  private static boolean enableFileSystemPaths;
-
-  @Test
   public void testPreExecuteWithNormalKey() throws Exception {
     ReplicationConfig ratis3Config =
         ReplicationConfig.fromProtoTypeAndFactor(RATIS, THREE);
@@ -140,12 +120,16 @@ public class TestOMKeyCreateRequest extends TestOMKeyRequest {
     OMException e = assertThrows(OMException.class,
         () -> preExecuteTest(false, 0, invalidReplication));
 
-    Assert.assertEquals(OMException.ResultCodes.INVALID_REQUEST,
+    Assertions.assertEquals(OMException.ResultCodes.INVALID_REQUEST,
         e.getResult());
   }
 
-  @Test
-  public void testValidateAndUpdateCache() throws Exception {
+  @ParameterizedTest
+  @MethodSource("data")
+  public void testValidateAndUpdateCache(
+      boolean setKeyPathLock, boolean setFileSystemPaths) throws Exception {
+    this.keyPathLockEnabled = setKeyPathLock;
+    this.enableFileSystemPaths = setFileSystemPaths;
     when(ozoneManager.getOzoneLockProvider()).thenReturn(
         new OzoneLockProvider(keyPathLockEnabled, enableFileSystemPaths));
 
@@ -169,7 +153,7 @@ public class TestOMKeyCreateRequest extends TestOMKeyRequest {
                 omKeyCreateRequest.getBucketLayout())
             .get(openKey);
 
-    Assert.assertNull(omKeyInfo);
+    Assertions.assertNull(omKeyInfo);
 
     OMClientResponse omKeyCreateResponse =
         omKeyCreateRequest.validateAndUpdateCache(ozoneManager, 100L,
@@ -179,11 +163,11 @@ public class TestOMKeyCreateRequest extends TestOMKeyRequest {
         omKeyCreateRequest.getBucketLayout());
 
     // Network returns only latest version.
-    Assert.assertEquals(1, omKeyCreateResponse.getOMResponse()
+    Assertions.assertEquals(1, omKeyCreateResponse.getOMResponse()
         .getCreateKeyResponse().getKeyInfo().getKeyLocationListCount());
 
     // Disk should have 1 version, as it is fresh key create.
-    Assert.assertEquals(1,
+    Assertions.assertEquals(1,
         omMetadataManager.getOpenKeyTable(
                 omKeyCreateRequest.getBucketLayout())
             .get(openKey).getKeyLocationVersions().size());
@@ -206,7 +190,7 @@ public class TestOMKeyCreateRequest extends TestOMKeyRequest {
         omMetadataManager.getOpenKeyTable(
                 omKeyCreateRequest.getBucketLayout())
             .get(openKey);
-    Assert.assertNull(omKeyInfo);
+    Assertions.assertNull(omKeyInfo);
 
     omKeyCreateRequest =
         getOMKeyCreateRequest(modifiedOmRequest);
@@ -219,20 +203,23 @@ public class TestOMKeyCreateRequest extends TestOMKeyRequest {
         omKeyCreateRequest.getBucketLayout());
 
     // Network returns only latest version
-    Assert.assertEquals(1, omKeyCreateResponse.getOMResponse()
+    Assertions.assertEquals(1, omKeyCreateResponse.getOMResponse()
         .getCreateKeyResponse().getKeyInfo().getKeyLocationListCount());
 
     // Disk should have 1 versions when bucket versioning is off.
-    Assert.assertEquals(1,
+    Assertions.assertEquals(1,
         omMetadataManager.getOpenKeyTable(
                 omKeyCreateRequest.getBucketLayout())
             .get(openKey).getKeyLocationVersions().size());
 
   }
 
-  @Test
-  public void testValidateAndUpdateCacheWithNamespaceQuotaExceeded()
-      throws Exception {
+  @ParameterizedTest
+  @MethodSource("data")
+  public void testValidateAndUpdateCacheWithNamespaceQuotaExceeded(
+      boolean setKeyPathLock, boolean setFileSystemPaths)throws Exception {
+    this.keyPathLockEnabled = setKeyPathLock;
+    this.enableFileSystemPaths = setFileSystemPaths;
     when(ozoneManager.getOzoneLockProvider()).thenReturn(
         new OzoneLockProvider(keyPathLockEnabled, enableFileSystemPaths));
     OMRequest modifiedOmRequest =
@@ -252,7 +239,7 @@ public class TestOMKeyCreateRequest extends TestOMKeyRequest {
     OMClientResponse omKeyCreateResponse =
         omKeyCreateRequest.validateAndUpdateCache(ozoneManager, 100L,
             ozoneManagerDoubleBufferHelper);
-    Assert.assertTrue(omKeyCreateResponse.getOMResponse().getStatus()
+    Assertions.assertTrue(omKeyCreateResponse.getOMResponse().getStatus()
         == OzoneManagerProtocolProtos.Status.QUOTA_EXCEEDED);
   }
 
@@ -260,7 +247,7 @@ public class TestOMKeyCreateRequest extends TestOMKeyRequest {
       OMClientResponse omKeyCreateResponse, long id, boolean override,
       BucketLayout bucketLayout) throws Exception {
 
-    Assert.assertEquals(OK,
+    Assertions.assertEquals(OK,
         omKeyCreateResponse.getOMResponse().getStatus());
 
     String openKey = getOpenKey(id);
@@ -270,26 +257,26 @@ public class TestOMKeyCreateRequest extends TestOMKeyRequest {
     OmKeyInfo omKeyInfo =
         omMetadataManager.getOpenKeyTable(bucketLayout).get(openKey);
 
-    Assert.assertNotNull(omKeyInfo);
-    Assert.assertNotNull(omKeyInfo.getLatestVersionLocations());
+    Assertions.assertNotNull(omKeyInfo);
+    Assertions.assertNotNull(omKeyInfo.getLatestVersionLocations());
 
     // As our data size is 100, and scmBlockSize is default to 1000, so we
     // shall have only one block.
     List<OmKeyLocationInfo> omKeyLocationInfoList =
         omKeyInfo.getLatestVersionLocations().getLocationList();
-    Assert.assertEquals(1, omKeyLocationInfoList.size());
+    Assertions.assertEquals(1, omKeyLocationInfoList.size());
 
     OmKeyLocationInfo omKeyLocationInfo = omKeyLocationInfoList.get(0);
 
     // Check modification time
-    Assert.assertEquals(modifiedOmRequest.getCreateKeyRequest()
+    Assertions.assertEquals(modifiedOmRequest.getCreateKeyRequest()
         .getKeyArgs().getModificationTime(), omKeyInfo.getModificationTime());
 
     if (!override) {
-      Assert.assertEquals(omKeyInfo.getModificationTime(),
+      Assertions.assertEquals(omKeyInfo.getModificationTime(),
           omKeyInfo.getCreationTime());
     } else {
-      Assert.assertNotEquals(omKeyInfo.getModificationTime(),
+      Assertions.assertNotEquals(omKeyInfo.getModificationTime(),
           omKeyInfo.getCreationTime());
     }
 
@@ -297,15 +284,18 @@ public class TestOMKeyCreateRequest extends TestOMKeyRequest {
     OzoneManagerProtocolProtos.KeyLocation keyLocation =
         modifiedOmRequest.getCreateKeyRequest().getKeyArgs().getKeyLocations(0);
 
-    Assert.assertEquals(keyLocation.getBlockID().getContainerBlockID()
+    Assertions.assertEquals(keyLocation.getBlockID().getContainerBlockID()
         .getContainerID(), omKeyLocationInfo.getContainerID());
-    Assert.assertEquals(keyLocation.getBlockID().getContainerBlockID()
+    Assertions.assertEquals(keyLocation.getBlockID().getContainerBlockID()
         .getLocalID(), omKeyLocationInfo.getLocalID());
   }
 
-  @Test
-  public void testValidateAndUpdateCacheWithNoSuchMultipartUploadError()
-      throws Exception {
+  @ParameterizedTest
+  @MethodSource("data")
+  public void testValidateAndUpdateCacheWithNoSuchMultipartUploadError(
+      boolean setKeyPathLock, boolean setFileSystemPaths) throws Exception {
+    this.keyPathLockEnabled = setKeyPathLock;
+    this.enableFileSystemPaths = setFileSystemPaths;
     when(ozoneManager.getOzoneLockProvider()).thenReturn(
         new OzoneLockProvider(keyPathLockEnabled, enableFileSystemPaths));
     int partNumber = 1;
@@ -328,13 +318,13 @@ public class TestOMKeyCreateRequest extends TestOMKeyRequest {
     OmKeyInfo omKeyInfo =
         omMetadataManager.getOpenKeyTable(getBucketLayout()).get(openKey);
 
-    Assert.assertNull(omKeyInfo);
+    Assertions.assertNull(omKeyInfo);
 
     OMClientResponse omKeyCreateResponse =
         omKeyCreateRequest.validateAndUpdateCache(ozoneManager, 100L,
             ozoneManagerDoubleBufferHelper);
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         OzoneManagerProtocolProtos.Status.NO_SUCH_MULTIPART_UPLOAD_ERROR,
         omKeyCreateResponse.getOMResponse().getStatus());
 
@@ -343,13 +333,17 @@ public class TestOMKeyCreateRequest extends TestOMKeyRequest {
     omKeyInfo =
         omMetadataManager.getOpenKeyTable(getBucketLayout()).get(openKey);
 
-    Assert.assertNull(omKeyInfo);
+    Assertions.assertNull(omKeyInfo);
   }
 
 
 
-  @Test
-  public void testValidateAndUpdateCacheWithVolumeNotFound() throws Exception {
+  @ParameterizedTest
+  @MethodSource("data")
+  public void testValidateAndUpdateCacheWithVolumeNotFound(
+      boolean setKeyPathLock, boolean setFileSystemPaths) throws Exception {
+    this.keyPathLockEnabled = setKeyPathLock;
+    this.enableFileSystemPaths = setFileSystemPaths;
     when(ozoneManager.getOzoneLockProvider()).thenReturn(
         new OzoneLockProvider(keyPathLockEnabled, enableFileSystemPaths));
     OMRequest modifiedOmRequest =
@@ -369,13 +363,13 @@ public class TestOMKeyCreateRequest extends TestOMKeyRequest {
     OmKeyInfo omKeyInfo =
         omMetadataManager.getOpenKeyTable(getBucketLayout()).get(openKey);
 
-    Assert.assertNull(omKeyInfo);
+    Assertions.assertNull(omKeyInfo);
 
     OMClientResponse omKeyCreateResponse =
         omKeyCreateRequest.validateAndUpdateCache(ozoneManager, 100L,
             ozoneManagerDoubleBufferHelper);
 
-    Assert.assertEquals(OzoneManagerProtocolProtos.Status.VOLUME_NOT_FOUND,
+    Assertions.assertEquals(OzoneManagerProtocolProtos.Status.VOLUME_NOT_FOUND,
         omKeyCreateResponse.getOMResponse().getStatus());
 
 
@@ -383,13 +377,17 @@ public class TestOMKeyCreateRequest extends TestOMKeyRequest {
     omKeyInfo =
         omMetadataManager.getOpenKeyTable(getBucketLayout()).get(openKey);
 
-    Assert.assertNull(omKeyInfo);
+    Assertions.assertNull(omKeyInfo);
 
   }
 
 
-  @Test
-  public void testValidateAndUpdateCacheWithBucketNotFound() throws Exception {
+  @ParameterizedTest
+  @MethodSource("data")
+  public void testValidateAndUpdateCacheWithBucketNotFound(
+      boolean setKeyPathLock, boolean setFileSystemPaths) throws Exception {
+    this.keyPathLockEnabled = setKeyPathLock;
+    this.enableFileSystemPaths = setFileSystemPaths;
     when(ozoneManager.getOzoneLockProvider()).thenReturn(
         new OzoneLockProvider(keyPathLockEnabled, enableFileSystemPaths));
     OMRequest modifiedOmRequest =
@@ -411,13 +409,13 @@ public class TestOMKeyCreateRequest extends TestOMKeyRequest {
     OmKeyInfo omKeyInfo =
         omMetadataManager.getOpenKeyTable(getBucketLayout()).get(openKey);
 
-    Assert.assertNull(omKeyInfo);
+    Assertions.assertNull(omKeyInfo);
 
     OMClientResponse omKeyCreateResponse =
         omKeyCreateRequest.validateAndUpdateCache(ozoneManager, 100L,
             ozoneManagerDoubleBufferHelper);
 
-    Assert.assertEquals(OzoneManagerProtocolProtos.Status.BUCKET_NOT_FOUND,
+    Assertions.assertEquals(OzoneManagerProtocolProtos.Status.BUCKET_NOT_FOUND,
         omKeyCreateResponse.getOMResponse().getStatus());
 
 
@@ -425,14 +423,17 @@ public class TestOMKeyCreateRequest extends TestOMKeyRequest {
     omKeyInfo =
         omMetadataManager.getOpenKeyTable(getBucketLayout()).get(openKey);
 
-    Assert.assertNull(omKeyInfo);
+    Assertions.assertNull(omKeyInfo);
 
   }
 
 
-  @Test
-  public void testValidateAndUpdateCacheWithInvalidPath() throws Exception {
-
+  @ParameterizedTest
+  @MethodSource("data")
+  public void testValidateAndUpdateCacheWithInvalidPath(
+      boolean setKeyPathLock, boolean setFileSystemPaths) throws Exception {
+    this.keyPathLockEnabled = setKeyPathLock;
+    this.enableFileSystemPaths = setFileSystemPaths;
     PrefixManager prefixManager = new PrefixManagerImpl(
         ozoneManager.getMetadataManager(), true);
     when(ozoneManager.getPrefixManager()).thenReturn(prefixManager);
@@ -458,13 +459,13 @@ public class TestOMKeyCreateRequest extends TestOMKeyRequest {
     OmKeyInfo omKeyInfo =
         omMetadataManager.getOpenKeyTable(getBucketLayout()).get(openKey);
 
-    Assert.assertNull(omKeyInfo);
+    Assertions.assertNull(omKeyInfo);
 
     OMClientResponse omKeyCreateResponse =
         omKeyCreateRequest.validateAndUpdateCache(ozoneManager, 100L,
             ozoneManagerDoubleBufferHelper);
 
-    Assert.assertEquals(OzoneManagerProtocolProtos.Status.INVALID_PATH,
+    Assertions.assertEquals(OzoneManagerProtocolProtos.Status.INVALID_PATH,
         omKeyCreateResponse.getOMResponse().getStatus());
 
 
@@ -473,7 +474,7 @@ public class TestOMKeyCreateRequest extends TestOMKeyRequest {
     omKeyInfo =
         omMetadataManager.getOpenKeyTable(getBucketLayout()).get(openKey);
 
-    Assert.assertNull(omKeyInfo);
+    Assertions.assertNull(omKeyInfo);
 
   }
   /**
@@ -490,12 +491,12 @@ public class TestOMKeyCreateRequest extends TestOMKeyRequest {
     OMRequest modifiedOmRequest =
         omKeyCreateRequest.preExecute(ozoneManager);
 
-    Assert.assertEquals(originalOMRequest.getCmdType(),
+    Assertions.assertEquals(originalOMRequest.getCmdType(),
         modifiedOmRequest.getCmdType());
-    Assert.assertEquals(originalOMRequest.getClientId(),
+    Assertions.assertEquals(originalOMRequest.getClientId(),
         modifiedOmRequest.getClientId());
 
-    Assert.assertTrue(modifiedOmRequest.hasCreateKeyRequest());
+    Assertions.assertTrue(modifiedOmRequest.hasCreateKeyRequest());
 
     CreateKeyRequest createKeyRequest =
         modifiedOmRequest.getCreateKeyRequest();
@@ -508,12 +509,12 @@ public class TestOMKeyCreateRequest extends TestOMKeyRequest {
         (keyArgs.getDataSize() - 1) / (blockSize * dataGroupSize) + 1);
 
     // Time should be set
-    Assert.assertTrue(keyArgs.getModificationTime() > 0);
+    Assertions.assertTrue(keyArgs.getModificationTime() > 0);
 
 
     // Client ID should be set.
-    Assert.assertTrue(createKeyRequest.hasClientID());
-    Assert.assertTrue(createKeyRequest.getClientID() > 0);
+    Assertions.assertTrue(createKeyRequest.hasClientID());
+    Assertions.assertTrue(createKeyRequest.getClientID() > 0);
 
 
     if (!originalOMRequest.getCreateKeyRequest().getKeyArgs()
@@ -522,21 +523,21 @@ public class TestOMKeyCreateRequest extends TestOMKeyRequest {
       List<OzoneManagerProtocolProtos.KeyLocation> keyLocations =
           keyArgs.getKeyLocationsList();
       // KeyLocation should be set.
-      Assert.assertEquals(preAllocatedBlocks, keyLocations.size());
-      Assert.assertEquals(CONTAINER_ID,
+      Assertions.assertEquals(preAllocatedBlocks, keyLocations.size());
+      Assertions.assertEquals(CONTAINER_ID,
           keyLocations.get(0).getBlockID().getContainerBlockID()
               .getContainerID());
-      Assert.assertEquals(LOCAL_ID,
+      Assertions.assertEquals(LOCAL_ID,
           keyLocations.get(0).getBlockID().getContainerBlockID()
               .getLocalID());
-      Assert.assertTrue(keyLocations.get(0).hasPipeline());
+      Assertions.assertTrue(keyLocations.get(0).hasPipeline());
 
-      Assert.assertEquals(0, keyLocations.get(0).getOffset());
+      Assertions.assertEquals(0, keyLocations.get(0).getOffset());
 
-      Assert.assertEquals(scmBlockSize, keyLocations.get(0).getLength());
+      Assertions.assertEquals(scmBlockSize, keyLocations.get(0).getLength());
     } else {
       // We don't create blocks for multipart key in createKey preExecute.
-      Assert.assertEquals(0, keyArgs.getKeyLocationsList().size());
+      Assertions.assertEquals(0, keyArgs.getKeyLocationsList().size());
     }
 
     return modifiedOmRequest;
@@ -607,9 +608,12 @@ public class TestOMKeyCreateRequest extends TestOMKeyRequest {
         .setCreateKeyRequest(createKeyRequest).build();
   }
 
-  @Test
-  public void testKeyCreateWithFileSystemPathsEnabled() throws Exception {
-
+  @ParameterizedTest
+  @MethodSource("data")
+  public void testKeyCreateWithFileSystemPathsEnabled(
+      boolean setKeyPathLock, boolean setFileSystemPaths) throws Exception {
+    this.keyPathLockEnabled = setKeyPathLock;
+    this.enableFileSystemPaths = setFileSystemPaths;
     OzoneConfiguration configuration = getOzoneConfiguration();
     configuration.setBoolean(OZONE_OM_ENABLE_FILESYSTEM_PATHS, true);
     when(ozoneManager.getConfiguration()).thenReturn(configuration);
@@ -725,16 +729,19 @@ public class TestOMKeyCreateRequest extends TestOMKeyRequest {
           .setClientId(UUID.randomUUID().toString())
           .setCreateKeyRequest(createKeyRequest).build();
 
-      OMException ex = Assert.assertThrows(OMException.class,
+      OMException ex = Assertions.assertThrows(OMException.class,
           () -> getOMKeyCreateRequest(omRequest).preExecute(ozoneManager)
       );
-      Assert.assertTrue(ex.getMessage().contains(expectedErrorMessage));
+      Assertions.assertTrue(ex.getMessage().contains(expectedErrorMessage));
     }
   }
 
-  @Test
-  public void testKeyCreateInheritParentDefaultAcls()
-      throws Exception {
+  @ParameterizedTest
+  @MethodSource("data")
+  public void testKeyCreateInheritParentDefaultAcls(
+      boolean setKeyPathLock, boolean setFileSystemPaths) throws Exception {
+    this.keyPathLockEnabled = setKeyPathLock;
+    this.enableFileSystemPaths = setFileSystemPaths;
     when(ozoneManager.getOzoneLockProvider()).thenReturn(
         new OzoneLockProvider(keyPathLockEnabled, enableFileSystemPaths));
 
@@ -754,7 +761,7 @@ public class TestOMKeyCreateRequest extends TestOMKeyRequest {
     String bucketKey = omMetadataManager.getBucketKey(volumeName, bucketName);
     List<OzoneAcl> bucketAcls = omMetadataManager.getBucketTable()
         .get(bucketKey).getAcls();
-    Assert.assertEquals(acls, bucketAcls);
+    Assertions.assertEquals(acls, bucketAcls);
 
     // create file inherit bucket DEFAULT acls
     OMRequest modifiedOmRequest =
@@ -795,13 +802,13 @@ public class TestOMKeyCreateRequest extends TestOMKeyRequest {
         .findAny().orElse(null);
 
     // Should inherit parent DEFAULT Acls
-    Assert.assertEquals("Failed to inherit parent DEFAULT acls!,",
-        parentDefaultAcl.stream()
+    Assertions.assertEquals(parentDefaultAcl.stream()
             .map(acl -> acl.setAclScope(OzoneAcl.AclScope.ACCESS))
-            .collect(Collectors.toList()), keyAcls);
+            .collect(Collectors.toList()), keyAcls,
+        "Failed to inherit parent DEFAULT acls!,");
 
     // Should not inherit parent ACCESS Acls
-    Assert.assertFalse(keyAcls.contains(parentAccessAcl));
+    Assertions.assertFalse(keyAcls.contains(parentAccessAcl));
   }
 
   protected void addToKeyTable(String keyName) throws Exception {
@@ -818,9 +825,9 @@ public class TestOMKeyCreateRequest extends TestOMKeyRequest {
       omKeyCreateRequest.preExecute(ozoneManager);
       fail("checkNotAValidPath failed for path" + keyName);
     } catch (IOException ex) {
-      Assert.assertTrue(ex instanceof OMException);
+      Assertions.assertTrue(ex instanceof OMException);
       OMException omException = (OMException) ex;
-      Assert.assertEquals(OMException.ResultCodes.INVALID_KEY_NAME,
+      Assertions.assertEquals(OMException.ResultCodes.INVALID_KEY_NAME,
           omException.getResult());
     }
 
@@ -839,7 +846,7 @@ public class TestOMKeyCreateRequest extends TestOMKeyRequest {
         omKeyCreateRequest.validateAndUpdateCache(ozoneManager,
             101L, ozoneManagerDoubleBufferHelper);
 
-    Assert.assertEquals(NOT_A_FILE,
+    Assertions.assertEquals(NOT_A_FILE,
         omClientResponse.getOMResponse().getStatus());
   }
 
@@ -857,7 +864,7 @@ public class TestOMKeyCreateRequest extends TestOMKeyRequest {
         omKeyCreateRequest.validateAndUpdateCache(ozoneManager,
             101L, ozoneManagerDoubleBufferHelper);
 
-    Assert.assertEquals(OK, omClientResponse.getOMResponse().getStatus());
+    Assertions.assertEquals(OK, omClientResponse.getOMResponse().getStatus());
 
     checkCreatedPaths(omKeyCreateRequest, omRequest, keyName);
   }
@@ -875,16 +882,16 @@ public class TestOMKeyCreateRequest extends TestOMKeyRequest {
     OmKeyInfo omKeyInfo =
         omMetadataManager.getOpenKeyTable(omKeyCreateRequest.getBucketLayout())
             .get(openKey);
-    Assert.assertNotNull(omKeyInfo);
+    Assertions.assertNotNull(omKeyInfo);
   }
 
   protected long checkIntermediatePaths(Path keyPath) throws Exception {
     // Check intermediate paths are created
     keyPath = keyPath.getParent();
     while (keyPath != null) {
-      Assert.assertNotNull(omMetadataManager.getKeyTable(getBucketLayout()).get(
-          omMetadataManager
-              .getOzoneDirKey(volumeName, bucketName, keyPath.toString())));
+      Assertions.assertNotNull(omMetadataManager.getKeyTable(getBucketLayout())
+          .get(omMetadataManager.getOzoneDirKey(
+              volumeName, bucketName, keyPath.toString())));
       keyPath = keyPath.getParent();
     }
     return -1;

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMKeyCreateRequestWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMKeyCreateRequestWithFSO.java
@@ -32,8 +32,8 @@ import org.apache.hadoop.ozone.om.request.OMRequestTestUtils;
 import org.apache.hadoop.ozone.om.response.OMClientResponse;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMRequest;
 import org.apache.hadoop.util.Time;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.nio.file.Path;
@@ -46,11 +46,6 @@ import static org.mockito.Mockito.when;
  * Tests OMCreateKeyRequestWithFSO class.
  */
 public class TestOMKeyCreateRequestWithFSO extends TestOMKeyCreateRequest {
-
-  public TestOMKeyCreateRequestWithFSO(boolean setKeyPathLock,
-                                       boolean setFileSystemPaths) {
-    super(setKeyPathLock, setFileSystemPaths);
-  }
 
   @Test
   public void testValidateAndUpdateCacheWithKeyContainsSnapshotReservedWord()
@@ -78,17 +73,19 @@ public class TestOMKeyCreateRequestWithFSO extends TestOMKeyCreateRequest {
       OMClientResponse omKeyCreateResponse =
           omKeyCreateRequest.validateAndUpdateCache(ozoneManager, 100L,
               ozoneManagerDoubleBufferHelper);
-      Assert.assertTrue(omKeyCreateResponse.getOMResponse().getSuccess());
-      Assert.assertEquals("Incorrect keyName", keyName,
+      Assertions.assertTrue(omKeyCreateResponse.getOMResponse().getSuccess());
+      Assertions.assertEquals(keyName,
           omKeyCreateResponse.getOMResponse()
-                .getCreateKeyResponse().getKeyInfo().getKeyName());
+                .getCreateKeyResponse().getKeyInfo().getKeyName(),
+          "Incorrect keyName");
     }
   }
 
   @Test
   public void testKeyCreateInheritParentDefaultAcls()
       throws Exception {
-    super.testKeyCreateInheritParentDefaultAcls();
+    super.testKeyCreateInheritParentDefaultAcls(
+        getKeyPathLockEnabled(), getEnableFileSystemPaths());
   }
 
   @Override
@@ -130,14 +127,14 @@ public class TestOMKeyCreateRequestWithFSO extends TestOMKeyCreateRequest {
 
     // Check open key entry
     Path keyPathFileName = keyPath.getFileName();
-    Assert.assertNotNull("Failed to find fileName", keyPathFileName);
+    Assertions.assertNotNull(keyPathFileName, "Failed to find fileName");
     String fileName = keyPathFileName.toString();
     String openKey = omMetadataManager.getOpenFileName(volumeId, bucketId,
             parentID, fileName, omRequest.getCreateKeyRequest().getClientID());
     OmKeyInfo omKeyInfo =
         omMetadataManager.getOpenKeyTable(omKeyCreateRequest.getBucketLayout())
             .get(openKey);
-    Assert.assertNotNull(omKeyInfo);
+    Assertions.assertNotNull(omKeyInfo);
   }
 
   @Override
@@ -147,7 +144,7 @@ public class TestOMKeyCreateRequestWithFSO extends TestOMKeyCreateRequest {
     String bucketKey = omMetadataManager.getBucketKey(volumeName, bucketName);
     OmBucketInfo omBucketInfo =
             omMetadataManager.getBucketTable().get(bucketKey);
-    Assert.assertNotNull("Bucket not found!", omBucketInfo);
+    Assertions.assertNotNull(omBucketInfo, "Bucket not found!");
     long lastKnownParentId = omBucketInfo.getObjectID();
     final long volumeId = omMetadataManager.getVolumeId(volumeName);
 
@@ -162,8 +159,8 @@ public class TestOMKeyCreateRequestWithFSO extends TestOMKeyCreateRequest {
       OmDirectoryInfo omDirInfo = omMetadataManager.getDirectoryTable().
               get(dbNodeName);
 
-      Assert.assertNotNull("Parent key path:" + fullKeyPath +
-              " doesn't exist", omDirInfo);
+      Assertions.assertNotNull(omDirInfo, "Parent key path:" + fullKeyPath +
+              " doesn't exist");
       lastKnownParentId = omDirInfo.getObjectID();
     }
 

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMKeyCreateRequestWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMKeyCreateRequestWithFSO.java
@@ -33,12 +33,15 @@ import org.apache.hadoop.ozone.om.response.OMClientResponse;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMRequest;
 import org.apache.hadoop.util.Time;
 import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.io.IOException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Iterator;
+import java.util.Arrays;
+import java.util.Collection;
 
 import static org.apache.hadoop.ozone.OzoneConsts.OM_SNAPSHOT_INDICATOR;
 import static org.mockito.Mockito.when;
@@ -47,12 +50,20 @@ import static org.mockito.Mockito.when;
  */
 public class TestOMKeyCreateRequestWithFSO extends TestOMKeyCreateRequest {
 
-  @Test
-  public void testValidateAndUpdateCacheWithKeyContainsSnapshotReservedWord()
-        throws Exception {
+  public static Collection<Object[]> data() {
+    return Arrays.asList(
+        new Object[]{true, true},
+        new Object[]{true, false},
+        new Object[]{false, true},
+        new Object[]{false, false});
+  }
+
+  @ParameterizedTest
+  @MethodSource("data")
+  public void testValidateAndUpdateCacheWithKeyContainsSnapshotReservedWord(
+      boolean setKeyPathLock, boolean setFileSystemPaths) throws Exception {
     when(ozoneManager.getOzoneLockProvider()).thenReturn(
-        new OzoneLockProvider(getKeyPathLockEnabled(),
-            getEnableFileSystemPaths()));
+        new OzoneLockProvider(setKeyPathLock, setFileSystemPaths));
 
     String[] validKeyNames = {
         keyName,
@@ -81,13 +92,6 @@ public class TestOMKeyCreateRequestWithFSO extends TestOMKeyCreateRequest {
     }
   }
 
-  @Test
-  public void testKeyCreateInheritParentDefaultAcls()
-      throws Exception {
-    super.testKeyCreateInheritParentDefaultAcls(
-        getKeyPathLockEnabled(), getEnableFileSystemPaths());
-  }
-
   @Override
   protected OzoneConfiguration getOzoneConfiguration() {
     OzoneConfiguration config = super.getOzoneConfiguration();
@@ -102,12 +106,10 @@ public class TestOMKeyCreateRequestWithFSO extends TestOMKeyCreateRequest {
     Path keyPath = Paths.get(keyName);
     long parentId = checkIntermediatePaths(keyPath);
     String fileName = OzoneFSUtils.getFileName(keyName);
-    OmKeyInfo omKeyInfo =
-            OMRequestTestUtils.createOmKeyInfo(volumeName, bucketName, fileName,
-                    HddsProtos.ReplicationType.RATIS,
-                    HddsProtos.ReplicationFactor.ONE,
-                    parentId + 1,
-                    parentId, 100, Time.now());
+    OmKeyInfo omKeyInfo = OMRequestTestUtils.createOmKeyInfo(volumeName,
+        bucketName, fileName, HddsProtos.ReplicationType.RATIS,
+        HddsProtos.ReplicationFactor.ONE,  parentId + 1, parentId, 100,
+        Time.now());
     OMRequestTestUtils.addFileToKeyTable(false, false,
             fileName, omKeyInfo, -1, 50, omMetadataManager);
   }
@@ -123,14 +125,14 @@ public class TestOMKeyCreateRequestWithFSO extends TestOMKeyCreateRequest {
 
     final long volumeId = omMetadataManager.getVolumeId(volumeName);
     final long bucketId = omMetadataManager.getBucketId(volumeName,
-            bucketName);
+        bucketName);
 
     // Check open key entry
     Path keyPathFileName = keyPath.getFileName();
     Assertions.assertNotNull(keyPathFileName, "Failed to find fileName");
     String fileName = keyPathFileName.toString();
     String openKey = omMetadataManager.getOpenFileName(volumeId, bucketId,
-            parentID, fileName, omRequest.getCreateKeyRequest().getClientID());
+        parentID, fileName, omRequest.getCreateKeyRequest().getClientID());
     OmKeyInfo omKeyInfo =
         omMetadataManager.getOpenKeyTable(omKeyCreateRequest.getBucketLayout())
             .get(openKey);
@@ -143,7 +145,7 @@ public class TestOMKeyCreateRequestWithFSO extends TestOMKeyCreateRequest {
     keyPath = keyPath.getParent(); // skip the file name
     String bucketKey = omMetadataManager.getBucketKey(volumeName, bucketName);
     OmBucketInfo omBucketInfo =
-            omMetadataManager.getBucketTable().get(bucketKey);
+        omMetadataManager.getBucketTable().get(bucketKey);
     Assertions.assertNotNull(omBucketInfo, "Bucket not found!");
     long lastKnownParentId = omBucketInfo.getObjectID();
     final long volumeId = omMetadataManager.getVolumeId(volumeName);
@@ -155,12 +157,12 @@ public class TestOMKeyCreateRequestWithFSO extends TestOMKeyCreateRequest {
       fullKeyPath.append(OzoneConsts.OM_KEY_PREFIX);
       fullKeyPath.append(fileName);
       String dbNodeName = omMetadataManager.getOzonePathKey(volumeId,
-              omBucketInfo.getObjectID(), lastKnownParentId, fileName);
+          omBucketInfo.getObjectID(), lastKnownParentId, fileName);
       OmDirectoryInfo omDirInfo = omMetadataManager.getDirectoryTable().
-              get(dbNodeName);
+          get(dbNodeName);
 
       Assertions.assertNotNull(omDirInfo, "Parent key path:" + fullKeyPath +
-              " doesn't exist");
+          " doesn't exist");
       lastKnownParentId = omDirInfo.getObjectID();
     }
 
@@ -171,14 +173,14 @@ public class TestOMKeyCreateRequestWithFSO extends TestOMKeyCreateRequest {
   protected String getOpenKey(long id) throws IOException {
 
     OmVolumeArgs volumeInfo = omMetadataManager.getVolumeTable()
-            .get(omMetadataManager.getVolumeKey(volumeName));
+        .get(omMetadataManager.getVolumeKey(volumeName));
     OmBucketInfo omBucketInfo = omMetadataManager.getBucketTable()
-            .get(omMetadataManager.getBucketKey(volumeName, bucketName));
+        .get(omMetadataManager.getBucketKey(volumeName, bucketName));
     return omMetadataManager.getOpenFileName(
-            volumeInfo == null ? 100 : volumeInfo.getObjectID(),
-            omBucketInfo == null ? 1000 : omBucketInfo.getObjectID(),
-            omBucketInfo == null ? 1000 : omBucketInfo.getObjectID(),
-            keyName, id);
+        volumeInfo == null ? 100 : volumeInfo.getObjectID(),
+        omBucketInfo == null ? 1000 : omBucketInfo.getObjectID(),
+        omBucketInfo == null ? 1000 : omBucketInfo.getObjectID(),
+        keyName, id);
 
   }
 
@@ -190,12 +192,12 @@ public class TestOMKeyCreateRequestWithFSO extends TestOMKeyCreateRequest {
         omMetadataManager.getBucketTable().get(bucketKey);
     if (omBucketInfo != null) {
       final long bucketId = omMetadataManager.getBucketId(volumeName,
-              bucketName);
+          bucketName);
       return omMetadataManager.getOzonePathKey(volumeId, bucketId,
-              omBucketInfo.getObjectID(), keyName);
+          omBucketInfo.getObjectID(), keyName);
     } else {
       return omMetadataManager.getOzonePathKey(volumeId, 1000,
-              1000, keyName);
+          1000, keyName);
     }
   }
 

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMKeyDeleteRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMKeyDeleteRequest.java
@@ -22,8 +22,8 @@ import java.util.UUID;
 
 import org.apache.hadoop.ozone.om.helpers.BucketLayout;
 import org.apache.hadoop.ozone.om.request.OMRequestTestUtils;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
 import org.apache.hadoop.ozone.om.response.OMClientResponse;
@@ -57,7 +57,7 @@ public class TestOMKeyDeleteRequest extends TestOMKeyRequest {
         omMetadataManager.getKeyTable(getBucketLayout()).get(ozoneKey);
 
     // As we added manually to key table.
-    Assert.assertNotNull(omKeyInfo);
+    Assertions.assertNotNull(omKeyInfo);
 
     OMRequest modifiedOmRequest =
             doPreExecute(createDeleteKeyRequest());
@@ -69,13 +69,13 @@ public class TestOMKeyDeleteRequest extends TestOMKeyRequest {
         omKeyDeleteRequest.validateAndUpdateCache(ozoneManager,
         100L, ozoneManagerDoubleBufferHelper);
 
-    Assert.assertEquals(OzoneManagerProtocolProtos.Status.OK,
+    Assertions.assertEquals(OzoneManagerProtocolProtos.Status.OK,
         omClientResponse.getOMResponse().getStatus());
     // Now after calling validateAndUpdateCache, it should be deleted.
 
     omKeyInfo = omMetadataManager.getKeyTable(getBucketLayout()).get(ozoneKey);
 
-    Assert.assertNull(omKeyInfo);
+    Assertions.assertNull(omKeyInfo);
   }
 
   @Test
@@ -96,7 +96,7 @@ public class TestOMKeyDeleteRequest extends TestOMKeyRequest {
         omKeyDeleteRequest.validateAndUpdateCache(ozoneManager,
             100L, ozoneManagerDoubleBufferHelper);
 
-    Assert.assertEquals(OzoneManagerProtocolProtos.Status.KEY_NOT_FOUND,
+    Assertions.assertEquals(OzoneManagerProtocolProtos.Status.KEY_NOT_FOUND,
         omClientResponse.getOMResponse().getStatus());
   }
 
@@ -112,7 +112,7 @@ public class TestOMKeyDeleteRequest extends TestOMKeyRequest {
         .validateAndUpdateCache(ozoneManager, 100L,
             ozoneManagerDoubleBufferHelper);
 
-    Assert.assertEquals(OzoneManagerProtocolProtos.Status.VOLUME_NOT_FOUND,
+    Assertions.assertEquals(OzoneManagerProtocolProtos.Status.VOLUME_NOT_FOUND,
         omClientResponse.getOMResponse().getStatus());
   }
 
@@ -130,7 +130,7 @@ public class TestOMKeyDeleteRequest extends TestOMKeyRequest {
         .validateAndUpdateCache(ozoneManager, 100L,
             ozoneManagerDoubleBufferHelper);
 
-    Assert.assertEquals(OzoneManagerProtocolProtos.Status.BUCKET_NOT_FOUND,
+    Assertions.assertEquals(OzoneManagerProtocolProtos.Status.BUCKET_NOT_FOUND,
             omClientResponse.getOMResponse().getStatus());
   }
 
@@ -148,7 +148,7 @@ public class TestOMKeyDeleteRequest extends TestOMKeyRequest {
     OMRequest modifiedOmRequest = omKeyDeleteRequest.preExecute(ozoneManager);
 
     // Will not be equal, as UserInfo will be set.
-    Assert.assertNotEquals(originalOmRequest, modifiedOmRequest);
+    Assertions.assertNotEquals(originalOmRequest, modifiedOmRequest);
 
     return modifiedOmRequest;
   }

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMKeyDeleteRequestWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMKeyDeleteRequestWithFSO.java
@@ -28,8 +28,8 @@ import org.apache.hadoop.ozone.om.request.OMRequestTestUtils;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMRequest;
 import org.apache.hadoop.ozone.security.acl.OzonePrefixPath;
 import org.apache.hadoop.util.Time;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.util.Iterator;
@@ -110,24 +110,25 @@ public class TestOMKeyDeleteRequestWithFSO extends TestOMKeyDeleteRequest {
         omMetadataManager.getKeyTable(getBucketLayout()).get(ozoneKey);
 
     // As we added manually to key table.
-    Assert.assertNotNull(omKeyInfo);
+    Assertions.assertNotNull(omKeyInfo);
 
     // OzonePrefixPathImpl on a directory
     OzonePrefixPathImpl ozonePrefixPath = new OzonePrefixPathImpl(volumeName,
         bucketName, "c", keyManager);
     OzoneFileStatus status = ozonePrefixPath.getOzoneFileStatus();
-    Assert.assertNotNull(status);
-    Assert.assertEquals("c", status.getTrimmedName());
-    Assert.assertTrue(status.isDirectory());
+    Assertions.assertNotNull(status);
+    Assertions.assertEquals("c", status.getTrimmedName());
+    Assertions.assertTrue(status.isDirectory());
     verifyPath(ozonePrefixPath, "c", "c/d");
     verifyPath(ozonePrefixPath, "c/d", "c/d/e");
     verifyPath(ozonePrefixPath, "c/d/e", "c/d/e/file1");
 
     try {
       ozonePrefixPath.getChildren("c/d/e/file1");
-      Assert.fail("Should throw INVALID_KEY_NAME as the given path is a file.");
+      Assertions.fail("Should throw INVALID_KEY_NAME as the given " +
+          "path is a file.");
     } catch (OMException ome) {
-      Assert.assertEquals(OMException.ResultCodes.INVALID_KEY_NAME,
+      Assertions.assertEquals(OMException.ResultCodes.INVALID_KEY_NAME,
           ome.getResult());
     }
 
@@ -135,10 +136,10 @@ public class TestOMKeyDeleteRequestWithFSO extends TestOMKeyDeleteRequest {
     ozonePrefixPath = new OzonePrefixPathImpl(volumeName,
         bucketName, "c/d/e/file1", keyManager);
     status = ozonePrefixPath.getOzoneFileStatus();
-    Assert.assertNotNull(status);
-    Assert.assertEquals("c/d/e/file1", status.getTrimmedName());
-    Assert.assertEquals("c/d/e/file1", status.getKeyInfo().getKeyName());
-    Assert.assertTrue(status.isFile());
+    Assertions.assertNotNull(status);
+    Assertions.assertEquals("c/d/e/file1", status.getTrimmedName());
+    Assertions.assertEquals("c/d/e/file1", status.getKeyInfo().getKeyName());
+    Assertions.assertTrue(status.isFile());
   }
 
   private void verifyPath(OzonePrefixPath ozonePrefixPath, String pathName,
@@ -146,11 +147,11 @@ public class TestOMKeyDeleteRequestWithFSO extends TestOMKeyDeleteRequest {
       throws IOException {
     Iterator<? extends OzoneFileStatus> pathItr = ozonePrefixPath.getChildren(
         pathName);
-    Assert.assertTrue("Failed to list keyPaths", pathItr.hasNext());
-    Assert.assertEquals(expectedPath, pathItr.next().getTrimmedName());
+    Assertions.assertTrue(pathItr.hasNext(), "Failed to list keyPaths");
+    Assertions.assertEquals(expectedPath, pathItr.next().getTrimmedName());
     try {
       pathItr.next();
-      Assert.fail("Reached end of the list!");
+      Assertions.fail("Reached end of the list!");
     } catch (NoSuchElementException nse) {
       // expected
     }
@@ -174,7 +175,7 @@ public class TestOMKeyDeleteRequestWithFSO extends TestOMKeyDeleteRequest {
 
     // 'x/y/z' has no sub-directories or sub files - recursive access check
     // should not be enabled for this case.
-    Assert.assertFalse(pathViewer.isCheckRecursiveAccess());
+    Assertions.assertFalse(pathViewer.isCheckRecursiveAccess());
 
     // Instantiate PrefixPath for parent key.
     pathViewer = new OzonePrefixPathImpl(volumeName,
@@ -182,7 +183,7 @@ public class TestOMKeyDeleteRequestWithFSO extends TestOMKeyDeleteRequest {
 
     // 'x/y/' has a sub-directory 'z', hence, we should be performing recursive
     // access check.
-    Assert.assertTrue(pathViewer.isCheckRecursiveAccess());
+    Assertions.assertTrue(pathViewer.isCheckRecursiveAccess());
 
     // Case 2:
     // We create a directory structure with a file as the leaf node.
@@ -193,7 +194,7 @@ public class TestOMKeyDeleteRequestWithFSO extends TestOMKeyDeleteRequest {
         omMetadataManager.getKeyTable(getBucketLayout()).get(ozoneKey);
 
     // As we added manually to key table.
-    Assert.assertNotNull(omKeyInfo);
+    Assertions.assertNotNull(omKeyInfo);
 
     // Instantiate PrefixPath for parent key 'c/d/'.
     pathViewer = new OzonePrefixPathImpl(volumeName,
@@ -201,7 +202,7 @@ public class TestOMKeyDeleteRequestWithFSO extends TestOMKeyDeleteRequest {
 
     // 'c/d' has a sub-directory 'e', hence, we should be performing recursive
     // access check.
-    Assert.assertTrue(pathViewer.isCheckRecursiveAccess());
+    Assertions.assertTrue(pathViewer.isCheckRecursiveAccess());
 
     // Instantiate PrefixPath for complete directory structure (without file).
     pathViewer = new OzonePrefixPathImpl(volumeName,
@@ -209,7 +210,7 @@ public class TestOMKeyDeleteRequestWithFSO extends TestOMKeyDeleteRequest {
 
     // 'c/d/e/' has a 'file1' under it, hence, we should be performing recursive
     // access check.
-    Assert.assertTrue(pathViewer.isCheckRecursiveAccess());
+    Assertions.assertTrue(pathViewer.isCheckRecursiveAccess());
 
     // Instantiate PrefixPath for complete file1.
     pathViewer = new OzonePrefixPathImpl(volumeName,
@@ -217,6 +218,6 @@ public class TestOMKeyDeleteRequestWithFSO extends TestOMKeyDeleteRequest {
 
     // Recursive access check is only enabled for directories, hence should be
     // false for file1.
-    Assert.assertFalse(pathViewer.isCheckRecursiveAccess());
+    Assertions.assertFalse(pathViewer.isCheckRecursiveAccess());
   }
 }

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMKeyPurgeRequestAndResponse.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMKeyPurgeRequestAndResponse.java
@@ -32,8 +32,8 @@ import org.apache.hadoop.ozone.om.request.snapshot.TestOMSnapshotCreateRequest;
 import org.apache.hadoop.ozone.om.response.snapshot.OMSnapshotCreateResponse;
 import org.apache.hadoop.ozone.om.snapshot.ReferenceCounted;
 import org.apache.hadoop.ozone.om.snapshot.SnapshotCache;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import org.apache.hadoop.ozone.om.response.key.OMKeyPurgeResponse;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.DeletedKeys;
@@ -44,7 +44,6 @@ import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.PurgeKe
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.Status;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.Type;
 import org.apache.hadoop.hdds.utils.db.BatchOperation;
-import org.junit.jupiter.api.Assertions;
 
 import static org.apache.hadoop.ozone.om.OmSnapshotManager.getSnapshotPrefix;
 import static org.mockito.ArgumentMatchers.any;
@@ -153,7 +152,7 @@ public class TestOMKeyPurgeRequestAndResponse extends TestOMKeyRequest {
     OMRequest modifiedOmRequest = omKeyPurgeRequest.preExecute(ozoneManager);
 
     // Will not be equal, as UserInfo will be set.
-    Assert.assertNotEquals(originalOmRequest, modifiedOmRequest);
+    Assertions.assertNotEquals(originalOmRequest, modifiedOmRequest);
 
     return modifiedOmRequest;
   }
@@ -165,7 +164,7 @@ public class TestOMKeyPurgeRequestAndResponse extends TestOMKeyRequest {
 
     // The keys should be present in the DeletedKeys table before purging
     for (String deletedKey : deletedKeyNames) {
-      Assert.assertTrue(omMetadataManager.getDeletedTable().isExist(
+      Assertions.assertTrue(omMetadataManager.getDeletedTable().isExist(
           deletedKey));
     }
 
@@ -198,7 +197,7 @@ public class TestOMKeyPurgeRequestAndResponse extends TestOMKeyRequest {
 
     // The keys should not exist in the DeletedKeys table
     for (String deletedKey : deletedKeyNames) {
-      Assert.assertFalse(omMetadataManager.getDeletedTable().isExist(
+      Assertions.assertFalse(omMetadataManager.getDeletedTable().isExist(
           deletedKey));
     }
   }
@@ -211,7 +210,7 @@ public class TestOMKeyPurgeRequestAndResponse extends TestOMKeyRequest {
     SnapshotInfo snapInfo = createSnapshot("snap1");
     // The keys should be not present in the active Db's deletedTable
     for (String deletedKey : deletedKeyNames) {
-      Assert.assertFalse(omMetadataManager.getDeletedTable().isExist(
+      Assertions.assertFalse(omMetadataManager.getDeletedTable().isExist(
           deletedKey));
     }
 
@@ -231,7 +230,7 @@ public class TestOMKeyPurgeRequestAndResponse extends TestOMKeyRequest {
 
     // The keys should be present in the snapshot's deletedTable
     for (String deletedKey : deletedKeyNames) {
-      Assert.assertTrue(omSnapshot.getMetadataManager()
+      Assertions.assertTrue(omSnapshot.getMetadataManager()
           .getDeletedTable().isExist(deletedKey));
     }
 
@@ -265,7 +264,7 @@ public class TestOMKeyPurgeRequestAndResponse extends TestOMKeyRequest {
 
     // The keys should not exist in the DeletedKeys table
     for (String deletedKey : deletedKeyNames) {
-      Assert.assertFalse(omSnapshot.getMetadataManager()
+      Assertions.assertFalse(omSnapshot.getMetadataManager()
           .getDeletedTable().isExist(deletedKey));
     }
 

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMKeyRenameRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMKeyRenameRequest.java
@@ -23,9 +23,9 @@ import java.util.UUID;
 
 import org.apache.hadoop.ozone.om.request.OMRequestTestUtils;
 import org.apache.hadoop.fs.Path;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
 import org.apache.hadoop.ozone.om.response.OMClientResponse;
@@ -47,7 +47,7 @@ public class TestOMKeyRenameRequest extends TestOMKeyRequest {
   protected String toKeyName;
   protected String dbToKey;
 
-  @Before
+  @BeforeEach
   public void createParentKey() throws Exception {
     OMRequestTestUtils.addVolumeAndBucketToDB(volumeName, bucketName,
         omMetadataManager, getBucketLayout());
@@ -76,17 +76,17 @@ public class TestOMKeyRenameRequest extends TestOMKeyRequest {
         omKeyRenameRequest.validateAndUpdateCache(ozoneManager, 100L,
             ozoneManagerDoubleBufferHelper);
 
-    Assert.assertEquals(OzoneManagerProtocolProtos.Status.OK,
+    Assertions.assertEquals(OzoneManagerProtocolProtos.Status.OK,
         omKeyRenameResponse.getOMResponse().getStatus());
 
     // Original key should be deleted, toKey should exist.
-    Assert.assertNull(omMetadataManager.getKeyTable(getBucketLayout())
+    Assertions.assertNull(omMetadataManager.getKeyTable(getBucketLayout())
         .get(dbFromKey));
 
     OmKeyInfo toKeyInfo =
             omMetadataManager.getKeyTable(getBucketLayout()).get(dbToKey);
 
-    Assert.assertNotNull(toKeyInfo);
+    Assertions.assertNotNull(toKeyInfo);
 
     KeyArgs keyArgs = modifiedOmRequest.getRenameKeyRequest().getKeyArgs();
 
@@ -112,7 +112,7 @@ public class TestOMKeyRenameRequest extends TestOMKeyRequest {
         omKeyRenameRequest.validateAndUpdateCache(ozoneManager, 100L,
             ozoneManagerDoubleBufferHelper);
 
-    Assert.assertEquals(OzoneManagerProtocolProtos.Status.KEY_NOT_FOUND,
+    Assertions.assertEquals(OzoneManagerProtocolProtos.Status.KEY_NOT_FOUND,
         omKeyRenameResponse.getOMResponse().getStatus());
   }
 
@@ -128,7 +128,7 @@ public class TestOMKeyRenameRequest extends TestOMKeyRequest {
         omKeyRenameRequest.validateAndUpdateCache(ozoneManager, 100L,
             ozoneManagerDoubleBufferHelper);
 
-    Assert.assertEquals(OzoneManagerProtocolProtos.Status.VOLUME_NOT_FOUND,
+    Assertions.assertEquals(OzoneManagerProtocolProtos.Status.VOLUME_NOT_FOUND,
         omKeyRenameResponse.getOMResponse().getStatus());
   }
 
@@ -147,7 +147,7 @@ public class TestOMKeyRenameRequest extends TestOMKeyRequest {
         omKeyRenameRequest.validateAndUpdateCache(ozoneManager, 100L,
             ozoneManagerDoubleBufferHelper);
 
-    Assert.assertEquals(OzoneManagerProtocolProtos.Status.BUCKET_NOT_FOUND,
+    Assertions.assertEquals(OzoneManagerProtocolProtos.Status.BUCKET_NOT_FOUND,
         omKeyRenameResponse.getOMResponse().getStatus());
   }
 
@@ -171,7 +171,7 @@ public class TestOMKeyRenameRequest extends TestOMKeyRequest {
         omKeyRenameRequest.validateAndUpdateCache(ozoneManager, 100L,
             ozoneManagerDoubleBufferHelper);
 
-    Assert.assertEquals(OzoneManagerProtocolProtos.Status.INVALID_KEY_NAME,
+    Assertions.assertEquals(OzoneManagerProtocolProtos.Status.INVALID_KEY_NAME,
         omKeyRenameResponse.getOMResponse().getStatus());
   }
 
@@ -195,7 +195,7 @@ public class TestOMKeyRenameRequest extends TestOMKeyRequest {
         omKeyRenameRequest.validateAndUpdateCache(ozoneManager, 100L,
             ozoneManagerDoubleBufferHelper);
 
-    Assert.assertEquals(OzoneManagerProtocolProtos.Status.INVALID_KEY_NAME,
+    Assertions.assertEquals(OzoneManagerProtocolProtos.Status.INVALID_KEY_NAME,
         omKeyRenameResponse.getOMResponse().getStatus());
   }
 
@@ -214,9 +214,9 @@ public class TestOMKeyRenameRequest extends TestOMKeyRequest {
 
     // Will not be equal, as UserInfo will be set and modification time is
     // set in KeyArgs.
-    Assert.assertNotEquals(originalOmRequest, modifiedOmRequest);
+    Assertions.assertNotEquals(originalOmRequest, modifiedOmRequest);
 
-    Assert.assertTrue(modifiedOmRequest.getRenameKeyRequest()
+    Assertions.assertTrue(modifiedOmRequest.getRenameKeyRequest()
         .getKeyArgs().getModificationTime() > 0);
 
     return modifiedOmRequest;
@@ -265,6 +265,6 @@ public class TestOMKeyRenameRequest extends TestOMKeyRequest {
     // For new key modification time should be updated.
     OmKeyInfo toKeyInfo =
         omMetadataManager.getKeyTable(getBucketLayout()).get(dbToKey);
-    Assert.assertEquals(except, toKeyInfo.getModificationTime());
+    Assertions.assertEquals(except, toKeyInfo.getModificationTime());
   }
 }

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMKeyRenameRequestWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMKeyRenameRequestWithFSO.java
@@ -34,9 +34,9 @@ import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.KeyArgs
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMRequest;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.RenameKeyRequest;
 import org.apache.hadoop.util.Time;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.util.UUID;
@@ -48,7 +48,7 @@ public class TestOMKeyRenameRequestWithFSO extends TestOMKeyRenameRequest {
   private OmKeyInfo fromKeyParentInfo;
   private OmKeyInfo toKeyParentInfo;
   @Override
-  @Before
+  @BeforeEach
   public void createParentKey() throws Exception {
     OMRequestTestUtils.addVolumeAndBucketToDB(volumeName, bucketName,
         omMetadataManager, getBucketLayout());
@@ -88,7 +88,7 @@ public class TestOMKeyRenameRequestWithFSO extends TestOMKeyRenameRequest {
     OMClientResponse response =
             omKeyRenameRequest.validateAndUpdateCache(ozoneManager, 100L,
             ozoneManagerDoubleBufferHelper);
-    Assert.assertEquals(OzoneManagerProtocolProtos.Status.RENAME_OPEN_FILE,
+    Assertions.assertEquals(OzoneManagerProtocolProtos.Status.RENAME_OPEN_FILE,
         response.getOMResponse().getStatus());
   }
 
@@ -96,7 +96,7 @@ public class TestOMKeyRenameRequestWithFSO extends TestOMKeyRenameRequest {
   @Test
   public void testValidateAndUpdateCacheWithToKeyInvalid() throws Exception {
     String invalidToKeyName = "invalid:";
-    Assert.assertThrows(
+    Assertions.assertThrows(
         OMException.class, () -> doPreExecute(createRenameKeyRequest(
             volumeName, bucketName, fromKeyName, invalidToKeyName)));  }
 
@@ -105,14 +105,14 @@ public class TestOMKeyRenameRequestWithFSO extends TestOMKeyRenameRequest {
     String emptyToKeyName = "";
     OMRequest omRequest = doPreExecute(createRenameKeyRequest(volumeName,
         bucketName, fromKeyName, emptyToKeyName));
-    Assert.assertEquals(omRequest.getRenameKeyRequest().getToKeyName(), "");
+    Assertions.assertEquals(omRequest.getRenameKeyRequest().getToKeyName(), "");
   }
 
   @Override
   @Test
   public void testValidateAndUpdateCacheWithFromKeyInvalid() throws Exception {
     String invalidFromKeyName = "";
-    Assert.assertThrows(
+    Assertions.assertThrows(
         OMException.class, () -> doPreExecute(createRenameKeyRequest(
             volumeName, bucketName, invalidFromKeyName, toKeyName)));
   }
@@ -135,8 +135,8 @@ public class TestOMKeyRenameRequestWithFSO extends TestOMKeyRenameRequest {
         modifiedOmRequest.getRenameKeyRequest().getKeyArgs().getKeyName();
     String expectedSrcKeyName = OmUtils.normalizeKey(toKeyName, false);
     String expectedDstKeyName = OmUtils.normalizeKey(fromKeyName, false);
-    Assert.assertEquals(expectedSrcKeyName, normalizedSrcName);
-    Assert.assertEquals(expectedDstKeyName, normalizedDstName);
+    Assertions.assertEquals(expectedSrcKeyName, normalizedSrcName);
+    Assertions.assertEquals(expectedDstKeyName, normalizedDstName);
   }
 
   /**
@@ -167,9 +167,9 @@ public class TestOMKeyRenameRequestWithFSO extends TestOMKeyRenameRequest {
 
     // Will not be equal, as UserInfo will be set and modification time is
     // set in KeyArgs.
-    Assert.assertNotEquals(originalOmRequest, modifiedOmRequest);
+    Assertions.assertNotEquals(originalOmRequest, modifiedOmRequest);
 
-    Assert.assertTrue(modifiedOmRequest.getRenameKeyRequest()
+    Assertions.assertTrue(modifiedOmRequest.getRenameKeyRequest()
         .getKeyArgs().getModificationTime() > 0);
 
     return modifiedOmRequest;
@@ -213,8 +213,10 @@ public class TestOMKeyRenameRequestWithFSO extends TestOMKeyRenameRequest {
         .getDirectoryTable().get(getDBKeyName(fromKeyParentInfo));
     OmDirectoryInfo updatedToKeyParentInfo = omMetadataManager
         .getDirectoryTable().get(getDBKeyName(toKeyParentInfo));
-    Assert.assertEquals(except, updatedFromKeyParentInfo.getModificationTime());
-    Assert.assertEquals(except, updatedToKeyParentInfo.getModificationTime());
+    Assertions.assertEquals(except,
+        updatedFromKeyParentInfo.getModificationTime());
+    Assertions.assertEquals(except,
+        updatedToKeyParentInfo.getModificationTime());
   }
 
   @Override

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMKeyRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMKeyRequest.java
@@ -18,6 +18,7 @@
 
 package org.apache.hadoop.ozone.om.request.key;
 
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Random;
@@ -48,11 +49,10 @@ import org.apache.hadoop.ozone.security.acl.OzoneNativeAuthorizer;
 import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.ozone.test.GenericTestUtils;
 import org.jetbrains.annotations.NotNull;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.io.TempDir;
 import org.mockito.Mockito;
 
 import org.apache.hadoop.hdds.client.ContainerBlockID;
@@ -89,8 +89,8 @@ import static org.mockito.Mockito.when;
  */
 @SuppressWarnings("visibilitymodifier")
 public class TestOMKeyRequest {
-  @Rule
-  public TemporaryFolder folder = new TemporaryFolder();
+  @TempDir
+  private Path folder;
 
   protected OzoneManager ozoneManager;
   protected KeyManager keyManager;
@@ -126,15 +126,15 @@ public class TestOMKeyRequest {
       });
 
 
-  @Before
+  @BeforeEach
   public void setup() throws Exception {
     ozoneManager = Mockito.mock(OzoneManager.class);
     omMetrics = OMMetrics.create();
     OzoneConfiguration ozoneConfiguration = getOzoneConfiguration();
     ozoneConfiguration.set(OMConfigKeys.OZONE_OM_DB_DIRS,
-        folder.newFolder().getAbsolutePath());
+        folder.toAbsolutePath().toString());
     ozoneConfiguration.set(OzoneConfigKeys.OZONE_METADATA_DIRS,
-        folder.newFolder().getAbsolutePath());
+        folder.toAbsolutePath().toString());
     ozoneConfiguration.setBoolean(OzoneConfigKeys.OZONE_FS_HSYNC_ENABLED, true);
     omMetadataManager = new OmMetadataManagerImpl(ozoneConfiguration,
         ozoneManager);
@@ -260,13 +260,13 @@ public class TestOMKeyRequest {
    */
   protected OmKeyInfo verifyPathInOpenKeyTable(String key, long id,
                                                boolean doAssert)
-          throws Exception {
+      throws Exception {
     String openKey = omMetadataManager.getOpenKey(volumeName, bucketName,
-            key, id);
+        key, id);
     OmKeyInfo omKeyInfo =
         omMetadataManager.getOpenKeyTable(getBucketLayout()).get(openKey);
     if (doAssert) {
-      Assert.assertNotNull("Failed to find key in OpenKeyTable", omKeyInfo);
+      Assertions.assertNotNull(omKeyInfo, "Failed to find key in OpenKeyTable");
     }
     return omKeyInfo;
   }
@@ -275,7 +275,7 @@ public class TestOMKeyRequest {
     return BucketLayout.DEFAULT;
   }
 
-  @After
+  @AfterEach
   public void stop() {
     omMetrics.unRegister();
     Mockito.framework().clearInlineMocks();

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMKeysDeleteRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMKeysDeleteRequest.java
@@ -139,7 +139,7 @@ public class TestOMKeysDeleteRequest extends TestOMKeyRequest {
 
     // Create 10 keys
     String parentDir = "/user";
-    String key = "";
+    String key;
 
 
     for (int i = 0; i < count; i++) {

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMKeysDeleteRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMKeysDeleteRequest.java
@@ -25,8 +25,8 @@ import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.DeleteKeyArgs;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.DeleteKeysRequest;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMRequest;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -60,21 +60,21 @@ public class TestOMKeysDeleteRequest extends TestOMKeyRequest {
         omKeysDeleteRequest.validateAndUpdateCache(ozoneManager, 100L,
             ozoneManagerDoubleBufferHelper);
 
-    Assert.assertTrue(omClientResponse.getOMResponse().getSuccess());
-    Assert.assertEquals(OzoneManagerProtocolProtos.Status.OK,
+    Assertions.assertTrue(omClientResponse.getOMResponse().getSuccess());
+    Assertions.assertEquals(OzoneManagerProtocolProtos.Status.OK,
         omClientResponse.getOMResponse().getStatus());
 
-    Assert.assertTrue(omClientResponse.getOMResponse().getDeleteKeysResponse()
-        .getStatus());
+    Assertions.assertTrue(omClientResponse.getOMResponse()
+        .getDeleteKeysResponse().getStatus());
     DeleteKeyArgs unDeletedKeys =
         omClientResponse.getOMResponse().getDeleteKeysResponse()
             .getUnDeletedKeys();
-    Assert.assertEquals(0,
+    Assertions.assertEquals(0,
         unDeletedKeys.getKeysCount());
 
     // Check all keys are deleted.
     for (String deleteKey : deleteKeyList) {
-      Assert.assertNull(omMetadataManager.getKeyTable(getBucketLayout())
+      Assertions.assertNull(omMetadataManager.getKeyTable(getBucketLayout())
           .get(omMetadataManager.getOzoneKey(volumeName, bucketName,
               deleteKey)));
     }
@@ -104,25 +104,25 @@ public class TestOMKeysDeleteRequest extends TestOMKeyRequest {
         omKeysDeleteRequest.validateAndUpdateCache(ozoneManager, 100L,
         ozoneManagerDoubleBufferHelper);
 
-    Assert.assertFalse(omClientResponse.getOMResponse().getSuccess());
-    Assert.assertEquals(PARTIAL_DELETE,
+    Assertions.assertFalse(omClientResponse.getOMResponse().getSuccess());
+    Assertions.assertEquals(PARTIAL_DELETE,
         omClientResponse.getOMResponse().getStatus());
 
-    Assert.assertFalse(omClientResponse.getOMResponse().getDeleteKeysResponse()
-        .getStatus());
+    Assertions.assertFalse(omClientResponse.getOMResponse()
+        .getDeleteKeysResponse().getStatus());
 
     // Check keys are deleted and in response check unDeletedKey.
     for (String deleteKey : deleteKeyList) {
-      Assert.assertNull(omMetadataManager.getKeyTable(getBucketLayout())
+      Assertions.assertNull(omMetadataManager.getKeyTable(getBucketLayout())
           .get(omMetadataManager.getOzoneKey(volumeName, bucketName,
               deleteKey)));
     }
 
     DeleteKeyArgs unDeletedKeys = omClientResponse.getOMResponse()
         .getDeleteKeysResponse().getUnDeletedKeys();
-    Assert.assertEquals(1,
+    Assertions.assertEquals(1,
         unDeletedKeys.getKeysCount());
-    Assert.assertEquals("dummy", unDeletedKeys.getKeys(0));
+    Assertions.assertEquals("dummy", unDeletedKeys.getKeys(0));
   }
 
   protected void createPreRequisites() throws Exception {

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMKeysDeleteRequestWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMKeysDeleteRequestWithFSO.java
@@ -23,6 +23,7 @@ import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
 import org.apache.hadoop.ozone.om.request.OMRequestTestUtils;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos;
 import org.apache.hadoop.util.Time;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.UUID;
@@ -35,6 +36,7 @@ import static org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.
 public class TestOMKeysDeleteRequestWithFSO extends TestOMKeysDeleteRequest {
 
   @Override
+  @Test
   public void testKeysDeleteRequest() throws Exception {
 
     createPreRequisites();
@@ -46,6 +48,7 @@ public class TestOMKeysDeleteRequestWithFSO extends TestOMKeysDeleteRequest {
   }
 
   @Override
+  @Test
   public void testKeysDeleteRequestFail() throws Exception {
     createPreRequisites();
     setOmRequest(getOmRequest().toBuilder().setDeleteKeysRequest(

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMKeysRenameRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMKeysRenameRequest.java
@@ -27,8 +27,8 @@ import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMReque
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.RenameKeysArgs;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.RenameKeysMap;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.RenameKeysRequest;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -54,8 +54,8 @@ public class TestOMKeysRenameRequest extends TestOMKeyRequest {
         omKeysRenameRequest.validateAndUpdateCache(ozoneManager, 100L,
             ozoneManagerDoubleBufferHelper);
 
-    Assert.assertTrue(omKeysRenameResponse.getOMResponse().getSuccess());
-    Assert.assertEquals(OzoneManagerProtocolProtos.Status.OK,
+    Assertions.assertTrue(omKeysRenameResponse.getOMResponse().getSuccess());
+    Assertions.assertEquals(OzoneManagerProtocolProtos.Status.OK,
         omKeysRenameResponse.getOMResponse().getStatus());
 
     for (int i = 0; i < count; i++) {
@@ -63,12 +63,12 @@ public class TestOMKeysRenameRequest extends TestOMKeyRequest {
       OmKeyInfo omKeyInfo = omMetadataManager.getKeyTable(getBucketLayout())
           .get(omMetadataManager.getOzoneKey(volumeName, bucketName,
               parentDir.concat("/key" + i)));
-      Assert.assertNull(omKeyInfo);
+      Assertions.assertNull(omKeyInfo);
 
       omKeyInfo = omMetadataManager.getKeyTable(getBucketLayout()).get(
           omMetadataManager.getOzoneKey(volumeName, bucketName,
               parentDir.concat("/newKey" + i)));
-      Assert.assertNotNull(omKeyInfo);
+      Assertions.assertNotNull(omKeyInfo);
     }
 
   }
@@ -84,8 +84,8 @@ public class TestOMKeysRenameRequest extends TestOMKeyRequest {
         omKeysRenameRequest.validateAndUpdateCache(ozoneManager, 100L,
             ozoneManagerDoubleBufferHelper);
 
-    Assert.assertFalse(omKeysRenameResponse.getOMResponse().getSuccess());
-    Assert.assertEquals(OzoneManagerProtocolProtos.Status.PARTIAL_RENAME,
+    Assertions.assertFalse(omKeysRenameResponse.getOMResponse().getSuccess());
+    Assertions.assertEquals(OzoneManagerProtocolProtos.Status.PARTIAL_RENAME,
         omKeysRenameResponse.getOMResponse().getStatus());
 
     // The keys（key0 to key9）can be renamed success.
@@ -94,18 +94,18 @@ public class TestOMKeysRenameRequest extends TestOMKeyRequest {
       OmKeyInfo omKeyInfo = omMetadataManager.getKeyTable(getBucketLayout())
           .get(omMetadataManager.getOzoneKey(volumeName, bucketName,
               parentDir.concat("/key" + i)));
-      Assert.assertNull(omKeyInfo);
+      Assertions.assertNull(omKeyInfo);
 
       omKeyInfo = omMetadataManager.getKeyTable(getBucketLayout()).get(
           omMetadataManager.getOzoneKey(volumeName, bucketName,
               parentDir.concat("/newKey" + i)));
-      Assert.assertNotNull(omKeyInfo);
+      Assertions.assertNotNull(omKeyInfo);
     }
 
     // The key not rename should be in unRenamedKeys.
     RenameKeysMap unRenamedKeys = omKeysRenameResponse.getOMResponse()
         .getRenameKeysResponse().getUnRenamedKeys(0);
-    Assert.assertEquals("testKey", unRenamedKeys.getFromKeyName());
+    Assertions.assertEquals("testKey", unRenamedKeys.getFromKeyName());
   }
 
   /**

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMOpenKeysDeleteRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMOpenKeysDeleteRequest.java
@@ -37,8 +37,7 @@ import org.apache.hadoop.ozone.om.helpers.OzoneFSUtils;
 import org.apache.hadoop.ozone.om.helpers.WithObjectID;
 import org.apache.hadoop.ozone.om.request.OMRequestTestUtils;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
 
 import org.apache.hadoop.ozone.om.response.OMClientResponse;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos
@@ -51,28 +50,18 @@ import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos
     .OpenKeyBucket;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos
     .OMRequest;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
-import org.junit.runners.Parameterized.Parameters;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
-/**
- * Tests OMOpenKeysDeleteRequest.
- */
-@RunWith(Parameterized.class)
 public class TestOMOpenKeysDeleteRequest extends TestOMKeyRequest {
 
-  private final BucketLayout bucketLayout;
-
-  public TestOMOpenKeysDeleteRequest(BucketLayout bucketLayout) {
-    this.bucketLayout = bucketLayout;
-  }
+  private BucketLayout bucketLayout;
 
   @Override
   public BucketLayout getBucketLayout() {
     return bucketLayout;
   }
 
-  @Parameters
   public static Collection<BucketLayout> bucketLayouts() {
     return Arrays.asList(
         BucketLayout.DEFAULT,
@@ -90,8 +79,11 @@ public class TestOMOpenKeysDeleteRequest extends TestOMKeyRequest {
    * the open key table.
    * @throws Exception
    */
-  @Test
-  public void testDeleteOpenKeysNotInTable() throws Exception {
+  @ParameterizedTest
+  @MethodSource("bucketLayouts")
+  public void testDeleteOpenKeysNotInTable(
+      BucketLayout bucketLayout) throws Exception {
+    this.bucketLayout = bucketLayout;
     OMRequestTestUtils.addVolumeAndBucketToDB(volumeName, bucketName,
             omMetadataManager, getBucketLayout());
     List<Pair<Long, OmKeyInfo>> openKeys =
@@ -108,8 +100,11 @@ public class TestOMOpenKeysDeleteRequest extends TestOMKeyRequest {
    * buckets.
    * @throws Exception
    */
-  @Test
-  public void testDeleteSubsetOfOpenKeys() throws Exception {
+  @ParameterizedTest
+  @MethodSource("bucketLayouts")
+  public void testDeleteSubsetOfOpenKeys(
+      BucketLayout bucketLayout) throws Exception {
+    this.bucketLayout = bucketLayout;
     final String volume1 = UUID.randomUUID().toString();
     final String volume2 = UUID.randomUUID().toString();
     final String bucket1 = UUID.randomUUID().toString();
@@ -170,8 +165,11 @@ public class TestOMOpenKeysDeleteRequest extends TestOMKeyRequest {
    * name, but different client IDs.
    * @throws Exception
    */
-  @Test
-  public void testDeleteSameKeyNameDifferentClient() throws Exception {
+  @ParameterizedTest
+  @MethodSource("bucketLayouts")
+  public void testDeleteSameKeyNameDifferentClient(
+      BucketLayout bucketLayout) throws Exception {
+    this.bucketLayout = bucketLayout;
     final String volume = UUID.randomUUID().toString();
     final String bucket = UUID.randomUUID().toString();
     final String key = UUID.randomUUID().toString();
@@ -199,8 +197,11 @@ public class TestOMOpenKeysDeleteRequest extends TestOMKeyRequest {
    *
    * @throws Exception
    */
-  @Test
-  public void testDeleteKeyWithHigherUpdateID() throws Exception {
+  @ParameterizedTest
+  @MethodSource("bucketLayouts")
+  public void testDeleteKeyWithHigherUpdateID(
+      BucketLayout bucketLayout) throws Exception {
+    this.bucketLayout = bucketLayout;
     final String volume = UUID.randomUUID().toString();
     final String bucket = UUID.randomUUID().toString();
 
@@ -249,7 +250,7 @@ public class TestOMOpenKeysDeleteRequest extends TestOMKeyRequest {
         openKeyDeleteRequest.validateAndUpdateCache(ozoneManager,
             transactionId, ozoneManagerDoubleBufferHelper);
 
-    Assert.assertEquals(Status.OK,
+    Assertions.assertEquals(Status.OK,
         omClientResponse.getOMResponse().getStatus());
 
     assertInOpenKeyTable(keysWithHigherUpdateID);
@@ -263,8 +264,10 @@ public class TestOMOpenKeysDeleteRequest extends TestOMKeyRequest {
    * that were submitted for deletion versus those that were actually deleted.
    * @throws Exception
    */
-  @Test
-  public void testMetrics() throws Exception {
+  @ParameterizedTest
+  @MethodSource("bucketLayouts")
+  public void testMetrics(BucketLayout bucketLayout) throws Exception {
+    this.bucketLayout = bucketLayout;
     final String volume = UUID.randomUUID().toString();
     final String bucket = UUID.randomUUID().toString();
     final String key = UUID.randomUUID().toString();
@@ -275,10 +278,10 @@ public class TestOMOpenKeysDeleteRequest extends TestOMKeyRequest {
             omMetadataManager, getBucketLayout());
 
     OMMetrics metrics = ozoneManager.getMetrics();
-    Assert.assertEquals(metrics.getNumOpenKeyDeleteRequests(), 0);
-    Assert.assertEquals(metrics.getNumOpenKeyDeleteRequestFails(), 0);
-    Assert.assertEquals(metrics.getNumOpenKeysSubmittedForDeletion(), 0);
-    Assert.assertEquals(metrics.getNumOpenKeysDeleted(), 0);
+    Assertions.assertEquals(metrics.getNumOpenKeyDeleteRequests(), 0);
+    Assertions.assertEquals(metrics.getNumOpenKeyDeleteRequestFails(), 0);
+    Assertions.assertEquals(metrics.getNumOpenKeysSubmittedForDeletion(), 0);
+    Assertions.assertEquals(metrics.getNumOpenKeysDeleted(), 0);
 
     List<Pair<Long, OmKeyInfo>> existentKeys =
         makeOpenKeys(volume, bucket, key, numExistentKeys);
@@ -291,11 +294,11 @@ public class TestOMOpenKeysDeleteRequest extends TestOMKeyRequest {
     assertNotInOpenKeyTable(existentKeys);
     assertNotInOpenKeyTable(nonExistentKeys);
 
-    Assert.assertEquals(1, metrics.getNumOpenKeyDeleteRequests());
-    Assert.assertEquals(0, metrics.getNumOpenKeyDeleteRequestFails());
-    Assert.assertEquals(numExistentKeys + numNonExistentKeys,
+    Assertions.assertEquals(1, metrics.getNumOpenKeyDeleteRequests());
+    Assertions.assertEquals(0, metrics.getNumOpenKeyDeleteRequestFails());
+    Assertions.assertEquals(numExistentKeys + numNonExistentKeys,
         metrics.getNumOpenKeysSubmittedForDeletion());
-    Assert.assertEquals(numExistentKeys, metrics.getNumOpenKeysDeleted());
+    Assertions.assertEquals(numExistentKeys, metrics.getNumOpenKeysDeleted());
   }
 
   /**
@@ -326,7 +329,7 @@ public class TestOMOpenKeysDeleteRequest extends TestOMKeyRequest {
         openKeyDeleteRequest.validateAndUpdateCache(ozoneManager,
             100L, ozoneManagerDoubleBufferHelper);
 
-    Assert.assertEquals(Status.OK,
+    Assertions.assertEquals(Status.OK,
         omClientResponse.getOMResponse().getStatus());
   }
 
@@ -415,7 +418,7 @@ public class TestOMOpenKeysDeleteRequest extends TestOMKeyRequest {
       throws Exception {
 
     for (String keyName : getDBKeyNames(openKeys)) {
-      Assert.assertTrue(omMetadataManager.getOpenKeyTable(getBucketLayout())
+      Assertions.assertTrue(omMetadataManager.getOpenKeyTable(getBucketLayout())
           .isExist(keyName));
     }
   }
@@ -432,8 +435,8 @@ public class TestOMOpenKeysDeleteRequest extends TestOMKeyRequest {
       throws Exception {
 
     for (String keyName : getDBKeyNames(openKeys)) {
-      Assert.assertFalse(omMetadataManager.getOpenKeyTable(getBucketLayout())
-          .isExist(keyName));
+      Assertions.assertFalse(omMetadataManager.getOpenKeyTable(
+          getBucketLayout()).isExist(keyName));
     }
   }
 
@@ -477,7 +480,7 @@ public class TestOMOpenKeysDeleteRequest extends TestOMKeyRequest {
         omOpenKeysDeleteRequest.preExecute(ozoneManager);
 
     // Will not be equal, as UserInfo will be set.
-    Assert.assertNotEquals(originalOmRequest, modifiedOmRequest);
+    Assertions.assertNotEquals(originalOmRequest, modifiedOmRequest);
 
     return modifiedOmRequest;
   }

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMOpenKeysDeleteRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMOpenKeysDeleteRequest.java
@@ -53,6 +53,9 @@ import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
+/**
+ * This class tests the OM Open Keys Delete Request.
+ */
 public class TestOMOpenKeysDeleteRequest extends TestOMKeyRequest {
 
   private BucketLayout bucketLayout;
@@ -82,8 +85,8 @@ public class TestOMOpenKeysDeleteRequest extends TestOMKeyRequest {
   @ParameterizedTest
   @MethodSource("bucketLayouts")
   public void testDeleteOpenKeysNotInTable(
-      BucketLayout bucketLayout) throws Exception {
-    this.bucketLayout = bucketLayout;
+      BucketLayout buckLayout) throws Exception {
+    this.bucketLayout = buckLayout;
     OMRequestTestUtils.addVolumeAndBucketToDB(volumeName, bucketName,
             omMetadataManager, getBucketLayout());
     List<Pair<Long, OmKeyInfo>> openKeys =
@@ -103,8 +106,8 @@ public class TestOMOpenKeysDeleteRequest extends TestOMKeyRequest {
   @ParameterizedTest
   @MethodSource("bucketLayouts")
   public void testDeleteSubsetOfOpenKeys(
-      BucketLayout bucketLayout) throws Exception {
-    this.bucketLayout = bucketLayout;
+      BucketLayout buckLayout) throws Exception {
+    this.bucketLayout = buckLayout;
     final String volume1 = UUID.randomUUID().toString();
     final String volume2 = UUID.randomUUID().toString();
     final String bucket1 = UUID.randomUUID().toString();
@@ -168,8 +171,8 @@ public class TestOMOpenKeysDeleteRequest extends TestOMKeyRequest {
   @ParameterizedTest
   @MethodSource("bucketLayouts")
   public void testDeleteSameKeyNameDifferentClient(
-      BucketLayout bucketLayout) throws Exception {
-    this.bucketLayout = bucketLayout;
+      BucketLayout buckLayout) throws Exception {
+    this.bucketLayout = buckLayout;
     final String volume = UUID.randomUUID().toString();
     final String bucket = UUID.randomUUID().toString();
     final String key = UUID.randomUUID().toString();
@@ -200,8 +203,8 @@ public class TestOMOpenKeysDeleteRequest extends TestOMKeyRequest {
   @ParameterizedTest
   @MethodSource("bucketLayouts")
   public void testDeleteKeyWithHigherUpdateID(
-      BucketLayout bucketLayout) throws Exception {
-    this.bucketLayout = bucketLayout;
+      BucketLayout buckLayout) throws Exception {
+    this.bucketLayout = buckLayout;
     final String volume = UUID.randomUUID().toString();
     final String bucket = UUID.randomUUID().toString();
 
@@ -266,8 +269,8 @@ public class TestOMOpenKeysDeleteRequest extends TestOMKeyRequest {
    */
   @ParameterizedTest
   @MethodSource("bucketLayouts")
-  public void testMetrics(BucketLayout bucketLayout) throws Exception {
-    this.bucketLayout = bucketLayout;
+  public void testMetrics(BucketLayout buckLayout) throws Exception {
+    this.bucketLayout = buckLayout;
     final String volume = UUID.randomUUID().toString();
     final String bucket = UUID.randomUUID().toString();
     final String key = UUID.randomUUID().toString();

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMPrefixAclRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMPrefixAclRequest.java
@@ -30,8 +30,8 @@ import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.AddAclR
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMRequest;
 import org.apache.hadoop.ozone.security.acl.OzoneObj;
 import org.apache.hadoop.ozone.security.acl.OzoneObjInfo;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import static org.mockito.Mockito.when;
 
@@ -65,7 +65,7 @@ public class TestOMPrefixAclRequest extends TestOMKeyRequest {
     OMClientResponse omClientResponse = omKeyPrefixAclRequest
         .validateAndUpdateCache(ozoneManager, 2,
             ozoneManagerDoubleBufferHelper);
-    Assert.assertEquals(OzoneManagerProtocolProtos.Status.OK,
+    Assertions.assertEquals(OzoneManagerProtocolProtos.Status.OK,
         omClientResponse.getOMResponse().getStatus());
   }
 
@@ -100,7 +100,7 @@ public class TestOMPrefixAclRequest extends TestOMKeyRequest {
     OMClientResponse omClientResponse1 = omPrefixRemoveAclRequest1
         .validateAndUpdateCache(ozoneManager, 3,
             ozoneManagerDoubleBufferHelper);
-    Assert.assertEquals(OzoneManagerProtocolProtos.Status.OK,
+    Assertions.assertEquals(OzoneManagerProtocolProtos.Status.OK,
         omClientResponse1.getOMResponse().getStatus());
 
     // Remove non-existing prefix acl.
@@ -111,7 +111,7 @@ public class TestOMPrefixAclRequest extends TestOMKeyRequest {
     OMClientResponse omClientResponse2 = omPrefixRemoveAclRequest2
         .validateAndUpdateCache(ozoneManager, 4,
             ozoneManagerDoubleBufferHelper);
-    Assert.assertEquals(OzoneManagerProtocolProtos.Status.PREFIX_NOT_FOUND,
+    Assertions.assertEquals(OzoneManagerProtocolProtos.Status.PREFIX_NOT_FOUND,
         omClientResponse2.getOMResponse().getStatus());
   }
 

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMSetTimesRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMSetTimesRequest.java
@@ -20,8 +20,8 @@ package org.apache.hadoop.ozone.om.request.key;
 import java.io.IOException;
 import java.util.UUID;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import org.apache.hadoop.ozone.om.request.OMRequestTestUtils;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos;
@@ -51,14 +51,14 @@ public class TestOMSetTimesRequest extends TestOMKeyRequest {
     long keyMtime =
         omMetadataManager.getKeyTable(getBucketLayout()).get(ozoneKey)
             .getModificationTime();
-    Assert.assertEquals(mtime, keyMtime);
+    Assertions.assertEquals(mtime, keyMtime);
 
     long newMtime = -1;
     executeAndReturn(newMtime);
     keyMtime =
         omMetadataManager.getKeyTable(getBucketLayout()).get(ozoneKey)
             .getModificationTime();
-    Assert.assertEquals(mtime, keyMtime);
+    Assertions.assertEquals(mtime, keyMtime);
   }
 
   protected void executeAndReturn(long mtime)
@@ -74,8 +74,8 @@ public class TestOMSetTimesRequest extends TestOMKeyRequest {
         .validateAndUpdateCache(ozoneManager, 100L,
             ozoneManagerDoubleBufferHelper);
     OMResponse omSetTimesResponse = omClientResponse.getOMResponse();
-    Assert.assertNotNull(omSetTimesResponse.getSetTimesResponse());
-    Assert.assertEquals(OzoneManagerProtocolProtos.Status.OK,
+    Assertions.assertNotNull(omSetTimesResponse.getSetTimesResponse());
+    Assertions.assertEquals(OzoneManagerProtocolProtos.Status.OK,
         omSetTimesResponse.getStatus());
   }
 

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMSetTimesRequestWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMSetTimesRequestWithFSO.java
@@ -17,8 +17,8 @@
  */
 package org.apache.hadoop.ozone.om.request.key;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.ozone.om.helpers.BucketLayout;
@@ -29,8 +29,8 @@ import org.apache.hadoop.ozone.om.request.file.OMFileRequest;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMRequest;
 import org.apache.hadoop.util.Time;
 
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Test cases for TestOMSetTimesRequestWithFSO.
@@ -59,7 +59,7 @@ public class TestOMSetTimesRequestWithFSO extends TestOMSetTimesRequest {
     assertNotNull(keyStatus);
     assertTrue(keyStatus.isDirectory());
     long keyMtime = keyStatus.getKeyInfo().getModificationTime();
-    Assert.assertEquals(mtime, keyMtime);
+    Assertions.assertEquals(mtime, keyMtime);
 
     long newMtime = -1;
     executeAndReturn(newMtime);
@@ -69,7 +69,7 @@ public class TestOMSetTimesRequestWithFSO extends TestOMSetTimesRequest {
     assertNotNull(keyStatus);
     assertTrue(keyStatus.isDirectory());
     keyMtime = keyStatus.getKeyInfo().getModificationTime();
-    Assert.assertEquals(mtime, keyMtime);
+    Assertions.assertEquals(mtime, keyMtime);
   }
 
   /**
@@ -91,19 +91,19 @@ public class TestOMSetTimesRequestWithFSO extends TestOMSetTimesRequest {
     assertTrue(keyStatus.isFile());
     OmKeyInfo omKeyInfo = omMetadataManager.getKeyTable(getBucketLayout())
         .get(tableKey);
-    Assert.assertEquals(omKeyInfo.getKeyName(), FILE_NAME);
+    Assertions.assertEquals(omKeyInfo.getKeyName(), FILE_NAME);
     long keyMtime = keyStatus.getKeyInfo().getModificationTime();
-    Assert.assertEquals(mtime, keyMtime);
+    Assertions.assertEquals(mtime, keyMtime);
     long newMtime = -1;
     executeAndReturn(newMtime);
     keyStatus = OMFileRequest.getOMKeyInfoIfExists(
         omMetadataManager, volumeName, bucketName, keyName, 0,
         ozoneManager.getDefaultReplicationConfig());
     omKeyInfo = omMetadataManager.getKeyTable(getBucketLayout()).get(tableKey);
-    Assert.assertEquals(omKeyInfo.getKeyName(), FILE_NAME);
+    Assertions.assertEquals(omKeyInfo.getKeyName(), FILE_NAME);
     assertTrue(keyStatus.isFile());
     keyMtime = keyStatus.getKeyInfo().getModificationTime();
-    Assert.assertEquals(mtime, keyMtime);
+    Assertions.assertEquals(mtime, keyMtime);
   }
 
   protected String addKeyToTable() throws Exception {

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/s3/multipart/TestS3ExpiredMultipartUploadsAbortRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/s3/multipart/TestS3ExpiredMultipartUploadsAbortRequest.java
@@ -89,8 +89,8 @@ public class TestS3ExpiredMultipartUploadsAbortRequest
   @ParameterizedTest
   @MethodSource("bucketLayouts")
   public void testAbortMPUsNotInTable(
-      BucketLayout bucketLayout) throws Exception {
-    this.bucketLayout = bucketLayout;
+      BucketLayout buckLayout) throws Exception {
+    this.bucketLayout = buckLayout;
     final String volumeName = UUID.randomUUID().toString();
     final String bucketName = UUID.randomUUID().toString();
 
@@ -111,8 +111,8 @@ public class TestS3ExpiredMultipartUploadsAbortRequest
   @ParameterizedTest
   @MethodSource("bucketLayouts")
   public void testAbortSubsetOfMPUs(
-      BucketLayout bucketLayout) throws Exception {
-    this.bucketLayout = bucketLayout;
+      BucketLayout buckLayout) throws Exception {
+    this.bucketLayout = buckLayout;
     final String volume1 = UUID.randomUUID().toString();
     final String volume2 = UUID.randomUUID().toString();
     final String bucket1 = UUID.randomUUID().toString();
@@ -164,8 +164,8 @@ public class TestS3ExpiredMultipartUploadsAbortRequest
   @ParameterizedTest
   @MethodSource("bucketLayouts")
   public void testAbortMPUsWithHigherUpdateID(
-      BucketLayout bucketLayout) throws Exception {
-    this.bucketLayout = bucketLayout;
+      BucketLayout buckLayout) throws Exception {
+    this.bucketLayout = buckLayout;
     final String volumeName = UUID.randomUUID().toString();
     final String bucketName = UUID.randomUUID().toString();
 
@@ -241,8 +241,8 @@ public class TestS3ExpiredMultipartUploadsAbortRequest
    */
   @ParameterizedTest
   @MethodSource("bucketLayouts")
-  public void testAbortOrphanMPUs(BucketLayout bucketLayout) throws Exception {
-    this.bucketLayout = bucketLayout;
+  public void testAbortOrphanMPUs(BucketLayout buckLayout) throws Exception {
+    this.bucketLayout = buckLayout;
     final String volumeName = UUID.randomUUID().toString();
     final String bucketName = UUID.randomUUID().toString();
 
@@ -268,8 +268,8 @@ public class TestS3ExpiredMultipartUploadsAbortRequest
    */
   @ParameterizedTest
   @MethodSource("bucketLayouts")
-  public void testMetrics(BucketLayout bucketLayout) throws Exception {
-    this.bucketLayout = bucketLayout;
+  public void testMetrics(BucketLayout buckLayout) throws Exception {
+    this.bucketLayout = buckLayout;
     final String volume = UUID.randomUUID().toString();
     final String bucket = UUID.randomUUID().toString();
     final String key = UUID.randomUUID().toString();

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/s3/multipart/TestS3ExpiredMultipartUploadsAbortRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/s3/multipart/TestS3ExpiredMultipartUploadsAbortRequest.java
@@ -451,8 +451,8 @@ public class TestS3ExpiredMultipartUploadsAbortRequest
           .validateAndUpdateCache(ozoneManager, trxnLogIndex,
               ozoneManagerDoubleBufferHelper);
 
-      Assertions.assertTrue(omClientResponse.getOMResponse().getStatus() ==
-          OzoneManagerProtocolProtos.Status.OK);
+      Assertions.assertSame(omClientResponse.getOMResponse().getStatus(),
+          Status.OK);
 
       trxnLogIndex++;
 
@@ -494,8 +494,8 @@ public class TestS3ExpiredMultipartUploadsAbortRequest
                 ozoneManager, trxnLogIndex, ozoneManagerDoubleBufferHelper);
         trxnLogIndex++;
 
-        Assertions.assertTrue(commitResponse.getOMResponse().getStatus() ==
-            OzoneManagerProtocolProtos.Status.OK);
+        Assertions.assertSame(commitResponse.getOMResponse().getStatus(),
+            Status.OK);
 
         // MPU part open key should be deleted after commit
         String partKey = omMetadataManager.getOpenFileName(volumeId, bucketId,
@@ -534,8 +534,8 @@ public class TestS3ExpiredMultipartUploadsAbortRequest
           .validateAndUpdateCache(ozoneManager, trxnLogIndex,
               ozoneManagerDoubleBufferHelper);
 
-      Assertions.assertTrue(omClientResponse.getOMResponse().getStatus() ==
-          OzoneManagerProtocolProtos.Status.OK);
+      Assertions.assertSame(omClientResponse.getOMResponse().getStatus(),
+          Status.OK);
 
       trxnLogIndex++;
 
@@ -573,8 +573,8 @@ public class TestS3ExpiredMultipartUploadsAbortRequest
                 ozoneManager, trxnLogIndex, ozoneManagerDoubleBufferHelper);
         trxnLogIndex++;
 
-        Assertions.assertTrue(commitResponse.getOMResponse().getStatus() ==
-            OzoneManagerProtocolProtos.Status.OK);
+        Assertions.assertSame(commitResponse.getOMResponse().getStatus(),
+            Status.OK);
 
         // MPU part open key should be deleted after commit
         String partKey = omMetadataManager.getOpenKey(volume, bucket, keyName,

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/s3/multipart/TestS3ExpiredMultipartUploadsAbortRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/s3/multipart/TestS3ExpiredMultipartUploadsAbortRequest.java
@@ -45,11 +45,9 @@ import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.Expired
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.MultipartUploadsExpiredAbortRequest;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMRequest;
 import org.apache.hadoop.util.Time;
-import org.junit.Assert;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
-import org.junit.runners.Parameterized.Parameters;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -62,22 +60,16 @@ import java.util.stream.Collectors;
 /**
  * Tests S3ExpiredMultipartUploadsAbortRequest.
  */
-@RunWith(Parameterized.class)
 public class TestS3ExpiredMultipartUploadsAbortRequest
     extends TestS3MultipartRequest {
 
-  private final BucketLayout bucketLayout;
-
-  public TestS3ExpiredMultipartUploadsAbortRequest(BucketLayout bucketLayout) {
-    this.bucketLayout = bucketLayout;
-  }
+  private BucketLayout bucketLayout;
 
   @Override
   public BucketLayout getBucketLayout() {
     return bucketLayout;
   }
 
-  @Parameters
   public static Collection<BucketLayout> bucketLayouts() {
     return Arrays.asList(
         BucketLayout.DEFAULT,
@@ -94,8 +86,11 @@ public class TestS3ExpiredMultipartUploadsAbortRequest
    * but before the request can process them, those MPUs are
    * completed/aborted and therefore removed from the multipartInfoTable.
    */
-  @Test
-  public void testAbortMPUsNotInTable() throws Exception {
+  @ParameterizedTest
+  @MethodSource("bucketLayouts")
+  public void testAbortMPUsNotInTable(
+      BucketLayout bucketLayout) throws Exception {
+    this.bucketLayout = bucketLayout;
     final String volumeName = UUID.randomUUID().toString();
     final String bucketName = UUID.randomUUID().toString();
 
@@ -113,8 +108,11 @@ public class TestS3ExpiredMultipartUploadsAbortRequest
    * Mixes which MPUs will be kept and deleted among different volumes and
    * buckets.
    */
-  @Test
-  public void testAbortSubsetOfMPUs() throws Exception {
+  @ParameterizedTest
+  @MethodSource("bucketLayouts")
+  public void testAbortSubsetOfMPUs(
+      BucketLayout bucketLayout) throws Exception {
+    this.bucketLayout = bucketLayout;
     final String volume1 = UUID.randomUUID().toString();
     final String volume2 = UUID.randomUUID().toString();
     final String bucket1 = UUID.randomUUID().toString();
@@ -163,8 +161,11 @@ public class TestS3ExpiredMultipartUploadsAbortRequest
    *
    * @throws Exception
    */
-  @Test
-  public void testAbortMPUsWithHigherUpdateID() throws Exception {
+  @ParameterizedTest
+  @MethodSource("bucketLayouts")
+  public void testAbortMPUsWithHigherUpdateID(
+      BucketLayout bucketLayout) throws Exception {
+    this.bucketLayout = bucketLayout;
     final String volumeName = UUID.randomUUID().toString();
     final String bucketName = UUID.randomUUID().toString();
 
@@ -222,7 +223,7 @@ public class TestS3ExpiredMultipartUploadsAbortRequest
         expiredMultipartUploadsAbortRequest.validateAndUpdateCache(ozoneManager,
             transactionId, ozoneManagerDoubleBufferHelper);
 
-    Assert.assertEquals(Status.OK,
+    Assertions.assertEquals(Status.OK,
         omClientResponse.getOMResponse().getStatus());
 
     assertInMultipartInfoTable(Collections.singletonList(
@@ -238,8 +239,10 @@ public class TestS3ExpiredMultipartUploadsAbortRequest
    * should fail if the MPU open key doesn't exist in MPU table,
    * aborting expired orphan MPUs should not fail.
    */
-  @Test
-  public void testAbortOrphanMPUs() throws Exception {
+  @ParameterizedTest
+  @MethodSource("bucketLayouts")
+  public void testAbortOrphanMPUs(BucketLayout bucketLayout) throws Exception {
+    this.bucketLayout = bucketLayout;
     final String volumeName = UUID.randomUUID().toString();
     final String bucketName = UUID.randomUUID().toString();
 
@@ -263,8 +266,10 @@ public class TestS3ExpiredMultipartUploadsAbortRequest
    * deleted.
    * @throws Exception
    */
-  @Test
-  public void testMetrics() throws Exception {
+  @ParameterizedTest
+  @MethodSource("bucketLayouts")
+  public void testMetrics(BucketLayout bucketLayout) throws Exception {
+    this.bucketLayout = bucketLayout;
     final String volume = UUID.randomUUID().toString();
     final String bucket = UUID.randomUUID().toString();
     final String key = UUID.randomUUID().toString();
@@ -277,11 +282,11 @@ public class TestS3ExpiredMultipartUploadsAbortRequest
     final int numParts = 5;
 
     OMMetrics metrics = ozoneManager.getMetrics();
-    Assert.assertEquals(0, metrics.getNumExpiredMPUAbortRequests());
-    Assert.assertEquals(0, metrics.getNumOpenKeyDeleteRequestFails());
-    Assert.assertEquals(0, metrics.getNumExpiredMPUSubmittedForAbort());
-    Assert.assertEquals(0, metrics.getNumExpiredMPUPartsAborted());
-    Assert.assertEquals(0, metrics.getNumExpiredMPUAbortRequestFails());
+    Assertions.assertEquals(0, metrics.getNumExpiredMPUAbortRequests());
+    Assertions.assertEquals(0, metrics.getNumOpenKeyDeleteRequestFails());
+    Assertions.assertEquals(0, metrics.getNumExpiredMPUSubmittedForAbort());
+    Assertions.assertEquals(0, metrics.getNumExpiredMPUPartsAborted());
+    Assertions.assertEquals(0, metrics.getNumExpiredMPUAbortRequestFails());
 
     List<String> existentMPUs =
         createMPUs(volume, bucket, key, numExistentMPUs, numParts,
@@ -295,14 +300,14 @@ public class TestS3ExpiredMultipartUploadsAbortRequest
     assertNotInMultipartInfoTable(existentMPUs);
     assertNotInMultipartInfoTable(nonExistentMPUs);
 
-    Assert.assertEquals(1, metrics.getNumExpiredMPUAbortRequests());
-    Assert.assertEquals(0,
+    Assertions.assertEquals(1, metrics.getNumExpiredMPUAbortRequests());
+    Assertions.assertEquals(0,
         metrics.getNumExpiredMPUAbortRequestFails());
-    Assert.assertEquals(numExistentMPUs + numNonExistentMPUs,
+    Assertions.assertEquals(numExistentMPUs + numNonExistentMPUs,
         metrics.getNumExpiredMPUSubmittedForAbort());
-    Assert.assertEquals(numExistentMPUs,
+    Assertions.assertEquals(numExistentMPUs,
         metrics.getNumExpiredMPUAborted());
-    Assert.assertEquals(numExistentMPUs * numParts,
+    Assertions.assertEquals(numExistentMPUs * numParts,
         metrics.getNumExpiredMPUPartsAborted());
   }
 
@@ -321,7 +326,7 @@ public class TestS3ExpiredMultipartUploadsAbortRequest
         expiredMultipartUploadsAbortRequest.preExecute(ozoneManager);
 
     // Will not be equal, as UserInfo will be set.
-    Assert.assertNotEquals(originalOMRequest, modifiedOmRequest);
+    Assertions.assertNotEquals(originalOMRequest, modifiedOmRequest);
 
     return modifiedOmRequest;
   }
@@ -355,7 +360,7 @@ public class TestS3ExpiredMultipartUploadsAbortRequest
         expiredMultipartUploadsAbortRequest.validateAndUpdateCache(
             ozoneManager, 100L, ozoneManagerDoubleBufferHelper);
 
-    Assert.assertEquals(Status.OK,
+    Assertions.assertEquals(Status.OK,
         omClientResponse.getOMResponse().getStatus());
   }
 
@@ -446,7 +451,7 @@ public class TestS3ExpiredMultipartUploadsAbortRequest
           .validateAndUpdateCache(ozoneManager, trxnLogIndex,
               ozoneManagerDoubleBufferHelper);
 
-      Assert.assertTrue(omClientResponse.getOMResponse().getStatus() ==
+      Assertions.assertTrue(omClientResponse.getOMResponse().getStatus() ==
           OzoneManagerProtocolProtos.Status.OK);
 
       trxnLogIndex++;
@@ -460,8 +465,8 @@ public class TestS3ExpiredMultipartUploadsAbortRequest
       String mpuOpenKey = OMMultipartUploadUtils
           .getMultipartOpenKey(volume, bucket, keyName, multipartUploadID,
               omMetadataManager, getBucketLayout());
-      Assert.assertNotNull(omMetadataManager.getOpenKeyTable(getBucketLayout())
-          .get(mpuOpenKey));
+      Assertions.assertNotNull(omMetadataManager.getOpenKeyTable(
+          getBucketLayout()).get(mpuOpenKey));
 
       mpuKeys.add(mpuKey);
 
@@ -489,13 +494,13 @@ public class TestS3ExpiredMultipartUploadsAbortRequest
                 ozoneManager, trxnLogIndex, ozoneManagerDoubleBufferHelper);
         trxnLogIndex++;
 
-        Assert.assertTrue(commitResponse.getOMResponse().getStatus() ==
+        Assertions.assertTrue(commitResponse.getOMResponse().getStatus() ==
             OzoneManagerProtocolProtos.Status.OK);
 
         // MPU part open key should be deleted after commit
         String partKey = omMetadataManager.getOpenFileName(volumeId, bucketId,
             parentID, fileName, clientID);
-        Assert.assertNull(
+        Assertions.assertNull(
             omMetadataManager.getOpenKeyTable(getBucketLayout()).get(partKey));
       }
     }
@@ -529,7 +534,7 @@ public class TestS3ExpiredMultipartUploadsAbortRequest
           .validateAndUpdateCache(ozoneManager, trxnLogIndex,
               ozoneManagerDoubleBufferHelper);
 
-      Assert.assertTrue(omClientResponse.getOMResponse().getStatus() ==
+      Assertions.assertTrue(omClientResponse.getOMResponse().getStatus() ==
           OzoneManagerProtocolProtos.Status.OK);
 
       trxnLogIndex++;
@@ -543,8 +548,8 @@ public class TestS3ExpiredMultipartUploadsAbortRequest
       String mpuOpenKey = OMMultipartUploadUtils
           .getMultipartOpenKey(volume, bucket, keyName, multipartUploadID,
               omMetadataManager, getBucketLayout());
-      Assert.assertNotNull(omMetadataManager.getOpenKeyTable(getBucketLayout())
-          .get(mpuOpenKey));
+      Assertions.assertNotNull(omMetadataManager.getOpenKeyTable(
+          getBucketLayout()).get(mpuOpenKey));
 
       mpuKeys.add(mpuKey);
 
@@ -568,13 +573,13 @@ public class TestS3ExpiredMultipartUploadsAbortRequest
                 ozoneManager, trxnLogIndex, ozoneManagerDoubleBufferHelper);
         trxnLogIndex++;
 
-        Assert.assertTrue(commitResponse.getOMResponse().getStatus() ==
+        Assertions.assertTrue(commitResponse.getOMResponse().getStatus() ==
             OzoneManagerProtocolProtos.Status.OK);
 
         // MPU part open key should be deleted after commit
         String partKey = omMetadataManager.getOpenKey(volume, bucket, keyName,
             clientID);
-        Assert.assertNull(
+        Assertions.assertNull(
             omMetadataManager.getOpenKeyTable(getBucketLayout()).get(partKey));
       }
     }
@@ -601,7 +606,7 @@ public class TestS3ExpiredMultipartUploadsAbortRequest
   private void assertInMultipartInfoTable(List<String> mpuKeys)
       throws Exception {
     for (String mpuKey: mpuKeys) {
-      Assert.assertTrue(omMetadataManager.getMultipartInfoTable()
+      Assertions.assertTrue(omMetadataManager.getMultipartInfoTable()
           .isExist(mpuKey));
     }
   }
@@ -609,7 +614,7 @@ public class TestS3ExpiredMultipartUploadsAbortRequest
   private void assertNotInMultipartInfoTable(List<String> mpuKeys)
       throws Exception {
     for (String mpuKey: mpuKeys) {
-      Assert.assertFalse(omMetadataManager.getMultipartInfoTable()
+      Assertions.assertFalse(omMetadataManager.getMultipartInfoTable()
           .isExist(mpuKey));
     }
   }
@@ -617,15 +622,15 @@ public class TestS3ExpiredMultipartUploadsAbortRequest
   private void assertNotInOpenKeyTable(List<String> mpuOpenKeys)
       throws Exception {
     for (String mpuOpenKey: mpuOpenKeys) {
-      Assert.assertFalse(omMetadataManager.getOpenKeyTable(getBucketLayout())
-          .isExist(mpuOpenKey));
+      Assertions.assertFalse(omMetadataManager.getOpenKeyTable(
+          getBucketLayout()).isExist(mpuOpenKey));
     }
   }
 
   private void assertInOpenKeyTable(List<String> mpuOpenKeys)
       throws Exception {
     for (String mpuOpenKey: mpuOpenKeys) {
-      Assert.assertTrue(omMetadataManager.getOpenKeyTable(getBucketLayout())
+      Assertions.assertTrue(omMetadataManager.getOpenKeyTable(getBucketLayout())
           .isExist(mpuOpenKey));
     }
   }

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/s3/multipart/TestS3InitiateMultipartUploadRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/s3/multipart/TestS3InitiateMultipartUploadRequest.java
@@ -28,8 +28,8 @@ import org.apache.hadoop.ozone.OzoneAcl;
 import org.apache.hadoop.ozone.om.helpers.OmBucketInfo;
 import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
 import org.apache.hadoop.ozone.om.request.OMRequestTestUtils;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import org.apache.hadoop.ozone.om.response.OMClientResponse;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos;
@@ -68,7 +68,7 @@ public class TestS3InitiateMultipartUploadRequest
         s3InitiateMultipartUploadRequest.validateAndUpdateCache(ozoneManager,
             100L, ozoneManagerDoubleBufferHelper);
 
-    Assert.assertEquals(OzoneManagerProtocolProtos.Status.OK,
+    Assertions.assertEquals(OzoneManagerProtocolProtos.Status.OK,
         omClientResponse.getOMResponse().getStatus());
 
     String multipartKey = getMultipartKey(volumeName, bucketName, keyName,
@@ -78,22 +78,22 @@ public class TestS3InitiateMultipartUploadRequest
     OmKeyInfo openMPUKeyInfo = omMetadataManager
         .getOpenKeyTable(s3InitiateMultipartUploadRequest.getBucketLayout())
         .get(multipartKey);
-    Assert.assertNotNull(openMPUKeyInfo);
-    Assert.assertNotNull(openMPUKeyInfo.getLatestVersionLocations());
-    Assert.assertTrue(openMPUKeyInfo.getLatestVersionLocations()
+    Assertions.assertNotNull(openMPUKeyInfo);
+    Assertions.assertNotNull(openMPUKeyInfo.getLatestVersionLocations());
+    Assertions.assertTrue(openMPUKeyInfo.getLatestVersionLocations()
         .isMultipartKey());
-    Assert.assertNotNull(omMetadataManager.getMultipartInfoTable()
+    Assertions.assertNotNull(omMetadataManager.getMultipartInfoTable()
         .get(multipartKey));
 
-    Assert.assertEquals(modifiedRequest.getInitiateMultiPartUploadRequest()
+    Assertions.assertEquals(modifiedRequest.getInitiateMultiPartUploadRequest()
             .getKeyArgs().getMultipartUploadID(),
         omMetadataManager.getMultipartInfoTable().get(multipartKey)
             .getUploadID());
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         modifiedRequest.getInitiateMultiPartUploadRequest().getKeyArgs()
             .getModificationTime(), openMPUKeyInfo.getModificationTime());
-    Assert.assertEquals(
+    Assertions.assertEquals(
         modifiedRequest.getInitiateMultiPartUploadRequest().getKeyArgs()
             .getModificationTime(), openMPUKeyInfo.getCreationTime());
 
@@ -118,17 +118,17 @@ public class TestS3InitiateMultipartUploadRequest
         s3InitiateMultipartUploadRequest.validateAndUpdateCache(ozoneManager,
             100L, ozoneManagerDoubleBufferHelper);
 
-    Assert.assertEquals(OzoneManagerProtocolProtos.Status.BUCKET_NOT_FOUND,
+    Assertions.assertEquals(OzoneManagerProtocolProtos.Status.BUCKET_NOT_FOUND,
         omClientResponse.getOMResponse().getStatus());
 
     String multipartKey = getMultipartKey(volumeName, bucketName, keyName,
         modifiedRequest.getInitiateMultiPartUploadRequest()
             .getKeyArgs().getMultipartUploadID());
 
-    Assert.assertNull(omMetadataManager
+    Assertions.assertNull(omMetadataManager
         .getOpenKeyTable(s3InitiateMultipartUploadRequest.getBucketLayout())
         .get(multipartKey));
-    Assert.assertNull(omMetadataManager.getMultipartInfoTable()
+    Assertions.assertNull(omMetadataManager.getMultipartInfoTable()
         .get(multipartKey));
   }
 
@@ -148,17 +148,17 @@ public class TestS3InitiateMultipartUploadRequest
         s3InitiateMultipartUploadRequest.validateAndUpdateCache(ozoneManager,
             100L, ozoneManagerDoubleBufferHelper);
 
-    Assert.assertEquals(OzoneManagerProtocolProtos.Status.VOLUME_NOT_FOUND,
+    Assertions.assertEquals(OzoneManagerProtocolProtos.Status.VOLUME_NOT_FOUND,
         omClientResponse.getOMResponse().getStatus());
 
     String multipartKey = getMultipartKey(volumeName, bucketName, keyName,
         modifiedRequest.getInitiateMultiPartUploadRequest()
             .getKeyArgs().getMultipartUploadID());
 
-    Assert.assertNull(omMetadataManager
+    Assertions.assertNull(omMetadataManager
         .getOpenKeyTable(s3InitiateMultipartUploadRequest.getBucketLayout())
         .get(multipartKey));
-    Assert.assertNull(omMetadataManager.getMultipartInfoTable()
+    Assertions.assertNull(omMetadataManager.getMultipartInfoTable()
         .get(multipartKey));
   }
 
@@ -191,7 +191,7 @@ public class TestS3InitiateMultipartUploadRequest
     String bucketKey = omMetadataManager.getBucketKey(volumeName, bucketName);
     List<OzoneAcl> bucketAcls = omMetadataManager.getBucketTable()
         .get(bucketKey).getAcls();
-    Assert.assertEquals(acls, bucketAcls);
+    Assertions.assertEquals(acls, bucketAcls);
 
     // create file with acls inherited from parent DEFAULT acls
     OMRequest modifiedRequest = doPreExecuteInitiateMPU(volumeName,
@@ -203,7 +203,7 @@ public class TestS3InitiateMultipartUploadRequest
     OMClientResponse omClientResponse =
         s3InitiateMultipartUploadRequest.validateAndUpdateCache(ozoneManager,
             100L, ozoneManagerDoubleBufferHelper);
-    Assert.assertEquals(OzoneManagerProtocolProtos.Status.OK,
+    Assertions.assertEquals(OzoneManagerProtocolProtos.Status.OK,
         omClientResponse.getOMResponse().getStatus());
 
     String multipartKey = getMultipartKey(volumeName, bucketName, keyName,
@@ -235,13 +235,13 @@ public class TestS3InitiateMultipartUploadRequest
 
     // Should inherit parent DEFAULT Acls
     // [user:newUser:rw[DEFAULT], group:newGroup:rwl[DEFAULT]]
-    Assert.assertEquals("Failed to inherit parent DEFAULT acls!",
-        parentDefaultAcl.stream()
+    Assertions.assertEquals(parentDefaultAcl.stream()
             .map(acl -> acl.setAclScope(OzoneAcl.AclScope.ACCESS))
-            .collect(Collectors.toList()), keyAcls);
+            .collect(Collectors.toList()), keyAcls,
+        "Failed to inherit parent DEFAULT acls!");
 
     // Should not inherit parent ACCESS Acls
-    Assert.assertFalse(keyAcls.contains(parentAccessAcl));
+    Assertions.assertFalse(keyAcls.contains(parentAccessAcl));
   }
 
 }

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/s3/multipart/TestS3InitiateMultipartUploadRequestWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/s3/multipart/TestS3InitiateMultipartUploadRequestWithFSO.java
@@ -133,7 +133,7 @@ public class TestS3InitiateMultipartUploadRequestWithFSO
     long parentID = bucketId;
     for (int indx = 0; indx < dirs.size(); indx++) {
       String dirName = dirs.get(indx);
-      String dbKey = "";
+      String dbKey;
       // for index=0, parentID is bucketID
       dbKey = omMetadataManager.getOzonePathKey(volumeId, bucketId,
               parentID, dirName);
@@ -233,7 +233,7 @@ public class TestS3InitiateMultipartUploadRequestWithFSO
     // [user:newUser:rw[DEFAULT], group:newGroup:rwl[DEFAULT]]
     for (int indx = 0; indx < dirs.size(); indx++) {
       String dirName = dirs.get(indx);
-      String dbKey = "";
+      String dbKey;
       // for index=0, parentID is bucketID
       dbKey = omMetadataManager.getOzonePathKey(volumeId, bucketId,
           parentID, dirName);

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/s3/multipart/TestS3InitiateMultipartUploadRequestWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/s3/multipart/TestS3InitiateMultipartUploadRequestWithFSO.java
@@ -29,8 +29,8 @@ import org.apache.hadoop.ozone.om.request.OMRequestTestUtils;
 import org.apache.hadoop.ozone.om.response.OMClientResponse;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMRequest;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -74,7 +74,7 @@ public class TestS3InitiateMultipartUploadRequestWithFSO
                     ozoneManager, 100L,
                     ozoneManagerDoubleBufferHelper);
 
-    Assert.assertEquals(OzoneManagerProtocolProtos.Status.OK,
+    Assertions.assertEquals(OzoneManagerProtocolProtos.Status.OK,
             omClientResponse.getOMResponse().getStatus());
 
     long parentID = verifyDirectoriesInDB(dirs, volumeId, bucketId);
@@ -92,33 +92,35 @@ public class TestS3InitiateMultipartUploadRequestWithFSO
     OmKeyInfo omKeyInfo = omMetadataManager
         .getOpenKeyTable(s3InitiateMultipartUploadReqFSO.getBucketLayout())
         .get(multipartOpenFileKey);
-    Assert.assertNotNull("Failed to find the fileInfo", omKeyInfo);
-    Assert.assertNotNull("Key Location is null!",
-        omKeyInfo.getLatestVersionLocations());
-    Assert.assertTrue("isMultipartKey is false!",
-        omKeyInfo.getLatestVersionLocations().isMultipartKey());
-    Assert.assertEquals("FileName mismatches!", fileName,
-            omKeyInfo.getKeyName());
-    Assert.assertEquals("ParentId mismatches!", parentID,
-            omKeyInfo.getParentObjectID());
+    Assertions.assertNotNull(omKeyInfo, "Failed to find the fileInfo");
+    Assertions.assertNotNull(omKeyInfo.getLatestVersionLocations(),
+        "Key Location is null!");
+    Assertions.assertTrue(
+        omKeyInfo.getLatestVersionLocations().isMultipartKey(),
+        "isMultipartKey is false!");
+    Assertions.assertEquals(fileName, omKeyInfo.getKeyName(),
+        "FileName mismatches!");
+    Assertions.assertEquals(parentID, omKeyInfo.getParentObjectID(),
+        "ParentId mismatches!");
 
     OmMultipartKeyInfo omMultipartKeyInfo = omMetadataManager
             .getMultipartInfoTable().get(multipartFileKey);
-    Assert.assertNotNull("Failed to find the multipartFileInfo",
-            omMultipartKeyInfo);
-    Assert.assertEquals("ParentId mismatches!", parentID,
-            omMultipartKeyInfo.getParentID());
+    Assertions.assertNotNull(omMultipartKeyInfo,
+        "Failed to find the multipartFileInfo");
+    Assertions.assertEquals(parentID,
+            omMultipartKeyInfo.getParentID(),
+        "ParentId mismatches!");
 
-    Assert.assertEquals(modifiedRequest.getInitiateMultiPartUploadRequest()
+    Assertions.assertEquals(modifiedRequest.getInitiateMultiPartUploadRequest()
             .getKeyArgs().getMultipartUploadID(),
         omMultipartKeyInfo
             .getUploadID());
 
-    Assert.assertEquals(modifiedRequest.getInitiateMultiPartUploadRequest()
+    Assertions.assertEquals(modifiedRequest.getInitiateMultiPartUploadRequest()
         .getKeyArgs().getModificationTime(),
         omKeyInfo
         .getModificationTime());
-    Assert.assertEquals(modifiedRequest.getInitiateMultiPartUploadRequest()
+    Assertions.assertEquals(modifiedRequest.getInitiateMultiPartUploadRequest()
             .getKeyArgs().getModificationTime(),
         omKeyInfo
             .getCreationTime());
@@ -137,10 +139,11 @@ public class TestS3InitiateMultipartUploadRequestWithFSO
               parentID, dirName);
       OmDirectoryInfo omDirInfo =
               omMetadataManager.getDirectoryTable().get(dbKey);
-      Assert.assertNotNull("Invalid directory!", omDirInfo);
-      Assert.assertEquals("Invalid directory!", dirName, omDirInfo.getName());
-      Assert.assertEquals("Invalid dir path!",
-              parentID + "/" + dirName, omDirInfo.getPath());
+      Assertions.assertNotNull(omDirInfo, "Invalid directory!");
+      Assertions.assertEquals(dirName, omDirInfo.getName(),
+          "Invalid directory!");
+      Assertions.assertEquals(parentID + "/" + dirName, omDirInfo.getPath(),
+          "Invalid dir path!");
       parentID = omDirInfo.getObjectID();
     }
     return parentID;
@@ -182,7 +185,7 @@ public class TestS3InitiateMultipartUploadRequestWithFSO
     String bucketKey = omMetadataManager.getBucketKey(volumeName, bucketName);
     List<OzoneAcl> bucketAcls = omMetadataManager.getBucketTable()
         .get(bucketKey).getAcls();
-    Assert.assertEquals(acls, bucketAcls);
+    Assertions.assertEquals(acls, bucketAcls);
 
     // create dir with acls inherited from parent DEFAULT acls
     final long volumeId = omMetadataManager.getVolumeId(volumeName);
@@ -209,7 +212,7 @@ public class TestS3InitiateMultipartUploadRequestWithFSO
         .getOpenKeyTable(s3InitiateMultipartUploadReqFSO.getBucketLayout())
         .get(multipartOpenFileKey);
 
-    Assert.assertEquals(OzoneManagerProtocolProtos.Status.OK,
+    Assertions.assertEquals(OzoneManagerProtocolProtos.Status.OK,
         omClientResponse.getOMResponse().getStatus());
 
     verifyKeyInheritAcls(dirs, omKeyInfo, volumeId, bucketId, bucketAcls);
@@ -239,8 +242,8 @@ public class TestS3InitiateMultipartUploadRequestWithFSO
       List<OzoneAcl> omDirAcls = omDirInfo.getAcls();
 
       System.out.println("  subdir acls : " + omDirInfo + " ==> " + omDirAcls);
-      Assert.assertEquals("Failed to inherit parent DEFAULT acls!",
-          expectedInheritAcls, omDirAcls);
+      Assertions.assertEquals(expectedInheritAcls, omDirAcls,
+          "Failed to inherit parent DEFAULT acls!");
 
       parentID = omDirInfo.getObjectID();
       expectedInheritAcls = omDirAcls;
@@ -249,14 +252,14 @@ public class TestS3InitiateMultipartUploadRequestWithFSO
       // [user:newUser:rw[ACCESS], group:newGroup:rwl[ACCESS]]
       if (indx == dirs.size() - 1) {
         // verify file acls
-        Assert.assertEquals(fileInfo.getParentObjectID(),
+        Assertions.assertEquals(fileInfo.getParentObjectID(),
             omDirInfo.getObjectID());
         List<OzoneAcl> fileAcls = fileInfo.getAcls();
         System.out.println("  file acls : " + fileInfo + " ==> " + fileAcls);
-        Assert.assertEquals("Failed to inherit parent DEFAULT acls!",
-            expectedInheritAcls.stream()
+        Assertions.assertEquals(expectedInheritAcls.stream()
                 .map(acl -> acl.setAclScope(OzoneAcl.AclScope.ACCESS))
-                .collect(Collectors.toList()), fileAcls);
+                .collect(Collectors.toList()), fileAcls,
+            "Failed to inherit parent DEFAULT acls!");
       }
     }
   }

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/s3/multipart/TestS3MultipartRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/s3/multipart/TestS3MultipartRequest.java
@@ -20,6 +20,7 @@
 package org.apache.hadoop.ozone.om.request.s3.multipart;
 
 import java.io.IOException;
+import java.nio.file.Path;
 import java.util.List;
 
 import org.apache.hadoop.hdds.client.ReplicationConfig;
@@ -27,11 +28,10 @@ import org.apache.hadoop.ozone.om.helpers.BucketLayout;
 import org.apache.hadoop.ozone.om.request.OMClientRequest;
 import org.apache.hadoop.ozone.om.upgrade.OMLayoutVersionManager;
 import org.apache.hadoop.ozone.security.acl.OzoneNativeAuthorizer;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.io.TempDir;
 import org.mockito.Mockito;
 
 import org.apache.commons.lang3.tuple.Pair;
@@ -64,8 +64,8 @@ import static org.mockito.Mockito.when;
  */
 @SuppressWarnings("visibilitymodifier")
 public class TestS3MultipartRequest {
-  @Rule
-  public TemporaryFolder folder = new TemporaryFolder();
+  @TempDir
+  private Path folder;
 
   protected OzoneManager ozoneManager;
   protected OMMetrics omMetrics;
@@ -79,13 +79,13 @@ public class TestS3MultipartRequest {
       });
 
 
-  @Before
+  @BeforeEach
   public void setup() throws Exception {
     ozoneManager = mock(OzoneManager.class);
     omMetrics = OMMetrics.create();
     OzoneConfiguration ozoneConfiguration = new OzoneConfiguration();
     ozoneConfiguration.set(OMConfigKeys.OZONE_OM_DB_DIRS,
-        folder.newFolder().getAbsolutePath());
+        folder.toAbsolutePath().toString());
     omMetadataManager = new OmMetadataManagerImpl(ozoneConfiguration,
         ozoneManager);
     when(ozoneManager.getMetrics()).thenReturn(omMetrics);
@@ -119,7 +119,7 @@ public class TestS3MultipartRequest {
   }
 
 
-  @After
+  @AfterEach
   public void stop() {
     omMetrics.unRegister();
     Mockito.framework().clearInlineMocks();
@@ -145,11 +145,11 @@ public class TestS3MultipartRequest {
     OMRequest modifiedRequest =
         s3InitiateMultipartUploadRequest.preExecute(ozoneManager);
 
-    Assert.assertNotEquals(omRequest, modifiedRequest);
-    Assert.assertTrue(modifiedRequest.hasInitiateMultiPartUploadRequest());
-    Assert.assertNotNull(modifiedRequest.getInitiateMultiPartUploadRequest()
+    Assertions.assertNotEquals(omRequest, modifiedRequest);
+    Assertions.assertTrue(modifiedRequest.hasInitiateMultiPartUploadRequest());
+    Assertions.assertNotNull(modifiedRequest.getInitiateMultiPartUploadRequest()
         .getKeyArgs().getMultipartUploadID());
-    Assert.assertTrue(modifiedRequest.getInitiateMultiPartUploadRequest()
+    Assertions.assertTrue(modifiedRequest.getInitiateMultiPartUploadRequest()
         .getKeyArgs().getModificationTime() > 0);
 
     return modifiedRequest;
@@ -177,13 +177,13 @@ public class TestS3MultipartRequest {
         OMRequestTestUtils.createCommitPartMPURequest(volumeName, bucketName,
             keyName, clientID, dataSize, multipartUploadID, partNumber);
     S3MultipartUploadCommitPartRequest s3MultipartUploadCommitPartRequest =
-            getS3MultipartUploadCommitReq(omRequest);
+        getS3MultipartUploadCommitReq(omRequest);
 
     OMRequest modifiedRequest =
         s3MultipartUploadCommitPartRequest.preExecute(ozoneManager);
 
     // UserInfo and modification time is set.
-    Assert.assertNotEquals(omRequest, modifiedRequest);
+    Assertions.assertNotEquals(omRequest, modifiedRequest);
 
     return modifiedRequest;
   }
@@ -214,28 +214,28 @@ public class TestS3MultipartRequest {
         s3MultipartUploadAbortRequest.preExecute(ozoneManager);
 
     // UserInfo and modification time is set.
-    Assert.assertNotEquals(omRequest, modifiedRequest);
+    Assertions.assertNotEquals(omRequest, modifiedRequest);
 
     return modifiedRequest;
 
   }
 
-  protected OMRequest doPreExecuteCompleteMPU(String volumeName,
-      String bucketName, String keyName, String multipartUploadID,
-      List<Part> partList) throws IOException {
+  protected OMRequest doPreExecuteCompleteMPU(
+      String volumeName, String bucketName, String keyName,
+      String multipartUploadID, List<Part> partList) throws IOException {
 
     OMRequest omRequest =
         OMRequestTestUtils.createCompleteMPURequest(volumeName, bucketName,
             keyName, multipartUploadID, partList);
 
     S3MultipartUploadCompleteRequest s3MultipartUploadCompleteRequest =
-            getS3MultipartUploadCompleteReq(omRequest);
+        getS3MultipartUploadCompleteReq(omRequest);
 
     OMRequest modifiedRequest =
         s3MultipartUploadCompleteRequest.preExecute(ozoneManager);
 
     // UserInfo and modification time is set.
-    Assert.assertNotEquals(omRequest, modifiedRequest);
+    Assertions.assertNotEquals(omRequest, modifiedRequest);
 
     return modifiedRequest;
 
@@ -253,8 +253,8 @@ public class TestS3MultipartRequest {
   protected OMRequest doPreExecuteInitiateMPUWithFSO(
       String volumeName, String bucketName, String keyName) throws Exception {
     OMRequest omRequest =
-            OMRequestTestUtils.createInitiateMPURequest(volumeName, bucketName,
-                    keyName);
+        OMRequestTestUtils.createInitiateMPURequest(volumeName, bucketName,
+            keyName);
 
     S3InitiateMultipartUploadRequestWithFSO
         s3InitiateMultipartUploadRequestWithFSO =
@@ -262,26 +262,26 @@ public class TestS3MultipartRequest {
             BucketLayout.FILE_SYSTEM_OPTIMIZED);
 
     OMRequest modifiedRequest =
-            s3InitiateMultipartUploadRequestWithFSO.preExecute(ozoneManager);
+        s3InitiateMultipartUploadRequestWithFSO.preExecute(ozoneManager);
 
-    Assert.assertNotEquals(omRequest, modifiedRequest);
-    Assert.assertTrue(modifiedRequest.hasInitiateMultiPartUploadRequest());
-    Assert.assertNotNull(modifiedRequest.getInitiateMultiPartUploadRequest()
-            .getKeyArgs().getMultipartUploadID());
-    Assert.assertTrue(modifiedRequest.getInitiateMultiPartUploadRequest()
-            .getKeyArgs().getModificationTime() > 0);
+    Assertions.assertNotEquals(omRequest, modifiedRequest);
+    Assertions.assertTrue(modifiedRequest.hasInitiateMultiPartUploadRequest());
+    Assertions.assertNotNull(modifiedRequest.getInitiateMultiPartUploadRequest()
+        .getKeyArgs().getMultipartUploadID());
+    Assertions.assertTrue(modifiedRequest.getInitiateMultiPartUploadRequest()
+        .getKeyArgs().getModificationTime() > 0);
 
     return modifiedRequest;
   }
 
   protected S3MultipartUploadCompleteRequest getS3MultipartUploadCompleteReq(
-          OMRequest omRequest) {
+      OMRequest omRequest) {
     return new S3MultipartUploadCompleteRequest(omRequest,
         BucketLayout.DEFAULT);
   }
 
   protected S3MultipartUploadCommitPartRequest getS3MultipartUploadCommitReq(
-          OMRequest omRequest) {
+      OMRequest omRequest) {
     return new S3MultipartUploadCommitPartRequest(omRequest,
         BucketLayout.DEFAULT);
   }

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/s3/multipart/TestS3MultipartUploadAbortRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/s3/multipart/TestS3MultipartUploadAbortRequest.java
@@ -22,8 +22,8 @@ import java.io.IOException;
 import java.util.UUID;
 
 import org.apache.hadoop.ozone.om.request.OMRequestTestUtils;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import org.apache.hadoop.ozone.om.response.OMClientResponse;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos;
@@ -88,11 +88,11 @@ public class TestS3MultipartUploadAbortRequest extends TestS3MultipartRequest {
         keyName, multipartUploadID);
 
     // Check table and response.
-    Assert.assertEquals(OzoneManagerProtocolProtos.Status.OK,
+    Assertions.assertEquals(OzoneManagerProtocolProtos.Status.OK,
         omClientResponse.getOMResponse().getStatus());
-    Assert.assertNull(
+    Assertions.assertNull(
         omMetadataManager.getMultipartInfoTable().get(multipartKey));
-    Assert.assertNull(omMetadataManager
+    Assertions.assertNull(omMetadataManager
         .getOpenKeyTable(s3MultipartUploadAbortRequest.getBucketLayout())
         .get(multipartOpenKey));
 
@@ -121,7 +121,7 @@ public class TestS3MultipartUploadAbortRequest extends TestS3MultipartRequest {
             ozoneManagerDoubleBufferHelper);
 
     // Check table and response.
-    Assert.assertEquals(
+    Assertions.assertEquals(
         OzoneManagerProtocolProtos.Status.NO_SUCH_MULTIPART_UPLOAD_ERROR,
         omClientResponse.getOMResponse().getStatus());
 
@@ -149,7 +149,7 @@ public class TestS3MultipartUploadAbortRequest extends TestS3MultipartRequest {
             ozoneManagerDoubleBufferHelper);
 
     // Check table and response.
-    Assert.assertEquals(
+    Assertions.assertEquals(
         OzoneManagerProtocolProtos.Status.VOLUME_NOT_FOUND,
         omClientResponse.getOMResponse().getStatus());
 
@@ -178,7 +178,7 @@ public class TestS3MultipartUploadAbortRequest extends TestS3MultipartRequest {
             ozoneManagerDoubleBufferHelper);
 
     // Check table and response.
-    Assert.assertEquals(
+    Assertions.assertEquals(
         OzoneManagerProtocolProtos.Status.BUCKET_NOT_FOUND,
         omClientResponse.getOMResponse().getStatus());
 

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/s3/multipart/TestS3MultipartUploadCommitPartRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/s3/multipart/TestS3MultipartUploadCommitPartRequest.java
@@ -28,8 +28,8 @@ import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos
     .OMRequest;
 import org.apache.hadoop.util.Time;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.util.UUID;
@@ -89,7 +89,7 @@ public class TestS3MultipartUploadCommitPartRequest
         2L, ozoneManagerDoubleBufferHelper);
 
 
-    Assert.assertTrue(omClientResponse.getOMResponse().getStatus()
+    Assertions.assertTrue(omClientResponse.getOMResponse().getStatus()
         == OzoneManagerProtocolProtos.Status.OK);
 
     String multipartOpenKey = getMultipartOpenKey(volumeName, bucketName,
@@ -98,21 +98,21 @@ public class TestS3MultipartUploadCommitPartRequest
     String multipartKey = omMetadataManager.getMultipartKey(volumeName,
         bucketName, keyName, multipartUploadID);
 
-    Assert.assertNotNull(
+    Assertions.assertNotNull(
         omMetadataManager.getMultipartInfoTable().get(multipartKey));
-    Assert.assertTrue(omMetadataManager.getMultipartInfoTable()
+    Assertions.assertTrue(omMetadataManager.getMultipartInfoTable()
         .get(multipartKey).getPartKeyInfoMap().size() == 1);
 
     OmKeyInfo mpuOpenKeyInfo = omMetadataManager
         .getOpenKeyTable(s3MultipartUploadCommitPartRequest.getBucketLayout())
         .get(multipartOpenKey);
-    Assert.assertNotNull(mpuOpenKeyInfo);
-    Assert.assertNotNull(mpuOpenKeyInfo.getLatestVersionLocations());
-    Assert.assertTrue(mpuOpenKeyInfo.getLatestVersionLocations()
+    Assertions.assertNotNull(mpuOpenKeyInfo);
+    Assertions.assertNotNull(mpuOpenKeyInfo.getLatestVersionLocations());
+    Assertions.assertTrue(mpuOpenKeyInfo.getLatestVersionLocations()
         .isMultipartKey());
 
     String partKey = getOpenKey(volumeName, bucketName, keyName, clientID);
-    Assert.assertNull(omMetadataManager
+    Assertions.assertNull(omMetadataManager
         .getOpenKeyTable(s3MultipartUploadCommitPartRequest.getBucketLayout())
         .get(partKey));
   }
@@ -145,13 +145,13 @@ public class TestS3MultipartUploadCommitPartRequest
             2L, ozoneManagerDoubleBufferHelper);
 
 
-    Assert.assertTrue(omClientResponse.getOMResponse().getStatus()
+    Assertions.assertTrue(omClientResponse.getOMResponse().getStatus()
         == OzoneManagerProtocolProtos.Status.NO_SUCH_MULTIPART_UPLOAD_ERROR);
 
     String multipartKey = omMetadataManager.getMultipartKey(volumeName,
         bucketName, keyName, multipartUploadID);
 
-    Assert.assertNull(
+    Assertions.assertNull(
         omMetadataManager.getMultipartInfoTable().get(multipartKey));
 
   }
@@ -184,10 +184,10 @@ public class TestS3MultipartUploadCommitPartRequest
             2L, ozoneManagerDoubleBufferHelper);
 
     if (getBucketLayout() == BucketLayout.FILE_SYSTEM_OPTIMIZED) {
-      Assert.assertTrue(omClientResponse.getOMResponse().getStatus()
+      Assertions.assertTrue(omClientResponse.getOMResponse().getStatus()
           == OzoneManagerProtocolProtos.Status.DIRECTORY_NOT_FOUND);
     } else {
-      Assert.assertTrue(omClientResponse.getOMResponse().getStatus()
+      Assertions.assertTrue(omClientResponse.getOMResponse().getStatus()
           == OzoneManagerProtocolProtos.Status.KEY_NOT_FOUND);
     }
 
@@ -220,7 +220,7 @@ public class TestS3MultipartUploadCommitPartRequest
         s3MultipartUploadCommitPartRequest.validateAndUpdateCache(ozoneManager,
             2L, ozoneManagerDoubleBufferHelper);
 
-    Assert.assertTrue(omClientResponse.getOMResponse().getStatus()
+    Assertions.assertTrue(omClientResponse.getOMResponse().getStatus()
         == OzoneManagerProtocolProtos.Status.BUCKET_NOT_FOUND);
 
   }

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/s3/multipart/TestS3MultipartUploadCommitPartRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/s3/multipart/TestS3MultipartUploadCommitPartRequest.java
@@ -89,8 +89,8 @@ public class TestS3MultipartUploadCommitPartRequest
         2L, ozoneManagerDoubleBufferHelper);
 
 
-    Assertions.assertTrue(omClientResponse.getOMResponse().getStatus()
-        == OzoneManagerProtocolProtos.Status.OK);
+    Assertions.assertSame(omClientResponse.getOMResponse().getStatus(),
+        OzoneManagerProtocolProtos.Status.OK);
 
     String multipartOpenKey = getMultipartOpenKey(volumeName, bucketName,
         keyName, multipartUploadID);
@@ -100,8 +100,8 @@ public class TestS3MultipartUploadCommitPartRequest
 
     Assertions.assertNotNull(
         omMetadataManager.getMultipartInfoTable().get(multipartKey));
-    Assertions.assertTrue(omMetadataManager.getMultipartInfoTable()
-        .get(multipartKey).getPartKeyInfoMap().size() == 1);
+    Assertions.assertEquals(1, omMetadataManager.getMultipartInfoTable()
+        .get(multipartKey).getPartKeyInfoMap().size());
 
     OmKeyInfo mpuOpenKeyInfo = omMetadataManager
         .getOpenKeyTable(s3MultipartUploadCommitPartRequest.getBucketLayout())
@@ -145,8 +145,8 @@ public class TestS3MultipartUploadCommitPartRequest
             2L, ozoneManagerDoubleBufferHelper);
 
 
-    Assertions.assertTrue(omClientResponse.getOMResponse().getStatus()
-        == OzoneManagerProtocolProtos.Status.NO_SUCH_MULTIPART_UPLOAD_ERROR);
+    Assertions.assertSame(omClientResponse.getOMResponse().getStatus(),
+        OzoneManagerProtocolProtos.Status.NO_SUCH_MULTIPART_UPLOAD_ERROR);
 
     String multipartKey = omMetadataManager.getMultipartKey(volumeName,
         bucketName, keyName, multipartUploadID);
@@ -184,11 +184,11 @@ public class TestS3MultipartUploadCommitPartRequest
             2L, ozoneManagerDoubleBufferHelper);
 
     if (getBucketLayout() == BucketLayout.FILE_SYSTEM_OPTIMIZED) {
-      Assertions.assertTrue(omClientResponse.getOMResponse().getStatus()
-          == OzoneManagerProtocolProtos.Status.DIRECTORY_NOT_FOUND);
+      Assertions.assertSame(omClientResponse.getOMResponse().getStatus(),
+          OzoneManagerProtocolProtos.Status.DIRECTORY_NOT_FOUND);
     } else {
-      Assertions.assertTrue(omClientResponse.getOMResponse().getStatus()
-          == OzoneManagerProtocolProtos.Status.KEY_NOT_FOUND);
+      Assertions.assertSame(omClientResponse.getOMResponse().getStatus(),
+          OzoneManagerProtocolProtos.Status.KEY_NOT_FOUND);
     }
 
   }
@@ -220,8 +220,8 @@ public class TestS3MultipartUploadCommitPartRequest
         s3MultipartUploadCommitPartRequest.validateAndUpdateCache(ozoneManager,
             2L, ozoneManagerDoubleBufferHelper);
 
-    Assertions.assertTrue(omClientResponse.getOMResponse().getStatus()
-        == OzoneManagerProtocolProtos.Status.BUCKET_NOT_FOUND);
+    Assertions.assertSame(omClientResponse.getOMResponse().getStatus(),
+        OzoneManagerProtocolProtos.Status.BUCKET_NOT_FOUND);
 
   }
 

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/s3/multipart/TestS3MultipartUploadCommitPartRequestWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/s3/multipart/TestS3MultipartUploadCommitPartRequestWithFSO.java
@@ -27,7 +27,7 @@ import org.apache.hadoop.ozone.om.helpers.OzoneFSUtils;
 import org.apache.hadoop.ozone.om.request.OMRequestTestUtils;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMRequest;
 import org.apache.hadoop.util.Time;
-import org.junit.Assert;
+import org.junit.jupiter.api.Assertions;
 
 import java.io.IOException;
 import java.util.UUID;
@@ -110,11 +110,11 @@ public class TestS3MultipartUploadCommitPartRequestWithFSO
     OMRequest modifiedRequest =
             s3InitiateMultipartUploadRequest.preExecute(ozoneManager);
 
-    Assert.assertNotEquals(omRequest, modifiedRequest);
-    Assert.assertTrue(modifiedRequest.hasInitiateMultiPartUploadRequest());
-    Assert.assertNotNull(modifiedRequest.getInitiateMultiPartUploadRequest()
+    Assertions.assertNotEquals(omRequest, modifiedRequest);
+    Assertions.assertTrue(modifiedRequest.hasInitiateMultiPartUploadRequest());
+    Assertions.assertNotNull(modifiedRequest.getInitiateMultiPartUploadRequest()
             .getKeyArgs().getMultipartUploadID());
-    Assert.assertTrue(modifiedRequest.getInitiateMultiPartUploadRequest()
+    Assertions.assertTrue(modifiedRequest.getInitiateMultiPartUploadRequest()
             .getKeyArgs().getModificationTime() > 0);
 
     return modifiedRequest;

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/s3/multipart/TestS3MultipartUploadCompleteRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/s3/multipart/TestS3MultipartUploadCompleteRequest.java
@@ -30,8 +30,8 @@ import org.apache.hadoop.ozone.om.helpers.OmBucketInfo;
 import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
 import org.apache.hadoop.ozone.om.request.OMRequestTestUtils;
 import org.apache.hadoop.ozone.om.helpers.RepeatedOmKeyInfo;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.ozone.om.response.OMClientResponse;
@@ -88,14 +88,14 @@ public class TestS3MultipartUploadCompleteRequest
 
     // deleted key entries count is expected to be 0
     if (count == 0) {
-      Assert.assertTrue(rangeKVs.size() == 0);
+      Assertions.assertTrue(rangeKVs.size() == 0);
       return;
     }
 
-    Assert.assertTrue(rangeKVs.size() >= 1);
+    Assertions.assertTrue(rangeKVs.size() >= 1);
 
     // Count must consider unused parts on commit
-    Assert.assertEquals(count,
+    Assertions.assertEquals(count,
         rangeKVs.get(0).getValue().getOmKeyInfoList().size());
   }
 
@@ -150,30 +150,31 @@ public class TestS3MultipartUploadCompleteRequest
     omClientResponse.checkAndUpdateDB(omMetadataManager, batchOperation);
     omMetadataManager.getStore().commitBatchOperation(batchOperation);
 
-    Assert.assertEquals(OzoneManagerProtocolProtos.Status.OK,
+    Assertions.assertEquals(OzoneManagerProtocolProtos.Status.OK,
         omClientResponse.getOMResponse().getStatus());
 
     String multipartKey = getMultipartKey(volumeName, bucketName, keyName,
             multipartUploadID);
 
-    Assert.assertNull(omMetadataManager
+    Assertions.assertNull(omMetadataManager
         .getOpenKeyTable(s3MultipartUploadCompleteRequest.getBucketLayout())
         .get(multipartKey));
-    Assert.assertNull(
+    Assertions.assertNull(
         omMetadataManager.getMultipartInfoTable().get(multipartKey));
     OmKeyInfo multipartKeyInfo = omMetadataManager
         .getKeyTable(s3MultipartUploadCompleteRequest.getBucketLayout())
         .get(getOzoneDBKey(volumeName, bucketName, keyName));
-    Assert.assertNotNull(multipartKeyInfo);
-    Assert.assertNotNull(multipartKeyInfo.getLatestVersionLocations());
-    Assert.assertTrue(multipartKeyInfo.getLatestVersionLocations()
+    Assertions.assertNotNull(multipartKeyInfo);
+    Assertions.assertNotNull(multipartKeyInfo.getLatestVersionLocations());
+    Assertions.assertTrue(multipartKeyInfo.getLatestVersionLocations()
         .isMultipartKey());
 
     OmBucketInfo omBucketInfo = omMetadataManager.getBucketTable()
         .getCacheValue(new CacheKey<>(
             omMetadataManager.getBucketKey(volumeName, bucketName)))
         .getCacheValue();
-    Assert.assertEquals(getNamespaceCount(), omBucketInfo.getUsedNamespace());
+    Assertions.assertEquals(getNamespaceCount(),
+        omBucketInfo.getUsedNamespace());
     return multipartUploadID;
   }
 
@@ -241,8 +242,8 @@ public class TestS3MultipartUploadCompleteRequest
             s3MultipartUploadCompleteRequest.validateAndUpdateCache(
                     ozoneManager, 3L, ozoneManagerDoubleBufferHelper);
 
-    Assert.assertEquals(OzoneManagerProtocolProtos.Status.INVALID_PART_ORDER,
-            omClientResponse.getOMResponse().getStatus());
+    Assertions.assertEquals(OzoneManagerProtocolProtos.Status
+            .INVALID_PART_ORDER, omClientResponse.getOMResponse().getStatus());
   }
 
   @Test
@@ -263,7 +264,7 @@ public class TestS3MultipartUploadCompleteRequest
         s3MultipartUploadCompleteRequest.validateAndUpdateCache(ozoneManager,
             3L, ozoneManagerDoubleBufferHelper);
 
-    Assert.assertEquals(OzoneManagerProtocolProtos.Status.VOLUME_NOT_FOUND,
+    Assertions.assertEquals(OzoneManagerProtocolProtos.Status.VOLUME_NOT_FOUND,
         omClientResponse.getOMResponse().getStatus());
 
   }
@@ -287,7 +288,7 @@ public class TestS3MultipartUploadCompleteRequest
         s3MultipartUploadCompleteRequest.validateAndUpdateCache(ozoneManager,
             3L, ozoneManagerDoubleBufferHelper);
 
-    Assert.assertEquals(OzoneManagerProtocolProtos.Status.BUCKET_NOT_FOUND,
+    Assertions.assertEquals(OzoneManagerProtocolProtos.Status.BUCKET_NOT_FOUND,
         omClientResponse.getOMResponse().getStatus());
 
   }
@@ -314,7 +315,7 @@ public class TestS3MultipartUploadCompleteRequest
         s3MultipartUploadCompleteRequest.validateAndUpdateCache(ozoneManager,
             3L, ozoneManagerDoubleBufferHelper);
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         OzoneManagerProtocolProtos.Status.NO_SUCH_MULTIPART_UPLOAD_ERROR,
         omClientResponse.getOMResponse().getStatus());
 

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/s3/multipart/TestS3MultipartUploadCompleteRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/s3/multipart/TestS3MultipartUploadCompleteRequest.java
@@ -88,7 +88,7 @@ public class TestS3MultipartUploadCompleteRequest
 
     // deleted key entries count is expected to be 0
     if (count == 0) {
-      Assertions.assertTrue(rangeKVs.size() == 0);
+      Assertions.assertEquals(0, rangeKVs.size());
       return;
     }
 

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/s3/multipart/TestS3MultipartUploadCompleteRequestWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/s3/multipart/TestS3MultipartUploadCompleteRequestWithFSO.java
@@ -27,7 +27,7 @@ import org.apache.hadoop.ozone.om.request.OMRequestTestUtils;
 import org.apache.hadoop.ozone.om.request.file.OMFileRequest;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMRequest;
 import org.apache.hadoop.util.Time;
-import org.junit.Assert;
+import org.junit.jupiter.api.Assertions;
 
 import java.io.IOException;
 import java.nio.file.Path;
@@ -67,7 +67,7 @@ public class TestS3MultipartUploadCompleteRequestWithFSO
       String keyName, long clientID) throws Exception {
     // need to initialize parentID
     String parentDir = OzoneFSUtils.getParentDir(keyName);
-    Assert.assertNotEquals("Parent doesn't exists!", parentDir, keyName);
+    Assertions.assertNotEquals("Parent doesn't exists!", parentDir, keyName);
 
     // add parentDir to dirTable
     long parentID = getParentID(volumeName, bucketName, keyName);

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/s3/security/TestS3GetSecretRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/s3/security/TestS3GetSecretRequest.java
@@ -56,14 +56,14 @@ import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.TenantA
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.Type;
 import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.hadoop.security.authentication.util.KerberosName;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 import java.io.IOException;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.UUID;
 
@@ -82,8 +82,8 @@ import static org.mockito.Mockito.when;
  */
 public class TestS3GetSecretRequest {
 
-  @Rule
-  public TemporaryFolder folder = new TemporaryFolder();
+  @TempDir
+  private Path folder;
 
   private OzoneManager ozoneManager;
   private OMMetrics omMetrics;
@@ -106,7 +106,7 @@ public class TestS3GetSecretRequest {
   private OMMultiTenantManager omMultiTenantManager;
   private Tenant tenant;
 
-  @Before
+  @BeforeEach
   public void setUp() throws Exception {
     KerberosName.setRuleMechanism(DEFAULT_MECHANISM);
     KerberosName.setRules(
@@ -114,10 +114,10 @@ public class TestS3GetSecretRequest {
         "RULE:[1:$1@$0](.*@EXAMPLE.COM)s/@.*//\n" +
         "DEFAULT");
     ugiAlice = UserGroupInformation.createRemoteUser(USER_ALICE);
-    Assert.assertEquals("alice", ugiAlice.getShortUserName());
+    Assertions.assertEquals("alice", ugiAlice.getShortUserName());
 
     ugiCarol = UserGroupInformation.createRemoteUser(USER_CAROL);
-    Assert.assertEquals("carol", ugiCarol.getShortUserName());
+    Assertions.assertEquals("carol", ugiCarol.getShortUserName());
 
     ozoneManager = mock(OzoneManager.class);
 
@@ -130,7 +130,7 @@ public class TestS3GetSecretRequest {
     omMetrics = OMMetrics.create();
     OzoneConfiguration conf = new OzoneConfiguration();
     conf.set(OMConfigKeys.OZONE_OM_DB_DIRS,
-        folder.newFolder().getAbsolutePath());
+        folder.toAbsolutePath().toString());
     // No need to conf.set(OzoneConfigKeys.OZONE_ADMINISTRATORS, ...) here
     //  as we did the trick earlier with mockito.
     OmMetadataManagerImpl omMetadataManager = new OmMetadataManagerImpl(conf,
@@ -172,7 +172,7 @@ public class TestS3GetSecretRequest {
         .thenReturn(Optional.of(ACCESS_ID_BOB));
   }
 
-  @After
+  @AfterEach
   public void tearDown() throws Exception {
     omMetrics.unRegister();
     framework().clearInlineMocks();
@@ -237,14 +237,14 @@ public class TestS3GetSecretRequest {
     S3Secret s3Secret1 = processSuccessSecretRequest(
         USER_ALICE, 1, true);
 
-    Assert.assertNotNull(s3Secret1);
+    Assertions.assertNotNull(s3Secret1);
 
     // 2. Get secret of "alice" (as herself) again.
     s3Secret1 = processSuccessSecretRequest(
         USER_ALICE, 2, false);
 
     // no secret is returned as secret already exists in the DB
-    Assert.assertNull(s3Secret1);
+    Assertions.assertNull(s3Secret1);
   }
 
   @Test
@@ -295,32 +295,32 @@ public class TestS3GetSecretRequest {
         s3GetSecretRequest.validateAndUpdateCache(ozoneManager,
             1, ozoneManagerDoubleBufferHelper);
     // Check response type and cast
-    Assert.assertTrue(omClientResponse1 instanceof S3GetSecretResponse);
+    Assertions.assertTrue(omClientResponse1 instanceof S3GetSecretResponse);
     final S3GetSecretResponse s3GetSecretResponse1 =
         (S3GetSecretResponse) omClientResponse1;
     // Secret is returned the first time
     final S3SecretValue s3SecretValue1 =
         s3GetSecretResponse1.getS3SecretValue();
-    Assert.assertEquals(userPrincipalId, s3SecretValue1.getKerberosID());
+    Assertions.assertEquals(userPrincipalId, s3SecretValue1.getKerberosID());
     final String awsSecret1 = s3SecretValue1.getAwsSecret();
-    Assert.assertNotNull(awsSecret1);
+    Assertions.assertNotNull(awsSecret1);
 
     final GetS3SecretResponse getS3SecretResponse1 =
         s3GetSecretResponse1.getOMResponse().getGetS3SecretResponse();
     // The secret inside should be the same.
     final S3Secret s3Secret2 = getS3SecretResponse1.getS3Secret();
-    Assert.assertEquals(userPrincipalId, s3Secret2.getKerberosID());
+    Assertions.assertEquals(userPrincipalId, s3Secret2.getKerberosID());
 
     // Run validateAndUpdateCache for the second time
     OMClientResponse omClientResponse2 =
         s3GetSecretRequest.validateAndUpdateCache(ozoneManager,
             2, ozoneManagerDoubleBufferHelper);
     // Check response type and cast
-    Assert.assertTrue(omClientResponse2 instanceof S3GetSecretResponse);
+    Assertions.assertTrue(omClientResponse2 instanceof S3GetSecretResponse);
     final S3GetSecretResponse s3GetSecretResponse2 =
         (S3GetSecretResponse) omClientResponse2;
     // no secret is returned as it is the second time
-    Assert.assertNull(s3GetSecretResponse2.getS3SecretValue());
+    Assertions.assertNull(s3GetSecretResponse2.getS3SecretValue());
   }
 
   @Test
@@ -351,12 +351,12 @@ public class TestS3GetSecretRequest {
         omTenantCreateRequest.validateAndUpdateCache(ozoneManager,
             txLogIndex, ozoneManagerDoubleBufferHelper);
     // Check response type and cast
-    Assert.assertTrue(omClientResponse instanceof OMTenantCreateResponse);
+    Assertions.assertTrue(omClientResponse instanceof OMTenantCreateResponse);
     final OMTenantCreateResponse omTenantCreateResponse =
         (OMTenantCreateResponse) omClientResponse;
     // Check response
-    Assert.assertTrue(omTenantCreateResponse.getOMResponse().getSuccess());
-    Assert.assertEquals(TENANT_ID,
+    Assertions.assertTrue(omTenantCreateResponse.getOMResponse().getSuccess());
+    Assertions.assertEquals(TENANT_ID,
         omTenantCreateResponse.getOmDBTenantState().getTenantId());
 
 
@@ -383,23 +383,23 @@ public class TestS3GetSecretRequest {
             txLogIndex, ozoneManagerDoubleBufferHelper);
 
     // Check response type and cast
-    Assert.assertTrue(
+    Assertions.assertTrue(
         omClientResponse instanceof OMTenantAssignUserAccessIdResponse);
     final OMTenantAssignUserAccessIdResponse
         omTenantAssignUserAccessIdResponse =
         (OMTenantAssignUserAccessIdResponse) omClientResponse;
 
     // Check response - successful as secret is created for the first time
-    Assert.assertTrue(omTenantAssignUserAccessIdResponse.getOMResponse()
+    Assertions.assertTrue(omTenantAssignUserAccessIdResponse.getOMResponse()
         .getSuccess());
-    Assert.assertTrue(omTenantAssignUserAccessIdResponse.getOMResponse()
+    Assertions.assertTrue(omTenantAssignUserAccessIdResponse.getOMResponse()
         .hasTenantAssignUserAccessIdResponse());
     final OmDBAccessIdInfo omDBAccessIdInfo =
         omTenantAssignUserAccessIdResponse.getOmDBAccessIdInfo();
-    Assert.assertNotNull(omDBAccessIdInfo);
+    Assertions.assertNotNull(omDBAccessIdInfo);
     final S3SecretValue originalS3Secret =
         omTenantAssignUserAccessIdResponse.getS3Secret();
-    Assert.assertNotNull(originalS3Secret);
+    Assertions.assertNotNull(originalS3Secret);
 
 
     // 3. S3GetSecretRequest: Get secret of "bob@EXAMPLE.COM" (as an admin).
@@ -419,19 +419,19 @@ public class TestS3GetSecretRequest {
             txLogIndex, ozoneManagerDoubleBufferHelper);
 
     // Check response type and cast
-    Assert.assertTrue(omClientResponse instanceof S3GetSecretResponse);
+    Assertions.assertTrue(omClientResponse instanceof S3GetSecretResponse);
     final S3GetSecretResponse s3GetSecretResponse =
         (S3GetSecretResponse) omClientResponse;
 
     // Check response
-    Assert.assertTrue(s3GetSecretResponse.getOMResponse().getSuccess());
+    Assertions.assertTrue(s3GetSecretResponse.getOMResponse().getSuccess());
     /*
        getS3SecretValue() should be null in this case because
        the entry is already inserted to DB in the previous request.
        The entry will get overwritten if it isn't null.
        See {@link S3GetSecretResponse#addToDBBatch}.
      */
-    Assert.assertNull(s3GetSecretResponse.getS3SecretValue());
+    Assertions.assertNull(s3GetSecretResponse.getS3SecretValue());
   }
 
 
@@ -452,7 +452,7 @@ public class TestS3GetSecretRequest {
             txLogIndex, ozoneManagerDoubleBufferHelper);
 
     // Check response type and cast
-    Assert.assertTrue(omClientResponse instanceof S3GetSecretResponse);
+    Assertions.assertTrue(omClientResponse instanceof S3GetSecretResponse);
     final S3GetSecretResponse s3GetSecretResponse =
         (S3GetSecretResponse) omClientResponse;
 
@@ -461,18 +461,18 @@ public class TestS3GetSecretRequest {
       // Check response
       final S3SecretValue s3SecretValue =
           s3GetSecretResponse.getS3SecretValue();
-      Assert.assertEquals(userPrincipalId, s3SecretValue.getKerberosID());
+      Assertions.assertEquals(userPrincipalId, s3SecretValue.getKerberosID());
       final String awsSecret1 = s3SecretValue.getAwsSecret();
-      Assert.assertNotNull(awsSecret1);
+      Assertions.assertNotNull(awsSecret1);
 
       final GetS3SecretResponse getS3SecretResponse =
           s3GetSecretResponse.getOMResponse().getGetS3SecretResponse();
       // The secret inside should be the same.
       final S3Secret s3Secret = getS3SecretResponse.getS3Secret();
-      Assert.assertEquals(userPrincipalId, s3Secret.getKerberosID());
+      Assertions.assertEquals(userPrincipalId, s3Secret.getKerberosID());
       return s3Secret;
     } else {
-      Assert.assertNull(s3GetSecretResponse.getS3SecretValue());
+      Assertions.assertNull(s3GetSecretResponse.getS3SecretValue());
     }
     return null;
 
@@ -485,11 +485,11 @@ public class TestS3GetSecretRequest {
           s3GetSecretRequest(userPrincipalId)
       ).preExecute(ozoneManager);
     } catch (OMException omEx) {
-      Assert.assertEquals(ResultCodes.USER_MISMATCH, omEx.getResult());
+      Assertions.assertEquals(ResultCodes.USER_MISMATCH, omEx.getResult());
       return;
     }
 
-    Assert.fail("Should have thrown OMException because alice should not have "
-        + "the permission to get bob's secret in this test case!");
+    Assertions.fail("Should have thrown OMException because alice should not " +
+        "have the permission to get bob's secret in this test case!");
   }
 }

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/s3/tenant/TestSetRangerServiceVersionRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/s3/tenant/TestSetRangerServiceVersionRequest.java
@@ -28,15 +28,15 @@ import org.apache.hadoop.ozone.om.upgrade.OMLayoutVersionManager;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMRequest;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.SetRangerServiceVersionRequest;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.Type;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 import org.mockito.Mockito;
 
 import java.io.IOException;
+import java.nio.file.Path;
 import java.util.UUID;
 
 /**
@@ -44,15 +44,15 @@ import java.util.UUID;
  */
 public class TestSetRangerServiceVersionRequest {
 
-  @Rule
-  public TemporaryFolder folder = new TemporaryFolder();
+  @TempDir
+  private Path folder;
 
   private OzoneManager ozoneManager;
   // Set ozoneManagerDoubleBuffer to do nothing.
   private final OzoneManagerDoubleBufferHelper ozoneManagerDoubleBufferHelper =
       ((response, transactionIndex) -> null);
 
-  @Before
+  @BeforeEach
   public void setUp() throws Exception {
     ozoneManager = Mockito.mock(OzoneManager.class);
     Mockito.when(ozoneManager.getVersionManager())
@@ -60,12 +60,12 @@ public class TestSetRangerServiceVersionRequest {
 
     final OzoneConfiguration conf = new OzoneConfiguration();
     conf.set(OMConfigKeys.OZONE_OM_DB_DIRS,
-        folder.newFolder().getAbsolutePath());
+        folder.toAbsolutePath().toString());
     Mockito.when(ozoneManager.getMetadataManager())
         .thenReturn(new OmMetadataManagerImpl(conf, ozoneManager));
   }
 
-  @After
+  @AfterEach
   public void tearDown() throws Exception {
     Mockito.framework().clearInlineMocks();
   }
@@ -98,13 +98,13 @@ public class TestSetRangerServiceVersionRequest {
             ozoneManager, txLogIndex, ozoneManagerDoubleBufferHelper);
 
     // Check response type and cast
-    Assert.assertTrue(clientResponse
+    Assertions.assertTrue(clientResponse
         instanceof OMSetRangerServiceVersionResponse);
     final OMSetRangerServiceVersionResponse omSetRangerServiceVersionResponse =
         (OMSetRangerServiceVersionResponse) clientResponse;
 
     // Verify response
     String verStr = omSetRangerServiceVersionResponse.getNewServiceVersion();
-    Assert.assertEquals(10L, Long.parseLong(verStr));
+    Assertions.assertEquals(10L, Long.parseLong(verStr));
   }
 }

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/security/TestOMDelegationTokenRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/security/TestOMDelegationTokenRequest.java
@@ -26,11 +26,13 @@ import org.apache.hadoop.ozone.om.OmMetadataManagerImpl;
 import org.apache.hadoop.ozone.om.OzoneManager;
 import org.apache.hadoop.ozone.om.ratis.utils.OzoneManagerDoubleBufferHelper;
 import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_DB_DIRS;
-import org.junit.Rule;
-import org.junit.Before;
-import org.junit.After;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.io.TempDir;
 import org.mockito.Mockito;
+
+import java.nio.file.Path;
+
 import static org.mockito.Mockito.when;
 
 /**
@@ -39,8 +41,8 @@ import static org.mockito.Mockito.when;
 @SuppressWarnings("visibilitymodifier")
 public class TestOMDelegationTokenRequest {
 
-  @Rule
-  public TemporaryFolder folder = new TemporaryFolder();
+  @TempDir
+  private Path folder;
 
   protected OzoneManager ozoneManager;
   protected OMMetrics omMetrics;
@@ -53,19 +55,19 @@ public class TestOMDelegationTokenRequest {
         return null;
       });
 
-  @Before
+  @BeforeEach
   public void setup() throws Exception {
     ozoneManager = Mockito.mock(OzoneManager.class);
 
     conf = new OzoneConfiguration();
     ((OzoneConfiguration) conf)
-        .set(OZONE_OM_DB_DIRS, folder.newFolder().getAbsolutePath());
+        .set(OZONE_OM_DB_DIRS, folder.toAbsolutePath().toString());
     omMetadataManager = new OmMetadataManagerImpl((OzoneConfiguration) conf,
         ozoneManager);
     when(ozoneManager.getMetadataManager()).thenReturn(omMetadataManager);
   }
 
-  @After
+  @AfterEach
   public void stop() {
     Mockito.framework().clearInlineMocks();
   }

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/security/TestOMGetDelegationTokenRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/security/TestOMGetDelegationTokenRequest.java
@@ -43,9 +43,9 @@ import org.mockito.Mockito;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.when;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * The class tests OMGetDelegationTokenRequest.
@@ -62,7 +62,7 @@ public class TestOMGetDelegationTokenRequest extends
   private OMGetDelegationTokenRequest omGetDelegationTokenRequest;
   private static final String CHECK_RESPONSE = "";
 
-  @Before
+  @BeforeEach
   public void setupGetDelegationToken() throws IOException {
     secretManager = Mockito.mock(OzoneDelegationTokenSecretManager.class);
     when(ozoneManager.getDelegationTokenMgr()).thenReturn(secretManager);
@@ -94,10 +94,10 @@ public class TestOMGetDelegationTokenRequest extends
   }
 
   private void verifyUnchangedRequest() {
-    Assert.assertEquals(
+    Assertions.assertEquals(
         originalRequest.getCmdType(),
         modifiedRequest.getCmdType());
-    Assert.assertEquals(
+    Assertions.assertEquals(
         originalRequest.getClientId(),
         modifiedRequest.getClientId());
   }
@@ -141,16 +141,16 @@ public class TestOMGetDelegationTokenRequest extends
         .getTokenRenewInterval();
     long renewInterval = modifiedRequest.getUpdateGetDelegationTokenRequest()
         .getTokenRenewInterval();
-    Assert.assertNotEquals(originalInterval, renewInterval);
-    Assert.assertEquals(tokenRenewInterval, renewInterval);
+    Assertions.assertNotEquals(originalInterval, renewInterval);
+    Assertions.assertEquals(tokenRenewInterval, renewInterval);
 
     /* In preExecute(), if the token is nonNull
      we set GetDelegationTokenResponse with response. */
-    Assert.assertNotEquals(CHECK_RESPONSE,
+    Assertions.assertNotEquals(CHECK_RESPONSE,
         modifiedRequest.getUpdateGetDelegationTokenRequest()
             .getGetDelegationTokenResponse()
             .toString());
-    Assert.assertNotNull(modifiedRequest
+    Assertions.assertNotNull(modifiedRequest
         .getUpdateGetDelegationTokenRequest()
         .getGetDelegationTokenResponse());
   }
@@ -165,7 +165,7 @@ public class TestOMGetDelegationTokenRequest extends
 
     /* In preExecute(), if the token is null
      we do not set GetDelegationTokenResponse with response. */
-    Assert.assertEquals(CHECK_RESPONSE,
+    Assertions.assertEquals(CHECK_RESPONSE,
         modifiedRequest.getUpdateGetDelegationTokenRequest()
             .getGetDelegationTokenResponse()
             .toString());
@@ -188,9 +188,10 @@ public class TestOMGetDelegationTokenRequest extends
 
     Optional<Long> responseRenewTime = Optional.fromNullable(
         omMetadataManager.getDelegationTokenTable().get(identifier));
-    Assert.assertEquals(Optional.of(renewTime), responseRenewTime);
+    Assertions.assertEquals(Optional.of(renewTime), responseRenewTime);
 
-    Assert.assertEquals(Status.OK, clientResponse.getOMResponse().getStatus());
+    Assertions.assertEquals(Status.OK, clientResponse.getOMResponse()
+        .getStatus());
   }
 
   @Test
@@ -202,13 +203,14 @@ public class TestOMGetDelegationTokenRequest extends
 
     boolean hasResponse = modifiedRequest.getUpdateGetDelegationTokenRequest()
         .getGetDelegationTokenResponse().hasResponse();
-    Assert.assertFalse(hasResponse);
+    Assertions.assertFalse(hasResponse);
 
     Optional<Long> responseRenewTime = Optional.fromNullable(
         omMetadataManager.getDelegationTokenTable().get(identifier));
-    Assert.assertEquals(Optional.absent(), responseRenewTime);
+    Assertions.assertEquals(Optional.absent(), responseRenewTime);
 
-    Assert.assertEquals(Status.OK, clientResponse.getOMResponse().getStatus());
+    Assertions.assertEquals(Status.OK, clientResponse.getOMResponse()
+        .getStatus());
   }
 
   @Test
@@ -222,9 +224,9 @@ public class TestOMGetDelegationTokenRequest extends
 
     boolean hasResponse = modifiedRequest.getUpdateGetDelegationTokenRequest()
         .getGetDelegationTokenResponse().hasResponse();
-    Assert.assertTrue(hasResponse);
+    Assertions.assertTrue(hasResponse);
 
-    Assert.assertNotEquals(Status.OK,
+    Assertions.assertNotEquals(Status.OK,
         clientResponse.getOMResponse().getStatus());
   }
 }

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/upgrade/TestOMCancelPrepareRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/upgrade/TestOMCancelPrepareRequest.java
@@ -24,8 +24,8 @@ import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMRequest;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.Type;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.PrepareStatusResponse.PrepareStatus;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.UUID;
 
@@ -53,21 +53,21 @@ public class TestOMCancelPrepareRequest extends TestOMKeyRequest {
     OzoneManagerPrepareState prepareState = ozoneManager.getPrepareState();
     OzoneManagerPrepareState.State state = prepareState.getState();
 
-    Assert.assertEquals(state.getStatus(), PrepareStatus.PREPARE_COMPLETED);
-    Assert.assertEquals(state.getIndex(), logIndex);
-    Assert.assertTrue(prepareState.getPrepareMarkerFile().exists());
-    Assert.assertFalse(prepareState.requestAllowed(Type.CreateVolume));
+    Assertions.assertEquals(state.getStatus(), PrepareStatus.PREPARE_COMPLETED);
+    Assertions.assertEquals(state.getIndex(), logIndex);
+    Assertions.assertTrue(prepareState.getPrepareMarkerFile().exists());
+    Assertions.assertFalse(prepareState.requestAllowed(Type.CreateVolume));
   }
 
   private void assertNotPrepared() {
     OzoneManagerPrepareState prepareState = ozoneManager.getPrepareState();
     OzoneManagerPrepareState.State state = prepareState.getState();
 
-    Assert.assertEquals(state.getStatus(), PrepareStatus.NOT_PREPARED);
-    Assert.assertEquals(state.getIndex(),
+    Assertions.assertEquals(state.getStatus(), PrepareStatus.NOT_PREPARED);
+    Assertions.assertEquals(state.getIndex(),
         OzoneManagerPrepareState.NO_PREPARE_INDEX);
-    Assert.assertFalse(prepareState.getPrepareMarkerFile().exists());
-    Assert.assertTrue(prepareState.requestAllowed(Type.CreateVolume));
+    Assertions.assertFalse(prepareState.getPrepareMarkerFile().exists());
+    Assertions.assertTrue(prepareState.requestAllowed(Type.CreateVolume));
   }
 
   private void submitCancelPrepareRequest() throws Exception {
@@ -81,7 +81,7 @@ public class TestOMCancelPrepareRequest extends TestOMKeyRequest {
         cancelPrepareRequest.validateAndUpdateCache(ozoneManager,
             LOG_INDEX, ozoneManagerDoubleBufferHelper);
 
-    Assert.assertEquals(OzoneManagerProtocolProtos.Status.OK,
+    Assertions.assertEquals(OzoneManagerProtocolProtos.Status.OK,
         omClientResponse.getOMResponse().getStatus());
   }
 
@@ -93,7 +93,7 @@ public class TestOMCancelPrepareRequest extends TestOMKeyRequest {
         omOpenKeysDeleteRequest.preExecute(ozoneManager);
 
     // Will not be equal, as UserInfo will be set.
-    Assert.assertNotEquals(originalOmRequest, modifiedOmRequest);
+    Assertions.assertNotEquals(originalOmRequest, modifiedOmRequest);
 
     return modifiedOmRequest;
   }

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/validation/TestRequestFeatureValidatorProcessor.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/validation/TestRequestFeatureValidatorProcessor.java
@@ -20,7 +20,7 @@ import com.google.testing.compile.Compilation;
 import com.google.testing.compile.JavaFileObjects;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.Type;
 import org.apache.ozone.annotations.RequestFeatureValidatorProcessor;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.lang.annotation.Annotation;
 import java.lang.annotation.ElementType;
@@ -38,8 +38,8 @@ import static org.apache.ozone.annotations.RequestFeatureValidatorProcessor.ERRO
 import static org.apache.ozone.annotations.RequestFeatureValidatorProcessor.ERROR_VALIDATOR_METHOD_HAS_TO_BE_STATIC;
 import static org.apache.ozone.annotations.RequestFeatureValidatorProcessor.ERROR_VALIDATOR_METHOD_HAS_TO_RETURN_OMREQUEST;
 import static org.apache.ozone.annotations.RequestFeatureValidatorProcessor.ERROR_VALIDATOR_METHOD_HAS_TO_RETURN_OMRESPONSE;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertSame;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
 
 /**
  * Compile tests against the annotation processor for the

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/validation/TestRequestValidations.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/validation/TestRequestValidations.java
@@ -28,10 +28,10 @@ import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMReque
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMResponse;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.Type;
 import org.apache.hadoop.ozone.upgrade.LayoutVersionManager;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -43,7 +43,7 @@ import static org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.
 import static org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.Type.CreateKey;
 import static org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.Type.DeleteKeys;
 import static org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.Type.RenameKey;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -63,33 +63,37 @@ public class TestRequestValidations {
 
   private OMMetadataManager metadataManager;
 
-  @Before
+  @BeforeEach
   public void setup() {
     metadataManager = mock(OMMetadataManager.class);
     startValidatorTest();
     validationListener.attach();
   }
 
-  @After
+  @AfterEach
   public void tearDown() {
     validationListener.detach();
     finishValidatorTest();
   }
 
-  @Test(expected = NullPointerException.class)
+  @Test
   public void testUsingRegistryWithoutLoading() throws Exception {
-    new RequestValidations()
-        .fromPackage(PACKAGE)
-        .withinContext(of(aFinalizedVersionManager(), metadataManager))
-        .validateRequest(aCreateKeyRequest(currentClientVersion()));
+    Assertions.assertThrows(NullPointerException.class, () -> {
+      new RequestValidations()
+          .fromPackage(PACKAGE)
+          .withinContext(of(aFinalizedVersionManager(), metadataManager))
+          .validateRequest(aCreateKeyRequest(currentClientVersion()));
+    });
   }
 
-  @Test(expected = NullPointerException.class)
+  @Test
   public void testUsingRegistryWithoutContext() throws Exception {
-    new RequestValidations()
-        .fromPackage(PACKAGE)
-        .load()
-        .validateRequest(aCreateKeyRequest(currentClientVersion()));
+    Assertions.assertThrows(NullPointerException.class, () -> {
+      new RequestValidations()
+          .fromPackage(PACKAGE)
+          .load()
+          .validateRequest(aCreateKeyRequest(currentClientVersion()));
+    });
   }
 
   @Test
@@ -268,7 +272,7 @@ public class TestRequestValidations {
         .thenReturn(BucketLayout.FILE_SYSTEM_OPTIMIZED);
 
     BucketLayout buckLayout = ctx.getBucketLayout("vol-1", "buck-1");
-    Assert.assertTrue(buckLayout.isFileSystemOptimized());
+    Assertions.assertTrue(buckLayout.isFileSystemOptimized());
   }
 
   private RequestValidations loadValidations(ValidationContext ctx) {

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/validation/TestValidatorRegistry.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/validation/TestValidatorRegistry.java
@@ -16,9 +16,9 @@
  */
 package org.apache.hadoop.ozone.om.request.validation;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.reflections.util.ClasspathHelper;
 
 import java.lang.reflect.Method;
@@ -40,8 +40,8 @@ import static org.apache.hadoop.ozone.om.request.validation.testvalidatorset1.Ge
 import static org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.Type.CreateDirectory;
 import static org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.Type.CreateKey;
 import static org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.Type.CreateVolume;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Validator registry tests.
@@ -58,12 +58,12 @@ public class TestValidatorRegistry {
   private static final String PACKAGE_WO_VALIDATORS =
       "org.apache.hadoop.hdds.annotation";
 
-  @Before
+  @BeforeEach
   public void setup() {
     startValidatorTest();
   }
 
-  @After
+  @AfterEach
   public void tearDown() {
     finishValidatorTest();
   }

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/volume/TestOMVolumeCreateRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/volume/TestOMVolumeCreateRequest.java
@@ -24,8 +24,8 @@ import org.apache.hadoop.ozone.om.exceptions.OMException;
 import org.apache.hadoop.ozone.om.response.volume.OMVolumeCreateResponse;
 import org.apache.hadoop.ozone.storage.proto.OzoneManagerStorageProtos;
 import org.apache.ozone.test.GenericTestUtils;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import org.apache.hadoop.ozone.om.helpers.OmVolumeArgs;
 import org.apache.hadoop.ozone.om.request.OMRequestTestUtils;
@@ -34,8 +34,8 @@ import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMRequest;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.VolumeInfo;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.when;
 
 /**
@@ -77,12 +77,13 @@ public class TestOMVolumeCreateRequest extends TestOMVolumeRequest {
       OMClientResponse omClientResponse =
           omVolumeCreateRequest.validateAndUpdateCache(ozoneManager,
               txLogIndex, ozoneManagerDoubleBufferHelper);
-      Assert.assertTrue(omClientResponse instanceof OMVolumeCreateResponse);
+      Assertions.assertTrue(omClientResponse instanceof OMVolumeCreateResponse);
       OMVolumeCreateResponse respone =
           (OMVolumeCreateResponse) omClientResponse;
-      Assert.assertEquals(expectedObjId, respone.getOmVolumeArgs()
+      Assertions.assertEquals(expectedObjId, respone.getOmVolumeArgs()
           .getObjectID());
-      Assert.assertEquals(txLogIndex, respone.getOmVolumeArgs().getUpdateID());
+      Assertions.assertEquals(txLogIndex,
+          respone.getOmVolumeArgs().getUpdateID());
     } catch (IllegalArgumentException ex) {
       GenericTestUtils.assertExceptionContains("should be greater than zero",
           ex);
@@ -109,8 +110,8 @@ public class TestOMVolumeCreateRequest extends TestOMVolumeRequest {
     // As we have not still called validateAndUpdateCache, get() should
     // return null.
 
-    Assert.assertNull(omMetadataManager.getVolumeTable().get(volumeKey));
-    Assert.assertNull(omMetadataManager.getUserTable().get(ownerKey));
+    Assertions.assertNull(omMetadataManager.getVolumeTable().get(volumeKey));
+    Assertions.assertNull(omMetadataManager.getUserTable().get(ownerKey));
 
     omVolumeCreateRequest = new OMVolumeCreateRequest(modifiedRequest);
     long txLogIndex = 2;
@@ -122,8 +123,8 @@ public class TestOMVolumeCreateRequest extends TestOMVolumeRequest {
 
     OzoneManagerProtocolProtos.OMResponse omResponse =
         omClientResponse.getOMResponse();
-    Assert.assertNotNull(omResponse.getCreateVolumeResponse());
-    Assert.assertEquals(OzoneManagerProtocolProtos.Status.OK,
+    Assertions.assertNotNull(omResponse.getCreateVolumeResponse());
+    Assertions.assertEquals(OzoneManagerProtocolProtos.Status.OK,
         omResponse.getStatus());
 
 
@@ -134,26 +135,28 @@ public class TestOMVolumeCreateRequest extends TestOMVolumeRequest {
     OmVolumeArgs omVolumeArgs =
         omMetadataManager.getVolumeTable().get(volumeKey);
     // As request is valid volume table should not have entry.
-    Assert.assertNotNull(omVolumeArgs);
-    Assert.assertEquals(expectedObjId, omVolumeArgs.getObjectID());
-    Assert.assertEquals(txLogIndex, omVolumeArgs.getUpdateID());
+    Assertions.assertNotNull(omVolumeArgs);
+    Assertions.assertEquals(expectedObjId, omVolumeArgs.getObjectID());
+    Assertions.assertEquals(txLogIndex, omVolumeArgs.getUpdateID());
 
     // Initial modificationTime should be equal to creationTime.
     long creationTime = omVolumeArgs.getCreationTime();
     long modificationTime = omVolumeArgs.getModificationTime();
-    Assert.assertEquals(creationTime, modificationTime);
+    Assertions.assertEquals(creationTime, modificationTime);
 
     // Check data from table and request.
-    Assert.assertEquals(volumeInfo.getVolume(), omVolumeArgs.getVolume());
-    Assert.assertEquals(volumeInfo.getOwnerName(), omVolumeArgs.getOwnerName());
-    Assert.assertEquals(volumeInfo.getAdminName(), omVolumeArgs.getAdminName());
-    Assert.assertEquals(volumeInfo.getCreationTime(),
+    Assertions.assertEquals(volumeInfo.getVolume(), omVolumeArgs.getVolume());
+    Assertions.assertEquals(volumeInfo.getOwnerName(),
+        omVolumeArgs.getOwnerName());
+    Assertions.assertEquals(volumeInfo.getAdminName(),
+        omVolumeArgs.getAdminName());
+    Assertions.assertEquals(volumeInfo.getCreationTime(),
         omVolumeArgs.getCreationTime());
 
     OzoneManagerStorageProtos.PersistedUserVolumeInfo userVolumeInfo =
         omMetadataManager.getUserTable().get(ownerKey);
-    Assert.assertNotNull(userVolumeInfo);
-    Assert.assertEquals(volumeName, userVolumeInfo.getVolumeNames(0));
+    Assertions.assertNotNull(userVolumeInfo);
+    Assertions.assertEquals(volumeName, userVolumeInfo.getVolumeNames(0));
 
     // Create another volume for the user.
     originalRequest = createVolumeRequest("vol1", adminName,
@@ -168,11 +171,11 @@ public class TestOMVolumeCreateRequest extends TestOMVolumeRequest {
         omVolumeCreateRequest.validateAndUpdateCache(ozoneManager, 2L,
             ozoneManagerDoubleBufferHelper);
 
-    Assert.assertEquals(OzoneManagerProtocolProtos.Status.OK,
+    Assertions.assertEquals(OzoneManagerProtocolProtos.Status.OK,
         omClientResponse.getOMResponse().getStatus());
 
-    Assert.assertTrue(omMetadataManager
-        .getUserTable().get(ownerKey).getVolumeNamesList().size() == 2);
+    Assertions.assertEquals(2, omMetadataManager
+        .getUserTable().get(ownerKey).getVolumeNamesList().size());
   }
 
   @Test
@@ -200,12 +203,12 @@ public class TestOMVolumeCreateRequest extends TestOMVolumeRequest {
 
     OzoneManagerProtocolProtos.OMResponse omResponse =
         omClientResponse.getOMResponse();
-    Assert.assertNotNull(omResponse.getCreateVolumeResponse());
-    Assert.assertEquals(OzoneManagerProtocolProtos.Status.VOLUME_ALREADY_EXISTS,
-        omResponse.getStatus());
+    Assertions.assertNotNull(omResponse.getCreateVolumeResponse());
+    Assertions.assertEquals(OzoneManagerProtocolProtos.Status
+            .VOLUME_ALREADY_EXISTS, omResponse.getStatus());
 
     // Check really if we have a volume with the specified volume name.
-    Assert.assertNotNull(omMetadataManager.getVolumeTable().get(
+    Assertions.assertNotNull(omMetadataManager.getVolumeTable().get(
         omMetadataManager.getVolumeKey(volumeName)));
   }
 
@@ -265,10 +268,10 @@ public class TestOMVolumeCreateRequest extends TestOMVolumeRequest {
     OzoneManagerProtocolProtos.OMResponse omResponse =
         omClientResponse.getOMResponse();
 
-    Assert.assertNotNull(omResponse.getCreateVolumeResponse());
-    Assert.assertEquals(OzoneManagerProtocolProtos.Status.OK,
+    Assertions.assertNotNull(omResponse.getCreateVolumeResponse());
+    Assertions.assertEquals(OzoneManagerProtocolProtos.Status.OK,
         omResponse.getStatus());
-    Assert.assertNotNull(omMetadataManager.getVolumeTable().get(
+    Assertions.assertNotNull(omMetadataManager.getVolumeTable().get(
         omMetadataManager.getVolumeKey(volumeName)));
   }
 
@@ -307,13 +310,13 @@ public class TestOMVolumeCreateRequest extends TestOMVolumeRequest {
     VolumeInfo updated = modifiedRequest.getCreateVolumeRequest()
         .getVolumeInfo();
 
-    Assert.assertEquals(original.getAdminName(), updated.getAdminName());
-    Assert.assertEquals(original.getVolume(), updated.getVolume());
-    Assert.assertEquals(original.getOwnerName(),
+    Assertions.assertEquals(original.getAdminName(), updated.getAdminName());
+    Assertions.assertEquals(original.getVolume(), updated.getVolume());
+    Assertions.assertEquals(original.getOwnerName(),
         updated.getOwnerName());
-    Assert.assertNotEquals(original.getCreationTime(),
+    Assertions.assertNotEquals(original.getCreationTime(),
         updated.getCreationTime());
-    Assert.assertNotEquals(original.getModificationTime(),
+    Assertions.assertNotEquals(original.getModificationTime(),
         updated.getModificationTime());
   }
 }

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/volume/TestOMVolumeDeleteRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/volume/TestOMVolumeDeleteRequest.java
@@ -82,8 +82,8 @@ public class TestOMVolumeDeleteRequest extends TestOMVolumeRequest {
     Assertions.assertEquals(OzoneManagerProtocolProtos.Status.OK,
         omResponse.getStatus());
 
-    Assertions.assertTrue(omMetadataManager.getUserTable().get(ownerKey)
-        .getVolumeNamesList().size() == 0);
+    Assertions.assertEquals(0, omMetadataManager.getUserTable().get(ownerKey)
+        .getVolumeNamesList().size());
     // As now volume is deleted, table should not have those entries.
     Assertions.assertNull(omMetadataManager.getVolumeTable().get(volumeKey));
   }

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/volume/TestOMVolumeDeleteRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/volume/TestOMVolumeDeleteRequest.java
@@ -21,8 +21,8 @@ package org.apache.hadoop.ozone.om.request.volume;
 import java.util.UUID;
 
 import org.apache.hadoop.ozone.om.request.OMRequestTestUtils;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import org.apache.hadoop.ozone.om.helpers.OmBucketInfo;
 import org.apache.hadoop.ozone.om.response.OMClientResponse;
@@ -46,7 +46,7 @@ public class TestOMVolumeDeleteRequest extends TestOMVolumeRequest {
         new OMVolumeDeleteRequest(originalRequest);
 
     OMRequest modifiedRequest = omVolumeDeleteRequest.preExecute(ozoneManager);
-    Assert.assertNotEquals(originalRequest, modifiedRequest);
+    Assertions.assertNotEquals(originalRequest, modifiedRequest);
   }
 
   @Test
@@ -69,8 +69,8 @@ public class TestOMVolumeDeleteRequest extends TestOMVolumeRequest {
     String ownerKey = omMetadataManager.getUserKey(ownerName);
 
 
-    Assert.assertNotNull(omMetadataManager.getVolumeTable().get(volumeKey));
-    Assert.assertNotNull(omMetadataManager.getUserTable().get(ownerKey));
+    Assertions.assertNotNull(omMetadataManager.getVolumeTable().get(volumeKey));
+    Assertions.assertNotNull(omMetadataManager.getUserTable().get(ownerKey));
 
     OMClientResponse omClientResponse =
         omVolumeDeleteRequest.validateAndUpdateCache(ozoneManager, 1,
@@ -78,14 +78,14 @@ public class TestOMVolumeDeleteRequest extends TestOMVolumeRequest {
 
     OzoneManagerProtocolProtos.OMResponse omResponse =
         omClientResponse.getOMResponse();
-    Assert.assertNotNull(omResponse.getCreateVolumeResponse());
-    Assert.assertEquals(OzoneManagerProtocolProtos.Status.OK,
+    Assertions.assertNotNull(omResponse.getCreateVolumeResponse());
+    Assertions.assertEquals(OzoneManagerProtocolProtos.Status.OK,
         omResponse.getStatus());
 
-    Assert.assertTrue(omMetadataManager.getUserTable().get(ownerKey)
+    Assertions.assertTrue(omMetadataManager.getUserTable().get(ownerKey)
         .getVolumeNamesList().size() == 0);
     // As now volume is deleted, table should not have those entries.
-    Assert.assertNull(omMetadataManager.getVolumeTable().get(volumeKey));
+    Assertions.assertNull(omMetadataManager.getVolumeTable().get(volumeKey));
   }
 
   @Test
@@ -105,8 +105,8 @@ public class TestOMVolumeDeleteRequest extends TestOMVolumeRequest {
 
     OzoneManagerProtocolProtos.OMResponse omResponse =
         omClientResponse.getOMResponse();
-    Assert.assertNotNull(omResponse.getCreateVolumeResponse());
-    Assert.assertEquals(OzoneManagerProtocolProtos.Status.VOLUME_NOT_FOUND,
+    Assertions.assertNotNull(omResponse.getCreateVolumeResponse());
+    Assertions.assertEquals(OzoneManagerProtocolProtos.Status.VOLUME_NOT_FOUND,
         omResponse.getStatus());
   }
 
@@ -139,8 +139,8 @@ public class TestOMVolumeDeleteRequest extends TestOMVolumeRequest {
 
     OzoneManagerProtocolProtos.OMResponse omResponse =
         omClientResponse.getOMResponse();
-    Assert.assertNotNull(omResponse.getCreateVolumeResponse());
-    Assert.assertEquals(OzoneManagerProtocolProtos.Status.VOLUME_NOT_EMPTY,
+    Assertions.assertNotNull(omResponse.getCreateVolumeResponse());
+    Assertions.assertEquals(OzoneManagerProtocolProtos.Status.VOLUME_NOT_EMPTY,
         omResponse.getStatus());
   }
 

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/volume/TestOMVolumeRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/volume/TestOMVolumeRequest.java
@@ -19,6 +19,7 @@
 
 package org.apache.hadoop.ozone.om.request.volume;
 
+import java.nio.file.Path;
 import java.util.UUID;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.ozone.audit.AuditLogger;
@@ -38,10 +39,9 @@ import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos
     .VolumeInfo;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.io.TempDir;
 import org.mockito.Mockito;
 
 import static org.mockito.ArgumentMatchers.any;
@@ -54,8 +54,8 @@ import static org.mockito.Mockito.when;
 @SuppressWarnings("visibilitymodifier")
 public class TestOMVolumeRequest {
 
-  @Rule
-  public TemporaryFolder folder = new TemporaryFolder();
+  @TempDir
+  private Path folder;
 
   protected OzoneManager ozoneManager;
   protected OMMetrics omMetrics;
@@ -67,13 +67,13 @@ public class TestOMVolumeRequest {
         return null;
       });
 
-  @Before
+  @BeforeEach
   public void setup() throws Exception {
     ozoneManager = mock(OzoneManager.class);
     omMetrics = OMMetrics.create();
     OzoneConfiguration ozoneConfiguration = new OzoneConfiguration();
     ozoneConfiguration.set(OMConfigKeys.OZONE_OM_DB_DIRS,
-        folder.newFolder().getAbsolutePath());
+        folder.toAbsolutePath().toString());
     omMetadataManager = new OmMetadataManagerImpl(ozoneConfiguration,
         ozoneManager);
     when(ozoneManager.getMetrics()).thenReturn(omMetrics);
@@ -88,7 +88,7 @@ public class TestOMVolumeRequest {
     Mockito.doNothing().when(auditLogger).logWrite(any(AuditMessage.class));
   }
 
-  @After
+  @AfterEach
   public void stop() {
     omMetrics.unRegister();
     Mockito.framework().clearInlineMocks();

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/volume/TestOMVolumeSetOwnerRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/volume/TestOMVolumeSetOwnerRequest.java
@@ -117,7 +117,7 @@ public class TestOMVolumeSetOwnerRequest extends TestOMVolumeRequest {
             omMetadataManager.getUserKey(ownerKey));
 
     Assertions.assertNotNull(oldOwnerVolumeList);
-    Assertions.assertTrue(oldOwnerVolumeList.getVolumeNamesList().size() == 0);
+    Assertions.assertEquals(0, oldOwnerVolumeList.getVolumeNamesList().size());
 
   }
 

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/volume/TestOMVolumeSetOwnerRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/volume/TestOMVolumeSetOwnerRequest.java
@@ -25,8 +25,8 @@ import java.util.UUID;
 
 import org.apache.hadoop.ozone.om.request.OMRequestTestUtils;
 import org.apache.hadoop.ozone.storage.proto.OzoneManagerStorageProtos;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos
@@ -50,7 +50,7 @@ public class TestOMVolumeSetOwnerRequest extends TestOMVolumeRequest {
 
     OMRequest modifiedRequest = omVolumeSetQuotaRequest.preExecute(
         ozoneManager);
-    Assert.assertNotEquals(modifiedRequest, originalRequest);
+    Assertions.assertNotEquals(modifiedRequest, originalRequest);
   }
 
 
@@ -84,14 +84,14 @@ public class TestOMVolumeSetOwnerRequest extends TestOMVolumeRequest {
 
     OzoneManagerProtocolProtos.OMResponse omResponse =
         omClientResponse.getOMResponse();
-    Assert.assertNotNull(omResponse.getSetVolumePropertyResponse());
-    Assert.assertEquals(OzoneManagerProtocolProtos.Status.OK,
+    Assertions.assertNotNull(omResponse.getSetVolumePropertyResponse());
+    Assertions.assertEquals(OzoneManagerProtocolProtos.Status.OK,
         omResponse.getStatus());
 
 
     String fromDBOwner = omMetadataManager
         .getVolumeTable().get(volumeKey).getOwnerName();
-    Assert.assertEquals(newOwner, fromDBOwner);
+    Assertions.assertEquals(newOwner, fromDBOwner);
 
     // modificationTime should be greater than creationTime.
     long creationTime = omMetadataManager.getVolumeTable()
@@ -103,21 +103,21 @@ public class TestOMVolumeSetOwnerRequest extends TestOMVolumeRequest {
     // millisecond - since there is no time-consuming operation between
     // OMRequestTestUtils.addVolumeToDB (sets creationTime) and
     // preExecute (sets modificationTime).
-    Assert.assertTrue(modificationTime >= creationTime);
+    Assertions.assertTrue(modificationTime >= creationTime);
 
     OzoneManagerStorageProtos.PersistedUserVolumeInfo newOwnerVolumeList =
         omMetadataManager.getUserTable().get(newOwnerKey);
 
-    Assert.assertNotNull(newOwnerVolumeList);
-    Assert.assertEquals(volumeName,
+    Assertions.assertNotNull(newOwnerVolumeList);
+    Assertions.assertEquals(volumeName,
         newOwnerVolumeList.getVolumeNamesList().get(0));
 
     OzoneManagerStorageProtos.PersistedUserVolumeInfo oldOwnerVolumeList =
         omMetadataManager.getUserTable().get(
             omMetadataManager.getUserKey(ownerKey));
 
-    Assert.assertNotNull(oldOwnerVolumeList);
-    Assert.assertTrue(oldOwnerVolumeList.getVolumeNamesList().size() == 0);
+    Assertions.assertNotNull(oldOwnerVolumeList);
+    Assertions.assertTrue(oldOwnerVolumeList.getVolumeNamesList().size() == 0);
 
   }
 
@@ -143,8 +143,8 @@ public class TestOMVolumeSetOwnerRequest extends TestOMVolumeRequest {
 
     OzoneManagerProtocolProtos.OMResponse omResponse =
         omClientResponse.getOMResponse();
-    Assert.assertNotNull(omResponse.getCreateVolumeResponse());
-    Assert.assertEquals(OzoneManagerProtocolProtos.Status.VOLUME_NOT_FOUND,
+    Assertions.assertNotNull(omResponse.getCreateVolumeResponse());
+    Assertions.assertEquals(OzoneManagerProtocolProtos.Status.VOLUME_NOT_FOUND,
         omResponse.getStatus());
 
   }
@@ -169,8 +169,8 @@ public class TestOMVolumeSetOwnerRequest extends TestOMVolumeRequest {
 
     OzoneManagerProtocolProtos.OMResponse omResponse =
         omClientResponse.getOMResponse();
-    Assert.assertNotNull(omResponse.getCreateVolumeResponse());
-    Assert.assertEquals(OzoneManagerProtocolProtos.Status.INVALID_REQUEST,
+    Assertions.assertNotNull(omResponse.getCreateVolumeResponse());
+    Assertions.assertEquals(OzoneManagerProtocolProtos.Status.INVALID_REQUEST,
         omResponse.getStatus());
   }
 
@@ -194,29 +194,29 @@ public class TestOMVolumeSetOwnerRequest extends TestOMVolumeRequest {
     OMClientResponse omClientResponse = setOwnerRequest.validateAndUpdateCache(
         ozoneManager, 1, ozoneManagerDoubleBufferHelper);
     // Response status should be OK and success flag should be true.
-    Assert.assertEquals(OzoneManagerProtocolProtos.Status.OK,
+    Assertions.assertEquals(OzoneManagerProtocolProtos.Status.OK,
         omClientResponse.getOMResponse().getStatus());
-    Assert.assertTrue(omClientResponse.getOMResponse().getSuccess());
+    Assertions.assertTrue(omClientResponse.getOMResponse().getSuccess());
 
     // Execute the same request again but with higher index
     setOwnerRequest.preExecute(ozoneManager);
     omClientResponse = setOwnerRequest.validateAndUpdateCache(
         ozoneManager, 2, ozoneManagerDoubleBufferHelper);
     // Response status should be OK, but success flag should be false.
-    Assert.assertEquals(OzoneManagerProtocolProtos.Status.OK,
+    Assertions.assertEquals(OzoneManagerProtocolProtos.Status.OK,
         omClientResponse.getOMResponse().getStatus());
-    Assert.assertFalse(omClientResponse.getOMResponse().getSuccess());
+    Assertions.assertFalse(omClientResponse.getOMResponse().getSuccess());
 
     // Check volume names list
     OzoneManagerStorageProtos.PersistedUserVolumeInfo userVolumeInfo =
         omMetadataManager.getUserTable().get(newOwner);
-    Assert.assertNotNull(userVolumeInfo);
+    Assertions.assertNotNull(userVolumeInfo);
     List<String> volumeNamesList = userVolumeInfo.getVolumeNamesList();
-    Assert.assertEquals(1, volumeNamesList.size());
+    Assertions.assertEquals(1, volumeNamesList.size());
 
     Set<String> volumeNamesSet = new HashSet<>(volumeNamesList);
     // If the set size isn't equal to list size, there are duplicates
     // in the list (which was the bug before the fix).
-    Assert.assertEquals(volumeNamesList.size(), volumeNamesSet.size());
+    Assertions.assertEquals(volumeNamesList.size(), volumeNamesSet.size());
   }
 }

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/volume/TestOMVolumeSetQuotaRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/volume/TestOMVolumeSetQuotaRequest.java
@@ -26,8 +26,8 @@ import org.apache.hadoop.ozone.om.helpers.OmVolumeArgs;
 import org.apache.hadoop.ozone.om.request.OMRequestTestUtils;
 import org.apache.hadoop.ozone.om.response.OMClientResponse;
 import org.apache.ozone.test.GenericTestUtils;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMRequest;
@@ -53,7 +53,7 @@ public class TestOMVolumeSetQuotaRequest extends TestOMVolumeRequest {
 
     OMRequest modifiedRequest = omVolumeSetQuotaRequest.preExecute(
         ozoneManager);
-    Assert.assertNotEquals(modifiedRequest, originalRequest);
+    Assertions.assertNotEquals(modifiedRequest, originalRequest);
   }
 
   @Test
@@ -81,7 +81,7 @@ public class TestOMVolumeSetQuotaRequest extends TestOMVolumeRequest {
     OmVolumeArgs omVolumeArgs =
         omMetadataManager.getVolumeTable().get(volumeKey);
     // As request is valid volume table should not have entry.
-    Assert.assertNotNull(omVolumeArgs);
+    Assertions.assertNotNull(omVolumeArgs);
     long quotaBytesBeforeSet = omVolumeArgs.getQuotaInBytes();
     long quotaNamespaceBeforeSet = omVolumeArgs.getQuotaInNamespace();
 
@@ -91,18 +91,18 @@ public class TestOMVolumeSetQuotaRequest extends TestOMVolumeRequest {
 
     OzoneManagerProtocolProtos.OMResponse omResponse =
         omClientResponse.getOMResponse();
-    Assert.assertNotNull(omResponse.getSetVolumePropertyResponse());
-    Assert.assertEquals(OzoneManagerProtocolProtos.Status.OK,
+    Assertions.assertNotNull(omResponse.getSetVolumePropertyResponse());
+    Assertions.assertEquals(OzoneManagerProtocolProtos.Status.OK,
         omResponse.getStatus());
 
 
     OmVolumeArgs ova = omMetadataManager.getVolumeTable().get(volumeKey);
     long quotaBytesAfterSet = ova.getQuotaInBytes();
     long quotaNamespaceAfterSet = ova.getQuotaInNamespace();
-    Assert.assertEquals(quotaInBytes, quotaBytesAfterSet);
-    Assert.assertEquals(quotaInNamespace, quotaNamespaceAfterSet);
-    Assert.assertNotEquals(quotaBytesBeforeSet, quotaBytesAfterSet);
-    Assert.assertNotEquals(quotaNamespaceBeforeSet, quotaNamespaceAfterSet);
+    Assertions.assertEquals(quotaInBytes, quotaBytesAfterSet);
+    Assertions.assertEquals(quotaInNamespace, quotaNamespaceAfterSet);
+    Assertions.assertNotEquals(quotaBytesBeforeSet, quotaBytesAfterSet);
+    Assertions.assertNotEquals(quotaNamespaceBeforeSet, quotaNamespaceAfterSet);
 
     // modificationTime should be greater than creationTime.
     long creationTime = omMetadataManager
@@ -114,7 +114,7 @@ public class TestOMVolumeSetQuotaRequest extends TestOMVolumeRequest {
     // millisecond - since there is no time-consuming operation between
     // OMRequestTestUtils.addVolumeToDB (sets creationTime) and
     // preExecute (sets modificationTime).
-    Assert.assertTrue(modificationTime >= creationTime);
+    Assertions.assertTrue(modificationTime >= creationTime);
   }
 
   @Test
@@ -139,8 +139,8 @@ public class TestOMVolumeSetQuotaRequest extends TestOMVolumeRequest {
 
     OzoneManagerProtocolProtos.OMResponse omResponse =
         omClientResponse.getOMResponse();
-    Assert.assertNotNull(omResponse.getCreateVolumeResponse());
-    Assert.assertEquals(OzoneManagerProtocolProtos.Status.VOLUME_NOT_FOUND,
+    Assertions.assertNotNull(omResponse.getCreateVolumeResponse());
+    Assertions.assertEquals(OzoneManagerProtocolProtos.Status.VOLUME_NOT_FOUND,
         omResponse.getStatus());
   }
 
@@ -164,8 +164,8 @@ public class TestOMVolumeSetQuotaRequest extends TestOMVolumeRequest {
 
     OzoneManagerProtocolProtos.OMResponse omResponse =
         omClientResponse.getOMResponse();
-    Assert.assertNotNull(omResponse.getCreateVolumeResponse());
-    Assert.assertEquals(OzoneManagerProtocolProtos.Status.INVALID_REQUEST,
+    Assertions.assertNotNull(omResponse.getCreateVolumeResponse());
+    Assertions.assertEquals(OzoneManagerProtocolProtos.Status.INVALID_REQUEST,
         omResponse.getStatus());
   }
 
@@ -195,13 +195,13 @@ public class TestOMVolumeSetQuotaRequest extends TestOMVolumeRequest {
         .validateAndUpdateCache(ozoneManager, 1,
             ozoneManagerDoubleBufferHelper);
     //capture the error log
-    Assert.assertTrue(logs.getOutput().contains(
+    Assertions.assertTrue(logs.getOutput().contains(
         "Changing volume quota failed for volume"));
 
-    Assert.assertFalse(omClientResponse.getOMResponse().getSuccess());
-    Assert.assertEquals(omClientResponse.getOMResponse().getStatus(),
+    Assertions.assertFalse(omClientResponse.getOMResponse().getSuccess());
+    Assertions.assertEquals(omClientResponse.getOMResponse().getStatus(),
         OzoneManagerProtocolProtos.Status.QUOTA_EXCEEDED);
-    Assert.assertTrue(omClientResponse.getOMResponse().getMessage().
+    Assertions.assertTrue(omClientResponse.getOMResponse().getMessage().
         contains("Total buckets quota in this volume " +
             "should not be greater than volume quota"));
   }
@@ -225,7 +225,7 @@ public class TestOMVolumeSetQuotaRequest extends TestOMVolumeRequest {
     OMClientResponse omClientResponse = omVolumeSetQuotaRequest
         .validateAndUpdateCache(ozoneManager, 1,
             ozoneManagerDoubleBufferHelper);
-    Assert.assertEquals(omClientResponse.getOMResponse().getStatus(),
+    Assertions.assertEquals(omClientResponse.getOMResponse().getStatus(),
         OzoneManagerProtocolProtos.Status.QUOTA_ERROR);
   }
 
@@ -256,7 +256,7 @@ public class TestOMVolumeSetQuotaRequest extends TestOMVolumeRequest {
     OMClientResponse omClientResponse = omVolumeSetQuotaRequest
         .validateAndUpdateCache(ozoneManager, 1,
             ozoneManagerDoubleBufferHelper);
-    Assert.assertEquals(omClientResponse.getOMResponse().getStatus(),
+    Assertions.assertEquals(omClientResponse.getOMResponse().getStatus(),
         OzoneManagerProtocolProtos.Status.OK);
   }
 
@@ -281,9 +281,10 @@ public class TestOMVolumeSetQuotaRequest extends TestOMVolumeRequest {
     OMClientResponse omClientResponse = omVolumeSetQuotaRequest
         .validateAndUpdateCache(ozoneManager, 1,
             ozoneManagerDoubleBufferHelper);
-    Assert.assertEquals(omClientResponse.getOMResponse().getStatus(),
+    Assertions.assertEquals(omClientResponse.getOMResponse().getStatus(),
         OzoneManagerProtocolProtos.Status.QUOTA_EXCEEDED);
-    Assert.assertTrue(omClientResponse.getOMResponse().getMessage().contains(
+    Assertions.assertTrue(omClientResponse.getOMResponse().getMessage()
+        .contains(
         "this volume should not be greater than volume namespace quota"));
   }
 }

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/volume/acl/TestOMVolumeAddAclRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/volume/acl/TestOMVolumeAddAclRequest.java
@@ -27,8 +27,8 @@ import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMRequest;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMResponse;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.List;
 import java.util.UUID;
@@ -52,12 +52,12 @@ public class TestOMVolumeAddAclRequest extends TestOMVolumeRequest {
 
     OMRequest modifiedRequest = omVolumeAddAclRequest.preExecute(
         ozoneManager);
-    Assert.assertNotEquals(modifiedRequest, originalRequest);
+    Assertions.assertNotEquals(modifiedRequest, originalRequest);
 
     long newModTime = modifiedRequest.getAddAclRequest().getModificationTime();
     // When preExecute() of adding acl,
     // the new modification time is greater than origin one.
-    Assert.assertTrue(newModTime > originModTime);
+    Assertions.assertTrue(newModTime > originModTime);
   }
 
   @Test
@@ -84,23 +84,23 @@ public class TestOMVolumeAddAclRequest extends TestOMVolumeRequest {
     OmVolumeArgs omVolumeArgs =
         omMetadataManager.getVolumeTable().get(volumeKey);
     // As request is valid volume table should have entry.
-    Assert.assertNotNull(omVolumeArgs);
+    Assertions.assertNotNull(omVolumeArgs);
 
     OMClientResponse omClientResponse =
         omVolumeAddAclRequest.validateAndUpdateCache(ozoneManager, 1,
             ozoneManagerDoubleBufferHelper);
 
     OMResponse omResponse = omClientResponse.getOMResponse();
-    Assert.assertNotNull(omResponse.getAddAclResponse());
-    Assert.assertEquals(OzoneManagerProtocolProtos.Status.OK,
+    Assertions.assertNotNull(omResponse.getAddAclResponse());
+    Assertions.assertEquals(OzoneManagerProtocolProtos.Status.OK,
         omResponse.getStatus());
 
     List<OzoneAcl> aclsAfterSet = omMetadataManager
         .getVolumeTable().get(volumeKey).getAcls();
 
     // acl is added to aclMapAfterSet
-    Assert.assertEquals(1, aclsAfterSet.size());
-    Assert.assertEquals(acl, aclsAfterSet.get(0));
+    Assertions.assertEquals(1, aclsAfterSet.size());
+    Assertions.assertEquals(acl, aclsAfterSet.get(0));
   }
 
   @Test
@@ -121,8 +121,8 @@ public class TestOMVolumeAddAclRequest extends TestOMVolumeRequest {
             ozoneManagerDoubleBufferHelper);
 
     OMResponse omResponse = omClientResponse.getOMResponse();
-    Assert.assertNotNull(omResponse.getAddAclResponse());
-    Assert.assertEquals(OzoneManagerProtocolProtos.Status.VOLUME_NOT_FOUND,
+    Assertions.assertNotNull(omResponse.getAddAclResponse());
+    Assertions.assertEquals(OzoneManagerProtocolProtos.Status.VOLUME_NOT_FOUND,
         omResponse.getStatus());
   }
 }

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/volume/acl/TestOMVolumeRemoveAclRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/volume/acl/TestOMVolumeRemoveAclRequest.java
@@ -26,8 +26,8 @@ import org.apache.hadoop.ozone.om.response.OMClientResponse;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMRequest;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMResponse;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.List;
 import java.util.UUID;
@@ -51,13 +51,13 @@ public class TestOMVolumeRemoveAclRequest extends TestOMVolumeRequest {
 
     OMRequest modifiedRequest = omVolumeRemoveAclRequest.preExecute(
         ozoneManager);
-    Assert.assertNotEquals(modifiedRequest, originalRequest);
+    Assertions.assertNotEquals(modifiedRequest, originalRequest);
 
     long newModTime = modifiedRequest.getRemoveAclRequest()
         .getModificationTime();
     // When preExecute() of removing acl,
     // the new modification time is greater than origin one.
-    Assert.assertTrue(newModTime > originModTime);
+    Assertions.assertTrue(newModTime > originModTime);
   }
 
   @Test
@@ -79,8 +79,8 @@ public class TestOMVolumeRemoveAclRequest extends TestOMVolumeRequest {
         omVolumeAddAclRequest.validateAndUpdateCache(ozoneManager, 1,
             ozoneManagerDoubleBufferHelper);
     OMResponse omAddAclResponse = omClientAddResponse.getOMResponse();
-    Assert.assertNotNull(omAddAclResponse.getAddAclResponse());
-    Assert.assertEquals(OzoneManagerProtocolProtos.Status.OK,
+    Assertions.assertNotNull(omAddAclResponse.getAddAclResponse());
+    Assertions.assertEquals(OzoneManagerProtocolProtos.Status.OK,
         omAddAclResponse.getStatus());
 
     // remove acl
@@ -96,23 +96,23 @@ public class TestOMVolumeRemoveAclRequest extends TestOMVolumeRequest {
     OmVolumeArgs omVolumeArgs =
         omMetadataManager.getVolumeTable().get(volumeKey);
     // As request is valid volume table should have entry.
-    Assert.assertNotNull(omVolumeArgs);
+    Assertions.assertNotNull(omVolumeArgs);
     List<OzoneAcl> aclsBeforeRemove = omVolumeArgs.getAcls();
-    Assert.assertEquals(acl, aclsBeforeRemove.get(0));
+    Assertions.assertEquals(acl, aclsBeforeRemove.get(0));
 
     OMClientResponse omClientRemoveResponse =
         omVolumeRemoveAclRequest.validateAndUpdateCache(ozoneManager, 2,
             ozoneManagerDoubleBufferHelper);
 
     OMResponse omRemoveAclResponse = omClientRemoveResponse.getOMResponse();
-    Assert.assertNotNull(omRemoveAclResponse.getRemoveAclResponse());
-    Assert.assertEquals(OzoneManagerProtocolProtos.Status.OK,
+    Assertions.assertNotNull(omRemoveAclResponse.getRemoveAclResponse());
+    Assertions.assertEquals(OzoneManagerProtocolProtos.Status.OK,
         omRemoveAclResponse.getStatus());
 
     // acl is removed from aclMapAfterSet
     List<OzoneAcl> aclsAfterRemove = omMetadataManager
         .getVolumeTable().get(volumeKey).getAcls();
-    Assert.assertEquals(0, aclsAfterRemove.size());
+    Assertions.assertEquals(0, aclsAfterRemove.size());
   }
 
   @Test
@@ -133,8 +133,8 @@ public class TestOMVolumeRemoveAclRequest extends TestOMVolumeRequest {
             ozoneManagerDoubleBufferHelper);
 
     OMResponse omResponse = omClientResponse.getOMResponse();
-    Assert.assertNotNull(omResponse.getRemoveAclResponse());
-    Assert.assertEquals(OzoneManagerProtocolProtos.Status.VOLUME_NOT_FOUND,
+    Assertions.assertNotNull(omResponse.getRemoveAclResponse());
+    Assertions.assertEquals(OzoneManagerProtocolProtos.Status.VOLUME_NOT_FOUND,
         omResponse.getStatus());
   }
 }

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/volume/acl/TestOMVolumeSetAclRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/volume/acl/TestOMVolumeSetAclRequest.java
@@ -27,8 +27,8 @@ import org.apache.hadoop.ozone.om.response.OMClientResponse;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMRequest;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMResponse;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.List;
 import java.util.UUID;
@@ -53,12 +53,12 @@ public class TestOMVolumeSetAclRequest extends TestOMVolumeRequest {
 
     OMRequest modifiedRequest = omVolumeSetAclRequest.preExecute(
         ozoneManager);
-    Assert.assertNotEquals(modifiedRequest, originalRequest);
+    Assertions.assertNotEquals(modifiedRequest, originalRequest);
 
     long newModTime = modifiedRequest.getSetAclRequest().getModificationTime();
     // When preExecute() of setting acl,
     // the new modification time is greater than origin one.
-    Assert.assertTrue(newModTime > originModTime);
+    Assertions.assertTrue(newModTime > originModTime);
   }
 
   @Test
@@ -89,26 +89,26 @@ public class TestOMVolumeSetAclRequest extends TestOMVolumeRequest {
     OmVolumeArgs omVolumeArgs =
         omMetadataManager.getVolumeTable().get(volumeKey);
     // As request is valid volume table should have entry.
-    Assert.assertNotNull(omVolumeArgs);
+    Assertions.assertNotNull(omVolumeArgs);
 
     OMClientResponse omClientResponse =
         omVolumeSetAclRequest.validateAndUpdateCache(ozoneManager, 1,
             ozoneManagerDoubleBufferHelper);
 
     OMResponse omResponse = omClientResponse.getOMResponse();
-    Assert.assertNotNull(omResponse.getSetAclResponse());
-    Assert.assertEquals(OzoneManagerProtocolProtos.Status.OK,
+    Assertions.assertNotNull(omResponse.getSetAclResponse());
+    Assertions.assertEquals(OzoneManagerProtocolProtos.Status.OK,
         omResponse.getStatus());
 
     List<OzoneAcl> aclsAfterSet = omMetadataManager
         .getVolumeTable().get(volumeKey).getAcls();
 
     // Acl is added to aclMapAfterSet
-    Assert.assertEquals(2, aclsAfterSet.size());
-    Assert.assertTrue("Access Acl should be set.",
-        aclsAfterSet.contains(userAccessAcl));
-    Assert.assertTrue("Default Acl should be set.",
-        aclsAfterSet.contains(groupDefaultAcl));
+    Assertions.assertEquals(2, aclsAfterSet.size());
+    Assertions.assertTrue(aclsAfterSet.contains(userAccessAcl),
+        "Access Acl should be set.");
+    Assertions.assertTrue(aclsAfterSet.contains(groupDefaultAcl),
+        "Default Acl should be set.");
   }
 
   @Test
@@ -130,8 +130,8 @@ public class TestOMVolumeSetAclRequest extends TestOMVolumeRequest {
             ozoneManagerDoubleBufferHelper);
 
     OMResponse omResponse = omClientResponse.getOMResponse();
-    Assert.assertNotNull(omResponse.getSetAclResponse());
-    Assert.assertEquals(OzoneManagerProtocolProtos.Status.VOLUME_NOT_FOUND,
+    Assertions.assertNotNull(omResponse.getSetAclResponse());
+    Assertions.assertEquals(OzoneManagerProtocolProtos.Status.VOLUME_NOT_FOUND,
         omResponse.getStatus());
   }
 }

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/TestCleanupTableInfo.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/TestCleanupTableInfo.java
@@ -52,18 +52,18 @@ import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.KeyArgs
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.KeyLocation;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMRequest;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.Type;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.reflections.Reflections;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
@@ -72,14 +72,15 @@ import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.spy;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.spy;
 
 /**
  * The test checks whether all {@link OMClientResponse} have defined the
@@ -87,7 +88,7 @@ import static org.mockito.Mockito.when;
  * For certain requests it check whether it is properly defined not just the
  * fact that it is defined.
  */
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class TestCleanupTableInfo {
   private static final String TEST_VOLUME_NAME = "testVol";
   private static final String TEST_BUCKET_NAME = "testBucket";
@@ -97,8 +98,8 @@ public class TestCleanupTableInfo {
   public static final String OM_RESPONSE_PACKAGE =
       "org.apache.hadoop.ozone.om.response";
 
-  @Rule
-  public TemporaryFolder folder = new TemporaryFolder();
+  @TempDir
+  private Path folder;
 
   @Mock
   private OMMetrics omMetrics;
@@ -106,6 +107,7 @@ public class TestCleanupTableInfo {
   @Mock
   private OzoneManagerDoubleBufferHelper dbh;
 
+  @Mock
   private OzoneManager om;
 
   /**
@@ -117,13 +119,11 @@ public class TestCleanupTableInfo {
    *  - disables ACLs
    *  - provides an audit logger
    *
-   * @return the mocked Ozone Manager
    * @throws IOException should not happen but declared in mocked methods
    */
-  @Before
+  @BeforeEach
   public void setupOzoneManagerMock()
       throws IOException {
-    om = mock(OzoneManager.class);
     OMMetadataManager metaMgr = createOMMetadataManagerSpy();
     when(om.getMetrics()).thenReturn(omMetrics);
     when(om.getMetadataManager()).thenReturn(metaMgr);
@@ -154,21 +154,22 @@ public class TestCleanupTableInfo {
     // OMEchoRPCWriteResponse does not need CleanupTable.
     subTypes.remove(OMEchoRPCWriteResponse.class);
     subTypes.forEach(aClass -> {
-      Assert.assertTrue(aClass + " does not have annotation of" +
-              " CleanupTableInfo",
-          aClass.isAnnotationPresent(CleanupTableInfo.class));
+      Assertions.assertTrue(aClass.isAnnotationPresent(CleanupTableInfo.class),
+          aClass + " does not have annotation of" +
+              " CleanupTableInfo");
       CleanupTableInfo annotation =
           aClass.getAnnotation(CleanupTableInfo.class);
       String[] cleanupTables = annotation.cleanupTables();
       boolean cleanupAll = annotation.cleanupAll();
       if (cleanupTables.length >= 1) {
-        Assert.assertTrue(
+        Assertions.assertTrue(
             Arrays.stream(cleanupTables).allMatch(tables::contains)
         );
       } else {
         assertTrue(cleanupAll);
       }
     });
+    reset(om);
   }
 
 
@@ -224,13 +225,10 @@ public class TestCleanupTableInfo {
     List<String> cleanup = Arrays.asList(ann.cleanupTables());
     for (String tableName : om.getMetadataManager().listTableNames()) {
       if (!cleanup.contains(tableName)) {
-        assertEquals(
-            "Cache item count of table " + tableName,
-            cacheItemCount.get(tableName).intValue(),
+        assertEquals(cacheItemCount.get(tableName).intValue(),
             Iterators.size(
                 om.getMetadataManager().getTable(tableName).cacheIterator()
-            )
-        );
+            ), "Cache item count of table " + tableName);
       }
     }
   }
@@ -281,9 +279,9 @@ public class TestCleanupTableInfo {
    */
   private OMMetadataManager createOMMetadataManagerSpy() throws IOException {
     OzoneConfiguration conf = new OzoneConfiguration();
-    File newFolder = folder.newFolder();
+    File newFolder = folder.toFile();
     if (!newFolder.exists()) {
-      Assert.assertTrue(newFolder.mkdirs());
+      Assertions.assertTrue(newFolder.mkdirs());
     }
     ServerUtils.setOzoneMetaDirPath(conf, newFolder.toString());
     return spy(new OmMetadataManagerImpl(conf, null));

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/bucket/TestOMBucketCreateResponse.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/bucket/TestOMBucketCreateResponse.java
@@ -19,15 +19,15 @@
 
 package org.apache.hadoop.ozone.om.response.bucket;
 
+import java.nio.file.Path;
 import java.util.UUID;
 
 import org.apache.hadoop.hdds.utils.db.Table;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.ozone.om.OMConfigKeys;
@@ -47,22 +47,22 @@ import org.apache.hadoop.hdds.utils.db.BatchOperation;
  */
 public class TestOMBucketCreateResponse {
 
-  @Rule
-  public TemporaryFolder folder = new TemporaryFolder();
+  @TempDir
+  private Path folder;
 
   private OMMetadataManager omMetadataManager;
   private BatchOperation batchOperation;
 
-  @Before
+  @BeforeEach
   public void setup() throws Exception {
     OzoneConfiguration ozoneConfiguration = new OzoneConfiguration();
     ozoneConfiguration.set(OMConfigKeys.OZONE_OM_DB_DIRS,
-        folder.newFolder().getAbsolutePath());
+        folder.toAbsolutePath().toString());
     omMetadataManager = new OmMetadataManagerImpl(ozoneConfiguration, null);
     batchOperation = omMetadataManager.getStore().initBatchOperation();
   }
 
-  @After
+  @AfterEach
   public void tearDown() {
     if (batchOperation != null) {
       batchOperation.close();
@@ -75,7 +75,7 @@ public class TestOMBucketCreateResponse {
     String bucketName = UUID.randomUUID().toString();
     OmBucketInfo omBucketInfo = TestOMResponseUtils.createBucket(
         volumeName, bucketName);
-    Assert.assertEquals(0,
+    Assertions.assertEquals(0,
         omMetadataManager.countRowsInTable(omMetadataManager.getBucketTable()));
     OMBucketCreateResponse omBucketCreateResponse =
         new OMBucketCreateResponse(OMResponse.newBuilder()
@@ -90,15 +90,15 @@ public class TestOMBucketCreateResponse {
     // Do manual commit and see whether addToBatch is successful or not.
     omMetadataManager.getStore().commitBatchOperation(batchOperation);
 
-    Assert.assertEquals(1,
+    Assertions.assertEquals(1,
         omMetadataManager.countRowsInTable(omMetadataManager.getBucketTable()));
 
     Table.KeyValue<String, OmBucketInfo> keyValue =
         omMetadataManager.getBucketTable().iterator().next();
 
-    Assert.assertEquals(omMetadataManager.getBucketKey(volumeName,
+    Assertions.assertEquals(omMetadataManager.getBucketKey(volumeName,
         bucketName), keyValue.getKey());
-    Assert.assertEquals(omBucketInfo, keyValue.getValue());
+    Assertions.assertEquals(omBucketInfo, keyValue.getValue());
   }
 
 

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/bucket/TestOMBucketDeleteResponse.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/bucket/TestOMBucketDeleteResponse.java
@@ -19,14 +19,14 @@
 
 package org.apache.hadoop.ozone.om.response.bucket;
 
+import java.nio.file.Path;
 import java.util.UUID;
 
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.ozone.om.OMConfigKeys;
@@ -48,23 +48,23 @@ import org.apache.hadoop.hdds.utils.db.BatchOperation;
  */
 public class TestOMBucketDeleteResponse {
 
-  @Rule
-  public TemporaryFolder folder = new TemporaryFolder();
+  @TempDir
+  private Path folder;
 
   private OMMetadataManager omMetadataManager;
   private BatchOperation batchOperation;
 
 
-  @Before
+  @BeforeEach
   public void setup() throws Exception {
     OzoneConfiguration ozoneConfiguration = new OzoneConfiguration();
     ozoneConfiguration.set(OMConfigKeys.OZONE_OM_DB_DIRS,
-        folder.newFolder().getAbsolutePath());
+        folder.toAbsolutePath().toString());
     omMetadataManager = new OmMetadataManagerImpl(ozoneConfiguration, null);
     batchOperation = omMetadataManager.getStore().initBatchOperation();
   }
 
-  @After
+  @AfterEach
   public void tearDown() {
     if (batchOperation != null) {
       batchOperation.close();
@@ -99,7 +99,7 @@ public class TestOMBucketDeleteResponse {
     // Do manual commit and see whether addToBatch is successful or not.
     omMetadataManager.getStore().commitBatchOperation(batchOperation);
 
-    Assert.assertNull(omMetadataManager.getBucketTable().get(
+    Assertions.assertNull(omMetadataManager.getBucketTable().get(
             omMetadataManager.getBucketKey(volumeName, bucketName)));
   }
 

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/bucket/TestOMBucketSetPropertyResponse.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/bucket/TestOMBucketSetPropertyResponse.java
@@ -19,15 +19,15 @@
 
 package org.apache.hadoop.ozone.om.response.bucket;
 
+import java.nio.file.Path;
 import java.util.UUID;
 
 import org.apache.hadoop.hdds.utils.db.Table;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.ozone.om.OMConfigKeys;
@@ -47,22 +47,22 @@ import org.apache.hadoop.hdds.utils.db.BatchOperation;
  */
 public class TestOMBucketSetPropertyResponse {
 
-  @Rule
-  public TemporaryFolder folder = new TemporaryFolder();
+  @TempDir
+  private Path folder;
 
   private OMMetadataManager omMetadataManager;
   private BatchOperation batchOperation;
 
-  @Before
+  @BeforeEach
   public void setup() throws Exception {
     OzoneConfiguration ozoneConfiguration = new OzoneConfiguration();
     ozoneConfiguration.set(OMConfigKeys.OZONE_OM_DB_DIRS,
-        folder.newFolder().getAbsolutePath());
+        folder.toAbsolutePath().toString());
     omMetadataManager = new OmMetadataManagerImpl(ozoneConfiguration, null);
     batchOperation = omMetadataManager.getStore().initBatchOperation();
   }
 
-  @After
+  @AfterEach
   public void tearDown() {
     if (batchOperation != null) {
       batchOperation.close();
@@ -90,15 +90,15 @@ public class TestOMBucketSetPropertyResponse {
     // Do manual commit and see whether addToBatch is successful or not.
     omMetadataManager.getStore().commitBatchOperation(batchOperation);
 
-    Assert.assertEquals(1,
+    Assertions.assertEquals(1,
         omMetadataManager.countRowsInTable(omMetadataManager.getBucketTable()));
 
     Table.KeyValue<String, OmBucketInfo> keyValue =
         omMetadataManager.getBucketTable().iterator().next();
 
-    Assert.assertEquals(omMetadataManager.getBucketKey(volumeName,
+    Assertions.assertEquals(omMetadataManager.getBucketKey(volumeName,
         bucketName), keyValue.getKey());
-    Assert.assertEquals(omBucketInfo, keyValue.getValue());
+    Assertions.assertEquals(omBucketInfo, keyValue.getValue());
   }
 
 

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/file/TestOMDirectoryCreateResponse.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/file/TestOMDirectoryCreateResponse.java
@@ -35,13 +35,13 @@ import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos
     .OMResponse;
 import org.apache.hadoop.hdds.utils.db.BatchOperation;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.UUID;
 import java.util.concurrent.ThreadLocalRandom;
@@ -50,22 +50,22 @@ import java.util.concurrent.ThreadLocalRandom;
  * Tests OMDirectoryCreateResponse.
  */
 public class TestOMDirectoryCreateResponse {
-  @Rule
-  public TemporaryFolder folder = new TemporaryFolder();
+  @TempDir
+  private Path folder;
 
   private OMMetadataManager omMetadataManager;
   private BatchOperation batchOperation;
 
-  @Before
+  @BeforeEach
   public void setup() throws Exception {
     OzoneConfiguration ozoneConfiguration = new OzoneConfiguration();
     ozoneConfiguration.set(OMConfigKeys.OZONE_OM_DB_DIRS,
-        folder.newFolder().getAbsolutePath());
+        folder.toAbsolutePath().toString());
     omMetadataManager = new OmMetadataManagerImpl(ozoneConfiguration, null);
     batchOperation = omMetadataManager.getStore().initBatchOperation();
   }
 
-  @After
+  @AfterEach
   public void tearDown() {
     if (batchOperation != null) {
       batchOperation.close();
@@ -105,14 +105,16 @@ public class TestOMDirectoryCreateResponse {
     // Do manual commit and see whether addToBatch is successful or not.
     omMetadataManager.getStore().commitBatchOperation(batchOperation);
 
-    Assert.assertNotNull(omMetadataManager.getKeyTable(getBucketLayout()).get(
-        omMetadataManager.getOzoneDirKey(volumeName, bucketName, keyName)));
+    Assertions.assertNotNull(omMetadataManager.getKeyTable(getBucketLayout())
+        .get(omMetadataManager.getOzoneDirKey(
+            volumeName, bucketName, keyName)));
 
     Table.KeyValue<String, OmBucketInfo> keyValue =
         omMetadataManager.getBucketTable().iterator().next();
-    Assert.assertEquals(omMetadataManager.getBucketKey(volumeName,
+    Assertions.assertEquals(omMetadataManager.getBucketKey(volumeName,
         bucketName), keyValue.getKey());
-    Assert.assertEquals(usedNamespace, keyValue.getValue().getUsedNamespace());
+    Assertions.assertEquals(usedNamespace,
+        keyValue.getValue().getUsedNamespace());
   }
 
   public BucketLayout getBucketLayout() {

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/file/TestOMDirectoryCreateResponseWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/file/TestOMDirectoryCreateResponseWithFSO.java
@@ -36,13 +36,13 @@ import org.apache.hadoop.ozone.om.request.file.OMDirectoryCreateRequestWithFSO;
 import org.apache.hadoop.ozone.om.response.TestOMResponseUtils;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMResponse;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 import java.io.IOException;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.UUID;
 import java.util.concurrent.ThreadLocalRandom;
@@ -51,17 +51,17 @@ import java.util.concurrent.ThreadLocalRandom;
  * Tests OMDirectoryCreateResponseWithFSO - prefix layout.
  */
 public class TestOMDirectoryCreateResponseWithFSO {
-  @Rule
-  public TemporaryFolder folder = new TemporaryFolder();
+  @TempDir
+  private Path folder;
 
   private OMMetadataManager omMetadataManager;
   private BatchOperation batchOperation;
 
-  @Before
+  @BeforeEach
   public void setup() throws Exception {
     OzoneConfiguration ozoneConfiguration = new OzoneConfiguration();
     ozoneConfiguration.set(OMConfigKeys.OZONE_OM_DB_DIRS,
-        folder.newFolder().getAbsolutePath());
+        folder.toAbsolutePath().toString());
     omMetadataManager = new OmMetadataManagerImpl(ozoneConfiguration, null);
     batchOperation = omMetadataManager.getStore().initBatchOperation();
   }
@@ -107,15 +107,16 @@ public class TestOMDirectoryCreateResponseWithFSO {
     // Do manual commit and see whether addToBatch is successful or not.
     omMetadataManager.getStore().commitBatchOperation(batchOperation);
 
-    Assert.assertNotNull(omMetadataManager.getDirectoryTable().get(
+    Assertions.assertNotNull(omMetadataManager.getDirectoryTable().get(
             omMetadataManager.getOzonePathKey(volumeId, bucketId,
                     parentID, keyName)));
 
     Table.KeyValue<String, OmBucketInfo> keyValue =
         omMetadataManager.getBucketTable().iterator().next();
-    Assert.assertEquals(omMetadataManager.getBucketKey(volumeName,
+    Assertions.assertEquals(omMetadataManager.getBucketKey(volumeName,
         bucketName), keyValue.getKey());
-    Assert.assertEquals(usedNamespace, keyValue.getValue().getUsedNamespace());
+    Assertions.assertEquals(usedNamespace,
+        keyValue.getValue().getUsedNamespace());
   }
 
   private void addVolumeToDB(String volumeName) throws IOException {

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/file/TestOMFileCreateResponseWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/file/TestOMFileCreateResponseWithFSO.java
@@ -27,7 +27,7 @@ import org.apache.hadoop.ozone.om.response.key.TestOMKeyCreateResponse;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMResponse;
 import org.apache.hadoop.util.Time;
 import org.jetbrains.annotations.NotNull;
-import org.junit.Assert;
+import org.junit.jupiter.api.Assertions;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -40,7 +40,7 @@ public class TestOMFileCreateResponseWithFSO extends TestOMKeyCreateResponse {
   @NotNull
   @Override
   protected OmKeyInfo getOmKeyInfo() {
-    Assert.assertNotNull(omBucketInfo);
+    Assertions.assertNotNull(omBucketInfo);
     return OMRequestTestUtils.createOmKeyInfo(volumeName,
             omBucketInfo.getBucketName(), keyName, replicationType,
             replicationFactor,
@@ -51,7 +51,7 @@ public class TestOMFileCreateResponseWithFSO extends TestOMKeyCreateResponse {
   @NotNull
   @Override
   protected String getOpenKeyName() throws IOException {
-    Assert.assertNotNull(omBucketInfo);
+    Assertions.assertNotNull(omBucketInfo);
     final long volumeId = omMetadataManager.getVolumeId(volumeName);
     final long bucketId = omMetadataManager.getBucketId(volumeName,
             bucketName);

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/key/TestOMAllocateBlockResponse.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/key/TestOMAllocateBlockResponse.java
@@ -20,8 +20,8 @@ package org.apache.hadoop.ozone.om.response.key;
 
 import org.apache.hadoop.ozone.om.helpers.OmBucketInfo;
 import org.jetbrains.annotations.NotNull;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
 import org.apache.hadoop.ozone.om.request.OMRequestTestUtils;
@@ -53,14 +53,14 @@ public class TestOMAllocateBlockResponse extends TestOMKeyResponse {
     String openKey = getOpenKey();
 
     // Not adding key entry before to test whether commit is successful or not.
-    Assert.assertFalse(
+    Assertions.assertFalse(
         omMetadataManager.getOpenKeyTable(getBucketLayout()).isExist(openKey));
     omAllocateBlockResponse.addToDBBatch(omMetadataManager, batchOperation);
 
     // Do manual commit and see whether addToBatch is successful or not.
     omMetadataManager.getStore().commitBatchOperation(batchOperation);
 
-    Assert.assertTrue(
+    Assertions.assertTrue(
         omMetadataManager.getOpenKeyTable(getBucketLayout()).isExist(openKey));
   }
 
@@ -79,7 +79,7 @@ public class TestOMAllocateBlockResponse extends TestOMKeyResponse {
 
     // Before calling addToDBBatch
     String openKey = getOpenKey();
-    Assert.assertFalse(
+    Assertions.assertFalse(
         omMetadataManager.getOpenKeyTable(getBucketLayout()).isExist(openKey));
 
     omAllocateBlockResponse.checkAndUpdateDB(omMetadataManager, batchOperation);
@@ -88,7 +88,7 @@ public class TestOMAllocateBlockResponse extends TestOMKeyResponse {
     omMetadataManager.getStore().commitBatchOperation(batchOperation);
 
     // As omResponse is error it is a no-op.
-    Assert.assertFalse(
+    Assertions.assertFalse(
         omMetadataManager.getOpenKeyTable(getBucketLayout()).isExist(openKey));
 
   }

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/key/TestOMKeyCommitResponse.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/key/TestOMKeyCommitResponse.java
@@ -25,8 +25,8 @@ import org.apache.hadoop.hdds.utils.db.Table;
 import org.apache.hadoop.ozone.OmUtils;
 import org.apache.hadoop.ozone.om.helpers.RepeatedOmKeyInfo;
 import org.jetbrains.annotations.NotNull;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
 import org.apache.hadoop.ozone.om.request.OMRequestTestUtils;
@@ -57,7 +57,7 @@ public class TestOMKeyCommitResponse extends TestOMKeyResponse {
     addKeyToOpenKeyTable();
 
     String openKey = getOpenKeyName();
-    Assert.assertTrue(
+    Assertions.assertTrue(
         omMetadataManager.getOpenKeyTable(getBucketLayout()).isExist(openKey));
 
     String ozoneKey = getOzoneKey();
@@ -70,9 +70,9 @@ public class TestOMKeyCommitResponse extends TestOMKeyResponse {
     omMetadataManager.getStore().commitBatchOperation(batchOperation);
 
     // When key commit key is deleted from openKey table and added to keyTable.
-    Assert.assertFalse(
+    Assertions.assertFalse(
         omMetadataManager.getOpenKeyTable(getBucketLayout()).isExist(openKey));
-    Assert.assertTrue(
+    Assertions.assertTrue(
         omMetadataManager.getKeyTable(getBucketLayout()).isExist(ozoneKey));
   }
 
@@ -99,7 +99,7 @@ public class TestOMKeyCommitResponse extends TestOMKeyResponse {
     // Adding it here.
     addKeyToOpenKeyTable();
 
-    Assert.assertTrue(
+    Assertions.assertTrue(
         omMetadataManager.getOpenKeyTable(getBucketLayout()).isExist(openKey));
 
     omKeyCommitResponse.checkAndUpdateDB(omMetadataManager, batchOperation);
@@ -110,9 +110,9 @@ public class TestOMKeyCommitResponse extends TestOMKeyResponse {
 
     // As omResponse is error it is a no-op. So, entry should still be in
     // openKey table.
-    Assert.assertTrue(
+    Assertions.assertTrue(
         omMetadataManager.getOpenKeyTable(getBucketLayout()).isExist(openKey));
-    Assert.assertFalse(
+    Assertions.assertFalse(
         omMetadataManager.getKeyTable(getBucketLayout()).isExist(ozoneKey));
   }
 
@@ -121,7 +121,7 @@ public class TestOMKeyCommitResponse extends TestOMKeyResponse {
     OmKeyInfo omKeyInfo = getOmKeyInfo();
     keysToDelete =
             OmUtils.prepareKeyForDelete(omKeyInfo, 100, false);
-    Assert.assertNotNull(keysToDelete);
+    Assertions.assertNotNull(keysToDelete);
     testAddToDBBatch();
 
     String deletedKey = omMetadataManager.getOzoneKey(volumeName,
@@ -129,8 +129,8 @@ public class TestOMKeyCommitResponse extends TestOMKeyResponse {
     List<? extends Table.KeyValue<String, RepeatedOmKeyInfo>> rangeKVs
         = omMetadataManager.getDeletedTable().getRangeKVs(
         null, 100, deletedKey);
-    Assert.assertTrue(rangeKVs.size() > 0);
-    Assert.assertEquals(1,
+    Assertions.assertTrue(rangeKVs.size() > 0);
+    Assertions.assertEquals(1,
         rangeKVs.get(0).getValue().getOmKeyInfoList().size());
 
   }
@@ -143,7 +143,7 @@ public class TestOMKeyCommitResponse extends TestOMKeyResponse {
 
   @NotNull
   protected String getOzoneKey() throws IOException {
-    Assert.assertNotNull(omBucketInfo);
+    Assertions.assertNotNull(omBucketInfo);
     return omMetadataManager.getOzoneKey(volumeName,
             omBucketInfo.getBucketName(), keyName);
   }
@@ -153,7 +153,7 @@ public class TestOMKeyCommitResponse extends TestOMKeyResponse {
           OzoneManagerProtocolProtos.OMResponse omResponse, String openKey,
           String ozoneKey, RepeatedOmKeyInfo deleteKeys, Boolean isHSync)
           throws IOException {
-    Assert.assertNotNull(omBucketInfo);
+    Assertions.assertNotNull(omBucketInfo);
     Map<String, RepeatedOmKeyInfo> deleteKeyMap = new HashMap<>();
     if (null != deleteKeys) {
       deleteKeys.getOmKeyInfoList().stream().forEach(e -> deleteKeyMap.put(

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/key/TestOMKeyCommitResponseWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/key/TestOMKeyCommitResponseWithFSO.java
@@ -29,7 +29,7 @@ import org.apache.hadoop.ozone.om.request.OMRequestTestUtils;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos;
 import org.apache.hadoop.util.Time;
 import org.jetbrains.annotations.NotNull;
-import org.junit.Assert;
+import org.junit.jupiter.api.Assertions;
 
 import java.io.IOException;
 
@@ -44,7 +44,7 @@ public class TestOMKeyCommitResponseWithFSO extends TestOMKeyCommitResponse {
       OzoneManagerProtocolProtos.OMResponse omResponse, String openKey,
       String ozoneKey, RepeatedOmKeyInfo deleteKeys, Boolean isHSync)
           throws IOException {
-    Assert.assertNotNull(omBucketInfo);
+    Assertions.assertNotNull(omBucketInfo);
     long volumeId = omMetadataManager.getVolumeId(omKeyInfo.getVolumeName());
     Map<String, RepeatedOmKeyInfo> deleteKeyMap = new HashMap<>();
     if (null != keysToDelete) {
@@ -61,7 +61,7 @@ public class TestOMKeyCommitResponseWithFSO extends TestOMKeyCommitResponse {
   @NotNull
   @Override
   protected OmKeyInfo getOmKeyInfo() {
-    Assert.assertNotNull(omBucketInfo);
+    Assertions.assertNotNull(omBucketInfo);
     return OMRequestTestUtils.createOmKeyInfo(volumeName,
             omBucketInfo.getBucketName(), keyName, replicationType,
             replicationFactor,
@@ -72,7 +72,7 @@ public class TestOMKeyCommitResponseWithFSO extends TestOMKeyCommitResponse {
   @NotNull
   @Override
   protected void addKeyToOpenKeyTable() throws Exception {
-    Assert.assertNotNull(omBucketInfo);
+    Assertions.assertNotNull(omBucketInfo);
     long parentID = omBucketInfo.getObjectID();
     long objectId = parentID + 10;
 
@@ -90,7 +90,7 @@ public class TestOMKeyCommitResponseWithFSO extends TestOMKeyCommitResponse {
   @NotNull
   @Override
   protected String getOpenKeyName() throws IOException  {
-    Assert.assertNotNull(omBucketInfo);
+    Assertions.assertNotNull(omBucketInfo);
     final long volumeId = omMetadataManager.getVolumeId(volumeName);
     final long bucketId = omMetadataManager.getBucketId(volumeName,
             bucketName);
@@ -101,7 +101,7 @@ public class TestOMKeyCommitResponseWithFSO extends TestOMKeyCommitResponse {
   @NotNull
   @Override
   protected String getOzoneKey()  throws IOException {
-    Assert.assertNotNull(omBucketInfo);
+    Assertions.assertNotNull(omBucketInfo);
     final long volumeId = omMetadataManager.getVolumeId(volumeName);
     final long bucketId = omMetadataManager.getBucketId(volumeName,
             bucketName);

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/key/TestOMKeyCreateResponse.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/key/TestOMKeyCreateResponse.java
@@ -20,8 +20,8 @@ package org.apache.hadoop.ozone.om.response.key;
 
 import org.apache.hadoop.ozone.om.helpers.OmBucketInfo;
 import org.jetbrains.annotations.NotNull;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos;
@@ -59,14 +59,14 @@ public class TestOMKeyCreateResponse extends TestOMKeyResponse {
 
     String openKey = getOpenKeyName();
 
-    Assert.assertFalse(
+    Assertions.assertFalse(
         omMetadataManager.getOpenKeyTable(getBucketLayout()).isExist(openKey));
     omKeyCreateResponse.addToDBBatch(omMetadataManager, batchOperation);
 
     // Do manual commit and see whether addToBatch is successful or not.
     omMetadataManager.getStore().commitBatchOperation(batchOperation);
 
-    Assert.assertTrue(
+    Assertions.assertTrue(
         omMetadataManager.getOpenKeyTable(getBucketLayout()).isExist(openKey));
   }
 
@@ -87,7 +87,7 @@ public class TestOMKeyCreateResponse extends TestOMKeyResponse {
 
     // Before calling addToDBBatch
     String openKey = getOpenKeyName();
-    Assert.assertFalse(
+    Assertions.assertFalse(
         omMetadataManager.getOpenKeyTable(getBucketLayout()).isExist(openKey));
 
     omKeyCreateResponse.checkAndUpdateDB(omMetadataManager, batchOperation);
@@ -96,7 +96,7 @@ public class TestOMKeyCreateResponse extends TestOMKeyResponse {
     omMetadataManager.getStore().commitBatchOperation(batchOperation);
 
     // As omResponse is error it is a no-op.
-    Assert.assertFalse(
+    Assertions.assertFalse(
         omMetadataManager.getOpenKeyTable(getBucketLayout()).isExist(openKey));
 
   }

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/key/TestOMKeyCreateResponseWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/key/TestOMKeyCreateResponseWithFSO.java
@@ -25,7 +25,7 @@ import org.apache.hadoop.ozone.om.request.OMRequestTestUtils;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMResponse;
 import org.apache.hadoop.util.Time;
 import org.jetbrains.annotations.NotNull;
-import org.junit.Assert;
+import org.junit.jupiter.api.Assertions;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -38,7 +38,7 @@ public class TestOMKeyCreateResponseWithFSO extends TestOMKeyCreateResponse {
   @NotNull
   @Override
   protected String getOpenKeyName() throws IOException {
-    Assert.assertNotNull(omBucketInfo);
+    Assertions.assertNotNull(omBucketInfo);
     final long volumeId = omMetadataManager.getVolumeId(volumeName);
     final long bucketId = omMetadataManager.getBucketId(volumeName,
             bucketName);
@@ -49,7 +49,7 @@ public class TestOMKeyCreateResponseWithFSO extends TestOMKeyCreateResponse {
   @NotNull
   @Override
   protected OmKeyInfo getOmKeyInfo() {
-    Assert.assertNotNull(omBucketInfo);
+    Assertions.assertNotNull(omBucketInfo);
     return OMRequestTestUtils.createOmKeyInfo(volumeName,
             omBucketInfo.getBucketName(), keyName, replicationType,
             replicationFactor,

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/key/TestOMKeyDeleteResponse.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/key/TestOMKeyDeleteResponse.java
@@ -28,8 +28,8 @@ import org.apache.hadoop.ozone.om.helpers.OmBucketInfo;
 import org.apache.hadoop.ozone.om.helpers.OmKeyLocationInfo;
 import org.apache.hadoop.ozone.om.helpers.RepeatedOmKeyInfo;
 import org.apache.hadoop.ozone.om.request.OMRequestTestUtils;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos;
@@ -58,14 +58,14 @@ public class TestOMKeyDeleteResponse extends TestOMKeyResponse {
     OMKeyDeleteResponse omKeyDeleteResponse = getOmKeyDeleteResponse(omKeyInfo,
             omResponse);
 
-    Assert.assertTrue(
+    Assertions.assertTrue(
         omMetadataManager.getKeyTable(getBucketLayout()).isExist(ozoneKey));
     omKeyDeleteResponse.addToDBBatch(omMetadataManager, batchOperation);
 
     // Do manual commit and see whether addToBatch is successful or not.
     omMetadataManager.getStore().commitBatchOperation(batchOperation);
 
-    Assert.assertFalse(
+    Assertions.assertFalse(
         omMetadataManager.getKeyTable(getBucketLayout()).isExist(ozoneKey));
 
     String deletedKey = omMetadataManager.getOzoneKey(volumeName, bucketName,
@@ -73,7 +73,7 @@ public class TestOMKeyDeleteResponse extends TestOMKeyResponse {
 
     // As default key entry does not have any blocks, it should not be in
     // deletedKeyTable.
-    Assert.assertFalse(omMetadataManager.getDeletedTable().isExist(
+    Assertions.assertFalse(omMetadataManager.getDeletedTable().isExist(
         deletedKey));
   }
 
@@ -115,14 +115,14 @@ public class TestOMKeyDeleteResponse extends TestOMKeyResponse {
     OMKeyDeleteResponse omKeyDeleteResponse = getOmKeyDeleteResponse(omKeyInfo,
             omResponse);
 
-    Assert.assertTrue(
+    Assertions.assertTrue(
         omMetadataManager.getKeyTable(getBucketLayout()).isExist(ozoneKey));
     omKeyDeleteResponse.addToDBBatch(omMetadataManager, batchOperation);
 
     // Do manual commit and see whether addToBatch is successful or not.
     omMetadataManager.getStore().commitBatchOperation(batchOperation);
 
-    Assert.assertFalse(
+    Assertions.assertFalse(
         omMetadataManager.getKeyTable(getBucketLayout()).isExist(ozoneKey));
     
     String deletedKey = omMetadataManager.getOzoneKey(volumeName, bucketName,
@@ -132,7 +132,7 @@ public class TestOMKeyDeleteResponse extends TestOMKeyResponse {
         null, 100, deletedKey);
 
     // Key has blocks, it should not be in deletedKeyTable.
-    Assert.assertTrue(rangeKVs.size() > 0);
+    Assertions.assertTrue(rangeKVs.size() > 0);
   }
 
 
@@ -152,7 +152,7 @@ public class TestOMKeyDeleteResponse extends TestOMKeyResponse {
 
     String ozoneKey = addKeyToTable();
 
-    Assert.assertTrue(
+    Assertions.assertTrue(
         omMetadataManager.getKeyTable(getBucketLayout()).isExist(ozoneKey));
 
     omKeyDeleteResponse.checkAndUpdateDB(omMetadataManager, batchOperation);
@@ -162,7 +162,7 @@ public class TestOMKeyDeleteResponse extends TestOMKeyResponse {
 
     // As omResponse is error it is a no-op. So, entry should be still in the
     // keyTable.
-    Assert.assertTrue(
+    Assertions.assertTrue(
         omMetadataManager.getKeyTable(getBucketLayout()).isExist(ozoneKey));
 
   }

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/key/TestOMKeyDeleteResponseWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/key/TestOMKeyDeleteResponseWithFSO.java
@@ -24,7 +24,7 @@ import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
 import org.apache.hadoop.ozone.om.request.OMRequestTestUtils;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos;
 import org.apache.hadoop.util.Time;
-import org.junit.Assert;
+import org.junit.jupiter.api.Assertions;
 
 /**
  * Tests OMKeyDeleteResponse - prefix layout.
@@ -65,7 +65,7 @@ public class TestOMKeyDeleteResponseWithFSO extends TestOMKeyDeleteResponse {
 
   @Override
   protected OmKeyInfo getOmKeyInfo() {
-    Assert.assertNotNull(getOmBucketInfo());
+    Assertions.assertNotNull(getOmBucketInfo());
     return OMRequestTestUtils.createOmKeyInfo(volumeName,
             getOmBucketInfo().getBucketName(), keyName, replicationType,
             replicationFactor,

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/key/TestOMKeyRenameResponse.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/key/TestOMKeyRenameResponse.java
@@ -25,8 +25,8 @@ import org.apache.hadoop.hdds.utils.db.Table;
 import org.apache.hadoop.ozone.om.helpers.BucketLayout;
 import org.apache.hadoop.ozone.om.helpers.OmBucketInfo;
 import org.apache.hadoop.ozone.om.request.OMRequestTestUtils;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos;
@@ -59,17 +59,18 @@ public class TestOMKeyRenameResponse extends TestOMKeyResponse {
     OMKeyRenameResponse omKeyRenameResponse =
         getOMKeyRenameResponse(omResponse, fromKeyInfo, toKeyInfo);
 
-    Assert.assertTrue(omMetadataManager.getKeyTable(getBucketLayout())
+    Assertions.assertTrue(omMetadataManager.getKeyTable(getBucketLayout())
         .isExist(dbFromKey));
-    Assert.assertFalse(omMetadataManager.getKeyTable(getBucketLayout())
+    Assertions.assertFalse(omMetadataManager.getKeyTable(getBucketLayout())
         .isExist(dbToKey));
-    Assert.assertTrue(omMetadataManager.getSnapshotRenamedTable().isEmpty());
+    Assertions.assertTrue(omMetadataManager.getSnapshotRenamedTable()
+        .isEmpty());
     if (getBucketLayout() == BucketLayout.FILE_SYSTEM_OPTIMIZED) {
-      Assert.assertFalse(omMetadataManager.getDirectoryTable()
+      Assertions.assertFalse(omMetadataManager.getDirectoryTable()
           .isExist(getDBKeyName(fromKeyParent)));
-      Assert.assertFalse(omMetadataManager.getDirectoryTable()
+      Assertions.assertFalse(omMetadataManager.getDirectoryTable()
           .isExist(getDBKeyName(toKeyParent)));
-      Assert.assertFalse(
+      Assertions.assertFalse(
           omMetadataManager.getBucketTable().iterator().hasNext());
     }
 
@@ -78,9 +79,9 @@ public class TestOMKeyRenameResponse extends TestOMKeyResponse {
     // Do manual commit and see whether addToBatch is successful or not.
     omMetadataManager.getStore().commitBatchOperation(batchOperation);
 
-    Assert.assertFalse(omMetadataManager.getKeyTable(getBucketLayout())
+    Assertions.assertFalse(omMetadataManager.getKeyTable(getBucketLayout())
         .isExist(dbFromKey));
-    Assert.assertTrue(omMetadataManager.getKeyTable(getBucketLayout())
+    Assertions.assertTrue(omMetadataManager.getKeyTable(getBucketLayout())
         .isExist(dbToKey));
 
     String renameDbKey = omMetadataManager.getRenameKey(
@@ -88,17 +89,17 @@ public class TestOMKeyRenameResponse extends TestOMKeyResponse {
         fromKeyInfo.getObjectID());
     // snapshotRenamedTable shouldn't contain those keys which
     // is not part of snapshot bucket.
-    Assert.assertFalse(omMetadataManager.getSnapshotRenamedTable()
+    Assertions.assertFalse(omMetadataManager.getSnapshotRenamedTable()
         .isExist(renameDbKey));
 
     if (getBucketLayout() == BucketLayout.FILE_SYSTEM_OPTIMIZED) {
-      Assert.assertTrue(omMetadataManager.getDirectoryTable()
+      Assertions.assertTrue(omMetadataManager.getDirectoryTable()
           .isExist(getDBKeyName(fromKeyParent)));
-      Assert.assertTrue(omMetadataManager.getDirectoryTable()
+      Assertions.assertTrue(omMetadataManager.getDirectoryTable()
           .isExist(getDBKeyName(toKeyParent)));
       Table.KeyValue<String, OmBucketInfo> keyValue =
           omMetadataManager.getBucketTable().iterator().next();
-      Assert.assertEquals(omMetadataManager.getBucketKey(
+      Assertions.assertEquals(omMetadataManager.getBucketKey(
           bucketInfo.getVolumeName(), bucketInfo.getBucketName()),
           keyValue.getKey());
     }
@@ -121,14 +122,14 @@ public class TestOMKeyRenameResponse extends TestOMKeyResponse {
     OMKeyRenameResponse omKeyRenameResponse = getOMKeyRenameResponse(
         omResponse, fromKeyInfo, toKeyInfo);
 
-    Assert.assertTrue(omMetadataManager.getKeyTable(getBucketLayout())
+    Assertions.assertTrue(omMetadataManager.getKeyTable(getBucketLayout())
         .isExist(dbFromKey));
-    Assert.assertFalse(omMetadataManager.getKeyTable(getBucketLayout())
+    Assertions.assertFalse(omMetadataManager.getKeyTable(getBucketLayout())
         .isExist(dbToKey));
     if (getBucketLayout() == BucketLayout.FILE_SYSTEM_OPTIMIZED) {
-      Assert.assertFalse(omMetadataManager.getDirectoryTable()
+      Assertions.assertFalse(omMetadataManager.getDirectoryTable()
           .isExist(getDBKeyName(fromKeyParent)));
-      Assert.assertFalse(omMetadataManager.getDirectoryTable()
+      Assertions.assertFalse(omMetadataManager.getDirectoryTable()
           .isExist(getDBKeyName(toKeyParent)));
     }
 
@@ -138,14 +139,14 @@ public class TestOMKeyRenameResponse extends TestOMKeyResponse {
     omMetadataManager.getStore().commitBatchOperation(batchOperation);
 
     // As omResponse has error, it is a no-op. So, no changes should happen.
-    Assert.assertTrue(omMetadataManager.getKeyTable(getBucketLayout())
+    Assertions.assertTrue(omMetadataManager.getKeyTable(getBucketLayout())
         .isExist(dbFromKey));
-    Assert.assertFalse(omMetadataManager.getKeyTable(getBucketLayout())
+    Assertions.assertFalse(omMetadataManager.getKeyTable(getBucketLayout())
         .isExist(dbToKey));
     if (getBucketLayout() == BucketLayout.FILE_SYSTEM_OPTIMIZED) {
-      Assert.assertFalse(omMetadataManager.getDirectoryTable()
+      Assertions.assertFalse(omMetadataManager.getDirectoryTable()
           .isExist(getDBKeyName(fromKeyParent)));
-      Assert.assertFalse(omMetadataManager.getDirectoryTable()
+      Assertions.assertFalse(omMetadataManager.getDirectoryTable()
           .isExist(getDBKeyName(toKeyParent)));
     }
   }

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/key/TestOMKeyResponse.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/key/TestOMKeyResponse.java
@@ -19,6 +19,7 @@
 package org.apache.hadoop.ozone.om.response.key;
 
 import java.io.IOException;
+import java.nio.file.Path;
 import java.util.Random;
 import java.util.UUID;
 
@@ -32,10 +33,9 @@ import org.apache.hadoop.ozone.om.helpers.OmVolumeArgs;
 import org.apache.hadoop.ozone.om.helpers.RepeatedOmKeyInfo;
 import org.apache.hadoop.ozone.om.request.OMRequestTestUtils;
 import org.jetbrains.annotations.NotNull;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.io.TempDir;
 import org.mockito.Mockito;
 
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
@@ -50,8 +50,8 @@ import org.apache.hadoop.hdds.utils.db.BatchOperation;
  */
 @SuppressWarnings("visibilitymodifier")
 public class TestOMKeyResponse {
-  @Rule
-  public TemporaryFolder folder = new TemporaryFolder();
+  @TempDir
+  private Path folder;
 
   protected OMMetadataManager omMetadataManager;
   protected BatchOperation batchOperation;
@@ -67,11 +67,11 @@ public class TestOMKeyResponse {
   protected long txnLogId = 100000L;
   protected RepeatedOmKeyInfo keysToDelete;
 
-  @Before
+  @BeforeEach
   public void setup() throws Exception {
     OzoneConfiguration ozoneConfiguration = getOzoneConfiguration();
     ozoneConfiguration.set(OMConfigKeys.OZONE_OM_DB_DIRS,
-        folder.newFolder().getAbsolutePath());
+        folder.toAbsolutePath().toString());
     omMetadataManager = new OmMetadataManagerImpl(ozoneConfiguration, null);
     batchOperation = omMetadataManager.getStore().initBatchOperation();
 
@@ -126,7 +126,7 @@ public class TestOMKeyResponse {
     return new OzoneConfiguration();
   }
 
-  @After
+  @AfterEach
   public void stop() {
     Mockito.framework().clearInlineMocks();
     if (batchOperation != null) {

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/key/TestOMKeysDeleteResponse.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/key/TestOMKeysDeleteResponse.java
@@ -25,8 +25,8 @@ import org.apache.hadoop.ozone.om.request.OMRequestTestUtils;
 import org.apache.hadoop.ozone.om.response.OMClientResponse;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.DeleteKeysResponse;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMResponse;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -88,14 +88,14 @@ public class TestOMKeysDeleteResponse extends TestOMKeyResponse {
 
     omMetadataManager.getStore().commitBatchOperation(batchOperation);
     for (String ozKey : ozoneKeys) {
-      Assert.assertNull(
+      Assertions.assertNull(
           omMetadataManager.getKeyTable(getBucketLayout()).get(ozKey));
 
       // ozKey had no block information associated with it, so it should have
       // been removed from the key table but not added to the delete table.
       RepeatedOmKeyInfo repeatedOmKeyInfo =
           omMetadataManager.getDeletedTable().get(ozKey);
-      Assert.assertNull(repeatedOmKeyInfo);
+      Assertions.assertNull(repeatedOmKeyInfo);
     }
 
   }
@@ -122,12 +122,12 @@ public class TestOMKeysDeleteResponse extends TestOMKeyResponse {
     omKeysDeleteResponse.checkAndUpdateDB(omMetadataManager, batchOperation);
 
     for (String ozKey : ozoneKeys) {
-      Assert.assertNotNull(
+      Assertions.assertNotNull(
           omMetadataManager.getKeyTable(getBucketLayout()).get(ozKey));
 
       RepeatedOmKeyInfo repeatedOmKeyInfo =
           omMetadataManager.getDeletedTable().get(ozKey);
-      Assert.assertNull(repeatedOmKeyInfo);
+      Assertions.assertNull(repeatedOmKeyInfo);
 
     }
 

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/key/TestOMKeysDeleteResponse.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/key/TestOMKeysDeleteResponse.java
@@ -58,7 +58,7 @@ public class TestOMKeysDeleteResponse extends TestOMKeyResponse {
     String parent = "/user";
     String key = "key";
 
-    String ozoneKey = "";
+    String ozoneKey;
     for (int i = 0; i < 10; i++) {
       keyName = parent.concat(key + i);
       OMRequestTestUtils.addKeyToTable(false, volumeName,

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/key/TestOMKeysDeleteResponseWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/key/TestOMKeysDeleteResponseWithFSO.java
@@ -86,7 +86,7 @@ public class TestOMKeysDeleteResponseWithFSO
         dirKeyInfo.getObjectID(), dirOzoneDBKey));
 
     // create set of keys directly under the bucket
-    String ozoneDBKey = "";
+    String ozoneDBKey;
     String keyPrefix = "key";
     for (int i = 0; i < 10; i++) {
       keyName = keyPrefix + i;

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/key/TestOMKeysDeleteResponseWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/key/TestOMKeysDeleteResponseWithFSO.java
@@ -34,8 +34,8 @@ import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.DeleteKeysResponse;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMResponse;
 import org.apache.hadoop.util.Time;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -134,31 +134,31 @@ public class TestOMKeysDeleteResponseWithFSO
 
     omMetadataManager.getStore().commitBatchOperation(batchOperation);
     for (String ozKey : getOzoneKeys()) {
-      Assert.assertNull(
+      Assertions.assertNull(
           omMetadataManager.getKeyTable(getBucketLayout()).get(ozKey));
 
       // ozKey had no block information associated with it, so it should have
       // been removed from the file table but not added to the delete table.
       RepeatedOmKeyInfo repeatedOmKeyInfo =
           omMetadataManager.getDeletedTable().get(ozKey);
-      Assert.assertNull(repeatedOmKeyInfo);
+      Assertions.assertNull(repeatedOmKeyInfo);
     }
 
     for (String dirDBKey : dirDBKeys) {
-      Assert.assertNull(
+      Assertions.assertNull(
           omMetadataManager.getDirectoryTable().get(dirDBKey));
 
       // dir deleted from DirTable
       RepeatedOmKeyInfo repeatedOmKeyInfo =
           omMetadataManager.getDeletedTable().get(dirDBKey);
-      Assert.assertNull(repeatedOmKeyInfo);
+      Assertions.assertNull(repeatedOmKeyInfo);
     }
 
     for (String dirDelDBKey : dirDelDBKeys) {
       // dir added to the deleted dir table, for deep cleanups
       OmKeyInfo omDirInfo =
           omMetadataManager.getDeletedDirTable().get(dirDelDBKey);
-      Assert.assertNotNull(omDirInfo);
+      Assertions.assertNotNull(omDirInfo);
     }
 
   }

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/key/TestOMKeysRenameResponse.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/key/TestOMKeysRenameResponse.java
@@ -26,8 +26,8 @@ import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.RenameK
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.Status;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.Type;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -69,9 +69,9 @@ public class TestOMKeysRenameResponse extends TestOMKeyResponse {
       String toKey = parentDir.concat("/newKey" + i);
       key = omMetadataManager.getOzoneKey(volumeName, bucketName, key);
       toKey = omMetadataManager.getOzoneKey(volumeName, bucketName, toKey);
-      Assert.assertFalse(
+      Assertions.assertFalse(
           omMetadataManager.getKeyTable(getBucketLayout()).isExist(key));
-      Assert.assertTrue(
+      Assertions.assertTrue(
           omMetadataManager.getKeyTable(getBucketLayout()).isExist(toKey));
     }
   }
@@ -101,9 +101,9 @@ public class TestOMKeysRenameResponse extends TestOMKeyResponse {
       key = omMetadataManager.getOzoneKey(volumeName, bucketName, key);
       toKey = omMetadataManager.getOzoneKey(volumeName, bucketName, toKey);
       // As omResponse has error, it is a no-op. So, no changes should happen.
-      Assert.assertTrue(
+      Assertions.assertTrue(
           omMetadataManager.getKeyTable(getBucketLayout()).isExist(key));
-      Assert.assertFalse(
+      Assertions.assertFalse(
           omMetadataManager.getKeyTable(getBucketLayout()).isExist(toKey));
     }
 

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/key/TestOMOpenKeysDeleteResponse.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/key/TestOMOpenKeysDeleteResponse.java
@@ -38,6 +38,9 @@ import java.util.UUID;
 
 import static org.apache.hadoop.ozone.om.request.OMRequestTestUtils.addBucketToDB;
 
+/**
+ * Tests the OM Response when open keys are deleted.
+ */
 public class TestOMOpenKeysDeleteResponse extends TestOMKeyResponse {
   private static final long KEY_LENGTH = 100;
   private BucketLayout bucketLayout;
@@ -61,8 +64,8 @@ public class TestOMOpenKeysDeleteResponse extends TestOMKeyResponse {
   @ParameterizedTest
   @MethodSource("bucketLayouts")
   public void testAddToDBBatchWithEmptyBlocks(
-      BucketLayout bucketLayout) throws Exception {
-    this.bucketLayout = bucketLayout;
+      BucketLayout buckLayout) throws Exception {
+    this.bucketLayout = buckLayout;
     OMRequestTestUtils.addVolumeAndBucketToDB(volumeName, bucketName,
             omMetadataManager, getBucketLayout());
     Map<String, OmKeyInfo> keysToDelete = addOpenKeysToDB(volumeName, 3);
@@ -93,8 +96,8 @@ public class TestOMOpenKeysDeleteResponse extends TestOMKeyResponse {
   @ParameterizedTest
   @MethodSource("bucketLayouts")
   public void testAddToDBBatchWithNonEmptyBlocks(
-      BucketLayout bucketLayout) throws Exception {
-    this.bucketLayout = bucketLayout;
+      BucketLayout buckLayout) throws Exception {
+    this.bucketLayout = buckLayout;
     OMRequestTestUtils.addVolumeAndBucketToDB(volumeName, bucketName,
             omMetadataManager, getBucketLayout());
     Map<String, OmKeyInfo> keysToDelete = addOpenKeysToDB(volumeName, 3,
@@ -136,8 +139,8 @@ public class TestOMOpenKeysDeleteResponse extends TestOMKeyResponse {
   @ParameterizedTest
   @MethodSource("bucketLayouts")
   public void testAddToDBBatchWithErrorResponse(
-      BucketLayout bucketLayout) throws Exception {
-    this.bucketLayout = bucketLayout;
+      BucketLayout buckLayout) throws Exception {
+    this.bucketLayout = buckLayout;
     OMRequestTestUtils.addVolumeAndBucketToDB(volumeName, bucketName,
             omMetadataManager, getBucketLayout());
     Map<String, OmKeyInfo> keysToDelete = addOpenKeysToDB(volumeName, 3);

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/key/TestOMOpenKeysDeleteResponse.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/key/TestOMOpenKeysDeleteResponse.java
@@ -26,11 +26,9 @@ import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.Status;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMResponse;
-import org.junit.Assert;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
-import org.junit.runners.Parameterized.Parameters;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.util.Arrays;
 import java.util.Collection;
@@ -40,24 +38,15 @@ import java.util.UUID;
 
 import static org.apache.hadoop.ozone.om.request.OMRequestTestUtils.addBucketToDB;
 
-/**
- * Tests OMOpenKeysDeleteResponse.
- */
-@RunWith(Parameterized.class)
 public class TestOMOpenKeysDeleteResponse extends TestOMKeyResponse {
   private static final long KEY_LENGTH = 100;
-  private final BucketLayout bucketLayout;
-
-  public TestOMOpenKeysDeleteResponse(BucketLayout bucketLayout) {
-    this.bucketLayout = bucketLayout;
-  }
+  private BucketLayout bucketLayout;
 
   @Override
   public BucketLayout getBucketLayout() {
     return bucketLayout;
   }
 
-  @Parameters
   public static Collection<BucketLayout> bucketLayouts() {
     return Arrays.asList(
         BucketLayout.DEFAULT,
@@ -69,8 +58,11 @@ public class TestOMOpenKeysDeleteResponse extends TestOMKeyResponse {
    * Tests deleting a subset of keys from the open key table DB when the keys
    * have no associated block data.
    */
-  @Test
-  public void testAddToDBBatchWithEmptyBlocks() throws Exception {
+  @ParameterizedTest
+  @MethodSource("bucketLayouts")
+  public void testAddToDBBatchWithEmptyBlocks(
+      BucketLayout bucketLayout) throws Exception {
+    this.bucketLayout = bucketLayout;
     OMRequestTestUtils.addVolumeAndBucketToDB(volumeName, bucketName,
             omMetadataManager, getBucketLayout());
     Map<String, OmKeyInfo> keysToDelete = addOpenKeysToDB(volumeName, 3);
@@ -81,16 +73,16 @@ public class TestOMOpenKeysDeleteResponse extends TestOMKeyResponse {
     for (String key: keysToDelete.keySet()) {
       // open keys with no associated block data should have been removed
       // from the open key table, but not added to the deleted table.
-      Assert.assertFalse(
+      Assertions.assertFalse(
           omMetadataManager.getOpenKeyTable(getBucketLayout()).isExist(key));
-      Assert.assertFalse(omMetadataManager.getDeletedTable().isExist(key));
+      Assertions.assertFalse(omMetadataManager.getDeletedTable().isExist(key));
     }
 
     for (String key: keysToKeep.keySet()) {
       // These keys should not have been removed from the open key table.
-      Assert.assertTrue(
+      Assertions.assertTrue(
           omMetadataManager.getOpenKeyTable(getBucketLayout()).isExist(key));
-      Assert.assertFalse(omMetadataManager.getDeletedTable().isExist(key));
+      Assertions.assertFalse(omMetadataManager.getDeletedTable().isExist(key));
     }
   }
 
@@ -98,8 +90,11 @@ public class TestOMOpenKeysDeleteResponse extends TestOMKeyResponse {
    * Tests deleting a subset of keys from the open key table DB when the keys
    * have associated block data.
    */
-  @Test
-  public void testAddToDBBatchWithNonEmptyBlocks() throws Exception {
+  @ParameterizedTest
+  @MethodSource("bucketLayouts")
+  public void testAddToDBBatchWithNonEmptyBlocks(
+      BucketLayout bucketLayout) throws Exception {
+    this.bucketLayout = bucketLayout;
     OMRequestTestUtils.addVolumeAndBucketToDB(volumeName, bucketName,
             omMetadataManager, getBucketLayout());
     Map<String, OmKeyInfo> keysToDelete = addOpenKeysToDB(volumeName, 3,
@@ -112,22 +107,23 @@ public class TestOMOpenKeysDeleteResponse extends TestOMKeyResponse {
     for (Map.Entry<String, OmKeyInfo> entry: keysToDelete.entrySet()) {
       // These keys should have been moved from the open key table to the
       // delete table.
-      Assert.assertFalse(
+      Assertions.assertFalse(
           omMetadataManager.getOpenKeyTable(getBucketLayout()).isExist(
               entry.getKey()));
       String deleteKey = omMetadataManager.getOzoneDeletePathKey(
           entry.getValue().getObjectID(), entry.getKey());
-      Assert.assertTrue(omMetadataManager.getDeletedTable().isExist(deleteKey));
+      Assertions.assertTrue(omMetadataManager.getDeletedTable()
+          .isExist(deleteKey));
     }
 
     for (Map.Entry<String, OmKeyInfo> entry: keysToKeep.entrySet()) {
       // These keys should not have been moved out of the open key table.
-      Assert.assertTrue(
+      Assertions.assertTrue(
           omMetadataManager.getOpenKeyTable(getBucketLayout()).isExist(
               entry.getKey()));
       String deleteKey = omMetadataManager.getOzoneDeletePathKey(
           entry.getValue().getObjectID(), entry.getKey());
-      Assert.assertFalse(omMetadataManager.getDeletedTable()
+      Assertions.assertFalse(omMetadataManager.getDeletedTable()
           .isExist(deleteKey));
     }
   }
@@ -137,8 +133,11 @@ public class TestOMOpenKeysDeleteResponse extends TestOMKeyResponse {
    * submitted response has an error status. In this case, no changes to the
    * DB should be made.
    */
-  @Test
-  public void testAddToDBBatchWithErrorResponse() throws Exception {
+  @ParameterizedTest
+  @MethodSource("bucketLayouts")
+  public void testAddToDBBatchWithErrorResponse(
+      BucketLayout bucketLayout) throws Exception {
+    this.bucketLayout = bucketLayout;
     OMRequestTestUtils.addVolumeAndBucketToDB(volumeName, bucketName,
             omMetadataManager, getBucketLayout());
     Map<String, OmKeyInfo> keysToDelete = addOpenKeysToDB(volumeName, 3);
@@ -148,9 +147,9 @@ public class TestOMOpenKeysDeleteResponse extends TestOMKeyResponse {
     for (String key: keysToDelete.keySet()) {
       // If an error occurs in the response, the batch operation moving keys
       // from the open key table to the delete table should not be committed.
-      Assert.assertTrue(
+      Assertions.assertTrue(
           omMetadataManager.getOpenKeyTable(getBucketLayout()).isExist(key));
-      Assert.assertFalse(omMetadataManager.getDeletedTable().isExist(key));
+      Assertions.assertFalse(omMetadataManager.getDeletedTable().isExist(key));
     }
   }
 
@@ -236,7 +235,7 @@ public class TestOMOpenKeysDeleteResponse extends TestOMKeyResponse {
             clientID, 0L, omMetadataManager);
         openKey = omMetadataManager.getOpenKey(volume, bucket, key, clientID);
       }
-      Assert.assertTrue(omMetadataManager.getOpenKeyTable(getBucketLayout())
+      Assertions.assertTrue(omMetadataManager.getOpenKeyTable(getBucketLayout())
           .isExist(openKey));
 
       newOpenKeys.put(openKey, omKeyInfo);

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/s3/multipart/TestS3ExpiredMultipartUploadsAbortResponse.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/s3/multipart/TestS3ExpiredMultipartUploadsAbortResponse.java
@@ -48,6 +48,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
+/**
+ * Tests S3 Expired Multipart Upload Abort Responses.
+ */
 public class TestS3ExpiredMultipartUploadsAbortResponse
     extends TestS3MultipartResponse {
 
@@ -73,8 +76,8 @@ public class TestS3ExpiredMultipartUploadsAbortResponse
   @ParameterizedTest
   @MethodSource("bucketLayouts")
   public void testAddToDBBatchWithEmptyParts(
-      BucketLayout bucketLayout) throws Exception {
-    this.bucketLayout = bucketLayout;
+      BucketLayout buckLayout) throws Exception {
+    this.bucketLayout = buckLayout;
     String volumeName = UUID.randomUUID().toString();
 
     Map<OmBucketInfo, List<OmMultipartAbortInfo>> mpusToAbort =
@@ -116,8 +119,8 @@ public class TestS3ExpiredMultipartUploadsAbortResponse
   @ParameterizedTest
   @MethodSource("bucketLayouts")
   public void testAddToDBBatchWithNonEmptyParts(
-      BucketLayout bucketLayout) throws Exception {
-    this.bucketLayout = bucketLayout;
+      BucketLayout buckLayout) throws Exception {
+    this.bucketLayout = buckLayout;
     String volumeName = UUID.randomUUID().toString();
 
     Map<OmBucketInfo, List<OmMultipartAbortInfo>> mpusToAbort =
@@ -179,8 +182,8 @@ public class TestS3ExpiredMultipartUploadsAbortResponse
   @ParameterizedTest
   @MethodSource("bucketLayouts")
   public void testAddToDBBatchWithErrorResponse(
-      BucketLayout bucketLayout) throws Exception {
-    this.bucketLayout = bucketLayout;
+      BucketLayout buckLayout) throws Exception {
+    this.bucketLayout = buckLayout;
     String volumeName = UUID.randomUUID().toString();
 
     Map<OmBucketInfo, List<OmMultipartAbortInfo>> mpusToAbort =

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/s3/multipart/TestS3InitiateMultipartUploadResponse.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/s3/multipart/TestS3InitiateMultipartUploadResponse.java
@@ -22,8 +22,8 @@ package org.apache.hadoop.ozone.om.response.s3.multipart;
 import java.util.UUID;
 
 import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 /**
  * Class tests S3 Initiate MPU response.
@@ -55,15 +55,15 @@ public class TestS3InitiateMultipartUploadResponse
 
     OmKeyInfo openMPUKeyInfo = omMetadataManager.getOpenKeyTable(
         getBucketLayout()).get(multipartKey);
-    Assert.assertNotNull(openMPUKeyInfo);
-    Assert.assertNotNull(openMPUKeyInfo.getLatestVersionLocations());
-    Assert.assertTrue(openMPUKeyInfo.getLatestVersionLocations()
+    Assertions.assertNotNull(openMPUKeyInfo);
+    Assertions.assertNotNull(openMPUKeyInfo.getLatestVersionLocations());
+    Assertions.assertTrue(openMPUKeyInfo.getLatestVersionLocations()
         .isMultipartKey());
 
-    Assert.assertNotNull(omMetadataManager.getMultipartInfoTable()
+    Assertions.assertNotNull(omMetadataManager.getMultipartInfoTable()
         .get(multipartKey));
 
-    Assert.assertEquals(multipartUploadID,
+    Assertions.assertEquals(multipartUploadID,
         omMetadataManager.getMultipartInfoTable().get(multipartKey)
             .getUploadID());
   }

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/s3/multipart/TestS3InitiateMultipartUploadResponseWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/s3/multipart/TestS3InitiateMultipartUploadResponseWithFSO.java
@@ -23,8 +23,8 @@ import org.apache.hadoop.ozone.om.helpers.BucketLayout;
 import org.apache.hadoop.ozone.om.helpers.OmDirectoryInfo;
 import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
 import org.apache.hadoop.ozone.om.helpers.OmMultipartKeyInfo;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -81,24 +81,26 @@ public class TestS3InitiateMultipartUploadResponseWithFSO
 
     OmKeyInfo omKeyInfo = omMetadataManager.getOpenKeyTable(getBucketLayout())
         .get(multipartOpenKey);
-    Assert.assertNotNull("Failed to find the fileInfo", omKeyInfo);
-    Assert.assertNotNull("Key Location is null!",
-        omKeyInfo.getLatestVersionLocations());
-    Assert.assertTrue("isMultipartKey is false!",
-        omKeyInfo.getLatestVersionLocations().isMultipartKey());
-    Assert.assertEquals("FileName mismatches!", fileName,
-            omKeyInfo.getKeyName());
-    Assert.assertEquals("ParentId mismatches!", parentID,
-            omKeyInfo.getParentObjectID());
+    Assertions.assertNotNull(omKeyInfo, "Failed to find the fileInfo");
+    Assertions.assertNotNull(omKeyInfo.getLatestVersionLocations(),
+        "Key Location is null!");
+    Assertions.assertTrue(
+        omKeyInfo.getLatestVersionLocations().isMultipartKey(),
+        "isMultipartKey is false!");
+    Assertions.assertEquals(fileName, omKeyInfo.getKeyName(),
+        "FileName mismatches!");
+    Assertions.assertEquals(parentID, omKeyInfo.getParentObjectID(),
+        "ParentId mismatches!");
 
     OmMultipartKeyInfo omMultipartKeyInfo = omMetadataManager
             .getMultipartInfoTable().get(multipartKey);
-    Assert.assertNotNull("Failed to find the multipartFileInfo",
-            omMultipartKeyInfo);
-    Assert.assertEquals("ParentId mismatches!", parentID,
-            omMultipartKeyInfo.getParentID());
+    Assertions.assertNotNull(omMultipartKeyInfo,
+        "Failed to find the multipartFileInfo");
+    Assertions.assertEquals(parentID, omMultipartKeyInfo.getParentID(),
+        "ParentId mismatches!");
 
-    Assert.assertEquals("Upload Id mismatches!", multipartUploadID,
-            omMultipartKeyInfo.getUploadID());
+    Assertions.assertEquals(multipartUploadID,
+        omMultipartKeyInfo.getUploadID(),
+        "Upload Id mismatches!");
   }
 }

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/s3/multipart/TestS3MultipartResponse.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/s3/multipart/TestS3MultipartResponse.java
@@ -20,6 +20,7 @@
 package org.apache.hadoop.ozone.om.response.s3.multipart;
 
 import java.io.IOException;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -37,10 +38,9 @@ import org.apache.hadoop.ozone.om.helpers.OmVolumeArgs;
 import org.apache.hadoop.ozone.om.helpers.OzoneFSUtils;
 import org.apache.hadoop.ozone.om.helpers.OmBucketInfo;
 import org.apache.hadoop.ozone.om.helpers.BucketLayout;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.io.TempDir;
 
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos;
@@ -66,22 +66,22 @@ import org.apache.hadoop.hdds.utils.db.BatchOperation;
 @SuppressWarnings("VisibilityModifier")
 public class TestS3MultipartResponse {
 
-  @Rule
-  public TemporaryFolder folder = new TemporaryFolder();
+  @TempDir
+  private Path folder;
 
   protected OMMetadataManager omMetadataManager;
   protected BatchOperation batchOperation;
 
-  @Before
+  @BeforeEach
   public void setup() throws Exception {
     OzoneConfiguration ozoneConfiguration = new OzoneConfiguration();
     ozoneConfiguration.set(OMConfigKeys.OZONE_OM_DB_DIRS,
-        folder.newFolder().getAbsolutePath());
+        folder.toAbsolutePath().toString());
     omMetadataManager = new OmMetadataManagerImpl(ozoneConfiguration, null);
     batchOperation = omMetadataManager.getStore().initBatchOperation();
   }
 
-  @After
+  @AfterEach
   public void tearDown() {
     if (batchOperation != null) {
       batchOperation.close();

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/s3/multipart/TestS3MultipartUploadAbortResponse.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/s3/multipart/TestS3MultipartUploadAbortResponse.java
@@ -93,8 +93,8 @@ public class TestS3MultipartUploadAbortResponse
         omMetadataManager.getMultipartInfoTable().get(multipartKey));
 
     // As no parts are created, so no entries should be there in delete table.
-    Assertions.assertTrue(omMetadataManager.countRowsInTable(
-        omMetadataManager.getDeletedTable()) == 0);
+    Assertions.assertEquals(0, omMetadataManager.countRowsInTable(
+        omMetadataManager.getDeletedTable()));
   }
 
   protected S3InitiateMultipartUploadResponse
@@ -164,8 +164,8 @@ public class TestS3MultipartUploadAbortResponse
         omMetadataManager.getMultipartInfoTable().get(multipartKey));
 
     // As 2 parts are created, so 2 entries should be there in delete table.
-    Assertions.assertTrue(omMetadataManager.countRowsInTable(
-        omMetadataManager.getDeletedTable()) == 2);
+    Assertions.assertEquals(2, omMetadataManager.countRowsInTable(
+        omMetadataManager.getDeletedTable()));
 
     String part1DeletedKeyName =
         omMetadataManager.getOzoneDeletePathKey(

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/s3/multipart/TestS3MultipartUploadAbortResponse.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/s3/multipart/TestS3MultipartUploadAbortResponse.java
@@ -25,8 +25,8 @@ import org.apache.hadoop.ozone.om.helpers.OmBucketInfo;
 import org.apache.hadoop.ozone.om.helpers.RepeatedOmKeyInfo;
 import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
 import org.apache.hadoop.ozone.om.helpers.OmMultipartKeyInfo;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos
     .PartKeyInfo;
@@ -69,10 +69,10 @@ public class TestS3MultipartUploadAbortResponse
     omMetadataManager.getStore().commitBatchOperation(batchOperation);
 
     // Make sure key is present in OpenKeyTable and MPU table before Abort.
-    Assert.assertNotNull(
+    Assertions.assertNotNull(
         omMetadataManager.getOpenKeyTable(getBucketLayout())
             .get(multipartOpenKey));
-    Assert.assertNotNull(
+    Assertions.assertNotNull(
         omMetadataManager.getMultipartInfoTable().get(multipartKey));
 
     S3MultipartUploadAbortResponse s3MultipartUploadAbortResponse =
@@ -86,14 +86,14 @@ public class TestS3MultipartUploadAbortResponse
     omMetadataManager.getStore().commitBatchOperation(batchOperation);
 
     // Key should be deleted from OpenKeyTable and MPU table after Abort.
-    Assert.assertNull(
+    Assertions.assertNull(
         omMetadataManager.getOpenKeyTable(getBucketLayout())
             .get(multipartOpenKey));
-    Assert.assertNull(
+    Assertions.assertNull(
         omMetadataManager.getMultipartInfoTable().get(multipartKey));
 
     // As no parts are created, so no entries should be there in delete table.
-    Assert.assertTrue(omMetadataManager.countRowsInTable(
+    Assertions.assertTrue(omMetadataManager.countRowsInTable(
         omMetadataManager.getDeletedTable()) == 0);
   }
 
@@ -158,13 +158,13 @@ public class TestS3MultipartUploadAbortResponse
 
     omMetadataManager.getStore().commitBatchOperation(batchOperation);
 
-    Assert.assertNull(
+    Assertions.assertNull(
         omMetadataManager.getOpenKeyTable(getBucketLayout()).get(multipartKey));
-    Assert.assertNull(
+    Assertions.assertNull(
         omMetadataManager.getMultipartInfoTable().get(multipartKey));
 
     // As 2 parts are created, so 2 entries should be there in delete table.
-    Assert.assertTrue(omMetadataManager.countRowsInTable(
+    Assertions.assertTrue(omMetadataManager.countRowsInTable(
         omMetadataManager.getDeletedTable()) == 2);
 
     String part1DeletedKeyName =
@@ -177,18 +177,18 @@ public class TestS3MultipartUploadAbortResponse
             omMultipartKeyInfo.getPartKeyInfo(2).getPartKeyInfo()
                 .getObjectID(), multipartKey);
 
-    Assert.assertNotNull(omMetadataManager.getDeletedTable().get(
+    Assertions.assertNotNull(omMetadataManager.getDeletedTable().get(
         part1DeletedKeyName));
-    Assert.assertNotNull(omMetadataManager.getDeletedTable().get(
+    Assertions.assertNotNull(omMetadataManager.getDeletedTable().get(
         part2DeletedKeyName));
 
     RepeatedOmKeyInfo ro =
         omMetadataManager.getDeletedTable().get(part1DeletedKeyName);
-    Assert.assertEquals(OmKeyInfo.getFromProtobuf(part1.getPartKeyInfo()),
+    Assertions.assertEquals(OmKeyInfo.getFromProtobuf(part1.getPartKeyInfo()),
         ro.getOmKeyInfoList().get(0));
 
     ro = omMetadataManager.getDeletedTable().get(part2DeletedKeyName);
-    Assert.assertEquals(OmKeyInfo.getFromProtobuf(part2.getPartKeyInfo()),
+    Assertions.assertEquals(OmKeyInfo.getFromProtobuf(part2.getPartKeyInfo()),
         ro.getOmKeyInfoList().get(0));
   }
 

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/s3/multipart/TestS3MultipartUploadCommitPartResponseWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/s3/multipart/TestS3MultipartUploadCommitPartResponseWithFSO.java
@@ -29,8 +29,8 @@ import org.apache.hadoop.ozone.om.request.OMRequestTestUtils;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.PartKeyInfo;
 import org.apache.hadoop.util.Time;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.UUID;
@@ -76,13 +76,13 @@ public class TestS3MultipartUploadCommitPartResponseWithFSO
 
     omMetadataManager.getStore().commitBatchOperation(batchOperation);
 
-    Assert.assertNull(
+    Assertions.assertNull(
         omMetadataManager.getOpenKeyTable(getBucketLayout()).get(openKey));
-    Assert.assertNotNull(
+    Assertions.assertNotNull(
         omMetadataManager.getMultipartInfoTable().get(multipartKey));
 
     // As no parts are created, so no entries should be there in delete table.
-    Assert.assertEquals(0, omMetadataManager.countRowsInTable(
+    Assertions.assertEquals(0, omMetadataManager.countRowsInTable(
             omMetadataManager.getDeletedTable()));
   }
 
@@ -139,15 +139,15 @@ public class TestS3MultipartUploadCommitPartResponseWithFSO
     s3MultipartUploadCommitPartResponse.checkAndUpdateDB(omMetadataManager,
             batchOperation);
 
-    Assert.assertNull(
+    Assertions.assertNull(
         omMetadataManager.getOpenKeyTable(getBucketLayout()).get(openKey));
-    Assert.assertNull(
+    Assertions.assertNull(
         omMetadataManager.getMultipartInfoTable().get(multipartKey));
 
     omMetadataManager.getStore().commitBatchOperation(batchOperation);
 
     // As 1 parts are created, so 1 entry should be there in delete table.
-    Assert.assertEquals(1, omMetadataManager.countRowsInTable(
+    Assertions.assertEquals(1, omMetadataManager.countRowsInTable(
         omMetadataManager.getDeletedTable()));
 
     String part1DeletedKeyName =
@@ -155,12 +155,12 @@ public class TestS3MultipartUploadCommitPartResponseWithFSO
             omMultipartKeyInfo.getPartKeyInfo(1).getPartKeyInfo()
                 .getObjectID(), multipartKey);
 
-    Assert.assertNotNull(omMetadataManager.getDeletedTable().get(
+    Assertions.assertNotNull(omMetadataManager.getDeletedTable().get(
         part1DeletedKeyName));
 
     RepeatedOmKeyInfo ro =
         omMetadataManager.getDeletedTable().get(part1DeletedKeyName);
-    Assert.assertEquals(OmKeyInfo.getFromProtobuf(part1.getPartKeyInfo()),
+    Assertions.assertEquals(OmKeyInfo.getFromProtobuf(part1.getPartKeyInfo()),
         ro.getOmKeyInfoList().get(0));
   }
 
@@ -218,15 +218,15 @@ public class TestS3MultipartUploadCommitPartResponseWithFSO
     s3MultipartUploadCommitPartResponse.checkAndUpdateDB(omMetadataManager,
             batchOperation);
 
-    Assert.assertNull(
+    Assertions.assertNull(
         omMetadataManager.getOpenKeyTable(getBucketLayout()).get(openKey));
-    Assert.assertNull(
+    Assertions.assertNull(
             omMetadataManager.getMultipartInfoTable().get(multipartKey));
 
     omMetadataManager.getStore().commitBatchOperation(batchOperation);
 
     // openkey entry should be there in delete table.
-    Assert.assertEquals(1, omMetadataManager.countRowsInTable(
+    Assertions.assertEquals(1, omMetadataManager.countRowsInTable(
             omMetadataManager.getDeletedTable()));
     String deletedKey = omMetadataManager
         .getMultipartKey(volumeName, bucketName, keyNameInvalid,
@@ -234,7 +234,7 @@ public class TestS3MultipartUploadCommitPartResponseWithFSO
     List<? extends Table.KeyValue<String, RepeatedOmKeyInfo>> rangeKVs
         = omMetadataManager.getDeletedTable().getRangeKVs(
         null, 100, deletedKey);
-    Assert.assertTrue(rangeKVs.size() > 0);
+    Assertions.assertTrue(rangeKVs.size() > 0);
   }
 
   private String getKeyName() {

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/s3/multipart/TestS3MultipartUploadCompleteResponseWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/s3/multipart/TestS3MultipartUploadCompleteResponseWithFSO.java
@@ -30,8 +30,8 @@ import org.apache.hadoop.ozone.om.request.OMRequestTestUtils;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.PartKeyInfo;
 import org.apache.hadoop.util.Time;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -104,10 +104,10 @@ public class TestS3MultipartUploadCompleteResponseWithFSO
     OmBucketInfo omBucketInfo =
         omMetadataManager.getBucketTable().get(bucketKey);
 
-    Assert.assertNotNull(
+    Assertions.assertNotNull(
         omMetadataManager.getMultipartInfoTable().get(dbMultipartKey));
-    Assert.assertNotNull(omMetadataManager.getOpenKeyTable(getBucketLayout())
-        .get(dbMultipartOpenKey));
+    Assertions.assertNotNull(omMetadataManager.getOpenKeyTable(
+        getBucketLayout()).get(dbMultipartOpenKey));
 
     List<OmKeyInfo> unUsedParts = new ArrayList<>();
     S3MultipartUploadCompleteResponse s3MultipartUploadCompleteResponse =
@@ -121,15 +121,15 @@ public class TestS3MultipartUploadCompleteResponseWithFSO
 
     omMetadataManager.getStore().commitBatchOperation(batchOperation);
 
-    Assert.assertNotNull(
+    Assertions.assertNotNull(
         omMetadataManager.getKeyTable(getBucketLayout()).get(dbKey));
-    Assert.assertNull(
+    Assertions.assertNull(
         omMetadataManager.getMultipartInfoTable().get(dbMultipartKey));
-    Assert.assertNull(omMetadataManager.getOpenKeyTable(getBucketLayout())
+    Assertions.assertNull(omMetadataManager.getOpenKeyTable(getBucketLayout())
         .get(dbMultipartOpenKey));
 
     // As no parts are created, so no entries should be there in delete table.
-    Assert.assertEquals(0, omMetadataManager.countRowsInTable(
+    Assertions.assertEquals(0, omMetadataManager.countRowsInTable(
             omMetadataManager.getDeletedTable()));
   }
 
@@ -188,10 +188,10 @@ public class TestS3MultipartUploadCompleteResponseWithFSO
     addS3MultipartUploadCommitPartResponseFSO(volumeName, bucketName, keyName,
         multipartUploadID, dbOpenKey);
 
-    Assert.assertNotNull(
+    Assertions.assertNotNull(
         omMetadataManager.getMultipartInfoTable().get(dbMultipartKey));
-    Assert.assertNotNull(omMetadataManager.getOpenKeyTable(getBucketLayout())
-        .get(dbMultipartOpenKey));
+    Assertions.assertNotNull(omMetadataManager.getOpenKeyTable(
+        getBucketLayout()).get(dbMultipartOpenKey));
 
     // S3MultipartUploadCompleteResponseWithFSO should accept null bucketInfo
     List<OmKeyInfo> unUsedParts = new ArrayList<>();
@@ -206,15 +206,15 @@ public class TestS3MultipartUploadCompleteResponseWithFSO
 
     omMetadataManager.getStore().commitBatchOperation(batchOperation);
 
-    Assert.assertNotNull(
+    Assertions.assertNotNull(
         omMetadataManager.getKeyTable(getBucketLayout()).get(dbKey));
-    Assert.assertNull(
+    Assertions.assertNull(
         omMetadataManager.getMultipartInfoTable().get(dbMultipartKey));
-    Assert.assertNull(omMetadataManager.getOpenKeyTable(getBucketLayout())
+    Assertions.assertNull(omMetadataManager.getOpenKeyTable(getBucketLayout())
         .get(dbMultipartOpenKey));
 
     // As no parts are created, so no entries should be there in delete table.
-    Assert.assertEquals(0, omMetadataManager.countRowsInTable(
+    Assertions.assertEquals(0, omMetadataManager.countRowsInTable(
         omMetadataManager.getDeletedTable()));
   }
 
@@ -232,7 +232,7 @@ public class TestS3MultipartUploadCompleteResponseWithFSO
 
     // As 1 unused parts exists, so 1 unused entry should be there in delete
     // table.
-    Assert.assertEquals(2, omMetadataManager.countRowsInTable(
+    Assertions.assertEquals(2, omMetadataManager.countRowsInTable(
             omMetadataManager.getDeletedTable()));
   }
 
@@ -265,12 +265,12 @@ public class TestS3MultipartUploadCompleteResponseWithFSO
     // Make sure new object isn't in delete table
     RepeatedOmKeyInfo ds = omMetadataManager.getDeletedTable().get(ozoneKey);
     for (OmKeyInfo omKeyInfo : ds.getOmKeyInfoList()) {
-      Assert.assertNotEquals(oId, omKeyInfo.getObjectID());
+      Assertions.assertNotEquals(oId, omKeyInfo.getObjectID());
     }
 
     // As 1 unused parts and 1 previously put-and-deleted object exist,
     // so 2 entries should be there in delete table.
-    Assert.assertEquals(3, omMetadataManager.countRowsInTable(
+    Assertions.assertEquals(3, omMetadataManager.countRowsInTable(
             omMetadataManager.getDeletedTable()));
   }
 
@@ -331,11 +331,11 @@ public class TestS3MultipartUploadCompleteResponseWithFSO
     omMetadataManager.getStore().commitBatchOperation(batchOperation);
     String dbKey = omMetadataManager.getOzonePathKey(volumeId, bucketId,
             parentID, omKeyInfoFSO.getFileName());
-    Assert.assertNotNull(
+    Assertions.assertNotNull(
         omMetadataManager.getKeyTable(getBucketLayout()).get(dbKey));
-    Assert.assertNull(
+    Assertions.assertNull(
             omMetadataManager.getMultipartInfoTable().get(dbMultipartKey));
-    Assert.assertNull(omMetadataManager.getOpenKeyTable(getBucketLayout())
+    Assertions.assertNull(omMetadataManager.getOpenKeyTable(getBucketLayout())
         .get(dbMultipartOpenKey));
 
     return omKeyInfoFSO.getObjectID();
@@ -371,28 +371,29 @@ public class TestS3MultipartUploadCompleteResponseWithFSO
     s3MultipartUploadCommitPartResponse.checkAndUpdateDB(omMetadataManager,
             batchOperation);
 
-    Assert.assertNull(
+    Assertions.assertNull(
         omMetadataManager.getOpenKeyTable(getBucketLayout()).get(multipartKey));
-    Assert.assertNull(
+    Assertions.assertNull(
         omMetadataManager.getMultipartInfoTable().get(multipartKey));
 
     omMetadataManager.getStore().commitBatchOperation(batchOperation);
 
     // As 1 parts are created, so 1 entry should be there in delete table.
-    Assert.assertEquals(deleteEntryCount, omMetadataManager.countRowsInTable(
+    Assertions.assertEquals(deleteEntryCount,
+        omMetadataManager.countRowsInTable(
         omMetadataManager.getDeletedTable()));
 
     String part1DeletedKeyName = omMetadataManager.getOzoneDeletePathKey(
         omMultipartKeyInfo.getPartKeyInfo(1).getPartKeyInfo().getObjectID(),
         multipartKey);
 
-    Assert.assertNotNull(omMetadataManager.getDeletedTable().get(
+    Assertions.assertNotNull(omMetadataManager.getDeletedTable().get(
         part1DeletedKeyName));
 
     RepeatedOmKeyInfo ro =
         omMetadataManager.getDeletedTable().get(part1DeletedKeyName);
     OmKeyInfo omPartKeyInfo = OmKeyInfo.getFromProtobuf(part1.getPartKeyInfo());
-    Assert.assertEquals(omPartKeyInfo, ro.getOmKeyInfoList().get(0));
+    Assertions.assertEquals(omPartKeyInfo, ro.getOmKeyInfoList().get(0));
 
     return omPartKeyInfo;
   }

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/security/TestOMDelegationTokenResponse.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/security/TestOMDelegationTokenResponse.java
@@ -24,34 +24,34 @@ import org.apache.hadoop.hdds.utils.db.BatchOperation;
 import org.apache.hadoop.ozone.om.OMConfigKeys;
 import org.apache.hadoop.ozone.om.OMMetadataManager;
 import org.apache.hadoop.ozone.om.OmMetadataManagerImpl;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.io.TempDir;
 import java.io.IOException;
+import java.nio.file.Path;
 
 /** Base test class for delegation token response. */
 @SuppressWarnings("visibilitymodifier")
 public class TestOMDelegationTokenResponse {
 
-  @Rule
-  public TemporaryFolder folder = new TemporaryFolder();
+  @TempDir
+  private Path folder;
 
   protected ConfigurationSource conf;
   protected OMMetadataManager omMetadataManager;
   protected BatchOperation batchOperation;
 
-  @Before
+  @BeforeEach
   public void setup() throws IOException {
     conf = new OzoneConfiguration();
     ((OzoneConfiguration) conf).set(OMConfigKeys.OZONE_OM_DB_DIRS,
-        folder.newFolder().getAbsolutePath());
+        folder.toAbsolutePath().toString());
     omMetadataManager = new OmMetadataManagerImpl((OzoneConfiguration) conf,
         null);
     batchOperation = omMetadataManager.getStore().initBatchOperation();
   }
 
-  @After
+  @AfterEach
   public void tearDown() {
     if (batchOperation != null) {
       batchOperation.close();

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/security/TestOMGetDelegationTokenResponse.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/security/TestOMGetDelegationTokenResponse.java
@@ -31,9 +31,9 @@ import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.Status;
 import org.apache.hadoop.ozone.security.proto.SecurityProtos.GetDelegationTokenRequestProto;
 import java.io.IOException;
 import java.util.UUID;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /** The class tests OMGetDelegationTokenResponse. */
 public class TestOMGetDelegationTokenResponse extends
@@ -42,7 +42,7 @@ public class TestOMGetDelegationTokenResponse extends
   private OzoneTokenIdentifier identifier;
   private UpdateGetDelegationTokenRequest updateGetDelegationTokenRequest;
 
-  @Before
+  @BeforeEach
   public void setupGetDelegationToken() {
     Text tester = new Text("tester");
     identifier = new OzoneTokenIdentifier(tester, tester, tester);
@@ -86,10 +86,10 @@ public class TestOMGetDelegationTokenResponse extends
     long rowNumInTable = 1;
     long rowNumInTokenTable = omMetadataManager
         .countRowsInTable(omMetadataManager.getDelegationTokenTable());
-    Assert.assertEquals(rowNumInTable, rowNumInTokenTable);
+    Assertions.assertEquals(rowNumInTable, rowNumInTokenTable);
 
     long renewTimeInTable = omMetadataManager.getDelegationTokenTable()
         .get(identifier);
-    Assert.assertEquals(renewTime, renewTimeInTable);
+    Assertions.assertEquals(renewTime, renewTimeInTable);
   }
 }

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/snapshot/TestOMSnapshotDeleteResponse.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/snapshot/TestOMSnapshotDeleteResponse.java
@@ -35,15 +35,15 @@ import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMRespo
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.Status;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.Type;
 import org.apache.hadoop.util.Time;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 import java.io.File;
 import java.util.UUID;
+import java.nio.file.Path;
 
 import static org.apache.hadoop.ozone.om.helpers.SnapshotInfo.SnapshotStatus.SNAPSHOT_ACTIVE;
 import static org.apache.hadoop.ozone.om.helpers.SnapshotInfo.SnapshotStatus.SNAPSHOT_DELETED;
@@ -53,24 +53,24 @@ import static org.apache.hadoop.ozone.om.helpers.SnapshotInfo.SnapshotStatus.SNA
  */
 public class TestOMSnapshotDeleteResponse {
 
-  @Rule
-  public TemporaryFolder folder = new TemporaryFolder();
+  @TempDir
+  private Path folder;
   
   private OMMetadataManager omMetadataManager;
   private BatchOperation batchOperation;
   private OzoneConfiguration ozoneConfiguration;
 
-  @Before
+  @BeforeEach
   public void setup() throws Exception {
     ozoneConfiguration = new OzoneConfiguration();
-    String fsPath = folder.newFolder().getAbsolutePath();
+    String fsPath = folder.toAbsolutePath().toString();
     ozoneConfiguration.set(OMConfigKeys.OZONE_OM_DB_DIRS,
         fsPath);
     omMetadataManager = new OmMetadataManagerImpl(ozoneConfiguration, null);
     batchOperation = omMetadataManager.getStore().initBatchOperation();
   }
 
-  @After
+  @AfterEach
   public void tearDown() {
     if (batchOperation != null) {
       batchOperation.close();
@@ -90,7 +90,7 @@ public class TestOMSnapshotDeleteResponse {
         Time.now());
 
     // confirm table is empty
-    Assert.assertEquals(0,
+    Assertions.assertEquals(0,
         omMetadataManager
         .countRowsInTable(omMetadataManager.getSnapshotInfoTable()));
 
@@ -112,10 +112,10 @@ public class TestOMSnapshotDeleteResponse {
     // Confirm snapshot directory was created
     String snapshotDir = OmSnapshotManager.getSnapshotPath(ozoneConfiguration,
         snapshotInfo);
-    Assert.assertTrue((new File(snapshotDir)).exists());
+    Assertions.assertTrue((new File(snapshotDir)).exists());
 
     // Confirm table has 1 entry
-    Assert.assertEquals(1, omMetadataManager
+    Assertions.assertEquals(1, omMetadataManager
         .countRowsInTable(omMetadataManager.getSnapshotInfoTable()));
 
     try (TableIterator<String, ? extends KeyValue<String, SnapshotInfo>> iter =
@@ -123,9 +123,10 @@ public class TestOMSnapshotDeleteResponse {
       // Check snapshotInfo entry content
       Table.KeyValue<String, SnapshotInfo> keyValue = iter.next();
       SnapshotInfo storedInfo = keyValue.getValue();
-      Assert.assertEquals(snapshotInfo.getTableKey(), keyValue.getKey());
-      Assert.assertEquals(snapshotInfo, storedInfo);
-      Assert.assertEquals(SNAPSHOT_ACTIVE, snapshotInfo.getSnapshotStatus());
+      Assertions.assertEquals(snapshotInfo.getTableKey(), keyValue.getKey());
+      Assertions.assertEquals(snapshotInfo, storedInfo);
+      Assertions.assertEquals(SNAPSHOT_ACTIVE,
+          snapshotInfo.getSnapshotStatus());
     }
 
     // Update snapshot status to DELETED
@@ -144,7 +145,7 @@ public class TestOMSnapshotDeleteResponse {
 
     // Confirm addToDBBatch result
     // 1. The table still has 1 entry
-    Assert.assertEquals(1, omMetadataManager
+    Assertions.assertEquals(1, omMetadataManager
         .countRowsInTable(omMetadataManager.getSnapshotInfoTable()));
 
     try (TableIterator<String, ? extends KeyValue<String, SnapshotInfo>> iter =
@@ -152,9 +153,10 @@ public class TestOMSnapshotDeleteResponse {
       // 2. snapshot status should now be DELETED
       Table.KeyValue<String, SnapshotInfo> keyValue = iter.next();
       SnapshotInfo storedInfo = keyValue.getValue();
-      Assert.assertEquals(snapshotInfo.getTableKey(), keyValue.getKey());
-      Assert.assertEquals(snapshotInfo, storedInfo);
-      Assert.assertEquals(SNAPSHOT_DELETED, snapshotInfo.getSnapshotStatus());
+      Assertions.assertEquals(snapshotInfo.getTableKey(), keyValue.getKey());
+      Assertions.assertEquals(snapshotInfo, storedInfo);
+      Assertions.assertEquals(SNAPSHOT_DELETED,
+          snapshotInfo.getSnapshotStatus());
     }
   }
 

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/volume/TestOMVolumeCreateResponse.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/volume/TestOMVolumeCreateResponse.java
@@ -125,8 +125,8 @@ public class TestOMVolumeCreateResponse {
     try {
       omVolumeCreateResponse.checkAndUpdateDB(omMetadataManager,
           batchOperation);
-      Assertions.assertTrue(omMetadataManager.countRowsInTable(
-          omMetadataManager.getVolumeTable()) == 0);
+      Assertions.assertEquals(0, omMetadataManager.countRowsInTable(
+          omMetadataManager.getVolumeTable()));
     } catch (IOException ex) {
       fail("testAddToDBBatchFailure failed");
     }

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/volume/TestOMVolumeCreateResponse.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/volume/TestOMVolumeCreateResponse.java
@@ -32,39 +32,39 @@ import org.apache.hadoop.ozone.storage.proto.
     OzoneManagerStorageProtos.PersistedUserVolumeInfo;
 import org.apache.hadoop.util.Time;
 import org.apache.hadoop.hdds.utils.db.BatchOperation;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 import java.io.IOException;
+import java.nio.file.Path;
 import java.util.UUID;
 
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  * This class tests OMVolumeCreateResponse.
  */
 public class TestOMVolumeCreateResponse {
 
-  @Rule
-  public TemporaryFolder folder = new TemporaryFolder();
+  @TempDir
+  private Path folder;
 
   private OMMetadataManager omMetadataManager;
   private BatchOperation batchOperation;
 
-  @Before
+  @BeforeEach
   public void setup() throws Exception {
     OzoneConfiguration ozoneConfiguration = new OzoneConfiguration();
     ozoneConfiguration.set(OMConfigKeys.OZONE_OM_DB_DIRS,
-        folder.newFolder().getAbsolutePath());
+        folder.toAbsolutePath().toString());
     omMetadataManager = new OmMetadataManagerImpl(ozoneConfiguration, null);
     batchOperation = omMetadataManager.getStore().initBatchOperation();
   }
 
-  @After
+  @AfterEach
   public void tearDown() {
     if (batchOperation != null) {
       batchOperation.close();
@@ -99,12 +99,12 @@ public class TestOMVolumeCreateResponse {
     omMetadataManager.getStore().commitBatchOperation(batchOperation);
 
 
-    Assert.assertEquals(1,
+    Assertions.assertEquals(1,
         omMetadataManager.countRowsInTable(omMetadataManager.getVolumeTable()));
-    Assert.assertEquals(omVolumeArgs,
+    Assertions.assertEquals(omVolumeArgs,
         omMetadataManager.getVolumeTable().iterator().next().getValue());
 
-    Assert.assertEquals(volumeList,
+    Assertions.assertEquals(volumeList,
         omMetadataManager.getUserTable().get(
             omMetadataManager.getUserKey(userName)));
   }
@@ -125,7 +125,7 @@ public class TestOMVolumeCreateResponse {
     try {
       omVolumeCreateResponse.checkAndUpdateDB(omMetadataManager,
           batchOperation);
-      Assert.assertTrue(omMetadataManager.countRowsInTable(
+      Assertions.assertTrue(omMetadataManager.countRowsInTable(
           omMetadataManager.getVolumeTable()) == 0);
     } catch (IOException ex) {
       fail("testAddToDBBatchFailure failed");

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/volume/TestOMVolumeDeleteResponse.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/volume/TestOMVolumeDeleteResponse.java
@@ -31,39 +31,39 @@ import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos
 import org.apache.hadoop.ozone.storage.proto.OzoneManagerStorageProtos.PersistedUserVolumeInfo;
 import org.apache.hadoop.util.Time;
 import org.apache.hadoop.hdds.utils.db.BatchOperation;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 import java.io.IOException;
 import java.util.UUID;
+import java.nio.file.Path;
 
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  * This class tests OMVolumeCreateResponse.
  */
 public class TestOMVolumeDeleteResponse {
 
-  @Rule
-  public TemporaryFolder folder = new TemporaryFolder();
+  @TempDir
+  private Path folder;
 
   private OMMetadataManager omMetadataManager;
   private BatchOperation batchOperation;
 
-  @Before
+  @BeforeEach
   public void setup() throws Exception {
     OzoneConfiguration ozoneConfiguration = new OzoneConfiguration();
     ozoneConfiguration.set(OMConfigKeys.OZONE_OM_DB_DIRS,
-        folder.newFolder().getAbsolutePath());
+        folder.toAbsolutePath().toString());
     omMetadataManager = new OmMetadataManagerImpl(ozoneConfiguration, null);
     batchOperation = omMetadataManager.getStore().initBatchOperation();
   }
 
-  @After
+  @AfterEach
   public void tearDown() {
     if (batchOperation != null) {
       batchOperation.close();
@@ -107,13 +107,11 @@ public class TestOMVolumeDeleteResponse {
     // Do manual commit and see whether addToBatch is successful or not.
     omMetadataManager.getStore().commitBatchOperation(batchOperation);
 
-    Assert.assertNull(null,
-        omMetadataManager.getVolumeTable().get(
+    Assertions.assertNull(omMetadataManager.getVolumeTable().get(
             omMetadataManager.getVolumeKey(volumeName)));
 
-    Assert.assertEquals(null,
-        omMetadataManager.getUserTable().get(
-            omMetadataManager.getUserKey(userName)));
+    Assertions.assertNull(omMetadataManager.getUserTable().get(
+        omMetadataManager.getUserKey(userName)));
   }
 
   @Test

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/volume/TestOMVolumeSetOwnerResponse.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/volume/TestOMVolumeSetOwnerResponse.java
@@ -155,8 +155,8 @@ public class TestOMVolumeSetOwnerResponse {
     try {
       omVolumeSetOwnerResponse.checkAndUpdateDB(omMetadataManager,
           batchOperation);
-      Assertions.assertTrue(omMetadataManager.countRowsInTable(
-          omMetadataManager.getVolumeTable()) == 0);
+      Assertions.assertEquals(0, omMetadataManager.countRowsInTable(
+          omMetadataManager.getVolumeTable()));
     } catch (IOException ex) {
       fail("testAddToDBBatchFailure failed");
     }

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/volume/TestOMVolumeSetOwnerResponse.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/volume/TestOMVolumeSetOwnerResponse.java
@@ -32,39 +32,39 @@ import org.apache.hadoop.ozone.storage.proto.OzoneManagerStorageProtos.Persisted
 import org.apache.hadoop.util.Time;
 import org.apache.hadoop.hdds.utils.db.BatchOperation;
 import org.apache.hadoop.hdds.utils.db.Table;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 import java.io.IOException;
+import java.nio.file.Path;
 import java.util.UUID;
 
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  * This class tests OMVolumeCreateResponse.
  */
 public class TestOMVolumeSetOwnerResponse {
 
-  @Rule
-  public TemporaryFolder folder = new TemporaryFolder();
+  @TempDir
+  private Path folder;
 
   private OMMetadataManager omMetadataManager;
   private BatchOperation batchOperation;
 
-  @Before
+  @BeforeEach
   public void setup() throws Exception {
     OzoneConfiguration ozoneConfiguration = new OzoneConfiguration();
     ozoneConfiguration.set(OMConfigKeys.OZONE_OM_DB_DIRS,
-        folder.newFolder().getAbsolutePath());
+        folder.toAbsolutePath().toString());
     omMetadataManager = new OmMetadataManagerImpl(ozoneConfiguration, null);
     batchOperation = omMetadataManager.getStore().initBatchOperation();
   }
 
-  @After
+  @AfterEach
   public void tearDown() {
     if (batchOperation != null) {
       batchOperation.close();
@@ -124,17 +124,17 @@ public class TestOMVolumeSetOwnerResponse {
     omMetadataManager.getStore().commitBatchOperation(batchOperation);
 
 
-    Assert.assertEquals(1,
+    Assertions.assertEquals(1,
         omMetadataManager.countRowsInTable(omMetadataManager.getVolumeTable()));
 
     Table.KeyValue<String, OmVolumeArgs> keyValue =
         omMetadataManager.getVolumeTable().iterator().next();
 
-    Assert.assertEquals(omMetadataManager.getVolumeKey(volumeName),
+    Assertions.assertEquals(omMetadataManager.getVolumeKey(volumeName),
         keyValue.getKey());
-    Assert.assertEquals(newOwnerVolumeArgs, keyValue.getValue());
+    Assertions.assertEquals(newOwnerVolumeArgs, keyValue.getValue());
 
-    Assert.assertEquals(volumeList,
+    Assertions.assertEquals(volumeList,
         omMetadataManager.getUserTable().get(
             omMetadataManager.getUserKey(newOwner)));
   }
@@ -155,7 +155,7 @@ public class TestOMVolumeSetOwnerResponse {
     try {
       omVolumeSetOwnerResponse.checkAndUpdateDB(omMetadataManager,
           batchOperation);
-      Assert.assertTrue(omMetadataManager.countRowsInTable(
+      Assertions.assertTrue(omMetadataManager.countRowsInTable(
           omMetadataManager.getVolumeTable()) == 0);
     } catch (IOException ex) {
       fail("testAddToDBBatchFailure failed");

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/volume/TestOMVolumeSetQuotaResponse.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/volume/TestOMVolumeSetQuotaResponse.java
@@ -123,8 +123,8 @@ public class TestOMVolumeSetQuotaResponse {
     try {
       omVolumeSetQuotaResponse.checkAndUpdateDB(omMetadataManager,
           batchOperation);
-      Assertions.assertTrue(omMetadataManager.countRowsInTable(
-          omMetadataManager.getVolumeTable()) == 0);
+      Assertions.assertEquals(0, omMetadataManager.countRowsInTable(
+          omMetadataManager.getVolumeTable()));
     } catch (IOException ex) {
       fail("testAddToDBBatchFailure failed");
     }

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/volume/TestOMVolumeSetQuotaResponse.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/volume/TestOMVolumeSetQuotaResponse.java
@@ -31,39 +31,39 @@ import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos
 import org.apache.hadoop.util.Time;
 import org.apache.hadoop.hdds.utils.db.BatchOperation;
 import org.apache.hadoop.hdds.utils.db.Table;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 import java.io.IOException;
+import java.nio.file.Path;
 import java.util.UUID;
 
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  * This class tests OMVolumeCreateResponse.
  */
 public class TestOMVolumeSetQuotaResponse {
 
-  @Rule
-  public TemporaryFolder folder = new TemporaryFolder();
+  @TempDir
+  private Path folder;
 
   private OMMetadataManager omMetadataManager;
   private BatchOperation batchOperation;
 
-  @Before
+  @BeforeEach
   public void setup() throws Exception {
     OzoneConfiguration ozoneConfiguration = new OzoneConfiguration();
     ozoneConfiguration.set(OMConfigKeys.OZONE_OM_DB_DIRS,
-        folder.newFolder().getAbsolutePath());
+        folder.toAbsolutePath().toString());
     omMetadataManager = new OmMetadataManagerImpl(ozoneConfiguration, null);
     batchOperation = omMetadataManager.getStore().initBatchOperation();
   }
 
-  @After
+  @AfterEach
   public void tearDown() {
     if (batchOperation != null) {
       batchOperation.close();
@@ -95,15 +95,15 @@ public class TestOMVolumeSetQuotaResponse {
     // Do manual commit and see whether addToBatch is successful or not.
     omMetadataManager.getStore().commitBatchOperation(batchOperation);
 
-    Assert.assertEquals(1,
+    Assertions.assertEquals(1,
         omMetadataManager.countRowsInTable(omMetadataManager.getVolumeTable()));
 
     Table.KeyValue<String, OmVolumeArgs> keyValue =
         omMetadataManager.getVolumeTable().iterator().next();
 
-    Assert.assertEquals(omMetadataManager.getVolumeKey(volumeName),
+    Assertions.assertEquals(omMetadataManager.getVolumeKey(volumeName),
         keyValue.getKey());
-    Assert.assertEquals(omVolumeArgs, keyValue.getValue());
+    Assertions.assertEquals(omVolumeArgs, keyValue.getValue());
 
   }
 
@@ -123,7 +123,7 @@ public class TestOMVolumeSetQuotaResponse {
     try {
       omVolumeSetQuotaResponse.checkAndUpdateDB(omMetadataManager,
           batchOperation);
-      Assert.assertTrue(omMetadataManager.countRowsInTable(
+      Assertions.assertTrue(omMetadataManager.countRowsInTable(
           omMetadataManager.getVolumeTable()) == 0);
     } catch (IOException ex) {
       fail("testAddToDBBatchFailure failed");

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/service/TestDirectoryDeletingService.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/service/TestDirectoryDeletingService.java
@@ -21,6 +21,7 @@ package org.apache.hadoop.ozone.om.service;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Path;
 import java.util.concurrent.TimeUnit;
 import org.apache.hadoop.hdds.client.StandaloneReplicationConfig;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
@@ -41,12 +42,11 @@ import org.apache.hadoop.ozone.om.request.OMRequestTestUtils;
 import org.apache.hadoop.util.Time;
 import org.apache.ozone.test.GenericTestUtils;
 import org.apache.ratis.util.ExitUtils;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_DIR_DELETING_SERVICE_INTERVAL;
 
@@ -54,23 +54,23 @@ import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_DIR_DELETING_SERVICE
  * Test Directory Deleting Service.
  */
 public class TestDirectoryDeletingService {
-  @Rule
-  public TemporaryFolder folder = new TemporaryFolder();
+  @TempDir
+  private Path folder;
   private OzoneManagerProtocol writeClient;
   private OzoneManager om;
   private String volumeName;
   private String bucketName;
 
-  @BeforeClass
+  @BeforeAll
   public static void setup() {
     ExitUtils.disableSystemExit();
   }
 
   private OzoneConfiguration createConfAndInitValues() throws IOException {
     OzoneConfiguration conf = new OzoneConfiguration();
-    File newFolder = folder.newFolder();
+    File newFolder = folder.toFile();
     if (!newFolder.exists()) {
-      Assert.assertTrue(newFolder.mkdirs());
+      Assertions.assertTrue(newFolder.mkdirs());
     }
     System.setProperty(DBConfigFromFile.CONFIG_DIR, "/");
     ServerUtils.setOzoneMetaDirPath(conf, newFolder.toString());
@@ -85,7 +85,7 @@ public class TestDirectoryDeletingService {
     return conf;
   }
 
-  @After
+  @AfterEach
   public void cleanup() throws Exception {
     om.stop();
   }
@@ -155,6 +155,6 @@ public class TestDirectoryDeletingService {
         () -> dirDeletingService.getMovedFilesCount() >= 1000
             && dirDeletingService.getMovedFilesCount() < 2000,
         500, 60000);
-    Assert.assertTrue(dirDeletingService.getRunCount().get() >= 1);
+    Assertions.assertTrue(dirDeletingService.getRunCount().get() >= 1);
   }
 }

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/service/TestKeyDeletingService.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/service/TestKeyDeletingService.java
@@ -21,6 +21,7 @@ package org.apache.hadoop.ozone.om.service;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -53,7 +54,8 @@ import org.apache.hadoop.ozone.om.request.OMRequestTestUtils;
 import org.apache.hadoop.ozone.om.snapshot.ReferenceCounted;
 import org.apache.hadoop.ozone.om.snapshot.SnapshotCache;
 import org.apache.ratis.util.ExitUtils;
-import org.junit.BeforeClass;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.io.TempDir;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -81,14 +83,10 @@ import static org.apache.hadoop.ozone.om.OmSnapshotManager.getSnapshotPrefix;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.fail;
 
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
-import org.junit.rules.TestRule;
-import org.junit.rules.Timeout;
-import org.apache.ozone.test.JUnit5AwareTimeout;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 /**
  * Test Key Deleting Service.
@@ -99,28 +97,25 @@ import org.apache.ozone.test.JUnit5AwareTimeout;
  * Metadata Manager. 3. Waits for a while for the KeyDeleting Service to pick up
  * and call into SCM. 4. Confirms that calls have been successful.
  */
+@Timeout(300)
 public class TestKeyDeletingService {
-  @Rule
-  public TemporaryFolder folder = new TemporaryFolder();
-
-  @Rule
-  public TestRule timeout = new JUnit5AwareTimeout(Timeout.seconds(300));
-
+  @TempDir
+  private Path folder;
   private OzoneManagerProtocol writeClient;
   private OzoneManager om;
   private static final Logger LOG =
       LoggerFactory.getLogger(TestKeyDeletingService.class);
 
-  @BeforeClass
+  @BeforeAll
   public static void setup() {
     ExitUtils.disableSystemExit();
   }
 
   private OzoneConfiguration createConfAndInitValues() throws IOException {
     OzoneConfiguration conf = new OzoneConfiguration();
-    File newFolder = folder.newFolder();
+    File newFolder = folder.toFile();
     if (!newFolder.exists()) {
-      Assert.assertTrue(newFolder.mkdirs());
+      Assertions.assertTrue(newFolder.mkdirs());
     }
     System.setProperty(DBConfigFromFile.CONFIG_DIR, "/");
     ServerUtils.setOzoneMetaDirPath(conf, newFolder.toString());
@@ -135,7 +130,7 @@ public class TestKeyDeletingService {
     return conf;
   }
 
-  @After
+  @AfterEach
   public void cleanup() throws Exception {
     om.stop();
   }
@@ -167,9 +162,9 @@ public class TestKeyDeletingService {
     GenericTestUtils.waitFor(
         () -> keyDeletingService.getDeletedKeyCount().get() >= keyCount,
         1000, 10000);
-    Assert.assertTrue(keyDeletingService.getRunCount().get() > 1);
-    Assert.assertEquals(0, keyManager.getPendingDeletionKeys(Integer.MAX_VALUE)
-        .getKeyBlocksList().size());
+    Assertions.assertTrue(keyDeletingService.getRunCount().get() > 1);
+    Assertions.assertEquals(0, keyManager.getPendingDeletionKeys(
+        Integer.MAX_VALUE).getKeyBlocksList().size());
   }
 
   @Test
@@ -212,8 +207,8 @@ public class TestKeyDeletingService {
         () -> keyDeletingService.getRunCount().get() >= 5,
         100, 1000);
     // Since SCM calls are failing, deletedKeyCount should be zero.
-    Assert.assertEquals(0, keyDeletingService.getDeletedKeyCount().get());
-    Assert.assertEquals(keyCount, keyManager
+    Assertions.assertEquals(0, keyDeletingService.getDeletedKeyCount().get());
+    Assertions.assertEquals(keyCount, keyManager
         .getPendingDeletionKeys(Integer.MAX_VALUE).getKeyBlocksList().size());
   }
 
@@ -261,7 +256,7 @@ public class TestKeyDeletingService {
         100, 1000);
     // the blockClient is set to fail the deletion of key blocks, hence no keys
     // will be deleted
-    Assert.assertEquals(0, keyDeletingService.getDeletedKeyCount().get());
+    Assertions.assertEquals(0, keyDeletingService.getDeletedKeyCount().get());
   }
 
   @Test
@@ -333,7 +328,7 @@ public class TestKeyDeletingService {
 
     // the blockClient is set to fail the deletion of key blocks, hence no keys
     // will be deleted
-    Assert.assertEquals(0, keyDeletingService.getDeletedKeyCount().get());
+    Assertions.assertEquals(0, keyDeletingService.getDeletedKeyCount().get());
   }
 
   @Test
@@ -369,16 +364,17 @@ public class TestKeyDeletingService {
     GenericTestUtils.waitFor(
         () -> keyDeletingService.getDeletedKeyCount().get() >= 1,
         1000, 10000);
-    Assert.assertTrue(keyDeletingService.getRunCount().get() > 1);
-    Assert.assertEquals(0, keyManager.getPendingDeletionKeys(Integer.MAX_VALUE)
-            .getKeyBlocksList().size());
+    Assertions.assertTrue(keyDeletingService.getRunCount().get() > 1);
+    Assertions.assertEquals(0, keyManager.getPendingDeletionKeys(
+        Integer.MAX_VALUE).getKeyBlocksList().size());
 
     // The 1st version of the key has 1 block and the 2nd version has 2
     // blocks. Hence, the ScmBlockClient should have received atleast 3
     // blocks for deletion from the KeyDeletionService
     ScmBlockLocationTestingClient scmBlockTestingClient =
         (ScmBlockLocationTestingClient) omTestManagers.getScmBlockClient();
-    Assert.assertTrue(scmBlockTestingClient.getNumberOfDeletedBlocks() >= 3);
+    Assertions.assertTrue(
+        scmBlockTestingClient.getNumberOfDeletedBlocks() >= 3);
   }
 
   private void createAndDeleteKeys(KeyManager keyManager, int keyCount,
@@ -447,12 +443,12 @@ public class TestKeyDeletingService {
     GenericTestUtils.waitFor(
         () -> keyDeletingService.getDeletedKeyCount().get() >= 1,
         1000, 10000);
-    Assert.assertTrue(keyDeletingService.getRunCount().get() > 1);
-    Assert.assertEquals(0, keyManager
+    Assertions.assertTrue(keyDeletingService.getRunCount().get() > 1);
+    Assertions.assertEquals(0, keyManager
         .getPendingDeletionKeys(Integer.MAX_VALUE).getKeyBlocksList().size());
 
     // deletedTable should have deleted key of the snapshot bucket
-    Assert.assertFalse(metadataManager.getDeletedTable().isEmpty());
+    Assertions.assertFalse(metadataManager.getDeletedTable().isEmpty());
     String ozoneKey1 =
         metadataManager.getOzoneKey(volumeName, bucketName1, keyName);
     String ozoneKey2 =
@@ -464,11 +460,11 @@ public class TestKeyDeletingService {
     List<? extends Table.KeyValue<String, RepeatedOmKeyInfo>> rangeKVs
         = metadataManager.getDeletedTable().getRangeKVs(
         null, 100, ozoneKey1);
-    Assert.assertTrue(rangeKVs.size() > 0);
+    Assertions.assertTrue(rangeKVs.size() > 0);
     rangeKVs
         = metadataManager.getDeletedTable().getRangeKVs(
         null, 100, ozoneKey2);
-    Assert.assertTrue(rangeKVs.size() == 0);
+    Assertions.assertTrue(rangeKVs.size() == 0);
   }
 
   /*

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/service/TestKeyDeletingService.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/service/TestKeyDeletingService.java
@@ -80,7 +80,6 @@ import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationFactor
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_BLOCK_DELETING_SERVICE_INTERVAL;
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_SNAPSHOT_DELETING_SERVICE_INTERVAL;
 import static org.apache.hadoop.ozone.om.OmSnapshotManager.getSnapshotPrefix;
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.fail;
 
 import org.junit.jupiter.api.AfterEach;
@@ -464,7 +463,7 @@ public class TestKeyDeletingService {
     rangeKVs
         = metadataManager.getDeletedTable().getRangeKVs(
         null, 100, ozoneKey2);
-    Assertions.assertTrue(rangeKVs.size() == 0);
+    Assertions.assertEquals(0, rangeKVs.size());
   }
 
   /*
@@ -670,10 +669,11 @@ t
       while (iterator.hasNext()) {
         Table.KeyValue<String, SnapshotInfo> snapshotEntry = iterator.next();
         String snapshotName = snapshotEntry.getValue().getName();
-        assertEquals(expectedSize.get(snapshotName), snapshotEntry.getValue().
+        Assertions.assertEquals(expectedSize.get(snapshotName),
+            snapshotEntry.getValue().
             getExclusiveSize());
         // Since for the test we are using RATIS/THREE
-        assertEquals(expectedSize.get(snapshotName) * 3,
+        Assertions.assertEquals(expectedSize.get(snapshotName) * 3,
             snapshotEntry.getValue().getExclusiveReplicatedSize());
       }
     }
@@ -686,7 +686,7 @@ t
              iterator = snapshotInfoTable.iterator()) {
       while (iterator.hasNext()) {
         SnapshotInfo snapInfo = iterator.next().getValue();
-        assertEquals(snapInfo.getDeepClean(), deepClean);
+        Assertions.assertEquals(snapInfo.getDeepClean(), deepClean);
       }
     }
   }

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/service/TestQuotaRepairTask.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/service/TestQuotaRepairTask.java
@@ -78,12 +78,12 @@ public class TestQuotaRepairTask extends TestOMKeyRequest {
     // and directory table
     OmBucketInfo obsBucketInfo = omMetadataManager.getBucketTable().get(
         omMetadataManager.getBucketKey(volumeName, bucketName));
-    Assertions.assertTrue(obsBucketInfo.getUsedNamespace() == 0);
-    Assertions.assertTrue(obsBucketInfo.getUsedBytes() == 0);
+    Assertions.assertEquals(0, obsBucketInfo.getUsedNamespace());
+    Assertions.assertEquals(0, obsBucketInfo.getUsedBytes());
     OmBucketInfo fsoBucketInfo = omMetadataManager.getBucketTable().get(
         omMetadataManager.getBucketKey(volumeName, fsoBucketName));
-    Assertions.assertTrue(fsoBucketInfo.getUsedNamespace() == 0);
-    Assertions.assertTrue(fsoBucketInfo.getUsedBytes() == 0);
+    Assertions.assertEquals(0, fsoBucketInfo.getUsedNamespace());
+    Assertions.assertEquals(0, fsoBucketInfo.getUsedBytes());
     
     QuotaRepairTask quotaRepairTask = new QuotaRepairTask(omMetadataManager);
     quotaRepairTask.repair();
@@ -94,10 +94,10 @@ public class TestQuotaRepairTask extends TestOMKeyRequest {
         omMetadataManager.getBucketKey(volumeName, bucketName));
     OmBucketInfo fsoUpdateBucketInfo = omMetadataManager.getBucketTable().get(
         omMetadataManager.getBucketKey(volumeName, fsoBucketName));
-    Assertions.assertTrue(obsUpdateBucketInfo.getUsedNamespace() == 10);
-    Assertions.assertTrue(obsUpdateBucketInfo.getUsedBytes() == 30000);
-    Assertions.assertTrue(fsoUpdateBucketInfo.getUsedNamespace() == 13);
-    Assertions.assertTrue(fsoUpdateBucketInfo.getUsedBytes() == 10000);
+    Assertions.assertEquals(10, obsUpdateBucketInfo.getUsedNamespace());
+    Assertions.assertEquals(30000, obsUpdateBucketInfo.getUsedBytes());
+    Assertions.assertEquals(13, fsoUpdateBucketInfo.getUsedNamespace());
+    Assertions.assertEquals(10000, fsoUpdateBucketInfo.getUsedBytes());
   }
 
   @Test
@@ -121,23 +121,23 @@ public class TestQuotaRepairTask extends TestOMKeyRequest {
     // pre check for quota flag
     OmBucketInfo bucketInfo = omMetadataManager.getBucketTable().get(
         omMetadataManager.getBucketKey(volumeName, bucketName));
-    Assertions.assertTrue(bucketInfo.getQuotaInBytes() == -2);
+    Assertions.assertEquals(-2, bucketInfo.getQuotaInBytes());
     
     omVolumeArgs = omMetadataManager.getVolumeTable().get(
         omMetadataManager.getVolumeKey(volumeName));
-    Assertions.assertTrue(omVolumeArgs.getQuotaInBytes() == -2);
-    Assertions.assertTrue(omVolumeArgs.getQuotaInNamespace() == -2);
+    Assertions.assertEquals(-2, omVolumeArgs.getQuotaInBytes());
+    Assertions.assertEquals(-2, omVolumeArgs.getQuotaInNamespace());
 
     QuotaRepairTask quotaRepairTask = new QuotaRepairTask(omMetadataManager);
     quotaRepairTask.repair();
 
     bucketInfo = omMetadataManager.getBucketTable().get(
         omMetadataManager.getBucketKey(volumeName, bucketName));
-    Assertions.assertTrue(bucketInfo.getQuotaInBytes() == -1);
+    Assertions.assertEquals(-1, bucketInfo.getQuotaInBytes());
     OmVolumeArgs volArgsVerify = omMetadataManager.getVolumeTable()
         .get(omMetadataManager.getVolumeKey(volumeName));
-    Assertions.assertTrue(volArgsVerify.getQuotaInBytes() == -1);
-    Assertions.assertTrue(volArgsVerify.getQuotaInNamespace() == -1);
+    Assertions.assertEquals(-1, volArgsVerify.getQuotaInBytes());
+    Assertions.assertEquals(-1, volArgsVerify.getQuotaInNamespace());
   }
 
   private void zeroOutBucketUsedBytes(String volumeName, String bucketName,

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/service/TestQuotaRepairTask.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/service/TestQuotaRepairTask.java
@@ -29,8 +29,8 @@ import org.apache.hadoop.ozone.om.helpers.OmVolumeArgs;
 import org.apache.hadoop.ozone.om.request.OMRequestTestUtils;
 import org.apache.hadoop.ozone.om.request.key.TestOMKeyRequest;
 import org.apache.hadoop.util.Time;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 
@@ -78,12 +78,12 @@ public class TestQuotaRepairTask extends TestOMKeyRequest {
     // and directory table
     OmBucketInfo obsBucketInfo = omMetadataManager.getBucketTable().get(
         omMetadataManager.getBucketKey(volumeName, bucketName));
-    Assert.assertTrue(obsBucketInfo.getUsedNamespace() == 0);
-    Assert.assertTrue(obsBucketInfo.getUsedBytes() == 0);
+    Assertions.assertTrue(obsBucketInfo.getUsedNamespace() == 0);
+    Assertions.assertTrue(obsBucketInfo.getUsedBytes() == 0);
     OmBucketInfo fsoBucketInfo = omMetadataManager.getBucketTable().get(
         omMetadataManager.getBucketKey(volumeName, fsoBucketName));
-    Assert.assertTrue(fsoBucketInfo.getUsedNamespace() == 0);
-    Assert.assertTrue(fsoBucketInfo.getUsedBytes() == 0);
+    Assertions.assertTrue(fsoBucketInfo.getUsedNamespace() == 0);
+    Assertions.assertTrue(fsoBucketInfo.getUsedBytes() == 0);
     
     QuotaRepairTask quotaRepairTask = new QuotaRepairTask(omMetadataManager);
     quotaRepairTask.repair();
@@ -94,10 +94,10 @@ public class TestQuotaRepairTask extends TestOMKeyRequest {
         omMetadataManager.getBucketKey(volumeName, bucketName));
     OmBucketInfo fsoUpdateBucketInfo = omMetadataManager.getBucketTable().get(
         omMetadataManager.getBucketKey(volumeName, fsoBucketName));
-    Assert.assertTrue(obsUpdateBucketInfo.getUsedNamespace() == 10);
-    Assert.assertTrue(obsUpdateBucketInfo.getUsedBytes() == 30000);
-    Assert.assertTrue(fsoUpdateBucketInfo.getUsedNamespace() == 13);
-    Assert.assertTrue(fsoUpdateBucketInfo.getUsedBytes() == 10000);
+    Assertions.assertTrue(obsUpdateBucketInfo.getUsedNamespace() == 10);
+    Assertions.assertTrue(obsUpdateBucketInfo.getUsedBytes() == 30000);
+    Assertions.assertTrue(fsoUpdateBucketInfo.getUsedNamespace() == 13);
+    Assertions.assertTrue(fsoUpdateBucketInfo.getUsedBytes() == 10000);
   }
 
   @Test
@@ -121,23 +121,23 @@ public class TestQuotaRepairTask extends TestOMKeyRequest {
     // pre check for quota flag
     OmBucketInfo bucketInfo = omMetadataManager.getBucketTable().get(
         omMetadataManager.getBucketKey(volumeName, bucketName));
-    Assert.assertTrue(bucketInfo.getQuotaInBytes() == -2);
+    Assertions.assertTrue(bucketInfo.getQuotaInBytes() == -2);
     
     omVolumeArgs = omMetadataManager.getVolumeTable().get(
         omMetadataManager.getVolumeKey(volumeName));
-    Assert.assertTrue(omVolumeArgs.getQuotaInBytes() == -2);
-    Assert.assertTrue(omVolumeArgs.getQuotaInNamespace() == -2);
+    Assertions.assertTrue(omVolumeArgs.getQuotaInBytes() == -2);
+    Assertions.assertTrue(omVolumeArgs.getQuotaInNamespace() == -2);
 
     QuotaRepairTask quotaRepairTask = new QuotaRepairTask(omMetadataManager);
     quotaRepairTask.repair();
 
     bucketInfo = omMetadataManager.getBucketTable().get(
         omMetadataManager.getBucketKey(volumeName, bucketName));
-    Assert.assertTrue(bucketInfo.getQuotaInBytes() == -1);
+    Assertions.assertTrue(bucketInfo.getQuotaInBytes() == -1);
     OmVolumeArgs volArgsVerify = omMetadataManager.getVolumeTable()
         .get(omMetadataManager.getVolumeKey(volumeName));
-    Assert.assertTrue(volArgsVerify.getQuotaInBytes() == -1);
-    Assert.assertTrue(volArgsVerify.getQuotaInNamespace() == -1);
+    Assertions.assertTrue(volArgsVerify.getQuotaInBytes() == -1);
+    Assertions.assertTrue(volArgsVerify.getQuotaInNamespace() == -1);
   }
 
   private void zeroOutBucketUsedBytes(String volumeName, String bucketName,

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/upgrade/TestOMLayoutFeatureAspect.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/upgrade/TestOMLayoutFeatureAspect.java
@@ -19,23 +19,23 @@
 package org.apache.hadoop.ozone.om.upgrade;
 
 import static org.apache.hadoop.ozone.om.upgrade.OMLayoutFeature.INITIAL_VERSION;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import java.io.IOException;
+import java.nio.file.Path;
 
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.ozone.om.OzoneManager;
 import org.apache.hadoop.ozone.om.exceptions.OMException;
 import org.aspectj.lang.JoinPoint;
 import org.aspectj.lang.reflect.MethodSignature;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 /**
  * Class to test annotation based interceptor that checks whether layout
@@ -43,15 +43,15 @@ import org.junit.rules.TemporaryFolder;
  */
 public class TestOMLayoutFeatureAspect {
 
-  @Rule
-  public TemporaryFolder temporaryFolder = new TemporaryFolder();
+  @TempDir
+  private Path temporaryFolder;
 
   private OzoneConfiguration configuration = new OzoneConfiguration();
 
-  @Before
+  @BeforeEach
   public void setUp() throws IOException {
     configuration.set("ozone.metadata.dirs",
-        temporaryFolder.newFolder().getAbsolutePath());
+        String.valueOf(temporaryFolder.toAbsolutePath()));
   }
 
   /**

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/upgrade/TestOMUpgradeFinalizer.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/upgrade/TestOMUpgradeFinalizer.java
@@ -24,15 +24,14 @@ import org.apache.hadoop.ozone.upgrade.LayoutFeature;
 import org.apache.hadoop.ozone.upgrade.UpgradeException;
 import org.apache.hadoop.ozone.upgrade.UpgradeFinalizer;
 import org.apache.hadoop.ozone.upgrade.UpgradeFinalizer.StatusAndMessages;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
-import org.mockito.stubbing.Answer;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.verification.VerificationMode;
-
+import org.mockito.stubbing.Answer;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Iterator;
@@ -47,22 +46,21 @@ import static org.apache.hadoop.ozone.upgrade.UpgradeFinalizer.Status.FINALIZATI
 import static org.apache.hadoop.ozone.upgrade.UpgradeFinalizer.Status.STARTING_FINALIZATION;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.instanceOf;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.anyInt;
-import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 /**
  * {@link OMUpgradeFinalizer} tests.
  */
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class TestOMUpgradeFinalizer {
 
   private static final String CLIENT_ID = "clientID";
@@ -70,9 +68,6 @@ public class TestOMUpgradeFinalizer {
 
   @Mock
   private OMLayoutVersionManager versionManager;
-
-  @Rule
-  public ExpectedException exception = ExpectedException.none();
 
   @Test
   public void testEmitsFinalizedStatusIfAlreadyFinalized() throws Exception {
@@ -147,10 +142,11 @@ public class TestOMUpgradeFinalizer {
     OMUpgradeFinalizer finalizer = new OMUpgradeFinalizer(versionManager);
     finalizer.finalize(CLIENT_ID, mockOzoneManager(2));
 
-    exception.expect(UpgradeException.class);
-    exception.expectMessage("Unknown client");
-
-    finalizer.reportStatus(OTHER_CLIENT_ID, false);
+    Throwable exception = Assertions.assertThrows(
+        UpgradeException.class, () -> {
+          finalizer.reportStatus(OTHER_CLIENT_ID, false);
+        });
+    assertThat(exception.getMessage(), containsString("Unknown client"));
   }
 
   @Test
@@ -249,7 +245,7 @@ public class TestOMUpgradeFinalizer {
 
   private OMLayoutFeature mockFeature(String name, int version) {
     OMLayoutFeature f = mock(OMLayoutFeature.class);
-    when(f.name()).thenReturn(name);
+    Mockito.lenient().when(f.name()).thenReturn(name);
     when(f.layoutVersion()).thenReturn(version);
     return f;
   }
@@ -277,13 +273,13 @@ public class TestOMUpgradeFinalizer {
     OMStorage st = mock(OMStorage.class);
     storedLayoutVersion = initialLayoutVersion;
 
-    doAnswer(
+    Mockito.lenient().doAnswer(
         (Answer<Void>) inv -> {
           storedLayoutVersion = inv.getArgument(0, Integer.class);
           return null;
         }).when(st).setLayoutVersion(anyInt());
 
-    when(st.getLayoutVersion())
+    Mockito.lenient().when(st.getLayoutVersion())
         .thenAnswer((Answer<Integer>) ignore -> storedLayoutVersion);
 
     when(mock.getOmStorage()).thenReturn(st);

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/upgrade/TestOMVersionManager.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/upgrade/TestOMVersionManager.java
@@ -24,9 +24,9 @@ import static org.apache.hadoop.ozone.om.upgrade.OMLayoutVersionManager.OM_REQUE
 import static org.apache.hadoop.ozone.om.upgrade.OMLayoutVersionManager.OM_UPGRADE_CLASS_PACKAGE;
 import static org.apache.hadoop.ozone.om.upgrade.OMLayoutVersionManager.getRequestClasses;
 import static org.apache.hadoop.ozone.upgrade.LayoutFeature.UpgradeActionType.VALIDATE_IN_PREFINALIZE;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doCallRealMethod;
 import static org.mockito.Mockito.mock;
@@ -48,8 +48,8 @@ import org.apache.hadoop.ozone.om.request.OMClientRequest;
 import org.apache.hadoop.ozone.upgrade.LayoutFeature.UpgradeActionType;
 import org.apache.ozone.test.UnhealthyTest;
 import org.apache.ozone.test.tag.Unhealthy;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 import org.junit.experimental.categories.Category;
 
 /**
@@ -75,7 +75,7 @@ public class TestOMVersionManager {
 
     try {
       new OMLayoutVersionManager(lV);
-      Assert.fail();
+      Assertions.fail();
     } catch (OMException ex) {
       assertEquals(NOT_SUPPORTED_OPERATION, ex.getResult());
     }
@@ -130,11 +130,11 @@ public class TestOMVersionManager {
           lVersion = annotation.value().layoutVersion();
         }
         if (requestTypes.contains(type + "-" + lVersion)) {
-          Assert.fail("Duplicate request/version type found : " + type);
+          Assertions.fail("Duplicate request/version type found : " + type);
         }
         requestTypes.add(type + "-" + lVersion);
       } catch (NoSuchMethodException nsmEx) {
-        Assert.fail("getRequestType method not defined in a class." +
+        Assertions.fail("getRequestType method not defined in a class." +
             nsmEx.getMessage());
       }
     }
@@ -176,8 +176,8 @@ public class TestOMVersionManager {
     lvm.registerUpgradeActions(OM_UPGRADE_CLASS_PACKAGE);
 
     action = INITIAL_VERSION.action(VALIDATE_IN_PREFINALIZE);
-    Assert.assertTrue(action.isPresent());
-    Assert.assertEquals(MockOmUpgradeAction.class, action.get().getClass());
+    Assertions.assertTrue(action.isPresent());
+    Assertions.assertEquals(MockOmUpgradeAction.class, action.get().getClass());
     OzoneManager omMock = mock(OzoneManager.class);
     action.get().execute(omMock);
     verify(omMock, times(1)).getVersion();

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/upgrade/TestOmVersionManagerRequestFactory.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/upgrade/TestOmVersionManagerRequestFactory.java
@@ -23,9 +23,7 @@ import static org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
-import java.util.List;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 import org.apache.hadoop.ozone.om.exceptions.OMException;
 import org.apache.hadoop.ozone.om.request.OMClientRequest;
@@ -60,33 +58,6 @@ public class TestOmVersionManagerRequestFactory {
     Class<? extends OMClientRequest> requestType =
         omVersionManager.getHandler(CreateKey.name());
     Assertions.assertEquals(requestType, OMKeyCreateRequest.class);
-  }
-
-  @Test
-  public void testAllOMRequestClassesHaveGetRequestTypeMethod()
-      throws Exception {
-    Reflections reflections = new Reflections(
-        "org.apache.hadoop.ozone.om.request");
-    Set<Class<? extends OMClientRequest>> subTypes =
-        reflections.getSubTypesOf(OMClientRequest.class);
-    List<Class<? extends OMClientRequest>> collect = subTypes.stream()
-            .filter(c -> !Modifier.isAbstract(c.getModifiers()))
-            .collect(Collectors.toList());
-
-    for (Class<? extends OMClientRequest> c : collect) {
-      Method getRequestTypeMethod = null;
-      try {
-        getRequestTypeMethod = c.getMethod("getRequestType");
-      } catch (NoSuchMethodException nsmEx) {
-        Assertions.fail(String.format(
-            "%s does not have the 'getRequestType' method " +
-            "which should be defined or inherited for every OM request class.",
-            c));
-      }
-      String type = (String) getRequestTypeMethod.invoke(null);
-      Assertions.assertNotNull(omVersionManager.getHandler(type),
-          String.format("Cannot get handler for %s", type));
-    }
   }
 
   @Test

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/upgrade/TestOmVersionManagerRequestFactory.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/upgrade/TestOmVersionManagerRequestFactory.java
@@ -33,9 +33,9 @@ import org.apache.hadoop.ozone.om.request.key.OMKeyCreateRequest;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMRequest;
 import org.apache.ozone.test.UnhealthyTest;
 import org.apache.ozone.test.tag.Unhealthy;
-import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 import org.junit.experimental.categories.Category;
 import org.reflections.Reflections;
 
@@ -48,7 +48,7 @@ public class TestOmVersionManagerRequestFactory {
 
   private static OMLayoutVersionManager omVersionManager;
 
-  @BeforeClass
+  @BeforeAll
   public static void setup() throws OMException {
     omVersionManager = new OMLayoutVersionManager(0);
   }
@@ -59,7 +59,7 @@ public class TestOmVersionManagerRequestFactory {
     // Try getting v1 of 'CreateKey'.
     Class<? extends OMClientRequest> requestType =
         omVersionManager.getHandler(CreateKey.name());
-    Assert.assertEquals(requestType, OMKeyCreateRequest.class);
+    Assertions.assertEquals(requestType, OMKeyCreateRequest.class);
   }
 
   @Test
@@ -78,14 +78,14 @@ public class TestOmVersionManagerRequestFactory {
       try {
         getRequestTypeMethod = c.getMethod("getRequestType");
       } catch (NoSuchMethodException nsmEx) {
-        Assert.fail(String.format(
+        Assertions.fail(String.format(
             "%s does not have the 'getRequestType' method " +
             "which should be defined or inherited for every OM request class.",
             c));
       }
       String type = (String) getRequestTypeMethod.invoke(null);
-      Assert.assertNotNull(String.format("Cannot get handler for %s", type),
-          omVersionManager.getHandler(type));
+      Assertions.assertNotNull(omVersionManager.getHandler(type),
+          String.format("Cannot get handler for %s", type));
     }
   }
 
@@ -103,11 +103,11 @@ public class TestOmVersionManagerRequestFactory {
       }
       Method getRequestTypeMethod = requestClass.getMethod(
           "getRequestType");
-      Assert.assertNotNull(getRequestTypeMethod);
+      Assertions.assertNotNull(getRequestTypeMethod);
 
       Constructor<? extends OMClientRequest> constructorWithOmRequestArg =
           requestClass.getDeclaredConstructor(OMRequest.class);
-      Assert.assertNotNull(constructorWithOmRequestArg);
+      Assertions.assertNotNull(constructorWithOmRequestArg);
     }
   }
 }

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/upgrade/TestOzoneManagerPrepareState.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/upgrade/TestOzoneManagerPrepareState.java
@@ -24,41 +24,41 @@ import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.ozone.om.OzoneManagerPrepareState;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.Type;
 import org.apache.ozone.test.LambdaTestUtils;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.nio.charset.Charset;
+import java.nio.file.Path;
 import java.util.Random;
 
 /**
  * Class to test Ozone Manager prepare state maintenance.
  */
 public class TestOzoneManagerPrepareState {
-  @Rule
-  public TemporaryFolder folder = new TemporaryFolder();
+  @TempDir
+  private Path folder;
 
   private static final int TEST_INDEX = 5;
   private OzoneManagerPrepareState prepareState;
   private static final Random RANDOM = new Random();
 
-  @Before
+  @BeforeEach
   public void setup() throws Exception {
     OzoneConfiguration conf = new OzoneConfiguration();
     conf.set(HddsConfigKeys.OZONE_METADATA_DIRS,
-        folder.getRoot().getAbsolutePath());
+        folder.toAbsolutePath().toString());
 
     prepareState = new OzoneManagerPrepareState(conf);
   }
 
-  @After
+  @AfterEach
   public void tearDown() throws Exception {
     // Clean up marker file from previous runs.
     prepareState.cancelPrepare();
@@ -224,30 +224,31 @@ public class TestOzoneManagerPrepareState {
 
   private void assertPrepareNotStarted() {
     OzoneManagerPrepareState.State state = prepareState.getState();
-    Assert.assertEquals(PrepareStatus.NOT_PREPARED, state.getStatus());
-    Assert.assertEquals(OzoneManagerPrepareState.NO_PREPARE_INDEX,
+    Assertions.assertEquals(PrepareStatus.NOT_PREPARED, state.getStatus());
+    Assertions.assertEquals(OzoneManagerPrepareState.NO_PREPARE_INDEX,
         state.getIndex());
-    Assert.assertFalse(prepareState.getPrepareMarkerFile().exists());
+    Assertions.assertFalse(prepareState.getPrepareMarkerFile().exists());
 
     assertPrepareGateDown();
   }
 
   private void assertPrepareInProgress() {
     OzoneManagerPrepareState.State state = prepareState.getState();
-    Assert.assertEquals(PrepareStatus.PREPARE_GATE_ENABLED, state.getStatus());
-    Assert.assertEquals(OzoneManagerPrepareState.NO_PREPARE_INDEX,
+    Assertions.assertEquals(PrepareStatus.PREPARE_GATE_ENABLED,
+        state.getStatus());
+    Assertions.assertEquals(OzoneManagerPrepareState.NO_PREPARE_INDEX,
         state.getIndex());
-    Assert.assertFalse(prepareState.getPrepareMarkerFile().exists());
+    Assertions.assertFalse(prepareState.getPrepareMarkerFile().exists());
 
     assertPrepareGateUp();
   }
 
   private void assertPrepareCompleted(long index) throws Exception {
     OzoneManagerPrepareState.State state = prepareState.getState();
-    Assert.assertEquals(PrepareStatus.PREPARE_COMPLETED,
+    Assertions.assertEquals(PrepareStatus.PREPARE_COMPLETED,
         state.getStatus());
-    Assert.assertEquals(index, state.getIndex());
-    Assert.assertEquals(index, readPrepareMarkerFile());
+    Assertions.assertEquals(index, state.getIndex());
+    Assertions.assertEquals(index, readPrepareMarkerFile());
 
     assertPrepareGateUp();
   }
@@ -257,16 +258,16 @@ public class TestOzoneManagerPrepareState {
     // allowed.
     for (Type cmdType: Type.values()) {
       if (cmdType == Type.Prepare || cmdType == Type.CancelPrepare) {
-        Assert.assertTrue(prepareState.requestAllowed(cmdType));
+        Assertions.assertTrue(prepareState.requestAllowed(cmdType));
       } else {
-        Assert.assertFalse(prepareState.requestAllowed(cmdType));
+        Assertions.assertFalse(prepareState.requestAllowed(cmdType));
       }
     }
   }
 
   private void assertPrepareGateDown() {
     for (Type cmdType: Type.values()) {
-      Assert.assertTrue(prepareState.requestAllowed(cmdType));
+      Assertions.assertTrue(prepareState.requestAllowed(cmdType));
     }
   }
 

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/security/TestAWSV4AuthValidator.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/security/TestAWSV4AuthValidator.java
@@ -25,6 +25,9 @@ import java.util.Collection;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+/**
+ * Tests AWS V4 Auth Validator.
+ */
 public class TestAWSV4AuthValidator {
 
   private String strToSign;
@@ -73,12 +76,12 @@ public class TestAWSV4AuthValidator {
 
   @ParameterizedTest
   @MethodSource("data")
-  public void testValidateRequest(String strToSign, String signature,
-                                  String awsAccessKey, Boolean result) {
-    this.strToSign = strToSign;
-    this.signature = signature;
-    this.awsAccessKey = awsAccessKey;
-    this.result = result;
+  public void testValidateRequest(String stringToSign, String sign,
+                                  String accessKey, Boolean testResult) {
+    this.strToSign = stringToSign;
+    this.signature = sign;
+    this.awsAccessKey = accessKey;
+    this.result = testResult;
     assertEquals(result, AWSV4AuthValidator.validateRequest(
             strToSign, signature, awsAccessKey));
   }

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/security/TestAWSV4AuthValidator.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/security/TestAWSV4AuthValidator.java
@@ -17,19 +17,14 @@
  */
 package org.apache.hadoop.ozone.security;
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.util.Arrays;
 import java.util.Collection;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
-/**
- * Test for {@link AWSV4AuthValidator}.
- * */
-@RunWith(Parameterized.class)
 public class TestAWSV4AuthValidator {
 
   private String strToSign;
@@ -37,15 +32,6 @@ public class TestAWSV4AuthValidator {
   private String awsAccessKey;
   private Boolean result;
 
-  public TestAWSV4AuthValidator(String strToSign, String signature,
-      String awsAccessKey, Boolean result) {
-    this.strToSign = strToSign;
-    this.signature = signature;
-    this.awsAccessKey = awsAccessKey;
-    this.result = result;
-  }
-
-  @Parameterized.Parameters
   public static Collection<Object[]> data() {
     return Arrays.asList(new Object[][]{
         {
@@ -85,8 +71,14 @@ public class TestAWSV4AuthValidator {
     });
   }
 
-  @Test
-  public void testValidateRequest() {
+  @ParameterizedTest
+  @MethodSource("data")
+  public void testValidateRequest(String strToSign, String signature,
+                                  String awsAccessKey, Boolean result) {
+    this.strToSign = strToSign;
+    this.signature = signature;
+    this.awsAccessKey = awsAccessKey;
+    this.result = result;
     assertEquals(result, AWSV4AuthValidator.validateRequest(
             strToSign, signature, awsAccessKey));
   }

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/security/TestOzoneDelegationTokenSecretManager.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/security/TestOzoneDelegationTokenSecretManager.java
@@ -20,6 +20,7 @@ package org.apache.hadoop.ozone.security;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Path;
 import java.security.KeyPair;
 import java.security.PrivateKey;
 import java.security.PublicKey;
@@ -57,20 +58,19 @@ import org.apache.hadoop.util.Time;
 
 import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_RATIS_ENABLE_KEY;
 import static org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMTokenProto.Type.S3AUTHINFO;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import org.apache.ratis.protocol.RaftPeerId;
 import org.bouncycastle.jcajce.provider.asymmetric.x509.CertificateFactory;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 import org.mockito.Mockito;
 
 /**
@@ -91,10 +91,10 @@ public class TestOzoneDelegationTokenSecretManager {
   private static final Text TEST_USER = new Text("testUser");
   private S3SecretManager s3SecretManager;
 
-  @Rule
-  public TemporaryFolder folder = new TemporaryFolder();
+  @TempDir
+  private Path folder;
 
-  @Before
+  @BeforeEach
   public void setUp() throws Exception {
     conf = createNewTestPath();
     securityConfig = new SecurityConfig(conf);
@@ -127,9 +127,9 @@ public class TestOzoneDelegationTokenSecretManager {
     //  OzoneDelegationTokenSecretManager, this test should be updated to
     //  test both ratis enabled and disabled case.
     config.setBoolean(OZONE_OM_RATIS_ENABLE_KEY, false);
-    File newFolder = folder.newFolder();
+    File newFolder = folder.toFile();
     if (!newFolder.exists()) {
-      Assert.assertTrue(newFolder.mkdirs());
+      Assertions.assertTrue(newFolder.mkdirs());
     }
     ServerUtils.setOzoneMetaDirPath(config, newFolder.toString());
     return config;
@@ -174,7 +174,7 @@ public class TestOzoneDelegationTokenSecretManager {
     };
   }
 
-  @After
+  @AfterEach
   public void tearDown() throws IOException {
     secretManager.stop();
     certificateClient.close();
@@ -190,8 +190,9 @@ public class TestOzoneDelegationTokenSecretManager {
     try {
       secretManager.retrievePassword(identifier);
     } catch (Exception e) {
-      Assert.assertEquals(SecretManager.InvalidToken.class, e.getClass());
-      Assert.assertEquals(OMNotLeaderException.class, e.getCause().getClass());
+      Assertions.assertEquals(SecretManager.InvalidToken.class, e.getClass());
+      Assertions.assertEquals(OMNotLeaderException.class,
+          e.getCause().getClass());
     }
 
     Mockito.doThrow(new OMLeaderNotReadyException("Leader not ready"))
@@ -199,8 +200,8 @@ public class TestOzoneDelegationTokenSecretManager {
     try {
       secretManager.retrievePassword(identifier);
     } catch (Exception e) {
-      Assert.assertEquals(SecretManager.InvalidToken.class, e.getClass());
-      Assert.assertEquals(OMLeaderNotReadyException.class,
+      Assertions.assertEquals(SecretManager.InvalidToken.class, e.getClass());
+      Assertions.assertEquals(OMLeaderNotReadyException.class,
           e.getCause().getClass());
     }
 
@@ -208,8 +209,8 @@ public class TestOzoneDelegationTokenSecretManager {
     try {
       secretManager.retrievePassword(identifier);
     } catch (Exception e) {
-      Assert.assertEquals(SecretManager.InvalidToken.class, e.getClass());
-      Assert.assertNull(e.getCause());
+      Assertions.assertEquals(SecretManager.InvalidToken.class, e.getClass());
+      Assertions.assertNull(e.getCause());
     }
   }
 
@@ -223,9 +224,9 @@ public class TestOzoneDelegationTokenSecretManager {
     OzoneTokenIdentifier identifier =
         OzoneTokenIdentifier.readProtoBuf(token.getIdentifier());
     // Check basic details.
-    Assert.assertTrue(identifier.getRealUser().equals(TEST_USER));
-    Assert.assertTrue(identifier.getRenewer().equals(TEST_USER));
-    Assert.assertTrue(identifier.getOwner().equals(TEST_USER));
+    Assertions.assertTrue(identifier.getRealUser().equals(TEST_USER));
+    Assertions.assertTrue(identifier.getRenewer().equals(TEST_USER));
+    Assertions.assertTrue(identifier.getOwner().equals(TEST_USER));
 
     validateHash(token.getPassword(), token.getIdentifier());
   }
@@ -252,7 +253,7 @@ public class TestOzoneDelegationTokenSecretManager {
     }
 
     long renewalTime = secretManager.renewToken(token, TEST_USER.toString());
-    Assert.assertTrue(renewalTime > 0);
+    Assertions.assertTrue(renewalTime > 0);
   }
 
   @Test
@@ -369,7 +370,7 @@ public class TestOzoneDelegationTokenSecretManager {
         .getSerialNumber().toString());
     id.setMaxDate(Time.now() + 60 * 60 * 24);
     id.setOwner(new Text("test"));
-    Assert.assertTrue(secretManager.verifySignature(id,
+    Assertions.assertTrue(secretManager.verifySignature(id,
         certificateClient.signData(id.getBytes())));
   }
 
@@ -383,7 +384,7 @@ public class TestOzoneDelegationTokenSecretManager {
     id.setOmCertSerialId("1927393");
     id.setMaxDate(Time.now() + 60 * 60 * 24);
     id.setOwner(new Text("test"));
-    Assert.assertFalse(secretManager.verifySignature(id, id.getBytes()));
+    Assertions.assertFalse(secretManager.verifySignature(id, id.getBytes()));
   }
 
   @Test
@@ -463,7 +464,7 @@ public class TestOzoneDelegationTokenSecretManager {
             securityConfig.getProvider());
     rsaSignature.initVerify(certificateClient.getPublicKey());
     rsaSignature.update(identifier);
-    Assert.assertTrue(rsaSignature.verify(hash));
+    Assertions.assertTrue(rsaSignature.verify(hash));
   }
 
   /**

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/security/TestOzoneDelegationTokenSecretManager.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/security/TestOzoneDelegationTokenSecretManager.java
@@ -224,9 +224,9 @@ public class TestOzoneDelegationTokenSecretManager {
     OzoneTokenIdentifier identifier =
         OzoneTokenIdentifier.readProtoBuf(token.getIdentifier());
     // Check basic details.
-    Assertions.assertTrue(identifier.getRealUser().equals(TEST_USER));
-    Assertions.assertTrue(identifier.getRenewer().equals(TEST_USER));
-    Assertions.assertTrue(identifier.getOwner().equals(TEST_USER));
+    assertEquals(identifier.getRealUser(), TEST_USER);
+    assertEquals(identifier.getRenewer(), TEST_USER);
+    assertEquals(identifier.getOwner(), TEST_USER);
 
     validateHash(token.getPassword(), token.getIdentifier());
   }

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/security/TestOzoneTokenIdentifier.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/security/TestOzoneTokenIdentifier.java
@@ -57,10 +57,10 @@ import org.apache.hadoop.util.Time;
 
 import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.commons.lang3.RandomUtils;
-import org.junit.AfterClass;
-import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -86,7 +86,7 @@ public class TestOzoneTokenIdentifier {
           + "SSL_RSA_EXPORT_WITH_DES40_CBC_SHA,"
           + "SSL_RSA_WITH_RC4_128_MD5";
 
-  @BeforeClass
+  @BeforeAll
   public static void setUp() throws Exception {
     base = new File(BASEDIR);
     FileUtil.fullyDelete(base);
@@ -103,7 +103,7 @@ public class TestOzoneTokenIdentifier {
     return conf;
   }
 
-  @AfterClass
+  @AfterAll
   public static void cleanUp() throws Exception {
     FileUtil.fullyDelete(base);
     KeyStoreTestUtil.cleanupSSLConfig(KEYSTORES_DIR, sslConfsDir);
@@ -295,7 +295,7 @@ public class TestOzoneTokenIdentifier {
     OzoneTokenIdentifier id2 = new OzoneTokenIdentifier();
 
     id2.readFields(dis);
-    Assert.assertEquals(id, id2);
+    Assertions.assertEquals(id, id2);
   }
 
 
@@ -327,7 +327,7 @@ public class TestOzoneTokenIdentifier {
     DataInputStream in = new DataInputStream(buf);
     OzoneTokenIdentifier idDecode = new OzoneTokenIdentifier();
     idDecode.readFields(in);
-    Assert.assertEquals(idEncode, idDecode);
+    Assertions.assertEquals(idEncode, idDecode);
   }
 
   @Test
@@ -342,9 +342,9 @@ public class TestOzoneTokenIdentifier {
     try {
       idRead =  idCodec.fromPersistedFormat(oldIdBytes);
     } catch (IOException ex) {
-      Assert.fail("Should not fail to load old token format");
+      Assertions.fail("Should not fail to load old token format");
     }
-    Assert.assertEquals("Deserialize Serialized Token should equal.",
-        idWrite, idRead);
+    Assertions.assertEquals(idWrite, idRead,
+        "Deserialize Serialized Token should equal.");
   }
 }

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/security/acl/TestOzoneAdministrators.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/security/acl/TestOzoneAdministrators.java
@@ -21,9 +21,9 @@ package org.apache.hadoop.ozone.security.acl;
 import org.apache.hadoop.hdds.server.OzoneAdmins;
 import org.apache.hadoop.ozone.om.exceptions.OMException;
 import org.apache.hadoop.security.UserGroupInformation;
-import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 import java.util.Collections;
 
@@ -37,7 +37,7 @@ public class TestOzoneAdministrators {
 
   private static OzoneNativeAuthorizer nativeAuthorizer;
 
-  @BeforeClass
+  @BeforeAll
   public static void setup() {
     nativeAuthorizer = new OzoneNativeAuthorizer();
   }
@@ -67,33 +67,37 @@ public class TestOzoneAdministrators {
           IAccessAuthorizer.ACLType.LIST);
       nativeAuthorizer.setOzoneReadOnlyAdmins(new OzoneAdmins(
           Collections.singletonList("testuser"), null));
-      Assert.assertTrue("matching read only admins are allowed to preform" +
-          "read operations", nativeAuthorizer.checkAccess(obj, context));
+      Assertions.assertTrue(nativeAuthorizer.checkAccess(obj, context),
+          "matching read only admins are allowed to preform" +
+          "read operations");
 
       context = getUserRequestContext("testuser",
           IAccessAuthorizer.ACLType.READ);
-      Assert.assertTrue("matching read only admins are allowed to preform" +
-          "read operations", nativeAuthorizer.checkAccess(obj, context));
+      Assertions.assertTrue(nativeAuthorizer.checkAccess(obj, context),
+          "matching read only admins are allowed to preform" +
+          "read operations");
 
       context = getUserRequestContext("testuser",
           IAccessAuthorizer.ACLType.READ_ACL);
-      Assert.assertTrue("matching read only admins are allowed to preform" +
-          "read operations", nativeAuthorizer.checkAccess(obj, context));
+      Assertions.assertTrue(nativeAuthorizer.checkAccess(obj, context),
+          "matching read only admins are allowed to preform" +
+          "read operations");
 
       context = getUserRequestContext("testuser",
           IAccessAuthorizer.ACLType.WRITE);
       RequestContext finalContext = context;
       // ACLType is WRITE
       // execute volumeManager.checkAccess volumeManager is null
-      Assert.assertThrows(NullPointerException.class,
+      Assertions.assertThrows(NullPointerException.class,
           () -> nativeAuthorizer.checkAccess(obj, finalContext));
 
       nativeAuthorizer.setOzoneReadOnlyAdmins(new OzoneAdmins(
           null, Collections.singletonList("testgroup")));
       context = getUserRequestContext("testuser",
           IAccessAuthorizer.ACLType.READ_ACL);
-      Assert.assertTrue("matching read only admins are allowed to preform" +
-          "read operations", nativeAuthorizer.checkAccess(obj, context));
+      Assertions.assertTrue(nativeAuthorizer.checkAccess(obj, context),
+          "matching read only admins are allowed to preform" +
+          "read operations");
     } finally {
       UserGroupInformation.reset();
     }
@@ -117,74 +121,84 @@ public class TestOzoneAdministrators {
   private void testAdminOperations(OzoneObj obj, RequestContext context)
       throws OMException {
     nativeAuthorizer.setOzoneAdmins(new OzoneAdmins(Collections.emptyList()));
-    Assert.assertFalse("empty admin list disallow anyone to perform " +
-            "admin operations", nativeAuthorizer.checkAccess(obj, context));
+    Assertions.assertFalse(nativeAuthorizer.checkAccess(obj, context), "empty" +
+        " admin list disallow anyone to perform " +
+            "admin operations");
 
     nativeAuthorizer.setOzoneAdmins(new OzoneAdmins(
         Collections.singletonList(OZONE_ADMINISTRATORS_WILDCARD)));
-    Assert.assertTrue("wildcard admin allows everyone to perform admin" +
-        " operations", nativeAuthorizer.checkAccess(obj, context));
+    Assertions.assertTrue(nativeAuthorizer.checkAccess(obj, context),
+        "wildcard admin allows everyone to perform admin" +
+        " operations");
 
     nativeAuthorizer.setOzoneAdmins(new OzoneAdmins(
         Collections.singletonList("testuser")));
-    Assert.assertTrue("matching admins are allowed to perform admin " +
-            "operations", nativeAuthorizer.checkAccess(obj, context));
+    Assertions.assertTrue(nativeAuthorizer.checkAccess(obj, context),
+        "matching admins are allowed to perform admin " +
+            "operations");
 
     nativeAuthorizer.setOzoneAdmins(new OzoneAdmins(
         asList(new String[]{"testuser2", "testuser"})));
-    Assert.assertTrue("matching admins are allowed to perform admin " +
-            "operations", nativeAuthorizer.checkAccess(obj, context));
+    Assertions.assertTrue(nativeAuthorizer.checkAccess(obj, context),
+        "matching admins are allowed to perform admin " +
+            "operations");
 
     nativeAuthorizer.setOzoneAdmins(new OzoneAdmins(
         asList(new String[]{"testuser2", "testuser3"})));
-    Assert.assertFalse("mismatching admins are not allowed perform " +
-        "admin operations", nativeAuthorizer.checkAccess(obj, context));
+    Assertions.assertFalse(nativeAuthorizer.checkAccess(obj, context),
+        "mismatching admins are not allowed perform " +
+        "admin operations");
 
     nativeAuthorizer.setOzoneReadOnlyAdmins(new OzoneAdmins(
         Collections.singletonList("testuser"), null));
     if (context.getAclRights() == IAccessAuthorizer.ACLType.LIST) {
-      Assert.assertTrue("matching read only user are allowed to preform" +
-          "read operations", nativeAuthorizer.checkAccess(obj, context));
+      Assertions.assertTrue(nativeAuthorizer.checkAccess(obj, context),
+          "matching read only user are allowed to preform" +
+          "read operations");
     } else if (context.getAclRights() == IAccessAuthorizer.ACLType.CREATE) {
-      Assert.assertFalse("mismatching read only user are allowed to preform" +
-          "read operations", nativeAuthorizer.checkAccess(obj, context));
+      Assertions.assertFalse(nativeAuthorizer.checkAccess(obj, context),
+          "mismatching read only user are allowed to preform" +
+          "read operations");
     }
 
     nativeAuthorizer.setOzoneReadOnlyAdmins(new OzoneAdmins(
         Collections.singletonList("testuser1"), null));
-    Assert.assertFalse("mismatching read only user are allowed to preform" +
-        "read operations", nativeAuthorizer.checkAccess(obj, context));
+    Assertions.assertFalse(nativeAuthorizer.checkAccess(obj, context),
+        "mismatching read only user are allowed to preform" +
+        "read operations");
   }
 
   private void testGroupAdminOperations(OzoneObj obj, RequestContext context)
       throws OMException {
     nativeAuthorizer.setOzoneAdmins(
         new OzoneAdmins(null, asList("testgroup", "anothergroup")));
-    Assert.assertTrue("Users from matching admin groups " +
-        "are allowed to perform admin operations",
-            nativeAuthorizer.checkAccess(obj, context));
+    Assertions.assertTrue(nativeAuthorizer.checkAccess(obj, context), "Users " +
+            "from matching admin groups " +
+        "are allowed to perform admin operations");
 
     nativeAuthorizer.setOzoneAdmins(
             new OzoneAdmins(null, asList("wronggroup")));
-    Assert.assertFalse("Users from mismatching admin groups " +
-        "are allowed to perform admin operations",
-            nativeAuthorizer.checkAccess(obj, context));
+    Assertions.assertFalse(nativeAuthorizer.checkAccess(obj, context), "Users" +
+            " from mismatching admin groups " +
+        "are allowed to perform admin operations");
 
     nativeAuthorizer.setOzoneReadOnlyAdmins(new OzoneAdmins(
         null, Collections.singletonList("testgroup")));
     if (context.getAclRights() == IAccessAuthorizer.ACLType.LIST) {
-      Assert.assertTrue("matching read only groups are allowed to preform" +
-          "read operations", nativeAuthorizer.checkAccess(obj, context));
+      Assertions.assertTrue(nativeAuthorizer.checkAccess(obj, context),
+          "matching read only groups are allowed to preform" +
+          "read operations");
     } else if (context.getAclRights() == IAccessAuthorizer.ACLType.CREATE) {
-      Assert.assertFalse("mismatching read only groups are allowed to " +
-          "preform read operations",
-              nativeAuthorizer.checkAccess(obj, context));
+      Assertions.assertFalse(nativeAuthorizer.checkAccess(obj, context),
+          "mismatching read only groups are allowed to " +
+          "preform read operations");
     }
 
     nativeAuthorizer.setOzoneReadOnlyAdmins(new OzoneAdmins(
         null, Collections.singletonList("testgroup1")));
-    Assert.assertFalse("mismatching read only groups are allowed to preform" +
-        "read operations", nativeAuthorizer.checkAccess(obj, context));
+    Assertions.assertFalse(nativeAuthorizer.checkAccess(obj, context),
+        "mismatching read only groups are allowed to preform" +
+        "read operations");
   }
 
   private RequestContext getUserRequestContext(String username,

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/security/acl/TestOzoneNativeAuthorizer.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/security/acl/TestOzoneNativeAuthorizer.java
@@ -79,6 +79,9 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+/**
+ * Tests Ozone Native Authorizer.
+ */
 public class TestOzoneNativeAuthorizer {
 
   private static final List<String> ADMIN_USERNAMES = singletonList("om");

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/security/acl/TestOzoneObj.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/security/acl/TestOzoneObj.java
@@ -22,7 +22,6 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
-
 import static org.mockito.Mockito.mock;
 
 /**
@@ -43,9 +42,8 @@ public class TestOzoneObj {
     builder = getBuilder(volume, bucket, key);
     objInfo = builder.build();
     Assertions.assertEquals(objInfo.getVolumeName(), volume);
-    Assertions.assertNotNull(objInfo.getOzonePrefixPathViewer(), "unexpected" +
-        " path " +
-        "accessor");
+    Assertions.assertNotNull(objInfo.getOzonePrefixPathViewer(),
+        "unexpected path accessor");
 
     objInfo = getBuilder(null, null, null).build();
     Assertions.assertNull(objInfo.getVolumeName());

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/security/acl/TestOzoneObj.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/security/acl/TestOzoneObj.java
@@ -18,11 +18,11 @@ package org.apache.hadoop.ozone.security.acl;
 
 import org.apache.hadoop.ozone.om.KeyManager;
 import org.apache.hadoop.ozone.om.OzonePrefixPathImpl;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 
-import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.mock;
 
 /**
@@ -42,18 +42,19 @@ public class TestOzoneObj {
 
     builder = getBuilder(volume, bucket, key);
     objInfo = builder.build();
-    assertEquals(objInfo.getVolumeName(), volume);
-    assertNotNull(objInfo.getOzonePrefixPathViewer(), "unexpected path " +
+    Assertions.assertEquals(objInfo.getVolumeName(), volume);
+    Assertions.assertNotNull(objInfo.getOzonePrefixPathViewer(), "unexpected" +
+        " path " +
         "accessor");
 
     objInfo = getBuilder(null, null, null).build();
-    assertNull(objInfo.getVolumeName());
-    assertNotNull(objInfo.getOzonePrefixPathViewer(), "unexpected path " +
+    Assertions.assertNull(objInfo.getVolumeName());
+    Assertions.assertNotNull(objInfo.getOzonePrefixPathViewer(), "unexpected path " +
             "accessor");
 
     objInfo = getBuilder(volume, null, null).build();
-    assertEquals(objInfo.getVolumeName(), volume);
-    assertNotNull(objInfo.getOzonePrefixPathViewer(), "unexpected path " +
+    Assertions.assertEquals(objInfo.getVolumeName(), volume);
+    Assertions.assertNotNull(objInfo.getOzonePrefixPathViewer(), "unexpected path " +
         "accessor");
 
   }

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/security/acl/TestOzoneObj.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/security/acl/TestOzoneObj.java
@@ -18,12 +18,12 @@ package org.apache.hadoop.ozone.security.acl;
 
 import org.apache.hadoop.ozone.om.KeyManager;
 import org.apache.hadoop.ozone.om.OzonePrefixPathImpl;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.Mockito.mock;
 
 /**
@@ -44,18 +44,18 @@ public class TestOzoneObj {
     builder = getBuilder(volume, bucket, key);
     objInfo = builder.build();
     assertEquals(objInfo.getVolumeName(), volume);
-    assertNotNull("unexpected path accessor",
-        objInfo.getOzonePrefixPathViewer());
+    assertNotNull(objInfo.getOzonePrefixPathViewer(), "unexpected path " +
+        "accessor");
 
     objInfo = getBuilder(null, null, null).build();
     assertEquals(objInfo.getVolumeName(), null);
-    assertNotNull("unexpected path accessor",
-        objInfo.getOzonePrefixPathViewer());
+    assertNotNull(objInfo.getOzonePrefixPathViewer(), "unexpected path " +
+            "accessor");
 
     objInfo = getBuilder(volume, null, null).build();
     assertEquals(objInfo.getVolumeName(), volume);
-    assertNotNull("unexpected path accessor",
-        objInfo.getOzonePrefixPathViewer());
+    assertNotNull(objInfo.getOzonePrefixPathViewer(), "unexpected path " +
+        "accessor");
 
   }
 

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/security/acl/TestOzoneObj.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/security/acl/TestOzoneObj.java
@@ -49,13 +49,13 @@ public class TestOzoneObj {
 
     objInfo = getBuilder(null, null, null).build();
     Assertions.assertNull(objInfo.getVolumeName());
-    Assertions.assertNotNull(objInfo.getOzonePrefixPathViewer(), "unexpected path " +
-            "accessor");
+    Assertions.assertNotNull(objInfo.getOzonePrefixPathViewer(),
+        "unexpected path accessor");
 
     objInfo = getBuilder(volume, null, null).build();
     Assertions.assertEquals(objInfo.getVolumeName(), volume);
-    Assertions.assertNotNull(objInfo.getOzonePrefixPathViewer(), "unexpected path " +
-        "accessor");
+    Assertions.assertNotNull(objInfo.getOzonePrefixPathViewer(),
+        "unexpected path accessor");
 
   }
 

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/security/acl/TestOzoneObj.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/security/acl/TestOzoneObj.java
@@ -22,8 +22,7 @@ import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.mock;
 
 /**
@@ -48,7 +47,7 @@ public class TestOzoneObj {
         "accessor");
 
     objInfo = getBuilder(null, null, null).build();
-    assertEquals(objInfo.getVolumeName(), null);
+    assertNull(objInfo.getVolumeName());
     assertNotNull(objInfo.getOzonePrefixPathViewer(), "unexpected path " +
             "accessor");
 

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/security/acl/TestParentAcl.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/security/acl/TestParentAcl.java
@@ -48,10 +48,10 @@ import org.apache.hadoop.security.authentication.client.AuthenticationException;
 import org.apache.ozone.test.GenericTestUtils;
 import org.apache.ozone.test.UnhealthyTest;
 import org.apache.ozone.test.tag.Unhealthy;
-import org.junit.AfterClass;
-import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 import org.junit.experimental.categories.Category;
 
 import java.io.File;
@@ -95,7 +95,7 @@ public class TestParentAcl {
   private static OzoneManagerProtocol writeClient;
   private static File testDir;
 
-  @BeforeClass
+  @BeforeAll
   public static void setup() throws IOException, AuthenticationException {
     ozConfig = new OzoneConfiguration();
     ozConfig.set(OZONE_ACL_AUTHORIZER_CLASS,
@@ -123,7 +123,7 @@ public class TestParentAcl {
         new String[]{"test1"});
   }
 
-  @AfterClass
+  @AfterAll
   public static void cleanup() throws IOException {
     FileUtils.deleteDirectory(testDir);
   }
@@ -240,31 +240,36 @@ public class TestParentAcl {
     OzoneAcl parentAcl = new OzoneAcl(USER,
         testUgi1.getUserName(), parentAclType, ACCESS);
 
-    Assert.assertFalse(nativeAuthorizer.checkAccess(child, requestContext));
+    Assertions.assertFalse(nativeAuthorizer.checkAccess(child, requestContext));
     if (child.getResourceType() == BUCKET) {
       // add the bucket acl
       addBucketAcl(child.getVolumeName(), child.getBucketName(), childAcl);
-      Assert.assertFalse(nativeAuthorizer.checkAccess(child, requestContext));
+      Assertions.assertFalse(nativeAuthorizer.checkAccess(
+          child, requestContext));
 
       // add the volume acl (parent), now bucket access is allowed.
       addVolumeAcl(child.getVolumeName(), parentAcl);
-      Assert.assertTrue(nativeAuthorizer.checkAccess(child, requestContext));
+      Assertions.assertTrue(nativeAuthorizer.checkAccess(
+          child, requestContext));
 
     } else if (child.getResourceType() == KEY) {
       // add key acl is not enough
       addKeyAcl(child.getVolumeName(), child.getBucketName(),
           child.getKeyName(), childAcl);
-      Assert.assertFalse(nativeAuthorizer.checkAccess(child, requestContext));
+      Assertions.assertFalse(nativeAuthorizer.checkAccess(
+          child, requestContext));
 
       // add the bucket acl is not enough (parent)
       addBucketAcl(child.getVolumeName(), child.getBucketName(), parentAcl);
-      Assert.assertFalse(nativeAuthorizer.checkAccess(child, requestContext));
+      Assertions.assertFalse(nativeAuthorizer.checkAccess(
+          child, requestContext));
 
       // add the volume acl (grand-parent), now key access is allowed.
       OzoneAcl parentVolumeAcl = new OzoneAcl(USER,
           testUgi1.getUserName(), READ, ACCESS);
       addVolumeAcl(child.getVolumeName(), parentVolumeAcl);
-      Assert.assertTrue(nativeAuthorizer.checkAccess(child, requestContext));
+      Assertions.assertTrue(nativeAuthorizer.checkAccess(
+          child, requestContext));
     }
   }
 

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/security/acl/TestRequestContext.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/security/acl/TestRequestContext.java
@@ -17,8 +17,8 @@
 package org.apache.hadoop.ozone.security.acl;
 
 import org.apache.hadoop.security.UserGroupInformation;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 
@@ -32,50 +32,50 @@ public class TestRequestContext {
     RequestContext context = getUserRequestContext("om",
             IAccessAuthorizer.ACLType.CREATE, false, "volume1",
             true);
-    Assert.assertTrue("Wrongly sets recursiveAccessCheck flag value",
-            context.isRecursiveAccessCheck());
+    Assertions.assertTrue(context.isRecursiveAccessCheck(),
+        "Wrongly sets recursiveAccessCheck flag value");
 
     context = getUserRequestContext("om",
             IAccessAuthorizer.ACLType.CREATE, false, "volume1",
             false);
-    Assert.assertFalse("Wrongly sets recursiveAccessCheck flag value",
-            context.isRecursiveAccessCheck());
+    Assertions.assertFalse(context.isRecursiveAccessCheck(),
+        "Wrongly sets recursiveAccessCheck flag value");
 
     context = getUserRequestContext(
             "user1", IAccessAuthorizer.ACLType.CREATE,
             true, "volume1");
-    Assert.assertFalse("Wrongly sets recursiveAccessCheck flag value",
-            context.isRecursiveAccessCheck());
+    Assertions.assertFalse(context.isRecursiveAccessCheck(),
+        "Wrongly sets recursiveAccessCheck flag value");
 
     RequestContext.Builder builder = new RequestContext.Builder();
 
-    Assert.assertFalse("Wrongly sets recursive flag value",
-            builder.build().isRecursiveAccessCheck());
+    Assertions.assertFalse(builder.build().isRecursiveAccessCheck(),
+        "Wrongly sets recursive flag value");
 
     builder.setRecursiveAccessCheck(true);
-    Assert.assertTrue("Wrongly sets recursive flag value",
-            builder.build().isRecursiveAccessCheck());
+    Assertions.assertTrue(builder.build().isRecursiveAccessCheck(),
+        "Wrongly sets recursive flag value");
 
     context = new RequestContext("host", null,
             null, "serviceId",
             IAccessAuthorizer.ACLIdentityType.GROUP,
             IAccessAuthorizer.ACLType.CREATE, "owner");
-    Assert.assertFalse("Wrongly sets recursive flag value",
-            context.isRecursiveAccessCheck());
+    Assertions.assertFalse(context.isRecursiveAccessCheck(),
+        "Wrongly sets recursive flag value");
 
     context = new RequestContext("host", null,
             null, "serviceId",
             IAccessAuthorizer.ACLIdentityType.GROUP,
             IAccessAuthorizer.ACLType.CREATE, "owner", false);
-    Assert.assertFalse("Wrongly sets recursive flag value",
-            context.isRecursiveAccessCheck());
+    Assertions.assertFalse(context.isRecursiveAccessCheck(),
+        "Wrongly sets recursive flag value");
 
     context = new RequestContext("host", null,
             null, "serviceId",
             IAccessAuthorizer.ACLIdentityType.GROUP,
             IAccessAuthorizer.ACLType.CREATE, "owner", true);
-    Assert.assertTrue("Wrongly sets recursive flag value",
-            context.isRecursiveAccessCheck());
+    Assertions.assertTrue(context.isRecursiveAccessCheck(),
+        "Wrongly sets recursive flag value");
   }
 
   private RequestContext getUserRequestContext(String username,

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/security/acl/TestVolumeOwner.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/security/acl/TestVolumeOwner.java
@@ -39,10 +39,10 @@ import org.apache.hadoop.ozone.om.request.OMRequestTestUtils;
 import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.hadoop.security.authentication.client.AuthenticationException;
 import org.apache.ozone.test.GenericTestUtils;
-import org.junit.AfterClass;
-import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 import java.io.File;
 import java.io.IOException;
@@ -75,7 +75,7 @@ public class TestVolumeOwner {
   private static OzoneManagerProtocol writeClient;
   private static File testDir;
 
-  @BeforeClass
+  @BeforeAll
   public static void setup() throws IOException, AuthenticationException {
     ozoneConfig = new OzoneConfiguration();
     ozoneConfig.set(OZONE_ACL_AUTHORIZER_CLASS,
@@ -103,7 +103,7 @@ public class TestVolumeOwner {
     prepareTestKeys();
   }
 
-  @AfterClass
+  @AfterAll
   public static void cleanup() throws IOException {
     FileUtils.deleteDirectory(testDir);
   }
@@ -172,27 +172,29 @@ public class TestVolumeOwner {
     // admin = true, owner = false, ownerName = testvolumeOwner
     RequestContext nonOwnerContext = getUserRequestContext("om",
         IAccessAuthorizer.ACLType.CREATE, false, getTestVolOwnerName(0));
-    Assert.assertTrue("matching admins are allowed to perform admin " +
-        "operations", nativeAuthorizer.checkAccess(vol0, nonOwnerContext));
+    Assertions.assertTrue(nativeAuthorizer.checkAccess(vol0, nonOwnerContext),
+        "matching admins are allowed to perform admin " +
+        "operations");
 
     // admin = true, owner = false, ownerName = null
-    Assert.assertTrue("matching admins are allowed to perform admin " +
-        "operations", nativeAuthorizer.checkAccess(vol0, nonOwnerContext));
+    Assertions.assertTrue(nativeAuthorizer.checkAccess(vol0, nonOwnerContext),
+        "matching admins are allowed to perform admin " +
+        "operations");
 
     // admin = false, owner = false, ownerName = testvolumeOwner
     RequestContext nonAdminNonOwnerContext = getUserRequestContext("testuser",
         IAccessAuthorizer.ACLType.CREATE, false, getTestVolOwnerName(0));
-    Assert.assertFalse("mismatching admins are not allowed to perform admin " +
-        "operations", nativeAuthorizer.checkAccess(vol0,
-        nonAdminNonOwnerContext));
+    Assertions.assertFalse(nativeAuthorizer.checkAccess(vol0,
+        nonAdminNonOwnerContext), "mismatching admins are not allowed to " +
+        "perform admin operations");
 
     // admin = false, owner = true
     RequestContext nonAdminOwnerContext = getUserRequestContext(
         getTestVolOwnerName(0), IAccessAuthorizer.ACLType.CREATE,
         true, getTestVolOwnerName(0));
-    Assert.assertFalse("mismatching admins are not allowed to perform admin " +
-        "operations even for owner", nativeAuthorizer.checkAccess(vol0,
-        nonAdminOwnerContext));
+    Assertions.assertFalse(nativeAuthorizer.checkAccess(vol0,
+        nonAdminOwnerContext), "mismatching admins are not allowed to " +
+        "perform admin operations even for owner");
 
     List<IAccessAuthorizer.ACLType> aclsToTest =
         Arrays.stream(IAccessAuthorizer.ACLType.values()).filter(
@@ -201,9 +203,9 @@ public class TestVolumeOwner {
     for (IAccessAuthorizer.ACLType type: aclsToTest) {
       nonAdminOwnerContext = getUserRequestContext(getTestVolOwnerName(0),
           type, true, getTestVolOwnerName(0));
-      Assert.assertTrue("Owner is allowed to perform all non-admin " +
-          "operations", nativeAuthorizer.checkAccess(vol0,
-          nonAdminOwnerContext));
+      Assertions.assertTrue(nativeAuthorizer.checkAccess(vol0,
+          nonAdminOwnerContext), "Owner is allowed to perform all non-admin " +
+          "operations");
     }
   }
 
@@ -216,18 +218,18 @@ public class TestVolumeOwner {
     for (IAccessAuthorizer.ACLType type: aclsToTest) {
       RequestContext nonAdminOwnerContext = getUserRequestContext(
           getTestVolOwnerName(1), type, true, getTestVolOwnerName(1));
-      Assert.assertTrue("non admin volume owner without acls are allowed" +
-          " to do " + type + " on bucket",
-          nativeAuthorizer.checkAccess(obj, nonAdminOwnerContext));
+      Assertions.assertTrue(nativeAuthorizer.checkAccess(obj,
+          nonAdminOwnerContext), "non admin volume owner without acls are " +
+          "allowed to do " + type + " on bucket");
     }
 
     // admin = false, owner = false
     for (IAccessAuthorizer.ACLType type: aclsToTest) {
       RequestContext nonAdminOwnerContext = getUserRequestContext(
           getTestVolOwnerName(1), type, false, getTestVolOwnerName(0));
-      Assert.assertFalse("non admin non volume owner without acls" +
-          " are not allowed to do " + type + " on bucket",
-          nativeAuthorizer.checkAccess(obj, nonAdminOwnerContext));
+      Assertions.assertFalse(nativeAuthorizer.checkAccess(obj,
+          nonAdminOwnerContext), "non admin non volume owner without acls" +
+          " are not allowed to do " + type + " on bucket");
     }
   }
 
@@ -240,18 +242,19 @@ public class TestVolumeOwner {
     for (IAccessAuthorizer.ACLType type: aclsToTest) {
       RequestContext nonAdminOwnerContext = getUserRequestContext(
           getTestVolOwnerName(0), type, true, getTestVolOwnerName(0));
-      Assert.assertTrue("non admin volume owner without acls are allowed to " +
-              "access key",
-          nativeAuthorizer.checkAccess(obj, nonAdminOwnerContext));
+      Assertions.assertTrue(nativeAuthorizer.checkAccess(obj,
+          nonAdminOwnerContext), "non admin volume owner without acls are " +
+          "allowed to access key");
     }
 
     // admin = false, owner = false
     for (IAccessAuthorizer.ACLType type: aclsToTest) {
       RequestContext nonAdminOwnerContext = getUserRequestContext(
           getTestVolOwnerName(0), type, false, getTestVolOwnerName(1));
-      Assert.assertFalse("non admin volume owner without acls are" +
-              " not allowed to access key",
-          nativeAuthorizer.checkAccess(obj, nonAdminOwnerContext));
+      Assertions.assertFalse(nativeAuthorizer.checkAccess(obj,
+              nonAdminOwnerContext),
+          "non admin volume owner without acls are" +
+              " not allowed to access key");
     }
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Migrating all the tests under ozone-common to Junit5 and making sure that Junit4 is not used in any of the tests. This PR also migrates the parametrized tests under ozone-manager to junit5.
Tested that using `grep -rlE "org.junit.[A-Z]" . --include '*.java'` command in hadoop-ozone/ozone-manager folder

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-9496 

## How was this patch tested?

This PR was tested by running the full CI - https://github.com/VarshaRaviCV/ozone/actions/runs/6794454191 