### PR TITLE
HDDS-9652. Legacy RM will not replicate all unhealthy containers when some are decommissioning

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/KeyValueContainer.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/KeyValueContainer.java
@@ -684,14 +684,15 @@ public class KeyValueContainer implements Container<KeyValueContainerData> {
       ContainerPacker<KeyValueContainerData> packer) throws IOException {
     writeLock();
     try {
-      // Closed/ Quasi closed containers are considered for replication by
-      // replication manager if they are under-replicated.
+      // Closed/ Quasi closed and unhealthy containers are considered for
+      // replication by replication manager if they are under-replicated.
       ContainerProtos.ContainerDataProto.State state =
           getContainerData().getState();
       if (!(state == ContainerProtos.ContainerDataProto.State.CLOSED ||
-          state == ContainerDataProto.State.QUASI_CLOSED)) {
+          state == ContainerDataProto.State.QUASI_CLOSED
+          || state == ContainerDataProto.State.UNHEALTHY)) {
         throw new IllegalStateException(
-            "Only (quasi)closed containers can be exported, but " +
+            "Only (quasi)closed and unhealthy containers can be exported. " +
                 "ContainerId=" + getContainerData().getContainerID() +
                 " is in state " + state);
       }

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestLegacyReplicationManager.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestLegacyReplicationManager.java
@@ -79,6 +79,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.Mockito;
 
@@ -1580,6 +1581,43 @@ public class TestLegacyReplicationManager {
           numReplicas;
       assertReplicaScheduled(numReplicasNeeded);
       assertUnderReplicatedCount(1);
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = LifeCycleState.class,
+        names = {"CLOSED", "QUASI_CLOSED"})
+    public void testUnderReplicatedWithOnlyUnhealthyReplicasDecommission(
+        LifeCycleState state)
+        throws Exception {
+      final ContainerInfo container = createContainer(state);
+      for (int i = 0; i < 2; i++) {
+        addReplica(container, NodeStatus.inServiceHealthy(), UNHEALTHY);
+      }
+      addReplica(container, new NodeStatus(DECOMMISSIONING, HEALTHY),
+          UNHEALTHY);
+      assertReplicaScheduled(1);
+      assertUnderReplicatedCount(1);
+      // Run again, and there should be a pending add scheduled, so nothing
+      // else should get scheduled.
+      assertReplicaScheduled(0);
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = LifeCycleState.class,
+        names = {"CLOSED", "QUASI_CLOSED"})
+    public void testOverReplicatedWithOnlyUnhealthyReplicasDecommission()
+        throws Exception {
+      final ContainerInfo container = createContainer(LifeCycleState.CLOSED);
+      for (int i = 0; i < 4; i++) {
+        addReplica(container, NodeStatus.inServiceHealthy(), UNHEALTHY);
+      }
+      assertDeleteScheduled(1);
+      assertUnderReplicatedCount(0);
+      assertOverReplicatedCount(1);
+
+      // Run again, and there should be a pending delete scheduled, so nothing
+      // else should get scheduled.
+      assertDeleteScheduled(0);
     }
 
     /**

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestRatisUnderReplicationHandler.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestRatisUnderReplicationHandler.java
@@ -390,6 +390,18 @@ public class TestRatisUnderReplicationHandler {
   }
 
   @Test
+  public void testDecommissionWithAllUnhealthyReplicas()
+      throws IOException {
+    Set<ContainerReplica> replicas
+        = createReplicas(container.containerID(), State.UNHEALTHY, 0, 0);
+    replicas.addAll(createReplicas(container.containerID(), State.UNHEALTHY,
+        Pair.of(DECOMMISSIONING, 0)));
+
+    testProcessing(replicas, Collections.emptyList(),
+        getUnderReplicatedHealthResult(), 2, 1);
+  }
+
+  @Test
   public void onlyHealthyReplicasShouldBeReplicatedWhenAvailable()
       throws IOException {
     Set<ContainerReplica> replicas

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestReplicationManager.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestReplicationManager.java
@@ -51,9 +51,11 @@ import org.apache.hadoop.util.Lists;
 import org.apache.ozone.test.TestClock;
 import org.apache.ratis.protocol.exceptions.NotLeaderException;
 import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 
@@ -114,7 +116,7 @@ public class TestReplicationManager {
   private ReplicationQueue repQueue;
   private Set<Pair<UUID, SCMCommand<?>>> commandsSent;
 
-  @Before
+  @BeforeEach
   public void setup() throws IOException {
     configuration = new OzoneConfiguration();
     configuration.set(HDDS_SCM_WAIT_TIME_AFTER_SAFE_MODE_EXIT, "0s");
@@ -297,13 +299,16 @@ public class TestReplicationManager {
     assertEquals(0, repQueue.overReplicatedQueueSize());
   }
 
-  @Test
-  public void testUnderReplicatedClosedContainerWithOnlyUnhealthyReplicas()
+  @ParameterizedTest
+  @EnumSource(value = HddsProtos.LifeCycleState.class,
+      names = {"CLOSED", "QUASI_CLOSED"})
+  public void testUnderReplicatedClosedContainerWithOnlyUnhealthyReplicas(
+      HddsProtos.LifeCycleState state)
       throws ContainerNotFoundException {
     RatisReplicationConfig ratisRepConfig =
         RatisReplicationConfig.getInstance(THREE);
     ContainerInfo container = createContainerInfo(ratisRepConfig, 1,
-        HddsProtos.LifeCycleState.CLOSED);
+        state);
     // Container is closed but replicas are UNHEALTHY
     Set<ContainerReplica> replicas =
         addReplicas(container, ContainerReplicaProto.State.UNHEALTHY, 0, 0);


### PR DESCRIPTION
## What changes were proposed in this pull request?
In a situation where a container is closed or quasi-closed with all unhealthy replicas, the legacy Replication Manager will not replicate the unhealthy containers if the under replication is caused by decommission.

Ie, if we have 3 replicas:

IN_SERVICE, unhealthy
IN_SERVICE, unhealthy
DECOMMISSIOING, unhealthy

Then the legacy RM will take no action and decommission will be stuck.

The new RM handles this state correctly and does not need to be changed.

Additionally, in KeyValueContainer.java, unhealthy replicas cannot be exported / replicated, so even if the RM was not present, replication still could not happen.

This change corrects both issues and adds a couple of extra tests to the new RM to prove it works ok.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-9652

## How was this patch tested?

New unit tests added.
