### PR TITLE
HDDS-9583. Test Hadoop compatibility in secure environment with all supported versions

### DIFF
--- a/hadoop-ozone/dist/src/main/compose/common/hadoop-secure.yaml
+++ b/hadoop-ozone/dist/src/main/compose/common/hadoop-secure.yaml
@@ -1,0 +1,72 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+version: "3.8"
+services:
+  rm:
+    image: ${HADOOP_IMAGE}:${HADOOP_VERSION}
+    hostname: rm
+    volumes:
+      - ../..:/opt/ozone
+      - ../../libexec/transformation.py:/opt/transformation.py
+      - ../_keytabs:/etc/security/keytabs
+      - ./krb5.conf:/etc/krb5.conf
+    ports:
+      - 8088:8088
+    env_file:
+      - docker-config
+      - ../common/hadoop.conf
+      - ../common/hadoop-security.conf
+      - ../common/hadoop${HADOOP_MAJOR_VERSION}.conf
+    command: ["yarn", "resourcemanager"]
+    profiles:
+      - hadoop
+  nm:
+    image: ${HADOOP_IMAGE}:${HADOOP_VERSION}
+    hostname: nm
+    volumes:
+      - ../..:/opt/ozone
+      - ../../libexec/transformation.py:/opt/transformation.py
+      - ../_keytabs:/etc/security/keytabs
+      - ./krb5.conf:/etc/krb5.conf
+    env_file:
+      - docker-config
+      - ../common/hadoop.conf
+      - ../common/hadoop-security.conf
+      - ../common/hadoop${HADOOP_MAJOR_VERSION}.conf
+    environment:
+      WAITFOR: rm:8088
+    command: ["yarn","nodemanager"]
+    profiles:
+      - hadoop
+  jhs:
+    image: ${HADOOP_IMAGE}:${HADOOP_VERSION}
+    container_name: jhs
+    hostname: jhs
+    volumes:
+      - ../..:/opt/ozone
+      - ../_keytabs:/etc/security/keytabs
+      - ./krb5.conf:/etc/krb5.conf
+      - ../../libexec/transformation.py:/opt/transformation.py
+    ports:
+      - 8188:8188
+    env_file:
+      - ./docker-config
+    environment:
+      WAITFOR: rm:8088
+    command: ["yarn","timelineserver"]
+    profiles:
+      - hadoop

--- a/hadoop-ozone/dist/src/main/compose/common/hadoop-security.conf
+++ b/hadoop-ozone/dist/src/main/compose/common/hadoop-security.conf
@@ -1,0 +1,28 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+YARN-SITE.XML_yarn.nodemanager.principal=nm/nm@EXAMPLE.COM
+YARN-SITE.XML_yarn.nodemanager.keytab=/etc/security/keytabs/nm.keytab
+YARN-SITE.XML_yarn.resourcemanager.keytab=/etc/security/keytabs/rm.keytab
+YARN-SITE.XML_yarn.resourcemanager.principal=rm/rm@EXAMPLE.COM
+YARN-SITE.XML_yarn.timeline-service.principal=jhs/jhs@EXAMPLE.COM
+YARN-SITE.XML_yarn.timeline-service.keytab=/etc/security/keytabs/jhs.keytab
+HADOOP-POLICY.XML_ozone.om.security.client.protocol.acl=*
+HADOOP-POLICY.XML_hdds.security.client.datanode.container.protocol.acl=*
+HADOOP-POLICY.XML_hdds.security.client.scm.container.protocol.acl=*
+HADOOP-POLICY.XML_hdds.security.client.scm.block.protocol.acl=*
+HADOOP-POLICY.XML_hdds.security.client.scm.certificate.protocol.acl=*
+HADOOP-POLICY.XML_org.apache.hadoop.yarn.server.api.ResourceTracker.acl=*

--- a/hadoop-ozone/dist/src/main/compose/common/hadoop.conf
+++ b/hadoop-ozone/dist/src/main/compose/common/hadoop.conf
@@ -27,9 +27,9 @@ MAPRED-SITE.XML_mapred.child.java.opts=-Xmx2g
 
 YARN-SITE.XML_yarn.app.mapreduce.am.staging-dir=/user
 YARN_SITE.XML_yarn.timeline-service.enabled=true
-#YARN_SITE.XML_yarn.timeline-service.generic.application.history.enabled=true
-#YARN_SITE.XML_yarn.timeline-service.hostname=jhs
-#YARN_SITE.XML_yarn.log.server.url=http://jhs:8188/applicationhistory/logs/
+YARN_SITE.XML_yarn.timeline-service.generic.application.history.enabled=true
+YARN_SITE.XML_yarn.timeline-service.hostname=jhs
+YARN_SITE.XML_yarn.log.server.url=http://jhs:8188/applicationhistory/logs/
 
 YARN-SITE.XML_yarn.nodemanager.pmem-check-enabled=false
 YARN-SITE.XML_yarn.nodemanager.delete.debug-delay-sec=6000

--- a/hadoop-ozone/dist/src/main/compose/ozonesecure-mr/.env
+++ b/hadoop-ozone/dist/src/main/compose/ozonesecure-mr/.env
@@ -15,8 +15,6 @@
 # limitations under the License.
 
 HDDS_VERSION=${hdds.version}
-HADOOP_IMAGE=apache/hadoop
-HADOOP_VERSION=${hadoop.version}
 OZONE_RUNNER_VERSION=${docker.ozone-runner.version}
 OZONE_RUNNER_IMAGE=apache/ozone-runner
 OZONE_TESTKRB5_IMAGE=${docker.ozone-testkr5b.image}

--- a/hadoop-ozone/dist/src/main/compose/ozonesecure-mr/docker-compose.yaml
+++ b/hadoop-ozone/dist/src/main/compose/ozonesecure-mr/docker-compose.yaml
@@ -19,16 +19,12 @@ services:
   kdc:
     image: ${OZONE_TESTKRB5_IMAGE}
     hostname: kdc
-    networks:
-      - ozone
     volumes:
       - ../..:/opt/hadoop
       - ../_keytabs:/etc/security/keytabs
     command: ["krb5kdc","-n"]
   kms:
-    image: ${HADOOP_IMAGE}:${HADOOP_VERSION}
-    networks:
-      - ozone
+    image: apache/hadoop:3
     ports:
       - 9600:9600
     env_file:
@@ -39,8 +35,6 @@ services:
     command: ["hadoop", "kms"]
   datanode:
     image: ${OZONE_RUNNER_IMAGE}:${OZONE_RUNNER_VERSION}
-    networks:
-      - ozone
     volumes:
       - ../..:/opt/hadoop
       - ../_keytabs:/etc/security/keytabs
@@ -55,8 +49,6 @@ services:
   om:
     image: ${OZONE_RUNNER_IMAGE}:${OZONE_RUNNER_VERSION}
     hostname: om
-    networks:
-      - ozone
     volumes:
       - ../..:/opt/hadoop
       - ../_keytabs:/etc/security/keytabs
@@ -73,8 +65,6 @@ services:
   s3g:
     image: ${OZONE_RUNNER_IMAGE}:${OZONE_RUNNER_VERSION}
     hostname: s3g
-    networks:
-      - ozone
     volumes:
       - ../..:/opt/hadoop
       - ../_keytabs:/etc/security/keytabs
@@ -89,8 +79,6 @@ services:
   scm:
     image: ${OZONE_RUNNER_IMAGE}:${OZONE_RUNNER_VERSION}
     hostname: scm
-    networks:
-      - ozone
     volumes:
       - ../..:/opt/hadoop
       - ../_keytabs:/etc/security/keytabs
@@ -105,54 +93,3 @@ services:
       OZONE-SITE.XML_hdds.scm.safemode.min.datanode: "${OZONE_SAFEMODE_MIN_DATANODES:-1}"
       OZONE_OPTS:
     command: ["/opt/hadoop/bin/ozone","scm"]
-  rm:
-    image: ${HADOOP_IMAGE}:${HADOOP_VERSION}
-    hostname: rm
-    networks:
-      - ozone
-    volumes:
-      - ../..:/opt/ozone
-      - ../_keytabs:/etc/security/keytabs
-      - ./krb5.conf:/etc/krb5.conf
-      - ../../libexec/transformation.py:/opt/transformation.py
-    ports:
-      - 8088:8088
-    env_file:
-      - ./docker-config
-    command: ["yarn", "resourcemanager"]
-  nm:
-    image: ${HADOOP_IMAGE}:${HADOOP_VERSION}
-    hostname: nm
-    networks:
-      - ozone
-    volumes:
-      - ../..:/opt/ozone
-      - ../_keytabs:/etc/security/keytabs
-      - ./krb5.conf:/etc/krb5.conf
-      - ../../libexec/transformation.py:/opt/transformation.py
-    env_file:
-      - ./docker-config
-    environment:
-      WAITFOR: rm:8088
-    command: ["yarn","nodemanager"]
-  jhs:
-    image: ${HADOOP_IMAGE}:${HADOOP_VERSION}
-    container_name: jhs
-    hostname: jhs
-    networks:
-      - ozone
-    volumes:
-      - ../..:/opt/ozone
-      - ../_keytabs:/etc/security/keytabs
-      - ./krb5.conf:/etc/krb5.conf
-      - ../../libexec/transformation.py:/opt/transformation.py
-    ports:
-      - 8188:8188
-    env_file:
-      - ./docker-config
-    environment:
-      WAITFOR: rm:8088
-    command: ["yarn","timelineserver"]
-networks:
-  ozone:
-    name: ozone

--- a/hadoop-ozone/dist/src/main/compose/ozonesecure-mr/docker-config
+++ b/hadoop-ozone/dist/src/main/compose/ozonesecure-mr/docker-config
@@ -62,84 +62,14 @@ HDFS-SITE.XML_dfs.web.authentication.kerberos.keytab=/etc/security/keytabs/dn.ke
 
 OZONE-SITE.XML_hdds.datanode.dir=/data/hdds
 OZONE-SITE.XML_hdds.datanode.volume.min.free.space=100MB
-HDFS-SITE.XML_dfs.datanode.address=0.0.0.0:1019
-HDFS-SITE.XML_dfs.datanode.http.address=0.0.0.0:1012
+
 CORE-SITE.XML_dfs.data.transfer.protection=authentication
 CORE-SITE.XML_hadoop.security.authentication=kerberos
 CORE-SITE.XML_hadoop.security.auth_to_local="DEFAULT"
 CORE-SITE.XML_hadoop.security.key.provider.path=kms://http@kms:9600/kms
 
-#temporary disable authorization as org.apache.hadoop.yarn.server.api.ResourceTrackerPB is not properly annotated to support it
+#temporarily disable authorization as org.apache.hadoop.yarn.server.api.ResourceTrackerPB is not properly annotated to support it
 CORE-SITE.XML_hadoop.security.authorization=false
-HADOOP-POLICY.XML_ozone.om.security.client.protocol.acl=*
-HADOOP-POLICY.XML_hdds.security.client.datanode.container.protocol.acl=*
-HADOOP-POLICY.XML_hdds.security.client.scm.container.protocol.acl=*
-HADOOP-POLICY.XML_hdds.security.client.scm.block.protocol.acl=*
-HADOOP-POLICY.XML_hdds.security.client.scm.certificate.protocol.acl=*
-HADOOP-POLICY.XML_org.apache.hadoop.yarn.server.api.ResourceTracker.acl=*
-
-HDFS-SITE.XML_rpc.metrics.quantile.enable=true
-HDFS-SITE.XML_rpc.metrics.percentiles.intervals=60,300
-
-CORE-SITE.XML_fs.AbstractFileSystem.o3fs.impl=org.apache.hadoop.fs.ozone.OzFs
-CORE-SITE.XML_fs.AbstractFileSystem.ofs.impl=org.apache.hadoop.fs.ozone.RootedOzFs
-CORE-SITE.XML_fs.defaultFS=ofs://om
-
-MAPRED-SITE.XML_mapreduce.framework.name=yarn
-MAPRED-SITE.XML_yarn.app.mapreduce.am.env=HADOOP_MAPRED_HOME=$HADOOP_HOME
-MAPRED-SITE.XML_mapreduce.map.env=HADOOP_MAPRED_HOME=$HADOOP_HOME
-MAPRED-SITE.XML_mapreduce.reduce.env=HADOOP_MAPRED_HOME=$HADOOP_HOME
-MAPRED-SITE.XML_mapreduce.map.memory.mb=2048
-MAPRED-SITE.XML_mapreduce.reduce.memory.mb=2048
-#MAPRED-SITE.XML_mapred.child.java.opts=-Xmx2048
-MAPRED-SITE.XML_mapreduce.application.classpath=/opt/hadoop/share/hadoop/mapreduce/*:/opt/hadoop/share/hadoop/mapreduce/lib/*:/opt/ozone/share/ozone/lib/ozone-filesystem-hadoop3-@project.version@.jar
-
-YARN-SITE.XML_yarn.app.mapreduce.am.staging-dir=/user
-YARN-SITE.XML_yarn.timeline-service.enabled=true
-YARN-SITE.XML_yarn.timeline-service.generic.application.history.enabled=true
-YARN-SITE.XML_yarn.timeline-service.hostname=jhs
-YARN-SITE.XML_yarn.timeline-service.principal=jhs/jhs@EXAMPLE.COM
-YARN-SITE.XML_yarn.timeline-service.keytab=/etc/security/keytabs/jhs.keytab
-YARN-SITE.XML_yarn.log.server.url=http://jhs:8188/applicationhistory/logs/
-
-YARN-SITE.XML_yarn.nodemanager.principal=nm/nm@EXAMPLE.COM
-YARN-SITE.XML_yarn.nodemanager.keytab=/etc/security/keytabs/nm.keytab
-YARN-SITE.XML_yarn.nodemanager.pmem-check-enabled=false
-YARN-SITE.XML_yarn.nodemanager.delete.debug-delay-sec=600
-YARN-SITE.XML_yarn.nodemanager.vmem-check-enabled=false
-YARN-SITE.XML_yarn.nodemanager.aux-services=mapreduce_shuffle
-YARN-SITE.XML_yarn.nodemanager.disk-health-checker.enable=false
-
-YARN-SITE.XML_yarn.resourcemanager.hostname=rm
-YARN-SITE.XML_yarn.resourcemanager.keytab=/etc/security/keytabs/rm.keytab
-YARN-SITE.XML_yarn.resourcemanager.principal=rm/rm@EXAMPLE.COM
-YARN-SITE.XML_yarn.resourcemanager.system.metrics.publisher.enabled=true
-
-YARN-SITE.XML_yarn.log-aggregation-enable=true
-YARN-SITE.XML_yarn.nodemanager.log-aggregation.roll-monitoring-interval-seconds=3600
-YARN-SITE.XML_yarn.nodemanager.delete.debug-delay-sec=600
-YARN-SITE.XML_yarn.nodemanager.disk-health-checker.max-disk-utilization-per-disk-percentage=99
-YARN-SITE.XML_yarn.nodemanager.disk-health-checker.enable=false
-
-# Yarn LinuxContainer requires the /opt/hadoop/etc/hadoop to be owned by root and not modifiable by other users,
-# which prevents start.sh from changing the configurations based on docker-config
-# YARN-SITE.XML_yarn.nodemanager.container-executor.class=org.apache.hadoop.yarn.server.nodemanager.LinuxContainerExecutor
-# YARN-SITE.XML_yarn.nodemanager.linux-container-executor.path=/opt/hadoop/bin/container-executor
-# YARN-SITE.XML_yarn.nodemanager.linux-container-executor.group=hadoop
-
-CAPACITY-SCHEDULER.XML_yarn.scheduler.capacity.maximum-applications=10000
-CAPACITY-SCHEDULER.XML_yarn.scheduler.capacity.maximum-am-resource-percent=0.1
-CAPACITY-SCHEDULER.XML_yarn.scheduler.capacity.resource-calculator=org.apache.hadoop.yarn.util.resource.DefaultResourceCalculator
-CAPACITY-SCHEDULER.XML_yarn.scheduler.capacity.root.queues=default
-CAPACITY-SCHEDULER.XML_yarn.scheduler.capacity.root.default.capacity=100
-CAPACITY-SCHEDULER.XML_yarn.scheduler.capacity.root.default.user-limit-factor=1
-CAPACITY-SCHEDULER.XML_yarn.scheduler.capacity.root.default.maximum-capacity=100
-CAPACITY-SCHEDULER.XML_yarn.scheduler.capacity.root.default.state=RUNNING
-CAPACITY-SCHEDULER.XML_yarn.scheduler.capacity.root.default.acl_submit_applications=*
-CAPACITY-SCHEDULER.XML_yarn.scheduler.capacity.root.default.acl_administer_queue=*
-CAPACITY-SCHEDULER.XML_yarn.scheduler.capacity.node-locality-delay=40
-CAPACITY-SCHEDULER.XML_yarn.scheduler.capacity.queue-mappings=
-CAPACITY-SCHEDULER.XML_yarn.scheduler.capacity.queue-mappings-override.enable=false
 
 #Enable this variable to print out all hadoop rpc traffic to the stdout. See http://byteman.jboss.org/ to define your own instrumentation.
 #BYTEMAN_SCRIPT_URL=https://raw.githubusercontent.com/apache/hadoop/trunk/dev-support/byteman/hadooprpc.btm
@@ -148,7 +78,6 @@ OZONE_DATANODE_SECURE_USER=root
 JAVA_HOME=/usr/lib/jvm/jre
 JSVC_HOME=/usr/bin
 
-HADOOP_CLASSPATH=/opt/ozone/share/ozone/lib/ozone-filesystem-hadoop3-@project.version@.jar
 OZONE_CLASSPATH=
 OZONE_CONF_DIR=/etc/hadoop
 OZONE_LOG_DIR=/var/log/hadoop

--- a/hadoop-ozone/dist/src/main/compose/ozonesecure-mr/test.sh
+++ b/hadoop-ozone/dist/src/main/compose/ozonesecure-mr/test.sh
@@ -20,26 +20,7 @@
 COMPOSE_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 export COMPOSE_DIR
 
-# shellcheck source=/dev/null
-source "$COMPOSE_DIR/../testlib.sh"
-
 export SECURITY_ENABLED=true
+export SCM=scm
 
-start_docker_env
-
-execute_robot_test om kinit.robot
-
-execute_robot_test om createmrenv.robot
-
-# reinitialize the directories to use
-export OZONE_DIR=/opt/ozone
-
-# shellcheck source=/dev/null
-source "$COMPOSE_DIR/../testlib.sh"
-
-execute_robot_test rm kinit-hadoop.robot
-
-for scheme in o3fs ofs; do
-  execute_robot_test rm -v "SCHEME:${scheme}" -N "hadoopfs-${scheme}" ozonefs/hadoopo3fs.robot
-  execute_robot_test rm -v "SCHEME:${scheme}" -N "mapreduce-${scheme}" mapreduce.robot
-done
+source "$COMPOSE_DIR/../common/hadoop-test.sh"


### PR DESCRIPTION
## What changes were proposed in this pull request?

Hadoop compatibility tests are run for versions [2.7, 3.1, 3.2, 3.3](https://github.com/apache/ozone/blob/0b377f7620b4795031a517a7d5a48c5995210d35/hadoop-ozone/dist/src/main/compose/common/hadoop-test.sh#L36) in [unsecure environment](https://github.com/apache/ozone/blob/0b377f7620b4795031a517a7d5a48c5995210d35/hadoop-ozone/dist/src/main/compose/ozone/test-hadoop.sh#L26), and for [3.3 in secure one](https://github.com/apache/ozone/blob/0b377f7620b4795031a517a7d5a48c5995210d35/hadoop-ozone/dist/src/main/compose/ozonesecure-mr/.env#L19).  However, part of the version-specific code is related to security.  Therefore, we should also test secure environment with all supported Hadoop versions.

This PR changes `ozonesecure-mr` to execute the tests using all 4 versions.

Note that with Hadoop 2.7.3 only HDFS compatibility test is run, MapReduce is skipped, because it is failing due to some token issue.  We'll try to fix that separately.  There is also [discussion](https://lists.apache.org/thread/q99x4f93yk20z6m8wsqpvwms1vqw030l) about moving to 2.10 (and dropping support for some other versions).

https://issues.apache.org/jira/browse/HDDS-9583

## How was this patch tested?

Verified execution in CI:

https://github.com/adoroszlai/hadoop-ozone/actions/runs/6801434278/job/18493333829#step:5:943
https://github.com/adoroszlai/hadoop-ozone/actions/runs/6801434278/job/18493333829#step:5:987
https://github.com/adoroszlai/hadoop-ozone/actions/runs/6801434278/job/18493333829#step:5:1055
https://github.com/adoroszlai/hadoop-ozone/actions/runs/6801434278/job/18493333829#step:5:1123