### PR TITLE
HDDS-9669. Remove unnecessary parent volume access check in OzoneAclUtils

### DIFF
--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneAclUtils.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneAclUtils.java
@@ -95,8 +95,7 @@ public final class OzoneAclUtils {
       break;
     case BUCKET:
     case KEY:
-    //For Bucket/Key/Prefix level access, first we need to check {OWNER} equal
-    // to volume owner on parent volume. Then we need to check {OWNER} equals
+    //For Bucket/Key/Prefix level access, we need to check {OWNER} equals
     // volume owner if current ugi user is volume owner else we need check
     //{OWNER} equals bucket owner for bucket/key/prefix.
     case PREFIX:
@@ -106,20 +105,6 @@ public final class OzoneAclUtils {
             user, remoteAddress, hostName, true,
             volOwner);
       } else {
-        IAccessAuthorizer.ACLType parentAclRight =
-            IAccessAuthorizer.ACLType.READ;
-        // OzoneNativeAuthorizer differs from Ranger Authorizer as Ranger
-        // requires only READ access on parent level access.
-        // OzoneNativeAuthorizer has different parent level access based on the
-        // child level access type.
-        if (omMetadataReader.isNativeAuthorizerEnabled() && resType == BUCKET) {
-          parentAclRight = getParentNativeAcl(aclType, resType);
-        }
-
-        omMetadataReader.checkAcls(OzoneObj.ResourceType.VOLUME, storeType,
-            parentAclRight, vol, bucket, key, user,
-            remoteAddress, hostName, true,
-            volOwner);
         omMetadataReader.checkAcls(resType, storeType,
             aclType, vol, bucket, key,
             user, remoteAddress, hostName, true,
@@ -130,56 +115,6 @@ public final class OzoneAclUtils {
       throw new OMException("Unexpected object type:" +
               resType, INVALID_REQUEST);
     }
-  }
-
-  /**
-   * get the Parent ACL based on child ACL and resource type.
-   * 
-   * @param aclRight child acl as required
-   * @param resType resource type
-   * @return parent acl
-   */
-  public static IAccessAuthorizer.ACLType getParentNativeAcl(
-      IAccessAuthorizer.ACLType aclRight, OzoneObj.ResourceType resType) {
-    // For volume, parent access has no meaning and not used
-    if (resType == VOLUME) {
-      return IAccessAuthorizer.ACLType.NONE;
-    }
-    
-    // Refined the parent for bucket, keys & prefix
-    // OP         |CHILD       |PARENT
-
-    // CREATE      NONE        WRITE
-    // DELETE      DELETE      READ
-    // WRITE       WRITE       WRITE     (For key/prefix, volume is READ)
-    // WRITE_ACL   WRITE_ACL   READ      (V1 WRITE_ACL=>WRITE)
-
-    // READ        READ        READ
-    // LIST        LIST        READ      (V1 LIST=>READ)
-    // READ_ACL    READ_ACL    READ      (V1 READ_ACL=>READ)
-
-    // for bucket, except CREATE, all cases need READ for volume
-    if (resType == BUCKET) {
-      if (aclRight == IAccessAuthorizer.ACLType.CREATE) {
-        return IAccessAuthorizer.ACLType.WRITE;
-      }
-      return IAccessAuthorizer.ACLType.READ;
-    }
-    
-    // else for key and prefix, bucket permission will be read
-    // except where key/prefix have CREATE and WRITE,
-    // bucket will have WRITE
-    IAccessAuthorizer.ACLType parentAclRight = aclRight;
-    if (aclRight == IAccessAuthorizer.ACLType.CREATE) {
-      parentAclRight = IAccessAuthorizer.ACLType.WRITE;
-    } else if (aclRight == IAccessAuthorizer.ACLType.READ_ACL
-        || aclRight == IAccessAuthorizer.ACLType.LIST
-        || aclRight == IAccessAuthorizer.ACLType.WRITE_ACL
-        || aclRight == IAccessAuthorizer.ACLType.DELETE) {
-      parentAclRight = IAccessAuthorizer.ACLType.READ;
-    }
-
-    return parentAclRight;
   }
 
   private static boolean isOwner(UserGroupInformation callerUgi,


### PR DESCRIPTION
## What changes were proposed in this pull request?

In `OzoneAclUtils` we have this volume check access when the object to access is not volume

```java
      //OzoneNativeAuthorizer differs from Ranger Authorizer as Ranger requires
      // only READ access on parent level access. OzoneNativeAuthorizer has
      // different parent level access based on the child level access type
      IAccessAuthorizer.ACLType parentAclRight = IAccessAuthorizer.ACLType.READ;
      if (omMetadataReader.isNativeAuthorizerEnabled() && resType == BUCKET) {
        parentAclRight = getParentNativeAcl(aclType, resType);
      }

      omMetadataReader.checkAcls(OzoneObj.ResourceType.VOLUME, storeType,
          parentAclRight, vol, bucket, key, user,
          remoteAddress, hostName, true,
          volOwner); 
```

From my understanding, this volume check should by right done in the respective authorizers (either OzoneNativeAuthorizer or RangerOzoneAuthorizer) and should not leak to the general ACL flow (e.g. getParentNativeAcl should be moved the OzoneNativeAuthorizer instead).

This patch will remove this check and refactor getNativeAcl to the OzoneNativeAuthorizer.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-9669

## How was this patch tested?

Existing CI.
