### PR TITLE
HDDS-9676. SORT_DATANODE audit log should include request details

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMBlockProtocolServer.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMBlockProtocolServer.java
@@ -24,6 +24,7 @@ package org.apache.hadoop.hdds.scm.server;
 import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeoutException;
@@ -338,6 +339,9 @@ public class SCMBlockProtocolServer implements
   public List<DatanodeDetails> sortDatanodes(List<String> nodes,
       String clientMachine) {
     boolean auditSuccess = true;
+    Map<String, String> auditMap = new LinkedHashMap<>();
+    auditMap.put("client", clientMachine);
+    auditMap.put("nodes", String.valueOf(nodes));
     try {
       NodeManager nodeManager = scm.getScmNodeManager();
       Node client = null;
@@ -361,13 +365,13 @@ public class SCMBlockProtocolServer implements
     } catch (Exception ex) {
       auditSuccess = false;
       AUDIT.logReadFailure(
-          buildAuditMessageForFailure(SCMAction.SORT_DATANODE, null, ex)
+          buildAuditMessageForFailure(SCMAction.SORT_DATANODE, auditMap, ex)
       );
       throw ex;
     } finally {
       if (auditSuccess) {
         AUDIT.logReadSuccess(
-            buildAuditMessageForSuccess(SCMAction.SORT_DATANODE, null)
+            buildAuditMessageForSuccess(SCMAction.SORT_DATANODE, auditMap)
         );
       }
     }


### PR DESCRIPTION
## What changes were proposed in this pull request?

SCM's audit log entry for sort datanodes request does not have information about the request (client, node list).  This change adds them.

https://issues.apache.org/jira/browse/HDDS-9676

## How was this patch tested?

Checked audit log entry, example:

```
2023-11-13 08:41:13,856 | INFO  | SCMAudit | user=hadoop | ip=10.5.0.70 | op=SORT_DATANODE {client=10.5.0.71, nodes=[6a9a42ad-9ecd-4e96-bf45-5255f6be66bf, a12806c3-6e7f-479a-be63-20cb3ecb0eb4, cfac92e5-cdce-471d-a995-e6f4dc22ea6f]} | ret=SUCCESS |  
```

CI:
https://github.com/adoroszlai/ozone/actions/runs/6847145541