### PR TITLE
HDDS-9682. Skip coverage check for dependabot

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ on:
 env:
   FAIL_FAST: ${{ github.event_name == 'pull_request' }}
   MAVEN_OPTS: -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.http.retryHandler.class=standard -Dmaven.wagon.http.retryHandler.count=3
-  OZONE_WITH_COVERAGE: ${{ github.repository == 'apache/ozone' && github.event_name != 'pull_request' }}
+  OZONE_WITH_COVERAGE: ${{ github.repository == 'apache/ozone' && github.event_name != 'pull_request' && !startsWith(github.ref_name, 'dependabot') }}
 jobs:
   build-info:
     runs-on: ubuntu-20.04
@@ -474,7 +474,7 @@ jobs:
   coverage:
     runs-on: ubuntu-20.04
     timeout-minutes: 30
-    if: github.repository == 'apache/ozone' && github.event_name != 'pull_request'
+    if: github.repository == 'apache/ozone' && github.event_name != 'pull_request' && !startsWith(github.ref_name, 'dependabot')
     needs:
       - unit
       - acceptance


### PR DESCRIPTION
## What changes were proposed in this pull request?

Coverage check is skipped in forks and for PRs.  However, dependabot pushes dependency version bumps to the main repo instead of its own fork.  The check is failing, because secrets required for this step are not available for the bot.  We should also skip coverage check for dependabot's branches.

https://issues.apache.org/jira/browse/HDDS-9682

## How was this patch tested?

`coverage` check was skipped when pushed to branch `dependabot-HDDS-9682` in `apache/ozone`:
https://github.com/apache/ozone/actions/runs/6854896922/job/18642348015