### PR TITLE
HDDS-9677. Reuse SCMDBDefinition instance in SCMMetadataStoreImpl#start()

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/metadata/SCMMetadataStoreImpl.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/metadata/SCMMetadataStoreImpl.java
@@ -120,8 +120,8 @@ public class SCMMetadataStoreImpl implements SCMMetadataStore {
   public void start(OzoneConfiguration config)
       throws IOException {
     if (this.store == null) {
-
-      File metaDir = HAUtils.getMetaDir(new SCMDBDefinition(), configuration);
+      SCMDBDefinition scmdbDefinition = new SCMDBDefinition();
+      File metaDir = HAUtils.getMetaDir(scmdbDefinition, configuration);
       // Check if there is a DB Inconsistent Marker in the metaDir. This
       // marker indicates that the DB is in an inconsistent state and hence
       // the OM process should be terminated.
@@ -137,8 +137,7 @@ public class SCMMetadataStoreImpl implements SCMMetadataStore {
         ExitUtils.terminate(1, errorMsg, LOG);
       }
 
-
-      this.store = DBStoreBuilder.createDBStore(config, new SCMDBDefinition());
+      this.store = DBStoreBuilder.createDBStore(config, scmdbDefinition);
 
       deletedBlocksTable =
           DELETED_BLOCKS.getTable(this.store);


### PR DESCRIPTION
## What changes were proposed in this pull request?
When SCMMetadataStoreImpl#start() is called, SCMDBDefinition instances will be created repeatedly, which will add more system overhead.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-9677

## How was this patch tested?
Just make sure that the existing unit tests pass.
