### PR TITLE
HDDS-9681. Allow OM to detect client address when using gRPC

### DIFF
--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/GrpcOzoneManagerMetadataInterceptor.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/GrpcOzoneManagerMetadataInterceptor.java
@@ -1,0 +1,56 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.ozone.om;
+
+import io.grpc.Context;
+import io.grpc.Contexts;
+import io.grpc.Grpc;
+import io.grpc.Metadata;
+import io.grpc.ServerCall;
+import io.grpc.ServerCallHandler;
+import io.grpc.ServerInterceptor;
+
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.util.Optional;
+
+/**
+ * Interceptor used to capture metadata for current gPRC call.
+ * Sets context to current call with necessary keys.
+ */
+public class GrpcOzoneManagerMetadataInterceptor implements ServerInterceptor {
+  /**
+   * Key gets client address for current gRPC call.
+   */
+  public static final Context.Key<String> CLIENT_ADDRESS_KEY =
+      Context.key("clientAddressKey");
+
+  @Override
+  public <ReqT, RespT> ServerCall.Listener<ReqT> interceptCall(
+      ServerCall<ReqT, RespT> serverCall, Metadata metadata,
+      ServerCallHandler<ReqT, RespT> next) {
+    String clientAddress = Optional.ofNullable(
+            (InetSocketAddress) serverCall.getAttributes()
+                .get(Grpc.TRANSPORT_ATTR_REMOTE_ADDR))
+        .map(InetSocketAddress::getAddress).map(InetAddress::getHostAddress)
+        .orElse(null);
+    Context context =
+        Context.current().withValue(CLIENT_ADDRESS_KEY, clientAddress);
+    return Contexts.interceptCall(context, serverCall, metadata, next);
+  }
+}

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/GrpcOzoneManagerServer.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/GrpcOzoneManagerServer.java
@@ -152,7 +152,8 @@ public class GrpcOzoneManagerServer {
                 delegationTokenMgr,
                 omServerConfig),
             new GrpcMetricsServerResponseInterceptor(omS3gGrpcMetrics),
-            new GrpcMetricsServerRequestInterceptor(omS3gGrpcMetrics)))
+            new GrpcMetricsServerRequestInterceptor(omS3gGrpcMetrics),
+            new GrpcOzoneManagerMetadataInterceptor()))
         .addTransportFilter(
             new GrpcMetricsServerTransportFilter(omS3gGrpcMetrics));
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmMetadataReader.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmMetadataReader.java
@@ -516,6 +516,10 @@ public class OmMetadataReader implements IOmMetadataReader, Auditor {
   static String getClientAddress() {
     String clientMachine = Server.getRemoteAddress();
     if (clientMachine == null) { //not a RPC client
+      clientMachine =
+          GrpcOzoneManagerMetadataInterceptor.CLIENT_ADDRESS_KEY.get();
+    }
+    if (clientMachine == null) { //not a gRPC client
       clientMachine = "";
     }
     return clientMachine;


### PR DESCRIPTION
## What changes were proposed in this pull request?
### Motivation
The RATIS object reading is currently implemented using a gRPC client (specifically, the BlockInputStream.getChunkInfos() method switches the pipeline type to STANDALONE, and the XceiverClientManager selects a gRPC client). Unfortunately, this configuration does not allow the Ozone Manager to determine the client's host address since the OmMetadatareader.getClientAddress() method only works for Hadoop RPC interactions. This failure to detect the client's address results in an empty nodesInOrder field in the response received by the client, causing the datanodes to be read in the default order in the pipeline, with the leader node being read first.

### Solution
Аdded possibility to define client address for gRPC calls. This helps to define closest node for read RATIS/THREE objects.

P.S. This patch was split from https://github.com/apache/ozone/pull/5574 Pull request.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-9651
https://issues.apache.org/jira/browse/HDDS-9681

## How was this patch tested?

Manual test with following steps: 

1. create an RATIS/THREE object in a cluster;
2. read object several times from one of pipeline's datanode where object stored;
3. check metrics - all read transactions were done from datanode where read requested (local copy is used);
4. repeat p. 2-3 on other nodes.