### PR TITLE
HDDS-9593. Replication Manager: Do not count unique origin nodes as over-replicated

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ReplicationManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ReplicationManager.java
@@ -244,7 +244,7 @@ public class ReplicationManager implements SCMService {
     this.ecMisReplicationCheckHandler =
         new ECMisReplicationCheckHandler(ecContainerPlacement);
     this.ratisReplicationCheckHandler =
-        new RatisReplicationCheckHandler(ratisContainerPlacement);
+        new RatisReplicationCheckHandler(ratisContainerPlacement, this);
     this.nodeManager = nodeManager;
     this.metrics = ReplicationManagerMetrics.create(this);
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

If a quasi closed container has replicas that are hosted by nodes with unique origins, then don't count them as over replicated because they're all needed.

This change is replicating the change to the Legacy Replication Manager made in [HDDS-9489](https://issues.apache.org/jira/browse/HDDS-9489)

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-9593

## How was this patch tested?

New unit tests added