### PR TITLE
HDDS-9587. `No serializer found for class ThreadLocal` in DBSCanner for pipelines in scm.db

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/debug/TestLDBCli.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/debug/TestLDBCli.java
@@ -41,6 +41,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Named;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -68,6 +69,7 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 public class TestLDBCli {
   private static final String KEY_TABLE = "keyTable";
   private static final String BLOCK_DATA = "block_data";
+  public static final String PIPELINES = "pipelines";
   private static final ObjectMapper MAPPER = new ObjectMapper();
   private OzoneConfiguration conf;
   private DBStore dbStore;
@@ -236,6 +238,30 @@ public class TestLDBCli {
     Assertions.assertTrue(stderr.toString().contains(stderrShouldContain));
   }
 
+  @Test
+  void testScanOfPipelinesWhenNoData() throws IOException {
+    // Prepare dummy table
+    prepareTable(PIPELINES, false);
+
+    // Prepare scan args
+    List<String> completeScanArgs = new ArrayList<>(Arrays.asList(
+        "--db", dbStore.getDbLocation().getAbsolutePath(),
+        "scan",
+        "--column-family", PIPELINES));
+
+    int exitCode = cmd.execute(completeScanArgs.toArray(new String[0]));
+    // Check exit code. Print stderr if not expected
+    Assertions.assertEquals(0, exitCode, stderr.toString());
+
+    if (exitCode == 0) {
+      // Verify stdout on success
+      Assertions.assertEquals("{  }\n", stdout.toString());
+    }
+
+    // Check stderr
+    Assertions.assertEquals("", stderr.toString());
+  }
+
   /**
    * Converts String input to a Map and compares to the given Map input.
    * @param expected expected result Map
@@ -315,7 +341,11 @@ public class TestLDBCli {
         }
       }
       break;
-
+    case PIPELINES:
+      // Empty table
+      dbStore = DBStoreBuilder.newBuilder(conf).setName("scm.db")
+          .setPath(tempDir.toPath()).addTable(PIPELINES).build();
+      break;
     default:
       throw new IllegalArgumentException("Unsupported table: " + tableName);
     }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/debug/TestLDBCli.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/debug/TestLDBCli.java
@@ -253,10 +253,8 @@ public class TestLDBCli {
     // Check exit code. Print stderr if not expected
     Assertions.assertEquals(0, exitCode, stderr.toString());
 
-    if (exitCode == 0) {
-      // Verify stdout on success
-      Assertions.assertEquals("{  }\n", stdout.toString());
-    }
+    // Check stdout
+    Assertions.assertEquals("{  }\n", stdout.toString());
 
     // Check stderr
     Assertions.assertEquals("", stderr.toString());

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/DBScanner.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/DBScanner.java
@@ -23,6 +23,7 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.PropertyAccessor;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectWriter;
+import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
@@ -428,7 +429,8 @@ public class DBScanner implements Callable<Void>, SubcommandWithParent {
         .setVisibility(PropertyAccessor.IS_GETTER,
             JsonAutoDetect.Visibility.NONE)
         // Exclude null values.
-        .setSerializationInclusion(JsonInclude.Include.NON_NULL);
+        .setSerializationInclusion(JsonInclude.Include.NON_NULL)
+        .disable(SerializationFeature.FAIL_ON_EMPTY_BEANS);
     public static final ObjectWriter WRITER;
 
     static {


### PR DESCRIPTION
## What changes were proposed in this pull request?
Fix for an exception which occurs during serialization of nodesInOrder when using ldb scan for scm.db and pipelines column family.

## What is the link to the Apache JIRA
[https://issues.apache.org/jira/browse/HDDS-9587](https://issues.apache.org/jira/browse/HDDS-9587)

## How was this patch tested?
Manual tests
