### PR TITLE
HDDS-8876. Marked TestOMRatisSnapshots unhealthy

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOMRatisSnapshots.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOMRatisSnapshots.java
@@ -51,7 +51,7 @@ import org.apache.hadoop.ozone.om.ratis.OzoneManagerRatisServerConfig;
 import org.apache.hadoop.ozone.om.ratis.utils.OzoneManagerRatisUtils;
 import org.apache.hadoop.ozone.om.snapshot.OmSnapshotUtils;
 import org.apache.ozone.test.GenericTestUtils;
-import org.apache.ozone.test.tag.Flaky;
+import org.apache.ozone.test.tag.Unhealthy;
 import org.apache.ratis.server.protocol.TermIndex;
 import org.assertj.core.api.Fail;
 import org.junit.jupiter.api.AfterEach;
@@ -105,7 +105,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * Tests the Ratis snapshots feature in OM.
  */
 @Timeout(5000)
-@Flaky("HDDS-8876")
+@Unhealthy("HDDS-8876")
 public class TestOMRatisSnapshots {
 
   private MiniOzoneHAClusterImpl cluster = null;


### PR DESCRIPTION
## What changes were proposed in this pull request?
TestOMRatisSnapshots is still failing after marking it [flaky](https://github.com/apache/ozone/commit/87958e61e9b40ef94d0cde61ced9cea1ac502db4) to run repeatedly. This change is to disable TestOMRatisSnapshots test for now.
 
## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-8876

